### PR TITLE
fix(doctor): skip pgvector + jsonb_integrity cleanly on PGLite (75→100 health)

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -369,16 +369,26 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
 
   // 4. pgvector extension
   progress.heartbeat('pgvector');
-  try {
-    const sql = db.getConnection();
-    const ext = await sql`SELECT extname FROM pg_extension WHERE extname = 'vector'`;
-    if (ext.length > 0) {
-      checks.push({ name: 'pgvector', status: 'ok', message: 'Extension installed' });
-    } else {
-      checks.push({ name: 'pgvector', status: 'fail', message: 'Extension not found. Run: CREATE EXTENSION vector;' });
+  if (engine.kind === 'pglite') {
+    // PGLite ships pgvector bundled via @electric-sql/pglite/vector;
+    // pg_extension introspection isn't exposed in the same form.
+    checks.push({
+      name: 'pgvector',
+      status: 'ok',
+      message: 'Skipped (PGLite — pgvector built-in, pg_extension not introspectable)',
+    });
+  } else {
+    try {
+      const sql = db.getConnection();
+      const ext = await sql`SELECT extname FROM pg_extension WHERE extname = 'vector'`;
+      if (ext.length > 0) {
+        checks.push({ name: 'pgvector', status: 'ok', message: 'Extension installed' });
+      } else {
+        checks.push({ name: 'pgvector', status: 'fail', message: 'Extension not found. Run: CREATE EXTENSION vector;' });
+      }
+    } catch {
+      checks.push({ name: 'pgvector', status: 'warn', message: 'Could not check pgvector extension' });
     }
-  } catch {
-    checks.push({ name: 'pgvector', status: 'warn', message: 'Could not check pgvector extension' });
   }
 
   // 4b. PgBouncer / prepared-statement compatibility.
@@ -777,36 +787,48 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
   // surface matches `repair-jsonb` (the previous 4-target scan missed a
   // repair target, per #254/Codex review).
   progress.heartbeat('jsonb_integrity');
-  try {
-    const sql = db.getConnection();
-    const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
-      { table: 'pages',         col: 'frontmatter',    expected: 'object' },
-      { table: 'raw_data',      col: 'data',           expected: 'object' },
-      { table: 'ingest_log',    col: 'pages_updated',  expected: 'array'  },
-      { table: 'files',         col: 'metadata',       expected: 'object' },
-      { table: 'page_versions', col: 'frontmatter',    expected: 'object' },
-    ];
-    let totalBad = 0;
-    const breakdown: string[] = [];
-    for (const { table, col } of targets) {
-      progress.heartbeat(`jsonb_integrity.${table}.${col}`);
-      const rows = await sql.unsafe(
-        `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
-      );
-      const n = Number((rows as any)[0]?.n ?? 0);
-      if (n > 0) { totalBad += n; breakdown.push(`${table}.${col}=${n}`); }
+  if (engine.kind === 'pglite') {
+    // db.getConnection() is the postgres.js singleton — not used by PGLite.
+    // The v0.12.0 double-encoding bug documented above only affected real
+    // Postgres roundtrips (CHANGELOG v0.12.2 explicitly noted PGLite was
+    // unaffected); skipping cleanly is not a quality regression.
+    checks.push({
+      name: 'jsonb_integrity',
+      status: 'ok',
+      message: 'Skipped (PGLite — v0.12.0 double-encoding bug only affected real Postgres)',
+    });
+  } else {
+    try {
+      const sql = db.getConnection();
+      const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
+        { table: 'pages',         col: 'frontmatter',    expected: 'object' },
+        { table: 'raw_data',      col: 'data',           expected: 'object' },
+        { table: 'ingest_log',    col: 'pages_updated',  expected: 'array'  },
+        { table: 'files',         col: 'metadata',       expected: 'object' },
+        { table: 'page_versions', col: 'frontmatter',    expected: 'object' },
+      ];
+      let totalBad = 0;
+      const breakdown: string[] = [];
+      for (const { table, col } of targets) {
+        progress.heartbeat(`jsonb_integrity.${table}.${col}`);
+        const rows = await sql.unsafe(
+          `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
+        );
+        const n = Number((rows as any)[0]?.n ?? 0);
+        if (n > 0) { totalBad += n; breakdown.push(`${table}.${col}=${n}`); }
+      }
+      if (totalBad === 0) {
+        checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'All JSONB columns store objects/arrays' });
+      } else {
+        checks.push({
+          name: 'jsonb_integrity',
+          status: 'warn',
+          message: `${totalBad} row(s) double-encoded (${breakdown.join(', ')}). Fix: gbrain repair-jsonb`,
+        });
+      }
+    } catch {
+      checks.push({ name: 'jsonb_integrity', status: 'warn', message: 'Could not check JSONB integrity' });
     }
