### PR TITLE
fix: bootstrap legacy mcp_request_log columns before v33

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -240,7 +240,15 @@ export class PGLiteEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema='public' AND table_name='content_chunks' AND column_name='symbol_name') AS symbol_name_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema='public' AND table_name='content_chunks' AND column_name='language') AS language_exists
+                WHERE table_schema='public' AND table_name='content_chunks' AND column_name='language') AS language_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema='public' AND table_name='mcp_request_log') AS mcp_log_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='mcp_request_log' AND column_name='agent_name') AS mcp_agent_name_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='mcp_request_log' AND column_name='params') AS mcp_params_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='mcp_request_log' AND column_name='error_message') AS mcp_error_message_exists
     `);
     const probe = rows[0] as {
       pages_exists: boolean;
@@ -252,6 +260,10 @@ export class PGLiteEngine implements BrainEngine {
       chunks_exists: boolean;
       symbol_name_exists: boolean;
       language_exists: boolean;
+      mcp_log_exists: boolean;
+      mcp_agent_name_exists: boolean;
+      mcp_params_exists: boolean;
+      mcp_error_message_exists: boolean;
     };
 
     const needsPagesBootstrap = probe.pages_exists && !probe.source_id_exists;
@@ -260,9 +272,11 @@ export class PGLiteEngine implements BrainEngine {
     const needsChunksBootstrap = probe.chunks_exists
       && (!probe.symbol_name_exists || !probe.language_exists);
     const needsPagesDeletedAt = probe.pages_exists && !probe.deleted_at_exists;
+    const needsMcpLogBootstrap = probe.mcp_log_exists
+      && (!probe.mcp_agent_name_exists || !probe.mcp_params_exists || !probe.mcp_error_message_exists);
 
     // Fresh installs (no tables yet) and modern brains both no-op.
-    if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap && !needsPagesDeletedAt) return;
+    if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap && !needsPagesDeletedAt && !needsMcpLogBootstrap) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
 
@@ -318,6 +332,20 @@ export class PGLiteEngine implements BrainEngine {
       // not to crash. v34 runs later via runMigrations and is idempotent.
       await this.db.exec(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsMcpLogBootstrap) {
+      // v0.26.3/v33 introduced `mcp_request_log.agent_name`, `params`, and
+      // `error_message`, and the embedded schema now creates an index on
+      // `agent_name`. Older brains can have the table without those columns,
+      // which wedges initSchema before numbered migrations get a chance to add
+      // them. Bootstrap only adds the forward-referenced columns; v33 remains
+      // responsible for the semantic backfill/index work.
+      await this.db.exec(`
+        ALTER TABLE mcp_request_log ADD COLUMN IF NOT EXISTS agent_name TEXT;
+        ALTER TABLE mcp_request_log ADD COLUMN IF NOT EXISTS params JSONB;
+        ALTER TABLE mcp_request_log ADD COLUMN IF NOT EXISTS error_message TEXT;
       `);
     }
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -174,6 +174,10 @@ export class PostgresEngine implements BrainEngine {
       chunks_exists: boolean;
       symbol_name_exists: boolean;
       language_exists: boolean;
+      mcp_log_exists: boolean;
+      mcp_agent_name_exists: boolean;
+      mcp_params_exists: boolean;
+      mcp_error_message_exists: boolean;
     }[]>`
       SELECT
         EXISTS (SELECT 1 FROM information_schema.tables
@@ -193,7 +197,15 @@ export class PostgresEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema = current_schema() AND table_name = 'content_chunks' AND column_name = 'symbol_name') AS symbol_name_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema = current_schema() AND table_name = 'content_chunks' AND column_name = 'language') AS language_exists
+                WHERE table_schema = current_schema() AND table_name = 'content_chunks' AND column_name = 'language') AS language_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema() AND table_name = 'mcp_request_log') AS mcp_log_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'mcp_request_log' AND column_name = 'agent_name') AS mcp_agent_name_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'mcp_request_log' AND column_name = 'params') AS mcp_params_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'mcp_request_log' AND column_name = 'error_message') AS mcp_error_message_exists
     `;
     const probe = probeRows[0]!;
 
@@ -205,8 +217,10 @@ export class PostgresEngine implements BrainEngine {
     // v0.26.5: pages_deleted_at_purge_idx in SCHEMA_SQL crashes if the column
     // doesn't exist yet. Migration v34 also adds it, but bootstrap runs first.
     const needsPagesDeletedAt = probe.pages_exists && !probe.deleted_at_exists;
+    const needsMcpLogBootstrap = probe.mcp_log_exists
+      && (!probe.mcp_agent_name_exists || !probe.mcp_params_exists || !probe.mcp_error_message_exists);
 
-    if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap && !needsPagesDeletedAt) return;
+    if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap && !needsPagesDeletedAt && !needsMcpLogBootstrap) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
 
@@ -261,6 +275,20 @@ export class PostgresEngine implements BrainEngine {
       // not to crash. v34 runs later via runMigrations and is idempotent.
       await conn.unsafe(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsMcpLogBootstrap) {
+      // v0.26.3/v33 introduced `mcp_request_log.agent_name`, `params`, and
+      // `error_message`, and the embedded schema now creates an index on
+      // `agent_name`. Older brains can have the table without those columns,
+      // which wedges initSchema before numbered migrations get a chance to add
+      // them. Bootstrap only adds the forward-referenced columns; v33 remains
+      // responsible for the semantic backfill/index work.
+      await conn.unsafe(`
+        ALTER TABLE mcp_request_log ADD COLUMN IF NOT EXISTS agent_name TEXT;
+        ALTER TABLE mcp_request_log ADD COLUMN IF NOT EXISTS params JSONB;
+        ALTER TABLE mcp_request_log ADD COLUMN IF NOT EXISTS error_message TEXT;
       `);
     }
   }

--- a/test/e2e/postgres-bootstrap.test.ts
+++ b/test/e2e/postgres-bootstrap.test.ts
@@ -41,7 +41,7 @@ describe.skipIf(skip)('PostgresEngine forward-reference bootstrap (E2E)', () => 
     await engine.disconnect();
   });
 
-  test('PostgresEngine.initSchema applies bootstrap → SCHEMA_SQL → migrations on pre-v0.18 brain', async () => {
+  test('PostgresEngine.initSchema applies bootstrap → SCHEMA_SQL → migrations on downgraded pre-v0.18 / pre-v33 shape', async () => {
     // First call: bring the test DB to LATEST shape so we have something to mutate.
     await engine.initSchema();
 
@@ -52,17 +52,23 @@ describe.skipIf(skip)('PostgresEngine forward-reference bootstrap (E2E)', () => 
     const conn = (engine as any).sql;
     await conn.unsafe(`TRUNCATE pages, content_chunks, links, tags, raw_data, timeline_entries, page_versions, ingest_log RESTART IDENTITY CASCADE`);
 
-    // Mutate to pre-v0.18 shape: drop source_id and the sources table.
-    // The advisory lock is released between initSchema calls, so this
-    // direct DDL won't deadlock.
+    // Mutate to an older shape: drop source_id / sources and also strip the
+    // v0.26.3 request-log columns that the newer embedded schema now indexes.
+    // The advisory lock is released between initSchema calls, so this direct
+    // DDL won't deadlock.
     await conn.unsafe(`
       ALTER TABLE pages DROP CONSTRAINT IF EXISTS pages_source_slug_key;
       ALTER TABLE pages ADD CONSTRAINT pages_slug_key UNIQUE (slug);
       DROP INDEX IF EXISTS idx_pages_source_id;
       ALTER TABLE pages DROP COLUMN IF EXISTS source_id CASCADE;
       DROP TABLE IF EXISTS sources CASCADE;
