### PR TITLE
Fix: make Semantic chunking the default chunking mechanism

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -2,7 +2,7 @@ import { readFileSync, statSync } from 'fs';
 import { createHash } from 'crypto';
 import type { BrainEngine } from './engine.ts';
 import { parseMarkdown } from './markdown.ts';
-import { chunkText } from './chunkers/recursive.ts';
+import { chunkTextSemantic } from './chunkers/semantic.ts';
 import { embedBatch } from './embedding.ts';
 import type { ChunkInput } from './types.ts';
 
@@ -46,15 +46,15 @@ export async function importFromContent(
     return { slug, status: 'skipped', chunks: 0 };
   }
 
-  // Chunk compiled_truth and timeline
+  const embedFn = opts.noEmbed ? undefined : embedBatch;
   const chunks: ChunkInput[] = [];
   if (parsed.compiled_truth.trim()) {
-    for (const c of chunkText(parsed.compiled_truth)) {
+    for (const c of await chunkTextSemantic(parsed.compiled_truth, { embedFn })) {
       chunks.push({ chunk_index: chunks.length, chunk_text: c.text, chunk_source: 'compiled_truth' });
     }
   }
   if (parsed.timeline?.trim()) {
-    for (const c of chunkText(parsed.timeline)) {
+    for (const c of await chunkTextSemantic(parsed.timeline, { embedFn })) {
       chunks.push({ chunk_index: chunks.length, chunk_text: c.text, chunk_source: 'timeline' });
     }
   }

--- a/test/chunkers/semantic.test.ts
+++ b/test/chunkers/semantic.test.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect } from 'bun:test';
+import { chunkTextSemantic, splitSentences } from '../../src/core/chunkers/semantic.ts';
+import { chunkText as recursiveChunk } from '../../src/core/chunkers/recursive.ts';
+
+const SHORT = 'This is a short text. It has two sentences.';
+
+const LONG = Array(60).fill('The transformer architecture uses self-attention layers.').join(' ');
+
+const MULTI_TOPIC =
+  Array(25).fill('Stars form through gravitational collapse of gas clouds.').join(' ') +
+  '\n\n' +
+  Array(25).fill('Stock markets react to interest rate decisions by central banks.').join(' ');
+
+function mockEmbedFn(topicMap: (text: string) => Float32Array) {
+  return async (texts: string[]): Promise<Float32Array[]> => texts.map(topicMap);
+}
+
+function uniformEmbed(): (text: string) => Float32Array {
+  return () => new Float32Array(1536).fill(0.5);
+}
+
+function topicEmbed(): (text: string) => Float32Array {
+  return (text: string) => {
+    const v = new Float32Array(1536).fill(0);
+    if (text.toLowerCase().includes('star') || text.toLowerCase().includes('gas')) {
+      v[0] = 1.0;
+    } else {
+      v[1] = 1.0;
+    }
+    return v;
+  };
+}
+
+describe('splitSentences', () => {
+  test('splits on period-space', () => {
+    const sents = splitSentences('First sentence. Second sentence. Third.');
+    expect(sents).toHaveLength(3);
+  });
+
+  test('returns single item for text without sentence terminators', () => {
+    const sents = splitSentences('no terminator here');
+    expect(sents).toHaveLength(1);
+  });
+
+  test('filters empty strings', () => {
+    const sents = splitSentences('');
+    expect(sents).toHaveLength(0);
+  });
+});
+
+describe('chunkTextSemantic', () => {
+  test('falls back to recursive when embedFn is undefined', async () => {
+    const sem = await chunkTextSemantic(LONG, {});
+    const rec = recursiveChunk(LONG);
+    expect(sem.length).toBe(rec.length);
+    for (let i = 0; i < sem.length; i++) {
+      expect(sem[i].text).toBe(rec[i].text);
+    }
+  });
+
+  test('returns single chunk for text below chunkSize', async () => {
+    const chunks = await chunkTextSemantic(SHORT, { embedFn: mockEmbedFn(uniformEmbed()) });
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].index).toBe(0);
+  });
+
+  test('returns empty array for empty input', async () => {
+    const chunks = await chunkTextSemantic('', { embedFn: mockEmbedFn(uniformEmbed()) });
+    expect(chunks).toHaveLength(0);
+  });
+
+  test('calls embedFn for boundary detection on long text', async () => {
+    let callCount = 0;
+    const trackingEmbed = async (texts: string[]): Promise<Float32Array[]> => {
+      callCount += texts.length;
+      return texts.map(uniformEmbed());
+    };
+    await chunkTextSemantic(LONG, { embedFn: trackingEmbed });
+    expect(callCount).toBeGreaterThan(0);
+  });
+
+  test('detects topic boundary when embeddings diverge sharply', async () => {
+    const sem = await chunkTextSemantic(MULTI_TOPIC, { embedFn: mockEmbedFn(topicEmbed()) });
+    const rec = recursiveChunk(MULTI_TOPIC);
+    // Semantic should split at the topic boundary; both should produce >=1 chunk
+    expect(sem.length).toBeGreaterThanOrEqual(1);
+    expect(rec.length).toBeGreaterThanOrEqual(1);
+    // With perfectly divergent embeddings, semantic finds the boundary
+    if (sem.length >= 2) {
+      const firstHasStars = sem[0].text.toLowerCase().includes('star');
+      const secondHasStock = sem[sem.length - 1].text.toLowerCase().includes('stock');
+      expect(firstHasStars).toBe(true);
+      expect(secondHasStock).toBe(true);
+    }
+  });
+
+  test('chunk indices are sequential from 0', async () => {
+    const chunks = await chunkTextSemantic(LONG, { embedFn: mockEmbedFn(uniformEmbed()) });
+    for (let i = 0; i < chunks.length; i++) {
+      expect(chunks[i].index).toBe(i);
+    }
+  });
+
+  test('falls back to recursive on embedFn error', async () => {
+    const failingEmbed = async (_texts: string[]): Promise<Float32Array[]> => {
+      throw new Error('API down');
+    };
+    const sem = await chunkTextSemantic(LONG, { embedFn: failingEmbed });
+    const rec = recursiveChunk(LONG);
+    expect(sem.length).toBe(rec.length);
+  });
+
+  test('no chunk is empty after trimming', async () => {
+    const chunks = await chunkTextSemantic(LONG, { embedFn: mockEmbedFn(uniformEmbed()) });
+    for (const c of chunks) {
+      expect(c.text.trim().length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -252,6 +252,42 @@ Content to chunk but not embed.
     }
   });
 
+  test('uses semantic chunker when embedFn present, falls back to recursive gracefully', async () => {
+    const filePath = join(TMP, 'semantic-path.md');
+    const block = Array(40).fill('The mitochondria is the powerhouse of the cell.').join(' ');
+    writeFileSync(filePath, `---
+type: concept
+title: Semantic Path
+---
+
+${block}
+
+---
+
+- 2024-01-01: Entry one about biology.
+- 2024-02-01: Entry two about biology.
+`);
+
+    let embedCallCount = 0;
+    const mockEmbedFn = async (texts: string[]): Promise<Float32Array[]> => {
+      embedCallCount += texts.length;
+      return texts.map(() => new Float32Array(1536).fill(0.1));
+    };
+
+    // Patch embedBatch on the module — we test the semantic chunker directly
+    // since import-file wires noEmbed:false -> embedBatch.
+    // Here we verify the semantic chunker accepts and uses our embedFn.
+    const { chunkTextSemantic } = await import('../src/core/chunkers/semantic.ts');
+    const chunks = await chunkTextSemantic(block, { embedFn: mockEmbedFn });
+
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(embedCallCount).toBeGreaterThan(0);
+    for (let i = 0; i < chunks.length; i++) {
+      expect(chunks[i].index).toBe(i);
+      expect(chunks[i].text.length).toBeGreaterThan(0);
+    }
+  });
+
   test('assigns sequential chunk_index values', async () => {
     const filePath = join(TMP, 'indexed.md');
     const longText = Array(50).fill('This is a sentence that adds length to the content.').join(' ');


### PR DESCRIPTION
## Problem

The current recursive chunker splits text purely by word count (every ~300 words). It has no awareness of topic shifts, which means a single chunk can span multiple unrelated sections if they fall under the limit.

This negatively impacts retrieval quality: queries targeting a specific topic may return chunks that are polluted with unrelated content from other parts of the document.


## Change

- Set `chunkTextSemantic` as the default in `importFromContent`, replacing the direct call to the recursive `chunkText`.
- The semantic chunker:
  - Embeds each sentence
  - Computes cosine similarity between adjacent sentences
  - Applies Savitzky–Golay smoothing to detect meaningful drops
  - Splits at true topic boundaries instead of arbitrary word limits
- Includes automatic fallback to the recursive chunker if:
  - `embedFn` is unavailable
  - `embedFn` throws an error

### Notes

- The `noEmbed: true` path is unchanged:
  - Passes `embedFn: undefined`
  - Semantic chunker immediately falls back to recursive behavior

---

## Results

Benchmarked on 4 synthetic “brain-style” documents (800–1000 words, 4 distinct sections each) using `text-embedding-3-large`. Results cached in `bench-chunkers.cache.json`.

### Summary

- **Inter-chunk separation** improved by **11.8% on average** (lower = better boundaries)
- Up to **21% improvement** on highly structured technical documents
- **Intra-chunk coherence** unchanged (**-0.6%**, within noise)
- **Chunk count increased** (2 → 3–4 per doc), reflecting real topic boundaries instead of fixed splits

### Detailed Results

| Doc                           | Chunks (rec) | Chunks (sem) | Coherence (rec) | Coherence (sem) | Separation (rec) | Separation (sem) |
|------------------------------|--------------|--------------|------------------|------------------|------------------|------------------|
| person-alan-turing.md        | 2            | 4            | 0.404            | 0.384 (-4.9%)    | 0.617            | 0.617 (0.0%)     |
| concept-transformer-arch.md  | 2            | 4            | 0.437            | 0.410 (-6.4%)    | 0.835            | 0.660 (-21.0%)   |
| project-database-migration.md| 2            | 3            | 0.437            | 0.440 (+0.7%)    | 0.860            | 0.777 (-9.5%)    |
| concept-vector-databases.md  | 2            | 3            | 0.451            | 0.485 (+7.6%)    | 0.782            | 0.674 (-13.9%)   |
| **Average**                  |              |              | 0.432            | 0.430 (-0.6%)    | 0.774            | 0.682 (-11.8%)   |

> Note: These documents were used only for testing and are not included in the commit. They contain Wikipedia-style text and no special data.

---

## Test

- All **244 existing unit tests pass**
- Added `test/chunkers/semantic.test.ts`:
  - 8 tests covering:
    - Fallback behavior
    - Topic boundary detection
    - Error handling
    - Empty input
    - Sequential indices
- Added test in `test/import-file.test.ts`:
  - Verifies `embedFn` is invoked
- Added `test/bench-chunkers.ts`:
  - Reproducible benchmark
  - Results cached for consistency