### PR TITLE
fix(autopilot): configurable max errors + exponential backoff (#168)

### DIFF
--- a/src/commands/autopilot-backoff.ts
+++ b/src/commands/autopilot-backoff.ts
@@ -1,0 +1,52 @@
+/**
+ * Failure-backoff helper for `gbrain autopilot` (issue #168).
+ *
+ * Pre-v0.14.3 autopilot exited hard after 5 consecutive failures, which
+ * a single transient Postgres event (pgbouncer reset, Supabase minor
+ * version upgrade, network blip) could easily trip. This helper returns
+ * the new error counter, the sleep interval before the next cycle, and
+ * whether the daemon should exit.
+ *
+ * Kept in its own module so it can be unit-tested without driving the
+ * infinite daemon loop in autopilot.ts.
+ */
+
+export interface FailureState {
+  consecutiveErrors: number;
+}
+
+export interface FailureOpts {
+  /** Counter value at or above which `shouldExit` flips to true. */
+  maxErrors: number;
+  /** Base cycle interval in ms. */
+  baseIntervalMs: number;
+  /** Optional ceiling on the backoff sleep. Default 30 minutes. */
+  backoffCapMs?: number;
+}
+
+export interface FailureResult {
+  consecutiveErrors: number;
+  sleepMs: number;
+  shouldExit: boolean;
+}
+
+export const DEFAULT_MAX_CONSECUTIVE_ERRORS = 20;
+export const DEFAULT_BACKOFF_CAP_MS = 30 * 60_000;
+
+/**
+ * Compute the next sleep interval and whether the daemon should stop.
+ *
+ * Exponential growth starting at baseIntervalMs: 1x, 2x, 4x, 8x, ..., capped.
+ * The exponent is clamped so a long run of failures can't overflow.
+ */
+export function computeFailureBackoff(
+  state: FailureState,
+  opts: FailureOpts,
+): FailureResult {
+  const next = state.consecutiveErrors + 1;
+  const shouldExit = next >= opts.maxErrors;
+  const cap = opts.backoffCapMs ?? DEFAULT_BACKOFF_CAP_MS;
+  const exponent = Math.min(next - 1, 10);
+  const sleepMs = Math.min(opts.baseIntervalMs * Math.pow(2, exponent), cap);
+  return { consecutiveErrors: next, sleepMs, shouldExit };
+}

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -23,6 +23,10 @@ import { execSync, spawn, type ChildProcess } from 'child_process';
 import type { BrainEngine } from '../core/engine.ts';
 import { loadPreferences } from '../core/preferences.ts';
 import { loadConfig } from '../core/config.ts';
+import {
+  computeFailureBackoff,
+  DEFAULT_MAX_CONSECUTIVE_ERRORS,
+} from './autopilot-backoff.ts';
 
 function parseArg(args: string[], flag: string): string | undefined {
   const idx = args.indexOf(flag);
@@ -72,7 +76,7 @@ export function resolveGbrainCliPath(): string {
 
 export async function runAutopilot(engine: BrainEngine, args: string[]) {
   if (args.includes('--help') || args.includes('-h')) {
-    console.log('Usage: gbrain autopilot [--repo <path>] [--interval N] [--json]\n       gbrain autopilot --install [--repo <path>]\n       gbrain autopilot --uninstall\n       gbrain autopilot --status [--json]\n\nSelf-maintaining brain daemon. Runs sync + extract + embed + backlinks in a loop.');
+    console.log('Usage: gbrain autopilot [--repo <path>] [--interval N] [--max-consecutive-errors N] [--json]\n       gbrain autopilot --install [--repo <path>]\n       gbrain autopilot --uninstall\n       gbrain autopilot --status [--json]\n\nSelf-maintaining brain daemon. Runs sync + extract + embed + backlinks in a loop.\n\n  --max-consecutive-errors N  Stop after N failed cycles in a row (default 20).\n                              Failing cycles back off exponentially so a single\n                              transient Postgres event does not trip the cap.');
     return;
   }
 
@@ -93,6 +97,10 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
   const baseInterval = parseInt(parseArg(args, '--interval') || '300', 10);
   const jsonMode = args.includes('--json');
   const forceInline = args.includes('--inline');
+  const maxConsecutiveErrors = parseInt(
+    parseArg(args, '--max-consecutive-errors') || String(DEFAULT_MAX_CONSECUTIVE_ERRORS),
+    10,
+  );
 
   if (!repoPath) {
     console.error('No repo path. Use --repo or run gbrain sync --repo first.');
@@ -115,7 +123,9 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
     writeFileSync(lockPath, String(process.pid));
   } catch { /* best-effort */ }
 
-  console.log(`Autopilot starting. Repo: ${repoPath}, interval: ${baseInterval}s`);
+  console.log(
+    `Autopilot starting. Repo: ${repoPath}, interval: ${baseInterval}s, max_consecutive_errors=${maxConsecutiveErrors}`,
+  );
 
   // Mode resolution: Minions dispatch when the user has opted in AND the
   // worker daemon can actually run (Postgres only; PGLite's exclusive file
@@ -272,12 +282,26 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
     if (cycleOk) {
       consecutiveErrors = 0;
     } else {
-      consecutiveErrors++;
-      if (consecutiveErrors >= 5) {
-        console.error('5 consecutive cycle failures. Stopping autopilot.');
+      // Issue #168: instead of a hard exit after 5 failures (which a single
+      // transient Postgres event reliably trips), route the failure through
+      // computeFailureBackoff — the counter grows, the sleep interval grows
+      // exponentially, and we only stop at --max-consecutive-errors.
+      const r = computeFailureBackoff(
+        { consecutiveErrors },
+        { maxErrors: maxConsecutiveErrors, baseIntervalMs: interval * 1000 },
+      );
+      consecutiveErrors = r.consecutiveErrors;
+      if (r.shouldExit) {
+        console.error(
+          `${maxConsecutiveErrors} consecutive cycle failures. Stopping autopilot.`,
+        );
         void shutdown('cycle-failure-cap');
         break;
       }
+      interval = Math.ceil(r.sleepMs / 1000);
+      console.error(
+        `[autopilot] cycle failed (${consecutiveErrors}/${maxConsecutiveErrors}); backing off ${interval}s`,
+      );
     }
 
     // Wait for next cycle

--- a/test/autopilot-backoff.test.ts
+++ b/test/autopilot-backoff.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  computeFailureBackoff,
+  DEFAULT_MAX_CONSECUTIVE_ERRORS,
+  DEFAULT_BACKOFF_CAP_MS,
+} from '../src/commands/autopilot-backoff.ts';
+
+// Regression coverage for https://github.com/garrytan/gbrain/issues/168:
+// autopilot used to exit hard after 5 consecutive failures. A single
+// transient Postgres event (pgbouncer reset, Supabase minor version
+// upgrade, network blip) reliably tripped that cap. The fix routes the
+// failure through computeFailureBackoff, which grows the counter AND
+// grows the sleep interval exponentially, so the daemon rides through
+// transient events instead of committing suicide on the first one.
+
+describe('computeFailureBackoff (issue #168)', () => {
+  test('does NOT shouldExit at the old-threshold (5 failures) when maxErrors=20', () => {
+    // Walk 5 cycles of failures. With the pre-fix threshold of 5 the
+    // daemon would have bailed; with maxErrors=20 it must keep running.
+    let state = { consecutiveErrors: 0 };
+    const opts = { maxErrors: 20, baseIntervalMs: 300_000 };
+    for (let i = 0; i < 5; i++) {
+      const r = computeFailureBackoff(state, opts);
+      state = { consecutiveErrors: r.consecutiveErrors };
+      expect(r.shouldExit).toBe(false);
+    }
+    expect(state.consecutiveErrors).toBe(5);
+  });
+
+  test('increments consecutiveErrors by exactly 1 per call', () => {
+    expect(
+      computeFailureBackoff({ consecutiveErrors: 0 }, { maxErrors: 20, baseIntervalMs: 1000 })
+        .consecutiveErrors,
+    ).toBe(1);
+    expect(
+      computeFailureBackoff({ consecutiveErrors: 7 }, { maxErrors: 20, baseIntervalMs: 1000 })
+        .consecutiveErrors,
+    ).toBe(8);
+  });
+
+  test('shouldExit flips true only when counter reaches maxErrors', () => {
+    // 19th failure: not yet.
+    expect(
+      computeFailureBackoff({ consecutiveErrors: 18 }, { maxErrors: 20, baseIntervalMs: 1000 })
+        .shouldExit,
+    ).toBe(false);
+    // 20th failure: exit.
+    expect(
+      computeFailureBackoff({ consecutiveErrors: 19 }, { maxErrors: 20, baseIntervalMs: 1000 })
+        .shouldExit,
+    ).toBe(true);
+  });
+
+  test('sleepMs grows exponentially from baseIntervalMs', () => {
+    const base = 10_000;
+    const opts = { maxErrors: 99, baseIntervalMs: base };
+    // next=1 -> 1x, next=2 -> 2x, next=3 -> 4x, next=4 -> 8x
+    expect(computeFailureBackoff({ consecutiveErrors: 0 }, opts).sleepMs).toBe(base * 1);
+    expect(computeFailureBackoff({ consecutiveErrors: 1 }, opts).sleepMs).toBe(base * 2);
+    expect(computeFailureBackoff({ consecutiveErrors: 2 }, opts).sleepMs).toBe(base * 4);
+    expect(computeFailureBackoff({ consecutiveErrors: 3 }, opts).sleepMs).toBe(base * 8);
+  });
+
+  test('sleepMs is clamped to backoffCapMs on long runs', () => {
+    const r = computeFailureBackoff(
+      { consecutiveErrors: 50 },
+      { maxErrors: 999, baseIntervalMs: 60_000, backoffCapMs: 30 * 60_000 },
+    );
+    expect(r.sleepMs).toBeLessThanOrEqual(30 * 60_000);
+    expect(r.sleepMs).toBe(30 * 60_000);
+  });
+
+  test('default cap is 30 minutes and default max is 20', () => {
+    expect(DEFAULT_MAX_CONSECUTIVE_ERRORS).toBe(20);
+    expect(DEFAULT_BACKOFF_CAP_MS).toBe(30 * 60_000);
+  });
+
+  test('pure function — same input returns same output', () => {
+    const a = computeFailureBackoff({ consecutiveErrors: 3 }, { maxErrors: 10, baseIntervalMs: 500 });
+    const b = computeFailureBackoff({ consecutiveErrors: 3 }, { maxErrors: 10, baseIntervalMs: 500 });
+    expect(a).toEqual(b);
+  });
+});


### PR DESCRIPTION
## Summary

`src/commands/autopilot.ts` hard-exited on the 5th consecutive cycle failure with no backoff. A single transient Postgres event (pgbouncer reset, Supabase minor version upgrade, a network blip) reliably tripped the cap — especially stacked with the reconnect bug tracked in #164 / #167, where one flaky `engine.getConfig('version')` would cascade into "every step of the cycle fails". 5 such cycles landed well within a 25-minute window and the daemon committed suicide.

This PR routes the failure path through a new pure helper, `computeFailureBackoff()`:

- New CLI flag `--max-consecutive-errors N` (default **20**, up from the hard-coded 5).
- Exponential backoff between failing cycles: 1x, 2x, 4x, 8x, ... capped at 30 minutes so a flaky hour does not burn the cap.
- Startup log now prints `max_consecutive_errors=N` so operators can tell from logs alone which policy the daemon is running under.
- `--help` text updated.

The helper lives in a standalone module (`autopilot-backoff.ts`) so it is unit-testable without driving the infinite daemon loop.

## Repro

`autopilot --interval 300` against a Supabase brain during a minor-version upgrade window — `engine.getConfig` throws for ~8–10 minutes and the daemon exits mid-day with "5 consecutive cycle failures. Stopping autopilot." (see #168 and the linked #164 / #167).

## Test plan

- [x] 7 new unit tests in `test/autopilot-backoff.test.ts`:
  - does NOT `shouldExit` at the old 5-failure threshold when `maxErrors=20`
  - counter increments by exactly 1 per call
  - `shouldExit` flips at `maxErrors` (boundary)
  - `sleepMs` grows exponentially from `baseIntervalMs` (1x, 2x, 4x, 8x)
  - `sleepMs` clamped to `backoffCapMs` on long runs
  - defaults: cap = 30min, max = 20
  - pure: same input returns same output
- [x] Existing `autopilot-install.test.ts` + `autopilot-resolve-cli.test.ts` still pass.
- [x] Full `bun test` suite: **1924 pass, 0 fail, 174 skip**.
- [ ] E2E suite not run (needs Postgres/Docker/real API keys).

## Non-goals

This PR does not touch the underlying reconnect flakiness tracked in #164 / #167 — it just stops autopilot from committing suicide while those are being investigated. Conservative enough that it should be safe to merge ahead of them.

Fixes #168

Made with [Cursor](https://cursor.com)