### PR TITLE
fix(cli): read stdin via fd 0 instead of '/dev/stdin' path (cross-platform)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { readFileSync } from 'fs';
+import { readFileSync, fstatSync } from 'fs';
 import { loadConfig, toEngineConfig } from './core/config.ts';
 import type { BrainEngine } from './core/engine.ts';
 import { operations, OperationError } from './core/operations.ts';
@@ -132,15 +132,30 @@ function parseOpArgs(op: Operation, args: string[]): Record<string, unknown> {
     }
   }
 
-  // Read stdin for content params
-  if (op.cliHints?.stdin && !params[op.cliHints.stdin] && !process.stdin.isTTY) {
-    const stdinContent = readFileSync('/dev/stdin', 'utf-8');
-    const MAX_STDIN = 5_000_000; // 5MB
-    if (Buffer.byteLength(stdinContent, 'utf-8') > MAX_STDIN) {
-      console.error(`Error: stdin content exceeds ${MAX_STDIN} bytes. Split into smaller inputs.`);
-      process.exit(1);
+  // Read stdin for content params.
+  // Cross-platform: read from fd 0 (works on Windows; '/dev/stdin' as a path
+  // resolves to C:\dev\stdin and ENOENTs there). Use fstatSync(0) instead of
+  // !isTTY because process.stdin.isTTY is `undefined` on Windows pipes which
+  // happens to coerce correctly today, but a stricter check also avoids
+  // blocking when fd 0 is detached (e.g. systemd service) by only consuming
+  // stdin when it's actually a pipe/file/socket.
+  if (op.cliHints?.stdin && !params[op.cliHints.stdin]) {
+    let hasReadableStdin = false;
+    try {
+      const st = fstatSync(0);
+      hasReadableStdin = st.isFIFO() || st.isFile() || st.isSocket();
+    } catch {
+      // fd 0 not statable (rare); skip stdin read.
     }
-    params[op.cliHints.stdin] = stdinContent;
+    if (hasReadableStdin) {
+      const stdinContent = readFileSync(0, 'utf-8');
+      const MAX_STDIN = 5_000_000; // 5MB
+      if (Buffer.byteLength(stdinContent, 'utf-8') > MAX_STDIN) {
+        console.error(`Error: stdin content exceeds ${MAX_STDIN} bytes. Split into smaller inputs.`);
+        process.exit(1);
+      }
+      params[op.cliHints.stdin] = stdinContent;
+    }
   }
 
   return params;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -133,12 +133,13 @@ function parseOpArgs(op: Operation, args: string[]): Record<string, unknown> {
   }
 
   // Read stdin for content params.
-  // Cross-platform: read from fd 0 (works on Windows; '/dev/stdin' as a path
-  // resolves to C:\dev\stdin and ENOENTs there). Use fstatSync(0) instead of
-  // !isTTY because process.stdin.isTTY is `undefined` on Windows pipes which
-  // happens to coerce correctly today, but a stricter check also avoids
-  // blocking when fd 0 is detached (e.g. systemd service) by only consuming
-  // stdin when it's actually a pipe/file/socket.
+  // Cross-platform: read from fd 0. Reading stdin via the path /dev/stdin
+  // (POSIX-only) resolves to C:\dev\stdin on Windows and ENOENTs there.
+  // Use fstatSync(0) instead of !isTTY because process.stdin.isTTY is
+  // `undefined` on Windows pipes which happens to coerce correctly today,
+  // but a stricter check also avoids blocking when fd 0 is detached (e.g.
+  // systemd service) by only consuming stdin when it's actually a
+  // pipe/file/socket.
   if (op.cliHints?.stdin && !params[op.cliHints.stdin]) {
     let hasReadableStdin = false;
     try {

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -10,7 +10,7 @@
  *   gbrain report --type enrichment-sweep --dir /path/to/brain
  */
 
-import { writeFileSync, mkdirSync, readFileSync } from 'fs';
+import { writeFileSync, mkdirSync, readFileSync, fstatSync } from 'fs';
 import { join } from 'path';
 
 export async function runReport(args: string[]) {
@@ -38,10 +38,23 @@ export async function runReport(args: string[]) {
     process.exit(1);
   }
 
-  // Read content from --content arg or stdin
+  // Read content from --content arg or stdin.
+  // Cross-platform stdin: fd 0 + fstatSync guard. See parseOpArgs in cli.ts
+  // for the same pattern. Reading stdin via the POSIX path /dev/stdin
+  // resolves to C:\dev\stdin on Windows (ENOENT), and !process.stdin.isTTY
+  // is unreliable across detached fd 0 setups (systemd services etc.).
   let content = contentIdx >= 0 ? args[contentIdx + 1] : null;
-  if (!content && !process.stdin.isTTY) {
-    content = readFileSync('/dev/stdin', 'utf-8');
+  if (!content) {
+    let hasReadableStdin = false;
+    try {
+      const st = fstatSync(0);
+      hasReadableStdin = st.isFIFO() || st.isFile() || st.isSocket();
+    } catch {
+      // fd 0 not statable; skip stdin read.
+    }
+    if (hasReadableStdin) {
+      content = readFileSync(0, 'utf-8');
+    }
   }
 
   if (!content?.trim()) {

--- a/test/cli-stdin-cross-platform.test.ts
+++ b/test/cli-stdin-cross-platform.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Regression tests for cross-platform stdin handling in the CLI.
+ *
+ * These tests guard against the Windows ENOENT regression caused by reading
+ * stdin via the path '/dev/stdin' (which resolves to C:\dev\stdin on Windows).
+ *
+ * Two stdin code paths are exercised:
+ *   1. parseOpArgs in src/cli.ts — drives `gbrain put` and any operation with
+ *      `cliHints.stdin` set
+ *   2. runReport in src/commands/report.ts — drives `gbrain report`
+ *
+ * Both must:
+ *   - Read from fd 0 (not '/dev/stdin') when stdin is a pipe
+ *   - Skip the read entirely (no block, no crash) when stdin is ignored/detached
+ *   - Honor an explicit --content/--arg value over piped stdin
+ *
+ * Tests use `gbrain report` because it does not require a database connection
+ * (writes a markdown file to a temp dir), so they are fast and hermetic.
+ *
+ * Tests are platform-agnostic by design: the bug they catch is Windows-only
+ * but the fix changes behavior on all platforms (stricter fd guard), so
+ * running them on Linux/macOS still validates the new code path.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync, readFileSync, readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+
+// fileURLToPath gives a native filesystem path (e.g. C:\Users\... on Windows,
+// /Users/... on macOS). new URL().pathname does not — on Windows it returns
+// a POSIX-style /C:/... that confuses `git -C` and shells.
+const CLI_PATH = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+// Use Bun.argv[0] (the absolute path to the running bun executable) instead of
+// the bare 'bun' string. On Windows the binary is bun.exe and is typically not
+// resolvable via libuv's spawn lookup unless invoked through a shell.
+const BUN_BIN = Bun.argv[0];
+const SPAWN_CMD = [BUN_BIN, 'run', CLI_PATH];
+
+// Run the CLI once with the given args and stdin spec; return stdout/stderr/exit.
+async function runCli(
+  args: string[],
+  opts: { stdin?: 'pipe' | 'ignore'; input?: string; timeoutMs?: number } = {},
+): Promise<{ stdout: string; stderr: string; exitCode: number; timedOut: boolean }> {
+  const proc = Bun.spawn([...SPAWN_CMD, ...args], {
+    cwd: REPO_ROOT,
+    stdin: opts.stdin ?? 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  if (opts.input !== undefined && proc.stdin) {
+    proc.stdin.write(opts.input);
+    proc.stdin.end();
+  }
+
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, timeoutMs);
+
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  clearTimeout(timer);
+
+  return { stdout, stderr, exitCode, timedOut };
+}
+
+describe('CLI stdin: cross-platform fd 0 handling (regression for Windows ENOENT)', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `gbrain-stdin-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (testDir && existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  // ── runReport in src/commands/report.ts ────────────────────────────────
+
+  test('report reads piped stdin via fd 0 (not /dev/stdin path)', async () => {
+    const body = 'piped report body — must reach the file via fd 0';
+    const result = await runCli(
+      ['report', '--type', 'test-stdin-pipe', '--title', 'Test', '--dir', testDir],
+      { stdin: 'pipe', input: body },
+    );
+
+    expect(result.timedOut).toBe(false);
+    expect(result.stderr).not.toContain('ENOENT');
+    expect(result.stderr).not.toContain('/dev/stdin');
+    expect(result.exitCode).toBe(0);
+
+    const reportDir = join(testDir, 'reports', 'test-stdin-pipe');
+    expect(existsSync(reportDir)).toBe(true);
+    const files = readdirSync(reportDir).filter((f) => f.endsWith('.md'));
+    expect(files.length).toBe(1);
+    const content = readFileSync(join(reportDir, files[0]), 'utf-8');
+    expect(content).toContain(body);
+  });
+
+  test('report does not block or crash when stdin is ignored (no input provided)', async () => {
+    // Without --content and without piped stdin, report must error fast,
+    // not block reading from a missing fd.
+    const result = await runCli(
+      ['report', '--type', 'test-stdin-none', '--title', 'Test', '--dir', testDir],
+      { stdin: 'ignore', timeoutMs: 5_000 },
+    );
+
+    expect(result.timedOut).toBe(false);
+    expect(result.stderr).not.toContain('ENOENT');
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/no content provided/i);
+  });
+
+  test('report --content takes precedence over piped stdin', async () => {
+    const fromArgs = 'content-from-args-wins';
+    const fromStdin = 'content-from-stdin-loses';
+    const result = await runCli(
+      [
+        'report',
+        '--type', 'test-stdin-precedence',
+        '--title', 'Test',
+        '--content', fromArgs,
+        '--dir', testDir,
+      ],
+      { stdin: 'pipe', input: fromStdin },
+    );
+
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(0);
+
+    const reportDir = join(testDir, 'reports', 'test-stdin-precedence');
+    const files = readdirSync(reportDir).filter((f) => f.endsWith('.md'));
+    const content = readFileSync(join(reportDir, files[0]), 'utf-8');
+    expect(content).toContain(fromArgs);
+    expect(content).not.toContain(fromStdin);
+  });
+
+  // ── parseOpArgs in src/cli.ts (smoke check via --help, no DB needed) ───
+
+  test('CLI --help with piped stdin does not read /dev/stdin or crash', async () => {
+    // --help short-circuits before parseOpArgs reads stdin, so this is a
+    // smoke test that the early-exit path is not destabilized by the new
+    // fstatSync guard. (The full put_page stdin path requires DB and is
+    // covered by the report tests above.)
+    const result = await runCli(
+      ['--help'],
+      { stdin: 'pipe', input: 'irrelevant data on stdin' },
+    );
+
+    expect(result.timedOut).toBe(false);
+    expect(result.stderr).not.toContain('ENOENT');
+    expect(result.stderr).not.toContain('/dev/stdin');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('gbrain');
+  });
+});
+
+// ── Source-level invariant: no remaining '/dev/stdin' literals in src/ ──
+
+describe('Source invariant: no /dev/stdin path literals', () => {
+  test("no source file under src/ contains a '/dev/stdin' string literal", async () => {
+    // Walk src/ and assert no .ts file uses the POSIX-only path. Comments are
+    // allowed (they document the historical fix), so we look only for the
+    // quoted string forms that actually trigger the bug.
+    //
+    // This guards against future code paths reintroducing the same regression
+    // outside the two known sites (cli.ts parseOpArgs, report.ts).
+    const { execFileSync } = await import('child_process');
+    let matches = '';
+    try {
+      matches = execFileSync(
+        'git',
+        [
+          '-C', REPO_ROOT,
+          'grep',
+          '-nE',
+          String.raw`["']/dev/stdin["']`,
+          '--', 'src/',
+        ],
+        { encoding: 'utf-8' },
+      );
+    } catch (e: any) {
+      // git grep exits 1 when no matches found — that's the success case.
+      if (e?.status === 1) matches = '';
+      else throw e;
+    }
+
+    expect(matches.trim()).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

`readFileSync('/dev/stdin', 'utf-8')` in `src/cli.ts` fails on Windows because the path resolves to `C:\dev\stdin` (ENOENT). Replace with `readFileSync(0, ...)` which targets fd 0 directly and is cross-platform. Also tighten the trigger condition so we only consume stdin when fd 0 is actually a pipe/file/socket.

## Problem

Any caller that pipes content into `gbrain put` on Windows hits:

```
ENOENT: no such file or directory, open 'C:\dev\stdin'
```

100% reproducible. Triggered every time `op.cliHints.stdin` is set, the param is missing from argv, and stdin is non-interactive — the exact path `gbrain put`, every Windows MCP-less integration, and any CI shell pipeline takes.

Two compounding factors hide this on POSIX:

1. **`/dev/stdin` is a POSIX special file path, not a portable convention.** Windows has no such path; Node/Bun resolve it as a relative path against the cwd. ENOENT is unavoidable.
2. **`!process.stdin.isTTY` happens to coerce correctly today on Windows pipes** (`isTTY === undefined`, negation is truthy), so the code path is entered, then immediately crashes.

Discovered while running `gbrain put` from a pi-coding-agent extension on Windows 11 + Bun 1.x — but the same crash reproduces with any direct shell invocation:

```bash
$ echo "# test" | gbrain put my-slug --title "test" --tags x
Failed to save "my-slug": ENOENT: no such file or directory, open 'C:\dev\stdin'
```

## Fix

```diff
-import { readFileSync } from 'fs';
+import { readFileSync, fstatSync } from 'fs';
 ...
-if (op.cliHints?.stdin && !params[op.cliHints.stdin] && !process.stdin.isTTY) {
-  const stdinContent = readFileSync('/dev/stdin', 'utf-8');
+if (op.cliHints?.stdin && !params[op.cliHints.stdin]) {
+  let hasReadableStdin = false;
+  try {
+    const st = fstatSync(0);
+    hasReadableStdin = st.isFIFO() || st.isFile() || st.isSocket();
+  } catch {
+    /* fd 0 not statable; skip stdin read */
+  }
+  if (hasReadableStdin) {
+    const stdinContent = readFileSync(0, 'utf-8');
+    ...
```

Two changes, both small and behavior-preserving on POSIX:

1. **`readFileSync('/dev/stdin')` → `readFileSync(0)`** — fd 0 is the canonical cross-platform way to read stdin in Node/Bun. Identical bytes returned on every platform.
2. **`!process.stdin.isTTY` → `fstatSync(0).isFIFO() || isFile() || isSocket()`** — explicit "is fd 0 actually something we can read from" check. Avoids the accidental `undefined`-coercion behavior on Windows, and avoids blocking when fd 0 is detached (e.g. systemd-launched processes where stdin is neither a TTY nor a pipe).

## Verification

- **Windows 11 + Bun 1.x** — `echo "..." | gbrain put my-slug --title "t" --tags x` returned `{"status":"created_or_updated", ...}` after the patch. Same command without the patch returns the ENOENT error reproducibly.
- **Cleanup**: `gbrain delete my-slug` confirmed the page existed and was removable.
- **No-stdin commands** (`gbrain doctor --json`, `gbrain search ...`, `gbrain get ...`) still return promptly — the new `fstatSync` guard correctly identifies non-piped invocations and skips the read.
- **Linux/macOS behavior unchanged**: `fd 0` and `'/dev/stdin'` resolve to the same file/fd; the FIFO/file/socket check matches the cases where the old `!isTTY` was previously meaningful.

## Why it matters beyond Windows

The `fstatSync(0)` guard also fixes a latent issue on Linux/macOS: `!process.stdin.isTTY` returns `true` for **detached fd 0** (systemd services, daemons launched without a controlling TTY), causing `readFileSync('/dev/stdin')` to either block forever or return EAGAIN/ENXIO depending on kernel version. The new guard explicitly checks for a readable fd type, so detached invocations cleanly skip stdin instead of hanging.

## Affected callers (downstream impact)

This bug silently breaks every tool that pipes content to `gbrain put` on Windows:

- **`gbrain put` direct shell pipe** — every doc snippet that uses `<<<"..."` or `cat file.md |` syntax
- **gstack `bin/gstack-memory-ingest.ts`** (per `USING_GBRAIN_WITH_GSTACK.md`) — its `gbrainPutPage` helper uses `execFileSync("gbrain", args, { input: page.body, stdio: ["pipe", "pipe", "pipe"] })`, the exact same code path
- **Any pi-coding-agent / Claude Code / Cursor extension** that wraps `gbrain put`

All of these work on macOS/Linux today and silently break on Windows. After this patch, they all start working with no caller-side changes.

## Out of scope

- Windows install path / `.bunx` quirks — orthogonal, not touched here
- `serve` HTTP/MCP transports — they parse JSON bodies and never touched the `/dev/stdin` path
- Stdin size cap (`MAX_STDIN = 5_000_000`) — preserved verbatim

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->