### PR TITLE
fix: doctor resolves skills/ from install path when run outside repo

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2,8 +2,9 @@ import type { BrainEngine } from '../core/engine.ts';
 import * as db from '../core/db.ts';
 import { LATEST_VERSION } from '../core/migrate.ts';
 import { checkResolvable } from '../core/check-resolvable.ts';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
+import { fileURLToPath } from 'url';
 
 export interface Check {
   name: string;
@@ -164,12 +165,49 @@ export async function runDoctor(engine: BrainEngine | null, args: string[]) {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Find the GBrain repo root by walking up from cwd looking for skills/RESOLVER.md */
+/**
+ * Find the GBrain repo root containing skills/RESOLVER.md.
+ *
+ * Resolution order (first hit wins):
+ *   1. `GBRAIN_SKILLS_DIR` env var — explicit override (must contain RESOLVER.md)
+ *   2. Walk up from cwd — the canonical "I'm inside a brain repo" case
+ *   3. Walk up from this module's install location — for hosted/CLI-only setups
+ *      where the user runs `gbrain` from `~` but the bundled skills live under
+ *      `node_modules/gbrain/skills/`
+ *
+ * Returns the directory that CONTAINS the `skills/` subdirectory, not the
+ * skills directory itself (callers do `join(root, 'skills')`).
+ */
 function findRepoRoot(): string | null {
-  let dir = process.cwd();
+  // 1. Explicit override
+  const envDir = process.env.GBRAIN_SKILLS_DIR;
+  if (envDir && existsSync(join(envDir, 'RESOLVER.md'))) {
+    // env var points at the skills/ dir itself; return its parent
+    return dirname(envDir);
+  }
+
+  // 2. Walk up from cwd
+  const fromCwd = walkUpFor(process.cwd(), 'skills/RESOLVER.md');
+  if (fromCwd) return fromCwd;
+
+  // 3. Walk up from this module's install path
+  try {
+    const moduleDir = dirname(fileURLToPath(import.meta.url));
+    const fromInstall = walkUpFor(moduleDir, 'skills/RESOLVER.md');
+    if (fromInstall) return fromInstall;
+  } catch {
+    // fileURLToPath failures are non-fatal; just means we can't fall back here
+  }
+
+  return null;
+}
+
+/** Walk up from `start` looking for a relative path. Returns the containing dir or null. */
+function walkUpFor(start: string, relPath: string): string | null {
+  let dir = start;
   for (let i = 0; i < 10; i++) {
-    if (existsSync(join(dir, 'skills', 'RESOLVER.md'))) return dir;
-    const parent = join(dir, '..');
+    if (existsSync(join(dir, relPath))) return dir;
+    const parent = dirname(dir);
     if (parent === dir) break;
     dir = parent;
   }

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -40,4 +40,53 @@ describe('doctor command', () => {
     // We can't call it directly (it calls process.exit), but we verify the signature
     expect(runDoctor.length).toBe(2); // engine, args
   });
+
+  test('resolver_health finds bundled skills when run outside repo', async () => {
+    // Simulates the hosted-CLI case: user runs `gbrain doctor` from a directory
+    // that has no skills/RESOLVER.md anywhere up the tree. The fallback should
+    // walk up from the module's install path and find the bundled skills/.
+    const { tmpdirSync } = await import('node:fs');
+    const os = await import('node:os');
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gbrain-doctor-'));
+    try {
+      const result = Bun.spawnSync({
+        cmd: ['bun', 'run', path.join(import.meta.dir, '..', 'src/cli.ts'), 'doctor', '--fast', '--json'],
+        cwd: tmp,
+        env: { ...process.env, GBRAIN_SKILLS_DIR: '' },
+      });
+      const stdout = new TextDecoder().decode(result.stdout);
+      const out = JSON.parse(stdout);
+      const resolver = out.checks.find((c: { name: string }) => c.name === 'resolver_health');
+      // Should NOT be "Could not find skills directory" — install fallback should hit
+      expect(resolver?.message ?? '').not.toContain('Could not find');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('resolver_health honors GBRAIN_SKILLS_DIR env override', async () => {
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gbrain-doctor-env-'));
+    const skills = path.join(tmp, 'skills');
+    fs.mkdirSync(skills);
+    fs.writeFileSync(path.join(skills, 'RESOLVER.md'), '# Resolver\n');
+    fs.writeFileSync(path.join(skills, 'manifest.json'), JSON.stringify({ skills: [] }));
+    try {
+      const result = Bun.spawnSync({
+        cmd: ['bun', 'run', path.join(import.meta.dir, '..', 'src/cli.ts'), 'doctor', '--fast', '--json'],
+        cwd: os.tmpdir(),
+        env: { ...process.env, GBRAIN_SKILLS_DIR: skills },
+      });
+      const stdout = new TextDecoder().decode(result.stdout);
+      const out = JSON.parse(stdout);
+      const resolver = out.checks.find((c: { name: string }) => c.name === 'resolver_health');
+      expect(resolver?.message ?? '').not.toContain('Could not find');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`gbrain doctor` reports `resolver_health: warn — "Could not find skills directory"` for every user who installed via `bun install github:garrytan/gbrain` and runs `gbrain` from `~` or any other directory that has no `skills/RESOLVER.md` up the tree. The bundled `skills/` directory lives under `node_modules/gbrain/skills/` but the cwd-only walk in `findRepoRoot()` never looks there.

Impact: every hosted-CLI install takes a permanent `-5` on the health score, plus the scary-sounding warning noise, even though everything is actually wired correctly.

## Fix

Three-tier resolution in `findRepoRoot()` (first hit wins):

1. **`GBRAIN_SKILLS_DIR` env var** — explicit override for Docker mounts, CI, monorepo subdirs, or anyone who wants a deterministic path.
2. **Walk up from cwd** — original behavior, preferred when you're inside a brain repo.
3. **Walk up from this module's install path** — via `fileURLToPath(import.meta.url)`, catches `node_modules/gbrain/` automatically without user config.

Also refactors the walk into a `walkUpFor(start, relPath)` helper so cwd and install-path both share a single, tested implementation.

## Test plan

- [x] `bun test test/doctor.test.ts` — 7 pass, 0 fail (2 new tests added)
- [x] `bun test` (full suite) — 823 pass, 126 skip, 0 fail
- [x] Verified from a hosted install on Linux aarch64: `cd ~ && gbrain doctor --fast --json` no longer shows "Could not find skills directory" — `resolver_health` now reports the actual resolver state (found 10 upstream DRY_VIOLATION warnings in bundled skill content, which is a separate issue).
- [x] Verified env override: `GBRAIN_SKILLS_DIR=/tmp/my-skills gbrain doctor --fast` uses the override path.
- [x] Verified cwd walk unchanged when running from inside a brain repo.

## New tests

- `resolver_health finds bundled skills when run outside repo` — spawns `gbrain doctor --fast --json` from a fresh tmpdir and asserts the message does not contain "Could not find".
- `resolver_health honors GBRAIN_SKILLS_DIR env override` — creates a tmpdir skills layout, points the env var at it, asserts the resolver finds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)