### PR TITLE
feat(embedding): support Azure OpenAI via env vars

### DIFF
--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -5,9 +5,16 @@
  * OpenAI text-embedding-3-large at 1536 dimensions.
  * Retry with exponential backoff (4s base, 120s cap, 5 retries).
  * 8000 character input truncation.
+ *
+ * Azure OpenAI is supported via env vars (AZURE_OPENAI_ENDPOINT +
+ * AZURE_OPENAI_API_KEY); when set, an AzureOpenAI client is used instead
+ * of the public OpenAI client. The deployment name defaults to
+ * `text-embedding-3-large` and can be overridden by
+ * AZURE_OPENAI_EMBEDDING_DEPLOYMENT. API version defaults to
+ * `2024-02-15-preview` and can be overridden by OPENAI_API_VERSION.
  */
 
-import OpenAI from 'openai';
+import OpenAI, { AzureOpenAI } from 'openai';
 
 const MODEL = 'text-embedding-3-large';
 const DIMENSIONS = 1536;
@@ -17,11 +24,20 @@ const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
 
-let client: OpenAI | null = null;
+let client: OpenAI | AzureOpenAI | null = null;
 
-function getClient(): OpenAI {
+function getClient(): OpenAI | AzureOpenAI {
   if (!client) {
-    client = new OpenAI();
+    if (process.env.AZURE_OPENAI_ENDPOINT) {
+      client = new AzureOpenAI({
+        endpoint: process.env.AZURE_OPENAI_ENDPOINT,
+        apiKey: process.env.AZURE_OPENAI_API_KEY,
+        apiVersion: process.env.OPENAI_API_VERSION || '2024-02-15-preview',
+        deployment: process.env.AZURE_OPENAI_EMBEDDING_DEPLOYMENT || MODEL,
+      });
+    } else {
+      client = new OpenAI();
+    }
   }
   return client;
 }


### PR DESCRIPTION
## Summary

When `AZURE_OPENAI_ENDPOINT` is set in the environment, `getClient()` now constructs an `AzureOpenAI` client instead of the public `OpenAI` one. Behavior is unchanged for everyone else (AZURE env unset → original code path).

Env contract:

| var | required | default |
|---|---|---|
| `AZURE_OPENAI_ENDPOINT` | yes (toggles Azure mode) | — |
| `AZURE_OPENAI_API_KEY` | yes | — |
| `OPENAI_API_VERSION` | no | `2024-02-15-preview` |
| `AZURE_OPENAI_EMBEDDING_DEPLOYMENT` | no | `text-embedding-3-large` |

The `AzureOpenAI` class is already a first-class export of `openai` (the SDK gbrain depends on), so this is zero new dependencies.

## Why

Many enterprises (healthcare, financial services, manufacturing) only get OpenAI access via Azure due to data residency / compliance. Today gbrain hard-codes `new OpenAI()` and there's no escape hatch, which blocks those users from `hybridSearch`'s embedding leg, brain-grade retrieval, and `gbrain doctor` health checks. This is the smallest additive change to unblock them.

Aligns with the resolver-registry refactor proposed in `docs/designs/KNOWLEDGE_RUNTIME.md` ("Refactor of `src/core/embedding.ts` into Resolver") — once the Resolver registry lands, this code can be ported as `resolvers/builtin/embedding/azure_openai.ts` alongside the OpenAI one. Until then, this small env-var dispatch unblocks the same use case.

## Test plan

- [x] `bun run build` succeeds, no type errors
- [x] Default path (no AZURE_OPENAI_ENDPOINT) is byte-identical behavior
- [x] AzureOpenAI path: smoke-tested constructor against a live `text-embedding-3-large` deployment (1536 dims)
- [ ] You may want to add a unit test asserting `getClient()` selects the right class based on env (happy to add if you want)

## Notes

- `AzureOpenAI` is imported as a named export alongside the default `OpenAI` import — same package, no SDK version bump needed.
- `client` type is widened to `OpenAI | AzureOpenAI`; the `embeddings.create` call site is unchanged because both classes expose the same `embeddings.create` shape.
- Default API version `2024-02-15-preview` chosen because it's the earliest stable version that supports the `dimensions` parameter on `text-embedding-3-large`. Users on older deployments can override via `OPENAI_API_VERSION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)