### PR TITLE
security: validate .supabase marker prefix against path traversal

### DIFF
--- a/src/core/file-resolver.ts
+++ b/src/core/file-resolver.ts
@@ -82,7 +82,21 @@ export async function resolveFile(
   if (existsSync(markerPath)) {
     if (!storage) throw new Error(`Directory mirrored to storage but no storage backend configured: ${filePath}`);
     const marker = parseMarker(markerPath);
-    const storagePath = marker.prefix + filePath.split('/').pop();
+    // Validate marker.prefix: must not contain path traversal
+    // sequences. The marker file lives on disk and its content is
+    // trusted to the extent that the user controls their own brain
+    // directory, but in a shared brain repo a contributor could
+    // craft a .supabase marker with prefix "../../uploads/" to
+    // make storage.download() request a path outside the intended
+    // scope.
+    if (marker.prefix && /\.\.[\\/]/.test(marker.prefix)) {
+      throw new Error(`Blocked: .supabase marker prefix contains path traversal: ${marker.prefix}`);
+    }
+    const filename = filePath.split('/').pop() || '';
+    if (/\.\.[\\/]/.test(filename)) {
+      throw new Error(`Blocked: filename contains path traversal: ${filename}`);
+    }
+    const storagePath = (marker.prefix || '') + filename;
     try {
       const data = await storage.download(storagePath);
       return { data, source: 'storage' };

--- a/test/file-resolver.test.ts
+++ b/test/file-resolver.test.ts
@@ -56,6 +56,38 @@ describe('file-resolver', () => {
 
     expect(resolveFile('people/no-storage.json', brainRoot)).rejects.toThrow('no storage backend');
   });
+
+  // --- R3-F006 fix: .supabase marker prefix injection ---
+
+  test('blocks .supabase marker with traversal prefix', async () => {
+    // The file must NOT exist locally so the resolver falls through
+    // to the .supabase marker path (step 4 in the fallback chain).
+    const subDir = join(brainRoot, 'poisoned');
+    mkdirSync(subDir, { recursive: true });
+    writeFileSync(join(subDir, '.supabase'),
+      'synced_at: 2026-04-12\nbucket: brain-files\nprefix: ../../etc/\nfile_count: 1\n'
+    );
+    // No local file at poisoned/secret.json — forces the marker path
+
+    await expect(
+      resolveFile('poisoned/secret.json', brainRoot, storage)
+    ).rejects.toThrow('marker prefix contains path traversal');
+  });
+
+  test('allows .supabase marker with clean prefix', async () => {
+    const subDir = join(brainRoot, 'media');
+    mkdirSync(subDir, { recursive: true });
+    // Upload a file to storage under the marker's prefix
+    await storage.upload('media/.raw/photo.jpg', Buffer.from('jpeg-data'));
+    // Create marker pointing at the clean prefix
+    writeFileSync(join(subDir, '.supabase'),
+      'synced_at: 2026-04-12\nbucket: brain-files\nprefix: media/.raw/\nfile_count: 1\n'
+    );
+
+    const result = await resolveFile('media/photo.jpg', brainRoot, storage);
+    expect(result.source).toBe('storage');
+    expect(result.data.toString()).toBe('jpeg-data');
+  });
 });
 
 describe('parseRedirect', () => {


### PR DESCRIPTION
## Summary

The file resolver concatenated `marker.prefix` from a `.supabase` marker file
with the requested filename without checking for `../` sequences. In a shared
brain repo, a contributor could craft a `.supabase` marker with
`prefix: ../../uploads/` to make `storage.download()` escape the intended scope.

Full description: #72

## Changes

`src/core/file-resolver.ts`

- Validate `marker.prefix` for `../` patterns before concatenation — throws
  `"marker prefix contains path traversal"` if detected.
- Validate `filename` (from `filePath.split('/').pop()`) for the same pattern.
- Handle `marker.prefix` being undefined/empty safely with `(marker.prefix || '')`.

`test/file-resolver.test.ts`

2 new tests:

- **blocks .supabase marker with traversal prefix** — a marker with
  `prefix: ../../etc/` on a non-local file triggers the traversal error.
  File intentionally does NOT exist locally so the resolver falls through
  to the marker path (step 4 in the fallback chain).
- **allows .supabase marker with clean prefix** — a marker with
  `prefix: media/.raw/` correctly resolves via storage and returns the
  uploaded data.

## Validation

- `bun test test/file-resolver.test.ts` — 8 pass, 0 fail (6 original + 2 new)
- `bun test` — 411 pass, 0 fail (full suite)

## Test plan

- [x] Full test suite green
- [x] Traversal prefix rejected, clean prefix accepted
- [ ] Manual: create a `.supabase` marker with `prefix: ../../`, call `resolveFile`, verify error