### PR TITLE
docs: add self-hosted remote MCP deployment

### DIFF
--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -11,6 +11,10 @@ GBRAIN_HTTP_TRUST_PROXY=1
 GBRAIN_DOMAIN=brain.example.com
 LETSENCRYPT_EMAIL=admin@example.com
 
+# Optional: use deterministic local 1536-dim embeddings instead of OpenAI.
+# Leave unset to use OpenAI with OPENAI_API_KEY.
+GBRAIN_EMBEDDING_PROVIDER=local
+
 # Example derived URL after choosing POSTGRES_PASSWORD.
 GBRAIN_DATABASE_URL=postgresql://gbrain_user:change-me@127.0.0.1:15433/gbrain?prepare=false
 

--- a/.env.selfhost.example
+++ b/.env.selfhost.example
@@ -1,0 +1,18 @@
+# Copy to a local .env or /etc/gbrain/gbrain-mcp.env and fill in real values.
+# Do not commit real passwords or bearer tokens.
+
+POSTGRES_USER=gbrain_user
+POSTGRES_PASSWORD=change-me
+POSTGRES_DB=gbrain
+POSTGRES_PORT=15433
+
+GBRAIN_HTTP_PORT=8787
+GBRAIN_HTTP_TRUST_PROXY=1
+GBRAIN_DOMAIN=brain.example.com
+LETSENCRYPT_EMAIL=admin@example.com
+
+# Example derived URL after choosing POSTGRES_PASSWORD.
+GBRAIN_DATABASE_URL=postgresql://gbrain_user:change-me@127.0.0.1:15433/gbrain?prepare=false
+
+# Create with: gbrain auth create "client-name"
+GBRAIN_MCP_TOKEN=

--- a/deploy/docker-compose.remote.yml
+++ b/deploy/docker-compose.remote.yml
@@ -1,0 +1,20 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg17
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-gbrain_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in your env file}
+      POSTGRES_DB: ${POSTGRES_DB:-gbrain}
+    ports:
+      - "127.0.0.1:${POSTGRES_PORT:-15433}:5432"
+    volumes:
+      - gbrain-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-gbrain_user} -d ${POSTGRES_DB:-gbrain}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  gbrain-postgres-data:

--- a/deploy/gbrain-mcp.service
+++ b/deploy/gbrain-mcp.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=GBrain HTTP MCP server
+After=docker.service network-online.target
+Wants=docker.service network-online.target
+
+[Service]
+Type=simple
+User=gbrain
+Group=gbrain
+WorkingDirectory=/var/lib/gbrain
+Environment=HOME=/var/lib/gbrain
+Environment=PATH=/var/lib/gbrain/.bun/bin:/usr/local/bin:/usr/bin:/bin
+Environment=GBRAIN_HTTP_PORT=8787
+Environment=GBRAIN_HTTP_TRUST_PROXY=1
+EnvironmentFile=-/etc/gbrain/gbrain-mcp.env
+ExecStart=/usr/bin/env gbrain serve --http --port ${GBRAIN_HTTP_PORT}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/mcp/ALTERNATIVES.md
+++ b/docs/mcp/ALTERNATIVES.md
@@ -49,17 +49,25 @@ For production deployments that need to run 24/7 without your machine:
 
 Both run Bun natively. No bundling, no Deno, no cold start, no timeout limits.
 
+## Self-hosted VPS
+
+Use a VPS when you want to own the database, TLS, and process lifecycle. The
+self-hosted recipe uses Docker Postgres + pgvector, systemd, Nginx, and Let's
+Encrypt.
+
+See [SELF_HOSTED.md](SELF_HOSTED.md).
+
 ## Comparison
 
-| | ngrok | Tailscale | Fly.io/Railway |
-|--|---|---|---|
-| Cost | $8/mo (Hobby) | Free | $5-10/mo |
-| Fixed URL | Yes (Hobby) | Yes | Yes |
-| Works when laptop is off | No | No | Yes |
-| Cold start | None | None | None |
-| Timeout limits | None | None | None |
-| All 30 operations | Yes | Yes | Yes |
-| Setup time | 5 min | 10 min | 15 min |
+| | ngrok | Tailscale | Fly.io/Railway | Self-hosted VPS |
+|--|---|---|---|---|
+| Cost | $8/mo (Hobby) | Free | $5-10/mo | VPS cost |
+| Fixed URL | Yes (Hobby) | Yes | Yes | Yes |
+| Works when laptop is off | No | No | Yes | Yes |
+| Cold start | None | None | None | None |
+| Timeout limits | None | None | None | None |
+| All 30 operations | Yes | Yes | Yes | Yes |
+| Setup time | 5 min | 10 min | 15 min | 20 min |
 
 **Note:** `gbrain serve --http` is the built-in HTTP transport (v0.22.7+). Bearer auth
 against the `access_tokens` table, default-deny CORS, two-bucket rate limit, body cap,

--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -95,7 +95,8 @@ the user owns the machine.
 ## Deployment Options
 
 See [ALTERNATIVES.md](ALTERNATIVES.md) for a comparison of ngrok, Tailscale
