### PR TITLE
security: enable RLS on 9 tables missing from schema.sql DO block + budget migration

### DIFF
--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -394,6 +394,16 @@ export const MIGRATIONS: Migration[] = [
       );
       CREATE INDEX IF NOT EXISTS idx_budget_reservations_expires
         ON budget_reservations(expires_at) WHERE status = 'held';
+      -- Match the RLS-ON + no-policies + BYPASSRLS pattern from schema.sql.
+      -- Only enable if the current role has BYPASSRLS so we don't lock
+      -- anyone out who happens to run this as a non-postgres role.
+      DO $$
+      BEGIN
+        IF (SELECT rolbypassrls FROM pg_roles WHERE rolname = current_user) THEN
+          ALTER TABLE budget_ledger ENABLE ROW LEVEL SECURITY;
+          ALTER TABLE budget_reservations ENABLE ROW LEVEL SECURITY;
+        END IF;
+      END $$;
     `,
   },
   {

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -539,6 +539,7 @@ DECLARE
 BEGIN
   SELECT rolbypassrls INTO has_bypass FROM pg_roles WHERE rolname = current_user;
   IF has_bypass THEN
+    -- Core knowledge graph
     ALTER TABLE pages ENABLE ROW LEVEL SECURITY;
     ALTER TABLE content_chunks ENABLE ROW LEVEL SECURITY;
     ALTER TABLE links ENABLE ROW LEVEL SECURITY;
@@ -549,7 +550,18 @@ BEGIN
     ALTER TABLE ingest_log ENABLE ROW LEVEL SECURITY;
     ALTER TABLE config ENABLE ROW LEVEL SECURITY;
     ALTER TABLE files ENABLE ROW LEVEL SECURITY;
+    -- Auth + request logging
+    ALTER TABLE access_tokens ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE mcp_request_log ENABLE ROW LEVEL SECURITY;
+    -- Minion runtime
     ALTER TABLE minion_jobs ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE minion_inbox ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE minion_attachments ENABLE ROW LEVEL SECURITY;
+    -- Subagent runtime
+    ALTER TABLE subagent_messages ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE subagent_tool_executions ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE subagent_rate_leases ENABLE ROW LEVEL SECURITY;
+    -- Multi-source + file migration
     ALTER TABLE sources ENABLE ROW LEVEL SECURITY;
     ALTER TABLE file_migration_ledger ENABLE ROW LEVEL SECURITY;
     RAISE NOTICE 'RLS enabled on all tables (role % has BYPASSRLS)', current_user;


### PR DESCRIPTION
## Summary

Fixes the `rls_disabled_in_public` findings that Supabase's weekly Security
Advisor flags on every gbrain Postgres deployment.

`src/schema.sql`'s RLS-enable DO block (around L438-449 on master) enumerates
11 tables, but **7 more tables declared in the same file were never added to
the block**, and **2 tables created in `migrate.ts` version 12 (`budget_ledger`)
have no RLS hook at all**. With no RLS, the Supabase anon key can CRUD rows
in those tables. `access_tokens` is the sharp edge — anon read equals
credential disclosure.

The intended design (RLS ON + zero policies = anon blocked, internal
`postgres` role unaffected via `BYPASSRLS`) is already proven by the 11
tables that *are* listed. This PR just completes the enumeration and adds
the equivalent BYPASSRLS-guarded block to the budget migration.

## Tables covered

**`src/schema.sql` DO block — 7 added:**

- `access_tokens`, `mcp_request_log` (auth + logging)
- `minion_inbox`, `minion_attachments` (minion runtime)
- `subagent_messages`, `subagent_tool_executions`, `subagent_rate_leases` (subagent runtime, v0.16+)

**`src/core/migrate.ts` version 12 — 2 added (new DO block):**

- `budget_ledger`, `budget_reservations`

## Reproduction

1. Deploy gbrain v0.13.1 – v0.16.4 against a Supabase Postgres instance
   (transaction pooler).
2. Run `gbrain sync` (or anything that triggers schema bootstrap).
3. Supabase Dashboard → Advisors → Security → Errors shows:

   ```
   RLS Disabled in Public — public.access_tokens
   RLS Disabled in Public — public.mcp_request_log
   RLS Disabled in Public — public.minion_inbox
   RLS Disabled in Public — public.minion_attachments
   RLS Disabled in Public — public.budget_ledger
   RLS Disabled in Public — public.budget_reservations
   ```

   (On v0.16+, three more — `subagent_messages`, `subagent_tool_executions`,
   `subagent_rate_leases` — are also present in schema.sql but missing from
   the RLS block.)

## Verification

- Applied the patch to a staging Supabase project via `gbrain sync` against
  a fresh DB → Advisor reports 0 errors, 4 pre-existing warnings unchanged
  (all related to #171 and extension-in-public, orthogonal to this PR).
- `gbrain sync` runs unchanged — the internal role has `BYPASSRLS` so every
  query still goes through.
- For existing users already on earlier versions, the following one-shot SQL
  in the Supabase SQL Editor clears the Advisor immediately:

  ```sql
  ALTER TABLE public.access_tokens ENABLE ROW LEVEL SECURITY;
  ALTER TABLE public.mcp_request_log ENABLE ROW LEVEL SECURITY;
  ALTER TABLE public.minion_inbox ENABLE ROW LEVEL SECURITY;
  ALTER TABLE public.minion_attachments ENABLE ROW LEVEL SECURITY;
  ALTER TABLE public.budget_ledger ENABLE ROW LEVEL SECURITY;
  ALTER TABLE public.budget_reservations ENABLE ROW LEVEL SECURITY;
  -- v0.16+:
  ALTER TABLE public.subagent_messages ENABLE ROW LEVEL SECURITY;
  ALTER TABLE public.subagent_tool_executions ENABLE ROW LEVEL SECURITY;
  ALTER TABLE public.subagent_rate_leases ENABLE ROW LEVEL SECURITY;
  ```

## Test results

```
bun test — 2020 pass, 0 fail, 179 skip, 5173 expect() calls (118 files, 79.85s)
```

All 15 migrations (including modified v12) applied cleanly on PGLite. The
`DO $$ ... pg_roles ...` BYPASSRLS guard evaluates to false on PGLite (no
catalog role), so the RLS statements are skipped — matching expected behavior
since RLS is a Postgres-only concern.

E2E tests requiring `DATABASE_URL` were skipped (no Postgres container in
this run). The schema.sql changes are exercised on every `gbrain sync`
bootstrap against real Supabase, verified in the staging project above.

## Related

- `#171` — mutable `search_path` on `update_page_search_vector*` trigger
  functions (Supabase linter WARN). Different root cause, same Advisor
  dashboard. Not touched here.

## Follow-up (out of scope for this PR)

A small helper (`enableRlsIfBypass(tables: string[])`) that every migration
creating new tables is expected to call would prevent this class of bug
from recurring. Happy to follow up with a separate PR if that approach
works for the project.

