### PR TITLE
fix(migrate): parse PGLite string embeddings before re-serializing for Postgres

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -861,7 +861,18 @@ export class PGLiteEngine implements BrainEngine {
        ORDER BY cc.chunk_index`,
       [slug]
     );
-    return (rows as Record<string, unknown>[]).map(r => rowToChunk(r, true));
+    return (rows as Record<string, unknown>[]).map(r => {
+      const chunk = rowToChunk(r, true);
+      // PGLite returns vector columns as JSON-stringified arrays. Parse to Float32Array
+      // so downstream code (e.g. postgres-engine.upsertChunks during migrate) can iterate.
+      // Mirrors the same defensive parse already in getEmbeddingsByChunkIds.
+      if (typeof chunk.embedding === 'string') {
+        try {
+          chunk.embedding = new Float32Array(JSON.parse(chunk.embedding));
+        } catch { /* leave as-is if unparseable */ }
+      }
+      return chunk;
+    });
   }
 
   async executeRaw<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]> {

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -304,7 +304,9 @@ export class PostgresEngine implements BrainEngine {
 
     for (const chunk of chunks) {
       const embeddingStr = chunk.embedding
-        ? '[' + Array.from(chunk.embedding).join(',') + ']'
+        ? (typeof chunk.embedding === 'string'
+            ? chunk.embedding
+            : '[' + Array.from(chunk.embedding).join(',') + ']')
         : null;
 
       if (embeddingStr) {


### PR DESCRIPTION
## Summary

`gbrain migrate --to <postgres-url>` (e.g. PGLite → Supabase) fails on the very first page with:

```
invalid input syntax for type vector: "[[,-,0,.,0,1,2,5,4,2,7,2,5,,,-,..."
```

The corrupted vector value is the embedding being **iterated character-by-character with commas**.

## Root cause

`pglite-engine.ts:getChunksWithEmbeddings` returns the `embedding` column as a JSON-stringified array (e.g. `"[0.1,0.2,...]"`), not a `Float32Array`. PGLite's pgvector returns vector columns this way.

The migrate then passes those chunks to `postgres-engine.ts:upsertChunks` which serializes embeddings:

```ts
const embeddingStr = chunk.embedding
  ? '[' + Array.from(chunk.embedding).join(',') + ']'
  : null;
```

When `chunk.embedding` is a string, `Array.from(string)` iterates characters (`["[", "0", ".", "1", ",", ...]`). Joining with `,` produces the malformed `"[[,0,.,1,,,0,.,2,..."` and pgvector rejects it.

The sister method `pglite-engine.ts:getEmbeddingsByChunkIds` already does the right thing — parses the string back to `Float32Array`. `getChunksWithEmbeddings` was missing the same defensive parse.

## Fix (defense in depth)

1. **`pglite-engine.ts getChunksWithEmbeddings`** — parse string embeddings to `Float32Array` at source, mirroring the pattern in `getEmbeddingsByChunkIds`.
2. **`postgres-engine.ts upsertChunks`** — also accept already-stringified pgvector-format embeddings (pass-through), in case any other call site hands us a string.

13 lines added, 2 lines changed.

## Reproduction

Any PGLite source brain with `chunks.embedding` populated:

```bash
gbrain init                          # creates PGLite brain
# add some content with embeddings
gbrain migrate --to <postgres-url>   # fails on first page
```

## Verification

After patch: migrate completes successfully, embeddings transfer intact.

Verified on a real 153-page PGLite → Supabase migration (472 chunks, 1536-dim `text-embedding-3-large` vectors). Pre-patch failed immediately; post-patch completed in ~3 minutes with all embeddings intact.

## Notes

- No new tests added — happy to add them if you want a specific test format. The fix follows the same defensive pattern already in `getEmbeddingsByChunkIds`, so it's symmetry rather than a new contract.
- Found while migrating a 0.10.2 brain. Verified bug still present on master (`81b3f7a`).
- Separate (lower-priority) finding from the same investigation: `gbrain put` returns the misleading error `Page not found: <slug>` when the slug contains uppercase letters. I'll file that as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)