### PR TITLE
doctor: use engine raw checks for PGLite health

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -323,8 +323,7 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
   // 4. pgvector extension
   progress.heartbeat('pgvector');
   try {
-    const sql = db.getConnection();
-    const ext = await sql`SELECT extname FROM pg_extension WHERE extname = 'vector'`;
+    const ext = await engine.executeRaw<{ extname: string }>("SELECT extname FROM pg_extension WHERE extname = 'vector'");
     if (ext.length > 0) {
       checks.push({ name: 'pgvector', status: 'ok', message: 'Extension installed' });
     } else {
@@ -600,7 +599,6 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
   // repair target, per #254/Codex review).
   progress.heartbeat('jsonb_integrity');
   try {
-    const sql = db.getConnection();
     const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
       { table: 'pages',         col: 'frontmatter',    expected: 'object' },
       { table: 'raw_data',      col: 'data',           expected: 'object' },
@@ -610,16 +608,23 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
     ];
     let totalBad = 0;
     const breakdown: string[] = [];
+    const skipped: string[] = [];
     for (const { table, col } of targets) {
       progress.heartbeat(`jsonb_integrity.${table}.${col}`);
-      const rows = await sql.unsafe(
+      const existsRows = await engine.executeRaw<{ r: string | null }>(`SELECT to_regclass('${table}') AS r`);
+      if (!existsRows[0]?.r) {
+        skipped.push(table);
+        continue;
+      }
+      const rows = await engine.executeRaw<{ n: number }>(
         `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
       );
-      const n = Number((rows as any)[0]?.n ?? 0);
+      const n = Number(rows[0]?.n ?? 0);
       if (n > 0) { totalBad += n; breakdown.push(`${table}.${col}=${n}`); }
     }
     if (totalBad === 0) {
-      checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'All JSONB columns store objects/arrays' });
+      const suffix = skipped.length > 0 ? ` (${skipped.join(', ')} not present in this engine)` : '';
+      checks.push({ name: 'jsonb_integrity', status: 'ok', message: `All JSONB columns store objects/arrays${suffix}` });
     } else {
       checks.push({
         name: 'jsonb_integrity',


### PR DESCRIPTION
## Summary
- check pgvector through the active engine instead of the Postgres singleton
- run JSONB integrity checks through the active engine
- skip absent optional tables such as `files` so PGLite installs do not report false warnings

## Why
On a PGLite-backed install, `doctor` can connect and operate correctly while the pgvector/jsonb checks still warn because they query through the Postgres singleton path or assume tables that are not present in the PGLite schema. This makes otherwise healthy PGLite installs show warnings.

## Test plan
- `bun test test/doctor.test.ts test/doctor-minions-check.test.ts test/doctor-fix.test.ts test/e2e/doctor-progress.test.ts`
- Verified on a real PGLite install: `gbrain doctor --json` reports `status: healthy`, `pgvector: ok`, and `jsonb_integrity: ok`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->