### PR TITLE
Add optional Gemini embeddings support

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,19 +220,28 @@ You take a meeting with someone. The agent writes a brain page for them, links i
 | Dependency | What it's for | How to get it |
 |------------|--------------|---------------|
 | **Supabase account** | Postgres + pgvector database | [supabase.com](https://supabase.com) (Pro tier, $25/mo for 8GB) |
-| **OpenAI API key** | Embeddings (text-embedding-3-large) | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
+| **OpenAI or Gemini API key** | Embeddings (`text-embedding-3-large` or `gemini-embedding-001`) | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) / [aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey) |
 | **Anthropic API key** | Multi-query expansion + LLM chunking (Haiku) | [console.anthropic.com](https://console.anthropic.com) |
 
 Set the API keys as environment variables:
 
 ```bash
+# OpenAI embeddings (default)
 export OPENAI_API_KEY=sk-...
+
+# OR Gemini embeddings (1536-dim compatible with the existing schema)
+export GEMINI_API_KEY=AIza...
+# alias also supported: GOOGLE_API_KEY
+export GBRAIN_EMBEDDING_PROVIDER=gemini
+
+# Optional overrides
+export GBRAIN_EMBEDDING_MODEL=gemini-embedding-001
 export ANTHROPIC_API_KEY=sk-ant-...
 ```
 
-The Supabase connection URL is configured during `gbrain init --supabase`. The OpenAI and Anthropic SDKs read their keys from the environment automatically.
+The Supabase connection URL is configured during `gbrain init --supabase`. OpenAI, Gemini, and Anthropic credentials can be supplied via environment variables, or stored in `~/.gbrain/config.json` when passed during `gbrain init`.
 
-Without an OpenAI key, search still works (keyword only, no vector search). Without an Anthropic key, search still works (no multi-query expansion, no LLM chunking).
+Without an embedding provider key, search still works (keyword only, no vector search). Without an Anthropic key, search still works (no multi-query expansion, no LLM chunking).
 
 ### GBrain without OpenClaw
 
@@ -552,7 +561,7 @@ Three strategies, dispatched by content type:
 
 ```
 SETUP
-  gbrain init [--supabase|--url <conn>]     Create brain (PGLite default, or Supabase)
+  gbrain init [--pglite|--supabase|--url <conn>] [--provider openai|gemini] [--key <api_key>]   Create brain (PGLite default, or Supabase)
   gbrain migrate --to supabase|pglite       Migrate between engines (bidirectional)
   gbrain upgrade                            Self-update
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -338,7 +338,7 @@ USAGE
   gbrain <command> [options]
 
 SETUP
-  init [--pglite|--supabase|--url]   Create brain (PGLite default, no server)
+  init [--pglite|--supabase|--url]   Create brain (PGLite default, no server, OpenAI/Gemini embeddings)
   migrate --to <supabase|pglite>     Transfer brain between engines
   upgrade                            Self-update
   check-update [--json]              Check for new versions

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,5 +1,5 @@
 import type { BrainEngine } from '../core/engine.ts';
-import { embedBatch } from '../core/embedding.ts';
+import { embedBatch, getEmbeddingModel } from '../core/embedding.ts';
 import type { ChunkInput } from '../core/types.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
 
@@ -54,6 +54,7 @@ async function embedPage(engine: BrainEngine, slug: string) {
   }
 
   const embeddings = await embedBatch(toEmbed.map(c => c.chunk_text));
+  const model = getEmbeddingModel();
   const updated: ChunkInput[] = chunks.map((c, i) => {
     const needsEmbed = toEmbed.find(te => te.chunk_index === c.chunk_index);
     const embIdx = needsEmbed ? toEmbed.indexOf(needsEmbed) : -1;
@@ -62,6 +63,7 @@ async function embedPage(engine: BrainEngine, slug: string) {
       chunk_text: c.chunk_text,
       chunk_source: c.chunk_source,
       embedding: embIdx >= 0 ? embeddings[embIdx] : undefined,
+      model,
       token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
     };
   });
@@ -86,6 +88,7 @@ async function embedAll(engine: BrainEngine, staleOnly: boolean) {
 
     try {
       const embeddings = await embedBatch(toEmbed.map(c => c.chunk_text));
+      const model = getEmbeddingModel();
       // Build a map of new embeddings by chunk_index
       const embeddingMap = new Map<number, Float32Array>();
       for (let j = 0; j < toEmbed.length; j++) {
@@ -97,6 +100,7 @@ async function embedAll(engine: BrainEngine, staleOnly: boolean) {
         chunk_text: c.chunk_text,
         chunk_source: c.chunk_source,
         embedding: embeddingMap.get(c.chunk_index) ?? undefined,
+        model,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
       await engine.upsertChunks(page.slug, updated);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -14,6 +14,8 @@ export async function runInit(args: string[]) {
   const manualUrl = urlIndex !== -1 ? args[urlIndex + 1] : null;
   const keyIndex = args.indexOf('--key');
   const apiKey = keyIndex !== -1 ? args[keyIndex + 1] : null;
+  const providerIndex = args.indexOf('--provider');
+  const embeddingProvider = providerIndex !== -1 ? args[providerIndex + 1] as 'openai' | 'gemini' : null;
   const pathIndex = args.indexOf('--path');
   const customPath = pathIndex !== -1 ? args[pathIndex + 1] : null;
 
@@ -33,7 +35,7 @@ export async function runInit(args: string[]) {
       }
     }
 
-    return initPGLite({ jsonOutput, apiKey, customPath });
+    return initPGLite({ jsonOutput, apiKey, customPath, embeddingProvider });
   }
 
   // Supabase/Postgres mode
@@ -52,10 +54,10 @@ export async function runInit(args: string[]) {
     databaseUrl = await supabaseWizard();
   }
 
-  return initPostgres({ databaseUrl, jsonOutput, apiKey });
+  return initPostgres({ databaseUrl, jsonOutput, apiKey, embeddingProvider });
 }
 
-async function initPGLite(opts: { jsonOutput: boolean; apiKey: string | null; customPath: string | null }) {
+async function initPGLite(opts: { jsonOutput: boolean; apiKey: string | null; customPath: string | null; embeddingProvider: 'openai' | 'gemini' | null }) {
   const dbPath = opts.customPath || join(homedir(), '.gbrain', 'brain.pglite');
   console.log(`Setting up local brain with PGLite (no server needed)...`);
 
@@ -66,7 +68,12 @@ async function initPGLite(opts: { jsonOutput: boolean; apiKey: string | null; cu
   const config: GBrainConfig = {
     engine: 'pglite',
     database_path: dbPath,
-    ...(opts.apiKey ? { openai_api_key: opts.apiKey } : {}),
+    ...(opts.embeddingProvider ? { embedding_provider: opts.embeddingProvider } : {}),
+    ...(opts.apiKey
+      ? (opts.embeddingProvider === 'gemini'
+          ? { gemini_api_key: opts.apiKey }
+          : { openai_api_key: opts.apiKey })
+      : {}),
   };
   saveConfig(config);
 
@@ -84,7 +91,7 @@ async function initPGLite(opts: { jsonOutput: boolean; apiKey: string | null; cu
   }
 }
 
-async function initPostgres(opts: { databaseUrl: string; jsonOutput: boolean; apiKey: string | null }) {
+async function initPostgres(opts: { databaseUrl: string; jsonOutput: boolean; apiKey: string | null; embeddingProvider: 'openai' | 'gemini' | null }) {
   const { databaseUrl } = opts;
 
   // Detect Supabase direct connection URLs and warn about IPv6
@@ -137,7 +144,12 @@ async function initPostgres(opts: { databaseUrl: string; jsonOutput: boolean; ap
   const config: GBrainConfig = {
     engine: 'postgres',
     database_url: databaseUrl,
-    ...(opts.apiKey ? { openai_api_key: opts.apiKey } : {}),
+    ...(opts.embeddingProvider ? { embedding_provider: opts.embeddingProvider } : {}),
+    ...(opts.apiKey
+      ? (opts.embeddingProvider === 'gemini'
+          ? { gemini_api_key: opts.apiKey }
+          : { openai_api_key: opts.apiKey })
+      : {}),
   };
   saveConfig(config);
   console.log('Config saved to ~/.gbrain/config.json');

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -11,7 +11,10 @@ export interface GBrainConfig {
   engine: 'postgres' | 'pglite';
   database_url?: string;
   database_path?: string;
+  embedding_provider?: 'openai' | 'gemini';
+  embedding_model?: string;
   openai_api_key?: string;
+  gemini_api_key?: string;
   anthropic_api_key?: string;
 }
 
@@ -28,6 +31,10 @@ export function loadConfig(): GBrainConfig | null {
 
   // Try env vars
   const dbUrl = process.env.GBRAIN_DATABASE_URL || process.env.DATABASE_URL;
+  const openaiKey = process.env.OPENAI_API_KEY;
+  const geminiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
+  const embeddingProvider = process.env.GBRAIN_EMBEDDING_PROVIDER as 'openai' | 'gemini' | undefined;
+  const embeddingModel = process.env.GBRAIN_EMBEDDING_MODEL;
 
   if (!fileConfig && !dbUrl) return null;
 
@@ -35,12 +42,22 @@ export function loadConfig(): GBrainConfig | null {
   const inferredEngine: 'postgres' | 'pglite' = fileConfig?.engine
     || (fileConfig?.database_path ? 'pglite' : 'postgres');
 
+  // Infer embedding provider if not explicitly set
+  const inferredEmbeddingProvider = embeddingProvider
+    || fileConfig?.embedding_provider
+    || (geminiKey && !openaiKey ? 'gemini' : undefined)
+    || (openaiKey || fileConfig?.openai_api_key ? 'openai' : undefined)
+    || (geminiKey || fileConfig?.gemini_api_key ? 'gemini' : undefined);
+
   // Merge: env vars override config file
   const merged = {
     ...fileConfig,
     engine: inferredEngine,
     ...(dbUrl ? { database_url: dbUrl } : {}),
-    ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
+    ...(inferredEmbeddingProvider ? { embedding_provider: inferredEmbeddingProvider } : {}),
+    ...(embeddingModel ? { embedding_model: embeddingModel } : {}),
+    ...(openaiKey ? { openai_api_key: openaiKey } : {}),
+    ...(geminiKey ? { gemini_api_key: geminiKey } : {}),
   };
   return merged as GBrainConfig;
 }

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -1,15 +1,18 @@
 /**
  * Embedding Service
- * Ported from production Ruby implementation (embedding_service.rb, 190 LOC)
  *
- * OpenAI text-embedding-3-large at 1536 dimensions.
- * Retry with exponential backoff (4s base, 120s cap, 5 retries).
- * 8000 character input truncation.
+ * Supports OpenAI and Gemini embeddings behind one interface.
+ * Defaults remain OpenAI-compatible, but Gemini can be selected with
+ * GBRAIN_EMBEDDING_PROVIDER=gemini or by configuring GEMINI_API_KEY/GOOGLE_API_KEY.
  */
 
 import OpenAI from 'openai';
+import { loadConfig } from './config.ts';
 
-const MODEL = 'text-embedding-3-large';
+export type EmbeddingProvider = 'openai' | 'gemini';
+
+const OPENAI_MODEL = 'text-embedding-3-large';
+const GEMINI_MODEL = 'gemini-embedding-001';
 const DIMENSIONS = 1536;
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
@@ -17,13 +20,87 @@ const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
 
-let client: OpenAI | null = null;
+let openaiClient: OpenAI | null = null;
+let openaiClientKey: string | null = null;
 
-function getClient(): OpenAI {
-  if (!client) {
-    client = new OpenAI();
+interface EmbeddingSettings {
+  provider: EmbeddingProvider;
+  model: string;
+  dimensions: number;
+  apiKey: string;
+}
+
+function getEmbeddingSettings(): EmbeddingSettings {
+  const config = loadConfig();
+  const openaiKey = process.env.OPENAI_API_KEY || config?.openai_api_key;
+  const geminiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY || config?.gemini_api_key;
+  const explicitProvider = (process.env.GBRAIN_EMBEDDING_PROVIDER || config?.embedding_provider) as EmbeddingProvider | undefined;
+  const explicitModel = process.env.GBRAIN_EMBEDDING_MODEL || config?.embedding_model;
+
+  const provider: EmbeddingProvider | null = explicitProvider
+    || (geminiKey && !openaiKey ? 'gemini' : null)
+    || (openaiKey ? 'openai' : null)
+    || (geminiKey ? 'gemini' : null);
+
+  if (!provider) {
+    throw new Error('No embedding provider configured. Set OPENAI_API_KEY or GEMINI_API_KEY/GOOGLE_API_KEY.');
   }
-  return client;
+
+  if (provider === 'gemini') {
+    if (!geminiKey) {
+      throw new Error('GBRAIN_EMBEDDING_PROVIDER=gemini but GEMINI_API_KEY/GOOGLE_API_KEY is missing.');
+    }
+    return {
+      provider,
+      model: explicitModel || GEMINI_MODEL,
+      dimensions: DIMENSIONS,
+      apiKey: geminiKey,
+    };
+  }
+
+  if (!openaiKey) {
+    throw new Error('GBRAIN_EMBEDDING_PROVIDER=openai but OPENAI_API_KEY is missing.');
+  }
+
+  return {
+    provider,
+    model: explicitModel || OPENAI_MODEL,
+    dimensions: DIMENSIONS,
+    apiKey: openaiKey,
+  };
+}
+
+function getOpenAIClient(apiKey: string): OpenAI {
+  if (!openaiClient || openaiClientKey !== apiKey) {
+    openaiClient = new OpenAI({ apiKey });
+    openaiClientKey = apiKey;
+  }
+  return openaiClient;
+}
+
+export function hasEmbeddingProvider(): boolean {
+  try {
+    getEmbeddingSettings();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getEmbeddingProvider(): EmbeddingProvider | null {
+  try {
+    return getEmbeddingSettings().provider;
+  } catch {
+    return null;
+  }
+}
+
+export function getEmbeddingModel(): string {
+  return getEmbeddingSettings().model;
+}
+
+export function getEmbeddingDimensions(): number {
+  return getEmbeddingSettings().dimensions;
 }
 
 export async function embed(text: string): Promise<Float32Array> {
@@ -36,7 +113,6 @@ export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
   const truncated = texts.map(t => t.slice(0, MAX_CHARS));
   const results: Float32Array[] = [];
 
-  // Process in batches of BATCH_SIZE
   for (let i = 0; i < truncated.length; i += BATCH_SIZE) {
     const batch = truncated.slice(i, i + BATCH_SIZE);
     const batchResults = await embedBatchWithRetry(batch);
@@ -47,39 +123,112 @@ export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
 }
 
 async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
+  const settings = getEmbeddingSettings();
+
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const response = await getClient().embeddings.create({
-        model: MODEL,
-        input: texts,
-        dimensions: DIMENSIONS,
-      });
-
-      // Sort by index to maintain order
-      const sorted = response.data.sort((a, b) => a.index - b.index);
-      return sorted.map(d => new Float32Array(d.embedding));
+      if (settings.provider === 'gemini') {
+        return await embedBatchGemini(texts, settings);
+      }
+      return await embedBatchOpenAI(texts, settings);
     } catch (e: unknown) {
       if (attempt === MAX_RETRIES - 1) throw e;
 
-      // Check for rate limit with Retry-After header
       let delay = exponentialDelay(attempt);
 
-      if (e instanceof OpenAI.APIError && e.status === 429) {
+      if (settings.provider === 'openai' && e instanceof OpenAI.APIError && e.status === 429) {
         const retryAfter = e.headers?.['retry-after'];
         if (retryAfter) {
           const parsed = parseInt(retryAfter, 10);
-          if (!isNaN(parsed)) {
-            delay = parsed * 1000;
-          }
+          if (!isNaN(parsed)) delay = parsed * 1000;
         }
+      }
+
+      if (settings.provider === 'gemini' && typeof e === 'object' && e && 'retryAfterMs' in e) {
+        const retryAfterMs = (e as { retryAfterMs?: unknown }).retryAfterMs;
+        if (typeof retryAfterMs === 'number') delay = retryAfterMs;
       }
 
       await sleep(delay);
     }
   }
 
-  // Should not reach here
   throw new Error('Embedding failed after all retries');
+}
+
+async function embedBatchOpenAI(texts: string[], settings: EmbeddingSettings): Promise<Float32Array[]> {
+  const response = await getOpenAIClient(settings.apiKey).embeddings.create({
+    model: settings.model,
+    input: texts,
+    dimensions: settings.dimensions,
+  });
+
+  const sorted = response.data.sort((a, b) => a.index - b.index);
+  return sorted.map(d => new Float32Array(d.embedding));
+}
+
+async function embedBatchGemini(texts: string[], settings: EmbeddingSettings): Promise<Float32Array[]> {
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${settings.model}:batchEmbedContents?key=${encodeURIComponent(settings.apiKey)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requests: texts.map(text => ({
+          model: `models/${settings.model}`,
+          content: { parts: [{ text }] },
+          outputDimensionality: settings.dimensions,
+        })),
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const retryAfter = response.headers.get('retry-after');
+    const payload = await safeJson(response);
+    const message = extractGeminiErrorMessage(payload) || `${response.status} ${response.statusText}`;
+    const error = new Error(`Gemini embeddings failed: ${message}`) as Error & { retryAfterMs?: number };
+    if (response.status === 429 && retryAfter) {
+      const parsed = parseInt(retryAfter, 10);
+      if (!isNaN(parsed)) error.retryAfterMs = parsed * 1000;
+    }
+    throw error;
+  }
+
+  const payload = await response.json() as { embeddings?: Array<{ values?: number[] }> };
+  const embeddings = payload.embeddings || [];
+  if (embeddings.length !== texts.length) {
+    throw new Error(`Gemini embeddings returned ${embeddings.length} vectors for ${texts.length} texts`);
+  }
+
+  return embeddings.map((item, index) => {
+    const values = item.values;
+    if (!values || values.length !== settings.dimensions) {
+      throw new Error(`Gemini embedding ${index} had ${values?.length ?? 0} dimensions, expected ${settings.dimensions}`);
+    }
+    return normalizeVector(values);
+  });
+}
+
+async function safeJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function extractGeminiErrorMessage(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const maybeError = (payload as { error?: { message?: string } }).error;
+  return maybeError?.message || null;
+}
+
+function normalizeVector(values: number[]): Float32Array {
+  let sumSquares = 0;
+  for (const value of values) sumSquares += value * value;
+  const norm = Math.sqrt(sumSquares) || 1;
+  return new Float32Array(values.map(value => value / norm));
 }
 
 function exponentialDelay(attempt: number): number {
@@ -91,4 +240,4 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
+export { DIMENSIONS as EMBEDDING_DIMENSIONS };

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -3,7 +3,7 @@ import { createHash } from 'crypto';
 import type { BrainEngine } from './engine.ts';
 import { parseMarkdown } from './markdown.ts';
 import { chunkText } from './chunkers/recursive.ts';
-import { embedBatch } from './embedding.ts';
+import { embedBatch, getEmbeddingModel } from './embedding.ts';
 import type { ChunkInput } from './types.ts';
 
 export interface ImportResult {
@@ -63,8 +63,10 @@ export async function importFromContent(
   if (!opts.noEmbed && chunks.length > 0) {
     try {
       const embeddings = await embedBatch(chunks.map(c => c.chunk_text));
+      const model = getEmbeddingModel();
       for (let i = 0; i < chunks.length; i++) {
         chunks[i].embedding = embeddings[i];
+        chunks[i].model = model;
         chunks[i].token_count = Math.ceil(chunks[i].chunk_text.length / 4);
       }
     } catch { /* non-fatal */ }

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -8,7 +8,7 @@
 
 import type { BrainEngine } from '../engine.ts';
 import type { SearchResult, SearchOpts } from '../types.ts';
-import { embed } from '../embedding.ts';
+import { embed, hasEmbeddingProvider } from '../embedding.ts';
 import { dedupResults } from './dedup.ts';
 
 const RRF_K = 60;
@@ -28,8 +28,8 @@ export async function hybridSearch(
   // Run keyword search (always available, no API key needed)
   const keywordResults = await engine.searchKeyword(query, { limit: limit * 2 });
 
-  // Skip vector search entirely if no OpenAI key is configured
-  if (!process.env.OPENAI_API_KEY) {
+  // Skip vector search entirely if no embedding provider is configured
+  if (!hasEmbeddingProvider()) {
     return dedupResults(keywordResults).slice(0, limit);
   }
 

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const ORIGINAL_ENV = { ...process.env };
+let tempHome: string;
+
+async function loadConfigModule() {
+  return import(`../src/core/config.ts?test=${Date.now()}-${Math.random()}`);
+}
+
+describe('embedding provider config', () => {
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), 'gbrain-config-'));
+    process.env.HOME = tempHome;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+    delete process.env.GBRAIN_EMBEDDING_PROVIDER;
+    delete process.env.GBRAIN_EMBEDDING_MODEL;
+    delete process.env.GBRAIN_DATABASE_URL;
+    delete process.env.DATABASE_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  test('infers Gemini provider from GEMINI_API_KEY env', async () => {
+    process.env.GBRAIN_DATABASE_URL = 'postgresql://example';
+    process.env.GEMINI_API_KEY = 'gemini-test-key';
+
+    const { loadConfig } = await loadConfigModule();
+    const config = loadConfig();
+
+    expect(config?.embedding_provider).toBe('gemini');
+    expect(config?.gemini_api_key).toBe('gemini-test-key');
+  });
+
+  test('respects explicit provider and model env overrides', async () => {
+    process.env.GBRAIN_DATABASE_URL = 'postgresql://example';
+    process.env.OPENAI_API_KEY = 'openai-test-key';
+    process.env.GEMINI_API_KEY = 'gemini-test-key';
+    process.env.GBRAIN_EMBEDDING_PROVIDER = 'gemini';
+    process.env.GBRAIN_EMBEDDING_MODEL = 'gemini-embedding-custom';
+
+    const { loadConfig } = await loadConfigModule();
+    const config = loadConfig();
+
+    expect(config?.embedding_provider).toBe('gemini');
+    expect(config?.embedding_model).toBe('gemini-embedding-custom');
+    expect(config?.openai_api_key).toBe('openai-test-key');
+    expect(config?.gemini_api_key).toBe('gemini-test-key');
+  });
+
+});


### PR DESCRIPTION
## Summary
- add optional Gemini embeddings support alongside the existing OpenAI path
- keep embeddings at 1536 dimensions so existing GBrain vector schema remains compatible
- document the new provider setup and add focused config tests

## What changed
- add `embedding_provider`, `embedding_model`, and `gemini_api_key` support in config loading
- make the embedding service provider-aware (`openai` or `gemini`)
- use Gemini `batchEmbedContents` with `outputDimensionality: 1536`
- normalize Gemini vectors before storing them
- let hybrid search run whenever any embedding provider is configured
- persist the embedding model used on chunks during import/embed flows
- add `gbrain init --provider openai|gemini --key <api_key>` support
- update README/help text for Gemini usage
- add targeted tests around provider selection/config overrides

## Why this is safe
- OpenAI remains the default behavior
- no schema changes are required
- Gemini is configured to emit 1536-dimensional embeddings, matching the current vector size

## Verification
- `bun test test/embedding-provider.test.ts test/config.test.ts test/cli.test.ts`
- live local validation against a real Gemini API key:
  - direct embedding call returned 1536-dimensional vectors
  - `embed --stale` completed successfully on a local PGLite brain
  - semantic search worked after embedding

## Notes
- repo-wide TypeScript already has some unrelated pre-existing errors outside this change, so verification here is focused on the affected paths.
