### PR TITLE
fix(cli): CLI_ONLY commands should short-circuit on --help instead of executing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,15 @@ for (const op of operations) {
 
 // CLI-only commands that bypass the operation layer
 const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think']);
+// CLI-only commands whose handlers print their own --help text. These are
+// excluded from the generic short-circuit so detailed per-command and
+// per-subcommand usage stays reachable.
+const CLI_ONLY_SELF_HELP = new Set([
+  'upgrade', 'post-upgrade', 'check-update',
+  'embed', 'config',
+  'skillpack', 'skillpack-check',
+  'integrations', 'friction',
+]);
 
 async function main() {
   // Parse global flags (--quiet / --progress-json / --progress-interval)
@@ -58,10 +67,14 @@ async function main() {
   }
 
   // Per-command --help
-  if (subArgs.includes('--help') || subArgs.includes('-h')) {
+  if (hasHelpFlag(subArgs)) {
     const op = cliOps.get(command);
     if (op) {
       printOpHelp(op);
+      return;
+    }
+    if (CLI_ONLY.has(command) && !CLI_ONLY_SELF_HELP.has(command)) {
+      printCliOnlyHelp(command);
       return;
     }
   }
@@ -134,6 +147,16 @@ async function main() {
   } finally {
     await engine.disconnect();
   }
+}
+
+function hasHelpFlag(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
+function printCliOnlyHelp(command: string) {
+  console.log(`Usage: gbrain ${command}`);
+  console.log('');
+  console.log(`gbrain ${command} - run gbrain --help for the full command list.`);
 }
 
 /**

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,8 +1,22 @@
 import { describe, test, expect } from 'bun:test';
-import { readFileSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 // Read cli.ts source for structural checks
 const cliSource = readFileSync(new URL('../src/cli.ts', import.meta.url), 'utf-8');
+const repoRoot = new URL('..', import.meta.url).pathname;
+
+function isolatedEnv(home: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value;
+  }
+  delete env.GBRAIN_DATABASE_URL;
+  delete env.DATABASE_URL;
+  env.GBRAIN_HOME = home;
+  return env;
+}
 
 describe('CLI structure', () => {
   test('imports operations from operations.ts', () => {
@@ -86,7 +100,7 @@ describe('CLI dispatch integration', () => {
 
   test('per-command --help prints usage without DB connection', async () => {
     const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', 'get', '--help'], {
-      cwd: new URL('..', import.meta.url).pathname,
+      cwd: repoRoot,
       stdout: 'pipe',
       stderr: 'pipe',
     });
@@ -98,7 +112,7 @@ describe('CLI dispatch integration', () => {
 
   test('upgrade --help prints usage without running upgrade', async () => {
     const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', 'upgrade', '--help'], {
-      cwd: new URL('..', import.meta.url).pathname,
+      cwd: repoRoot,
       stdout: 'pipe',
       stderr: 'pipe',
     });
@@ -108,9 +122,72 @@ describe('CLI dispatch integration', () => {
     expect(exitCode).toBe(0);
   });
 
+  test('sync --help short-circuits CLI-only dispatch without running sync', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-cli-help-'));
+    try {
+      const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', 'sync', '--help'], {
+        cwd: repoRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: isolatedEnv(home),
+      });
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      const exitCode = await proc.exited;
+      expect(stdout).toContain('Usage: gbrain sync');
+      expect(stdout).toContain('run gbrain --help for the full command list');
+      expect(stdout).not.toContain('Already up to date.');
+      expect(stderr).not.toContain('Already up to date.');
+      expect(existsSync(join(home, '.gbrain', 'config.json'))).toBe(false);
+      expect(exitCode).toBe(0);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test('doctor --help short-circuits CLI-only dispatch without diagnostics', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-cli-help-'));
+    try {
+      const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', 'doctor', '--help'], {
+        cwd: repoRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: isolatedEnv(home),
+      });
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      const exitCode = await proc.exited;
+      expect(stdout).toContain('Usage: gbrain doctor');
+      expect(stdout).not.toContain('resolver_health');
+      expect(stderr).not.toContain('No brain configured');
+      expect(exitCode).toBe(0);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test('init --help short-circuits CLI-only dispatch without writing config', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-cli-help-'));
+    try {
+      const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', 'init', '--help'], {
+        cwd: repoRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: isolatedEnv(home),
+      });
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      expect(stdout).toContain('Usage: gbrain init');
+      expect(existsSync(join(home, '.gbrain', 'config.json'))).toBe(false);
+      expect(exitCode).toBe(0);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   test('--help prints global help', async () => {
     const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', '--help'], {
-      cwd: new URL('..', import.meta.url).pathname,
+      cwd: repoRoot,
       stdout: 'pipe',
       stderr: 'pipe',
     });
@@ -123,7 +200,7 @@ describe('CLI dispatch integration', () => {
 
   test('--tools-json outputs valid JSON with operations', async () => {
     const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', '--tools-json'], {
-      cwd: new URL('..', import.meta.url).pathname,
+      cwd: repoRoot,
       stdout: 'pipe',
       stderr: 'pipe',
     });


### PR DESCRIPTION
## Summary

`gbrain sync --help`, `gbrain doctor --help`, `gbrain init --help`, and other `CLI_ONLY` commands no longer fall through to live execution when invoked with `--help`. They now print a generic usage line and exit 0 without running.

## Why this matters

[Issue #578](https://github.com/garrytan/gbrain/issues/578) diagnosed the dispatcher in `src/cli.ts:57-67`: the per-command `--help` short-circuit only fired when `cliOps.get(command)` returned a shared op. For `CLI_ONLY` commands (`sync`, `doctor`, `init`, `autopilot`, ~50 entries total), `cliOps.get()` returned `undefined`, so the `if (op)` branch never executed and dispatch fell through to `handleCliOnly()`.

@jbaham2 confirmed the same bug class on `gbrain init --help` with destructive impact: their existing postgres-mode `~/.gbrain/config.json` was overwritten by the init default (PGLite), silently disconnecting them from a populated brain. Recovery required setting `GBRAIN_DATABASE_URL` to override the now-broken config.

## Approach

Smallest-diff fix matching the plan's Option A:

1. Added `CLI_ONLY_SELF_HELP` allowlist for commands whose handlers already implement `--help` correctly. Verified by reading each handler's source:
   - `upgrade`, `post-upgrade`, `check-update`
   - `embed`, `config`
   - `skillpack`, `skillpack-check`
   - `integrations`, `friction`
2. When the dispatcher sees `--help`/`-h` for a `CLI_ONLY` command not in the allowlist, it prints a generic usage line via `printCliOnlyHelp(command)` and returns BEFORE `handleCliOnly()` is reached.
3. Allowlisted commands fall through to `handleCliOnly()` so their detailed per-command and per-subcommand help (`gbrain skillpack install --help`, `gbrain integrations show --help`, etc.) stays reachable.

The trade-off: commands not in the allowlist get a generic placeholder rather than hand-rolled per-command usage. That seems like the right default given the size of `CLI_ONLY` (~50 entries) and that the issue specifically called out destructive fall-through as the problem to solve.

If you'd prefer a different cut (e.g., short-circuit only the explicitly-confirmed list of `sync`/`doctor`/`init`/`autopilot`, or expand the allowlist further), happy to adjust.

## Testing

`bun test test/cli.test.ts` (17/17 pass) and `bun run typecheck` clean. Added focused integration tests that spawn `bun run src/cli.ts <cmd> --help` and assert:

- `gbrain sync --help` exits 0 with help text and does NOT run a sync (no `git pull`, no DB writes, no `Already up to date.` output).
- `gbrain doctor --help` exits 0 without running diagnostics.
- `gbrain init --help` exits 0 without writing or overwriting `config.json`.

Smoke-tested allowlisted commands locally to confirm their detailed help is preserved:
- `gbrain skillpack --help` -> subcommand list with descriptions.
- `gbrain integrations --help` -> integration dashboard usage.
- `gbrain friction --help` -> friction reporter subcommand list.

Fixes #578

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->