### PR TITLE
fix: prevent CREATE INDEX from running before migration bootstraps v27 columns

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -152,6 +152,12 @@ export class PostgresEngine implements BrainEngine {
    *   - `links.origin_page_id` column (indexed by `idx_links_origin`) — v0.13
    *   - `content_chunks.symbol_name` column (indexed by `idx_chunks_symbol_name`) — v0.19
    *   - `content_chunks.language` column (indexed by `idx_chunks_language`) — v0.19
+   *   - `content_chunks.search_vector` column (indexed by `idx_chunks_search_vector`,
+   *     written by `chunk_search_vector_trigger`) — v0.20 (v27)
+   *   - `content_chunks.symbol_name_qualified` column (indexed by
+   *     `idx_chunks_symbol_qualified`, fired-on by `chunk_search_vector_trigger`) — v0.20 (v27)
+   *   - `content_chunks.doc_comment` column (fired-on by `chunk_search_vector_trigger`) — v0.20 (v27)
+   *   - `content_chunks.parent_symbol_path` column — v0.20 (v27)
    *
    * Keep this in sync with the PGLite version; covered by
    * `test/schema-bootstrap-coverage.test.ts` (PGLite side) and
@@ -172,6 +178,10 @@ export class PostgresEngine implements BrainEngine {
       chunks_exists: boolean;
       symbol_name_exists: boolean;
       language_exists: boolean;
+      search_vector_exists: boolean;
+      symbol_name_qualified_exists: boolean;
+      doc_comment_exists: boolean;
+      parent_symbol_path_exists: boolean;
     }[]>`
       SELECT
         EXISTS (SELECT 1 FROM information_schema.tables
@@ -189,7 +199,15 @@ export class PostgresEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema = current_schema() AND table_name = 'content_chunks' AND column_name = 'symbol_name') AS symbol_name_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema = current_schema() AND table_name = 'content_chunks' AND column_name = 'language') AS language_exists
+                WHERE table_schema = current_schema() AND table_name = 'content_chunks' AND column_name = 'language') AS language_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'content_chunks' AND column_name = 'search_vector') AS search_vector_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'content_chunks' AND column_name = 'symbol_name_qualified') AS symbol_name_qualified_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'content_chunks' AND column_name = 'doc_comment') AS doc_comment_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'content_chunks' AND column_name = 'parent_symbol_path') AS parent_symbol_path_exists
     `;
     const probe = probeRows[0]!;
 
@@ -198,8 +216,13 @@ export class PostgresEngine implements BrainEngine {
       && (!probe.link_source_exists || !probe.origin_page_id_exists);
     const needsChunksBootstrap = probe.chunks_exists
       && (!probe.symbol_name_exists || !probe.language_exists);
+    const needsChunksFtsBootstrap = probe.chunks_exists
+      && (!probe.search_vector_exists
+          || !probe.symbol_name_qualified_exists
+          || !probe.doc_comment_exists
+          || !probe.parent_symbol_path_exists);
 
-    if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap) return;
+    if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap && !needsChunksFtsBootstrap) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
 
@@ -244,6 +267,29 @@ export class PostgresEngine implements BrainEngine {
       await conn.unsafe(`
         ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS language TEXT;
         ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS symbol_name TEXT;
+      `);
+    }
+
+    if (needsChunksFtsBootstrap) {
+      // v27 (cathedral_ii_foundation) adds the chunk-grain FTS surface:
+      //   - search_vector / symbol_name_qualified / doc_comment / parent_symbol_path
+      // SCHEMA_SQL forward-references all four via:
+      //   - CREATE INDEX idx_chunks_search_vector ON content_chunks USING GIN(search_vector)
+      //   - CREATE INDEX idx_chunks_symbol_qualified ON content_chunks(symbol_name_qualified) WHERE ...
+      //   - update_chunk_search_vector() function body (writes search_vector,
+      //     reads doc_comment + symbol_name_qualified + chunk_text)
+      //   - chunk_search_vector_trigger BEFORE INSERT OR UPDATE OF
+      //     (chunk_text, doc_comment, symbol_name_qualified)
+      // Without this bootstrap, a pre-v27 brain wedges with
+      // `column "search_vector" does not exist` on the first init that hits
+      // a v0.22+ schema blob (issue #561).
+      // v27 runs later via runMigrations and is idempotent (`IF NOT EXISTS`
+      // / `ADD COLUMN IF NOT EXISTS` everywhere).
+      await conn.unsafe(`
+        ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS search_vector TSVECTOR;
+        ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS symbol_name_qualified TEXT;
+        ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS doc_comment TEXT;
+        ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS parent_symbol_path TEXT[];
       `);
     }
   }

