### PR TITLE
fix(pglite): fail loudly on $bunfs data-dir paths (#250)

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -7,6 +7,7 @@ import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
 import { runMigrations } from './migrate.ts';
 import { PGLITE_SCHEMA_SQL } from './pglite-schema.ts';
 import { acquireLock, releaseLock, type LockHandle } from './pglite-lock.ts';
+import { assertRealFilesystemPath } from './pglite-path-guard.ts';
 import type {
   Page, PageInput, PageFilters, PageType,
   Chunk, ChunkInput,
@@ -35,6 +36,10 @@ export class PGLiteEngine implements BrainEngine {
   // Lifecycle
   async connect(config: EngineConfig): Promise<void> {
     const dataDir = config.database_path || undefined; // undefined = in-memory
+
+    // Fail loud if we were handed a $bunfs path (issue #250) -- PGLite WASM
+    // cannot read Bun single-file-executable virtual paths.
+    assertRealFilesystemPath(dataDir);
 
     // Acquire file lock to prevent concurrent PGLite access (crashes with Aborted())
     this._lock = await acquireLock(dataDir);

--- a/src/core/pglite-path-guard.ts
+++ b/src/core/pglite-path-guard.ts
@@ -1,0 +1,51 @@
+/**
+ * Guard against `$bunfs` data-directory paths in PGLite (issue #250).
+ *
+ * When gbrain is compiled with `bun build --compile`, Bun mounts the
+ * bundled files under the `$bunfs://` virtual filesystem. The PGLite
+ * WASM module expects a real on-disk path and will either throw an
+ * opaque WASM panic or silently create a broken data directory — both
+ * leave users with a half-initialized brain and no actionable signal.
+ *
+ * This helper detects the prefix up front so we can fail with a clear,
+ * actionable error instead.
+ *
+ * Kept in its own module so it can be unit-tested without spinning up
+ * PGLite (which is ~50 MB of WASM and is not friendly to isolated
+ * tests).
+ */
+
+/**
+ * Returns true iff the given path lives inside Bun's `$bunfs` virtual FS.
+ *
+ * Covers the documented shapes:
+ *   - `$bunfs://...`          (URL-style)
+ *   - `/$bunfs/...`           (absolute-path style, seen on Linux)
+ *   - `$bunfs/...`            (relative-ish, seen when argv[1] is used)
+ */
+export function isBunfsPath(p: string | undefined | null): boolean {
+  if (!p) return false;
+  return p.startsWith('$bunfs')
+    || p.startsWith('/$bunfs/')
+    || p.includes('/$bunfs/')
+    || p.startsWith('$bunfs://');
+}
+
+/**
+ * Throw if the given path is a `$bunfs` path. Message points the user at
+ * the documented `bun run src/cli.ts` workaround so they know what to do.
+ */
+export function assertRealFilesystemPath(p: string | undefined | null): void {
+  if (!isBunfsPath(p)) return;
+  throw new Error(
+    `PGLite cannot use a Bun single-file-executable path for its data directory:\n` +
+    `  ${p}\n\n` +
+    `Bun's 'bun build --compile' mounts bundled files under $bunfs://, which is a\n` +
+    `virtual filesystem that PGLite's WASM module cannot access.\n\n` +
+    `Workarounds:\n` +
+    `  - Run from source:  bun run src/cli.ts <command>\n` +
+    `  - Or pass --database-path with a real on-disk path\n` +
+    `    (e.g. ~/.gbrain/brain.pglite).\n\n` +
+    `See https://github.com/garrytan/gbrain/issues/250 for background.`,
+  );
+}

--- a/test/pglite-path-guard.test.ts
+++ b/test/pglite-path-guard.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  isBunfsPath,
+  assertRealFilesystemPath,
+} from '../src/core/pglite-path-guard.ts';
+
+// Regression coverage for https://github.com/garrytan/gbrain/issues/250:
+// When `gbrain` is compiled with `bun build --compile`, Bun mounts bundled
+// files under `$bunfs://`, which PGLite's WASM module cannot access. The
+// previous failure mode was an opaque WASM panic or silent corruption; the
+// fix is a loud, actionable error before PGLite even starts.
+
+describe('isBunfsPath (issue #250)', () => {
+  test('detects $bunfs:// URL-style paths', () => {
+    expect(isBunfsPath('$bunfs://root/brain.pglite')).toBe(true);
+  });
+
+  test('detects $bunfs/... bare-prefix paths', () => {
+    expect(isBunfsPath('$bunfs/root/brain.pglite')).toBe(true);
+  });
+
+  test('detects /$bunfs/... absolute-path style', () => {
+    expect(isBunfsPath('/$bunfs/root/brain.pglite')).toBe(true);
+  });
+
+  test('detects embedded /$bunfs/ in a deeper path', () => {
+    expect(isBunfsPath('/tmp/build/outdir/$bunfs/root/brain.pglite')).toBe(true);
+  });
+
+  test('accepts normal on-disk paths', () => {
+    expect(isBunfsPath('/Users/me/.gbrain/brain.pglite')).toBe(false);
+    expect(isBunfsPath('./brain.pglite')).toBe(false);
+    expect(isBunfsPath('brain.pglite')).toBe(false);
+    expect(isBunfsPath('/home/me/.gbrain/brain.pglite')).toBe(false);
+  });
+
+  test('is tolerant of empty/null/undefined', () => {
+    expect(isBunfsPath(undefined)).toBe(false);
+    expect(isBunfsPath(null)).toBe(false);
+    expect(isBunfsPath('')).toBe(false);
+  });
+});
+
+describe('assertRealFilesystemPath (issue #250)', () => {
+  test('throws on $bunfs paths with an actionable error message', () => {
+    let err: Error | null = null;
+    try {
+      assertRealFilesystemPath('$bunfs://root/brain.pglite');
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).not.toBeNull();
+    const msg = err!.message;
+    // Must mention PGLite (what failed).
+    expect(msg).toMatch(/PGLite/);
+    // Must mention the offending path.
+    expect(msg).toContain('$bunfs://root/brain.pglite');
+    // Must surface the documented workaround.
+    expect(msg).toMatch(/bun run src\/cli\.ts/);
+    // Must mention --database-path option.
+    expect(msg).toMatch(/--database-path/);
+    // Must point at the issue for context.
+    expect(msg).toMatch(/issues\/250/);
+  });
+
+  test('no-op on normal paths', () => {
+    expect(() => assertRealFilesystemPath('/Users/me/.gbrain/brain.pglite')).not.toThrow();
+    expect(() => assertRealFilesystemPath(undefined)).not.toThrow();
+    expect(() => assertRealFilesystemPath(null)).not.toThrow();
+    expect(() => assertRealFilesystemPath('')).not.toThrow();
+  });
+
+  test('throws on every documented $bunfs shape', () => {
+    expect(() => assertRealFilesystemPath('$bunfs/root/brain.pglite')).toThrow(/PGLite/);
+    expect(() => assertRealFilesystemPath('/$bunfs/root/brain.pglite')).toThrow(/PGLite/);
+    expect(() => assertRealFilesystemPath('/tmp/$bunfs/root/brain.pglite')).toThrow(/PGLite/);
+  });
+});


### PR DESCRIPTION
## Summary

When `gbrain` is compiled with `bun build --compile`, Bun mounts the bundled files under `$bunfs://` — a virtual filesystem that PGLite's WASM module cannot read. The existing failure mode was either an opaque WASM panic or silent corruption of the on-disk brain state, leaving users with a half-initialized brain and no actionable signal about what went wrong.

This PR adds a small guard — `assertRealFilesystemPath()` — called at the top of `PGLiteEngine.connect()`, *before* the file lock or PGLite itself is touched. The guard detects the `$bunfs` prefix and throws with an actionable error pointing at the documented workarounds:

- Run from source: `bun run src/cli.ts <command>`
- Or pass `--database-path` with a real on-disk path

## Coverage

The detector covers every documented `$bunfs` shape:

- `$bunfs://...` (URL-style)
- `$bunfs/...` (bare prefix)
- `/$bunfs/...` (absolute-path style, seen on Linux)
- `/<anything>/$bunfs/...` (nested)

Null / undefined / empty paths (in-memory PGLite, no data-dir) are unaffected.

## Test plan

- [x] 9 new unit tests in `test/pglite-path-guard.test.ts`:
  - `isBunfsPath` returns `true` for each documented shape
  - `isBunfsPath` returns `false` for normal paths and empty inputs
  - `assertRealFilesystemPath` throws with a message that mentions PGLite, the offending path, the `bun run src/cli.ts` workaround, `--database-path`, and the issue number for context
  - no-op on normal/undefined paths
- [x] Existing `pglite-lock.test.ts` + `engine-factory.test.ts` still pass.
- [x] Full `bun test` suite: **1926 pass, 0 fail, 174 skip**.
- [ ] E2E suite not run.

## Non-goals

This PR doesn't fix the underlying "compiled binary can't use PGLite" limitation — that likely needs PGLite WASM upstream work to read from `$bunfs`, or a one-time copy-to-tmp dance during startup. What this PR does is replace "opaque WASM panic / silent corruption" with "clear, actionable error pointing at the workaround", so the ~20 users who hit this in #250 stop losing time to it.

Fixes #250

Made with [Cursor](https://cursor.com)