### PR TITLE
fix: preserve CJK characters in slugify, prevent silent collision

### DIFF
--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -235,6 +235,11 @@ export function isSyncable(path: string, opts: SyncableOptions = {}): boolean {
   return true;
 }
 
+// CJK ranges: Han, Hiragana, Katakana, Hangul. Same set used by the chunker
+// (see src/core/chunkers/recursive.ts) and query expansion (PR #98) for
+// consistent CJK handling across the codebase.
+const CJK_CLASS = '\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af';
+
 /**
  * Character class for the lowercase-canonical form of a slug segment after
  * slugifySegment() has run. Lowercase letters, digits, dots, underscores,
@@ -250,13 +255,16 @@ export const SLUG_SEGMENT_PATTERN = /[a-z0-9._-]+/;
 
 /**
  * Slugify a single path segment: lowercase, strip special chars, spaces → hyphens.
+ * CJK characters are preserved (not stripped) so Chinese/Japanese/Korean
+ * filenames produce meaningful, non-colliding slugs.
  */
 export function slugifySegment(segment: string): string {
   return segment
     .normalize('NFD')                     // Decompose accented chars
-    .replace(/[\u0300-\u036f]/g, '')      // Strip accent marks
+    .replace(/[\u0300-\u036f]/g, '')      // Strip Latin accent marks
+    .normalize('NFC')                     // Recompose Hangul syllables (NFD splits them into Jamo)
     .toLowerCase()
-    .replace(/[^a-z0-9.\s_-]/g, '')      // Keep alphanumeric, dots, spaces, underscores, hyphens
+    .replace(new RegExp(`[^a-z0-9.\\s_${CJK_CLASS}-]`, 'g'), '') // Keep ASCII alphanum, dots, spaces, _-, CJK
     .replace(/[\s]+/g, '-')              // Spaces → hyphens
     .replace(/-+/g, '-')                 // Collapse multiple hyphens
     .replace(/^-|-$/g, '');              // Strip leading/trailing hyphens

--- a/test/slug-validation.test.ts
+++ b/test/slug-validation.test.ts
@@ -51,6 +51,32 @@ describe('slugifySegment', () => {
   test('handles curly quotes and ellipsis', () => {
     expect(slugifySegment('she\u2026said \u201chello\u201d')).toBe('shesaid-hello');
   });
+
+  test('preserves Chinese characters (Han)', () => {
+    expect(slugifySegment('品牌圣经')).toBe('品牌圣经');
+    expect(slugifySegment('销售论证文档')).toBe('销售论证文档');
+  });
+
+  test('preserves Japanese (Hiragana + Katakana)', () => {
+    expect(slugifySegment('ひらがな')).toBe('ひらがな');
+    expect(slugifySegment('カタカナ')).toBe('カタカナ');
+    expect(slugifySegment('テスト文書')).toBe('テスト文書');
+  });
+
+  test('preserves Korean (Hangul)', () => {
+    expect(slugifySegment('한글테스트')).toBe('한글테스트');
+  });
+
+  test('mixed CJK + ASCII: lowercase ASCII, preserve CJK, space → hyphen', () => {
+    expect(slugifySegment('ICP-理想客户画像')).toBe('icp-理想客户画像');
+    expect(slugifySegment('你好 world')).toBe('你好-world');
+  });
+
+  test('two different CJK names produce different slugs (no collision)', () => {
+    // Regression: before this fix, both collapsed to empty string and their
+    // pages would overwrite each other during import.
+    expect(slugifySegment('品牌圣经')).not.toBe(slugifySegment('销售论证文档'));
+  });
 });
 
 describe('slugifyPath', () => {
@@ -109,6 +135,24 @@ describe('slugifyPath', () => {
   test('meetings transcript example', () => {
     expect(slugifyPath('meetings/transcripts/2026-01-21 maria - california c4 collaboration discussion.md'))
       .toBe('meetings/transcripts/2026-01-21-maria-california-c4-collaboration-discussion');
+  });
+
+  test('pure-CJK filenames keep their characters', () => {
+    expect(slugifyPath('inbox/品牌圣经.md')).toBe('inbox/品牌圣经');
+    expect(slugifyPath('inbox/销售论证文档.md')).toBe('inbox/销售论证文档');
+  });
+
+  test('pure-CJK filenames do not collide', () => {
+    // Regression: before this fix, both pure-CJK files collapsed to the
+    // parent directory slug (e.g., "inbox") and silently overwrote each
+    // other during gbrain import (reported as "N imported, 0 errors").
+    const slug1 = slugifyPath('inbox/品牌圣经.md');
+    const slug2 = slugifyPath('inbox/销售论证文档.md');
+    expect(slug1).not.toBe(slug2);
+  });
+
+  test('CJK directory names also preserved', () => {
+    expect(slugifyPath('会议/2026-04-14.md')).toBe('会议/2026-04-14');
   });
 });
 


### PR DESCRIPTION
## Summary

`slugifySegment()` in `src/core/sync.ts` uses `/[^a-z0-9.\s_-]/g` to strip \"special\" chars. That regex strips **every non-ASCII character**, including all CJK. Consequence:

- `品牌圣经.md` → slug segment `\"\"` (empty)
- `销售论证文档.md` → slug segment `\"\"` (empty)

Both empty segments are filtered out by `slugifyPath`'s `.filter(Boolean)`, and both files collapse to the parent directory slug (e.g., `inbox`). The second import **silently overwrites** the first. Worse, `gbrain import` reports `N imported, 0 errors` because UPSERT doesn't distinguish overwrite from insert.

This is the slug-layer counterpart to #98 (query expansion) and #114 (chunker) — the same ASCII-only assumption baked into a third part of the codebase.

## Reproduction

```bash
mkdir repro && cd repro
echo '# A' > 品牌圣经.md
echo '# B' > 销售论证文档.md
gbrain init
gbrain import .
# → \"2 pages imported, 0 errors\"
gbrain list
# → Only 1 page! One file was silently overwritten.
```

## Fix

Two small changes in `src/core/sync.ts`:

1. **Add CJK ranges to the character whitelist.** Han (`\u4e00-\u9fff`), Hiragana (`\u3040-\u309f`), Katakana (`\u30a0-\u30ff`), Hangul Syllables (`\uac00-\ud7af`). Same set used by the chunker fix (#114) and expansion fix (#98) for consistency.

2. **Re-normalize to NFC after the accent-strip step.** NFD decomposes Hangul syllables (e.g., `한`) into conjoining Jamo (`ㅎ` + `ㅏ` + `ㄴ`) in the U+1100 block, which sit **outside** the Hangul Syllables block. Without re-composing, Korean names would still collapse to empty. The NFD+NFC dance is the same trick Unicode libraries use to apply combining-mark operations on Latin without mangling Hangul.

## Impact

- **2 files changed**, +54 / -2 lines
- Zero behavior change for ASCII-only text (same regex shape, same steps, same output)
- Pure and mixed CJK filenames now produce meaningful, **non-colliding** slugs
- Closes a silent-data-loss class of bug for CJK users

## Test plan

- [x] 8 new cases in `test/slug-validation.test.ts`:
  - `slugifySegment` preserves Chinese (`品牌圣经` → `品牌圣经`)
  - `slugifySegment` preserves Japanese (Hiragana `ひらがな`, Katakana `カタカナ`, mixed `テスト文書`)
  - `slugifySegment` preserves Korean (`한글테스트` → `한글테스트`) — exercises the NFC recomposition
  - `slugifySegment` mixed CJK + ASCII: lowercases ASCII, preserves CJK, space → hyphen (`ICP-理想客户画像` → `icp-理想客户画像`)
  - `slugifySegment` collision regression: two different CJK names produce different slugs
  - `slugifyPath` pure-CJK files keep their characters (`inbox/品牌圣经.md` → `inbox/品牌圣经`)
  - `slugifyPath` collision regression at the path level
  - `slugifyPath` CJK directory names preserved
- [x] All 46 slug tests pass (8 new + 38 existing)
- [x] `bun test` shows no new regressions (the 4 pre-existing `PGLiteEngine` failures are unrelated and exist on `master`)

Companion to #114 (chunker CJK fix). Either can be merged independently.