### PR TITLE
fix: parse pgvector embeddings before cosine rescoring

### DIFF
--- a/recipes/x-to-brain.md
+++ b/recipes/x-to-brain.md
@@ -11,10 +11,10 @@ secrets:
     where: https://developer.x.com/en/portal/dashboard — create a project + app, copy the Bearer Token from "Keys and tokens"
 health_checks:
   - type: http
-    url: "https://api.x.com/2/users/me"
+    url: "https://api.x.com/2/users/by/username/X"
     auth: bearer
     auth_token: "$X_BEARER_TOKEN"
-    label: "X API"
+    label: "X API bearer auth"
 setup_time: 15 min
 cost_estimate: "$0-200/mo (Free tier: 1 app, read-only. Basic: $200/mo for search + higher limits)"
 ---

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -17,7 +17,7 @@ import type {
 } from './types.ts';
 import { GBrainError } from './types.ts';
 import * as db from './db.ts';
-import { validateSlug, contentHash, rowToPage, rowToChunk, rowToSearchResult } from './utils.ts';
+import { validateSlug, contentHash, parseEmbedding, rowToPage, rowToChunk, rowToSearchResult } from './utils.ts';
 
 export class PostgresEngine implements BrainEngine {
   private _sql: ReturnType<typeof postgres> | null = null;
@@ -275,7 +275,8 @@ export class PostgresEngine implements BrainEngine {
     `;
     const result = new Map<number, Float32Array>();
     for (const row of rows) {
-      if (row.embedding) result.set(row.id as number, row.embedding as Float32Array);
+      const embedding = parseEmbedding(row.embedding);
+      if (embedding) result.set(row.id as number, embedding);
     }
     return result;
   }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,6 +1,26 @@
 import { createHash } from 'crypto';
 import type { Page, PageInput, PageType, Chunk, SearchResult } from './types.ts';
 
+export function parseEmbedding(value: unknown): Float32Array | null {
+  if (!value) return null;
+
+  if (value instanceof Float32Array) return value;
+
+  if (Array.isArray(value)) {
+    return new Float32Array(value.map(Number));
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) return null;
+    const body = trimmed.slice(1, -1).trim();
+    if (!body) return new Float32Array();
+    return new Float32Array(body.split(',').map(part => Number(part.trim())));
+  }
+
+  return null;
+}
+
 /**
  * Validate and normalize a slug. Slugs are lowercased repo-relative paths.
  * Rejects empty slugs, path traversal (..), and leading /.
@@ -50,7 +70,7 @@ export function rowToChunk(row: Record<string, unknown>, includeEmbedding = fals
     chunk_index: row.chunk_index as number,
     chunk_text: row.chunk_text as string,
     chunk_source: row.chunk_source as 'compiled_truth' | 'timeline',
-    embedding: includeEmbedding && row.embedding ? row.embedding as Float32Array : null,
+    embedding: includeEmbedding ? parseEmbedding(row.embedding) : null,
     model: row.model as string,
     token_count: row.token_count as number | null,
     embedded_at: row.embedded_at ? new Date(row.embedded_at as string) : null,

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { validateSlug, contentHash, rowToPage, rowToChunk, rowToSearchResult } from '../src/core/utils.ts';
+import { validateSlug, contentHash, parseEmbedding, rowToPage, rowToChunk, rowToSearchResult } from '../src/core/utils.ts';
 
 describe('validateSlug', () => {
   test('accepts valid slugs', () => {
@@ -97,6 +97,40 @@ describe('rowToChunk', () => {
       model: 'test', token_count: 5, embedded_at: '2024-01-01',
     }, true);
     expect(chunk.embedding).not.toBeNull();
+  });
+
+  test('parses pgvector string embeddings when requested', () => {
+    const chunk = rowToChunk({
+      id: 1, page_id: 1, chunk_index: 0, chunk_text: 'text',
+      chunk_source: 'compiled_truth', embedding: '[0.1, 0.2, 0.3]',
+      model: 'test', token_count: 5, embedded_at: '2024-01-01',
+    }, true);
+    expect(chunk.embedding).toBeInstanceOf(Float32Array);
+    expect(Array.from(chunk.embedding || [])).toHaveLength(3);
+    expect(chunk.embedding?.[0]).toBeCloseTo(0.1, 6);
+    expect(chunk.embedding?.[1]).toBeCloseTo(0.2, 6);
+    expect(chunk.embedding?.[2]).toBeCloseTo(0.3, 6);
+  });
+});
+
+describe('parseEmbedding', () => {
+  test('returns Float32Array unchanged', () => {
+    const emb = new Float32Array([0.1, 0.2]);
+    expect(parseEmbedding(emb)).toBe(emb);
+  });
+
+  test('parses pgvector text into Float32Array', () => {
+    const parsed = parseEmbedding('[0.1, 0.2, 0.3]');
+    expect(parsed).toBeInstanceOf(Float32Array);
+    expect(Array.from(parsed || [])).toHaveLength(3);
+    expect(parsed?.[0]).toBeCloseTo(0.1, 6);
+    expect(parsed?.[1]).toBeCloseTo(0.2, 6);
+    expect(parsed?.[2]).toBeCloseTo(0.3, 6);
+  });
+
+  test('returns null for unsupported embedding values', () => {
+    expect(parseEmbedding(null)).toBeNull();
+    expect(parseEmbedding('not-a-vector')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Fix a Postgres/Supabase search bug where `gbrain query` could render `[NaN]`
scores after cosine rescoring.

The root cause was that `getEmbeddingsByChunkIds()` could return pgvector values
as strings (for example `"[0.1, 0.2, ...]"`) instead of `Float32Array`s. Those
string values were then passed into cosine similarity math, which produced
`NaN` scores.

This change adds a shared embedding parser and uses it in the Postgres path
before cosine rescoring.

## Changes

- add `parseEmbedding()` in `src/core/utils.ts`
- use `parseEmbedding()` in `rowToChunk()`
- use `parseEmbedding()` in `PostgresEngine.getEmbeddingsByChunkIds()`
- add regression tests for pgvector-string parsing in `test/utils.test.ts`

## Why this is needed

Before this fix, hybrid search itself was returning valid RRF scores, but the
Postgres/Supabase cosine rescoring step converted them into `NaN` because the
embedding type coming back from the DB was not normalized.

After this fix, query results render normal numeric scores again and semantic
ranking works as expected on the Postgres engine.

## Test Plan

Run the targeted unit tests:

```bash
bun test test/utils.test.ts test/search.test.ts
```

Manual verification against a real Supabase-backed brain:

```bash
gbrain query "what happened in ayor pmo meetings"
```
Before this fix, the query output showed `[NaN]` scores.
After this fix, the query output shows normal numeric scores like `[0.8315]`.