### PR TITLE
v0.29.1 feat: recency boost for search

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -275,6 +275,12 @@ export interface BrainEngine {
    */
   getBacklinkCounts(slugs: string[]): Promise<Map<string, number>>;
   /**
+   * v0.27.0: for a list of slugs, return their updated_at timestamps (or created_at fallback).
+   * Used by hybrid search recency boost. Single SQL query, not N+1.
+   * Slugs with no timestamp get no entry in the map.
+   */
+  getPageTimestamps(slugs: string[]): Promise<Map<string, Date>>;
+  /**
    * Return every page with no inbound links (from any source).
    * Domain comes from the frontmatter `domain` field (null if unset).
    * The caller filters pseudo-pages + derives display domain.

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1193,6 +1193,16 @@ export class PGLiteEngine implements BrainEngine {
     return result;
   }
 
+  async getPageTimestamps(slugs: string[]): Promise<Map<string, Date>> {
+    if (slugs.length === 0) return new Map();
+    const { rows } = await this.db.query(
+      `SELECT slug, COALESCE(updated_at, created_at) as ts
+       FROM pages WHERE slug = ANY($1::text[])`,
+      [slugs]
+    );
+    return new Map(rows.map((r: any) => [r.slug as string, new Date(r.ts as string)]));
+  }
+
   async findOrphanPages(): Promise<Array<{ slug: string; title: string; domain: string | null }>> {
     const { rows } = await this.db.query(
       `SELECT

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -506,6 +506,17 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    // v0.27.0: date filtering support
+    let afterDateClause = '';
+    if (opts?.afterDate) {
+      params.push(opts.afterDate);
+      afterDateClause = `AND COALESCE(p.updated_at, p.created_at) > $${params.length}::timestamptz`;
+    }
+    let beforeDateClause = '';
+    if (opts?.beforeDate) {
+      params.push(opts.beforeDate);
+      beforeDateClause = `AND COALESCE(p.updated_at, p.created_at) < $${params.length}::timestamptz`;
+    }
     params.push(innerLimit);
     const innerLimitParam = `$${params.length}`;
     params.push(limit);
@@ -534,6 +545,8 @@ export class PostgresEngine implements BrainEngine {
           ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
           ${languageClause}
           ${symbolKindClause}
+          ${afterDateClause}
+          ${beforeDateClause}
           ${hardExcludeClause}
           ${visibilityClause}
         ORDER BY score DESC
@@ -615,6 +628,17 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    // v0.27.0: date filtering support
+    let afterDateClause = '';
+    if (opts?.afterDate) {
+      params.push(opts.afterDate);
+      afterDateClause = `AND COALESCE(p.updated_at, p.created_at) > $${params.length}::timestamptz`;
+    }
+    let beforeDateClause = '';
+    if (opts?.beforeDate) {
+      params.push(opts.beforeDate);
+      beforeDateClause = `AND COALESCE(p.updated_at, p.created_at) < $${params.length}::timestamptz`;
+    }
     params.push(limit);
     const limitParam = `$${params.length}`;
     params.push(offset);
@@ -638,6 +662,8 @@ export class PostgresEngine implements BrainEngine {
         ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
         ${languageClause}
         ${symbolKindClause}
+        ${afterDateClause}
+        ${beforeDateClause}
         ${hardExcludeClause}
         ${visibilityClause}
       ORDER BY score DESC
@@ -703,6 +729,17 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    // v0.27.0: date filtering support
+    let afterDateClause = '';
+    if (opts?.afterDate) {
+      params.push(opts.afterDate);
+      afterDateClause = `AND COALESCE(p.updated_at, p.created_at) > $${params.length}::timestamptz`;
+    }
+    let beforeDateClause = '';
+    if (opts?.beforeDate) {
+      params.push(opts.beforeDate);
+      beforeDateClause = `AND COALESCE(p.updated_at, p.created_at) < $${params.length}::timestamptz`;
+    }
     params.push(innerLimit);
     const innerLimitParam = `$${params.length}`;
     params.push(limit);
@@ -731,6 +768,8 @@ export class PostgresEngine implements BrainEngine {
           ${excludeSlugsClause}
           ${languageClause}
           ${symbolKindClause}
+          ${afterDateClause}
+          ${beforeDateClause}
           ${hardExcludeClause}
           ${visibilityClause}
         ORDER BY cc.embedding <=> $1::vector
@@ -1236,6 +1275,16 @@ export class PostgresEngine implements BrainEngine {
       result.set(r.slug, Number(r.cnt));
     }
     return result;
+  }
+
+  async getPageTimestamps(slugs: string[]): Promise<Map<string, Date>> {
+    if (slugs.length === 0) return new Map();
+    const sql = this.sql;
+    const rows = await sql`
+      SELECT slug, COALESCE(updated_at, created_at) as ts
+      FROM pages WHERE slug = ANY(${slugs}::text[])
+    `;
+    return new Map(rows.map(r => [r.slug as string, new Date(r.ts as string)]));
   }
 
   async findOrphanPages(): Promise<Array<{ slug: string; title: string; domain: string | null }>> {

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -16,6 +16,7 @@ import { embed } from '../embedding.ts';
 import { dedupResults } from './dedup.ts';
 import { autoDetectDetail } from './intent.ts';
 import { expandAnchors, hydrateChunks } from './two-pass.ts';
+import { applyRecencyBoost } from './recency.ts';
 
 const RRF_K = 60;
 const COMPILED_TRUTH_BOOST = 2.0;
@@ -228,6 +229,23 @@ export async function hybridSearch(
     } catch {
       // Expansion is best-effort — missing edge tables or a transient
       // DB error must not break base hybrid retrieval.
+    }
+  }
+
+  // v0.27.0: recency boost — applied after backlink boost, before dedup.
+  // Auto-enabled when intent is temporal/event (detail='high'), or when
+  // opts.recencyBoost is explicitly set. Strength 1 = moderate (30-day
+  // halflife), 2 = aggressive (7-day halflife). Connection to intent.ts:
+  // temporal/event queries → detail='high' → recencyStrength=1 here.
+  const recencyStrength = opts?.recencyBoost ?? (detail === 'high' ? 1 : 0);
+  if (recencyStrength > 0 && fused.length > 0) {
+    try {
+      const recencySlugs = Array.from(new Set(fused.map(r => r.slug)));
+      const timestamps = await engine.getPageTimestamps(recencySlugs);
+      applyRecencyBoost(fused, timestamps, recencyStrength as 1 | 2);
+      fused.sort((a, b) => b.score - a.score);
+    } catch {
+      // Recency boost failure is non-fatal: keep existing ranking.
     }
   }
 

--- a/src/core/search/recency.ts
+++ b/src/core/search/recency.ts
@@ -1,0 +1,68 @@
+/**
+ * Recency Boost for Search Results (v0.27.0)
+ *
+ * Applies a time-decay boost to search results so newer pages rank higher.
+ * Uses a hyperbolic decay curve — recent pages get a meaningful boost,
+ * but old pages aren't completely buried.
+ *
+ * Boost formula: score *= (1 + coefficient / (1 + days_old / halflife))
+ *
+ * At halflife days old, the boost is halved.
+ * strength=1: halflife=30 days, coefficient=1.0 (moderate — temporal queries)
+ * strength=2: halflife=7 days, coefficient=1.5 (aggressive — "what's new" queries)
+ *
+ * Brand-new page at strength=1: factor = 1 + 1.0 / (1 + 0/30) = 2.0x
+ * 30-day-old page at strength=1: factor = 1 + 1.0 / (1 + 1) = 1.5x
+ * 365-day-old page at strength=1: factor = 1 + 1.0 / (1 + 12.17) = ~1.076x
+ *
+ * Brand-new page at strength=2: factor = 1 + 1.5 / (1 + 0/7) = 2.5x
+ * 7-day-old page at strength=2: factor = 1 + 1.5 / (1 + 1) = 1.75x
+ * 365-day-old page at strength=2: factor = 1 + 1.5 / (1 + 52.14) = ~1.028x
+ *
+ * Same contract as applyBacklinkBoost: mutates results in place, caller re-sorts.
+ */
+
+import type { SearchResult } from '../types.ts';
+
+const DEBUG = process.env.GBRAIN_SEARCH_DEBUG === '1';
+
+interface RecencyConfig {
+  halflifeDays: number;
+  coefficient: number;
+}
+
+const STRENGTH_CONFIG: Record<1 | 2, RecencyConfig> = {
+  1: { halflifeDays: 30, coefficient: 1.0 },
+  2: { halflifeDays: 7, coefficient: 1.5 },
+};
+
+/**
+ * Apply recency boost to a result list in place. Mutates each result's score
+ * by (1 + coefficient / (1 + days_old / halflife)). Pure data transform; no DB call.
+ * Caller fetches timestamps via engine.getPageTimestamps.
+ */
+export function applyRecencyBoost(
+  results: SearchResult[],
+  pageTimestamps: Map<string, Date>,
+  strength: 1 | 2,
+): void {
+  const config = STRENGTH_CONFIG[strength];
+  const now = Date.now();
+
+  for (const r of results) {
+    const ts = pageTimestamps.get(r.slug);
+    if (!ts) continue; // no timestamp → no boost (factor = 1.0)
+
+    const msOld = now - ts.getTime();
+    const daysOld = Math.max(0, msOld / (1000 * 60 * 60 * 24));
+    const factor = 1.0 + config.coefficient / (1.0 + daysOld / config.halflifeDays);
+
+    if (DEBUG) {
+      console.error(
+        `[search-debug] recency: ${r.slug} days_old=${daysOld.toFixed(1)} factor=${factor.toFixed(4)} strength=${strength} score=${r.score.toFixed(4)}→${(r.score * factor).toFixed(4)}`,
+      );
+    }
+
+    r.score *= factor;
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -208,6 +208,12 @@ export interface SearchOpts {
    * undefined to search all sources.
    */
   sourceId?: string;
+  /** v0.27.0: filter results to pages updated/created after this date. ISO-8601 string. */
+  afterDate?: string;
+  /** v0.27.0: filter results to pages updated/created before this date. ISO-8601 string. */
+  beforeDate?: string;
+  /** v0.27.0: recency boost strength. 0 = off, 1 = moderate, 2 = aggressive. Default: auto-detected from intent. */
+  recencyBoost?: 0 | 1 | 2;
 }
 
 /**

--- a/test/recency-boost.test.ts
+++ b/test/recency-boost.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'bun:test';
+import { applyRecencyBoost } from '../src/core/search/recency.ts';
+import type { SearchResult } from '../src/core/types.ts';
+
+function makeResult(slug: string, score: number): SearchResult {
+  return {
+    slug,
+    page_id: 1,
+    title: slug,
+    type: 'concept' as any,
+    chunk_text: 'test',
+    chunk_source: 'compiled_truth',
+    chunk_id: 1,
+    chunk_index: 0,
+    score,
+    stale: false,
+  };
+}
+
+function daysAgo(days: number): Date {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+describe('applyRecencyBoost', () => {
+  it('brand-new page gets max boost at strength=1 (~2.0x)', () => {
+    const results = [makeResult('new-page', 1.0)];
+    const timestamps = new Map([['new-page', new Date()]]);
+    applyRecencyBoost(results, timestamps, 1);
+    // factor = 1 + 1.0 / (1 + 0/30) = 2.0
+    expect(results[0].score).toBeCloseTo(2.0, 1);
+  });
+
+  it('brand-new page gets max boost at strength=2 (~2.5x)', () => {
+    const results = [makeResult('new-page', 1.0)];
+    const timestamps = new Map([['new-page', new Date()]]);
+    applyRecencyBoost(results, timestamps, 2);
+    // factor = 1 + 1.5 / (1 + 0/7) = 2.5
+    expect(results[0].score).toBeCloseTo(2.5, 1);
+  });
+
+  it('30-day-old page gets ~half boost at strength=1 (~1.5x)', () => {
+    const results = [makeResult('old-page', 1.0)];
+    const timestamps = new Map([['old-page', daysAgo(30)]]);
+    applyRecencyBoost(results, timestamps, 1);
+    // factor = 1 + 1.0 / (1 + 30/30) = 1 + 1/2 = 1.5
+    expect(results[0].score).toBeCloseTo(1.5, 1);
+  });
+
+  it('365-day-old page gets minimal boost at strength=1', () => {
+    const results = [makeResult('ancient', 1.0)];
+    const timestamps = new Map([['ancient', daysAgo(365)]]);
+    applyRecencyBoost(results, timestamps, 1);
+    // factor = 1 + 1.0 / (1 + 365/30) ≈ 1.076
+    expect(results[0].score).toBeGreaterThan(1.0);
+    expect(results[0].score).toBeLessThan(1.1);
+  });
+
+  it('strength=2 decays faster than strength=1', () => {
+    const r1 = [makeResult('page', 1.0)];
+    const r2 = [makeResult('page', 1.0)];
+    const timestamps = new Map([['page', daysAgo(14)]]);
+    applyRecencyBoost(r1, timestamps, 1);
+    applyRecencyBoost(r2, timestamps, 2);
+    // At 14 days: strength=1 factor = 1 + 1/(1+14/30) ≈ 1.68
+    // At 14 days: strength=2 factor = 1 + 1.5/(1+14/7) = 1 + 1.5/3 = 1.5
+    // strength=2 has already decayed more at 14 days
+    expect(r1[0].score).toBeGreaterThan(r2[0].score);
+  });
+
+  it('page with no timestamp gets no boost (score unchanged)', () => {
+    const results = [makeResult('no-ts', 0.75)];
+    const timestamps = new Map<string, Date>(); // empty
+    applyRecencyBoost(results, timestamps, 1);
+    expect(results[0].score).toBe(0.75);
+  });
+
+  it('empty results array is a no-op', () => {
+    const results: SearchResult[] = [];
+    const timestamps = new Map<string, Date>();
+    applyRecencyBoost(results, timestamps, 1);
+    expect(results).toHaveLength(0);
+  });
+
+  it('mutates results in place (same contract as backlink boost)', () => {
+    const result = makeResult('test', 1.0);
+    const results = [result];
+    const timestamps = new Map([['test', new Date()]]);
+    applyRecencyBoost(results, timestamps, 1);
+    // Same object reference, mutated score
+    expect(results[0]).toBe(result);
+    expect(result.score).toBeGreaterThan(1.0);
+  });
+
+  it('multiple results get independent boosts', () => {
+    const results = [
+      makeResult('new', 1.0),
+      makeResult('medium', 1.0),
+      makeResult('old', 1.0),
+    ];
+    const timestamps = new Map<string, Date>([
+      ['new', daysAgo(0)],
+      ['medium', daysAgo(30)],
+      ['old', daysAgo(365)],
+    ]);
+    applyRecencyBoost(results, timestamps, 1);
+    expect(results[0].score).toBeGreaterThan(results[1].score);
+    expect(results[1].score).toBeGreaterThan(results[2].score);
+  });
+});
+
+// Intent detection tests (recency is auto-triggered by temporal intent)
+import { classifyQueryIntent } from '../src/core/search/intent.ts';
+
+describe('intent classification → recency triggering', () => {
+  it('"what\'s new with Ollama" → temporal (triggers recency)', () => {
+    expect(classifyQueryIntent("what's new with Ollama")).toBe('temporal');
+  });
+
+  it('"recent updates on X" → temporal (triggers recency)', () => {
+    expect(classifyQueryIntent('recent updates on X')).toBe('temporal');
+  });
+
+  it('"latest on YC Labs" → temporal (triggers recency)', () => {
+    expect(classifyQueryIntent('latest on YC Labs')).toBe('temporal');
+  });
+
+  it('"who is Garry Tan" → entity (no recency)', () => {
+    expect(classifyQueryIntent('who is Garry Tan')).toBe('entity');
+  });
+
+  it('"tell me about Ollama" → entity (no recency)', () => {
+    expect(classifyQueryIntent('tell me about Ollama')).toBe('entity');
+  });
+
+  it('"Ollama" (bare name) → general (no recency)', () => {
+    expect(classifyQueryIntent('Ollama')).toBe('general');
+  });
+});


### PR DESCRIPTION
Adds temporal recency boost to hybrid search.

New pipeline stage: keyword + vector → RRF → cosine re-score → backlink boost → **recency boost** → dedup

**Why:** GBrain search has no temporal weighting. A page from 2024 scores the same as one from yesterday. Tip from Pradeep (Jo W24): having data indexed by date gets you super freaking far.

**How:**
- `applyRecencyBoost` (hyperbolic decay, 30-day or 7-day halflife)
- Auto-detection: temporal queries trigger recency boost automatically
- Date filters (`afterDate`/`beforeDate`) on all three search paths
- `getPageTimestamps` on both Postgres and PGLite engines
- 15 tests passing, zero regressions, clean typecheck

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->