### PR TITLE
fix(backlinks): dedup gaps by (sourcePage, targetPage) before fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to GBrain will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **`backlinks` no longer writes duplicate timeline entries when a source
+  page mentions the same target multiple times.** `findBacklinkGaps`
+  returned one gap per `[[entity]]` instance in source content, and
+  `hasBacklink` checked an on-disk snapshot of the target that didn't
+  update as gaps accumulated. Result: a source mentioning a target N
+  times produced N timeline entries on that target. `findBacklinkGaps`
+  now dedups its return value by `(sourcePage, targetPage)` before
+  returning. Two new tests in `test/backlinks.test.ts` cover the
+  regression and the legit-distinct-targets non-collapse case.
+
 ## [0.26.0] - 2026-04-25
 
 ## **Multi-agent MCP is real. OAuth 2.1, HTTP server, React admin dashboard. Ship once, every AI client connects.**

--- a/src/commands/backlinks.ts
+++ b/src/commands/backlinks.ts
@@ -118,7 +118,19 @@ export function findBacklinkGaps(brainDir: string): BacklinkGap[] {
     }
   }
 
-  return gaps;
+  // Dedup gaps by (sourcePage, targetPage). extractEntityRefs returns one
+  // ref per `[[entity]]` instance in the source content; without this dedup,
+  // a source mentioning the same target N times produces N gaps and (after
+  // fixBacklinkGaps writes) N duplicate timeline entries on the target.
+  // hasBacklink can't catch this because target.content is a snapshot — it
+  // doesn't update as we accumulate gaps in this loop.
+  const seen = new Set<string>();
+  return gaps.filter((g) => {
+    const key = `${g.sourcePage}\0${g.targetPage}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 /** Fix back-link gaps by appending timeline entries to target pages */

--- a/test/backlinks.test.ts
+++ b/test/backlinks.test.ts
@@ -1,9 +1,13 @@
 import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   extractEntityRefs,
   extractPageTitle,
   hasBacklink,
   buildBacklinkEntry,
+  findBacklinkGaps,
 } from '../src/commands/backlinks.ts';
 
 describe('extractEntityRefs', () => {
@@ -76,5 +80,58 @@ describe('buildBacklinkEntry', () => {
   test('builds properly formatted entry', () => {
     const entry = buildBacklinkEntry('Q1 Review', '../../meetings/q1-review.md', '2026-04-11');
     expect(entry).toBe('- **2026-04-11** | Referenced in [Q1 Review](../../meetings/q1-review.md)');
+  });
+});
+
+describe('findBacklinkGaps', () => {
+  // Helper: build a hermetic brain dir for the test, return its path.
+  function buildBrain(files: Record<string, string>): string {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-test-'));
+    for (const [rel, content] of Object.entries(files)) {
+      const full = join(dir, rel);
+      mkdirSync(join(full, '..'), { recursive: true });
+      writeFileSync(full, content);
+    }
+    return dir;
+  }
+
+  test('dedups multiple references from the same source to the same target', () => {
+    // Source page mentions [Jane Doe] three times; without the dedup guard
+    // the function returns 3 gaps and fixBacklinkGaps writes 3 duplicate
+    // timeline entries on jane-doe.md. Regression guard for the dedup fix.
+    const brain = buildBrain({
+      'people/jane-doe.md':
+        '---\ntitle: Jane Doe\n---\n# Jane Doe\n\n## Timeline\n',
+      'meetings/q1-review.md':
+        '# Q1 Review\n\nDiscussed plans with [Jane Doe](../people/jane-doe.md). ' +
+        'Then [Jane Doe](../people/jane-doe.md) shared the deck. Finally [Jane Doe](../people/jane-doe.md) signed off.',
+    });
+    try {
+      const gaps = findBacklinkGaps(brain);
+      const janeGaps = gaps.filter((g) => g.targetPage === 'people/jane-doe.md');
+      expect(janeGaps).toHaveLength(1);
+      expect(janeGaps[0].sourcePage).toBe('meetings/q1-review.md');
+    } finally {
+      rmSync(brain, { recursive: true, force: true });
+    }
+  });
+
+  test('keeps separate gaps for the same source referencing different targets', () => {
+    // Dedup must not collapse legitimately-distinct (source, target) pairs.
+    const brain = buildBrain({
+      'people/alice.md': '---\ntitle: Alice\n---\n# Alice\n',
+      'people/bob.md': '---\ntitle: Bob\n---\n# Bob\n',
+      'meetings/sync.md':
+        '# Sync\n\n[Alice](../people/alice.md) and [Bob](../people/bob.md) attended.',
+    });
+    try {
+      const gaps = findBacklinkGaps(brain);
+      const syncGaps = gaps.filter((g) => g.sourcePage === 'meetings/sync.md');
+      expect(syncGaps).toHaveLength(2);
+      const targets = syncGaps.map((g) => g.targetPage).sort();
+      expect(targets).toEqual(['people/alice.md', 'people/bob.md']);
+    } finally {
+      rmSync(brain, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

`findBacklinkGaps` returns one gap per `[[entity]]` instance found in source content, and `hasBacklink` checks an on-disk snapshot of the target page that never updates as gaps accumulate. Result: a source mentioning the same target N times produces N gaps, and `fixBacklinkGaps` writes N duplicate timeline entries on the target.

Caught while cleaning up a brain hub page that had grown 235 duplicate `Referenced in` lines from a handful of recurring openclaw archive sources.

## Fix

Three lines at the end of `findBacklinkGaps` filter the gaps array by a `(sourcePage, targetPage)` key, keeping the first occurrence. No behavior change for callers that already get one gap per unique pair.

```ts
const seen = new Set<string>();
return gaps.filter((g) => {
  const key = `${g.sourcePage}\0${g.targetPage}`;
  if (seen.has(key)) return false;
  seen.add(key);
  return true;
});
```

Doing the dedup inside `findBacklinkGaps` (rather than in `runBacklinksCore` before the fix-call site) keeps the fix self-contained and means any other consumer of `findBacklinkGaps` also gets the deduped output.

## Tests

Two new tests in `test/backlinks.test.ts`:

- `findBacklinkGaps > dedups multiple references from the same source to the same target` — regression guard. Source page mentions Jane Doe 3x; expects exactly 1 gap.
- `findBacklinkGaps > keeps separate gaps for the same source referencing different targets` — non-collapse guard. Source mentions Alice and Bob; expects 2 distinct gaps.

`bun test test/backlinks.test.ts` → 14 pass, 0 fail.

## CHANGELOG

Added entry under `[Unreleased]` → `### Fixed`. If you'd prefer a different convention (no Unreleased section, or different fence style), happy to adjust.

## Test plan

- [x] `bun test test/backlinks.test.ts` (14 pass)
- [ ] Manual: run `gbrain backlinks fix --dir <brain>` against a brain with known multi-reference sources, verify timeline gets one entry per (source, target) pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->