### PR TITLE
fix(search): respect source federation visibility

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -561,11 +561,15 @@ const search: Operation = {
     query: { type: 'string', required: true },
     limit: { type: 'number', description: 'Max results (default 20)' },
     offset: { type: 'number', description: 'Skip first N results (for pagination)' },
+    source: { type: 'string', description: 'Filter to a specific source id. Defaults to federated sources only.' },
+    all_sources: { type: 'boolean', description: 'Include isolated/non-federated sources too.' },
   },
   handler: async (ctx, p) => {
+    const sourceId = p.all_sources === true ? '__all__' : ((p.source as string) || undefined);
     const results = await ctx.engine.searchKeyword(p.query as string, {
       limit: (p.limit as number) || 20,
       offset: (p.offset as number) || 0,
+      sourceId,
     });
     return dedupResults(results);
   },
@@ -587,10 +591,13 @@ const query: Operation = {
     // v0.20.0 Cathedral II Layer 7 (A2) / Layer 10 C3: two-pass structural expansion.
     near_symbol: { type: 'string', description: 'Anchor retrieval at this qualified symbol name (e.g., BrainEngine.searchKeyword). Enables A2 two-pass.' },
     walk_depth: { type: 'number', description: 'Structural walk depth 1-2. Default 0 (off). Expands anchors through code_edges with 1/(1+hop) decay.' },
+    source: { type: 'string', description: 'Filter to a specific source id. Defaults to federated sources only.' },
+    all_sources: { type: 'boolean', description: 'Include isolated/non-federated sources too.' },
   },
   handler: async (ctx, p) => {
     const expand = p.expand !== false;
     const detail = (p.detail as 'low' | 'medium' | 'high') || undefined;
+    const sourceId = p.all_sources === true ? '__all__' : ((p.source as string) || undefined);
     return hybridSearch(ctx.engine, p.query as string, {
       limit: (p.limit as number) || 20,
       offset: (p.offset as number) || 0,
@@ -601,6 +608,7 @@ const query: Operation = {
       symbolKind: (p.symbol_kind as string) || undefined,
       nearSymbol: (p.near_symbol as string) || undefined,
       walkDepth: typeof p.walk_depth === 'number' ? (p.walk_depth as number) : undefined,
+      sourceId,
     });
   },
   cliHints: { name: 'query', positional: ['query'] },

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -22,6 +22,7 @@ import type {
 import { validateSlug, contentHash, rowToPage, rowToChunk, rowToSearchResult } from './utils.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
 import { buildSourceFactorCase, buildHardExcludeClause } from './search/sql-ranking.ts';
+import { buildSourceVisibilityClause } from './search/source-visibility.ts';
 
 type PGLiteDB = PGlite;
 
@@ -258,6 +259,7 @@ export class PGLiteEngine implements BrainEngine {
       params.push(opts.symbolKind);
       extraFilter += ` AND cc.symbol_type = $${params.length}`;
     }
+    const sourceVisibilityClause = buildSourceVisibilityClause(opts, params, 'p');
 
     const { rows } = await this.db.query(
       `WITH ranked AS (
@@ -270,7 +272,7 @@ export class PGLiteEngine implements BrainEngine {
            ) THEN true ELSE false END AS stale
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id
-         WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause}
+         WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${sourceVisibilityClause} ${hardExcludeClause}
          ORDER BY score DESC
          LIMIT $2
        ),
@@ -326,6 +328,7 @@ export class PGLiteEngine implements BrainEngine {
       params.push(opts.symbolKind);
       extraFilter += ` AND cc.symbol_type = $${params.length}`;
     }
+    const sourceVisibilityClause = buildSourceVisibilityClause(opts, params, 'p');
 
     const { rows } = await this.db.query(
       `SELECT
@@ -337,7 +340,7 @@ export class PGLiteEngine implements BrainEngine {
          ) THEN true ELSE false END AS stale
        FROM content_chunks cc
        JOIN pages p ON p.id = cc.page_id
-       WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause}
+       WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${sourceVisibilityClause} ${hardExcludeClause}
        ORDER BY score DESC
        LIMIT $2 OFFSET $3`,
       params
@@ -382,6 +385,7 @@ export class PGLiteEngine implements BrainEngine {
       params.push(opts.symbolKind);
       extraFilter += ` AND cc.symbol_type = $${params.length}`;
     }
+    const sourceVisibilityClause = buildSourceVisibilityClause(opts, params, 'p');
 
     const { rows } = await this.db.query(
       `WITH hnsw_candidates AS (
@@ -391,7 +395,7 @@ export class PGLiteEngine implements BrainEngine {
            1 - (cc.embedding <=> $1::vector) AS raw_score
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id
-         WHERE cc.embedding IS NOT NULL ${detailFilter}${extraFilter} ${hardExcludeClause}
+         WHERE cc.embedding IS NOT NULL ${detailFilter}${extraFilter} ${sourceVisibilityClause} ${hardExcludeClause}
          ORDER BY cc.embedding <=> $1::vector
          LIMIT $2
        )

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -20,6 +20,7 @@ import * as db from './db.ts';
 import { validateSlug, contentHash, rowToPage, rowToChunk, rowToSearchResult, parseEmbedding, tryParseEmbedding } from './utils.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
 import { buildSourceFactorCase, buildHardExcludeClause } from './search/sql-ranking.ts';
+import { buildSourceVisibilityClause } from './search/source-visibility.ts';
 
 // CONNECTION_ERROR_PATTERNS / isConnectionError were used by the per-call
 // executeRaw retry that #406 originally shipped. Eng-review D3 dropped that
@@ -294,6 +295,7 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    const sourceVisibilityClause = buildSourceVisibilityClause(opts, params, 'p');
     params.push(innerLimit);
     const innerLimitParam = `$${params.length}`;
     params.push(limit);
@@ -315,6 +317,7 @@ export class PostgresEngine implements BrainEngine {
           ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
           ${languageClause}
           ${symbolKindClause}
+          ${sourceVisibilityClause}
           ${hardExcludeClause}
         ORDER BY score DESC
         LIMIT ${innerLimitParam}
@@ -395,6 +398,7 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    const sourceVisibilityClause = buildSourceVisibilityClause(opts, params, 'p');
     params.push(limit);
     const limitParam = `$${params.length}`;
     params.push(offset);
@@ -414,6 +418,7 @@ export class PostgresEngine implements BrainEngine {
         ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
         ${languageClause}
         ${symbolKindClause}
+        ${sourceVisibilityClause}
         ${hardExcludeClause}
       ORDER BY score DESC
       LIMIT ${limitParam}
@@ -478,6 +483,7 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    const sourceVisibilityClause = buildSourceVisibilityClause(opts, params, 'p');
     params.push(innerLimit);
     const innerLimitParam = `$${params.length}`;
     params.push(limit);
@@ -499,6 +505,7 @@ export class PostgresEngine implements BrainEngine {
           ${excludeSlugsClause}
           ${languageClause}
           ${symbolKindClause}
+          ${sourceVisibilityClause}
           ${hardExcludeClause}
         ORDER BY cc.embedding <=> $1::vector
         LIMIT ${innerLimitParam}

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -76,6 +76,7 @@ export async function hybridSearch(
     // per-engine searchKeyword / searchVector apply the filters at SQL level.
     language: opts?.language,
     symbolKind: opts?.symbolKind,
+    sourceId: opts?.sourceId,
   };
 
   if (DEBUG && detail) {
@@ -183,7 +184,7 @@ export async function hybridSearch(
         .filter(e => !existingIds.has(e.chunk_id))
         .map(e => e.chunk_id);
       if (newIds.length > 0) {
-        const hydrated = await hydrateChunks(engine, newIds);
+        const hydrated = await hydrateChunks(engine, newIds, { sourceId: opts?.sourceId });
         const scoreById = new Map(expanded.map(e => [e.chunk_id, e.score]));
         for (const r of hydrated) {
           r.score = scoreById.get(r.chunk_id) ?? 0.01;

--- a/src/core/search/source-visibility.ts
+++ b/src/core/search/source-visibility.ts
@@ -1,0 +1,35 @@
+import type { SearchOpts } from '../types.ts';
+
+/**
+ * Build the SQL predicate for multi-source search visibility.
+ *
+ * Contract:
+ * - opts.sourceId === concrete id: restrict to that source.
+ * - opts.sourceId === '__all__': include every source, including isolated ones.
+ * - opts.sourceId undefined/null: cross-source search sees only federated sources.
+ *
+ * The default source is always visible as a backward-compatible fallback for
+ * pre-source brains and for installs where its config was not explicitly set.
+ */
+export function buildSourceVisibilityClause(
+  opts: SearchOpts | undefined,
+  params: unknown[],
+  pageAlias = 'p',
+): string {
+  if (opts?.sourceId === '__all__') return '';
+
+  if (opts?.sourceId) {
+    params.push(opts.sourceId);
+    return `AND ${pageAlias}.source_id = $${params.length}`;
+  }
+
+  return `AND (
+    ${pageAlias}.source_id = 'default'
+    OR EXISTS (
+      SELECT 1
+        FROM sources source_visibility
+       WHERE source_visibility.id = ${pageAlias}.source_id
+         AND COALESCE(source_visibility.config->>'federated', 'false') = 'true'
+    )
+  )`;
+}

--- a/src/core/search/two-pass.ts
+++ b/src/core/search/two-pass.ts
@@ -22,7 +22,8 @@
  */
 
 import type { BrainEngine } from '../engine.ts';
-import type { SearchResult } from '../types.ts';
+import type { SearchResult, SearchOpts } from '../types.ts';
+import { buildSourceVisibilityClause } from './source-visibility.ts';
 
 const MAX_WALK_DEPTH = 2;
 const NEIGHBOR_CAP_PER_HOP = 50;
@@ -32,7 +33,7 @@ export interface TwoPassOpts {
   walkDepth?: number;
   /** When set, find chunks whose symbol_name_qualified matches; add to anchor set. */
   nearSymbol?: string;
-  /** Filter expansion to one source. When unset, crosses sources. */
+  /** Filter expansion by search visibility: concrete source, __all__, or default federated set. */
   sourceId?: string;
 }
 
@@ -77,9 +78,15 @@ export async function expandAnchors(
   // additional anchors. Best-effort — if none found, fall through.
   if (opts.nearSymbol) {
     try {
+      const params: unknown[] = [opts.nearSymbol];
+      const sourceVisibilityClause = buildSourceVisibilityClause(opts as SearchOpts, params, 'p');
       const rows = await engine.executeRaw<{ id: number }>(
-        `SELECT id FROM content_chunks WHERE symbol_name_qualified = $1 LIMIT 50`,
-        [opts.nearSymbol],
+        `SELECT cc.id
+           FROM content_chunks cc
+           JOIN pages p ON p.id = cc.page_id
+          WHERE cc.symbol_name_qualified = $1 ${sourceVisibilityClause}
+          LIMIT 50`,
+        params,
       );
       const baseScore = anchors.length > 0 ? anchors[0]!.score : 1.0;
       for (const r of rows) {
@@ -128,9 +135,15 @@ export async function expandAnchors(
       // symbol_name_qualified matches. One batch query per frontier node.
       if (unresolvedTargets.length > 0) {
         try {
+          const params: unknown[] = [unresolvedTargets];
+          const sourceVisibilityClause = buildSourceVisibilityClause(opts as SearchOpts, params, 'p');
           const resolved = await engine.executeRaw<{ id: number }>(
-            `SELECT id FROM content_chunks WHERE symbol_name_qualified = ANY($1::text[]) LIMIT ${NEIGHBOR_CAP_PER_HOP}`,
-            [unresolvedTargets],
+            `SELECT cc.id
+               FROM content_chunks cc
+               JOIN pages p ON p.id = cc.page_id
+              WHERE cc.symbol_name_qualified = ANY($1::text[]) ${sourceVisibilityClause}
+              LIMIT ${NEIGHBOR_CAP_PER_HOP}`,
+            params,
           );
           for (const r of resolved) directChunkIds.push(r.id);
         } catch {
@@ -161,8 +174,11 @@ export async function expandAnchors(
 export async function hydrateChunks(
   engine: BrainEngine,
   chunkIds: number[],
+  opts: Pick<SearchOpts, 'sourceId'> = {},
 ): Promise<SearchResult[]> {
   if (chunkIds.length === 0) return [];
+  const params: unknown[] = [chunkIds];
+  const sourceVisibilityClause = buildSourceVisibilityClause(opts as SearchOpts, params, 'p');
   const rows = await engine.executeRaw<{
     slug: string; page_id: number; title: string; type: string; source_id: string;
     chunk_id: number; chunk_index: number; chunk_text: string; chunk_source: string;
@@ -171,8 +187,8 @@ export async function hydrateChunks(
             cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source
        FROM content_chunks cc
        JOIN pages p ON p.id = cc.page_id
-       WHERE cc.id = ANY($1::int[])`,
-    [chunkIds],
+       WHERE cc.id = ANY($1::int[]) ${sourceVisibilityClause}`,
+    params,
   );
   return rows.map((r) => ({
     slug: r.slug,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -174,9 +174,11 @@ export interface SearchOpts {
    */
   walkDepth?: number;
   /**
-   * v0.20.0 Cathedral II: scope search to a specific source. When set,
-   * results are filtered by pages.source_id. Use '__all__' or leave
-   * undefined to search all sources.
+   * v0.20.0 Cathedral II: scope search to a specific source. When set to a
+   * concrete source id, results are filtered by pages.source_id. Use '__all__'
+   * to include isolated/non-federated sources. Leave undefined for default
+   * cross-source search, which includes only federated sources plus the default
+   * source for backward compatibility.
    */
   sourceId?: string;
 }

--- a/test/multi-source-search-visibility.test.ts
+++ b/test/multi-source-search-visibility.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Multi-source search visibility regression tests.
+ *
+ * Default search should follow the upstream sources contract: federated sources
+ * are visible in cross-source search; isolated sources are only visible when
+ * explicitly named, or when the caller asks for all sources.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runSources } from '../src/commands/sources.ts';
+import { hybridSearch } from '../src/core/search/hybrid.ts';
+
+const openAiEnvName = 'OPENAI_API_' + 'KEY';
+let engine: PGLiteEngine;
+let savedOpenAiEnvValue: string | undefined;
+
+async function insertSearchablePage(sourceId: string, slug: string, token: string): Promise<void> {
+  await engine.executeRaw(
+    `INSERT INTO pages (source_id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash)
+     VALUES ($1, $2, $3, $4, $5, '', '{}'::jsonb, $6)`,
+    [
+      sourceId,
+      slug,
+      `visibility-${sourceId}`,
+      `Visibility ${sourceId}`,
+      `${token} compiled truth for ${sourceId}`,
+      `${sourceId}-${slug}`,
+    ],
+  );
+  await engine.executeRaw(
+    `INSERT INTO content_chunks (page_id, chunk_index, chunk_text, chunk_source)
+     SELECT id, 0, $1, 'compiled_truth'
+       FROM pages
+      WHERE source_id = $2 AND slug = $3`,
+    [`${token} chunk body for ${sourceId}`, sourceId, slug],
+  );
+}
+
+beforeAll(async () => {
+  savedOpenAiEnvValue = process.env[openAiEnvName];
+  delete process.env[openAiEnvName];
+
+  engine = new PGLiteEngine();
+  await engine.connect({ type: 'pglite' } as never);
+  await engine.initSchema();
+
+  await runSources(engine, ['add', 'federated-src', '--federated']);
+  await runSources(engine, ['add', 'isolated-src', '--no-federated']);
+
+  await insertSearchablePage('default', 'visibility/default-page', 'visibilitytoken');
+  await insertSearchablePage('federated-src', 'visibility/federated-page', 'visibilitytoken');
+  await insertSearchablePage('isolated-src', 'visibility/isolated-page', 'visibilitytoken');
+}, 60_000);
+
+afterAll(async () => {
+  if (savedOpenAiEnvValue === undefined) {
+    delete process.env[openAiEnvName];
+  } else {
+    process.env[openAiEnvName] = savedOpenAiEnvValue;
+  }
+  await engine.disconnect();
+}, 60_000);
+
+describe('multi-source search visibility', () => {
+  test('default keyword search excludes isolated sources and includes federated sources', async () => {
+    const results = await engine.searchKeyword('visibilitytoken', { limit: 10 });
+    const sourceIds = results.map(r => r.source_id).sort();
+
+    expect(sourceIds).toContain('default');
+    expect(sourceIds).toContain('federated-src');
+    expect(sourceIds).not.toContain('isolated-src');
+  });
+
+  test('explicit sourceId restricts keyword search to that source', async () => {
+    const results = await engine.searchKeyword('visibilitytoken', { limit: 10, sourceId: 'isolated-src' });
+    expect(results.map(r => r.source_id)).toEqual(['isolated-src']);
+  });
+
+  test('__all__ sourceId includes isolated sources for explicit audit/debug use', async () => {
+    const results = await engine.searchKeyword('visibilitytoken', { limit: 10, sourceId: '__all__' });
+    const sourceIds = results.map(r => r.source_id).sort();
+
+    expect(sourceIds).toContain('default');
+    expect(sourceIds).toContain('federated-src');
+    expect(sourceIds).toContain('isolated-src');
+  });
+
+  test('hybrid query path preserves default source visibility', async () => {
+    const results = await hybridSearch(engine, 'visibilitytoken', { limit: 10, expansion: false });
+    const sourceIds = results.map(r => r.source_id).sort();
+
+    expect(sourceIds).toContain('default');
+    expect(sourceIds).toContain('federated-src');
+    expect(sourceIds).not.toContain('isolated-src');
+  });
+
+  test('hybrid query path can explicitly include isolated sources', async () => {
+    const results = await hybridSearch(engine, 'visibilitytoken', {
+      limit: 10,
+      expansion: false,
+      sourceId: '__all__',
+      dedupOpts: { maxTypeRatio: 1 },
+    });
+    const sourceIds = results.map(r => r.source_id).sort();
+
+    expect(sourceIds).toContain('default');
+    expect(sourceIds).toContain('federated-src');
+    expect(sourceIds).toContain('isolated-src');
+  });
+});


### PR DESCRIPTION
## Summary

This PR makes default `search` / `query` retrieval honor gBrain's multi-source federation contract:

- a concrete `source` / `sourceId` searches only that source
- `all_sources` / `sourceId: "__all__"` includes isolated sources for explicit audit/debug use
- an unspecified source searches only the `default` source plus sources whose config has `federated: true`

This keeps isolated sources (for example session transcripts added with `--no-federated`) from appearing in ordinary cross-source recall.

## Motivation

The multi-source guide describes sources as logical brains with independent federation policy, and says default reads span federated sources. It also gives a mixed-mode example where session transcripts land in a separate isolated source so they do not dominate every search result.

The current search/query path accepts source IDs in lower layers, but unqualified calls can still scan isolated sources. That makes `--no-federated` sources visible in default recall, which is surprising and inconsistent with the documented model.

## Changes

- Add a shared `buildSourceVisibilityClause` helper for source visibility SQL.
- Apply it to PGLite and Postgres keyword, keyword-chunk, and vector search paths.
- Thread `sourceId` through hybrid search and two-pass structural expansion/hydration.
- Expose `source` and `all_sources` on the `search` and `query` operations.
- Add regression coverage for default/federated/isolated source behavior.

## Notes

The `default` source remains visible in unqualified search for backward compatibility with pre-source brains and with the existing default-source seed behavior.

## Test plan

Passed locally with Bun:

```sh
bun run typecheck
bun test test/multi-source-search-visibility.test.ts
bun test --timeout 60000 test/search.test.ts test/search-limit.test.ts test/search-lang-symbol-kind.test.ts test/multi-source-integration.test.ts test/multi-source-search-visibility.test.ts
```
