### PR TITLE
fix: point init's soul-audit hint at the /soul-audit skill

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -377,6 +377,6 @@ export function reportModStatus(): void {
     console.log('  cd ~/.claude/skills/gstack && ./setup');
   }
   console.log('Resolver: skills/RESOLVER.md');
-  console.log('Soul audit: run `gbrain soul-audit` to customize agent identity');
+  console.log('Soul audit: run the skill `/soul-audit` to customize agent identity');
   console.log('');
 }


### PR DESCRIPTION
## Summary

`gbrain init`'s post-install hint currently tells users to run `gbrain soul-audit`, but no such subcommand exists in `src/cli.ts`. The soul-audit workflow ships as a skill at `skills/soul-audit/SKILL.md`, not a CLI command. Anyone who copy-pasted the hint hit `unknown command`.

This PR updates the one-line message in `src/commands/init.ts:380` to point at the `/soul-audit` skill instead.

## What changed

```diff
- console.log('Soul audit: run `gbrain soul-audit` to customize agent identity');
+ console.log('Soul audit: run the skill `/soul-audit` to customize agent identity');
```

## Test plan

- [x] `grep -n "soul-audit\|soul_audit" src/cli.ts` confirms no CLI subcommand exists
- [x] `ls skills/soul-audit/SKILL.md` confirms the skill is the actual entry point
- [x] Run `gbrain init` in a fresh dir and confirm the new hint renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->