### PR TITLE
fix(schema): add missing idx_pages_updated_at_desc index (#170)

### DIFF
--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -284,6 +284,16 @@ export const MIGRATIONS: Migration[] = [
       DROP FUNCTION IF EXISTS update_page_search_vector_from_timeline();
     `,
   },
+  {
+    version: 11,
+    name: 'add_pages_updated_at_desc_index',
+    // Fixes slow "list pages newest-first" queries on large brains (#170).
+    // Without this index, `SELECT * FROM pages ORDER BY updated_at DESC` does a seqscan
+    // + external sort (~14s on 31k rows). With the index it's an Index Scan (~11ms).
+    sql: `
+      CREATE INDEX IF NOT EXISTS idx_pages_updated_at_desc ON pages (updated_at DESC);
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS pages (
 CREATE INDEX IF NOT EXISTS idx_pages_type ON pages(type);
 CREATE INDEX IF NOT EXISTS idx_pages_frontmatter ON pages USING GIN(frontmatter);
 CREATE INDEX IF NOT EXISTS idx_pages_trgm ON pages USING GIN(title gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_pages_updated_at_desc ON pages (updated_at DESC);
 
 -- ============================================================
 -- content_chunks: chunked content with embeddings


### PR DESCRIPTION
## Summary

Fixes slow "list pages newest-first" queries on large brains by adding a covering B-tree index on `pages(updated_at DESC)`.

## Problem

Without this index, `SELECT * FROM pages ORDER BY updated_at DESC` does a sequential scan + external sort on the heap. On a 31k-row brain this takes ~14.6 seconds per call, consuming ~35 minutes of cumulative wall time for autopilot health/dashboard queries alone.

## Fix

```sql
CREATE INDEX IF NOT EXISTS idx_pages_updated_at_desc ON pages (updated_at DESC);
```

After the index: `Index Scan using idx_pages_updated_at_desc on pages (cost 11 vs 6693)` — roughly **1000x improvement**.

## Changes

- **src/schema.sql**: add `idx_pages_updated_at_desc` for fresh installs
- **src/core/migrate.ts**: add migration v11 so existing brains auto-apply the index on next startup

Closes #170.