### PR TITLE
fix(sync): handle detached HEAD by skipping pull and ingesting local working tree

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -196,6 +196,33 @@ function git(repoPath: string, ...args: string[]): string {
   }).trim();
 }
 
+function isDetachedHead(repoPath: string): boolean {
+  try {
+    git(repoPath, 'symbolic-ref', '--quiet', 'HEAD');
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+function unique<T>(items: T[]): T[] {
+  return [...new Set(items)];
+}
+
+function buildDetachedWorkingTreeManifest(repoPath: string): SyncManifest {
+  const manifest = buildSyncManifest(git(repoPath, 'diff', '--name-status', '-M', 'HEAD'));
+  const untracked = git(repoPath, 'ls-files', '--others', '--exclude-standard')
+    .split('\n')
+    .filter(line => line.length > 0);
+
+  return {
+    added: unique([...manifest.added, ...untracked]),
+    modified: unique(manifest.modified),
+    deleted: unique(manifest.deleted),
+    renamed: manifest.renamed,
+  };
+}
+
 // v0.18.0 Step 5: source-scoped sync state helpers. When opts.sourceId
 // is set, read/write the per-source row instead of the global config
 // keys. These wrappers centralize the branch so every read/write site
@@ -375,13 +402,21 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     throw new Error(`Not a git repository: ${repoPath}. GBrain sync requires a git-initialized repo.`);
   }
 
+  // Detect detached HEAD up front so the working-tree fallback fires for both
+  // the default sync and `--no-pull` callers. Only the actual git pull is
+  // gated on opts.noPull.
+  const detachedHead = isDetachedHead(repoPath);
+  if (detachedHead && !opts.noPull) {
+    console.error(`Detached HEAD on ${repoPath}; skipping git pull. Syncing from local working tree.`);
+  }
+
   // Git pull (unless --no-pull). v0.28.1 codex finding (HIGH): the legacy
   // git() helper at sync.ts:192 spawns git without GIT_SSRF_FLAGS, so
   // every steady-state pull was bypassing the redirect/submodule/protocol
   // hardening that cloneRepo applies. Route through pullRepo from
   // git-remote.ts so the flag set is consistent across initial clone and
   // ongoing pulls — single source of truth for the defensive flags.
-  if (!opts.noPull) {
+  if (!opts.noPull && !detachedHead) {
     try {
       const { pullRepo } = await import('../core/git-remote.ts');
       pullRepo(repoPath);
@@ -440,8 +475,14 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   const currentVersion = String(CHUNKER_VERSION);
   const versionMismatch = storedVersion !== null && storedVersion !== currentVersion;
   const versionNeverSet = storedVersion === null && opts.sourceId !== undefined;
+  const detachedWorkingTreeManifest = detachedHead ? buildDetachedWorkingTreeManifest(repoPath) : null;
+  const hasDetachedWorkingTreeChanges = detachedWorkingTreeManifest !== null &&
+    (detachedWorkingTreeManifest.added.length > 0 ||
+      detachedWorkingTreeManifest.modified.length > 0 ||
+      detachedWorkingTreeManifest.deleted.length > 0 ||
+      detachedWorkingTreeManifest.renamed.length > 0);
 
-  if (lastCommit === headCommit && !versionMismatch && !versionNeverSet) {
+  if (lastCommit === headCommit && !versionMismatch && !versionNeverSet && !hasDetachedWorkingTreeChanges) {
     return {
       status: 'up_to_date',
       fromCommit: lastCommit,
@@ -466,6 +507,12 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // Diff using git diff (net result, not per-commit)
   const diffOutput = git(repoPath, 'diff', '--name-status', '-M', `${lastCommit}..${headCommit}`);
   const manifest = buildSyncManifest(diffOutput);
+  if (detachedWorkingTreeManifest) {
+    manifest.added = unique([...manifest.added, ...detachedWorkingTreeManifest.added]);
+    manifest.modified = unique([...manifest.modified, ...detachedWorkingTreeManifest.modified]);
+    manifest.deleted = unique([...manifest.deleted, ...detachedWorkingTreeManifest.deleted]);
+    manifest.renamed = [...manifest.renamed, ...detachedWorkingTreeManifest.renamed];
+  }
 
   // Filter to syncable files (strategy-aware)
   const syncOpts = opts.strategy ? { strategy: opts.strategy } : undefined;

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -359,6 +359,90 @@ describe('performSync dry-run never writes', () => {
     // Structural assertion: the contract includes `embedded: number`.
     expect(typeof result.embedded).toBe('number');
   });
+
+  test('detached HEAD skips git pull and ingests local working-tree files', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const seeded = await performSync(engine, {
+      repoPath,
+      noPull: true,
+      noEmbed: true,
+      noExtract: true,
+    });
+    expect(seeded.status).toBe('first_sync');
+
+    execSync('git checkout --detach HEAD', { cwd: repoPath, stdio: 'pipe' });
+    writeFileSync(join(repoPath, 'people/detached-local.md'), [
+      '---',
+      'type: person',
+      'title: Detached Local',
+      '---',
+      '',
+      'This file exists only in the detached working tree.',
+    ].join('\n'));
+
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(' '));
+    };
+
+    try {
+      const result = await performSync(engine, {
+        repoPath,
+        noEmbed: true,
+        noExtract: true,
+      });
+
+      expect(result.status).toBe('synced');
+      expect(result.added).toBe(1);
+      expect(result.pagesAffected).toContain('people/detached-local');
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(errors.join('\n')).toContain(`Detached HEAD on ${repoPath}; skipping git pull. Syncing from local working tree.`);
+    expect(errors.join('\n')).not.toContain('git pull failed');
+
+    const page = await engine.getPage('people/detached-local');
+    expect(page).not.toBeNull();
+    expect(page!.title).toBe('Detached Local');
+  });
+
+  test('detached HEAD with --no-pull also ingests local working-tree files', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const seeded = await performSync(engine, {
+      repoPath,
+      noPull: true,
+      noEmbed: true,
+      noExtract: true,
+    });
+    expect(seeded.status).toBe('first_sync');
+
+    execSync('git checkout --detach HEAD', { cwd: repoPath, stdio: 'pipe' });
+    writeFileSync(join(repoPath, 'people/detached-nopull.md'), [
+      '---',
+      'type: person',
+      'title: Detached NoPull',
+      '---',
+      '',
+      'Only in detached working tree, --no-pull caller.',
+    ].join('\n'));
+
+    const result = await performSync(engine, {
+      repoPath,
+      noPull: true,
+      noEmbed: true,
+      noExtract: true,
+    });
+
+    expect(result.status).toBe('synced');
+    expect(result.added).toBe(1);
+    expect(result.pagesAffected).toContain('people/detached-nopull');
+
+    const page = await engine.getPage('people/detached-nopull');
+    expect(page).not.toBeNull();
+    expect(page!.title).toBe('Detached NoPull');
+  });
 });
 
 describe('sync regression — #132 nested transaction deadlock', () => {


### PR DESCRIPTION
## Summary

`gbrain sync` on a detached-HEAD repo no longer silently no-ops. It now detects the detached state up front, skips `git pull --ff-only`, and falls back to ingesting the working tree (tracked diff against HEAD plus untracked files) so local-only edits get picked up.

## Why this matters

[Issue #574](https://github.com/garrytan/gbrain/issues/574) describes the exact failure mode: in a detached-HEAD worktree, `git pull --ff-only` errors with "You are not currently on a branch", the existing `try/catch` swallows it as `Warning: git pull failed:`, and the rest of sync sees `lastCommit === HEAD`, short-circuits to "Already up to date.", and never reads the working tree. Reporter cited the gstack `gstack-brain-sync` federation flow where two worktrees can't share `main`, so the brain worktree gets stuck in detached HEAD and silently no-ops every subsequent sync.

## Approach

Picked option (b) from the issue body (skip pull, ingest working tree) over (a) hard-fail and (c) skip + non-zero exit. (b) preserves the federation use case the reporter described while still surfacing what happened in the user-facing message.

Changes in `src/commands/sync.ts`:

1. Added `isDetachedHead(repoPath)` using `git symbolic-ref --quiet HEAD` (exit code 1 -> detached). Wrapped in try/catch so the existing `git()` helper's exception path doesn't surface to the user.
2. Detection runs unconditionally, NOT inside `if (!opts.noPull)`. This way `gbrain sync --no-pull` on a detached worktree also gets the working-tree fallback, not just the default-pull path.
3. The actual `git pull` is now gated on `!opts.noPull && !detachedHead`. Existing pull semantics for the attached-HEAD path are unchanged.
4. Added `buildDetachedWorkingTreeManifest(repoPath)` that combines `git diff --name-status HEAD` (tracked changes) and `git ls-files --others --exclude-standard` (untracked files) into the same `SyncManifest` shape the rest of the pipeline uses. The downstream sync flow processes added/modified/deleted/renamed without caring whether the source was a commit diff or a working-tree diff.

The user-facing message is the literal string from the issue's option (b): `Detached HEAD on <repoPath>; skipping git pull. Syncing from local working tree.` Exit code stays 0 because we did sync, just from a different source.

If you'd rather have option (a) hard-fail or (c) explicit skip + non-zero exit, the delta is small. Happy to switch.

## Testing

`bun run typecheck` clean. `bun test test/sync.test.ts` detached-HEAD tests both pass:

- `detached HEAD skips git pull and ingests local working-tree files` — default-pull path. Asserts no `git pull failed` warning, the local-only file gets imported, and `result.added === 1`.
- `detached HEAD with --no-pull also ingests local working-tree files` — `--no-pull` path. Asserts the working-tree fallback fires regardless of pull mode, since detection is outside the pull gate.

Both tests use a real `git worktree`-style detached checkout (`git checkout --detach HEAD`) and write a markdown file that doesn't exist anywhere in git history, then verify the page is imported with the expected title.

Fixes #574

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->