### PR TITLE
feat: support local embedding config and fix extract dedup

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -29,6 +29,17 @@ export interface ExtractedTimelineEntry {
   detail?: string;
 }
 
+export function normalizeTimelineDate(value: string | Date): string {
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return value;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString().slice(0, 10);
+}
+
+export function timelineEntryKey(slug: string, date: string | Date, summary: string): string {
+  return `${slug}::${normalizeTimelineDate(date)}::${summary}`;
+}
+
 interface ExtractResult {
   links_created: number;
   timeline_entries_created: number;
@@ -271,7 +282,7 @@ async function extractTimelineFromDir(
     const pages = await engine.listPages({ limit: 100000 });
     for (const page of pages) {
       for (const entry of await engine.getTimeline(page.slug)) {
-        existing.add(`${page.slug}::${entry.date}::${entry.summary}`);
+        existing.add(timelineEntryKey(page.slug, entry.date, entry.summary));
       }
     }
   } catch { /* fresh brain */ }
@@ -282,7 +293,7 @@ async function extractTimelineFromDir(
       const content = readFileSync(files[i].path, 'utf-8');
       const slug = files[i].relPath.replace('.md', '');
       for (const entry of extractTimelineFromContent(content, slug)) {
-        const key = `${entry.slug}::${entry.date}::${entry.summary}`;
+        const key = timelineEntryKey(entry.slug, entry.date, entry.summary);
         if (existing.has(key)) continue;
         existing.add(key);
         if (dryRun) {
@@ -313,6 +324,15 @@ async function extractTimelineFromDir(
 export async function extractLinksForSlugs(engine: BrainEngine, repoPath: string, slugs: string[]): Promise<number> {
   const allFiles = walkMarkdownFiles(repoPath);
   const allSlugs = new Set(allFiles.map(f => f.relPath.replace('.md', '')));
+  const existing = new Set<string>();
+  for (const slug of slugs) {
+    try {
+      for (const link of await engine.getLinks(slug)) {
+        existing.add(`${link.from_slug}::${link.to_slug}`);
+      }
+    } catch { /* skip */ }
+  }
+
   let created = 0;
   for (const slug of slugs) {
     const filePath = join(repoPath, slug + '.md');
@@ -320,7 +340,13 @@ export async function extractLinksForSlugs(engine: BrainEngine, repoPath: string
     try {
       const content = readFileSync(filePath, 'utf-8');
       for (const link of extractLinksFromFile(content, slug + '.md', allSlugs)) {
-        try { await engine.addLink(link.from_slug, link.to_slug, link.context, link.link_type); created++; } catch { /* skip */ }
+        const key = `${link.from_slug}::${link.to_slug}`;
+        if (existing.has(key)) continue;
+        try {
+          await engine.addLink(link.from_slug, link.to_slug, link.context, link.link_type);
+          existing.add(key);
+          created++;
+        } catch { /* skip */ }
       }
     } catch { /* skip */ }
   }
@@ -328,6 +354,15 @@ export async function extractLinksForSlugs(engine: BrainEngine, repoPath: string
 }
 
 export async function extractTimelineForSlugs(engine: BrainEngine, repoPath: string, slugs: string[]): Promise<number> {
+  const existing = new Set<string>();
+  for (const slug of slugs) {
+    try {
+      for (const entry of await engine.getTimeline(slug)) {
+        existing.add(timelineEntryKey(slug, entry.date, entry.summary));
+      }
+    } catch { /* skip */ }
+  }
+
   let created = 0;
   for (const slug of slugs) {
     const filePath = join(repoPath, slug + '.md');
@@ -335,7 +370,13 @@ export async function extractTimelineForSlugs(engine: BrainEngine, repoPath: str
     try {
       const content = readFileSync(filePath, 'utf-8');
       for (const entry of extractTimelineFromContent(content, slug)) {
-        try { await engine.addTimelineEntry(entry.slug, { date: entry.date, source: entry.source, summary: entry.summary, detail: entry.detail }); created++; } catch { /* skip */ }
+        const key = timelineEntryKey(entry.slug, entry.date, entry.summary);
+        if (existing.has(key)) continue;
+        try {
+          await engine.addTimelineEntry(entry.slug, { date: entry.date, source: entry.source, summary: entry.summary, detail: entry.detail });
+          existing.add(key);
+          created++;
+        } catch { /* skip */ }
       }
     } catch { /* skip */ }
   }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -13,6 +13,10 @@ export interface GBrainConfig {
   database_path?: string;
   openai_api_key?: string;
   anthropic_api_key?: string;
+  embedding_base_url?: string;
+  embedding_api_key?: string;
+  embedding_model?: string;
+  embedding_dimensions?: number;
 }
 
 /**
@@ -28,6 +32,13 @@ export function loadConfig(): GBrainConfig | null {
 
   // Try env vars
   const dbUrl = process.env.GBRAIN_DATABASE_URL || process.env.DATABASE_URL;
+  const embeddingBaseUrl = process.env.GBRAIN_EMBEDDING_BASE_URL || process.env.OPENAI_BASE_URL;
+  const embeddingApiKey = process.env.GBRAIN_EMBEDDING_API_KEY;
+  const embeddingModel = process.env.GBRAIN_EMBEDDING_MODEL;
+  const embeddingDimensionsRaw = process.env.GBRAIN_EMBEDDING_DIMENSIONS;
+  const embeddingDimensions = embeddingDimensionsRaw
+    ? parseInt(embeddingDimensionsRaw, 10)
+    : undefined;
 
   if (!fileConfig && !dbUrl) return null;
 
@@ -41,6 +52,12 @@ export function loadConfig(): GBrainConfig | null {
     engine: inferredEngine,
     ...(dbUrl ? { database_url: dbUrl } : {}),
     ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
+    ...(embeddingBaseUrl ? { embedding_base_url: embeddingBaseUrl } : {}),
+    ...(embeddingApiKey ? { embedding_api_key: embeddingApiKey } : {}),
+    ...(embeddingModel ? { embedding_model: embeddingModel } : {}),
+    ...(embeddingDimensions !== undefined && !Number.isNaN(embeddingDimensions)
+      ? { embedding_dimensions: embeddingDimensions }
+      : {}),
   };
   return merged as GBrainConfig;
 }

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -1,29 +1,101 @@
 /**
  * Embedding Service
- * Ported from production Ruby implementation (embedding_service.rb, 190 LOC)
  *
- * OpenAI text-embedding-3-large at 1536 dimensions.
- * Retry with exponential backoff (4s base, 120s cap, 5 retries).
- * 8000 character input truncation.
+ * Default: OpenAI text-embedding-3-large.
+ * Local/OpenAI-compatible override: configure embedding_base_url + embedding_model
+ * in ~/.gbrain/config.json (or env vars) and this module will route requests there.
  */
 
 import OpenAI from 'openai';
+import { loadConfig, type GBrainConfig } from './config.ts';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
+const DEFAULT_MODEL = 'text-embedding-3-large';
+const DEFAULT_DIMENSIONS = 1536;
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
+const LOCAL_API_KEY_FALLBACK = 'local-embedding';
+
+export interface ResolvedEmbeddingConfig {
+  baseUrl?: string;
+  apiKey: string;
+  model: string;
+  dimensions: number;
+  isCustomBaseUrl: boolean;
+}
 
 let client: OpenAI | null = null;
+let clientCacheKey: string | null = null;
 
-function getClient(): OpenAI {
-  if (!client) {
-    client = new OpenAI();
+function parseDimensions(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) return Math.floor(value);
+  if (typeof value === 'string') {
+    const parsed = parseInt(value, 10);
+    if (!Number.isNaN(parsed) && parsed > 0) return parsed;
   }
+  return DEFAULT_DIMENSIONS;
+}
+
+export function resolveEmbeddingConfig(config: GBrainConfig | null = loadConfig()): ResolvedEmbeddingConfig {
+  const baseUrl = config?.embedding_base_url?.trim() || undefined;
+  const model = config?.embedding_model?.trim() || DEFAULT_MODEL;
+  const dimensions = parseDimensions(config?.embedding_dimensions);
+  const isCustomBaseUrl = Boolean(baseUrl);
+  const apiKey =
+    config?.embedding_api_key?.trim()
+    || config?.openai_api_key?.trim()
+    || (isCustomBaseUrl ? LOCAL_API_KEY_FALLBACK : '');
+
+  return {
+    baseUrl,
+    apiKey,
+    model,
+    dimensions,
+    isCustomBaseUrl,
+  };
+}
+
+function getClient(config: ResolvedEmbeddingConfig): OpenAI {
+  const cacheKey = JSON.stringify({
+    baseUrl: config.baseUrl || '',
+    apiKey: config.apiKey,
+  });
+
+  if (!client || clientCacheKey !== cacheKey) {
+    client = new OpenAI({
+      apiKey: config.apiKey,
+      ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
+    });
+    clientCacheKey = cacheKey;
+  }
+
   return client;
+}
+
+export function buildEmbeddingRequest(texts: string[], config: ResolvedEmbeddingConfig): {
+  model: string;
+  input: string[];
+  dimensions?: number;
+} {
+  const request: {
+    model: string;
+    input: string[];
+    dimensions?: number;
+  } = {
+    model: config.model,
+    input: texts,
+  };
+
+  // Custom OpenAI-compatible local servers usually expose a fixed embedding width.
+  // Do not force the OpenAI-only `dimensions` parameter there unless we later add
+  // explicit capability negotiation.
+  if (!config.isCustomBaseUrl) {
+    request.dimensions = config.dimensions;
+  }
+
+  return request;
 }
 
 export async function embed(text: string): Promise<Float32Array> {
@@ -36,7 +108,6 @@ export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
   const truncated = texts.map(t => t.slice(0, MAX_CHARS));
   const results: Float32Array[] = [];
 
-  // Process in batches of BATCH_SIZE
   for (let i = 0; i < truncated.length; i += BATCH_SIZE) {
     const batch = truncated.slice(i, i + BATCH_SIZE);
     const batchResults = await embedBatchWithRetry(batch);
@@ -47,21 +118,19 @@ export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
 }
 
 async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
+  const config = resolveEmbeddingConfig();
+
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const response = await getClient().embeddings.create({
-        model: MODEL,
-        input: texts,
-        dimensions: DIMENSIONS,
-      });
+      const response = await getClient(config).embeddings.create(
+        buildEmbeddingRequest(texts, config),
+      );
 
-      // Sort by index to maintain order
       const sorted = response.data.sort((a, b) => a.index - b.index);
       return sorted.map(d => new Float32Array(d.embedding));
     } catch (e: unknown) {
       if (attempt === MAX_RETRIES - 1) throw e;
 
-      // Check for rate limit with Retry-After header
       let delay = exponentialDelay(attempt);
 
       if (e instanceof OpenAI.APIError && e.status === 429) {
@@ -78,7 +147,6 @@ async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
     }
   }
 
-  // Should not reach here
   throw new Error('Embedding failed after all retries');
 }
 
@@ -91,4 +159,4 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
+export { DEFAULT_MODEL as EMBEDDING_MODEL, DEFAULT_DIMENSIONS as EMBEDDING_DIMENSIONS };

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -321,16 +321,20 @@ export class PGLiteEngine implements BrainEngine {
 
   // Links
   async addLink(from: string, to: string, context?: string, linkType?: string): Promise<void> {
-    await this.db.query(
+    const result = await this.db.query(
       `INSERT INTO links (from_page_id, to_page_id, link_type, context)
        SELECT f.id, t.id, $3, $4
        FROM pages f, pages t
        WHERE f.slug = $1 AND t.slug = $2
        ON CONFLICT (from_page_id, to_page_id) DO UPDATE SET
          link_type = EXCLUDED.link_type,
-         context = EXCLUDED.context`,
+         context = EXCLUDED.context
+       RETURNING id`,
       [from, to, linkType || '', context || '']
     );
+    if ((result.rows as unknown[]).length === 0) {
+      throw new Error(`addLink failed: page "${from}" or "${to}" not found`);
+    }
   }
 
   async removeLink(from: string, to: string): Promise<void> {
@@ -433,12 +437,16 @@ export class PGLiteEngine implements BrainEngine {
 
   // Timeline
   async addTimelineEntry(slug: string, entry: TimelineInput): Promise<void> {
-    await this.db.query(
+    const result = await this.db.query(
       `INSERT INTO timeline_entries (page_id, date, source, summary, detail)
        SELECT id, $2::date, $3, $4, $5
-       FROM pages WHERE slug = $1`,
+       FROM pages WHERE slug = $1
+       RETURNING id`,
       [slug, entry.date, entry.source || '', entry.summary, entry.detail || '']
     );
+    if ((result.rows as unknown[]).length === 0) {
+      throw new Error(`addTimelineEntry failed: page "${slug}" not found`);
+    }
   }
 
   async getTimeline(slug: string, opts?: TimelineOpts): Promise<TimelineEntry[]> {

--- a/test/embedding-config.test.ts
+++ b/test/embedding-config.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { buildEmbeddingRequest, resolveEmbeddingConfig } from '../src/core/embedding.ts';
+
+describe('resolveEmbeddingConfig', () => {
+  test('uses local fallback api key when custom base URL is configured', () => {
+    const resolved = resolveEmbeddingConfig({
+      engine: 'pglite',
+      embedding_base_url: 'http://127.0.0.1:8100/v1',
+      embedding_model: 'gte-Qwen2-1.5B-instruct',
+      embedding_dimensions: 1536,
+    });
+
+    expect(resolved.baseUrl).toBe('http://127.0.0.1:8100/v1');
+    expect(resolved.apiKey).toBe('local-embedding');
+    expect(resolved.model).toBe('gte-Qwen2-1.5B-instruct');
+    expect(resolved.dimensions).toBe(1536);
+    expect(resolved.isCustomBaseUrl).toBe(true);
+  });
+
+  test('prefers explicit embedding api key when provided', () => {
+    const resolved = resolveEmbeddingConfig({
+      engine: 'pglite',
+      embedding_base_url: 'http://127.0.0.1:8100/v1',
+      embedding_api_key: 'secret-key',
+    });
+
+    expect(resolved.apiKey).toBe('secret-key');
+  });
+});
+
+describe('buildEmbeddingRequest', () => {
+  test('omits dimensions for custom local base URLs', () => {
+    const config = resolveEmbeddingConfig({
+      engine: 'pglite',
+      embedding_base_url: 'http://127.0.0.1:8100/v1',
+      embedding_model: 'gte-Qwen2-1.5B-instruct',
+      embedding_dimensions: 1536,
+    });
+
+    expect(buildEmbeddingRequest(['hello'], config)).toEqual({
+      model: 'gte-Qwen2-1.5B-instruct',
+      input: ['hello'],
+    });
+  });
+
+  test('keeps dimensions for default OpenAI embedding requests', () => {
+    const config = resolveEmbeddingConfig({
+      engine: 'pglite',
+      openai_api_key: 'sk-test',
+    });
+
+    expect(buildEmbeddingRequest(['hello'], config)).toEqual({
+      model: 'text-embedding-3-large',
+      input: ['hello'],
+      dimensions: 1536,
+    });
+  });
+});

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -3,6 +3,8 @@ import {
   extractMarkdownLinks,
   extractLinksFromFile,
   extractTimelineFromContent,
+  normalizeTimelineDate,
+  timelineEntryKey,
   walkMarkdownFiles,
 } from '../src/commands/extract.ts';
 
@@ -78,6 +80,15 @@ describe('extractLinksFromFile', () => {
     const allSlugs = new Set(['deals/seed', 'companies/brex']);
     const links = extractLinksFromFile(content, 'deals/seed.md', allSlugs);
     expect(links[0].link_type).toBe('deal_for');
+  });
+});
+
+describe('timelineEntryKey', () => {
+  it('normalizes Date and string dates to the same dedup key', () => {
+    const fromString = timelineEntryKey('projects/gbrain', '2026-04-16', 'Did thing');
+    const fromDate = timelineEntryKey('projects/gbrain', new Date('2026-04-16T00:00:00.000Z'), 'Did thing');
+    expect(fromString).toBe(fromDate);
+    expect(normalizeTimelineDate(new Date('2026-04-16T00:00:00.000Z'))).toBe('2026-04-16');
   });
 });
 

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -276,6 +276,11 @@ describe('PGLiteEngine: Links', () => {
     expect(links.length).toBe(0);
   });
 
+  test('addLink throws for missing source or target page', async () => {
+    await expect(engine.addLink('people/missing', 'companies/acme')).rejects.toThrow('addLink failed');
+    await expect(engine.addLink('people/alice', 'companies/missing')).rejects.toThrow('addLink failed');
+  });
+
   test('traverseGraph with depth', async () => {
     await engine.addLink('people/alice', 'companies/acme');
     await engine.addLink('companies/acme', 'companies/beta');
@@ -347,6 +352,12 @@ describe('PGLiteEngine: Timeline', () => {
     });
     expect(filtered.length).toBe(1);
     expect(filtered[0].summary).toBe('Jun');
+  });
+
+  test('addTimelineEntry throws for missing page', async () => {
+    await expect(
+      engine.addTimelineEntry('test/missing', { date: '2024-01-01', summary: 'Ghost entry' })
+    ).rejects.toThrow('addTimelineEntry failed');
   });
 });
 


### PR DESCRIPTION
## Summary
- add local embedding config support for OpenAI-compatible embedding endpoints
- make extract skip counting missing-page inserts as created in the PGLite path
- normalize timeline dedup keys so repeated extract runs stay idempotent

## Validation
- bun test test/embedding-config.test.ts
- bun test test/extract.test.ts test/pglite-engine.test.ts
- gbrain extract all --dir /Users/eusin/brain --json
