### PR TITLE
fix(markdown): NESTED_QUOTES skips flow-sequence arrays of quoted strings (closes #529)

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -219,11 +219,20 @@ function collectValidationErrors(
   // 5. NESTED_QUOTES — common breakage pattern: `title: "Name "Nick" Last"`.
   //    Detect any frontmatter `key: ...` line whose value contains 3 or more
   //    unescaped double-quote characters. A clean quoted value has 2.
+  //
+  //    Skip flow-sequence arrays of quoted strings (`key: ["A", "B", ...]`)
+  //    and quoted-wikilink arrays (`key: ["[[A]]", "[[B]]"]`) — these are
+  //    legitimate YAML and parse correctly. The genuine "nested quote"
+  //    pattern is a SINGLE value containing inner unescaped quotes, not a
+  //    flow-array of independently-quoted items. Closes #529.
   for (let i = firstNonEmpty + 1; i < closeLine; i++) {
     const line = lines[i];
     const m = line.match(/^\s*[A-Za-z_][\w-]*\s*:\s*(.*)$/);
     if (!m) continue;
-    const value = m[1];
+    const value = m[1].trim();
+    // Skip flow-sequence arrays: `[...]`. Items inside are independently
+    // quoted; per-line quote-counting is the wrong primitive for flow-arrays.
+    if (value.startsWith('[') && value.endsWith(']')) continue;
     let count = 0;
     for (let j = 0; j < value.length; j++) {
       if (value[j] === '"' && (j === 0 || value[j - 1] !== '\\')) count++;

--- a/test/markdown-validation.test.ts
+++ b/test/markdown-validation.test.ts
@@ -133,6 +133,28 @@ describe('parseMarkdown validation surface', () => {
       const parsed = parseMarkdown(md, undefined, { validate: true });
       expect(parsed.errors!.map(e => e.code)).not.toContain('NESTED_QUOTES');
     });
+
+    // Regression for #529: flow-sequence arrays of quoted strings are
+    // legitimate YAML and must not trigger NESTED_QUOTES even though the
+    // line contains 3+ unescaped double quotes.
+    test('flow-array of quoted IDs does not trigger (#529)', () => {
+      const md = `${fence}\ntype: law\nrelated: ["LAW-001", "LAW-009", "LAW-013"]\n${fence}\n\nbody`;
+      const parsed = parseMarkdown(md, undefined, { validate: true });
+      expect(parsed.errors!.map(e => e.code)).not.toContain('NESTED_QUOTES');
+    });
+
+    test('flow-array of quoted wikilinks does not trigger (#529)', () => {
+      const md = `${fence}\ntype: spec\nrelated: ["[[skill-a]]", "[[skill-b]]", "[[skill-c]]"]\n${fence}\n\nbody`;
+      const parsed = parseMarkdown(md, undefined, { validate: true });
+      expect(parsed.errors!.map(e => e.code)).not.toContain('NESTED_QUOTES');
+    });
+
+    test('inline-style genuine nested-quote on single value still triggers', () => {
+      // Single value (NOT a flow-array) with inner unescaped quote — real bug.
+      const md = `${fence}\ntype: concept\ntitle: "He said "hello" loudly"\n${fence}\n\nbody`;
+      const parsed = parseMarkdown(md, undefined, { validate: true });
+      expect(parsed.errors!.map(e => e.code)).toContain('NESTED_QUOTES');
+    });
   });
 
   describe('EMPTY_FRONTMATTER', () => {


### PR DESCRIPTION
## Summary

Closes #529.

The `NESTED_QUOTES` lint check counts unescaped double-quotes per line. This produces false-positives on legitimate YAML flow-sequence arrays of quoted strings:

```yaml
related: ["LAW-001", "LAW-009", "LAW-013"]
```

This line has 6 unescaped double quotes, but each is part of an independently-quoted item — the YAML is valid and parses correctly. The check fired anyway because per-line quote-counting is the wrong primitive for flow-arrays.

## Fix

Skip lines where the value starts with `[` and ends with `]`. Genuine nested-quote pattern is a SINGLE value containing inner unescaped quotes (`title: "He said "hello" loudly"`), which is what the check was originally designed for.

## Tests

Added 3 regression tests in `test/markdown-validation.test.ts`:

1. Flow-array of quoted IDs (`["LAW-001", "LAW-009"]`) — must NOT trigger
2. Flow-array of quoted wikilinks (`["[[skill-a]]", "[[skill-b]]"]`) — must NOT trigger
3. Inline genuine nested-quote on single value (`title: "a "b" c"`) — must STILL trigger (no false-negative)

`bun test test/markdown-validation.test.ts` → **22/22 pass**.

## Impact

On the Nous AGaaS production wiki (2533 pages, gbrain v0.22.16):
- 14+ legitimate vault files were tripping NESTED_QUOTES with `related: ["[[X]]"]` syntax
- Brain owners couldn't reach `Health 100/100` without rewriting valid YAML

After this fix: 0 NESTED_QUOTES findings on the same brain.

## Related

- Issue #529 (this PR closes)
- Issue #530 — separate FP on `graph_coverage` for markdown-only brains, separate PR coming.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->