### PR TITLE
[codex] support OpenAI API key files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ gbrain import ~/notes/          # index your markdown
 gbrain query "what themes show up across my notes?"
 ```
 
+For embeddings and hybrid/vector search, GBrain keeps the existing
+`OPENAI_API_KEY` behavior. If you run GBrain inside a broader agent harness and
+do not want that key in the parent process environment, set
+`OPENAI_API_KEY_FILE=/path/to/openai-key.env` instead. The file may contain
+either a raw key or an env-style `OPENAI_API_KEY=...` line; GBrain reads it
+internally without writing the key back to `process.env`.
+
 **Do NOT use `bun install -g github:garrytan/gbrain`.** Bun blocks the top-level
 postinstall hook on global installs, so schema migrations never run and the CLI
 aborts with `Aborted()` the first time it opens PGLite. Use `git clone + bun install

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -157,7 +157,7 @@ RRF fusion, multi-query expansion, and 4-layer dedup are engine-agnostic. They o
 **PGLite-specific details:**
 - Uses `pglite-schema.ts` for DDL (pgvector extension, pg_trgm, triggers, indexes)
 - Parameterized queries throughout (shared utilities in `src/core/utils.ts`)
-- `hybridSearch` keyword-only fallback when `OPENAI_API_KEY` is not set
+- `hybridSearch` keyword-only fallback when neither `OPENAI_API_KEY` nor `OPENAI_API_KEY_FILE` is set
 - Data stored at `~/.gbrain/brain.db` (configurable)
 - pgvector HNSW index for cosine similarity vector search (same as Postgres)
 - tsvector + ts_rank for full-text search (same as Postgres)

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -136,11 +136,16 @@ export function readOpenAIApiKeyFile(path: string | undefined): string | undefin
   return firstRawValue;
 }
 
