### PR TITLE
fix(pglite): guard idx_pages_source_id against pre-v21 brains (upgrade blocker)

### DIFF
--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -63,7 +63,18 @@ CREATE TABLE IF NOT EXISTS pages (
 CREATE INDEX IF NOT EXISTS idx_pages_type ON pages(type);
 CREATE INDEX IF NOT EXISTS idx_pages_frontmatter ON pages USING GIN(frontmatter);
 CREATE INDEX IF NOT EXISTS idx_pages_trgm ON pages USING GIN(title gin_trgm_ops);
-CREATE INDEX IF NOT EXISTS idx_pages_source_id ON pages(source_id);
+-- Guarded for existing brains where pages was created pre-v21 (no source_id
+-- column yet). Migration v21 adds the column; this index gets re-attempted
+-- via IF NOT EXISTS on the next initSchema. Fresh installs (CREATE TABLE
+-- above adds source_id) enter the branch immediately.
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='pages' AND column_name='source_id'
+  ) THEN
+    EXECUTE 'CREATE INDEX IF NOT EXISTS idx_pages_source_id ON pages(source_id)';
+  END IF;
+END $$;
 
 -- ============================================================
 -- content_chunks: chunked content with embeddings


### PR DESCRIPTION
## Summary

**Critical upgrade blocker** for existing PGLite brains at schema version 13-20: every attempt to upgrade to v0.18.0+ crashes with `column "source_id" does not exist`, and the v0.18.0 migration goes wedged after 3 consecutive partials.

## Root cause

`initSchema()` runs `pglite-schema.ts` **before** migrations apply, on every connect. The current schema includes:

\`\`\`sql
CREATE INDEX IF NOT EXISTS idx_pages_source_id ON pages(source_id);
\`\`\`

On existing brains created before v0.18.0, `pages` exists from an older schema without `source_id`. The `CREATE TABLE IF NOT EXISTS pages (...)` above is a no-op (table already exists), so the column stays missing. Then the unguarded `CREATE INDEX` hits the column before migration v21 has a chance to add it — crash.

## Fix

Wrap the index creation in a `DO` block that probes `information_schema.columns` first. Fresh installs enter the branch on first `initSchema` call (because the `CREATE TABLE` just created the column). Existing brains skip the index on first pass, let migration v21 add the column, then get the index on the very next `initSchema` call.

## Reproduction

- Start with any PGLite brain at schema version ≤ 20 (i.e. any brain upgrading from v0.13/v0.14/v0.15/v0.16/v0.17).
- Run \`gbrain apply-migrations --yes\`.
- Observe \`column "source_id" does not exist\` and \`Migration v0.18.0 is WEDGED\` after three retry cycles.

This PR, applied to v0.20.4, unblocks a clean v13 → v24 schema migration on an 80-page PGLite brain in my setup.

## Related memory / context

This is the "PGLite 顺序" failure mode called out in my lessons log from the 2026-04-21 upgrade cycle (see \`lessons_2026-04-21.md\` in our local CLAUDE notes). Keeping it for posterity in case other brains at v14.x attempt the same jump.

## Test plan

- [x] Reproduced on an 80-page PGLite brain pinned at schema v13 — crashed every upgrade until this fix.
- [x] After fix: \`gbrain init --migrate-only\` applies v14-v24 cleanly, \`gbrain apply-migrations --yes\` completes v0.18.0 through v0.18.1, \`gbrain doctor\` reports \`schema_version: Version 24 (latest: 24)\`.
- [ ] Fresh PGLite install path worth a look from reviewers — I verified manually but don't have an automated test against a brand-new \`~/.gbrain\` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)