### PR TITLE
feat(cli): add 'gbrain reindex-search-vector' command (3/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,33 @@ The whole loop is described in [`docs/architecture/topologies.md`](docs/architec
 **Self-wiring knowledge graph.** Every `put_page` extracts entity refs from markdown/wikilinks/typed-link syntax and writes edges with zero LLM calls. Typed edges (`attended`, `works_at`, `invested_in`, `founded`, `advises`, `mentions`, …). Multi-hop traversal via `gbrain graph-query`. The graph is what produces the +31.4 P@5 lift over vector-only RAG. **Obsidian-style vaults:** bare `[[note-name]]` wikilinks that point across folders — you wrote `[[struktura]]` but the page lives at `projects/struktura.md` — resolve by basename once you opt in with `gbrain config set link_resolution.global_basename true`. Off by default; `gbrain doctor` tells you how many edges you'd gain before you flip it. See [migrating an Obsidian vault](INSTALL_FOR_AGENTS.md#step-45-wire-the-knowledge-graph).
 
 **Job queue (Minions).** BullMQ-shaped, Postgres-native job queue. Durable subagents (LLM tool loops that survive crashes via two-phase pending→done persistence), shell jobs with audit, child jobs with cascading timeouts, rate leases for outbound providers, attachments via S3/Supabase storage. Replaces "spawn subagent as fire-and-forget Promise" with something that recovers from anything.
+### Non-English brains (FTS language config)
+
+The Postgres full-text search tokenizer is configurable via `GBRAIN_FTS_LANGUAGE`. Defaults to `english`. Set it to any text-search configuration that exists in your Postgres instance:
+
+```bash
+export GBRAIN_FTS_LANGUAGE=portuguese     # uses built-in portuguese stemmer
+export GBRAIN_FTS_LANGUAGE=spanish        # built-in spanish stemmer
+export GBRAIN_FTS_LANGUAGE=pt_br          # custom config (e.g. unaccent + portuguese)
+```
+
+List available configs: `psql -c "SELECT cfgname FROM pg_ts_config"`. To create a custom accent-insensitive Portuguese config, see [docs/guides/multi-language-fts.md](docs/guides/multi-language-fts.md).
+
+Both the **query side** (`websearch_to_tsquery`) and the **write side** (the trigger functions that populate `pages.search_vector` and `content_chunks.search_vector`) honor `GBRAIN_FTS_LANGUAGE`. On first install, schema migration v33 reads the env var and creates trigger functions in the configured language; subsequent inserts/updates tokenize using that setting.
+
+To change language on a brain that has already run v33, use the dedicated CLI command:
+
+```bash
+export GBRAIN_FTS_LANGUAGE=portuguese
+gbrain reindex-search-vector --dry-run    # preview row counts
+gbrain reindex-search-vector --yes        # recreate triggers + backfill
+```
+
+The command is idempotent (re-running with the same language is a no-op for vector content) and uses the same recreate-and-backfill primitives as v33.
+
+For accent-insensitive Portuguese (`pt_br`), see [docs/guides/multi-language-fts.md](docs/guides/multi-language-fts.md) for the `unaccent` + portuguese stemmer recipe.
+
+## Why it works: many strategies in concert
 
 **43 curated skills.** Routing lives in [`skills/RESOLVER.md`](skills/RESOLVER.md). Covers signal capture, ingest (idea / media / meeting), enrichment, querying, brain ops, citation fixing, daily task management, cron scheduling, reports, voice, soul audit, skill creation, eval framework, and migrations. Skills are markdown files (tool-agnostic), packaged as a single skillpack the installer drops into your agent workspace.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1679,6 +1679,33 @@ The whole loop is described in [`docs/architecture/topologies.md`](docs/architec
 **Self-wiring knowledge graph.** Every `put_page` extracts entity refs from markdown/wikilinks/typed-link syntax and writes edges with zero LLM calls. Typed edges (`attended`, `works_at`, `invested_in`, `founded`, `advises`, `mentions`, …). Multi-hop traversal via `gbrain graph-query`. The graph is what produces the +31.4 P@5 lift over vector-only RAG. **Obsidian-style vaults:** bare `[[note-name]]` wikilinks that point across folders — you wrote `[[struktura]]` but the page lives at `projects/struktura.md` — resolve by basename once you opt in with `gbrain config set link_resolution.global_basename true`. Off by default; `gbrain doctor` tells you how many edges you'd gain before you flip it. See [migrating an Obsidian vault](INSTALL_FOR_AGENTS.md#step-45-wire-the-knowledge-graph).
 
 **Job queue (Minions).** BullMQ-shaped, Postgres-native job queue. Durable subagents (LLM tool loops that survive crashes via two-phase pending→done persistence), shell jobs with audit, child jobs with cascading timeouts, rate leases for outbound providers, attachments via S3/Supabase storage. Replaces "spawn subagent as fire-and-forget Promise" with something that recovers from anything.
+### Non-English brains (FTS language config)
+
+The Postgres full-text search tokenizer is configurable via `GBRAIN_FTS_LANGUAGE`. Defaults to `english`. Set it to any text-search configuration that exists in your Postgres instance:
+
+```bash
+export GBRAIN_FTS_LANGUAGE=portuguese     # uses built-in portuguese stemmer
+export GBRAIN_FTS_LANGUAGE=spanish        # built-in spanish stemmer
+export GBRAIN_FTS_LANGUAGE=pt_br          # custom config (e.g. unaccent + portuguese)
+```
+
+List available configs: `psql -c "SELECT cfgname FROM pg_ts_config"`. To create a custom accent-insensitive Portuguese config, see [docs/guides/multi-language-fts.md](docs/guides/multi-language-fts.md).
+
+Both the **query side** (`websearch_to_tsquery`) and the **write side** (the trigger functions that populate `pages.search_vector` and `content_chunks.search_vector`) honor `GBRAIN_FTS_LANGUAGE`. On first install, schema migration v33 reads the env var and creates trigger functions in the configured language; subsequent inserts/updates tokenize using that setting.
+
+To change language on a brain that has already run v33, use the dedicated CLI command:
+
+```bash
+export GBRAIN_FTS_LANGUAGE=portuguese
+gbrain reindex-search-vector --dry-run    # preview row counts
+gbrain reindex-search-vector --yes        # recreate triggers + backfill
+```
+
+The command is idempotent (re-running with the same language is a no-op for vector content) and uses the same recreate-and-backfill primitives as v33.
+
+For accent-insensitive Portuguese (`pt_br`), see [docs/guides/multi-language-fts.md](docs/guides/multi-language-fts.md) for the `unaccent` + portuguese stemmer recipe.
+
+## Why it works: many strategies in concert
 
 **43 curated skills.** Routing lives in [`skills/RESOLVER.md`](skills/RESOLVER.md). Covers signal capture, ingest (idea / media / meeting), enrichment, querying, brain ops, citation fixing, daily task management, cron scheduling, reports, voice, soul audit, skill creation, eval framework, and migrations. Skills are markdown files (tool-agnostic), packaged as a single skillpack the installer drops into your agent workspace.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'enrich', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'onboard', 'conversation-parser', 'status', 'connect', 'skillopt', 'quarantine', 'self-upgrade']);
+const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'enrich', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'onboard', 'conversation-parser', 'status', 'connect', 'skillopt', 'quarantine', 'self-upgrade', 'reindex-search-vector']);
 // CLI-only commands whose handlers print their own --help text. These are
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
@@ -1886,6 +1886,14 @@ async function handleCliOnly(command: string, args: string[]) {
         await runBackfillCommand(args);
         return;
       }