-    if (totalBad === 0) {
-      checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'All JSONB columns store objects/arrays' });
-    } else {
-      checks.push({
-        name: 'jsonb_integrity',
-        status: 'warn',
-        message: `${totalBad} row(s) double-encoded (${breakdown.join(', ')}). Fix: gbrain repair-jsonb`,
-      });
-    }
-  } catch {
-    checks.push({ name: 'jsonb_integrity', status: 'warn', message: 'Could not check JSONB integrity' });
   }
 
   // 11. Markdown body completeness (v0.12.3 reliability wave).


### PR DESCRIPTION
## Problem

On PGLite engines, two doctor checks call `db.getConnection()` (the `postgres.js` singleton) which isn't used by PGLite — the call throws, lands in the `catch` block, and surfaces as `Could not check ...` WARN status. That penalizes health score on every install that hasn't migrated to Supabase/Postgres.

Sample output on PGLite before this PR (after applying current master):

```
[WARN] pgvector: Could not check pgvector extension
[WARN] jsonb_integrity: Could not check JSONB integrity
Health score: 90/100. All checks OK (some warnings).
```

(`rls` was fixed separately on master since this PR's original revision; this update narrows scope to the two checks still warning.)

## Fix

Match the existing pattern used by `rls` / `rls_event_trigger` / `queue_health` / `markdown_body_completeness`: when `engine.kind === 'pglite'`, emit `status: 'ok'` with a `Skipped (PGLite — …)` message explaining why the check doesn't apply. The Postgres path is byte-identical (only wrapped in an outer `if` branch).

After this PR on the same PGLite install:

```
[OK] pgvector: Skipped (PGLite — pgvector built-in, pg_extension not introspectable)
[OK] jsonb_integrity: Skipped (PGLite — v0.12.0 double-encoding bug only affected real Postgres)
Health score: 100/100. All checks passed.
```

## Rationale per check

1. **pgvector** — PGLite ships pgvector bundled via `@electric-sql/pglite/vector` (WASM); there's no `pg_extension` row to verify and the extension introspection isn't exposed in the same form.
2. **jsonb_integrity** — The v0.12.0 `${JSON.stringify(x)}::jsonb` double-encode bug was explicitly noted in the v0.12.2 CHANGELOG as only affecting real Postgres (`postgres.js` stringified a second time; PGLite did not). The v0.12.2 migration already no-ops on PGLite for the same reason. Doctor should too.

## Test

- **PGLite**: health score 75 → 100 (or 90 → 100 with current master where `rls` already passes), two WARNs become OK.
- **Postgres**: no behavior change. The `engine.kind === 'pglite'` guard only branches into the new skip path; the original code paths (`try { … pg_extension … }` and the `jsonb_typeof` scan) are unchanged for Postgres.

## Notes

This rebases #226's original three-check fix onto current master and drops the `rls` portion (since master fixed it differently in the meantime). Keeps the score penalty reserved for genuinely actionable warnings, so `gbrain doctor` remains a reliable signal on both engine types.