### PR TITLE
fix: support Voyage 4 Large 2048d schema setup

### DIFF
--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -11,12 +11,23 @@
 
 import type { Implementation } from './types.ts';
 
+const VOYAGE_OUTPUT_DIMENSION_MODELS = new Set([
+  'voyage-4-large',
+  'voyage-4',
+  'voyage-4-lite',
+  'voyage-3-large',
+  'voyage-3.5',
+  'voyage-3.5-lite',
+  'voyage-code-3',
+]);
+
 /**
  * Build the providerOptions blob for embedMany() that pins output dimensions.
  *
  * Matryoshka providers (OpenAI text-embedding-3, Gemini embedding-001) can be
- * asked to return reduced-dim vectors. openai-compatible + anthropic do not
- * take a dimension parameter.
+ * asked to return reduced-dim vectors. Anthropic does not take a dimension
+ * parameter. Most openai-compatible providers do not either, but Voyage's
+ * OpenAI-compatible embeddings endpoint accepts `output_dimension`.
  */
 export function dimsProviderOptions(
   implementation: Implementation,
@@ -41,8 +52,12 @@ export function dimsProviderOptions(
       // Anthropic has no embedding model.
       return undefined;
     case 'openai-compatible':
-      // Ollama, LM Studio, vLLM, Voyage-compat, LiteLLM: no standard dim param.
-      // Users pick a model that natively outputs the dims they want.
+      // Most openai-compatible providers (Ollama, LM Studio, vLLM, LiteLLM)
+      // do not expose a standard dimensions knob. Voyage's compat endpoint is
+      // the exception: it accepts output_dimension and defaults to 1024 dims.
+      if (VOYAGE_OUTPUT_DIMENSION_MODELS.has(modelId)) {
+        return { openaiCompatible: { output_dimension: dims } };
+      }
       return undefined;
   }
 }

--- a/src/core/ai/recipes/voyage.ts
+++ b/src/core/ai/recipes/voyage.ts
@@ -16,7 +16,7 @@ export const voyage: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['voyage-3-large', 'voyage-3', 'voyage-3-lite'],
+      models: ['voyage-4-large', 'voyage-4', 'voyage-3.5', 'voyage-3-large', 'voyage-3', 'voyage-3-lite'],
       default_dims: 1024,
       cost_per_1m_tokens_usd: 0.18,
       price_last_verified: '2026-04-20',

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -16,6 +16,8 @@
  * test/edge-bundle.test.ts has a drift detection test.
  */
 
