### PR TITLE
fix(config): resolve HOME at call time instead of module load

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -19,8 +19,14 @@ export type DbUrlSource =
   | 'config-file-path' // PGLite: config file present, no URL but database_path set
   | null;
 
-// Lazy-evaluated to avoid calling homedir() at module scope (breaks in serverless/bundled environments)
-function getConfigDir() { return join(homedir(), '.gbrain'); }
+// Resolve HOME at CALL time, not module-load time. Bun/Node cache os.homedir()
+// on first call and ignore later HOME mutations, which breaks test isolation
+// (tests set process.env.HOME = tmpdir in beforeEach but homedir() is already
+// frozen, so loadConfig() reads the real ~/.gbrain/config.json and
+// createEngine().connect() hits prod). Prefer process.env.HOME when set.
+// Matches src/commands/migrations/v0_14_0.ts:35 pattern.
+function resolveHome(): string { return process.env.HOME || homedir(); }
+function getConfigDir() { return join(resolveHome(), '.gbrain'); }
 function getConfigPath() { return join(getConfigDir(), 'config.json'); }
 
 export interface GBrainConfig {


### PR DESCRIPTION
## Context

Discovered while debugging a daily fork-merge automation that was rolling back on what looked like v0.18.0 test regressions. Root cause turned out to be this pre-existing test-harness bug, not anything v0.18.0 introduced - any developer running `bun test` on a machine with a populated `~/.gbrain/config.json` hits it.

Two other fixes came out of the same investigation wave and are filed separately so each can be reviewed on its own merits:
- #362 — migration v21 tries to drop `pages_slug_key` without handling the legacy `files_page_slug_fkey` dependency, blocking every existing brain's upgrade path
- #363 — orphan pgbouncer backends hold row locks for 24h+ when postgres.js disconnects mid-transaction; adds session-level timeouts on connect

## Summary

`src/core/config.ts` calls `homedir()` at module load time. Bun and Node both cache `os.homedir()` on first call, so tests that do `process.env.HOME = tmpHome` in `beforeEach` have no effect - `loadConfig()` keeps reading the real `~/.gbrain/config.json`.

The visible symptom is `test/migrations-v0_14_0.test.ts` timing out:

- `Bug 5 + Bug 8 — v0_14_0 module shape > orchestrator returns complete when phase A is skipped (no config)` hangs for 5000ms
- `Bug 5 — Phase B host-work entry dedup > first run writes the entry, second run is a skip` hangs for 5000ms

Both call `v0_14_0.orchestrator()`. The test sets `HOME=tmpHome` expecting Phase A to short-circuit on `loadConfig() === null`. Instead, `loadConfig()` reads the developer's real config (pointing at a live Postgres), `createEngine().connect()` blocks on the socket, and the test hits its timeout. Reproduces on any machine with a populated `~/.gbrain/config.json`.

The fix mirrors the `resolveHome()` pattern already used in `src/commands/migrations/v0_14_0.ts:35` and `src/core/preferences.ts`: prefer `process.env.HOME` when set, fall back to `homedir()`. No behavior change outside test contexts that mutate `HOME`.

## Verification

```
bun test test/migrations-v0_14_0.test.ts
# 8 pass, 0 fail, 24ms

bun test test/config.test.ts
# 8 pass, 0 fail, 17ms

bun test
# failure set is identical to running with an `HOME=/tmp/fake` wrapper -
# this fix replaces the wrapper, it does not mask or change any other tests.
```

## Test plan

- [x] `test/migrations-v0_14_0.test.ts` now passes without an `HOME=...` wrapper
- [x] `test/config.test.ts` unchanged
- [x] No regressions in full `bun test` suite (delta against pre-fix run is 0, i.e. the 17 remaining post-v0.18.0 failures on my local fork are all unrelated and present with or without this change)
- [ ] Run on a machine with no `~/.gbrain/config.json` to confirm the fallback path still works (expected to be identical behavior)
