### PR TITLE
perf: incremental extract — only process slugs that sync touched

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -295,6 +295,13 @@ export interface ExtractOpts {
   dryRun?: boolean;
   /** Emit JSON (progress to stderr, result to stdout) instead of human text. */
   jsonMode?: boolean;
+  /**
+   * Incremental mode: only extract from these specific slugs.
+   * When provided, skips the full directory walk and reads only the
+   * files corresponding to these slugs. Massive perf win on large brains.
+   * Pass undefined or omit for a full walk (CLI / first-run path).
+   */
+  slugs?: string[];
 }
 
 /**
@@ -315,6 +322,21 @@ export async function runExtractCore(engine: BrainEngine, opts: ExtractOpts): Pr
   const jsonMode = !!opts.jsonMode;
   const result: ExtractResult = { links_created: 0, timeline_entries_created: 0, pages_processed: 0 };
 
+  // Incremental path: if specific slugs provided, only extract from those files.
+  // This is the cycle path — sync tells us what changed, we only re-extract those.
+  if (opts.slugs !== undefined) {
+    if (opts.slugs.length === 0) {
+      // Nothing changed — skip entirely.
+      return result;
+    }
+    const r = await extractForSlugs(engine, opts.dir, opts.slugs, opts.mode, dryRun, jsonMode);
+    result.links_created = r.links_created;
+    result.timeline_entries_created = r.timeline_created;
+    result.pages_processed = r.pages;
+    return result;
+  }
+
+  // Full walk path: CLI `gbrain extract` or first-run.
   if (opts.mode === 'links' || opts.mode === 'all') {
     const r = await extractLinksFromDir(engine, opts.dir, dryRun, jsonMode);
     result.links_created = r.created;
@@ -409,6 +431,118 @@ export async function runExtract(engine: BrainEngine, args: string[]) {
   } else if (!dryRun) {
     console.log(`\nDone: ${result.links_created} links, ${result.timeline_entries_created} timeline entries from ${result.pages_processed} pages`);
   }
+}
+
+/**
+ * Incremental extract: process only the specified slugs.
+ *
+ * Instead of walking 54K+ files, reads only the files that sync says changed.
+ * Still needs the full slug set for link resolution (resolveSlug needs to know
+ * all valid targets), but that's a single readdir, not 54K readFileSync calls.
+ *
+ * Combines links + timeline extraction in a single pass over each file —
+ * the full-walk path reads every file TWICE (once for links, once for timeline).
+ */
+async function extractForSlugs(
+  engine: BrainEngine,
+  brainDir: string,
+  slugs: string[],
+  mode: 'links' | 'timeline' | 'all',
+  dryRun: boolean,
+  jsonMode: boolean,
+): Promise<{ links_created: number; timeline_created: number; pages: number }> {
+  // Build the full slug set for link resolution (fast: just readdir, no file reads)
+  const allFiles = walkMarkdownFiles(brainDir);
+  const allSlugs = new Set(allFiles.map(f => f.relPath.replace('.md', '')));
+
+  const doLinks = mode === 'links' || mode === 'all';
+  const doTimeline = mode === 'timeline' || mode === 'all';
+
+  const progress = createProgress(cliOptsToProgressOptions(getCliOptions()));
+  progress.start('extract.incremental', slugs.length);
+
+  let linksCreated = 0;
+  let timelineCreated = 0;
+  let pagesProcessed = 0;
+
+  const linkBatch: LinkBatchInput[] = [];
+  const timelineBatch: TimelineBatchInput[] = [];
+
+  async function flushLinks() {
+    if (linkBatch.length === 0) return;
+    try {
+      linksCreated += await engine.addLinksBatch(linkBatch);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (!jsonMode) console.error(`  link batch error (${linkBatch.length} rows lost): ${msg}`);
+    } finally {
+      linkBatch.length = 0;
+    }
+  }
+
+  async function flushTimeline() {
+    if (timelineBatch.length === 0) return;
+    try {
+      timelineCreated += await engine.addTimelineEntriesBatch(timelineBatch);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (!jsonMode) console.error(`  timeline batch error (${timelineBatch.length} rows lost): ${msg}`);
+    } finally {
+      timelineBatch.length = 0;
+    }
+  }
+
+  for (const slug of slugs) {
+    const relPath = slug + '.md';
+    const fullPath = join(brainDir, relPath);
+
+    try {
+      if (!existsSync(fullPath)) continue; // deleted file — sync already handled removal
+      const content = readFileSync(fullPath, 'utf-8');
+
+      // Links
+      if (doLinks) {
+        const links = await extractLinksFromFile(content, relPath, allSlugs);
+        for (const link of links) {
+          if (dryRun) {
+            if (!jsonMode) console.log(`  ${link.from_slug} → ${link.to_slug} (${link.link_type})`);
+            linksCreated++;
+          } else {
+            linkBatch.push(link);
+            if (linkBatch.length >= BATCH_SIZE) await flushLinks();
+          }
+        }
+      }
+
+      // Timeline
+      if (doTimeline) {
+        const entries = extractTimelineFromContent(content, slug);
+        for (const entry of entries) {
+          if (dryRun) {
+            if (!jsonMode) console.log(`  ${entry.slug}: ${entry.date} — ${entry.summary}`);
+            timelineCreated++;
+          } else {
+            timelineBatch.push({ slug: entry.slug, date: entry.date, source: entry.source, summary: entry.summary, detail: entry.detail });
+            if (timelineBatch.length >= BATCH_SIZE) await flushTimeline();
+          }
+        }
+      }
+
+      pagesProcessed++;
+    } catch { /* skip unreadable */ }
+    progress.tick(1);
+  }
+
+  await flushLinks();
+  await flushTimeline();
+  progress.finish();
+
+  if (!jsonMode) {
+    const label = dryRun ? '(dry run) would create' : 'created';
+    console.log(`Incremental extract: ${label} ${linksCreated} link(s), ${timelineCreated} timeline entries from ${pagesProcessed}/${slugs.length} page(s)`);
+  }
+
+  return { links_created: linksCreated, timeline_created: timelineCreated, pages: pagesProcessed };
 }
 
 async function extractLinksFromDir(

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -416,12 +416,18 @@ async function runPhaseBacklinks(brainDir: string, dryRun: boolean): Promise<Pha
   }
 }
 
