### PR TITLE
fix(test): increase timeout for v0_14_0 migration dedup test

### DIFF
--- a/test/migrations-v0_14_0.test.ts
+++ b/test/migrations-v0_14_0.test.ts
@@ -77,7 +77,7 @@ describe('Bug 5 — Phase B host-work entry dedup', () => {
     const entry = JSON.parse(readFileSync(hostPath, 'utf-8').split('\n')[0]);
     expect(entry.migration).toBe('0.14.0');
     expect(entry.skill).toBe('skills/migrations/v0.14.0.md');
-  });
+  }, 30_000);
 
   test('dry-run writes nothing', async () => {
     const { v0_14_0 } = await import('../src/commands/migrations/v0_14_0.ts');


### PR DESCRIPTION
## Summary

The 'Phase B host-work entry dedup' test in `test/migrations-v0_14_0.test.ts` runs `v0_14_0.orchestrator()` twice, which deterministically exceeds bun's default 5000ms timeout on some hardware (reported as 5001ms failures in 5/5 runs).

Adds an explicit 30s timeout to this test case.

Fixes #298

This contribution was developed with AI assistance (Claude Code).