### PR TITLE
fix(cli): reject unknown --flag on op commands; add put --file

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,8 @@ SETUP
 
 PAGES
   gbrain get <slug>                     Read a page (fuzzy slug matching)
-  gbrain put <slug> [< file.md]         Write/update (auto-versions)
+  gbrain put <slug> --file PATH         Write/update from file (auto-versions)
+  gbrain put <slug> --content "..."     Write/update inline (or pipe via stdin)
   gbrain delete <slug>                  Delete a page
   gbrain list [--type T] [--tag T]      List with filters
 

--- a/docs/GBRAIN_V0.md
+++ b/docs/GBRAIN_V0.md
@@ -242,7 +242,7 @@ Every error follows the style guide: problem + cause + fix + docs link.
 ```
 gbrain init [--supabase|--url <conn>]     # create brain
 gbrain get <slug>                          # read a page
-gbrain put <slug> [< file.md]             # write/update a page
+gbrain put <slug> [--file PATH|--content TEXT|< file.md]  # write/update a page
 gbrain search <query>                      # keyword search (tsvector)
 gbrain query <question>                    # hybrid search (RRF + expansion)
 gbrain ingest <file> [--type ...]         # ingest a source document

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1637,7 +1637,8 @@ SETUP
 
 PAGES
   gbrain get <slug>                     Read a page (fuzzy slug matching)
-  gbrain put <slug> [< file.md]         Write/update (auto-versions)
+  gbrain put <slug> --file PATH         Write/update from file (auto-versions)
+  gbrain put <slug> --content "..."     Write/update inline (or pipe via stdin)
   gbrain delete <slug>                  Delete a page
   gbrain list [--type T] [--tag T]      List with filters
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -118,12 +118,31 @@ function parseOpArgs(op: Operation, args: string[]): Record<string, unknown> {
     const arg = args[i];
     if (arg.startsWith('--')) {
       const key = arg.slice(2).replace(/-/g, '_');
+      // Cross-cutting global flag: parseGlobalFlags() already set
+      // cliOpts.dryRun and left `--dry-run` in the arg stream so CLI_ONLY
+      // commands can parse it locally. Skip here so the strict-unknown
+      // check below doesn't reject it on op-backed commands.
+      if (key === 'dry_run') continue;
       const paramDef = op.params[key];
-      if (paramDef?.type === 'boolean') {
+      // Reject unknown flags. Silently absorbing them caused this whole family
+      // of bugs: --file consumed the path into a ghost key, --cotent (typo of
+      // --content) ate the user's content. Fail loud — list the recognized
+      // flags so the caller can self-correct.
+      if (!paramDef) {
+        const cmd = op.cliHints?.name ?? op.name;
+        const recognized = Object.keys(op.params).map(k => `--${k.replace(/_/g, '-')}`).sort();
+        console.error(`Error: unknown flag ${arg} for \`gbrain ${cmd}\``);
+        console.error(`  Recognized flags: ${recognized.join(', ')}`);
+        process.exit(1);
+      }
+      if (paramDef.type === 'boolean') {
         params[key] = true;
       } else if (i + 1 < args.length) {
         params[key] = args[++i];
-        if (paramDef?.type === 'number') params[key] = Number(params[key]);
+        if (paramDef.type === 'number') params[key] = Number(params[key]);
+      } else {
+        console.error(`Error: flag ${arg} requires a value`);
+        process.exit(1);
       }
     } else if (posIdx < positional.length) {
       const key = positional[posIdx++];
@@ -146,16 +165,17 @@ function parseOpArgs(op: Operation, args: string[]): Record<string, unknown> {
   return params;
 }
 
-function makeContext(engine: BrainEngine, params: Record<string, unknown>): OperationContext {
+function makeContext(engine: BrainEngine, _params: Record<string, unknown>): OperationContext {
+  const cliOpts = getCliOptions();
   return {
     engine,
     config: loadConfig() || { engine: 'postgres' },
     logger: { info: console.log, warn: console.warn, error: console.error },
-    dryRun: (params.dry_run as boolean) || false,
+    dryRun: cliOpts.dryRun,
     // Local CLI invocation — the user owns the machine; do not apply remote-caller
     // confinement (e.g., cwd-locked file_upload).
     remote: false,
-    cliOpts: getCliOptions(),
+    cliOpts,
   };
 }
 
@@ -532,7 +552,7 @@ SETUP
 
 PAGES
   get <slug>                         Read a page
-  put <slug> [< file.md]             Write/update a page
+  put <slug> [--file PATH|--content TEXT]  Write/update a page (or pipe markdown via stdin)
   delete <slug>                      Delete a page
   list [--type T] [--tag T] [-n N]   List pages
 

--- a/src/core/cli-options.ts
+++ b/src/core/cli-options.ts
@@ -15,12 +15,14 @@ export interface CliOptions {
   quiet: boolean;
   progressJson: boolean;
   progressInterval: number; // ms
+  dryRun: boolean;
 }
 
 export const DEFAULT_CLI_OPTIONS: CliOptions = {
   quiet: false,
   progressJson: false,
   progressInterval: 1000,
+  dryRun: false,
 };
 
 /**
@@ -32,6 +34,8 @@ export const DEFAULT_CLI_OPTIONS: CliOptions = {
  *   --progress-json
  *   --progress-interval=<ms>
  *   --progress-interval <ms>   (space-separated form)
+ *   --dry-run                  (cross-cutting; honored by any mutating op
+ *                               that checks ctx.dryRun)
  *
  * Unknown flags are passed through unchanged — per-command parsers see them.
  */
@@ -47,6 +51,16 @@ export function parseGlobalFlags(argv: string[]): { cliOpts: CliOptions; rest: s
     }
     if (a === '--progress-json') {
       cliOpts.progressJson = true;
+      continue;
+    }
+    if (a === '--dry-run') {
+      // Cross-cutting: honored by every mutating op (`ctx.dryRun`) AND by
+      // CLI_ONLY commands that parse their own --dry-run from subArgs
+      // (doctor, dream, lint, check-resolvable, repair-jsonb). We therefore
+      // set cliOpts here but KEEP --dry-run in `rest` so the per-command
+      // parsers still find it. parseOpArgs() has a matching carveout.
+      cliOpts.dryRun = true;
+      rest.push(a);
       continue;
     }
     if (a === '--progress-interval' && i + 1 < argv.length) {
@@ -143,5 +157,6 @@ export function childGlobalFlags(cliOpts?: CliOptions): string {
   if (opts.progressInterval !== DEFAULT_CLI_OPTIONS.progressInterval) {
     parts.push(`--progress-interval=${opts.progressInterval}`);
   }
+  if (opts.dryRun) parts.push('--dry-run');
   return parts.length > 0 ? ' ' + parts.join(' ') : '';
 }

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -3,7 +3,7 @@
  * Each operation defines its schema, handler, and optional CLI hints.
  */
 
-import { lstatSync, realpathSync } from 'fs';
+import { lstatSync, readFileSync, realpathSync, statSync } from 'fs';
 import { resolve, relative, sep } from 'path';
 import type { BrainEngine } from './engine.ts';
 import { clampSearchLimit } from './engine.ts';
@@ -187,7 +187,7 @@ export interface OperationContext {
    * may leave it undefined — consumers default to quiet/no-progress for
    * background work.
    */
-  cliOpts?: { quiet: boolean; progressJson: boolean; progressInterval: number };
+  cliOpts?: { quiet: boolean; progressJson: boolean; progressInterval: number; dryRun: boolean };
 }
 
 export interface Operation {
@@ -240,16 +240,57 @@ const get_page: Operation = {
   cliHints: { name: 'get', positional: ['slug'] },
 };
 
+const PUT_FILE_MAX_BYTES = 5_000_000; // 5MB — matches the stdin cap in cli.ts
+
 const put_page: Operation = {
   name: 'put_page',
   description: 'Write/update a page (markdown with frontmatter). Chunks, embeds, reconciles tags, and (when auto_link/auto_timeline are enabled) extracts + reconciles graph links and timeline entries.',
   params: {
     slug: { type: 'string', required: true, description: 'Page slug' },
-    content: { type: 'string', required: true, description: 'Full markdown content with YAML frontmatter' },
+    // `content` is effectively required but exactly one of {content, file,
+    // piped stdin} must be present. Expressing that "one of N" is awkward in
+    // the flat required-check, so validate in the handler (below) after
+    // --file → content resolution.
+    content: { type: 'string', description: 'Full markdown content with YAML frontmatter (or use --file / pipe via stdin)' },
+    file: { type: 'string', description: 'Path to a markdown file to read (local CLI only; alternative to --content)' },
   },
   mutating: true,
   handler: async (ctx, p) => {
     const slug = p.slug as string;
+
+    // Resolve --file into content before any side-effectful branch so the
+    // mutex + size cap + remote-denial fire on dry-run too (preview the
+    // validation, not the write).
+    if (p.file) {
+      if (ctx.remote === true) {
+        throw new OperationError(
+          'permission_denied',
+          '--file is not available for remote/MCP callers. Pass content directly via the `content` param.',
+        );
+      }
+      if (p.content) {
+        throw new OperationError(
+          'invalid_params',
+          'Cannot use both --file and --content — pick one.',
+        );
+      }
+      const filePath = resolve(p.file as string);
+      const st = statSync(filePath);
+      if (st.size > PUT_FILE_MAX_BYTES) {
+        throw new OperationError(
+          'invalid_params',
+          `File exceeds ${PUT_FILE_MAX_BYTES} bytes (${st.size}). Split into smaller inputs.`,
+        );
+      }
+      p.content = readFileSync(filePath, 'utf-8');
+    }
+
+    if (typeof p.content !== 'string' || p.content.length === 0) {
+      throw new OperationError(
+        'invalid_params',
+        'put_page requires content. Pass --content "...", --file <path>, or pipe markdown via stdin.',
+      );
+    }
 
     // Subagent namespace enforcement (v0.15+). Runs BEFORE the dry-run
     // short-circuit so preview calls surface the same rejection. Confines

--- a/test/cli-options.test.ts
+++ b/test/cli-options.test.ts
@@ -64,9 +64,31 @@ describe('parseGlobalFlags', () => {
   });
 
   test('all global flags combined', () => {
-    const r = parseGlobalFlags(['--quiet', '--progress-json', '--progress-interval=250', 'sync']);
-    expect(r.cliOpts).toEqual({ quiet: true, progressJson: true, progressInterval: 250 });
-    expect(r.rest).toEqual(['sync']);
+    const r = parseGlobalFlags(['--quiet', '--progress-json', '--progress-interval=250', '--dry-run', 'sync']);
+    expect(r.cliOpts).toEqual({ quiet: true, progressJson: true, progressInterval: 250, dryRun: true });
+    // --dry-run is a pass-through global — set on cliOpts AND left in rest
+    // so CLI_ONLY commands (doctor, dream, lint, etc.) can parse it locally.
+    // Ordering within `rest` follows the original argv ordering.
+    expect(r.rest).toEqual(['--dry-run', 'sync']);
+  });
+
+  test('--dry-run: sets dryRun=true AND passes through to rest', () => {
+    const r = parseGlobalFlags(['put', 'concepts/foo', '--dry-run', '--content', 'x']);
+    expect(r.cliOpts.dryRun).toBe(true);
+    expect(r.rest).toContain('--dry-run');
+    expect(r.rest).toEqual(['put', 'concepts/foo', '--dry-run', '--content', 'x']);
+  });
+
+  test('--dry-run leading before subcommand', () => {
+    const r = parseGlobalFlags(['--dry-run', 'put', 'concepts/foo']);
+    expect(r.cliOpts.dryRun).toBe(true);
+    // Flag passes through — ordering preserved minus stripped flags (none here).
+    expect(r.rest).toEqual(['--dry-run', 'put', 'concepts/foo']);
+  });
+
+  test('dryRun defaults to false when --dry-run absent', () => {
+    const r = parseGlobalFlags(['put', 'concepts/foo']);
+    expect(r.cliOpts.dryRun).toBe(false);
   });
 });
 
@@ -78,7 +100,7 @@ describe('getCliOptions / setCliOptions singleton', () => {
 
   test('setCliOptions applies + getCliOptions returns a copy', () => {
     _resetCliOptionsForTest();
-    setCliOptions({ quiet: false, progressJson: true, progressInterval: 250 });
+    setCliOptions({ quiet: false, progressJson: true, progressInterval: 250, dryRun: false });
     expect(getCliOptions().progressJson).toBe(true);
     expect(getCliOptions().progressInterval).toBe(250);
   });
@@ -138,12 +160,12 @@ describe('CLI integration: progress streams to the right channel', () => {
 
 describe('cliOptsToProgressOptions', () => {
   test('--quiet → quiet mode', () => {
-    const opts = cliOptsToProgressOptions({ quiet: true, progressJson: false, progressInterval: 1000 });
+    const opts = cliOptsToProgressOptions({ quiet: true, progressJson: false, progressInterval: 1000, dryRun: false });
     expect(opts.mode).toBe('quiet');
   });
 
   test('--progress-json → json mode with interval', () => {
-    const opts = cliOptsToProgressOptions({ quiet: false, progressJson: true, progressInterval: 500 });
+    const opts = cliOptsToProgressOptions({ quiet: false, progressJson: true, progressInterval: 500, dryRun: false });
     expect(opts.mode).toBe('json');
     expect(opts.minIntervalMs).toBe(500);
   });
@@ -155,7 +177,7 @@ describe('cliOptsToProgressOptions', () => {
   });
 
   test('quiet takes priority over progressJson', () => {
-    const opts = cliOptsToProgressOptions({ quiet: true, progressJson: true, progressInterval: 1000 });
+    const opts = cliOptsToProgressOptions({ quiet: true, progressJson: true, progressInterval: 1000, dryRun: false });
     expect(opts.mode).toBe('quiet');
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -137,3 +137,51 @@ describe('CLI dispatch integration', () => {
     expect(tools[0]).toHaveProperty('parameters');
   });
 });
+
+describe('strict flag parsing (v0.18.3+)', () => {
+  test('unknown --flag on a command prints error + recognized flags, exits 1', async () => {
+    // Prior to v0.18.3 the parser silently absorbed --file into a ghost key;
+    // now it rejects any flag not declared on the op. `put --bogus-flag foo`
+    // is mutating, but dispatch fails at parse time before any DB connect.
+    const proc = Bun.spawn(
+      ['bun', 'run', 'src/cli.ts', 'put', 'concepts/x', '--bogus-flag', 'foo'],
+      {
+        cwd: new URL('..', import.meta.url).pathname,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    );
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('unknown flag --bogus-flag');
+    expect(stderr).toContain('Recognized flags:');
+    // put_page now lists --content and --file (plus slug, which isn't a --flag).
+    expect(stderr).toContain('--content');
+    expect(stderr).toContain('--file');
+  });
+
+  test('unknown --flag typo caught (regression guard for --cotent etc.)', async () => {
+    // Typo-class silent-absorb bug: before v0.18.3, `--cotent foo` sent foo
+    // into a ghost key and stdin-fallback filled content with an empty read.
+    const proc = Bun.spawn(
+      ['bun', 'run', 'src/cli.ts', 'put', 'concepts/x', '--cotent', 'hi'],
+      {
+        cwd: new URL('..', import.meta.url).pathname,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    );
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('unknown flag --cotent');
+  });
+
+  test('help hint shows --file / --content, not `[< file.md]`', () => {
+    // The top-level `gbrain --help` used to say `put <slug> [< file.md]`,
+    // which read flag-shaped and misled agents into guessing --file.
+    expect(cliSource).not.toMatch(/put <slug> \[< file\.md\]/);
+    expect(cliSource).toContain('--file PATH');
+  });
+});

--- a/test/put-file-flag.test.ts
+++ b/test/put-file-flag.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the `put_page` --file flag (v0.18.3+).
+ *
+ * Covers:
+ *  - --file reads the file into content (dry-run short-circuits before the engine call)
+ *  - --file + --content → invalid_params (mutex)
+ *  - --file over size cap → invalid_params
+ *  - --file with remote=true (MCP) → permission_denied (no host filesystem access from agents)
+ *  - Empty content (no --file, no --content, no stdin) → invalid_params with guidance
+ */
+
+import { afterAll, beforeAll, describe, test, expect } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { operations, OperationError } from '../src/core/operations.ts';
+import type { Operation, OperationContext } from '../src/core/operations.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+const put_page = operations.find(o => o.name === 'put_page') as Operation;
+if (!put_page) throw new Error('put_page op missing');
+
+function makeCtx(overrides: Partial<OperationContext> = {}): OperationContext {
+  const engine = {} as BrainEngine;
+  return {
+    engine,
+    config: { engine: 'postgres' } as any,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    dryRun: true, // short-circuits before engine call so we never need a real DB
+    remote: false,
+    ...overrides,
+  };
+}
+
+const SAMPLE = `---
+title: Sample
+type: concept
+---
+
+# Sample
+
+Body text.
+`;
+
+let tmpDir: string;
+let samplePath: string;
+let bigPath: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'gbrain-put-file-'));
+  samplePath = join(tmpDir, 'sample.md');
+  writeFileSync(samplePath, SAMPLE, 'utf-8');
+  bigPath = join(tmpDir, 'too-big.md');
+  // 5MB cap; write 5,000,001 bytes to trip the size check.
+  writeFileSync(bigPath, 'x'.repeat(5_000_001), 'utf-8');
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('put_page --file', () => {
+  test('reads file and passes through the content pipeline (dry-run)', async () => {
+    const ctx = makeCtx();
+    const result = await put_page.handler(ctx, { slug: 'concepts/sample', file: samplePath });
+    expect(result).toMatchObject({ dry_run: true, action: 'put_page', slug: 'concepts/sample' });
+  });
+
+  test('rejects --file + --content with invalid_params', async () => {
+    const ctx = makeCtx();
+    await expect(
+      put_page.handler(ctx, { slug: 'concepts/sample', file: samplePath, content: 'inline' }),
+    ).rejects.toBeInstanceOf(OperationError);
+    try {
+      await put_page.handler(ctx, { slug: 'concepts/sample', file: samplePath, content: 'inline' });
+    } catch (e) {
+      expect((e as OperationError).code).toBe('invalid_params');
+      expect((e as OperationError).message).toContain('Cannot use both');
+    }
+  });
+
+  test('rejects oversized file with invalid_params', async () => {
+    const ctx = makeCtx();
+    try {
+      await put_page.handler(ctx, { slug: 'concepts/big', file: bigPath });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(OperationError);
+      expect((e as OperationError).code).toBe('invalid_params');
+      expect((e as OperationError).message).toMatch(/exceeds/);
+    }
+  });
+
+  test('rejects --file from remote callers with permission_denied', async () => {
+    const ctx = makeCtx({ remote: true });
+    try {
+      await put_page.handler(ctx, { slug: 'concepts/sample', file: samplePath });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(OperationError);
+      expect((e as OperationError).code).toBe('permission_denied');
+      expect((e as OperationError).message).toMatch(/remote|MCP/);
+    }
+  });
+
+  test('rejects missing content (no --file, no --content)', async () => {
+    const ctx = makeCtx();
+    try {
+      await put_page.handler(ctx, { slug: 'concepts/blank' });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(OperationError);
+      expect((e as OperationError).code).toBe('invalid_params');
+      expect((e as OperationError).message).toMatch(/--content|--file|stdin/);
+    }
+  });
+
+  test('rejects empty string content (same as missing)', async () => {
+    const ctx = makeCtx();
+    try {
+      await put_page.handler(ctx, { slug: 'concepts/empty', content: '' });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(OperationError);
+      expect((e as OperationError).code).toBe('invalid_params');
+    }
+  });
+});


### PR DESCRIPTION
Silent swallow of unrecognized flags was the root of a family of agent-facing bugs: --file being absorbed into a ghost key, typos like --cotent eating the user's content, and --dry-run landing on no-one. parseOpArgs now fails loud on any undeclared flag and lists the recognized set, so callers self-correct instead of silently writing empty pages.

--file <path> is now a real, first-class flag on put_page: reads the file into content with a 5MB cap, mutex-checks against --content, and rejects MCP/remote callers (no host filesystem access to agents).

--dry-run is promoted to a cross-cutting global flag recognized by parseGlobalFlags() AND passed through to subArgs, so CLI_ONLY commands (doctor, dream, lint, check-resolvable, repair-jsonb) keep parsing it locally while op-backed commands honor ctx.dryRun via cliOpts.

Closes #380