### PR TITLE
fix(db): disable prepared statements on Supabase pooler to prevent cross-connection statement-cache errors

### DIFF
--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -52,11 +52,21 @@ export async function connect(config: EngineConfig): Promise<void> {
     );
   }
 
+  // Transaction-mode poolers (Supabase pgbouncer on :6543, or
+  // pooler.supabase.com) invalidate server-side prepared statements between
+  // connection releases. postgres.js caches prepared statements by default,
+  // so a later query on a different underlying connection that reuses the
+  // same prepared-statement name trips `prepared statement "xyz" does not
+  // exist`. Detect pooler URLs and disable prepared statements; direct
+  // connections (port 5432, non-pooler hosts) keep prepare=true for perf.
+  const isPooler = /pooler\.supabase\.com|:6543/i.test(url);
+
   try {
     sql = postgres(url, {
       max: resolvePoolSize(),
       idle_timeout: 20,
       connect_timeout: 10,
+      prepare: !isPooler,
       types: {
         // Register pgvector type
         bigint: postgres.BigInt,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -37,10 +37,14 @@ export class PostgresEngine implements BrainEngine {
       const url = config.database_url;
       if (!url) throw new GBrainError('No database URL', 'database_url is missing', 'Provide --url');
       const size = Math.min(config.poolSize, db.resolvePoolSize(config.poolSize));
+      // See db.ts connect() for rationale: pgbouncer transaction mode
+      // invalidates prepared statements between connection releases.
+      const isPooler = /pooler\.supabase\.com|:6543/i.test(url);
       this._sql = postgres(url, {
         max: size,
         idle_timeout: 20,
         connect_timeout: 10,
+        prepare: !isPooler,
         types: { bigint: postgres.BigInt },
       });
       await this._sql`SELECT 1`;


### PR DESCRIPTION
## Problem

Users on the Supabase transaction pooler (port `:6543` or `pooler.supabase.com`) hit sporadic `prepared statement "abc123" does not exist` errors under sustained gbrain load (sync, extract, embed, autopilot).

**Root cause:** pgbouncer in transaction mode recycles underlying Postgres connections between client queries. postgres.js caches prepared statements by name and reuses them — but the next query may land on a different underlying connection where that prepared-statement name is unknown. Postgres raises the error and the query fails.

Repro (bare postgres.js against Supabase pooler):
```
sql = postgres("postgresql://...@aws-1-us-west-1.pooler.supabase.com:6543/postgres", { max: 10 });
// Run enough parameterized queries to exhaust the pool and start reusing connections
// → "prepared statement 's1' does not exist"
```

## Fix

Detect pooler URLs by regex on the connection string and pass `prepare: false` to postgres.js. Direct connections (port 5432, non-pooler hosts) keep `prepare: true` and retain plan-caching perf.

```ts
const isPooler = /pooler\.supabase\.com|:6543/i.test(url);
sql = postgres(url, {
  // ...
  prepare: !isPooler,
});
```

Applied at the two `postgres(url, ...)` call sites:
- [src/core/db.ts](src/core/db.ts) `connect()` — the module-global singleton used by the CLI
- [src/core/postgres-engine.ts](src/core/postgres-engine.ts) `connect()` with `config.poolSize` — the instance pool used by worker isolation

## Empirical

Carried as a local patch for ~6 months against Supabase pooler on a ~31k-page brain. Without it, sustained load surfaces \"prepared statement\" errors within minutes. With it, zero occurrences across sync/extract/embed/autopilot over that span.

## Impact

- **Pooler users**: no more cross-connection statement-cache errors. Slight per-query overhead from skipping the prepared-statement optimization (negligible in practice).
- **Direct-Postgres users**: zero change — `isPooler` evaluates false, `prepare` stays true.
- **Schema**: no change.
- **Tests**: none added. The fix is a config flag driven by URL inspection; the behavior is entirely in postgres.js.

## Notes

- Alternative: `prepare: false` unconditionally. Rejected because direct-Postgres users would pay the unnecessary perf cost.
- Alternative: env-var opt-in (e.g. `GBRAIN_POOLER_MODE=1`). Rejected because pooler URLs are self-identifying — no reason to require manual configuration.
- The regex matches both the Supabase-specific pooler hostname AND the generic `:6543` transaction-mode port, covering self-hosted pgbouncer too.

If the regex approach feels too magical, happy to rework as an explicit `{pooler: true}` config option instead.