### PR TITLE
feat: add Ollama bge-m3 local embedding support

### DIFF
--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -1,29 +1,38 @@
 /**
  * Embedding Service
- * Ported from production Ruby implementation (embedding_service.rb, 190 LOC)
  *
- * OpenAI text-embedding-3-large at 1536 dimensions.
+ * Supports two backends:
+ * - OpenAI text-embedding-3-large (1536 dimensions) via OpenAI API
+ * - Ollama with bge-m3 (1024 dimensions) for local inference
+ *
+ * Set OLLAMA_URL to enable Ollama backend.
+ * e.g. OLLAMA_URL=http://localhost:11434
+ *
  * Retry with exponential backoff (4s base, 120s cap, 5 retries).
  * 8000 character input truncation.
  */
 
 import OpenAI from 'openai';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
+// Config
+const OLLAMA_URL = process.env['OLLAMA_URL'] ?? '';
+const USE_OLLAMA = Boolean(OLLAMA_URL);
+const OPENAI_MODEL = 'text-embedding-3-large';
+const OLLAMA_MODEL = 'bge-m3';
+const DIMENSIONS = 1024; // bge-m3 uses 1024 dims; OpenAI uses 1536
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
 
-let client: OpenAI | null = null;
+let openAIClient: OpenAI | null = null;
 
