### PR TITLE
fix(sync): skip 'git pull' silently when repo has no upstream

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -48,14 +48,23 @@ export async function performSync(engine: BrainEngine, opts: SyncOpts): Promise<
 
   // Git pull (unless --no-pull)
   if (!opts.noPull) {
+    // Skip silently if repo has no upstream tracking branch (local-only vault).
+    let hasUpstream = true;
     try {
-      git(repoPath, 'pull', '--ff-only');
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      if (msg.includes('non-fast-forward') || msg.includes('diverged')) {
-        console.error(`Warning: git pull failed (remote diverged). Syncing from local state.`);
-      } else {
-        console.error(`Warning: git pull failed: ${msg.slice(0, 100)}`);
+      git(repoPath, 'rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}');
+    } catch {
+      hasUpstream = false;
+    }
+    if (hasUpstream) {
+      try {
+        git(repoPath, 'pull', '--ff-only');
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg.includes('non-fast-forward') || msg.includes('diverged')) {
+          console.error(`Warning: git pull failed (remote diverged). Syncing from local state.`);
+        } else {
+          console.error(`Warning: git pull failed: ${msg.slice(0, 100)}`);
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem

When a GBrain sync repo is a local-only git repo (committed locally, never pushed to a remote — e.g. an Obsidian vault used as the single source of truth for one user), every sync emits this multi-line warning:

```
There is no tracking information for the current branch.
Please specify which branch you want to merge with.
...
    git branch --set-upstream-to=<remote>/<branch> main

Warning: git pull failed: Command failed: git -C /path/to/vault pull --ff-only
There is no tracking informatio
```

Under `gbrain autopilot`, this fires on every cycle (default 5 min). The autopilot.err log fills up with the same message, drowning out any real warnings that would actually need attention.

The repo isn't broken — it's just local. `gbrain sync` still works, because the function catches the thrown error. But the noise is unconditional.

## Fix

Before `git pull --ff-only`, probe for an upstream tracking branch with:

```
git rev-parse --abbrev-ref --symbolic-full-name @{u}
```

If that errors, the current branch has no upstream configured — skip pull silently. Otherwise, run pull and preserve the existing error handling for non-fast-forward / diverged remotes.

## Behavior

| Setup | Before | After |
|---|---|---|
| Local-only repo, no remote | WARN every sync | Silent (skip pull) |
| Remote configured, clean pull | OK | OK (unchanged) |
| Remote configured, diverged | "remote diverged" WARN | "remote diverged" WARN (unchanged) |
| Remote configured, other git error | generic pull WARN | generic pull WARN (unchanged) |

## Motivation

Using a local git-tracked Obsidian vault (or any personal notes repo) as a GBrain sync source is a common pattern — it gives you commit history and lint triggers without needing a hosted remote. Punishing that setup with log spam discourages it.

Local-only git repos should remain first-class: they still sync, they just don't get pulled.

## Test

- Local-only repo: `gbrain sync` and autopilot no longer print the tracking warning; other output unchanged.
- Repo with remote, clean: git pull still runs.
- Repo with remote, diverged: existing warning still fires.
