### PR TITLE
Add configurable embedding provider support

### DIFF
--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -20,11 +20,16 @@ restart the shell or add the PATH export to the shell profile.
 Ask the user for these:
 
 ```bash
-export OPENAI_API_KEY=sk-...          # required for vector search
+export OPENAI_API_KEY=sk-...          # default embedding provider (OpenAI)
 export ANTHROPIC_API_KEY=sk-ant-...   # optional, improves search quality
+# Optional embedding overrides:
+export EMBEDDING_PROVIDER=openai      # or voyage
+export EMBEDDING_MODEL=text-embedding-3-large
+export EMBEDDING_DIMENSIONS=1536
+export VOYAGE_API_KEY=pa-...          # required only when EMBEDDING_PROVIDER=voyage
 ```
 
-Save to shell profile or `.env`. Without OpenAI, keyword search still works.
+Save to shell profile or `.env`. Without an embedding API key, keyword search still works.
 Without Anthropic, search works but skips query expansion.
 
 ## Step 3: Create the Brain

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ FILES
   gbrain files list|upload|sync|verify  File storage operations
 
 EMBEDDINGS
-  gbrain embed [<slug>|--all|--stale]   Generate/refresh embeddings
+  gbrain embed [<slug>|--all|--stale]   Generate/refresh embeddings (provider via EMBEDDING_PROVIDER/EMBEDDING_MODEL/EMBEDDING_DIMENSIONS)
 
 LINKS + GRAPH
   gbrain link|unlink|backlinks|graph    Cross-reference management

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,5 +1,5 @@
 import type { BrainEngine } from '../core/engine.ts';
-import { embedBatch } from '../core/embedding.ts';
+import { embedBatch, getEmbeddingConfig } from '../core/embedding.ts';
 import type { ChunkInput } from '../core/types.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
 
@@ -30,6 +30,7 @@ export async function runEmbed(engine: BrainEngine, args: string[]) {
 }
 
 async function embedPage(engine: BrainEngine, slug: string) {
+  const embeddingConfig = getEmbeddingConfig();
   const page = await engine.getPage(slug);
   if (!page) {
     throw new Error(`Page not found: ${slug}`);
@@ -73,6 +74,7 @@ async function embedPage(engine: BrainEngine, slug: string) {
     chunk_text: c.chunk_text,
     chunk_source: c.chunk_source,
     embedding: embeddingMap.get(c.chunk_index),
+    model: embeddingConfig.model,
     token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
   }));
 
