### PR TITLE
feat: parameterize content_chunks.embedding dimension

### DIFF
--- a/src/core/embedding-config.ts
+++ b/src/core/embedding-config.ts
@@ -1,0 +1,61 @@
+/**
+ * Embedding configuration helpers.
+ *
+ * Kept separate from `embedding.ts` so that engine code, migrations, and
+ * tests can read the configured model/dim without reaching into the OpenAI
+ * client module — which is mocked aggressively by `test/embed.test.ts`.
+ *
+ * Default: OpenAI text-embedding-3-large at 1536 dimensions (legacy baseline).
+ *
+ * Override via env:
+ *   GBRAIN_EMBEDDING_MODEL       — model name passed to the API
+ *   GBRAIN_EMBEDDING_DIMENSIONS  — output vector dim, must match the column type
+ *   GBRAIN_EMBEDDING_BASE_URL    — OpenAI-compatible endpoint (Ollama, vLLM, …)
+ *   GBRAIN_EMBEDDING_API_KEY     — overrides OPENAI_API_KEY for the embed client only
+ */
+
+export const DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-large';
+export const DEFAULT_EMBEDDING_DIMENSIONS = 1536;
+
+/**
+ * Read the configured embedding model. Falls back to the legacy default so
+ * existing brains stay byte-identical when no env var is set.
+ */
+export function getEmbeddingModel(): string {
+  const v = process.env.GBRAIN_EMBEDDING_MODEL;
+  return v && v.trim().length > 0 ? v : DEFAULT_EMBEDDING_MODEL;
+}
+
+/**
+ * Read the configured embedding dimensions. Must match the type of the
+ * `content_chunks.embedding` column — migration v30 keeps them in sync.
+ */
+export function getEmbeddingDimensions(): number {
+  const v = process.env.GBRAIN_EMBEDDING_DIMENSIONS;
+  if (!v) return DEFAULT_EMBEDDING_DIMENSIONS;
+  const n = parseInt(v, 10);
+  if (Number.isNaN(n) || n <= 0) {
+    throw new Error(
+      `GBRAIN_EMBEDDING_DIMENSIONS must be a positive integer, got "${v}"`,
+    );
+  }
+  return n;
+}
+
+/**
+ * Read the optional OpenAI-compatible base URL. Used by the embedding client
+ * to redirect requests to local servers like Ollama (`http://localhost:11434/v1`).
+ */
+export function getEmbeddingBaseUrl(): string | undefined {
+  const v = process.env.GBRAIN_EMBEDDING_BASE_URL;
+  return v && v.trim().length > 0 ? v : undefined;
+}
+
+/**
+ * Read the embedder-specific API key, falling back to OPENAI_API_KEY. Lets
+ * users keep a real OpenAI key for chat models while pointing embeddings at
+ * a self-hosted endpoint with a placeholder key.
+ */
+export function getEmbeddingApiKey(): string | undefined {
+  return process.env.GBRAIN_EMBEDDING_API_KEY || process.env.OPENAI_API_KEY;
+}

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -2,15 +2,23 @@
  * Embedding Service
  * Ported from production Ruby implementation (embedding_service.rb, 190 LOC)
  *
- * OpenAI text-embedding-3-large at 1536 dimensions.
+ * Default: OpenAI text-embedding-3-large at 1536 dimensions.
+ * Configuration is read from `embedding-config.ts` (env-driven).
+ *
  * Retry with exponential backoff (4s base, 120s cap, 5 retries).
  * 8000 character input truncation.
  */
 
 import OpenAI from 'openai';
