### PR TITLE
fix(test): isolate $HOME in mechanical.test.ts so E2E suite stops clobbering user config

### DIFF
--- a/test/e2e/mechanical.test.ts
+++ b/test/e2e/mechanical.test.ts
@@ -24,6 +24,29 @@ import { importFromContent } from '../../src/core/import-file.ts';
 const skip = !hasDatabase();
 const describeE2E = skip ? describe.skip : describe;
 
+// HOME isolation. Several tests in this file shell out to `gbrain init` and
+// `gbrain import` via Bun.spawnSync. `gbrain init` calls saveConfig() which
+// writes to $HOME/.gbrain/config.json, and `gbrain import` writes a sync
+// bookmark to the same directory. Without isolating $HOME, these tests
+// clobber the user's real production gbrain config every time `bun run
+// test:e2e` is executed. Sibling test/e2e/migration-flow.test.ts solved
+// this with a module-level temp HOME; mirror that pattern here so the
+// E2E suite stops mutating user state.
+let _origHome: string | undefined;
+let _tmpHome: string | undefined;
+if (!skip) {
+  _origHome = process.env.HOME;
+  _tmpHome = mkdtempSync(join(tmpdir(), 'gbrain-e2e-mechanical-home-'));
+  process.env.HOME = _tmpHome;
+}
+
+afterAll(() => {
+  if (skip) return;
+  if (_origHome === undefined) delete process.env.HOME;
+  else process.env.HOME = _origHome;
+  try { if (_tmpHome) rmSync(_tmpHome, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
 function makeCtx(opts: { remote?: boolean } = {}): OperationContext {
   return {
     engine: getEngine(),


### PR DESCRIPTION
## Summary

`test/e2e/mechanical.test.ts` shells out to `gbrain init --non-interactive`, `gbrain import`, and a few other CLI commands via `Bun.spawnSync`. The four `cliEnv()` helpers (lines 719, 942, 1204, 1249) forward `process.env` unchanged. So when these subprocesses call `saveConfig()`, they write to the developer's real `~/.gbrain/config.json` — overwriting whatever production `database_url` was there with the test container's URL (`postgresql://postgres:postgres@localhost:5433/gbrain_test`).

I hit this today the hard way. Ran `bun run test:e2e` to verify an unrelated patch, came back to my brain pointing at a torn-down localhost container.

The fix is a module-level temp HOME plus an `afterAll` restore. `test/e2e/migration-flow.test.ts:62-78` already does this for the same reason — this PR mirrors that pattern in `mechanical.test.ts`.

```ts
let _origHome: string | undefined;
let _tmpHome: string | undefined;
if (!skip) {
  _origHome = process.env.HOME;
  _tmpHome = mkdtempSync(join(tmpdir(), 'gbrain-e2e-mechanical-home-'));
  process.env.HOME = _tmpHome;
}

afterAll(() => {
  if (skip) return;
  if (_origHome === undefined) delete process.env.HOME;
  else process.env.HOME = _origHome;
  try { if (_tmpHome) rmSync(_tmpHome, { recursive: true, force: true }); } catch { /* best-effort */ }
});
```

No new helpers, no behavioral change to any test — just the user's real config stops getting clobbered.

## Test plan

- [x] Manual repro before the patch: `md5 ~/.gbrain/config.json` → run E2E → `md5` again → hash differs, file contains the test container URL.
- [x] After the patch: `md5 ~/.gbrain/config.json` before/after running the six describe blocks that exercise spawned CLI subprocesses (Setup Journey, Init Edge Cases, Schema Idempotency, RLS Verification, Doctor Command, Parallel Import) — hash identical, file unchanged. 26/26 tests pass.
- [x] All other pre-existing tests in `mechanical.test.ts` continue to pass — the temp HOME doesn't affect anything that doesn't shell out (in-process `db.connect()` calls use `DATABASE_URL` directly, not config-file lookup).

## Why this matters beyond my own machine

The same bug fires on any CI that runs `bun run test:e2e` if it caches `~/.gbrain` between jobs (e.g. self-hosted runners with persistent home directories). And it makes the local-dev story for /ship and /review ergonomically broken — running tests is supposed to be safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)