### PR TITLE
security: confine OpenClaw skills dir to its workspace via realpath

### DIFF
--- a/src/core/repo-root.ts
+++ b/src/core/repo-root.ts
@@ -1,5 +1,5 @@
-import { existsSync } from 'fs';
-import { isAbsolute, join, resolve as resolvePath } from 'path';
+import { existsSync, realpathSync } from 'fs';
+import { isAbsolute, join, relative, resolve as resolvePath, sep } from 'path';
 import { RESOLVER_FILENAMES, hasResolverFile } from './resolver-filenames.ts';
 
 /**
@@ -47,10 +47,55 @@ export interface SkillsDirDetection {
 }
 
 /**
+ * isPathContained returns true when `child` lexically resolves to a
+ * descendant of (or equal to) `parent` after canonicalization. Used by
+ * resolveWorkspaceSkillsDir to confirm that the skills dir we are
+ * about to hand back to readFileSync / readdirSync callers has not
+ * been symlinked outside the declared workspace.
+ *
+ * Uses the same idiom as src/core/operations.ts:92-100 for upload
+ * strict-mode confinement: realpath both ends, then path.relative
+ * must produce a non-`..`-prefixed, non-absolute result.
+ *
+ * On any realpathSync failure (missing dir, EACCES, ELOOP) we fall
+ * back to lexical containment via path.relative — better to refuse a
+ * legit-but-unstattable workspace than to silently trust an escape.
+ */
+function isPathContained(parent: string, child: string): boolean {
+  let realParent: string;
+  let realChild: string;
+  try {
+    realParent = realpathSync(parent);
+    realChild = realpathSync(child);
+  } catch {
+    // Lexical fallback: at minimum confirm the unresolved paths look
+    // contained. This catches the obvious escape attempts even when
+    // realpath cannot run (e.g. the symlink target does not yet exist).
+    realParent = resolvePath(parent);
+    realChild = resolvePath(child);
+  }
+  const rel = relative(realParent, realChild);
+  if (rel === '') return true;
+  if (rel.startsWith('..')) return false;
+  if (rel.startsWith(`..${sep}`)) return false;
+  if (isAbsolute(rel)) return false;
+  return true;
+}
+
+/**
  * Given a workspace root, resolve where the skills directory should
  * live. Returns the skills dir + the specific source variant. Returns
  * null if neither `workspace/skills/<RESOLVER|AGENTS>` nor
  * `workspace/<AGENTS|RESOLVER>` exists.
+ *
+ * Symlink confinement: the resolved skills dir must canonicalize to a
+ * path under the workspace root. Without this, an attacker who controls
+ * `$OPENCLAW_WORKSPACE` (multi-user host, npm postinstall, shell-rc
+ * poisoning) could plant `workspace/skills` as a symlink to an
+ * arbitrary directory. Downstream readFileSync / readdirSync calls
+ * follow symlinks by default, so the resolver, skillpack-check, and
+ * subagent loader would then read attacker-controlled SKILL.md files
+ * believing they came from the workspace.
  *
  * `sourceSubdir` / `sourceRoot` let callers distinguish "skills-dir
  * variant" from "workspace-root variant" for --verbose logging.
@@ -62,14 +107,14 @@ function resolveWorkspaceSkillsDir(
 ): SkillsDirDetection | null {
   // Preferred: workspace/skills with a resolver file inside it (gbrain-native).
   const subdir = join(workspace, 'skills');
-  if (hasResolverFile(subdir)) {
+  if (hasResolverFile(subdir) && isPathContained(workspace, subdir)) {
     return { dir: subdir, source: sourceSubdir };
   }
   // Fallback: resolver file at workspace root (OpenClaw-native layout).
   // The skills/ subtree still governs file layout even when routing lives
   // at workspace root. Return the skills subdir so downstream file lookups
   // work; the resolver parser knows how to look one level up.
-  if (hasResolverFile(workspace) && existsSync(subdir)) {
+  if (hasResolverFile(workspace) && existsSync(subdir) && isPathContained(workspace, subdir)) {
     return { dir: subdir, source: sourceRoot };
   }
   return null;
@@ -145,6 +190,11 @@ function isGbrainRepoRoot(dir: string): boolean {
  * messages when auto-detect fails. Mirrors the priority order used by
  * `autoDetectSkillsDir`.
  */
