### PR TITLE
feat(config): GBRAIN_DATABASE_PATH env override for configless operation

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -28,17 +28,20 @@ export function loadConfig(): GBrainConfig | null {
 
   // Try env vars
   const dbUrl = process.env.GBRAIN_DATABASE_URL || process.env.DATABASE_URL;
+  const dbPath = process.env.GBRAIN_DATABASE_PATH;
 
-  if (!fileConfig && !dbUrl) return null;
+  if (!fileConfig && !dbUrl && !dbPath) return null;
 
-  // Infer engine type if not explicitly set
-  const inferredEngine: 'postgres' | 'pglite' = fileConfig?.engine
-    || (fileConfig?.database_path ? 'pglite' : 'postgres');
+  // Infer engine type: explicit path => pglite, explicit url => postgres, otherwise use config
+  const inferredEngine: 'postgres' | 'pglite' = dbPath
+    ? 'pglite'
+    : (fileConfig?.engine || (fileConfig?.database_path ? 'pglite' : 'postgres'));
 
   // Merge: env vars override config file
   const merged = {
     ...fileConfig,
     engine: inferredEngine,
+    ...(dbPath ? { database_path: dbPath } : {}),
     ...(dbUrl ? { database_url: dbUrl } : {}),
     ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
   };


### PR DESCRIPTION
## Summary

Adds `GBRAIN_DATABASE_PATH` environment variable to allow gbrain to operate without a config file. When set, gbrain automatically infers `engine: pglite` and uses the specified path.

## Motivation

In sandboxed environments (e.g. OpenClaw exec sandbox, containerized deployments), writing to `~/.gbrain/config.json` may not be feasible. This env var unblocks those use cases without requiring filesystem access for configuration.

Also addresses HOME override non-propagation issues in child processes — the env var travels through process boundaries cleanly.

## Precedence

- Explicit `GBRAIN_DATABASE_PATH` → pglite engine with that path
- Explicit database URL in config → postgres engine
- Default → existing config file behavior

## Changes

- `src/core/config.ts`: 7 insertions, 4 deletions