### PR TITLE
feat: add global JSON output flag

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,7 @@ async function main() {
   // BEFORE command dispatch, so `gbrain --progress-json doctor` works.
   // The stripped argv is what the command sees.
   const rawArgs = process.argv.slice(2);
-  const { cliOpts, rest: args } = parseGlobalFlags(rawArgs);
+  const { cliOpts, rest: args } = parseGlobalFlags(rawArgs, { jsonPassThroughCommands: CLI_ONLY });
   setCliOptions(cliOpts);
 
   let command = args[0];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,7 +94,9 @@ async function main() {
 
     const ctx = makeContext(engine, params);
     const result = await op.handler(ctx, params);
-    const output = formatResult(op.name, result);
+    const output = getCliOptions().json
+      ? JSON.stringify(result, null, 2) + '\n'
+      : formatResult(op.name, result);
     if (output) process.stdout.write(output);
   } catch (e: unknown) {
     if (e instanceof OperationError) {
@@ -618,7 +620,12 @@ function printHelp() {
   console.log(`gbrain ${VERSION} -- personal knowledge brain
 
 USAGE
-  gbrain <command> [options]
+  gbrain [--json] <command> [options]
+
+GLOBAL OPTIONS
+  --json                             Emit raw JSON for shared operation commands
+  --quiet                            Suppress non-essential output
+  --progress-json                    Emit progress events as JSON
 
 SETUP
   init [--pglite|--supabase|--url]   Create brain (PGLite default, no server)

--- a/src/core/cli-options.ts
+++ b/src/core/cli-options.ts
@@ -15,12 +15,14 @@ export interface CliOptions {
   quiet: boolean;
   progressJson: boolean;
   progressInterval: number; // ms
+  json: boolean;
 }
 
 export const DEFAULT_CLI_OPTIONS: CliOptions = {
   quiet: false,
   progressJson: false,
   progressInterval: 1000,
+  json: false,
 };
 
 /**
@@ -29,6 +31,7 @@ export const DEFAULT_CLI_OPTIONS: CliOptions = {
  *
  * Recognized:
  *   --quiet
+ *   --json
  *   --progress-json
  *   --progress-interval=<ms>
  *   --progress-interval <ms>   (space-separated form)
@@ -43,6 +46,14 @@ export function parseGlobalFlags(argv: string[]): { cliOpts: CliOptions; rest: s
     const a = argv[i];
     if (a === '--quiet') {
       cliOpts.quiet = true;
+      continue;
+    }
+    if (a === '--json') {
+      if (rest.length === 0) {
+        cliOpts.json = true;
+        continue;
+      }
+      rest.push(a);
       continue;
     }
     if (a === '--progress-json') {

--- a/src/core/cli-options.ts
+++ b/src/core/cli-options.ts
@@ -38,9 +38,20 @@ export const DEFAULT_CLI_OPTIONS: CliOptions = {
  *
  * Unknown flags are passed through unchanged — per-command parsers see them.
  */
-export function parseGlobalFlags(argv: string[]): { cliOpts: CliOptions; rest: string[] } {
+export interface ParseGlobalFlagsOptions {
+  /**
+   * Commands that own their own command-local `--json` parser. When `--json`
+   * appears after one of these command tokens, keep it in `rest` so the command
+   * can preserve its existing CLI contract. `--json` before the command remains
+   * a top-level global flag.
+   */
+  jsonPassThroughCommands?: ReadonlySet<string>;
+}
+
+export function parseGlobalFlags(argv: string[], options: ParseGlobalFlagsOptions = {}): { cliOpts: CliOptions; rest: string[] } {
   const cliOpts: CliOptions = { ...DEFAULT_CLI_OPTIONS };
   const rest: string[] = [];
+  let command: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -49,11 +60,11 @@ export function parseGlobalFlags(argv: string[]): { cliOpts: CliOptions; rest: s
       continue;
     }
     if (a === '--json') {
-      if (rest.length === 0) {
+      if (command && options.jsonPassThroughCommands?.has(command)) {
+        rest.push(a);
+      } else {
         cliOpts.json = true;
-        continue;
       }
-      rest.push(a);
       continue;
     }
     if (a === '--progress-json') {
@@ -69,6 +80,7 @@ export function parseGlobalFlags(argv: string[]): { cliOpts: CliOptions; rest: s
         continue;
       }
       // not a number — let per-command parser handle; pass through
+      if (!command && !a.startsWith('-')) command = a;
       rest.push(a);
       continue;
     }
@@ -82,6 +94,7 @@ export function parseGlobalFlags(argv: string[]): { cliOpts: CliOptions; rest: s
       rest.push(a);
       continue;
     }
+    if (!command && !a.startsWith('-')) command = a;
     rest.push(a);
   }
 

--- a/test/cli-options.test.ts
+++ b/test/cli-options.test.ts
@@ -57,15 +57,27 @@ describe('parseGlobalFlags', () => {
     expect(r.rest).toContain('--progress-interval=-1');
   });
 
+  test('strips --json before the command and sets json=true', () => {
+    const r = parseGlobalFlags(['--json', 'search', 'ADU permit']);
+    expect(r.cliOpts.json).toBe(true);
+    expect(r.rest).toEqual(['search', 'ADU permit']);
+  });
+
+  test('keeps command-local --json after the command', () => {
+    const r = parseGlobalFlags(['check-resolvable', '--skills-dir', './skills', '--json']);
+    expect(r.cliOpts.json).toBe(false);
+    expect(r.rest).toEqual(['check-resolvable', '--skills-dir', './skills', '--json']);
+  });
+
   test('unknown flags pass through unchanged', () => {
-    const r = parseGlobalFlags(['doctor', '--fast', '--json', '--foo=bar']);
-    expect(r.rest).toEqual(['doctor', '--fast', '--json', '--foo=bar']);
+    const r = parseGlobalFlags(['doctor', '--fast', '--foo=bar']);
+    expect(r.rest).toEqual(['doctor', '--fast', '--foo=bar']);
     expect(r.cliOpts).toEqual(DEFAULT_CLI_OPTIONS);
   });
 
   test('all global flags combined', () => {
-    const r = parseGlobalFlags(['--quiet', '--progress-json', '--progress-interval=250', 'sync']);
-    expect(r.cliOpts).toEqual({ quiet: true, progressJson: true, progressInterval: 250 });
+    const r = parseGlobalFlags(['--quiet', '--json', '--progress-json', '--progress-interval=250', 'sync']);
+    expect(r.cliOpts).toEqual({ quiet: true, json: true, progressJson: true, progressInterval: 250 });
     expect(r.rest).toEqual(['sync']);
   });
 });
@@ -78,7 +90,7 @@ describe('getCliOptions / setCliOptions singleton', () => {
 
   test('setCliOptions applies + getCliOptions returns a copy', () => {
     _resetCliOptionsForTest();
-    setCliOptions({ quiet: false, progressJson: true, progressInterval: 250 });
+    setCliOptions({ quiet: false, json: false, progressJson: true, progressInterval: 250 });
     expect(getCliOptions().progressJson).toBe(true);
     expect(getCliOptions().progressInterval).toBe(250);
   });
@@ -138,12 +150,12 @@ describe('CLI integration: progress streams to the right channel', () => {
 
 describe('cliOptsToProgressOptions', () => {
   test('--quiet → quiet mode', () => {
-    const opts = cliOptsToProgressOptions({ quiet: true, progressJson: false, progressInterval: 1000 });
+    const opts = cliOptsToProgressOptions({ quiet: true, json: false, progressJson: false, progressInterval: 1000 });
     expect(opts.mode).toBe('quiet');
   });
 
   test('--progress-json → json mode with interval', () => {
-    const opts = cliOptsToProgressOptions({ quiet: false, progressJson: true, progressInterval: 500 });
+    const opts = cliOptsToProgressOptions({ quiet: false, json: false, progressJson: true, progressInterval: 500 });
     expect(opts.mode).toBe('json');
     expect(opts.minIntervalMs).toBe(500);
   });
@@ -155,7 +167,7 @@ describe('cliOptsToProgressOptions', () => {
   });
 
   test('quiet takes priority over progressJson', () => {
-    const opts = cliOptsToProgressOptions({ quiet: true, progressJson: true, progressInterval: 1000 });
+    const opts = cliOptsToProgressOptions({ quiet: true, json: false, progressJson: true, progressInterval: 1000 });
     expect(opts.mode).toBe('quiet');
   });
 });

--- a/test/cli-options.test.ts
+++ b/test/cli-options.test.ts
@@ -63,8 +63,17 @@ describe('parseGlobalFlags', () => {
     expect(r.rest).toEqual(['search', 'ADU permit']);
   });
 
-  test('keeps command-local --json after the command', () => {
-    const r = parseGlobalFlags(['check-resolvable', '--skills-dir', './skills', '--json']);
+  test('strips --json after a shared-operation command and sets json=true', () => {
+    const r = parseGlobalFlags(['search', 'ADU permit', '--json']);
+    expect(r.cliOpts.json).toBe(true);
+    expect(r.rest).toEqual(['search', 'ADU permit']);
+  });
+
+  test('keeps command-local --json after an allowlisted CLI-only command', () => {
+    const r = parseGlobalFlags(
+      ['check-resolvable', '--skills-dir', './skills', '--json'],
+      { jsonPassThroughCommands: new Set(['check-resolvable']) },
+    );
     expect(r.cliOpts.json).toBe(false);
     expect(r.rest).toEqual(['check-resolvable', '--skills-dir', './skills', '--json']);
   });


### PR DESCRIPTION
## Summary
- Add a global `gbrain --json <operation>` flag for shared operation commands.
- Preserve existing command-local `--json` behavior for CLI-only commands such as `check-resolvable`.
- Document global options in top-level help.

## Why
Agent integrations need stable machine-readable output from shared operations like `search` and `query` without parsing human-formatted CLI text.

## Test Plan
- `bun run typecheck`
- `bun test test/cli-options.test.ts`
- `bun test test/check-resolvable.test.ts test/skillpack-sync-guard.test.ts test/skills-conformance.test.ts`
- `bun src/cli.ts --json search 'ADU permit' --limit 1`
- `bun src/cli.ts check-resolvable --skills-dir ./skills --json`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->