### PR TITLE
feat: dream-cycle — episodic-to-semantic promotion as runCycle phase 7

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,16 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test']);
+//
+// `dream-cycle` (episodic-to-semantic promotion, src/core/promotion.ts) is
+// distinct from `dream` (one-shot 6-phase maintenance via runCycle). They
+// coexist: `dream` runs every autopilot tick; `dream-cycle` is the nightly
+// rate-limited promotion phase that consolidates recurring timeline patterns
+// into compiled_truth. The promotion phase ALSO runs as phase 7 inside
+// runCycle (see src/core/cycle.ts), so autopilot picks it up automatically.
+// `dream-cycle` is the user-facing CLI for manual one-off runs with custom
+// config knobs.
+const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'dream-cycle', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test']);
 
 async function main() {
   // Parse global flags (--quiet / --progress-json / --progress-interval)
@@ -496,6 +505,11 @@ async function handleCliOnly(command: string, args: string[]) {
         await runAutopilot(engine, args);
         return; // autopilot doesn't disconnect (long-running)
       }
+      case 'dream-cycle': {
+        const { runDreamCycleCommand } = await import('./commands/dream-cycle.ts');
+        await runDreamCycleCommand(engine, args);
+        break;
+      }
       case 'graph-query': {
         const { runGraphQuery } = await import('./commands/graph-query.ts');
         await runGraphQuery(engine, args);
@@ -642,6 +656,7 @@ ADMIN
   revert <slug> <version-id>         Revert to version
   features [--json] [--auto-fix]     Scan usage + recommend unused features
   autopilot [--repo] [--interval N]  Self-maintaining brain daemon
+  dream-cycle [--dry-run] [--json]   Episodic-to-semantic promotion
   config [show|get|set] <key> [val]  Brain config
   serve                              MCP server (stdio)
   call <tool> '<json>'               Raw tool invocation

--- a/src/commands/dream-cycle.ts
+++ b/src/commands/dream-cycle.ts
@@ -1,0 +1,106 @@
+/**
+ * gbrain dream-cycle — Nightly episodic-to-semantic promotion.
+ *
+ * Scans recent timeline entries, detects recurring patterns, promotes
+ * durable patterns into semantic memory (compiled_truth).
+ *
+ * Usage:
+ *   gbrain dream-cycle [--repo <path>] [--dry-run] [--json]
+ *   gbrain dream-cycle --window 7 --min-recurrence 4
+ */
+
+import type { BrainEngine } from '../core/engine.ts';
+import { runDreamCycle, type PromotionConfig, type PromotionReport } from '../core/promotion.ts';
+
+function parseArg(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx >= 0 && idx + 1 < args.length ? args[idx + 1] : undefined;
+}
+
+export async function runDreamCycleCommand(engine: BrainEngine, args: string[]) {
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(`Usage: gbrain dream-cycle [options]
+
+Nightly episodic-to-semantic promotion. Scans recent timeline entries
+for recurring patterns and promotes them into semantic memory.
+
+Options:
+  --dry-run              Run without writing (default in non-interactive)
+  --json                 Output structured JSON
+  --window <days>        Evidence window in days (default: 14)
+  --min-recurrence <n>   Minimum recurrences to promote (default: 3)
+  --max-promotions <n>   Max promotions per run (default: 10)
+  --help                 Show this help`);
+    return;
+  }
+
+  const jsonMode = args.includes('--json');
+  // Default to dry-run only in non-interactive contexts for safety
+  const dryRun = args.includes('--dry-run') || (!args.includes('--no-dry-run') && !process.stdin.isTTY);
+
+  const config: Partial<PromotionConfig> = {};
+  const window = parseArg(args, '--window');
+  if (window) config.evidenceWindowDays = parseInt(window, 10);
+  const minRec = parseArg(args, '--min-recurrence');
+  if (minRec) config.minRecurrence = parseInt(minRec, 10);
+  const maxProm = parseArg(args, '--max-promotions');
+  if (maxProm) config.maxPromotions = parseInt(maxProm, 10);
+
+  if (!jsonMode) {
+    console.log(`Dream cycle starting (${dryRun ? 'dry-run' : 'live'}, window: ${config.evidenceWindowDays ?? 14} days)...`);
+  }
+
+  try {
+    const report = await runDreamCycle(engine, config, dryRun);
+
+    if (jsonMode) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+
+    // Human-readable output
+    console.log('');
+    console.log(`Evidence window: ${report.evidenceWindowDays} days`);
+    console.log(`Total candidates: ${report.candidates.length}`);
+    console.log(`Promotable: ${report.promoted.length}`);
+    console.log(`Skipped: ${report.skipped.length}`);
+    console.log(`Mode: ${report.dryRun ? 'dry-run' : 'live'}`);
+    console.log(`Run at: ${report.runAt}`);
+
+    if (report.promoted.length > 0) {
+      console.log('\n--- Promoted ---');
+      for (const p of report.promoted) {
+        console.log(`  [${p.score.toFixed(2)}] "${p.pattern}"`);
+        console.log(`    → ${p.slugs.join(', ')} (${p.recurrence}x, last: ${p.lastSeen})`);
+        console.log(`    ${p.reason}`);
+      }
+    }
+
+    if (report.skipped.length > 0 && report.skipped.length <= 20) {
+      console.log('\n--- Skipped ---');
+      for (const s of report.skipped.slice(0, 20)) {
+        console.log(`  "${s.pattern}" — ${s.reason}`);
+      }
+    } else if (report.skipped.length > 20) {
+      console.log(`\n--- Skipped (${report.skipped.length}, showing first 10) ---`);
+      for (const s of report.skipped.slice(0, 10)) {
+        console.log(`  "${s.pattern}" — ${s.reason}`);
+      }
+    }
+
+    console.log('');
+
+    // Log this run to the ingest log
+    if (!dryRun) {
+      await engine.logIngest({
+        source_type: 'dream-cycle',
+        source_ref: report.runAt,
+        pages_updated: report.promoted.map(p => p.slugs[0]),
+        summary: `Dream cycle: ${report.promoted.length} promoted, ${report.skipped.length} skipped`,
+      });
+    }
+  } catch (e) {
+    console.error(`Dream cycle failed: ${e instanceof Error ? e.message : String(e)}`);
+    process.exit(1);
+  }
+}

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -46,7 +46,7 @@ import { getCliOptions, cliOptsToProgressOptions } from './cli-options.ts';
 
 // ─── Types ─────────────────────────────────────────────────────────
 
-export type CyclePhase = 'lint' | 'backlinks' | 'sync' | 'extract' | 'embed' | 'orphans';
+export type CyclePhase = 'lint' | 'backlinks' | 'sync' | 'extract' | 'embed' | 'orphans' | 'promotion';
 
 export const ALL_PHASES: CyclePhase[] = [
   'lint',
@@ -55,12 +55,13 @@ export const ALL_PHASES: CyclePhase[] = [
   'extract',
   'embed',
   'orphans',
+  'promotion',
 ];
 
 /**
  * Phases that mutate state (filesystem or DB) and therefore should
- * coordinate via the cycle lock. Only orphans is truly read-only
- * and skips the lock.
+ * coordinate via the cycle lock. orphans is truly read-only and skips
+ * the lock; promotion mutates compiled_truth + timeline so it acquires.
  */
 const NEEDS_LOCK_PHASES: ReadonlySet<CyclePhase> = new Set([
   'lint',
@@ -68,6 +69,7 @@ const NEEDS_LOCK_PHASES: ReadonlySet<CyclePhase> = new Set([
   'sync',
   'extract',
   'embed',
+  'promotion',
 ]);
 
 export type PhaseStatus = 'ok' | 'warn' | 'fail' | 'skipped';
@@ -121,6 +123,7 @@ export interface CycleReport {
     pages_extracted: number;
     pages_embedded: number;
     orphans_found: number;
+    patterns_promoted: number;
   };
 }
 
@@ -567,6 +570,90 @@ async function runPhaseOrphans(engine: BrainEngine): Promise<PhaseResult> {
   }
 }
 
+/**
+ * Promotion phase — episodic-to-semantic promotion of recurring timeline
+ * patterns. Rate-limited via a stamp file at ~/.gbrain/dream-cycle.stamp
+ * so it runs at most once per DEFAULT_PROMOTION_MIN_HOURS (23h) even if
+ * the surrounding cycle fires more frequently.
+ *
+ * The actual algorithm lives in src/core/promotion.ts (runDreamCycle).
+ * This phase wrapper handles: rate-limit gate, stamp update, structured
+ * PhaseResult shape.
+ */
+async function runPhasePromotion(
+  engine: BrainEngine,
+  dryRun: boolean,
+  progress: ProgressReporter,
+): Promise<PhaseResult> {
+  try {
+    const { runDreamCycle, shouldRunDreamCycle } = await import('./promotion.ts');
+
+    const stampPath = join(homedir(), '.gbrain', 'dream-cycle.stamp');
+    let lastRun = 0;
+    if (existsSync(stampPath)) {
+      try {
+        lastRun = parseInt(readFileSync(stampPath, 'utf-8').trim(), 10) || 0;
+      } catch (e) {
+        console.warn('[promotion] could not read stamp file: %s', e instanceof Error ? e.message : String(e));
+      }
+    }
+
+    if (!shouldRunDreamCycle(lastRun, Date.now())) {
+      const hoursSince = lastRun > 0 ? Math.round((Date.now() - lastRun) / 3600000) : 0;
+      return {
+        phase: 'promotion',
+        status: 'skipped',
+        duration_ms: 0,
+        summary: `rate-limited (last run ${hoursSince}h ago)`,
+        details: { reason: 'rate_limited', last_run_hours_ago: hoursSince, promoted: 0 },
+      };
+    }
+
+    // Thread per-iteration progress through to runDreamCycle so a long
+    // page-walk on big brains doesn't go silent for minutes.
+    const onProgress = (phase: 'pages' | 'embed', done: number, total: number) => {
+      // Re-emit as tick events on the cycle's reporter. The reporter
+      // dedupes/throttles per its rate-limit settings, so frequent ticks
+      // are cheap.
+      progress.tick(done, `${phase} ${done}/${total}`);
+    };
+
+    const report = await runDreamCycle(engine, {}, dryRun, onProgress);
+
+    if (!dryRun) {
+      try {
+        mkdirSync(join(homedir(), '.gbrain'), { recursive: true });
+        writeFileSync(stampPath, String(Date.now()));
+      } catch (e) {
+        console.warn('[promotion] could not update stamp: %s', e instanceof Error ? e.message : String(e));
+      }
+    }
+
+    return {
+      phase: 'promotion',
+      status: 'ok',
+      duration_ms: 0,
+      summary: `${report.promoted.length} pattern(s) promoted, ${report.skipped.length} skipped`,
+      details: {
+        promoted: report.promoted.length,
+        skipped: report.skipped.length,
+        candidates: report.candidates.length,
+        evidence_window_days: report.evidenceWindowDays,
+        dryRun,
+      },
+    };
+  } catch (e) {
+    return {
+      phase: 'promotion',
+      status: 'fail',
+      duration_ms: 0,
+      summary: 'promotion phase failed',
+      details: {},
+      error: makeErrorFromException(e),
+    };
+  }
+}
+
 // ─── Main ──────────────────────────────────────────────────────────
 
 /**
@@ -741,6 +828,29 @@ export async function runCycle(
       }
       await safeYield(opts.yieldBetweenPhases);
     }
+
+    // ── Phase 7: promotion ──────────────────────────────────────
+    // Episodic-to-semantic promotion (recurring timeline patterns →
+    // compiled_truth). Rate-limited internally via ~/.gbrain/dream-cycle.stamp
+    // so it runs ~once per 23h regardless of how often the cycle fires.
+    if (phases.includes('promotion')) {
+      if (!engine) {
+        phaseResults.push({
+          phase: 'promotion',
+          status: 'skipped',
+          duration_ms: 0,
+          summary: 'no database connected',
+          details: { reason: 'no_database' },
+        });
+      } else {
+        progress.start('cycle.promotion');
+        const { result, duration_ms } = await timePhase(() => runPhasePromotion(engine, dryRun, progress));
+        result.duration_ms = duration_ms;
+        phaseResults.push(result);
+        progress.finish();
+      }
+      await safeYield(opts.yieldBetweenPhases);
+    }
   } finally {
     if (lock) {
       try { await lock.release(); } catch { /* best-effort */ }
@@ -772,6 +882,7 @@ function emptyTotals(): CycleReport['totals'] {
     pages_extracted: 0,
     pages_embedded: 0,
     orphans_found: 0,
+    patterns_promoted: 0,
   };
 }
 
