### PR TITLE
fix: soul-audit init message references non-existent CLI command

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -377,6 +377,6 @@ export function reportModStatus(): void {
     console.log('  cd ~/.claude/skills/gstack && ./setup');
   }
   console.log('Resolver: skills/RESOLVER.md');
-  console.log('Soul audit: run `gbrain soul-audit` to customize agent identity');
+  console.log('Soul audit: ask your AI agent to run the soul-audit skill to customize identity');
   console.log('');
 }


### PR DESCRIPTION
## Problem

`gbrain init` prints:
```
Soul audit: run `gbrain soul-audit` to customize agent identity
```

But `gbrain soul-audit` is not a CLI command — it's a skill (markdown file in `skills/soul-audit/SKILL.md`) meant to be executed by an AI agent. Running `gbrain soul-audit` produces:
```
Unknown command: soul-audit
```

## Fix

Updated the message to direct users to ask their AI agent to run the skill instead.