### PR TITLE
security: cap pglite search queries at 8s to match postgres parity

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -23,6 +23,48 @@ import { validateSlug, contentHash, rowToPage, rowToChunk, rowToSearchResult } f
 
 type PGLiteDB = PGlite;
 
+/**
+ * Search-path query timeout — matches the Postgres engine's
+ * `SET LOCAL statement_timeout = '8s'` wrapper on `searchKeyword` /
+ * `searchVector` (see `postgres-engine.ts`).
+ *
+ * PGLite runs Postgres in WASM in the same Node/Bun event loop. A SET LOCAL
+ * is a no-op across `.query()` boundaries on PGLite (each call auto-commits),
+ * so we approximate the same protection at the JS layer with Promise.race.
+ *
+ * Caveat: the WASM query keeps running to completion in the background even
+ * after we reject. This frees the awaiting caller (so the MCP session /
+ * autopilot daemon does not hang indefinitely on a pathological query) but
+ * does not actually cancel the underlying work. A true cancel requires
+ * PGLite to expose a cancel token upstream. Track:
+ *   https://github.com/electric-sql/pglite/issues (no cancel API as of 0.4.x)
+ */
+const SEARCH_QUERY_TIMEOUT_MS = 8000;
+
+async function queryWithTimeout<T>(
+  db: PGlite,
+  sql: string,
+  params: unknown[],
+  timeoutMs: number,
+  label: string,
+): Promise<{ rows: T[] }> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`pglite ${label} query exceeded ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+  });
+  try {
+    return (await Promise.race([
+      db.query(sql, params),
+      timeoutPromise,
+    ])) as { rows: T[] };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export class PGLiteEngine implements BrainEngine {
   private _db: PGLiteDB | null = null;
   private _lock: LockHandle | null = null;
@@ -180,7 +222,12 @@ export class PGLiteEngine implements BrainEngine {
       console.warn(`[gbrain] Warning: search limit clamped from ${opts.limit} to ${MAX_SEARCH_LIMIT}`);
     }
 
-    const { rows } = await this.db.query(
+    // Search timeout — parity with postgres-engine.ts searchKeyword.
+    // Prevents a pathological tsquery or large corpus from freezing the
+    // single-threaded PGLite WASM event loop, which would otherwise hang
+    // the MCP session and any in-process autopilot / jobs worker.
+    const { rows } = await queryWithTimeout<Record<string, unknown>>(
+      this.db,
       `SELECT
         p.slug, p.id as page_id, p.title, p.type,
         cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
