### PR TITLE
fix(search): composite ts_rank + chunk_index picker for keyword search representative

### DIFF
--- a/docs/eval-artifacts/eval-baseline.json
+++ b/docs/eval-artifacts/eval-baseline.json
@@ -1,0 +1,346 @@
+{
+  "run_at": "2026-04-28T13:54:08.190Z",
+  "corpus": "5 ML textbooks (2872 chunks) embedded in GBrain (Supabase+pgvector+text-embedding-3-small)",
+  "elapsed_sec": 77.9,
+  "aggregate": {
+    "questions": 20,
+    "mean_ndcg5": 0.7012522984129118,
+    "mean_recall10": 0.8,
+    "mean_mrr": 0.6833333333333333,
+    "mean_marker_hits_top10": 0.05,
+    "top1_hits": 12,
+    "any_hit": 16,
+    "misses": 4
+  },
+  "per_question": [
+    {
+      "id": "q01",
+      "expected_book": "books/murphy-probabilistic-perspective",
+      "metrics": {
+        "mrr": 0,
+        "recall10": 0,
+        "ndcg5": 0,
+        "firstRelIdx": -1,
+        "numRelInTop10": 0,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "geron-hands-on-ml",
+        "murphy-probabilistic-advanced",
+        "bishop-prml"
+      ]
+    },
+    {
+      "id": "q02",
+      "expected_book": "books/murphy-probabilistic-perspective",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q03",
+      "expected_book": "books/murphy-probabilistic-perspective",
+      "metrics": {
+        "mrr": 0.5,
+        "recall10": 1,
+        "ndcg5": 0.6309297535714575,
+        "firstRelIdx": 1,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q04",
+      "expected_book": "books/murphy-probabilistic-perspective",
+      "metrics": {
+        "mrr": 0.3333333333333333,
+        "recall10": 1,
+        "ndcg5": 0.5,
+        "firstRelIdx": 2,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced",
+        "bishop-prml",
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q05",
+      "expected_book": "books/bishop-prml",
+      "metrics": {
+        "mrr": 0.3333333333333333,
+        "recall10": 1,
+        "ndcg5": 0.5,
+        "firstRelIdx": 2,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced",
+        "geron-hands-on-ml",
+        "bishop-prml"
+      ]
+    },
+    {
+      "id": "q06",
+      "expected_book": "books/bishop-prml",
+      "metrics": {
+        "mrr": 0,
+        "recall10": 0,
+        "ndcg5": 0,
+        "firstRelIdx": -1,
+        "numRelInTop10": 0,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q07",
+      "expected_book": "books/bishop-prml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "bishop-prml",
+        "murphy-probabilistic-perspective",
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q08",
+      "expected_book": "books/bishop-prml",
+      "metrics": {
+        "mrr": 0.5,
+        "recall10": 1,
+        "ndcg5": 0.6240505200038379,
+        "firstRelIdx": 1,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced",
+        "bishop-prml",
+        "murphy-probabilistic-perspective",
+        "murphy-probabilistic-perspective-toc",
+        "bishop-prml-toc"
+      ]
+    },
+    {
+      "id": "q09",
+      "expected_book": "books/murphy-probabilistic-advanced",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q10",
+      "expected_book": "books/murphy-probabilistic-advanced",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced",
+        "bishop-prml",
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q11",
+      "expected_book": "books/murphy-probabilistic-advanced",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 0.9197207891481876,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced",
+        "geron-hands-on-ml",
+        "murphy-probabilistic-advanced-toc",
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q12",
+      "expected_book": "books/murphy-probabilistic-advanced",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced",
+        "bishop-prml",
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q13",
+      "expected_book": "books/huyen-designing-ml-systems",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 0.8503449055347546,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "huyen-designing-ml-systems",
+        "murphy-probabilistic-advanced",
+        "geron-hands-on-ml",
+        "bishop-prml",
+        "huyen-designing-ml-systems-toc"
+      ]
+    },
+    {
+      "id": "q14",
+      "expected_book": "books/huyen-designing-ml-systems",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "huyen-designing-ml-systems",
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q15",
+      "expected_book": "books/huyen-designing-ml-systems",
+      "metrics": {
+        "mrr": 0,
+        "recall10": 0,
+        "ndcg5": 0,
+        "firstRelIdx": -1,
+        "numRelInTop10": 0,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": []
+    },
+    {
+      "id": "q16",
+      "expected_book": "books/huyen-designing-ml-systems",
+      "metrics": {
+        "mrr": 0,
+        "recall10": 0,
+        "ndcg5": 0,
+        "firstRelIdx": -1,
+        "numRelInTop10": 0,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-perspective",
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q17",
+      "expected_book": "books/geron-hands-on-ml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "geron-hands-on-ml"
+      ]
+    },
+    {
+      "id": "q18",
+      "expected_book": "books/geron-hands-on-ml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "geron-hands-on-ml",
+        "murphy-probabilistic-perspective",
+        "huyen-designing-ml-systems"
+      ]
+    },
+    {
+      "id": "q19",
+      "expected_book": "books/geron-hands-on-ml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 1
+      },
+      "top5_slugs": [
+        "geron-hands-on-ml",
+        "huyen-designing-ml-systems"
+      ]
+    },
+    {
+      "id": "q20",
+      "expected_book": "books/geron-hands-on-ml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "geron-hands-on-ml",
+        "murphy-probabilistic-advanced"
+      ]
+    }
+  ]
+}

