### PR TITLE
fix(throttle): use /proc/meminfo MemAvailable on Linux

### DIFF
--- a/src/core/backoff.ts
+++ b/src/core/backoff.ts
@@ -81,6 +81,20 @@ function getLoad(): number {
 
 /** Get memory usage fraction (0-1) */
 function getMemoryUsage(): number {
+  // Prefer /proc/meminfo MemAvailable on Linux — os.freemem() returns
+  // MemFree which excludes page cache, falsely reading "high pressure"
+  // in any container where the kernel caches files.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require('fs');
+    const meminfo: string = fs.readFileSync('/proc/meminfo', 'utf8');
+    const totalKb = Number(meminfo.match(/MemTotal:\s+(\d+)/)?.[1]);
+    const availKb = Number(meminfo.match(/MemAvailable:\s+(\d+)/)?.[1]);
+    if (totalKb > 0 && availKb >= 0) return 1 - availKb / totalKb;
+  } catch {
+    /* fall through to os.freemem() (non-Linux or /proc unavailable) */
+  }
+  // Non-Linux fallback (macOS, Windows, or any host without /proc/meminfo)
   const total = totalmem();
   if (total === 0) return 0;
   return 1 - (freemem() / total);


### PR DESCRIPTION
## Problem

`waitForCapacity()` in `src/core/backoff.ts` rejects every batch / enrichment job in a healthy Linux container, even when the host has gigabytes of usable memory free.

`getMemoryUsage()` (lines 83-87 on master) computes:

```ts
return 1 - (freemem() / total);
```

Node's `os.freemem()` reports Linux's `MemFree` from `/proc/meminfo`. `MemFree` is _not_ "memory available for new allocations" — it excludes the page cache, which the kernel grows aggressively in any environment that reads files. In containers this is essentially always the case, so `MemFree` is routinely under 5% of `MemTotal` while `MemAvailable` (the kernel's actual "free for new allocations" estimate, factoring in reclaimable cache) is plentiful.

## Concrete failure

Observed today on `eco-brain-worker` deployed to Zeabur (Bun runtime, Linux container, 4 GB RAM):

```
Throttle timeout: system overloaded after 20 attempts (~600s).
Load: 12%, Memory: 97%
```

…on every `enrich-page` job. At the same moment, `cat /proc/meminfo` inside that container showed:

```
MemTotal:        4194304 kB
MemFree:           96820 kB     # <- what os.freemem() returns -> 97% "used"
MemAvailable:    1448712 kB     # <- what htop/free -h show -> 65% used
```

So with the current `getMemoryUsage()` the throttle reports 97% used (above the 85% `memoryStopPct` default) and refuses to proceed, when in reality the system has ~1.4 GB of immediately-allocatable memory.

`free -h`, `htop`, Kubernetes' OOM killer, cgroup memory accounting, and container schedulers all use `MemAvailable` (or equivalent) for exactly this reason — `MemFree` was never the right number to gate on.

## Fix

On Linux (when `/proc/meminfo` is readable), parse `MemAvailable` and `MemTotal` and compute:

```ts
1 - MemAvailable / MemTotal
```

Fall through to the existing `os.freemem()/totalmem()` everywhere else (macOS, Windows, sandboxed envs without `/proc`) so non-Linux behaviour is unchanged.

The change is purely in `getMemoryUsage()`; the rest of the throttle logic, the `memoryStopPct` default (0.85), and the public API are untouched.

## Diff scope

- 1 file: `src/core/backoff.ts`
- +14 lines, -0 lines
- Type signature, imports, callers, and tests are unchanged. `bun run typecheck` passes.

## Out of scope (deliberately)

An env override like `GBRAIN_MEMORY_STOP_PCT` (or moving thresholds into config) would also be reasonable but is out of scope for this PR — this is a data-correctness fix only. Happy to do that as a follow-up if desired.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->