### PR TITLE
Fix: Update pglite-schema.ts default embedding model to nomic-embed-text

### DIFF
--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -71,8 +71,8 @@ CREATE TABLE IF NOT EXISTS content_chunks (
   chunk_index   INTEGER NOT NULL,
   chunk_text    TEXT    NOT NULL,
   chunk_source  TEXT    NOT NULL DEFAULT 'compiled_truth',
-  embedding     vector(1536),
-  model         TEXT    NOT NULL DEFAULT 'text-embedding-3-large',
+  embedding     vector(768),
+  model         TEXT    NOT NULL DEFAULT 'nomic-embed-text',
   token_count   INTEGER,
   embedded_at   TIMESTAMPTZ,
   created_at    TIMESTAMPTZ NOT NULL DEFAULT now()


### PR DESCRIPTION
This PR updates the default embedding model in  to  (768 dimensions), aligning it with the dynamic Ollama integration already present in . This ensures consistency when using Ollama embeddings with GBrain.