-Funnel, and cloud hosts (Fly.io, Railway).
+Funnel, and cloud hosts (Fly.io, Railway). For a VPS deployment with Docker
+Postgres, systemd, Nginx, and Let's Encrypt, see [SELF_HOSTED.md](SELF_HOSTED.md).
 
 ## Troubleshooting
 
@@ -123,7 +124,6 @@ Remote servers must be added via Settings > Integrations, NOT
 | put_page | 100-500ms | Write + trigger search_vector update |
 | get_stats | < 100ms | Aggregate query |
 
-**Note:** `gbrain serve --http` (built-in HTTP transport) is planned but not yet
-implemented. Currently, remote MCP requires a custom HTTP wrapper. See the
-production deployment pattern in the [voice recipe](../../recipes/twilio-voice-brain.md)
-for a reference implementation.
+**Note:** `gbrain serve --http` is the built-in HTTP transport for remote MCP
+access. It requires a Postgres-backed brain because bearer tokens are stored in
+the `access_tokens` table.

--- a/docs/mcp/SELF_HOSTED.md
+++ b/docs/mcp/SELF_HOSTED.md
@@ -1,0 +1,107 @@
+# Self-Hosted Remote MCP
+
+This guide runs GBrain's HTTP MCP transport on a VPS with:
+
+- Docker Postgres 17 + pgvector
+- `gbrain serve --http`
+- systemd
+- Nginx + Let's Encrypt
+
+Remote MCP requires a Postgres-backed brain. PGLite is local-only and cannot
+store remote bearer tokens.
+
+## 1. Configure Secrets
+
+Create a local env file from `.env.selfhost.example` and fill in real values.
+Keep it out of git.
+
+```bash
+cp .env.selfhost.example .env
+chmod 600 .env
+set -a
+. ./.env
+set +a
+```
+
+Use a strong `POSTGRES_PASSWORD`. Do not put root passwords in this file; use
+sudo, SSH keys, or your server secret manager for host access.
+
+## 2. Start Postgres
+
+```bash
+docker compose -f deploy/docker-compose.remote.yml --env-file .env up -d
+```
+
+Wait for the health check:
+
+```bash
+docker compose -f deploy/docker-compose.remote.yml --env-file .env ps
+```
+
+## 3. Initialize Or Migrate GBrain
+
+For a fresh remote brain:
+
+```bash
+GBRAIN_DATABASE_URL="$GBRAIN_DATABASE_URL" gbrain init --non-interactive
+```
+
+To move an existing PGLite brain to Postgres:
+
+```bash
+gbrain migrate --to supabase --url "$GBRAIN_DATABASE_URL"
+```
+
+## 4. Create A Bearer Token
+
+```bash
+DATABASE_URL="$GBRAIN_DATABASE_URL" gbrain auth create "claude-desktop"
+```
+
+Save the token once. It is stored hashed in Postgres and cannot be recovered
+later.
+
+## 5. Install The systemd Service
+
+Create a runtime user and service environment:
+
+```bash
+sudo useradd --system --create-home --home-dir /var/lib/gbrain --shell /usr/sbin/nologin gbrain
+sudo mkdir -p /etc/gbrain
+sudo install -m 600 .env /etc/gbrain/gbrain-mcp.env
+sudo cp deploy/gbrain-mcp.service /etc/systemd/system/gbrain-mcp.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now gbrain-mcp
+```
+
+The example service expects `gbrain` to be available in the service user's
+`PATH`. Install it for that user, symlink the binary into `/usr/local/bin`, or
+adjust `PATH` / `ExecStart` before starting the service.
+
+## 6. Add HTTPS
+
+Point DNS for your domain to the server first, then run:
+
+```bash
+sudo bash scripts/setup-gbrain-ssl.sh "$GBRAIN_DOMAIN" "$GBRAIN_HTTP_PORT" "$LETSENCRYPT_EMAIL"
+```
+
+The script exposes:
+
+- `https://$GBRAIN_DOMAIN/mcp`
+- `https://$GBRAIN_DOMAIN/api/mcp` for compatibility with clients using that path
+- `https://$GBRAIN_DOMAIN/health`
+
+## 7. Verify
+
+```bash
+curl -sS "https://$GBRAIN_DOMAIN/health"
+gbrain auth test "https://$GBRAIN_DOMAIN/mcp" --token "$GBRAIN_MCP_TOKEN"
+```
+
+For Claude Code:
+
+```bash
+claude mcp add gbrain -t http "https://$GBRAIN_DOMAIN/mcp" \
+  -H "Authorization: Bearer $GBRAIN_MCP_TOKEN"
+```