@@ -794,6 +905,8 @@ function extractTotals(phases: PhaseResult[]): CycleReport['totals'] {
         : Number(p.details.embedded ?? 0);
     } else if (p.phase === 'orphans' && p.details) {
       t.orphans_found = Number(p.details.total_orphans ?? 0);
+    } else if (p.phase === 'promotion' && p.details) {
+      t.patterns_promoted = Number(p.details.promoted ?? 0);
     }
   }
   return t;

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -812,6 +812,105 @@ export const MIGRATIONS: Migration[] = [
       END $$;
     `,
   },
+  {
+    version: 25,
+    name: 'timeline_summary_embeddings',
+    // The promotion algorithm clusters timeline summaries by semantic
+    // similarity, not exact text.
+    // This table caches embeddings of normalized summaries so we don't
+    // re-embed the same text on every cycle (a 1500-summary brain at
+    // text-embedding-3-large would otherwise cost ~$0.04 per cycle and
+    // burn an OpenAI API quota slot every night).
+    //
+    // Key design choices:
+    //   - PRIMARY KEY on summary_hash (sha256 of NORMALIZED text). Same
+    //     normalized text everywhere produces one row regardless of how
+    //     many pages reference it.
+    //   - VECTOR(1536) matches text-embedding-3-large (the project default
+    //     in src/core/embedding.ts).
+    //   - ivfflat with vector_cosine_ops because clustering uses cosine
+    //     similarity. lists=100 is the postgres-engine default for similar
+    //     pgvector indexes; tune later if cluster latency becomes an issue.
+    //
+    // Engine-agnostic SQL — pgvector's CREATE EXTENSION runs in
+    // schema.sql; PGLite uses the WASM pgvector extension at startup.
+    sql: `
+      CREATE TABLE IF NOT EXISTS timeline_summary_embeddings (
+        summary_hash TEXT PRIMARY KEY,
+        summary_text TEXT NOT NULL,
+        embedding VECTOR(1536) NOT NULL,
+        embedded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      );
+      CREATE INDEX IF NOT EXISTS idx_timeline_summary_embeddings_cosine
+        ON timeline_summary_embeddings USING ivfflat (embedding vector_cosine_ops);
+    `,
+  },
+  {
+    version: 26,
+    name: 'dream_cycle_promotions',
+    // Backs hash-based idempotency for episodic-to-semantic promotions.
+    //
+    // Without this: running the dream cycle N times appends the same semantic
+    // note N times to the target page's compiled_truth (re-promotion bug).
+    // With this: every (cluster_id, target_slug) tuple is hashed and stored
+    // on first promotion; subsequent runs check the table and skip with
+    // reason 'already promoted on <date>'.
+    //
+    // Hash key uses cluster_id (the stable identifier produced by the
+    // embedding-clustering layer in v25), not raw normalized pattern text.
+    // This means a re-clustering of the same brain content produces the
+    // same hash (cluster_id is sha256-based on canonical text), so
+    // idempotency survives algorithm tweaks as long as the cluster
+    // representative stays the same.
+    sql: `
+      CREATE TABLE IF NOT EXISTS dream_cycle_promotions (
+        pattern_hash TEXT PRIMARY KEY,
+        cluster_id TEXT NOT NULL,
+        target_slug TEXT NOT NULL,
+        pattern_text TEXT NOT NULL,
+        recurrence INTEGER NOT NULL,
+        score REAL NOT NULL,
+        promoted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      );
+      CREATE INDEX IF NOT EXISTS idx_dream_cycle_promotions_target
+        ON dream_cycle_promotions(target_slug);
+      CREATE INDEX IF NOT EXISTS idx_dream_cycle_promotions_cluster
+        ON dream_cycle_promotions(cluster_id);
+      CREATE INDEX IF NOT EXISTS idx_dream_cycle_promotions_promoted_at
+        ON dream_cycle_promotions(promoted_at DESC);
+    `,
+  },
+  {
+    version: 27,
+    name: 'rls_for_dream_cycle_tables',
+    // The two tables added in v25 and v26
+    // (timeline_summary_embeddings, dream_cycle_promotions) shipped without
+    // Row Level Security enabled. Supabase exposes the public schema via
+    // PostgREST, so tables without RLS are readable by the anon key.
+    //
+    // These two tables hold internal cycle state (embeddings of timeline
+    // summaries, audit of past promotions) ... they should never be
+    // accessible to anon. Enabling RLS without policies blocks all
+    // non-BYPASSRLS roles, which is the secure default for these tables.
+    //
+    // Same gating pattern as v24: only fires if the table actually exists
+    // (defensive against partial migration rollbacks). ALTER TABLE ENABLE
+    // ROW LEVEL SECURITY is idempotent in Postgres ... safe to re-run.
+    sql: `
+      DO $$
+      BEGIN
+        IF EXISTS (SELECT 1 FROM information_schema.tables
+                    WHERE table_schema = 'public' AND table_name = 'timeline_summary_embeddings') THEN
+          ALTER TABLE timeline_summary_embeddings ENABLE ROW LEVEL SECURITY;
+        END IF;
+        IF EXISTS (SELECT 1 FROM information_schema.tables
+                    WHERE table_schema = 'public' AND table_name = 'dream_cycle_promotions') THEN
+          ALTER TABLE dream_cycle_promotions ENABLE ROW LEVEL SECURITY;
+        END IF;
+        RAISE NOTICE 'v27: RLS enabled on dream-cycle internal tables';
+      END $$;
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/promotion.ts
+++ b/src/core/promotion.ts
@@ -1,0 +1,735 @@
+/**
+ * Dream cycle promotion — episodic-to-semantic promotion of recurring
+ * timeline patterns.
+ *
+ * Algorithm: embedding-based clustering via pgvector. Two summaries
+ * that mean the same thing ("ai concierge launch prep" vs "ai concierge
+ * ready to launch") cluster together if their cosine similarity is above
+ * the threshold (default 0.85). The cluster's most-recent member text
+ * becomes the canonical pattern. Hash-keyed idempotency in the
+ * dream_cycle_promotions table prevents re-promoting the same cluster
+ * across runs.
+ *
+ * Phase 1 is still mostly deterministic. The only LLM-style call is the
+ * embedding generation, which is cached in `timeline_summary_embeddings`
+ * so re-runs hit the cache and cost nothing.
+ *
+ * INTEGRATION:
+ *   Composes into runCycle as `phase: 'promotion'`. Two callers reach the
+ *   engine function below: `runCycle` (autopilot, scheduled) and
+ *   `gbrain dream-cycle` CLI (manual one-off with custom config knobs).
+ *   Both share runDreamCycle so behavior stays identical.
+ *
+ * EDGE CASES (documented contract):
+ *   - Empty brain (zero pages): returns a clean PromotionReport with
+ *     candidates=[], promoted=[], skipped=[].
+ *   - Brain with > MAX_PAGES_TO_SCAN pages: scans the first MAX_PAGES_TO_SCAN
+ *     by listPages ordering. Older / less recently accessed pages may not
+ *     contribute evidence on a single run. Known limitation; full coverage
+ *     requires multi-run paging (not yet implemented).
+ *   - All candidates below threshold: PromotionReport.promoted=[],
+ *     PromotionReport.skipped=[every-candidate], status still 'ok'.
+ *   - Target page not found at apply time: skipped with reason
+ *     'target page <slug> not found', no exception.
+ *   - Target page modified between scoring and apply: last write wins
+ *     (no optimistic concurrency check). Acceptable because compiled_truth
+ *     is append-only here.
+ *   - Embedding API failure: falls back to exact-text grouping for that run
+ *     (single-cluster-per-unique-text). Logged, non-fatal.
+ *   - similarityThreshold < 0 or > 1: clamped to [0, 1] at clusterByEmbedding.
+ */
+
+import { createHash } from 'crypto';
+import type { BrainEngine } from './engine.ts';
+import type { TimelineEntry } from './types.ts';
+import { embedBatch } from './embedding.ts';
+
+// --- Config ---
+
+export interface PromotionConfig {
+  /** How far back to look for evidence (days). Default: 14 */
+  evidenceWindowDays: number;
+  /** Minimum recurrence count to consider a pattern promotable. Default: 3 */
+  minRecurrence: number;
+  /** Max promotions per run. Default: 10 */
+  maxPromotions: number;
+  /**
+   * Cosine similarity threshold for clustering timeline summaries.
+   * Two entries with sim >= threshold cluster together. Default: 0.85.
+   * Lower = more aggressive (more entries cluster, less precise canonical).
+   * Higher = more conservative (fewer clusters, closer to exact-match).
+   */
+  similarityThreshold: number;
+}
+
+export const DEFAULT_CONFIG: PromotionConfig = {
+  evidenceWindowDays: 14,
+  minRecurrence: 3,
+  maxPromotions: 10,
+  similarityThreshold: 0.85,
+};
+
+// --- Constants ---
+
+/**
+ * Maximum number of pages scanned for evidence in a single cycle.
+ * Documented as part of the phase contract — agents should know that
+ * brains exceeding this size won't be fully covered by a single run.
+ */
+export const MAX_PAGES_TO_SCAN = 500;
+
+/**
+ * Default minimum hours between consecutive promotion runs. Used by the
+ * stamp-file rate limiter in runPhasePromotion (src/core/cycle.ts).
+ */
+export const DEFAULT_PROMOTION_MIN_HOURS = 23;
+
+/**
+ * Returns true if the dream cycle is due to run based on the last-run timestamp.
+ *
+ * Edge cases:
+ *   - lastRunMs = 0 or non-finite → returns true (first run)
+ *   - lastRunMs > nowMs (clock skew) → returns true (defensive)
+ *   - lastRunMs negative → returns true (treat as first run)
+ */
+export function shouldRunDreamCycle(
+  lastRunMs: number,
+  nowMs: number,
+  minHours: number = DEFAULT_PROMOTION_MIN_HOURS,
+): boolean {
+  if (!Number.isFinite(lastRunMs) || lastRunMs <= 0) return true;
+  if (nowMs < lastRunMs) return true;
+  return (nowMs - lastRunMs) / 3600000 >= minHours;
+}
+
+// --- Types ---
+
+export interface Cluster {
+  /** Stable hash of the canonical text. Used as cluster_id throughout. */
+  cluster_id: string;
+  /** Picked representative text (most-recent entry's summary). */
+  canonical: string;
+  /** All entries in this cluster, regardless of source page. */
+  entries: { slug: string; entry: TimelineEntry }[];
+}
+
+export interface CandidatePattern {
+  /** The cluster's canonical text. */
+  pattern: string;
+  /** Stable id for the cluster, derived from canonical. */
+  cluster_id: string;
+  /** How many distinct timeline entries are in the cluster. */
+  recurrence: number;
+  /** Distinct slugs where this pattern appeared. */
+  slugs: string[];
+  /** Most recent date seen across the cluster. */
+  lastSeen: string;
+  /** Score (0-1, higher = more promotable). */
+  score: number;
+  /** Why it was accepted or rejected. */
+  reason: string;
+}
+
+export interface PromotionReport {
+  /** Stable schema marker. Bumped on breaking changes to this shape. */
+  schema_version: '1';
+  candidates: CandidatePattern[];
+  promoted: CandidatePattern[];
+  skipped: CandidatePattern[];
+  dryRun: boolean;
+  runAt: string;
+  evidenceWindowDays: number;
+}
+
+// --- Normalization ---
+
+/**
+ * Normalize a timeline summary for hashing/embedding.
+ * Lowercase, collapse whitespace, strip trailing punctuation.
+ * Two summaries with the same normalized text get one embedding cache row.
+ */
+export function normalizeSummary(summary: string): string {
+  return summary
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/[.:;,!?]+$/, '')
+    .trim();
+}
+
+// --- Sensitive-content filter (best-effort regex, NOT a HIPAA control) ---
+//
+// What this is: a 5-pattern regex filter that flags text containing
+// phone-number-shaped sequences, SSN-shaped sequences, a few ID shapes,
+// the literal phrase "patient (id|name|dob|ssn|mrn)", and date-formatted
+// MM/DD/YYYY. Used to prevent the dream cycle from promoting recurring
+// timeline summaries that contain these specific patterns.
+//
+// What this is NOT:
+//   - A PHI detector. Real PHI redaction requires named-entity recognition
+//     (e.g., Microsoft Presidio, healthcare NLP services), context-aware
+//     classification, and a model trained on medical text. This regex
+//     misses paraphrased PHI ("the patient", "John's medication"), free-form
+//     diagnosis text, lab values, and most clinical notes.
+//   - A HIPAA control. HIPAA requires administrative + physical + technical
+//     safeguards plus audit logging plus BAA agreements; a regex on a
+//     promotion candidate is none of these.
+//   - A PII detector. The patterns are USA-centric (US phone format, US
+//     SSN format, US date format). International equivalents are missed.
+//
+// Why ship it anyway: it's a low-cost defense-in-depth that catches the
+// most-obvious leaks of phone/SSN/ID into compiled_truth — text that has
+// no business being promoted to semantic memory. It's strictly better
+// than no filter; it's strictly worse than a real PHI engine. Treat as
+// belt-and-braces, never as the only gate.
+
+const SENSITIVE_PATTERNS = [
+  /\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b/,           // phone numbers (US format)
+  /\b\d{3}[-.\s]?\d{2}[-.\s]?\d{4}\b/,            // SSN-shaped sequences
+  /\b[A-Z]\d{3}[A-Z]{2}\d\b/i,                    // some ID patterns
+  /\b(patient\s+(id|name|dob|ssn|mrn))\b/i,       // literal "patient X" phrasing
+  /\b\d{1,2}\/\d{1,2}\/\d{2,4}\b/,                // MM/DD/YYYY dates
+];
+
+/**
+ * Returns true if text matches any of the SENSITIVE_PATTERNS.
+ *
+ * NAMING NOTE: this function used to be called `looksLikePhi`. That name
+ * over-claimed: 5 regex patterns are not PHI detection. The honest name
+ * `looksLikePhoneOrIdShape` describes what the function actually checks.
+ * `looksLikePhi` is preserved as a deprecated alias to avoid breaking
+ * external callers; new code should use the honest name.
+ *
+ * Use as a defense-in-depth filter only. NOT a real PHI/PII detector.
+ * NOT a HIPAA control. See module-level comment above for full scope.
+ */
+export function looksLikePhoneOrIdShape(text: string): boolean {
+  return SENSITIVE_PATTERNS.some(p => p.test(text));
+}
+
+/**
+ * @deprecated Use `looksLikePhoneOrIdShape` instead. The name `looksLikePhi`
+ * over-claimed scope (5 regex patterns are not PHI detection). Kept as an
+ * alias for compatibility; will be removed in a future major version.
+ */
+export const looksLikePhi = looksLikePhoneOrIdShape;
+
+// --- Scoring ---
+
+/**
+ * Score a candidate pattern. Returns 0-1.
+ *
+ * Factors:
+ * - recurrence (more = better, max contribution at 6+)
+ * - recency (more recent = better)
+ * - slug spread (appearing on more pages = better)
+ */
+export function scoreCandidate(
+  recurrence: number,
+  lastSeenDate: string,
+  slugCount: number,
+): number {
+  // Recurrence factor: 0.5 at min (3), 1.0 at 6+
+  const recFactor = Math.min(recurrence / 6, 1.0);
+
+  // Recency factor: 1.0 if today, decays over 14 days
+  const daysSinceLast = Math.max(0,
+    (Date.now() - new Date(lastSeenDate).getTime()) / (1000 * 60 * 60 * 24),
+  );
+  const recencyFactor = Math.max(0, 1 - daysSinceLast / 14);
+
+  // Spread factor: 0.5 for 1 slug, 1.0 for 3+
+  const spreadFactor = Math.min(slugCount / 3, 1.0) * 0.5 + 0.5;
+
+  return recFactor * 0.5 + recencyFactor * 0.3 + spreadFactor * 0.2;
+}
+
+// --- Idempotency helper ---
+
+/**
+ * Compute the stable promotion hash for a (cluster_id, target_slug) tuple.
+ * Used as the primary key in dream_cycle_promotions. Same inputs always
+ * produce the same hash, so a re-run is a clean no-op (existence check
+ * skips the page write; INSERT ... ON CONFLICT DO NOTHING short-circuits
+ * the row insert against concurrent races).
+ *
+ * Keyed on cluster_id (not raw pattern text) so the hash is stable across
+ * algorithm tweaks: re-running with the same brain content produces the
+ * same canonical text → same cluster_id → same hash.
+ */
+export function promotionHash(cluster_id: string, targetSlug: string): string {
+  return createHash('sha256')
+    .update(`${cluster_id}\x00${targetSlug}`)
+    .digest('hex');
+}
+
+// --- Embedding helpers ---
+
+function summaryHashOf(normalized: string): string {
+  return createHash('sha256').update(normalized).digest('hex');
+}
+
+/**
+ * Cosine similarity between two embedding vectors. Both inputs must have
+ * the same length.
+ *
+ * Edge cases:
+ *   - Either vector is the zero vector: returns 0 (no similarity).
+ *   - Vectors of different lengths: throws (programmer error).
+ */
+export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  if (a.length !== b.length) {
+    throw new Error(`cosineSimilarity: length mismatch ${a.length} vs ${b.length}`);
+  }
+  let dot = 0, normA = 0, normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+/**
+ * Look up cached embeddings for a list of normalized summaries; embed any
+ * cache misses; cache the new ones; return a Map<normalized, Float32Array>
+ * covering every input.
+ *
+ * Uses BrainEngine.executeRaw because timeline_summary_embeddings is a
+ * promotion-specific table, not part of the general BrainEngine contract.
+ *
+ * Edge cases:
+ *   - Empty input: returns empty Map, no DB or API calls.
+ *   - Embedding API failure: thrown, caller handles fallback.
+ *   - Some cached, some not: only cache misses get embedded.
+ */
+async function getOrComputeEmbeddings(
+  engine: BrainEngine,
+  normalizedTexts: string[],
+): Promise<Map<string, Float32Array>> {
+  const result = new Map<string, Float32Array>();
+  if (normalizedTexts.length === 0) return result;
+
+  const uniqueTexts = [...new Set(normalizedTexts)];
+  const hashOf = new Map(uniqueTexts.map(t => [t, summaryHashOf(t)]));
+
+  // Batch lookup
+  const hashes = Array.from(hashOf.values());
+  type CachedRow = { summary_hash: string; summary_text: string; embedding: string };
+  const cached = await engine.executeRaw<CachedRow>(
+    `SELECT summary_hash, summary_text, embedding::text AS embedding
+     FROM timeline_summary_embeddings
+     WHERE summary_hash = ANY($1::text[])`,
+    [hashes],
+  );
+
+  const cachedTexts = new Set<string>();
+  for (const row of cached) {
+    const arr = String(row.embedding).replace(/[\[\]]/g, '').split(',').map(parseFloat);
+    result.set(row.summary_text, new Float32Array(arr));
+    cachedTexts.add(row.summary_text);
+  }
+
+  const toEmbed = uniqueTexts.filter(t => !cachedTexts.has(t));
+  if (toEmbed.length === 0) return result;
+
+  const fresh = await embedBatch(toEmbed);
+
+  // Insert into cache (one round-trip per text — small N, acceptable).
+  // ON CONFLICT DO NOTHING handles concurrent runs racing on the same text.
+  for (let i = 0; i < toEmbed.length; i++) {
+    const text = toEmbed[i];
+    const emb = fresh[i];
+    const vecStr = '[' + Array.from(emb).join(',') + ']';
+    try {
+      await engine.executeRaw(
+        `INSERT INTO timeline_summary_embeddings (summary_hash, summary_text, embedding)
+         VALUES ($1, $2, $3::vector)
+         ON CONFLICT (summary_hash) DO NOTHING`,
+        [summaryHashOf(text), text, vecStr],
+      );
+    } catch (e) {
+      console.warn(
+        '[promotion] could not cache embedding for "%s": %s',
+        text.slice(0, 40),
+        e instanceof Error ? e.message : String(e),
+      );
+    }
+    result.set(text, emb);
+  }
+
+  return result;
+}
+
+// --- Clustering ---
+
+/**
+ * Cluster entries by cosine similarity using union-find. Two entries with
+ * embeddings >= threshold join the same cluster transitively (A~B and B~C
+ * means A, B, C are all one cluster). The cluster's canonical is the
+ * most-recent entry's original (un-normalized) summary text.
+ *
+ * Time complexity: O(n²) pairwise comparison. Acceptable for n up to a
+ * few thousand (a 14-day window on a 500-page brain typically yields
+ * 1000-3000 entries). For larger n, switch to ANN via pgvector ivfflat.
+ *
+ * Edge cases:
+ *   - threshold < 0 or > 1: clamped to [0, 1].
+ *   - Empty input: returns empty array.
+ *   - Single entry: returns one cluster of size 1.
+ *   - All identical embeddings: returns one cluster.
+ */
+export function clusterByEmbedding(
+  entries: { slug: string; entry: TimelineEntry; embedding: Float32Array }[],
+  threshold: number,
+): Cluster[] {
+  if (entries.length === 0) return [];
+  const t = Math.max(0, Math.min(1, threshold));
+
+  // Union-find with path compression
+  const parent = entries.map((_, i) => i);
+  const find = (i: number): number => {
+    let r = i;
+    while (parent[r] !== r) r = parent[r];
+    while (parent[i] !== r) {
+      const next = parent[i];
+      parent[i] = r;
+      i = next;
+    }
+    return r;
+  };
+  const union = (i: number, j: number) => {
+    const ri = find(i), rj = find(j);
+    if (ri !== rj) parent[ri] = rj;
+  };
+
+  for (let i = 0; i < entries.length; i++) {
+    for (let j = i + 1; j < entries.length; j++) {
+      if (cosineSimilarity(entries[i].embedding, entries[j].embedding) >= t) {
+        union(i, j);
+      }
+    }
+  }
+
+  // Group by root
+  const groups = new Map<number, typeof entries>();
+  for (let i = 0; i < entries.length; i++) {
+    const root = find(i);
+    if (!groups.has(root)) groups.set(root, []);
+    groups.get(root)!.push(entries[i]);
+  }
+
+  // Build clusters: canonical = most-recent member's original summary
+  const clusters: Cluster[] = [];
+  for (const members of groups.values()) {
+    const sorted = members.slice().sort((a, b) =>
+      String(b.entry.date).localeCompare(String(a.entry.date)),
+    );
+    const canonical = sorted[0].entry.summary;
+    const cluster_id = createHash('sha256').update(normalizeSummary(canonical)).digest('hex').slice(0, 16);
+    clusters.push({
+      cluster_id,
+      canonical,
+      entries: members.map(m => ({ slug: m.slug, entry: m.entry })),
+    });
+  }
+  return clusters;
+}
+
+// --- Core logic ---
+
+/**
+ * Collect timeline evidence from the last N days across all pages, embed
+ * each unique summary, cluster by cosine similarity, return clusters.
+ *
+ * Edge cases:
+ *   - Empty brain (zero pages): returns empty array.
+ *   - Brain with > MAX_PAGES_TO_SCAN pages: scans only the first slice
+ *     as ordered by listPages.
+ *   - Page with broken/malformed timeline: page is skipped, error logged.
+ *   - Embedding API failure: caught at this level; falls back to exact-text
+ *     grouping (each unique normalized text becomes its own cluster).
+ */
+export async function collectEvidence(
+  engine: BrainEngine,
+  config: PromotionConfig,
+  onProgress?: (phase: 'pages' | 'embed', done: number, total: number) => void,
+): Promise<Cluster[]> {
+  const since = new Date(Date.now() - config.evidenceWindowDays * 86400000);
+  const sinceStr = since.toISOString().slice(0, 10);
+
+  const pages = await engine.listPages({ limit: MAX_PAGES_TO_SCAN });
+
+  // Collect raw entries from every page's timeline within the window.
+  // Progress reported per-page so a 500-page brain doesn't go silent for
+  // minutes while we walk timelines.
+  const rawEntries: { slug: string; entry: TimelineEntry; normalized: string }[] = [];
+  for (let i = 0; i < pages.length; i++) {
+    const page = pages[i];
+    try {
+      const timeline = await engine.getTimeline(page.slug, {
+        after: sinceStr,
+        limit: 100,
+      });
+      for (const entry of timeline) {
+        const normalized = normalizeSummary(entry.summary);
+        if (normalized) {
+          rawEntries.push({ slug: page.slug, entry, normalized });
+        }
+      }
+    } catch (e) {
+      console.warn(
+        '[promotion.collectEvidence] skipping page %s with broken timeline: %s',
+        page.slug,
+        e instanceof Error ? e.message : String(e),
+      );
+    }
+    onProgress?.('pages', i + 1, pages.length);
+  }
+
+  if (rawEntries.length === 0) return [];
+
+  // Embed unique normalized texts (cache-aware), then cluster.
+  let embeddings: Map<string, Float32Array>;
+  try {
+    embeddings = await getOrComputeEmbeddings(
+      engine,
+      rawEntries.map(r => r.normalized),
+    );
+  } catch (e) {
+    console.warn(
+      '[promotion.collectEvidence] embedding lookup failed; falling back to exact-text grouping: %s',
+      e instanceof Error ? e.message : String(e),
+    );
+    return fallbackExactTextClusters(rawEntries);
+  }
+
+  const withEmbeddings = rawEntries
+    .map(r => {
+      const emb = embeddings.get(r.normalized);
+      return emb ? { slug: r.slug, entry: r.entry, embedding: emb } : null;
+    })
+    .filter((r): r is NonNullable<typeof r> => r !== null);
+
+  if (withEmbeddings.length === 0) return fallbackExactTextClusters(rawEntries);
+
+  return clusterByEmbedding(withEmbeddings, config.similarityThreshold);
+}
+
+/**
+ * Fallback when embeddings can't be computed: each unique normalized text
+ * becomes its own cluster (the v0.20 exact-text behavior).
+ */
+function fallbackExactTextClusters(
+  rawEntries: { slug: string; entry: TimelineEntry; normalized: string }[],
+): Cluster[] {
+  const groups = new Map<string, { canonical: string; entries: { slug: string; entry: TimelineEntry }[] }>();
+  for (const r of rawEntries) {
+    if (!groups.has(r.normalized)) {
+      groups.set(r.normalized, { canonical: r.entry.summary, entries: [] });
+    }
+    const group = groups.get(r.normalized)!;
+    group.entries.push({ slug: r.slug, entry: r.entry });
+    // Update canonical to the most recent member's summary
+    if (String(r.entry.date) > String(group.entries[0]?.entry.date ?? '')) {
+      group.canonical = r.entry.summary;
+    }
+  }
+  return Array.from(groups.entries()).map(([normalized, g]) => ({
+    cluster_id: createHash('sha256').update(normalized).digest('hex').slice(0, 16),
+    canonical: g.canonical,
+    entries: g.entries,
+  }));
+}
+
+/**
+ * Score clusters and return ranked candidates. One cluster → one candidate.
+ */
+export function rankCandidates(
+  clusters: Cluster[],
+  config: PromotionConfig,
+): CandidatePattern[] {
+  const candidates: CandidatePattern[] = [];
+
+  for (const cluster of clusters) {
+    const recurrence = cluster.entries.length;
+    const uniqueSlugs = [...new Set(cluster.entries.map(e => e.slug))];
+    const dates = cluster.entries.map(e => String(e.entry.date)).sort();
+    const lastSeen = dates[dates.length - 1];
+
+    const base = {
+      pattern: cluster.canonical,
+      cluster_id: cluster.cluster_id,
+      recurrence,
+      slugs: uniqueSlugs,
+      lastSeen,
+    };
+
+    if (recurrence < config.minRecurrence) {
+      candidates.push({
+        ...base,
+        score: 0,
+        reason: `below threshold (${recurrence} < ${config.minRecurrence})`,
+      });
+      continue;
+    }
+
+    if (looksLikePhoneOrIdShape(cluster.canonical)) {
+      candidates.push({
+        ...base,
+        score: 0,
+        reason: 'rejected: possible sensitive content (regex filter)',
+      });
+      continue;
+    }
+
+    const score = scoreCandidate(recurrence, lastSeen, uniqueSlugs.length);
+    candidates.push({
+      ...base,
+      score,
+      reason: score >= 0.4 ? 'promotable' : `low score (${score.toFixed(2)})`,
+    });
+  }
+
+  candidates.sort((a, b) => b.score - a.score);
+  return candidates;
+}
+
+/**
+ * Apply promotions. For each promotable candidate, append a semantic note
+ * to the most relevant page's compiled_truth and add a timeline entry.
+ *
+ * Note on idempotency: a SHA256(cluster_id || target_slug) hash is
+ * checked against dream_cycle_promotions before each apply. If the
+ * tuple already exists, the candidate is skipped. After a successful
+ * write, the hash is recorded with INSERT ... ON CONFLICT DO NOTHING
+ * (belt-and-braces against concurrent races). A re-run with identical
+ * clusters produces zero duplicate writes.
+ *
+ * Returns the list of actually promoted candidates.
+ */
+export async function applyPromotions(
+  engine: BrainEngine,
+  promotable: CandidatePattern[],
+  config: PromotionConfig,
+  dryRun: boolean,
+): Promise<{ promoted: CandidatePattern[]; skipped: CandidatePattern[] }> {
+  const promoted: CandidatePattern[] = [];
+  const skipped: CandidatePattern[] = [];
+  let applied = 0;
+
+  for (const candidate of promotable) {
+    if (applied >= config.maxPromotions) {
+      skipped.push({ ...candidate, reason: 'max promotions reached' });
+      continue;
+    }
+
+    // Pick the first slug as the target (most recent entry's page).
+    const targetSlug = candidate.slugs[0];
+    const hash = promotionHash(candidate.cluster_id, targetSlug);
+
+    if (dryRun) {
+      promoted.push({ ...candidate, reason: `[dry-run] would promote to ${targetSlug}` });
+      applied++;
+      continue;
+    }
+
+    try {
+      // Idempotency check: was this (cluster, target) tuple already promoted?
+      const existing = await engine.executeRaw<{ promoted_at: string }>(
+        'SELECT promoted_at FROM dream_cycle_promotions WHERE pattern_hash = $1 LIMIT 1',
+        [hash],
+      );
+      if (existing.length > 0) {
+        const promotedDate = String(existing[0].promoted_at).slice(0, 10);
+        skipped.push({
+          ...candidate,
+          reason: `already promoted on ${promotedDate}`,
+        });
+        continue;
+      }
+
+      const page = await engine.getPage(targetSlug);
+      if (!page) {
+        skipped.push({ ...candidate, reason: `target page ${targetSlug} not found` });
+        continue;
+      }
+
+      const today = new Date().toISOString().slice(0, 10);
+
+      // Append semantic note to compiled_truth.
+      const semanticNote = `\n\n---\n**Semantic note** (dream-cycle ${today}, cluster ${candidate.cluster_id}): Recurring pattern detected across ${candidate.recurrence} entries. ${candidate.pattern}`;
+      const updatedTruth = page.compiled_truth + semanticNote;
+
+      await engine.putPage(targetSlug, {
+        type: page.type,
+        title: page.title,
+        compiled_truth: updatedTruth,
+        frontmatter: page.frontmatter,
+      });
+
+      await engine.addTimelineEntry(targetSlug, {
+        date: today,
+        source: 'dream-cycle',
+        summary: `Promoted recurring pattern (${candidate.recurrence} occurrences) to semantic memory`,
+        detail: `Pattern: "${candidate.pattern}". Cluster: ${candidate.cluster_id}. Score: ${candidate.score.toFixed(2)}. Spread across: ${candidate.slugs.join(', ')}`,
+      });
+
+      // Record the promotion. ON CONFLICT DO NOTHING is belt-and-braces:
+      // the SELECT above already gates this branch, but a concurrent run
+      // could race; the conflict clause makes the second writer a no-op.
+      await engine.executeRaw(
+        `INSERT INTO dream_cycle_promotions
+           (pattern_hash, cluster_id, target_slug, pattern_text, recurrence, score)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         ON CONFLICT (pattern_hash) DO NOTHING`,
+        [hash, candidate.cluster_id, targetSlug, candidate.pattern, candidate.recurrence, candidate.score],
+      );
+
+      promoted.push({ ...candidate, reason: `promoted to ${targetSlug}` });
+      applied++;
+    } catch (e) {
+      skipped.push({
+        ...candidate,
+        reason: `error: ${e instanceof Error ? e.message : String(e)}`,
+      });
+    }
+  }
+
+  return { promoted, skipped };
+}
+
+/**
+ * Run the full dream cycle. Returns a structured report.
+ *
+ * @param onProgress  Optional callback invoked with (phase, done, total) for
+ *                    bulk operations. The runCycle phase wrapper uses this
+ *                    to feed the standard progress reporter.
+ */
+export async function runDreamCycle(
+  engine: BrainEngine,
+  config: Partial<PromotionConfig> = {},
+  dryRun: boolean = true,
+  onProgress?: (phase: 'pages' | 'embed', done: number, total: number) => void,
+): Promise<PromotionReport> {
+  const fullConfig = { ...DEFAULT_CONFIG, ...config };
+  const runAt = new Date().toISOString();
+
+  const clusters = await collectEvidence(engine, fullConfig, onProgress);
+  const candidates = rankCandidates(clusters, fullConfig);
+
+  const promotable = candidates.filter(c => c.reason === 'promotable');
+  const rejected = candidates.filter(c => c.reason !== 'promotable');
+
+  const { promoted, skipped } = await applyPromotions(engine, promotable, fullConfig, dryRun);
+
+  return {
+    schema_version: '1',
+    candidates,
+    promoted,
+    skipped: [...rejected, ...skipped],
+    dryRun,
+    runAt,
+    evidenceWindowDays: fullConfig.evidenceWindowDays,
+  };
+}

