### PR TITLE
Add claude-code-capture recipe: ambient signals from Stop hook

### DIFF
--- a/recipes/claude-code-capture.md
+++ b/recipes/claude-code-capture.md
@@ -1,0 +1,291 @@
+---
+id: claude-code-capture
+name: Claude Code Capture
+version: 0.1.0
+description: Ambient signal capture from Claude Code sessions. A Stop hook runs after every session, asks Haiku to extract decisions / original thinking / entities / concepts, and writes selective brain pages. Mirrors the openclaw signal-detector skill, ported to Claude Code's hook mechanism.
+category: sense
+requires: []
+secrets:
+  - name: ANTHROPIC_API_KEY
+    description: Anthropic API key. OPTIONAL — only used if `claude` CLI is not installed. With Claude Pro/Max subscription installed, the recipe uses `claude -p` and pays nothing extra.
+    where: https://console.anthropic.com/settings/keys — only needed if you want to run the hook on a server without the `claude` CLI authed.
+health_checks:
+  - type: command
+    argv: ["test", "-x", "$HOME/.gbrain/hooks/signal-detector.py"]
+    label: "signal-detector.py installed"
+  - type: command
+    argv: ["jq", "-e", ".hooks.Stop[].hooks[] | select(.command | contains(\"signal-detector\"))", "$HOME/.claude/settings.json"]
+    label: "Stop hook wired in settings.json"
+setup_time: 5 min
+cost_estimate: "$0/mo with Claude Pro/Max subscription (uses `claude -p` headless). ~1-3¢ per session with ANTHROPIC_API_KEY (Haiku 4.5 prices). Recipe picks the cheaper path automatically."
+---
+
+# Claude Code Capture: Ambient Brain Capture from Terminal Sessions
+
+By default, Claude Code does NOT write to your brain. The MCP wiring lets the
+model query/write *during* a conversation, but sessions end without leaving any
+trail in the brain. This recipe fixes that with a Stop hook: at the end of
+every session, Haiku reads the transcript, extracts only the signals worth
+keeping, and writes selective pages.
+
+This is the openclaw `signal-detector` pattern (which fires per-message on
+inbound Telegram messages), ported to Claude Code's hook mechanism (which fires
+per-session at end-of-session).
+
+## IMPORTANT: Instructions for the Agent
+
+**You are the installer.** Follow these steps precisely.
+
+**The core pattern: end-of-session hook spawns capture in background.**
+The hook runs `python3 ~/.gbrain/hooks/signal-detector.py` with `async: true`,
+so the user is never blocked. The script reads the just-finished transcript
+(`.jsonl` under `~/.claude/projects/<sanitized-cwd>/`), asks Haiku to extract
+*structured* signals (decisions, originals, entities, concepts), and writes
+each as its own brain page via `gbrain put`. The full transcript is NEVER
+saved — only signals worth keeping forever.
+
+**Why end-of-session and not per-message:**
+- During a session the model already has GBrain MCP tools and can call
+  `gbrain put` on demand when the user asks. This recipe is for the rest —
+  the implicit knowledge that emerged but no one bothered to save.
+- One Haiku call per session is much cheaper than one per message.
+- A user can always ask the model directly to save during the conversation;
+  this recipe is the safety net.
+
+**Do not skip steps. Verify after each step.**
+
+## Architecture
+
+```
+Claude Code session ends
+  ↓
+Stop hook fires (async, never blocks user)
+  ↓
+~/.gbrain/hooks/signal-detector.py
+  ├─ recursion guard: if env GBRAIN_HOOK_RUNNING=1 → exit 0 (we're inside a child claude -p call)
+  ├─ read JSON event from stdin: { transcript_path, session_id }
+  ├─ fall back to newest *.jsonl in ~/.claude/projects/<sanitized-cwd>/ if path missing
+  ├─ skip if transcript < 2KB (trivial sessions ignored)
+  ├─ extract last 200 user/assistant turns to plain text (truncate to 30k chars)
+  ├─ pick auth mode:
+  │    1. PREFERRED: `claude -p --model claude-haiku-4-5 ...` (Pro/Max subscription, $0)
+  │    2. FALLBACK: direct API with ANTHROPIC_API_KEY
+  │    3. NEITHER: log [skip] reason=no_auth, exit 0
+  ├─ robust JSON extraction (find first balanced {...}, ignore prose/fences)
+  ├─ pre-validate slugs (kebab segments, lowercase, max 120 chars)
+  ├─ YAML-escape title and session_id in frontmatter (prevents YAML parse errors)
+  ├─ for each signal: gbrain put <slug> with frontmatter (source_session, captured_at)
+  ├─ if write fails: log slug + reason + stderr to write-failures.log sidecar
+  └─ write one-line summary to ~/.gbrain/hooks/signal-detector.log
+```
+
+## What gets captured
+
+| Category | Slug pattern | What it is |
+|---|---|---|
+| Decisions | `decisions/<kebab>` | Concrete decisions made in the session |
+| Insights (originals) | `originals/<kebab>` | User's original thinking — exact phrasing, NOT paraphrased |
+| Entities | `people/<kebab>` or `companies/<kebab>` | Notable people/companies mentioned |
+| Concepts | `concepts/<kebab>` | World concepts or domain ideas referenced |
+
+What is NOT captured:
+
+- The full transcript (would be noise; Claude Code's local auto-memory at `~/.claude/projects/<dir>/memory/` already handles that locally).
+- Operational chatter (yes/no/run-this — flagged with `skip_reason: "operational"` and dropped).
+- Sessions under 2KB of transcript (skipped as too small).
+
+## Setup Flow
+
+### Step 1: Verify Claude Code is installed and the brain is reachable
+
+```bash
+claude --version           # need >= 2.x
+gbrain --version           # need 0.2x.x (canonical Garry Tan version, not the npm squat)
+gbrain doctor --fast       # health score >= 80 expected
+```
+
+If `gbrain` shows a 1.x.x version, the user installed the squatted npm package
+instead of `bun install -g github:garrytan/gbrain`. Fix with:
+
+```bash
+bun remove -g gbrain && bun install -g github:garrytan/gbrain
+```
+
+### Step 2: Install the capture script
+
+```bash
+mkdir -p ~/.gbrain/hooks
+curl -fsSL https://raw.githubusercontent.com/garrytan/gbrain/master/recipes/claude-code-capture/signal-detector.py \
+  -o ~/.gbrain/hooks/signal-detector.py
+chmod 700 ~/.gbrain/hooks/signal-detector.py
+```
+
+Validate:
+
+```bash
+python3 -c "import py_compile; py_compile.compile('$HOME/.gbrain/hooks/signal-detector.py', doraise=True)" \
+  && echo "PASS: script syntax valid"
+```
+
+### Step 3: Wire the Stop hook into `~/.claude/settings.json`
+
+Append this entry to the `hooks.Stop` array in the user's `~/.claude/settings.json`
+(merge with existing hooks; do not replace):
+
+```json
+{
+  "hooks": {
+    "Stop": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "python3 $HOME/.gbrain/hooks/signal-detector.py",
+        "timeout": 120,
+        "async": true
+      }]
+    }]
+  }
+}
+```
+
+`async: true` is critical: the hook fires in background and never blocks the
+user. `timeout: 120` is generous because Haiku extraction takes 5–30s on a
+typical session.
+
+Validate:
+
+```bash
+jq -e '.hooks.Stop[] | .hooks[] | select(.command | contains("signal-detector")) | .command' \
+  ~/.claude/settings.json \
+  && echo "PASS: hook wired"
+```
+
+After editing, the user must open `/hooks` in Claude Code once or restart the
+client so the watcher picks up the new entry.
+
+### Step 4: Smoke test
+
+The script handles a fully-empty stdin gracefully (exits 0 with a `[skip]`
+log line). Test it:
+
+```bash
+echo '{}' | python3 ~/.gbrain/hooks/signal-detector.py
+tail -1 ~/.gbrain/hooks/signal-detector.log
+```
+
+Expected output (one of):
+- `[skip:unknown] reason=transcript too small` (no real session yet)
+- `[ok:unknown] auth=claude_cli captured: N decisions, N insights, N entities, N concepts (Xs, transcript Yb)` (a session existed and was processed)
+
+### Step 5: Real end-to-end test
+
+```bash
+claude
+# Have a real conversation with at least one decision and one named entity.
+# Press Ctrl+D to exit (do NOT type "/exit"; the Stop hook fires on session
+# termination, not on the /exit slash command).
+# Wait ~30s.
+tail -1 ~/.gbrain/hooks/signal-detector.log
+```
+
+Expected: an `[ok:<sid>]` line with non-zero counts.
+
+Then:
+
+```bash
+gbrain list -n 5
+```
+
+You should see new pages with `decisions/`, `originals/`, `concepts/`, etc.
+slugs from this session.
+
+## What the agent should do after Step 5
+
+The agent's job ends after Step 5. Capture is now ambient — every Claude Code
+session ends with selective signals in the brain. The user does not need to do
+anything else.
+
+If the user wants to disable capture temporarily, they can comment out the
+hook in `~/.claude/settings.json` or set the env var `GBRAIN_HOOK_RUNNING=1`
+in their shell.
+
+## Multi-machine
+
+Each machine runs its own `~/.gbrain/hooks/signal-detector.py` and points at
+the same `gbrain` config (same `database_url`). All captures land in the
+shared brain. Provenance is preserved via the `source_session: <uuid>`
+frontmatter on each page, so the user can always tell which machine and
+session a page came from.
+
+## Auth mode details
+
+The script picks the cheaper path automatically:
+
+1. **PREFERRED: `claude -p` (subscription).** If `claude` is in `PATH`, the
+   script invokes:
+   ```
+   claude -p --model claude-haiku-4-5-20251001 "<prompt>+<transcript>"
+   ```
+   This uses the user's Claude Pro/Max OAuth — zero extra cost. Recursion is
+   prevented by setting `GBRAIN_HOOK_RUNNING=1` in the child env; the script
+   bails immediately if it sees that var on entry.
+
+2. **FALLBACK: direct API.** If `claude` is not installed (e.g., on a
+   headless server that has only the gbrain CLI), the script falls back to
+   a direct `https://api.anthropic.com/v1/messages` call with
+   `ANTHROPIC_API_KEY`. ~1-3¢ per session at Haiku-4-5 prices.
+
+3. **NO AUTH AVAILABLE:** logs `[skip:<sid>] reason=no_auth` and exits 0
+   cleanly. The user can either `npm i -g @anthropic-ai/claude-code` (free,
+   uses subscription if logged in) or set `ANTHROPIC_API_KEY`.
+
+## Logs
+
+| Path | Purpose |
+|---|---|
+| `~/.gbrain/hooks/signal-detector.log` | One line per run: `[ok|empty|skip:<sid>] auth=<mode> captured: ... (Xs, transcript Yb)` |
+| `~/.gbrain/hooks/write-failures.log` | One line per failed `gbrain put`: timestamp, slug, reason, stderr (truncated). Diagnoses YAML errors, invalid slugs, CLI timeouts. |
+| `~/.gbrain/hooks/last-extraction-raw.txt` | Last raw Haiku response — only written on parse failure. Inspect to tune the prompt. |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `[skip] reason=no ANTHROPIC_API_KEY` | Neither `claude` CLI nor API key available | Install Claude Code (`npm i -g @anthropic-ai/claude-code`) or set `ANTHROPIC_API_KEY` in `~/gbrain/.env` |
+| `[empty:<sid>]` on a real conversation | Haiku returned no signals | Inspect `~/.gbrain/hooks/last-extraction-raw.txt`. The prompt may need tuning for the user's domain |
+| `proposed=N/written=0` | All `gbrain put` calls failed | Inspect `~/.gbrain/hooks/write-failures.log`. Common causes: invalid slugs from Haiku (script pre-validates and logs `slug_invalid_chars`), YAML parse error in title (script YAML-escapes; if you see this, please file an issue with the title that broke) |
+| Hook never fires | Settings watcher missed the change | User must open `/hooks` once in Claude Code or restart |
+| Recursive loop | Stop hook firing on the child `claude -p` invocation | Should not happen — recursion guard via `GBRAIN_HOOK_RUNNING=1` env var. If you see it, file an issue |
+
+## Cost / latency
+
+| Path | Latency per session | Cost per session |
+|---|---|---|
+| `claude -p` (subscription) | 10-40s | $0 |
+| Direct API (fallback) | 5-25s | ~1-3¢ |
+
+Both run async, so the user never waits.
+
+## Reference implementation
+
+Source: [recipes/claude-code-capture/signal-detector.py](claude-code-capture/signal-detector.py)
+Installer: [recipes/claude-code-capture/install.sh](claude-code-capture/install.sh)
+
+The script is single-file Python 3 with stdlib only (no `requests`, no `pyyaml`)
+so it ships with no install footprint beyond `python3` + `gbrain` + (optionally)
+`claude`.
+
+## Comparison with openclaw signal-detector
+
+| | openclaw signal-detector | This recipe |
+|---|---|---|
+| Trigger | Every inbound Telegram message | End of every Claude Code session |
+| Where it runs | Inside the openclaw agent loop | As a Stop hook spawned by Claude Code |
+| Model | Whatever the agent is configured to use | Haiku 4.5 (cheap, fast) |
+| Auth | Whatever the agent uses | Subscription via `claude -p` (preferred) or API key (fallback) |
+| Capture latency | Real-time (during conversation) | End-of-session (batch, async) |
+| Output | decisions/originals/people/companies/concepts pages | same |
+| Shared brain | Yes (writes to same Postgres) | yes |
+
+Both write to the SAME GBrain Postgres → unified memory across all entry
+points (Telegram via openclaw, terminal via Claude Code, etc.).

--- a/recipes/claude-code-capture/install.sh
+++ b/recipes/claude-code-capture/install.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Reference installer for the claude-code-capture recipe.
+# Idempotent. Documented in ../claude-code-capture.md.
+#
+# Usage:
+#   bash <(curl -fsSL https://raw.githubusercontent.com/garrytan/gbrain/master/recipes/claude-code-capture/install.sh)
+
+set -euo pipefail
+
+C_OK=$'\033[32m'; C_WARN=$'\033[33m'; C_ERR=$'\033[31m'; C_RESET=$'\033[0m'
+ok()   { echo "${C_OK}✓${C_RESET} $*"; }
+warn() { echo "${C_WARN}⚠${C_RESET} $*"; }
+err()  { echo "${C_ERR}✗${C_RESET} $*" >&2; }
+
+HOOKS_DIR="$HOME/.gbrain/hooks"
+SCRIPT_DST="$HOOKS_DIR/signal-detector.py"
+SETTINGS="$HOME/.claude/settings.json"
+
+mkdir -p "$HOOKS_DIR"
+
+echo "→ Downloading signal-detector.py from upstream..."
+RAW_URL="https://raw.githubusercontent.com/garrytan/gbrain/master/recipes/claude-code-capture/signal-detector.py"
+curl -fsSL "$RAW_URL" -o "$SCRIPT_DST"
+chmod 700 "$SCRIPT_DST"
+ok "Installed $SCRIPT_DST"
+
+echo "→ Checking auth mode..."
+if command -v claude >/dev/null 2>&1; then
+  ok "claude CLI found ($(command -v claude)) — capture will use your Pro/Max subscription (no extra cost)"
+else
+  ENV_FILE="${GBRAIN_ENV_FILE:-$HOME/gbrain/.env}"
+  if [ -f "$ENV_FILE" ] && grep -q "^ANTHROPIC_API_KEY=" "$ENV_FILE"; then
+    ok "ANTHROPIC_API_KEY found in $ENV_FILE — capture will use direct API (~1-3¢/session)"
+  elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    ok "ANTHROPIC_API_KEY found in shell env — capture will use direct API (~1-3¢/session)"
+  else
+    warn "Neither claude CLI nor ANTHROPIC_API_KEY found"
+    warn "Capture will skip until one is available. Either:"
+    warn "  - Install Claude Code:  npm i -g @anthropic-ai/claude-code"
+    warn "  - Or add to $ENV_FILE:  ANTHROPIC_API_KEY=sk-ant-..."
+  fi
+fi
+
+echo "→ Wiring Stop hook into $SETTINGS..."
+if [ ! -f "$SETTINGS" ]; then
+  echo '{}' > "$SETTINGS"
+fi
+cp "$SETTINGS" "$SETTINGS.bak-pre-capture-$(date +%s)"
+
+python3 - <<PY
+import json, os, tempfile
+p = "$SETTINGS"
+with open(p) as f: d = json.load(f)
+d.setdefault("hooks", {}).setdefault("Stop", [])
+
+new_cmd = "python3 $SCRIPT_DST"
+existing = []
+for entry in d["hooks"]["Stop"]:
+    for h in entry.get("hooks", []):
+        if h.get("type") == "command":
+            existing.append(h.get("command",""))
+
+if new_cmd in existing:
+    print("Already wired — skipping merge.")
+else:
+    d["hooks"]["Stop"].append({
+        "matcher": "",
+        "hooks": [{
+            "type": "command",
+            "command": new_cmd,
+            "timeout": 120,
+            "async": True
+        }]
+    })
+
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(p))
+with os.fdopen(fd, "w") as f:
+    json.dump(d, f, indent=2)
+os.chmod(tmp, 0o600)
+os.replace(tmp, p)
+print("Settings written.")
+PY
+
+ok "Stop hook wired"
+
+if command -v jq >/dev/null 2>&1; then
+  if jq -e '.hooks.Stop[].hooks[] | select(.command | contains("signal-detector"))' "$SETTINGS" >/dev/null 2>&1; then
+    ok "jq validation passed"
+  else
+    err "jq validation FAILED — settings.json may be malformed"
+    exit 1
+  fi
+fi
+
+echo "→ Smoke testing script..."
+echo '{}' | python3 "$SCRIPT_DST" || true
+LAST_LOG=$(tail -1 "$HOOKS_DIR/signal-detector.log" 2>/dev/null || echo "")
+[ -n "$LAST_LOG" ] && ok "Script ran. Last log: $LAST_LOG"
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  ✅ claude-code-capture installed"
+echo "════════════════════════════════════════════"
+echo ""
+echo "  Open /hooks in Claude Code (or restart) to load the new hook."
+echo "  See recipes/claude-code-capture.md for full details."
+echo ""

