### PR TITLE
fix(postgres-engine): run migrations before SCHEMA_SQL in initSchema()

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -61,12 +61,16 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   async initSchema(): Promise<void> {
-    await this.db.exec(PGLITE_SCHEMA_SQL);
-
+    // Run migrations first so that new columns/indexes exist before
+    // PGLITE_SCHEMA_SQL's CREATE INDEX statements reference them.
+    // For fresh installs: migrations are no-ops (tables created below);
+    // for upgrades: migrations add new columns first, then the indexes succeed.
     const { applied } = await runMigrations(this);
     if (applied > 0) {
       console.log(`  ${applied} migration(s) applied`);
     }
+
+    await this.db.exec(PGLITE_SCHEMA_SQL);
   }
 
   async transaction<T>(fn: (engine: BrainEngine) => Promise<T>): Promise<T> {

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -62,13 +62,17 @@ export class PostgresEngine implements BrainEngine {
     // on DDL statements (DROP TRIGGER + CREATE TRIGGER acquire AccessExclusiveLock)
     await conn`SELECT pg_advisory_lock(42)`;
     try {
-      await conn.unsafe(SCHEMA_SQL);
-
-      // Run any pending migrations automatically
+      // Run any pending migrations first so that new columns/indexes exist
+      // before SCHEMA_SQL's CREATE INDEX statements reference them.
+      // For fresh installs: migrations are no-ops (all tables are created by
+      // SCHEMA_SQL below); for upgrades: migrations add new columns first,
+      // then SCHEMA_SQL's CREATE INDEX IF NOT EXISTS succeeds.
       const { applied } = await runMigrations(this);
       if (applied > 0) {
         console.log(`  ${applied} migration(s) applied`);
       }
+
+      await conn.unsafe(SCHEMA_SQL);
     } finally {
       await conn`SELECT pg_advisory_unlock(42)`;
     }


### PR DESCRIPTION
## Summary

- **Bug**: Upgrades from pre-v0.13 fail because `initSchema()` runs `SCHEMA_SQL` before `runMigrations()`. When `CREATE INDEX IF NOT EXISTS idx_links_source ON links(link_source)` executes, the `link_source` column doesn't exist yet (added by migration 11).
- **Fix**: Reorder `initSchema()` to run migrations first, then `SCHEMA_SQL`. This ensures new columns exist before `SCHEMA_SQL`'s index statements reference them.
- **Scope**: Both `PostgresEngine.initSchema()` and `PGliteEngine.initSchema()` had the same bug — both are fixed.
- **Behavior**:
  - Fresh installs: migrations are no-ops, `SCHEMA_SQL` creates everything
  - Upgrades: migrations add new columns first, `SCHEMA_SQL`'s `CREATE INDEX IF NOT EXISTS` succeeds

## Test plan

- [x] Code review: logic verified
- [ ] Run E2E tests against real Postgres (requires `bun test:e2e`)

Fixes garrytan/gbrain#243  
Fixes garrytan/gbrain#239