### PR TITLE
feat: add experimental PGlite local-file mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ GBrain doesn't ship with demo data. It finds YOUR markdown and makes it searchab
 === Discovery Complete ===
 ```
 
-**Act 2: Import.** Your files move from the repo into your Postgres-backed brain.
+**Act 2: Import.** Your files move from the repo into Supabase.
 
 ```bash
 gbrain import ~/git/brain/
@@ -171,11 +171,11 @@ Your file count will be different. Your queries will be different. The agent pic
 
 **Without Postgres**, you can use the GBrain knowledge model right now: the [skills](docs/GBRAIN_SKILLPACK.md), [schema](docs/GBRAIN_RECOMMENDED_SCHEMA.md), and compiled truth + timeline pattern work with any agent that reads and writes markdown files. Add Postgres when `grep` stops being enough.
 
-**With Postgres**, GBrain normally needs three things:
+**With Postgres**, GBrain needs three things:
 
 | Dependency | What it's for | How to get it |
 |------------|--------------|---------------|
-| **Postgres database** | Postgres + pgvector database | Supabase, self-hosted Postgres, Docker, Neon, RDS, etc. Must support `vector` + `pg_trgm` |
+| **Supabase account** | Postgres + pgvector database | [supabase.com](https://supabase.com) (Pro tier, $25/mo for 8GB) |
 | **OpenAI API key** | Embeddings (text-embedding-3-large) | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
 | **Anthropic API key** | Multi-query expansion + LLM chunking (Haiku) | [console.anthropic.com](https://console.anthropic.com) |
 
@@ -187,8 +187,6 @@ export ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 The Supabase connection URL is configured during `gbrain init`. The OpenAI and Anthropic SDKs read their keys from the environment automatically.
-
-**Experimental local mode:** you can also try `gbrain init --pglite ~/.gbrain/brain.db` to run against a persisted local PGlite-backed database without provisioning an external Postgres service. This is experimental and currently optimized for easier adoption in local/OpenClaw/Hermes-style environments, not for maximum scale.
 
 Without an OpenAI key, search still works (keyword only, no vector search). Without an Anthropic key, search still works (no multi-query expansion, no LLM chunking).
 
@@ -204,11 +202,8 @@ knowledge brain.
    curl -fsSL https://bun.sh/install | bash
    Then run: bun add github:garrytan/gbrain
 
-2. Run: `gbrain init --url <your-postgres-connection-string>`
-   (or use `gbrain init --supabase` if you want the Supabase-flavored wizard)
-
-   Experimental local-file mode:
-   `gbrain init --pglite ~/.gbrain/brain.db`
+2. Run: gbrain init --supabase
+   (follow the wizard to connect my Supabase database)
 
 3. Scan ~/git/ and ~/Documents/ for markdown repos,
    pick the best one, and run: gbrain import <path> --no-embed
@@ -268,9 +263,7 @@ Install globally and use gbrain from the terminal:
 
 ```bash
 bun add -g github:garrytan/gbrain
-gbrain init --url <conn>        # any Postgres URL with vector + pg_trgm
-# or experimental local-file mode:
-gbrain init --pglite ~/.gbrain/brain.db
+gbrain init --supabase          # guided wizard, connects to your Postgres
 gbrain import ~/git/brain/      # index your markdown
 gbrain query "what do we know about competitive dynamics?"
 ```
@@ -372,14 +365,11 @@ After upgrading, run `gbrain init` again to apply any schema migrations (idempot
 After installing via CLI or library path, run the setup wizard:
 
 ```bash
-# Guided setup: accepts any Postgres connection URL (or use the Supabase-flavored wizard)
-gbrain init --url <conn>
+# Guided wizard: auto-provisions Supabase or accepts a connection URL
+gbrain init --supabase
 
 # Or connect to any Postgres with pgvector
-gbrain init --url postgresql://user:***@host:5432/dbname
-
-# Or use experimental local-file mode with PGlite
-gbrain init --pglite ~/.gbrain/brain.db
+gbrain init --url postgresql://user:pass@host:5432/dbname
 ```
 
 The init wizard:

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ GBrain doesn't ship with demo data. It finds YOUR markdown and makes it searchab
 === Discovery Complete ===
 ```
 
-**Act 2: Import.** Your files move from the repo into Supabase.
+**Act 2: Import.** Your files move from the repo into your Postgres-backed brain.
 
 ```bash
 gbrain import ~/git/brain/
@@ -171,11 +171,11 @@ Your file count will be different. Your queries will be different. The agent pic
 
 **Without Postgres**, you can use the GBrain knowledge model right now: the [skills](docs/GBRAIN_SKILLPACK.md), [schema](docs/GBRAIN_RECOMMENDED_SCHEMA.md), and compiled truth + timeline pattern work with any agent that reads and writes markdown files. Add Postgres when `grep` stops being enough.
 
-**With Postgres**, GBrain needs three things:
+**With Postgres**, GBrain normally needs three things:
 
 | Dependency | What it's for | How to get it |
 |------------|--------------|---------------|
-| **Supabase account** | Postgres + pgvector database | [supabase.com](https://supabase.com) (Pro tier, $25/mo for 8GB) |
+| **Postgres database** | Postgres + pgvector database | Supabase, self-hosted Postgres, Docker, Neon, RDS, etc. Must support `vector` + `pg_trgm` |
 | **OpenAI API key** | Embeddings (text-embedding-3-large) | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
 | **Anthropic API key** | Multi-query expansion + LLM chunking (Haiku) | [console.anthropic.com](https://console.anthropic.com) |
 
@@ -187,6 +187,8 @@ export ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 The Supabase connection URL is configured during `gbrain init`. The OpenAI and Anthropic SDKs read their keys from the environment automatically.
+
+**Experimental local mode:** you can also try `gbrain init --pglite ~/.gbrain/brain.db` to run against a persisted local PGlite-backed database without provisioning an external Postgres service. This is experimental and currently optimized for easier adoption in local/OpenClaw/Hermes-style environments, not for maximum scale.
 
 Without an OpenAI key, search still works (keyword only, no vector search). Without an Anthropic key, search still works (no multi-query expansion, no LLM chunking).
 
@@ -202,8 +204,11 @@ knowledge brain.
    curl -fsSL https://bun.sh/install | bash
    Then run: bun add github:garrytan/gbrain
 
-2. Run: gbrain init --supabase
-   (follow the wizard to connect my Supabase database)
+2. Run: `gbrain init --url <your-postgres-connection-string>`
+   (or use `gbrain init --supabase` if you want the Supabase-flavored wizard)
+
+   Experimental local-file mode:
+   `gbrain init --pglite ~/.gbrain/brain.db`
 
 3. Scan ~/git/ and ~/Documents/ for markdown repos,
    pick the best one, and run: gbrain import <path> --no-embed
@@ -263,7 +268,9 @@ Install globally and use gbrain from the terminal:
 
 ```bash
 bun add -g github:garrytan/gbrain
-gbrain init --supabase          # guided wizard, connects to your Postgres
+gbrain init --url <conn>        # any Postgres URL with vector + pg_trgm
+# or experimental local-file mode:
+gbrain init --pglite ~/.gbrain/brain.db
 gbrain import ~/git/brain/      # index your markdown
 gbrain query "what do we know about competitive dynamics?"
 ```
@@ -365,11 +372,14 @@ After upgrading, run `gbrain init` again to apply any schema migrations (idempot
 After installing via CLI or library path, run the setup wizard:
 
 ```bash
-# Guided wizard: auto-provisions Supabase or accepts a connection URL
-gbrain init --supabase
+# Guided setup: accepts any Postgres connection URL (or use the Supabase-flavored wizard)
+gbrain init --url <conn>
 
 # Or connect to any Postgres with pgvector
-gbrain init --url postgresql://user:pass@host:5432/dbname
+gbrain init --url postgresql://user:***@host:5432/dbname
+
+# Or use experimental local-file mode with PGlite
+gbrain init --pglite ~/.gbrain/brain.db
 ```
 
 The init wizard:

--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,12 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "gbrain",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.30.0",
+        "@electric-sql/pglite": "^0.4.4",
+        "@electric-sql/pglite-socket": "^0.1.4",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "gray-matter": "^4.0.3",
         "openai": "^4.0.0",
@@ -19,6 +20,10 @@
   },
   "packages": {
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.30.1", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-nuKvp7wOIz6BFei8WrTdhmSsx5mwnArYyJgh4+vYu3V4J0Ltb8Xm3odPm51n1aSI0XxNCrDl7O88cxCtUdAkaw=="],
+
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.4.4", "", {}, "sha512-g/6CWAJ4XOkObWCWAQ2IReZD8VvsDy3poRHSKvpRR2F96F8WJ3HVbjpso3gN7l0q6QPPgvxSSpl/qo5k8a7mkQ=="],
+
+    "@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.1.4", "", { "peerDependencies": { "@electric-sql/pglite": "0.4.4" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-2LuMFxJPE2FbjWDrWpylWwhZ5uT03rQfBLM7g2AdZmiG3JjC8sbYFkFR4ZeoqVcn22wKzpJTXFV22mQ+s4Oueg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.0",
+    "@electric-sql/pglite": "^0.4.4",
+    "@electric-sql/pglite-socket": "^0.1.4",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "gray-matter": "^4.0.3",
     "openai": "^4.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -292,7 +292,7 @@ async function handleCliOnly(command: string, args: string[]) {
 async function connectEngine(): Promise<BrainEngine> {
   const config = loadConfig();
   if (!config) {
-    console.error('No brain configured. Run: gbrain init --supabase');
+    console.error('No brain configured. Run: gbrain init --url <connection_string>, gbrain init --pglite <file_path>, or gbrain init --supabase.');
     process.exit(1);
   }
   const engine = new PostgresEngine();
@@ -328,7 +328,7 @@ USAGE
   gbrain <command> [options]
 
 SETUP
-  init [--supabase|--url <conn>]     Create brain (guided wizard)
+  init [--supabase|--url <conn>|--pglite <file>] Create brain (Postgres URL or experimental local PGlite)
   upgrade                            Self-update
   check-update [--json]              Check for new versions
   doctor [--json]                    Health check (pgvector, RLS, schema, embeddings)

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -6,6 +6,7 @@ import type { BrainEngine } from '../core/engine.ts';
 import { PostgresEngine } from '../core/postgres-engine.ts';
 import { importFile } from '../core/import-file.ts';
 import { loadConfig } from '../core/config.ts';
+import { isPGliteConfig, resolveImportWorkerCount } from '../core/pglite.ts';
 
 function defaultWorkers(): number {
   const cpuCount = cpus().length;
@@ -25,6 +26,7 @@ export async function runImport(engine: BrainEngine, args: string[]) {
   const workersIdx = args.indexOf('--workers');
   const workersArg = workersIdx !== -1 ? args[workersIdx + 1] : null;
   const workerCount = workersArg ? parseInt(workersArg, 10) : 1;
+  const config = loadConfig();
   // Find dir: first non-flag arg that isn't a value for --workers
   const flagValues = new Set<number>();
   if (workersIdx !== -1) flagValues.add(workersIdx + 1);
@@ -58,7 +60,10 @@ export async function runImport(engine: BrainEngine, args: string[]) {
   }
 
   // Determine actual worker count
-  const actualWorkers = workerCount > 1 ? workerCount : 1;
+  const actualWorkers = Math.max(1, resolveImportWorkerCount(workerCount, config));
+  if (isPGliteConfig(config) && workerCount > 1) {
+    console.log('PGlite mode forces single-worker import; ignoring requested --workers value.');
+  }
   if (actualWorkers > 1) {
     console.log(`Using ${actualWorkers} parallel workers`);
   }
@@ -125,7 +130,6 @@ export async function runImport(engine: BrainEngine, args: string[]) {
 
   if (actualWorkers > 1) {
     // Parallel: create per-worker engine instances with small pool
-    const config = loadConfig();
     const workerEngines = await Promise.all(
       Array.from({ length: actualWorkers }, async () => {
         const eng = new PostgresEngine();

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,6 +1,37 @@
 import { execSync } from 'child_process';
 import { PostgresEngine } from '../core/postgres-engine.ts';
 import { saveConfig, type GBrainConfig } from '../core/config.ts';
+import { getPGliteDataDir } from '../core/pglite.ts';
+
+export function isSupabaseDirectUrl(url: string): boolean {
+  return /db\.[a-z]+\.supabase\.co/.test(url) || url.includes('.supabase.co:5432');
+}
+
+export function getConnectionHelpText(): string {
+  return [
+    '',
+    'Enter your Postgres connection URL:',
+    '  Local Postgres:   postgresql://postgres:***@localhost:5432/gbrain',
+    '  Hosted Postgres:  postgresql://user:***@db.example.com:5432/gbrain',
+    '  Supabase pooler:  postgresql://postgres.[ref]:***@aws-0-[region].pooler.supabase.com:6543/postgres',
+    '',
+    'For Supabase, use Project Settings > Database > Connection string > URI > Session pooler.',
+    'For local/self-hosted Postgres, make sure the database can run: CREATE EXTENSION vector; and CREATE EXTENSION pg_trgm;',
+    '',
+  ].join('\n');
+}
+
+export function getPGliteHelpText(): string {
+  return [
+    '',
+    'Use a local persisted PGlite database file path:',
+    '  gbrain init --pglite ~/.gbrain/brain.db',
+    '',
+    `PGlite stores its internal data in: ${getPGliteDataDir('~/.gbrain/brain.db')}`,
+    'This mode is experimental and is meant to avoid requiring an external Postgres service.',
+    '',
+  ].join('\n');
+}
 
 export async function runInit(args: string[]) {
   const isSupabase = args.includes('--supabase');
@@ -8,19 +39,30 @@ export async function runInit(args: string[]) {
   const jsonOutput = args.includes('--json');
   const urlIndex = args.indexOf('--url');
   const manualUrl = urlIndex !== -1 ? args[urlIndex + 1] : null;
+  const pgliteIndex = args.indexOf('--pglite');
+  const manualPGlitePath = pgliteIndex !== -1 ? args[pgliteIndex + 1] : null;
   const keyIndex = args.indexOf('--key');
   const apiKey = keyIndex !== -1 ? args[keyIndex + 1] : null;
 
-  let databaseUrl: string;
+  let engineType: 'postgres' | 'pglite' = 'postgres';
+  let databaseUrl = '';
+  let databasePath = '';
 
-  if (manualUrl) {
+  if (manualPGlitePath) {
+    engineType = 'pglite';
+    databasePath = manualPGlitePath;
+  } else if (manualUrl) {
     databaseUrl = manualUrl;
   } else if (isNonInteractive) {
+    const envPath = process.env.GBRAIN_DATABASE_PATH;
     const envUrl = process.env.GBRAIN_DATABASE_URL || process.env.DATABASE_URL;
-    if (envUrl) {
+    if (envPath) {
+      engineType = 'pglite';
+      databasePath = envPath;
+    } else if (envUrl) {
       databaseUrl = envUrl;
     } else {
-      console.error('--non-interactive requires --url <connection_string> or GBRAIN_DATABASE_URL env var');
+      console.error('--non-interactive requires --url <connection_string>, --pglite <file_path>, GBRAIN_DATABASE_URL, or GBRAIN_DATABASE_PATH');
       process.exit(1);
     }
   } else if (isSupabase) {
@@ -30,7 +72,7 @@ export async function runInit(args: string[]) {
   }
 
   // Detect Supabase direct connection URLs and warn about IPv6
-  if (databaseUrl.match(/db\.[a-z]+\.supabase\.co/) || databaseUrl.includes('.supabase.co:5432')) {
+  if (engineType === 'postgres' && isSupabaseDirectUrl(databaseUrl)) {
     console.warn('');
     console.warn('WARNING: You provided a Supabase direct connection URL (db.*.supabase.co:5432).');
     console.warn('  Direct connections are IPv6 only and fail in many environments.');
@@ -44,11 +86,13 @@ export async function runInit(args: string[]) {
   console.log('Connecting to database...');
   const engine = new PostgresEngine();
   try {
-    await engine.connect({ database_url: databaseUrl });
+    await engine.connect(engineType === 'pglite'
+      ? { engine: 'pglite', database_path: databasePath }
+      : { engine: 'postgres', database_url: databaseUrl });
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
     // Provide better error for Supabase IPv6 failures
-    if (databaseUrl.includes('supabase.co') && (msg.includes('ECONNREFUSED') || msg.includes('ETIMEDOUT'))) {
+    if (engineType === 'postgres' && databaseUrl.includes('supabase.co') && (msg.includes('ECONNREFUSED') || msg.includes('ETIMEDOUT'))) {
       console.error('Connection failed. Supabase direct connections (db.*.supabase.co:5432) are IPv6 only.');
       console.error('Use the Session pooler connection string instead (port 6543):');
       console.error('  Supabase Dashboard > gear icon (Project Settings) > Database >');
@@ -62,8 +106,7 @@ export async function runInit(args: string[]) {
     const conn = (engine as any).sql || (await import('../core/db.ts')).getConnection();
     const ext = await conn`SELECT extname FROM pg_extension WHERE extname = 'vector'`;
     if (ext.length === 0) {
-      console.error('pgvector extension not found. Run in Supabase SQL Editor:');
-      console.error('  CREATE EXTENSION vector;');
+      console.error('pgvector extension not found. Run: CREATE EXTENSION vector;');
       await engine.disconnect();
       process.exit(1);
     }
@@ -76,8 +119,10 @@ export async function runInit(args: string[]) {
 
   // Save config
   const config: GBrainConfig = {
-    engine: 'postgres',
-    database_url: databaseUrl,
+    engine: engineType,
+    ...(engineType === 'pglite'
+      ? { database_path: databasePath }
+      : { database_url: databaseUrl }),
     ...(apiKey ? { openai_api_key: apiKey } : {}),
   };
   saveConfig(config);
@@ -88,7 +133,7 @@ export async function runInit(args: string[]) {
   await engine.disconnect();
 
   if (jsonOutput) {
-    console.log(JSON.stringify({ status: 'success', pages: stats.page_count, config_path: '~/.gbrain/config.json' }));
+    console.log(JSON.stringify({ status: 'success', engine: engineType, pages: stats.page_count, config_path: '~/.gbrain/config.json' }));
   } else {
     console.log(`\nBrain ready. ${stats.page_count} pages.`);
     console.log('Next: gbrain import <dir> to migrate your markdown.');
@@ -105,14 +150,11 @@ async function supabaseWizard(): Promise<string> {
     console.log('Then use: gbrain init --url <your-connection-string>');
   } catch {
     console.log('Supabase CLI not found.');
-    console.log('Or provide a connection URL directly.');
+    console.log('You can still use any Postgres connection URL directly.');
   }
 
   // Fallback to manual URL
-  console.log('\nEnter your Supabase/Postgres connection URL:');
-  console.log('  Format: postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres');
-  console.log('  Find it: Supabase Dashboard > gear icon (Project Settings) > Database >');
-  console.log('           Connection string > URI tab > change dropdown to "Session pooler"\n');
+  console.log(getConnectionHelpText());
 
   const url = await readLine('Connection URL: ');
   if (!url) {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -7,7 +7,7 @@ const CONFIG_DIR = join(homedir(), '.gbrain');
 const CONFIG_PATH = join(CONFIG_DIR, 'config.json');
 
 export interface GBrainConfig {
-  engine: 'postgres' | 'sqlite';
+  engine: 'postgres' | 'sqlite' | 'pglite';
   database_url?: string;
   database_path?: string;
   openai_api_key?: string;
@@ -27,16 +27,34 @@ export function loadConfig(): GBrainConfig | null {
 
   // Try env vars
   const dbUrl = process.env.GBRAIN_DATABASE_URL || process.env.DATABASE_URL;
+  const dbPath = process.env.GBRAIN_DATABASE_PATH;
 
-  if (!fileConfig && !dbUrl) return null;
+  if (!fileConfig && !dbUrl && !dbPath) return null;
 
-  // Merge: env vars override config file
-  return {
+  // Merge with explicit engine precedence:
+  // DATABASE_URL/GBRAIN_DATABASE_URL forces postgres mode.
+  // GBRAIN_DATABASE_PATH forces pglite mode when no URL override is present.
+  const merged: GBrainConfig = {
     engine: 'postgres',
     ...fileConfig,
-    ...(dbUrl ? { database_url: dbUrl } : {}),
     ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
   };
+
+  if (dbUrl) {
+    merged.engine = 'postgres';
+    merged.database_url = dbUrl;
+    delete merged.database_path;
+    return merged;
+  }
+
+  if (dbPath) {
+    merged.engine = 'pglite';
+    merged.database_path = dbPath;
+    delete merged.database_url;
+    return merged;
+  }
+
+  return merged;
 }
 
 export function saveConfig(config: GBrainConfig): void {

--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -2,15 +2,17 @@ import postgres from 'postgres';
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { GBrainError, type EngineConfig } from './types.ts';
+import { isPGliteConfig, startPGliteBridge, type PGliteBridgeHandle } from './pglite.ts';
 
 let sql: ReturnType<typeof postgres> | null = null;
+let pgliteBridge: PGliteBridgeHandle | null = null;
 
 export function getConnection(): ReturnType<typeof postgres> {
   if (!sql) {
     throw new GBrainError(
       'No database connection',
       'connect() has not been called',
-      'Run gbrain init --supabase or gbrain init --url <connection_string>',
+      'Run gbrain init --url <connection_string>, gbrain init --pglite <file_path>, or gbrain init --supabase',
     );
   }
   return sql;
@@ -19,17 +21,30 @@ export function getConnection(): ReturnType<typeof postgres> {
 export async function connect(config: EngineConfig): Promise<void> {
   if (sql) return;
 
-  const url = config.database_url;
-  if (!url) {
+  const url = isPGliteConfig(config)
+    ? null
+    : config.database_url;
+  if (!url && !isPGliteConfig(config)) {
     throw new GBrainError(
       'No database URL',
       'database_url is missing from config',
-      'Run gbrain init --supabase or gbrain init --url <connection_string>',
+      'Run gbrain init --url <connection_string>, gbrain init --pglite <file_path>, or gbrain init --supabase',
+    );
+  }
+
+  if (isPGliteConfig(config) && !config.database_path) {
+    throw new GBrainError(
+      'No database path',
+      'database_path is missing from config for pglite engine',
+      'Run gbrain init --pglite <file_path>',
     );
   }
 
   try {
-    sql = postgres(url, {
+    const connectionUrl = isPGliteConfig(config)
+      ? (pgliteBridge = await startPGliteBridge(config.database_path!)).connectionString
+      : url!;
+    sql = postgres(connectionUrl, {
       max: 10,
       idle_timeout: 20,
       connect_timeout: 10,
@@ -43,6 +58,10 @@ export async function connect(config: EngineConfig): Promise<void> {
     await sql`SELECT 1`;
   } catch (e: unknown) {
     sql = null;
+    if (pgliteBridge) {
+      await pgliteBridge.stop();
+      pgliteBridge = null;
+    }
     const msg = e instanceof Error ? e.message : String(e);
     throw new GBrainError(
       'Cannot connect to database',
@@ -56,6 +75,10 @@ export async function disconnect(): Promise<void> {
   if (sql) {
     await sql.end();
     sql = null;
+  }
+  if (pgliteBridge) {
+    await pgliteBridge.stop();
+    pgliteBridge = null;
   }
 }
 

--- a/src/core/pglite.ts
+++ b/src/core/pglite.ts
@@ -1,0 +1,67 @@
+import { dirname, resolve } from 'path';
+import { mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { PGlite } from '@electric-sql/pglite';
+import { vector } from '@electric-sql/pglite/vector';
+import { pg_trgm } from '@electric-sql/pglite/contrib/pg_trgm';
+import { PGLiteSocketServer } from '@electric-sql/pglite-socket';
+import type { EngineConfig } from './types.ts';
+
+export interface PGliteBridgeHandle {
+  connectionString: string;
+  stop(): Promise<void>;
+}
+
+export function getPGliteDataDir(databasePath: string): string {
+  const expandedPath = databasePath.startsWith('~/')
+    ? resolve(homedir(), databasePath.slice(2))
+    : resolve(databasePath);
+  return `${expandedPath}.pglite`;
+}
+
+export function isPGliteConfig(config: EngineConfig | null | undefined): boolean {
+  return config?.engine === 'pglite';
+}
+
+export function resolveImportWorkerCount(requestedWorkers: number, config: EngineConfig | null | undefined): number {
+  if (isPGliteConfig(config)) return 1;
+  return requestedWorkers;
+}
+
+export async function startPGliteBridge(databasePath: string): Promise<PGliteBridgeHandle> {
+  const dataDir = getPGliteDataDir(databasePath);
+  mkdirSync(dirname(dataDir), { recursive: true });
+
+  const db = await PGlite.create(dataDir, {
+    extensions: {
+      vector,
+      pg_trgm,
+    },
+  });
+
+  await db.exec(`
+    CREATE EXTENSION IF NOT EXISTS vector;
+    CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  `);
+
+  const server = new PGLiteSocketServer({
+    db,
+    host: '127.0.0.1',
+    port: 0,
+    maxConnections: 4,
+  });
+  await server.start();
+
+  const rawConn = server.getServerConn();
+  const connectionString = rawConn.includes('://')
+    ? rawConn
+    : `postgresql://postgres@${rawConn}/postgres`;
+
+  return {
+    connectionString,
+    async stop() {
+      await server.stop();
+      await db.close();
+    },
+  };
+}

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -18,6 +18,7 @@ import type {
 } from './types.ts';
 import { GBrainError } from './types.ts';
 import * as db from './db.ts';
+import { isPGliteConfig } from './pglite.ts';
 
 export class PostgresEngine implements BrainEngine {
   private _sql: ReturnType<typeof postgres> | null = null;
@@ -30,6 +31,14 @@ export class PostgresEngine implements BrainEngine {
 
   // Lifecycle
   async connect(config: EngineConfig & { poolSize?: number }): Promise<void> {
+    if (isPGliteConfig(config) && config.poolSize) {
+      throw new GBrainError(
+        'PGlite does not support pooled worker connections',
+        'poolSize was requested while using the pglite engine',
+        'Run imports with a single worker in pglite mode',
+      );
+    }
+
     if (config.poolSize) {
       // Instance-level connection for worker isolation
       const url = config.database_url;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -167,7 +167,7 @@ export interface IngestLogInput {
 export interface EngineConfig {
   database_url?: string;
   database_path?: string;
-  engine?: 'postgres' | 'sqlite';
+  engine?: 'postgres' | 'sqlite' | 'pglite';
 }
 
 // Errors

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from 'bun:test';
-import { readFileSync } from 'fs';
+import { readFileSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
 // redactUrl is not exported, so we test it by reading the source and
 // reimplementing the regex to verify the pattern, then test via CLI
@@ -59,5 +61,46 @@ describe('config source correctness', () => {
 
   test('redactUrl uses the correct regex pattern', () => {
     expect(configSource).toContain('postgresql:\\/\\/');
+  });
+});
+
+describe('setup guidance strings', () => {
+  test('CLI no-config help includes postgres and pglite setup paths', async () => {
+    const cliSource = readFileSync(
+      new URL('../src/cli.ts', import.meta.url),
+      'utf-8',
+    );
+    expect(cliSource).toContain('gbrain init --url <connection_string>');
+    expect(cliSource).toContain('gbrain init --pglite <file_path>');
+  });
+});
+
+describe('loadConfig precedence', () => {
+  test('DATABASE_URL overrides persisted pglite engine config', () => {
+    const home = join(tmpdir(), `gbrain-config-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const hermesHome = join(home, '.gbrain');
+    mkdirSync(hermesHome, { recursive: true });
+    writeFileSync(join(hermesHome, 'config.json'), JSON.stringify({
+      engine: 'pglite',
+      database_path: '/tmp/local.db',
+    }));
+
+    const result = Bun.spawnSync({
+      cmd: ['bun', '--eval', `import { loadConfig } from './src/core/config.ts'; console.log(JSON.stringify(loadConfig()));`],
+      cwd: join(import.meta.dir, '..'),
+      env: {
+        ...process.env,
+        HOME: home,
+        DATABASE_URL: 'postgresql://override-host:5432/gbrain',
+      },
+    });
+
+    const stdout = new TextDecoder().decode(result.stdout).trim();
+    rmSync(home, { recursive: true, force: true });
+
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.engine).toBe('postgres');
+    expect(parsed.database_url).toBe('postgresql://override-host:5432/gbrain');
   });
 });

--- a/test/pglite.test.ts
+++ b/test/pglite.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import postgres from 'postgres';
+import { getPGliteDataDir, resolveImportWorkerCount, startPGliteBridge } from '../src/core/pglite.ts';
+
+const cleanupPaths = new Set<string>();
+
+function makeTempPath(name: string): string {
+  const path = join(tmpdir(), `gbrain-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  cleanupPaths.add(path);
+  return path;
+}
+
+afterEach(() => {
+  for (const path of cleanupPaths) {
+    if (existsSync(path)) rmSync(path, { recursive: true, force: true });
+  }
+  cleanupPaths.clear();
+});
+
+describe('pglite path handling', () => {
+  test('maps configured file path to an internal pglite data dir', () => {
+    expect(getPGliteDataDir('/tmp/brain.db')).toBe('/tmp/brain.db.pglite');
+  });
+
+  test('expands tilde-prefixed file paths into the user home directory', () => {
+    expect(getPGliteDataDir('~/.gbrain/brain.db')).toContain('/.gbrain/brain.db.pglite');
+    expect(getPGliteDataDir('~/.gbrain/brain.db')).not.toContain('/~/.gbrain/brain.db.pglite');
+  });
+});
+
+describe('embedded import worker policy', () => {
+  test('forces single-worker import in pglite mode', () => {
+    expect(resolveImportWorkerCount(4, { engine: 'pglite', database_path: '/tmp/brain.db' })).toBe(1);
+  });
+
+  test('keeps requested worker count for postgres mode', () => {
+    expect(resolveImportWorkerCount(4, { engine: 'postgres', database_url: 'postgresql://example' })).toBe(4);
+  });
+});
+
+describe('pglite socket bridge', () => {
+  test('supports postgres client queries plus vector/trgm/trigger features', async () => {
+    const databasePath = makeTempPath('brain.db');
+    const bridge = await startPGliteBridge(databasePath);
+    const sql = postgres(bridge.connectionString, { max: 1, idle_timeout: 1, connect_timeout: 5 });
+
+    try {
+      const one = await sql`SELECT 1 as n`;
+      expect(one[0].n).toBe(1);
+
+      await sql.unsafe(`
+        CREATE EXTENSION IF NOT EXISTS vector;
+        CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+        CREATE TABLE items (
+          id SERIAL PRIMARY KEY,
+          title TEXT NOT NULL,
+          embedding vector(3),
+          search_vector tsvector,
+          touched_at TIMESTAMPTZ
+        );
+
+        CREATE INDEX idx_items_title_trgm ON items USING GIN(title gin_trgm_ops);
+        CREATE INDEX idx_items_embedding ON items USING hnsw (embedding vector_cosine_ops);
+
+        CREATE OR REPLACE FUNCTION touch_items() RETURNS trigger AS $$
+        BEGIN
+          NEW.touched_at := now();
+          NEW.search_vector := to_tsvector('english', NEW.title);
+          RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+
+        CREATE TRIGGER trg_touch_items
+          BEFORE INSERT OR UPDATE ON items
+          FOR EACH ROW
+          EXECUTE FUNCTION touch_items();
+      `);
+
+      await sql.unsafe(`INSERT INTO items (title, embedding) VALUES ('hello world', '[1,2,3]'::vector)`);
+      const rows = await sql.unsafe(`SELECT title, touched_at IS NOT NULL AS touched, search_vector::text AS sv FROM items`);
+      expect(rows[0].title).toBe('hello world');
+      expect(rows[0].touched).toBe(true);
+      expect(String(rows[0].sv)).toContain('hello');
+    } finally {
+      await sql.end();
+      await bridge.stop();
+    }
+  }, 30000);
+});

--- a/test/setup-branching.test.ts
+++ b/test/setup-branching.test.ts
@@ -1,11 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { extractProjectRef } from '../src/core/supabase-admin.ts';
-import { cpus, totalmem } from 'os';
-
-// IPv6 detection (mirrors logic in init.ts)
-function isSupabaseDirectUrl(url: string): boolean {
-  return /db\.[a-z]+\.supabase\.co/.test(url) || url.includes('.supabase.co:5432');
-}
+import { isSupabaseDirectUrl, getConnectionHelpText, getPGliteHelpText } from '../src/commands/init.ts';
 
 describe('IPv6 detection', () => {
   test('detects db.xxx.supabase.co as direct (IPv6)', () => {
@@ -57,6 +52,22 @@ describe('defaultWorkers auto-tuning', () => {
   test('returns at least 2 for any CPU count', () => {
     const result = defaultWorkers(1, 8);
     expect(result).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('connection help text', () => {
+  test('mentions generic Postgres before Supabase specifics', () => {
+    const help = getConnectionHelpText();
+    expect(help).toContain('Enter your Postgres connection URL');
+    expect(help).toContain('Local Postgres');
+    expect(help).toContain('Hosted Postgres');
+    expect(help).toContain('Supabase pooler');
+  });
+
+  test('mentions experimental pglite local file mode', () => {
+    const help = getPGliteHelpText();
+    expect(help).toContain('gbrain init --pglite ~/.gbrain/brain.db');
+    expect(help).toContain('experimental');
   });
 });
 


### PR DESCRIPTION
## Summary
- add experimental `--pglite <file>` init path for a persisted local-file GBrain DB
- start PGlite with `pgvector` + `pg_trgm`, then expose it through `pglite-socket` so the existing `postgres.js`-based engine can keep working
- force single-worker import in PGlite mode for the first implementation
- add targeted tests plus smoke coverage for vector/HNSW/trigger compatibility and config precedence

## Why
This reduces adoption friction by letting GBrain run without provisioning an external Postgres service, which fits many OpenClaw / Hermes Agent local runtime environments.

## Test Plan
- `bun test test/pglite.test.ts test/setup-branching.test.ts test/config.test.ts`
- smoke tested:
  - `gbrain init --pglite ~/.gbrain/brain.db --json`
  - `gbrain import --no-embed --workers 4 <repo>` (forced to single-worker in pglite mode)
  - `gbrain stats`
  - `gbrain search Victor`

## Notes / Caveats
- this PR is intentionally **draft** because the feature is still experimental
- current implementation uses a local unauthenticated socket bridge on `127.0.0.1` while GBrain is running; that is acceptable for local single-user workflows but should not be oversold as hardened
- import concurrency is intentionally constrained to 1 worker in PGlite mode for now

Closes #32
