### PR TITLE
fix: improve PGLite stale lock cleanup robustness

### DIFF
--- a/src/core/pglite-lock.ts
+++ b/src/core/pglite-lock.ts
@@ -20,6 +20,8 @@ import { join } from 'path';
 const LOCK_DIR_NAME = '.gbrain-lock';
 const LOCK_FILE = 'lock';
 const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes — embed jobs can be long
+const RETRY_DELAY_MS = 500; // Delay between acquisition attempts
+const STALE_CLEANUP_DELAY_MS = 100; // Brief delay after cleaning stale lock before retrying
 
 export interface LockHandle {
   lockDir: string;
@@ -75,20 +77,40 @@ export async function acquireLock(dataDir: string | undefined, opts?: { timeoutM
 
         // Is the locking process still alive?
         if (!isProcessAlive(lockPid)) {
-          // Stale lock — clean it up
-          try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition, try again */ }
+          // Stale lock (dead process) — remove immediately, no need to wait
+          try {
+            rmSync(lockDir, { recursive: true, force: true });
+            // Brief delay to let the filesystem settle after removal
+            await new Promise(r => setTimeout(r, STALE_CLEANUP_DELAY_MS));
+          } catch {
+            // Race condition — another process may have already cleaned it up; retry
+            await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+            continue;
+          }
         } else if (Date.now() - lockTime > STALE_THRESHOLD_MS) {
-          // Lock held for too long — assume stale (e.g., process hung)
-          // Still alive but probably stuck — force remove
-          try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition */ }
+          // Lock held for too long by a live process — assume hung, force remove
+          try {
+            rmSync(lockDir, { recursive: true, force: true });
+            await new Promise(r => setTimeout(r, STALE_CLEANUP_DELAY_MS));
+          } catch {
+            await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+            continue;
+          }
         } else {
           // Lock is held by a live process — wait and retry
           await new Promise(r => setTimeout(r, 1000));
           continue;
         }
       } catch {
-        // Corrupt lock file — remove it
-        try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition */ }
+        // Corrupt or unreadable lock file — attempt removal
+        try {
+          rmSync(lockDir, { recursive: true, force: true });
+          await new Promise(r => setTimeout(r, STALE_CLEANUP_DELAY_MS));
+        } catch {
+          // Could not remove — retry after delay
+          await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+          continue;
+        }
       }
     }
 
@@ -105,8 +127,8 @@ export async function acquireLock(dataDir: string | undefined, opts?: { timeoutM
 
       return { lockDir, acquired: true };
     } catch (e: unknown) {
-      // mkdir failed — someone else grabbed it between our check and mkdir
-      // This is fine, we'll retry
+      // mkdir failed — someone else grabbed it between our check and mkdir, or stale removal
+      // didn't take effect yet. Either way, we'll retry.
       if (Date.now() - startTime >= timeoutMs) {
         // Timeout — report which process holds the lock
         const lockPath = join(lockDir, LOCK_FILE);
@@ -114,7 +136,7 @@ export async function acquireLock(dataDir: string | undefined, opts?: { timeoutM
           const lockData = JSON.parse(readFileSync(lockPath, 'utf-8'));
           throw new Error(
             `GBrain: Timed out waiting for PGLite lock. Process ${lockData.pid} has held it since ${new Date(lockData.acquired_at).toISOString()} (command: ${lockData.command}). ` +
-            `If that process is dead, remove ${lockDir} and try again.`
+            `If that process is dead, run: rm -rf ${lockDir}`
           );
         } catch (readErr) {
           if (readErr instanceof Error && readErr.message.startsWith('GBrain')) throw readErr;
@@ -124,7 +146,7 @@ export async function acquireLock(dataDir: string | undefined, opts?: { timeoutM
         }
       }
       // Brief wait before retry
-      await new Promise(r => setTimeout(r, 500));
+      await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #251 — improves the PGLite advisory lock cleanup to handle unclean shutdowns (SIGKILL, OOM) more reliably.

## Problem

When a GBrain process is killed via SIGKILL or crashes due to OOM, the `.gbrain-lock/` directory remains on disk. Subsequent GBrain processes try to acquire the lock but can fail because:

1. **Silent rmSync failures**: After detecting a stale lock (dead PID), `rmSync` could fail silently (catch swallows error), then `mkdirSync` also fails because the directory still exists — the loop retries but makes no progress.
2. **No delay after removal**: Even when `rmSync` succeeds, attempting `mkdirSync` immediately creates a race window on some filesystems (especially macOS APFS).
3. **Corrupt lock falls through**: If the lock file is unreadable (corrupt), the code removes it but then falls through to `mkdirSync` without checking if removal succeeded.

## Changes

- **Dead-PID cleanup**: After `rmSync` succeeds, wait 100ms (`STALE_CLEANUP_DELAY_MS`) before attempting `mkdirSync` to let the filesystem settle.
- **rmSync failure handling**: On `rmSync` failure, immediately `continue` the retry loop instead of falling through to a guaranteed-failing `mkdirSync`.
- **Corrupt lock handling**: Same pattern — attempt removal, delay, continue on failure.
- **Extracted constants**: `RETRY_DELAY_MS` and `STALE_CLEANUP_DELAY_MS` for configurability.
- **Better error message**: Timeout message now shows `rm -rf <path>` as the manual cleanup command.

## Testing

Tested locally by:
1. Creating a stale lock with a dead PID → lock cleaned up immediately on next `gbrain stats` call
2. Simulating rmSync failure (chmod 000 on lock dir) → retry loop continues and eventually succeeds after manual cleanup

## Note

This is a partial fix for #251. A more complete solution would add a `--force-unlock` CLI flag, but that requires changes to the CLI argument parser which are out of scope for this PR.