### PR TITLE
fix: run migrations before schema SQL in initSchema()

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -61,12 +61,17 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   async initSchema(): Promise<void> {
-    await this.db.exec(PGLITE_SCHEMA_SQL);
-
+    // Run migrations FIRST so that upgrade brains (pre-v0.13) get the new
+    // columns (link_source, origin_page_id, origin_field) before the schema
+    // SQL tries to CREATE INDEX on them.  On a fresh brain the migration
+    // chain is a no-op (IF NOT EXISTS / ADD COLUMN IF NOT EXISTS everywhere)
+    // and the subsequent schema SQL creates the full schema cleanly.
     const { applied } = await runMigrations(this);
     if (applied > 0) {
       console.log(`  ${applied} migration(s) applied`);
     }
+
+    await this.db.exec(PGLITE_SCHEMA_SQL);
   }
 
   async transaction<T>(fn: (engine: BrainEngine) => Promise<T>): Promise<T> {

--- a/src/core/pglite-lock.ts
+++ b/src/core/pglite-lock.ts
@@ -75,20 +75,23 @@ export async function acquireLock(dataDir: string | undefined, opts?: { timeoutM
 
         // Is the locking process still alive?
         if (!isProcessAlive(lockPid)) {
-          // Stale lock — clean it up
+          // Stale lock — clean it up and retry immediately
           try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition, try again */ }
+          continue;
         } else if (Date.now() - lockTime > STALE_THRESHOLD_MS) {
           // Lock held for too long — assume stale (e.g., process hung)
-          // Still alive but probably stuck — force remove
+          // Still alive but probably stuck — force remove and retry
           try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition */ }
+          continue;
         } else {
           // Lock is held by a live process — wait and retry
           await new Promise(r => setTimeout(r, 1000));
           continue;
         }
       } catch {
-        // Corrupt lock file — remove it
-        try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition */ }
+        // Corrupt lock file — remove it and retry immediately
+        try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition, try again */ }
+        continue;
       }
     }
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -65,13 +65,16 @@ export class PostgresEngine implements BrainEngine {
     // on DDL statements (DROP TRIGGER + CREATE TRIGGER acquire AccessExclusiveLock)
     await conn`SELECT pg_advisory_lock(42)`;
     try {
-      await conn.unsafe(SCHEMA_SQL);
-
-      // Run any pending migrations automatically
+      // Run migrations FIRST so that upgrade brains (pre-v0.13) get the new
+      // columns (link_source, origin_page_id, origin_field) before the schema
+      // SQL tries to CREATE INDEX on them.  On a fresh brain the migration
+      // chain is a no-op and the subsequent schema SQL creates the full schema.
       const { applied } = await runMigrations(this);
       if (applied > 0) {
         console.log(`  ${applied} migration(s) applied`);
       }
+
+      await conn.unsafe(SCHEMA_SQL);
     } finally {
       await conn`SELECT pg_advisory_unlock(42)`;
     }


### PR DESCRIPTION
## Summary

Two orthogonal fixes:

### 1. `initSchema()`: run migrations BEFORE schema SQL (both engines)

Both `PGLiteEngine.initSchema()` and `PostgresEngine.initSchema()` were executing the embedded schema SQL (which includes `CREATE INDEX` statements on `link_source`, `origin_page_id`, `origin_field` columns) **before** running `runMigrations()`. On brains upgraded from pre-v0.13 (schema v10), those columns don't exist yet when the schema SQL runs, causing the init to fail with `column link_source does not exist`.

**Fix:** Swap the order — run `runMigrations()` first, then execute the schema SQL.

- On a **fresh brain**: migrations are a no-op (all statements use `IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS`), and the subsequent schema SQL creates the full schema cleanly.
- On an **upgrade brain**: migrations add the new columns and indexes first, then the schema SQL's `CREATE INDEX` statements succeed.

### 2. `pglite-lock.ts`: retry immediately after removing stale/corrupt locks

After removing a stale (dead PID or expired timestamp) or corrupt (unreadable JSON) lock directory, the acquire loop now `continue`s directly instead of falling through to the `mkdirSync` re-acquire attempt. This avoids a race where the stale cleanup succeeds but the immediate re-acquire attempt races with another process that just released the same lock.

**Fix:** Add `continue` after each lock-removal branch to restart the loop from the top rather than re-entering the acquire path mid-cleanup.

## Test plan

- [x] Existing `pglite-engine.test.ts` unit tests pass (no DB required)
- [ ] E2E migration-flow test against a pre-v0.13 brain (requires Postgres+pgvector)

## Related issues

Fixes #239, #243, #251, #266.