@@ -194,10 +241,12 @@ export class PGLiteEngine implements BrainEngine {
       ORDER BY score DESC
       LIMIT $2
       OFFSET $3`,
-      [query, limit, offset]
+      [query, limit, offset],
+      SEARCH_QUERY_TIMEOUT_MS,
+      'searchKeyword',
     );
 
-    return (rows as Record<string, unknown>[]).map(rowToSearchResult);
+    return rows.map(rowToSearchResult);
   }
 
   async searchVector(embedding: Float32Array, opts?: SearchOpts): Promise<SearchResult[]> {
@@ -210,7 +259,10 @@ export class PGLiteEngine implements BrainEngine {
       console.warn(`[gbrain] Warning: search limit clamped from ${opts.limit} to ${MAX_SEARCH_LIMIT}`);
     }
 
-    const { rows } = await this.db.query(
+    // Search timeout — parity with postgres-engine.ts searchVector. See
+    // searchKeyword above for rationale.
+    const { rows } = await queryWithTimeout<Record<string, unknown>>(
+      this.db,
       `SELECT
         p.slug, p.id as page_id, p.title, p.type,
         cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
@@ -224,10 +276,12 @@ export class PGLiteEngine implements BrainEngine {
       ORDER BY cc.embedding <=> $1::vector
       LIMIT $2
       OFFSET $3`,
-      [vecStr, limit, offset]
+      [vecStr, limit, offset],
+      SEARCH_QUERY_TIMEOUT_MS,
+      'searchVector',
     );
 
-    return (rows as Record<string, unknown>[]).map(rowToSearchResult);
+    return rows.map(rowToSearchResult);
   }
 
   async getEmbeddingsByChunkIds(ids: number[]): Promise<Map<number, Float32Array>> {

--- a/test/pglite-search-timeout.test.ts
+++ b/test/pglite-search-timeout.test.ts
@@ -1,0 +1,106 @@
+/**
+ * pglite-engine.ts search path timeout — parity with postgres-engine.ts.
+ *
+ * Regression guard for R8-F1 (engine-parity DoS gap, 2026-04-20):
+ * postgres-engine.ts wraps `searchKeyword` and `searchVector` in
+ * `sql.begin` + `SET LOCAL statement_timeout = '8s'` so that a pathological
+ * tsquery or similarity scan can't freeze the pooled connection. PGLite
+ * auto-commits each `.query()` call so `SET LOCAL` is a no-op, and prior
+ * to this fix there was NO equivalent protection on PGLite — a single slow
+ * query would hang the single-threaded WASM event loop and with it the
+ * MCP session, `gbrain jobs work` daemon, and autopilot cycle.
+ *
+ * The fix wraps the two search queries in a `queryWithTimeout` helper that
+ * uses `Promise.race` against an 8s timer. The WASM query keeps running to
+ * completion in the background (PGLite has no cancel API at 0.4.x) but the
+ * awaiting caller is freed, matching the Postgres engine's 8s ceiling.
+ *
+ * Two coverage layers:
+ *   1. Source-level: the search paths call `queryWithTimeout`, not raw
+ *      `this.db.query`.
+ *   2. Functional: a fake PGLite whose `.query()` never resolves triggers
+ *      the timeout path and rejects with the documented error.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const SRC = readFileSync(
+  join(import.meta.dir, '..', 'src', 'core', 'pglite-engine.ts'),
+  'utf-8',
+);
+
+// Strip comments so commentary mentioning the anti-pattern doesn't false-positive.
+function stripComments(s: string): string {
+  return s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|\s)\/\/[^\n]*/g, '$1');
+}
+
+describe('pglite-engine / search path timeout (R8-F1)', () => {
+  test('queryWithTimeout helper exists with an 8s default cap', () => {
+    const stripped = stripComments(SRC);
+    expect(stripped).toContain('SEARCH_QUERY_TIMEOUT_MS = 8000');
+    expect(stripped).toMatch(/async function queryWithTimeout/);
+  });
+
+  test('searchKeyword routes through queryWithTimeout', () => {
+    const stripped = stripComments(SRC);
+    // Grab just the searchKeyword method body.
+    const match = stripped.match(/async searchKeyword[\s\S]*?^\s\s\}/m);
+    expect(match).not.toBeNull();
+    const body = match![0];
+    expect(body).toContain('queryWithTimeout');
+    expect(body).not.toMatch(/\bthis\.db\.query\(/);
+  });
+
+  test('searchVector routes through queryWithTimeout', () => {
+    const stripped = stripComments(SRC);
+    const match = stripped.match(/async searchVector[\s\S]*?^\s\s\}/m);
+    expect(match).not.toBeNull();
+    const body = match![0];
+    expect(body).toContain('queryWithTimeout');
+    expect(body).not.toMatch(/\bthis\.db\.query\(/);
+  });
+
+  test('queryWithTimeout rejects when the underlying query never resolves', async () => {
+    // Import the module and pull out the helper via a test seam. Since
+    // queryWithTimeout is module-local, we exercise it via the exported
+    // engine class with a fake db.
+    const { PGLiteEngine } = await import('../src/core/pglite-engine.ts');
+    const engine = new PGLiteEngine();
+    // Inject a fake db whose .query() never resolves. Cast through unknown
+    // to bypass the private field type; the test is validating the timeout,
+    // not the engine's type hygiene.
+    const hangingDb = {
+      query: () => new Promise(() => {}),
+    };
+    (engine as unknown as { _db: unknown })._db = hangingDb;
+
+    // searchKeyword must reject within well under 8s. Use a tight 1s test
+    // deadline to keep the suite fast — the helper's own 8000ms cap still
+    // governs the engine's behavior in production; we just don't want the
+    // test to wait that long. Patch the helper's timeout for this call by
+    // monkey-patching the timer: easier to wait 8s than to refactor the
+    // constant for test injection, so we just trust the cap and check that
+    // the rejection path fires rather than hanging forever.
+    const start = Date.now();
+    let threw: Error | null = null;
+    try {
+      // Race the engine call against a 9s test timer so a bug that removes
+      // the timeout surfaces as a test-level timeout rather than a hang.
+      await Promise.race([
+        engine.searchKeyword('ignored'),
+        new Promise((_, rej) =>
+          setTimeout(() => rej(new Error('test harness bail: engine.searchKeyword did not reject within 9s')), 9000),
+        ),
+      ]);
+    } catch (err) {
+      threw = err as Error;
+    }
+    const elapsedMs = Date.now() - start;
+    expect(threw).not.toBeNull();
+    expect(threw!.message).toMatch(/pglite searchKeyword query exceeded|test harness bail/);
+    // Sanity: the 8s cap should fire well before the 9s test bail.
+    expect(elapsedMs).toBeLessThan(8500);
+  }, 15000);
+});


### PR DESCRIPTION
## Summary

`postgres-engine.ts` protects `searchKeyword` and `searchVector` with
`sql.begin` + `SET LOCAL statement_timeout = '8s'` so an attacker-crafted
tsquery or similarity scan can't freeze a pooled connection. PGLite
auto-commits each `.query()` call, so `SET LOCAL` is a no-op there (the
code already notes this at `pglite-engine.ts:445-448`). The search paths
on PGLite were left with no equivalent protection.

Since `gbrain init` defaults to PGLite for brains under 1000 pages, most
users run on the engine that has no timeout. A pathological query hangs
the single-threaded WASM event loop and with it the MCP stdio session,
the `gbrain jobs work` daemon, and any in-process autopilot cycle.
The user has to kill the process to recover.

This PR closes the parity gap by wrapping both search queries in a
`queryWithTimeout` helper that races `db.query()` against an 8s timer.

## Root cause

`pglite-engine.ts` searchKeyword + searchVector call `this.db.query(...)`
directly. On a big corpus or a pathological input, those queries run
long enough to starve the event loop. Unlike Postgres (where
`statement_timeout` kicks in), there is no ceiling on PGLite.

Attack shapes:

1. `search(query=<pathological tsquery>)` — many ORs + rare tokens force
   extensive rank scoring.
2. `search(query=<common term>)` on a very large brain where the corpus
   itself is the pathology.
3. Vector search variants of either.

The MCP boundary is stdio today, so the practical threat model is an
agent-side prompt injection tricking its own Claude into issuing a bad
search, which then self-DoSes the user's gbrain process.

## Fix

New module-level helper in `src/core/pglite-engine.ts`:

```ts
const SEARCH_QUERY_TIMEOUT_MS = 8000;

async function queryWithTimeout<T>(
  db: PGlite,
  sql: string,
  params: unknown[],
  timeoutMs: number,
  label: string,
): Promise<{ rows: T[] }> {
  let timer: ReturnType<typeof setTimeout> | undefined;
  const timeoutPromise = new Promise<never>((_, reject) => {
    timer = setTimeout(
      () => reject(new Error(\`pglite \${label} query exceeded \${timeoutMs}ms\`)),
      timeoutMs,
    );
  });
  try {
    return (await Promise.race([
      db.query(sql, params),
      timeoutPromise,
    ])) as { rows: T[] };
  } finally {
    if (timer) clearTimeout(timer);
  }
}
```

Both `searchKeyword` and `searchVector` now go through
`queryWithTimeout(this.db, sql, params, SEARCH_QUERY_TIMEOUT_MS, '<label>')`.
Return shape and downstream code (`rows.map(rowToSearchResult)`) are
unchanged.

## Known caveat (documented inline)

`Promise.race` frees the awaiting caller but does not actually cancel
the underlying WASM work. The query keeps running in the background
until it finishes naturally. This is a strict improvement over an
unbounded hang: the agent session, jobs daemon, and autopilot cycle
resume after 8s instead of blocking indefinitely. True cancellation
requires PGLite to expose a cancel token upstream (not present in
`@electric-sql/pglite@0.4.x`). Docstring points at that caveat for
future follow-up.

## Scope choice

Only the two paths that have the equivalent Postgres defense
(`searchKeyword`, `searchVector`) are wrapped, to keep this change
purely a parity fix. Other PGLite methods (`resolveSlugs`,
`findByTitleFuzzy`, `traverseGraph`) are also missing timeouts and
are reachable via MCP, but wrapping them is additional surface area
and belongs in a follow-up if the maintainer wants it. Happy to
extend in this PR on request.

## Test plan

New file: `test/pglite-search-timeout.test.ts`.

- [x] Source-level: `searchKeyword` + `searchVector` call
      `queryWithTimeout`, not raw `this.db.query` (grep against the
      compiled source body of each method).
- [x] Source-level: `SEARCH_QUERY_TIMEOUT_MS = 8000` constant exists.
- [x] Functional: inject a fake `db` whose `.query()` never resolves.
      `engine.searchKeyword('ignored')` must reject with the documented
      \`pglite searchKeyword query exceeded ...\` message, within the 8s
      cap (test asserts < 8.5s; harness bails at 9s if nothing fires).
- [x] `bun test` — full suite: 1747 pass / 0 fail / 174 skip
      (E2E skipped without `DATABASE_URL`, per standard).

## Risk

- `Promise.race` + `setTimeout` is stdlib-level; no new runtime
  requirements.
- The helper's return type lines up with the existing destructure
  (`const { rows } = ...`). No behavior change on successful queries.
- Unsuccessful (timeout) path now surfaces a clear `Error` to the
  caller instead of hanging — that is the point. Callers of `search`
  currently have no error handling for hang cases; they will now see
  a deterministic rejection they can log and retry.
- `pg_trgm.similarity_threshold` and similar GUC-inlined thresholds
  elsewhere are intentionally left alone; this PR only reaches what
  Postgres already treats as timed-search territory.

## Notes

Flagged as part of an ongoing security audit; no public disclosure of
PoC details until this lands. Happy to rebase on request.