### PR TITLE
fix: harden local embedding and source-aware sync

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -11,6 +11,8 @@ import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts'
 import type { DbUrlSource } from '../core/config.ts';
 import { join } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { createHash } from 'crypto';
 
 export interface Check {
   name: string;
@@ -180,6 +182,86 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
     }
   } catch {
     // Read/parse failure is itself best-effort; skip silently.
+  }
+
+  // 3b-ter. Embedding runtime configuration (filesystem/config-only).
+  // Catches the class of bug where config says Ollama/768 but runtime still
+  // gates on OPENAI_API_KEY or assumes OpenAI dimensions.
+  try {
+    const { getEmbeddingConfig, embeddingsConfigured } = await import('../core/embedding.ts');
+    const cfg = getEmbeddingConfig();
+    const configured = embeddingsConfigured();
+    const noOpenAi = !process.env.OPENAI_API_KEY;
+    const dim = cfg.dimensions;
+    const provider = cfg.provider;
+    const model = cfg.model;
+    if (!configured) {
+      checks.push({
+        name: 'embedding_runtime',
+        status: 'warn',
+        message: `provider=${provider} model=${model} dimensions=${dim}; embeddings not configured`,
+      });
+    } else if (provider === 'ollama' && noOpenAi) {
+      checks.push({
+        name: 'embedding_runtime',
+        status: 'ok',
+        message: `provider=ollama model=${model} dimensions=${dim}; OPENAI_API_KEY not required`,
+      });
+    } else {
+      checks.push({
+        name: 'embedding_runtime',
+        status: 'ok',
+        message: `provider=${provider} model=${model} dimensions=${dim}`,
+      });
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    checks.push({ name: 'embedding_runtime', status: 'warn', message: `Could not inspect embedding runtime: ${msg}` });
+  }
+
+  // 3b. Active CLI path. This catches the repo-source vs globally-installed or
+  // installed-copy drift that made repo patches appear ineffective.
+  try {
+    const cliPath = execFileSync('which', ['gbrain'], { encoding: 'utf8' }).trim();
+    const invokedPath = process.argv[1] ?? 'unknown';
+    const repoRoot = findRepoRoot();
+    const repoHint = repoRoot ? `; repo=${repoRoot}` : '';
+    let status: Check['status'] = 'ok';
+    let driftDetail = '';
+
+    if (repoRoot && invokedPath.includes('/node_modules/')) {
+      const criticalFiles = [
+        'src/commands/doctor.ts',
+        'src/commands/sync.ts',
+        'src/core/db-lock.ts',
+        'src/core/embedding.ts',
+        'src/core/pglite-engine.ts',
+        'src/core/postgres-engine.ts',
+      ];
+      const mismatched = criticalFiles.filter((rel) => {
+        const repoFile = join(repoRoot, rel);
+        const installedFile = invokedPath.replace(/src\/cli\.ts$/, rel);
+        if (!existsSync(repoFile) || !existsSync(installedFile)) return true;
+        const hash = (path: string) => createHash('sha256').update(readFileSync(path)).digest('hex');
+        return hash(repoFile) !== hash(installedFile);
+      });
+      if (mismatched.length > 0) {
+        status = 'warn';
+        driftDetail = `; drift=${mismatched.join(',')}`;
+      } else {
+        driftDetail = '; installed copy matches repo critical files';
+      }
+    }
+
+    checks.push({
+      name: 'active_cli_path',
+      status,
+      message: status === 'warn'
+        ? `gbrain executable=${cliPath}; invoked=${invokedPath}${repoHint}${driftDetail}. Run package install/link if local edits should be active.`
+        : `gbrain executable=${cliPath}; invoked=${invokedPath}${repoHint}${driftDetail}`,
+    });
+  } catch {
+    checks.push({ name: 'active_cli_path', status: 'warn', message: 'gbrain executable path unavailable' });
   }
 
   // 3b-bis. Supervisor health (filesystem-only: PID liveness + audit log).

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -25,7 +25,7 @@ import {
   shouldRunParallel,
   parseWorkers,
 } from '../core/sync-concurrency.ts';
-import { tryAcquireDbLock, SYNC_LOCK_ID } from '../core/db-lock.ts';
+import { acquireDbLockOrInfo, SYNC_LOCK_ID } from '../core/db-lock.ts';
 import { loadStorageConfig } from '../core/storage-config.ts';
 import { getDefaultSourcePath } from '../core/source-resolver.ts';
 
@@ -294,13 +294,18 @@ export async function performSync(engine: BrainEngine, opts: SyncOpts): Promise<
   // mechanism (none in v0.22.13; reserved for future).
   let lockHandle: { release: () => Promise<void> } | null = null;
   if (!opts.skipLock) {
-    lockHandle = await tryAcquireDbLock(engine, SYNC_LOCK_ID);
-    if (!lockHandle) {
+    const lockResult = await acquireDbLockOrInfo(engine, SYNC_LOCK_ID);
+    if (!lockResult.handle) {
+      const info = (lockResult as { handle: null; info: import('../core/db-lock.ts').DbLockInfo | null }).info;
+      const details = info
+        ? ` holder_pid=${info.holder_pid ?? 'unknown'} holder_host=${info.holder_host ?? 'unknown'} acquired_at=${info.acquired_at ?? 'unknown'} ttl_expires_at=${info.ttl_expires_at ?? 'unknown'}.`
+        : '';
       throw new Error(
-        `Another sync is in progress (lock ${SYNC_LOCK_ID} held). ` +
-        `Wait for it to finish, or run 'gbrain doctor' if it has been more than 30 minutes.`,
+        `Another sync is in progress (lock ${SYNC_LOCK_ID} held).${details} ` +
+        `If the holder is dead, same-host stale locks are auto-cleared; otherwise wait or inspect with 'gbrain doctor --locks'.`,
       );
     }
+    lockHandle = lockResult.handle;
   }
 
   try {
@@ -579,7 +584,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
         return;
       }
       try {
-        const result = await importFile(eng, filePath, path, { noEmbed });
+        const result = await importFile(eng, filePath, path, { noEmbed, sourceId: opts.sourceId });
         if (result.status === 'imported') {
           chunksCreated += result.chunks;
           pagesAffected.push(result.slug);
@@ -823,19 +828,46 @@ async function performFullSync(
     };
   }
 
-  // v0.22.13 (PR #490 A1 + Q5): full sync is always "large" by definition
-  // (entire working tree). Auto-concurrency fires unconditionally for Postgres;
-  // PGLite stays serial because its engine is single-connection. Routes the
-  // policy through autoConcurrency() so it stays consistent with incremental
-  // sync and the jobs handler.
-  const FULL_SYNC_LARGE_MARKER = Number.MAX_SAFE_INTEGER;
-  const fullConcurrency = autoConcurrency(engine, FULL_SYNC_LARGE_MARKER, opts.concurrency);
-  console.log(`Running full import of ${repoPath}${fullConcurrency > 1 ? ` (${fullConcurrency} workers)` : ''}...`);
-  const { runImport } = await import('./import.ts');
-  const importArgs = [repoPath];
-  if (opts.noEmbed) importArgs.push('--no-embed');
-  if (fullConcurrency > 1) importArgs.push('--workers', String(fullConcurrency));
-  const result = await runImport(engine, importArgs, { commit: headCommit });
+  const strategy = opts.strategy ?? 'markdown';
+
+  let result: { imported: number; chunksCreated: number; failures: Array<{ path: string; error: string; line?: number }> };
+
+  if (strategy === 'markdown') {
+    // v0.22.13 (PR #490 A1 + Q5): full markdown sync keeps using the optimized
+    // import command path for backwards compatibility.
+    const FULL_SYNC_LARGE_MARKER = Number.MAX_SAFE_INTEGER;
+    const fullConcurrency = autoConcurrency(engine, FULL_SYNC_LARGE_MARKER, opts.concurrency);
+    console.log(`Running full import of ${repoPath}${fullConcurrency > 1 ? ` (${fullConcurrency} workers)` : ''}...`);
+    const { runImport } = await import('./import.ts');
+    const importArgs = [repoPath];
+    if (opts.noEmbed) importArgs.push('--no-embed');
+    if (fullConcurrency > 1) importArgs.push('--workers', String(fullConcurrency));
+    result = await runImport(engine, importArgs, { commit: headCommit });
+  } else {
+    // Source-scoped code/auto sync must honor strategy and sourceId. runImport
+    // only walks Markdown files and writes default-source pages, so do the
+    // strategy-aware walk here and route through importFile(..., sourceId).
+    const files: string[] = [];
+    walkSyncableFiles(repoPath, (filePath) => files.push(relative(repoPath, filePath)), strategy);
+    console.log(`Running full ${strategy} import of ${repoPath} (${files.length} files)...`);
+    let imported = 0;
+    let chunksCreated = 0;
+    const failures: Array<{ path: string; error: string; line?: number }> = [];
+    for (const rel of files) {
+      try {
+        const r = await importFile(engine, join(repoPath, rel), rel, { noEmbed: opts.noEmbed, sourceId: opts.sourceId });
+        if (r.status === 'imported') {
+          imported++;
+          chunksCreated += r.chunks;
+        } else if (r.status === 'skipped' && r.error) {
+          failures.push({ path: rel, error: r.error });
+        }
+      } catch (e: unknown) {
+        failures.push({ path: rel, error: e instanceof Error ? e.message : String(e) });
+      }
+    }
+    result = { imported, chunksCreated, failures };
+  }
 
   // Bug 9 — gate the full-sync bookmark on success. runImport already
   // writes its own sync.last_commit conditionally (import.ts), but

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -31,6 +31,14 @@ export interface GBrainConfig {
   database_path?: string;
   openai_api_key?: string;
   anthropic_api_key?: string;
+  /** Embedding backend. Defaults to OpenAI for existing installs. */
+  embedding_provider?: 'openai' | 'ollama' | string;
+  /** Embedding model name for the selected provider. */
+  embedding_model?: string;
+  /** Expected embedding dimensions for the configured model/vector column. */
+  embedding_dimensions?: number;
+  /** Base URL for local/OpenAI-compatible embedding providers such as Ollama. */
+  embedding_base_url?: string;
   /**
    * Optional storage backend config (S3/Supabase/local). Shape matches
    * `StorageConfig` in `./storage.ts`. Typed as `unknown` here to avoid

--- a/src/core/db-lock.ts
+++ b/src/core/db-lock.ts
@@ -9,17 +9,6 @@
  * transaction pooling drops session state between calls. This row-based
  * lock survives PgBouncer because it's plain INSERT/UPDATE/DELETE with
  * a TTL fallback (a crashed holder's row times out).
- *
- * Why a separate table-row per lock id rather than reusing the cycle lock:
- * the cycle lock is broader (covers every phase). performSync's write-window
- * is narrower. If performSync reused the cycle lock and the cycle handler
- * called performSync, the inner acquire would deadlock against itself. Two
- * lock ids let callers nest cleanly: cycle holds gbrain-cycle for its run;
- * performSync (called from anywhere — cycle, jobs handler, CLI) takes
- * gbrain-sync just for the write window.
- *
- * v0.22.13 — added in PR #490 to fix CODEX-2 (no cross-process lock for
- * direct sync paths). The cycle path was already protected.
  */
 import { hostname } from 'os';
 import type { BrainEngine } from './engine.ts';
@@ -30,23 +19,30 @@ export interface DbLockHandle {
   refresh: () => Promise<void>;
 }
 
+export interface DbLockInfo {
+  id: string;
+  holder_pid: number | null;
+  holder_host: string | null;
+  acquired_at: string | null;
+  ttl_expires_at: string | null;
+}
+
 /** Default TTL: 30 minutes, same as cycle lock. */
 const DEFAULT_TTL_MINUTES = 30;
+
+function rawAccess(engine: BrainEngine) {
+  const maybePG = engine as unknown as { sql?: (...args: unknown[]) => Promise<unknown> };
+  const maybePGLite = engine as unknown as {
+    db?: { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> };
+  };
+  return { maybePG, maybePGLite };
+}
 
 /**
  * Try to acquire a named DB lock.
  *
  * Returns a handle on success. Returns `null` if another live holder has
  * the lock (its row exists and ttl_expires_at is in the future).
- *
- * The acquire is upsert-style:
- *   INSERT ... ON CONFLICT (id) DO UPDATE
- *     ... WHERE existing.ttl_expires_at < NOW()
- *   RETURNING id
- *
- * Empty RETURNING means the existing row is still live. An expired holder
- * (worker crashed without releasing) is auto-superseded by the UPDATE
- * branch.
  */
 export async function tryAcquireDbLock(
   engine: BrainEngine,
@@ -55,13 +51,7 @@ export async function tryAcquireDbLock(
 ): Promise<DbLockHandle | null> {
   const pid = process.pid;
   const host = hostname();
-
-  // Engine-agnostic: prefer the engine's raw escape hatch (`sql` for postgres-js,
-  // `db.query` for PGLite). Mirrors cycle.ts's pattern so behavior stays identical.
-  const maybePG = engine as unknown as { sql?: (...args: unknown[]) => Promise<unknown> };
-  const maybePGLite = engine as unknown as {
-    db?: { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> };
-  };
+  const { maybePG, maybePGLite } = rawAccess(engine);
 
   if (engine.kind === 'postgres' && maybePG.sql) {
     const sql = maybePG.sql as any;
@@ -132,6 +122,67 @@ export async function tryAcquireDbLock(
   }
 
   throw new Error(`Unknown engine kind for db-lock: ${engine.kind}`);
+}
+
+function isPidAlive(pid: number | null | undefined): boolean {
+  if (!pid || pid <= 0) return false;
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+export async function getDbLockInfo(engine: BrainEngine, lockId: string): Promise<DbLockInfo | null> {
+  const { maybePG, maybePGLite } = rawAccess(engine);
+  if (engine.kind === 'postgres' && maybePG.sql) {
+    const sql = maybePG.sql as any;
+    const rows = await sql`
+      SELECT id, holder_pid, holder_host, acquired_at::text, ttl_expires_at::text
+      FROM gbrain_cycle_locks WHERE id = ${lockId} LIMIT 1
+    ` as DbLockInfo[];
+    return rows[0] ?? null;
+  }
+  if (engine.kind === 'pglite' && maybePGLite.db) {
+    const { rows } = await maybePGLite.db.query(
+      `SELECT id, holder_pid, holder_host, acquired_at::text, ttl_expires_at::text
+       FROM gbrain_cycle_locks WHERE id = $1 LIMIT 1`,
+      [lockId],
+    );
+    return (rows[0] as DbLockInfo | undefined) ?? null;
+  }
+  return null;
+}
+
+async function clearDbLock(engine: BrainEngine, lockId: string): Promise<void> {
+  const { maybePG, maybePGLite } = rawAccess(engine);
+  if (engine.kind === 'postgres' && maybePG.sql) {
+    const sql = maybePG.sql as any;
+    await sql`DELETE FROM gbrain_cycle_locks WHERE id = ${lockId}`;
+    return;
+  }
+  if (engine.kind === 'pglite' && maybePGLite.db) {
+    await maybePGLite.db.query(`DELETE FROM gbrain_cycle_locks WHERE id = $1`, [lockId]);
+  }
+}
+
+/**
+ * Acquire a lock, auto-clearing the common interrupted-agent case: same-host
+ * lock row whose holder PID is no longer alive. Returns lock info on failure
+ * so callers can print actionable diagnostics.
+ */
+export async function acquireDbLockOrInfo(
+  engine: BrainEngine,
+  lockId: string,
+  ttlMinutes: number = DEFAULT_TTL_MINUTES,
+): Promise<{ handle: DbLockHandle; clearedStale?: DbLockInfo } | { handle: null; info: DbLockInfo | null }> {
+  const first = await tryAcquireDbLock(engine, lockId, ttlMinutes);
+  if (first) return { handle: first };
+
+  const info = await getDbLockInfo(engine, lockId);
+  const sameHost = info?.holder_host === hostname();
+  if (sameHost && !isPidAlive(info?.holder_pid)) {
+    await clearDbLock(engine, lockId);
+    const second = await tryAcquireDbLock(engine, lockId, ttlMinutes);
+    if (second) return { handle: second, clearedStale: info ?? undefined };
+  }
+  return { handle: null, info };
 }
 
 /** Lock id for performSync's writer window. Distinct from gbrain-cycle so the

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -2,16 +2,24 @@
  * Embedding Service
  * Ported from production Ruby implementation (embedding_service.rb, 190 LOC)
  *
- * OpenAI text-embedding-3-large at 1536 dimensions.
+ * OpenAI text-embedding-3-large at 1536 dimensions by default.
+ * Can be configured for local Ollama embeddings via ~/.gbrain/config.json:
+ * embedding_provider=ollama, embedding_model=nomic-embed-text,
+ * embedding_dimensions=768, embedding_base_url=http://localhost:11434.
  * Retry with exponential backoff (4s base, 120s cap, 5 retries).
- * 8000 character input truncation.
+ * Provider-specific input truncation. Ollama/local embedding models often
+ * have much smaller context windows than OpenAI embedding models.
  */
 
 import OpenAI from 'openai';
+import { loadConfig } from './config.ts';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
-const MAX_CHARS = 8000;
+const DEFAULT_PROVIDER = 'openai';
+const DEFAULT_MODEL = 'text-embedding-3-large';
+const DEFAULT_DIMENSIONS = 1536;
+const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434';
+const OPENAI_MAX_CHARS = 8000;
+const OLLAMA_MAX_CHARS = 1800;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
@@ -26,10 +34,58 @@ function getClient(): OpenAI {
   return client;
 }
 
+export interface EmbeddingRuntimeConfig {
+  provider: string;
+  model: string;
+  dimensions: number;
+  baseUrl?: string;
+}
+
+export function getEmbeddingConfig(): EmbeddingRuntimeConfig {
+  const cfg = loadConfig();
+  const provider = (
+    process.env.GBRAIN_EMBED_PROVIDER ||
+    process.env.GBRAIN_EMBEDDING_PROVIDER ||
+    cfg?.embedding_provider ||
+    DEFAULT_PROVIDER
+  ).toLowerCase();
+
+  const model =
+    process.env.GBRAIN_EMBED_MODEL ||
+    process.env.GBRAIN_EMBEDDING_MODEL ||
+    cfg?.embedding_model ||
+    (provider === 'ollama' ? 'nomic-embed-text' : DEFAULT_MODEL);
+
+  const dimensionsRaw =
+    process.env.GBRAIN_EMBED_DIMENSIONS ||
+    process.env.GBRAIN_EMBEDDING_DIMENSIONS ||
+    (cfg?.embedding_dimensions != null ? String(cfg.embedding_dimensions) : '');
+  const dimensions = Number.parseInt(dimensionsRaw, 10) ||
+    (provider === 'ollama' ? 768 : DEFAULT_DIMENSIONS);
+
+  const baseUrl =
+    process.env.GBRAIN_EMBED_BASE_URL ||
+    process.env.GBRAIN_EMBEDDING_BASE_URL ||
+    cfg?.embedding_base_url ||
+    (provider === 'ollama' ? DEFAULT_OLLAMA_BASE_URL : undefined);
+
+  return { provider, model, dimensions, baseUrl };
+}
+
+export function embeddingsConfigured(): boolean {
+  const cfg = getEmbeddingConfig();
+  if (cfg.provider === 'ollama') return true;
+  return Boolean(process.env.OPENAI_API_KEY || loadConfig()?.openai_api_key);
+}
+
 export async function embed(text: string): Promise<Float32Array> {
-  const truncated = text.slice(0, MAX_CHARS);
+  const truncated = text.slice(0, maxCharsForProvider());
   const result = await embedBatch([truncated]);
   return result[0];
+}
+
+function maxCharsForProvider(): number {
+  return getEmbeddingConfig().provider === 'ollama' ? OLLAMA_MAX_CHARS : OPENAI_MAX_CHARS;
 }
 
 export interface EmbedBatchOptions {
@@ -45,7 +101,7 @@ export async function embedBatch(
   texts: string[],
   options: EmbedBatchOptions = {},
 ): Promise<Float32Array[]> {
-  const truncated = texts.map(t => t.slice(0, MAX_CHARS));
+  const truncated = texts.map(t => t.slice(0, maxCharsForProvider()));
   const results: Float32Array[] = [];
 
   // Process in batches of BATCH_SIZE
@@ -60,12 +116,17 @@ export async function embedBatch(
 }
 
 async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
+  const cfg = getEmbeddingConfig();
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
+      if (cfg.provider === 'ollama') {
+        return await embedBatchWithOllama(texts, cfg);
+      }
+
       const response = await getClient().embeddings.create({
-        model: MODEL,
+        model: cfg.model,
         input: texts,
-        dimensions: DIMENSIONS,
+        dimensions: cfg.dimensions,
       });
 
       // Sort by index to maintain order
@@ -95,6 +156,30 @@ async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
   throw new Error('Embedding failed after all retries');
 }
 
+async function embedBatchWithOllama(texts: string[], cfg: EmbeddingRuntimeConfig): Promise<Float32Array[]> {
+  const baseUrl = (cfg.baseUrl || DEFAULT_OLLAMA_BASE_URL).replace(/\/$/, '');
+  const response = await fetch(`${baseUrl}/api/embed`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model: cfg.model, input: texts }),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Ollama embedding failed (${response.status}): ${body.slice(0, 300)}`);
+  }
+  const payload = await response.json() as { embeddings?: number[][]; embedding?: number[] };
+  const rawEmbeddings = payload.embeddings ?? (payload.embedding ? [payload.embedding] : undefined);
+  if (!rawEmbeddings || rawEmbeddings.length !== texts.length) {
+    throw new Error(`Ollama returned ${rawEmbeddings?.length ?? 0} embedding(s) for ${texts.length} input(s)`);
+  }
+  return rawEmbeddings.map((embedding) => {
+    if (embedding.length !== cfg.dimensions) {
+      throw new Error(`Ollama returned ${embedding.length} dimensions, expected ${cfg.dimensions}`);
+    }
+    return new Float32Array(embedding);
+  });
+}
+
 function exponentialDelay(attempt: number): number {
   const delay = BASE_DELAY_MS * Math.pow(2, attempt);
   return Math.min(delay, MAX_DELAY_MS);
@@ -104,7 +189,8 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
+export const EMBEDDING_MODEL = getEmbeddingConfig().model;
+export const EMBEDDING_DIMENSIONS = getEmbeddingConfig().dimensions;
 
 /**
  * v0.20.0 Cathedral II Layer 8 (D1): USD cost per 1k tokens for

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -185,7 +185,7 @@ export interface BrainEngine {
   getEmbeddingsByChunkIds(ids: number[]): Promise<Map<number, Float32Array>>;
 
   // Chunks
-  upsertChunks(slug: string, chunks: ChunkInput[]): Promise<void>;
+  upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string }): Promise<void>;
   getChunks(slug: string): Promise<Chunk[]>;
   /**
    * Count chunks across the entire brain where embedded_at IS NULL.
@@ -283,7 +283,7 @@ export interface BrainEngine {
   findOrphanPages(): Promise<Array<{ slug: string; title: string; domain: string | null }>>;
 
   // Tags
-  addTag(slug: string, tag: string): Promise<void>;
+  addTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void>;
   removeTag(slug: string, tag: string): Promise<void>;
   getTags(slug: string): Promise<string[]>;
 

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -185,7 +185,7 @@ export async function importFromContent(
   engine: BrainEngine,
   slug: string,
   content: string,
-  opts: { noEmbed?: boolean } = {},
+  opts: { noEmbed?: boolean; sourceId?: string } = {},
 ): Promise<ImportResult> {
   // Reject oversized payloads before any parsing, chunking, or embedding happens.
   // Uses Buffer.byteLength to count UTF-8 bytes the same way disk size would,
@@ -223,7 +223,7 @@ export async function importFromContent(
     tags: parsed.tags,
   };
 
-  const existing = await engine.getPage(slug);
+  const existing = await engine.getPage(slug, opts.sourceId ? { sourceId: opts.sourceId } : undefined);
   if (existing?.content_hash === hash) {
     return { slug, status: 'skipped', chunks: 0, parsedPage };
   }
@@ -270,6 +270,7 @@ export async function importFromContent(
     if (existing) await tx.createVersion(slug);
 
     await tx.putPage(slug, {
+      source_id: opts.sourceId,
       type: parsed.type,
       title: parsed.title,
       compiled_truth: parsed.compiled_truth,
@@ -285,11 +286,11 @@ export async function importFromContent(
       if (!newTags.has(old)) await tx.removeTag(slug, old);
     }
     for (const tag of parsed.tags) {
-      await tx.addTag(slug, tag);
+      await tx.addTag(slug, tag, opts.sourceId ? { sourceId: opts.sourceId } : undefined);
     }
 
     if (chunks.length > 0) {
-      await tx.upsertChunks(slug, chunks);
+      await tx.upsertChunks(slug, chunks, opts.sourceId ? { sourceId: opts.sourceId } : undefined);
     } else {
       // Content is empty — delete stale chunks so they don't ghost in search results
       await tx.deleteChunks(slug);
@@ -339,7 +340,7 @@ export async function importFromFile(
   engine: BrainEngine,
   filePath: string,
   relativePath: string,
-  opts: { noEmbed?: boolean; inferFrontmatter?: boolean } = {},
+  opts: { noEmbed?: boolean; inferFrontmatter?: boolean; sourceId?: string } = {},
 ): Promise<ImportResult> {
   // Defense-in-depth: reject symlinks before reading content.
   const lstat = lstatSync(filePath);
@@ -404,7 +405,7 @@ export async function importCodeFile(
   engine: BrainEngine,
   relativePath: string,
   content: string,
-  opts: { noEmbed?: boolean; force?: boolean } = {},
+  opts: { noEmbed?: boolean; force?: boolean; sourceId?: string } = {},
 ): Promise<ImportResult> {
   const slug = slugifyCodePath(relativePath);
   const lang = detectCodeLanguage(relativePath) || 'unknown';
@@ -421,7 +422,7 @@ export async function importCodeFile(
     .update(JSON.stringify({ title, type: 'code', content, lang, chunker_version: CHUNKER_VERSION }))
     .digest('hex');
 
-  const existing = await engine.getPage(slug);
+  const existing = await engine.getPage(slug, opts.sourceId ? { sourceId: opts.sourceId } : undefined);
   if (!opts.force && existing?.content_hash === hash) {
     return { slug, status: 'skipped', chunks: 0 };
   }
@@ -497,6 +498,7 @@ export async function importCodeFile(
     if (existing) await tx.createVersion(slug);
 
     await tx.putPage(slug, {
+      source_id: opts.sourceId,
       type: 'code' as PageType,
       page_kind: 'code',
       title,
@@ -506,11 +508,11 @@ export async function importCodeFile(
       content_hash: hash,
     });
 
-    await tx.addTag(slug, 'code');
-    await tx.addTag(slug, lang);
+    await tx.addTag(slug, 'code', opts.sourceId ? { sourceId: opts.sourceId } : undefined);
+    await tx.addTag(slug, lang, opts.sourceId ? { sourceId: opts.sourceId } : undefined);
 
     if (chunks.length > 0) {
-      await tx.upsertChunks(slug, chunks);
+      await tx.upsertChunks(slug, chunks, opts.sourceId ? { sourceId: opts.sourceId } : undefined);
     } else {
       await tx.deleteChunks(slug);
     }

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -10,6 +10,7 @@ import { clampSearchLimit } from './engine.ts';
 import type { GBrainConfig } from './config.ts';
 import type { PageType } from './types.ts';
 import { importFromContent } from './import-file.ts';
+import { embeddingsConfigured } from './embedding.ts';
 import { hybridSearch } from './search/hybrid.ts';
 import { expandQuery } from './search/expansion.ts';
 import { dedupResults } from './search/dedup.ts';
@@ -374,11 +375,9 @@ const put_page: Operation = {
     }
 
     if (ctx.dryRun) return { dry_run: true, action: 'put_page', slug: p.slug };
-    // Skip embedding when no OpenAI key is configured. importFromContent's existing
-    // try/catch around embed only catches; without a key the OpenAI client would
-    // attempt 5 retries with exponential backoff (up to ~2 minutes total) before
-    // giving up. Detect early.
-    const noEmbed = !process.env.OPENAI_API_KEY;
+    // Skip embedding only when no embedding provider is configured. Local Ollama
+    // embeddings do not require OPENAI_API_KEY.
+    const noEmbed = !embeddingsConfigured();
     const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed });
 
     // Auto-link post-hook: runs AFTER importFromContent (which is its own

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -372,14 +372,14 @@ export class PGLiteEngine implements BrainEngine {
     const frontmatter = page.frontmatter || {};
 
     // v0.18.0 Step 2: source_id relies on the schema DEFAULT 'default' so
-    // existing callers still target the default source without threading
-    // a parameter. ON CONFLICT target becomes (source_id, slug) since the
-    // global UNIQUE(slug) was dropped in migration v17. Step 5+ will
-    // surface an explicit sourceId param on putPage for multi-source sync.
+    // Source-aware upsert: callers that do not pass source_id still target the
+    // default source via the schema default. Explicit source-aware sync/import
+    // paths pass page.source_id so pages/chunks/tags remain isolated per source.
     const pageKind = page.page_kind || 'markdown';
+    const sourceId = page.source_id || 'default';
     const { rows } = await this.db.query(
-      `INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, now())
+      `INSERT INTO pages (source_id, slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, now())
        ON CONFLICT (source_id, slug) DO UPDATE SET
          type = EXCLUDED.type,
          page_kind = EXCLUDED.page_kind,
@@ -389,8 +389,8 @@ export class PGLiteEngine implements BrainEngine {
          frontmatter = EXCLUDED.frontmatter,
          content_hash = EXCLUDED.content_hash,
          updated_at = now()
-       RETURNING id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at`,
-      [slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash]
+       RETURNING id, source_id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at`,
+      [sourceId, slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash]
     );
     return rowToPage(rows[0] as Record<string, unknown>);
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -304,7 +304,7 @@ export class PostgresEngine implements BrainEngine {
     const sourceCondition = sourceId ? sql`AND source_id = ${sourceId}` : sql``;
     const deletedCondition = includeDeleted ? sql`` : sql`AND deleted_at IS NULL`;
     const rows = await sql`
-      SELECT id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at, deleted_at
+      SELECT id, source_id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at, deleted_at
       FROM pages
       WHERE slug = ${slug} ${sourceCondition} ${deletedCondition}
       LIMIT 1
@@ -324,9 +324,10 @@ export class PostgresEngine implements BrainEngine {
     // was dropped in migration v17. See pglite-engine.ts for matching
     // notes; multi-source sync (Step 5) will surface an explicit sourceId.
     const pageKind = page.page_kind || 'markdown';
+    const sourceId = page.source_id || 'default';
     const rows = await sql`
-      INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
-      VALUES (${slug}, ${page.type}, ${pageKind}, ${page.title}, ${page.compiled_truth}, ${page.timeline || ''}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now())
+      INSERT INTO pages (source_id, slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
+      VALUES (${sourceId}, ${slug}, ${page.type}, ${pageKind}, ${page.title}, ${page.compiled_truth}, ${page.timeline || ''}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now())
       ON CONFLICT (source_id, slug) DO UPDATE SET
         type = EXCLUDED.type,
         page_kind = EXCLUDED.page_kind,
@@ -336,7 +337,7 @@ export class PostgresEngine implements BrainEngine {
         frontmatter = EXCLUDED.frontmatter,
         content_hash = EXCLUDED.content_hash,
         updated_at = now()
-      RETURNING id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at
+      RETURNING id, source_id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at
     `;
     return rowToPage(rows[0]);
   }
@@ -770,11 +771,12 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Chunks
-  async upsertChunks(slug: string, chunks: ChunkInput[]): Promise<void> {
+  async upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string }): Promise<void> {
     const sql = this.sql;
 
     // Get page_id
-    const pages = await sql`SELECT id FROM pages WHERE slug = ${slug}`;
+    const sourceCondition = opts?.sourceId ? sql`AND source_id = ${opts.sourceId}` : sql``;
+    const pages = await sql`SELECT id FROM pages WHERE slug = ${slug} ${sourceCondition}`;
     if (pages.length === 0) throw new Error(`Page not found: ${slug}`);
     const pageId = pages[0].id;
 
@@ -1255,11 +1257,12 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Tags
-  async addTag(slug: string, tag: string): Promise<void> {
+  async addTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void> {
     const sql = this.sql;
     // Verify page exists before attempting insert (ON CONFLICT DO NOTHING
     // swallows the "already tagged" case, but we still need to detect missing pages)
-    const page = await sql`SELECT id FROM pages WHERE slug = ${slug}`;
+    const sourceCondition = opts?.sourceId ? sql`AND source_id = ${opts.sourceId}` : sql``;
+    const page = await sql`SELECT id FROM pages WHERE slug = ${slug} ${sourceCondition}`;
     if (page.length === 0) throw new Error(`addTag failed: page "${slug}" not found`);
     await sql`
       INSERT INTO tags (page_id, tag)

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -12,7 +12,7 @@
 import type { BrainEngine } from '../engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../engine.ts';
 import type { SearchResult, SearchOpts, HybridSearchMeta } from '../types.ts';
-import { embed } from '../embedding.ts';
+import { embed, embeddingsConfigured } from '../embedding.ts';
 import { dedupResults } from './dedup.ts';
 import { autoDetectDetail } from './intent.ts';
 import { expandAnchors, hydrateChunks } from './two-pass.ts';
@@ -111,8 +111,8 @@ export async function hybridSearch(
   // Run keyword search (always available, no API key needed)
   const keywordResults = await engine.searchKeyword(query, searchOpts);
 
-  // Skip vector search entirely if no OpenAI key is configured
-  if (!process.env.OPENAI_API_KEY) {
+  // Skip vector search entirely if no embedding provider is configured.
+  if (!embeddingsConfigured()) {
     // Apply backlink boost in keyword-only path too. One getBacklinkCounts query
     // per search request; not N+1.
     if (keywordResults.length > 0) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -29,6 +29,7 @@ export interface Page {
 export type PageKind = 'markdown' | 'code';
 
 export interface PageInput {
+  source_id?: string;
   type: PageType;
   title: string;
   compiled_truth: string;

--- a/test/embedding-runtime.test.ts
+++ b/test/embedding-runtime.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+const originalFetch = globalThis.fetch;
+const originalOpenAIKey = process.env.OPENAI_API_KEY;
+
+function resetEnv() {
+  delete process.env.GBRAIN_EMBED_PROVIDER;
+  delete process.env.GBRAIN_EMBEDDING_PROVIDER;
+  delete process.env.GBRAIN_EMBED_MODEL;
+  delete process.env.GBRAIN_EMBEDDING_MODEL;
+  delete process.env.GBRAIN_EMBED_DIMENSIONS;
+  delete process.env.GBRAIN_EMBEDDING_DIMENSIONS;
+  delete process.env.GBRAIN_EMBED_BASE_URL;
+  delete process.env.GBRAIN_EMBEDDING_BASE_URL;
+  if (originalOpenAIKey === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = originalOpenAIKey;
+  globalThis.fetch = originalFetch;
+}
+
+afterEach(resetEnv);
+
+describe('embedding runtime configuration', () => {
+  test('Ollama is considered configured without OPENAI_API_KEY', async () => {
+    delete process.env.OPENAI_API_KEY;
+    process.env.GBRAIN_EMBED_PROVIDER = 'ollama';
+    process.env.GBRAIN_EMBED_MODEL = 'nomic-embed-text';
+    process.env.GBRAIN_EMBED_DIMENSIONS = '768';
+    process.env.GBRAIN_EMBED_BASE_URL = 'http://127.0.0.1:11434';
+
+    const { embeddingsConfigured, getEmbeddingConfig } = await import('../src/core/embedding.ts');
+
+    expect(embeddingsConfigured()).toBe(true);
+    expect(getEmbeddingConfig()).toMatchObject({
+      provider: 'ollama',
+      model: 'nomic-embed-text',
+      dimensions: 768,
+    });
+  });
+
+  test('Ollama embedding input is truncated before fetch so oversized code chunks do not hit model context limits', async () => {
+    delete process.env.OPENAI_API_KEY;
+    process.env.GBRAIN_EMBED_PROVIDER = 'ollama';
+    process.env.GBRAIN_EMBED_MODEL = 'nomic-embed-text';
+    process.env.GBRAIN_EMBED_DIMENSIONS = '768';
+    process.env.GBRAIN_EMBED_BASE_URL = 'http://ollama.test';
+
+    let observedInput = '';
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as { input: string[] };
+      observedInput = body.input[0] ?? '';
+      return new Response(JSON.stringify({ embeddings: [Array.from({ length: 768 }, () => 0.01)] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    const { embed } = await import('../src/core/embedding.ts');
+    const result = await embed('x'.repeat(50_000));
+
+    expect(result.length).toBe(768);
+    expect(observedInput.length).toBeLessThanOrEqual(1800);
+  });
+});

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -361,6 +361,61 @@ describe('performSync dry-run never writes', () => {
   });
 });
 
+describe('performSync code strategy source isolation', () => {
+  let engine: PGLiteEngine;
+  let repoPath: string;
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+  });
+
+  beforeEach(async () => {
+    await resetPgliteState(engine);
+    repoPath = mkdtempSync(join(tmpdir(), 'gbrain-sync-code-source-'));
+    execSync('git init', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git config user.email "test@test.com"', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git config user.name "Test"', { cwd: repoPath, stdio: 'pipe' });
+    mkdirSync(join(repoPath, 'src'), { recursive: true });
+    writeFileSync(join(repoPath, 'src/index.ts'), 'export function performSyncSmoke() { return 42; }\n');
+    writeFileSync(join(repoPath, 'README.md'), '# ignored by code strategy\n');
+    execSync('git add -A && git commit -m "initial code"', { cwd: repoPath, stdio: 'pipe' });
+  });
+
+  afterEach(() => {
+    if (repoPath) rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  test('full code sync writes pages under the requested source_id, not default', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    await (engine as any).db.query(
+      `INSERT INTO sources (id, name, local_path, config)
+       VALUES ($1, $2, $3, $4::jsonb)
+       ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path`,
+      ['test-code-source', 'Test Code Source', repoPath, '{}'],
+    );
+
+    const result = await performSync(engine, {
+      repoPath,
+      full: true,
+      noPull: true,
+      noEmbed: true,
+      strategy: 'code',
+      sourceId: 'test-code-source',
+    });
+
+    expect(result.status).toBe('first_sync');
+    expect(result.added).toBeGreaterThan(0);
+    expect(await engine.getPage('src-index-ts', { sourceId: 'test-code-source' })).not.toBeNull();
+    expect(await engine.getPage('src-index-ts', { sourceId: 'default' })).toBeNull();
+  });
+});
+
 describe('sync regression — #132 nested transaction deadlock', () => {
   test('src/commands/sync.ts does not wrap the add/modify loop in engine.transaction()', async () => {
     const source = await Bun.file(new URL('../src/commands/sync.ts', import.meta.url)).text();


### PR DESCRIPTION
## Summary
- Support local Ollama embedding runtime without requiring `OPENAI_API_KEY`.
- Preserve explicit `source_id` through source-aware code sync, including PGLite.
- Add doctor checks for embedding runtime and active CLI/package drift.
- Improve DB sync lock diagnostics and stale/dead PID lock recovery.
- Add regression tests for oversized Ollama input and source-aware full code sync.

## Test plan
- `bun test ./test/embedding-runtime.test.ts ./test/embed.test.ts ./test/sync.test.ts`
- Local smoke: `env -u OPENAI_API_KEY gbrain doctor --fast --json`
- Local smoke: `env -u OPENAI_API_KEY gbrain put ...` + `gbrain search ...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->