### PR TITLE
[codex] Close database engines during CLI signal shutdown

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { operations, OperationError } from './core/operations.ts';
 import type { Operation, OperationContext } from './core/operations.ts';
 import { serializeMarkdown } from './core/markdown.ts';
 import { parseGlobalFlags, setCliOptions, getCliOptions } from './core/cli-options.ts';
+import { installEngineSignalShutdown } from './core/signal-shutdown.ts';
 import { VERSION } from './version.ts';
 
 // Build CLI name -> operation lookup
@@ -78,6 +79,7 @@ async function main() {
   }
 
   const engine = await connectEngine();
+  const uninstallSignalShutdown = installEngineSignalShutdown(engine);
   try {
     const params = parseOpArgs(op, subArgs);
 
@@ -105,6 +107,7 @@ async function main() {
     console.error(e instanceof Error ? e.message : String(e));
     process.exit(1);
   } finally {
+    uninstallSignalShutdown();
     await engine.disconnect();
   }
 }
@@ -399,10 +402,16 @@ async function handleCliOnly(command: string, args: string[]) {
       // "user chose --fast while config is present".
       await runDoctor(null, args, getDbUrlSource());
     } else {
+      let uninstallSignalShutdown: (() => void) | null = null;
       try {
         const eng = await connectEngine();
-        await runDoctor(eng, args);
-        await eng.disconnect();
+        uninstallSignalShutdown = installEngineSignalShutdown(eng);
+        try {
+          await runDoctor(eng, args);
+        } finally {
+          uninstallSignalShutdown();
+          await eng.disconnect();
+        }
       } catch {
         // DB unavailable — still run filesystem checks
         await runDoctor(null, args, getDbUrlSource());
@@ -433,14 +442,17 @@ async function handleCliOnly(command: string, args: string[]) {
     // reports DB phases as skipped when engine is null.
     const { runDream } = await import('./commands/dream.ts');
     let eng: BrainEngine | null = null;
+    let uninstallSignalShutdown: (() => void) | null = null;
     try {
       eng = await connectEngine();
+      uninstallSignalShutdown = installEngineSignalShutdown(eng);
     } catch {
       // DB unavailable — lint + backlinks still run against the brain dir.
     }
     try {
       await runDream(eng, args);
     } finally {
+      uninstallSignalShutdown?.();
       if (eng) await eng.disconnect();
     }
     return;
@@ -448,6 +460,7 @@ async function handleCliOnly(command: string, args: string[]) {
 
   // All remaining CLI-only commands need a DB connection
   const engine = await connectEngine();
+  const uninstallSignalShutdown = installEngineSignalShutdown(engine);
   try {
     switch (command) {
       case 'import': {
@@ -610,6 +623,7 @@ async function handleCliOnly(command: string, args: string[]) {
       }
     }
   } finally {
+    uninstallSignalShutdown();
     if (command !== 'serve') await engine.disconnect();
   }
 }

--- a/src/core/signal-shutdown.ts
+++ b/src/core/signal-shutdown.ts
@@ -1,0 +1,71 @@
+import type { BrainEngine } from './engine.ts';
+
+export type ShutdownSignal = 'SIGINT' | 'SIGTERM';
+
+type SignalProcess = Pick<NodeJS.Process, 'on' | 'removeListener'>;
+
+export interface SignalShutdownOptions {
+  process?: SignalProcess;
+  exit?: (code: number) => never;
+  log?: (message: string) => void;
+}
+
+export function signalExitCode(signal: ShutdownSignal): number {
+  return signal === 'SIGINT' ? 130 : 143;
+}
+
+/**
+ * Install CLI-level signal cleanup for DB-backed commands.
+ *
+ * Plain `finally { engine.disconnect() }` is not enough for SIGTERM/SIGINT:
+ * once a process-level signal handler exists elsewhere (for example progress
+ * reporting), the default process termination path no longer guarantees that
+ * finally blocks run before an external supervisor escalates to SIGKILL.
+ */
+export function installEngineSignalShutdown(
+  engine: Pick<BrainEngine, 'disconnect'>,
+  opts: SignalShutdownOptions = {},
+): () => void {
+  const target = opts.process ?? process;
+  const exit = opts.exit ?? ((code: number): never => process.exit(code));
+  const log = opts.log ?? ((message: string) => console.error(message));
+
+  let shuttingDown = false;
+  let uninstalled = false;
+
+  const uninstall = () => {
+    if (uninstalled) return;
+    uninstalled = true;
+    target.removeListener('SIGINT', onSigint);
+    target.removeListener('SIGTERM', onSigterm);
+  };
+
+  const shutdown = (signal: ShutdownSignal) => {
+    const code = signalExitCode(signal);
+    if (shuttingDown) {
+      exit(code);
+      return;
+    }
+    shuttingDown = true;
+
+    void (async () => {
+      try {
+        await engine.disconnect();
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        log(`[gbrain] ${signal}: engine disconnect failed during shutdown: ${msg}`);
+      } finally {
+        uninstall();
+        exit(code);
+      }
+    })();
+  };
+
+  const onSigint = () => shutdown('SIGINT');
+  const onSigterm = () => shutdown('SIGTERM');
+
+  target.on('SIGINT', onSigint);
+  target.on('SIGTERM', onSigterm);
+
+  return uninstall;
+}

--- a/test/signal-shutdown.test.ts
+++ b/test/signal-shutdown.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import { installEngineSignalShutdown, signalExitCode } from '../src/core/signal-shutdown.ts';
+
+class FakeProcess extends EventEmitter {
+  exitCode: number | null = null;
+
+  exit(code?: number): never {
+    this.exitCode = code ?? 0;
+    return undefined as never;
+  }
+}
+
+describe('signal shutdown', () => {
+  test('maps interrupt and terminate signals to shell-compatible exit codes', () => {
+    expect(signalExitCode('SIGINT')).toBe(130);
+    expect(signalExitCode('SIGTERM')).toBe(143);
+  });
+
+  test('disconnects the engine before exiting on SIGTERM', async () => {
+    const events: string[] = [];
+    const fakeProcess = new FakeProcess();
+    const engine = {
+      async disconnect() {
+        events.push('disconnect');
+      },
+    };
+
+    installEngineSignalShutdown(engine, {
+      process: fakeProcess as unknown as NodeJS.Process,
+      exit: (code) => fakeProcess.exit(code),
+      log: () => {},
+    });
+
+    fakeProcess.emit('SIGTERM');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events).toEqual(['disconnect']);
+    expect(fakeProcess.exitCode).toBe(143);
+  });
+
+  test('SIGINT uses exit code 130 after cleanup', async () => {
+    const fakeProcess = new FakeProcess();
+    const engine = {
+      async disconnect() {},
+    };
+
+    installEngineSignalShutdown(engine, {
+      process: fakeProcess as unknown as NodeJS.Process,
+      exit: (code) => fakeProcess.exit(code),
+      log: () => {},
+    });
+
+    fakeProcess.emit('SIGINT');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fakeProcess.exitCode).toBe(130);
+  });
+});


### PR DESCRIPTION
## Summary

- install CLI-level SIGINT/SIGTERM cleanup for DB-backed commands
- disconnect the active database engine before exiting on external termination
- add regression coverage for signal exit codes and disconnect-before-exit ordering

## Root Cause

`gbrain dream` and `gbrain embed` can run under external timeout supervisors. The progress reporter registers process-level signal handlers, and once a SIGTERM/SIGINT listener exists the runtime no longer follows the default termination path. That can leave the CLI alive after the first timeout signal until a supervisor escalates to a hard kill, bypassing `finally { engine.disconnect() }` and leaving PGLite without a clean close.

## Implementation

This adds a small CLI shutdown helper that installs SIGINT/SIGTERM handlers around DB-backed command execution. On the first signal, it awaits `engine.disconnect()`, unregisters its handlers, and exits with shell-compatible signal codes: 130 for SIGINT and 143 for SIGTERM. Repeated signals while cleanup is in progress exit immediately.

The helper is wired into regular operation dispatch, `dream`, DB-backed CLI-only commands including `embed` and `sync`, and the DB path for `doctor`.

## Validation

- `bun run typecheck`
- `bun test test/signal-shutdown.test.ts test/cli-options.test.ts test/dream.test.ts test/embed.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->