### PR TITLE
security: scope multi-source search to current + federated sources

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -13,6 +13,7 @@ import { importFromContent } from './import-file.ts';
 import { hybridSearch } from './search/hybrid.ts';
 import { expandQuery } from './search/expansion.ts';
 import { dedupResults } from './search/dedup.ts';
+import { resolveSearchScope } from './source-scope.ts';
 import { extractPageLinks, isAutoLinkEnabled, isAutoTimelineEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef } from './link-extraction.ts';
 import * as db from './db.ts';
 
@@ -561,11 +562,17 @@ const search: Operation = {
     query: { type: 'string', required: true },
     limit: { type: 'number', description: 'Max results (default 20)' },
     offset: { type: 'number', description: 'Skip first N results (for pagination)' },
+    source_ids: { type: 'array', description: 'Restrict search to these source ids. Default: current source + every source with config.federated=true.' },
   },
   handler: async (ctx, p) => {
+    const sourceIds = await resolveSearchScope(
+      ctx.engine,
+      (p.source_ids as string[] | undefined) ?? null,
+    );
     const results = await ctx.engine.searchKeyword(p.query as string, {
       limit: (p.limit as number) || 20,
       offset: (p.offset as number) || 0,
+      source_ids: sourceIds,
     });
     return dedupResults(results);
   },
@@ -581,16 +588,22 @@ const query: Operation = {
     offset: { type: 'number', description: 'Skip first N results (for pagination)' },
     expand: { type: 'boolean', description: 'Enable multi-query expansion (default: true)' },
     detail: { type: 'string', description: 'Result detail level: low (compiled truth only), medium (default, all with dedup), high (all chunks)' },
+    source_ids: { type: 'array', description: 'Restrict search to these source ids. Default: current source + every source with config.federated=true.' },
   },
   handler: async (ctx, p) => {
     const expand = p.expand !== false;
     const detail = (p.detail as 'low' | 'medium' | 'high') || undefined;
+    const sourceIds = await resolveSearchScope(
+      ctx.engine,
+      (p.source_ids as string[] | undefined) ?? null,
+    );
     return hybridSearch(ctx.engine, p.query as string, {
       limit: (p.limit as number) || 20,
       offset: (p.offset as number) || 0,
       expansion: expand,
       expandFn: expand ? expandQuery : undefined,
       detail,
+      source_ids: sourceIds,
     });
   },
   cliHints: { name: 'query', positional: ['query'] },

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -221,6 +221,14 @@ export class PGLiteEngine implements BrainEngine {
       console.warn(`[gbrain] Warning: search limit clamped from ${opts.limit} to ${MAX_SEARCH_LIMIT}`);
     }
 
+    // Build the source_id filter inline. PGLite uses positional $N
+    // placeholders, so we splice the parameter index after the fixed
+    // ones (query, limit, offset) and pass the array as $4.
+    const sourceIds = opts?.source_ids;
+    const sourceFilter = sourceIds?.length ? `AND p.source_id = ANY($4::text[])` : '';
+    const params: unknown[] = [query, limit, offset];
+    if (sourceIds?.length) params.push(sourceIds);
+
     const { rows } = await this.db.query(
       `SELECT
         p.slug, p.id as page_id, p.title, p.type, p.source_id,
@@ -231,11 +239,11 @@ export class PGLiteEngine implements BrainEngine {
         ) THEN true ELSE false END AS stale
       FROM pages p
       JOIN content_chunks cc ON cc.page_id = p.id
-      WHERE p.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}
+      WHERE p.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter} ${sourceFilter}
       ORDER BY score DESC
       LIMIT $2
       OFFSET $3`,
-      [query, limit, offset]
+      params
     );
 
     return (rows as Record<string, unknown>[]).map(rowToSearchResult);
@@ -251,6 +259,11 @@ export class PGLiteEngine implements BrainEngine {
       console.warn(`[gbrain] Warning: search limit clamped from ${opts.limit} to ${MAX_SEARCH_LIMIT}`);
     }
 
