### PR TITLE
fix(db): disable prepared statements by default for pooler compat

### DIFF
--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -57,6 +57,7 @@ export async function connect(config: EngineConfig): Promise<void> {
       max: resolvePoolSize(),
       idle_timeout: 20,
       connect_timeout: 10,
+      prepare: false,
       types: {
         // Register pgvector type
         bigint: postgres.BigInt,


### PR DESCRIPTION
## What

Adds `prepare: false` to the postgres.js connection options in `db.ts`.

## Why

Supabase Supavisor and PgBouncer in transaction mode don't support prepared statements — session state isn't preserved between queries, so prepared statement references become dangling. 

While `?prepare=false` in the connection URL already handles this (postgres.js parses it correctly), setting it explicitly in the options object provides a safety net for:
- Users who configure their DB URL without the query param
- Any future refactoring that might construct the URL differently

## Testing

- All 1743 bun tests pass, 0 failures
- Verified `gbrain search` and `gbrain query` work correctly with the change
- Single line change, low risk

## Impact

postgres.js defaults `prepare: true`. This makes gbrain work correctly with transaction-mode poolers out of the box.

Ref: https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler