### PR TITLE
fix(upgrade): detect README "Standalone CLI" installs as 'source'

### DIFF
--- a/src/commands/check-update.ts
+++ b/src/commands/check-update.ts
@@ -36,6 +36,7 @@ function upgradeCommandForMethod(method: string): string {
     case 'bun': return 'bun update gbrain';
     case 'clawhub': return 'clawhub update gbrain';
     case 'binary': return 'Download from https://github.com/garrytan/gbrain/releases';
+    case 'source': return 'gbrain upgrade';
     default: return 'gbrain upgrade';
   }
 }

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,11 +1,11 @@
 import { execSync } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync } from 'fs';
-import { join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { VERSION } from '../version.ts';
 
 export async function runUpgrade(args: string[]) {
   if (args.includes('--help') || args.includes('-h')) {
-    console.log('Usage: gbrain upgrade\n\nSelf-update the CLI.\n\nDetects install method (bun, binary, clawhub) and runs the appropriate update.\nAfter upgrading, shows what\'s new and offers to set up new features.');
+    console.log('Usage: gbrain upgrade\n\nSelf-update the CLI.\n\nDetects install method (bun, binary, clawhub, source) and runs the appropriate update.\n"source" = the README\'s "Standalone CLI" install (git clone + bun link); upgrades via git pull --ff-only + bun install.\nAfter upgrading, shows what\'s new and offers to set up new features.');
     return;
   }
 
@@ -43,11 +43,30 @@ export async function runUpgrade(args: string[]) {
       }
       break;
 
+    case 'source': {
+      // README "Standalone CLI" install: git clone + bun install + bun link.
+      // Upgrade = fast-forward pull on the clone (bun-link symlink chain
+      // means PATH binary updates in place). Then re-run bun install in
+      // case package.json/bun.lock changed; cheap when nothing did.
+      const repoRoot = dirname(dirname(resolve(process.argv[1] || '')));
+      console.log(`Upgrading via git pull in ${repoRoot}...`);
+      try {
+        execSync(`git -C "${repoRoot}" pull --ff-only`, { stdio: 'inherit', timeout: 120_000 });
+        execSync('bun install --silent', { stdio: 'inherit', cwd: repoRoot, timeout: 120_000 });
+        upgraded = true;
+      } catch {
+        console.error('Upgrade failed. Try running manually:');
+        console.error(`  cd "${repoRoot}" && git pull --ff-only && bun install`);
+      }
+      break;
+    }
+
     default:
       console.error('Could not detect installation method.');
       console.log('Try one of:');
       console.log('  bun update gbrain');
       console.log('  clawhub update gbrain');
+      console.log('  cd <gbrain-clone> && git pull && bun install   # if installed via README "Standalone CLI" steps');
       console.log('  Download from https://github.com/garrytan/gbrain/releases');
   }
 
@@ -234,12 +253,32 @@ function isNewerThan(version: string, baseline: string): boolean {
   return false;
 }
 
-export function detectInstallMethod(): 'bun' | 'binary' | 'clawhub' | 'unknown' {
+export function detectInstallMethod(): 'bun' | 'binary' | 'clawhub' | 'source' | 'unknown' {
   const execPath = process.execPath || '';
+  const argv1 = process.argv[1] || '';
 
   // Check if running from node_modules (bun/npm install)
-  if (execPath.includes('node_modules') || process.argv[1]?.includes('node_modules')) {
+  if (execPath.includes('node_modules') || argv1.includes('node_modules')) {
     return 'bun';
+  }
+
+  // Check if running directly from a git clone — the README's "Standalone CLI"
+  // install path: `git clone … && cd gbrain && bun install && bun link`.
+  // Bun resolves the bun-link symlink chain to the clone's realpath, so a
+  // PATH-installed gbrain sees argv[1] = /Users/x/gbrain/src/cli.ts (no
+  // node_modules in it). Resolve to absolute first so this still fires when
+  // the script is invoked as `bun src/cli.ts` from a relative cwd.
+  // Distinguishes from a compiled binary (next case) by checking for the
+  // .ts entry path, and from arbitrary scripts by requiring a sibling .git.
+  if (argv1) {
+    const argv1Abs = resolve(argv1);
+    const isCliEntry = argv1Abs.endsWith('/src/cli.ts') || argv1Abs.endsWith('\\src\\cli.ts');
+    if (isCliEntry) {
+      const repoRoot = dirname(dirname(argv1Abs));
+      if (existsSync(join(repoRoot, '.git'))) {
+        return 'source';
+      }
+    }
   }
 
   // Check if running as compiled binary

--- a/test/upgrade.test.ts
+++ b/test/upgrade.test.ts
@@ -38,16 +38,48 @@ describe('detectInstallMethod heuristic (source analysis)', () => {
     'utf-8',
   );
 
-  test('checks node_modules before binary', () => {
+  test('checks node_modules before source', () => {
+    // Order matters: globally-installed copies live in node_modules and must
+    // be detected as 'bun' before the source-clone heuristic gets a shot.
     const nodeModulesIdx = source.indexOf('node_modules');
+    const sourceIdx = source.indexOf("return 'source'");
+    expect(nodeModulesIdx).toBeLessThan(sourceIdx);
+  });
+
+  test('checks source before binary', () => {
+    // A bun-linked clone has argv[1] ending in /src/cli.ts; a compiled binary
+    // has execPath ending in /gbrain. They are distinguishable, but ordering
+    // source first keeps the README "Standalone CLI" cohort on the fast path.
+    const sourceIdx = source.indexOf("return 'source'");
     const binaryIdx = source.indexOf("endsWith('/gbrain')");
-    expect(nodeModulesIdx).toBeLessThan(binaryIdx);
+    expect(sourceIdx).toBeLessThan(binaryIdx);
   });
 
   test('checks binary before clawhub', () => {
     const binaryIdx = source.indexOf("endsWith('/gbrain')");
     const clawhubIdx = source.indexOf("clawhub --version");
     expect(binaryIdx).toBeLessThan(clawhubIdx);
+  });
+
+  test('source detection requires both /src/cli.ts entry path and a .git sibling', () => {
+    // Defends against false positives — global installs have argv[1] in
+    // node_modules (caught earlier), and ad-hoc bun scripts that happen to
+    // be named src/cli.ts shouldn't be misdetected without a .git sibling.
+    expect(source).toContain(".endsWith('/src/cli.ts')");
+    expect(source).toMatch(/existsSync\(join\(repoRoot, '\.git'\)\)/);
+  });
+
+  test('source detection resolves argv[1] to absolute path', () => {
+    // Without resolve(), invoking `bun src/cli.ts` from inside the clone
+    // leaves argv[1] = "src/cli.ts" (relative) and endsWith('/src/cli.ts')
+    // returns false. resolve() makes detection robust to cwd.
+    expect(source).toContain("resolve(argv1)");
+  });
+
+  test('source upgrade runs git pull --ff-only and bun install', () => {
+    expect(source).toContain('git -C');
+    expect(source).toContain('--ff-only');
+    expect(source).toContain('bun install');
   });
 
   test('uses clawhub --version, not which clawhub', () => {
@@ -61,8 +93,8 @@ describe('detectInstallMethod heuristic (source analysis)', () => {
     expect(timeoutMatches.length).toBeGreaterThanOrEqual(2); // bun + clawhub detection at minimum
   });
 
-  test('return type is bun | binary | clawhub | unknown', () => {
-    expect(source).toContain("'bun' | 'binary' | 'clawhub' | 'unknown'");
+  test('return type is bun | binary | clawhub | source | unknown', () => {
+    expect(source).toContain("'bun' | 'binary' | 'clawhub' | 'source' | 'unknown'");
   });
 
   test('does not reference npm in case labels or messages', () => {


### PR DESCRIPTION
## Problem

The README's recommended standalone install path —

```bash
git clone https://github.com/garrytan/gbrain.git && cd gbrain && bun install && bun link
```

— is unsupported by `gbrain upgrade`. `detectInstallMethod()` returns `'unknown'` for this cohort, so the upgrade command prints:

```
Detected install method: unknown
Could not detect installation method.
Try one of:
  bun update gbrain
  clawhub update gbrain
  Download from https://github.com/garrytan/gbrain/releases
```

All three fallbacks are dead ends:

1. **`bun update gbrain`** — there's an unrelated npm package called `gbrain` (a GPU JS ML library, currently at v1.3.1). Running this installs the wrong package into `node_modules/gbrain` and silently does nothing useful for the bun-link install.
2. **`clawhub update gbrain`** — `clawhub` is an external tool many users won't have.
3. **Download from GitHub Releases** — there are no releases on `garrytan/gbrain` (`/releases/latest` returns 404).

So the README's blessed "Standalone CLI" install has no working self-upgrade path. Users have to know to `cd ~/gbrain && git pull && bun install` manually.

## Fix

Add a fourth case, `'source'`, to `detectInstallMethod()`:

- Triggers when `path.resolve(argv[1])` ends in `/src/cli.ts` AND the parent's parent contains a `.git` directory.
- Ordered AFTER the node_modules check so `bun add -g gbrain` global installs are still caught as `'bun'`.
- Ordered BEFORE the binary check so the README "Standalone CLI" cohort takes the fast path (binary check is on `execPath`, source check is on `argv[1]`, so they're disjoint anyway — but ordering by frequency feels right).

The `case 'source'` upgrade body runs:

```bash
git -C <repoRoot> pull --ff-only
bun install --silent
```

Bun-link's symlink chain (`~/.bun/bin/gbrain → ~/gbrain/src/cli.ts`) means the on-PATH binary updates in place after `git pull`. The `bun install` covers the case where the pull added a dependency; cheap no-op when nothing changed.

Also threads `'source'` through `check-update.ts`'s `upgradeCommandForMethod` so `gbrain check-update` recommends `gbrain upgrade` for clone installs (which now actually works).

## Why `path.resolve(argv[1])`

Without it, `bun src/cli.ts` (run from the clone's cwd) leaves `argv[1] = "src/cli.ts"` (relative) and `endsWith('/src/cli.ts')` returns false. PATH-installed bun-link sees an absolute path because bun resolves the symlink chain to the real path, but defending against the cwd-relative case is one line.

## Tests

`test/upgrade.test.ts` extended with 5 new source-method assertions:

- `checks node_modules before source` — order assertion (false-positive defense)
- `checks source before binary` — order assertion
- `source detection requires both /src/cli.ts entry path and a .git sibling` — dual-condition defense
- `source detection resolves argv[1] to absolute path` — robust to relative cwd
- `source upgrade runs git pull --ff-only and bun install` — upgrade body shape
- Updated the type-signature assertion to `'bun' | 'binary' | 'clawhub' | 'source' | 'unknown'`

All 13 tests pass:

```
$ bun test test/upgrade.test.ts
 13 pass
 0 fail
 23 expect() calls
```

Functional smoke test in a synthetic clone (mkdir + .git + src/cli.ts):

```
--- Absolute path ---
detected: source
--- Relative path (cd in) ---
detected: source
```

## Out of scope

- Doesn't change `gbrain check-update`'s GitHub Releases API call (which 404s for this repo). That's a separate cleanup.
- Doesn't add a binary self-update path (still "not yet implemented" — separate issue).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->