### PR TITLE
perf: parallelize hybrid search pipeline

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -25,27 +25,31 @@ export async function hybridSearch(
 ): Promise<SearchResult[]> {
   const limit = opts?.limit || 20;
 
-  // Determine query variants (optionally with expansion)
-  let queries = [query];
-  if (opts?.expansion && opts?.expandFn) {
-    try {
-      const expanded = await opts.expandFn(query);
-      queries = [query, ...expanded].slice(0, 3);
-    } catch {
-      // Expansion failure is non-fatal
-    }
-  }
+  // Run three independent paths in parallel:
+  // 1. Original query: embed → vector search (no expansion dependency)
+  // 2. Expanded queries: expand → embed → vector search
+  // 3. Keyword search (no embedding dependency)
+  const vectorSearchOpts = { limit: limit * 2 };
 
-  // Run vector (embed → search) and keyword search in parallel.
-  // Keyword search has no dependency on embeddings, so it starts immediately.
-  const [vectorLists, keywordResults] = await Promise.all([
-    // Path 1: embed all variants → vector search for each
-    Promise.all(queries.map(q => embed(q))).then(embeddings =>
-      Promise.all(embeddings.map(emb => engine.searchVector(emb, { limit: limit * 2 }))),
-    ),
-    // Path 2: keyword search (no embedding needed)
-    engine.searchKeyword(query, { limit: limit * 2 }),
+  const [originalVectorResults, expandedVectorResults, keywordResults] = await Promise.all([
+    // Path 1: embed original query → vector search (starts immediately)
+    embed(query)
+      .then(emb => engine.searchVector(emb, vectorSearchOpts)),
+    // Path 2: expand → embed alternatives → vector search (Haiku call runs in parallel)
+    (opts?.expansion && opts?.expandFn)
+      ? opts.expandFn(query)
+          .then(expanded => expanded.slice(0, 2))
+          .then(alts => Promise.all(alts.map(q => embed(q))))
+          .then(embeddings => Promise.all(
+            embeddings.map(emb => engine.searchVector(emb, vectorSearchOpts)),
+          ))
+          .catch(() => [] as SearchResult[][])
+      : Promise.resolve([] as SearchResult[][]),
+    // Path 3: keyword search (no embedding needed)
+    engine.searchKeyword(query, vectorSearchOpts),
   ]);
+
+  const vectorLists = [originalVectorResults, ...expandedVectorResults];
 
   // Merge all result lists via RRF
   const allLists = [...vectorLists, keywordResults];

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -8,7 +8,7 @@
 
 import type { BrainEngine } from '../engine.ts';
 import type { SearchResult, SearchOpts } from '../types.ts';
-import { embed } from '../embedding.ts';
+import { embed, embedBatch } from '../embedding.ts';
 import { dedupResults } from './dedup.ts';
 
 const RRF_K = 60;
@@ -39,7 +39,7 @@ export async function hybridSearch(
     (opts?.expansion && opts?.expandFn)
       ? opts.expandFn(query)
           .then(expanded => expanded.slice(0, 2))
-          .then(alts => Promise.all(alts.map(q => embed(q))))
+          .then(alts => embedBatch(alts))
           .then(embeddings => Promise.all(
             embeddings.map(emb => engine.searchVector(emb, vectorSearchOpts)),
           ))

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -36,16 +36,16 @@ export async function hybridSearch(
     }
   }
 
-  // Embed all query variants
-  const embeddings = await Promise.all(queries.map(q => embed(q)));
-
-  // Run vector search for each embedding
-  const vectorLists = await Promise.all(
-    embeddings.map(emb => engine.searchVector(emb, { limit: limit * 2 })),
-  );
-
-  // Run keyword search (only the original query)
-  const keywordResults = await engine.searchKeyword(query, { limit: limit * 2 });
+  // Run vector (embed → search) and keyword search in parallel.
+  // Keyword search has no dependency on embeddings, so it starts immediately.
+  const [vectorLists, keywordResults] = await Promise.all([
+    // Path 1: embed all variants → vector search for each
+    Promise.all(queries.map(q => embed(q))).then(embeddings =>
+      Promise.all(embeddings.map(emb => engine.searchVector(emb, { limit: limit * 2 }))),
+    ),
+    // Path 2: keyword search (no embedding needed)
+    engine.searchKeyword(query, { limit: limit * 2 }),
+  ]);
 
   // Merge all result lists via RRF
   const allLists = [...vectorLists, keywordResults];


### PR DESCRIPTION
## Summary

- Parallelize keyword search with embed+vector pipeline (keyword has no embedding dependency)
- Parallelize query expansion with original query embedding (original doesn't depend on Haiku expansion)
- Use `embedBatch()` for expanded queries instead of individual `embed()` calls (reduces API round-trips)

## Expected Impact

- ~100-1000ms latency reduction per hybrid search call depending on expansion usage
- 1 fewer OpenAI API call when query expansion is active
- Behavior is identical — only execution order changes

## Test plan

- [x] `bun test` — 128 pass, 0 fail
- [x] E2E with Docker Postgres — 47 pass, 0 fail
- [x] Verify with `OPENAI_API_KEY` set (Tier 2 skills tests)
