### PR TITLE
fix: extend noEmbed guard to cover Voyage/Anthropic provider path

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -230,11 +230,13 @@ const put_page: Operation = {
   handler: async (ctx, p) => {
     if (ctx.dryRun) return { dry_run: true, action: 'put_page', slug: p.slug };
     const slug = p.slug as string;
-    // Skip embedding when no OpenAI key is configured. importFromContent's existing
+    // Skip embedding when no embedding provider key is configured. importFromContent's existing
     // try/catch around embed only catches; without a key the OpenAI client would
     // attempt 5 retries with exponential backoff (up to ~2 minutes total) before
     // giving up. Detect early.
-    const noEmbed = !process.env.OPENAI_API_KEY;
+    // Supports OpenAI (OPENAI_API_KEY) or Voyage/Anthropic path (VOYAGE_API_KEY or ANTHROPIC_API_KEY).
+    const hasEmbedKey = !!process.env.OPENAI_API_KEY || !!process.env.VOYAGE_API_KEY || !!process.env.ANTHROPIC_API_KEY;
+    const noEmbed = !hasEmbedKey;
     const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed });
 
     // Auto-link post-hook: runs AFTER importFromContent (which is its own


### PR DESCRIPTION
## Problem

When using the Voyage AI or Anthropic embedding provider, `OPENAI_API_KEY` must be **unset** for the provider detection logic in `embedding.ts` to activate the Voyage path:

```ts
const USE_ANTHROPIC = !process.env.OPENAI_API_KEY && !!process.env.ANTHROPIC_API_KEY;
```

However, `operations.ts` was checking only `OPENAI_API_KEY` to gate embedding:

```ts
const noEmbed = !process.env.OPENAI_API_KEY;
```

This means any deployment using Voyage AI (with `OPENAI_API_KEY` unset) silently skips all embedding on every `put_page` call — resulting in 0 chunks embedded and degraded search quality.

## Fix

Check for **any** valid embedding provider key:

```ts
const hasEmbedKey = !!process.env.OPENAI_API_KEY || !!process.env.VOYAGE_API_KEY || !!process.env.ANTHROPIC_API_KEY;
const noEmbed = !hasEmbedKey;
```

## Impact

- Embedding coverage goes from 0% → 100% for Voyage/Anthropic deployments
- No change for existing OpenAI deployments
- Fixes the issue described in the `embedding.ts` comment about Anthropic/Voyage routing