### PR TITLE
security: contain path traversal in check-resolvable and doctor

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2,8 +2,19 @@ import type { BrainEngine } from '../core/engine.ts';
 import * as db from '../core/db.ts';
 import { LATEST_VERSION } from '../core/migrate.ts';
 import { checkResolvable } from '../core/check-resolvable.ts';
-import { join } from 'path';
+import { join, resolve, sep } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
+
+// resolveInsideSkills — see src/core/check-resolvable.ts for the
+// identical helper and rationale. Duplicated here (not exported) to
+// keep doctor's public surface stable.
+function resolveInsideSkills(skillsDir: string, candidate: string): string | null {
+  const baseResolved = resolve(skillsDir);
+  const joinedResolved = resolve(baseResolved, candidate);
+  if (joinedResolved === baseResolved) return joinedResolved;
+  if (!joinedResolved.startsWith(baseResolved + sep)) return null;
+  return joinedResolved;
+}
 
 export interface Check {
   name: string;
@@ -203,7 +214,11 @@ function checkSkillConformance(skillsDir: string): Check {
     const failing: string[] = [];
 
     for (const skill of skills) {
-      const skillPath = join(skillsDir, skill.path);
+      const skillPath = resolveInsideSkills(skillsDir, skill.path);
+      if (skillPath === null) {
+        failing.push(`${skill.name}: path escapes skills directory`);
+        continue;
+      }
       if (!existsSync(skillPath)) {
         failing.push(`${skill.name}: file missing`);
         continue;

--- a/src/core/check-resolvable.ts
+++ b/src/core/check-resolvable.ts
@@ -11,7 +11,23 @@
  */
 
 import { readFileSync, existsSync, readdirSync } from 'fs';
-import { join, relative } from 'path';
+import { join, relative, resolve, sep } from 'path';
+
+// resolveInsideSkills returns an absolute path iff `candidate`, joined
+// under skillsDir, stays within skillsDir. Otherwise null. Used to guard
+// every filesystem op against path-traversal payloads in manifest.json or
+// RESOLVER.md — both of which are string sources that can carry `../`.
+//
+// The separator-terminated prefix check avoids the "/foo vs /foobar"
+// false accept where `path.resolve(baseResolved, candidate).startsWith(baseResolved)`
+// would otherwise succeed for `skillsDir-sibling/...`.
+function resolveInsideSkills(skillsDir: string, candidate: string): string | null {
+  const baseResolved = resolve(skillsDir);
+  const joinedResolved = resolve(baseResolved, candidate);
+  if (joinedResolved === baseResolved) return joinedResolved;
+  if (!joinedResolved.startsWith(baseResolved + sep)) return null;
+  return joinedResolved;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,7 +41,7 @@ export interface ResolvableFix {
 }
 
 export interface ResolvableIssue {
-  type: 'unreachable' | 'mece_overlap' | 'mece_gap' | 'dry_violation' | 'missing_file' | 'orphan_trigger';
+  type: 'unreachable' | 'mece_overlap' | 'mece_gap' | 'dry_violation' | 'missing_file' | 'orphan_trigger' | 'invalid_path';
   severity: 'error' | 'warning';
   skill: string;
   message: string;
@@ -225,7 +241,18 @@ export function checkResolvable(skillsDir: string): ResolvableReport {
     // Resolver uses 'skills/query/SKILL.md', manifest uses 'query/SKILL.md'
     // The file on disk is at skillsDir + 'query/SKILL.md'
     const relPath = entry.skillPath.replace(/^skills\//, '');
-    const fullPath = join(skillsDir, relPath);
+    const fullPath = resolveInsideSkills(skillsDir, relPath);
+
+    if (fullPath === null) {
+      issues.push({
+        type: 'invalid_path',
+        severity: 'error',
+        skill: entry.skillPath,
+        message: `RESOLVER.md entry '${entry.skillPath}' escapes the skills directory`,
+        action: `Remove the entry or replace the path with one under '${skillsDir}'`,
+      });
+      continue;
+    }
 
     if (!existsSync(fullPath)) {
       issues.push({
@@ -258,7 +285,17 @@ export function checkResolvable(skillsDir: string): ResolvableReport {
   // Build trigger→skill map from SKILL.md frontmatter triggers
   const triggerMap = new Map<string, string[]>();
   for (const skill of manifest) {
-    const skillPath = join(skillsDir, skill.path);
+    const skillPath = resolveInsideSkills(skillsDir, skill.path);
+    if (skillPath === null) {
+      issues.push({
+        type: 'invalid_path',
+        severity: 'error',
+        skill: skill.name,
+        message: `manifest.json entry for '${skill.name}' escapes the skills directory (path: '${skill.path}')`,
+        action: `Remove the entry or use a path relative to '${skillsDir}' without '..'`,
+      });
+      continue;
+    }
     if (!existsSync(skillPath)) continue;
     try {
       const content = readFileSync(skillPath, 'utf-8');
@@ -292,7 +329,8 @@ export function checkResolvable(skillsDir: string): ResolvableReport {
   let gaps = 0;
   for (const skill of manifest) {
     if (OVERLAP_WHITELIST.has(skill.name)) continue; // always-on don't need triggers
-    const skillPath = join(skillsDir, skill.path);
+    const skillPath = resolveInsideSkills(skillsDir, skill.path);
+    if (skillPath === null) continue; // already reported in pass 3
     if (!existsSync(skillPath)) continue;
     try {
       const content = readFileSync(skillPath, 'utf-8');
@@ -319,7 +357,8 @@ export function checkResolvable(skillsDir: string): ResolvableReport {
 
   // 5. DRY detection — inlined cross-cutting rules
   for (const skill of manifest) {
-    const skillPath = join(skillsDir, skill.path);
+    const skillPath = resolveInsideSkills(skillsDir, skill.path);
+    if (skillPath === null) continue; // already reported in pass 3
     if (!existsSync(skillPath)) continue;
     try {
       const content = readFileSync(skillPath, 'utf-8');

--- a/test/check-resolvable.test.ts
+++ b/test/check-resolvable.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { join } from "path";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "fs";
+import { tmpdir } from "os";
 import { checkResolvable, parseResolverEntries } from "../src/core/check-resolvable.ts";
 
 const SKILLS_DIR = join(import.meta.dir, "..", "skills");
@@ -124,5 +126,152 @@ describe("checkResolvable — real skills directory", () => {
 
   test("summary counts are consistent", () => {
     expect(report.summary.reachable + report.summary.unreachable).toBe(report.summary.total_skills);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: path traversal in manifest.json / RESOLVER.md
+//
+// checkResolvable takes skillsDir from the caller and joins it with string
+// values from manifest.json and RESOLVER.md. Those inputs can be edited in
+// a PR, in a committed file, or by a downstream consumer of the library.
+// A payload like `"path": "../../../etc/passwd"` or a RESOLVER.md row with
+// `skills/../../etc/hosts/SKILL.md` must not cause the function to read
+// (or even stat) files outside skillsDir.
+// ---------------------------------------------------------------------------
+
+describe("checkResolvable — path traversal containment", () => {
+  function makeSandbox(): string {
+    const sandbox = mkdtempSync(join(tmpdir(), "gbrain-pt-"));
+    const skillsDir = join(sandbox, "skills");
+    mkdirSync(skillsDir, { recursive: true });
+    // Minimal legitimate skill so the report is comparable against real runs
+    mkdirSync(join(skillsDir, "query"), { recursive: true });
+    writeFileSync(
+      join(skillsDir, "query", "SKILL.md"),
+      "---\ntriggers:\n  - foo\n---\n# query\n"
+    );
+    writeFileSync(
+      join(skillsDir, "RESOLVER.md"),
+      "## Brain\n| Trigger | Skill |\n|---|---|\n| foo | `skills/query/SKILL.md` |\n"
+    );
+    return sandbox;
+  }
+
+  test("malicious manifest path is rejected as invalid_path, not read", () => {
+    const sandbox = makeSandbox();
+    const skillsDir = join(sandbox, "skills");
+
+    // Pre-seed an outside-of-skills sentinel file that a traversal would hit
+    // if the check were missing. We never expect the code to read it.
+    const sentinel = join(sandbox, "SECRET.md");
+    writeFileSync(sentinel, "---\ntriggers:\n  - ohno\n---\n# DO NOT READ\n");
+
+    writeFileSync(
+      join(skillsDir, "manifest.json"),
+      JSON.stringify({
+        skills: [
+          { name: "query", path: "query/SKILL.md" },
+          { name: "evil", path: "../SECRET.md" },
+        ],
+      })
+    );
+
+    try {
+      const report = checkResolvable(skillsDir);
+
+      const invalid = report.issues.filter(i => i.type === "invalid_path");
+      expect(invalid.length).toBeGreaterThan(0);
+      expect(invalid.some(i => i.skill === "evil")).toBe(true);
+
+      // The sentinel file's unique trigger must NOT have made it into the
+      // report's trigger analysis — if it did, the code read it.
+      const overlap = report.issues.find(i =>
+        i.type === "mece_overlap" && i.message.includes("ohno")
+      );
+      expect(overlap).toBeUndefined();
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  test("absolute path in manifest is rejected", () => {
+    const sandbox = makeSandbox();
+    const skillsDir = join(sandbox, "skills");
+
+    writeFileSync(
+      join(skillsDir, "manifest.json"),
+      JSON.stringify({
+        skills: [
+          { name: "absolute", path: "/etc/hosts" },
+        ],
+      })
+    );
+
+    try {
+      const report = checkResolvable(skillsDir);
+      const invalid = report.issues.filter(i => i.type === "invalid_path");
+      expect(invalid.some(i => i.skill === "absolute")).toBe(true);
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  test("malicious RESOLVER.md entry is rejected, no stat on outside path", () => {
+    const sandbox = makeSandbox();
+    const skillsDir = join(sandbox, "skills");
+
+    // Empty manifest so we only exercise the RESOLVER code path
+    writeFileSync(join(skillsDir, "manifest.json"), JSON.stringify({ skills: [] }));
+
+    // Overwrite RESOLVER.md with a traversal row. The parser's regex
+    // (`skills/[^`]+/SKILL\.md`) still matches, but the resolver must
+    // refuse to stat the resulting path.
+    writeFileSync(
+      join(skillsDir, "RESOLVER.md"),
+      "## Evil\n| Trigger | Skill |\n|---|---|\n" +
+      "| bad | `skills/../../etc/hosts/SKILL.md` |\n"
+    );
+
+    try {
+      const report = checkResolvable(skillsDir);
+
+      // The resolver row should surface as invalid_path, not missing_file —
+      // missing_file would imply we did an existsSync on /etc/hosts/SKILL.md.
+      const invalid = report.issues.filter(i => i.type === "invalid_path");
+      expect(invalid.length).toBeGreaterThan(0);
+      expect(invalid.some(i => i.message.includes("escapes the skills directory"))).toBe(true);
+
+      const missing = report.issues.filter(i => i.type === "missing_file");
+      expect(missing.some(m => m.skill.includes("/etc/hosts"))).toBe(false);
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  test("benign normalized paths still resolve (e.g. foo/../query)", () => {
+    const sandbox = makeSandbox();
+    const skillsDir = join(sandbox, "skills");
+
+    writeFileSync(
+      join(skillsDir, "manifest.json"),
+      JSON.stringify({
+        skills: [
+          // Legit skill expressed via a normalized-to-inside path
+          { name: "query", path: "tmp/../query/SKILL.md" },
+        ],
+      })
+    );
+
+    try {
+      const report = checkResolvable(skillsDir);
+      // Must NOT treat this as invalid — it resolves inside skillsDir
+      const invalidForQuery = report.issues.filter(
+        i => i.type === "invalid_path" && i.skill === "query"
+      );
+      expect(invalidForQuery.length).toBe(0);
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

The skill resolver (`checkResolvable`) and the doctor command's skill conformance check both trust two files that users routinely hand-edit or pull from a PR: `skills/manifest.json` and `skills/RESOLVER.md`. Both files carry paths that end up on the filesystem as `existsSync` / `readFileSync` arguments, and today nothing stops those paths from pointing outside the `skills/` directory.

The practical effect: if someone opens a PR (or edits a local checkout, or publishes a skill bundle) that puts `"path": "../../../etc/passwd"` in `manifest.json`, or writes a RESOLVER.md row like `` `skills/../../etc/hosts/SKILL.md` ``, the next `gbrain doctor` or `bun test` run happily stats and reads those outside files. `gbrain doctor --json` then echoes the result back in its report. On any host where doctor output gets shared — CI logs, a support paste, a GitHub issue — that leaks parts of the host's filesystem structure. It is also a useful primitive for a subsequent attack: confirm which sensitive files exist before chaining into something heavier.

The vulnerable pattern, same in both files:

```ts
const skillPath = join(skillsDir, skill.path);   // skill.path from manifest.json
existsSync(skillPath);
readFileSync(skillPath, 'utf-8');
```

`path.join` preserves `../` segments, so the joined path can land anywhere the process has read access. This PR adds a containment check at every such site so the filesystem boundary is the defence, not the trust put in the input files.

## Root cause

- Neither call site normalizes the joined path. `path.join` keeps `../` segments intact when they appear mid-path — `join('skills', '../../../etc/passwd')` becomes `../../etc/passwd` relative to cwd, which `existsSync` happily follows.
- The RESOLVER.md parser's regex (`\`(skills\/[^\`]+\/SKILL\.md)\``) accepts `skills/../../etc/...` because `[^\`]+` does not forbid `..`.

## Fix

Private helper in each file:

```ts
function resolveInsideSkills(skillsDir: string, candidate: string): string | null {
  const baseResolved = resolve(skillsDir);
  const joinedResolved = resolve(baseResolved, candidate);
  if (joinedResolved === baseResolved) return joinedResolved;
  if (!joinedResolved.startsWith(baseResolved + sep)) return null;
  return joinedResolved;
}
```

- `path.resolve` normalizes `..` segments before the comparison, so `foo/../query/SKILL.md` resolves to `<base>/query/SKILL.md` and is still accepted.
- The separator-terminated prefix check (`base + sep`) avoids the `/foo` vs `/foobar` false accept. `resolve()` never leaves a trailing separator on a non-root path, so the check is exact.
- On failure the helper returns `null` and the caller records a new `invalid_path` issue on the report instead of calling `existsSync` / `readFileSync`.

The helper is deliberately duplicated in `doctor.ts` rather than exported from `check-resolvable.ts`. The public surface of `check-resolvable.ts` is consumed by `bun test`, `skill-creator`, and other callers; growing that surface for a 10-line helper is more risk than benefit.

## ResolvableIssue surface

Adds one value to the `type` union:

```diff
  type: 'unreachable' | 'mece_overlap' | 'mece_gap' | 'dry_violation'
-      | 'missing_file' | 'orphan_trigger';
+      | 'missing_file' | 'orphan_trigger' | 'invalid_path';
```

`invalid_path` is `severity: 'error'`. Consumers that switch on `type` get a compile-time nudge; consumers that only read `message` / `action` continue unchanged.

## Reproduction

Before the fix, against a fresh `skills/` directory with a malicious manifest:

```bash
mkdir -p /tmp/sandbox/skills/query
echo -e "---\ntriggers:\n  - foo\n---\n# query" > /tmp/sandbox/skills/query/SKILL.md
cat > /tmp/sandbox/skills/RESOLVER.md <<'EOF'
| Trigger | Skill |
|---|---|
| foo | `skills/query/SKILL.md` |
EOF
cat > /tmp/sandbox/skills/manifest.json <<'EOF'
{"skills":[{"name":"evil","path":"../../../etc/hosts"}]}
EOF
bun -e '
  const { checkResolvable } = await import("./src/core/check-resolvable.ts");
  console.log(checkResolvable("/tmp/sandbox/skills"));
'
# Before: the code calls readFileSync("/etc/hosts") silently and proceeds.
# After:  report.issues has an "invalid_path" entry for "evil", no fs read.
```

## Sibling review

Grepped `src/` for all `join(skillsDir, …)` callsites and classified:

| File | Line | Input | Status |
|---|---|---|---|
| `src/core/check-resolvable.ts` | 132 | `'manifest.json'` literal | safe, kept |
| `src/core/check-resolvable.ts` | 176 | `'RESOLVER.md'` literal | safe, kept |
| `src/core/check-resolvable.ts` | 246 | `relPath` from RESOLVER.md regex | **fixed** via helper |
| `src/core/check-resolvable.ts` | 278 | `skill.path` from manifest | **fixed** via helper |
| `src/core/check-resolvable.ts` | 316 | `skill.path` from manifest | **fixed** via helper |
| `src/core/check-resolvable.ts` | 345 | `skill.path` from manifest | **fixed** via helper |
| `src/commands/doctor.ts` | 206 | `skill.path` from manifest | **fixed** via helper |
| `src/commands/init.ts` | 300 | reads manifest only, no path derivation | safe |
| `src/core/file-resolver.ts` | 63 | different feature (brain file resolver, not skills) | out of scope |

## Test results

`test/check-resolvable.test.ts` — 17 tests, all passing (13 pre-existing, 4 new).

### New regression tests

1. **`malicious manifest path is rejected as invalid_path, not read`** — plants a sentinel file outside `skillsDir` with a unique trigger; asserts the report has `invalid_path` for the malicious entry AND that the sentinel's trigger did not make it into the MECE map (proving the file was never read).
2. **`absolute path in manifest is rejected`** — `/etc/hosts` as `skill.path` becomes an `invalid_path` issue.
3. **`malicious RESOLVER.md entry is rejected, no stat on outside path`** — asserts the escape shows up as `invalid_path`, not as `missing_file`. `missing_file` would prove an `existsSync` ran against `/etc/hosts/SKILL.md`, which would be a leak.
4. **`benign normalized paths still resolve (e.g. foo/../query)`** — asserts the helper does not over-reject paths that normalize back inside `skillsDir`.

### Negative control

Reverting `src/core/check-resolvable.ts` to master and rerunning the same test file fails 3 of the 4 new tests. The `existsSync` outside `skillsDir` runs and `missing_file` shows up instead of `invalid_path`, confirming the pre-fix code really did stat outside the skills directory.

### Full suite

```
bun test
 850 pass
 126 skip     (E2E without DATABASE_URL / API keys)
   0 fail
Ran 976 tests across 52 files.
```

## What stayed in place

- The RESOLVER.md regex (`\`(skills\/[^\`]+\/SKILL\.md)\``) is unchanged. Narrowing it (rejecting `..`) would move the fix into the parser, but the canonical containment belongs at the filesystem boundary — parser changes are more likely to silently break legitimate rows. The resolver now defends at the point where the harm would actually occur.
- Public API of `checkResolvable(skillsDir)` and `checkSkillConformance(skillsDir)` unchanged.
- No new dependencies.

## Files

```
 src/commands/doctor.ts        |  19 +++++-
 src/core/check-resolvable.ts  |  51 +++++++++++++--
 test/check-resolvable.test.ts | 149 ++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 211 insertions(+), 8 deletions(-)
```

## How to verify

```bash
git checkout security/check-resolvable-path-traversal
bun install
bun test test/check-resolvable.test.ts   # 17 pass
bun test                                   # 850 pass, 0 fail
```
