### PR TITLE
fix(sync): reconcile sync-failures.jsonl with reality

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -11,6 +11,7 @@ import {
   isCodeFilePath,
   isMarkdownFilePath,
   isImageFilePath as isImageFilePathFromSync,
+  resolveSyncFailure,
   type SyncStrategy,
 } from '../core/sync.ts';
 import { sortNewestFirst } from '../core/sort-newest-first.ts';
@@ -249,6 +250,9 @@ export async function runImport(
         importedSlugs.push(result.slug);
         // v0.33.2: path-based checkpoint — record only on success.
         completed.add(relativePath);
+        // Bug 9 follow-up — a path that imports successfully must drop out
+        // of sync-failures.jsonl, otherwise stale entries accumulate forever.
+        resolveSyncFailure(relativePath);
       } else {
         skipped++;
         if (result.error && result.error !== 'unchanged') {
@@ -259,6 +263,8 @@ export async function runImport(
           // 'unchanged' or no-error skip: content_hash matched a prior
           // successful import, so this file IS done for checkpoint purposes.
           completed.add(relativePath);
+          // Hash-identical content already in DB also clears stale failures.
+          resolveSyncFailure(relativePath);
         }
       }
     } catch (e: unknown) {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -15,6 +15,7 @@ import {
   unacknowledgedSyncFailures,
   acknowledgeSyncFailures,
   formatCodeBreakdown,
+  resolveSyncFailure,
 } from '../core/sync.ts';
 import { estimateTokens, CHUNKER_VERSION } from '../core/chunkers/code.ts';
 import {
@@ -1433,6 +1434,9 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
           // slugs (paths in filtered.deleted but with no DB row) so
           // downstream extract/embed don't waste lookups.
           pagesAffected.push(...deleted);
+          for (const path of batch) {
+            resolveSyncFailure(path);
+          }
         } catch (err) {
           // D7 decompose: a transient blip on this batch shouldn't lose all
           // 500 deletes. Fall back to per-slug deletePage for THIS batch
@@ -1442,6 +1446,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
             try {
               await engine.deletePage(slugs[j], deleteScopedOpts);
               pagesAffected.push(slugs[j]);
+              resolveSyncFailure(batch[j]);
             } catch (perSlugErr) {
               failedFiles.push({
                 path: batch[j],
@@ -1467,6 +1472,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
         try {
           await engine.deletePage(slug, deleteOpts);
           pagesAffected.push(slug);
+          resolveSyncFailure(path);
         } catch (err) {
           failedFiles.push({
             path,
@@ -1548,6 +1554,11 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
         if (result.status === 'imported') chunksCreated += result.chunks;
       }
       pagesAffected.push(newSlug);
+      // Bug 9 follow-up — clear stale JSONL entries under both the old and
+      // new path. A file that previously failed under `from` and is now
+      // successfully present as `to` should not stay listed as failed.
+      resolveSyncFailure(from);
+      resolveSyncFailure(to);
       progress.tick(1, newSlug);
     }
     progress.finish();
@@ -1626,8 +1637,15 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
           // persist. partial() reports this so cron operators see how
           // much actually landed before --timeout fired.
           filesImported++;
+          // Bug 9 follow-up — reconcile JSONL with reality. A file that
+          // imports successfully should drop out of sync-failures even if it
+          // got there via a previous run.
+          resolveSyncFailure(path);
         } else if (result.status === 'skipped' && (result as any).error) {
           failedFiles.push({ path, error: String((result as any).error) });
+        } else if (result.status === 'skipped') {
+          // Hash-identical content already in DB — same reconciliation.
+          resolveSyncFailure(path);
         }
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -481,7 +481,7 @@ export function resolveSlugForPath(filePath: string, repoPrefix?: string): strin
 //   3. Let `gbrain sync --skip-failed` acknowledge a known-bad set so
 //      repos with many broken files aren't permanently stuck.
 
-import { existsSync as _existsSync, readFileSync as _readFileSync, appendFileSync as _appendFileSync, mkdirSync as _mkdirSync } from 'fs';
+import { existsSync as _existsSync, readFileSync as _readFileSync, appendFileSync as _appendFileSync, mkdirSync as _mkdirSync, writeFileSync as _writeFileSync, unlinkSync as _unlinkSync } from 'fs';
 import { join as _joinPath } from 'path';
 import { gbrainPath as _gbrainPath } from './config.ts';
 import { createHash as _createHash } from 'crypto';
@@ -743,4 +743,35 @@ export function acknowledgeSyncFailures(): AcknowledgeResult {
 /** Return only unacknowledged failures. */
 export function unacknowledgedSyncFailures(): SyncFailure[] {
   return loadSyncFailures().filter(f => !f.acknowledged);
+}
+
+/**
+ * Drop every failure entry whose path matches. Called when a previously-failed
+ * file successfully imports through any code path (sync, put_page, autopilot)
+ * so the JSONL reconciles with reality instead of carrying ghost records
+ * forever. Returns the number of entries removed.
+ *
+ * Bug 9 follow-up: prior to this, the JSONL was append-only outside of
+ * `--skip-failed`, so a file could already be in the DB while still listed as
+ * failed. Now any path that successfully imports / is deleted / is renamed
+ * away from automatically drops out.
+ *
+ * Concurrency caveat: read-modify-write is not atomic. If `gbrain sync` and the
+ * autopilot daemon race on the same JSONL, one writer's update can clobber the
+ * other. Same limitation applies to `acknowledgeSyncFailures`. Acceptable for
+ * now because failures are rare and both writers are idempotent on retry.
+ */
+export function resolveSyncFailure(path: string): number {
+  const entries = loadSyncFailures();
+  if (entries.length === 0) return 0;
+  const remaining = entries.filter(e => e.path !== path);
+  const removed = entries.length - remaining.length;
+  if (removed === 0) return 0;
+  const fp = syncFailuresPath();
+  if (remaining.length === 0) {
+    try { _unlinkSync(fp); } catch { /* already gone */ }
+  } else {
+    _writeFileSync(fp, remaining.map(e => JSON.stringify(e)).join('\n') + '\n');
+  }
+  return removed;
 }

--- a/test/sync-failures.test.ts
+++ b/test/sync-failures.test.ts
@@ -588,3 +588,53 @@ describe('v0.41.6.0 D2 — embedding error classification', () => {
     expect(classifyErrorCode('some random unmatched error message')).toBe('UNKNOWN');
   });
 });
+
+describe('Bug 9 follow-up — resolveSyncFailure', () => {
+  test('removes all entries matching the path, returns the count', async () => {
+    const { recordSyncFailures, resolveSyncFailure, loadSyncFailures } = await import('../src/core/sync.ts');
+    recordSyncFailures(
+      [
+        { path: 'a.md', error: 'first attempt' },
+        { path: 'b.md', error: 'unrelated' },
+        { path: 'a.md', error: 'second attempt (different commit)' },
+      ],
+      'commit1',
+    );
+    // Second call uses a fresh commit so the second 'a.md' isn't dedup-collapsed.
+    recordSyncFailures([{ path: 'a.md', error: 'third attempt' }], 'commit2');
+
+    const before = loadSyncFailures();
+    const aEntries = before.filter(e => e.path === 'a.md').length;
+    expect(aEntries).toBeGreaterThanOrEqual(2);
+
+    const removed = resolveSyncFailure('a.md');
+    expect(removed).toBe(aEntries);
+
+    const after = loadSyncFailures();
+    expect(after.find(e => e.path === 'a.md')).toBeUndefined();
+    expect(after.find(e => e.path === 'b.md')).toBeDefined();
+  });
+
+  test('returns 0 and is a no-op when path is not in the log', async () => {
+    const { recordSyncFailures, resolveSyncFailure, loadSyncFailures } = await import('../src/core/sync.ts');
+    recordSyncFailures([{ path: 'a.md', error: 'err' }], 'commit1');
+    const before = loadSyncFailures();
+    expect(resolveSyncFailure('not-recorded.md')).toBe(0);
+    const after = loadSyncFailures();
+    expect(after).toEqual(before);
+  });
+
+  test('removes the file when the last entry is resolved', async () => {
+    const { recordSyncFailures, resolveSyncFailure, syncFailuresPath } = await import('../src/core/sync.ts');
+    const { existsSync: _existsSync } = await import('fs');
+    recordSyncFailures([{ path: 'only.md', error: 'err' }], 'commit1');
+    expect(_existsSync(syncFailuresPath())).toBe(true);
+    expect(resolveSyncFailure('only.md')).toBe(1);
+    expect(_existsSync(syncFailuresPath())).toBe(false);
+  });
+
+  test('returns 0 when no JSONL file exists', async () => {
+    const { resolveSyncFailure } = await import('../src/core/sync.ts');
+    expect(resolveSyncFailure('whatever.md')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Bug 9 follow-up. v0.31 already shipped `acknowledgeSyncFailures` + the `--skip-failed`/`--retry-failed` operator workflows, but the JSONL was still append-only between cycles: a file that legitimately succeeded on a later attempt stayed listed as failed forever, padding doctor noise and confusing operators.

Tight on scope after rebase to v0.32.0 — this PR now only adds the missing reconciliation primitive and its call sites. The empty-diff `--retry-failed` / `--skip-failed` fallthrough is already on master from upstream's own work, so this branch no longer touches that surface.

### Real-world trigger

A brain with CJK-named pages hit a transient parse failure on 2026-04-27, recorded 6 entries to `~/.gbrain/sync-failures.jsonl`, then self-healed in the DB through a subsequent `put_page` flow — but the JSONL kept those 6 entries forever. Every `gbrain doctor` run flagged them as broken even though the underlying error (`Invalid slug: ""` from pre-#115 CJK slugify) no longer occurs.

## Changes

- **`src/core/sync.ts`**: new `resolveSyncFailure(path: string): number`. Removes all JSONL entries by path; unlinks the file when the last entry clears. Same read-modify-write concurrency caveat as `acknowledgeSyncFailures` (documented inline).

- **`src/commands/import.ts`**: on successful import and on hash-identical skip, calls `resolveSyncFailure(relativePath)`.

- **`src/commands/sync.ts`**: same primitive fires from `deletes` (file gone), `renames` (both `from` + `to`), and the per-file import success / hash-identical skip paths inside `importOnePath`.

- **`test/sync-failures.test.ts`**: 4 new cases — removal-with-count, no-op on unmatched path, last-entry file deletion, absent-file return-zero.

## Test plan

- [x] `bun test test/sync-failures.test.ts` — 45/45 pass
- [x] `bun run typecheck` clean (after fresh `bun install` to drop stale lock entries)
- [x] Cherry-pick onto v0.32.0 (commit `0ad309e`) — clean apply, no conflicts after the scope reduction

## Note on prior scope

This PR was originally larger (8 tests, ~250 lines) and included the `--retry-failed` fallthrough at the `lastCommit === headCommit` early return. Upstream landed that exact handling independently before v0.32.0, so the rebased version drops the overlap and ships only the missing reconciliation hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)