### PR TITLE
fix: preserve canonical pages during sync and honor config API key

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -118,18 +118,11 @@ export async function performSync(engine: BrainEngine, opts: SyncOpts): Promise<
     renamed: manifest.renamed.filter(r => isSyncable(r.to)),
   };
 
-  // Delete pages that became un-syncable (modified but filtered out)
-  const unsyncableModified = manifest.modified.filter(p => !isSyncable(p));
-  for (const path of unsyncableModified) {
-    const slug = pathToSlug(path);
-    try {
-      const existing = await engine.getPage(slug);
-      if (existing) {
-        await engine.deletePage(slug);
-        console.log(`  Deleted un-syncable page: ${slug}`);
-      }
-    } catch { /* ignore */ }
-  }
+  // Intentionally do NOT delete modified files that are now filtered out.
+  // Files like index.md/log.md/README.md may be excluded from git sync on purpose
+  // while still being canonical pages that are managed separately via put/extract.
+  // Auto-deleting them here causes data loss and graph breakage during otherwise
+  // healthy syncs. Only explicit deletes/renames should remove pages.
 
   const totalChanges = filtered.added.length + filtered.modified.length +
     filtered.deleted.length + filtered.renamed.length;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -42,6 +42,11 @@ export function loadConfig(): GBrainConfig | null {
     ...(dbUrl ? { database_url: dbUrl } : {}),
     ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
   };
+
+  if (!process.env.OPENAI_API_KEY && merged.openai_api_key) {
+    process.env.OPENAI_API_KEY = merged.openai_api_key;
+  }
+
   return merged as GBrainConfig;
 }
 

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -8,6 +8,7 @@
  */
 
 import OpenAI from 'openai';
+import { loadConfig } from './config.ts';
 
 const MODEL = 'text-embedding-3-large';
 const DIMENSIONS = 1536;
@@ -21,7 +22,11 @@ let client: OpenAI | null = null;
 
 function getClient(): OpenAI {
   if (!client) {
-    client = new OpenAI();
+    const apiKey = process.env.OPENAI_API_KEY || loadConfig()?.openai_api_key;
+    if (!apiKey) {
+      throw new Error('The OPENAI_API_KEY environment variable is missing or empty; either provide it, or set openai_api_key in ~/.gbrain/config.json.');
+    }
+    client = new OpenAI({ apiKey });
   }
   return client;
 }

--- a/test/e2e/sync.test.ts
+++ b/test/e2e/sync.test.ts
@@ -253,6 +253,45 @@ describeE2E('E2E: Git-to-DB Sync Pipeline', () => {
     expect(ops).toBeNull();
   });
 
+  test('modified non-syncable canonical pages are preserved and not auto-deleted', async () => {
+    const { performSync } = await import('../../src/commands/sync.ts');
+    const engine = getEngine();
+
+    // Seed index as an intentionally canonical page managed outside git sync.
+    await engine.putPage('index', {
+      type: 'concept',
+      title: 'Index',
+      compiled_truth: '# Index\n\nCanonical hub page.',
+      timeline: '',
+      frontmatter: {},
+      tags: [],
+      content_hash: 'seed-index',
+    } as any);
+
+    // Modify index.md in the repo. It remains non-syncable by design.
+    writeFileSync(join(repoPath, 'index.md'), [
+      '---',
+      'title: Index',
+      '---',
+      '',
+      '# Index',
+      '',
+      'Updated canonical hub content.',
+    ].join('\n'));
+    gitCommit(repoPath, 'modify index');
+
+    const result = await performSync(engine, {
+      repoPath,
+      noPull: true,
+      noEmbed: true,
+    });
+
+    expect(result.status).toBe('up_to_date');
+    const index = await engine.getPage('index');
+    expect(index).not.toBeNull();
+    expect(index!.title).toBe('Index');
+  });
+
   test('sync stores last_commit and last_run in config', async () => {
     const engine = getEngine();
 


### PR DESCRIPTION
## Summary\n- preserve modified non-syncable canonical pages like index/log during sync instead of deleting them\n- load the embedding API key from gbrain config when the environment variable is absent\n- add an e2e regression test covering canonical-page preservation\n\n## Validation\n- unit tests passed locally\n- e2e sync regression test passed locally\n- verified the patched installed CLI repaired the live shared brain workflow