### PR TITLE
security: pin marked.js to v15.0.7 + add SRI integrity hash

### DIFF
--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -314,7 +314,7 @@ export function generateHtml({ title, markdown, encrypted }: GenerateHtmlOptions
 ${passwordHtml}
 <div id="content"></div>
 ${encryptedVars}
-<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"><\/script>
+<script src="https://cdn.jsdelivr.net/npm/marked@15.0.7/marked.min.js" integrity="sha384-H+hy9ULve6xfxRkWIh/YOtvDdpXgV2fmAGQkIDTxIgZwNoaoBal14Di2YTMR6MzR" crossorigin="anonymous"><\/script>
 ${contentScript}
 </body>
 </html>`;


### PR DESCRIPTION
## Summary

Published HTML loaded marked.js from an unpinned CDN URL without Subresource
Integrity. A CDN compromise or MITM injects arbitrary JS into every published page.

Full description: #70

## Changes

`src/commands/publish.ts`

- Pinned marked.js URL from `npm/marked/marked.min.js` to `npm/marked@15.0.7/marked.min.js`
- Added `integrity="sha384-H+hy9ULve6xfxRkWIh/YOtvDdpXgV2fmAGQkIDTxIgZwNoaoBal14Di2YTMR6MzR"`
- Added `crossorigin="anonymous"` (required for SRI cross-origin)

## Validation

- integrity hash computed: `curl -sL URL | openssl dgst -sha384 -binary | openssl base64 -A`
- Static check: template contains `integrity=`, `crossorigin=`, `@15.0.7`, no unpinned reference ✓
- `bun test` — 409 pass, 0 fail

## Test plan

- [x] Full test suite green
- [x] Static template verification passes
- [ ] Manual: `gbrain publish page.md --out test.html`, open in browser, verify marked.js loads successfully with SRI