### PR TITLE
fix: sync skills/manifest.json version with package.json (0.10.0 → 0.22.5)

### DIFF
--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "gbrain",
-  "version": "0.10.0",
+  "version": "0.22.5",
   "conformance_version": "1.0.0",
   "description": "Personal knowledge brain with hybrid RAG search \u2014 GStack mod for agent platforms",
   "skills": [


### PR DESCRIPTION
## Summary

- Bump `skills/manifest.json` `version` from `0.10.0` to `0.22.5` to match `package.json`
- No skill-list changes; the `skills` array is already current (includes `frontmatter-guard`)

## Why

`skills/manifest.json` `version` has been pinned at `0.10.0` since v0.10 while `package.json` advanced to v0.22.5. Tools that read the manifest report the wrong version:
- `gbrain check-resolvable` exposes the manifest version
- Downstream skill loaders / agent platforms (OpenClaw, Hermes, Claude.ai with custom MCP) inspect the conformance descriptor
- Anyone diffing `manifest.json` against `package.json` sees a confusing 12-version skew

## Suggested follow-up (separate PR)

To keep these in lockstep automatically, either:
1. Add a CI check that fails when `skills/manifest.json:version` ≠ `package.json:version`, or
2. Have the release script bump both in the same commit

I'm happy to send a follow-up PR for whichever you prefer.

## Test plan

- [x] `cat skills/manifest.json | jq .version` returns `"0.22.5"`
- [x] No other fields changed (diff is one line)
- [x] Skill list unchanged from previous manifest (no behavior delta)

---

Found via /cso security audit on a 31k-page brain. Same audit produced two related issue reports: #485 (`check-backlinks fix [dir]` ignores arg) and #486 (`check-update --json` returns `no_releases`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->