### PR TITLE
Fix gbrain init --supabase not exiting after completion

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -129,6 +129,7 @@ function readLine(prompt: string): Promise<string> {
     process.stdin.setEncoding('utf-8');
     process.stdin.once('data', (chunk) => {
       data = chunk.toString().trim();
+      process.stdin.pause();
       resolve(data);
     });
     process.stdin.resume();


### PR DESCRIPTION
The readLine function calls process.stdin.resume() but never pauses it again. This keeps the event loop alive after init completes. This causes gbrain init command to not exit after completing its work.