### PR TITLE
support custom OpenAI-compatible embedding servers and other models

### DIFF
--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -9,8 +9,9 @@
 
 import OpenAI from 'openai';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
+const MODEL = process.env.GBRAIN_EMBEDDING_MODEL || 'text-embedding-3-large';
+const DIMENSIONS = parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS || '1536', 10);
+const OMIT_DIMENSIONS = process.env.GBRAIN_EMBEDDING_OMIT_DIMENSIONS === 'true';
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
@@ -65,12 +66,25 @@ async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
       const response = await getClient().embeddings.create({
         model: MODEL,
         input: texts,
-        dimensions: DIMENSIONS,
+        ...(OMIT_DIMENSIONS ? {} : { dimensions: DIMENSIONS }),
       });
 
       // Sort by index to maintain order
       const sorted = response.data.sort((a, b) => a.index - b.index);
-      return sorted.map(d => new Float32Array(d.embedding));
+      return sorted.map(d => {
+        // Servers that ignore the `dimensions` request param (or where we set
+        // OMIT_DIMENSIONS=true for non-Matryoshka models) may return more
+        // values than DIMENSIONS. For Matryoshka-trained models, slicing the
+        // first N dims and L2-renormalizing preserves cosine retrieval quality.
+        if (d.embedding.length > DIMENSIONS) {
+          const sliced = d.embedding.slice(0, DIMENSIONS);
+          let s = 0;
+          for (const x of sliced) s += x * x;
+          const norm = Math.sqrt(s) || 1;
+          return new Float32Array(sliced.map(x => x / norm));
+        }
+        return new Float32Array(d.embedding);
+      });
     } catch (e: unknown) {
       if (attempt === MAX_RETRIES - 1) throw e;
 


### PR DESCRIPTION
Currently embedding.ts hardcodes text-embedding-3-large at 1536 dims.
This patch makes the model and dimensions overridable via env vars, plus
adds a workaround for self-hosted endpoints that don't accept OpenAI's
`dimensions` request param.            
                                                              
The OpenAI SDK already reads OPENAI_BASE_URL and OPENAI_API_KEY from env,
so pointing gbrain at a self-hosted server was already half-possible.
The remaining gaps were the hardcoded model + dims.
                                           
New env vars added by this patch (all optional):
                                                              
- GBRAIN_EMBEDDING_MODEL — override the model name
- GBRAIN_EMBEDDING_DIMENSIONS — override the target dim (default 1536)                                                                                                                                                                                                                                                                  
- GBRAIN_EMBEDDING_OMIT_DIMENSIONS — don't send the `dimensions` param                                                                                                                                                                                                                                                                    
                                                              
Existing env vars used by the OpenAI SDK (already supported, listed for                                                                                                                                                                                                                                                                   
completeness so a self-hosted user has the full set in one place):
- OPENAI_BASE_URL — point at your self-hosted endpoint                                                                                                                                                                                                                                                                                  
- OPENAI_API_KEY — required non-empty by the SDK; any string works if your server has no auth                                                                                                                                                                                                                                             
                                           
If the server returns more dims than configured (e.g. a Matryoshka-trained                                                                                                                                                                                                                                                                
model where the param is omitted or ignored), we slice the prefix and                                                                                                                                                                                                                                                                   
L2-renormalize. That keeps cosine retrieval quality on MRL models.                                                                                                                                                                                                                                                                        

Tested with vLLM 0.20 + Qwen/Qwen3-Embedding-4B (native 2560-dim)                                                                                                                                                                                                                                                                         
truncated to 1536. Full re-index of 4098 chunks across 736 pages,                                                                                                                                                                                                                                                                       
gbrain doctor reports 100% coverage. Default behavior unchanged for                                                                                                                                                                                                                                                                       
users on OpenAI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->