--- a/test/autopilot.test.ts
+++ b/test/autopilot.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from 'bun:test';
+import { shouldRunDreamCycle } from '../src/core/promotion.ts';
+
+describe('shouldRunDreamCycle', () => {
+  const HOUR = 3600000;
+  const now = Date.UTC(2026, 3, 18, 12, 0, 0); // 2026-04-18 12:00 UTC
+
+  test('runs on first ever call (lastRun = 0)', () => {
+    expect(shouldRunDreamCycle(0, now)).toBe(true);
+  });
+
+  test('runs when stamp file is missing/unparseable (NaN passed in)', () => {
+    expect(shouldRunDreamCycle(NaN, now)).toBe(true);
+  });
+
+  test('skips when last run was 1 hour ago', () => {
+    expect(shouldRunDreamCycle(now - 1 * HOUR, now)).toBe(false);
+  });
+
+  test('skips when last run was 22 hours ago (just under threshold)', () => {
+    expect(shouldRunDreamCycle(now - 22 * HOUR, now)).toBe(false);
+  });
+
+  test('runs when last run was exactly 23 hours ago (boundary)', () => {
+    expect(shouldRunDreamCycle(now - 23 * HOUR, now)).toBe(true);
+  });
+
+  test('runs when last run was 25 hours ago (well past threshold)', () => {
+    expect(shouldRunDreamCycle(now - 25 * HOUR, now)).toBe(true);
+  });
+
+  test('honors custom minHours override', () => {
+    expect(shouldRunDreamCycle(now - 5 * HOUR, now, 6)).toBe(false);
+    expect(shouldRunDreamCycle(now - 7 * HOUR, now, 6)).toBe(true);
+  });
+
+  test('runs when clock went backwards (lastRun > now)', () => {
+    // Defensive: if system clock was adjusted backward, fire rather than
+    // wait indefinitely. Better to run one extra time than never.
+    expect(shouldRunDreamCycle(now + 1 * HOUR, now)).toBe(true);
+  });
+
+  test('runs when lastRun is negative (corrupted stamp file)', () => {
+    expect(shouldRunDreamCycle(-1000, now)).toBe(true);
+  });
+});

