### PR TITLE
fix(migration): v0.13.0 bun init scaffolds into user cwd on `bun link` installs

### DIFF
--- a/src/commands/migrations/v0_13_0.ts
+++ b/src/commands/migrations/v0_13_0.ts
@@ -38,10 +38,26 @@ import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhase
 // links (v0.12.1 pattern — migrations can time out on the 60s default).
 // Use the CURRENTLY-RUNNING binary path (not `gbrain` off $PATH). After
 // `gbrain upgrade` rewrites the binary, a bare `gbrain` could resolve to
-// an older installed copy via alias shadowing or stale PATH cache. The
-// active process.execPath is the one that loaded THIS migration module,
-// so recursing into it is always the right binary.
-const GBRAIN = process.execPath;
+// an older installed copy via alias shadowing or stale PATH cache.
+//
+// `process.execPath` alone is wrong for `bun link` dev installs: there,
+// execPath is `/path/to/bun` (the runtime), not the gbrain CLI — and
+// invoking `bun extract ...` makes Bun treat `extract` as an unknown
+// subcommand and fall through to `bun init`, which SCAFFOLDS A NEW
+// PROJECT in cwd (creates CLAUDE.md, README.md, tsconfig.json, index.ts,
+// .cursor/). That will OVERWRITE user files in whatever cwd this runs
+// from. Seen in the wild: v0.13.0 wedged migration on a `bun link`
+// install scaffolded bun boilerplate into ~/.hermes/.
+//
+// Correct invocation for both topologies:
+//   compiled binary: argv = [/path/to/gbrain, ...userArgs]
+//                    → `${argv[0]} extract ...`
+//   bun link dev:    argv = [/path/to/bun, /path/to/src/cli.ts, ...userArgs]
+//                    → `${argv[0]} ${argv[1]} extract ...`
+const _scriptPath = process.argv[1];
+const GBRAIN = _scriptPath && _scriptPath.endsWith('.ts')
+  ? `${process.execPath} ${_scriptPath}`  // dev: bun + cli.ts
+  : process.execPath;                      // compiled gbrain binary
 
 function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'schema', status: 'skipped', detail: 'dry-run' };


### PR DESCRIPTION
## Summary

The v0.13.0 migration orchestrator uses `process.execPath` to re-invoke gbrain as a subprocess. On compiled gbrain binaries (`bun build --compile`), `execPath` **is** the gbrain binary and this works. On `bun link`-style dev installs, `execPath` is the Bun runtime (`/path/to/bun`), not gbrain. Invoking `bun extract links --source db --include-frontmatter` makes Bun treat `extract` as an unknown subcommand and fall through to **`bun init`** — Bun's blank-project scaffolder — which:

1. Writes `CLAUDE.md`, `README.md`, `index.ts`, `tsconfig.json` to the current working directory
2. Creates a `.cursor/rules/` directory with a symlinked mdc file back to CLAUDE.md
3. **Overwrites any existing files with those names**

Because `stdio: 'inherit'` passes through, the migration's `execSync` feeds interactive prompt defaults straight into `bun init`'s TTY questions (template selection, package.json init, dependency install). It completes silently from the orchestrator's perspective, then fails at `bun init`'s "Script not found 'extract'" error. The wedged-migration retry loop scaffolds the same files 3× before the 3-partial cap (v0.14.2) finally blocks further attempts.

## Reproduction

1. Install gbrain via `bun link` (from a local checkout) instead of the compiled binary
2. Create a v0.13.0-pending brain (any brain that predates the frontmatter graph migration)
3. `cd ~/some-directory-with-a-CLAUDE.md`
4. Run `gbrain apply-migrations --yes`
5. Observe `~/some-directory-with-a-CLAUDE.md` gets **overwritten** with Bun scaffold content

**Actual impact seen in the field:** on a `bun link` install with cwd=`~/.hermes/` (the Hermes Agent config directory), the wedged migration ran 3 times and clobbered `~/.hermes/CLAUDE.md` and `~/.hermes/README.md`, plus created stray `index.ts`, `tsconfig.json`, `.cursor/` entries. Content loss recoverable only via backup (APFS `kMDItemContentCreationDate` confirms overwrite vs. create).

## Fix

Reconstruct the original invocation from `process.argv[0]` + `process.argv[1]` instead of `process.execPath`:

```ts
const _scriptPath = process.argv[1];
const GBRAIN = _scriptPath && _scriptPath.endsWith('.ts')
  ? `${process.execPath} ${_scriptPath}`  // bun link dev: "bun /path/to/cli.ts"
  : process.execPath;                      // compiled: "/path/to/gbrain"
```

Works for both topologies:
- **Compiled binary** — `argv = [gbrain, ...userArgs]` → unchanged behavior
- **`bun link` dev** — `argv = [bun, /path/to/src/cli.ts, ...userArgs]` → correct

## Test plan

- [x] Verified on local `bun link` install: migration now completes (v13→v15 applied, schema up to date)
- [x] No regression on extract phase: `Done: 0 links, 0 timeline entries from 13 pages` returned cleanly from the subprocess
- [x] Brain doctor: health 45 → 85, schema_version OK, minions_migration OK
- [x] Minions smoke test: PASS in 0.53s

## Why this only hit dev installs

Upstream CI and the shipped installer run the compiled binary, where `process.execPath` = gbrain. The bug is invisible there. Anyone running from a `bun link`'d source checkout (contributors, forks, local mods like the 8 community PRs around embedding providers) hits it the moment they try to apply v0.13.0.

## Defensive suggestion (not in this PR)

Even with this fix, `execSync(..., { stdio: 'inherit' })` on any subprocess that might fall through to `bun init` is a footgun. Consider adding `cwd: os.tmpdir()` to migration subprocess invocations as defense in depth — if a future migration ever misroutes again, scaffolded junk lands in `/tmp` instead of user directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)