### PR TITLE
feat(exports): add ./enrichment to package.json exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "./backoff": "./src/core/backoff.ts",
     "./search/hybrid": "./src/core/search/hybrid.ts",
     "./search/expansion": "./src/core/search/expansion.ts",
-    "./extract": "./src/commands/extract.ts"
+    "./extract": "./src/commands/extract.ts",
+    "./enrichment": "./src/core/enrichment-service.ts"
   },
   "scripts": {
     "dev": "bun run src/cli.ts",


### PR DESCRIPTION
## Summary

Adds a single `./enrichment` entry to the `exports` map in `package.json`,
pointing to the existing `src/core/enrichment-service.ts`. Purely additive
— no file is moved, no symbol is renamed, no behavior changes.

```diff
     "./search/expansion": "./src/core/search/expansion.ts",
-    "./extract": "./src/commands/extract.ts"
+    "./extract": "./src/commands/extract.ts",
+    "./enrichment": "./src/core/enrichment-service.ts"
   },
```

## Motivation

External consumers — e.g. user-built ingestion workers that want to plug
entity enrichment into their own pipelines — need to call the symbols
that `src/core/enrichment-service.ts` already exports:

- `extractAndEnrich`
- `enrichEntity`
- `enrichEntities`
- `extractEntities`
- `slugifyEntity`
- `entityPagePath`

Today, because `enrichment-service.ts` is not in the `exports` map, the
only way to reach those symbols from outside the package is a deep import:

```ts
import { extractAndEnrich } from "gbrain/src/core/enrichment-service";
```

That has two problems:

1. **Outside the public contract.** Any internal reshuffle of `src/core/`
   silently breaks downstream consumers, because nothing pins this path
   as part of the API surface.
2. **Not type-resolvable by default.** TypeScript with default
   `moduleResolution` rejects deep imports that are not declared in
   `exports`, so consumers have to add custom `paths` mappings in their
   `tsconfig.json` just to compile.

After this change, consumers can write:

```ts
import { extractAndEnrich } from "gbrain/enrichment";
```

…in the same shape as the existing `gbrain/extract`, `gbrain/operations`,
`gbrain/engine`, etc.

## Discovery

Found while wiring `extractAndEnrich` into an external `eco-brain-worker`
service as a Phase 1.5 follow-up — the deep-import workaround was the
clear sharp edge, and a 1-line addition to `exports` cleans it up for
every future consumer.

## Test plan

- [x] `package.json` parses as valid JSON (verified locally with `python -m json.tool`).
- [x] Diff is exactly the 2 lines shown above (1 added entry + trailing comma on the previous line).
- [x] No other file touched.
- [ ] CI green on this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->