### PR TITLE
docs(mcp): document Zo bash dispatch as a third Cowork integration option

### DIFF
--- a/docs/mcp/CLAUDE_COWORK.md
+++ b/docs/mcp/CLAUDE_COWORK.md
@@ -1,6 +1,6 @@
 # Connect GBrain to Claude Cowork
 
-Two ways to get GBrain into Cowork sessions:
+Three ways to get GBrain into Cowork sessions:
 
 ## Option 1: Remote (via self-hosted server + tunnel)
 
@@ -27,7 +27,73 @@ Desktop bridges local MCP servers into Cowork via its SDK layer.
 This means: if `gbrain serve` is running and configured in Claude Desktop,
 you don't need a separate server for Cowork.
 
+## Option 3: Zo bash dispatch (via existing zo-computer MCP)
+
+If you run gbrain on a [Zo Computer](https://zo.computer) workspace and
+already use Cowork's existing `mcp__zo-computer__run_bash_command` tool,
+gbrain CLI invocations work without configuring a separate MCP server. The
+Cowork session reaches gbrain by shelling out to Zo:
+
+```typescript
+// From the Cowork session:
+mcp__zo-computer__run_bash_command({
+  cmd: 'cd /home/workspace/.vendor/garrytan-gbrain && PATH="/root/.bun/bin:$PATH" gbrain query "what do we know about Courtney?"'
+})
+```
+
+This avoids running a separate MCP server, separate auth tokens, or a
+custom HTTP wrapper. The trade-off is per-call quoting discipline — the
+shell is the trust boundary, so payloads with special characters (quotes,
+newlines, markdown fences, Unicode) need explicit quoting.
+
+### When to use it
+
+- You already have a Zo Computer workspace with gbrain installed.
+- You don't want to run a separate MCP server (Option 1) or rely on Claude
+  Desktop being open (Option 2).
+- You're operating Cowork as an external session-scoped agent reaching a
+  shared brain on Zo, rather than embedding gbrain in the local sandbox.
+
+### Per-call quoting examples
+
+```bash
+# 1. Quoted strings — single-quote the gbrain payload, double-quote the cmd
+cd /home/workspace/.vendor/garrytan-gbrain && gbrain query "Courtney McCoy"
+
+# 2. Newlines / heredoc payloads
+gbrain query "$(cat <<'PAYLOAD'
+multi-line
+question
+PAYLOAD
+)"
+
+# 3. Markdown fences in payload — base64 encode to dodge shell parsing
+echo 'YGBgcHl0aG9uCi4uLgo=' | base64 -d | gbrain ingest --kind=link --stdin
+
+# 4. Slug arguments — backticks-in-prose stay safe with double-quoted cmd
+gbrain get concepts/access-policy-cowork-zo
+
+# 5. Multi-line chained pipeline — &&-chain or trailing backslash
+cd /home/workspace/.vendor/garrytan-gbrain && \
+  PATH="/root/.bun/bin:$PATH" gbrain sync --repo /home/workspace/brain --no-pull && \
+  PATH="/root/.bun/bin:$PATH" gbrain embed --stale
+
+# 6. Unicode — single-quote payloads with em-dashes / non-Latin scripts
+gbrain query 'what does the policy say about “zero-human” constraints?'
+```
+
+### Future-state trigger
+
+If `mcp__gbrain__*` tools ever appear directly in the Cowork connector
+inventory, prefer Option 1 or Option 2 — direct MCP avoids the shell trust
+boundary entirely. Until then, Zo bash dispatch is the fastest path from
+zero to "Cowork can read my Zo gbrain."
+
 ## Which to use?
 
-- **Remote server:** works even when your laptop is closed, available to all org members
-- **Local Bridge:** zero extra setup if Claude Desktop already has GBrain, but requires your machine to be running
+- **Remote server (Option 1):** works even when your laptop is closed,
+  available to all org members. Best for teams.
+- **Local Bridge (Option 2):** zero extra setup if Claude Desktop already
+  has GBrain, but requires your machine to be running.
+- **Zo bash dispatch (Option 3):** zero extra setup if you already use Zo
+  Computer; per-call quoting is the only discipline to learn.


### PR DESCRIPTION
## What

Adds a third documented way to reach gbrain from Cowork: via the existing `mcp__zo-computer__run_bash_command` channel on Zo Computer workspaces.

The existing `docs/mcp/CLAUDE_COWORK.md` documents two paths:
1. Remote MCP server (org connector + ngrok / Tailscale Funnel)
2. Local Bridge via Claude Desktop

This PR adds **Option 3: Zo bash dispatch**, which is in active use on Zo Computer workspaces where Cowork-Claude is an external session-scoped agent reaching a shared brain on Zo, rather than embedding gbrain in the local Cowork sandbox.

## Why

Without this third option documented, agents starting a fresh Cowork session on a Zo workspace either:
- Spin up a separate MCP server they don't actually need, OR
- Assume Cowork can't reach gbrain at all and operate degraded.

Both failure modes are common in practice. The pattern works well — it just needed to be in the docs.

## What's added

- One new section: "Option 3: Zo bash dispatch (via existing zo-computer MCP)"
- 6 per-call quoting examples (quoted strings, newlines/heredoc, markdown fences via base64, slug args, &&-chained pipelines, Unicode payloads) so users have a working pattern for each common payload shape
- Future-state trigger: when `mcp__gbrain__*` tools appear directly in Cowork's connector inventory, Options 1 and 2 become preferable since they avoid the shell trust boundary entirely
- "Which to use?" comparison table updated to include Option 3

## Trade-off note

Option 3 has per-call quoting discipline as its trade-off — the shell is the trust boundary, so payloads with special characters need explicit quoting. The 6 examples cover the common cases. This is documented in the PR's "Per-call quoting examples" section.

## Provenance

Authored as part of WGOV-161 finishing-plan ADR-028 (Zo-side ratification of the Cowork → gbrain dispatch contract). The Zo-side ADR is at `ABP/projects/workspace-mgmt/adr/ADR-028-cowork-zo-dispatch-contract.md` in our internal monorepo. Live-tested on a Zo workspace running gbrain 0.20.4 against `/home/workspace/brain` (git-initialized 2026-04-25 per ADR-026).

## Validation

- The 6 example invocations all run cleanly on Zo (gbrain 0.20.4, bun 1.x).
- No existing content changed; new option added alongside.
- Markdown lints clean (consistent heading levels, code-fence languages, list formatting).

Happy to revise tone, scope, or examples if a different framing fits the docs better.