### PR TITLE
fix: CJK word count in query expansion

### DIFF
--- a/src/core/search/expansion.ts
+++ b/src/core/search/expansion.ts
@@ -22,7 +22,9 @@ function getClient(): Anthropic {
 }
 
 export async function expandQuery(query: string): Promise<string[]> {
-  const wordCount = (query.match(/\S+/g) || []).length;
+  // CJK text is not space-delimited — count characters instead of whitespace-separated tokens
+  const hasCJK = /[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/.test(query);
+  const wordCount = hasCJK ? query.replace(/\s/g, '').length : (query.match(/\S+/g) || []).length;
   if (wordCount < MIN_WORDS) return [query];
 
   try {


### PR DESCRIPTION
## Summary

- `expandQuery()` skips queries with fewer than 3 words, but counts words by splitting on whitespace
- CJK text (Chinese/Japanese/Korean) is not space-delimited — a query like `"向量搜索优化"` is counted as 1 "word" and silently skipped
- This means **all short CJK queries never get expanded**, degrading search quality for CJK users

## Fix

Detect CJK characters (Unicode ranges for Han, Hiragana, Katakana, Hangul) and count non-whitespace characters instead of space-separated tokens when CJK is present.

```ts
// Before: always space-based
const wordCount = (query.match(/\S+/g) || []).length;

// After: CJK-aware
const hasCJK = /[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/.test(query);
const wordCount = hasCJK ? query.replace(/\s/g, '').length : (query.match(/\S+/g) || []).length;
```

## Impact

- **3 lines changed**, 1 file (`src/core/search/expansion.ts`)
- Zero behavior change for non-CJK queries
- CJK queries that were silently skipped now get properly expanded

## Test plan

- [ ] Verify `expandQuery("向量搜索")` no longer returns early (was counted as 1 word, now 4 chars)
- [ ] Verify `expandQuery("hello world")` still returns early (2 words < 3)
- [ ] Verify `expandQuery("machine learning models")` still works (3 words ≥ 3)