### PR TITLE
fix(serve-http): preserve items field for array params in tools/list

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -624,6 +624,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
               description: v.description,
               ...(v.enum ? { enum: v.enum } : {}),
               ...(v.default !== undefined ? { default: v.default } : {}),
+              ...(v.items ? { items: { type: v.items.type } } : {}),
             }]),
           ),
           required: Object.entries(op.params).filter(([, v]) => v.required).map(([k]) => k),


### PR DESCRIPTION
## Summary

`gbrain serve --http` rejects connections from OpenAI Codex with HTTP 400 because the `tools/list` response sends array parameters without the required `items` JSON Schema field.

## Reproducer

1. Brain on v0.26.3, schema v33, `gbrain serve --http --port 8000`.
2. Mint a token: `gbrain auth create test`.
3. Call tools/list:

    curl -s -X POST http://localhost:8000/mcp \
      -H "Authorization: Bearer $TOKEN" \
      -H "Content-Type: application/json" \
      -H "Accept: application/json, text/event-stream" \
      -d '{"jsonrpc":"2.0","method":"tools/list","id":1,"params":{}}' \
      | grep -oE '"pages_updated":\{[^}]+\}'

Response (broken):

    "pages_updated":{"type":"array"}

Expected:

    "pages_updated":{"type":"array","items":{"type":"string"}}

## Impact

OpenAI Codex (gpt-5.5 via openai-codex provider) returns:

    HTTP 400: Invalid schema for function 'mcp_gbrain_log_ingest':
    In context=('properties', 'pages_updated'), array schema missing items.
    type: invalid_request_error
    code: invalid_function_parameters

Anthropic, Kimi, and most other providers accept the malformed schema, so this only fires under strict OpenAI tool validation. Affects every array param across all gbrain tools served via the new HTTP transport (e.g., `log_ingest.pages_updated`).

## Root cause

`src/mcp/tool-defs.ts` serializes operations via `buildToolDefs()` which correctly preserves `items`:

    ...(v.items ? { items: { type: v.items.type } } : {}),

`src/commands/serve-http.ts` (introduced in v0.26.0) inlines its own serializer for the `ListToolsRequestSchema` handler around line 619-625 that drops `items`:

    properties: Object.fromEntries(
      Object.entries(op.params).map(([k, v]) => [k, {
        type: v.type,
        description: v.description,
        ...(v.enum ? { enum: v.enum } : {}),
        ...(v.default !== undefined ? { default: v.default } : {}),
        // missing: items handler
      }]),
    ),

The stdio path (which goes through `buildToolDefs`) is unaffected, which is why this didn't surface until v0.26.0 introduced the native HTTP server.

## Fix

One-line addition in `src/commands/serve-http.ts` near line 627:

    diff
    --- a/src/commands/serve-http.ts
    +++ b/src/commands/serve-http.ts
    @@ -624,6 +624,7 @@
                   type: v.type,
                   description: v.description,
                   ...(v.enum ? { enum: v.enum } : {}),
                   ...(v.default !== undefined ? { default: v.default } : {}),
    +              ...(v.items ? { items: { type: v.items.type } } : {}),
                 }]),

Verified locally on v0.26.3 (commit f082501): after the patch, the wire format includes `"items":{"type":"string"}` and OpenAI Codex accepts the tool list. Hermes (NousResearch agent on openai-codex provider) and OpenClaw both reconnect cleanly.

## Suggested follow-ups

- Replace the inline serializer in `serve-http.ts` with a call to `buildToolDefs()` so the two paths can't drift again.
- Add a test that parses the `tools/list` response through OpenAI's tool-validation schema (or just asserts that any param with `type: 'array'` has an `items` field).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->