### PR TITLE
feat: provider auth resolver seam

### DIFF
--- a/docs/guides/provider-auth.md
+++ b/docs/guides/provider-auth.md
@@ -1,0 +1,55 @@
+# Provider Auth Sources
+
+GBrain can run provider calls from two credential sources:
+
+- environment variables, such as `OPENAI_API_KEY` or `VOYAGE_API_KEY`;
+- a host-managed OpenClaw auth profile, such as `openclaw-codex` or
+  `openclaw-openai`.
+
+Environment variables still win when present. The host profile is a secondary
+source for users who already authenticated inside their agent host and do not
+want every GBrain workflow to ask for another model API key.
+
+```mermaid
+flowchart LR
+  User["User asks agent to enrich, embed, or answer"]
+  Host["Host runtime\nOpenClaw, Codex, Claude Code, Hermes"]
+  Profile["Host auth profile\nOAuth/runtime credential"]
+  GBrain["GBrain provider auth resolver"]
+  Env["Env key present?"]
+  Provider["AI provider call"]
+
+  User --> Host
+  Host --> Profile
+  Host --> GBrain
+  GBrain --> Env
+  Env -- yes --> Provider
+  Env -- no, host profile configured --> Profile
+  Profile --> Provider
+```
+
+Why this matters:
+
+- host-authenticated users can reuse the credential path they already set up;
+- provider setup remains explicit and inspectable with `gbrain providers`;
+- secrets do not travel through tool payloads, PR logs, or JSON responses;
+- non-OpenClaw users keep the normal env-based path.
+
+Example config:
+
+```json
+{
+  "ai": {
+    "embedding_model": "openai:text-embedding-3-large",
+    "provider_auth": {
+      "openai": {
+        "prefer": "openclaw-codex"
+      }
+    }
+  }
+}
+```
+
+For reviewers: this is a credential-source seam, not a new hosted auth system.
+The resolver reports only the source class, expected credential key, profile
+name, and readiness. It never returns the token value through status output.

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -10,7 +10,8 @@ import { configureGateway, embedOne, isAvailable as gwIsAvailable, chat as gwCha
 import { probeOllama, probeLMStudio } from '../core/ai/probes.ts';
 import { loadConfig } from '../core/config.ts';
 import { AIConfigError, AITransientError } from '../core/ai/errors.ts';
-import type { Recipe } from '../core/ai/types.ts';
+import { resolveProviderAuth, redactAuthResolution } from '../core/ai/auth.ts';
+import type { AIGatewayConfig, AuthSourceClass, Recipe } from '../core/ai/types.ts';
 
 const SCHEMA_VERSION = 1;
 
@@ -26,28 +27,35 @@ interface ProviderOption {
   cost_per_1m_output_usd?: number;
   price_last_verified?: string;
   env_ready: boolean;
+  auth_source: AuthSourceClass;
   tier: 'native' | 'openai-compat';
   pros: string[];
   cons: string[];
 }
 
+let gatewayConfig: AIGatewayConfig;
+
 function configureFromEnv(): void {
   const config = loadConfig();
-  configureGateway({
+  gatewayConfig = {
     embedding_model: config?.embedding_model,
     embedding_dimensions: config?.embedding_dimensions,
     expansion_model: config?.expansion_model,
     chat_model: config?.chat_model,
     chat_fallback_chain: config?.chat_fallback_chain,
     base_urls: config?.provider_base_urls,
+    provider_auth: config?.provider_auth,
     env: { ...process.env },
-  });
+  };
+  configureGateway(gatewayConfig);
+}
+
+function authResolution(recipe: Recipe) {
+  return resolveProviderAuth(recipe, gatewayConfig);
 }
 
 function envReady(recipe: Recipe): boolean {
-  const required = recipe.auth_env?.required ?? [];
-  if (required.length === 0) return true; // e.g. local Ollama
-  return required.every(k => !!process.env[k]);
+  return authResolution(recipe).isConfigured;
 }
 
 export async function runProviders(subcommand: string | undefined, args: string[]): Promise<void> {
@@ -106,8 +114,11 @@ function runList(_args: string[]): void {
     const hasEmbed = !!r.touchpoints.embedding && (r.touchpoints.embedding.models.length > 0);
     const hasExpand = !!r.touchpoints.expansion;
     const hasChat = !!r.touchpoints.chat && r.touchpoints.chat.models.length > 0;
-    const ready = envReady(r);
-    const status = ready ? '✓ ready' : `✗ missing ${r.auth_env?.required?.[0] ?? 'setup'}`;
+    const resolution = authResolution(r);
+    const ready = resolution.isConfigured;
+    const status = ready
+      ? `✓ ready (${resolution.source})`
+      : `✗ ${resolution.missingReason ?? 'missing credentials'}`;
     rows.push(
       r.id.padEnd(14) +
       r.tier.padEnd(18) +
@@ -208,9 +219,10 @@ function runEnv(args: string[]): void {
   const optional = recipe.auth_env?.optional ?? [];
   if (required.length > 0) {
     console.log('Required:');
+    const resolution = authResolution(recipe);
     for (const k of required) {
-      const set = !!process.env[k];
-      console.log(`  ${k.padEnd(32)} ${set ? '✓ set' : '✗ not set'}`);
+      const selected = resolution.source === 'env' && resolution.credentialKey === k;
+      console.log(`  ${k.padEnd(32)} ${selected ? '✓ selected' : process.env[k] ? '• available' : '✗ not set'}`);
     }
   } else {
     console.log('Required: (none)');
@@ -222,6 +234,10 @@ function runEnv(args: string[]): void {
       console.log(`  ${k.padEnd(32)} ${set ? '✓ set' : '✗ not set'}`);
     }
   }
+  const resolution = redactAuthResolution(authResolution(recipe));
+  console.log(`\nSelected auth source: ${String(resolution.source)}`);
+  if (resolution.credentialKey) console.log(`Credential key: ${String(resolution.credentialKey)}`);
+  if (resolution.missingReason) console.log(`Status: ${String(resolution.missingReason)}`);
   if (recipe.auth_env?.setup_url) {
     console.log(`\nSetup: ${recipe.auth_env.setup_url}`);
   }
@@ -259,6 +275,7 @@ async function runExplain(args: string[]): Promise<void> {
         cost_per_1m_tokens_usd: m.cost_per_1m_tokens_usd,
         price_last_verified: m.price_last_verified,
         env_ready: envReady(r) || (r.id === 'ollama' && ollama.models_endpoint_valid === true),
+        auth_source: authResolution(r).source,
         tier: r.tier,
         pros: prosFor(r, 'embedding'),
         cons: consFor(r),
@@ -273,6 +290,7 @@ async function runExplain(args: string[]): Promise<void> {
         cost_per_1m_tokens_usd: m.cost_per_1m_tokens_usd,
         price_last_verified: m.price_last_verified,
         env_ready: envReady(r),
+        auth_source: authResolution(r).source,
         tier: r.tier,
         pros: prosFor(r, 'expansion'),
         cons: consFor(r),
@@ -288,6 +306,7 @@ async function runExplain(args: string[]): Promise<void> {
         cost_per_1m_output_usd: m.cost_per_1m_output_usd,
         price_last_verified: m.price_last_verified,
         env_ready: envReady(r),
+        auth_source: authResolution(r).source,
         tier: r.tier,
         pros: prosFor(r, 'chat'),
         cons: consFor(r),
@@ -326,20 +345,20 @@ async function runExplain(args: string[]): Promise<void> {
   for (const o of options.filter(x => x.touchpoint === 'embedding')) {
     const cost = o.cost_per_1m_tokens_usd !== undefined ? `$${o.cost_per_1m_tokens_usd}/1M` : '—';
     const dims = o.dims ? `${o.dims}d` : '—';
-    console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${dims.padEnd(8)} ${cost.padEnd(10)} ${o.tier}`);
+    console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${dims.padEnd(8)} ${cost.padEnd(10)} ${o.tier} ${o.auth_source}`);
   }
   console.log('');
   console.log('Expansion options:');
   for (const o of options.filter(x => x.touchpoint === 'expansion')) {
     const cost = o.cost_per_1m_tokens_usd !== undefined ? `$${o.cost_per_1m_tokens_usd}/1M` : '—';
-    console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${cost.padEnd(10)} ${o.tier}`);
+    console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${cost.padEnd(10)} ${o.tier} ${o.auth_source}`);
   }
   console.log('');
   console.log('Chat options:');
   for (const o of options.filter(x => x.touchpoint === 'chat')) {
     const inCost = o.cost_per_1m_input_usd !== undefined ? `in $${o.cost_per_1m_input_usd}` : '—';
     const outCost = o.cost_per_1m_output_usd !== undefined ? `out $${o.cost_per_1m_output_usd}` : '—';
-    console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${inCost.padEnd(12)} ${outCost.padEnd(12)} ${o.tier}`);
+    console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${inCost.padEnd(12)} ${outCost.padEnd(12)} ${o.tier} ${o.auth_source}`);
   }
   console.log('');
   console.log(`Recommended: ${matrix.recommended}`);

--- a/src/core/ai/auth.ts
+++ b/src/core/ai/auth.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+import type { AIGatewayConfig, AuthResolution, ProviderAuthConfig, Recipe } from './types.ts';
+
+const OPENCLAW_CODEX_PROFILE = 'openclaw-codex';
+const OPENCLAW_OPENAI_PROFILE = 'openclaw-openai';
+
+const PROFILE_ENV_HINTS: Record<string, string[]> = {
+  [OPENCLAW_CODEX_PROFILE]: ['OPENAI_API_KEY', 'CODEX_API_KEY', 'OPENCLAW_CODEX_TOKEN'],
+  [OPENCLAW_OPENAI_PROFILE]: ['OPENAI_API_KEY'],
+};
+
+export function getProviderAuthConfig(config: AIGatewayConfig | undefined, recipe: Recipe): ProviderAuthConfig {
+  return config?.provider_auth?.[recipe.id] ?? {};
+}
+
+export function resolveProviderAuth(recipe: Recipe, config: AIGatewayConfig): AuthResolution {
+  const providerConfig = getProviderAuthConfig(config, recipe);
+  const envResolution = resolveEnvAuth(recipe, config.env);
+  if (envResolution) return envResolution;
+
+  if (providerConfig.prefer === 'openclaw-codex' || providerConfig.prefer === 'openclaw-openai') {
+    return resolveOpenClawProfileAuth(recipe, providerConfig);
+  }
+
+  return missingResolution(recipe, providerConfig);
+}
+
+export function redactAuthResolution(resolution: AuthResolution): Record<string, unknown> {
+  return {
+    source: resolution.source,
+    credentialKey: resolution.credentialKey,
+    isConfigured: resolution.isConfigured,
+    missingReason: resolution.missingReason,
+    meta: resolution.meta ?? {},
+  };
+}
+
+export function getCredentialValue(resolution: AuthResolution): string | undefined {
+  return resolution.value;
+}
+
+function resolveEnvAuth(recipe: Recipe, env: Record<string, string | undefined>): AuthResolution | null {
+  const required = recipe.auth_env?.required ?? [];
+  if (required.length === 0) {
+    return {
+      source: 'unauthenticated',
+      isConfigured: true,
+      meta: { mode: 'unauthenticated' },
+    };
+  }
+
+  for (const key of required) {
+    const value = env[key];
+    if (value) {
+      return {
+        source: 'env',
+        credentialKey: key,
+        value,
+        isConfigured: true,
+        meta: { mode: 'env' },
+      };
+    }
+  }
+
+  return null;
+}
+
+function resolveOpenClawProfileAuth(recipe: Recipe, providerConfig: ProviderAuthConfig): AuthResolution {
+  const profile = providerConfig.profile ?? defaultProfileForRecipe(recipe);
+  const path = providerConfig.openclawAuthPath ?? defaultOpenClawAuthPath();
+  const raw = readOpenClawAuthRecord(path, profile);
+  if (!raw) {
+    return missingResolution(recipe, providerConfig, `OpenClaw profile "${profile}" not found at ${path}`);
+  }
+
+  const envHints = PROFILE_ENV_HINTS[profile] ?? recipe.auth_env?.required ?? [];
+  const found = envHints.find(key => typeof raw[key] === 'string' && raw[key]);
+  if (!found) {
+    return missingResolution(recipe, providerConfig, `OpenClaw profile "${profile}" missing expected token field`);
+  }
+
+  return {
+    source: providerConfig.prefer ?? 'openclaw-codex',
+    credentialKey: found,
+    value: String(raw[found]),
+    isConfigured: true,
+    meta: {
+      mode: 'openclaw-profile',
+      profile,
+      path,
+    },
+  };
+}
+
+function missingResolution(recipe: Recipe, providerConfig: ProviderAuthConfig, reason?: string): AuthResolution {
+  const expected = providerConfig.prefer === 'openclaw-codex' || providerConfig.prefer === 'openclaw-openai'
+    ? providerConfig.profile ?? defaultProfileForRecipe(recipe)
+    : recipe.auth_env?.required?.[0];
+
+  return {
+    source: 'missing',
+    credentialKey: expected,
+    isConfigured: false,
+    missingReason: reason ?? defaultMissingReason(recipe, providerConfig),
+    meta: {
+      mode: providerConfig.prefer ?? 'env',
+    },
+  };
+}
+
+function defaultMissingReason(recipe: Recipe, providerConfig: ProviderAuthConfig): string {
+  if (providerConfig.prefer === 'openclaw-codex' || providerConfig.prefer === 'openclaw-openai') {
+    return `OpenClaw profile "${providerConfig.profile ?? defaultProfileForRecipe(recipe)}" is not configured.`;
+  }
+  const required = recipe.auth_env?.required ?? [];
+  if (required.length === 0) return 'No credentials required.';
+  return `Missing ${required.join(', ')}.`;
+}
+
+function defaultProfileForRecipe(recipe: Recipe): string {
+  return recipe.id === 'openai' ? OPENCLAW_CODEX_PROFILE : OPENCLAW_OPENAI_PROFILE;
+}
+
+function defaultOpenClawAuthPath(): string {
+  return join(homedir(), '.openclaw', 'auth.json');
+}
+
+function readOpenClawAuthRecord(path: string, profile: string): Record<string, unknown> | null {
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf-8'));
+    return findProfileRecord(raw, profile);
+  } catch {
+    return null;
+  }
+}
+
+function findProfileRecord(raw: unknown, profile: string): Record<string, unknown> | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+
+  const direct = obj[profile];
+  if (direct && typeof direct === 'object') return direct as Record<string, unknown>;
+
+  const profiles = obj.profiles;
+  if (profiles && typeof profiles === 'object') {
+    const nested = (profiles as Record<string, unknown>)[profile];
+    if (nested && typeof nested === 'object') return nested as Record<string, unknown>;
+  }
+
+  return null;
+}

--- a/src/core/ai/auth.ts
+++ b/src/core/ai/auth.ts
@@ -69,7 +69,7 @@ function resolveEnvAuth(recipe: Recipe, env: Record<string, string | undefined>)
 }
 
 function resolveOpenClawProfileAuth(recipe: Recipe, providerConfig: ProviderAuthConfig): AuthResolution {
-  const profile = providerConfig.profile ?? defaultProfileForRecipe(recipe);
+  const profile = providerConfig.profile ?? defaultProfileForConfig(recipe, providerConfig);
   const path = providerConfig.openclawAuthPath ?? defaultOpenClawAuthPath();
   const raw = readOpenClawAuthRecord(path, profile);
   if (!raw) {
@@ -96,9 +96,7 @@ function resolveOpenClawProfileAuth(recipe: Recipe, providerConfig: ProviderAuth
 }
 
 function missingResolution(recipe: Recipe, providerConfig: ProviderAuthConfig, reason?: string): AuthResolution {
-  const expected = providerConfig.prefer === 'openclaw-codex' || providerConfig.prefer === 'openclaw-openai'
-    ? providerConfig.profile ?? defaultProfileForRecipe(recipe)
-    : recipe.auth_env?.required?.[0];
+  const expected = recipe.auth_env?.required?.[0];
 
   return {
     source: 'missing',
@@ -107,20 +105,25 @@ function missingResolution(recipe: Recipe, providerConfig: ProviderAuthConfig, r
     missingReason: reason ?? defaultMissingReason(recipe, providerConfig),
     meta: {
       mode: providerConfig.prefer ?? 'env',
+      ...(providerConfig.prefer === 'openclaw-codex' || providerConfig.prefer === 'openclaw-openai'
+        ? { profile: providerConfig.profile ?? defaultProfileForConfig(recipe, providerConfig) }
+        : {}),
     },
   };
 }
 
 function defaultMissingReason(recipe: Recipe, providerConfig: ProviderAuthConfig): string {
   if (providerConfig.prefer === 'openclaw-codex' || providerConfig.prefer === 'openclaw-openai') {
-    return `OpenClaw profile "${providerConfig.profile ?? defaultProfileForRecipe(recipe)}" is not configured.`;
+    return `OpenClaw profile "${providerConfig.profile ?? defaultProfileForConfig(recipe, providerConfig)}" is not configured.`;
   }
   const required = recipe.auth_env?.required ?? [];
   if (required.length === 0) return 'No credentials required.';
   return `Missing ${required.join(', ')}.`;
 }
 
-function defaultProfileForRecipe(recipe: Recipe): string {
+function defaultProfileForConfig(recipe: Recipe, providerConfig: ProviderAuthConfig): string {
+  if (providerConfig.prefer === 'openclaw-openai') return OPENCLAW_OPENAI_PROFILE;
+  if (providerConfig.prefer === 'openclaw-codex') return OPENCLAW_CODEX_PROFILE;
   return recipe.id === 'openai' ? OPENCLAW_CODEX_PROFILE : OPENCLAW_OPENAI_PROFILE;
 }
 

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -30,9 +30,11 @@ import { z } from 'zod';
 
 import type {
   AIGatewayConfig,
+  AuthResolution,
   Recipe,
   TouchpointKind,
 } from './types.ts';
+import { resolveProviderAuth } from './auth.ts';
 import { resolveRecipe, assertTouchpoint } from './model-resolver.ts';
 import { dimsProviderOptions } from './dims.ts';
 import { AIConfigError, AITransientError, normalizeAIError } from './errors.ts';
@@ -55,6 +57,7 @@ export function configureGateway(config: AIGatewayConfig): void {
     chat_model: config.chat_model ?? DEFAULT_CHAT_MODEL,
     chat_fallback_chain: config.chat_fallback_chain,
     base_urls: config.base_urls,
+    provider_auth: config.provider_auth,
     env: config.env,
   };
   _modelCache.clear();
@@ -123,10 +126,7 @@ export function isAvailable(touchpoint: TouchpointKind): boolean {
     // Openai-compat recipes with empty models list (e.g. litellm template) require user-provided model
     if (Array.isArray(touchpointConfig.models) && touchpointConfig.models.length === 0 && recipe.id === 'litellm') return false;
 
-    // For openai-compatible without auth requirements (Ollama local), treat as always-available.
-    const required = recipe.auth_env?.required ?? [];
-    if (required.length === 0) return true;
-    return required.every(k => !!_config!.env[k]);
+    return resolveProviderAuth(recipe, _config!).isConfigured;
   } catch {
     return false;
   }
@@ -149,13 +149,10 @@ async function resolveEmbeddingProvider(modelStr: string): Promise<{ model: any;
 }
 
 function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
+  const auth = resolveProviderAuth(recipe, cfg);
   switch (recipe.implementation) {
     case 'native-openai': {
-      const apiKey = cfg.env.OPENAI_API_KEY;
-      if (!apiKey) throw new AIConfigError(
-        `OpenAI embedding requires OPENAI_API_KEY.`,
-        recipe.setup_hint,
-      );
+      const apiKey = requireAuth(auth, recipe, 'embedding');
       const client = createOpenAI({ apiKey });
       // AI SDK v6: use .textEmbeddingModel() for embeddings
       return (client as any).textEmbeddingModel
@@ -163,11 +160,7 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
         : (client as any).embedding(modelId);
     }
     case 'native-google': {
-      const apiKey = cfg.env.GOOGLE_GENERATIVE_AI_API_KEY;
-      if (!apiKey) throw new AIConfigError(
-        `Google embedding requires GOOGLE_GENERATIVE_AI_API_KEY.`,
-        recipe.setup_hint,
-      );
+      const apiKey = requireAuth(auth, recipe, 'embedding');
       const client = createGoogleGenerativeAI({ apiKey });
       return (client as any).textEmbeddingModel
         ? (client as any).textEmbeddingModel(modelId)
@@ -184,15 +177,9 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
         recipe.setup_hint,
       );
       // For openai-compatible, auth is optional (ollama local) but pass a dummy key if unauthenticated.
-      const apiKey = recipe.auth_env?.required[0]
-        ? cfg.env[recipe.auth_env.required[0]]
-        : (cfg.env[`${recipe.id.toUpperCase()}_API_KEY`] ?? 'unauthenticated');
-      if (recipe.auth_env?.required.length && !apiKey) {
-        throw new AIConfigError(
-          `${recipe.name} requires ${recipe.auth_env.required[0]}.`,
-          recipe.setup_hint,
-        );
-      }
+      const apiKey = auth.source === 'unauthenticated'
+        ? (cfg.env[`${recipe.id.toUpperCase()}_API_KEY`] ?? 'unauthenticated')
+        : requireAuth(auth, recipe, 'embedding');
       const client = createOpenAICompatible({
         name: recipe.id,
         baseURL: baseUrl,
@@ -203,6 +190,16 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
     default:
       throw new AIConfigError(`Unknown implementation: ${(recipe as any).implementation}`);
   }
+}
+
+function requireAuth(resolution: AuthResolution, recipe: Recipe, action: string): string {
+  if (!resolution.isConfigured || !resolution.value) {
+    throw new AIConfigError(
+      `${recipe.name} ${action} requires ${resolution.credentialKey ?? 'credentials'}.`,
+      resolution.missingReason ?? recipe.setup_hint,
+    );
+  }
+  return resolution.value;
 }
 
 /** Embed many texts. Truncates to 8000 chars. Throws AIConfigError or AITransientError. */
@@ -259,28 +256,26 @@ async function resolveExpansionProvider(modelStr: string): Promise<{ model: any;
 }
 
 function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
+  const auth = resolveProviderAuth(recipe, cfg);
   switch (recipe.implementation) {
     case 'native-openai': {
-      const apiKey = cfg.env.OPENAI_API_KEY;
-      if (!apiKey) throw new AIConfigError(`OpenAI expansion requires OPENAI_API_KEY.`, recipe.setup_hint);
+      const apiKey = requireAuth(auth, recipe, 'expansion');
       return createOpenAI({ apiKey }).languageModel(modelId);
     }
     case 'native-google': {
-      const apiKey = cfg.env.GOOGLE_GENERATIVE_AI_API_KEY;
-      if (!apiKey) throw new AIConfigError(`Google expansion requires GOOGLE_GENERATIVE_AI_API_KEY.`, recipe.setup_hint);
+      const apiKey = requireAuth(auth, recipe, 'expansion');
       return createGoogleGenerativeAI({ apiKey }).languageModel(modelId);
     }
     case 'native-anthropic': {
-      const apiKey = cfg.env.ANTHROPIC_API_KEY;
-      if (!apiKey) throw new AIConfigError(`Anthropic expansion requires ANTHROPIC_API_KEY.`, recipe.setup_hint);
+      const apiKey = requireAuth(auth, recipe, 'expansion');
       return createAnthropic({ apiKey }).languageModel(modelId);
     }
     case 'openai-compatible': {
       const baseUrl = cfg.base_urls?.[recipe.id] ?? recipe.base_url_default;
       if (!baseUrl) throw new AIConfigError(`${recipe.name} requires a base URL.`, recipe.setup_hint);
-      const apiKey = recipe.auth_env?.required[0]
-        ? cfg.env[recipe.auth_env.required[0]]
-        : 'unauthenticated';
+      const apiKey = auth.source === 'unauthenticated'
+        ? 'unauthenticated'
+        : requireAuth(auth, recipe, 'expansion');
       return createOpenAICompatible({
         name: recipe.id,
         baseURL: baseUrl,
@@ -416,30 +411,26 @@ async function resolveChatProvider(modelStr: string): Promise<{ model: any; reci
 }
 
 function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
+  const auth = resolveProviderAuth(recipe, cfg);
   switch (recipe.implementation) {
     case 'native-openai': {
-      const apiKey = cfg.env.OPENAI_API_KEY;
-      if (!apiKey) throw new AIConfigError(`OpenAI chat requires OPENAI_API_KEY.`, recipe.setup_hint);
+      const apiKey = requireAuth(auth, recipe, 'chat');
       return createOpenAI({ apiKey }).languageModel(modelId);
     }
     case 'native-google': {
-      const apiKey = cfg.env.GOOGLE_GENERATIVE_AI_API_KEY;
-      if (!apiKey) throw new AIConfigError(`Google chat requires GOOGLE_GENERATIVE_AI_API_KEY.`, recipe.setup_hint);
+      const apiKey = requireAuth(auth, recipe, 'chat');
       return createGoogleGenerativeAI({ apiKey }).languageModel(modelId);
     }
     case 'native-anthropic': {
-      const apiKey = cfg.env.ANTHROPIC_API_KEY;
-      if (!apiKey) throw new AIConfigError(`Anthropic chat requires ANTHROPIC_API_KEY.`, recipe.setup_hint);
+      const apiKey = requireAuth(auth, recipe, 'chat');
       return createAnthropic({ apiKey }).languageModel(modelId);
     }
     case 'openai-compatible': {
       const baseUrl = cfg.base_urls?.[recipe.id] ?? recipe.base_url_default;
       if (!baseUrl) throw new AIConfigError(`${recipe.name} requires a base URL.`, recipe.setup_hint);
-      const required = recipe.auth_env?.required ?? [];
-      const apiKey = required[0] ? cfg.env[required[0]] : 'unauthenticated';
-      if (required.length > 0 && !apiKey) {
-        throw new AIConfigError(`${recipe.name} requires ${required[0]}.`, recipe.setup_hint);
-      }
+      const apiKey = auth.source === 'unauthenticated'
+        ? 'unauthenticated'
+        : requireAuth(auth, recipe, 'chat');
       return createOpenAICompatible({
         name: recipe.id,
         baseURL: baseUrl,

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -37,6 +37,12 @@ export interface ExpansionTouchpoint {
   price_last_verified?: string;
 }
 
+export interface AuthEnvConfig {
+  required: string[];
+  optional?: string[];
+  setup_url?: string;
+}
+
 /**
  * Chat touchpoint: tool-using conversational LLMs that can drive Minions
  * subagents. `supports_tools` and `supports_subagent_loop` are intentionally
@@ -73,11 +79,7 @@ export interface Recipe {
   /** For openai-compatible tier: default base URL. May be overridden by env or wizard. */
   base_url_default?: string;
   /** Env var name(s) for auth; first is required, rest are optional. */
-  auth_env?: {
-    required: string[];
-    optional?: string[];
-    setup_url?: string;
-  };
+  auth_env?: AuthEnvConfig;
   touchpoints: {
     embedding?: EmbeddingTouchpoint;
     expansion?: ExpansionTouchpoint;
@@ -92,6 +94,26 @@ export interface Recipe {
   aliases?: Record<string, string>;
   /** One-line description of setup (shown in wizard + env subcommand). */
   setup_hint?: string;
+}
+
+export type AuthSourceClass = 'env' | 'openclaw-codex' | 'openclaw-openai' | 'unauthenticated' | 'missing';
+
+export interface ProviderAuthConfig {
+  /** Env auth remains highest-priority; this explicitly enables a secondary source. */
+  prefer?: Exclude<AuthSourceClass, 'env' | 'unauthenticated' | 'missing'>;
+  /** Optional profile name for host-managed auth. */
+  profile?: string;
+  /** Optional auth store override for tests or nonstandard installs. */
+  openclawAuthPath?: string;
+}
+
+export interface AuthResolution {
+  source: AuthSourceClass;
+  credentialKey?: string;
+  value?: string;
+  isConfigured: boolean;
+  missingReason?: string;
+  meta?: Record<string, unknown>;
 }
 
 export interface AIGatewayConfig {
@@ -111,6 +133,8 @@ export interface AIGatewayConfig {
   chat_fallback_chain?: string[];
   /** Optional per-provider base URL override (openai-compatible variants). */
   base_urls?: Record<string, string>;
+  /** Optional provider auth source overrides keyed by recipe id. */
+  provider_auth?: Record<string, ProviderAuthConfig>;
   /** Env snapshot read once at configuration time. Gateway never reads process.env at call time. */
   env: Record<string, string | undefined>;
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, chmodSync, existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import type { ProviderAuthConfig } from './ai/types.ts';
 import type { EngineConfig } from './types.ts';
 
 /**
@@ -48,6 +49,8 @@ export interface GBrainConfig {
   chat_fallback_chain?: string[];
   /** Optional base URL overrides for openai-compatible providers (keyed by recipe id). */
   provider_base_urls?: Record<string, string>;
+  /** Optional provider auth overrides (for example, explicit OpenClaw profile selection). */
+  provider_auth?: Record<string, ProviderAuthConfig>;
   /**
    * Optional storage backend config (S3/Supabase/local). Shape matches
    * `StorageConfig` in `./storage.ts`. Typed as `unknown` here to avoid
@@ -103,6 +106,17 @@ export function loadConfig(): GBrainConfig | null {
       ? { chat_fallback_chain: process.env.GBRAIN_CHAT_FALLBACK_CHAIN.split(',').map(s => s.trim()).filter(Boolean) }
       : {}),
   };
+  if (process.env.GBRAIN_OPENAI_AUTH_SOURCE === 'openclaw-codex' || process.env.GBRAIN_OPENAI_AUTH_SOURCE === 'openclaw-openai') {
+    merged.provider_auth = {
+      ...(merged.provider_auth ?? {}),
+      openai: {
+        ...(merged.provider_auth?.openai ?? {}),
+        prefer: process.env.GBRAIN_OPENAI_AUTH_SOURCE,
+        ...(process.env.GBRAIN_OPENAI_AUTH_PROFILE ? { profile: process.env.GBRAIN_OPENAI_AUTH_PROFILE } : {}),
+        ...(process.env.GBRAIN_OPENCLAW_AUTH_PATH ? { openclawAuthPath: process.env.GBRAIN_OPENCLAW_AUTH_PATH } : {}),
+      },
+    };
+  }
   return merged as GBrainConfig;
 }
 

--- a/test/ai/auth.test.ts
+++ b/test/ai/auth.test.ts
@@ -45,6 +45,7 @@ describe('provider auth resolver', () => {
       provider_auth: { openai: { prefer: 'openclaw-codex', profile: 'missing', openclawAuthPath: authPath } },
     }));
     expect(resolution.source).toBe('missing');
+    expect(resolution.credentialKey).toBe('OPENAI_API_KEY');
     expect(resolution.isConfigured).toBe(false);
     expect(resolution.missingReason).toContain('missing');
     expect(JSON.stringify(redactAuthResolution(resolution))).not.toContain('secret');
@@ -59,6 +60,22 @@ describe('provider auth resolver', () => {
     expect(resolution.source).toBe('openclaw-codex');
     expect(resolution.credentialKey).toBe('OPENAI_API_KEY');
     expect(resolution.value).toBe('oc-secret');
+  });
+
+  test('openclaw-openai preference defaults to the openclaw-openai profile', () => {
+    writeFileSync(authPath, JSON.stringify({
+      profiles: {
+        'openclaw-codex': { OPENAI_API_KEY: 'wrong-profile' },
+        'openclaw-openai': { OPENAI_API_KEY: 'right-profile' },
+      },
+    }));
+    const resolution = resolveProviderAuth(openai, config({
+      env: {},
+      provider_auth: { openai: { prefer: 'openclaw-openai', openclawAuthPath: authPath } },
+    }));
+    expect(resolution.source).toBe('openclaw-openai');
+    expect(resolution.value).toBe('right-profile');
+    expect(resolution.meta?.profile).toBe('openclaw-openai');
   });
 
   test('redaction omits token values', () => {

--- a/test/ai/auth.test.ts
+++ b/test/ai/auth.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { redactAuthResolution, resolveProviderAuth } from '../../src/core/ai/auth.ts';
+import { configureGateway, isAvailable, resetGateway } from '../../src/core/ai/gateway.ts';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+import type { AIGatewayConfig } from '../../src/core/ai/types.ts';
+
+const openai = getRecipe('openai');
+const ollama = getRecipe('ollama');
+if (!openai) throw new Error('openai recipe missing');
+if (!ollama) throw new Error('ollama recipe missing');
+
+describe('provider auth resolver', () => {
+  let tempDir: string;
+  let authPath: string;
+
+  beforeEach(() => {
+    resetGateway();
+    tempDir = mkdtempSync(join(tmpdir(), 'gbrain-auth-'));
+    mkdirSync(join(tempDir, '.openclaw'), { recursive: true });
+    authPath = join(tempDir, '.openclaw', 'auth.json');
+  });
+
+  afterEach(() => {
+    resetGateway();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('env fallback remains highest priority when OpenClaw auth is configured', () => {
+    writeOpenClawProfile({ OPENAI_API_KEY: 'oc-secret' });
+    const resolution = resolveProviderAuth(openai, config({
+      env: { OPENAI_API_KEY: 'env-secret' },
+      provider_auth: { openai: { prefer: 'openclaw-codex', openclawAuthPath: authPath } },
+    }));
+    expect(resolution.source).toBe('env');
+    expect(resolution.value).toBe('env-secret');
+  });
+
+  test('missing OpenClaw profile reports missing without secret leakage', () => {
+    const resolution = resolveProviderAuth(openai, config({
+      env: {},
+      provider_auth: { openai: { prefer: 'openclaw-codex', profile: 'missing', openclawAuthPath: authPath } },
+    }));
+    expect(resolution.source).toBe('missing');
+    expect(resolution.isConfigured).toBe(false);
+    expect(resolution.missingReason).toContain('missing');
+    expect(JSON.stringify(redactAuthResolution(resolution))).not.toContain('secret');
+  });
+
+  test('selected OpenClaw profile provides credential source class', () => {
+    writeOpenClawProfile({ OPENAI_API_KEY: 'oc-secret' });
+    const resolution = resolveProviderAuth(openai, config({
+      env: {},
+      provider_auth: { openai: { prefer: 'openclaw-codex', openclawAuthPath: authPath } },
+    }));
+    expect(resolution.source).toBe('openclaw-codex');
+    expect(resolution.credentialKey).toBe('OPENAI_API_KEY');
+    expect(resolution.value).toBe('oc-secret');
+  });
+
+  test('redaction omits token values', () => {
+    writeOpenClawProfile({ OPENAI_API_KEY: 'oc-secret' });
+    const resolution = resolveProviderAuth(openai, config({
+      env: {},
+      provider_auth: { openai: { prefer: 'openclaw-codex', openclawAuthPath: authPath } },
+    }));
+    const redacted = redactAuthResolution(resolution);
+    expect(JSON.stringify(redacted)).not.toContain('oc-secret');
+    expect(redacted).toMatchObject({ source: 'openclaw-codex', credentialKey: 'OPENAI_API_KEY' });
+  });
+
+  test('unauthenticated local provider remains configured', () => {
+    const resolution = resolveProviderAuth(ollama, config({ env: {} }));
+    expect(resolution.source).toBe('unauthenticated');
+    expect(resolution.isConfigured).toBe(true);
+  });
+
+  test('gateway embedding availability respects selected OpenClaw profile', () => {
+    writeOpenClawProfile({ OPENAI_API_KEY: 'oc-secret' });
+    configureGateway(config({
+      embedding_model: 'openai:text-embedding-3-large',
+      provider_auth: { openai: { prefer: 'openclaw-codex', openclawAuthPath: authPath } },
+      env: {},
+    }));
+    expect(isAvailable('embedding')).toBe(true);
+  });
+
+  test('gateway chat availability respects selected OpenClaw profile', () => {
+    writeOpenClawProfile({ OPENAI_API_KEY: 'oc-secret' });
+    configureGateway(config({
+      chat_model: 'openai:gpt-5.2',
+      provider_auth: { openai: { prefer: 'openclaw-codex', openclawAuthPath: authPath } },
+      env: {},
+    }));
+    expect(isAvailable('chat')).toBe(true);
+  });
+
+  test('gateway availability is false when selected profile is missing', () => {
+    configureGateway(config({
+      embedding_model: 'openai:text-embedding-3-large',
+      provider_auth: { openai: { prefer: 'openclaw-codex', openclawAuthPath: authPath } },
+      env: {},
+    }));
+    expect(isAvailable('embedding')).toBe(false);
+  });
+
+  function writeOpenClawProfile(record: Record<string, string>): void {
+    writeFileSync(authPath, JSON.stringify({ profiles: { 'openclaw-codex': record } }));
+  }
+});
+
+function config(overrides: Partial<AIGatewayConfig>): AIGatewayConfig {
+  return {
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    expansion_model: 'anthropic:claude-haiku-4-5-20251001',
+    chat_model: 'anthropic:claude-sonnet-4-6-20250929',
+    env: {},
+    ...overrides,
+  };
+}


### PR DESCRIPTION
Fixes #543.  
Updates #544.  
Replaces the stale/conflicting durable resolver PR #546.

## Plain-English Summary

This is the OAuth/profile bridge foundation.

Today, many tools make users paste provider API keys into every app that wants embeddings or model calls. Host apps such as OpenClaw can already have a logged-in, user-approved auth profile. GBrain should be able to ask the host for the right credential source without storing or printing secrets itself.

This PR adds that resolver seam on top of the v0.27 provider gateway. Env/API keys still work and remain highest priority, but host-authenticated profiles can become an opt-in credential source.

```mermaid
flowchart LR
  A["GBrain provider call"] --> B["provider auth resolver"]
  B --> C{"env key present?"}
  C -->|yes| D["use env/API key"]
  C -->|no| E{"configured host profile?"}
  E -->|OpenClaw/Codex| F["read host auth profile"]
  F --> G["return redacted credential source metadata"]
  D --> H["Vercel AI SDK gateway"]
  G --> H
  H --> I["embedding / expansion / chat"]
```

## Why OAuth/Profile Auth Matters

For normal users, this means fewer separate setup chores and fewer places where secrets can leak. If a trusted host already owns the login flow, GBrain can be configured to use that host profile as the credential source instead of asking every user to manage another model key.

For maintainers, this keeps the boundary clean: GBrain resolves a credential source, reports redacted metadata, and lets the existing provider gateway make the model call. It does not become an OpenClaw-specific app.

## What Changed

- Adds `src/core/ai/auth.ts` as a single credential-source resolver.
- Keeps env/API-key credentials as the default and highest-priority source.
- Adds explicit OpenClaw/Codex profile auth as a secondary opt-in source for OpenAI.
- Threads `provider_auth` through gateway config and file/env config.
- Uses the resolver for embedding, expansion, and the new v0.27 chat path.
- Updates `gbrain providers` status/explain/env output to report credential source class without exposing token values.
- Adds resolver tests for env precedence, missing profile behavior, redaction, unauthenticated local providers, OpenClaw-backed embedding readiness, and OpenClaw-backed chat readiness.
- Adds `docs/guides/provider-auth.md` with a human/maintainer explanation of credential-source resolution.

## Non-goals

- No implicit scanning of arbitrary secret locations.
- No mutation of OpenClaw config or auth state.
- No claim that OpenClaw/Codex OAuth extraction is fully shipped by this upstream core seam.
- No raw credential values in provider output.

## Review-Fix Pass

Latest review-fix commit: `265dd4f`.

Fixed Copilot review findings around:

- `prefer: openclaw-openai` defaulting to the wrong profile;
- missing OpenClaw profile errors reading like fake env vars instead of reporting the expected env key plus profile metadata.

## Validation

- `git diff --check`
- `bun run verify`
- `bun test test/ai/auth.test.ts test/ai/gateway.test.ts test/ai/gateway-chat.test.ts`
- focused review-fix rerun: `bun test test/ai/auth.test.ts test/ai/gateway.test.ts` -> `29 pass, 0 fail`
- prior full isolated run: `HOME=$(mktemp -d) bun run test` -> `3837 pass, 0 fail`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
