### PR TITLE
feat: add oauth and ollama embedding support

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,4 +1,5 @@
 import type { BrainEngine } from '../core/engine.ts';
+import { ensureEmbeddingSchema, resolveEmbeddingSettings } from '../core/embedding-config.ts';
 import { embedBatch } from '../core/embedding.ts';
 import type { ChunkInput } from '../core/types.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
@@ -53,7 +54,9 @@ async function embedPage(engine: BrainEngine, slug: string) {
     return;
   }
 
-  const embeddings = await embedBatch(toEmbed.map(c => c.chunk_text));
+  await ensureEmbeddingSchema(engine);
+  const settings = await resolveEmbeddingSettings(engine);
+  const embeddings = await embedBatch(toEmbed.map(c => c.chunk_text), engine);
   const updated: ChunkInput[] = chunks.map((c, i) => {
     const needsEmbed = toEmbed.find(te => te.chunk_index === c.chunk_index);
     const embIdx = needsEmbed ? toEmbed.indexOf(needsEmbed) : -1;
@@ -62,6 +65,7 @@ async function embedPage(engine: BrainEngine, slug: string) {
       chunk_text: c.chunk_text,
       chunk_source: c.chunk_source,
       embedding: embIdx >= 0 ? embeddings[embIdx] : undefined,
+      model: embIdx >= 0 ? settings.model : c.model,
       token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
     };
   });
