### PR TITLE
test(e2e): make helpers idempotent under bun test 1.2.x batch beforeAll model

### DIFF
--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -63,21 +63,30 @@ export function hasDatabase(): boolean {
   return !!DATABASE_URL;
 }
 
+// Track whether the DB is already connected. bun test 1.2.x runs every
+// describe's `beforeAll` serially before any test starts, then runs every
+// `afterAll` likewise. With a global singleton engine + db connection,
+// describe N+1's setupDB() races describe N's afterAll() — the last
+// `teardownDB()` closes the connection that earlier describe tests still
+// need. Making setupDB idempotent (no disconnect/reconnect when already
+// pointed at the right URL) and teardownDB conditional fixes this without
+// requiring every test file to manage its own engine.
+let dbInitialized = false;
+
 /**
  * Connect to DB, run schema init, truncate all tables.
- * Call in beforeAll() of each test file.
+ * Idempotent — safe to call from multiple describe.beforeAll hooks.
  */
 export async function setupDB(): Promise<PostgresEngine> {
   if (!DATABASE_URL) {
     throw new Error('DATABASE_URL not set. Copy .env.testing.example to .env.testing and configure it.');
   }
 
-  // Disconnect any prior connection (clean slate)
-  await db.disconnect();
-
-  // Connect fresh
-  await db.connect({ database_url: DATABASE_URL });
-  await db.initSchema();
+  if (!dbInitialized) {
+    await db.connect({ database_url: DATABASE_URL });
+    await db.initSchema();
+    dbInitialized = true;
+  }
 
   // Truncate all data tables (preserves schema + extensions).
   // Some tables (e.g. v0.28 takes/synthesis_evidence) only exist after
@@ -98,25 +107,30 @@ export async function setupDB(): Promise<PostgresEngine> {
     ON CONFLICT (key) DO NOTHING
   `);
 
-  engine = new PostgresEngine();
-  await engine.connect({ database_url: DATABASE_URL });
+  if (!engine) {
+    engine = new PostgresEngine();
+    await engine.connect({ database_url: DATABASE_URL });
+  }
   // Apply MIGRATIONS via the engine path. db.initSchema above only runs the
   // embedded SCHEMA_SQL baseline; migrations like v31 (takes) live in the
   // MIGRATIONS array and only run when engine.initSchema() executes them.
-  // Idempotent: re-running migrations on an already-migrated DB is a no-op.
+  // Idempotent: re-running migrations on an already-migrated DB is a no-op,
+  // so safe to call on every setupDB() — TRUNCATE above wipes the migration
+  // ledger so we need this to re-run anyway.
   await engine.initSchema();
   return engine;
 }
 
 /**
- * Disconnect from DB. Call in afterAll() of each test file.
+ * No-op while the test process is alive. Real teardown happens via
+ * Bun's process exit — postgres.js closes pooled connections then.
+ *
+ * Why: bun test runs every describe's afterAll AFTER every describe's
+ * test body finishes. Closing the shared engine between describes would
+ * leave later describes unable to query (see comment on dbInitialized).
  */
 export async function teardownDB(): Promise<void> {
-  if (engine) {
-    await engine.disconnect();
-    engine = null;
-  }
-  await db.disconnect();
+  // Intentionally empty — connection closes on process exit.
 }
 
 /**


### PR DESCRIPTION
## Summary

Partial fix for #473. Drops `bun test test/e2e/mechanical.test.ts` failures from **64 → 19** on bun 1.2.19.

## Root cause (full detail in #473)

bun test 1.2.x runs every describe's `beforeAll` serially **before any test starts**, not interleaved with that describe's tests. Combined with `helpers.ts`'s singleton engine + per-`setupDB()` disconnect/reconnect, the last describe's `afterAll` closes the shared db connection while earlier describes' tests still expect it open.

## Fix

- `setupDB()` only calls `db.connect()` + `db.initSchema()` + `new PostgresEngine()` once per process. Subsequent calls only run TRUNCATE + reseed config.
- `teardownDB()` becomes a no-op. postgres.js closes pooled connections on process exit, which is sufficient for the test process lifecycle.

Per-describe TRUNCATE still runs, so describes that pair `setupDB()` with `importFixtures()` retain their isolation. Fixture-importing describes are unaffected.

## What this does NOT fix

`mechanical.test.ts` has describes that TRUNCATE without re-importing fixtures (`E2E: file_list LIMIT enforcement`, `E2E: Setup Journey`, `E2E: Schema Idempotency`, `E2E: RLS Verification`, `E2E: Parallel Import`, `E2E: Performance Baselines`, etc.). Under the bun batch model, those wipe fixtures the next describe's tests still expect. Fixing that is a restructuring of `mechanical.test.ts` itself — separate PR / different design choice.

## Verified locally

- `bun 1.2.19`, macOS, Postgres 17.6 (Homebrew, native, not Docker)
- `DATABASE_URL=postgresql://user@localhost:5432/gbrain_test bun test test/e2e/mechanical.test.ts`
- Before this PR: 14 pass / 64 fail
- After this PR: 59 pass / 19 fail (every remaining failure is a fixture-state issue, not a connection-state issue)

## Test plan

- [x] Local Postgres 17.6 + bun 1.2.19: failures drop from 64 → 19
- [ ] Verify CI's bun version still passes after this change (idempotent guard adds no behavior on first call)
- [ ] Verify `scripts/run-e2e.sh` (per-file serialization) is unaffected — file-process boundary resets `dbInitialized`

## Related

- #473 — full root cause writeup with sentinel-traced execution order
- #472 — separate `file_list` BigInt fix that surfaced this E2E framework issue while verifying the fix