### PR TITLE
security: gate command DSL health checks on isEmbedded

### DIFF
--- a/src/commands/integrations.ts
+++ b/src/commands/integrations.ts
@@ -194,6 +194,17 @@ export async function executeHealthCheck(
     }
 
     case 'command': {
+      // Gate: non-embedded recipes (loaded from CWD) must not execute
+      // arbitrary commands. The string path has isUnsafeHealthCheck()
+      // but the typed DSL command path was missing the isEmbedded
+      // check entirely. A CWD recipe with embedded=true bypasses both.
+      if (!isEmbedded) {
+        return {
+          ...base,
+          status: 'blocked',
+          output: `Blocked: command health checks are only allowed in embedded (first-party) recipes. Move this recipe to the installed recipes directory.`,
+        };
+      }
       try {
         const { spawnSync } = await import('child_process');
         const result = spawnSync(check.argv[0], check.argv.slice(1), {

--- a/test/integrations.test.ts
+++ b/test/integrations.test.ts
@@ -394,6 +394,19 @@ describe('executeHealthCheck', () => {
     expect(result.status).toBe('fail');
   });
 
+  test('command blocked for non-embedded recipes', async () => {
+    // A CWD recipe (isEmbedded=false) must not be allowed to execute
+    // arbitrary commands via the typed DSL. Only first-party embedded
+    // recipes get command execution.
+    const result = await executeHealthCheck(
+      { type: 'command', argv: ['whoami'], label: 'whoami' },
+      'test-id',
+      false, // non-embedded
+    );
+    expect(result.status).toBe('blocked');
+    expect(result.output).toContain('only allowed in embedded');
+  });
+
   test('any_of returns ok if first check passes', async () => {
     process.env.TEST_ANYOF = 'yes';
     const result = await executeHealthCheck({


### PR DESCRIPTION
## Summary

`gbrain integrations doctor` runs health checks from recipe YAML files. In v0.9.3,
a typed DSL was added with 4 check types: `http`, `env_exists`, `command`, and `any_of`.
The `command` type runs a binary via `spawnSync`.

The problem: recipes can be loaded from `recipes/` in the current working directory.
The old string-based health checks had an `isUnsafeHealthCheck()` guard for non-embedded
recipes, but the new `command` DSL type skips that check entirely. A malicious recipe
in CWD with a `command` health check executes arbitrary binaries on `gbrain integrations doctor`.

## What the fix does

Before calling `spawnSync`, the handler checks `isEmbedded`. If the recipe is NOT
first-party (loaded from CWD), the command check returns `status: 'blocked'` without
executing anything. First-party recipes continue to work as before.

## Changes

`src/commands/integrations.ts`
- `isEmbedded` gate at the top of the `command` case, before `spawnSync`

`test/integrations.test.ts`
- New test: command check with `isEmbedded=false` returns blocked
- Existing command tests (exit 0 ok, exit 1 fail) still pass with `isEmbedded=true`

## Validation

- `bun test test/integrations.test.ts` — 38 pass, 0 fail