### PR TITLE
fix(embed): clamp chunks to 8100 tokens before OpenAI call

### DIFF
--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -4,14 +4,22 @@
  *
  * OpenAI text-embedding-3-large at 1536 dimensions.
  * Retry with exponential backoff (4s base, 120s cap, 5 retries).
- * 8000 character input truncation.
+ * Token-based input truncation (8100 tokens, ~92 token headroom under
+ * the 8192 ceiling enforced by text-embedding-3-{small,large}).
  */
 
 import OpenAI from 'openai';
 
 const MODEL = 'text-embedding-3-large';
 const DIMENSIONS = 1536;
-const MAX_CHARS = 8000;
+// OpenAI text-embedding-3-{small,large} hard-cap input at 8192 tokens.
+// We clamp at 8100 to leave ~92 tokens of headroom for any tokenizer
+// drift between cl100k_base (what we count with) and OpenAI server-side
+// tokenization (which is the same family but version-pinned separately).
+const MAX_TOKENS = 8100;
+// Fallback character cap when tiktoken fails to load. Conservative ~2:1
+// char-to-token ratio so dense code/markup still fits under 8192 tokens.
+const FALLBACK_MAX_CHARS = 16000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
@@ -26,8 +34,61 @@ function getClient(): OpenAI {
   return client;
 }
 
+// Lazy + cached cl100k_base encoder. Same encoder text-embedding-3-large
+// uses on the server, mirroring the pattern in src/core/chunkers/code.ts
+// (estimateTokens). Pay init cost once per process; per-chunk overhead
+// is then O(n) in text length.
+let tiktokenEncoder:
+  | { encode: (s: string) => Uint32Array; decode: (t: Uint32Array) => Uint8Array; free: () => void }
+  | null = null;
+let tiktokenInitialized = false;
+const utf8Decoder = new TextDecoder('utf-8');
+
+function initTokenizer(): void {
+  if (tiktokenInitialized) return;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const m = require('@dqbd/tiktoken');
+    tiktokenEncoder = m.get_encoding('cl100k_base');
+  } catch {
+    tiktokenEncoder = null;
+  }
+  tiktokenInitialized = true;
+}
+
+/**
+ * Truncate `text` so its cl100k_base token count is <= MAX_TOKENS.
+ *
+ * Why this exists: chunkers target ~300 words per chunk, but the recursive
+ * merger lets chunks grow up to ~1.5x target plus 50-word overlap. Dense
+ * code or markup hits 2-3 tokens per char (vs 0.25 tokens/char for prose),
+ * so a 600-word chunk can exceed 8192 tokens and OpenAI rejects with HTTP
+ * 400 ("Invalid 'input[0]': maximum input length is 8192 tokens"). The
+ * old MAX_CHARS=8000 cap did not account for this.
+ *
+ * UTF-8 safety: we encode -> slice tokens -> decode bytes -> TextDecoder.
+ * TextDecoder defaults to fatal=false and replaces invalid sequences,
+ * which preserves UTF-8 boundaries even if a multi-byte char straddles
+ * the truncation point.
+ */
+function truncateToTokens(text: string): string {
+  if (!text) return text;
+  initTokenizer();
+  if (!tiktokenEncoder) {
+    // Fallback path: tiktoken failed to load (vanishingly unlikely once
+    // it loaded successfully for the chunker). Use a conservative char
+    // cap that still keeps dense content under 8192 tokens.
+    return text.length > FALLBACK_MAX_CHARS ? text.slice(0, FALLBACK_MAX_CHARS) : text;
+  }
+  const tokens = tiktokenEncoder.encode(text);
+  if (tokens.length <= MAX_TOKENS) return text;
+  const sliced = tokens.slice(0, MAX_TOKENS);
+  const bytes = tiktokenEncoder.decode(sliced);
+  return utf8Decoder.decode(bytes);
+}
+
 export async function embed(text: string): Promise<Float32Array> {
-  const truncated = text.slice(0, MAX_CHARS);
+  const truncated = truncateToTokens(text);
   const result = await embedBatch([truncated]);
   return result[0];
 }
