### PR TITLE
feat: quick OpenClaw Codex auth adapter for providers

### DIFF
--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -6,7 +6,7 @@
  */
 
 import { listRecipes, getRecipe } from '../core/ai/recipes/index.ts';
-import { configureGateway, embedOne, isAvailable as gwIsAvailable } from '../core/ai/gateway.ts';
+import { configureGateway, embedOne, isAvailable as gwIsAvailable, getCredentialSource } from '../core/ai/gateway.ts';
 import { probeOllama, probeLMStudio } from '../core/ai/probes.ts';
 import { loadConfig } from '../core/config.ts';
 import { AIConfigError, AITransientError } from '../core/ai/errors.ts';
@@ -40,8 +40,20 @@ function configureFromEnv(): void {
 
 function envReady(recipe: Recipe): boolean {
   const required = recipe.auth_env?.required ?? [];
+  if (recipe.id === 'openai') {
+    return !!process.env.OPENAI_API_KEY || process.env.GBRAIN_OPENCLAW_CODEX_AUTH === '1';
+  }
   if (required.length === 0) return true; // e.g. local Ollama
   return required.every(k => !!process.env[k]);
+}
+
+function providerStatus(recipe: Recipe): string {
+  if (!envReady(recipe)) return `✗ missing ${recipe.auth_env?.required?.[0] ?? 'setup'}`;
+  if (recipe.id === 'openai') {
+    if (process.env.OPENAI_API_KEY) return '✓ ready (env)';
+    if (process.env.GBRAIN_OPENCLAW_CODEX_AUTH === '1') return '✓ ready (OpenClaw auth opt-in)';
+  }
+  return '✓ ready';
 }
 
 export async function runProviders(subcommand: string | undefined, args: string[]): Promise<void> {
@@ -93,8 +105,7 @@ function runList(_args: string[]): void {
   for (const r of recipes) {
     const hasEmbed = !!r.touchpoints.embedding && (r.touchpoints.embedding.models.length > 0);
     const hasExpand = !!r.touchpoints.expansion;
-    const ready = envReady(r);
-    const status = ready ? '✓ ready' : `✗ missing ${r.auth_env?.required?.[0] ?? 'setup'}`;
+    const status = providerStatus(r);
     rows.push(
       r.id.padEnd(14) +
       r.tier.padEnd(18) +
@@ -134,6 +145,9 @@ async function runTest(args: string[]): Promise<void> {
     const v = await embedOne('gbrain smoke test');
     const ms = Date.now() - start;
     console.log(`  ✓ ${ms}ms, ${v.length} dims`);
+    const source = getCredentialSource('openai');
+    if (source?.kind === 'openclaw-codex-auth') console.log('  source: OpenClaw Codex auth');
+    else if (modelArg?.startsWith('openai:') || (!modelArg && process.env.OPENAI_API_KEY)) console.log('  source: env');
     console.log('\nAll probes green.');
   } catch (e) {
     const ms = Date.now() - start;
@@ -171,7 +185,9 @@ function runEnv(args: string[]): void {
     console.log('Required:');
     for (const k of required) {
       const set = !!process.env[k];
-      console.log(`  ${k.padEnd(32)} ${set ? '✓ set' : '✗ not set'}`);
+      const openclawSatisfied = recipe.id === 'openai' && k === 'OPENAI_API_KEY' && process.env.GBRAIN_OPENCLAW_CODEX_AUTH === '1';
+      const status = set ? '✓ set' : openclawSatisfied ? '✓ via OpenClaw opt-in' : '✗ not set';
+      console.log(`  ${k.padEnd(32)} ${status}`);
     }
   } else {
     console.log('Required: (none)');
@@ -185,6 +201,9 @@ function runEnv(args: string[]): void {
   }
   if (recipe.auth_env?.setup_url) {
     console.log(`\nSetup: ${recipe.auth_env.setup_url}`);
+  }
+  if (recipe.id === 'openai') {
+    console.log('\nOptional OpenClaw auth opt-in: set GBRAIN_OPENCLAW_CODEX_AUTH=1 and either GBRAIN_OPENCLAW_AUTH_PATH=/path/to/auth.json or GBRAIN_OPENCLAW_AUTH_DIR=/path/to/openclaw/auth.');
   }
   if (recipe.setup_hint) {
     console.log(`\n${recipe.setup_hint}`);

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -32,10 +32,12 @@ import type {
   AIGatewayConfig,
   Recipe,
   TouchpointKind,
+  CredentialSourceInfo,
 } from './types.ts';
 import { resolveRecipe, assertTouchpoint } from './model-resolver.ts';
 import { dimsProviderOptions } from './dims.ts';
 import { AIConfigError, AITransientError, normalizeAIError } from './errors.ts';
+import { resolveOpenClawCodexAuthToken } from './openclaw-auth.ts';
 
 const MAX_CHARS = 8000;
 const DEFAULT_EMBEDDING_MODEL = 'openai:text-embedding-3-large';
@@ -53,6 +55,7 @@ export function configureGateway(config: AIGatewayConfig): void {
     expansion_model: config.expansion_model ?? DEFAULT_EXPANSION_MODEL,
     base_urls: config.base_urls,
     env: config.env,
+    credential_sources: config.credential_sources ? { ...config.credential_sources } : undefined,
   };
   _modelCache.clear();
 }
@@ -86,6 +89,25 @@ export function getExpansionModel(): string {
   return requireConfig().expansion_model ?? DEFAULT_EXPANSION_MODEL;
 }
 
+export function getCredentialSource(providerId: string): CredentialSourceInfo | null {
+  const cfg = requireConfig();
+  return cfg.credential_sources?.[providerId] ?? null;
+}
+
+function resolveOpenAIApiKey(cfg: AIGatewayConfig): string | null {
+  const direct = cfg.env.OPENAI_API_KEY?.trim();
+  if (direct) return direct;
+  const resolved = resolveOpenClawCodexAuthToken(cfg.env);
+  if (resolved) {
+    cfg.credential_sources = {
+      ...(cfg.credential_sources ?? {}),
+      openai: { kind: 'openclaw-codex-auth', detail: resolved.profilePath },
+    };
+    return resolved.token;
+  }
+  return null;
+}
+
 /**
  * Check whether a touchpoint can be served given the current config.
  * Replaces scattered `!process.env.OPENAI_API_KEY` checks (Codex C3).
@@ -112,6 +134,7 @@ export function isAvailable(touchpoint: TouchpointKind): boolean {
 
     // For openai-compatible without auth requirements (Ollama local), treat as always-available.
     const required = recipe.auth_env?.required ?? [];
+    if (recipe.id === 'openai') return !!resolveOpenAIApiKey(_config!);
     if (required.length === 0) return true;
     return required.every(k => !!_config!.env[k]);
   } catch {
@@ -138,9 +161,9 @@ async function resolveEmbeddingProvider(modelStr: string): Promise<{ model: any;
 function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
   switch (recipe.implementation) {
     case 'native-openai': {
-      const apiKey = cfg.env.OPENAI_API_KEY;
+      const apiKey = resolveOpenAIApiKey(cfg);
       if (!apiKey) throw new AIConfigError(
-        `OpenAI embedding requires OPENAI_API_KEY.`,
+        `OpenAI embedding requires OPENAI_API_KEY or opt-in OpenClaw Codex auth.`,
         recipe.setup_hint,
       );
       const client = createOpenAI({ apiKey });
@@ -248,8 +271,8 @@ async function resolveExpansionProvider(modelStr: string): Promise<{ model: any;
 function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
   switch (recipe.implementation) {
     case 'native-openai': {
-      const apiKey = cfg.env.OPENAI_API_KEY;
-      if (!apiKey) throw new AIConfigError(`OpenAI expansion requires OPENAI_API_KEY.`, recipe.setup_hint);
+      const apiKey = resolveOpenAIApiKey(cfg);
+      if (!apiKey) throw new AIConfigError(`OpenAI expansion requires OPENAI_API_KEY or opt-in OpenClaw Codex auth.`, recipe.setup_hint);
       return createOpenAI({ apiKey }).languageModel(modelId);
     }
     case 'native-google': {

--- a/src/core/ai/openclaw-auth.ts
+++ b/src/core/ai/openclaw-auth.ts
@@ -1,0 +1,62 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export interface OpenClawAuthTokenResolution {
+  token: string;
+  source: 'openclaw-codex-auth';
+  profilePath: string;
+}
+
+function parseJsonFile(path: string): any | null {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function pickToken(value: any): string | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidates = [
+    value.access_token,
+    value.api_key,
+    value.token,
+    value.oauth?.access_token,
+    value.oauth?.token,
+    value.tokens?.access_token,
+    value.tokens?.api_key,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
+  }
+  return null;
+}
+
+function candidatePaths(baseDir: string): string[] {
+  return [
+    join(baseDir, 'auth.json'),
+    join(baseDir, 'codex-auth.json'),
+    join(baseDir, 'openai-auth.json'),
+    join(baseDir, 'profiles', 'codex.json'),
+    join(baseDir, 'profiles', 'openai.json'),
+    join(baseDir, 'auth', 'codex.json'),
+    join(baseDir, 'auth', 'openai.json'),
+  ];
+}
+
+export function resolveOpenClawCodexAuthToken(env: Record<string, string | undefined>): OpenClawAuthTokenResolution | null {
+  if (env.GBRAIN_OPENCLAW_CODEX_AUTH !== '1') return null;
+  const explicitPath = env.GBRAIN_OPENCLAW_AUTH_PATH?.trim();
+  const baseDir = env.GBRAIN_OPENCLAW_AUTH_DIR?.trim() || env.OPENCLAW_AUTH_DIR?.trim() || '';
+  const paths = [
+    ...(explicitPath ? [explicitPath] : []),
+    ...(baseDir ? candidatePaths(baseDir) : []),
+  ];
+  for (const path of paths) {
+    if (!path || !existsSync(path)) continue;
+    const parsed = parseJsonFile(path);
+    const token = pickToken(parsed);
+    if (token) return { token, source: 'openclaw-codex-auth', profilePath: path };
+  }
+  return null;
+}

--- a/src/core/ai/recipes/openai.ts
+++ b/src/core/ai/recipes/openai.ts
@@ -24,5 +24,5 @@ export const openai: Recipe = {
       price_last_verified: '2026-04-20',
     },
   },
-  setup_hint: 'Get an API key at https://platform.openai.com/api-keys, then `export OPENAI_API_KEY=...`',
+  setup_hint: 'Get an API key at https://platform.openai.com/api-keys, then `export OPENAI_API_KEY=...`, or opt in to local OpenClaw Codex auth with GBRAIN_OPENCLAW_CODEX_AUTH=1.',
 };

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -55,6 +55,11 @@ export interface Recipe {
   setup_hint?: string;
 }
 
+export interface CredentialSourceInfo {
+  kind: 'env' | 'openclaw-codex-auth';
+  detail?: string;
+}
+
 export interface AIGatewayConfig {
   /** Current embedding model as "provider:modelId" (e.g. "openai:text-embedding-3-large"). */
   embedding_model?: string;
@@ -66,6 +71,8 @@ export interface AIGatewayConfig {
   base_urls?: Record<string, string>;
   /** Env snapshot read once at configuration time. Gateway never reads process.env at call time. */
   env: Record<string, string | undefined>;
+  /** Optional non-secret credential-source hints keyed by provider id. */
+  credential_sources?: Partial<Record<string, CredentialSourceInfo>>;
 }
 
 export interface ParsedModelId {

--- a/test/ai/openclaw-auth.test.ts
+++ b/test/ai/openclaw-auth.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { resolveOpenClawCodexAuthToken } from '../../src/core/ai/openclaw-auth.ts';
+import { configureGateway, resetGateway, isAvailable, getCredentialSource } from '../../src/core/ai/gateway.ts';
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'gbrain-openclaw-auth-'));
+}
+
+describe('openclaw auth resolver', () => {
+  test('returns null unless opt-in env is enabled', () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, 'auth.json'), JSON.stringify({ access_token: 'sk-test' }));
+    expect(resolveOpenClawCodexAuthToken({ GBRAIN_OPENCLAW_AUTH_DIR: dir })).toBeNull();
+  });
+
+  test('resolves token from explicit auth path', () => {
+    const dir = makeTempDir();
+    const path = join(dir, 'codex.json');
+    writeFileSync(path, JSON.stringify({ oauth: { access_token: 'sk-codex' } }));
+    const resolved = resolveOpenClawCodexAuthToken({
+      GBRAIN_OPENCLAW_CODEX_AUTH: '1',
+      GBRAIN_OPENCLAW_AUTH_PATH: path,
+    });
+    expect(resolved?.token).toBe('sk-codex');
+    expect(resolved?.profilePath).toBe(path);
+  });
+
+  test('resolves token from auth dir candidate path', () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, 'profiles'), { recursive: true });
+    writeFileSync(join(dir, 'profiles', 'codex.json'), JSON.stringify({ tokens: { api_key: 'sk-dir' } }));
+    const resolved = resolveOpenClawCodexAuthToken({
+      GBRAIN_OPENCLAW_CODEX_AUTH: '1',
+      GBRAIN_OPENCLAW_AUTH_DIR: dir,
+    });
+    expect(resolved?.token).toBe('sk-dir');
+  });
+});
+
+describe('gateway OpenClaw OpenAI availability', () => {
+  test('openai embedding is available via opt-in OpenClaw auth without OPENAI_API_KEY', () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, 'auth.json'), JSON.stringify({ access_token: 'sk-from-openclaw' }));
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-large',
+      embedding_dimensions: 1536,
+      env: {
+        GBRAIN_OPENCLAW_CODEX_AUTH: '1',
+        GBRAIN_OPENCLAW_AUTH_DIR: dir,
+      },
+    });
+    expect(isAvailable('embedding')).toBe(true);
+    expect(getCredentialSource('openai')).toEqual({ kind: 'openclaw-codex-auth', detail: join(dir, 'auth.json') });
+    resetGateway();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a minimal, opt-in OpenClaw/Codex auth path for GBrain's OpenAI provider integration.

