### PR TITLE
postgres-engine: scope search statement_timeout to the transaction

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -191,11 +191,17 @@ export class PostgresEngine implements BrainEngine {
     const detailLow = opts?.detail === 'low';
 
     // Search-only timeout: prevents DoS via expensive queries without
-    // affecting long-running operations like embed --all or bulk import
-    await sql`SET statement_timeout = '8s'`;
-    try {
+    // affecting long-running operations like embed --all or bulk import.
+    // SET LOCAL inside sql.begin() scopes the GUC to the transaction so
+    // it can never leak onto a pooled connection returned to other
+    // callers. A bare `SET statement_timeout` goes to an arbitrary
+    // connection from the pool, lives past this method, and either
+    // clips an unrelated caller's long-running query (DoS) or — via
+    // `SET statement_timeout = 0` — disables the guard for them.
+    const rows = await sql.begin(async sql => {
+      await sql`SET LOCAL statement_timeout = '8s'`;
       // CTE: rank pages by FTS score, then pick the best chunk per page in SQL
-      const rows = await sql`
+      return await sql`
         WITH ranked_pages AS (
           SELECT p.id, p.slug, p.title, p.type,
             ts_rank(p.search_vector, websearch_to_tsquery('english', ${query})) AS score
@@ -221,10 +227,8 @@ export class PostgresEngine implements BrainEngine {
         FROM best_chunks
         ORDER BY score DESC
       `;
-      return rows.map(rowToSearchResult);
-    } finally {
-      await sql`SET statement_timeout = '0'`;
-    }
+    });
+    return rows.map(rowToSearchResult);
   }
 
   async searchVector(embedding: Float32Array, opts?: SearchOpts): Promise<SearchResult[]> {
@@ -241,10 +245,12 @@ export class PostgresEngine implements BrainEngine {
 
     const vecStr = '[' + Array.from(embedding).join(',') + ']';
 
-    // Search-only timeout (see searchKeyword for rationale)
-    await sql`SET statement_timeout = '8s'`;
-    try {
-      const rows = await sql`
+    // Search-only timeout (see searchKeyword for rationale). SET LOCAL +
+    // sql.begin ensures the GUC stays transaction-scoped on the pooled
+    // connection.
+    const rows = await sql.begin(async sql => {
+      await sql`SET LOCAL statement_timeout = '8s'`;
+      return await sql`
         SELECT
           p.slug, p.id as page_id, p.title, p.type,
           cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
@@ -260,10 +266,8 @@ export class PostgresEngine implements BrainEngine {
         LIMIT ${limit}
         OFFSET ${offset}
       `;
-      return rows.map(rowToSearchResult);
-    } finally {
-      await sql`SET statement_timeout = '0'`;
-    }
+    });
+    return rows.map(rowToSearchResult);
   }
 
   async getEmbeddingsByChunkIds(ids: number[]): Promise<Map<number, Float32Array>> {

--- a/test/postgres-engine.test.ts
+++ b/test/postgres-engine.test.ts
@@ -1,0 +1,112 @@
+/**
+ * postgres-engine.ts source-level guardrails.
+ *
+ * Live Postgres coverage for search paths lives in test/e2e/search-quality.test.ts.
+ * This file stays fast and DB-free: it inspects the source of
+ * src/core/postgres-engine.ts to lock in decisions that protect the
+ * shared connection pool from per-request GUC leaks.
+ *
+ * Regression: R6-F006 / R4-F002.
+ * searchKeyword and searchVector used to call bare
+ *   await sql`SET statement_timeout = '8s'`
+ *   ...query...
+ *   finally { await sql`SET statement_timeout = '0'` }
+ * against the shared pool. Each tagged template picks an arbitrary
+ * connection, so the SET, the query, and the reset could all land on
+ * DIFFERENT connections. Worst case: the 8s GUC sticks on some pooled
+ * connection and clips the next caller's long-running query; or the
+ * reset to 0 lands on a connection that other code expected to be
+ * protected. The fix wraps each query in sql.begin() and uses
+ * SET LOCAL so the GUC is transaction-scoped and auto-resets on
+ * COMMIT/ROLLBACK, regardless of error path.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const SRC = readFileSync(
+  join(import.meta.dir, '..', 'src', 'core', 'postgres-engine.ts'),
+  'utf-8',
+);
+
+describe('postgres-engine / search path timeout isolation', () => {
+  test('no bare `SET statement_timeout` statement survives', () => {
+    // Strip comments so the commentary mentioning the anti-pattern does
+    // not trigger a false positive. Block-comment + line-comment strip.
+    const stripped = SRC
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|\s)\/\/[^\n]*/g, '$1');
+
+    // Match a tagged-template statement of the form
+    //   sql`SET statement_timeout = ...`
+    // that is NOT preceded by LOCAL. This is the exact shape that bleeds
+    // onto pooled connections; SET LOCAL is safe inside a transaction.
+    const bare = stripped.match(
+      /sql`\s*SET\s+(?!LOCAL\s)statement_timeout\b[^`]*`/gi,
+    );
+    expect(bare).toBeNull();
+  });
+
+  test('searchKeyword wraps its query in sql.begin()', () => {
+    const fn = extractMethod(SRC, 'searchKeyword');
+    expect(fn).toMatch(/sql\.begin\s*\(\s*async\s+sql\s*=>/);
+  });
+
+  test('searchVector wraps its query in sql.begin()', () => {
+    const fn = extractMethod(SRC, 'searchVector');
+    expect(fn).toMatch(/sql\.begin\s*\(\s*async\s+sql\s*=>/);
+  });
+
+  test('both search methods use SET LOCAL for the timeout', () => {
+    const keyword = extractMethod(SRC, 'searchKeyword');
+    const vector = extractMethod(SRC, 'searchVector');
+    expect(keyword).toMatch(/SET\s+LOCAL\s+statement_timeout/);
+    expect(vector).toMatch(/SET\s+LOCAL\s+statement_timeout/);
+  });
+
+  test('neither search method clears the timeout with `SET statement_timeout = 0`', () => {
+    // The reset-to-zero pattern was the other half of the leak: if SET
+    // LOCAL is in play, COMMIT handles the reset and an explicit
+    // `SET statement_timeout = '0'` would itself leak the GUC change
+    // onto the returned connection. Strip comments first so the
+    // commentary in the method itself (which quotes the anti-pattern
+    // to explain it) does not trigger a false positive.
+    const keyword = stripComments(extractMethod(SRC, 'searchKeyword'));
+    const vector = stripComments(extractMethod(SRC, 'searchVector'));
+    expect(keyword).not.toMatch(/SET\s+statement_timeout\s*=\s*['"]?0/);
+    expect(vector).not.toMatch(/SET\s+statement_timeout\s*=\s*['"]?0/);
+  });
+});
+
+function stripComments(s: string): string {
+  return s
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|\s)\/\/[^\n]*/g, '$1');
+}
+
+// extractMethod grabs the body of a class method by brace-matching from
+// its opening line. Returns the method body up to the matching closing
+// brace. Good enough for the small number of methods in this file.
+function extractMethod(source: string, name: string): string {
+  // Find "async <name>(" at method-definition indentation (2 spaces).
+  const openRe = new RegExp(`^\\s+async\\s+${name}\\s*\\(`, 'm');
+  const match = openRe.exec(source);
+  if (!match) {
+    throw new Error(`method ${name} not found in postgres-engine.ts`);
+  }
+  // Scan forward balancing braces.
+  let i = source.indexOf('{', match.index);
+  if (i < 0) throw new Error(`no opening brace for ${name}`);
+  const start = i;
+  let depth = 0;
+  for (; i < source.length; i++) {
+    const c = source[i];
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces in ${name}`);
+}


### PR DESCRIPTION
## Summary

`searchKeyword` and `searchVector` in `src/core/postgres-engine.ts` are the two hot-path search methods. Both run on a shared postgres.js client whose default pool size is 10 connections, and both try to cap query runtime with a `statement_timeout` GUC so a bad query can't hog a connection forever:

```ts
await sql`SET statement_timeout = '8s'`;
try {
  const rows = await sql`<search query>`;
  return rows.map(rowToSearchResult);
} finally {
  await sql`SET statement_timeout = '0'`;
}
```

The intent is right. The implementation leaks because every tagged-template call is an independent round-trip that picks an arbitrary connection from the pool. Under concurrency — which is exactly the shape of a hot search path — the three statements can land on different connections:

- The `SET` modifies connection A. Connection A returns to the pool with `statement_timeout = '8s'` still set.
- The search query runs on connection B (pool picked a different one).
- The `finally` reset lands on connection C.

What the next caller sees depends on which connection the pool hands them:

- If they grab A, any long-running query they run gets **clipped at 8s** — wrong cancellation for `embed --all`, large imports, admin queries, anything that's allowed to take time.
- If the reset-to-zero landed on D, any future caller on D gets the guard **disabled**, so they can no longer rely on the cap.

An error between the `SET` and the `finally` makes it permanent. The leaked GUC sits on a pooled connection until the pool churns it out or the process restarts.

Reported as R6-F006 in the latest audit; the earlier audit filed the same pattern on `searchKeyword` alone as R4-F002, and the regression check found it still present at v0.10.1. This PR closes both.

## Fix

Wrap each search query in `sql.begin(async sql => …)` and use `SET LOCAL`:

```ts
const rows = await sql.begin(async sql => {
  await sql`SET LOCAL statement_timeout = '8s'`;
  return await sql`<search query>`;
});
return rows.map(rowToSearchResult);
```

Two invariants hold now that didn't before:

1. **One connection for the whole transaction.** postgres.js reserves a single connection for the body of `sql.begin`. The `SET LOCAL`, the query, and the implicit `COMMIT` all run on the same connection, so the timeout really applies to the query we care about.
2. **Scoped GUC, no manual reset.** `SET LOCAL` is transaction-scoped; `COMMIT` restores the previous value automatically. `ROLLBACK` (triggered by any throw inside the callback) does the same. The explicit `finally { SET = 0 }` is gone because it cannot be needed.

No API change. Search semantics are identical: same 8s cap, same behaviour on valid and invalid queries, same return shape. `embed --all`, bulk import, and other long-running paths were never inside these methods and are unaffected.

### Why a transaction rather than a second dedicated pool

A reserved single-connection pool for searches would also work but adds a second postgres.js client, a second set of connect / disconnect hooks, and a second thing to keep in sync with auth and RLS. A transaction wrapper is three extra lines of code, zero new config, and uses the library's intended primitive for scoped GUCs.

## Reproduction

Before the fix, a concurrency smoke test makes the leak visible on a live pool:

```ts
// SETUP: two clients pointing at the same DB, one small pool
const sql = postgres(url, { max: 10 });

// Request A: the search method crashes after SET, before finally
await sql`SET statement_timeout = '8s'`;
throw new Error('boom');  // finally reset never runs

// Request B: runs a long query that should be allowed
await sql`SELECT pg_sleep(30)`;
// → query cancelled at 8s. That's the leak.
```

With `sql.begin`, the same crash path aborts the transaction on its own connection; the 8s GUC never survives the rollback.

## Sibling review

Grepped `src/core/postgres-engine.ts` for every `SET` statement:

| Line | Statement | Scope | Status |
|---|---|---|---|
| previous 195 | `SET statement_timeout = '8s'` in searchKeyword | pool-wide (leak) | **fixed** to `SET LOCAL` inside `sql.begin` |
| previous 226 | `SET statement_timeout = '0'` in searchKeyword finally | pool-wide (leak) | **removed**; COMMIT resets |
| previous 245 | `SET statement_timeout = '8s'` in searchVector | pool-wide (leak) | **fixed** to `SET LOCAL` inside `sql.begin` |
| previous 265 | `SET statement_timeout = '0'` in searchVector finally | pool-wide (leak) | **removed**; COMMIT resets |

No other `SET` statements against the pool elsewhere in `src/`. A grep for `SET LOCAL` in the rest of the codebase returned nothing, so the new pattern does not collide with existing usage.

## Test results

### Source-level guardrails — `test/postgres-engine.test.ts`

Live Postgres coverage lives in `test/e2e/search-quality.test.ts` and will keep exercising these methods end-to-end when `DATABASE_URL` is set. The new file is a fast, DB-free guardrail against future regressions:

1. **`no bare SET statement_timeout statement survives`** — strips comments, then asserts no `` sql`SET statement_timeout` `` remains outside a `SET LOCAL`. If a future change reintroduces the anti-pattern, this turns red before review.
2. **`searchKeyword wraps its query in sql.begin()`** — structural check on the method body.
3. **`searchVector wraps its query in sql.begin()`** — same.
4. **Both methods use `SET LOCAL`.**
5. **Neither method explicitly clears the timeout with `SET statement_timeout = 0`.**

All five pass on this branch. Against master (the vulnerable code) the same file fails 5/5 — the tests catch the exact shape of the bug.

### Full suite

```
bun test
 846 pass
 131 skip     (E2E without DATABASE_URL)
   0 fail
Ran 977 tests across 53 files.
```

## What stayed in place

- Public engine API (`searchKeyword`, `searchVector`) is byte-identical in signature and return type.
- 8-second timeout and `clampSearchLimit` behaviour preserved.
- Pool configuration untouched: `max`, `idle_timeout`, `connect_timeout` come from `connect()` as before.
- No new dependency.

## Files

```
 src/core/postgres-engine.ts  |  36 ++++++++---------
 test/postgres-engine.test.ts | 112 +++++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 132 insertions(+), 16 deletions(-)
```

## How to verify

```bash
git checkout security/postgres-pool-timeout-leak
bun install
bun test test/postgres-engine.test.ts   # 5 pass
bun test                                  # 846 pass, 0 fail
# Optional, requires DATABASE_URL:
bun run test:e2e                          # search-quality suite hits the new code paths
```