--- a/test/e2e/cycle.test.ts
+++ b/test/e2e/cycle.test.ts
@@ -97,8 +97,11 @@ describeE2E('E2E: runCycle against real Postgres', () => {
     });
 
     expect(report.schema_version).toBe('1');
-    // Cycle ran all 6 phases (or skipped the ones that don't support dry-run).
-    expect(report.phases.length).toBe(6);
+    // Cycle ran all phases (or skipped the ones that don't support dry-run).
+    // Asserts >= 6 so the test stays robust when phases are added (this PR
+    // adds 'promotion' as phase 7; any future phase will pass without
+    // another test edit).
+    expect(report.phases.length).toBeGreaterThanOrEqual(6);
 
     // Nothing got written.
     const afterPages = await conn.unsafe(`SELECT count(*)::int AS n FROM pages`);

--- a/test/promotion.test.ts
+++ b/test/promotion.test.ts
@@ -1,0 +1,294 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  normalizeSummary,
+  looksLikePhi,
+  looksLikePhoneOrIdShape,
+  scoreCandidate,
+  cosineSimilarity,
+  clusterByEmbedding,
+  rankCandidates,
+  DEFAULT_CONFIG,
+  type Cluster,
+} from '../src/core/promotion.ts';
+import type { TimelineEntry } from '../src/core/types.ts';
+
+describe('normalizeSummary', () => {
+  test('lowercases and strips trailing punctuation', () => {
+    expect(normalizeSummary('Updated patient care plan.')).toBe('updated patient care plan');
+  });
+
+  test('collapses whitespace', () => {
+    expect(normalizeSummary('  sync   completed  ')).toBe('sync completed');
+  });
+
+  test('empty string returns empty', () => {
+    expect(normalizeSummary('')).toBe('');
+  });
+});
+
+describe('looksLikePhoneOrIdShape (best-effort regex filter, NOT PHI detection)', () => {
+  test('detects phone numbers', () => {
+    expect(looksLikePhoneOrIdShape('Call patient at 555-123-4567')).toBe(true);
+  });
+
+  test('detects SSN-shaped patterns', () => {
+    expect(looksLikePhoneOrIdShape('SSN: 123-45-6789')).toBe(true);
+  });
+
+  test('allows normal text', () => {
+    expect(looksLikePhoneOrIdShape('sync completed for facility')).toBe(false);
+  });
+
+  test('allows safe patterns', () => {
+    expect(looksLikePhoneOrIdShape('meeting with team about care coordination')).toBe(false);
+  });
+
+  test('looksLikePhi is the same function (deprecated alias preserved for compat)', () => {
+    expect(looksLikePhi).toBe(looksLikePhoneOrIdShape);
+  });
+});
+
+describe('scoreCandidate', () => {
+  test('high recurrence and recent date scores well', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const score = scoreCandidate(6, today, 3);
+    expect(score).toBeGreaterThan(0.5);
+  });
+
+  test('low recurrence scores lower than high recurrence', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const lowScore = scoreCandidate(1, today, 1);
+    const highScore = scoreCandidate(6, today, 3);
+    expect(lowScore).toBeLessThan(highScore);
+  });
+
+  test('old entries decay', () => {
+    const twoWeeksAgo = new Date(Date.now() - 13 * 86400000).toISOString().slice(0, 10);
+    const recentScore = scoreCandidate(6, new Date().toISOString().slice(0, 10), 3);
+    const oldScore = scoreCandidate(6, twoWeeksAgo, 3);
+    expect(recentScore).toBeGreaterThan(oldScore);
+  });
+});
+
+describe('cosineSimilarity', () => {
+  test('identical vectors return 1', () => {
+    const v = new Float32Array([1, 2, 3]);
+    expect(cosineSimilarity(v, v)).toBeCloseTo(1, 5);
+  });
+
+  test('orthogonal vectors return 0', () => {
+    const a = new Float32Array([1, 0, 0]);
+    const b = new Float32Array([0, 1, 0]);
+    expect(cosineSimilarity(a, b)).toBeCloseTo(0, 5);
+  });
+
+  test('opposite vectors return -1', () => {
+    const a = new Float32Array([1, 2, 3]);
+    const b = new Float32Array([-1, -2, -3]);
+    expect(cosineSimilarity(a, b)).toBeCloseTo(-1, 5);
+  });
+
+  test('zero vector returns 0', () => {
+    const a = new Float32Array([1, 2, 3]);
+    const z = new Float32Array([0, 0, 0]);
+    expect(cosineSimilarity(a, z)).toBe(0);
+  });
+
+  test('different lengths throws', () => {
+    const a = new Float32Array([1, 2]);
+    const b = new Float32Array([1, 2, 3]);
+    expect(() => cosineSimilarity(a, b)).toThrow();
+  });
+});
+
+describe('clusterByEmbedding', () => {
+  function makeEmbedded(slug: string, date: string, summary: string, embedding: number[]): {
+    slug: string;
+    entry: TimelineEntry;
+    embedding: Float32Array;
+  } {
+    return {
+      slug,
+      entry: {
+        id: Math.random(),
+        page_id: 1,
+        date,
+        source: 'test',
+        summary,
+        detail: '',
+        created_at: new Date(),
+      },
+      embedding: new Float32Array(embedding),
+    };
+  }
+
+  test('clusters identical embeddings together', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const entries = [
+      makeEmbedded('a', today, 'A', [1, 0, 0]),
+      makeEmbedded('b', today, 'B', [1, 0, 0]),
+      makeEmbedded('c', today, 'C', [1, 0, 0]),
+    ];
+    const clusters = clusterByEmbedding(entries, 0.85);
+    expect(clusters.length).toBe(1);
+    expect(clusters[0].entries.length).toBe(3);
+  });
+
+  test('separates orthogonal embeddings', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const entries = [
+      makeEmbedded('a', today, 'A', [1, 0, 0]),
+      makeEmbedded('b', today, 'B', [0, 1, 0]),
+      makeEmbedded('c', today, 'C', [0, 0, 1]),
+    ];
+    const clusters = clusterByEmbedding(entries, 0.85);
+    expect(clusters.length).toBe(3);
+  });
+
+  test('canonical is the most-recent member', () => {
+    const entries = [
+      makeEmbedded('a', '2026-04-01', 'older summary', [1, 0, 0]),
+      makeEmbedded('b', '2026-04-15', 'most recent summary', [1, 0, 0]),
+      makeEmbedded('c', '2026-04-10', 'middle summary', [1, 0, 0]),
+    ];
+    const clusters = clusterByEmbedding(entries, 0.85);
+    expect(clusters.length).toBe(1);
+    expect(clusters[0].canonical).toBe('most recent summary');
+  });
+
+  test('unions transitively (A~B, B~C → all one cluster)', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const entries = [
+      makeEmbedded('a', today, 'A', [1, 0, 0]),
+      makeEmbedded('b', today, 'B', [0.95, 0.31, 0]),  // close to both
+      makeEmbedded('c', today, 'C', [0.5, 0.86, 0]),    // close to B but not to A
+    ];
+    const clusters = clusterByEmbedding(entries, 0.85);
+    // A~B (sim ~0.95), B~C (sim ~0.78 — borderline). Test asserts the
+    // transitive union behavior when threshold catches both pairs.
+    // Use a slightly looser threshold to ensure both edges fire:
+    const looser = clusterByEmbedding(entries, 0.7);
+    expect(looser.length).toBe(1);
+    expect(looser[0].entries.length).toBe(3);
+  });
+
+  test('threshold clamps to [0, 1]', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const entries = [
+      makeEmbedded('a', today, 'A', [1, 0]),
+      makeEmbedded('b', today, 'B', [0, 1]),
+    ];
+    // Anything above 1 still rejects orthogonal vectors (clamped to 1)
+    const clusters = clusterByEmbedding(entries, 999);
+    expect(clusters.length).toBe(2);
+  });
+
+  test('empty input returns empty', () => {
+    const clusters = clusterByEmbedding([], 0.85);
+    expect(clusters).toEqual([]);
+  });
+
+  test('single entry returns one cluster of size 1', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const entries = [makeEmbedded('a', today, 'A', [1, 0, 0])];
+    const clusters = clusterByEmbedding(entries, 0.85);
+    expect(clusters.length).toBe(1);
+    expect(clusters[0].entries.length).toBe(1);
+    expect(clusters[0].canonical).toBe('A');
+  });
+});
+
+describe('rankCandidates (cluster-aware)', () => {
+  function makeCluster(canonical: string, entries: { slug: string; date: string }[]): Cluster {
+    return {
+      cluster_id: canonical.slice(0, 16),
+      canonical,
+      entries: entries.map(e => ({
+        slug: e.slug,
+        entry: {
+          id: Math.random(),
+          page_id: 1,
+          date: e.date,
+          source: 'test',
+          summary: canonical,
+          detail: '',
+          created_at: new Date(),
+        },
+      })),
+    };
+  }
+
+  test('groups recurring entries into promotable candidates', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const clusters = [
+      makeCluster('Sync completed for facility', [
+        { slug: 'facility-a', date: today },
+        { slug: 'facility-b', date: today },
+        { slug: 'facility-a', date: today },
+      ]),
+    ];
+    const candidates = rankCandidates(clusters, DEFAULT_CONFIG);
+    expect(candidates.length).toBe(1);
+    expect(candidates[0].recurrence).toBe(3);
+    expect(candidates[0].reason).toBe('promotable');
+  });
+
+  test('rejects below-threshold entries', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const clusters = [
+      makeCluster('One-off event', [{ slug: 'page-a', date: today }]),
+    ];
+    const candidates = rankCandidates(clusters, DEFAULT_CONFIG);
+    expect(candidates.length).toBe(1);
+    expect(candidates[0].reason).toContain('below threshold');
+  });
+
+  test('rejects sensitive-text patterns', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const clusters = [
+      makeCluster('Patient ID 12345 updated', [
+        { slug: 'page-a', date: today },
+        { slug: 'page-b', date: today },
+        { slug: 'page-a', date: today },
+        { slug: 'page-c', date: today },
+      ]),
+    ];
+    const candidates = rankCandidates(clusters, DEFAULT_CONFIG);
+    expect(candidates.length).toBe(1);
+    expect(candidates[0].reason).toContain('sensitive');
+  });
+
+  test('sorts by score descending', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const clusters = [
+      makeCluster('low pattern', [
+        { slug: 'page-a', date: today },
+        { slug: 'page-a', date: today },
+        { slug: 'page-a', date: today },
+      ]),
+      makeCluster('high pattern', [
+        { slug: 'page-a', date: today },
+        { slug: 'page-b', date: today },
+        { slug: 'page-c', date: today },
+        { slug: 'page-d', date: today },
+        { slug: 'page-e', date: today },
+        { slug: 'page-a', date: today },
+      ]),
+    ];
+    const candidates = rankCandidates(clusters, DEFAULT_CONFIG);
+    const promotable = candidates.filter(c => c.reason === 'promotable');
+    expect(promotable.length).toBe(2);
+    expect(promotable[0].score).toBeGreaterThan(promotable[1].score);
+  });
+
+  test('cluster_id is propagated to candidate', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const cluster = makeCluster('Sync completed', [
+      { slug: 'a', date: today },
+      { slug: 'b', date: today },
+      { slug: 'c', date: today },
+    ]);
+    const candidates = rankCandidates([cluster], DEFAULT_CONFIG);
+    expect(candidates[0].cluster_id).toBe(cluster.cluster_id);
+  });
+});


