### PR TITLE
fix(sync): honor dry_run flag in performFullSync

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -366,6 +366,18 @@ async function performFullSync(
   headCommit: string,
   opts: SyncOpts,
 ): Promise<SyncResult> {
+  if (opts.dryRun) {
+    console.log(`Sync dry run: full import of ${repoPath} (first sync)`);
+    return {
+      status: 'dry_run',
+      fromCommit: null,
+      toCommit: headCommit,
+      added: 0, modified: 0, deleted: 0, renamed: 0,
+      chunksCreated: 0,
+      pagesAffected: [],
+    };
+  }
+
   console.log(`Running full import of ${repoPath}...`);
   const { runImport } = await import('./import.ts');
   const importArgs = [repoPath];


### PR DESCRIPTION
## Summary

`performFullSync` (first-sync / force-full paths) did not check `opts.dryRun`, so `sync_brain` with `dry_run: true` on a first sync still wrote pages. The incremental sync path correctly returned a `dry_run` status result, but the full sync path skipped the check entirely.

Adds an early return matching the incremental path pattern (line 152-170) when `opts.dryRun` is true.

Fixes #140

This contribution was developed with AI assistance (Claude Code).