### PR TITLE
feat: mdx support and scan/import progress indicators

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -107,7 +107,7 @@ export async function runImport(engine: BrainEngine, args: string[]) {
       skipped++;
     }
     processed++;
-    if (processed % 100 === 0 || processed === files.length) {
+    if (processed % 10 === 0 || processed === files.length) {
       logProgress();
       // Save checkpoint every 100 files
       if (processed % 100 === 0) {
@@ -199,8 +199,14 @@ export async function runImport(engine: BrainEngine, args: string[]) {
 
 function collectMarkdownFiles(dir: string): string[] {
   const files: string[] = [];
+  let dirsScanned = 0;
 
   function walk(d: string) {
+    dirsScanned++;
+    if (dirsScanned % 10 === 0) {
+      process.stdout.write(`\rScanning... ${dirsScanned} dirs, ${files.length} .md files found`);
+    }
+
     for (const entry of readdirSync(d)) {
       // Skip hidden dirs and .raw dirs
       if (entry.startsWith('.')) continue;
@@ -210,12 +216,13 @@ function collectMarkdownFiles(dir: string): string[] {
 
       if (stat.isDirectory()) {
         walk(full);
-      } else if (entry.endsWith('.md')) {
+      } else if (entry.endsWith('.md') || entry.endsWith('.mdx')) {
         files.push(full);
       }
     }
   }
 
   walk(dir);
+  if (dirsScanned >= 100) process.stdout.write('\r\x1b[K');
   return files.sort();
 }


### PR DESCRIPTION
## Changes

**MDX support**

`.mdx` files are silently ignored by `gbrain import`. Next.js, Gatsby, and Astro projects store content as MDX — this adds them alongside `.md`.

**Progress indicators**

- Scanning large directory trees showed no output, making it look frozen. Now shows a live `Scanning... N dirs, M .md files found` counter during traversal.
- Import progress was reported every 100 files. For most users with <100 files, nothing printed until completion. Now reports every 10 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)