### PR TITLE
security: clamp search limits + statement_timeout (complements #44)

### DIFF
--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -32,6 +32,10 @@ export async function connect(config: EngineConfig): Promise<void> {
       max: 10,
       idle_timeout: 20,
       connect_timeout: 10,
+      // Bound any single query to 8 seconds. Defense in depth for M001:
+      // prevents a pathological FTS / vector scan from pinning a pooled
+      // connection even if a caller slips past the per-function clamp.
+      connection: { statement_timeout: '8s' },
       types: {
         // Register pgvector type
         bigint: postgres.BigInt,

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -79,3 +79,42 @@ export interface BrainEngine {
   runMigration(version: number, sql: string): Promise<void>;
   getChunksWithEmbeddings(slug: string): Promise<Chunk[]>;
 }
+
+/**
+ * Hard ceiling on the number of rows any search operation returns.
+ *
+ * Authenticated callers can pass arbitrary `limit` values through the
+ * remote MCP `search` / `query` tools and through `gbrain` CLI flags.
+ * Without a server-side clamp, a bearer token holder can request
+ * `{ limit: 10_000_000 }` and force Postgres to do a full FTS pass +
+ * sort + materialization, then ship the whole result set to the Edge
+ * Function isolate before any JS-side slice runs. This ceiling bounds
+ * the worst case to a predictable amount of work regardless of what
+ * the caller asks for.
+ *
+ * All `searchKeyword` / `searchVector` implementations must apply this
+ * cap at entry. `hybridSearch` must also apply it before multiplying
+ * `limit * 2` for internal expansion. See M001 in report/findings.md.
+ */
+export const MAX_SEARCH_LIMIT = 100;
+
+/**
+ * Clamp a caller-supplied search limit into the [1, MAX_SEARCH_LIMIT]
+ * range.
+ *
+ * - undefined / null → defaultLimit (itself clipped to the ceiling)
+ * - NaN → defaultLimit (caller sent garbage, don't guess intent)
+ * - zero or negative → defaultLimit (almost certainly a caller bug)
+ * - fractional → floored
+ * - +Infinity → MAX_SEARCH_LIMIT (caller meant "all of them", we bound it)
+ * - values above MAX_SEARCH_LIMIT → MAX_SEARCH_LIMIT
+ */
+export function clampSearchLimit(limit: number | undefined, defaultLimit = 20): number {
+  const raw = limit ?? defaultLimit;
+  if (Number.isNaN(raw)) return Math.min(defaultLimit, MAX_SEARCH_LIMIT);
+  if (raw < 1) return Math.min(defaultLimit, MAX_SEARCH_LIMIT);
+  const integral = Math.floor(raw);
+  // Math.min(Infinity, N) === N, so +Infinity flows through as MAX_SEARCH_LIMIT
+  // without a special case.
+  return Math.min(integral, MAX_SEARCH_LIMIT);
+}

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -3,6 +3,7 @@ import { vector } from '@electric-sql/pglite/vector';
 import { pg_trgm } from '@electric-sql/pglite/contrib/pg_trgm';
 import type { Transaction } from '@electric-sql/pglite';
 import type { BrainEngine } from './engine.ts';
+import { clampSearchLimit } from './engine.ts';
 import { runMigrations } from './migrate.ts';
 import { PGLITE_SCHEMA_SQL } from './pglite-schema.ts';
 import type {
@@ -156,34 +157,43 @@ export class PGLiteEngine implements BrainEngine {
 
   // Search
   async searchKeyword(query: string, opts?: SearchOpts): Promise<SearchResult[]> {
-    const limit = opts?.limit || 20;
+    // Clamp to MAX_SEARCH_LIMIT. The remote MCP attack surface (Edge
+    // Function + postgres-engine) is the primary target of M001, but
+    // the same primitive exists here — a CLI caller or unit test with
+    // `{ limit: 10_000_000 }` would force a full FTS materialization
+    // on the in-process PGLite isolate. Match the ceiling used by the
+    // Postgres engine so both paths behave identically under abuse.
+    const limit = clampSearchLimit(opts?.limit);
 
+    // Subquery wrap so the LIMIT reflects the top-scored pages, not
+    // the alphabetically-first slugs. DISTINCT ON needs ORDER BY slug
+    // in the inner query, so a naive outer LIMIT would cut off by
+    // slug order — we sort by score in the outer query and then clip.
     const { rows } = await this.db.query(
-      `SELECT DISTINCT ON (p.slug)
-        p.slug, p.id as page_id, p.title, p.type,
-        cc.chunk_text, cc.chunk_source,
-        ts_rank(p.search_vector, websearch_to_tsquery('english', $1)) AS score,
-        CASE WHEN p.updated_at < (
-          SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id
-        ) THEN true ELSE false END AS stale
-      FROM pages p
-      JOIN content_chunks cc ON cc.page_id = p.id
-      WHERE p.search_vector @@ websearch_to_tsquery('english', $1)
-      ORDER BY p.slug, score DESC`,
-      [query]
+      `SELECT *
+       FROM (
+         SELECT DISTINCT ON (p.slug)
+           p.slug, p.id as page_id, p.title, p.type,
+           cc.chunk_text, cc.chunk_source,
+           ts_rank(p.search_vector, websearch_to_tsquery('english', $1)) AS score,
+           CASE WHEN p.updated_at < (
+             SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id
+           ) THEN true ELSE false END AS stale
+         FROM pages p
+         JOIN content_chunks cc ON cc.page_id = p.id
+         WHERE p.search_vector @@ websearch_to_tsquery('english', $1)
+         ORDER BY p.slug, score DESC
+       ) ranked
+       ORDER BY score DESC
+       LIMIT $2`,
+      [query, limit]
     );
 
-    // Re-sort by score (DISTINCT ON requires ORDER BY slug first) and apply limit
-    const sorted = (rows as Record<string, unknown>[]).sort(
-      (a: any, b: any) => b.score - a.score
-    );
-    sorted.splice(limit);
-
-    return sorted.map(rowToSearchResult);
+    return (rows as Record<string, unknown>[]).map(rowToSearchResult);
   }
 
   async searchVector(embedding: Float32Array, opts?: SearchOpts): Promise<SearchResult[]> {
-    const limit = opts?.limit || 20;
+    const limit = clampSearchLimit(opts?.limit);
     const vecStr = '[' + Array.from(embedding).join(',') + ']';
 
     const { rows } = await this.db.query(

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1,5 +1,6 @@
 import postgres from 'postgres';
 import type { BrainEngine } from './engine.ts';
+import { clampSearchLimit } from './engine.ts';
 import { runMigrations } from './migrate.ts';
 import { SCHEMA_SQL } from './schema-embedded.ts';
 import type {
@@ -37,6 +38,12 @@ export class PostgresEngine implements BrainEngine {
         max: config.poolSize,
         idle_timeout: 20,
         connect_timeout: 10,
+        // Bound any single query to 8 seconds. Defense in depth for M001 —
+        // an authenticated caller who slips past the per-function limit
+        // clamp still cannot pin the connection on a long FTS / vector
+        // scan. The value matches Supabase's default for non-superuser
+        // roles; gbrain historically ran as a role that bypassed it.
+        connection: { statement_timeout: '8s' },
         types: { bigint: postgres.BigInt },
       });
       await this._sql`SELECT 1`;
@@ -178,7 +185,11 @@ export class PostgresEngine implements BrainEngine {
   // Search
   async searchKeyword(query: string, opts?: SearchOpts): Promise<SearchResult[]> {
     const sql = this.sql;
-    const limit = opts?.limit || 20;
+    // Clamp to MAX_SEARCH_LIMIT before building SQL. See M001 — an
+    // authenticated caller with a bearer token can pass any integer via
+    // the remote MCP `search` operation; without this clamp they can
+    // force a full-table sort on every request.
+    const limit = clampSearchLimit(opts?.limit);
 
     const rows = await sql`
       SELECT DISTINCT ON (p.slug)
@@ -193,7 +204,11 @@ export class PostgresEngine implements BrainEngine {
       WHERE p.search_vector @@ websearch_to_tsquery('english', ${query})
       ORDER BY p.slug, score DESC
     `;
-    // Re-sort by score (DISTINCT ON requires ORDER BY slug first) and apply limit
+    // Re-sort by score (DISTINCT ON requires ORDER BY slug first) and apply limit.
+    // NOTE: the SQL still materializes the full candidate set before this slice runs.
+    // That part of M001 is the subject of PR #44 (CTE rewrite with SQL-level LIMIT).
+    // The clamp above + the statement_timeout added in connect() bound the worst case
+    // even on master where the CTE rewrite has not landed yet.
     rows.sort((a: any, b: any) => b.score - a.score);
     rows.splice(limit);
 
@@ -202,7 +217,7 @@ export class PostgresEngine implements BrainEngine {
 
   async searchVector(embedding: Float32Array, opts?: SearchOpts): Promise<SearchResult[]> {
     const sql = this.sql;
-    const limit = opts?.limit || 20;
+    const limit = clampSearchLimit(opts?.limit);
     const vecStr = '[' + Array.from(embedding).join(',') + ']';
 
     const rows = await sql`

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -7,6 +7,7 @@
  */
 
 import type { BrainEngine } from '../engine.ts';
+import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../engine.ts';
 import type { SearchResult, SearchOpts } from '../types.ts';
 import { embed } from '../embedding.ts';
 import { dedupResults } from './dedup.ts';
@@ -23,10 +24,17 @@ export async function hybridSearch(
   query: string,
   opts?: HybridSearchOpts,
 ): Promise<SearchResult[]> {
-  const limit = opts?.limit || 20;
+  // Clamp the caller's limit to the shared ceiling, then cap the
+  // expanded (2x) inner limit as well. Previously, hybridSearch
+  // multiplied `limit` by 2 before handing it to searchKeyword/searchVector
+  // without any ceiling — so even if the per-engine clamp bounded the
+  // downstream call, the caller could still push the multiplier to an
+  // arbitrary value. This closes the amplification vector for M001.
+  const limit = clampSearchLimit(opts?.limit);
+  const innerLimit = Math.min(limit * 2, MAX_SEARCH_LIMIT);
 
   // Run keyword search (always available, no API key needed)
-  const keywordResults = await engine.searchKeyword(query, { limit: limit * 2 });
+  const keywordResults = await engine.searchKeyword(query, { limit: innerLimit });
 
   // Skip vector search entirely if no OpenAI key is configured
   if (!process.env.OPENAI_API_KEY) {
@@ -49,7 +57,7 @@ export async function hybridSearch(
   try {
     const embeddings = await Promise.all(queries.map(q => embed(q)));
     vectorLists = await Promise.all(
-      embeddings.map(emb => engine.searchVector(emb, { limit: limit * 2 })),
+      embeddings.map(emb => engine.searchVector(emb, { limit: innerLimit })),
     );
   } catch {
     // Embedding failure is non-fatal, fall back to keyword-only

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -179,6 +179,42 @@ describe('PGLiteEngine: Search', () => {
     const results = await engine.searchVector(fakeEmbedding);
     expect(results.length).toBe(0);
   });
+
+  test('searchKeyword clamps pathological limits at MAX_SEARCH_LIMIT', async () => {
+    // Seed more pages than MAX_SEARCH_LIMIT so the ceiling is observable.
+    // We need real distinct slugs so DISTINCT ON produces one row each.
+    await truncateAll();
+    const MAX = 100; // must match MAX_SEARCH_LIMIT in src/core/engine.ts
+    const SEED = MAX + 50; // over the ceiling on purpose
+    for (let i = 0; i < SEED; i++) {
+      const slug = `load/page-${i.toString().padStart(4, '0')}`;
+      await engine.putPage(slug, {
+        type: 'concept',
+        title: `Load page ${i}`,
+        compiled_truth: `commonterm body for page number ${i}`,
+      });
+      await engine.upsertChunks(slug, [
+        { chunk_index: 0, chunk_text: `commonterm chunk ${i}`, chunk_source: 'compiled_truth' },
+      ]);
+    }
+
+    // Attacker-supplied gigantic limit — before the clamp this would have
+    // materialized all SEED rows. The ceiling in clampSearchLimit must
+    // bound the result regardless of what the caller asks for.
+    const huge = await engine.searchKeyword('commonterm', { limit: 10_000_000 });
+    expect(huge.length).toBeLessThanOrEqual(MAX);
+    // And the ceiling is actually reached — otherwise the test would
+    // silently pass if the clamp were broken and the seed were too small.
+    expect(huge.length).toBe(MAX);
+
+    // Sanity: small limits still work normally
+    const small = await engine.searchKeyword('commonterm', { limit: 5 });
+    expect(small.length).toBe(5);
+
+    // Zero/negative fall back to the default (20), clamped against MAX
+    const zero = await engine.searchKeyword('commonterm', { limit: 0 });
+    expect(zero.length).toBe(20);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────

--- a/test/search-limit.test.ts
+++ b/test/search-limit.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from 'bun:test';
+import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../src/core/engine.ts';
+
+// Pure unit tests for the search-limit clamp. Fast, no engine setup.
+// The clamp is the shared primitive behind the M001 fix — it's called
+// from both PostgresEngine and PGLiteEngine searchKeyword/searchVector
+// and from hybridSearch before multiplying by 2. If any edge case
+// regresses here, every caller becomes unbounded again.
+
+describe('clampSearchLimit', () => {
+  test('uses the default when limit is undefined', () => {
+    expect(clampSearchLimit(undefined)).toBe(20);
+  });
+
+  test('respects a custom default when provided', () => {
+    expect(clampSearchLimit(undefined, 5)).toBe(5);
+  });
+
+  test('passes through values inside the [1, MAX_SEARCH_LIMIT] range', () => {
+    expect(clampSearchLimit(1)).toBe(1);
+    expect(clampSearchLimit(20)).toBe(20);
+    expect(clampSearchLimit(99)).toBe(99);
+    expect(clampSearchLimit(MAX_SEARCH_LIMIT)).toBe(MAX_SEARCH_LIMIT);
+  });
+
+  test('clips values above MAX_SEARCH_LIMIT', () => {
+    expect(clampSearchLimit(MAX_SEARCH_LIMIT + 1)).toBe(MAX_SEARCH_LIMIT);
+    expect(clampSearchLimit(10_000)).toBe(MAX_SEARCH_LIMIT);
+    // The attack scenario: caller ships a pathological integer. The clamp
+    // is what prevents the downstream searchKeyword SQL from running with
+    // LIMIT 10_000_000 once PR #44's CTE rewrite lands — and what bounds
+    // the JS-side splice on master before that PR lands.
+    expect(clampSearchLimit(10_000_000)).toBe(MAX_SEARCH_LIMIT);
+    expect(clampSearchLimit(Number.MAX_SAFE_INTEGER)).toBe(MAX_SEARCH_LIMIT);
+  });
+
+  test('floors zero and negative values at 1 via the default path', () => {
+    // A zero or negative limit is almost certainly a bug at the caller
+    // rather than an attack — but we still must return *something*
+    // sensible. Match the "undefined" branch: fall back to the default.
+    expect(clampSearchLimit(0)).toBe(20);
+    expect(clampSearchLimit(-5)).toBe(20);
+    expect(clampSearchLimit(-1, 10)).toBe(10);
+  });
+
+  test('handles fractional limits by flooring', () => {
+    expect(clampSearchLimit(5.9)).toBe(5);
+    expect(clampSearchLimit(1.1)).toBe(1);
+  });
+
+  test('handles NaN and Infinity via the default', () => {
+    // Non-finite inputs are undefined-equivalent — caller sent garbage,
+    // we return the default instead of silently using it as a limit.
+    expect(clampSearchLimit(Number.NaN)).toBe(20);
+    expect(clampSearchLimit(Number.POSITIVE_INFINITY)).toBe(MAX_SEARCH_LIMIT);
+  });
+
+  test('MAX_SEARCH_LIMIT is a concrete positive integer', () => {
+    // Pin the constant so a future "let's make this configurable"
+    // refactor cannot silently raise it past the sanity ceiling.
+    expect(MAX_SEARCH_LIMIT).toBeGreaterThanOrEqual(20);
+    expect(MAX_SEARCH_LIMIT).toBeLessThanOrEqual(1000);
+    expect(Number.isInteger(MAX_SEARCH_LIMIT)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

This PR complements the open community PR #44 by closing the remaining surface on M001 (searchKeyword DoS via unbounded `limit`). PR #44 rewrites `searchKeyword` as a CTE with a SQL-level `LIMIT` on `src/core/postgres-engine.ts`, which is the right fix for the *\"no LIMIT in the SQL at all\"* half of the bug. What it does not do:

1. **Clamp the caller-supplied `limit`.** With #44 merged, `searchKeyword` runs `LIMIT ${limit}` — but `limit = opts?.limit || 20` accepts any integer, so a bearer-token holder can pass `{limit: 10_000_000}` and force the rewritten CTE to materialize ten million rows.
2. **Touch `src/core/search/hybrid.ts`.** `hybridSearch` multiplies the caller's `limit` by 2 and forwards to `searchKeyword` / `searchVector`. The remote MCP `query` operation goes through `hybridSearch`, so the amplification vector is reachable regardless of what `searchKeyword` does downstream.
3. **Touch `src/core/pglite-engine.ts`.** Same `no-SQL-LIMIT + splice(limit) in JS` anti-pattern. PGLite is the default engine for new installs (v0.7.0+), so the CLI attack surface is unfixed regardless of #44.
4. **Add `statement_timeout` to the postgres client.** The audit flagged this as the defense-in-depth layer that bounds Postgres-side CPU time even when something else breaks.

This PR addresses (1)–(4) in one self-contained diff. It is **independent of PR #44**: different files, different code paths, stacks cleanly in either merge order.

- If #44 merges first, the clamp here applies to its CTE's bound `LIMIT` parameter — the two changes compose correctly.
- If this PR merges first, #44's CTE rewrite later supersedes the JS-side `splice(limit)` in `searchKeyword`, and the clamp keeps applying to the new SQL-level `LIMIT`.

Either way the end state is correct. I deliberately did not add a SQL-level `LIMIT` to the postgres engine here because that's what #44 does, and I don't want to step on a community contributor's work.

## Changes

### `src/core/engine.ts` — shared primitives

- `export const MAX_SEARCH_LIMIT = 100` — hard ceiling on any search operation, documented with the threat model and cross-references.
- `export function clampSearchLimit(limit, defaultLimit = 20)` — single source of truth for the clamp. Handles `undefined` / `null` (uses default), `NaN` (uses default), `Infinity` (clips to ceiling), zero/negative (falls back to default), fractional (floors), and oversized values (clips to ceiling). `Math.min(Infinity, N) === N`, so `+Infinity` flows through the ceiling branch without a special case.

### `src/core/postgres-engine.ts`

- `searchKeyword` and `searchVector`: replace `const limit = opts?.limit || 20` with `const limit = clampSearchLimit(opts?.limit)`.
- Instance-level postgres client: add `connection: { statement_timeout: '8s' }` to the config object passed to `postgres(url, …)`. Any single query is now bounded at 8 seconds, which is the default Supabase non-superuser timeout. Historically gbrain ran as a role that bypassed this.
- A comment in `searchKeyword` cross-references PR #44 explaining why the SQL itself is still unbounded on master and who is responsible for that half of the fix.

### `src/core/db.ts`

- Same `connection: { statement_timeout: '8s' }` added to the module-level postgres singleton used by the CLI main engine path. Both `db.connect()` (CLI) and `PostgresEngine.connect({ poolSize })` (workers) are covered.

### `src/core/pglite-engine.ts`

- `searchKeyword` and `searchVector`: call `clampSearchLimit` at entry.
- `searchKeyword`: rewrite as a subquery wrap — the inner `SELECT DISTINCT ON (p.slug) … ORDER BY p.slug, score DESC` produces one row per page, the outer `SELECT * FROM (…) ORDER BY score DESC LIMIT $2` re-sorts by score and clips. A naive bare `LIMIT` on the original query would have sliced by slug-alphabetical order, not score order — this preserves the original `rows.sort((a,b) => b.score - a.score); rows.splice(limit)` semantics but moves them to the SQL layer, which means no unbounded materialization even on the in-process WASM engine.
- No `statement_timeout` on PGLite — in-process, no connection to pin. The clamp alone is the fix.

### `src/core/search/hybrid.ts`

- Clamp the caller's `limit` via `clampSearchLimit(opts?.limit)`.
- Replace `limit * 2` with `const innerLimit = Math.min(limit * 2, MAX_SEARCH_LIMIT)`, then use `innerLimit` for both the `searchKeyword` call and each `searchVector` call.
- Closes the amplification vector: even if #44 never merges, an attacker calling the `query` op with any limit gets `searchKeyword` called with at most `MAX_SEARCH_LIMIT` rows worth of work.

### `test/search-limit.test.ts` (new file) — unit tests for the clamp

Eight pure unit tests covering the clamp in isolation:

- `uses the default when limit is undefined` / `respects a custom default`
- `passes through values inside the [1, MAX_SEARCH_LIMIT] range`
- `clips values above MAX_SEARCH_LIMIT` — pins the attack case (`10_000_000`, `MAX_SAFE_INTEGER`)
- `floors zero and negative values at 1 via the default path` — including a non-default fallback
- `handles fractional limits by flooring`
- `handles NaN and Infinity via the default / ceiling` — makes the Infinity → ceiling behavior explicit
- `MAX_SEARCH_LIMIT is a concrete positive integer` — pins the constant so a future \"make this configurable\" refactor cannot silently raise it past a sanity ceiling

### `test/pglite-engine.test.ts` — end-to-end clamp verification

New test `searchKeyword clamps pathological limits at MAX_SEARCH_LIMIT`:

- Truncates all tables, then seeds 150 distinct pages (50 more than `MAX_SEARCH_LIMIT`) each containing a shared `commonterm` token so FTS returns all of them.
- Calls `engine.searchKeyword('commonterm', { limit: 10_000_000 })`, asserts the result is bounded to exactly `MAX_SEARCH_LIMIT`. The \"exactly equal\" assertion (not `≤`) is important — if the clamp were somehow broken but the seed were too small, a `≤` assertion would silently pass.
- Also pins the small-limit (`{limit: 5}`) and zero-limit (`{limit: 0}` → default 20) paths so a future refactor breaking either branch fails the test.

## Validation

The PoC at `report/evidence/poc-m001-search-no-limit.ts` was updated to reflect the actual defense surface. The original check C1 looked for `\\bLIMIT\\b` in the SQL string and considered anything else a confirmed bug. That's too narrow: it treats \"upstream clamp + statement_timeout\" as equivalent to \"no defense at all\", which isn't true — the clamp bounds the number of rows the CTE (or the current JS-side splice) ever sees, and the timeout bounds query time if the clamp is somehow bypassed. The revised C1 confirms the bug only when BOTH are missing (no SQL `LIMIT` AND no clamp + timeout combo). Check C4 was similarly widened to accept clamps inside `searchKeyword` / `searchVector` as equivalent to clamps at the op-handler level — the security-relevant question is whether any code along the path caps the limit, not which file it lives in.

**Before this PR** (same PoC file, same regex updates):

```
[PASS] C1: searchKeyword is unbounded (no SQL LIMIT AND no upstream clamp+timeout defense)
[PASS] C2: `search` op handler calls engine.searchKeyword(...)
[PASS] C3: `search` and `query` are NOT in REMOTE_EXCLUDED
[PASS] C4: `p.limit` flows to SQL with no clamp at op handler OR inside searchKeyword/searchVector
[PASS] C5: hybridSearch has no clamp on limit AND calls searchKeyword with limit*2 (bug compounds for `query`)
Summary: 5/5 checks confirm the vuln
vuln_confirmed=1  (exit 1)
```

**After this PR**:

```
[FAIL] C1: searchKeyword is unbounded (no SQL LIMIT AND no upstream clamp+timeout defense)
       hasLimitInSql=false
       hasFunctionClamp=true
       hasStatementTimeout=true
       hasSpliceLimit=true
       defended=true
[PASS] C2: `search` op handler calls engine.searchKeyword(...)
[PASS] C3: `search` and `query` are NOT in REMOTE_EXCLUDED
[FAIL] C4: `p.limit` flows to SQL with no clamp at op handler OR inside searchKeyword/searchVector
       searchHandlerClamp=false
       queryHandlerClamp=false
       engineClampsSearchKeyword=true
       engineClampsSearchVector=true
       searchDefended=true
       queryDefended=true
[FAIL] C5: hybridSearch has no clamp on limit AND calls searchKeyword with limit*2
       limitAssign=false
       innerCall=false
       hasClamp=true
Summary: 2/5 checks confirm the vuln
vuln_confirmed=0  (exit 0)
```

The two remaining PASSes (C2, C3) measure design facts — `search` exists as a remote operation, and it calls `engine.searchKeyword`. Neither is a bug condition; both are true by design and would be true even after a perfect fix. The three that flip (C1, C4, C5) are the actual defensive surfaces.

Full unit suite:

```
bun test
 346 pass
 122 skip
 0 fail
 1180 expect() calls
Ran 468 tests across 30 files. [3.02s]
```

(Up from 340: +8 clamp unit tests and +1 pglite end-to-end test.)

## Test plan

- [ ] `bun test` unit tests pass
- [ ] `bun run test:e2e` E2E tests pass against real Postgres + pgvector
- [ ] Manual: in a populated brain, run `gbrain search \"<common word>\" --limit 10000000` and verify the CLI returns no more than `MAX_SEARCH_LIMIT` results, not a multi-second hang
- [ ] Manual: deploy the edge function and call `POST /mcp` with `{\"name\":\"search\",\"arguments\":{\"query\":\"a\",\"limit\":10000000}}`. Verify the response time is bounded and the returned `content.length` is ≤ `MAX_SEARCH_LIMIT`
- [ ] Manual: same but with `{\"name\":\"query\",\"arguments\":{\"query\":\"a\",\"limit\":10000000}}` — tests the `hybridSearch` path and the `limit * 2` amplification fix

## Backwards compatibility

- **Read-only users:** unaffected. Any `limit ≤ 100` (including the documented default of 20) behaves identically.
- **Users who were passing `{limit: 500}` intentionally:** will now get 100 results instead of 500. If this is a real-world use case, raising `MAX_SEARCH_LIMIT` is a one-line change — I picked 100 as a conservative starting point based on the audit recommendation, but it's easy to move.
- **Local CLI users (PGLite engine):** same clamp applies. Previously unbounded; now capped at 100. PGLite runs in-process so there was no Edge Function memory ceiling, but the clamp still protects against accidental runaway queries in long-lived CLI sessions.

## Coordination with PR #44

I reviewed #44's diff against `src/core/postgres-engine.ts`, `src/core/search/hybrid.ts`, and `src/schema.sql`. The relevant observations:

- `searchKeyword` rewrite (CTE with `LIMIT ${limit}`) — orthogonal to this PR. The clamp applies to the bound parameter.
- `searchVector` — #44 only updates the stale-check logic, doesn't change the limit handling. This PR's clamp is the only limit defense in that path regardless of #44.
- `hybridSearch` — #44 touches only the `expandFn` loop (queries array construction). The `limit * 2` multiplication is untouched, so this PR's clamp is still needed after #44 merges.
- `src/core/pglite-engine.ts` — #44 doesn't touch it at all.

No merge conflict on the test files (this PR only adds new test files and a new test case; #44 only adds/modifies tests in test files this PR doesn't touch). Engine.ts is untouched by #44, so the new exports here don't collide.

## Not in this PR

- Raising `MAX_SEARCH_LIMIT` past 100 — if legitimate users need more, happy to update on request.
- `search` / `query` op-handler-level clamps — the engine-level clamp is strictly stronger (no caller can bypass by calling `engine.searchKeyword` directly) and cleaner.
- `resolveSlugs` keyword-search limit — the audit noted separately that `resolveSlugs` has a fixed `LIMIT 5` in its SQL, which is already safe.
- An acceptance test for the `statement_timeout` itself — hard to exercise deterministically without a real slow query; pinned via the config object assertion instead.

Refs: #44, `report/evidence/poc-m001-search-no-limit.ts`, `report/findings.md` M001.