### PR TITLE
v0.23.1 fix(test): isolate HOME in run-e2e.sh to stop config corruption

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -726,6 +726,26 @@ permission to run them — see the "run without asking" rule above.
 Never leave `gbrain-test-pg` running. If you find a stale one from a previous run,
 stop and remove it before starting a new one.
 
+#### HOME isolation contract (v0.23.1+)
+
+`scripts/run-e2e.sh` redirects `HOME` and `GBRAIN_HOME` to a `mktemp -d` tmpdir
+before bun starts, so config writes triggered by tests (e.g. `setupDB` calling
+`saveConfig` for the test container) land in the tmpdir instead of the user's
+real `~/.gbrain/config.json`. After the run, the wrapper md5-compares the user
+config against its pre-run snapshot.
+
+Two rules for agents:
+
+- **Always run E2E via `bun run test:e2e`,** never via direct `bun test test/e2e/*.test.ts`
+  invocations. The direct path skips the wrapper and re-opens the
+  config-clobber footgun.
+- **If the wrapper exits `2` with a `HOME isolation breach detected` banner,
+  STOP.** That exit code (distinct from `1`, which is test failure) means a
+  test still escaped isolation: a code path inside gbrain wrote to
+  `~/.gbrain/config.json` despite both env vars being redirected. Restoring
+  the user config from a backup and rerunning hides a real bug. File an
+  issue with the banner output instead.
+
 ## Search Mode (v0.32.3)
 
 GBrain ships three named search modes that bundle the search-lite knobs from

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -834,6 +834,26 @@ permission to run them — see the "run without asking" rule above.
 Never leave `gbrain-test-pg` running. If you find a stale one from a previous run,
 stop and remove it before starting a new one.
 
+#### HOME isolation contract (v0.23.1+)
+
+`scripts/run-e2e.sh` redirects `HOME` and `GBRAIN_HOME` to a `mktemp -d` tmpdir
+before bun starts, so config writes triggered by tests (e.g. `setupDB` calling
+`saveConfig` for the test container) land in the tmpdir instead of the user's
+real `~/.gbrain/config.json`. After the run, the wrapper md5-compares the user
+config against its pre-run snapshot.
+
+Two rules for agents:
+
+- **Always run E2E via `bun run test:e2e`,** never via direct `bun test test/e2e/*.test.ts`
+  invocations. The direct path skips the wrapper and re-opens the
+  config-clobber footgun.
+- **If the wrapper exits `2` with a `HOME isolation breach detected` banner,
+  STOP.** That exit code (distinct from `1`, which is test failure) means a
+  test still escaped isolation: a code path inside gbrain wrote to
+  `~/.gbrain/config.json` despite both env vars being redirected. Restoring
+  the user config from a backup and rerunning hides a real bug. File an
+  issue with the banner output instead.
+
 ## Search Mode (v0.32.3)
 
 GBrain ships three named search modes that bundle the search-lite knobs from

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -20,10 +20,51 @@
 # which is too tight for setupDB's TRUNCATE CASCADE on ~30 tables on
 # CI runners under load (one CI flake observed on PR #475 hitting
 # exactly 5000.09ms in the Tags beforeAll).
