### PR TITLE
feat: page versioning, soft deletes, and read audit (provenance & derivative state)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror']);
+const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'history', 'revert', 'resurrect', 'purge', 'audit']);
 
 async function main() {
   // Parse global flags (--quiet / --progress-json / --progress-interval)
@@ -249,9 +249,16 @@ function formatResult(opName: string, result: unknown): string {
     case 'get_versions': {
       const versions = result as any[];
       if (versions.length === 0) return 'No versions.\n';
-      return versions.map(v =>
-        `#${v.id}  ${v.snapshot_at?.toString().slice(0, 19) || '?'}  ${v.compiled_truth?.slice(0, 60) || ''}...`,
-      ).join('\n') + '\n';
+      return versions.map(v => {
+        const kind = v.kind ? ` [${v.kind}]` : '';
+        const prov = v.provenance?.source ? ` <${v.provenance.source}>` : '';
+        return `#${v.id}  ${v.snapshot_at?.toString().slice(0, 19) || '?'}${kind}${prov}  ${v.compiled_truth?.slice(0, 60) || ''}...`;
+      }).join('\n') + '\n';
+    }
+    case 'revert_version': {
+      const r = result as { status?: string; hint?: string; slug?: string; version_id?: number };
+      if (r.hint) return `${r.status ?? 'ok'} ${r.slug ?? ''} #${r.version_id ?? ''}\n${r.hint}\n`;
+      return JSON.stringify(result, null, 2) + '\n';
     }
     default:
       return JSON.stringify(result, null, 2) + '\n';
@@ -590,6 +597,31 @@ async function handleCliOnly(command: string, args: string[]) {
         await runSources(engine, args);
         break;
       }
+      case 'history': {
+        const { runHistoryCmd } = await import('./commands/page-history.ts');
+        await runHistoryCmd(engine, args);
+        break;
+      }
+      case 'revert': {
+        const { runRevertCmd } = await import('./commands/page-history.ts');
+        await runRevertCmd(engine, args);
+        break;
+      }
+      case 'resurrect': {
+        const { runResurrectCmd } = await import('./commands/page-history.ts');
+        await runResurrectCmd(engine, args);
+        break;
+      }
+      case 'purge': {
+        const { runPurgeCmd } = await import('./commands/page-history.ts');
+        await runPurgeCmd(engine, args);
+        break;
+      }
+      case 'audit': {
+        const { runAudit } = await import('./commands/audit.ts');
+        await runAudit(engine, args);
+        break;
+      }
     }
   } finally {
     if (command !== 'serve') await engine.disconnect();
@@ -741,8 +773,11 @@ JOBS (Minions)
 ADMIN
   stats                              Brain statistics
   health                             Brain health dashboard
-  history <slug>                     Page version history
+  history <slug> [--diff|--prune ...] Page version history
   revert <slug> <version-id>         Revert to version
+  resurrect <slug>                   Undelete tombstoned page
+  purge <slug> [--yes]               Hard-delete page + history (local only)
+  audit reads|prune                  Read MCP audit (eval_candidates read tools)
   features [--json] [--auto-fix]     Scan usage + recommend unused features
   autopilot [--repo] [--interval N]  Self-maintaining brain daemon
   config [show|get|set] <key> [val]  Brain config

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,0 +1,157 @@
+import type { BrainEngine } from '../core/engine.ts';
+import type { EvalCaptureToolName, EvalCandidate } from '../core/types.ts';
+
+const READ_TOOLS = new Set<EvalCaptureToolName>([
+  'get_page',
+  'list_pages',
+  'traverse_graph',
+  'get_links',
+  'get_backlinks',
+  'get_timeline',
+  'get_tags',
+  'find_orphans',
+  'resolve_slugs',
+  'get_chunks',
+]);
+
+function parseDurationMs(s: string): number | null {
+  const m = s.match(/^(\d+)\s*(ms|s|m|h|d|w)$/i);
+  if (!m) return null;
+  const n = parseInt(m[1]!, 10);
+  const u = m[2]!.toLowerCase();
+  if (u === 'ms') return n;
+  if (u === 's') return n * 1000;
+  if (u === 'm') return n * 60_000;
+  if (u === 'h') return n * 3_600_000;
+  if (u === 'd') return n * 86_400_000;
+  return n * 7 * 86_400_000;
+}
+
+function printHelpReads(): void {
+  process.stderr.write(`gbrain audit reads — browse captured read/query/search audit rows
+
+USAGE:
+  gbrain audit reads [--since DUR] [--slug HINT] [--tool NAME] [--token NAME]
+                    [--limit N] [--include-query-search] [--json]
+
+FLAGS:
+  --since DUR         Only rows newer than now - DUR (default 24h).
+  --slug HINT          Substring match on query text or params_jsonb (ILIKE).
+  --tool NAME          eval_candidates.tool_name filter.
+  --token NAME         mcp_token_name equals this value (exact).
+  --limit N           Max rows (default 500, max 100000).
+  --include-query-search  Include query + search rows (default: reads only).
+  --json               JSON array output.
+`);
+}
+
+function printHelpPrune(): void {
+  process.stderr.write(`gbrain audit prune — delete old read-audit rows (not query/search)
+
+USAGE:
+  gbrain audit prune --older-than DUR [--dry-run]
+
+Requires --older-than. Does not delete tool_name query or search rows.
+Use \`gbrain eval prune\` to prune retrieval rows only.
+`);
+}
+
+export async function runAudit(engine: BrainEngine, args: string[]): Promise<void> {
+  const sub = args[0];
+  const rest = args.slice(1);
+  if (sub === 'reads') {
+    if (rest.includes('--help') || rest.includes('-h')) {
+      printHelpReads();
+      return;
+    }
+    const json = rest.includes('--json');
+    let sinceMs = 24 * 3_600_000;
+    const si = rest.indexOf('--since');
+    if (si >= 0 && rest[si + 1]) {
+      const ms = parseDurationMs(rest[si + 1]);
+      if (ms === null) {
+        console.error(`Invalid --since: ${rest[si + 1]}`);
+        process.exit(1);
+      }
+      sinceMs = ms;
+    }
+    const slugHint = (() => {
+      const i = rest.indexOf('--slug');
+      return i >= 0 ? rest[i + 1] : undefined;
+    })();
+    const tool = (() => {
+      const i = rest.indexOf('--tool');
+      return i >= 0 ? (rest[i + 1] as EvalCaptureToolName) : undefined;
+    })();
+    const token = (() => {
+      const i = rest.indexOf('--token');
+      return i >= 0 ? rest[i + 1] : undefined;
+    })();
+    const actor = (() => {
+      const i = rest.indexOf('--actor');
+      return i >= 0 ? rest[i + 1] : undefined;
+    })();
+    const includeQS = rest.includes('--include-query-search');
+    let limit = 500;
+    const li = rest.indexOf('--limit');
+    if (li >= 0 && rest[li + 1]) limit = Math.min(100000, Math.max(1, Number(rest[li + 1])));
+
+    const since = new Date(Date.now() - sinceMs);
+    const rowsAll = await engine.listEvalCandidates({
+      since,
+      limit,
+      tool,
+      slugHint,
+      mcpTokenName: token,
+    });
+
+    let rows: EvalCandidate[] = rowsAll;
+    if (!includeQS) {
+      rows = rows.filter(r => READ_TOOLS.has(r.tool_name));
+    }
+    if (actor) {
+      rows = rows.filter(r => {
+        const pj = JSON.stringify(r.params_jsonb ?? {});
+        return pj.includes(actor) || (r.query && r.query.includes(actor));
+      });
+    }
+
+    if (json) {
+      process.stdout.write(JSON.stringify(rows, null, 2) + '\n');
+      return;
+    }
+    for (const r of rows) {
+      const ts = r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at);
+      process.stdout.write(
+        `${ts}\t${r.tool_name}\t${r.remote ? 'remote' : 'local'}\t${r.mcp_token_name ?? '-'}\t${(r.query ?? '').slice(0, 80)}\n`,
+      );
+    }
+    return;
+  }
+
+  if (sub === 'prune') {
+    if (rest.includes('--help') || rest.includes('-h')) {
+      printHelpPrune();
+      return;
+    }
+    let olderMs: number | null = null;
+    const oi = rest.indexOf('--older-than');
+    if (oi >= 0 && rest[oi + 1]) olderMs = parseDurationMs(rest[oi + 1]);
+    if (olderMs === null) {
+      console.error('audit prune requires --older-than DUR (e.g. 30d)');
+      process.exit(1);
+    }
+    const dry = rest.includes('--dry-run');
+    const cutoff = new Date(Date.now() - olderMs);
+    if (dry) {
+      process.stdout.write(JSON.stringify({ dry_run: true, cutoff: cutoff.toISOString(), read_tools_only: true }, null, 2) + '\n');
+      return;
+    }
+    const n = await engine.deleteEvalCandidatesBefore(cutoff, { readToolsOnly: true });
+    process.stdout.write(`Deleted ${n} read-audit row(s) older than ${cutoff.toISOString()}.\n`);
+    return;
+  }
+
+  console.error('Usage: gbrain audit reads | gbrain audit prune');
+  process.exit(1);
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -771,6 +771,58 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
     }
   }
 
+  progress.heartbeat('page_versions_health');
+  try {
+    const orphanRows = await engine.executeRaw<{ c: string | number }>(
+      `SELECT COUNT(*)::int AS c FROM page_versions pv
+       WHERE pv.page_id IS NOT NULL
+         AND NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = pv.page_id)`,
+    );
+    const orphanPv = Number(orphanRows[0]?.c ?? 0);
+
+    const tombRows = await engine.executeRaw<{ c: string | number }>(
+      `SELECT COUNT(*)::int AS c FROM page_versions
+       WHERE kind = 'delete' AND snapshot_at < now() - interval '90 days'`,
+    );
+    const oldTomb = Number(tombRows[0]?.c ?? 0);
+
+    const cntRows = await engine.executeRaw<{ pv: string | number; pg: string | number }>(
+      `SELECT
+         (SELECT COUNT(*)::int FROM page_versions) AS pv,
+         (SELECT COUNT(*)::int FROM pages WHERE deleted_at IS NULL) AS pg`,
+    );
+    const pv = Number(cntRows[0]?.pv ?? 0);
+    const pg = Number(cntRows[0]?.pg ?? 0);
+    const ratio = pg > 0 ? pv / pg : 0;
+
+    const parts: string[] = [];
+    if (orphanPv > 0) parts.push(`${orphanPv} orphaned version row(s)`);
+    if (oldTomb > 0) parts.push(`${oldTomb} delete tombstone(s) older than 90d`);
+    if (pv > 100_000) parts.push(`page_versions=${pv}`);
+    else if (ratio > 500 && pg > 0) parts.push(`high version churn (versions/pages=${ratio.toFixed(0)})`);
+
+    if (parts.length === 0) {
+      checks.push({ name: 'page_versions_health', status: 'ok', message: 'No versioning growth concerns' });
+    } else {
+      checks.push({
+        name: 'page_versions_health',
+        status: 'warn',
+        message: `${parts.join('; ')}. Run \`gbrain history prune\` or investigate.`,
+      });
+    }
+  } catch (err) {
+    const code = (err as { code?: string } | null)?.code;
+    if (code === '42P01') {
+      checks.push({ name: 'page_versions_health', status: 'ok', message: 'Skipped (page_versions unavailable)' });
+    } else {
+      checks.push({
+        name: 'page_versions_health',
+        status: 'warn',
+        message: `Could not check page_versions: ${(err as Error)?.message ?? String(err)}`,
+      });
+    }
+  }
+
   // 11b. Queue health (v0.19.1 queue-resilience wave).
   // Postgres-only because PGLite has no multi-process worker surface. Two
   // subchecks, both cheap (single SELECT each, status-index-covered):

--- a/src/commands/migrate-engine.ts
+++ b/src/commands/migrate-engine.ts
@@ -120,7 +120,7 @@ export async function runMigrateEngine(sourceEngine: BrainEngine, args: string[]
     // Delete all pages (cascades to chunks, links, tags, etc.)
     const pages = await targetEngine.listPages({ limit: 100000 });
     for (const p of pages) {
-      await targetEngine.deletePage(p.slug);
+      await targetEngine.purgePage(p.slug);
     }
   }
 
@@ -141,7 +141,7 @@ export async function runMigrateEngine(sourceEngine: BrainEngine, args: string[]
 
   // Get all source pages
   const sourceStats = await sourceEngine.getStats();
-  const allPages = await sourceEngine.listPages({ limit: 100000 });
+  const allPages = await sourceEngine.listPages({ limit: 100000, includeDeleted: true });
   const pagesToMigrate = allPages.filter(p => !completedSet.has(p.slug));
 
   console.log(`Migrating ${pagesToMigrate.length} pages (${allPages.length} total, ${completedSet.size} already done)...`);
@@ -160,6 +160,14 @@ export async function runMigrateEngine(sourceEngine: BrainEngine, args: string[]
       frontmatter: page.frontmatter,
       content_hash: page.content_hash,
     });
+
+    if (page.deleted_at) {
+      const d = page.deleted_at instanceof Date ? page.deleted_at.toISOString() : String(page.deleted_at);
+      await targetEngine.executeRaw(
+        `UPDATE pages SET deleted_at = $1::timestamptz WHERE slug = $2`,
+        [d, page.slug],
+      );
+    }
 
     // Copy chunks with embeddings
     const chunks = await sourceEngine.getChunksWithEmbeddings(page.slug);
@@ -197,10 +205,30 @@ export async function runMigrateEngine(sourceEngine: BrainEngine, args: string[]
       await targetEngine.putRawData(page.slug, rd.source, rd.data);
     }
 
-    // Copy versions
-    const versions = await sourceEngine.getVersions(page.slug);
-    // Versions are snapshots, we recreate them on the target
-    // (createVersion takes a snapshot of current state, which we just set)
+    const versionsSrc = await sourceEngine.getVersions(page.slug, { includeDeletedPage: true });
+    const targetRow = await targetEngine.getPage(page.slug, { includeDeleted: true });
+    if (targetRow && versionsSrc.length > 0) {
+      for (const v of versionsSrc) {
+        const fm = typeof v.frontmatter === 'object' ? JSON.stringify(v.frontmatter ?? {}) : String(v.frontmatter ?? '{}');
+        const prov = typeof v.provenance === 'object' ? JSON.stringify(v.provenance ?? {}) : String(v.provenance ?? '{}');
+        const snap = v.snapshot_at instanceof Date ? v.snapshot_at.toISOString() : String(v.snapshot_at);
+        await targetEngine.executeRaw(
+          `INSERT INTO page_versions (page_id, source_id, slug, compiled_truth, frontmatter, tags, kind, provenance, snapshot_at)
+           VALUES ($1::int, $2, $3, $4, $5::jsonb, $6, $7, $8::jsonb, $9::timestamptz)`,
+          [
+            targetRow.id,
+            v.source_id,
+            v.slug,
+            v.compiled_truth,
+            fm,
+            v.tags,
+            v.kind,
+            prov,
+            snap,
+          ],
+        );
+      }
+    }
 
     // Track progress
     manifest!.completed_slugs.push(page.slug);

