### PR TITLE
feat(list_pages): add tags_all / tags_any for AND / OR tag filtering

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -111,8 +111,17 @@ function parseOpArgs(op: Operation, args: string[]): Record<string, unknown> {
       if (paramDef?.type === 'boolean') {
         params[key] = true;
       } else if (i + 1 < args.length) {
-        params[key] = args[++i];
-        if (paramDef?.type === 'number') params[key] = Number(params[key]);
+        const raw = args[++i];
+        if (paramDef?.type === 'number') {
+          params[key] = Number(raw);
+        } else if (paramDef?.type === 'array') {
+          // Comma-separated values, or repeated flag. Repeat appends, comma splits.
+          const parts = raw.split(',').map(s => s.trim()).filter(Boolean);
+          const existing = (params[key] as string[] | undefined) || [];
+          params[key] = [...existing, ...parts];
+        } else {
+          params[key] = raw;
+        }
       }
     } else if (posIdx < positional.length) {
       const key = positional[posIdx++];
@@ -343,7 +352,8 @@ PAGES
   get <slug>                         Read a page
   put <slug> [< file.md]             Write/update a page
   delete <slug>                      Delete a page
-  list [--type T] [--tag T] [-n N]   List pages
+  list [--type T] [--tag T] [--tags-all t1,t2] [--tags-any t1,t2] [-n N]
+                                     List pages (tags-all = AND, tags-any = OR)
 
 SEARCH
   search <query>                     Keyword search (tsvector)

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -146,16 +146,28 @@ const delete_page: Operation = {
 
 const list_pages: Operation = {
   name: 'list_pages',
-  description: 'List pages with optional filters',
+  description: 'List pages with optional filters. Tag filters can be combined: `tags_all` requires every tag to be present on a page (AND), `tags_any` requires at least one of the listed tags to be present (OR). Use namespaced tag values like `firm_type:saas`, `theme:leadership`.',
   params: {
     type: { type: 'string', description: 'Filter by page type' },
-    tag: { type: 'string', description: 'Filter by tag' },
+    tag: { type: 'string', description: 'Filter by a single tag (legacy, prefer tags_all)' },
+    tags_all: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Require every tag in this list to be present on the page (AND semantics).',
+    },
+    tags_any: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Require at least one tag in this list to be present on the page (OR semantics).',
+    },
     limit: { type: 'number', description: 'Max results (default 50)' },
   },
   handler: async (ctx, p) => {
     const pages = await ctx.engine.listPages({
       type: p.type as any,
       tag: p.tag as string,
+      tags_all: p.tags_all as string[] | undefined,
+      tags_any: p.tags_any as string[] | undefined,
       limit: (p.limit as number) || 50,
     });
     return pages.map(pg => ({

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -127,32 +127,60 @@ export class PostgresEngine implements BrainEngine {
     const limit = filters?.limit || 100;
     const offset = filters?.offset || 0;
 
-    let rows;
-    if (filters?.type && filters?.tag) {
-      rows = await sql`
-        SELECT p.* FROM pages p
-        JOIN tags t ON t.page_id = p.id
-        WHERE p.type = ${filters.type} AND t.tag = ${filters.tag}
-        ORDER BY p.updated_at DESC LIMIT ${limit} OFFSET ${offset}
-      `;
-    } else if (filters?.type) {
-      rows = await sql`
-        SELECT * FROM pages WHERE type = ${filters.type}
-        ORDER BY updated_at DESC LIMIT ${limit} OFFSET ${offset}
-      `;
-    } else if (filters?.tag) {
-      rows = await sql`
-        SELECT p.* FROM pages p
-        JOIN tags t ON t.page_id = p.id
-        WHERE t.tag = ${filters.tag}
-        ORDER BY p.updated_at DESC LIMIT ${limit} OFFSET ${offset}
-      `;
-    } else {
-      rows = await sql`
-        SELECT * FROM pages
-        ORDER BY updated_at DESC LIMIT ${limit} OFFSET ${offset}
-      `;
+    // Normalize single `tag` into `tags_all` so all tag filters share one code path.
+    const tagsAll: string[] = [
+      ...(filters?.tag ? [filters.tag] : []),
+      ...(filters?.tags_all ?? []),
+    ];
+    const tagsAny: string[] = filters?.tags_any ?? [];
+
+    // Fast path: no tag filters -> plain query (no joins).
+    if (tagsAll.length === 0 && tagsAny.length === 0) {
+      const rows = filters?.type
+        ? await sql`
+            SELECT * FROM pages WHERE type = ${filters.type}
+            ORDER BY updated_at DESC LIMIT ${limit} OFFSET ${offset}
+          `
+        : await sql`
+            SELECT * FROM pages
+            ORDER BY updated_at DESC LIMIT ${limit} OFFSET ${offset}
+          `;
+      return rows.map(rowToPage);
     }
+
+    // Tag-filter path: GROUP BY + HAVING counts, composable across tags_all and tags_any.
+    //
+    // Strategy:
+    //   WHERE t.tag = ANY($candidate) AND (p.type filter if any)
+    //   GROUP BY p.id
+    //   HAVING count DISTINCT matching tags_all = tags_all.length
+    //      AND (tags_any empty OR count DISTINCT matching tags_any >= 1)
+    //
+    // The candidate set is the union of tags_all and tags_any so one join covers both.
+    const candidate = [...new Set([...tagsAll, ...tagsAny])];
+
+    const typeClause = filters?.type
+      ? sql`AND p.type = ${filters.type}`
+      : sql``;
+
+    const havingAll = tagsAll.length > 0
+      ? sql`COUNT(DISTINCT t.tag) FILTER (WHERE t.tag = ANY(${tagsAll})) = ${tagsAll.length}`
+      : sql`TRUE`;
+
+    const havingAny = tagsAny.length > 0
+      ? sql`AND COUNT(DISTINCT t.tag) FILTER (WHERE t.tag = ANY(${tagsAny})) >= 1`
+      : sql``;
+
+    const rows = await sql`
+      SELECT p.* FROM pages p
+      JOIN tags t ON t.page_id = p.id
+      WHERE t.tag = ANY(${candidate})
+      ${typeClause}
+      GROUP BY p.id
+      HAVING ${havingAll} ${havingAny}
+      ORDER BY p.updated_at DESC
+      LIMIT ${limit} OFFSET ${offset}
+    `;
 
     return rows.map(rowToPage);
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -26,6 +26,8 @@ export interface PageInput {
 export interface PageFilters {
   type?: PageType;
   tag?: string;
+  tags_all?: string[];
+  tags_any?: string[];
   limit?: number;
   offset?: number;
 }

--- a/test/e2e/mechanical.test.ts
+++ b/test/e2e/mechanical.test.ts
@@ -94,6 +94,67 @@ describeE2E('E2E: Page CRUD', () => {
     expect(ycPages.some((p: any) => p.slug === 'people/sarah-chen')).toBe(true);
   });
 
+  test('list_pages tags_all AND: two required tags both present', async () => {
+    // Sarah Chen has tags: founder, yc-w25, ai-agents. Only page with both founder+yc-w25.
+    const pages = await callOp('list_pages', {
+      tags_all: ['founder', 'yc-w25'],
+    }) as any[];
+    expect(pages.length).toBe(1);
+    expect(pages[0].slug).toBe('people/sarah-chen');
+  });
+
+  test('list_pages tags_all AND: no page has all three, empty result', async () => {
+    // No single page has founder AND investor AND technical.
+    const pages = await callOp('list_pages', {
+      tags_all: ['founder', 'investor', 'technical'],
+    }) as any[];
+    expect(pages.length).toBe(0);
+  });
+
+  test('list_pages tags_all AND: one tag nonexistent, empty result', async () => {
+    const pages = await callOp('list_pages', {
+      tags_all: ['founder', 'tag-that-does-not-exist'],
+    }) as any[];
+    expect(pages.length).toBe(0);
+  });
+
+  test('list_pages tags_any OR: any of the listed tags matches', async () => {
+    // investor -> Marcus Reid; technical -> Priya Patel. Both should be returned.
+    const pages = await callOp('list_pages', {
+      tags_any: ['investor', 'technical'],
+    }) as any[];
+    const slugs = pages.map((p: any) => p.slug).sort();
+    expect(slugs).toContain('people/marcus-reid');
+    expect(slugs).toContain('people/priya-patel');
+    expect(slugs).not.toContain('people/sarah-chen');
+  });
+
+  test('list_pages tags_all + tags_any combined', async () => {
+    // Must have yc-w25 AND (founder OR investor). Only Sarah Chen satisfies.
+    const pages = await callOp('list_pages', {
+      tags_all: ['yc-w25'],
+      tags_any: ['founder', 'investor'],
+    }) as any[];
+    expect(pages.length).toBe(1);
+    expect(pages[0].slug).toBe('people/sarah-chen');
+  });
+
+  test('list_pages type filter + tags_all composes', async () => {
+    const pages = await callOp('list_pages', {
+      type: 'person',
+      tags_all: ['ai-agents'],
+    }) as any[];
+    expect(pages.length).toBe(1);
+    expect(pages[0].slug).toBe('people/sarah-chen');
+    expect(pages[0].type).toBe('person');
+  });
+
+  test('list_pages legacy tag param still works alongside tags_all', async () => {
+    // `tag` is normalized into tags_all internally.
+    const pages = await callOp('list_pages', { tag: 'founder' }) as any[];
+    expect(pages.some((p: any) => p.slug === 'people/sarah-chen')).toBe(true);
+  });
+
   test('put_page updates existing page', async () => {
     const updated = readFileSync(join(FIXTURES_PATH, 'people/sarah-chen.md'), 'utf-8')
       .replace('Stanford CS', 'MIT CS');


### PR DESCRIPTION
## Summary

Extends `list_pages` (and the underlying `listPages` engine method) to accept two new array params:

- **`tags_all: string[]`** — every listed tag must be present on the page (AND)
- **`tags_any: string[]`** — at least one listed tag must be present (OR)

Both compose with each other and with the existing `type` filter. The existing single-tag `tag` param is fully preserved and is normalized into `tags_all` internally, so all tag filtering now flows through one code path with exact-match semantics via `GROUP BY page_id` + `HAVING COUNT(DISTINCT tag) FILTER (WHERE ...)`.

No schema changes. No breaking changes. Fast path unchanged: queries with no tag filter still hit `pages` directly with no join.

## Motivation

The current `list_pages` takes at most one tag string, which is fine for simple lookups but rules out AND-of-tags segmentation. The moment a user starts storing namespaced classification tags like `firm_type:saas`, `geo_country:SG`, `function:product`, `seniority:director` and wants to ask "who are the SaaS product directors in Singapore?", single-tag filtering can't express it - you have to fall back to dumping a large candidate set and filtering in application code, which defeats the purpose of having tags in the database.

This came up while building a personal CRM on top of GBrain. The CRM uses GBrain's existing `tags` table with namespaced values (`firm_type:*`, `function:*`, `theme:*`, `domain:*`, etc.) and needs arbitrary AND + OR combinations for outreach segmentation. Rather than ship a custom query helper in the app, extending the built-in operation felt cleaner - other users will almost certainly want multi-dimensional tag queries once they start tagging seriously.

## API

```ts
// AND: must have all three tags
list_pages({ tags_all: ['firm_type:saas', 'function:product', 'seniority:director'] })

// OR: must have at least one
list_pages({ tags_any: ['geo_country:SG', 'geo_country:MY', 'geo_country:ID'] })

// Combined: must be a SaaS product director in any ASEAN country
list_pages({
  type: 'person',
  tags_all: ['firm_type:saas', 'function:product', 'seniority:director'],
  tags_any: ['geo_country:SG', 'geo_country:MY', 'geo_country:ID', 'geo_country:TH', 'geo_country:VN', 'geo_country:PH'],
})
```

CLI supports both via comma-separated values and repeated flags:

```bash
gbrain list --type person --tags-all firm_type:saas,function:product
gbrain list --tags-any investor,founder --tags-all yc-w25
```

## Implementation

- **`src/core/types.ts`** — added `tags_all?: string[]` and `tags_any?: string[]` to `PageFilters`
- **`src/core/postgres-engine.ts`** — rewrote `listPages`:
  - Fast path when no tag filters: unchanged, no join
  - Tag filter path: one query with `JOIN tags`, `GROUP BY p.id`, `HAVING COUNT(DISTINCT t.tag) FILTER (WHERE t.tag = ANY($all)) = $all.length AND COUNT(DISTINCT t.tag) FILTER (WHERE t.tag = ANY($any)) >= 1`
  - Legacy `tag` param is prepended to `tags_all` internally
- **`src/core/operations.ts`** — added the two array params with descriptions. `'array'` was already a supported `ParamDef` type so no changes to the contract or MCP schema generation.
- **`src/cli.ts`** — `parseOpArgs` now handles `type: 'array'` params by splitting on commas and appending on repeat
- **`test/e2e/mechanical.test.ts`** — 7 new E2E tests

## Tests

7 new E2E tests against the existing fixtures (Sarah Chen has `founder, yc-w25, ai-agents`; Marcus Reid has `investor, ai-focus`; Priya Patel has `technical, ai-research`):

1. `tags_all` AND with two required tags both present — returns exactly Sarah Chen
2. `tags_all` AND where no single page has all three required tags — empty result
3. `tags_all` AND with one nonexistent tag — empty result
4. `tags_any` OR — returns Marcus and Priya (investor OR technical), excludes Sarah
5. `tags_all` + `tags_any` combined (`yc-w25` AND (`founder` OR `investor`)) — returns only Sarah
6. `type` + `tags_all` composes correctly — person with `ai-agents` returns Sarah
7. Legacy `tag` param still works (normalized into `tags_all` internally)

Full suite result on a fresh pgvector container off `master`:

- Unit: 276 pass, 0 fail (1 unrelated pre-existing S3Storage test fails because `@aws-sdk/client-s3` isn't resolvable in my local `node_modules` — not touched by this PR)
- E2E Tier 1: 88 pass, 0 fail (the 7 new tests included)

## Compatibility

- Existing single-tag `list_pages({tag: 'foo'})` callers are unaffected. The `tag` param is still documented, still accepted, still returns the same result set.
- MCP clients automatically pick up the new params via the existing `operations.ts` → tool schema generator. No MCP server changes required.
- No schema migration needed. Uses the existing `tags` table unchanged.

## Notes / tradeoffs

- AND and OR semantics are separated into two params rather than a nested boolean expression tree. For the 95% case this is simpler to use and to document. If someone needs arbitrary boolean logic later, a third param accepting a small AST could be added without breaking this API.
- `tags_any` returns a page if any one of the listed tags is present — it is not a ranking signal. If future work wants "rank pages by how many of these tags they hit", that's a separate feature on top of this one.

Happy to adjust naming, docs, or add more tests if you'd like anything changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)