+/** Extended sync result that also carries the changed slug list for downstream phases. */
+interface SyncPhaseResult extends PhaseResult {
+  /** Slugs that sync added or modified. Used by extract for incremental processing. */
+  pagesAffected?: string[];
+}
+
 async function runPhaseSync(
   engine: BrainEngine,
   brainDir: string,
   dryRun: boolean,
   pull: boolean,
-): Promise<PhaseResult> {
+): Promise<SyncPhaseResult> {
   try {
     const { performSync } = await import('../commands/sync.ts');
     const result = await performSync(engine, {
@@ -448,6 +454,7 @@ async function runPhaseSync(
         syncStatus: result.status,
         dryRun,
       },
+      pagesAffected: result.pagesAffected,
     };
   } catch (e) {
     return {
@@ -465,6 +472,7 @@ async function runPhaseExtract(
   engine: BrainEngine,
   brainDir: string,
   dryRun: boolean,
+  changedSlugs?: string[],
 ): Promise<PhaseResult> {
   try {
     const { runExtractCore } = await import('../commands/extract.ts');
@@ -480,15 +488,29 @@ async function runPhaseExtract(
         details: { dryRun: true, reason: 'no_dry_run_support' },
       };
     }
-    const result = await runExtractCore(engine, { mode: 'all', dir: brainDir });
+    // Incremental path: if sync told us which slugs changed, only extract those.
+    // On a 54K-page brain this turns a 10-minute full walk into a sub-second pass.
+    const result = await runExtractCore(engine, {
+      mode: 'all',
+      dir: brainDir,
+      slugs: changedSlugs,  // undefined = full walk (first run / manual)
+    });
     const linksCreated = result?.links_created ?? 0;
     const timelineCreated = result?.timeline_entries_created ?? 0;
+    const incremental = changedSlugs !== undefined;
     return {
       phase: 'extract',
       status: 'ok',
       duration_ms: 0,
-      summary: `${linksCreated} link(s), ${timelineCreated} timeline entries`,
-      details: { linksCreated, timelineCreated, pages_processed: result?.pages_processed ?? 0 },
+      summary: incremental
+        ? `${linksCreated} link(s), ${timelineCreated} timeline entries (incremental: ${changedSlugs.length} slugs)`
+        : `${linksCreated} link(s), ${timelineCreated} timeline entries`,
+      details: {
+        linksCreated, timelineCreated,
+        pages_processed: result?.pages_processed ?? 0,
+        incremental,
+        ...(incremental ? { slugs_targeted: changedSlugs.length } : {}),
+      },
     };
   } catch (e) {
     return {
@@ -663,6 +685,8 @@ export async function runCycle(
     }
 
     // ── Phase 3: sync ───────────────────────────────────────────
+    // Track which slugs sync touched so extract can run incrementally.
+    let syncPagesAffected: string[] | undefined;
     if (phases.includes('sync')) {
       if (!engine) {
         phaseResults.push({
@@ -676,6 +700,8 @@ export async function runCycle(
         progress.start('cycle.sync');
         const { result, duration_ms } = await timePhase(() => runPhaseSync(engine, opts.brainDir, dryRun, pull));
         result.duration_ms = duration_ms;
+        // Capture changed slugs for incremental extract.
+        syncPagesAffected = (result as SyncPhaseResult).pagesAffected;
         phaseResults.push(result);
         progress.finish();
       }
@@ -693,8 +719,11 @@ export async function runCycle(
           details: { reason: 'no_database' },
         });
       } else {
+        // Pass changed slugs from sync for incremental extract.
+        // If sync didn't run (phases exclude it) or failed, syncPagesAffected
+        // is undefined → extract falls back to full walk (safe default).
         progress.start('cycle.extract');
-        const { result, duration_ms } = await timePhase(() => runPhaseExtract(engine, opts.brainDir, dryRun));
+        const { result, duration_ms } = await timePhase(() => runPhaseExtract(engine, opts.brainDir, dryRun, syncPagesAffected));
         result.duration_ms = duration_ms;
         phaseResults.push(result);
         progress.finish();


### PR DESCRIPTION
## Problem

On a brain with 54K+ pages, the autopilot-cycle extract phase is a performance cliff. Every 5-minute cycle:

1. **Walks the entire brain directory** — `walkMarkdownFiles()` does a recursive `readdirSync` + `readFileSync` on every `.md` file
2. **Does it twice** — once for link extraction (`extract.links_fs`), once for timeline extraction (`extract.timeline_fs`)
3. **Writes zero rows** most cycles — the DB uses `ON CONFLICT` (upsert), so unchanged files produce no new data

**Observed impact in production (54,461 pages):**
- Extract phase alone consumed 600s+ per cycle (the full job timeout)
- Jobs regularly died with `timeout exceeded` errors
- Dead autopilot-cycle jobs held the Postgres cycle lock for their full 30-min TTL
- All subsequent cycles returned `skipped: cycle_already_running`
- Meanwhile, the cron submitted a new autopilot-cycle every 5 minutes → queue backlog grew to 20-35 waiting jobs
- Shell jobs (enrichment, data pipelines, etc.) starved because autopilot-cycle monopolized worker slots

**Timeline of incidents:**
- Queue depth hit 36 waiting + 3 stalled during overnight monitoring
- Worker had to be force-killed (SIGKILL — SIGTERM did not work because the zombie extract handler held the event loop)
- After killing the worker, the Postgres cycle lock persisted for 30 more minutes, blocking all cycles
- Pattern repeated across multiple cycles over 24h+

**Root cause:** `runPhaseExtract()` in `cycle.ts` calls `runExtractCore(engine, { mode: 'all', dir: brainDir })` which calls `extractLinksFromDir()` + `extractTimelineFromDir()` — both invoke `walkMarkdownFiles(brainDir)` which does a full recursive directory walk + readFileSync on every `.md` file. The sync phase already returns `pagesAffected: string[]` but extract ignores it.

## Error Log

Full error output from dead autopilot-cycle jobs:

```
Job #1286: autopilot-cycle (DEAD after 0 attempts)
  Queue: default | Priority: 0
  Attempts: 0/2 (started: 1)
  Started: 2026-04-24T22:20:03.661Z
  Finished: 2026-04-24T22:30:15.149Z
  Error: timeout exceeded
  Data: {"repoPath":"/data/brain"}
```

```
Job #1353: autopilot-cycle (DEAD after 0 attempts)
  Started: 2026-04-25T01:25:06.699Z
  Finished: 2026-04-25T01:35:27.521Z
  Error: timeout exceeded
```

```
Job #1365: autopilot-cycle (DEAD after 0 attempts)
  Started: 2026-04-25T01:40:03.305Z
  Finished: 2026-04-25T01:50:27.542Z
  Error: timeout exceeded
```

Worker log showing the extract phase grinding through all 54K pages before timing out:

```
[extract.timeline_fs] 45645/54461 (83%)
[extract.timeline_fs] 46595/54461 (85%)
[extract.timeline_fs] 47858/54461 (87%)
[extract.timeline_fs] 49498/54461 (90%)
[extract.timeline_fs] 51889/54461 (95%)
[extract.timeline_fs] 53918/54461 (99%)
[extract.timeline_fs] 54461/54461 (100%) done
Timeline: created 0 entries from 54461 pages
[cycle.extract] done
[cycle.embed] start
Job 1290 (autopilot-cycle) hit per-job timeout (600000ms), aborting
Job 1290 (autopilot-cycle) did not exit within 30s of abort. Force-evicting
from inFlight to unblock worker. The handler is still running but the worker
will claim new jobs.
```

Queue state showing the resulting backlog:

```
Job Stats (last 24h):
  Type           Total   Done    Failed   Dead   Avg Time
  shell          73      59      0        12     542.6s
  autopilot-cycle 288     173     0        3      131.3s

  Queue health: 36 waiting, 3 active, 3 stalled
```

## What We Tried

1. **Killed the stuck worker (SIGTERM)** — did not work. The zombie extract handler held the event loop. Required SIGKILL.

2. **Cancelled stalled + duplicate queued jobs** — cleared the backlog (20 duplicate autopilot-cycle jobs cancelled, 925 old completed jobs pruned). Queue went to 0 waiting. But the root cause remained: the next cycle would walk 54K files again.

3. **Manually released the Postgres cycle lock** — the killed worker left a live lock row with 30-min TTL. Had to `DELETE FROM gbrain_cycle_locks` to unblock new cycles. This confirmed the lock-leak pattern.

4. **Restarted worker using `jobs supervisor`** (auto-crash-restart instead of bare `jobs work`) — improved resilience but didn't fix the performance problem. Supervisor successfully restarted after the SIGKILL, but the next autopilot-cycle still took 1106.4s on the first run (full walk).

5. **Implemented incremental extract (this PR)** — piped sync's `pagesAffected` to extract. Immediate improvement: 0.2s per cycle instead of 600s+. The 54K walk only happens on first run or CLI invocation.

**Hotfix:** Deployed directly to the production instance for immediate relief. This PR is the clean version of the same change for merging to master.

## Solution

Pipe the sync phase's `pagesAffected` list into the extract phase. When provided, extract reads only those specific files instead of walking the entire brain.

### Changes

**`src/commands/extract.ts`:**
- Add `slugs?: string[]` to `ExtractOpts` for incremental mode
- Add `extractForSlugs()` — processes only the specified slugs in a single pass (combined links + timeline), vs the full-walk path which reads every file twice
- When `slugs` is an empty array (nothing changed), return immediately with zero counts
- When `slugs` is undefined (CLI usage, first run), fall back to the existing full walk — no behavior change for `gbrain extract` CLI
- Still builds the full slug set via `walkMarkdownFiles()` for link resolution (resolveSlug needs all valid targets), but this is a single `readdir` traversal, not 54K `readFileSync` calls

**`src/core/cycle.ts`:**
- `runPhaseSync` now returns `pagesAffected` from the sync result (via `SyncPhaseResult` interface extension)
- `runCycle` captures `syncPagesAffected` after Phase 3 and passes it to Phase 4
- `runPhaseExtract` accepts optional `changedSlugs` parameter
- If sync didn't run or failed, `syncPagesAffected` is undefined → extract falls back to full walk (safe default)
- Extract phase summary now reports `(incremental: N slugs)` for observability

### Behavior matrix

| Scenario | Extract behavior |
|----------|-----------------|
| Normal autopilot-cycle (sync ran, 3 pages changed) | Reads 3 files, skips 54K |
| Normal autopilot-cycle (sync ran, nothing changed) | Returns immediately, 0 file reads |
| Autopilot-cycle (sync phase not in phase list) | Full walk (syncPagesAffected is undefined) |
| Autopilot-cycle (sync failed) | Full walk (safe fallback) |
| CLI `gbrain extract all` | Full walk (slugs not passed) |
| CLI `gbrain extract --source db` | Unchanged (DB path, not FS) |

## Results

Before and after on a 54,461-page brain:

| Metric | Before | After |
|--------|--------|-------|
| Extract phase duration | 600s+ (often timeout) | 0.2s (typical cycle) |
| Files read per cycle | 54,461 × 2 = 108,922 | 0-10 (only changed) |
| Autopilot-cycle total | 10-18 minutes | < 1 second |
| Queue depth (observed) | 20-36 waiting | 0 waiting |
| Dead jobs from timeout | 3-5 per day | 0 |

**Job log comparison:**
```
# Before (full walk): 1106.4 seconds
Job #1312: autopilot-cycle (COMPLETED) Time: 1106.4s

# After (incremental): 0.2 seconds
Job #1316: autopilot-cycle (COMPLETED) Time: 0.2s
```

Incremental extract in action (3 files changed by sync):
```
[cycle.sync] done
[cycle.extract] start
[extract.incremental] start
[extract.incremental] 3/3 (100%)
[extract.incremental] 3/3 (100%) done
Incremental extract: created 0 link(s), 0 timeline entries from 3/3 page(s)
[cycle.extract] done
```

## Testing

- `bun run typecheck` — clean
- `bun test -- extract` — 124 tests pass, 0 failures
- Production hotfix deployed and running stable for 12+ hours

## Related

- Companion to #403 (AbortSignal propagation). #403 adds the safety net for slow phases; this PR eliminates the cause.
