### PR TITLE
fix(put): lowercase caller-supplied slug in importFromContent (#200)

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -55,6 +55,12 @@ export async function importFromContent(
   content: string,
   opts: { noEmbed?: boolean } = {},
 ): Promise<ImportResult> {
+  // Normalize slug to lowercase to match engine-level validateSlug behavior.
+  // Without this, putPage stores the page at the lowercased slug while the
+  // followup tx.upsertChunks/getTags/addTag lookups use the caller's raw
+  // (possibly uppercase) slug and fail with "Page not found: <slug>".
+  slug = slug.toLowerCase();
+
   // Reject oversized payloads before any parsing, chunking, or embedding happens.
   // Uses Buffer.byteLength to count UTF-8 bytes the same way disk size would,
   // so the network path behaves identically to the file path.

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -380,6 +380,35 @@ Content to chunk but not embed.
     expect(result.status).toBe('imported');
   });
 
+  test('lowercases caller-supplied slug so putPage and upsertChunks agree', async () => {
+    // Engine-level validateSlug lowercases, so putPage stored the page at the
+    // lowercased slug. If importFromContent leaves the caller's casing intact,
+    // the same-transaction tx.upsertChunks/getTags calls look up the page by
+    // the raw uppercase slug and throw "Page not found". See issue #200.
+    const content = `---
+type: concept
+title: TestUpper
+---
+
+Content that should succeed despite uppercase slug input.
+`;
+
+    const engine = mockEngine();
+    const result = await importFromContent(engine, 'claude-memory/TestUpper/test', content, { noEmbed: true });
+
+    expect(result.status).toBe('imported');
+    expect(result.slug).toBe('claude-memory/testupper/test');
+
+    const calls = (engine as any)._calls;
+    const putCall = calls.find((c: any) => c.method === 'putPage');
+    expect(putCall).toBeTruthy();
+    expect(putCall.args[0]).toBe('claude-memory/testupper/test');
+
+    const chunkCall = calls.find((c: any) => c.method === 'upsertChunks');
+    expect(chunkCall).toBeTruthy();
+    expect(chunkCall.args[0]).toBe('claude-memory/testupper/test');
+  });
+
   test('assigns sequential chunk_index values', async () => {
     const filePath = join(TMP, 'indexed.md');
     const longText = Array(50).fill('This is a sentence that adds length to the content.').join(' ');


### PR DESCRIPTION
## Summary

Fixes #200 — `gbrain put <slug>` with uppercase letters failed with the misleading error `Page not found: <slug>`, identical to the `gbrain get` error for a genuinely missing page.

## Root cause

`putPage` runs `validateSlug` internally and stores the page at the lowercased slug. However, the same-transaction calls that follow (`tx.upsertChunks`, `tx.getTags`, `tx.addTag`, `tx.removeTag`) use whatever slug the caller handed to `importFromContent`. With `claude-memory/TestUpper/test` the `upsertChunks` lookup hits `SELECT id FROM pages WHERE slug = 'claude-memory/TestUpper/test'`, finds nothing, and throws `Page not found: claude-memory/TestUpper/test` — the exact message `get_page` emits for a genuine miss.

The bug reporter's 236-file bulk migration silently dropped 30 writes under `claude-memory/DogskinMap/*` and `claude-memory/SolarPower/*` until they A/B-tested `TestUpper` vs `testlower`.

## Fix

Lowercase the slug once at the top of `importFromContent` so `putPage`, `getTags`, `addTag`, `removeTag`, and `upsertChunks` all operate on the same normalized slug.

## Test plan

- [x] Added a regression test in `test/import-file.test.ts` that feeds an uppercase slug through `importFromContent` and asserts both `putPage` and `upsertChunks` are called with the lowercased slug.
- [x] `bun test test/import-file.test.ts` — 17 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)