### PR TITLE
fix: resolve CLI via argv[1] + bun for migration re-invocation

### DIFF
--- a/src/commands/migrations/gbrain-self.ts
+++ b/src/commands/migrations/gbrain-self.ts
@@ -1,0 +1,44 @@
+/**
+ * Resolve the command prefix used to re-invoke the CURRENTLY-RUNNING gbrain
+ * CLI from a migration. Must survive bun-link installs where
+ * `process.execPath` is the bun interpreter (`/Users/…/.bun/bin/bun`), not
+ * the gbrain entry script.
+ *
+ * Strategy: prefix `bun run <cli.ts>` where cli.ts comes from
+ * `process.argv[1]`. This works in three install shapes:
+ *
+ *   - dev:        `bun run src/cli.ts apply-migrations`
+ *                 → argv[1] = /…/src/cli.ts
+ *   - bun link:   `gbrain apply-migrations` (symlink -> .../node_modules/gbrain/src/cli.ts)
+ *                 → argv[1] = /…/node_modules/gbrain/src/cli.ts (bun resolves the symlink)
+ *   - shebang:    `/usr/bin/env bun` at top of cli.ts with direct invocation
+ *                 → argv[1] = /…/cli.ts
+ *
+ * We intentionally DO NOT fall back to a bare `gbrain` on $PATH: after
+ * `gbrain upgrade` rewrites the binary, a stale PATH entry could resolve
+ * to a different version. argv[1] is always the module that loaded this
+ * migration code, so it's the right gbrain by definition.
+ */
+
+function shellQuote(s: string): string {
+  // Safe single-quoting for POSIX sh. Replaces each ' with '\''.
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Returns a shell-ready command prefix (already quoted) that re-invokes
+ * this gbrain CLI. Append your subcommand + args as a plain string:
+ *
+ *   execSync(`${gbrainSelfCmd()} init --migrate-only`, {...});
+ */
+export function gbrainSelfCmd(): string {
+  const bun = shellQuote(process.execPath);
+  const cli = process.argv[1];
+  if (!cli) {
+    // Should never happen — bun always sets argv[1] to the entry script.
+    // Fall back to the $PATH lookup so something still runs instead of
+    // throwing from inside a migration.
+    return 'gbrain';
+  }
+  return `${bun} run ${shellQuote(cli)}`;
+}

--- a/src/commands/migrations/v0_11_0.ts
+++ b/src/commands/migrations/v0_11_0.ts
@@ -23,6 +23,14 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, lstatSync, statSync, realpathSync } from 'fs';
 import { join, resolve, dirname } from 'path';
 import { execSync } from 'child_process';
+
+import { gbrainSelfCmd } from './gbrain-self.ts';
+
+// Re-invoke the CURRENTLY-RUNNING gbrain CLI. `gbrain` off $PATH is unsafe
+// here: on bun-linked installs `process.execPath` is the bun interpreter,
+// not the gbrain entry. gbrainSelfCmd() builds `bun run <argv[1]>` which
+// always resolves to the right binary.
+const GBRAIN = gbrainSelfCmd();
 import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhaseResult } from './types.ts';
 import { savePreferences, loadPreferences, appendCompletedMigration } from '../../core/preferences.ts';
 import { promptLine } from '../../core/cli-util.ts';
