### PR TITLE
docs(frontmatter): document validate single-target pitfall

### DIFF
--- a/skills/frontmatter-guard/SKILL.md
+++ b/skills/frontmatter-guard/SKILL.md
@@ -80,6 +80,14 @@ gbrain frontmatter validate <path> --json
 
 Exit code 0 = clean; 1 = errors found. Use this in CI pipelines or pre-commit hooks.
 
+Important CLI scope pitfall: `gbrain frontmatter validate` is a **single-target** command. Do not pass several file paths in one invocation and assume all were checked; validate a directory, or loop over files one at a time and record each result. In one reviewer run, a multi-path invocation only reported the final target, so the safe pattern is:
+
+```bash
+for f in changed-a.md changed-b.md; do
+  gbrain frontmatter validate "$f" --json
+done
+```
+
 ### Phase 3: Fix
 
 When issues are found:


### PR DESCRIPTION
## Summary
- Documents that `gbrain frontmatter validate` should be treated as a single-target command.
- Adds a safe loop pattern for agents validating multiple changed files.
- Prevents reviewers/agents from silently assuming multiple paths were checked when only one result is reported.

## Test Plan
- `gbrain frontmatter validate skills/frontmatter-guard/SKILL.md --json`
- `gbrain skillpack-check --quiet`
- `bun test test/skills-conformance.test.ts test/resolver.test.ts test/skillpack-sync-guard.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->