### PR TITLE
feat: Shippable Standard quality framework — 6-gate enforcement for shipping changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
     "typecheck": "tsc --noEmit",
     "check:jsonb": "scripts/check-jsonb-pattern.sh",
     "check:progress": "scripts/check-progress-to-stdout.sh",
+    "check:shippable": "scripts/check-shippable.sh",
+    "check:preship-e2e": "scripts/preship-e2e.sh",
+    "preship": "scripts/check-shippable.sh && scripts/preship-e2e.sh",
+    "preship:gate-only": "scripts/check-shippable.sh",
     "postinstall": "command -v gbrain >/dev/null 2>&1 && gbrain apply-migrations --yes --non-interactive || echo '[gbrain] postinstall skipped. If installed via bun install -g github:...: run `gbrain doctor` and `gbrain apply-migrations --yes` manually. See https://github.com/garrytan/gbrain/issues/218' 1>&2",
     "prepublish:clawhub": "bun run build:all",
     "publish:clawhub": "clawhub package publish . --family bundle-plugin"

--- a/quality/criteria.md
+++ b/quality/criteria.md
@@ -1,0 +1,134 @@
+# GBrain Shippable Standard — Quality Criteria
+
+This is the project's canonical quality bar. Every shipping change is checked
+against these 6 gates before merge. Failures classified `blocking` halt the
+ship; `warning` failures land but get tracked.
+
+**Enforcement:** `bun run preship` chains two stages:
+
+1. **Static gate scan** ... `scripts/check-shippable.sh` walks the 6 gates
+   against the diff. Fast, local, no DB. Catches contract drift, empty
+   catches, missing schema_version, raw SQL bypasses.
+2. **E2E** ... `scripts/preship-e2e.sh` runs Tier 1 mechanical tests when
+   feasible. Catches integration regressions (stale assertions, schema
+   drift, real-DB behavior) that the static scan can't. Order of attempts:
+     - DATABASE_URL set + reachable → run `bun run test:e2e` against it
+     - Docker available + responsive → spin test container, run, tear down
+     - Neither → SKIP loudly, exit 0 (CI is authoritative; do NOT merge red)
+
+The static gate alone is not enough ... PRs #17-19 demonstrated this:
+all three landed green-on-gate but red-on-E2E because the gate doesn't
+exercise the migration runner. `bun run preship` is now a single
+command that closes that loop locally when possible and surfaces the
+gap loudly when it can't.
+
+To run only the static gate (e.g., for a docs-only PR), use
+`bun run preship:gate-only`. To force-skip E2E (cosmetic PRs only),
+set `GBRAIN_PRESHIP_SKIP_E2E=1`. To turn the soft-skip into a hard
+fail (CI environments), set `GBRAIN_PRESHIP_REQUIRE_E2E=1`.
+
+The pre-ship skill (`skills/pre-ship-check/SKILL.md`) still walks the
+gates as agent judgment for the categories the static scan can't decide
+mechanically (PROOF, SCOPE, INTEGRATION-architectural). Wired into
+`/ship`'s pre-landing review phase.
+
+**Scope of checking:** gates run on lines ADDED in the current diff, not
+on whole files. Pre-existing patterns in modified files are not the fork's
+debt to fix in this PR ... they belong to whoever introduced them. Files
+byte-identical to `upstream/master` are fully exempted (the fork inherits
+upstream's quality, doesn't need to rewrite it). Override modes for
+audit-style scans:
+- `GBRAIN_SHIPPABLE_FULL_FILE=1` — flag every issue in changed files,
+  not just newly-added lines (use when cleaning up inherited debt).
+- `GBRAIN_NO_UPSTREAM_EXEMPT=1` — disable the upstream-byte-identical
+  exemption (use for upstream-bound PRs where you DO want to clean up
+  upstream patterns before submitting).
+
+**Scope:** This file is the project-specific instance of the global Quality
+Gate framework documented in `~/.claude/CLAUDE.md`. Gates here apply to
+GBrain code (TypeScript engine, skills, scripts). Gate the bar, not the
+journey — these answer "is it shippable?", not "is it perfect?"
+
+---
+
+## Category: CONTRACT (public API stability)
+## Criteria:
+  - Every public type that's part of an agent-consumable contract has a `schema_version: '<n>'` field. Agents need this to know when output shape changed.
+  - Edge-case behavior for N=0, N>cap, missing input, malformed input is documented in the function/method header. If undocumented, the implicit answer is "undefined behavior" and reviewers reject.
+  - Default values for cap/limit parameters are explicit, named constants (not magic numbers in the function body).
+  - When changing a public interface, the change is breaking ONLY if no consumer would silently misbehave. Otherwise add a new field and deprecate the old.
+## Severity: blocking
+## Source: dream-cycle review 2026-04-24 (missing schema_version on PromotionReport, silent listPages limit:500 cap)
+## Last triggered: 2026-04-24
+
+---
+
+## Category: IDEMPOTENCY (mutation safety)
+## Criteria:
+  - If this operation runs N times in a row, the resulting state equals running it once. State-mutating ops are keyed against duplicate writes (idempotency key, ON CONFLICT, hash-of-content lookup, or equivalent).
+  - Re-running on already-processed input produces a no-op or a structured "already processed" response, not a duplicate row / appended block / re-fired side effect.
+  - Migrations and bulk operations are resumable from interrupt — if killed mid-run, the next invocation picks up cleanly.
+  - When idempotency is genuinely impossible (e.g. external API call without idempotency support), the docstring says so explicitly and the caller can opt out.
+## Severity: blocking
+## Source: dream-cycle review 2026-04-24 (naive `compiled_truth + semanticNote` re-appends on every cycle)
+## Last triggered: 2026-04-24
+
+---
+
+## Category: OBSERVABILITY (visibility into what happened)
+## Criteria:
+  - Bulk operations (>1s typical runtime, or >100 items) stream progress through `src/core/progress.ts`. Silent multi-minute operations are forbidden.
+  - Errors carry structured context: at minimum `{ class, code, message }`, plus `hint` and `docs_url` where applicable. No bare `throw new Error("string")` in agent-facing code paths.
+  - Catch blocks are never empty. If you genuinely want to swallow an error, the comment above explains why and the swallowed error is at minimum logged at debug level. The pattern `} catch { /* skip */ }` is a code smell.
+  - Audit-worthy operations (writes, mutations, external API calls) emit a JSONL audit trail line. Pattern follows `src/core/minions/shell-audit.ts`.
+## Severity: blocking (empty catches), warning (missing progress on borderline-bulk ops)
+## Source: dream-cycle review 2026-04-24 (silent 500-page scan, empty catch in collectEvidence)
+## Last triggered: 2026-04-24
+
+---
+
+## Category: INTEGRATION (composes with existing primitives)
+## Criteria:
+  - New features reach into the project's documented primitives, they don't duplicate or bypass them. Specifically: brain reads/writes go through `BrainEngine`, maintenance phases compose into `runCycle` (`src/core/cycle.ts`), background work goes through Minions (`src/core/minions/`), and progress through `src/core/progress.ts`.
+  - When the natural fit is "new phase in an existing pipeline," the change ADDS the phase, doesn't fork the pipeline.
+  - Public APIs follow the Contract-First pattern: types defined in `src/core/operations.ts` or equivalent, then CLI + MCP both generated from that single source.
+  - Trust boundary respected: `OperationContext.remote=true` callers are gated tighter than `remote=false` (CLI). Security-sensitive ops default to strict.
+## Severity: blocking
+## Source: dream-cycle review 2026-04-24 (added as sibling autopilot step instead of `phase: 'promotion'` in runCycle)
+## Last triggered: 2026-04-24
+
+---
+
+## Category: PROOF (real-data validation)
+## Criteria:
+  - Has been run end-to-end against real production-shape data, not just unit-test fixtures. PR description names the data set or environment.
+  - For brain operations specifically: dry-run on the Supabase brain (project `rlgonegzlxakquoiyzqq`), report numbers in PR. "Tested on real brain" without numbers is not enough.
+  - For algorithms with thresholds, dials, or scoring: include the actual threshold-vs-output curve from real data. If the default settings produce zero useful output on a real brain, the algorithm is wrong.
+  - For mutations: ran with `--dry-run` first, verified the proposed mutation list looks sane, then ran without dry-run on a non-production target if such exists.
+## Severity: blocking
+## Source: dream-cycle review 2026-04-24 (live dry-run returned 0 promotables — exact-text grouping fails on real brain)
+## Last triggered: 2026-04-24
+
+---
+
+## Category: SCOPE (docs match reality)
+## Criteria:
+  - Function/module docstrings describe what the code actually does, not what we hope it does. Aspirational docs are technical debt.
+  - Claims about security, performance, or completeness are honestly bounded. "Best-effort regex filter for phone numbers and SSN-shaped strings" not "PHI detection."
+  - When something is a known limitation (won't scale past N, doesn't handle case Y), the docstring says so. Surfacing limitations costs nothing; hiding them costs trust.
+  - Anti-patterns and "do not use this for X" are documented in the SKILL.md / module header, not buried in code review history.
+## Severity: warning
+## Source: dream-cycle review 2026-04-24 ("PHI detection" claim from 5 regex patterns is over-claiming)
+## Last triggered: 2026-04-24
+
+---
+
+## Maintenance
+
+Per `~/.claude/CLAUDE.md` Quality Gate rules:
+- Criteria that catch a real issue: update `Last triggered` to today's date.
+- Criteria triggered 3+ times: promote severity warning → blocking, OR mark "always check" in the gate-runner.
+- Criteria never triggered after 10+ evaluations: surface for pruning. Don't keep dead gates.
+- New failure pattern found in production: add a new gate or extend an existing one. Cite the incident in `Source`.
+
+When gates change, also update `skills/pre-ship-check/SKILL.md` so the runner reflects the current bar.