+
+      DROP INDEX IF EXISTS idx_mcp_log_agent_time;
+      ALTER TABLE mcp_request_log DROP COLUMN IF EXISTS agent_name;
+      ALTER TABLE mcp_request_log DROP COLUMN IF EXISTS params;
+      ALTER TABLE mcp_request_log DROP COLUMN IF EXISTS error_message;
     `);
-    await engine.setConfig('version', '20');
+    await engine.setConfig('version', '29');
 
     // The path under test: full PostgresEngine.initSchema() including the
     // bootstrap call, SCHEMA_SQL replay, and runMigrations chain.
@@ -82,6 +88,15 @@ describe.skipIf(skip)('PostgresEngine forward-reference bootstrap (E2E)', () => 
     // Verify the default source row was seeded.
     const srcCheck = await conn`SELECT id FROM sources WHERE id = 'default'`;
     expect(srcCheck).toHaveLength(1);
+
+    // Verify the v0.26.3 request-log columns exist after upgrade.
+    const logCols = await conn`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_schema = current_schema()
+        AND table_name = 'mcp_request_log'
+        AND column_name IN ('agent_name', 'params', 'error_message')
+    `;
+    expect(logCols).toHaveLength(3);
   });
 
   test('PostgresEngine.initSchema is idempotent on a brain already at LATEST', async () => {

--- a/test/schema-bootstrap-coverage.test.ts
+++ b/test/schema-bootstrap-coverage.test.ts
@@ -63,6 +63,12 @@ const REQUIRED_BOOTSTRAP_COVERAGE: ForwardReference[] = [
   // v0.26.5 — forward-referenced by `CREATE INDEX pages_deleted_at_purge_idx
   // ON pages (deleted_at) WHERE deleted_at IS NOT NULL`.
   { kind: 'column', table: 'pages', column: 'deleted_at' },
