### PR TITLE
fix(hybrid): propagate SearchOpts filters to inner keyword/vector searches

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -68,7 +68,11 @@ export async function hybridSearch(
 
   // Auto-detect detail level from query intent when caller doesn't specify
   const detail = opts?.detail ?? autoDetectDetail(query);
-  const searchOpts: SearchOpts = { limit: innerLimit, detail };
+  // Propagate filter options (type, exclude_slugs, etc.) from caller opts to inner
+  // searchKeyword/searchVector calls. Without the spread, filters were silently
+  // dropped. `limit` is overridden to innerLimit (RRF needs more candidates) and
+  // `offset` is forced to 0 (outer result is sliced at the end of this function).
+  const searchOpts: SearchOpts = { ...opts, limit: innerLimit, offset: 0, detail };
 
   if (DEBUG && detail) {
     console.error(`[search-debug] auto-detail=${detail} for query="${query}"`);

--- a/test/hybrid-search-opts.test.ts
+++ b/test/hybrid-search-opts.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression test for hybridSearch dropping filter options on inner search calls.
+ *
+ * Before fix: `const searchOpts: SearchOpts = { limit: innerLimit, detail };`
+ *   silently dropped caller-provided `type`, `exclude_slugs` (and any future
+ *   filter field) from the SearchOpts forwarded to engine.searchKeyword and
+ *   engine.searchVector.
+ *
+ * After fix: `const searchOpts: SearchOpts = { ...opts, limit: innerLimit, offset: 0, detail };`
+ *   propagates every caller-provided filter to inner searches.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { hybridSearch } from '../src/core/search/hybrid.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+import type { SearchOpts, SearchResult } from '../src/core/types.ts';
+
+function makeMockEngine(): {
+  engine: BrainEngine;
+  capturedKeywordOpts: SearchOpts[];
+  capturedVectorOpts: SearchOpts[];
+} {
+  const capturedKeywordOpts: SearchOpts[] = [];
+  const capturedVectorOpts: SearchOpts[] = [];
+
+  const engine = {
+    async searchKeyword(_query: string, opts?: SearchOpts): Promise<SearchResult[]> {
+      capturedKeywordOpts.push(opts ?? {});
+      return [];
+    },
+    async searchVector(_embedding: Float32Array, opts?: SearchOpts): Promise<SearchResult[]> {
+      capturedVectorOpts.push(opts ?? {});
+      return [];
+    },
+    async getBacklinkCounts(_slugs: string[]): Promise<Map<string, number>> {
+      return new Map();
+    },
+  } as unknown as BrainEngine;
+
+  return { engine, capturedKeywordOpts, capturedVectorOpts };
+}
+
+describe('hybridSearch options propagation', () => {
+  test('forwards caller-provided `type` filter to searchKeyword', async () => {
+    const { engine, capturedKeywordOpts } = makeMockEngine();
+    // Ensure vector search path is skipped (no OPENAI_API_KEY).
+    const priorKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try {
+      await hybridSearch(engine, 'anything', { type: 'person' });
+    } finally {
+      if (priorKey !== undefined) process.env.OPENAI_API_KEY = priorKey;
+    }
+
+    expect(capturedKeywordOpts.length).toBeGreaterThan(0);
+    expect(capturedKeywordOpts[0].type).toBe('person');
+  });
+
+  test('forwards caller-provided `exclude_slugs` filter to searchKeyword', async () => {
+    const { engine, capturedKeywordOpts } = makeMockEngine();
+    const priorKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try {
+      await hybridSearch(engine, 'anything', { exclude_slugs: ['foo', 'bar'] });
+    } finally {
+      if (priorKey !== undefined) process.env.OPENAI_API_KEY = priorKey;
+    }
+
+    expect(capturedKeywordOpts[0].exclude_slugs).toEqual(['foo', 'bar']);
+  });
+
+  test('overrides caller-provided `limit` and `offset` for inner searches', async () => {
+    // limit must be innerLimit (limit*2 capped at MAX_SEARCH_LIMIT), not the caller's
+    // limit — inner searches need more candidates for RRF fusion. offset must be 0
+    // because outer slicing applies offset to the final result set.
+    const { engine, capturedKeywordOpts } = makeMockEngine();
+    const priorKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try {
+      await hybridSearch(engine, 'anything', { limit: 10, offset: 5 });
+    } finally {
+      if (priorKey !== undefined) process.env.OPENAI_API_KEY = priorKey;
+    }
+
+    expect(capturedKeywordOpts[0].limit).toBe(20); // 10 * 2
+    expect(capturedKeywordOpts[0].offset).toBe(0);
+  });
+
+  test('handles undefined opts without throwing', async () => {
+    const { engine, capturedKeywordOpts } = makeMockEngine();
+    const priorKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try {
+      await hybridSearch(engine, 'anything');
+    } finally {
+      if (priorKey !== undefined) process.env.OPENAI_API_KEY = priorKey;
+    }
+
+    expect(capturedKeywordOpts.length).toBe(1);
+    expect(capturedKeywordOpts[0].limit).toBe(40); // default 20 * 2
+  });
+});


### PR DESCRIPTION
## Summary

`hybridSearch()` silently drops caller-provided `type` and `exclude_slugs` filter options when building `searchOpts` for inner `searchKeyword` / `searchVector` calls:

https://github.com/garrytan/gbrain/blob/master/src/core/search/hybrid.ts#L71

```typescript
const searchOpts: SearchOpts = { limit: innerLimit, detail };
```

Any caller using `hybridSearch(engine, query, { type: 'person' })` or `{ exclude_slugs: [...] }` gets unfiltered results while believing the filter is applied — the outer `hybridSearch` never reads those fields again, and the inner searches never see them.

## Fix

One-line spread before overriding `limit` / `offset` / `detail`:

```typescript
const searchOpts: SearchOpts = { ...opts, limit: innerLimit, offset: 0, detail };
```

This preserves every caller-provided filter field (current and future — any field added to `SearchOpts` becomes automatically propagated, no additional plumbing).

`offset` is explicitly set to `0` on the inner searches because the outer `hybridSearch` slices the final result set at `[offset, offset+limit]` itself — propagating the caller's offset into the inner searches would double-apply it.

## Test plan

Added `test/hybrid-search-opts.test.ts` with 4 regression tests covering:

- `type` filter propagates to `searchKeyword`
- `exclude_slugs` propagates
- `limit` is overridden to `innerLimit` (outer `limit * 2`) and `offset` is forced to `0`
- `undefined` opts don't throw

All existing tests still pass (`bun test test/search.test.ts test/search-limit.test.ts` — 42 pass, 0 fail).

Happy to add similar tests on the vector path or integration-level tests if that would help. Also flagged as draft in case you'd prefer a different fix shape (e.g., explicit per-field spread instead of full `...opts`).