This is the small compatibility layer for OpenClaw deployments where Codex/OpenAI credentials are already managed by OpenClaw auth profile state instead of being duplicated into `OPENAI_API_KEY`.

Fixes #542.  
Part of #544.

## Motivation

OpenClaw customer VMs can already have Codex/OpenAI OAuth profile state available locally. GBrain's provider gateway currently treats OpenAI readiness as an API-key-only check. That blocks support KB rollout paths where GBrain should reuse the same runtime-managed auth substrate rather than asking users/operators to copy secrets into another environment variable.

This PR keeps the scope intentionally narrow: preserve current env behavior, add one explicit fallback path, and avoid changing the larger provider architecture.

## Behavior

Credential precedence for OpenAI provider calls becomes:

1. `OPENAI_API_KEY` when present.
2. Explicit OpenClaw/Codex auth opt-in when configured.
3. Missing auth error as before.

OpenClaw auth is not auto-discovered by default. The caller must opt in with the new configuration/env path.

## Changes

- Adds a small OpenClaw/Codex auth resolver for OpenAI provider use.
- Wires OpenAI embedding and expansion calls to use env credentials first, then the explicit OpenClaw auth fallback.
- Extends provider status/reporting so readiness can reflect OpenClaw-backed auth without printing token values.
- Updates OpenAI recipe/type metadata to describe the additional auth source.
- Adds focused tests for resolver behavior and gateway availability.

## Safety / privacy

- No raw token values are printed in provider output or errors.
- OpenClaw profile use is opt-in.
- Existing env/API-key behavior remains backward compatible and highest priority.
- The resolver checks only explicit configured paths / known profile state shapes, not arbitrary filesystem locations.

## Testing

- `bun test test/ai/openclaw-auth.test.ts test/ai/gateway.test.ts`
- `bun run typecheck`

## Notes for reviewers

This is intentionally the quick compatibility path. The more general provider-auth abstraction is tracked separately in #543 / #546 so this PR stays small and easy to review.
