### PR TITLE
fix: migrate embeddings to 384 dimensions

### DIFF
--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -2,7 +2,7 @@
  * Embedding Service
  * Ported from production Ruby implementation (embedding_service.rb, 190 LOC)
  *
- * OpenAI text-embedding-3-large at 1536 dimensions.
+ * OpenAI text-embedding-3-large at the configured embedding dimension.
  * Retry with exponential backoff (4s base, 120s cap, 5 retries).
  * 8000 character input truncation.
  */
@@ -10,7 +10,7 @@
 import OpenAI from 'openai';
 
 const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
+const DIMENSIONS = Number(process.env.GBRAIN_EMBEDDING_DIMENSIONS || '384');
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -1101,6 +1101,34 @@ export const MIGRATIONS: Migration[] = [
       END $$;
     `,
   },
+  {
+    version: 31,
+    name: 'embedding_dimension_384',
+    // Local embedding installs can use compact 384-dimensional vectors.
+    // Existing PGLite brains created from older schemas still have
+    // content_chunks.embedding as vector(1536), which rejects the 384-dim
+    // vectors returned by the local OpenAI-compatible Qwen3 shim. Convert
+    // the column and metadata together, rebuilding the HNSW index around
+    // the type change. Existing 1536-dim embeddings are expected to be
+    // regenerated after this migration.
+    sqlFor: {
+      postgres: `
+        DROP INDEX IF EXISTS idx_chunks_embedding;
+        ALTER TABLE content_chunks ALTER COLUMN embedding DROP DEFAULT;
+        ALTER TABLE content_chunks ALTER COLUMN embedding TYPE vector(384) USING NULL;
+        CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);
+        UPDATE config SET value = '384' WHERE key = 'embedding_dimensions';
+      `,
+      pglite: `
+        DROP INDEX IF EXISTS idx_chunks_embedding;
+        ALTER TABLE content_chunks ALTER COLUMN embedding DROP DEFAULT;
+        ALTER TABLE content_chunks ALTER COLUMN embedding TYPE vector(384) USING NULL;
+        CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);
+        UPDATE config SET value = '384' WHERE key = 'embedding_dimensions';
+      `,
+    },
+    sql: '',
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -74,7 +74,7 @@ CREATE TABLE IF NOT EXISTS content_chunks (
   chunk_index   INTEGER NOT NULL,
   chunk_text    TEXT    NOT NULL,
   chunk_source  TEXT    NOT NULL DEFAULT 'compiled_truth',
-  embedding     vector(1536),
+  embedding     vector(384),
   model         TEXT    NOT NULL DEFAULT 'text-embedding-3-large',
   token_count   INTEGER,
   embedded_at   TIMESTAMPTZ,
@@ -201,7 +201,7 @@ INSERT INTO config (key, value) VALUES
   ('version', '1'),
   ('engine', 'pglite'),
   ('embedding_model', 'text-embedding-3-large'),
-  ('embedding_dimensions', '1536'),
+  ('embedding_dimensions', '384'),
   ('chunk_strategy', 'semantic')
 ON CONFLICT (key) DO NOTHING;
 

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -95,7 +95,7 @@ CREATE TABLE IF NOT EXISTS content_chunks (
   chunk_index           INTEGER NOT NULL,
   chunk_text            TEXT    NOT NULL,
   chunk_source          TEXT    NOT NULL DEFAULT 'compiled_truth',
-  embedding             vector(1536),
+  embedding             vector(384),
   model                 TEXT    NOT NULL DEFAULT 'text-embedding-3-large',
   token_count           INTEGER,
   embedded_at           TIMESTAMPTZ,
@@ -321,7 +321,7 @@ CREATE TABLE IF NOT EXISTS config (
 INSERT INTO config (key, value) VALUES
   ('version', '1'),
   ('embedding_model', 'text-embedding-3-large'),
-  ('embedding_dimensions', '1536'),
+  ('embedding_dimensions', '384'),
   ('chunk_strategy', 'semantic')
 ON CONFLICT (key) DO NOTHING;
 

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -91,7 +91,7 @@ CREATE TABLE IF NOT EXISTS content_chunks (
   chunk_index           INTEGER NOT NULL,
   chunk_text            TEXT    NOT NULL,
   chunk_source          TEXT    NOT NULL DEFAULT 'compiled_truth',
-  embedding             vector(1536),
+  embedding             vector(384),
   model                 TEXT    NOT NULL DEFAULT 'text-embedding-3-large',
   token_count           INTEGER,
   embedded_at           TIMESTAMPTZ,
@@ -317,7 +317,7 @@ CREATE TABLE IF NOT EXISTS config (
 INSERT INTO config (key, value) VALUES
   ('version', '1'),
   ('embedding_model', 'text-embedding-3-large'),
-  ('embedding_dimensions', '1536'),
+  ('embedding_dimensions', '384'),
   ('chunk_strategy', 'semantic')
 ON CONFLICT (key) DO NOTHING;
 

--- a/test/e2e/cycle.test.ts
+++ b/test/e2e/cycle.test.ts
@@ -23,7 +23,7 @@ import { hasDatabase, setupDB, teardownDB, getEngine, getConn } from './helpers.
 mock.module('../../src/core/embedding.ts', () => ({
   embedBatch: async (texts: string[]) => {
     // Deterministic fake vector for each chunk.
-    return texts.map(() => new Float32Array(1536));
+    return texts.map(() => new Float32Array(384));
   },
 }));
 

--- a/test/e2e/dream.test.ts
+++ b/test/e2e/dream.test.ts
@@ -18,7 +18,7 @@ import { hasDatabase, setupDB, teardownDB, getEngine, getConn } from './helpers.
 
 // Mock embedBatch so embed phase doesn't call OpenAI.
 mock.module('../../src/core/embedding.ts', () => ({
-  embedBatch: async (texts: string[]) => texts.map(() => new Float32Array(1536)),
+  embedBatch: async (texts: string[]) => texts.map(() => new Float32Array(384)),
 }));
 
 const { runDream } = await import('../../src/commands/dream.ts');

--- a/test/e2e/search-swamp.test.ts
+++ b/test/e2e/search-swamp.test.ts
@@ -14,7 +14,7 @@ import type { ChunkInput } from '../../src/core/types.ts';
 
 let engine: PGLiteEngine;
 
-function basisEmbedding(idx: number, dim = 1536): Float32Array {
+function basisEmbedding(idx: number, dim = 384): Float32Array {
   const emb = new Float32Array(dim);
   emb[idx % dim] = 1.0;
   return emb;
@@ -122,7 +122,7 @@ describe('searchVector swamp resistance', () => {
     // Query vector is close to all three pages (mixed direction). Without
     // source-boost the chat pages would tie or win on raw cosine; with
     // source-boost the originals/ page dominates.
-    const queryVec = new Float32Array(1536);
+    const queryVec = new Float32Array(384);
     queryVec[7] = 0.6; // article direction
     queryVec[8] = 0.55; // chat-1 direction (slightly higher, simulating swamp)
     queryVec[9] = 0.55; // chat-2 direction

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -18,7 +18,7 @@ mock.module('../src/core/embedding.ts', () => ({
     // Simulate API latency so concurrent workers actually overlap.
     await new Promise(r => setTimeout(r, 30));
     activeEmbedCalls--;
-    return texts.map(() => new Float32Array(1536));
+    return texts.map(() => new Float32Array(384));
   },
 }));
 

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -202,6 +202,47 @@ describe('migrate — ordering guarantee (v15 must NOT be skipped by v16)', () =
   });
 });
 
+describe('migrate — embedding dimension 384 regression', () => {
+  const embeddingMigration = MIGRATIONS.find(m => m.name === 'embedding_dimension_384');
+
+  test('migration exists and migrates legacy vector(1536) brains to vector(384)', () => {
+    expect(embeddingMigration).toBeDefined();
+    expect(embeddingMigration!.version).toBeGreaterThan(30);
+    const pgliteSql = embeddingMigration!.sqlFor?.pglite || embeddingMigration!.sql;
+    expect(pgliteSql).toContain('ALTER TABLE content_chunks ALTER COLUMN embedding TYPE vector(384)');
+    expect(pgliteSql).toContain("UPDATE config SET value = '384' WHERE key = 'embedding_dimensions'");
+    expect(pgliteSql).toContain('DROP INDEX IF EXISTS idx_chunks_embedding');
+    expect(pgliteSql).toContain('CREATE INDEX IF NOT EXISTS idx_chunks_embedding');
+  });
+
+  test('PGLite migration converts existing vector(1536) column to 384 and updates config', async () => {
+    const engine = new PGLiteEngine();
+    try {
+      await engine.connect({});
+      await engine.initSchema();
+      const db = (engine as any).db;
+
+      await db.exec(`DROP INDEX IF EXISTS idx_chunks_embedding`);
+      await db.exec(`ALTER TABLE content_chunks ALTER COLUMN embedding TYPE vector(1536)`);
+      await db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops)`);
+      await engine.setConfig('embedding_dimensions', '1536');
+      await engine.setConfig('version', '30');
+
+      await runMigrations(engine);
+
+      const dimRows = (await db.query(`
+        SELECT atttypmod FROM pg_attribute
+        WHERE attrelid = 'content_chunks'::regclass AND attname = 'embedding'
+      `)).rows as Array<{ atttypmod: number }>;
+      expect(dimRows[0].atttypmod).toBe(384);
+      expect(await engine.getConfig('embedding_dimensions')).toBe('384');
+      expect(await engine.getConfig('version')).toBe(String(LATEST_VERSION));
+    } finally {
+      await engine.disconnect();
+    }
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────
 // v0.18.1 RLS hardening — structural guard for migration v24
 // ─────────────────────────────────────────────────────────────────

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -211,7 +211,7 @@ describe('PGLiteEngine: Search', () => {
   });
 
   test('searchVector returns empty when no embeddings', async () => {
-    const fakeEmbedding = new Float32Array(1536);
+    const fakeEmbedding = new Float32Array(384);
     const results = await engine.searchVector(fakeEmbedding);
     expect(results.length).toBe(0);
   });
