### PR TITLE
feat: provider auth resolver seam

### DIFF
--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -5,12 +5,13 @@
  * users can verify provider setup before `gbrain init`.
  */
 
+import { resolveProviderAuth, redactAuthResolution } from '../core/ai/auth.ts';
 import { listRecipes, getRecipe } from '../core/ai/recipes/index.ts';
 import { configureGateway, embedOne, isAvailable as gwIsAvailable } from '../core/ai/gateway.ts';
 import { probeOllama, probeLMStudio } from '../core/ai/probes.ts';
 import { loadConfig } from '../core/config.ts';
 import { AIConfigError, AITransientError } from '../core/ai/errors.ts';
-import type { Recipe } from '../core/ai/types.ts';
+import type { AIGatewayConfig, AuthSourceClass, Recipe } from '../core/ai/types.ts';
 
 const SCHEMA_VERSION = 1;
 
@@ -22,26 +23,33 @@ interface ProviderOption {
   cost_per_1m_tokens_usd?: number;
   price_last_verified?: string;
   env_ready: boolean;
+  auth_source: AuthSourceClass;
   tier: 'native' | 'openai-compat';
   pros: string[];
   cons: string[];
 }
 
+let gatewayConfig: AIGatewayConfig;
+
 function configureFromEnv(): void {
   const config = loadConfig();
-  configureGateway({
+  gatewayConfig = {
     embedding_model: config?.embedding_model,
     embedding_dimensions: config?.embedding_dimensions,
     expansion_model: config?.expansion_model,
     base_urls: config?.provider_base_urls,
+    provider_auth: config?.provider_auth,
     env: { ...process.env },
-  });
+  };
+  configureGateway(gatewayConfig);
+}
+
+function authResolution(recipe: Recipe) {
+  return resolveProviderAuth(recipe, gatewayConfig);
 }
 
 function envReady(recipe: Recipe): boolean {
-  const required = recipe.auth_env?.required ?? [];
-  if (required.length === 0) return true; // e.g. local Ollama
-  return required.every(k => !!process.env[k]);
+  return authResolution(recipe).isConfigured;
 }
 
 export async function runProviders(subcommand: string | undefined, args: string[]): Promise<void> {
@@ -93,8 +101,11 @@ function runList(_args: string[]): void {
   for (const r of recipes) {
     const hasEmbed = !!r.touchpoints.embedding && (r.touchpoints.embedding.models.length > 0);
     const hasExpand = !!r.touchpoints.expansion;
-    const ready = envReady(r);
-    const status = ready ? '✓ ready' : `✗ missing ${r.auth_env?.required?.[0] ?? 'setup'}`;
+    const resolution = authResolution(r);
+    const ready = resolution.isConfigured;
+    const status = ready
+      ? `✓ ready (${resolution.source})`
+      : `✗ ${resolution.source === 'missing' ? resolution.missingReason ?? 'missing credentials' : resolution.source}`;
     rows.push(
       r.id.padEnd(14) +
       r.tier.padEnd(18) +
@@ -170,8 +181,9 @@ function runEnv(args: string[]): void {
   if (required.length > 0) {
     console.log('Required:');
     for (const k of required) {
-      const set = !!process.env[k];
-      console.log(`  ${k.padEnd(32)} ${set ? '✓ set' : '✗ not set'}`);
+      const resolution = authResolution(recipe);
+      const set = resolution.source === 'env' && resolution.credentialKey === k;
+      console.log(`  ${k.padEnd(32)} ${set ? '✓ selected' : process.env[k] ? '• available' : '✗ not set'}`);
     }
   } else {
     console.log('Required: (none)');
@@ -183,6 +195,10 @@ function runEnv(args: string[]): void {
       console.log(`  ${k.padEnd(32)} ${set ? '✓ set' : '✗ not set'}`);
     }
   }
+  const resolution = redactAuthResolution(authResolution(recipe));
+  console.log(`\nSelected auth source: ${String(resolution.source)}`);
+  if (resolution.credentialKey) console.log(`Credential key: ${String(resolution.credentialKey)}`);
+  if (resolution.missingReason) console.log(`Status: ${String(resolution.missingReason)}`);
   if (recipe.auth_env?.setup_url) {
     console.log(`\nSetup: ${recipe.auth_env.setup_url}`);
   }
@@ -217,6 +233,7 @@ async function runExplain(args: string[]): Promise<void> {
         cost_per_1m_tokens_usd: m.cost_per_1m_tokens_usd,
         price_last_verified: m.price_last_verified,
         env_ready: envReady(r) || (r.id === 'ollama' && ollama.models_endpoint_valid === true),
+        auth_source: authResolution(r).source,
         tier: r.tier,
         pros: prosFor(r, 'embedding'),
         cons: consFor(r),
@@ -231,6 +248,7 @@ async function runExplain(args: string[]): Promise<void> {
         cost_per_1m_tokens_usd: m.cost_per_1m_tokens_usd,
         price_last_verified: m.price_last_verified,
         env_ready: envReady(r),
+        auth_source: authResolution(r).source,
         tier: r.tier,
         pros: prosFor(r, 'expansion'),
         cons: consFor(r),
@@ -269,13 +287,13 @@ async function runExplain(args: string[]): Promise<void> {
   for (const o of options.filter(x => x.touchpoint === 'embedding')) {
     const cost = o.cost_per_1m_tokens_usd !== undefined ? `$${o.cost_per_1m_tokens_usd}/1M` : '—';
     const dims = o.dims ? `${o.dims}d` : '—';
-    console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${dims.padEnd(8)} ${cost.padEnd(10)} ${o.tier}`);
+    console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${dims.padEnd(8)} ${cost.padEnd(10)} ${o.tier} ${o.auth_source}`);
   }
   console.log('');
   console.log('Expansion options:');
   for (const o of options.filter(x => x.touchpoint === 'expansion')) {
     const cost = o.cost_per_1m_tokens_usd !== undefined ? `$${o.cost_per_1m_tokens_usd}/1M` : '—';
-    console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${cost.padEnd(10)} ${o.tier}`);
+    console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${cost.padEnd(10)} ${o.tier} ${o.auth_source}`);
   }
   console.log('');
   console.log(`Recommended: ${matrix.recommended}`);

--- a/src/core/ai/auth.ts
+++ b/src/core/ai/auth.ts
@@ -1,0 +1,155 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+import type { AIGatewayConfig, AuthResolution, ProviderAuthConfig, Recipe } from './types.ts';
+
+const OPENCLAW_CODEX_PROFILE = 'openclaw-codex';
+const OPENCLAW_OPENAI_PROFILE = 'openclaw-openai';
+
+const PROFILE_ENV_HINTS: Record<string, string[]> = {
+  [OPENCLAW_CODEX_PROFILE]: ['OPENCLAW_CODEX_TOKEN', 'CODEX_API_KEY', 'OPENAI_API_KEY'],
+  [OPENCLAW_OPENAI_PROFILE]: ['OPENAI_API_KEY'],
+};
+
+export function getProviderAuthConfig(config: AIGatewayConfig | undefined, recipe: Recipe): ProviderAuthConfig {
+  return config?.provider_auth?.[recipe.id] ?? {};
+}
+
+export function resolveProviderAuth(recipe: Recipe, config: AIGatewayConfig): AuthResolution {
+  const providerConfig = getProviderAuthConfig(config, recipe);
+  const envResolution = resolveEnvAuth(recipe, config.env);
+  if (envResolution) return envResolution;
+
+  if (providerConfig.prefer === 'openclaw-codex' || providerConfig.prefer === 'openclaw-openai') {
+    return resolveOpenClawProfileAuth(recipe, config, providerConfig);
+  }
+
+  return missingResolution(recipe, providerConfig);
+}
+
+export function redactAuthResolution(resolution: AuthResolution): Record<string, unknown> {
+  const meta = resolution.meta ?? {};
+  return {
+    source: resolution.source,
+    credentialKey: resolution.credentialKey,
+    isConfigured: resolution.isConfigured,
+    missingReason: resolution.missingReason,
+    meta,
+  };
+}
+
+export function getCredentialValue(resolution: AuthResolution): string | undefined {
+  return resolution.value;
+}
+
+function resolveEnvAuth(recipe: Recipe, env: Record<string, string | undefined>): AuthResolution | null {
+  const required = recipe.auth_env?.required ?? [];
+  if (required.length === 0) {
+    return {
+      source: 'unauthenticated',
+      isConfigured: true,
+      meta: { mode: 'unauthenticated' },
+    };
+  }
+
+  for (const key of required) {
+    const value = env[key];
+    if (value) {
+      return {
+        source: 'env',
+        credentialKey: key,
+        value,
+        isConfigured: true,
+        meta: { mode: 'env' },
+      };
+    }
+  }
+
+  return null;
+}
+
+function resolveOpenClawProfileAuth(recipe: Recipe, config: AIGatewayConfig, providerConfig: ProviderAuthConfig): AuthResolution {
+  const profile = providerConfig.profile ?? defaultProfileForRecipe(recipe);
+  const path = providerConfig.openclawAuthPath ?? defaultOpenClawAuthPath();
+  const raw = readOpenClawAuthRecord(path, profile);
+  if (!raw) {
+    return missingResolution(recipe, providerConfig, `OpenClaw profile \"${profile}\" not found at ${path}`);
+  }
+
+  const envHints = PROFILE_ENV_HINTS[profile] ?? recipe.auth_env?.required ?? [];
+  const found = envHints.find(key => typeof raw[key] === 'string' && raw[key]);
+  if (!found) {
+    return missingResolution(recipe, providerConfig, `OpenClaw profile \"${profile}\" missing expected token field`);
+  }
+
+  return {
+    source: providerConfig.prefer ?? 'openclaw-codex',
+    credentialKey: found,
+    value: String(raw[found]),
+    isConfigured: true,
+    meta: {
+      mode: 'openclaw-profile',
+      profile,
+      path,
+    },
+  };
+}
+
+function missingResolution(recipe: Recipe, providerConfig: ProviderAuthConfig, reason?: string): AuthResolution {
+  const expected = providerConfig.prefer === 'openclaw-codex' || providerConfig.prefer === 'openclaw-openai'
+    ? providerConfig.profile ?? defaultProfileForRecipe(recipe)
+    : recipe.auth_env?.required?.[0];
+
+  return {
+    source: 'missing',
+    credentialKey: expected,
+    isConfigured: false,
+    missingReason: reason ?? defaultMissingReason(recipe, providerConfig),
+    meta: {
+      mode: providerConfig.prefer ?? 'env',
+    },
+  };
+}
+
+function defaultMissingReason(recipe: Recipe, providerConfig: ProviderAuthConfig): string {
+  if (providerConfig.prefer === 'openclaw-codex' || providerConfig.prefer === 'openclaw-openai') {
+    return `OpenClaw profile \"${providerConfig.profile ?? defaultProfileForRecipe(recipe)}\" is not configured.`;
+  }
+  const required = recipe.auth_env?.required ?? [];
+  if (required.length === 0) return 'No credentials required.';
+  return `Missing ${required.join(', ')}.`;
+}
+
+function defaultProfileForRecipe(recipe: Recipe): string {
+  return recipe.id === 'openai' ? OPENCLAW_CODEX_PROFILE : OPENCLAW_OPENAI_PROFILE;
+}
+
+function defaultOpenClawAuthPath(): string {
+  return join(homedir(), '.openclaw', 'auth.json');
+}
+
+function readOpenClawAuthRecord(path: string, profile: string): Record<string, unknown> | null {
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    return findProfileRecord(raw, profile);
+  } catch {
+    return null;
+  }
+}
+
+function findProfileRecord(raw: unknown, profile: string): Record<string, unknown> | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+
+  const direct = obj[profile];
+  if (direct && typeof direct === 'object') return direct as Record<string, unknown>;
+
+  const profiles = obj.profiles;
+  if (profiles && typeof profiles === 'object') {
+    const nested = (profiles as Record<string, unknown>)[profile];
+    if (nested && typeof nested === 'object') return nested as Record<string, unknown>;
+  }
+
+  return null;
+}

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -30,9 +30,11 @@ import { z } from 'zod';
 
 import type {
   AIGatewayConfig,
+  AuthResolution,
   Recipe,
   TouchpointKind,
 } from './types.ts';
+import { resolveProviderAuth } from './auth.ts';
 import { resolveRecipe, assertTouchpoint } from './model-resolver.ts';
 import { dimsProviderOptions } from './dims.ts';
 import { AIConfigError, AITransientError, normalizeAIError } from './errors.ts';
@@ -52,6 +54,7 @@ export function configureGateway(config: AIGatewayConfig): void {
     embedding_dimensions: config.embedding_dimensions ?? DEFAULT_EMBEDDING_DIMENSIONS,
     expansion_model: config.expansion_model ?? DEFAULT_EXPANSION_MODEL,
     base_urls: config.base_urls,
+    provider_auth: config.provider_auth,
     env: config.env,
   };
   _modelCache.clear();
@@ -111,9 +114,8 @@ export function isAvailable(touchpoint: TouchpointKind): boolean {
     if (Array.isArray(touchpointConfig.models) && touchpointConfig.models.length === 0 && recipe.id === 'litellm') return false;
 
     // For openai-compatible without auth requirements (Ollama local), treat as always-available.
-    const required = recipe.auth_env?.required ?? [];
-    if (required.length === 0) return true;
-    return required.every(k => !!_config!.env[k]);
+    const resolution = resolveProviderAuth(recipe, _config!);
+    return resolution.isConfigured;
   } catch {
     return false;
   }
@@ -135,14 +137,21 @@ async function resolveEmbeddingProvider(modelStr: string): Promise<{ model: any;
   return { model, recipe, modelId: parsed.modelId };
 }
 
+function requireAuth(resolution: AuthResolution, recipe: Recipe, action: string): string {
+  if (!resolution.isConfigured || !resolution.value) {
+    throw new AIConfigError(
+      `${recipe.name} ${action} requires ${resolution.credentialKey ?? 'credentials'}.`,
+      recipe.setup_hint,
+    );
+  }
+  return resolution.value;
+}
+
 function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
+  const auth = resolveProviderAuth(recipe, cfg);
   switch (recipe.implementation) {
     case 'native-openai': {
-      const apiKey = cfg.env.OPENAI_API_KEY;
-      if (!apiKey) throw new AIConfigError(
-        `OpenAI embedding requires OPENAI_API_KEY.`,
-        recipe.setup_hint,
-      );
+      const apiKey = requireAuth(auth, recipe, 'embedding');
       const client = createOpenAI({ apiKey });
       // AI SDK v6: use .textEmbeddingModel() for embeddings
       return (client as any).textEmbeddingModel
@@ -150,11 +159,7 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
         : (client as any).embedding(modelId);
     }
     case 'native-google': {
-      const apiKey = cfg.env.GOOGLE_GENERATIVE_AI_API_KEY;
-      if (!apiKey) throw new AIConfigError(
-        `Google embedding requires GOOGLE_GENERATIVE_AI_API_KEY.`,
-        recipe.setup_hint,
-      );
+      const apiKey = requireAuth(auth, recipe, 'embedding');
       const client = createGoogleGenerativeAI({ apiKey });
       return (client as any).textEmbeddingModel
         ? (client as any).textEmbeddingModel(modelId)
@@ -171,15 +176,9 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
         recipe.setup_hint,
       );
       // For openai-compatible, auth is optional (ollama local) but pass a dummy key if unauthenticated.
-      const apiKey = recipe.auth_env?.required[0]
-        ? cfg.env[recipe.auth_env.required[0]]
-        : (cfg.env[`${recipe.id.toUpperCase()}_API_KEY`] ?? 'unauthenticated');
-      if (recipe.auth_env?.required.length && !apiKey) {
-        throw new AIConfigError(
-          `${recipe.name} requires ${recipe.auth_env.required[0]}.`,
-          recipe.setup_hint,
-        );
-      }
+      const apiKey = auth.source === 'unauthenticated'
+        ? 'unauthenticated'
+        : requireAuth(auth, recipe, 'embedding');
       const client = createOpenAICompatible({
         name: recipe.id,
         baseURL: baseUrl,
@@ -246,28 +245,26 @@ async function resolveExpansionProvider(modelStr: string): Promise<{ model: any;
 }
 
 function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
+  const auth = resolveProviderAuth(recipe, cfg);
   switch (recipe.implementation) {
     case 'native-openai': {
-      const apiKey = cfg.env.OPENAI_API_KEY;
-      if (!apiKey) throw new AIConfigError(`OpenAI expansion requires OPENAI_API_KEY.`, recipe.setup_hint);
+      const apiKey = requireAuth(auth, recipe, 'expansion');
       return createOpenAI({ apiKey }).languageModel(modelId);
     }
     case 'native-google': {
-      const apiKey = cfg.env.GOOGLE_GENERATIVE_AI_API_KEY;
-      if (!apiKey) throw new AIConfigError(`Google expansion requires GOOGLE_GENERATIVE_AI_API_KEY.`, recipe.setup_hint);
+      const apiKey = requireAuth(auth, recipe, 'expansion');
       return createGoogleGenerativeAI({ apiKey }).languageModel(modelId);
     }
     case 'native-anthropic': {
-      const apiKey = cfg.env.ANTHROPIC_API_KEY;
-      if (!apiKey) throw new AIConfigError(`Anthropic expansion requires ANTHROPIC_API_KEY.`, recipe.setup_hint);
+      const apiKey = requireAuth(auth, recipe, 'expansion');
       return createAnthropic({ apiKey }).languageModel(modelId);
     }
     case 'openai-compatible': {
       const baseUrl = cfg.base_urls?.[recipe.id] ?? recipe.base_url_default;
       if (!baseUrl) throw new AIConfigError(`${recipe.name} requires a base URL.`, recipe.setup_hint);
-      const apiKey = recipe.auth_env?.required[0]
-        ? cfg.env[recipe.auth_env.required[0]]
-        : 'unauthenticated';
+      const apiKey = auth.source === 'unauthenticated'
+        ? 'unauthenticated'
+        : requireAuth(auth, recipe, 'expansion');
       return createOpenAICompatible({
         name: recipe.id,
         baseURL: baseUrl,

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -30,6 +30,12 @@ export interface ExpansionTouchpoint {
   price_last_verified?: string;
 }
 
+export interface AuthEnvConfig {
+  required: string[];
+  optional?: string[];
+  setup_url?: string;
+}
+
 export interface Recipe {
   /** Stable lowercase id used in `provider:model` strings. Unique across recipes. */
   id: string;
@@ -42,17 +48,33 @@ export interface Recipe {
   /** For openai-compatible tier: default base URL. May be overridden by env or wizard. */
   base_url_default?: string;
   /** Env var name(s) for auth; first is required, rest are optional. */
-  auth_env?: {
-    required: string[];
-    optional?: string[];
-    setup_url?: string;
-  };
+  auth_env?: AuthEnvConfig;
   touchpoints: {
     embedding?: EmbeddingTouchpoint;
     expansion?: ExpansionTouchpoint;
   };
   /** One-line description of setup (shown in wizard + env subcommand). */
   setup_hint?: string;
+}
+
+export type AuthSourceClass = 'env' | 'openclaw-codex' | 'openclaw-openai' | 'unauthenticated' | 'missing';
+
+export interface ProviderAuthConfig {
+  /** Default env auth remains highest-priority unless this explicitly selects another source. */
+  prefer?: Exclude<AuthSourceClass, 'env' | 'unauthenticated' | 'missing'>;
+  /** Optional profile name for OpenClaw-backed auth. */
+  profile?: string;
+  /** Optional auth store override for tests or nonstandard installs. */
+  openclawAuthPath?: string;
+}
+
+export interface AuthResolution {
+  source: AuthSourceClass;
+  credentialKey?: string;
+  value?: string;
+  isConfigured: boolean;
+  missingReason?: string;
+  meta?: Record<string, unknown>;
 }
 
 export interface AIGatewayConfig {
@@ -64,6 +86,8 @@ export interface AIGatewayConfig {
   expansion_model?: string;
   /** Optional per-provider base URL override (openai-compatible variants). */
   base_urls?: Record<string, string>;
+  /** Optional provider auth source overrides keyed by recipe id. */
+  provider_auth?: Record<string, ProviderAuthConfig>;
   /** Env snapshot read once at configuration time. Gateway never reads process.env at call time. */
   env: Record<string, string | undefined>;
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, chmodSync, existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import type { ProviderAuthConfig } from './ai/types.ts';
 import type { EngineConfig } from './types.ts';
 
 /**
@@ -35,6 +36,8 @@ export interface GBrainConfig {
   expansion_model?: string;
   /** Optional base URL overrides for openai-compatible providers (keyed by recipe id). */
   provider_base_urls?: Record<string, string>;
+  /** Optional provider auth overrides (e.g. explicit OpenClaw profile selection). */
+  provider_auth?: Record<string, ProviderAuthConfig>;
   /**
    * Optional storage backend config (S3/Supabase/local). Shape matches
    * `StorageConfig` in `./storage.ts`. Typed as `unknown` here to avoid
@@ -74,6 +77,17 @@ export function loadConfig(): GBrainConfig | null {
     ...(process.env.GBRAIN_EMBEDDING_DIMENSIONS ? { embedding_dimensions: parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS, 10) } : {}),
     ...(process.env.GBRAIN_EXPANSION_MODEL ? { expansion_model: process.env.GBRAIN_EXPANSION_MODEL } : {}),
   };
+  if (process.env.GBRAIN_OPENAI_AUTH_SOURCE === 'openclaw-codex' || process.env.GBRAIN_OPENAI_AUTH_SOURCE === 'openclaw-openai') {
+    merged.provider_auth = {
+      ...(merged.provider_auth ?? {}),
+      openai: {
+        ...(merged.provider_auth?.openai ?? {}),
+        prefer: process.env.GBRAIN_OPENAI_AUTH_SOURCE,
+        ...(process.env.GBRAIN_OPENAI_AUTH_PROFILE ? { profile: process.env.GBRAIN_OPENAI_AUTH_PROFILE } : {}),
+        ...(process.env.GBRAIN_OPENCLAW_AUTH_PATH ? { openclawAuthPath: process.env.GBRAIN_OPENCLAW_AUTH_PATH } : {}),
+      },
+    };
+  }
   return merged as GBrainConfig;
 }
 

--- a/test/ai/auth.test.ts
+++ b/test/ai/auth.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { redactAuthResolution, resolveProviderAuth } from '../../src/core/ai/auth.ts';
+import { configureGateway, isAvailable, resetGateway } from '../../src/core/ai/gateway.ts';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+import type { AIGatewayConfig } from '../../src/core/ai/types.ts';
+
+const openai = getRecipe('openai');
+if (!openai) throw new Error('openai recipe missing');
+
+describe('provider auth resolver', () => {
+  let tempDir: string;
+  let authPath: string;
+
+  beforeEach(() => {
+    resetGateway();
+    tempDir = mkdtempSync(join(tmpdir(), 'gbrain-auth-'));
+    mkdirSync(join(tempDir, '.openclaw'), { recursive: true });
+    authPath = join(tempDir, '.openclaw', 'auth.json');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('env fallback remains highest priority even when openclaw auth is configured', () => {
+    writeFileSync(authPath, JSON.stringify({ profiles: { 'openclaw-codex': { OPENAI_API_KEY: 'oc-secret' } } }));
+    const resolution = resolveProviderAuth(openai, config({
+      env: { OPENAI_API_KEY: 'env-secret' },
+      provider_auth: { openai: { prefer: 'openclaw-codex', openclawAuthPath: authPath } },
+    }));
+    expect(resolution.source).toBe('env');
+    expect(resolution.value).toBe('env-secret');
+  });
+
+  test('missing openclaw profile reports missing without secret leakage', () => {
+    const resolution = resolveProviderAuth(openai, config({
+      env: {},
+      provider_auth: { openai: { prefer: 'openclaw-codex', profile: 'missing', openclawAuthPath: authPath } },
+    }));
+    expect(resolution.source).toBe('missing');
+    expect(resolution.isConfigured).toBe(false);
+    expect(resolution.missingReason).toContain('missing');
+  });
+
+  test('selected openclaw profile provides credential source class', () => {
+    writeFileSync(authPath, JSON.stringify({ profiles: { 'openclaw-codex': { OPENAI_API_KEY: 'oc-secret' } } }));
+    const resolution = resolveProviderAuth(openai, config({
+      env: {},
+      provider_auth: { openai: { prefer: 'openclaw-codex', openclawAuthPath: authPath } },
+    }));
+    expect(resolution.source).toBe('openclaw-codex');
+    expect(resolution.credentialKey).toBe('OPENAI_API_KEY');
+    expect(resolution.value).toBe('oc-secret');
+  });
+
+  test('redaction omits token values', () => {
+    writeFileSync(authPath, JSON.stringify({ profiles: { 'openclaw-codex': { OPENAI_API_KEY: 'oc-secret' } } }));
+    const resolution = resolveProviderAuth(openai, config({
+      env: {},
+      provider_auth: { openai: { prefer: 'openclaw-codex', openclawAuthPath: authPath } },
+    }));
+    const redacted = redactAuthResolution(resolution);
+    expect(JSON.stringify(redacted)).not.toContain('oc-secret');
+    expect(redacted).toMatchObject({ source: 'openclaw-codex', credentialKey: 'OPENAI_API_KEY' });
+  });
+
+  test('gateway availability respects selected openclaw profile', () => {
+    writeFileSync(authPath, JSON.stringify({ profiles: { 'openclaw-codex': { OPENAI_API_KEY: 'oc-secret' } } }));
+    configureGateway(config({
+      embedding_model: 'openai:text-embedding-3-large',
+      provider_auth: { openai: { prefer: 'openclaw-codex', openclawAuthPath: authPath } },
+      env: {},
+    }));
+    expect(isAvailable('embedding')).toBe(true);
+  });
+
+  test('gateway availability is false when selected profile is missing', () => {
+    configureGateway(config({
+      embedding_model: 'openai:text-embedding-3-large',
+      provider_auth: { openai: { prefer: 'openclaw-codex', openclawAuthPath: authPath } },
+      env: {},
+    }));
+    expect(isAvailable('embedding')).toBe(false);
+  });
+
+});
+
+function config(overrides: Partial<AIGatewayConfig>): AIGatewayConfig {
+  return {
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    expansion_model: 'anthropic:claude-haiku-4-5-20251001',
+    env: {},
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

Introduces a durable provider-auth resolver seam for GBrain's AI gateway and provider status surfaces.

The goal is to move credential lookup out of scattered env reads and into a small abstraction that can support multiple credential sources safely: environment variables today, OpenClaw/Codex auth profiles for OpenAI, and future provider auth sources later.

Fixes #543.  
Part of #544.

## Motivation

GBrain provider support is expanding beyond simple API-key-only setups. OpenClaw deployments may already have OAuth-backed Codex/OpenAI credentials, while other environments will continue to use direct env vars.

Without a resolver seam, each provider call site and status surface has to know how to check credentials. That makes readiness reporting inconsistent and makes it harder to add new credential sources without spreading secret-handling logic across the codebase.

## Design

This PR adds a provider-auth resolver layer with these principles:

- Environment/API-key credentials remain the default and highest-priority source.
- OpenClaw-backed profile auth is explicit and opt-in.
- Gateway code asks the resolver for usable credentials instead of reading every source inline.
- Provider status reports credential source class, not secret contents.
- Missing auth remains a clear configuration error with setup guidance.

## Changes

- Adds `src/core/ai/auth.ts` for provider credential resolution.
- Extends AI gateway/config types for provider auth source metadata.
- Adds optional `provider_auth` config and environment wiring for OpenAI auth source selection.
- Updates gateway embedding/expansion auth lookup to use the resolver seam.
- Updates `gbrain providers` output to show safe credential source information.
- Adds focused auth tests covering env fallback, missing profile handling, profile selection, and redaction.

## Safety / privacy

- Credential source labels are reported; token values are not.
- Env credentials continue to win first, so existing deployments do not change behavior.
- OpenClaw auth profile support is opt-in rather than silently scanning local runtime state.
- The resolver is intentionally narrow at first: OpenAI/OpenClaw profile auth only, with the interface ready for future providers.

## Testing

- `bun test test/ai/auth.test.ts test/ai/gateway.test.ts test/config.test.ts`
- `bun run typecheck`

## Notes for reviewers

This is the durable version of the auth work. The smaller compatibility patch lives in #545, but this PR is the preferred long-term architecture because it centralizes provider credential resolution and readiness reporting.
