### PR TITLE
fix(embed): SQL-filter stale chunks in --stale path (#161)

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -117,8 +117,46 @@ async function embedPage(engine: BrainEngine, slug: string) {
   console.log(`${slug}: embedded ${toEmbed.length} chunks`);
 }
 
+/**
+ * Fetch the set of slugs that have at least one stale chunk (embedded_at IS NULL).
+ * Used to avoid a full-brain walk in `embedAll(engine, true)` when coverage is
+ * already 100% or near-100% — see issue #161.
+ *
+ * Falls back to `null` (meaning "iterate all pages") when the engine's raw-SQL
+ * escape hatch isn't available, e.g. test mocks that don't implement
+ * executeRaw. Callers must treat null as "proceed with a full walk".
+ */
+async function listStaleSlugs(engine: BrainEngine): Promise<string[] | null> {
+  try {
+    const rows = await engine.executeRaw<{ slug: string }>(
+      `SELECT DISTINCT p.slug
+       FROM content_chunks c
+       JOIN pages p ON p.id = c.page_id
+       WHERE c.embedded_at IS NULL
+       ORDER BY p.slug`,
+    );
+    return rows.map(r => r.slug);
+  } catch {
+    return null;
+  }
+}
+
 async function embedAll(engine: BrainEngine, staleOnly: boolean) {
-  const pages = await engine.listPages({ limit: 100000 });
+  let pages: { slug: string }[];
+  if (staleOnly) {
+    const staleSlugs = await listStaleSlugs(engine);
+    if (staleSlugs !== null) {
+      if (staleSlugs.length === 0) {
+        console.log('No stale chunks to embed.');
+        return;
+      }
+      pages = staleSlugs.map(slug => ({ slug }));
+    } else {
+      pages = await engine.listPages({ limit: 100000 });
+    }
+  } else {
+    pages = await engine.listPages({ limit: 100000 });
+  }
   let total = 0;
   let embedded = 0;
   let processed = 0;

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -116,6 +116,12 @@ describe('runEmbed --all (parallel)', () => {
       listPages: async () => pages,
       getChunks: async (slug: string) => chunksBySlug.get(slug) || [],
       upsertChunks: async () => {},
+      // With the issue #161 SQL pre-filter, executeRaw returns the pre-filtered
+      // set of stale slugs. Mock it to return only the stale one.
+      executeRaw: async (sql: string) => {
+        if (/embedded_at IS NULL/i.test(sql)) return [{ slug: 'stale' }];
+        return [];
+      },
     });
 
     process.env.GBRAIN_EMBED_CONCURRENCY = '5';
@@ -123,6 +129,60 @@ describe('runEmbed --all (parallel)', () => {
     await runEmbed(engine, ['--stale']);
 
     // Only the stale page triggers an embedBatch call.
+    expect(totalEmbedCalls).toBe(1);
+  });
+
+  test('--stale with 100% coverage does NOT walk every page (issue #161)', async () => {
+    // Regression for https://github.com/garrytan/gbrain/issues/161:
+    // when executeRaw reports zero stale chunks, embedAll must short-circuit
+    // BEFORE falling back to listPages({ limit: 100000 }) + per-page getChunks.
+    const engineCalls: string[] = [];
+    const engine = mockEngine({
+      executeRaw: async (sql: string) => {
+        engineCalls.push('executeRaw');
+        if (/embedded_at IS NULL/i.test(sql)) return [];
+        throw new Error('unexpected sql in test');
+      },
+      listPages: async () => {
+        engineCalls.push('listPages');
+        // If we got here, the bug is back: the code walked every page.
+        return Array.from({ length: 31_139 }, (_, i) => ({ slug: `page-${i}` }));
+      },
+      getChunks: async () => {
+        engineCalls.push('getChunks');
+        return [];
+      },
+    });
+
+    await runEmbed(engine, ['--stale']);
+
+    expect(engineCalls).toContain('executeRaw');
+    expect(engineCalls).not.toContain('listPages');
+    expect(engineCalls).not.toContain('getChunks');
+    expect(totalEmbedCalls).toBe(0);
+  });
+
+  test('--stale falls back to full walk when executeRaw is unsupported', async () => {
+    // Back-compat: older engine implementations (or test doubles) without
+    // executeRaw should still work via the pre-#161 path.
+    const pages = [
+      { slug: 'a' },
+      { slug: 'b' },
+    ];
+    const chunksBySlug = new Map<string, any[]>([
+      ['a', [{ chunk_index: 0, chunk_text: 'hi', chunk_source: 'compiled_truth', embedded_at: null, token_count: 1 }]],
+      ['b', [{ chunk_index: 0, chunk_text: 'hi', chunk_source: 'compiled_truth', embedded_at: '2026-01-01', token_count: 1 }]],
+    ]);
+
+    const engine = mockEngine({
+      listPages: async () => pages,
+      getChunks: async (slug: string) => chunksBySlug.get(slug) || [],
+      upsertChunks: async () => {},
+      executeRaw: async () => { throw new Error('not implemented'); },
+    });
+
+    await runEmbed(engine, ['--stale']);
+
     expect(totalEmbedCalls).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

`embedAll(engine, /*staleOnly=*/true)` previously called `engine.listPages({ limit: 100000 })` and then iterated *every* page's chunks in application code, skipping those where every chunk already had `embedded_at` set. At 100% coverage that meant every autopilot cycle walked every page and did zero real work — the exact symptom in #161 ("embed --stale unexpectedly iterates all 31,139 pages").

This PR pushes the "is this page stale?" decision down to the database with a single `SELECT DISTINCT p.slug ... WHERE c.embedded_at IS NULL` query. At 100% coverage we short-circuit with `No stale chunks to embed.` and return. Below 100% coverage we only iterate pages that actually have at least one un-embedded chunk.

Falls back to the old full-walk path when the engine doesn't expose `executeRaw` (e.g. stub engines in tests), so this is fully backward-compatible.

## Repro

Against any brain at 100% embedding coverage:

```
gbrain embed --stale
```

- **Before:** walks every page (`listPages({ limit: 100000 })` + per-page chunk fetch).
- **After:** one SQL round-trip, prints `No stale chunks to embed.`, returns.

## Test plan

- [x] New unit test: `--stale with 100% coverage does NOT walk every page (issue #161)` — asserts `listPages` and `getChunks` are never called when the `WHERE embedded_at IS NULL` query returns `[]`.
- [x] New unit test: `--stale falls back to full walk when executeRaw is unsupported` — guards the back-compat path.
- [x] Existing `skips pages whose chunks are all already embedded when --stale` updated to mock `executeRaw` alongside `listPages`.
- [x] Full `bun test` suite: **1919 pass, 0 fail, 174 skip** (E2E gated on Postgres/Docker, not run).
- [ ] E2E suite (`docker-compose.test.yml`) — not run in this PR; left to CI/maintainer since it needs Postgres + pgvector + real API keys.

Fixes #161

Made with [Cursor](https://cursor.com)