### PR TITLE
fix: return clean auth failures for invalid MCP bearer tokens

### DIFF
--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -22,6 +22,7 @@ import type {
 import type { OAuthServerProvider, AuthorizationParams } from '@modelcontextprotocol/sdk/server/auth/provider.js';
 import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { hashToken, generateToken, isUndefinedColumnError } from './utils.ts';
 
 // ---------------------------------------------------------------------------
@@ -395,7 +396,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
       // throw here rather than return an undefined-bearing AuthInfo.
       const expiresAt = coerceTimestamp(row.expires_at);
       if (expiresAt === undefined || expiresAt < now) {
-        throw new Error('Token expired');
+        throw new InvalidTokenError('Token expired');
       }
       return {
         token,
@@ -430,7 +431,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
       } as AuthInfo;
     }
 
-    throw new Error('Invalid token');
+    throw new InvalidTokenError('Invalid token');
   }
 
   // -------------------------------------------------------------------------

--- a/test/e2e/serve-http-oauth.test.ts
+++ b/test/e2e/serve-http-oauth.test.ts
@@ -171,11 +171,12 @@ describeE2E('serve-http OAuth 2.1 E2E (v0.26.1 + v0.26.2 + v0.26.3)', () => {
 
   test('expired/invalid token is rejected at /mcp', async () => {
     const res = await mcpCall('gbrain_at_totally_fake_token', 'tools/list');
-    // Invalid tokens should not return 200 with tool results
     const body = await res.text();
+    // Invalid bearer tokens must be clean auth failures, not 500s. The MCP
+    // SDK maps InvalidTokenError to 401 with the OAuth error payload.
+    expect(res.status).toBe(401);
     expect(body).not.toContain('"tools"');
-    // Should be an error status (401, 403, or 500 depending on SDK error mapping)
-    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(body).toContain('invalid_token');
   });
 
   test('missing Authorization header returns 401', async () => {

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { PGlite } from '@electric-sql/pglite';
 import { vector } from '@electric-sql/pglite/vector';
 import { pg_trgm } from '@electric-sql/pglite/contrib/pg_trgm';
+import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { GBrainOAuthProvider, coerceTimestamp } from '../src/core/oauth-provider.ts';
 import { hashToken, generateToken } from '../src/core/utils.ts';
 import { PGLITE_SCHEMA_SQL } from '../src/core/pglite-schema.ts';
@@ -210,11 +211,11 @@ describe('verifyAccessToken', () => {
       INSERT INTO oauth_tokens (token_hash, token_type, client_id, scopes, expires_at)
       VALUES (${hash}, ${'access'}, ${firstClient.client_id as string}, ${'{read}'}, ${Math.floor(Date.now() / 1000) - 100})
     `;
-    await expect(provider.verifyAccessToken(expiredToken)).rejects.toThrow('expired');
+    await expect(provider.verifyAccessToken(expiredToken)).rejects.toThrow(InvalidTokenError);
   });
 
   test('unknown token is rejected', async () => {
-    await expect(provider.verifyAccessToken('nonexistent-token')).rejects.toThrow('Invalid token');
+    await expect(provider.verifyAccessToken('nonexistent-token')).rejects.toThrow(InvalidTokenError);
   });
 
   test('NULL expires_at is treated as expired (fail-closed)', async () => {
@@ -228,7 +229,7 @@ describe('verifyAccessToken', () => {
       INSERT INTO oauth_tokens (token_hash, token_type, client_id, scopes, expires_at)
       VALUES (${hash}, ${'access'}, ${firstClient.client_id as string}, ${'{read}'}, ${null})
     `;
-    await expect(provider.verifyAccessToken(nullExpiryToken)).rejects.toThrow('expired');
+    await expect(provider.verifyAccessToken(nullExpiryToken)).rejects.toThrow(InvalidTokenError);
   });
 
   test('cascade-deleted client invalidates its tokens (Invalid token, not Expired)', async () => {


### PR DESCRIPTION
## Summary
- throw MCP SDK InvalidTokenError for expired and unknown OAuth bearer tokens
- tighten the HTTP OAuth E2E expectation so invalid /mcp bearer tokens must return a clean 401 invalid_token response, not 500
- add PGLite unit coverage that verifyAccessToken rejects invalid/expired tokens with InvalidTokenError

Closes #616.

## Verification
- bun run typecheck
- bun test test/oauth.test.ts
- bun test test/e2e/serve-http-oauth.test.ts (skips without DATABASE_URL)

Note: this avoids changing GBrain auth semantics in downstream AStack wrappers; the fix aligns the provider with the MCP SDK bearerAuth error contract.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->