+import { applyChunkEmbeddingIndexPolicy } from './vector-index.ts';
+
 const PGLITE_SCHEMA_SQL_TEMPLATE = `
 -- GBrain PGLite schema (local embedded Postgres)
 
@@ -212,8 +214,8 @@ CREATE TABLE IF NOT EXISTS config (
 INSERT INTO config (key, value) VALUES
   ('version', '1'),
   ('engine', 'pglite'),
-  ('embedding_model', 'text-embedding-3-large'),
-  ('embedding_dimensions', '1536'),
+  ('embedding_model', '__EMBEDDING_MODEL__'),
+  ('embedding_dimensions', '__EMBEDDING_DIMS__'),
   ('chunk_strategy', 'semantic')
 ON CONFLICT (key) DO NOTHING;
 
@@ -532,9 +534,14 @@ DROP FUNCTION IF EXISTS update_page_search_vector_from_timeline();
  * Defaults preserve v0.13 behavior (1536d + text-embedding-3-large).
  */
 export function getPGLiteSchema(dims: number = 1536, model: string = 'text-embedding-3-large'): string {
-  return PGLITE_SCHEMA_SQL_TEMPLATE
-    .replace(/__EMBEDDING_DIMS__/g, String(dims))
-    .replace(/__EMBEDDING_MODEL__/g, model);
+  const parsedDims = Number(dims);
+  if (!Number.isInteger(parsedDims) || parsedDims <= 0) {
+    throw new Error(`Invalid embedding dimensions: ${dims}`);
+  }
+  const sanitizedModel = String(model).replace(/'/g, "''");
+  return applyChunkEmbeddingIndexPolicy(PGLITE_SCHEMA_SQL_TEMPLATE, parsedDims)
+    .replace(/__EMBEDDING_DIMS__/g, String(parsedDims))
+    .replace(/__EMBEDDING_MODEL__/g, sanitizedModel);
 }
 
 /** Back-compat: pre-computed default-1536 schema for existing callers. */

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4,6 +4,7 @@ import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
 import { runMigrations } from './migrate.ts';
 import { SCHEMA_SQL } from './schema-embedded.ts';
 import { verifySchema } from './schema-verify.ts';
+import { applyChunkEmbeddingIndexPolicy } from './vector-index.ts';
 import type {
   Page, PageInput, PageFilters, PageType,
   Chunk, ChunkInput, StaleChunkRow,
@@ -110,7 +111,7 @@ export class PostgresEngine implements BrainEngine {
       model = gw.getEmbeddingModel().split(':').slice(1).join(':') || model;
     } catch { /* gateway not yet configured — use defaults */ }
 
-    const sql = SCHEMA_SQL
+    const sql = applyChunkEmbeddingIndexPolicy(SCHEMA_SQL, dims)
       .replace(/vector\(1536\)/g, `vector(${dims})`)
       .replace(/'text-embedding-3-large'/g, `'${model}'`);
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -25,6 +25,22 @@ import { validateSlug, contentHash, rowToPage, rowToChunk, rowToSearchResult, pa
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
 import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause } from './search/sql-ranking.ts';
 
+function escapeSqlStringLiteral(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+export function getPostgresSchema(dims: number = 1536, model: string = 'text-embedding-3-large'): string {
+  const parsedDims = Number(dims);
+  if (!Number.isInteger(parsedDims) || parsedDims <= 0) {
+    throw new Error(`Invalid embedding dimensions: ${dims}`);
+  }
+  const sanitizedModel = escapeSqlStringLiteral(String(model));
+  return applyChunkEmbeddingIndexPolicy(SCHEMA_SQL, parsedDims)
+    .replace(/vector\(1536\)/g, `vector(${parsedDims})`)
+    .replace(/'text-embedding-3-large'/g, `'${sanitizedModel}'`)
+    .replace(/\('embedding_dimensions', '1536'\)/g, `('embedding_dimensions', '${parsedDims}')`);
+}
+
 // CONNECTION_ERROR_PATTERNS / isConnectionError were used by the per-call
 // executeRaw retry that #406 originally shipped. Eng-review D3 dropped that
 // retry as unsound (regex idempotence-boundary doesn't hold for writable
@@ -111,9 +127,7 @@ export class PostgresEngine implements BrainEngine {
       model = gw.getEmbeddingModel().split(':').slice(1).join(':') || model;
     } catch { /* gateway not yet configured — use defaults */ }
 
-    const sql = applyChunkEmbeddingIndexPolicy(SCHEMA_SQL, dims)
-      .replace(/vector\(1536\)/g, `vector(${dims})`)
-      .replace(/'text-embedding-3-large'/g, `'${model}'`);
+    const sql = getPostgresSchema(dims, model);
 
     // Advisory lock prevents concurrent initSchema() calls from deadlocking
     // on DDL statements (DROP TRIGGER + CREATE TRIGGER acquire AccessExclusiveLock).

--- a/src/core/vector-index.ts
+++ b/src/core/vector-index.ts
@@ -1,0 +1,16 @@
+export const PGVECTOR_HNSW_VECTOR_MAX_DIMS = 2000;
+
+const CHUNK_EMBEDDING_HNSW_INDEX =
+  'CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);';
+
+export function chunkEmbeddingIndexSql(dims: number): string {
+  if (dims <= PGVECTOR_HNSW_VECTOR_MAX_DIMS) return CHUNK_EMBEDDING_HNSW_INDEX;
+  return [
+    '-- idx_chunks_embedding skipped: pgvector HNSW vector indexes support',
+    `-- at most ${PGVECTOR_HNSW_VECTOR_MAX_DIMS} dimensions; exact vector scans remain available.`,
+  ].join('\n');
+}
+
+export function applyChunkEmbeddingIndexPolicy(sql: string, dims: number): string {
+  return sql.replaceAll(CHUNK_EMBEDDING_HNSW_INDEX, chunkEmbeddingIndexSql(dims));
+}

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -151,8 +151,18 @@ describe('dims.dimsProviderOptions', () => {
     expect(opts).toBeUndefined();
   });
 
-  test('openai-compatible returns undefined (no standard dim param)', () => {
+  test('openai-compatible returns undefined for providers without a dim param', () => {
     const opts = dimsProviderOptions('openai-compatible', 'nomic-embed-text', 768);
+    expect(opts).toBeUndefined();
+  });
+
+  test('Voyage openai-compatible returns output_dimension', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'voyage-4-large', 2048);
+    expect(opts).toEqual({ openaiCompatible: { output_dimension: 2048 } });
+  });
+
+  test('Voyage model without flexible dimensions returns undefined', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'voyage-3-lite', 1024);
     expect(opts).toBeUndefined();
   });
 });

--- a/test/ai/schema-templating.test.ts
+++ b/test/ai/schema-templating.test.ts
@@ -14,6 +14,8 @@ describe('getPGLiteSchema', () => {
     const sql = getPGLiteSchema(768, 'gemini-embedding-001');
     expect(sql).toMatch(/vector\(768\)/);
     expect(sql).toMatch(/'gemini-embedding-001'/);
+    expect(sql).toMatch(/\('embedding_model', 'gemini-embedding-001'\)/);
+    expect(sql).toMatch(/\('embedding_dimensions', '768'\)/);
     expect(sql).not.toMatch(/vector\(1536\)/);
   });
 
@@ -21,6 +23,18 @@ describe('getPGLiteSchema', () => {
     const sql = getPGLiteSchema(1024, 'voyage-3-large');
     expect(sql).toMatch(/vector\(1024\)/);
     expect(sql).toMatch(/'voyage-3-large'/);
+    expect(sql).toMatch(/\('embedding_model', 'voyage-3-large'\)/);
+    expect(sql).toMatch(/\('embedding_dimensions', '1024'\)/);
+    expect(sql).toContain('idx_chunks_embedding ON content_chunks USING hnsw');
+  });
+
+  test('Voyage 2048d skips unsupported HNSW index but keeps vector column', () => {
+    const sql = getPGLiteSchema(2048, 'voyage-4-large');
+    expect(sql).toMatch(/vector\(2048\)/);
+    expect(sql).toMatch(/'voyage-4-large'/);
+    expect(sql).toMatch(/\('embedding_dimensions', '2048'\)/);
+    expect(sql).not.toContain('idx_chunks_embedding ON content_chunks USING hnsw');
+    expect(sql).toContain('exact vector scans remain available');
   });
 
   test('PGLITE_SCHEMA_SQL back-compat constant is the default-dim schema', () => {

--- a/test/ai/schema-templating.test.ts
+++ b/test/ai/schema-templating.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { getPGLiteSchema, PGLITE_SCHEMA_SQL } from '../../src/core/pglite-schema.ts';
+import { getPostgresSchema } from '../../src/core/postgres-engine.ts';
 
 describe('getPGLiteSchema', () => {
   test('default produces v0.13-compatible schema (1536d + text-embedding-3-large)', () => {
@@ -39,5 +40,21 @@ describe('getPGLiteSchema', () => {
 
   test('PGLITE_SCHEMA_SQL back-compat constant is the default-dim schema', () => {
     expect(PGLITE_SCHEMA_SQL).toBe(getPGLiteSchema());
+  });
+});
+
+describe('getPostgresSchema', () => {
+  test('Voyage 2048d updates vector column and seeded config but skips HNSW', () => {
+    const sql = getPostgresSchema(2048, 'voyage-4-large');
+    expect(sql).toMatch(/vector\(2048\)/);
+    expect(sql).toMatch(/\('embedding_model', 'voyage-4-large'\)/);
+    expect(sql).toMatch(/\('embedding_dimensions', '2048'\)/);
+    expect(sql).not.toContain('idx_chunks_embedding ON content_chunks USING hnsw');
+  });
+
+  test('escapes configured model before inserting into schema SQL literals', () => {
+    const sql = getPostgresSchema(1024, "voyage-weird'quoted");
+    expect(sql).toContain("'voyage-weird''quoted'");
+    expect(sql).not.toContain("'voyage-weird'quoted'");
   });
 });


### PR DESCRIPTION
Fixes #640.

## Plain-English Summary

Voyage 4 Large can return 2048-dimensional embeddings. That is useful for technical docs because the vectors have more room to represent fine-grained concepts, but pgvector's HNSW index has a 2000-dimensional limit.

This PR lets GBrain store and query Voyage 4 Large 2048d vectors safely: storage stays `vector(2048)`, exact vector scans still work, and only the unsupported HNSW index is skipped.

```mermaid
flowchart LR
  A["GBRAIN_EMBEDDING_MODEL=voyage:voyage-4-large"] --> B["AI gateway"]
  B --> C["Voyage output_dimension=2048"]
  C --> D["schema helper"]
  D --> E["content_chunks.embedding vector(2048)"]
  D --> F{"dims > 2000?"}
  F -->|yes| G["skip HNSW index"]
  F -->|no| H["create HNSW index"]
  E --> I["exact scans remain valid"]
