### PR TITLE
Make entity link directories configurable

### DIFF
--- a/docs/UPGRADING_DOWNSTREAM_AGENTS.md
+++ b/docs/UPGRADING_DOWNSTREAM_AGENTS.md
@@ -55,6 +55,9 @@ to the graph (`links` table) with inferred relationship types. Stale links
 - The `put_page` MCP response includes `auto_links: { created, removed, errors }`
   so the agent can verify outcomes.
 - To disable: `gbrain config set auto_link false`. Default is on.
+- To customize which top-level directories count as path-based entity refs:
+  `gbrain config set extract.link_dirs 'people,companies,01 Projects,03 Resources'`.
+  Leave unset or empty to use the built-in defaults.
 - Timeline entries with specific dates still need explicit `gbrain timeline-add`
   (or batch via `gbrain extract timeline --source db`).
 ```

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -23,7 +23,7 @@ import type { PageType } from '../core/types.ts';
 import { parseMarkdown } from '../core/markdown.ts';
 import {
   extractPageLinks, parseTimelineEntries, inferLinkType, makeResolver,
-  extractFrontmatterLinks,
+  extractFrontmatterLinks, getEntityLinkDirs,
   type UnresolvedFrontmatterRef,
 } from '../core/link-extraction.ts';
 import { createProgress } from '../core/progress.ts';
@@ -716,6 +716,7 @@ async function extractLinksFromDB(
   opts?: { includeFrontmatter?: boolean },
 ): Promise<{ created: number; pages: number; unresolved: UnresolvedFrontmatterRef[] }> {
   const includeFrontmatter = opts?.includeFrontmatter ?? false;
+  const entityDirs = await getEntityLinkDirs(engine);
   // Batch resolver: pg_trgm + exact only, NO search fallback. Dodges the
   // N-thousand API call trap on 46K-page brains. Resolver has a per-run
   // cache so duplicate names (same person appearing on many pages) resolve
@@ -769,7 +770,7 @@ async function extractLinksFromDB(
     // user-invoked `gbrain extract links` stays outgoing-only.
     const activeResolver = includeFrontmatter ? resolver : nullResolver;
     const extracted = await extractPageLinks(
-      slug, fullContent, page.frontmatter, page.type, activeResolver,
+      slug, fullContent, page.frontmatter, page.type, activeResolver, { entityDirs },
     );
     unresolved.push(...extracted.unresolved);
 

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -38,13 +38,70 @@ export interface EntityRef {
 export type LinkResolutionType = 'qualified' | 'unqualified';
 
 /**
- * Directory prefix whitelist. These are the top-level slug dirs the extractor
- * recognizes as entity references. Upstream canonical + our extensions:
- *   - Gbrain canonical: people, companies, meetings, concepts, deal, civic, project, source, media, yc, projects
- *   - Our domain extensions: tech, finance, personal, openclaw (domain-organized wikis)
- *   - Our entity prefix: entities (we kept some legacy entities/projects/ pages)
+ * Default directory prefix whitelist. These are the top-level slug dirs the
+ * extractor recognizes as entity references when no override is configured.
  */
-const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities)';
+export const DEFAULT_ENTITY_LINK_DIRS = [
+  'people', 'companies', 'meetings', 'concepts', 'deal', 'civic',
+  'project', 'projects', 'source', 'media', 'yc', 'tech', 'finance',
+  'personal', 'openclaw', 'entities',
+] as const;
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeEntityLinkDirs(entityDirs?: readonly string[]): string[] {
+  const raw = entityDirs && entityDirs.length > 0 ? entityDirs : DEFAULT_ENTITY_LINK_DIRS;
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const dir of raw) {
+    const trimmed = dir.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+function buildDirPattern(entityDirs?: readonly string[]): string {
+  const dirs = normalizeEntityLinkDirs(entityDirs);
+  return `(?:${dirs.map(escapeRegex).join('|')})`;
+}
+
+function buildEntityRefRegex(entityDirs?: readonly string[]): RegExp {
+  const dirPattern = buildDirPattern(entityDirs);
+  return new RegExp(
+    `\\[([^\\]]+)\\]\\((?:\\.\\.\\/)*(${dirPattern}\\/[^)\\s]+?)(?:\\.md)?\\)`,
+    'g',
+  );
+}
+
+function buildWikilinkRegex(entityDirs?: readonly string[]): RegExp {
+  const dirPattern = buildDirPattern(entityDirs);
+  return new RegExp(
+    `\\[\\[(${dirPattern}\\/[^|\\]#]+?)(?:#[^|\\]]*?)?(?:\\|([^\\]]+?))?\\]\\]`,
+    'g',
+  );
+}
+
+function buildQualifiedWikilinkRegex(entityDirs?: readonly string[]): RegExp {
+  const dirPattern = buildDirPattern(entityDirs);
+  return new RegExp(
+    `\\[\\[([a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?):(${dirPattern}\\/[^|\\]#]+?)(?:#[^|\\]]*?)?(?:\\|([^\\]]+?))?\\]\\]`,
+    'g',
+  );
+}
+
+function buildBareSlugRegex(entityDirs?: readonly string[]): RegExp {
+  const dirPattern = buildDirPattern(entityDirs);
+  return new RegExp(
+    `\\b(${dirPattern}\\/[a-z0-9][a-z0-9/-]*[a-z0-9])\\b`,
+    'g',
+  );
+}
 
 /**
  * Match `[Name](path)` markdown links pointing to entity directories.
@@ -56,10 +113,7 @@ const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|pr
  * The regex permits an optional `../` prefix (any number) and an optional
  * `.md` suffix so the same function works for both filesystem and DB content.
  */
-const ENTITY_REF_RE = new RegExp(
-  `\\[([^\\]]+)\\]\\((?:\\.\\.\\/)*(${DIR_PATTERN}\\/[^)\\s]+?)(?:\\.md)?\\)`,
-  'g',
-);
+const ENTITY_REF_RE = buildEntityRefRegex();
 
 /**
  * Match Obsidian-style `[[path]]` or `[[path|Display Text]]` wikilinks.
@@ -69,10 +123,7 @@ const ENTITY_REF_RE = new RegExp(
  * anchors (`#heading`), skips external URLs. Wiki KBs use this format almost
  * exclusively so missing it leaves the graph empty.
  */
-const WIKILINK_RE = new RegExp(
-  `\\[\\[(${DIR_PATTERN}\\/[^|\\]#]+?)(?:#[^|\\]]*?)?(?:\\|([^\\]]+?))?\\]\\]`,
-  'g',
-);
+const WIKILINK_RE = buildWikilinkRegex();
 
 /**
  * v0.17.0: qualified wikilink `[[source-id:dir/slug]]` or
@@ -86,10 +137,7 @@ const WIKILINK_RE = new RegExp(
  * the unqualified regex (the source prefix would not satisfy DIR_PATTERN
  * anyway, but the two-pass approach keeps intent crystal-clear).
  */
-const QUALIFIED_WIKILINK_RE = new RegExp(
-  `\\[\\[([a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?):(${DIR_PATTERN}\\/[^|\\]#]+?)(?:#[^|\\]]*?)?(?:\\|([^\\]]+?))?\\]\\]`,
-  'g',
-);
+const QUALIFIED_WIKILINK_RE = buildQualifiedWikilinkRegex();
 
 /**
  * Strip fenced code blocks (```...```) and inline code (`...`) from markdown,
@@ -178,16 +226,19 @@ export function extractCodeRefs(content: string): CodeRef[] {
  * here; caller dedups). Slugs appearing inside fenced or inline code blocks
  * are excluded — those are typically code samples, not real entity references.
  */
-export function extractEntityRefs(content: string): EntityRef[] {
+export function extractEntityRefs(content: string, opts?: { entityDirs?: readonly string[] }): EntityRef[] {
   const stripped = stripCodeBlocks(content);
   const refs: EntityRef[] = [];
+  const entityRefRe = opts?.entityDirs ? buildEntityRefRegex(opts.entityDirs) : ENTITY_REF_RE;
+  const wikilinkRe = opts?.entityDirs ? buildWikilinkRegex(opts.entityDirs) : WIKILINK_RE;
+  const qualifiedWikilinkRe = opts?.entityDirs ? buildQualifiedWikilinkRegex(opts.entityDirs) : QUALIFIED_WIKILINK_RE;
   let match: RegExpExecArray | null;
 
   // 1. Markdown links: [Name](path)
   //    Markdown links have no source-qualification syntax — they're
   //    always unqualified. Omit sourceId so the shape stays compatible
   //    with pre-v0.17 consumers doing strict equality.
-  const mdPattern = new RegExp(ENTITY_REF_RE.source, ENTITY_REF_RE.flags);
+  const mdPattern = new RegExp(entityRefRe.source, entityRefRe.flags);
   while ((match = mdPattern.exec(stripped)) !== null) {
     const name = match[1];
     const fullPath = match[2];
@@ -200,7 +251,7 @@ export function extractEntityRefs(content: string): EntityRef[] {
   //     Must run BEFORE the unqualified pass or we'd double-emit. We also
   //     mask out the matched spans so pass 2b can't grab them.
   const qualifiedRanges: Array<[number, number]> = [];
-  const qualPattern = new RegExp(QUALIFIED_WIKILINK_RE.source, QUALIFIED_WIKILINK_RE.flags);
+  const qualPattern = new RegExp(qualifiedWikilinkRe.source, qualifiedWikilinkRe.flags);
   while ((match = qualPattern.exec(stripped)) !== null) {
     const sourceId = match[1];
     let slug = match[2].trim();
@@ -216,7 +267,7 @@ export function extractEntityRefs(content: string): EntityRef[] {
   // 2b. Unqualified Obsidian wikilinks: [[path]] or [[path|Display Text]]
   //     Same shape rule: omit sourceId when unqualified.
   const unmasked = maskRanges(stripped, qualifiedRanges);
-  const wikiPattern = new RegExp(WIKILINK_RE.source, WIKILINK_RE.flags);
+  const wikiPattern = new RegExp(wikilinkRe.source, wikilinkRe.flags);
   while ((match = wikiPattern.exec(unmasked)) !== null) {
     let slug = match[1].trim();
     if (!slug) continue;
@@ -313,11 +364,13 @@ export async function extractPageLinks(
   frontmatter: Record<string, unknown>,
   pageType: PageType,
   resolver: SlugResolver,
+  opts?: { entityDirs?: readonly string[] },
 ): Promise<PageLinksResult> {
   const candidates: LinkCandidate[] = [];
+  const entityDirs = opts?.entityDirs;
 
   // 1. Markdown entity refs.
-  for (const ref of extractEntityRefs(content)) {
+  for (const ref of extractEntityRefs(content, { entityDirs })) {
     const idx = content.indexOf(ref.name);
     // Wider context window (240 chars vs original 80) catches verbs that
     // appear at sentence-or-paragraph distance from the slug — common in
@@ -336,10 +389,7 @@ export async function extractPageLinks(
   // Limited to the same entity directories ENTITY_REF_RE covers.
   // Code blocks are stripped first — slugs in code samples are not real refs.
   const strippedContent = stripCodeBlocks(content);
-  const bareRe = new RegExp(
-    `\\b(${DIR_PATTERN}\\/[a-z0-9][a-z0-9/-]*[a-z0-9])\\b`,
-    'g',
-  );
+  const bareRe = buildBareSlugRegex(entityDirs);
   let m: RegExpExecArray | null;
   while ((m = bareRe.exec(strippedContent)) !== null) {
     // Skip matches that are part of a markdown link (already handled above).
@@ -852,6 +902,20 @@ function isValidDate(s: string): boolean {
 }
 
 // ─── Auto-link config ───────────────────────────────────────────
+
+/**
+ * Read the configured entity-link directories for path-based extraction.
+ *
+ * Config key: `extract.link_dirs`
+ * Format: comma and/or newline separated top-level prefixes.
+ * Falls back to DEFAULT_ENTITY_LINK_DIRS when unset or empty.
+ */
+export async function getEntityLinkDirs(engine: BrainEngine): Promise<string[]> {
+  const val = await engine.getConfig('extract.link_dirs');
+  if (val == null) return [...DEFAULT_ENTITY_LINK_DIRS];
+  const parsed = normalizeEntityLinkDirs(val.split(/[\n,]/g));
+  return parsed.length > 0 ? parsed : [...DEFAULT_ENTITY_LINK_DIRS];
+}
 
 /**
  * Read the auto_link config flag. Defaults to TRUE (auto-link is on by default).

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -15,7 +15,7 @@ import { expandQuery } from './search/expansion.ts';
 import { dedupResults } from './search/dedup.ts';
 import { captureEvalCandidate, isEvalCaptureEnabled, isEvalScrubEnabled } from './eval-capture.ts';
 import type { HybridSearchMeta } from './types.ts';
-import { extractPageLinks, isAutoLinkEnabled, isAutoTimelineEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef } from './link-extraction.ts';
+import { extractPageLinks, getEntityLinkDirs, isAutoLinkEnabled, isAutoTimelineEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef } from './link-extraction.ts';
 import * as db from './db.ts';
 
 // --- Types ---
@@ -497,8 +497,9 @@ async function runAutoLink(
   const fullContent = parsed.compiled_truth + '\n' + parsed.timeline;
   // Live-mode resolver: per-put throwaway cache, pg_trgm + optional search.
   const resolver = makeResolver(engine, { mode: 'live' });
+  const entityDirs = await getEntityLinkDirs(engine);
   const { candidates, unresolved } = await extractPageLinks(
-    slug, fullContent, parsed.frontmatter, parsed.type, resolver,
+    slug, fullContent, parsed.frontmatter, parsed.type, resolver, { entityDirs },
   );
 
   // Resolve which targets exist (skip refs to non-existent pages to avoid FK

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -7,6 +7,8 @@ import {
   makeResolver,
   parseTimelineEntries,
   isAutoLinkEnabled,
+  getEntityLinkDirs,
+  DEFAULT_ENTITY_LINK_DIRS,
   FRONTMATTER_LINK_MAP,
   type SlugResolver,
 } from '../src/core/link-extraction.ts';
@@ -70,6 +72,46 @@ describe('extractEntityRefs', () => {
     const refs = extractEntityRefs('See [Standup](meetings/2026-01-15-standup).');
     expect(refs.length).toBe(1);
     expect(refs[0].dir).toBe('meetings');
+  });
+
+  test('respects custom entityDirs for markdown links', () => {
+    const content = 'See [GBrain adoption](01 Projects/gbrain-adoption).';
+    expect(extractEntityRefs(content)).toEqual([]);
+
+    const refs = extractEntityRefs(content, { entityDirs: ['01 Projects', 'people'] });
+    expect(refs).toEqual([
+      { name: 'GBrain adoption', slug: '01 Projects/gbrain-adoption', dir: '01 Projects' },
+    ]);
+  });
+
+  test('respects custom entityDirs for wikilinks', () => {
+    const content = 'See [[03 Resources/email-digest|Email digest]].';
+    expect(extractEntityRefs(content)).toEqual([]);
+
+    const refs = extractEntityRefs(content, { entityDirs: ['03 Resources', 'people'] });
+    expect(refs).toEqual([
+      { name: 'Email digest', slug: '03 Resources/email-digest', dir: '03 Resources' },
+    ]);
+  });
+
+  test('respects custom entityDirs for qualified wikilinks', () => {
+    const content = 'See [[wiki:03 Resources/email-digest|Email digest]].';
+    expect(extractEntityRefs(content)).toEqual([]);
+
+    const refs = extractEntityRefs(content, { entityDirs: ['03 Resources', 'people'] });
+    expect(refs).toEqual([
+      { name: 'Email digest', slug: '03 Resources/email-digest', dir: '03 Resources', sourceId: 'wiki' },
+    ]);
+  });
+
+  test('escapes custom entityDirs before building regexes', () => {
+    const content = 'See [[Projects (Active)/gbrain-pr|GBrain PR]].';
+    const refs = extractEntityRefs(content, { entityDirs: ['Projects (Active)'] });
+    expect(refs).toEqual([
+      { name: 'GBrain PR', slug: 'Projects (Active)/gbrain-pr', dir: 'Projects (Active)' },
+    ]);
+
+    expect(extractEntityRefs('See [[Projects Active/gbrain-pr]].', { entityDirs: ['Projects (Active)'] })).toEqual([]);
   });
 });
 
@@ -142,6 +184,23 @@ describe('extractPageLinks', () => {
     );
     const aliceLink = candidates.find(c => c.targetSlug === 'people/alice');
     expect(aliceLink!.linkType).toBe('attended');
+  });
+
+  test('respects custom entityDirs for bare slug extraction', async () => {
+    const content = 'See 03 Resources/email-digest for details.';
+    const baseline = await extractPageLinks('docs/x', content, {}, 'concept', nullResolver);
+    expect(baseline.candidates).toEqual([]);
+
+    const { candidates } = await extractPageLinks(
+      'docs/x',
+      content,
+      {},
+      'concept',
+      nullResolver,
+      { entityDirs: ['03 Resources', 'people'] },
+    );
+    const digest = candidates.find(c => c.targetSlug === '03 Resources/email-digest');
+    expect(digest).toBeDefined();
   });
 });
 
@@ -398,6 +457,23 @@ function makeFakeEngine(configMap: Map<string, string | null>): BrainEngine {
     getConfig: async (key: string) => configMap.get(key) ?? null,
   } as unknown as BrainEngine;
 }
+
+describe('getEntityLinkDirs', () => {
+  test('uses defaults when config is unset', async () => {
+    const engine = makeFakeEngine(new Map());
+    expect(await getEntityLinkDirs(engine)).toEqual([...DEFAULT_ENTITY_LINK_DIRS]);
+  });
+
+  test('uses defaults when config is empty after trimming', async () => {
+    const engine = makeFakeEngine(new Map([['extract.link_dirs', ' ,  \n  , ']]));
+    expect(await getEntityLinkDirs(engine)).toEqual([...DEFAULT_ENTITY_LINK_DIRS]);
+  });
+
+  test('parses comma/newline-separated custom dirs and de-dupes case-insensitively', async () => {
+    const engine = makeFakeEngine(new Map([['extract.link_dirs', 'people, 01 Projects\n03 Resources\npeople\n03 resources']]));
+    expect(await getEntityLinkDirs(engine)).toEqual(['people', '01 Projects', '03 Resources']);
+  });
+});
 
 describe('isAutoLinkEnabled', () => {
   test('null/undefined -> true (default on)', async () => {


### PR DESCRIPTION
Replace the hardcoded top-level entity directory whitelist with a configurable list used by path-based link extraction.

This keeps the existing matching behavior for nested paths after a recognized top-level directory, but allows the recognized top-level prefixes themselves to be customized.

Configuration:
  extract.link_dirs = people,companies,meetings,concepts,deal,civic,project,projects,source,media,yc

Custom example:
  extract.link_dirs = people,companies,01 Projects,03 Resources

When unset or empty, extraction falls back to DEFAULT_ENTITY_LINK_DIRS.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->