### PR TITLE
fix(config): postgres always wins over pglite when URL is available

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -68,9 +68,24 @@ export function loadConfig(): GBrainConfig | null {
 
   if (!fileConfig && !dbUrl) return null;
 
-  // Infer engine type if not explicitly set
-  const inferredEngine: 'postgres' | 'pglite' = fileConfig?.engine
-    || (fileConfig?.database_path ? 'pglite' : 'postgres');
+  // Infer engine type.
+  // HARD RULE: if a Postgres URL is available (env or config), engine is
+  // always 'postgres'. PGLite is a fallback for zero-config local-only
+  // setups that have no Postgres URL at all. A config file that says
+  // engine:'pglite' while a database_url exists is a misconfiguration —
+  // Postgres wins unconditionally.
+  const hasPostgresUrl = !!(dbUrl || fileConfig?.database_url);
+  const inferredEngine: 'postgres' | 'pglite' = hasPostgresUrl
+    ? 'postgres'
+    : (fileConfig?.engine || (fileConfig?.database_path ? 'pglite' : 'postgres'));
+
+  // Warn if config says pglite but we're overriding to postgres
+  if (hasPostgresUrl && fileConfig?.engine === 'pglite') {
+    console.error(
+      '[gbrain] WARNING: config says engine:pglite but a Postgres URL is available. ' +
+      'Overriding to postgres. Remove engine/database_path from config to silence this.'
+    );
+  }
 
   // Merge: env vars override config file
   const merged = {


### PR DESCRIPTION
## Problem

A stale `config.json` with `engine: pglite` blocked the minion worker daemon for hours, even though Supabase Postgres was fully configured. The worker kept failing with "PGLite uses an exclusive file lock" because the config inference logic trusted the file over the actual database connection.

## Fix

If a Postgres `database_url` exists (via env var or config file), the engine is **always** `postgres` regardless of what the config file says. PGLite is now strictly a fallback for zero-config local-only setups that have no Postgres URL at all.

A warning is logged when the override fires so operators can clean up stale configs.

## What happened

`/data/.gbrain/config.json` had `{"engine": "pglite", "database_path": "/data/.gbrain/brain.pglite"}` while `SUPABASE_DB_URL` was set and working. The old inference logic on line 72-73 took the config file at face value. All minion jobs sat in `waiting` with no worker able to start.

## Testing

Verified: with the bad config restored, `loadConfig()` now returns `engine: postgres` and logs the warning.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->