### PR TITLE
Windows compat: readFileSync fd 0 + Bun-aware migration recurse

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,7 +127,7 @@ function parseOpArgs(op: Operation, args: string[]): Record<string, unknown> {
 
   // Read stdin for content params
   if (op.cliHints?.stdin && !params[op.cliHints.stdin] && !process.stdin.isTTY) {
-    const stdinContent = readFileSync('/dev/stdin', 'utf-8');
+    const stdinContent = readFileSync(0, 'utf-8');
     const MAX_STDIN = 5_000_000; // 5MB
     if (Buffer.byteLength(stdinContent, 'utf-8') > MAX_STDIN) {
       console.error(`Error: stdin content exceeds ${MAX_STDIN} bytes. Split into smaller inputs.`);

--- a/src/commands/migrations/v0_13_0.ts
+++ b/src/commands/migrations/v0_13_0.ts
@@ -41,7 +41,11 @@ import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhase
 // an older installed copy via alias shadowing or stale PATH cache. The
 // active process.execPath is the one that loaded THIS migration module,
 // so recursing into it is always the right binary.
-const GBRAIN = process.execPath;
+// Exception: under Bun, process.execPath is bun[.exe], not gbrain — so
+// recursing would shell out to `bun extract` (command not found). Fall
+// back to the `gbrain` command name in that case.
+declare const Bun: { version: string } | undefined;
+const GBRAIN = typeof Bun !== 'undefined' ? 'gbrain' : process.execPath;
 
 function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'schema', status: 'skipped', detail: 'dry-run' };

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -41,7 +41,7 @@ export async function runReport(args: string[]) {
   // Read content from --content arg or stdin
   let content = contentIdx >= 0 ? args[contentIdx + 1] : null;
   if (!content && !process.stdin.isTTY) {
-    content = readFileSync('/dev/stdin', 'utf-8');
+    content = readFileSync(0, 'utf-8');
   }
 
   if (!content?.trim()) {


### PR DESCRIPTION
## Summary

Two Windows-only breakages hit on a fresh v0.13/v0.14 install running gbrain via Bun. Both are small, zero-risk portability fixes.

### 1. `readFileSync('/dev/stdin')` → `readFileSync(0)`

`src/cli.ts:130` and `src/commands/report.ts:44` read piped stdin via the `/dev/stdin` pseudo-file, which doesn't exist on Windows. Any `gbrain put-page < file.md` or `gbrain report <<<"..."` invocation throws `ENOENT`.

`readFileSync(0)` passes the stdin file descriptor directly — works identically on Linux, macOS, and Windows under both Node and Bun. No behavior change on Unix.

### 2. `process.execPath` is `bun.exe` under Bun, not `gbrain`

`src/commands/migrations/v0_13_0.ts:44` stores `GBRAIN = process.execPath` and later shells out to it:

```ts
execSync(`${GBRAIN} extract links --source db ...`)
```

When gbrain runs via `bun run src/cli.ts`, `process.execPath` resolves to `bun.exe` (Windows) or `bun` (Unix), so the migration tries to run `bun extract` and fails with "command not found" — leaving the brain half-migrated.

Fix: detect Bun via the global `Bun` object and fall back to the `gbrain` command name. In the native-binary case (`bin/gbrain`) the original behavior is preserved — `Bun` is undefined, `process.execPath` points at the real binary. The original comment's concern about PATH shadowing only applies to the `gbrain upgrade` case with a native binary, which this branch doesn't touch.

## Test plan

- [x] `gbrain put-page < some-file.md` — no ENOENT
- [x] `gbrain apply-migrations --yes --non-interactive` — completes through v0.13.0 phase B
- [x] `gbrain doctor --fast` — no regressions
- [x] Ran on a real brain (176 pages) end-to-end, including the v0.13 → v0.14.2 migration path under Bun 1.3.11 on Windows 11

## Context

Found while upgrading from v0.13.1 to the `garrytan/embedding-providers` branch (v0.15.0) on Windows. Without these patches the upgrade path is blocked on Windows + Bun setups. Happy to split into two PRs if you'd prefer; kept as one since they're both the same "portability" theme and each is a two-line change.