### PR TITLE
fix(import): apply isSyncable() filter so import and sync walkers agree

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -7,6 +7,7 @@ import { importFile } from '../core/import-file.ts';
 import { loadConfig } from '../core/config.ts';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
+import { isSyncable } from '../core/sync.ts';
 
 function defaultWorkers(): number {
   const cpuCount = cpus().length;
@@ -296,6 +297,14 @@ export function collectMarkdownFiles(dir: string): string[] {
       if (stat.isDirectory()) {
         walk(full);
       } else if (entry.endsWith('.md') || entry.endsWith('.mdx')) {
+        // Apply the same filter `gbrain sync` uses so the two walkers can't
+        // disagree about what counts as a page. Without this, scaffolding
+        // files (README.md / index.md / log.md / schema.md) and ops/ paths
+        // leak into `gbrain import` even though `gbrain sync` correctly
+        // skips them, polluting the pages table with orphan scaffolding
+        // rows that drag brain_score's noOrphans factor down. See #345.
+        const relPath = relative(dir, full).replace(/\\/g, '/');
+        if (!isSyncable(relPath)) continue;
         files.push(full);
       }
     }

--- a/test/import-walker.test.ts
+++ b/test/import-walker.test.ts
@@ -87,3 +87,88 @@ describe('collectMarkdownFiles — symlink containment', () => {
     expect(files).not.toContain(join(root, 'dangling.md'));
   });
 });
+
+// These tests exercise the isSyncable() filter the import walker now applies
+// so it agrees with `gbrain sync` about what counts as a page. Before this
+// fix, `gbrain import` walked every .md/.mdx and let scaffolding files
+// (README.md, schema.md, index.md, log.md) plus ops/ paths through, even
+// though sync correctly skipped them. Those leaked rows had no inbound links
+// and dragged brain_score's noOrphans factor down. See issue #345.
+describe('collectMarkdownFiles — isSyncable filter parity', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'gbrain-walker-isSyncable-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test('skips directory README.md scaffolding files', () => {
+    mkdirSync(join(root, 'companies'));
+    mkdirSync(join(root, 'people'));
+    writeFileSync(join(root, 'companies', 'README.md'), '# Companies index\n');
+    writeFileSync(join(root, 'people', 'README.md'), '# People index\n');
+    writeFileSync(join(root, 'companies', 'acme.md'), '# Acme\n');
+    writeFileSync(join(root, 'people', 'alice.md'), '# Alice\n');
+
+    const files = collectMarkdownFiles(root);
+    expect(files).toContain(join(root, 'companies', 'acme.md'));
+    expect(files).toContain(join(root, 'people', 'alice.md'));
+    expect(files).not.toContain(join(root, 'companies', 'README.md'));
+    expect(files).not.toContain(join(root, 'people', 'README.md'));
+  });
+
+  test('skips top-level scaffolding meta files', () => {
+    writeFileSync(join(root, 'README.md'), '# brain\n');
+    writeFileSync(join(root, 'schema.md'), '# schema\n');
+    writeFileSync(join(root, 'index.md'), '# index\n');
+    writeFileSync(join(root, 'log.md'), '# log\n');
+    writeFileSync(join(root, 'notes.md'), '# real page\n');
+
+    const files = collectMarkdownFiles(root);
+    expect(files).toContain(join(root, 'notes.md'));
+    expect(files).not.toContain(join(root, 'README.md'));
+    expect(files).not.toContain(join(root, 'schema.md'));
+    expect(files).not.toContain(join(root, 'index.md'));
+    expect(files).not.toContain(join(root, 'log.md'));
+  });
+
+  test('skips ops/ directory contents', () => {
+    mkdirSync(join(root, 'ops'));
+    writeFileSync(join(root, 'ops', 'deploy-log.md'), '# deploy log\n');
+    writeFileSync(join(root, 'ops', 'config.md'), '# ops config\n');
+    writeFileSync(join(root, 'real.md'), '# real page\n');
+
+    const files = collectMarkdownFiles(root);
+    expect(files).toContain(join(root, 'real.md'));
+    expect(files).not.toContain(join(root, 'ops', 'deploy-log.md'));
+    expect(files).not.toContain(join(root, 'ops', 'config.md'));
+  });
+
+  test('skips .raw/ sidecar directory contents', () => {
+    mkdirSync(join(root, 'people'));
+    mkdirSync(join(root, 'people', 'alice.raw'));
+    writeFileSync(join(root, 'people', 'alice.raw', 'source.md'), '# source\n');
+    writeFileSync(join(root, 'people', 'alice.md'), '# Alice\n');
+
+    const files = collectMarkdownFiles(root);
+    expect(files).toContain(join(root, 'people', 'alice.md'));
+    expect(files).not.toContain(join(root, 'people', 'alice.raw', 'source.md'));
+  });
+
+  test('still includes legitimate nested .md and .mdx pages', () => {
+    mkdirSync(join(root, 'a'));
+    mkdirSync(join(root, 'a', 'b'));
+    mkdirSync(join(root, 'a', 'b', 'c'));
+    writeFileSync(join(root, 'a', 'b', 'c', 'deep.md'), '# deep\n');
+    writeFileSync(join(root, 'a', 'b', 'c', 'mdx-page.mdx'), '# mdx\n');
+    writeFileSync(join(root, 'flat.md'), '# flat\n');
+
+    const files = collectMarkdownFiles(root);
+    expect(files).toContain(join(root, 'flat.md'));
+    expect(files).toContain(join(root, 'a', 'b', 'c', 'deep.md'));
+    expect(files).toContain(join(root, 'a', 'b', 'c', 'mdx-page.mdx'));
+  });
+});


### PR DESCRIPTION
`gbrain sync` and `gbrain import` had separate file walkers that disagreed about what counts as a page. `isSyncable()` in `src/core/sync.ts` correctly excludes scaffolding files (README.md, schema.md, index.md, log.md), the `ops/` directory, and `.raw/` sidecar dirs, but `collectMarkdownFiles` in `src/commands/import.ts` walked every .md/.mdx without applying the filter.

Effect: every full import re-introduced directory READMEs as page records. Nothing links to them, `orphans.ts` counted them, and `brain_score`'s `noOrphans` factor dropped accordingly (~1 point per ~6 README orphans on a 109-page brain).

Fix: call `isSyncable(relativePath)` before pushing a file. Path is normalized to forward slashes first because `isSyncable()` checks `startsWith('ops/')` etc. and Node's `relative()` returns backslashes on Windows.

Tests: 5 new cases in `test/import-walker.test.ts` covering README skipping, top-level meta files, `ops/`, `.raw/`, plus a positive control for legitimate nested .md/.mdx pages. All pass locally.

Closes #345