### PR TITLE
feat(embedding): support provider-agnostic OpenAI-compat endpoint

### DIFF
--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -9,19 +9,23 @@
 
 import OpenAI from 'openai';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
+const MODEL = process.env.GBRAIN_EMBED_MODEL || 'text-embedding-3-large';
+const DIMENSIONS = parseInt(process.env.GBRAIN_EMBED_DIMENSIONS || '1536', 10);
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
+const IS_OPENAI_NATIVE = MODEL.startsWith('text-embedding-');
 
 let client: OpenAI | null = null;
 
 function getClient(): OpenAI {
   if (!client) {
-    client = new OpenAI();
+    client = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY || 'local-ollama-no-key-needed',
+      baseURL: process.env.OPENAI_BASE_URL,
+    });
   }
   return client;
 }
@@ -52,7 +56,7 @@ async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
       const response = await getClient().embeddings.create({
         model: MODEL,
         input: texts,
-        dimensions: DIMENSIONS,
+        ...(IS_OPENAI_NATIVE ? { dimensions: DIMENSIONS } : {}),
       });
 
       // Sort by index to maintain order


### PR DESCRIPTION
## Summary

Adds environment variable support for configuring embedding providers, enabling local models (Ollama, llama.cpp) and other OpenAI-compatible endpoints without code changes.

**New env vars:**
- `GBRAIN_EMBED_MODEL` — override embedding model (default: text-embedding-3-large)
- `GBRAIN_EMBED_DIMENSIONS` — override vector dimensions (default: 1536)
- `OPENAI_BASE_URL` — point to non-OpenAI providers (e.g. http://localhost:11434/v1 for Ollama)

The `dimensions` parameter is only sent for OpenAI-native models (those starting with `text-embedding-`) to avoid breaking non-OpenAI providers that don't support it.

## Motivation

Running gbrain with local embedding models (nomic-embed-text via Ollama) currently requires patching `embedding.ts`. This PR makes the provider configurable at runtime, which is useful for:
- Privacy-sensitive deployments
- Offline/airgapped environments
- Cost reduction (local vs cloud)

## Changes

- `src/core/embedding.ts`: 8 insertions, 4 deletions