### PR TITLE
ci: add bun-windows-x64 to release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,15 @@ jobs:
           - os: macos-latest
             target: bun-darwin-arm64
             artifact: gbrain-darwin-arm64
+            ext: ""
           - os: ubuntu-latest
             target: bun-linux-x64
             artifact: gbrain-linux-x64
+            ext: ""
+          - os: windows-latest
+            target: bun-windows-x64
+            artifact: gbrain-windows-x64
+            ext: ".exe"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -26,11 +32,11 @@ jobs:
           bun-version: latest
       - run: bun install
       - run: bun test
-      - run: bun build --compile --target=${{ matrix.target }} --outfile bin/${{ matrix.artifact }} src/cli.ts
+      - run: bun build --compile --target=${{ matrix.target }} --outfile bin/${{ matrix.artifact }}${{ matrix.ext }} src/cli.ts
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ matrix.artifact }}
-          path: bin/${{ matrix.artifact }}
+          path: bin/${{ matrix.artifact }}${{ matrix.ext }}
 
   release:
     needs: build
@@ -45,4 +51,5 @@ jobs:
           files: |
             artifacts/gbrain-darwin-arm64/gbrain-darwin-arm64
             artifacts/gbrain-linux-x64/gbrain-linux-x64
+            artifacts/gbrain-windows-x64/gbrain-windows-x64.exe
           generate_release_notes: true

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "dev": "bun run src/cli.ts",
     "build": "bun build --compile --outfile bin/gbrain src/cli.ts",
-    "build:all": "bun build --compile --target=bun-darwin-arm64 --outfile bin/gbrain-darwin-arm64 src/cli.ts && bun build --compile --target=bun-linux-x64 --outfile bin/gbrain-linux-x64 src/cli.ts",
+    "build:all": "bun build --compile --target=bun-darwin-arm64 --outfile bin/gbrain-darwin-arm64 src/cli.ts && bun build --compile --target=bun-linux-x64 --outfile bin/gbrain-linux-x64 src/cli.ts && bun build --compile --target=bun-windows-x64 --outfile bin/gbrain-windows-x64.exe src/cli.ts",
     "build:schema": "bash scripts/build-schema.sh",
     "test": "bun test",
     "test:e2e": "bun test test/e2e/",


### PR DESCRIPTION
## Summary

Add `bun-windows-x64` to the release build matrix so tagged releases publish `gbrain-windows-x64.exe` alongside the Mac and Linux artifacts. Windows users currently have no upgrade path — `gbrain upgrade` on a binary install sends people to the Releases page, which has no Windows download. They either rebuild from source locally on every bump or stay stuck on whatever version they first compiled.

**Why this matters:**
The npm name `gbrain` is already taken (by an unrelated ML library, `stormcolor/gbrain`@1.3.1), so `bun install -g gbrain` isn't an option for Windows users either. Without a CI-published `.exe`, Windows has no supported install path at all. This PR closes that gap with one matrix entry.

## Changes

- `.github/workflows/release.yml` — add Windows to the build matrix:
  - New `ext` column on the matrix so the shared `--outfile` / `upload-artifact path` pattern works: empty on macOS/Linux, `.exe` on Windows.
  - Add `artifacts/gbrain-windows-x64/gbrain-windows-x64.exe` to the release files list so the artifact lands on the Releases page.
- `package.json` — extend `build:all` with the Windows target so `bun run build:all` matches CI and local devs get parity.

## Dependency

Depends on the companion PR that fixes Bun's `--compile` asset embedding for PGLite. Without that fix, the Windows `.exe` **compiles** successfully (verified locally: 114 MB binary produced on `windows-latest`-equivalent), but **crashes at runtime** on the first PGLite command with `Extension bundle not found`. Same crash happens on Mac and Linux today — it just hasn't been felt because the binary test loop is light. Merge that PR first, then this one.

## Test plan

- [x] Verified locally: `bun build --compile --target=bun-windows-x64 --outfile bin/gbrain-windows-x64.exe src/cli.ts` succeeds (887 modules bundled, ~114 MB output).
- [x] YAML lints cleanly, matrix expansion covers all three `os` / `target` / `artifact` / `ext` combinations.
- [ ] CI run on a tag push, validating all three artifacts land in the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)