### PR TITLE
fix(db-lock): probe holder PID, not just TTL, on DB lock acquire

### DIFF
--- a/src/core/db-lock.ts
+++ b/src/core/db-lock.ts
@@ -34,6 +34,57 @@ export interface DbLockHandle {
 const DEFAULT_TTL_MINUTES = 30;
 
 /**
+ * Probe whether a process is alive on the local machine.
+ *
+ * `process.kill(pid, 0)` is the canonical Unix liveness check: signal 0 is a
+ * no-op send that only validates the target.
+ *   - returns normally → process exists (live holder).
+ *   - ESRCH            → no such process (dead; safe to take over).
+ *   - EPERM            → exists but we can't signal it (real holder; alive).
+ *
+ * pid <= 0 is treated as dead: pid 0 would signal the whole process group,
+ * and a corrupt/empty holder_pid row should be reclaimable.
+ *
+ * #480: a SIGKILL / OOM / power-off holder leaves a full-TTL row behind, so
+ * without a liveness probe every acquirer skips for up to the full TTL.
+ */
+export function isPidAliveLocal(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: unknown) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code === 'ESRCH') return false;
+    if (err.code === 'EPERM') return true;
+    throw err;
+  }
+}
+
+/**
+ * Decide whether the current process should take over a held lock whose TTL
+ * has NOT yet expired. Pure + injectable so tests don't fork processes.
+ *
+ *   - holder on a different host → skip (can't probe; trust the TTL).
+ *   - holder on this host and alive (or EPERM) → skip (real live holder).
+ *   - holder on this host and dead (ESRCH) → acquire (zombie row).
+ *
+ * #480 follow-up to PR #477: same bug family as the autopilot file-lock fix,
+ * but for the DB row in gbrain_cycle_locks (shared by cycle + sync + migrate
+ * lock ids, so this one helper covers all three surfaces).
+ */
+export function decideLockAcquisition(opts: {
+  holderPid: number;
+  holderHost: string;
+  currentHost: string;
+  isPidAlive?: (pid: number) => boolean;
+}): 'acquire' | 'skip' {
+  if (opts.holderHost !== opts.currentHost) return 'skip';
+  const probe = opts.isPidAlive ?? isPidAliveLocal;
+  return probe(opts.holderPid) ? 'skip' : 'acquire';
+}
+
+/**
  * Try to acquire a named DB lock.
  *
  * Returns a handle on success. Returns `null` if another live holder has
@@ -80,7 +131,8 @@ export async function tryAcquireDbLock(
     // `gbrain sync --break-lock --max-age <s>` uses last_refreshed_at (not
     // acquired_at) to identify wedged-but-alive holders without stealing
     // healthy long-running holders that are actively refreshing.
-    const rows: Array<{ id: string }> = await sql`
+    // Step 1: standard UPSERT — succeeds for a fresh row OR a TTL-expired holder.
+    let rows: Array<{ id: string }> = await sql`
       INSERT INTO gbrain_cycle_locks (id, holder_pid, holder_host, acquired_at, ttl_expires_at, last_refreshed_at)
       VALUES (${lockId}, ${pid}, ${host}, NOW(), NOW() + ${ttl}::interval, NOW())
       ON CONFLICT (id) DO UPDATE
@@ -92,7 +144,38 @@ export async function tryAcquireDbLock(
         WHERE gbrain_cycle_locks.ttl_expires_at < NOW()
       RETURNING id
     `;
-    if (rows.length === 0) return null;
+    if (rows.length === 0) {
+      // #480: row is held and TTL not expired. Probe the holder — a dead
+      // same-host PID (SIGKILL/OOM/power-off) is a zombie row we can take
+      // over now instead of waiting out the full TTL.
+      const held: Array<{ holder_pid: number; holder_host: string }> = await sql`
+        SELECT holder_pid, holder_host FROM gbrain_cycle_locks WHERE id = ${lockId}
+      `;
+      const h = held[0];
+      if (
+        !h ||
+        decideLockAcquisition({
+          holderPid: Number(h.holder_pid),
+          holderHost: h.holder_host,
+          currentHost: host,
+        }) === 'skip'
+      ) {
+        return null;
+      }
+      // Take over, guarded by the observed holder_pid + host so a racing
+      // acquirer between SELECT and UPDATE doesn't get stomped.
+      rows = await sql`
+        UPDATE gbrain_cycle_locks
+          SET holder_pid = ${pid},
+              holder_host = ${host},
+              acquired_at = NOW(),
+              ttl_expires_at = NOW() + ${ttl}::interval,
+              last_refreshed_at = NOW()
+        WHERE id = ${lockId} AND holder_pid = ${h.holder_pid} AND holder_host = ${h.holder_host}
+        RETURNING id
+      `;
+      if (rows.length === 0) return null; // lost the takeover race
+    }
     const deregister = registerCleanup(`db-lock:${lockId}`, async () => {
       await sql`
         DELETE FROM gbrain_cycle_locks
@@ -125,7 +208,8 @@ export async function tryAcquireDbLock(
   if (engine.kind === 'pglite' && maybePGLite.db) {
     const db = maybePGLite.db;
     const ttl = `${ttlMinutes} minutes`;
-    const { rows } = await db.query(
+    // Step 1: standard UPSERT — succeeds for a fresh row OR a TTL-expired holder.
+    let { rows } = await db.query(
       `INSERT INTO gbrain_cycle_locks (id, holder_pid, holder_host, acquired_at, ttl_expires_at, last_refreshed_at)
        VALUES ($1, $2, $3, NOW(), NOW() + $4::interval, NOW())
        ON CONFLICT (id) DO UPDATE
@@ -138,7 +222,37 @@ export async function tryAcquireDbLock(
        RETURNING id`,
       [lockId, pid, host, ttl],
     );
-    if (rows.length === 0) return null;
+    if (rows.length === 0) {
+      // #480: held row, TTL not expired. Probe the holder — same dance as the
+      // postgres branch. PGLite is single-writer in normal use, but the lock
+      // row is shared across concurrent processes, so a zombie holder_pid
+      // from a crashed sibling still needs reclaiming.
+      const held = (await db.query(
+        `SELECT holder_pid, holder_host FROM gbrain_cycle_locks WHERE id = $1`,
+        [lockId],
+      )).rows as Array<{ holder_pid: number; holder_host: string }>;
+      const h = held[0];
+      if (
+        !h ||
+        decideLockAcquisition({
+          holderPid: Number(h.holder_pid),
+          holderHost: h.holder_host,
+          currentHost: host,
+        }) === 'skip'
+      ) {
+        return null;
+      }
+      rows = (await db.query(
+        `UPDATE gbrain_cycle_locks
+            SET holder_pid = $2, holder_host = $3, acquired_at = NOW(),
+                ttl_expires_at = NOW() + $4::interval,
+                last_refreshed_at = NOW()
+          WHERE id = $1 AND holder_pid = $5 AND holder_host = $6
+         RETURNING id`,
+        [lockId, pid, host, ttl, h.holder_pid, h.holder_host],
+      )).rows;
+      if (rows.length === 0) return null; // lost the takeover race
+    }
     const deregister = registerCleanup(`db-lock:${lockId}`, async () => {
       await db.query(
         `DELETE FROM gbrain_cycle_locks WHERE id = $1 AND holder_pid = $2`,

--- a/test/db-lock-pid-probe.test.ts
+++ b/test/db-lock-pid-probe.test.ts
@@ -1,0 +1,151 @@
+/**
+ * DB-lock PID probe — #480 rewritten for v0.38's lock refactor.
+ *
+ * `gbrain_cycle_locks` is a 30-minute TTL row shared by the cycle lock,
+ * performSync's writer lock, and the migrate lock (all via tryAcquireDbLock).
+ * Before this fix the only takeover path was `ttl_expires_at < NOW()`. After a
+ * SIGKILL / OOM / power-off the holder PID is dead but the row still has up to
+ * 30 minutes of life, so every acquirer skipped with the lock held. A real
+ * brain lost 14 hours of sync to this.
+ *
+ * Fix: when the UPSERT finds a live (non-expired) row, probe the holder PID
+ * via process.kill(pid, 0) when the host matches. Dead same-host holder →
+ * take over now. Different host → trust the TTL (can't probe remotely).
+ *
+ * Originally landed in src/core/cycle.ts (PR #480); v0.38 moved the DB lock
+ * into src/core/db-lock.ts, so the probe moves with it.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { hostname } from 'os';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import {
+  tryAcquireDbLock,
+  isPidAliveLocal,
+  decideLockAcquisition,
+} from '../src/core/db-lock.ts';
+
+describe('decideLockAcquisition (pure)', () => {
+  const here = hostname();
+
+  test('different host → skip (cannot probe; trust TTL)', () => {
+    expect(
+      decideLockAcquisition({
+        holderPid: 99999,
+        holderHost: 'some-other-machine.local',
+        currentHost: here,
+        isPidAlive: () => false, // even a "dead" probe is untrusted across hosts
+      }),
+    ).toBe('skip');
+  });
+
+  test('same host + alive PID → skip (live holder)', () => {
+    expect(
+      decideLockAcquisition({
+        holderPid: 1234,
+        holderHost: here,
+        currentHost: here,
+        isPidAlive: (pid) => {
+          expect(pid).toBe(1234);
+          return true;
+        },
+      }),
+    ).toBe('skip');
+  });
+
+  test('same host + dead PID → acquire (zombie row)', () => {
+    expect(
+      decideLockAcquisition({
+        holderPid: 1234,
+        holderHost: here,
+        currentHost: here,
+        isPidAlive: () => false,
+      }),
+    ).toBe('acquire');
+  });
+});
+
+describe('isPidAliveLocal (real probe)', () => {
+  test('current process is alive', () => {
+    expect(isPidAliveLocal(process.pid)).toBe(true);
+  });
+
+  test('pid 1 (init/launchd) is alive via EPERM', () => {
+    // We can't signal init, so kill(1,0) throws EPERM → treated as alive.
+    expect(isPidAliveLocal(1)).toBe(true);
+  });
+
+  test('an impossible pid is dead', () => {
+    expect(isPidAliveLocal(2147483646)).toBe(false);
+  });
+
+  test('pid 0 and negative are dead (never signal the process group)', () => {
+    expect(isPidAliveLocal(0)).toBe(false);
+    expect(isPidAliveLocal(-1)).toBe(false);
+  });
+});
+
+describe('tryAcquireDbLock takeover (PGLite)', () => {
+  let engine: PGLiteEngine;
+  const here = hostname();
+  const LOCK = 'gbrain-cycle';
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+  });
+
+  beforeEach(async () => {
+    await engine.executeRaw('DELETE FROM gbrain_cycle_locks');
+  });
+
+  async function seedHolder(pid: number, host: string) {
+    await engine.executeRaw(
+      `INSERT INTO gbrain_cycle_locks (id, holder_pid, holder_host, acquired_at, ttl_expires_at)
+       VALUES ($1, $2, $3, NOW(), NOW() + INTERVAL '30 minutes')`,
+      [LOCK, pid, host],
+    );
+  }
+
+  async function holderPid(): Promise<number | null> {
+    const rows = await engine.executeRaw<{ holder_pid: number }>(
+      `SELECT holder_pid FROM gbrain_cycle_locks WHERE id = $1`,
+      [LOCK],
+    );
+    return rows[0] ? Number(rows[0].holder_pid) : null;
+  }
+
+  test('fresh row → acquires', async () => {
+    const handle = await tryAcquireDbLock(engine, LOCK, 30);
+    expect(handle).not.toBeNull();
+    expect(await holderPid()).toBe(process.pid);
+    await handle!.release();
+  });
+
+  test('live same-host holder → null (no takeover)', async () => {
+    await seedHolder(1, here); // pid 1 is alive via EPERM
+    const handle = await tryAcquireDbLock(engine, LOCK, 30);
+    expect(handle).toBeNull();
+    expect(await holderPid()).toBe(1); // untouched
+  });
+
+  test('dead same-host holder → takes over (#480 core fix)', async () => {
+    await seedHolder(2147483646, here); // impossible pid, fresh TTL
+    const handle = await tryAcquireDbLock(engine, LOCK, 30);
+    expect(handle).not.toBeNull();
+    expect(await holderPid()).toBe(process.pid); // reclaimed
+    await handle!.release();
+  });
+
+  test('dead holder on a different host → null (trust TTL, cannot probe)', async () => {
+    await seedHolder(2147483646, 'other-machine.example');
+    const handle = await tryAcquireDbLock(engine, LOCK, 30);
+    expect(handle).toBeNull();
+    expect(await holderPid()).toBe(2147483646); // untouched
+  });
+});


### PR DESCRIPTION
## Probe holder PID, not just TTL, on DB lock acquire

`gbrain_cycle_locks` is a 30-minute TTL row that gates state-mutating cycle phases. The acquire only took over a row when `ttl_expires_at < NOW()`. After a SIGKILL / OOM / power-off the holder PID is dead but the row still has full TTL, so every subsequent acquirer skips with `cycle_already_running` for up to 30 minutes. A launchd-managed brain lost 14 hours of sync to this.

**Fix**: when the UPSERT finds a non-expired held row, probe the holder. Same host + dead PID (ESRCH) → take over via an UPDATE guarded by the observed `(holder_pid, holder_host)` so a racing acquirer can't be stomped. Different host → trust the TTL (can't probe remotely). Sister fix to #477 (the `autopilot.lock` file lock).

---

### Rebased onto v0.40.x (was originally against cycle.ts)

v0.38 extracted the DB lock out of `cycle.ts:acquirePostgresLock` into the shared `db-lock.ts:tryAcquireDbLock` (now backing the cycle lock, performSync's writer lock, AND the migrate lock). The original patch's target function no longer exists, so this rebase **moves the PID probe into `db-lock.ts`** — one helper now protects all three lock surfaces instead of just the cycle lock.

Note: v0.40's `acquireFileLock` (the engine===null path) already grew an inline PID probe upstream, but `tryAcquireDbLock` (the path every Postgres deployment uses) is still TTL-only — so this fix is still needed.

Tests: `test/db-lock-pid-probe.test.ts` — 11 cases (pure `isPidAliveLocal` / `decideLockAcquisition` + PGLite real-takeover integration: fresh acquire, live holder skip, dead same-host takeover, different-host trust-TTL).