### PR TITLE
fix: parse pgvector embedding strings in hybrid search re-scoring

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -272,7 +272,11 @@ export class PostgresEngine implements BrainEngine {
     `;
     const result = new Map<number, Float32Array>();
     for (const row of rows) {
-      if (row.embedding) result.set(row.id as number, row.embedding as Float32Array);
+      if (!row.embedding) continue;
+      const emb = typeof row.embedding === 'string'
+        ? new Float32Array(JSON.parse(row.embedding))
+        : row.embedding as Float32Array;
+      result.set(row.id as number, emb);
     }
     return result;
   }

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -239,3 +239,20 @@ describe('applyBacklinkBoost (v0.10.1)', () => {
     expect(results[2].score).toBeGreaterThan(results[1].score);
   });
 });
+
+describe('pgvector string embedding parsing', () => {
+  test('cosineSimilarity works with Float32Array parsed from pgvector string', () => {
+    const vecStr = '[-0.01,0.02,0.03,0.04,0.05]';
+    const parsed = new Float32Array(JSON.parse(vecStr));
+    const reference = new Float32Array([-0.01, 0.02, 0.03, 0.04, 0.05]);
+    expect(cosineSimilarity(parsed, reference)).toBeCloseTo(1.0, 5);
+  });
+
+  test('string cast as Float32Array produces NaN (the bug)', () => {
+    const vecStr = '[-0.01,0.02,0.03]';
+    const badCast = vecStr as unknown as Float32Array;
+    const ref = new Float32Array([1, 2, 3]);
+    const result = cosineSimilarity(badCast, ref);
+    expect(Number.isNaN(result)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- The `postgres` npm library returns pgvector embedding columns as strings (e.g., `"[-0.01,0.02,...]"`), not `Float32Array`
- `getEmbeddingsByChunkIds` cast these strings directly with `as Float32Array`, so `cosineSimilarity` multiplied string characters instead of numbers, producing `NaN`
- All `gbrain query` (hybrid search) scores displayed as `[NaN]` — keyword-only `gbrain search` was unaffected since it doesn't re-score with cosine similarity
- Fix: detect string embeddings and parse via `JSON.parse` into `Float32Array`

## Test plan
- [x] Added unit test proving the bug mechanism (string cast → NaN in cosineSimilarity)
- [x] Added unit test proving the fix (JSON.parse → Float32Array → correct cosine similarity)
- [x] Full test suite passes (1302 pass, 0 fail)
- [x] Verified on live Postgres with 4,188 embedded chunks: `gbrain query "Tom's girlfriend"` now returns `[0.9163]` instead of `[NaN]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)