### PR TITLE
security: reject untrusted .gbrain-source dotfiles in walk-up

### DIFF
--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -13,7 +13,7 @@
  * commands (Steps 4/5), and the operation layer (Step 2+).
  */
 
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, lstatSync, type Stats } from 'fs';
 import { join, dirname, resolve } from 'path';
 import type { BrainEngine } from './engine.ts';
 
@@ -23,6 +23,38 @@ const DOTFILE = '.gbrain-source';
 // like `[wiki:slug]` can't have ugly edges like `[wiki-:slug]`.
 const SOURCE_ID_RE = /^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$/;
 
+/**
+ * isTrustedDotfile rejects a candidate `.gbrain-source` path that an
+ * attacker could plant in a directory the victim's CWD walks through.
+ *
+ * Three conditions trip the check:
+ *   - the path is a symbolic link (an attacker-planted symlink can
+ *     redirect the resolver to a victim-owned file with hostile content)
+ *   - the file is not owned by the current process user (the most
+ *     common hijack: write `.gbrain-source` in `/tmp/foo/` while the
+ *     victim's CWD is `/tmp/foo/bar`)
+ *   - the file is world-writable (anyone can rewrite it after the
+ *     fact, even if it was created by the right user)
+ *
+ * On platforms without numeric uid/mode (Windows: `process.getuid` is
+ * undefined), the function returns `true` so existing setups keep
+ * working — the threat model is multi-user POSIX hosts where dotfile
+ * walks cross trust boundaries.
+ */
+function isTrustedDotfile(stats: Stats): boolean {
+  if (stats.isSymbolicLink()) return false;
+  if (typeof process.getuid !== 'function') return true;
+  const myUid = process.getuid();
+  // Allow root-owned files when running as root; otherwise the file
+  // must be owned by the current user. Cross-uid ownership is the
+  // hijack vector this whole helper exists to block.
+  if (stats.uid !== myUid && !(myUid === 0 && stats.uid === 0)) return false;
+  // World-writable bit set: any other user can clobber the contents
+  // even if the file is currently owned by the victim.
+  if ((stats.mode & 0o002) !== 0) return false;
+  return true;
+}
+
 function readDotfileWalk(startDir: string): string | null {
   let dir = resolve(startDir);
   // Guard against infinite loops on malformed paths.
@@ -30,10 +62,16 @@ function readDotfileWalk(startDir: string): string | null {
     const candidate = join(dir, DOTFILE);
     if (existsSync(candidate)) {
       try {
-        const content = readFileSync(candidate, 'utf8').trim().split('\n')[0].trim();
-        if (SOURCE_ID_RE.test(content)) return content;
+        // lstatSync (not statSync) so a symlink does not get
+        // followed-and-then-trusted. The owner / world-writable check
+        // applies to the dotfile itself.
+        const stats = lstatSync(candidate);
+        if (isTrustedDotfile(stats)) {
+          const content = readFileSync(candidate, 'utf8').trim().split('\n')[0].trim();
+          if (SOURCE_ID_RE.test(content)) return content;
+        }
       } catch {
-        // Unreadable dotfile — skip and keep walking.
+        // Unreadable dotfile or stat failure — skip and keep walking.
       }
     }
     const parent = dirname(dir);
@@ -135,5 +173,6 @@ async function assertSourceExists(engine: BrainEngine, id: string): Promise<void
 /** Exposed for tests. */
 export const __testing = {
   readDotfileWalk,
+  isTrustedDotfile,
   SOURCE_ID_RE,
 };

--- a/test/source-resolver.test.ts
+++ b/test/source-resolver.test.ts
@@ -188,3 +188,99 @@ describe('SOURCE_ID_RE', () => {
     }
   });
 });
