### PR TITLE
test(home-isolation): assert homedir() contract instead of '/tmp/' sentinel

### DIFF
--- a/test/gbrain-home-isolation.test.ts
+++ b/test/gbrain-home-isolation.test.ts
@@ -16,7 +16,7 @@
 
 import { describe, test, expect } from 'bun:test';
 import { mkdtempSync, existsSync, readdirSync, statSync, rmSync } from 'fs';
-import { tmpdir } from 'os';
+import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 
 // Save original env so we don't leak between tests.
@@ -44,10 +44,11 @@ describe('GBRAIN_HOME write-side isolation', () => {
     delete process.env.GBRAIN_HOME;
     try {
       const { configDir } = await import('../src/core/config.ts');
-      const result = configDir();
-      // Should NOT contain the test tmpdir; should resolve to a real homedir path.
-      expect(result.endsWith('.gbrain')).toBe(true);
-      expect(result.startsWith('/tmp/')).toBe(false);
+      // Contract: when GBRAIN_HOME is unset, configDir() === os.homedir()/.gbrain.
+      // Asserting against os.homedir() (rather than a "not /tmp/" sentinel) keeps
+      // this test correct under safety wrappers that redirect HOME=/tmp/... — the
+      // behavior we care about is that the fallback path equals homedir().
+      expect(configDir()).toBe(join(homedir(), '.gbrain'));
     } finally {
       if (ORIG_GBRAIN_HOME !== undefined) process.env.GBRAIN_HOME = ORIG_GBRAIN_HOME;
     }


### PR DESCRIPTION
## Summary
- Replace the brittle `result.startsWith('/tmp/')` sentinel in `test/gbrain-home-isolation.test.ts` with the real contract: `configDir() === join(homedir(), '.gbrain')` when `GBRAIN_HOME` is unset.

## Why
The fallback test was asserting "the resolved path doesn't start with `/tmp/`" as a proxy for "this resolved to the real homedir." That sentinel is incompatible with the very HOME-isolation pattern the rest of the suite relies on:

- `scripts/run-e2e.sh` redirects `HOME` to a `mktemp -d` tmpdir before bun starts (the v0.23.1+ HOME isolation contract).
- Downstream forks running the full unit suite under similar wrappers (e.g. nightly maintenance jobs that set `HOME=$(mktemp -d /tmp/gbrain-test-home.XXXXXX)` to dodge the `~/.gbrain/config.json` clobber footgun) hit the same conflict.
- Bun caches `os.homedir()` on first call, so `process.env.HOME` mutation in `beforeEach` cannot redirect it away from the wrapper's tmp path.

When the wrapper sets `HOME=/tmp/...`, `os.homedir()` correctly returns `/tmp/...`, `configDir()` correctly returns `/tmp/.../.gbrain` — and the old test fails even though the implementation is right.

## What changes
- Add `homedir` import from `os`.
- Replace the two-line sentinel (`endsWith('.gbrain')` + `not startsWith('/tmp/')`) with one assertion: `expect(configDir()).toBe(join(homedir(), '.gbrain'))`.

This is exactly what the contract says: when `GBRAIN_HOME` is unset, `configDir()` falls back to `homedir() + '.gbrain'`. The new assertion is hermetic regardless of what HOME is — it asserts the equality, not a path-shape sentinel.

## Test plan
- [x] `bun test test/gbrain-home-isolation.test.ts` under `HOME=/tmp/gbrain-test-home.XXXXXX` (the wrapper case that previously failed) — now passes
- [x] `bun test test/gbrain-home-isolation.test.ts` under real HOME — still passes (5 tests, 14 expect calls)
- [x] No other test files reference this assertion shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->