### PR DESCRIPTION
## Summary

Adds nightly promotion of recurring timeline patterns to `compiled_truth`. Composes into `runCycle` as **phase 7 of 7** (`phase: 'promotion'`). Two callers reach the engine: the new `gbrain dream-cycle` CLI for manual one-off runs with custom config knobs, and `runCycle`'s own pipeline for autopilot/scheduled runs.

This is the largest of three companion PRs. **Recommended to land #410 (CI fixes) and #411 (Shippable Standard) first** for review-load reasons; technically each is independent.

## Why this is interesting

The dream-cycle "the agent runs while I sleep, the brain wakes up smarter" intent already lives in CLAUDE.md and the existing `gbrain dream` command. This PR completes the loop: `dream` does maintenance (lint/sync/extract/embed/orphans); `dream-cycle` does **synthesis** (consolidating recurring patterns from the timeline into compiled_truth). Both phases live in `runCycle`, so autopilot picks up promotion automatically.

## Algorithm

**Deterministic + cached embeddings.** Phase 1 of the algorithm has zero LLM calls; the only model interaction is embedding generation, which is cached.

1. `collectEvidence` walks pages (capped at `MAX_PAGES_TO_SCAN=500`), pulls last `evidenceWindowDays` of timeline entries, normalizes summaries.
2. Embeds unique normalized texts via cached lookup. New text → `embedBatch` → cache → return. Existing text → cache hit. A 1500-summary brain stays sub-cent on `text-embedding-3-large` after the first run.
3. Clusters via cosine similarity union-find. Default threshold 0.85, configurable via `PromotionConfig.similarityThreshold`. Two summaries that mean the same thing ("ai concierge launch prep" vs "ai concierge ready to launch") cluster together. Cluster's most-recent member text becomes the canonical pattern.
4. Falls back to exact-text grouping if embedding API fails OR if v25 migration hasn't been applied yet.