--- a/docs/eval-artifacts/eval-v1-pure-tsrank.json
+++ b/docs/eval-artifacts/eval-v1-pure-tsrank.json
@@ -1,0 +1,381 @@
+{
+  "run_at": "2026-04-28T14:56:27.190Z",
+  "corpus": "5 ML textbooks (2872 chunks) embedded in GBrain (Supabase+pgvector+text-embedding-3-small)",
+  "elapsed_sec": 184,
+  "aggregate": {
+    "questions": 20,
+    "mean_ndcg5": 0.7692407738527927,
+    "mean_recall10": 0.95,
+    "mean_mrr": 0.7291666666666666,
+    "mean_marker_hits_top10": 0.65,
+    "top1_hits": 11,
+    "any_hit": 19,
+    "misses": 1
+  },
+  "per_question": [
+    {
+      "id": "q01",
+      "expected_book": "books/murphy-probabilistic-perspective",
+      "metrics": {
+        "mrr": 0.3333333333333333,
+        "recall10": 1,
+        "ndcg5": 0.5437713091520254,
+        "firstRelIdx": 2,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 1
+      },
+      "top5_slugs": [
+        "bishop-prml",
+        "bishop-prml",
+        "murphy-probabilistic-perspective",
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q02",
+      "expected_book": "books/murphy-probabilistic-perspective",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-perspective",
+        "murphy-probabilistic-perspective",
+        "murphy-probabilistic-advanced",
+        "huyen-designing-ml-systems",
+        "huyen-designing-ml-systems"
+      ]
+    },
+    {
+      "id": "q03",
+      "expected_book": "books/murphy-probabilistic-perspective",
+      "metrics": {
+        "mrr": 0.5,
+        "recall10": 1,
+        "ndcg5": 0.6309297535714575,
+        "firstRelIdx": 1,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-perspective",
+        "murphy-probabilistic-advanced",
+        "bishop-prml",
+        "bishop-prml"
+      ]
+    },
+    {
+      "id": "q04",
+      "expected_book": "books/murphy-probabilistic-perspective",
+      "metrics": {
+        "mrr": 0,
+        "recall10": 0,
+        "ndcg5": 0,
+        "firstRelIdx": -1,
+        "numRelInTop10": 0,
+        "markerHitsTop10": 2
+      },
+      "top5_slugs": [
+        "geron-hands-on-ml",
+        "murphy-probabilistic-advanced",
+        "bishop-prml",
+        "geron-hands-on-ml",
+        "bishop-prml"
+      ]
+    },
+    {
+      "id": "q05",
+      "expected_book": "books/bishop-prml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 0.8772153153380493,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "bishop-prml",
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-perspective",
+        "bishop-prml",
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q06",
+      "expected_book": "books/bishop-prml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "bishop-prml",
+        "bishop-prml",
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q07",
+      "expected_book": "books/bishop-prml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 0.8772153153380493,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 2
+      },
+      "top5_slugs": [
+        "bishop-prml",
+        "geron-hands-on-ml",
+        "murphy-probabilistic-advanced",
+        "bishop-prml",
+        "geron-hands-on-ml"
+      ]
+    },
+    {
+      "id": "q08",
+      "expected_book": "books/bishop-prml",
+      "metrics": {
+        "mrr": 0.5,
+        "recall10": 1,
+        "ndcg5": 0.5307212739772434,
+        "firstRelIdx": 1,
+        "numRelInTop10": 3,
+        "markerHitsTop10": 1
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-perspective-toc",
+        "bishop-prml-toc",
+        "bishop-prml",
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q09",
+      "expected_book": "books/murphy-probabilistic-advanced",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q10",
+      "expected_book": "books/murphy-probabilistic-advanced",
+      "metrics": {
+        "mrr": 0.5,
+        "recall10": 1,
+        "ndcg5": 0.6934264036172708,
+        "firstRelIdx": 1,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-perspective",
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q11",
+      "expected_book": "books/murphy-probabilistic-advanced",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 0.9674679834891693,
+        "firstRelIdx": 0,
+        "numRelInTop10": 3,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced-toc",
+        "murphy-probabilistic-advanced",
+        "geron-hands-on-ml",
+        "murphy-probabilistic-advanced",
+        "geron-hands-on-ml"
+      ]
+    },
+    {
+      "id": "q12",
+      "expected_book": "books/murphy-probabilistic-advanced",
+      "metrics": {
+        "mrr": 0.25,
+        "recall10": 1,
+        "ndcg5": 0.2640681225725909,
+        "firstRelIdx": 3,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 2
+      },
+      "top5_slugs": [
+        "bishop-prml",
+        "murphy-probabilistic-perspective",
+        "bishop-prml",
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q13",
+      "expected_book": "books/huyen-designing-ml-systems",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 3,
+        "markerHitsTop10": 1
+      },
+      "top5_slugs": [
+        "huyen-designing-ml-systems-toc",
+        "huyen-designing-ml-systems",
+        "huyen-designing-ml-systems",
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q14",
+      "expected_book": "books/huyen-designing-ml-systems",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "huyen-designing-ml-systems",
+        "huyen-designing-ml-systems",
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q15",
+      "expected_book": "books/huyen-designing-ml-systems",
+      "metrics": {
+        "mrr": 0.5,
+        "recall10": 1,
+        "ndcg5": 0.6934264036172708,
+        "firstRelIdx": 1,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "reports/diagnostics/2026-04-28-chunk-collapse",
+        "huyen-designing-ml-systems",
+        "huyen-designing-ml-systems"
+      ]
+    },
+    {
+      "id": "q16",
+      "expected_book": "books/huyen-designing-ml-systems",
+      "metrics": {
+        "mrr": 0.5,
+        "recall10": 1,
+        "ndcg5": 0.6934264036172708,
+        "firstRelIdx": 1,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 1
+      },
+      "top5_slugs": [
+        "reports/diagnostics/2026-04-28-chunk-collapse",
+        "huyen-designing-ml-systems",
+        "huyen-designing-ml-systems",
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q17",
+      "expected_book": "books/geron-hands-on-ml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 1
+      },
+      "top5_slugs": [
+        "geron-hands-on-ml",
+        "geron-hands-on-ml"
+      ]
+    },
+    {
+      "id": "q18",
+      "expected_book": "books/geron-hands-on-ml",
+      "metrics": {
+        "mrr": 0.5,
+        "recall10": 1,
+        "ndcg5": 0.6934264036172708,
+        "firstRelIdx": 1,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 2
+      },
+      "top5_slugs": [
+        "huyen-designing-ml-systems",
+        "geron-hands-on-ml",
+        "geron-hands-on-ml",
+        "murphy-probabilistic-perspective",
+        "huyen-designing-ml-systems"
+      ]
+    },
+    {
+      "id": "q19",
+      "expected_book": "books/geron-hands-on-ml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "geron-hands-on-ml",
+        "geron-hands-on-ml"
+      ]
+    },
+    {
+      "id": "q20",
+      "expected_book": "books/geron-hands-on-ml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 0.9197207891481876,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "geron-hands-on-ml",
+        "murphy-probabilistic-advanced",
+        "geron-hands-on-ml",
+        "huyen-designing-ml-systems",
+        "murphy-probabilistic-advanced"
+      ]
+    }
+  ]
+}

