### PR TITLE
fix(config): prefer ~/.gbrain/config.json over generic DATABASE_URL

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -9,8 +9,17 @@ import type { EngineConfig } from './types.ts';
  * instead of the misleading "No database configured" when GBRAIN_DATABASE_URL
  * (or DATABASE_URL) is actually set.
  *
- * Precedence matches loadConfig(): env vars win over config-file URL. Returns
- * null only when NO source provides a URL at all.
+ * Precedence matches loadConfig():
+ *   1. GBRAIN_DATABASE_URL  (explicit gbrain-targeted override)
+ *   2. config-file          (~/.gbrain/config.json)
+ *   3. DATABASE_URL         (generic fallback — used only when no config exists)
+ *
+ * The generic DATABASE_URL ranks below the config file because bun auto-loads
+ * `.env` from cwd, so an unrelated project's DATABASE_URL would otherwise
+ * hijack the brain connection. GBRAIN_DATABASE_URL still wins for users who
+ * intentionally want to override.
+ *
+ * Returns null only when NO source provides a URL at all.
  */
 export type DbUrlSource =
   | 'env:GBRAIN_DATABASE_URL'
@@ -19,8 +28,10 @@ export type DbUrlSource =
   | 'config-file-path' // PGLite: config file present, no URL but database_path set
   | null;
 