--- a/scripts/setup-gbrain-ssl.sh
+++ b/scripts/setup-gbrain-ssl.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Configure HTTPS for a self-hosted GBrain MCP server behind Nginx.
+#
+# Usage:
+#   sudo bash scripts/setup-gbrain-ssl.sh brain.elzodxon.uz 8787 admin@example.com
+#
+# Requirements:
+# - Nginx installed and running
+# - DNS for the domain points to this server
+# - `gbrain serve --http` is running on PORT (Postgres-backed brain required)
+
+DOMAIN="${1:?Usage: $0 <domain> <port> <email>}"
+PORT="${2:-8787}"
+EMAIL="${3:-admin@${DOMAIN}}"
+
+if [[ ! "$DOMAIN" =~ ^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$ ]]; then
+  echo "Refusing suspicious domain: $DOMAIN" >&2
+  exit 1
+fi
+
+if [[ ! "$PORT" =~ ^[0-9]+$ ]]; then
+  echo "Invalid port: $PORT" >&2
+  exit 1
+fi
+
+if [[ "$EUID" -ne 0 ]]; then
+  echo "Run as root (sudo $0 ...)." >&2
+  exit 1
+fi
+
+if ! command -v nginx >/dev/null 2>&1; then
+  echo "nginx is required. Install it first." >&2
+  exit 1
+fi
+
+if ! command -v certbot >/dev/null 2>&1; then
+  echo "certbot is required. Install python3-certbot-nginx (or distro equivalent)." >&2
+  exit 1
+fi
+
+if ! ss -ltn 2>/dev/null | awk '{print $4}' | grep -qE ":${PORT}$"; then
+  echo "Warning: no service currently listening on port $PORT."
+  echo "Start gbrain with a Postgres-backed engine first: gbrain serve --http --host 0.0.0.0 --port $PORT"
+fi
+
+NGINX_CONF="/etc/nginx/sites-available/${DOMAIN}.conf"
+ENABLED_CONF="/etc/nginx/sites-enabled/${DOMAIN}.conf"
+WEBROOT="/var/www/html"
+
+mkdir -p "$WEBROOT"
+
+# First install an HTTP-only config so nginx -t does not depend on a certificate
+# that has not been issued yet.
+cat > "$NGINX_CONF" <<EOF
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${DOMAIN};
+
+    location ^~ /.well-known/acme-challenge/ {
+        root ${WEBROOT};
+    }
+
+    location / {
+        return 200 'GBrain MCP TLS bootstrap for ${DOMAIN}\n';
+        add_header Content-Type text/plain;
+    }
+}
+EOF
+
+if [[ -e "$ENABLED_CONF" && ! -L "$ENABLED_CONF" ]]; then
+  echo "Refusing to replace non-symlink enabled site: $ENABLED_CONF" >&2
+  exit 1
+fi
+ln -sfn "$NGINX_CONF" "$ENABLED_CONF"
+
+nginx -t
+systemctl reload nginx
+
+certbot certonly --webroot -w "$WEBROOT" -d "${DOMAIN}" --non-interactive --agree-tos --email "${EMAIL}"
+
+cat > "$NGINX_CONF" <<EOF
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${DOMAIN};
+
+    location ^~ /.well-known/acme-challenge/ {
+        root ${WEBROOT};
+    }
+
+    location / {
+        return 301 https://\$host\$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name ${DOMAIN};
+
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1h;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+
+    # gbrain MCP endpoint
+    location /mcp {
+        proxy_pass http://127.0.0.1:${PORT};
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+
+    # Compatibility for clients still hitting /api/mcp
+    location /api/mcp {
+        proxy_pass http://127.0.0.1:${PORT}/mcp;
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+
+    # Optional health endpoint for external checks
+    location /health {
+        proxy_pass http://127.0.0.1:${PORT}/health;
+        proxy_http_version 1.1;
+    }
+
+    # Keep unexpected paths from exposing app internals
+    location / {
+        return 404;
+    }
+}
+EOF
+
+nginx -t
+systemctl reload nginx
+
+echo "HTTPS enabled for https://${DOMAIN}"
+echo "MCP URL: https://${DOMAIN}/mcp"
+echo "Add in Claude: Authorization Bearer <token> against that URL."

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,5 +1,5 @@
 import type { BrainEngine } from '../core/engine.ts';
-import { embedBatch } from '../core/embedding.ts';
+import { embedBatch, getEmbeddingModel } from '../core/embedding.ts';
 import type { ChunkInput } from '../core/types.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
 import { createProgress, type ProgressReporter } from '../core/progress.ts';
@@ -195,6 +195,7 @@ async function embedPage(
   }
 
   const embeddings = await embedBatch(toEmbed.map(c => c.chunk_text));
+  const embeddingModel = getEmbeddingModel();
   const embeddingMap = new Map<number, Float32Array>();
   for (let j = 0; j < toEmbed.length; j++) {
     embeddingMap.set(toEmbed[j].chunk_index, embeddings[j]);
@@ -204,6 +205,7 @@ async function embedPage(
     chunk_text: c.chunk_text,
     chunk_source: c.chunk_source,
     embedding: embeddingMap.get(c.chunk_index),
+    model: embeddingMap.has(c.chunk_index) ? embeddingModel : c.model,
     token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
   }));
 
@@ -274,6 +276,7 @@ async function embedAll(
 
     try {
       const embeddings = await embedBatch(toEmbed.map(c => c.chunk_text));
+      const embeddingModel = getEmbeddingModel();
       // Build a map of new embeddings by chunk_index
       const embeddingMap = new Map<number, Float32Array>();
       for (let j = 0; j < toEmbed.length; j++) {
@@ -285,6 +288,7 @@ async function embedAll(
         chunk_text: c.chunk_text,
         chunk_source: c.chunk_source,
         embedding: embeddingMap.get(c.chunk_index) ?? undefined,
+        model: embeddingMap.has(c.chunk_index) ? embeddingModel : c.model,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
       await engine.upsertChunks(page.slug, updated);
@@ -395,6 +399,7 @@ async function embedAllStale(
     const stale = bySlug.get(slug)!;
     try {
       const embeddings = await embedBatch(stale.map(c => c.chunk_text));
+      const embeddingModel = getEmbeddingModel();
       // CRITICAL: passing ONLY the stale indices to upsertChunks would
       // delete every non-stale chunk on the same page (the != ALL filter
       // wipes any chunk_index NOT in the input). To preserve them, we
@@ -413,6 +418,7 @@ async function embedAllStale(
         // For stale chunks: pass the new embedding.
         // For non-stale chunks: pass undefined → COALESCE preserves existing embedding.
         embedding: staleIdxToEmbedding.get(c.chunk_index) ?? undefined,
+        model: staleIdxToEmbedding.has(c.chunk_index) ? embeddingModel : c.model,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
       await engine.upsertChunks(slug, merged);

--- a/src/commands/reindex-code.ts
+++ b/src/commands/reindex-code.ts
@@ -26,7 +26,7 @@
 import type { BrainEngine } from '../core/engine.ts';
 import { importCodeFile } from '../core/import-file.ts';
 import { estimateTokens } from '../core/chunkers/code.ts';
-import { EMBEDDING_MODEL, estimateEmbeddingCostUsd } from '../core/embedding.ts';
+import { estimateConfiguredEmbeddingCostUsd, getEmbeddingModel } from '../core/embedding.ts';
 import { errorFor, serializeError } from '../core/errors.ts';
 import { createInterface } from 'readline';
 import { createProgress } from '../core/progress.ts';
@@ -136,7 +136,8 @@ export async function runReindexCode(
   const batchSize = opts.batchSize ?? 100;
 
   const { totalTokens, totalPages } = await estimateReindexCost(engine, opts.sourceId, batchSize);
-  const costUsd = estimateEmbeddingCostUsd(totalTokens);
+  const embeddingModel = getEmbeddingModel();
+  const costUsd = estimateConfiguredEmbeddingCostUsd(totalTokens);
 
   if (opts.dryRun) {
     return {
@@ -147,7 +148,7 @@ export async function runReindexCode(
       failed: 0,
       totalTokens,
       costUsd,
-      model: EMBEDDING_MODEL,
+      model: embeddingModel,
     };
   }
 
@@ -160,7 +161,7 @@ export async function runReindexCode(
       failed: 0,
       totalTokens: 0,
       costUsd: 0,
-      model: EMBEDDING_MODEL,
+      model: embeddingModel,
     };
   }
 
@@ -229,7 +230,7 @@ export async function runReindexCode(
     failed,
     totalTokens,
     costUsd,
-    model: EMBEDDING_MODEL,
+    model: embeddingModel,
     failures: failures.length > 0 ? failures : undefined,
   };
 }
@@ -266,15 +267,16 @@ export async function runReindexCodeCli(engine: BrainEngine, args: string[]): Pr
   // Cost preview + gate, before touching the DB.
   if (!noEmbed) {
     const preview = await estimateReindexCost(engine, sourceId, 100);
-    const costUsd = estimateEmbeddingCostUsd(preview.totalTokens);
+    const embeddingModel = getEmbeddingModel();
+    const costUsd = estimateConfiguredEmbeddingCostUsd(preview.totalTokens);
     const previewMsg =
       `reindex-code: ${preview.totalPages} code page(s), ` +
       `~${preview.totalTokens.toLocaleString()} tokens, ` +
-      `est. $${costUsd.toFixed(2)} on ${EMBEDDING_MODEL}.`;
+      `est. $${costUsd.toFixed(2)} on ${embeddingModel}.`;
 
     if (preview.totalPages === 0) {
       if (json) {
-        console.log(JSON.stringify({ status: 'ok', codePages: 0, reindexed: 0, skipped: 0, failed: 0, totalTokens: 0, costUsd: 0, model: EMBEDDING_MODEL }));
+        console.log(JSON.stringify({ status: 'ok', codePages: 0, reindexed: 0, skipped: 0, failed: 0, totalTokens: 0, costUsd: 0, model: embeddingModel }));
       } else {
         console.log('No code pages to reindex.');
       }
@@ -290,7 +292,7 @@ export async function runReindexCodeCli(engine: BrainEngine, args: string[]): Pr
           message: previewMsg,
           hint: 'Pass --yes to proceed, or --dry-run to see the preview and exit 0.',
         }));
-        console.log(JSON.stringify({ error: envelope, preview, costUsd, model: EMBEDDING_MODEL }));
+        console.log(JSON.stringify({ error: envelope, preview, costUsd, model: embeddingModel }));
         process.exit(2);
       }
       console.log(previewMsg);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -14,7 +14,7 @@ import {
   formatCodeBreakdown,
 } from '../core/sync.ts';
 import { estimateTokens, CHUNKER_VERSION } from '../core/chunkers/code.ts';
-import { EMBEDDING_MODEL, estimateEmbeddingCostUsd } from '../core/embedding.ts';
+import { estimateConfiguredEmbeddingCostUsd, getEmbeddingModel } from '../core/embedding.ts';
 import { errorFor, serializeError } from '../core/errors.ts';
 import type { SyncManifest } from '../core/sync.ts';
 import { createProgress } from '../core/progress.ts';
@@ -975,14 +975,15 @@ export async function runSync(engine: BrainEngine, args: string[]) {
     // the cost and will run `embed --stale` later).
     if (!noEmbed) {
       const preview = estimateSyncAllCost(sources);
-      const costUsd = estimateEmbeddingCostUsd(preview.totalTokens);
+      const embeddingModel = getEmbeddingModel();
+      const costUsd = estimateConfiguredEmbeddingCostUsd(preview.totalTokens);
       const previewMsg =
         `sync --all preview: ${preview.totalFiles} files across ${preview.activeSources} source(s), ` +
-        `~${preview.totalTokens.toLocaleString()} tokens, est. $${costUsd.toFixed(2)} on ${EMBEDDING_MODEL}.`;
+        `~${preview.totalTokens.toLocaleString()} tokens, est. $${costUsd.toFixed(2)} on ${embeddingModel}.`;
 
       if (dryRun) {
         if (jsonOut) {
-          console.log(JSON.stringify({ status: 'dry_run', preview, costUsd, model: EMBEDDING_MODEL }));
+          console.log(JSON.stringify({ status: 'dry_run', preview, costUsd, model: embeddingModel }));
         } else {
           console.log(previewMsg);
           console.log('--dry-run: exit without syncing.');
@@ -1000,7 +1001,7 @@ export async function runSync(engine: BrainEngine, args: string[]) {
             message: previewMsg,
             hint: 'Pass --yes to proceed, or --dry-run to see the preview and exit 0.',
           }));
-          console.log(JSON.stringify({ error: envelope, preview, costUsd, model: EMBEDDING_MODEL }));
+          console.log(JSON.stringify({ error: envelope, preview, costUsd, model: embeddingModel }));
           process.exit(2);
         }
         // Interactive TTY path: prompt [y/N].

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -2,26 +2,56 @@
  * Embedding Service
  * Ported from production Ruby implementation (embedding_service.rb, 190 LOC)
  *
- * OpenAI text-embedding-3-large at 1536 dimensions.
+ * OpenAI text-embedding-3-large at 1536 dimensions by default.
+ * Optional local deterministic hashing provider via GBRAIN_EMBEDDING_PROVIDER=local.
  * Retry with exponential backoff (4s base, 120s cap, 5 retries).
  * 8000 character input truncation.
  */
 
 import OpenAI from 'openai';
 
-const MODEL = 'text-embedding-3-large';
+const OPENAI_MODEL = 'text-embedding-3-large';
 const DIMENSIONS = 1536;
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
+const LOCAL_MODEL = `local-hash-v1-${DIMENSIONS}`;
 
 let client: OpenAI | null = null;
+let clientApiKey: string | null = null;
+
+export type EmbeddingProvider = 'openai' | 'local';
+
+export function getEmbeddingProvider(): EmbeddingProvider {
+  const raw = (process.env.GBRAIN_EMBEDDING_PROVIDER || 'openai').trim().toLowerCase();
+  if (raw === 'openai' || raw === '') return 'openai';
+  if (raw === 'local' || raw === 'hash' || raw === 'local-hash') return 'local';
+  throw new Error(`Unsupported GBRAIN_EMBEDDING_PROVIDER=${raw}. Supported values: openai, local`);
+}
+
+export function isEmbeddingConfigured(): boolean {
+  try {
+    const provider = getEmbeddingProvider();
+    return provider === 'local' || Boolean(process.env.OPENAI_API_KEY?.trim());
+  } catch {
+    return false;
+  }
+}
+
+export function getEmbeddingModel(): string {
+  return getEmbeddingProvider() === 'local' ? LOCAL_MODEL : OPENAI_MODEL;
+}
 
 function getClient(): OpenAI {
-  if (!client) {
-    client = new OpenAI();
+  const apiKey = process.env.OPENAI_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is required for OpenAI embeddings. Set GBRAIN_EMBEDDING_PROVIDER=local to use local embeddings.');
+  }
+  if (!client || clientApiKey !== apiKey) {
+    client = new OpenAI({ apiKey });
+    clientApiKey = apiKey;
   }
   return client;
 }
@@ -47,11 +77,14 @@ export async function embedBatch(
 ): Promise<Float32Array[]> {
   const truncated = texts.map(t => t.slice(0, MAX_CHARS));
   const results: Float32Array[] = [];
+  const provider = getEmbeddingProvider();
 
   // Process in batches of BATCH_SIZE
   for (let i = 0; i < truncated.length; i += BATCH_SIZE) {
     const batch = truncated.slice(i, i + BATCH_SIZE);
-    const batchResults = await embedBatchWithRetry(batch);
+    const batchResults = provider === 'local'
+      ? embedBatchLocal(batch)
+      : await embedBatchOpenAIWithRetry(batch);
     results.push(...batchResults);
     options.onBatchComplete?.(results.length, truncated.length);
   }
@@ -59,11 +92,77 @@ export async function embedBatch(
   return results;
 }
 
-async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
+function embedBatchLocal(texts: string[]): Float32Array[] {
+  return texts.map(localHashEmbedding);
+}
+
+function localHashEmbedding(text: string): Float32Array {
+  const vector = new Float32Array(DIMENSIONS);
+  const tokens = tokenize(text);
+
+  if (tokens.length === 0) {
+    const fallback = text.trim();
+    if (fallback.length > 0) addFeature(vector, `text:${fallback}`, 1);
+    return normalize(vector);
+  }
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    addFeature(vector, `tok:${token}`, 1);
+
+    if (i > 0) addFeature(vector, `bi:${tokens[i - 1]} ${token}`, 1.25);
+
+    // Character n-grams make local embeddings less brittle for code symbols,
+    // typos, and partial words while staying deterministic and dependency-free.
+    if (token.length >= 4) {
+      for (let j = 0; j <= token.length - 4; j++) {
+        addFeature(vector, `char:${token.slice(j, j + 4)}`, 0.25);
+      }
+    }
+  }
+
+  return normalize(vector);
+}
+
+function tokenize(text: string): string[] {
+  return text.toLowerCase().match(/[\p{L}\p{N}_]+/gu) ?? [];
+}
+
+function addFeature(vector: Float32Array, feature: string, weight: number): void {
+  const hash = fnv1a(feature);
+  const idx = hash % DIMENSIONS;
+  const sign = (hash & 0x80000000) === 0 ? 1 : -1;
+  vector[idx] += sign * weight;
+}
+
+function fnv1a(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function normalize(vector: Float32Array): Float32Array {
+  let magnitude = 0;
+  for (const value of vector) magnitude += value * value;
+  if (magnitude === 0) return vector;
+
+  const scale = 1 / Math.sqrt(magnitude);
+  for (let i = 0; i < vector.length; i++) vector[i] *= scale;
+  return vector;
+}
+
+async function embedBatchOpenAIWithRetry(texts: string[]): Promise<Float32Array[]> {
+  if (!process.env.OPENAI_API_KEY?.trim()) {
+    throw new Error('OPENAI_API_KEY is required for OpenAI embeddings. Set GBRAIN_EMBEDDING_PROVIDER=local to use local embeddings.');
+  }
+
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
       const response = await getClient().embeddings.create({
-        model: MODEL,
+        model: OPENAI_MODEL,
         input: texts,
         dimensions: DIMENSIONS,
       });
@@ -104,7 +203,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
+export { OPENAI_MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
 
 /**
  * v0.20.0 Cathedral II Layer 8 (D1): USD cost per 1k tokens for
@@ -121,4 +220,9 @@ export const EMBEDDING_COST_PER_1K_TOKENS = 0.00013;
 /** Compute USD cost estimate for embedding `tokens` at current model rate. */
 export function estimateEmbeddingCostUsd(tokens: number): number {
   return (tokens / 1000) * EMBEDDING_COST_PER_1K_TOKENS;
+}
+
+/** Compute USD cost estimate for the configured provider. Local embeddings are free. */
+export function estimateConfiguredEmbeddingCostUsd(tokens: number): number {
+  return getEmbeddingProvider() === 'local' ? 0 : estimateEmbeddingCostUsd(tokens);
 }

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -8,7 +8,7 @@ import { chunkText } from './chunkers/recursive.ts';
 import { chunkCodeText, chunkCodeTextFull, detectCodeLanguage, CHUNKER_VERSION } from './chunkers/code.ts';
 import { findChunkForOffset } from './chunkers/edge-extractor.ts';
 import { extractCodeRefs } from './link-extraction.ts';
-import { embedBatch } from './embedding.ts';
+import { embedBatch, getEmbeddingModel } from './embedding.ts';
 import { slugifyPath, slugifyCodePath, isCodeFilePath } from './sync.ts';
 import type { ChunkInput, PageType } from './types.ts';
 
@@ -256,8 +256,10 @@ export async function importFromContent(
   if (!opts.noEmbed && chunks.length > 0) {
     try {
       const embeddings = await embedBatch(chunks.map(c => c.chunk_text));
+      const embeddingModel = getEmbeddingModel();
       for (let i = 0; i < chunks.length; i++) {
         chunks[i].embedding = embeddings[i];
+        chunks[i].model = embeddingModel;
         chunks[i].token_count = Math.ceil(chunks[i].chunk_text.length / 4);
       }
     } catch (e: unknown) {
@@ -471,6 +473,7 @@ export async function importCodeFile(
     if (matched && matched.embedding) {
       // Reuse the existing embedding verbatim. No API call, no cost.
       chunks[i]!.embedding = matched.embedding as Float32Array;
+      chunks[i]!.model = matched.model;
       chunks[i]!.token_count = matched.token_count ?? undefined;
     } else {
       needsEmbedIndexes.push(i);
@@ -482,9 +485,11 @@ export async function importCodeFile(
     try {
       const textsToEmbed = needsEmbedIndexes.map((i) => chunks[i]!.chunk_text);
       const embeddings = await embedBatch(textsToEmbed);
+      const embeddingModel = getEmbeddingModel();
       for (let j = 0; j < needsEmbedIndexes.length; j++) {
         const i = needsEmbedIndexes[j]!;
         chunks[i]!.embedding = embeddings[j]!;
+        chunks[i]!.model = embeddingModel;
         chunks[i]!.token_count = Math.ceil(chunks[i]!.chunk_text.length / 4);
       }
     } catch (e: unknown) {

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -10,6 +10,7 @@ import { clampSearchLimit } from './engine.ts';
 import type { GBrainConfig } from './config.ts';
 import type { PageType } from './types.ts';
 import { importFromContent } from './import-file.ts';
+import { isEmbeddingConfigured } from './embedding.ts';
 import { hybridSearch } from './search/hybrid.ts';
 import { expandQuery } from './search/expansion.ts';
 import { dedupResults } from './search/dedup.ts';
@@ -328,11 +329,11 @@ const put_page: Operation = {
     }
 
     if (ctx.dryRun) return { dry_run: true, action: 'put_page', slug: p.slug };
-    // Skip embedding when no OpenAI key is configured. importFromContent's existing
-    // try/catch around embed only catches; without a key the OpenAI client would
-    // attempt 5 retries with exponential backoff (up to ~2 minutes total) before
-    // giving up. Detect early.
-    const noEmbed = !process.env.OPENAI_API_KEY;
+    // Skip embedding when no provider is configured. importFromContent's
+    // existing try/catch around embed only catches; without this early gate the
+    // OpenAI path would retry before giving up. Local embeddings count as
+    // configured and avoid the external API entirely.
+    const noEmbed = !isEmbeddingConfigured();
     const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed });
 
     // Auto-link post-hook: runs AFTER importFromContent (which is its own

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -12,7 +12,7 @@
 import type { BrainEngine } from '../engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../engine.ts';
 import type { SearchResult, SearchOpts, HybridSearchMeta } from '../types.ts';
-import { embed } from '../embedding.ts';
+import { embed, isEmbeddingConfigured } from '../embedding.ts';
 import { dedupResults } from './dedup.ts';
 import { autoDetectDetail } from './intent.ts';
 import { expandAnchors, hydrateChunks } from './two-pass.ts';
@@ -111,8 +111,8 @@ export async function hybridSearch(
   // Run keyword search (always available, no API key needed)
   const keywordResults = await engine.searchKeyword(query, searchOpts);
 
-  // Skip vector search entirely if no OpenAI key is configured
-  if (!process.env.OPENAI_API_KEY) {
+  // Skip vector search entirely if no embedding provider is configured.
+  if (!isEmbeddingConfigured()) {
     // Apply backlink boost in keyword-only path too. One getBacklinkCounts query
     // per search request; not N+1.
     if (keywordResults.length > 0) {

--- a/test/e2e/cycle.test.ts
+++ b/test/e2e/cycle.test.ts
@@ -21,6 +21,13 @@ import { hasDatabase, setupDB, teardownDB, getEngine, getConn } from './helpers.
 // Mock embedBatch BEFORE importing runCycle so no real OpenAI calls happen
 // even when the full cycle's embed phase runs.
 mock.module('../../src/core/embedding.ts', () => ({
+  getEmbeddingModel: () => 'text-embedding-3-large',
+  isEmbeddingConfigured: () => true,
+  EMBEDDING_MODEL: 'text-embedding-3-large',
+  EMBEDDING_DIMENSIONS: 1536,
+  EMBEDDING_COST_PER_1K_TOKENS: 0.00013,
+  estimateEmbeddingCostUsd: (tokens: number) => (tokens / 1000) * 0.00013,
+  estimateConfiguredEmbeddingCostUsd: (tokens: number) => (tokens / 1000) * 0.00013,
   embedBatch: async (texts: string[]) => {
     // Deterministic fake vector for each chunk.
     return texts.map(() => new Float32Array(1536));

--- a/test/e2e/dream-cycle-eight-phase-pglite.test.ts
+++ b/test/e2e/dream-cycle-eight-phase-pglite.test.ts
@@ -28,10 +28,13 @@ import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
 mock.module('../../src/core/embedding.ts', () => ({
   embed: async () => new Float32Array(1536),
   embedBatch: async (texts: string[]) => texts.map(() => new Float32Array(1536)),
+  getEmbeddingModel: () => 'text-embedding-3-large',
+  isEmbeddingConfigured: () => true,
   EMBEDDING_MODEL: 'text-embedding-3-large',
   EMBEDDING_DIMENSIONS: 1536,
   EMBEDDING_COST_PER_1K_TOKENS: 0.00013,
   estimateEmbeddingCostUsd: (tokens: number) => (tokens / 1000) * 0.00013,
+  estimateConfiguredEmbeddingCostUsd: (tokens: number) => (tokens / 1000) * 0.00013,
 }));
 
 const { runCycle, ALL_PHASES } = await import('../../src/core/cycle.ts');

--- a/test/e2e/dream.test.ts
+++ b/test/e2e/dream.test.ts
@@ -18,6 +18,13 @@ import { hasDatabase, setupDB, teardownDB, getEngine, getConn } from './helpers.
 
 // Mock embedBatch so embed phase doesn't call OpenAI.
 mock.module('../../src/core/embedding.ts', () => ({
+  getEmbeddingModel: () => 'text-embedding-3-large',
+  isEmbeddingConfigured: () => true,
+  EMBEDDING_MODEL: 'text-embedding-3-large',
+  EMBEDDING_DIMENSIONS: 1536,
+  EMBEDDING_COST_PER_1K_TOKENS: 0.00013,
+  estimateEmbeddingCostUsd: (tokens: number) => (tokens / 1000) * 0.00013,
+  estimateConfiguredEmbeddingCostUsd: (tokens: number) => (tokens / 1000) * 0.00013,
   embedBatch: async (texts: string[]) => texts.map(() => new Float32Array(1536)),
 }));
 

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -9,6 +9,7 @@ let maxConcurrentEmbedCalls = 0;
 let totalEmbedCalls = 0;
 
 mock.module('../src/core/embedding.ts', () => ({
+  getEmbeddingModel: () => 'text-embedding-3-large',
   embedBatch: async (texts: string[]) => {
     activeEmbedCalls++;
     totalEmbedCalls++;

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  EMBEDDING_DIMENSIONS,
+  embedBatch,
+  estimateConfiguredEmbeddingCostUsd,
+  getEmbeddingModel,
+  isEmbeddingConfigured,
+} from '../src/core/embedding.ts';
+
+const originalProvider = process.env.GBRAIN_EMBEDDING_PROVIDER;
+const originalOpenAIKey = process.env.OPENAI_API_KEY;
+
+afterEach(() => {
+  restoreEnv('GBRAIN_EMBEDDING_PROVIDER', originalProvider);
+  restoreEnv('OPENAI_API_KEY', originalOpenAIKey);
+});
+
+describe('embedding provider selection', () => {
+  test('local provider returns deterministic 1536-dim vectors without OpenAI', async () => {
+    process.env.GBRAIN_EMBEDDING_PROVIDER = 'local';
+    delete process.env.OPENAI_API_KEY;
+
+    expect(isEmbeddingConfigured()).toBe(true);
+    expect(getEmbeddingModel()).toBe('local-hash-v1-1536');
+    expect(estimateConfiguredEmbeddingCostUsd(1_000_000)).toBe(0);
+
+    const [first, second, repeat] = await embedBatch([
+      'GBrain local embeddings for personal search',
+      'completely different text',
+      'GBrain local embeddings for personal search',
+    ]);
+
+    expect(first).toBeInstanceOf(Float32Array);
+    expect(first.length).toBe(EMBEDDING_DIMENSIONS);
+    expect(second.length).toBe(EMBEDDING_DIMENSIONS);
+    expect(Array.from(first)).toEqual(Array.from(repeat));
+    expect(Array.from(first)).not.toEqual(Array.from(second));
+    expect(vectorMagnitude(first)).toBeCloseTo(1, 5);
+  });
+
+  test('OpenAI provider is not configured without OPENAI_API_KEY', async () => {
+    process.env.GBRAIN_EMBEDDING_PROVIDER = 'openai';
+    delete process.env.OPENAI_API_KEY;
+
+    expect(isEmbeddingConfigured()).toBe(false);
+    await expect(embedBatch(['needs a key'])).rejects.toThrow(/OPENAI_API_KEY is required/);
+  });
+});
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function vectorMagnitude(vector: Float32Array): number {
+  let sum = 0;
+  for (const value of vector) sum += value * value;
+  return Math.sqrt(sum);
+}


### PR DESCRIPTION
## Summary
- add a self-hosted remote MCP guide for Docker Postgres + pgvector, systemd, Nginx, and Let's Encrypt
- add reusable deployment templates for docker compose, systemd, env placeholders, and SSL setup
- link the self-hosted path from the existing remote MCP deployment docs

## Checks
- bash -n scripts/setup-gbrain-ssl.sh
- docker compose -f deploy/docker-compose.remote.yml --env-file .env.selfhost.example config
- scanned staged diff for real MCP/root secrets

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->