### PR TITLE
fix(tests): complete embed.ts mock so later tests can import `embed`

### DIFF
--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -20,6 +20,12 @@ mock.module('../src/core/embedding.ts', () => ({
     activeEmbedCalls--;
     return texts.map(() => new Float32Array(1536));
   },
+  // Preserve the full shape of embedding.ts so tests that load *after* this
+  // mock (Bun's mock.module is process-global) don't blow up with
+  // "Export named 'embed' not found".
+  embed: async (_text: string) => new Float32Array(1536),
+  EMBEDDING_MODEL: 'mock-embedding',
+  EMBEDDING_DIMENSIONS: 1536,
 }));
 
 // Import AFTER mocking.


### PR DESCRIPTION
## Summary

`test/embed.test.ts` mocks `../src/core/embedding.ts` but the mock only provides `embedBatch`. Because Bun's `mock.module()` is process-global (not per-file), once that test runs, any later test whose transitive imports touch `embedding.ts#embed` fails to load with:

```
SyntaxError: Export named 'embed' not found in module
  src/core/embedding.ts
      at loadAndEvaluateModule (2:1)
```

The mock now mirrors the full public surface of `embedding.ts` (`embed`, `embedBatch`, `EMBEDDING_MODEL`, `EMBEDDING_DIMENSIONS`). Pure test-shape change — no production code affected, no existing assertions changed.

## Repro

```
bun test test/embed.test.ts test/e2e/mechanical.test.ts
```

Before: `3 pass, 1 fail, 1 error`
After: `3 pass, 0 fail`

Full suite (on my machine, `bun 1.3.11`, no `DATABASE_URL`):
- Before: `469 pass, 3 fail, 3 errors`
- After: `590 pass, 0 fail, 126 skip` (DB-backed tests skipped as expected)

## Test plan

- [x] `bun test test/embed.test.ts` — existing concurrency assertions still hold
- [x] `bun test` — full non-DB suite green
- [x] `rg "mock.module" test/` reviewed — no other mocks with the same partial-shape problem

## Out of scope

A more robust fix would unmock in an `afterAll` so later test files see the real module. Bun doesn't have `mock.unmock.module()` yet (there's ongoing discussion upstream), so matching the full shape is the minimal correct fix today.