--- a/src/commands/page-history.ts
+++ b/src/commands/page-history.ts
@@ -1,0 +1,223 @@
+import type { BrainEngine } from '../core/engine.ts';
+import type { PageVersion } from '../core/types.ts';
+
+function parseDuration(input: string): Date {
+  const m = /^(\d+)\s*(s|m|h|d|w)$/i.exec(input.trim());
+  if (!m) throw new Error(`Invalid duration "${input}". Use e.g. 30d, 2h, 90m, 60s.`);
+  const n = Number(m[1]);
+  const unit = m[2].toLowerCase();
+  const seconds = unit === 's' ? n
+    : unit === 'm' ? n * 60
+    : unit === 'h' ? n * 3600
+    : unit === 'd' ? n * 86400
+    : n * 7 * 86400;
+  return new Date(Date.now() - seconds * 1000);
+}
+
+function diffArrays(a: string[], b: string[]): { added: string[]; removed: string[] } {
+  const sa = new Set(a);
+  const sb = new Set(b);
+  return {
+    added: b.filter(x => !sa.has(x)),
+    removed: a.filter(x => !sb.has(x)),
+  };
+}
+
+function diffObjects(a: Record<string, unknown>, b: Record<string, unknown>): {
+  added: Record<string, unknown>;
+  removed: Record<string, unknown>;
+  changed: Record<string, { from: unknown; to: unknown }>;
+} {
+  const added: Record<string, unknown> = {};
+  const removed: Record<string, unknown> = {};
+  const changed: Record<string, { from: unknown; to: unknown }> = {};
+  for (const k of Object.keys(a)) {
+    if (!(k in b)) removed[k] = a[k];
+    else if (JSON.stringify(a[k]) !== JSON.stringify(b[k])) changed[k] = { from: a[k], to: b[k] };
+  }
+  for (const k of Object.keys(b)) {
+    if (!(k in a)) added[k] = b[k];
+  }
+  return { added, removed, changed };
+}
+
+function unifiedDiff(from: string, to: string): string {
+  const a = from.split('\n');
+  const b = to.split('\n');
+  const out: string[] = [];
+  const max = Math.max(a.length, b.length);
+  for (let i = 0; i < max; i++) {
+    const left = a[i];
+    const right = b[i];
+    if (left === right) continue;
+    if (left !== undefined) out.push(`- ${left}`);
+    if (right !== undefined) out.push(`+ ${right}`);
+  }
+  return out.join('\n');
+}
+
+function printVersions(slug: string, versions: PageVersion[], json: boolean) {
+  if (json) {
+    process.stdout.write(JSON.stringify(versions, null, 2) + '\n');
+    return;
+  }
+  if (versions.length === 0) {
+    process.stdout.write(`No history for ${slug}.\n`);
+    return;
+  }
+  for (const v of versions) {
+    const ts = v.snapshot_at instanceof Date ? v.snapshot_at.toISOString() : String(v.snapshot_at);
+    const prov = v.provenance && (v.provenance as { source?: string }).source
+      ? ` <${(v.provenance as { source?: string }).source}>`
+      : '';
+    process.stdout.write(`#${v.id}\t${ts}\t[${v.kind}]${prov}\t${v.compiled_truth.slice(0, 60).replace(/\n/g, ' ')}\n`);
+  }
+}
+
+export async function runHistoryCmd(engine: BrainEngine, args: string[]): Promise<void> {
+  const json = args.includes('--json');
+  const includeOrphan = args.includes('--include-orphan');
+  const positional = args.filter(a => !a.startsWith('--'));
+  const sub = positional[0];
+
+  if (sub === 'prune') {
+    const slugIdx = args.indexOf('--slug');
+    const slug = slugIdx >= 0 ? args[slugIdx + 1] : undefined;
+    const keepIdx = args.indexOf('--keep-last');
+    const keepLast = keepIdx >= 0 ? Number(args[keepIdx + 1]) : undefined;
+    const olderIdx = args.indexOf('--older-than');
+    const olderThan = olderIdx >= 0 ? parseDuration(args[olderIdx + 1]) : undefined;
+    const dryRun = args.includes('--dry-run');
+
+    if (keepLast === undefined && olderThan === undefined) {
+      throw new Error('history prune requires --keep-last N or --older-than DUR.');
+    }
+    if (keepLast !== undefined && (!Number.isFinite(keepLast) || keepLast < 0)) {
+      throw new Error('--keep-last must be a non-negative integer.');
+    }
+    if (keepLast !== undefined && !slug) {
+      throw new Error('--keep-last requires --slug to scope the prune.');
+    }
+
+    if (dryRun) {
+      const out = {
+        dry_run: true,
+        slug: slug ?? null,
+        keep_last: keepLast,
+        older_than: olderThan?.toISOString() ?? null,
+        global_older_than: slug ? false : !!olderThan,
+      };
+      process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+      return;
+    }
+    const removed = await engine.prunePageVersions({ slug, keepLast, olderThan });
+    process.stdout.write(json ? JSON.stringify({ removed }, null, 2) + '\n' : `Removed ${removed} version(s).\n`);
+    return;
+  }
+
+  const slug = positional[0];
+  if (!slug) {
+    throw new Error('Usage: gbrain history <slug> [--include-orphan] [--diff <from> <to>] [--json]\n       gbrain history prune [--slug X] [--keep-last N | --older-than DUR] [--dry-run]');
+  }
+
+  const diffIdx = args.indexOf('--diff');
+  if (diffIdx >= 0) {
+    const fromV = Number(args[diffIdx + 1]);
+    const toV = Number(args[diffIdx + 2]);
+    if (!Number.isFinite(fromV) || !Number.isFinite(toV)) {
+      throw new Error('--diff requires two numeric version ids: --diff <from> <to>');
+    }
+    const diff = await engine.diffPageVersions(slug, fromV, toV);
+    if (json) {
+      process.stdout.write(JSON.stringify(diff, null, 2) + '\n');
+      return;
+    }
+    process.stdout.write(`# diff ${slug} #${fromV} → #${toV}\n\n`);
+    const ct = unifiedDiff(diff.compiled_truth.from, diff.compiled_truth.to);
+    if (ct) {
+      process.stdout.write('## compiled_truth\n');
+      process.stdout.write(ct + '\n\n');
+    } else {
+      process.stdout.write('## compiled_truth: unchanged\n\n');
+    }
+    const fmDiff = diffObjects(diff.frontmatter.from, diff.frontmatter.to);
+    if (Object.keys(fmDiff.added).length || Object.keys(fmDiff.removed).length || Object.keys(fmDiff.changed).length) {
+      process.stdout.write('## frontmatter\n');
+      for (const [k, v] of Object.entries(fmDiff.added)) process.stdout.write(`+ ${k}: ${JSON.stringify(v)}\n`);
+      for (const [k, v] of Object.entries(fmDiff.removed)) process.stdout.write(`- ${k}: ${JSON.stringify(v)}\n`);
+      for (const [k, v] of Object.entries(fmDiff.changed)) process.stdout.write(`~ ${k}: ${JSON.stringify(v.from)} → ${JSON.stringify(v.to)}\n`);
+      process.stdout.write('\n');
+    } else {
+      process.stdout.write('## frontmatter: unchanged\n\n');
+    }
+    const tagDiff = diffArrays(diff.tags.from, diff.tags.to);
+    if (tagDiff.added.length || tagDiff.removed.length) {
+      process.stdout.write('## tags\n');
+      for (const t of tagDiff.added) process.stdout.write(`+ ${t}\n`);
+      for (const t of tagDiff.removed) process.stdout.write(`- ${t}\n`);
+    } else {
+      process.stdout.write('## tags: unchanged\n');
+    }
+    return;
+  }
+
+  const versions = await engine.getVersions(slug, { includeDeletedPage: includeOrphan });
+  printVersions(slug, versions, json);
+}
+
+export async function runResurrectCmd(engine: BrainEngine, args: string[]): Promise<void> {
+  const slug = args.find(a => !a.startsWith('--'));
+  const json = args.includes('--json');
+  if (!slug) throw new Error('Usage: gbrain resurrect <slug>');
+  const existing = await engine.getPage(slug, { includeDeleted: true });
+  if (!existing) {
+    throw new Error(`Page not found: ${slug}`);
+  }
+  if (!existing.deleted_at) {
+    const out = { status: 'already_active', slug };
+    process.stdout.write(json ? JSON.stringify(out, null, 2) + '\n' : `Page ${slug} is already active.\n`);
+    return;
+  }
+  await engine.resurrectSoftDeletedPage(slug);
+  await engine.createVersion(slug, {
+    kind: 'update',
+    provenance: { source: 'cli_resurrect' },
+  });
+  const out = { status: 'resurrected', slug };
+  process.stdout.write(json ? JSON.stringify(out, null, 2) + '\n' : `Resurrected ${slug}.\n`);
+}
+
+export async function runPurgeCmd(engine: BrainEngine, args: string[]): Promise<void> {
+  const slug = args.find(a => !a.startsWith('--'));
+  const json = args.includes('--json');
+  const yes = args.includes('--yes') || args.includes('-y');
+  if (!slug) throw new Error('Usage: gbrain purge <slug> --yes');
+  if (!yes) {
+    throw new Error(`Refusing to hard-delete ${slug} without --yes. Use \`gbrain delete <slug>\` for soft delete.`);
+  }
+  await engine.purgePage(slug);
+  const out = { status: 'purged', slug };
+  process.stdout.write(json ? JSON.stringify(out, null, 2) + '\n' : `Purged ${slug} (history removed).\n`);
+}
+
+export async function runRevertCmd(engine: BrainEngine, args: string[]): Promise<void> {
+  const positional = args.filter(a => !a.startsWith('--'));
+  const json = args.includes('--json');
+  const dryRun = args.includes('--dry-run');
+  const slug = positional[0];
+  const versionId = Number(positional[1]);
+  if (!slug || !Number.isFinite(versionId)) {
+    throw new Error('Usage: gbrain revert <slug> <version-id> [--dry-run] [--json]');
+  }
+  if (dryRun) {
+    const out = { dry_run: true, slug, version_id: versionId };
+    process.stdout.write(json ? JSON.stringify(out, null, 2) + '\n' : `Would revert ${slug} to version #${versionId}.\n`);
+    return;
+  }
+  await engine.revertToVersion(slug, versionId, {
+    provenance: { source: 'cli_revert', target_version_id: versionId },
+  });
+  const hint = `Run \`gbrain extract --slugs ${slug} && gbrain embed --stale --slugs ${slug}\` to refresh derived state.`;
+  const out = { status: 'reverted', slug, version_id: versionId, hint };
+  process.stdout.write(json ? JSON.stringify(out, null, 2) + '\n' : `Reverted ${slug} to version #${versionId}.\n${hint}\n`);
+}

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -434,7 +434,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     try {
       const existing = await engine.getPage(slug);
       if (existing) {
-        await engine.deletePage(slug);
+        await engine.purgePage(slug);
         console.log(`  Deleted un-syncable page: ${slug}`);
       }
     } catch { /* ignore */ }
@@ -500,7 +500,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     progress.start('sync.deletes', filtered.deleted.length);
     for (const path of filtered.deleted) {
       const slug = resolveSlugForPath(path);
-      await engine.deletePage(slug);
+      await engine.purgePage(slug);
       pagesAffected.push(slug);
       progress.tick(1, slug);
     }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -50,6 +50,10 @@ export interface GBrainConfig {
     /** false disables PII scrubbing before insert. Defaults to true. */
     scrub_pii?: boolean;
   };
+  audit?: {
+    /** When true, log read-tool calls to eval_candidates (query/search unaffected by eval.capture off). File-plane ~/.gbrain/config.json only. */
+    reads?: boolean;
+  };
 }
 
 /**

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -5,13 +5,14 @@ import type {
   Link, GraphNode, GraphPath,
   TimelineEntry, TimelineInput, TimelineOpts,
   RawData,
-  PageVersion,
+  PageVersion, PageVersionOpts, PageVersionDiff,
   BrainStats, BrainHealth,
   IngestLogEntry, IngestLogInput,
   EngineConfig,
   CodeEdgeInput, CodeEdgeResult,
   EvalCandidate, EvalCandidateInput,
   EvalCaptureFailure, EvalCaptureFailureReason,
+  EvalCaptureToolName,
 } from './types.ts';
 
 /** Input row for addLinksBatch. Optional fields default to '' (matches NOT NULL DDL). */
@@ -128,9 +129,14 @@ export interface BrainEngine {
   withReservedConnection<T>(fn: (conn: ReservedConnection) => Promise<T>): Promise<T>;
 
   // Pages CRUD
-  getPage(slug: string): Promise<Page | null>;
+  getPage(slug: string, opts?: { includeDeleted?: boolean }): Promise<Page | null>;
   putPage(slug: string, page: PageInput): Promise<Page>;
-  deletePage(slug: string): Promise<void>;
+  /** Hard delete page and dependent rows. Used by sync, migrate, gbrain purge. */
+  purgePage(slug: string): Promise<void>;
+  /** Soft-delete: sets deleted_at, preserves row. */
+  softDeletePage(slug: string, opts?: PageVersionOpts): Promise<void>;
+  /** Clear deleted_at for a slug (no-op if not soft-deleted). */
+  resurrectSoftDeletedPage(slug: string): Promise<void>;
   listPages(filters?: PageFilters): Promise<Page[]>;
   resolveSlugs(partial: string): Promise<string[]>;
   /**
@@ -280,9 +286,12 @@ export interface BrainEngine {
   putDreamVerdict(filePath: string, contentHash: string, verdict: DreamVerdictInput): Promise<void>;
 
   // Versions
-  createVersion(slug: string): Promise<PageVersion>;
-  getVersions(slug: string): Promise<PageVersion[]>;
-  revertToVersion(slug: string, versionId: number): Promise<void>;
+  createVersion(slug: string, opts?: PageVersionOpts): Promise<PageVersion>;
+  getVersions(slug: string, opts?: { includeDeletedPage?: boolean }): Promise<PageVersion[]>;
+  getPageVersionById(versionId: number): Promise<PageVersion | null>;
+  revertToVersion(slug: string, versionId: number, opts?: PageVersionOpts): Promise<void>;
+  diffPageVersions(slug: string, fromVersionId: number, toVersionId: number): Promise<PageVersionDiff>;
+  prunePageVersions(opts: { slug?: string; keepLast?: number; olderThan?: Date }): Promise<number>;
 
   // Stats + health
   getStats(): Promise<BrainStats>;
@@ -374,9 +383,9 @@ export interface BrainEngine {
   /** Insert a captured candidate. Returns the new row id. Best-effort: callers swallow failures and route them through `logEvalCaptureFailure`. */
   logEvalCandidate(input: EvalCandidateInput): Promise<number>;
   /** Read candidates by time window / limit / tool filter. Used by `gbrain eval export`. */
-  listEvalCandidates(filter?: { since?: Date; limit?: number; tool?: 'query' | 'search' }): Promise<EvalCandidate[]>;
-  /** Delete candidates created before `date`. Returns rows deleted. Used by `gbrain eval prune`. */
-  deleteEvalCandidatesBefore(date: Date): Promise<number>;
+  listEvalCandidates(filter?: { since?: Date; limit?: number; tool?: EvalCaptureToolName; slugHint?: string; mcpTokenName?: string }): Promise<EvalCandidate[]>;
+  /** Delete candidates created before `date`. Returns rows deleted. Used by `gbrain eval prune`. When `opts.readToolsOnly`, only rows whose tool_name is not `query` or `search`. */
+  deleteEvalCandidatesBefore(date: Date, opts?: { readToolsOnly?: boolean }): Promise<number>;
   /** Log a capture failure so `gbrain doctor` can surface drops cross-process. Best-effort; symmetric with logEvalCandidate (failure-of-failure is lost). */
   logEvalCaptureFailure(reason: EvalCaptureFailureReason): Promise<void>;
   /** Read capture failures within an optional time window. Used by `gbrain doctor`. */

--- a/src/core/eval-capture-scrub.ts
+++ b/src/core/eval-capture-scrub.ts
@@ -78,27 +78,28 @@ export function scrubPii(input: string): string {
   if (!input) return input;
   let out = input;
 
-  // 1. Emails
   out = out.replace(EMAIL_RE, REDACTED);
-
-  // 2. Phones (before SSN so +1-555-XX doesn't look like part of a dashes-only SSN)
   out = out.replace(PHONE_RE, REDACTED);
-
-  // 3. SSN (after phones)
   out = out.replace(SSN_RE, REDACTED);
-
-  // 4. JWT (distinctive prefix, safe to run anywhere in the pipeline)
   out = out.replace(JWT_RE, REDACTED);
-
-  // 5. Bearer tokens
   out = out.replace(BEARER_RE, `Bearer ${REDACTED}`);
-
-  // 6. Credit cards: every candidate must pass Luhn to be replaced.
   out = out.replace(CC_RE, (match) => {
     const digitsOnly = match.replace(/\D/g, '');
     if (digitsOnly.length < 13 || digitsOnly.length > 19) return match;
     return luhnOk(digitsOnly) ? REDACTED : match;
   });
 
+  return out;
+}
+
+export function scrubPiiObject(input: unknown): unknown {
+  if (input == null) return input;
+  if (typeof input === 'string') return scrubPii(input);
+  if (typeof input !== 'object') return input;
+  if (Array.isArray(input)) return input.map(scrubPiiObject);
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+    out[k] = scrubPiiObject(v);
+  }
   return out;
 }

--- a/src/core/eval-capture.ts
+++ b/src/core/eval-capture.ts
@@ -38,39 +38,44 @@ import type { BrainEngine } from './engine.ts';
 import type {
   EvalCandidateInput,
   EvalCaptureFailureReason,
+  EvalCaptureToolName,
   HybridSearchMeta,
   SearchResult,
 } from './types.ts';
 import type { GBrainConfig } from './config.ts';
-import { scrubPii } from './eval-capture-scrub.ts';
+import { scrubPii, scrubPiiObject } from './eval-capture-scrub.ts';
 
 // HybridSearchMeta is canonical in src/core/types.ts and exported via the
 // public `gbrain/types` subpath. Surfaced from hybridSearch via the
 // optional onMeta callback in HybridSearchOpts (Lane 1C).
 export type { HybridSearchMeta };
 
