### PR TITLE
fix(skills): ingest + enrich delegate notability gate to brain-filing-rules

### DIFF
--- a/skills/enrich/SKILL.md
+++ b/skills/enrich/SKILL.md
@@ -95,7 +95,7 @@ Extract people, companies, concepts from the incoming signal.
 For each entity:
 - `gbrain search "name"` -- does a page already exist?
 - **If yes:** UPDATE path (add new signal, update compiled truth if material)
-- **If no:** CREATE path (check notability gate first, then create)
+- **If no:** CREATE path (check notability gate, see `skills/_brain-filing-rules.md`, then create)
 
 ### Step 3: Extract signal from source
 

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -61,7 +61,7 @@ Every fact written to a brain page must carry an inline `[Source: ...]` citation
 2. **For each entity mentioned:**
    - Read the entity's page from gbrain to check if it exists
    - If exists: update compiled_truth (rewrite State section with new info, don't append)
-   - If new: check notability gate, then store the page in gbrain with the appropriate type and slug
+   - If new: check notability gate (see `skills/_brain-filing-rules.md`), then store the page in gbrain with the appropriate type and slug
 3. **Append to timeline.** Add a timeline entry in gbrain for each event, with date, summary, and source citation.
 4. **Create cross-reference links.** Link entities in gbrain for every entity pair mentioned together, using the appropriate relationship type.
 5. **Back-link all entities.** Update EVERY mentioned entity's page with a back-link to this page (Iron Law).


### PR DESCRIPTION
## Summary

Closes the two remaining `dry_violation` warnings under `gbrain check-resolvable`:

```
• dry_violation      ingest                   Replace inlined rules with a reference to one of: conventions/quality.md, _brain-filing-rules.md
• dry_violation      enrich                   Replace inlined rules with a reference to one of: conventions/quality.md, _brain-filing-rules.md
```

## Root cause

`extractDelegationTargets` only recognizes backtick-wrapped paths (`\`skills/conventions/X.md\`` or `\`skills/_brain-filing-rules.md\``) within `DRY_PROXIMITY_LINES` (40 lines) of each `/notability.*gate/i` match. Both skills mentioned 'notability gate' in prose at lines that lacked a same-line backtick reference, even though the file as a whole had references elsewhere.

## Fix

Two surgical 1-line rewrites to inline the backtick ref on the same line as the violating mention:

- `skills/ingest/SKILL.md:64` — added `(see \`skills/_brain-filing-rules.md\`)` after 'check notability gate'.
- `skills/enrich/SKILL.md:98` — added `, see \`skills/_brain-filing-rules.md\`,` after 'check notability gate'.

## Verification

```bash
$ gbrain check-resolvable
Auto-detected skills directory from repo root skills/: /private/tmp/gbrain-fix/skills
resolver_health: OK — 30 skills, all reachable
```

Was 2 warnings; now clean.

## Related

- Companion to PR #535 (NESTED_QUOTES detector FP) and PR #536 (graph_coverage on markdown brains).
- Closes the last 2 advisory dry_violation warnings on a Tan-default `skills/` tree.
- Tested against gbrain v0.22.16 master + cherry-picks of #535/#536 on Nous AGaaS production wiki (2812 pages, 100% embedded).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->