### PR TITLE
feat(embed): support local models + configurable dims/cost via GBRAIN_EMBED_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,54 @@ embedded PG 17.5
 
 PGLite: embedded Postgres, no server, zero config. When your brain outgrows local (1000+ files, multi-device), `gbrain migrate --to supabase` moves everything.
 
+## Local models (Ollama, LM Studio, vLLM, Together)
+
+By default GBrain embeds via OpenAI `text-embedding-3-large` at 1536 dims. Every knob is configurable through `GBRAIN_EMBED_*` env vars so you can point the embedding service at any OpenAI-compatible endpoint — local or remote, paid or free.
+
+```bash
+# Ollama (local, free)
+export GBRAIN_EMBED_URL=http://localhost:11434/v1
+export GBRAIN_EMBED_MODEL=nomic-embed-text
+export GBRAIN_EMBED_DIMENSIONS=768
+export GBRAIN_EMBED_KEY=ollama        # any non-empty value
+export GBRAIN_EMBED_COST_PER_1K=0     # local = $0
+
+# LM Studio (local, free)
+export GBRAIN_EMBED_URL=http://localhost:1234/v1
+export GBRAIN_EMBED_MODEL=text-embedding-bge-m3
+export GBRAIN_EMBED_DIMENSIONS=1024
+
+# Together AI (cheap remote)
+export GBRAIN_EMBED_URL=https://api.together.xyz/v1
+export GBRAIN_EMBED_MODEL=BAAI/bge-large-en-v1.5
+export GBRAIN_EMBED_DIMENSIONS=1024
+export GBRAIN_EMBED_KEY=$TOGETHER_API_KEY
+export GBRAIN_EMBED_COST_PER_1K=0.00001
+```
+
+Full env reference:
+
+| Var | Default | Notes |
+|---|---|---|
+| `GBRAIN_EMBED_MODEL` | `text-embedding-3-large` | Model id sent to the API |
+| `GBRAIN_EMBED_DIMENSIONS` | `1536` | Must match the model's actual dim |
+| `GBRAIN_EMBED_URL` | (OpenAI default) | Base URL for OpenAI-compatible servers |
+| `GBRAIN_EMBED_KEY` | (`OPENAI_API_KEY`) | API key override (any non-empty value works for Ollama) |
+| `GBRAIN_EMBED_COST_PER_1K` | `0.00013` | USD; set to `0` for local |
+| `GBRAIN_EMBED_BATCH` | `100` | Batch size for bulk embed |
+| `GBRAIN_EMBED_MAX_CHARS` | `8000` | Per-input character truncation |
+
+**Changing dimensions on an existing brain:** schema migration v33 resizes the `content_chunks.embedding` column when `GBRAIN_EMBED_DIMENSIONS` differs from the current value, but only if no embeddings exist yet (pgvector can't cast between dims). To migrate a populated brain:
+
+```bash
+psql $DATABASE_URL -c "UPDATE content_chunks SET embedding = NULL"
+export GBRAIN_EMBED_DIMENSIONS=768
+gbrain init --migrate-only      # v33 resizes the column
+gbrain embed --all              # re-embed everything at the new dim
+```
+
+Validation: model names, dims, URLs, and costs are all validated before use. Invalid values fall back to defaults with a warning so a typo can't silently corrupt the brain.
+
 ## File Storage
 
 Brain repos accumulate binaries. GBrain has a three-stage migration:

--- a/src/core/embedding-config.ts
+++ b/src/core/embedding-config.ts
@@ -1,0 +1,165 @@
+/**
+ * Embedding service configuration.
+ *
+ * Historically GBrain hardcoded:
+ *   - model        = 'text-embedding-3-large'
+ *   - dimensions   = 1536
+ *   - cost/1k      = $0.00013 (OpenAI 2026 pricing)
+ *   - baseURL      = OpenAI default
+ *   - API key      = OPENAI_API_KEY
+ *   - batch size   = 100
+ *
+ * That worked when "embedding" meant "OpenAI". Today users want local
+ * inference (Ollama, LM Studio, vLLM, Together, Fireworks) — different
+ * models, different dimensions, different (or zero) cost. This module
+ * centralizes every knob behind GBRAIN_EMBED_* env vars with backward-
+ * compatible defaults.
+ *
+ * Validation: every value is read once, validated, cached. Invalid values
+ * fall back to the historical default with a one-time warning so a typo
+ * doesn't silently corrupt the brain.
+ *
+ * Important constraint: changing GBRAIN_EMBED_DIMENSIONS on an existing
+ * brain is a schema change (the `embedding` column is `vector(N)` and
+ * Postgres won't auto-cast between dims). The migration story for that
+ * is out of scope for this module — see docs/guides/local-models.md.
+ */
+
+export interface EmbeddingConfig {
+  /** Model identifier sent to the embeddings API (e.g. 'text-embedding-3-large', 'nomic-embed-text', 'mxbai-embed-large'). */
+  model: string;
+  /** Output vector dimensions. Must match the model's actual dimension. */
+  dimensions: number;
+  /** USD cost per 1k tokens. Set to 0 for local models. */
+  costPer1kTokens: number;
+  /** Optional baseURL override for OpenAI-compatible endpoints (Ollama, LM Studio, vLLM, etc.). */
+  baseUrl: string | undefined;
+  /** Optional API key override. Falls back to OPENAI_API_KEY when undefined. */
+  apiKey: string | undefined;
+  /** Batch size for bulk embedding requests. */
+  batchSize: number;
+  /** Maximum input character length before truncation. */
+  maxChars: number;
+}
+
+const DEFAULTS: EmbeddingConfig = {
+  model: 'text-embedding-3-large',
+  dimensions: 1536,
+  costPer1kTokens: 0.00013,
+  baseUrl: undefined,
+  apiKey: undefined,
+  batchSize: 100,
+  maxChars: 8000,
+};
+
+let cached: EmbeddingConfig | null = null;
+
+/** Hard limits that prevent obviously-invalid configs from reaching Postgres. */
+const MIN_DIM = 1;
+const MAX_DIM = 16384; // pgvector hard limit for hnsw indexes
+const MIN_BATCH = 1;
+const MAX_BATCH = 2048;
+
+function readInt(envKey: string, fallback: number, min: number, max: number): number {
+  const raw = process.env[envKey];
+  if (!raw) return fallback;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) {
+    console.warn(`[gbrain] Invalid ${envKey}='${raw}' (not an integer). Falling back to ${fallback}.`);
+    return fallback;
+  }
+
+  if (parsed < min || parsed > max) {
+    console.warn(`[gbrain] ${envKey}=${parsed} out of range [${min}, ${max}]. Falling back to ${fallback}.`);
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function readFloat(envKey: string, fallback: number, min: number, max: number): number {
+  const raw = process.env[envKey];
+  if (!raw) return fallback;
+
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed)) {
+    console.warn(`[gbrain] Invalid ${envKey}='${raw}' (not a number). Falling back to ${fallback}.`);
+    return fallback;
+  }
+
+  if (parsed < min || parsed > max) {
+    console.warn(`[gbrain] ${envKey}=${parsed} out of range [${min}, ${max}]. Falling back to ${fallback}.`);
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function readModel(envKey: string, fallback: string): string {
+  const raw = process.env[envKey]?.trim();
+  if (!raw) return fallback;
+
+  // Model identifiers can contain letters, digits, hyphens, underscores,
+  // colons (Ollama uses 'model:tag'), dots (versioned models), and slashes
+  // (HuggingFace-style 'org/model'). Reject anything else as a guard
+  // against accidental shell expansion or whitespace.
+  if (!/^[a-zA-Z0-9._:\-/]+$/.test(raw)) {
+    console.warn(`[gbrain] Invalid ${envKey}='${raw}' (contains forbidden characters). Falling back to '${fallback}'.`);
+    return fallback;
+  }
+
+  return raw;
+}
+
+function readUrl(envKey: string): string | undefined {
+  const raw = process.env[envKey]?.trim();
+  if (!raw) return undefined;
+
+  // Defensive parse — if it doesn't look like a URL, ignore it so the
+  // OpenAI client falls back to its default endpoint.
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      console.warn(`[gbrain] Invalid ${envKey}='${raw}' (must be http:// or https://). Ignoring.`);
+      return undefined;
+    }
+    return raw;
+  } catch {
+    console.warn(`[gbrain] Invalid ${envKey}='${raw}' (not a valid URL). Ignoring.`);
+    return undefined;
+  }
+}
+
+/**
+ * Returns the active embedding configuration, reading from env once and
+ * caching the result. Subsequent calls return the same object.
+ */
+export function getEmbeddingConfig(): EmbeddingConfig {
+  if (cached !== null) return cached;
+
+  cached = {
+    model: readModel('GBRAIN_EMBED_MODEL', DEFAULTS.model),
+    dimensions: readInt('GBRAIN_EMBED_DIMENSIONS', DEFAULTS.dimensions, MIN_DIM, MAX_DIM),
+    costPer1kTokens: readFloat('GBRAIN_EMBED_COST_PER_1K', DEFAULTS.costPer1kTokens, 0, 1000),
+    baseUrl: readUrl('GBRAIN_EMBED_URL'),
+    apiKey: process.env.GBRAIN_EMBED_KEY?.trim() || undefined,
+    batchSize: readInt('GBRAIN_EMBED_BATCH', DEFAULTS.batchSize, MIN_BATCH, MAX_BATCH),
+    maxChars: readInt('GBRAIN_EMBED_MAX_CHARS', DEFAULTS.maxChars, 100, 100_000),
+  };
+
+  return cached;
+}
+
+/**
+ * Resets the cached config. Tests only — don't use in production code.
+ */
+export function resetEmbeddingConfigCache(): void {
+  cached = null;
+}
+
+/**
+ * The static defaults, exposed so tests and migration code can compare
+ * against the historical baseline without re-reading env.
+ */
+export const EMBEDDING_DEFAULTS: Readonly<EmbeddingConfig> = Object.freeze(DEFAULTS);

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -2,39 +2,59 @@
  * Embedding Service
  * Ported from production Ruby implementation (embedding_service.rb, 190 LOC)
  *