```

## What Changed

- Adds current Voyage embedding models, including `voyage-4-large`.
- Sends Voyage's `output_dimension` provider option for modern Voyage models that support flexible dimensions.
- Keeps older/fixed-dimension Voyage models from receiving unsupported dimension options.
- Allows `vector(2048)` storage while skipping only the unsupported pgvector HNSW chunk embedding index above 2000 dims.
- Keeps the HNSW index for supported dimensions such as 1024 and 1536.
- Writes the configured embedding model and dimension into generated PGLite and Postgres schema config seeds.
- Escapes model strings when templating Postgres schema SQL.

Voyage docs list 2048/1024/512/256 as supported `output_dimension` values for modern Voyage models, with 1024 as the default: https://docs.voyageai.com/reference/embeddings-api

## Root Cause

pgvector can store `vector(2048)`, but HNSW vector indexes have a 2000-dimensional cap. GBrain's schema templating replaced the vector column dimension but still emitted:

```sql
CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);
```

A Voyage 4 Large 2048d brain could therefore fail during schema/index creation even though exact vector scans were still valid.

## Human Walkthrough

Think of this as letting GBrain use a sharper map for documents without forcing Postgres to build an index type it cannot legally build. Search still works; the one impossible optimization is skipped.

## Review-Fix Pass

Latest review-fix commit: `169a79c`.

Fixed Copilot review findings around:

- Postgres seeded `embedding_dimensions` still reporting `1536`;
- SQL literal escaping for configured model names.

## Validation

- `git diff --check`
- `bun run verify`
- `bun test test/ai/gateway.test.ts test/ai/schema-templating.test.ts`
- focused review-fix rerun: `bun test test/ai/schema-templating.test.ts test/ai/gateway.test.ts` -> `29 pass, 0 fail`
- prior full isolated run: `HOME=$(mktemp -d) bun run test` -> `3832 pass, 0 fail`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
