### PR TITLE
ci: Tier 1 runs all 20 E2E files; fix three test fragilities

### DIFF
--- a/.env.testing.example
+++ b/.env.testing.example
@@ -7,6 +7,13 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5433/gbrain_test
 # Option B: Real Supabase instance (tests the actual production path)
 # DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-0-us-east-1.pooler.supabase.com:6543/postgres
 
+# Required for tests that exercise the Minions shell handler (e.g.
+# test/e2e/minions-shell.test.ts). The shell handler refuses to register
+# unless this is '1' — it's a security gate against arbitrary shell exec.
+# Safe to enable in test envs against a localhost test container; do NOT
+# set this in production environments unless you've reviewed the RCE risk.
+GBRAIN_ALLOW_SHELL_JOBS=1
+
 # Tier 2 (required for skill tests, optional for mechanical tests)
 OPENAI_API_KEY=sk-...
 ANTHROPIC_API_KEY=sk-ant-...

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,9 +37,20 @@ jobs:
           bun-version: latest
       - run: bun install
       - name: Run Tier 1 E2E tests
-        run: bun test test/e2e/mechanical.test.ts test/e2e/mcp.test.ts
+        # Run every test/e2e/*.test.ts via scripts/run-e2e.sh (what
+        # `bun run test:e2e` invokes). Previously this listed only
+        # mechanical.test.ts + mcp.test.ts, leaving 18 files untested
+        # in CI. The other files (cycle.test.ts, minions-shell.test.ts,
+        # sync.test.ts, upgrade.test.ts, etc) are mechanical too and
+        # run cleanly against the same Postgres service. skills.test.ts
+        # is included but skips gracefully when API keys are not set
+        # (Tier 2 below sets them and runs skills properly).
+        run: bun run test:e2e
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/gbrain_test
+          # Required for test/e2e/minions-shell.test.ts. Safe in CI
+          # runner against the ephemeral test container.
+          GBRAIN_ALLOW_SHELL_JOBS: '1'
 
   tier2:
     name: Tier 2 (LLM Skills)

