### PR TITLE
fix: log embedding failures and fix O(n²) chunk lookup in embedPage

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -54,17 +54,17 @@ async function embedPage(engine: BrainEngine, slug: string) {
   }
 
   const embeddings = await embedBatch(toEmbed.map(c => c.chunk_text));
-  const updated: ChunkInput[] = chunks.map((c, i) => {
-    const needsEmbed = toEmbed.find(te => te.chunk_index === c.chunk_index);
-    const embIdx = needsEmbed ? toEmbed.indexOf(needsEmbed) : -1;
-    return {
-      chunk_index: c.chunk_index,
-      chunk_text: c.chunk_text,
-      chunk_source: c.chunk_source,
-      embedding: embIdx >= 0 ? embeddings[embIdx] : undefined,
-      token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
-    };
-  });
+  const embeddingMap = new Map<number, Float32Array>();
+  for (let j = 0; j < toEmbed.length; j++) {
+    embeddingMap.set(toEmbed[j].chunk_index, embeddings[j]);
+  }
+  const updated: ChunkInput[] = chunks.map(c => ({
+    chunk_index: c.chunk_index,
+    chunk_text: c.chunk_text,
+    chunk_source: c.chunk_source,
+    embedding: embeddingMap.get(c.chunk_index),
+    token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
+  }));
 
   await engine.upsertChunks(slug, updated);
   console.log(`${slug}: embedded ${toEmbed.length} chunks`);

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -67,7 +67,9 @@ export async function importFromContent(
         chunks[i].embedding = embeddings[i];
         chunks[i].token_count = Math.ceil(chunks[i].chunk_text.length / 4);
       }
-    } catch { /* non-fatal */ }
+    } catch (e: unknown) {
+      console.error(`  Warning: embedding failed for ${slug}: ${e instanceof Error ? e.message : String(e)}`);
+    }
   }
 
   // Transaction wraps all DB writes


### PR DESCRIPTION
## Summary

- Log embedding errors in `importFromContent()` instead of silently swallowing them
- Replace O(n²) `find()` + `indexOf()` with Map lookup in `embedPage()`, matching the pattern already used by `embedAll()` in the same file

## Details

### 1. Silent embedding failure (`src/core/import-file.ts`)

`importFromContent()` had a bare `catch { /* non-fatal */ }` that swallowed all embedding errors — API rate limits, auth failures, timeouts, network issues. Pages got imported without embeddings but the user had no indication why vector search was returning poor results.

Now logs:
```
Warning: embedding failed for my-page: 429 Too Many Requests
```

The error is still non-fatal (page import continues without embeddings), but at least the user knows what happened and can run `gbrain embed --stale` to fix it.

### 2. O(n²) chunk lookup (`src/commands/embed.ts`)

`embedPage()` used `toEmbed.find()` + `toEmbed.indexOf()` for every chunk to map embeddings back — two linear scans per chunk. Replaced with a single `Map<number, Float32Array>` lookup, matching the pattern `embedAll()` already uses 30 lines below in the same file.

## Test plan

- [x] All 256 unit tests pass (`bun test` — 0 failures)
- [x] 9/9 `import-file.test.ts` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)