-/** Context needed to build a capture row. Bundled so op handlers don't thread 8 args. */
 export interface CaptureContext {
-  /** 'query' or 'search'; captured only for these two ops. */
   tool_name: 'query' | 'search';
-  /** Pre-scrub query text. scrubPii runs INSIDE buildEvalCandidateInput when scrub_pii !== false. */
   query: string;
-  /** Result set from the op handler. */
   results: SearchResult[];
-  /** Side-channel metadata from hybridSearch. For 'search' ops, pass vector_enabled:false, others null/false. */
   meta: HybridSearchMeta;
-  /** How long the underlying op took, in milliseconds. */
   latency_ms: number;
-  /** OperationContext.remote — true for MCP callers, false for local CLI. */
   remote: boolean;
-  /** The `expand` flag as requested by the caller (query-only; null for search). */
   expand_enabled: boolean | null;
-  /** The `detail` flag as requested (query-only). */
   detail: 'low' | 'medium' | 'high' | null;
-  /** OperationContext.jobId if present. */
   job_id: number | null;
-  /** OperationContext.subagentId if present. */
   subagent_id: number | null;
+  mcp_token_name?: string | null;
+}
+
+export interface ReadAuditContext {
+  tool_name: Exclude<EvalCaptureToolName, 'query' | 'search'>;
+  query: string;
+  params: Record<string, unknown>;
+  retrieved_slugs: string[];
+  retrieved_chunk_ids?: number[];
+  source_ids?: string[];
+  latency_ms: number;
+  remote: boolean;
+  job_id: number | null;
+  subagent_id: number | null;
+  mcp_token_name?: string | null;
 }
 
 /**
@@ -104,6 +109,7 @@ export function buildEvalCandidateInput(
   return {
     tool_name: ctx.tool_name,
     query,
+    params_jsonb: {},
     retrieved_slugs: [...slugsSet],
     retrieved_chunk_ids: chunkIds,
     source_ids: [...sourceSet],
@@ -116,6 +122,38 @@ export function buildEvalCandidateInput(
     remote: ctx.remote,
     job_id: ctx.job_id,
     subagent_id: ctx.subagent_id,
+    mcp_token_name: ctx.mcp_token_name ?? null,
+  };
+}
+
+export function buildReadAuditInput(
+  ctx: ReadAuditContext,
+  opts: { scrub_pii?: boolean } = {},
+): EvalCandidateInput {
+  const shouldScrub = opts.scrub_pii !== false;
+  const query = shouldScrub ? scrubPii(ctx.query) : ctx.query;
+  const params = shouldScrub
+    ? (scrubPiiObject(ctx.params) as Record<string, unknown>)
+    : ctx.params;
+  const slugsSet = new Set<string>();
+  for (const s of ctx.retrieved_slugs) slugsSet.add(s);
+  return {
+    tool_name: ctx.tool_name,
+    query,
+    params_jsonb: params,
+    retrieved_slugs: [...slugsSet],
+    retrieved_chunk_ids: ctx.retrieved_chunk_ids ?? [],
+    source_ids: ctx.source_ids ?? [],
+    expand_enabled: null,
+    detail: null,
+    detail_resolved: null,
+    vector_enabled: false,
+    expansion_applied: false,
+    latency_ms: ctx.latency_ms,
+    remote: ctx.remote,
+    job_id: ctx.job_id,
+    subagent_id: ctx.subagent_id,
+    mcp_token_name: ctx.mcp_token_name ?? null,
   };
 }
 
@@ -162,8 +200,25 @@ export async function captureEvalCandidate(
     try {
       await engine.logEvalCaptureFailure(reason);
     } catch (failureErr) {
-      // Failure-of-failure: last-resort stderr. Doctor can't see this
-      // row, but we've exhausted the persistent path.
+      // eslint-disable-next-line no-console
+      console.warn('[eval-capture] secondary failure logging also failed:', failureErr);
+    }
+  }
+}
+
+export async function captureReadAudit(
+  engine: BrainEngine,
+  ctx: ReadAuditContext,
+  opts: { scrub_pii?: boolean } = {},
+): Promise<void> {
+  try {
+    const input = buildReadAuditInput(ctx, opts);
+    await engine.logEvalCandidate(input);
+  } catch (err) {
+    const reason = classifyCaptureFailure(err);
+    try {
+      await engine.logEvalCaptureFailure(reason);
+    } catch (failureErr) {
       // eslint-disable-next-line no-console
       console.warn('[eval-capture] secondary failure logging also failed:', failureErr);
     }
@@ -193,6 +248,14 @@ export function isEvalCaptureEnabled(config: GBrainConfig | null | undefined): b
   if (config?.eval?.capture === true) return true;
   if (config?.eval?.capture === false) return false;
   return process.env.GBRAIN_CONTRIBUTOR_MODE === '1';
+}
+
+export function isReadAuditEnabled(config: GBrainConfig | null | undefined): boolean {
+  if (config?.audit?.reads === true) return true;
+  if (config?.audit?.reads === false) return false;
+  if (process.env.GBRAIN_AUDIT_READS === '1') return true;
+  if (process.env.GBRAIN_AUDIT_READS === '0') return false;
+  return false;
 }
 
 /**

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -267,7 +267,7 @@ export async function importFromContent(
 
   // Transaction wraps all DB writes
   await engine.transaction(async (tx) => {
-    if (existing) await tx.createVersion(slug);
+    if (existing) await tx.createVersion(slug, { kind: 'update', provenance: { source: 'import_file' } });
 
     await tx.putPage(slug, {
       type: parsed.type,
@@ -277,6 +277,7 @@ export async function importFromContent(
       frontmatter: parsed.frontmatter,
       content_hash: hash,
     });
+    if (!existing) await tx.createVersion(slug, { kind: 'create', provenance: { source: 'import_file' } });
 
     // Tag reconciliation: remove stale, add current
     const existingTags = await tx.getTags(slug);
@@ -494,7 +495,7 @@ export async function importCodeFile(
 
   // Store
   await engine.transaction(async (tx) => {
-    if (existing) await tx.createVersion(slug);
+    if (existing) await tx.createVersion(slug, { kind: 'update', provenance: { source: 'import_code_file' } });
 
     await tx.putPage(slug, {
       type: 'code' as PageType,
@@ -505,6 +506,7 @@ export async function importCodeFile(
       frontmatter: { language: lang, file: relativePath },
       content_hash: hash,
     });
+    if (!existing) await tx.createVersion(slug, { kind: 'create', provenance: { source: 'import_code_file' } });
 
     await tx.addTag(slug, 'code');
     await tx.addTag(slug, lang);

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -1201,6 +1201,68 @@ export const MIGRATIONS: Migration[] = [
     },
     sql: '',
   },
+  {
+    version: 32,
+    name: 'page_versions_read_audit_soft_delete',
+    sql: `
+      ALTER TABLE pages ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+      ALTER TABLE page_versions ADD COLUMN IF NOT EXISTS source_id TEXT;
+      ALTER TABLE page_versions ADD COLUMN IF NOT EXISTS slug TEXT;
+      ALTER TABLE page_versions ADD COLUMN IF NOT EXISTS tags TEXT[];
+      ALTER TABLE page_versions ADD COLUMN IF NOT EXISTS provenance JSONB;
+      ALTER TABLE page_versions ADD COLUMN IF NOT EXISTS kind TEXT;
+
+      UPDATE page_versions SET source_id = 'default' WHERE source_id IS NULL;
+      ALTER TABLE page_versions ALTER COLUMN source_id SET DEFAULT 'default';
+
+      UPDATE page_versions SET slug = '_' WHERE slug IS NULL OR slug = '';
+      ALTER TABLE page_versions ALTER COLUMN slug SET DEFAULT '_';
+
+      UPDATE page_versions pv
+      SET slug = p.slug, source_id = p.source_id
+      FROM pages p
+      WHERE pv.page_id IS NOT NULL AND p.id = pv.page_id;
+
+      ALTER TABLE page_versions ALTER COLUMN source_id SET NOT NULL;
+      ALTER TABLE page_versions ALTER COLUMN slug SET NOT NULL;
+
+      UPDATE page_versions SET tags = '{}'::text[] WHERE tags IS NULL;
+      ALTER TABLE page_versions ALTER COLUMN tags SET DEFAULT '{}'::text[];
+      ALTER TABLE page_versions ALTER COLUMN tags SET NOT NULL;
+
+      UPDATE page_versions SET provenance = '{"source":"unknown"}'::jsonb WHERE provenance IS NULL;
+      ALTER TABLE page_versions ALTER COLUMN provenance SET DEFAULT '{}'::jsonb;
+      ALTER TABLE page_versions ALTER COLUMN provenance SET NOT NULL;
+
+      UPDATE page_versions SET kind = 'update' WHERE kind IS NULL;
+      ALTER TABLE page_versions ALTER COLUMN kind SET DEFAULT 'update';
+      ALTER TABLE page_versions ALTER COLUMN kind SET NOT NULL;
+      ALTER TABLE page_versions DROP CONSTRAINT IF EXISTS page_versions_kind_check;
+      ALTER TABLE page_versions ADD CONSTRAINT page_versions_kind_check
+        CHECK (kind IN ('create', 'update', 'delete'));
+
+      ALTER TABLE page_versions DROP CONSTRAINT IF EXISTS page_versions_page_id_fkey;
+      ALTER TABLE page_versions ALTER COLUMN page_id DROP NOT NULL;
+      ALTER TABLE page_versions ADD CONSTRAINT page_versions_page_id_fkey
+        FOREIGN KEY (page_id) REFERENCES pages(id) ON DELETE SET NULL;
+
+      CREATE INDEX IF NOT EXISTS idx_page_versions_slug_snapshot
+        ON page_versions(slug, snapshot_at DESC);
+
+      ALTER TABLE eval_candidates ADD COLUMN IF NOT EXISTS params_jsonb JSONB NOT NULL DEFAULT '{}'::jsonb;
+      ALTER TABLE eval_candidates ADD COLUMN IF NOT EXISTS mcp_token_name TEXT;
+      ALTER TABLE eval_candidates DROP CONSTRAINT IF EXISTS eval_candidates_tool_name_check;
+      ALTER TABLE eval_candidates ADD CONSTRAINT eval_candidates_tool_name_check CHECK (
+        tool_name IN (
+          'query', 'search', 'get_page', 'list_pages', 'traverse_graph', 'get_links',
+          'get_backlinks', 'get_timeline', 'get_tags', 'find_orphans', 'resolve_slugs', 'get_chunks'
+        )
+      );
+      CREATE INDEX IF NOT EXISTS idx_eval_candidates_tool_created
+        ON eval_candidates(tool_name, created_at DESC);
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -13,7 +13,8 @@ import { importFromContent } from './import-file.ts';
 import { hybridSearch } from './search/hybrid.ts';
 import { expandQuery } from './search/expansion.ts';
 import { dedupResults } from './search/dedup.ts';
-import { captureEvalCandidate, isEvalCaptureEnabled, isEvalScrubEnabled } from './eval-capture.ts';
+import { captureEvalCandidate, captureReadAudit, isEvalCaptureEnabled, isEvalScrubEnabled, isReadAuditEnabled } from './eval-capture.ts';
+import type { EvalCaptureToolName } from './types.ts';
 import type { HybridSearchMeta } from './types.ts';
 import { extractPageLinks, isAutoLinkEnabled, isAutoTimelineEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef } from './link-extraction.ts';
 import * as db from './db.ts';
@@ -225,6 +226,12 @@ export interface OperationContext {
    */
   allowedSlugPrefixes?: string[];
   /**
+   * Bearer-token name used to authenticate the MCP HTTP request, if any.
+   * Threaded into eval_candidates / read-audit rows so reviewers can
+   * attribute reads to the originating credential.
+   */
+  mcpTokenName?: string;
+  /**
    * Resolved global CLI options (--quiet / --progress-json / --progress-interval).
    * CLI callers populate this from `getCliOptions()`. MCP / library callers
    * may leave it undefined — consumers default to quiet/no-progress for
@@ -249,35 +256,69 @@ export interface Operation {
 
 // --- Page CRUD ---
 
+function maybeAuditRead(
+  ctx: OperationContext,
+  toolName: Exclude<EvalCaptureToolName, 'query' | 'search'>,
+  params: Record<string, unknown>,
+  retrievedSlugs: string[],
+  startedAt: number,
+  extras?: { retrieved_chunk_ids?: number[]; source_ids?: string[]; querySummary?: string },
+): void {
+  if (!isReadAuditEnabled(ctx.config)) return;
+  void captureReadAudit(
+    ctx.engine,
+    {
+      tool_name: toolName,
+      query: extras?.querySummary ?? toolName,
+      params,
+      retrieved_slugs: retrievedSlugs,
+      retrieved_chunk_ids: extras?.retrieved_chunk_ids,
+      source_ids: extras?.source_ids,
+      latency_ms: Date.now() - startedAt,
+      remote: ctx.remote ?? false,
+      job_id: ctx.jobId ?? null,
+      subagent_id: ctx.subagentId ?? null,
+      mcp_token_name: ctx.mcpTokenName ?? null,
+    },
+    { scrub_pii: isEvalScrubEnabled(ctx.config) },
+  );
+}
+
 const get_page: Operation = {
   name: 'get_page',
   description: 'Read a page by slug (supports optional fuzzy matching)',
   params: {
     slug: { type: 'string', required: true, description: 'Page slug' },
     fuzzy: { type: 'boolean', description: 'Enable fuzzy slug resolution (default: false)' },
+    include_deleted: { type: 'boolean', description: 'Include soft-deleted pages (default: false)' },
   },
   handler: async (ctx, p) => {
+    const startedAt = Date.now();
     const slug = p.slug as string;
     const fuzzy = (p.fuzzy as boolean) || false;
+    const includeDeleted = (p.include_deleted as boolean) || false;
 
-    let page = await ctx.engine.getPage(slug);
+    let page = await ctx.engine.getPage(slug, { includeDeleted });
     let resolved_slug: string | undefined;
 
     if (!page && fuzzy) {
       const candidates = await ctx.engine.resolveSlugs(slug);
       if (candidates.length === 1) {
-        page = await ctx.engine.getPage(candidates[0]);
+        page = await ctx.engine.getPage(candidates[0], { includeDeleted });
         resolved_slug = candidates[0];
       } else if (candidates.length > 1) {
+        maybeAuditRead(ctx, 'get_page', { slug, fuzzy, include_deleted: includeDeleted }, [], startedAt);
         return { error: 'ambiguous_slug', candidates };
       }
     }
 
     if (!page) {
+      maybeAuditRead(ctx, 'get_page', { slug, fuzzy, include_deleted: includeDeleted }, [], startedAt);
       throw new OperationError('page_not_found', `Page not found: ${slug}`, 'Check the slug or use fuzzy: true');
     }
 
     const tags = await ctx.engine.getTags(page.slug);
+    maybeAuditRead(ctx, 'get_page', { slug, fuzzy, include_deleted: includeDeleted, resolved_slug }, [page.slug], startedAt);
     return { ...page, tags, ...(resolved_slug ? { resolved_slug } : {}) };
   },
   cliHints: { name: 'get', positional: ['slug'] },
@@ -581,17 +622,95 @@ async function runAutoLink(
 
 const delete_page: Operation = {
   name: 'delete_page',
-  description: 'Delete a page',
+  description: 'Soft-delete a page (writes a tombstone version; page can be resurrected)',
   params: {
     slug: { type: 'string', required: true },
   },
   mutating: true,
   handler: async (ctx, p) => {
-    if (ctx.dryRun) return { dry_run: true, action: 'delete_page', slug: p.slug };
-    await ctx.engine.deletePage(p.slug as string);
-    return { status: 'deleted' };
+    const slug = p.slug as string;
+    if (ctx.dryRun) return { dry_run: true, action: 'delete_page', slug };
+    const provenance: Record<string, unknown> = {
+      source: ctx.viaSubagent ? 'subagent_delete' : (ctx.remote ? 'mcp_delete' : 'cli_delete'),
+    };
+    if (ctx.subagentId != null) provenance.subagent_id = ctx.subagentId;
+    if (ctx.jobId != null) provenance.job_id = ctx.jobId;
+    if (ctx.mcpTokenName) provenance.mcp_token_name = ctx.mcpTokenName;
+    await ctx.engine.softDeletePage(slug, { provenance, kind: 'update' });
+    return { status: 'soft_deleted', slug, hint: `Run \`gbrain resurrect ${slug}\` to undo.` };
   },
   cliHints: { name: 'delete', positional: ['slug'] },
+};
+
+const purge_page: Operation = {
+  name: 'purge_page',
+  description: 'Hard-delete a page and its history (CLI-only; agents cannot call).',
+  params: {
+    slug: { type: 'string', required: true },
+  },
+  mutating: true,
+  handler: async (ctx, p) => {
+    if (ctx.remote) {
+      throw new OperationError(
+        'permission_denied',
+        'purge_page is local-only',
+        'Run `gbrain purge <slug> --yes` from a terminal on the host machine.',
+      );
+    }
+    const slug = p.slug as string;
+    if (ctx.dryRun) return { dry_run: true, action: 'purge_page', slug };
+    await ctx.engine.purgePage(slug);
+    return { status: 'purged', slug };
+  },
+  cliHints: { name: 'purge', positional: ['slug'], hidden: true },
+};
+
+const resurrect_page: Operation = {
+  name: 'resurrect_page',
+  description: 'Clear deleted_at on a soft-deleted page.',
+  params: {
+    slug: { type: 'string', required: true },
+  },
+  mutating: true,
+  handler: async (ctx, p) => {
+    const slug = p.slug as string;
+    if (ctx.dryRun) return { dry_run: true, action: 'resurrect_page', slug };
+    const existing = await ctx.engine.getPage(slug, { includeDeleted: true });
+    if (!existing) {
+      throw new OperationError('page_not_found', `Page not found: ${slug}`, 'Check the slug.');
+    }
+    if (!existing.deleted_at) {
+      return { status: 'already_active', slug };
+    }
+    await ctx.engine.resurrectSoftDeletedPage(slug);
+    const provenance: Record<string, unknown> = {
+      source: ctx.viaSubagent ? 'subagent_resurrect' : (ctx.remote ? 'mcp_resurrect' : 'cli_resurrect'),
+    };
+    if (ctx.subagentId != null) provenance.subagent_id = ctx.subagentId;
+    if (ctx.jobId != null) provenance.job_id = ctx.jobId;
+    if (ctx.mcpTokenName) provenance.mcp_token_name = ctx.mcpTokenName;
+    await ctx.engine.createVersion(slug, { kind: 'update', provenance });
+    return { status: 'resurrected', slug };
+  },
+  cliHints: { name: 'resurrect', positional: ['slug'], hidden: true },
+};
+
+const diff_page_versions: Operation = {
+  name: 'diff_page_versions',
+  description: 'Diff two versions of a page',
+  params: {
+    slug: { type: 'string', required: true },
+    from_version: { type: 'number', required: true },
+    to_version: { type: 'number', required: true },
+  },
+  handler: async (ctx, p) => {
+    return ctx.engine.diffPageVersions(
+      p.slug as string,
+      p.from_version as number,
+      p.to_version as number,
+    );
+  },
+  cliHints: { name: 'page-diff', positional: ['slug', 'from_version', 'to_version'] },
 };
 
 const list_pages: Operation = {
@@ -601,19 +720,32 @@ const list_pages: Operation = {
     type: { type: 'string', description: 'Filter by page type' },
     tag: { type: 'string', description: 'Filter by tag' },
     limit: { type: 'number', description: 'Max results (default 50)' },
+    include_deleted: { type: 'boolean', description: 'Include soft-deleted pages (default: false)' },
   },
   handler: async (ctx, p) => {
+    const startedAt = Date.now();
+    const limit = clampSearchLimit(p.limit as number | undefined, 50, 100);
+    const includeDeleted = (p.include_deleted as boolean) || false;
     const pages = await ctx.engine.listPages({
       type: p.type as any,
       tag: p.tag as string,
-      limit: clampSearchLimit(p.limit as number | undefined, 50, 100),
+      limit,
+      includeDeleted,
     });
-    return pages.map(pg => ({
+    const result = pages.map(pg => ({
       slug: pg.slug,
       type: pg.type,
       title: pg.title,
       updated_at: pg.updated_at,
     }));
+    maybeAuditRead(
+      ctx,
+      'list_pages',
+      { type: p.type ?? null, tag: p.tag ?? null, limit, include_deleted: includeDeleted },
+      result.map(r => r.slug),
+      startedAt,
+    );
+    return result;
   },
   cliHints: { name: 'list' },
 };
@@ -655,6 +787,7 @@ const search: Operation = {
           detail: null,
           job_id: ctx.jobId ?? null,
           subagent_id: ctx.subagentId ?? null,
+          mcp_token_name: ctx.mcpTokenName ?? null,
         },
         { scrub_pii: isEvalScrubEnabled(ctx.config) },
       );
@@ -726,6 +859,7 @@ const query: Operation = {
           detail: detail ?? null,
           job_id: ctx.jobId ?? null,
           subagent_id: ctx.subagentId ?? null,
+          mcp_token_name: ctx.mcpTokenName ?? null,
         },
         { scrub_pii: isEvalScrubEnabled(ctx.config) },
       );
@@ -777,7 +911,11 @@ const get_tags: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.getTags(p.slug as string);
+    const startedAt = Date.now();
+    const slug = p.slug as string;
+    const result = await ctx.engine.getTags(slug);
+    maybeAuditRead(ctx, 'get_tags', { slug }, [slug], startedAt);
+    return result;
   },
   cliHints: { name: 'tags', positional: ['slug'] },
 };
@@ -828,7 +966,12 @@ const get_links: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.getLinks(p.slug as string);
+    const startedAt = Date.now();
+    const slug = p.slug as string;
+    const links = await ctx.engine.getLinks(slug);
+    const targets = Array.from(new Set(links.map(l => (l as { to_slug?: string }).to_slug).filter((s): s is string => !!s)));
+    maybeAuditRead(ctx, 'get_links', { slug }, [slug, ...targets], startedAt);
+    return links;
   },
 };
 
@@ -839,7 +982,12 @@ const get_backlinks: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.getBacklinks(p.slug as string);
+    const startedAt = Date.now();
+    const slug = p.slug as string;
+    const links = await ctx.engine.getBacklinks(slug);
+    const sources = Array.from(new Set(links.map(l => (l as { from_slug?: string }).from_slug).filter((s): s is string => !!s)));
+    maybeAuditRead(ctx, 'get_backlinks', { slug }, [slug, ...sources], startedAt);
+    return links;
   },
   cliHints: { name: 'backlinks', positional: ['slug'] },
 };
@@ -872,12 +1020,29 @@ const traverse_graph: Operation = {
     const depth = Math.max(1, Math.min(requestedDepth, TRAVERSE_DEPTH_CAP));
     const linkType = p.link_type as string | undefined;
     const direction = p.direction as 'in' | 'out' | 'both' | undefined;
-    // Backward compat: when neither link_type nor direction is provided, return
-    // the legacy GraphNode[] shape. Once either is set, switch to GraphPath[].
+    const startedAt = Date.now();
+    let retrievedSlugs: string[];
+    let result: unknown;
     if (linkType === undefined && direction === undefined) {
-      return ctx.engine.traverseGraph(slug, depth);
+      const nodes = await ctx.engine.traverseGraph(slug, depth);
+      retrievedSlugs = nodes.map(n => (n as { slug?: string }).slug).filter((s): s is string => !!s);
+      result = nodes;
+    } else {
+      const paths = await ctx.engine.traversePaths(slug, { depth, linkType, direction });
+      const set = new Set<string>([slug]);
+      for (const p of paths) {
+        if ((p as { from_slug?: string }).from_slug) set.add((p as { from_slug?: string }).from_slug!);
+        if ((p as { to_slug?: string }).to_slug) set.add((p as { to_slug?: string }).to_slug!);
+      }
+      retrievedSlugs = [...set];
+      result = paths;
     }
-    return ctx.engine.traversePaths(slug, { depth, linkType, direction });
+    maybeAuditRead(
+      ctx, 'traverse_graph',
+      { slug, depth, link_type: linkType ?? null, direction: direction ?? null },
+      retrievedSlugs, startedAt,
+    );
+    return result;
   },
   cliHints: { name: 'graph', positional: ['slug'] },
 };
@@ -931,7 +1096,11 @@ const get_timeline: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.getTimeline(p.slug as string);
+    const startedAt = Date.now();
+    const slug = p.slug as string;
+    const result = await ctx.engine.getTimeline(slug);
+    maybeAuditRead(ctx, 'get_timeline', { slug }, [slug], startedAt);
+    return result;
   },
   cliHints: { name: 'timeline', positional: ['slug'] },
 };
@@ -963,28 +1132,49 @@ const get_versions: Operation = {
   description: 'Page version history',
   params: {
     slug: { type: 'string', required: true },
+    include_orphan: {
+      type: 'boolean',
+      description: 'Include history for soft-deleted pages too (default: false).',
+    },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.getVersions(p.slug as string);
+    return ctx.engine.getVersions(p.slug as string, {
+      includeDeletedPage: (p.include_orphan as boolean) || false,
+    });
   },
-  cliHints: { name: 'history', positional: ['slug'] },
+  cliHints: { name: 'history', positional: ['slug'], hidden: true },
 };
 
 const revert_version: Operation = {
   name: 'revert_version',
-  description: 'Revert page to a previous version',
+  description: 'Revert page to a previous version (snapshots current state first; restores compiled_truth + frontmatter + tags).',
   params: {
     slug: { type: 'string', required: true },
     version_id: { type: 'number', required: true },
   },
   mutating: true,
   handler: async (ctx, p) => {
-    if (ctx.dryRun) return { dry_run: true, action: 'revert_version', slug: p.slug, version_id: p.version_id };
-    await ctx.engine.createVersion(p.slug as string);
-    await ctx.engine.revertToVersion(p.slug as string, p.version_id as number);
-    return { status: 'reverted' };
+    const slug = p.slug as string;
+    const versionId = p.version_id as number;
+    if (ctx.dryRun) {
+      return { dry_run: true, action: 'revert_version', slug, version_id: versionId };
+    }
+    const provenance: Record<string, unknown> = {
+      source: 'revert',
+      target_version_id: versionId,
+    };
+    if (ctx.subagentId != null) provenance.subagent_id = ctx.subagentId;
+    if (ctx.jobId != null) provenance.job_id = ctx.jobId;
+    if (ctx.mcpTokenName) provenance.mcp_token_name = ctx.mcpTokenName;
+    await ctx.engine.revertToVersion(slug, versionId, { provenance });
+    return {
+      status: 'reverted',
+      slug,
+      version_id: versionId,
+      hint: `Run \`gbrain extract --slugs ${slug} && gbrain embed --stale --slugs ${slug}\` to refresh derived state.`,
+    };
   },
-  cliHints: { name: 'revert', positional: ['slug', 'version_id'] },
+  cliHints: { name: 'revert', positional: ['slug', 'version_id'], hidden: true },
 };
 
 // --- Sync ---
@@ -1052,7 +1242,11 @@ const resolve_slugs: Operation = {
     partial: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.resolveSlugs(p.partial as string);
+    const startedAt = Date.now();
+    const partial = p.partial as string;
+    const slugs = await ctx.engine.resolveSlugs(partial);
+    maybeAuditRead(ctx, 'resolve_slugs', { partial }, slugs, startedAt);
+    return slugs;
   },
 };
 
@@ -1063,7 +1257,12 @@ const get_chunks: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.getChunks(p.slug as string);
+    const startedAt = Date.now();
+    const slug = p.slug as string;
+    const chunks = await ctx.engine.getChunks(slug);
+    const chunkIds = chunks.map(c => (c as { id?: number }).id).filter((n): n is number => typeof n === 'number');
+    maybeAuditRead(ctx, 'get_chunks', { slug }, [slug], startedAt, { retrieved_chunk_ids: chunkIds });
+    return chunks;
   },
 };
 
@@ -1431,8 +1630,15 @@ const find_orphans: Operation = {
     },
   },
   handler: async (ctx, p) => {
+    const startedAt = Date.now();
+    const includePseudo = (p.include_pseudo as boolean) || false;
     const { findOrphans } = await import('../commands/orphans.ts');
-    return findOrphans(ctx.engine, { includePseudo: (p.include_pseudo as boolean) || false });
+    const result = await findOrphans(ctx.engine, { includePseudo });
+    const slugs = Array.isArray(result)
+      ? result.map(r => (r as { slug?: string }).slug).filter((s): s is string => !!s)
+      : [];
+    maybeAuditRead(ctx, 'find_orphans', { include_pseudo: includePseudo }, slugs, startedAt);
+    return result;
   },
   cliHints: { name: 'orphans', hidden: true },
 };
@@ -1441,7 +1647,7 @@ const find_orphans: Operation = {
 
 export const operations: Operation[] = [
   // Page CRUD
-  get_page, put_page, delete_page, list_pages,
+  get_page, put_page, delete_page, purge_page, resurrect_page, diff_page_versions, list_pages,
   // Search
   search, query,
   // Tags

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -14,12 +14,13 @@ import type {
   Link, GraphNode, GraphPath,
   TimelineEntry, TimelineInput, TimelineOpts,
   RawData,
-  PageVersion,
+  PageVersion, PageVersionOpts, PageVersionDiff,
   BrainStats, BrainHealth,
   IngestLogEntry, IngestLogInput,
   EngineConfig,
   EvalCandidate, EvalCandidateInput,
   EvalCaptureFailure, EvalCaptureFailureReason,
+  EvalCaptureToolName,
 } from './types.ts';
 import { validateSlug, contentHash, rowToPage, rowToChunk, rowToSearchResult } from './utils.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
@@ -329,11 +330,15 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Pages CRUD
-  async getPage(slug: string): Promise<Page | null> {
+  async getPage(slug: string, opts?: { includeDeleted?: boolean }): Promise<Page | null> {
+    const inc = !!opts?.includeDeleted;
     const { rows } = await this.db.query(
-      `SELECT id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at
-       FROM pages WHERE slug = $1`,
-      [slug]
+      inc
+        ? `SELECT id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash,
+           deleted_at, created_at, updated_at FROM pages WHERE slug = $1`
+        : `SELECT id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash,
+           deleted_at, created_at, updated_at FROM pages WHERE slug = $1 AND deleted_at IS NULL`,
+      [slug],
     );
     if (rows.length === 0) return null;
     return rowToPage(rows[0] as Record<string, unknown>);
@@ -344,11 +349,6 @@ export class PGLiteEngine implements BrainEngine {
     const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
 
-    // v0.18.0 Step 2: source_id relies on the schema DEFAULT 'default' so
-    // existing callers still target the default source without threading
-    // a parameter. ON CONFLICT target becomes (source_id, slug) since the
-    // global UNIQUE(slug) was dropped in migration v17. Step 5+ will
-    // surface an explicit sourceId param on putPage for multi-source sync.
     const pageKind = page.page_kind || 'markdown';
     const { rows } = await this.db.query(
       `INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
@@ -361,15 +361,51 @@ export class PGLiteEngine implements BrainEngine {
          timeline = EXCLUDED.timeline,
          frontmatter = EXCLUDED.frontmatter,
          content_hash = EXCLUDED.content_hash,
+         deleted_at = NULL,
          updated_at = now()
-       RETURNING id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at`,
-      [slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash]
+       RETURNING id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash,
+         deleted_at, created_at, updated_at`,
+      [slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash],
     );
     return rowToPage(rows[0] as Record<string, unknown>);
   }
 
-  async deletePage(slug: string): Promise<void> {
+  async purgePage(slug: string): Promise<void> {
+    await this.db.query('DELETE FROM page_versions WHERE slug = $1', [slug]);
     await this.db.query('DELETE FROM pages WHERE slug = $1', [slug]);
+  }
+
+  async softDeletePage(slug: string, opts?: PageVersionOpts): Promise<void> {
+    const { rows } = await this.db.query(
+      `SELECT id FROM pages WHERE slug = $1 AND deleted_at IS NULL`,
+      [slug],
+    );
+    if (rows.length === 0) throw new Error(`softDelete failed: active page "${slug}" not found`);
+    await this.createVersion(slug, { ...opts, kind: opts?.kind ?? 'update' });
+    await this.db.query(
+      `UPDATE pages SET deleted_at = now(), updated_at = now() WHERE slug = $1 AND deleted_at IS NULL`,
+      [slug],
+    );
+    const tombProv = opts?.provenance ?? { source: 'soft_delete' };
+    await this.db.query(
+      `INSERT INTO page_versions (page_id, source_id, slug, compiled_truth, frontmatter, tags, kind, provenance)
+       SELECT p.id, p.source_id, p.slug, p.compiled_truth, p.frontmatter,
+         COALESCE((
+           SELECT array_agg(tag ORDER BY tag) FROM tags t WHERE t.page_id = p.id
+         ), '{}'::text[]),
+         'delete',
+         $2::jsonb
+       FROM pages p WHERE p.slug = $1`,
+      [slug, JSON.stringify(tombProv)],
+    );
+  }
+
+  async resurrectSoftDeletedPage(slug: string): Promise<void> {
+    await this.db.query(
+      `UPDATE pages SET deleted_at = NULL, updated_at = now()
+       WHERE slug = $1 AND deleted_at IS NOT NULL`,
+      [slug],
+    );
   }
 
   async listPages(filters?: PageFilters): Promise<Page[]> {
@@ -399,6 +435,9 @@ export class PGLiteEngine implements BrainEngine {
       params.push(escaped);
       where.push(`p.slug LIKE $${params.length} ESCAPE '\\'`);
     }
+    if (!filters?.includeDeleted) {
+      where.push(`p.deleted_at IS NULL`);
+    }
 
     const whereSql = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
     params.push(limit, offset);
@@ -414,7 +453,7 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   async getAllSlugs(): Promise<Set<string>> {
-    const { rows } = await this.db.query('SELECT slug FROM pages');
+    const { rows } = await this.db.query('SELECT slug FROM pages WHERE deleted_at IS NULL');
     return new Set((rows as { slug: string }[]).map(r => r.slug));
   }
 
@@ -427,7 +466,7 @@ export class PGLiteEngine implements BrainEngine {
     const { rows } = await this.db.query(
       `SELECT slug, similarity(title, $1) AS sim
        FROM pages
-       WHERE title % $1 OR slug ILIKE $2
+       WHERE deleted_at IS NULL AND (title % $1 OR slug ILIKE $2)
        ORDER BY sim DESC
        LIMIT 5`,
       [partial, '%' + partial + '%']
@@ -490,7 +529,7 @@ export class PGLiteEngine implements BrainEngine {
            ) THEN true ELSE false END AS stale
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id
-         WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause}
+         WHERE p.deleted_at IS NULL AND cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause}
          ORDER BY score DESC
          LIMIT $2
        ),
@@ -557,7 +596,7 @@ export class PGLiteEngine implements BrainEngine {
          ) THEN true ELSE false END AS stale
        FROM content_chunks cc
        JOIN pages p ON p.id = cc.page_id
-       WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause}
+       WHERE p.deleted_at IS NULL AND cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause}
        ORDER BY score DESC
        LIMIT $2 OFFSET $3`,
       params
@@ -611,7 +650,7 @@ export class PGLiteEngine implements BrainEngine {
            1 - (cc.embedding <=> $1::vector) AS raw_score
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id
-         WHERE cc.embedding IS NOT NULL ${detailFilter}${extraFilter} ${hardExcludeClause}
+         WHERE p.deleted_at IS NULL AND cc.embedding IS NOT NULL ${detailFilter}${extraFilter} ${hardExcludeClause}
          ORDER BY cc.embedding <=> $1::vector
          LIMIT $2
        )
@@ -1083,15 +1122,13 @@ export class PGLiteEngine implements BrainEngine {
   async getBacklinkCounts(slugs: string[]): Promise<Map<string, number>> {
     const result = new Map<string, number>();
     if (slugs.length === 0) return result;
-    // Initialize all slugs to 0 so callers get a consistent map.
     for (const s of slugs) result.set(s, 0);
 
-    // PGLite needs explicit cast for array binding (does not auto-serialize JS arrays).
     const { rows } = await this.db.query(
       `SELECT p.slug AS slug, COUNT(l.id)::int AS cnt
        FROM pages p
        LEFT JOIN links l ON l.to_page_id = p.id
-       WHERE p.slug = ANY($1::text[])
+       WHERE p.deleted_at IS NULL AND p.slug = ANY($1::text[])
        GROUP BY p.slug`,
       [slugs]
     );
@@ -1108,7 +1145,8 @@ export class PGLiteEngine implements BrainEngine {
          COALESCE(p.title, p.slug) AS title,
          p.frontmatter->>'domain' AS domain
        FROM pages p
-       WHERE NOT EXISTS (
+       WHERE p.deleted_at IS NULL
+         AND NOT EXISTS (
          SELECT 1 FROM links l WHERE l.to_page_id = p.id
        )
        ORDER BY p.slug`
@@ -1289,45 +1327,163 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Versions
-  async createVersion(slug: string): Promise<PageVersion> {
+  async createVersion(slug: string, opts?: PageVersionOpts): Promise<PageVersion> {
+    const kind = opts?.kind ?? 'update';
+    const provenance = opts?.provenance ?? { source: 'unknown' };
+    const provJson = JSON.stringify(provenance);
+    const fromClause = opts?.snapshotIncludeDeleted
+      ? `FROM pages p WHERE p.slug = $1`
+      : `FROM pages p WHERE p.slug = $1 AND p.deleted_at IS NULL`;
     const { rows } = await this.db.query(
-      `INSERT INTO page_versions (page_id, compiled_truth, frontmatter)
-       SELECT id, compiled_truth, frontmatter
-       FROM pages WHERE slug = $1
-       RETURNING *`,
-      [slug]
+      `INSERT INTO page_versions (
+        page_id, source_id, slug, compiled_truth, frontmatter, tags, kind, provenance
+      )
+      SELECT
+        p.id, p.source_id, p.slug, p.compiled_truth, p.frontmatter,
+        COALESCE((
+          SELECT array_agg(tag ORDER BY tag) FROM tags t WHERE t.page_id = p.id
+        ), '{}'::text[]),
+        $2::text,
+        $3::jsonb
+      ${fromClause}
+      RETURNING *`,
+      [slug, kind, provJson],
     );
-    return rows[0] as unknown as PageVersion;
+    if (rows.length === 0) throw new Error(`createVersion failed: page "${slug}" not found`);
+    return pgliteRowToPageVersion(rows[0] as Record<string, unknown>);
   }
 
-  async getVersions(slug: string): Promise<PageVersion[]> {
-    const { rows } = await this.db.query(
-      `SELECT pv.* FROM page_versions pv
-       JOIN pages p ON p.id = pv.page_id
-       WHERE p.slug = $1
-       ORDER BY pv.snapshot_at DESC`,
-      [slug]
-    );
-    return rows as unknown as PageVersion[];
+  async getVersions(slug: string, opts?: { includeDeletedPage?: boolean }): Promise<PageVersion[]> {
+    let rows;
+    if (opts?.includeDeletedPage) {
+      const q = await this.db.query(
+        `SELECT * FROM page_versions WHERE slug = $1 ORDER BY snapshot_at DESC, id DESC`,
+        [slug],
+      );
+      rows = q.rows;
+    } else {
+      const q = await this.db.query(
+        `SELECT pv.* FROM page_versions pv
+         JOIN pages p ON p.id = pv.page_id AND p.deleted_at IS NULL
+         WHERE pv.slug = $1
+         ORDER BY pv.snapshot_at DESC, pv.id DESC`,
+        [slug],
+      );
+      rows = q.rows;
+    }
+    return (rows as Record<string, unknown>[]).map(pgliteRowToPageVersion);
   }
 
-  async revertToVersion(slug: string, versionId: number): Promise<void> {
+  async getPageVersionById(versionId: number): Promise<PageVersion | null> {
+    const { rows } = await this.db.query(`SELECT * FROM page_versions WHERE id = $1`, [versionId]);
+    if (rows.length === 0) return null;
+    return pgliteRowToPageVersion(rows[0] as Record<string, unknown>);
+  }
+
+  async revertToVersion(slug: string, versionId: number, opts?: PageVersionOpts): Promise<void> {
+    const tgt = await this.getPageVersionById(versionId);
+    if (!tgt || tgt.slug !== slug) throw new Error(`Version ${versionId} not found for slug "${slug}"`);
+
+    await this.createVersion(slug, {
+      kind: 'update',
+      provenance: { source: 'before_revert', ...opts?.provenance },
+      snapshotIncludeDeleted: true,
+    });
+
+    const fmJson = JSON.stringify(tgt.frontmatter ?? {});
+    if (tgt.kind === 'delete') {
+      await this.db.query(
+        `UPDATE pages SET
+          compiled_truth = $2,
+          frontmatter = $3::jsonb,
+          updated_at = now(),
+          deleted_at = now()
+        WHERE slug = $1`,
+        [slug, tgt.compiled_truth, fmJson],
+      );
+    } else {
+      await this.db.query(
+        `UPDATE pages SET
+          compiled_truth = $2,
+          frontmatter = $3::jsonb,
+          updated_at = now(),
+          deleted_at = NULL
+        WHERE slug = $1`,
+        [slug, tgt.compiled_truth, fmJson],
+      );
+    }
+
     await this.db.query(
-      `UPDATE pages SET
-        compiled_truth = pv.compiled_truth,
-        frontmatter = pv.frontmatter,
-        updated_at = now()
-      FROM page_versions pv
-      WHERE pages.slug = $1 AND pv.id = $2 AND pv.page_id = pages.id`,
-      [slug, versionId]
+      `DELETE FROM tags WHERE page_id = (SELECT id FROM pages WHERE slug = $1)`,
+      [slug],
     );
+    for (const tag of tgt.tags ?? []) {
+      await this.db.query(
+        `INSERT INTO tags (page_id, tag)
+         SELECT id, $2 FROM pages WHERE slug = $1
+         ON CONFLICT (page_id, tag) DO NOTHING`,
+        [slug, tag],
+      );
+    }
+  }
+
+  async diffPageVersions(slug: string, fromVersionId: number, toVersionId: number): Promise<PageVersionDiff> {
+    const a = await this.getPageVersionById(fromVersionId);
+    const b = await this.getPageVersionById(toVersionId);
+    if (!a || !b || a.slug !== slug || b.slug !== slug) {
+      throw new Error(`Versions not found or slug mismatch for "${slug}"`);
+    }
+    return {
+      compiled_truth: { from: a.compiled_truth, to: b.compiled_truth },
+      frontmatter: { from: a.frontmatter ?? {}, to: b.frontmatter ?? {} },
+      tags: { from: [...(a.tags ?? [])].sort(), to: [...(b.tags ?? [])].sort() },
+    };
+  }
+
+  async prunePageVersions(opts: { slug?: string; keepLast?: number; olderThan?: Date }): Promise<number> {
+    const keepLast = opts.keepLast !== undefined ? Math.max(0, Math.floor(opts.keepLast)) : null;
+    const olderThan = opts.olderThan ?? null;
+
+    if (opts.slug && keepLast != null && keepLast >= 0) {
+      const del = await this.db.query(
+        `DELETE FROM page_versions pv
+         WHERE pv.slug = $1
+           AND pv.id NOT IN (
+             SELECT id FROM page_versions
+             WHERE slug = $1
+             ORDER BY snapshot_at DESC, id DESC
+             LIMIT $2
+           )
+         RETURNING id`,
+        [opts.slug, keepLast],
+      );
+      return del.rows.length;
+    }
+
+    if (!opts.slug && olderThan) {
+      const del = await this.db.query(
+        `DELETE FROM page_versions WHERE snapshot_at < $1 RETURNING id`,
+        [olderThan],
+      );
+      return del.rows.length;
+    }
+
+    if (opts.slug && olderThan) {
+      const del = await this.db.query(
+        `DELETE FROM page_versions WHERE slug = $1 AND snapshot_at < $2 RETURNING id`,
+        [opts.slug, olderThan],
+      );
+      return del.rows.length;
+    }
+
+    return 0;
   }
 
   // Stats + health
   async getStats(): Promise<BrainStats> {
     const { rows: [stats] } = await this.db.query(`
       SELECT
-        (SELECT count(*) FROM pages) as page_count,
+        (SELECT count(*) FROM pages WHERE deleted_at IS NULL) as page_count,
         (SELECT count(*) FROM content_chunks) as chunk_count,
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NOT NULL) as embedded_count,
         (SELECT count(*) FROM links) as link_count,
@@ -1336,7 +1492,7 @@ export class PGLiteEngine implements BrainEngine {
     `);
 
     const { rows: types } = await this.db.query(
-      `SELECT type, count(*)::int as count FROM pages GROUP BY type ORDER BY count DESC`
+      `SELECT type, count(*)::int as count FROM pages WHERE deleted_at IS NULL GROUP BY type ORDER BY count DESC`
     );
     const pages_by_type: Record<string, number> = {};
     for (const t of types as { type: string; count: number }[]) {
@@ -1679,14 +1835,15 @@ export class PGLiteEngine implements BrainEngine {
   async logEvalCandidate(input: EvalCandidateInput): Promise<number> {
     const { rows } = await this.db.query<{ id: number }>(
       `INSERT INTO eval_candidates (
-         tool_name, query, retrieved_slugs, retrieved_chunk_ids, source_ids,
+         tool_name, query, params_jsonb, retrieved_slugs, retrieved_chunk_ids, source_ids,
          expand_enabled, detail, detail_resolved, vector_enabled, expansion_applied,
-         latency_ms, remote, job_id, subagent_id
-       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+         latency_ms, remote, job_id, subagent_id, mcp_token_name
+       ) VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
        RETURNING id`,
       [
         input.tool_name,
         input.query,
+        JSON.stringify(input.params_jsonb ?? {}),
         input.retrieved_slugs,
         input.retrieved_chunk_ids,
         input.source_ids,
@@ -1699,36 +1856,116 @@ export class PGLiteEngine implements BrainEngine {
         input.remote,
         input.job_id,
         input.subagent_id,
+        input.mcp_token_name ?? null,
       ]
     );
     return rows[0]!.id;
   }
 
-  async listEvalCandidates(filter?: { since?: Date; limit?: number; tool?: 'query' | 'search' }): Promise<EvalCandidate[]> {
+  async listEvalCandidates(filter?: {
+    since?: Date;
+    limit?: number;
+    tool?: EvalCaptureToolName;
+    slugHint?: string;
+    mcpTokenName?: string;
+  }): Promise<EvalCandidate[]> {
     const raw = filter?.limit;
     const limit = (raw === undefined || raw === null || !Number.isFinite(raw) || raw <= 0)
       ? 1000
       : Math.min(Math.floor(raw), 100000);
     const since = filter?.since ?? new Date(0);
-    const tool = filter?.tool ?? null;
-    // id DESC tiebreaker — see postgres-engine for rationale.
-    const { rows } = tool
-      ? await this.db.query(
+    const tool = filter?.tool;
+    const slugHint = filter?.slugHint?.trim();
+    const mcpTok = filter?.mcpTokenName;
+
+    const escLike = (s: string) => s.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+
+    if (slugHint) {
+      const like = `%${escLike(slugHint)}%`;
+      if (tool && mcpTok) {
+        const { rows } = await this.db.query(
+          `SELECT * FROM eval_candidates
+           WHERE created_at >= $1 AND tool_name = $2 AND mcp_token_name = $3
+             AND (query ILIKE $4 ESCAPE '\\' OR params_jsonb::text ILIKE $4 ESCAPE '\\')
+           ORDER BY created_at DESC, id DESC LIMIT $5`,
+          [since, tool, mcpTok, like, limit],
+        );
+        return rows as unknown as EvalCandidate[];
+      }
+      if (tool) {
+        const { rows } = await this.db.query(
           `SELECT * FROM eval_candidates
            WHERE created_at >= $1 AND tool_name = $2
-           ORDER BY created_at DESC, id DESC LIMIT $3`,
-          [since, tool, limit]
-        )
-      : await this.db.query(
-          `SELECT * FROM eval_candidates
-           WHERE created_at >= $1
-           ORDER BY created_at DESC, id DESC LIMIT $2`,
-          [since, limit]
+             AND (query ILIKE $3 ESCAPE '\\' OR params_jsonb::text ILIKE $3 ESCAPE '\\')
+           ORDER BY created_at DESC, id DESC LIMIT $4`,
+          [since, tool, like, limit],
         );
+        return rows as unknown as EvalCandidate[];
+      }
+      if (mcpTok) {
+        const { rows } = await this.db.query(
+          `SELECT * FROM eval_candidates
+           WHERE created_at >= $1 AND mcp_token_name = $2
+             AND (query ILIKE $3 ESCAPE '\\' OR params_jsonb::text ILIKE $3 ESCAPE '\\')
+           ORDER BY created_at DESC, id DESC LIMIT $4`,
+          [since, mcpTok, like, limit],
+        );
+        return rows as unknown as EvalCandidate[];
+      }
+      const { rows } = await this.db.query(
+        `SELECT * FROM eval_candidates
+         WHERE created_at >= $1
+           AND (query ILIKE $2 ESCAPE '\\' OR params_jsonb::text ILIKE $2 ESCAPE '\\')
+         ORDER BY created_at DESC, id DESC LIMIT $3`,
+        [since, like, limit],
+      );
+      return rows as unknown as EvalCandidate[];
+    }
+    if (tool && mcpTok) {
+      const { rows } = await this.db.query(
+        `SELECT * FROM eval_candidates
+         WHERE created_at >= $1 AND tool_name = $2 AND mcp_token_name = $3
+         ORDER BY created_at DESC, id DESC LIMIT $4`,
+        [since, tool, mcpTok, limit],
+      );
+      return rows as unknown as EvalCandidate[];
+    }
+    if (tool) {
+      const { rows } = await this.db.query(
+        `SELECT * FROM eval_candidates
+         WHERE created_at >= $1 AND tool_name = $2
+         ORDER BY created_at DESC, id DESC LIMIT $3`,
+        [since, tool, limit],
+      );
+      return rows as unknown as EvalCandidate[];
+    }
+    if (mcpTok) {
+      const { rows } = await this.db.query(
+        `SELECT * FROM eval_candidates
+         WHERE created_at >= $1 AND mcp_token_name = $2
+         ORDER BY created_at DESC, id DESC LIMIT $3`,
+        [since, mcpTok, limit],
+      );
+      return rows as unknown as EvalCandidate[];
+    }
+    const { rows } = await this.db.query(
+      `SELECT * FROM eval_candidates
+       WHERE created_at >= $1
+       ORDER BY created_at DESC, id DESC LIMIT $2`,
+      [since, limit],
+    );
     return rows as unknown as EvalCandidate[];
   }
 
-  async deleteEvalCandidatesBefore(date: Date): Promise<number> {
+  async deleteEvalCandidatesBefore(date: Date, opts?: { readToolsOnly?: boolean }): Promise<number> {
+    if (opts?.readToolsOnly) {
+      const { rows } = await this.db.query(
+        `DELETE FROM eval_candidates WHERE created_at < $1
+          AND tool_name NOT IN ('query', 'search') RETURNING id`,
+        [date]
+      );
+      return rows.length;
+    }
     const { rows } = await this.db.query(
       `DELETE FROM eval_candidates WHERE created_at < $1 RETURNING id`,
       [date]
@@ -1751,6 +1988,33 @@ export class PGLiteEngine implements BrainEngine {
     );
     return rows as unknown as EvalCaptureFailure[];
   }
+}
+
+function pgliteRowToPageVersion(row: Record<string, unknown>): PageVersion {
+  const k = row.kind as string;
+  const kind: PageVersion['kind'] =
+    k === 'create' || k === 'delete' || k === 'update' ? k : 'update';
+  const fm = typeof row.frontmatter === 'string'
+    ? JSON.parse(row.frontmatter) as Record<string, unknown>
+    : (row.frontmatter as Record<string, unknown>) ?? {};
+  let provRaw = row.provenance;
+  if (typeof provRaw === 'string') provRaw = JSON.parse(provRaw) as Record<string, unknown>;
+  const provenance =
+    provRaw && typeof provRaw === 'object' ? (provRaw as Record<string, unknown>) : {};
+  const tags = Array.isArray(row.tags) ? [...(row.tags as string[])] : [];
+  const sa = row.snapshot_at;
+  return {
+    id: row.id as number,
+    page_id: row.page_id == null ? null : (row.page_id as number),
+    source_id: (row.source_id as string) ?? 'default',
+    slug: (row.slug as string) ?? '',
+    compiled_truth: (row.compiled_truth as string) ?? '',
+    frontmatter: fm,
+    tags,
+    kind,
+    provenance,
+    snapshot_at: sa instanceof Date ? sa : new Date(sa as string),
+  };
 }
 
 function rowToCodeEdge(row: Record<string, unknown>): import('./types.ts').CodeEdgeResult {

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -55,6 +55,7 @@ CREATE TABLE IF NOT EXISTS pages (
   timeline      TEXT    NOT NULL DEFAULT '',
   frontmatter   JSONB   NOT NULL DEFAULT '{}',
   content_hash  TEXT,
+  deleted_at    TIMESTAMPTZ,
   created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
   CONSTRAINT pages_source_slug_key UNIQUE (source_id, slug)
@@ -169,13 +170,20 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_timeline_dedup ON timeline_entries(page_id
 -- ============================================================
 CREATE TABLE IF NOT EXISTS page_versions (
   id             SERIAL PRIMARY KEY,
-  page_id        INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+  page_id        INTEGER REFERENCES pages(id) ON DELETE SET NULL,
+  source_id      TEXT    NOT NULL DEFAULT 'default',
+  slug           TEXT    NOT NULL,
   compiled_truth TEXT    NOT NULL,
   frontmatter    JSONB   NOT NULL DEFAULT '{}',
+  tags           TEXT[]  NOT NULL DEFAULT '{}',
+  kind           TEXT    NOT NULL DEFAULT 'update'
+                   CHECK (kind IN ('create', 'update', 'delete')),
+  provenance     JSONB   NOT NULL DEFAULT '{}'::jsonb,
   snapshot_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE INDEX IF NOT EXISTS idx_versions_page ON page_versions(page_id);
+CREATE INDEX IF NOT EXISTS idx_page_versions_slug_snapshot ON page_versions(slug, snapshot_at DESC);
 
 -- ============================================================
 -- ingest_log (v0.18.0 Step 1: source_id deferred to v17, see src/schema.sql)
@@ -367,8 +375,12 @@ CREATE INDEX IF NOT EXISTS idx_cycle_locks_ttl ON gbrain_cycle_locks(ttl_expires
 -- cross-engine spec.
 CREATE TABLE IF NOT EXISTS eval_candidates (
   id                    SERIAL PRIMARY KEY,
-  tool_name             TEXT         NOT NULL CHECK (tool_name IN ('query', 'search')),
+  tool_name             TEXT         NOT NULL CHECK (tool_name IN (
+    'query', 'search', 'get_page', 'list_pages', 'traverse_graph', 'get_links',
+    'get_backlinks', 'get_timeline', 'get_tags', 'find_orphans', 'resolve_slugs', 'get_chunks'
+  )),
   query                 TEXT         NOT NULL CHECK (length(query) <= 51200),
+  params_jsonb          JSONB        NOT NULL DEFAULT '{}'::jsonb,
   retrieved_slugs       TEXT[]       NOT NULL DEFAULT '{}',
   retrieved_chunk_ids   INTEGER[]    NOT NULL DEFAULT '{}',
   source_ids            TEXT[]       NOT NULL DEFAULT '{}',
@@ -381,9 +393,11 @@ CREATE TABLE IF NOT EXISTS eval_candidates (
   remote                BOOLEAN      NOT NULL,
   job_id                INTEGER,
   subagent_id           INTEGER,
+  mcp_token_name        TEXT,
   created_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_eval_candidates_created_at ON eval_candidates(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_eval_candidates_tool_created ON eval_candidates(tool_name, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS eval_capture_failures (
   id      SERIAL       PRIMARY KEY,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -11,12 +11,13 @@ import type {
   Link, GraphNode, GraphPath,
   TimelineEntry, TimelineInput, TimelineOpts,
   RawData,
-  PageVersion,
+  PageVersion, PageVersionOpts, PageVersionDiff,
   BrainStats, BrainHealth,
   IngestLogEntry, IngestLogInput,
   EngineConfig,
   EvalCandidate, EvalCandidateInput,
   EvalCaptureFailure, EvalCaptureFailureReason,
+  EvalCaptureToolName,
 } from './types.ts';
 import { GBrainError } from './types.ts';
 import * as db from './db.ts';
@@ -278,12 +279,20 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Pages CRUD
-  async getPage(slug: string): Promise<Page | null> {
+  async getPage(slug: string, opts?: { includeDeleted?: boolean }): Promise<Page | null> {
     const sql = this.sql;
-    const rows = await sql`
-      SELECT id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at
-      FROM pages WHERE slug = ${slug}
-    `;
+    const inc = !!opts?.includeDeleted;
+    const rows = inc
+      ? await sql`
+        SELECT id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash,
+               deleted_at, created_at, updated_at
+        FROM pages WHERE slug = ${slug}
+      `
+      : await sql`
+        SELECT id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash,
+               deleted_at, created_at, updated_at
+        FROM pages WHERE slug = ${slug} AND deleted_at IS NULL
+      `;
     if (rows.length === 0) return null;
     return rowToPage(rows[0]);
   }
@@ -310,15 +319,47 @@ export class PostgresEngine implements BrainEngine {
         timeline = EXCLUDED.timeline,
         frontmatter = EXCLUDED.frontmatter,
         content_hash = EXCLUDED.content_hash,
+        deleted_at = NULL,
         updated_at = now()
-      RETURNING id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at
+      RETURNING id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash,
+        deleted_at, created_at, updated_at
     `;
     return rowToPage(rows[0]);
   }
 
-  async deletePage(slug: string): Promise<void> {
+  async purgePage(slug: string): Promise<void> {
     const sql = this.sql;
+    await sql`DELETE FROM page_versions WHERE slug = ${slug}`;
     await sql`DELETE FROM pages WHERE slug = ${slug}`;
+  }
+
+  async softDeletePage(slug: string, opts?: PageVersionOpts): Promise<void> {
+    const sql = this.sql;
+    const row = await sql`
+      SELECT id FROM pages WHERE slug = ${slug} AND deleted_at IS NULL
+    `;
+    if (row.length === 0) throw new Error(`softDelete failed: active page "${slug}" not found`);
+    await this.createVersion(slug, { ...opts, kind: opts?.kind ?? 'update' });
+    await sql`UPDATE pages SET deleted_at = now(), updated_at = now() WHERE slug = ${slug} AND deleted_at IS NULL`;
+    const tombProv = opts?.provenance ?? { source: 'soft_delete' };
+    await sql`
+      INSERT INTO page_versions (page_id, source_id, slug, compiled_truth, frontmatter, tags, kind, provenance)
+      SELECT p.id, p.source_id, p.slug, p.compiled_truth, p.frontmatter,
+        COALESCE((
+          SELECT array_agg(tag ORDER BY tag) FROM tags t WHERE t.page_id = p.id
+        ), '{}'::text[]),
+        'delete',
+        ${sql.json(tombProv as Parameters<typeof sql.json>[0])}
+      FROM pages p WHERE p.slug = ${slug}
+    `;
+  }
+
+  async resurrectSoftDeletedPage(slug: string): Promise<void> {
+    const sql = this.sql;
+    await sql`
+      UPDATE pages SET deleted_at = NULL, updated_at = now()
+      WHERE slug = ${slug} AND deleted_at IS NOT NULL
+    `;
   }
 
   async listPages(filters?: PageFilters): Promise<Page[]> {
@@ -336,6 +377,7 @@ export class PostgresEngine implements BrainEngine {
     const tagJoin = filters?.tag ? sql`JOIN tags t ON t.page_id = p.id` : sql``;
     const tagCondition = filters?.tag ? sql`AND t.tag = ${filters.tag}` : sql``;
     const updatedCondition = updatedAfter ? sql`AND p.updated_at > ${updatedAfter}::timestamptz` : sql``;
+    const deletedCondition = filters?.includeDeleted ? sql`` : sql`AND p.deleted_at IS NULL`;
     // slugPrefix uses the (source_id, slug) UNIQUE btree index for range scans.
     // Escape LIKE metacharacters so the user prefix is treated as a literal.
     const slugPrefix = filters?.slugPrefix;
@@ -346,7 +388,7 @@ export class PostgresEngine implements BrainEngine {
     const rows = await sql`
       SELECT p.* FROM pages p
       ${tagJoin}
-      WHERE 1=1 ${typeCondition} ${tagCondition} ${updatedCondition} ${slugCondition}
+      WHERE 1=1 ${deletedCondition} ${typeCondition} ${tagCondition} ${updatedCondition} ${slugCondition}
       ORDER BY p.updated_at DESC LIMIT ${limit} OFFSET ${offset}
     `;
 
@@ -355,7 +397,7 @@ export class PostgresEngine implements BrainEngine {
 
   async getAllSlugs(): Promise<Set<string>> {
     const sql = this.sql;
-    const rows = await sql`SELECT slug FROM pages`;
+    const rows = await sql`SELECT slug FROM pages WHERE deleted_at IS NULL`;
     return new Set(rows.map((r) => r.slug as string));
   }
 
@@ -363,14 +405,14 @@ export class PostgresEngine implements BrainEngine {
     const sql = this.sql;
 
     // Try exact match first
-    const exact = await sql`SELECT slug FROM pages WHERE slug = ${partial}`;
+    const exact = await sql`SELECT slug FROM pages WHERE slug = ${partial} AND deleted_at IS NULL`;
     if (exact.length > 0) return [exact[0].slug];
 
     // Fuzzy match via pg_trgm
     const fuzzy = await sql`
       SELECT slug, similarity(title, ${partial}) AS sim
       FROM pages
-      WHERE title % ${partial} OR slug ILIKE ${'%' + partial + '%'}
+      WHERE deleted_at IS NULL AND (title % ${partial} OR slug ILIKE ${'%' + partial + '%'})
       ORDER BY sim DESC
       LIMIT 5
     `;
@@ -451,6 +493,7 @@ export class PostgresEngine implements BrainEngine {
         FROM content_chunks cc
         JOIN pages p ON p.id = cc.page_id
         WHERE cc.search_vector @@ websearch_to_tsquery('english', $1)
+          AND p.deleted_at IS NULL
           ${typeClause}
           ${excludeSlugsClause}
           ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
@@ -550,6 +593,7 @@ export class PostgresEngine implements BrainEngine {
       FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id
       WHERE cc.search_vector @@ websearch_to_tsquery('english', $1)
+        AND p.deleted_at IS NULL
         ${typeClause}
         ${excludeSlugsClause}
         ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
@@ -635,6 +679,7 @@ export class PostgresEngine implements BrainEngine {
         FROM content_chunks cc
         JOIN pages p ON p.id = cc.page_id
         WHERE cc.embedding IS NOT NULL
+          AND p.deleted_at IS NULL
           ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
           ${typeClause}
           ${excludeSlugsClause}
@@ -1137,7 +1182,7 @@ export class PostgresEngine implements BrainEngine {
       SELECT p.slug as slug, COUNT(l.id)::int as cnt
       FROM pages p
       LEFT JOIN links l ON l.to_page_id = p.id
-      WHERE p.slug = ANY(${slugs}::text[])
+      WHERE p.deleted_at IS NULL AND p.slug = ANY(${slugs}::text[])
       GROUP BY p.slug
     `;
     for (const r of rows as unknown as { slug: string; cnt: number }[]) {
@@ -1154,7 +1199,8 @@ export class PostgresEngine implements BrainEngine {
         COALESCE(p.title, p.slug) AS title,
         p.frontmatter->>'domain' AS domain
       FROM pages p
-      WHERE NOT EXISTS (
+      WHERE p.deleted_at IS NULL
+        AND NOT EXISTS (
         SELECT 1 FROM links l WHERE l.to_page_id = p.id
       )
       ORDER BY p.slug
@@ -1339,39 +1385,152 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Versions
-  async createVersion(slug: string): Promise<PageVersion> {
+  async createVersion(slug: string, opts?: PageVersionOpts): Promise<PageVersion> {
     const sql = this.sql;
+    const kind = opts?.kind ?? 'update';
+    const provenance = opts?.provenance ?? { source: 'unknown' };
+    const delFrag = opts?.snapshotIncludeDeleted ? sql`` : sql`AND p.deleted_at IS NULL`;
     const rows = await sql`
-      INSERT INTO page_versions (page_id, compiled_truth, frontmatter)
-      SELECT id, compiled_truth, frontmatter
-      FROM pages WHERE slug = ${slug}
+      INSERT INTO page_versions (
+        page_id, source_id, slug, compiled_truth, frontmatter, tags, kind, provenance
+      )
+      SELECT
+        p.id, p.source_id, p.slug, p.compiled_truth, p.frontmatter,
+        COALESCE((
+          SELECT array_agg(tag ORDER BY tag) FROM tags t WHERE t.page_id = p.id
+        ), '{}'::text[]),
+        ${kind},
+        ${sql.json(provenance as Parameters<typeof sql.json>[0])}
+      FROM pages p WHERE p.slug = ${slug} ${delFrag}
       RETURNING *
     `;
     if (rows.length === 0) throw new Error(`createVersion failed: page "${slug}" not found`);
-    return rows[0] as unknown as PageVersion;
+    return pgRowToPageVersion(rows[0]);
   }
 
-  async getVersions(slug: string): Promise<PageVersion[]> {
+  async getVersions(slug: string, opts?: { includeDeletedPage?: boolean }): Promise<PageVersion[]> {
     const sql = this.sql;
-    const rows = await sql`
-      SELECT pv.* FROM page_versions pv
-      JOIN pages p ON p.id = pv.page_id
-      WHERE p.slug = ${slug}
-      ORDER BY pv.snapshot_at DESC
-    `;
-    return rows as unknown as PageVersion[];
+    let rows;
+    if (opts?.includeDeletedPage) {
+      rows = await sql`
+        SELECT * FROM page_versions
+        WHERE slug = ${slug}
+        ORDER BY snapshot_at DESC, id DESC
+      `;
+    } else {
+      rows = await sql`
+        SELECT pv.* FROM page_versions pv
+        JOIN pages p ON p.id = pv.page_id AND p.deleted_at IS NULL
+        WHERE pv.slug = ${slug}
+        ORDER BY pv.snapshot_at DESC, pv.id DESC
+      `;
+    }
+    return rows.map(pgRowToPageVersion);
   }
 
-  async revertToVersion(slug: string, versionId: number): Promise<void> {
+  async getPageVersionById(versionId: number): Promise<PageVersion | null> {
     const sql = this.sql;
+    const rows = await sql`SELECT * FROM page_versions WHERE id = ${versionId}`;
+    if (rows.length === 0) return null;
+    return pgRowToPageVersion(rows[0]);
+  }
+
+  async revertToVersion(slug: string, versionId: number, opts?: PageVersionOpts): Promise<void> {
+    const sql = this.sql;
+    const tgt = await this.getPageVersionById(versionId);
+    if (!tgt || tgt.slug !== slug) throw new Error(`Version ${versionId} not found for slug "${slug}"`);
+
+    await this.createVersion(slug, {
+      kind: 'update',
+      provenance: { source: 'before_revert', ...opts?.provenance },
+      snapshotIncludeDeleted: true,
+    });
+
+    const fm = sql.json(tgt.frontmatter as Parameters<typeof sql.json>[0]);
+    if (tgt.kind === 'delete') {
+      await sql`
+        UPDATE pages SET
+          compiled_truth = ${tgt.compiled_truth},
+          frontmatter = ${fm},
+          updated_at = now(),
+          deleted_at = now()
+        WHERE slug = ${slug}
+      `;
+    } else {
+      await sql`
+        UPDATE pages SET
+          compiled_truth = ${tgt.compiled_truth},
+          frontmatter = ${fm},
+          updated_at = now(),
+          deleted_at = NULL
+        WHERE slug = ${slug}
+      `;
+    }
+
     await sql`
-      UPDATE pages SET
-        compiled_truth = pv.compiled_truth,
-        frontmatter = pv.frontmatter,
-        updated_at = now()
-      FROM page_versions pv
-      WHERE pages.slug = ${slug} AND pv.id = ${versionId} AND pv.page_id = pages.id
+      DELETE FROM tags
+      WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug})
     `;
+    for (const tag of tgt.tags ?? []) {
+      await sql`
+        INSERT INTO tags (page_id, tag)
+        SELECT id, ${tag} FROM pages WHERE slug = ${slug}
+        ON CONFLICT (page_id, tag) DO NOTHING
+      `;
+    }
+  }
+
+  async diffPageVersions(slug: string, fromVersionId: number, toVersionId: number): Promise<PageVersionDiff> {
+    const a = await this.getPageVersionById(fromVersionId);
+    const b = await this.getPageVersionById(toVersionId);
+    if (!a || !b || a.slug !== slug || b.slug !== slug) {
+      throw new Error(`Versions not found or slug mismatch for "${slug}"`);
+    }
+    return {
+      compiled_truth: { from: a.compiled_truth, to: b.compiled_truth },
+      frontmatter: { from: a.frontmatter ?? {}, to: b.frontmatter ?? {} },
+      tags: { from: [...(a.tags ?? [])].sort(), to: [...(b.tags ?? [])].sort() },
+    };
+  }
+
+  async prunePageVersions(opts: { slug?: string; keepLast?: number; olderThan?: Date }): Promise<number> {
+    const sql = this.sql;
+    const keepLast = opts.keepLast !== undefined ? Math.max(0, Math.floor(opts.keepLast)) : null;
+    const olderThan = opts.olderThan ?? null;
+
+    if (opts.slug && keepLast != null && keepLast >= 0) {
+      const del = await sql`
+        DELETE FROM page_versions pv
+        WHERE pv.slug = ${opts.slug}
+          AND pv.id NOT IN (
+            SELECT id FROM page_versions
+            WHERE slug = ${opts.slug}
+            ORDER BY snapshot_at DESC, id DESC
+            LIMIT ${keepLast}
+          )
+        RETURNING id
+      `;
+      return del.length;
+    }
+
+    if (!opts.slug && olderThan) {
+      const del = await sql`
+        DELETE FROM page_versions WHERE snapshot_at < ${olderThan}
+        RETURNING id
+      `;
+      return del.length;
+    }
+
+    if (opts.slug && olderThan) {
+      const del = await sql`
+        DELETE FROM page_versions
+        WHERE slug = ${opts.slug} AND snapshot_at < ${olderThan}
+        RETURNING id
+      `;
+      return del.length;
+    }
+
+    return 0;
   }
 
   // Stats + health
@@ -1379,7 +1538,7 @@ export class PostgresEngine implements BrainEngine {
     const sql = this.sql;
     const [stats] = await sql`
       SELECT
-        (SELECT count(*) FROM pages) as page_count,
+        (SELECT count(*) FROM pages WHERE deleted_at IS NULL) as page_count,
         (SELECT count(*) FROM content_chunks) as chunk_count,
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NOT NULL) as embedded_count,
         (SELECT count(*) FROM links) as link_count,
@@ -1388,7 +1547,7 @@ export class PostgresEngine implements BrainEngine {
     `;
 
     const types = await sql`
-      SELECT type, count(*)::int as count FROM pages GROUP BY type ORDER BY count DESC
+      SELECT type, count(*)::int as count FROM pages WHERE deleted_at IS NULL GROUP BY type ORDER BY count DESC
     `;
     const pages_by_type: Record<string, number> = {};
     for (const t of types) {
@@ -1742,50 +1901,121 @@ export class PostgresEngine implements BrainEngine {
   // Eval capture (v0.25.0). See BrainEngine interface docs.
   async logEvalCandidate(input: EvalCandidateInput): Promise<number> {
     const sql = this.sql;
+    const paramsJson = sql.json((input.params_jsonb ?? {}) as unknown as Parameters<typeof sql.json>[0]);
     const rows = await sql`
       INSERT INTO eval_candidates (
-        tool_name, query, retrieved_slugs, retrieved_chunk_ids, source_ids,
+        tool_name, query, params_jsonb, retrieved_slugs, retrieved_chunk_ids, source_ids,
         expand_enabled, detail, detail_resolved, vector_enabled, expansion_applied,
-        latency_ms, remote, job_id, subagent_id
+        latency_ms, remote, job_id, subagent_id, mcp_token_name
       ) VALUES (
-        ${input.tool_name}, ${input.query}, ${input.retrieved_slugs}, ${input.retrieved_chunk_ids}, ${input.source_ids},
+        ${input.tool_name}, ${input.query}, ${paramsJson}, ${input.retrieved_slugs}, ${input.retrieved_chunk_ids}, ${input.source_ids},
         ${input.expand_enabled}, ${input.detail}, ${input.detail_resolved}, ${input.vector_enabled}, ${input.expansion_applied},
-        ${input.latency_ms}, ${input.remote}, ${input.job_id}, ${input.subagent_id}
+        ${input.latency_ms}, ${input.remote}, ${input.job_id}, ${input.subagent_id}, ${input.mcp_token_name ?? null}
       )
       RETURNING id
     `;
     return rows[0]!.id as number;
   }
 
-  async listEvalCandidates(filter?: { since?: Date; limit?: number; tool?: 'query' | 'search' }): Promise<EvalCandidate[]> {
+  async listEvalCandidates(filter?: {
+    since?: Date;
+    limit?: number;
+    tool?: EvalCaptureToolName;
+    slugHint?: string;
+    mcpTokenName?: string;
+  }): Promise<EvalCandidate[]> {
     const sql = this.sql;
     const raw = filter?.limit;
     const limit = (raw === undefined || raw === null || !Number.isFinite(raw) || raw <= 0)
       ? 1000
       : Math.min(Math.floor(raw), 100000);
     const since = filter?.since ?? new Date(0);
-    const tool = filter?.tool ?? null;
-    // id DESC tiebreaker so same-millisecond inserts return deterministically
-    // — without this, `gbrain eval export --since` could dupe or miss rows
-    // across non-overlapping windows.
-    const rows = tool
-      ? await sql`
+    const tool = filter?.tool;
+    const slugHint = filter?.slugHint?.trim();
+    const mcpTok = filter?.mcpTokenName;
+
+    let rows;
+
+    const escLike = (s: string) => s.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+
+    if (slugHint) {
+      const like = `%${escLike(slugHint)}%`;
+      if (tool && mcpTok) {
+        rows = await sql`
           SELECT * FROM eval_candidates
-          WHERE created_at >= ${since} AND tool_name = ${tool}
-          ORDER BY created_at DESC, id DESC
-          LIMIT ${limit}
-        `
-      : await sql`
-          SELECT * FROM eval_candidates
-          WHERE created_at >= ${since}
+          WHERE created_at >= ${since} AND tool_name = ${tool} AND mcp_token_name = ${mcpTok}
+            AND (query ILIKE ${like} ESCAPE '\\' OR params_jsonb::text ILIKE ${like} ESCAPE '\\')
           ORDER BY created_at DESC, id DESC
           LIMIT ${limit}
         `;
+      } else if (tool) {
+        rows = await sql`
+          SELECT * FROM eval_candidates
+          WHERE created_at >= ${since} AND tool_name = ${tool}
+            AND (query ILIKE ${like} ESCAPE '\\' OR params_jsonb::text ILIKE ${like} ESCAPE '\\')
+          ORDER BY created_at DESC, id DESC
+          LIMIT ${limit}
+        `;
+      } else if (mcpTok) {
+        rows = await sql`
+          SELECT * FROM eval_candidates
+          WHERE created_at >= ${since} AND mcp_token_name = ${mcpTok}
+            AND (query ILIKE ${like} ESCAPE '\\' OR params_jsonb::text ILIKE ${like} ESCAPE '\\')
+          ORDER BY created_at DESC, id DESC
+          LIMIT ${limit}
+        `;
+      } else {
+        rows = await sql`
+          SELECT * FROM eval_candidates
+          WHERE created_at >= ${since}
+            AND (query ILIKE ${like} ESCAPE '\\' OR params_jsonb::text ILIKE ${like} ESCAPE '\\')
+          ORDER BY created_at DESC, id DESC
+          LIMIT ${limit}
+        `;
+      }
+    } else if (tool && mcpTok) {
+      rows = await sql`
+        SELECT * FROM eval_candidates
+        WHERE created_at >= ${since} AND tool_name = ${tool} AND mcp_token_name = ${mcpTok}
+        ORDER BY created_at DESC, id DESC
+        LIMIT ${limit}
+      `;
+    } else if (tool) {
+      rows = await sql`
+        SELECT * FROM eval_candidates
+        WHERE created_at >= ${since} AND tool_name = ${tool}
+        ORDER BY created_at DESC, id DESC
+        LIMIT ${limit}
+      `;
+    } else if (mcpTok) {
+      rows = await sql`
+        SELECT * FROM eval_candidates
+        WHERE created_at >= ${since} AND mcp_token_name = ${mcpTok}
+        ORDER BY created_at DESC, id DESC
+        LIMIT ${limit}
+      `;
+    } else {
+      rows = await sql`
+        SELECT * FROM eval_candidates
+        WHERE created_at >= ${since}
+        ORDER BY created_at DESC, id DESC
+        LIMIT ${limit}
+      `;
+    }
+
     return rows as unknown as EvalCandidate[];
   }
 
-  async deleteEvalCandidatesBefore(date: Date): Promise<number> {
+  async deleteEvalCandidatesBefore(date: Date, opts?: { readToolsOnly?: boolean }): Promise<number> {
     const sql = this.sql;
+    if (opts?.readToolsOnly) {
+      const rows = await sql`
+        DELETE FROM eval_candidates WHERE created_at < ${date}
+          AND tool_name NOT IN ('query', 'search')
+        RETURNING id
+      `;
+      return rows.length;
+    }
     const rows = await sql`
       DELETE FROM eval_candidates WHERE created_at < ${date} RETURNING id
     `;
@@ -1807,6 +2037,33 @@ export class PostgresEngine implements BrainEngine {
     `;
     return rows as unknown as EvalCaptureFailure[];
   }
+}
+
+function pgRowToPageVersion(row: Record<string, unknown>): PageVersion {
+  const k = row.kind as string;
+  const kind: PageVersion['kind'] =
+    k === 'create' || k === 'delete' || k === 'update' ? k : 'update';
+  const tags = row.tags as string[] | null | undefined;
+  const fm = typeof row.frontmatter === 'string'
+    ? JSON.parse(row.frontmatter) as Record<string, unknown>
+    : (row.frontmatter as Record<string, unknown>) ?? {};
+  const prov = typeof row.provenance === 'string'
+    ? JSON.parse(row.provenance) as Record<string, unknown>
+    : (row.provenance as Record<string, unknown>) ?? {};
+  return {
+    id: row.id as number,
+    page_id: row.page_id == null ? null : (row.page_id as number),
+    source_id: (row.source_id as string) ?? 'default',
+    slug: (row.slug as string) ?? '',
+    compiled_truth: (row.compiled_truth as string) ?? '',
+    frontmatter: fm,
+    tags: Array.isArray(tags) ? [...tags] : [],
+    kind,
+    provenance: prov,
+    snapshot_at: row.snapshot_at instanceof Date
+      ? row.snapshot_at
+      : new Date(row.snapshot_at as string),
+  };
 }
 
 function pgRowToCodeEdge(row: Record<string, unknown>): import('./types.ts').CodeEdgeResult {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -18,6 +18,7 @@ export interface Page {
   content_hash?: string;
   created_at: Date;
   updated_at: Date;
+  deleted_at?: Date | null;
 }
 
 export type PageKind = 'markdown' | 'code';
@@ -53,7 +54,38 @@ export interface PageFilters {
    * queries to a tier directory without loading every page into memory.
    */
   slugPrefix?: string;