--- a/recipes/claude-code-capture/signal-detector.py
+++ b/recipes/claude-code-capture/signal-detector.py
@@ -42,8 +42,18 @@ MAX_TRANSCRIPT_CHARS = 30000
 MODEL = "claude-haiku-4-5-20251001"
 
 # ─── Logging ─────────────────────────────────────────────
+def _ensure_secure(path: Path) -> None:
+    """Ensure file exists with 600 perms (owner-only)."""
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+    try:
+        path.chmod(0o600)
+    except Exception:
+        pass
+
 def log(msg: str) -> None:
-    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _ensure_secure(LOG_FILE)
     with LOG_FILE.open("a") as f:
         f.write(f"{datetime.now(timezone.utc).isoformat(timespec='seconds')} {msg}\n")
 
@@ -136,12 +146,12 @@ def _extract_first_json_object(text: str) -> str | None:
 def _parse_extraction(raw_text: str) -> dict:
     json_text = _extract_first_json_object(raw_text)
     if not json_text:
-        (HOME / ".gbrain/hooks/last-extraction-raw.txt").write_text(raw_text[:8000])
+        _p = HOME / ".gbrain/hooks/last-extraction-raw.txt"; _ensure_secure(_p); _p.write_text(raw_text[:8000]); _p.chmod(0o600)
         return {"skip_reason": "no_json_object_found", "decisions":[], "insights":[], "entities":[], "concepts":[]}
     try:
         return json.loads(json_text)
     except Exception as e:
