### PR TITLE
fix: preserve source id during sync imports

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -28,7 +28,11 @@ export interface RunImportResult {
   failures: Array<{ path: string; error: string }>;
 }
 
-export async function runImport(engine: BrainEngine, args: string[], opts: { commit?: string } = {}): Promise<RunImportResult> {
+export async function runImport(
+  engine: BrainEngine,
+  args: string[],
+  opts: { commit?: string; sourceId?: string } = {},
+): Promise<RunImportResult> {
   const noEmbed = args.includes('--no-embed');
   const fresh = args.includes('--fresh');
   const jsonOutput = args.includes('--json');
@@ -105,7 +109,7 @@ export async function runImport(engine: BrainEngine, args: string[], opts: { com
   async function processFile(eng: BrainEngine, filePath: string) {
     const relativePath = relative(dir, filePath);
     try {
-      const result = await importFile(eng, filePath, relativePath, { noEmbed });
+      const result = await importFile(eng, filePath, relativePath, { noEmbed, sourceId: opts.sourceId });
       if (result.status === 'imported') {
         imported++;
         chunksCreated += result.chunks;

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -28,6 +28,30 @@ export interface RunImportResult {
   failures: Array<{ path: string; error: string }>;
 }
 
+async function writeImportSyncAnchor(
+  engine: BrainEngine,
+  sourceId: string | undefined,
+  which: 'repo_path' | 'last_commit',
+  value: string,
+): Promise<void> {
+  if (sourceId !== undefined) {
+    const col = which === 'repo_path' ? 'local_path' : 'last_commit';
+    if (which === 'last_commit') {
+      await engine.executeRaw(
+        `UPDATE sources SET last_commit = $1, last_sync_at = now() WHERE id = $2`,
+        [value, sourceId],
+      );
+    } else {
+      await engine.executeRaw(
+        `UPDATE sources SET ${col} = $1 WHERE id = $2`,
+        [value, sourceId],
+      );
+    }
+    return;
+  }
+  await engine.setConfig(`sync.${which}`, value);
+}
+
 export async function runImport(
   engine: BrainEngine,
   args: string[],
@@ -274,7 +298,7 @@ export async function runImport(
       recordSyncFailures(failures, gitHead);
     }
     if (failures.length === 0) {
-      await engine.setConfig('sync.last_commit', gitHead);
+      await writeImportSyncAnchor(engine, opts.sourceId, 'last_commit', gitHead);
     } else {
       console.error(
         `\nImport completed with ${failures.length} failure(s). ` +
@@ -283,7 +307,7 @@ export async function runImport(
       );
     }
     await engine.setConfig('sync.last_run', new Date().toISOString());
-    await engine.setConfig('sync.repo_path', dir);
+    await writeImportSyncAnchor(engine, opts.sourceId, 'repo_path', dir);
   }
 
   return { imported, skipped, errors, chunksCreated, failures };

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -432,9 +432,9 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   for (const path of unsyncableModified) {
     const slug = resolveSlugForPath(path);
     try {
-      const existing = await engine.getPage(slug);
+      const existing = await engine.getPage(slug, opts.sourceId ? { sourceId: opts.sourceId } : undefined);
       if (existing) {
-        await engine.deletePage(slug);
+        await engine.deletePage(slug, opts.sourceId ? { sourceId: opts.sourceId } : undefined);
         console.log(`  Deleted un-syncable page: ${slug}`);
       }
     } catch { /* ignore */ }
@@ -500,7 +500,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     progress.start('sync.deletes', filtered.deleted.length);
     for (const path of filtered.deleted) {
       const slug = resolveSlugForPath(path);
-      await engine.deletePage(slug);
+      await engine.deletePage(slug, opts.sourceId ? { sourceId: opts.sourceId } : undefined);
       pagesAffected.push(slug);
       progress.tick(1, slug);
     }
@@ -524,7 +524,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       // Reimport at new path (picks up content changes)
       const filePath = join(repoPath, to);
       if (existsSync(filePath)) {
-        const result = await importFile(engine, filePath, to, { noEmbed });
+        const result = await importFile(engine, filePath, to, { noEmbed, sourceId: opts.sourceId });
         if (result.status === 'imported') chunksCreated += result.chunks;
       }
       pagesAffected.push(newSlug);
@@ -579,7 +579,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
         return;
       }
       try {
-        const result = await importFile(eng, filePath, path, { noEmbed });
+        const result = await importFile(eng, filePath, path, { noEmbed, sourceId: opts.sourceId });
         if (result.status === 'imported') {
           chunksCreated += result.chunks;
           pagesAffected.push(result.slug);
@@ -835,7 +835,7 @@ async function performFullSync(
   const importArgs = [repoPath];
   if (opts.noEmbed) importArgs.push('--no-embed');
   if (fullConcurrency > 1) importArgs.push('--workers', String(fullConcurrency));
-  const result = await runImport(engine, importArgs, { commit: headCommit });
+  const result = await runImport(engine, importArgs, { commit: headCommit, sourceId: opts.sourceId });
 
   // Bug 9 — gate the full-sync bookmark on success. runImport already
   // writes its own sync.last_commit conditionally (import.ts), but

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -206,7 +206,7 @@ async function readSyncAnchor(
   sourceId: string | undefined,
   which: 'repo_path' | 'last_commit',
 ): Promise<string | null> {
-  if (sourceId) {
+  if (sourceId !== undefined) {
     const col = which === 'repo_path' ? 'local_path' : 'last_commit';
     const rows = await engine.executeRaw<Record<string, string | null>>(
       `SELECT ${col} AS value FROM sources WHERE id = $1`,
@@ -223,7 +223,7 @@ async function writeSyncAnchor(
   which: 'repo_path' | 'last_commit',
   value: string,
 ): Promise<void> {
-  if (sourceId) {
+  if (sourceId !== undefined) {
     const col = which === 'repo_path' ? 'local_path' : 'last_commit';
     // last_sync_at bookmarked on every last_commit advance.
     if (which === 'last_commit') {
@@ -259,7 +259,7 @@ async function readChunkerVersion(
   engine: BrainEngine,
   sourceId: string | undefined,
 ): Promise<string | null> {
-  if (!sourceId) return null;
+  if (sourceId === undefined) return null;
   const rows = await engine.executeRaw<{ chunker_version: string | null }>(
     `SELECT chunker_version FROM sources WHERE id = $1`,
     [sourceId],
@@ -272,7 +272,7 @@ async function writeChunkerVersion(
   sourceId: string | undefined,
   version: string,
 ): Promise<void> {
-  if (!sourceId) return;
+  if (sourceId === undefined) return;
   await engine.executeRaw(
     `UPDATE sources SET chunker_version = $1 WHERE id = $2`,
     [version, sourceId],
@@ -316,7 +316,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // Resolve repo path
   const repoPath = opts.repoPath || await readSyncAnchor(engine, opts.sourceId, 'repo_path');
   if (!repoPath) {
-    const hint = opts.sourceId
+    const hint = opts.sourceId !== undefined
       ? `Source "${opts.sourceId}" has no local_path. Run: gbrain sources add ${opts.sourceId} --path <path>`
       : `No repo path specified. Use --repo or run gbrain init with --repo first.`;
     throw new Error(hint);
@@ -432,9 +432,10 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   for (const path of unsyncableModified) {
     const slug = resolveSlugForPath(path);
     try {
-      const existing = await engine.getPage(slug, opts.sourceId ? { sourceId: opts.sourceId } : undefined);
+      const sourceOpts = opts.sourceId !== undefined ? { sourceId: opts.sourceId } : undefined;
+      const existing = await engine.getPage(slug, sourceOpts);
       if (existing) {
-        await engine.deletePage(slug, opts.sourceId ? { sourceId: opts.sourceId } : undefined);
+        await engine.deletePage(slug, sourceOpts);
         console.log(`  Deleted un-syncable page: ${slug}`);
       }
     } catch { /* ignore */ }
@@ -500,7 +501,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     progress.start('sync.deletes', filtered.deleted.length);
     for (const path of filtered.deleted) {
       const slug = resolveSlugForPath(path);
-      await engine.deletePage(slug, opts.sourceId ? { sourceId: opts.sourceId } : undefined);
+      await engine.deletePage(slug, opts.sourceId !== undefined ? { sourceId: opts.sourceId } : undefined);
       pagesAffected.push(slug);
       progress.tick(1, slug);
     }

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -136,7 +136,7 @@ export interface BrainEngine {
    * by `restore_page` flow, and by operator diagnostics.
    */
   getPage(slug: string, opts?: GetPageOpts): Promise<Page | null>;
-  putPage(slug: string, page: PageInput): Promise<Page>;
+  putPage(slug: string, page: PageInput, opts?: { sourceId?: string }): Promise<Page>;
   /**
    * Hard-delete a page row. Cascades to content_chunks, page_links,
    * chunk_relations via existing FK ON DELETE CASCADE.
@@ -146,7 +146,7 @@ export interface BrainEngine {
    * as the underlying primitive used by `purgeDeletedPages` and by callers
    * that explicitly want hard-delete semantics (e.g. test setup teardown).
    */
-  deletePage(slug: string): Promise<void>;
+  deletePage(slug: string, opts?: { sourceId?: string }): Promise<void>;
   /**
    * v0.26.5 — set `deleted_at = now()` on a page. Returns the slug if a row
    * was soft-deleted, null if no row matched (already soft-deleted OR not found).
@@ -185,8 +185,8 @@ export interface BrainEngine {
   getEmbeddingsByChunkIds(ids: number[]): Promise<Map<number, Float32Array>>;
 
   // Chunks
-  upsertChunks(slug: string, chunks: ChunkInput[]): Promise<void>;
-  getChunks(slug: string): Promise<Chunk[]>;
+  upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string }): Promise<void>;
+  getChunks(slug: string, opts?: { sourceId?: string }): Promise<Chunk[]>;
   /**
    * Count chunks across the entire brain where embedded_at IS NULL.
    * Pre-flight short-circuit for `embed --stale` so a 100%-embedded brain
@@ -202,7 +202,7 @@ export interface BrainEngine {
    * Bounded by an internal LIMIT of 100000 to mirror listPages.
    */
   listStaleChunks(): Promise<StaleChunkRow[]>;
-  deleteChunks(slug: string): Promise<void>;
+  deleteChunks(slug: string, opts?: { sourceId?: string }): Promise<void>;
 
   // Links
   /**
@@ -283,9 +283,9 @@ export interface BrainEngine {
   findOrphanPages(): Promise<Array<{ slug: string; title: string; domain: string | null }>>;
 
   // Tags
-  addTag(slug: string, tag: string): Promise<void>;
-  removeTag(slug: string, tag: string): Promise<void>;
-  getTags(slug: string): Promise<string[]>;
+  addTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void>;
+  removeTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void>;
+  getTags(slug: string, opts?: { sourceId?: string }): Promise<string[]>;
 
   // Timeline
   /**
@@ -319,7 +319,7 @@ export interface BrainEngine {
   putDreamVerdict(filePath: string, contentHash: string, verdict: DreamVerdictInput): Promise<void>;
 
   // Versions
-  createVersion(slug: string): Promise<PageVersion>;
+  createVersion(slug: string, opts?: { sourceId?: string }): Promise<PageVersion>;
   getVersions(slug: string): Promise<PageVersion[]>;
   revertToVersion(slug: string, versionId: number): Promise<void>;
 

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -320,8 +320,8 @@ export interface BrainEngine {
 
   // Versions
   createVersion(slug: string, opts?: { sourceId?: string }): Promise<PageVersion>;
-  getVersions(slug: string): Promise<PageVersion[]>;
-  revertToVersion(slug: string, versionId: number): Promise<void>;
+  getVersions(slug: string, opts?: { sourceId?: string }): Promise<PageVersion[]>;
+  revertToVersion(slug: string, versionId: number, opts?: { sourceId?: string }): Promise<void>;
 
   // Stats + health
   getStats(): Promise<BrainStats>;

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -167,6 +167,13 @@ export interface ImportResult {
   parsedPage?: ParsedPage;
 }
 
+interface ImportOptions {
+  noEmbed?: boolean;
+  inferFrontmatter?: boolean;
+  force?: boolean;
+  sourceId?: string;
+}
+
 const MAX_FILE_SIZE = 5_000_000; // 5MB
 
 /**
@@ -185,7 +192,7 @@ export async function importFromContent(
   engine: BrainEngine,
   slug: string,
   content: string,
-  opts: { noEmbed?: boolean } = {},
+  opts: ImportOptions = {},
 ): Promise<ImportResult> {
   // Reject oversized payloads before any parsing, chunking, or embedding happens.
   // Uses Buffer.byteLength to count UTF-8 bytes the same way disk size would,
@@ -223,7 +230,8 @@ export async function importFromContent(
     tags: parsed.tags,
   };
 
-  const existing = await engine.getPage(slug);
+  const sourceOpts = opts.sourceId ? { sourceId: opts.sourceId } : undefined;
+  const existing = await engine.getPage(slug, sourceOpts);
   if (existing?.content_hash === hash) {
     return { slug, status: 'skipped', chunks: 0, parsedPage };
   }
@@ -261,7 +269,7 @@ export async function importFromContent(
 
   // Transaction wraps all DB writes
   await engine.transaction(async (tx) => {
-    if (existing) await tx.createVersion(slug);
+    if (existing) await tx.createVersion(slug, sourceOpts);
 
     await tx.putPage(slug, {
       type: parsed.type,
@@ -270,23 +278,23 @@ export async function importFromContent(
       timeline: parsed.timeline || '',
       frontmatter: parsed.frontmatter,
       content_hash: hash,
-    });
+    }, sourceOpts);
 
     // Tag reconciliation: remove stale, add current
-    const existingTags = await tx.getTags(slug);
+    const existingTags = await tx.getTags(slug, sourceOpts);
     const newTags = new Set(parsed.tags);
     for (const old of existingTags) {
-      if (!newTags.has(old)) await tx.removeTag(slug, old);
+      if (!newTags.has(old)) await tx.removeTag(slug, old, sourceOpts);
     }
     for (const tag of parsed.tags) {
-      await tx.addTag(slug, tag);
+      await tx.addTag(slug, tag, sourceOpts);
     }
 
     if (chunks.length > 0) {
-      await tx.upsertChunks(slug, chunks);
+      await tx.upsertChunks(slug, chunks, sourceOpts);
     } else {
       // Content is empty — delete stale chunks so they don't ghost in search results
-      await tx.deleteChunks(slug);
+      await tx.deleteChunks(slug, sourceOpts);
     }
 
     // v0.19.0 E1 — doc↔impl linking: if this markdown page cites code paths
@@ -333,7 +341,7 @@ export async function importFromFile(
   engine: BrainEngine,
   filePath: string,
   relativePath: string,
-  opts: { noEmbed?: boolean; inferFrontmatter?: boolean } = {},
+  opts: ImportOptions = {},
 ): Promise<ImportResult> {
   // Defense-in-depth: reject symlinks before reading content.
   const lstat = lstatSync(filePath);
@@ -398,7 +406,7 @@ export async function importCodeFile(
   engine: BrainEngine,
   relativePath: string,
   content: string,
-  opts: { noEmbed?: boolean; force?: boolean } = {},
+  opts: ImportOptions = {},
 ): Promise<ImportResult> {
   const slug = slugifyCodePath(relativePath);
   const lang = detectCodeLanguage(relativePath) || 'unknown';
@@ -415,7 +423,8 @@ export async function importCodeFile(
     .update(JSON.stringify({ title, type: 'code', content, lang, chunker_version: CHUNKER_VERSION }))
     .digest('hex');
 
-  const existing = await engine.getPage(slug);
+  const sourceOpts = opts.sourceId ? { sourceId: opts.sourceId } : undefined;
+  const existing = await engine.getPage(slug, sourceOpts);
   if (!opts.force && existing?.content_hash === hash) {
     return { slug, status: 'skipped', chunks: 0 };
   }
@@ -453,7 +462,7 @@ export async function importCodeFile(
   // OpenAI API. Order matters: our chunk_index is semantic (tree-sitter
   // order), so a matching (chunk_index, text_hash) means a verbatim
   // preserved symbol.
-  const existingChunks = existing ? await engine.getChunks(slug) : [];
+  const existingChunks = existing ? await engine.getChunks(slug, sourceOpts) : [];
   const existingByKey = new Map<string, typeof existingChunks[number]>();
   for (const ec of existingChunks) {
     existingByKey.set(`${ec.chunk_index}:${ec.chunk_text}`, ec);
@@ -488,7 +497,7 @@ export async function importCodeFile(
 
   // Store
   await engine.transaction(async (tx) => {
-    if (existing) await tx.createVersion(slug);
+    if (existing) await tx.createVersion(slug, sourceOpts);
 
     await tx.putPage(slug, {
       type: 'code' as PageType,
@@ -498,15 +507,15 @@ export async function importCodeFile(
       timeline: '',
       frontmatter: { language: lang, file: relativePath },
       content_hash: hash,
-    });
+    }, sourceOpts);
 
-    await tx.addTag(slug, 'code');
-    await tx.addTag(slug, lang);
+    await tx.addTag(slug, 'code', sourceOpts);
+    await tx.addTag(slug, lang, sourceOpts);
 
     if (chunks.length > 0) {
-      await tx.upsertChunks(slug, chunks);
+      await tx.upsertChunks(slug, chunks, sourceOpts);
     } else {
-      await tx.deleteChunks(slug);
+      await tx.deleteChunks(slug, sourceOpts);
     }
   });
 
@@ -517,7 +526,7 @@ export async function importCodeFile(
   // chunk IDs are stable.
   if (extractedEdges.length > 0 && chunks.length > 0) {
     try {
-      const persistedChunks = await engine.getChunks(slug);
+      const persistedChunks = await engine.getChunks(slug, sourceOpts);
       const byIndex = new Map<number, { id?: number; symbol_name_qualified?: string | null; start_line?: number | null; end_line?: number | null }>();
       for (const pc of persistedChunks) {
         byIndex.set(pc.chunk_index, pc);

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -174,6 +174,10 @@ interface ImportOptions {
   sourceId?: string;
 }
 
+function sourceOptions(sourceId: string | undefined): { sourceId: string } | undefined {
+  return sourceId !== undefined ? { sourceId } : undefined;
+}
+
 const MAX_FILE_SIZE = 5_000_000; // 5MB
 
 /**
@@ -230,7 +234,7 @@ export async function importFromContent(
     tags: parsed.tags,
   };
 
-  const sourceOpts = opts.sourceId ? { sourceId: opts.sourceId } : undefined;
+  const sourceOpts = sourceOptions(opts.sourceId);
   const existing = await engine.getPage(slug, sourceOpts);
   if (existing?.content_hash === hash) {
     return { slug, status: 'skipped', chunks: 0, parsedPage };
@@ -423,7 +427,7 @@ export async function importCodeFile(
     .update(JSON.stringify({ title, type: 'code', content, lang, chunker_version: CHUNKER_VERSION }))
     .digest('hex');
 
-  const sourceOpts = opts.sourceId ? { sourceId: opts.sourceId } : undefined;
+  const sourceOpts = sourceOptions(opts.sourceId);
   const existing = await engine.getPage(slug, sourceOpts);
   if (!opts.force && existing?.content_hash === hash) {
     return { slug, status: 'skipped', chunks: 0 };

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1088,9 +1088,13 @@ const get_versions: Operation = {
   description: 'Page version history',
   params: {
     slug: { type: 'string', required: true },
+    source_id: { type: 'string' },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.getVersions(p.slug as string);
+    return ctx.engine.getVersions(
+      p.slug as string,
+      p.source_id !== undefined ? { sourceId: p.source_id as string } : undefined,
+    );
   },
   scope: 'read',
   cliHints: { name: 'history', positional: ['slug'] },
@@ -1102,13 +1106,15 @@ const revert_version: Operation = {
   params: {
     slug: { type: 'string', required: true },
     version_id: { type: 'number', required: true },
+    source_id: { type: 'string' },
   },
   mutating: true,
   scope: 'write',
   handler: async (ctx, p) => {
     if (ctx.dryRun) return { dry_run: true, action: 'revert_version', slug: p.slug, version_id: p.version_id };
-    await ctx.engine.createVersion(p.slug as string);
-    await ctx.engine.revertToVersion(p.slug as string, p.version_id as number);
+    const sourceOpts = p.source_id !== undefined ? { sourceId: p.source_id as string } : undefined;
+    await ctx.engine.createVersion(p.slug as string, sourceOpts);
+    await ctx.engine.revertToVersion(p.slug as string, p.version_id as number, sourceOpts);
     return { status: 'reverted' };
   },
   cliHints: { name: 'revert', positional: ['slug', 'version_id'] },

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -352,13 +352,9 @@ export class PGLiteEngine implements BrainEngine {
   async getPage(slug: string, opts?: { sourceId?: string; includeDeleted?: boolean }): Promise<Page | null> {
     // v0.26.5: hide soft-deleted by default; opt-in via opts.includeDeleted.
     const includeDeleted = opts?.includeDeleted === true;
-    const sourceId = opts?.sourceId;
-    const where: string[] = ['slug = $1'];
-    const params: unknown[] = [slug];
-    if (sourceId) {
-      params.push(sourceId);
-      where.push(`source_id = $${params.length}`);
-    }
+    const sourceId = opts?.sourceId ?? 'default';
+    const where: string[] = ['slug = $1', 'source_id = $2'];
+    const params: unknown[] = [slug, sourceId];
     if (!includeDeleted) {
       where.push('deleted_at IS NULL');
     }
@@ -371,10 +367,11 @@ export class PGLiteEngine implements BrainEngine {
     return rowToPage(rows[0] as Record<string, unknown>);
   }
 
-  async putPage(slug: string, page: PageInput): Promise<Page> {
+  async putPage(slug: string, page: PageInput, opts?: { sourceId?: string }): Promise<Page> {
     slug = validateSlug(slug);
     const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
+    const sourceId = opts?.sourceId ?? page.source_id ?? 'default';
 
     // v0.18.0 Step 2: source_id relies on the schema DEFAULT 'default' so
     // existing callers still target the default source without threading
@@ -383,8 +380,8 @@ export class PGLiteEngine implements BrainEngine {
     // surface an explicit sourceId param on putPage for multi-source sync.
     const pageKind = page.page_kind || 'markdown';
     const { rows } = await this.db.query(
-      `INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, now())
+      `INSERT INTO pages (source_id, slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, now())
        ON CONFLICT (source_id, slug) DO UPDATE SET
          type = EXCLUDED.type,
          page_kind = EXCLUDED.page_kind,
@@ -395,13 +392,13 @@ export class PGLiteEngine implements BrainEngine {
          content_hash = EXCLUDED.content_hash,
          updated_at = now()
        RETURNING id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at`,
-      [slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash]
+      [sourceId, slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash]
     );
     return rowToPage(rows[0] as Record<string, unknown>);
   }
 
-  async deletePage(slug: string): Promise<void> {
-    await this.db.query('DELETE FROM pages WHERE slug = $1', [slug]);
+  async deletePage(slug: string, opts?: { sourceId?: string }): Promise<void> {
+    await this.db.query('DELETE FROM pages WHERE slug = $1 AND source_id = $2', [slug, opts?.sourceId ?? 'default']);
   }
 
   async softDeletePage(slug: string, opts?: { sourceId?: string }): Promise<{ slug: string } | null> {
@@ -748,9 +745,12 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Chunks
-  async upsertChunks(slug: string, chunks: ChunkInput[]): Promise<void> {
+  async upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string }): Promise<void> {
     // Get page_id
-    const pageResult = await this.db.query('SELECT id FROM pages WHERE slug = $1', [slug]);
+    const pageResult = await this.db.query(
+      'SELECT id FROM pages WHERE slug = $1 AND source_id = $2',
+      [slug, opts?.sourceId ?? 'default'],
+    );
     if (pageResult.rows.length === 0) throw new Error(`Page not found: ${slug}`);
     const pageId = (pageResult.rows[0] as { id: number }).id;
 
@@ -835,13 +835,13 @@ export class PGLiteEngine implements BrainEngine {
     );
   }
 
-  async getChunks(slug: string): Promise<Chunk[]> {
+  async getChunks(slug: string, opts?: { sourceId?: string }): Promise<Chunk[]> {
     const { rows } = await this.db.query(
       `SELECT cc.* FROM content_chunks cc
        JOIN pages p ON p.id = cc.page_id
-       WHERE p.slug = $1
+       WHERE p.slug = $1 AND p.source_id = $2
        ORDER BY cc.chunk_index`,
-      [slug]
+      [slug, opts?.sourceId ?? 'default']
     );
     return (rows as Record<string, unknown>[]).map(r => rowToChunk(r));
   }
@@ -869,11 +869,11 @@ export class PGLiteEngine implements BrainEngine {
     return rows as unknown as StaleChunkRow[];
   }
 
-  async deleteChunks(slug: string): Promise<void> {
+  async deleteChunks(slug: string, opts?: { sourceId?: string }): Promise<void> {
     await this.db.query(
       `DELETE FROM content_chunks
-       WHERE page_id = (SELECT id FROM pages WHERE slug = $1)`,
-      [slug]
+       WHERE page_id = (SELECT id FROM pages WHERE slug = $1 AND source_id = $2)`,
+      [slug, opts?.sourceId ?? 'default']
     );
   }
 
@@ -1214,30 +1214,30 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Tags
-  async addTag(slug: string, tag: string): Promise<void> {
+  async addTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void> {
     await this.db.query(
       `INSERT INTO tags (page_id, tag)
-       SELECT id, $2 FROM pages WHERE slug = $1
+       SELECT id, $2 FROM pages WHERE slug = $1 AND source_id = $3
        ON CONFLICT (page_id, tag) DO NOTHING`,
-      [slug, tag]
+      [slug, tag, opts?.sourceId ?? 'default']
     );
   }
 
-  async removeTag(slug: string, tag: string): Promise<void> {
+  async removeTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void> {
     await this.db.query(
       `DELETE FROM tags
-       WHERE page_id = (SELECT id FROM pages WHERE slug = $1)
+       WHERE page_id = (SELECT id FROM pages WHERE slug = $1 AND source_id = $3)
          AND tag = $2`,
-      [slug, tag]
+      [slug, tag, opts?.sourceId ?? 'default']
     );
   }
 
-  async getTags(slug: string): Promise<string[]> {
+  async getTags(slug: string, opts?: { sourceId?: string }): Promise<string[]> {
     const { rows } = await this.db.query(
       `SELECT tag FROM tags
-       WHERE page_id = (SELECT id FROM pages WHERE slug = $1)
+       WHERE page_id = (SELECT id FROM pages WHERE slug = $1 AND source_id = $2)
        ORDER BY tag`,
-      [slug]
+      [slug, opts?.sourceId ?? 'default']
     );
     return (rows as { tag: string }[]).map(r => r.tag);
   }
@@ -1386,13 +1386,13 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Versions
-  async createVersion(slug: string): Promise<PageVersion> {
+  async createVersion(slug: string, opts?: { sourceId?: string }): Promise<PageVersion> {
     const { rows } = await this.db.query(
       `INSERT INTO page_versions (page_id, compiled_truth, frontmatter)
        SELECT id, compiled_truth, frontmatter
-       FROM pages WHERE slug = $1
+       FROM pages WHERE slug = $1 AND source_id = $2
        RETURNING *`,
-      [slug]
+      [slug, opts?.sourceId ?? 'default']
     );
     return rows[0] as unknown as PageVersion;
   }

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1397,26 +1397,26 @@ export class PGLiteEngine implements BrainEngine {
     return rows[0] as unknown as PageVersion;
   }
 
-  async getVersions(slug: string): Promise<PageVersion[]> {
+  async getVersions(slug: string, opts?: { sourceId?: string }): Promise<PageVersion[]> {
     const { rows } = await this.db.query(
       `SELECT pv.* FROM page_versions pv
        JOIN pages p ON p.id = pv.page_id
-       WHERE p.slug = $1
+       WHERE p.slug = $1 AND p.source_id = $2
        ORDER BY pv.snapshot_at DESC`,
-      [slug]
+      [slug, opts?.sourceId ?? 'default']
     );
     return rows as unknown as PageVersion[];
   }
 
-  async revertToVersion(slug: string, versionId: number): Promise<void> {
+  async revertToVersion(slug: string, versionId: number, opts?: { sourceId?: string }): Promise<void> {
     await this.db.query(
       `UPDATE pages SET
         compiled_truth = pv.compiled_truth,
         frontmatter = pv.frontmatter,
         updated_at = now()
       FROM page_versions pv
-      WHERE pages.slug = $1 AND pv.id = $2 AND pv.page_id = pages.id`,
-      [slug, versionId]
+      WHERE pages.slug = $1 AND pages.source_id = $2 AND pv.id = $3 AND pv.page_id = pages.id`,
+      [slug, opts?.sourceId ?? 'default', versionId]
     );
   }
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -307,26 +307,26 @@ export class PostgresEngine implements BrainEngine {
   async getPage(slug: string, opts?: { sourceId?: string; includeDeleted?: boolean }): Promise<Page | null> {
     const sql = this.sql;
     const includeDeleted = opts?.includeDeleted === true;
-    const sourceId = opts?.sourceId;
+    const sourceId = opts?.sourceId ?? 'default';
     // v0.26.5: default hides soft-deleted rows. Compose with optional sourceId
     // filter via fragment chaining (postgres.js supports sql`` composition).
-    const sourceCondition = sourceId ? sql`AND source_id = ${sourceId}` : sql``;
     const deletedCondition = includeDeleted ? sql`` : sql`AND deleted_at IS NULL`;
     const rows = await sql`
       SELECT id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at, deleted_at
       FROM pages
-      WHERE slug = ${slug} ${sourceCondition} ${deletedCondition}
+      WHERE slug = ${slug} AND source_id = ${sourceId} ${deletedCondition}
       LIMIT 1
     `;
     if (rows.length === 0) return null;
     return rowToPage(rows[0]);
   }
 
-  async putPage(slug: string, page: PageInput): Promise<Page> {
+  async putPage(slug: string, page: PageInput, opts?: { sourceId?: string }): Promise<Page> {
     slug = validateSlug(slug);
     const sql = this.sql;
     const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
+    const sourceId = opts?.sourceId ?? page.source_id ?? 'default';
 
     // v0.18.0 Step 2: source_id relies on schema DEFAULT 'default'. ON
     // CONFLICT target becomes (source_id, slug) since global UNIQUE(slug)
@@ -334,8 +334,8 @@ export class PostgresEngine implements BrainEngine {
     // notes; multi-source sync (Step 5) will surface an explicit sourceId.
     const pageKind = page.page_kind || 'markdown';
     const rows = await sql`
-      INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
-      VALUES (${slug}, ${page.type}, ${pageKind}, ${page.title}, ${page.compiled_truth}, ${page.timeline || ''}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now())
+      INSERT INTO pages (source_id, slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
+      VALUES (${sourceId}, ${slug}, ${page.type}, ${pageKind}, ${page.title}, ${page.compiled_truth}, ${page.timeline || ''}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now())
       ON CONFLICT (source_id, slug) DO UPDATE SET
         type = EXCLUDED.type,
         page_kind = EXCLUDED.page_kind,
@@ -350,9 +350,9 @@ export class PostgresEngine implements BrainEngine {
     return rowToPage(rows[0]);
   }
 
-  async deletePage(slug: string): Promise<void> {
+  async deletePage(slug: string, opts?: { sourceId?: string }): Promise<void> {
     const sql = this.sql;
-    await sql`DELETE FROM pages WHERE slug = ${slug}`;
+    await sql`DELETE FROM pages WHERE slug = ${slug} AND source_id = ${opts?.sourceId ?? 'default'}`;
   }
 
   async softDeletePage(slug: string, opts?: { sourceId?: string }): Promise<{ slug: string } | null> {
@@ -779,11 +779,11 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Chunks
-  async upsertChunks(slug: string, chunks: ChunkInput[]): Promise<void> {
+  async upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string }): Promise<void> {
     const sql = this.sql;
 
     // Get page_id
-    const pages = await sql`SELECT id FROM pages WHERE slug = ${slug}`;
+    const pages = await sql`SELECT id FROM pages WHERE slug = ${slug} AND source_id = ${opts?.sourceId ?? 'default'}`;
     if (pages.length === 0) throw new Error(`Page not found: ${slug}`);
     const pageId = pages[0].id;
 
@@ -868,12 +868,12 @@ export class PostgresEngine implements BrainEngine {
     );
   }
 
-  async getChunks(slug: string): Promise<Chunk[]> {
+  async getChunks(slug: string, opts?: { sourceId?: string }): Promise<Chunk[]> {
     const sql = this.sql;
     const rows = await sql`
       SELECT cc.* FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id
-      WHERE p.slug = ${slug}
+      WHERE p.slug = ${slug} AND p.source_id = ${opts?.sourceId ?? 'default'}
       ORDER BY cc.chunk_index
     `;
     return rows.map((r) => rowToChunk(r as Record<string, unknown>));
@@ -903,11 +903,11 @@ export class PostgresEngine implements BrainEngine {
     return rows as unknown as StaleChunkRow[];
   }
 
-  async deleteChunks(slug: string): Promise<void> {
+  async deleteChunks(slug: string, opts?: { sourceId?: string }): Promise<void> {
     const sql = this.sql;
     await sql`
       DELETE FROM content_chunks
-      WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug})
+      WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug} AND source_id = ${opts?.sourceId ?? 'default'})
     `;
   }
 
@@ -1264,11 +1264,11 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Tags
-  async addTag(slug: string, tag: string): Promise<void> {
+  async addTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void> {
     const sql = this.sql;
     // Verify page exists before attempting insert (ON CONFLICT DO NOTHING
     // swallows the "already tagged" case, but we still need to detect missing pages)
-    const page = await sql`SELECT id FROM pages WHERE slug = ${slug}`;
+    const page = await sql`SELECT id FROM pages WHERE slug = ${slug} AND source_id = ${opts?.sourceId ?? 'default'}`;
     if (page.length === 0) throw new Error(`addTag failed: page "${slug}" not found`);
     await sql`
       INSERT INTO tags (page_id, tag)
@@ -1277,20 +1277,20 @@ export class PostgresEngine implements BrainEngine {
     `;
   }
 
-  async removeTag(slug: string, tag: string): Promise<void> {
+  async removeTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void> {
     const sql = this.sql;
     await sql`
       DELETE FROM tags
-      WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug})
+      WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug} AND source_id = ${opts?.sourceId ?? 'default'})
         AND tag = ${tag}
     `;
   }
 
-  async getTags(slug: string): Promise<string[]> {
+  async getTags(slug: string, opts?: { sourceId?: string }): Promise<string[]> {
     const sql = this.sql;
     const rows = await sql`
       SELECT tag FROM tags
-      WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug})
+      WHERE page_id = (SELECT id FROM pages WHERE slug = ${slug} AND source_id = ${opts?.sourceId ?? 'default'})
       ORDER BY tag
     `;
     return rows.map((r) => r.tag as string);
@@ -1440,12 +1440,12 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Versions
-  async createVersion(slug: string): Promise<PageVersion> {
+  async createVersion(slug: string, opts?: { sourceId?: string }): Promise<PageVersion> {
     const sql = this.sql;
     const rows = await sql`
       INSERT INTO page_versions (page_id, compiled_truth, frontmatter)
       SELECT id, compiled_truth, frontmatter
-      FROM pages WHERE slug = ${slug}
+      FROM pages WHERE slug = ${slug} AND source_id = ${opts?.sourceId ?? 'default'}
       RETURNING *
     `;
     if (rows.length === 0) throw new Error(`createVersion failed: page "${slug}" not found`);

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1452,18 +1452,18 @@ export class PostgresEngine implements BrainEngine {
     return rows[0] as unknown as PageVersion;
   }
 
-  async getVersions(slug: string): Promise<PageVersion[]> {
+  async getVersions(slug: string, opts?: { sourceId?: string }): Promise<PageVersion[]> {
     const sql = this.sql;
     const rows = await sql`
       SELECT pv.* FROM page_versions pv
       JOIN pages p ON p.id = pv.page_id
-      WHERE p.slug = ${slug}
+      WHERE p.slug = ${slug} AND p.source_id = ${opts?.sourceId ?? 'default'}
       ORDER BY pv.snapshot_at DESC
     `;
     return rows as unknown as PageVersion[];
   }
 
-  async revertToVersion(slug: string, versionId: number): Promise<void> {
+  async revertToVersion(slug: string, versionId: number, opts?: { sourceId?: string }): Promise<void> {
     const sql = this.sql;
     await sql`
       UPDATE pages SET
@@ -1471,7 +1471,10 @@ export class PostgresEngine implements BrainEngine {
         frontmatter = pv.frontmatter,
         updated_at = now()
       FROM page_versions pv
-      WHERE pages.slug = ${slug} AND pv.id = ${versionId} AND pv.page_id = pages.id
+      WHERE pages.slug = ${slug}
+        AND pages.source_id = ${opts?.sourceId ?? 'default'}
+        AND pv.id = ${versionId}
+        AND pv.page_id = pages.id
     `;
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -40,8 +40,10 @@ export interface PageInput {
    * to 'markdown' when omitted so existing callers work unchanged. Set to
    * 'code' by importCodeFile; drives orphans filter, auto-link bypass, and
    * `query --lang` filtering.
-   */
+  */
   page_kind?: PageKind;
+  /** Target source for multi-source imports. Defaults to 'default'. */
+  source_id?: string;
 }
 
 export interface PageFilters {
@@ -70,7 +72,7 @@ export interface PageFilters {
 
 /** v0.26.5 — opts for getPage / softDeletePage / restorePage. */
 export interface GetPageOpts {
-  /** Filter to a specific source. When omitted, getPage returns the first slug match across sources (pre-existing semantics). */
+  /** Filter to a specific source. When omitted, page CRUD uses the default source. */
   sourceId?: string;
   /** Include soft-deleted pages. Default false. See PageFilters.includeDeleted. */
   includeDeleted?: boolean;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -72,7 +72,7 @@ export interface PageFilters {
 
 /** v0.26.5 — opts for getPage / softDeletePage / restorePage. */
 export interface GetPageOpts {
-  /** Filter to a specific source. When omitted, page CRUD uses the default source. */
+  /** Filter get/soft-delete/restore calls to a specific source. When omitted, uses the default source. */
   sourceId?: string;
   /** Include soft-deleted pages. Default false. See PageFilters.includeDeleted. */
   includeDeleted?: boolean;

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -359,6 +359,83 @@ describe('performSync dry-run never writes', () => {
     // Structural assertion: the contract includes `embedded: number`.
     expect(typeof result.embedded).toBe('number');
   });
+
+  test('full sync writes pages under the requested source, not default', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config)
+       VALUES ($1, $2, $3, '{}'::jsonb)`,
+      ['source-sync', 'source-sync', repoPath],
+    );
+
+    const result = await performSync(engine, {
+      repoPath,
+      noPull: true,
+      noEmbed: true,
+      sourceId: 'source-sync',
+    });
+
+    expect(result.status).toBe('first_sync');
+    expect(await engine.getPage('people/alice', { sourceId: 'source-sync' })).not.toBeNull();
+    expect(await engine.getPage('people/bob', { sourceId: 'source-sync' })).not.toBeNull();
+    expect(await engine.getPage('people/alice')).toBeNull();
+
+    const rows = await engine.executeRaw<{ source_id: string; n: number }>(
+      `SELECT source_id, COUNT(*)::int AS n
+         FROM pages
+        WHERE slug IN ('people/alice', 'people/bob')
+        GROUP BY source_id
+        ORDER BY source_id`,
+    );
+    expect(rows).toEqual([{ source_id: 'source-sync', n: 2 }]);
+  });
+
+  test('runImport threads sourceId into imported pages, chunks, tags, and versions', async () => {
+    const { runImport } = await import('../src/commands/import.ts');
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config)
+       VALUES ($1, $2, $3, '{}'::jsonb)`,
+      ['source-import', 'source-import', repoPath],
+    );
+    writeFileSync(join(repoPath, 'people/alice.md'), [
+      '---',
+      'type: person',
+      'title: Alice',
+      'tags: [original]',
+      '---',
+      '',
+      'Alice is a person.',
+    ].join('\n'));
+
+    const first = await runImport(engine, [repoPath, '--no-embed'], { sourceId: 'source-import' });
+    expect(first.imported).toBe(2);
+    expect(await engine.getPage('people/alice', { sourceId: 'source-import' })).not.toBeNull();
+    expect(await engine.getPage('people/alice')).toBeNull();
+    expect(await engine.getChunks('people/alice', { sourceId: 'source-import' })).toHaveLength(1);
+    expect(await engine.getTags('people/alice', { sourceId: 'source-import' })).toEqual(['original']);
+
+    writeFileSync(join(repoPath, 'people/alice.md'), [
+      '---',
+      'type: person',
+      'title: Alice Updated',
+      'tags: [updated]',
+      '---',
+      '',
+      'Alice is a person with updated notes.',
+    ].join('\n'));
+
+    const second = await runImport(engine, [repoPath, '--no-embed'], { sourceId: 'source-import' });
+    expect(second.imported).toBe(1);
+    expect(await engine.getTags('people/alice', { sourceId: 'source-import' })).toEqual(['updated']);
+    const versions = await engine.executeRaw<{ n: number }>(
+      `SELECT COUNT(*)::int AS n
+         FROM page_versions pv
+         JOIN pages p ON p.id = pv.page_id
+        WHERE p.slug = 'people/alice'
+          AND p.source_id = 'source-import'`,
+    );
+    expect(versions[0].n).toBe(1);
+  });
 });
 
 describe('sync regression — #132 nested transaction deadlock', () => {

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -390,6 +390,33 @@ describe('performSync dry-run never writes', () => {
     expect(rows).toEqual([{ source_id: 'source-sync', n: 2 }]);
   });
 
+  test('empty-string source id is still an explicit source scope', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config)
+       VALUES ($1, $2, $3, '{}'::jsonb)`,
+      ['', 'empty-source', repoPath],
+    );
+
+    const result = await performSync(engine, {
+      repoPath,
+      noPull: true,
+      noEmbed: true,
+      sourceId: '',
+    });
+
+    expect(result.status).toBe('first_sync');
+    expect(await engine.getPage('people/alice', { sourceId: '' })).not.toBeNull();
+    expect(await engine.getPage('people/alice')).toBeNull();
+    expect(await engine.getConfig('sync.last_commit')).toBeNull();
+    const rows = await engine.executeRaw<{ last_commit: string | null; chunker_version: string | null }>(
+      `SELECT last_commit, chunker_version FROM sources WHERE id = $1`,
+      [''],
+    );
+    expect(rows[0].last_commit).toBeTruthy();
+    expect(rows[0].chunker_version).toBeTruthy();
+  });
+
   test('runImport threads sourceId into imported pages, chunks, tags, and versions', async () => {
     const { runImport } = await import('../src/commands/import.ts');
     await engine.executeRaw(
@@ -435,6 +462,49 @@ describe('performSync dry-run never writes', () => {
           AND p.source_id = 'source-import'`,
     );
     expect(versions[0].n).toBe(1);
+  });
+
+  test('version history and revert are scoped by source id', async () => {
+    const { importFromContent } = await import('../src/core/import-file.ts');
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config)
+       VALUES ($1, $2, $3, '{}'::jsonb)`,
+      ['version-source', 'version-source', repoPath],
+    );
+
+    await importFromContent(engine, 'people/shared', [
+      '---',
+      'type: person',
+      'title: Default Shared',
+      '---',
+      '',
+      'Default source body.',
+    ].join('\n'), { noEmbed: true });
+    await importFromContent(engine, 'people/shared', [
+      '---',
+      'type: person',
+      'title: Named Shared',
+      '---',
+      '',
+      'Named source first body.',
+    ].join('\n'), { noEmbed: true, sourceId: 'version-source' });
+    await importFromContent(engine, 'people/shared', [
+      '---',
+      'type: person',
+      'title: Named Shared Updated',
+      '---',
+      '',
+      'Named source updated body.',
+    ].join('\n'), { noEmbed: true, sourceId: 'version-source' });
+
+    const defaultVersions = await engine.getVersions('people/shared');
+    const namedVersions = await engine.getVersions('people/shared', { sourceId: 'version-source' });
+    expect(defaultVersions).toHaveLength(0);
+    expect(namedVersions).toHaveLength(1);
+
+    await engine.revertToVersion('people/shared', namedVersions[0].id, { sourceId: 'version-source' });
+    expect((await engine.getPage('people/shared'))?.title).toBe('Default Shared');
+    expect((await engine.getPage('people/shared', { sourceId: 'version-source' }))?.compiled_truth).toBe('Named source first body.');
   });
 });
 


### PR DESCRIPTION
Fixes #540.
Supersedes #541, which was based on the old `garrytan/embedding-providers` branch and now conflicts with current `master`.

## Plain-English Summary

GBrain now supports multiple named sources. That only works if every page, chunk, tag, and version is written back to the same source it came from.

Before this fix, `gbrain sync --source docs` could correctly remember that it was syncing `docs`, but the import/write path could still reconcile content by slug alone. If two sources both had `README.md`, the named source could accidentally touch `default`. That is data bleed, and it makes multi-source brains unsafe for real teams.

This PR makes source identity part of the write contract.

```mermaid
flowchart LR
  A["source: docs"] --> B["sync/import"]
  C["source: support-kb"] --> B
  B --> D["page key: source_id + slug"]
  D --> E["pages"]
  D --> F["chunks"]
  D --> G["tags"]
  D --> H["versions"]
  E --> I["search stays scoped to the right source"]
```

## Maintainer Notes

- Threads optional `sourceId` from full sync and incremental sync into `runImport()` / `importFile()`.
- Threads optional `sourceId` through `importFromContent()` and code-file import.
- Scopes page writes, deletes, chunk writes, tag reconciliation, and page-version creation by `(source_id, slug)` in both PGLite and Postgres engines.
- Preserves back-compat: callers that omit `sourceId` still target `source_id='default'`.
- Keeps empty-string source ids explicit by checking `sourceId !== undefined`, matching the existing regression expectations.
- Extends version APIs so `getVersions()` and `revertToVersion()` can target the same source-aware identity as writes.

## Human Walkthrough

If your company has two knowledge folders with the same file names, GBrain should not guess which one you meant. This change makes the folder/source name travel with the document all the way into storage, history, tags, and search chunks.

## Review-Fix Pass

Latest review-fix commit: `415ee45`.

Fixed Copilot review findings around:

- empty-string `sourceId` handling;
- source-scoped version history and revert;
- over-broad `GetPageOpts` docs;
- source-scoped import sync anchors.

## Validation

- `git diff --check`
- `bun run verify`
- `bun test test/sync.test.ts test/import-file.test.ts test/multi-source-integration.test.ts`
- focused review-fix rerun: `bun test test/sync.test.ts test/pglite-engine.test.ts` -> `128 pass, 0 fail`
- prior full isolated run: `HOME=$(mktemp -d) bun run test` -> `3831 pass, 0 fail`

## Notes

The first full local test run without HOME isolation hit this machine's real `~/.gbrain`, causing an unrelated `BrainRegistry` test to resolve the host brain instead of failing as the test expects. Re-running with a clean HOME matches CI/test isolation and passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
