### PR TITLE
security: doctor rls_policies check for BYPASSRLS gate drift

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -437,6 +437,93 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
     } catch {
       checks.push({ name: 'rls', status: 'warn', message: 'Could not check RLS status' });
     }
+
+    // 5b. RLS policy coverage — drift guard for the BYPASSRLS gate.
+    //
+    // The schema enables RLS on every public table inside a `DO $$` block
+    // gated on the runtime role having BYPASSRLS, then ships ZERO
+    // CREATE POLICY statements (src/schema.sql:530-567). The intent is
+    // deny-by-default: any non-bypass role sees zero rows, postgres role
+    // sees everything via the bypass.
+    //
+    // That holds today, but it depends entirely on the connecting role
+    // keeping its BYPASSRLS attribute. If an operator runs
+    // `ALTER ROLE postgres NOBYPASSRLS;` on a managed Supabase project,
+    // a future Supabase setup change reassigns the gbrain owner role, or
+    // a migration adds a new app role for a web frontend, every
+    // RLS-enabled table without a policy goes invisible to that role —
+    // legit reads return empty, writes return zero rows affected, and
+    // doctor would otherwise report `rls: ok` because the tables ARE
+    // enabled.
+    //
+    // This check makes the assumption testable at runtime: it cross-
+    // references RLS-enabled tables against pg_policies + the current
+    // role's rolbypassrls and surfaces the failure mode loudly.
+    progress.heartbeat('rls_policies');
+    try {
+      const sql = db.getConnection();
+      const stateRows = (await sql`
+        SELECT
+          (SELECT rolbypassrls FROM pg_roles WHERE rolname = current_user) AS has_bypass,
+          ARRAY(
+            SELECT t.tablename
+              FROM pg_tables t
+             WHERE t.schemaname = 'public'
+               AND t.rowsecurity
+               AND NOT EXISTS (
+                 SELECT 1 FROM pg_policies p
+                  WHERE p.schemaname = 'public' AND p.tablename = t.tablename
+               )
+             ORDER BY t.tablename
+          ) AS policyless_tables
+      `) as Array<{ has_bypass: boolean | null; policyless_tables: string[] }>;
+      const state = stateRows[0];
+      const hasBypass = state?.has_bypass === true;
+      const policyless = state?.policyless_tables ?? [];
+
+      if (policyless.length === 0) {
+        checks.push({
+          name: 'rls_policies',
+          status: 'ok',
+          message: hasBypass
+            ? 'Every RLS-enabled table has a policy or is reachable via BYPASSRLS.'
+            : 'Every RLS-enabled table has at least one policy.',
+        });
+      } else if (hasBypass) {
+        // Healthy state: bypass role is the gate, every other role is
+        // denied by absence of policies. Surface as ok with a hint so
+        // an operator who is about to flip BYPASSRLS off knows what
+        // breaks.
+        checks.push({
+          name: 'rls_policies',
+          status: 'ok',
+          message:
+            `Deny-by-default for ${policyless.length} RLS-enabled table(s) (current role "${'$user' /* placeholder for log */}" has BYPASSRLS so reads still work). ` +
+            `If you ever drop BYPASSRLS or add a non-bypass role for app traffic, those tables go invisible until you write CREATE POLICY for that role. ` +
+            `Tables: ${policyless.join(', ')}.`,
+        });
+      } else {
+        // Drift: tables are RLS-enabled, no policies, AND the current
+        // role can't bypass. This means data is invisible to the
+        // current connection. That's almost certainly the operator's
+        // bug, not gbrain's intent.
+        const remediation = policyless
+          .map(n => `CREATE POLICY "gbrain_bypass_${n.replace(/[^a-z0-9_]/gi, '_')}" ON "public"."${n.replace(/"/g, '""')}" USING (true);`)
+          .join(' ');
+        checks.push({
+          name: 'rls_policies',
+          status: 'fail',
+          message:
+            `${policyless.length} RLS-enabled table(s) have no policy AND the current role does not have BYPASSRLS. ` +
+            `Reads against these tables return zero rows. ` +
+            `Tables: ${policyless.join(', ')}. ` +
+            `Either grant BYPASSRLS to the connecting role, or write at least one CREATE POLICY per table. ` +
+            `Open-by-default escape hatch (use only if you understand the exposure): ${remediation}`,
+        });
+      }
+    } catch {
+      checks.push({ name: 'rls_policies', status: 'warn', message: 'Could not check RLS policy coverage' });
+    }
   }
 
   // 6. Schema version — also surfaces the #218 "postinstall silently failed"

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -144,4 +144,55 @@ describe('doctor command', () => {
     // requirement to write a real justification, not just the prefix.
     expect(rlsBlock).toMatch(/reason=/);
   });
