### PR TITLE
test(e2e): isolate HOME in Setup Journey + Init Edge Cases blocks

### DIFF
--- a/test/e2e/mechanical.test.ts
+++ b/test/e2e/mechanical.test.ts
@@ -580,13 +580,31 @@ describeE2E('E2E: Idempotency', () => {
 // ─────────────────────────────────────────────────────────────────
 
 describeE2E('E2E: Setup Journey', () => {
+  // Isolate HOME so `gbrain init --non-interactive --url ...` cannot clobber
+  // the developer's real ~/.gbrain/config.json when tests run against
+  // Supabase creds in CI, or against localhost in dev. See the pattern in
+  // test/e2e/migration-flow.test.ts for the canonical HOME-override setup.
+  let origHome: string | undefined;
+  let tempHome: string | undefined;
+
   beforeAll(async () => {
+    origHome = process.env.HOME;
+    tempHome = mkdtempSync(join(tmpdir(), 'gbrain-e2e-setup-home-'));
+    process.env.HOME = tempHome;
     await setupDB();
   });
-  afterAll(teardownDB);
+  afterAll(async () => {
+    await teardownDB();
+    if (origHome === undefined) delete process.env.HOME;
+    else process.env.HOME = origHome;
+    try { if (tempHome) rmSync(tempHome, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
 
   const cliCwd = join(import.meta.dir, '../..');
-  const cliEnv = () => ({ ...process.env, DATABASE_URL: process.env.DATABASE_URL! });
+  // Pass HOME explicitly so subprocesses see the temp HOME, not the caller's
+  // real HOME. Without this, ...process.env would have already been captured
+  // at module load before the beforeAll override took effect.
+  const cliEnv = () => ({ ...process.env, DATABASE_URL: process.env.DATABASE_URL!, HOME: process.env.HOME! });
 
   test('gbrain init --non-interactive connects and initializes', () => {
     const result = Bun.spawnSync({
@@ -650,10 +668,24 @@ describeE2E('E2E: Setup Journey', () => {
 // ─────────────────────────────────────────────────────────────────
 
 describeE2E('E2E: Init Edge Cases', () => {
-  afterAll(teardownDB);
+  // Same HOME-isolation rationale as the Setup Journey block above.
+  let origHome: string | undefined;
+  let tempHome: string | undefined;
+
+  beforeAll(() => {
+    origHome = process.env.HOME;
+    tempHome = mkdtempSync(join(tmpdir(), 'gbrain-e2e-init-edge-home-'));
+    process.env.HOME = tempHome;
+  });
+  afterAll(async () => {
+    await teardownDB();
+    if (origHome === undefined) delete process.env.HOME;
+    else process.env.HOME = origHome;
+    try { if (tempHome) rmSync(tempHome, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
 
   test('init --non-interactive without URL fails gracefully', () => {
-    const env = { ...process.env };
+    const env = { ...process.env, HOME: process.env.HOME! };
     delete env.DATABASE_URL;
     delete env.GBRAIN_DATABASE_URL;
     const result = Bun.spawnSync({


### PR DESCRIPTION
## The bug

The `E2E: Setup Journey` block in `test/e2e/mechanical.test.ts` runs `gbrain init --non-interactive --url $DATABASE_URL` in a subprocess that inherits the real `HOME` env var. `gbrain init` calls `saveConfig()` (`src/commands/init.ts:198`) which writes to `~/.gbrain/config.json` in whatever `homedir()` returns - i.e. the developer's real home directory.

Run this exact command from `CONTRIBUTING.md`:

```
DATABASE_URL=postgresql://postgres:postgres@localhost:5434/gbrain_test bun run test:e2e
```

...and your real `~/.gbrain/config.json` gets silently overwritten with:

```json
{"engine":"postgres","database_url":"postgresql://postgres:postgres@localhost:5434/gbrain_test"}
```

Any Supabase URL and API keys that were in the config are gone. The gbrain CLI then fails with `28P01 password authentication failed` on the next real-brain query.

I hit this on my 13k-page brain today running migrations. Cost ~90 minutes of debugging before we realized tests had clobbered the config.

## The fix

Override `process.env.HOME` to a fresh `mkdtempSync()` dir in `beforeAll`, restore in `afterAll`, and pass `HOME` explicitly to spawned subprocesses. This is the same pattern already used in `test/e2e/migration-flow.test.ts` (see lines 62-73, 80-90) - that file is the only other e2e test that had the discipline to isolate HOME correctly.

Applied the same fix defensively to `E2E: Init Edge Cases` even though its current test strips `DATABASE_URL` before spawning. If a future test in that block calls `gbrain init` with a URL, the isolation is already there.

## Scope

- One file changed: `test/e2e/mechanical.test.ts`
- +36 lines, -4 lines
- Zero production code changes
- Zero new dependencies (`mkdtempSync`, `rmSync`, `tmpdir`, `join` already imported)
- Test behavior unchanged, just safer re: developer's real config

## Verification

Locally: file builds clean via `bun build`, matches the migration-flow.test.ts pattern which is already known-good in the existing E2E suite.