### PR TITLE
fix: support CJK characters in slugs and Chinese namespace directories

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -44,7 +44,7 @@ export type LinkResolutionType = 'qualified' | 'unqualified';
  *   - Our domain extensions: tech, finance, personal, openclaw (domain-organized wikis)
  *   - Our entity prefix: entities (we kept some legacy entities/projects/ pages)
  */
-const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities)';
+const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities|名雅居|人物|公司|概念|会议|产品|工艺|材料|系统|设备|营销工具|业务|流程|问题|项目|博主|同行|客户|学者|供应商|服务商|科技|行业|方法论|ai工具|技术|书籍|营销)';
 
 /**
  * Match `[Name](path)` markdown links pointing to entity directories.

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -213,7 +213,7 @@ export function slugifySegment(segment: string): string {
     .normalize('NFD')                     // Decompose accented chars
     .replace(/[\u0300-\u036f]/g, '')      // Strip accent marks
     .toLowerCase()
-    .replace(/[^a-z0-9.\s_-]/g, '')      // Keep alphanumeric, dots, spaces, underscores, hyphens
+    .replace(/[^a-z0-9\u4e00-\u9fff\u3400-\u4dbf.\s_-]/g, '')      // Keep alphanumeric, CJK, dots, spaces, underscores, hyphens
     .replace(/[\s]+/g, '-')              // Spaces → hyphens
     .replace(/-+/g, '-')                 // Collapse multiple hyphens
     .replace(/^-|-$/g, '');              // Strip leading/trailing hyphens


### PR DESCRIPTION
## Problem

GBrain\'s slug generation strips all non-ASCII characters, producing empty slugs for paths that are entirely in Chinese (e.g., `名雅居/会议/2026-04-30-全屋定制讨论`). This causes sync failures for users with Chinese knowledge base structures.

Additionally, the link extraction regex only matches English directory names, so wiki-links like `[[名雅居/公司/名雅居]]` or `[[人物/学者/柏拉图]]` are not recognized.

## Changes

### `src/core/sync.ts` — CJK slug support
Added CJK Unified Ideograph Unicode ranges (`U+4E00-U+9FFF`, `U+3400-U+4DBF`) to the `slugifySegment` regex so Chinese (and Japanese Kanji / Korean Hanja) characters are preserved during slug generation.

### `src/core/link-extraction.ts` — Chinese namespace directories
Extended `DIR_PATTERN` to include common Chinese directory names used in knowledge bases.

## Testing

- 222 pages with Chinese slugs successfully synced (was 91 failures before fix)
- Wiki-link extraction works for Chinese namespaced pages
- `gbrain doctor` score: 80-82/100 with no dead links

## Notes

- The DIR_PATTERN addition is intentionally broad — it covers common Chinese knowledge base category names. A more elegant approach might be to make DIR_PATTERN configurable, but this is a minimal fix.
- Only 2 lines changed across 2 files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->