### PR TITLE
fix: keep query working without embeddings

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -572,7 +572,7 @@ PAGES
 
 SEARCH
   search <query>                     Keyword search (tsvector)
-  query <question> [--no-expand]     Hybrid search (RRF + expansion)
+  query <question> [--no-expand]     Hybrid search (RRF + expansion, falls back to keyword-only)
   ask <question> [--no-expand]       Alias for query
 
 IMPORT/EXPORT

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -484,12 +484,20 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
     if (health.embed_coverage >= 0.9) {
       checks.push({ name: 'embeddings', status: 'ok', message: `${pct}% coverage, ${health.missing_embeddings} missing` });
     } else if (health.embed_coverage > 0) {
-      checks.push({ name: 'embeddings', status: 'warn', message: `${pct}% coverage, ${health.missing_embeddings} missing. Run: gbrain embed --stale` });
+      checks.push({
+        name: 'embeddings',
+        status: 'warn',
+        message: `${pct}% coverage, ${health.missing_embeddings} missing. Run: gbrain embed --stale. Query still works with keyword-only fallback if embeddings are unavailable.`,
+      });
     } else {
-      checks.push({ name: 'embeddings', status: 'warn', message: 'No embeddings yet. Run: gbrain embed --stale' });
+      checks.push({
+        name: 'embeddings',
+        status: 'warn',
+        message: 'No embeddings yet. Run: gbrain embed --stale. Query still works with keyword-only fallback if your provider does not support /embeddings.',
+      });
     }
   } catch {
-    checks.push({ name: 'embeddings', status: 'warn', message: 'Could not check embedding health' });
+    checks.push({ name: 'embeddings', status: 'warn', message: 'Could not check embedding health. Query may still work via keyword-only fallback.' });
   }
 
   // 8. Graph health (link + timeline coverage on entity pages).

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -9,7 +9,7 @@
 
 import OpenAI from 'openai';
 
-const MODEL = 'text-embedding-3-large';
+const MODEL = process.env.GBRAIN_EMBEDDING_MODEL ?? 'text-embedding-3-large';
 const DIMENSIONS = 1536;
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -77,10 +77,7 @@ export async function hybridSearch(
   // Run keyword search (always available, no API key needed)
   const keywordResults = await engine.searchKeyword(query, searchOpts);
 
-  // Skip vector search entirely if no OpenAI key is configured
-  if (!process.env.OPENAI_API_KEY) {
-    // Apply backlink boost in keyword-only path too. One getBacklinkCounts query
-    // per search request; not N+1.
+  const returnKeywordOnly = async (): Promise<SearchResult[]> => {
     if (keywordResults.length > 0) {
       try {
         const slugs = Array.from(new Set(keywordResults.map(r => r.slug)));
@@ -91,7 +88,20 @@ export async function hybridSearch(
         // Boost failure is non-fatal: keep unboosted ranking.
       }
     }
-    return dedupResults(keywordResults).slice(offset, offset + limit);
+
+    const deduped = dedupResults(keywordResults, opts?.dedupOpts);
+    if (deduped.length === 0 && opts?.detail === 'low') {
+      return hybridSearch(engine, query, { ...opts, detail: 'high' });
+    }
+
+    return deduped.slice(offset, offset + limit);
+  };
+
+  // Skip vector search entirely if no OpenAI key is configured.
+  // Also keep a stable keyword-only path for providers that expose chat/completions
+  // but not /embeddings.
+  if (!process.env.OPENAI_API_KEY) {
+    return returnKeywordOnly();
   }
 
   // Determine query variants (optionally with expansion)
@@ -117,11 +127,12 @@ export async function hybridSearch(
       embeddings.map(emb => engine.searchVector(emb, searchOpts)),
     );
   } catch {
-    // Embedding failure is non-fatal, fall back to keyword-only
+    // Embedding failure is non-fatal; treat unsupported providers the same as no embeddings.
+    return returnKeywordOnly();
   }
 
   if (vectorLists.length === 0) {
-    return dedupResults(keywordResults).slice(offset, offset + limit);
+    return returnKeywordOnly();
   }
 
   // Merge all result lists via RRF (includes normalization + boost)

--- a/test/hybrid-search.test.ts
+++ b/test/hybrid-search.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect, mock } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+import type { SearchResult } from '../src/core/types.ts';
+
+mock.module('../src/core/embedding.ts', () => ({
+  embed: async () => {
+    throw new Error('404 page not found');
+  },
+}));
+
+const { hybridSearch } = await import('../src/core/search/hybrid.ts');
+
+function makeResult(overrides: Partial<SearchResult> = {}): SearchResult {
+  return {
+    slug: 'history/claude-code',
+    page_id: 1,
+    title: 'Claude Code History',
+    type: 'note',
+    chunk_text: 'Claude Code 历史对话',
+    chunk_source: 'compiled_truth',
+    chunk_id: 1,
+    chunk_index: 0,
+    score: 0.5,
+    stale: false,
+    ...overrides,
+  };
+}
+
+function mockEngine(overrides: Partial<Record<string, any>> = {}): BrainEngine {
+  return new Proxy({} as BrainEngine, {
+    get(_, prop: string) {
+      if (prop in overrides) return overrides[prop];
+      return () => Promise.resolve([]);
+    },
+  });
+}
+
+describe('hybridSearch keyword-only fallback', () => {
+  test('returns keyword results when embedding provider fails', async () => {
+    const keywordResults = [
+      makeResult({ slug: 'history/claude-code', score: 0.6, chunk_text: 'Claude Code 历史对话与 MCP 排障' }),
+      makeResult({
+        slug: 'history/codex',
+        page_id: 2,
+        chunk_id: 2,
+        score: 0.4,
+        title: 'Codex History',
+        chunk_text: 'Codex 历史对话',
+      }),
+    ];
+
+    const engine = mockEngine({
+      searchKeyword: async () => keywordResults,
+      getBacklinkCounts: async () => new Map([
+        ['history/claude-code', 10],
+        ['history/codex', 0],
+      ]),
+      searchVector: async () => {
+        throw new Error('searchVector should not run when embed fails');
+      },
+    });
+
+    process.env.OPENAI_API_KEY = 'test-key';
+
+    const results = await hybridSearch(engine, 'Claude Code 历史对话', { limit: 10 });
+
+    expect(results).toHaveLength(2);
+    expect(results[0].slug).toBe('history/claude-code');
+    expect(results[0].score).toBeGreaterThan(0.6);
+    expect(results[1].slug).toBe('history/codex');
+  });
+
+  test('skips vector path entirely when no OPENAI_API_KEY is configured', async () => {
+    const engine = mockEngine({
+      searchKeyword: async () => [makeResult({ slug: 'history/claude-code', score: 0.7 })],
+      getBacklinkCounts: async () => new Map(),
+      searchVector: async () => {
+        throw new Error('searchVector should not run without OPENAI_API_KEY');
+      },
+    });
+
+    delete process.env.OPENAI_API_KEY;
+
+    const results = await hybridSearch(engine, 'Claude Code 历史对话', { limit: 10 });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].slug).toBe('history/claude-code');
+  });
+});


### PR DESCRIPTION
## Summary
- keep `query` on the keyword-only path when embeddings are unavailable or unsupported
- allow the embedding model to be overridden via `GBRAIN_EMBEDDING_MODEL`
- clarify fallback behavior in `doctor` output, CLI help text, and add regression tests

## Test plan
- [x] `bun test test/hybrid-search.test.ts`
- [x] `bun run src/cli.ts --help`
- [x] `gbrain doctor --json`