### PR TITLE
fix(subagent): drop JSON.stringify on jsonb writes (orchestrator slug-collection bug)

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -4714,16 +4714,28 @@ export async function buildChecks(
   try {
     const sql = db.getConnection();
     const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
-      { table: 'pages',         col: 'frontmatter',    expected: 'object' },
-      { table: 'raw_data',      col: 'data',           expected: 'object' },
-      { table: 'ingest_log',    col: 'pages_updated',  expected: 'array'  },
-      { table: 'files',         col: 'metadata',       expected: 'object' },
-      { table: 'page_versions', col: 'frontmatter',    expected: 'object' },
+      { table: 'pages',                    col: 'frontmatter',    expected: 'object' },
+      { table: 'raw_data',                 col: 'data',           expected: 'object' },
+      { table: 'ingest_log',               col: 'pages_updated',  expected: 'array'  },
+      { table: 'files',                    col: 'metadata',       expected: 'object' },
+      { table: 'page_versions',            col: 'frontmatter',    expected: 'object' },
+      // v0.16.0+ subagent persistence — second double-encode site,
+      // surfaced by orchestrator slug-collection failures in dream synthesize.
+      { table: 'subagent_messages',        col: 'content_blocks', expected: 'array'  },
+      { table: 'subagent_tool_executions', col: 'input',          expected: 'object' },
+      { table: 'subagent_tool_executions', col: 'output',         expected: 'object' },
     ];
     let totalBad = 0;
     const breakdown: string[] = [];
     for (const { table, col } of targets) {
       progress.heartbeat(`jsonb_integrity.${table}.${col}`);
+      // Skip targets whose table doesn't exist on this brain (subagent_*
+      // tables are v0.15+; pre-v0.15 brains naturally lack them).
+      const existsRows = await sql.unsafe(
+        `SELECT to_regclass($1) IS NOT NULL AS exists`,
+        [table],
+      );
+      if (!(existsRows as any)[0]?.exists) continue;
       const rows = await sql.unsafe(
         `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
       );

--- a/src/commands/repair-jsonb.ts
+++ b/src/commands/repair-jsonb.ts
@@ -16,16 +16,26 @@
  * (it never wrote string-typed JSONB).
  *
  * Affected columns (audit of src/schema.sql):
- *   - pages.frontmatter           (postgres-engine.ts:107 putPage)
- *   - raw_data.data               (postgres-engine.ts:668 putRawData)
- *   - ingest_log.pages_updated    (postgres-engine.ts:846 logIngest)
- *   - files.metadata              (commands/files.ts:254 file upload)
- *   - page_versions.frontmatter   (downstream of pages.frontmatter via
- *                                  INSERT...SELECT FROM pages)
+ *   - pages.frontmatter                    (postgres-engine.ts:107 putPage)
+ *   - raw_data.data                        (postgres-engine.ts:668 putRawData)
+ *   - ingest_log.pages_updated             (postgres-engine.ts:846 logIngest)
+ *   - files.metadata                       (commands/files.ts:254 file upload)
+ *   - page_versions.frontmatter            (downstream of pages.frontmatter via
+ *                                           INSERT...SELECT FROM pages)
+ *   - subagent_messages.content_blocks     (subagent.ts:599 persistMessage —
+ *                                           v0.16.0+, fixed in vCURRENT)
+ *   - subagent_tool_executions.input       (subagent.ts:625/660 persistToolExec
+ *                                           Pending/Failed — same wave)
+ *   - subagent_tool_executions.output      (subagent.ts:639 persistToolExecComplete
+ *                                           — same wave)
  *
- * Other JSONB columns (minion_jobs.{data,result,progress,stacktrace},
- * minion_inbox.payload) were always written via parameterized form ($N::jsonb
- * with a string parameter, not interpolation) so they were never affected.
+ * The subagent_* writes were broken via a slightly different shape than the
+ * v0.12.0 wave: they used `engine.executeRaw` (postgres.js `unsafe`) with
+ * `JSON.stringify(value)` + `$N::jsonb` cast. postgres.js's unsafe path
+ * binds the resulting string as text, then the `::jsonb` cast wraps it as
+ * a jsonb string scalar instead of parsing it. queue.ts and other
+ * `executeRaw` callers were not affected because they pass raw objects
+ * (postgres.js v3 auto-encodes objects to jsonb).
  */
 
 import { loadConfig, toEngineConfig } from '../core/config.ts';
@@ -42,11 +52,14 @@ interface RepairTarget {
 }
 
 const TARGETS: RepairTarget[] = [
-  { table: 'pages',          column: 'frontmatter',    keyCol: 'slug' },
-  { table: 'raw_data',       column: 'data',           keyCol: 'source' },
-  { table: 'ingest_log',     column: 'pages_updated',  keyCol: 'source_ref' },
-  { table: 'files',          column: 'metadata',       keyCol: 'storage_path' },
-  { table: 'page_versions',  column: 'frontmatter',    keyCol: 'snapshot_at' },
+  { table: 'pages',                     column: 'frontmatter',     keyCol: 'slug' },
+  { table: 'raw_data',                  column: 'data',            keyCol: 'source' },
+  { table: 'ingest_log',                column: 'pages_updated',   keyCol: 'source_ref' },
+  { table: 'files',                     column: 'metadata',        keyCol: 'storage_path' },
+  { table: 'page_versions',             column: 'frontmatter',     keyCol: 'snapshot_at' },
+  { table: 'subagent_messages',         column: 'content_blocks',  keyCol: 'job_id' },
+  { table: 'subagent_tool_executions',  column: 'input',           keyCol: 'tool_use_id' },
+  { table: 'subagent_tool_executions',  column: 'output',          keyCol: 'tool_use_id' },
 ];
 
 export interface RepairResult {
@@ -113,6 +126,19 @@ export async function repairJsonb(opts: RepairOpts = { dryRun: false }): Promise
     let repaired = 0;
 
     try {
+      // Skip targets whose table doesn't exist yet — relevant for the
+      // v0_12_2 migration on pre-v0.15 brains (subagent_* tables hadn't
+      // been added yet) and any future schema additions to TARGETS.
+      const existsRows = await sql.unsafe(
+        `SELECT to_regclass($1) IS NOT NULL AS exists`,
+        [t.table],
+      ) as Array<{ exists: boolean }>;
+      if (!existsRows[0]?.exists) {
+        progress.tick(1, `${t.table}.${t.column}=skipped(no-table)`);
+        result.per_target.push({ table: t.table, column: t.column, rows_repaired: 0 });
+        continue;
+      }
+
       if (opts.dryRun) {
         const rows = await sql.unsafe(
           `SELECT count(*)::int AS n FROM ${t.table} WHERE jsonb_typeof(${t.column}) = 'string'`,

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -1104,6 +1104,11 @@ async function loadPriorTools(engine: BrainEngine, jobId: number): Promise<Persi
 }
 
 async function persistMessage(engine: BrainEngine, jobId: number, msg: PersistedMessage): Promise<void> {
+  // postgres.js v3's `unsafe` path double-wraps a JSON.stringify'd string when
+  // bound to a `::jsonb` cast (the wire layer treats the string as a JSONB
+  // string scalar, then the cast no-ops). Passing the raw value lets postgres.js
+  // and PGLite each apply their own correct jsonb encoding. Verified against
+  // both engines via test/e2e/postgres-jsonb.test.ts and PGLite parity tests.
   await engine.executeRaw(
     `INSERT INTO subagent_messages (job_id, message_idx, role, content_blocks,
         tokens_in, tokens_out, tokens_cache_read, tokens_cache_create, model)
@@ -1113,7 +1118,7 @@ async function persistMessage(engine: BrainEngine, jobId: number, msg: Persisted
       jobId,
       msg.message_idx,
       msg.role,
-      JSON.stringify(msg.content_blocks),
+      msg.content_blocks,
       msg.tokens_in,
       msg.tokens_out,
       msg.tokens_cache_read,
@@ -1131,15 +1136,14 @@ async function persistToolExecPending(
   toolName: string,
   input: unknown,
 ): Promise<void> {
-  // Serialize to JSON string for the ::jsonb cast. When `input` is already a
-  // string (e.g. pre-serialized), avoid double-encoding which produces a jsonb
-  // scalar string instead of a jsonb object — breaking `input->>'key'` lookups.
-  const jsonStr = typeof input === 'string' ? input : JSON.stringify(input);
+  // Pass raw value to ::jsonb — postgres.js v3 and PGLite each apply their own
+  // correct jsonb encoding. Pre-stringifying produces a jsonb scalar string
+  // instead of a jsonb object, breaking `input->>'key'` lookups.
   await engine.executeRaw(
     `INSERT INTO subagent_tool_executions (job_id, message_idx, tool_use_id, tool_name, input, status)
      VALUES ($1, $2, $3, $4, $5::jsonb, 'pending')
      ON CONFLICT (job_id, tool_use_id) DO NOTHING`,
-    [jobId, messageIdx, toolUseId, toolName, jsonStr],
+    [jobId, messageIdx, toolUseId, toolName, input],
   );
 }
 
@@ -1153,7 +1157,7 @@ async function persistToolExecComplete(
     `UPDATE subagent_tool_executions
         SET status = 'complete', output = $3::jsonb, ended_at = now()
       WHERE job_id = $1 AND tool_use_id = $2`,
-    [jobId, toolUseId, typeof output === 'string' ? output : JSON.stringify(output)],
+    [jobId, toolUseId, output],
   );
 }
 
@@ -1173,7 +1177,7 @@ async function persistToolExecFailed(
      VALUES ($1, $2, $3, $4, $5::jsonb, 'failed', $6, now())
      ON CONFLICT (job_id, tool_use_id) DO UPDATE
        SET status = 'failed', error = EXCLUDED.error, ended_at = now()`,
-    [jobId, messageIdx, toolUseId, toolName, typeof input === 'string' ? input : JSON.stringify(input), error],
+    [jobId, messageIdx, toolUseId, toolName, input, error],
   );
 }
 

--- a/test/repair-jsonb.test.ts
+++ b/test/repair-jsonb.test.ts
@@ -19,9 +19,10 @@ describe('repairJsonb — PGLite short-circuit', () => {
     });
     expect(result.engine).toBe('pglite');
     expect(result.total_repaired).toBe(0);
-    // All 5 columns reported: pages.frontmatter, raw_data.data,
-    // ingest_log.pages_updated, files.metadata, page_versions.frontmatter.
-    expect(result.per_target.length).toBe(5);
+    // All 8 columns reported: 5 from the v0.12.0 wave + 3 from the v0.16.0
+    // subagent_* wave (added when persistMessage / persistToolExec* was
+    // identified as a second double-encode site).
+    expect(result.per_target.length).toBe(8);
     for (const t of result.per_target) {
       expect(t.rows_repaired).toBe(0);
     }
@@ -32,6 +33,9 @@ describe('repairJsonb — PGLite short-circuit', () => {
       'page_versions.frontmatter',
       'pages.frontmatter',
       'raw_data.data',
+      'subagent_messages.content_blocks',
+      'subagent_tool_executions.input',
+      'subagent_tool_executions.output',
     ]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the v0.16.0+ jsonb double-encode bug in `src/core/minions/handlers/subagent.ts` that breaks dream synthesize's orchestrator slug-collection. Symptom: `transcripts_processed=1, pages_written=0` even when child subagents successfully wrote pages to the DB.

## Root cause

The four `subagent_*` jsonb writers (`persistMessage`, `persistToolExec{Pending,Complete,Failed}`) used `engine.executeRaw` (which routes to postgres.js's `unsafe()`) with `JSON.stringify(value)` plus `$N::jsonb` cast. Verified empirically:

```
P1 JSON.stringify(obj) + $::jsonb  →  jsonb_typeof='string'   (broken — current code)
P2 raw object         + (no cast)  →  jsonb_typeof='object'   (correct)
P3 raw object         + $::jsonb   →  jsonb_typeof='object'   (correct — this PR)
P4 sql.json(obj) via unsafe        →  jsonb_typeof='object'   (correct)
```

postgres.js v3 auto-encodes objects/arrays for jsonb columns. queue.ts:233 already passes raw objects for `minion_jobs.data` and was never affected. PGLite handles raw values identically (verified — all three patterns produce object jsonb on PGLite).

## Symptom this resolves

`collectChildPutPageSlugs` in `src/core/cycle/synthesize.ts:459` queries:
```sql
SELECT input->>'slug' FROM subagent_tool_executions WHERE ...
```

On string-typed jsonb the `->>` operator returns NULL, so `pages_written` reports 0 even when child subagents successfully put_page'd. The reverse-write step that mirrors DB → markdown then has no targets, leaving real synthesized pages stranded in the DB. After this fix, the orchestrator picks up slugs correctly and the dream cycle closes the loop end-to-end.

## Companion changes in this commit

- `repair-jsonb` extended from 5 → 8 columns (subagent_messages.content_blocks, subagent_tool_executions.{input, output}); each target guarded with `to_regclass()` so pre-v0.15 brains that lack the subagent_* tables don't throw at upgrade time.
- `doctor`'s `jsonb_integrity` check extended to the same 8 columns with the same guard. Any user hitting this bug will see "X rows double-encoded ... Fix: gbrain repair-jsonb" instead of silent dream failures.
- Header comment of `repair-jsonb.ts` updated: the prior claim that the parameterized `$N::jsonb` form was always safe was wrong — safety came from queue.ts/sources.ts/etc. passing raw objects, not from the binding form itself.

## Field evidence

On the developer's brain at the time of fix (production gbrain deployment, postgres engine):
- subagent_messages.content_blocks: 40/40 corrupt
- subagent_tool_executions.input: 39/39 corrupt
- subagent_tool_executions.output: 39/39 corrupt

`gbrain repair-jsonb` after this patch repaired all 118 rows. Subsequent `gbrain dream --input <transcript> --json` produced `pages_written=2, reverse_write_count=2`, child job completed, and the rendered markdown landed on disk.

## Test plan

- [x] `bun run typecheck` clean
- [x] 245 tests pass across minions, subagent-handler, cycle-synthesize, cycle-patterns, repair-jsonb, migrations-v0_12_2, doctor
- [x] End-to-end: fresh transcript → `gbrain dream --input` → DB has object-typed jsonb → orchestrator returns correct slugs → markdown lands on disk
- [ ] Reviewer should consider whether to ship a one-shot migration that auto-runs `repair-jsonb` for affected tables, or rely on `gbrain doctor` to nudge users — current PR ships the detection + repair tool but does not auto-trigger it

## Upstream context

PR #525 (chmod fix, by another author) was unrelated to this jsonb work despite name overlap from local commits that mis-attributed it. PR #539 (open) does post-hoc UPDATE-based data repair in synthesize.ts/patterns.ts but does NOT patch the write path — this PR is the missing complement. They can land in either order: this PR stops the bleeding, #539 cleans existing brains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->