### PR TITLE
Add local Ollama embedding setup for OpenAI-compatible endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,20 @@ You take a meeting with someone. The agent writes a brain page for them, links i
 Set the API keys as environment variables:
 
 ```bash
-export OPENAI_API_KEY=sk-...
-export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=***
+export ANTHROPIC_API_KEY=***
 ```
+
+Or use a local Ollama embedding model through its OpenAI-compatible endpoint:
+
+```bash
+export OPENAI_API_KEY=dummy
+export OPENAI_BASE_URL=http://127.0.0.1:11434/v1
+export OPENAI_EMBED_MODEL=qwen3-embedding:4b
+export OPENAI_EMBED_DIMENSIONS=1536
+```
+
+See [`docs/guides/local-ollama-embeddings.md`](docs/guides/local-ollama-embeddings.md) for the full setup and the schema-compatibility caveat.
 
 The Supabase connection URL is configured during `gbrain init --supabase`. The OpenAI and Anthropic SDKs read their keys from the environment automatically.
 

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -94,7 +94,7 @@ export interface BrainEngine {
 
 **Slug-based API, not ID-based.** Every method takes slugs, not numeric IDs. The engine resolves slugs to IDs internally. This keeps the interface portable... slugs are strings, IDs are database-specific.
 
-**Embedding is NOT in the engine.** The engine stores embeddings and searches by vector, but it doesn't generate embeddings. `src/core/embedding.ts` handles that. This is intentional: embedding is an external API call (OpenAI), not a storage concern. All engines share the same embedding service.
+**Embedding is NOT in the engine.** The engine stores embeddings and searches by vector, but it doesn't generate embeddings. `src/core/embedding.ts` handles that. This is intentional: embedding is an external API call, not a storage concern. By default this uses OpenAI, but the same client path can target Ollama's OpenAI-compatible endpoint with environment variables. All engines share the same embedding service.
 
 **Chunking is NOT in the engine.** Same logic. `src/core/chunkers/` handles chunking. The engine stores and retrieves chunks. All engines share the same chunkers.
 

--- a/docs/GBRAIN_VERIFY.md
+++ b/docs/GBRAIN_VERIFY.md
@@ -114,6 +114,10 @@ gbrain embed --stale
 If `OPENAI_API_KEY` is not set, embeddings can't be generated. Keyword search
 still works without embeddings, but hybrid/semantic search won't.
 
+If you're using a local Ollama embedding model through the OpenAI-compatible API,
+make sure `OPENAI_BASE_URL`, `OPENAI_EMBED_MODEL`, and `OPENAI_EMBED_DIMENSIONS`
+are also set. See `docs/guides/local-ollama-embeddings.md`.
+
 ### 4c. End-to-End Test
 
 This is the real test. Edit a brain page, push, wait, search.

--- a/docs/guides/local-ollama-embeddings.md
+++ b/docs/guides/local-ollama-embeddings.md
@@ -1,0 +1,54 @@
+# Local Ollama embeddings via OpenAI-compatible API
+
+## Goal
+Run GBrain semantic search against a local Ollama embedding model without changing the current 1536-dimension vector schema.
+
+## When to use this
+- You want local embeddings instead of hosted OpenAI embeddings
+- You already have an Ollama embedding model on the same machine
+- You want `gbrain embed` and `gbrain query` to keep working with the existing OpenAI client path
+
+## Working setup
+GBrain's embedding client uses the OpenAI SDK. Ollama exposes an OpenAI-compatible endpoint at `/v1/embeddings`, so the simplest integration is to point GBrain at that endpoint and override the embedding model name.
+
+### Required environment variables
+
+```bash
+export OPENAI_API_KEY=dummy
+export OPENAI_BASE_URL=http://127.0.0.1:11434/v1
+export OPENAI_EMBED_MODEL=qwen3-embedding:4b
+export OPENAI_EMBED_DIMENSIONS=1536
+```
+
+### Why this works
+- `OPENAI_BASE_URL` redirects the OpenAI SDK to Ollama's local OpenAI-compatible server.
+- `OPENAI_EMBED_MODEL` tells GBrain which local embedding model to request.
+- `OPENAI_EMBED_DIMENSIONS=1536` keeps the returned vectors aligned with the current `vector(1536)` schema used by GBrain.
+- `OPENAI_API_KEY` only needs to be non-empty because the OpenAI SDK requires it; Ollama does not validate a real OpenAI key for local calls.
+
+## Important detail: use `/v1/embeddings`, not Ollama's native `/api/embed`
+Some Ollama embedding models return their native dimensionality on `/api/embed` (for example, `qwen3-embedding:4b` can return 2560 dimensions). That will not fit GBrain's current schema.
+
+The OpenAI-compatible `/v1/embeddings` endpoint can return 1536-dimensional vectors when the request includes `dimensions: 1536`, which preserves compatibility with the existing schema and search pipeline.
+
+## Verification steps
+
+```bash
+# Backfill any missing embeddings
+gbrain embed --stale
+
+# Confirm embeddings now exist
+gbrain stats
+
+# Run a semantic query
+gbrain query "How can AI analysis be made trustworthy for product decisions?"
+```
+
+Expected result:
+- `Embedded` count increases in `gbrain stats`
+- `gbrain query` returns semantically relevant chunks, not just exact keyword matches
+
+## Notes
+- Keyword search still works without any embeddings.
+- This setup is especially useful for local-first PGLite installs.
+- If you switch to a different local embedding model, make sure it can return 1536 dimensions or update the schema and migration path accordingly.

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -9,8 +9,8 @@
 
 import OpenAI from 'openai';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
+const MODEL = process.env.OPENAI_EMBED_MODEL || 'text-embedding-3-large';
+const DIMENSIONS = Number(process.env.OPENAI_EMBED_DIMENSIONS || '1536');
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;


### PR DESCRIPTION
## Summary
- document how to run GBrain embeddings against a local Ollama server via the OpenAI-compatible `/v1/embeddings` endpoint
- make the embedding model and dimensions configurable via environment variables so local models can be used without editing source each time
- add verification notes about the 1536-dimension schema compatibility caveat

## Why
I validated this locally with `qwen3-embedding:4b` on Ollama. The important detail is that Ollama's native `/api/embed` can return a model's native dimension, while the OpenAI-compatible endpoint can return `1536` dimensions when requested, which matches GBrain's current schema.

## Test Plan
- `bun test test/embed.test.ts`
- verified locally that `gbrain embed --stale` and `gbrain query` work against a local Ollama server configured through `OPENAI_BASE_URL`, `OPENAI_EMBED_MODEL`, and `OPENAI_EMBED_DIMENSIONS`
