### PR TITLE
feat: replace split Google recipes with unified google-tools-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ The whole loop is described in [`docs/architecture/topologies.md`](docs/architec
 
 Data flowing into the brain. Each integration is a recipe — markdown + setup hints — that ships in `recipes/` and is discoverable via `gbrain integrations list`.
 
+- **Google Workspace**: Gmail, Calendar, Drive, Docs, Sheets, Forms, Slides via unified MCP (153 tools). Setup recipe: [`recipes/google-tools-mcp.md`](recipes/google-tools-mcp.md). *Replaces the deprecated credential-gateway, email-to-brain, and calendar-to-brain recipes.*
 - **Voice**: Phone calls create brain pages via Twilio + OpenAI Realtime (or DIY STT+LLM+TTS). Setup recipe: [`recipes/twilio-voice-brain.md`](recipes/twilio-voice-brain.md).
 - **Email + calendar**: webhook handlers that route to brain signals. [`docs/integrations/meeting-webhooks.md`](docs/integrations/meeting-webhooks.md).
 - **Embedding providers**: 14 recipes covering OpenAI (default fallback), Voyage, ZeroEntropy (default), Google Gemini, Azure OpenAI, MiniMax, Alibaba DashScope, Zhipu, Ollama (local), llama.cpp llama-server (local), LiteLLM proxy. Pricing matrix + decision tree in [`docs/integrations/embedding-providers.md`](docs/integrations/embedding-providers.md).
-- **Credential gateway**: vault-aware secret distribution. [`docs/integrations/credential-gateway.md`](docs/integrations/credential-gateway.md).
 - **MCP clients**: every major MCP client is supported. [`docs/mcp/`](docs/mcp/) per-client setup.
 
 ## Architecture

--- a/docs/GBRAIN_SKILLPACK.md
+++ b/docs/GBRAIN_SKILLPACK.md
@@ -85,12 +85,13 @@ Wiring up your life.
 
 | Guide | What It Covers |
 |-------|---------------|
-| [Credential Gateway](integrations/credential-gateway.md) | ClawVisor / Hermes for Gmail, Calendar, Contacts |
+| [Google Tools MCP](../recipes/google-tools-mcp.md) | Unified Google Workspace — Gmail, Calendar, Drive, Docs, Sheets, Forms, Slides via MCP (153 tools). Replaces credential-gateway + email-to-brain + calendar-to-brain |
+| ~~[Credential Gateway](integrations/credential-gateway.md)~~ | ~~ClawVisor / Hermes for Gmail, Calendar, Contacts~~ *Deprecated — use Google Tools MCP* |
 | [Meeting & Call Webhooks](integrations/meeting-webhooks.md) | Circleback transcripts + Quo/OpenPhone SMS/calls |
 | [Voice-to-Brain](../recipes/twilio-voice-brain.md) | Phone calls + WebRTC browser calls create brain pages. 25 production patterns: identity separation, bid system, conversation timing, proactive advisor, prompt compression, caller routing, dynamic VAD, real-time logging, belt-and-suspenders post-call |
-| [Email-to-Brain](../recipes/email-to-brain.md) | Gmail messages flow into entity pages via deterministic collector |
+| ~~[Email-to-Brain](../recipes/email-to-brain.md)~~ | ~~Gmail messages flow into entity pages via deterministic collector~~ *Deprecated — use Google Tools MCP* |
 | [X-to-Brain](../recipes/x-to-brain.md) | Twitter monitoring with deletion detection + engagement velocity |
-| [Calendar-to-Brain](../recipes/calendar-to-brain.md) | Google Calendar events become searchable daily brain pages |
+| ~~[Calendar-to-Brain](../recipes/calendar-to-brain.md)~~ | ~~Google Calendar events become searchable daily brain pages~~ *Deprecated — use Google Tools MCP* |
 | [Meeting Sync](../recipes/meeting-sync.md) | Circleback transcripts auto-import with attendee propagation |
 
 ## Administration

--- a/docs/designs/HOMEBREW_FOR_PERSONAL_AI.md
+++ b/docs/designs/HOMEBREW_FOR_PERSONAL_AI.md
@@ -76,12 +76,14 @@ setup. If voice-to-brain requires credential-gateway, the agent sets up
 credential-gateway first.
 
 ```
-credential-gateway
-  ├── voice-to-brain (requires credentials for Twilio)
-  ├── email-to-brain (requires credentials for Gmail)
-  └── calendar-to-brain (requires credentials for Google Calendar)
+google-tools-mcp (Gmail, Calendar, Drive, Docs, Sheets, Forms, Slides)
+  │
+  └── (no dependencies — single OAuth, self-contained)
 
-x-to-brain (standalone, uses X API directly)
+# Legacy (deprecated):
+# credential-gateway
+#   ├── email-to-brain
+#   └── calendar-to-brain
 ```
 
 ### Health Dashboard

--- a/docs/guides/cron-schedule.md
+++ b/docs/guides/cron-schedule.md
@@ -18,10 +18,10 @@ fixed. You wake up and the brain is smarter than when you went to sleep.
 
 | Frequency | Job | Brain Interaction | Recipe |
 |-----------|-----|-------------------|--------|
-| On demand | Email monitoring | `list_messages` + `get_message` via google-tools-mcp, then entity enrichment | [google-tools-mcp](../../recipes/google-tools-mcp.md) |
+| Every 30 min | Email monitoring | Search sender, update people pages | [google-tools-mcp](../../recipes/google-tools-mcp.md) |
 | Every 30 min | X/Twitter collection | Create/update media pages, entity extraction | [x-to-brain](../../recipes/x-to-brain.md) |
 | 3x/day (weekdays) | Meeting sync | Full ingestion + attendee propagation | [meeting-sync](../../recipes/meeting-sync.md) |
-| On demand | Calendar context | `get_events` via google-tools-mcp, attendee enrichment | [google-tools-mcp](../../recipes/google-tools-mcp.md) |
+| Weekly | Calendar sync | Daily files + attendee enrichment | [google-tools-mcp](../../recipes/google-tools-mcp.md) |
 | Daily AM | Morning briefing | Search calendar attendees, deal status, active threads | [briefing skill](../../skills/briefing/SKILL.md) |
 | Weekly | Brain maintenance | `gbrain doctor`, embed stale, orphan detection | [maintain skill](../../skills/maintain/SKILL.md) |
 | Nightly | Dream cycle | Entity sweep, enrich thin spots, fix citations | See below |
@@ -29,14 +29,17 @@ fixed. You wake up and the brain is smarter than when you went to sleep.
 ## Implementation: Setting Up Cron Jobs
 
 ```bash
-# Email + Calendar: now handled on-demand via google-tools-mcp MCP tools
-# (list_messages, get_message, get_events, etc.) — no cron needed
+# Email collector — every 30 minutes
+*/30 * * * * cd /path/to/email-collector && node email-collector.mjs collect && node email-collector.mjs digest
 
 # X/Twitter collector — every 30 minutes
 */30 * * * * cd /path/to/x-collector && node x-collector.mjs collect >> /tmp/x-collector.log 2>&1
 
 # Meeting sync — 10 AM, 4 PM, 9 PM on weekdays
 0 10,16,21 * * 1-5 cd /path/to/meeting-sync && node meeting-sync.mjs >> /tmp/meeting-sync.log 2>&1
+
+# Calendar sync — Sundays at 10 AM
+0 10 * * 0 cd /path/to/calendar-sync && node calendar-sync.mjs --start $(date -v-7d +%Y-%m-%d) --end $(date +%Y-%m-%d)
 
 # Brain health — weekly Mondays at 6 AM
 0 6 * * 1 gbrain doctor --json >> /tmp/gbrain-health.log 2>&1 && gbrain embed --stale
@@ -181,7 +184,7 @@ echo "Dream cycle complete at $(date)"
    Verify output went to `/tmp/cron-held/`, not to messaging.
 2. **Dream cycle:** Run the dream cycle manually. Check that thin entity pages
    got enriched and broken citations were fixed.
-3. **Email access:** Call `list_messages` via google-tools-mcp. Verify recent emails returned.
+3. **Email collector cron:** Wait 30 minutes. Check `data/digests/` for new digest.
 4. **Morning briefing:** Check that held messages appear in the briefing.
 5. **Health check:** Run `gbrain doctor --json`. All checks should pass.
 

--- a/docs/guides/cron-schedule.md
+++ b/docs/guides/cron-schedule.md
@@ -18,10 +18,10 @@ fixed. You wake up and the brain is smarter than when you went to sleep.
 
 | Frequency | Job | Brain Interaction | Recipe |
 |-----------|-----|-------------------|--------|
-| Every 30 min | Email monitoring | Search sender, update people pages | [email-to-brain](../../recipes/email-to-brain.md) |
+| On demand | Email monitoring | `list_messages` + `get_message` via google-tools-mcp, then entity enrichment | [google-tools-mcp](../../recipes/google-tools-mcp.md) |
 | Every 30 min | X/Twitter collection | Create/update media pages, entity extraction | [x-to-brain](../../recipes/x-to-brain.md) |
 | 3x/day (weekdays) | Meeting sync | Full ingestion + attendee propagation | [meeting-sync](../../recipes/meeting-sync.md) |
-| Weekly | Calendar sync | Daily files + attendee enrichment | [calendar-to-brain](../../recipes/calendar-to-brain.md) |
+| On demand | Calendar context | `get_events` via google-tools-mcp, attendee enrichment | [google-tools-mcp](../../recipes/google-tools-mcp.md) |
 | Daily AM | Morning briefing | Search calendar attendees, deal status, active threads | [briefing skill](../../skills/briefing/SKILL.md) |
 | Weekly | Brain maintenance | `gbrain doctor`, embed stale, orphan detection | [maintain skill](../../skills/maintain/SKILL.md) |
 | Nightly | Dream cycle | Entity sweep, enrich thin spots, fix citations | See below |
@@ -29,17 +29,14 @@ fixed. You wake up and the brain is smarter than when you went to sleep.
 ## Implementation: Setting Up Cron Jobs
 
 ```bash
-# Email collector — every 30 minutes
-*/30 * * * * cd /path/to/email-collector && node email-collector.mjs collect && node email-collector.mjs digest
+# Email + Calendar: now handled on-demand via google-tools-mcp MCP tools
+# (list_messages, get_message, get_events, etc.) — no cron needed
 
 # X/Twitter collector — every 30 minutes
 */30 * * * * cd /path/to/x-collector && node x-collector.mjs collect >> /tmp/x-collector.log 2>&1
 
 # Meeting sync — 10 AM, 4 PM, 9 PM on weekdays
 0 10,16,21 * * 1-5 cd /path/to/meeting-sync && node meeting-sync.mjs >> /tmp/meeting-sync.log 2>&1
-
-# Calendar sync — Sundays at 10 AM
-0 10 * * 0 cd /path/to/calendar-sync && node calendar-sync.mjs --start $(date -v-7d +%Y-%m-%d) --end $(date +%Y-%m-%d)
 
 # Brain health — weekly Mondays at 6 AM
 0 6 * * 1 gbrain doctor --json >> /tmp/gbrain-health.log 2>&1 && gbrain embed --stale
@@ -184,7 +181,7 @@ echo "Dream cycle complete at $(date)"
    Verify output went to `/tmp/cron-held/`, not to messaging.
 2. **Dream cycle:** Run the dream cycle manually. Check that thin entity pages
    got enriched and broken citations were fixed.
-3. **Email collector cron:** Wait 30 minutes. Check `data/digests/` for new digest.
+3. **Email access:** Call `list_messages` via google-tools-mcp. Verify recent emails returned.
 4. **Morning briefing:** Check that held messages appear in the briefing.
 5. **Health check:** Run `gbrain doctor --json`. All checks should pass.
 

--- a/docs/guides/cron-schedule.md
+++ b/docs/guides/cron-schedule.md
@@ -16,30 +16,31 @@ fixed. You wake up and the brain is smarter than when you went to sleep.
 
 ## The Schedule
 
+**Cron-triggered jobs:**
+
 | Frequency | Job | Brain Interaction | Recipe |
 |-----------|-----|-------------------|--------|
-| Every 30 min | Email monitoring | Search sender, update people pages | [google-tools-mcp](../../recipes/google-tools-mcp.md) |
 | Every 30 min | X/Twitter collection | Create/update media pages, entity extraction | [x-to-brain](../../recipes/x-to-brain.md) |
 | 3x/day (weekdays) | Meeting sync | Full ingestion + attendee propagation | [meeting-sync](../../recipes/meeting-sync.md) |
-| Weekly | Calendar sync | Daily files + attendee enrichment | [google-tools-mcp](../../recipes/google-tools-mcp.md) |
 | Daily AM | Morning briefing | Search calendar attendees, deal status, active threads | [briefing skill](../../skills/briefing/SKILL.md) |
 | Weekly | Brain maintenance | `gbrain doctor`, embed stale, orphan detection | [maintain skill](../../skills/maintain/SKILL.md) |
 | Nightly | Dream cycle | Entity sweep, enrich thin spots, fix citations | See below |
 
+**On-demand via MCP (no cron needed):**
+
+| Trigger | Job | Brain Interaction | Recipe |
+|---------|-----|-------------------|--------|
+| On demand | Email access | Search sender, update people pages | [google-tools-mcp](../../recipes/google-tools-mcp.md) |
+| On demand | Calendar access | Attendee enrichment, event management | [google-tools-mcp](../../recipes/google-tools-mcp.md) |
+
 ## Implementation: Setting Up Cron Jobs
 
 ```bash
-# Email collector — every 30 minutes
-*/30 * * * * cd /path/to/email-collector && node email-collector.mjs collect && node email-collector.mjs digest
-
 # X/Twitter collector — every 30 minutes
 */30 * * * * cd /path/to/x-collector && node x-collector.mjs collect >> /tmp/x-collector.log 2>&1
 
 # Meeting sync — 10 AM, 4 PM, 9 PM on weekdays
 0 10,16,21 * * 1-5 cd /path/to/meeting-sync && node meeting-sync.mjs >> /tmp/meeting-sync.log 2>&1
-
-# Calendar sync — Sundays at 10 AM
-0 10 * * 0 cd /path/to/calendar-sync && node calendar-sync.mjs --start $(date -v-7d +%Y-%m-%d) --end $(date +%Y-%m-%d)
 
 # Brain health — weekly Mondays at 6 AM
 0 6 * * 1 gbrain doctor --json >> /tmp/gbrain-health.log 2>&1 && gbrain embed --stale
@@ -47,6 +48,9 @@ fixed. You wake up and the brain is smarter than when you went to sleep.
 # Dream cycle — nightly at 2 AM
 0 2 * * * /path/to/dream-cycle.sh
 ```
+
+> **Note:** Email and Calendar no longer need cron jobs. Use `google-tools-mcp` MCP tools
+> (`list_messages`, `get_events`, etc.) on demand from any agent session.
 
 ### Quiet Hours Gate (MANDATORY)
 

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -28,13 +28,14 @@ These are integration recipes your agent can set up for you. Run
 
 | Recipe | Category | Requires | What It Does | Setup Time |
 |--------|----------|----------|-------------|------------|
+| [google-tools-mcp](../../recipes/google-tools-mcp.md) | Infra | — | **Unified Google Workspace** — Gmail, Calendar, Drive, Docs, Sheets, Forms, Slides via MCP (153 tools) | 5 min |
 | [ngrok-tunnel](../../recipes/ngrok-tunnel.md) | Infra | — | Fixed public URL for MCP + voice ($8/mo) | 10 min |
-| [credential-gateway](../../recipes/credential-gateway.md) | Infra | — | Gmail + Calendar access (ClawVisor or Google OAuth) | 15 min |
 | [voice-to-brain](../../recipes/twilio-voice-brain.md) | Sense | ngrok-tunnel | Phone calls create brain pages via Twilio + OpenAI Realtime | 30 min |
-| [email-to-brain](../../recipes/email-to-brain.md) | Sense | credential-gateway | Gmail messages flow into entity pages via deterministic collector | 20 min |
 | [x-to-brain](../../recipes/x-to-brain.md) | Sense | — | Twitter timeline, mentions, keyword monitoring with deletion detection | 15 min |
-| [calendar-to-brain](../../recipes/calendar-to-brain.md) | Sense | credential-gateway | Google Calendar events become searchable daily brain pages | 20 min |
 | [meeting-sync](../../recipes/meeting-sync.md) | Sense | — | Circleback meeting transcripts auto-import with attendee propagation | 15 min |
+| ~~[credential-gateway](../../recipes/credential-gateway.md)~~ | ~~Infra~~ | — | ~~Gmail + Calendar access~~ *Deprecated — use google-tools-mcp* | — |
+| ~~[email-to-brain](../../recipes/email-to-brain.md)~~ | ~~Sense~~ | — | ~~Gmail collector~~ *Deprecated — use google-tools-mcp* | — |
+| ~~[calendar-to-brain](../../recipes/calendar-to-brain.md)~~ | ~~Sense~~ | — | ~~Calendar sync~~ *Deprecated — use google-tools-mcp* | — |
 
 ### Manual Integration Guides
 

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -34,8 +34,8 @@ These are integration recipes your agent can set up for you. Run
 | [x-to-brain](../../recipes/x-to-brain.md) | Sense | — | Twitter timeline, mentions, keyword monitoring with deletion detection | 15 min |
 | [meeting-sync](../../recipes/meeting-sync.md) | Sense | — | Circleback meeting transcripts auto-import with attendee propagation | 15 min |
 | ~~[credential-gateway](../../recipes/credential-gateway.md)~~ | ~~Infra~~ | — | ~~Gmail + Calendar access~~ *Deprecated — use google-tools-mcp* | — |
-| ~~[email-to-brain](../../recipes/email-to-brain.md)~~ | ~~Sense~~ | — | ~~Gmail collector~~ *Deprecated — use google-tools-mcp* | — |
-| ~~[calendar-to-brain](../../recipes/calendar-to-brain.md)~~ | ~~Sense~~ | — | ~~Calendar sync~~ *Deprecated — use google-tools-mcp* | — |
+| ~~[email-to-brain](../../recipes/email-to-brain.md)~~ | ~~Sense~~ | credential-gateway | ~~Gmail collector~~ *Deprecated — use google-tools-mcp* | — |
+| ~~[calendar-to-brain](../../recipes/calendar-to-brain.md)~~ | ~~Sense~~ | credential-gateway | ~~Calendar sync~~ *Deprecated — use google-tools-mcp* | — |
 
 ### Manual Integration Guides
 

--- a/docs/integrations/credential-gateway.md
+++ b/docs/integrations/credential-gateway.md
@@ -1,3 +1,6 @@
+> **DEPRECATED:** See [google-tools-mcp](../../recipes/google-tools-mcp.md) for
+> the recommended Google Workspace setup.
+
 # Credential Gateway (ClawVisor / Hermes)
 
 

--- a/recipes/calendar-to-brain.md
+++ b/recipes/calendar-to-brain.md
@@ -2,7 +2,7 @@
 id: calendar-to-brain
 name: Calendar-to-Brain
 version: 0.7.0
-description: Google Calendar events become searchable brain pages. Daily files with attendees, locations, and meeting prep context.
+description: "[DEPRECATED — use google-tools-mcp] Google Calendar events become searchable brain pages. Daily files with attendees, locations, and meeting prep context."
 category: sense
 requires: [credential-gateway]
 secrets:
@@ -31,6 +31,12 @@ health_checks:
 setup_time: 20 min
 cost_estimate: "$0 (both options are free)"
 ---
+
+> **DEPRECATED:** This recipe is superseded by [google-tools-mcp](google-tools-mcp.md),
+> which provides Calendar access (8 tools including create/update/delete events, free/busy,
+> recurring instances) as part of a unified Google Workspace MCP server. No custom sync
+> scripts or cron jobs needed. See [google-tools-mcp](google-tools-mcp.md). This recipe
+> remains available for users who prefer the deterministic collector with historical backfill.
 
 # Calendar-to-Brain: Your Schedule Becomes Searchable Memory
 

--- a/recipes/credential-gateway.md
+++ b/recipes/credential-gateway.md
@@ -2,7 +2,7 @@
 id: credential-gateway
 name: Credential Gateway
 version: 0.7.0
-description: Secure access to Gmail, Google Calendar, and other Google services. ClawVisor (recommended) or direct Google OAuth.
+description: "[DEPRECATED — use google-tools-mcp] Secure access to Gmail, Google Calendar, and other Google services. ClawVisor (recommended) or direct Google OAuth."
 category: infra
 requires: []
 secrets:
@@ -31,6 +31,12 @@ health_checks:
 setup_time: 15 min
 cost_estimate: "$0 (both options are free)"
 ---
+
+> **DEPRECATED:** This recipe is superseded by [google-tools-mcp](google-tools-mcp.md),
+> which provides unified access to Gmail, Calendar, Drive, Docs, Sheets, Forms, and
+> Slides with a single OAuth flow and 153 tools. See [google-tools-mcp](google-tools-mcp.md)
+> for the recommended setup. This recipe remains available for users who prefer
+> ClawVisor or need the legacy approach.
 
 # Credential Gateway: Secure Access to Google Services
 

--- a/recipes/email-to-brain.md
+++ b/recipes/email-to-brain.md
@@ -2,7 +2,7 @@
 id: email-to-brain
 name: Email-to-Brain
 version: 0.7.0
-description: Gmail messages flow into brain pages. Deterministic collector pulls emails, agent analyzes and enriches entities.
+description: "[DEPRECATED — use google-tools-mcp] Gmail messages flow into brain pages. Deterministic collector pulls emails, agent analyzes and enriches entities."
 category: sense
 requires: [credential-gateway]
 secrets:
@@ -31,6 +31,12 @@ health_checks:
 setup_time: 20 min
 cost_estimate: "$0 (both options are free)"
 ---
+
+> **DEPRECATED:** This recipe is superseded by [google-tools-mcp](google-tools-mcp.md),
+> which provides Gmail access (69 tools including send, read, drafts, labels, filters,
+> threads) as part of a unified Google Workspace MCP server. No custom collector scripts
+> or cron jobs needed. See [google-tools-mcp](google-tools-mcp.md). This recipe remains
+> available for users who prefer the deterministic collector pattern with ClawVisor.
 
 # Email-to-Brain: Gmail Messages That Update Your Brain
 

--- a/recipes/google-tools-mcp.md
+++ b/recipes/google-tools-mcp.md
@@ -5,23 +5,20 @@ version: 1.0.0
 description: Unified Google Workspace access via MCP — Gmail, Calendar, Drive, Docs, Sheets, Forms, and Slides. 153 tools, single OAuth, one-command install. Replaces credential-gateway + email-to-brain + calendar-to-brain.
 category: infra
 requires: []
-secrets:
-  - name: GOOGLE_CLIENT_ID
-    description: Google OAuth2 client ID for google-tools-mcp
-    where: https://console.cloud.google.com/apis/credentials — create OAuth 2.0 Client ID (Desktop app)
-  - name: GOOGLE_CLIENT_SECRET
-    description: Google OAuth2 client secret for google-tools-mcp
-    where: https://console.cloud.google.com/apis/credentials — same page as client ID
+secrets: []
 health_checks:
   - type: command
     argv: ["npx", "-y", "google-tools-mcp", "--help"]
     label: "google-tools-mcp available"
   - type: any_of
-    label: "Google OAuth credentials"
+    label: "Google OAuth credentials configured"
     checks:
       - type: env_exists
         name: GOOGLE_CLIENT_ID
-        label: "GOOGLE_CLIENT_ID"
+        label: "GOOGLE_CLIENT_ID (env var)"
+      - type: command
+        argv: ["sh", "-c", "test -f \"/c/Users/2supe/.config/google-tools-mcp/credentials.json\" || test -f \"/c/Users/2supe/.config/google-tools-mcp/.env\""]
+        label: "google-tools-mcp credentials file"
 setup_time: 5 min
 cost_estimate: "$0 (Google APIs free tier)"
 ---
@@ -60,16 +57,16 @@ detection, brain enrichment, classification) is unchanged.
 
 ## What You Get
 