+
+  // RLS policy coverage — drift guard for the BYPASSRLS gate.
+  // The schema enables RLS without writing any CREATE POLICY statements;
+  // it relies on the connecting role having BYPASSRLS. These structural
+  // assertions make sure the new check stays wired and raises loudly on
+  // role drift / policy regression.
+  test('rls_policies check exists and joins pg_policies against rowsecurity', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    const block = source.slice(
+      source.indexOf("// 5b. RLS policy coverage"),
+      source.indexOf('// 6. Schema version'),
+    );
+    expect(block.length).toBeGreaterThan(0);
+    expect(block).toContain('rls_policies');
+    // Must consult both rowsecurity AND pg_policies in one round-trip.
+    expect(block).toMatch(/pg_tables[\s\S]{0,500}rowsecurity[\s\S]{0,500}pg_policies/);
+    // Must read rolbypassrls so the remediation can distinguish "operator
+    // intentional deny-by-default" from "role drift locked the app out".
+    expect(block).toContain('rolbypassrls');
+  });
+
+  test('rls_policies fails loudly when current role lacks BYPASSRLS and tables have no policy', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    const block = source.slice(
+      source.indexOf("// 5b. RLS policy coverage"),
+      source.indexOf('// 6. Schema version'),
+    );
+    // Both branches present: ok (deny-by-default with bypass) and fail
+    // (drift — current role can't read).
+    expect(block).toMatch(/status:\s*'fail'/);
+    expect(block).toMatch(/status:\s*'ok'/);
+    // Remediation must offer either grant BYPASSRLS or write a policy.
+    expect(block).toMatch(/BYPASSRLS|CREATE POLICY/i);
+  });
+
+  test('rls_policies skips on PGLite (no PostgREST, not applicable)', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    // The pglite branch returns before the postgres-only block; the
+    // rls_policies check sits inside the same `else` arm as the rls check.
+    // Verify both checks live under the same engine.kind === 'postgres' arm
+    // by ensuring the policy check sits between the existing RLS check and
+    // the schema-version check, NOT inside an early return for pglite.
+    const pgliteBranch = source.slice(
+      source.indexOf("if (engine.kind === 'pglite')"),
+      source.indexOf('// 5b. RLS policy coverage'),
+    );
+    expect(pgliteBranch).toContain("name: 'rls'");
+    // The pglite branch must NOT mention the new check name — confirms
+    // the check is in the postgres-only `else` arm.
+    expect(pgliteBranch).not.toContain('rls_policies');
+  });
 });


### PR DESCRIPTION
## Summary

The schema enables RLS on every public table inside a `DO \$\$` block
gated on the runtime role having BYPASSRLS, then ships ZERO
`CREATE POLICY` statements (`src/schema.sql:530-567`). The intent is
deny-by-default: postgres bypasses RLS and sees everything, every
other role sees zero rows.

This works today, but the gate is load-bearing on a runtime role
attribute that nothing in the schema enforces or detects drift on.
The existing `rls` doctor check only verifies tables ARE enabled — it
cannot catch the failure mode where enablement is intact but the
bypass disappears.

## Failure modes this catches

- Operator runs `ALTER ROLE postgres NOBYPASSRLS;` on a managed
  Supabase project. RLS still enabled, role can no longer bypass,
  every read returns zero rows. App breaks silently.
- Future Supabase setup change reassigns the gbrain owner role to one
  without BYPASSRLS.
- A new app role is added for a web frontend (the kind PostgREST
  exposes) without writing `CREATE POLICY` for it.

In every case the existing `rls` check still reports `ok` because the
tables ARE enabled.

## What changes

A new doctor check `rls_policies` runs alongside the existing `rls`
check, inside the same postgres-only branch (skips on PGLite). It
consults `rowsecurity`, `pg_policies`, and `pg_roles.rolbypassrls` in
a single round-trip:

| Tables w/o policy | Current role BYPASSRLS | Status | Message |
|---|---|---|---|
| 0 | any | `ok` | every RLS-enabled table has a policy |
| > 0 | yes | `ok` | deny-by-default with named hint about what breaks if bypass is lost |
| > 0 | no | `fail` | role drift — reads return 0 rows; remediation suggests GRANT BYPASSRLS or CREATE POLICY |

The fail message names every affected table and offers an open-by-
default escape hatch for operators who understand the exposure.

## Backwards compatibility

- No schema changes, no migrations, no behavior changes for any
  existing op or query.
- Default Supabase / postgres-role install: `rls_policies` reports
  `ok` (deny-by-default with bypass) — no new noise.
- PGLite installs: skipped entirely (same as the existing `rls`
  check).
- The check name is new, so any caller that grepped on existing check
  names (`rls`, `jsonb_integrity`, etc.) is unaffected.

## Test coverage

`test/doctor.test.ts` adds three structural assertions following the
same source-grep pattern the rest of the rls test block uses, so a
silent revert fails loudly without a live Postgres:

- check is wired and joins `pg_policies` against `rowsecurity`
- both `status: ok` and `status: fail` branches are present
- check is in the postgres-only arm, NOT in the PGLite branch

Full `doctor.test.ts` suite passes (16/16). `bun run typecheck` clean.

## Why this matters

A security control that depends on a runtime role attribute, with no
detection for that attribute being changed, is a control that fails
silently. The check is purely additive, takes one round-trip per
doctor run, and turns "RLS works because postgres has BYPASSRLS" from
an undocumented invariant into a doctor assertion an operator sees.

The schema's intent stays exactly as documented at `src/schema.sql:532`.
This PR just makes the assumption testable.