### PR TITLE
feat(exports): export ./mcp/tool-defs for downstream consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "./backoff": "./src/core/backoff.ts",
     "./search/hybrid": "./src/core/search/hybrid.ts",
     "./search/expansion": "./src/core/search/expansion.ts",
-    "./extract": "./src/commands/extract.ts"
+    "./extract": "./src/commands/extract.ts",
+    "./mcp/tool-defs": "./src/mcp/tool-defs.ts"
   },
   "scripts": {
     "dev": "bun run src/cli.ts",

--- a/test/public-exports.test.ts
+++ b/test/public-exports.test.ts
@@ -50,6 +50,7 @@ const EXPECTED_EXPORTS: ExpectedExport[] = [
   { subpath: 'gbrain/search/hybrid', canary: ['hybridSearch', 'rrfFusion'] },
   { subpath: 'gbrain/search/expansion', canary: ['expandQuery'] },
   { subpath: 'gbrain/extract', canary: [] },
+  { subpath: 'gbrain/mcp/tool-defs', canary: ['buildToolDefs'] },
 ];
 
 function readPackageExports(): Record<string, string> {
@@ -65,7 +66,7 @@ describe('public exports — package.json exports map', () => {
     // Adding new exports: increment this + add to EXPECTED_EXPORTS below.
     // Removing exports: see CLAUDE.md "Removing any of these is a
     // breaking change going forward" — bump minor and update this count.
-    expect(count).toBe(17);
+    expect(count).toBe(18);
   });
 
   test('EXPECTED_EXPORTS list matches the exports map exactly (no drift)', () => {


### PR DESCRIPTION
## What

Adds `./mcp/tool-defs` to the `package.json` exports map, making `buildToolDefs(ops)` and the `McpToolDef` type importable from outside the package. Extends `test/public-exports.test.ts` with a canary symbol and bumps the locked count 17 → 18.

## Why

Downstream consumers that import from `gbrain/operations` to compose their own MCP surface need the same schema-derivation helper that `src/mcp/server.ts` and `src/mcp/dispatch.ts` already use internally. Today `tool-defs.ts` is reachable only by reaching past the exports map, which forces consumers to either copy `buildToolDefs` (drift risk every gbrain release) or import via `gbrain/src/mcp/tool-defs` (relies on the package layout, not stable).

Exporting it makes the consumer use case first-class without any behavior change.

## Use case (concrete)

We're building a multi-tenant governance layer that wraps gbrain. Per our project's ADR, gbrain stays untouched as a library dependency; our layer adds spaces, agent identity, approvals, and audit. Our HTTP/MCP server imports from `gbrain/operations` and assembles its own tool surface, and we'd like to reuse `buildToolDefs` so the schemas track gbrain's exact shape across upgrades instead of going stale on a copy.

## Scope

- One subpath added to the `exports` map (mirrors the pattern of `./engine`, `./operations`, `./search/hybrid`, etc.)
- One entry added to `EXPECTED_EXPORTS` with `buildToolDefs` as the canary (per the contract test's "to add a new public export, extend EXPECTED_EXPORTS" comment)
- Locked count bumped 17 → 18
- No code changes to `tool-defs.ts` itself
- No behavior changes for existing consumers

Per `CLAUDE.md`'s "Removing any of these is a breaking change going forward" — this is purely additive, so it's a minor-bump-safe addition.

## Test

`bun test test/public-exports.test.ts` — covers the new subpath via the same package-name resolution pattern as the other 17 entries.

Happy to adjust scope or messaging. Thanks for considering.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->