-function getClient(): OpenAI {
-  if (!client) {
-    client = new OpenAI();
+function getOpenAIClient(): OpenAI {
+  if (!openAIClient) {
+    openAIClient = new OpenAI();
   }
-  return client;
+  return openAIClient;
 }
 
 export async function embed(text: string): Promise<Float32Array> {
@@ -39,29 +48,28 @@ export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
   // Process in batches of BATCH_SIZE
   for (let i = 0; i < truncated.length; i += BATCH_SIZE) {
     const batch = truncated.slice(i, i + BATCH_SIZE);
-    const batchResults = await embedBatchWithRetry(batch);
+    const batchResults = USE_OLLAMA
+      ? await embedBatchOllama(batch)
+      : await embedBatchOpenAI(batch);
     results.push(...batchResults);
   }
 
   return results;
 }
 
-async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
+async function embedBatchOpenAI(texts: string[]): Promise<Float32Array[]> {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const response = await getClient().embeddings.create({
-        model: MODEL,
+      const response = await getOpenAIClient().embeddings.create({
+        model: OPENAI_MODEL,
         input: texts,
-        dimensions: DIMENSIONS,
+        dimensions: 1536,
       });
 
-      // Sort by index to maintain order
       const sorted = response.data.sort((a, b) => a.index - b.index);
       return sorted.map(d => new Float32Array(d.embedding));
     } catch (e: unknown) {
       if (attempt === MAX_RETRIES - 1) throw e;
-
-      // Check for rate limit with Retry-After header
       let delay = exponentialDelay(attempt);
 
       if (e instanceof OpenAI.APIError && e.status === 429) {
@@ -77,9 +85,30 @@ async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
       await sleep(delay);
     }
   }
+  throw new Error('OpenAI embedding failed after all retries');
+}
 
-  // Should not reach here
-  throw new Error('Embedding failed after all retries');
+async function embedBatchOllama(texts: string[]): Promise<Float32Array[]> {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(`${OLLAMA_URL}/api/embed`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: OLLAMA_MODEL, input: texts }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Ollama embedding failed: ${response.status} ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as { embeddings: number[][] };
+      return data.embeddings.map(embedding => new Float32Array(embedding));
+    } catch (e: unknown) {
+      if (attempt === MAX_RETRIES - 1) throw e;
+      await sleep(exponentialDelay(attempt));
+    }
+  }
+  throw new Error('Ollama embedding failed after all retries');
 }
 
 function exponentialDelay(attempt: number): number {
@@ -91,4 +120,4 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
+export { OPENAI_MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS, USE_OLLAMA };

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -41,6 +41,8 @@ CREATE INDEX IF NOT EXISTS idx_pages_trgm ON pages USING GIN(title gin_trgm_ops)
 
 -- ============================================================
 -- content_chunks: chunked content with embeddings
+-- Note: vector dimensions must match your embedding provider.
+-- bge-m3 (Ollama) = 1024 dims, text-embedding-3-large (OpenAI) = 1536 dims.
 -- ============================================================
 CREATE TABLE IF NOT EXISTS content_chunks (
   id            SERIAL PRIMARY KEY,
@@ -48,8 +50,8 @@ CREATE TABLE IF NOT EXISTS content_chunks (
   chunk_index   INTEGER NOT NULL,
   chunk_text    TEXT    NOT NULL,
   chunk_source  TEXT    NOT NULL DEFAULT 'compiled_truth',
-  embedding     vector(1536),
-  model         TEXT    NOT NULL DEFAULT 'text-embedding-3-large',
+  embedding     vector(1024),
+  model         TEXT    NOT NULL DEFAULT 'bge-m3',
   token_count   INTEGER,
   embedded_at   TIMESTAMPTZ,
   created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -154,8 +156,8 @@ CREATE TABLE IF NOT EXISTS config (
 INSERT INTO config (key, value) VALUES
   ('version', '1'),
   ('engine', 'pglite'),
-  ('embedding_model', 'text-embedding-3-large'),
-  ('embedding_dimensions', '1536'),
+  ('embedding_model', 'bge-m3'),
+  ('embedding_dimensions', '1024'),
   ('chunk_strategy', 'semantic')
 ON CONFLICT (key) DO NOTHING;
 

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -25,6 +25,9 @@ CREATE INDEX IF NOT EXISTS idx_pages_trgm ON pages USING GIN(title gin_trgm_ops)
 
 -- ============================================================
 -- content_chunks: chunked content with embeddings
+-- Note: vector dimensions must match your embedding provider.
+-- bge-m3 (Ollama) = 1024 dims, text-embedding-3-large (OpenAI) = 1536 dims.
+-- Change dimension below and re-run import with --fresh to re-embed existing data.
 -- ============================================================
 CREATE TABLE IF NOT EXISTS content_chunks (
   id            SERIAL PRIMARY KEY,
@@ -32,8 +35,8 @@ CREATE TABLE IF NOT EXISTS content_chunks (
   chunk_index   INTEGER NOT NULL,
   chunk_text    TEXT    NOT NULL,
   chunk_source  TEXT    NOT NULL DEFAULT 'compiled_truth',
-  embedding     vector(1536),
-  model         TEXT    NOT NULL DEFAULT 'text-embedding-3-large',
+  embedding     vector(1024),
+  model         TEXT    NOT NULL DEFAULT 'bge-m3',
   token_count   INTEGER,
   embedded_at   TIMESTAMPTZ,
   created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -137,8 +140,8 @@ CREATE TABLE IF NOT EXISTS config (
 
 INSERT INTO config (key, value) VALUES
   ('version', '1'),
-  ('embedding_model', 'text-embedding-3-large'),
-  ('embedding_dimensions', '1536'),
+  ('embedding_model', 'bge-m3'),
+  ('embedding_dimensions', '1024'),
   ('chunk_strategy', 'semantic')
 ON CONFLICT (key) DO NOTHING;
 


### PR DESCRIPTION
## Summary

Adds support for local embedding inference via Ollama with the bge-m3 model, in addition to the existing OpenAI backend.

### Changes

**src/core/embedding.ts**
- Refactor embedding backend into two paths: OpenAI (, 1536 dims) and Ollama (, 1024 dims)
- Enable Ollama by setting  env var (e.g. )
- OpenAI remains the default when  is not set

**src/schema.sql + src/core/pglite-schema.ts**
- Change default  +  (was  + )
- Add comments documenting provider/dimension requirements

### Usage



### Note for existing users

If you already have embeddings at 1536 dimensions, you need to re-import with  to re-embed with the new model.