-        (HOME / ".gbrain/hooks/last-extraction-raw.txt").write_text(raw_text[:8000])
+        _p = HOME / ".gbrain/hooks/last-extraction-raw.txt"; _ensure_secure(_p); _p.write_text(raw_text[:8000]); _p.chmod(0o600)
         return {"skip_reason": f"parse_error: {e}", "decisions":[], "insights":[], "entities":[], "concepts":[]}
 
 # ─── Auth mode 1: claude CLI (subscription) ──────────────
@@ -203,7 +213,7 @@ WRITE_FAILURES_LOG = HOME / ".gbrain/hooks/write-failures.log"
 
 def _log_write_failure(slug: str, reason: str, stderr: str = "") -> None:
     try:
-        WRITE_FAILURES_LOG.parent.mkdir(parents=True, exist_ok=True)
+        _ensure_secure(WRITE_FAILURES_LOG)
         with WRITE_FAILURES_LOG.open("a") as f:
             ts = datetime.now(timezone.utc).isoformat(timespec='seconds')
             f.write(f"{ts}\tslug={slug}\treason={reason}\tstderr={stderr[:300]}\n")
@@ -312,7 +322,7 @@ def main():
         log(f"[empty:{session_id}] auth={auth_mode} Haiku returned 0 signals ({extraction_secs}s, transcript {bytes_size}b) — likely operational session, or prompt needs tuning. Saved raw to last-extraction-raw.txt")
         # Save the raw signals we got for debugging
         try:
