### PR TITLE
fix(put_page): clear error for uppercase slugs before DB call (#200)

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -230,6 +230,11 @@ const put_page: Operation = {
   handler: async (ctx, p) => {
     if (ctx.dryRun) return { dry_run: true, action: 'put_page', slug: p.slug };
     const slug = p.slug as string;
+    // Reject uppercase slugs early with a clear message rather than letting
+    // them fail later with a misleading "Page not found" error.
+    if (/[A-Z]/.test(slug)) {
+      throw new OperationError('invalid_params', `Slug must be lowercase letters, digits, hyphens, and forward slugs only. Got: "${slug}"`);
+    }
     // Skip embedding when no OpenAI key is configured. importFromContent's existing
     // try/catch around embed only catches; without a key the OpenAI client would
     // attempt 5 retries with exponential backoff (up to ~2 minutes total) before


### PR DESCRIPTION
## Summary

`gbrain put "SomeSlug/test"` rejects uppercase slugs with a descriptive error instead of letting them fail with a misleading "Page not found" message once they reach the engine layer.

## Fix

Added an early validation in `put_page` handler that checks for uppercase characters and throws a clear `invalid_params` error:

```
Error [invalid_params]: Slug must be lowercase letters, digits, hyphens, and forward slugs only. Got: "SomeSlug/test"
```

This matches the existing `validatePageSlug()` function's behavior, but fires before any DB operations.

## Why

The previous flow was:
1. `gbrain put SomeSlug/test` → `importFromContent(engine, "SomeSlug/test", ...)`
2. `engine.putPage("SomeSlug/test", ...)` calls `validateSlug()` → lowercases to `"some slug/test"`
3. INSERT with lowercased slug succeeds
4. **But** somewhere the page wasn't found later, causing "Page not found" with the original uppercase slug

Users debugging the misleading error chased paths like "Did the page get deleted?", "Is my slug typo'd?", "Is the database disconnected?" before realizing the actual cause was uppercase characters.

Closes #200.