### PR TITLE
security: use lstatSync in files.ts collectFiles walker

### DIFF
--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync, statSync, existsSync, writeFileSync, unlinkSync, mkdirSync } from 'fs';
+import { readFileSync, readdirSync, statSync, lstatSync, existsSync, writeFileSync, unlinkSync, mkdirSync } from 'fs';
 import { join, relative, extname, basename, dirname } from 'path';
 import { createHash } from 'crypto';
 import type { BrainEngine } from '../core/engine.ts';
@@ -614,9 +614,26 @@ function collectFiles(dir: string): string[] {
   function walk(d: string) {
     for (const entry of readdirSync(d)) {
       if (entry.startsWith('.')) continue;
+      if (entry === 'node_modules') continue;
 
       const full = join(d, entry);
-      const stat = statSync(full);
+      let stat;
+      try {
+        // lstatSync, not statSync: must NOT follow symlinks. A
+        // symlink inside a shared brain directory can point at any
+        // user-readable file; following it would upload the target
+        // to storage, where a bearer-token holder can download it.
+        stat = lstatSync(full);
+      } catch {
+        // Broken symlink or permission error
+        continue;
+      }
+
+      if (stat.isSymbolicLink()) {
+        // Skip symlinks entirely — blocks both file exfil and
+        // circular-symlink DoS.
+        continue;
+      }
 
       if (stat.isDirectory()) {
         walk(full);


### PR DESCRIPTION
## Summary

`collectFiles()` in `src/commands/files.ts` used `statSync` which follows
symlinks. A symlink inside a shared brain directory pointing at a sensitive
file would be uploaded to storage and downloadable via the MCP `file_url` tool.

Same class as L002 (import walker) but in a different walker.

Full description: #71

## Changes

`src/commands/files.ts`

- Import `lstatSync` alongside existing `statSync` (which is still used elsewhere)
- Replace `statSync(full)` with `lstatSync(full)` in the walker
- Add `stat.isSymbolicLink()` → skip (blocks file exfil and circular-symlink DoS)
- Add `try/catch` around `lstatSync` (broken symlink / permission error → skip)
- Add `node_modules` skip

## Validation

- `lstatSync` on a symlink returns `isSymbolicLink() === true`, `isFile() === false` ✓
- Source code verified: walker uses `lstatSync`, has `isSymbolicLink` check, has `node_modules` skip ✓
- `bun test` — 409 pass, 0 fail

## Test plan

- [x] Full test suite green
- [x] Runtime verification: symlink detected as symbolic link, not as file
- [ ] Manual: create a symlink in a brain dir, run `gbrain files scan`, verify the symlink is skipped