### PR TITLE
fix(migrations): bump v0.12.0 backfill timeout from 10min to 30min

### DIFF
--- a/src/commands/migrations/v0_12_0.ts
+++ b/src/commands/migrations/v0_12_0.ts
@@ -89,7 +89,7 @@ function phaseCBackfillLinks(opts: OrchestratorOpts): OrchestratorPhaseResult {
     // --source db is idempotent: the UNIQUE constraint on
     // (from_page_id, to_page_id, link_type) and ON CONFLICT DO NOTHING
     // make re-runs cheap. Empty brains return 0/0 quickly.
-    execSync('gbrain extract links --source db', { stdio: 'inherit', timeout: 600_000, env: process.env });
+    execSync('gbrain extract links --source db', { stdio: 'inherit', timeout: 1_800_000, env: process.env });
     return { name: 'backfill_links', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -100,7 +100,7 @@ function phaseCBackfillLinks(opts: OrchestratorOpts): OrchestratorPhaseResult {
 function phaseDBackfillTimeline(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'backfill_timeline', status: 'skipped', detail: 'dry-run' };
   try {
-    execSync('gbrain extract timeline --source db', { stdio: 'inherit', timeout: 600_000, env: process.env });
+    execSync('gbrain extract timeline --source db', { stdio: 'inherit', timeout: 1_800_000, env: process.env });
     return { name: 'backfill_timeline', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);


### PR DESCRIPTION
## Problem

`phaseCBackfillLinks` and `phaseDBackfillTimeline` in `src/commands/migrations/v0_12_0.ts` each wrap `gbrain extract {links,timeline} --source db` in an `execSync` call with `timeout: 600_000` (10 minutes).

On a brain of non-trivial size that is too tight. On my 13,002-page brain, each extraction takes ~11 minutes - right past the cutoff. Both phases return `failed`, the orchestrator marks the migration `partial`, and the daily post-upgrade hook keeps retrying the same thing and failing the same way every day.

## Fix

Bump both timeouts from `600_000` (10 min) to `1_800_000` (30 min).

At the observed rate of ~50 sec/1k pages this covers brains up to ~35k pages; larger brains will need a proportional extension, but 30 min is a far safer default than 10 min for any non-trivial corpus.

## Verification

On a 13,002-page brain (127,093 chunks, all embedded):

Before the fix: migration consistently finished as `partial`, both backfill phases timed out at ~10 min with no output written.

After the fix: migration completes cleanly in ~22 min total. Both backfill phases run to completion (~11 min each), produce their summary lines, and verify phase runs after. Migration status: `complete`.

## Scope

One-line change to two lines in one file. No new imports, no test changes needed (the existing `test/migrate.test.ts` doesn't exercise real `execSync` against prod-sized data so the timeout path isn't covered by tests today - consider that a follow-up).