--- a/test/e2e/mechanical.test.ts
+++ b/test/e2e/mechanical.test.ts
@@ -786,9 +786,17 @@ describeE2E('E2E: Init Edge Cases', () => {
     const env = { ...process.env };
     delete env.DATABASE_URL;
     delete env.GBRAIN_DATABASE_URL;
+    // Run from /tmp so Bun does NOT auto-load the project's .env (which
+    // contains DATABASE_URL on dev machines and would re-populate the env
+    // we just deleted, defeating the test). cwd determines Bun's .env
+    // search root; an absolute path to src/cli.ts lets us still execute
+    // the right script. CI runners don't have .env so the bug doesn't
+    // surface there ... but every developer machine does. Without this
+    // cwd switch, this test passes on CI and fails locally.
+    const cliPath = join(import.meta.dir, '../..', 'src/cli.ts');
     const result = Bun.spawnSync({
-      cmd: ['bun', 'run', 'src/cli.ts', 'init', '--non-interactive'],
-      cwd: join(import.meta.dir, '../..'),
+      cmd: ['bun', 'run', cliPath, 'init', '--non-interactive'],
+      cwd: '/tmp',
       env,
       timeout: 10_000,
     });
@@ -1124,9 +1132,16 @@ describeE2E('E2E: RLS Verification', () => {
       expect(result.exitCode).toBe(0);
       expect(stderr + stdout).not.toMatch(/42P01|does not exist.*budget/i);
 
-      // Version must have advanced to 24.
+      // Version must have advanced past 24. Originally this asserted exactly
+      // '24' because that was the latest version when the test was written.
+      // After the dream-cycle remediation added v25/v26/v27, re-rolling to 23
+      // and re-running runs ALL pending migrations, so the version lands at
+      // the current LATEST_VERSION. The intent of the test is "v24 didn't
+      // crash with 42P01" — assert v24 successfully ran, not that v24 is the
+      // last migration that exists.
       const afterRows = await conn.unsafe(`SELECT value FROM config WHERE key = 'version'`);
-      expect((afterRows[0] as any).value).toBe('24');
+      const versionAfter = parseInt((afterRows[0] as any).value, 10);
+      expect(versionAfter).toBeGreaterThanOrEqual(24);
 
       // The tables stayed dropped (v12 didn't re-run because current=23 > 12
       // was already true before this test ran). That's intentional — we're

--- a/test/init-migrate-only.test.ts
+++ b/test/init-migrate-only.test.ts
@@ -22,16 +22,21 @@ let tmp: string;
 let origHome: string | undefined;
 
 function run(args: string[]): { exitCode: number; stdout: string; stderr: string } {
-  // Strip DATABASE_URL / GBRAIN_DATABASE_URL from the subprocess env. The
+  // Strip every env var that loadConfig() reads (src/core/config.ts). The
   // "no config" error-path tests need loadConfig() to return null, which it
-  // won't if any env var fallback is set (src/core/config.ts:30). Tests
-  // that seed their own config use freshHomeWithConfig() below.
+  // won't if any env var fallback is set. Tests that seed their own config
+  // use freshHomeWithConfig() below.
   const env = { ...process.env, HOME: tmp } as Record<string, string | undefined>;
   delete env.DATABASE_URL;
   delete env.GBRAIN_DATABASE_URL;
   try {
+    // cwd: tmp so Bun does not auto-load the project's .env into the
+    // subprocess and re-inject the env vars we just stripped. CLI is passed
+    // as an absolute path (set above), so the cwd swap doesn't affect script
+    // resolution.
     const stdout = execFileSync('bun', ['run', CLI, ...args], {
       env: env as Record<string, string>,
+      cwd: tmp,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });

--- a/test/skillpack-check.test.ts
+++ b/test/skillpack-check.test.ts
@@ -30,8 +30,11 @@ function run(args: string[]): { exitCode: number; stdout: string; stderr: string
   delete env.DATABASE_URL;
   delete env.GBRAIN_DATABASE_URL;
   try {
+    // cwd: tmp so Bun does not auto-load the project's .env into the
+    // subprocess and re-inject the env vars we just stripped.
     const stdout = execFileSync('bun', ['run', CLI, ...args], {
       env: env as Record<string, string>,
+      cwd: tmp,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });


### PR DESCRIPTION
Hi! I've been running `bun run test:e2e` end-to-end locally against a Docker test container while working on a fork, and surfaced three classes of fixable bugs that don't show up in the current CI workflow because Tier 1 only runs 2 of the 20 E2E files. This PR fixes all of them.

## Summary of changes

| File | What |
|---|---|
| `.github/workflows/e2e.yml` | Tier 1 now runs every `test/e2e/*.test.ts` via `bun run test:e2e` (was 2 files). `GBRAIN_ALLOW_SHELL_JOBS=1` added so `minions-shell.test.ts` can register its handler. |
| `test/e2e/mechanical.test.ts` | Fix `init --non-interactive without URL` (Bun .env auto-load) + fix `v24 self-heals` (stale version literal). |
| `test/init-migrate-only.test.ts` | Same Bun .env auto-load fix. |
| `test/skillpack-check.test.ts` | Same Bun .env auto-load fix. |
| `.env.testing.example` | Added `GBRAIN_ALLOW_SHELL_JOBS=1` with explanation. |

## The bugs

### 1. Tier 1 ran 2 of 20 E2E files

`.github/workflows/e2e.yml` listed only `mechanical.test.ts + mcp.test.ts`. The other 18 mechanical files (cycle.test.ts, sync.test.ts, upgrade.test.ts, minions-shell.test.ts, etc.) were never exercised in CI. **Result: green CI was a partial gate.** Switching to `bun run test:e2e` (which iterates every `test/e2e/*.test.ts` via `scripts/run-e2e.sh`) makes CI = local; new E2E files added later get picked up automatically.

`GBRAIN_ALLOW_SHELL_JOBS=1` added to the Tier 1 env because `test/e2e/minions-shell.test.ts` needs it (the shell handler refuses to register otherwise). Safe in the CI runner against the ephemeral postgres service.

### 2. Bun .env auto-load defeats env-deletion tests

Three test files (mechanical, init-migrate-only, skillpack-check) delete `DATABASE_URL` from the spawned subprocess env to test "no config" paths. But Bun auto-loads `.env` from cwd, and the spawn used `cwd: project_root`. Result: the deleted env vars get re-injected from project `.env`, defeating the test. **CI passes** because CI runners have no `.env` at project root. **Local runs fail** on every developer machine that has a `.env`.

Fix: spawn with `cwd: '/tmp'` (no `.env` there) and pass `src/cli.ts` as an absolute path so script resolution is cwd-independent. The bug-fix pattern is the same in all three files.

### 3. `v24 self-heals` test asserts exact version literal `'24'`

After rolling schema version back to 23 and re-triggering initSchema, the test asserts the resulting version is exactly `'24'`. That's correct when v24 is the latest migration, but the next time anyone adds v25, the rollback-and-replay advances to LATEST_VERSION (>=25), not 24. The literal is a time bomb.

Fix: assert `version >= 24`. The intent ("v24 ran cleanly without 42P01") is preserved; the assertion is robust to any future migration.

### 4. `.env.testing.example` missing `GBRAIN_ALLOW_SHELL_JOBS`

`test/e2e/minions-shell.test.ts` requires `GBRAIN_ALLOW_SHELL_JOBS=1` to even register the handler. Without it the test silently fails because the worker rejects the job as "shell handler disabled." Adding to `.env.testing.example` with an explanatory comment so contributors don't trip on it.

## Validation

- `bun test test/e2e/mechanical.test.ts test/init-migrate-only.test.ts test/skillpack-check.test.ts`: **87/87 pass**
- Diff is 49 insertions / 8 deletions across 5 files; no algorithm changes, all test infrastructure / CI workflow.

## Why these went undetected for so long

The CI workflow shape masked them. With Tier 1 running just 2 files, files like minions-shell.test.ts were never executed by CI, so the missing `GBRAIN_ALLOW_SHELL_JOBS` flag never produced a failing run. Similarly, the .env auto-load fragility doesn't fire in CI environments because they lack `.env`. The fix that stops this entire class of bug is the workflow change to run all 20 files; the others are downstream cleanups that get the new tests to actually pass.

Happy to split into separate PRs if you'd prefer per-bug review. Or merge all together — your call.