### PR TITLE
feat(search): make FTS language configurable via GBRAIN_FTS_LANGUAGE (1/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,33 @@ The whole loop is described in [`docs/architecture/topologies.md`](docs/architec
 **Self-wiring knowledge graph.** Every `put_page` extracts entity refs from markdown/wikilinks/typed-link syntax and writes edges with zero LLM calls. Typed edges (`attended`, `works_at`, `invested_in`, `founded`, `advises`, `mentions`, …). Multi-hop traversal via `gbrain graph-query`. The graph is what produces the +31.4 P@5 lift over vector-only RAG. **Obsidian-style vaults:** bare `[[note-name]]` wikilinks that point across folders — you wrote `[[struktura]]` but the page lives at `projects/struktura.md` — resolve by basename once you opt in with `gbrain config set link_resolution.global_basename true`. Off by default; `gbrain doctor` tells you how many edges you'd gain before you flip it. See [migrating an Obsidian vault](INSTALL_FOR_AGENTS.md#step-45-wire-the-knowledge-graph).
 
 **Job queue (Minions).** BullMQ-shaped, Postgres-native job queue. Durable subagents (LLM tool loops that survive crashes via two-phase pending→done persistence), shell jobs with audit, child jobs with cascading timeouts, rate leases for outbound providers, attachments via S3/Supabase storage. Replaces "spawn subagent as fire-and-forget Promise" with something that recovers from anything.
+### Non-English brains (FTS language config)
+
+The Postgres full-text search tokenizer is configurable via `GBRAIN_FTS_LANGUAGE`. Defaults to `english`. Set it to any text-search configuration that exists in your Postgres instance:
+
+```bash
+export GBRAIN_FTS_LANGUAGE=portuguese     # uses built-in portuguese stemmer
+export GBRAIN_FTS_LANGUAGE=spanish        # built-in spanish stemmer
+export GBRAIN_FTS_LANGUAGE=pt_br          # custom config (e.g. unaccent + portuguese)
+```
+
+List available configs: `psql -c "SELECT cfgname FROM pg_ts_config"`. To create a custom accent-insensitive Portuguese config, see [docs/guides/multi-language-fts.md](docs/guides/multi-language-fts.md).
+
+Both the **query side** (`websearch_to_tsquery`) and the **write side** (the trigger functions that populate `pages.search_vector` and `content_chunks.search_vector`) honor `GBRAIN_FTS_LANGUAGE`. On first install, schema migration v33 reads the env var and creates trigger functions in the configured language; subsequent inserts/updates tokenize using that setting.
+
+To change language on a brain that has already run v33, use the dedicated CLI command:
+
+```bash
+export GBRAIN_FTS_LANGUAGE=portuguese
+gbrain reindex-search-vector --dry-run    # preview row counts
+gbrain reindex-search-vector --yes        # recreate triggers + backfill
+```
+
+The command is idempotent (re-running with the same language is a no-op for vector content) and uses the same recreate-and-backfill primitives as v33.
+
+For accent-insensitive Portuguese (`pt_br`), see [docs/guides/multi-language-fts.md](docs/guides/multi-language-fts.md) for the `unaccent` + portuguese stemmer recipe.
+
+## Why it works: many strategies in concert
 
 **43 curated skills.** Routing lives in [`skills/RESOLVER.md`](skills/RESOLVER.md). Covers signal capture, ingest (idea / media / meeting), enrichment, querying, brain ops, citation fixing, daily task management, cron scheduling, reports, voice, soul audit, skill creation, eval framework, and migrations. Skills are markdown files (tool-agnostic), packaged as a single skillpack the installer drops into your agent workspace.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1679,6 +1679,33 @@ The whole loop is described in [`docs/architecture/topologies.md`](docs/architec
 **Self-wiring knowledge graph.** Every `put_page` extracts entity refs from markdown/wikilinks/typed-link syntax and writes edges with zero LLM calls. Typed edges (`attended`, `works_at`, `invested_in`, `founded`, `advises`, `mentions`, …). Multi-hop traversal via `gbrain graph-query`. The graph is what produces the +31.4 P@5 lift over vector-only RAG. **Obsidian-style vaults:** bare `[[note-name]]` wikilinks that point across folders — you wrote `[[struktura]]` but the page lives at `projects/struktura.md` — resolve by basename once you opt in with `gbrain config set link_resolution.global_basename true`. Off by default; `gbrain doctor` tells you how many edges you'd gain before you flip it. See [migrating an Obsidian vault](INSTALL_FOR_AGENTS.md#step-45-wire-the-knowledge-graph).
 
 **Job queue (Minions).** BullMQ-shaped, Postgres-native job queue. Durable subagents (LLM tool loops that survive crashes via two-phase pending→done persistence), shell jobs with audit, child jobs with cascading timeouts, rate leases for outbound providers, attachments via S3/Supabase storage. Replaces "spawn subagent as fire-and-forget Promise" with something that recovers from anything.
+### Non-English brains (FTS language config)
+
+The Postgres full-text search tokenizer is configurable via `GBRAIN_FTS_LANGUAGE`. Defaults to `english`. Set it to any text-search configuration that exists in your Postgres instance:
+
+```bash
+export GBRAIN_FTS_LANGUAGE=portuguese     # uses built-in portuguese stemmer
+export GBRAIN_FTS_LANGUAGE=spanish        # built-in spanish stemmer
+export GBRAIN_FTS_LANGUAGE=pt_br          # custom config (e.g. unaccent + portuguese)
+```
+
+List available configs: `psql -c "SELECT cfgname FROM pg_ts_config"`. To create a custom accent-insensitive Portuguese config, see [docs/guides/multi-language-fts.md](docs/guides/multi-language-fts.md).
+
+Both the **query side** (`websearch_to_tsquery`) and the **write side** (the trigger functions that populate `pages.search_vector` and `content_chunks.search_vector`) honor `GBRAIN_FTS_LANGUAGE`. On first install, schema migration v33 reads the env var and creates trigger functions in the configured language; subsequent inserts/updates tokenize using that setting.
+
+To change language on a brain that has already run v33, use the dedicated CLI command:
+
+```bash
+export GBRAIN_FTS_LANGUAGE=portuguese
+gbrain reindex-search-vector --dry-run    # preview row counts
+gbrain reindex-search-vector --yes        # recreate triggers + backfill
+```
+
+The command is idempotent (re-running with the same language is a no-op for vector content) and uses the same recreate-and-backfill primitives as v33.
+
+For accent-insensitive Portuguese (`pt_br`), see [docs/guides/multi-language-fts.md](docs/guides/multi-language-fts.md) for the `unaccent` + portuguese stemmer recipe.
+
+## Why it works: many strategies in concert
 
 **43 curated skills.** Routing lives in [`skills/RESOLVER.md`](skills/RESOLVER.md). Covers signal capture, ingest (idea / media / meeting), enrichment, querying, brain ops, citation fixing, daily task management, cron scheduling, reports, voice, soul audit, skill creation, eval framework, and migrations. Skills are markdown files (tool-agnostic), packaged as a single skillpack the installer drops into your agent workspace.
 

--- a/src/core/fts-language.ts
+++ b/src/core/fts-language.ts
@@ -1,0 +1,69 @@
+/**
+ * Full-text search language configuration.
+ *
+ * Postgres tsvector/tsquery require a text search configuration name (e.g.
+ * 'english', 'portuguese', 'spanish'). Historically GBrain hardcoded
+ * 'english' across engines and trigger functions, which broke search
+ * quality for non-English brains (no stemming, no stop-word removal).
+ *
+ * This helper centralizes the choice. Default stays 'english' for backward
+ * compatibility — only users who set GBRAIN_FTS_LANGUAGE see different
+ * behavior.
+ *
+ * Custom configs (e.g. accent-insensitive 'pt_br' built with unaccent +
+ * portuguese stemmer) are supported as long as the configuration exists
+ * in the target Postgres instance. See docs/guides/multi-language-fts.md
+ * for setup instructions.
+ *
+ * Validation: only allow lowercase letters, digits, and underscores. This
+ * prevents SQL injection when the value is interpolated into queries
+ * (Postgres tsvector functions don't accept parameterized config names —
+ * they must be literals or identifiers).
+ */
+
+const VALID_CONFIG_NAME = /^[a-z][a-z0-9_]*$/;
+const DEFAULT_LANGUAGE = 'english';
+
+let cachedLanguage: string | null = null;
+
+/**
+ * Returns the configured Postgres text search configuration name.
+ *
+ * Resolution order:
+ *   1. process.env.GBRAIN_FTS_LANGUAGE (if set and valid)
+ *   2. 'english' (default — preserves existing behavior)
+ *
+ * The return value is safe to interpolate directly into SQL because it
+ * passes the VALID_CONFIG_NAME guard. If validation fails, falls back to
+ * the default and emits a one-time warning.
+ *
+ * Cached on first call; reset with `resetFtsLanguageCache()` (test only).
+ */
+export function getFtsLanguage(): string {
+  if (cachedLanguage !== null) return cachedLanguage;
+
+  const raw = process.env.GBRAIN_FTS_LANGUAGE?.trim();
+  if (!raw) {
+    cachedLanguage = DEFAULT_LANGUAGE;
+    return cachedLanguage;
+  }
+
+  if (!VALID_CONFIG_NAME.test(raw)) {
+    console.warn(
+      `[gbrain] Invalid GBRAIN_FTS_LANGUAGE='${raw}' — must match /^[a-z][a-z0-9_]*$/. ` +
+      `Falling back to '${DEFAULT_LANGUAGE}'.`
+    );
+    cachedLanguage = DEFAULT_LANGUAGE;
+    return cachedLanguage;
+  }
+
+  cachedLanguage = raw;
+  return cachedLanguage;
+}
+
+/**
+ * Resets the cached language. Tests only — don't use in production code.
+ */
+export function resetFtsLanguageCache(): void {
+  cachedLanguage = null;
+}

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -24,6 +24,7 @@ import { PGLITE_SCHEMA_SQL, getPGLiteSchema } from './pglite-schema.ts';
 import { DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_DIMENSIONS } from './ai/defaults.ts';
 import { DELETE_BATCH_SIZE } from './engine-constants.ts';
 import { acquireLock, releaseLock, type LockHandle } from './pglite-lock.ts';
+import { getFtsLanguage } from './fts-language.ts';
 import type {
   Page, PageInput, PageFilters, PageType,
   Chunk, ChunkInput, StaleChunkRow, StalePageRow,
@@ -1504,20 +1505,24 @@ export class PGLiteEngine implements BrainEngine {
       extraFilter += ` AND p.source_id = $${params.length}`;
     }
 
+    // FTS config name (e.g. 'english', 'pt_br'). Validated by getFtsLanguage()
+    // — safe to interpolate into raw SQL.
+    const ftsLang = getFtsLanguage();
+
     const { rows } = await this.db.query(
       `WITH ranked AS (
          SELECT
            p.slug, p.id as page_id, p.title, p.type, p.source_id,
            p.effective_date, p.effective_date_source,
            cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
-           ts_rank(cc.search_vector, websearch_to_tsquery('english', $1)) * ${sourceFactorCase} AS score,
+           ts_rank(cc.search_vector, websearch_to_tsquery('${ftsLang}', $1)) * ${sourceFactorCase} AS score,
            CASE WHEN p.updated_at < (
              SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id
            ) THEN true ELSE false END AS stale
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id
          JOIN sources s ON s.id = p.source_id
-         WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
+         WHERE cc.search_vector @@ websearch_to_tsquery('${ftsLang}', $1) ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
            -- v0.27.1: hide image rows from default text-keyword search so
            -- OCR text doesn't drown text-page hits. Image-similarity queries
            -- run a separate vector path on embedding_image.
@@ -1736,20 +1741,23 @@ export class PGLiteEngine implements BrainEngine {
     }
 
     // visibilityClause already declared above (v0.32.7: hoisted so CJK branch can reuse).
+    // FTS config name (e.g. 'english', 'pt_br'). Validated by getFtsLanguage()
+    // — safe to interpolate into raw SQL.
+    const ftsLang = getFtsLanguage();
 
     const { rows } = await this.db.query(
       `SELECT
          p.slug, p.id as page_id, p.title, p.type, p.source_id,
          p.effective_date, p.effective_date_source,
          cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
-         ts_rank(cc.search_vector, websearch_to_tsquery('english', $1)) * ${sourceFactorCase} AS score,
+         ts_rank(cc.search_vector, websearch_to_tsquery('${ftsLang}', $1)) * ${sourceFactorCase} AS score,
          CASE WHEN p.updated_at < (
            SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id
          ) THEN true ELSE false END AS stale
        FROM content_chunks cc
        JOIN pages p ON p.id = cc.page_id
        JOIN sources s ON s.id = p.source_id
-       WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
+       WHERE cc.search_vector @@ websearch_to_tsquery('${ftsLang}', $1) ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
        ORDER BY score DESC
        LIMIT $2 OFFSET $3`,
       params

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -34,6 +34,7 @@ import {
   COLUMN_NAME_REGEX,
   EmbeddingColumnNotRegisteredError,
 } from './search/embedding-column.ts';
+import { getFtsLanguage } from './fts-language.ts';
 import type {
   Page, PageInput, PageFilters, PageType,
   Chunk, ChunkInput, StaleChunkRow, StalePageRow,
@@ -1596,6 +1597,9 @@ export class PostgresEngine implements BrainEngine {
     // column lookup. NOT bypassed by detail=high — soft-delete is a contract,
     // not a temporal preference.
     const visibilityClause = buildVisibilityClause('p', 's');
+    // FTS config name (e.g. 'english', 'pt_br'). Validated by getFtsLanguage()
+    // — safe to interpolate into raw SQL.
+    const ftsLang = getFtsLanguage();
 
     const rawQuery = `
       WITH ranked_chunks AS (
@@ -1603,11 +1607,11 @@ export class PostgresEngine implements BrainEngine {
           p.slug, p.id as page_id, p.title, p.type, p.source_id,
           p.effective_date, p.effective_date_source,
           cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
-          ts_rank(cc.search_vector, websearch_to_tsquery('english', $1)) * ${sourceFactorCase} AS score
+          ts_rank(cc.search_vector, websearch_to_tsquery('${ftsLang}', $1)) * ${sourceFactorCase} AS score
         FROM content_chunks cc
         JOIN pages p ON p.id = cc.page_id
         JOIN sources s ON s.id = p.source_id
-        WHERE cc.search_vector @@ websearch_to_tsquery('english', $1)
+        WHERE cc.search_vector @@ websearch_to_tsquery('${ftsLang}', $1)
           ${typeClause}
           ${typesClause}
           ${excludeSlugsClause}
@@ -1735,18 +1739,21 @@ export class PostgresEngine implements BrainEngine {
 
     // v0.26.5: visibility filter for searchKeywordChunks (anchor primitive).
     const visibilityClause = buildVisibilityClause('p', 's');
+    // FTS config name (e.g. 'english', 'pt_br'). Validated by getFtsLanguage()
+    // — safe to interpolate into raw SQL.
+    const ftsLang = getFtsLanguage();
 
     const rawQuery = `
       SELECT
         p.slug, p.id as page_id, p.title, p.type, p.source_id,
         p.effective_date, p.effective_date_source,
         cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
-        ts_rank(cc.search_vector, websearch_to_tsquery('english', $1)) * ${sourceFactorCase} AS score,
+        ts_rank(cc.search_vector, websearch_to_tsquery('${ftsLang}', $1)) * ${sourceFactorCase} AS score,
         false AS stale
       FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id
       JOIN sources s ON s.id = p.source_id
-      WHERE cc.search_vector @@ websearch_to_tsquery('english', $1)
+      WHERE cc.search_vector @@ websearch_to_tsquery('${ftsLang}', $1)
         ${typeClause}
         ${typesClause}
         ${excludeSlugsClause}

--- a/test/fts-language.test.ts
+++ b/test/fts-language.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { getFtsLanguage, resetFtsLanguageCache } from '../src/core/fts-language.ts';
+
+const ENV_KEY = 'GBRAIN_FTS_LANGUAGE';
+
+beforeEach(() => {
+  delete process.env[ENV_KEY];
+  resetFtsLanguageCache();
+});
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+  resetFtsLanguageCache();
+});
+
+describe('getFtsLanguage', () => {
+  test('defaults to english when env is unset', () => {
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('defaults to english when env is empty string', () => {
+    process.env[ENV_KEY] = '';
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('defaults to english when env is whitespace', () => {
+    process.env[ENV_KEY] = '   ';
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('reads valid pt_br config', () => {
+    process.env[ENV_KEY] = 'pt_br';
+    expect(getFtsLanguage()).toBe('pt_br');
+  });
+
+  test('reads valid simple language name', () => {
+    process.env[ENV_KEY] = 'spanish';
+    expect(getFtsLanguage()).toBe('spanish');
+  });
+
+  test('reads name with underscores and digits', () => {
+    process.env[ENV_KEY] = 'custom_lang_v2';
+    expect(getFtsLanguage()).toBe('custom_lang_v2');
+  });
+
+  test('rejects names with quotes (SQL injection guard)', () => {
+    process.env[ENV_KEY] = "english'; DROP TABLE pages; --";
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('rejects names with spaces', () => {
+    process.env[ENV_KEY] = 'pt br';
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('rejects names with hyphens', () => {
+    process.env[ENV_KEY] = 'pt-br';
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('rejects names starting with digit', () => {
+    process.env[ENV_KEY] = '1lang';
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('rejects uppercase (Postgres config names are lowercase)', () => {
+    process.env[ENV_KEY] = 'English';
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('caches after first read', () => {
+    process.env[ENV_KEY] = 'pt_br';
+    expect(getFtsLanguage()).toBe('pt_br');
+
+    // Mutate env after first read \u2014 cached value wins.
+    process.env[ENV_KEY] = 'spanish';
+    expect(getFtsLanguage()).toBe('pt_br');
+  });
+
+  test('resetFtsLanguageCache clears cache', () => {
+    process.env[ENV_KEY] = 'pt_br';
+    expect(getFtsLanguage()).toBe('pt_br');
+
+    resetFtsLanguageCache();
+    process.env[ENV_KEY] = 'spanish';
+    expect(getFtsLanguage()).toBe('spanish');
+  });
+
+  test('trims surrounding whitespace from valid value', () => {
+    process.env[ENV_KEY] = '  pt_br  ';
+    expect(getFtsLanguage()).toBe('pt_br');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `GBRAIN_FTS_LANGUAGE` env var (default `'english'`) so non-English brains can opt into a Postgres text-search configuration that actually understands their content.

This is **PR 1 of 3** in a series. It fixes the *query side* only — the trigger functions that populate `search_vector` are addressed in the follow-up PRs:
- **PR 2:** schema migration v33 to recreate trigger functions with the configured language
- **PR 3:** `gbrain reindex-search-vector` CLI for changing language post-install

Each PR is mergeable on its own. The series can be reviewed and landed incrementally.

## Why

Searching a Portuguese (or Spanish, German, etc.) brain currently runs every query through the English stemmer and stop-word list. Result: Portuguese queries lose stemming entirely (`reuniões` doesn't match `reunião`) and miss obvious matches that vector search alone can't recover.

Today the workaround is a downstream patch that hardcodes a different language string into the engine. That patch breaks on every upstream merge. This PR makes the choice configurable so downstream forks for non-English deployments stop accumulating merge debt.

## What changed

- **New file:** `src/core/fts-language.ts` — `getFtsLanguage()` reads `GBRAIN_FTS_LANGUAGE`, validates against `/^[a-z][a-z0-9_]*$/`, falls back to `'english'` on missing/invalid, caches after first read.
- **`postgres-engine.ts`** + **`pglite-engine.ts`:** the four `websearch_to_tsquery('english', ...)` calls in `searchKeyword` and `searchKeywordChunks` now interpolate the helper's return value.
- **README.md:** new "Non-English brains (FTS language config)" subsection under Search.

## Validation strategy

Postgres `tsvector` / `tsquery` functions don't accept parameterized config names — the language **must** be a literal in the SQL string. So we interpolate, but only after the regex guard:

```ts
const VALID_CONFIG_NAME = /^[a-z][a-z0-9_]*$/;
```

A deliberately malicious `GBRAIN_FTS_LANGUAGE="english'; DROP TABLE pages; --"` falls back to `'english'` with a one-time warning. Verified by a unit test.

## Tests

14 unit tests in `test/fts-language.test.ts`:
- defaults (unset / empty / whitespace)
- valid configs (`pt_br`, `spanish`, `custom_lang_v2`)
- rejected forms (quotes, spaces, hyphens, leading digit, uppercase)
- caching behavior + reset for tests
- whitespace trimming on valid input

```
$ bun test test/fts-language.test.ts
 14 pass
 0 fail
```

`bun run typecheck` clean. `bun run build` produces a working compiled binary.

## Backward-compatible

100%. With `GBRAIN_FTS_LANGUAGE` unset, the helper returns `'english'` and every call site emits the same SQL it always has.

## What's NOT in this PR

- The trigger functions in `schema.sql`, `schema-embedded.ts`, `pglite-schema.ts` still hardcode `'english'`. **PR 2 (#581)** ships an idempotent migration that recreates them using the helper.
- A dedicated CLI command for re-applying language changes after install lives in **PR 3 (#582)**.

If only PR 1 lands, the practical effect for non-English users is: query-side stemming starts working immediately, but `search_vector` content keeps tokenizing as English until `pages` / `content_chunks` are rewritten (which `gbrain sync --force` would also do). PR 2 closes that gap idempotently.
