### PR TITLE
Fix Korean and non-Latin path slug handling

### DIFF
--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -206,14 +206,17 @@ export function isSyncable(path: string, opts: SyncableOptions = {}): boolean {
 }
 
 /**
- * Slugify a single path segment: lowercase, strip special chars, spaces → hyphens.
+ * Slugify a single path segment: lowercase, strip punctuation, spaces → hyphens.
+ * Unicode letters/numbers are preserved. Otherwise a filename like
+ * `people/<unicode>.md` collapses to `people`, colliding with the parent page.
  */
 export function slugifySegment(segment: string): string {
   return segment
     .normalize('NFD')                     // Decompose accented chars
     .replace(/[\u0300-\u036f]/g, '')      // Strip accent marks
+    .normalize('NFC')                     // Recompose non-Latin scripts decomposed by NFD
     .toLowerCase()
-    .replace(/[^a-z0-9.\s_-]/g, '')      // Keep alphanumeric, dots, spaces, underscores, hyphens
+    .replace(/[^\p{L}\p{N}.\s_-]/gu, '') // Keep Unicode letters/numbers, dots, spaces, underscores, hyphens
     .replace(/[\s]+/g, '-')              // Spaces → hyphens
     .replace(/-+/g, '-')                 // Collapse multiple hyphens
     .replace(/^-|-$/g, '');              // Strip leading/trailing hyphens

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -149,6 +149,27 @@ Content.
     expect(result.slug).toBe('concepts/from-path');
   });
 
+  test('preserves non-ASCII path-derived slug during import', async () => {
+    const filePath = join(TMP, 'unicode-path.md');
+    writeFileSync(filePath, `---
+type: person
+title: Unicode Example
+---
+
+Content.
+`);
+
+    const engine = mockEngine();
+    const result = await importFile(engine, filePath, 'people/\ud55c\uae00-\uc608\uc2dc.md', { noEmbed: true });
+
+    expect(result.status).toBe('imported');
+    expect(result.slug).toBe('people/\ud55c\uae00-\uc608\uc2dc');
+
+    const calls = (engine as any)._calls;
+    const putCall = calls.find((c: any) => c.method === 'putPage');
+    expect(putCall.args[0]).toBe('people/\ud55c\uae00-\uc608\uc2dc');
+  });
+
   test('skips symlinks in importFromFile (defense-in-depth)', async () => {
     // Even if the walker somehow passes a symlink through, importFromFile
     // should catch it and return skipped.

--- a/test/slug-validation.test.ts
+++ b/test/slug-validation.test.ts
@@ -51,6 +51,11 @@ describe('slugifySegment', () => {
   test('handles curly quotes and ellipsis', () => {
     expect(slugifySegment('she\u2026said \u201chello\u201d')).toBe('shesaid-hello');
   });
+
+  test('preserves non-ASCII letters instead of collapsing segment', () => {
+    expect(slugifySegment('\ud55c\uae00-\uc608\uc2dc')).toBe('\ud55c\uae00-\uc608\uc2dc');
+    expect(slugifySegment('\u65e5\u672c\u8a9e\u30c6\u30b9\u30c8')).toBe('\u65e5\u672c\u8a9e\u30c6\u30b9\u30c8');
+  });
 });
 
 describe('slugifyPath', () => {
@@ -81,6 +86,11 @@ describe('slugifyPath', () => {
 
   test('filters empty segments from all-special-chars dirs', () => {
     expect(slugifyPath('!!!/file.md')).toBe('file');
+  });
+
+  test('preserves non-ASCII filename segments to avoid parent-slug collisions', () => {
+    expect(slugifyPath('people/\ud55c\uae00-\uc608\uc2dc.md')).toBe('people/\ud55c\uae00-\uc608\uc2dc');
+    expect(slugifyPath('notes/\u65e5\u672c\u8a9e\u30c6\u30b9\u30c8.md')).toBe('notes/\u65e5\u672c\u8a9e\u30c6\u30b9\u30c8');
   });
 
   test('preserves dots in filenames', () => {

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -147,6 +147,11 @@ describe('pathToSlug', () => {
   test('strips special characters', () => {
     expect(pathToSlug('notes/meeting (march 2024).md')).toBe('notes/meeting-march-2024');
   });
+
+  test('preserves non-ASCII filename segments instead of collapsing to parent slug', () => {
+    expect(pathToSlug('people/\ud55c\uae00-\uc608\uc2dc.md')).toBe('people/\ud55c\uae00-\uc608\uc2dc');
+    expect(pathToSlug('people/\ub2e4\ub978-\uc608\uc2dc.md')).toBe('people/\ub2e4\ub978-\uc608\uc2dc');
+  });
 });
 
 describe('isSyncable edge cases', () => {


### PR DESCRIPTION
## Problem
Korean entity pages stored as Markdown files can currently lose their filename-derived slug during sync/import.

For example, a path like `people/<korean-name>.md` is slugified segment-by-segment. The current path slugifier strips every character outside ASCII `[a-z0-9]`, so the Korean filename segment becomes empty and the final slug collapses to just `people`.

That creates two concrete problems:
- direct lookup for the page-specific slug fails because the page was not indexed under `people/<korean-name>`
- multiple Korean filenames under the same directory can collide on the same parent slug, e.g. `people`

The bug is not Korean-specific in implementation; it affects non-Latin filename segments generally. The motivating case here is Korean person/entity pages.

## Fix
- Preserve Unicode letters/numbers when deriving slugs from path segments
- Recompose decomposed Unicode after accent stripping so Korean and other non-Latin filenames do not collapse to their parent path slug
- Add regression coverage for slug validation, path-to-slug sync behavior, and import path-derived slugs

## Tests
- `bun test test/import-file.test.ts test/slug-validation.test.ts test/sync.test.ts`
- `git diff HEAD~1..HEAD --check`
