### PR TITLE
fix: MCP put_page semantic parity + DB→markdown reconciliation

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -3,8 +3,8 @@
  * Each operation defines its schema, handler, and optional CLI hints.
  */
 
-import { lstatSync, realpathSync } from 'fs';
-import { resolve, relative, sep } from 'path';
+import { lstatSync, realpathSync, existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from 'fs';
+import { resolve, relative, sep, dirname, join, isAbsolute } from 'path';
 import type { BrainEngine } from './engine.ts';
 import { clampSearchLimit } from './engine.ts';
 import type { GBrainConfig } from './config.ts';
@@ -13,7 +13,8 @@ import { importFromContent } from './import-file.ts';
 import { hybridSearch } from './search/hybrid.ts';
 import { expandQuery } from './search/expansion.ts';
 import { dedupResults } from './search/dedup.ts';
-import { extractPageLinks, isAutoLinkEnabled, isAutoTimelineEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef } from './link-extraction.ts';
+import { extractPageLinks, extractFrontmatterLinks, isAutoLinkEnabled, isAutoTimelineEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef, type LinkCandidate } from './link-extraction.ts';
+import { serializeMarkdown } from './markdown.ts';
 import * as db from './db.ts';
 
 // --- Types ---
@@ -278,39 +279,47 @@ const put_page: Operation = {
     const noEmbed = !process.env.OPENAI_API_KEY;
     const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed });
 
-    // Auto-link post-hook: runs AFTER importFromContent (which is its own
-    // transaction). Runs even on status='skipped' so reconciliation catches drift
-    // between the page text and the links table. Failures are non-blocking.
+    // Auto-link + auto-timeline post-hook: runs AFTER importFromContent (which
+    // is its own transaction). Runs even on status='skipped' so reconciliation
+    // catches drift between page text and the links table. Failures are
+    // non-blocking.
     //
-    // SECURITY: skipped for remote (MCP) callers. Auto-link's bare-slug regex
-    // matches `people/X` etc. anywhere in page text, including code fences,
-    // quoted strings, and prompt-injected content. An untrusted page can plant
-    // arbitrary outbound links by including `see meetings/board-q1` in its body.
-    // Combined with the backlink boost in hybridSearch, attacker-placed targets
-    // would surface higher in search. Local CLI users (ctx.remote=false) opt
-    // into this behavior; MCP/remote writes do not.
+    // SECURITY: write path differs by caller mode (Block 7-1, 2026-04-26).
+    //
+    // - Local (ctx.remote=false): full extraction. Bare-slug regex matches
+    //   `people/X` etc. anywhere in page text, INCLUDING code fences, quoted
+    //   strings, and prompt-injected content. Local CLI users own their
+    //   filesystem and opt into this behavior.
+    //
+    // - Remote (ctx.remote=true): SAFE extraction. We only mine YAML
+    //   frontmatter fields (attendees, see_also, related, sources, etc.) which
+    //   are explicit, structured declarations from the writer — equivalent to
+    //   a curated page declaring `attendees: [raymond-zhu]`. The bare-slug
+    //   body regex is skipped: an attacker-controlled page can no longer plant
+    //   outbound edges via "see meetings/board-q1" in body text.
+    //
+    //   Timeline extraction runs for remote writes too: timeline entries
+    //   attach to the page being written (not arbitrary other pages), so the
+    //   prompt-injection vector that bare-slug regex enables doesn't apply.
     let autoLinks:
-      | { created: number; removed: number; errors: number; unresolved: UnresolvedFrontmatterRef[] }
+      | { created: number; removed: number; errors: number; unresolved: UnresolvedFrontmatterRef[]; mode?: 'frontmatter_only' }
       | { error: string }
-      | { skipped: 'remote' }
       | undefined;
