### PR TITLE
Update Render deployment link for AlphaClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ GBrain is those patterns, generalized. 25 skills. Install in 30 minutes. Your ag
 
 GBrain is designed to be installed and operated by an AI agent. If you don't have one running yet:
 
-- **[OpenClaw](https://openclaw.ai)** ... Deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/alphaclaw) (one click, 8GB+ RAM)
+- **[OpenClaw](https://openclaw.ai)** ... Deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/openclaw-render-template) (one click, 8GB+ RAM)
 - **[Hermes Agent](https://github.com/NousResearch/hermes-agent)** ... Deploy on [Railway](https://github.com/praveen-ks-2001/hermes-agent-template) (one click)
 
 Paste this into your agent:


### PR DESCRIPTION
@chrysb moved the Render template from [the original repo](https://github.com/chrysb/alphaclaw) to [a new one specifically for Render](https://github.com/chrysb/openclaw-render-template) that still runs AlphaClaw. The new one click Render link is https://render.com/deploy?repo=https://github.com/chrysb/openclaw-render-template so this PR switches to that link in the README.

Clicking the old link leads to this problem in Render
<img width="550" height="237" alt="Screenshot 2026-04-15 at 1 26 29 PM" src="https://github.com/user-attachments/assets/cf4a1722-a8ae-4285-bf25-46b97dd014a2" />

The deploy to Render button on the readme of the original repo now links to this new template
<img width="907" height="1105" alt="Screenshot 2026-04-15 at 1 31 01 PM" src="https://github.com/user-attachments/assets/a355fef8-f603-4647-ab07-3ecb07d8d434" />