-export function resolveOpenAIApiKey(config: GBrainConfig | null = loadConfig()): string | undefined {
-  return process.env.OPENAI_API_KEY
-    || readOpenAIApiKeyFile(process.env.OPENAI_API_KEY_FILE)
-    || config?.openai_api_key
-    || readOpenAIApiKeyFile(config?.openai_api_key_file);
+export function resolveOpenAIApiKey(config?: GBrainConfig | null): string | undefined {
+  const envKey = process.env.OPENAI_API_KEY;
+  if (envKey) return envKey;
+
+  const envFileKey = readOpenAIApiKeyFile(process.env.OPENAI_API_KEY_FILE);
+  if (envFileKey) return envFileKey;
+
+  const resolvedConfig = config === undefined ? loadConfig() : config;
+  return resolvedConfig?.openai_api_key
+    || readOpenAIApiKeyFile(resolvedConfig?.openai_api_key_file);
 }
 
 export function hasOpenAIApiKey(config?: GBrainConfig | null): boolean {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, mkdirSync, chmodSync, existsSync } from 'fs';
-import { join } from 'path';
+import { isAbsolute, join, resolve } from 'path';
 import { homedir } from 'os';
 import type { EngineConfig } from './types.ts';
 
@@ -30,6 +30,7 @@ export interface GBrainConfig {
   database_url?: string;
   database_path?: string;
   openai_api_key?: string;
+  openai_api_key_file?: string;
   anthropic_api_key?: string;
   /**
    * Optional storage backend config (S3/Supabase/local). Shape matches
@@ -78,8 +79,72 @@ export function loadConfig(): GBrainConfig | null {
     engine: inferredEngine,
     ...(dbUrl ? { database_url: dbUrl } : {}),
     ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
+    ...(process.env.OPENAI_API_KEY_FILE ? { openai_api_key_file: process.env.OPENAI_API_KEY_FILE } : {}),
   };
   return merged as GBrainConfig;
+}
+
+function expandUserPath(path: string): string {
+  if (path === '~') return homedir();
+  if (path.startsWith('~/')) return join(homedir(), path.slice(2));
+  return path;
+}
+
+function resolveKeyFilePath(path: string): string {
+  const expanded = expandUserPath(path.trim());
+  return isAbsolute(expanded) ? expanded : resolve(expanded);
+}
+
+function unquoteEnvValue(value: string): string {
+  const trimmed = value.trim();
+  if (
+    trimmed.length >= 2
+    && ((trimmed.startsWith('"') && trimmed.endsWith('"'))
+      || (trimmed.startsWith("'") && trimmed.endsWith("'")))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+export function readOpenAIApiKeyFile(path: string | undefined): string | undefined {
+  if (!path || !path.trim()) return undefined;
+
+  let raw: string;
+  try {
+    raw = readFileSync(resolveKeyFilePath(path), 'utf-8');
+  } catch {
+    return undefined;
+  }
+
+  let firstRawValue: string | undefined;
+  for (const originalLine of raw.split(/\r?\n/)) {
+    const trimmed = originalLine.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const line = trimmed.startsWith('export ') ? trimmed.slice('export '.length).trim() : trimmed;
+    const eq = line.indexOf('=');
+    if (eq > 0) {
+      const key = line.slice(0, eq).trim();
+      const value = unquoteEnvValue(line.slice(eq + 1));
+      if (key === 'OPENAI_API_KEY' && value) return value;
+    } else if (!firstRawValue) {
+      firstRawValue = unquoteEnvValue(trimmed);
+    }
+  }
+
+  return firstRawValue;
+}
+
+export function resolveOpenAIApiKey(config: GBrainConfig | null = loadConfig()): string | undefined {
+  return process.env.OPENAI_API_KEY
+    || readOpenAIApiKeyFile(process.env.OPENAI_API_KEY_FILE)
+    || config?.openai_api_key
+    || readOpenAIApiKeyFile(config?.openai_api_key_file);
+}
+
+export function hasOpenAIApiKey(config?: GBrainConfig | null): boolean {
+  return !!resolveOpenAIApiKey(config);
 }
 
 export function saveConfig(config: GBrainConfig): void {

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -8,6 +8,7 @@
  */
 
 import OpenAI from 'openai';
+import { resolveOpenAIApiKey } from './config.ts';
 
 const MODEL = 'text-embedding-3-large';
 const DIMENSIONS = 1536;
@@ -21,7 +22,7 @@ let client: OpenAI | null = null;
 
 function getClient(): OpenAI {
   if (!client) {
-    client = new OpenAI();
+    client = new OpenAI({ apiKey: resolveOpenAIApiKey() });
   }
   return client;
 }

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -7,7 +7,7 @@ import { lstatSync, realpathSync } from 'fs';
 import { resolve, relative, sep } from 'path';
 import type { BrainEngine } from './engine.ts';
 import { clampSearchLimit } from './engine.ts';
-import type { GBrainConfig } from './config.ts';
+import { hasOpenAIApiKey, type GBrainConfig } from './config.ts';
 import type { PageType } from './types.ts';
 import { importFromContent } from './import-file.ts';
 import { hybridSearch } from './search/hybrid.ts';
@@ -332,7 +332,7 @@ const put_page: Operation = {
     // try/catch around embed only catches; without a key the OpenAI client would
     // attempt 5 retries with exponential backoff (up to ~2 minutes total) before
     // giving up. Detect early.
-    const noEmbed = !process.env.OPENAI_API_KEY;
+    const noEmbed = !hasOpenAIApiKey();
     const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed });
 
     // Auto-link post-hook: runs AFTER importFromContent (which is its own

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -332,7 +332,7 @@ const put_page: Operation = {
     // try/catch around embed only catches; without a key the OpenAI client would
     // attempt 5 retries with exponential backoff (up to ~2 minutes total) before
     // giving up. Detect early.
-    const noEmbed = !hasOpenAIApiKey();
+    const noEmbed = !hasOpenAIApiKey(ctx.config);
     const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed });
 
     // Auto-link post-hook: runs AFTER importFromContent (which is its own
@@ -701,6 +701,7 @@ const query: Operation = {
       symbolKind: (p.symbol_kind as string) || undefined,
       nearSymbol: (p.near_symbol as string) || undefined,
       walkDepth: typeof p.walk_depth === 'number' ? (p.walk_depth as number) : undefined,
+      config: ctx.config,
       onMeta: (m) => { capturedMeta = m; },
     });
     const latency_ms = Date.now() - startedAt;

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -13,6 +13,7 @@ import type { BrainEngine } from '../engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../engine.ts';
 import type { SearchResult, SearchOpts, HybridSearchMeta } from '../types.ts';
 import { embed } from '../embedding.ts';
+import { hasOpenAIApiKey } from '../config.ts';
 import { dedupResults } from './dedup.ts';
 import { autoDetectDetail } from './intent.ts';
 import { expandAnchors, hydrateChunks } from './two-pass.ts';
