### PR TITLE
fix: skip node_modules and handle broken symlinks in import walker

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -202,11 +202,16 @@ function collectMarkdownFiles(dir: string): string[] {
 
   function walk(d: string) {
     for (const entry of readdirSync(d)) {
-      // Skip hidden dirs and .raw dirs
-      if (entry.startsWith('.')) continue;
+      // Skip hidden dirs, node_modules, and .raw dirs
+      if (entry.startsWith('.') || entry === 'node_modules') continue;
 
       const full = join(d, entry);
-      const stat = statSync(full);
+      let stat;
+      try {
+        stat = statSync(full);
+      } catch {
+        continue;
+      }
 
       if (stat.isDirectory()) {
         walk(full);


### PR DESCRIPTION
## Problem

`gbrain import <dir>` crashes immediately on any JavaScript/TypeScript project directory:

```
ENOENT: no such file or directory, stat '.../node_modules/web/node_modules/@ai-sdk/xai'
```

Two root causes:
1. The walker descends into `node_modules`, which can contain thousands of files, broken symlinks, and nested packages
2. `statSync` is called without error handling, so any unreadable entry (broken symlink, permission error) crashes the entire import

## Fix

- Skip `node_modules` directories in the recursive walker
- Wrap `statSync` in try/catch to gracefully skip unreadable entries

## Test

```bash
gbrain import ~/path/to/any-js-project   # previously crashed, now works
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)