### PR TITLE
fix(schema): add SET search_path to update_page_search_vector trigger

### DIFF
--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -227,7 +227,13 @@ ALTER TABLE pages ADD COLUMN IF NOT EXISTS search_vector tsvector;
 CREATE INDEX IF NOT EXISTS idx_pages_search ON pages USING GIN(search_vector);
 
 -- Function to rebuild search_vector for a page
-CREATE OR REPLACE FUNCTION update_page_search_vector() RETURNS trigger AS \$\$
+-- SET search_path prevents Supabase linter WARN about mutable search_path.
+-- Fully qualified references (public.timeline_entries) are also safe but
+-- SET search_path is the minimal change that satisfies the security check.
+CREATE OR REPLACE FUNCTION update_page_search_vector() RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_catalog
+AS \$\$
 DECLARE
   timeline_text TEXT;
 BEGIN
@@ -246,7 +252,7 @@ BEGIN
 
   RETURN NEW;
 END;
-\$\$ LANGUAGE plpgsql;
+\$\$;
 
 DROP TRIGGER IF EXISTS trg_pages_search_vector ON pages;
 CREATE TRIGGER trg_pages_search_vector

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -223,7 +223,13 @@ ALTER TABLE pages ADD COLUMN IF NOT EXISTS search_vector tsvector;
 CREATE INDEX IF NOT EXISTS idx_pages_search ON pages USING GIN(search_vector);
 
 -- Function to rebuild search_vector for a page
-CREATE OR REPLACE FUNCTION update_page_search_vector() RETURNS trigger AS $$
+-- SET search_path prevents Supabase linter WARN about mutable search_path.
+-- Fully qualified references (public.timeline_entries) are also safe but
+-- SET search_path is the minimal change that satisfies the security check.
+CREATE OR REPLACE FUNCTION update_page_search_vector() RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_catalog
+AS $$
 DECLARE
   timeline_text TEXT;
 BEGIN
@@ -242,7 +248,7 @@ BEGIN
 
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 DROP TRIGGER IF EXISTS trg_pages_search_vector ON pages;
 CREATE TRIGGER trg_pages_search_vector


### PR DESCRIPTION
## Summary

- **Bug**: The `update_page_search_vector()` trigger function used an unqualified reference to `timeline_entries`, relying on the caller's `search_path`. This triggers a Supabase security linter WARN about mutable `search_path`.
- **Fix**: Add `SET search_path = public, pg_catalog` to the function definition, locking down its schema context and preventing supply-chain attacks where a user creates a malicious `timeline_entries` table in another schema.
- **Files changed**: `schema.sql` (source of truth) and `schema-embedded.ts` (auto-generated)

## Test plan

- [x] Code review: change is minimal and targeted
- [ ] Run Supabase security advisor to verify WARN is cleared

Fixes garrytan/gbrain#171