+#
+# HOME isolation: E2E tests call paths that resolve to gbrain init / saveConfig
+# (e.g. setupDB writing config for the test container) and would otherwise
+# write the user's real ~/.gbrain/config.json. The wrapper redirects HOME and
+# GBRAIN_HOME to a tmpdir before bun starts so config writes land in the
+# tmpdir, then verifies the user's real config md5 didn't change after the run.
+# Both env vars are required: loadConfig/saveConfig resolve via HOME, while
+# configPath/getDbUrlSource honor GBRAIN_HOME; setting only one leaves the
+# other path escaping isolation. HOME is set before bun starts because Bun's
+# os.homedir() caches at first call and in-process mutation would not take.
+# Trap cleans up the tmpdir even on test failure.
 
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+
+# --- HOME isolation: snapshot real user config before switching ---
+# Tolerate unset HOME (minimal containers, exotic CI shells) without tripping set -u.
+REAL_HOME="${HOME:-/tmp}"
+USER_CONFIG="$REAL_HOME/.gbrain/config.json"
+USER_CONFIG_EXISTED=0
+USER_CONFIG_MD5=""
+# `{ ... } || true` swallows non-zero exit when the file is missing or md5 isn't
+# installed, so set -e never aborts before the post-run breach detector can run.
+md5_of() {
+  { if command -v md5 >/dev/null 2>&1; then
+      md5 -q "$1" 2>/dev/null
+    elif command -v md5sum >/dev/null 2>&1; then
+      md5sum "$1" 2>/dev/null | awk '{print $1}'
+    fi
+  } || true
+}
+if [ -f "$USER_CONFIG" ]; then
+  USER_CONFIG_EXISTED=1
+  USER_CONFIG_MD5=$(md5_of "$USER_CONFIG")
+fi
+
+# Portable mktemp: explicit XXXXXX is required by GNU mktemp on Linux CI.
+# `-t prefix` works on BSD but errors on GNU when the template lacks Xs.
+E2E_TMP_HOME=$(mktemp -d "${TMPDIR:-/tmp}/gbrain-e2e.XXXXXX")
+trap 'rm -rf "$E2E_TMP_HOME"' EXIT
+
+export HOME="$E2E_TMP_HOME"
+export GBRAIN_HOME="$E2E_TMP_HOME"
+mkdir -p "$E2E_TMP_HOME/.gbrain"
 
 # --dry-run-list: print the resolved file list (one per line) and exit. Used
 # by scripts/ci-local.sh to smoke-test the argv branching at startup.
@@ -119,6 +160,39 @@ echo "E2E SUMMARY (sequential execution)"
 echo "========================================"
 echo "Files: $((pass_files + fail_files)) total, $pass_files passed, $fail_files failed"
 echo "Tests: $total_pass passed, $total_fail failed"
