### PR TITLE
fix(embedding): force encoding_format=float for non-OpenAI providers

### DIFF
--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -9,8 +9,15 @@
 
 import OpenAI from 'openai';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
+// [brain-private patch] Make model and dimensions configurable via env vars.
+// Defaults preserved for upstream compatibility.
+const MODEL = process.env.GBRAIN_EMBED_MODEL || 'text-embedding-3-large';
+const DIMENSIONS = process.env.GBRAIN_EMBED_DIMENSIONS
+  ? parseInt(process.env.GBRAIN_EMBED_DIMENSIONS, 10)
+  : 1536;
+// When using Ollama or another provider that doesn't support the `dimensions`
+// API parameter, set GBRAIN_EMBED_SKIP_DIMENSIONS_PARAM=1 to omit it from requests.
+const SKIP_DIMENSIONS_PARAM = process.env.GBRAIN_EMBED_SKIP_DIMENSIONS_PARAM === '1';
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
@@ -49,11 +56,17 @@ export async function embedBatch(texts: string[]): Promise<Float32Array[]> {
 async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const response = await getClient().embeddings.create({
+      const createParams: any = {
         model: MODEL,
         input: texts,
-        dimensions: DIMENSIONS,
-      });
+        // Force 'float' so the SDK skips its base64-decode path — LiteLLM/Ollama
+        // return plain arrays even when base64 is requested, which corrupts results.
+        encoding_format: 'float',
+      };
+      if (!SKIP_DIMENSIONS_PARAM) {
+        createParams.dimensions = DIMENSIONS;
+      }
+      const response = await getClient().embeddings.create(createParams);
 
       // Sort by index to maintain order
       const sorted = response.data.sort((a, b) => a.index - b.index);


### PR DESCRIPTION
## Summary

The OpenAI Node SDK v6+ adds `encoding_format: "base64"` by default to embedding requests. When using a proxy that doesn't honor that parameter (LiteLLM → Ollama, among others), the server returns a JSON array but the SDK decodes it as if it were base64 bytes — yielding a `Float32Array` of `N/4` entries instead of `N`. Surfaces as `expected 1024 dimensions, not 256` errors when embedding against non-OpenAI providers.

Forcing `encoding_format: 'float'` keeps the response as a native array. Works with real OpenAI (which returns plain arrays in that mode) and with LiteLLM/Ollama proxies.

This PR also adds env-var configuration for model and dimensions — useful for anyone pointing gbrain at a non-OpenAI embedding endpoint:
- `GBRAIN_EMBED_MODEL` (default: `text-embedding-3-large`)
- `GBRAIN_EMBED_DIMENSIONS` (default: `1536`)
- `GBRAIN_EMBED_SKIP_DIMENSIONS_PARAM=1` (omit the `dimensions` param entirely — some non-OpenAI providers reject unknown params)

## Motivation

Running gbrain against a local LiteLLM proxy routing to Ollama's `bge-m3` (1024-dim native) — every embed request errored out with the dimension mismatch above. Direct curl to the same proxy endpoint returned correct 1024-dim arrays, but the SDK's internal base64 path corrupted the result. Explicit `encoding_format: 'float'` is the cleanest fix and aligns with OpenAI's documented behavior.

## Test plan

- [ ] Verified against real OpenAI `text-embedding-3-large` (1536 dim) — returns correct dimensions
- [ ] Verified against LiteLLM → Ollama `bge-m3` (1024 dim) — returns correct dimensions
- [x] Confirmed in local brain: previously 100% embed failures → 968 chunks embedded in test run, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)