### PR TITLE
fix: use config API key for embeddings

### DIFF
--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -8,6 +8,7 @@
  */
 
 import OpenAI from 'openai';
+import { loadConfig } from './config.ts';
 
 const MODEL = 'text-embedding-3-large';
 const DIMENSIONS = 1536;
@@ -18,10 +19,17 @@ const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
 
 let client: OpenAI | null = null;
+let clientApiKey: string | undefined;
+
+export function resolveApiKey(): string | undefined {
+  return process.env.OPENAI_API_KEY || loadConfig()?.openai_api_key;
+}
 
 function getClient(): OpenAI {
-  if (!client) {
-    client = new OpenAI();
+  const apiKey = resolveApiKey();
+  if (!client || clientApiKey !== apiKey) {
+    client = apiKey ? new OpenAI({ apiKey }) : new OpenAI();
+    clientApiKey = apiKey;
   }
   return client;
 }

--- a/test/embedding-config.test.ts
+++ b/test/embedding-config.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function runResolveApiKey(homeDir: string, env: Record<string, string | undefined> = {}) {
+  const proc = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      '--eval',
+      `import { resolveApiKey } from './src/core/embedding.ts'; console.log(resolveApiKey() ?? '');`,
+    ],
+    cwd: '/Users/basitmustafa/Documents/GitHub/upstream/gbrain',
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      OPENAI_API_KEY: env.OPENAI_API_KEY,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  return {
+    exitCode: proc.exitCode,
+    stdout: new TextDecoder().decode(proc.stdout).trim(),
+    stderr: new TextDecoder().decode(proc.stderr).trim(),
+  };
+}
+
+describe('embedding config', () => {
+  test('uses config openai_api_key when env var is absent', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'gbrain-config-test-'));
+    try {
+      mkdirSync(join(homeDir, '.gbrain'), { recursive: true });
+      writeFileSync(
+        join(homeDir, '.gbrain', 'config.json'),
+        JSON.stringify({ engine: 'postgres', openai_api_key: 'config-key' }),
+      );
+
+      const result = runResolveApiKey(homeDir);
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toBe('config-key');
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+
+  test('prefers OPENAI_API_KEY env var over config openai_api_key', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'gbrain-config-test-'));
+    try {
+      mkdirSync(join(homeDir, '.gbrain'), { recursive: true });
+      writeFileSync(
+        join(homeDir, '.gbrain', 'config.json'),
+        JSON.stringify({ engine: 'postgres', openai_api_key: 'config-key' }),
+      );
+
+      const result = runResolveApiKey(homeDir, { OPENAI_API_KEY: 'env-key' });
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toBe('env-key');
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- resolve the embedding client API key from either `OPENAI_API_KEY` or `~/.gbrain/config.json`
- rebuild the OpenAI client when the resolved key changes so tests can cover env/config precedence cleanly
- add a focused regression test for config-backed embedding credentials

## Why this matters
`gbrain embed --stale` currently assumes `OPENAI_API_KEY` is present in the shell environment. In real local installs, `gbrain init` persists `openai_api_key` in `~/.gbrain/config.json`, and other commands already rely on config loading. That leaves embeddings in a broken state for users whose shell env is clean but whose saved config is valid.

## Test plan
- [x] `bun test test/embedding-config.test.ts test/embed.test.ts`
- [x] `bun test`
- [ ] `bun run test:e2e` *(blocked locally: no reachable test Postgres at `localhost:5434` in this environment, ideally CI checks will spin up/set up an env appropriate for this)*
