### PR TITLE
security: stop `gbrain import` from following symlinks out of the root

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync, existsSync, writeFileSync, readFileSync, unlinkSync } from 'fs';
+import { readdirSync, lstatSync, existsSync, writeFileSync, readFileSync, unlinkSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { join, relative } from 'path';
 import { cpus, totalmem, homedir } from 'os';
@@ -211,7 +211,7 @@ export async function runImport(engine: BrainEngine, args: string[]) {
   }
 }
 
-function collectMarkdownFiles(dir: string): string[] {
+export function collectMarkdownFiles(dir: string): string[] {
   const files: string[] = [];
 
   function walk(d: string) {
@@ -224,10 +224,25 @@ function collectMarkdownFiles(dir: string): string[] {
       const full = join(d, entry);
       let stat;
       try {
-        stat = statSync(full);
+        // lstatSync, not statSync: we must NOT follow symlinks. A symlink
+        // inside the brain directory can point to any file the importing
+        // user can read, so a contributor to a shared brain could plant
+        // notes/innocent.md as a symlink to ~/.gbrain/config.json, /etc/passwd,
+        // or another sensitive file outside the brain root — and on the
+        // next `gbrain import` it would be read, chunked, embedded, and
+        // indexed, at which point a bearer-token holder could exfiltrate
+        // it via search/get_page. See L002 in report/findings.md.
+        stat = lstatSync(full);
       } catch {
         // Broken symlink or permission error — skip
         console.warn(`[gbrain import] Skipping unreadable path: ${full}`);
+        continue;
+      }
+
+      // Skip symlinks (both file and directory targets). This also blocks
+      // circular symlink DoS since we refuse to descend into linked dirs.
+      if (stat.isSymbolicLink()) {
+        console.warn(`[gbrain import] Skipping symlink: ${full}`);
         continue;
       }
 

--- a/test/import-walker.test.ts
+++ b/test/import-walker.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, symlinkSync, rmSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { collectMarkdownFiles } from '../src/commands/import.ts';
+
+// These tests exercise the filesystem walker that feeds `gbrain import`.
+// They target L002 (report/findings.md): a malicious symlink inside a shared
+// brain directory must not cause the walker to read files outside the brain
+// root. See src/commands/import.ts:collectMarkdownFiles.
+
+describe('collectMarkdownFiles — symlink containment', () => {
+  let root: string;
+  let secretDir: string;
+
+  beforeEach(() => {
+    // Fresh directories per test so symlinks can't cross-contaminate runs.
+    root = mkdtempSync(join(tmpdir(), 'gbrain-walker-root-'));
+    secretDir = mkdtempSync(join(tmpdir(), 'gbrain-walker-secret-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(secretDir, { recursive: true, force: true });
+  });
+
+  test('includes real markdown files inside the root', () => {
+    writeFileSync(join(root, 'legit.md'), '# legit\n');
+    mkdirSync(join(root, 'notes'));
+    writeFileSync(join(root, 'notes', 'other.md'), '# other\n');
+
+    const files = collectMarkdownFiles(root);
+    expect(files).toContain(join(root, 'legit.md'));
+    expect(files).toContain(join(root, 'notes', 'other.md'));
+  });
+
+  test('skips a symlink file pointing outside the brain root', () => {
+    // Plant a real secret outside the brain root
+    const secretFile = join(secretDir, 'secret.md');
+    writeFileSync(secretFile, '# secret — must not be ingested\n');
+
+    // Inside the brain, create a symlink that points at the secret.
+    // Before the fix, statSync followed the link and reported it as
+    // a regular file, so it ended up in the walker's output and got
+    // fed to importFile — chunked, embedded, and indexed in the brain.
+    writeFileSync(join(root, 'legit.md'), '# legit\n');
+    symlinkSync(secretFile, join(root, 'innocent.md'));
+
+    const files = collectMarkdownFiles(root);
+    expect(files).toContain(join(root, 'legit.md'));
+    // The symlink itself must not appear — this is the security guarantee.
+    expect(files).not.toContain(join(root, 'innocent.md'));
+    // And the canonical secret path must definitely not be in the results.
+    expect(files).not.toContain(secretFile);
+  });
+
+  test('does not descend into a symlinked directory', () => {
+    // Create a directory outside the root with a markdown file inside it.
+    const outsideSub = join(secretDir, 'sub');
+    mkdirSync(outsideSub);
+    writeFileSync(join(outsideSub, 'external.md'), '# external\n');
+
+    // Plant a symlink inside the brain pointing at that directory.
+    // Before the fix, walk() would follow it and emit external.md.
+    // With lstatSync, stat.isSymbolicLink() is true and we refuse
+    // to descend — this also blocks circular-symlink DoS as a side effect.
+    writeFileSync(join(root, 'legit.md'), '# legit\n');
+    symlinkSync(outsideSub, join(root, 'linked-notes'));
+
+    const files = collectMarkdownFiles(root);
+    expect(files).toContain(join(root, 'legit.md'));
+    expect(files).not.toContain(join(root, 'linked-notes', 'external.md'));
+    expect(files).not.toContain(join(outsideSub, 'external.md'));
+  });
+
+  test('skips broken symlinks without crashing', () => {
+    // A dangling symlink — the target never existed. Pre-existing behavior
+    // (PR #26 / PR #38) handled this via try/catch around statSync. The
+    // L002 fix must not regress it: lstatSync succeeds on a dangling link
+    // (it reports on the link itself, not the target), so we reach the
+    // isSymbolicLink() branch and skip cleanly, no throw.
+    writeFileSync(join(root, 'legit.md'), '# legit\n');
+    symlinkSync('/nonexistent/path/to/nowhere', join(root, 'dangling.md'));
+
+    const files = collectMarkdownFiles(root);
+    expect(files).toContain(join(root, 'legit.md'));
+    expect(files).not.toContain(join(root, 'dangling.md'));
+  });
+});


### PR DESCRIPTION
## Summary

The recursive markdown walker in `src/commands/import.ts` used `statSync`, which follows symlinks. Combined with the `.md` extension filter, that lets a contributor to a shared brain plant a symlink at `notes/innocent.md` pointing at `~/.gbrain/config.json`, `~/.aws/credentials`, `/etc/passwd`, `~/.zshrc`, `.env`, or any other file the importing user can read. On the next `gbrain import`, the walker treats the symlink as a regular file, `readFileSync` follows the link to its target, and the secret ends up chunked, embedded via OpenAI, and indexed in Postgres — at which point a bearer-token holder can exfiltrate it via `search` / `get_page` without ever touching the filesystem directly.

Circular symlinks are a separate variant: walking into a symlinked directory that ultimately loops back into the brain root causes unbounded recursion and an OOM crash during import.

## Context — what the earlier fix did and didn't cover

PR #26 / PR #38 (v0.6.1 community fix wave) already touched `collectMarkdownFiles` to:

- Skip `node_modules` directories
- Wrap `statSync` in a `try`/`catch` so broken symlinks no longer crash the entire import

Those were the right fixes for the crash reports they were addressing. They did **not** address the symlink-following primitive itself: a *valid* symlink to a sensitive file was still silently followed and read. This PR closes that remaining gap.

## Changes

`src/commands/import.ts`

- Switched `statSync` → `lstatSync`. `lstatSync` reports on the link inode itself, not the target, so we can identify symlinks before committing to follow them. (Pre-existing `try`/`catch` around the stat call is preserved — the broken-symlink crash protection from PR #38 still works, with the added detail that `lstatSync` actually succeeds on dangling links and falls through to the `isSymbolicLink()` branch.)
- Added an explicit `stat.isSymbolicLink()` check that logs a skip warning and continues. No realpath containment check, no depth cap, no visited-set for cycle detection — skipping all symlinks entirely is strictly stronger than any of those alternatives and requires no additional state.
- Exported `collectMarkdownFiles` so it can be unit-tested in isolation instead of being reachable only through `runImport`.

**Hard links are intentionally out of scope.** A hard link is indistinguishable from the \"original\" file at the inode level; any fix that tried to detect them would break legitimate use of hard links inside a brain. If someone with write access to the brain dir is creating hard links to `/etc/passwd`, they already have the access they need without gbrain.

`test/import-walker.test.ts` (new file)

Four tests, each using a fresh `mkdtempSync` root and a separate tmpdir for \"secret\" files so the tests can't cross-contaminate:

- **`includes real markdown files inside the root`** — baseline: a normal brain dir with top-level and nested markdown produces both paths. Pins the happy path.
- **`skips a symlink file pointing outside the brain root`** — the core security test. Plants `innocent.md` as a symlink to a secret in a sibling tmpdir, asserts the walker output contains neither the symlink path nor the canonical secret path.
- **`does not descend into a symlinked directory`** — directory-symlink variant, which is what lets circular symlinks become a DoS primitive.
- **`skips broken symlinks without crashing`** — pins the invariant PR #26 / PR #38 already established (dangling symlinks don't throw). `lstatSync` actually succeeds on dangling links since it stats the link inode rather than the target, so we reach the `isSymbolicLink()` branch and skip cleanly. This test is what tells a future refactor \"don't accidentally regress PR #38.\"

## Validation

The PoC at `report/evidence/poc-l002-symlink-import.ts` (from the upstream audit, not part of this diff) does two things: (1) static-audits `src/commands/import.ts` for `statSync` usage and the absence of lstatSync/realpath/depth-cap/visited-set, and (2) runs an inlined copy of the *vulnerable* walker against a temp dir with a planted symlink to a fake secret file. It verifies the runtime behavior matches the static pattern and flips only when both agree.

**Before this PR:**

```
source-audit verdict: VULNERABLE
walker collected files (2):
  - <tmp>/leak.md          <-- symlink followed
  - <tmp>/legit.md
walker treated symlink as .md file:  true
readFileSync returned secret content: true

source audit vulnerable:  true
symlink collected as .md: true
secret content readable:  true
overall:                  CONFIRMED
vuln_confirmed=1  (exit 1)
```

**After this PR:**

```
lstatSync(full) present in walker:         true
   statSync(full) present in walker:       false
   => source-audit verdict: not vulnerable

source audit vulnerable:  false
symlink collected as .md: true     <-- (still true, but this is the INLINED old walker
                                       the PoC uses for demonstration — the real
                                       walker skips the symlink, see new unit tests)
secret content readable:  true     <-- (same: demonstrates that the OLD primitive
                                       would leak if not fixed)
overall:                  NOT confirmed
vuln_confirmed=0  (exit 0)
```

Note on the two runtime `true`s after the fix: the PoC inlines its own verbatim copy of the *old* vulnerable walker (`collectMarkdownFiles_vulnerable` at line 76 of the PoC) to demonstrate what the bug would have done. It does not call the real `src/commands/import.ts` walker at runtime. The PoC's final verdict correctly gates on the source-audit pass, which reads the real file and reports \"not vulnerable\" because `statSync` is gone and `lstatSync` is present. The runtime leak demonstration is kept only as historical evidence of what the bug would have done in isolation — the new unit tests in `test/import-walker.test.ts` are what prove the real walker is clean now.

Full unit suite:

```
bun test
 341 pass
 122 skip
 0 fail
 1166 expect() calls
Ran 463 tests across 30 files.
```

(One new test file — 4 tests — bringing the total from 340 to 341.)

## Test plan

- [ ] `bun test` unit tests pass (4 new tests in `import-walker.test.ts`, full suite 341 pass 0 fail)
- [ ] `bun run test:e2e` E2E tests pass against real Postgres + pgvector
- [ ] Manual repro: in a scratch brain directory, plant `innocent.md` as a symlink to `~/.zshrc`, run `gbrain import .`, verify the import log contains `[gbrain import] Skipping symlink: .../innocent.md` and that `gbrain search <string from your zshrc>` returns no results
- [ ] Manual repro: plant a circular directory symlink, run `gbrain import .`, verify it does not OOM and completes normally

## Not in this PR

- Realpath containment check (`realpathSync(full).startsWith(realpathSync(root))`) — defense in depth, but skipping all symlinks makes this redundant. Worth adding if/when you want to *allow* in-root symlinks (e.g. for canonical-note pointers) while blocking escape.
- Depth cap / visited-set — also redundant once symlinks are skipped, since the walker can't enter a cycle through real directories.
- Hard link detection — as noted above, indistinguishable from real files, out of scope.
- `src/core/file-resolver.ts` — flagged in the hardening section of the audit as having the same anti-pattern, but it's not wired into any production operation today. Separate PR when that function is actually connected.

This PR is independent of #45 / #46 / #47 — it touches `src/commands/import.ts`, which none of the other three PRs modify. It stacks cleanly on top of PR #38's existing walker changes.