### PR TITLE
Fix source config federation health

### DIFF
--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -64,10 +64,20 @@ interface SourceListEntry {
 // ── Helpers ─────────────────────────────────────────────────
 
 function parseConfig(config: unknown): Record<string, unknown> {
-  if (typeof config === 'string') {
-    try { return JSON.parse(config) as Record<string, unknown>; } catch { return {}; }
+  let value = config;
+
+  // Older installs could store JSONB config as a JSON string; later jsonb
+  // concatenation could then create arrays like ["{...}", {...}]. Normalize
+  // defensively on read while repair scripts/migrations fix rows to objects.
+  for (let i = 0; i < 3 && typeof value === 'string'; i++) {
+    try { value = JSON.parse(value); } catch { return {}; }
   }
-  if (typeof config === 'object' && config !== null) return config as Record<string, unknown>;
+
+  if (Array.isArray(value)) {
+    return value.reduce<Record<string, unknown>>((acc, item) => ({ ...acc, ...parseConfig(item) }), {});
+  }
+
+  if (typeof value === 'object' && value !== null) return value as Record<string, unknown>;
   return {};
 }
 
@@ -138,13 +148,21 @@ async function runAdd(engine: BrainEngine, args: string[]): Promise<void> {
     }
   }
 
-  const config = federated === null ? {} : { federated };
-  await engine.executeRaw(
-    `INSERT INTO sources (id, name, local_path, config)
-         VALUES ($1, $2, $3, $4::jsonb)
-     ON CONFLICT (id) DO NOTHING`,
-    [id, displayName, localPath, JSON.stringify(config)],
-  );
+  if (federated === null) {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config)
+           VALUES ($1, $2, $3, '{}'::jsonb)
+       ON CONFLICT (id) DO NOTHING`,
+      [id, displayName, localPath],
+    );
+  } else {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config)
+           VALUES ($1, $2, $3, jsonb_build_object('federated', $4::boolean))
+       ON CONFLICT (id) DO NOTHING`,
+      [id, displayName, localPath, federated],
+    );
+  }
 
   const created = await fetchSource(engine, id);
   if (!created) {
@@ -315,11 +333,12 @@ async function runFederate(engine: BrainEngine, args: string[], value: boolean):
     console.error(`Source "${id}" not found.`);
     process.exit(4);
   }
-  const config = parseConfig(src.config);
-  config.federated = value;
   await engine.executeRaw(
-    `UPDATE sources SET config = $1::jsonb WHERE id = $2`,
-    [JSON.stringify(config), id],
+    `UPDATE sources
+        SET config = ((CASE WHEN jsonb_typeof(config) = 'object' THEN config ELSE '{}'::jsonb END) - 'federated')
+          || jsonb_build_object('federated', $1::boolean)
+      WHERE id = $2`,
+    [value, id],
   );
   console.log(`Source "${id}" is now ${value ? 'federated (appears in cross-source default search)' : 'isolated (only searched when explicitly named)'}.`);
 }

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -1065,6 +1065,61 @@ export const MIGRATIONS: Migration[] = [
     },
     sql: '',
   },
