### PR TITLE
fix: CJK word count and delimiters in recursive chunker

### DIFF
--- a/src/core/chunkers/recursive.ts
+++ b/src/core/chunkers/recursive.ts
@@ -16,8 +16,11 @@
 const DELIMITERS: string[][] = [
   ['\n\n'],                          // L0: paragraphs
   ['\n'],                            // L1: lines
-  ['. ', '! ', '? ', '.\n', '!\n', '?\n'], // L2: sentences
-  ['; ', ': ', ', '],                // L3: clauses
+  // L2: sentences (ASCII + CJK full-width). Full-width '。！？' are unambiguous
+  // sentence endings in Chinese/Japanese — no trailing space required.
+  ['. ', '! ', '? ', '.\n', '!\n', '?\n', '。', '！', '？'],
+  // L3: clauses (ASCII + CJK full-width). '、' is Japanese list separator.
+  ['; ', ': ', ', ', '；', '：', '，', '、'],
   [],                                // L4: words (whitespace split)
 ];
 
@@ -138,6 +141,20 @@ function splitAtDelimiters(text: string, delimiters: string[]): string[] {
  * Fallback: split on whitespace boundaries to hit target word count.
  */
 function splitOnWhitespace(text: string, target: number): string[] {
+  // CJK fallback: a paragraph of Chinese/Japanese with no whitespace would
+  // produce a single "word" via the regex below, defeating the size target.
+  // Slice at character boundaries so each piece is ≤ target chars (≈ tokens).
+  if (CJK_RE.test(text) && !/\s/.test(text)) {
+    const pieces: string[] = [];
+    for (let i = 0; i < text.length; i += target) {
+      const piece = text.slice(i, i + target);
+      if (piece.trim().length > 0) {
+        pieces.push(piece);
+      }
+    }
+    return pieces;
+  }
+
   const words = text.match(/\S+\s*/g) || [];
   if (words.length === 0) return [];
 
@@ -218,6 +235,18 @@ function extractTrailingContext(text: string, targetWords: number): string {
   return trailing;
 }
 
+// CJK ranges: Han, Hiragana, Katakana, Hangul. Mirrors the detection in
+// search/expansion.ts (PR #98) so word-count semantics stay consistent.
+const CJK_RE = /[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/;
+
 function countWords(text: string): number {
+  // CJK text is not space-delimited — a whole paragraph of Chinese would
+  // be counted as 1 "word" by the whitespace-based regex, so the chunker
+  // never splits it and the entire paragraph gets sent as one >8192-token
+  // embedding request. Count non-whitespace characters when CJK is present
+  // so 1 char ≈ 1 "word" and chunkSize targets still bound chunk size.
+  if (CJK_RE.test(text)) {
+    return text.replace(/\s/g, '').length;
+  }
   return (text.match(/\S+/g) || []).length;
 }

--- a/test/chunkers/recursive.test.ts
+++ b/test/chunkers/recursive.test.ts
@@ -132,4 +132,34 @@ describe('Recursive Text Chunker', () => {
     const chunks = chunkText(text, { chunkSize: 10 });
     expect(chunks.length).toBeGreaterThan(1);
   });
+
+  test('splits long Chinese paragraph into multiple chunks (CJK word count)', () => {
+    // A 2,000-char Chinese paragraph would be counted as 1 "word" by the
+    // whitespace regex (no spaces between Chinese chars) and returned as a
+    // single chunk, which then exceeds OpenAI's 8192-token embedding limit.
+    // With CJK-aware counting, 1 char ≈ 1 "word" and chunkSize bounds apply.
+    const paragraph = '这是一段很长的中文文字用来测试分块器是否能够正确处理中日韩文字。'.repeat(60);
+    const chunks = chunkText(paragraph, { chunkSize: 100 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      // Each chunk should be within 1.5x of target (the greedy-merge tolerance)
+      const charCount = chunk.text.replace(/\s/g, '').length;
+      expect(charCount).toBeLessThanOrEqual(150);
+    }
+  });
+
+  test('splits Japanese and Korean text as well', () => {
+    const japanese = 'これは日本語のテストです。分割されるべきです。'.repeat(40);
+    const korean = '이것은 한국어 테스트입니다. 분할되어야 합니다.'.repeat(40);
+    const jaChunks = chunkText(japanese, { chunkSize: 50 });
+    const koChunks = chunkText(korean, { chunkSize: 50 });
+    expect(jaChunks.length).toBeGreaterThan(1);
+    expect(koChunks.length).toBeGreaterThan(1);
+  });
+
+  test('mixed CJK + English text still gets split', () => {
+    const mixed = ('Hello world 你好世界 this is 混合文本 testing. ').repeat(50);
+    const chunks = chunkText(mixed, { chunkSize: 50 });
+    expect(chunks.length).toBeGreaterThan(1);
+  });
 });


### PR DESCRIPTION
## Summary

The recursive chunker's `countWords()` uses `text.match(/\S+/g)` to count whitespace-separated tokens. CJK text (Chinese/Japanese/Korean) has no spaces between characters, so a whole paragraph of Chinese is counted as **1 \"word\"**. The chunker never splits it, the paragraph gets sent as one >8192-token embedding request, and OpenAI returns:

> `Error embedding: 400 Invalid 'input[N]': maximum input length is 8192 tokens`

This is the chunker-side counterpart to #98 (`fix: CJK word count in query expansion`), which fixed the same root cause in `expandQuery()`.

## Reproduction

```bash
# Any pure Chinese markdown file >~2KB triggers it
gbrain import path/to/chinese-notes/
gbrain embed --stale
# → Error embedding <slug>: 400 Invalid 'input[N]': maximum input length is 8192 tokens
```

Real case that surfaced this: a 101 KB Chinese interview transcript produced chunks that each exceeded the OpenAI embedding token limit, so those chunks never got vectorized and vector search on them silently degraded.

## Fix

Three small changes in `src/core/chunkers/recursive.ts`:

1. **`countWords()` — CJK-aware counting.** When CJK characters are present, count non-whitespace characters (1 char ≈ 1 \"word\"). Mirrors the detection already used in `search/expansion.ts` (PR #98) so semantics stay consistent across the codebase.

2. **`DELIMITERS` L2 and L3 — CJK full-width punctuation.** Chinese/Japanese use `。！？` for sentence endings and `；：，、` for clauses. Without these, a CJK paragraph finds no split points even when the size target is exceeded.

3. **`splitOnWhitespace()` — character-slice fallback.** When a CJK paragraph reaches the whitespace-split level but has no whitespace, fall back to character-boundary slicing (`text.slice(i, i + target)`) so each piece is ≤ target characters.

## Impact

- **2 files changed**, +61 / -2 lines
- Zero behavior change for non-CJK text (same regex, same code path)
- Pure CJK paragraphs now split into ≤ target-char chunks instead of one oversized chunk
- Unblocks embedding + vector search for CJK users

## Test plan

- [x] 3 new tests in `test/chunkers/recursive.test.ts` cover:
  - Long Chinese paragraph splits into multiple chunks with per-chunk char count ≤ 1.5× target (greedy-merge tolerance)
  - Japanese (Hiragana + `。`) and Korean (Hangul + space-delimited) both split
  - Mixed CJK + English text still splits
- [x] All 18 chunker tests pass locally (15 existing + 3 new)
- [x] `bun test` shows no new regressions (the 4 pre-existing failures in `PGLiteEngine` are unrelated and exist on `master`)

Inspired by and stylistically consistent with #98 by @YIING99.