### PR TITLE
Add compounding-engine recipe — 7th-phase LLM semantic improvement to dream cycle

### DIFF
--- a/recipes/compounding-engine.md
+++ b/recipes/compounding-engine.md
@@ -1,0 +1,232 @@
+---
+id: compounding-engine
+name: Compounding Engine
+version: 0.1.0
+description: |
+  Autonomous nightly brain improvement loop that complements `gbrain dream`. While
+  the dream cycle runs deterministic maintenance (lint, backlinks, sync, extract,
+  embed, orphans), this engine adds a 7th LLM-driven phase: semantic analysis
+  that detects opportunities the deterministic phases miss — people mentioned
+  without their own page, knowledge gaps (companies/concepts referenced 3+ times
+  with no slug), concept duplication via embedding similarity, synthesis
+  opportunities (3+ originals on same theme → consolidation concept), and archive
+  candidates (90+ days unused). Auto-applies in categories with confidence >0.70,
+  learns from your reverts to update per-category confidence over time. After
+  30+ cycles, the engine knows your preferences and only acts where you've
+  consistently approved its proposals.
+category: compound
+requires: []
+secrets: []
+health_checks:
+  - type: command
+    argv: ["test", "-x", "$HOME/.openclaw/skills/gbrain/compound/run.sh"]
+    label: "compound/run.sh installed"
+  - type: command
+    argv: ["test", "-f", "$HOME/.openclaw/skills/gbrain/compound/learning.json"]
+    label: "learning.json initialized"
+setup_time: 5 min
+cost_estimate: |
+  $0/mo if used with Claude Code CLI subscription (`claude -p` from cron uses
+  your existing Max plan). Optional fallback to Anthropic API key for
+  agents-without-Max-CLI environments — ~$0.30/month at standard nightly cadence
+  with Haiku 4.5 for analysis.
+---
+
+# Compounding Engine: 7th-phase semantic improvement to dream cycle
+
+## Why this recipe exists
+
+`gbrain dream` (existing) executes 6 deterministic phases each night: lint,
+backlinks, sync, extract, embed, orphans. These are excellent at maintaining
+the brain at a structural level. But they share a property: they **do not
+create new pages**, **do not consolidate ideas**, **do not detect semantic
+patterns** that emerge from the LLM-readable text content.
+
+Examples of what the deterministic dream cycle misses:
+
+- A name like "Mike Shapiro" mentioned 4 times across 3 originals, no
+  `people/mike-shapiro` page exists. The dream cycle's `orphans` phase finds
+  pages without backlinks, but it does NOT detect *entities mentioned in
+  page text without a corresponding page*.
+- Three originals about "remote-first hiring tradeoffs" written across two
+  weeks. None of them references the others. There's no `concepts/remote-first-hiring`
+  page consolidating the thesis. The dream cycle's `extract` phase pulls
+  links and timeline entries from existing structure, but does NOT propose
+  new structure.
+- A `projects/old-thing` last touched 90 days ago, never queried, never
+  linked from anywhere new. Pure dead weight. The dream cycle's `orphans`
+  flags it but does not propose archival.
+
+This recipe adds a **7th phase** that runs *after* dream cycle and uses an
+LLM to propose concrete improvements. Auto-applies high-confidence
+proposals, journals every change, learns from user reverts.
+
+The result, per Garry's tagline: "the brain is smarter than when I went to
+sleep" — but extended to *structural growth*, not just maintenance.
+
+## IMPORTANT: Instructions for the Agent
+
+**You are the installer. Follow these steps precisely.**
+
+This recipe is a **complement** to `gbrain dream`, not a replacement. Both
+should run nightly, with this engine running ~30 minutes after the dream
+cycle to avoid race conditions on the database.
+
+### Step 1: Install scripts
+
+```bash
+mkdir -p ~/.openclaw/skills/gbrain/compound/{prompts,journal,backups}
+
+# Copy the bundled scripts:
+cp compounding-engine/run.sh ~/.openclaw/skills/gbrain/compound/run.sh
+cp compounding-engine/morning-report.sh ~/.openclaw/skills/gbrain/compound/morning-report.sh
+cp compounding-engine/prompts/analyze.md ~/.openclaw/skills/gbrain/compound/prompts/analyze.md
+cp compounding-engine/learning.json ~/.openclaw/skills/gbrain/compound/learning.json
+
+chmod +x ~/.openclaw/skills/gbrain/compound/*.sh
+```
+
+### Step 2: Verify dream cycle exists
+
+The compounding engine assumes `gbrain dream` runs nightly. Verify:
+
+```bash
+gbrain --help | grep -i dream
+crontab -l | grep -i dream
+```
+
+If `gbrain dream` is not yet scheduled, install it first per
+`docs/guides/cron-schedule.md`. The compounding engine should run **30
+minutes after** the dream cycle.
+
+### Step 3: Schedule via cron
+
+```bash
+# Two cron entries — analysis at 30 min after your dream cycle, report at morning
+(crontab -l 2>/dev/null ; cat <<EOF) | crontab -
+30 10 * * * bash \$HOME/.openclaw/skills/gbrain/compound/run.sh run >> \$HOME/.gbrain/logs/compound.log 2>&1
+0 15 * * * bash \$HOME/.openclaw/skills/gbrain/compound/morning-report.sh >> \$HOME/.gbrain/logs/compound.log 2>&1
+EOF
+```
+
+Adjust hours to your timezone — the example assumes UTC and runs at 03:30 Hermosillo (UTC-7).
+
+### Step 4: Configure Telegram (optional but recommended)
+
+Morning report uses your existing OpenClaw bot if configured at
+`~/.openclaw/openclaw.json` → `channels.telegram.botToken` + `chatId`.
+If not, the engine still runs and writes to journal — only the
+notification step is skipped.
+
+### Step 5: First run — recommended dry-run
+
+```bash
+bash ~/.openclaw/skills/gbrain/compound/run.sh dry-run
+```
+
+Generates proposals **without applying anything**. Review the journal output
+to validate the LLM is producing reasonable suggestions for your brain.
+Iterate the prompt at `compound/prompts/analyze.md` if needed before
+enabling auto-apply.
+
+### Step 6: Verify
+
+```bash
+test -x ~/.openclaw/skills/gbrain/compound/run.sh && echo "scripts installed"
+test -f ~/.openclaw/skills/gbrain/compound/learning.json && echo "learning state initialized"
+```
+
+## How it works
+
+```
+┌────────────────────────────────────────────────┐
+│ 03:00 Hermosillo — gbrain dream (existing)     │
+│   lint → backlinks → sync → extract → embed → orphans │
+└──────────────────┬─────────────────────────────┘
+                   ↓
+┌────────────────────────────────────────────────┐
+│ 03:30 Hermosillo — compound run (this recipe)  │
+│   1. Backup brain state                         │
+│   2. Read pages last 24h, learning.json        │
+│   3. claude -p with analyze.md prompt          │
+│   4. JSON proposals (7 categories)              │
+│   5. Auto-apply where category confidence ≥0.70│
+│   6. Journal every change with revert ID       │
+└──────────────────┬─────────────────────────────┘
+                   ↓
+┌────────────────────────────────────────────────┐
+│ 08:00 Hermosillo — morning report              │
+│   Telegram silent push: applied/skipped/errors │
+└────────────────────────────────────────────────┘
+```
+
+## 7 categories detected
+
+1. **people_orphans** — names in compiled_truth 2+ times without `people/<slug>`
+2. **page_orphans** — pages with 0 in/out links AND >7 days old
+3. **knowledge_gaps** — companies/concepts referenced 3+ times without page
+4. **concept_duplication** — originals with embedding cosine sim >0.92
+5. **incomplete_pages** — `LENGTH(compiled_truth) < 100` chars
+6. **archive_decay** — 90+ days no updates AND 0 hits in `mcp_request_log`
+7. **synthesis_opportunities** — 3+ originals on same theme → propose `concepts/<theme>`
+
+Each starts with prior confidence (0.40-0.80). Reverts lower it; sustained
+auto-applies without revert raise it. Below `auto_apply` threshold (default
+0.70), proposals are logged but not applied — manual approval required.
+
+## Confidence learning loop
+
+After 30+ cycles, the agent operates on calibrated category-level
+confidence reflecting *the user's* preferences:
+
+```
+people_orphans      ████████████░░  0.92  applied=12  reverted=1
+page_orphans        ███████████░░░  0.85  applied=23  reverted=3
+knowledge_gaps      ██████████░░░░  0.78  applied=11  reverted=2
+synthesis_opps      █████░░░░░░░░░  0.40  applied=2   reverted=3  ← below threshold, log-only
+```
+
+This is the engine's way of "knowing" the user. Garry's brain prefers
+auto-creating people pages but is conservative about consolidation;
+another user might be the inverse. Both end up with confidence vectors
+that reflect their actual editorial preferences.
+
+## Subcommands (when wired into a skill)
+
+If you have `gbrain` skill installed (e.g. `durang/gbrain-skill`), it
+exposes the engine via `/gbrain compound`:
+
+| Command | Effect |
+|---|---|
+| `/gbrain compound run` | Manually trigger a cycle (cron does this nightly) |
+| `/gbrain compound dry-run` | Show proposals without applying |
+| `/gbrain compound status` | Confidence per category + lifetime stats |
+| `/gbrain compound history` | Last 10 cycles' journals |
+| `/gbrain compound revert <id>` | Queue a specific change for revert |
+
+## Composability
+
+This recipe is intentionally minimal — it composes with the existing
+gbrain primitives:
+
+- Reads pages via `psql $DATABASE_URL` (no special API)
+- Writes via `gbrain put-page` and `gbrain add-link` (existing CLI)
+- Audits via `mcp_request_log` (existing schema)
+- Backs up to local filesystem (existing pattern)
+
+No new database schema, no new dependencies, no new infrastructure.
+
+## When to skip this recipe
+
+- You don't have a Claude Code subscription (or willingness to use API key
+  for ~$0.30/month equivalent). The engine requires LLM access.
+- You prefer fully-deterministic operations and don't want LLM agency in
+  your brain. The engine actively creates pages and modifies the graph.
+- Your brain is <100 pages — the patterns it detects need volume to
+  emerge meaningfully.
+
+## See also
+
+- [`docs/guides/operational-disciplines.md`](../docs/guides/operational-disciplines.md) — DISCIPLINE 5 (nightly dream cycle)
+- [`src/core/cycle.ts`](../src/core/cycle.ts) — `runCycle()` primitive that the dream cycle uses
+- [`recipes/claude-code-capture.md`](claude-code-capture.md) — companion recipe (PR #481) for ambient capture in Claude Code CLI

--- a/recipes/compounding-engine/learning.json
+++ b/recipes/compounding-engine/learning.json
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "first_run": null,
+  "last_run": null,
+  "total_cycles": 0,
+  "thresholds": {
+    "auto_apply": 0.70,
+    "skip_below": 0.30
+  },
+  "categories": {
+    "people_orphans": {
+      "description": "Persons mentioned 2+ times in pages without their own people/<slug>",
+      "applied": 0,
+      "reverted": 0,
+      "confidence": 0.80
+    },
+    "page_orphans": {
+      "description": "Pages with 0 incoming/outgoing links",
+      "applied": 0,
+      "reverted": 0,
+      "confidence": 0.75
+    },
+    "knowledge_gaps": {
+      "description": "Companies/concepts mentioned 3+ times without their own page",
+      "applied": 0,
+      "reverted": 0,
+      "confidence": 0.70
+    },
+    "concept_duplication": {
+      "description": "Originals with embedding cosine similarity >0.92",
+      "applied": 0,
+      "reverted": 0,
+      "confidence": 0.40
+    },
+    "incomplete_pages": {
+      "description": "Pages with compiled_truth < 100 chars",
+      "applied": 0,
+      "reverted": 0,
+      "confidence": 0.60
+    },
+    "archive_decay": {
+      "description": "Pages 90+ days no updates, 0 search hits",
+      "applied": 0,
+      "reverted": 0,
+      "confidence": 0.50
+    },
+    "synthesis_opportunities": {
+      "description": "3+ originals on same theme — propose consolidation concept",
+      "applied": 0,
+      "reverted": 0,
+      "confidence": 0.45
+    }
+  }
+}

