### PR TITLE
Fix: Bug: MCP get_timeline returns empty [] while CLI timeline works

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -82,6 +82,8 @@ export async function startMcpServer(engine: BrainEngine) {
     }
 
     try {
+      // Ensure engine is ready and sees any data written by other processes (e.g. CLI)
+      await engine.prepare();
       const result = await op.handler(ctx, safeParams);
       return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
     } catch (e: unknown) {
@@ -118,5 +120,6 @@ export async function handleToolCall(
     remote: false,
   };
 
+  await engine.prepare();
   return op.handler(ctx, params);
 }


### PR DESCRIPTION
The issue is caused by the MCP server maintaining a long-lived PGLite connection. PGLite (especially in WASM/Node environments) can sometimes hold state in memory or buffers that isn't automatically synchronized when an external process (like the CLI) modifies the underlying database files. In the CLI, a new engine instance is typically created for each command, ensuring it sees fresh data. In the MCP server, the same engine instance is reused. By calling `await engine.prepare()` before executing each tool handler, we ensure that the engine refreshes its connection state and acknowledges any changes made to the database since the last call. This fix is applied to both the main MCP server handler and the `handleToolCall` helper used by the `gbrain call` command.

Test: 1. Start the gbrain MCP server (e.g., using an MCP client like Hermes).
2. Using the CLI in a separate terminal, add timeline entries to a page: `gbrain put test-page '<!-- timeline --> entry at 12:00'`. 
3. Verify the CLI sees the entry: `gbrain timeline test-page` (should show the entry).
4. Invoke the `get_timeline` tool via the MCP server for 'test-page'.
5. Confirm the MCP server returns the entry instead of an empty array [].