-            (HOME / ".gbrain/hooks/last-extraction-raw.txt").write_text(json.dumps(signals, indent=2)[:8000])
+            _p = HOME / ".gbrain/hooks/last-extraction-raw.txt"; _ensure_secure(_p); _p.write_text(json.dumps(signals, indent=2)[:8000]); _p.chmod(0o600)
         except Exception:
             pass
         return 0

--- a/recipes/claude-code-capture/signal-detector.py
+++ b/recipes/claude-code-capture/signal-detector.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""
+Claude Code Stop hook → ambient signal capture into GBrain.
+
+Mirrors OpenClaw's signal-detector skill pattern: extracts ORIGINAL THINKING +
+ENTITY MENTIONS from the just-finished session and writes selective pages to
+GBrain. Does NOT save the full transcript (that would be noise).
+
+Auth modes (preferred order):
+  1. `claude -p` (uses your Claude Pro/Max subscription, $0 extra)
+  2. ANTHROPIC_API_KEY direct API call (~1-3¢ per session)
+
+Recursion guard: if env GBRAIN_HOOK_RUNNING=1, exit immediately. The script
+sets that var before invoking `claude -p` so the spawned child's Stop hook
+short-circuits instead of looping.
+
+Wire-up: ~/.claude/settings.json hooks.Stop entry running:
+    python3 ~/.gbrain/hooks/signal-detector.py
+"""
+
+from __future__ import annotations
+import json, os, sys, shutil, subprocess, time, urllib.request, urllib.error
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ─── Config ──────────────────────────────────────────────
+HOME = Path.home()
+GBRAIN_BIN = os.environ.get("GBRAIN_BIN", str(HOME / ".bun/bin/gbrain"))
+ENV_FILE = Path(os.environ.get("GBRAIN_ENV_FILE", str(HOME / "gbrain/.env")))
+LOG_FILE = HOME / ".gbrain/hooks/signal-detector.log"
+
+def _detect_projects_dir() -> Path:
+    base = HOME / ".claude/projects"
+    if not base.is_dir(): return base
+    cands = [p for p in base.iterdir() if p.is_dir()]
+    if not cands: return base
+    return max(cands, key=lambda p: max((j.stat().st_mtime for j in p.glob("*.jsonl")), default=0))
+
+PROJECTS_DIR = _detect_projects_dir()
+MIN_TRANSCRIPT_BYTES = 2000
+MAX_TRANSCRIPT_CHARS = 30000
+MODEL = "claude-haiku-4-5-20251001"
+
+# ─── Logging ─────────────────────────────────────────────
+def log(msg: str) -> None:
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with LOG_FILE.open("a") as f:
+        f.write(f"{datetime.now(timezone.utc).isoformat(timespec='seconds')} {msg}\n")
+
+# ─── Env file loader ─────────────────────────────────────
+def load_env_file(path: Path) -> dict:
+    env = {}
+    if not path.exists(): return env
+    for line in path.read_text(errors="ignore").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line: continue
+        k, _, v = line.partition("=")
+        env[k.strip()] = v.strip().strip('"').strip("'")
+    return env
+
+# ─── Transcript handling ─────────────────────────────────
+def find_transcript(event: dict) -> Path | None:
+    p = event.get("transcript_path") or ""
+    if p and Path(p).is_file(): return Path(p)
+    candidates = sorted(PROJECTS_DIR.glob("*.jsonl"), key=lambda x: x.stat().st_mtime, reverse=True)
+    return candidates[0] if candidates else None
+
+def extract_turns(transcript: Path, max_turns: int = 200) -> str:
+    turns = []
+    for line in transcript.read_text(errors="ignore").splitlines():
+        line = line.strip()
+        if not line: continue
+        try: ev = json.loads(line)
+        except: continue
+        msg = ev.get("message") or {}
+        role = msg.get("role")
+        content = msg.get("content")
+        if not (role and content): continue
+        if isinstance(content, list):
+            text = "\n".join(c.get("text","") for c in content if isinstance(c,dict) and c.get("type")=="text").strip()
+        elif isinstance(content, str):
+            text = content
+        else:
+            text = ""
+        if text:
+            turns.append(f"[{role}]\n{text}\n")
+    return ("\n---\n".join(turns[-max_turns:]))[:MAX_TRANSCRIPT_CHARS]
+
+# ─── Prompts ─────────────────────────────────────────────
+SYSTEM_PROMPT = """You are signal-detector. Your ONLY job is to output a JSON object.
+You output NOTHING else. No prose. No greeting. No analysis. No markdown.
+Your output MUST start with { and end with }. Anything else is failure."""
+
+EXTRACTION_PROMPT = """Extract structured signals from this Claude Code session transcript.
+
+Schema (output ONLY this JSON object):
+{
+  "decisions":   [{"slug":"decisions/<kebab>","title":"...","summary":"<2-4 sentences>"}],
+  "insights":    [{"slug":"originals/<kebab>","title":"...","summary":"<user's exact phrasing>"}],
+  "entities":    [{"slug":"people/<kebab>|companies/<kebab>","title":"...","summary":"..."}],
+  "concepts":    [{"slug":"concepts/<kebab>","title":"...","summary":"..."}],
+  "skip_reason": null
+}
+
+Rules:
+- If session is purely operational (only commands, no decisions/insights), return all empty arrays and skip_reason="operational".
+- Capture USER'S exact phrasing in insights — do not paraphrase.
+- Only emit signals worth keeping forever. Skip noise.
+- Slugs MUST be kebab-case, max 60 chars, alphanumeric + hyphens only.
+- Total signals across all categories: at most 8.
+
+Transcript follows after the marker. Output ONLY the JSON object.
+
+=== TRANSCRIPT START ===
+"""
+
+# ─── JSON extraction ─────────────────────────────────────
+def _extract_first_json_object(text: str) -> str | None:
+    start = text.find("{")
+    if start < 0: return None
+    depth = 0; in_string = False; escape = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escape: escape = False
+            elif ch == "\\": escape = True
+            elif ch == '"': in_string = False
+        else:
+            if ch == '"': in_string = True
+            elif ch == "{": depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0: return text[start:i+1]
+    return None
+
+def _parse_extraction(raw_text: str) -> dict:
+    json_text = _extract_first_json_object(raw_text)
+    if not json_text:
+        (HOME / ".gbrain/hooks/last-extraction-raw.txt").write_text(raw_text[:8000])
+        return {"skip_reason": "no_json_object_found", "decisions":[], "insights":[], "entities":[], "concepts":[]}
+    try:
+        return json.loads(json_text)
+    except Exception as e:
+        (HOME / ".gbrain/hooks/last-extraction-raw.txt").write_text(raw_text[:8000])
+        return {"skip_reason": f"parse_error: {e}", "decisions":[], "insights":[], "entities":[], "concepts":[]}
+
+# ─── Auth mode 1: claude CLI (subscription) ──────────────
+def call_via_claude_cli(transcript: str) -> dict:
+    claude_bin = shutil.which("claude")
+    if not claude_bin:
+        return {"skip_reason": "claude_cli_not_found"}
+    full_prompt = f"{SYSTEM_PROMPT}\n\n{EXTRACTION_PROMPT}{transcript}\n=== TRANSCRIPT END ===\n\nNow output the JSON object:"
+    child_env = {**os.environ, "GBRAIN_HOOK_RUNNING": "1"}
+    try:
+        r = subprocess.run(
+            [claude_bin, "-p", "--model", MODEL, full_prompt],
+            env=child_env, capture_output=True, text=True, timeout=180
+        )
+    except subprocess.TimeoutExpired:
+        return {"skip_reason": "claude_cli_timeout"}
+    except Exception as e:
+        return {"skip_reason": f"claude_cli_error: {e}"}
+    if r.returncode != 0:
+        return {"skip_reason": f"claude_cli_exit_{r.returncode}: {(r.stderr or '')[:200]}"}
+    return _parse_extraction(r.stdout)
+
+# ─── Auth mode 2: direct API (fallback) ──────────────────
+def call_via_api(api_key: str, transcript: str) -> dict:
+    body = json.dumps({
+        "model": MODEL, "max_tokens": 2000,
+        "system": SYSTEM_PROMPT,
+        "messages": [{"role":"user","content": EXTRACTION_PROMPT + transcript + "\n=== TRANSCRIPT END ===\n\nNow output the JSON object:"}]
+    }).encode()
+    req = urllib.request.Request("https://api.anthropic.com/v1/messages", data=body,
+        headers={"Content-Type":"application/json","x-api-key":api_key,"anthropic-version":"2023-06-01"})
+    try:
+        resp = urllib.request.urlopen(req, timeout=90).read().decode()
+    except urllib.error.HTTPError as e:
+        return {"skip_reason": f"api_http_{e.code}"}
+    except Exception as e:
+        return {"skip_reason": f"api_net_error: {e}"}
+    text = json.loads(resp)["content"][0]["text"]
+    return _parse_extraction(text)
+
+# ─── Routing: prefer subscription, fall back to API ─────
+def call_extraction(transcript: str, api_key: str | None) -> tuple[dict, str]:
+    """Returns (signals_dict, auth_mode_used)."""
+    cli_result = call_via_claude_cli(transcript)
+    if not cli_result.get("skip_reason"):
+        return cli_result, "claude_cli"
+    cli_skip = cli_result.get("skip_reason", "")
+    if api_key:
+        api_result = call_via_api(api_key, transcript)
+        if not api_result.get("skip_reason"):
+            return api_result, "api"
+        return api_result, "api"
+    return {"skip_reason": f"no_auth ({cli_skip})", "decisions":[], "insights":[], "entities":[], "concepts":[]}, "none"
+
+# ─── GBrain page write ───────────────────────────────────
+SLUG_RE = __import__("re").compile(r"^[a-z0-9][a-z0-9-]*(?:/[a-z0-9][a-z0-9-]*)*$")
+
+WRITE_FAILURES_LOG = HOME / ".gbrain/hooks/write-failures.log"
+
+def _log_write_failure(slug: str, reason: str, stderr: str = "") -> None:
+    try:
+        WRITE_FAILURES_LOG.parent.mkdir(parents=True, exist_ok=True)
+        with WRITE_FAILURES_LOG.open("a") as f:
+            ts = datetime.now(timezone.utc).isoformat(timespec='seconds')
+            f.write(f"{ts}\tslug={slug}\treason={reason}\tstderr={stderr[:300]}\n")
+    except Exception:
+        pass
+
+def _yaml_escape(s: str) -> str:
+    """Quote a string for safe YAML inclusion. Always double-quoted to handle
+    colons, hashes, brackets, leading/trailing whitespace, etc."""
+    s = s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ").replace("\r", "")
+    return f'"{s}"'
+
+def write_to_gbrain(slug: str, title: str, body: str, session_id: str) -> bool:
+    # Pre-validate slug to avoid wasted gbrain CLI invocations
+    if not slug or len(slug) > 120 or "//" in slug or slug.startswith("/") or slug.endswith("/"):
+        _log_write_failure(slug, "slug_invalid_shape")
+        return False
+    if not SLUG_RE.match(slug):
+        _log_write_failure(slug, "slug_invalid_chars")
+        return False
+    if not title or not body:
+        _log_write_failure(slug, "empty_title_or_body")
+        return False
+    page = (
+        f"---\n"
+        f"type: {slug.split('/',1)[0]}\n"
+        f"title: {_yaml_escape(title)}\n"
+        f"source_session: {_yaml_escape(session_id)}\n"
+        f"captured_at: {datetime.now(timezone.utc).isoformat(timespec='seconds')}\n"
+        f"---\n\n{body}\n"
+    )
+    try:
+        r = subprocess.run([GBRAIN_BIN, "put", slug], input=page,
+                           capture_output=True, text=True, timeout=30)
+        if r.returncode == 0:
+            return True
+        _log_write_failure(slug, f"exit_{r.returncode}", r.stderr or r.stdout)
+        return False
+    except subprocess.TimeoutExpired:
+        _log_write_failure(slug, "timeout")
+        return False
+    except Exception as e:
+        _log_write_failure(slug, f"exception: {e}")
+        return False
+
+# ─── Main ────────────────────────────────────────────────
+def main():
+    # Recursion guard: if a child claude -p invocation triggered this hook, bail.
+    if os.environ.get("GBRAIN_HOOK_RUNNING") == "1":
+        return 0
+
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        event = json.loads(sys.stdin.read() or "{}")
+    except Exception:
+        event = {}
+    session_id = event.get("session_id", "unknown")[:36]
+
+    transcript = find_transcript(event)
+    if not transcript:
+        log(f"[skip:{session_id}] no transcript found")
+        return 0
+
+    bytes_size = transcript.stat().st_size
+    if bytes_size < MIN_TRANSCRIPT_BYTES:
+        log(f"[skip:{session_id}] transcript too small ({bytes_size}b)")
+        return 0
+
+    transcript_txt = extract_turns(transcript)
+    if not transcript_txt:
+        log(f"[skip:{session_id}] empty extraction")
+        return 0
+
+    env = load_env_file(ENV_FILE)
+    api_key = os.environ.get("ANTHROPIC_API_KEY") or env.get("ANTHROPIC_API_KEY")
+
+    t0 = time.monotonic()
+    signals, auth_mode = call_extraction(transcript_txt, api_key)
+    extraction_secs = round(time.monotonic() - t0, 1)
+    if signals.get("skip_reason"):
+        log(f"[skip:{session_id}] auth={auth_mode} reason={signals['skip_reason']} ({extraction_secs}s)")
+        return 0
+
+    # Count what Haiku PROPOSED vs what ACTUALLY got written
+    proposed = {cat: len(signals.get(cat) or []) for cat in ("decisions","insights","entities","concepts")}
+    counts = {"decisions":0, "insights":0, "entities":0, "concepts":0}
+    write_failures = 0
+    for cat in ("decisions","insights","entities","concepts"):
+        for item in (signals.get(cat) or []):
+            slug = (item.get("slug") or "").strip()
+            title = (item.get("title") or "").strip()
+            body = (item.get("summary") or "").strip()
+            if not (slug and title and body):
+                continue
+            if write_to_gbrain(slug, title, body, session_id):
+                counts[cat] += 1
+            else:
+                write_failures += 1
+
+    total_proposed = sum(proposed.values())
+    total_written = sum(counts.values())
+
+    # Distinguish: empty extraction (signals=0) vs operational (Haiku said skip) vs error
+    if total_proposed == 0:
+        log(f"[empty:{session_id}] auth={auth_mode} Haiku returned 0 signals ({extraction_secs}s, transcript {bytes_size}b) — likely operational session, or prompt needs tuning. Saved raw to last-extraction-raw.txt")
+        # Save the raw signals we got for debugging
+        try:
+            (HOME / ".gbrain/hooks/last-extraction-raw.txt").write_text(json.dumps(signals, indent=2)[:8000])
+        except Exception:
+            pass
+        return 0
+
+    extra = ""
+    if write_failures:
+        extra = f", {write_failures} write_failures"
+    if total_written < total_proposed:
+        extra += f", proposed={total_proposed}/written={total_written}"
+    log(f"[ok:{session_id}] auth={auth_mode} captured: {counts['decisions']} decisions, {counts['insights']} insights, {counts['entities']} entities, {counts['concepts']} concepts ({extraction_secs}s, transcript {bytes_size}b{extra})")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipes/claude-code-capture/signal-detector.py
+++ b/recipes/claude-code-capture/signal-detector.py
@@ -155,8 +155,29 @@ def _parse_extraction(raw_text: str) -> dict:
         return {"skip_reason": f"parse_error: {e}", "decisions":[], "insights":[], "entities":[], "concepts":[]}
 
 # ─── Auth mode 1: claude CLI (subscription) ──────────────
+def _find_claude_bin() -> str | None:
+    """Find `claude` CLI even if it's not in the spawned hook's PATH.
+    Stop hooks inherit a minimal PATH from Claude Code's launcher, so
+    shutil.which alone misses Homebrew/bun/local installs. We probe the
+    common locations explicitly."""
+    candidates = []
+    via_path = shutil.which("claude")
+    if via_path:
+        candidates.append(via_path)
+    candidates.extend([
+        "/opt/homebrew/bin/claude",      # macOS Apple Silicon Homebrew
+        "/usr/local/bin/claude",          # macOS Intel Homebrew + Linux
+        str(HOME / ".bun/bin/claude"),    # bun install -g
+        str(HOME / ".local/bin/claude"),  # pip --user
+        "/snap/bin/claude",               # Linux snap
+    ])
+    for c in candidates:
+        if c and Path(c).is_file() and os.access(c, os.X_OK):
+            return c
+    return None
+
 def call_via_claude_cli(transcript: str) -> dict:
-    claude_bin = shutil.which("claude")
+    claude_bin = _find_claude_bin()
     if not claude_bin:
         return {"skip_reason": "claude_cli_not_found"}
     full_prompt = f"{SYSTEM_PROMPT}\n\n{EXTRACTION_PROMPT}{transcript}\n=== TRANSCRIPT END ===\n\nNow output the JSON object:"


### PR DESCRIPTION
# PR description (paste when opening PR upstream)

## Summary

Adds a `claude-code-capture` recipe — ambient signal capture from Claude Code
sessions. Mirrors the openclaw `signal-detector` skill pattern, ported to
Claude Code's Stop hook mechanism so end-of-session signals (decisions,
original thinking, entities, concepts) get written to GBrain automatically
without the user having to remember to save anything.

The MCP wiring (already documented in `docs/mcp/CLAUDE_CODE.md`) lets the
model query/write *during* a conversation. This recipe complements that by
catching the rest — implicit knowledge that emerged but no one bothered to
save.

## What's added

- `recipes/claude-code-capture.md` — full recipe with architecture,
  step-by-step setup, troubleshooting, comparison with openclaw signal-detector
- `recipes/claude-code-capture/signal-detector.py` — single-file Python 3
  reference implementation, stdlib only (no `requests`, no `pyyaml`)
- `recipes/claude-code-capture/install.sh` — idempotent installer

## Design highlights

- **Auth picks the cheaper path automatically.** With `claude` CLI available
  (which any Claude Code user already has), runs `claude -p --model
  claude-haiku-4-5` and uses Pro/Max subscription auth → $0 extra. Falls
  back to direct Anthropic API with `ANTHROPIC_API_KEY` for headless
  servers without `claude`. Recursion guard via `GBRAIN_HOOK_RUNNING` env
  var prevents the child `claude -p` invocation from re-firing the hook.
  Probes hardcoded paths (`/opt/homebrew/bin/claude`, `~/.bun/bin/claude`,
  etc.) so the script works even when Stop hooks inherit a minimal PATH.
- **Captures structured signals only**, never the full transcript. Skip
  rules: < 2KB transcripts, operational-only sessions (Haiku flags with
  `skip_reason: "operational"`).
- **Defensive on every failure path.** Slug pre-validation, YAML escape
  for title/session_id (caught a real bug where Haiku-generated titles
  with colons broke frontmatter), per-failure logging to a sidecar
  `write-failures.log` with stderr captured, 0600 perms enforced on all
  log files (API key in `~/gbrain/.env` + transcript fragments warrant
  owner-only).
- **Multi-machine native.** Each node runs its own hook against the same
  shared brain; provenance preserved via `source_session` frontmatter.
- **Async + non-blocking.** Hook configured with `async: true` + 120s
  timeout; user is never made to wait.

## Validation

End-to-end tested across two machines (EC2 server + Mac laptop) sharing the
same Supabase brain:

- 12 signals captured from Mac sessions, all visible from EC2 with
  source_session frontmatter intact
- Auto-fire confirmed with sessions `d773895a-...` and `aeac4708-...`
  (auth=claude_cli, no manual invocation)
- Recursion guard verified (env var → silent exit 0)
- Edge cases: empty stdin, malformed JSON event, non-existent transcript
  path → all graceful, exit 0
- 7 iterations during validation surfaced and fixed: subscription routing,
  empty-result distinction, slug validation, YAML escaping, log perms,
  PATH-inheritance fallback for spawned hooks

## Out of scope (deliberate)

- **Claude Desktop / claude.ai web / mobile / Perplexity capture.** Those
  clients have no Stop-hook mechanism. The companion path (HTTP wrapper
  around `gbrain serve`) referenced in `docs/mcp/DEPLOY.md` would let the
  *model* write to GBrain on demand from those clients via MCP, but
  *automatic* end-of-session capture for them is a separate design
  problem.

## Reference repo with continuous improvements

A mirror of this implementation, with potentially-faster iteration between
upstream releases, lives at https://github.com/durang/gbrain-skill (see
`CAPTURE.md` and `signal-detector.py`).

🤖 Co-authored with Claude Opus 4.7