### PR TITLE
fix: health parity across engines, real file_url, stronger doctor checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to GBrain will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **`gbrain health` now reports the same thing no matter which engine you're on.** The Postgres engine's `getHealth` used a different definition of `stale_pages`, `orphan_pages`, and `dead_links` than PGLite — so `gbrain doctor --json` told you different stories depending on your backend. Both engines now use the PGLite semantics: stale = compiled truth older than the latest timeline entry, orphan = no incoming links, dead = a link pointing at a missing page.
+- **`file_url` returns a URL you can actually open.** The MCP/CLI `file_url` operation used to return a hardcoded `gbrain:files/<path>` placeholder. It now returns a signed URL for Supabase Storage, a public URL for S3/R2/MinIO, and a `file://` path for local — all routed through your configured storage backend.
+
+### Added
+
+- **`gbrain doctor` catches missing API keys before you hit a real query.** New checks: `api_keys` (fails if `OPENAI_API_KEY` is missing — required for vector search — and warns on missing `ANTHROPIC_API_KEY`), `embedding_smoke` (actually calls OpenAI with one tiny input so you know the key works), `storage_backend` (probes the configured backend if it isn't local), and `hnsw_index` (warns if the vector index is missing so you don't wonder why search is slow).
+
 ## [0.9.1] - 2026-04-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ markdown files (tool-agnostic, work with both CLI and plugin contexts).
 - `src/core/operations.ts` — Contract-first operation definitions (the foundation)
 - `src/core/engine.ts` — Pluggable engine interface (BrainEngine)
 - `src/core/engine-factory.ts` — Engine factory with dynamic imports (`'pglite'` | `'postgres'`)
-- `src/core/pglite-engine.ts` — PGLite (embedded Postgres 17.5 via WASM) implementation, all 37 BrainEngine methods
+- `src/core/pglite-engine.ts` — PGLite (embedded Postgres 17.5 via WASM) implementation, all 39 BrainEngine methods
 - `src/core/pglite-schema.ts` — PGLite-specific DDL (pgvector, pg_trgm, triggers)
 - `src/core/postgres-engine.ts` — Postgres + pgvector implementation (Supabase / self-hosted)
 - `src/core/utils.ts` — Shared SQL utilities extracted from postgres-engine.ts
