### PR TITLE
security: clamp list_pages and get_ingest_log limits

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -4,6 +4,7 @@
  */
 
 import type { BrainEngine } from './engine.ts';
+import { clampSearchLimit } from './engine.ts';
 import type { GBrainConfig } from './config.ts';
 import { importFromContent } from './import-file.ts';
 import { hybridSearch } from './search/hybrid.ts';
@@ -156,7 +157,7 @@ const list_pages: Operation = {
     const pages = await ctx.engine.listPages({
       type: p.type as any,
       tag: p.tag as string,
-      limit: (p.limit as number) || 50,
+      limit: clampSearchLimit(p.limit as number | undefined, 50),
     });
     return pages.map(pg => ({
       slug: pg.slug,
@@ -529,7 +530,7 @@ const get_ingest_log: Operation = {
     limit: { type: 'number', description: 'Max entries (default 20)' },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.getIngestLog({ limit: (p.limit as number) || 20 });
+    return ctx.engine.getIngestLog({ limit: clampSearchLimit(p.limit as number | undefined, 20) });
   },
 };
 


### PR DESCRIPTION
## Summary

Several gbrain MCP operations accept a `limit` parameter that controls how many
results to return. The `search` and `query` operations were already capped at 100 via
`clampSearchLimit` (fixed in v0.9.1). Two other operations were not:

- `list_pages`: `(p.limit as number) || 50` — no cap
- `get_ingest_log`: `(p.limit as number) || 20` — no cap

The problem: an MCP caller can pass `{limit: 10000000}` and force the engine to
return an unbounded result set, consuming memory on the server.

## What the fix does

Both operations now use `clampSearchLimit(p.limit, defaultValue)` — the same function
that already caps `search` and `query`. The ceiling is `MAX_SEARCH_LIMIT = 100`.
Normal usage (limit under 100) is unaffected.

## Changes

`src/core/operations.ts`
- Import `clampSearchLimit` from `engine.ts`
- `list_pages` handler: `clampSearchLimit(p.limit, 50)`
- `get_ingest_log` handler: `clampSearchLimit(p.limit, 20)`

## Validation

- `bun test test/parity.test.ts` — 10 pass (operation contract intact)
- `bun test test/search-limit.test.ts` — 11 pass (clamp logic verified)
- Runtime: `clampSearchLimit(10000000, 50)` → 100, `clampSearchLimit(undefined, 50)` → 50