### PR TITLE
fix: respect openai_api_key from ~/.gbrain/config.json in embed/search paths

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -68,6 +68,27 @@ export function loadConfig(): GBrainConfig | null {
   return merged as GBrainConfig;
 }
 
+/**
+ * Resolve OpenAI API key from env (highest precedence) or config file.
+ * Independent of engine config — works even when no DB is configured.
+ * Returns undefined if neither source provides a key.
+ *
+ * Centralized so embed/query/auto-embed paths use the same precedence and
+ * file-fallback semantics. Without this helper, those paths would only see
+ * env vars, forcing users to shell-export the key (a real UX/security gap on
+ * systems where keys deliberately don't live in interactive shell env).
+ */
+export function getOpenAIKey(): string | undefined {
+  if (process.env.OPENAI_API_KEY) return process.env.OPENAI_API_KEY;
+  try {
+    const raw = readFileSync(getConfigPath(), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<GBrainConfig>;
+    return parsed.openai_api_key;
+  } catch {
+    return undefined;
+  }
+}
+
 export function saveConfig(config: GBrainConfig): void {
   mkdirSync(getConfigDir(), { recursive: true });
   writeFileSync(getConfigPath(), JSON.stringify(config, null, 2) + '\n', { mode: 0o600 });

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -8,6 +8,7 @@
  */
 
 import OpenAI from 'openai';
+import { getOpenAIKey } from './config.ts';
 
 const MODEL = 'text-embedding-3-large';
 const DIMENSIONS = 1536;
@@ -21,7 +22,7 @@ let client: OpenAI | null = null;
 
 function getClient(): OpenAI {
   if (!client) {
-    client = new OpenAI();
+    client = new OpenAI({ apiKey: getOpenAIKey() });
   }
   return client;
 }

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -7,7 +7,7 @@ import { lstatSync, realpathSync } from 'fs';
 import { resolve, relative, sep } from 'path';
 import type { BrainEngine } from './engine.ts';
 import { clampSearchLimit } from './engine.ts';
-import type { GBrainConfig } from './config.ts';
+import { type GBrainConfig, getOpenAIKey } from './config.ts';
 import type { PageType } from './types.ts';
 import { importFromContent } from './import-file.ts';
 import { hybridSearch } from './search/hybrid.ts';
@@ -275,7 +275,7 @@ const put_page: Operation = {
     // try/catch around embed only catches; without a key the OpenAI client would
     // attempt 5 retries with exponential backoff (up to ~2 minutes total) before
     // giving up. Detect early.
-    const noEmbed = !process.env.OPENAI_API_KEY;
+    const noEmbed = !getOpenAIKey();
     const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed });
 
     // Auto-link post-hook: runs AFTER importFromContent (which is its own

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -13,6 +13,7 @@ import type { BrainEngine } from '../engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../engine.ts';
 import type { SearchResult, SearchOpts } from '../types.ts';
 import { embed } from '../embedding.ts';
+import { getOpenAIKey } from '../config.ts';
 import { dedupResults } from './dedup.ts';
 import { autoDetectDetail } from './intent.ts';
 
@@ -78,7 +79,7 @@ export async function hybridSearch(
   const keywordResults = await engine.searchKeyword(query, searchOpts);
 
   // Skip vector search entirely if no OpenAI key is configured
-  if (!process.env.OPENAI_API_KEY) {
+  if (!getOpenAIKey()) {
     // Apply backlink boost in keyword-only path too. One getBacklinkCounts query
     // per search request; not N+1.
     if (keywordResults.length > 0) {


### PR DESCRIPTION
## Summary

`gbrain config set openai_api_key X` writes the key to the engine's config table via `engine.setConfig`, but `embedding.ts:24` instantiates `new OpenAI()` with no args — which only reads `process.env.OPENAI_API_KEY`. Same gap exists in `operations.ts:278` (auto-embed-on-write gate) and `search/hybrid.ts:81` (vector search gate).

Net effect: users who run `gbrain config set openai_api_key sk-...` (or write the key to `~/.gbrain/config.json` directly) hit `"OPENAI_API_KEY environment variable is missing or empty"` errors despite the key being persisted in two places gbrain reasonably reads from. The CLI says success, the embed says missing.

This is a real UX issue on systems that deliberately don't shell-export API keys — NixOS + home-manager, per-process `.env` loading via `python-dotenv`, anywhere least-privilege shell hygiene is the convention.

## Repro

```bash
unset OPENAI_API_KEY
gbrain init --pglite
gbrain config set openai_api_key sk-...
gbrain config get openai_api_key  # ✅ returns the key
echo "test" | gbrain put test-page  # writes ok, but auto-embed silently skipped (operations.ts:278)
gbrain embed --stale  # ❌ fails: "OPENAI_API_KEY environment variable is missing or empty"
gbrain query "test"  # ❌ falls back to keyword-only (hybrid.ts:81)
```

## Fix

Adds `getOpenAIKey()` helper to `core/config.ts` that returns env-first, then falls back to reading `openai_api_key` from `~/.gbrain/config.json` directly (independent of engine config — works even when no DB is configured). Three call sites updated:

| File | Change |
| --- | --- |
| `core/embedding.ts` | `new OpenAI({ apiKey: getOpenAIKey() })` |
| `core/operations.ts:278` | auto-embed gate respects file fallback |
| `core/search/hybrid.ts:81` | vector search gate respects file fallback |

Same env > file precedence that `loadConfig()` already uses for `database_url`.

## Verification

```
$ unset OPENAI_API_KEY
$ # Key is in ~/.gbrain/config.json (mode 0600), nothing in shell env
$ echo "test" | gbrain put test-page  # ✅ auto-embeds (was: silently skipped)
$ gbrain embed --stale                # ✅ works (was: failed)
$ gbrain query "test"                 # ✅ semantic results (was: keyword-only)
```

## Tests

bun test → **2164 pass / 0 fail / 250 skip** (skips are pre-existing env-conditional tests, unrelated). Patch is **+27 / -4 lines**.

```
2164 pass
 250 skip
   0 fail
5599 expect() calls
Ran 2414 tests across 128 files. [74.03s]
```

## Out of scope (possible follow-ups)

- The PGLite-stored copy from `gbrain config set openai_api_key X` is now dead code. A future PR could route bootstrap-key writes (engine, database_url, `*_api_key`, `*_token`) to the file instead of the engine table.
- Adding a `gbrain config unset <key>` command would help users clean up the dead PGLite row left behind by old setups.

## Test plan

- [x] bun test passes
- [x] Manual verification with `unset OPENAI_API_KEY` and key in `~/.gbrain/config.json` only
- [x] `gbrain put` auto-embeds via the patched gate
- [x] `gbrain query` returns semantic (not keyword-only) results
- [x] `gbrain embed --stale` runs without env

🤖 Generated with [Claude Code](https://claude.com/claude-code)