+  // v0.26.3 — forward-referenced by `CREATE INDEX idx_mcp_log_agent_time
+  // ON mcp_request_log(agent_name, created_at DESC)` and the newer request-log
+  // insert/update paths.
+  { kind: 'column', table: 'mcp_request_log', column: 'agent_name' },
+  { kind: 'column', table: 'mcp_request_log', column: 'params' },
+  { kind: 'column', table: 'mcp_request_log', column: 'error_message' },
 ];
 
 test('applyForwardReferenceBootstrap covers every forward reference declared in REQUIRED_BOOTSTRAP_COVERAGE', async () => {
@@ -95,6 +101,11 @@ test('applyForwardReferenceBootstrap covers every forward reference declared in 
 
       DROP INDEX IF EXISTS pages_deleted_at_purge_idx;
       ALTER TABLE pages DROP COLUMN IF EXISTS deleted_at;
+
+      DROP INDEX IF EXISTS idx_mcp_log_agent_time;
+      ALTER TABLE mcp_request_log DROP COLUMN IF EXISTS agent_name;
+      ALTER TABLE mcp_request_log DROP COLUMN IF EXISTS params;
+      ALTER TABLE mcp_request_log DROP COLUMN IF EXISTS error_message;
     `);
 
     // Run bootstrap in isolation (NOT initSchema). This is what we're testing.
@@ -150,6 +161,10 @@ test('after bootstrap, PGLITE_SCHEMA_SQL replays without crashing on missing for
       ALTER TABLE links DROP COLUMN IF EXISTS origin_page_id;
       DROP INDEX IF EXISTS pages_deleted_at_purge_idx;
       ALTER TABLE pages DROP COLUMN IF EXISTS deleted_at;
+      DROP INDEX IF EXISTS idx_mcp_log_agent_time;
+      ALTER TABLE mcp_request_log DROP COLUMN IF EXISTS agent_name;
+      ALTER TABLE mcp_request_log DROP COLUMN IF EXISTS params;
+      ALTER TABLE mcp_request_log DROP COLUMN IF EXISTS error_message;
     `);
 
     // Bootstrap, then schema replay. Either step crashing fails the test.


### PR DESCRIPTION
## Summary
- bootstrap legacy `mcp_request_log` columns before schema replay
- cover the gap in both PGLite and Postgres forward-reference bootstrap paths
- add regression coverage so this wedge class is caught in CI

## Repro
On an older brain upgraded to `v0.26.6`, `initSchema()` can fail before migration `v33` runs when `mcp_request_log` already exists but still has the older shape:
- no `agent_name`
- no `params`
- no `error_message`

The embedded schema now references that newer shape during schema replay/index creation, so numbered migrations never get a chance to add the columns.

## Fix
- probe `mcp_request_log` in both engines' `applyForwardReferenceBootstrap()`
- if the table exists and any of the three columns are missing, add them during bootstrap
- leave `v33` responsible for the normal migration/backfill/index work

## Validation
- reproduced on a real local upgrade from `0.22.4` / schema `29` to `0.26.6`
- verified a restored pre-upgrade PGLite backup upgrades cleanly with this patch
- added coverage in:
  - `test/schema-bootstrap-coverage.test.ts`
  - `test/e2e/postgres-bootstrap.test.ts`
- ran:
  - `bun test test/schema-bootstrap-coverage.test.ts test/bootstrap.test.ts test/migrate.test.ts`

Fixes #609.