--- a/test/e2e/postgres-bootstrap.test.ts
+++ b/test/e2e/postgres-bootstrap.test.ts
@@ -12,6 +12,10 @@
  * Covers issues #366, #375, #378 — Postgres-side wedges where pre-v0.18
  * brains crashed on `column "source_id" does not exist`.
  *
+ * Also covers #561 — pre-v27 brains wedging on
+ * `column "search_vector" does not exist` after v0.22+ added the chunk-grain
+ * FTS forward-references without extending the bootstrap.
+ *
  * NOTE: snapshot-based historical state simulation is out of scope for this
  * wave (would require maintaining historical schema dumps). The test
  * mutates a fresh-LATEST brain to a pre-v0.18 shape; codex flagged this as
@@ -82,6 +86,62 @@ describe.skipIf(skip)('PostgresEngine forward-reference bootstrap (E2E)', () => 
     // Verify the default source row was seeded.
     const srcCheck = await conn`SELECT id FROM sources WHERE id = 'default'`;
     expect(srcCheck).toHaveLength(1);
+  });
+
+  test('PostgresEngine.initSchema bootstraps v27 chunk-grain FTS columns on pre-v0.21 brain (issue #561)', async () => {
+    // Regression test for the v27 (cathedral_ii_foundation) wedge: a brain
+    // that pre-dates content_chunks.search_vector / symbol_name_qualified /
+    // doc_comment / parent_symbol_path used to crash on
+    // `CREATE INDEX idx_chunks_search_vector` and the
+    // chunk_search_vector_trigger because SCHEMA_SQL ran before runMigrations
+    // had a chance to apply v27.
+    //
+    // Bring DB to LATEST, then mutate to pre-v27 shape and re-init.
+    await engine.initSchema();
+
+    const conn = (engine as any).sql;
+    await conn.unsafe(`TRUNCATE pages, content_chunks, links, tags, raw_data, timeline_entries, page_versions, ingest_log RESTART IDENTITY CASCADE`);
+
+    // Drop the v27 dependents first, then the columns they reference.
+    await conn.unsafe(`
+      DROP TRIGGER IF EXISTS chunk_search_vector_trigger ON content_chunks;
+      DROP FUNCTION IF EXISTS update_chunk_search_vector();
+      DROP INDEX IF EXISTS idx_chunks_search_vector;
+      DROP INDEX IF EXISTS idx_chunks_symbol_qualified;
+      ALTER TABLE content_chunks DROP COLUMN IF EXISTS search_vector;
+      ALTER TABLE content_chunks DROP COLUMN IF EXISTS symbol_name_qualified;
+      ALTER TABLE content_chunks DROP COLUMN IF EXISTS doc_comment;
+      ALTER TABLE content_chunks DROP COLUMN IF EXISTS parent_symbol_path;
+    `);
+    await engine.setConfig('version', '26');
+
+    // Path under test: bootstrap must add the four v27 columns BEFORE
+    // SCHEMA_SQL hits its CREATE INDEX / CREATE TRIGGER references.
+    await engine.initSchema();
+
+    expect(await engine.getConfig('version')).toBe(String(LATEST_VERSION));
+
+    // Every v27 forward-reference target survives the upgrade.
+    const cols = await conn<{ column_name: string }[]>`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_schema = current_schema()
+        AND table_name = 'content_chunks'
+        AND column_name IN ('search_vector', 'symbol_name_qualified', 'doc_comment', 'parent_symbol_path')
+    `;
+    const names = new Set(cols.map((r: { column_name: string }) => r.column_name));
+    expect(names.has('search_vector')).toBe(true);
+    expect(names.has('symbol_name_qualified')).toBe(true);
+    expect(names.has('doc_comment')).toBe(true);
+    expect(names.has('parent_symbol_path')).toBe(true);
+
+    // The chunk-grain FTS index is back too (this is what crashed pre-fix).
+    const idxCheck = await conn`
+      SELECT indexname FROM pg_indexes
+      WHERE schemaname = current_schema()
+        AND tablename = 'content_chunks'
+        AND indexname = 'idx_chunks_search_vector'
+    `;
+    expect(idxCheck).toHaveLength(1);
   });
 
   test('PostgresEngine.initSchema is idempotent on a brain already at LATEST', async () => {


### PR DESCRIPTION
Closes #561.

## Bug

Pre-v0.21 Postgres brains wedge on `initSchema()` with `column "search_vector" does not exist` (or `symbol_name_qualified`, `doc_comment`, `parent_symbol_path`) once the v0.22+ schema blob picks up v27's chunk-grain FTS forward-references.

`SCHEMA_SQL` runs **before** `runMigrations()` in `PostgresEngine.initSchema()`. v27 (`cathedral_ii_foundation`) added these statements to `src/schema.sql`:

```sql
CREATE INDEX IF NOT EXISTS idx_chunks_search_vector ON content_chunks USING GIN(search_vector);
CREATE INDEX IF NOT EXISTS idx_chunks_symbol_qualified ON content_chunks(symbol_name_qualified) WHERE ...;
CREATE OR REPLACE FUNCTION update_chunk_search_vector() ...;
CREATE TRIGGER chunk_search_vector_trigger BEFORE INSERT OR UPDATE OF chunk_text, doc_comment, symbol_name_qualified ...;
```

…but didn't extend `PostgresEngine.applyForwardReferenceBootstrap()`. Old brains crash before runMigrations gets to apply v27. Same wedge class the bootstrap was originally built to prevent (#239, #243, #266, #357, #366, #374, #375, #378, #395, #396 per the coverage test docstring).

## Fix

Extend `applyForwardReferenceBootstrap()` in `src/core/postgres-engine.ts` to probe for and add the four v27 columns (`search_vector`, `symbol_name_qualified`, `doc_comment`, `parent_symbol_path`) when `content_chunks` exists but the columns don't. Idempotent (`ADD COLUMN IF NOT EXISTS`), no-op on fresh installs and modern brains.

This is **Option A** — the structural fix the codebase already chose for the v0.18 / v0.13 / v0.19 cases. The maintenance contract in the JSDoc + coverage test (`test/schema-bootstrap-coverage.test.ts`) explicitly invites this: when a future migration adds a column-with-index referenced by SCHEMA_SQL, extend `applyForwardReferenceBootstrap` and the coverage list. v27 missed both steps; this PR completes them on the Postgres side.

## What I did NOT touch

- **`pglite-engine.ts` / `pglite-schema.ts`** — `pglite-schema.ts` is hand-maintained (per its own header) and currently doesn't include the v27 chunk-grain FTS indexes/trigger, so PGLite brains aren't bitten by this bug. Adding entries to `REQUIRED_BOOTSTRAP_COVERAGE` would test forward-references that don't exist on that side.

  If you'd like PGLite to also gain the v27 chunk-grain FTS surface in `pglite-schema.ts`, that's a separate feature PR — I'd be happy to do it as a follow-up. For this PR I kept the change scope tight to the bug.

- **`src/schema.sql`** — the structural fix doesn't require schema changes. The forward-references stay where they are; the bootstrap fills in what they need.

- **`src/core/schema-embedded.ts`** — auto-generated from `src/schema.sql` via `scripts/build-schema.sh`; unchanged.

## Tests

Added `PostgresEngine.initSchema bootstraps v27 chunk-grain FTS columns on pre-v0.21 brain (issue #561)` to `test/e2e/postgres-bootstrap.test.ts`. Same pattern as the existing pre-v0.18 test:

1. Bring a test DB to LATEST.
2. Drop the v27 columns + their dependents (trigger, indexes, function), reset `config.version` to `26`.
3. Call `engine.initSchema()` — must succeed without crashing.
4. Assert version is `LATEST_VERSION`, the four v27 columns are back, and `idx_chunks_search_vector` exists.

The existing PGLite-side `test/schema-bootstrap-coverage.test.ts` still passes (verified locally — 2/2 tests, 6 expect() calls). Postgres e2e suite needs `DATABASE_URL`; CI will run it.

Local typecheck passes (`bunx --bun tsc --noEmit -p .`) on the touched files.

## Why now

A downstream user (COS) has been carrying a 100+ line bash post-install patch (`patch-gbrain-initschema.sh`) for ~2 weeks that sed-injects `ALTER TABLE content_chunks ADD COLUMN IF NOT EXISTS …` into the generated `schema-embedded.ts`. Idempotent, but needs reapplying after every `bun install -g gbrain`. Filing this PR so the patch can be retired upstream and other users don't hit the same wedge.

## Considered alternatives

**Option B** — wrap the offending `CREATE INDEX` statements in `DO $$ BEGIN IF EXISTS (...) THEN EXECUTE '...'; END IF; END $$` blocks inside `src/schema.sql`. This is what the COS bash patch does post-install. Rejected because the codebase has already standardized on the bootstrap pattern; adding inline guards would fragment the approach and bypass the coverage-test contract.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->