-    let autoTimeline: { created: number } | { error: string } | { skipped: 'remote' } | undefined;
-    if (ctx.remote === true) {
-      autoLinks = { skipped: 'remote' };
-      autoTimeline = { skipped: 'remote' };
-    } else if (result.parsedPage) {
+    let autoTimeline: { created: number } | { error: string } | undefined;
+    if (result.parsedPage) {
+      const mode: 'full' | 'frontmatter_only' = ctx.remote === true ? 'frontmatter_only' : 'full';
       try {
         const enabled = await isAutoLinkEnabled(ctx.engine);
         if (enabled) {
-          autoLinks = await runAutoLink(ctx.engine, slug, result.parsedPage);
+          autoLinks = await runAutoLink(ctx.engine, slug, result.parsedPage, mode);
         }
       } catch (e) {
         autoLinks = { error: e instanceof Error ? e.message : String(e) };
       }
-      // Timeline extraction mirrors auto-link: runs post-write, best-effort,
-      // never blocks the write. ON CONFLICT DO NOTHING in
-      // addTimelineEntriesBatch keeps it idempotent across re-writes, so a
-      // page that's edited and re-written won't duplicate its own timeline.
+      // Timeline extraction: runs post-write, best-effort, never blocks the
+      // write. ON CONFLICT DO NOTHING in addTimelineEntriesBatch keeps it
+      // idempotent across re-writes, so a page that's edited and re-written
+      // won't duplicate its own timeline.
       try {
         const enabled = await isAutoTimelineEnabled(ctx.engine);
         if (enabled) {
@@ -331,6 +340,21 @@ const put_page: Operation = {
         }
       } catch (e) {
         autoTimeline = { error: e instanceof Error ? e.message : String(e) };
+      }
+    }
+
+    // DB → markdown reconciliation for remote writes (Block 7-2, 2026-04-26).
+    // MCP writes land in Supabase; without write-back, the markdown source-
+    // of-truth in $GBRAIN_BRAIN_ROOT/<slug>.md stays stale and a repo-only DR
+    // would lose the page. Opt-in via env var; refuses to clobber files that
+    // contain a `<!-- sync:end -->` marker (calendar/email pipeline output).
+    // Best-effort, non-blocking.
+    let brainExport: { exported: true; path: string } | { skipped: string } | { error: string } | undefined;
+    if (ctx.remote === true && result.parsedPage) {
+      try {
+        brainExport = exportToBrainRepo(slug, result.parsedPage);
+      } catch (e) {
+        brainExport = { error: e instanceof Error ? e.message : String(e) };
       }
     }
 
@@ -362,6 +386,7 @@ const put_page: Operation = {
       ...(autoLinks ? { auto_links: autoLinks } : {}),
       ...(autoTimeline ? { auto_timeline: autoTimeline } : {}),
       ...(writerLint ? { writer_lint: writerLint } : {}),
+      ...(brainExport ? { brain_export: brainExport } : {}),
     };
   },
   cliHints: { name: 'put', positional: ['slug'], stdin: 'content' },
@@ -381,13 +406,27 @@ async function runAutoLink(
   engine: BrainEngine,
   slug: string,
   parsed: { type: PageType; compiled_truth: string; timeline: string; frontmatter: Record<string, unknown> },
-): Promise<{ created: number; removed: number; errors: number; unresolved: UnresolvedFrontmatterRef[] }> {
-  const fullContent = parsed.compiled_truth + '\n' + parsed.timeline;
+  mode: 'full' | 'frontmatter_only' = 'full',
+): Promise<{ created: number; removed: number; errors: number; unresolved: UnresolvedFrontmatterRef[]; mode?: 'frontmatter_only' }> {
   // Live-mode resolver: per-put throwaway cache, pg_trgm + optional search.
   const resolver = makeResolver(engine, { mode: 'live' });
-  const { candidates, unresolved } = await extractPageLinks(
-    slug, fullContent, parsed.frontmatter, parsed.type, resolver,
-  );
+  let candidates: LinkCandidate[];
+  let unresolved: UnresolvedFrontmatterRef[];
+  if (mode === 'frontmatter_only') {
+    // Block 7-1: remote (MCP) writes skip the bare-slug body regex which is
+    // a prompt-injection vector, but still extract explicit YAML edges
+    // (attendees, see_also, related, sources, partner, investors, etc.).
+    const fmResult = await extractFrontmatterLinks(slug, parsed.type, parsed.frontmatter, resolver);
+    candidates = fmResult.candidates;
+    unresolved = fmResult.unresolved;
+  } else {
+    const fullContent = parsed.compiled_truth + '\n' + parsed.timeline;
+    const result = await extractPageLinks(
+      slug, fullContent, parsed.frontmatter, parsed.type, resolver,
+    );
+    candidates = result.candidates;
+    unresolved = result.unresolved;
+  }
 
   // Resolve which targets exist (skip refs to non-existent pages to avoid FK
   // violation churn in addLink). One getAllSlugs call upfront, O(1) lookup.
@@ -510,7 +549,94 @@ async function runAutoLink(
     return { created, removed, errors };
   });
 
-  return { ...result, unresolved };
+  return { ...result, unresolved, ...(mode === 'frontmatter_only' ? { mode } : {}) };
+}
+
+/**
+ * DB → markdown reconciliation for remote MCP writes (Block 7-2).
+ *
+ * Without this, MCP put_page lands in Supabase only and the markdown source-
+ * of-truth in `~/brain` stays stale. Repo-only DR (clone + import) loses the
+ * page.
+ *
+ * Behavior:
+ *   - Opt-in via `GBRAIN_BRAIN_ROOT` env var (set in `~/.gbrain/.env`).
+ *     Unset → no-op, returns { skipped: 'no_brain_root' }.
+ *   - Refuses to clobber files containing `<!-- sync:end -->` — that marker
+ *     identifies pages owned by the calendar/email pipelines, which preserve
+ *     manual notes BELOW the marker. Returns { skipped: 'sync_managed' }.
+ *   - Refuses to clobber under raw-import prefixes (daily/email/, daily/
+ *     calendar/, sources/contacts/, sources/meetings/) which are owned by
+ *     external pipelines. Returns { skipped: 'raw_import_path' }.
+ *   - Skips when serialized content is byte-identical to existing file
+ *     (avoids spurious git diffs). Returns { skipped: 'unchanged' }.
+ *   - Atomic write: temp file in same dir, then rename. Avoids torn writes
+ *     racing the auto-push agent.
+ *
+ * Errors are caught by the caller; never blocks the put_page response.
+ */
+export function exportToBrainRepo(
+  slug: string,
+  parsed: { type: PageType; title: string; compiled_truth: string; timeline: string; frontmatter: Record<string, unknown>; tags: string[] },
+): { exported: true; path: string } | { skipped: string } {
+  const root = process.env.GBRAIN_BRAIN_ROOT;
+  if (!root) return { skipped: 'no_brain_root' };
+  if (!isAbsolute(root)) return { skipped: 'brain_root_not_absolute' };
+
+  // Block writes to slugs owned by external pipelines (raw imports). The MCP
+  // server should not be re-rendering email/calendar/contact dumps.
+  const RAW_IMPORT_PREFIXES = [
+    'daily/email/',
+    'daily/calendar/',
+    'sources/contacts/',
+    'sources/meetings/',
+  ];
+  if (RAW_IMPORT_PREFIXES.some(p => slug.startsWith(p))) {
+    return { skipped: 'raw_import_path' };
+  }
+
+  // Path-traversal guard: the rendered path must remain inside the brain root.
+  const targetPath = resolve(root, `${slug}.md`);
+  const rootResolved = resolve(root);
+  if (!targetPath.startsWith(rootResolved + sep) && targetPath !== rootResolved) {
+    return { skipped: 'path_traversal_blocked' };
+  }
+
+  // Refuse to overwrite sync-managed pages (calendar invite renderer leaves a
+  // <!-- sync:end --> marker so manual notes survive).
+  if (existsSync(targetPath)) {
+    try {
+      const existing = readFileSync(targetPath, 'utf-8');
+      if (existing.includes('<!-- sync:end -->')) {
+        return { skipped: 'sync_managed' };
+      }
+      // Render once, compare; if identical, no-op (avoids touching mtime).
+      const rendered = serializeMarkdown(
+        parsed.frontmatter, parsed.compiled_truth, parsed.timeline,
+        { type: parsed.type, title: parsed.title, tags: parsed.tags },
+      );
+      if (existing === rendered) return { skipped: 'unchanged' };
+      writeAtomic(targetPath, rendered);
+      return { exported: true, path: targetPath };
+    } catch (e) {
+      throw new Error(`brain export failed for ${slug}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  // New file: create parent dirs as needed, then atomic write.
+  const rendered = serializeMarkdown(
+    parsed.frontmatter, parsed.compiled_truth, parsed.timeline,
+    { type: parsed.type, title: parsed.title, tags: parsed.tags },
+  );
+  mkdirSync(dirname(targetPath), { recursive: true });
+  writeAtomic(targetPath, rendered);
+  return { exported: true, path: targetPath };
+}
+
+function writeAtomic(targetPath: string, content: string): void {
+  const tmpPath = `${targetPath}.tmp.${process.pid}.${Date.now()}`;
+  writeFileSync(tmpPath, content, 'utf-8');
+  renameSync(tmpPath, targetPath);
 }
 
 const delete_page: Operation = {

--- a/test/export-to-brain-repo.test.ts
+++ b/test/export-to-brain-repo.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Block 7-2 — DB → markdown reconciliation for remote MCP writes.
+ *
+ * Pins the safety + idempotency contract of exportToBrainRepo:
+ *   - opt-in via GBRAIN_BRAIN_ROOT env var
+ *   - refuses to clobber sync-managed files (<!-- sync:end -->)
+ *   - refuses to clobber raw-import-prefix slugs (daily/email/, etc.)
+ *   - skips when serialized content is byte-identical (no spurious diffs)
+ *   - writes new files atomically (temp + rename), creating parent dirs
+ *   - blocks path-traversal attempts (resolve outside root)
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync, readdirSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { exportToBrainRepo } from '../src/core/operations.ts';
+
+let root: string;
+let originalRoot: string | undefined;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'gbrain-export-test-'));
+  originalRoot = process.env.GBRAIN_BRAIN_ROOT;
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  if (originalRoot === undefined) delete process.env.GBRAIN_BRAIN_ROOT;
+  else process.env.GBRAIN_BRAIN_ROOT = originalRoot;
+});
+
+const samplePage = {
+  type: 'concept' as const,
+  title: 'Sample Concept',
+  compiled_truth: 'Body text here.',
+  timeline: '',
+  frontmatter: {},
+  tags: ['x'],
+};
+
+describe('exportToBrainRepo (Block 7-2)', () => {
+  test('skips when GBRAIN_BRAIN_ROOT is unset', () => {
+    delete process.env.GBRAIN_BRAIN_ROOT;
+    const r = exportToBrainRepo('concepts/foo', samplePage);
+    expect(r).toEqual({ skipped: 'no_brain_root' });
+  });
+
+  test('skips when GBRAIN_BRAIN_ROOT is relative (must be absolute)', () => {
+    process.env.GBRAIN_BRAIN_ROOT = './relative/path';
+    const r = exportToBrainRepo('concepts/foo', samplePage);
+    expect(r).toEqual({ skipped: 'brain_root_not_absolute' });
+  });
+
+  test('writes a new file atomically and creates parent dirs', () => {
+    process.env.GBRAIN_BRAIN_ROOT = root;
+    const r = exportToBrainRepo('concepts/foo', samplePage);
+    expect(r).toMatchObject({ exported: true });
+    const target = join(root, 'concepts/foo.md');
+    expect(existsSync(target)).toBe(true);
+    const written = readFileSync(target, 'utf-8');
+    expect(written).toContain('title: Sample Concept');
+    expect(written).toContain('Body text here.');
+    // No leftover temp files.
+    const conceptsDir = join(root, 'concepts');
+    expect(readdirSync(conceptsDir)).toEqual(['foo.md']);
+  });
+
+  test('skips when content is byte-identical to existing file (no spurious diffs)', () => {
+    process.env.GBRAIN_BRAIN_ROOT = root;
+    // First write
+    exportToBrainRepo('concepts/foo', samplePage);
+    // Second write with identical content
+    const r = exportToBrainRepo('concepts/foo', samplePage);
+    expect(r).toEqual({ skipped: 'unchanged' });
+  });
+
+  test('overwrites when content differs (atomic temp+rename)', () => {
+    process.env.GBRAIN_BRAIN_ROOT = root;
+    exportToBrainRepo('concepts/foo', samplePage);
+    const r = exportToBrainRepo('concepts/foo', { ...samplePage, compiled_truth: 'Different body.' });
+    expect(r).toMatchObject({ exported: true });
+    const written = readFileSync(join(root, 'concepts/foo.md'), 'utf-8');
+    expect(written).toContain('Different body.');
+  });
+
+  test('refuses to clobber sync-managed files (<!-- sync:end -->)', () => {
+    process.env.GBRAIN_BRAIN_ROOT = root;
+    const target = join(root, 'meetings/2026-04-26-test.md');
+    mkdirSync(join(root, 'meetings'), { recursive: true });
+    writeFileSync(target, `---\ntitle: Meeting\n---\n\n<!-- sync:end -->\n\nManual notes here.`, 'utf-8');
+    const r = exportToBrainRepo('meetings/2026-04-26-test', { ...samplePage, type: 'meeting' as const, title: 'Meeting' });
+    expect(r).toEqual({ skipped: 'sync_managed' });
+    // File untouched.
+    expect(readFileSync(target, 'utf-8')).toContain('Manual notes here.');
+  });
+
+  test.each([
+    ['daily/email/foo', 'daily/email/'],
+    ['daily/calendar/personal/2026/04/26/x', 'daily/calendar/'],
+    ['sources/contacts/raymond', 'sources/contacts/'],
+    ['sources/meetings/2026-04-26-test', 'sources/meetings/'],
+  ])('refuses raw-import prefix slug %s', (slug) => {
+    process.env.GBRAIN_BRAIN_ROOT = root;
+    const r = exportToBrainRepo(slug, samplePage);
+    expect(r).toEqual({ skipped: 'raw_import_path' });
+  });
+
+  test('blocks path-traversal in slug (e.g. ../../etc/passwd)', () => {
+    process.env.GBRAIN_BRAIN_ROOT = root;
+    const r = exportToBrainRepo('../../etc/passwd', samplePage);
+    expect(r).toEqual({ skipped: 'path_traversal_blocked' });
+  });
+});


### PR DESCRIPTION
## Summary

Two related correctness fixes for the MCP write path. Surfaced by an independent codex deep review of an 0.21.0 production deployment.

### 1) `put_page` skipped auto-link/timeline silently for remote callers

`src/core/operations.ts` previously returned `skipped: 'remote'` for both auto-link and auto-timeline whenever `ctx.remote === true`. The skip was security-motivated — `extractPageLinks`' bare-slug body regex (`people/X` matched anywhere in page text) is a prompt-injection vector: an attacker-controlled page can plant outbound edges via `see meetings/board-q1` in body text, and the `backlink_boost` in `hybridSearch` then surfaces those targets higher.

**Fix:** split the extraction into a safe variant that mines only YAML frontmatter fields (`attendees`, `see_also`, `related`, `sources`, `partner`, `investors`, etc.) for remote callers. Frontmatter is an explicit, structured declaration — equivalent to a curated page setting `attendees: [raymond-zhu]`. The bare-slug body regex remains skipped for remote.

Timeline extraction now also runs for remote writes — timeline entries attach to the page being written (not arbitrary other pages), so the prompt-injection vector that bare-slug regex enables doesn't apply.

`runAutoLink()` takes a new `mode: 'full' | 'frontmatter_only'` arg, defaulting to `'full'` for local callers. The remote branch passes `'frontmatter_only'`. The returned object includes `mode` when the safer path was taken so callers can audit.

### 2) MCP writes never reached the markdown source-of-truth

New `exportToBrainRepo()` runs after a successful remote `put_page` when `GBRAIN_BRAIN_ROOT` is set. Renders the page back to `\${BRAIN_ROOT}/<slug>.md` via existing `serializeMarkdown()`. Atomic temp+rename. Refuses to clobber:
- sync-managed files (containing `<!-- sync:end -->` — e.g. calendar invite renderer output that preserves manual notes below the marker)
- raw-import-prefix slugs (`daily/email/`, `daily/calendar/`, `sources/contacts/`, `sources/meetings/`) — owned by external pipelines
- path-traversal attempts (resolve outside the brain root)

Skips byte-identical content to avoid spurious git diffs. New files create parent dirs. Errors are caught by the `put_page` handler and surfaced in the response as `brain_export: { error }` — never blocks the write.

**Opt-in:** `GBRAIN_BRAIN_ROOT` unset (default) preserves prior behavior. When set, the auto-push agent (or any equivalent) picks up new files on its next cycle so remote writes propagate to other machines via the same git path that local writes use.

## Test plan

- [x] New `test/export-to-brain-repo.test.ts` (11 tests):
  - `no_brain_root` skip when env unset
  - `brain_root_not_absolute` rejection
  - atomic write + parent-dir mkdirp on new file
  - idempotent same-content (skip with `unchanged`)
  - overwrite when content differs
  - `sync_managed` refusal preserves manual notes
  - all 4 raw-import prefixes refused
  - path-traversal blocked
- [x] `test/put-page-namespace.test.ts` (12 tests) — unchanged, still passes
- [x] `test/link-extraction.test.ts` (94 tests) — unchanged, still passes
- [x] `bun run typecheck` clean (only pre-existing unrelated `web-tree-sitter` errors remain)
- [ ] Reviewer: this changes the response shape — `auto_links` no longer can be `{ skipped: 'remote' }`. Consumers that pattern-matched on that string need to handle `mode: 'frontmatter_only'` instead. (None in upstream that I could find; flagging for downstream awareness.)

## Notes

The `GBRAIN_BRAIN_ROOT` design is intentionally opt-in to avoid surprising existing deployments. Open to changing the env var name or making it a config field instead — happy to follow whatever convention you prefer.