### PR TITLE
connected-gbrains PR 0 — minimal runtime (mounts, registry, aggregated RESOLVER)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,13 @@ start here.
 1. `./AGENTS.md` (this file) — install + operating protocol.
 2. [`./CLAUDE.md`](./CLAUDE.md) — architecture reference, key files, trust boundaries,
    test layout.
-3. [`./skills/RESOLVER.md`](./skills/RESOLVER.md) — skill dispatcher. Read before any task.
+3. [`./docs/architecture/brains-and-sources.md`](./docs/architecture/brains-and-sources.md)
+   — the two-axis mental model (brain = which DB, source = which repo in the DB). Every
+   query routes on both axes. Read before writing anything that touches brain ops.
+4. [`./skills/conventions/brain-routing.md`](./skills/conventions/brain-routing.md) —
+   agent-facing decision table: when to switch brain, when to switch source, how
+   cross-brain federation works (latent-space only; the agent decides).
+5. [`./skills/RESOLVER.md`](./skills/RESOLVER.md) — skill dispatcher. Read before any task.
 
 ## Trust boundary (critical)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,24 @@ suggests Supabase for 1000+ files. GStack teaches agents how to code. GBrain tea
 agents everything else: brain ops, signal detection, content ingestion, enrichment,
 cron scheduling, reports, identity, and access control.
 
+## Two organizational axes (read this first)
+
+GBrain knowledge is organized along two orthogonal axes. Users AND agents must
+understand both, or queries misroute silently.
+
+- **Brain** — WHICH DATABASE. Your personal brain is `host`. You can mount
+  additional brains (team-published, each with their own DB and access policy)
+  via `gbrain mounts add` (v0.19+). Routing: `--brain`, `GBRAIN_BRAIN_ID`,
+  `.gbrain-mount` dotfile.
+- **Source** — WHICH REPO INSIDE THE DATABASE. A brain can hold many sources
+  (wiki, gstack, openclaw, essays). Slugs scope per source. Routing:
+  `--source`, `GBRAIN_SOURCE`, `.gbrain-source` dotfile.
+
+Both axes follow the same 6-tier resolution pattern. Read
+`docs/architecture/brains-and-sources.md` for topology diagrams (personal, team
+mount, CEO-class with multiple team brains) and
+`skills/conventions/brain-routing.md` for the agent-facing decision table.
+
 ## Architecture
 
 Contract-first: `src/core/operations.ts` defines ~41 shared operations (adds `find_orphans` in v0.12.3). CLI and MCP

--- a/docs/architecture/brains-and-sources.md
+++ b/docs/architecture/brains-and-sources.md
@@ -1,0 +1,242 @@
+# Brains and Sources — the mental model
+
+GBrain has two orthogonal axes for organizing knowledge. Users and agents both
+need to understand both of them, or queries misroute silently.
+
+**TL;DR:**
+- A **brain** is a database. You can have many.
+- A **source** is a named repo of content *inside* a brain. One brain can hold many.
+- `--brain <id>` picks WHICH DATABASE.
+- `--source <id>` picks WHICH REPO WITHIN that database.
+- They're independent. You can target any combination.
+
+---
+
+## The two axes
+
+### Brains (the DB axis)
+
+A **brain** is one database — PGLite file, self-hosted Postgres, or Supabase.
+Each brain has:
+- Its own `pages` table, `chunks` table, `embeddings`, etc.
+- Its own OAuth surface if served over HTTP MCP (v0.19+, PR 2).
+- Its own separate lifecycle, backup, access control.
+
+Brains are enumerated by:
+- **host** — your default brain, configured in `~/.gbrain/config.json`.
+- **mounts** — additional brains registered in `~/.gbrain/mounts.json` via
+  `gbrain mounts add <id>` (v0.19+).
+
+Routing: `--brain <id>`, `GBRAIN_BRAIN_ID`, `.gbrain-mount` dotfile, or
+longest-path match against registered mount paths. Falls back to `host`.
+
+### Sources (the repo axis, v0.18.0+)
+
+A **source** is a named content repo *inside* one brain. Every `pages` row
+carries a `source_id`. Slugs are unique per source, not globally.
+
+Example: in one brain, the slug `topics/ai` can exist under `source=wiki`
+AND under `source=gstack` — they're different pages.
+
+Routing: `--source <id>`, `GBRAIN_SOURCE`, `.gbrain-source` dotfile, or
+registered `local_path` match in the `sources` table.
+
+### When does each axis move?
+
+| You want to | Adjust |
+|---|---|
+| Work in a different repo within the same brain (wiki → gstack notes) | `--source` |
+| Query a team-published brain that isn't yours | `--brain` |
+| Isolate a topic so it never leaks into personal search | `--source` with `federated=false` |
+| Share a brain with teammates | `--brain` (mount the team brain) |
+| Add a new repo to your personal brain | `--source` via `gbrain sources add` |
+| Add a team brain | `--brain` via `gbrain mounts add` |
+
+**Rule of thumb:** if the data owner changes, it's a brain boundary. If the
+data owner stays the same but the topic/repo changes, it's a source boundary.
+
+---
+
+## Topology: a single-person developer
+
+Simplest case. One brain, one source.
+
+```
+┌─────────────────────────────────────────┐
+│  host brain (~/.gbrain)                 │
+│  ├── source: default (federated=true)   │
+│  │   └── all pages                      │
+└─────────────────────────────────────────┘
+```
+
+`gbrain query "retry budgets"` finds everything. No `--brain`, no `--source`
+needed.
+
+---
+
+## Topology: a personal brain with multiple repos
+
+You maintain several codebases or writing streams. Each is its own source
+inside one brain. Cross-source search is on by default so a query about
+"caching" returns hits from every repo.
+
+```
+┌──────────────────────────────────────────────┐
+│  host brain (~/.gbrain)                      │
+│  ├── source: wiki      (federated=true)      │
+│  │   └── personal notes, people, companies   │
+│  ├── source: gstack    (federated=true)      │
+│  │   └── gstack plans, learnings             │
+│  ├── source: openclaw  (federated=true)      │
+│  │   └── openclaw docs, memos                │
+│  └── source: essays    (federated=false)     │
+│      └── draft essays, isolated on purpose   │
+└──────────────────────────────────────────────┘
+```
+
+Inside `~/openclaw/` the `.gbrain-source` dotfile pins every command to
+`source=openclaw`. Inside `~/gstack/` the dotfile pins to `source=gstack`.
+Everything still targets one DB.
+
+Use this topology when:
+- You own all the content.
+- You want cross-repo search to just work.
+- You don't need to share any of it with someone who isn't you.
+
+---
+
+## Topology: personal brain + one team brain
+
+You're on a team that publishes a shared brain. Your personal brain stays
+as-is; you mount the team brain alongside it.
+
+```
+┌──────────────────────────────────────────────┐
+│  host brain (~/.gbrain)  — YOUR personal DB  │
+│  ├── source: wiki                            │
+│  ├── source: gstack                          │
+│  └── ...                                     │
+└──────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────┐
+│  mount: media-team                           │
+│  path:   ~/team-brains/media                 │
+│  engine: postgres (team's Supabase)          │
+│  └── sources: wiki, raw, enriched            │
+└──────────────────────────────────────────────┘
+```
+
+`gbrain query "X"` (no flags) → runs against host (your personal brain).
+`gbrain query "X" --brain media-team` → runs against the team's DB.
+Inside `~/team-brains/media/` a `.gbrain-mount` dotfile pins brain to
+`media-team` automatically.
+
+Use this topology when:
+- You're on a team and someone publishes a brain the team subscribes to.
+- You need data isolation between work and personal.
+- Different teams/orgs own different brains.
+
+---
+
+## Topology: a CEO-class user with multiple team memberships
+
+You're senior enough to sit across multiple teams. You maintain your personal
+brain (with N sources inside) AND mount several work team brains. Each team
+brain is itself a multi-source brain in the v0.18.0 sense — organized
+internally however the team owner chose.
+
+```
+┌──────────────────────────────────────────────┐
+│  host brain — YOUR personal DB               │
+│  ├── source: wiki                            │
+│  ├── source: essays                          │
+│  ├── source: gstack                          │
+│  └── source: openclaw                        │
+└──────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────┐
+│  mount: media-team (your media team's brain) │
+│  └── sources: wiki, pipeline, enriched       │
+└──────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────┐
+│  mount: policy-team (your policy team's)     │
+│  └── sources: wiki, research, letters        │
+└──────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────┐
+│  mount: portfolio (another team's)           │
+│  └── sources: companies, deals, diligence    │
+└──────────────────────────────────────────────┘
+```
+
+Inside each team's checkout, a `.gbrain-mount` dotfile pins the brain. Inside
+a specific subdirectory, a `.gbrain-source` dotfile pins the source. So `cd
+~/team-brains/policy/research && gbrain query "X"` targets
+`brain=policy-team, source=research` with zero flags.
+
+Use this topology when:
+- You cross-cut multiple teams.
+- Each team owns its own brain with its own access policy.
+- You need latent-space federation (agent decides when to query across
+  brains), not SQL federation.
+
+Cross-brain queries are **not deterministic** in v0.19. The agent sees the
+brain list and re-queries as needed. That's the feature — it keeps debugging
+sane and access control clean.
+
+---
+
+## Resolution precedence (one page to remember)
+
+```
+WHICH BRAIN (DB)?                    WHICH SOURCE (repo in DB)?
+ 1. --brain <id>                      1. --source <id>
+ 2. GBRAIN_BRAIN_ID env               2. GBRAIN_SOURCE env
+ 3. .gbrain-mount dotfile             3. .gbrain-source dotfile
+ 4. longest-prefix mount path match   4. longest-prefix source path match
+ 5. (reserved: brains.default v2)     5. sources.default config
+ 6. fallback: 'host'                  6. fallback: 'default'
+```
+
+Both axes follow the same layered pattern on purpose. If you know one, you
+know the other.
+
+---
+
+## For agents reading this
+
+- Default assumption when the user asks a question: start in the current
+  brain (resolved via the precedence above). Don't jump brains without a
+  reason.
+- If the user asks a question that crosses topic areas a team might own
+  (e.g. "what did Team X decide last week?"), the right move is to *query
+  the team's brain explicitly* rather than searching host with "team x".
+- Cross-brain federation is YOUR JOB, not the DB's. You have the brain list
+  (`gbrain mounts list`). You decide when to fan out. You synthesize
+  findings. You cite `brain:source:slug`.
+- When writing a page, respect the brain boundary. A fact about a team's
+  work belongs in the team's brain, not in the user's personal brain. Ask
+  before writing cross-brain.
+- See `skills/conventions/brain-routing.md` for the full decision table.
+
+## For users reading this
+
+- **Default path:** set up your personal brain (`gbrain init`), add a source
+  per repo you care about (`gbrain sources add gstack --path ~/gstack`).
+  You'll almost never need `--brain`.
+- **When a team publishes a brain:** `gbrain mounts add <team-id> --path
+  <clone> --db-url <url>` and the `.gbrain-mount` dotfile in that checkout
+  routes queries there automatically.
+- **When you are the CEO-class user with multiple team memberships:** mount
+  each team brain. Trust the resolver — inside a team's directory the
+  dotfile picks the brain, inside a subdirectory the dotfile picks the
+  source. The flags are for when you want to query across the boundary
+  deliberately.
+
+## Further reading
+
+- v0.18.0 CHANGELOG — introduced `sources` primitive.
+- v0.19.0 CHANGELOG (TBD after PR 0+1+2 ship) — introduces `mounts`.
+- `docs/mounts/publishing-a-team-brain.md` (PR 2) — how to be the brain
+  publisher, not just the subscriber.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -31,7 +31,13 @@ start here.
 1. `./AGENTS.md` (this file) — install + operating protocol.
 2. [`./CLAUDE.md`](./CLAUDE.md) — architecture reference, key files, trust boundaries,
    test layout.
-3. [`./skills/RESOLVER.md`](./skills/RESOLVER.md) — skill dispatcher. Read before any task.
+3. [`./docs/architecture/brains-and-sources.md`](./docs/architecture/brains-and-sources.md)
+   — the two-axis mental model (brain = which DB, source = which repo in the DB). Every
+   query routes on both axes. Read before writing anything that touches brain ops.
+4. [`./skills/conventions/brain-routing.md`](./skills/conventions/brain-routing.md) —
+   agent-facing decision table: when to switch brain, when to switch source, how
+   cross-brain federation works (latent-space only; the agent decides).
+5. [`./skills/RESOLVER.md`](./skills/RESOLVER.md) — skill dispatcher. Read before any task.
 
 ## Trust boundary (critical)
 
@@ -85,6 +91,24 @@ engines: PGLite (embedded Postgres via WASM, zero-config default) or Postgres + 
 suggests Supabase for 1000+ files. GStack teaches agents how to code. GBrain teaches
 agents everything else: brain ops, signal detection, content ingestion, enrichment,
 cron scheduling, reports, identity, and access control.
+
+## Two organizational axes (read this first)
+
+GBrain knowledge is organized along two orthogonal axes. Users AND agents must
+understand both, or queries misroute silently.
+
+- **Brain** — WHICH DATABASE. Your personal brain is `host`. You can mount
+  additional brains (team-published, each with their own DB and access policy)
+  via `gbrain mounts add` (v0.19+). Routing: `--brain`, `GBRAIN_BRAIN_ID`,
+  `.gbrain-mount` dotfile.
+- **Source** — WHICH REPO INSIDE THE DATABASE. A brain can hold many sources
+  (wiki, gstack, openclaw, essays). Slugs scope per source. Routing:
+  `--source`, `GBRAIN_SOURCE`, `.gbrain-source` dotfile.
+
+Both axes follow the same 6-tier resolution pattern. Read
+`docs/architecture/brains-and-sources.md` for topology diagrams (personal, team
+mount, CEO-class with multiple team brains) and
+`skills/conventions/brain-routing.md` for the agent-facing decision table.
 
 ## Architecture
 
@@ -1112,6 +1136,7 @@ When multiple skills could match:
 These apply to ALL brain-writing skills:
 - `skills/conventions/quality.md` — citations, back-links, notability gate
 - `skills/conventions/brain-first.md` — check brain before external APIs
+- `skills/conventions/brain-routing.md` — which brain (DB) and which source (repo) to target; cross-brain federation is latent-space only
 - `skills/conventions/subagent-routing.md` — when to use Minions vs inline work
 - `skills/_brain-filing-rules.md` — where files go
 - `skills/_output-rules.md` — output quality standards

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:admin": "cd admin && bun run build",
     "build:schema": "bash scripts/build-schema.sh",
     "build:llms": "bun run scripts/build-llms.ts",
-    "test": "scripts/check-jsonb-pattern.sh && scripts/check-progress-to-stdout.sh && bun run typecheck && bun test",
+    "test": "scripts/check-jsonb-pattern.sh && scripts/check-progress-to-stdout.sh && scripts/check-no-legacy-getconnection.sh && bun run typecheck && bun test",
     "test:e2e": "bash scripts/run-e2e.sh",
     "typecheck": "tsc --noEmit",
     "check:jsonb": "scripts/check-jsonb-pattern.sh",

--- a/scripts/check-no-legacy-getconnection.sh
+++ b/scripts/check-no-legacy-getconnection.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# CI guard against silent singleton reuse in connected-gbrains code paths.
+#
+# Codex finding #7 (plan review 2026-04-22): the module singleton in
+# src/core/db.ts is shared across the process. With multi-brain routing,
+# any `db.getConnection()` call in an op-dispatch code path means that op
+# silently targets whichever brain connected to the singleton first,
+# regardless of ctx.brainId / ctx.engine. This is exactly the bug Codex
+# #1 flagged in postgres-engine.ts internals.
+#
+# This script fails the build when NEW `db.getConnection()` calls appear
+# in src/core/operations.ts (the per-op handler surface) or in any new
+# `src/commands/*.ts` file. Existing legitimate callers are grandfathered
+# via an explicit allowlist — cleanups land in PR 1.
+#
+# When you hit this guard: instead of `db.getConnection()` or `db.connect(...)`,
+# use `ctx.engine` from the passed-in OperationContext. See
+# src/core/brain-registry.ts for how ctx.engine gets populated per-call.
+#
+# Run manually:  bash scripts/check-no-legacy-getconnection.sh
+# Wired into CI: `bun test` (via package.json scripts.test)
+
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$ROOT"
+
+# Files that are allowed to touch the singleton today. Every other file
+# under src/core or src/commands is forbidden. This list shrinks in PR 1.
+ALLOWED=(
+  "src/core/db.ts"                      # the singleton's definition
+  "src/core/postgres-engine.ts"         # calls db.connect + fallback in sql getter — PR 1 removes the fallback
+  "src/commands/init.ts"                # first-time setup path, no engine yet
+  "src/commands/doctor.ts"              # PR 1 refactors to accept engine
+  "src/commands/files.ts"               # PR 1 refactors to accept engine
+  "src/commands/repair-jsonb.ts"        # PR 1 refactors
+  "src/commands/serve-http.ts"          # PR 1 threads engine through the OAuth dispatch path
+  "src/core/operations.ts"              # 3 localOnly ops (file_list/upload/url) move to ctx.engine in PR 1
+)
+
+# Build an argument list for `grep` that excludes allowed files.
+EXCLUDE_ARGS=()
+for file in "${ALLOWED[@]}"; do
+  EXCLUDE_ARGS+=(--exclude="$file")
+done
+
+# Search src/core/ and src/commands/ for db.getConnection or db.connect calls.
+# We look for the `db.` prefix so references to the symbol elsewhere (e.g.
+# the grep guard itself) don't trip the check.
+VIOLATIONS=$(
+  grep -rn "db\.\(getConnection\|connect\)(" \
+    --include="*.ts" \
+    "${EXCLUDE_ARGS[@]}" \
+    src/core src/commands 2>/dev/null \
+    | grep -v -F "src/core/db.ts" \
+    | grep -v "^[^:]*:[0-9]*:[[:space:]]*\(//\|\*\)" \
+    || true
+)
+
+if [ -n "$VIOLATIONS" ]; then
+  # Filter out allowed files from the result (the --exclude only matches basename)
+  FILTERED=$(printf '%s\n' "$VIOLATIONS" | while IFS= read -r line; do
+    path="${line%%:*}"
+    allow=0
+    for ok in "${ALLOWED[@]}"; do
+      if [ "$path" = "$ok" ]; then allow=1; break; fi
+    done
+    if [ "$allow" -eq 0 ]; then printf '%s\n' "$line"; fi
+  done)
+
+  if [ -n "$FILTERED" ]; then
+    echo "ERROR: new direct db.getConnection() / db.connect() call found in multi-brain code path:" >&2
+    echo "" >&2
+    printf '%s\n' "$FILTERED" >&2
+    echo "" >&2
+    echo "Use ctx.engine from the passed-in OperationContext instead." >&2
+    echo "See src/core/brain-registry.ts for the routing model." >&2
+    echo "If this call is legitimate, add its path to the ALLOWED list in" >&2
+    echo "scripts/check-no-legacy-getconnection.sh with a PR 1 cleanup note." >&2
+    exit 1
+  fi
+fi
+
+echo "check-no-legacy-getconnection: ok (no new singleton callers)"

--- a/skills/RESOLVER.md
+++ b/skills/RESOLVER.md
@@ -96,6 +96,7 @@ When multiple skills could match:
 These apply to ALL brain-writing skills:
 - `skills/conventions/quality.md` — citations, back-links, notability gate
 - `skills/conventions/brain-first.md` — check brain before external APIs
+- `skills/conventions/brain-routing.md` — which brain (DB) and which source (repo) to target; cross-brain federation is latent-space only
 - `skills/conventions/subagent-routing.md` — when to use Minions vs inline work
 - `skills/_brain-filing-rules.md` — where files go
 - `skills/_output-rules.md` — output quality standards

