### PR TITLE
fix(migrate): drop files_page_slug_fkey before pages_slug_key in v21 (closes #360)

### DIFF
--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -573,7 +573,31 @@ export const MIGRATIONS: Migration[] = [
     //
     // Idempotent: IF NOT EXISTS on ADD COLUMN, DROP IF EXISTS on the old
     // constraint, DO block guard on the new constraint creation.
+    //
+    // Pre-v0.17 schemas declared `files.page_slug TEXT REFERENCES pages(slug)
+    // ON UPDATE CASCADE ON DELETE SET NULL`. That FK implicitly depends on
+    // the UNIQUE constraint on `pages(slug)` (named `pages_slug_key` when the
+    // column was declared UNIQUE inline), so dropping the constraint below
+    // fails on every existing brain with:
+    //   ERROR: cannot drop constraint pages_slug_key on table pages because
+    //   other objects depend on it
+    //   DETAIL: constraint files_page_slug_fkey on table files depends on
+    //   index pages_slug_key
+    // `src/core/schema-embedded.ts` no longer declares the page_slug FK for
+    // new installs, but migration-path brains still carry it. Drop it first;
+    // migration 23 replaces the `page_slug`-based reference with a proper
+    // `files.page_id INTEGER REFERENCES pages(id)` column anyway.
     sql: `
+      -- Wrap in DO block with exception handler: PGLite has no 'files' table
+      -- (see schema notes), so a bare ALTER TABLE files ... would throw
+      -- 'relation "files" does not exist'. Catching undefined_table keeps
+      -- this migration safe to run on both engines.
+      DO $$ BEGIN
+        EXECUTE 'ALTER TABLE files DROP CONSTRAINT IF EXISTS files_page_slug_fkey';
+      EXCEPTION
+        WHEN undefined_table THEN NULL;
+      END $$;
+
       ALTER TABLE pages ADD COLUMN IF NOT EXISTS source_id TEXT
         NOT NULL DEFAULT 'default' REFERENCES sources(id) ON DELETE CASCADE;
 


### PR DESCRIPTION
## Summary

Migration 21 fails on every existing pre-v0.17 brain the moment `gbrain apply-migrations --yes` reaches it:

```
ERROR: cannot drop constraint pages_slug_key on table pages because other objects depend on it
DETAIL: constraint files_page_slug_fkey on table files depends on index pages_slug_key
```

Root cause: pre-v0.17 schemas declared `files.page_slug TEXT REFERENCES pages(slug) ON UPDATE CASCADE ON DELETE SET NULL`. That FK implicitly depends on the UNIQUE index backing `pages_slug_key`. Migration 21's `ALTER TABLE pages DROP CONSTRAINT IF EXISTS pages_slug_key` hits the dependency and aborts the transaction.

`src/core/schema-embedded.ts` already dropped this FK for new installs (noted in the comment block at the files table definition), but the migration path for existing brains never executed a `DROP CONSTRAINT` on the FK, so every upgrading brain hit this wall.

## Fix

Prepend an `ALTER TABLE files DROP CONSTRAINT IF EXISTS files_page_slug_fkey` to migration 21's SQL. Wrapped in a PL/pgSQL `EXCEPTION WHEN undefined_table` block so PGLite (which has no `files` table) doesn't throw on the missing relation.

The FK is replaced by a proper `files.page_id INTEGER REFERENCES pages(id)` column in migration 23, so dropping one migration earlier is clean - the referential link is reestablished by the time v23 lands.

## Verification

```bash
bun test test/migrate.test.ts
# 34 pass, 0 fail, 2.66s
```

Reproduced against Supabase Postgres 17, empty files table, ~15k pages:
- Before the fix: v21 aborts the migration chain with the error quoted above
- After the fix: v21 completes; 15,580 pages get `source_id='default'`, composite UNIQUE swap lands, migration 23 then adds `files.page_id` FK cleanly

## Test plan

- [x] Unit: migrate.test.ts still green (all 34 tests pass on PGLite)
- [x] Integration: manual apply against a real Postgres instance with the legacy FK present
- [ ] Reviewer: confirm no new installs are impacted (schema-embedded.ts doesn't declare the FK, so the DROP is a no-op for them)

Closes #360.