### PR TITLE
feat(cli): add ask alias for query

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ const CLI_ONLY = new Set(['init', 'upgrade', 'check-update', 'import', 'export',
 
 async function main() {
   const args = process.argv.slice(2);
-  const command = args[0];
+  let command = args[0];
 
   if (!command || command === '--help' || command === '-h') {
     printHelp();
@@ -42,6 +42,11 @@ async function main() {
   }
 
   const subArgs = args.slice(1);
+
+  // DX alias: `ask` is a natural-language alias for `query`
+  if (command === 'ask') {
+    command = 'query';
+  }
 
   // Per-command --help
   if (subArgs.includes('--help') || subArgs.includes('-h')) {
@@ -342,6 +347,7 @@ PAGES
 SEARCH
   search <query>                     Keyword search (tsvector)
   query <question> [--no-expand]     Hybrid search (RRF + expansion)
+  ask <question> [--no-expand]       Alias for query
 
 IMPORT/EXPORT
   import <dir> [--no-embed]          Import markdown directory


### PR DESCRIPTION
Adds `gbrain ask` as a natural language alias for `gbrain query`.

Motivation
- `docs/GBRAIN_V0.md` calls out a `gbrain ask` alias as a P1 TODO.
- `ask` is more intuitive for new users than `query`.

Implementation
- The CLI maps `ask` to `query` early in dispatch.
- Global help now includes `ask` under SEARCH.

Test
- `bun test test/cli.test.ts`