@@ -81,6 +83,7 @@ async function embedPage(engine: BrainEngine, slug: string) {
 }
 
 async function embedAll(engine: BrainEngine, staleOnly: boolean) {
+  const embeddingConfig = getEmbeddingConfig();
   const pages = await engine.listPages({ limit: 100000 });
   let total = 0;
   let embedded = 0;
@@ -121,6 +124,7 @@ async function embedAll(engine: BrainEngine, staleOnly: boolean) {
         chunk_text: c.chunk_text,
         chunk_source: c.chunk_source,
         embedding: embeddingMap.get(c.chunk_index) ?? undefined,
+        model: embeddingConfig.model,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
       await engine.upsertChunks(page.slug, updated);

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -2,28 +2,84 @@
  * Embedding Service
  * Ported from production Ruby implementation (embedding_service.rb, 190 LOC)
  *
- * OpenAI text-embedding-3-large at 1536 dimensions.
+ * Default: OpenAI text-embedding-3-large at 1536 dimensions.
+ * Optional provider override: Voyage AI with configurable model/dimensions.
  * Retry with exponential backoff (4s base, 120s cap, 5 retries).
  * 8000 character input truncation.
  */
 
 import OpenAI from 'openai';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
+const DEFAULT_PROVIDER = 'openai';
+const DEFAULT_MODEL = 'text-embedding-3-large';
+const DEFAULT_DIMENSIONS = 1536;
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
 
-let client: OpenAI | null = null;
+let openAIClient: OpenAI | null = null;
 
-function getClient(): OpenAI {
-  if (!client) {
-    client = new OpenAI();
+export interface EmbeddingConfig {
+  provider: 'openai' | 'voyage';
+  model: string;
+  dimensions?: number;
+}
+
+function getOpenAIClient(): OpenAI {
+  if (!openAIClient) {
+    openAIClient = new OpenAI();
   }
-  return client;
+  return openAIClient;
+}
+
+export function getEmbeddingConfig(): EmbeddingConfig {
+  const providerRaw = (process.env.EMBEDDING_PROVIDER || DEFAULT_PROVIDER).toLowerCase();
+  const model = process.env.EMBEDDING_MODEL || DEFAULT_MODEL;
+  const dimensionsRaw = process.env.EMBEDDING_DIMENSIONS;
+  const dimensions = dimensionsRaw ? parseInt(dimensionsRaw, 10) : DEFAULT_DIMENSIONS;
+
+  if (providerRaw !== 'openai' && providerRaw !== 'voyage') {
+    throw new Error(`Unsupported embedding provider: ${providerRaw}. Expected openai or voyage.`);
+  }
+
+  if (dimensionsRaw && Number.isNaN(dimensions)) {
+    throw new Error(`Invalid EMBEDDING_DIMENSIONS: ${dimensionsRaw}`);
+  }
+
+  return {
+    provider: providerRaw,
+    model,
+    dimensions,
+  };
+}
+
+async function createVoyageEmbeddings(texts: string[], config: EmbeddingConfig): Promise<Float32Array[]> {
+  const apiKey = process.env.VOYAGE_API_KEY;
+  if (!apiKey) throw new Error('VOYAGE_API_KEY is required when EMBEDDING_PROVIDER=voyage');
+
+  const response = await fetch('https://api.voyageai.com/v1/embeddings', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: config.model,
+      input: texts,
+      ...(config.dimensions ? { output_dimension: config.dimensions } : {}),
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Voyage embedding request failed (${response.status}): ${body}`);
+  }
+
+  const json = await response.json() as { data: Array<{ index: number; embedding: number[] }> };
+  const sorted = json.data.sort((a, b) => a.index - b.index);
+  return sorted.map(d => new Float32Array(d.embedding));
 }
 
 export async function embed(text: string): Promise<Float32Array> {
@@ -36,7 +92,6 @@ export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
   const truncated = texts.map(t => t.slice(0, MAX_CHARS));
   const results: Float32Array[] = [];
 
-  // Process in batches of BATCH_SIZE
   for (let i = 0; i < truncated.length; i += BATCH_SIZE) {
     const batch = truncated.slice(i, i + BATCH_SIZE);
     const batchResults = await embedBatchWithRetry(batch);
@@ -47,21 +102,25 @@ export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
 }
 
 async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
+  const config = getEmbeddingConfig();
+
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const response = await getClient().embeddings.create({
-        model: MODEL,
+      if (config.provider === 'voyage') {
+        return await createVoyageEmbeddings(texts, config);
+      }
+
+      const response = await getOpenAIClient().embeddings.create({
+        model: config.model,
         input: texts,
-        dimensions: DIMENSIONS,
+        ...(config.dimensions ? { dimensions: config.dimensions } : {}),
       });
 
-      // Sort by index to maintain order
       const sorted = response.data.sort((a, b) => a.index - b.index);
       return sorted.map(d => new Float32Array(d.embedding));
     } catch (e: unknown) {
       if (attempt === MAX_RETRIES - 1) throw e;
 
-      // Check for rate limit with Retry-After header
       let delay = exponentialDelay(attempt);
 
       if (e instanceof OpenAI.APIError && e.status === 429) {
@@ -78,7 +137,6 @@ async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
     }
   }
 
-  // Should not reach here
   throw new Error('Embedding failed after all retries');
 }
 
@@ -91,4 +149,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
+export const EMBEDDING_PROVIDER = DEFAULT_PROVIDER;
+export const EMBEDDING_MODEL = DEFAULT_MODEL;
+export const EMBEDDING_DIMENSIONS = DEFAULT_DIMENSIONS;

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { getEmbeddingConfig } from '../src/core/embedding.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 
 // Mock the embedding module BEFORE importing runEmbed, so runEmbed picks up
@@ -51,6 +52,32 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.GBRAIN_EMBED_CONCURRENCY;
+  delete process.env.EMBEDDING_PROVIDER;
+  delete process.env.EMBEDDING_MODEL;
+  delete process.env.EMBEDDING_DIMENSIONS;
+  delete process.env.VOYAGE_API_KEY;
+});
+
+describe('embedding config', () => {
+  test('defaults to OpenAI text-embedding-3-large at 1536 dims', () => {
+    expect(getEmbeddingConfig()).toEqual({
+      provider: 'openai',
+      model: 'text-embedding-3-large',
+      dimensions: 1536,
+    });
+  });
+
+  test('reads Voyage provider overrides from env', () => {
+    process.env.EMBEDDING_PROVIDER = 'voyage';
+    process.env.EMBEDDING_MODEL = 'voyage-4-large';
+    process.env.EMBEDDING_DIMENSIONS = '1024';
+
+    expect(getEmbeddingConfig()).toEqual({
+      provider: 'voyage',
+      model: 'voyage-4-large',
+      dimensions: 1024,
+    });
+  });
 });
 
 describe('runEmbed --all (parallel)', () => {


### PR DESCRIPTION
## Summary
- make embedding provider, model, and dimensions configurable via env vars
- preserve the current OpenAI defaults while adding Voyage AI support
- add minimal docs and focused tests for the new config path

## Validation
- bun install
- bun test test/embed.test.ts

Closes #133