+/** Exposed for tests. */
+export const __testing = {
+  isPathContained,
+};
+
 export const AUTO_DETECT_HINT = [
   `  1. --skills-dir flag`,
   `  2. $OPENCLAW_WORKSPACE/{skills/,}{${RESOLVER_FILENAMES.join(',')}}`,

--- a/test/repo-root.test.ts
+++ b/test/repo-root.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, afterEach } from 'bun:test';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { autoDetectSkillsDir, findRepoRoot } from '../src/core/repo-root.ts';
+import { autoDetectSkillsDir, findRepoRoot, __testing } from '../src/core/repo-root.ts';
 
 describe('findRepoRoot', () => {
   const created: string[] = [];
@@ -158,5 +158,65 @@ describe('findRepoRoot', () => {
     // Source is still `env` — the distinction is which file was found,
     // and RESOLVER.md takes precedence inside resolveWorkspaceSkillsDir.
     expect(found.source).toBe('openclaw_workspace_env');
+  });
+
+  // Symlink confinement — auto-detect must not return a skills dir that
+  // canonicalizes outside the declared workspace. Without this guard,
+  // an attacker who controls $OPENCLAW_WORKSPACE can plant
+  // workspace/skills as a symlink to an arbitrary directory; downstream
+  // readFileSync / readdirSync calls would then load attacker-controlled
+  // SKILL.md files believing they came from the workspace.
+
+  it('symlink confinement: rejects workspace/skills that points outside the workspace', () => {
+    const workspace = scratch();
+    const attackerPayload = scratch();
+    // Plant a normal skills/ tree the resolver would happily accept,
+    // but inside the attacker-controlled directory.
+    const evilSkills = join(attackerPayload, 'skills');
+    mkdirSync(join(evilSkills, 'evil-skill'), { recursive: true });
+    writeFileSync(join(evilSkills, 'RESOLVER.md'), '# RESOLVER\n');
+    writeFileSync(join(evilSkills, 'evil-skill', 'SKILL.md'), '# evil\n');
+    // workspace/skills is a symlink that escapes the declared workspace.
+    symlinkSync(evilSkills, join(workspace, 'skills'));
+
+    const found = autoDetectSkillsDir(scratch(), { OPENCLAW_WORKSPACE: workspace });
+    // The escaping symlink must not be returned. Falling through to
+    // dir=null is the correct refusal; the operator gets a clear "no
+    // workspace found" instead of silently loading attacker code.
+    expect(found.dir).toBeNull();
+  });
+
+  it('symlink confinement: accepts workspace/skills that is a symlink WITHIN the workspace', () => {
+    // Legit local-dev pattern: workspace/skills -> workspace/_real-skills.
+    const workspace = scratch();
+    const realSkills = join(workspace, '_real-skills');
+    mkdirSync(realSkills, { recursive: true });
+    writeFileSync(join(realSkills, 'RESOLVER.md'), '# RESOLVER\n');
+    symlinkSync(realSkills, join(workspace, 'skills'));
+
+    const found = autoDetectSkillsDir(scratch(), { OPENCLAW_WORKSPACE: workspace });
+    expect(found.dir).toBe(join(workspace, 'skills'));
+    expect(found.source).toBe('openclaw_workspace_env');
+  });
+
+  it('isPathContained accepts equal + descendant paths, rejects siblings + parents', () => {
+    const root = scratch();
+    const child = join(root, 'a', 'b');
+    mkdirSync(child, { recursive: true });
+    expect(__testing.isPathContained(root, root)).toBe(true);
+    expect(__testing.isPathContained(root, child)).toBe(true);
+    // Sibling (different scratch dir).
+    const other = scratch();
+    expect(__testing.isPathContained(root, other)).toBe(false);
+    // Walking up via .. must not pass containment.
+    expect(__testing.isPathContained(child, root)).toBe(false);
+  });
+
+  it('isPathContained rejects symlink that escapes via realpath', () => {
+    const root = scratch();
+    const outside = scratch();
+    const link = join(root, 'pointing-out');
+    symlinkSync(outside, link);
+    expect(__testing.isPathContained(root, link)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

`resolveWorkspaceSkillsDir` in `src/core/repo-root.ts` builds the
skills directory using `path.join` + `existsSync` but never
canonicalizes the result. Downstream readers (`check-resolvable.ts`,
`skillify.ts`, `skillpack.ts`, `routing-eval.ts`) follow symlinks by
default, so an attacker who controls `\$OPENCLAW_WORKSPACE` can plant
`workspace/skills` as a symlink to an arbitrary directory and every
skill loader trusts the result as if it lived under the declared
workspace.

## Threat model

Any process that can set `OPENCLAW_WORKSPACE` is in scope: a multi-
user host where another user owns the env-var target, an npm
postinstall on a shared workspace, shell-rc poisoning, a container
with a bind-mounted workspace whose host-side has been tampered with.
None of these require root or container escape.

This is orthogonal to PR #156 (path traversal inside manifest
entries). That PR validates `..` segments in parsed manifest strings.
The attack here never needs `..` — a single symlink at
`workspace/skills` is enough to escape the boundary.

## What changes

A new helper `isPathContained(parent, child)` in `src/core/repo-root.ts`
is called against both skills-subdir layouts before
`resolveWorkspaceSkillsDir` hands back a result:

- `realpath` both ends
- require `path.relative(realParent, realChild)` to produce a non-`..`-
  prefixed, non-absolute result

Same idiom that `src/core/operations.ts:92-100` already uses for
`file_upload`'s strict mode, so the security pattern is already in
the codebase, just not applied here.

On any `realpathSync` failure we fall back to lexical containment
(resolved absolute paths via `path.relative`) — better to refuse a
legit-but-unstattable workspace than to silently trust an escape via
a symlink whose target does not yet exist.

## Backwards compatibility

Legit local-dev pattern of symlinking `workspace/skills` to
`workspace/_real-skills` (or any other path INSIDE the workspace)
continues to work — the symlink target is contained, so
`isPathContained` returns true. The change only refuses symlinks
that escape the declared workspace boundary.

`autoDetectSkillsDir`'s priority ordering is unchanged. The `~/.openclaw/`
home fallback, the `findRepoRoot` walk, and the `./skills` cwd
fallback all use the same hardened helper now, so they get the same
guarantee as the env-var path.

## Test coverage

`test/repo-root.test.ts` adds four cases:

- escape: `workspace/skills` symlinked to an outside directory →
  `autoDetectSkillsDir` returns `dir=null` (refusal)
- legit: `workspace/skills` symlinked to `workspace/_real-skills` →
  accepted, descendant containment respected
- `isPathContained` unit: equal/descendant pass, sibling/parent fail
- `isPathContained` unit: symlink that escapes via realpath rejected

Full `repo-root.test.ts` (16/16) and related `check-resolvable-cli`
+ `regression-v0_16_4` tests (40/40 across 3 files) all pass.
`bun run typecheck` clean.

## Why this matters

The convenience of letting `\$OPENCLAW_WORKSPACE` point anywhere has
a cost: any process that can set the variable can substitute the skill
tree the resolver loads. The fix is small (one helper, two call sites)
and additive — every legitimate workspace, including symlinked
`workspace/skills` that stays inside its declared boundary, continues
to work. Only escapes are refused.