--- a/docs/eval-artifacts/eval-v2-composite.json
+++ b/docs/eval-artifacts/eval-v2-composite.json
@@ -1,0 +1,382 @@
+{
+  "run_at": "2026-04-28T15:08:15.394Z",
+  "corpus": "5 ML textbooks (2872 chunks) embedded in GBrain (Supabase+pgvector+text-embedding-3-small)",
+  "elapsed_sec": 172.4,
+  "aggregate": {
+    "questions": 20,
+    "mean_ndcg5": 0.7980571706243346,
+    "mean_recall10": 1,
+    "mean_mrr": 0.7625,
+    "mean_marker_hits_top10": 0.6,
+    "top1_hits": 12,
+    "any_hit": 20,
+    "misses": 0
+  },
+  "per_question": [
+    {
+      "id": "q01",
+      "expected_book": "books/murphy-probabilistic-perspective",
+      "metrics": {
+        "mrr": 0.3333333333333333,
+        "recall10": 1,
+        "ndcg5": 0.5706417189553201,
+        "firstRelIdx": 2,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 1
+      },
+      "top5_slugs": [
+        "bishop-prml",
+        "bishop-prml",
+        "murphy-probabilistic-perspective",
+        "murphy-probabilistic-perspective",
+        "geron-hands-on-ml"
+      ]
+    },
+    {
+      "id": "q02",
+      "expected_book": "books/murphy-probabilistic-perspective",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-perspective",
+        "murphy-probabilistic-perspective",
+        "murphy-probabilistic-advanced",
+        "huyen-designing-ml-systems",
+        "huyen-designing-ml-systems"
+      ]
+    },
+    {
+      "id": "q03",
+      "expected_book": "books/murphy-probabilistic-perspective",
+      "metrics": {
+        "mrr": 0.5,
+        "recall10": 1,
+        "ndcg5": 0.6309297535714575,
+        "firstRelIdx": 1,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-perspective",
+        "murphy-probabilistic-advanced",
+        "bishop-prml",
+        "bishop-prml"
+      ]
+    },
+    {
+      "id": "q04",
+      "expected_book": "books/murphy-probabilistic-perspective",
+      "metrics": {
+        "mrr": 0.16666666666666666,
+        "recall10": 1,
+        "ndcg5": 0,
+        "firstRelIdx": 5,
+        "numRelInTop10": 1,
+        "markerHitsTop10": 1
+      },
+      "top5_slugs": [
+        "geron-hands-on-ml",
+        "murphy-probabilistic-advanced",
+        "geron-hands-on-ml",
+        "bishop-prml",
+        "bishop-prml"
+      ]
+    },
+    {
+      "id": "q05",
+      "expected_book": "books/bishop-prml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 0.8772153153380493,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "bishop-prml",
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-perspective",
+        "bishop-prml",
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q06",
+      "expected_book": "books/bishop-prml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "bishop-prml",
+        "bishop-prml",
+        "murphy-probabilistic-perspective",
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q07",
+      "expected_book": "books/bishop-prml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 2
+      },
+      "top5_slugs": [
+        "bishop-prml",
+        "bishop-prml",
+        "geron-hands-on-ml",
+        "murphy-probabilistic-advanced",
+        "geron-hands-on-ml"
+      ]
+    },
+    {
+      "id": "q08",
+      "expected_book": "books/bishop-prml",
+      "metrics": {
+        "mrr": 0.5,
+        "recall10": 1,
+        "ndcg5": 0.7122630665145961,
+        "firstRelIdx": 1,
+        "numRelInTop10": 3,
+        "markerHitsTop10": 1
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-perspective-toc",
+        "bishop-prml-toc",
+        "bishop-prml",
+        "murphy-probabilistic-perspective",
+        "bishop-prml"
+      ]
+    },
+    {
+      "id": "q09",
+      "expected_book": "books/murphy-probabilistic-advanced",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q10",
+      "expected_book": "books/murphy-probabilistic-advanced",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-advanced",
+        "geron-hands-on-ml",
+        "bishop-prml"
+      ]
+    },
+    {
+      "id": "q11",
+      "expected_book": "books/murphy-probabilistic-advanced",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 0.9060254355346823,
+        "firstRelIdx": 0,
+        "numRelInTop10": 3,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "murphy-probabilistic-advanced-toc",
+        "geron-hands-on-ml",
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-advanced",
+        "geron-hands-on-ml"
+      ]
+    },
+    {
+      "id": "q12",
+      "expected_book": "books/murphy-probabilistic-advanced",
+      "metrics": {
+        "mrr": 0.25,
+        "recall10": 1,
+        "ndcg5": 0.2640681225725909,
+        "firstRelIdx": 3,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 2
+      },
+      "top5_slugs": [
+        "bishop-prml",
+        "murphy-probabilistic-perspective",
+        "bishop-prml",
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q13",
+      "expected_book": "books/huyen-designing-ml-systems",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 3,
+        "markerHitsTop10": 1
+      },
+      "top5_slugs": [
+        "huyen-designing-ml-systems-toc",
+        "huyen-designing-ml-systems",
+        "huyen-designing-ml-systems",
+        "murphy-probabilistic-advanced",
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q14",
+      "expected_book": "books/huyen-designing-ml-systems",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "huyen-designing-ml-systems",
+        "huyen-designing-ml-systems",
+        "murphy-probabilistic-advanced"
+      ]
+    },
+    {
+      "id": "q15",
+      "expected_book": "books/huyen-designing-ml-systems",
+      "metrics": {
+        "mrr": 0.5,
+        "recall10": 1,
+        "ndcg5": 0.6934264036172708,
+        "firstRelIdx": 1,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "reports/diagnostics/2026-04-28-chunk-collapse",
+        "huyen-designing-ml-systems",
+        "huyen-designing-ml-systems"
+      ]
+    },
+    {
+      "id": "q16",
+      "expected_book": "books/huyen-designing-ml-systems",
+      "metrics": {
+        "mrr": 0.5,
+        "recall10": 1,
+        "ndcg5": 0.6934264036172708,
+        "firstRelIdx": 1,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 1
+      },
+      "top5_slugs": [
+        "reports/diagnostics/2026-04-28-chunk-collapse",
+        "huyen-designing-ml-systems",
+        "huyen-designing-ml-systems",
+        "murphy-probabilistic-advanced",
+        "geron-hands-on-ml"
+      ]
+    },
+    {
+      "id": "q17",
+      "expected_book": "books/geron-hands-on-ml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 1
+      },
+      "top5_slugs": [
+        "geron-hands-on-ml",
+        "geron-hands-on-ml"
+      ]
+    },
+    {
+      "id": "q18",
+      "expected_book": "books/geron-hands-on-ml",
+      "metrics": {
+        "mrr": 0.5,
+        "recall10": 1,
+        "ndcg5": 0.6934264036172708,
+        "firstRelIdx": 1,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 2
+      },
+      "top5_slugs": [
+        "huyen-designing-ml-systems",
+        "geron-hands-on-ml",
+        "geron-hands-on-ml",
+        "huyen-designing-ml-systems",
+        "murphy-probabilistic-perspective"
+      ]
+    },
+    {
+      "id": "q19",
+      "expected_book": "books/geron-hands-on-ml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 1,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "geron-hands-on-ml",
+        "geron-hands-on-ml"
+      ]
+    },
+    {
+      "id": "q20",
+      "expected_book": "books/geron-hands-on-ml",
+      "metrics": {
+        "mrr": 1,
+        "recall10": 1,
+        "ndcg5": 0.9197207891481876,
+        "firstRelIdx": 0,
+        "numRelInTop10": 2,
+        "markerHitsTop10": 0
+      },
+      "top5_slugs": [
+        "geron-hands-on-ml",
+        "murphy-probabilistic-advanced",
+        "geron-hands-on-ml",
+        "huyen-designing-ml-systems",
+        "murphy-probabilistic-advanced"
+      ]
+    }
+  ]
+}

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -455,7 +455,7 @@ export class PostgresEngine implements BrainEngine {
       best_per_page AS (
         SELECT DISTINCT ON (slug) *
         FROM ranked_chunks
-        ORDER BY slug, score DESC
+        ORDER BY slug, (0.6 * score + 0.4 / (chunk_index + 1)) DESC
       )
       SELECT slug, page_id, title, type, source_id,
         chunk_id, chunk_index, chunk_text, chunk_source, score,


### PR DESCRIPTION
## Summary

Front-matter chunks (`chunk_index=0`, often a document title or table of contents) win the `searchKeyword` per-slug picker when their `tsquery` match score is high enough, even when chapter content on the same page is the right answer. This PR replaces the `best_per_page` ORDER BY with a composite formula:

```sql
ORDER BY slug, (0.6 * score + 0.4 / (chunk_index + 1)) DESC
```

so chapter chunks with strong `ts_rank` matches outrank front-matter, while front-matter still wins ties when no chunk strongly matches.

## Eval (sanitized JSONs in `docs/eval-artifacts/`)

| Metric | baseline | v1 pure ts_rank | **v2 composite (this PR)** |
|---|---|---|---|
| NDCG@5 | 0.7013 | 0.7692 | **0.7981** |
| Recall@10 | 0.80 | 0.95 | **1.00** |
| Misses | 4/20 | 1/20 | **0/20** |

Per-question chunk-collapse misses (q01, q06, q15, q16) all recover. The artifacts are sanitized (slug-only top-5, no chunk text, no question text) to avoid leaking copyrighted textbook excerpts from the eval corpus.

## Caveats — please read before merging

1. **Eval was run against v0.14.2 page-grain code path**, not master's v0.20.0+ chunk-grain code. The fix is transplanted to master's `best_per_page` CTE because the bug shape is the same (DISTINCT-ON picker), but master's `WHERE cc.search_vector @@ tsquery` filter likely makes the bug milder here. Maintainer should confirm by running the eval on master with this branch.
2. **Three queries lose top-1 rank** (q04 multinomial logistic regression, q12 Gaussian process regression, q18 gradient boosting). Recall is preserved, but a different page wins top-1 because the new representative chunk's embedding changes `hybrid.ts` `cosineReScore` blend output. This is downstream of the picker and is its own investigation — flagging for follow-up, not addressed here.
3. **Tuning constants (0.6 / 0.4) are heuristic.** Open to alternatives: tune, expose as a knob, or drop the chunk_index fallback entirely.

## Test plan

- [x] `bun test test/search.test.ts test/postgres-engine.test.ts test/search-limit.test.ts test/dedup.test.ts` — 57/57 search-suite passing on the v0.14.2 base where the eval was run. Master tests not yet run on this branch.
- [ ] Maintainer to run full `bun test` on master with this branch
- [ ] Maintainer to run RAG eval on master and confirm metrics
- [ ] Maintainer judgment on tuning constants and whether `cosineReScore` in `hybrid.ts` needs a paired change for the q04/q12/q18 ranking flips

Filed as **draft** — explicit ack from maintainer needed before this is ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->