### PR TITLE
feat(ingest): add async agent-native gbrain ingest

### DIFF
--- a/docs/guides/gbrain-ingest.md
+++ b/docs/guides/gbrain-ingest.md
@@ -48,6 +48,47 @@ Progress phases include `resolve`, `wiki_write`, `db_import`, optional
 `enrich`, and `done`. Repeated identical submissions coalesce by idempotency key
 or complete as `no-op`.
 
+Enrichment has its own status inside the terminal job result:
+
+- `succeeded`: Codex OAuth returned cited JSON and the worker wrote extracted
+  people, organizations, concepts, relationships, or timeline entries.
+- `skipped`: enrichment was disabled, the source import was a no-op, or the
+  cited extraction produced no durable candidates.
+- `timeout`: the Codex OAuth enrichment attempt exceeded its bounded runtime.
+- `configuration_error`: the Codex OAuth route is unavailable, unauthenticated,
+  interactive, missing, or rejected before usable output.
+- `failed`: enrichment returned unusable output or hit another bounded failure.
+
+If source write/import succeeds but enrichment fails, the job still reaches a
+terminal result and records the enrichment status. Worker cancellation,
+lock-loss, or job timeout still aborts the child Codex process and lets Minions
+mark the job according to queue policy.
+
+## Runtime Health Checks
+
+Use the cheap checks first:
+
+```bash
+gbrain doctor --fast --json --codex-oauth-smoke
+gbrain jobs smoke --gbrain-ingest --json --timeout-ms 60000
+gbrain jobs get <job-id>
+```
+
+`doctor --codex-oauth-smoke` is opt-in because it runs a tiny live
+`codex exec` probe. It verifies the explicit `gpt-5.4-mini` Codex OAuth route
+and reports a sanitized failure if the gateway user needs OAuth setup. It does
+not fall back to an OpenAI API key.
+
+`jobs smoke --gbrain-ingest` enqueues a tiny signal-mode canary, starts a worker
+for the smoke queue, waits only for a bounded terminal state, and prints the job
+id plus `gbrain jobs get <job-id>` for follow-up. It reports enqueue, worker
+terminal status, and enrichment status separately so operators can tell queue
+health from OAuth health.
+
+Avoid pasting raw prompts, raw service logs, or secret-bearing environment
+output into docs, brain pages, or handoffs. If service logs are needed, use
+redacted counts and status summaries before inspecting full journal lines.
+
 ## Hook Canaries
 
 Unit tests prove the hook emits/enqueues distilled payloads. They do not prove a

--- a/docs/guides/gbrain-ingest.md
+++ b/docs/guides/gbrain-ingest.md
@@ -1,0 +1,56 @@
+# gbrain-ingest
+
+`gbrain-ingest` is the agent-native ingest entrypoint. It validates a text, URL,
+or local text file, enqueues a protected `gbrain-ingest` Minions job, prints a
+job id immediately, and returns. Workers do enrichment, canonical writes,
+database import, and embeddings later.
+
+```bash
+printf '%s\n' 'Remember this: retrieval notes should cite sources.' | gbrain-ingest
+gbrain-ingest --url https://example.com/article --json
+gbrain ingest --file ./notes/meeting.md --title "Meeting notes"
+gbrain jobs get <job-id>
+```
+
+## Modes
+
+- `--mode explicit` preserves the submitted source/provenance and is for direct
+  user or agent requests.
+- `--mode signal` is for hooks. Signal payloads must be distilled summaries or
+  explicit `remember this` content, never raw prompts, tool output, or full
+  transcripts.
+
+## Worker Contract
+
+Workers claim jobs from the shared PostgreSQL Minions queue. The foreground
+command only validates and enqueues; it does not fetch URLs, call inference,
+write wiki pages, write canonical pages, or embed content.
+
+The ingest worker writes accepted source pages to the configured filesystem
+brain source when `sources.local_path` is set, then imports the same markdown
+into PostgreSQL/searchable state with embeddings deferred. If no local path is
+configured for the target source, the worker records `wiki_write:
+skipped_no_local_path` and still imports into PostgreSQL. Enrichment uses Codex
+OAuth with `gpt-5.4-mini` only. OpenAI API keys are not read for inference.
+Embeddings use the existing scoped embedding-key path and unchanged chunks reuse
+existing vectors.
+
+## Status And Debugging
+
+```bash
+gbrain jobs list --status waiting --limit 50
+gbrain jobs list --status active
+gbrain jobs get <job-id>
+gbrain jobs supervisor status --json
+```
+
+Progress phases include `resolve`, `wiki_write`, `db_import`, optional
+`enrich`, and `done`. Repeated identical submissions coalesce by idempotency key
+or complete as `no-op`.
+
+## Hook Canaries
+
+Unit tests prove the hook emits/enqueues distilled payloads. They do not prove a
+model saw dynamic context. Treat OpenClaw `agent:bootstrap` as the supported
+prompt-visible path unless a live canary proves another hook surface reaches the
+final model prompt.

--- a/docs/guides/minions-shell-jobs.md
+++ b/docs/guides/minions-shell-jobs.md
@@ -73,6 +73,37 @@ On one terminal, start a persistent worker:
 GBRAIN_ALLOW_SHELL_JOBS=1 gbrain jobs work
 ```
 
+For a systemd user service, `EnvironmentFile=` files must use systemd syntax:
+
+```ini
+GBRAIN_ALLOW_SHELL_JOBS=1
+GBRAIN_WORKER_CONCURRENCY=1
+GBRAIN_INGEST_ENRICH=1
+GBRAIN_EMBEDDINGS_OPENAI_API_KEY=...
+```
+
+Do not put shell syntax such as `export KEY=value`, quotes intended for a shell,
+or command substitutions in files referenced by `EnvironmentFile=`. systemd
+will ignore malformed assignments and may include the ignored line in journal
+diagnostics. Keep embeddings keys available to the worker only for embedding
+phases; GBrain strips OpenAI and embedding API-key variables from the Codex
+OAuth inference child process.
+
+After editing a user service env file, prefer redacted verification:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user restart gbrain-worker.service
+systemctl --user is-active gbrain-worker.service
+journalctl --user -u gbrain-worker.service --since -5m --no-pager \
+  | grep -E 'Ignoring environment assignment|invalid environment' \
+  | wc -l
+```
+
+Do not paste raw journal lines into handoffs when they may contain ignored env
+assignments or secret values. Record counts/status and inspect full logs only as
+a last resort.
+
 Rewrite crontab to submit shell jobs (no `--follow`):
 
 ```cron

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1189,6 +1189,7 @@ This is the dispatcher. Skills are the implementation. **Read the skill file bef
 | "Research", "track", "extract from email", "investor updates", "donations" | `skills/data-research/SKILL.md` |
 | Share a brain page as a link | `skills/publish/SKILL.md` |
 | "validate frontmatter", "check frontmatter", "fix frontmatter", "frontmatter audit", "brain lint" | `skills/frontmatter-guard/SKILL.md` |
+| "gbrain-ingest", "remember this", "ingest into gbrain", "save this to gbrain", "preserve this in gbrain" | `skills/gbrain-ingest/SKILL.md` |
 
 ## Content & media ingestion
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "src/core/index.ts",
   "bin": {
-    "gbrain": "src/cli.ts"
+    "gbrain": "src/cli.ts",
+    "gbrain-ingest": "src/cli.ts"
   },
   "exports": {
     ".": "./src/core/index.ts",

--- a/skills/RESOLVER.md
+++ b/skills/RESOLVER.md
@@ -22,6 +22,7 @@ This is the dispatcher. Skills are the implementation. **Read the skill file bef
 | "Research", "track", "extract from email", "investor updates", "donations" | `skills/data-research/SKILL.md` |
 | Share a brain page as a link | `skills/publish/SKILL.md` |
 | "validate frontmatter", "check frontmatter", "fix frontmatter", "frontmatter audit", "brain lint" | `skills/frontmatter-guard/SKILL.md` |
+| "gbrain-ingest", "remember this", "ingest into gbrain", "save this to gbrain", "preserve this in gbrain" | `skills/gbrain-ingest/SKILL.md` |
 
 ## Content & media ingestion
 

--- a/skills/gbrain-ingest/SKILL.md
+++ b/skills/gbrain-ingest/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: gbrain-ingest
+description: Queue async GBrain ingest without blocking agent work.
+triggers:
+  - "gbrain-ingest"
+  - "remember this"
+  - "ingest into gbrain"
+  - "save this to gbrain"
+  - "preserve this in gbrain"
+---
+
+# gbrain-ingest
+
+Use this when the user asks to remember, save, ingest, or preserve durable
+content in GBrain and the current turn should not wait for enrichment.
+
+## Contract
+
+This skill queues durable GBrain ingestion work and returns immediately. The
+foreground agent gets a `job_id`, `status_command`, and `status_url`; source
+normalization, filesystem brain write, database import, relationship
+extraction, concept/person/company surfacing, and enrichment happen in the
+worker.
+
+## Command
+
+```bash
+gbrain-ingest --text "Remember this: ..." --json
+gbrain-ingest --url https://example.com/page --json
+gbrain-ingest --file ./notes/source.md --json
+```
+
+The command returns immediately with `job_id`, `status_command`, and
+`status_url`. Check progress with:
+
+```bash
+gbrain jobs get <job-id>
+```
+
+## Rules
+
+- Do not use GBrain MCP.
+- Do not call `gbrain serve`.
+- Do not store raw transcripts, raw prompts, or raw tool output from automatic
+  hook capture.
+- Use `--mode signal` only for distilled hook payloads and explicit
+  `remember this` moments.
+- Write/enrichment inference is handled by workers through Codex OAuth with
+  `gpt-5.4-mini`.
+- OpenAI API-key material is for embeddings only.
+- When the target source has `sources.local_path`, the worker writes the source
+  markdown into that filesystem brain before importing the same content into
+  PostgreSQL/searchable state.
+
+## Anti-Patterns
+
+- Do not block the current coding turn to extract entities or enrich pages.
+- Do not store raw transcripts, raw prompts, or raw tool output from automatic
+  hook capture.
+- Do not pass secret material as ingest content.
+- Do not re-run embedding work for unchanged chunks.
+
+## Output Format
+
+For `--json`, return one JSON object with:
+
+- `job_id`
+- `queued`
+- `idempotency_key`
+- `status_command`
+- `status_url`
+- `job_name`
+- `queue`
+
+For human output, print the job id and the status command only.

--- a/skills/gbrain-ingest/SKILL.md
+++ b/skills/gbrain-ingest/SKILL.md
@@ -37,6 +37,17 @@ The command returns immediately with `job_id`, `status_command`, and
 gbrain jobs get <job-id>
 ```
 
+For runtime health, prefer bounded status surfaces before raw logs:
+
+```bash
+gbrain doctor --fast --json --codex-oauth-smoke
+gbrain jobs smoke --gbrain-ingest --json --timeout-ms 60000
+```
+
+The doctor smoke is opt-in and verifies the non-interactive Codex OAuth route
+for `gpt-5.4-mini`. The jobs smoke proves enqueue, worker terminal status, and
+enrichment status separately.
+
 ## Rules
 
 - Do not use GBrain MCP.
@@ -48,6 +59,9 @@ gbrain jobs get <job-id>
 - Write/enrichment inference is handled by workers through Codex OAuth with
   `gpt-5.4-mini`.
 - OpenAI API-key material is for embeddings only.
+- If source/import succeeds and enrichment fails, the job must still reach a
+  terminal result with `enrichment.status` such as `timeout`,
+  `configuration_error`, `failed`, or `skipped`.
 - When the target source has `sources.local_path`, the worker writes the source
   markdown into that filesystem brain before importing the same content into
   PostgreSQL/searchable state.
@@ -59,6 +73,8 @@ gbrain jobs get <job-id>
   hook capture.
 - Do not pass secret material as ingest content.
 - Do not re-run embedding work for unchanged chunks.
+- Do not paste raw service logs, raw prompts, or environment output into docs or
+  brain pages while debugging. Use redacted job/doctor/smoke output first.
 
 ## Output Format
 

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -26,6 +26,26 @@ writes_to:
 
 Ingest meetings, articles, media, documents, and conversations into the brain.
 
