### PR TITLE
fix: vector serialization bug during PGLite to Postgres migration

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -26,6 +26,7 @@ type PGLiteDB = PGlite;
 export class PGLiteEngine implements BrainEngine {
   private _db: PGLiteDB | null = null;
   private _lock: LockHandle | null = null;
+  private _vectorParsers: Record<number, (v: string) => Float32Array> = {};
 
   get db(): PGLiteDB {
     if (!this._db) throw new Error('PGLite not connected. Call connect() first.');
@@ -62,6 +63,15 @@ export class PGLiteEngine implements BrainEngine {
 
   async initSchema(): Promise<void> {
     await this.db.exec(PGLITE_SCHEMA_SQL);
+
+    // Resolve pgvector's dynamic OID so we can parse vector columns as Float32Array
+    const oidRes = await this.db.query(`SELECT oid FROM pg_type WHERE typname = 'vector'`);
+    if (oidRes.rows.length > 0) {
+      const oid = (oidRes.rows[0] as { oid: number }).oid;
+      this._vectorParsers = {
+        [oid]: (v: string) => new Float32Array(v.slice(1, -1).split(',').map(Number)),
+      };
+    }
 
     const { applied } = await runMigrations(this);
     if (applied > 0) {
@@ -642,7 +652,8 @@ export class PGLiteEngine implements BrainEngine {
        JOIN pages p ON p.id = cc.page_id
        WHERE p.slug = $1
        ORDER BY cc.chunk_index`,
-      [slug]
+      [slug],
+      { parsers: this._vectorParsers },
     );
     return (rows as Record<string, unknown>[]).map(r => rowToChunk(r, true));
   }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -43,6 +43,21 @@ export function rowToPage(row: Record<string, unknown>): Page {
   };
 }
 
+/**
+ * Normalize a raw embedding value to Float32Array.
+ * PGLite's pgvector returns embeddings as a string like "[0.1,0.2,...]",
+ * while Postgres drivers may return Float32Array or number[].
+ */
+function parseEmbedding(raw: unknown): Float32Array {
+  if (raw instanceof Float32Array) return raw;
+  if (typeof raw === 'string') {
+    const nums = raw.slice(1, -1).split(',').map(Number);
+    return new Float32Array(nums);
+  }
+  if (Array.isArray(raw)) return new Float32Array(raw);
+  throw new Error(`Unexpected embedding type: ${typeof raw}`);
+}
+
 export function rowToChunk(row: Record<string, unknown>, includeEmbedding = false): Chunk {
   return {
     id: row.id as number,
@@ -50,7 +65,7 @@ export function rowToChunk(row: Record<string, unknown>, includeEmbedding = fals
     chunk_index: row.chunk_index as number,
     chunk_text: row.chunk_text as string,
     chunk_source: row.chunk_source as 'compiled_truth' | 'timeline',
-    embedding: includeEmbedding && row.embedding ? row.embedding as Float32Array : null,
+    embedding: includeEmbedding && row.embedding ? parseEmbedding(row.embedding) : null,
     model: row.model as string,
     token_count: row.token_count as number | null,
     embedded_at: row.embedded_at ? new Date(row.embedded_at as string) : null,

--- a/test/e2e/cross-engine.test.ts
+++ b/test/e2e/cross-engine.test.ts
@@ -1,0 +1,168 @@
+/**
+ * E2E Cross-engine Migration Tests
+ *
+ * Tests embedding and metadata round-trips between Postgres and PGLite.
+ * Requires DATABASE_URL env var or .env.testing file.
+ *
+ * Run separately from mechanical tests:
+ *   DATABASE_URL=... bun test test/e2e/cross-engine.test.ts
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { hasDatabase, setupDB, teardownDB, getEngine } from './helpers.ts';
+import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+import type { Chunk } from '../../src/core/types.ts';
+
+const skip = !hasDatabase();
+const describeE2E = skip ? describe.skip : describe;
+
+const testPage = {
+  type: 'concept' as const,
+  title: 'Migration Test',
+  compiled_truth: '# Migration Test\nEmbedding round-trip test.',
+  frontmatter: {},
+};
+
+const makeEmbedding = () => {
+  const emb = new Float32Array(1536);
+  emb[0] = 0.1; emb[1] = 0.2; emb[2] = 0.3; emb[3] = -0.5;
+  emb[100] = 0.99; emb[1535] = -0.01;
+  return emb;
+};
+
+function toChunkInput(c: Chunk) {
+  return {
+    chunk_index: c.chunk_index,
+    chunk_text: c.chunk_text,
+    chunk_source: c.chunk_source,
+    embedding: c.embedding || undefined,
+    model: c.model,
+    token_count: c.token_count || undefined,
+  };
+}
+
+describeE2E('E2E: Cross-engine migration', () => {
+  beforeAll(async () => {
+    await setupDB();
+  });
+  afterAll(teardownDB);
+
+  test('Postgres→PGLite embedding round-trip', async () => {
+    const pg = getEngine();
+    const embedding = makeEmbedding();
+
+    await pg.putPage('test/migrate-to-pglite', testPage);
+    await pg.upsertChunks('test/migrate-to-pglite', [
+      { chunk_index: 0, chunk_text: 'Chunk zero', chunk_source: 'compiled_truth', embedding },
+      { chunk_index: 1, chunk_text: 'Chunk one', chunk_source: 'compiled_truth', embedding: undefined },
+    ]);
+
+    const sourceChunks = await pg.getChunksWithEmbeddings('test/migrate-to-pglite');
+    expect(sourceChunks.length).toBe(2);
+    expect(sourceChunks[0].embedding).toBeInstanceOf(Float32Array);
+    expect(sourceChunks[1].embedding).toBeNull();
+
+    const pglite = new PGLiteEngine();
+    await pglite.connect({});
+    await pglite.initSchema();
+    try {
+      await pglite.putPage('test/migrate-to-pglite', testPage);
+      await pglite.upsertChunks('test/migrate-to-pglite', sourceChunks.map(toChunkInput));
+
+      const targetChunks = await pglite.getChunksWithEmbeddings('test/migrate-to-pglite');
+      expect(targetChunks.length).toBe(2);
+
+      const emb = targetChunks[0].embedding;
+      expect(emb).toBeInstanceOf(Float32Array);
+      expect(emb!.length).toBe(1536);
+      expect(emb![0]).toBeCloseTo(0.1);
+      expect(emb![1]).toBeCloseTo(0.2);
+      expect(emb![3]).toBeCloseTo(-0.5);
+      expect(emb![100]).toBeCloseTo(0.99);
+      expect(emb![1535]).toBeCloseTo(-0.01);
+
+      expect(targetChunks[1].embedding).toBeNull();
+    } finally {
+      await pglite.disconnect();
+    }
+  });
+
+  test('PGLite→Postgres embedding round-trip', async () => {
+    const embedding = makeEmbedding();
+
+    const pglite = new PGLiteEngine();
+    await pglite.connect({});
+    await pglite.initSchema();
+
+    let sourceChunks: Chunk[];
+    try {
+      await pglite.putPage('test/migrate-to-pg', testPage);
+      await pglite.upsertChunks('test/migrate-to-pg', [
+        { chunk_index: 0, chunk_text: 'Chunk from pglite', chunk_source: 'compiled_truth', embedding },
+      ]);
+
+      sourceChunks = await pglite.getChunksWithEmbeddings('test/migrate-to-pg');
+      expect(sourceChunks.length).toBe(1);
+      expect(sourceChunks[0].embedding).toBeInstanceOf(Float32Array);
+    } finally {
+      await pglite.disconnect();
+    }
+
+    const pg = getEngine();
+    await pg.putPage('test/migrate-to-pg', testPage);
+    await pg.upsertChunks('test/migrate-to-pg', sourceChunks!.map(toChunkInput));
+
+    const targetChunks = await pg.getChunksWithEmbeddings('test/migrate-to-pg');
+    expect(targetChunks.length).toBe(1);
+
+    const emb = targetChunks[0].embedding;
+    expect(emb).toBeInstanceOf(Float32Array);
+    expect(emb!.length).toBe(1536);
+    expect(emb![0]).toBeCloseTo(0.1);
+    expect(emb![1]).toBeCloseTo(0.2);
+    expect(emb![3]).toBeCloseTo(-0.5);
+    expect(emb![100]).toBeCloseTo(0.99);
+    expect(emb![1535]).toBeCloseTo(-0.01);
+  });
+
+  test('tags and timeline survive cross-engine migration', async () => {
+    const pg = getEngine();
+
+    await pg.putPage('test/migrate-meta', testPage);
+    await pg.addTag('test/migrate-meta', 'tag-alpha');
+    await pg.addTag('test/migrate-meta', 'tag-beta');
+    await pg.addTimelineEntry('test/migrate-meta', {
+      date: '2026-01-15',
+      source: 'e2e-test',
+      summary: 'Timeline survives migration',
+    });
+
+    const tags = await pg.getTags('test/migrate-meta');
+    const timeline = await pg.getTimeline('test/migrate-meta');
+
+    const pglite = new PGLiteEngine();
+    await pglite.connect({});
+    await pglite.initSchema();
+    try {
+      await pglite.putPage('test/migrate-meta', testPage);
+      for (const tag of tags) await pglite.addTag('test/migrate-meta', tag);
+      for (const entry of timeline) {
+        await pglite.addTimelineEntry('test/migrate-meta', {
+          date: entry.date,
+          source: entry.source,
+          summary: entry.summary,
+          detail: entry.detail,
+        });
+      }
+
+      const targetTags = await pglite.getTags('test/migrate-meta');
+      expect(targetTags.sort()).toEqual(['tag-alpha', 'tag-beta']);
+
+      const targetTimeline = await pglite.getTimeline('test/migrate-meta');
+      expect(targetTimeline.length).toBe(1);
+      expect(targetTimeline[0].summary).toBe('Timeline survives migration');
+    } finally {
+      await pglite.disconnect();
+    }
+  });
+});

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -242,6 +242,61 @@ describe('PGLiteEngine: Chunks', () => {
     expect(chunks.length).toBe(1);
     expect(chunks[0].embedding).not.toBeNull();
   });
+
+  // Issue #91: PGLite pgvector returns embeddings as strings, not Float32Array
+  test('getChunksWithEmbeddings returns Float32Array (not string)', async () => {
+    await engine.putPage('test/embed-type', testPage);
+    const embedding = new Float32Array(1536);
+    embedding[0] = 0.1; embedding[1] = 0.2; embedding[2] = 0.3; embedding[3] = -0.5;
+    await engine.upsertChunks('test/embed-type', [
+      { chunk_index: 0, chunk_text: 'Type check', chunk_source: 'compiled_truth', embedding },
+    ]);
+    const chunks = await engine.getChunksWithEmbeddings('test/embed-type');
+    const emb = chunks[0].embedding;
+    expect(emb).toBeInstanceOf(Float32Array);
+    expect(emb!.length).toBe(1536);
+    expect(emb![0]).toBeCloseTo(0.1);
+    expect(emb![1]).toBeCloseTo(0.2);
+    expect(emb![3]).toBeCloseTo(-0.5);
+  });
+
+  test('embedding survives PGLite→PGLite migration round-trip (#91)', async () => {
+    await engine.putPage('test/embed-migrate', testPage);
+    const embedding = new Float32Array(1536);
+    embedding[0] = 0.1; embedding[1] = 0.2; embedding[3] = -0.5;
+    await engine.upsertChunks('test/embed-migrate', [
+      { chunk_index: 0, chunk_text: 'Migrate me', chunk_source: 'compiled_truth', embedding },
+    ]);
+
+    // Read from source (same path as migrate-engine.ts)
+    const sourceChunks = await engine.getChunksWithEmbeddings('test/embed-migrate');
+
+    // Write to a second PGLite (simulates migration target)
+    const target = new PGLiteEngine();
+    await target.connect({});
+    await target.initSchema();
+    try {
+      await target.putPage('test/embed-migrate', testPage);
+      await target.upsertChunks('test/embed-migrate', sourceChunks.map(c => ({
+        chunk_index: c.chunk_index,
+        chunk_text: c.chunk_text,
+        chunk_source: c.chunk_source,
+        embedding: c.embedding || undefined,
+        model: c.model,
+        token_count: c.token_count || undefined,
+      })));
+
+      const targetChunks = await target.getChunksWithEmbeddings('test/embed-migrate');
+      expect(targetChunks.length).toBe(1);
+      const emb = targetChunks[0].embedding;
+      expect(emb).toBeInstanceOf(Float32Array);
+      expect(emb![0]).toBeCloseTo(0.1);
+      expect(emb![1]).toBeCloseTo(0.2);
+      expect(emb![3]).toBeCloseTo(-0.5);
+    } finally {
+      await target.disconnect();
+    }
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #91

PGLite's pgvector extension returns embeddings as strings (e.g. `"[0.1,0.2,...]"`), not `Float32Array`. During migration, `Array.from(string)` splits into individual characters, producing invalid vector literals like `"[[,0,.,1,,,...]"` that Postgres rejects.

### Root cause

- `rowToChunk()` in `utils.ts` casts `row.embedding as Float32Array` — a type assertion, not a conversion
- `upsertChunks()` calls `Array.from(embedding).join(',')` which destructures a string char-by-char

### Fix (two layers)

1. **Driver-level** (`pglite-engine.ts`): Register a custom type parser for pgvector's dynamic OID in `initSchema()`, so PGLite returns `Float32Array` directly — matches Postgres engine behavior
2. **Defense-in-depth** (`utils.ts`): Add `parseEmbedding()` in `rowToChunk()` that normalizes `string | Array | Float32Array` → `Float32Array`, as a safety net for all engines

### Files changed

- `src/core/pglite-engine.ts` — `_vectorParsers` field, OID lookup in `initSchema`, parser in `getChunksWithEmbeddings`
- `src/core/utils.ts` — `parseEmbedding()` helper, used in `rowToChunk`
- `test/pglite-engine.test.ts` — 2 regression tests (type check + migration round-trip)

## Test plan

- [x] `bun test test/pglite-engine.test.ts` — 57 pass, 0 fail
- [x] `bun test` — 412 pass, 0 fail (1 pre-existing failure unrelated: missing `marked` package)
- [x] E2E with real Postgres: `bun run test:e2e` against pgvector container — 81 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)