-| Service | Tool Count | Key Tools |
-|---------|-----------|-----------|
-| Gmail | 69 | `list_messages`, `get_message`, `send_message`, `reply_message`, `create_draft`, `list_threads`, `get_thread`, `list_labels`, `create_filter` |
-| Calendar | 8 | `get_events`, `list_calendars`, `manage_event`, `get_busy`, `get_free`, `move_event` |
-| Drive | 18 | `listDriveFiles`, `searchDocuments`, `getFileInfo`, `downloadFile`, `readFile`, `uploadFile`, `createFolder`, `moveFile` |
-| Docs | 22 | `readDocument`, `appendText`, `modifyText`, `insertTable`, `appendMarkdown`, `replaceDocumentWithMarkdown`, `addComment` |
-| Sheets | 29 | `readSpreadsheet`, `writeSpreadsheet`, `appendRows`, `createSpreadsheet`, `formatCells`, `insertChart` |
-| Forms | 6 | `create_form`, `get_form`, `batch_update_form`, `list_form_responses` |
-| Slides | 16 | `createPresentation`, `getPresentation`, `createSlidesTextBox`, `updateSpeakerNotes` |
-| Utility | 3 | `help`, `troubleshoot`, `feedback` |
+| Service | Key Tools |
+|---------|-----------|
+| Gmail | `list_messages`, `get_message`, `send_message`, `reply_message`, `create_draft`, `list_threads`, `get_thread`, `list_labels`, `create_filter` |
+| Calendar | `get_events`, `list_calendars`, `manage_event`, `get_busy`, `get_free`, `move_event` |
+| Drive | `listDriveFiles`, `searchDocuments`, `getFileInfo`, `downloadFile`, `readFile`, `uploadFile`, `createFolder`, `moveFile` |
+| Docs | `readDocument`, `appendText`, `modifyText`, `insertTable`, `appendMarkdown`, `replaceDocumentWithMarkdown`, `addComment` |
+| Sheets | `readSpreadsheet`, `writeSpreadsheet`, `appendRows`, `createSpreadsheet`, `formatCells`, `insertChart` |
+| Forms | `create_form`, `get_form`, `batch_update_form`, `list_form_responses` |
+| Slides | `createPresentation`, `getPresentation`, `createSlidesTextBox`, `updateSpeakerNotes` |
+| Utility | `help`, `troubleshoot`, `feedback` |
 
 **Total: 153 tools.** All available the moment the server starts.
 