+## Async Agent-Native Entry Point
+
+For coding-agent sessions, prefer the queue-first command when ingestion should
+not add latency to the user turn:
+
+```bash
+gbrain-ingest --text "Remember this: ..." --json
+gbrain-ingest --url https://example.com/page --json
+gbrain-ingest --file ./notes/source.md --json
+```
+
+The command returns a job id and status command immediately. Enrichment,
+canonical writes, PostgreSQL import, and embeddings happen in Minions workers.
+Use `gbrain jobs get <job-id>` to inspect progress.
+
+Automatic hook capture must use `--mode signal` with distilled content only.
+Do not store raw prompts, raw transcripts, or raw tool output. Write/enrichment
+inference uses Codex OAuth with `gpt-5.4-mini`; OpenAI API keys are scoped to
+embeddings only.
+
 > **Filing rule:** Read `skills/_brain-filing-rules.md` before creating any new page.
 
 ## Contract

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -10,6 +10,11 @@
       "description": "Route content to specialized ingestion skills. Detects input type and delegates."
     },
     {
+      "name": "gbrain-ingest",
+      "path": "gbrain-ingest/SKILL.md",
+      "description": "Queue async GBrain ingest jobs that return immediately with job status metadata."
+    },
+    {
       "name": "query",
       "path": "query/SKILL.md",
       "description": "Answer questions using 3-layer search, synthesis, and citation propagation"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { readFileSync } from 'fs';
+import { basename } from 'path';
 import { loadConfig, toEngineConfig } from './core/config.ts';
 import type { BrainEngine } from './core/engine.ts';
 import { operations, OperationError } from './core/operations.ts';
@@ -19,7 +20,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'repos', 'code-def', 'code-refs', 'reindex-code', 'code-callers', 'code-callees', 'frontmatter', 'auth']);
+const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'ingest', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'repos', 'code-def', 'code-refs', 'reindex-code', 'code-callers', 'code-callees', 'frontmatter', 'auth']);
 
 async function main() {
   // Parse global flags (--quiet / --progress-json / --progress-interval)
@@ -29,9 +30,11 @@ async function main() {
   const { cliOpts, rest: args } = parseGlobalFlags(rawArgs);
   setCliOptions(cliOpts);
 
-  let command = args[0];
+  const invokedAs = basename(process.argv[1] || '');
+  const ingestAlias = invokedAs === 'gbrain-ingest';
+  let command = ingestAlias ? 'ingest' : args[0];
 
-  if (!command || command === '--help' || command === '-h') {
+  if (!command || (!ingestAlias && (command === '--help' || command === '-h'))) {
     printHelp();
     return;
   }
@@ -47,7 +50,7 @@ async function main() {
     return;
   }
 
-  const subArgs = args.slice(1);
+  const subArgs = ingestAlias ? args : args.slice(1);
 
   // DX alias: `ask` is a natural-language alias for `query`
   if (command === 'ask') {
@@ -486,6 +489,11 @@ async function handleCliOnly(command: string, args: string[]) {
         await runAgent(engine, args);
         break;
       }
+      case 'ingest': {
+        const { runIngest } = await import('./commands/ingest.ts');
+        await runIngest(engine, args);
+        break;
+      }
       case 'sync': {
         const { runSync } = await import('./commands/sync.ts');
         await runSync(engine, args);
@@ -640,6 +648,7 @@ SEARCH
   ask <question> [--no-expand]       Alias for query
 
 IMPORT/EXPORT
+  ingest [--text T|--url U|--file P] Enqueue async memory ingest
   import <dir> [--no-embed]          Import markdown directory
   sync [--repo <path>] [flags]       Git-to-brain incremental sync
   sync --watch [--interval N]        Continuous sync (loops until stopped)

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -19,6 +19,11 @@ export interface Check {
   issues?: Array<{ type: string; skill: string; action: string; fix?: any }>;
 }
 
+function parseDoctorFlag(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx >= 0 && idx + 1 < args.length ? args[idx + 1] : undefined;
+}
+
 /**
  * Run doctor with filesystem-first, DB-second architecture.
  * Filesystem checks (resolver, conformance) run without engine.
@@ -272,6 +277,34 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
     }
   } catch {
     // Best-effort. A broken JSONL should not stop doctor.
+  }
+
+  if (args.includes('--codex-oauth-smoke')) {
+    const { GBRAIN_INGEST_INFERENCE_MODEL, runCodexOAuthInference, CodexOAuthInferenceError } =
+      await import('../core/ingest/codex-oauth.ts');
+    const timeoutRaw = parseDoctorFlag(args, '--codex-oauth-timeout-ms');
+    const timeoutMs = timeoutRaw !== undefined ? Math.max(1, parseInt(timeoutRaw, 10) || 1) : 15_000;
+    try {
+      const result = await runCodexOAuthInference({
+        prompt: 'Reply with exactly: gbrain-codex-oauth-ok',
+        model: GBRAIN_INGEST_INFERENCE_MODEL,
+        timeoutMs,
+      });
+      checks.push({
+        name: 'codex_oauth_enrichment',
+        status: result.text.trim() ? 'ok' : 'fail',
+        message: `Codex OAuth enrichment available via model=${GBRAIN_INGEST_INFERENCE_MODEL}; inference env strips OpenAI API-key variables`,
+      });
+    } catch (e) {
+      const code = e instanceof CodexOAuthInferenceError ? e.code : 'runner_failed';
+      checks.push({
+        name: 'codex_oauth_enrichment',
+        status: 'fail',
+        message:
+          `Codex OAuth enrichment unavailable for model=${GBRAIN_INGEST_INFERENCE_MODEL} ` +
+          `(code=${code}). Ensure the gateway user can run non-interactive codex exec through OAuth; no API-key fallback was used.`,
+      });
+    }
   }
 
   // --- DB checks (skip if --fast or no engine) ---

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -360,15 +360,20 @@ async function embedAllStale(
 
   // Pull only the stale chunks (no embedding column).
   const staleRows = await engine.listStaleChunks();
-  // Group by slug so each slug → array of stale chunks for batched embedding.
-  const bySlug = new Map<string, typeof staleRows>();
+  // Group by source + slug so same-slug pages in different brain sources
+  // are embedded and upserted independently.
+  const bySourceSlug = new Map<string, typeof staleRows>();
+  const keyParts = new Map<string, { sourceId: string; slug: string }>();
   for (const row of staleRows) {
-    const list = bySlug.get(row.slug);
+    const sourceId = row.source_id || 'default';
+    const key = `${sourceId}\0${row.slug}`;
+    keyParts.set(key, { sourceId, slug: row.slug });
+    const list = bySourceSlug.get(key);
     if (list) list.push(row);
-    else bySlug.set(row.slug, [row]);
+    else bySourceSlug.set(key, [row]);
   }
 
-  const slugs = Array.from(bySlug.keys());
+  const keys = Array.from(bySourceSlug.keys());
   const totalStaleChunks = staleRows.length;
   result.total_chunks += totalStaleChunks;
   // skipped is "chunks we considered and skipped due to having an embedding".
@@ -378,21 +383,22 @@ async function embedAllStale(
 
   if (dryRun) {
     result.would_embed += totalStaleChunks;
-    result.pages_processed += slugs.length;
+    result.pages_processed += keys.length;
     if (onProgress) {
       // Emit a single tick to satisfy the contract (CLI progress reporters
       // expect at least one start/finish pair).
-      onProgress(slugs.length, slugs.length, 0);
+      onProgress(keys.length, keys.length, 0);
     }
-    console.log(`[dry-run] Would embed ${totalStaleChunks} chunks across ${slugs.length} pages`);
+    console.log(`[dry-run] Would embed ${totalStaleChunks} chunks across ${keys.length} pages`);
     return;
   }
 
   const CONCURRENCY = parseInt(process.env.GBRAIN_EMBED_CONCURRENCY || '20', 10);
   let processed = 0;
 
-  async function embedOneSlug(slug: string) {
-    const stale = bySlug.get(slug)!;
+  async function embedOneSourceSlug(key: string) {
+    const { sourceId, slug } = keyParts.get(key)!;
+    const stale = bySourceSlug.get(key)!;
     try {
       const embeddings = await embedBatch(stale.map(c => c.chunk_text));
       // CRITICAL: passing ONLY the stale indices to upsertChunks would
@@ -401,7 +407,7 @@ async function embedAllStale(
       // re-fetch existing chunks for this page and merge. Bounded by the
       // stale slug count, not by total slugs — autopilot common case
       // is 0 stale (pre-flight short-circuit, never reaches this path).
-      const existing = await engine.getChunks(slug);
+      const existing = await engine.getChunks(slug, sourceId);
       const staleIdxToEmbedding = new Map<number, Float32Array>();
       for (let j = 0; j < stale.length; j++) {
         staleIdxToEmbedding.set(stale[j].chunk_index, embeddings[j]);
@@ -415,26 +421,26 @@ async function embedAllStale(
         embedding: staleIdxToEmbedding.get(c.chunk_index) ?? undefined,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
-      await engine.upsertChunks(slug, merged);
+      await engine.upsertChunks(slug, merged, sourceId);
       result.embedded += stale.length;
     } catch (e: unknown) {
       console.error(`\n  Error embedding ${slug}: ${e instanceof Error ? e.message : e}`);
     }
     processed++;
     result.pages_processed++;
-    onProgress?.(processed, slugs.length, result.embedded);
+    onProgress?.(processed, keys.length, result.embedded);
   }
 
   let nextIdx = 0;
   async function worker() {
-    while (nextIdx < slugs.length) {
+    while (nextIdx < keys.length) {
       const idx = nextIdx++;
-      await embedOneSlug(slugs[idx]);
+      await embedOneSourceSlug(keys[idx]);
     }
   }
 
-  const numWorkers = Math.min(CONCURRENCY, slugs.length);
+  const numWorkers = Math.min(CONCURRENCY, keys.length);
   await Promise.all(Array.from({ length: numWorkers }, () => worker()));
 
-  console.log(`Embedded ${result.embedded} chunks across ${slugs.length} pages`);
+  console.log(`Embedded ${result.embedded} chunks across ${keys.length} pages`);
 }

--- a/src/commands/ingest.ts
+++ b/src/commands/ingest.ts
@@ -1,0 +1,91 @@
+import type { BrainEngine } from '../core/engine.ts';
+import { normalizeIngestInput } from '../core/ingest/input.ts';
+import { enqueueIngestJob } from '../core/ingest/enqueue.ts';
+import type { IngestMode } from '../core/ingest/types.ts';
+
+type Writer = (text: string) => void;
+
+export interface RunIngestIo {
+  stdin?: string;
+  stdout?: Writer;
+  stderr?: Writer;
+  cwd?: string;
+}
+
+function parseFlag(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx >= 0 && idx + 1 < args.length ? args[idx + 1] : undefined;
+}
+
+function hasFlag(args: string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+function printHelp(out: Writer): void {
+  out(`gbrain ingest — enqueue async GBrain memory ingestion
+
+USAGE
+  gbrain ingest [--text TEXT | --url URL | --file PATH] [--mode explicit|signal] [--json]
+  gbrain-ingest [--text TEXT | --url URL | --file PATH] [--mode explicit|signal] [--json]
+
+The command validates input and queues a gbrain-ingest job immediately. Workers
+perform enrichment, wiki writes, database import, and embeddings asynchronously.
+`);
+}
+
+async function readStdin(io: RunIngestIo): Promise<string | undefined> {
+  if (typeof io.stdin === 'string') return io.stdin;
+  if (process.stdin.isTTY) return undefined;
+  return Bun.file('/dev/stdin').text();
+}
+
+export async function runIngest(engine: BrainEngine, args: string[], io: RunIngestIo = {}): Promise<void> {
+  const stdout = io.stdout ?? ((text: string) => process.stdout.write(text));
+  const stderr = io.stderr ?? ((text: string) => process.stderr.write(text));
+
+  if (hasFlag(args, '--help') || hasFlag(args, '-h')) {
+    printHelp(stdout);
+    return;
+  }
+
+  const json = hasFlag(args, '--json');
+  const modeRaw = parseFlag(args, '--mode') ?? 'explicit';
+  if (modeRaw !== 'explicit' && modeRaw !== 'signal') {
+    throw new Error(`--mode must be explicit or signal, got ${modeRaw}`);
+  }
+
+  const stdin = parseFlag(args, '--text') === undefined
+    && parseFlag(args, '--url') === undefined
+    && parseFlag(args, '--file') === undefined
+      ? await readStdin(io)
+      : undefined;
+
+  const input = await normalizeIngestInput({
+    text: parseFlag(args, '--text') ?? stdin,
+    url: parseFlag(args, '--url'),
+    file: parseFlag(args, '--file'),
+    mode: modeRaw as IngestMode,
+    title: parseFlag(args, '--title'),
+    sourceId: parseFlag(args, '--source') ?? parseFlag(args, '--source-id'),
+    cwd: io.cwd,
+    metadata: {
+      submitted_by: 'gbrain-cli',
+      foreground_policy: 'enqueue-only',
+    },
+  });
+
+  const result = await enqueueIngestJob(engine, input, {
+    queue: parseFlag(args, '--queue') ?? undefined,
+  });
+
+  if (json) {
+    stdout(`${JSON.stringify(result)}\n`);
+    return;
+  }
+
+  const verb = result.queued ? 'Queued' : 'Found existing';
+  stdout(`${verb} GBrain ingest job #${result.job_id}\n`);
+  stdout(`Status: ${result.status_command}\n`);
+  stdout(`Job URL: ${result.status_url}\n`);
+  stderr('');
+}

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -179,6 +179,7 @@ HANDLER TYPES (built in)
   extract           Extract links + timeline entries; '{"mode":"all"}'
   backlinks         Check or fix back-links; '{"action":"fix"}'
   autopilot-cycle   One autopilot pass (sync+extract+embed+backlinks)
+  gbrain-ingest     Async source/signal ingest; submitted by gbrain-ingest
   shell             Run a command or argv. Requires GBRAIN_ALLOW_SHELL_JOBS=1
                     on the worker. Params: {cmd?, argv?, cwd, env?}.
                     See: docs/guides/minions-shell-jobs.md
@@ -964,6 +965,14 @@ export async function registerBuiltinHandlers(worker: MinionWorker, engine: Brai
       report,
     };
   });
+
+  {
+    const { makeIngestHandler } = await import('../core/ingest/handler.ts');
+    worker.register('gbrain-ingest', makeIngestHandler({
+      engine,
+      enableEnrichment: process.env.GBRAIN_INGEST_ENRICH !== '0',
+    }));
+  }
 
   // Shell handler is always registered. Runtime env guard lives inside the
   // handler so claimed jobs emit a clear rejection log on workers missing

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -7,6 +7,7 @@ import type { BrainEngine } from '../core/engine.ts';
 import { MinionQueue } from '../core/minions/queue.ts';
 import { MinionWorker } from '../core/minions/worker.ts';
 import type { MinionJob, MinionJobStatus } from '../core/minions/types.ts';
+import { normalizeIngestInput } from '../core/ingest/input.ts';
 
 function parseFlag(args: string[], flag: string): string | undefined {
   const idx = args.indexOf(flag);
@@ -111,6 +112,73 @@ function formatJobDetail(job: MinionJob): string {
   return lines.join('\n');
 }
 
+export interface GbrainIngestSmokeOpts {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  queue?: string;
+}
+
+export interface GbrainIngestSmokeResult {
+  job_id: number;
+  queued: true;
+  status_command: string;
+  queue: string;
+  terminal_status: MinionJobStatus | 'timeout';
+  timed_out: boolean;
+  enrichment_status?: string;
+}
+
+export async function runGbrainIngestSmoke(
+  engine: BrainEngine,
+  opts: GbrainIngestSmokeOpts = {},
+): Promise<GbrainIngestSmokeResult> {
+  const queueName = opts.queue ?? 'smoke';
+  const timeoutMs = opts.timeoutMs ?? 60_000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 250;
+  const queue = new MinionQueue(engine);
+  await queue.ensureSchema();
+  const input = await normalizeIngestInput({
+    text: `GBrain ingest smoke canary ${Date.now()}`,
+    title: 'GBrain ingest smoke canary',
+    mode: 'signal',
+    metadata: {
+      submitted_by: 'gbrain-jobs-smoke',
+      foreground_policy: 'enqueue-only',
+    },
+  });
+  const job = await queue.add('gbrain-ingest', input as unknown as Record<string, unknown>, {
+    queue: queueName,
+    max_attempts: 1,
+    timeout_ms: timeoutMs,
+    idempotency_key: `gbrain-ingest-smoke:${input.content_hash}`,
+  }, { allowProtectedSubmit: true });
+
+  const worker = new MinionWorker(engine, { queue: queueName, pollInterval: pollIntervalMs });
+  await registerBuiltinHandlers(worker, engine);
+  const workerPromise = worker.start();
+
+  let final: MinionJob | null = null;
+  for (let elapsed = 0; elapsed < timeoutMs; elapsed += pollIntervalMs) {
+    await new Promise(r => setTimeout(r, pollIntervalMs));
+    final = await queue.getJob(job.id);
+    if (final && ['completed', 'failed', 'dead', 'cancelled'].includes(final.status)) break;
+  }
+  worker.stop();
+  await workerPromise;
+
+  const result = final?.result as Record<string, unknown> | null | undefined;
+  const enrichment = result?.enrichment as Record<string, unknown> | undefined;
+  return {
+    job_id: job.id,
+    queued: true,
+    status_command: `gbrain jobs get ${job.id}`,
+    queue: queueName,
+    terminal_status: final?.status ?? 'timeout',
+    timed_out: !final || !['completed', 'failed', 'dead', 'cancelled'].includes(final.status),
+    enrichment_status: typeof enrichment?.status === 'string' ? enrichment.status : undefined,
+  };
+}
+
 export async function runJobs(engine: BrainEngine, args: string[]): Promise<void> {
   const sub = args[0];
 
@@ -131,7 +199,8 @@ USAGE
   gbrain jobs prune [--older-than 30d]
   gbrain jobs delete <id>
   gbrain jobs stats
-  gbrain jobs smoke
+  gbrain jobs smoke [--sigkill-rescue] [--wedge-rescue]
+  gbrain jobs smoke --gbrain-ingest [--timeout-ms N] [--json]
   gbrain jobs work [--queue Q] [--concurrency N] [--max-rss MB]
   gbrain jobs supervisor [start] [--detach] [--json]
                          [--concurrency N] [--queue Q] [--pid-file PATH]
@@ -485,6 +554,29 @@ HANDLER TYPES (built in)
       catch (e) {
         console.error(`SMOKE FAIL — schema init: ${e instanceof Error ? e.message : String(e)}`);
         process.exit(1);
+      }
+
+      if (hasFlag(args, '--gbrain-ingest')) {
+        const jsonMode = hasFlag(args, '--json');
+        const timeoutRaw = parseFlag(args, '--timeout-ms');
+        const timeoutMs = timeoutRaw !== undefined ? parseInt(timeoutRaw, 10) : 60_000;
+        const result = await runGbrainIngestSmoke(engine, {
+          timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 60_000,
+          queue: parseFlag(args, '--queue') ?? 'smoke',
+        });
+        if (jsonMode) {
+          console.log(JSON.stringify(result));
+        } else if (result.timed_out) {
+          console.log(`SMOKE WAIT — gbrain-ingest job #${result.job_id} did not reach terminal state before timeout`);
+          console.log(`Status: ${result.status_command}`);
+        } else {
+          console.log(
+            `SMOKE PASS — gbrain-ingest job #${result.job_id} terminal=${result.terminal_status}` +
+            `${result.enrichment_status ? ` enrichment=${result.enrichment_status}` : ''}`
+          );
+          console.log(`Status: ${result.status_command}`);
+        }
+        process.exit(result.terminal_status === 'completed' ? 0 : 1);
       }
 
       const sigkillRescue = hasFlag(args, '--sigkill-rescue');

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -8,6 +8,8 @@
  */
 
 import OpenAI from 'openai';
+import { execFileSync } from 'child_process';
+import { platform } from 'os';
 
 const MODEL = 'text-embedding-3-large';
 const DIMENSIONS = 1536;
@@ -16,12 +18,49 @@ const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
+const KEYCHAIN_SERVICE = 'gbrain-openai-embeddings';
 
 let client: OpenAI | null = null;
+let clientApiKey: string | null = null;
+let cachedKeychainApiKey: string | undefined | null = null;
+
+export interface EmbeddingApiKeyOptions {
+  includeKeychain?: boolean;
+}
+
+export function resolveEmbeddingApiKey(options: EmbeddingApiKeyOptions = {}): string | undefined {
+  const scopedKey =
+    cleanSecret(process.env.GBRAIN_EMBEDDINGS_OPENAI_API_KEY) ||
+    cleanSecret(process.env.GBRAIN_OPENAI_EMBEDDING_API_KEY);
+  if (scopedKey) return scopedKey;
+
+  if (options.includeKeychain !== false) {
+    const keychainKey = readKeychainEmbeddingApiKey();
+    if (keychainKey) return keychainKey;
+  }
+
+  if (process.env.GBRAIN_ALLOW_LEGACY_OPENAI_API_KEY_FOR_EMBEDDINGS === '1') {
+    return cleanSecret(process.env.OPENAI_API_KEY);
+  }
+
+  return undefined;
+}
+
+export function hasEmbeddingApiKey(options: EmbeddingApiKeyOptions = {}): boolean {
+  return Boolean(resolveEmbeddingApiKey(options));
+}
 
 function getClient(): OpenAI {
-  if (!client) {
-    client = new OpenAI();
+  const apiKey = resolveEmbeddingApiKey();
+  if (!apiKey) {
+    throw new Error(
+      'GBrain embedding OpenAI API key is not configured. Set GBRAIN_EMBEDDINGS_OPENAI_API_KEY for this process or store it in the macOS Keychain service gbrain-openai-embeddings.'
+    );
+  }
+
+  if (!client || clientApiKey !== apiKey) {
+    client = new OpenAI({ apiKey });
+    clientApiKey = apiKey;
   }
   return client;
 }
@@ -105,6 +144,34 @@ function sleep(ms: number): Promise<void> {
 }
 
 export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
+export { BATCH_SIZE as EMBEDDING_BATCH_SIZE };
+
+function cleanSecret(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function readKeychainEmbeddingApiKey(): string | undefined {
+  if (platform() !== 'darwin') return undefined;
+  if (cachedKeychainApiKey !== null) return cachedKeychainApiKey;
+
+  try {
+    const output = execFileSync(
+      'security',
+      ['find-generic-password', '-s', KEYCHAIN_SERVICE, '-w'],
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 2000,
+      },
+    );
+    cachedKeychainApiKey = cleanSecret(output);
+  } catch {
+    cachedKeychainApiKey = undefined;
+  }
+
+  return cachedKeychainApiKey;
+}
 
 /**
  * v0.20.0 Cathedral II Layer 8 (D1): USD cost per 1k tokens for

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -131,16 +131,16 @@ export interface BrainEngine {
   getEmbeddingsByChunkIds(ids: number[]): Promise<Map<number, Float32Array>>;
 
   // Chunks
-  upsertChunks(slug: string, chunks: ChunkInput[]): Promise<void>;
-  getChunks(slug: string): Promise<Chunk[]>;
+  upsertChunks(slug: string, chunks: ChunkInput[], sourceId?: string): Promise<void>;
+  getChunks(slug: string, sourceId?: string): Promise<Chunk[]>;
   /**
-   * Count chunks across the entire brain where embedded_at IS NULL.
+   * Count chunks across the entire brain where embedding IS NULL.
    * Pre-flight short-circuit for `embed --stale` so a 100%-embedded brain
    * does no further work after a single SELECT count(*) (~50 bytes wire).
    */
   countStaleChunks(): Promise<number>;
   /**
-   * Return every chunk where embedded_at IS NULL, with the metadata needed
+   * Return every chunk where embedding IS NULL, with the metadata needed
    * to call embedBatch + upsertChunks. The `embedding` column is omitted
    * by design — stale rows have NULL embeddings, so shipping them wastes
    * wire bytes for no gain. Caller groups by slug, embeds, and re-upserts.

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -252,16 +252,34 @@ export async function importFromContent(
     chunks.push(...fenceChunks);
   }
 
+  const existingChunks = existing ? await engine.getChunks(slug) : [];
+  const existingByKey = new Map<string, typeof existingChunks[number]>();
+  for (const ec of existingChunks) {
+    existingByKey.set(`${ec.chunk_index}:${ec.chunk_text}`, ec);
+  }
+  const needsEmbedIndexes: number[] = [];
+  for (let i = 0; i < chunks.length; i++) {
+    const key = `${chunks[i]!.chunk_index}:${chunks[i]!.chunk_text}`;
+    const matched = existingByKey.get(key);
+    if (matched && matched.embedding) {
+      chunks[i]!.embedding = matched.embedding as Float32Array;
+      chunks[i]!.token_count = matched.token_count ?? undefined;
+    } else {
+      needsEmbedIndexes.push(i);
+    }
+  }
+
   // Embed BEFORE the transaction (external API call)
-  if (!opts.noEmbed && chunks.length > 0) {
+  if (!opts.noEmbed && needsEmbedIndexes.length > 0) {
     try {
-      const embeddings = await embedBatch(chunks.map(c => c.chunk_text));
-      for (let i = 0; i < chunks.length; i++) {
-        chunks[i].embedding = embeddings[i];
-        chunks[i].token_count = Math.ceil(chunks[i].chunk_text.length / 4);
+      const embeddings = await embedBatch(needsEmbedIndexes.map(i => chunks[i]!.chunk_text));
+      for (let j = 0; j < needsEmbedIndexes.length; j++) {
+        const i = needsEmbedIndexes[j]!;
+        chunks[i]!.embedding = embeddings[j]!;
+        chunks[i]!.token_count = Math.ceil(chunks[i]!.chunk_text.length / 4);
       }
     } catch (e: unknown) {
-      console.warn(`[gbrain] embedding failed for ${slug} (${chunks.length} chunks): ${e instanceof Error ? e.message : String(e)}`);
+      console.warn(`[gbrain] embedding failed for ${slug} (${needsEmbedIndexes.length} changed chunks): ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 

--- a/src/core/ingest/codex-oauth.ts
+++ b/src/core/ingest/codex-oauth.ts
@@ -1,14 +1,19 @@
 import { mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
-
-const execFileAsync = promisify(execFile);
+import { spawn, type ChildProcess } from 'child_process';
 
 export const GBRAIN_INGEST_INFERENCE_MODEL = 'gpt-5.4-mini';
+export const DEFAULT_CODEX_OAUTH_TIMEOUT_MS = 120_000;
 
-export type CodexOAuthInferenceErrorCode = 'configuration_error' | 'model_rejected' | 'runner_failed';
+export type CodexOAuthInferenceErrorCode =
+  | 'configuration_error'
+  | 'model_rejected'
+  | 'runner_failed'
+  | 'timeout'
+  | 'aborted'
+  | 'empty_output'
+  | 'oauth_unavailable';
 
 export class CodexOAuthInferenceError extends Error {
   constructor(message: string, public readonly code: CodexOAuthInferenceErrorCode) {
@@ -20,6 +25,7 @@ export class CodexOAuthInferenceError extends Error {
 export interface CodexOAuthRunnerRequest {
   prompt: string;
   model: typeof GBRAIN_INGEST_INFERENCE_MODEL;
+  signal?: AbortSignal;
 }
 
 export interface CodexOAuthRunnerResult {
@@ -34,6 +40,8 @@ export interface CodexOAuthInferenceRequest {
   prompt: string;
   model: string;
   runner?: CodexOAuthRunner;
+  timeoutMs?: number;
+  signal?: AbortSignal;
 }
 
 const INFERENCE_SECRET_ENV_KEYS = new Set([
@@ -51,11 +59,82 @@ export function sanitizeInferenceEnv(env: NodeJS.ProcessEnv = process.env): Node
   return out;
 }
 
+function classifyRunnerError(error: unknown): CodexOAuthInferenceError {
+  if (error instanceof CodexOAuthInferenceError) return error;
+  const message = error instanceof Error ? error.message : String(error);
+  const stderr = typeof (error as any)?.stderr === 'string' ? (error as any).stderr : '';
+  const combined = `${message}\n${stderr}`;
+  if (/aborted|aborterror/i.test(combined)) {
+    return new CodexOAuthInferenceError('Codex OAuth inference was aborted', 'aborted');
+  }
+  if (/timed? ?out|timeout|ETIMEDOUT/i.test(combined)) {
+    return new CodexOAuthInferenceError('Codex OAuth inference timed out', 'timeout');
+  }
+  if (/ENOENT|not found|No such file/i.test(combined)) {
+    return new CodexOAuthInferenceError('Codex CLI is not available for OAuth inference', 'configuration_error');
+  }
+  if (/(login|auth|oauth|unauthenticated|authentication|sign in|interactive|browser|device code)/i.test(combined)) {
+    return new CodexOAuthInferenceError('Codex OAuth route is unavailable or requires interactive authentication', 'oauth_unavailable');
+  }
+  return new CodexOAuthInferenceError('Codex OAuth inference failed', 'runner_failed');
+}
+
+function killProcessTree(child: ChildProcess, signal: NodeJS.Signals = 'SIGTERM'): void {
+  if (!child.pid) return;
+  try {
+    if (process.platform !== 'win32') {
+      process.kill(-child.pid, signal);
+    } else {
+      child.kill(signal);
+    }
+  } catch {
+    try { child.kill(signal); } catch { /* already gone */ }
+  }
+}
+
+function waitForChild(
+  child: ChildProcess,
+  signal?: AbortSignal,
+): Promise<{ code: number | null; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    let stderr = '';
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal?.removeEventListener('abort', onAbort);
+      fn();
+    };
+    const onAbort = () => {
+      killProcessTree(child, 'SIGTERM');
+      setTimeout(() => killProcessTree(child, 'SIGKILL'), 2_000).unref?.();
+      settle(() => reject(new CodexOAuthInferenceError('Codex OAuth inference was aborted', 'aborted')));
+    };
+
+    child.stderr?.on('data', chunk => {
+      stderr = `${stderr}${String(chunk)}`.slice(-8_000);
+    });
+    child.on('error', error => {
+      settle(() => reject(error));
+    });
+    child.on('close', code => {
+      settle(() => resolve({ code, stderr }));
+    });
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+    }
+  });
+}
+
 async function liveCodexOAuthRunner(request: CodexOAuthRunnerRequest): Promise<CodexOAuthRunnerResult> {
   const dir = mkdtempSync(join(tmpdir(), 'gbrain-codex-oauth-'));
   const outputPath = join(dir, 'last-message.txt');
   try {
-    await execFileAsync('codex', [
+    const child = spawn('codex', [
       'exec',
       '--model', request.model,
       '--skip-git-repo-check',
@@ -65,23 +144,65 @@ async function liveCodexOAuthRunner(request: CodexOAuthRunnerRequest): Promise<C
       request.prompt,
     ], {
       env: sanitizeInferenceEnv(),
-      timeout: 120_000,
-      maxBuffer: 10 * 1024 * 1024,
+      detached: process.platform !== 'win32',
+      stdio: ['ignore', 'ignore', 'pipe'],
     });
+    const { code, stderr } = await waitForChild(child, request.signal);
+    if (code !== 0) {
+      const error = new Error(`Codex OAuth process exited with code ${code}`);
+      (error as any).stderr = stderr;
+      throw error;
+    }
     const text = readFileSync(outputPath, 'utf8').trim();
     if (!text) {
-      throw new CodexOAuthInferenceError('Codex OAuth runner returned an empty response', 'runner_failed');
+      throw new CodexOAuthInferenceError('Codex OAuth runner returned an empty response', 'empty_output');
     }
     return { text, route: 'codex-oauth', model: request.model };
   } catch (e) {
-    if (e instanceof CodexOAuthInferenceError) throw e;
-    const message = e instanceof Error ? e.message : String(e);
-    const code: CodexOAuthInferenceErrorCode = /ENOENT|not found|No such file/i.test(message)
-      ? 'configuration_error'
-      : 'runner_failed';
-    throw new CodexOAuthInferenceError(`Codex OAuth inference failed: ${message}`, code);
+    throw classifyRunnerError(e);
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function deriveAbortReason(signal?: AbortSignal): CodexOAuthInferenceError {
+  const reason = signal?.reason;
+  if (reason instanceof CodexOAuthInferenceError) return reason;
+  return new CodexOAuthInferenceError('Codex OAuth inference was aborted', 'aborted');
+}
+
+async function runWithBoundaries(
+  run: (signal?: AbortSignal) => Promise<CodexOAuthRunnerResult>,
+  opts: { timeoutMs: number; signal?: AbortSignal },
+): Promise<CodexOAuthRunnerResult> {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  const abort = (reason: unknown) => {
+    if (!controller.signal.aborted) controller.abort(reason);
+  };
+  const onExternalAbort = () => abort(deriveAbortReason(opts.signal));
+  if (opts.signal) {
+    if (opts.signal.aborted) throw deriveAbortReason(opts.signal);
+    opts.signal.addEventListener('abort', onExternalAbort, { once: true });
+  }
+  if (opts.timeoutMs > 0) {
+    timeout = setTimeout(() => {
+      abort(new CodexOAuthInferenceError('Codex OAuth inference timed out', 'timeout'));
+    }, opts.timeoutMs);
+  }
+
+  try {
+    return await Promise.race([
+      run(controller.signal),
+      new Promise<never>((_, reject) => {
+        controller.signal.addEventListener('abort', () => reject(deriveAbortReason(controller.signal)), { once: true });
+      }),
+    ]);
+  } catch (e) {
+    throw classifyRunnerError(e);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    opts.signal?.removeEventListener('abort', onExternalAbort);
   }
 }
 
@@ -96,8 +217,16 @@ export async function runCodexOAuthInference(request: CodexOAuthInferenceRequest
     throw new CodexOAuthInferenceError('GBrain ingest inference prompt is empty', 'runner_failed');
   }
   const runner = request.runner ?? liveCodexOAuthRunner;
-  return runner({
-    prompt: request.prompt,
-    model: GBRAIN_INGEST_INFERENCE_MODEL,
+  const result = await runWithBoundaries((signal) => runner({
+      prompt: request.prompt,
+      model: GBRAIN_INGEST_INFERENCE_MODEL,
+      signal,
+    }), {
+      timeoutMs: request.timeoutMs ?? DEFAULT_CODEX_OAUTH_TIMEOUT_MS,
+      signal: request.signal,
   });
+  if (!result.text.trim()) {
+    throw new CodexOAuthInferenceError('Codex OAuth runner returned an empty response', 'empty_output');
+  }
+  return { ...result, text: result.text.trim(), model: result.model ?? GBRAIN_INGEST_INFERENCE_MODEL };
 }

--- a/src/core/ingest/codex-oauth.ts
+++ b/src/core/ingest/codex-oauth.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export const GBRAIN_INGEST_INFERENCE_MODEL = 'gpt-5.4-mini';
+
+export type CodexOAuthInferenceErrorCode = 'configuration_error' | 'model_rejected' | 'runner_failed';
+
+export class CodexOAuthInferenceError extends Error {
+  constructor(message: string, public readonly code: CodexOAuthInferenceErrorCode) {
+    super(message);
+    this.name = 'CodexOAuthInferenceError';
+  }
+}
+
+export interface CodexOAuthRunnerRequest {
+  prompt: string;
+  model: typeof GBRAIN_INGEST_INFERENCE_MODEL;
+}
+
+export interface CodexOAuthRunnerResult {
+  text: string;
+  route: 'codex-oauth';
+  model?: string;
+}
+
+export type CodexOAuthRunner = (request: CodexOAuthRunnerRequest) => Promise<CodexOAuthRunnerResult>;
+
+export interface CodexOAuthInferenceRequest {
+  prompt: string;
+  model: string;
+  runner?: CodexOAuthRunner;
+}
+
+const INFERENCE_SECRET_ENV_KEYS = new Set([
+  'OPENAI_API_KEY',
+  'GBRAIN_EMBEDDINGS_OPENAI_API_KEY',
+  'GBRAIN_OPENAI_EMBEDDING_API_KEY',
+]);
+
+export function sanitizeInferenceEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (INFERENCE_SECRET_ENV_KEYS.has(key)) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+async function liveCodexOAuthRunner(request: CodexOAuthRunnerRequest): Promise<CodexOAuthRunnerResult> {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-codex-oauth-'));
+  const outputPath = join(dir, 'last-message.txt');
+  try {
+    await execFileAsync('codex', [
+      'exec',
+      '--model', request.model,
+      '--skip-git-repo-check',
+      '--ephemeral',
+      '--sandbox', 'read-only',
+      '--output-last-message', outputPath,
+      request.prompt,
+    ], {
+      env: sanitizeInferenceEnv(),
+      timeout: 120_000,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    const text = readFileSync(outputPath, 'utf8').trim();
+    if (!text) {
+      throw new CodexOAuthInferenceError('Codex OAuth runner returned an empty response', 'runner_failed');
+    }
+    return { text, route: 'codex-oauth', model: request.model };
+  } catch (e) {
+    if (e instanceof CodexOAuthInferenceError) throw e;
+    const message = e instanceof Error ? e.message : String(e);
+    const code: CodexOAuthInferenceErrorCode = /ENOENT|not found|No such file/i.test(message)
+      ? 'configuration_error'
+      : 'runner_failed';
+    throw new CodexOAuthInferenceError(`Codex OAuth inference failed: ${message}`, code);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+export async function runCodexOAuthInference(request: CodexOAuthInferenceRequest): Promise<CodexOAuthRunnerResult> {
+  if (request.model !== GBRAIN_INGEST_INFERENCE_MODEL) {
+    throw new CodexOAuthInferenceError(
+      `GBrain ingest inference requires model=${GBRAIN_INGEST_INFERENCE_MODEL}; got ${String(request.model || '(omitted)')}`,
+      'model_rejected',
+    );
+  }
+  if (!request.prompt.trim()) {
+    throw new CodexOAuthInferenceError('GBrain ingest inference prompt is empty', 'runner_failed');
+  }
+  const runner = request.runner ?? liveCodexOAuthRunner;
+  return runner({
+    prompt: request.prompt,
+    model: GBRAIN_INGEST_INFERENCE_MODEL,
+  });
+}

--- a/src/core/ingest/enqueue.ts
+++ b/src/core/ingest/enqueue.ts
@@ -1,0 +1,45 @@
+import type { BrainEngine } from '../engine.ts';
+import { MinionQueue } from '../minions/queue.ts';
+import type { NormalizedIngestInput, EnqueueIngestResult } from './types.ts';
+import { INGEST_JOB_NAME, INGEST_QUEUE_NAME } from './types.ts';
+
+export function ingestIdempotencyKey(input: NormalizedIngestInput): string {
+  const scope = input.source_id ?? 'default';
+  const locator = input.url ?? input.file?.path ?? input.kind;
+  return `${INGEST_JOB_NAME}:${input.mode}:${scope}:${input.kind}:${input.content_hash}:${locator}`;
+}
+
+export async function enqueueIngestJob(
+  engine: BrainEngine,
+  input: NormalizedIngestInput,
+  opts: { queue?: string; priority?: number; maxAttempts?: number } = {},
+): Promise<EnqueueIngestResult> {
+  const queueName = opts.queue ?? INGEST_QUEUE_NAME;
+  const idempotencyKey = ingestIdempotencyKey(input);
+  const queue = new MinionQueue(engine);
+  await queue.ensureSchema();
+  const existingRows = await engine.executeRaw<{ id: number }>(
+    `SELECT id FROM minion_jobs WHERE idempotency_key = $1 LIMIT 1`,
+    [idempotencyKey],
+  );
+  const hadExisting = existingRows.length > 0;
+
+  const job = await queue.add(INGEST_JOB_NAME, input as unknown as Record<string, unknown>, {
+    queue: queueName,
+    priority: opts.priority ?? 0,
+    max_attempts: opts.maxAttempts ?? 3,
+    max_stalled: 5,
+    timeout_ms: 10 * 60 * 1000,
+    idempotency_key: idempotencyKey,
+  }, { allowProtectedSubmit: true });
+
+  return {
+    job_id: job.id,
+    queued: !hadExisting,
+    idempotency_key: idempotencyKey,
+    status_command: `gbrain jobs get ${job.id}`,
+    status_url: `gbrain://jobs/${job.id}`,
+    job_name: INGEST_JOB_NAME,
+    queue: job.queue,
+  };
+}

--- a/src/core/ingest/enrichment.ts
+++ b/src/core/ingest/enrichment.ts
@@ -2,9 +2,11 @@ import type { BrainEngine } from '../engine.ts';
 import type { PageType } from '../types.ts';
 import { slugifySegment } from '../sync.ts';
 import {
+  CodexOAuthInferenceError,
   GBRAIN_INGEST_INFERENCE_MODEL,
   runCodexOAuthInference,
   type CodexOAuthRunner,
+  type CodexOAuthInferenceErrorCode,
 } from './codex-oauth.ts';
 
 type EntityKind = 'people' | 'organizations' | 'concepts';
@@ -45,12 +47,30 @@ export interface EnrichAcceptedSourceRequest {
   sourceText: string;
   runner?: CodexOAuthRunner;
   allowPartial?: boolean;
+  signal?: AbortSignal;
 }
 
 export interface EnrichAcceptedSourceResult {
   status: 'enriched' | 'skipped';
   updated_slugs: string[];
   skipped: number;
+}
+
+export type BoundedEnrichmentStatus =
+  | 'succeeded'
+  | 'skipped'
+  | 'failed'
+  | 'timeout'
+  | 'configuration_error';
+
+export interface BoundedEnrichmentResult {
+  status: BoundedEnrichmentStatus;
+  error_code?: CodexOAuthInferenceErrorCode | 'enrichment_failed';
+  message?: string;
+  reason?: 'disabled' | 'source_noop';
+  updated_slugs?: string[];
+  skipped?: number;
+  raw_status?: EnrichAcceptedSourceResult['status'];
 }
 
 function asArray(value: unknown): unknown[] {
@@ -184,6 +204,7 @@ export async function enrichAcceptedSource(req: EnrichAcceptedSourceRequest): Pr
     prompt: enrichmentPrompt(req.sourceTitle, req.sourceText),
     model: GBRAIN_INGEST_INFERENCE_MODEL,
     runner: req.runner,
+    signal: req.signal,
   });
   const extracted = validateEnrichmentOutput(response.text, { allowPartial: req.allowPartial });
   const nameToSlug = new Map<string, string>();
@@ -218,5 +239,43 @@ export async function enrichAcceptedSource(req: EnrichAcceptedSourceRequest): Pr
     status: updated.size > 0 || extracted.timeline.length > 0 ? 'enriched' : 'skipped',
     updated_slugs: Array.from(updated),
     skipped,
+  };
+}
+
+export function summarizeSuccessfulEnrichment(result: EnrichAcceptedSourceResult): BoundedEnrichmentResult {
+  return {
+    status: result.status === 'enriched' ? 'succeeded' : 'skipped',
+    raw_status: result.status,
+    updated_slugs: result.updated_slugs,
+    skipped: result.skipped,
+  };
+}
+
+export function summarizeFailedEnrichment(error: unknown): BoundedEnrichmentResult {
+  if (error instanceof CodexOAuthInferenceError) {
+    if (error.code === 'timeout') {
+      return {
+        status: 'timeout',
+        error_code: error.code,
+        message: 'Codex OAuth enrichment timed out',
+      };
+    }
+    if (error.code === 'configuration_error' || error.code === 'oauth_unavailable' || error.code === 'model_rejected') {
+      return {
+        status: 'configuration_error',
+        error_code: error.code,
+        message: 'Codex OAuth enrichment is unavailable or misconfigured',
+      };
+    }
+    return {
+      status: 'failed',
+      error_code: error.code,
+      message: 'Codex OAuth enrichment failed',
+    };
+  }
+  return {
+    status: 'failed',
+    error_code: 'enrichment_failed',
+    message: 'GBrain enrichment failed',
   };
 }

--- a/src/core/ingest/enrichment.ts
+++ b/src/core/ingest/enrichment.ts
@@ -1,0 +1,222 @@
+import type { BrainEngine } from '../engine.ts';
+import type { PageType } from '../types.ts';
+import { slugifySegment } from '../sync.ts';
+import {
+  GBRAIN_INGEST_INFERENCE_MODEL,
+  runCodexOAuthInference,
+  type CodexOAuthRunner,
+} from './codex-oauth.ts';
+
+type EntityKind = 'people' | 'organizations' | 'concepts';
+
+interface CandidateEntity {
+  name: string;
+  citation?: string;
+  confidence?: number;
+}
+
+interface CandidateRelationship {
+  from: string;
+  to: string;
+  type?: string;
+  citation?: string;
+  confidence?: number;
+}
+
+interface CandidateTimeline {
+  date: string;
+  summary: string;
+  citation?: string;
+  confidence?: number;
+}
+
+export interface EnrichmentOutput {
+  people: CandidateEntity[];
+  organizations: CandidateEntity[];
+  concepts: CandidateEntity[];
+  relationships: CandidateRelationship[];
+  timeline: CandidateTimeline[];
+}
+
+export interface EnrichAcceptedSourceRequest {
+  engine: BrainEngine;
+  sourceSlug: string;
+  sourceTitle: string;
+  sourceText: string;
+  runner?: CodexOAuthRunner;
+  allowPartial?: boolean;
+}
+
+export interface EnrichAcceptedSourceResult {
+  status: 'enriched' | 'skipped';
+  updated_slugs: string[];
+  skipped: number;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function cleanName(value: unknown): string {
+  return typeof value === 'string' ? value.trim().slice(0, 120) : '';
+}
+
+function hasCitation(candidate: { citation?: string }): boolean {
+  return typeof candidate.citation === 'string' && candidate.citation.trim().length > 0;
+}
+
+function entitySlug(kind: EntityKind, name: string): string {
+  const segment = slugifySegment(name.replace(/\./g, ' ')) || 'unknown';
+  if (kind === 'people') return `people/${segment}`;
+  if (kind === 'organizations') return `companies/${segment}`;
+  return `concepts/${segment}`;
+}
+
+function entityType(kind: EntityKind): PageType {
+  if (kind === 'people') return 'person';
+  if (kind === 'organizations') return 'company';
+  return 'concept';
+}
+
+function validateEntity(raw: unknown, kind: EntityKind, allowPartial: boolean): CandidateEntity | null {
+  const r = raw as Record<string, unknown>;
+  const candidate: CandidateEntity = {
+    name: cleanName(r?.name),
+    citation: typeof r?.citation === 'string' ? r.citation.trim() : undefined,
+    confidence: typeof r?.confidence === 'number' ? r.confidence : undefined,
+  };
+  if (!candidate.name || !hasCitation(candidate)) {
+    if (allowPartial) return null;
+    throw new Error(`${kind} enrichment candidate requires name and citation`);
+  }
+  if (candidate.confidence !== undefined && candidate.confidence < 0.45) return null;
+  return candidate;
+}
+
+function validateRelationship(raw: unknown, allowPartial: boolean): CandidateRelationship | null {
+  const r = raw as Record<string, unknown>;
+  const candidate: CandidateRelationship = {
+    from: cleanName(r?.from),
+    to: cleanName(r?.to),
+    type: typeof r?.type === 'string' ? slugifySegment(r.type) : 'related',
+    citation: typeof r?.citation === 'string' ? r.citation.trim() : undefined,
+    confidence: typeof r?.confidence === 'number' ? r.confidence : undefined,
+  };
+  if (!candidate.from || !candidate.to || !hasCitation(candidate)) {
+    if (allowPartial) return null;
+    throw new Error('relationship enrichment candidate requires from, to, and citation');
+  }
+  if (candidate.confidence !== undefined && candidate.confidence < 0.45) return null;
+  return candidate;
+}
+
+function validateTimeline(raw: unknown, allowPartial: boolean): CandidateTimeline | null {
+  const r = raw as Record<string, unknown>;
+  const candidate: CandidateTimeline = {
+    date: typeof r?.date === 'string' ? r.date.trim() : '',
+    summary: typeof r?.summary === 'string' ? r.summary.trim() : '',
+    citation: typeof r?.citation === 'string' ? r.citation.trim() : undefined,
+    confidence: typeof r?.confidence === 'number' ? r.confidence : undefined,
+  };
+  if (!/^\d{4}-\d{2}-\d{2}/.test(candidate.date) || !candidate.summary || !hasCitation(candidate)) {
+    if (allowPartial) return null;
+    throw new Error('timeline enrichment candidate requires ISO date, summary, and citation');
+  }
+  if (candidate.confidence !== undefined && candidate.confidence < 0.45) return null;
+  return candidate;
+}
+
+export function validateEnrichmentOutput(rawText: string, opts: { allowPartial?: boolean } = {}): EnrichmentOutput {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    throw new Error('enrichment output must be valid JSON');
+  }
+  const obj = parsed as Record<string, unknown>;
+  const allowPartial = opts.allowPartial === true;
+
+  return {
+    people: asArray(obj.people).map(v => validateEntity(v, 'people', allowPartial)).filter((v): v is CandidateEntity => !!v),
+    organizations: asArray(obj.organizations).map(v => validateEntity(v, 'organizations', allowPartial)).filter((v): v is CandidateEntity => !!v),
+    concepts: asArray(obj.concepts).map(v => validateEntity(v, 'concepts', allowPartial)).filter((v): v is CandidateEntity => !!v),
+    relationships: asArray(obj.relationships).map(v => validateRelationship(v, allowPartial)).filter((v): v is CandidateRelationship => !!v),
+    timeline: asArray(obj.timeline).map(v => validateTimeline(v, allowPartial)).filter((v): v is CandidateTimeline => !!v),
+  };
+}
+
+function enrichmentPrompt(sourceTitle: string, sourceText: string): string {
+  return [
+    'Extract only evidence-backed durable memory candidates from this source.',
+    'Return compact JSON with keys: people, organizations, concepts, relationships, timeline.',
+    'Every candidate MUST include a short citation copied from the source text.',
+    'Do not infer uncited facts. Do not include raw transcript beyond citations.',
+    '',
+    `Title: ${sourceTitle}`,
+    '',
+    sourceText.slice(0, 12000),
+  ].join('\n');
+}
+
+async function upsertEntity(engine: BrainEngine, kind: EntityKind, entity: CandidateEntity, sourceSlug: string): Promise<string> {
+  const slug = entitySlug(kind, entity.name);
+  const existing = await engine.getPage(slug);
+  const evidence = `- [[${sourceSlug}]]: "${entity.citation}"`;
+  const current = existing?.compiled_truth ?? '';
+  const compiled = current.includes(evidence)
+    ? current
+    : [current || `# ${entity.name}`, '', '## Evidence', evidence].filter(Boolean).join('\n');
+  await engine.putPage(slug, {
+    type: entityType(kind),
+    title: entity.name,
+    compiled_truth: compiled,
+    frontmatter: {
+      gbrain_ingest_enriched: true,
+      evidence_sources: [sourceSlug],
+    },
+  });
+  await engine.addLink(slug, sourceSlug, entity.citation, 'cites', 'manual');
+  return slug;
+}
+
+export async function enrichAcceptedSource(req: EnrichAcceptedSourceRequest): Promise<EnrichAcceptedSourceResult> {
+  const response = await runCodexOAuthInference({
+    prompt: enrichmentPrompt(req.sourceTitle, req.sourceText),
+    model: GBRAIN_INGEST_INFERENCE_MODEL,
+    runner: req.runner,
+  });
+  const extracted = validateEnrichmentOutput(response.text, { allowPartial: req.allowPartial });
+  const nameToSlug = new Map<string, string>();
+  const updated = new Set<string>();
+  let skipped = 0;
+
+  for (const kind of ['people', 'organizations', 'concepts'] as EntityKind[]) {
+    for (const entity of extracted[kind]) {
+      const slug = await upsertEntity(req.engine, kind, entity, req.sourceSlug);
+      nameToSlug.set(entity.name.toLowerCase(), slug);
+      updated.add(slug);
+    }
+  }
+
+  for (const rel of extracted.relationships) {
+    const from = nameToSlug.get(rel.from.toLowerCase());
+    const to = nameToSlug.get(rel.to.toLowerCase());
+    if (!from || !to) { skipped++; continue; }
+    await req.engine.addLink(from, to, rel.citation, rel.type || 'related', 'manual');
+  }
+
+  const timelineTarget = Array.from(updated).find(slug => slug.startsWith('concepts/')) ?? req.sourceSlug;
+  for (const entry of extracted.timeline) {
+    await req.engine.addTimelineEntry(timelineTarget, {
+      date: entry.date,
+      summary: entry.summary,
+      source: `${req.sourceSlug}: ${entry.citation}`,
+    });
+  }
+
+  return {
+    status: updated.size > 0 || extracted.timeline.length > 0 ? 'enriched' : 'skipped',
+    updated_slugs: Array.from(updated),
+    skipped,
+  };
+}

--- a/src/core/ingest/handler.ts
+++ b/src/core/ingest/handler.ts
@@ -1,0 +1,267 @@
+import { createHash } from 'crypto';
+import { isIP } from 'net';
+import { existsSync, statSync } from 'fs';
+import { join } from 'path';
+import type { BrainEngine } from '../engine.ts';
+import type { MinionHandler, MinionJobContext } from '../minions/types.ts';
+import { importFromContent } from '../import-file.ts';
+import { serializeMarkdown } from '../markdown.ts';
+import { slugifySegment } from '../sync.ts';
+import { writeBrainPage } from '../brain-writer.ts';
+import type { NormalizedIngestInput } from './types.ts';
+import { INGEST_PAYLOAD_VERSION } from './types.ts';
+import type { CodexOAuthRunner } from './codex-oauth.ts';
+
+export interface FetchedText {
+  finalUrl: string;
+  contentType: string;
+  text: string;
+}
+
+export interface IngestHandlerDeps {
+  engine: BrainEngine;
+  fetchText?: (url: string, signal?: AbortSignal) => Promise<FetchedText>;
+  enableEnrichment?: boolean;
+  inferenceRunner?: CodexOAuthRunner;
+}
+
+const MAX_URL_BYTES = 5 * 1024 * 1024;
+
+interface SourceLocalPath {
+  sourceId: string;
+  localPath: string | null;
+}
+
+function shortHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+function assertNormalizedInput(data: Record<string, unknown>): NormalizedIngestInput {
+  if (data.version !== INGEST_PAYLOAD_VERSION) {
+    throw new Error(`unsupported gbrain-ingest payload version: ${String(data.version)}`);
+  }
+  if (data.kind !== 'text' && data.kind !== 'url' && data.kind !== 'file') {
+    throw new Error(`unsupported gbrain-ingest kind: ${String(data.kind)}`);
+  }
+  if (data.mode !== 'explicit' && data.mode !== 'signal') {
+    throw new Error(`unsupported gbrain-ingest mode: ${String(data.mode)}`);
+  }
+  if (typeof data.content_hash !== 'string' || data.content_hash.length < 16) {
+    throw new Error('gbrain-ingest payload missing content_hash');
+  }
+  return data as unknown as NormalizedIngestInput;
+}
+
+function isPrivateIPv4(host: string): boolean {
+  const parts = host.split('.').map(p => Number.parseInt(p, 10));
+  if (parts.length !== 4 || parts.some(p => !Number.isInteger(p) || p < 0 || p > 255)) return false;
+  const [a, b] = parts;
+  return a === 10
+    || a === 127
+    || (a === 172 && b >= 16 && b <= 31)
+    || (a === 192 && b === 168)
+    || (a === 169 && b === 254)
+    || a === 0;
+}
+
+export function assertPublicHttpUrl(rawUrl: string): URL {
+  const url = new URL(rawUrl);
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error(`unsupported URL scheme: ${url.protocol}`);
+  }
+  const host = url.hostname.toLowerCase();
+  if (host === 'localhost' || host.endsWith('.localhost')) {
+    throw new Error(`refusing private URL host: ${url.hostname}`);
+  }
+  const ipKind = isIP(host);
+  if (ipKind === 4 && isPrivateIPv4(host)) {
+    throw new Error(`refusing private URL host: ${url.hostname}`);
+  }
+  if (ipKind === 6) {
+    const normalized = host.replace(/^\[|\]$/g, '');
+    if (normalized === '::1' || normalized.startsWith('fc') || normalized.startsWith('fd') || normalized.startsWith('fe80')) {
+      throw new Error(`refusing private URL host: ${url.hostname}`);
+    }
+  }
+  return url;
+}
+
+function htmlToText(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export async function fetchPublicText(url: string, signal?: AbortSignal): Promise<FetchedText> {
+  let current = assertPublicHttpUrl(url).toString();
+  for (let i = 0; i < 5; i++) {
+    const response = await fetch(current, { redirect: 'manual', signal });
+    const location = response.headers.get('location');
+    if (location && response.status >= 300 && response.status < 400) {
+      current = assertPublicHttpUrl(new URL(location, current).toString()).toString();
+      continue;
+    }
+    const contentType = response.headers.get('content-type') ?? '';
+    if (!response.ok) {
+      throw new Error(`URL fetch failed ${response.status} ${response.statusText}`);
+    }
+    if (!/^(text\/|application\/(json|ld\+json|xml|xhtml\+xml))/.test(contentType)) {
+      throw new Error(`unsupported URL content type: ${contentType || '(missing)'}`);
+    }
+    const text = await response.text();
+    if (Buffer.byteLength(text, 'utf8') > MAX_URL_BYTES) {
+      throw new Error(`URL response exceeds ${MAX_URL_BYTES} bytes`);
+    }
+    return { finalUrl: current, contentType, text };
+  }
+  throw new Error('too many URL redirects');
+}
+
+async function resolveJobContent(input: NormalizedIngestInput, deps: IngestHandlerDeps, signal: AbortSignal): Promise<{
+  text: string;
+  resolvedUrl?: string;
+  contentType?: string;
+}> {
+  if (input.kind === 'url') {
+    if (!input.url) throw new Error('URL ingest missing url');
+    assertPublicHttpUrl(input.url);
+    const fetched = await (deps.fetchText ?? fetchPublicText)(input.url, signal);
+    return {
+      text: fetched.contentType.includes('html') ? htmlToText(fetched.text) : fetched.text.trim(),
+      resolvedUrl: fetched.finalUrl,
+      contentType: fetched.contentType,
+    };
+  }
+  if (!input.text || input.text.trim().length === 0) {
+    throw new Error(`${input.kind} ingest missing text content`);
+  }
+  return { text: input.text.trim() };
+}
+
+function titleFor(input: NormalizedIngestInput, text: string): string {
+  if (input.title?.trim()) return input.title.trim();
+  if (input.url) return new URL(input.url).hostname;
+  if (input.file?.name) return input.file.name.replace(/\.[^.]+$/, '');
+  return text.split(/\r?\n/)[0]?.slice(0, 80).trim() || 'GBrain ingest source';
+}
+
+function slugFor(input: NormalizedIngestInput, title: string): string {
+  const base = slugifySegment(title) || 'source';
+  return `sources/${base}-${shortHash(input.content_hash)}`;
+}
+
+function buildSourceMarkdown(input: NormalizedIngestInput, title: string, text: string, resolved?: { resolvedUrl?: string; contentType?: string }): string {
+  const compiled = [
+    '## Source Content',
+    '',
+    text,
+    '',
+    '## Provenance',
+    '',
+    `- Ingest mode: ${input.mode}`,
+    `- Input kind: ${input.kind}`,
+    input.url ? `- URL: ${input.url}` : '',
+    resolved?.resolvedUrl && resolved.resolvedUrl !== input.url ? `- Final URL: ${resolved.resolvedUrl}` : '',
+    input.file?.name ? `- File: ${input.file.name}` : '',
+  ].filter(Boolean).join('\n');
+
+  const frontmatter = Object.fromEntries(Object.entries({
+    ingest_source: 'gbrain-ingest',
+    input_kind: input.kind,
+    mode: input.mode,
+    content_hash: input.content_hash,
+    url: input.url,
+    final_url: resolved?.resolvedUrl,
+    content_type: resolved?.contentType,
+    file_name: input.file?.name,
+    source_id: input.source_id,
+  }).filter(([, value]) => value !== undefined));
+
+  return serializeMarkdown(frontmatter, compiled, '', { type: 'source', title, tags: ['gbrain-ingest'] });
+}
+
+async function sourceLocalPath(engine: BrainEngine, sourceId: string): Promise<SourceLocalPath> {
+  const rows = await engine.executeRaw<{ id: string; local_path: string | null }>(
+    `SELECT id, local_path FROM sources WHERE id = $1`,
+    [sourceId],
+  );
+  if (!rows[0]) {
+    throw new Error(`gbrain-ingest source "${sourceId}" is not registered. Run: gbrain sources list`);
+  }
+  return { sourceId: rows[0].id, localPath: rows[0].local_path };
+}
+
+async function writeSourceMarkdownIfConfigured(
+  engine: BrainEngine,
+  sourceId: string,
+  slug: string,
+  markdown: string,
+): Promise<{ status: 'written' | 'skipped_no_local_path'; path?: string; source_id: string }> {
+  const source = await sourceLocalPath(engine, sourceId);
+  if (!source.localPath) {
+    return { status: 'skipped_no_local_path', source_id: source.sourceId };
+  }
+  if (!existsSync(source.localPath) || !statSync(source.localPath).isDirectory()) {
+    throw new Error(`gbrain-ingest source "${source.sourceId}" local_path is missing or not a directory: ${source.localPath}`);
+  }
+  const filePath = join(source.localPath, `${slug}.md`);
+  writeBrainPage(filePath, markdown, { sourcePath: source.localPath });
+  return { status: 'written', path: filePath, source_id: source.sourceId };
+}
+
+export function makeIngestHandler(deps: IngestHandlerDeps): MinionHandler {
+  return async (job: MinionJobContext) => {
+    const input = assertNormalizedInput(job.data);
+    await job.updateProgress({ phase: 'resolve', kind: input.kind });
+    const resolved = await resolveJobContent(input, deps, job.signal);
+    const title = titleFor(input, resolved.text);
+    const slug = slugFor(input, title);
+    const markdown = buildSourceMarkdown(input, title, resolved.text, resolved);
+    const sourceId = input.source_id ?? 'default';
+
+    await job.updateProgress({ phase: 'wiki_write', slug, source_id: sourceId });
+    const wikiWrite = await writeSourceMarkdownIfConfigured(deps.engine, sourceId, slug, markdown);
+
+    await job.updateProgress({ phase: 'db_import', slug });
+    const imported = await importFromContent(deps.engine, slug, markdown, { noEmbed: true });
+    await deps.engine.logIngest({
+      source_type: 'gbrain-ingest',
+      source_ref: input.url ?? input.file?.path ?? input.content_hash,
+      pages_updated: [slug],
+      summary: `${input.kind} ingest ${imported.status} for ${slug}`,
+    });
+
+    const status = imported.status === 'skipped' ? 'no-op' : 'succeeded';
+    let enrichment: unknown = 'disabled';
+    if (deps.enableEnrichment && status !== 'no-op') {
+      await job.updateProgress({ phase: 'enrich', slug });
+      const { enrichAcceptedSource } = await import('./enrichment.ts');
+      enrichment = await enrichAcceptedSource({
+        engine: deps.engine,
+        sourceSlug: slug,
+        sourceTitle: title,
+        sourceText: resolved.text,
+        runner: deps.inferenceRunner,
+        allowPartial: true,
+      });
+    }
+
+    await job.updateProgress({ phase: 'done', status, slug });
+    return {
+      status,
+      updated_slugs: [slug],
+      chunks: imported.chunks,
+      content_hash: input.content_hash,
+      wiki_write: wikiWrite,
+      embedding: 'deferred',
+      enrichment,
+    };
+  };
+}

--- a/src/core/ingest/handler.ts
+++ b/src/core/ingest/handler.ts
@@ -10,7 +10,8 @@ import { slugifySegment } from '../sync.ts';
 import { writeBrainPage } from '../brain-writer.ts';
 import type { NormalizedIngestInput } from './types.ts';
 import { INGEST_PAYLOAD_VERSION } from './types.ts';
-import type { CodexOAuthRunner } from './codex-oauth.ts';
+import { CodexOAuthInferenceError, type CodexOAuthRunner } from './codex-oauth.ts';
+import type { BoundedEnrichmentResult } from './enrichment.ts';
 
 export interface FetchedText {
   finalUrl: string;
@@ -239,21 +240,31 @@ export function makeIngestHandler(deps: IngestHandlerDeps): MinionHandler {
     });
 
     const status = imported.status === 'skipped' ? 'no-op' : 'succeeded';
-    let enrichment: unknown = 'disabled';
-    if (deps.enableEnrichment && status !== 'no-op') {
+    let enrichment: BoundedEnrichmentResult = { status: 'skipped', reason: 'disabled' };
+    if (status === 'no-op') {
+      enrichment = { status: 'skipped', reason: 'source_noop' };
+    } else if (deps.enableEnrichment) {
       await job.updateProgress({ phase: 'enrich', slug });
-      const { enrichAcceptedSource } = await import('./enrichment.ts');
-      enrichment = await enrichAcceptedSource({
-        engine: deps.engine,
-        sourceSlug: slug,
-        sourceTitle: title,
-        sourceText: resolved.text,
-        runner: deps.inferenceRunner,
-        allowPartial: true,
-      });
+      const { enrichAcceptedSource, summarizeFailedEnrichment, summarizeSuccessfulEnrichment } = await import('./enrichment.ts');
+      try {
+        enrichment = summarizeSuccessfulEnrichment(await enrichAcceptedSource({
+          engine: deps.engine,
+          sourceSlug: slug,
+          sourceTitle: title,
+          sourceText: resolved.text,
+          runner: deps.inferenceRunner,
+          allowPartial: true,
+          signal: job.signal,
+        }));
+      } catch (e) {
+        if (job.signal.aborted || (e instanceof CodexOAuthInferenceError && e.code === 'aborted')) {
+          throw e;
+        }
+        enrichment = summarizeFailedEnrichment(e);
+      }
     }
 
-    await job.updateProgress({ phase: 'done', status, slug });
+    await job.updateProgress({ phase: 'done', status, slug, enrichment_status: enrichment.status });
     return {
       status,
       updated_slugs: [slug],

--- a/src/core/ingest/input.ts
+++ b/src/core/ingest/input.ts
@@ -1,0 +1,123 @@
+import { createHash } from 'crypto';
+import { basename, resolve } from 'path';
+import { lstatSync, readFileSync, statSync } from 'fs';
+import type { NormalizeIngestInputOptions, NormalizedIngestInput } from './types.ts';
+import { INGEST_PAYLOAD_VERSION } from './types.ts';
+
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+const TEXT_FILE_EXTENSIONS = new Set([
+  '.md', '.markdown', '.mdx', '.txt', '.text', '.json', '.jsonl', '.yaml', '.yml',
+  '.csv', '.tsv', '.log',
+]);
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function fileExtension(path: string): string {
+  const idx = path.lastIndexOf('.');
+  return idx >= 0 ? path.slice(idx).toLowerCase() : '';
+}
+
+function countProvided(opts: NormalizeIngestInputOptions): number {
+  return [opts.text, opts.url, opts.file].filter(v => typeof v === 'string' && v.length > 0).length;
+}
+
+export async function normalizeIngestInput(opts: NormalizeIngestInputOptions): Promise<NormalizedIngestInput> {
+  const mode = opts.mode ?? 'explicit';
+  if (mode !== 'explicit' && mode !== 'signal') {
+    throw new Error(`invalid ingest mode: ${mode}`);
+  }
+
+  const provided = countProvided(opts);
+  if (provided !== 1) {
+    throw new Error(provided === 0
+      ? 'ingest input is empty; pass text, --url, --file, or stdin'
+      : 'provide exactly one ingest input source');
+  }
+
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+  const submittedAt = new Date().toISOString();
+  const base = {
+    version: INGEST_PAYLOAD_VERSION as typeof INGEST_PAYLOAD_VERSION,
+    mode,
+    submitted_at: submittedAt,
+    title: opts.title,
+    source_id: opts.sourceId,
+    metadata: opts.metadata ?? {},
+  };
+
+  if (typeof opts.text === 'string' && opts.text.length > 0) {
+    const text = opts.text.trim();
+    if (text.length === 0) throw new Error('ingest text is empty');
+    if (Buffer.byteLength(text, 'utf8') > maxBytes) {
+      throw new Error(`ingest text exceeds ${maxBytes} bytes`);
+    }
+    return {
+      ...base,
+      kind: 'text',
+      text,
+      content_hash: sha256(`text:${mode}:${text}`),
+    };
+  }
+
+  if (typeof opts.url === 'string' && opts.url.length > 0) {
+    let parsed: URL;
+    try {
+      parsed = new URL(opts.url);
+    } catch {
+      throw new Error(`invalid URL: ${opts.url}`);
+    }
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      throw new Error(`unsupported URL scheme: ${parsed.protocol}`);
+    }
+    parsed.hash = '';
+    const canonicalUrl = parsed.toString();
+    return {
+      ...base,
+      kind: 'url',
+      url: canonicalUrl,
+      content_hash: sha256(`url:${mode}:${canonicalUrl}`),
+    };
+  }
+
+  const cwd = opts.cwd ?? process.cwd();
+  const filePath = resolve(cwd, opts.file!);
+  const lst = lstatSync(filePath);
+  if (lst.isSymbolicLink()) {
+    throw new Error(`ingest file must not be a symlink: ${filePath}`);
+  }
+  const st = statSync(filePath);
+  if (!st.isFile()) {
+    throw new Error(`ingest file must be a regular file: ${filePath}`);
+  }
+  if (st.size <= 0) {
+    throw new Error(`ingest file is empty: ${filePath}`);
+  }
+  if (st.size > maxBytes) {
+    throw new Error(`ingest file exceeds ${maxBytes} bytes: ${filePath}`);
+  }
+  const ext = fileExtension(filePath);
+  if (!TEXT_FILE_EXTENSIONS.has(ext)) {
+    throw new Error(`unsupported ingest file type: ${ext || '(none)'}`);
+  }
+  const text = readFileSync(filePath, 'utf8').trim();
+  if (text.length === 0) {
+    throw new Error(`ingest file is empty after trimming: ${filePath}`);
+  }
+
+  return {
+    ...base,
+    kind: 'file',
+    text,
+    file: {
+      path: filePath,
+      name: basename(filePath),
+      size_bytes: st.size,
+      mtime_ms: st.mtimeMs,
+    },
+    content_hash: sha256(`file:${mode}:${filePath}:${st.size}:${st.mtimeMs}:${text}`),
+  };
+}
+
+export const __testing = { sha256 };

--- a/src/core/ingest/types.ts
+++ b/src/core/ingest/types.ts
@@ -1,0 +1,47 @@
+export const INGEST_JOB_NAME = 'gbrain-ingest';
+export const INGEST_QUEUE_NAME = 'default';
+export const INGEST_PAYLOAD_VERSION = 1;
+
+export type IngestInputKind = 'text' | 'url' | 'file';
+export type IngestMode = 'explicit' | 'signal';
+
+export interface NormalizedIngestInput {
+  version: typeof INGEST_PAYLOAD_VERSION;
+  kind: IngestInputKind;
+  mode: IngestMode;
+  content_hash: string;
+  submitted_at: string;
+  text?: string;
+  url?: string;
+  file?: {
+    path: string;
+    name: string;
+    size_bytes: number;
+    mtime_ms: number;
+  };
+  title?: string;
+  source_id?: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface NormalizeIngestInputOptions {
+  text?: string;
+  url?: string;
+  file?: string;
+  mode?: IngestMode;
+  title?: string;
+  sourceId?: string;
+  cwd?: string;
+  maxBytes?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EnqueueIngestResult {
+  job_id: number;
+  queued: boolean;
+  idempotency_key: string;
+  status_command: string;
+  status_url: string;
+  job_name: typeof INGEST_JOB_NAME;
+  queue: string;
+}

--- a/src/core/minions/protected-names.ts
+++ b/src/core/minions/protected-names.ts
@@ -20,6 +20,9 @@ export const PROTECTED_JOB_NAMES: ReadonlySet<string> = new Set([
   // trusted local `submit_job` (ctx.remote=false) can insert these rows.
   'subagent',
   'subagent_aggregator',
+  // Async ingest can spend inference and embedding budget in workers. Only the
+  // local CLI/hook path may submit it directly.
+  'gbrain-ingest',
 ]);
 
 /** Check a job name against the protected set. Normalizes whitespace first. */

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -10,6 +10,7 @@ import { clampSearchLimit } from './engine.ts';
 import type { GBrainConfig } from './config.ts';
 import type { PageType } from './types.ts';
 import { importFromContent } from './import-file.ts';
+import { hasEmbeddingApiKey } from './embedding.ts';
 import { hybridSearch } from './search/hybrid.ts';
 import { expandQuery } from './search/expansion.ts';
 import { dedupResults } from './search/dedup.ts';
@@ -275,7 +276,7 @@ const put_page: Operation = {
     // try/catch around embed only catches; without a key the OpenAI client would
     // attempt 5 retries with exponential backoff (up to ~2 minutes total) before
     // giving up. Detect early.
-    const noEmbed = !process.env.OPENAI_API_KEY;
+    const noEmbed = !hasEmbeddingApiKey();
     const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed });
 
     // Auto-link post-hook: runs AFTER importFromContent (which is its own

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -546,9 +546,11 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Chunks
-  async upsertChunks(slug: string, chunks: ChunkInput[]): Promise<void> {
+  async upsertChunks(slug: string, chunks: ChunkInput[], sourceId?: string): Promise<void> {
     // Get page_id
-    const pageResult = await this.db.query('SELECT id FROM pages WHERE slug = $1', [slug]);
+    const pageResult = sourceId
+      ? await this.db.query('SELECT id FROM pages WHERE slug = $1 AND source_id = $2', [slug, sourceId])
+      : await this.db.query('SELECT id FROM pages WHERE slug = $1', [slug]);
     if (pageResult.rows.length === 0) throw new Error(`Page not found: ${slug}`);
     const pageId = (pageResult.rows[0] as { id: number }).id;
 
@@ -633,14 +635,22 @@ export class PGLiteEngine implements BrainEngine {
     );
   }
 
-  async getChunks(slug: string): Promise<Chunk[]> {
-    const { rows } = await this.db.query(
-      `SELECT cc.* FROM content_chunks cc
-       JOIN pages p ON p.id = cc.page_id
-       WHERE p.slug = $1
-       ORDER BY cc.chunk_index`,
-      [slug]
-    );
+  async getChunks(slug: string, sourceId?: string): Promise<Chunk[]> {
+    const { rows } = sourceId
+      ? await this.db.query(
+        `SELECT cc.* FROM content_chunks cc
+         JOIN pages p ON p.id = cc.page_id
+         WHERE p.slug = $1 AND p.source_id = $2
+         ORDER BY cc.chunk_index`,
+        [slug, sourceId],
+      )
+      : await this.db.query(
+        `SELECT cc.* FROM content_chunks cc
+         JOIN pages p ON p.id = cc.page_id
+         WHERE p.slug = $1
+         ORDER BY cc.chunk_index`,
+        [slug],
+      );
     return (rows as Record<string, unknown>[]).map(r => rowToChunk(r));
   }
 
@@ -656,7 +666,7 @@ export class PGLiteEngine implements BrainEngine {
 
   async listStaleChunks(): Promise<StaleChunkRow[]> {
     const { rows } = await this.db.query(
-      `SELECT p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+      `SELECT p.source_id, p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
               cc.model, cc.token_count
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -670,11 +670,13 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Chunks
-  async upsertChunks(slug: string, chunks: ChunkInput[]): Promise<void> {
+  async upsertChunks(slug: string, chunks: ChunkInput[], sourceId?: string): Promise<void> {
     const sql = this.sql;
 
     // Get page_id
-    const pages = await sql`SELECT id FROM pages WHERE slug = ${slug}`;
+    const pages = sourceId
+      ? await sql`SELECT id FROM pages WHERE slug = ${slug} AND source_id = ${sourceId}`
+      : await sql`SELECT id FROM pages WHERE slug = ${slug}`;
     if (pages.length === 0) throw new Error(`Page not found: ${slug}`);
     const pageId = pages[0].id;
 
@@ -759,14 +761,21 @@ export class PostgresEngine implements BrainEngine {
     );
   }
 
-  async getChunks(slug: string): Promise<Chunk[]> {
+  async getChunks(slug: string, sourceId?: string): Promise<Chunk[]> {
     const sql = this.sql;
-    const rows = await sql`
-      SELECT cc.* FROM content_chunks cc
-      JOIN pages p ON p.id = cc.page_id
-      WHERE p.slug = ${slug}
-      ORDER BY cc.chunk_index
-    `;
+    const rows = sourceId
+      ? await sql`
+        SELECT cc.* FROM content_chunks cc
+        JOIN pages p ON p.id = cc.page_id
+        WHERE p.slug = ${slug} AND p.source_id = ${sourceId}
+        ORDER BY cc.chunk_index
+      `
+      : await sql`
+        SELECT cc.* FROM content_chunks cc
+        JOIN pages p ON p.id = cc.page_id
+        WHERE p.slug = ${slug}
+        ORDER BY cc.chunk_index
+      `;
     return rows.map((r) => rowToChunk(r as Record<string, unknown>));
   }
 
@@ -783,7 +792,7 @@ export class PostgresEngine implements BrainEngine {
   async listStaleChunks(): Promise<StaleChunkRow[]> {
     const sql = this.sql;
     const rows = await sql`
-      SELECT p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+      SELECT p.source_id, p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
              cc.model, cc.token_count
       FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -12,7 +12,7 @@
 import type { BrainEngine } from '../engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../engine.ts';
 import type { SearchResult, SearchOpts } from '../types.ts';
-import { embed } from '../embedding.ts';
+import { embed, hasEmbeddingApiKey } from '../embedding.ts';
 import { dedupResults } from './dedup.ts';
 import { autoDetectDetail } from './intent.ts';
 import { expandAnchors, hydrateChunks } from './two-pass.ts';
@@ -86,7 +86,7 @@ export async function hybridSearch(
   const keywordResults = await engine.searchKeyword(query, searchOpts);
 
   // Skip vector search entirely if no OpenAI key is configured
-  if (!process.env.OPENAI_API_KEY) {
+  if (!hasEmbeddingApiKey()) {
     // Apply backlink boost in keyword-only path too. One getBacklinkCounts query
     // per search request; not N+1.
     if (keywordResults.length > 0) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -77,6 +77,7 @@ export interface Chunk {
  * rows) embedding bytes over the wire. See `embed --stale` egress fix.
  */
 export interface StaleChunkRow {
+  source_id?: string | null;
   slug: string;
   chunk_index: number;
   chunk_text: string;

--- a/test/codex-oauth-inference.test.ts
+++ b/test/codex-oauth-inference.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  CodexOAuthInferenceError,
+  runCodexOAuthInference,
+  sanitizeInferenceEnv,
+} from '../src/core/ingest/codex-oauth.ts';
+
+describe('Codex OAuth inference adapter', () => {
+  test('calls the injected runner with explicit gpt-5.4-mini', async () => {
+    const calls: unknown[] = [];
+    const result = await runCodexOAuthInference({
+      prompt: 'Extract cited entities.',
+      model: 'gpt-5.4-mini',
+      runner: async (req) => {
+        calls.push(req);
+        return { text: '{"entities":[]}', route: 'codex-oauth' };
+      },
+    });
+
+    expect(result.text).toBe('{"entities":[]}');
+    expect(calls).toEqual([
+      expect.objectContaining({ prompt: 'Extract cited entities.', model: 'gpt-5.4-mini' }),
+    ]);
+  });
+
+  test('rejects omitted or non-mini models before invoking a runner', async () => {
+    let invoked = false;
+    const runner = async () => {
+      invoked = true;
+      return { text: 'nope', route: 'codex-oauth' as const };
+    };
+
+    await expect(runCodexOAuthInference({ prompt: 'x', model: undefined as any, runner }))
+      .rejects.toThrow(/requires model=gpt-5.4-mini/);
+    await expect(runCodexOAuthInference({ prompt: 'x', model: 'gpt-5.4', runner }))
+      .rejects.toThrow(/requires model=gpt-5.4-mini/);
+    await expect(runCodexOAuthInference({ prompt: 'x', model: 'gpt-5.5', runner }))
+      .rejects.toThrow(/requires model=gpt-5.4-mini/);
+    expect(invoked).toBe(false);
+  });
+
+  test('strips OpenAI API keys from the live runner environment', () => {
+    const env = sanitizeInferenceEnv({
+      OPENAI_API_KEY: 'sk-secret',
+      GBRAIN_EMBEDDINGS_OPENAI_API_KEY: 'sk-embed',
+      GBRAIN_OPENAI_EMBEDDING_API_KEY: 'sk-embed2',
+      CODEX_HOME: '/tmp/codex',
+      PATH: '/bin',
+    });
+
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.GBRAIN_EMBEDDINGS_OPENAI_API_KEY).toBeUndefined();
+    expect(env.GBRAIN_OPENAI_EMBEDDING_API_KEY).toBeUndefined();
+    expect(env.CODEX_HOME).toBe('/tmp/codex');
+    expect(env.PATH).toBe('/bin');
+  });
+
+  test('missing Codex OAuth route fails closed as a configuration error', async () => {
+    await expect(runCodexOAuthInference({
+      prompt: 'x',
+      model: 'gpt-5.4-mini',
+      runner: async () => {
+        throw new CodexOAuthInferenceError('codex CLI not found', 'configuration_error');
+      },
+    })).rejects.toMatchObject({
+      code: 'configuration_error',
+    });
+  });
+});

--- a/test/codex-oauth-inference.test.ts
+++ b/test/codex-oauth-inference.test.ts
@@ -66,4 +66,63 @@ describe('Codex OAuth inference adapter', () => {
       code: 'configuration_error',
     });
   });
+
+  test('times out an injected runner and reports a sanitized timeout', async () => {
+    await expect(runCodexOAuthInference({
+      prompt: 'secret prompt should not appear in errors',
+      model: 'gpt-5.4-mini',
+      timeoutMs: 5,
+      runner: async () => {
+        await new Promise(resolve => setTimeout(resolve, 30));
+        return { text: '{"late":true}', route: 'codex-oauth' };
+      },
+    })).rejects.toMatchObject({
+      code: 'timeout',
+      message: expect.not.stringContaining('secret prompt'),
+    });
+  });
+
+  test('aborts an injected runner and reports an abort without raw prompt text', async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(new Error('operator-cancelled')), 5);
+
+    await expect(runCodexOAuthInference({
+      prompt: 'do not leak this cancellation prompt',
+      model: 'gpt-5.4-mini',
+      signal: controller.signal,
+      runner: async (req) => {
+        expect((req as any).signal).toBe(controller.signal);
+        await new Promise(resolve => setTimeout(resolve, 30));
+        return { text: '{"late":true}', route: 'codex-oauth' };
+      },
+    })).rejects.toMatchObject({
+      code: 'aborted',
+      message: expect.not.stringContaining('do not leak'),
+    });
+  });
+
+  test('classifies empty runner output as empty_output', async () => {
+    await expect(runCodexOAuthInference({
+      prompt: 'x',
+      model: 'gpt-5.4-mini',
+      runner: async () => ({ text: '   ', route: 'codex-oauth' }),
+    })).rejects.toMatchObject({
+      code: 'empty_output',
+    });
+  });
+
+  test('classifies auth-like runner failures without leaking stderr or secrets', async () => {
+    await expect(runCodexOAuthInference({
+      prompt: 'x',
+      model: 'gpt-5.4-mini',
+      runner: async () => {
+        const error = new Error('Command failed with stderr: login required sk-test-secret-value');
+        (error as any).stderr = 'Please run codex login with token sk-test-secret-value';
+        throw error;
+      },
+    })).rejects.toMatchObject({
+      code: 'oauth_unavailable',
+      message: expect.not.stringContaining('sk-test-secret-value'),
+    });
+  });
 });

--- a/test/doctor-minions-check.test.ts
+++ b/test/doctor-minions-check.test.ts
@@ -24,14 +24,14 @@ const CLI = join(__dirname, '..', 'src', 'cli.ts');
 let tmp: string;
 let origHome: string | undefined;
 
-function run(args: string[]): { exitCode: number; stdout: string; stderr: string } {
+function run(args: string[], envOverrides: Record<string, string | undefined> = {}): { exitCode: number; stdout: string; stderr: string } {
   // Strip DATABASE_URL so doctor runs filesystem-only for these tests.
   // Half-migrated checks run in the filesystem section; no DB needed.
-  const env = { ...process.env, HOME: tmp } as Record<string, string | undefined>;
+  const env = { ...process.env, HOME: tmp, ...envOverrides } as Record<string, string | undefined>;
   delete env.DATABASE_URL;
   delete env.GBRAIN_DATABASE_URL;
   try {
-    const stdout = execFileSync('bun', ['run', CLI, ...args], {
+    const stdout = execFileSync(process.execPath, ['run', CLI, ...args], {
       env: env as Record<string, string>,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -242,5 +242,23 @@ describe('gbrain doctor — half-migrated Minions detection', () => {
     expect(result.exitCode).toBe(1);
     expect(result.stdout).toContain('MINIONS HALF-INSTALLED');
     expect(result.stdout).toContain('gbrain apply-migrations --yes');
+  });
+
+  test('codex oauth smoke reports missing CLI without leaking API key env values', () => {
+    const result = run(['doctor', '--fast', '--json', '--codex-oauth-smoke'], {
+      PATH: '/tmp/gbrain-no-codex-path',
+      OPENAI_API_KEY: 'sk-test-do-not-print',
+      GBRAIN_EMBEDDINGS_OPENAI_API_KEY: 'sk-test-embed-do-not-print',
+    });
+
+    expect(result.exitCode).toBe(1);
+    const payload = JSON.parse(result.stdout);
+    const check = payload.checks.find((c: any) => c.name === 'codex_oauth_enrichment');
+    expect(check).toEqual(expect.objectContaining({
+      status: 'fail',
+    }));
+    expect(check.message).toContain('gpt-5.4-mini');
+    expect(result.stdout).not.toContain('sk-test-do-not-print');
+    expect(result.stdout).not.toContain('sk-test-embed-do-not-print');
   });
 });

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -348,6 +348,46 @@ describe('runEmbedCore --stale egress fix (SQL-side filter)', () => {
     expect(staleChunkInUpsert.embedding).toBeInstanceOf(Float32Array);
   });
 
+  test('--stale keeps same-slug pages isolated by source_id', async () => {
+    const { runEmbedCore } = await import('../src/commands/embed.ts');
+    const stale = [
+      { source_id: 'default', slug: 'docs/install/updating', chunk_index: 0, chunk_text: 'default stale', chunk_source: 'compiled_truth' as const, model: null, token_count: null },
+      { source_id: 'openclaw', slug: 'docs/install/updating', chunk_index: 0, chunk_text: 'openclaw stale', chunk_source: 'compiled_truth' as const, model: null, token_count: null },
+    ];
+    const fullChunks: Record<string, any[]> = {
+      'default:docs/install/updating': [
+        { chunk_index: 0, chunk_text: 'default stale', chunk_source: 'compiled_truth', embedded_at: null, token_count: 2 },
+        { chunk_index: 1, chunk_text: 'default fresh', chunk_source: 'compiled_truth', embedded_at: '2026-01-01', token_count: 2 },
+      ],
+      'openclaw:docs/install/updating': [
+        { chunk_index: 0, chunk_text: 'openclaw stale', chunk_source: 'compiled_truth', embedded_at: null, token_count: 2 },
+        { chunk_index: 1, chunk_text: 'openclaw fresh', chunk_source: 'compiled_truth', embedded_at: '2026-01-01', token_count: 2 },
+      ],
+    };
+    const upsertCalls: Array<{ slug: string; sourceId: string | undefined; chunks: any[] }> = [];
+    const engine = mockEngine({
+      countStaleChunks: async () => 2,
+      listStaleChunks: async () => stale,
+      getChunks: async (slug: string, sourceId?: string) => fullChunks[`${sourceId ?? 'default'}:${slug}`] || [],
+      upsertChunks: async (slug: string, chunks: any[], sourceId?: string) => {
+        upsertCalls.push({ slug, sourceId, chunks });
+      },
+    });
+
+    const result = await runEmbedCore(engine, { stale: true });
+
+    expect(result.embedded).toBe(2);
+    expect(result.pages_processed).toBe(2);
+    expect(upsertCalls.map(c => `${c.sourceId}:${c.slug}`).sort()).toEqual([
+      'default:docs/install/updating',
+      'openclaw:docs/install/updating',
+    ]);
+    for (const call of upsertCalls) {
+      const indices = call.chunks.map((c: any) => c.chunk_index);
+      expect(indices).toEqual([0, 1]);
+    }
+  });
+
   test('--stale dry-run: counts stale via countStaleChunks, reports via listStaleChunks, no embedBatch or upsertChunks', async () => {
     const { runEmbedCore } = await import('../src/commands/embed.ts');
     const stale = [

--- a/test/embedding-auth.test.ts
+++ b/test/embedding-auth.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  EMBEDDING_BATCH_SIZE,
+  hasEmbeddingApiKey,
+  resolveEmbeddingApiKey,
+} from '../src/core/embedding.ts';
+
+const ENV_KEYS = [
+  'GBRAIN_EMBEDDINGS_OPENAI_API_KEY',
+  'GBRAIN_OPENAI_EMBEDDING_API_KEY',
+  'OPENAI_API_KEY',
+  'GBRAIN_ALLOW_LEGACY_OPENAI_API_KEY_FOR_EMBEDDINGS',
+];
+
+const savedEnv = new Map<string, string | undefined>();
+for (const key of ENV_KEYS) savedEnv.set(key, process.env[key]);
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function clearEmbeddingEnv(): void {
+  for (const key of ENV_KEYS) delete process.env[key];
+}
+
+describe('embedding API key resolution', () => {
+  test('uses the gbrain-scoped embedding key instead of global OPENAI_API_KEY', () => {
+    clearEmbeddingEnv();
+    process.env.OPENAI_API_KEY = 'global-inference-key';
+    process.env.GBRAIN_EMBEDDINGS_OPENAI_API_KEY = 'embedding-only-key';
+
+    expect(resolveEmbeddingApiKey({ includeKeychain: false })).toBe('embedding-only-key');
+    expect(hasEmbeddingApiKey({ includeKeychain: false })).toBe(true);
+  });
+
+  test('does not treat global OPENAI_API_KEY as an embedding key by default', () => {
+    clearEmbeddingEnv();
+    process.env.OPENAI_API_KEY = 'global-inference-key';
+
+    expect(resolveEmbeddingApiKey({ includeKeychain: false })).toBeUndefined();
+    expect(hasEmbeddingApiKey({ includeKeychain: false })).toBe(false);
+  });
+
+  test('requires an explicit compatibility flag before using OPENAI_API_KEY for embeddings', () => {
+    clearEmbeddingEnv();
+    process.env.OPENAI_API_KEY = 'legacy-key';
+    process.env.GBRAIN_ALLOW_LEGACY_OPENAI_API_KEY_FOR_EMBEDDINGS = '1';
+
+    expect(resolveEmbeddingApiKey({ includeKeychain: false })).toBe('legacy-key');
+  });
+
+  test('keeps embedding requests batched', () => {
+    expect(EMBEDDING_BATCH_SIZE).toBe(100);
+  });
+});

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -273,6 +273,41 @@ This is compiled truth content that should be chunked as compiled_truth source.
     expect(tlChunks.length).toBeGreaterThan(0);
   });
 
+  test('markdown import reuses embeddings for unchanged chunks when content changes elsewhere', async () => {
+    const existingEmbedding = new Float32Array([0.1, 0.2, 0.3]);
+    const engine = mockEngine({
+      getPage: () => Promise.resolve({ content_hash: 'old-hash' }),
+      getChunks: () => Promise.resolve([
+        {
+          chunk_index: 0,
+          chunk_text: 'Shared chunk stays the same.',
+          chunk_source: 'compiled_truth',
+          embedding: existingEmbedding,
+          token_count: 7,
+        },
+      ]),
+    });
+
+    const result = await importFromContent(engine, 'concepts/reuse', `---
+type: concept
+title: Reuse
+---
+
+Shared chunk stays the same.
+
+<!-- timeline -->
+
+New dated note.
+`, { noEmbed: true });
+
+    expect(result.status).toBe('imported');
+    const chunkCall = (engine as any)._calls.find((c: any) => c.method === 'upsertChunks');
+    const chunks = chunkCall.args[1];
+    expect(chunks[0].embedding).toBe(existingEmbedding);
+    expect(chunks[0].token_count).toBe(7);
+    expect(chunks[1].embedding).toBeUndefined();
+  });
+
   test('handles file with minimal content', async () => {
     const filePath = join(TMP, 'minimal.md');
     writeFileSync(filePath, `---

--- a/test/ingest-cli.test.ts
+++ b/test/ingest-cli.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { MinionQueue } from '../src/core/minions/queue.ts';
+import { runIngest } from '../src/commands/ingest.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ database_url: '' });
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await engine.executeRaw('DELETE FROM minion_jobs');
+});
+
+describe('runIngest', () => {
+  test('--json prints stable job id and status fields', async () => {
+    const out: string[] = [];
+    await runIngest(engine, ['--json'], {
+      stdin: 'Remember this: Codex writes use OAuth only.',
+      stdout: (line) => out.push(line),
+    });
+
+    const payload = JSON.parse(out.join(''));
+    expect(payload.job_id).toBeGreaterThan(0);
+    expect(payload.status_command).toBe(`gbrain jobs get ${payload.job_id}`);
+    expect(payload.queued).toBe(true);
+    expect(payload.idempotency_key).toContain('gbrain-ingest:');
+  });
+
+  test('human output returns immediately with job id and status command', async () => {
+    const out: string[] = [];
+    await runIngest(engine, ['--text', 'A durable note for the async queue.'], {
+      stdout: (line) => out.push(line),
+    });
+
+    const text = out.join('');
+    expect(text).toMatch(/Queued GBrain ingest job #\d+/);
+    expect(text).toMatch(/gbrain jobs get \d+/);
+
+    const queue = new MinionQueue(engine);
+    const jobs = await queue.getJobs({ name: 'gbrain-ingest' });
+    expect(jobs).toHaveLength(1);
+  });
+
+  test('does not run worker enrichment in the foreground', async () => {
+    const out: string[] = [];
+    await runIngest(engine, ['--text', 'Fast foreground only.'], {
+      stdout: (line) => out.push(line),
+    });
+
+    const queue = new MinionQueue(engine);
+    const jobs = await queue.getJobs({ name: 'gbrain-ingest' });
+    expect(jobs[0]?.status).toBe('waiting');
+    expect(jobs[0]?.progress).toBeNull();
+    expect(jobs[0]?.result).toBeNull();
+  });
+});

--- a/test/ingest-enqueue.test.ts
+++ b/test/ingest-enqueue.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, symlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { MinionQueue } from '../src/core/minions/queue.ts';
+import { isProtectedJobName } from '../src/core/minions/protected-names.ts';
+import { normalizeIngestInput } from '../src/core/ingest/input.ts';
+import { enqueueIngestJob } from '../src/core/ingest/enqueue.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ database_url: '' });
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await engine.executeRaw('DELETE FROM minion_jobs');
+});
+
+describe('normalizeIngestInput', () => {
+  test('accepts explicit stdin text and derives a stable content hash', async () => {
+    const input = await normalizeIngestInput({ text: 'Remember this: GBrain writes async.' });
+
+    expect(input.kind).toBe('text');
+    expect(input.mode).toBe('explicit');
+    expect(input.content_hash).toHaveLength(64);
+    expect(input.text).toBe('Remember this: GBrain writes async.');
+  });
+
+  test('accepts https URLs without fetching in the foreground', async () => {
+    const input = await normalizeIngestInput({ url: 'https://example.com/a#frag' });
+
+    expect(input.kind).toBe('url');
+    expect(input.url).toBe('https://example.com/a');
+    expect(input.text).toBeUndefined();
+  });
+
+  test('accepts a normal local markdown file and rejects a final-component symlink', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-ingest-input-'));
+    try {
+      const note = join(dir, 'note.md');
+      writeFileSync(note, '# Note\n\nPortable memory.');
+      const input = await normalizeIngestInput({ file: note, cwd: dir });
+      expect(input.kind).toBe('file');
+      expect(input.file?.path).toBe(note);
+      expect(input.text).toContain('Portable memory.');
+
+      const target = join(dir, 'target.md');
+      const link = join(dir, 'link.md');
+      writeFileSync(target, 'secret');
+      symlinkSync(target, link);
+      await expect(normalizeIngestInput({ file: link, cwd: dir })).rejects.toThrow(/symlink/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects empty input and unsupported URL schemes before queue submission', async () => {
+    await expect(normalizeIngestInput({ text: '   ' })).rejects.toThrow(/empty/i);
+    await expect(normalizeIngestInput({ url: 'file:///etc/passwd' })).rejects.toThrow(/unsupported URL scheme/i);
+  });
+});
+
+describe('enqueueIngestJob', () => {
+  test('gbrain-ingest is a protected job name', async () => {
+    expect(isProtectedJobName('gbrain-ingest')).toBe(true);
+    const queue = new MinionQueue(engine);
+    await expect(queue.add('gbrain-ingest', { text: 'x' })).rejects.toThrow(/protected job name/);
+  });
+
+  test('inserts a protected gbrain-ingest job with status metadata', async () => {
+    const input = await normalizeIngestInput({ text: 'Remember this: hooks must stay async.' });
+    const result = await enqueueIngestJob(engine, input);
+
+    expect(result.queued).toBe(true);
+    expect(result.job_id).toBeGreaterThan(0);
+    expect(result.status_command).toBe(`gbrain jobs get ${result.job_id}`);
+    expect(result.idempotency_key).toContain('gbrain-ingest:');
+
+    const queue = new MinionQueue(engine);
+    const job = await queue.getJob(result.job_id);
+    expect(job?.name).toBe('gbrain-ingest');
+    expect(job?.status).toBe('waiting');
+    expect(job?.data.kind).toBe('text');
+  });
+
+  test('repeated identical input returns the existing queued job', async () => {
+    const input = await normalizeIngestInput({ text: 'Same durable thing.' });
+    const first = await enqueueIngestJob(engine, input);
+    const second = await enqueueIngestJob(engine, input);
+
+    expect(second.job_id).toBe(first.job_id);
+    expect(second.queued).toBe(false);
+
+    const queue = new MinionQueue(engine);
+    const jobs = await queue.getJobs({ name: 'gbrain-ingest' });
+    expect(jobs).toHaveLength(1);
+  });
+});

--- a/test/ingest-enrichment.test.ts
+++ b/test/ingest-enrichment.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { enrichAcceptedSource, validateEnrichmentOutput } from '../src/core/ingest/enrichment.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ database_url: '' });
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await engine.executeRaw('DELETE FROM links');
+  await engine.executeRaw('DELETE FROM timeline_entries');
+  await engine.executeRaw('DELETE FROM content_chunks');
+  await engine.executeRaw('DELETE FROM pages');
+});
+
+describe('validateEnrichmentOutput', () => {
+  test('rejects malformed output and uncited canonical candidates', () => {
+    expect(() => validateEnrichmentOutput('not json')).toThrow(/valid JSON/);
+    expect(() => validateEnrichmentOutput(JSON.stringify({
+      people: [{ name: 'Alice' }],
+    }))).toThrow(/citation/i);
+  });
+});
+
+describe('enrichAcceptedSource', () => {
+  test('writes cited people, organizations, concepts, relationships, and timeline entries', async () => {
+    await engine.putPage('sources/demo', {
+      type: 'source',
+      title: 'Demo source',
+      compiled_truth: 'Alice Chen at Acme discussed Async Ingest on 2026-04-29.',
+      frontmatter: {},
+    });
+
+    const result = await enrichAcceptedSource({
+      engine,
+      sourceSlug: 'sources/demo',
+      sourceTitle: 'Demo source',
+      sourceText: 'Alice Chen at Acme discussed Async Ingest on 2026-04-29.',
+      runner: async () => ({
+        route: 'codex-oauth',
+        text: JSON.stringify({
+          people: [{ name: 'Alice Chen', citation: 'Alice Chen at Acme' }],
+          organizations: [{ name: 'Acme', citation: 'at Acme' }],
+          concepts: [{ name: 'Async Ingest', citation: 'Async Ingest' }],
+          relationships: [{
+            from: 'Alice Chen',
+            to: 'Acme',
+            type: 'works_with',
+            citation: 'Alice Chen at Acme',
+          }],
+          timeline: [{
+            date: '2026-04-29',
+            summary: 'Alice Chen discussed Async Ingest at Acme.',
+            citation: '2026-04-29',
+          }],
+        }),
+      }),
+    });
+
+    expect(result.status).toBe('enriched');
+    expect(result.updated_slugs).toEqual(expect.arrayContaining([
+      'people/alice-chen',
+      'companies/acme',
+      'concepts/async-ingest',
+    ]));
+
+    const person = await engine.getPage('people/alice-chen');
+    expect(person?.compiled_truth).toContain('Evidence');
+    expect(person?.compiled_truth).toContain('sources/demo');
+
+    const links = await engine.getLinks('people/alice-chen');
+    expect(links.map(l => l.to_slug)).toContain('companies/acme');
+    expect(links.map(l => l.to_slug)).toContain('sources/demo');
+
+    const timeline = await engine.getTimeline('concepts/async-ingest');
+    expect(timeline[0]?.summary).toContain('Alice Chen discussed');
+  });
+
+  test('low-confidence or uncited items are skipped without canonical writes', async () => {
+    await engine.putPage('sources/demo', {
+      type: 'source',
+      title: 'Demo source',
+      compiled_truth: 'Thin content.',
+      frontmatter: {},
+    });
+
+    const result = await enrichAcceptedSource({
+      engine,
+      sourceSlug: 'sources/demo',
+      sourceTitle: 'Demo source',
+      sourceText: 'Thin content.',
+      runner: async () => ({
+        route: 'codex-oauth',
+        text: JSON.stringify({
+          concepts: [{ name: 'Uncited Concept' }],
+          people: [],
+          organizations: [],
+          relationships: [],
+          timeline: [],
+        }),
+      }),
+      allowPartial: true,
+    });
+
+    expect(result.status).toBe('skipped');
+    expect(await engine.getPage('concepts/uncited-concept')).toBeNull();
+  });
+});

--- a/test/ingest-handler.test.ts
+++ b/test/ingest-handler.test.ts
@@ -7,6 +7,7 @@ import { MinionWorker } from '../src/core/minions/worker.ts';
 import { registerBuiltinHandlers } from '../src/commands/jobs.ts';
 import { normalizeIngestInput } from '../src/core/ingest/input.ts';
 import { makeIngestHandler } from '../src/core/ingest/handler.ts';
+import { CodexOAuthInferenceError } from '../src/core/ingest/codex-oauth.ts';
 
 let engine: PGLiteEngine;
 
@@ -33,8 +34,8 @@ function fakeJob(data: Record<string, unknown>, progress: unknown[] = []) {
     name: 'gbrain-ingest',
     data,
     attempts_made: 0,
-    signal: { aborted: false },
-    shutdownSignal: { aborted: false },
+    signal: new AbortController().signal,
+    shutdownSignal: new AbortController().signal,
     updateProgress: async (p: unknown) => { progress.push(p); },
     updateTokens: async () => {},
     log: async () => {},
@@ -126,6 +127,95 @@ describe('gbrain-ingest worker handler', () => {
     expect((second as any).status).toBe('no-op');
     const pages = await engine.listPages({ type: 'source' });
     expect(pages).toHaveLength(1);
+  });
+
+  test('enrichment timeout after import completes as terminal partial success', async () => {
+    const input = await normalizeIngestInput({
+      text: 'Remember this: bounded enrichment failures keep the source durable.',
+      title: 'Bounded enrichment',
+    });
+    const progress: unknown[] = [];
+    const result = await makeIngestHandler({
+      engine,
+      enableEnrichment: true,
+      inferenceRunner: async () => {
+        throw new CodexOAuthInferenceError('Codex OAuth inference timed out', 'timeout');
+      },
+    })(fakeJob(input as unknown as Record<string, unknown>, progress));
+
+    expect((result as any).status).toBe('succeeded');
+    expect((result as any).enrichment).toEqual(expect.objectContaining({
+      status: 'timeout',
+      error_code: 'timeout',
+    }));
+    expect(JSON.stringify((result as any).enrichment)).not.toContain('bounded enrichment failures');
+    expect(progress).toEqual(expect.arrayContaining([
+      expect.objectContaining({ phase: 'enrich' }),
+      expect.objectContaining({ phase: 'done', enrichment_status: 'timeout' }),
+    ]));
+  });
+
+  test('configuration failure after import completes without leaking raw errors', async () => {
+    const input = await normalizeIngestInput({
+      text: 'Remember this: OAuth configuration failures should be inspectable.',
+      title: 'OAuth unavailable',
+    });
+    const result = await makeIngestHandler({
+      engine,
+      enableEnrichment: true,
+      inferenceRunner: async () => {
+        throw new CodexOAuthInferenceError('Codex OAuth route is unavailable or requires interactive authentication', 'oauth_unavailable');
+      },
+    })(fakeJob(input as unknown as Record<string, unknown>));
+
+    expect((result as any).status).toBe('succeeded');
+    expect((result as any).enrichment).toEqual(expect.objectContaining({
+      status: 'configuration_error',
+      error_code: 'oauth_unavailable',
+    }));
+  });
+
+  test('no-op imports skip enrichment runner', async () => {
+    const input = await normalizeIngestInput({ text: 'Duplicate enrichment skip.' });
+    const handler = makeIngestHandler({ engine });
+    await handler(fakeJob(input as unknown as Record<string, unknown>));
+    let invoked = false;
+
+    const second = await makeIngestHandler({
+      engine,
+      enableEnrichment: true,
+      inferenceRunner: async () => {
+        invoked = true;
+        return { route: 'codex-oauth', text: '{}' };
+      },
+    })(fakeJob(input as unknown as Record<string, unknown>));
+
+    expect((second as any).status).toBe('no-op');
+    expect((second as any).enrichment).toEqual({ status: 'skipped', reason: 'source_noop' });
+    expect(invoked).toBe(false);
+  });
+
+  test('worker abort during enrichment is propagated instead of completed', async () => {
+    const input = await normalizeIngestInput({
+      text: 'Remember this: worker aborts must not become successful jobs.',
+      title: 'Abort propagation',
+    });
+    const controller = new AbortController();
+    const job = fakeJob(input as unknown as Record<string, unknown>);
+    job.signal = controller.signal;
+
+    const promise = makeIngestHandler({
+      engine,
+      enableEnrichment: true,
+      inferenceRunner: async (req) => {
+        expect((req as any).signal).toBe(controller.signal);
+        controller.abort(new Error('timeout'));
+        await new Promise(resolve => setTimeout(resolve, 5));
+        return { route: 'codex-oauth', text: '{}' };
+      },
+    })(job);
+
+    await expect(promise).rejects.toMatchObject({ code: 'aborted' });
   });
 
   test('URL input fetches through an SSRF-safe resolver before importing', async () => {

--- a/test/ingest-handler.test.ts
+++ b/test/ingest-handler.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { MinionWorker } from '../src/core/minions/worker.ts';
+import { registerBuiltinHandlers } from '../src/commands/jobs.ts';
+import { normalizeIngestInput } from '../src/core/ingest/input.ts';
+import { makeIngestHandler } from '../src/core/ingest/handler.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ database_url: '' });
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await engine.executeRaw('DELETE FROM content_chunks');
+  await engine.executeRaw('DELETE FROM ingest_log');
+  await engine.executeRaw('DELETE FROM pages');
+  await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
+});
+
+function fakeJob(data: Record<string, unknown>, progress: unknown[] = []) {
+  return {
+    id: 123,
+    name: 'gbrain-ingest',
+    data,
+    attempts_made: 0,
+    signal: { aborted: false },
+    shutdownSignal: { aborted: false },
+    updateProgress: async (p: unknown) => { progress.push(p); },
+    updateTokens: async () => {},
+    log: async () => {},
+    isActive: async () => true,
+    readInbox: async () => [],
+  } as any;
+}
+
+describe('gbrain-ingest worker handler', () => {
+  test('registerBuiltinHandlers registers gbrain-ingest', async () => {
+    const worker = new MinionWorker(engine, { queue: 'test' });
+    await registerBuiltinHandlers(worker, engine);
+    expect(worker.registeredNames).toContain('gbrain-ingest');
+  });
+
+  test('text input writes a source page, chunks it without embedding, and logs ingest', async () => {
+    const input = await normalizeIngestInput({
+      text: 'Remember this: GBrain ingest must write PostgreSQL state.',
+      title: 'Async ingest contract',
+    });
+    const progress: unknown[] = [];
+
+    const result = await makeIngestHandler({ engine })(fakeJob(input as unknown as Record<string, unknown>, progress));
+
+    expect((result as any).status).toBe('succeeded');
+    expect((result as any).updated_slugs).toHaveLength(1);
+    const slug = (result as any).updated_slugs[0];
+
+    const page = await engine.getPage(slug);
+    expect(page?.type).toBe('source');
+    expect(page?.title).toBe('Async ingest contract');
+    expect(page?.frontmatter.content_hash).toBe(input.content_hash);
+
+    const chunks = await engine.getChunks(slug);
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks.every(c => c.embedding === null)).toBe(true);
+
+    const log = await engine.getIngestLog({ limit: 5 });
+    expect(log[0]?.source_type).toBe('gbrain-ingest');
+    expect(log[0]?.pages_updated).toEqual([slug]);
+
+    expect(progress).toEqual(expect.arrayContaining([
+      expect.objectContaining({ phase: 'resolve' }),
+      expect.objectContaining({ phase: 'wiki_write' }),
+      expect.objectContaining({ phase: 'db_import' }),
+      expect.objectContaining({ phase: 'done' }),
+    ]));
+  });
+
+  test('writes the same source markdown to the filesystem brain when local_path is configured', async () => {
+    const repo = mkdtempSync(join(tmpdir(), 'gbrain-ingest-wiki-'));
+    try {
+      await engine.executeRaw(
+        `UPDATE sources SET local_path = $1 WHERE id = 'default'`,
+        [repo],
+      );
+      const input = await normalizeIngestInput({
+        text: 'Remember this: the wiki brain receives the raw source page too.',
+        title: 'Wiki and Postgres ingest',
+      });
+
+      const result = await makeIngestHandler({ engine })(fakeJob(input as unknown as Record<string, unknown>));
+      const slug = (result as any).updated_slugs[0];
+      const expectedPath = join(repo, `${slug}.md`);
+
+      expect((result as any).wiki_write).toEqual(expect.objectContaining({
+        status: 'written',
+        source_id: 'default',
+        path: expectedPath,
+      }));
+      expect(existsSync(expectedPath)).toBe(true);
+      expect(readFileSync(expectedPath, 'utf8')).toContain('the wiki brain receives the raw source page too');
+
+      const page = await engine.getPage(slug);
+      expect(page?.compiled_truth).toContain('the wiki brain receives the raw source page too');
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test('re-running identical content returns no-op without duplicate pages', async () => {
+    const input = await normalizeIngestInput({ text: 'Duplicate durable content.' });
+    const handler = makeIngestHandler({ engine });
+
+    const first = await handler(fakeJob(input as unknown as Record<string, unknown>));
+    const second = await handler(fakeJob(input as unknown as Record<string, unknown>));
+
+    expect((first as any).status).toBe('succeeded');
+    expect((second as any).status).toBe('no-op');
+    const pages = await engine.listPages({ type: 'source' });
+    expect(pages).toHaveLength(1);
+  });
+
+  test('URL input fetches through an SSRF-safe resolver before importing', async () => {
+    const input = await normalizeIngestInput({ url: 'https://example.com/notes' });
+    const handler = makeIngestHandler({
+      engine,
+      fetchText: async (url) => {
+        expect(url).toBe('https://example.com/notes');
+        return {
+          finalUrl: url,
+          contentType: 'text/html',
+          text: '<html><title>Example</title><body>Public source content.</body></html>',
+        };
+      },
+    });
+
+    const result = await handler(fakeJob(input as unknown as Record<string, unknown>));
+    expect((result as any).status).toBe('succeeded');
+    const page = await engine.getPage((result as any).updated_slugs[0]);
+    expect(page?.compiled_truth).toContain('Public source content.');
+    expect(page?.frontmatter.url).toBe('https://example.com/notes');
+  });
+});

--- a/test/jobs-ingest-smoke.test.ts
+++ b/test/jobs-ingest-smoke.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runGbrainIngestSmoke } from '../src/commands/jobs.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ database_url: '' });
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await engine.executeRaw('DELETE FROM minion_jobs');
+  await engine.executeRaw('DELETE FROM content_chunks');
+  await engine.executeRaw('DELETE FROM ingest_log');
+  await engine.executeRaw('DELETE FROM pages');
+});
+
+describe('gbrain jobs smoke --gbrain-ingest', () => {
+  test('returns job id, status command, terminal result, and enrichment status', async () => {
+    const prior = process.env.GBRAIN_INGEST_ENRICH;
+    process.env.GBRAIN_INGEST_ENRICH = '0';
+    try {
+      const result = await runGbrainIngestSmoke(engine, { timeoutMs: 5_000, pollIntervalMs: 50 });
+
+      expect(result.job_id).toBeGreaterThan(0);
+      expect(result.status_command).toBe(`gbrain jobs get ${result.job_id}`);
+      expect(result.terminal_status).toBe('completed');
+      expect(result.enrichment_status).toBe('skipped');
+      expect(result.timed_out).toBe(false);
+    } finally {
+      if (prior === undefined) delete process.env.GBRAIN_INGEST_ENRICH;
+      else process.env.GBRAIN_INGEST_ENRICH = prior;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add async gbrain-ingest CLI/bin path that returns job id/status immediately
- add protected worker handler that writes source markdown to configured filesystem brain source and imports the same content into DB
- add async enrichment using Codex OAuth with explicit gpt-5.4-mini and no OpenAI API keys in inference env
- reuse unchanged markdown chunk embeddings to avoid re-embedding untouched content
- add agent skill/docs and tests

## Verification
- bun run test
- bun run typecheck
- bun run build
- python3 ~/.config/dotstate/storage/Personal/.claude/hooks/test_gbrain_agent_hook.py
- node --test ~/.openclaw/hooks/gbrain-agent/handler.test.mjs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->