+  {
+    version: 30,
+    name: 'sources_config_jsonb_object',
+    // v0.22.1 — repair source config rows written as JSONB strings/arrays by
+    // older source-management paths. `sources.config` is documented as an
+    // object ({ federated, access_policy, ... }); storing a JSON string makes
+    // `sources list` report false federation after `sources federate` says
+    // success. Normalize existing rows without changing valid object configs.
+    sql: `
+      DO $$
+      DECLARE
+        r RECORD;
+        parsed JSONB;
+        elem JSONB;
+        merged JSONB;
+      BEGIN
+        FOR r IN SELECT id, config FROM sources LOOP
+          parsed := r.config;
+
+          IF jsonb_typeof(parsed) = 'string' THEN
+            BEGIN
+              parsed := (parsed #>> '{}')::jsonb;
+            EXCEPTION WHEN others THEN
+              parsed := '{}'::jsonb;
+            END;
+          END IF;
+
+          IF jsonb_typeof(parsed) = 'array' THEN
+            merged := '{}'::jsonb;
+            FOR elem IN SELECT value FROM jsonb_array_elements(parsed) LOOP
+              IF jsonb_typeof(elem) = 'string' THEN
+                BEGIN
+                  elem := (elem #>> '{}')::jsonb;
+                EXCEPTION WHEN others THEN
+                  elem := '{}'::jsonb;
+                END;
+              END IF;
+
+              IF jsonb_typeof(elem) = 'object' THEN
+                merged := merged || elem;
+              END IF;
+            END LOOP;
+            parsed := merged;
+          END IF;
+
+          IF jsonb_typeof(parsed) IS DISTINCT FROM 'object' THEN
+            parsed := '{}'::jsonb;
+          END IF;
+
+          UPDATE sources SET config = parsed WHERE id = r.id;
+        END LOOP;
+      END $$;
+    `,
+  },
+
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/test/sources.test.ts
+++ b/test/sources.test.ts
@@ -109,7 +109,7 @@ describe('sources add', () => {
     expect(insert!.params[0]).toBe('gstack');
     expect(insert!.params[1]).toBe('gstack'); // name defaults to id
     expect(insert!.params[2]).toBe('/tmp/gstack');
-    expect(insert!.params[3]).toBe('{}'); // federated unset → empty config
+    expect(insert!.params).toEqual(['gstack', 'gstack', '/tmp/gstack']); // federated unset → empty config
   });
 
   test('--federated sets config.federated = true', async () => {
@@ -126,7 +126,7 @@ describe('sources add', () => {
     });
     await runSources(engine, ['add', 'wiki', '--path', '/tmp/wiki', '--federated']);
     const insert = calls.find(c => c.sql.includes('INSERT INTO sources'));
-    expect(insert!.params[3]).toBe('{"federated":true}');
+    expect(insert!.params[3]).toBe(true);
   });
 
   test('--no-federated sets config.federated = false (isolation opt-in)', async () => {
@@ -143,7 +143,7 @@ describe('sources add', () => {
     });
     await runSources(engine, ['add', 'yc-media', '--path', '/tmp/yc', '--no-federated']);
     const insert = calls.find(c => c.sql.includes('INSERT INTO sources'));
-    expect(insert!.params[3]).toBe('{"federated":false}');
+    expect(insert!.params[3]).toBe(false);
   });
 
   test('rejects overlapping paths (per eng review finding 4.1)', async () => {
@@ -231,9 +231,9 @@ describe('sources federate / unfederate', () => {
       ],
     });
     await runSources(engine, ['federate', 'gstack']);
-    const upd = calls.find(c => c.sql.includes('UPDATE sources SET config'));
+    const upd = calls.find(c => c.sql.includes('UPDATE sources'));
     expect(upd).toBeDefined();
-    expect(JSON.parse(upd!.params[0] as string)).toEqual({ federated: true });
+    expect(upd!.params).toEqual([true, 'gstack']);
   });
 
   test('unfederate preserves other config keys', async () => {
@@ -243,10 +243,10 @@ describe('sources federate / unfederate', () => {
       ],
     });
     await runSources(engine, ['unfederate', 'gstack']);
-    const upd = calls.find(c => c.sql.includes('UPDATE sources SET config'));
-    const parsed = JSON.parse(upd!.params[0] as string);
-    // Must preserve ttl_days while flipping federated.
-    expect(parsed.ttl_days).toBe(90);
-    expect(parsed.federated).toBe(false);
+    const upd = calls.find(c => c.sql.includes('UPDATE sources'));
+    // Must preserve ttl_days while flipping federated in SQL.
+    expect(upd!.sql).toContain("jsonb_typeof(config) = 'object'");
+    expect(upd!.sql).toContain("- 'federated'");
+    expect(upd!.params).toEqual([false, 'gstack']);
   });
 });


### PR DESCRIPTION
## Summary
- normalize legacy `sources.config` JSONB strings/arrays back into object configs via schema migration v30
- make `sources add` and `sources federate` write config with `jsonb_build_object` instead of JSON-string params
- make source config reads defensive for older bad rows

## Testing
- `bun run typecheck`
- `bun test --timeout=60000 test/sources.test.ts test/multi-source-integration.test.ts test/check-resolvable.test.ts test/doctor-fix.test.ts`
- `bun test --timeout=60000 test/migrate.test.ts test/apply-migrations.test.ts`

## Privacy check
- Diff contains only repo code/tests. No local brain content, env files, tokens, private paths, calendar/email/X/Twilio/ngrok data, or user-specific runtime config.
