### PR TITLE
fix(skillpack-check): resolve gbrain via PATH first, survive Bun --compile

### DIFF
--- a/src/commands/skillpack-check.ts
+++ b/src/commands/skillpack-check.ts
@@ -16,30 +16,54 @@
  *   2 — Could not determine (missing binary / crashed).
  */
 
-import { execFileSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import { VERSION } from '../version.ts';
 import { getCliOptions } from '../core/cli-options.ts';
 
 /**
  * Resolve the gbrain binary + args for spawning subcommands from
- * within skillpack-check. Handles three install cases:
- *   - Running the compiled binary (argv[1] ends in /gbrain): re-exec it.
- *   - Running via `bun run src/cli.ts` (argv[1] is a .ts file): prefix with `bun run`.
- *   - Anything else: fall back to `which gbrain` on $PATH.
+ * within skillpack-check. Mirrors `resolveGbrainCliPath()` in autopilot.ts:
+ * try the PATH shim first (canonical for installed builds, and the only path
+ * that survives Bun --compile — where `process.argv[1]` becomes the
+ * in-bundle pseudo-path `/$bunfs/root/gbrain` that doesn't exist on disk),
+ * then exec/argv fallbacks for direct-invocation and .ts dev mode.
  */
-function gbrainSpawn(): { cmd: string; prefix: string[] } {
-  const arg1 = process.argv[1] ?? '';
-  if (arg1.endsWith('/gbrain') || arg1.endsWith('\\gbrain.exe')) {
-    return { cmd: arg1, prefix: [] };
-  }
-  if (arg1.endsWith('.ts') || arg1.endsWith('.mjs') || arg1.endsWith('.js')) {
-    return { cmd: 'bun', prefix: ['run', arg1] };
-  }
-  const execPath = process.execPath ?? '';
+export function gbrainSpawn(opts?: {
+  argv?: readonly string[];
+  execPath?: string;
+  whichResolver?: () => string | null;
+}): { cmd: string; prefix: string[] } {
+  const argv = opts?.argv ?? process.argv;
+  const execPath = opts?.execPath ?? process.execPath ?? '';
+  const whichResolver = opts?.whichResolver ?? defaultWhichResolver;
+
+  const which = whichResolver();
+  if (which) return { cmd: which, prefix: [] };
+
   if (execPath.endsWith('/gbrain') || execPath.endsWith('\\gbrain.exe')) {
     return { cmd: execPath, prefix: [] };
   }
+
+  const arg1 = argv[1] ?? '';
+  if (!arg1.startsWith('/$bunfs/')) {
+    if (arg1.endsWith('/gbrain') || arg1.endsWith('\\gbrain.exe')) {
+      return { cmd: arg1, prefix: [] };
+    }
+    if (arg1.endsWith('.ts') || arg1.endsWith('.mjs') || arg1.endsWith('.js')) {
+      return { cmd: 'bun', prefix: ['run', arg1] };
+    }
+  }
+
   return { cmd: 'gbrain', prefix: [] };
+}
+
+function defaultWhichResolver(): string | null {
+  try {
+    const out = execSync('which gbrain', { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
 }
 
 interface DoctorCheck {

--- a/test/skillpack-check.test.ts
+++ b/test/skillpack-check.test.ts
@@ -19,6 +19,7 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execFileSync } from 'child_process';
+import { gbrainSpawn } from '../src/commands/skillpack-check.ts';
 
 const CLI = join(__dirname, '..', 'src', 'cli.ts');
 
@@ -130,5 +131,57 @@ describe('gbrain skillpack-check', () => {
     const report = JSON.parse(result.stdout);
     expect(report.summary).toMatch(/\d+ action\(s\)/);
     expect(report.summary).toContain(report.actions[0]);
+  });
+});
+
+describe('gbrainSpawn — binary resolution', () => {
+  test('PATH which result wins when present', () => {
+    const result = gbrainSpawn({
+      argv: ['bun', '/$bunfs/root/gbrain'],
+      execPath: '/Users/me/.bun/install/global/node_modules/gbrain/src/cli.ts',
+      whichResolver: () => '/usr/local/bin/gbrain',
+    });
+    expect(result).toEqual({ cmd: '/usr/local/bin/gbrain', prefix: [] });
+  });
+
+  test('Bun --compile artifact (argv[1]=/$bunfs/...) without PATH falls back to execPath when /gbrain', () => {
+    // Regression: previously argv[1].endsWith('/gbrain') matched the
+    // in-bundle pseudo-path and skillpack-check tried to execFileSync
+    // '/$bunfs/root/gbrain', failing with ENOENT.
+    const result = gbrainSpawn({
+      argv: ['bun', '/$bunfs/root/gbrain'],
+      execPath: '/Users/me/.bun/bin/gbrain',
+      whichResolver: () => null,
+    });
+    expect(result).toEqual({ cmd: '/Users/me/.bun/bin/gbrain', prefix: [] });
+  });
+
+  test('Bun --compile artifact + non-/gbrain execPath + no PATH → falls through to bare gbrain', () => {
+    // Belt-and-suspenders: even when execPath is the .ts symlink target
+    // (the actual installed shape), we never try to spawn the bunfs path.
+    const result = gbrainSpawn({
+      argv: ['bun', '/$bunfs/root/gbrain'],
+      execPath: '/Users/me/.bun/install/global/node_modules/gbrain/src/cli.ts',
+      whichResolver: () => null,
+    });
+    expect(result).toEqual({ cmd: 'gbrain', prefix: [] });
+  });
+
+  test('compiled binary direct invocation (real argv[1] ends with /gbrain) without PATH', () => {
+    const result = gbrainSpawn({
+      argv: ['bun', '/usr/local/bin/gbrain'],
+      execPath: '/some/other/path',
+      whichResolver: () => null,
+    });
+    expect(result).toEqual({ cmd: '/usr/local/bin/gbrain', prefix: [] });
+  });
+
+  test('dev mode (.ts argv[1]) without PATH → bun run prefix', () => {
+    const result = gbrainSpawn({
+      argv: ['bun', '/Users/me/clones/gbrain/src/cli.ts'],
+      execPath: '/Users/me/.bun/bin/bun',
+      whichResolver: () => null,
+    });
+    expect(result).toEqual({ cmd: 'bun', prefix: ['run', '/Users/me/clones/gbrain/src/cli.ts'] });
   });
 });


### PR DESCRIPTION
## Summary

`gbrain skillpack-check` always exits with `healthy: false` on the canonical install (Bun `--compile` binary at `~/.bun/install/global/node_modules/gbrain/src/cli.ts`). Both subcalls — `doctor --json` and `apply-migrations --list` — die with `ENOENT: no such file or directory, posix_spawn '/$bunfs/root/gbrain'` before any check can run.

Same root cause as #250 / #290 (Bun `--compile` mounts bundled files under the `$bunfs/` virtual filesystem), different surface. `gbrainSpawn()` in `src/commands/skillpack-check.ts` checks `argv[1].endsWith('/gbrain')` first; on a compiled binary `argv[1]` is `/$bunfs/root/gbrain`, the suffix matches, and `execFileSync` is called with a path that doesn't exist on disk.

`autopilot.ts:resolveGbrainCliPath()` already handles this correctly by trying `which gbrain` first. This PR mirrors that pattern in `gbrainSpawn()`.

## Reproduction (against current master, v0.26.2)

```bash
$ gbrain skillpack-check
{
  "healthy": false,
  "summary": "gbrain skillpack needs attention: 2 action(s) — Investigate doctor failure: doctor failed: ENOENT: no such file or directory, posix_spawn '/$bunfs/root/gbrain'",
  "actions": [
    "Investigate doctor failure: doctor failed: ENOENT: no such file or directory, posix_spawn '/\$bunfs/root/gbrain'",
    "Investigate apply-migrations failure: apply-migrations --list failed: ENOENT: no such file or directory, posix_spawn '/\$bunfs/root/gbrain'"
  ],
  "doctor":  { "error": "doctor failed: ENOENT: ..." },
  "migrations": { "error": "apply-migrations --list failed: ENOENT: ..." }
}
$ echo \$?
1
```

After this PR: `\"healthy\": true`, real check output, exit 0.

## Changes

- **`src/commands/skillpack-check.ts`** — rewrite `gbrainSpawn()` resolution order to mirror `autopilot.ts:resolveGbrainCliPath()`:
  1. \`which gbrain\` (canonical PATH shim, survives \`--compile\`)
  2. \`process.execPath\` if it ends in \`/gbrain\`
  3. \`argv[1]\` — but explicitly skip if it starts with \`/\$bunfs/\`
  4. \`.ts\` / \`.mjs\` / \`.js\` argv[1] → \`bun run <path>\` (dev mode preserved)
  5. Fall back to bare \`gbrain\` (let \$PATH resolve)
- Function is now \`export\`ed with optional dependency injection (\`argv\`, \`execPath\`, \`whichResolver\`) so the resolution branches can be unit-tested without spawning real subprocesses.

## Test plan

- [x] \`bun test test/skillpack-check.test.ts\` — **10 pass, 0 fail** (5 existing subprocess tests + 5 new \`gbrainSpawn\` unit tests):
  - PATH \`which\` result wins regardless of argv shape
  - Bunfs argv[1] + \`/gbrain\` execPath → uses execPath (regression case for direct compiled-binary invocation)
  - Bunfs argv[1] + non-\`/gbrain\` execPath → falls through to bare \`gbrain\` (regression case for the canonical Bun-shim install — argv[1] is \`/\$bunfs/root/gbrain\`, execPath is \`/path/to/cli.ts\`)
  - Real \`/gbrain\` argv[1] → uses argv[1]
  - \`.ts\` argv[1] → returns \`{cmd: 'bun', prefix: ['run', argv[1]]}\` (dev mode preserved)
- [x] \`bun run typecheck\` clean
- [x] \`bun build --compile --outfile /tmp/gbrain-fixed src/cli.ts\` then ran \`gbrain skillpack-check\` against a real OpenClaw skills directory — returns \`\"healthy\": true\`, exit 0, with the real resolver_health warnings instead of the ENOENT noise.

## Related

- #250 — sibling instance of the same bug class (Bun \`--compile\` + \`/\$bunfs/\` paths) on the PGLite data-dir surface.
- #290 — fail-loudly fix for the PGLite manifestation; this PR is the same pattern applied to the \`skillpack-check\` spawn site.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->