### PR TITLE
fix: parse pgvector string to Float32Array in hybrid search cosine re-score

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -275,7 +275,8 @@ export class PostgresEngine implements BrainEngine {
     `;
     const result = new Map<number, Float32Array>();
     for (const row of rows) {
-      if (row.embedding) result.set(row.id as number, row.embedding as Float32Array);
+      const parsed = parseEmbedding(row.embedding);
+      if (parsed) result.set(row.id as number, parsed);
     }
     return result;
   }
@@ -710,4 +711,26 @@ export class PostgresEngine implements BrainEngine {
     `;
     return rows.map((r: Record<string, unknown>) => rowToChunk(r, true));
   }
+}
+
+/**
+ * Parse an embedding value from any runtime shape into a Float32Array.
+ * postgres (Porsager) returns pgvector columns as strings ("[0.1,0.2,...]")
+ * by default — no custom type parser is registered. The previous code cast
+ * directly as Float32Array, which is a compile-time no-op and caused NaN
+ * scores downstream in cosine similarity.
+ */
+function parseEmbedding(raw: unknown): Float32Array | null {
+  if (!raw) return null;
+  if (raw instanceof Float32Array) return raw;
+  if (Array.isArray(raw)) return new Float32Array(raw);
+  if (typeof raw === 'string') {
+    const clean = raw.trim().replace(/^\[|\]$/g, '');
+    if (!clean) return null;
+    const parts = clean.split(',');
+    const arr = new Float32Array(parts.length);
+    for (let i = 0; i < parts.length; i++) arr[i] = parseFloat(parts[i]);
+    return arr;
+  }
+  return null;
 }

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -204,11 +204,14 @@ async function cosineReScore(
 
 export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
   let dot = 0, magA = 0, magB = 0;
-  for (let i = 0; i < a.length; i++) {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
     dot += a[i] * b[i];
     magA += a[i] * a[i];
     magB += b[i] * b[i];
   }
   const denom = Math.sqrt(magA) * Math.sqrt(magB);
-  return denom === 0 ? 0 : dot / denom;
+  if (!Number.isFinite(denom) || denom === 0) return 0;
+  const result = dot / denom;
+  return Number.isFinite(result) ? result : 0;
 }


### PR DESCRIPTION
## TL;DR

On a Supabase + pgvector brain, every `gbrain query` returns `[NaN]` as the relevance score, and semantically relevant chunks are not ranked correctly. Root cause: `row.embedding` from the `postgres` client is a **string**, not a `Float32Array`. The existing cast is compile-time only. Downstream cosine similarity returns `NaN`, poisoning the blended score.

One patch fixes both the display issue and the ranking regression.

## Reproduction

1. `gbrain init --supabase` (or migrate a PGLite brain to Supabase)
2. Import a corpus with enough content to exercise vector search (I used 5 ML textbooks — ~2,900 chunks)
3. Run any hybrid query:

   ```
   $ gbrain query "EM algorithm Gaussian mixture model"
   [NaN] murphy-probabilistic-perspective -- ...
   [NaN] bishop-prml -- ...
   [NaN] ...
   ```

   Scores should be in `[0,1]`; instead they're all `NaN`.

4. The ranking is also broken: queries that have a near-exact chunk match (e.g. Murphy's §11.4.2 "EM for GMMs" for the query above) don't surface that chunk at rank 1.

## Root cause

In `src/core/postgres-engine.ts`, `getEmbeddingsByChunkIds` does:

```ts
for (const row of rows) {
  if (row.embedding) result.set(row.id as number, row.embedding as Float32Array);
}
```

But `postgres` (Porsager's client) has no registered type parser for `pgvector`, so `row.embedding` comes back as a **string** like `"[0.1,0.2,...,0.5]"`. The `as Float32Array` cast is a TypeScript compile-time assertion and does nothing at runtime.

Downstream, `cosineSimilarity` in `src/core/search/hybrid.ts` iterates `a.length` expecting a typed array. When `a` is a string:
- `a.length` is the character count (~12k for a 1536-dim vector)
- `a[i]` is a single character (`"["`, `","`, `"0"`, ...)
- `a[i] * b[i]` = `"[" * 0.1` = `NaN`
- `NaN` propagates through `dot`, `magA`, `magB`, `denom`
- The `denom === 0` guard is false for `NaN` (NaN !== 0)
- Function returns `NaN`

In `cosineReScore`, `blended = 0.7 * normRrf + 0.3 * cosine` becomes `NaN`. The CLI displays `NaN.toFixed(4) === "NaN"`. Ranking degenerates because all chunks get the same `NaN` score and `.sort((a,b) => b.score - a.score)` becomes order-dependent on input order.

## Fix

Two small changes:

1. **`postgres-engine.ts`**: add a `parseEmbedding()` helper that accepts the three runtime shapes (`Float32Array` pass-through, `number[]` wrap, pgvector-string parse) and returns a `Float32Array | null`. Use it in `getEmbeddingsByChunkIds` instead of the unsafe cast.

2. **`hybrid.ts`**: harden `cosineSimilarity` with `Number.isFinite` guards and bound the loop by `Math.min(a.length, b.length)` — defense in depth against future malformed embeddings (e.g. dimension drift).

Diff: +29 / -3 lines across 2 files. No API changes.

## Verification

Same corpus, same query, after the patch:

```
$ gbrain query "EM algorithm Gaussian mixture model"
[0.9091] bishop-prml -- We first of all use the Gaussian mixture distribution to motivate the EM...
[0.8973] bishop-prml -- See the text for details. and the M step, for reasons that will become apparent...
[0.8730] murphy-probabilistic-perspective -- 11.4.2 EM for GMMs In this section, we discuss how to fit a mixture...
```

Scores are real floats in `[0,1]`; the canonical chunk (Murphy §11.4.2) appears in the top 3 where it belongs.

Additional smoke test on unrelated queries:

```
$ gbrain query "variational autoencoder ELBO reparametrization"
[0.9065] murphy-probabilistic-advanced -- ...we can use the inference network to compute an approximate posterior...

$ gbrain query "Bayesian posterior mean variance conjugate prior"
[0.8953] murphy-probabilistic-advanced -- ...
[0.8704] bishop-prml -- the Bayesian paradigm leads very naturally to a sequential view...
```

## Alternatives considered

- **Register a pgvector type parser with postgres client** (`postgres({ types: { vector: ... } })`). Cleaner in theory, but requires knowing the pgvector OID at connect time and has wider surface area. Parsing per-row in `parseEmbedding` is more defensive and keeps the fix local to the one call-site that needed it. Happy to switch to the type-parser approach if preferred.
- **Test PGLite path**: I only have a Supabase deployment to verify against. The `PGLiteEngine.getEmbeddingsByChunkIds` may or may not have the same issue depending on how `@electric-sql/pglite` exposes vector columns — worth a look.

## Related

- The same bug likely explains any silent ranking regression reported by users who moved from PGLite to Postgres/Supabase.
- No issue was open for this that I could find (searched for "NaN", "score", "cosine"); happy to open one if preferred.