+      case 'reindex-search-vector': {
+        // PR #3: explicit recreate of FTS trigger functions + backfill,
+        // honoring GBRAIN_FTS_LANGUAGE. Use after changing the language
+        // env var on a brain that already ran v33.
+        const { runReindexSearchVectorCli } = await import('./commands/reindex-search-vector.ts');
+        await runReindexSearchVectorCli(engine, args);
+        break;
+      }
       case 'code-callers': {
         // v0.20.0 Cathedral II Layer 10 (C4): "who calls <symbol>?"
         const { runCodeCallers } = await import('./commands/code-callers.ts');
@@ -2209,6 +2217,9 @@ CODE INDEXING (v0.19.0 / v0.20.0 Cathedral II)
   query <q> --symbol-kind <k>        Filter to symbol type (function|class|method|...) (v0.20.0)
   reconcile-links [--dry-run]        Batch-recompute doc↔impl edges (v0.20.0)
   reindex-code [--source id] [--yes] Explicit code-page reindex (v0.20.0)
+  reindex-search-vector [--dry-run] [--yes] [--json]
+                                Recreate FTS triggers + backfill under
+                                $GBRAIN_FTS_LANGUAGE (default 'english')
   sync --strategy code               Sync code files into the brain
 
 JOBS (Minions)

--- a/src/commands/reindex-search-vector.ts
+++ b/src/commands/reindex-search-vector.ts
@@ -1,0 +1,213 @@
+/**
+ * `gbrain reindex-search-vector` — recreate FTS trigger functions and
+ * backfill existing rows under the language configured via
+ * GBRAIN_FTS_LANGUAGE.
+ *
+ * Why this command exists: schema migration v116 stamps the trigger
+ * functions with the configured language at first apply. After that,
+ * changing the env var has no effect on the write side because v116
+ * already shows as "applied" — the migrations runner will skip it.
+ * This command is the documented escape hatch: it re-runs the same
+ * recreate-and-backfill logic v116 uses, gated on an explicit user
+ * action so the operation is intentional and visible (writes touch
+ * every row in pages and content_chunks for non-english languages).
+ *
+ * Idempotent: running twice with the same GBRAIN_FTS_LANGUAGE produces
+ * the same trigger function bodies and the same tokenized vectors.
+ *
+ * Flags:
+ *   --dry-run    Show what would happen, exit 0 without touching DB.
+ *   --yes        Skip interactive [y/N]. Required for non-TTY.
+ *   --json       Machine-readable result envelope.
+ *
+ * Cost: trigger recreate is sub-millisecond. Backfill is one tsvector
+ * rebuild per page + per chunk. On a 20K-page brain with 80K chunks,
+ * expect ~5-15s depending on Postgres CPU and content size.
+ */
+
+import type { BrainEngine } from '../core/engine.ts';
+import { getFtsLanguage } from '../core/fts-language.ts';
+import { createInterface } from 'readline';
+
+export interface ReindexSearchVectorOpts {
+  dryRun?: boolean;
+  yes?: boolean;
+  json?: boolean;
+}
+
+export interface ReindexSearchVectorResult {
+  status: 'ok' | 'dry_run' | 'cancelled';
+  language: string;
+  pagesUpdated: number;
+  chunksUpdated: number;
+  triggersRecreated: number;
+  durationMs: number;
+}
+
+interface CountRow {
+  pages: number;
+  chunks: number;
+}
+
+/**
+ * Programmatic entrypoint — takes a typed opts object. Used by tests and
+ * future internal callers. The CLI wrapper is `runReindexSearchVectorCli`
+ * defined at the bottom of this file.
+ */
+export async function runReindexSearchVector(
+  engine: BrainEngine,
+  opts: ReindexSearchVectorOpts
+): Promise<ReindexSearchVectorResult> {
+  const lang = getFtsLanguage();
+  const startedAt = Date.now();
+
+  // Inventory: how many rows will the backfill touch?
+  const counts = await engine.executeRaw<CountRow>(
+    `SELECT
+       (SELECT COUNT(*)::int FROM pages WHERE search_vector IS NOT NULL) AS pages,
+       (SELECT COUNT(*)::int FROM content_chunks WHERE search_vector IS NOT NULL) AS chunks`
+  );
+  const pagesCount = counts[0]?.pages ?? 0;
+  const chunksCount = counts[0]?.chunks ?? 0;
+
+  if (opts.dryRun) {
+    const result: ReindexSearchVectorResult = {
+      status: 'dry_run',
+      language: lang,
+      pagesUpdated: pagesCount,
+      chunksUpdated: chunksCount,
+      triggersRecreated: 0,
+      durationMs: Date.now() - startedAt,
+    };
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(`[dry-run] Would recreate 2 trigger functions with language='${lang}'`);
+      console.log(`[dry-run] Would backfill ${pagesCount} pages + ${chunksCount} chunks`);
+      console.log(`[dry-run] Skipping all DB writes. Pass --yes to apply.`);
+    }
+    return result;
+  }
+
+  // Confirm unless --yes (or --json, which is non-interactive by contract).
+  if (!opts.yes && !opts.json) {
+    if (!process.stdin.isTTY) {
+      console.error('Refusing to run without --yes in non-TTY environment.');
+      process.exit(2);
+    }
+
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    const answer = await new Promise<string>(resolve => {
+      rl.question(
+        `Recreate FTS triggers with language='${lang}' and backfill ${pagesCount} pages + ${chunksCount} chunks? [y/N]: `,
+        resolve
+      );
+    });
+    rl.close();
+
+    if (!/^y(es)?$/i.test(answer.trim())) {
+      const result: ReindexSearchVectorResult = {
+        status: 'cancelled',
+        language: lang,
+        pagesUpdated: 0,
+        chunksUpdated: 0,
+        triggersRecreated: 0,
+        durationMs: Date.now() - startedAt,
+      };
+      console.log('Cancelled.');
+      return result;
+    }
+  }
+
+  // Recreate trigger functions. The strings are intentionally identical to
+  // the v116 migration body — keeping them in lockstep is the contract.
+  const recreatePagesFn = `
+    CREATE OR REPLACE FUNCTION update_page_search_vector() RETURNS trigger AS $fn$
+    DECLARE
+      timeline_text TEXT;
+    BEGIN
+      SELECT coalesce(string_agg(summary || ' ' || detail, ' '), '')
+      INTO timeline_text
+      FROM timeline_entries
+      WHERE page_id = NEW.id;
+
+      NEW.search_vector :=
+        setweight(to_tsvector('${lang}', coalesce(NEW.title, '')), 'A') ||
+        setweight(to_tsvector('${lang}', coalesce(NEW.compiled_truth, '')), 'B') ||
+        setweight(to_tsvector('${lang}', coalesce(NEW.timeline, '')), 'C') ||
+        setweight(to_tsvector('${lang}', coalesce(timeline_text, '')), 'C');
+
+      RETURN NEW;
+    END;
+    $fn$ LANGUAGE plpgsql;
+  `;
+
+  const recreateChunksFn = `
+    CREATE OR REPLACE FUNCTION update_chunk_search_vector() RETURNS TRIGGER AS $fn$
+    BEGIN
+      NEW.search_vector :=
+        setweight(to_tsvector('${lang}', COALESCE(NEW.doc_comment, '')), 'A') ||
+        setweight(to_tsvector('${lang}', COALESCE(NEW.symbol_name_qualified, '')), 'A') ||
+        setweight(to_tsvector('${lang}', COALESCE(NEW.chunk_text, '')), 'B');
+      RETURN NEW;
+    END;
+    $fn$ LANGUAGE plpgsql;
+  `;
+
+  await engine.executeRaw(recreatePagesFn);
+  await engine.executeRaw(recreateChunksFn);
+
+  // Backfill: UPDATE-to-self forces the trigger to re-fire for pages
+  // (Postgres re-fires on UPDATE-to-same-value); content_chunks gets a
+  // direct vector compute since the column itself is what we want.
+  const backfillPages = `
+    UPDATE pages SET id = id WHERE search_vector IS NOT NULL;
+  `;
+
+  const backfillChunks = `
+    UPDATE content_chunks
+    SET search_vector =
+      setweight(to_tsvector('${lang}', COALESCE(doc_comment, '')), 'A') ||
+      setweight(to_tsvector('${lang}', COALESCE(symbol_name_qualified, '')), 'A') ||
+      setweight(to_tsvector('${lang}', COALESCE(chunk_text, '')), 'B')
+    WHERE search_vector IS NOT NULL;
+  `;
+
+  await engine.executeRaw(backfillPages);
+  await engine.executeRaw(backfillChunks);
+
+  const result: ReindexSearchVectorResult = {
+    status: 'ok',
+    language: lang,
+    pagesUpdated: pagesCount,
+    chunksUpdated: chunksCount,
+    triggersRecreated: 2,
+    durationMs: Date.now() - startedAt,
+  };
+
+  if (opts.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`\u2705 Recreated 2 trigger functions with language='${lang}'`);
+    console.log(`\u2705 Backfilled ${pagesCount} pages + ${chunksCount} chunks (${result.durationMs}ms)`);
+  }
+
+  return result;
+}
+
+/**
+ * CLI entrypoint. Parses argv flags and dispatches to runReindexSearchVector.
+ * Matches the style of `reindex-code`: --dry-run, --yes/-y, --json.
+ *
+ * Exit codes: 0 success/dry-run/cancelled, 2 if non-TTY without --yes.
+ */
+export async function runReindexSearchVectorCli(
+  engine: BrainEngine,
+  args: string[]
+): Promise<void> {
+  const dryRun = args.includes('--dry-run');
+  const yes = args.includes('--yes') || args.includes('-y');
+  const json = args.includes('--json');
+
+  await runReindexSearchVector(engine, { dryRun, yes, json });
+}