- * OpenAI text-embedding-3-large at 1536 dimensions.
+ * Defaults to OpenAI text-embedding-3-large at 1536 dimensions, but every
+ * knob (model, dims, base URL, API key, cost, batch size, max chars) is
+ * configurable via GBRAIN_EMBED_* env vars. See src/core/embedding-config.ts
+ * for the full list and validation rules.
+ *
+ * To run against a local Ollama instance:
+ *   export GBRAIN_EMBED_URL=http://localhost:11434/v1
+ *   export GBRAIN_EMBED_MODEL=nomic-embed-text
+ *   export GBRAIN_EMBED_DIMENSIONS=768
+ *   export GBRAIN_EMBED_KEY=ollama        # any non-empty value
+ *   export GBRAIN_EMBED_COST_PER_1K=0     # local = free
+ *
  * Retry with exponential backoff (4s base, 120s cap, 5 retries).
- * 8000 character input truncation.
  */
 
 import OpenAI from 'openai';
+import { getEmbeddingConfig } from './embedding-config.ts';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
-const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
-const BATCH_SIZE = 100;
 
 let client: OpenAI | null = null;
 
 function getClient(): OpenAI {
   if (!client) {
-    client = new OpenAI();
+    const cfg = getEmbeddingConfig();
+    const opts: ConstructorParameters<typeof OpenAI>[0] = {};
+    if (cfg.baseUrl) opts.baseURL = cfg.baseUrl;
+    if (cfg.apiKey) opts.apiKey = cfg.apiKey;
+    client = new OpenAI(opts);
   }
   return client;
 }
 
