### PR TITLE
fix: add /meetings/ and /notes/ to inferType path rules

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -168,6 +168,10 @@ function inferType(filePath?: string): PageType {
   if (lower.includes('/civic/')) return 'civic';
   if (lower.includes('/projects/') || lower.includes('/project/')) return 'project';
   if (lower.includes('/sources/') || lower.includes('/source/')) return 'source';
+  if (lower.includes('/meetings/')) return 'meeting';
+  if (lower.includes('/meeting/')) return 'meeting';
+  if (lower.includes('/notes/')) return 'note';
+  if (lower.includes('/note/')) return 'note';
   if (lower.includes('/media/')) return 'media';
   return 'concept';
 }


### PR DESCRIPTION
## Problem

`inferType` in `src/core/markdown.ts` has path-based rules for `people/`, `companies/`, `deals/`, `projects/`, `sources/`, `media/`, and several wiki subtypes — but no rule for `/meetings/` or `/notes/`.

Pages stored in a `meetings/` directory (common for Granola, calendar sync, and other meeting ingestion pipelines) fall through to the default `concept` type, even when their directory clearly signals they are meetings. Same for `notes/`.

## Impact

In our brain (5,190 pages), 756 meeting pages were mis-typed as `concept` because of this gap. The `meeting` and `note` types already exist in `PageType` (`src/core/types.ts`) and are referenced in the meeting-ingestion skill, but `inferType` never returns them from path inference.

## Fix

Adds four lines to `inferType`, before the `/media/` catch-all:

```typescript
if (lower.includes('/meetings/')) return 'meeting';
if (lower.includes('/meeting/')) return 'meeting';
if (lower.includes('/notes/')) return 'note';
if (lower.includes('/note/')) return 'note';
```

No behavior change for pages with explicit `type:` in frontmatter (frontmatter always wins via line 43).