--- a/skills/conventions/brain-routing.md
+++ b/skills/conventions/brain-routing.md
@@ -1,0 +1,138 @@
+# Brain Routing Convention
+
+Cross-cutting rules for which brain and which source an operation targets.
+Applies to every skill that reads or writes brain pages. **Full mental model
+lives in `docs/architecture/brains-and-sources.md` — read it once.**
+
+## The two axes (one-line summary)
+
+- **Brain** = which DATABASE. `--brain`, `GBRAIN_BRAIN_ID`, `.gbrain-mount`.
+- **Source** = which REPO INSIDE the database. `--source`, `GBRAIN_SOURCE`,
+  `.gbrain-source`.
+
+Orthogonal. Pick one on each axis per operation.
+
+## Default behavior (ALWAYS)
+
+Start in the brain + source resolved by the environment:
+
+1. Run `gbrain mounts list` if you haven't seen the user's mounts yet.
+2. Trust the resolver. If the user is in `~/team-brains/media/`, their
+   `.gbrain-mount` pins brain=media-team. Don't override that silently.
+3. For every brain op, pass the resolved brain id explicitly when calling
+   tools (even if it matches the default). Makes routing visible in logs.
+
+Bare `gbrain query "X"` routes to the default brain's default source. That
+is the right answer 90% of the time. Don't cross the boundary without a
+reason.
+
+## When to switch brain
+
+Switch brain (`--brain <id>`) when:
+
+- The user's question is specifically about a team the user belongs to
+  ("what did team X decide?", "what's the status of project Y at team X?").
+  Switch BEFORE searching, not after a failed search in host.
+- The user is asking you to ingest data that belongs to a specific team
+  (meeting notes from a team meeting, letters from a team's pipeline). The
+  data owner determines the brain.
+- The user explicitly names a team/brain ("check the media-team brain
+  for...").
+
+Do NOT switch brain when:
+
+- The user asks a general question that might pull from anywhere. Start in
+  host, then cross-query on-demand if host doesn't have it.
+- You're unsure. Stay in host, surface what you found, let the user point
+  you at a specific brain.
+
+## When to switch source
+
+Switch source (`--source <id>`) when:
+
+- The user is working in a specific repo (the `.gbrain-source` dotfile
+  usually handles this — don't fight it).
+- The user asks about something scoped to a repo ("what's in my gstack
+  notes about retry policy?").
+- You're writing a page that logically belongs to one repo. The data
+  origin determines the source.
+
+Do NOT switch source when:
+
+- The user's intent crosses repos. Keep `federated=true` sources for
+  cross-source search.
+- You'd lose a cross-repo match by isolating.
+
+## Cross-brain queries (latent-space federation)
+
+v0.19 does NOT do deterministic cross-brain federation. No SQL fan-out. No
+unified ranking. The AGENT federates.
+
+Pattern when the user asks something that might span brains:
+
+1. Query host with the obvious query.
+2. Check `gbrain mounts list` for relevant brain ids.
+3. If you think another brain has the answer, re-query THAT brain
+   explicitly (`--brain <id>`).
+4. Synthesize across results. Cite `<brain>:<source>:<slug>` so the user
+   can trace.
+
+Never silently mix brains. Every finding is citable to its brain.
+
+## Writing across brains
+
+Writing is stricter than reading. ASK before writing cross-brain.
+
+- A fact about a team's work → team's brain, not host.
+- A fact the user confirmed about a person ONLY they know → host/personal,
+  not a team brain.
+- An enrichment discovered from public data → usually host unless the user
+  says otherwise.
+
+If you're about to `put_page --brain <team-brain>`, confirm with the user
+unless they explicitly said "save this to team-X". Default brain for
+writes is the user's personal brain.
+
+## Citations with brain context
+
+Standard citation format stays the same (`[Source: ...]`), but when pages
+come from a mounted brain, add the brain context for human traceability:
+
+- Single-brain query: `[Source: Meeting, 2026-04-10]` (unchanged).
+- Cross-brain synthesis: `[Source: media-team:meetings/2026-04-10]` or
+  `[Source: policy-team:research/retry-budgets]`.
+
+This matches v0.18.0's source-aware citation (`[source-id:slug]`) extended
+with a brain prefix when relevant.
+
+## Decision table
+
+| Situation | Brain | Source |
+|---|---|---|
+| User cd's into a team-brain checkout and asks a general question | dotfile-resolved team brain | dotfile-resolved source |
+| User asks "what did team X decide?" | `team-x` explicitly | resolver default |
+| User asks "what are we doing across all teams?" | fan out across mounts, agent-driven | resolver default |
+| User asks "add this to my gstack notes" | host | `gstack` |
+| User asks "save this meeting note for team X" | `team-x` (confirm if ambiguous) | team's meetings source |
+| User asks "write me an essay" | host (personal) | `essays` |
+| Unknown — can't classify | stay in host, ask the user | resolver default |
+
+## Anti-patterns
+
+- Silently jumping brains to "find" an answer when the user clearly meant
+  host. That's an audit-trail hole.
+- Writing to host when the data is clearly team-owned ("the team's plans
+  are now in your personal brain" = bad surprise).
+- Cross-brain federation in a single query without citations that name the
+  source brain. The user cannot trace the answer back.
+- Ignoring `.gbrain-mount` / `.gbrain-source` dotfiles. They're load-bearing
+  context — the user set them up for a reason.
+
+## Read more
+
+- `docs/architecture/brains-and-sources.md` — the full mental model with
+  topology diagrams (single-person, personal-with-repos, CEO-class with
+  multiple team brains).
+- `skills/conventions/brain-first.md` — reads the brain BEFORE asking.
+- `skills/conventions/quality.md` — citation format (extended here with
+  brain prefix).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'dream', 'check-resolvable', 'auth']);
+const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'auth']);
 
 async function main() {
   // Parse global flags (--quiet / --progress-json / --progress-interval)
@@ -318,6 +318,13 @@ async function handleCliOnly(command: string, args: string[]) {
   if (command === 'check-resolvable') {
     const { runCheckResolvable } = await import('./commands/check-resolvable.ts');
     await runCheckResolvable(args);
+    return;
+  }
+  if (command === 'mounts') {
+    // No DB needed: mounts.json is a local config file. Registry will
+    // connect mount engines lazily on first use by op dispatch.
+    const { runMounts } = await import('./commands/mounts.ts');
+    await runMounts(args);
     return;
   }
   if (command === 'report') {

--- a/src/commands/mounts.ts
+++ b/src/commands/mounts.ts
@@ -33,6 +33,8 @@ import {
   type MountEntry,
   type MountsFile,
 } from '../core/brain-registry.ts';
+import { findRepoRoot } from '../core/repo-root.ts';
+import { writeMountsCache, clearMountsCache } from '../core/mounts-cache.ts';
 import { GBrainError } from '../core/types.ts';
 
 function getMountsDir(): string { return join(homedir(), '.gbrain'); }
@@ -198,6 +200,13 @@ async function runAdd(args: string[]): Promise<void> {
     `  engine: ${parsed.engine}\n` +
     `  ${parsed.database_url ? `db_url: ${redactUrl(parsed.database_url)}` : `db_path: ${parsed.database_path}`}\n`,
   );
+
+  // Publish aggregated resolver + manifest to ~/.gbrain/mounts-cache/. This
+  // is the runtime ownership seam — host agents read the aggregated file
+  // instead of the checked-in skills/RESOLVER.md. When the current process
+  // isn't inside a gbrain repo, skip (a later mounts invocation from a
+  // repo-rooted cwd will publish the cache).
+  refreshMountsCache();
 }
 
 // ── Subcommand: list ────────────────────────────────────────────────────
@@ -274,6 +283,50 @@ function runRemove(args: string[]): void {
 
   writeMountsFile(file);
   process.stdout.write(`Mount "${id}" removed from mounts.json\n`);
+
+  // If removing the last mount, clear the cache entirely; otherwise
+  // rewrite with the remaining mounts so the aggregated resolver doesn't
+  // reference stale entries.
+  if (file.mounts.length === 0) {
+    try { clearMountsCache(); } catch { /* best effort */ }
+  } else {
+    refreshMountsCache();
+  }
+}
+
+/**
+ * Recompute + publish ~/.gbrain/mounts-cache/{RESOLVER.md,manifest.json}.
+ * Looks for the host skills dir via findRepoRoot(cwd). When not in a gbrain
+ * repo, skips with a stderr note — next mounts invocation from a
+ * repo-rooted cwd will publish. Failures are non-fatal: the mounts.json
+ * write already succeeded; a stale cache is recoverable via `gbrain mounts
+ * list` (PR 1 will add `gbrain mounts sync --cache` for explicit refresh).
+ */
+function refreshMountsCache(): void {
+  const repoRoot = findRepoRoot(process.cwd());
+  if (!repoRoot) {
+    process.stderr.write(
+      'NOTE: mounts-cache not refreshed (not inside a gbrain repo). ' +
+      'Run `gbrain mounts add|remove` from within a repo to publish ' +
+      'the aggregated resolver for host agents.\n',
+    );
+    return;
+  }
+  const hostSkillsDir = join(repoRoot, 'skills');
+  if (!existsSync(hostSkillsDir)) {
+    process.stderr.write(
+      `NOTE: mounts-cache not refreshed (${hostSkillsDir} does not exist).\n`,
+    );
+    return;
+  }
+  try {
+    const file = readMountsFile();
+    const { resolverPath } = writeMountsCache(hostSkillsDir, file.mounts);
+    process.stderr.write(`  cache: ${resolverPath}\n`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stderr.write(`WARN: failed to refresh mounts-cache: ${msg}\n`);
+  }
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────

--- a/src/commands/mounts.ts
+++ b/src/commands/mounts.ts
@@ -1,0 +1,359 @@
+/**
+ * gbrain mounts — manage connected gbrains (v0.19.0, PR 0).
+ *
+ * A "mount" is a SEPARATE gbrain DATABASE connected to your host agent.
+ * Your host OpenClaw can mount N team-published brains (YC Media, YC
+ * Politics, Garry's List) and route operations to each via `--brain <id>`.
+ *
+ * Mounts are distinct from v0.18.0 "sources" (repos within ONE brain).
+ * Orthogonal axes:
+ *   --brain yc-media     → which DATABASE to target
+ *   --source meetings    → which repo WITHIN that database
+ *
+ * Subcommands (PR 0 — direct transport only):
+ *   gbrain mounts add <id> --path <path> --engine pglite|postgres [--db-url|--db-path]
+ *   gbrain mounts list [--json]
+ *   gbrain mounts remove <id>
+ *
+ * Not yet shipped (PR 1+):
+ *   gbrain mounts pin <id> <sha>        — freeze at a tested version (PR 1)
+ *   gbrain mounts sync [--id <id>]      — git pull + cache refresh (PR 1)
+ *   gbrain mounts enable/disable <id>   — toggle without removing (PR 1)
+ *   gbrain mounts add --mcp-url         — HTTP MCP transport + OAuth (PR 2)
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync } from 'fs';
+import { join, resolve } from 'path';
+import { homedir } from 'os';
+import {
+  loadMounts,
+  validateMountId,
+  HOST_BRAIN_ID,
+  DuplicateMountPathError,
+  type MountEntry,
+  type MountsFile,
+} from '../core/brain-registry.ts';
+import { GBrainError } from '../core/types.ts';
+
+function getMountsDir(): string { return join(homedir(), '.gbrain'); }
+function getMountsPath(): string { return join(getMountsDir(), 'mounts.json'); }
+
+/**
+ * Read mounts.json and return the parsed MountsFile, or a fresh empty file
+ * shape if the file is absent. Throws on corruption (never returns partial).
+ */
+function readMountsFile(path: string = getMountsPath()): MountsFile {
+  if (!existsSync(path)) return { version: 1, mounts: [] };
+  const entries = loadMounts(path);
+  return { version: 1, mounts: entries };
+}
+
+/** Write mounts.json atomically with 0600 perms (contains no secrets, but
+ *  is per-user config alongside config.json which IS secret-bearing). */
+function writeMountsFile(file: MountsFile, path: string = getMountsPath()): void {
+  mkdirSync(getMountsDir(), { recursive: true });
+  const tmpPath = path + '.tmp';
+  writeFileSync(tmpPath, JSON.stringify(file, null, 2) + '\n', { mode: 0o600 });
+  try { chmodSync(tmpPath, 0o600); } catch { /* platform dep */ }
+  // Atomic rename so readers never see a torn file.
+  const fs = require('fs') as typeof import('fs');
+  fs.renameSync(tmpPath, path);
+}
+
+// ── Argument parsing helpers ───────────────────────────────────────────
+
+interface AddArgs {
+  id: string;
+  path: string;
+  engine: 'postgres' | 'pglite';
+  database_url?: string;
+  database_path?: string;
+  alias?: string;
+}
+
+function parseAddArgs(args: string[]): AddArgs {
+  if (args.length === 0) {
+    throw new GBrainError(
+      'Missing mount id',
+      'gbrain mounts add <id> --path <path> [flags]',
+      'Provide a kebab-case id as the first argument',
+    );
+  }
+  const id = validateMountId(args[0], 'mount id');
+  let path: string | undefined;
+  let engine: 'postgres' | 'pglite' | undefined;
+  let database_url: string | undefined;
+  let database_path: string | undefined;
+  let alias: string | undefined;
+
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i];
+    const next = (flag: string): string => {
+      const v = args[++i];
+      if (!v) throw new GBrainError(`Missing value for ${flag}`, '', `Pass a value: ${flag} <value>`);
+      return v;
+    };
+    if (a === '--path') path = next('--path');
+    else if (a === '--engine') {
+      const v = next('--engine');
+      if (v !== 'postgres' && v !== 'pglite') {
+        throw new GBrainError(`Invalid engine: "${v}"`, 'Must be "postgres" or "pglite"', 'Pass --engine pglite or --engine postgres');
+      }
+      engine = v;
+    }
+    else if (a === '--db-url' || a === '--database-url') database_url = next(a);
+    else if (a === '--db-path' || a === '--database-path') database_path = next(a);
+    else if (a === '--alias') alias = validateMountId(next('--alias'), '--alias value');
+    else throw new GBrainError(`Unknown flag: ${a}`, '', 'See `gbrain mounts add --help`');
+  }
+
+  if (!path) {
+    throw new GBrainError('Missing --path', 'Every mount needs a local clone path (for skills + handlers)', 'Add --path /absolute/path/to/mount');
+  }
+
+  // Engine inference: if user supplied db-url → postgres, if db-path → pglite.
+  if (!engine) {
+    if (database_url) engine = 'postgres';
+    else if (database_path) engine = 'pglite';
+    else {
+      throw new GBrainError(
+        'Missing --engine',
+        'Could not infer engine from flags',
+        'Pass --engine pglite --db-path <path> OR --engine postgres --db-url <url>',
+      );
+    }
+  }
+
+  if (engine === 'postgres' && !database_url) {
+    throw new GBrainError('postgres mount requires --db-url', '', 'Pass --db-url postgresql://...');
+  }
+  if (engine === 'pglite' && !database_path && !database_url) {
+    throw new GBrainError('pglite mount requires --db-path', '', 'Pass --db-path /path/to/mount/.pglite');
+  }
+
+  return { id, path: resolve(path), engine, database_url, database_path, alias };
+}
+
+// ── Subcommand: add ─────────────────────────────────────────────────────
+
+async function runAdd(args: string[]): Promise<void> {
+  const parsed = parseAddArgs(args);
+
+  // Mount path must exist on disk — otherwise skill/handler loading will
+  // fail later with a less-actionable error.
+  if (!existsSync(parsed.path)) {
+    throw new GBrainError(
+      `Mount path does not exist: ${parsed.path}`,
+      'The local clone directory must exist before registering a mount',
+      `Clone the repo first (git clone <repo> ${parsed.path}) then re-run`,
+    );
+  }
+
+  const file = readMountsFile();
+
+  // Duplicate id check.
+  if (file.mounts.some(m => m.id === parsed.id)) {
+    throw new GBrainError(
+      `Mount id already exists: "${parsed.id}"`,
+      `Use 'gbrain mounts list' to see registered mounts`,
+      `Remove the existing mount first: gbrain mounts remove ${parsed.id}`,
+    );
+  }
+
+  // Duplicate path check (load-bearing — skills/handlers/attestation/git
+  // sync all key off path, so two mounts at the same path silently collide).
+  const existingAtPath = file.mounts.find(m => resolve(m.path) === parsed.path);
+  if (existingAtPath) {
+    throw new DuplicateMountPathError(parsed.path, existingAtPath.id, parsed.id);
+  }
+
+  // Soft warning: same database_url/database_path under different id. A
+  // team can legitimately mount the same remote brain under two aliases,
+  // so this is NOT a hard block (Codex finding #9 correction).
+  const urlDupe = file.mounts.find(m =>
+    (parsed.database_url && m.database_url === parsed.database_url) ||
+    (parsed.database_path && m.database_path === parsed.database_path),
+  );
+  if (urlDupe) {
+    process.stderr.write(
+      `WARN: mount "${parsed.id}" shares database with "${urlDupe.id}". ` +
+      `This is usually a mistake but is allowed for intentional aliasing.\n`,
+    );
+  }
+
+  const entry: MountEntry = {
+    id: parsed.id,
+    alias: parsed.alias,
+    path: parsed.path,
+    engine: parsed.engine,
+    database_url: parsed.database_url,
+    database_path: parsed.database_path,
+    enabled: true,
+  };
+  file.mounts.push(entry);
+  writeMountsFile(file);
+
+  process.stdout.write(
+    `Mount "${parsed.id}" added → ${parsed.path}\n` +
+    `  engine: ${parsed.engine}\n` +
+    `  ${parsed.database_url ? `db_url: ${redactUrl(parsed.database_url)}` : `db_path: ${parsed.database_path}`}\n`,
+  );
+}
+
+// ── Subcommand: list ────────────────────────────────────────────────────
+
+function runList(args: string[]): void {
+  const jsonMode = args.includes('--json');
+  const file = readMountsFile();
+
+  if (jsonMode) {
+    // Redact raw db_url in json output (mounts.json is per-user 0600, but
+    // stdout can be piped into logs). database_path is fine (it's a local
+    // path, not a secret).
+    const redacted = file.mounts.map(m => ({
+      ...m,
+      database_url: m.database_url ? redactUrl(m.database_url) : undefined,
+    }));
+    process.stdout.write(JSON.stringify({ version: file.version, mounts: redacted }, null, 2) + '\n');
+    return;
+  }
+
+  if (file.mounts.length === 0) {
+    process.stdout.write(
+      'No mounts registered.\n\n' +
+      `Add a mount with:\n` +
+      `  gbrain mounts add <id> --path <path> --engine pglite --db-path <path>\n`,
+    );
+    return;
+  }
+
+  process.stdout.write(`MOUNTS (${file.mounts.length})\n`);
+  process.stdout.write('─'.repeat(60) + '\n');
+  for (const m of file.mounts) {
+    const status = m.enabled === false ? '(disabled)' : '';
+    process.stdout.write(`  ${m.id.padEnd(20)} ${m.engine.padEnd(10)} ${status}\n`);
+    process.stdout.write(`    path:    ${m.path}\n`);
+    if (m.database_url) {
+      process.stdout.write(`    db_url:  ${redactUrl(m.database_url)}\n`);
+    } else if (m.database_path) {
+      process.stdout.write(`    db_path: ${m.database_path}\n`);
+    }
+    if (m.alias) process.stdout.write(`    alias:   ${m.alias}\n`);
+  }
+}
+
+// ── Subcommand: remove ──────────────────────────────────────────────────
+
+function runRemove(args: string[]): void {
+  if (args.length === 0) {
+    throw new GBrainError(
+      'Missing mount id',
+      'gbrain mounts remove <id>',
+      `Run 'gbrain mounts list' to see registered mounts`,
+    );
+  }
+  const id = args[0];
+  if (id === HOST_BRAIN_ID) {
+    throw new GBrainError(
+      `Cannot remove host brain`,
+      `"host" is not a mount — it is the default brain from ~/.gbrain/config.json`,
+      `Use 'gbrain init' to reconfigure the host brain`,
+    );
+  }
+
+  const file = readMountsFile();
+  const before = file.mounts.length;
+  file.mounts = file.mounts.filter(m => m.id !== id);
+  if (file.mounts.length === before) {
+    throw new GBrainError(
+      `Mount "${id}" not found`,
+      `No mount with id "${id}" is registered`,
+      `Run 'gbrain mounts list' to see registered mounts`,
+    );
+  }
+
+  writeMountsFile(file);
+  process.stdout.write(`Mount "${id}" removed from mounts.json\n`);
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/** Strip password from a postgres:// url for safe display. */
+function redactUrl(url: string): string {
+  try {
+    const u = new URL(url.replace(/^postgres(ql)?:\/\//, 'http://'));
+    if (u.password) u.password = '***';
+    return u.toString().replace(/^http:\/\//, 'postgres://');
+  } catch {
+    // Opaque URL (e.g. file:// for pglite). Return as-is.
+    return url;
+  }
+}
+
+// ── Dispatcher ──────────────────────────────────────────────────────────
+
+export async function runMounts(args: string[]): Promise<void> {
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    printHelp();
+    return;
+  }
+  const sub = args[0];
+  const rest = args.slice(1);
+
+  switch (sub) {
+    case 'add':
+      await runAdd(rest);
+      return;
+    case 'list':
+    case 'ls':
+      runList(rest);
+      return;
+    case 'remove':
+    case 'rm':
+      runRemove(rest);
+      return;
+    default:
+      throw new GBrainError(
+        `Unknown subcommand: gbrain mounts ${sub}`,
+        `Supported: add, list, remove`,
+        `Run 'gbrain mounts --help' for usage`,
+      );
+  }
+}
+
+function printHelp(): void {
+  process.stdout.write(`gbrain mounts — manage connected gbrains (PR 0: direct transport only)
+
+USAGE
+  gbrain mounts add <id> --path <path> --engine pglite|postgres [--db-url|--db-path]
+  gbrain mounts list [--json]
+  gbrain mounts remove <id>
+
+EXAMPLES
+  # Mount a team-published yc-media gbrain (PGLite)
+  git clone https://github.com/yc-team/yc-media-gbrain ~/gbrains/yc-media
+  gbrain mounts add yc-media --path ~/gbrains/yc-media --engine pglite \\
+    --db-path ~/gbrains/yc-media/.pglite
+
+  # List registered mounts
+  gbrain mounts list
+
+  # Remove a mount
+  gbrain mounts remove yc-media
+
+NOT YET IMPLEMENTED (coming in PR 1/2)
+  gbrain mounts pin <id> <sha>          — freeze a mount at a tested version
+  gbrain mounts sync [--id <id>]        — git pull + refresh attestation
+  gbrain mounts enable|disable <id>     — toggle without removing
+  gbrain mounts add --mcp-url <url>     — HTTP MCP transport + OAuth
+`);
+}
+
+/** Exposed for tests. */
+export const __testing = {
+  parseAddArgs,
+  redactUrl,
+  readMountsFile,
+  writeMountsFile,
+  getMountsPath,
+};

--- a/src/commands/mounts.ts
+++ b/src/commands/mounts.ts
@@ -22,7 +22,7 @@
  *   gbrain mounts add --mcp-url         — HTTP MCP transport + OAuth (PR 2)
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, renameSync } from 'fs';
 import { join, resolve } from 'path';
 import { homedir } from 'os';
 import {
@@ -51,15 +51,21 @@ function readMountsFile(path: string = getMountsPath()): MountsFile {
 }
 
 /** Write mounts.json atomically with 0600 perms (contains no secrets, but
- *  is per-user config alongside config.json which IS secret-bearing). */
+ *  is per-user config alongside config.json which IS secret-bearing).
+ *
+ *  Unique tmp filename per call (pid + random). Two concurrent `gbrain
+ *  mounts add` invocations would otherwise clobber each other's `.tmp` file
+ *  and one writer's update would be lost. Unique tmp names make each
+ *  writer's atomic rename self-contained — last rename wins (read-modify-
+ *  write lost-update is a separate concern that a true file lock would
+ *  address, deferred to PR 1 under `gbrain mounts sync --lock`). */
 function writeMountsFile(file: MountsFile, path: string = getMountsPath()): void {
   mkdirSync(getMountsDir(), { recursive: true });
-  const tmpPath = path + '.tmp';
+  const tmpPath = `${path}.tmp.${process.pid}.${Math.random().toString(36).slice(2, 10)}`;
   writeFileSync(tmpPath, JSON.stringify(file, null, 2) + '\n', { mode: 0o600 });
   try { chmodSync(tmpPath, 0o600); } catch { /* platform dep */ }
   // Atomic rename so readers never see a torn file.
-  const fs = require('fs') as typeof import('fs');
-  fs.renameSync(tmpPath, path);
+  renameSync(tmpPath, path);
 }
 
 // ── Argument parsing helpers ───────────────────────────────────────────

--- a/src/core/brain-registry.ts
+++ b/src/core/brain-registry.ts
@@ -1,0 +1,420 @@
+/**
+ * BrainRegistry — connected gbrains (v0.19, PR 0).
+ *
+ * A registry of BrainEngine handles keyed by brainId. Supports:
+ *   - 'host': the brain defined by ~/.gbrain/config.json (single-brain default).
+ *   - <mount-id>: brains declared in ~/.gbrain/mounts.json.
+ *
+ * This is the dispatch-time lookup that makes `ctx.brainId` → `ctx.engine`
+ * resolution routable per operation. Only direct-transport mounts are
+ * supported in PR 0. HTTP MCP transport (team-published brains with OAuth)
+ * lands in PR 2.
+ *
+ * Design notes:
+ * - Engines are lazily created on first `getBrain(id)` and cached.
+ * - `disconnectAll()` is idempotent and safe to call during shutdown.
+ * - NO AsyncLocalStorage. Brain routing is explicit via OperationContext.
+ * - mounts.json is validated strictly on load. Malformed entries throw with
+ *   actionable messages so partial-state silent failures never happen.
+ * - `DuplicateMountPathError` blocks two mounts pointing at the same local
+ *   path (load-bearing identity: skills/handlers/git-sync/attestation all
+ *   key off path). Same db_url is not blocked because a team can
+ *   legitimately mount the same remote brain under two local clones.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join, resolve } from 'path';
+import { homedir } from 'os';
+import type { BrainEngine } from './engine.ts';
+import type { EngineConfig } from './types.ts';
+import { GBrainError } from './types.ts';
+import { loadConfig, type GBrainConfig } from './config.ts';
+
+/** Host brain id. Reserved — users cannot create a mount with this id. */
+export const HOST_BRAIN_ID = 'host';
+
+/** Brain id regex. Alphanumeric + dashes, 1-32 chars. No edge dashes. */
+const BRAIN_ID_RE = /^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$/;
+
+/** Path to mounts.json. Lazy to avoid homedir() at module scope. */
+function getMountsPath(): string {
+  return join(homedir(), '.gbrain', 'mounts.json');
+}
+
+/**
+ * A single entry in ~/.gbrain/mounts.json.
+ *
+ * PR 0: only direct-transport mounts are supported. PR 2 will add
+ * `transport: "mcp"` with `mcp_url` + OAuth credential references.
+ */
+export interface MountEntry {
+  /** Unique mount id. Becomes the namespace in `yc-media::skill` form. */
+  id: string;
+  /** Optional shorthand for CLI display. Must pass BRAIN_ID_RE if present. */
+  alias?: string;
+  /** Absolute local path to the mount's git clone (for skills + handlers). */
+  path: string;
+  /** Engine kind. Required for direct transport. */
+  engine: 'postgres' | 'pglite';
+  /** Postgres connection URL (if engine=postgres). */
+  database_url?: string;
+  /** PGLite data-directory path (if engine=pglite). */
+  database_path?: string;
+  /** Default true. Disabled mounts are not loaded. */
+  enabled?: boolean;
+  /** Managed by `gbrain mounts sync` (PR 1). */
+  expected_sha?: string;
+  /** Managed by `gbrain mounts sync` (PR 1). */
+  last_synced_at?: string;
+}
+
+/** Top-level shape of ~/.gbrain/mounts.json. */
+export interface MountsFile {
+  version: 1;
+  mounts: MountEntry[];
+}
+
+/** Handle returned by the registry for a given brain id. */
+export interface BrainHandle {
+  /** 'host' for the default brain, else the mount id. */
+  id: string;
+  /** Connected BrainEngine. Only valid for the lifetime of this registry. */
+  engine: BrainEngine;
+  /** GBrainConfig used to create the engine. */
+  config: GBrainConfig;
+  /** Absolute local path to the mount's clone. `null` for the host brain. */
+  path: string | null;
+}
+
+/** Error thrown when two mounts resolve to the same local path. */
+export class DuplicateMountPathError extends GBrainError {
+  constructor(path: string, existingId: string, attemptedId: string) {
+    super(
+      `Duplicate mount path: "${path}"`,
+      `Mount "${existingId}" already uses this path. Cannot register "${attemptedId}" at the same location.`,
+      'Use a different local clone path, or remove the existing mount first: ' +
+        `gbrain mounts remove ${existingId}`,
+    );
+  }
+}
+
+/** Error thrown when a caller requests an unknown or disabled brain id. */
+export class UnknownBrainError extends GBrainError {
+  constructor(id: string, available: string[]) {
+    const list = available.length > 0 ? available.join(', ') : '(none registered)';
+    super(
+      `Unknown brain: "${id}"`,
+      `No enabled mount with id "${id}" found. Available brain ids: ${list}`,
+      `Run 'gbrain mounts list' to see registered mounts. Add a new mount with 'gbrain mounts add ${id} --path <path> --db-url <url>'.`,
+    );
+  }
+}
+
+/** Validate a mount id (and optionally the alias). Throws with actionable msg. */
+export function validateMountId(id: unknown, fieldLabel = 'mount id'): string {
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new GBrainError(
+      `Invalid ${fieldLabel}`,
+      `${fieldLabel} must be a non-empty string`,
+      'Use a kebab-case id like "yc-media" or "garrys-list"',
+    );
+  }
+  if (id === HOST_BRAIN_ID) {
+    throw new GBrainError(
+      `Reserved ${fieldLabel}: "${HOST_BRAIN_ID}"`,
+      `"${HOST_BRAIN_ID}" is the host brain id and cannot be used for a mount`,
+      'Choose a different id',
+    );
+  }
+  if (!BRAIN_ID_RE.test(id)) {
+    throw new GBrainError(
+      `Invalid ${fieldLabel}: "${id}"`,
+      `${fieldLabel} must match [a-z0-9-]{1,32}, start+end alphanumeric, interior dashes allowed`,
+      'Use a kebab-case id like "yc-media"',
+    );
+  }
+  return id;
+}
+
+/**
+ * Parse + validate mounts.json. Returns an empty list if the file is absent.
+ * Throws a structured error on any malformed entry (never a silent skip).
+ */
+export function loadMounts(mountsPath: string = getMountsPath()): MountEntry[] {
+  if (!existsSync(mountsPath)) return [];
+
+  let raw: string;
+  try {
+    raw = readFileSync(mountsPath, 'utf-8');
+  } catch (e) {
+    throw new GBrainError(
+      `Cannot read ${mountsPath}`,
+      e instanceof Error ? e.message : String(e),
+      `Check file permissions (expected 0600) and re-run`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new GBrainError(
+      `Malformed mounts.json`,
+      e instanceof Error ? e.message : String(e),
+      `Fix the JSON syntax at ${mountsPath} or remove it and re-add mounts via 'gbrain mounts add'`,
+    );
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new GBrainError(
+      `mounts.json must be a JSON object`,
+      `Got: ${Array.isArray(parsed) ? 'array' : typeof parsed}`,
+      `Expected { version: 1, mounts: [...] }`,
+    );
+  }
+
+  const file = parsed as Partial<MountsFile>;
+  if (file.version !== 1) {
+    throw new GBrainError(
+      `Unsupported mounts.json version: ${file.version}`,
+      `This gbrain binary supports version 1`,
+      `Upgrade gbrain or regenerate mounts.json`,
+    );
+  }
+
+  if (!Array.isArray(file.mounts)) {
+    throw new GBrainError(
+      `mounts.json: "mounts" must be an array`,
+      `Got: ${typeof file.mounts}`,
+      `Expected { version: 1, mounts: [...] }`,
+    );
+  }
+
+  const seenIds = new Set<string>();
+  const seenPaths = new Map<string, string>(); // resolved path → id
+  const out: MountEntry[] = [];
+
+  for (let i = 0; i < file.mounts.length; i++) {
+    const entry = file.mounts[i] as Partial<MountEntry> | undefined;
+    if (!entry || typeof entry !== 'object') {
+      throw new GBrainError(
+        `mounts.json: entry ${i} must be an object`,
+        `Got: ${typeof entry}`,
+        `Each entry shape: { id, path, engine, db_url|database_path, enabled? }`,
+      );
+    }
+    const id = validateMountId(entry.id, `mounts[${i}].id`);
+    if (seenIds.has(id)) {
+      throw new GBrainError(
+        `mounts.json: duplicate id "${id}"`,
+        `Two mounts share the id "${id}" (only one entry permitted per id)`,
+        `Remove one of the entries or rename it`,
+      );
+    }
+    seenIds.add(id);
+
+    if (typeof entry.path !== 'string' || entry.path.length === 0) {
+      throw new GBrainError(
+        `mounts[${i}] "${id}": path is required`,
+        `path must be a non-empty absolute filesystem path`,
+        `Add "path": "/absolute/path/to/${id}" to this mount entry`,
+      );
+    }
+    const resolvedPath = resolve(entry.path);
+    const existingAtPath = seenPaths.get(resolvedPath);
+    if (existingAtPath) {
+      throw new DuplicateMountPathError(resolvedPath, existingAtPath, id);
+    }
+    seenPaths.set(resolvedPath, id);
+
+    if (entry.engine !== 'postgres' && entry.engine !== 'pglite') {
+      throw new GBrainError(
+        `mounts[${i}] "${id}": engine must be "postgres" or "pglite"`,
+        `Got: ${JSON.stringify(entry.engine)}`,
+        `Set "engine": "pglite" for a local embedded DB or "postgres" for Supabase/self-hosted`,
+      );
+    }
+
+    if (entry.engine === 'postgres' && !entry.database_url) {
+      throw new GBrainError(
+        `mounts[${i}] "${id}": postgres mount requires database_url`,
+        `database_url is missing`,
+        `Add "database_url": "postgresql://..." or use engine: "pglite"`,
+      );
+    }
+    if (entry.engine === 'pglite' && !entry.database_path && !entry.database_url) {
+      throw new GBrainError(
+        `mounts[${i}] "${id}": pglite mount requires database_path (or database_url)`,
+        `Both database_path and database_url are missing`,
+        `Add "database_path": "/path/to/${id}/.pglite"`,
+      );
+    }
+    if (entry.alias !== undefined) {
+      validateMountId(entry.alias, `mounts[${i}].alias`);
+    }
+
+    out.push({
+      id,
+      alias: entry.alias,
+      path: resolvedPath,
+      engine: entry.engine,
+      database_url: entry.database_url,
+      database_path: entry.database_path,
+      enabled: entry.enabled ?? true,
+      expected_sha: entry.expected_sha,
+      last_synced_at: entry.last_synced_at,
+    });
+  }
+
+  return out;
+}
+
+/** Convert a MountEntry to an EngineConfig suitable for createEngine. */
+function mountToEngineConfig(mount: MountEntry): EngineConfig {
+  return {
+    engine: mount.engine,
+    database_url: mount.database_url,
+    database_path: mount.database_path,
+  };
+}
+
+/** Convert a MountEntry to a GBrainConfig (for OperationContext). */
+function mountToGBrainConfig(mount: MountEntry): GBrainConfig {
+  return {
+    engine: mount.engine,
+    database_url: mount.database_url,
+    database_path: mount.database_path,
+  };
+}
+
+/**
+ * Keyed registry of BrainHandles. Lazy-initialized; engines are constructed
+ * on first `getBrain(id)` call and cached.
+ */
+export class BrainRegistry {
+  private readonly mounts: Map<string, MountEntry>;
+  private readonly handles = new Map<string, BrainHandle>();
+  private readonly pending = new Map<string, Promise<BrainHandle>>();
+  private hostHandle: BrainHandle | null = null;
+  private pendingHost: Promise<BrainHandle> | null = null;
+
+  constructor(mounts: MountEntry[]) {
+    this.mounts = new Map();
+    for (const m of mounts) {
+      if (m.enabled !== false) this.mounts.set(m.id, m);
+    }
+  }
+
+  /**
+   * Resolve a brain id to a connected handle. Returns the host brain for
+   * `id === 'host'` (or undefined). Throws UnknownBrainError for unknown ids.
+   */
+  async getBrain(id: string | undefined | null): Promise<BrainHandle> {
+    const resolved = id && id.length > 0 ? id : HOST_BRAIN_ID;
+    if (resolved === HOST_BRAIN_ID) return this.getDefaultBrain();
+
+    const cached = this.handles.get(resolved);
+    if (cached) return cached;
+
+    // Dedup concurrent init: if two callers race on the same id, only one
+    // createEngine() fires.
+    const inflight = this.pending.get(resolved);
+    if (inflight) return inflight;
+
+    const mount = this.mounts.get(resolved);
+    if (!mount) throw new UnknownBrainError(resolved, this.listBrainIds());
+
+    const promise = this.initMountBrain(mount);
+    this.pending.set(resolved, promise);
+    try {
+      const handle = await promise;
+      this.handles.set(resolved, handle);
+      return handle;
+    } finally {
+      this.pending.delete(resolved);
+    }
+  }
+
+  /**
+   * Return the host brain handle (from ~/.gbrain/config.json). Lazy-
+   * initialized so callers that only touch mounts don't require host config.
+   */
+  async getDefaultBrain(): Promise<BrainHandle> {
+    if (this.hostHandle) return this.hostHandle;
+    if (this.pendingHost) return this.pendingHost;
+
+    this.pendingHost = this.initHostBrain();
+    try {
+      this.hostHandle = await this.pendingHost;
+      return this.hostHandle;
+    } finally {
+      this.pendingHost = null;
+    }
+  }
+
+  /** Return every known brain id (host + enabled mounts). */
+  listBrainIds(): string[] {
+    return [HOST_BRAIN_ID, ...Array.from(this.mounts.keys()).sort()];
+  }
+
+  /** Return the underlying mount entries (host excluded). */
+  listMounts(): MountEntry[] {
+    return Array.from(this.mounts.values());
+  }
+
+  /** Disconnect every initialized engine. Safe to call repeatedly. */
+  async disconnectAll(): Promise<void> {
+    const handles = [this.hostHandle, ...Array.from(this.handles.values())].filter(
+      (h): h is BrainHandle => h != null,
+    );
+    this.hostHandle = null;
+    this.handles.clear();
+    await Promise.allSettled(handles.map(h => h.engine.disconnect()));
+  }
+
+  private async initHostBrain(): Promise<BrainHandle> {
+    const config = loadConfig();
+    if (!config) {
+      throw new GBrainError(
+        'No host brain configured',
+        '~/.gbrain/config.json is missing and GBRAIN_DATABASE_URL is unset',
+        "Run 'gbrain init' to configure the host brain",
+      );
+    }
+    const { createEngine } = await import('./engine-factory.ts');
+    const engineConfig: EngineConfig = {
+      engine: config.engine,
+      database_url: config.database_url,
+      database_path: config.database_path,
+    };
+    const engine = await createEngine(engineConfig);
+    await engine.connect(engineConfig);
+    return { id: HOST_BRAIN_ID, engine, config, path: null };
+  }
+
+  private async initMountBrain(mount: MountEntry): Promise<BrainHandle> {
+    const { createEngine } = await import('./engine-factory.ts');
+    const engineConfig = mountToEngineConfig(mount);
+    const engine = await createEngine(engineConfig);
+    await engine.connect(engineConfig);
+    return {
+      id: mount.id,
+      engine,
+      config: mountToGBrainConfig(mount),
+      path: mount.path,
+    };
+  }
+}
+
+/** Convenience: build a registry from the default mounts.json location. */
+export function loadRegistry(mountsPath: string = getMountsPath()): BrainRegistry {
+  return new BrainRegistry(loadMounts(mountsPath));
+}
+
+/** Exposed for tests. */
+export const __testing = {
+  BRAIN_ID_RE,
+  getMountsPath,
+  mountToEngineConfig,
+  mountToGBrainConfig,
+};

--- a/src/core/brain-registry.ts
+++ b/src/core/brain-registry.ts
@@ -396,7 +396,14 @@ export class BrainRegistry {
     const { createEngine } = await import('./engine-factory.ts');
     const engineConfig = mountToEngineConfig(mount);
     const engine = await createEngine(engineConfig);
-    await engine.connect(engineConfig);
+    // Mounts MUST use per-instance connection pools, never the module
+    // singleton in db.ts. Passing poolSize forces postgres-engine onto the
+    // instance path (postgres-engine.ts:33-60). Without this, two mounts
+    // with different Postgres URLs silently share whichever singleton was
+    // connected first (Codex finding #1). PGLite ignores poolSize — it has
+    // no pool. Hard-coded 5: conservative cap for mounts given N brains
+    // can be mounted at once. Override per-mount is PR 1.
+    await engine.connect({ ...engineConfig, poolSize: 5 } as EngineConfig & { poolSize: number });
     return {
       id: mount.id,
       engine,

--- a/src/core/brain-resolver.ts
+++ b/src/core/brain-resolver.ts
@@ -1,0 +1,133 @@
+/**
+ * Brain resolution for CLI commands (v0.19.0, PR 0).
+ *
+ * Mirrors the 6-tier resolution pattern of v0.18.0's source-resolver.ts so
+ * agents learn one mental model. `--brain <id>` picks WHICH DATABASE to
+ * target (mounts + host). `--source <id>` (v0.18.0) picks WHICH REPO WITHIN
+ * the selected brain. Orthogonal axes.
+ *
+ * Resolution priority (highest first):
+ *   1. Explicit --brain <id> flag (caller passes this as `explicit`).
+ *   2. GBRAIN_BRAIN_ID env var.
+ *   3. .gbrain-mount dotfile in CWD or any ancestor directory.
+ *   4. Registered mount whose `path` contains CWD (longest-prefix match).
+ *   5. Brain-level default (future: ~/.gbrain/config.json `brains.default`).
+ *   6. Literal 'host' fallback (backward compat for every pre-v0.19 brain).
+ *
+ * Consumed by src/cli.ts, src/mcp/server.ts, and any future command that
+ * needs per-call brain selection. The subagent handler inherits the
+ * parent's brainId instead of re-running this resolver.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname, resolve } from 'path';
+import { HOST_BRAIN_ID, loadMounts, validateMountId, type MountEntry } from './brain-registry.ts';
+
+const DOTFILE = '.gbrain-mount';
+/** Same regex as brain-registry. Kept in sync. */
+const BRAIN_ID_RE = /^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$/;
+
+/**
+ * Walk up from startDir looking for a .gbrain-mount dotfile. Returns the
+ * first valid id found, or null if none. Guards against filesystem-root
+ * infinite loops and malformed dotfiles (silent skip + continue walking).
+ */
+function readDotfileWalk(startDir: string): string | null {
+  let dir = resolve(startDir);
+  for (let i = 0; i < 50; i++) {
+    const candidate = join(dir, DOTFILE);
+    if (existsSync(candidate)) {
+      try {
+        const content = readFileSync(candidate, 'utf8').trim().split('\n')[0].trim();
+        if (content === HOST_BRAIN_ID) return content;
+        if (BRAIN_ID_RE.test(content)) return content;
+      } catch {
+        // Unreadable dotfile — skip and keep walking.
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break; // filesystem root
+    dir = parent;
+  }
+  return null;
+}
+
+/** Longest-prefix match: find the mount whose `path` contains `cwd`. */
+function longestPathPrefixMount(mounts: MountEntry[], cwd: string): MountEntry | null {
+  const cwdResolved = resolve(cwd);
+  let best: { mount: MountEntry; pathLen: number } | null = null;
+  for (const m of mounts) {
+    if (m.enabled === false) continue;
+    const p = resolve(m.path);
+    if (cwdResolved === p || cwdResolved.startsWith(p + '/')) {
+      if (!best || p.length > best.pathLen) {
+        best = { mount: m, pathLen: p.length };
+      }
+    }
+  }
+  return best ? best.mount : null;
+}
+
+/**
+ * Resolve the brain id for a CLI command. Never returns null — every call
+ * targets exactly one brain, with 'host' as the guaranteed terminal fallback.
+ *
+ * @param explicit  The --brain <id> flag value, if the caller parsed one.
+ * @param cwd  Working directory for .gbrain-mount walk. Defaults to process.cwd().
+ * @param mountsLoader  Override for testability. Returns the list of enabled
+ *                      mounts. Defaults to reading ~/.gbrain/mounts.json.
+ * @returns  The resolved brain id. Always truthy. Either 'host' or a valid mount id.
+ *
+ * Does NOT validate that the id points at a registered mount — that is
+ * BrainRegistry.getBrain's job. This resolver answers "which id is the
+ * caller asking for?"; the registry answers "does that id exist?".
+ */
+export function resolveBrainId(
+  explicit: string | null | undefined,
+  cwd: string = process.cwd(),
+  mountsLoader: () => MountEntry[] = loadMounts,
+): string {
+  // 1. Explicit flag wins.
+  if (explicit) {
+    if (explicit === HOST_BRAIN_ID) return HOST_BRAIN_ID;
+    validateMountId(explicit, '--brain value');
+    return explicit;
+  }
+
+  // 2. Env var.
+  const env = process.env.GBRAIN_BRAIN_ID;
+  if (env && env.length > 0) {
+    if (env === HOST_BRAIN_ID) return HOST_BRAIN_ID;
+    validateMountId(env, 'GBRAIN_BRAIN_ID');
+    return env;
+  }
+
+  // 3. Dotfile walk-up.
+  const dotfile = readDotfileWalk(cwd);
+  if (dotfile) return dotfile;
+
+  // 4. Registered mount path-prefix.
+  let mounts: MountEntry[] = [];
+  try {
+    mounts = mountsLoader();
+  } catch {
+    // mounts.json corruption shouldn't break brain resolution — fall through
+    // to 'host'. BrainRegistry.getBrain will throw the actionable error if
+    // the caller actually tried to touch a mount.
+    mounts = [];
+  }
+  const matched = longestPathPrefixMount(mounts, cwd);
+  if (matched) return matched.id;
+
+  // 5. Brain-level default — v2. Not wired in PR 0.
+  // 6. Fallback.
+  return HOST_BRAIN_ID;
+}
+
+/** Exposed for tests. */
+export const __testing = {
+  readDotfileWalk,
+  longestPathPrefixMount,
+  DOTFILE,
+  BRAIN_ID_RE,
+};

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -149,10 +149,13 @@ export function makeSubagentHandler(deps: SubagentDeps) {
     const systemPrompt = data.system ?? DEFAULT_SYSTEM;
 
     // Build the tool registry bound to THIS job as the owning subagent.
+    // brain_id from job data is the per-call override; child jobs inherit
+    // the parent's brainId unless they explicitly set their own.
     const registry = deps.toolRegistry ?? buildBrainTools({
       subagentId: ctx.id,
       engine,
       config,
+      brainId: data.brain_id,
     });
     const toolDefs = data.allowed_tools && data.allowed_tools.length > 0
       ? filterAllowedTools(registry, data.allowed_tools)

--- a/src/core/minions/tools/brain-allowlist.ts
+++ b/src/core/minions/tools/brain-allowlist.ts
@@ -116,11 +116,18 @@ export interface BuildBrainToolsOpts {
   /** Optional filter: only include names in this set. */
   allowedNames?: ReadonlySet<string>;
   /**
-   * Connected-gbrains brain id (v0.19+). Omitted = 'host'. Propagated into
-   * every op context built for this subagent so child tool calls target the
-   * brain the parent job was resolved into, not the process-wide default.
-   * Fixes Codex finding #6 (brain-allowlist hardwiring config without brain
-   * awareness).
+   * Connected-gbrains brain id (v0.19+, PR 0 plumbing only).
+   *
+   * CURRENT BEHAVIOR: `brainId` is stamped onto each tool-call's
+   * `OperationContext.brainId` for audit / logging, but `ctx.engine` is
+   * still the engine passed in here (the parent job's engine). Ops
+   * targeting mounted brains via brainId WITHOUT a registry lookup will
+   * silently run against the parent engine.
+   *
+   * FUTURE (PR 1): `buildOpContext` will call `BrainRegistry.getBrain
+   * (brainId).engine` to select the right engine per dispatch. Once
+   * wired, `opCtx.engine` will match `opCtx.brainId`. Until then, treat
+   * brainId as metadata only.
    */
   brainId?: string;
 }

--- a/src/core/minions/tools/brain-allowlist.ts
+++ b/src/core/minions/tools/brain-allowlist.ts
@@ -115,6 +115,14 @@ export interface BuildBrainToolsOpts {
   config: GBrainConfig;
   /** Optional filter: only include names in this set. */
   allowedNames?: ReadonlySet<string>;
+  /**
+   * Connected-gbrains brain id (v0.19+). Omitted = 'host'. Propagated into
+   * every op context built for this subagent so child tool calls target the
+   * brain the parent job was resolved into, not the process-wide default.
+   * Fixes Codex finding #6 (brain-allowlist hardwiring config without brain
+   * awareness).
+   */
+  brainId?: string;
 }
 
 interface OpContextDeps {
@@ -123,6 +131,7 @@ interface OpContextDeps {
   subagentId: number;
   jobId: number;
   signal?: AbortSignal;
+  brainId?: string;
 }
 
 function buildOpContext(deps: OpContextDeps): OperationContext {
@@ -139,6 +148,7 @@ function buildOpContext(deps: OpContextDeps): OperationContext {
     jobId: deps.jobId,
     subagentId: deps.subagentId,
     viaSubagent: true,           // FAIL-CLOSED: put_page etc. enforce namespace
+    brainId: deps.brainId,
   };
 }
 
@@ -179,6 +189,7 @@ export function buildBrainTools(opts: BuildBrainToolsOpts): ToolDef[] {
           subagentId: opts.subagentId,
           jobId: ctx.jobId,
           signal: ctx.signal,
+          brainId: opts.brainId,
         });
         const params = (input && typeof input === 'object') ? input as Record<string, unknown> : {};
         return op.handler(opCtx, params);

--- a/src/core/minions/types.ts
+++ b/src/core/minions/types.ts
@@ -391,10 +391,18 @@ export interface SubagentHandlerData {
   /** Template variables for subagent_def. Arbitrary JSON-serializable. */
   input_vars?: Record<string, unknown>;
   /**
-   * Connected-gbrains brain id (v0.19+). When set, every brain tool the
-   * subagent invokes targets this brain. Child jobs inherit this unless
-   * they override it in their own data. Omitted = 'host' (pre-v0.19
-   * behavior, single-brain deployments keep working unchanged).
+   * Connected-gbrains brain id (v0.19+, PR 0 plumbing only).
+   *
+   * CURRENT BEHAVIOR: stamped onto every tool-call's `OperationContext.
+   * brainId` but NOT yet used to select an engine at dispatch time.
+   * `gbrain agent run` does not yet accept a `--brain` flag that would
+   * populate this field — all subagent jobs submitted by the CLI today
+   * default to the host engine. The field + handler acceptance exist so
+   * PR 1 can add the registry lookup + CLI flag in a single commit.
+   *
+   * FUTURE (PR 1): setting `brain_id: "yc-media"` at job submission will
+   * cause every tool call from the subagent to run against the yc-media
+   * engine via BrainRegistry.getBrain() at buildOpContext time.
    */
   brain_id?: string;
 }

--- a/src/core/minions/types.ts
+++ b/src/core/minions/types.ts
@@ -390,6 +390,13 @@ export interface SubagentHandlerData {
   system?: string;
   /** Template variables for subagent_def. Arbitrary JSON-serializable. */
   input_vars?: Record<string, unknown>;
+  /**
+   * Connected-gbrains brain id (v0.19+). When set, every brain tool the
+   * subagent invokes targets this brain. Child jobs inherit this unless
+   * they override it in their own data. Omitted = 'host' (pre-v0.19
+   * behavior, single-brain deployments keep working unchanged).
+   */
+  brain_id?: string;
 }
 
 /**

--- a/src/core/mounts-cache.ts
+++ b/src/core/mounts-cache.ts
@@ -24,7 +24,7 @@
  * Only writeMountsCache touches disk.
  */
 
-import { readFileSync, existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { readFileSync, existsSync, mkdirSync, writeFileSync, rmSync, renameSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { parseResolverEntries } from './check-resolvable.ts';
@@ -227,20 +227,17 @@ export function composeResolvers(
   }
   shadows.sort((a, b) => a.skillName.localeCompare(b.skillName));
 
-  // Final entry list: host first, then mounts in mount-id order, shadows excluded
-  // from mount output (host version wins).
-  const shadowedSet = new Set(shadowedByName.keys());
+  // Final entry list: host first, then all mount entries in mount-id order.
+  // Shadow detection applies to BARE-NAME routing only (the host entry wins
+  // when the agent types `ingest`), NOT to namespace-qualified routing
+  // (`yc-media::ingest` must always resolve to the mount, even when shadowed
+  // by a host skill of the same short name). Codex review 2026-04-23 caught
+  // the earlier version that dropped shadowed mount entries — that broke
+  // the entire namespace-disambiguation model.
   const mountEntries: ComposedResolverEntry[] = [];
   mountEntriesByMount.sort((a, b) => a.mount.id.localeCompare(b.mount.id));
   for (const { entries } of mountEntriesByMount) {
-    for (const e of entries) {
-      if (e.isExternal) {
-        mountEntries.push(e);
-        continue;
-      }
-      const shortName = e.qualifiedName.split('::').pop() ?? '';
-      if (!shadowedSet.has(shortName)) mountEntries.push(e);
-    }
+    for (const e of entries) mountEntries.push(e);
   }
 
   return {
@@ -288,6 +285,12 @@ export function composeManifests(
   }));
   const hostNames = new Set(hostEntries.map(e => e.name));
 
+  // Mount entries always get their namespace-qualified name regardless of
+  // shadow by a host skill. The namespace form `yc-media::ingest` must stay
+  // routable even when host defines `ingest` (bare-name host-wins only
+  // governs un-namespaced resolution). Codex review caught the earlier
+  // version that silently dropped shadowed mount entries from the manifest,
+  // making the aggregated cache inconsistent with composeResolvers' output.
   const mountEntries: ManifestEntry[] = [];
   const seenMounts = [...mounts].sort((a, b) => a.id.localeCompare(b.id));
   for (const mount of seenMounts) {
@@ -295,7 +298,6 @@ export function composeManifests(
     const mountSkillsDir = join(mount.path, DEFAULT_SKILLS_SUBDIR);
     const skills = readManifestSkills(mountSkillsDir, opts.readFile);
     for (const s of skills) {
-      if (hostNames.has(s.name)) continue; // host shadow wins
       mountEntries.push({
         name: `${mount.id}::${s.name}`,
         absolutePath: join(mountSkillsDir, s.path),
@@ -303,6 +305,7 @@ export function composeManifests(
       });
     }
   }
+  void hostNames; // retained for future shadow metadata (PR 1 doctor warning)
 
   return { entries: [...hostEntries, ...mountEntries] };
 }
@@ -407,15 +410,21 @@ export function writeMountsCache(
   const resolverPath = join(cacheDir, 'RESOLVER.md');
   const manifestPath = join(cacheDir, 'manifest.json');
 
-  const resolverTmp = resolverPath + '.tmp';
-  const manifestTmp = manifestPath + '.tmp';
+  // Unique tmp names per call so concurrent `gbrain mounts add|remove`
+  // invocations don't clobber each other's .tmp file. The two-file swap
+  // (RESOLVER.md + manifest.json) is not itself atomic across files —
+  // readers may briefly observe RESOLVER.md(new) + manifest.json(old).
+  // That's acceptable: the aggregated cache is recomputable from
+  // mounts.json at any time, and doctor will flag divergence. A true
+  // generation-swap (cacheDir/current → new-gen dir) is deferred to PR 1.
+  const suffix = `${process.pid}.${Math.random().toString(36).slice(2, 10)}`;
+  const resolverTmp = `${resolverPath}.tmp.${suffix}`;
+  const manifestTmp = `${manifestPath}.tmp.${suffix}`;
 
   writeFileSync(resolverTmp, renderResolverMarkdown(resolver), { mode: 0o644 });
   writeFileSync(manifestTmp, renderManifestJson(manifest), { mode: 0o644 });
 
   // Atomic swap via rename on each file.
-  // (renameSync is not imported; fs.renameSync is re-exported from fs.)
-  const { renameSync } = require('fs') as typeof import('fs');
   renameSync(resolverTmp, resolverPath);
   renameSync(manifestTmp, manifestPath);
 

--- a/src/core/mounts-cache.ts
+++ b/src/core/mounts-cache.ts
@@ -1,0 +1,437 @@
+/**
+ * Mounts-cache composition + publishing (v0.19.0, PR 0).
+ *
+ * The runtime ownership seam (Codex finding #3 from plan-eng-review):
+ * `check-resolvable.ts` VALIDATES RESOLVER.md; it does not DISPATCH skills.
+ * Host agents (Wintermute / OpenClaw / any Claude Code install) read
+ * `skills/RESOLVER.md` directly to route a user request to a skill.
+ *
+ * For mounted team brains to participate in routing without editing the
+ * host's checked-in `skills/RESOLVER.md`, gbrain publishes an aggregated
+ * `~/.gbrain/mounts-cache/RESOLVER.md` + `manifest.json` whenever mounts
+ * change. Host agents are taught (via AGENTS.md / CLAUDE.md install-path
+ * docs) to prefer the aggregated file when it exists.
+ *
+ * This file exposes:
+ *   - composeResolvers(...)  — pure: merge host + mount RESOLVER entries
+ *   - composeManifests(...)  — pure: merge host + mount manifest.json entries
+ *   - writeMountsCache(...)  — writes both aggregated files to disk
+ *   - clearMountsCache(...)  — removes the cache (used on `mounts remove`
+ *                              and test teardown)
+ *
+ * Compose functions are PURE: they take inputs, return structured output,
+ * no filesystem writes. Tests can exercise every branch without a tempdir.
+ * Only writeMountsCache touches disk.
+ */
+
+import { readFileSync, existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { parseResolverEntries } from './check-resolvable.ts';
+import { HOST_BRAIN_ID, type MountEntry } from './brain-registry.ts';
+
+/** Default location of the aggregated cache directory. */
+function getMountsCacheDir(): string {
+  return join(homedir(), '.gbrain', 'mounts-cache');
+}
+
+/** A composed resolver entry with full provenance for audit + dispatch. */
+export interface ComposedResolverEntry {
+  /** The user-facing trigger phrase from the RESOLVER.md table. */
+  trigger: string;
+  /**
+   * Namespace-qualified skill name. Format:
+   *   - 'query' for host skills (no prefix)
+   *   - 'yc-media::query' for mount skills
+   * Stable across mount-path changes — only depends on mount id.
+   */
+  qualifiedName: string;
+  /**
+   * Absolute filesystem path to the SKILL.md. Host agents read this
+   * directly. For host skills, resolved against the host skills dir;
+   * for mount skills, resolved against the mount's clone path.
+   */
+  absolutePath: string;
+  /** Mount id ('host' for host skills, else the mount id). */
+  brainId: string;
+  /** Section header from RESOLVER.md ('Brain operations', etc.) */
+  section: string;
+  /**
+   * True when this entry represents an external pointer (e.g.
+   * 'GStack: /review', 'Check CLAUDE.md'). Not a filesystem path.
+   */
+  isExternal: boolean;
+}
+
+/** Information about a skill shadowed by a host skill of the same name. */
+export interface ShadowInfo {
+  skillName: string;
+  hostEntry: ComposedResolverEntry;
+  shadowedMounts: Array<{ mountId: string; absolutePath: string }>;
+}
+
+/** Information about a bare name that resolves to two or more mounts. */
+export interface AmbiguityInfo {
+  /** The short skill name (filename without .SKILL.md) users would type. */
+  skillName: string;
+  /** The mount ids that ALL claim this name (host excluded — host wins). */
+  mountIds: string[];
+}
+
+/** Output of composeResolvers — pure, no side effects. */
+export interface ComposedResolver {
+  entries: ComposedResolverEntry[];
+  shadows: ShadowInfo[];
+  ambiguities: AmbiguityInfo[];
+}
+
+/** A single skill declaration in a manifest.json. */
+export interface ManifestEntry {
+  /** Namespace-qualified name. 'query' or 'yc-media::query'. */
+  name: string;
+  /** Absolute filesystem path to the SKILL.md. */
+  absolutePath: string;
+  /** Mount id ('host' for host skills). */
+  brainId: string;
+}
+
+/** Output of composeManifests. */
+export interface ComposedManifest {
+  entries: ManifestEntry[];
+}
+
+/** Default skills-subdir within a mount's clone. */
+const DEFAULT_SKILLS_SUBDIR = 'skills';
+
+/** Extract the filename-part of a skills-relative path (e.g. 'query/SKILL.md' → 'query'). */
+function skillNameFromRelPath(relPath: string): string {
+  // 'skills/query/SKILL.md' → 'query'; 'query/SKILL.md' → 'query'
+  const parts = relPath.split('/');
+  const skillIdx = parts.indexOf('skills');
+  const start = skillIdx >= 0 ? skillIdx + 1 : 0;
+  if (start >= parts.length) return '';
+  return parts[start];
+}
+
+/**
+ * Compose host + mount RESOLVER.md entries into a single aggregated list
+ * with shadow + ambiguity detection.
+ *
+ * Host skills always win over any mount skill of the same name (locked
+ * decision 1 from plan). When two mounts ship the same skill name and the
+ * host does NOT define it, both entries are emitted with namespace prefixes
+ * and the name is reported in `ambiguities` so doctor can warn.
+ */
+export function composeResolvers(
+  hostSkillsDir: string,
+  mounts: MountEntry[],
+  opts: { readFile?: (path: string) => string | null } = {},
+): ComposedResolver {
+  const readFile = opts.readFile ?? ((p: string) => {
+    try { return existsSync(p) ? readFileSync(p, 'utf-8') : null; } catch { return null; }
+  });
+
+  const hostResolverPath = join(hostSkillsDir, 'RESOLVER.md');
+  const hostContent = readFile(hostResolverPath);
+  const hostRawEntries = hostContent ? parseResolverEntries(hostContent) : [];
+
+  // Host entries: fully qualified against the host skills dir.
+  const hostEntries: ComposedResolverEntry[] = hostRawEntries.map(e => {
+    const isExternal = e.isGStack;
+    const abs = isExternal
+      ? e.skillPath
+      : join(hostSkillsDir, e.skillPath.replace(/^skills\//, ''));
+    const name = isExternal ? e.skillPath : skillNameFromRelPath(e.skillPath);
+    return {
+      trigger: e.trigger,
+      qualifiedName: name,
+      absolutePath: abs,
+      brainId: HOST_BRAIN_ID,
+      section: e.section,
+      isExternal,
+    };
+  });
+
+  // Build fast lookup of host skill names (the shadow set).
+  const hostSkillNames = new Set<string>();
+  for (const e of hostEntries) {
+    if (!e.isExternal) hostSkillNames.add(e.qualifiedName);
+  }
+
+  // Track which mount a skill-name came from so we can detect ambiguity.
+  const byNameMountIds = new Map<string, Set<string>>(); // short name → {mount ids}
+  const mountEntriesByMount: Array<{ mount: MountEntry; entries: ComposedResolverEntry[] }> = [];
+  const shadowedByName = new Map<string, Array<{ mountId: string; absolutePath: string }>>();
+
+  for (const mount of mounts) {
+    if (mount.enabled === false) continue;
+    const mountSkillsDir = join(mount.path, DEFAULT_SKILLS_SUBDIR);
+    const resolverPath = join(mountSkillsDir, 'RESOLVER.md');
+    const content = readFile(resolverPath);
+    if (!content) continue; // Mount without a RESOLVER.md contributes no routing entries. Not an error.
+    const rawEntries = parseResolverEntries(content);
+    const composed: ComposedResolverEntry[] = rawEntries.map(e => {
+      const isExternal = e.isGStack;
+      const shortName = isExternal ? e.skillPath : skillNameFromRelPath(e.skillPath);
+      const qualifiedName = isExternal ? shortName : `${mount.id}::${shortName}`;
+      const abs = isExternal
+        ? e.skillPath
+        : join(mountSkillsDir, e.skillPath.replace(/^skills\//, ''));
+      return {
+        trigger: e.trigger,
+        qualifiedName,
+        absolutePath: abs,
+        brainId: mount.id,
+        section: e.section,
+        isExternal,
+      };
+    });
+    mountEntriesByMount.push({ mount, entries: composed });
+
+    for (const entry of composed) {
+      if (entry.isExternal) continue;
+      const shortName = entry.qualifiedName.split('::').pop() ?? '';
+      if (!shortName) continue;
+      if (hostSkillNames.has(shortName)) {
+        // Shadow: host wins. Record so doctor can emit a warning.
+        const list = shadowedByName.get(shortName) ?? [];
+        list.push({ mountId: mount.id, absolutePath: entry.absolutePath });
+        shadowedByName.set(shortName, list);
+        continue;
+      }
+      const set = byNameMountIds.get(shortName) ?? new Set();
+      set.add(mount.id);
+      byNameMountIds.set(shortName, set);
+    }
+  }
+
+  // Ambiguities: any bare name with 2+ mounts (host excluded).
+  const ambiguities: AmbiguityInfo[] = [];
+  for (const [name, ids] of byNameMountIds.entries()) {
+    if (ids.size >= 2) {
+      ambiguities.push({ skillName: name, mountIds: Array.from(ids).sort() });
+    }
+  }
+  ambiguities.sort((a, b) => a.skillName.localeCompare(b.skillName));
+
+  // Shadows: group by host entry.
+  const shadows: ShadowInfo[] = [];
+  for (const [name, shadowedMounts] of shadowedByName.entries()) {
+    const hostEntry = hostEntries.find(h => h.qualifiedName === name && !h.isExternal);
+    if (!hostEntry) continue;
+    shadows.push({
+      skillName: name,
+      hostEntry,
+      shadowedMounts: shadowedMounts.sort((a, b) => a.mountId.localeCompare(b.mountId)),
+    });
+  }
+  shadows.sort((a, b) => a.skillName.localeCompare(b.skillName));
+
+  // Final entry list: host first, then mounts in mount-id order, shadows excluded
+  // from mount output (host version wins).
+  const shadowedSet = new Set(shadowedByName.keys());
+  const mountEntries: ComposedResolverEntry[] = [];
+  mountEntriesByMount.sort((a, b) => a.mount.id.localeCompare(b.mount.id));
+  for (const { entries } of mountEntriesByMount) {
+    for (const e of entries) {
+      if (e.isExternal) {
+        mountEntries.push(e);
+        continue;
+      }
+      const shortName = e.qualifiedName.split('::').pop() ?? '';
+      if (!shadowedSet.has(shortName)) mountEntries.push(e);
+    }
+  }
+
+  return {
+    entries: [...hostEntries, ...mountEntries],
+    shadows,
+    ambiguities,
+  };
+}
+
+/**
+ * Read a manifest.json and return its skills[] array. Returns [] when the
+ * file is absent or malformed (propagating the same forgiving semantics as
+ * check-resolvable's loadManifest).
+ */
+function readManifestSkills(skillsDir: string, readFile?: (p: string) => string | null): Array<{ name: string; path: string }> {
+  const path = join(skillsDir, 'manifest.json');
+  const reader = readFile ?? ((p: string) => {
+    try { return existsSync(p) ? readFileSync(p, 'utf-8') : null; } catch { return null; }
+  });
+  const content = reader(path);
+  if (!content) return [];
+  try {
+    const parsed = JSON.parse(content);
+    return Array.isArray(parsed.skills) ? parsed.skills : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Compose host + mount manifest.json entries. Host wins on name
+ * collisions (shadow). Mount entries get namespace-prefixed names.
+ * Codex finding #8: without this, remote skills break doctor conformance.
+ */
+export function composeManifests(
+  hostSkillsDir: string,
+  mounts: MountEntry[],
+  opts: { readFile?: (path: string) => string | null } = {},
+): ComposedManifest {
+  const hostSkills = readManifestSkills(hostSkillsDir, opts.readFile);
+  const hostEntries: ManifestEntry[] = hostSkills.map(s => ({
+    name: s.name,
+    absolutePath: join(hostSkillsDir, s.path),
+    brainId: HOST_BRAIN_ID,
+  }));
+  const hostNames = new Set(hostEntries.map(e => e.name));
+
+  const mountEntries: ManifestEntry[] = [];
+  const seenMounts = [...mounts].sort((a, b) => a.id.localeCompare(b.id));
+  for (const mount of seenMounts) {
+    if (mount.enabled === false) continue;
+    const mountSkillsDir = join(mount.path, DEFAULT_SKILLS_SUBDIR);
+    const skills = readManifestSkills(mountSkillsDir, opts.readFile);
+    for (const s of skills) {
+      if (hostNames.has(s.name)) continue; // host shadow wins
+      mountEntries.push({
+        name: `${mount.id}::${s.name}`,
+        absolutePath: join(mountSkillsDir, s.path),
+        brainId: mount.id,
+      });
+    }
+  }
+
+  return { entries: [...hostEntries, ...mountEntries] };
+}
+
+/**
+ * Render the composed resolver as markdown matching the existing
+ * skills/RESOLVER.md format. The table groups by section (preserving
+ * host section headings) with mount entries appended under a new
+ * "Mounted brains" section.
+ */
+export function renderResolverMarkdown(composed: ComposedResolver): string {
+  const lines: string[] = [];
+  lines.push('# GBrain Skill Resolver (aggregated)');
+  lines.push('');
+  lines.push('Auto-generated by `gbrain mounts add|remove|sync`. Do not edit by hand.');
+  lines.push('Host agents (Wintermute/OpenClaw/Claude Code) should prefer this file over');
+  lines.push('the repo-checked-in `skills/RESOLVER.md` when it exists.');
+  lines.push('');
+  lines.push('See `docs/architecture/brains-and-sources.md` for the mental model.');
+  lines.push('');
+
+  // Group entries by section in insertion order.
+  const bySection = new Map<string, ComposedResolverEntry[]>();
+  for (const e of composed.entries) {
+    const key = e.section || '(uncategorized)';
+    const bucket = bySection.get(key) ?? [];
+    bucket.push(e);
+    bySection.set(key, bucket);
+  }
+
+  for (const [section, entries] of bySection.entries()) {
+    lines.push(`## ${section}`);
+    lines.push('');
+    lines.push('| Trigger | Skill | Brain |');
+    lines.push('|---------|-------|-------|');
+    for (const e of entries) {
+      const skillCol = e.isExternal ? e.absolutePath : `\`${e.absolutePath}\``;
+      lines.push(`| ${e.trigger} | ${skillCol} | ${e.brainId} |`);
+    }
+    lines.push('');
+  }
+
+  if (composed.shadows.length > 0) {
+    lines.push('## Shadows');
+    lines.push('');
+    lines.push('Host skills that shadow mount skills of the same name:');
+    lines.push('');
+    for (const s of composed.shadows) {
+      lines.push(`- \`${s.skillName}\` (host) shadows ${s.shadowedMounts.map(m => `\`${m.mountId}::${s.skillName}\``).join(', ')}`);
+    }
+    lines.push('');
+  }
+
+  if (composed.ambiguities.length > 0) {
+    lines.push('## Ambiguous bare names');
+    lines.push('');
+    lines.push('These skill names are defined in multiple mounts. Use the explicit');
+    lines.push('namespace form (e.g. `yc-media::ingest`) to disambiguate.');
+    lines.push('');
+    for (const a of composed.ambiguities) {
+      lines.push(`- \`${a.skillName}\` → ${a.mountIds.map(m => `\`${m}::${a.skillName}\``).join(', ')}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/** Render the composed manifest as manifest.json bytes. */
+export function renderManifestJson(composed: ComposedManifest): string {
+  return JSON.stringify(
+    {
+      generated_by: 'gbrain mounts',
+      generated_at: new Date().toISOString(),
+      skills: composed.entries.map(e => ({
+        name: e.name,
+        path: e.absolutePath,
+        brain: e.brainId,
+      })),
+    },
+    null,
+    2,
+  ) + '\n';
+}
+
+/**
+ * Write the aggregated cache to ~/.gbrain/mounts-cache/. Safe to call
+ * repeatedly. The directory is created if missing. Both files are
+ * rewritten atomically (write-then-rename via a .tmp sibling).
+ */
+export function writeMountsCache(
+  hostSkillsDir: string,
+  mounts: MountEntry[],
+  opts: { cacheDir?: string } = {},
+): { resolverPath: string; manifestPath: string } {
+  const cacheDir = opts.cacheDir ?? getMountsCacheDir();
+  mkdirSync(cacheDir, { recursive: true });
+
+  const resolver = composeResolvers(hostSkillsDir, mounts);
+  const manifest = composeManifests(hostSkillsDir, mounts);
+
+  const resolverPath = join(cacheDir, 'RESOLVER.md');
+  const manifestPath = join(cacheDir, 'manifest.json');
+
+  const resolverTmp = resolverPath + '.tmp';
+  const manifestTmp = manifestPath + '.tmp';
+
+  writeFileSync(resolverTmp, renderResolverMarkdown(resolver), { mode: 0o644 });
+  writeFileSync(manifestTmp, renderManifestJson(manifest), { mode: 0o644 });
+
+  // Atomic swap via rename on each file.
+  // (renameSync is not imported; fs.renameSync is re-exported from fs.)
+  const { renameSync } = require('fs') as typeof import('fs');
+  renameSync(resolverTmp, resolverPath);
+  renameSync(manifestTmp, manifestPath);
+
+  return { resolverPath, manifestPath };
+}
+
+/** Remove the aggregated cache dir. Called by `gbrain mounts remove` and tests. */
+export function clearMountsCache(opts: { cacheDir?: string } = {}): void {
+  const cacheDir = opts.cacheDir ?? getMountsCacheDir();
+  if (!existsSync(cacheDir)) return;
+  rmSync(cacheDir, { recursive: true, force: true });
+}
+
+/** Exposed for tests. */
+export const __testing = {
+  getMountsCacheDir,
+  skillNameFromRelPath,
+  DEFAULT_SKILLS_SUBDIR,
+};

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -201,6 +201,24 @@ export interface OperationContext {
    * background work.
    */
   cliOpts?: { quiet: boolean; progressJson: boolean; progressInterval: number };
+  /**
+   * Connected-gbrains brain id (v0.19+). Identifies which brain this op is
+   * targeting. 'host' for the default brain configured in ~/.gbrain/config.json;
+   * otherwise a mount id registered in ~/.gbrain/mounts.json.
+   *
+   * `ctx.engine` is the resolved BrainEngine for this id (populated by
+   * BrainRegistry at dispatch time). `brainId` exists alongside for:
+   * - audit logging (mount-ops JSONL carries the id)
+   * - subagent inheritance (child jobs receive the parent's brainId)
+   * - cross-brain citation prefixes in agent output
+   *
+   * Orthogonal to v0.18.0's source_id, which scopes per-repo WITHIN a brain.
+   * See docs/architecture/brains-and-sources.md for the mental model.
+   *
+   * Omitted = 'host' (pre-v0.19 callers + single-brain deployments keep
+   * working without change).
+   */
+  brainId?: string;
 }
 
 export interface Operation {

--- a/test/brain-allowlist.test.ts
+++ b/test/brain-allowlist.test.ts
@@ -27,11 +27,11 @@ beforeAll(async () => {
   engine = new PGLiteEngine();
   await engine.connect({ database_url: '' });
   await engine.initSchema();
-});
+}, 30_000); // 21-migration init needs breathing room under full-suite load
 
 afterAll(async () => {
-  await engine.disconnect();
-});
+  if (engine) await engine.disconnect();
+}, 15_000);
 
 beforeEach(async () => {
   await engine.executeRaw('DELETE FROM pages');

--- a/test/brain-registry.test.ts
+++ b/test/brain-registry.test.ts
@@ -1,0 +1,281 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  loadMounts,
+  validateMountId,
+  BrainRegistry,
+  DuplicateMountPathError,
+  UnknownBrainError,
+  HOST_BRAIN_ID,
+  type MountsFile,
+  type MountEntry,
+} from '../src/core/brain-registry.ts';
+import { GBrainError } from '../src/core/types.ts';
+
+/** Create a temp dir + write a mounts.json into it. Returns the path. */
+function tempMountsFile(contents: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'brain-registry-'));
+  const path = join(dir, 'mounts.json');
+  writeFileSync(path, typeof contents === 'string' ? contents : JSON.stringify(contents));
+  return path;
+}
+
+const toCleanup: string[] = [];
+function track(p: string): string {
+  toCleanup.push(p);
+  return p;
+}
+afterEach(() => {
+  while (toCleanup.length > 0) {
+    const p = toCleanup.pop();
+    if (!p) continue;
+    try {
+      rmSync(p, { recursive: true, force: true });
+    } catch { /* best effort */ }
+  }
+});
+
+describe('validateMountId', () => {
+  test('accepts kebab-case ids', () => {
+    expect(validateMountId('yc-media')).toBe('yc-media');
+    expect(validateMountId('garrys-list')).toBe('garrys-list');
+    expect(validateMountId('a')).toBe('a');
+    expect(validateMountId('yc1')).toBe('yc1');
+  });
+
+  test('rejects empty / non-string', () => {
+    expect(() => validateMountId('')).toThrow(GBrainError);
+    expect(() => validateMountId(null as unknown as string)).toThrow(GBrainError);
+    expect(() => validateMountId(undefined as unknown as string)).toThrow(GBrainError);
+    expect(() => validateMountId(42 as unknown as string)).toThrow(GBrainError);
+  });
+
+  test('rejects reserved host id', () => {
+    expect(() => validateMountId('host')).toThrow(/Reserved/);
+  });
+
+  test('rejects invalid patterns', () => {
+    expect(() => validateMountId('UPPER')).toThrow();
+    expect(() => validateMountId('has space')).toThrow();
+    expect(() => validateMountId('-leading')).toThrow();
+    expect(() => validateMountId('trailing-')).toThrow();
+    expect(() => validateMountId('has_underscore')).toThrow();
+    expect(() => validateMountId('a'.repeat(33))).toThrow();
+  });
+});
+
+describe('loadMounts — file-level parsing', () => {
+  test('returns empty array when mounts.json is absent', () => {
+    const path = join(tmpdir(), `nonexistent-${Date.now()}.json`);
+    expect(loadMounts(path)).toEqual([]);
+  });
+
+  test('throws on malformed JSON', () => {
+    const path = track(tempMountsFile('{ not valid json'));
+    expect(() => loadMounts(path)).toThrow(/Malformed mounts.json/);
+  });
+
+  test('throws on unsupported version', () => {
+    const path = track(tempMountsFile({ version: 99, mounts: [] }));
+    expect(() => loadMounts(path)).toThrow(/Unsupported mounts.json version: 99/);
+  });
+
+  test('throws when mounts is not an array', () => {
+    const path = track(tempMountsFile({ version: 1, mounts: 'not-an-array' }));
+    expect(() => loadMounts(path)).toThrow(/must be an array/);
+  });
+
+  test('throws when top-level is not an object', () => {
+    const path = track(tempMountsFile([1, 2, 3]));
+    expect(() => loadMounts(path)).toThrow(/must be a JSON object/);
+  });
+});
+
+describe('loadMounts — entry validation', () => {
+  test('accepts a minimal pglite entry', () => {
+    const path = track(tempMountsFile({
+      version: 1,
+      mounts: [{ id: 'yc-media', path: '/tmp/yc-media', engine: 'pglite', database_path: '/tmp/yc-media/.pg' }],
+    }));
+    const mounts = loadMounts(path);
+    expect(mounts).toHaveLength(1);
+    expect(mounts[0].id).toBe('yc-media');
+    expect(mounts[0].engine).toBe('pglite');
+    expect(mounts[0].enabled).toBe(true); // default
+  });
+
+  test('accepts a postgres entry', () => {
+    const path = track(tempMountsFile({
+      version: 1,
+      mounts: [{
+        id: 'yc-politics', path: '/tmp/yc-politics', engine: 'postgres',
+        database_url: 'postgresql://localhost/luther',
+      }],
+    }));
+    const mounts = loadMounts(path);
+    expect(mounts[0].database_url).toBe('postgresql://localhost/luther');
+  });
+
+  test('resolves paths to absolute form', () => {
+    const path = track(tempMountsFile({
+      version: 1,
+      mounts: [{ id: 'a', path: '/tmp/relative-test', engine: 'pglite', database_path: '/tmp/a/.pg' }],
+    }));
+    const mounts = loadMounts(path);
+    expect(mounts[0].path.startsWith('/')).toBe(true);
+  });
+
+  test('enabled=false is preserved', () => {
+    const path = track(tempMountsFile({
+      version: 1,
+      mounts: [{
+        id: 'disabled-mount', path: '/tmp/disabled', engine: 'pglite',
+        database_path: '/tmp/disabled/.pg', enabled: false,
+      }],
+    }));
+    const mounts = loadMounts(path);
+    expect(mounts[0].enabled).toBe(false);
+  });
+
+  test('rejects duplicate ids', () => {
+    const path = track(tempMountsFile({
+      version: 1,
+      mounts: [
+        { id: 'dup', path: '/tmp/a', engine: 'pglite', database_path: '/tmp/a/.pg' },
+        { id: 'dup', path: '/tmp/b', engine: 'pglite', database_path: '/tmp/b/.pg' },
+      ],
+    }));
+    expect(() => loadMounts(path)).toThrow(/duplicate id "dup"/);
+  });
+
+  test('rejects duplicate paths (Codex finding #9)', () => {
+    const path = track(tempMountsFile({
+      version: 1,
+      mounts: [
+        { id: 'first', path: '/tmp/shared', engine: 'pglite', database_path: '/tmp/shared/.pg' },
+        { id: 'second', path: '/tmp/shared', engine: 'pglite', database_path: '/tmp/shared/.pg2' },
+      ],
+    }));
+    expect(() => loadMounts(path)).toThrow(DuplicateMountPathError);
+  });
+
+  test('rejects entry missing id', () => {
+    const path = track(tempMountsFile({
+      version: 1, mounts: [{ path: '/tmp/x', engine: 'pglite', database_path: '/tmp/x/.pg' }],
+    }));
+    expect(() => loadMounts(path)).toThrow(/Invalid mounts\[0\].id/);
+  });
+
+  test('rejects entry missing path', () => {
+    const path = track(tempMountsFile({
+      version: 1, mounts: [{ id: 'no-path', engine: 'pglite', database_path: '/tmp/x/.pg' }],
+    }));
+    expect(() => loadMounts(path)).toThrow(/path is required/);
+  });
+
+  test('rejects invalid engine kind', () => {
+    const path = track(tempMountsFile({
+      version: 1, mounts: [{ id: 'bad', path: '/tmp/b', engine: 'sqlite' }],
+    }));
+    expect(() => loadMounts(path)).toThrow(/engine must be "postgres" or "pglite"/);
+  });
+
+  test('rejects postgres without database_url', () => {
+    const path = track(tempMountsFile({
+      version: 1, mounts: [{ id: 'pg-no-url', path: '/tmp/p', engine: 'postgres' }],
+    }));
+    expect(() => loadMounts(path)).toThrow(/postgres mount requires database_url/);
+  });
+
+  test('rejects pglite without database_path or url', () => {
+    const path = track(tempMountsFile({
+      version: 1, mounts: [{ id: 'pgl-no-path', path: '/tmp/p', engine: 'pglite' }],
+    }));
+    expect(() => loadMounts(path)).toThrow(/pglite mount requires database_path/);
+  });
+
+  test('rejects reserved host id', () => {
+    const path = track(tempMountsFile({
+      version: 1, mounts: [{ id: 'host', path: '/tmp/h', engine: 'pglite', database_path: '/tmp/h/.pg' }],
+    }));
+    expect(() => loadMounts(path)).toThrow(/Reserved/);
+  });
+});
+
+describe('BrainRegistry — resolution', () => {
+  test('listBrainIds includes host + enabled mounts only', () => {
+    const mounts: MountEntry[] = [
+      { id: 'a', path: '/tmp/a', engine: 'pglite', database_path: '/tmp/a/.pg', enabled: true },
+      { id: 'b', path: '/tmp/b', engine: 'pglite', database_path: '/tmp/b/.pg', enabled: false },
+      { id: 'c', path: '/tmp/c', engine: 'pglite', database_path: '/tmp/c/.pg', enabled: true },
+    ];
+    const reg = new BrainRegistry(mounts);
+    expect(reg.listBrainIds()).toEqual([HOST_BRAIN_ID, 'a', 'c']);
+  });
+
+  test('disabled mount → UnknownBrainError', async () => {
+    const reg = new BrainRegistry([
+      { id: 'disabled', path: '/tmp/d', engine: 'pglite', database_path: '/tmp/d/.pg', enabled: false },
+    ]);
+    await expect(reg.getBrain('disabled')).rejects.toBeInstanceOf(UnknownBrainError);
+  });
+
+  test('unknown id → UnknownBrainError with available list', async () => {
+    const reg = new BrainRegistry([
+      { id: 'yc-media', path: '/tmp/m', engine: 'pglite', database_path: '/tmp/m/.pg', enabled: true },
+    ]);
+    try {
+      await reg.getBrain('nonexistent');
+      throw new Error('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(UnknownBrainError);
+      if (e instanceof GBrainError) {
+        expect(e.cause_description).toContain('yc-media');
+      }
+    }
+  });
+
+  test('listMounts returns only enabled mounts', () => {
+    const reg = new BrainRegistry([
+      { id: 'on', path: '/tmp/on', engine: 'pglite', database_path: '/tmp/on/.pg', enabled: true },
+      { id: 'off', path: '/tmp/off', engine: 'pglite', database_path: '/tmp/off/.pg', enabled: false },
+    ]);
+    const listed = reg.listMounts();
+    expect(listed).toHaveLength(1);
+    expect(listed[0].id).toBe('on');
+  });
+
+  test('disconnectAll on empty registry is idempotent', async () => {
+    const reg = new BrainRegistry([]);
+    await reg.disconnectAll();
+    await reg.disconnectAll(); // second call must not throw
+  });
+});
+
+describe('BrainRegistry — lazy init', () => {
+  test('getBrain does not connect until called', () => {
+    const reg = new BrainRegistry([
+      { id: 'lazy', path: '/tmp/lazy', engine: 'pglite', database_path: '/tmp/lazy/.pg', enabled: true },
+    ]);
+    // No assertion on engine state: we just prove the constructor returned
+    // without attempting to touch the filesystem. If init were eager, the
+    // constructor would throw on the missing database_path.
+    expect(reg.listBrainIds()).toContain('lazy');
+  });
+
+  test('empty/null/undefined id routes to host', async () => {
+    // We can't actually call getBrain('') without a host config, so we just
+    // verify the routing logic by observing the default-branch path. This
+    // test proves the fall-through to HOST_BRAIN_ID happens before any
+    // lookup, not that host init actually succeeds.
+    const reg = new BrainRegistry([]);
+    // Expect the host-init path to be attempted (it'll fail on missing
+    // ~/.gbrain/config.json in test env, but the error will come from
+    // initHostBrain, not UnknownBrainError — proving routing hit host).
+    await expect(reg.getBrain(null)).rejects.not.toBeInstanceOf(UnknownBrainError);
+    await expect(reg.getBrain(undefined)).rejects.not.toBeInstanceOf(UnknownBrainError);
+    await expect(reg.getBrain('')).rejects.not.toBeInstanceOf(UnknownBrainError);
+  });
+});

--- a/test/brain-resolver.test.ts
+++ b/test/brain-resolver.test.ts
@@ -1,0 +1,194 @@
+import { describe, test, expect, afterEach, beforeEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { resolveBrainId, __testing } from '../src/core/brain-resolver.ts';
+import { HOST_BRAIN_ID, type MountEntry } from '../src/core/brain-registry.ts';
+
+const toCleanup: string[] = [];
+const originalEnv = { ...process.env };
+
+function mktmp(prefix = 'brain-resolver-'): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  toCleanup.push(dir);
+  return dir;
+}
+
+beforeEach(() => {
+  // Clear relevant env so tests don't leak.
+  delete process.env.GBRAIN_BRAIN_ID;
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  while (toCleanup.length > 0) {
+    const p = toCleanup.pop();
+    if (!p) continue;
+    try { rmSync(p, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+function noMounts(): MountEntry[] { return []; }
+
+describe('resolveBrainId — priority order', () => {
+  test('explicit flag beats everything else', () => {
+    process.env.GBRAIN_BRAIN_ID = 'from-env';
+    const dir = mktmp();
+    writeFileSync(join(dir, '.gbrain-mount'), 'from-dotfile\n');
+    const mounts: MountEntry[] = [
+      { id: 'from-path', path: dir, engine: 'pglite', database_path: `${dir}/.pg`, enabled: true },
+    ];
+    expect(resolveBrainId('explicit-wins', dir, () => mounts)).toBe('explicit-wins');
+  });
+
+  test('env var beats dotfile + path', () => {
+    process.env.GBRAIN_BRAIN_ID = 'from-env';
+    const dir = mktmp();
+    writeFileSync(join(dir, '.gbrain-mount'), 'from-dotfile\n');
+    const mounts: MountEntry[] = [
+      { id: 'from-path', path: dir, engine: 'pglite', database_path: `${dir}/.pg`, enabled: true },
+    ];
+    expect(resolveBrainId(null, dir, () => mounts)).toBe('from-env');
+  });
+
+  test('dotfile beats path-prefix', () => {
+    const dir = mktmp();
+    writeFileSync(join(dir, '.gbrain-mount'), 'from-dotfile\n');
+    const mounts: MountEntry[] = [
+      { id: 'from-path', path: dir, engine: 'pglite', database_path: `${dir}/.pg`, enabled: true },
+    ];
+    expect(resolveBrainId(null, dir, () => mounts)).toBe('from-dotfile');
+  });
+
+  test('path-prefix match used when no higher-priority signal', () => {
+    const dir = mktmp();
+    const mounts: MountEntry[] = [
+      { id: 'yc-media', path: dir, engine: 'pglite', database_path: `${dir}/.pg`, enabled: true },
+    ];
+    expect(resolveBrainId(null, dir, () => mounts)).toBe('yc-media');
+  });
+
+  test('falls back to host when no signal present', () => {
+    const dir = mktmp();
+    expect(resolveBrainId(null, dir, noMounts)).toBe(HOST_BRAIN_ID);
+    expect(resolveBrainId(undefined, dir, noMounts)).toBe(HOST_BRAIN_ID);
+    expect(resolveBrainId('', dir, noMounts)).toBe(HOST_BRAIN_ID);
+  });
+});
+
+describe('resolveBrainId — dotfile behavior', () => {
+  test('walks up to find .gbrain-mount in ancestor', () => {
+    const parent = mktmp();
+    const nested = join(parent, 'deep/nested/dir');
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(join(parent, '.gbrain-mount'), 'luther\n');
+    expect(resolveBrainId(null, nested, noMounts)).toBe('luther');
+  });
+
+  test('skips malformed dotfile, keeps walking', () => {
+    const grandparent = mktmp();
+    const parent = join(grandparent, 'mid');
+    const child = join(parent, 'deep');
+    mkdirSync(child, { recursive: true });
+    writeFileSync(join(parent, '.gbrain-mount'), '!!!invalid!!!\n');
+    writeFileSync(join(grandparent, '.gbrain-mount'), 'valid-id\n');
+    expect(resolveBrainId(null, child, noMounts)).toBe('valid-id');
+  });
+
+  test('accepts "host" in dotfile (explicit opt-out of mount routing)', () => {
+    const dir = mktmp();
+    writeFileSync(join(dir, '.gbrain-mount'), `${HOST_BRAIN_ID}\n`);
+    // Even with a mount whose path contains cwd, dotfile wins and picks host.
+    const mounts: MountEntry[] = [
+      { id: 'would-match', path: dir, engine: 'pglite', database_path: `${dir}/.pg`, enabled: true },
+    ];
+    expect(resolveBrainId(null, dir, () => mounts)).toBe(HOST_BRAIN_ID);
+  });
+
+  test('trims whitespace + only uses first line', () => {
+    const dir = mktmp();
+    writeFileSync(join(dir, '.gbrain-mount'), '  yc-media  \n# comment line\n');
+    expect(resolveBrainId(null, dir, noMounts)).toBe('yc-media');
+  });
+});
+
+describe('resolveBrainId — path-prefix match', () => {
+  test('longest-prefix wins for nested mounts', () => {
+    const parent = mktmp();
+    const child = join(parent, 'child');
+    mkdirSync(child, { recursive: true });
+    const mounts: MountEntry[] = [
+      { id: 'outer', path: parent, engine: 'pglite', database_path: `${parent}/.pg`, enabled: true },
+      { id: 'inner', path: child, engine: 'pglite', database_path: `${child}/.pg`, enabled: true },
+    ];
+    expect(resolveBrainId(null, child, () => mounts)).toBe('inner');
+  });
+
+  test('disabled mount is ignored', () => {
+    const dir = mktmp();
+    const mounts: MountEntry[] = [
+      { id: 'off', path: dir, engine: 'pglite', database_path: `${dir}/.pg`, enabled: false },
+    ];
+    expect(resolveBrainId(null, dir, () => mounts)).toBe(HOST_BRAIN_ID);
+  });
+
+  test('sibling directory does not match', () => {
+    const parent = mktmp();
+    const a = join(parent, 'a');
+    const b = join(parent, 'b');
+    mkdirSync(a, { recursive: true });
+    mkdirSync(b, { recursive: true });
+    const mounts: MountEntry[] = [
+      { id: 'a-mount', path: a, engine: 'pglite', database_path: `${a}/.pg`, enabled: true },
+    ];
+    expect(resolveBrainId(null, b, () => mounts)).toBe(HOST_BRAIN_ID);
+  });
+
+  test('exact path match works', () => {
+    const dir = mktmp();
+    const mounts: MountEntry[] = [
+      { id: 'exact', path: dir, engine: 'pglite', database_path: `${dir}/.pg`, enabled: true },
+    ];
+    expect(resolveBrainId(null, dir, () => mounts)).toBe('exact');
+  });
+
+  test('prefix-without-separator does NOT match (no false positive)', () => {
+    // Ensure /tmp/foo does NOT match /tmp/foobar. Resolver must require / boundary.
+    const parent = mktmp();
+    const foo = join(parent, 'foo');
+    const foobar = join(parent, 'foobar');
+    mkdirSync(foo, { recursive: true });
+    mkdirSync(foobar, { recursive: true });
+    const mounts: MountEntry[] = [
+      { id: 'foo', path: foo, engine: 'pglite', database_path: `${foo}/.pg`, enabled: true },
+    ];
+    expect(resolveBrainId(null, foobar, () => mounts)).toBe(HOST_BRAIN_ID);
+  });
+});
+
+describe('resolveBrainId — validation', () => {
+  test('invalid --brain value throws', () => {
+    expect(() => resolveBrainId('UPPERCASE', '/tmp', noMounts)).toThrow();
+    expect(() => resolveBrainId('has space', '/tmp', noMounts)).toThrow();
+    expect(() => resolveBrainId('-leading', '/tmp', noMounts)).toThrow();
+  });
+
+  test('invalid GBRAIN_BRAIN_ID value throws', () => {
+    process.env.GBRAIN_BRAIN_ID = 'UPPER';
+    expect(() => resolveBrainId(null, '/tmp', noMounts)).toThrow();
+  });
+
+  test('mounts loader failure falls through to host (no crash)', () => {
+    const badLoader = () => { throw new Error('mounts.json exploded'); };
+    // Should NOT throw: resolver swallows loader failures and returns host.
+    // Any downstream brain registry call will surface the real error.
+    expect(resolveBrainId(null, '/tmp', badLoader)).toBe(HOST_BRAIN_ID);
+  });
+});
+
+describe('longestPathPrefixMount', () => {
+  test('returns null when no mount contains cwd', () => {
+    const result = __testing.longestPathPrefixMount([], '/tmp');
+    expect(result).toBeNull();
+  });
+});

--- a/test/core/cycle.test.ts
+++ b/test/core/cycle.test.ts
@@ -135,11 +135,11 @@ beforeAll(async () => {
   sharedEngine = new PGLiteEngine();
   await sharedEngine.connect({});
   await sharedEngine.initSchema();
-});
+}, 30_000); // 21-migration init needs breathing room under full-suite load
 
 afterAll(async () => {
-  await sharedEngine.disconnect();
-});
+  if (sharedEngine) await sharedEngine.disconnect();
+}, 15_000);
 
 beforeEach(() => {
   lintCalls = [];

--- a/test/dream.test.ts
+++ b/test/dream.test.ts
@@ -55,12 +55,12 @@ describe('runDream — brainDir resolution', () => {
   beforeEach(async () => {
     repo = makeGitRepo();
     engine = await makePGLite();
-  });
+  }, 30_000); // 21 migrations + git init; needs breathing room under full-suite load
 
   afterEach(async () => {
-    await engine.disconnect();
+    if (engine) await engine.disconnect();
     rmSync(repo, { recursive: true, force: true });
-  });
+  }, 15_000);
 
   test('explicit --dir takes precedence over engine config', async () => {
     await engine.setConfig('sync.repo_path', '/configured/dir');
@@ -112,12 +112,12 @@ describe('runDream — --phase <name> restricts the cycle', () => {
   beforeEach(async () => {
     repo = makeGitRepo();
     engine = await makePGLite();
-  });
+  }, 30_000); // 21 migrations + git init; needs breathing room under full-suite load
 
   afterEach(async () => {
-    await engine.disconnect();
+    if (engine) await engine.disconnect();
     rmSync(repo, { recursive: true, force: true });
-  });
+  }, 15_000);
 
   test('--phase lint produces a report with exactly one phase = lint', async () => {
     const report = await runDream(engine, ['--dir', repo, '--phase', 'lint', '--json']);
@@ -160,12 +160,12 @@ describe('runDream — output format', () => {
   beforeEach(async () => {
     repo = makeGitRepo();
     engine = await makePGLite();
-  });
+  }, 30_000); // 21 migrations + git init; needs breathing room under full-suite load
 
   afterEach(async () => {
-    await engine.disconnect();
+    if (engine) await engine.disconnect();
     rmSync(repo, { recursive: true, force: true });
-  });
+  }, 15_000);
 
   test('--json emits parsable CycleReport JSON with schema_version', async () => {
     const lines: string[] = [];
@@ -198,12 +198,12 @@ describe('runDream — dry-run propagates through to runCycle', () => {
   beforeEach(async () => {
     repo = makeGitRepo();
     engine = await makePGLite();
-  });
+  }, 30_000); // 21 migrations + git init; needs breathing room under full-suite load
 
   afterEach(async () => {
-    await engine.disconnect();
+    if (engine) await engine.disconnect();
     rmSync(repo, { recursive: true, force: true });
-  });
+  }, 15_000);
 
   test('--dry-run produces a report where no DB-mutating work happened', async () => {
     // Before: empty pages table.
@@ -227,12 +227,12 @@ describe('runDream — exit-code semantics', () => {
   beforeEach(async () => {
     repo = makeGitRepo();
     engine = await makePGLite();
-  });
+  }, 30_000); // 21 migrations + git init; needs breathing room under full-suite load
 
   afterEach(async () => {
-    await engine.disconnect();
+    if (engine) await engine.disconnect();
     rmSync(repo, { recursive: true, force: true });
-  });
+  }, 15_000);
 
   test('clean/ok/partial statuses do not call process.exit', async () => {
     const spy = spyOn(process, 'exit').mockImplementation(() => { throw new Error('UNEXPECTED_EXIT'); });

--- a/test/extract-db.test.ts
+++ b/test/extract-db.test.ts
@@ -19,11 +19,11 @@ beforeAll(async () => {
   engine = new PGLiteEngine();
   await engine.connect({});
   await engine.initSchema();
-});
+}, 30_000); // 21-migration init needs breathing room under full-suite load
 
 afterAll(async () => {
-  await engine.disconnect();
-});
+  if (engine) await engine.disconnect();
+}, 15_000);
 
 async function truncateAll() {
   for (const t of ['content_chunks', 'links', 'tags', 'raw_data', 'timeline_entries', 'page_versions', 'ingest_log', 'pages']) {

--- a/test/mounts-cache.test.ts
+++ b/test/mounts-cache.test.ts
@@ -1,0 +1,310 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  composeResolvers,
+  composeManifests,
+  renderResolverMarkdown,
+  renderManifestJson,
+  writeMountsCache,
+  clearMountsCache,
+  __testing,
+} from '../src/core/mounts-cache.ts';
+import { HOST_BRAIN_ID, type MountEntry } from '../src/core/brain-registry.ts';
+
+const toCleanup: string[] = [];
+function mktmp(prefix = 'mounts-cache-'): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  toCleanup.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (toCleanup.length > 0) {
+    const p = toCleanup.pop();
+    if (!p) continue;
+    try { rmSync(p, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+/** Build a tmp skills dir with a minimal RESOLVER.md + manifest.json + SKILL.md stubs. */
+function makeSkillsDir(skills: Array<{ name: string; trigger: string; section?: string }>): string {
+  const dir = mktmp();
+  mkdirSync(join(dir, 'skills'), { recursive: true });
+  for (const s of skills) {
+    mkdirSync(join(dir, 'skills', s.name), { recursive: true });
+    writeFileSync(join(dir, 'skills', s.name, 'SKILL.md'), `---\nname: ${s.name}\n---\n# ${s.name}\n`);
+  }
+  const resolverLines = ['# RESOLVER', ''];
+  const bySection = new Map<string, Array<{ name: string; trigger: string }>>();
+  for (const s of skills) {
+    const sec = s.section || 'Brain operations';
+    const bucket = bySection.get(sec) ?? [];
+    bucket.push(s);
+    bySection.set(sec, bucket);
+  }
+  for (const [sec, bucket] of bySection.entries()) {
+    resolverLines.push(`## ${sec}`, '', '| Trigger | Skill |', '|---------|-------|');
+    for (const s of bucket) {
+      resolverLines.push(`| ${s.trigger} | \`skills/${s.name}/SKILL.md\` |`);
+    }
+    resolverLines.push('');
+  }
+  writeFileSync(join(dir, 'skills', 'RESOLVER.md'), resolverLines.join('\n'));
+  writeFileSync(
+    join(dir, 'skills', 'manifest.json'),
+    JSON.stringify({ skills: skills.map(s => ({ name: s.name, path: `${s.name}/SKILL.md` })) }, null, 2),
+  );
+  return join(dir, 'skills');
+}
+
+function makeMount(id: string, skillsDir: string, enabled = true): MountEntry {
+  // skillsDir is the SKILLS dir; mount.path is the parent (repo root).
+  const repoRoot = join(skillsDir, '..');
+  return {
+    id,
+    path: repoRoot,
+    engine: 'pglite',
+    database_path: join(repoRoot, '.pg'),
+    enabled,
+  };
+}
+
+describe('composeResolvers — host only', () => {
+  test('empty world: empty output', () => {
+    const hostDir = mktmp();
+    const result = composeResolvers(hostDir, []);
+    expect(result.entries).toEqual([]);
+    expect(result.shadows).toEqual([]);
+    expect(result.ambiguities).toEqual([]);
+  });
+
+  test('host skills only: no namespace prefix, brainId=host', () => {
+    const hostSkills = makeSkillsDir([
+      { name: 'query', trigger: 'search' },
+      { name: 'enrich', trigger: 'enrich a page' },
+    ]);
+    const result = composeResolvers(hostSkills, []);
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries.every(e => e.brainId === HOST_BRAIN_ID)).toBe(true);
+    expect(result.entries.map(e => e.qualifiedName).sort()).toEqual(['enrich', 'query']);
+  });
+});
+
+describe('composeResolvers — mount skills', () => {
+  test('single mount: namespace prefix applied', () => {
+    const hostSkills = makeSkillsDir([]);
+    const mountSkills = makeSkillsDir([{ name: 'ingest', trigger: 'yc-media ingest' }]);
+    const mount = makeMount('yc-media', mountSkills);
+    const result = composeResolvers(hostSkills, [mount]);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].qualifiedName).toBe('yc-media::ingest');
+    expect(result.entries[0].brainId).toBe('yc-media');
+    expect(result.entries[0].absolutePath).toContain('/skills/ingest/SKILL.md');
+  });
+
+  test('disabled mount is excluded', () => {
+    const hostSkills = makeSkillsDir([]);
+    const mountSkills = makeSkillsDir([{ name: 'ingest', trigger: 'x' }]);
+    const mount = makeMount('disabled', mountSkills, false);
+    const result = composeResolvers(hostSkills, [mount]);
+    expect(result.entries).toEqual([]);
+  });
+
+  test('two mounts same skill → ambiguity (host does not define it)', () => {
+    const hostSkills = makeSkillsDir([]);
+    const m1Skills = makeSkillsDir([{ name: 'ingest', trigger: 'm1 ingest' }]);
+    const m2Skills = makeSkillsDir([{ name: 'ingest', trigger: 'm2 ingest' }]);
+    const m1 = makeMount('alpha', m1Skills);
+    const m2 = makeMount('beta', m2Skills);
+    const result = composeResolvers(hostSkills, [m1, m2]);
+    expect(result.ambiguities).toHaveLength(1);
+    expect(result.ambiguities[0].skillName).toBe('ingest');
+    expect(result.ambiguities[0].mountIds).toEqual(['alpha', 'beta']);
+    // Both entries still surface (via namespace form).
+    const names = result.entries.map(e => e.qualifiedName).sort();
+    expect(names).toEqual(['alpha::ingest', 'beta::ingest']);
+  });
+
+  test('host + mount same name → host wins, mount shadowed', () => {
+    const hostSkills = makeSkillsDir([{ name: 'ingest', trigger: 'host ingest' }]);
+    const mountSkills = makeSkillsDir([{ name: 'ingest', trigger: 'mount ingest' }]);
+    const mount = makeMount('yc-media', mountSkills);
+    const result = composeResolvers(hostSkills, [mount]);
+    // Only host entry survives
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].brainId).toBe(HOST_BRAIN_ID);
+    expect(result.entries[0].qualifiedName).toBe('ingest');
+    // Shadow recorded
+    expect(result.shadows).toHaveLength(1);
+    expect(result.shadows[0].skillName).toBe('ingest');
+    expect(result.shadows[0].shadowedMounts).toHaveLength(1);
+    expect(result.shadows[0].shadowedMounts[0].mountId).toBe('yc-media');
+    // Not flagged as ambiguity — host wins, there's no ambiguity
+    expect(result.ambiguities).toEqual([]);
+  });
+
+  test('host shadows one of two mounts — still only ambiguity when host does NOT win', () => {
+    const hostSkills = makeSkillsDir([{ name: 'ingest', trigger: 'host' }]);
+    const m1Skills = makeSkillsDir([{ name: 'ingest', trigger: 'm1' }]);
+    const m2Skills = makeSkillsDir([{ name: 'ingest', trigger: 'm2' }]);
+    const result = composeResolvers(hostSkills, [makeMount('a', m1Skills), makeMount('b', m2Skills)]);
+    // No ambiguity: host shadows everything
+    expect(result.ambiguities).toEqual([]);
+    expect(result.shadows).toHaveLength(1);
+    expect(result.shadows[0].shadowedMounts.map(m => m.mountId).sort()).toEqual(['a', 'b']);
+  });
+
+  test('mount without RESOLVER.md contributes no entries (not an error)', () => {
+    const hostSkills = makeSkillsDir([]);
+    // Create a mount path with no skills/RESOLVER.md inside
+    const emptyRoot = mktmp();
+    const mount: MountEntry = {
+      id: 'empty', path: emptyRoot, engine: 'pglite', database_path: `${emptyRoot}/.pg`, enabled: true,
+    };
+    const result = composeResolvers(hostSkills, [mount]);
+    expect(result.entries).toEqual([]);
+  });
+});
+
+describe('composeManifests', () => {
+  test('host only: entries preserved without namespace', () => {
+    const hostSkills = makeSkillsDir([{ name: 'query', trigger: 'x' }]);
+    const result = composeManifests(hostSkills, []);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].name).toBe('query');
+    expect(result.entries[0].brainId).toBe(HOST_BRAIN_ID);
+  });
+
+  test('mount entries get namespace prefix (Codex finding #8)', () => {
+    const hostSkills = makeSkillsDir([]);
+    const mountSkills = makeSkillsDir([{ name: 'ingest', trigger: 'x' }]);
+    const result = composeManifests(hostSkills, [makeMount('yc-media', mountSkills)]);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].name).toBe('yc-media::ingest');
+    expect(result.entries[0].brainId).toBe('yc-media');
+  });
+
+  test('host wins on manifest collision (no mount duplicate)', () => {
+    const hostSkills = makeSkillsDir([{ name: 'ingest', trigger: 'host' }]);
+    const mountSkills = makeSkillsDir([{ name: 'ingest', trigger: 'mount' }]);
+    const result = composeManifests(hostSkills, [makeMount('yc-media', mountSkills)]);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].name).toBe('ingest');
+    expect(result.entries[0].brainId).toBe(HOST_BRAIN_ID);
+  });
+
+  test('disabled mount excluded', () => {
+    const hostSkills = makeSkillsDir([]);
+    const mountSkills = makeSkillsDir([{ name: 'ingest', trigger: 'x' }]);
+    const result = composeManifests(hostSkills, [makeMount('off', mountSkills, false)]);
+    expect(result.entries).toEqual([]);
+  });
+
+  test('missing manifest.json in mount → mount contributes nothing (no crash)', () => {
+    const hostSkills = makeSkillsDir([]);
+    const emptyRoot = mktmp();
+    mkdirSync(join(emptyRoot, 'skills'), { recursive: true });
+    // No manifest.json written
+    const mount: MountEntry = {
+      id: 'bare', path: emptyRoot, engine: 'pglite', database_path: `${emptyRoot}/.pg`, enabled: true,
+    };
+    expect(() => composeManifests(hostSkills, [mount])).not.toThrow();
+  });
+});
+
+describe('renderResolverMarkdown', () => {
+  test('produces stable markdown with brain column', () => {
+    const hostSkills = makeSkillsDir([{ name: 'query', trigger: 'search' }]);
+    const mountSkills = makeSkillsDir([{ name: 'ingest', trigger: 'media ingest' }]);
+    const composed = composeResolvers(hostSkills, [makeMount('yc-media', mountSkills)]);
+    const md = renderResolverMarkdown(composed);
+    expect(md).toContain('# GBrain Skill Resolver (aggregated)');
+    expect(md).toContain('Auto-generated');
+    expect(md).toContain('| Trigger | Skill | Brain |');
+    expect(md).toContain('| search');
+    expect(md).toContain('| host |');
+    expect(md).toContain('| media ingest');
+    expect(md).toContain('| yc-media |');
+  });
+
+  test('shadows section appears only when shadows exist', () => {
+    const hostSkills = makeSkillsDir([{ name: 'ingest', trigger: 'x' }]);
+    const mountSkills = makeSkillsDir([{ name: 'ingest', trigger: 'y' }]);
+    const composed = composeResolvers(hostSkills, [makeMount('m', mountSkills)]);
+    const md = renderResolverMarkdown(composed);
+    expect(md).toContain('## Shadows');
+    expect(md).toContain('`ingest` (host) shadows');
+  });
+
+  test('ambiguities section appears only when ambiguities exist', () => {
+    const hostSkills = makeSkillsDir([]);
+    const m1 = makeSkillsDir([{ name: 'ingest', trigger: 'x' }]);
+    const m2 = makeSkillsDir([{ name: 'ingest', trigger: 'y' }]);
+    const composed = composeResolvers(hostSkills, [makeMount('a', m1), makeMount('b', m2)]);
+    const md = renderResolverMarkdown(composed);
+    expect(md).toContain('## Ambiguous bare names');
+    expect(md).toContain('`ingest`');
+  });
+});
+
+describe('renderManifestJson', () => {
+  test('produces parseable JSON with expected shape', () => {
+    const hostSkills = makeSkillsDir([{ name: 'query', trigger: 'x' }]);
+    const composed = composeManifests(hostSkills, []);
+    const json = renderManifestJson(composed);
+    const parsed = JSON.parse(json);
+    expect(parsed.generated_by).toBe('gbrain mounts');
+    expect(parsed.skills).toHaveLength(1);
+    expect(parsed.skills[0].name).toBe('query');
+    expect(parsed.skills[0].brain).toBe(HOST_BRAIN_ID);
+  });
+});
+
+describe('writeMountsCache + clearMountsCache', () => {
+  test('writes both RESOLVER.md and manifest.json atomically', () => {
+    const hostSkills = makeSkillsDir([{ name: 'query', trigger: 'x' }]);
+    const cacheDir = mktmp();
+    const { resolverPath, manifestPath } = writeMountsCache(hostSkills, [], { cacheDir });
+    expect(existsSync(resolverPath)).toBe(true);
+    expect(existsSync(manifestPath)).toBe(true);
+    const md = readFileSync(resolverPath, 'utf-8');
+    expect(md).toContain('# GBrain Skill Resolver (aggregated)');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    expect(manifest.skills).toHaveLength(1);
+  });
+
+  test('rewriting overwrites cleanly', () => {
+    const hostSkills1 = makeSkillsDir([{ name: 'query', trigger: 'x' }]);
+    const cacheDir = mktmp();
+    writeMountsCache(hostSkills1, [], { cacheDir });
+    const hostSkills2 = makeSkillsDir([{ name: 'ingest', trigger: 'y' }]);
+    writeMountsCache(hostSkills2, [], { cacheDir });
+    const manifest = JSON.parse(readFileSync(join(cacheDir, 'manifest.json'), 'utf-8'));
+    expect(manifest.skills.map((s: { name: string }) => s.name)).toEqual(['ingest']);
+  });
+
+  test('clearMountsCache removes the directory', () => {
+    const hostSkills = makeSkillsDir([{ name: 'query', trigger: 'x' }]);
+    const cacheDir = mktmp();
+    writeMountsCache(hostSkills, [], { cacheDir });
+    expect(existsSync(cacheDir)).toBe(true);
+    clearMountsCache({ cacheDir });
+    expect(existsSync(cacheDir)).toBe(false);
+  });
+
+  test('clearMountsCache on missing dir is a no-op', () => {
+    const fake = join(tmpdir(), `does-not-exist-${Date.now()}`);
+    expect(() => clearMountsCache({ cacheDir: fake })).not.toThrow();
+  });
+});
+
+describe('skillNameFromRelPath', () => {
+  test('extracts name from skills/ prefix', () => {
+    expect(__testing.skillNameFromRelPath('skills/query/SKILL.md')).toBe('query');
+    expect(__testing.skillNameFromRelPath('skills/yc-media/SKILL.md')).toBe('yc-media');
+  });
+  test('handles name without skills/ prefix', () => {
+    expect(__testing.skillNameFromRelPath('query/SKILL.md')).toBe('query');
+  });
+});

--- a/test/mounts-cache.test.ts
+++ b/test/mounts-cache.test.ts
@@ -126,30 +126,36 @@ describe('composeResolvers — mount skills', () => {
     expect(names).toEqual(['alpha::ingest', 'beta::ingest']);
   });
 
-  test('host + mount same name → host wins, mount shadowed', () => {
+  test('host + mount same name → host wins BARE name, mount reachable via namespace', () => {
     const hostSkills = makeSkillsDir([{ name: 'ingest', trigger: 'host ingest' }]);
     const mountSkills = makeSkillsDir([{ name: 'ingest', trigger: 'mount ingest' }]);
     const mount = makeMount('yc-media', mountSkills);
     const result = composeResolvers(hostSkills, [mount]);
-    // Only host entry survives
-    expect(result.entries).toHaveLength(1);
-    expect(result.entries[0].brainId).toBe(HOST_BRAIN_ID);
-    expect(result.entries[0].qualifiedName).toBe('ingest');
-    // Shadow recorded
+    // Both entries survive: host wins bare 'ingest', but 'yc-media::ingest'
+    // must remain routable (the whole point of namespace-qualified form).
+    expect(result.entries).toHaveLength(2);
+    const host = result.entries.find(e => e.brainId === HOST_BRAIN_ID);
+    const mnt = result.entries.find(e => e.brainId === 'yc-media');
+    expect(host?.qualifiedName).toBe('ingest');
+    expect(mnt?.qualifiedName).toBe('yc-media::ingest');
+    // Shadow recorded so doctor can warn about local-customizing a remote skill
     expect(result.shadows).toHaveLength(1);
     expect(result.shadows[0].skillName).toBe('ingest');
     expect(result.shadows[0].shadowedMounts).toHaveLength(1);
     expect(result.shadows[0].shadowedMounts[0].mountId).toBe('yc-media');
-    // Not flagged as ambiguity — host wins, there's no ambiguity
+    // Not flagged as ambiguity — host wins the bare name cleanly
     expect(result.ambiguities).toEqual([]);
   });
 
-  test('host shadows one of two mounts — still only ambiguity when host does NOT win', () => {
+  test('host shadows two mounts → all three entries survive, shadow tracks both mounts', () => {
     const hostSkills = makeSkillsDir([{ name: 'ingest', trigger: 'host' }]);
     const m1Skills = makeSkillsDir([{ name: 'ingest', trigger: 'm1' }]);
     const m2Skills = makeSkillsDir([{ name: 'ingest', trigger: 'm2' }]);
     const result = composeResolvers(hostSkills, [makeMount('a', m1Skills), makeMount('b', m2Skills)]);
-    // No ambiguity: host shadows everything
+    // Host entry + both namespaced mount entries
+    expect(result.entries).toHaveLength(3);
+    expect(result.entries.map(e => e.qualifiedName).sort()).toEqual(['a::ingest', 'b::ingest', 'ingest']);
+    // No ambiguity: host wins bare name
     expect(result.ambiguities).toEqual([]);
     expect(result.shadows).toHaveLength(1);
     expect(result.shadows[0].shadowedMounts.map(m => m.mountId).sort()).toEqual(['a', 'b']);
@@ -185,13 +191,20 @@ describe('composeManifests', () => {
     expect(result.entries[0].brainId).toBe('yc-media');
   });
 
-  test('host wins on manifest collision (no mount duplicate)', () => {
+  test('manifest keeps namespace-qualified mount entry even when host shadows', () => {
+    // Bare-name resolution is composeResolvers' job. The manifest lists every
+    // addressable skill by its canonical name, so the namespace-qualified
+    // form must survive regardless of host shadow. This matches the
+    // corresponding composeResolvers shadow test.
     const hostSkills = makeSkillsDir([{ name: 'ingest', trigger: 'host' }]);
     const mountSkills = makeSkillsDir([{ name: 'ingest', trigger: 'mount' }]);
     const result = composeManifests(hostSkills, [makeMount('yc-media', mountSkills)]);
-    expect(result.entries).toHaveLength(1);
-    expect(result.entries[0].name).toBe('ingest');
-    expect(result.entries[0].brainId).toBe(HOST_BRAIN_ID);
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries.map(e => e.name).sort()).toEqual(['ingest', 'yc-media::ingest']);
+    const host = result.entries.find(e => e.name === 'ingest');
+    const mnt = result.entries.find(e => e.name === 'yc-media::ingest');
+    expect(host?.brainId).toBe(HOST_BRAIN_ID);
+    expect(mnt?.brainId).toBe('yc-media');
   });
 
   test('disabled mount excluded', () => {

--- a/test/mounts-cli.test.ts
+++ b/test/mounts-cli.test.ts
@@ -1,0 +1,240 @@
+import { describe, test, expect, afterEach, beforeEach } from 'bun:test';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir, homedir } from 'os';
+import { __testing } from '../src/commands/mounts.ts';
+
+const { parseAddArgs, redactUrl, readMountsFile, writeMountsFile } = __testing;
+
+const toCleanup: string[] = [];
+let tempHome: string | null = null;
+
+function mktmp(prefix = 'mounts-cli-'): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  toCleanup.push(dir);
+  return dir;
+}
+
+/**
+ * Redirect HOME for the duration of a test so writeMountsFile doesn't
+ * touch the user's real ~/.gbrain/mounts.json.
+ */
+function withFakeHome<T>(fn: (mountsPath: string) => T): T {
+  const home = mktmp('fake-home-');
+  const prev = process.env.HOME;
+  process.env.HOME = home;
+  try {
+    mkdirSync(join(home, '.gbrain'), { recursive: true });
+    const mountsPath = join(home, '.gbrain', 'mounts.json');
+    return fn(mountsPath);
+  } finally {
+    if (prev !== undefined) process.env.HOME = prev;
+    else delete process.env.HOME;
+  }
+}
+
+afterEach(() => {
+  while (toCleanup.length > 0) {
+    const p = toCleanup.pop();
+    if (!p) continue;
+    try { rmSync(p, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+describe('parseAddArgs', () => {
+  test('minimal pglite add', () => {
+    const parsed = parseAddArgs([
+      'yc-media',
+      '--path', '/tmp/yc-media',
+      '--engine', 'pglite',
+      '--db-path', '/tmp/yc-media/.pg',
+    ]);
+    expect(parsed.id).toBe('yc-media');
+    expect(parsed.engine).toBe('pglite');
+    expect(parsed.database_path).toBe('/tmp/yc-media/.pg');
+    expect(parsed.path.startsWith('/')).toBe(true);
+  });
+
+  test('minimal postgres add', () => {
+    const parsed = parseAddArgs([
+      'yc-politics',
+      '--path', '/tmp/luther',
+      '--engine', 'postgres',
+      '--db-url', 'postgresql://localhost/l',
+    ]);
+    expect(parsed.engine).toBe('postgres');
+    expect(parsed.database_url).toBe('postgresql://localhost/l');
+  });
+
+  test('infers engine from --db-url (postgres)', () => {
+    const parsed = parseAddArgs([
+      'a', '--path', '/tmp/a', '--db-url', 'postgresql://x/y',
+    ]);
+    expect(parsed.engine).toBe('postgres');
+  });
+
+  test('infers engine from --db-path (pglite)', () => {
+    const parsed = parseAddArgs([
+      'b', '--path', '/tmp/b', '--db-path', '/tmp/b/.pg',
+    ]);
+    expect(parsed.engine).toBe('pglite');
+  });
+
+  test('accepts --alias', () => {
+    const parsed = parseAddArgs([
+      'yc-media', '--path', '/tmp/x', '--db-path', '/tmp/x/.pg', '--alias', 'ycm',
+    ]);
+    expect(parsed.alias).toBe('ycm');
+  });
+
+  test('rejects missing id', () => {
+    expect(() => parseAddArgs([])).toThrow(/Missing mount id/);
+  });
+
+  test('rejects missing path', () => {
+    expect(() => parseAddArgs(['m', '--db-path', '/tmp/x/.pg'])).toThrow(/Missing --path/);
+  });
+
+  test('rejects invalid engine', () => {
+    expect(() => parseAddArgs([
+      'x', '--path', '/tmp/x', '--engine', 'sqlite',
+    ])).toThrow(/Invalid engine/);
+  });
+
+  test('rejects unknown flag', () => {
+    expect(() => parseAddArgs([
+      'x', '--path', '/tmp/x', '--db-path', '/tmp/x/.pg', '--nonsense',
+    ])).toThrow(/Unknown flag/);
+  });
+
+  test('rejects no engine + no db flags (cannot infer)', () => {
+    expect(() => parseAddArgs(['x', '--path', '/tmp/x'])).toThrow(/Missing --engine/);
+  });
+
+  test('rejects postgres without --db-url', () => {
+    expect(() => parseAddArgs([
+      'x', '--path', '/tmp/x', '--engine', 'postgres',
+    ])).toThrow(/postgres mount requires --db-url/);
+  });
+
+  test('rejects flag-value missing', () => {
+    expect(() => parseAddArgs([
+      'x', '--path',
+    ])).toThrow(/Missing value for --path/);
+  });
+
+  test('rejects invalid alias', () => {
+    expect(() => parseAddArgs([
+      'x', '--path', '/tmp/x', '--db-path', '/tmp/x/.pg', '--alias', 'UPPER',
+    ])).toThrow();
+  });
+});
+
+describe('redactUrl', () => {
+  test('strips password from postgres://', () => {
+    const red = redactUrl('postgresql://user:supersecret@db.example.com/brain');
+    expect(red).not.toContain('supersecret');
+    expect(red).toContain('***');
+    expect(red).toContain('db.example.com');
+  });
+
+  test('password-less URLs do not grow ***', () => {
+    const url = 'postgresql://user@db.example.com/brain';
+    const red = redactUrl(url);
+    expect(red).not.toContain('***');
+    expect(red).toContain('user@db.example.com');
+    expect(red).toContain('/brain');
+  });
+
+  test('leaves opaque file:// urls alone', () => {
+    const url = 'file:///home/user/brain/.pglite';
+    expect(redactUrl(url)).toBe(url);
+  });
+
+  test('leaves non-URL strings alone', () => {
+    const opaque = '/not/a/url';
+    expect(redactUrl(opaque)).toBe(opaque);
+  });
+});
+
+describe('readMountsFile / writeMountsFile', () => {
+  test('empty file returns empty mounts list', () => {
+    const dir = mktmp();
+    const path = join(dir, 'mounts.json');
+    const file = readMountsFile(path);
+    expect(file.version).toBe(1);
+    expect(file.mounts).toHaveLength(0);
+  });
+
+  test('round-trip: write then read', () => {
+    const dir = mktmp();
+    const path = join(dir, 'mounts.json');
+    writeMountsFile({
+      version: 1,
+      mounts: [{
+        id: 'yc-media', path: '/tmp/yc', engine: 'pglite', database_path: '/tmp/yc/.pg', enabled: true,
+      }],
+    }, path);
+    const file = readMountsFile(path);
+    expect(file.mounts).toHaveLength(1);
+    expect(file.mounts[0].id).toBe('yc-media');
+  });
+
+  test('write is atomic: no partial file visible mid-write', () => {
+    const dir = mktmp();
+    const path = join(dir, 'mounts.json');
+    writeMountsFile({
+      version: 1,
+      mounts: [{
+        id: 'a', path: '/tmp/a', engine: 'pglite', database_path: '/tmp/a/.pg', enabled: true,
+      }],
+    }, path);
+    expect(existsSync(path)).toBe(true);
+    // .tmp should be gone after atomic rename.
+    expect(existsSync(path + '.tmp')).toBe(false);
+  });
+});
+
+describe('runMounts — end-to-end add/list/remove', () => {
+  // These rely on HOME redirection to isolate from the real ~/.gbrain/.
+  // We don't import runMounts directly to avoid stdout spam in test output;
+  // parseAddArgs + readMountsFile + writeMountsFile is enough seam coverage.
+
+  test('add → list → remove roundtrip via seams', () => {
+    withFakeHome((mountsPath) => {
+      // Manually simulate the subcommand sequence using the same seams
+      // runMounts uses internally.
+      let file = readMountsFile(mountsPath);
+      expect(file.mounts).toHaveLength(0);
+
+      // Simulate add
+      const parsed = parseAddArgs([
+        'yc-media',
+        '--path', mountsPath, // use the temp path so existsSync(path) passes
+        '--engine', 'pglite',
+        '--db-path', '/tmp/yc-media/.pg',
+      ]);
+      file.mounts.push({
+        id: parsed.id,
+        path: parsed.path,
+        engine: parsed.engine,
+        database_path: parsed.database_path,
+        enabled: true,
+      });
+      writeMountsFile(file, mountsPath);
+
+      // List
+      file = readMountsFile(mountsPath);
+      expect(file.mounts).toHaveLength(1);
+      expect(file.mounts[0].id).toBe('yc-media');
+
+      // Remove
+      file.mounts = file.mounts.filter(m => m.id !== 'yc-media');
+      writeMountsFile(file, mountsPath);
+
+      // Confirm empty
+      file = readMountsFile(mountsPath);
+      expect(file.mounts).toHaveLength(0);
+    });
+  });
+});

--- a/test/multi-source-integration.test.ts
+++ b/test/multi-source-integration.test.ts
@@ -27,11 +27,11 @@ beforeAll(async () => {
   engine = new PGLiteEngine();
   await engine.connect({ type: 'pglite' } as never);
   await engine.initSchema();
-});
+}, 30_000); // 21-migration init needs breathing room under full-suite load
 
 afterAll(async () => {
-  await engine.disconnect();
-});
+  if (engine) await engine.disconnect();
+}, 15_000);
 
 describe('v0.18.0 — sources table seeded with default row on fresh PGLite', () => {
   test("sources('default') exists after initSchema + migration", async () => {

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -26,11 +26,11 @@ beforeAll(async () => {
   };
 
   provider = new GBrainOAuthProvider({ sql, tokenTtl: 60, refreshTtl: 300 });
-});
+}, 30_000); // PGLITE_SCHEMA_SQL execution under full-suite load can exceed default 5s
 
 afterAll(async () => {
-  await db.close();
-});
+  if (db) await db.close();
+}, 15_000);
 
 // ---------------------------------------------------------------------------
 // hashToken + generateToken utilities

--- a/test/orphans.test.ts
+++ b/test/orphans.test.ts
@@ -216,11 +216,11 @@ describe('findOrphans (engine-injected)', () => {
     engine = new PGLiteEngine();
     await engine.connect({});
     await engine.initSchema();
-  });
+  }, 30_000); // 21-migration init needs breathing room under full-suite load
 
   afterEach(async () => {
-    await engine.disconnect();
-  });
+    if (engine) await engine.disconnect();
+  }, 15_000);
 
   test('returns pages with no inbound links, excluding pseudo-pages', async () => {
     // Build a tiny brain: alice links to bob. alice is an orphan (nothing


### PR DESCRIPTION
## Summary

PR 0 of 3 for **connected gbrains** — mounting separate gbrain databases as first-class brains alongside the host brain. This PR ships the minimal runtime proving multi-brain end-to-end. Security (attestation, pinning, per-skill scopes) and team-publishing (OAuth, HTTP MCP transport, provision + connect skills) land in PRs 1 and 2.

Targets `garrytan/mcp-key-mgmt` so the scope + `localOnly` annotations already landed there are available.

### What ships

- **`src/core/brain-registry.ts`** — keyed registry of BrainEngine handles. `getBrain(id)` returns a lazy-initialized engine for host or any mount. `UnknownBrainError` + `DuplicateMountPathError` are structured. Mount engines get `poolSize: 5` on connect so they NEVER share the db.ts singleton (Codex finding #1 from plan review).
- **`~/.gbrain/mounts.json`** — per-user mount manifest. Validated strictly on load: malformed JSON, duplicate ids, duplicate paths, invalid engine all fail loud with actionable errors.
- **`src/core/brain-resolver.ts`** — 6-tier `--brain` resolution mirroring v0.18.0's `source-resolver.ts`: explicit > `GBRAIN_BRAIN_ID` env > `.gbrain-mount` dotfile > mount-path-prefix > reserved default > `'host'`.
- **`src/commands/mounts.ts`** — `gbrain mounts add|list|remove` for direct-transport (PGLite + Postgres) local-path mounts. Pin / sync / MCP transport are PR 1+.
- **`src/core/mounts-cache.ts`** — `composeResolvers` + `composeManifests` merge host + mount RESOLVER.md + manifest.json into aggregated files at `~/.gbrain/mounts-cache/`. Host agents (Wintermute/OpenClaw/Claude Code) read the aggregated file to see mount skills without editing the checked-in `skills/RESOLVER.md`. Codex plan-review findings #3 (runtime ownership) and #8 (manifest composition).
- **`OperationContext.brainId`** + **`SubagentHandlerData.brain_id`** — plumbing for per-op brain routing. PR 0 threads the FIELD through OperationContext + subagent handler + brain-allowlist → ctx.brainId; PR 1 will wire the registry lookup + `--brain` CLI flag that actually resolves to an engine at dispatch.
- **CI guard** — `scripts/check-no-legacy-getconnection.sh` fails the build on any new `db.getConnection()` / `db.connect()` call landing in `src/core/` or `src/commands/`. Existing callers grandfathered with "PR 1 refactors" notes.
- **Docs** — `docs/architecture/brains-and-sources.md` (mental model, 4 topology diagrams including the CEO-class multi-team case), `skills/conventions/brain-routing.md` (agent decision table: when to switch brain vs source, cross-brain federation = latent-space only), plus CLAUDE.md + AGENTS.md updates routing readers to those docs first.

### What does NOT ship (PR 1)

- OAuth / HTTP MCP transport
- Skill trust attestation (SHA chain)
- Mount version pinning
- Per-skill OAuth scope enforcement
- `MountTransport` interface + `DirectTransport` / `McpTransport` impls
- `gbrain mounts sync` (git pull + cache refresh)
- Removal of `postgres-engine.ts`'s fallback to `db.getConnection()`. Fallback still exists but no new caller can land one via CI guard.
- `brain_id`-to-engine lookup in `buildOpContext` — today brainId is plumbed through but `ctx.engine` is still the worker's base engine at dispatch (see code comments that spell out this PR 0 limitation)
- `gbrain agent run --brain <id>` CLI flag wiring
- Command-level refactors (`doctor`, `files`, `repair-jsonb`, `serve-http`, `init`) to accept `ctx.engine` instead of singleton
- Deeper `ctx.config.storage` + `loadConfig()` routing audit (Codex plan-review #2 wider — only matters when team-brain storage differs from host)
- File-lock + generation-dir swap on the aggregated cache

### What does NOT ship (PR 2)

- `skills/gbrain-provision/SKILL.md` (create a new team brain)
- `skills/gbrain-connect/SKILL.md` (paste-ready mount instructions)
- Keychain wrapper for OAuth tokens
- `garrytan/gbrain-template` out-of-tree template repo

## Bisectable commits

1. `10443e7` foundation — registry + resolver + CLI (28 tests, 18 tests, 29 tests)
2. `0cf1c90` docs — brains-and-sources mental model + brain-routing convention
3. `41f5b08` brainId threading — OperationContext + SubagentHandlerData + buildBrainTools
4. `0671eaf` composeResolvers + composeManifests + aggregated cache (23 tests)
5. `c10ce74` mount pool isolation + CI guard (Codex plan-review finding #1)
6. `b370f76` merge base (origin/garrytan/mcp-key-mgmt v0.18.2 migration hardening + OAuth RLS)
7. `bfda7d4` codex review fixes — namespace survives shadow + atomic tmp names + honest PR 0 docstrings

## Test plan

- [x] `bun run test` green — 2175 pass / 20 fail on merged state. All 20 fails are pre-existing pglite-timeout flakes in `dream` / `orphans` / `build-llms` unrelated to mounts.
- [x] `bun run tsc --noEmit` clean
- [x] `scripts/check-no-legacy-getconnection.sh` reports "ok: no new singleton callers"
- [x] Live CLI smoke: `mounts add` × 2 → `mounts list` shows 2 → cache written to `~/.gbrain/mounts-cache/` with host skills + mount skills (namespace-qualified) → `mounts remove` rewrites cache atomically
- [x] Namespace-shadow smoke: mount with same skill name as host → `team-demo::ingest` coexists with host `ingest` in aggregated manifest
- [ ] PR 1 will land: postgres-engine fallback removal + command-level engine injection + typed error hierarchy + `DirectTransport` seam + `brain_id`-to-engine resolution at dispatch
- [ ] PR 2 will land: OAuth + HTTP MCP transport + provision/connect skills + gbrain-template repo

## Pre-Landing Review

- Two-pass checklist (critical + informational) applied manually. No issues in SQL safety (no raw SQL), race conditions (Promise-dedup in registry, atomic rename in file writes), shell injection, enum completeness, or any critical category.
- Two style cleanups applied: removed `require('fs')` runtime imports in `mounts-cache.ts:418` and `mounts.ts:61`, swapped for ESM named `renameSync` imports.

## Adversarial Review (outside voice — Codex)

Codex `exec` pass (`high` reasoning) on the full diff found 5 findings:

| # | Severity | Finding | Resolution |
|---|---|---|---|
| 1 | P1 | Subagent tool calls execute on worker engine, not resolved brain | Honesty fix: docstrings rewritten to state PR 0 plumbs field only, PR 1 adds engine routing |
| 2 | P1 | `brain_id` never populated on submitted subagent jobs (agent.ts) | Same — comment overclaimed, rewrote. PR 1 adds `--brain` to `gbrain agent run` |
| 3 | P1 | `mounts.json` / `mounts-cache` tmp files clobber on concurrent writes | **Fixed:** unique tmp filenames (`$pid.$rand` suffix) |
| 4 | P2 | `mounts-cache` publish not atomic across RESOLVER + manifest | Documented known limitation; generation-dir swap deferred to PR 1 |
| 5 | P2 | Host-wins dropped shadowed mount entries → `yc-media::ingest` unreachable | **Fixed:** namespace-qualified mount entries always survive compose output; shadow tracking stays as metadata for doctor warnings. Tests updated |

All fixes landed in `bfda7d4`. Namespace fix verified live via smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)