### PR TITLE
fix: preserve CJK paths in gbrain sync (core.quotepath=false)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -163,7 +163,12 @@ export interface SyncOpts {
 }
 
 function git(repoPath: string, ...args: string[]): string {
-  return execFileSync('git', ['-C', repoPath, ...args], {
+  // `-c core.quotepath=false` keeps CJK / unicode paths in git diff/log output
+  // as-is (UTF-8) instead of the default double-quoted octal-escaped form
+  // (e.g. `"inbox/\350\256\260\345\275\225.md"`). Without this, filenames
+  // containing non-ASCII characters produce diff entries that don't match
+  // anything on disk, and gbrain sync silently drops them from the manifest.
+  return execFileSync('git', ['-c', 'core.quotepath=false', '-C', repoPath, ...args], {
     encoding: 'utf-8',
     timeout: 30000,
   }).trim();

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -54,6 +54,38 @@ describe('buildSyncManifest', () => {
     expect(manifest.added).toEqual(['people/a.md']);
     expect(manifest.modified).toEqual(['people/b.md']);
   });
+
+  // CJK / unicode path handling. The sync pipeline relies on `-c core.quotepath=false`
+  // being passed to the git call site (see src/commands/sync.ts git() helper) so
+  // these paths arrive here in UTF-8 instead of git's default double-quoted
+  // octal-escaped form (e.g. `"inbox/\350\256\260\345\275\225.md"`). Without
+  // that flag, the paths below would come in quoted+escaped, fail downstream
+  // filesystem lookups, and get silently dropped from the manifest.
+
+  test('preserves pure-CJK filenames (Chinese/Japanese/Korean)', () => {
+    const output = `A\tinbox/品牌圣经.md\nM\tinbox/ひらがな.md\nA\tinbox/한글.md`;
+    const manifest = buildSyncManifest(output);
+    expect(manifest.added).toEqual(['inbox/品牌圣经.md', 'inbox/한글.md']);
+    expect(manifest.modified).toEqual(['inbox/ひらがな.md']);
+  });
+
+  test('preserves CJK filenames with spaces (Apple Notes export pattern)', () => {
+    // Real-world example: Apple Notes exports files named like
+    // "2026-04-14 22_38 记录-个人智能体_原文.md" — spaces + CJK trigger
+    // git's path quoting unless core.quotepath=false is set.
+    const output = `A\tinbox/2026-04-14 22_38 记录-个人智能体_原文.md\nA\tinbox/2026-04-14 23_58 记录-人人都要龙虾群_原文.md`;
+    const manifest = buildSyncManifest(output);
+    expect(manifest.added).toEqual([
+      'inbox/2026-04-14 22_38 记录-个人智能体_原文.md',
+      'inbox/2026-04-14 23_58 记录-人人都要龙虾群_原文.md',
+    ]);
+  });
+
+  test('preserves CJK rename entries', () => {
+    const output = `R100\tinbox/旧名字.md\tinbox/新名字.md`;
+    const manifest = buildSyncManifest(output);
+    expect(manifest.renamed).toEqual([{ from: 'inbox/旧名字.md', to: 'inbox/新名字.md' }]);
+  });
 });
 
 describe('isSyncable', () => {


### PR DESCRIPTION
## Summary

`gbrain sync` silently drops files with non-ASCII names from the sync manifest. Git's default `diff --name-status` output wraps CJK/unicode paths in double quotes with octal byte escapes:

```
A	\"inbox/2026-04-14 22_38 \350\256\260\345\275\225.md\"
```

`buildSyncManifest` treats that entire string as the literal path, downstream filesystem lookups fail, and the file is silently dropped. The user sees `added: 0, chunksCreated: 0` in the sync result even though git has the file committed, and `gbrain search` can't find the content. The cron log reports success because nothing technically errored.

This is the sync-layer counterpart to the same CJK root cause class fixed in #98 (query expansion), #114 (chunker), and #115 (slugify): ASCII-only assumptions baked into a fourth part of the codebase.

## Reproduction

```bash
mkdir /tmp/brain && cd /tmp/brain && git init
gbrain init
echo \"# test content\" > \"inbox/测试文件.md\"
git add . && git commit -m \"add test\"
gbrain sync --repo .
# → Output: { \"added\": 0, \"chunksCreated\": 0 }     ← bug
# → But `git log --stat` clearly shows the file was added.
# → `gbrain list` shows no new page; `gbrain search \"测试\"` returns nothing.
```

Real-world case: Apple Notes exports produce names like `2026-04-14 22_38 记录-个人智能体_原文.md` — the space + CJK combo guarantees git quoting, and those files never make it into the brain via the live-sync cron.

## Fix

One-line change to the `git()` helper in `src/commands/sync.ts`: prepend `-c core.quotepath=false` before the subcommand.

```ts
// before
execFileSync('git', ['-C', repoPath, ...args], ...)

// after
execFileSync('git', ['-c', 'core.quotepath=false', '-C', repoPath, ...args], ...)
```

`core.quotepath=false` tells git to emit paths as-is (UTF-8) in diff/log output. Setting it at the helper level means all current and future git invocations through this code path are covered — not just `diff`.

## Impact

- **2 files changed**, **+38 / -1 lines** (1-line code fix + explanatory comment + 3 tests)
- **Zero behavior change for ASCII-only paths** (same flag, same output format)
- **CJK filenames — with or without spaces — now sync correctly**
- Unblocks Chinese/Japanese/Korean users whose incremental sync has been silently partial
- Also fixes Apple Notes export (spaces + CJK) which is a common ingest pattern

## Test plan

- [x] 3 new tests in `test/sync.test.ts`:
  - Pure CJK filenames (Chinese Han, Japanese Hiragana, Korean Hangul)
  - CJK filenames with spaces (Apple Notes export pattern)
  - CJK rename entries
- [x] All 35 sync tests pass (32 existing + 3 new)
- [x] Full `bun test` suite runs clean — no new regressions (the 4 pre-existing `PGLiteEngine` failures are unrelated and exist on `master`)

## Note on manual workaround

Existing users affected by this bug can recover by running `gbrain sync --full` once, which uses a filesystem walker instead of git-diff parsing and correctly picks up all CJK files. After this PR lands, incremental sync handles them natively.

Third in the CJK series after #114 (chunker) and #115 (slugify). All three are independent, small, and can merge in any order.