### PR TITLE
fix(import): allow frontmatter slug for un-sluggable root paths (CJK filenames)

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -427,7 +427,21 @@ export async function importFromFile(
   // the path-derived slug, so a mismatch here means the frontmatter is trying
   // to rewrite a page whose filesystem location says something different.
   const expectedSlug = slugifyPath(relativePath);
-  if (parsed.slug !== expectedSlug) {
+
+  // Exception: root-level filenames composed only of non-Latin characters can
+  // slugify to "". In that case there is no usable path-derived authority, so
+  // allow an explicit frontmatter slug instead of forcing the user to rename or
+  // move the human-readable file on disk.
+  const effectiveSlug = expectedSlug || parsed.slug;
+  if (!expectedSlug && !parsed.slug) {
+    return {
+      slug: expectedSlug,
+      status: 'skipped',
+      chunks: 0,
+      error: `Invalid slug: "". Add a frontmatter "slug:" field or move the file (from ${relativePath}).`,
+    };
+  }
+  if (expectedSlug && parsed.slug !== expectedSlug) {
     return {
       slug: expectedSlug,
       status: 'skipped',
@@ -438,13 +452,13 @@ export async function importFromFile(
     };
   }
 
-  // Pass the path-derived slug explicitly so that any future change to
+  // Pass the authoritative slug explicitly so that any future change to
   // parseMarkdown's precedence rules cannot re-introduce this bug.
   // v0.29.1: thread the basename (without extension) for filename-date
   // precedence in computeEffectiveDate. e.g. `daily/2024-03-15.md` →
   // filename `2024-03-15`.
   const fileBasename = basename(relativePath, '.md');
-  return importFromContent(engine, expectedSlug, content, { ...opts, filename: fileBasename });
+  return importFromContent(engine, effectiveSlug, content, { ...opts, filename: fileBasename });
 }
 
 /**

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -111,6 +111,27 @@ Poisoned content that would overwrite people/elon.
     expect((engine as any)._calls.length).toBe(0);
   });
 
+  test('accepts frontmatter slug for un-sluggable root CJK filename', async () => {
+    const filePath = join(TMP, '小米.md');
+    writeFileSync(filePath, `---
+type: company
+title: 小米
+slug: companies/xiaomi
+---
+
+Chinese root filename with explicit durable slug.
+`);
+
+    const engine = mockEngine();
+    const result = await importFile(engine, filePath, '小米.md', { noEmbed: true });
+
+    expect(result.status).toBe('imported');
+    expect(result.slug).toBe('companies/xiaomi');
+    const calls = (engine as any)._calls;
+    const putCall = calls.find((c: any) => c.method === 'putPage');
+    expect(putCall.args[0]).toBe('companies/xiaomi');
+  });
+
   test('accepts frontmatter slug that matches the file path', async () => {
     // Sanity: a legitimate file whose frontmatter slug happens to equal the
     // path-derived slug must still import.


### PR DESCRIPTION
## Summary

`slugifyPath()` strips non-ASCII characters before validation. A markdown file at the brain repo root with a Chinese-only (or any non-Latin) filename — `小米.md`, `品牌圣经.md`, `创意原型库.md` — sluggifies to the empty string, which fails downstream `Invalid slug: ""` validation. Sync silently rejects the file every cycle and the failure accumulates in `~/.gbrain/sync-failures.jsonl`.

The previous code preferred the (empty) path-derived slug over the frontmatter slug, so users adding an explicit `slug:` field to the frontmatter saw their file STILL rejected, this time with a `SLUG_MISMATCH` error — a frustrating second failure mode for the same root cause.

## Fix

When `slugifyPath(relativePath)` returns empty AND the file's frontmatter has a `slug:` field, use the frontmatter slug as the authority. The original anti-spoofing rule (path slug exists AND frontmatter slug differs → reject) is preserved unchanged: a normal file at `wiki/people/elon.md` cannot impersonate a different page via frontmatter.

The exception only fires when there is no usable path-derived slug to begin with. Empty-on-both-sides yields a friendlier error message that points at the fix (add a frontmatter `slug:` or move the file).

## Impact

In the field this affected 23 files in a 1386-page brain on the maintainer's deployment — all root-level Chinese-named files. Without this fix, brain sync had a 70-row backlog of `Invalid slug: ""` failures that re-appeared every 15-minute live-sync cycle.

## Test plan

- [x] `bun run typecheck` clean
- [x] New case in `test/import-file.test.ts` asserting `小米.md` with `slug: companies/xiaomi` imports correctly
- [x] Existing attack-defense case (`notes/random.md` trying to claim `people/elon`) unchanged and still rejected
- [x] All 33 import-file tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->