### PR TITLE
feat: add Nanobot MCP integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ GBrain is designed to be installed and operated by an AI agent. If you don't hav
 
 - **[OpenClaw](https://openclaw.ai)** ... Deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/alphaclaw) (one click, 8GB+ RAM)
 - **[Hermes Agent](https://github.com/NousResearch/hermes-agent)** ... Deploy on [Railway](https://github.com/praveen-ks-2001/hermes-agent-template) (one click)
+- **[Nanobot](https://github.com/HKUDS/nanobot)** ... Self-hosted, `uv tool install nanobot-ai` (lightweight, runs on Linux, macOS, and Windows)
 
 Paste this into your agent:
 

--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -63,6 +63,7 @@ if compromised. Tokens are stored SHA-256 hashed in your database.
 - **Claude Code:** [setup guide](CLAUDE_CODE.md)
 - **Claude Desktop:** [setup guide](CLAUDE_DESKTOP.md) (must use GUI, not JSON config)
 - **Claude Cowork:** [setup guide](CLAUDE_COWORK.md)
+- **Nanobot:** [setup guide](NANOBOT.md)
 - **Perplexity:** [setup guide](PERPLEXITY.md)
 
 ### 4. Verify

--- a/docs/mcp/NANOBOT.md
+++ b/docs/mcp/NANOBOT.md
@@ -1,0 +1,56 @@
+# Connect GBrain to Nanobot
+
+[Nanobot](https://github.com/HKUDS/nanobot) is an open-source, self-hosted AI agent with built-in MCP client support (stdio, SSE, and streamable HTTP transports). No adapter code needed — just add GBrain to your MCP server config.
+
+## Local (recommended, zero server needed)
+
+Add this to your `config.json`:
+
+```json
+{
+  "mcp_servers": {
+    "gbrain": {
+      "command": "gbrain",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+Nanobot spawns `gbrain serve` as a stdio subprocess. No server, no tunnel, no token needed. Works with both PGLite and Supabase engines.
+
+## Remote (access from any machine)
+
+If you have GBrain running on a server with a public tunnel (see
+[ngrok-tunnel recipe](../../recipes/ngrok-tunnel.md)):
+
+```json
+{
+  "mcp_servers": {
+    "gbrain": {
+      "type": "streamableHttp",
+      "url": "https://YOUR-DOMAIN.ngrok.app/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_TOKEN"
+      }
+    }
+  }
+}
+```
+
+Replace `YOUR-DOMAIN` with your ngrok domain and `YOUR_TOKEN` with a token
+from `bun run src/commands/auth.ts create "nanobot"`.
+
+## Verify
+
+Restart nanobot, then ask:
+
+```
+search for [any topic in your brain]
+```
+
+You should see results from your GBrain knowledge base. Nanobot registers GBrain tools with the `mcp_gbrain_` prefix (e.g. `mcp_gbrain_search`, `mcp_gbrain_query`, `mcp_gbrain_get_page`).
+
+## Skillpack (recommended)
+
+Copy the relevant sections from [GBRAIN_SKILLPACK.md](../GBRAIN_SKILLPACK.md) into your nanobot skill or AGENTS.md so the agent knows WHEN and HOW to use each tool — read before responding, write after learning, detect entities on every message.


### PR DESCRIPTION
## What

Add Nanobot (https://github.com/HKUDS/nanobot) as a supported MCP client in GBrain.

Nanobot is an open-source, self-hosted AI agent with built-in MCP client support (stdio, SSE, streamable HTTP). No adapter code needed — GBrain tools are auto-registered via `mcp_servers` config.

## Changes

| File | Change |
|------|--------|
| `docs/mcp/NANOBOT.md` | New integration guide (local stdio + remote streamableHttp) |
| `README.md` | Add Nanobot config example alongside Claude Code / Cursor |
| `docs/mcp/DEPLOY.md` | Add Nanobot to supported client list |

## How it works

```json
{
  "mcp_servers": {
    "gbrain": {
      "command": "gbrain",
      "args": ["serve"]
    }
  }
}
```

Nanobot spawns `gbrain serve` as a stdio subprocess. All GBrain tools become available with the `mcp_gbrain_` prefix (e.g. `mcp_gbrain_search`, `mcp_gbrain_query`).

## Manual test screenshots:

<img width="834" height="1222" alt="image" src="https://github.com/user-attachments/assets/f14c1a5b-a06c-4cbb-b6c3-16582b991d4c" />
