### PR TITLE
Normalize fs extraction slugs to sync/import format

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -28,6 +28,7 @@ import {
 } from '../core/link-extraction.ts';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
+import { slugifyPath } from '../core/sync.ts';
 
 // Batch size for addLinksBatch / addTimelineEntriesBatch.
 // Postgres bind-parameter limit is 65535. Links use 4 cols/row → 16K hard ceiling;
@@ -135,13 +136,13 @@ export function extractMarkdownLinks(content: string): { name: string; relTarget
 export function resolveSlug(fileDir: string, relTarget: string, allSlugs: Set<string>): string | null {
   const targetNoExt = relTarget.endsWith('.md') ? relTarget.slice(0, -3) : relTarget;
 
-  const s1 = join(fileDir, targetNoExt);
+  const s1 = slugifyPath(join(fileDir, targetNoExt));
   if (allSlugs.has(s1)) return s1;
 
   const parts = fileDir.split('/').filter(Boolean);
   for (let strip = 1; strip <= parts.length; strip++) {
     const ancestor = parts.slice(0, parts.length - strip).join('/');
-    const candidate = ancestor ? join(ancestor, targetNoExt) : targetNoExt;
+    const candidate = slugifyPath(ancestor ? join(ancestor, targetNoExt) : targetNoExt);
     if (allSlugs.has(candidate)) return candidate;
   }
 
@@ -197,8 +198,8 @@ export async function extractLinksFromFile(
   opts?: { includeFrontmatter?: boolean },
 ): Promise<ExtractedLink[]> {
   const links: ExtractedLink[] = [];
-  const slug = relPath.replace('.md', '');
-  const fileDir = dirname(relPath);
+  const slug = slugifyPath(relPath);
+  const fileDir = dirname(slug);
   const fm = parseFrontmatterFromContent(content, relPath);
 
   for (const { name, relTarget } of extractMarkdownLinks(content)) {
@@ -453,7 +454,7 @@ async function extractForSlugs(
 ): Promise<{ links_created: number; timeline_created: number; pages: number }> {
   // Build the full slug set for link resolution (fast: just readdir, no file reads)
   const allFiles = walkMarkdownFiles(brainDir);
-  const allSlugs = new Set(allFiles.map(f => f.relPath.replace('.md', '')));
+  const allSlugs = new Set(allFiles.map(f => slugifyPath(f.relPath)));
 
   const doLinks = mode === 'links' || mode === 'all';
   const doTimeline = mode === 'timeline' || mode === 'all';
@@ -549,7 +550,7 @@ async function extractLinksFromDir(
   engine: BrainEngine, brainDir: string, dryRun: boolean, jsonMode: boolean,
 ): Promise<{ created: number; pages: number }> {
   const files = walkMarkdownFiles(brainDir);
-  const allSlugs = new Set(files.map(f => f.relPath.replace('.md', '')));
+  const allSlugs = new Set(files.map(f => slugifyPath(f.relPath)));
 
   // Progress stream on stderr (separate from the action-events --json writes
   // to stdout, which tests grep for). Rate-gated; respects global --quiet /
@@ -640,7 +641,7 @@ async function extractTimelineFromDir(
   for (let i = 0; i < files.length; i++) {
     try {
       const content = readFileSync(files[i].path, 'utf-8');
-      const slug = files[i].relPath.replace('.md', '');
+      const slug = slugifyPath(files[i].relPath);
       for (const entry of extractTimelineFromContent(content, slug)) {
         if (dryRunSeen) {
           const key = `${entry.slug}::${entry.date}::${entry.summary}`;
@@ -670,7 +671,7 @@ async function extractTimelineFromDir(
 
 export async function extractLinksForSlugs(engine: BrainEngine, repoPath: string, slugs: string[]): Promise<number> {
   const allFiles = walkMarkdownFiles(repoPath);
-  const allSlugs = new Set(allFiles.map(f => f.relPath.replace('.md', '')));
+  const allSlugs = new Set(allFiles.map(f => slugifyPath(f.relPath)));
   let created = 0;
   for (const slug of slugs) {
     const filePath = join(repoPath, slug + '.md');

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -49,6 +49,14 @@ describe('extractLinksFromFile', () => {
     expect(links).toHaveLength(0);
   });
 
+  it('normalizes filesystem-style relpaths to imported slugs', async () => {
+    const content = 'See [TaskPilot](../03 Projects/TaskPilot/TaskPilot.md) and [Team](Team.md).';
+    const allSlugs = new Set(['01-maps/home', '01-maps/team', '03-projects/taskpilot/taskpilot']);
+    const links = await extractLinksFromFile(content, '01 Maps/Home.md', allSlugs);
+    expect(links.map(l => l.from_slug)).toEqual(['01-maps/home', '01-maps/home']);
+    expect(links.map(l => l.to_slug)).toEqual(['03-projects/taskpilot/taskpilot', '01-maps/team']);
+  });
+
   it('extracts frontmatter company links (v0.13, includeFrontmatter opt-in)', async () => {
     const content = '---\ncompany: brex\ntype: person\n---\nContent.';
     // v0.13 canonical: person page with company: X → person → company works_at (outgoing).


### PR DESCRIPTION
Title: Normalize fs extraction slugs to sync/import format

Summary:
- Fix fs link extraction so it slugifies repo-relative file paths with the same `slugifyPath()` logic used by sync/import.
- This closes the mismatch where fs extraction found candidate links but persisted zero rows because candidates used raw file paths like `03 Projects/...` while DB pages were stored as normalized slugs like `03-projects/...`.
- Add a regression test covering filesystem-style relpaths with spaces/caps resolving to normalized imported slugs.

Change:
- `src/commands/extract.ts`
  - import `slugifyPath` from `src/core/sync.ts`
  - normalize `resolveSlug()` candidates via `slugifyPath()`
  - normalize fs-source `from_slug` generation in `extractLinksFromFile()`
  - normalize fs-source `allSlugs` sets in full and incremental extraction paths
  - normalize fs timeline slug generation for consistency in fs paths touched here
- `test/extract.test.ts`
  - add regression test: `01 Maps/Home.md` with links to `../03 Projects/TaskPilot/TaskPilot.md` and `Team.md` resolves to `03-projects/taskpilot/taskpilot` and `01-maps/team`

Why this matters:
- Before patch:
  - `gbrain extract links --source fs --dir ~/sliday-brain --dry-run` showed many candidate edges
  - actual `gbrain extract links --source fs --dir ~/sliday-brain` created `0` links
  - root cause: `addLinksBatch` joins on DB slugs, but fs extractor emitted raw relpaths
- After patch:
  - fs extraction populated the graph successfully on a live brain (`Links: 327`)
  - orphan count dropped from `124` to `55`

Validation:
- `bun test test/extract.test.ts`
- `bun src/cli.ts sync --repo /home/stas/sliday-brain`
- `bun src/cli.ts extract links --source fs --dir /home/stas/sliday-brain`
- `bun src/cli.ts stats`
- `bun src/cli.ts orphans --count`

Observed live result after patch:
- `Links: 327`
- `orphans: 55`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->