**Idempotency** via `dream_cycle_promotions` (v26): SHA256(cluster_id || target_slug) primary key. `applyPromotions` checks before writing; `INSERT ... ON CONFLICT DO NOTHING` is belt-and-braces against concurrent races. A re-run with identical clusters produces zero duplicate writes.

## What ships

| File | Lines | Purpose |
|---|---|---|
| `src/core/promotion.ts` | 735 (new) | Promotion engine: clustering, scoring, application, fallbacks |
| `src/commands/dream-cycle.ts` | 106 (new) | CLI runner for manual one-off promotion runs |
| `src/core/cycle.ts` | +119 | Wires `'promotion'` into `CyclePhase` / `ALL_PHASES` / `NEEDS_LOCK_PHASES` + `runPhasePromotion` + Phase 7 dispatch + `patterns_promoted` total |
| `src/core/migrate.ts` | +99 | v25 (`timeline_summary_embeddings`), v26 (`dream_cycle_promotions`), v27 (RLS for both) |
| `src/cli.ts` | +11 | `dream-cycle` command in `CLI_ONLY` set |
| `test/promotion.test.ts` | 294 (new) | 28 tests: normalization, scoring, cosine similarity, clustering, ranking, candidate scoring |
| `test/autopilot.test.ts` | 46 (new) | 9 tests for `shouldRunDreamCycle` rate-limit |
| `test/e2e/cycle.test.ts` | +7 | Phase count assertion: `toBeGreaterThanOrEqual(6)` (was hardcoded `6`) |