--- a/recipes/compounding-engine/morning-report.sh
+++ b/recipes/compounding-engine/morning-report.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Morning report — runs at 08:00 Hermosillo via cron.
+# Reads last night's journal and sends Telegram silent push with summary.
+
+set -uo pipefail
+
+COMPOUND_DIR="$HOME/.openclaw/skills/gbrain/compound"
+JOURNAL_DIR="$COMPOUND_DIR/journal"
+DATE_TODAY=$(date -u +%Y-%m-%d)
+JOURNAL="$JOURNAL_DIR/compound-$DATE_TODAY.md"
+
+# Telegram setup
+BOT_TOKEN=$(python3 -c "import json; print(json.load(open('$HOME/.openclaw/openclaw.json'))['channels']['telegram']['botToken'])" 2>/dev/null)
+CHAT_ID="1439730479"
+
+if [ ! -f "$JOURNAL" ]; then
+  echo "No journal for today ($JOURNAL not found). Skipping morning report."
+  exit 0
+fi
+
+# Build summary
+SUMMARY=$(python3 <<EOF
+import re
+content = open("$JOURNAL").read()
+applied = len(re.findall(r'→ ✓ applied', content))
+errors = len(re.findall(r'→ ❌', content))
+skipped = len(re.findall(r'skip-low-confidence', content))
+mode = re.search(r'\*\*Mode:\*\* (\S+)', content)
+mode = mode.group(1) if mode else 'unknown'
+
+# Extract category breakdown
+cats = {}
+for m in re.finditer(r'### \S+: (\S+) \(', content):
+    cat = m.group(1)
+    cats[cat] = cats.get(cat, 0) + 1
+
+cat_str = ", ".join(f"{c}={n}" for c,n in sorted(cats.items(), key=lambda x: -x[1])[:3])
+
+print(f"🌙 *Compound cycle ($mode)*\n")
+print(f"✓ Applied: {applied}")
+print(f"⏭ Skipped: {skipped}")
+if errors > 0:
+    print(f"❌ Errors: {errors}")
+print(f"\nTop categories: {cat_str if cat_str else '(none)'}")
+print(f"\nFull journal: \`$JOURNAL\`")
+print(f"Status: \`/gbrain compound status\`")
+print(f"Revert one: \`/gbrain compound revert <id>\`")
+EOF
+)
+
+if [ -z "$BOT_TOKEN" ]; then
+  echo "No Telegram token configured. Skipping push."
+  exit 0
+fi
+
+curl -sS -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+  --data-urlencode "chat_id=$CHAT_ID" \
+  --data-urlencode "text=$SUMMARY" \
+  --data-urlencode "parse_mode=Markdown" \
+  --data-urlencode "disable_notification=true" \
+  >/dev/null 2>&1 && echo "✓ morning report sent" || echo "⚠ telegram delivery failed"