--- a/scripts/check-shippable.sh
+++ b/scripts/check-shippable.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# check-shippable.sh — Automated gate checks for the GBrain Shippable Standard.
+#
+# Walks a list of changed files, applies grep/AST patterns for each gate that
+# can be reduced to a deterministic check. Emits JSONL findings to stdout.
+# Judgment-based gates (PROOF, SCOPE, INTEGRATION-architectural) are left to
+# the agent in skills/pre-ship-check/SKILL.md.
+#
+# Usage:
+#   scripts/check-shippable.sh                    # diff vs master
+#   scripts/check-shippable.sh --base <ref>       # diff vs explicit base
+#   scripts/check-shippable.sh --all              # whole tree (audit mode)
+#   scripts/check-shippable.sh --files f1 f2 ...  # explicit file list
+#
+# Output: one JSON object per line to stdout. Schema:
+#   { gate, severity, file, line, evidence, fix_hint }
+#
+# Exit code: 0 if no blocking findings, 1 if any blocking finding emitted.
+# Compatibility: macOS bash 3.2 + Linux bash 4+.
+
+set -euo pipefail
+
+# Force C locale so awk can process arbitrary byte sequences in source files
+# (multibyte characters in comments, identifiers, etc.) without aborting.
+export LC_ALL=C
+export LANG=C
+
+BASE="master"
+MODE="diff"
+FILES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base) BASE="$2"; shift 2 ;;
+    --all) MODE="all"; shift ;;
+    --files) shift; while [[ $# -gt 0 && "$1" != --* ]]; do FILES+=("$1"); shift; done; MODE="explicit" ;;
+    -h|--help)
+      grep '^# ' "$0" | sed 's/^# //'
+      exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# --- Build the file list (bash 3.2 compatible, no mapfile) ---
+build_diff_list() {
+  # Capture committed + staged + unstaged changes vs $BASE.
+  # `git diff $BASE` (no triple-dot) includes the working tree, which is what
+  # a pre-ship check actually wants — what's *going to* ship, not just what's
+  # already committed. Then add untracked files explicitly.
+  local committed_or_uncommitted untracked
+  committed_or_uncommitted=$(git diff "$BASE" --name-only --diff-filter=AM 2>/dev/null | grep -E '\.(ts|js|md)$' || true)
+  untracked=$(git ls-files --others --exclude-standard 2>/dev/null | grep -E '\.(ts|js|md)$' || true)
+  while IFS= read -r line; do [[ -n "$line" ]] && FILES+=("$line"); done < <(
+    printf '%s\n%s\n' "$committed_or_uncommitted" "$untracked" | sort -u | grep -v '^$' || true
+  )
+}
+
+build_all_list() {
+  while IFS= read -r line; do FILES+=("$line"); done < <(
+    git ls-files | grep -E '\.(ts|js|md)$'
+  )
+}
+
+case "$MODE" in
+  diff) build_diff_list ;;
+  all) build_all_list ;;
+  explicit) : ;; # FILES already populated
+esac
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo '{"status":"no_changes","blocking_count":0,"warning_count":0}'
+  exit 0
+fi
+
+BLOCKING=0
+WARNINGS=0
+
+# --- Diff-awareness: only flag lines that were ADDED in this diff ---
+# Pre-existing patterns in modified files are not the fork's debt to fix.
+# Cache added-line sets per file in /tmp for the duration of this run.
+ADDED_LINES_CACHE_DIR="/tmp/shippable-$$"
+mkdir -p "$ADDED_LINES_CACHE_DIR"
+trap 'rm -rf "$ADDED_LINES_CACHE_DIR"' EXIT
+
+build_added_lines_for_file() {
+  local f="$1"
+  local cache_file="$ADDED_LINES_CACHE_DIR/$(echo "$f" | tr '/' '_').added"
+  [[ -f "$cache_file" ]] && return 0
+
+  # Untracked files (new): all lines are added.
+  if ! git ls-files --error-unmatch -- "$f" >/dev/null 2>&1; then
+    if [[ -f "$f" ]]; then
+      awk 'NR { print NR }' "$f" > "$cache_file"
+    else
+      : > "$cache_file"
+    fi
+    return 0
+  fi
+
+  # Tracked: parse hunk bodies line-by-line. Only `+` lines (excluding `+++`
+  # file markers) are true additions; context and `-` lines don't count.
+  # Hunk headers tell us where the new-file line counter starts.
+  git diff "$BASE" -- "$f" --unified=0 2>/dev/null | awk '
+    /^\+\+\+ / { in_hunk = 0; next }
+    /^--- /    { in_hunk = 0; next }
+    /^@@/ {
+      if (match($0, /\+([0-9]+)/)) {
+        cur_line = substr($0, RSTART+1, RLENGTH-1) + 0
+        in_hunk = 1
+      }
+      next
+    }
+    in_hunk && /^\+/ {
+      print cur_line
+      cur_line++
+      next
+    }
+    in_hunk && /^-/ { next }              # removed: no new-line advance
+    in_hunk && /^[ ]/ { cur_line++; next } # context: advance counter
+    in_hunk && /^\\/ { next }              # "\ No newline at end of file"
+  ' > "$cache_file"
+}
+
+is_line_added() {
+  local f="$1" line="$2"
+  local cache_file="$ADDED_LINES_CACHE_DIR/$(echo "$f" | tr '/' '_').added"
+  [[ -f "$cache_file" ]] || build_added_lines_for_file "$f"
+  grep -qFx "$line" "$cache_file"
+}
+
+emit() {
+  local gate="$1" severity="$2" file="$3" line="$4" evidence="$5" fix="$6"
+  # Diff-aware suppression: skip findings on lines that were not added in this
+  # diff. Pre-existing content in modified files is upstream's responsibility,
+  # not the fork's.
+  if [[ "${GBRAIN_SHIPPABLE_FULL_FILE:-0}" != "1" ]]; then
+    is_line_added "$file" "$line" || return 0
+  fi
+  if [[ "$severity" == "blocking" ]]; then BLOCKING=$((BLOCKING+1)); else WARNINGS=$((WARNINGS+1)); fi
+  local ev fx
+  ev=$(printf '%s' "$evidence" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr '\n' ' ')
+  fx=$(printf '%s' "$fix" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr '\n' ' ')
+  printf '{"gate":"%s","severity":"%s","file":"%s","line":%s,"evidence":"%s","fix_hint":"%s"}\n' \
+    "$gate" "$severity" "$file" "$line" "$ev" "$fx"
+}
+
+# --- Gate: OBSERVABILITY — empty catch blocks (multi-line aware) ---
+# Detects:
+#   } catch {}                                  (single-line empty)
+#   } catch (e) {}                              (single-line empty with var)
+#   } catch { /* anything */ }                  (single-line comment-only)
+#   } catch {<newline>// comment<newline>}      (multi-line comment-only)
+#   } catch {<newline>}                         (multi-line empty)
+check_empty_catches() {
+  local f="$1"
+  case "$f" in *.ts|*.js) ;; *) return 0 ;; esac
+  [[ -f "$f" ]] || return 0
+
+  # awk state machine: when we see `catch ... {`, start capturing until matching `}`,
+  # checking if any non-comment, non-whitespace content appears.
+  awk -v file="$f" '
+    {
+      # Detect start of catch block
+      if (match($0, /catch[[:space:]]*(\([^)]*\))?[[:space:]]*\{/)) {
+        catch_start = NR
+        catch_evidence = $0
+        # Strip everything before the catch
+        rest = substr($0, RSTART + RLENGTH)
+        depth = 1
+        has_content = 0
+        # Check the rest of this line (after the {)
+        # Strip /* ... */ comments
+        gsub(/\/\*[^*]*\*\//, "", rest)
+        # Strip // ... comments
+        sub(/\/\/.*/, "", rest)
+        # Count braces
+        for (i = 1; i <= length(rest); i++) {
+          c = substr(rest, i, 1)
+          if (c == "{") depth++
+          else if (c == "}") {
+            depth--
+            if (depth == 0) {
+              # Check if anything before this } was non-whitespace
+              prefix = substr(rest, 1, i - 1)
+              gsub(/[[:space:]]/, "", prefix)
+              if (length(prefix) > 0) has_content = 1
+              if (!has_content) {
+                printf "%d\t%s\n", catch_start, catch_evidence
+              }
+              catch_start = 0
+              break
+            }
+          } else if (c !~ /[[:space:]]/) {
+            has_content = 1
+          }
+        }
+        next
+      }
+      # If we are inside a catch block, accumulate
+      if (catch_start) {
+        line = $0
+        gsub(/\/\*[^*]*\*\//, "", line)
+        sub(/\/\/.*/, "", line)
+        for (i = 1; i <= length(line); i++) {
+          c = substr(line, i, 1)
+          if (c == "{") depth++
+          else if (c == "}") {
+            depth--
+            if (depth == 0) {
+              prefix = substr(line, 1, i - 1)
+              gsub(/[[:space:]]/, "", prefix)
+              if (length(prefix) > 0) has_content = 1
+              if (!has_content) {
+                printf "%d\t%s\n", catch_start, catch_evidence
+              }
+              catch_start = 0
+              break
+            }
+          } else if (c !~ /[[:space:]]/) {
+            has_content = 1
+          }
+        }
+      }
+    }
+  ' "$f" > /tmp/shippable-catch-$$.txt
+  while IFS=$'\t' read -r line evidence; do
+    emit "OBSERVABILITY" "blocking" "$f" "$line" "$evidence" \
+      "Empty catch swallows errors silently. Replace with structured logging: catch (e) { console.warn('[<context>] failed: %s', e instanceof Error ? e.message : String(e)); }"
+  done < /tmp/shippable-catch-$$.txt
+  rm -f /tmp/shippable-catch-$$.txt
+}
+
+# --- Gate: OBSERVABILITY — bulk operations without progress reporter ---
+check_missing_progress() {
+  local f="$1"
+  case "$f" in src/*.ts|src/*/*.ts|src/*/*/*.ts|src/*/*/*/*.ts) ;; *) return 0 ;; esac
+  [[ -f "$f" ]] || return 0
+
+  if grep -qE 'for[[:space:]]*\(.*[[:space:]]of[[:space:]]+(pages|files|entries|items|candidates|results)\b' "$f" 2>/dev/null && \
+     ! grep -q "createProgress\|startHeartbeat\|onProgress" "$f" 2>/dev/null; then
+    local line
+    line=$(grep -nE 'for[[:space:]]*\(.*[[:space:]]of[[:space:]]+(pages|files|entries|items|candidates|results)\b' "$f" | head -1 | cut -d: -f1)
+    emit "OBSERVABILITY" "warning" "$f" "${line:-1}" \
+      "Bulk loop over pages/files/entries with no progress reporter import" \
+      "If this loop is bulk (>100 iter) consider createProgress from src/core/progress.ts. Skip if loop is bounded small."
+  fi
+}
+
+# --- Gate: CONTRACT — exported Report types missing schema_version ---
+check_report_schema_version() {
+  local f="$1"
+  case "$f" in *.ts) ;; *) return 0 ;; esac
+  [[ -f "$f" ]] || return 0
+
+  awk '
+    /^export interface [A-Z][A-Za-z0-9_]*Report\b/ {
+      iface_name = $3; iface_line = NR; in_iface = 1; found_schema = 0; next
+    }
+    in_iface && /schema_version[[:space:]]*:/ { found_schema = 1 }
+    in_iface && /^}/ {
+      if (!found_schema) print iface_name "\t" iface_line
+      in_iface = 0
+    }
+  ' "$f" > /tmp/shippable-schema-$$.txt
+  while IFS=$'\t' read -r name line; do
+    emit "CONTRACT" "blocking" "$f" "$line" \
+      "interface ${name} has no schema_version field" \
+      "Add 'schema_version: \"1\"' as a literal-typed field. Agents need this to detect output-shape changes across versions."
+  done < /tmp/shippable-schema-$$.txt
+  rm -f /tmp/shippable-schema-$$.txt
+}
+
+# --- Gate: INTEGRATION — raw SQL outside engine implementations ---
+check_engine_bypass() {
+  local f="$1"
+  case "$f" in *.ts) ;; *) return 0 ;; esac
+  [[ -f "$f" ]] || return 0
+
+  # Engine implementations and migration code are allowed raw SQL
+  case "$f" in
+    src/core/*-engine.ts|src/core/migrate.ts|src/core/db.ts|src/core/pglite-schema.ts|src/schema*.ts|src/core/utils.ts) return 0 ;;
+  esac
+
+  grep -nE 'sql[[:space:]]*`(SELECT|INSERT|UPDATE|DELETE|CREATE|ALTER|DROP)\b' "$f" 2>/dev/null > /tmp/shippable-sql-$$.txt || true
+  while IFS=':' read -r line evidence; do
+    [[ -z "$line" ]] && continue
+    emit "INTEGRATION" "warning" "$f" "$line" "$evidence" \
+      "Raw SQL outside engine implementations. Reach into BrainEngine methods instead. If new capability, add it to the engine interface first."
+  done < /tmp/shippable-sql-$$.txt
+  rm -f /tmp/shippable-sql-$$.txt
+}
+
+# --- Upstream-identical exemption ---
+# A file that's byte-identical to upstream/master represents debt the fork
+# didn't introduce. Don't block the ship on inherited upstream patterns.
+# Newly-modified or fork-only files run gates normally.
+#
+# Set GBRAIN_NO_UPSTREAM_EXEMPT=1 to disable (e.g. for upstream-bound PRs
+# where you DO want to clean up inherited debt before submitting).
+EXEMPTED=0
+is_upstream_identical() {
+  local f="$1"
+  [[ "${GBRAIN_NO_UPSTREAM_EXEMPT:-0}" == "1" ]] && return 1
+  git rev-parse --verify upstream/master >/dev/null 2>&1 || return 1
+  git ls-tree upstream/master -- "$f" >/dev/null 2>&1 || return 1
+  [[ -z "$(git diff upstream/master -- "$f" 2>/dev/null)" ]]
+}
+
+# --- Run all checks against the file list ---
+for f in "${FILES[@]}"; do
+  if is_upstream_identical "$f"; then
+    EXEMPTED=$((EXEMPTED+1))
+    continue
+  fi
+  check_empty_catches "$f"
+  check_missing_progress "$f"
+  check_report_schema_version "$f"
+  check_engine_bypass "$f"
+done
+
+# --- Summary line at end (machine-readable) ---
+printf '{"summary":{"blocking_count":%d,"warning_count":%d,"upstream_exempted_files":%d}}\n' "$BLOCKING" "$WARNINGS" "$EXEMPTED"
+
+# --- Exit code ---
+[[ "$BLOCKING" -eq 0 ]]

--- a/scripts/preship-e2e.sh
+++ b/scripts/preship-e2e.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# preship-e2e.sh — Run Tier 1 E2E tests when feasible during pre-ship.
+#
+# Closes the framework gap that let PRs #17-19 land while their E2E test
+# was failing on master. The Shippable Standard's gate scan is fast and
+# local; E2E catches integration regressions. Both belong in `preship`.
+#
+# Behavior (in order, first match wins):
+#   1. DATABASE_URL set + reachable      → run bun run test:e2e against it
+#   2. Docker available + responsive     → spin test container, run, tear down
+#   3. Neither                           → SKIP loudly, exit 0 (CI is authoritative)
+#
+# Why skip-loud-exit-0 instead of exit 1: blocking ship on "you don't have
+# Docker" punishes laptops without docker. The framework's enforcement
+# story: preship catches what it can locally; CI is the authoritative
+# gate (and you should not merge red CI). Loud skip makes the gap visible
+# without blocking work.
+#
+# Override flags:
+#   GBRAIN_PRESHIP_SKIP_E2E=1  Don't run E2E even if reachable. For
+#                              cosmetic-only PRs (docs, comments) when
+#                              you're confident E2E isn't relevant. Use
+#                              sparingly — abuse defeats the gate.
+#   GBRAIN_PRESHIP_REQUIRE_E2E=1  Reverse: skip-when-impossible becomes
+#                                 fail-when-impossible. For CI environments
+#                                 where you DO want a hard gate.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Auto-source .env.testing if it exists. This is the canonical place per
+# .env.testing.example for the local Tier 1 DATABASE_URL. Sourcing it here
+# means the user runs `bun run preship` once and Path 1 fires automatically
+# without having to remember the env var. The file is gitignored, so each
+# machine has its own copy.
+#
+# Explicit DATABASE_URL in the parent shell still wins (set -a is scoped to
+# this `if` block, so we don't override an already-exported value).
+if [[ -f .env.testing ]]; then
+  # shellcheck disable=SC1091  (file is .env-format, not bash; that's fine)
+  set -a
+  # Only export vars from .env.testing that aren't already set, so a parent
+  # shell's DATABASE_URL takes precedence.
+  while IFS='=' read -r key value; do
+    [[ -z "$key" || "$key" =~ ^# ]] && continue
+    # Strip surrounding quotes from value if present
+    value="${value#\"}"; value="${value%\"}"
+    value="${value#\'}"; value="${value%\'}"
+    if [[ -z "${!key:-}" ]]; then
+      export "$key=$value"
+    fi
+  done < .env.testing
+  set +a
+fi
+
+# Honor the explicit skip first.
+if [[ "${GBRAIN_PRESHIP_SKIP_E2E:-0}" == "1" ]]; then
+  echo "[preship-e2e] SKIPPED via GBRAIN_PRESHIP_SKIP_E2E=1" >&2
+  echo "[preship-e2e] Reminder: CI Tier 1 (Mechanical) will run E2E. Do NOT merge if CI is red." >&2
+  exit 0
+fi
+
+REQUIRE_E2E="${GBRAIN_PRESHIP_REQUIRE_E2E:-0}"
+
+# --- Path 1: caller already has DATABASE_URL pointing at a reachable test DB ---
+
+try_existing_database_url() {
+  [[ -n "${DATABASE_URL:-}" ]] || return 1
+
+  # Refuse to run E2E against the live brain. The Supabase pooler URL is the
+  # canonical production target; running E2E against it would write/truncate
+  # real data. Hard-fail with a clear message instead of silently nuking.
+  if [[ "$DATABASE_URL" == *"supabase.com"* || "$DATABASE_URL" == *"supabase.co"* ]]; then
+    echo "[preship-e2e] REFUSING: DATABASE_URL points at Supabase ($(echo "$DATABASE_URL" | sed 's|://[^@]*@|://***@|'))." >&2
+    echo "[preship-e2e] E2E truncates tables. Set DATABASE_URL to a local test DB instead, or unset it to use the Docker fallback." >&2
+    exit 2
+  fi
+
+  # Parse host + port from DATABASE_URL for pg_isready. Falls back to localhost:5432.
+  local host port
+  host=$(printf '%s' "$DATABASE_URL" | sed -nE 's|^postgres(ql)?://[^@]*@([^:/]+).*|\2|p')
+  port=$(printf '%s' "$DATABASE_URL" | sed -nE 's|^postgres(ql)?://[^@]*@[^:]+:([0-9]+).*|\2|p')
+  host="${host:-localhost}"
+  port="${port:-5432}"
+
+  if command -v pg_isready >/dev/null 2>&1; then
+    if pg_isready -h "$host" -p "$port" -t 3 >/dev/null 2>&1; then
+      echo "[preship-e2e] Using existing DATABASE_URL ($host:$port). Running test:e2e..." >&2
+      bun run test:e2e
+      return 0
+    fi
+    echo "[preship-e2e] DATABASE_URL set but $host:$port is not reachable; falling through." >&2
+    return 1
+  fi
+
+  # No pg_isready — try the test run anyway and let bun report.
+  echo "[preship-e2e] DATABASE_URL set; pg_isready not installed. Attempting E2E directly..." >&2
+  bun run test:e2e
+  return 0
+}
+
+# --- Path 2: spin a Docker test container, run E2E, tear down ---
+
+try_docker() {
+  command -v docker >/dev/null 2>&1 || return 1
+  docker info >/dev/null 2>&1 || return 1
+
+  # Pick a free port — try 5434 first (the project default per CLAUDE.md),
+  # fall back through 5435/5436/5437 if any is busy.
+  local port
+  for candidate in 5434 5435 5436 5437; do
+    if ! docker ps --filter "publish=$candidate" --format '{{.Names}}' | grep -q .; then
+      port=$candidate
+      break
+    fi
+  done
+  if [[ -z "${port:-}" ]]; then
+    echo "[preship-e2e] No free port in 5434-5437; falling through." >&2
+    return 1
+  fi
+
+  local container="gbrain-preship-pg-$$"
+  echo "[preship-e2e] Starting Docker test DB on port $port (container: $container)..." >&2
+
+  # Tear down on any exit (success, failure, Ctrl-C).
+  trap 'docker stop "$container" >/dev/null 2>&1 || true; docker rm "$container" >/dev/null 2>&1 || true' EXIT
+
+  if ! docker run -d --name "$container" \
+       -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres \
+       -e POSTGRES_DB=gbrain_test \
+       -p "$port:5432" \
+       pgvector/pgvector:pg16 >/dev/null; then
+    echo "[preship-e2e] Failed to start Docker container; falling through." >&2
+    return 1
+  fi
+
+  # Wait until ready, max 30s. Don't loop forever if pg never comes up.
+  local attempts=0
+  until docker exec "$container" pg_isready -U postgres >/dev/null 2>&1; do
+    attempts=$((attempts + 1))
+    if [[ $attempts -gt 30 ]]; then
+      echo "[preship-e2e] Postgres did not become ready in 30s; aborting Docker path." >&2
+      return 1
+    fi
+    sleep 1
+  done
+
+  echo "[preship-e2e] DB ready. Running test:e2e..." >&2
+  DATABASE_URL="postgresql://postgres:postgres@localhost:$port/gbrain_test" bun run test:e2e
+}
+
+# --- Path 3: skip-loud (or fail-loud if REQUIRE_E2E=1) ---
+
+skip_or_fail() {
+  if [[ "$REQUIRE_E2E" == "1" ]]; then
+    echo "[preship-e2e] FAIL: GBRAIN_PRESHIP_REQUIRE_E2E=1 but no test DB available" >&2
+    echo "[preship-e2e]       (no reachable DATABASE_URL, no responsive Docker daemon)." >&2
+    echo "[preship-e2e]       Either start Docker, set DATABASE_URL to a local test DB, or unset GBRAIN_PRESHIP_REQUIRE_E2E." >&2
+    exit 1
+  fi
+  echo ""                                                                    >&2
+  echo "[preship-e2e] ╔════════════════════════════════════════════════════╗" >&2
+  echo "[preship-e2e] ║  E2E SKIPPED                                       ║" >&2
+  echo "[preship-e2e] ║  No reachable DATABASE_URL and no responsive       ║" >&2
+  echo "[preship-e2e] ║  Docker daemon. Tier 1 (Mechanical) will run in    ║" >&2
+  echo "[preship-e2e] ║  CI; you are responsible for green CI before merge.║" >&2
+  echo "[preship-e2e] ║                                                    ║" >&2
+  echo "[preship-e2e] ║  To run E2E locally: start Docker and re-run, OR   ║" >&2
+  echo "[preship-e2e] ║  point DATABASE_URL at a local test Postgres.      ║" >&2
+  echo "[preship-e2e] ╚════════════════════════════════════════════════════╝" >&2
+  echo ""                                                                    >&2
+  exit 0
+}
+
+# --- Main: try paths in order ---
+
+if try_existing_database_url; then
+  exit 0
+fi
+
+if try_docker; then
+  exit 0
+fi
+
+skip_or_fail

--- a/skills/pre-ship-check/SKILL.md
+++ b/skills/pre-ship-check/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: pre-ship-check
+version: 1.0.0
+description: |
+  Walk a diff through the 6 Shippable Standard quality gates (CONTRACT, IDEMPOTENCY,
+  OBSERVABILITY, INTEGRATION, PROOF, SCOPE) defined in quality/criteria.md.
+  Combines automated grep-based checks with agent judgment for gates that
+  require context. Invoke before /ship to catch blocking-severity failures
+  early. Returns exit 1 on any blocking finding.
+triggers:
+  - "pre-ship check"
+  - "shippable check"
+  - "ready to ship"
+  - "quality gate"
+  - "before I ship"
+  - "is this shippable"
+  - "shippable standard"
+tools:
+  - shell
+mutating: false
+---
+
+# Pre-Ship Check — Shippable Standard
+
+> **Source of truth:** [quality/criteria.md](../../quality/criteria.md). The gate definitions live there. This skill is the runner.
+> **When invoked:** before `/ship`, before opening a PR, or when the agent/user wants a sanity check. NOT yet auto-wired into the ship workflow ... that is a follow-up. Today, the agent is responsible for invoking this skill. Run `bun run preship` from CLI for the same check.
+
+## Contract
+
+This skill guarantees:
+- Every gate in `quality/criteria.md` is evaluated against the current diff.
+- Each gate produces a structured finding: `{ gate, severity, file:line, evidence, fix_hint }`.
+- Blocking-severity failures HALT the ship workflow; warning-severity failures land but get logged.
+- The output is BOTH a human-readable report (for the user) AND a JSON envelope (for the ship workflow to consume).
+- Re-running the skill on the same diff produces the same findings (deterministic — gates that need agent judgment use temperature 0 prompts).
+
+## Phases
+
+### 1. Identify the diff
+
+```bash
+# Default: diff vs base branch (master)
+git diff master...HEAD --name-only > /tmp/preship-changed.txt
+
+# Or against an explicit base
+git diff <base>...HEAD --name-only > /tmp/preship-changed.txt
+```
+
+If the changed-files list is empty, exit 0 with `{ status: 'no_changes' }`. Nothing to check.
+
+### 2. Run automated gate checks
+
+Invoke `scripts/check-shippable.sh` against the changed-files list. This handles the gates that can be reduced to grep/AST patterns:
+
+| Gate | Automated check |
+|---|---|
+| CONTRACT | grep TypeScript files for new exported `interface .*Report` types missing `schema_version:` |
+| OBSERVABILITY | grep for empty catch blocks: `catch\s*(\([^)]*\))?\s*\{\s*\}` and trivial-skip patterns |
+| OBSERVABILITY | grep for bulk file ops (>100 iter loops over pages/files) without `createProgress` import |
+| INTEGRATION | grep for raw SQL strings outside engine implementations (engine bypass smell) |
+
+Output: `/tmp/preship-automated.json` with one line per finding.
+
+### 3. Walk the judgment gates
+
+For gates that need context (PROOF, SCOPE, INTEGRATION-architectural-fit, IDEMPOTENCY-semantic), examine the diff and PR description. Apply each gate's criteria from `quality/criteria.md`:
+
+- **CONTRACT — edge cases documented?** Read changed function/method headers; do docstrings name N=0, N>cap, malformed input behaviors? Flag undocumented surfaces.
+- **IDEMPOTENCY — duplicate-safe?** Trace mutating ops in the diff; is there an idempotency key, ON CONFLICT, content-hash lookup, or other dedup mechanism? Flag naive append/insert.
+- **INTEGRATION — composes vs duplicates?** For new feature code, identify which existing primitive it should compose into (BrainEngine, runCycle, Minions, progress.ts). Flag bypasses.
+- **PROOF — real-data evidence?** Read the PR description. Does it cite real-data validation with numbers (page counts, scores, timing)? Flag "tested on real brain" claims without numbers.
+- **SCOPE — claims honest?** Read changed docstrings. Are claims about security/performance/completeness honest about their limits? Flag aspirational documentation.
+
+Use temperature 0 for each judgment so re-runs produce the same findings.
+
+### 4. Produce the report
+
+Combine automated + judgment findings into a single structured envelope:
+
+```json
+{
+  "schema_version": "1",
+  "status": "blocked" | "warnings_only" | "clean" | "no_changes",
+  "gates_evaluated": ["CONTRACT", "IDEMPOTENCY", "OBSERVABILITY", "INTEGRATION", "PROOF", "SCOPE"],
+  "blocking_count": <int>,
+  "warning_count": <int>,
+  "findings": [
+    {
+      "gate": "OBSERVABILITY",
+      "severity": "blocking",
+      "file": "src/core/promotion.ts",
+      "line": 149,
+      "evidence": "} catch { /* skip pages with broken timelines */ }",
+      "fix_hint": "Replace empty catch with structured logging. Pattern: catch (e) { console.warn('[collectEvidence] skipping page %s: %s', page.slug, errMessage(e)); }"
+    }
+  ]
+}
+```
+
+Also produce a human-readable Markdown summary alongside.
+
+### 5. Exit code + ship-workflow contract
+
+- `exit 0` if `status` is `clean`, `warnings_only`, or `no_changes`.
+- `exit 1` if `status` is `blocked` (any blocking finding present).
+- Print the JSON envelope to stdout (machine-readable), the Markdown summary to stderr (human-readable). Stdout/stderr split matches `progress.ts` convention.
+
+`/ship` reads stdout; on `exit 1`, /ship halts with the findings list and instructs the user (or another agent) to fix.
+
+## Output Format
+
+### Human-readable (stderr)
+
+```markdown
+## Pre-Ship Check — <branch> vs <base>
+
+**Status: BLOCKED** (2 blocking, 1 warning)
+
+### Blocking findings
+
+#### OBSERVABILITY: empty catch block at src/core/promotion.ts:149
+Evidence: `} catch { /* skip pages with broken timelines */ }`
+Fix: Replace with structured logging. Pattern: `catch (e) { console.warn('...', errMessage(e)); }`
+
+#### INTEGRATION: bypasses runCycle at src/commands/autopilot.ts:342
+Evidence: dream-cycle added as sibling step in autopilot, not as a phase inside runCycle
+Fix: Move to src/core/cycle.ts as `phase: 'promotion'`. See quality/criteria.md INTEGRATION gate.
+
+### Warnings
+
+#### SCOPE: over-claims at src/core/promotion.ts:80
+Evidence: `looksLikePhi` claims "PHI detection" with 5 regex patterns
+Fix: Rename to `looksLikePhiOrSensitive` and scope docstring: "best-effort regex filter for phone/SSN-shaped strings, NOT a HIPAA control"
+```
+
+### Machine-readable (stdout)
+
+The JSON envelope from Phase 4. Stable schema (`schema_version: '1'`).
+
+## Anti-Patterns
+
+- Running this skill AFTER ship instead of before. Pre-ship check is a gate, not an audit. Land-then-check defeats the purpose.
+- Manually overriding blocking findings without changing the gate criteria first. If a finding is genuinely a false positive, fix the gate (in `quality/criteria.md` AND this skill's logic) before bypassing.
+- Adding new gates without updating `quality/criteria.md`. The criteria file is the source of truth; the skill is the runner.
+- Treating warnings as ignorable forever. Warnings triggered 3+ times should be promoted to blocking (per the Maintenance section in `quality/criteria.md`).
+- Running the skill in CI but not in `/ship`. Both should invoke it; CI catches things that escape pre-ship.
+
+## Tools Used
+
+- `shell` — runs `git diff`, `scripts/check-shippable.sh`, and emits the structured report.
+- (none from gbrain operations.ts — this skill is a pre-merge gate, not a brain operation)
+
+## See also
+
+- [quality/criteria.md](../../quality/criteria.md) — the gate definitions (source of truth)
+- [scripts/check-shippable.sh](../../scripts/check-shippable.sh) — automated gate checks
+- `~/.claude/CLAUDE.md` Quality Gate section — the global framework this skill instantiates for GBrain


### PR DESCRIPTION
## Summary

Introduces a 6-gate quality framework that runs as `bun run preship` to enforce the contract CLAUDE.md "Pre-ship requirements" already documents but doesn't execute. Catches a class of bugs that escape current review (missing schema_version, empty catches, re-promotion duplicates, silent multi-minute ops, etc.).

This is companion to a separate test/CI fix PR I'm also opening. **That one should land first** — this PR's E2E stage assumes Tier 1 has a healthy test surface, which the companion fixes.

## The 6 gates

| # | Gate | Catches |
|---|---|---|
| 1 | **CONTRACT** | schema_version on public types, edge cases documented, named constants for caps/limits |
| 2 | **IDEMPOTENCY** | mutating ops are duplicate-safe across reruns |
| 3 | **OBSERVABILITY** | bulk ops report progress, errors are structured, no empty catches |
| 4 | **INTEGRATION** | composes into existing primitives (BrainEngine, runCycle, Minions, progress.ts), no engine bypass |
| 5 | **PROOF** | tested on real production-shape data, not just unit fixtures |
| 6 | **SCOPE** | docstrings match actual behavior, claims about security/performance honestly bounded |

`quality/criteria.md` is the source of truth. The runner (`scripts/check-shippable.sh`) handles the gates that reduce to deterministic checks (multi-line empty-catch detection via awk, missing schema_version on `Report` types, raw SQL outside engine implementations); `skills/pre-ship-check/SKILL.md` is the agent skill that handles the judgment-based gates (PROOF, SCOPE, architectural INTEGRATION).

## What ships

- `quality/criteria.md` — the 6-gate spec
- `scripts/check-shippable.sh` — bash 3.2-compatible static gate runner with **line-level diff awareness** (only flags lines ADDED in current diff, not pre-existing content in modified files) and **upstream-byte-identical exemption** (downstream forks inherit upstream's quality)
- `scripts/preship-e2e.sh` — E2E runner. Auto-sources `.env.testing`. Three paths: existing `DATABASE_URL`, Docker auto-spin (ports 5434-5437), skip-loud. Refuses Supabase URLs (E2E truncates tables)
- `skills/pre-ship-check/SKILL.md` — the agent skill that walks the gates
- `package.json` — `bun run preship` (full chain), `preship:gate-only` (fast)

## Why this matters

- **Shippable code is a property of the codebase, not a property of any single agent's discipline.** CLAUDE.md says "agents should run E2E before shipping." That's documentation; this PR makes it executable.
- The static gate alone has caught real bugs in development on a fork: a re-promotion bug from naive `compiled_truth` concatenation; missing `schema_version` on a Report type; empty catch swallowing per-page errors. All three would have shipped without the gate.
- The framework's own diff passes its own gate (self-checking).

## Override flags

| Flag | Effect |
|---|---|
| `GBRAIN_SHIPPABLE_FULL_FILE=1` | Flag every issue in changed files, not just newly-added lines (audit mode for cleaning inherited debt) |
| `GBRAIN_NO_UPSTREAM_EXEMPT=1` | Disable upstream-byte-identical exemption (for upstream-bound PRs where you DO want to clean inherited patterns before submitting) |
| `GBRAIN_PRESHIP_SKIP_E2E=1` | Skip E2E (cosmetic-only PRs) |
| `GBRAIN_PRESHIP_REQUIRE_E2E=1` | Fail-loud when E2E can't run (CI environments) |

## Validation

- [x] Self-check on this PR's diff: 0 blocking, 0 warnings
- [x] `bun run preship:gate-only`: clean
- [x] The chain works end-to-end against a Postgres test container in author's local dev environment

## Notes

- The line-level diff awareness uses `git diff --unified=0` and parses hunk bodies line-by-line (NOT the hunk header counts, which include context lines). This means the gate doesn't bark on pre-existing patterns in files you happen to touch — important for files like `src/core/cycle.ts` that have long-standing intentional empty catches.
- The upstream-byte-identical exemption is dormant on this repo (`upstream/master` ref doesn't exist on `garrytan/gbrain`) but useful for downstream forks. Doesn't add complexity; harmless on the upstream itself.
- 806 insertions / 0 deletions: pure addition. No existing code modified.

Happy to discuss naming (Shippable Standard? Quality Gate? something else?) and the framework's location (`/quality/` vs alternative).