### PR TITLE
security: enforce path-authoritative slug in importFromFile

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -4,6 +4,7 @@ import type { BrainEngine } from './engine.ts';
 import { parseMarkdown } from './markdown.ts';
 import { chunkText } from './chunkers/recursive.ts';
 import { embedBatch } from './embedding.ts';
+import { slugifyPath } from './sync.ts';
 import type { ChunkInput } from './types.ts';
 
 export interface ImportResult {
@@ -103,6 +104,13 @@ export async function importFromContent(
 
 /**
  * Import from a file path. Validates size, reads content, delegates to importFromContent.
+ *
+ * Slug authority: the path on disk is the source of truth. `frontmatter.slug`
+ * is only accepted when it matches `slugifyPath(relativePath)`. A mismatch is
+ * rejected rather than silently honored — otherwise a file at `notes/random.md`
+ * could declare `slug: people/elon` in frontmatter and overwrite the legitimate
+ * `people/elon` page on the next `gbrain sync` or `gbrain import`. In shared
+ * brains where PRs are mergeable, this is a silent page-hijack primitive.
  */
 export async function importFromFile(
   engine: BrainEngine,
@@ -117,7 +125,25 @@ export async function importFromFile(
 
   const content = readFileSync(filePath, 'utf-8');
   const parsed = parseMarkdown(content, relativePath);
-  return importFromContent(engine, parsed.slug, content, opts);
+
+  // Enforce path-authoritative slug. parseMarkdown prefers frontmatter.slug over
+  // the path-derived slug, so a mismatch here means the frontmatter is trying
+  // to rewrite a page whose filesystem location says something different.
+  const expectedSlug = slugifyPath(relativePath);
+  if (parsed.slug !== expectedSlug) {
+    return {
+      slug: expectedSlug,
+      status: 'skipped',
+      chunks: 0,
+      error:
+        `Frontmatter slug "${parsed.slug}" does not match path-derived slug "${expectedSlug}" ` +
+        `(from ${relativePath}). Remove the frontmatter "slug:" line or move the file.`,
+    };
+  }
+
+  // Pass the path-derived slug explicitly so that any future change to
+  // parseMarkdown's precedence rules cannot re-introduce this bug.
+  return importFromContent(engine, expectedSlug, content, opts);
 }
 
 // Backward compat

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -87,6 +87,72 @@ This is the compiled truth.
     expect((engine as any)._calls.length).toBe(0);
   });
 
+  test('rejects frontmatter slug that does not match the file path', async () => {
+    // In a shared brain where contributors can land PRs, this prevents a
+    // poisoned notes/random.md from declaring `slug: people/elon` in its
+    // frontmatter and overwriting the legitimate people/elon page on sync.
+    // See L001 in report/findings.md.
+    const filePath = join(TMP, 'hijack.md');
+    writeFileSync(filePath, `---
+type: person
+title: Elon Musk
+slug: people/elon
+---
+
+Poisoned content that would overwrite people/elon.
+`);
+
+    const engine = mockEngine();
+    const result = await importFile(engine, filePath, 'notes/random.md', { noEmbed: true });
+
+    expect(result.status).toBe('skipped');
+    expect(result.error).toContain('people/elon');
+    expect(result.error).toContain('notes/random');
+    // No writes to the DB — the hijack never reaches putPage/createVersion.
+    expect((engine as any)._calls.length).toBe(0);
+  });
+
+  test('accepts frontmatter slug that matches the file path', async () => {
+    // Sanity: a legitimate file whose frontmatter slug happens to equal the
+    // path-derived slug must still import. This is the case for any brain
+    // that was originally exported from another tool with matching slugs.
+    const filePath = join(TMP, 'alice.md');
+    writeFileSync(filePath, `---
+type: person
+title: Alice
+slug: people/alice-smith
+---
+
+Legit content.
+`);
+
+    const engine = mockEngine();
+    const result = await importFile(engine, filePath, 'people/alice-smith.md', { noEmbed: true });
+
+    expect(result.status).toBe('imported');
+    expect(result.slug).toBe('people/alice-smith');
+  });
+
+  test('uses path-derived slug when no frontmatter slug is set', async () => {
+    // The common case: no frontmatter.slug, so the path determines the slug.
+    // This test pins the authority: the slug must come from the path even
+    // though parseMarkdown's fallback would have produced the same answer.
+    const filePath = join(TMP, 'concept-path.md');
+    writeFileSync(filePath, `---
+type: concept
+title: From Path
+---
+
+Content.
+`);
+
+    const engine = mockEngine();
+    const result = await importFile(engine, filePath, 'concepts/from-path.md', { noEmbed: true });
+
+    expect(result.status).toBe('imported');
+    expect(result.slug).toBe('concepts/from-path');
+  });
+
   test('skips file when content hash matches (idempotent)', async () => {
     const filePath = join(TMP, 'unchanged.md');
     writeFileSync(filePath, `---


### PR DESCRIPTION
## Summary

`parseMarkdown` returns `frontmatter.slug` when the frontmatter declares one, and falls back to `inferSlug(filePath)` otherwise. `importFromFile` then passes that parsed slug verbatim into `importFromContent`. In a team brain where contributors can land PRs, a poisoned `notes/random.md` with frontmatter

```yaml
---
slug: people/elon
type: person
title: Elon Musk
---
```

silently overwrites the legitimate `people/elon` page on the next `gbrain sync` or `gbrain import` — the sync filter (`isSyncable()` in `src/core/sync.ts`) only checks file extensions and never inspects frontmatter, so a reviewer sees a harmless new note in an unfamiliar directory and merges it. The attack is recoverable via `page_versions` (the import pipeline snapshots the old content before overwrite) but only if the operator notices.

The realistic damage isn't data loss — it's silent context poisoning of an LLM that reads the brain through gbrain's MCP tools.

## Changes

`src/core/import-file.ts`

- Imports `slugifyPath` from `./sync.ts`.
- Inside `importFromFile`, after `parseMarkdown(content, relativePath)`, computes `expectedSlug = slugifyPath(relativePath)` and rejects the import when `parsed.slug !== expectedSlug`. The rejection returns `{ status: 'skipped', chunks: 0, error: 'Frontmatter slug \"X\" does not match path-derived slug \"Y\" (from path). Remove the frontmatter \"slug:\" line or move the file.' }` — same `ImportResult` shape the existing \"file too large\" path already uses.
- Passes `expectedSlug` (not `parsed.slug`) into `importFromContent` on the match path too, so a future change to `parseMarkdown`'s precedence rules cannot silently re-introduce this bug.
- Added a docblock explaining the slug-authority rule and the threat model.

`test/import-file.test.ts`

- **`rejects frontmatter slug that does not match the file path`** — a hijack file at `notes/random.md` with `slug: people/elon` in its frontmatter is rejected with `status: 'skipped'`, and the error message contains both slugs. Critically, the mock engine sees **zero** calls — no partial write, no version snapshot of the target page, no tag reconciliation. This is what makes it safe for a caller to retry or ignore.
- **`accepts frontmatter slug that matches the file path`** — a legitimate file whose frontmatter `slug` happens to equal the path-derived slug (common for brains exported from other tools that write both) still imports cleanly. This pins the \"match\" branch so a future regression doesn't break legitimate redundant-slug imports.
- **`uses path-derived slug when no frontmatter slug is set`** — pins the authority on the filesystem path even when `parseMarkdown`'s fallback would produce the same answer.

## Scope decisions

**Why not also fix it at `parseMarkdown`:** `parseMarkdown` has a second caller path — `importFromContent(slug, content)` — where the function receives a caller-supplied slug and no filesystem path to compare against. Changing `parseMarkdown` to ignore `frontmatter.slug` entirely would make that path lose the ability to round-trip existing pages (the MCP `put_page` operation). The slug-authority rule only makes sense when there's a disk path to be authoritative *against*, which is why the check has to live on `importFromFile`.

**Why not also check `frontmatter.type`:** Same hijack primitive exists for `type`, but type is a classification label, not a primary key — a wrong type renders the page in the wrong category but doesn't overwrite a different page. Lower severity, leaving it as a separate follow-up so this PR stays focused on the actual overwrite vector.

**Why not silently ignore `frontmatter.slug` instead of rejecting:** Silent override would mask user mistakes. If a user has a brain where frontmatter slugs have drifted from the filesystem layout, a clear error message tells them exactly what to fix; silent ignore would leave them wondering why `gbrain search` doesn't find the page they just synced.

## Validation

The PoC at `report/evidence/poc-l001-frontmatter-slug-hijack.ts` (from the upstream audit, not part of this diff) runs 9 static + runtime checks. It requires all 9 to PASS for the vuln to be confirmed. One regex was widened in this run to also match the indirect `const expectedSlug = slugifyPath(relativePath); if (parsed.slug !== expectedSlug)` pattern, in addition to the direct inline comparison — otherwise check 4 would have been a false negative against the fix.

**Before this PR:**

```
[PASS] markdown.ts: frontmatter.slug preferred over inferSlug(filePath)
[PASS] markdown.ts: frontmatter.type preferred over inferType(filePath)
[PASS] import-file.ts: importFromFile passes parsed.slug through (not relativePath)
[PASS] import-file.ts: NO consistency check between parsed.slug and relativePath
[PASS] sync.ts: performSync calls importFile(engine, filePath, path, ...) per file
[PASS] sync.ts: NO consistency check between file path and imported slug
[PASS] core/sync.ts: isSyncable() never inspects frontmatter content
[PASS] runtime: parseMarkdown returns frontmatter slug, not path slug
[PASS] runtime: parseMarkdown returns frontmatter type, not path type
vuln_confirmed=1  (exit 1)
```

**After this PR:**

```
[PASS] markdown.ts: frontmatter.slug preferred over inferSlug(filePath)
[PASS] markdown.ts: frontmatter.type preferred over inferType(filePath)
[FAIL] import-file.ts: importFromFile passes parsed.slug through (not relativePath)
[FAIL] import-file.ts: NO consistency check between parsed.slug and relativePath
[PASS] sync.ts: performSync calls importFile(engine, filePath, path, ...) per file
[PASS] sync.ts: NO consistency check between file path and imported slug
[PASS] core/sync.ts: isSyncable() never inspects frontmatter content
[PASS] runtime: parseMarkdown returns frontmatter slug, not path slug
[PASS] runtime: parseMarkdown returns frontmatter type, not path type
vuln_confirmed=0  (exit 0)
```

Two checks flipped — the ones that specifically measured `importFromFile`'s behavior. The other checks remain PASS because they describe the unchanged `parseMarkdown` behavior and the unchanged `sync.ts` flow, which is correct: the fix lives at the `importFromFile` boundary, not deeper in the stack. Any caller that reaches the brain through `importFromFile` (CLI `import`, CLI `sync`, auto-sync cron) is protected.

Full unit suite:

```
bun test
 340 pass
 122 skip
 0 fail
 1164 expect() calls
```

## Backwards compatibility

**Behavior change for users whose frontmatter slugs drift from the filesystem layout.** If a user's brain has a file at `notes/a.md` with frontmatter `slug: people/alice`, the import now returns `{ status: 'skipped', error: ... }` instead of silently rewriting the `people/alice` page. The error message tells them exactly how to fix it: remove the frontmatter line or move the file.

I checked whether frontmatter-slug-as-override is documented anywhere — it isn't. `serializeMarkdown` (`src/core/markdown.ts:99`) doesn't emit a `slug:` line, `pathToSlug` (`src/core/sync.ts:131`) is explicitly a path-to-slug converter, and the README / CLAUDE.md describe the filesystem layout as authoritative. Users who had frontmatter slugs that happened to match the path are unaffected (covered by the `accepts matching frontmatter slug` test).

## Test plan

- [ ] `bun test` unit tests pass
- [ ] `bun run test:e2e` E2E tests pass against real Postgres + pgvector
- [ ] Create a fresh brain with `gbrain init`, add two files:
  - [ ] `people/alice-smith.md` — frontmatter `slug: people/alice-smith`, imports normally
  - [ ] `notes/random.md` — frontmatter `slug: people/elon`, returns `skipped` with the mismatch error
- [ ] Verify `people/elon` does **not** exist in the brain after the second import
- [ ] Run `gbrain sync` on a repo that contains both files — same results, sync continues past the rejected file

## Not in this PR

- `frontmatter.type` mismatch handling (lower-severity variant of the same primitive, separate PR).
- Warning vs. rejection mode — current choice is hard rejection. If feedback says otherwise, easy to change.
- A `parseMarkdown` signature that exposes `hadFrontmatterSlug` / `hadFrontmatterType` flags for other callers that want their own authority rules. Not needed for this fix.

This PR is independent of #45 (scope enforcement) and #46 (`importFromContent` size guard) — it touches a different function and different code path.