### PR TITLE
fix(engine): SET LOCAL statement_timeout = 0 for schema/migration/transaction paths on Supabase pooler

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -78,9 +78,22 @@ export class PostgresEngine implements BrainEngine {
     // on DDL statements (DROP TRIGGER + CREATE TRIGGER acquire AccessExclusiveLock)
     await conn`SELECT pg_advisory_lock(42)`;
     try {
-      await conn.unsafe(SCHEMA_SQL);
+      // Wrap SCHEMA_SQL in a transaction so `SET LOCAL statement_timeout = 0`
+      // takes effect on Supabase's transaction pooler (PgBouncer at port 6543).
+      // On the pooler, session-level SET and connection startup params are
+      // stripped/ignored; only SET LOCAL inside an explicit transaction
+      // survives. Without this wrap, the SCHEMA_SQL bootstrap (which can
+      // include long backfills the first time it touches a brain with
+      // thousands of rows) is killed by the default 2-min statement_timeout.
+      await conn.begin(async (tx) => {
+        await tx.unsafe('SET LOCAL statement_timeout = 0');
+        await tx.unsafe(SCHEMA_SQL);
+      });
 
-      // Run any pending migrations automatically
+      // Run any pending migrations automatically. Each migration is wrapped
+      // in its own transaction by runMigrations() / engine.transaction(),
+      // and runMigration() prepends `SET LOCAL statement_timeout = 0` there
+      // — so they're independently protected from the pooler timeout.
       const { applied } = await runMigrations(this);
       if (applied > 0) {
         console.log(`  ${applied} migration(s) applied`);
@@ -93,6 +106,15 @@ export class PostgresEngine implements BrainEngine {
   async transaction<T>(fn: (engine: BrainEngine) => Promise<T>): Promise<T> {
     const conn = this._sql || db.getConnection();
     return conn.begin(async (tx) => {
+      // Bypass Supabase pooler's 2-min default for the duration of this
+      // transaction. SET LOCAL is scoped here only — query paths that want a
+      // tight fail-fast (e.g., searchKeyword/searchVector) override it with
+      // their own SET LOCAL inside the same transaction. Without this,
+      // importFromContent's chunk upserts + tag reconciliation can exceed
+      // 2 min on slow links and put_page silently fails on every write.
+      // Migration paths get this for free since they go through transaction()
+      // via runMigrations().
+      await tx.unsafe('SET LOCAL statement_timeout = 0');
       // Create a scoped engine with tx as its connection, no shared state mutation
       const txEngine = Object.create(this) as PostgresEngine;
       Object.defineProperty(txEngine, 'sql', { get: () => tx });
@@ -1314,7 +1336,14 @@ export class PostgresEngine implements BrainEngine {
   // Migration support
   async runMigration(_version: number, sqlStr: string): Promise<void> {
     const conn = this.sql;
-    await conn.unsafe(sqlStr);
+    // Disable statement_timeout for migrations. Supabase's default (60-120s)
+    // kills long ALTER TABLE backfills — e.g., v0.13's
+    // `UPDATE links SET link_source = 'markdown'` on a brain with thousands
+    // of edges. SET LOCAL is scoped to the surrounding transaction (migrate.ts
+    // wraps runMigration in engine.transaction by default). Outside a
+    // transaction Postgres just emits a warning and proceeds, which is fine
+    // for the CONCURRENTLY-only non-transactional path.
+    await conn.unsafe('SET LOCAL statement_timeout = 0;\n' + sqlStr);
   }
 
   async getChunksWithEmbeddings(slug: string): Promise<Chunk[]> {

--- a/test/postgres-engine.test.ts
+++ b/test/postgres-engine.test.ts
@@ -105,7 +105,8 @@ function stripComments(s: string): string {
 // brace. Good enough for the small number of methods in this file.
 function extractMethod(source: string, name: string): string {
   // Find "async <name>(" at method-definition indentation (2 spaces).
-  const openRe = new RegExp(`^\\s+async\\s+${name}\\s*\\(`, 'm');
+  // Accept an optional generic parameter list (`async transaction<T>(...)`).
+  const openRe = new RegExp(`^\\s+async\\s+${name}(?:\\s*<[^>]+>)?\\s*\\(`, 'm');
   const match = openRe.exec(source);
   if (!match) {
     throw new Error(`method ${name} not found in postgres-engine.ts`);
@@ -125,3 +126,53 @@ function extractMethod(source: string, name: string): string {
   }
   throw new Error(`unbalanced braces in ${name}`);
 }
+
+/**
+ * Supabase pooler (PgBouncer transaction mode, port 6543) silently strips
+ * connection-level statement_timeout startup parameters and session-scoped
+ * SET. Only `SET LOCAL` inside an explicit transaction survives. Without
+ * this, schema bootstrap, migrations, and put_page write paths silently
+ * hit the pooler's 2-min default — visible as "canceling statement due to
+ * statement timeout" with no other context.
+ *
+ * These guardrails lock in the SET LOCAL placement so a future refactor
+ * doesn't regress the fix. DB-free — pure source inspection.
+ */
+describe('postgres-engine / pooler timeout compatibility', () => {
+  test('runMigration prepends SET LOCAL statement_timeout = 0', () => {
+    const fn = stripComments(extractMethod(SRC, 'runMigration'));
+    // Must contain SET LOCAL prefix concatenated before the migration sqlStr.
+    expect(fn).toMatch(/SET\s+LOCAL\s+statement_timeout\s*=\s*0\s*;[\s\S]*\+\s*sqlStr/);
+  });
+
+  test('runMigration does not use a bare SET (would leak across pooled connections)', () => {
+    const fn = stripComments(extractMethod(SRC, 'runMigration'));
+    expect(fn).not.toMatch(/[^L]\bSET\s+(?!LOCAL\s)statement_timeout/i);
+  });
+
+  test('initSchema wraps SCHEMA_SQL in a conn.begin() transaction', () => {
+    const fn = extractMethod(SRC, 'initSchema');
+    expect(fn).toMatch(/conn\.begin\s*\(\s*async\s*\(\s*tx\s*\)\s*=>/);
+    // SCHEMA_SQL must be inside that transaction, not a bare conn.unsafe().
+    const stripped = stripComments(fn);
+    expect(stripped).toMatch(/tx\.unsafe\s*\(\s*SCHEMA_SQL\s*\)/);
+    expect(stripped).not.toMatch(/conn\.unsafe\s*\(\s*SCHEMA_SQL\s*\)/);
+  });
+
+  test('initSchema sets SET LOCAL statement_timeout = 0 inside the SCHEMA_SQL transaction', () => {
+    const fn = extractMethod(SRC, 'initSchema');
+    expect(fn).toMatch(/SET\s+LOCAL\s+statement_timeout\s*=\s*0/);
+  });
+
+  test('transaction() sets SET LOCAL statement_timeout = 0 before the user callback', () => {
+    const fn = extractMethod(SRC, 'transaction');
+    expect(fn).toMatch(/tx\.unsafe\s*\(\s*['"]SET LOCAL statement_timeout = 0['"]\s*\)/);
+    // Ordering: SET must be issued before fn(txEngine) so user code runs
+    // under the loosened timeout. Verify by source position.
+    const setIdx = fn.search(/SET\s+LOCAL\s+statement_timeout/);
+    const callIdx = fn.search(/fn\s*\(\s*txEngine\s*\)/);
+    expect(setIdx).toBeGreaterThan(-1);
+    expect(callIdx).toBeGreaterThan(-1);
+    expect(setIdx).toBeLessThan(callIdx);
+  });
+});


### PR DESCRIPTION
## Summary

Supabase's transaction pooler (PgBouncer at port 6543) silently strips session-level GUCs and connection startup parameters. Only `SET LOCAL` inside an explicit transaction survives across pooled queries. This PR adds `SET LOCAL statement_timeout = 0` to the three engine paths that need it, as a surgical fix for the pooler-timeout wedge.

## What's broken without this

On a Supabase pooled deployment, three paths silently hit the pooler's 2-min default and fail with `canceling statement due to statement timeout`:

1. **`SCHEMA_SQL` bootstrap in `initSchema()`** — on a brain large enough to trigger v0.13's `UPDATE links SET link_source = 'markdown'` backfill on first run, the bootstrap can't finish inside 2 min. Leaves the schema half-applied — produces `there is no unique or exclusion constraint matching the ON CONFLICT specification` on every subsequent `put_page` because v0.13 dropped the old unique constraint but the new one was never created.

2. **Migration SQL via `runMigration()`** — v0.13's `UPDATE links SET link_source = 'markdown'` exceeds 2 min on thousands of edges; the subsequent ALTER TABLE drop+add of the unique constraint only completes if the UPDATE does.

3. **`importFromContent`'s transaction inside `operations.put_page`** — chunk upserts + tag reconciliation + version creation can exceed 2 min on slow links, which then takes down every page write.

## The change

3-touch surgical change in `src/core/postgres-engine.ts`:

- `initSchema()`: wrap `SCHEMA_SQL` in `conn.begin()` with `SET LOCAL` inside.
- `transaction()`: set `SET LOCAL` as the first statement before invoking the user callback.
- `runMigration()`: prepend `SET LOCAL` to the migration SQL string.

`SET LOCAL` is transaction-scoped, so it auto-resets on COMMIT/ROLLBACK and never leaks to other pool consumers. Existing `SET LOCAL '8s'` overrides in `searchKeyword` / `searchVector` still apply where set — they win inside their own sub-transaction.

Direct (non-pooled) Supabase connections at port 5432 already work without this; this strictly fixes the pooler path. Other Postgres deployments that already have a generous `statement_timeout` are unaffected.

## Tests

Adds 5 source-level guardrail tests in the same DB-free style as the existing `searchKeyword/searchVector wraps in sql.begin()` tests, so a future refactor can't silently regress any of the three placements:

- `runMigration prepends SET LOCAL statement_timeout = 0`
- `runMigration does not use a bare SET (would leak across pooled connections)`
- `initSchema wraps SCHEMA_SQL in a conn.begin() transaction`
- `initSchema sets SET LOCAL statement_timeout = 0 inside the SCHEMA_SQL transaction`
- `transaction() sets SET LOCAL statement_timeout = 0 before the user callback` (verifies source ordering)

Also extends `extractMethod` to recognize generic-typed methods (`async transaction<T>(...)`) since the existing regex only matched non-generic signatures.

## Verification

Tested live against a wedged Supabase brain (port 6543 pooler, 530 pages, v0.13 partial migration). Before this change: ~~ ``put_page`` hangs 2 min, then fails with the timeout error. After: ``put_page`` returns ``created_or_updated`` in ~1s.

Repro before:

```
$ time gbrain call put_page '{\"slug\":\"test/x\",\"content\":\"# x\"}'
canceling statement due to statement timeout
gbrain call put_page  0.26s user 0.09s system 0% cpu 2:00.59 total
```

After this PR (same brain, same Supabase project, gbrain rebuilt with these patches):

```
$ time gbrain call put_page '{\"slug\":\"test/x\",\"content\":\"# x\"}'
{ \"slug\": \"test/x\", \"status\": \"created_or_updated\", \"chunks\": 1 }
gbrain call put_page  0.20s user 0.06s system 23% cpu 1.16s total
```

## Test plan

- [x] `bun test test/postgres-engine.test.ts` — 11 tests pass (6 existing + 5 new)
- [x] `bun test test/postgres-engine.test.ts test/apply-migrations.test.ts test/backoff.test.ts` — 40 pass / 0 fail
- [x] `scripts/check-jsonb-pattern.sh` — clean
- [x] Live verification on a real wedged Supabase brain: `put_page` succeeds where it previously hung 2 min
- [ ] Maintainer's own e2e on PGLite (separate engine; SET LOCAL is a no-op there) and on a healthy Supabase brain

🤖 Generated with [Claude Code](https://claude.com/claude-code)