### PR TITLE
feat: support Ollama as embedding backend via environment variables

### DIFF
--- a/docs/guides/ollama-embedding.md
+++ b/docs/guides/ollama-embedding.md
@@ -1,0 +1,125 @@
+# Ollama Embedding Configuration Guide
+
+Use local Ollama as gbrain's embedding backend, no OpenAI API key required.
+
+## Supported Models
+
+Ollama supports any embedding model that implements the `/v1/embeddings` API:
+
+- `qwen3-embedding:latest` - Qwen3 embedding, 32-4096 configurable dimensions
+- `mxbai-embed-large:latest` - Mxbai embedding
+- `bge-m3:latest` - BGE M3 embedding
+
+## Environment Variables
+
+Add to `~/.zshrc` or `~/.bashrc`:
+
+```bash
+# Ollama embedding configuration for gbrain
+export GBRAIN_EMBEDDING_BASE_URL="http://localhost:11434/v1"
+export GBRAIN_EMBEDDING_MODEL="qwen3-embedding:latest"
+export GBRAIN_EMBEDDING_DIMENSIONS="1536"
+export GBRAIN_EMBEDDING_API_KEY=""  # Ollama doesn't need a key, but OpenAI SDK requires non-empty
+```
+
+## Dimension Settings
+
+### qwen3-embedding
+
+qwen3-embedding supports any dimension from 32 to 4096.
+
+**Recommended settings:**
+
+| Use case | Dimensions | Notes |
+|----------|------------|-------|
+| gbrain default | 1536 | Matches OpenAI text-embedding-3-large |
+| High precision | 4096 | Maximum dimension, best quality, more storage |
+| Resource saving | 1024 | Minimum recommended, fastest |
+
+```bash
+# gbrain default (1536)
+export GBRAIN_EMBEDDING_DIMENSIONS="1536"
+
+# Maximum precision (4096)
+export GBRAIN_EMBEDDING_DIMENSIONS="4096"
+```
+
+Verify dimensions:
+```bash
+curl http://localhost:11434/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{"model":"qwen3-embedding:latest","input":"test","dimensions":1536}' \
+  | python3 -c "import sys,json; print(len(json.load(sys.stdin)['data'][0]['embedding']))"
+```
+
+## Ollama Service
+
+Ensure Ollama service is running:
+
+```bash
+# Start Ollama service (macOS)
+ollama serve
+
+# Verify service status
+curl http://localhost:11434/api/tags
+```
+
+## Usage
+
+### CLI Usage
+
+```bash
+# Write page (via stdin)
+echo "# My Page
+
+Content here." | gbrain put my-page
+
+# Keyword search
+gbrain search "keyword"
+
+# Vector query
+gbrain query "natural language question"
+```
+
+### Claude Code MCP
+
+Configure gbrain MCP server:
+
+```bash
+claude mcp add gbrain -- sh -c "GBRAIN_DB=~/.gbrain/brain.pglite bun run /path/to/gbrain/src/cli.ts serve"
+```
+
+## Troubleshooting
+
+### Embedding fails
+
+1. Verify Ollama service is running:
+   ```bash
+   curl http://localhost:11434/api/tags
+   ```
+
+2. Check environment variables:
+   ```bash
+   echo $GBRAIN_EMBEDDING_BASE_URL
+   echo $GBRAIN_EMBEDDING_MODEL
+   ```
+
+3. Test API directly:
+   ```bash
+   curl http://localhost:11434/v1/embeddings \
+     -d '{"model":"qwen3-embedding:latest","input":"hello"}'
+   ```
+
+### Dimension mismatch
+
+If you see `expected 1536 dimensions, not X` error:
+- Check `GBRAIN_EMBEDDING_DIMENSIONS` environment variable
+- Verify Ollama model supports the configured dimension
+- qwen3-embedding supports 32-4096
+
+### API Key error
+
+Ollama doesn't need an API key, but OpenAI SDK requires a non-empty value:
+```bash
+export GBRAIN_EMBEDDING_API_KEY=""  # Must be set, even if empty
+```

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -13,6 +13,9 @@ export interface GBrainConfig {
   database_path?: string;
   openai_api_key?: string;
   anthropic_api_key?: string;
+  embedding_model?: string;
+  embedding_base_url?: string;
+  embedding_dimensions?: number;
 }
 
 /**
@@ -41,6 +44,9 @@ export function loadConfig(): GBrainConfig | null {
     engine: inferredEngine,
     ...(dbUrl ? { database_url: dbUrl } : {}),
     ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
+    ...(process.env.GBRAIN_EMBEDDING_MODEL ? { embedding_model: process.env.GBRAIN_EMBEDDING_MODEL } : {}),
+    ...(process.env.GBRAIN_EMBEDDING_BASE_URL ? { embedding_base_url: process.env.GBRAIN_EMBEDDING_BASE_URL } : {}),
+    ...(process.env.GBRAIN_EMBEDDING_DIMENSIONS ? { embedding_dimensions: parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS, 10) } : {}),
   };
   return merged as GBrainConfig;
 }

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -5,23 +5,40 @@
  * OpenAI text-embedding-3-large at 1536 dimensions.
  * Retry with exponential backoff (4s base, 120s cap, 5 retries).
  * 8000 character input truncation.
+ *
+ * Environment variables:
+ *   GBRAIN_EMBEDDING_MODEL      - Embedding model name (default: text-embedding-3-large)
+ *   GBRAIN_EMBEDDING_BASE_URL   - Custom endpoint URL (e.g., http://localhost:11434/v1 for Ollama)
+ *   GBRAIN_EMBEDDING_DIMENSIONS - Embedding dimensions (default: 1536)
+ *   OPENAI_BASE_URL / OPENAI_API_KEY - Standard OpenAI SDK env vars
  */
 
 import OpenAI from 'openai';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