@@ -270,7 +270,7 @@ describe('PGLiteEngine: Chunks', () => {
 
   test('getChunksWithEmbeddings returns embedding data', async () => {
     await engine.putPage('test/embed', testPage);
-    const embedding = new Float32Array(1536).fill(0.1);
+    const embedding = new Float32Array(384).fill(0.1);
     await engine.upsertChunks('test/embed', [
       { chunk_index: 0, chunk_text: 'With embedding', chunk_source: 'compiled_truth', embedding },
     ]);


### PR DESCRIPTION
## Summary
- Add migration v31 to convert legacy `content_chunks.embedding` columns from `vector(1536)` to `vector(384)`.
- Align PGLite/Postgres schema defaults and `embedding_dimensions` config metadata to 384.
- Make the runtime embedding dimension default match the 384-dimensional schema, while still allowing `GBRAIN_EMBEDDING_DIMENSIONS` override.
- Update embedding-related tests and mocks to use 384-dimensional vectors.

## Why
Local OpenAI-compatible embedding providers such as compact Qwen3 embedding shims can return 384-dimensional vectors. Existing GBrain schemas declared `content_chunks.embedding` as `vector(1536)`, causing real writes to fail with dimension mismatch errors.

## Review notes
- The migration intentionally uses `USING NULL` when changing `vector(1536)` to `vector(384)`, because existing 1536-dimensional embeddings cannot be preserved in a 384-dimensional column and should be regenerated.
- Rebased on latest `garrytan/gbrain:master`; upstream v30 is preserved as `dream_verdicts_table`, and this PR now uses v31 for the embedding migration.
- Independent reviewer pass completed after fixing the runtime/schema default mismatch.

## Test Plan
- [x] `bun test test/migrate.test.ts test/pglite-engine.test.ts test/embed.test.ts test/e2e/search-swamp.test.ts --timeout=60000`
  - `159 pass`
  - `0 fail`
- [x] `bun run typecheck`

## CI
GitHub Actions currently reports `action_required` for upstream workflows on this fork PR, with no jobs started.