+
+// ── Dotfile trust check ────────────────────────────────────
+//
+// The dotfile walk-up reads `.gbrain-source` from any ancestor of the
+// CWD. Without an ownership check, an attacker who can write into a
+// shared ancestor (e.g. `/tmp/poc/`) can hijack the resolved source
+// for any user whose CWD lives below it. The check rejects three
+// classes of untrusted dotfiles: symlinks, files owned by another
+// user, and world-writable files.
+
+describe('dotfile trust check (owner / symlink / world-writable)', () => {
+  let tmpdirPath: string;
+
+  beforeEach(() => {
+    tmpdirPath = mkdtempSync(join(tmpdir(), 'gbrain-resolver-trust-'));
+  });
+  afterEach(() => {
+    rmSync(tmpdirPath, { recursive: true, force: true });
+  });
+
+  test('accepts a normal user-owned, non-symlink, non-world-writable dotfile', async () => {
+    writeFileSync(join(tmpdirPath, '.gbrain-source'), 'wiki\n', { mode: 0o644 });
+    const engine = makeStub(['default', 'wiki'], [], null);
+    const id = await resolveSourceId(engine, null, tmpdirPath);
+    expect(id).toBe('wiki');
+  });
+
+  test('rejects a symlinked dotfile', async () => {
+    if (typeof process.getuid !== 'function') return; // POSIX only
+    const real = join(tmpdirPath, '.gbrain-real');
+    writeFileSync(real, 'hijacked\n');
+    const link = join(tmpdirPath, '.gbrain-source');
+    // Use require() to access symlinkSync without restructuring imports.
+    const { symlinkSync } = await import('fs');
+    symlinkSync(real, link);
+    const engine = makeStub(['default', 'hijacked'], [], null);
+    const id = await resolveSourceId(engine, null, tmpdirPath);
+    // Symlink rejected → walk continues → reaches FS root → returns 'default'.
+    expect(id).toBe('default');
+  });
+
+  test('rejects a world-writable dotfile', async () => {
+    if (typeof process.getuid !== 'function') return;
+    const path = join(tmpdirPath, '.gbrain-source');
+    writeFileSync(path, 'hijacked\n');
+    // umask masks the 0o002 bit on writeFileSync's mode arg, so set it
+    // explicitly after creation.
+    const { chmodSync } = await import('fs');
+    chmodSync(path, 0o666);
+    const engine = makeStub(['default', 'hijacked'], [], null);
+    const id = await resolveSourceId(engine, null, tmpdirPath);
+    expect(id).toBe('default');
+  });
+
+  test('isTrustedDotfile rejects symlink stats', () => {
+    const fakeSymlink = {
+      isSymbolicLink: () => true,
+      uid: typeof process.getuid === 'function' ? process.getuid() : 0,
+      mode: 0o644,
+    } as ReturnType<typeof __testing.isTrustedDotfile> extends boolean
+      ? Parameters<typeof __testing.isTrustedDotfile>[0]
+      : never;
+    expect(__testing.isTrustedDotfile(fakeSymlink as Parameters<typeof __testing.isTrustedDotfile>[0])).toBe(false);
+  });
+
+  test('isTrustedDotfile rejects foreign-owned files', () => {
+    if (typeof process.getuid !== 'function') return;
+    const myUid = process.getuid();
+    const foreign = {
+      isSymbolicLink: () => false,
+      uid: myUid + 1, // some other uid that is not us and not 0
+      mode: 0o644,
+    } as Parameters<typeof __testing.isTrustedDotfile>[0];
+    expect(__testing.isTrustedDotfile(foreign)).toBe(false);
+  });
+
+  test('isTrustedDotfile rejects world-writable files (mode bit 0o002)', () => {
+    if (typeof process.getuid !== 'function') return;
+    const ww = {
+      isSymbolicLink: () => false,
+      uid: process.getuid()!,
+      mode: 0o666,
+    } as Parameters<typeof __testing.isTrustedDotfile>[0];
+    expect(__testing.isTrustedDotfile(ww)).toBe(false);
+  });
+
+  test('isTrustedDotfile accepts owner-only file (mode 0o600)', () => {
+    if (typeof process.getuid !== 'function') return;
+    const ok = {
+      isSymbolicLink: () => false,
+      uid: process.getuid()!,
+      mode: 0o600,
+    } as Parameters<typeof __testing.isTrustedDotfile>[0];
+    expect(__testing.isTrustedDotfile(ok)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`readDotfileWalk` reads `.gbrain-source` from any ancestor of the CWD
(up to 50 levels). The only check before loading the file was
`existsSync` + a regex on the value. There was no ownership, symlink,
or world-writable check.

On a multi-user POSIX host that means an attacker who can write into
a shared ancestor directory (typical: `/tmp/poc/`) can plant a
`.gbrain-source` there with a forged source_id. Any other user whose
CWD lives below the attacker's directory gets the resolver to return
the attacker's source_id, and downstream operations attribute reads /
writes to the wrong source.

## Threat model

Multi-user host where one user can write into a directory another
user's CWD descends into:

- `/tmp`, `/var/tmp`, `/dev/shm` — sticky-bit lets you create files
  there but does not stop your file from being read
- shared NFS / SMB mounts
- CI runners with shared workspace volumes
- container hosts with shared `/workspace` bind-mounts

The hijack does not require root or container escape — just write
access to a single ancestor of the victim's CWD.

## What changes

`isTrustedDotfile(stats)` is called via `lstatSync` (never `statSync`,
so a symlink is not followed-and-then-trusted) before reading any
candidate dotfile. It rejects three classes of untrusted files:

- symlinks (attacker-planted redirect)
- foreign-owned files (`stats.uid !== process.getuid()`, with the
  `root-as-root` allowance)
- world-writable files (`stats.mode & 0o002`, even when ownership is
  legitimate — anyone can clobber later)

On platforms without numeric uid/mode (Windows: `process.getuid` is
undefined) the helper returns `true` so existing setups keep working.
The threat model is multi-user POSIX hosts.

## Backwards compatibility

- Single-user / personal-machine setups are unaffected: the dotfile
  in your own home / project tree is owned by you, not a symlink, and
  not world-writable.
- Existing `multi-source-integration.test.ts` walk-up cases still
  pass (the test creates the dotfile with the test runner's uid).
- A user who actually wants the cross-user setup can use any of the
  three explicit overrides that already exist: `--source` flag,
  `GBRAIN_SOURCE` env var, or `gbrain sources default <id>`. Those
  paths bypass the dotfile walk entirely.

## Test coverage

`test/source-resolver.test.ts` adds a 7-case block:

- normal user-owned non-symlink non-world-writable dotfile is accepted
- symlinked dotfile is rejected, walk continues to fallback
- world-writable dotfile is rejected (umask-aware via `chmodSync` after
  create because `writeFileSync`'s mode arg is masked)
- `isTrustedDotfile` unit cases for symlink / foreign uid / 0o002 /
  owner-only 0o600

Full `source-resolver.test.ts` suite: 21/21 pass. Related
`multi-source-integration.test.ts` (37 cases across both files):
all green. `bun run typecheck` clean.

## Why this matters

The walk-up is convenient for projects whose layout uses a top-level
`.gbrain-source` file checked into git. The convenience cost was that
the resolver trusted any dotfile that happened to be in any ancestor.
On a single-user laptop nothing was wrong; on a shared host the
default behavior was hijackable. After this change the dotfile is
trusted only when the file ownership actually matches the process,
which is the assumption every gbrain user already had in mind.