-// Lazy-evaluated to avoid calling homedir() at module scope (breaks in serverless/bundled environments)
-function getConfigDir() { return join(homedir(), '.gbrain'); }
+// Lazy-evaluated to avoid calling homedir() at module scope (breaks in serverless/bundled environments).
+// Prefer process.env.HOME so tests and runtime overrides work — bun caches homedir() after first call.
+function home() { return process.env.HOME || homedir(); }
+function getConfigDir() { return join(home(), '.gbrain'); }
 function getConfigPath() { return join(getConfigDir(), 'config.json'); }
 
 export interface GBrainConfig {
@@ -39,7 +50,16 @@ export interface GBrainConfig {
 }
 
 /**
- * Load config with credential precedence: env vars > config file.
+ * Load config with credential precedence:
+ *   1. GBRAIN_DATABASE_URL   (explicit gbrain-targeted override)
+ *   2. ~/.gbrain/config.json (the brain's own config)
+ *   3. DATABASE_URL          (generic fallback, only if no config file URL)
+ *
+ * The generic DATABASE_URL is ranked below the config file because bun
+ * auto-loads `.env` from cwd, so running gbrain inside an unrelated project
+ * directory would otherwise let that project's DATABASE_URL hijack the brain
+ * connection. Users who want explicit override still have GBRAIN_DATABASE_URL.
+ *
  * Plugin config is handled by the plugin runtime injecting env vars.
  */
 export function loadConfig(): GBrainConfig | null {
@@ -49,8 +69,11 @@ export function loadConfig(): GBrainConfig | null {
     fileConfig = JSON.parse(raw) as GBrainConfig;
   } catch { /* no config file */ }
 
-  // Try env vars
-  const dbUrl = process.env.GBRAIN_DATABASE_URL || process.env.DATABASE_URL;
+  const explicitGbrainUrl = process.env.GBRAIN_DATABASE_URL;
+  const genericUrl = process.env.DATABASE_URL;
+  const fileUrl = fileConfig?.database_url;
+  // GBRAIN_DATABASE_URL > config file > DATABASE_URL.
+  const dbUrl = explicitGbrainUrl || fileUrl || genericUrl;
 
   if (!fileConfig && !dbUrl) return null;
 
@@ -58,7 +81,6 @@ export function loadConfig(): GBrainConfig | null {
   const inferredEngine: 'postgres' | 'pglite' = fileConfig?.engine
     || (fileConfig?.database_path ? 'pglite' : 'postgres');
 
-  // Merge: env vars override config file
   const merged = {
     ...fileConfig,
     engine: inferredEngine,
@@ -87,29 +109,32 @@ export function toEngineConfig(config: GBrainConfig): EngineConfig {
 }
 
 export function configDir(): string {
-  return join(homedir(), '.gbrain');
+  return getConfigDir();
 }
 
 export function configPath(): string {
-  return join(configDir(), 'config.json');
+  return getConfigPath();
 }
 
 /**
  * Introspect where the active DB URL would come from if we tried to connect.
- * Never throws, never connects. Env vars take precedence (matches loadConfig).
+ * Never throws, never connects. Matches loadConfig() precedence:
+ *   GBRAIN_DATABASE_URL > config file > DATABASE_URL.
  */
 export function getDbUrlSource(): DbUrlSource {
   if (process.env.GBRAIN_DATABASE_URL) return 'env:GBRAIN_DATABASE_URL';
-  if (process.env.DATABASE_URL) return 'env:DATABASE_URL';
-  if (!existsSync(configPath())) return null;
-  try {
-    const raw = readFileSync(configPath(), 'utf-8');
-    const parsed = JSON.parse(raw) as Partial<GBrainConfig>;
-    if (parsed.database_url) return 'config-file';
-    if (parsed.database_path) return 'config-file-path';
-    return null;
-  } catch {
-    // Config file exists but is unreadable/malformed — treat as null source.
-    return null;
+
+  let parsed: Partial<GBrainConfig> | null = null;
+  if (existsSync(configPath())) {
+    try {
+      parsed = JSON.parse(readFileSync(configPath(), 'utf-8')) as Partial<GBrainConfig>;
+    } catch {
+      // Config file exists but is unreadable/malformed — fall through.
+    }
   }
+  if (parsed?.database_url) return 'config-file';
+
+  if (process.env.DATABASE_URL) return 'env:DATABASE_URL';
+  if (parsed?.database_path) return 'config-file-path';
+  return null;
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,8 @@
-import { describe, test, expect } from 'bun:test';
-import { readFileSync } from 'fs';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { readFileSync, mkdirSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadConfig, getDbUrlSource } from '../src/core/config.ts';
 
 // redactUrl is not exported, so we test it by reading the source and
 // reimplementing the regex to verify the pattern, then test via CLI
@@ -59,5 +62,78 @@ describe('config source correctness', () => {
 
   test('redactUrl uses the correct regex pattern', () => {
     expect(configSource).toContain('postgresql:\\/\\/');
+  });
+});
+
+describe('loadConfig precedence', () => {
+  // Bun auto-loads `.env` from cwd, so a user running `gbrain` inside an
+  // unrelated project picks up that project's DATABASE_URL. The brain's own
+  // ~/.gbrain/config.json must beat that generic var; only the explicit
+  // GBRAIN_DATABASE_URL is allowed to override the config file.
+  let tmp: string;
+  let prevHome: string | undefined;
+  let prevGbrainUrl: string | undefined;
+  let prevDbUrl: string | undefined;
+
+  const writeConfig = (json: object) => {
+    mkdirSync(join(tmp, '.gbrain'), { recursive: true });
+    writeFileSync(join(tmp, '.gbrain', 'config.json'), JSON.stringify(json));
+  };
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'gbrain-config-test-'));
+    prevHome = process.env.HOME;
+    prevGbrainUrl = process.env.GBRAIN_DATABASE_URL;
+    prevDbUrl = process.env.DATABASE_URL;
+    process.env.HOME = tmp;
+    delete process.env.GBRAIN_DATABASE_URL;
+    delete process.env.DATABASE_URL;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME; else process.env.HOME = prevHome;
+    if (prevGbrainUrl === undefined) delete process.env.GBRAIN_DATABASE_URL;
+    else process.env.GBRAIN_DATABASE_URL = prevGbrainUrl;
+    if (prevDbUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = prevDbUrl;
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  test('config file URL beats generic DATABASE_URL', () => {
+    writeConfig({ engine: 'postgres', database_url: 'postgresql://config-host/brain' });
+    process.env.DATABASE_URL = 'postgresql://random-project-host/somedb';
+    expect(loadConfig()?.database_url).toBe('postgresql://config-host/brain');
+    expect(getDbUrlSource()).toBe('config-file');
+  });
+
+  test('GBRAIN_DATABASE_URL beats config file', () => {
+    writeConfig({ engine: 'postgres', database_url: 'postgresql://config-host/brain' });
+    process.env.GBRAIN_DATABASE_URL = 'postgresql://override-host/brain';
+    expect(loadConfig()?.database_url).toBe('postgresql://override-host/brain');
+    expect(getDbUrlSource()).toBe('env:GBRAIN_DATABASE_URL');
+  });
+
+  test('GBRAIN_DATABASE_URL beats generic DATABASE_URL when no config', () => {
+    process.env.GBRAIN_DATABASE_URL = 'postgresql://gbrain-host/brain';
+    process.env.DATABASE_URL = 'postgresql://random-project-host/somedb';
+    expect(loadConfig()?.database_url).toBe('postgresql://gbrain-host/brain');
+    expect(getDbUrlSource()).toBe('env:GBRAIN_DATABASE_URL');
+  });
+
+  test('falls back to DATABASE_URL when no config file and no GBRAIN_DATABASE_URL', () => {
+    process.env.DATABASE_URL = 'postgresql://fallback-host/brain';
+    expect(loadConfig()?.database_url).toBe('postgresql://fallback-host/brain');
+    expect(getDbUrlSource()).toBe('env:DATABASE_URL');
+  });
+
+  test('returns null when no source provides a URL', () => {
+    expect(loadConfig()).toBeNull();
+    expect(getDbUrlSource()).toBeNull();
+  });
+
+  test('PGLite config-file-path is preserved when no URL anywhere', () => {
+    writeConfig({ engine: 'pglite', database_path: '/tmp/some-pglite' });
+    expect(loadConfig()?.database_path).toBe('/tmp/some-pglite');
+    expect(getDbUrlSource()).toBe('config-file-path');
   });
 });

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -46,11 +46,23 @@ describe('doctor command', () => {
 
   // Bug 7 — --fast should differentiate "no config anywhere" from "user
   // chose --fast with GBRAIN_DATABASE_URL / config-file URL present".
+  // GBRAIN_DATABASE_URL is the only env var that wins over a config file;
+  // generic DATABASE_URL is a last-resort fallback (see config.ts precedence).
   test('getDbUrlSource reflects GBRAIN_DATABASE_URL env var', async () => {
+    const { mkdtempSync, rmSync } = await import('fs');
+    const { tmpdir } = await import('os');
+    const { join } = await import('path');
     const { getDbUrlSource } = await import('../src/core/config.ts');
+
     const orig = process.env.GBRAIN_DATABASE_URL;
     const origAlt = process.env.DATABASE_URL;
+    const origHome = process.env.HOME;
+    // Isolate HOME so the user's real ~/.gbrain/config.json doesn't influence
+    // the assertion. Without this, the config-file URL beats DATABASE_URL.
+    const tmp = mkdtempSync(join(tmpdir(), 'gbrain-doctor-test-'));
+    process.env.HOME = tmp;
     try {
+      delete process.env.DATABASE_URL;
       process.env.GBRAIN_DATABASE_URL = 'postgresql://test@localhost/x';
       expect(getDbUrlSource()).toBe('env:GBRAIN_DATABASE_URL');
       delete process.env.GBRAIN_DATABASE_URL;
@@ -61,6 +73,9 @@ describe('doctor command', () => {
       else process.env.GBRAIN_DATABASE_URL = orig;
       if (origAlt === undefined) delete process.env.DATABASE_URL;
       else process.env.DATABASE_URL = origAlt;
+      if (origHome === undefined) delete process.env.HOME;
+      else process.env.HOME = origHome;
+      try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
     }
   });
 


### PR DESCRIPTION
## Summary

Running \`gbrain\` from inside an unrelated project (e.g. a Rails/FastAPI repo whose \`.env\` exports \`DATABASE_URL\`) silently hijacks the brain connection. Bun auto-loads \`.env\` from cwd, so \`process.env.DATABASE_URL\` is set to the host project's DB. Today's precedence is **env > config file**, so gbrain connects to the wrong DB and dies with:

\`\`\`
relation "pages" does not exist
\`\`\`

This PR reorders the precedence so the brain's own config wins over the generic env var, while still letting the explicit gbrain-targeted env var override:

1. \`GBRAIN_DATABASE_URL\` &nbsp;(explicit gbrain override)
2. \`~/.gbrain/config.json\` &nbsp;(the brain's own config)
3. \`DATABASE_URL\` &nbsp;(last-resort fallback when no config exists)

## Reproduction (before this change)

\`\`\`bash
cd ~/dev/some-fastapi-project   # has DATABASE_URL=postgresql://localhost/myapp in .env
gbrain doctor --fast
# → "URL present from env:DATABASE_URL"   ← wrong DB

gbrain embed --stale
# → relation "pages" does not exist
\`\`\`

After this change, \`doctor --fast\` reports \`URL present from config-file\` and embed runs against the correct gbrain DB.

## Why \`process.env.HOME || homedir()\`

Tests need to override HOME to a tmpdir so they don't read the developer's real \`~/.gbrain/config.json\`. Bun caches \`os.homedir()\` after first call, so mutating \`process.env.HOME\` mid-process doesn't propagate through \`homedir()\` alone. Switching to \`process.env.HOME || homedir()\` fixes that — and matches the pattern already used in \`src/core/preferences.ts\`.

## Test plan

- [x] \`bun test test/config.test.ts\` — 14 pass (6 new precedence tests)
- [x] \`bun test test/doctor.test.ts\` — 13 pass (existing \`getDbUrlSource\` test updated to isolate HOME)
- [x] \`bun test test/migrations-v0_13_1.test.ts test/init-migrate-only.test.ts test/migrations-v0_14_0.test.ts\` — 16 pass (other consumers of \`loadConfig\`)
- [x] Manual: \`gbrain doctor --fast\` and \`gbrain embed --stale\` from a project dir whose \`.env\` exports \`DATABASE_URL\` — both connect to the correct brain DB

## Files

- \`src/core/config.ts\` — precedence reorder + HOME-aware home() helper
- \`test/config.test.ts\` — 6 precedence tests
- \`test/doctor.test.ts\` — isolate HOME in existing test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->