@@ -59,7 +67,7 @@ export interface PendingHostWorkEntry {
 function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'schema', status: 'skipped', detail: 'dry-run' };
   try {
-    execSync('gbrain init --migrate-only', { stdio: 'inherit', timeout: 60_000, env: process.env });
+    execSync(`${GBRAIN} init --migrate-only`, { stdio: 'inherit', timeout: 60_000, env: process.env });
     return { name: 'schema', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -74,7 +82,7 @@ function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
 function phaseBSmoke(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'smoke', status: 'skipped', detail: 'dry-run' };
   try {
-    execSync('gbrain jobs smoke', { stdio: 'inherit', timeout: 30_000, env: process.env });
+    execSync(`${GBRAIN} jobs smoke`, { stdio: 'inherit', timeout: 30_000, env: process.env });
     return { name: 'smoke', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -395,7 +403,7 @@ function phaseFInstall(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'install', status: 'skipped', detail: 'dry-run' };
   if (opts.noAutopilotInstall) return { name: 'install', status: 'skipped', detail: '--no-autopilot-install' };
   try {
-    execSync('gbrain autopilot --install --yes', { stdio: 'inherit', timeout: 60_000, env: process.env });
+    execSync(`${GBRAIN} autopilot --install --yes`, { stdio: 'inherit', timeout: 60_000, env: process.env });
     return { name: 'install', status: 'complete' };
   } catch (e) {
     // Install is best-effort — log but don't fail the whole migration. User

--- a/src/commands/migrations/v0_12_0.ts
+++ b/src/commands/migrations/v0_12_0.ts
@@ -31,6 +31,13 @@
  */
 
 import { execSync } from 'child_process';
+
+import { gbrainSelfCmd } from './gbrain-self.ts';
+
+// Re-invoke the CURRENTLY-RUNNING gbrain CLI. `gbrain` off $PATH is unsafe
+// on bun-linked installs where process.execPath is the bun interpreter,
+// not the gbrain entry script. gbrainSelfCmd() builds `bun run <argv[1]>`.
+const GBRAIN = gbrainSelfCmd();
 import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhaseResult } from './types.ts';
 import { appendCompletedMigration } from '../../core/preferences.ts';
 
@@ -42,7 +49,7 @@ function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
     // 10-minute budget. Migrations v8/v9 dedup with helper-index should be sub-second
     // even on 80K-duplicate brains, but the outer wall-clock cap shouldn't be the
     // failure mode (the prior 60s ceiling tripped Garry's production upgrade).
-    execSync('gbrain init --migrate-only', { stdio: 'inherit', timeout: 600_000, env: process.env });
+    execSync(`${GBRAIN} init --migrate-only`, { stdio: 'inherit', timeout: 600_000, env: process.env });
     return { name: 'schema', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -66,7 +73,7 @@ function phaseBConfigCheck(opts: OrchestratorOpts): OrchestratorPhaseResult & { 
   // Default behavior when unset = enabled (per isAutoLinkEnabled).
   let raw = '';
   try {
-    raw = execSync('gbrain config get auto_link', { encoding: 'utf-8', timeout: 10_000, env: process.env }).trim();
+    raw = execSync(`${GBRAIN} config get auto_link`, { encoding: 'utf-8', timeout: 10_000, env: process.env }).trim();
   } catch {
     // get exits non-zero when the key isn't set — that's fine, defaults to enabled.
     raw = '';
@@ -92,7 +99,7 @@ function phaseCBackfillLinks(opts: OrchestratorOpts): OrchestratorPhaseResult {
     // --source db is idempotent: the UNIQUE constraint on
     // (from_page_id, to_page_id, link_type) and ON CONFLICT DO NOTHING
     // make re-runs cheap. Empty brains return 0/0 quickly.
-    execSync('gbrain extract links --source db', { stdio: 'inherit', timeout: 600_000, env: process.env });
+    execSync(`${GBRAIN} extract links --source db`, { stdio: 'inherit', timeout: 600_000, env: process.env });
     return { name: 'backfill_links', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -103,7 +110,7 @@ function phaseCBackfillLinks(opts: OrchestratorOpts): OrchestratorPhaseResult {
 function phaseDBackfillTimeline(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'backfill_timeline', status: 'skipped', detail: 'dry-run' };
   try {
-    execSync('gbrain extract timeline --source db', { stdio: 'inherit', timeout: 600_000, env: process.env });
+    execSync(`${GBRAIN} extract timeline --source db`, { stdio: 'inherit', timeout: 600_000, env: process.env });
     return { name: 'backfill_timeline', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -121,7 +128,7 @@ interface StatsSnapshot {
 
 function readStats(): StatsSnapshot | null {
   try {
-    const out = execSync('gbrain get_stats --json 2>/dev/null || gbrain stats', {
+    const out = execSync(`${GBRAIN} get_stats --json 2>/dev/null || ${GBRAIN} stats`, {
       encoding: 'utf-8', timeout: 30_000, env: process.env,
     });
     // The fallback `gbrain stats` prints human-readable output; parse loosely.

--- a/src/commands/migrations/v0_12_2.ts
+++ b/src/commands/migrations/v0_12_2.ts
@@ -21,6 +21,13 @@
  */
 
 import { execSync } from 'child_process';
+
+import { gbrainSelfCmd } from './gbrain-self.ts';
+
+// Re-invoke the CURRENTLY-RUNNING gbrain CLI. `gbrain` off $PATH is unsafe
+// on bun-linked installs where process.execPath is the bun interpreter,
+// not the gbrain entry script. gbrainSelfCmd() builds `bun run <argv[1]>`.
+const GBRAIN = gbrainSelfCmd();
 import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhaseResult } from './types.ts';
 import { appendCompletedMigration } from '../../core/preferences.ts';
 
@@ -29,7 +36,7 @@ import { appendCompletedMigration } from '../../core/preferences.ts';
 function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'schema', status: 'skipped', detail: 'dry-run' };
   try {
-    execSync('gbrain init --migrate-only', { stdio: 'inherit', timeout: 60_000, env: process.env });
+    execSync(`${GBRAIN} init --migrate-only`, { stdio: 'inherit', timeout: 60_000, env: process.env });
     return { name: 'schema', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -42,7 +49,7 @@ function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
 function phaseBRepair(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'jsonb_repair', status: 'skipped', detail: 'dry-run' };
   try {
-    execSync('gbrain repair-jsonb', { stdio: 'inherit', timeout: 600_000, env: process.env });
+    execSync(`${GBRAIN} repair-jsonb`, { stdio: 'inherit', timeout: 600_000, env: process.env });
     return { name: 'jsonb_repair', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -55,7 +62,7 @@ function phaseBRepair(opts: OrchestratorOpts): OrchestratorPhaseResult {
 function phaseCVerify(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'verify', status: 'skipped', detail: 'dry-run' };
   try {
-    const out = execSync('gbrain repair-jsonb --dry-run --json', {
+    const out = execSync(`${GBRAIN} repair-jsonb --dry-run --json`, {
       encoding: 'utf-8', timeout: 60_000, env: process.env,
     });
     const parsed = JSON.parse(out) as { total_repaired?: number; engine?: string };

--- a/src/commands/migrations/v0_13_0.ts
+++ b/src/commands/migrations/v0_13_0.ts
@@ -28,6 +28,7 @@
 import { execSync } from 'child_process';
 import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhaseResult } from './types.ts';
 import { appendCompletedMigration } from '../../core/preferences.ts';
+import { gbrainSelfCmd } from './gbrain-self.ts';
 
 // ── Phase A — Schema ────────────────────────────────────────
 //
@@ -35,12 +36,13 @@ import { appendCompletedMigration } from '../../core/preferences.ts';
 // and swaps the unique constraint. Schema build time on 46K pages is
 // ~10s (ALTER + index builds). Bumped timeout accounts for slow Supabase
 // links (v0.12.1 pattern — migrations can time out on the 60s default).
-// Use the CURRENTLY-RUNNING binary path (not `gbrain` off $PATH). After
-// `gbrain upgrade` rewrites the binary, a bare `gbrain` could resolve to
-// an older installed copy via alias shadowing or stale PATH cache. The
-// active process.execPath is the one that loaded THIS migration module,
-// so recursing into it is always the right binary.
-const GBRAIN = process.execPath;
+// Use the CURRENTLY-RUNNING binary (not `gbrain` off $PATH). After `gbrain
+// upgrade` rewrites the binary, a bare `gbrain` could resolve to an older
+// installed copy via alias shadowing or stale PATH cache. gbrainSelfCmd()
+// builds `bun run <argv[1]>` so it works for both direct `bun run src/cli.ts`
+// and bun-link installs where process.execPath is the bun interpreter rather
+// than the gbrain entry script.
+const GBRAIN = gbrainSelfCmd();
 
 function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'schema', status: 'skipped', detail: 'dry-run' };


### PR DESCRIPTION
## Summary

`gbrain apply-migrations --yes` fails for bun-linked installs because migrations re-invoke the CLI via `process.execPath`, which resolves to the bun interpreter (`~/.bun/bin/bun`) rather than the gbrain CLI script.

## Symptoms

On a bun-linked install (`bun install && bun link` — the recommended install path):

```
$ gbrain apply-migrations --yes
? Select a project template - Press return to submit.
     Blank           <-- bun init prompt fires instead of gbrain init
     React
     Library
...
error: Script not found "extract"
Migration v0.13.0 finished as PARTIAL.
```

Root cause: `bin/gbrain` is a symlink to `src/cli.ts` executed via bun. `process.execPath` returns `/Users/.../.bun/bin/bun`, so `execSync(\`${process.execPath} init --migrate-only\`)` runs `bun init`, not `gbrain init`. Same for `extract` and other migration sub-invocations.

## Fix

Add a small helper `src/commands/migrations/gbrain-self.ts` that exposes `gbrainSelfCmd()` returning a shell-safe `bun run <argv[1]>` command string, and route all migration re-invocations through it.

- `src/commands/migrations/gbrain-self.ts` (new, 44 lines)
- `src/commands/migrations/v0_11_0.ts`, `v0_12_0.ts`, `v0_12_2.ts`, `v0_13_0.ts` — replace `process.execPath` / bare `gbrain` shell-outs with `gbrainSelfCmd()`.

Works in:
- dev (`bun run src/cli.ts ...`)
- bun-linked installs (argv[1] is the linked symlink target)
- direct shebang invocation (argv[1] is the script path)

## Verification

```
$ gbrain apply-migrations --yes --dry-run
# plans migration phases; no bun init prompt

$ gbrain apply-migrations --yes
# completes cleanly; doctor no longer reports HALF-INSTALLED

$ gbrain doctor --json | jq '.checks[] | select(.name=="minions_migration")'
# absent (fixed)
```

## Testing notes

Applied and verified on macOS (arm64) with Bun v1.3.10 against a 1,595-page PGLite brain. Pre-fix: 100% reproducible failure. Post-fix: all migrations run to completion on the same DB state.

No schema or behavioral changes — purely fixes how migrations shell out to re-invoke themselves. Idempotent, backwards compatible.

## Authorship note

This patch originated in downstream scaffolde-ai and was cherry-picked here for upstream contribution.
