### PR TITLE
feat(check-update): detect source-linked installs via git

### DIFF
--- a/src/commands/check-update.ts
+++ b/src/commands/check-update.ts
@@ -1,9 +1,12 @@
 import { VERSION } from '../version.ts';
 import { detectInstallMethod } from './upgrade.ts';
+import { execSync } from 'child_process';
+import { realpathSync, existsSync } from 'fs';
+import { dirname, join } from 'path';
 
 interface CheckUpdateResult {
   current_version: string;
-  current_source: 'package-json';
+  current_source: 'package-json' | 'source';
   latest_version: string;
   update_available: boolean;
   upgrade_command: string;
@@ -36,7 +39,32 @@ function upgradeCommandForMethod(method: string): string {
     case 'bun': return 'bun update gbrain';
     case 'clawhub': return 'clawhub update gbrain';
     case 'binary': return 'Download from https://github.com/garrytan/gbrain/releases';
+    case 'source': return 'git pull origin master';
     default: return 'gbrain upgrade';
+  }
+}
+
+function checkSourceUpdate(): { ahead: number; commits: string[] } | null {
+  try {
+    const arg1 = process.argv[1] ?? '';
+    let dir = dirname(realpathSync(arg1));
+    let gitDir = '';
+    for (let i = 0; i < 5; i++) {
+      if (existsSync(join(dir, '.git'))) { gitDir = dir; break; }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+    if (!gitDir) return null;
+    execSync('git fetch origin', { cwd: gitDir, stdio: 'pipe', timeout: 15_000 });
+    const log = execSync('git log HEAD..origin/master --oneline', {
+      cwd: gitDir, encoding: 'utf-8', timeout: 5_000,
+    }).trim();
+    if (!log) return { ahead: 0, commits: [] };
+    const commits = log.split('\n').filter(l => l.trim());
+    return { ahead: commits.length, commits };
+  } catch {
+    return null;
   }
 }
 
@@ -126,6 +154,47 @@ export async function runCheckUpdate(args: string[]) {
   const json = args.includes('--json');
   const method = detectInstallMethod();
   const upgradeCmd = upgradeCommandForMethod(method);
+
+  if (method === 'source') {
+    const sourceResult = checkSourceUpdate();
+    if (sourceResult && sourceResult.ahead > 0) {
+      if (json) {
+        console.log(JSON.stringify({
+          current_version: VERSION,
+          current_source: 'source',
+          latest_version: `${sourceResult.ahead} commit(s) behind origin/master`,
+          update_available: true,
+          upgrade_command: upgradeCmd,
+          release_url: 'https://github.com/garrytan/gbrain',
+          changelog_diff: sourceResult.commits.join('\n'),
+          published_at: '',
+        }, null, 2));
+      } else {
+        console.log(`GBrain ${VERSION} (source install) — ${sourceResult.ahead} commit(s) behind origin/master`);
+        for (const c of sourceResult.commits.slice(0, 5)) console.log(`  ${c}`);
+        if (sourceResult.commits.length > 5) console.log(`  ... and ${sourceResult.commits.length - 5} more`);
+        console.log(`Run: ${upgradeCmd}`);
+      }
+      return;
+    }
+    if (sourceResult) {
+      if (json) {
+        console.log(JSON.stringify({
+          current_version: VERSION,
+          current_source: 'source',
+          latest_version: VERSION,
+          update_available: false,
+          upgrade_command: upgradeCmd,
+          release_url: '',
+          changelog_diff: '',
+          published_at: '',
+        }, null, 2));
+      } else {
+        console.log(`GBrain ${VERSION} (source install) is up to date with origin/master.`);
+      }
+      return;
+    }
+  }
 
   const release = await fetchLatestRelease();
 

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -43,6 +43,23 @@ export async function runUpgrade(args: string[]) {
       }
       break;
 
+    case 'source':
+      console.log('Source install detected. Upgrading via git pull...');
+      try {
+        const arg1 = process.argv[1] ?? '';
+        let gitDir = dirname(realpathSync(arg1));
+        for (let i = 0; i < 5; i++) {
+          if (existsSync(join(gitDir, '.git'))) break;
+          gitDir = dirname(gitDir);
+        }
+        execSync('git pull origin master', { cwd: gitDir, stdio: 'inherit', timeout: 60_000 });
+        execSync('bun install', { cwd: gitDir, stdio: 'inherit', timeout: 120_000 });
+        upgraded = true;
+      } catch {
+        console.error('Source upgrade failed. Try manually: cd <repo> && git pull origin master && bun install');
+      }
+      break;
+
     default:
       console.error('Could not detect installation method.');
       console.log('Try one of:');

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
-import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync } from 'fs';
-import { join } from 'path';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, realpathSync } from 'fs';
+import { join, dirname } from 'path';
 import { VERSION } from '../version.ts';
 
 export async function runUpgrade(args: string[]) {
@@ -234,7 +234,7 @@ function isNewerThan(version: string, baseline: string): boolean {
   return false;
 }
 
-export function detectInstallMethod(): 'bun' | 'binary' | 'clawhub' | 'unknown' {
+export function detectInstallMethod(): 'bun' | 'binary' | 'clawhub' | 'source' | 'unknown' {
   const execPath = process.execPath || '';
 
   // Check if running from node_modules (bun/npm install)
@@ -254,6 +254,20 @@ export function detectInstallMethod(): 'bun' | 'binary' | 'clawhub' | 'unknown' 
   } catch {
     // not available
   }
+
+  // Check if running from a git checkout (source-linked install)
+  try {
+    const arg1 = process.argv[1] ?? '';
+    if (arg1) {
+      let dir = dirname(realpathSync(arg1));
+      for (let i = 0; i < 5; i++) {
+        if (existsSync(join(dir, '.git'))) return 'source';
+        const parent = dirname(dir);
+        if (parent === dir) break;
+        dir = parent;
+      }
+    }
+  } catch { /* ignore */ }
 
   return 'unknown';
 }

--- a/test/check-update.test.ts
+++ b/test/check-update.test.ts
@@ -155,7 +155,7 @@ describe('check-update CLI', () => {
     expect(output).toHaveProperty('current_version');
     expect(output).toHaveProperty('update_available');
     expect(output).toHaveProperty('upgrade_command');
-    expect(output).toHaveProperty('current_source', 'package-json');
+    expect(['package-json', 'source']).toContain(output.current_source);
     expect(typeof output.update_available).toBe('boolean');
   });
 });


### PR DESCRIPTION
## Summary

- `detectInstallMethod()` now returns `'source'` for git checkout installs by walking up from the script location looking for a `.git` directory
- `check-update` uses `git fetch origin` + `git log HEAD..origin/master --oneline` for source installs instead of querying GitHub Releases (which returns `no_releases` / `error` for source users)
- `upgradeCommandForMethod('source')` returns `git pull origin master`
- Test updated to accept both `package-json` and `source` as valid `current_source` values (since CI also runs from a git checkout)

**Before:** source installs always see `update_available: false` with `error: "no_releases"`.
**After:** source installs see commit-level upstream comparison with actionable `git pull` command.

Fixes #302

This contribution was developed with AI assistance (Claude Code).