+/**
+ * Reset the cached OpenAI client. Tests only — flush after mutating env
+ * vars that affect the client (baseURL, apiKey).
+ */
+export function resetEmbeddingClient(): void {
+  client = null;
+}
+
 export async function embed(text: string): Promise<Float32Array> {
-  const truncated = text.slice(0, MAX_CHARS);
+  const cfg = getEmbeddingConfig();
+  const truncated = text.slice(0, cfg.maxChars);
   const result = await embedBatch([truncated]);
   return result[0];
 }
 
 export interface EmbedBatchOptions {
   /**
-   * Optional callback fired after each 100-item sub-batch completes.
+   * Optional callback fired after each sub-batch completes.
    * CLI wrappers tick a reporter; Minion handlers can call
    * job.updateProgress here instead of hooking the per-page callback.
    */
@@ -45,12 +65,12 @@ export async function embedBatch(
   texts: string[],
   options: EmbedBatchOptions = {},
 ): Promise<Float32Array[]> {
-  const truncated = texts.map(t => t.slice(0, MAX_CHARS));
+  const cfg = getEmbeddingConfig();
+  const truncated = texts.map(t => t.slice(0, cfg.maxChars));
   const results: Float32Array[] = [];
 
-  // Process in batches of BATCH_SIZE
-  for (let i = 0; i < truncated.length; i += BATCH_SIZE) {
-    const batch = truncated.slice(i, i + BATCH_SIZE);
+  for (let i = 0; i < truncated.length; i += cfg.batchSize) {
+    const batch = truncated.slice(i, i + cfg.batchSize);
     const batchResults = await embedBatchWithRetry(batch);
     results.push(...batchResults);
     options.onBatchComplete?.(results.length, truncated.length);
@@ -60,13 +80,25 @@ export async function embedBatch(
 }
 
 async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
+  const cfg = getEmbeddingConfig();
+
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const response = await getClient().embeddings.create({
-        model: MODEL,
+      // Some OpenAI-compatible providers (e.g. Ollama, LM Studio) do NOT
+      // accept a `dimensions` param — they always return the model's native
+      // dim. We pass it only when targeting the actual OpenAI endpoint
+      // (cfg.baseUrl is undefined). For custom endpoints, the dim env var
+      // is purely informational; the actual dim must match what the model
+      // returns or pgvector inserts will fail with a clear error.
+      const request: Parameters<ReturnType<typeof getClient>['embeddings']['create']>[0] = {
+        model: cfg.model,
         input: texts,
-        dimensions: DIMENSIONS,
-      });
+      };
+      if (!cfg.baseUrl) {
+        request.dimensions = cfg.dimensions;
+      }
+
+      const response = await getClient().embeddings.create(request);
 
       // Sort by index to maintain order
       const sorted = response.data.sort((a, b) => a.index - b.index);
@@ -104,21 +136,43 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
+// ============================================================
+// Backward-compatible exports
+//
+// Pre-existing callers import these as plain constants. We can't make
+// them live-track env vars without runtime trickery (Proxy on a primitive
+// is fragile — `${X}` fails). So they snapshot the config at module load.
+//
+// New code should call getEmbeddingConfig() directly to pick up env
+// changes made after module load (e.g. tests, reindex commands that flip
+// providers mid-process).
+// ============================================================
+
+const _initialConfig = getEmbeddingConfig();
+
+/** @deprecated Prefer getEmbeddingConfig().model — this snapshots at module load. */
+export const EMBEDDING_MODEL = _initialConfig.model;
+
+/** @deprecated Prefer getEmbeddingConfig().dimensions — this snapshots at module load. */
+export const EMBEDDING_DIMENSIONS = _initialConfig.dimensions;
 
 /**
- * v0.20.0 Cathedral II Layer 8 (D1): USD cost per 1k tokens for
- * text-embedding-3-large. Used by `gbrain sync --all` cost preview and
+ * v0.20.0 Cathedral II Layer 8 (D1): USD cost per 1k tokens. Defaults to
+ * text-embedding-3-large pricing ($0.00013) but configurable via
+ * GBRAIN_EMBED_COST_PER_1K. Used by `gbrain sync --all` cost preview and
  * the reindex-code backfill command to surface expected spend before
  * the agent/user accepts an expensive operation.
  *
- * Value: $0.00013 / 1k tokens as of 2026. Update when OpenAI changes
- * pricing. Single source of truth — every cost-preview surface reads
- * this constant, so a pricing change is a one-line edit.
+ * Local models: set to 0.
+ *
+ * @deprecated Prefer getEmbeddingConfig().costPer1kTokens — this snapshots at module load.
  */
-export const EMBEDDING_COST_PER_1K_TOKENS = 0.00013;
+export const EMBEDDING_COST_PER_1K_TOKENS = _initialConfig.costPer1kTokens;
 
-/** Compute USD cost estimate for embedding `tokens` at current model rate. */
+/**
+ * Compute USD cost estimate for embedding `tokens` at current model rate.
+ * Reads the live config each call, so cost env changes take effect mid-process.
+ */
 export function estimateEmbeddingCostUsd(tokens: number): number {
-  return (tokens / 1000) * EMBEDDING_COST_PER_1K_TOKENS;
+  return (tokens / 1000) * getEmbeddingConfig().costPer1kTokens;
 }

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -1,5 +1,6 @@
 import type { BrainEngine } from './engine.ts';
 import { slugifyPath } from './sync.ts';
+import { getEmbeddingConfig, EMBEDDING_DEFAULTS } from './embedding-config.ts';
 
 /**
  * Schema migrations — run automatically on initSchema().
@@ -1262,6 +1263,84 @@ export const MIGRATIONS: Migration[] = [
         END IF;
       END $$;
     `,
+  },
+  {
+    version: 33,
+    name: 'configurable_embedding_dimensions',
+    // When GBRAIN_EMBED_DIMENSIONS differs from the schema default (1536),
+    // resize the content_chunks.embedding column AND update the
+    // embedding_dimensions config row so search and ingestion stay in sync.
+    //
+    // Safety: refuses to resize when chunks already have non-NULL embeddings,
+    // because pgvector cannot cast between dimensions — every existing vector
+    // would be invalid at the new size. The error message points users at
+    // the documented re-embed flow (drop embeddings + reindex).
+    //
+    // When configured dim equals schema default: no-op.
+    // When configured dim differs but no embeddings exist: ALTER TYPE +
+    //   recreate the HNSW index at the new dim + update config row.
+    // When configured dim differs AND embeddings exist: raise with guidance.
+    sql: '',
+    handler: async (engine) => {
+      const cfg = getEmbeddingConfig();
+      const targetDim = cfg.dimensions;
+      const defaultDim = EMBEDDING_DEFAULTS.dimensions;
+
+      if (targetDim === defaultDim) {
+        return;
+      }
+
+      // Inventory: do we have any embeddings written? If yes, we can't
+      // resize without dropping them.
+      const counts = await engine.executeRaw<{ embedded: number }>(
+        `SELECT COUNT(*)::int AS embedded FROM content_chunks WHERE embedding IS NOT NULL`,
+      );
+      const embedded = counts[0]?.embedded ?? 0;
+
+      if (embedded > 0) {
+        throw new Error(
+          `v33 configurable_embedding_dimensions: GBRAIN_EMBED_DIMENSIONS=${targetDim} ` +
+          `differs from current schema dim ${defaultDim}, but ${embedded} chunk(s) already have embeddings. ` +
+          `pgvector cannot cast between dimensions. To resize: ` +
+          `\n  1. UPDATE content_chunks SET embedding = NULL;` +
+          `\n  2. Re-run apply-migrations (this migration will then resize the column).` +
+          `\n  3. gbrain embed --all  (re-embed everything at the new dim).` +
+          `\nSee docs/guides/local-models.md for the full procedure.`,
+        );
+      }
+
+      // Safe to resize: column has no embeddings yet, so the dim change
+      // is structural only. Drop the HNSW index first (it's tied to the
+      // old dim), ALTER, recreate index at new dim.
+      await engine.executeRaw(`DROP INDEX IF EXISTS idx_chunks_embedding`);
+      await engine.executeRaw(
+        `ALTER TABLE content_chunks ALTER COLUMN embedding TYPE vector(${targetDim})`,
+      );
+      await engine.executeRaw(
+        `CREATE INDEX idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops)`,
+      );
+
+      // Keep the config row in sync so anything reading 'embedding_dimensions'
+      // from the config table sees the active value.
+      await engine.executeRaw(
+        `INSERT INTO config (key, value) VALUES ('embedding_dimensions', $1) ` +
+        `ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+        [String(targetDim)],
+      );
+
+      // Also update the embedding_model row when the model env is set.
+      if (cfg.model !== EMBEDDING_DEFAULTS.model) {
+        await engine.executeRaw(
+          `INSERT INTO config (key, value) VALUES ('embedding_model', $1) ` +
+          `ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+          [cfg.model],
+        );
+      }
+
+      console.log(
+        `  v33: resized content_chunks.embedding to vector(${targetDim}) and updated config rows`,
+      );
+    },
   },
 ];
 

--- a/test/embedding-config.test.ts
+++ b/test/embedding-config.test.ts
@@ -1,0 +1,249 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  getEmbeddingConfig,
+  resetEmbeddingConfigCache,
+  EMBEDDING_DEFAULTS,
+} from '../src/core/embedding-config.ts';
+
+const ENV_KEYS = [
+  'GBRAIN_EMBED_MODEL',
+  'GBRAIN_EMBED_DIMENSIONS',
+  'GBRAIN_EMBED_COST_PER_1K',
+  'GBRAIN_EMBED_URL',
+  'GBRAIN_EMBED_KEY',
+  'GBRAIN_EMBED_BATCH',
+  'GBRAIN_EMBED_MAX_CHARS',
+];
+
+const originals: Record<string, string | undefined> = {};
+for (const k of ENV_KEYS) originals[k] = process.env[k];
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+  resetEmbeddingConfigCache();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    delete process.env[k];
+    if (originals[k] !== undefined) process.env[k] = originals[k]!;
+  }
+  resetEmbeddingConfigCache();
+});
+
+describe('getEmbeddingConfig — defaults', () => {
+  test('all-unset returns historical defaults', () => {
+    const cfg = getEmbeddingConfig();
+    expect(cfg.model).toBe('text-embedding-3-large');
+    expect(cfg.dimensions).toBe(1536);
+    expect(cfg.costPer1kTokens).toBe(0.00013);
+    expect(cfg.baseUrl).toBeUndefined();
+    expect(cfg.apiKey).toBeUndefined();
+    expect(cfg.batchSize).toBe(100);
+    expect(cfg.maxChars).toBe(8000);
+  });
+
+  test('EMBEDDING_DEFAULTS is frozen', () => {
+    expect(Object.isFrozen(EMBEDDING_DEFAULTS)).toBe(true);
+  });
+
+  test('EMBEDDING_DEFAULTS matches initial config', () => {
+    const cfg = getEmbeddingConfig();
+    expect(cfg.model).toBe(EMBEDDING_DEFAULTS.model);
+    expect(cfg.dimensions).toBe(EMBEDDING_DEFAULTS.dimensions);
+    expect(cfg.costPer1kTokens).toBe(EMBEDDING_DEFAULTS.costPer1kTokens);
+  });
+});
+
+describe('getEmbeddingConfig — model parsing', () => {
+  test('reads valid OpenAI-style model', () => {
+    process.env.GBRAIN_EMBED_MODEL = 'text-embedding-3-small';
+    expect(getEmbeddingConfig().model).toBe('text-embedding-3-small');
+  });
+
+  test('reads Ollama-style tagged model', () => {
+    process.env.GBRAIN_EMBED_MODEL = 'nomic-embed-text:latest';
+    expect(getEmbeddingConfig().model).toBe('nomic-embed-text:latest');
+  });
+
+  test('reads HuggingFace org/model', () => {
+    process.env.GBRAIN_EMBED_MODEL = 'BAAI/bge-large-en';
+    expect(getEmbeddingConfig().model).toBe('BAAI/bge-large-en');
+  });
+
+  test('rejects model with spaces', () => {
+    process.env.GBRAIN_EMBED_MODEL = 'bad model';
+    expect(getEmbeddingConfig().model).toBe('text-embedding-3-large');
+  });
+
+  test('rejects model with shell metacharacters', () => {
+    process.env.GBRAIN_EMBED_MODEL = 'model; rm -rf /';
+    expect(getEmbeddingConfig().model).toBe('text-embedding-3-large');
+  });
+
+  test('empty string falls back to default', () => {
+    process.env.GBRAIN_EMBED_MODEL = '';
+    expect(getEmbeddingConfig().model).toBe('text-embedding-3-large');
+  });
+});
+
+describe('getEmbeddingConfig — dimensions parsing', () => {
+  test('reads valid dimensions', () => {
+    process.env.GBRAIN_EMBED_DIMENSIONS = '768';
+    expect(getEmbeddingConfig().dimensions).toBe(768);
+  });
+
+  test('reads large dimensions (Mistral, Cohere v3)', () => {
+    process.env.GBRAIN_EMBED_DIMENSIONS = '4096';
+    expect(getEmbeddingConfig().dimensions).toBe(4096);
+  });
+
+  test('rejects non-integer', () => {
+    process.env.GBRAIN_EMBED_DIMENSIONS = 'not-a-number';
+    expect(getEmbeddingConfig().dimensions).toBe(1536);
+  });
+
+  test('rejects negative', () => {
+    process.env.GBRAIN_EMBED_DIMENSIONS = '-100';
+    expect(getEmbeddingConfig().dimensions).toBe(1536);
+  });
+
+  test('rejects zero', () => {
+    process.env.GBRAIN_EMBED_DIMENSIONS = '0';
+    expect(getEmbeddingConfig().dimensions).toBe(1536);
+  });
+
+  test('rejects above pgvector hnsw limit (16384)', () => {
+    process.env.GBRAIN_EMBED_DIMENSIONS = '99999';
+    expect(getEmbeddingConfig().dimensions).toBe(1536);
+  });
+});
+
+describe('getEmbeddingConfig — cost parsing', () => {
+  test('reads zero cost (local model)', () => {
+    process.env.GBRAIN_EMBED_COST_PER_1K = '0';
+    expect(getEmbeddingConfig().costPer1kTokens).toBe(0);
+  });
+
+  test('reads decimal cost', () => {
+    process.env.GBRAIN_EMBED_COST_PER_1K = '0.00002';
+    expect(getEmbeddingConfig().costPer1kTokens).toBe(0.00002);
+  });
+
+  test('reads scientific notation', () => {
+    process.env.GBRAIN_EMBED_COST_PER_1K = '1.3e-4';
+    expect(getEmbeddingConfig().costPer1kTokens).toBe(0.00013);
+  });
+
+  test('rejects non-numeric', () => {
+    process.env.GBRAIN_EMBED_COST_PER_1K = 'free';
+    expect(getEmbeddingConfig().costPer1kTokens).toBe(0.00013);
+  });
+
+  test('rejects negative cost', () => {
+    process.env.GBRAIN_EMBED_COST_PER_1K = '-1';
+    expect(getEmbeddingConfig().costPer1kTokens).toBe(0.00013);
+  });
+});
+
+describe('getEmbeddingConfig — URL parsing', () => {
+  test('reads localhost Ollama URL', () => {
+    process.env.GBRAIN_EMBED_URL = 'http://localhost:11434/v1';
+    expect(getEmbeddingConfig().baseUrl).toBe('http://localhost:11434/v1');
+  });
+
+  test('reads HTTPS URL', () => {
+    process.env.GBRAIN_EMBED_URL = 'https://api.together.xyz/v1';
+    expect(getEmbeddingConfig().baseUrl).toBe('https://api.together.xyz/v1');
+  });
+
+  test('rejects non-URL string', () => {
+    process.env.GBRAIN_EMBED_URL = 'localhost:11434';
+    expect(getEmbeddingConfig().baseUrl).toBeUndefined();
+  });
+
+  test('rejects file:// scheme', () => {
+    process.env.GBRAIN_EMBED_URL = 'file:///etc/passwd';
+    expect(getEmbeddingConfig().baseUrl).toBeUndefined();
+  });
+
+  test('rejects javascript:// scheme', () => {
+    process.env.GBRAIN_EMBED_URL = 'javascript:alert(1)';
+    expect(getEmbeddingConfig().baseUrl).toBeUndefined();
+  });
+
+  test('empty string returns undefined', () => {
+    process.env.GBRAIN_EMBED_URL = '';
+    expect(getEmbeddingConfig().baseUrl).toBeUndefined();
+  });
+});
+
+describe('getEmbeddingConfig — API key', () => {
+  test('reads custom key', () => {
+    process.env.GBRAIN_EMBED_KEY = 'sk-local-abc123';
+    expect(getEmbeddingConfig().apiKey).toBe('sk-local-abc123');
+  });
+
+  test('empty string returns undefined (falls back to OPENAI_API_KEY)', () => {
+    process.env.GBRAIN_EMBED_KEY = '';
+    expect(getEmbeddingConfig().apiKey).toBeUndefined();
+  });
+
+  test('whitespace-only returns undefined', () => {
+    process.env.GBRAIN_EMBED_KEY = '   ';
+    expect(getEmbeddingConfig().apiKey).toBeUndefined();
+  });
+});
+
+describe('getEmbeddingConfig — batch size', () => {
+  test('reads valid batch size', () => {
+    process.env.GBRAIN_EMBED_BATCH = '50';
+    expect(getEmbeddingConfig().batchSize).toBe(50);
+  });
+
+  test('rejects above ceiling (2048)', () => {
+    process.env.GBRAIN_EMBED_BATCH = '99999';
+    expect(getEmbeddingConfig().batchSize).toBe(100);
+  });
+
+  test('rejects zero', () => {
+    process.env.GBRAIN_EMBED_BATCH = '0';
+    expect(getEmbeddingConfig().batchSize).toBe(100);
+  });
+});
+
+describe('getEmbeddingConfig — caching', () => {
+  test('caches first read', () => {
+    process.env.GBRAIN_EMBED_MODEL = 'first';
+    expect(getEmbeddingConfig().model).toBe('first');
+
+    process.env.GBRAIN_EMBED_MODEL = 'second';
+    expect(getEmbeddingConfig().model).toBe('first'); // cached
+  });
+
+  test('resetEmbeddingConfigCache clears cache', () => {
+    process.env.GBRAIN_EMBED_MODEL = 'first';
+    expect(getEmbeddingConfig().model).toBe('first');
+
+    resetEmbeddingConfigCache();
+    process.env.GBRAIN_EMBED_MODEL = 'second';
+    expect(getEmbeddingConfig().model).toBe('second');
+  });
+});
+
+describe('getEmbeddingConfig — full local-model scenario', () => {
+  test('Ollama-style configuration', () => {
+    process.env.GBRAIN_EMBED_URL = 'http://localhost:11434/v1';
+    process.env.GBRAIN_EMBED_MODEL = 'nomic-embed-text';
+    process.env.GBRAIN_EMBED_DIMENSIONS = '768';
+    process.env.GBRAIN_EMBED_KEY = 'ollama';
+    process.env.GBRAIN_EMBED_COST_PER_1K = '0';
+
+    const cfg = getEmbeddingConfig();
+    expect(cfg.baseUrl).toBe('http://localhost:11434/v1');
+    expect(cfg.model).toBe('nomic-embed-text');
+    expect(cfg.dimensions).toBe(768);
+    expect(cfg.apiKey).toBe('ollama');
+    expect(cfg.costPer1kTokens).toBe(0);
+  });
+});

--- a/test/embedding-dimensions-migration.test.ts
+++ b/test/embedding-dimensions-migration.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { MIGRATIONS, LATEST_VERSION } from '../src/core/migrate.ts';
+import { resetEmbeddingConfigCache } from '../src/core/embedding-config.ts';
+
+const ENV_KEY = 'GBRAIN_EMBED_DIMENSIONS';
+const MODEL_KEY = 'GBRAIN_EMBED_MODEL';
+const original = process.env[ENV_KEY];
+const originalModel = process.env[MODEL_KEY];
+
+interface MockState {
+  calls: Array<{ sql: string; params?: unknown[] }>;
+  embeddedRows: number;
+}
+
+function makeMockEngine(state: MockState): BrainEngine {
+  return {
+    executeRaw: async (sql: string, params?: unknown[]) => {
+      state.calls.push({ sql, params });
+      if (sql.includes('SELECT COUNT') && sql.includes('embedding IS NOT NULL')) {
+        return [{ embedded: state.embeddedRows }];
+      }
+      return [];
+    },
+  } as unknown as BrainEngine;
+}
+
+beforeEach(() => {
+  delete process.env[ENV_KEY];
+  delete process.env[MODEL_KEY];
+  resetEmbeddingConfigCache();
+});
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+  delete process.env[MODEL_KEY];
+  if (original !== undefined) process.env[ENV_KEY] = original;
+  if (originalModel !== undefined) process.env[MODEL_KEY] = originalModel;
+  resetEmbeddingConfigCache();
+});
+
+describe('v33 configurable_embedding_dimensions migration', () => {
+  test('migration is registered at version 33', () => {
+    const v33 = MIGRATIONS.find(m => m.version === 33);
+    expect(v33).toBeDefined();
+    expect(v33?.name).toBe('configurable_embedding_dimensions');
+  });
+
+  test('LATEST_VERSION is 33', () => {
+    expect(LATEST_VERSION).toBe(33);
+  });
+
+  test('default dim (1536) is a no-op', async () => {
+    const v33 = MIGRATIONS.find(m => m.version === 33);
+    const state: MockState = { calls: [], embeddedRows: 0 };
+    const engine = makeMockEngine(state);
+
+    await v33?.handler?.(engine);
+
+    expect(state.calls.length).toBe(0);
+  });
+
+  test('non-default dim with empty embeddings: drops index, alters, recreates', async () => {
+    const v33 = MIGRATIONS.find(m => m.version === 33);
+    process.env[ENV_KEY] = '768';
+    resetEmbeddingConfigCache();
+
+    const state: MockState = { calls: [], embeddedRows: 0 };
+    const engine = makeMockEngine(state);
+
+    await v33?.handler?.(engine);
+
+    // 1 SELECT COUNT, 1 DROP INDEX, 1 ALTER TYPE, 1 CREATE INDEX, 1 INSERT config
+    expect(state.calls.length).toBe(5);
+    expect(state.calls[0].sql).toMatch(/SELECT COUNT/);
+    expect(state.calls[1].sql).toMatch(/DROP INDEX IF EXISTS idx_chunks_embedding/);
+    expect(state.calls[2].sql).toMatch(/ALTER TABLE content_chunks ALTER COLUMN embedding TYPE vector\(768\)/);
+    expect(state.calls[3].sql).toMatch(/CREATE INDEX idx_chunks_embedding/);
+    expect(state.calls[3].sql).toMatch(/hnsw/);
+    expect(state.calls[4].sql).toMatch(/INSERT INTO config/);
+    expect(state.calls[4].params).toEqual(['768']);
+  });
+
+  test('non-default dim with custom model: also updates embedding_model config row', async () => {
+    const v33 = MIGRATIONS.find(m => m.version === 33);
+    process.env[ENV_KEY] = '768';
+    process.env[MODEL_KEY] = 'nomic-embed-text';
+    resetEmbeddingConfigCache();
+
+    const state: MockState = { calls: [], embeddedRows: 0 };
+    const engine = makeMockEngine(state);
+
+    await v33?.handler?.(engine);
+
+    // 1 SELECT, 1 DROP, 1 ALTER, 1 CREATE INDEX, 1 dims-config, 1 model-config = 6
+    expect(state.calls.length).toBe(6);
+    const lastCall = state.calls[5];
+    expect(lastCall.sql).toMatch(/INSERT INTO config/);
+    expect(lastCall.params).toEqual(['nomic-embed-text']);
+  });
+
+  test('non-default dim WITH existing embeddings: throws with actionable message', async () => {
+    const v33 = MIGRATIONS.find(m => m.version === 33);
+    process.env[ENV_KEY] = '768';
+    resetEmbeddingConfigCache();
+
+    const state: MockState = { calls: [], embeddedRows: 4372 };
+    const engine = makeMockEngine(state);
+
+    await expect(v33?.handler?.(engine)).rejects.toThrow(/4372 chunk\(s\) already have embeddings/);
+    await expect(v33?.handler?.(engine)).rejects.toThrow(/UPDATE content_chunks SET embedding = NULL/);
+    await expect(v33?.handler?.(engine)).rejects.toThrow(/local-models\.md/);
+  });
+
+  test('invalid dim falls back to default (no-op, no error)', async () => {
+    const v33 = MIGRATIONS.find(m => m.version === 33);
+    process.env[ENV_KEY] = '99999'; // exceeds pgvector ceiling
+    resetEmbeddingConfigCache();
+
+    const state: MockState = { calls: [], embeddedRows: 0 };
+    const engine = makeMockEngine(state);
+
+    // getEmbeddingConfig returns 1536 fallback, so handler is a no-op
+    await v33?.handler?.(engine);
+    expect(state.calls.length).toBe(0);
+  });
+
+  test('handler is async function', () => {
+    const v33 = MIGRATIONS.find(m => m.version === 33);
+    expect(v33?.handler?.constructor.name).toBe('AsyncFunction');
+  });
+});


### PR DESCRIPTION
## Summary

Adds first-class support for local embedding models (Ollama, LM Studio, vLLM) and any OpenAI-compatible endpoint (Together, Fireworks, Cohere, etc.) via a complete `GBRAIN_EMBED_*` env var surface. Also makes embedding dimensions and per-token cost configurable so the cost-preview surfaces stop reporting OpenAI prices for free local inference.

This PR is **independent** of the i18n series (#580 #581 #582) but follows the same pattern: env vars with validated defaults, no behavior change when unset, schema migration for the dim resize because pgvector won't auto-cast.

## Why

The embedding service hardcoded:
- `model = 'text-embedding-3-large'`
- `dimensions = 1536`
- `baseURL = OpenAI default`
- `apiKey = OPENAI_API_KEY`
- `batchSize = 100`
- `costPer1kTokens = 0.00013`

That made local inference and non-OpenAI providers impossible without forking. For users hitting OpenAI rate limits, running air-gapped, or using cheaper alternatives (Cohere v3 at $0.0001/1k, BGE/Nomic at $0, Mistral 1024-dim), this was a hard dependency that couldn't be worked around without source patches.

## What changed

### New file: `src/core/embedding-config.ts`

`getEmbeddingConfig()` reads:

| Var | Default | Range / format |
|---|---|---|
| `GBRAIN_EMBED_MODEL` | `text-embedding-3-large` | `/^[a-zA-Z0-9._:\-/]+$/` (allows OpenAI, Ollama `:tag`, HF `org/model`) |
| `GBRAIN_EMBED_DIMENSIONS` | `1536` | `[1, 16384]` (pgvector HNSW ceiling) |
| `GBRAIN_EMBED_URL` | OpenAI default | Must parse as http:// or https:// |
| `GBRAIN_EMBED_KEY` | `OPENAI_API_KEY` | Any non-empty string (Ollama accepts `'ollama'`) |
| `GBRAIN_EMBED_COST_PER_1K` | `0.00013` | `>= 0` (set to 0 for local) |
| `GBRAIN_EMBED_BATCH` | `100` | `[1, 2048]` |
| `GBRAIN_EMBED_MAX_CHARS` | `8000` | `[100, 100000]` |

Cached on first read; tests reset via `resetEmbeddingConfigCache()`. Invalid values fall back to the historical default with a one-time warning so a typo can't silently corrupt the brain.

### Refactored `src/core/embedding.ts`

- `getClient()` builds `OpenAI({ baseURL, apiKey })` from the config
- `embedBatchWithRetry` skips the `dimensions` request param when targeting a custom `baseURL` — Ollama and most local servers reject it (they always return the model's native dim)
- `estimateEmbeddingCostUsd` reads cost live so env changes mid-process take effect
- Old `EMBEDDING_MODEL` / `EMBEDDING_DIMENSIONS` / `EMBEDDING_COST_PER_1K_TOKENS` exports are kept as `@deprecated` module-load snapshots — 12 existing callers continue to work unchanged

### New schema migration v33

`configurable_embedding_dimensions`. When `GBRAIN_EMBED_DIMENSIONS != 1536`:

- **Embeddings exist:** throws with actionable error pointing at the re-embed flow (`UPDATE ... SET embedding = NULL` → re-run migrate → `gbrain embed --all`). pgvector cannot cast between dims, so silent resize would corrupt data.
- **No embeddings yet:** drops HNSW index, `ALTER TABLE ... TYPE vector(N)`, recreates HNSW at the new dim, updates `embedding_dimensions` and (if set) `embedding_model` config rows.

When dim equals default: pure no-op.

## Local model usage examples (in README)

```bash
# Ollama (local, free)
export GBRAIN_EMBED_URL=http://localhost:11434/v1
export GBRAIN_EMBED_MODEL=nomic-embed-text
export GBRAIN_EMBED_DIMENSIONS=768
export GBRAIN_EMBED_KEY=ollama
export GBRAIN_EMBED_COST_PER_1K=0

# LM Studio (local, free)
export GBRAIN_EMBED_URL=http://localhost:1234/v1
export GBRAIN_EMBED_MODEL=text-embedding-bge-m3
export GBRAIN_EMBED_DIMENSIONS=1024

# Together AI (cheap remote)
export GBRAIN_EMBED_URL=https://api.together.xyz/v1
export GBRAIN_EMBED_MODEL=BAAI/bge-large-en-v1.5
export GBRAIN_EMBED_DIMENSIONS=1024
export GBRAIN_EMBED_KEY=$TOGETHER_API_KEY
export GBRAIN_EMBED_COST_PER_1K=0.00001
```

## Validation guards

- **Model:** regex blocks shell metacharacters. `GBRAIN_EMBED_MODEL='model; rm -rf /'` falls back to default.
- **URL:** `new URL()` parse + scheme allow-list. `file://` and `javascript://` are rejected.
- **Numeric:** clamped to safe ranges. `GBRAIN_EMBED_DIMENSIONS=99999` falls back (above pgvector HNSW ceiling). `GBRAIN_EMBED_BATCH=0` falls back.
- **Migration:** the dim resize requires empty embeddings — refuses to corrupt data, points users at the documented re-embed flow.

## Tests

**35 unit tests** in `test/embedding-config.test.ts`: defaults, every env var, caching, validation rejections (shell metacharacters, dangerous URL schemes, out-of-range numerics), and a full local-Ollama scenario.

**8 unit tests** in `test/embedding-dimensions-migration.test.ts`: no-op on default, drop-index/alter/recreate with custom dim, config row updates for both dim and model, actionable-error path when embeddings exist.

**Existing `test/embed.test.ts` (11 tests)** continues to pass — backward compat verified.

```
$ bun test test/embedding-config.test.ts test/embedding-dimensions-migration.test.ts test/embed.test.ts
 54 pass
 0 fail
 123 expect() calls
```

`bun run typecheck` clean. `bun run build` produces a working compiled binary. `gbrain doctor` reports 95/100 health on a real 2782-page brain after the changes.

## Trade-offs considered

- **Persist embedding config in the `config` table?** The schema already has `embedding_model` and `embedding_dimensions` rows there. The migration syncs them when env differs from default, but env wins at runtime. This matches the precedent for `GBRAIN_DATABASE_URL` (env > config file). Could swap precedence later if there's demand.
- **Auto-detect the model's actual dim from a probe call?** Tempting but adds startup latency and a hard dependency on the embedding endpoint being reachable at init time. Operator declares the dim, validation ensures it's sane, runtime errors surface mismatches clearly.
- **Cost table per model?** Single env var keeps the surface small. Operators with multi-model setups can run separate brains. A static lookup table would go stale fast (provider pricing changes monthly).

## Backward-compatible

100% with all-unset env. Defaults match the pre-PR hardcoded values exactly. Existing brains keep using OpenAI `text-embedding-3-large` at 1536 dims with no behavior change. The 12 call sites that import `EMBEDDING_MODEL`/`EMBEDDING_DIMENSIONS`/`EMBEDDING_COST_PER_1K_TOKENS` keep working — those exports are now `@deprecated` module-load snapshots so source compat is preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->