### PR TITLE
fix(autopilot): reconnect crash, silent 0-chunk loop, and dirty-shutdown Aborted()

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -22,7 +22,7 @@ import { join } from 'path';
 import { execSync, spawn, type ChildProcess } from 'child_process';
 import type { BrainEngine } from '../core/engine.ts';
 import { loadPreferences } from '../core/preferences.ts';
-import { loadConfig } from '../core/config.ts';
+import { loadConfig, toEngineConfig } from '../core/config.ts';
 
 function parseArg(args: string[], flag: string): string | undefined {
   const idx = args.indexOf(flag);
@@ -122,6 +122,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
   // lock blocks a separate worker process).
   const mode = loadPreferences().minion_mode ?? 'pain_triggered';
   const cfg = loadConfig();
+  const engineCfg = cfg ? toEngineConfig(cfg) : null;
   const engineType = cfg?.engine ?? 'pglite';
   const useMinionsDispatch = mode !== 'off' && engineType === 'postgres' && !forceInline;
 
@@ -175,6 +176,11 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
         try { workerProc.kill('SIGKILL'); } catch { /* already dead */ }
       }
     }
+    // Close the engine so PGLite can flush WAL and release postmaster.pid.
+    // Without this, the next autopilot start sees a dirty data dir and
+    // PGLite's WASM recovery aborts with `Aborted()` (assertions stripped
+    // from the PGLite dist), leaving launchd in a respawn crash loop.
+    try { await engine.disconnect(); } catch { /* already disconnected */ }
     try { unlinkSync(lockPath); } catch { /* already gone */ }
     process.exit(0);
   };
@@ -197,7 +203,8 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
     } catch {
       try {
         await engine.disconnect();
-        await (engine as any).connect?.();
+        if (!engineCfg) throw new Error('cannot reconnect: engine config unavailable (loadConfig returned null)');
+        await engine.connect(engineCfg);
       } catch (e) { logError('reconnect', e); }
     }
 

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,7 +1,38 @@
 import type { BrainEngine } from '../core/engine.ts';
 import { embedBatch } from '../core/embedding.ts';