--- a/src/core/fts-language.ts
+++ b/src/core/fts-language.ts
@@ -1,0 +1,69 @@
+/**
+ * Full-text search language configuration.
+ *
+ * Postgres tsvector/tsquery require a text search configuration name (e.g.
+ * 'english', 'portuguese', 'spanish'). Historically GBrain hardcoded
+ * 'english' across engines and trigger functions, which broke search
+ * quality for non-English brains (no stemming, no stop-word removal).
+ *
+ * This helper centralizes the choice. Default stays 'english' for backward
+ * compatibility — only users who set GBRAIN_FTS_LANGUAGE see different
+ * behavior.
+ *
+ * Custom configs (e.g. accent-insensitive 'pt_br' built with unaccent +
+ * portuguese stemmer) are supported as long as the configuration exists
+ * in the target Postgres instance. See docs/guides/multi-language-fts.md
+ * for setup instructions.
+ *
+ * Validation: only allow lowercase letters, digits, and underscores. This
+ * prevents SQL injection when the value is interpolated into queries
+ * (Postgres tsvector functions don't accept parameterized config names —
+ * they must be literals or identifiers).
+ */
+
+const VALID_CONFIG_NAME = /^[a-z][a-z0-9_]*$/;
+const DEFAULT_LANGUAGE = 'english';
+
+let cachedLanguage: string | null = null;
+
+/**
+ * Returns the configured Postgres text search configuration name.
+ *
+ * Resolution order:
+ *   1. process.env.GBRAIN_FTS_LANGUAGE (if set and valid)
+ *   2. 'english' (default — preserves existing behavior)
+ *
+ * The return value is safe to interpolate directly into SQL because it
+ * passes the VALID_CONFIG_NAME guard. If validation fails, falls back to
+ * the default and emits a one-time warning.
+ *
+ * Cached on first call; reset with `resetFtsLanguageCache()` (test only).
+ */
+export function getFtsLanguage(): string {
+  if (cachedLanguage !== null) return cachedLanguage;
+
+  const raw = process.env.GBRAIN_FTS_LANGUAGE?.trim();
+  if (!raw) {
+    cachedLanguage = DEFAULT_LANGUAGE;
+    return cachedLanguage;
+  }
+
+  if (!VALID_CONFIG_NAME.test(raw)) {
+    console.warn(
+      `[gbrain] Invalid GBRAIN_FTS_LANGUAGE='${raw}' — must match /^[a-z][a-z0-9_]*$/. ` +
+      `Falling back to '${DEFAULT_LANGUAGE}'.`
+    );
+    cachedLanguage = DEFAULT_LANGUAGE;
+    return cachedLanguage;
+  }
+
+  cachedLanguage = raw;
+  return cachedLanguage;
+}
+
+/**
+ * Resets the cached language. Tests only — don't use in production code.
+ */
+export function resetFtsLanguageCache(): void {
+  cachedLanguage = null;
+}

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -1,5 +1,6 @@
 import type { BrainEngine } from './engine.ts';
 import { slugifyPath } from './sync.ts';