+  /** When true, include soft-deleted pages (deleted_at IS NOT NULL). */
+  includeDeleted?: boolean;
 }
+
+export type PageVersionKind = 'create' | 'update' | 'delete';
+
+export interface PageVersionOpts {
+  kind?: PageVersionKind;
+  provenance?: Record<string, unknown>;
+  /** Snapshot source row even when soft-deleted (revert precondition). */
+  snapshotIncludeDeleted?: boolean;
+}
+
+export interface PageVersionDiff {
+  compiled_truth: { from: string; to: string };
+  frontmatter: { from: Record<string, unknown>; to: Record<string, unknown> };
+  tags: { from: string[]; to: string[] };
+}
+
+export type EvalCaptureToolName =
+  | 'query'
+  | 'search'
+  | 'get_page'
+  | 'list_pages'
+  | 'traverse_graph'
+  | 'get_links'
+  | 'get_backlinks'
+  | 'get_timeline'
+  | 'get_tags'
+  | 'find_orphans'
+  | 'resolve_slugs'
+  | 'get_chunks';
 
 // Chunks
 export interface Chunk {
@@ -309,9 +341,14 @@ export interface RawData {
 // Versions
 export interface PageVersion {
   id: number;
-  page_id: number;
+  page_id: number | null;
+  source_id: string;
+  slug: string;
   compiled_truth: string;
   frontmatter: Record<string, unknown>;
+  tags: string[];
+  kind: PageVersionKind;
+  provenance: Record<string, unknown>;
   snapshot_at: Date;
 }
 
@@ -395,9 +432,10 @@ export interface IngestLogInput {
 // eval_capture_failures table records insert failures so gbrain doctor can
 // surface silent capture drops cross-process.
 export interface EvalCandidateInput {
-  tool_name: 'query' | 'search';
-  /** Already PII-scrubbed by captureEvalCandidate before this point. */
+  tool_name: EvalCaptureToolName;
+  /** Already PII-scrubbed by captureEvalCandidate before this point. Summary string for reads. */
   query: string;
+  params_jsonb?: Record<string, unknown>;
   retrieved_slugs: string[];
   retrieved_chunk_ids: number[];
   source_ids: string[];
@@ -416,6 +454,7 @@ export interface EvalCandidateInput {
   remote: boolean;
   job_id: number | null;
   subagent_id: number | null;
+  mcp_token_name?: string | null;
 }
 
 export interface EvalCandidate extends EvalCandidateInput {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -29,7 +29,10 @@ export function contentHash(page: PageInput): string {
 }
 
 export function rowToPage(row: Record<string, unknown>): Page {
-  return {
+  const dm = row.deleted_at as string | Date | null | undefined;
+  let deleted_at: Date | undefined;
+  if (dm != null) deleted_at = new Date(dm instanceof Date ? dm.toISOString() : (dm as string));
+  const out: Page = {
     id: row.id as number,
     slug: row.slug as string,
     type: row.type as PageType,
@@ -41,6 +44,8 @@ export function rowToPage(row: Record<string, unknown>): Page {
     created_at: new Date(row.created_at as string),
     updated_at: new Date(row.updated_at as string),
   };
+  if (deleted_at != null && !Number.isNaN(deleted_at.getTime())) out.deleted_at = deleted_at;
+  return out;
 }
 
 /**

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -21,6 +21,8 @@ export interface DispatchOpts {
   remote?: boolean;
   /** Override the default stderr logger (e.g. CLI uses console.* directly). */
   logger?: OperationContext['logger'];
+  /** Bearer token name used by the HTTP transport, propagated into audit rows. */
+  mcpTokenName?: string;
 }
 
 /** Validate required params exist and have the expected type. Returns null on success, error message on failure. */
@@ -59,6 +61,7 @@ export function buildOperationContext(
     logger: opts.logger || stderrLogger,
     dryRun: !!params.dry_run,
     remote: opts.remote ?? true,
+    mcpTokenName: opts.mcpTokenName,
   };
 }
 

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -320,7 +320,7 @@ export async function startHttpTransport(opts: HttpTransportOptions) {
       if (method === 'tools/call') {
         const toolName: string = params?.name ?? 'unknown';
         const args: Record<string, unknown> = params?.arguments ?? {};
-        const result = await dispatchToolCall(engine, toolName, args, { remote: true });
+        const result = await dispatchToolCall(engine, toolName, args, { remote: true, mcpTokenName: auth.tokenName! });
         const status = result.isError ? 'error' : 'success';
         logRequest(auth.tokenName!, `tools/call:${toolName}`, status, Date.now() - startedMs);
         return Response.json(

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS pages (
   timeline      TEXT    NOT NULL DEFAULT '',
   frontmatter   JSONB   NOT NULL DEFAULT '{}',
   content_hash  TEXT,
+  deleted_at    TIMESTAMPTZ,
   created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
   CONSTRAINT pages_source_slug_key UNIQUE (source_id, slug)
@@ -283,13 +284,20 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_timeline_dedup ON timeline_entries(page_id
 -- ============================================================
 CREATE TABLE IF NOT EXISTS page_versions (
   id             SERIAL PRIMARY KEY,
-  page_id        INTEGER NOT NULL REFERENCES pages(id) ON DELETE CASCADE,
+  page_id        INTEGER REFERENCES pages(id) ON DELETE SET NULL,
+  source_id      TEXT    NOT NULL DEFAULT 'default',
+  slug           TEXT    NOT NULL,
   compiled_truth TEXT    NOT NULL,
   frontmatter    JSONB   NOT NULL DEFAULT '{}',
+  tags           TEXT[]  NOT NULL DEFAULT '{}',
+  kind           TEXT    NOT NULL DEFAULT 'update'
+                   CHECK (kind IN ('create', 'update', 'delete')),
+  provenance     JSONB   NOT NULL DEFAULT '{}'::jsonb,
   snapshot_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE INDEX IF NOT EXISTS idx_versions_page ON page_versions(page_id);
+CREATE INDEX IF NOT EXISTS idx_page_versions_slug_snapshot ON page_versions(slug, snapshot_at DESC);
 
 -- ============================================================
 -- ingest_log
@@ -637,8 +645,12 @@ CREATE INDEX IF NOT EXISTS idx_cycle_locks_ttl ON gbrain_cycle_locks(ttl_expires
 -- CLI process boundaries).
 CREATE TABLE IF NOT EXISTS eval_candidates (
   id                    SERIAL PRIMARY KEY,
-  tool_name             TEXT         NOT NULL CHECK (tool_name IN ('query', 'search')),
+  tool_name             TEXT         NOT NULL CHECK (tool_name IN (
+    'query', 'search', 'get_page', 'list_pages', 'traverse_graph', 'get_links',
+    'get_backlinks', 'get_timeline', 'get_tags', 'find_orphans', 'resolve_slugs', 'get_chunks'
+  )),
   query                 TEXT         NOT NULL CHECK (length(query) <= 51200),
+  params_jsonb          JSONB        NOT NULL DEFAULT '{}'::jsonb,
   retrieved_slugs       TEXT[]       NOT NULL DEFAULT '{}',
   retrieved_chunk_ids   INTEGER[]    NOT NULL DEFAULT '{}',
   source_ids            TEXT[]       NOT NULL DEFAULT '{}',
@@ -651,9 +663,11 @@ CREATE TABLE IF NOT EXISTS eval_candidates (
   remote                BOOLEAN      NOT NULL,
   job_id                INTEGER,
   subagent_id           INTEGER,
+  mcp_token_name        TEXT,
   created_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_eval_candidates_created_at ON eval_candidates(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_eval_candidates_tool_created ON eval_candidates(tool_name, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS eval_capture_failures (
   id      SERIAL       PRIMARY KEY,

--- a/test/code-def-refs.test.ts
+++ b/test/code-def-refs.test.ts
@@ -31,7 +31,7 @@ beforeAll(async () => {
   disconnect(): Promise<void>;
   getPage(slug: string): Promise<{ slug: string; title: string; content: string } | null>;
   putPage(slug: string, page: { title: string; content: string }): Promise<void>;
-  deletePage(slug: string): Promise<void>;
+  purgePage(slug: string): Promise<void>;
   searchKeyword(query: string, opts?: { limit?: number }): Promise<Array<{ slug: string; score: number }>>;
   searchVector(embedding: Float32Array, opts?: { limit?: number }): Promise<Array<{ slug: string; score: number }>>;
   getChunks(slug: string): Promise<Array<{ chunk_text: string; embedding: Float32Array | null }>>;
@@ -68,7 +68,7 @@ export class PGLiteEngine implements BrainEngine {
     console.log('put', slug, page.title, page.content.length, 'chars');
   }
 
-  async deletePage(slug: string): Promise<void> {
+  async purgePage(slug: string): Promise<void> {
     if (!slug) throw new Error('slug required');
     console.log('delete', slug);
   }

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -896,6 +896,23 @@ describe('migration v31 — eval_capture_tables', () => {
   });
 });
 
+describe('migration v32 — page_versions_read_audit_soft_delete', () => {
+  test('single shared sql bumps pages + page_versions + eval_candidates', () => {
+    const v32 = MIGRATIONS.find(m => m.version === 32);
+    expect(v32).toBeDefined();
+    expect(v32?.name).toBe('page_versions_read_audit_soft_delete');
+    expect(v32?.sql).toContain('pages ADD COLUMN IF NOT EXISTS deleted_at');
+    expect(v32?.sql).toContain('page_versions_kind_check');
+    expect(v32?.sql).toContain('params_jsonb');
+    expect(v32?.sql).toContain('mcp_token_name');
+    expect(v32?.sql).toContain("'get_chunks'");
+  });
+
+  test('LATEST_VERSION caught up to 32', () => {
+    expect(LATEST_VERSION).toBeGreaterThanOrEqual(32);
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────
 // PR #363 regression guards — session timeouts via startup parameters
 // resolveSessionTimeouts — GBRAIN_*_TIMEOUT env overrides

--- a/test/page-versions.test.ts
+++ b/test/page-versions.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import type { PageInput } from '../src/core/types.ts';
+
+let engine: PGLiteEngine;
+
+const testPage: PageInput = {
+  type: 'concept',
+  title: 'Pv',
+  compiled_truth: 'one',
+  timeline: '',
+};
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+async function truncateAll() {
+  await (engine as any).db.exec(`TRUNCATE TABLE eval_candidates RESTART IDENTITY`);
+  await (engine as any).db.exec(`TRUNCATE TABLE pages RESTART IDENTITY CASCADE`);
+}
+
+describe('page versions + soft delete (PGLite)', () => {
+  beforeEach(truncateAll);
+
+  test('revertToVersion restores prior compiled_truth', async () => {
+    await engine.putPage('test/rv', { ...testPage, compiled_truth: 'alpha' });
+    const vid = (await engine.createVersion('test/rv', { provenance: { source: 'snap' }, kind: 'update' })).id;
+    await engine.putPage('test/rv', { ...testPage, compiled_truth: 'beta' });
+    await engine.revertToVersion('test/rv', vid);
+    const p = await engine.getPage('test/rv');
+    expect(p?.compiled_truth).toBe('alpha');
+  });
+
+  test('softDelete hides page from default getPage/list; includeDeleted restores getPage', async () => {
+    await engine.putPage('test/sd', testPage);
+    await engine.softDeletePage('test/sd');
+    expect(await engine.getPage('test/sd')).toBeNull();
+    expect((await engine.listPages()).some(p => p.slug === 'test/sd')).toBe(false);
+    const tomb = await engine.getPage('test/sd', { includeDeleted: true });
+    expect(tomb?.deleted_at).toBeTruthy();
+    const vv = await engine.getVersions('test/sd', { includeDeletedPage: true });
+    expect(vv.some(v => v.kind === 'delete')).toBe(true);
+  });
+
+  test('resurrectSoftDeletedPage clears tombstone visibility', async () => {
+    await engine.putPage('test/rs', testPage);
+    await engine.softDeletePage('test/rs');
+    await engine.resurrectSoftDeletedPage('test/rs');
+    const p = await engine.getPage('test/rs');
+    expect(p).not.toBeNull();
+    expect(p?.deleted_at == null).toBe(true);
+  });
+
+  test('diffPageVersions returns both bodies', async () => {
+    await engine.putPage('test/diff', { ...testPage, compiled_truth: 'a' });
+    const a = (await engine.createVersion('test/diff', { kind: 'update', provenance: { source: 't' } })).id;
+    await engine.putPage('test/diff', { ...testPage, compiled_truth: 'b' });
+    const b = (await engine.createVersion('test/diff', { kind: 'update', provenance: { source: 't' } })).id;
+    const d = await engine.diffPageVersions('test/diff', a, b);
+    expect(d.compiled_truth.from).toBe('a');
+    expect(d.compiled_truth.to).toBe('b');
+  });
+
+  test('deleteEvalCandidatesBefore readToolsOnly keeps query rows', async () => {
+    const base = {
+      query: 'x',
+      retrieved_slugs: [] as string[],
+      retrieved_chunk_ids: [] as number[],
+      source_ids: [] as string[],
+      detail: null,
+      detail_resolved: null,
+      expand_enabled: null,
+      vector_enabled: false,
+      expansion_applied: false,
+      latency_ms: 1,
+      remote: true,
+      job_id: null,
+      subagent_id: null,
+    };
+    await engine.logEvalCandidate({ ...base, tool_name: 'get_page' });
+    await engine.logEvalCandidate({ ...base, tool_name: 'query', query: 'q' });
+    const old = new Date(Date.now() - 86400000 * 400);
+    await engine.executeRaw(`UPDATE eval_candidates SET created_at = $1`, [old]);
+    const n = await engine.deleteEvalCandidatesBefore(new Date(Date.now() - 86400000), { readToolsOnly: true });
+    expect(n).toBe(1);
+    const rows = await engine.listEvalCandidates({ since: new Date(0), limit: 100 });
+    expect(rows.some(r => r.tool_name === 'query')).toBe(true);
+    expect(rows.some(r => r.tool_name === 'get_page')).toBe(false);
+  });
+});

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -76,9 +76,9 @@ describe('PGLiteEngine: Pages', () => {
     expect(result).toBeNull();
   });
 
-  test('deletePage removes page', async () => {
+  test('purgePage removes page', async () => {
     await engine.putPage('test/delete-me', testPage);
-    await engine.deletePage('test/delete-me');
+    await engine.purgePage('test/delete-me');
     const result = await engine.getPage('test/delete-me');
     expect(result).toBeNull();
   });
@@ -746,7 +746,7 @@ describe('PGLiteEngine: Cascade deletes', () => {
     ]);
     await engine.addTag('test/cascade', 'cascade-tag');
 
-    await engine.deletePage('test/cascade');
+    await engine.purgePage('test/cascade');
 
     const chunks = await engine.getChunks('test/cascade');
     expect(chunks.length).toBe(0);

--- a/test/read-audit.test.ts
+++ b/test/read-audit.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect } from 'bun:test';
+import { buildReadAuditInput } from '../src/core/eval-capture.ts';
+
+describe('buildReadAuditInput', () => {
+  test('maps read context into EvalCandidateInput with params_jsonb', () => {
+    const input = buildReadAuditInput({
+      tool_name: 'get_page',
+      query: 'read slug test/x',
+      params: { slug: 'test/x', include_deleted: false },
+      retrieved_slugs: ['test/x'],
+      retrieved_chunk_ids: [],
+      source_ids: ['default'],
+      latency_ms: 5,
+      remote: true,
+      job_id: null,
+      subagent_id: null,
+      mcp_token_name: 'z',
+    });
+    expect(input.tool_name).toBe('get_page');
+    expect(input.params_jsonb).toEqual({ slug: 'test/x', include_deleted: false });
+    expect(input.vector_enabled).toBe(false);
+    expect(input.mcp_token_name).toBe('z');
+    expect(input.detail).toBeNull();
+    expect(input.expand_enabled).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

This PR makes rewritten and deleted brain content **easier to reason about**, not silently lost. Together, **version history**, **soft delete + tombstones**, **hard purge**, and **read-path audit capture** anchor a simple contract: edits that reflect personal framing or agent-assisted rewrites behave like **derivative works** relative to imported or hand-authored source material.

The spine is engine-level lineage: **`page_versions`** rows carry **slug, source, kind, snapshot time**, and **`provenance`**, **`pages.deleted_at`** marks withdrawn live rows without wiping history unless an operator **`purge`**s, and **`eval_candidates`** records read traffic with **`params_jsonb`** (and optional MCP token attribution) alongside existing query/search capture.

Higher layers already stamp frontmatter markers on some synthesized paths; **this branch supplies the durability under that story** so what is live, what was true at time T, and what was withdrawn remain answerable inside the DB and CLI regardless of prose wrapping.

## Problem / motivation

Once agents or personalization loops revise pages faster than humans reread originals, installs risk **silent drift**: the newest text wins on screen while prior wording and withdrawals disappear unless we store **snapshots**, **withdrawal semantics**, and **attributable reads**. Soft delete plus explicit purge separates "hide from retrieval" from "erase lineage." Expanded read audit makes retrieval and inspection traffic reusable for debugging regressions **without** collapsing read rows into unstructured logs.

This treats **derivative state** as something to track at the persistence layer **before** relying purely on Markdown convention.

## Capabilities shipped

**Lifecycle & lineage**
- **History** snapshots with kinds (`create` / `update` / **`delete`** tombstone) and structured provenance.
- **Revert** rewinds live page state from a snapshot; **diff** compares two snapshots.
- **Soft delete**: default delete path avoids hard row removal until **purge** (operator-trusted posture per contract).
- **Resurrect** clears tombstone semantics on the live row; **purge** removes page plus version history where allowed.

**Ops & MCP**
- **Read auditing** on `eval_candidates` with **`params_jsonb`** and optional **`mcp_token_name`**, plumbed through shared MCP dispatch (stdio + HTTP as applicable).

**Migrate & hygiene**
- **Engine migrate** preserves **`deleted_at`** and copies **`page_versions`** into the target.
- **Doctor**: **`page_versions_health`** warns on orphaned version rows and unreasonable version churn.

**Ingest**
- **Import / version provenance** uses explicit sources (`import_file`, `import_code_file`) where applicable so ingestion-authored rows remain distinguishable from discretionary edits downstream.

## Review map (major touchpoints)

| Area | Paths |
|------|--------|
| Schema | `src/schema.sql`, `src/core/migrate.ts`, PGLite schema |
| Engines | `src/core/engine.ts`, `src/core/pglite-engine.ts`, `src/core/postgres-engine.ts`, `src/core/types.ts` |
| Contract | `src/core/operations.ts`, `src/mcp/dispatch.ts`, `src/mcp/http-transport.ts` |
| CLI | `src/cli.ts`, `src/commands/page-history.ts`, `src/commands/audit.ts` |
| Cross-engine | `src/commands/migrate-engine.ts` |
| Health | `src/commands/doctor.ts` |
| Supporting | `src/core/eval-capture.ts`, `src/core/eval-capture-scrub.ts`, `src/core/import-file.ts`, `src/commands/sync.ts`, `src/core/config.ts`, `src/core/utils.ts` |

## Migration

Migration **v32** (`page_versions_read_audit_soft_delete`) aligns **`pages.deleted_at`**, **`page_versions`** shape (slug, tags, provenance, kind constraint, indexing), and **`eval_candidates`** (params JSON, MCP token column, broader `tool_name` check aligned with DDL).

_Please confirm post-merge: `gbrain apply-migrations --yes` path for upgraded brains._

## Tests

- **`test/page-versions.test.ts`** (PGLite: revert, soft-delete visibility and tombstones, resurrect, cross-version diff, `deleteEvalCandidatesBefore` when `readToolsOnly` so query/search captures are preserved).
- **`test/read-audit.test.ts`** (read audit payload shaping into `EvalCandidateInput`).
- **`test/migrate.test.ts`** (v32 presence and key DDL strings plus `LATEST_VERSION` baseline).
- Adjustments where existing tests pin engine behavior or totals (`test/pglite-engine.test.ts`, `test/code-def-refs.test.ts`).

## Verification run by contributor

Before opening this PR locally:

```bash
bun run typecheck
bun run test
```

(Full parity with CI: **`bun run ci:local`** when Docker / gitleaks are available.)

## Maintainer note — frontmatter

Skills and repo conventions can keep marking personalized or synthesized outputs in frontmatter (derivative classification, citations, synthesized flags — whatever standardizes next). That remains a presentation contract **on top of** this persistence layer.

## Relation to project direction conceptually

The goal is to keep **derivative rewrites identifiable and reversible**, keep **withdrawal** explicit (**tombstones** + **`deleted_at`**), keep **reads observable** for operators and CI-style replay, so operators do not have to trust a single flattened Markdown file as sole ground truth.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->