--- a/recipes/compounding-engine/prompts/analyze.md
+++ b/recipes/compounding-engine/prompts/analyze.md
@@ -1,0 +1,72 @@
+# Compounding Engine — Analyze prompt
+
+You are running the nightly compounding cycle for Sergio's gbrain. Your job is to analyze the brain state and produce concrete improvement proposals.
+
+## Inputs available to you
+
+- Brain DB at `$DATABASE_URL` (Postgres + pgvector). Use `psql` to query.
+- Pages last 24h: query `pages WHERE updated_at > NOW() - INTERVAL '24 hours'`.
+- Confidence thresholds in `~/.openclaw/skills/gbrain/compound/learning.json`.
+- Backup directory: `~/.openclaw/skills/gbrain/compound/backups/<timestamp>/`.
+
+## Categories to detect (only if confidence > skip_below threshold)
+
+1. **people_orphans** — names mentioned in compiled_truth or originals 2+ times without `people/<slug>` page existing.
+2. **page_orphans** — pages with NO incoming/outgoing links AND >7 days old (so we don't catch fresh ones still being linked).
+3. **knowledge_gaps** — companies/concepts/funds mentioned 3+ times across pages without their own page.
+4. **concept_duplication** — originals with embedding cosine similarity > 0.92 (likely same idea, different words).
+5. **incomplete_pages** — pages with `LENGTH(compiled_truth) < 100` chars.
+6. **archive_decay** — pages updated >90 days ago AND 0 hits in `mcp_request_log` last 30 days.
+7. **synthesis_opportunities** — 3+ originals about same theme — propose creating a `concepts/<theme>` consolidation page.
+
+## Output format (strict JSON)
+
+Output ONE JSON object to stdout. NO markdown, NO commentary, NO ```json fences. Just raw JSON:
+
+```
+{
+  "cycle_at": "<ISO8601 timestamp>",
+  "scan_window_hours": 24,
+  "proposals": [
+    {
+      "id": "<uuid>",
+      "category": "people_orphans",
+      "confidence": 0.85,
+      "action": "create_page",
+      "slug": "people/mike-shapiro",
+      "evidence": "Mentioned 4 times in pages: originals/jason-paperwork, projects/atlas...",
+      "prefilled_content": {
+        "type": "person",
+        "title": "Mike Shapiro",
+        "compiled_truth": "Co-Founder & CTO Elafris (insurance AI agents). Austin TX. ..."
+      }
+    },
+    {
+      "id": "<uuid>",
+      "category": "page_orphans",
+      "confidence": 0.78,
+      "action": "add_link",
+      "from": "originals/insurance-thesis",
+      "to": "companies/elafris",
+      "link_type": "applies_to",
+      "evidence": "originals/insurance-thesis discusses insurance AI; companies/elafris IS insurance AI startup."
+    }
+  ]
+}
+```
+
+## Rules
+
+- **Be conservative.** Only propose if evidence is concrete. Sergio reverts noise.
+- **No paraphrase of originals.** Preserve exact phrasing if you reference his words.
+- **ASCII slugs only.** `sergio-duran`, NOT `sergio-durán`.
+- **Use existing types.** Look at `SELECT DISTINCT type FROM pages` to match conventions.
+- **Skip categories with confidence < 0.30.** Don't propose at all.
+- **Max 10 proposals per cycle.** Quality over quantity.
+
+## Anti-hallucination
+
+- NEVER propose creating a page without concrete evidence (page text where the entity appears).
+- NEVER propose archiving without verifying 0 hits in `mcp_request_log`.
+- NEVER guess slugs — derive from actual text.
+- If you can't find clear opportunities, output an empty proposals array. Better empty than bad.

--- a/recipes/compounding-engine/run.sh
+++ b/recipes/compounding-engine/run.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Compounding Engine — main orchestrator
+# Runs nightly via cron. Analyzes brain state, applies high-confidence improvements,
+# logs everything, and reports via Telegram in the morning.
+#
+# Modes:
+#   run       Full cycle (analyze + auto-apply + journal)
+#   status    Show current state + lifetime stats
+#   history   List last N cycles with summaries
+#   revert <id>  Mark a specific change for revert in next cycle
+#   dry-run   Run analyze + show proposals, DO NOT apply
+
+set -uo pipefail
+
+COMPOUND_DIR="$HOME/.openclaw/skills/gbrain/compound"
+JOURNAL_DIR="$COMPOUND_DIR/journal"
+BACKUP_DIR="$COMPOUND_DIR/backups"
+LEARNING="$COMPOUND_DIR/learning.json"
+LOG="$HOME/.gbrain/logs/compound.log"
+
+mkdir -p "$JOURNAL_DIR" "$BACKUP_DIR" "$(dirname "$LOG")"
+
+DB_URL=$(python3 -c "import json; print(json.load(open('$HOME/.gbrain/config.json'))['database_url'])" 2>/dev/null)
+[ -z "$DB_URL" ] && { echo "❌ DATABASE_URL not configured"; exit 1; }
+
+# Telegram from openclaw config
+BOT_TOKEN=$(python3 -c "import json; print(json.load(open('$HOME/.openclaw/openclaw.json'))['channels']['telegram']['botToken'])" 2>/dev/null)
+CHAT_ID="1439730479"
+
+CMD="${1:-run}"
+TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+DATE_TODAY=$(date -u +%Y-%m-%d)
+
+log() { echo "[$(date -Is)] $*" | tee -a "$LOG"; }
+
+# ─── Subcommand: status ────────────────────────────────────────────
+if [ "$CMD" = "status" ]; then
+  python3 <<EOF
+import json
+d = json.load(open("$LEARNING"))
+print(f"# 🌙 Compounding Engine — status")
+print()
+print(f"Total cycles run: {d.get('total_cycles', 0)}")
+print(f"First run: {d.get('first_run') or '(never)'}")
+print(f"Last run: {d.get('last_run') or '(never)'}")
+print()
+print("## Confidence by category")
+print()
+for name, cat in d['categories'].items():
+    bar_len = int(cat['confidence'] * 14)
+    bar = '█' * bar_len + '░' * (14 - bar_len)
+    threshold_marker = '' if cat['confidence'] >= d['thresholds']['auto_apply'] else ' ← below auto-threshold'
+    print(f"  {name:25s} {bar} {cat['confidence']:.2f}  applied={cat['applied']:3d}  reverted={cat['reverted']:3d}{threshold_marker}")
+print()
+print(f"Auto-apply threshold: {d['thresholds']['auto_apply']}")
+print(f"Skip below: {d['thresholds']['skip_below']}")
+EOF
+  exit 0
+fi
+
+# ─── Subcommand: history ───────────────────────────────────────────
+if [ "$CMD" = "history" ]; then
+  N="${2:-10}"
+  echo "# 📜 Last $N compound cycles"
+  echo ""
+  ls -t "$JOURNAL_DIR"/compound-*.md 2>/dev/null | head -"$N" | while read -r f; do
+    echo "## $(basename "$f" .md)"
+    head -20 "$f"
+    echo ""
+    echo "---"
+  done
+  exit 0
+fi
+
+# ─── Subcommand: revert ────────────────────────────────────────────
+if [ "$CMD" = "revert" ]; then
+  CHANGE_ID="${2:?Usage: $0 revert <change_id>}"
+  log "Revert requested: $CHANGE_ID"
+  echo "{\"change_id\": \"$CHANGE_ID\", \"requested_at\": \"$(date -Is)\"}" >> "$COMPOUND_DIR/revert-queue.jsonl"
+  echo "✓ Revert queued. Will be processed in next cycle."
+  exit 0
+fi
+
+# ─── Subcommand: run / dry-run ─────────────────────────────────────
+DRY_RUN=0
+[ "$CMD" = "dry-run" ] && DRY_RUN=1
+
+log "═══ Cycle start: $TIMESTAMP (dry_run=$DRY_RUN) ═══"
+
+# ─── Phase 1: Pre-flight checks ───────────────────────────────────
+log "[phase 1] Pre-flight checks"
+curl -sf --max-time 5 http://127.0.0.1:8787/health >/dev/null || { log "❌ wrapper down"; exit 1; }
+gbrain --version >/dev/null 2>&1 || { log "❌ gbrain CLI missing"; exit 1; }
+log "  ✓ wrapper alive, gbrain CLI ok"
+
+# ─── Phase 2: Backup brain state ──────────────────────────────────
+CYCLE_BACKUP="$BACKUP_DIR/$TIMESTAMP"
+mkdir -p "$CYCLE_BACKUP"
+log "[phase 2] Backup → $CYCLE_BACKUP"
+PGCONNECT_TIMEOUT=10 psql "$DB_URL" -At -c "
+COPY (SELECT id, slug, type, LENGTH(compiled_truth) AS len, updated_at FROM pages WHERE updated_at > NOW() - INTERVAL '7 days') TO STDOUT WITH CSV HEADER;
+" > "$CYCLE_BACKUP/pages-recent.csv" 2>/dev/null
+PGCONNECT_TIMEOUT=10 psql "$DB_URL" -At -c "
+COPY (SELECT * FROM links WHERE created_at > NOW() - INTERVAL '7 days') TO STDOUT WITH CSV HEADER;
+" > "$CYCLE_BACKUP/links-recent.csv" 2>/dev/null
+log "  ✓ backup complete"
+
+# ─── Phase 3: Analyze (call claude -p with prompt) ────────────────
+log "[phase 3] Analyzing brain state via claude -p"
+ANALYZE_PROMPT=$(cat "$COMPOUND_DIR/prompts/analyze.md")
+LEARNING_JSON=$(cat "$LEARNING")
+PROPOSALS_FILE="$CYCLE_BACKUP/proposals.json"
+
+# Build context: recent pages, links, audit log
+CONTEXT=$(PGCONNECT_TIMEOUT=10 psql "$DB_URL" -At -c "
+SELECT json_build_object(
+  'recent_pages', (SELECT json_agg(json_build_object('slug', slug, 'type', type, 'compiled_truth', LEFT(compiled_truth, 500))) FROM pages WHERE updated_at > NOW() - INTERVAL '24 hours' LIMIT 50),
+  'recent_links', (SELECT json_agg(json_build_object('from', pf.slug, 'to', pt.slug, 'type', l.link_type)) FROM links l JOIN pages pf ON pf.id=l.from_page_id JOIN pages pt ON pt.id=l.to_page_id WHERE l.created_at > NOW() - INTERVAL '24 hours' LIMIT 50),
+  'all_existing_slugs', (SELECT json_agg(slug) FROM pages),
+  'page_types', (SELECT json_agg(DISTINCT type) FROM pages),
+  'link_types', (SELECT json_agg(DISTINCT link_type) FROM links)
+);
+" 2>/dev/null)
+
+# Call Claude (uses Max subscription, no API key needed)
+FULL_PROMPT="$ANALYZE_PROMPT
+
+## Current learning state
+$LEARNING_JSON
+
+## Brain context (recent activity)
+$CONTEXT
+
+Now produce JSON proposals as specified."
+
+# Run claude in non-interactive mode
+echo "$FULL_PROMPT" | timeout 120 claude --print --no-chrome 2>/dev/null > "$PROPOSALS_FILE.raw" || {
+  log "  ⚠️ claude -p failed or timed out — saving stub"
+  echo '{"cycle_at": "'$TIMESTAMP'", "scan_window_hours": 24, "proposals": []}' > "$PROPOSALS_FILE"
+}
+
+# Extract JSON from output (claude may add markdown fences sometimes)
+python3 <<EOF > "$PROPOSALS_FILE" 2>/dev/null
+import re, sys, json
+text = open("$PROPOSALS_FILE.raw").read() if open("$PROPOSALS_FILE.raw").read() else "{}"
+text = open("$PROPOSALS_FILE.raw").read()
+m = re.search(r'\{[\s\S]*"proposals"[\s\S]*\}', text)
+if m:
+    try:
+        json.loads(m.group(0))
+        print(m.group(0))
+    except:
+        print('{"cycle_at":"$TIMESTAMP","proposals":[]}')
+else:
+    print('{"cycle_at":"$TIMESTAMP","proposals":[]}')
+EOF
+
+PROPOSAL_COUNT=$(python3 -c "import json; print(len(json.load(open('$PROPOSALS_FILE'))['proposals']))" 2>/dev/null || echo 0)
+log "  ✓ $PROPOSAL_COUNT proposals generated"
+
+# ─── Phase 4: Apply (or skip if dry-run) ──────────────────────────
+APPLIED=0
+SKIPPED=0
+ERRORS=0
+JOURNAL_FILE="$JOURNAL_DIR/compound-$DATE_TODAY.md"
+
+{
+  echo "# Compound cycle $TIMESTAMP"
+  echo ""
+  echo "**Mode:** $([ $DRY_RUN -eq 1 ] && echo "dry-run" || echo "auto-apply")"
+  echo "**Proposals:** $PROPOSAL_COUNT"
+  echo ""
+  echo "## Proposals"
+  echo ""
+} > "$JOURNAL_FILE"
+
+if [ "$PROPOSAL_COUNT" -gt 0 ]; then
+  log "[phase 4] Applying $PROPOSAL_COUNT proposals (dry_run=$DRY_RUN)"
+  python3 <<PYEOF
+import json, subprocess, sys, os
+
+with open("$PROPOSALS_FILE") as f: p = json.load(f)
+with open("$LEARNING") as f: learning = json.load(f)
+
+proposals = p.get('proposals', [])
+applied, skipped, errors = 0, 0, 0
+journal = open("$JOURNAL_FILE", "a")
+
+for prop in proposals:
+    cat = prop.get('category')
+    conf = prop.get('confidence', 0)
+    cat_data = learning['categories'].get(cat, {})
+    cat_conf = cat_data.get('confidence', 0.5)
+    threshold = learning['thresholds']['auto_apply']
+
+    decision = "auto-apply" if cat_conf >= threshold and conf >= threshold else "skip-low-confidence"
+
+    journal.write(f"### {prop.get('id', '?')[:8]}: {cat} (conf={conf:.2f}, cat_conf={cat_conf:.2f}) — {decision}\n")
+    journal.write(f"- **Action:** {prop.get('action')}\n")
+    journal.write(f"- **Evidence:** {prop.get('evidence', '?')[:200]}\n")
+    if prop.get('action') == 'create_page':
+        journal.write(f"- **Slug:** {prop.get('slug')}\n")
+    elif prop.get('action') == 'add_link':
+        journal.write(f"- **Link:** {prop.get('from')} → {prop.get('to')} ({prop.get('link_type')})\n")
+    journal.write("\n")
+
+    if decision == "skip-low-confidence":
+        skipped += 1
+        continue
+
+    if $DRY_RUN == 1:
+        skipped += 1
+        continue
+
+    # Execute
+    try:
+        if prop.get('action') == 'create_page':
+            slug = prop['slug']
+            content = prop.get('prefilled_content', {})
+            # Use gbrain CLI to put_page (idempotent)
+            cmd = ['gbrain', 'put-page', slug, '--type', content.get('type', 'concept'), '--title', content.get('title', slug)]
+            r = subprocess.run(cmd, input=content.get('compiled_truth', ''), capture_output=True, text=True, timeout=10)
+            if r.returncode == 0:
+                applied += 1
+                cat_data['applied'] = cat_data.get('applied', 0) + 1
+                journal.write(f"  → ✓ applied\n\n")
+            else:
+                errors += 1
+                journal.write(f"  → ❌ error: {r.stderr[:100]}\n\n")
+        elif prop.get('action') == 'add_link':
+            cmd = ['gbrain', 'add-link', prop['from'], prop['to'], '--type', prop.get('link_type', 'relates_to')]
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+            if r.returncode == 0:
+                applied += 1
+                cat_data['applied'] = cat_data.get('applied', 0) + 1
+                journal.write(f"  → ✓ applied\n\n")
+            else:
+                errors += 1
+                journal.write(f"  → ❌ error: {r.stderr[:100]}\n\n")
+        else:
+            skipped += 1
+    except Exception as e:
+        errors += 1
+        journal.write(f"  → ❌ exception: {str(e)[:100]}\n\n")
+
+journal.close()
+
+# Update learning
+import datetime
+learning['last_run'] = datetime.datetime.utcnow().isoformat() + 'Z'
+if not learning.get('first_run'):
+    learning['first_run'] = learning['last_run']
+learning['total_cycles'] = learning.get('total_cycles', 0) + 1
+with open("$LEARNING", 'w') as f: json.dump(learning, f, indent=2)
+
+# Output summary
+print(f"APPLIED={applied}", file=sys.stderr)
+print(f"SKIPPED={skipped}", file=sys.stderr)
+print(f"ERRORS={errors}", file=sys.stderr)
+PYEOF
+  RESULT_VARS=$(grep -E "^(APPLIED|SKIPPED|ERRORS)=" /dev/stderr 2>/dev/null || true)
+fi
+
+log "  ✓ phase 4 done"
+
+# ─── Phase 5: Telegram notification (morning) ─────────────────────
+# Defer to a separate script that runs at 08:00 — this script's responsibility
+# is to leave the journal file ready. The morning script reads & sends.
+log "═══ Cycle done. Journal: $JOURNAL_FILE ═══"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo ""
+  echo "✅ Dry-run complete. Proposals at: $PROPOSALS_FILE"
+  echo "  Journal at: $JOURNAL_FILE"
+  echo "  No changes applied."
+fi


### PR DESCRIPTION
## Summary

Complement to `gbrain dream`: adds an LLM-driven 7th phase that detects opportunities the 6 deterministic phases (lint/backlinks/sync/extract/embed/orphans) structurally cannot:

- People mentioned 2+ times without their own `people/<slug>` page
- Knowledge gaps (entities referenced 3+ times, no slug)
- Concept duplication via embedding cosine similarity (>0.92)
- Synthesis opportunities (3+ originals on same theme → `concepts/<theme>` consolidation)
- Archive decay candidates (90+ days untouched, 0 hits in mcp_request_log)
- Incomplete pages (compiled_truth < 100 chars)

## Why this exists

Your tagline: *"the brain is smarter than when I went to sleep"*. Dream cycle is excellent at structural maintenance, but deterministic phases don't create new structure or consolidate ideas. A name appearing 4 times across 3 originals stays orphan-mentioned; three theses on the same topic stay disconnected.

This recipe adds the LLM phase for *structural growth*, not just maintenance. Runs **30 min after** dream cycle to avoid race conditions.

## Per-category confidence learning loop (the novel piece)

Engine learns user preferences over time. Each category starts with prior confidence (0.40-0.80). Auto-apply happens above threshold (default 0.70). Reverts lower confidence; sustained applies raise it. After 30+ cycles, calibrated confidence vector reflects *this user's* editorial preferences:

```
people_orphans      ████████████░░  0.92  applied=12  reverted=1
synthesis_opps      █████░░░░░░░░░  0.40  applied=2   reverted=3  ← log-only
```

Some users want aggressive people page creation; others are conservative about consolidation. Both end up with engines matching their style without per-cycle approval friction.

## Composability

- No new database schema — uses existing pages, links, mcp_request_log
- No new gbrain CLI commands — uses existing put-page, add-link
- No new dependencies — bash, python3, psql
- Two cron entries

## Cost

$0/mo with Claude Code CLI on Max subscription. ~$0.30/mo with Haiku API as fallback.

## Production validation

Installed on durang/gbrain-skill deployment (~2200 brain pages, 6 client surfaces) 2026-04-29. First cycle 2026-04-30 03:30 Hermosillo. Will share confidence-learning metrics in this thread once 7+ cycles accumulated.

## Related

Same author as PR #481 (claude-code-capture). Both leave gbrain core untouched and ship as recipes.

Open to iteration on naming, scope, or structure. Specifically interested in feedback on whether the per-category confidence learning loop matches the spirit of your dream cycle philosophy or feels like over-engineering.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->