### PR TITLE
fix: remove outer transaction wrapper in sync to prevent PGlite deadlock

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -203,8 +203,12 @@ export async function performSync(engine: BrainEngine, opts: SyncOpts): Promise<
     pagesAffected.push(newSlug);
   }
 
-  // Process adds and modifies
-  const useTransaction = (filtered.added.length + filtered.modified.length) > 10;
+  // Process adds and modifies.
+  // NOTE: importFile manages its own transaction internally. Wrapping all
+  // importFile() calls in an outer engine.transaction() causes nested
+  // db.transaction() calls that deadlock PGlite's event loop indefinitely
+  // (reproducible with >10 files in a single sync). Each file import is
+  // individually atomic — no outer wrapper needed.
   const processAddsModifies = async () => {
     for (const path of [...filtered.added, ...filtered.modified]) {
       const filePath = join(repoPath, path);
@@ -222,11 +226,7 @@ export async function performSync(engine: BrainEngine, opts: SyncOpts): Promise<
     }
   };
 
-  if (useTransaction) {
-    await engine.transaction(async () => { await processAddsModifies(); });
-  } else {
-    await processAddsModifies();
-  }
+  await processAddsModifies();
 
   const elapsed = Date.now() - start;
 


### PR DESCRIPTION
## Problem

When syncing more than 10 changed files, `sync.ts` wraps all `importFile()` calls inside a single `engine.transaction()`:

```ts
const useTransaction = (filtered.added.length + filtered.modified.length) > 10;
if (useTransaction) {
  await engine.transaction(async () => { await processAddsModifies(); });
} else {
  await processAddsModifies();
}
```

However, `importFile()` opens its own inner transaction on the same DB connection. **PGlite does not support nested transactions** — the event loop hangs indefinitely with no error, no output, and no timeout.

This makes `gbrain sync` silently hang forever whenever a repo has more than 10 changed files.

## Fix

Remove the conditional outer `engine.transaction()` wrapper. Each `importFile()` call is already individually atomic, so no outer wrapper is needed.

## Reproduction

1. Have a git repo with 11+ changed markdown files tracked in gbrain
2. Run `gbrain sync --repo <path>`
3. Observe: process hangs at 0% CPU indefinitely

## Testing

Verified locally with a repo containing 17 changed files — sync now completes successfully.