### PR TITLE
fix(chunker): cap chunk size + bump MARKDOWN_CHUNKER_VERSION (long-CJK embedding fix)

### DIFF
--- a/src/core/chunkers/recursive.ts
+++ b/src/core/chunkers/recursive.ts
@@ -21,9 +21,12 @@ const DELIMITERS: string[][] = [
   [],                                // L4: words (whitespace split)
 ];
 
+export const MARKDOWN_CHUNKER_VERSION = 2;
+
 export interface ChunkOptions {
   chunkSize?: number;    // target words per chunk (default 300)
   chunkOverlap?: number; // overlap words (default 50)
+  maxChars?: number;     // hard safety cap for CJK / no-whitespace text (default 6000)
 }
 
 export interface TextChunk {
@@ -39,6 +42,7 @@ import { stripTakesFence } from '../takes-fence.ts';
 export function chunkText(text: string, opts?: ChunkOptions): TextChunk[] {
   const chunkSize = opts?.chunkSize || 300;
   const chunkOverlap = opts?.chunkOverlap || 50;
+  const maxChars = opts?.maxChars || 6000;
 
   if (!text || text.trim().length === 0) return [];
 
@@ -49,17 +53,37 @@ export function chunkText(text: string, opts?: ChunkOptions): TextChunk[] {
   const stripped = stripTakesFence(text);
   if (!stripped || stripped.trim().length === 0) return [];
 
-  const wordCount = countWords(stripped);
+  const trimmed = stripped.trim();
+  const wordCount = countWords(trimmed);
   if (wordCount <= chunkSize) {
-    return [{ text: stripped.trim(), index: 0 }];
+    if (trimmed.length <= maxChars) return [{ text: trimmed, index: 0 }];
+    return splitByChars(trimmed, maxChars, Math.min(500, Math.floor(maxChars / 10)))
+      .map((t, i) => ({ text: t.trim(), index: i }));
   }
 
   // Recursively split, then greedily merge to target size
-  const pieces = recursiveSplit(stripped, 0, chunkSize);
+  const pieces = recursiveSplit(trimmed, 0, chunkSize);
   const merged = greedyMerge(pieces, chunkSize);
   const withOverlap = applyOverlap(merged, chunkOverlap);
 
-  return withOverlap.map((t, i) => ({ text: t.trim(), index: i }));
+  const capped = withOverlap.flatMap(chunk =>
+    chunk.length > maxChars
+      ? splitByChars(chunk, maxChars, Math.min(500, Math.floor(maxChars / 10)))
+      : [chunk],
+  );
+
+  return capped.map((t, i) => ({ text: t.trim(), index: i }));
+}
+
+function splitByChars(text: string, maxChars: number, overlapChars: number): string[] {
+  const chunks: string[] = [];
+  const stride = Math.max(1, maxChars - overlapChars);
+  for (let start = 0; start < text.length; start += stride) {
+    const slice = text.slice(start, start + maxChars);
+    if (slice.trim().length > 0) chunks.push(slice);
+    if (start + maxChars >= text.length) break;
+  }
+  return chunks;
 }
 
 function recursiveSplit(text: string, level: number, target: number): string[] {

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -4,7 +4,7 @@ import { createHash } from 'crypto';
 import { marked } from 'marked';
 import type { BrainEngine, FileSpec } from './engine.ts';
 import { parseMarkdown } from './markdown.ts';
-import { chunkText } from './chunkers/recursive.ts';
+import { chunkText, MARKDOWN_CHUNKER_VERSION } from './chunkers/recursive.ts';
 import { chunkCodeText, chunkCodeTextFull, detectCodeLanguage, CHUNKER_VERSION } from './chunkers/code.ts';
 import { findChunkForOffset } from './chunkers/edge-extractor.ts';
 import { extractCodeRefs, imageOfCandidates } from './link-extraction.ts';
@@ -227,6 +227,7 @@ export async function importFromContent(
       timeline: parsed.timeline,
       frontmatter: parsed.frontmatter,
       tags: parsed.tags.sort(),
+      markdown_chunker_version: MARKDOWN_CHUNKER_VERSION,
     }))
     .digest('hex');
 

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -185,6 +185,7 @@ Same content.
     // Hash now includes ALL fields (title, type, frontmatter, tags)
     const { createHash } = await import('crypto');
     const { parseMarkdown } = await import('../src/core/markdown.ts');
+    const { MARKDOWN_CHUNKER_VERSION } = await import('../src/core/chunkers/recursive.ts');
     const content = `---
 type: concept
 title: Unchanged
@@ -201,6 +202,7 @@ Same content.
         timeline: parsed.timeline,
         frontmatter: parsed.frontmatter,
         tags: parsed.tags.sort(),
+        markdown_chunker_version: MARKDOWN_CHUNKER_VERSION,
       }))
       .digest('hex');
 

--- a/test/recursive-chunker.test.ts
+++ b/test/recursive-chunker.test.ts
@@ -1,0 +1,12 @@
+import { describe, test, expect } from 'bun:test';
+import { chunkText } from '../src/core/chunkers/recursive.ts';
+
+describe('recursive markdown chunker', () => {
+  test('hard-splits long CJK text without whitespace so embedding inputs stay bounded', () => {
+    const text = '汉'.repeat(20000);
+    const chunks = chunkText(text);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(Math.max(...chunks.map(c => c.text.length))).toBeLessThanOrEqual(6000);
+  });
+});


### PR DESCRIPTION
## Summary

The recursive markdown chunker's word-level splitter degrades on text without whitespace boundaries — most commonly long-form CJK prose. The chunker treats the whole paragraph as one "word" and produces a single chunk that can exceed OpenAI's `text-embedding-3-large` 8192-token input limit, at which point `gbrain embed --stale` rejects the chunk and the page never gets a vector.

## Fix

- Add `maxChars` option (default 6000 chars). Any chunk longer than this gets a final pass through `splitByChars()`, which slides over the text in `(maxChars - overlap_chars)` strides where `overlap_chars = min(500, maxChars/10)`. Chunks stay overlapping enough to preserve semantic continuity across the cut.
- Apply the cap to both the "single chunk for short text" path and the "merged chunks after recursive split" path.
- Trim the input once at the top so the cap and the word count agree on the same content.

## Breaking-change notice (re-embed required)

This commit bumps `MARKDOWN_CHUNKER_VERSION` from (implicit) 1 to a named constant of 2 and folds it into `importFromContent`'s content_hash. **Every existing markdown page is detected as "shape changed" on the next sync, triggering a clean re-chunk + re-embed under the new splitter.**

On a 1386-page brain like the developer's, this is roughly 4M re-embedded tokens (~$0.50 on text-embedding-3-large) and a one-time ~3-5min re-embed wall clock. Unavoidable: leaving v1 chunks in place would mean some pages stay un-embedded forever (the original symptom this fix addresses).

For users on small brains (<200 pages), re-embed is essentially free. For users on large brains, it's a few cents and a few minutes; cost should be communicated in the release notes.

## Test plan

- [x] New `test/recursive-chunker.test.ts` asserts a 20K-character pure CJK input (zero whitespace) gets sliced into multiple chunks each ≤ 6000 chars
- [x] Existing chunker tests unaffected
- [x] On the maintainer's brain: 23 pages had missing embeddings due to this exact chunker bug. After this patch + a re-embed pass, `gbrain embed --stale` reports 0 missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->