### PR TITLE
fix: 12 data integrity, search, and safety issues

### DIFF
--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -3,6 +3,7 @@ import { GBrainError, type EngineConfig } from './types.ts';
 import { SCHEMA_SQL } from './schema-embedded.ts';
 
 let sql: ReturnType<typeof postgres> | null = null;
+let connectedUrl: string | null = null;
 
 export function getConnection(): ReturnType<typeof postgres> {
   if (!sql) {
@@ -16,7 +17,13 @@ export function getConnection(): ReturnType<typeof postgres> {
 }
 
 export async function connect(config: EngineConfig): Promise<void> {
-  if (sql) return;
+  if (sql) {
+    // Warn if a different URL is passed — the old connection is still in use
+    if (config.database_url && connectedUrl && config.database_url !== connectedUrl) {
+      console.warn('[gbrain] connect() called with a different database_url but a connection already exists. Using existing connection.');
+    }
+    return;
+  }
 
   const url = config.database_url;
   if (!url) {
@@ -40,8 +47,10 @@ export async function connect(config: EngineConfig): Promise<void> {
 
     // Test connection
     await sql`SELECT 1`;
+    connectedUrl = url;
   } catch (e: unknown) {
     sql = null;
+    connectedUrl = null;
     const msg = e instanceof Error ? e.message : String(e);
     throw new GBrainError(
       'Cannot connect to database',
@@ -55,6 +64,7 @@ export async function disconnect(): Promise<void> {
   if (sql) {
     await sql.end();
     sql = null;
+    connectedUrl = null;
   }
 }
 

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -67,7 +67,9 @@ export async function importFromContent(
         chunks[i].embedding = embeddings[i];
         chunks[i].token_count = Math.ceil(chunks[i].chunk_text.length / 4);
       }
-    } catch { /* non-fatal */ }
+    } catch (e: unknown) {
+      console.warn(`[gbrain] embedding failed for ${slug} (${chunks.length} chunks): ${e instanceof Error ? e.message : String(e)}`);
+    }
   }
 
   // Transaction wraps all DB writes
@@ -95,6 +97,9 @@ export async function importFromContent(
 
     if (chunks.length > 0) {
       await tx.upsertChunks(slug, chunks);
+    } else {
+      // Content is empty — delete stale chunks so they don't ghost in search results
+      await tx.deleteChunks(slug);
     }
   });
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -98,7 +98,7 @@ export class PostgresEngine implements BrainEngine {
   async putPage(slug: string, page: PageInput): Promise<Page> {
     slug = validateSlug(slug);
     const sql = this.sql;
-    const hash = page.content_hash || contentHash(page.compiled_truth, page.timeline || '');
+    const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
 
     const rows = await sql`
@@ -179,23 +179,34 @@ export class PostgresEngine implements BrainEngine {
   async searchKeyword(query: string, opts?: SearchOpts): Promise<SearchResult[]> {
     const sql = this.sql;
     const limit = opts?.limit || 20;
+    const type = opts?.type;
+    const excludeSlugs = opts?.exclude_slugs;
 
+    // CTE: rank pages by FTS score, then pick the best chunk per page in SQL
     const rows = await sql`
-      SELECT DISTINCT ON (p.slug)
-        p.slug, p.id as page_id, p.title, p.type,
-        cc.chunk_text, cc.chunk_source,
-        ts_rank(p.search_vector, websearch_to_tsquery('english', ${query})) AS score,
-        CASE WHEN p.updated_at < (
-          SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id
-        ) THEN true ELSE false END AS stale
-      FROM pages p
-      JOIN content_chunks cc ON cc.page_id = p.id
-      WHERE p.search_vector @@ websearch_to_tsquery('english', ${query})
-      ORDER BY p.slug, score DESC
+      WITH ranked_pages AS (
+        SELECT p.id, p.slug, p.title, p.type,
+          ts_rank(p.search_vector, websearch_to_tsquery('english', ${query})) AS score
+        FROM pages p
+        WHERE p.search_vector @@ websearch_to_tsquery('english', ${query})
+          ${type ? sql`AND p.type = ${type}` : sql``}
+          ${excludeSlugs?.length ? sql`AND p.slug != ALL(${excludeSlugs})` : sql``}
+        ORDER BY score DESC
+        LIMIT ${limit}
+      ),
+      best_chunks AS (
+        SELECT DISTINCT ON (rp.slug)
+          rp.slug, rp.id as page_id, rp.title, rp.type, rp.score,
+          cc.chunk_text, cc.chunk_source
+        FROM ranked_pages rp
+        JOIN content_chunks cc ON cc.page_id = rp.id
+        ORDER BY rp.slug, cc.chunk_index
+      )
+      SELECT slug, page_id, title, type, chunk_text, chunk_source, score,
+        false AS stale
+      FROM best_chunks
+      ORDER BY score DESC
     `;
-    // Re-sort by score (DISTINCT ON requires ORDER BY slug first) and apply limit
-    rows.sort((a: any, b: any) => b.score - a.score);
-    rows.splice(limit);
 
     return rows.map(rowToSearchResult);
   }
@@ -203,6 +214,8 @@ export class PostgresEngine implements BrainEngine {
   async searchVector(embedding: Float32Array, opts?: SearchOpts): Promise<SearchResult[]> {
     const sql = this.sql;
     const limit = opts?.limit || 20;
+    const type = opts?.type;
+    const excludeSlugs = opts?.exclude_slugs;
     const vecStr = '[' + Array.from(embedding).join(',') + ']';
 
     const rows = await sql`
@@ -210,12 +223,12 @@ export class PostgresEngine implements BrainEngine {
         p.slug, p.id as page_id, p.title, p.type,
         cc.chunk_text, cc.chunk_source,
         1 - (cc.embedding <=> ${vecStr}::vector) AS score,
-        CASE WHEN p.updated_at < (
-          SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id
-        ) THEN true ELSE false END AS stale
+        false AS stale
       FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id
       WHERE cc.embedding IS NOT NULL
+        ${type ? sql`AND p.type = ${type}` : sql``}
+        ${excludeSlugs?.length ? sql`AND p.slug != ALL(${excludeSlugs})` : sql``}
       ORDER BY cc.embedding <=> ${vecStr}::vector
       LIMIT ${limit}
     `;
@@ -298,7 +311,7 @@ export class PostgresEngine implements BrainEngine {
   // Links
   async addLink(from: string, to: string, context?: string, linkType?: string): Promise<void> {
     const sql = this.sql;
-    await sql`
+    const result = await sql`
       INSERT INTO links (from_page_id, to_page_id, link_type, context)
       SELECT f.id, t.id, ${linkType || ''}, ${context || ''}
       FROM pages f, pages t
@@ -306,7 +319,9 @@ export class PostgresEngine implements BrainEngine {
       ON CONFLICT (from_page_id, to_page_id) DO UPDATE SET
         link_type = EXCLUDED.link_type,
         context = EXCLUDED.context
+      RETURNING id
     `;
+    if (result.length === 0) throw new Error(`addLink failed: page "${from}" or "${to}" not found`);
   }
 
   async removeLink(from: string, to: string): Promise<void> {
@@ -381,9 +396,13 @@ export class PostgresEngine implements BrainEngine {
   // Tags
   async addTag(slug: string, tag: string): Promise<void> {
     const sql = this.sql;
+    // Verify page exists before attempting insert (ON CONFLICT DO NOTHING
+    // swallows the "already tagged" case, but we still need to detect missing pages)
+    const page = await sql`SELECT id FROM pages WHERE slug = ${slug}`;
+    if (page.length === 0) throw new Error(`addTag failed: page "${slug}" not found`);
     await sql`
       INSERT INTO tags (page_id, tag)
-      SELECT id, ${tag} FROM pages WHERE slug = ${slug}
+      VALUES (${page[0].id}, ${tag})
       ON CONFLICT (page_id, tag) DO NOTHING
     `;
   }
@@ -410,11 +429,13 @@ export class PostgresEngine implements BrainEngine {
   // Timeline
   async addTimelineEntry(slug: string, entry: TimelineInput): Promise<void> {
     const sql = this.sql;
-    await sql`
+    const result = await sql`
       INSERT INTO timeline_entries (page_id, date, source, summary, detail)
       SELECT id, ${entry.date}::date, ${entry.source || ''}, ${entry.summary}, ${entry.detail || ''}
       FROM pages WHERE slug = ${slug}
+      RETURNING id
     `;
+    if (result.length === 0) throw new Error(`addTimelineEntry failed: page "${slug}" not found`);
   }
 
   async getTimeline(slug: string, opts?: TimelineOpts): Promise<TimelineEntry[]> {
@@ -451,14 +472,16 @@ export class PostgresEngine implements BrainEngine {
   // Raw data
   async putRawData(slug: string, source: string, data: object): Promise<void> {
     const sql = this.sql;
-    await sql`
+    const result = await sql`
       INSERT INTO raw_data (page_id, source, data)
       SELECT id, ${source}, ${JSON.stringify(data)}::jsonb
       FROM pages WHERE slug = ${slug}
       ON CONFLICT (page_id, source) DO UPDATE SET
         data = EXCLUDED.data,
         fetched_at = now()
+      RETURNING id
     `;
+    if (result.length === 0) throw new Error(`putRawData failed: page "${slug}" not found`);
   }
 
   async getRawData(slug: string, source?: string): Promise<RawData[]> {
@@ -489,6 +512,7 @@ export class PostgresEngine implements BrainEngine {
       FROM pages WHERE slug = ${slug}
       RETURNING *
     `;
+    if (rows.length === 0) throw new Error(`createVersion failed: page "${slug}" not found`);
     return rows[0] as unknown as PageVersion;
   }
 
@@ -555,13 +579,16 @@ export class PostgresEngine implements BrainEngine {
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NOT NULL)::float /
           GREATEST((SELECT count(*) FROM content_chunks), 1)::float as embed_coverage,
         (SELECT count(*) FROM pages p
-         WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
+         WHERE (p.compiled_truth != '' OR p.timeline != '')
+           AND NOT EXISTS (SELECT 1 FROM content_chunks cc WHERE cc.page_id = p.id)
         ) as stale_pages,
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
+           AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
         ) as orphan_pages,
-        (SELECT count(*) FROM links l
-         WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)
+        (SELECT count(*) FROM content_chunks cc
+         JOIN pages p ON p.id = cc.page_id
+         WHERE p.compiled_truth = '' AND p.timeline = ''
         ) as dead_links,
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NULL) as missing_embeddings
     `;

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -34,11 +34,13 @@ export async function hybridSearch(
   }
 
   // Determine query variants (optionally with expansion)
+  // expandQuery already includes the original query in its return value,
+  // so we use it directly instead of prepending query again
   let queries = [query];
   if (opts?.expansion && opts?.expandFn) {
     try {
-      const expanded = await opts.expandFn(query);
-      queries = [query, ...expanded].slice(0, 3);
+      queries = await opts.expandFn(query);
+      if (queries.length === 0) queries = [query];
     } catch {
       // Expansion failure is non-fatal
     }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import type { Page, PageType, Chunk, SearchResult } from './types.ts';
+import type { Page, PageInput, PageType, Chunk, SearchResult } from './types.ts';
 
 /**
  * Validate and normalize a slug. Slugs are lowercased repo-relative paths.
@@ -13,10 +13,19 @@ export function validateSlug(slug: string): string {
 }
 
 /**
- * SHA-256 hash of compiled_truth + timeline, used for import idempotency.
+ * SHA-256 hash of page content, used for import idempotency.
+ * Hashes all PageInput fields to match importFromContent's hash algorithm.
  */
-export function contentHash(compiledTruth: string, timeline: string): string {
-  return createHash('sha256').update(compiledTruth + '\n---\n' + timeline).digest('hex');
+export function contentHash(page: PageInput): string {
+  return createHash('sha256')
+    .update(JSON.stringify({
+      title: page.title,
+      type: page.type,
+      compiled_truth: page.compiled_truth,
+      timeline: page.timeline || '',
+      frontmatter: page.frontmatter || {},
+    }))
+    .digest('hex');
 }
 
 export function rowToPage(row: Record<string, unknown>): Page {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -3,9 +3,28 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { BrainEngine } from '../core/engine.ts';
 import { operations, OperationError } from '../core/operations.ts';
-import type { OperationContext } from '../core/operations.ts';
+import type { Operation, OperationContext } from '../core/operations.ts';
 import { loadConfig } from '../core/config.ts';
 import { VERSION } from '../version.ts';
+
+/** Validate required params exist and have the expected type */
+function validateParams(op: Operation, params: Record<string, unknown>): string | null {
+  for (const [key, def] of Object.entries(op.params)) {
+    if (def.required && (params[key] === undefined || params[key] === null)) {
+      return `Missing required parameter: ${key}`;
+    }
+    if (params[key] !== undefined && params[key] !== null) {
+      const val = params[key];
+      const expected = def.type;
+      if (expected === 'string' && typeof val !== 'string') return `Parameter "${key}" must be a string`;
+      if (expected === 'number' && typeof val !== 'number') return `Parameter "${key}" must be a number`;
+      if (expected === 'boolean' && typeof val !== 'boolean') return `Parameter "${key}" must be a boolean`;
+      if (expected === 'object' && (typeof val !== 'object' || Array.isArray(val))) return `Parameter "${key}" must be an object`;
+      if (expected === 'array' && !Array.isArray(val)) return `Parameter "${key}" must be an array`;
+    }
+  }
+  return null;
+}
 
 export async function startMcpServer(engine: BrainEngine) {
   const server = new Server(
@@ -54,8 +73,14 @@ export async function startMcpServer(engine: BrainEngine) {
       dryRun: !!(params?.dry_run),
     };
 
+    const safeParams = params || {};
+    const validationError = validateParams(op, safeParams);
+    if (validationError) {
+      return { content: [{ type: 'text', text: JSON.stringify({ error: 'invalid_params', message: validationError }, null, 2) }], isError: true };
+    }
+
     try {
-      const result = await op.handler(ctx, params || {});
+      const result = await op.handler(ctx, safeParams);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     } catch (e: unknown) {
       if (e instanceof OperationError) {
@@ -78,6 +103,9 @@ export async function handleToolCall(
 ): Promise<unknown> {
   const op = operations.find(o => o.name === tool);
   if (!op) throw new Error(`Unknown tool: ${tool}`);
+
+  const validationError = validateParams(op, params);
+  if (validationError) throw new Error(validationError);
 
   const ctx: OperationContext = {
     engine,

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -2,6 +2,8 @@
 
 CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
+-- gen_random_uuid() is core in Postgres 13+; enable pgcrypto as fallback for older versions
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 -- ============================================================
 -- pages: the core content table


### PR DESCRIPTION
## Summary

Cross-model code review (OpenAI Codex reviewing the codebase, Claude verifying and fixing) found 12 concrete issues across data integrity, search correctness, and API safety. All fixes are surgical — no refactors, no feature changes.

**Data integrity (3 fixes):**
- Orphan chunks ghost in search when page content is emptied — now deletes stale chunks
- 5 write APIs (addLink, addTag, addTimelineEntry, putRawData, createVersion) silently no-op when the target page doesn't exist — now throw with clear error messages
- contentHash mismatch between import pipeline and direct putPage — unified to hash all PageInput fields

**Search correctness (4 fixes):**
- Keyword search was unbounded — fetched ALL matching rows then sorted/trimmed in JS. Rewritten as CTE with SQL-level LIMIT
- Hybrid search embedded the original query twice (expandQuery already includes it). Saves ~50% embedding cost per expanded search
- SearchOpts `type` and `exclude_slugs` were advertised but never implemented — now wired into both keyword and vector search
- Stale flag on search results was self-canceling (timeline trigger bumps updated_at) — replaced with honest `false`

**Health metrics (1 fix):**
- `stale_pages` always returned 0 (timeline trigger self-cancels the check). Now: pages with content but zero chunks (unsearchable by vector)
- `dead_links` always returned 0 (CASCADE). Now: orphan chunks on empty pages (ghost search results)
- `orphan_pages` now checks both link directions

**Safety (3 fixes):**
- MCP server had no param validation — added `validateParams()` checking required params and types before handlers run
- Connection singleton silently ignored different URLs on subsequent `connect()` calls — now warns
- Schema portability: added `pgcrypto` extension for `gen_random_uuid()` on Postgres < 13

**Observability (1 fix):**
- Embedding failures were swallowed with `catch { /* non-fatal */ }` — now logs slug, chunk count, and error message

## Test plan

- [ ] Unit tests pass (`bun test`)
- [ ] E2E tests pass against real Postgres+pgvector (`bun run test:e2e`)
- [ ] Verify keyword search returns bounded results on large corpus
- [ ] Verify `gbrain health` reports non-zero stale_pages for pages with content but no chunks
- [ ] Verify addTag/addLink throw when page doesn't exist (instead of silent success)
- [ ] Verify MCP server rejects calls with missing required params

🤖 Generated with [Claude Code](https://claude.com/claude-code)