### PR TITLE
fix(sync): quote ISO-date titles + defensive TEXT coercion in put_page

### DIFF
--- a/src/core/frontmatter-inference.ts
+++ b/src/core/frontmatter-inference.ts
@@ -374,9 +374,18 @@ export function serializeFrontmatter(fm: InferredFrontmatter): string {
 
   const lines: string[] = ['---'];
 
-  // Title — quote if it contains special YAML chars
-  const needsQuote = /[:"'#\[\]{}|>&*!?,]/.test(fm.title);
-  lines.push(`title: ${needsQuote ? JSON.stringify(fm.title) : fm.title}`);
+  // Title — quote if it contains special YAML chars OR if it would be parsed
+  // as a non-string YAML scalar (date, number, bool, null). The previous
+  // regex missed YAML's implicit-type resolution: an unquoted `title: 2026-05-01`
+  // round-trips to a JS Date and crashes downstream callers that pass it as a
+  // PG TEXT param ("Invalid input for string type"). Quoting any title that
+  // could be coerced to a non-string is the right defense.
+  const looksLikeYamlScalar =
+    /[:"'#\[\]{}|>&*!?,]/.test(fm.title) ||
+    /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2})?)?$/.test(fm.title) || // ISO date / datetime
+    /^-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?$/.test(fm.title) ||                  // number
+    /^(?:true|false|yes|no|on|off|null|~)$/i.test(fm.title);                // bool / null
+  lines.push(`title: ${looksLikeYamlScalar ? JSON.stringify(fm.title) : fm.title}`);
 
   lines.push(`type: ${fm.type}`);
 

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -344,6 +344,20 @@ export class PGLiteEngine implements BrainEngine {
     const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
 
+    // Defensive coercion: PGlite's TEXT serializer rejects non-string values
+    // with "Invalid input for string type". When upstream parsers (e.g.
+    // frontmatter-inference) emit an unquoted `title: 2026-05-01`, gray-matter
+    // resolves it as a JS Date via YAML 1.1 implicit-type rules. Coerce here
+    // so a single bad title field can't poison sync for the whole file.
+    const rawTitle = page.title as unknown;
+    const safeTitle = typeof rawTitle === 'string'
+      ? rawTitle
+      : (rawTitle instanceof Date ? rawTitle.toISOString().slice(0, 10) : String(rawTitle ?? ''));
+    const rawCT = page.compiled_truth as unknown;
+    const safeCompiledTruth = typeof rawCT === 'string' ? rawCT : String(rawCT ?? '');
+    const rawTL = page.timeline as unknown;
+    const safeTimeline = typeof rawTL === 'string' ? rawTL : (rawTL ? String(rawTL) : '');
+
     // v0.18.0 Step 2: source_id relies on the schema DEFAULT 'default' so
     // existing callers still target the default source without threading
     // a parameter. ON CONFLICT target becomes (source_id, slug) since the
@@ -363,7 +377,7 @@ export class PGLiteEngine implements BrainEngine {
          content_hash = EXCLUDED.content_hash,
          updated_at = now()
        RETURNING id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at`,
-      [slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash]
+      [slug, page.type, pageKind, safeTitle, safeCompiledTruth, safeTimeline, JSON.stringify(frontmatter), hash]
     );
     return rowToPage(rows[0] as Record<string, unknown>);
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -294,6 +294,18 @@ export class PostgresEngine implements BrainEngine {
     const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
 
+    // Defensive coercion (mirrors pglite-engine.ts): postgres also rejects
+    // non-string values for TEXT columns. YAML 1.1 implicit-type resolution
+    // can turn an unquoted ISO-date title into a JS Date in upstream parsers.
+    const rawTitle = page.title as unknown;
+    const safeTitle = typeof rawTitle === 'string'
+      ? rawTitle
+      : (rawTitle instanceof Date ? rawTitle.toISOString().slice(0, 10) : String(rawTitle ?? ''));
+    const rawCT = page.compiled_truth as unknown;
+    const safeCompiledTruth = typeof rawCT === 'string' ? rawCT : String(rawCT ?? '');
+    const rawTL = page.timeline as unknown;
+    const safeTimeline = typeof rawTL === 'string' ? rawTL : (rawTL ? String(rawTL) : '');
+
     // v0.18.0 Step 2: source_id relies on schema DEFAULT 'default'. ON
     // CONFLICT target becomes (source_id, slug) since global UNIQUE(slug)
     // was dropped in migration v17. See pglite-engine.ts for matching
@@ -301,7 +313,7 @@ export class PostgresEngine implements BrainEngine {
     const pageKind = page.page_kind || 'markdown';
     const rows = await sql`
       INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
-      VALUES (${slug}, ${page.type}, ${pageKind}, ${page.title}, ${page.compiled_truth}, ${page.timeline || ''}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now())
+      VALUES (${slug}, ${page.type}, ${pageKind}, ${safeTitle}, ${safeCompiledTruth}, ${safeTimeline}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now())
       ON CONFLICT (source_id, slug) DO UPDATE SET
         type = EXCLUDED.type,
         page_kind = EXCLUDED.page_kind,

--- a/test/frontmatter-inference.test.ts
+++ b/test/frontmatter-inference.test.ts
@@ -238,6 +238,37 @@ describe('serializeFrontmatter', () => {
     expect(fm).not.toContain('source');
     expect(fm).not.toContain('tags');
   });
+
+  // Regression: bare ISO-date titles (e.g. daily-log files like `2026-05-01.md`)
+  // were emitted unquoted, then YAML 1.1 implicit-type resolution turned them
+  // into JS Date objects in gray-matter, which crashed pglite/postgres TEXT
+  // serializers with "Invalid input for string type" during `gbrain sync`.
+  // Quote anything that would resolve to a non-string YAML scalar.
+  test('quotes ISO-date titles (regression: gray-matter Date coercion)', () => {
+    const fm = serializeFrontmatter({ title: '2026-05-01', type: 'note' });
+    expect(fm).toContain('title: "2026-05-01"');
+    expect(fm).not.toMatch(/^title: 2026-05-01$/m);
+  });
+
+  test('quotes ISO-datetime titles', () => {
+    const fm = serializeFrontmatter({ title: '2026-05-01T10:30:00', type: 'note' });
+    expect(fm).toContain('title: "2026-05-01T10:30:00"');
+  });
+
+  test('quotes numeric titles', () => {
+    const fm = serializeFrontmatter({ title: '42', type: 'note' });
+    expect(fm).toContain('title: "42"');
+  });
+
+  test('quotes boolean-like titles', () => {
+    const fm = serializeFrontmatter({ title: 'yes', type: 'note' });
+    expect(fm).toContain('title: "yes"');
+  });
+
+  test('quotes null-like titles', () => {
+    const fm = serializeFrontmatter({ title: 'null', type: 'note' });
+    expect(fm).toContain('title: "null"');
+  });
 });
 
 // ── Integration ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`gbrain sync` crashed with `Invalid input for string type` on any file whose H1 heading was a bare ISO date (e.g. daily-log files like `memory/2026-05-01.md`).

## Root cause

1. `frontmatter-inference.ts` emitted unquoted `title: 2026-05-01` when no frontmatter was present on the source file.
2. gray-matter parsed that via YAML 1.1 implicit-type rules, turning the string into a JS `Date` object.
3. The `Date` flowed through `importFromContent` into `pglite-engine.putPage` as the title `TEXT` parameter, which pglite's serializer rejects.

## Fix

- `serializeFrontmatter` now quotes any title that would resolve to a non-string YAML scalar (ISO date/datetime, number, bool, null).
- Belt-and-suspenders coercion in `pglite-engine.putPage` and `postgres-engine.putPage`: if `title` / `compiled_truth` / `timeline` arrive as non-strings, coerce before parameter binding so a single bad upstream parser cannot poison the whole sync run.

## Tests

5 regression tests added in `test/frontmatter-inference.test.ts` covering ISO date / ISO datetime / numeric / bool-like / null-like title strings. Full suite (40 tests) passes.

## Verification

`gbrain sync` now imports `memory/2026-04-01.md`, `memory/2026-04-28.md`, `memory/2026-05-01.md` cleanly. Local health score 90/100, no new entries in `sync_failures`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->