### PR TITLE
Fix bootstrap crash on schema upgrade: missing v27 Cathedral II columns

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -235,13 +235,18 @@ export class PostgresEngine implements BrainEngine {
     }
 
     if (needsChunksBootstrap) {
-      // v26 (content_chunks_code_metadata) adds the full code-chunk metadata
-      // surface. The bootstrap only adds the two columns the schema blob's
-      // partial indexes reference (idx_chunks_symbol_name, idx_chunks_language).
-      // v26 runs later via runMigrations and adds the rest idempotently.
+      // v26 (content_chunks_code_metadata) and v27 (cathedral_ii_foundation)
+      // add the full code-chunk and chunk-grain FTS surfaces. The bootstrap
+      // only adds the columns the schema blob's indexes reference
+      // (idx_chunks_symbol_name, idx_chunks_language, idx_chunks_search_vector).
+      // v26 and v27 run later via runMigrations and add the rest idempotently.
       await conn.unsafe(`
         ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS language TEXT;
         ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS symbol_name TEXT;
+        ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS parent_symbol_path TEXT[];
+        ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS doc_comment TEXT;
+        ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS symbol_name_qualified TEXT;
+        ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS search_vector TSVECTOR;
       `);
     }
   }


### PR DESCRIPTION
## Summary

`PostgresEngine.initSchema()` crashes during bootstrap on brains upgrading from a pre-v0.20 schema. The `applyForwardReferenceBootstrap` block adds the v0.19 columns (`language`, `symbol_name`) that the schema blob's partial indexes need, but does not add the v0.20 (Cathedral II) columns that `idx_chunks_search_vector` references. SCHEMA_SQL crashes before `runMigrations()` can apply v27, so the brain never reaches a usable state.

## Reproduction

On a Postgres brain whose `content_chunks` is at the v13 era (no `search_vector`, no `language`, no `symbol_name`), upgrading the binary to a build that includes the v27 Cathedral II foundation fails on first init:

```
ERROR:  column "search_vector" does not exist
```

The error fires inside `await conn.unsafe(SCHEMA_SQL)` in `initSchema()`, before `runMigrations()` runs (postgres-engine.ts:122-127).

## Root cause

`applyForwardReferenceBootstrap()` exists precisely to add forward-referenced columns SCHEMA_SQL relies on, so v27's `ADD COLUMN IF NOT EXISTS` for the new columns never gets a chance to land.

The existing `if (needsChunksBootstrap)` block (postgres-engine.ts:237-246) only adds `language` and `symbol_name`. v27 (`cathedral_ii_foundation`) added a fifth content_chunks index, `idx_chunks_search_vector` on `search_vector`, and three sibling columns (`parent_symbol_path`, `doc_comment`, `symbol_name_qualified`) that the v27 trigger and CREATE INDEX statements reference. The bootstrap was never extended to cover those, so for v13 brains the schema blob crashes on the GIN index before `runMigrations()` can run v27.

## Fix

Mirror v27's column adds into the existing `needsChunksBootstrap` block, alongside `language` and `symbol_name`. All four are `ADD COLUMN IF NOT EXISTS`, so v27 stays a no-op on brains that already have them. Comment block updated to mention v27 in addition to v26 and to name the index that was crashing.

```typescript
if (needsChunksBootstrap) {
  // v26 (content_chunks_code_metadata) and v27 (cathedral_ii_foundation) add
  // the full code-chunk and chunk-grain FTS surfaces. The bootstrap only adds
  // the columns the schema blob's indexes reference (idx_chunks_symbol_name,
  // idx_chunks_language, idx_chunks_search_vector). v26 and v27 run later via
  // runMigrations and add the rest idempotently.
  await conn.unsafe(`
    ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS language TEXT;
    ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS symbol_name TEXT;
    ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS parent_symbol_path TEXT[];
    ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS doc_comment TEXT;
    ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS symbol_name_qualified TEXT;
    ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS search_vector TSVECTOR;
  `);
}
```

## Scope

This patch covers the v13-era path where the probe already triggers (`symbol_name` and `language` both missing). A pre-v0.20 brain that already has `language` and `symbol_name` (a v0.19 brain that was never upgraded past 19) would skip the block entirely and still hit the same crash; extending the probe condition is a separate, optional follow-up and is intentionally not bundled here.

## Tests

`test/e2e/postgres-bootstrap.test.ts` covers the existing v0.18 / v0.13 / v0.19 fixtures, but there is no v13-era fixture exercising the v27 path. Can add a v13 fixture in a follow-up if there's a preferred pattern, or include it in this PR if you want it bundled.

## Related PRs

Same shape as the prior bootstrap-extension PRs that handled earlier forward-reference gaps: #266, #357, #366, #375, #378, #396.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->