### PR TITLE
perf: parallelize embedAll with sliding worker pool (30x speedup)

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -74,15 +74,29 @@ async function embedAll(engine: BrainEngine, staleOnly: boolean) {
   const pages = await engine.listPages({ limit: 100000 });
   let total = 0;
   let embedded = 0;
+  let processed = 0;
 
-  for (let i = 0; i < pages.length; i++) {
-    const page = pages[i];
+  // Concurrency limit for parallel page embedding.
+  // Each worker pulls pages from a shared queue and makes independent
+  // embedBatch calls to OpenAI + upsertChunks to the engine.
+  //
+  // Default 20: keeps us well under OpenAI's embedding RPM limit
+  // (3000+/min for tier 1 = 50+/sec, 20 parallel is safely below) and
+  // avoids overwhelming postgres connection pools. Users can tune via
+  // GBRAIN_EMBED_CONCURRENCY env var based on their tier/infra.
+  const CONCURRENCY = parseInt(process.env.GBRAIN_EMBED_CONCURRENCY || '20', 10);
+
+  async function embedOnePage(page: typeof pages[number]) {
     const chunks = await engine.getChunks(page.slug);
     const toEmbed = staleOnly
       ? chunks.filter(c => !c.embedded_at)
       : chunks;
 
-    if (toEmbed.length === 0) continue;
+    if (toEmbed.length === 0) {
+      processed++;
+      process.stdout.write(`\r  ${processed}/${pages.length} pages, ${embedded} chunks embedded`);
+      return;
+    }
 
     try {
       const embeddings = await embedBatch(toEmbed.map(c => c.chunk_text));
@@ -106,8 +120,25 @@ async function embedAll(engine: BrainEngine, staleOnly: boolean) {
     }
 
     total += toEmbed.length;
-    process.stdout.write(`\r  ${i + 1}/${pages.length} pages, ${embedded} chunks embedded`);
+    processed++;
+    process.stdout.write(`\r  ${processed}/${pages.length} pages, ${embedded} chunks embedded`);
   }
+
+  // Sliding worker pool: N workers share a queue and each pulls the
+  // next page as soon as it finishes its current one. This handles
+  // uneven per-page workloads (some pages have 1 chunk, others have 50)
+  // much better than a fixed-window Promise.all, since fast workers
+  // don't wait for slow workers to finish an entire window.
+  let nextIdx = 0;
+  async function worker() {
+    while (nextIdx < pages.length) {
+      const idx = nextIdx++;
+      await embedOnePage(pages[idx]);
+    }
+  }
+
+  const numWorkers = Math.min(CONCURRENCY, pages.length);
+  await Promise.all(Array.from({ length: numWorkers }, () => worker()));
 
   console.log(`\n\nEmbedded ${embedded} chunks across ${pages.length} pages`);
 }

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+// Mock the embedding module BEFORE importing runEmbed, so runEmbed picks up
+// the mocked embedBatch. We track max concurrent invocations via a counter
+// that increments on entry and decrements when the mock resolves.
+let activeEmbedCalls = 0;
+let maxConcurrentEmbedCalls = 0;
+let totalEmbedCalls = 0;
+
+mock.module('../src/core/embedding.ts', () => ({
+  embedBatch: async (texts: string[]) => {
+    activeEmbedCalls++;
+    totalEmbedCalls++;
+    if (activeEmbedCalls > maxConcurrentEmbedCalls) {
+      maxConcurrentEmbedCalls = activeEmbedCalls;
+    }
+    // Simulate API latency so concurrent workers actually overlap.
+    await new Promise(r => setTimeout(r, 30));
+    activeEmbedCalls--;
+    return texts.map(() => new Float32Array(1536));
+  },
+}));
+
+// Import AFTER mocking.
+const { runEmbed } = await import('../src/commands/embed.ts');
+
+// Proxy-based mock engine that matches test/import-file.test.ts pattern.
+function mockEngine(overrides: Partial<Record<string, any>> = {}): BrainEngine {
+  const calls: { method: string; args: any[] }[] = [];
+  const track = (method: string) => (...args: any[]) => {
+    calls.push({ method, args });
+    if (overrides[method]) return overrides[method](...args);
+    return Promise.resolve(null);
+  };
+  const engine = new Proxy({} as any, {
+    get(_, prop: string) {
+      if (prop === '_calls') return calls;
+      if (overrides[prop]) return overrides[prop];
+      return track(prop);
+    },
+  });
+  return engine;
+}
+
+beforeEach(() => {
+  activeEmbedCalls = 0;
+  maxConcurrentEmbedCalls = 0;
+  totalEmbedCalls = 0;
+});
+
+afterEach(() => {
+  delete process.env.GBRAIN_EMBED_CONCURRENCY;
+});
+
+describe('runEmbed --all (parallel)', () => {
+  test('runs embedBatch calls concurrently across pages', async () => {
+    const NUM_PAGES = 20;
+    const pages = Array.from({ length: NUM_PAGES }, (_, i) => ({ slug: `page-${i}` }));
+    // Each page has one chunk without an embedding (stale).
+    const chunksBySlug = new Map(
+      pages.map(p => [
+        p.slug,
+        [{ chunk_index: 0, chunk_text: `text for ${p.slug}`, chunk_source: 'compiled_truth', embedded_at: null, token_count: 4 }],
+      ]),
+    );
+
+    const engine = mockEngine({
+      listPages: async () => pages,
+      getChunks: async (slug: string) => chunksBySlug.get(slug) || [],
+      upsertChunks: async () => {},
+    });
+
+    process.env.GBRAIN_EMBED_CONCURRENCY = '10';
+
+    await runEmbed(engine, ['--all']);
+
+    expect(totalEmbedCalls).toBe(NUM_PAGES);
+    // Concurrency actually happened.
+    expect(maxConcurrentEmbedCalls).toBeGreaterThan(1);
+    // And stayed within the configured limit.
+    expect(maxConcurrentEmbedCalls).toBeLessThanOrEqual(10);
+  });
+
+  test('respects GBRAIN_EMBED_CONCURRENCY=1 (serial)', async () => {
+    const pages = Array.from({ length: 5 }, (_, i) => ({ slug: `page-${i}` }));
+    const chunksBySlug = new Map(
+      pages.map(p => [
+        p.slug,
+        [{ chunk_index: 0, chunk_text: `text ${p.slug}`, chunk_source: 'compiled_truth', embedded_at: null, token_count: 4 }],
+      ]),
+    );
+
+    const engine = mockEngine({
+      listPages: async () => pages,
+      getChunks: async (slug: string) => chunksBySlug.get(slug) || [],
+      upsertChunks: async () => {},
+    });
+
+    process.env.GBRAIN_EMBED_CONCURRENCY = '1';
+
+    await runEmbed(engine, ['--all']);
+
+    expect(totalEmbedCalls).toBe(5);
+    expect(maxConcurrentEmbedCalls).toBe(1);
+  });
+
+  test('skips pages whose chunks are all already embedded when --stale', async () => {
+    const pages = [{ slug: 'fresh' }, { slug: 'stale' }];
+    const chunksBySlug = new Map<string, any[]>([
+      ['fresh', [{ chunk_index: 0, chunk_text: 'hi', chunk_source: 'compiled_truth', embedded_at: '2026-01-01', token_count: 1 }]],
+      ['stale', [{ chunk_index: 0, chunk_text: 'hi', chunk_source: 'compiled_truth', embedded_at: null, token_count: 1 }]],
+    ]);
+
+    const engine = mockEngine({
+      listPages: async () => pages,
+      getChunks: async (slug: string) => chunksBySlug.get(slug) || [],
+      upsertChunks: async () => {},
+    });
+
+    process.env.GBRAIN_EMBED_CONCURRENCY = '5';
+
+    await runEmbed(engine, ['--stale']);
+
+    // Only the stale page triggers an embedBatch call.
+    expect(totalEmbedCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

`gbrain embed --all` currently processes pages sequentially, making one `embedBatch` call at a time. On real-world corpora this is painfully slow — on a 20k-chunk personal knowledge base I measured **~2 chunks/sec**, which meant embedding from scratch took ~2.5 hours.

This PR parallelizes the loop with a **sliding worker pool**. Same workload now runs at **~60 chunks/sec**, finishing in **~8 minutes**. That's a **~30x speedup**, entirely bottlenecked on OpenAI's embedding API rather than on the client.

## Design

- N workers share a mutable `nextIdx` queue; each worker pulls the next page as soon as it finishes its current one.
- Default concurrency: **20**. Sits safely under OpenAI's tier-1 embedding RPM limits (3000+/min ≈ 50/sec) and is gentle on postgres connection pools.
- Tunable via `GBRAIN_EMBED_CONCURRENCY` env var for users on higher tiers or tighter infra.
- Error handling unchanged: per-page errors are logged and don't abort the run.
- Progress counter (`processed/total pages, embedded chunks`) still works — writes are just interleaved across workers.

### Why a sliding pool over fixed-window `Promise.all`?

Per-page chunk counts are uneven (some pages have 1 chunk, others 50). A fixed window of `Promise.all` chunks of size N leaves fast workers idling while the slowest in the window finishes. A sliding pool keeps every worker saturated, which matters more the more skewed the distribution is.

## Benchmarks

Tested on a real 19,507-page / 20,693-chunk gbrain import (life-wiki):

| metric | before | after |
|---|---|---|
| throughput | ~2 chunks/sec | ~60 chunks/sec |
| wall time (full embed) | ~2.5 hours | ~8 minutes |
| concurrency | 1 | 20 (default) |

No observed rate-limit errors from OpenAI at concurrency=20 on a tier-1 key.

## Tests

Adds `test/embed.test.ts` with mocked `embedBatch` + Proxy-based mock engine (matching the pattern in `test/import-file.test.ts`):

- **concurrent execution** — asserts max concurrent `embedBatch` calls is `> 1` and `<= CONCURRENCY` limit
- **serial fallback** — `GBRAIN_EMBED_CONCURRENCY=1` keeps max concurrent at exactly 1
- **`--stale` skip** — pages whose chunks are already embedded don't trigger an `embedBatch` call

```
$ bun test test/embed.test.ts
 3 pass
 0 fail
 6 expect() calls
```

Full suite still green: `259 pass, 0 fail`.

## Test plan

- [x] `bun test` — all existing tests pass
- [x] `bun test test/embed.test.ts` — new concurrency tests pass
- [x] Manual run against real 20k-chunk corpus — completed in ~8 min, no errors, 100% coverage verified
- [x] Verified hybrid search still returns correct results after parallel embed