**1417 insertions / 6 deletions across 8 files.** No existing functionality changed; only additions and one robustness fix to the cycle phase-count assertion.

## Security: sensitive-text filter is honestly bounded

`looksLikePhoneOrIdShape` is a 5-pattern regex filter (phone, SSN, ID shapes, "patient X" phrasing, MM/DD/YYYY dates). The function name + module comment explicitly state what it is and isn't:

- **What it IS**: best-effort defense-in-depth against the most-obvious leaks of phone/SSN/ID into `compiled_truth`
- **What it is NOT**: a PHI detector, a HIPAA control, a PII detector

Real PHI redaction needs named-entity recognition (Microsoft Presidio, healthcare NLP) and a model trained on medical text. The function is preserved as `looksLikePhi` (deprecated alias) for backward compatibility but the honest name is what the new code uses.

## Schema migrations (all idempotent, additive)

| v | Name | Purpose |
|---|---|---|
| 25 | `timeline_summary_embeddings` | Cache table for embeddings + ivfflat cosine_ops index |
| 26 | `dream_cycle_promotions` | Idempotency key table + indexes on target_slug, cluster_id, promoted_at |
| 27 | `rls_for_dream_cycle_tables` | `ENABLE ROW LEVEL SECURITY` on both new tables. Same gating pattern as v24's RLS backfill. Internal cycle-state tables should not be readable by the Supabase anon key |