@@ -112,7 +113,7 @@ export async function hybridSearch(
   const keywordResults = await engine.searchKeyword(query, searchOpts);
 
   // Skip vector search entirely if no OpenAI key is configured
-  if (!process.env.OPENAI_API_KEY) {
+  if (!hasOpenAIApiKey()) {
     // Apply backlink boost in keyword-only path too. One getBacklinkCounts query
     // per search request; not N+1.
     if (keywordResults.length > 0) {

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -13,7 +13,7 @@ import type { BrainEngine } from '../engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../engine.ts';
 import type { SearchResult, SearchOpts, HybridSearchMeta } from '../types.ts';
 import { embed } from '../embedding.ts';
-import { hasOpenAIApiKey } from '../config.ts';
+import { hasOpenAIApiKey, type GBrainConfig } from '../config.ts';
 import { dedupResults } from './dedup.ts';
 import { autoDetectDetail } from './intent.ts';
 import { expandAnchors, hydrateChunks } from './two-pass.ts';
@@ -48,6 +48,12 @@ export function applyBacklinkBoost(results: SearchResult[], counts: Map<string, 
 
 export interface HybridSearchOpts extends SearchOpts {
   expansion?: boolean;
+  /**
+   * Already-loaded file/env config from the operation layer. Passing this keeps
+   * hybridSearch from re-reading config.json on every hot-path query when env
+   * vars are absent.
+   */
+  config?: GBrainConfig | null;
   expandFn?: (query: string) => Promise<string[]>;
   /** Override default RRF K constant (default: 60). Lower values boost top-ranked results more. */
   rrfK?: number;
@@ -113,7 +119,7 @@ export async function hybridSearch(
   const keywordResults = await engine.searchKeyword(query, searchOpts);
 
   // Skip vector search entirely if no OpenAI key is configured
-  if (!hasOpenAIApiKey()) {
+  if (!hasOpenAIApiKey(opts?.config)) {
     // Apply backlink boost in keyword-only path too. One getBacklinkCounts query
     // per search request; not N+1.
     if (keywordResults.length > 0) {

--- a/src/core/transcription.ts
+++ b/src/core/transcription.ts
@@ -8,6 +8,7 @@
 
 import { statSync, readFileSync } from 'fs';
 import { basename, extname } from 'path';
+import { resolveOpenAIApiKey } from './config.ts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -88,14 +89,14 @@ export async function transcribe(
 
 function detectProvider(): 'groq' | 'openai' {
   if (process.env.GROQ_API_KEY) return 'groq';
-  if (process.env.OPENAI_API_KEY) return 'openai';
+  if (resolveOpenAIApiKey()) return 'openai';
   return 'groq'; // default, will fail with clear error if no key
 }
 
 function getApiKey(provider: string): string | undefined {
   switch (provider) {
     case 'groq': return process.env.GROQ_API_KEY;
-    case 'openai': return process.env.OPENAI_API_KEY;
+    case 'openai': return resolveOpenAIApiKey();
     case 'deepgram': return process.env.DEEPGRAM_API_KEY;
     default: return undefined;
   }

--- a/test/hybrid-meta.test.ts
+++ b/test/hybrid-meta.test.ts
@@ -20,6 +20,7 @@ import type { PageInput, HybridSearchMeta } from '../src/core/types.ts';
 
 let engine: PGLiteEngine;
 const savedKey = process.env.OPENAI_API_KEY;
+const savedKeyFile = process.env.OPENAI_API_KEY_FILE;
 
 beforeAll(async () => {
   engine = new PGLiteEngine();
@@ -36,6 +37,8 @@ beforeAll(async () => {
 afterAll(async () => {
   if (savedKey === undefined) delete process.env.OPENAI_API_KEY;
   else process.env.OPENAI_API_KEY = savedKey;
+  if (savedKeyFile === undefined) delete process.env.OPENAI_API_KEY_FILE;
+  else process.env.OPENAI_API_KEY_FILE = savedKeyFile;
   await engine.disconnect();
 });
 
@@ -48,6 +51,7 @@ async function runWithMeta(query: string, opts: Parameters<typeof hybridSearch>[
 describe('hybridSearch return shape (v0.25.0 keeps SearchResult[])', () => {
   test('returns SearchResult[] (unchanged from Cathedral II contract)', async () => {
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY_FILE;
     const out = await hybridSearch(engine, 'alice');
     expect(Array.isArray(out)).toBe(true);
   });
@@ -56,6 +60,7 @@ describe('hybridSearch return shape (v0.25.0 keeps SearchResult[])', () => {
 describe('hybridSearch onMeta callback — vector_enabled', () => {
   test('false when OPENAI_API_KEY is missing (keyword-only path)', async () => {
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY_FILE;
     const meta = await runWithMeta('alice');
     expect(meta).not.toBeNull();
     expect(meta!.vector_enabled).toBe(false);
@@ -65,12 +70,14 @@ describe('hybridSearch onMeta callback — vector_enabled', () => {
 describe('hybridSearch onMeta callback — detail_resolved', () => {
   test('passes through explicit detail override (caller specified "high")', async () => {
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY_FILE;
     const meta = await runWithMeta('alice', { detail: 'high' });
     expect(meta!.detail_resolved).toBe('high');
   });
 
   test('detail_resolved reflects autoDetect output when caller omits detail', async () => {
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY_FILE;
     const meta = await runWithMeta('alice');
     expect([null, 'low', 'medium', 'high']).toContain(meta!.detail_resolved);
   });
@@ -79,12 +86,14 @@ describe('hybridSearch onMeta callback — detail_resolved', () => {
 describe('hybridSearch onMeta callback — expansion_applied', () => {
   test('false when expansion flag is off', async () => {
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY_FILE;
     const meta = await runWithMeta('alice', { expansion: false });
     expect(meta!.expansion_applied).toBe(false);
   });
 
   test('false when OPENAI_API_KEY missing (early-return short-circuits expansion)', async () => {
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY_FILE;
     const meta = await runWithMeta('alice', {
       expansion: true,
       expandFn: async () => ['alice', 'alice example', 'the person alice'],
@@ -96,6 +105,7 @@ describe('hybridSearch onMeta callback — expansion_applied', () => {
 describe('onMeta callback omitted', () => {
   test('hybridSearch works without onMeta (existing Cathedral II callers unaffected)', async () => {
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY_FILE;
     const out = await hybridSearch(engine, 'alice');
     expect(Array.isArray(out)).toBe(true);
   });

--- a/test/mcp-eval-capture.test.ts
+++ b/test/mcp-eval-capture.test.ts
@@ -24,9 +24,11 @@ import type { PageInput } from '../src/core/types.ts';
 
 let engine: PGLiteEngine;
 const savedKey = process.env.OPENAI_API_KEY;
+const savedKeyFile = process.env.OPENAI_API_KEY_FILE;
 
 beforeAll(async () => {
   delete process.env.OPENAI_API_KEY; // force keyword-only path so tests don't need live credentials
+  delete process.env.OPENAI_API_KEY_FILE;
   engine = new PGLiteEngine();
   await engine.connect({});
   await engine.initSchema();
@@ -41,6 +43,8 @@ beforeAll(async () => {
 afterAll(async () => {
   if (savedKey === undefined) delete process.env.OPENAI_API_KEY;
   else process.env.OPENAI_API_KEY = savedKey;
+  if (savedKeyFile === undefined) delete process.env.OPENAI_API_KEY_FILE;
+  else process.env.OPENAI_API_KEY_FILE = savedKeyFile;
   await engine.disconnect();
 });
 

--- a/test/openai-key-config.test.ts
+++ b/test/openai-key-config.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { readOpenAIApiKeyFile, resolveOpenAIApiKey } from '../src/core/config.ts';
+
+const savedEnv = {
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  OPENAI_API_KEY_FILE: process.env.OPENAI_API_KEY_FILE,
+  GBRAIN_HOME: process.env.GBRAIN_HOME,
+};
+
+let tmp: string | null = null;
+
+function restoreEnv(key: keyof typeof savedEnv) {
+  const value = savedEnv[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+beforeEach(() => {
+  tmp = null;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_API_KEY_FILE;
+  delete process.env.GBRAIN_HOME;
+});
+
+afterEach(() => {
+  restoreEnv('OPENAI_API_KEY');
+  restoreEnv('OPENAI_API_KEY_FILE');
+  restoreEnv('GBRAIN_HOME');
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+});
+
+function makeTmpDir(): string {
+  tmp = tmp || mkdtempSync(join(tmpdir(), 'gbrain-openai-key-'));
+  return tmp;
+}
+
+describe('OpenAI API key file support', () => {
+  test('reads raw key files', () => {
+    const dir = makeTmpDir();
+    const keyFile = join(dir, 'openai-key');
+    writeFileSync(keyFile, 'sk-test-raw\n');
+
+    expect(readOpenAIApiKeyFile(keyFile)).toBe('sk-test-raw');
+  });
+
+  test('reads env-style key files without mutating process.env', () => {
+    const dir = makeTmpDir();
+    const keyFile = join(dir, 'openai-key.env');
+    writeFileSync(keyFile, '# local key\nexport OPENAI_API_KEY="sk-test-env-file"\n');
+
+    process.env.OPENAI_API_KEY_FILE = keyFile;
+
+    expect(resolveOpenAIApiKey()).toBe('sk-test-env-file');
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+  });
+
+  test('uses OPENAI_API_KEY before OPENAI_API_KEY_FILE for compatibility', () => {
+    const dir = makeTmpDir();
+    const keyFile = join(dir, 'openai-key.env');
+    writeFileSync(keyFile, 'OPENAI_API_KEY=sk-test-file\n');
+
+    process.env.OPENAI_API_KEY = 'sk-test-env';
+    process.env.OPENAI_API_KEY_FILE = keyFile;
+
+    expect(resolveOpenAIApiKey()).toBe('sk-test-env');
+  });
+
+  test('uses config openai_api_key_file when env vars are absent', () => {
+    const dir = makeTmpDir();
+    const gbrainDir = join(dir, '.gbrain');
+    const keyFile = join(dir, 'openai-key.env');
+    mkdirSync(gbrainDir, { recursive: true });
+    writeFileSync(keyFile, "OPENAI_API_KEY='sk-test-config-file'\n");
+    writeFileSync(join(gbrainDir, 'config.json'), JSON.stringify({
+      engine: 'pglite',
+      database_path: join(dir, 'brain.pglite'),
+      openai_api_key_file: keyFile,
+    }));
+
+    process.env.GBRAIN_HOME = dir;
+
+    expect(resolveOpenAIApiKey()).toBe('sk-test-config-file');
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+  });
+});

--- a/test/openai-key-config.test.ts
+++ b/test/openai-key-config.test.ts
@@ -68,6 +68,24 @@ describe('OpenAI API key file support', () => {
     expect(resolveOpenAIApiKey()).toBe('sk-test-env');
   });
 
+  test('does not load config before returning OPENAI_API_KEY', () => {
+    process.env.OPENAI_API_KEY = 'sk-test-env';
+    process.env.GBRAIN_HOME = 'relative-path-would-throw-if-loaded';
+
+    expect(resolveOpenAIApiKey()).toBe('sk-test-env');
+  });
+
+  test('does not load config before returning OPENAI_API_KEY_FILE', () => {
+    const dir = makeTmpDir();
+    const keyFile = join(dir, 'openai-key.env');
+    writeFileSync(keyFile, 'OPENAI_API_KEY=sk-test-file\n');
+
+    process.env.OPENAI_API_KEY_FILE = keyFile;
+    process.env.GBRAIN_HOME = 'relative-path-would-throw-if-loaded';
+
+    expect(resolveOpenAIApiKey()).toBe('sk-test-file');
+  });
+
   test('uses config openai_api_key_file when env vars are absent', () => {
     const dir = makeTmpDir();
     const gbrainDir = join(dir, '.gbrain');

--- a/test/openai-key-config.test.ts
+++ b/test/openai-key-config.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { readOpenAIApiKeyFile, resolveOpenAIApiKey } from '../src/core/config.ts';
+import { hasOpenAIApiKey, readOpenAIApiKeyFile, resolveOpenAIApiKey } from '../src/core/config.ts';
 
 const savedEnv = {
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
@@ -102,5 +102,12 @@ describe('OpenAI API key file support', () => {
 
     expect(resolveOpenAIApiKey()).toBe('sk-test-config-file');
     expect(process.env.OPENAI_API_KEY).toBeUndefined();
+  });
+
+  test('uses provided config without loading config.json', () => {
+    process.env.GBRAIN_HOME = 'relative-path-would-throw-if-loaded';
+
+    expect(resolveOpenAIApiKey({ engine: 'pglite', openai_api_key: 'sk-test-config' })).toBe('sk-test-config');
+    expect(hasOpenAIApiKey({ engine: 'pglite', openai_api_key: 'sk-test-config' })).toBe(true);
   });
 });

--- a/test/openai-key-hotpath.test.ts
+++ b/test/openai-key-hotpath.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { operationsByName, type OperationContext } from '../src/core/operations.ts';
+
+const savedEnv = {
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  OPENAI_API_KEY_FILE: process.env.OPENAI_API_KEY_FILE,
+  GBRAIN_HOME: process.env.GBRAIN_HOME,
+};
+
+function restoreEnv(key: keyof typeof savedEnv) {
+  const value = savedEnv[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+beforeEach(() => {
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_API_KEY_FILE;
+  process.env.GBRAIN_HOME = 'relative-path-would-throw-if-loaded';
+});
+
+afterEach(() => {
+  restoreEnv('OPENAI_API_KEY');
+  restoreEnv('OPENAI_API_KEY_FILE');
+  restoreEnv('GBRAIN_HOME');
+});
+
+async function makeContext(): Promise<{ ctx: OperationContext; engine: PGLiteEngine }> {
+  const engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  const ctx: OperationContext = {
+    engine,
+    config: { engine: 'pglite' },
+    logger: console,
+    dryRun: false,
+    remote: true,
+  };
+  return { ctx, engine };
+}
+
+describe('OpenAI API key hot-path config reuse', () => {
+  test('query reuses ctx.config instead of loading config.json', async () => {
+    const { ctx, engine } = await makeContext();
+    try {
+      await engine.putPage('people/alice-example', {
+        type: 'person',
+        title: 'Alice Example',
+        compiled_truth: 'Alice Example is a test person.',
+      });
+
+      const out = await operationsByName.query.handler(ctx, { query: 'alice', limit: 5 });
+      expect(Array.isArray(out)).toBe(true);
+    } finally {
+      await engine.disconnect();
+    }
+  });
+
+  test('put_page reuses ctx.config instead of loading config.json', async () => {
+    const { ctx, engine } = await makeContext();
+    try {
+      const out = await operationsByName.put_page.handler(ctx, {
+        slug: 'notes/hotpath-config-reuse',
+        content: '# Hotpath Config Reuse\n\nThis write should skip embedding without loading config.json.',
+      });
+
+      expect(out).toMatchObject({ slug: 'notes/hotpath-config-reuse' });
+    } finally {
+      await engine.disconnect();
+    }
+  });
+});

--- a/test/transcription.test.ts
+++ b/test/transcription.test.ts
@@ -35,8 +35,10 @@ describe('transcription', () => {
     const { transcribe } = await import('../src/core/transcription.ts');
     const groq = process.env.GROQ_API_KEY;
     const openai = process.env.OPENAI_API_KEY;
+    const openaiFile = process.env.OPENAI_API_KEY_FILE;
     delete process.env.GROQ_API_KEY;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY_FILE;
 
     try {
       await transcribe(TMP_MP3, {});
@@ -47,6 +49,7 @@ describe('transcription', () => {
     } finally {
       if (groq) process.env.GROQ_API_KEY = groq;
       if (openai) process.env.OPENAI_API_KEY = openai;
+      if (openaiFile) process.env.OPENAI_API_KEY_FILE = openaiFile;
     }
   });
 


### PR DESCRIPTION
## Summary

- Add `OPENAI_API_KEY_FILE` and `openai_api_key_file` support for OpenAI-backed GBrain paths.
- Read raw-key or env-style key files internally without writing the key into `process.env`.
- Route embeddings, hybrid search gating, `put_page` auto-embedding, and OpenAI transcription through the shared key resolver.
- Document the key-file option for agent harnesses where the parent process should not inherit `OPENAI_API_KEY`.

Fixes #569.

## Why

Agent harnesses may use OAuth or another auth path for their own OpenAI-backed tooling. Requiring `OPENAI_API_KEY` in the parent environment can cause unrelated tools or subagents to pick up API-key auth. This keeps existing env-var behavior but lets users scope the API key to GBrain without mutating global process env.

## Validation

- `bun test test/openai-key-config.test.ts test/hybrid-meta.test.ts test/mcp-eval-capture.test.ts test/transcription.test.ts --timeout=60000`
- `bun run typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->