### PR TITLE
feat: multi-provider embedding support (7 providers incl. China: DashScope, DeepSeek, Zhipu)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -14,11 +14,17 @@ export interface GBrainConfig {
   openai_api_key?: string;
   anthropic_api_key?: string;
   // Multi-provider embedding support
-  embedding_provider?: 'openai' | 'gemini' | 'ollama' | 'custom';
+  embedding_provider?: 'openai' | 'gemini' | 'ollama' | 'dashscope' | 'deepseek' | 'zhipu' | 'custom';
   embedding_model?: string;
   embedding_dimensions?: number;
   gemini_api_key?: string;
   ollama_base_url?: string;
+  dashscope_api_key?: string;
+  dashscope_base_url?: string;
+  deepseek_api_key?: string;
+  deepseek_base_url?: string;
+  zhipu_api_key?: string;
+  zhipu_base_url?: string;
   embedding_api_key?: string;
   embedding_base_url?: string;
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -13,6 +13,14 @@ export interface GBrainConfig {
   database_path?: string;
   openai_api_key?: string;
   anthropic_api_key?: string;
+  // Multi-provider embedding support
+  embedding_provider?: 'openai' | 'gemini' | 'ollama' | 'custom';
+  embedding_model?: string;
+  embedding_dimensions?: number;
+  gemini_api_key?: string;
+  ollama_base_url?: string;
+  embedding_api_key?: string;
+  embedding_base_url?: string;
 }
 
 /**

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -1,7 +1,12 @@
 /**
- * Embedding Service — Multi-Provider
+ * Embedding Service — Multi-Provider (v2)
  *
- * Supports: OpenAI, Gemini, Ollama, and any OpenAI-compatible endpoint.
+ * Supports:
+ *   International: OpenAI, Gemini, Ollama
+ *   China: DashScope (Qwen), DeepSeek, Zhipu (GLM)
+ *   Generic: any OpenAI-compatible endpoint
+ *
+ * All providers use OpenAI SDK with different baseURL + apiKey.
  * Provider is selected via GBRAIN_EMBEDDING_PROVIDER env var or config file.
  * Default: "openai" (backward compatible).
  *
@@ -14,7 +19,14 @@ import { loadConfig } from './config.ts';
 
 // ── Provider registry ──────────────────────────────────────────────
 
-export type EmbeddingProvider = 'openai' | 'gemini' | 'ollama' | 'custom';
+export type EmbeddingProvider =
+  | 'openai'
+  | 'gemini'
+  | 'ollama'
+  | 'dashscope'   // Alibaba Qwen
+  | 'deepseek'
+  | 'zhipu'       // GLM / ChatGLM
+  | 'custom';
 
 interface ProviderConfig {
   provider: EmbeddingProvider;
@@ -22,13 +34,23 @@ interface ProviderConfig {
   dimensions: number;
   apiKey?: string;
   baseUrl?: string;
+  /** Whether to send `dimensions` param in API request */
+  sendDimensions: boolean;
 }
 
