### PR TITLE
v0.42.59.0 fix(files): normalize bigint sizes before JSON serialization

### DIFF
--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -116,8 +116,7 @@ async function listFiles(engine: BrainEngine, slug?: string) {
 
   console.log(`${rows.length} file(s):`);
   for (const row of rows) {
-    const sizeBytes = row.size_bytes as number | null;
-    const size = sizeBytes ? `${Math.round(sizeBytes / 1024)}KB` : '?';
+    const size = row.size_bytes ? `${Math.round(Number(row.size_bytes) / 1024)}KB` : '?';
     console.log(`  ${row.page_slug || '(unlinked)'} / ${row.filename}  [${size}, ${row.mime_type || '?'}]`);
   }
 }

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2686,10 +2686,16 @@ const file_list: Operation = {
   handler: async (_ctx, p) => {
     const sql = db.getConnection();
     const slug = p.slug as string | undefined;
-    if (slug) {
-      return sql`SELECT id, page_slug, filename, storage_path, mime_type, size_bytes, content_hash, created_at FROM files WHERE page_slug = ${slug} ORDER BY filename LIMIT ${FILE_LIST_LIMIT}`;
-    }
-    return sql`SELECT id, page_slug, filename, storage_path, mime_type, size_bytes, content_hash, created_at FROM files ORDER BY page_slug, filename LIMIT ${FILE_LIST_LIMIT}`;
+    const rows = slug
+      ? await sql`SELECT id, page_slug, filename, storage_path, mime_type, size_bytes, content_hash, created_at FROM files WHERE page_slug = ${slug} ORDER BY filename LIMIT ${FILE_LIST_LIMIT}`
+      : await sql`SELECT id, page_slug, filename, storage_path, mime_type, size_bytes, content_hash, created_at FROM files ORDER BY page_slug, filename LIMIT ${FILE_LIST_LIMIT}`;
+    // Postgres returns size_bytes (BIGINT) as native BigInt — JSON.stringify
+    // throws on those, breaking MCP callers. PGLite returns Number already.
+    // 9 PB ceiling (2^53 bytes) is far above any plausible file size.
+    return rows.map((r: Record<string, unknown>) => ({
+      ...r,
+      size_bytes: r.size_bytes == null ? null : Number(r.size_bytes),
+    }));
   },
 };
 

--- a/test/e2e/mechanical.test.ts
+++ b/test/e2e/mechanical.test.ts
@@ -582,6 +582,11 @@ describeE2E('E2E: Files', () => {
       const files = await callOp('file_list', {}) as any[];
       expect(files.length).toBe(1);
 
+      // Regression: Postgres BIGINT(size_bytes) returned native BigInt before
+      // v0.22.5 so the MCP serializer threw and CLI listFiles div-by-1024 threw.
+      expect(typeof files[0].size_bytes).toBe('number');
+      expect(() => JSON.stringify(files)).not.toThrow();
+
       // Verify file_url returns URI format
       const url = await callOp('file_url', { storage_path: result.storage_path }) as any;
       expect(url.url).toContain('gbrain:files/');

--- a/test/files.test.ts
+++ b/test/files.test.ts
@@ -1,10 +1,12 @@
-import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll, spyOn } from 'bun:test';
 import { writeFileSync, mkdirSync, rmSync, symlinkSync, mkdtempSync } from 'fs';
 import { join, basename } from 'path';
 import { createHash } from 'crypto';
 import { extname } from 'path';
 import { tmpdir } from 'os';
 import { collectFiles } from '../src/commands/files.ts';
+import { operationsByName } from '../src/core/operations.ts';
+import * as db from '../src/core/db.ts';
 
 const TMP = join(import.meta.dir, '.tmp-files-test');
 
@@ -180,6 +182,38 @@ describe('collectFiles (production import)', () => {
       expect(files.map(f => basename(f))).not.toContain('broken.txt');
     } finally {
       rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  test('file_list normalizes BigInt size_bytes for JSON serialization', async () => {
+    // Postgres BIGINT(size_bytes) returns native BigInt under postgres.js's
+    // {bigint: postgres.BigInt} type map. Both JSON.stringify (MCP) and the
+    // CLI's `size_bytes / 1024` divide trip on it. Regression for the bug
+    // openclaw's agent surfaced in v0.22.4.
+    const fakeRows = [
+      { id: 1, page_slug: 'a', filename: 'f1', storage_path: 'a/f1',
+        mime_type: 'text/plain', size_bytes: 4096n, content_hash: 'h1',
+        created_at: '2026-04-27' },
+      { id: 2, page_slug: 'a', filename: 'f2', storage_path: 'a/f2',
+        mime_type: null, size_bytes: null, content_hash: 'h2',
+        created_at: '2026-04-27' },
+    ];
+    const fakeSql: any = (..._: unknown[]) => Promise.resolve(fakeRows);
+    const spy = spyOn(db, 'getConnection').mockReturnValue(fakeSql);
+
+    try {
+      const op = operationsByName['file_list'];
+      const ctx: any = { engine: null, config: {}, logger: { info() {}, warn() {}, error() {} }, dryRun: false, remote: true };
+      const result = await op.handler(ctx, {}) as Array<Record<string, unknown>>;
+
+      expect(result.length).toBe(2);
+      expect(typeof result[0].size_bytes).toBe('number');
+      expect(result[0].size_bytes).toBe(4096);
+      expect(result[1].size_bytes).toBeNull();
+      // The exact failure mode openclaw reported.
+      expect(() => JSON.stringify(result)).not.toThrow();
+    } finally {
+      spy.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Problem

Postgres returns `files.size_bytes` (`BIGINT`) as a native JavaScript `BigInt`. Returning that value directly from `file_list` makes JSON serialization fail, and using it in CLI arithmetic can also throw. PGLite returns a normal number, so PGLite-only coverage does not expose the bug.

## Fix

Normalize `size_bytes` to `Number` at the operation boundary and in the CLI display path. The exact-integer ceiling is far above any practical attachment size.

## Coverage

- Unit regression supplies native `BigInt` rows, preserves `null`, and proves the result is JSON-serializable.
- Mechanical Postgres E2E now asserts the wire value is a number.
- Rebuilt as one focused commit on `v0.42.59.0` / `master` (`5008b287`).

## Verification

- `bun test test/files.test.ts`: 24 passed, 0 failed
- `bun run typecheck`: passed
- `bun run verify`: passed
- Full `bun test`: passed
- Real-Postgres E2E was not rerun locally because the Docker daemon is unavailable; the E2E assertion remains in the PR for CI.
