### PR TITLE
fix(config): render object values in 'gbrain config show' instead of [object Object]

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -9,6 +9,25 @@ function redactUrl(url: string): string {
   );
 }
 
+function redactConfigValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactConfigValue);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, val]) => {
+        if (typeof val === 'string') {
+          if (/key|secret|token|password/i.test(key)) return [key, '***'];
+          if (val.includes('postgresql://')) return [key, redactUrl(val)];
+          return [key, val];
+        }
+        return [key, redactConfigValue(val)];
+      }),
+    );
+  }
+  return value;
+}
+
 export async function runConfig(engine: BrainEngine, args: string[]) {
   const action = args[0];
   const key = args[1];
@@ -26,7 +45,9 @@ export async function runConfig(engine: BrainEngine, args: string[]) {
         ? redactUrl(v)
         : typeof v === 'string' && (k.includes('key') || k.includes('secret'))
           ? '***'
-          : v;
+          : typeof v === 'object' && v !== null
+            ? JSON.stringify(redactConfigValue(v), null, 2).split('\n').join('\n    ')
+            : v;
       console.log(`  ${k}: ${display}`);
     }
     return;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from 'bun:test';
-import { readFileSync } from 'fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { runConfig } from '../src/commands/config.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 // redactUrl is not exported, so we test it by reading the source and
 // reimplementing the regex to verify the pattern, then test via CLI
@@ -59,5 +64,54 @@ describe('config source correctness', () => {
 
   test('redactUrl uses the correct regex pattern', () => {
     expect(configSource).toContain('postgresql:\\/\\/');
+  });
+});
+
+describe('config show', () => {
+  test('renders object values as indented JSON and preserves string redaction', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-config-show-'));
+    const configDir = join(home, '.gbrain');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), JSON.stringify({
+      engine: 'postgres',
+      database_url: 'postgresql://user:secret@host:5432/dbname',
+      openai_api_key: 'sk-test',
+      provider_base_urls: {
+        ollama: 'http://localhost:11434',
+      },
+      storage: {
+        bucket: 'brain-files',
+        serviceRoleKey: 'nested-service-role-secret',
+      },
+      replicas: {
+        analytics: 'postgresql://reader:nested-pg-pass@analytics:5432/db',
+      },
+    }, null, 2));
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      await withEnv({ GBRAIN_HOME: home, OPENAI_API_KEY: undefined }, async () => {
+        await runConfig({} as BrainEngine, ['show']);
+      });
+    } finally {
+      console.log = originalLog;
+      rmSync(home, { recursive: true, force: true });
+    }
+
+    const output = logs.join('\n');
+    expect(output).not.toContain('[object Object]');
+    expect(output).toContain('provider_base_urls: {');
+    expect(output).toContain('      "ollama": "http://localhost:11434"');
+    expect(output).toContain('database_url: postgresql://user:***@host:5432/dbname');
+    expect(output).toContain('openai_api_key: ***');
+    expect(output).toContain('storage: {');
+    expect(output).toContain('      "bucket": "brain-files"');
+    expect(output).toContain('      "serviceRoleKey": "***"');
+    expect(output).not.toContain('nested-service-role-secret');
+    expect(output).toContain('"analytics": "postgresql://reader:***@analytics:5432/db"');
+    expect(output).not.toContain('nested-pg-pass');
   });
 });


### PR DESCRIPTION
## Summary

`gbrain config show` now renders object-valued config fields as indented JSON instead of `[object Object]`. The reporter's `provider_base_urls: { "ollama": "http://localhost:11434" }` example now reads correctly.

## Why this matters

The existing rendering ternary in `src/commands/config.ts` only handled string values. When `config.json` contained an object value, `console.log` coerced it via `Object.prototype.toString` and printed the literal string `[object Object]`. Reporter [#575](https://github.com/garrytan/gbrain/issues/575) hit this with `provider_base_urls`, which is the natural shape for per-provider endpoint maps.

Decided to throw my hat in the ring and help @garrytan !

## Approach

- Added an object-rendering branch to the existing ternary. Multi-line JSON is indented by 4 spaces on continuation lines so nested keys still read as part of the parent entry.
- Added a small recursive `redactConfigValue` helper that runs before `JSON.stringify`, so nested credentials are not unmasked by the new rendering. Specifically:
  - String values whose key matches `/key|secret|token|password/i` render as `***` (the same pattern the existing top-level redaction uses, applied recursively).
  - String values that look like `postgresql://` URLs go through the existing `redactUrl` (the same pattern the existing top-level path uses, applied recursively).
- Top-level redaction behaviour is unchanged; the helper only applies to the new object-rendering branch.

## Testing

`bun test test/config.test.ts` (9/9 pass) and `bun run typecheck` both clean. The added test covers:

- `provider_base_urls` renders as JSON (no `[object Object]`).
- Top-level `database_url` still goes through `redactUrl`.
- Top-level `openai_api_key` still renders as `***`.
- Nested `storage.serviceRoleKey` is redacted (catches the secret-name regex applied recursively).
- Nested `replicas.analytics` postgres URL is redacted (catches `redactUrl` applied recursively).

Fixes #575

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->