-const PROVIDER_DEFAULTS: Record<EmbeddingProvider, { model: string; dimensions: number }> = {
-  openai:  { model: 'text-embedding-3-large', dimensions: 1536 },
-  gemini:  { model: 'gemini-embedding-001',    dimensions: 1536 },
-  ollama:  { model: 'nomic-embed-text',       dimensions: 768  },
-  custom:  { model: 'text-embedding-3-large', dimensions: 1536 },
+const PROVIDER_DEFAULTS: Record<EmbeddingProvider, {
+  model: string;
+  dimensions: number;
+  baseUrl?: string;
+  sendDimensions: boolean;
+}> = {
+  openai:    { model: 'text-embedding-3-large', dimensions: 1536, sendDimensions: true },
+  gemini:    { model: 'gemini-embedding-001',   dimensions: 768,  baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai/', sendDimensions: true },
+  ollama:    { model: 'nomic-embed-text',       dimensions: 768,  baseUrl: 'http://localhost:11434/v1', sendDimensions: false },
+  dashscope: { model: 'text-embedding-v3',      dimensions: 1024, baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1', sendDimensions: true },
+  deepseek:  { model: 'deepseek-embedding-v2',  dimensions: 768,  baseUrl: 'https://api.deepseek.com/v1', sendDimensions: false },
+  zhipu:     { model: 'embedding-3',            dimensions: 2048, baseUrl: 'https://open.bigmodel.cn/api/paas/v4', sendDimensions: false },
+  custom:    { model: 'text-embedding-3-large', dimensions: 1536, sendDimensions: true },
 };
 
 // ── Configuration resolution ───────────────────────────────────────
@@ -55,6 +77,8 @@ function resolveProvider(): ProviderConfig {
     10
   );
 
+  const sendDimensions = defaults.sendDimensions;
+
   let apiKey: string | undefined;
   let baseUrl: string | undefined;
 
@@ -65,11 +89,23 @@ function resolveProvider(): ProviderConfig {
       break;
     case 'gemini':
       apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY || (config as any)?.gemini_api_key;
-      baseUrl = 'https://generativelanguage.googleapis.com/v1beta/openai/';
+      baseUrl = defaults.baseUrl;
       break;
     case 'ollama':
-      baseUrl = process.env.OLLAMA_BASE_URL || (config as any)?.ollama_base_url || 'http://localhost:11434/v1';
+      baseUrl = process.env.OLLAMA_BASE_URL || (config as any)?.ollama_base_url || defaults.baseUrl;
       apiKey = 'ollama'; // Ollama doesn't need a real key but OpenAI SDK requires one
+      break;
+    case 'dashscope':
+      apiKey = process.env.DASHSCOPE_API_KEY || (config as any)?.dashscope_api_key;
+      baseUrl = process.env.DASHSCOPE_BASE_URL || (config as any)?.dashscope_base_url || defaults.baseUrl;
+      break;
+    case 'deepseek':
+      apiKey = process.env.DEEPSEEK_API_KEY || (config as any)?.deepseek_api_key;
+      baseUrl = process.env.DEEPSEEK_BASE_URL || (config as any)?.deepseek_base_url || defaults.baseUrl;
+      break;
+    case 'zhipu':
+      apiKey = process.env.ZHIPU_API_KEY || (config as any)?.zhipu_api_key;
+      baseUrl = process.env.ZHIPU_BASE_URL || (config as any)?.zhipu_base_url || defaults.baseUrl;
       break;
     case 'custom':
       apiKey = process.env.GBRAIN_EMBEDDING_API_KEY || (config as any)?.embedding_api_key;
@@ -77,7 +113,7 @@ function resolveProvider(): ProviderConfig {
       break;
   }
 
-  return { provider, model, dimensions, apiKey, baseUrl };
+  return { provider, model, dimensions, apiKey, baseUrl, sendDimensions };
 }
 
 // ── Client management ──────────────────────────────────────────────
@@ -100,8 +136,8 @@ function getClient(): { client: OpenAI; config: ProviderConfig } {
     if (config.apiKey) clientOpts.apiKey = config.apiKey;
     if (config.baseUrl) clientOpts.baseURL = config.baseUrl;
 
-    // Gemini and Ollama don't need org/project
-    if (config.provider === 'gemini' || config.provider === 'ollama') {
+    // Non-OpenAI providers don't need org/project
+    if (config.provider !== 'openai') {
       clientOpts.organization = null;
       clientOpts.project = null;
     }
@@ -139,13 +175,15 @@ async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      // Gemini's OpenAI-compat endpoint supports `dimensions` for
-      // gemini-embedding-001 to truncate output dimensions.
       const createParams: Record<string, unknown> = {
         model: config.model,
         input: texts,
-        dimensions: config.dimensions,
       };
+
+      // Only send dimensions if the provider supports it
+      if (config.sendDimensions && config.dimensions) {
+        createParams.dimensions = config.dimensions;
+      }
 
       const response = await client.embeddings.create(createParams as any);
 
@@ -186,7 +224,6 @@ function sleep(ms: number): Promise<void> {
 
 // ── Exported constants (dynamic based on config) ───────────────────
 
-// For backward compatibility, export resolved values
 const _resolved = resolveProvider();
 export const EMBEDDING_MODEL = _resolved.model;
 export const EMBEDDING_DIMENSIONS = _resolved.dimensions;

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -1,30 +1,119 @@
 /**
- * Embedding Service
- * Ported from production Ruby implementation (embedding_service.rb, 190 LOC)
+ * Embedding Service — Multi-Provider
  *
- * OpenAI text-embedding-3-large at 1536 dimensions.
+ * Supports: OpenAI, Gemini, Ollama, and any OpenAI-compatible endpoint.
+ * Provider is selected via GBRAIN_EMBEDDING_PROVIDER env var or config file.
+ * Default: "openai" (backward compatible).
+ *
  * Retry with exponential backoff (4s base, 120s cap, 5 retries).
  * 8000 character input truncation.
  */
 
 import OpenAI from 'openai';
+import { loadConfig } from './config.ts';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
+// ── Provider registry ──────────────────────────────────────────────
+
+export type EmbeddingProvider = 'openai' | 'gemini' | 'ollama' | 'custom';
+
+interface ProviderConfig {
+  provider: EmbeddingProvider;
+  model: string;
+  dimensions: number;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+const PROVIDER_DEFAULTS: Record<EmbeddingProvider, { model: string; dimensions: number }> = {
+  openai:  { model: 'text-embedding-3-large', dimensions: 1536 },
+  gemini:  { model: 'gemini-embedding-001',    dimensions: 1536 },
+  ollama:  { model: 'nomic-embed-text',       dimensions: 768  },
+  custom:  { model: 'text-embedding-3-large', dimensions: 1536 },
+};
+
+// ── Configuration resolution ───────────────────────────────────────
+
+function resolveProvider(): ProviderConfig {
+  const config = loadConfig() as Record<string, unknown> | null;
+
+  const provider = (
+    process.env.GBRAIN_EMBEDDING_PROVIDER
+    || (config as any)?.embedding_provider
+    || 'openai'
+  ) as EmbeddingProvider;
+
+  const defaults = PROVIDER_DEFAULTS[provider] || PROVIDER_DEFAULTS.openai;
+
+  const model = process.env.GBRAIN_EMBEDDING_MODEL
+    || (config as any)?.embedding_model
+    || defaults.model;
+
+  const dimensions = parseInt(
+    process.env.GBRAIN_EMBEDDING_DIMENSIONS
+    || (config as any)?.embedding_dimensions
+    || String(defaults.dimensions),
+    10
+  );
+
+  let apiKey: string | undefined;
+  let baseUrl: string | undefined;
+
+  switch (provider) {
+    case 'openai':
+      apiKey = process.env.OPENAI_API_KEY || (config as any)?.openai_api_key;
+      baseUrl = process.env.OPENAI_BASE_URL;
+      break;
+    case 'gemini':
+      apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY || (config as any)?.gemini_api_key;
+      baseUrl = 'https://generativelanguage.googleapis.com/v1beta/openai/';
+      break;
+    case 'ollama':
+      baseUrl = process.env.OLLAMA_BASE_URL || (config as any)?.ollama_base_url || 'http://localhost:11434/v1';
+      apiKey = 'ollama'; // Ollama doesn't need a real key but OpenAI SDK requires one
+      break;
+    case 'custom':
+      apiKey = process.env.GBRAIN_EMBEDDING_API_KEY || (config as any)?.embedding_api_key;
+      baseUrl = process.env.GBRAIN_EMBEDDING_BASE_URL || (config as any)?.embedding_base_url;
+      break;
+  }
+
+  return { provider, model, dimensions, apiKey, baseUrl };
+}
+
+// ── Client management ──────────────────────────────────────────────
+
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
 
-let client: OpenAI | null = null;
+let cachedClient: OpenAI | null = null;
+let cachedConfig: ProviderConfig | null = null;
 
-function getClient(): OpenAI {
-  if (!client) {
-    client = new OpenAI();
+function getClient(): { client: OpenAI; config: ProviderConfig } {
+  const config = resolveProvider();
+
+  // Recreate client if provider config changed
+  if (!cachedClient || JSON.stringify(cachedConfig) !== JSON.stringify(config)) {
+    const clientOpts: Record<string, unknown> = {};
+    if (config.apiKey) clientOpts.apiKey = config.apiKey;
+    if (config.baseUrl) clientOpts.baseURL = config.baseUrl;
+
+    // Gemini and Ollama don't need org/project
+    if (config.provider === 'gemini' || config.provider === 'ollama') {
+      clientOpts.organization = null;
+      clientOpts.project = null;
+    }
+
+    cachedClient = new OpenAI(clientOpts as any);
+    cachedConfig = config;
   }
-  return client;
+
+  return { client: cachedClient, config };
 }
+
+// ── Public API (unchanged signatures) ──────────────────────────────
 
 export async function embed(text: string): Promise<Float32Array> {
   const truncated = text.slice(0, MAX_CHARS);
@@ -36,7 +125,6 @@ export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
   const truncated = texts.map(t => t.slice(0, MAX_CHARS));
   const results: Float32Array[] = [];
 
-  // Process in batches of BATCH_SIZE
   for (let i = 0; i < truncated.length; i += BATCH_SIZE) {
     const batch = truncated.slice(i, i + BATCH_SIZE);
     const batchResults = await embedBatchWithRetry(batch);
@@ -47,21 +135,25 @@ export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
 }
 
 async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
+  const { client, config } = getClient();
+
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const response = await getClient().embeddings.create({
-        model: MODEL,
+      // Gemini's OpenAI-compat endpoint supports `dimensions` for
+      // gemini-embedding-001 to truncate output dimensions.
+      const createParams: Record<string, unknown> = {
+        model: config.model,
         input: texts,
-        dimensions: DIMENSIONS,
-      });
+        dimensions: config.dimensions,
+      };
 
-      // Sort by index to maintain order
-      const sorted = response.data.sort((a, b) => a.index - b.index);
-      return sorted.map(d => new Float32Array(d.embedding));
+      const response = await client.embeddings.create(createParams as any);
+
+      const sorted = response.data.sort((a: any, b: any) => a.index - b.index);
+      return sorted.map((d: any) => new Float32Array(d.embedding));
     } catch (e: unknown) {
       if (attempt === MAX_RETRIES - 1) throw e;
 
-      // Check for rate limit with Retry-After header
       let delay = exponentialDelay(attempt);
 
       if (e instanceof OpenAI.APIError && e.status === 429) {
@@ -78,9 +170,10 @@ async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
     }
   }
 
-  // Should not reach here
   throw new Error('Embedding failed after all retries');
 }
+
+// ── Utilities ──────────────────────────────────────────────────────
 
 function exponentialDelay(attempt: number): number {
   const delay = BASE_DELAY_MS * Math.pow(2, attempt);
@@ -91,4 +184,9 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
+// ── Exported constants (dynamic based on config) ───────────────────
+
+// For backward compatibility, export resolved values
+const _resolved = resolveProvider();
+export const EMBEDDING_MODEL = _resolved.model;
+export const EMBEDDING_DIMENSIONS = _resolved.dimensions;

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -3,6 +3,7 @@ import { vector } from '@electric-sql/pglite/vector';
 import { pg_trgm } from '@electric-sql/pglite/contrib/pg_trgm';
 import type { Transaction } from '@electric-sql/pglite';
 import type { BrainEngine } from './engine.ts';
+import { EMBEDDING_MODEL } from './embedding.ts';
 import { runMigrations } from './migrate.ts';
 import { PGLITE_SCHEMA_SQL } from './pglite-schema.ts';
 import type {
@@ -238,10 +239,10 @@ export class PGLiteEngine implements BrainEngine {
 
       if (embeddingStr) {
         rowParts.push(`($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}::vector, $${paramIdx++}, $${paramIdx++}, now())`);
-        params.push(pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source, embeddingStr, chunk.model || 'text-embedding-3-large', chunk.token_count || null);
+        params.push(pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source, embeddingStr, chunk.model || EMBEDDING_MODEL, chunk.token_count || null);
       } else {
         rowParts.push(`($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, NULL, $${paramIdx++}, $${paramIdx++}, NULL)`);
-        params.push(pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source, chunk.model || 'text-embedding-3-large', chunk.token_count || null);
+        params.push(pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source, chunk.model || EMBEDDING_MODEL, chunk.token_count || null);
       }
     }
 

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -13,6 +13,8 @@
  * test/edge-bundle.test.ts has a drift detection test.
  */
 
+import { EMBEDDING_DIMENSIONS, EMBEDDING_MODEL } from './embedding.ts';
+
 export const PGLITE_SCHEMA_SQL = `
 -- GBrain PGLite schema (local embedded Postgres)
 
@@ -48,7 +50,7 @@ CREATE TABLE IF NOT EXISTS content_chunks (
   chunk_index   INTEGER NOT NULL,
   chunk_text    TEXT    NOT NULL,
   chunk_source  TEXT    NOT NULL DEFAULT 'compiled_truth',
-  embedding     vector(1536),
+  embedding     vector(${EMBEDDING_DIMENSIONS}),
   model         TEXT    NOT NULL DEFAULT 'text-embedding-3-large',
   token_count   INTEGER,
   embedded_at   TIMESTAMPTZ,
@@ -154,8 +156,8 @@ CREATE TABLE IF NOT EXISTS config (
 INSERT INTO config (key, value) VALUES
   ('version', '1'),
   ('engine', 'pglite'),
-  ('embedding_model', 'text-embedding-3-large'),
-  ('embedding_dimensions', '1536'),
+  ('embedding_model', '${EMBEDDING_MODEL}'),
+  ('embedding_dimensions', '${EMBEDDING_DIMENSIONS}'),
   ('chunk_strategy', 'semantic')
 ON CONFLICT (key) DO NOTHING;
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1,5 +1,6 @@
 import postgres from 'postgres';
 import type { BrainEngine } from './engine.ts';
+import { EMBEDDING_MODEL } from './embedding.ts';
 import { runMigrations } from './migrate.ts';
 import { SCHEMA_SQL } from './schema-embedded.ts';
 import type {
@@ -255,10 +256,10 @@ export class PostgresEngine implements BrainEngine {
 
       if (embeddingStr) {
         rows.push(`($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}::vector, $${paramIdx++}, $${paramIdx++}, now())`);
-        params.push(pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source, embeddingStr, chunk.model || 'text-embedding-3-large', chunk.token_count || null);
+        params.push(pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source, embeddingStr, chunk.model || EMBEDDING_MODEL, chunk.token_count || null);
       } else {
         rows.push(`($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, NULL, $${paramIdx++}, $${paramIdx++}, NULL)`);
-        params.push(pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source, chunk.model || 'text-embedding-3-large', chunk.token_count || null);
+        params.push(pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source, chunk.model || EMBEDDING_MODEL, chunk.token_count || null);
       }
     }
 

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -1,6 +1,8 @@
 // AUTO-GENERATED — do not edit. Run: bun run build:schema
 // Source: src/schema.sql
 
+import { EMBEDDING_DIMENSIONS, EMBEDDING_MODEL } from './embedding.ts';
+
 export const SCHEMA_SQL = `
 -- GBrain Postgres + pgvector schema
 
@@ -36,7 +38,7 @@ CREATE TABLE IF NOT EXISTS content_chunks (
   chunk_index   INTEGER NOT NULL,
   chunk_text    TEXT    NOT NULL,
   chunk_source  TEXT    NOT NULL DEFAULT 'compiled_truth',
-  embedding     vector(1536),
+  embedding     vector(${EMBEDDING_DIMENSIONS}),
   model         TEXT    NOT NULL DEFAULT 'text-embedding-3-large',
   token_count   INTEGER,
   embedded_at   TIMESTAMPTZ,
@@ -141,8 +143,8 @@ CREATE TABLE IF NOT EXISTS config (
 
 INSERT INTO config (key, value) VALUES
   ('version', '1'),
-  ('embedding_model', 'text-embedding-3-large'),
-  ('embedding_dimensions', '1536'),
+  ('embedding_model', '${EMBEDDING_MODEL}'),
+  ('embedding_dimensions', '${EMBEDDING_DIMENSIONS}'),
   ('chunk_strategy', 'semantic')
 ON CONFLICT (key) DO NOTHING;
 

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -28,8 +28,15 @@ export async function hybridSearch(
   // Run keyword search (always available, no API key needed)
   const keywordResults = await engine.searchKeyword(query, { limit: limit * 2 });
 
-  // Skip vector search entirely if no OpenAI key is configured
-  if (!process.env.OPENAI_API_KEY) {
+  // Skip vector search if no embedding API key is configured for any provider
+  const hasEmbeddingKey = !!(
+    process.env.OPENAI_API_KEY ||
+    process.env.GEMINI_API_KEY ||
+    process.env.GOOGLE_API_KEY ||
+    process.env.GBRAIN_EMBEDDING_API_KEY ||
+    process.env.GBRAIN_EMBEDDING_PROVIDER === 'ollama'
+  );
+  if (!hasEmbeddingKey) {
     return dedupResults(keywordResults).slice(0, limit);
   }
 


### PR DESCRIPTION
## Multi-Provider Embedding Support

Makes GBrain's embedding layer pluggable across 7 providers via a single env var.

### Supported Providers

| Provider | Model | Dimensions | Region |
|----------|-------|-----------|--------|
| **openai** (default) | text-embedding-3-large | 1536 | Global |
| **gemini** | gemini-embedding-001 | 768 | Global |
| **ollama** | nomic-embed-text | 768 | Local |
| **dashscope** (Qwen) | text-embedding-v3 | 1024 | China |
| **deepseek** | deepseek-embedding-v2 | 768 | China |
| **zhipu** (GLM) | embedding-3 | 2048 | China |
| **custom** | any OpenAI-compatible | configurable | Any |

### Changes

- `embedding.ts`: Rewrote provider registry with 7 providers, per-provider defaults (model, dimensions, baseURL, sendDimensions flag)
- `config.ts`: Added new provider types and env var mappings (DASHSCOPE_API_KEY, DEEPSEEK_API_KEY, ZHIPU_API_KEY)
- `pglite-schema.ts` + `schema-embedded.ts`: Replaced hardcoded `vector(1536)` with dynamic `EMBEDDING_DIMENSIONS`; replaced hardcoded model name in config table defaults
- All providers use OpenAI SDK with different baseURL (no new dependencies)
- Backward compatible: defaults to openai if no env var is set

### Usage

```bash
# Use Gemini
export GBRAIN_EMBEDDING_PROVIDER=gemini
export GEMINI_API_KEY=your-key

# Use DashScope (Alibaba Qwen) 
export GBRAIN_EMBEDDING_PROVIDER=dashscope
export DASHSCOPE_API_KEY=your-key

# Use DeepSeek
export GBRAIN_EMBEDDING_PROVIDER=deepseek
export DEEPSEEK_API_KEY=your-key

# Use Zhipu GLM
export GBRAIN_EMBEDDING_PROVIDER=zhipu
export ZHIPU_API_KEY=your-key
```
