### PR TITLE
feat: gbrain serve --http — Streamable HTTP MCP transport

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -305,7 +305,7 @@ async function handleCliOnly(command: string, args: string[]) {
       }
       case 'serve': {
         const { runServe } = await import('./commands/serve.ts');
-        await runServe(engine);
+        await runServe(engine, args);
         return; // serve doesn't disconnect
       }
       case 'call': {
@@ -436,6 +436,7 @@ ADMIN
   revert <slug> <version-id>         Revert to version
   config [show|get|set] <key> [val]  Brain config
   serve                              MCP server (stdio)
+  serve --http [--port N] [--auth]   MCP server (HTTP, default port 8787)
   call <tool> '<json>'               Raw tool invocation
   version                            Version info
   --tools-json                       Tool discovery (JSON)

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,7 +1,68 @@
+import { createHash } from 'crypto';
 import type { BrainEngine } from '../core/engine.ts';
+import { loadConfig, type GBrainConfig } from '../core/config.ts';
 import { startMcpServer } from '../mcp/server.ts';
+import { startHttpMcpServer, type TokenValidator } from '../mcp/http-server.ts';
 
-export async function runServe(engine: BrainEngine) {
-  console.error('Starting GBrain MCP server (stdio)...');
-  await startMcpServer(engine);
+/**
+ * Create a token validator following established repo patterns:
+ * - Postgres: standalone postgres() connection, same as auth.ts (lines 30, 56, 83)
+ * - PGLite: (engine as any).db, same as init.ts (line 116)
+ */
+function createTokenValidator(engine: BrainEngine, config: GBrainConfig): TokenValidator {
+  if (config.database_url) {
+    let sql: ReturnType<typeof import('postgres').default> | null = null;
+    return async (token: string): Promise<string | null> => {
+      const hash = createHash('sha256').update(token).digest('hex');
+      try {
+        if (!sql) {
+          const postgres = (await import('postgres')).default;
+          sql = postgres(config.database_url!, { max: 2, idle_timeout: 20 });
+        }
+        const rows = await sql`SELECT name FROM access_tokens WHERE token_hash = ${hash} AND revoked_at IS NULL`;
+        if (rows.length === 0) return null;
+        const tokenName = rows[0].name as string;
+        sql`UPDATE access_tokens SET last_used_at = now() WHERE token_hash = ${hash}`.catch(() => {});
+        return tokenName;
+      } catch (e: unknown) {
+        process.stderr.write(`[error] Token validation failed: ${e instanceof Error ? e.message : e}\n`);
+        return null;
+      }
+    };
+  }
+
+  return async (token: string): Promise<string | null> => {
+    const hash = createHash('sha256').update(token).digest('hex');
+    try {
+      const db = (engine as any).db;
+      if (!db) { process.stderr.write('[warn] Token validation: no DB connection\n'); return null; }
+      const { rows } = await db.query(
+        `SELECT name FROM access_tokens WHERE token_hash = $1 AND revoked_at IS NULL`, [hash]
+      );
+      if (rows.length === 0) return null;
+      const tokenName = (rows[0] as { name: string }).name;
+      db.query(`UPDATE access_tokens SET last_used_at = now() WHERE token_hash = $1`, [hash]).catch(() => {});
+      return tokenName;
+    } catch (e: unknown) {
+      process.stderr.write(`[error] Token validation failed: ${e instanceof Error ? e.message : e}\n`);
+      return null;
+    }
+  };
+}
+
+export async function runServe(engine: BrainEngine, args: string[] = []) {
+  if (args.includes('--http')) {
+    const portIdx = args.indexOf('--port');
+    const port = portIdx >= 0 ? parseInt(args[portIdx + 1], 10) : 8787;
+    if (isNaN(port) || port < 1 || port > 65535) {
+      console.error('Invalid port. Usage: gbrain serve --http --port 8787');
+      process.exit(1);
+    }
+    const config = loadConfig() || { engine: 'postgres' as const };
+    const tokenValidator = args.includes('--auth') ? createTokenValidator(engine, config) : undefined;
+    await startHttpMcpServer(engine, { port, tokenValidator });
+  } else {
+    console.error('Starting GBrain MCP server (stdio)...');
+    await startMcpServer(engine);
+  }
 }

--- a/src/mcp/http-server.ts
+++ b/src/mcp/http-server.ts
@@ -1,0 +1,95 @@
+/**
+ * HTTP MCP server — exposes all 30+ operations over Streamable HTTP.
+ *
+ * Uses the MCP SDK's WebStandardStreamableHTTPServerTransport with Bun.serve().
+ * Auth is a caller-provided callback, keeping this module engine-independent.
+ */
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import type { BrainEngine } from '../core/engine.ts';
+import { createMcpServer } from './server.ts';
+import { VERSION } from '../version.ts';
+
+export type TokenValidator = (token: string) => Promise<string | null>;
+
+export interface HttpServerOptions {
+  port: number;
+  tokenValidator?: TokenValidator;
+}
+
+export async function startHttpMcpServer(
+  engine: BrainEngine,
+  opts: HttpServerOptions,
+): Promise<ReturnType<typeof Bun.serve>> {
+  const { port, tokenValidator } = opts;
+
+  let httpServer: ReturnType<typeof Bun.serve>;
+  try {
+    httpServer = Bun.serve({
+      port,
+      async fetch(req: Request): Promise<Response> {
+        const url = new URL(req.url);
+
+        if (url.pathname === '/health') {
+          return new Response(JSON.stringify({ status: 'ok', version: VERSION }), {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        if (url.pathname === '/mcp') {
+          if (tokenValidator) {
+            const authHeader = req.headers.get('Authorization');
+            if (!authHeader?.startsWith('Bearer ')) {
+              return new Response(JSON.stringify({ error: 'Missing Authorization header' }), {
+                status: 401, headers: { 'Content-Type': 'application/json' },
+              });
+            }
+            let tokenName: string | null;
+            try {
+              tokenName = await tokenValidator(authHeader.slice(7));
+            } catch (e: unknown) {
+              process.stderr.write(`[error] Token validation error: ${e instanceof Error ? e.message : e}\n`);
+              tokenName = null;
+            }
+            if (!tokenName) {
+              return new Response(JSON.stringify({ error: 'Invalid or revoked token' }), {
+                status: 401, headers: { 'Content-Type': 'application/json' },
+              });
+            }
+          }
+
+          const transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: undefined,
+            enableJsonResponse: true,
+          });
+          const mcpServer = createMcpServer(engine);
+          await mcpServer.connect(transport);
+
+          try {
+            const response = await transport.handleRequest(req);
+            mcpServer.close().catch(() => {});
+            return response;
+          } catch (e: unknown) {
+            mcpServer.close().catch(() => {});
+            process.stderr.write(`[error] MCP request failed: ${e instanceof Error ? e.message : e}\n`);
+            return new Response(JSON.stringify({ error: 'Internal server error' }), {
+              status: 500, headers: { 'Content-Type': 'application/json' },
+            });
+          }
+        }
+
+        return new Response('Not Found', { status: 404 });
+      },
+    });
+  } catch (e: unknown) {
+    console.error(`Failed to start HTTP server on port ${port}: ${e instanceof Error ? e.message : e}`);
+    process.exit(1);
+  }
+
+  console.error(`GBrain HTTP MCP server listening on http://localhost:${httpServer.port}/mcp`);
+  console.error(`Health check: http://localhost:${httpServer.port}/health`);
+  console.error(tokenValidator
+    ? 'Auth: Bearer token required (create with: bun run src/commands/auth.ts create <name>)'
+    : 'Auth: disabled (use --auth to require Bearer tokens)');
+
+  return httpServer;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,7 +8,7 @@ import { loadConfig } from '../core/config.ts';
 import { VERSION } from '../version.ts';
 
 /** Validate required params exist and have the expected type */
-function validateParams(op: Operation, params: Record<string, unknown>): string | null {
+export function validateParams(op: Operation, params: Record<string, unknown>): string | null {
   for (const [key, def] of Object.entries(op.params)) {
     if (def.required && (params[key] === undefined || params[key] === null)) {
       return `Missing required parameter: ${key}`;
@@ -26,13 +26,13 @@ function validateParams(op: Operation, params: Record<string, unknown>): string 
   return null;
 }
 
-export async function startMcpServer(engine: BrainEngine) {
+/** Create a configured MCP Server instance. Used by both stdio and HTTP transports. */
+export function createMcpServer(engine: BrainEngine): Server {
   const server = new Server(
     { name: 'gbrain', version: VERSION },
     { capabilities: { tools: {} } },
   );
 
-  // Generate tool definitions from operations
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: operations.map(op => ({
       name: op.name,
@@ -54,7 +54,6 @@ export async function startMcpServer(engine: BrainEngine) {
     })),
   }));
 
-  // Dispatch tool calls to operation handlers
   server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
     const { name, arguments: params } = request.params;
     const op = operations.find(o => o.name === name);
@@ -91,6 +90,11 @@ export async function startMcpServer(engine: BrainEngine) {
     }
   });
 
+  return server;
+}
+
+export async function startMcpServer(engine: BrainEngine) {
+  const server = createMcpServer(engine);
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -1,0 +1,139 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { startHttpMcpServer, type TokenValidator } from '../src/mcp/http-server.ts';
+import { createHash } from 'crypto';
+
+let engine: PGLiteEngine;
+let baseUrl: string;
+let httpServer: ReturnType<typeof Bun.serve>;
+const PORT = 18787;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  await engine.putPage('test/hello', {
+    type: 'concept', title: 'Hello World',
+    compiled_truth: 'A test page for the HTTP MCP server.',
+  });
+  httpServer = await startHttpMcpServer(engine, { port: PORT });
+  baseUrl = `http://localhost:${PORT}`;
+});
+
+afterAll(async () => {
+  httpServer.stop(true);
+  await engine.disconnect();
+});
+
+async function mcpPost(url: string, method: string, params: unknown, id: number, extra?: Record<string, string>) {
+  return fetch(`${url}/mcp`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json, text/event-stream', ...extra },
+    body: JSON.stringify({ jsonrpc: '2.0', method, params, id }),
+  });
+}
+
+async function parseRes(res: Response): Promise<any> {
+  const text = await res.text();
+  try { return JSON.parse(text); } catch {}
+  for (const line of text.split('\n').filter(l => l.startsWith('data:'))) {
+    try { const d = JSON.parse(line.slice(5).trim()); if (d.result || d.error) return d; } catch {}
+  }
+  throw new Error(`Unparseable: ${text.slice(0, 200)}`);
+}
+
+describe('HTTP MCP Server', () => {
+  test('health check', async () => {
+    const res = await fetch(`${baseUrl}/health`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('ok');
+    expect(body.version).toBeTruthy();
+  });
+
+  test('404 for unknown paths', async () => {
+    expect((await fetch(`${baseUrl}/unknown`)).status).toBe(404);
+  });
+
+  test('initialize handshake', async () => {
+    const body = await parseRes(await mcpPost(baseUrl, 'initialize', {
+      protocolVersion: '2025-03-26', capabilities: {},
+      clientInfo: { name: 'test', version: '1.0' },
+    }, 1));
+    expect(body.result.serverInfo.name).toBe('gbrain');
+  });
+
+  test('tools/list returns 30+ operations', async () => {
+    const body = await parseRes(await mcpPost(baseUrl, 'tools/list', {}, 2));
+    expect(body.result.tools.length).toBeGreaterThan(25);
+    const names = body.result.tools.map((t: any) => t.name);
+    expect(names).toContain('get_page');
+    expect(names).toContain('search');
+    expect(names).toContain('get_stats');
+  });
+
+  test('tools/call get_page round-trip', async () => {
+    const body = await parseRes(await mcpPost(baseUrl, 'tools/call', {
+      name: 'get_page', arguments: { slug: 'test/hello' },
+    }, 3));
+    const page = JSON.parse(body.result.content[0].text);
+    expect(page.title).toBe('Hello World');
+  });
+
+  test('tools/call unknown tool → error', async () => {
+    const body = await parseRes(await mcpPost(baseUrl, 'tools/call', {
+      name: 'nope', arguments: {},
+    }, 4));
+    expect(body.result.isError).toBe(true);
+  });
+
+  test('tools/call missing required param → error', async () => {
+    const body = await parseRes(await mcpPost(baseUrl, 'tools/call', {
+      name: 'get_page', arguments: {},
+    }, 5));
+    expect(body.result.isError).toBe(true);
+  });
+
+  test('5 concurrent requests', async () => {
+    const reqs = Array.from({ length: 5 }, (_, i) =>
+      mcpPost(baseUrl, 'tools/call', { name: 'get_stats', arguments: {} }, 100 + i)
+    );
+    for (const res of await Promise.all(reqs)) {
+      const body = await parseRes(res);
+      expect(JSON.parse(body.result.content[0].text).page_count).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe('HTTP MCP Server: Auth', () => {
+  let authUrl: string;
+  let authServer: ReturnType<typeof Bun.serve>;
+  const TOKEN = 'gbrain_test_abc123';
+  const HASH = createHash('sha256').update(TOKEN).digest('hex');
+  const validator: TokenValidator = async (t) => {
+    return createHash('sha256').update(t).digest('hex') === HASH ? 'test' : null;
+  };
+
+  beforeAll(async () => {
+    authServer = await startHttpMcpServer(engine, { port: 18788, tokenValidator: validator });
+    authUrl = 'http://localhost:18788';
+  });
+  afterAll(() => authServer.stop(true));
+
+  test('valid token → 200', async () => {
+    const res = await mcpPost(authUrl, 'tools/list', {}, 1, { Authorization: `Bearer ${TOKEN}` });
+    expect(res.ok).toBe(true);
+  });
+
+  test('bad token → 401', async () => {
+    expect((await mcpPost(authUrl, 'tools/list', {}, 2, { Authorization: 'Bearer wrong' })).status).toBe(401);
+  });
+
+  test('no header → 401', async () => {
+    expect((await mcpPost(authUrl, 'tools/list', {}, 3)).status).toBe(401);
+  });
+
+  test('health bypasses auth', async () => {
+    expect((await fetch(`${authUrl}/health`)).status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Implements [`gbrain serve --http`](https://github.com/garrytan/gbrain/blob/master/TODOS.md#gbrain-serve---http--flyiorailway-deployment) (TODOS.md P2, blocks P0 ChatGPT OAuth).

```bash
gbrain serve --http                  # port 8787
gbrain serve --http --port 3000     # custom port
gbrain serve --http --auth          # Bearer token auth
```

### Changes

| File | Delta | What |
|------|-------|------|
| `src/mcp/server.ts` | +3 lines | Export `createMcpServer` + `validateParams` |
| `src/mcp/http-server.ts` | new | HTTP transport, health check, auth callback |
| `src/commands/serve.ts` | modified | --http/--port/--auth flags, token validator |
| `src/cli.ts` | +2 lines | Pass args to serve, help text |
| `test/http-server.test.ts` | new | 12 tests |

### Design

- **Minimal touch to existing code.** `server.ts` gains 3 lines (two `export` keywords + extract `createMcpServer`). Everything else is new files or the serve command.
- **`http-server.ts` has zero engine coupling.** Auth is a `TokenValidator` callback provided by the caller.
- **Token validation follows existing patterns.** Postgres: standalone `postgres()` connection (same as `auth.ts`). PGLite: `(engine as any).db` (same as `init.ts:116`).
- **Zero new dependencies.** `@modelcontextprotocol/sdk` already in tree.
- **Compatible with `auth.ts test`** smoke-test client.

### Tests (12)

- Health check, 404 routing, MCP initialize, tools/list (30+ tools)
- tools/call round-trip (real PGLite DB), unknown tool error, missing param error
- 5 concurrent requests handled independently
- Auth: valid token, invalid token, missing header, health bypasses auth

```
454 pass, 0 fail, 0 regressions
```

## Test plan

- [x] `bun test` — 454 pass, 0 fail
- [x] E2E MCP test passes (handleToolCall export unchanged)
- [x] Concurrent requests verified
- [x] Auth: valid/invalid/missing/bypass all tested
- [x] Servers shut down in afterAll (no port leaks)