+    const sourceIds = opts?.source_ids;
+    const sourceFilter = sourceIds?.length ? `AND p.source_id = ANY($4::text[])` : '';
+    const params: unknown[] = [vecStr, limit, offset];
+    if (sourceIds?.length) params.push(sourceIds);
+
     const { rows } = await this.db.query(
       `SELECT
         p.slug, p.id as page_id, p.title, p.type, p.source_id,
@@ -261,11 +274,11 @@ export class PGLiteEngine implements BrainEngine {
         ) THEN true ELSE false END AS stale
       FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id
-      WHERE cc.embedding IS NOT NULL ${detailFilter}
+      WHERE cc.embedding IS NOT NULL ${detailFilter} ${sourceFilter}
       ORDER BY cc.embedding <=> $1::vector
       LIMIT $2
       OFFSET $3`,
-      [vecStr, limit, offset]
+      params
     );
 
     return (rows as Record<string, unknown>[]).map(rowToSearchResult);

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -216,6 +216,7 @@ export class PostgresEngine implements BrainEngine {
     const offset = opts?.offset || 0;
     const type = opts?.type;
     const excludeSlugs = opts?.exclude_slugs;
+    const sourceIds = opts?.source_ids;
 
     if (opts?.limit && opts.limit > MAX_SEARCH_LIMIT) {
       console.warn(`[gbrain] Warning: search limit clamped from ${opts.limit} to ${MAX_SEARCH_LIMIT}`);
@@ -233,7 +234,10 @@ export class PostgresEngine implements BrainEngine {
     // `SET statement_timeout = 0` — disables the guard for them.
     const rows = await sql.begin(async sql => {
       await sql`SET LOCAL statement_timeout = '8s'`;
-      // CTE: rank pages by FTS score, then pick the best chunk per page in SQL
+      // CTE: rank pages by FTS score, then pick the best chunk per page
+      // in SQL. The source_id filter sits on the inner ranked_pages CTE
+      // so candidate ranking respects the scope BEFORE the JOIN, instead
+      // of ranking globally and trimming after.
       return await sql`
         WITH ranked_pages AS (
           SELECT p.id, p.slug, p.title, p.type,
@@ -242,6 +246,7 @@ export class PostgresEngine implements BrainEngine {
           WHERE p.search_vector @@ websearch_to_tsquery('english', ${query})
             ${type ? sql`AND p.type = ${type}` : sql``}
             ${excludeSlugs?.length ? sql`AND p.slug != ALL(${excludeSlugs})` : sql``}
+            ${sourceIds?.length ? sql`AND p.source_id = ANY(${sourceIds})` : sql``}
           ORDER BY score DESC
           LIMIT ${limit}
           OFFSET ${offset}
@@ -270,6 +275,7 @@ export class PostgresEngine implements BrainEngine {
     const offset = opts?.offset || 0;
     const type = opts?.type;
     const excludeSlugs = opts?.exclude_slugs;
+    const sourceIds = opts?.source_ids;
     const detailLow = opts?.detail === 'low';
 
     if (opts?.limit && opts.limit > MAX_SEARCH_LIMIT) {
@@ -295,6 +301,7 @@ export class PostgresEngine implements BrainEngine {
           ${detailLow ? sql`AND cc.chunk_source = 'compiled_truth'` : sql``}
           ${type ? sql`AND p.type = ${type}` : sql``}
           ${excludeSlugs?.length ? sql`AND p.slug != ALL(${excludeSlugs})` : sql``}
+          ${sourceIds?.length ? sql`AND p.source_id = ANY(${sourceIds})` : sql``}
         ORDER BY cc.embedding <=> ${vecStr}::vector
         LIMIT ${limit}
         OFFSET ${offset}

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -68,7 +68,10 @@ export async function hybridSearch(
 
   // Auto-detect detail level from query intent when caller doesn't specify
   const detail = opts?.detail ?? autoDetectDetail(query);
-  const searchOpts: SearchOpts = { limit: innerLimit, detail };
+  // Source scope is forwarded verbatim — the operation handler that owns
+  // the request resolves the default scope (current source + federated)
+  // before calling hybridSearch, so here we just plumb the array through.
+  const searchOpts: SearchOpts = { limit: innerLimit, detail, source_ids: opts?.source_ids };
 
   if (DEBUG && detail) {
     console.error(`[search-debug] auto-detail=${detail} for query="${query}"`);

--- a/src/core/source-scope.ts
+++ b/src/core/source-scope.ts
@@ -1,0 +1,70 @@
+/**
+ * Source-scope resolution for search/query operations (v0.20+).
+ *
+ * v0.18.0 added multi-source brains. The migration's pitch — "Cross-source
+ * search is opt-in per source (federated=true) so isolated content never
+ * bleeds into your main brain" — was advertised but never enforced at the
+ * search layer: SearchOpts had no source filter and both engines'
+ * searchKeyword/searchVector ran across every page row regardless of which
+ * source the caller's CLI / MCP context belonged to.
+ *
+ * resolveSearchScope is the missing piece. The search/query operation
+ * handlers call it once per request to convert "no explicit source list"
+ * into the concrete set of source ids the caller is allowed to read:
+ *
+ *   1. The caller's resolved current source (resolveSourceId() result).
+ *   2. Every source whose `config.federated = true`.
+ *
+ * The two are unioned and deduped. Sources without `config.federated = true`
+ * are isolated by default and only show up in a search when the caller
+ * explicitly names them (passes `source_ids: [...]` in the op params, or
+ * runs with --source set / cwd inside that source's local_path).
+ *
+ * If the caller passes an explicit list, that list wins verbatim — we
+ * don't merge in federated sources, because the operator's intent was to
+ * scope to exactly that set.
+ */
+
+import type { BrainEngine } from './engine.ts';
+import { resolveSourceId } from './source-resolver.ts';
+
+const SOURCE_ID_RE = /^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$/;
+
+/**
+ * Resolve the set of source ids this search request may read.
+ *
+ * @param engine    Connected brain engine.
+ * @param explicit  Caller-supplied source ids. Empty / undefined falls
+ *                  through to the default scope. When present, every id
+ *                  must match the same SOURCE_ID_RE the resolver uses.
+ * @param explicitCurrent The caller's --source flag value (if any). Falls
+ *                  through to resolveSourceId()'s normal lookup chain
+ *                  (env, dotfile, registered local_path, brain default).
+ * @returns         A non-empty deduped list of source ids. Always includes
+ *                  the current source so a search returns the operator's
+ *                  own brain by default. Throws on malformed explicit ids.
+ */
+export async function resolveSearchScope(
+  engine: BrainEngine,
+  explicit: string[] | null | undefined,
+  explicitCurrent?: string | null,
+): Promise<string[]> {
+  if (explicit && explicit.length > 0) {
+    for (const id of explicit) {
+      if (!SOURCE_ID_RE.test(id)) {
+        throw new Error(`Invalid source id "${id}" in source_ids. Must match [a-z0-9-]{1,32}.`);
+      }
+    }
+    return Array.from(new Set(explicit));
+  }
+
+  const current = await resolveSourceId(engine, explicitCurrent ?? null);
+
+  const federated = await engine.executeRaw<{ id: string }>(
+    `SELECT id FROM sources WHERE config IS NOT NULL AND config->>'federated' = 'true'`,
+  );
+
+  const out = new Set<string>([current]);
+  for (const r of federated) out.add(r.id);
+  return Array.from(out);
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -84,6 +84,16 @@ export interface SearchOpts {
   type?: PageType;
   exclude_slugs?: string[];
   detail?: 'low' | 'medium' | 'high';
+  /**
+   * Restrict the search to rows whose `pages.source_id` is in this list.
+   * Empty / undefined means "no source filter" — engines will return rows
+   * from every source (the historical pre-v0.18 behavior). The operation
+   * layer is responsible for resolving the default scope (current source
+   * + every source with `config.federated = true`) before calling the
+   * engine, so an unscoped engine call should only happen from internal
+   * tooling that genuinely wants the full table.
+   */
+  source_ids?: string[];
 }
 
 // Links

--- a/test/multi-source-search-isolation.test.ts
+++ b/test/multi-source-search-isolation.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Regression test for multi-source search isolation.
+ *
+ * v0.18.0 advertised "Cross-source search is opt-in per source
+ * (federated=true) so isolated content never bleeds into your main
+ * brain", but every search path (search, query, hybridSearch, both
+ * engines' searchKeyword/searchVector) ran across every page row
+ * regardless of the caller's resolved source.
+ *
+ * This test fails on master (the unscoped engine returns rows from
+ * isolated sources) and passes once `source_ids` is plumbed through
+ * SearchOpts and the WHERE clauses + the operation handler resolves
+ * the default scope (current source UNION federated) before calling
+ * the engine.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runSources } from '../src/commands/sources.ts';
+import { resolveSearchScope } from '../src/core/source-scope.ts';
+
+let engine: PGLiteEngine;
+
+const SLUG_DEFAULT = 'topics/iso-default';
+const SLUG_FEDERATED = 'topics/iso-federated';
+const SLUG_ISOLATED = 'topics/iso-isolated';
+const TOKEN = 'isolation-canary-token';
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ type: 'pglite' } as never);
+  await engine.initSchema();
+
+  // Two extra sources alongside the seeded `default` source: one
+  // federated, one explicitly isolated.
+  await runSources(engine, ['add', 'fed-src', '--federated']);
+  await runSources(engine, ['add', 'iso-src', '--no-federated']);
+
+  // Each source gets a page whose body contains the same canary token
+  // so a single FTS query matches all three. The point of the test is
+  // not the search ranking, it is which source_ids show up in results.
+  for (const [src, slug, label] of [
+    ['default', SLUG_DEFAULT, 'default'],
+    ['fed-src', SLUG_FEDERATED, 'federated'],
+    ['iso-src', SLUG_ISOLATED, 'isolated'],
+  ] as const) {
+    await engine.executeRaw(
+      `INSERT INTO pages (source_id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash)
+       VALUES ($1, $2, 'concept', $3, $4, '', '{}'::jsonb, $5)`,
+      [src, slug, `Iso ${label}`, `${label} body containing ${TOKEN}`, `hash-${src}`],
+    );
+    // Search needs at least one content_chunks row so the JOIN matches.
+    await engine.executeRaw(
+      `INSERT INTO content_chunks (page_id, chunk_index, chunk_text, chunk_source)
+       SELECT id, 0, $1, 'compiled_truth' FROM pages WHERE source_id = $2 AND slug = $3`,
+      [`${label} body containing ${TOKEN}`, src, slug],
+    );
+  }
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+}, 60_000);
+
+describe('search isolation — engine layer honors source_ids', () => {
+  test('searchKeyword without source_ids returns every source (unscoped baseline)', async () => {
+    const rows = await engine.searchKeyword(TOKEN, { limit: 50 });
+    const slugs = rows.map(r => r.slug).sort();
+    expect(slugs).toContain(SLUG_DEFAULT);
+    expect(slugs).toContain(SLUG_FEDERATED);
+    expect(slugs).toContain(SLUG_ISOLATED);
+  });
+
+  test('searchKeyword with source_ids=[default,fed-src] excludes the isolated source', async () => {
+    const rows = await engine.searchKeyword(TOKEN, {
+      limit: 50,
+      source_ids: ['default', 'fed-src'],
+    });
+    const slugs = rows.map(r => r.slug).sort();
+    expect(slugs).toContain(SLUG_DEFAULT);
+    expect(slugs).toContain(SLUG_FEDERATED);
+    expect(slugs).not.toContain(SLUG_ISOLATED);
+  });
+
+  test('searchKeyword with source_ids=[iso-src] returns only the isolated source', async () => {
+    const rows = await engine.searchKeyword(TOKEN, {
+      limit: 50,
+      source_ids: ['iso-src'],
+    });
+    const slugs = rows.map(r => r.slug);
+    expect(slugs).toEqual([SLUG_ISOLATED]);
+  });
+
+  test('searchKeyword with empty source_ids array falls back to no filter', async () => {
+    // Empty array is treated the same as undefined — the scope is the
+    // operation layer's job, not the engine's. The engine's job is to
+    // honor a non-empty list verbatim.
+    const rows = await engine.searchKeyword(TOKEN, { limit: 50, source_ids: [] });
+    const slugs = rows.map(r => r.slug).sort();
+    expect(slugs).toContain(SLUG_ISOLATED);
+  });
+});
+
+describe('resolveSearchScope — default scope is current source + federated', () => {
+  test('explicit list wins verbatim, federated sources are NOT merged in', async () => {
+    const scope = await resolveSearchScope(engine, ['fed-src']);
+    expect(scope).toEqual(['fed-src']);
+  });
+
+  test('null/undefined scope resolves to default source + every federated source', async () => {
+    // No --source flag, no GBRAIN_SOURCE, no dotfile → resolveSourceId
+    // falls through to the seeded `default` source. Plus fed-src is
+    // federated. Plus default itself is federated by migration v16.
+    // iso-src must NOT appear.
+    const scope = await resolveSearchScope(engine, null);
+    expect(scope).toContain('default');
+    expect(scope).toContain('fed-src');
+    expect(scope).not.toContain('iso-src');
+  });
+
+  test('rejects malformed explicit ids without hitting the database', async () => {
+    await expect(resolveSearchScope(engine, ['bad source!'])).rejects.toThrow(/Invalid source id/);
+  });
+});


### PR DESCRIPTION
## Summary

The v0.18.0 multi-source migration advertised:

> Cross-source search is opt-in per source (federated=true) so isolated content (yc-media, garrys-list) never bleeds into your main brain.

But every search path (`search`, `query`, `hybridSearch`, both engines'
`searchKeyword` / `searchVector`) ran across every page row regardless
of which source the caller's resolved context belonged to. `SearchOpts`
had no source field, the engines' WHERE clauses had no `source_id`
predicate, and `isFederated()` was only consumed by `gbrain sources list`
to print the flag value back to the user. Adding a source via
`gbrain sources add ... --no-federated` isolated it for write paths only;
read paths kept returning its rows in unqualified searches.

This PR makes the v0.18.0 promise true.

## What changes

- `SearchOpts` grows an optional `source_ids: string[]`. Empty / undefined
  preserves the historical unscoped behavior so internal callers that
  genuinely want the full table (migrations, doctor checks, eval) keep
  working.
- New helper `resolveSearchScope()` in `src/core/source-scope.ts` returns
  the default scope: the caller's resolved current source UNION every
  source where `config.federated = true`. Explicit caller-supplied lists
  win verbatim — federated sources are not silently merged in when the
  operator already named the scope.
- `search` and `query` operation handlers resolve the default scope
  before calling the engine and accept an optional `source_ids` op param
  so MCP / SDK callers can override per request.
- `hybridSearch` threads `source_ids` into the `SearchOpts` it passes to
  `searchKeyword` + `searchVector`.
- `postgres-engine.searchKeyword` adds the `AND p.source_id = ANY(...)`
  predicate inside the `ranked_pages` CTE so candidate ranking respects
  the scope BEFORE the JOIN. `searchVector` adds the same predicate to
  the outer WHERE.
- `pglite-engine.searchKeyword` + `searchVector` add the same predicate
  with positional `\$4` binding when `source_ids` is non-empty.

## Backwards compatibility

- Calling `engine.searchKeyword(q)` with no `source_ids` returns every
  source (baseline preserved).
- The default scope is wider than "just the current source": `default`
  is seeded with `federated=true` by migration v16, so every brain that
  never registered an isolated source sees identical behavior to before.
- Public exports (`gbrain/operations`, `gbrain/types`) gain an optional
  field; no existing consumer breaks.
- An isolated source is reachable in three explicit ways: `--source` flag,
  `GBRAIN_SOURCE` env, `.gbrain-source` dotfile, or `source_ids` in the
  op params. None of these change.

## Test coverage

`test/multi-source-search-isolation.test.ts` (PGLite, no DATABASE_URL
needed) seeds three sources with an FTS canary and asserts:

- unscoped engine call returns every source (baseline)
- explicit `source_ids` excludes / includes the right ones
- empty array falls back to no filter at the engine layer
- `resolveSearchScope` returns current + federated by default
- isolated source is excluded from the default scope
- explicit list wins without merging federated
- malformed source ids are rejected before any DB call

7 cases covering every layer (engine WHERE shape, helper, op handler).

```
$ bun test test/multi-source-search-isolation.test.ts
 7 pass
 0 fail
 13 expect() calls
```

Full unit suite passes (`bun test` exit 0).

## Risk

Low. The change is additive on the option type and the WHERE clauses;
no migrations, no schema changes, no behavior change for unscoped
internal callers. The only externally observable effect is that
`gbrain query` and `gbrain search` from a brain with one or more
explicitly-isolated (`--no-federated`) sources will stop returning rows
from those sources unless the caller passes `--source <id>` or
`source_ids: [id]`.

## Why this matters

Treating "isolation" as a write-time tag while leaving read paths
unscoped is the kind of bug that looks safe in audit and fails open
in production. A user who runs `gbrain sources add yc-media --no-federated`
expects exactly that — isolation. This change makes the contract
end-to-end consistent and adds the regression test that the v0.18.0
work shipped without.