@@ -45,7 +106,7 @@ export async function embedBatch(
   texts: string[],
   options: EmbedBatchOptions = {},
 ): Promise<Float32Array[]> {
-  const truncated = texts.map(t => t.slice(0, MAX_CHARS));
+  const truncated = texts.map(t => truncateToTokens(t));
   const results: Float32Array[] = [];
 
   // Process in batches of BATCH_SIZE


### PR DESCRIPTION
## Symptom

Production gbrain workers are looping on:

```
[gbrain] embedding failed for <slug>: 400 Invalid 'input[0]': maximum input length is 8192 tokens.
```

20+ pages stuck — every retry hits the same OpenAI 400, so chunks never clear `embedded_at IS NULL`. Affected pages annotate as `(1 chunks)` / `(2 chunks)` / `(3 chunks)`, so the batch isn't pathological in count — it's pathological in size.

## Root cause

`src/core/embedding.ts` truncates inputs at **8000 characters**, but `text-embedding-3-large` (and `-small`) reject anything over **8192 tokens** (per [OpenAI's embeddings docs](https://platform.openai.com/docs/guides/embeddings/embedding-models) — both `text-embedding-3-small` and `text-embedding-3-large` enforce the 8192-token ceiling).

The char-token ratio depends entirely on content shape with `cl100k_base`:

| Content | chars/token | 8000 chars ≈ |
|---|---|---|
| English prose | ~4 | ~2000 tokens (safe) |
| Code | ~2-3 | ~3000-4000 tokens (safe-ish) |
| Dense JSON / minified markup | ~1-2 | **~4000-8000+ tokens** |
| CJK / base64 blobs | ~0.5-1 | **~8000-16000+ tokens** |

Chunker output isn't bounded by tokens either — `src/core/chunkers/recursive.ts` targets 300 words but the merger lets chunks grow to ~1.5x target plus 50-word overlap, so a 600-word chunk of dense content easily crosses 8192 tokens.

`embedBatchWithRetry` only handles HTTP 429; HTTP 400 is rethrown after 5 retries, blocking the slug indefinitely.

## Fix

Replace the character-based slice in `embed()` and `embedBatch()` with `truncateToTokens()` backed by `@dqbd/tiktoken`'s `cl100k_base` encoder — the same encoder already used by `src/core/chunkers/code.ts` (`estimateTokens`, L979-995). Lazy-init at module level (one allocation per process), encode → slice at 8100 tokens → decode bytes → recover via `TextDecoder` so multi-byte UTF-8 sequences straddling the cut point are handled cleanly.

Why 8100 not 8192: ~92 tokens of headroom for tokenizer drift between client `cl100k_base` and OpenAI's server-side tokenizer (same family, version-pinned independently).

Falls back to a 16k-char slice if tiktoken somehow fails to load (vanishingly unlikely once it loaded for the chunker, but keeps `embed` available either way).

## Why this is safe

- **Single file**: `src/core/embedding.ts`, +65/-4 lines.
- **No new deps**: `@dqbd/tiktoken ^1.0.22` is already in `package.json` (L61) and used by the code chunker.
- **Backward compatible**: all chunks under 8100 tokens (the overwhelming majority) pass through unchanged. Only oversize chunks see different behaviour — and previously those were returning HTTP 400 instead of an embedding, so any output is strictly better.
- **No chunker changes**: chunking strategy and embedding model are untouched.
- **No API surface change**: `embed()` and `embedBatch()` signatures unchanged.

## Verification

- `bun run typecheck` (`tsc --noEmit`) — clean.
- Runtime sanity test against the actual `cl100k_base` encoder:
  - 62K-char dense JSON (42K tokens) → truncated to exactly 8100 tokens.
  - 12K-char Chinese text (24K tokens) → truncated to exactly 8100 tokens, UTF-8 preserved.
  - Short text (`"hello world"`, 2 tokens) → passes through unchanged.

## Diff sketch

```diff
-const MAX_CHARS = 8000;
+const MAX_TOKENS = 8100;
+const FALLBACK_MAX_CHARS = 16000;

+let tiktokenEncoder: { encode, decode, free } | null = null;
+function initTokenizer() { ... lazy require('@dqbd/tiktoken') ... }
+function truncateToTokens(text: string): string { ... encode → slice → decode ... }

-const truncated = text.slice(0, MAX_CHARS);
+const truncated = truncateToTokens(text);

-const truncated = texts.map(t => t.slice(0, MAX_CHARS));
+const truncated = texts.map(t => truncateToTokens(t));
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->