### PR TITLE
fix: initSchema runs migrations before SCHEMA_SQL on drifted DBs

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4,7 +4,7 @@ import { pg_trgm } from '@electric-sql/pglite/contrib/pg_trgm';
 import type { Transaction } from '@electric-sql/pglite';
 import type { BrainEngine, LinkBatchInput, TimelineBatchInput, ReservedConnection } from './engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
-import { runMigrations } from './migrate.ts';
+import { LATEST_VERSION, runMigrations } from './migrate.ts';
 import { PGLITE_SCHEMA_SQL } from './pglite-schema.ts';
 import { acquireLock, releaseLock, type LockHandle } from './pglite-lock.ts';
 import type {
@@ -86,12 +86,50 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   async initSchema(): Promise<void> {
-    await this.db.exec(PGLITE_SCHEMA_SQL);
+    // BAT-540: same order-of-ops fix as PostgresEngine. PGLITE_SCHEMA_SQL
+    // embeds the latest schema and references columns that pending
+    // migrations would have added (e.g. page_kind, symbol_name). On a
+    // drifted PGLite file (gbrain version-bumped without ever opening the
+    // brain), running the schema first would fail before runMigrations
+    // could self-heal. See PostgresEngine.initSchema for the full rationale.
+    const drifted = await this.isDriftedDatabase();
 
-    const { applied } = await runMigrations(this);
-    if (applied > 0) {
-      console.log(`  ${applied} migration(s) applied`);
+    if (drifted) {
+      const { applied } = await runMigrations(this);
+      if (applied > 0) {
+        console.log(`  ${applied} migration(s) applied`);
+      }
+      // Idempotent reassertion after migrations bring schema up.
+      await this.db.exec(PGLITE_SCHEMA_SQL);
+    } else {
+      await this.db.exec(PGLITE_SCHEMA_SQL);
+      const { applied } = await runMigrations(this);
+      if (applied > 0) {
+        console.log(`  ${applied} migration(s) applied`);
+      }
     }
+  }
+
+  /**
+   * Mirrors PostgresEngine.isDriftedDatabase. Returns true when the brain
+   * file has a config table with version < LATEST_VERSION. False on a
+   * fresh file (no config table) or on a brain already at LATEST_VERSION.
+   */
+  private async isDriftedDatabase(): Promise<boolean> {
+    const tableRows = await this.db.query<{ oid: string | null }>(
+      `SELECT to_regclass('public.config') AS oid`,
+    );
+    const configExists = tableRows.rows[0]?.oid != null;
+    if (!configExists) return false;
+
+    const versionRows = await this.db.query<{ value: string }>(
+      `SELECT value FROM config WHERE key = 'version'`,
+    );
+    if (versionRows.rows.length === 0) return false;
+
+    const live = parseInt(versionRows.rows[0].value, 10);
+    if (!Number.isFinite(live)) return false;
+    return live < LATEST_VERSION;
   }
 
   async withReservedConnection<T>(fn: (conn: ReservedConnection) => Promise<T>): Promise<T> {

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1,7 +1,7 @@
 import postgres from 'postgres';
 import type { BrainEngine, LinkBatchInput, TimelineBatchInput, ReservedConnection } from './engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
-import { runMigrations } from './migrate.ts';
+import { LATEST_VERSION, runMigrations } from './migrate.ts';
 import { SCHEMA_SQL } from './schema-embedded.ts';
 import type {
   Page, PageInput, PageFilters, PageType,
@@ -78,16 +78,68 @@ export class PostgresEngine implements BrainEngine {
     // on DDL statements (DROP TRIGGER + CREATE TRIGGER acquire AccessExclusiveLock)
     await conn`SELECT pg_advisory_lock(42)`;
     try {
-      await conn.unsafe(SCHEMA_SQL);
+      // BAT-540: SCHEMA_SQL embeds the *latest* schema state. On a drifted DB
+      // (live version < LATEST_VERSION) it references columns that pending
+      // migrations would have added — e.g. CREATE INDEX ... ON
+      // content_chunks(symbol_name) fails on a v18 DB because symbol_name is
+      // added by the v0.19.0 migration. Running it before runMigrations()
+      // means the migration runner never gets a chance to self-heal: operators
+      // had to pull migration SQL bodies out of migrate.ts and run them
+      // manually via psql.
+      //
+      // Order: drifted DBs run migrations FIRST (bring schema up before the
+      // bleeding-edge SCHEMA_SQL replay), fresh / current DBs keep the
+      // historical order (SCHEMA_SQL builds the v1 baseline, then migrations
+      // run as no-ops to bump config.version to LATEST_VERSION).
+      const drifted = await this.isDriftedDatabase();
 
-      // Run any pending migrations automatically
-      const { applied } = await runMigrations(this);
-      if (applied > 0) {
-        console.log(`  ${applied} migration(s) applied`);
+      if (drifted) {
+        const { applied } = await runMigrations(this);
+        if (applied > 0) {
+          console.log(`  ${applied} migration(s) applied`);
+        }
+        // Idempotent reassertion. After migrations the schema is at
+        // LATEST_VERSION, so SCHEMA_SQL is mostly a no-op — but it catches
+        // any drift not covered by a numbered migration (e.g. an index
+        // hand-dropped on prod, or a trigger replaced under the hood).
+        await conn.unsafe(SCHEMA_SQL);
+      } else {
+        // Fresh install or already at LATEST_VERSION: keep the historical
+        // order. Migrations 2..LATEST expect the v1 baseline tables to
+        // exist, so SCHEMA_SQL must run first on a fresh DB.
+        await conn.unsafe(SCHEMA_SQL);
+        const { applied } = await runMigrations(this);
+        if (applied > 0) {
+          console.log(`  ${applied} migration(s) applied`);
+        }
       }
     } finally {
       await conn`SELECT pg_advisory_unlock(42)`;
     }
+  }
+
+  /**
+   * Returns true if the DB has been initialized previously and its config.version
+   * is behind LATEST_VERSION. False on fresh DBs (no config table) and on DBs
+   * already at or beyond LATEST_VERSION. The result drives initSchema()'s
+   * SCHEMA_SQL/runMigrations ordering — see BAT-540 for the recurrence.
+   *
+   * Uses to_regclass() so the lookup is cheap and side-effect-free, and does
+   * NOT throw on missing tables (information_schema.tables would also work but
+   * incurs a heavier catalog scan).
+   */
+  private async isDriftedDatabase(): Promise<boolean> {
+    const conn = this.sql;
+    const tableRows = await conn`SELECT to_regclass('public.config') AS oid`;
+    const configExists = tableRows[0]?.oid != null;
+    if (!configExists) return false; // fresh DB
+
+    const versionRows = await conn`SELECT value FROM config WHERE key = 'version'`;
+    if (versionRows.length === 0) return false; // never migrated; treat as fresh
+
+    const live = parseInt(versionRows[0].value as string, 10);
+    if (!Number.isFinite(live)) return false; // corrupt value; let SCHEMA_SQL+migrations re-establish state
+    return live < LATEST_VERSION;
   }
 
   async transaction<T>(fn: (engine: BrainEngine) => Promise<T>): Promise<T> {

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -809,3 +809,144 @@ describe('PR #356 — non-transactional DDL runs via reserved connection', () =>
     expect(fnBody).toContain("SET statement_timeout = '600000'");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────
+// BAT-540 — initSchema must self-heal a drifted DB
+// ─────────────────────────────────────────────────────────────────
+//
+// The bug: PostgresEngine.initSchema() ran SCHEMA_SQL *before* runMigrations().
+// SCHEMA_SQL embeds the latest schema state — `CREATE INDEX ... ON
+// content_chunks(symbol_name)` was added by the v26 migration. On a drifted
+// DB (live config.version < 26) the index DDL fails because symbol_name
+// hasn't been added yet, and runMigrations never gets to run.
+//
+// Field impact (BAT-237): operators had to pull migration SQL bodies out of
+// migrate.ts and replay them via psql by hand. `gbrain init --migrate-only`,
+// the documented self-heal path, was effectively a no-op.
+//
+// The fix: detect drift (config.version < LATEST_VERSION) and run migrations
+// FIRST, then replay SCHEMA_SQL idempotently. Fresh DBs keep the historical
+// order because migrations 2..LATEST expect the v1 baseline tables to exist.
+//
+// This regression test reproduces drift on PGLite (the bug shape matches across
+// engines because PGLITE_SCHEMA_SQL has the same bleeding-edge references at
+// line 94: `CREATE INDEX ... ON content_chunks(symbol_name)`) and asserts:
+//   1. initSchema succeeds without throwing.
+//   2. config.version is bumped back to LATEST_VERSION.
+//   3. The dropped column is restored by the migration runner.
+//   4. The acceptance criterion: a put-page round-trip works end-to-end.
+describe('BAT-540 — initSchema self-heals a drifted DB', () => {
+  let engine: PGLiteEngine;
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+  });
+
+  test('initSchema on a drifted DB (v25 ≤ k ≤ v26) succeeds and reaches LATEST_VERSION', async () => {
+    const db = (engine as PGLiteEngine & { db: { exec: (s: string) => Promise<unknown>; query: <T>(s: string, p?: unknown[]) => Promise<{ rows: T[] }> } }).db;
+
+    // Recreate drift: drop the v26 artifacts (the column + its index).
+    // SCHEMA_SQL re-references content_chunks(symbol_name) — without the
+    // pre-fix order swap, the next initSchema would fail right here.
+    await db.exec(`DROP INDEX IF EXISTS idx_chunks_symbol_name`);
+    await db.exec(`DROP INDEX IF EXISTS idx_chunks_language`);
+    // PGLite supports DROP COLUMN; cascade picks up the partial-index
+    // dependencies if any survived the explicit DROP INDEX above.
+    await db.exec(`ALTER TABLE content_chunks DROP COLUMN IF EXISTS symbol_name CASCADE`);
+    await db.exec(`ALTER TABLE content_chunks DROP COLUMN IF EXISTS language CASCADE`);
+
+    // Wind config.version back to v25 so the migration runner sees v26+ as
+    // pending. (Two versions behind — the issue's acceptance criterion calls
+    // out k≥2.)
+    await engine.setConfig('version', '25');
+
+    // Pre-condition: column must actually be gone, otherwise the test would
+    // pass trivially even with the bug intact.
+    const before = await db.query<{ exists: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_name = 'content_chunks' AND column_name = 'symbol_name'
+       ) AS exists`,
+    );
+    expect(before.rows[0].exists).toBe(false);
+
+    // Act: run initSchema. With the bug, this throws because
+    // PGLITE_SCHEMA_SQL's `CREATE INDEX ... ON content_chunks(symbol_name)`
+    // hits a column that doesn't exist before runMigrations re-adds it.
+    await engine.initSchema();
+
+    // Assert: column is back, version is at LATEST, put-page round-trip works.
+    const after = await db.query<{ exists: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_name = 'content_chunks' AND column_name = 'symbol_name'
+       ) AS exists`,
+    );
+    expect(after.rows[0].exists).toBe(true);
+
+    const versionStr = await engine.getConfig('version');
+    expect(parseInt(versionStr || '0', 10)).toBe(LATEST_VERSION);
+
+    // Acceptance: put + get a page end-to-end (mirrors the bug's manual
+    // verify line "gbrain put debug/init-order-test").
+    await engine.putPage('debug/init-order-test', {
+      type: 'concept',
+      title: 'init order test',
+      compiled_truth: 'BAT-540',
+      timeline: '',
+    });
+    const got = await engine.getPage('debug/init-order-test');
+    expect(got).not.toBeNull();
+    expect(got?.compiled_truth).toBe('BAT-540');
+  }, 120_000);
+
+  test('initSchema is idempotent on a current DB', async () => {
+    // Sanity: rerunning initSchema on a freshly-migrated DB is a no-op
+    // (no migrations applied, no errors thrown). This also exercises the
+    // "fresh / current" branch of the new drift detection.
+    await engine.initSchema();
+    const versionStr = await engine.getConfig('version');
+    expect(parseInt(versionStr || '0', 10)).toBe(LATEST_VERSION);
+  });
+});
+
+describe('BAT-540 — initSchema source-level guards', () => {
+  test('PostgresEngine.initSchema branches on a drift detector', () => {
+    const src = readFileSync(resolve('src/core/postgres-engine.ts'), 'utf-8');
+    expect(src).toContain('isDriftedDatabase');
+    // The fix is the order swap: when drifted, runMigrations must be called
+    // before SCHEMA_SQL. Locate the drifted branch and assert ordering.
+    const initIdx = src.indexOf('async initSchema');
+    expect(initIdx).toBeGreaterThan(-1);
+    const fnEnd = src.indexOf('async transaction', initIdx);
+    const body = src.slice(initIdx, fnEnd);
+    const driftedIdx = body.indexOf('if (drifted)');
+    expect(driftedIdx).toBeGreaterThan(-1);
+    const branch = body.slice(driftedIdx, body.indexOf('} else', driftedIdx));
+    const migIdx = branch.indexOf('runMigrations(this)');
+    const schemaIdx = branch.indexOf('SCHEMA_SQL');
+    expect(migIdx).toBeGreaterThan(-1);
+    expect(schemaIdx).toBeGreaterThan(migIdx);
+  });
+
+  test('PGLiteEngine.initSchema branches on the same drift detector', () => {
+    const src = readFileSync(resolve('src/core/pglite-engine.ts'), 'utf-8');
+    expect(src).toContain('isDriftedDatabase');
+    const initIdx = src.indexOf('async initSchema');
+    const fnEnd = src.indexOf('private async isDriftedDatabase', initIdx);
+    const body = src.slice(initIdx, fnEnd);
+    const driftedIdx = body.indexOf('if (drifted)');
+    expect(driftedIdx).toBeGreaterThan(-1);
+    const branch = body.slice(driftedIdx, body.indexOf('} else', driftedIdx));
+    const migIdx = branch.indexOf('runMigrations(this)');
+    const schemaIdx = branch.indexOf('PGLITE_SCHEMA_SQL');
+    expect(migIdx).toBeGreaterThan(-1);
+    expect(schemaIdx).toBeGreaterThan(migIdx);
+  });
+});


### PR DESCRIPTION
## Summary

- `PostgresEngine.initSchema()` ran `SCHEMA_SQL` before `runMigrations()`. `SCHEMA_SQL` embeds the latest schema and references columns that pending migrations would have added (e.g. `CREATE INDEX ... ON content_chunks(symbol_name)` from v26). On a drifted DB this fails before the migration runner gets to self-heal — `gbrain init --migrate-only` was effectively a no-op for any DB more than zero versions behind.
- Detect drift (`config.version < LATEST_VERSION`) and swap the order: migrations first, then `SCHEMA_SQL` as an idempotent reassertion. Fresh DBs keep the historical order because migrations 2..LATEST expect the v1 baseline tables to exist.
- Same patch applied to `PGLiteEngine` — `PGLITE_SCHEMA_SQL` has the identical bleeding-edge column references.

## Origin

Surfaced during repair of BAT-237 (`page_kind` column missing on writes; resolved manually via `psql`). This PR is the upstream patch so the recurrence shape can't bite again.

## Test plan

- [x] `bun test test/migrate.test.ts` — 53 pass, includes new BAT-540 regression suite.
- [x] `bun test` (focused: migrate / init / engine / postgres / pglite / apply-migrations / migration-resume / migrations-registry) — 195 pass, 0 fail.
- [x] `scripts/check-jsonb-pattern.sh`, `scripts/check-progress-to-stdout.sh`, `scripts/check-wasm-embedded.sh` — all OK.
- [x] Verified the regression test catches the bug: temporarily reverted the fix; the new `BAT-540 — initSchema self-heals a drifted DB` test fails with `column "symbol_name" does not exist` (the exact failure mode from BAT-237). Restoring the fix turns it green.

## Acceptance criteria (from BAT-540)

- ✅ `gbrain init --migrate-only` against a DB N versions behind LATEST_VERSION succeeds without manual psql intervention. Reproduced by the regression test which winds the brain back to v25 (k=2 versions behind v27 schema), drops the v26 column + index, then asserts `initSchema()` brings it back to LATEST_VERSION and a put/get round-trip works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->