### PR TITLE
fix(doctor): skip graph_coverage when brain has 0 entity pages (closes #530)

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -517,18 +517,35 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
 
   // 8. Graph health (link + timeline coverage on entity pages).
   // dead_links removed in v0.10.1: ON DELETE CASCADE on link FKs makes it always 0.
+  //
+  // Skip when the brain has 0 entity pages (markdown-only wikis, journals,
+  // notes brains). The coverage formula divides by entity-page count, so it's
+  // structurally undefined when no entities exist — emitting WARN under that
+  // condition is a false positive. Closes #530.
   progress.heartbeat('graph_coverage');
   try {
     const health = await engine.getHealth();
+    const entityCount = (await engine.executeRaw<{ count: number }>(
+      "SELECT COUNT(*)::int AS count FROM pages WHERE type IN ('entity', 'person', 'company', 'organization')",
+    ))[0]?.count ?? 0;
+
     const linkPct = ((health.link_coverage ?? 0) * 100).toFixed(0);
     const timelinePct = ((health.timeline_coverage ?? 0) * 100).toFixed(0);
-    if ((health.link_coverage ?? 0) >= 0.5 && (health.timeline_coverage ?? 0) >= 0.5) {
+    if (entityCount === 0) {
+      // Markdown-only / journal / wiki brain — no entity pages to compute
+      // coverage against. Coverage formula is structurally inapplicable.
+      checks.push({
+        name: 'graph_coverage',
+        status: 'ok',
+        message: 'No entity pages — graph_coverage not applicable (markdown-only brain)',
+      });
+    } else if ((health.link_coverage ?? 0) >= 0.5 && (health.timeline_coverage ?? 0) >= 0.5) {
       checks.push({ name: 'graph_coverage', status: 'ok', message: `Entity link coverage ${linkPct}%, timeline ${timelinePct}%` });
     } else {
       checks.push({
         name: 'graph_coverage',
         status: 'warn',
-        message: `Entity link coverage ${linkPct}%, timeline ${timelinePct}%. Run: gbrain link-extract && gbrain timeline-extract`,
+        message: `Entity link coverage ${linkPct}%, timeline ${timelinePct}% (${entityCount} entity pages). Run: gbrain extract all`,
       });
     }
 


### PR DESCRIPTION
## Summary

Closes #530.

`gbrain doctor`'s `graph_coverage` check measures `link_coverage` (fraction of entity pages with inbound links) and `timeline_coverage` (fraction with timeline entries). Both formulas divide by entity-page count.

For **markdown-only brains** (journals, wikis, notes — Karpathy's original LLM Wiki use case) entity count is 0, so coverage is structurally undefined. The check still reported `warn: 0%` under that condition, blocking `Health 100/100`.

## Fix

Detect entity-page count via SQL. If 0, mark check `ok` with explanation. Otherwise keep existing logic but update hint to current `gbrain extract all` (the `link-extract` / `timeline-extract` commands referenced in the old hint were renamed to `extract` in v0.22).

```typescript
const entityCount = (await engine.executeRaw<{ count: number }>(
  "SELECT COUNT(*)::int AS count FROM pages WHERE type IN ('entity', 'person', 'company', 'organization')",
))[0]?.count ?? 0;

if (entityCount === 0) {
  checks.push({
    name: 'graph_coverage',
    status: 'ok',
    message: 'No entity pages — graph_coverage not applicable (markdown-only brain)',
  });
}
```

## Tested on real production brain

Nous AGaaS wiki:
- 2533 markdown pages
- 100% embedded
- 6086 wikilinks (real, populated)
- 1964 timeline entries (real, populated)
- 0 entity pages
- 0 code chunks

Before this PR: `[WARN] graph_coverage: Entity link coverage 0%, timeline 0%. Run: gbrain link-extract && gbrain timeline-extract` (stale commands, FP for our brain shape).

After this PR: `[OK] graph_coverage: No entity pages — not applicable`.

Doctor health correctly recognizes the brain as healthy.

## Related

- Issue #530 (this PR closes)
- PR #535 (separate fix for #529 NESTED_QUOTES FP)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->