### PR TITLE
security: add LIMIT to file_list slug-filtered query

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -529,6 +529,8 @@ const get_ingest_log: Operation = {
 
 // --- File Operations ---
 
+const FILE_LIST_LIMIT = 100;
+
 const file_list: Operation = {
   name: 'file_list',
   description: 'List stored files',
@@ -538,10 +540,14 @@ const file_list: Operation = {
   handler: async (_ctx, p) => {
     const sql = db.getConnection();
     const slug = p.slug as string | undefined;
+    // Both branches need a LIMIT. Without one, the slug-filtered
+    // branch materializes every file for that slug — an authenticated
+    // caller can force unbounded memory consumption on the Edge
+    // Function isolate by targeting a page with many attachments.
     if (slug) {
-      return sql`SELECT id, page_slug, filename, storage_path, mime_type, size_bytes, content_hash, created_at FROM files WHERE page_slug = ${slug} ORDER BY filename`;
+      return sql`SELECT id, page_slug, filename, storage_path, mime_type, size_bytes, content_hash, created_at FROM files WHERE page_slug = ${slug} ORDER BY filename LIMIT ${FILE_LIST_LIMIT}`;
     }
-    return sql`SELECT id, page_slug, filename, storage_path, mime_type, size_bytes, content_hash, created_at FROM files ORDER BY page_slug, filename LIMIT 100`;
+    return sql`SELECT id, page_slug, filename, storage_path, mime_type, size_bytes, content_hash, created_at FROM files ORDER BY page_slug, filename LIMIT ${FILE_LIST_LIMIT}`;
   },
 };
 


### PR DESCRIPTION
## Summary

The `file_list` operation had asymmetric LIMIT handling: the unfiltered branch
carried `LIMIT 100` but the slug-filtered branch had none. An authenticated
caller could force unbounded result-set materialization on the Edge Function.

Full description: #69

## Changes

`src/core/operations.ts`

- Extract `FILE_LIST_LIMIT = 100` as a named constant.
- Both SQL branches (slug-filtered and unfiltered) now use `LIMIT ${FILE_LIST_LIMIT}`.

## Validation

- `bun test test/parity.test.ts` — 10 pass (operation contract intact)
- `bun test` — 409 pass, 0 fail (full suite)
- Static check: both SQL strings in file_list handler contain LIMIT ✓

## Test plan

- [x] Parity test passes (operation schema unchanged)
- [x] Full test suite green
- [ ] Manual: `gbrain call file_list --slug people/elon` returns at most 100 rows