### PR TITLE
fix: extend DIR_PATTERN to cover Evo brain directories

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -43,8 +43,9 @@ export type LinkResolutionType = 'qualified' | 'unqualified';
  *   - Gbrain canonical: people, companies, meetings, concepts, deal, civic, project, source, media, yc, projects
  *   - Our domain extensions: tech, finance, personal, openclaw (domain-organized wikis)
  *   - Our entity prefix: entities (we kept some legacy entities/projects/ pages)
+ *   - Evo's brain directories: agents, systems, ideas, tools, org, archive, hiring, household, inbox
  */
-const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities)';
+const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|deals|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities|agents|systems|ideas|tools|org|archive|hiring|household|inbox)';
 
 /**
  * Match `[Name](path)` markdown links pointing to entity directories.


### PR DESCRIPTION
Evo's brain uses agents/, systems/, ideas/, tools/, org/, archive/, hiring/, household/, inbox/ as top-level entity directories. Without these in DIR_PATTERN, the wiki-link extractor silently drops all links pointing to entities in those directories.

Also adds missing 'deals' plural variant.

Fixes #382