### PR TITLE
Support writing page type inference

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -169,6 +169,7 @@ function inferType(filePath?: string): PageType {
   if (lower.includes('/projects/') || lower.includes('/project/')) return 'project';
   if (lower.includes('/sources/') || lower.includes('/source/')) return 'source';
   if (lower.includes('/media/')) return 'media';
+  if (lower.includes('/writing/')) return 'writing';
   return 'concept';
 }
 

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -265,6 +265,7 @@ Some content.`;
     expect(parseMarkdown('', 'people/someone.md').type).toBe('person');
     expect(parseMarkdown('', 'concepts/thing.md').type).toBe('concept');
     expect(parseMarkdown('', 'companies/acme.md').type).toBe('company');
+    expect(parseMarkdown('', 'writing/post.md').type).toBe('writing');
   });
 
   test('infers type from wiki subdirectory paths', () => {


### PR DESCRIPTION
## What changed
- add `writing` to `PageType`
- infer `/writing/` paths as `writing`
- add a regression test for `writing/post.md`

## Why
`docs/GBRAIN_RECOMMENDED_SCHEMA.md` documents a `writing/` directory, but runtime type inference defaulted those pages to `concept`.

Closes #176.

## Validation
- `bun test test/markdown.test.ts`
- `bun test test/import-file.test.ts`
- `bun test test/slug-validation.test.ts`
