### PR TITLE
fix(engine): getChunks no longer fetches the 6 KB embedding it discards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to GBrain will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **`getChunks` no longer fetches the 6 KB embedding column it throws away.** Both engines' `getChunks(slug)` did `SELECT cc.*`, which pulls the full pgvector embedding over the wire, and `rowToChunk(row, includeEmbedding=false)` discarded it client-side. On Supabase / managed Postgres, where network egress is billed, this was measurable: `pg_stat_statements` on one production brain showed this exact query at 10.6M calls / 29.9M rows returned, costing ~22 GB of wasted egress per day — effectively the entire MCP baseline for that user. Fix is an explicit column list that omits `cc.embedding`; callers needing the vector already use `getChunksWithEmbeddings`. New regression test in `pglite-engine.test.ts` asserts `getChunks` returns `embedding: null` even when a vector is stored. PGLite gets the same treatment for parity.
+
 ## [0.18.0] - 2026-04-22
 
 ## **Multi-source brains. One database, many repos. Federated or isolated, you choose.**

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -330,8 +330,12 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   async getChunks(slug: string): Promise<Chunk[]> {
+    // Explicit column list excludes cc.embedding. Matches postgres-engine.ts for
+    // parity and contract consistency; rowToChunk discards the column anyway.
     const { rows } = await this.db.query(
-      `SELECT cc.* FROM content_chunks cc
+      `SELECT cc.id, cc.page_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+              cc.model, cc.token_count, cc.embedded_at, cc.created_at
+       FROM content_chunks cc
        JOIN pages p ON p.id = cc.page_id
        WHERE p.slug = $1
        ORDER BY cc.chunk_index`,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -354,8 +354,13 @@ export class PostgresEngine implements BrainEngine {
 
   async getChunks(slug: string): Promise<Chunk[]> {
     const sql = this.sql;
+    // Explicit column list excludes cc.embedding (~6 KB pgvector per row). rowToChunk
+    // discards it anyway when includeEmbedding=false, so fetching it over the wire is
+    // pure network waste. Use getChunksWithEmbeddings when the vector is actually needed.
     const rows = await sql`
-      SELECT cc.* FROM content_chunks cc
+      SELECT cc.id, cc.page_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+             cc.model, cc.token_count, cc.embedded_at, cc.created_at
+      FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id
       WHERE p.slug = ${slug}
       ORDER BY cc.chunk_index

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -242,6 +242,24 @@ describe('PGLiteEngine: Chunks', () => {
     expect(chunks.length).toBe(1);
     expect(chunks[0].embedding).not.toBeNull();
   });
+
+  test('getChunks never returns embedding data (egress contract)', async () => {
+    // Regression guard: getChunks must NOT fetch the embedding column from the DB.
+    // On Supabase / managed Postgres, fetching pgvector-sized columns (~6 KB each)
+    // per MCP get_chunks call costs measurable egress. rowToChunk discards the
+    // value when includeEmbedding=false, so the SQL must select named columns
+    // (no cc.*) and skip cc.embedding. Callers needing the vector use
+    // getChunksWithEmbeddings.
+    await engine.putPage('test/no-embed', testPage);
+    const embedding = new Float32Array(1536).fill(0.5);
+    await engine.upsertChunks('test/no-embed', [
+      { chunk_index: 0, chunk_text: 'With embedding stored', chunk_source: 'compiled_truth', embedding },
+    ]);
+    const chunks = await engine.getChunks('test/no-embed');
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].embedding).toBeNull();
+    expect(chunks[0].chunk_text).toBe('With embedding stored');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `BrainEngine.getChunks(slug)` does `SELECT cc.*` in both `postgres-engine.ts` and `pglite-engine.ts`, which pulls the `embedding` column (pgvector, ~6 KB/row) over the wire
- `rowToChunk(row, includeEmbedding=false)` in `src/core/utils.ts` then discards the embedding client-side — so on Supabase / managed Postgres, every `get_chunks` MCP call pays for bytes that the JavaScript immediately throws away
- Fix is an explicit column list that omits `cc.embedding`. Callers that actually need the vector already route through `getChunksWithEmbeddings`, which is unchanged

## Real-world impact

On one production brain (31k pages, ~87k chunks, Supabase Pro), `pg_stat_statements` showed this exact query at the top of the board:

```
SELECT cc.* FROM content_chunks cc
JOIN pages p ON p.id = cc.page_id
WHERE p.slug = $1
ORDER BY cc.chunk_index
```

- **10,602,629 calls**
- **29,886,447 rows returned**
- avg 3 rows/call × ~7 KB/row (1.2 KB chunk_text + ~6 KB embedding) = **~21 KB egress/call**
- cumulative: **~222 GB over ~10 days ≈ 22 GB/day**

That's roughly the entire baseline MCP egress on that account — enough by itself to push a 250 GB Pro plan into overage territory on a personal-scale brain. No feature relies on this data; `rowToChunk` throws it away.

## Diff

Two-line change per engine (postgres + pglite for parity) to replace `SELECT cc.*` with the explicit column list. PGLite doesn't pay egress, but keeping the two engines in lockstep preserves the contract invariant that `getChunks` never touches `cc.embedding`.

## Test plan

- [x] New regression test in `test/pglite-engine.test.ts`: stores a chunk with a non-null `Float32Array(1536)` embedding, then asserts `getChunks` returns `embedding: null`. If anyone reintroduces `SELECT cc.*`, this fails.
- [x] `bun test test/pglite-engine.test.ts` → 86 pass / 0 fail
- [x] Existing `getChunksWithEmbeddings` test unchanged and still passes — confirms the vector-using path is not broken
- [ ] E2E against real Postgres — not run locally; happy to add coverage in `test/e2e/` if you'd prefer the assertion live against Postgres too

## Not touched

- `getChunksWithEmbeddings` — unchanged, still does `SELECT cc.*`, still returns the full vector. This is the intentional path for vector-search callers.
- `searchVector` / `searchKeyword` — independent code paths, not affected.
- Chunk row type contract — same shape, `embedding: null` case was already reachable via `includeEmbedding=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)