### PR TITLE
fix: PGLiteEngine contentHash called with wrong arguments, breaking import idempotency

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -90,7 +90,7 @@ export class PGLiteEngine implements BrainEngine {
 
   async putPage(slug: string, page: PageInput): Promise<Page> {
     slug = validateSlug(slug);
-    const hash = page.content_hash || contentHash(page.compiled_truth, page.timeline || '');
+    const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
 
     const { rows } = await this.db.query(

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -58,6 +58,22 @@ describe('PGLiteEngine: Pages', () => {
     expect(fetched!.content_hash).toBeTruthy();
   });
 
+  test('putPage generates unique content_hash per page content', async () => {
+    const pageA = await engine.putPage('test/hash-a', {
+      type: 'person', title: 'Alice',
+      compiled_truth: 'Alice is the CEO of Acme Corp.',
+    });
+    const pageB = await engine.putPage('test/hash-b', {
+      type: 'company', title: 'Beta Inc',
+      compiled_truth: 'Beta Inc builds enterprise software.',
+    });
+
+    // Different content MUST produce different hashes (import idempotency depends on this)
+    expect(pageA.content_hash).toBeTruthy();
+    expect(pageB.content_hash).toBeTruthy();
+    expect(pageA.content_hash).not.toBe(pageB.content_hash);
+  });
+
   test('putPage upserts on conflict', async () => {
     await engine.putPage('test/upsert', testPage);
     const updated = await engine.putPage('test/upsert', {


### PR DESCRIPTION
## Summary

`PGLiteEngine.putPage()` passes `contentHash(page.compiled_truth, page.timeline || '')` — two string arguments — to a function that expects a single `PageInput` object. JavaScript silently ignores the second argument, and the string has no `.title`, `.type`, `.compiled_truth` properties, so they all resolve to `undefined`. The result: **every page in PGLite gets the identical hash `e38978dc...`**, completely breaking import idempotency.

`PostgresEngine.putPage()` correctly calls `contentHash(page)`. This is a one-line fix to match.

### Bug proof

```
=== BUG: Different content produces IDENTICAL hashes ===
Hash A: e38978dc212c0efa...
Hash B: e38978dc212c0efa...
Hash C: e38978dc212c0efa...
All identical? true

=== FIX: PageInput objects produce UNIQUE hashes ===
Hash A: 1fd286540e1244ef...
Hash B: 83e302605af63fdc...
Different? true
```

### Impact

- Every PGLite user (the default engine) is affected
- Import idempotency broken — the system cannot detect which pages actually changed on re-import
- `gbrain sync` re-processes unchanged files on every run

### Changes

| File | Change |
|------|--------|
| `src/core/pglite-engine.ts` | Fix `contentHash(page.compiled_truth, ...)` → `contentHash(page)` |
| `test/pglite-engine.test.ts` | Add regression test: different pages must produce different hashes |

### Test results

```
443 pass, 0 fail (full suite)
42 pass, 0 fail (pglite-engine tests, including new regression test)
```

The regression test was verified to **fail** with the old code (showing the constant hash `e38978dc...`) and **pass** with the fix.

## Test plan

- [x] `bun test` — 443 pass, 0 fail
- [x] New regression test proves the bug existed and is now fixed
- [x] Verified fix matches PostgresEngine behavior (`contentHash(page)`)