-import type { ChunkInput } from '../core/types.ts';
+import type { Chunk, ChunkInput, Page } from '../core/types.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
+
+/**
+ * Return the chunks for a page, creating them on first call.
+ *
+ * Chunks are the unit of embedding. Sync and extract never create them —
+ * chunking happens lazily the first time we try to embed a page.
+ * Without this helper, the `--stale`/`--all` paths would silently skip any
+ * page that had never been individually embedded (getChunks returns [],
+ * filter returns [], page is "skipped, nothing to do"). Autopilot would
+ * then report `0 chunks embedded` forever even with unembedded content.
+ */
+async function ensureChunks(engine: BrainEngine, page: Page): Promise<Chunk[]> {
+  const existing = await engine.getChunks(page.slug);
+  if (existing.length > 0) return existing;
+
+  const inputs: ChunkInput[] = [];
+  if (page.compiled_truth.trim()) {
+    for (const c of chunkText(page.compiled_truth)) {
+      inputs.push({ chunk_index: inputs.length, chunk_text: c.text, chunk_source: 'compiled_truth' });
+    }
+  }
+  if (page.timeline.trim()) {
+    for (const c of chunkText(page.timeline)) {
+      inputs.push({ chunk_index: inputs.length, chunk_text: c.text, chunk_source: 'timeline' });
+    }
+  }
+  if (inputs.length === 0) return existing; // page has no content to chunk
+
+  await engine.upsertChunks(page.slug, inputs);
+  return engine.getChunks(page.slug);
+}
 
 export interface EmbedOpts {
   /** Embed ALL pages (every chunk). */
@@ -72,26 +103,7 @@ async function embedPage(engine: BrainEngine, slug: string) {
     throw new Error(`Page not found: ${slug}`);
   }
 
-  // Get existing chunks or create new ones
-  let chunks = await engine.getChunks(slug);
-  if (chunks.length === 0) {
-    // Create chunks first
-    const inputs: ChunkInput[] = [];
-    if (page.compiled_truth.trim()) {
-      for (const c of chunkText(page.compiled_truth)) {
-        inputs.push({ chunk_index: inputs.length, chunk_text: c.text, chunk_source: 'compiled_truth' });
-      }
-    }
-    if (page.timeline.trim()) {
-      for (const c of chunkText(page.timeline)) {
-        inputs.push({ chunk_index: inputs.length, chunk_text: c.text, chunk_source: 'timeline' });
-      }
-    }
-    if (inputs.length > 0) {
-      await engine.upsertChunks(slug, inputs);
-      chunks = await engine.getChunks(slug);
-    }
-  }
+  const chunks = await ensureChunks(engine, page);
 
   // Embed chunks without embeddings
   const toEmbed = chunks.filter(c => !c.embedded_at);
@@ -134,7 +146,7 @@ async function embedAll(engine: BrainEngine, staleOnly: boolean) {
   const CONCURRENCY = parseInt(process.env.GBRAIN_EMBED_CONCURRENCY || '20', 10);
 
   async function embedOnePage(page: typeof pages[number]) {
-    const chunks = await engine.getChunks(page.slug);
+    const chunks = await ensureChunks(engine, page);
     const toEmbed = staleOnly
       ? chunks.filter(c => !c.embedded_at)
       : chunks;

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -105,6 +105,52 @@ describe('runEmbed --all (parallel)', () => {
     expect(maxConcurrentEmbedCalls).toBe(1);
   });
 
+  test('creates chunks lazily for pages that have none, then embeds them (--stale)', async () => {
+    // Regression: prior to the ensureChunks refactor, embedAll skipped any
+    // page whose getChunks returned []. Sync/extract never create chunks,
+    // so any page that had never been individually embedded would be stuck
+    // at 0 chunks forever and autopilot would report "0 chunks embedded"
+    // on every cycle. This test catches that regression.
+    const pages = [{
+      slug: 'never-chunked',
+      compiled_truth: 'Hello world. This is the compiled truth.',
+      timeline: '',
+    }];
+    // Stateful mock: upsertChunks actually persists, getChunks reflects it.
+    const store = new Map<string, any[]>();
+    let upsertCalls = 0;
+
+    const engine = mockEngine({
+      listPages: async () => pages,
+      getChunks: async (slug: string) => store.get(slug) ?? [],
+      upsertChunks: async (slug: string, inputs: any[]) => {
+        upsertCalls++;
+        const existing = store.get(slug) ?? [];
+        const byIndex = new Map<number, any>(existing.map(c => [c.chunk_index, c]));
+        for (const inp of inputs) {
+          const prev = byIndex.get(inp.chunk_index);
+          byIndex.set(inp.chunk_index, {
+            ...(prev ?? {}),
+            ...inp,
+            embedded_at: inp.embedding ? '2026-04-19' : (prev?.embedded_at ?? null),
+          });
+        }
+        store.set(slug, Array.from(byIndex.values()).sort((a, b) => a.chunk_index - b.chunk_index));
+      },
+    });
+
+    process.env.GBRAIN_EMBED_CONCURRENCY = '1';
+
+    await runEmbed(engine, ['--stale']);
+
+    // Chunks were created (1st upsert) and then embedded (2nd upsert).
+    expect(upsertCalls).toBe(2);
+    expect(totalEmbedCalls).toBe(1);
+    const finalChunks = store.get('never-chunked') ?? [];
+    expect(finalChunks.length).toBeGreaterThan(0);
+    expect(finalChunks.every((c: any) => c.embedded_at !== null)).toBe(true);
+  });
+
   test('skips pages whose chunks are all already embedded when --stale', async () => {
     const pages = [{ slug: 'fresh' }, { slug: 'stale' }];
     const chunksBySlug = new Map<string, any[]>([


### PR DESCRIPTION
## Summary

Three bugs in the autopilot + embed path that compound into a total
autopilot breakdown on PGLite: autopilot either silently idles or goes
into a launchd respawn crash loop. All three reproduce consistently on
a fresh brain.

- **Bug 1 — autopilot reconnect crash.** Every DB reconnect attempt fails
  with `undefined is not an object (evaluating 'config.database_path')`.
- **Bug 2 — `Embedded 0 chunks across N pages` forever.** Pages that
  weren't individually embedded stay stuck at 0 chunks, and autopilot
  never recovers.
- **Bug 3 — `Aborted(). Build with -sASSERTIONS for more info.` on the
  next autopilot start** after any SIGTERM-triggered shutdown.

## Root causes

### Bug 1 — `src/commands/autopilot.ts`

The cycle loop's health-check reconnect called
`(engine as any).connect?.()` with no argument, but
`BrainEngine.connect(config: EngineConfig)` requires one. Inside
`PGLiteEngine.connect`, `config.database_path` throws immediately. Every
subsequent step (`sync`, `extract`, `embed`, `health`) then fails with
`PGLite not connected. Call connect() first.` for the rest of that
process lifetime.

Fix: capture `toEngineConfig(loadConfig())` once at startup and pass it
to the reconnect call. Drops the `as any` cast.

### Bug 2 — `src/commands/embed.ts`

Chunks are the unit of embedding. `embedPage()` (single-slug path)
creates them lazily on first call. `embedAll()` → `embedOnePage()` did
not — it just ran `getChunks()` and skipped the page if the result was
empty. Pages that weren't individually embedded via `gbrain embed <slug>`
never got chunked, so autopilot (which calls
`runEmbedCore({ stale: true })` → `embedAll()`) reported
`Embedded 0 chunks across N pages` on every cycle indefinitely. Sync
attempts inline embedding and can fail silently (missing
\`OPENAI_API_KEY\`, transient rate-limit errors, etc.), leaving the page
persisted but un-chunked — so pages drift into this state in normal
operation.

Fix: extract an \`ensureChunks(engine, page)\` helper and call it from
both \`embedPage\` and \`embedOnePage\`. The \`staleOnly\` filter still
applies after creation (new chunks have \`embedded_at === null\`, so
they count as stale and get embedded in the same pass).

### Bug 3 — `src/commands/autopilot.ts` (shutdown handler)

On SIGTERM/SIGINT, the shutdown handler drains the worker child and
removes the autopilot lock file, but **never calls
`engine.disconnect()`**. PGLite is left with \`postmaster.pid\` intact
and WAL potentially mid-flush. The next autopilot start inherits that
dirty data directory; PGLite's WASM recovery panics with \`Aborted()\`
(assertions stripped from the PGLite dist, so no stack), and launchd
goes into a respawn crash loop. Before Bug 1 was fixed, the reconnect
crash masked this as a different failure; fixing Bug 1 exposed Bug 3 as
the real persistent-corruption culprit.

Fix: \`await engine.disconnect()\` before unlinking the lock and calling
\`process.exit(0)\`.

## Tests

- Existing \`test/embed.test.ts\` (10 tests) still pass.
- New regression test: \`creates chunks lazily for pages that have none,
  then embeds them (--stale)\`. Fails on \`master\` (upsertCalls is 0
  because the page is skipped). Passes with the fix (upsertCalls is 2 —
  chunks created, then embeddings written — and the final chunks all
  have non-null \`embedded_at\`).
- Full suite: **1381 pass / 0 fail** / 168 skip (e2e skips gated on
  \`DATABASE_URL\`, unrelated).
- \`bash scripts/check-jsonb-pattern.sh\`: OK.
- \`bun run build\`: clean compile, 905 modules.

## Manual verification

Reproduced and fixed end-to-end on a real \`~/.gbrain/brain.pglite\` brain
with 139 markdown source files:

1. \`mv ~/.gbrain/brain.pglite{,.corrupt.\$(date +%s)}\`
2. \`gbrain init\`, \`gbrain sync --repo ~/Projects/Second Brain\` — 128
   pages imported, 811 chunks created.
3. \`gbrain embed --all\` — \`Embedded 845 chunks across 138 pages\` (the
   extra 34 chunks are from pages \`ensureChunks\` recovered that sync
   had missed). Without the fix, this step produced
   \`Embedded 0 chunks\` for unchunked pages.
4. \`launchctl bootstrap gui/\$(id -u) ~/Library/LaunchAgents/com.gbrain.autopilot.plist\` —
   autopilot starts, first cycle:
   \`Links: created 360 from 139 pages\`, \`Embedded 0 chunks across 138
   pages\` (correct: all stale chunks already embedded),
   \`[cycle] score=82 elapsed=2s next=300s\`. No \`Aborted()\`, no
   \`PGLite not connected\` errors. Subsequent
   \`launchctl bootout … bootstrap\` cycles stay clean — Bug 3 verified.

## Test plan

- [x] \`bun test\` — 1381 pass, 0 fail
- [x] \`bun run build\` — clean compile
- [x] \`bash scripts/check-jsonb-pattern.sh\` — OK
- [x] Manual verification on a real brain (see above)
- [ ] Reviewer sanity check: the \`as any\` cast in the reconnect path is
      gone — \`engine.connect(engineCfg)\` is now typed directly against
      \`BrainEngine.connect(config: EngineConfig)\`.

## Follow-ups (not in this PR)

- PGLite single-writer coexistence: when autopilot holds the lock,
  manual \`gbrain <cmd>\` commands fail with
  \`Timed out waiting for PGLite lock\` (working as designed, but
  friction-heavy). A \`gbrain autopilot pause\`/\`resume\` pair using a
  sentinel file in the main loop would make this painless. Bigger lift:
  autopilot daemon mode serving queries over a Unix socket, so CLI
  commands don't need exclusive DB access at all — docker/gpg-agent
  pattern. Happy to follow up in a separate PR after this lands.
- Hardening \`pglite-lock.ts\`: atomic temp-then-rename lockfile writes,
  and treating empty-lock-file as \"still writing, wait\" rather than
  \"corrupt, remove\" — closes a race that can also produce
  \`Aborted()\`. Again, separate PR, interacts with the daemon-mode
  discussion above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)