### PR TITLE
fix: preserve CJK slugs during import

### DIFF
--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -104,7 +104,7 @@ export function slugifySegment(segment: string): string {
     .normalize('NFD')                     // Decompose accented chars
     .replace(/[\u0300-\u036f]/g, '')      // Strip accent marks
     .toLowerCase()
-    .replace(/[^a-z0-9.\s_-]/g, '')      // Keep alphanumeric, dots, spaces, underscores, hyphens
+    .replace(/[^\p{L}\p{N}.\s_-]/gu, '')  // Keep letters/numbers across scripts, dots, spaces, underscores, hyphens
     .replace(/[\s]+/g, '-')              // Spaces → hyphens
     .replace(/-+/g, '-')                 // Collapse multiple hyphens
     .replace(/^-|-$/g, '');              // Strip leading/trailing hyphens

--- a/test/slug-validation.test.ts
+++ b/test/slug-validation.test.ts
@@ -51,6 +51,14 @@ describe('slugifySegment', () => {
   test('handles curly quotes and ellipsis', () => {
     expect(slugifySegment('she\u2026said \u201chello\u201d')).toBe('shesaid-hello');
   });
+
+  test('preserves CJK characters instead of collapsing to empty', () => {
+    expect(slugifySegment('草莓-温室设计技术规范-云合')).toBe('草莓-温室设计技术规范-云合');
+  });
+
+  test('preserves mixed CJK and ASCII segments', () => {
+    expect(slugifySegment('草莓-H型高架基质栽培技术规程')).toBe('草莓-h型高架基质栽培技术规程');
+  });
 });
 
 describe('slugifyPath', () => {
@@ -109,6 +117,16 @@ describe('slugifyPath', () => {
   test('meetings transcript example', () => {
     expect(slugifyPath('meetings/transcripts/2026-01-21 maria - california c4 collaboration discussion.md'))
       .toBe('meetings/transcripts/2026-01-21-maria-california-c4-collaboration-discussion');
+  });
+
+  test('preserves CJK filenames under source directories', () => {
+    expect(slugifyPath('sources/草莓-温室设计技术规范-云合.md'))
+      .toBe('sources/草莓-温室设计技术规范-云合');
+  });
+
+  test('preserves mixed CJK and ASCII filenames under source directories', () => {
+    expect(slugifyPath('sources/草莓-H型高架基质栽培技术规程.md'))
+      .toBe('sources/草莓-h型高架基质栽培技术规程');
   });
 });
 


### PR DESCRIPTION
## Summary
- preserve non-ASCII letters and numbers when slugifying path segments
- add regression tests for CJK-only and mixed CJK/ASCII filenames under sources/

## Problem
`slugifySegment()` currently strips everything outside ASCII `[a-z0-9]`. For Chinese filenames this can collapse a whole segment to an empty string, or reduce mixed names to a single ASCII character.

Real examples from a local brain repo:
- `sources/草莓-温室设计技术规范-云合.md` became `sources`
- `sources/草莓-H型高架基质栽培技术规程.md` became `sources/h`

That means these pages are imported under the wrong slug or dropped from retrieval entirely, even though the markdown content is valid.

## Verification
- `bun test test/slug-validation.test.ts test/sync.test.ts`