### PR TITLE
fix(mcp): graceful stdio shutdown to release PGLite lock on client disconnect

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -26,6 +26,46 @@ export async function runServe(engine: BrainEngine, args: string[] = []) {
     await runServeHttp(engine, { port, tokenTtl, enableDcr, publicUrl });
   } else {
     console.error('Starting GBrain MCP server (stdio)...');
+
+    let shuttingDown = false;
+    let parentWatchdog: ReturnType<typeof setInterval> | undefined;
+
+    const shutdown = async (reason: string) => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      if (parentWatchdog) clearInterval(parentWatchdog);
+      console.error(`GBrain MCP server shutting down (${reason})...`);
+      try {
+        await engine.disconnect();
+      } catch (err) {
+        console.error('GBrain MCP server cleanup failed:', err);
+      }
+      process.exit(0);
+    };
+
+    for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
+      process.once(signal, () => void shutdown(signal));
+    }
+
+    // MCP stdio clients should close stdin when the session ends. Bun processes
+    // observed under launch/CLI clients can otherwise become PPID=1 orphans and
+    // keep the PGLite lock forever, blocking all future GBrain MCP starts.
+    process.stdin.once('end', () => void shutdown('stdin:end'));
+    process.stdin.once('close', () => void shutdown('stdin:close'));
+
+    const initialParentPid = process.ppid;
+    parentWatchdog = setInterval(() => {
+      if (initialParentPid !== 1 && process.ppid === 1) {
+        void shutdown('parent exited');
+      }
+    }, 5000);
+    parentWatchdog.unref?.();
+
     await startMcpServer(engine);
+    console.error('GBrain MCP server ready.');
+
+    // Keep process ownership explicit: shutdown paths above release the engine
+    // and PGLite lock instead of relying on implicit process teardown.
+    await new Promise<void>(() => {});
   }
 }


### PR DESCRIPTION
## Problem

When `gbrain serve` runs as an MCP stdio child of a CLI client (Claude Desktop, hermes-agent, etc.), the bun process can become a PPID=1 orphan after the parent exits without ever shutting down. The PGLite WAL lock is held indefinitely, blocking every subsequent `gbrain serve` start with:

```
GBrain: Timed out waiting for PGLite lock.
```

I hit this repeatedly running gbrain alongside hermes-agent in Claude Desktop on macOS. Once the client restarts, the previous serve subprocess survives, holds the lock, and the new instance can't start until manually killed.

## Fix

Three independent shutdown paths in the stdio branch of `runServe`:

1. **POSIX signals** — `SIGINT`/`SIGTERM`/`SIGHUP` trigger graceful `engine.disconnect()` then `process.exit(0)`.
2. **stdin lifecycle** — `process.stdin.once('end' | 'close')`. Per MCP spec, stdio clients close stdin when the session ends; this is the canonical signal.
3. **Orphan watchdog** — every 5 s, if `process.ppid === 1` and we didn't START at ppid=1, treat as parent-died and shut down. Catches the launchd/CLI cases where stdin doesn't close cleanly.

All three paths converge on an idempotent `shutdown()` helper. The keep-alive Promise ensures shutdown paths always execute instead of relying on `startMcpServer`'s implicit lifecycle.

The `--http` branch is unaffected — HTTP transport has its own lifecycle in `serve-http.ts`.

## Verification

Reproduced the lock-stuck state by killing the parent without closing stdin → orphan held the lock indefinitely. With this patch, the watchdog fires within 5 s and the next `gbrain serve` starts cleanly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->