### PR TITLE
fix(doctor): graph_coverage hint references the actual extract commands

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -505,7 +505,7 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
       checks.push({
         name: 'graph_coverage',
         status: 'warn',
-        message: `Entity link coverage ${linkPct}%, timeline ${timelinePct}%. Run: gbrain link-extract && gbrain timeline-extract`,
+        message: `Entity link coverage ${linkPct}%, timeline ${timelinePct}%. Run: gbrain extract links && gbrain extract timeline`,
       });
     }
 

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -2,8 +2,7 @@
  * Shared link/timeline extraction utilities.
  *
  * Used by:
- *   - src/commands/link-extract.ts        (batch DB extraction)
- *   - src/commands/timeline-extract.ts    (batch DB extraction)
+ *   - src/commands/extract.ts             (batch DB extraction: `gbrain extract links|timeline|all`)
  *   - src/commands/backlinks.ts           (filesystem walk, legacy)
  *   - src/core/operations.ts put_page     (auto-link post-hook)
  *


### PR DESCRIPTION
## Summary

`gbrain doctor`'s `graph_coverage` warning currently suggests two commands that don't exist:

```
[WARN] graph_coverage: Entity link coverage 0%, timeline 0%. Run: gbrain link-extract && gbrain timeline-extract
```

```
$ gbrain link-extract
Unknown command: link-extract
$ gbrain timeline-extract
Unknown command: timeline-extract
```

The actual subcommands are `gbrain extract links` and `gbrain extract timeline` (or `gbrain extract all` to do both), defined in [src/commands/extract.ts](src/commands/extract.ts).

This is the moment the user is trying to learn the tool, so a wrong hint here is high-friction. Fix is a one-line string change in [src/commands/doctor.ts:508](src/commands/doctor.ts#L508).

## Also in this PR

A stale doc comment in [src/core/link-extraction.ts:5-6](src/core/link-extraction.ts#L5) referenced `src/commands/link-extract.ts` and `src/commands/timeline-extract.ts` — both were consolidated into `src/commands/extract.ts` some time ago. Updated the comment to point at the current file.

## Repro

```bash
gbrain doctor
# warning prints "Run: gbrain link-extract && gbrain timeline-extract"
gbrain link-extract        # Unknown command
gbrain extract links       # works
```

## After

```
[WARN] graph_coverage: Entity link coverage 0%, timeline 0%. Run: gbrain extract links && gbrain extract timeline
```

## Notes

- Hit this on a fresh upgrade from v0.14.2 → v0.20.4. Whole upgrade landed cleanly otherwise — really nice work on the dream/runCycle primitive and the supervisor.
- Tested locally: `bunx tsc --noEmit` clean, `bun test` no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