+
+# --- HOME isolation verification: fail loud on any out-of-isolation write ---
+# Runs regardless of test pass/fail; isolation breach is higher-severity than
+# any individual test failure. Exit 2 distinguishes from exit 1 (test failure).
+# Three breach modes covered:
+#   1. Config existed before AND was modified (md5 changed)
+#   2. Config existed before AND was deleted during the run
+#   3. Config did NOT exist before but was created during the run
+AFTER_EXISTS=0
+[ -f "$USER_CONFIG" ] && AFTER_EXISTS=1
+AFTER_MD5=""
+if [ "$AFTER_EXISTS" = "1" ]; then
+  AFTER_MD5=$(md5_of "$USER_CONFIG")
+fi
+BREACH_REASON=""
+if [ "$USER_CONFIG_EXISTED" = "1" ] && [ "$AFTER_EXISTS" = "0" ]; then
+  BREACH_REASON="config existed before run but was deleted"
+elif [ "$USER_CONFIG_EXISTED" = "0" ] && [ "$AFTER_EXISTS" = "1" ]; then
+  BREACH_REASON="config did not exist before run but was created"
+elif [ -n "$USER_CONFIG_MD5" ] && [ "$AFTER_MD5" != "$USER_CONFIG_MD5" ]; then
+  BREACH_REASON="config md5 changed during run"
+fi
+if [ -n "$BREACH_REASON" ]; then
+  echo "" >&2
+  echo "ERROR: HOME isolation breach detected." >&2
+  echo "  Reason: $BREACH_REASON" >&2
+  echo "  Path: $USER_CONFIG" >&2
+  echo "  Before: existed=$USER_CONFIG_EXISTED md5=${USER_CONFIG_MD5:-none}" >&2
+  echo "  After:  existed=$AFTER_EXISTS md5=${AFTER_MD5:-none}" >&2
+  echo "  A test wrote outside the tmpdir HOME despite the override." >&2
+  exit 2
+fi
+
 if [ ${#fail_list[@]} -gt 0 ]; then
   echo ""
   echo "Failing files:"

--- a/test/gbrain-home-isolation.test.ts
+++ b/test/gbrain-home-isolation.test.ts
@@ -16,7 +16,7 @@
 
 import { describe, test, expect } from 'bun:test';
 import { mkdtempSync, existsSync, readdirSync, statSync, rmSync } from 'fs';
-import { tmpdir } from 'os';
+import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 
 // Save original env so we don't leak between tests.
@@ -44,10 +44,11 @@ describe('GBRAIN_HOME write-side isolation', () => {
     delete process.env.GBRAIN_HOME;
     try {
       const { configDir } = await import('../src/core/config.ts');
-      const result = configDir();
-      // Should NOT contain the test tmpdir; should resolve to a real homedir path.
-      expect(result.endsWith('.gbrain')).toBe(true);
-      expect(result.startsWith('/tmp/')).toBe(false);
+      // Contract: when GBRAIN_HOME is unset, configDir() === os.homedir()/.gbrain.
+      // Asserting against os.homedir() (rather than a "not /tmp/" sentinel) keeps
+      // this test correct under safety wrappers that redirect HOME=/tmp/... — the
+      // behavior we care about is that the fallback path equals homedir().
+      expect(configDir()).toBe(join(homedir(), '.gbrain'));
     } finally {
       if (ORIG_GBRAIN_HOME !== undefined) process.env.GBRAIN_HOME = ORIG_GBRAIN_HOME;
     }


### PR DESCRIPTION
## Summary

Replaces #513 with a clean, minimally-scoped version. Same fix, smaller diff.

Closes a recurring incident where `bun run test:e2e` overwrote the user's real `~/.gbrain/config.json` to point at the docker test container, then wedged the live autopilot when the container tore down. Three operators hit this in 16 days, the most recent ~24 hours ago.

The fix is in `scripts/run-e2e.sh`: export both `HOME` and `GBRAIN_HOME` to a `mktemp -d` tmpdir before bun starts, so config writes during the suite land in the tmpdir instead of `~/.gbrain/config.json`. After the run, the wrapper md5-compares the real user config to its pre-run snapshot (three breach modes covered: modified, deleted, or created-from-nothing) and exits `2` with a loud `HOME isolation breach detected` banner if anything escaped the override. Distinct from exit `1` (test failure) so CI logs make root cause obvious.

Both env vars are required: `loadConfig` / `saveConfig` resolve via `HOME`, while `configPath` / `getDbUrlSource` honor `GBRAIN_HOME`. Setting only one leaves the other path escaping isolation. `HOME` is set before `bun` starts because Bun's `os.homedir()` caches at first call; in-process mutation can't beat the cache.

## What changed in this rebase (2026-04-30)

This PR was originally drafted against v0.22.8.1, but upstream master moved to v0.23.0 in the meantime. Rebased onto current `upstream/master` and retargeted the version bump to **v0.23.1** so the PR lands cleanly on top of v0.23.0 without out-of-order semver. The `fix(test): isolate HOME` commit is unchanged content; only the `chore: bump` commit was rewritten to target v0.23.1 and use the v0.23.1 CHANGELOG voice.

## Why a new PR instead of force-pushing #513

The branch behind #513 (`garrytan/e2e-home-isolation`) had picked up 41 commits of unrelated downstream Phase 2 work that hadn't been merged upstream yet. Force-rebasing it on current upstream master would have turned a single-file E2E fix into a 27-file, +2,208-line integration PR with substantive `src/cli.ts` conflicts. This branch is `upstream/master` + 2 commits, exactly what the PR claims to be.

## Commits (2, bisectable)

- `fix(test): isolate HOME in run-e2e.sh to stop config corruption` ... the actual fix (cherry-picked from #513's `df60281`)
- `chore: bump version and changelog (v0.23.1)` ... version bump retargeted from v0.22.8.1 to v0.23.1 after upstream advanced to v0.23.0

The `fix(docs): regenerate llms-full.txt` commit from #513 was specific to fork-side drift and does not apply to upstream master.

## Test Coverage

The wrapper itself acts as the regression test: every E2E run now md5-compares the user config and fails loud on isolation breach.

Verified on the same fix content (cherry-picked unchanged):

- `bash -n scripts/run-e2e.sh`: clean
- `bun run test:e2e` against `pgvector/pgvector:pg16` on port 5434: **27 files, 245 tests, 0 failures**
- User config md5 byte-identical before and after run (`bd38fb4bd78f86b0b5092bbf0876d023` both times)

## Test plan

- [x] `scripts/run-e2e.sh` syntax (`bash -n`)
- [x] `package.json` valid JSON, `version` matches `VERSION` (`0.23.1`)
- [x] CHANGELOG ordering: `[0.23.1] -> [0.23.0] -> [0.22.16]`
- [x] E2E suite passes with isolation active (verified on `df60281` source, same content as current `e5e01a4`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
