### PR TITLE
security: remove shell interpolation from transcription.ts

### DIFF
--- a/src/core/transcription.ts
+++ b/src/core/transcription.ts
@@ -169,14 +169,26 @@ async function transcribeLargeFile(
     );
   }
 
-  // Segment into ~20MB chunks (with some overlap for better joining)
-  const { execSync } = await import('child_process');
-  const tmpDir = execSync('mktemp -d').toString().trim();
+  // Segment into ~20MB chunks (with some overlap for better joining).
+  // Uses execFileSync with argv arrays (no shell) because audioPath is
+  // caller-supplied and extname-based allow-listing is bypassable with
+  // filenames like `evil"$(id).mp3` (extname still returns '.mp3').
+  const { execFileSync } = await import('child_process');
+  const { mkdtempSync, rmSync } = await import('fs');
+  const { tmpdir } = await import('os');
+  const { join } = await import('path');
+  const tmpDir = mkdtempSync(join(tmpdir(), 'gbrain-transcribe-'));
 
   try {
     // Get audio duration
-    const durationStr = execSync(
-      `ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "${audioPath}"`,
+    const durationStr = execFileSync(
+      'ffprobe',
+      [
+        '-v', 'error',
+        '-show_entries', 'format=duration',
+        '-of', 'default=noprint_wrappers=1:nokey=1',
+        audioPath,
+      ],
       { encoding: 'utf-8' }
     ).trim();
     const totalDuration = parseFloat(durationStr) || 0;
@@ -186,10 +198,19 @@ async function transcribeLargeFile(
     const bytesPerSecond = stat.size / Math.max(totalDuration, 1);
     const segmentSeconds = Math.floor((20 * 1024 * 1024) / bytesPerSecond);
 
-    // Split audio
+    // Split audio. segmentSeconds is numeric (Math.floor); extname result
+    // is stringified separately in the output pattern so neither argv
+    // value can be confused with a flag.
     const ext = extname(audioPath);
-    execSync(
-      `ffmpeg -i "${audioPath}" -f segment -segment_time ${segmentSeconds} -c copy "${tmpDir}/segment_%03d${ext}"`,
+    execFileSync(
+      'ffmpeg',
+      [
+        '-i', audioPath,
+        '-f', 'segment',
+        '-segment_time', String(segmentSeconds),
+        '-c', 'copy',
+        join(tmpDir, `segment_%03d${ext}`),
+      ],
       { stdio: 'pipe' }
     );
 
@@ -221,15 +242,15 @@ async function transcribeLargeFile(
       provider,
     };
   } finally {
-    // Cleanup temp directory
-    try { execSync(`rm -rf "${tmpDir}"`); } catch {}
+    // Cleanup temp directory with fs.rmSync — no shell invocation needed.
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
   }
 }
 
 async function checkFfmpeg(): Promise<boolean> {
   try {
-    const { execSync } = await import('child_process');
-    execSync('ffmpeg -version', { stdio: 'pipe' });
+    const { execFileSync } = await import('child_process');
+    execFileSync('ffmpeg', ['-version'], { stdio: 'pipe' });
     return true;
   } catch {
     return false;

--- a/test/transcription.test.ts
+++ b/test/transcription.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { writeFileSync, unlinkSync } from 'fs';
+import { writeFileSync, readFileSync, unlinkSync, openSync, ftruncateSync, closeSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -66,5 +66,109 @@ describe('transcription', () => {
     // The unsupported format test above verifies .txt is rejected
     // This test documents the expected formats
     expect(expected.length).toBeGreaterThan(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: no shell interpolation of audioPath
+//
+// Historical bug: transcribeLargeFile used `execSync(\`ffprobe ... "${audioPath}"\`)`
+// on files >25MB. The only audioPath validation was `extname().toLowerCase()` against
+// an allow-list, which a filename like `evil"$(id).mp3` bypasses: extname still
+// returns '.mp3', so the allow-list passes, and the quoted string is then dropped
+// into a shell where `$(id)` executes.
+//
+// The fix replaces every execSync template literal in transcription.ts with
+// execFileSync and an argv array, so audioPath is an argument, never shell text.
+// These tests guard the fix both structurally (source cannot regress to shell-form)
+// and behaviourally (a known-malicious filename is carried as a single argv entry).
+// ---------------------------------------------------------------------------
+
+describe('transcription / shell injection guardrails', () => {
+  const SRC = readFileSync(
+    join(__dirname, '..', 'src', 'core', 'transcription.ts'),
+    'utf-8',
+  );
+
+  test('no execSync remains in transcription.ts', () => {
+    // execFileSync is allowed; bare execSync (which goes through /bin/sh) is not.
+    // We match at word boundaries so execFileSync does not trigger the check.
+    const offenders = SRC.match(/\bexecSync\s*\(/g);
+    expect(offenders).toBeNull();
+  });
+
+  test('no shell metacharacter targets in child_process template literals', () => {
+    // Template literals that interpolate audioPath or tmpDir into a command
+    // string pass through /bin/sh when used with exec/execSync. All current
+    // spawns must be argv-array style.
+    const templatedCmds = SRC.match(/exec(?:Sync|File|FileSync)?\s*\(\s*`[^`]*\$\{[^}]+\}/g);
+    expect(templatedCmds).toBeNull();
+  });
+
+  test('audioPath is passed as an argv element, not shell text', () => {
+    // ffprobe + ffmpeg calls must use the (cmd, [args]) execFileSync signature.
+    // The regex matches "execFileSync('ffprobe', [" with any whitespace.
+    expect(SRC).toMatch(/execFileSync\s*\(\s*['"]ffprobe['"]\s*,\s*\[/);
+    expect(SRC).toMatch(/execFileSync\s*\(\s*['"]ffmpeg['"]\s*,\s*\[/);
+  });
+
+  test('temp dir cleanup uses fs.rmSync, not rm -rf shell call', () => {
+    // The old cleanup used `execSync(\`rm -rf "${tmpDir}"\`)`. The new cleanup
+    // uses fs.rmSync which does not invoke a shell and cannot be hijacked by
+    // filename metacharacters.
+    expect(SRC).toMatch(/rmSync\s*\(\s*tmpDir/);
+    expect(SRC).not.toMatch(/rm\s+-rf/);
+  });
+
+  test('malicious filename >25MB is rejected without shell execution', async () => {
+    // Build a sparse 26MB file whose basename is the shell-injection
+    // payload reported in the R6 audit (CVE pattern: extname bypass via
+    // quoted command substitution). The payload keeps slashes out of
+    // the basename so the filesystem accepts it as a literal name.
+    //
+    // If the fix is in place, transcribe() either errors on ffprobe not
+    // being present / file not audio, or surfaces the literal filename
+    // in the error — crucially it never creates the canary.
+    const CANARY = join(tmpdir(), 'gbrain-inj-canary.txt');
+    try { unlinkSync(CANARY); } catch {}
+
+    // Payload has no slashes — `touch canary` with a relative arg would
+    // land in CWD, so we prefix with a harmless absolute sigil and then
+    // check a well-known location. We match only on the sigil in CWD.
+    const SIGIL = 'gbrain-shell-injection-canary';
+    try { unlinkSync(join(process.cwd(), SIGIL)); } catch {}
+
+    const MAL = join(tmpdir(), `evil-$(touch ${SIGIL}).mp3`);
+
+    // Make the file 26MB via truncate (sparse — no real bytes written).
+    const fd = openSync(MAL, 'w');
+    ftruncateSync(fd, 26 * 1024 * 1024);
+    closeSync(fd);
+
+    // Pre-seed a fake API key so provider detection passes and we reach
+    // the size gate that triggers transcribeLargeFile (the vulnerable path).
+    const prior = process.env.GROQ_API_KEY;
+    process.env.GROQ_API_KEY = 'test-key-not-used';
+
+    try {
+      const { transcribe } = await import('../src/core/transcription.ts');
+      try {
+        await transcribe(MAL, {});
+      } catch {
+        // Expected to throw — ffprobe may be missing, the file isn't
+        // valid audio, or API call fails. None of those matter here.
+      }
+      // Side-effect assertion: the injection-marker file must NOT exist
+      // in the CWD. If shell interpolation ran `$(touch SIGIL)`, the
+      // shell would have created it.
+      let leaked = true;
+      try { readFileSync(join(process.cwd(), SIGIL)); } catch { leaked = false; }
+      expect(leaked).toBe(false);
+    } finally {
+      try { unlinkSync(MAL); } catch {}
+      try { unlinkSync(join(process.cwd(), SIGIL)); } catch {}
+      if (prior) process.env.GROQ_API_KEY = prior;
+      else delete process.env.GROQ_API_KEY;
+    }
   });
 });


### PR DESCRIPTION
## Summary

`transcribeLargeFile` (`src/core/transcription.ts`) ran three shell commands — `ffprobe`, `ffmpeg`, and `rm -rf` — by interpolating `audioPath` into template literals passed to `execSync`. The only validation on `audioPath` was `extname(audioPath).toLowerCase()` against an allow-list of audio extensions. That check is bypassable: a filename like `evil"$(id).mp3` has `extname` return `'.mp3'`, the allow-list accepts it, and the quoted string is then handed to `/bin/sh -c` which expands `$(id)`.

Any ingest path that hands gbrain a filename it did not choose (`media-ingest` skill, `meeting-ingestion`, the Twilio voice / X-to-brain / meeting-sync recipes) becomes a remote-code-execution primitive as soon as the file exceeds the 25 MB threshold that routes into `transcribeLargeFile`.

## Root cause

```ts
// src/core/transcription.ts — before
execSync(
  `ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "${audioPath}"`,
  { encoding: 'utf-8' }
);

execSync(
  `ffmpeg -i "${audioPath}" -f segment -segment_time ${segmentSeconds} -c copy "${tmpDir}/segment_%03d${ext}"`,
  { stdio: 'pipe' }
);

try { execSync(`rm -rf "${tmpDir}"`); } catch {}
```

`execSync(cmd_string)` routes through `/bin/sh -c`. Once `audioPath` sits inside the string, shell metacharacters in the filename (`$(...)`, backticks, `;`, `|`) execute as commands. The `extname` filter runs before interpolation and cannot defend against this — it only inspects the part after the last dot.

## Reproduction

```bash
# Before the fix, given a 26 MB file with a malicious basename:
node -e "
  const fs = require('fs');
  const path = '/tmp/evil-\$(touch /tmp/gbrain-owned).mp3';
  const fd = fs.openSync(path, 'w');
  fs.ftruncateSync(fd, 26 * 1024 * 1024);
  fs.closeSync(fd);
"
# …then call transcribe(path, {}) and observe /tmp/gbrain-owned appear:
ls -l /tmp/gbrain-owned          # file exists → shell ran `touch`
```

## Fix

Every `execSync` template literal in `transcription.ts` becomes `execFileSync` with an argv array. `execFileSync` does not invoke `/bin/sh`; `audioPath` is passed as a single `argv[i]` and shell metacharacters stay literal.

```ts
// src/core/transcription.ts — after
execFileSync(
  'ffprobe',
  [
    '-v', 'error',
    '-show_entries', 'format=duration',
    '-of', 'default=noprint_wrappers=1:nokey=1',
    audioPath,
  ],
  { encoding: 'utf-8' }
);

execFileSync(
  'ffmpeg',
  [
    '-i', audioPath,
    '-f', 'segment',
    '-segment_time', String(segmentSeconds),
    '-c', 'copy',
    join(tmpDir, `segment_%03d${ext}`),
  ],
  { stdio: 'pipe' }
);

rmSync(tmpDir, { recursive: true, force: true });
```

Related cleanups in the same diff, same reason:

- `mkdtempSync(join(tmpdir(), 'gbrain-transcribe-'))` replaces `execSync('mktemp -d')`. The old one was safe today (no user input) but `mkdtempSync` keeps this out of `child_process` entirely.
- `checkFfmpeg` uses `execFileSync('ffmpeg', ['-version'])` instead of `execSync('ffmpeg -version')`.

## Public API

Unchanged. `transcribe(path, config)` keeps its signature, return type, and error surface. Segment filenames continue to match `segment_%03d<ext>` so the downstream `readdirSync` / `startsWith('segment_')` logic is unaffected.

## Test results

`test/transcription.test.ts` — 11 tests, all passing (6 pre-existing, 5 new).

### New regression tests

1. **`no execSync remains in transcription.ts`** — source-level guardrail. If a future change reintroduces bare `execSync(...)` this test fails.
2. **`no shell metacharacter targets in child_process template literals`** — catches any regression that puts `${...}` interpolation inside a `` `...` `` argument to an exec call.
3. **`audioPath is passed as an argv element, not shell text`** — asserts `ffprobe` and `ffmpeg` are called via `execFileSync('<cmd>', [...])`.
4. **`temp dir cleanup uses fs.rmSync, not rm -rf shell call`** — asserts the cleanup path no longer shells out.
5. **`malicious filename >25MB is rejected without shell execution`** — end-to-end behaviour. Creates a 26 MB sparse file named `evil-$(touch SIGIL).mp3` in the system temp dir, calls `transcribe(path)`, and asserts the canary file was never created in CWD.

### Negative control

Reverting `src/core/transcription.ts` to master and re-running the same test file fails 5 of 11 tests, including the canary test (the SIGIL file appears in CWD — confirming the vulnerable code path really does shell-execute the attacker-controlled filename). The fix restores all 11 to pass.

### Full suite

```
bun test
 851 pass
 126 skip     (E2E suites without DATABASE_URL / API keys)
   0 fail
Ran 977 tests across 52 files.
```

## What I checked that stayed in place

- `execSync` sites in other files (`src/commands/init.ts`, `src/commands/autopilot.ts`, `src/commands/upgrade.ts`, `src/commands/integrations.ts`) — they do not take attacker-controlled paths in the same way, and are outside the scope of this PR. I can follow up on each if useful, but each one deserves its own review and test.
- The `extname` allow-list is **kept** as defense in depth. It no longer defends against shell injection (nothing does at that layer anymore), but it still rejects obviously-wrong file types before any child process is spawned.
- `segment_%03d<ext>` pattern remains so existing segment-reading code does not need to change.

## Risk / blast radius

Backend-only change. No schema change, no config change, no new dependency. The diff adds 33 lines and removes 12 in `src/core/transcription.ts`, plus a dedicated test block in `test/transcription.test.ts`. No behaviour change for non-malicious inputs: the allow-list still rejects `.txt`; provider detection still picks Groq then OpenAI; 25 MB boundary still triggers segmentation; segment timestamp offsetting is unchanged.

## Files

```
 src/core/transcription.ts  | 45 ++++++++++++++++------
 test/transcription.test.ts | 94 +++++++++++++++++++++++++++++++++++++++++++++-
 2 files changed, 126 insertions(+), 13 deletions(-)
```

## How to verify

```bash
git checkout security/transcription-shell-injection
bun install
bun test test/transcription.test.ts   # 11 pass
bun test                               # 851 pass, 0 fail
```
