### PR TITLE
docs(skill): harden orphan enumeration guidance in maintain

### DIFF
--- a/skills/maintain/SKILL.md
+++ b/skills/maintain/SKILL.md
@@ -48,6 +48,9 @@ Pages where compiled_truth is older than the latest timeline entry. The assessme
 
 ### Orphan pages
 Pages with zero inbound links. Nobody references them.
+- Enumerate orphan work with `gbrain orphans` / `find_orphans`; treat this as authoritative over `gbrain health` / `get_health.orphan_pages`
+- Use `get_health.orphan_pages` only as a rough dashboard signal; do not use it to scope, verify, or close an orphan-remediation lane
+- During concurrent writes, even `find_orphans` can flutter by ±1; re-run after writes settle before claiming an exact final orphan count
 - Review orphans: are they genuinely isolated or just missing links?
 - Add links in gbrain from related pages or flag for deletion
 


### PR DESCRIPTION
## Summary
- clarify that orphan remediation should enumerate with `gbrain orphans` / `find_orphans`
- mark `get_health.orphan_pages` as a dashboard signal, not a closure/verification surface
- record the observed ±1 concurrent-write flutter caveat for exact final counts

## Why

Supporting record: GBrain concept page `gbrain-orphan-enumeration-authoritative-surface` (created 2026-04-20T10:08:11Z).

Relevant quote from that record:

> For orphan work on a gbrain instance, `gbrain orphans` (CLI) / `find_orphans` (MCP) is the authoritative surface. The aggregate `get_health.orphan_pages` field is unreliable for this purpose.

Supporting evidence timestamp from `reports/gbrain-bounded-orphan-citation-fixer-sweep/2026-04-20-0049`:

> `get_health` reported `orphan_pages: 0` while explicit enumeration via `find_orphans` still returned real remaining orphans.

Additional 2026-04-20 follow-up observation from `originals/jack-electrum-orphan-alias-dedup-lane-closeout-doctrine`:

> `find_orphans` itself can flutter by ±1 during concurrent writes.

## How to Verify

1. Read the `### Orphan pages` section in `skills/maintain/SKILL.md`.
2. Confirm it now instructs `gbrain orphans` / `find_orphans` as the authoritative surface over `get_health.orphan_pages`.
3. Confirm it warns that exact final orphan counts can flutter by ±1 during concurrent writes.

## Risk Assessment

Low — documentation-only clarification in the maintenance skill; no runtime behavior changes.
