### PR TITLE
fix: use typed request schemas for MCP server handler registration

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,5 +1,6 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { BrainEngine } from '../core/engine.ts';
 import { operations, OperationError } from '../core/operations.ts';
 import type { OperationContext } from '../core/operations.ts';
@@ -13,7 +14,7 @@ export async function startMcpServer(engine: BrainEngine) {
   );
 
   // Generate tool definitions from operations
-  server.setRequestHandler('tools/list' as any, async () => ({
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: operations.map(op => ({
       name: op.name,
       description: op.description,
@@ -35,7 +36,7 @@ export async function startMcpServer(engine: BrainEngine) {
   }));
 
   // Dispatch tool calls to operation handlers
-  server.setRequestHandler('tools/call' as any, async (request: any) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
     const { name, arguments: params } = request.params;
     const op = operations.find(o => o.name === name);
     if (!op) {


### PR DESCRIPTION
## Summary

Replace string literal handler registration (`'tools/list' as any`, `'tools/call' as any`) with the SDK's typed Zod request schemas (`ListToolsRequestSchema`, `CallToolRequestSchema`). The string literal approach causes `setRequestHandler` to fail silently in `@modelcontextprotocol/sdk` v1.29.0, outputting "Schema is missing a method literal" and dropping the connection immediately.

## Changes

- Added import for `ListToolsRequestSchema` and `CallToolRequestSchema` from `@modelcontextprotocol/sdk/types.js`
- Replaced `'tools/list' as any` with `ListToolsRequestSchema` (`src/mcp/server.ts:17`)
- Replaced `'tools/call' as any` with `CallToolRequestSchema` (`src/mcp/server.ts:39`)

## Testing

`bun test` passes (232 pass, 109 skip for E2E requiring DATABASE_URL).

Fixes #9

This contribution was developed with AI assistance (Codex).