### PR TITLE
chore(search): harden cosineSimilarity against malformed embedding pairs

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -254,11 +254,14 @@ async function cosineReScore(
 
 export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
   let dot = 0, magA = 0, magB = 0;
-  for (let i = 0; i < a.length; i++) {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
     dot += a[i] * b[i];
     magA += a[i] * a[i];
     magB += b[i] * b[i];
   }
   const denom = Math.sqrt(magA) * Math.sqrt(magB);
-  return denom === 0 ? 0 : dot / denom;
+  if (!Number.isFinite(denom) || denom === 0) return 0;
+  const result = dot / denom;
+  return Number.isFinite(result) ? result : 0;
 }

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -150,6 +150,27 @@ describe('cosineSimilarity', () => {
     b[5] = 1.0;
     expect(cosineSimilarity(a, b)).toBe(0);
   });
+
+  test('dimension mismatch returns finite similarity over shared prefix', () => {
+    const a = new Float32Array([1, 2, 3]);
+    const b = new Float32Array([1, 2]);
+    expect(cosineSimilarity(a, b)).toBeCloseTo(1.0, 5);
+    expect(cosineSimilarity(b, a)).toBeCloseTo(1.0, 5);
+  });
+
+  test('non-finite denominator from huge vectors returns 0', () => {
+    const huge = new Float32Array([1e39, 1e39, 1e39]);
+    const v = new Float32Array([1, 1, 1]);
+    expect(cosineSimilarity(huge, v)).toBe(0);
+    expect(cosineSimilarity(v, huge)).toBe(0);
+  });
+
+  test('NaN element in input returns 0 (not NaN)', () => {
+    const withNaN = new Float32Array([1, NaN, 3]);
+    const v = new Float32Array([1, 2, 3]);
+    expect(cosineSimilarity(withNaN, v)).toBe(0);
+    expect(cosineSimilarity(v, withNaN)).toBe(0);
+  });
 });
 
 describe('CJK word count in expansion', () => {


### PR DESCRIPTION
## Context

`parseEmbedding` (landed in #196, v0.12.1) guarantees a valid `Float32Array` for the happy path of vector search on a Supabase / pgvector brain. That solved the live `[NaN]` score bug.

`cosineSimilarity` is still a public export that can be called with data from other sources: future embedding models at different dimensions, direct callers from user code, test fixtures. None of those go through `parseEmbedding`. So the function itself is worth hardening.

## Change

Purely defensive. Five lines added, two changed. No API change. No behavior change on valid finite dim-matched vectors — same scores.

```ts
export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
  let dot = 0, magA = 0, magB = 0;
  const len = Math.min(a.length, b.length);       // NEW: dim-mismatch safe
  for (let i = 0; i < len; i++) {
    dot += a[i] * b[i];
    magA += a[i] * a[i];
    magB += b[i] * b[i];
  }
  const denom = Math.sqrt(magA) * Math.sqrt(magB);
  if (!Number.isFinite(denom) || denom === 0) return 0;  // NEW: Infinity/NaN safe
  const result = dot / denom;
  return Number.isFinite(result) ? result : 0;           // NEW: belt & suspenders
}
```

## Three failure modes this prevents

1. **Dimension mismatch.** If `b.length < a.length` (caller passes a 768-dim vector to a brain storing 1536-dim), the old loop ran past `b`'s end, multiplying `undefined * undefined = NaN`, which poisoned `magB` and the return value. Now the loop runs over the common prefix and returns a finite similarity over the shared dimensions.

2. **Non-finite denominator from huge vectors.** If either vector has values large enough that squared sums overflow to `Infinity`, `sqrt(Infinity) * sqrt(Infinity) = Infinity`. The old `denom === 0` guard misses that (`Infinity !== 0`), and `dot / Infinity` silently returns `0` or `NaN` depending on `dot`. The explicit `Number.isFinite(denom)` check is clear and fast.

3. **Non-finite final result.** Belt-and-suspenders check on `dot / denom`. Since `cosineSimilarity`'s output feeds directly into the blended score `0.7 * rrf + 0.3 * cosine`, a single `NaN` propagates through every downstream result the same way #196 fixed at the data-ingest boundary. Better to catch it here too.

## Why this is separate from #196

Minimum blast radius. #196 was a bug fix (wrong data shape from the wire). This is defensive coding around a pure function that downstream consumers may call with arbitrary inputs. Different rationale, different reviewer mental model, so a narrow PR keeps the signal tight.

## Testing

No new tests needed — existing `cosineSimilarity` tests pass unchanged (same scores for valid inputs). Happy to add a dim-mismatch unit test if the maintainer wants it; it's a single `expect(cosineSimilarity(new Float32Array([1,2,3]), new Float32Array([1,2]))).toBeCloseTo(...)` case.

## Related

This was discovered while debugging the v0.10.0 `[NaN]` bug on a local install that hadn't picked up #196 yet. Once I pulled the latest upstream and saw parseEmbedding was already in, I kept only the cosine-hardening half as a separate narrow PR. Credit to @leonardsellem for the original fix in #175 / merged #196.

Closing my earlier duplicate PR #292 in favor of this.
