### PR TITLE
[codex] finish voyage embedding slice

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,5 +1,5 @@
 import type { BrainEngine } from '../core/engine.ts';
-import { embedBatch } from '../core/embedding.ts';
+import { embedBatch, EMBEDDING_MODEL } from '../core/embedding.ts';
 import type { ChunkInput } from '../core/types.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
 
@@ -109,7 +109,8 @@ async function embedPage(engine: BrainEngine, slug: string) {
     chunk_index: c.chunk_index,
     chunk_text: c.chunk_text,
     chunk_source: c.chunk_source,
-    embedding: embeddingMap.get(c.chunk_index),
+    embedding: embeddingMap.get(c.chunk_index) ?? c.embedding,
+    model: embeddingMap.has(c.chunk_index) ? EMBEDDING_MODEL : c.model,
     token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
   }));
 
@@ -157,7 +158,8 @@ async function embedAll(engine: BrainEngine, staleOnly: boolean) {
         chunk_index: c.chunk_index,
         chunk_text: c.chunk_text,
         chunk_source: c.chunk_source,
-        embedding: embeddingMap.get(c.chunk_index) ?? undefined,
+        embedding: embeddingMap.get(c.chunk_index) ?? c.embedding,
+        model: embeddingMap.has(c.chunk_index) ? EMBEDDING_MODEL : c.model,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
       await engine.upsertChunks(page.slug, updated);

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -1,16 +1,40 @@
 /**
  * Embedding Service
- * Ported from production Ruby implementation (embedding_service.rb, 190 LOC)
+ * Supports OpenAI by default, and Voyage when VOYAGE_API_KEY is present.
  *
- * OpenAI text-embedding-3-large at 1536 dimensions.
+ * Current storage schema is vector(1536), so Voyage defaults to voyage-large-2
+ * to avoid a database migration during local bootstrap.
  * Retry with exponential backoff (4s base, 120s cap, 5 retries).
  * 8000 character input truncation.
  */
 
 import OpenAI from 'openai';
 
-const MODEL = 'text-embedding-3-large';
+type EmbeddingProvider = 'openai' | 'voyage';
+
+interface EmbeddingConfig {
+  provider: EmbeddingProvider;
+  model: string;
+  dimensions: number;
+  enabled: boolean;
+}
+
 const DIMENSIONS = 1536;
+
+export function resolveEmbeddingConfig(env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env): EmbeddingConfig {
+  const provider: EmbeddingProvider = env.VOYAGE_API_KEY ? 'voyage' : 'openai';
+
+  return {
+    provider,
+    model: provider === 'voyage' ? 'voyage-large-2' : 'text-embedding-3-large',
+    dimensions: DIMENSIONS,
+    enabled: Boolean(env.VOYAGE_API_KEY || env.OPENAI_API_KEY),
+  };
+}
+
+const CONFIG = resolveEmbeddingConfig();
+const PROVIDER = CONFIG.provider;
+const MODEL = CONFIG.model;
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
@@ -21,9 +45,18 @@ let client: OpenAI | null = null;
 
 function getClient(): OpenAI {
   if (!client) {
-    client = new OpenAI();
+    client = new OpenAI(PROVIDER === 'voyage'
+      ? {
+          apiKey: process.env.VOYAGE_API_KEY,
+          baseURL: 'https://api.voyageai.com/v1',
+        }
+      : undefined);
   }
   return client;
+}
+
+export function embeddingsEnabled(): boolean {
+  return resolveEmbeddingConfig().enabled;
 }
 
 export async function embed(text: string): Promise<Float32Array> {
@@ -49,11 +82,18 @@ export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
 async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const response = await getClient().embeddings.create({
-        model: MODEL,
-        input: texts,
-        dimensions: DIMENSIONS,
-      });
+      const response = await getClient().embeddings.create(
+        PROVIDER === 'voyage'
+          ? {
+              model: MODEL,
+              input: texts,
+            }
+          : {
+              model: MODEL,
+              input: texts,
+              dimensions: DIMENSIONS,
+            },
+      );
 
       // Sort by index to maintain order
       const sorted = response.data.sort((a, b) => a.index - b.index);

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -3,7 +3,7 @@ import { createHash } from 'crypto';
 import type { BrainEngine } from './engine.ts';
 import { parseMarkdown } from './markdown.ts';
 import { chunkText } from './chunkers/recursive.ts';
-import { embedBatch } from './embedding.ts';
+import { embedBatch, EMBEDDING_MODEL } from './embedding.ts';
 import { slugifyPath } from './sync.ts';
 import type { ChunkInput, PageType } from './types.ts';
 
@@ -115,6 +115,7 @@ export async function importFromContent(
       const embeddings = await embedBatch(chunks.map(c => c.chunk_text));
       for (let i = 0; i < chunks.length; i++) {
         chunks[i].embedding = embeddings[i];
+        chunks[i].model = EMBEDDING_MODEL;
         chunks[i].token_count = Math.ceil(chunks[i].chunk_text.length / 4);
       }
     } catch (e: unknown) {

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -12,7 +12,7 @@
 import type { BrainEngine } from '../engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../engine.ts';
 import type { SearchResult, SearchOpts } from '../types.ts';
-import { embed } from '../embedding.ts';
+import { embed, embeddingsEnabled } from '../embedding.ts';
 import { dedupResults } from './dedup.ts';
 import { autoDetectDetail } from './intent.ts';
 
@@ -77,8 +77,8 @@ export async function hybridSearch(
   // Run keyword search (always available, no API key needed)
   const keywordResults = await engine.searchKeyword(query, searchOpts);
 
-  // Skip vector search entirely if no OpenAI key is configured
-  if (!process.env.OPENAI_API_KEY) {
+  // Skip vector search entirely if no embedding provider is configured.
+  if (!embeddingsEnabled()) {
     // Apply backlink boost in keyword-only path too. One getBacklinkCounts query
     // per search request; not N+1.
     if (keywordResults.length > 0) {

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -9,6 +9,7 @@ let maxConcurrentEmbedCalls = 0;
 let totalEmbedCalls = 0;
 
 mock.module('../src/core/embedding.ts', () => ({
+  EMBEDDING_MODEL: 'text-embedding-3-large',
   embedBatch: async (texts: string[]) => {
     activeEmbedCalls++;
     totalEmbedCalls++;
@@ -124,5 +125,98 @@ describe('runEmbed --all (parallel)', () => {
 
     // Only the stale page triggers an embedBatch call.
     expect(totalEmbedCalls).toBe(1);
+  });
+
+  test('preserves existing embedding metadata on fresh chunks when embedding a single page', async () => {
+    const existingEmbedding = new Float32Array([1, 2, 3]);
+    const chunks = [
+      {
+        chunk_index: 0,
+        chunk_text: 'already embedded',
+        chunk_source: 'compiled_truth',
+        embedded_at: '2026-01-01',
+        embedding: existingEmbedding,
+        model: 'legacy-model',
+        token_count: 4,
+      },
+      {
+        chunk_index: 1,
+        chunk_text: 'stale chunk',
+        chunk_source: 'timeline',
+        embedded_at: null,
+        token_count: 3,
+      },
+    ];
+    let updatedChunks: any[] | undefined;
+
+    const engine = mockEngine({
+      getPage: async () => ({ slug: 'page-1', compiled_truth: 'x', timeline: 'y' }),
+      getChunks: async () => chunks,
+      upsertChunks: async (_slug: string, nextChunks: any[]) => {
+        updatedChunks = nextChunks;
+      },
+    });
+
+    await runEmbed(engine, ['page-1']);
+
+    expect(updatedChunks).toBeTruthy();
+    expect(updatedChunks).toHaveLength(2);
+
+    const freshChunk = updatedChunks!.find((chunk: any) => chunk.chunk_index === 0);
+    const staleChunk = updatedChunks!.find((chunk: any) => chunk.chunk_index === 1);
+
+    expect(freshChunk.embedding).toBe(existingEmbedding);
+    expect(freshChunk.model).toBe('legacy-model');
+    expect(staleChunk.embedding).toBeInstanceOf(Float32Array);
+    expect(staleChunk.model).toBe('text-embedding-3-large');
+  });
+
+  test('preserves existing embedding metadata on fresh chunks when embedding stale pages in bulk', async () => {
+    const existingEmbedding = new Float32Array([4, 5, 6]);
+    const pages = [{ slug: 'page-1' }];
+    const chunksBySlug = new Map<string, any[]>([
+      ['page-1', [
+        {
+          chunk_index: 0,
+          chunk_text: 'already embedded',
+          chunk_source: 'compiled_truth',
+          embedded_at: '2026-01-01',
+          embedding: existingEmbedding,
+          model: 'legacy-model',
+          token_count: 4,
+        },
+        {
+          chunk_index: 1,
+          chunk_text: 'stale chunk',
+          chunk_source: 'timeline',
+          embedded_at: null,
+          token_count: 3,
+        },
+      ]],
+    ]);
+    let updatedChunks: any[] | undefined;
+
+    const engine = mockEngine({
+      listPages: async () => pages,
+      getChunks: async (slug: string) => chunksBySlug.get(slug) || [],
+      upsertChunks: async (_slug: string, nextChunks: any[]) => {
+        updatedChunks = nextChunks;
+      },
+    });
+
+    process.env.GBRAIN_EMBED_CONCURRENCY = '1';
+
+    await runEmbed(engine, ['--stale']);
+
+    expect(updatedChunks).toBeTruthy();
+    expect(updatedChunks).toHaveLength(2);
+
+    const freshChunk = updatedChunks!.find((chunk: any) => chunk.chunk_index === 0);
+    const staleChunk = updatedChunks!.find((chunk: any) => chunk.chunk_index === 1);
+
+    expect(freshChunk.embedding).toBe(existingEmbedding);
+    expect(freshChunk.model).toBe('legacy-model');
+    expect(staleChunk.embedding).toBeInstanceOf(Float32Array);
+    expect(staleChunk.model).toBe('text-embedding-3-large');
   });
 });

--- a/test/embedding.test.ts
+++ b/test/embedding.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+
+describe('embedding config', () => {
+  test('defaults to OpenAI config when no embedding keys are present', async () => {
+    const mod = await import('../src/core/embedding.ts');
+    const config = mod.resolveEmbeddingConfig({});
+
+    expect(config.provider).toBe('openai');
+    expect(config.model).toBe('text-embedding-3-large');
+    expect(config.enabled).toBe(false);
+    expect(config.dimensions).toBe(1536);
+  });
+
+  test('enables OpenAI embeddings when OPENAI_API_KEY is present', async () => {
+    const mod = await import('../src/core/embedding.ts');
+    const config = mod.resolveEmbeddingConfig({ OPENAI_API_KEY: 'openai-key' });
+
+    expect(config.provider).toBe('openai');
+    expect(config.model).toBe('text-embedding-3-large');
+    expect(config.enabled).toBe(true);
+  });
+
+  test('prefers Voyage when VOYAGE_API_KEY is present', async () => {
+    const mod = await import('../src/core/embedding.ts');
+    const config = mod.resolveEmbeddingConfig({
+      OPENAI_API_KEY: 'openai-key',
+      VOYAGE_API_KEY: 'voyage-key',
+    });
+
+    expect(config.provider).toBe('voyage');
+    expect(config.model).toBe('voyage-large-2');
+    expect(config.enabled).toBe(true);
+    expect(config.dimensions).toBe(1536);
+  });
+});

--- a/test/import-file-embedding.test.ts
+++ b/test/import-file-embedding.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect, mock } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+mock.module('../src/core/embedding.ts', () => ({
+  EMBEDDING_MODEL: 'voyage-large-2',
+  embedBatch: async (texts: string[]) => texts.map(() => new Float32Array([1, 2, 3])),
+}));
+
+const { importFromContent } = await import('../src/core/import-file.ts');
+
+function mockEngine(overrides: Partial<Record<string, any>> = {}): BrainEngine {
+  const calls: { method: string; args: any[] }[] = [];
+  const track = (method: string) => (...args: any[]) => {
+    calls.push({ method, args });
+    if (overrides[method]) return overrides[method](...args);
+    return Promise.resolve(null);
+  };
+
+  const engine = new Proxy({} as any, {
+    get(_, prop: string) {
+      if (prop === '_calls') return calls;
+      if (prop === 'getTags') return overrides.getTags || (() => Promise.resolve([]));
+      if (prop === 'getPage') return overrides.getPage || (() => Promise.resolve(null));
+      if (prop === 'transaction') return async (fn: (tx: BrainEngine) => Promise<any>) => fn(engine);
+      return track(prop);
+    },
+  });
+  return engine;
+}
+
+describe('importFromContent embedding metadata', () => {
+  test('stores EMBEDDING_MODEL on chunks when embeddings are generated', async () => {
+    const engine = mockEngine();
+
+    const result = await importFromContent(
+      engine,
+      'concepts/with-embedding-model',
+      `---\ntype: concept\ntitle: Embedded\n---\n\nCompiled truth text.\n\n---\n\n- 2026-01-01: Timeline item.\n`,
+    );
+
+    expect(result.status).toBe('imported');
+
+    const calls = (engine as any)._calls;
+    const chunkCall = calls.find((c: any) => c.method === 'upsertChunks');
+    expect(chunkCall).toBeTruthy();
+
+    const chunks = chunkCall.args[1];
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const chunk of chunks) {
+      expect(chunk.embedding).toBeInstanceOf(Float32Array);
+      expect(chunk.model).toBe('voyage-large-2');
+    }
+  });
+});


### PR DESCRIPTION
## What changed

This finishes the local Voyage embedding slice and turns it into a deliberate, test-backed change set instead of a half-finished dirty diff.

- preserves existing `embedding` and `model` metadata when `gbrain embed <slug>` or `gbrain embed --stale` hits pages with a mix of fresh and stale chunks
- adds explicit provider resolution in `src/core/embedding.ts` via `resolveEmbeddingConfig()`
- enables Voyage embeddings when `VOYAGE_API_KEY` is present while keeping OpenAI as the default path
- stores `EMBEDDING_MODEL` on chunks created during import embedding
- reuses shared `embeddingsEnabled()` logic in hybrid search instead of hard-coding `OPENAI_API_KEY`
- adds focused regression coverage for embed preservation, provider selection, and import-time embedding metadata

## Why it changed

The branch had two real issues:

1. A data-loss regression in the embed command path where mixed fresh/stale pages could lose existing embedding metadata.
2. A broader Voyage-provider diff that was green by accident, but not directly tested at the decision points that now matter.

This closes both gaps.

## Impact

- `gbrain embed --stale` is now safe on partially embedded pages.
- Voyage can be selected intentionally through environment configuration without leaving the decision logic opaque.
- Imported chunks now record the actual embedding model used.
- Search skips vector mode whenever neither OpenAI nor Voyage embeddings are configured.

## Root cause

The stale-embed updater rebuilt chunk rows from the newly embedded subset and used `undefined` for missing entries, which wiped pre-existing metadata on untouched chunks. Separately, the Voyage-provider path had been added as a dirty local slice without direct regression tests on provider selection or import-time model stamping.

## Validation

- `bun test`
- `bun build --compile --outfile /tmp/gbrain-current-build src/cli.ts`
