### PR TITLE
fix(doctor): check ALL public tables for RLS, upgrade to fail severity

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -276,22 +276,28 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
     // best-effort; never fail doctor on this check
   }
 
-  // 5. RLS
+  // 5. RLS — check ALL public tables, not just gbrain's own.
+  // Any table without RLS in the public schema is a security risk:
+  // Supabase exposes the public schema via PostgREST, so tables without
+  // RLS are readable/writable by anyone with the anon key.
   progress.heartbeat('rls');
   try {
     const sql = db.getConnection();
     const tables = await sql`
       SELECT tablename, rowsecurity FROM pg_tables
       WHERE schemaname = 'public'
-        AND tablename IN ('pages','content_chunks','links','tags','raw_data',
-                           'page_versions','timeline_entries','ingest_log','config','files')
     `;
     const noRls = tables.filter((t: any) => !t.rowsecurity);
     if (noRls.length === 0) {
-      checks.push({ name: 'rls', status: 'ok', message: 'RLS enabled on all tables' });
+      checks.push({ name: 'rls', status: 'ok', message: `RLS enabled on all ${tables.length} public tables` });
     } else {
       const names = noRls.map((t: any) => t.tablename).join(', ');
-      checks.push({ name: 'rls', status: 'warn', message: `RLS not enabled on: ${names}` });
+      checks.push({
+        name: 'rls',
+        status: 'fail',
+        message: `${noRls.length} table(s) WITHOUT Row Level Security: ${names}. `
+          + `Fix: ALTER TABLE public.<name> ENABLE ROW LEVEL SECURITY;`,
+      });
     }
   } catch {
     checks.push({ name: 'rls', status: 'warn', message: 'Could not check RLS status' });


### PR DESCRIPTION
## What

The `gbrain doctor` RLS check was hardcoded to only verify 10 gbrain-managed tables. Any other table in the `public` schema was invisible to the check.

## Why

12 tables existed without RLS for months — publicly readable by anyone with the Supabase anon key. Tables like `karma_network` (11K rows), `screenshot_jobs` (648 rows), and `subagent_tool_executions` (466 rows) were completely exposed.

The root cause: the check only looked at `pages, content_chunks, links, tags, raw_data, page_versions, timeline_entries, ingest_log, config, files`. Everything else was invisible.

## Changes

- Query **ALL** tables in `public` schema (`WHERE schemaname = 'public'`), not a hardcoded list
- Upgrade severity from `warn` to `fail` — missing RLS is a security issue, not a suggestion
- Include total table count in success message
- Include remediation SQL in failure message

## Context

Supabase exposes the `public` schema via PostgREST. Any table without RLS is readable/writable by the `anon` key by default. This is a platform design choice (opt-in security), which makes it critical that `gbrain doctor` catches ALL unprotected tables, not just the ones gbrain created.