### PR TITLE
fix: orphan denominator + first-sync strategy forwarding

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -4,6 +4,7 @@ import { join, relative } from 'path';
 import { cpus, totalmem, homedir } from 'os';
 import type { BrainEngine } from '../core/engine.ts';
 import { importFile } from '../core/import-file.ts';
+import { isSyncable } from '../core/sync.ts';
 import { loadConfig } from '../core/config.ts';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
@@ -35,20 +36,37 @@ export async function runImport(engine: BrainEngine, args: string[], opts: { com
   const workersIdx = args.indexOf('--workers');
   const workersArg = workersIdx !== -1 ? args[workersIdx + 1] : null;
   const workerCount = workersArg ? parseInt(workersArg, 10) : 1;
-  // Find dir: first non-flag arg that isn't a value for --workers
+  // Strategy controls which file types are walked. Default is 'markdown'
+  // (preserves prior behavior). 'code' walks code files only; 'auto' walks
+  // both. When invoked via `gbrain sync --strategy <s>` (incremental or
+  // first-sync), sync.ts forwards the same flag here so first-sync of a
+  // code source actually picks up code files instead of silently importing
+  // only markdown.
+  const strategyIdx = args.indexOf('--strategy');
+  const strategyArg = strategyIdx !== -1 ? args[strategyIdx + 1] : null;
+  const strategy: 'markdown' | 'code' | 'auto' =
+    strategyArg === 'code' || strategyArg === 'auto' || strategyArg === 'markdown'
+      ? strategyArg
+      : 'markdown';
+  // Find dir: first non-flag arg that isn't a value for --workers / --strategy
   const flagValues = new Set<number>();
   if (workersIdx !== -1) flagValues.add(workersIdx + 1);
+  if (strategyIdx !== -1) flagValues.add(strategyIdx + 1);
   const dirArg = args.find((a, i) => !a.startsWith('--') && !flagValues.has(i));
 
   if (!dirArg) {
-    console.error('Usage: gbrain import <dir> [--no-embed] [--workers N] [--fresh] [--json]');
+    console.error('Usage: gbrain import <dir> [--no-embed] [--workers N] [--fresh] [--json] [--strategy markdown|code|auto]');
     process.exit(1);
   }
   const dir: string = dirArg;  // narrowed; survives closure capture
 
-  // Collect all .md files
-  const allFiles = collectMarkdownFiles(dir);
-  console.log(`Found ${allFiles.length} markdown files`);
+  // Collect files according to strategy. 'markdown' (default) preserves the
+  // historical behavior; 'code'/'auto' switches to the strategy-aware walker
+  // so importFile can route to importCodeFile via isCodeFilePath.
+  const allFiles = strategy === 'markdown'
+    ? collectMarkdownFiles(dir)
+    : collectSyncableFiles(dir, strategy);
+  console.log(`Found ${allFiles.length} file(s) (strategy=${strategy})`);
 
   // Resume from checkpoint if available
   const checkpointPath = join(homedir(), '.gbrain', 'import-checkpoint.json');
@@ -297,6 +315,51 @@ export function collectMarkdownFiles(dir: string): string[] {
         walk(full);
       } else if (entry.endsWith('.md') || entry.endsWith('.mdx')) {
         files.push(full);
+      }
+    }
+  }
+
+  walk(dir);
+  return files.sort();
+}
+
+/**
+ * Walk all syncable files under `dir` honoring `strategy` ('code' or 'auto').
+ * Mirrors collectMarkdownFiles' symlink/hidden/node_modules safety rules but
+ * delegates the per-file inclusion check to `isSyncable`, so the markdown
+ * importer can consume code files via the same code path the incremental
+ * sync uses (same skipFiles, .raw/, ops/, glob filters, etc.).
+ *
+ * Use this instead of collectMarkdownFiles when strategy is 'code' or 'auto'.
+ */
+export function collectSyncableFiles(dir: string, strategy: 'code' | 'auto'): string[] {
+  const files: string[] = [];
+
+  function walk(d: string) {
+    for (const entry of readdirSync(d)) {
+      if (entry.startsWith('.')) continue;
+      if (entry === 'node_modules') continue;
+
+      const full = join(d, entry);
+      let stat;
+      try {
+        stat = lstatSync(full);
+      } catch {
+        console.warn(`[gbrain import] Skipping unreadable path: ${full}`);
+        continue;
+      }
+
+      // Same symlink-rejection rule as collectMarkdownFiles — see L002.
+      if (stat.isSymbolicLink()) {
+        console.warn(`[gbrain import] Skipping symlink: ${full}`);
+        continue;
+      }
+
+      if (stat.isDirectory()) {
+        walk(full);
+      } else {
+        const relPath = relative(dir, full);
+        if (isSyncable(relPath, { strategy })) files.push(full);
       }
     }
   }

--- a/src/commands/orphans.ts
+++ b/src/commands/orphans.ts
@@ -50,6 +50,17 @@ const DENY_PREFIXES = [
   'scripts/',
   'templates/',
   'openclaw/config/',
+  // Raw-import leaf pages — same exclusion list used by `getHealth`'s
+  // orphan denominator in pglite-engine.ts and postgres-engine.ts.
+  // These are external data dumps (per-thread email, per-event calendar
+  // invites, contacts dumps, transcript JSONs); having no inbound
+  // wikilinks is the expected steady state, not a content problem.
+  // Aligning the two surfaces means `gbrain orphans` and brain_score
+  // agree on which pages count as orphan signal vs. background noise.
+  'daily/email/',
+  'daily/calendar/',
+  'sources/contacts/',
+  'sources/meetings/',
 ];
 
 /** First slug segments where no inbound links is expected */

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -621,11 +621,15 @@ async function performFullSync(
   // Fixes the silent-write-on-dry-run bug where performFullSync called
   // runImport unconditionally regardless of opts.dryRun.
   if (opts.dryRun) {
-    const { collectMarkdownFiles } = await import('./import.ts');
-    const allFiles = collectMarkdownFiles(repoPath);
+    const { collectMarkdownFiles, collectSyncableFiles } = await import('./import.ts');
+    // Honor strategy so dry-run of a code/auto source shows the correct
+    // file count instead of silently filtering everything out.
+    const allFiles = (opts.strategy && opts.strategy !== 'markdown')
+      ? collectSyncableFiles(repoPath, opts.strategy)
+      : collectMarkdownFiles(repoPath);
     const syncableRelPaths = allFiles
       .map(abs => relative(repoPath, abs))
-      .filter(rel => isSyncable(rel));
+      .filter(rel => isSyncable(rel, opts.strategy ? { strategy: opts.strategy } : undefined));
     console.log(
       `Full-sync dry run: ${syncableRelPaths.length} file(s) would be imported ` +
       `from ${repoPath} @ ${headCommit.slice(0, 8)}.`,
@@ -648,6 +652,15 @@ async function performFullSync(
   const { runImport } = await import('./import.ts');
   const importArgs = [repoPath];
   if (opts.noEmbed) importArgs.push('--no-embed');
+  // Forward strategy so first-sync of a code/auto source actually picks up
+  // code files. Prior to this fix, performFullSync silently dropped the
+  // strategy and runImport defaulted to markdown-only — registering a code
+  // source and running `gbrain sync --strategy code` for the first time
+  // would import only the markdown files in the repo and leave the
+  // code-grain page_kind table empty. (Fixes HANDOFF gotcha 12d.)
+  if (opts.strategy && opts.strategy !== 'markdown') {
+    importArgs.push('--strategy', opts.strategy);
+  }
   const result = await runImport(engine, importArgs, { commit: headCommit });
 
   // Bug 9 — gate the full-sync bookmark on success. runImport already

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1118,12 +1118,30 @@ export class PGLiteEngine implements BrainEngine {
         (SELECT count(*) FROM pages p
          WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
         ) as stale_pages,
-        -- Bug 11 — orphan = islanded (no inbound AND no outbound).
-        -- See BrainHealth.orphan_pages docstring; docs updated to match this.
+        -- Orphan = islanded (no inbound AND no outbound) AMONG pages that
+        -- could plausibly be linked. Raw-import leaf pages are external
+        -- data dumps with no expectation of inbound wikilinks; counting
+        -- them as orphans inflates the metric and obscures real graph
+        -- health. Both numerator and the relevant_page_count denominator
+        -- below exclude these prefixes:
+        --   daily/email/%       — per-thread email renders (e.g. M365 mail)
+        --   daily/calendar/%    — per-event calendar invites (Apple Cal)
+        --   sources/contacts/%  — Google Contacts dumps
+        --   sources/meetings/%  — raw transcript JSONs (granola/tldv/fathom)
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+           AND p.slug NOT LIKE 'daily/email/%'
+           AND p.slug NOT LIKE 'daily/calendar/%'
+           AND p.slug NOT LIKE 'sources/contacts/%'
+           AND p.slug NOT LIKE 'sources/meetings/%'
         ) as orphan_pages,
+        (SELECT count(*) FROM pages p
+         WHERE p.slug NOT LIKE 'daily/email/%'
+           AND p.slug NOT LIKE 'daily/calendar/%'
+           AND p.slug NOT LIKE 'sources/contacts/%'
+           AND p.slug NOT LIKE 'sources/meetings/%'
+        ) as relevant_page_count,
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)
         ) as dead_links,
@@ -1150,6 +1168,7 @@ export class PGLiteEngine implements BrainEngine {
 
     const r = h as Record<string, unknown>;
     const pageCount = Number(r.page_count);
+    const relevantPageCount = Number(r.relevant_page_count);
     const embedCoverage = Number(r.embed_coverage);
     const orphanPages = Number(r.orphan_pages);
     const deadLinks = Number(r.dead_links);
@@ -1158,7 +1177,10 @@ export class PGLiteEngine implements BrainEngine {
 
     const linkDensity = pageCount > 0 ? Math.min(linkCount / pageCount, 1) : 0;
     const timelineCoverageDensity = pageCount > 0 ? Math.min(pagesWithTimeline / pageCount, 1) : 0;
-    const noOrphans = pageCount > 0 ? 1 - (orphanPages / pageCount) : 1;
+    // no_orphans uses relevant_page_count (excludes daily/email/* and
+    // daily/calendar/* — raw-import leaf pages that have no expectation of
+    // inbound wikilinks). See orphan_pages CTE comment above.
+    const noOrphans = relevantPageCount > 0 ? 1 - (orphanPages / relevantPageCount) : 1;
     const noDeadLinks = pageCount > 0 ? 1 - Math.min(deadLinks / pageCount, 1) : 1;
     // Bug 11 — per-component points. Sum equals brainScore by construction
     // so `doctor` can render a breakdown that adds up to the total.

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1251,10 +1251,30 @@ export class PostgresEngine implements BrainEngine {
         (SELECT count(*) FROM pages p
          WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
         ) as stale_pages,
+        -- Orphan = islanded (no inbound AND no outbound) AMONG pages that
+        -- could plausibly be linked. Raw-import leaf pages are external
+        -- data dumps with no expectation of inbound wikilinks; counting
+        -- them as orphans inflates the metric and obscures real graph
+        -- health. Both numerator and the relevant_page_count denominator
+        -- below exclude these prefixes:
+        --   daily/email/%       — per-thread email renders (e.g. M365 mail)
+        --   daily/calendar/%    — per-event calendar invites (Apple Cal)
+        --   sources/contacts/%  — Google Contacts dumps
+        --   sources/meetings/%  — raw transcript JSONs (granola/tldv/fathom)
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+           AND p.slug NOT LIKE 'daily/email/%'
+           AND p.slug NOT LIKE 'daily/calendar/%'
+           AND p.slug NOT LIKE 'sources/contacts/%'
+           AND p.slug NOT LIKE 'sources/meetings/%'
         ) as orphan_pages,
+        (SELECT count(*) FROM pages p
+         WHERE p.slug NOT LIKE 'daily/email/%'
+           AND p.slug NOT LIKE 'daily/calendar/%'
+           AND p.slug NOT LIKE 'sources/contacts/%'
+           AND p.slug NOT LIKE 'sources/meetings/%'
+        ) as relevant_page_count,
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)
         ) as dead_links,
@@ -1279,6 +1299,7 @@ export class PostgresEngine implements BrainEngine {
     `;
 
     const pageCount = Number(h.page_count);
+    const relevantPageCount = Number(h.relevant_page_count);
     const embedCoverage = Number(h.embed_coverage);
     const orphanPages = Number(h.orphan_pages);
     const deadLinks = Number(h.dead_links);
@@ -1288,7 +1309,10 @@ export class PostgresEngine implements BrainEngine {
     // brain_score: 0-100 weighted average
     const linkDensity = pageCount > 0 ? Math.min(linkCount / pageCount, 1) : 0;
     const timelineCoverageWhole = pageCount > 0 ? Math.min(pagesWithTimeline / pageCount, 1) : 0;
-    const noOrphans = pageCount > 0 ? 1 - (orphanPages / pageCount) : 1;
+    // no_orphans uses relevant_page_count (excludes daily/email/* and
+    // daily/calendar/* — raw-import leaf pages that have no expectation of
+    // inbound wikilinks). See orphan_pages CTE comment above.
+    const noOrphans = relevantPageCount > 0 ? 1 - (orphanPages / relevantPageCount) : 1;
     const noDeadLinks = pageCount > 0 ? 1 - Math.min(deadLinks / pageCount, 1) : 1;
     // Per-component points. Sum equals brainScore by construction.
     const embedCoverageScore = pageCount === 0 ? 0 : Math.round(embedCoverage * 35);

--- a/test/brain-score-breakdown.test.ts
+++ b/test/brain-score-breakdown.test.ts
@@ -114,6 +114,98 @@ describe('Bug 11 — orphan_pages is "no inbound links"', () => {
   });
 });
 
+describe('orphan denominator excludes raw-import leaf pages', () => {
+  test('daily/email/* pages do not count as orphans', async () => {
+    // 10 email-thread pages (all islanded) + 1 normal islanded page.
+    // Without the fix: orphan_pages = 11 → no_orphans_score collapses.
+    // With the fix: orphan_pages = 1 (relevant_page_count=1 too).
+    for (let i = 0; i < 10; i++) {
+      await engine.putPage(`daily/email/personal/2026/04/27/thread-${i}`, {
+        type: 'note', title: `Thread ${i}`, compiled_truth: 'body', frontmatter: {},
+      });
+    }
+    await engine.putPage('genuine-orphan', {
+      type: 'note', title: 'Real orphan', compiled_truth: 'no edges', frontmatter: {},
+    });
+
+    const h = await engine.getHealth();
+    expect(h.orphan_pages).toBe(1);
+    expect(h.page_count).toBe(11);
+    // 1 orphan / 1 relevant = 100% orphan → no_orphans_score = 0.
+    // (relevant_page_count = 11 - 10 daily/email = 1.)
+    expect(h.no_orphans_score).toBe(0);
+  });
+
+  test('daily/calendar/* pages do not count as orphans', async () => {
+    for (let i = 0; i < 5; i++) {
+      await engine.putPage(`daily/calendar/work-wag/2026/04/27/event-${i}`, {
+        type: 'note', title: `Event ${i}`, compiled_truth: 'event body', frontmatter: {},
+      });
+    }
+    const h = await engine.getHealth();
+    expect(h.orphan_pages).toBe(0);
+    expect(h.page_count).toBe(5);
+    // No relevant pages → noOrphans defaults to 1 → score 15/15.
+    expect(h.no_orphans_score).toBe(15);
+  });
+
+  test('sources/contacts/* pages do not count as orphans', async () => {
+    for (let i = 0; i < 3; i++) {
+      await engine.putPage(`sources/contacts/google/contact-${i}`, {
+        type: 'note', title: `Contact ${i}`, compiled_truth: 'contact dump', frontmatter: {},
+      });
+    }
+    const h = await engine.getHealth();
+    expect(h.orphan_pages).toBe(0);
+  });
+
+  test('sources/meetings/* pages do not count as orphans', async () => {
+    for (let i = 0; i < 4; i++) {
+      await engine.putPage(`sources/meetings/granola/transcript-${i}`, {
+        type: 'note', title: `Transcript ${i}`, compiled_truth: 'transcript', frontmatter: {},
+      });
+    }
+    const h = await engine.getHealth();
+    expect(h.orphan_pages).toBe(0);
+  });
+
+  test('relevant_page_count denominator lifts no_orphans_score when only excluded pages are orphans', async () => {
+    // 8 daily/email orphans + 2 connected normal pages.
+    // numerator (orphan_pages) = 0 (the 8 daily/email are excluded; a→b are linked)
+    // denominator (relevant_page_count) = 2
+    // noOrphans = 1 → no_orphans_score = 15/15.
+    for (let i = 0; i < 8; i++) {
+      await engine.putPage(`daily/email/personal/2026/04/27/t-${i}`, {
+        type: 'note', title: `T${i}`, compiled_truth: 'x', frontmatter: {},
+      });
+    }
+    await engine.putPage('a', { type: 'note', title: 'A', compiled_truth: 'a', frontmatter: {} });
+    await engine.putPage('b', { type: 'note', title: 'B', compiled_truth: 'b', frontmatter: {} });
+    const aId = (await (engine as any).db.query(`SELECT id FROM pages WHERE slug='a'`)).rows[0].id;
+    const bId = (await (engine as any).db.query(`SELECT id FROM pages WHERE slug='b'`)).rows[0].id;
+    await (engine as any).db.query(
+      `INSERT INTO links (from_page_id, to_page_id, link_type) VALUES ($1, $2, 'mentions')`,
+      [aId, bId],
+    );
+
+    const h = await engine.getHealth();
+    expect(h.orphan_pages).toBe(0);
+    expect(h.no_orphans_score).toBe(15);
+  });
+
+  test('an islanded page with a non-excluded prefix is still an orphan', async () => {
+    // Defensive: only the four specified prefixes are excluded.
+    await engine.putPage('daily/note/2026-04-27', {
+      type: 'note', title: 'Note', compiled_truth: 'note', frontmatter: {},
+    });
+    await engine.putPage('sources/blog/post', {
+      type: 'note', title: 'Post', compiled_truth: 'post', frontmatter: {},
+    });
+    const h = await engine.getHealth();
+    expect(h.orphan_pages).toBe(2);
+  });
+});
+
 describe('Bug 11 — doctor renders brain_score breakdown', () => {
   test('doctor source contains brain_score breakdown rendering', async () => {
     const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();

--- a/test/orphans.test.ts
+++ b/test/orphans.test.ts
@@ -86,6 +86,34 @@ describe('shouldExclude', () => {
     expect(shouldExclude('entities/product-hunt')).toBe(true);
   });
 
+  test('excludes deny-prefix: daily/email/ (raw email-thread dumps)', () => {
+    expect(shouldExclude('daily/email/personal/2026/04/27/some-thread')).toBe(true);
+    expect(shouldExclude('daily/email/work-wag/2026/04/27/another-thread')).toBe(true);
+  });
+
+  test('excludes deny-prefix: daily/calendar/ (raw calendar invites)', () => {
+    expect(shouldExclude('daily/calendar/personal/2026/04/27/event-x')).toBe(true);
+    expect(shouldExclude('daily/calendar/work-dhow/2026/04/27/standup')).toBe(true);
+  });
+
+  test('excludes deny-prefix: sources/contacts/ (Google Contacts dumps)', () => {
+    expect(shouldExclude('sources/contacts/google/john-doe')).toBe(true);
+  });
+
+  test('excludes deny-prefix: sources/meetings/ (transcript JSONs)', () => {
+    expect(shouldExclude('sources/meetings/granola/2026-04-27-standup')).toBe(true);
+  });
+
+  test('does NOT exclude daily/* outside email and calendar', () => {
+    expect(shouldExclude('daily/note/2026-04-27')).toBe(false);
+    expect(shouldExclude('daily/journal/2026-04-27')).toBe(false);
+  });
+
+  test('does NOT exclude sources/* outside contacts and meetings', () => {
+    expect(shouldExclude('sources/notion/wag/some-page')).toBe(false);
+    expect(shouldExclude('sources/blog/post')).toBe(false);
+  });
+
   test('does NOT exclude a normal content page', () => {
     expect(shouldExclude('companies/acme')).toBe(false);
     expect(shouldExclude('people/jane-doe')).toBe(false);


### PR DESCRIPTION
## Summary

Two small, unrelated correctness fixes bundled together. Both surfaced while operating gbrain on a 7k-page production brain (M2 + M4 sharing one Supabase) and both have low blast radius.

### 1) Orphan denominator excludes raw-import leaf pages

**File:** `src/core/{pglite,postgres}-engine.ts` — `getHealth()`

Raw-import leaf pages — per-thread email under `daily/email/`, per-event calendar invites under `daily/calendar/`, Google Contacts dumps under `sources/contacts/`, and transcript JSONs under `sources/meetings/` — are external data dumps with no expectation of inbound wikilinks. Counting them as orphans inflated the `no_orphans` component and obscured real graph health.

Both the numerator (`orphan_pages`) and a new `relevant_page_count` denominator now exclude these prefixes. Only the `no_orphans` component is affected; other components keep the global `page_count` denominator.

**Verified on a 7,172-page brain:** orphans component 10/15 → 14/15, brain_score 93 → 97/100. The remaining 1 orphan point reflects ~200 islanded pages in `skills/`, `docs/`, `test/`, `personal/`, and a handful of `companies/` — real graph gaps, not raw-import noise.

### 2) First-sync strategy forwarding

**Files:** `src/commands/sync.ts` (`performFullSync`), `src/commands/import.ts` (`runImport`)

`performFullSync` now forwards `opts.strategy` to `runImport` via `importArgs` (`--strategy <s>`). Previously dropped, so first sync of a code source silently imported only markdown.

`runImport` accepts `--strategy` and uses a new `collectSyncableFiles()` helper for `code`/`auto` strategies so `importFile` (which already routes via `isCodeFilePath`) actually sees code files. Markdown-strategy path is unchanged (default). `collectSyncableFiles()` mirrors `collectMarkdownFiles`' symlink/hidden safety rules but delegates per-file inclusion to the strategy-aware `isSyncable` from `src/core/sync.ts`. Dry-run path also honors strategy now.

## Test plan

- [x] `bun run typecheck` clean (only pre-existing unrelated `web-tree-sitter` errors remain)
- [x] Live brain verification: orphan component 10/15 → 14/15 with the denominator fix
- [x] First-sync of a code source now indexes code (not just markdown) with `--strategy code`
- [ ] Reviewer: spot-check the prefix list in `relevant_page_count` matches your project's raw-import conventions

## Notes

Happy to split into two PRs if preferred — they're independent. Bundled here because they came out of the same op session and both are small.