--- a/recipes/google-tools-mcp.md
+++ b/recipes/google-tools-mcp.md
@@ -1,0 +1,371 @@
+---
+id: google-tools-mcp
+name: Google Tools MCP
+version: 1.0.0
+description: Unified Google Workspace access via MCP — Gmail, Calendar, Drive, Docs, Sheets, Forms, and Slides. 153 tools, single OAuth, one-command install. Replaces credential-gateway + email-to-brain + calendar-to-brain.
+category: infra
+requires: []
+secrets:
+  - name: GOOGLE_CLIENT_ID
+    description: Google OAuth2 client ID for google-tools-mcp
+    where: https://console.cloud.google.com/apis/credentials — create OAuth 2.0 Client ID (Desktop app)
+  - name: GOOGLE_CLIENT_SECRET
+    description: Google OAuth2 client secret for google-tools-mcp
+    where: https://console.cloud.google.com/apis/credentials — same page as client ID
+health_checks:
+  - type: command
+    argv: ["npx", "-y", "google-tools-mcp", "--help"]
+    label: "google-tools-mcp available"
+  - type: any_of
+    label: "Google OAuth credentials"
+    checks:
+      - type: env_exists
+        name: GOOGLE_CLIENT_ID
+        label: "GOOGLE_CLIENT_ID"
+setup_time: 5 min
+cost_estimate: "$0 (Google APIs free tier)"
+---
+
+# Google Tools MCP: All of Google Workspace in One MCP Server
+
+One MCP server. One OAuth login. 153 tools across Gmail, Calendar, Drive, Docs,
+Sheets, Forms, and Slides. Read AND write. No custom collector scripts, no cron
+jobs, no credential gateway.
+
+This recipe replaces `credential-gateway`, `email-to-brain`, and
+`calendar-to-brain`. If you have those set up, see "Migrating from Split Recipes"
+below.
+
+## IMPORTANT: Instructions for the Agent
+
+**You are the installer.** Follow these steps precisely. Verify after each step.
+
+**What this replaces:**
+- `credential-gateway` — google-tools-mcp handles its own OAuth. No ClawVisor
+  dependency, no manual token management, no competing auth paths.
+- `email-to-brain` — instead of a custom Node.js collector that paginates Gmail
+  and produces digests, call `list_messages` / `get_message` / `list_threads`
+  directly via MCP tools.
+- `calendar-to-brain` — instead of a custom sync script, call `get_events` /
+  `list_calendars` directly via MCP tools.
+
+**What this does NOT replace:**
+- `meeting-sync` (Circleback) — unaffected, continues independently.
+- `x-to-brain` (Twitter) — unaffected.
+- `voice-to-brain` (Twilio) — unaffected.
+
+**The core pattern is preserved:** MCP tools ARE the deterministic data layer.
+They handle pagination, auth, and API calls reliably. Your judgment role (entity
+detection, brain enrichment, classification) is unchanged.
+
+## What You Get
+
+| Service | Tool Count | Key Tools |
+|---------|-----------|-----------|
+| Gmail | 69 | `list_messages`, `get_message`, `send_message`, `reply_message`, `create_draft`, `list_threads`, `get_thread`, `list_labels`, `create_filter` |
+| Calendar | 8 | `get_events`, `list_calendars`, `manage_event`, `get_busy`, `get_free`, `move_event` |
+| Drive | 18 | `listDriveFiles`, `searchDocuments`, `getFileInfo`, `downloadFile`, `readFile`, `uploadFile`, `createFolder`, `moveFile` |
+| Docs | 22 | `readDocument`, `appendText`, `modifyText`, `insertTable`, `appendMarkdown`, `replaceDocumentWithMarkdown`, `addComment` |
+| Sheets | 29 | `readSpreadsheet`, `writeSpreadsheet`, `appendRows`, `createSpreadsheet`, `formatCells`, `insertChart` |
+| Forms | 6 | `create_form`, `get_form`, `batch_update_form`, `list_form_responses` |
+| Slides | 16 | `createPresentation`, `getPresentation`, `createSlidesTextBox`, `updateSpeakerNotes` |
+| Utility | 3 | `help`, `troubleshoot`, `feedback` |
+
+**Total: 153 tools.** All available the moment the server starts.
+
+## Prerequisites
+
+1. **GBrain installed and configured** (`gbrain doctor` passes)
+2. **Node.js 18+** (for npx)
+
+## Setup Flow
+
+### Step 1: Run the Setup Wizard
+
+The setup wizard automates the entire Google Cloud configuration. Run:
+
+```bash
+npx -y google-tools-mcp setup
+```
+
+The wizard will:
+
+1. **Open the Google Cloud Console APIs page** in your browser. Enable these APIs
+   when prompted (click "Enable" on each):
+   - Gmail API
+   - Google Drive API
+   - Google Docs API
+   - Google Sheets API
+   - Google Calendar API
+   - Google Forms API
+
+2. **Open the OAuth Consent Screen configuration.** Configure:
+   - User type: **External** (or Internal for Google Workspace)
+   - App name: anything (e.g., "GBrain")
+   - User support email: your email
+   - Developer contact: your email
+   - Scopes: the wizard tells you which to add
+   - **Test users: add your own email address** (CRITICAL — without this, Google
+     blocks the auth flow with "Access denied")
+
+3. **Open the Credentials page.** Create credentials:
+   - Click **"+ CREATE CREDENTIALS"** → **"OAuth client ID"**
+   - Application type: **Desktop app**
+   - Name: anything (e.g., "GBrain")
+   - Copy the **Client ID** and **Client Secret** when shown
+
+4. **Prompt you to paste** the Client ID and Client Secret. The wizard saves them
+   to `~/.config/google-tools-mcp/credentials.json`.
+
+5. **Run the OAuth flow.** Opens your browser to Google's consent screen. Sign in,
+   grant access. The token is saved to `~/.config/google-tools-mcp/token.json`.
+
+**STOP and verify:**
+```bash
+npx -y google-tools-mcp auth
+```
+Should show "Already authenticated" or complete the auth flow successfully.
+
+**If the wizard fails or you prefer manual setup, see Step 1B below.**
+
+### Step 1B: Manual Setup (Fallback)
+
+Only use this if the wizard didn't work.
+
+Tell the user:
+"I need Google OAuth2 credentials. Here's exactly how:
+
+1. Go to https://console.cloud.google.com/apis/credentials
+   (create a Google Cloud project if you don't have one — it's free)
+2. Click **'+ CREATE CREDENTIALS'** > **'OAuth client ID'**
+3. If prompted, configure the OAuth consent screen:
+   - User type: **External**
+   - App name: 'GBrain'
+   - Test users: **add your own email address**
+4. Application type: **Desktop app**, name: 'GBrain'
+5. Copy **Client ID** and **Client Secret**
+6. Enable these APIs (click Enable on each):
+   - https://console.cloud.google.com/apis/library/gmail.googleapis.com
+   - https://console.cloud.google.com/apis/library/drive.googleapis.com
+   - https://console.cloud.google.com/apis/library/docs.googleapis.com
+   - https://console.cloud.google.com/apis/library/sheets.googleapis.com
+   - https://console.cloud.google.com/apis/library/calendar-json.googleapis.com
+   - https://console.cloud.google.com/apis/library/forms.googleapis.com"
+
+Save credentials via ONE of:
+- **Option A** (recommended): Download `credentials.json` from Google Cloud Console
+  → save to `~/.config/google-tools-mcp/credentials.json`
+- **Option B**: Create `~/.config/google-tools-mcp/.env` with:
+  ```
+  GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+  GOOGLE_CLIENT_SECRET=your-client-secret
+  ```
+- **Option C**: Set environment variables directly
+
+Then authenticate:
+```bash
+npx -y google-tools-mcp auth
+```
+
+### Step 2: Add to Claude Code
+
+**User-scope (available in all projects — recommended):**
+```bash
+claude mcp add -s user google -- npx -y google-tools-mcp
+```
+
+**Project-scope (current project only):**
+```bash
+claude mcp add google -- npx -y google-tools-mcp
+```
+
+**With env vars (if not using credentials.json):**
+```bash
+claude mcp add -s user google \
+  -e GOOGLE_CLIENT_ID=your-client-id \
+  -e GOOGLE_CLIENT_SECRET=your-client-secret \
+  -- npx -y google-tools-mcp
+```
+
+**STOP and verify:** Restart Claude Code. The MCP server should connect.
+If it doesn't, check `npx -y google-tools-mcp --help` runs without error.
+
+### Step 3: Verify Each Google Service
+
+Test that each service is accessible. Ask the agent to run these checks:
+
+**Gmail:**
+```
+Call the list_messages tool with maxResults: 3
+```
+Expected: Returns 3 recent email subjects and senders.
+
+**Calendar:**
+```
+Call the get_events tool with maxResults: 3
+```
+Expected: Returns upcoming calendar events with times and attendees.
+
+**Drive:**
+```
+Call the listDriveFiles tool with pageSize: 3
+```
+Expected: Returns recent Drive files with names and types.
+
+**Docs (if you have any Google Docs):**
+```
+Call the searchDocuments tool with query: "" and pageSize: 3
+```
+Expected: Returns Google Docs file names.
+
+**If any service fails:**
+1. Check that the API is enabled in Google Cloud Console
+2. Re-authenticate: `npx -y google-tools-mcp auth`
+3. Run the troubleshoot tool: `Call the troubleshoot tool`
+   (shows auth status, API connectivity, config, environment info)
+
+### Step 4: Multi-Account Support (Optional)
+
+If you use multiple Google accounts (work + personal):
+
+```bash
+# Work account
+claude mcp add -s user google-work \
+  -e GOOGLE_MCP_PROFILE=work \
+  -- npx -y google-tools-mcp
+
+# Personal account
+claude mcp add -s user google-personal \
+  -e GOOGLE_MCP_PROFILE=personal \
+  -- npx -y google-tools-mcp
+```
+
+Each profile stores tokens separately in `~/.config/google-tools-mcp/<profile>/`.
+Authenticate each profile:
+```bash
+GOOGLE_MCP_PROFILE=work npx -y google-tools-mcp auth
+GOOGLE_MCP_PROFILE=personal npx -y google-tools-mcp auth
+```
+
+### Step 5: Log Setup Completion
+
+```bash
+mkdir -p ~/.gbrain/integrations/google-tools-mcp
+echo '{"ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","event":"setup_complete","source_version":"1.0.0","status":"ok"}' >> ~/.gbrain/integrations/google-tools-mcp/heartbeat.jsonl
+```
+
+Tell the user: "Google Tools MCP is set up. You now have full read/write access
+to Gmail, Calendar, Drive, Docs, Sheets, Forms, and Slides. No cron jobs needed —
+all data is pulled on demand."
+
+## Using Google Tools for Brain Enrichment
+
+### Email Enrichment (Replaces email-to-brain)
+
+Instead of a cron-based collector script, pull and process emails on demand:
+
+1. **Pull recent messages:**
+   - `list_messages` with query `is:inbox newer_than:1d` to get today's inbox
+   - `get_message` for full content of each message
+   - `list_threads` to see conversation context
+
+2. **Triage and filter:**
+   - Skip noise: noreply@, notifications@, calendar-notification@
+   - Flag signatures: DocuSign, Dropbox Sign, HelloSign, PandaDoc
+   - Prioritize: real messages from real people
+
+3. **Entity detection and brain enrichment** (your judgment — unchanged):
+   - Detect people and companies mentioned
+   - `gbrain search "sender name"` — check for existing page
+   - Update brain pages with timeline entries:
+     `- YYYY-MM-DD | Email from {sender}: {subject} [Source: Gmail, {date}]`
+   - Create pages for notable new contacts
+
+4. **Gmail write capabilities (NEW):**
+   - `send_message` — send emails with full brain context
+   - `reply_message` — reply to threads
+   - `create_draft` — draft for user review before sending
+   - `forward_message` — forward with context
+
+5. **Sync:** `gbrain sync --no-pull --no-embed && gbrain embed --stale`
+
+### Calendar Enrichment (Replaces calendar-to-brain)
+
+1. **Pull events:**
+   - `get_events` — today's and upcoming events
+   - `list_calendars` — all connected calendars
+   - `get_busy` / `get_free` — availability windows
+
+2. **Meeting prep** (your judgment — unchanged):
+   - For each attendee: `gbrain search "attendee name"` → load context
+   - Brief the user on who they're meeting, last interaction, open threads
+   - Flag first-time meetings (no brain page = cold contact)
+
+3. **Post-meeting enrichment:**
+   - Update attendee pages with timeline entries
+   - `manage_event` — create follow-up events
+   - `move_event` — reschedule
+
+4. **Calendar write capabilities (NEW):**
+   - `manage_event` — create, update, delete events
+   - `move_event` — reschedule between calendars
+
+### Drive, Docs, Sheets (NEW — Not Previously Possible)
+
+- **Before meetings:** `searchDocuments` for shared docs, `readDocument` for content
+- **Spreadsheet data:** `readSpreadsheet` for tracking sheets, OKRs, pipeline data
+- **File management:** `listDriveFiles`, `moveFile`, `uploadFile`, `downloadFile`
+- **Read any file:** `readFile` handles PDFs, Word docs (.docx), spreadsheets
+- **Document editing:** `appendMarkdown`, `modifyText`, `replaceDocumentWithMarkdown`
+
+## Migrating from Split Recipes
+
+If you previously set up `credential-gateway`, `email-to-brain`, and/or
+`calendar-to-brain`:
+
+1. **Set up google-tools-mcp** following Steps 1-5 above
+2. **Remove old cron jobs:**
+   ```bash
+   crontab -l | grep -v email-collector | grep -v calendar-sync | crontab -
+   ```
+3. **Old collector data is preserved** — JSON files and digests remain in their
+   directories. Brain pages are unchanged.
+4. **ClawVisor is now optional** for Google services. Still needed if you use it
+   for iMessage or other non-Google integrations.
+
+## Troubleshooting
+
+**"google-tools-mcp: command not found":**
+- Ensure Node.js 18+ is installed: `node --version`
+- Try: `npx -y google-tools-mcp --help`
+
+**Auth fails or token expired:**
+- Re-run: `npx -y google-tools-mcp auth`
+- If consent screen is in "Testing" mode, tokens expire weekly — re-auth when needed
+
+**"insufficient permissions":**
+- Ensure all 6 Google APIs are enabled in Cloud Console
+- Re-authenticate to pick up new scopes: `npx -y google-tools-mcp auth`
+
+**Multiple accounts not working:**
+- Verify each profile has a unique `GOOGLE_MCP_PROFILE` value
+- Check token files: `ls ~/.config/google-tools-mcp/<profile>/`
+
+**Something else:**
+- Call the `troubleshoot` tool — it runs diagnostics (auth status, API connectivity,
+  config, recent logs, environment info) and suggests fixes
+- Call the `feedback` tool — files a bug report with auto-collected diagnostics
+
+## Links
+
+- [google-tools-mcp on GitHub](https://github.com/karthikcsq/google-tools-mcp)
+- [google-tools-mcp on npm](https://www.npmjs.com/package/google-tools-mcp)
+- [Issue #126](https://github.com/garrytan/gbrain/issues/126)
+
+## Cost Estimate
+
+| Component | Monthly Cost |
+|-----------|-------------|
+| Google APIs | $0 (within free quota) |
+| google-tools-mcp | $0 (MIT open source) |
+| **Total** | **$0** |

--- a/recipes/google-tools-mcp.md
+++ b/recipes/google-tools-mcp.md
@@ -17,8 +17,11 @@ health_checks:
         name: GOOGLE_CLIENT_ID
         label: "GOOGLE_CLIENT_ID (env var)"
       - type: command
-        argv: ["sh", "-c", "test -f \"/c/Users/2supe/.config/google-tools-mcp/credentials.json\" || test -f \"/c/Users/2supe/.config/google-tools-mcp/.env\""]
-        label: "google-tools-mcp credentials file"
+        argv:
+          - sh
+          - -c
+          - test -f "$HOME/.config/google-tools-mcp/gcp-oauth.keys.json" || test -f "$HOME/.config/google-tools-mcp/google-oauth.keys.json" || test -f "$HOME/.config/google-tools-mcp/oauth.keys.json"
+        label: "google-tools-mcp OAuth config file present"
 setup_time: 5 min
 cost_estimate: "$0 (Google APIs free tier)"
 ---
@@ -95,6 +98,7 @@ The wizard will:
    - Google Sheets API
    - Google Calendar API
    - Google Forms API
+   - Google Slides API
 
 2. **Open the OAuth Consent Screen configuration.** Configure:
    - User type: **External** (or Internal for Google Workspace)
@@ -147,7 +151,8 @@ Tell the user:
    - https://console.cloud.google.com/apis/library/docs.googleapis.com
    - https://console.cloud.google.com/apis/library/sheets.googleapis.com
    - https://console.cloud.google.com/apis/library/calendar-json.googleapis.com
-   - https://console.cloud.google.com/apis/library/forms.googleapis.com"
+   - https://console.cloud.google.com/apis/library/forms.googleapis.com
+   - https://console.cloud.google.com/apis/library/slides.googleapis.com"
 
 Save credentials via ONE of:
 - **Option A** (recommended): Download `credentials.json` from Google Cloud Console
@@ -341,7 +346,7 @@ If you previously set up `credential-gateway`, `email-to-brain`, and/or
 - If consent screen is in "Testing" mode, tokens expire weekly — re-auth when needed
 
 **"insufficient permissions":**
-- Ensure all 6 Google APIs are enabled in Cloud Console
+- Ensure all 7 Google APIs are enabled in Cloud Console
 - Re-authenticate to pick up new scopes: `npx -y google-tools-mcp auth`
 
 **Multiple accounts not working:**


### PR DESCRIPTION
## Summary

- Adds `recipes/google-tools-mcp.md` — unified Google Workspace recipe (Gmail, Calendar, Drive, Docs, Sheets, Forms, Slides) via [google-tools-mcp](https://github.com/karthikcsq/google-tools-mcp)
- Deprecates `credential-gateway`, `email-to-brain`, `calendar-to-brain` with migration notices
- Updates docs (`cron-schedule`, `SKILLPACK`, `integrations/README`, `HOMEBREW_FOR_PERSONAL_AI`, `credential-gateway` doc) to reflect new approach

### Why

The current approach requires 3 sequential recipes (~55 min setup), custom Node.js collector scripts, and 3+ cron jobs — all for read-only access to just Gmail and Calendar.

google-tools-mcp provides 153 tools across 7 Google services with a single `npx` command and one OAuth flow (~5 min setup). Read AND write. No custom code to maintain.

### What's preserved

- The "code for data, LLMs for judgment" pattern — MCP tools are the deterministic data layer
- Legacy recipes remain functional for ClawVisor users or collector-based workflows
- meeting-sync, x-to-brain, voice-to-brain are unaffected

Closes #126

## Test plan

- [ ] `gbrain integrations list` shows the new google-tools-mcp recipe
- [ ] Deprecated recipes still parse correctly with `[DEPRECATED]` in description
- [ ] Cron schedule doc no longer lists email/calendar cron jobs
- [ ] All markdown links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)