@@ -81,7 +81,7 @@ parity), `test/cli.test.ts` (CLI structure), `test/config.test.ts` (config redac
 `test/setup-branching.test.ts` (setup flow), `test/slug-validation.test.ts` (slug validation),
 `test/storage.test.ts` (storage backends), `test/supabase-admin.test.ts` (Supabase admin),
 `test/yaml-lite.test.ts` (YAML parsing), `test/check-update.test.ts` (version check + update CLI),
-`test/pglite-engine.test.ts` (PGLite engine, all 37 BrainEngine methods),
+`test/pglite-engine.test.ts` (PGLite engine, all 39 BrainEngine methods),
 `test/utils.test.ts` (shared SQL utilities), `test/engine-factory.test.ts` (engine factory + dynamic imports),
 `test/integrations.test.ts` (recipe parsing, CLI routing, recipe validation),
 `test/publish.test.ts` (content stripping, encryption, password generation, HTML output),

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ I was setting up my [OpenClaw](https://openclaw.ai) agent and started a markdown
 
 The agent runs while I sleep. The dream cycle scans every conversation, enriches missing entities, fixes broken citations, and consolidates memory. I wake up and the brain is smarter than when I went to sleep. See the [cron schedule guide](docs/guides/cron-schedule.md) for setup.
 
-**PGLite runs locally by default.** `gbrain init` gives you embedded Postgres with pgvector, hybrid search, and all 37 operations. No server, no subscription. When your brain outgrows local (1000+ files, multi-device access, remote MCP), `gbrain migrate --to supabase` moves everything to managed Postgres.
+**PGLite runs locally by default.** `gbrain init` gives you embedded Postgres with pgvector, hybrid search, and all 39 engine operations. No server, no subscription. When your brain outgrows local (1000+ files, multi-device access, remote MCP), `gbrain migrate --to supabase` moves everything to managed Postgres.
 
 ## Architecture
 

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -152,7 +152,7 @@ RRF fusion, multi-query expansion, and 4-layer dedup are engine-agnostic. They o
 
 **Dependencies:** `@electric-sql/pglite` (v0.4.4+)
 
-**What it is:** Embedded Postgres 17.5 compiled to WASM via ElectricSQL's PGLite. Runs in-process, no server, no Docker, no accounts. Same SQL as PostgresEngine -- not a separate dialect. All 37 BrainEngine methods implemented.
+**What it is:** Embedded Postgres 17.5 compiled to WASM via ElectricSQL's PGLite. Runs in-process, no server, no Docker, no accounts. Same SQL as PostgresEngine -- not a separate dialect. All 39 BrainEngine methods implemented.
 
 **PGLite-specific details:**
 - Uses `pglite-schema.ts` for DDL (pgvector extension, pg_trgm, triggers, indexes)

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,6 +1,7 @@
 import type { BrainEngine } from '../core/engine.ts';
 import * as db from '../core/db.ts';
 import { LATEST_VERSION } from '../core/migrate.ts';
+import { loadConfig } from '../core/config.ts';
 
 interface Check {
   name: string;
@@ -82,6 +83,65 @@ export async function runDoctor(engine: BrainEngine, args: string[]) {
     }
   } catch {
     checks.push({ name: 'embeddings', status: 'warn', message: 'Could not check embedding health' });
+  }
+
+  // 6. API keys
+  const hasOpenAI = !!process.env.OPENAI_API_KEY;
+  const hasAnthropic = !!process.env.ANTHROPIC_API_KEY;
+  if (hasOpenAI && hasAnthropic) {
+    checks.push({ name: 'api_keys', status: 'ok', message: 'OPENAI_API_KEY and ANTHROPIC_API_KEY set' });
+  } else if (hasOpenAI) {
+    checks.push({ name: 'api_keys', status: 'warn', message: 'OPENAI_API_KEY set; ANTHROPIC_API_KEY missing (query expansion disabled)' });
+  } else {
+    checks.push({ name: 'api_keys', status: 'fail', message: 'OPENAI_API_KEY not set. Vector search and embedding will fail. Run: export OPENAI_API_KEY=sk-...' });
+  }
+
+  // 7. Embedding smoke test (only if OPENAI set)
+  if (hasOpenAI) {
+    try {
+      const { embed } = await import('../core/embedding.ts');
+      await embed('gbrain doctor smoke test');
+      checks.push({ name: 'embedding_smoke', status: 'ok', message: 'OpenAI embeddings reachable' });
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      checks.push({ name: 'embedding_smoke', status: 'fail', message: `Smoke test failed: ${msg}. Check API key validity, quota, and network.` });
+    }
+  }
+
+  // 8. Storage backend
+  const config = loadConfig();
+  const storageCfg = (config as unknown as { storage?: { backend?: string } } | null)?.storage;
+  if (!storageCfg || !storageCfg.backend) {
+    checks.push({ name: 'storage_backend', status: 'ok', message: 'No storage backend configured (files commands disabled)' });
+  } else if (storageCfg.backend === 'local') {
+    checks.push({ name: 'storage_backend', status: 'ok', message: 'Local storage backend' });
+  } else {
+    try {
+      const { createStorage } = await import('../core/storage.ts');
+      const storage = await createStorage(storageCfg as Parameters<typeof createStorage>[0]);
+      await storage.list('');
+      checks.push({ name: 'storage_backend', status: 'ok', message: `${storageCfg.backend} storage reachable` });
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      checks.push({ name: 'storage_backend', status: 'fail', message: `${storageCfg.backend} storage unreachable: ${msg}` });
+    }
+  }
+
+  // 9. HNSW index on content_chunks.embedding
+  try {
+    const sql = db.getConnection();
+    const indexes = await sql`
+      SELECT indexname, indexdef FROM pg_indexes
+      WHERE schemaname = 'public' AND tablename = 'content_chunks'
+    `;
+    const hasHnsw = (indexes as { indexdef: string }[]).some(i => /USING\s+hnsw/i.test(i.indexdef));
+    if (hasHnsw) {
+      checks.push({ name: 'hnsw_index', status: 'ok', message: 'HNSW index present on content_chunks.embedding' });
+    } else {
+      checks.push({ name: 'hnsw_index', status: 'warn', message: 'HNSW index missing on content_chunks.embedding (vector search will be slow). Run gbrain init to rebuild schema.' });
+    }
+  } catch {
+    checks.push({ name: 'hnsw_index', status: 'warn', message: 'Could not check HNSW index' });
   }
 
   outputResults(checks, jsonOutput);

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -625,18 +625,30 @@ const file_upload: Operation = {
 
 const file_url: Operation = {
   name: 'file_url',
-  description: 'Get a URL for a stored file',
+  description: 'Get a URL for a stored file (signed where the backend supports it)',
   params: {
     storage_path: { type: 'string', required: true },
   },
-  handler: async (_ctx, p) => {
+  handler: async (ctx, p) => {
+    const storagePath = p.storage_path as string;
     const sql = db.getConnection();
-    const rows = await sql`SELECT storage_path, mime_type, size_bytes FROM files WHERE storage_path = ${p.storage_path as string}`;
+    const rows = await sql`SELECT storage_path, mime_type, size_bytes FROM files WHERE storage_path = ${storagePath}`;
     if (rows.length === 0) {
-      throw new OperationError('storage_error', `File not found: ${p.storage_path}`);
+      throw new OperationError('storage_error', `File not found: ${storagePath}`, 'Upload via gbrain files upload, or check the path with gbrain files list');
     }
-    // TODO: generate signed URL from Supabase Storage
-    return { storage_path: rows[0].storage_path, url: `gbrain:files/${rows[0].storage_path}` };
+
+    if (!ctx.config.storage) {
+      throw new OperationError(
+        'storage_error',
+        'No storage backend configured',
+        'Set storage backend via gbrain config set storage.backend <local|supabase|s3>',
+      );
+    }
+
+    const { createStorage } = await import('./storage.ts');
+    const storage = await createStorage(ctx.config.storage as Parameters<typeof createStorage>[0]);
+    const url = await storage.getUrl(storagePath);
+    return { storage_path: rows[0].storage_path, url };
   },
 };
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -604,16 +604,13 @@ export class PostgresEngine implements BrainEngine {
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NOT NULL)::float /
           GREATEST((SELECT count(*) FROM content_chunks), 1)::float as embed_coverage,
         (SELECT count(*) FROM pages p
-         WHERE (p.compiled_truth != '' OR p.timeline != '')
-           AND NOT EXISTS (SELECT 1 FROM content_chunks cc WHERE cc.page_id = p.id)
+         WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
         ) as stale_pages,
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
-           AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
         ) as orphan_pages,
-        (SELECT count(*) FROM content_chunks cc
-         JOIN pages p ON p.id = cc.page_id
-         WHERE p.compiled_truth = '' AND p.timeline = ''
+        (SELECT count(*) FROM links l
+         WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)
         ) as dead_links,
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NULL) as missing_embeddings
     `;

--- a/test/e2e/mechanical.test.ts
+++ b/test/e2e/mechanical.test.ts
@@ -339,6 +339,37 @@ describeE2E('E2E: Admin', () => {
     expect(typeof health.page_count).toBe('number');
     expect(typeof health.embed_coverage).toBe('number');
   });
+
+  test('get_health semantics: orphans, stale, dead_links match PGLite definitions', async () => {
+    // Fresh setup so counts are deterministic.
+    await setupDB();
+
+    const engine = getEngine();
+    const basePage = {
+      type: 'concept' as const,
+      title: 'base',
+      compiled_truth: 'hello',
+      timeline: '',
+    };
+
+    await engine.putPage('test/a', { ...basePage, title: 'A' });
+    await engine.putPage('test/b', { ...basePage, title: 'B' });
+    await engine.putPage('test/c', { ...basePage, title: 'C' });
+    await engine.addLink('test/b', 'test/a'); // A has incoming → not orphan
+
+    await engine.addTimelineEntry('test/c', { date: '2030-01-01', summary: 'future' });
+    const conn = getConn();
+    await conn`UPDATE pages SET updated_at = '2020-01-01' WHERE slug = 'test/c'`;
+
+    const health = await engine.getHealth();
+    expect(health.page_count).toBe(3);
+    expect(health.orphan_pages).toBe(2); // B and C
+    expect(health.stale_pages).toBe(1); // C
+    expect(health.dead_links).toBe(0); // FK protects under normal ops
+
+    // Re-import fixtures so downstream tests (if any) still see the canonical set.
+    await importFixtures();
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────
@@ -420,38 +451,79 @@ describeE2E('E2E: Ingest Log & Raw Data', () => {
 // ─────────────────────────────────────────────────────────────────
 
 describeE2E('E2E: Files', () => {
+  let storageDir: string;
+
   beforeAll(async () => {
     await setupDB();
     await importFixtures();
+    storageDir = mkdtempSync(join(tmpdir(), 'gbrain-e2e-storage-'));
   });
-  afterAll(teardownDB);
+  afterAll(() => {
+    rmSync(storageDir, { recursive: true, force: true });
+    return teardownDB();
+  });
+
+  function makeCtxWithStorage() {
+    return {
+      engine: getEngine(),
+      config: {
+        engine: 'postgres' as const,
+        database_url: process.env.DATABASE_URL!,
+        storage: { backend: 'local' as const, bucket: 'test', localPath: storageDir },
+      },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      dryRun: false,
+    };
+  }
+
+  async function callOpWithStorage(name: string, params: Record<string, unknown> = {}) {
+    const op = operationsByName[name];
+    if (!op) throw new Error(`Unknown operation: ${name}`);
+    return op.handler(makeCtxWithStorage() as any, params);
+  }
 
   test('file_list returns empty initially', async () => {
     const files = await callOp('file_list', {}) as any[];
     expect(files.length).toBe(0);
   });
 
-  test('file_upload stores metadata + file_list shows it', async () => {
-    // Create a temp file
+  test('file_upload stores metadata + file_list shows it + file_url returns a real URL', async () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'gbrain-e2e-'));
     const tmpFile = join(tmpDir, 'test-doc.pdf');
     writeFileSync(tmpFile, 'fake pdf content');
 
     try {
-      const result = await callOp('file_upload', {
+      const result = await callOpWithStorage('file_upload', {
         path: tmpFile,
         page_slug: 'people/sarah-chen',
       }) as any;
       expect(result.status).toBe('uploaded');
       expect(result.storage_path).toContain('sarah-chen');
 
-      // Verify file_list
       const files = await callOp('file_list', {}) as any[];
       expect(files.length).toBe(1);
 
-      // Verify file_url returns URI format
-      const url = await callOp('file_url', { storage_path: result.storage_path }) as any;
-      expect(url.url).toContain('gbrain:files/');
+      // file_url must return a real URL from the configured backend
+      const url = await callOpWithStorage('file_url', { storage_path: result.storage_path }) as any;
+      expect(url.url).not.toContain('gbrain:files/');
+      expect(url.url.startsWith('file://')).toBe(true);
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  test('file_url fails with actionable error when no storage is configured', async () => {
+    // First upload a file with storage configured so the files row exists.
+    const tmpDir = mkdtempSync(join(tmpdir(), 'gbrain-e2e-nostorage-'));
+    const tmpFile = join(tmpDir, 'x.bin');
+    writeFileSync(tmpFile, 'bytes');
+    try {
+      const uploaded = await callOpWithStorage('file_upload', { path: tmpFile }) as any;
+
+      // Now try file_url without storage in the context.
+      expect(
+        callOp('file_url', { storage_path: uploaded.storage_path }),
+      ).rejects.toThrow(/No storage backend configured/);
     } finally {
       rmSync(tmpDir, { recursive: true });
     }
@@ -774,7 +846,7 @@ describeE2E('E2E: Doctor Command', () => {
   const cliCwd = join(import.meta.dir, '../..');
   const cliEnv = () => ({ ...process.env, DATABASE_URL: process.env.DATABASE_URL!, GBRAIN_DATABASE_URL: process.env.DATABASE_URL! });
 
-  test('gbrain doctor exits 0 on healthy DB', () => {
+  test('gbrain doctor exits 0 only when API keys + DB are both healthy', () => {
     // Init first so config exists for CLI
     Bun.spawnSync({
       cmd: ['bun', 'run', 'src/cli.ts', 'init', '--non-interactive', '--url', process.env.DATABASE_URL!],
@@ -786,7 +858,14 @@ describeE2E('E2E: Doctor Command', () => {
       env: cliEnv(),
       timeout: 15_000,
     });
-    expect(result.exitCode).toBe(0);
+    // Without OPENAI_API_KEY, the api_keys check now fails (by design: README
+    // treats it as required for vector search). Accept 1 in that case; require
+    // 0 only when a real key is present.
+    if (process.env.OPENAI_API_KEY) {
+      expect(result.exitCode).toBe(0);
+    } else {
+      expect(result.exitCode).toBe(1);
+    }
   }, 60_000);
 
   test('gbrain doctor --json produces valid JSON', () => {

--- a/test/parity.test.ts
+++ b/test/parity.test.ts
@@ -66,8 +66,10 @@ describe('operations contract parity', () => {
     }
   });
 
-  test('operations count is at least 30', () => {
-    expect(operations.length).toBeGreaterThanOrEqual(30);
+  test('operations count matches README claim (30 MCP tools)', () => {
+    // If this fails, update README.md's "30 MCP tools" claim and add/remove
+    // the matching operation below. Keeping this exact prevents silent drift.
+    expect(operations.length).toBe(30);
   });
 
   test('MCP tool definitions can be generated from operations', () => {

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -1,5 +1,5 @@
 /**
- * PGLite Engine Tests — validates all 37 BrainEngine methods against PGLite (in-memory).
+ * PGLite Engine Tests — validates all 39 BrainEngine methods against PGLite (in-memory).
  *
  * No Docker, no DATABASE_URL, no external dependencies. Runs instantly in CI.
  */
@@ -444,6 +444,50 @@ describe('PGLiteEngine: Stats & Health', () => {
     expect(health.page_count).toBe(1);
     expect(health.missing_embeddings).toBe(1); // chunk has no embedding
     expect(health.embed_coverage).toBe(0);
+  });
+});
+
+describe('PGLiteEngine: getHealth semantics', () => {
+  beforeAll(async () => {
+    await truncateAll();
+
+    // Page A: referenced by another page → not orphan
+    await engine.putPage('test/a', { ...testPage, title: 'A' });
+    // Page B: links to A → so A has incoming; B itself has no incoming → orphan
+    await engine.putPage('test/b', { ...testPage, title: 'B' });
+    await engine.addLink('test/b', 'test/a');
+
+    // Page C: stale — updated_at older than latest timeline entry
+    await engine.putPage('test/c', { ...testPage, title: 'C' });
+    await engine.addTimelineEntry('test/c', { date: '2030-01-01', summary: 'future entry' });
+    // Force updated_at to be in the past so timeline entry's created_at > updated_at
+    await (engine as any).db.exec(
+      `UPDATE pages SET updated_at = '2020-01-01' WHERE slug = 'test/c'`,
+    );
+    // B and C have no incoming links → orphans
+  });
+
+  test('orphan_pages counts pages with no incoming links', async () => {
+    const health = await engine.getHealth();
+    // A has an incoming link; B and C do not.
+    expect(health.orphan_pages).toBe(2);
+  });
+
+  test('stale_pages counts pages whose updated_at precedes latest timeline entry', async () => {
+    const health = await engine.getHealth();
+    expect(health.stale_pages).toBe(1); // just C
+  });
+
+  test('dead_links is zero under FK-protected inserts', async () => {
+    // ON DELETE CASCADE on links.to_page_id prevents dead links under normal
+    // operation. This check still runs so corrupt data shows up.
+    const health = await engine.getHealth();
+    expect(health.dead_links).toBe(0);
+  });
+
+  test('page_count reflects all pages', async () => {
+    const health = await engine.getHealth();
+    expect(health.page_count).toBe(3);
   });
 });
 


### PR DESCRIPTION
  ## Summary                                                
  - `getHealth` on the Postgres engine now matches PGLite semantics (stale = compiled truth behind timeline, orphan = no   
  incoming links, dead_links = link to missing page). `gbrain doctor` / `gbrain health` no longer reports different things 
  on different engines.                                                                                                    
  - `file_url` returns a real URL from the configured storage backend (signed on Supabase, public on S3/R2/MinIO, `file://`
   on local) instead of the `gbrain:files/…` placeholder.                                                                  
  - `gbrain doctor` adds checks for API keys (fails on missing `OPENAI_API_KEY`), a tiny live OpenAI embedding smoke test,
  the configured storage backend, and the HNSW vector index.                                                               
  - Doc drift fix: 37 → 39 BrainEngine methods across README, CLAUDE.md, ENGINES.md, test header. Parity test asserts exact
   `operations.length === 30` so MCP tool count can't drift silently again.                                                
                                                            
  ## Test plan                                                                                                             
  - [x] `bun test` — 446 pass, 124 skip, 0 fail             
  - [x] E2E against `pgvector/pgvector:pg16` on port 5434 — 83 pass, 8 skip (API-key-dependent), 0 fail                    
  - [x] New `getHealth` semantics tests on both PGLite and Postgres paths                                                  
  - [x] Updated E2E file_upload/file_url test asserts a real URL, not the placeholder                                      
  - [x] Updated doctor E2E test reflects fail-on-missing-`OPENAI_API_KEY` 