### PR TITLE
fix(orphans): route through engine.executeRaw for PGLite support

### DIFF
--- a/src/commands/orphans.ts
+++ b/src/commands/orphans.ts
@@ -13,7 +13,6 @@
  */
 
 import type { BrainEngine } from '../core/engine.ts';
-import * as db from '../core/db.ts';
 
 // --- Types ---
 
@@ -98,11 +97,10 @@ export function deriveDomain(frontmatterDomain: string | null | undefined, slug:
 
 /**
  * Find pages with no inbound links.
- * Returns raw rows from the DB (all pages regardless of filter).
+ * Returns raw rows from the engine (all pages regardless of filter).
  */
-export async function queryOrphanPages(): Promise<{ slug: string; title: string; domain: string | null }[]> {
-  const sql = db.getConnection();
-  const rows = await sql`
+export async function queryOrphanPages(engine: BrainEngine): Promise<{ slug: string; title: string; domain: string | null }[]> {
+  return engine.executeRaw<{ slug: string; title: string; domain: string | null }>(`
     SELECT
       p.slug,
       COALESCE(p.title, p.slug) AS title,
@@ -112,22 +110,19 @@ export async function queryOrphanPages(): Promise<{ slug: string; title: string;
       SELECT 1 FROM links l WHERE l.to_page_id = p.id
     )
     ORDER BY p.slug
-  `;
-  return rows as { slug: string; title: string; domain: string | null }[];
+  `);
 }
 
 /**
  * Find orphan pages, with optional pseudo-page filtering.
  * Returns structured OrphanResult with totals.
  */
-export async function findOrphans(includePseudo: boolean = false): Promise<OrphanResult> {
-  const allOrphans = await queryOrphanPages();
-  const totalPages = allOrphans.length; // pages with no inbound links
+export async function findOrphans(engine: BrainEngine, includePseudo: boolean = false): Promise<OrphanResult> {
+  const allOrphans = await queryOrphanPages(engine);
 
   // Count total pages in DB for the summary line
-  const sql = db.getConnection();
-  const [{ count: totalPagesCount }] = await sql`SELECT count(*)::int AS count FROM pages`;
-  const total = Number(totalPagesCount);
+  const totalRows = await engine.executeRaw<{ count: number | string }>(`SELECT count(*)::int AS count FROM pages`);
+  const total = Number(totalRows[0]?.count ?? 0);
 
   const filtered = includePseudo
     ? allOrphans
@@ -189,7 +184,7 @@ export function formatOrphansText(result: OrphanResult): string {
 
 // --- CLI entry point ---
 
-export async function runOrphans(_engine: BrainEngine, args: string[]) {
+export async function runOrphans(engine: BrainEngine, args: string[]) {
   const json = args.includes('--json');
   const count = args.includes('--count');
   const includePseudo = args.includes('--include-pseudo');
@@ -211,7 +206,7 @@ Summary line: N orphans out of M linkable pages (K total; K-M excluded)
     return;
   }
 
-  const result = await findOrphans(includePseudo);
+  const result = await findOrphans(engine, includePseudo);
 
   if (count) {
     console.log(String(result.total_orphans));


### PR DESCRIPTION
## Summary

`gbrain orphans` errors with `No database connection: connect() has not been called` on every PGLite brain, even when `gbrain stats`, `ask`, and `extract` all work fine on the same brain.

Root cause: `orphans.ts` calls `db.getConnection()` directly — the singleton populated by `db.connect()` in `core/db.ts`. That singleton is only populated by `PostgresEngine`; `PGLiteEngine` keeps its connection on the engine instance and never touches the singleton, so the orphans query never finds a connection.

## Fix

Route the two SQL queries through `engine.executeRaw<T>(sql, params?)` instead. Both `PostgresEngine` and `PGLiteEngine` already implement `executeRaw` on the `BrainEngine` interface, so this reuses the existing abstraction without adding new methods.

`runOrphans` already received the connected `engine` from `cli.ts` but was ignoring it (`_engine`); the patch threads it through `findOrphans` → `queryOrphanPages`.

## Verification

On a 983-page PGLite brain (the case that previously errored):

- `gbrain orphans --count` → `901`
- `gbrain orphans --json` returns the full grouped list
- `bun test test/orphans.test.ts` → 31 pass / 0 fail

The pure helper tests (`shouldExclude`, `deriveDomain`, `formatOrphansText`) continue to pass unchanged.

## Test plan

- [ ] Reviewer confirms `gbrain orphans` now works on a PGLite brain
- [ ] Reviewer confirms behavior is unchanged on a Postgres/Supabase brain (same SQL, just routed through the engine instead of the global singleton)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->