+const MODEL = process.env.GBRAIN_EMBEDDING_MODEL || 'text-embedding-3-large';
+const DIMENSIONS = parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS || '1536', 10);
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
 
+// Support custom base URL for Ollama and other OpenAI-compatible endpoints
+const BASE_URL = process.env.GBRAIN_EMBEDDING_BASE_URL || process.env.OPENAI_BASE_URL;
+// Use explicit env var if set (including empty string), otherwise fall back to standard OpenAI env vars
+const API_KEY = process.env.GBRAIN_EMBEDDING_API_KEY !== undefined
+  ? process.env.GBRAIN_EMBEDDING_API_KEY
+  : (process.env.OPENAI_API_KEY || 'not-needed');
+
+
 let client: OpenAI | null = null;
 
 function getClient(): OpenAI {
   if (!client) {
-    client = new OpenAI();
+    client = new OpenAI({
+      baseURL: BASE_URL,
+      apiKey: API_KEY,
+    });
   }
   return client;
 }

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -234,7 +234,10 @@ const put_page: Operation = {
     // try/catch around embed only catches; without a key the OpenAI client would
     // attempt 5 retries with exponential backoff (up to ~2 minutes total) before
     // giving up. Detect early.
-    const noEmbed = !process.env.OPENAI_API_KEY;
+    const hasEmbeddingConfig = process.env.OPENAI_API_KEY ||
+      process.env.GBRAIN_EMBEDDING_API_KEY !== undefined ||
+      process.env.GBRAIN_EMBEDDING_BASE_URL;
+    const noEmbed = !hasEmbeddingConfig;
     const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed });
 
     // Auto-link post-hook: runs AFTER importFromContent (which is its own


### PR DESCRIPTION
## Summary

Add configurable embedding backend support for Ollama and other OpenAI-compatible embedding services via environment variables.

- Supports `GBRAIN_EMBEDDING_BASE_URL`, `GBRAIN_EMBEDDING_MODEL`, `GBRAIN_EMBEDDING_DIMENSIONS`, `GBRAIN_EMBEDDING_API_KEY`
- Adds `docs/guides/ollama-embedding.md` configuration guide

## Changes

| File | Change |
|------|--------|
| `src/core/embedding.ts` | Ollama/OpenAI-compatible embedding backend support |
| `src/core/config.ts` | Add embedding config to GBrainConfig |
| `src/core/operations.ts` | Fix noEmbed detection for custom embedding backends |
| `docs/guides/ollama-embedding.md` | New guide for Ollama configuration |

## Test plan

- [ ] `bun test` passes
- [ ] E2E tests pass
- [ ] Verify Ollama embedding works with `GBRAIN_EMBEDDING_BASE_URL=http://localhost:11434`