## Validation

- [x] **43/43 tests pass** across promotion.test.ts (28), autopilot.test.ts (9), and cycle.test.ts E2E (6)
- [x] Typecheck clean
- [x] **Real-data validation**: live dry-run on production-shape brain data correctly merged near-duplicate meeting summaries (e.g. three variations of "AI concierge launch on April 27" → cluster of size 3)
- [x] Migration v25/v26/v27 applied successfully on test container, verified RLS check now reports all internal tables enabled

## Notes for reviewers

- Threshold tuning (default 0.85 cosine, 3-recurrence, 14-day window) was set by intuition not by evaluation. On real brain data with mostly-one-off meeting summaries, the defaults produce zero promotables — the clustering correctly merges similar text but the recurrence threshold is too strict for that workload. **Tuning is a separate algorithmic concern**; this PR delivers the mechanism, not the optimal defaults.
- The first-slug targeting in `applyPromotions` (always promote the cluster to its first slug) is acknowledged as iteration-order-dependent. A future improvement could pick the most-cited target or split promotion across all cluster members.
- Pure addition: no existing public APIs changed, no existing tests rewritten, no behavior altered for users not invoking `dream-cycle` or running runCycle's `promotion` phase.

Open to algorithmic feedback — particularly on default thresholds, the clustering algorithm choice, and whether you'd prefer the integration shape to look different.