### PR TITLE
feat(submit_job): pass idempotency_key through MCP op to queue

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1171,6 +1171,7 @@ const submit_job: Operation = {
     max_attempts: { type: 'number', description: 'Max retry attempts (default: 3)' },
     delay: { type: 'number', description: 'Delay in ms before eligible' },
     timeout_ms: { type: 'number', description: 'Per-job wall-clock timeout in ms; aborted job goes to dead' },
+    idempotency_key: { type: 'string', description: 'Optional dedup key. Same key in queue coalesces to existing row (UNIQUE partial index, see queue.ts:94-103). Useful for at-least-once producers (e.g. sync clients firing per-page submit_job).' },
   },
   mutating: true,
   handler: async (ctx, p) => {
@@ -1199,6 +1200,7 @@ const submit_job: Operation = {
       max_attempts: (p.max_attempts as number) || 3,
       delay: (p.delay as number) || undefined,
       timeout_ms: (p.timeout_ms as number) || undefined,
+      idempotency_key: (p.idempotency_key as string) || undefined,
     }, trusted);
   },
 };


### PR DESCRIPTION
## Summary

`MinionQueue.add()` accepts an `idempotency_key` (queue.ts:94-103) that dedups via a `UNIQUE` partial index + `ON CONFLICT DO NOTHING` — concurrent submits with the same key return the same row. But the `submit_job` MCP operation (operations.ts:1163-1204) didn't expose this knob in its params allow-list and didn't forward it into `queue.add()`, so MCP clients couldn't reach the existing dedup primitive.

This 2-line change wires it through.

## Motivating use case

A per-page sync client (in our case, `notion-sync`) fires `submit_job('enrich-page', { slug })` after every successful `put_page` — including identical-content re-pushes during normal polling. Without passthrough, every re-push silently enqueues a new job and the worker re-runs the full enrichment chain. With passthrough, identical re-pushes coalesce; only edits with a new content hash trigger fresh enrichment:

```ts
await callMcpTool(config, 'submit_job', {
  name: 'enrich-page',
  data: { slug, source: 'notion-sync' },
  idempotency_key: \`enrich-page:\${slug}:\${contentHash.slice(0, 12)}\`,
});
```

The 12-char hash prefix (~48 bits) is enough entropy for de-duplication at the rates a single brain sees.

## Diff scope

```
 src/core/operations.ts | 2 ++
 1 file changed, 2 insertions(+)
```

- `params`: add \`idempotency_key: { type: 'string', ... }\` as optional
- `handler`: forward \`(p.idempotency_key as string) || undefined\` into the existing \`queue.add(...)\` opts

## Test plan

- [x] Existing queue.ts tests already cover the underlying dedup semantics (UNIQUE partial index, ON CONFLICT DO NOTHING)
- [x] Branch builds locally (\`bun run typecheck\`)
- [ ] Reviewer can verify by submitting two jobs with same name + idempotency_key and confirming the second returns the same job ID

## Notes

- Pure plumbing change. No new behavior on the queue side.
- Mirrors the existing pattern for other passthrough params (priority, max_attempts, delay, timeout_ms).
- No version bump or migration; the underlying schema already supports the column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->