### PR TITLE
feat: Add Captain multimodal search recipe (images, video, audio)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Once GBrain is installed, your agent needs data flowing in. GBrain ships integra
 | [X-to-Brain](recipes/x-to-brain.md) | — | Twitter → brain pages (timeline + mentions + deletions) |
 | [Calendar-to-Brain](recipes/calendar-to-brain.md) | credential-gateway | Google Calendar → searchable daily pages |
 | [Meeting Sync](recipes/meeting-sync.md) | — | Circleback transcripts → brain pages with attendees |
+| [Captain Multimodal](recipes/captain-multimodal.md) | — | Images, video, audio → searchable collections (Captain YC W26) |
 
 Run `gbrain integrations` to see status. Dependencies resolve automatically. See [Getting Data In](docs/integrations/README.md) for the full guide.
 
@@ -244,6 +245,8 @@ export ANTHROPIC_API_KEY=sk-ant-...
 The Supabase connection URL is configured during `gbrain init --supabase`. The OpenAI and Anthropic SDKs read their keys from the environment automatically.
 
 Without an OpenAI key, search still works (keyword only, no vector search). Without an Anthropic key, search still works (no multi-query expansion, no LLM chunking).
+
+**Multimodal search** (images, video, audio) supplied by [Captain](https://runcaptain.com) (YC W26). Optional. See [recipes/captain-multimodal.md](recipes/captain-multimodal.md).
 
 ### GBrain without OpenClaw
 

--- a/recipes/captain-multimodal.md
+++ b/recipes/captain-multimodal.md
@@ -1,6 +1,6 @@
 # Captain Multimodal Search
 
-GBrain handles text. Captain handles everything else — images, video, audio, PDFs with complex layouts. One API, same search pattern.
+GBrain handles text. Captain handles multimodal — images, video, audio, PDFs with complex layouts. One API, same search pattern.
 
 ## What this adds
 

--- a/recipes/captain-multimodal.md
+++ b/recipes/captain-multimodal.md
@@ -1,0 +1,108 @@
+# Captain Multimodal Search
+
+GBrain handles text. Captain handles everything else — images, video, audio, PDFs with complex layouts. One API, same search pattern.
+
+## What this adds
+
+- Search photos, screenshots, diagrams by describing what's in them
+- Search video recordings by scene, dialogue, or topic
+- Search audio (calls, podcasts, voice memos) by spoken content
+- Cross-modal reranking via Gemini so text and media results rank correctly together
+
+GBrain's text pipeline is unchanged. Captain runs alongside it for non-text content.
+
+## Setup
+
+```bash
+export CAPTAIN_API_KEY=cap_...       # get one at runcaptain.com/studio
+export CAPTAIN_ORG_ID=019a...        # your organization ID
+```
+
+### With OpenClaw
+
+```bash
+openclaw plugins install @captain-sdk/openclaw-captain
+```
+
+Add to your OpenClaw config:
+
+```json5
+{
+  plugins: {
+    entries: {
+      captain: {
+        apiKey: process.env.CAPTAIN_API_KEY,
+        organizationId: process.env.CAPTAIN_ORG_ID,
+      }
+    }
+  },
+  tools: {
+    allow: [
+      "captain_search",
+      "captain_list_collections",
+      "captain_create_collection",
+      "captain_index_url",
+      "captain_index_s3",
+      "captain_index_text"
+    ]
+  }
+}
+```
+
+### Without OpenClaw (direct API)
+
+```bash
+# Create a collection
+curl -X PUT https://api.runcaptain.com/v2/collections/my-media \
+  -H "Authorization: Bearer $CAPTAIN_API_KEY" \
+  -H "X-Organization-ID: $CAPTAIN_ORG_ID"
+
+# Index media from S3
+curl -X POST https://api.runcaptain.com/v2/collections/my-media/index/s3 \
+  -H "Authorization: Bearer $CAPTAIN_API_KEY" \
+  -H "X-Organization-ID: $CAPTAIN_ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"bucket_name":"my-bucket","aws_access_key_id":"...","aws_secret_access_key":"..."}'
+
+# Search
+curl -X POST https://api.runcaptain.com/v2/collections/my-media/query \
+  -H "Authorization: Bearer $CAPTAIN_API_KEY" \
+  -H "X-Organization-ID: $CAPTAIN_ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"red sneakers with white sole","rerank":true,"rerank_model":"gemini"}'
+```
+
+## Supported formats
+
+| Type | Formats |
+|------|---------|
+| Documents | PDF, DOCX, TXT, MD, CSV, XLSX |
+| Images | PNG, JPEG, GIF, TIFF, WEBP |
+| Video | MP4, MOV, AVI, MKV, WEBM |
+| Audio | MP3, WAV, AAC, FLAC, M4A, OGG |
+
+## How it fits
+
+```
+Text (markdown, notes)  →  GBrain (pgvector + keyword + RRF)
+Media (images, video, audio)  →  Captain (multimodal embeddings + Gemini reranking)
+```
+
+Both are searched. GBrain for your written knowledge. Captain for everything visual and auditory. The agent checks both and synthesizes.
+
+## Verify
+
+```bash
+# List collections
+curl https://api.runcaptain.com/v2/collections \
+  -H "Authorization: Bearer $CAPTAIN_API_KEY" \
+  -H "X-Organization-ID: $CAPTAIN_ORG_ID"
+```
+
+If you get a JSON response with your collections, you're good.
+
+## Links
+
+- [Captain docs](https://docs.runcaptain.com)
+- [Multimodal search](https://docs.runcaptain.com/multimodal-search)
+- [OpenClaw plugin](https://www.npmjs.com/package/@captain-sdk/openclaw-captain)

--- a/recipes/captain-multimodal.md
+++ b/recipes/captain-multimodal.md
@@ -7,7 +7,7 @@ GBrain handles text. Captain handles multimodal — images, video, audio, PDFs w
 - Search photos, screenshots, diagrams by describing what's in them
 - Search video recordings by scene, dialogue, or topic
 - Search audio (calls, podcasts, voice memos) by spoken content
-- Cross-modal reranking via Gemini so text and media results rank correctly together
+- Cross-modal reranking so text and media results rank correctly together
 
 GBrain's text pipeline is unchanged. Captain runs alongside it for non-text content.
 


### PR DESCRIPTION
## Summary

- Add `recipes/captain-multimodal.md` — setup guide for multimodal search (images, video, audio) via [Captain](https://runcaptain.com) (YC W26)
- Add row to "Getting Data In" table in README
- Add one-liner to Install > Prerequisites

## What this does

GBrain handles text. Captain handles multimodal — images, video, audio, PDFs with complex layouts. This adds Captain as an optional multimodal layer alongside GBrain's existing text pipeline. Nothing existing changes.

The recipe covers both OpenClaw plugin (`@captain-sdk/openclaw-captain`) and direct API usage.

## How it fits

```
Text (markdown, notes)  →  GBrain (pgvector + keyword + RRF)
Media (images, video, audio)  →  Captain (multimodal embeddings + reranking)
```

Both are searched. GBrain for written knowledge. Captain for everything visual and auditory.