+import {
+  DEFAULT_EMBEDDING_MODEL,
+  DEFAULT_EMBEDDING_DIMENSIONS,
+  getEmbeddingModel,
+  getEmbeddingDimensions,
+  getEmbeddingBaseUrl,
+  getEmbeddingApiKey,
+} from './embedding-config.ts';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
@@ -21,9 +29,24 @@ let client: OpenAI | null = null;
 
 function getClient(): OpenAI {
   if (!client) {
-    client = new OpenAI();
+    const apiKey = getEmbeddingApiKey();
+    const baseURL = getEmbeddingBaseUrl();
+    client = new OpenAI({
+      ...(apiKey ? { apiKey } : {}),
+      ...(baseURL ? { baseURL } : {}),
+    });
   }
   return client;
+}
+
+/**
+ * Reset the cached OpenAI client. Tests use this when they re-stub env vars
+ * mid-suite; production code never needs to call it.
+ *
+ * @internal
+ */
+export function resetEmbeddingClient(): void {
+  client = null;
 }
 
 export async function embed(text: string): Promise<Float32Array> {
@@ -60,12 +83,14 @@ export async function embedBatch(
 }
 
 async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
+  const model = getEmbeddingModel();
+  const dimensions = getEmbeddingDimensions();
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
       const response = await getClient().embeddings.create({
-        model: MODEL,
+        model,
         input: texts,
-        dimensions: DIMENSIONS,
+        dimensions,
       });
 
       // Sort by index to maintain order
@@ -104,7 +129,22 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
+/**
+ * Backward-compat exports. Module-load constants are kept around because
+ * other call sites import them directly; they reflect the env at first import.
+ * Prefer the function form for code that may run after env mutation (tests).
+ */
+export const EMBEDDING_MODEL = getEmbeddingModel();
+export const EMBEDDING_DIMENSIONS = getEmbeddingDimensions();
+
+// Re-export config helpers so callers that already import from `embedding.ts`
+// keep working. New code should import from `embedding-config.ts` directly.
+export {
+  getEmbeddingModel,
+  getEmbeddingDimensions,
+  DEFAULT_EMBEDDING_MODEL,
+  DEFAULT_EMBEDDING_DIMENSIONS,
+};
 
 /**
  * v0.20.0 Cathedral II Layer 8 (D1): USD cost per 1k tokens for
@@ -115,6 +155,10 @@ export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
  * Value: $0.00013 / 1k tokens as of 2026. Update when OpenAI changes
  * pricing. Single source of truth — every cost-preview surface reads
  * this constant, so a pricing change is a one-line edit.
+ *
+ * Only meaningful when the configured model is OpenAI's; for self-hosted
+ * embedders the cost is zero by definition. Callers can branch on
+ * `getEmbeddingModel()` if they need a strict zero for non-OpenAI runs.
  */
 export const EMBEDDING_COST_PER_1K_TOKENS = 0.00013;
 

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -1,5 +1,6 @@
 import type { BrainEngine } from './engine.ts';
 import { slugifyPath } from './sync.ts';
+import { getEmbeddingDimensions, getEmbeddingModel } from './embedding-config.ts';
 
 /**
  * Schema migrations — run automatically on initSchema().
@@ -1064,6 +1065,76 @@ export const MIGRATIONS: Migration[] = [
       pglite: `-- PGLite: no-op. RLS check runs only against Postgres E2E.`,
     },
     sql: '',
+  },
+  {
+    version: 30,
+    name: 'dynamic_embedding_dimensions',
+    // Re-type `content_chunks.embedding` to match the configured dimension
+    // (GBRAIN_EMBEDDING_DIMENSIONS env var, default 1536). Idempotent: a no-op
+    // when the stored config dim already matches the runtime config.
+    //
+    // When the dim changes, all existing embeddings are dropped (no math
+    // exists to convert across dimensions) and the user must run
+    // `gbrain embed --stale` to repopulate.
+    //
+    // Both engines use HNSW for the embedding index (schema.sql:116,
+    // pglite-schema.ts:92) so the recreate clause is identical.
+    sql: '',
+    handler: async (engine) => {
+      const targetDim = getEmbeddingDimensions();
+      const targetModel = getEmbeddingModel();
+
+      // Read current dim from the config table. Default to 1536 (legacy
+      // baseline) if the row is missing — this can happen on very old brains
+      // that pre-date the seeded `embedding_dimensions` row.
+      const dimRows = await engine.executeRaw<{ value: string }>(
+        `SELECT value FROM config WHERE key = 'embedding_dimensions'`,
+      );
+      const currentDim = dimRows.length > 0 ? parseInt(dimRows[0].value, 10) : 1536;
+
+      if (currentDim === targetDim) {
+        // Sync the model name in case the user changed it without changing dim.
+        await engine.executeRaw(
+          `INSERT INTO config (key, value) VALUES ('embedding_model', $1)
+           ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+          [targetModel],
+        );
+        return;
+      }
+
+      console.log(
+        `  v30: re-typing content_chunks.embedding from vector(${currentDim}) to vector(${targetDim})`,
+      );
+      console.log(
+        `  All existing embeddings will be dropped. Run \`gbrain embed --stale\` to repopulate.`,
+      );
+
+      await engine.executeRaw(`DROP INDEX IF EXISTS idx_chunks_embedding`);
+      // ALTER COLUMN ... USING NULL is the only safe path: we can't math
+      // a 1536-vector into a 1024-vector. Embeddings get nuked, embedded_at
+      // is reset so `gbrain embed --stale` picks them up.
+      await engine.executeRaw(
+        `ALTER TABLE content_chunks ALTER COLUMN embedding TYPE vector(${targetDim}) USING NULL`,
+      );
+      await engine.executeRaw(
+        `UPDATE content_chunks SET embedded_at = NULL WHERE embedded_at IS NOT NULL`,
+      );
+      await engine.executeRaw(
+        `CREATE INDEX IF NOT EXISTS idx_chunks_embedding
+           ON content_chunks USING hnsw (embedding vector_cosine_ops)`,
+      );
+
+      await engine.executeRaw(
+        `INSERT INTO config (key, value) VALUES ('embedding_dimensions', $1)
+         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+        [String(targetDim)],
+      );
+      await engine.executeRaw(
+        `INSERT INTO config (key, value) VALUES ('embedding_model', $1)
+         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+        [targetModel],
+      );
+    },
   },
 ];
 

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -20,6 +20,7 @@ import type {
   EngineConfig,
 } from './types.ts';
 import { validateSlug, contentHash, rowToPage, rowToChunk, rowToSearchResult } from './utils.ts';
+import { getEmbeddingModel } from './embedding-config.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
 import { buildSourceFactorCase, buildHardExcludeClause } from './search/sql-ranking.ts';
 
@@ -474,7 +475,7 @@ export class PGLiteEngine implements BrainEngine {
         rowParts.push(`($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}::vector, $${paramIdx++}, $${paramIdx++}, now(), $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}::text[], $${paramIdx++}, $${paramIdx++})`);
         params.push(
           pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source,
-          embeddingStr, chunk.model || 'text-embedding-3-large', chunk.token_count || null,
+          embeddingStr, chunk.model || getEmbeddingModel(), chunk.token_count || null,
           chunk.language || null, chunk.symbol_name || null, chunk.symbol_type || null,
           chunk.start_line ?? null, chunk.end_line ?? null,
           parentPath, chunk.doc_comment || null, chunk.symbol_name_qualified || null,
@@ -483,7 +484,7 @@ export class PGLiteEngine implements BrainEngine {
         rowParts.push(`($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, NULL, $${paramIdx++}, $${paramIdx++}, NULL, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}::text[], $${paramIdx++}, $${paramIdx++})`);
         params.push(
           pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source,
-          chunk.model || 'text-embedding-3-large', chunk.token_count || null,
+          chunk.model || getEmbeddingModel(), chunk.token_count || null,
           chunk.language || null, chunk.symbol_name || null, chunk.symbol_type || null,
           chunk.start_line ?? null, chunk.end_line ?? null,
           parentPath, chunk.doc_comment || null, chunk.symbol_name_qualified || null,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -18,6 +18,7 @@ import type {
 import { GBrainError } from './types.ts';
 import * as db from './db.ts';
 import { validateSlug, contentHash, rowToPage, rowToChunk, rowToSearchResult, parseEmbedding, tryParseEmbedding } from './utils.ts';
+import { getEmbeddingModel } from './embedding-config.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
 import { buildSourceFactorCase, buildHardExcludeClause } from './search/sql-ranking.ts';
 
@@ -578,7 +579,7 @@ export class PostgresEngine implements BrainEngine {
         rows.push(`($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}::vector, $${paramIdx++}, $${paramIdx++}, now(), $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}::text[], $${paramIdx++}, $${paramIdx++})`);
         params.push(
           pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source,
-          embeddingStr, chunk.model || 'text-embedding-3-large', chunk.token_count || null,
+          embeddingStr, chunk.model || getEmbeddingModel(), chunk.token_count || null,
           chunk.language || null, chunk.symbol_name || null, chunk.symbol_type || null,
           chunk.start_line ?? null, chunk.end_line ?? null,
           parentPath, chunk.doc_comment || null, chunk.symbol_name_qualified || null,
@@ -587,7 +588,7 @@ export class PostgresEngine implements BrainEngine {
         rows.push(`($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, NULL, $${paramIdx++}, $${paramIdx++}, NULL, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}::text[], $${paramIdx++}, $${paramIdx++})`);
         params.push(
           pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source,
-          chunk.model || 'text-embedding-3-large', chunk.token_count || null,
+          chunk.model || getEmbeddingModel(), chunk.token_count || null,
           chunk.language || null, chunk.symbol_name || null, chunk.symbol_type || null,
           chunk.start_line ?? null, chunk.end_line ?? null,
           parentPath, chunk.doc_comment || null, chunk.symbol_name_qualified || null,

--- a/test/embedding-config.test.ts
+++ b/test/embedding-config.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the configurable embedding helpers.
+ *
+ * The functions read `process.env` on each call, so the tests just
+ * mutate env vars and reset between cases — no dynamic re-import needed.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { getEmbeddingModel, getEmbeddingDimensions } from '../src/core/embedding-config.ts';
+
+const ENV_KEYS = [
+  'GBRAIN_EMBEDDING_MODEL',
+  'GBRAIN_EMBEDDING_DIMENSIONS',
+  'GBRAIN_EMBEDDING_BASE_URL',
+  'GBRAIN_EMBEDDING_API_KEY',
+] as const;
+
+describe('embedding config — getEmbeddingModel', () => {
+  const saved = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) saved.set(k, process.env[k]);
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const [k, v] of saved) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  test('defaults to text-embedding-3-large when env unset', () => {
+    expect(getEmbeddingModel()).toBe('text-embedding-3-large');
+  });
+
+  test('returns env value when GBRAIN_EMBEDDING_MODEL is set', () => {
+    process.env.GBRAIN_EMBEDDING_MODEL = 'bge-m3';
+    expect(getEmbeddingModel()).toBe('bge-m3');
+  });
+
+  test('falls back to default when env is empty string', () => {
+    process.env.GBRAIN_EMBEDDING_MODEL = '';
+    expect(getEmbeddingModel()).toBe('text-embedding-3-large');
+  });
+
+  test('falls back to default when env is whitespace-only', () => {
+    process.env.GBRAIN_EMBEDDING_MODEL = '   ';
+    expect(getEmbeddingModel()).toBe('text-embedding-3-large');
+  });
+});
+
+describe('embedding config — getEmbeddingDimensions', () => {
+  const saved = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) saved.set(k, process.env[k]);
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const [k, v] of saved) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  test('defaults to 1536 when env unset', () => {
+    expect(getEmbeddingDimensions()).toBe(1536);
+  });
+
+  test('returns 1024 when GBRAIN_EMBEDDING_DIMENSIONS=1024 (bge-m3)', () => {
+    process.env.GBRAIN_EMBEDDING_DIMENSIONS = '1024';
+    expect(getEmbeddingDimensions()).toBe(1024);
+  });
+
+  test('returns 768 for typical small embedders (nomic-embed-text)', () => {
+    process.env.GBRAIN_EMBEDDING_DIMENSIONS = '768';
+    expect(getEmbeddingDimensions()).toBe(768);
+  });
+
+  test('throws on non-numeric value', () => {
+    process.env.GBRAIN_EMBEDDING_DIMENSIONS = 'big';
+    expect(() => getEmbeddingDimensions()).toThrow(/must be a positive integer/);
+  });
+
+  test('throws on zero', () => {
+    process.env.GBRAIN_EMBEDDING_DIMENSIONS = '0';
+    expect(() => getEmbeddingDimensions()).toThrow(/must be a positive integer/);
+  });
+
+  test('throws on negative number', () => {
+    process.env.GBRAIN_EMBEDDING_DIMENSIONS = '-5';
+    expect(() => getEmbeddingDimensions()).toThrow(/must be a positive integer/);
+  });
+});

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -80,6 +80,35 @@ describe('migrate v20 — sources_table_additive', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────
+// v30 — dynamic_embedding_dimensions
+// ─────────────────────────────────────────────────────────────────
+describe('migrate v30 — dynamic_embedding_dimensions', () => {
+  const v30 = MIGRATIONS.find(m => m.version === 30);
+
+  test('v30 exists with the expected name', () => {
+    expect(v30).toBeDefined();
+    expect(v30!.name).toBe('dynamic_embedding_dimensions');
+  });
+
+  test('v30 is handler-only (no SQL string)', () => {
+    expect(v30!.sql).toBe('');
+    expect(typeof v30!.handler).toBe('function');
+  });
+
+  test('LATEST_VERSION includes v30', () => {
+    expect(LATEST_VERSION).toBeGreaterThanOrEqual(30);
+  });
+
+  test('v30 is the latest by default', () => {
+    // Defensive: v30 should remain the tail of the chain unless a later
+    // migration explicitly supersedes it. If a v31 lands, this assertion
+    // tells the contributor to think about ordering with the dim re-type.
+    const versions = MIGRATIONS.map(m => m.version);
+    expect(Math.max(...versions)).toBe(LATEST_VERSION);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────
 // v0.18.0 — v17 pages_source_id_composite_unique (Step 2, Lane B)
 // ─────────────────────────────────────────────────────────────────
 describe('migrate v21 — pages_source_id_composite_unique', () => {


### PR DESCRIPTION
## Summary

- Add env-driven config helpers in a new `src/core/embedding-config.ts`:
  `GBRAIN_EMBEDDING_MODEL`, `GBRAIN_EMBEDDING_DIMENSIONS`, `GBRAIN_EMBEDDING_BASE_URL`, `GBRAIN_EMBEDDING_API_KEY`. Defaults preserve `text-embedding-3-large` / 1536 dim, so brains that don't set anything stay byte-identical.
- Migration v30 `dynamic_embedding_dimensions` (handler-based) detects mismatch between the stored `config.embedding_dimensions` row and the runtime config: drops the HNSW index, ALTERs `content_chunks.embedding` to the new `vector(N)` type, resets `embedded_at`, recreates the index, and syncs both config rows. Idempotent — no-op when dims already match.
- Replace hardcoded `'text-embedding-3-large'` defaults in `postgres-engine.ts` and `pglite-engine.ts` upsert paths with `getEmbeddingModel()` so chunks land with the correct model tag.
- The OpenAI embed client now respects `GBRAIN_EMBEDDING_BASE_URL` / `GBRAIN_EMBEDDING_API_KEY`, enabling Ollama / vLLM / LM Studio / Azure-style endpoints.
- Schema baseline (`schema.sql`, `schema-embedded.ts`, `pglite-schema.ts`) stays at `vector(1536)`. Existing brains migrate via v30 only when their configured dim differs.

## Example — running on Ollama bge-m3 (1024 dim)

```bash
export GBRAIN_EMBEDDING_BASE_URL=http://localhost:11434/v1
export GBRAIN_EMBEDDING_API_KEY=ollama
export GBRAIN_EMBEDDING_MODEL=bge-m3
export GBRAIN_EMBEDDING_DIMENSIONS=1024

gbrain apply-migrations --yes   # v30 re-types the column
gbrain embed --stale            # repopulate
```

## Why a separate `embedding-config.ts` module

`test/embed.test.ts` aggressively mocks the whole `embedding.ts` module. If the config helpers lived there, the mock would shadow them for every co-resident test. Putting them in a peer module that no one mocks keeps the engine code, the migration, and the unit tests all reading the real env-driven values — and lets `embed.test.ts` stay focused on `embedBatch` concurrency.

## Why migration-only (not parameterized baseline)

Baseline `vector(1536)` is left as-is so existing brains start byte-identical and the schema build pipeline (`scripts/build-schema.sh`, `schema-embedded.ts`) needs no refactor. v30 handles dim drift on demand, which is the only case where it actually matters. If a future change wants to parameterize the baseline, that's a separate, heavier PR — happy to follow up if preferred.

## Why the dim change drops embeddings

There is no mathematically valid way to map a 1536-dim vector to 1024 dim or vice versa. v30 sets `embedded_at = NULL` so `gbrain embed --stale` picks up every chunk; the user runs that once and the brain is back in shape.

## Test Plan

```
bun run typecheck                              # passes
bun test test/embedding-config.test.ts         # 10 tests — env-var contract
bun test test/migrate.test.ts                  # extended with v30 registration
bun test test/embed.test.ts                    # mock simplified, still 11 tests
bun test test/apply-migrations.test.ts test/init-migrate-only.test.ts
bash scripts/check-jsonb-pattern.sh
bash scripts/check-progress-to-stdout.sh
bash scripts/check-wasm-embedded.sh
```

E2E (requires Postgres+pgvector):
- The new migration runs as v30 in `runMigrations()` — covered by `test/e2e/mechanical.test.ts`'s schema bring-up. A targeted test for dim re-type would be a useful follow-up but needs DB lifecycle plumbing I didn't want to slip in here.

## Relationship to #450

#450 introduces a richer provider abstraction (`openai`, `openai-compatible`, `copilot`) that subsumes the env vars in this PR. The two are complementary:

- This PR closes the schema gap (`vector(1536)` was the real blocker).
- #450 closes the client gap (multiple providers behind one factory).

If #450 lands first, the embed client in `embedding.ts` can be swapped for the provider factory and the env-var names already match (`GBRAIN_EMBEDDING_*`); the schema/migration layer here remains untouched. If this lands first, #450 keeps its provider factory and just imports the same helpers from `embedding-config.ts`.

Closes #133.