### PR TITLE
fix(engines): run pending migrations before schema.sql snapshot on upgrade paths

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -86,11 +86,32 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   async initSchema(): Promise<void> {
-    await this.db.exec(PGLITE_SCHEMA_SQL);
+    // Fresh-install vs upgrade detection. See PostgresEngine.initSchema for
+    // the full rationale; the short version is that PGLITE_SCHEMA_SQL is the
+    // v(LATEST) target snapshot and on a pre-LATEST brain it forward-
+    // references columns added by pending migrations. Running migrations
+    // first brings the schema to LATEST shape; the snapshot then runs as an
+    // idempotent confirmation pass.
+    const probe = await this.db.query<{ rel: string | null }>(
+      `SELECT to_regclass('public.config') AS rel`
+    );
+    const isExistingBrain = probe.rows[0]?.rel !== null;
 
-    const { applied } = await runMigrations(this);
-    if (applied > 0) {
-      console.log(`  ${applied} migration(s) applied`);
+    if (isExistingBrain) {
+      const { applied } = await runMigrations(this);
+      if (applied > 0) {
+        console.log(`  ${applied} migration(s) applied`);
+      }
+      await this.db.exec(PGLITE_SCHEMA_SQL);
+    } else {
+      // Fresh install: PGLITE_SCHEMA_SQL creates everything at v(LATEST)
+      // shape, then runMigrations records version + runs any handler-only
+      // side effects (SQL parts no-op via IF NOT EXISTS).
+      await this.db.exec(PGLITE_SCHEMA_SQL);
+      const { applied } = await runMigrations(this);
+      if (applied > 0) {
+        console.log(`  ${applied} migration(s) applied`);
+      }
     }
   }
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -78,12 +78,52 @@ export class PostgresEngine implements BrainEngine {
     // on DDL statements (DROP TRIGGER + CREATE TRIGGER acquire AccessExclusiveLock)
     await conn`SELECT pg_advisory_lock(42)`;
     try {
-      await conn.unsafe(SCHEMA_SQL);
+      // Fresh-install vs upgrade detection. On a fresh install, the `config`
+      // table doesn't exist yet → schema.sql creates it as part of bootstrap.
+      // On an upgrade, `config` exists and `config.version` reflects what
+      // migrations have already run. `to_regclass` returns NULL for missing
+      // relations rather than raising, which keeps the probe cheap.
+      const probe = await conn`SELECT to_regclass('public.config') AS rel`;
+      const isExistingBrain = probe[0]?.rel !== null;
 
-      // Run any pending migrations automatically
-      const { applied } = await runMigrations(this);
-      if (applied > 0) {
-        console.log(`  ${applied} migration(s) applied`);
+      if (isExistingBrain) {
+        // Upgrade path: run pending MIGRATIONS first. SCHEMA_SQL is the
+        // *target* snapshot of v(LATEST), and on a pre-LATEST brain it
+        // forward-references columns added by pending migrations.
+        // Concrete examples that bit users in the wild:
+        //
+        //   v0.18.x — schema.sql added
+        //     CREATE INDEX idx_pages_source_id ON pages(source_id);
+        //   while pages.source_id was first added by migration v21.
+        //   Pre-v21 brains aborted initSchema with "column 'source_id'
+        //   does not exist" before MIGRATIONS got a chance to add it.
+        //
+        //   v0.21.x — schema.sql added
+        //     CREATE INDEX idx_chunks_symbol_name
+        //       ON content_chunks(symbol_name) WHERE symbol_name IS NOT NULL;
+        //   while content_chunks.symbol_name was first added by migration
+        //   v26. Pre-v26 brains aborted with "column 'symbol_name' does
+        //   not exist".
+        //
+        // Running MIGRATIONS first brings the schema up to LATEST shape
+        // (every column the snapshot references now exists), then SCHEMA_SQL
+        // becomes an idempotent CREATE * IF NOT EXISTS confirmation pass.
+        const { applied } = await runMigrations(this);
+        if (applied > 0) {
+          console.log(`  ${applied} migration(s) applied`);
+        }
+        await conn.unsafe(SCHEMA_SQL);
+      } else {
+        // Fresh-install path: SCHEMA_SQL creates everything at v(LATEST)
+        // shape (tables, columns, indexes, triggers, RLS policies). Then
+        // runMigrations records `config.version = LATEST` and fires any
+        // handler-only side effects. The SQL portion of each migration
+        // no-ops via ADD COLUMN/CREATE INDEX IF NOT EXISTS.
+        await conn.unsafe(SCHEMA_SQL);
+        const { applied } = await runMigrations(this);
+        if (applied > 0) {
+          console.log(`  ${applied} migration(s) applied`);
+        }
       }
     } finally {
       await conn`SELECT pg_advisory_unlock(42)`;

--- a/test/regression-init-schema-forward-refs.test.ts
+++ b/test/regression-init-schema-forward-refs.test.ts
@@ -1,0 +1,104 @@
+/**
+ * test/regression-init-schema-forward-refs.test.ts
+ *
+ * Regression guard for the schema.sql / runMigrations ordering bug.
+ *
+ * BACKGROUND
+ * ──────────
+ * `engine.initSchema()` historically ran SCHEMA_SQL first and runMigrations
+ * second. That works on a fresh install (SCHEMA_SQL bootstraps everything at
+ * v(LATEST) shape), but breaks every upgrade that crosses a release where
+ * SCHEMA_SQL added a new CREATE INDEX referencing a column added by a
+ * pending migration.
+ *
+ * Examples that bit users in the wild:
+ *   - v0.18.x: SCHEMA_SQL added
+ *       CREATE INDEX idx_pages_source_id ON pages(source_id);
+ *     while pages.source_id was first added by migration v21. Pre-v21
+ *     brains aborted initSchema with "column 'source_id' does not exist"
+ *     before runMigrations got a chance to add it.
+ *   - v0.21.x: SCHEMA_SQL added
+ *       CREATE INDEX idx_chunks_symbol_name
+ *         ON content_chunks(symbol_name) WHERE symbol_name IS NOT NULL;
+ *     while content_chunks.symbol_name was first added by migration v26.
+ *     Pre-v26 brains aborted with "column 'symbol_name' does not exist".
+ *
+ * The fix swaps the order on existing brains: runMigrations FIRST (brings
+ * schema to v(LATEST) shape), SCHEMA_SQL second (idempotent confirmation
+ * pass via CREATE * IF NOT EXISTS).
+ *
+ * THIS TEST
+ * ─────────
+ * Reconstructs the v0.21.x failure shape against PGLite. Drops the
+ * symbol_name column + its partial index after a clean LATEST bootstrap,
+ * rolls config.version backwards to 25, and re-runs initSchema. With
+ * the fix, runMigrations re-adds the column before SCHEMA_SQL's
+ * forward-referencing CREATE INDEX hits it. Without the fix, initSchema
+ * aborts on "column does not exist".
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { LATEST_VERSION } from '../src/core/migrate.ts';
+
+describe('regression: initSchema forward-reference ordering', () => {
+  it('upgrade path — pre-v26 brain re-runs migrations before schema.sql snapshot', async () => {
+    const engine = new PGLiteEngine();
+    await engine.connect({}); // in-memory
+    await engine.initSchema(); // baseline → v(LATEST)
+
+    // Roll back to a pre-v26 shape: drop the partial index then the column.
+    // ALTER TABLE DROP COLUMN would CASCADE the index automatically, but
+    // dropping it explicitly mirrors what an actual pre-v26 install looks
+    // like (the index didn't exist there either).
+    await engine.executeRaw(`DROP INDEX IF EXISTS idx_chunks_symbol_name`);
+    await engine.executeRaw(
+      `ALTER TABLE content_chunks DROP COLUMN IF EXISTS symbol_name`,
+    );
+    await engine.setConfig('version', '25');
+
+    // Before the fix, this throws `column "symbol_name" does not exist`
+    // at the SCHEMA_SQL step and never reaches runMigrations. After the
+    // fix, runMigrations runs first, re-adds the column via v26, and
+    // SCHEMA_SQL succeeds as an idempotent confirmation pass.
+    await expect(engine.initSchema()).resolves.toBeUndefined();
+
+    // The column is back.
+    const cols = (await engine.executeRaw<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_name='content_chunks' AND column_name='symbol_name'`,
+    )) as Array<{ column_name: string }>;
+    expect(cols.length).toBe(1);
+
+    // Version advanced to LATEST.
+    const ver = await engine.getConfig('version');
+    expect(ver).toBe(String(LATEST_VERSION));
+  });
+
+  it('fresh-install path — initSchema bootstraps a brand-new brain to LATEST', async () => {
+    // Fresh PGLiteEngine: config table doesn't exist yet → fresh-install
+    // branch fires. SCHEMA_SQL creates everything at v(LATEST) shape, then
+    // runMigrations records version + handler side effects.
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    await expect(engine.initSchema()).resolves.toBeUndefined();
+
+    const ver = await engine.getConfig('version');
+    expect(ver).toBe(String(LATEST_VERSION));
+  });
+
+  it('idempotency — re-running initSchema on a current brain is a no-op', async () => {
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+    const verAfterFirst = await engine.getConfig('version');
+
+    // Second call: existing-brain branch, no pending migrations,
+    // SCHEMA_SQL is the idempotent confirmation pass.
+    await expect(engine.initSchema()).resolves.toBeUndefined();
+    const verAfterSecond = await engine.getConfig('version');
+
+    expect(verAfterSecond).toBe(verAfterFirst);
+    expect(verAfterSecond).toBe(String(LATEST_VERSION));
+  });
+});


### PR DESCRIPTION
## Summary

`engine.initSchema()` runs `SCHEMA_SQL` first and `runMigrations()` second. That works on a fresh install — `SCHEMA_SQL` bootstraps everything at v(LATEST) shape, then `runMigrations` records `config.version` and fires handler-only side effects.

It **breaks every upgrade** across a release where `SCHEMA_SQL` added a partial-index or foreign-key reference to a column that a pending migration is responsible for adding. `SCHEMA_SQL` aborts on the forward reference, `runMigrations` is never reached, the brain is deadlocked at the previous version.

## How users hit this

Two majors in a row:

**v0.18.x.** `SCHEMA_SQL` added:
```sql
CREATE INDEX idx_pages_source_id ON pages(source_id);
CREATE INDEX idx_files_page_id   ON files(page_id);
CREATE INDEX idx_files_source_id ON files(source_id);
```
…while `pages.source_id` was first added by migration **v21** and the `files.*` columns by **v23**. Pre-v21 brains aborted with `column "source_id" does not exist`.

**v0.21.x.** `SCHEMA_SQL` added:
```sql
CREATE INDEX idx_chunks_symbol_name
  ON content_chunks(symbol_name) WHERE symbol_name IS NOT NULL;
```
…while `content_chunks.symbol_name` was first added by migration **v26**. Pre-v26 brains aborted with `column "symbol_name" does not exist`.

Both releases left affected users with no path forward via `gbrain apply-migrations` — recovery required manual SQL surgery (apply pending migrations directly via psql / supabase MCP, manually bump `config.version`, then re-run `apply-migrations` so it fast-paths through). I just shipped that recovery for myself on the v0.20.4 → v0.22.0 upgrade and figured it was worth a structural fix.

## The fix

Swap the order on **existing brains**. `SCHEMA_SQL` is the *target* snapshot of v(LATEST); on a pre-LATEST brain some of its DDL is correctly not yet applicable. Running pending migrations first brings the schema to LATEST shape so `SCHEMA_SQL` becomes an idempotent `CREATE * IF NOT EXISTS` confirmation pass.

Detection uses `to_regclass('public.config')` — returns NULL for missing relations rather than raising, which keeps the probe cheap and avoids try/catch fragility. On a fresh install the config table doesn't exist yet, so the probe takes the original ordering (`SCHEMA_SQL` → `runMigrations`) which bootstraps everything from scratch. On an existing brain, config exists and we take the new ordering (`runMigrations` → `SCHEMA_SQL`).

Both engines patched. PGLite is in-memory so it doesn't bite users in the same way (every PGLite test starts from fresh-install state), but PGLite-backed brains that survive across `gbrain` upgrades are also affected.

## Test plan

- [x] **New regression test** — `test/regression-init-schema-forward-refs.test.ts`. Reconstructs the v0.21.x failure shape against PGLite: drops the `symbol_name` column + its partial index after a clean LATEST bootstrap, rolls `config.version` backwards to 25, re-runs `initSchema`. Without this fix, the second `initSchema` rejects at the `SCHEMA_SQL` step. With the fix, `runMigrations` re-adds the column via v26 before `SCHEMA_SQL`'s `CREATE INDEX` hits it. Verified that the test FAILS without the engine patches applied, PASSES with them. Plus a fresh-install path test and an idempotency test.
- [x] `bun test test/pglite-engine.test.ts` — 85/85 pass (full BrainEngine method coverage including the existing initSchema-in-beforeEach pattern).
- [x] `bun test test/migrate.test.ts` — 49/49 pass.
- [x] `bun test test/regression-init-schema-forward-refs.test.ts` — 3/3 pass.
- [ ] E2E against real Postgres (`test/e2e/`) — requires `DATABASE_URL`; not run in this branch but the postgres-engine code path is symmetric to PGLite's.

## Not in this PR

I considered making `SCHEMA_SQL` no longer contain forward-referencing CREATE INDEX statements (i.e., only the migration that adds the column knows about its index). That's a bigger refactor and changes the contract that `SCHEMA_SQL` is the v(LATEST) target — happy to discuss if you'd prefer that direction. The reorder fix in this PR is the minimal change that prevents the next major upgrade from biting the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)