@@ -85,7 +89,9 @@ async function embedAll(engine: BrainEngine, staleOnly: boolean) {
     if (toEmbed.length === 0) continue;
 
     try {
-      const embeddings = await embedBatch(toEmbed.map(c => c.chunk_text));
+      await ensureEmbeddingSchema(engine);
+      const settings = await resolveEmbeddingSettings(engine);
+      const embeddings = await embedBatch(toEmbed.map(c => c.chunk_text), engine);
       // Build a map of new embeddings by chunk_index
       const embeddingMap = new Map<number, Float32Array>();
       for (let j = 0; j < toEmbed.length; j++) {
@@ -97,6 +103,7 @@ async function embedAll(engine: BrainEngine, staleOnly: boolean) {
         chunk_text: c.chunk_text,
         chunk_source: c.chunk_source,
         embedding: embeddingMap.get(c.chunk_index) ?? undefined,
+        model: embeddingMap.has(c.chunk_index) ? settings.model : c.model,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
       await engine.upsertChunks(page.slug, updated);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -13,6 +13,11 @@ export interface GBrainConfig {
   database_path?: string;
   openai_api_key?: string;
   anthropic_api_key?: string;
+  embedding_provider?: 'openai' | 'ollama';
+  embedding_model?: string;
+  embedding_dimensions?: number;
+  embedding_base_url?: string;
+  ollama_base_url?: string;
 }
 
 /**

--- a/src/core/embedding-config.ts
+++ b/src/core/embedding-config.ts
@@ -1,0 +1,183 @@
+import type { BrainEngine } from './engine.ts';
+import { loadConfig } from './config.ts';
+import { resolveOpenAICredentials } from './openai-credentials.ts';
+
+const DEFAULT_OPENAI_MODEL = 'text-embedding-3-large';
+const DEFAULT_OPENAI_DIMENSIONS = 1536;
+const DEFAULT_OLLAMA_MODEL = 'nomic-embed-text';
+const DEFAULT_OLLAMA_DIMENSIONS = 768;
+const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
+
+type Provider = 'openai' | 'ollama';
+type EnvLike = Record<string, string | undefined>;
+type EngineConfigMap = Record<string, string | null | undefined>;
+
+export interface ResolvedEmbeddingSettings {
+  provider: Provider;
+  model: string;
+  dimensions: number;
+  baseURL?: string;
+}
+
+export interface ResolveEmbeddingSettingsSources {
+  env?: EnvLike;
+  engineConfig?: EngineConfigMap;
+  fileConfig?: {
+    embedding_provider?: string;
+    embedding_model?: string;
+    embedding_dimensions?: number;
+    embedding_base_url?: string;
+    ollama_base_url?: string;
+  } | null;
+}
+
+export async function resolveEmbeddingSettings(engine?: BrainEngine): Promise<ResolvedEmbeddingSettings> {
+  const env = process.env as EnvLike;
+  const fileConfig = loadConfig();
+  const engineConfig = engine ? await loadEngineConfig(engine) : undefined;
+  return resolveEmbeddingSettingsFromSources({ env, engineConfig, fileConfig });
+}
+
+export function resolveEmbeddingSettingsFromSources(sources: ResolveEmbeddingSettingsSources): ResolvedEmbeddingSettings {
+  const env = sources.env || {};
+  const engineConfig = sources.engineConfig || {};
+  const fileConfig = sources.fileConfig || null;
+
+  const provider = normalizeProvider(
+    env.GBRAIN_EMBEDDING_PROVIDER
+    || stringValue(engineConfig.embedding_provider)
+    || fileConfig?.embedding_provider,
+  );
+
+  const defaults = provider === 'ollama'
+    ? {
+        model: DEFAULT_OLLAMA_MODEL,
+        dimensions: DEFAULT_OLLAMA_DIMENSIONS,
+        baseURL: DEFAULT_OLLAMA_BASE_URL,
+      }
+    : {
+        model: DEFAULT_OPENAI_MODEL,
+        dimensions: DEFAULT_OPENAI_DIMENSIONS,
+        baseURL: undefined,
+      };
+
+  const model = normalize(
+    env.GBRAIN_EMBEDDING_MODEL
+    || stringValue(engineConfig.embedding_model)
+    || fileConfig?.embedding_model,
+  ) || defaults.model;
+
+  const dimensions = normalizePositiveInt(
+    env.GBRAIN_EMBEDDING_DIMENSIONS
+    || stringValue(engineConfig.embedding_dimensions)
+    || numberValue(fileConfig?.embedding_dimensions),
+  ) || defaults.dimensions;
+
+  const baseURL = normalizeBaseURL(
+    provider === 'ollama'
+      ? env.GBRAIN_OLLAMA_BASE_URL
+        || env.OLLAMA_HOST
+        || stringValue(engineConfig.embedding_base_url)
+        || stringValue(engineConfig.ollama_base_url)
+        || fileConfig?.embedding_base_url
+        || fileConfig?.ollama_base_url
+        || defaults.baseURL
+      : env.GBRAIN_OPENAI_BASE_URL
+        || env.OPENAI_BASE_URL
+        || stringValue(engineConfig.embedding_base_url)
+        || fileConfig?.embedding_base_url
+        || defaults.baseURL,
+  );
+
+  return { provider, model, dimensions, baseURL };
+}
+
+export async function hasEmbeddingSupport(engine?: BrainEngine): Promise<boolean> {
+  const settings = await resolveEmbeddingSettings(engine);
+  if (settings.provider === 'ollama') return true;
+  return !!resolveOpenAICredentials();
+}
+
+export async function ensureEmbeddingSchema(engine: BrainEngine): Promise<void> {
+  const settings = await resolveEmbeddingSettings(engine);
+  const currentDimensions = await engine.getEmbeddingDimensions();
+
+  if (currentDimensions !== settings.dimensions) {
+    await engine.runMigration(0, buildEmbeddingMigrationSql(settings.dimensions));
+  }
+
+  await engine.setConfig('embedding_provider', settings.provider);
+  await engine.setConfig('embedding_model', settings.model);
+  await engine.setConfig('embedding_dimensions', String(settings.dimensions));
+  if (settings.baseURL) {
+    await engine.setConfig('embedding_base_url', settings.baseURL);
+  }
+}
+
+export function buildEmbeddingMigrationSql(dimensions: number): string {
+  const safeDimensions = normalizePositiveInt(String(dimensions));
+  if (!safeDimensions) {
+    throw new Error(`Invalid embedding dimensions: ${dimensions}`);
+  }
+
+  return `
+    DROP INDEX IF EXISTS idx_chunks_embedding;
+    UPDATE content_chunks SET embedding = NULL, embedded_at = NULL;
+    ALTER TABLE content_chunks
+      ALTER COLUMN embedding TYPE vector(${safeDimensions}) USING NULL;
+    CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);
+  `;
+}
+
+async function loadEngineConfig(engine: BrainEngine): Promise<EngineConfigMap> {
+  const keys = [
+    'embedding_provider',
+    'embedding_model',
+    'embedding_dimensions',
+    'embedding_base_url',
+    'ollama_base_url',
+  ];
+
+  const entries = await Promise.all(keys.map(async (key) => [key, await engine.getConfig(key)] as const));
+  return Object.fromEntries(entries);
+}
+
+function normalizeProvider(value: unknown): Provider {
+  return normalize(value).toLowerCase() === 'ollama' ? 'ollama' : 'openai';
+}
+
+function normalize(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function stringValue(value: unknown): string | undefined {
+  const normalized = normalize(value);
+  return normalized || undefined;
+}
+
+function numberValue(value: unknown): string | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? String(value) : undefined;
+}
+
+function normalizePositiveInt(value: unknown): number | undefined {
+  const normalized = normalize(value);
+  if (!normalized) return undefined;
+  const parsed = parseInt(normalized, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return parsed;
+}
+
+function normalizeBaseURL(value: unknown): string | undefined {
+  const normalized = normalize(value).replace(/\/+$/, '');
+  if (!normalized) return undefined;
+  if (normalized.startsWith('http://') || normalized.startsWith('https://')) return normalized;
+  return `http://${normalized}`;
+}
+
+export {
+  DEFAULT_OPENAI_MODEL,
+  DEFAULT_OPENAI_DIMENSIONS,
+  DEFAULT_OLLAMA_MODEL,
+  DEFAULT_OLLAMA_DIMENSIONS,
+  DEFAULT_OLLAMA_BASE_URL,
+};

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -8,60 +8,76 @@
  */
 
 import OpenAI from 'openai';
+import type { BrainEngine } from './engine.ts';
+import { resolveOpenAICredentials } from './openai-credentials.ts';
+import { resolveEmbeddingSettings } from './embedding-config.ts';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
 
-let client: OpenAI | null = null;
+let openAIClient: OpenAI | null = null;
+let openAIClientCacheKey = '';
 
-function getClient(): OpenAI {
-  if (!client) {
-    client = new OpenAI();
+async function getOpenAIClient(engine?: BrainEngine): Promise<{ client: OpenAI; model: string; dimensions: number }> {
+  const settings = await resolveEmbeddingSettings(engine);
+  const creds = resolveOpenAICredentials();
+  if (!creds) {
+    throw new Error('No OpenAI-compatible credentials found. Set OPENAI_API_KEY or authenticate Hermes/Codex first.');
   }
-  return client;
+
+  const cacheKey = `${creds.baseURL || ''}|${creds.apiKey}`;
+  if (!openAIClient || openAIClientCacheKey !== cacheKey) {
+    openAIClient = new OpenAI({
+      apiKey: creds.apiKey,
+      ...(creds.baseURL ? { baseURL: creds.baseURL } : {}),
+    });
+    openAIClientCacheKey = cacheKey;
+  }
+
+  return { client: openAIClient, model: settings.model, dimensions: settings.dimensions };
 }
 
-export async function embed(text: string): Promise<Float32Array> {
+export async function embed(text: string, engine?: BrainEngine): Promise<Float32Array> {
   const truncated = text.slice(0, MAX_CHARS);
-  const result = await embedBatch([truncated]);
+  const result = await embedBatch([truncated], engine);
   return result[0];
 }
 
-export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
+export async function embedBatch(texts: string[], engine?: BrainEngine): Promise<Float32Array[]> {
+  const settings = await resolveEmbeddingSettings(engine);
   const truncated = texts.map(t => t.slice(0, MAX_CHARS));
   const results: Float32Array[] = [];
 
-  // Process in batches of BATCH_SIZE
   for (let i = 0; i < truncated.length; i += BATCH_SIZE) {
     const batch = truncated.slice(i, i + BATCH_SIZE);
-    const batchResults = await embedBatchWithRetry(batch);
+    const batchResults = settings.provider === 'ollama'
+      ? await embedBatchWithOllama(batch, settings)
+      : await embedBatchWithOpenAI(batch, engine);
     results.push(...batchResults);
   }
 
   return results;
 }
 
-async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
+async function embedBatchWithOpenAI(texts: string[], engine?: BrainEngine): Promise<Float32Array[]> {
+  const { client, model, dimensions } = await getOpenAIClient(engine);
+
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const response = await getClient().embeddings.create({
-        model: MODEL,
+      const response = await client.embeddings.create({
+        model,
         input: texts,
-        dimensions: DIMENSIONS,
+        dimensions,
       });
 
-      // Sort by index to maintain order
       const sorted = response.data.sort((a, b) => a.index - b.index);
       return sorted.map(d => new Float32Array(d.embedding));
     } catch (e: unknown) {
       if (attempt === MAX_RETRIES - 1) throw e;
 
-      // Check for rate limit with Retry-After header
       let delay = exponentialDelay(attempt);
 
       if (e instanceof OpenAI.APIError && e.status === 429) {
@@ -78,8 +94,44 @@ async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
     }
   }
 
-  // Should not reach here
   throw new Error('Embedding failed after all retries');
+}
+
+async function embedBatchWithOllama(
+  texts: string[],
+  settings: Awaited<ReturnType<typeof resolveEmbeddingSettings>>,
+): Promise<Float32Array[]> {
+  const response = await fetch(`${settings.baseURL || 'http://127.0.0.1:11434'}/api/embed`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model: settings.model,
+      input: texts,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Ollama embeddings failed (${response.status}): ${body.slice(0, 400)}`);
+  }
+
+  const payload = await response.json() as { embeddings?: number[][]; embedding?: number[]; error?: string };
+  const rawEmbeddings = Array.isArray(payload.embeddings)
+    ? payload.embeddings
+    : Array.isArray(payload.embedding)
+      ? [payload.embedding]
+      : null;
+
+  if (!rawEmbeddings) {
+    throw new Error(`Ollama embeddings response missing embeddings array${payload.error ? `: ${payload.error}` : ''}`);
+  }
+
+  return rawEmbeddings.map((embedding, index) => {
+    if (embedding.length !== settings.dimensions) {
+      throw new Error(`Ollama embedding dimension mismatch for item ${index}: expected ${settings.dimensions}, got ${embedding.length}`);
+    }
+    return new Float32Array(embedding);
+  });
 }
 
 function exponentialDelay(attempt: number): number {
@@ -91,4 +143,4 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
+export { DEFAULT_OPENAI_MODEL as EMBEDDING_MODEL, DEFAULT_OPENAI_DIMENSIONS as EMBEDDING_DIMENSIONS } from './embedding-config.ts';

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -77,5 +77,6 @@ export interface BrainEngine {
 
   // Migration support
   runMigration(version: number, sql: string): Promise<void>;
+  getEmbeddingDimensions(): Promise<number | null>;
   getChunksWithEmbeddings(slug: string): Promise<Chunk[]>;
 }

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -3,6 +3,7 @@ import { createHash } from 'crypto';
 import type { BrainEngine } from './engine.ts';
 import { parseMarkdown } from './markdown.ts';
 import { chunkText } from './chunkers/recursive.ts';
+import { resolveEmbeddingSettings, ensureEmbeddingSchema } from './embedding-config.ts';
 import { embedBatch } from './embedding.ts';
 import type { ChunkInput } from './types.ts';
 
@@ -62,9 +63,12 @@ export async function importFromContent(
   // Embed BEFORE the transaction (external API call)
   if (!opts.noEmbed && chunks.length > 0) {
     try {
-      const embeddings = await embedBatch(chunks.map(c => c.chunk_text));
+      await ensureEmbeddingSchema(engine);
+      const settings = await resolveEmbeddingSettings(engine);
+      const embeddings = await embedBatch(chunks.map(c => c.chunk_text), engine);
       for (let i = 0; i < chunks.length; i++) {
         chunks[i].embedding = embeddings[i];
+        chunks[i].model = settings.model;
         chunks[i].token_count = Math.ceil(chunks[i].chunk_text.length / 4);
       }
     } catch { /* non-fatal */ }

--- a/src/core/openai-credentials.ts
+++ b/src/core/openai-credentials.ts
@@ -1,0 +1,107 @@
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+const DEFAULT_CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex';
+
+type EnvLike = Record<string, string | undefined>;
+
+export interface OpenAICredentials {
+  apiKey: string;
+  baseURL?: string;
+  source: 'env' | 'hermes-auth-store' | 'codex-cli';
+  authMode: 'api-key' | 'chatgpt';
+}
+
+export interface ResolveOpenAICredentialsOpts {
+  env?: EnvLike;
+  homeDir?: string;
+}
+
+export function resolveOpenAICredentials(opts: ResolveOpenAICredentialsOpts = {}): OpenAICredentials | null {
+  const env = opts.env || (process.env as EnvLike);
+  const homeDir = opts.homeDir || homedir();
+
+  const envApiKey = normalize(env.OPENAI_API_KEY);
+  if (envApiKey) {
+    return {
+      apiKey: envApiKey,
+      baseURL: normalizeBaseURL(env.OPENAI_BASE_URL),
+      source: 'env',
+      authMode: 'api-key',
+    };
+  }
+
+  const hermesCreds = readHermesCodexCredentials(homeDir, env);
+  if (hermesCreds) return hermesCreds;
+
+  return readCodexCliCredentials(homeDir, env);
+}
+
+export function hasOpenAICredentials(opts: ResolveOpenAICredentialsOpts = {}): boolean {
+  return !!resolveOpenAICredentials(opts);
+}
+
+function readHermesCodexCredentials(homeDir: string, env: EnvLike): OpenAICredentials | null {
+  const authPath = join(homeDir, '.hermes', 'auth.json');
+  const authStore = readJson(authPath);
+  const providers = authStore?.providers;
+  const codex = isRecord(providers) ? providers['openai-codex'] : null;
+  if (!isRecord(codex)) return null;
+
+  const tokens = codex.tokens;
+  if (!isRecord(tokens)) return null;
+
+  const accessToken = normalize(tokens.access_token);
+  if (!accessToken) return null;
+
+  return {
+    apiKey: accessToken,
+    baseURL: normalizeBaseURL(env.HERMES_CODEX_BASE_URL) || DEFAULT_CODEX_BASE_URL,
+    source: 'hermes-auth-store',
+    authMode: 'chatgpt',
+  };
+}
+
+function readCodexCliCredentials(homeDir: string, env: EnvLike): OpenAICredentials | null {
+  const codexHome = normalize(env.CODEX_HOME) || join(homeDir, '.codex');
+  const authPath = join(codexHome, 'auth.json');
+  const payload = readJson(authPath);
+  const tokens = payload?.tokens;
+  if (!isRecord(tokens)) return null;
+
+  const accessToken = normalize(tokens.access_token);
+  if (!accessToken) return null;
+
+  return {
+    apiKey: accessToken,
+    baseURL: normalizeBaseURL(env.HERMES_CODEX_BASE_URL) || DEFAULT_CODEX_BASE_URL,
+    source: 'codex-cli',
+    authMode: 'chatgpt',
+  };
+}
+
+function readJson(path: string): Record<string, any> | null {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    return isRecord(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalize(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeBaseURL(value: unknown): string | undefined {
+  const normalized = normalize(value).replace(/\/+$/, '');
+  return normalized || undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export { DEFAULT_CODEX_BASE_URL };

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -611,6 +611,22 @@ export class PGLiteEngine implements BrainEngine {
     await this.db.exec(sql);
   }
 
+  async getEmbeddingDimensions(): Promise<number | null> {
+    const { rows } = await this.db.query(
+      `SELECT format_type(a.atttypid, a.atttypmod) AS type
+       FROM pg_attribute a
+       JOIN pg_class c ON c.oid = a.attrelid
+       WHERE c.relname = 'content_chunks'
+         AND a.attname = 'embedding'
+         AND a.attnum > 0
+         AND NOT a.attisdropped`
+    );
+    if (rows.length === 0) return null;
+    const type = String((rows[0] as { type: string }).type || '');
+    const match = type.match(/vector\((\d+)\)/);
+    return match ? parseInt(match[1], 10) : null;
+  }
+
   async getChunksWithEmbeddings(slug: string): Promise<Chunk[]> {
     const { rows } = await this.db.query(
       `SELECT cc.* FROM content_chunks cc

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -629,6 +629,23 @@ export class PostgresEngine implements BrainEngine {
     await conn.unsafe(sqlStr);
   }
 
+  async getEmbeddingDimensions(): Promise<number | null> {
+    const conn = this.sql;
+    const rows = await conn`
+      SELECT format_type(a.atttypid, a.atttypmod) AS type
+      FROM pg_attribute a
+      JOIN pg_class c ON c.oid = a.attrelid
+      WHERE c.relname = 'content_chunks'
+        AND a.attname = 'embedding'
+        AND a.attnum > 0
+        AND NOT a.attisdropped
+    `;
+    if (rows.length === 0) return null;
+    const type = String(rows[0].type || '');
+    const match = type.match(/vector\((\d+)\)/);
+    return match ? parseInt(match[1], 10) : null;
+  }
+
   async getChunksWithEmbeddings(slug: string): Promise<Chunk[]> {
     const conn = this.sql;
     const rows = await conn`

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -9,6 +9,7 @@
 import type { BrainEngine } from '../engine.ts';
 import type { SearchResult, SearchOpts } from '../types.ts';
 import { embed } from '../embedding.ts';
+import { ensureEmbeddingSchema, hasEmbeddingSupport } from '../embedding-config.ts';
 import { dedupResults } from './dedup.ts';
 
 const RRF_K = 60;
@@ -28,10 +29,12 @@ export async function hybridSearch(
   // Run keyword search (always available, no API key needed)
   const keywordResults = await engine.searchKeyword(query, { limit: limit * 2 });
 
-  // Skip vector search entirely if no OpenAI key is configured
-  if (!process.env.OPENAI_API_KEY) {
+  // Skip vector search entirely if the active embedding provider is unavailable
+  if (!(await hasEmbeddingSupport(engine))) {
     return dedupResults(keywordResults).slice(0, limit);
   }
+
+  await ensureEmbeddingSchema(engine);
 
   // Determine query variants (optionally with expansion)
   let queries = [query];
@@ -47,7 +50,7 @@ export async function hybridSearch(
   // Embed all query variants and run vector search
   let vectorLists: SearchResult[][] = [];
   try {
-    const embeddings = await Promise.all(queries.map(q => embed(q)));
+    const embeddings = await Promise.all(queries.map(q => embed(q, engine)));
     vectorLists = await Promise.all(
       embeddings.map(emb => engine.searchVector(emb, { limit: limit * 2 })),
     );

--- a/test/embedding-config.test.ts
+++ b/test/embedding-config.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect } from 'bun:test';
+import { buildEmbeddingMigrationSql, resolveEmbeddingSettingsFromSources } from '../src/core/embedding-config.ts';
+
+describe('resolveEmbeddingSettingsFromSources', () => {
+  test('defaults to OpenAI settings when no overrides are present', () => {
+    const settings = resolveEmbeddingSettingsFromSources({ env: {} });
+
+    expect(settings).toEqual({
+      provider: 'openai',
+      model: 'text-embedding-3-large',
+      dimensions: 1536,
+      baseURL: undefined,
+    });
+  });
+
+  test('uses Ollama defaults when provider is ollama', () => {
+    const settings = resolveEmbeddingSettingsFromSources({
+      env: { GBRAIN_EMBEDDING_PROVIDER: 'ollama' },
+    });
+
+    expect(settings).toEqual({
+      provider: 'ollama',
+      model: 'nomic-embed-text',
+      dimensions: 768,
+      baseURL: 'http://127.0.0.1:11434',
+    });
+  });
+
+  test('engine config overrides provider/model/dimensions/base URL', () => {
+    const settings = resolveEmbeddingSettingsFromSources({
+      env: {},
+      engineConfig: {
+        embedding_provider: 'ollama',
+        embedding_model: 'mxbai-embed-large',
+        embedding_dimensions: '1024',
+        embedding_base_url: 'http://localhost:11434/',
+      },
+    });
+
+    expect(settings).toEqual({
+      provider: 'ollama',
+      model: 'mxbai-embed-large',
+      dimensions: 1024,
+      baseURL: 'http://localhost:11434',
+    });
+  });
+
+  test('environment variables win over engine config', () => {
+    const settings = resolveEmbeddingSettingsFromSources({
+      env: {
+        GBRAIN_EMBEDDING_PROVIDER: 'openai',
+        GBRAIN_EMBEDDING_MODEL: 'text-embedding-3-small',
+        GBRAIN_EMBEDDING_DIMENSIONS: '512',
+        GBRAIN_OPENAI_BASE_URL: 'https://example.com/v1/',
+      },
+      engineConfig: {
+        embedding_provider: 'ollama',
+        embedding_model: 'nomic-embed-text',
+        embedding_dimensions: '768',
+        embedding_base_url: 'http://localhost:11434',
+      },
+    });
+
+    expect(settings).toEqual({
+      provider: 'openai',
+      model: 'text-embedding-3-small',
+      dimensions: 512,
+      baseURL: 'https://example.com/v1',
+    });
+  });
+});
+
+describe('buildEmbeddingMigrationSql', () => {
+  test('rebuilds the embedding column and clears stale vectors', () => {
+    const sql = buildEmbeddingMigrationSql(768);
+
+    expect(sql).toContain('DROP INDEX IF EXISTS idx_chunks_embedding');
+    expect(sql).toContain('UPDATE content_chunks SET embedding = NULL, embedded_at = NULL');
+    expect(sql).toContain('ALTER TABLE content_chunks');
+    expect(sql).toContain('ALTER COLUMN embedding TYPE vector(768) USING NULL');
+    expect(sql).toContain('CREATE INDEX IF NOT EXISTS idx_chunks_embedding');
+  });
+});

--- a/test/embedding-schema.test.ts
+++ b/test/embedding-schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { ensureEmbeddingSchema } from '../src/core/embedding-config.ts';
+
+async function getEmbeddingColumnType(engine: PGLiteEngine): Promise<string> {
+  const result = await engine.db.query(`
+    SELECT format_type(a.atttypid, a.atttypmod) AS type
+    FROM pg_attribute a
+    JOIN pg_class c ON c.oid = a.attrelid
+    WHERE c.relname = 'content_chunks'
+      AND a.attname = 'embedding'
+      AND a.attnum > 0
+      AND NOT a.attisdropped
+  `);
+  return (result.rows[0] as { type: string }).type;
+}
+
+describe('ensureEmbeddingSchema', () => {
+  test('migrates the vector column when config dimensions changed ahead of the schema', async () => {
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+
+    expect(await getEmbeddingColumnType(engine)).toBe('vector(1536)');
+
+    await engine.setConfig('embedding_provider', 'ollama');
+    await engine.setConfig('embedding_model', 'nomic-embed-text');
+    await engine.setConfig('embedding_dimensions', '768');
+    await engine.setConfig('embedding_base_url', 'http://127.0.0.1:11434');
+
+    await ensureEmbeddingSchema(engine);
+
+    expect(await getEmbeddingColumnType(engine)).toBe('vector(768)');
+
+    await engine.disconnect();
+  });
+});

--- a/test/openai-credentials.test.ts
+++ b/test/openai-credentials.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { hasOpenAICredentials, resolveOpenAICredentials } from '../src/core/openai-credentials.ts';
+
+const DEFAULT_CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex';
+
+function withTempHome(run: (homeDir: string) => void) {
+  const homeDir = mkdtempSync(join(tmpdir(), 'gbrain-openai-creds-'));
+  try {
+    run(homeDir);
+  } finally {
+    rmSync(homeDir, { recursive: true, force: true });
+  }
+}
+
+describe('resolveOpenAICredentials', () => {
+  test('prefers OPENAI_API_KEY from env over oauth stores', () => {
+    withTempHome((homeDir) => {
+      mkdirSync(join(homeDir, '.hermes'), { recursive: true });
+      writeFileSync(join(homeDir, '.hermes', 'auth.json'), JSON.stringify({
+        version: 1,
+        providers: {
+          'openai-codex': {
+            tokens: {
+              access_token: 'oauth-access',
+              refresh_token: 'oauth-refresh',
+            },
+          },
+        },
+      }));
+
+      const creds = resolveOpenAICredentials({
+        env: {
+          OPENAI_API_KEY: 'sk-test',
+          OPENAI_BASE_URL: 'https://api.openai.com/v1/',
+        },
+        homeDir,
+      });
+
+      expect(creds).toEqual({
+        apiKey: 'sk-test',
+        baseURL: 'https://api.openai.com/v1',
+        source: 'env',
+        authMode: 'api-key',
+      });
+    });
+  });
+
+  test('falls back to Hermes openai-codex auth store', () => {
+    withTempHome((homeDir) => {
+      mkdirSync(join(homeDir, '.hermes'), { recursive: true });
+      writeFileSync(join(homeDir, '.hermes', 'auth.json'), JSON.stringify({
+        version: 1,
+        providers: {
+          'openai-codex': {
+            tokens: {
+              access_token: 'oauth-access',
+              refresh_token: 'oauth-refresh',
+            },
+            auth_mode: 'chatgpt',
+          },
+        },
+      }));
+
+      const creds = resolveOpenAICredentials({ env: {}, homeDir });
+
+      expect(creds).toEqual({
+        apiKey: 'oauth-access',
+        baseURL: DEFAULT_CODEX_BASE_URL,
+        source: 'hermes-auth-store',
+        authMode: 'chatgpt',
+      });
+      expect(hasOpenAICredentials({ env: {}, homeDir })).toBe(true);
+    });
+  });
+
+  test('falls back to Codex CLI auth.json when Hermes auth is absent', () => {
+    withTempHome((homeDir) => {
+      const codexHome = join(homeDir, 'custom-codex-home');
+      mkdirSync(codexHome, { recursive: true });
+      writeFileSync(join(codexHome, 'auth.json'), JSON.stringify({
+        tokens: {
+          access_token: 'cli-access',
+          refresh_token: 'cli-refresh',
+        },
+      }));
+
+      const creds = resolveOpenAICredentials({
+        env: { CODEX_HOME: codexHome },
+        homeDir,
+      });
+
+      expect(creds).toEqual({
+        apiKey: 'cli-access',
+        baseURL: DEFAULT_CODEX_BASE_URL,
+        source: 'codex-cli',
+        authMode: 'chatgpt',
+      });
+    });
+  });
+
+  test('returns null when no env key or oauth tokens exist', () => {
+    withTempHome((homeDir) => {
+      expect(resolveOpenAICredentials({ env: {}, homeDir })).toBeNull();
+      expect(hasOpenAICredentials({ env: {}, homeDir })).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- resolve OpenAI credentials from env, Hermes auth store, or Codex auth store
- add configurable embedding provider settings and Ollama embedding support
- auto-sync vector dimensions to the active embedding model and add regression tests

## Verification
- bun test
- bun run src/cli.ts embed --stale
- bun run src/cli.ts doctor --json

## Notes
- direct push to upstream was not permitted, so this PR comes from a fork
- local verification confirmed Ollama nomic-embed-text embeddings at 768 dimensions