### PR TITLE
fix: embed stale chunks by page identity

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -324,13 +324,13 @@ async function embedAll(
 
 /**
  * SQL-side stale path: replaces the listPages + per-page getChunks
- * walk with a count + slug-grouped SELECT. Preserves the existing
+ * walk with a count + page-scoped SELECT. Preserves the existing
  * functional contract (every chunk where embedding IS NULL gets
  * embedded; nothing else is touched) without paying egress on
  * already-embedded chunks.
  *
  * Why a separate function: the staleOnly path doesn't need
- * listPages at all and groups by slug differently. Forking the
+ * listPages at all and groups by source-scoped page identity differently. Forking the
  * function makes the read-bytes path explicit and keeps the --all
  * path verbatim from prior behavior.
  *
@@ -360,15 +360,18 @@ async function embedAllStale(
 
   // Pull only the stale chunks (no embedding column).
   const staleRows = await engine.listStaleChunks();
-  // Group by slug so each slug → array of stale chunks for batched embedding.
-  const bySlug = new Map<string, typeof staleRows>();
+  // Group by source-scoped page identity. Slugs are unique only within a
+  // source_id, so grouping by slug alone can merge chunks from different
+  // pages and send duplicate chunk_index rows into one upsert.
+  const byPage = new Map<string, typeof staleRows>();
   for (const row of staleRows) {
-    const list = bySlug.get(row.slug);
+    const key = row.page_id != null ? `page:${row.page_id}` : `slug:${row.slug}`;
+    const list = byPage.get(key);
     if (list) list.push(row);
-    else bySlug.set(row.slug, [row]);
+    else byPage.set(key, [row]);
   }
 
-  const slugs = Array.from(bySlug.keys());
+  const groups = Array.from(byPage.values());
   const totalStaleChunks = staleRows.length;
   result.total_chunks += totalStaleChunks;
   // skipped is "chunks we considered and skipped due to having an embedding".
@@ -378,30 +381,33 @@ async function embedAllStale(
 
   if (dryRun) {
     result.would_embed += totalStaleChunks;
-    result.pages_processed += slugs.length;
+    result.pages_processed += groups.length;
     if (onProgress) {
       // Emit a single tick to satisfy the contract (CLI progress reporters
       // expect at least one start/finish pair).
-      onProgress(slugs.length, slugs.length, 0);
+      onProgress(groups.length, groups.length, 0);
     }
-    console.log(`[dry-run] Would embed ${totalStaleChunks} chunks across ${slugs.length} pages`);
+    console.log(`[dry-run] Would embed ${totalStaleChunks} chunks across ${groups.length} pages`);
     return;
   }
 
   const CONCURRENCY = parseInt(process.env.GBRAIN_EMBED_CONCURRENCY || '20', 10);
   let processed = 0;
 
-  async function embedOneSlug(slug: string) {
-    const stale = bySlug.get(slug)!;
+  async function embedOneGroup(stale: typeof staleRows) {
+    const first = stale[0];
+    const slug = first.slug;
     try {
       const embeddings = await embedBatch(stale.map(c => c.chunk_text));
       // CRITICAL: passing ONLY the stale indices to upsertChunks would
       // delete every non-stale chunk on the same page (the != ALL filter
       // wipes any chunk_index NOT in the input). To preserve them, we
       // re-fetch existing chunks for this page and merge. Bounded by the
-      // stale slug count, not by total slugs — autopilot common case
+      // stale page count, not by total pages — autopilot common case
       // is 0 stale (pre-flight short-circuit, never reaches this path).
-      const existing = await engine.getChunks(slug);
+      const existing = first.page_id != null
+        ? await engine.getChunksByPageId(first.page_id)
+        : await engine.getChunks(slug);
       const staleIdxToEmbedding = new Map<number, Float32Array>();
       for (let j = 0; j < stale.length; j++) {
         staleIdxToEmbedding.set(stale[j].chunk_index, embeddings[j]);
@@ -415,26 +421,30 @@ async function embedAllStale(
         embedding: staleIdxToEmbedding.get(c.chunk_index) ?? undefined,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
-      await engine.upsertChunks(slug, merged);
+      if (first.page_id != null) {
+        await engine.upsertChunksByPageId(first.page_id, merged);
+      } else {
+        await engine.upsertChunks(slug, merged);
+      }
       result.embedded += stale.length;
     } catch (e: unknown) {
       console.error(`\n  Error embedding ${slug}: ${e instanceof Error ? e.message : e}`);
     }
     processed++;
     result.pages_processed++;
-    onProgress?.(processed, slugs.length, result.embedded);
+    onProgress?.(processed, groups.length, result.embedded);
   }
 
   let nextIdx = 0;
   async function worker() {
-    while (nextIdx < slugs.length) {
+    while (nextIdx < groups.length) {
       const idx = nextIdx++;
-      await embedOneSlug(slugs[idx]);
+      await embedOneGroup(groups[idx]);
     }
   }
 
-  const numWorkers = Math.min(CONCURRENCY, slugs.length);
+  const numWorkers = Math.min(CONCURRENCY, groups.length);
   await Promise.all(Array.from({ length: numWorkers }, () => worker()));
 
-  console.log(`Embedded ${result.embedded} chunks across ${slugs.length} pages`);
+  console.log(`Embedded ${result.embedded} chunks across ${groups.length} pages`);
 }

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -365,7 +365,9 @@ async function embedAllStale(
   // pages and send duplicate chunk_index rows into one upsert.
   const byPage = new Map<string, typeof staleRows>();
   for (const row of staleRows) {
-    const key = row.page_id != null ? `page:${row.page_id}` : `slug:${row.slug}`;
+    const key = row.page_id != null
+      ? `page:${row.page_id}`
+      : `source:${row.source_id ?? 'unknown'}:slug:${row.slug}`;
     const list = byPage.get(key);
     if (list) list.push(row);
     else byPage.set(key, [row]);

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -186,18 +186,20 @@ export interface BrainEngine {
 
   // Chunks
   upsertChunks(slug: string, chunks: ChunkInput[]): Promise<void>;
+  upsertChunksByPageId(pageId: number, chunks: ChunkInput[]): Promise<void>;
   getChunks(slug: string): Promise<Chunk[]>;
+  getChunksByPageId(pageId: number): Promise<Chunk[]>;
   /**
-   * Count chunks across the entire brain where embedded_at IS NULL.
+   * Count chunks across the entire brain where embedding IS NULL.
    * Pre-flight short-circuit for `embed --stale` so a 100%-embedded brain
    * does no further work after a single SELECT count(*) (~50 bytes wire).
    */
   countStaleChunks(): Promise<number>;
   /**
-   * Return every chunk where embedded_at IS NULL, with the metadata needed
-   * to call embedBatch + upsertChunks. The `embedding` column is omitted
+   * Return every chunk where embedding IS NULL, with the metadata needed
+   * to call embedBatch + page-scoped upsert. The `embedding` column is omitted
    * by design — stale rows have NULL embeddings, so shipping them wastes
-   * wire bytes for no gain. Caller groups by slug, embeds, and re-upserts.
+   * wire bytes for no gain.
    *
    * Bounded by an internal LIMIT of 100000 to mirror listPages.
    */

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -753,7 +753,10 @@ export class PGLiteEngine implements BrainEngine {
     const pageResult = await this.db.query('SELECT id FROM pages WHERE slug = $1', [slug]);
     if (pageResult.rows.length === 0) throw new Error(`Page not found: ${slug}`);
     const pageId = (pageResult.rows[0] as { id: number }).id;
+    await this.upsertChunksByPageId(Number(pageId), chunks);
+  }
 
+  async upsertChunksByPageId(pageId: number, chunks: ChunkInput[]): Promise<void> {
     // Remove chunks that no longer exist
     const newIndices = chunks.map(c => c.chunk_index);
     if (newIndices.length > 0) {
@@ -846,6 +849,16 @@ export class PGLiteEngine implements BrainEngine {
     return (rows as Record<string, unknown>[]).map(r => rowToChunk(r));
   }
 
+  async getChunksByPageId(pageId: number): Promise<Chunk[]> {
+    const { rows } = await this.db.query(
+      `SELECT cc.* FROM content_chunks cc
+       WHERE cc.page_id = $1
+       ORDER BY cc.chunk_index`,
+      [pageId]
+    );
+    return (rows as Record<string, unknown>[]).map(r => rowToChunk(r));
+  }
+
   async countStaleChunks(): Promise<number> {
     const { rows } = await this.db.query(
       `SELECT count(*)::int AS count
@@ -858,7 +871,8 @@ export class PGLiteEngine implements BrainEngine {
 
   async listStaleChunks(): Promise<StaleChunkRow[]> {
     const { rows } = await this.db.query(
-      `SELECT p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+      `SELECT p.id AS page_id, p.source_id, p.slug,
+              cc.chunk_index, cc.chunk_text, cc.chunk_source,
               cc.model, cc.token_count
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -786,7 +786,11 @@ export class PostgresEngine implements BrainEngine {
     const pages = await sql`SELECT id FROM pages WHERE slug = ${slug}`;
     if (pages.length === 0) throw new Error(`Page not found: ${slug}`);
     const pageId = pages[0].id;
+    await this.upsertChunksByPageId(Number(pageId), chunks);
+  }
 
+  async upsertChunksByPageId(pageId: number, chunks: ChunkInput[]): Promise<void> {
+    const sql = this.sql;
     // Remove chunks that no longer exist (chunk_index beyond new count)
     const newIndices = chunks.map(c => c.chunk_index);
     if (newIndices.length > 0) {
@@ -879,6 +883,16 @@ export class PostgresEngine implements BrainEngine {
     return rows.map((r) => rowToChunk(r as Record<string, unknown>));
   }
 
+  async getChunksByPageId(pageId: number): Promise<Chunk[]> {
+    const sql = this.sql;
+    const rows = await sql`
+      SELECT cc.* FROM content_chunks cc
+      WHERE cc.page_id = ${pageId}
+      ORDER BY cc.chunk_index
+    `;
+    return rows.map((r) => rowToChunk(r as Record<string, unknown>));
+  }
+
   async countStaleChunks(): Promise<number> {
     const sql = this.sql;
     const [row] = await sql`
@@ -892,7 +906,8 @@ export class PostgresEngine implements BrainEngine {
   async listStaleChunks(): Promise<StaleChunkRow[]> {
     const sql = this.sql;
     const rows = await sql`
-      SELECT p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+      SELECT p.id AS page_id, p.source_id, p.slug,
+             cc.chunk_index, cc.chunk_text, cc.chunk_source,
              cc.model, cc.token_count
       FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -106,6 +106,10 @@ export interface Chunk {
  * rows) embedding bytes over the wire. See `embed --stale` egress fix.
  */
 export interface StaleChunkRow {
+  /** Source-scoped page identity. Present for engines that support source-scoped stale embedding. */
+  page_id?: number;
+  /** Source id for diagnostics/grouping. Slugs are only unique within a source. */
+  source_id?: string;
   slug: string;
   chunk_index: number;
   chunk_text: string;

--- a/test/embed.serial.test.ts
+++ b/test/embed.serial.test.ts
@@ -401,6 +401,50 @@ describe('runEmbedCore --stale egress fix (SQL-side filter)', () => {
     expect(upsertByPageCalls[0].chunks[0].embedding).toBeInstanceOf(Float32Array);
   });
 
+  test('--stale groups fallback rows by source id and slug when page id is unavailable', async () => {
+    const { runEmbedCore } = await import('../src/commands/embed.ts');
+    const stale = [
+      {
+        source_id: 'source-a',
+        slug: 'shared-slug',
+        chunk_index: 0,
+        chunk_text: 'stale in first source',
+        chunk_source: 'compiled_truth' as const,
+        model: null,
+        token_count: null,
+      },
+      {
+        source_id: 'source-b',
+        slug: 'shared-slug',
+        chunk_index: 0,
+        chunk_text: 'stale in second source',
+        chunk_source: 'compiled_truth' as const,
+        model: null,
+        token_count: null,
+      },
+    ];
+    const upsertCalls: Array<{ slug: string; chunks: any[] }> = [];
+    const engine = mockEngine({
+      countStaleChunks: async () => 2,
+      listStaleChunks: async () => stale,
+      getChunks: async () => [
+        { chunk_index: 0, chunk_text: 'stale fallback row', chunk_source: 'compiled_truth', embedded_at: null, token_count: 5 },
+      ],
+      upsertChunks: async (slug: string, chunks: any[]) => {
+        upsertCalls.push({ slug, chunks });
+      },
+    });
+
+    const result = await runEmbedCore(engine, { stale: true });
+
+    expect(result.embedded).toBe(2);
+    expect(result.pages_processed).toBe(2);
+    expect(totalEmbedCalls).toBe(2);
+    expect(upsertCalls).toHaveLength(2);
+    expect(upsertCalls.every(call => call.slug === 'shared-slug')).toBe(true);
+    expect(upsertCalls.every(call => call.chunks[0].embedding instanceof Float32Array)).toBe(true);
+  });
+
   test('--stale dry-run: counts stale via countStaleChunks, reports via listStaleChunks, no embedBatch or upsertChunks', async () => {
     const { runEmbedCore } = await import('../src/commands/embed.ts');
     const stale = [

--- a/test/embed.serial.test.ts
+++ b/test/embed.serial.test.ts
@@ -348,6 +348,59 @@ describe('runEmbedCore --stale egress fix (SQL-side filter)', () => {
     expect(staleChunkInUpsert.embedding).toBeInstanceOf(Float32Array);
   });
 
+  test('--stale embeds duplicate slugs by page id instead of ambiguous slug', async () => {
+    const { runEmbedCore } = await import('../src/commands/embed.ts');
+    const stale = [
+      {
+        page_id: 202,
+        source_id: 'source-b',
+        slug: 'shared-slug',
+        chunk_index: 0,
+        chunk_text: 'stale in second source',
+        chunk_source: 'compiled_truth' as const,
+        model: null,
+        token_count: null,
+      },
+    ];
+    const chunksByPageId: Record<number, any[]> = {
+      202: [
+        { chunk_index: 0, chunk_text: 'stale in second source', chunk_source: 'compiled_truth', embedded_at: null, token_count: 6 },
+      ],
+    };
+    const upsertByPageCalls: Array<{ pageId: number; chunks: any[] }> = [];
+    let ambiguousSlugRead = false;
+    let ambiguousSlugWrite = false;
+    const engine = mockEngine({
+      countStaleChunks: async () => 1,
+      listStaleChunks: async () => stale,
+      getChunks: async () => {
+        ambiguousSlugRead = true;
+        return [
+          { chunk_index: 0, chunk_text: 'fresh first source', chunk_source: 'compiled_truth', embedded_at: '2026-01-01', token_count: 5 },
+          { chunk_index: 0, chunk_text: 'stale in second source', chunk_source: 'compiled_truth', embedded_at: null, token_count: 6 },
+        ];
+      },
+      upsertChunks: async () => {
+        ambiguousSlugWrite = true;
+        throw new Error('ambiguous slug upsert should not be used');
+      },
+      getChunksByPageId: async (pageId: number) => chunksByPageId[pageId] || [],
+      upsertChunksByPageId: async (pageId: number, chunks: any[]) => {
+        upsertByPageCalls.push({ pageId, chunks });
+      },
+    });
+
+    const result = await runEmbedCore(engine, { stale: true });
+
+    expect(result.embedded).toBe(1);
+    expect(result.pages_processed).toBe(1);
+    expect(ambiguousSlugRead).toBe(false);
+    expect(ambiguousSlugWrite).toBe(false);
+    expect(upsertByPageCalls).toHaveLength(1);
+    expect(upsertByPageCalls[0].pageId).toBe(202);
+    expect(upsertByPageCalls[0].chunks[0].embedding).toBeInstanceOf(Float32Array);
+  });
+
   test('--stale dry-run: counts stale via countStaleChunks, reports via listStaleChunks, no embedBatch or upsertChunks', async () => {
     const { runEmbedCore } = await import('../src/commands/embed.ts');
     const stale = [


### PR DESCRIPTION
Summary
- Fixes gbrain embed --stale for brains with duplicate slugs across multiple sources.
- listStaleChunks now returns page_id/source_id, and the stale embed path groups and upserts by page identity instead of ambiguous slug.
- Adds a regression test that reproduces duplicate-slug stale chunks without calling ambiguous slug read/write paths.

Why
pages enforces uniqueness on source_id plus slug, not global slug. The stale embed fast path grouped rows by slug; when the same slug exists in multiple sources it can merge duplicate chunk_index rows and fail with Postgres ON CONFLICT DO UPDATE command cannot affect row a second time, leaving stale chunks unembedded.

Verification
- bun test test/embed.serial.test.ts --timeout 30000
- bun run typecheck

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->