+import { getFtsLanguage } from './fts-language.ts';
 
 /**
  * Schema migrations — run automatically on initSchema().
@@ -5185,6 +5186,93 @@ export const MIGRATIONS: Migration[] = [
           FOREIGN KEY (op, fingerprint) REFERENCES op_checkpoints (op, fingerprint) ON DELETE CASCADE
       );
     `,
+  },
+  {
+    version: 116,
+    name: 'configurable_fts_language',
+    // Recreate the two search_vector trigger functions using the language
+    // configured via GBRAIN_FTS_LANGUAGE (default 'english'). Idempotent:
+    // CREATE OR REPLACE swaps the function body atomically; no trigger
+    // recreation needed since the trigger references the function by name.
+    //
+    // Why a handler instead of a static SQL string: Postgres tsvector
+    // functions don't accept parameterized config names — the language
+    // must be a literal in the SQL. getFtsLanguage() validates the value
+    // (lowercase letters/digits/underscores only) before interpolation.
+    //
+    // Function bodies mirror schema-embedded.ts / pglite-schema.ts exactly,
+    // with only the text-search config name parameterized. Keep all three
+    // in sync when the trigger logic changes.
+    //
+    // Backfill: after recreating the functions, re-tokenize existing rows
+    // under the new language. Skipped when the configured language is
+    // 'english' (trigger output identical — re-tokenizing is wasted I/O).
+    // To change language after this migration has run, use
+    // `gbrain reindex-search-vector`.
+    sql: '',
+    handler: async (engine) => {
+      const lang = getFtsLanguage();
+
+      const recreatePagesFn = `
+        CREATE OR REPLACE FUNCTION update_page_search_vector() RETURNS trigger AS $fn$
+        DECLARE
+          timeline_text TEXT;
+        BEGIN
+          SELECT coalesce(string_agg(summary || ' ' || detail, ' '), '')
+          INTO timeline_text
+          FROM timeline_entries
+          WHERE page_id = NEW.id;
+
+          NEW.search_vector :=
+            setweight(to_tsvector('${lang}', coalesce(NEW.title, '')), 'A') ||
+            setweight(to_tsvector('${lang}', coalesce(NEW.compiled_truth, '')), 'B') ||
+            setweight(to_tsvector('${lang}', coalesce(NEW.timeline, '')), 'C') ||
+            setweight(to_tsvector('${lang}', coalesce(timeline_text, '')), 'C');
+
+          RETURN NEW;
+        END;
+        $fn$ LANGUAGE plpgsql;
+      `;
+
+      const recreateChunksFn = `
+        CREATE OR REPLACE FUNCTION update_chunk_search_vector() RETURNS TRIGGER AS $fn$
+        BEGIN
+          NEW.search_vector :=
+            setweight(to_tsvector('${lang}', COALESCE(NEW.doc_comment, '')), 'A') ||
+            setweight(to_tsvector('${lang}', COALESCE(NEW.symbol_name_qualified, '')), 'A') ||
+            setweight(to_tsvector('${lang}', COALESCE(NEW.chunk_text, '')), 'B');
+          RETURN NEW;
+        END;
+        $fn$ LANGUAGE plpgsql;
+      `;
+
+      await engine.executeRaw(recreatePagesFn);
+      await engine.executeRaw(recreateChunksFn);
+
+      if (lang === 'english') {
+        console.log(`  v116: trigger functions recreated with language='english' (default — no backfill needed)`);
+        return;
+      }
+
+      // Backfill existing rows under the new tokenizer. UPDATE-to-same-value
+      // re-fires the pages trigger; chunks are rewritten directly with the
+      // same expression as the trigger.
+      await engine.executeRaw(`
+        UPDATE pages SET id = id
+        WHERE search_vector IS NOT NULL;
+      `);
+
+      await engine.executeRaw(`
+        UPDATE content_chunks
+        SET search_vector =
+          setweight(to_tsvector('${lang}', COALESCE(doc_comment, '')), 'A') ||
+          setweight(to_tsvector('${lang}', COALESCE(symbol_name_qualified, '')), 'A') ||
+          setweight(to_tsvector('${lang}', COALESCE(chunk_text, '')), 'B')
+        WHERE search_vector IS NOT NULL;
+      `);
+
+      console.log(`  v116: trigger functions recreated with language='${lang}' + backfilled existing rows`);
+    },
   },
 ];
 

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -24,6 +24,7 @@ import { PGLITE_SCHEMA_SQL, getPGLiteSchema } from './pglite-schema.ts';
 import { DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_DIMENSIONS } from './ai/defaults.ts';
 import { DELETE_BATCH_SIZE } from './engine-constants.ts';
 import { acquireLock, releaseLock, type LockHandle } from './pglite-lock.ts';
+import { getFtsLanguage } from './fts-language.ts';
 import type {
   Page, PageInput, PageFilters, PageType,
   Chunk, ChunkInput, StaleChunkRow, StalePageRow,
@@ -1504,20 +1505,24 @@ export class PGLiteEngine implements BrainEngine {
       extraFilter += ` AND p.source_id = $${params.length}`;
     }
 
+    // FTS config name (e.g. 'english', 'pt_br'). Validated by getFtsLanguage()
+    // — safe to interpolate into raw SQL.
+    const ftsLang = getFtsLanguage();
+
     const { rows } = await this.db.query(
       `WITH ranked AS (
          SELECT
            p.slug, p.id as page_id, p.title, p.type, p.source_id,
            p.effective_date, p.effective_date_source,
            cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
-           ts_rank(cc.search_vector, websearch_to_tsquery('english', $1)) * ${sourceFactorCase} AS score,
+           ts_rank(cc.search_vector, websearch_to_tsquery('${ftsLang}', $1)) * ${sourceFactorCase} AS score,
            CASE WHEN p.updated_at < (
              SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id
            ) THEN true ELSE false END AS stale
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id
          JOIN sources s ON s.id = p.source_id
-         WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
+         WHERE cc.search_vector @@ websearch_to_tsquery('${ftsLang}', $1) ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
            -- v0.27.1: hide image rows from default text-keyword search so
            -- OCR text doesn't drown text-page hits. Image-similarity queries
            -- run a separate vector path on embedding_image.
@@ -1736,20 +1741,23 @@ export class PGLiteEngine implements BrainEngine {
     }
 
     // visibilityClause already declared above (v0.32.7: hoisted so CJK branch can reuse).
+    // FTS config name (e.g. 'english', 'pt_br'). Validated by getFtsLanguage()
+    // — safe to interpolate into raw SQL.
+    const ftsLang = getFtsLanguage();
 
     const { rows } = await this.db.query(
       `SELECT
          p.slug, p.id as page_id, p.title, p.type, p.source_id,
          p.effective_date, p.effective_date_source,
          cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
-         ts_rank(cc.search_vector, websearch_to_tsquery('english', $1)) * ${sourceFactorCase} AS score,
+         ts_rank(cc.search_vector, websearch_to_tsquery('${ftsLang}', $1)) * ${sourceFactorCase} AS score,
          CASE WHEN p.updated_at < (
            SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id
          ) THEN true ELSE false END AS stale
        FROM content_chunks cc
        JOIN pages p ON p.id = cc.page_id
        JOIN sources s ON s.id = p.source_id
-       WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
+       WHERE cc.search_vector @@ websearch_to_tsquery('${ftsLang}', $1) ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
        ORDER BY score DESC
        LIMIT $2 OFFSET $3`,
       params

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -34,6 +34,7 @@ import {
   COLUMN_NAME_REGEX,
   EmbeddingColumnNotRegisteredError,
 } from './search/embedding-column.ts';
+import { getFtsLanguage } from './fts-language.ts';
 import type {
   Page, PageInput, PageFilters, PageType,
   Chunk, ChunkInput, StaleChunkRow, StalePageRow,
@@ -1596,6 +1597,9 @@ export class PostgresEngine implements BrainEngine {
     // column lookup. NOT bypassed by detail=high — soft-delete is a contract,
     // not a temporal preference.
     const visibilityClause = buildVisibilityClause('p', 's');
+    // FTS config name (e.g. 'english', 'pt_br'). Validated by getFtsLanguage()
+    // — safe to interpolate into raw SQL.
+    const ftsLang = getFtsLanguage();
 
     const rawQuery = `
       WITH ranked_chunks AS (
@@ -1603,11 +1607,11 @@ export class PostgresEngine implements BrainEngine {
           p.slug, p.id as page_id, p.title, p.type, p.source_id,
           p.effective_date, p.effective_date_source,
           cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
-          ts_rank(cc.search_vector, websearch_to_tsquery('english', $1)) * ${sourceFactorCase} AS score
+          ts_rank(cc.search_vector, websearch_to_tsquery('${ftsLang}', $1)) * ${sourceFactorCase} AS score
         FROM content_chunks cc
         JOIN pages p ON p.id = cc.page_id
         JOIN sources s ON s.id = p.source_id
-        WHERE cc.search_vector @@ websearch_to_tsquery('english', $1)
+        WHERE cc.search_vector @@ websearch_to_tsquery('${ftsLang}', $1)
           ${typeClause}
           ${typesClause}
           ${excludeSlugsClause}
@@ -1735,18 +1739,21 @@ export class PostgresEngine implements BrainEngine {
 
     // v0.26.5: visibility filter for searchKeywordChunks (anchor primitive).
     const visibilityClause = buildVisibilityClause('p', 's');
+    // FTS config name (e.g. 'english', 'pt_br'). Validated by getFtsLanguage()
+    // — safe to interpolate into raw SQL.
+    const ftsLang = getFtsLanguage();
 
     const rawQuery = `
       SELECT
         p.slug, p.id as page_id, p.title, p.type, p.source_id,
         p.effective_date, p.effective_date_source,
         cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
-        ts_rank(cc.search_vector, websearch_to_tsquery('english', $1)) * ${sourceFactorCase} AS score,
+        ts_rank(cc.search_vector, websearch_to_tsquery('${ftsLang}', $1)) * ${sourceFactorCase} AS score,
         false AS stale
       FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id
       JOIN sources s ON s.id = p.source_id
-      WHERE cc.search_vector @@ websearch_to_tsquery('english', $1)
+      WHERE cc.search_vector @@ websearch_to_tsquery('${ftsLang}', $1)
         ${typeClause}
         ${typesClause}
         ${excludeSlugsClause}

--- a/test/fts-language-migration.test.ts
+++ b/test/fts-language-migration.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { MIGRATIONS, LATEST_VERSION } from '../src/core/migrate.ts';
+import { resetFtsLanguageCache } from '../src/core/fts-language.ts';
+
+const ENV_KEY = 'GBRAIN_FTS_LANGUAGE';
+const originalLang = process.env[ENV_KEY];
+
+beforeEach(() => {
+  delete process.env[ENV_KEY];
+  resetFtsLanguageCache();
+});
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+  if (originalLang !== undefined) process.env[ENV_KEY] = originalLang;
+  resetFtsLanguageCache();
+});
+
+describe('configurable_fts_language migration', () => {
+  test('migration is registered', () => {
+    const ftsMig = MIGRATIONS.find(m => m.name === 'configurable_fts_language');
+    expect(ftsMig).toBeDefined();
+    expect(ftsMig?.version).toBeGreaterThan(115);
+  });
+
+  test('fts migration is the latest migration', () => {
+    expect(MIGRATIONS.find(m => m.name === 'configurable_fts_language')?.version).toBe(LATEST_VERSION);
+  });
+
+  test('ftsMig uses handler (not static SQL) because language interpolation is dynamic', () => {
+    const ftsMig = MIGRATIONS.find(m => m.name === 'configurable_fts_language');
+    expect(ftsMig?.sql).toBe('');
+    expect(ftsMig?.handler).toBeTypeOf('function');
+  });
+
+  test('ftsMig handler is async', () => {
+    const ftsMig = MIGRATIONS.find(m => m.name === 'configurable_fts_language');
+    // Async function check: the constructor name is 'AsyncFunction'
+    expect(ftsMig?.handler?.constructor.name).toBe('AsyncFunction');
+  });
+
+  test('migration handler issues recreate-function calls (smoke check via mock engine)', async () => {
+    const ftsMig = MIGRATIONS.find(m => m.name === 'configurable_fts_language');
+    const calls: string[] = [];
+
+    const mockEngine = {
+      executeRaw: async (sql: string) => {
+        calls.push(sql);
+        return [];
+      },
+    } as unknown as BrainEngine;
+
+    process.env[ENV_KEY] = 'english';
+    resetFtsLanguageCache();
+
+    await ftsMig?.handler?.(mockEngine);
+
+    // Default 'english' \u2014 no backfill, only 2 CREATE OR REPLACE calls.
+    expect(calls.length).toBe(2);
+    expect(calls[0]).toContain('CREATE OR REPLACE FUNCTION update_page_search_vector');
+    expect(calls[0]).toContain("to_tsvector('english'");
+    expect(calls[1]).toContain('CREATE OR REPLACE FUNCTION update_chunk_search_vector');
+    expect(calls[1]).toContain("to_tsvector('english'");
+  });
+
+  test('non-english language triggers backfill', async () => {
+    const ftsMig = MIGRATIONS.find(m => m.name === 'configurable_fts_language');
+    const calls: string[] = [];
+
+    const mockEngine = {
+      executeRaw: async (sql: string) => {
+        calls.push(sql);
+        return [];
+      },
+    } as unknown as BrainEngine;
+
+    process.env[ENV_KEY] = 'pt_br';
+    resetFtsLanguageCache();
+
+    await ftsMig?.handler?.(mockEngine);
+
+    // pt_br \u2014 2 CREATE + 2 backfill UPDATEs = 4 calls
+    expect(calls.length).toBe(4);
+    expect(calls[0]).toContain("to_tsvector('pt_br'");
+    expect(calls[1]).toContain("to_tsvector('pt_br'");
+    expect(calls[2]).toMatch(/UPDATE pages/);
+    expect(calls[3]).toContain("to_tsvector('pt_br'");
+    expect(calls[3]).toMatch(/UPDATE content_chunks/);
+  });
+
+  test('invalid language falls back to english (no SQL injection)', async () => {
+    const ftsMig = MIGRATIONS.find(m => m.name === 'configurable_fts_language');
+    const calls: string[] = [];
+
+    const mockEngine = {
+      executeRaw: async (sql: string) => {
+        calls.push(sql);
+        return [];
+      },
+    } as unknown as BrainEngine;
+
+    process.env[ENV_KEY] = "english'; DROP TABLE pages; --";
+    resetFtsLanguageCache();
+
+    await ftsMig?.handler?.(mockEngine);
+
+    // Falls back to english: 2 CREATE OR REPLACE only, no DROP TABLE in any SQL.
+    expect(calls.length).toBe(2);
+    for (const sql of calls) {
+      expect(sql).not.toContain('DROP TABLE');
+      expect(sql).toContain("to_tsvector('english'");
+    }
+  });
+});

--- a/test/fts-language.test.ts
+++ b/test/fts-language.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { getFtsLanguage, resetFtsLanguageCache } from '../src/core/fts-language.ts';
+
+const ENV_KEY = 'GBRAIN_FTS_LANGUAGE';
+
+beforeEach(() => {
+  delete process.env[ENV_KEY];
+  resetFtsLanguageCache();
+});
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+  resetFtsLanguageCache();
+});
+
+describe('getFtsLanguage', () => {
+  test('defaults to english when env is unset', () => {
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('defaults to english when env is empty string', () => {
+    process.env[ENV_KEY] = '';
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('defaults to english when env is whitespace', () => {
+    process.env[ENV_KEY] = '   ';
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('reads valid pt_br config', () => {
+    process.env[ENV_KEY] = 'pt_br';
+    expect(getFtsLanguage()).toBe('pt_br');
+  });
+
+  test('reads valid simple language name', () => {
+    process.env[ENV_KEY] = 'spanish';
+    expect(getFtsLanguage()).toBe('spanish');
+  });
+
+  test('reads name with underscores and digits', () => {
+    process.env[ENV_KEY] = 'custom_lang_v2';
+    expect(getFtsLanguage()).toBe('custom_lang_v2');
+  });
+
+  test('rejects names with quotes (SQL injection guard)', () => {
+    process.env[ENV_KEY] = "english'; DROP TABLE pages; --";
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('rejects names with spaces', () => {
+    process.env[ENV_KEY] = 'pt br';
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('rejects names with hyphens', () => {
+    process.env[ENV_KEY] = 'pt-br';
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('rejects names starting with digit', () => {
+    process.env[ENV_KEY] = '1lang';
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('rejects uppercase (Postgres config names are lowercase)', () => {
+    process.env[ENV_KEY] = 'English';
+    expect(getFtsLanguage()).toBe('english');
+  });
+
+  test('caches after first read', () => {
+    process.env[ENV_KEY] = 'pt_br';
+    expect(getFtsLanguage()).toBe('pt_br');
+
+    // Mutate env after first read \u2014 cached value wins.
+    process.env[ENV_KEY] = 'spanish';
+    expect(getFtsLanguage()).toBe('pt_br');
+  });
+
+  test('resetFtsLanguageCache clears cache', () => {
+    process.env[ENV_KEY] = 'pt_br';
+    expect(getFtsLanguage()).toBe('pt_br');
+
+    resetFtsLanguageCache();
+    process.env[ENV_KEY] = 'spanish';
+    expect(getFtsLanguage()).toBe('spanish');
+  });
+
+  test('trims surrounding whitespace from valid value', () => {
+    process.env[ENV_KEY] = '  pt_br  ';
+    expect(getFtsLanguage()).toBe('pt_br');
+  });
+});

--- a/test/reindex-search-vector.test.ts
+++ b/test/reindex-search-vector.test.ts
@@ -1,0 +1,146 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { runReindexSearchVector } from '../src/commands/reindex-search-vector.ts';
+import { resetFtsLanguageCache } from '../src/core/fts-language.ts';
+
+const ENV_KEY = 'GBRAIN_FTS_LANGUAGE';
+const originalLang = process.env[ENV_KEY];
+
+interface MockState {
+  calls: string[];
+  rowsToReturn: { pages: number; chunks: number };
+}
+
+function makeMockEngine(state: MockState): BrainEngine {
+  return {
+    executeRaw: async (sql: string) => {
+      state.calls.push(sql);
+      // Inventory query — return the configured counts
+      if (sql.includes('SELECT') && sql.includes('FROM pages WHERE search_vector')) {
+        return [{ pages: state.rowsToReturn.pages, chunks: state.rowsToReturn.chunks }];
+      }
+      return [];
+    },
+  } as unknown as BrainEngine;
+}
+
+beforeEach(() => {
+  delete process.env[ENV_KEY];
+  resetFtsLanguageCache();
+});
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+  if (originalLang !== undefined) process.env[ENV_KEY] = originalLang;
+  resetFtsLanguageCache();
+});
+
+describe('runReindexSearchVector', () => {
+  test('--dry-run does not issue any DDL or backfill SQL', async () => {
+    const state: MockState = { calls: [], rowsToReturn: { pages: 100, chunks: 500 } };
+    const engine = makeMockEngine(state);
+
+    process.env[ENV_KEY] = 'pt_br';
+    resetFtsLanguageCache();
+
+    const result = await runReindexSearchVector(engine, { dryRun: true, json: true });
+
+    expect(result.status).toBe('dry_run');
+    expect(result.language).toBe('pt_br');
+    expect(result.pagesUpdated).toBe(100);
+    expect(result.chunksUpdated).toBe(500);
+    expect(result.triggersRecreated).toBe(0);
+
+    // Only the inventory query — no CREATE OR REPLACE, no UPDATE.
+    expect(state.calls.length).toBe(1);
+    expect(state.calls[0]).toContain('SELECT');
+    expect(state.calls[0]).not.toContain('CREATE OR REPLACE');
+    expect(state.calls[0]).not.toContain('UPDATE');
+  });
+
+  test('--yes recreates triggers + backfills with configured language', async () => {
+    const state: MockState = { calls: [], rowsToReturn: { pages: 50, chunks: 200 } };
+    const engine = makeMockEngine(state);
+
+    process.env[ENV_KEY] = 'pt_br';
+    resetFtsLanguageCache();
+
+    const result = await runReindexSearchVector(engine, { yes: true, json: true });
+
+    expect(result.status).toBe('ok');
+    expect(result.language).toBe('pt_br');
+    expect(result.triggersRecreated).toBe(2);
+    expect(result.pagesUpdated).toBe(50);
+    expect(result.chunksUpdated).toBe(200);
+
+    // 1 inventory + 2 CREATE + 2 backfills = 5 calls
+    expect(state.calls.length).toBe(5);
+    expect(state.calls[1]).toContain('CREATE OR REPLACE FUNCTION update_page_search_vector');
+    expect(state.calls[1]).toContain("to_tsvector('pt_br'");
+    expect(state.calls[2]).toContain('CREATE OR REPLACE FUNCTION update_chunk_search_vector');
+    expect(state.calls[2]).toContain("to_tsvector('pt_br'");
+    expect(state.calls[3]).toMatch(/UPDATE pages/);
+    expect(state.calls[4]).toMatch(/UPDATE content_chunks/);
+    expect(state.calls[4]).toContain("to_tsvector('pt_br'");
+  });
+
+  test('default english language still recreates + backfills (no shortcut here)', async () => {
+    // Note: unlike v33 migration, the CLI command intentionally backfills even
+    // for english. The user explicitly asked for it, so we honor it. v33 skips
+    // backfill for english because it auto-runs on first apply.
+    const state: MockState = { calls: [], rowsToReturn: { pages: 10, chunks: 30 } };
+    const engine = makeMockEngine(state);
+
+    const result = await runReindexSearchVector(engine, { yes: true, json: true });
+
+    expect(result.status).toBe('ok');
+    expect(result.language).toBe('english');
+    expect(state.calls.length).toBe(5);
+
+    // Trigger recreates (calls 1, 2) and chunks backfill (call 4) embed the
+    // language literal. Pages backfill (call 3) is UPDATE-to-self that
+    // re-fires the trigger, so the language literal lives in the trigger
+    // function body — not in the UPDATE statement.
+    expect(state.calls[1]).toContain("'english'");
+    expect(state.calls[2]).toContain("'english'");
+    expect(state.calls[3]).toMatch(/UPDATE pages/);
+    expect(state.calls[4]).toContain("'english'");
+  });
+
+  test('SQL injection attempt falls back to english', async () => {
+    const state: MockState = { calls: [], rowsToReturn: { pages: 10, chunks: 30 } };
+    const engine = makeMockEngine(state);
+
+    process.env[ENV_KEY] = "english'; DROP TABLE pages; --";
+    resetFtsLanguageCache();
+
+    const result = await runReindexSearchVector(engine, { yes: true, json: true });
+
+    expect(result.language).toBe('english');
+    for (const sql of state.calls) {
+      expect(sql).not.toContain('DROP TABLE');
+    }
+  });
+
+  test('empty inventory still completes successfully', async () => {
+    const state: MockState = { calls: [], rowsToReturn: { pages: 0, chunks: 0 } };
+    const engine = makeMockEngine(state);
+
+    const result = await runReindexSearchVector(engine, { yes: true, json: true });
+
+    expect(result.status).toBe('ok');
+    expect(result.pagesUpdated).toBe(0);
+    expect(result.chunksUpdated).toBe(0);
+    expect(result.triggersRecreated).toBe(2);
+  });
+
+  test('result includes durationMs', async () => {
+    const state: MockState = { calls: [], rowsToReturn: { pages: 1, chunks: 1 } };
+    const engine = makeMockEngine(state);
+
+    const result = await runReindexSearchVector(engine, { yes: true, json: true });
+
+    expect(typeof result.durationMs).toBe('number');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `gbrain reindex-search-vector` — an explicit CLI command that recreates FTS trigger functions and backfills existing rows under the language configured via `GBRAIN_FTS_LANGUAGE`.

This is **PR 3 of 3** in a series. **Depends on #580 and #581.** Closes the post-install gap left by #581: changing language after v33 has already run can't go back through the migrations runner (v33 shows as applied), so users need a dedicated entry point.

## Why this command exists

Schema migration v33 (#581) stamps the trigger function bodies with the language at first apply. After that:

- Changing `GBRAIN_FTS_LANGUAGE` and rerunning `gbrain init --migrate-only` is a no-op because v33 shows as applied.
- The only way to re-apply is to manually reset `config.version` to 32 — fragile, undocumented, scary.

This command is the documented escape hatch. It runs the same recreate-and-backfill primitives as v33, but gated on an explicit user action so the operation is intentional and visible.

## Behavior

- Reads `GBRAIN_FTS_LANGUAGE` via the same `getFtsLanguage()` helper as the engines (#580) and v33 migration (#581) — three sites, one source of truth.
- `--dry-run` shows row counts (pages + chunks affected) without touching the DB.
- `--yes` / `-y` skips interactive prompt; required in non-TTY contexts.
- `--json` emits a structured result envelope (`{ status, language, pagesUpdated, chunksUpdated, triggersRecreated, durationMs }`) for scripting.
- Trigger recreate is atomic via `CREATE OR REPLACE FUNCTION`; backfill is `UPDATE pages SET id = id` (re-fires trigger) + direct `UPDATE content_chunks SET search_vector = ...` — same patterns as v33.

## Validated against a real brain

Tested on a Postgres-backed brain with **2,782 pages and 4,372 chunks**:

```bash
$ GBRAIN_FTS_LANGUAGE=pt_br gbrain reindex-search-vector --dry-run
[dry-run] Would recreate 2 trigger functions with language='pt_br'
[dry-run] Would backfill 2782 pages + 4372 chunks
[dry-run] Skipping all DB writes. Pass --yes to apply.

$ GBRAIN_FTS_LANGUAGE=pt_br gbrain reindex-search-vector --yes
✅ Recreated 2 trigger functions with language='pt_br'
✅ Backfilled 2782 pages + 4372 chunks (8204ms)

$ GBRAIN_FTS_LANGUAGE=pt_br gbrain reindex-search-vector --yes --json
{
  "status": "ok",
  "language": "pt_br",
  "pagesUpdated": 2782,
  "chunksUpdated": 4372,
  "triggersRecreated": 2,
  "durationMs": 7313
}
```

After running, `gbrain search "operações"` (with diacritics) continues to return correct hits via the Portuguese stemmer.

## Tests

6 unit tests in `test/reindex-search-vector.test.ts`:

- `--dry-run` issues only the inventory `SELECT`; no `CREATE OR REPLACE`, no `UPDATE`
- `--yes` issues 5 SQL calls in expected order (inventory → 2 recreates → 2 backfills)
- Default `english` still recreates and backfills (CLI honors the user's intent; v33 is the only place that shortcuts english)
- SQL injection attempt falls back to `'english'`, emits no `DROP TABLE`
- Empty inventory completes with `triggersRecreated: 2`, `pagesUpdated: 0`, `chunksUpdated: 0`
- `result.durationMs` is a non-negative number

Combined with PRs #580 and #581: **27/27 unit tests pass.**

```
$ bun test test/fts-language.test.ts test/fts-language-migration.test.ts test/reindex-search-vector.test.ts
 27 pass
 0 fail
```

`bun run typecheck` clean. `bun run build` produces a working compiled binary.

## Trade-offs considered

- **Persist language in `config` table instead of relying on env var?** Decided against. Env vars are the established GBrain pattern (`GBRAIN_EMBED_MODEL`, `GBRAIN_BRAIN_ID`, `GBRAIN_DATABASE_URL`). Adding a config-table entry creates ambiguity about precedence (env vs DB) and a new failure mode (env says one thing, DB says another). Single source of truth via env is simpler.
- **Auto-detect language drift at startup?** Could compare configured language vs trigger body in `pg_proc` and emit a warning. Out of scope for this PR; happy to follow up if there's interest.
- **Show progress for large brains?** Backfill is two `UPDATE` statements, no obvious progress hook. On a 20K-page brain expect ~30-60s. Could add `\copy`-style progress later if real users hit it.

## Backward-compatible

Command is additive. Default behavior of the brain (with no language env var set) is unchanged. Calling the command on an `english`-default brain is safe and idempotent — it just rewrites trigger bodies that produce identical output.

## End of the series

With #580, #581, and this PR landed, GBrain supports first-class non-English brains:

```bash
# Fresh install, Portuguese:
export GBRAIN_FTS_LANGUAGE=portuguese
gbrain init                              # v33 stamps triggers with portuguese
gbrain import ~/notas/                   # pages tokenize as portuguese
gbrain query "reuniões importantes"      # query side stems portuguese

# Later, switch to a custom unaccent + portuguese config:
export GBRAIN_FTS_LANGUAGE=pt_br
gbrain reindex-search-vector --yes       # recreate + backfill with pt_br
```

Happy to discuss design alternatives or split this further if it'd help review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->