### PR TITLE
feat: import normalized media evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ GBrain ships integration recipes that your agent sets up for you. Each recipe te
 | [X-to-Brain](recipes/x-to-brain.md) | — | Twitter timeline + mentions + deletions |
 | [Calendar-to-Brain](recipes/calendar-to-brain.md) | credential-gateway | Google Calendar to searchable daily pages |
 | [Meeting Sync](recipes/meeting-sync.md) | — | Circleback transcripts to brain pages with attendees |
+| [Media Evidence](docs/guides/media-evidence.md) | extractor JSON | OCR/captions/transcripts into searchable media pages |
 
 **Data research recipes** extract structured data from email into tracked brain pages. Built-in recipes for investor updates (MRR, ARR, runway, headcount), expense tracking, and company metrics. Create your own with `gbrain research init`.
 
@@ -683,6 +684,10 @@ SEARCH
 IMPORT
   gbrain import <dir> [--no-embed] [--workers N]
                                         Import markdown (idempotent)
+  gbrain import-media --slug <s> --extraction <json>
+                                        Import normalized media evidence
+  gbrain ingest-media <file> --extract <json>
+                                        Import local media with precomputed evidence
   gbrain sync [--repo <path>] [--workers N]
                                         Git-to-brain incremental sync
                                         (>100-file diffs auto-parallelize 4 workers on Postgres)

--- a/docs/guides/content-media.md
+++ b/docs/guides/content-media.md
@@ -3,6 +3,16 @@
 ## Goal
 YouTube videos, social media, PDFs, and documents become searchable brain pages with the agent's own analysis and full cross-references to every entity mentioned.
 
+## Current Core Import Path
+For media extractors that already produce structured output, use the normalized evidence importer first:
+
+```bash
+gbrain import-media --slug media/evidence/example --extraction example.extraction.json --no-embed
+gbrain ingest-media ./screenshot.png --extract screenshot.extraction.json --no-embed
+```
+
+The extractor JSON is normalized from `gbrain.media-extraction.v1` into `gbrain.media-evidence.v1`, stored in `raw_data`, and indexed as searchable page chunks. See [Media Evidence Import](media-evidence.md).
+
 ## What the User Gets
 Without this: media links are bookmarks that decay -- you remember watching a video but can't find what was said, who said it, or why it mattered. With this: every piece of media is a permanent brain page with the agent's analysis layered on top, every mentioned entity gets a back-link, and the full content is searchable forever.
 

--- a/docs/guides/media-evidence.md
+++ b/docs/guides/media-evidence.md
@@ -1,0 +1,57 @@
+# Media Evidence Import
+
+GBrain can import normalized media evidence as searchable brain pages. This is the text-backed foundation for image, PDF, audio, and video support: an extractor produces JSON, then GBrain stores the normalized evidence and indexes its caption/OCR/transcript text.
+
+This does not perform binary image or video understanding by itself. Use an OCR, transcript, multimodal, or host adapter to produce `gbrain.media-extraction.v1` JSON first.
+
+## Schemas
+
+Extractor output uses `gbrain.media-extraction.v1`:
+
+```json
+{
+  "kind": "image",
+  "sourceRef": "screenshots/error.png",
+  "title": "Stripe login error screenshot",
+  "ocrText": "Stripe API key invalid.",
+  "tags": ["stripe", "error"],
+  "segments": [
+    {
+      "id": "image-root",
+      "kind": "asset",
+      "caption": "Dashboard screenshot with error banner",
+      "ocrText": "Stripe API key invalid."
+    }
+  ]
+}
+```
+
+GBrain normalizes that into `gbrain.media-evidence.v1`, stores it in `raw_data`, and chunks the searchable text alongside the media page.
+
+## CLI
+
+Import precomputed extraction JSON:
+
+```bash
+gbrain import-media \
+  --slug media/evidence/stripe-login \
+  --extraction stripe-login.extraction.json \
+  --media-file screenshots/stripe-login.png \
+  --no-embed
+```
+
+Use `ingest-media` when you want the media file to define the default slug and source reference:
+
+```bash
+gbrain ingest-media screenshots/stripe-login.png \
+  --extract stripe-login.extraction.json \
+  --no-embed
+```
+
+`--no-embed` still indexes keyword-searchable chunks. Run `gbrain embed <slug>` later if you want vector embeddings for the imported page.
+
+## Boundaries
+
+- Core GBrain accepts normalized evidence JSON and makes it searchable.
+- Provider or host adapters are responsible for OCR, captions, transcripts, and multimodal extraction.
+- Full binary image/video understanding and multimodal embeddings are follow-up layers, not requirements for this importer.

--- a/docs/guides/media-evidence.md
+++ b/docs/guides/media-evidence.md
@@ -4,6 +4,28 @@ GBrain can import normalized media evidence as searchable brain pages. This is t
 
 This does not perform binary image or video understanding by itself. Use an OCR, transcript, multimodal, or host adapter to produce `gbrain.media-extraction.v1` JSON first.
 
+```mermaid
+flowchart LR
+  Media["Media file\nimage, PDF, audio, video"]
+  Extractor["Extractor or host adapter\nOCR, captioning, transcript"]
+  Extraction["gbrain.media-extraction.v1\nnormalized extractor output"]
+  Importer["gbrain import-media / ingest-media"]
+  Page["Media page\ncompiled truth + frontmatter"]
+  Raw["raw_data sidecar\ngbrain.media-evidence.v1"]
+  Chunks["Search chunks\nkeyword now, embeddings optional"]
+
+  Media --> Extractor
+  Extractor --> Extraction
+  Extraction --> Importer
+  Importer --> Page
+  Importer --> Raw
+  Importer --> Chunks
+```
+
+In plain English: the extractor tells GBrain what the media contains. GBrain
+then gives that media a normal brain page, keeps the structured evidence in
+`raw_data`, and makes the useful text searchable.
+
 ## Schemas
 
 Extractor output uses `gbrain.media-extraction.v1`:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2042,6 +2042,7 @@ GBrain ships integration recipes that your agent sets up for you. Each recipe te
 | [X-to-Brain](recipes/x-to-brain.md) | — | Twitter timeline + mentions + deletions |
 | [Calendar-to-Brain](recipes/calendar-to-brain.md) | credential-gateway | Google Calendar to searchable daily pages |
 | [Meeting Sync](recipes/meeting-sync.md) | — | Circleback transcripts to brain pages with attendees |
+| [Media Evidence](docs/guides/media-evidence.md) | extractor JSON | OCR/captions/transcripts into searchable media pages |
 
 **Data research recipes** extract structured data from email into tracked brain pages. Built-in recipes for investor updates (MRR, ARR, runway, headcount), expense tracking, and company metrics. Create your own with `gbrain research init`.
 
@@ -2286,6 +2287,10 @@ SEARCH
 IMPORT
   gbrain import <dir> [--no-embed] [--workers N]
                                         Import markdown (idempotent)
+  gbrain import-media --slug <s> --extraction <json>
+                                        Import normalized media evidence
+  gbrain ingest-media <file> --extract <json>
+                                        Import local media with precomputed evidence
   gbrain sync [--repo <path>] [--workers N]
                                         Git-to-brain incremental sync
                                         (>100-file diffs auto-parallelize 4 workers on Postgres)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3815,6 +3815,70 @@ hashes match. If both a cron and `--watch` fire simultaneously, no conflict.
 
 ---
 
+## docs/guides/media-evidence.md
+
+Source: https://raw.githubusercontent.com/garrytan/gbrain/master/docs/guides/media-evidence.md
+
+# Media Evidence Import
+
+GBrain can import normalized media evidence as searchable brain pages. This is the text-backed foundation for image, PDF, audio, and video support: an extractor produces JSON, then GBrain stores the normalized evidence and indexes its caption/OCR/transcript text.
+
+This does not perform binary image or video understanding by itself. Use an OCR, transcript, multimodal, or host adapter to produce `gbrain.media-extraction.v1` JSON first.
+
+## Schemas
+
+Extractor output uses `gbrain.media-extraction.v1`:
+
+```json
+{
+  "kind": "image",
+  "sourceRef": "screenshots/error.png",
+  "title": "Stripe login error screenshot",
+  "ocrText": "Stripe API key invalid.",
+  "tags": ["stripe", "error"],
+  "segments": [
+    {
+      "id": "image-root",
+      "kind": "asset",
+      "caption": "Dashboard screenshot with error banner",
+      "ocrText": "Stripe API key invalid."
+    }
+  ]
+}
+```
+
+GBrain normalizes that into `gbrain.media-evidence.v1`, stores it in `raw_data`, and chunks the searchable text alongside the media page.
+
+## CLI
+
+Import precomputed extraction JSON:
+
+```bash
+gbrain import-media \
+  --slug media/evidence/stripe-login \
+  --extraction stripe-login.extraction.json \
+  --media-file screenshots/stripe-login.png \
+  --no-embed
+```
+
+Use `ingest-media` when you want the media file to define the default slug and source reference:
+
+```bash
+gbrain ingest-media screenshots/stripe-login.png \
+  --extract stripe-login.extraction.json \
+  --no-embed
+```
+
+`--no-embed` still indexes keyword-searchable chunks. Run `gbrain embed <slug>` later if you want vector embeddings for the imported page.
+
+## Boundaries
+
+- Core GBrain accepts normalized evidence JSON and makes it searchable.
+- Provider or host adapters are responsible for OCR, captions, transcripts, and multimodal extraction.
+- Full binary image/video understanding and multimodal embeddings are follow-up layers, not requirements for this importer.
+
+---
+
 ## docs/guides/cron-schedule.md
 
 Source: https://raw.githubusercontent.com/garrytan/gbrain/master/docs/guides/cron-schedule.md

--- a/llms.txt
+++ b/llms.txt
@@ -17,6 +17,7 @@ Repo: https://github.com/garrytan/gbrain
 - [docs/ENGINES.md](https://raw.githubusercontent.com/garrytan/gbrain/master/docs/ENGINES.md): PGLite vs Postgres trade-off and when to migrate.
 - [docs/GBRAIN_RECOMMENDED_SCHEMA.md](https://raw.githubusercontent.com/garrytan/gbrain/master/docs/GBRAIN_RECOMMENDED_SCHEMA.md): MECE directory structure (people/, companies/, concepts/).
 - [docs/guides/live-sync.md](https://raw.githubusercontent.com/garrytan/gbrain/master/docs/guides/live-sync.md): Incremental markdown sync setup.
+- [docs/guides/media-evidence.md](https://raw.githubusercontent.com/garrytan/gbrain/master/docs/guides/media-evidence.md): Normalized media evidence import for OCR, captions, and transcripts.
 - [docs/guides/cron-schedule.md](https://raw.githubusercontent.com/garrytan/gbrain/master/docs/guides/cron-schedule.md): Recurring job scheduling.
 - [docs/guides/minions-deployment.md](https://raw.githubusercontent.com/garrytan/gbrain/master/docs/guides/minions-deployment.md): Deploying the gbrain jobs worker: crontab + watchdog, inline --follow, systemd/Procfile/fly.toml, upgrade checklist.
 - [docs/guides/quiet-hours.md](https://raw.githubusercontent.com/garrytan/gbrain/master/docs/guides/quiet-hours.md): Notification hold + timezone-aware delivery.

--- a/scripts/llms-config.ts
+++ b/scripts/llms-config.ts
@@ -88,6 +88,12 @@ export const SECTIONS: DocSection[] = [
         path: "docs/guides/live-sync.md",
       },
       {
+        title: "docs/guides/media-evidence.md",
+        description:
+          "Normalized media evidence import for OCR, captions, and transcripts.",
+        path: "docs/guides/media-evidence.md",
+      },
+      {
         title: "docs/guides/cron-schedule.md",
         description: "Recurring job scheduling.",
         path: "docs/guides/cron-schedule.md",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror']);
+const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'import-media', 'ingest-media', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror']);
 
 async function main() {
   // Parse global flags (--quiet / --progress-json / --progress-interval)
@@ -461,6 +461,16 @@ async function handleCliOnly(command: string, args: string[]) {
         await runImport(engine, args);
         break;
       }
+      case 'import-media': {
+        const { runImportMedia } = await import('./commands/import-media.ts');
+        await runImportMedia(engine, args);
+        break;
+      }
+      case 'ingest-media': {
+        const { runIngestMedia } = await import('./commands/import-media.ts');
+        await runIngestMedia(engine, args);
+        break;
+      }
       case 'export': {
         const { runExport } = await import('./commands/export.ts');
         await runExport(engine, args);
@@ -697,6 +707,10 @@ SEARCH
 
 IMPORT/EXPORT
   import <dir> [--no-embed]          Import markdown directory
+  import-media --slug <s> --extraction <json>
+                                     Import normalized media evidence JSON
+  ingest-media <file> --extract <json>
+                                     Import local media with precomputed evidence
   sync [--repo <path>] [flags]       Git-to-brain incremental sync
   sync --watch [--interval N]        Continuous sync (loops until stopped)
   sync --install-cron                Install persistent sync daemon

--- a/src/commands/import-media.ts
+++ b/src/commands/import-media.ts
@@ -1,0 +1,183 @@
+import { existsSync, readFileSync, statSync } from 'fs';
+import { basename, extname } from 'path';
+import type { BrainEngine } from '../core/engine.ts';
+import { serializeMarkdown } from '../core/markdown.ts';
+import {
+  defaultMediaContent,
+  importNormalizedMediaEvidence,
+  type MediaFileMetadata,
+} from '../core/import-media.ts';
+import {
+  mediaExtractionToEvidence,
+  normalizeMediaExtraction,
+  type MediaExtraction,
+  type MediaExtractionKind,
+} from '../core/media-extraction.ts';
+
+const MIME_TYPES: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.heic': 'image/heic',
+  '.pdf': 'application/pdf',
+  '.mp4': 'video/mp4',
+  '.mov': 'video/quicktime',
+  '.m4a': 'audio/mp4',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.markdown': 'text/markdown',
+  '.srt': 'text/plain',
+  '.vtt': 'text/vtt',
+  '.json': 'application/json',
+};
+
+function importUsage(): never {
+  console.error('Usage: gbrain import-media --slug <slug> --extraction <file.json> [--content-file <file.md>] [--media-file <path>] [--source <ref>] [--raw-data-source <name>] [--title <title>] [--type image|pdf|video|audio] [--no-embed]');
+  process.exit(1);
+}
+
+function ingestUsage(): never {
+  console.error('Usage: gbrain ingest-media <file> --extract <file.json> [--slug <slug>] [--title <title>] [--source <ref>] [--type image|pdf|video|audio] [--content-file <file.md>] [--no-embed]');
+  process.exit(1);
+}
+
+function getFlag(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  return idx !== -1 ? args[idx + 1] : undefined;
+}
+
+function getMimeType(filePath: string): string | null {
+  const ext = extname(filePath).toLowerCase();
+  return MIME_TYPES[ext] || null;
+}
+
+function defaultMediaSlug(filename: string): string {
+  const stem = basename(filename, extname(filename))
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'untitled';
+  return `media/evidence/${stem}`;
+}
+
+function fileKindOverride(explicit: string | undefined, extraction: MediaExtraction, mimeType: string | null): MediaExtractionKind {
+  if (explicit) {
+    if (['image', 'pdf', 'video', 'audio'].includes(explicit)) return explicit as MediaExtractionKind;
+    throw new Error('--type must be one of: image, pdf, video, audio');
+  }
+  if (mimeType?.startsWith('image/')) return 'image';
+  if (mimeType?.startsWith('audio/')) return 'audio';
+  if (mimeType?.startsWith('video/')) return 'video';
+  if (mimeType === 'application/pdf') return 'pdf';
+  return extraction.kind;
+}
+
+function readMediaFileMetadata(mediaFilePath: string | undefined): MediaFileMetadata | undefined {
+  if (!mediaFilePath) return undefined;
+  const stat = statSync(mediaFilePath);
+  return {
+    filename: basename(mediaFilePath),
+    mimeType: getMimeType(mediaFilePath),
+    sizeBytes: stat.size,
+  };
+}
+
+function existingPageContent(existing: Awaited<ReturnType<BrainEngine['getPage']>>): string | undefined {
+  if (!existing) return undefined;
+  return serializeMarkdown(existing.frontmatter || {}, existing.compiled_truth, existing.timeline || '', {
+    type: existing.type,
+    title: existing.title,
+    tags: [],
+  });
+}
+
+function assertJsonExtractionFile(extractionFile: string): void {
+  if (extractionFile === 'openclaw') {
+    throw new Error('Core GBrain expects normalized gbrain.media-extraction.v1 JSON here. Host adapters can produce that JSON before calling ingest-media.');
+  }
+}
+
+export async function runImportMedia(engine: BrainEngine, args: string[]) {
+  const slug = getFlag(args, '--slug');
+  const contentFile = getFlag(args, '--content-file');
+  const extractionFile = getFlag(args, '--extraction');
+  const source = getFlag(args, '--source');
+  const rawDataSource = getFlag(args, '--raw-data-source');
+  const mediaFilePath = getFlag(args, '--media-file');
+  const title = getFlag(args, '--title');
+  const type = getFlag(args, '--type');
+  const noEmbed = args.includes('--no-embed');
+
+  if (!slug || !extractionFile) importUsage();
+  assertJsonExtractionFile(extractionFile);
+  if ((contentFile && !existsSync(contentFile)) || !existsSync(extractionFile) || (mediaFilePath && !existsSync(mediaFilePath))) {
+    importUsage();
+  }
+
+  const extractionJson = JSON.parse(readFileSync(extractionFile, 'utf-8')) as unknown;
+  const normalized = normalizeMediaExtraction(extractionJson);
+  const mimeType = mediaFilePath ? getMimeType(mediaFilePath) : null;
+  const evidence = mediaExtractionToEvidence({
+    ...normalized,
+    kind: fileKindOverride(type, normalized, mimeType),
+    sourceRef: source || mediaFilePath || normalized.sourceRef || normalized.title,
+  });
+
+  const finalTitle = title || normalized.title || (mediaFilePath ? basename(mediaFilePath) : slug);
+  const existing = await engine.getPage(slug);
+  const content = contentFile
+    ? readFileSync(contentFile, 'utf-8')
+    : existingPageContent(existing) ?? defaultMediaContent(finalTitle, evidence);
+
+  const result = await importNormalizedMediaEvidence(engine, {
+    slug,
+    content,
+    evidence,
+    rawDataSource: rawDataSource ?? 'gbrain.media-evidence.v1',
+    mediaFile: readMediaFileMetadata(mediaFilePath),
+    pageTitle: finalTitle,
+    noEmbed,
+  });
+
+  console.log(JSON.stringify({
+    status: result.status,
+    slug: result.slug,
+    raw_data_source: result.rawDataSource,
+    segment_count: evidence.segments.length,
+    evidence_text_length: evidence.text.length,
+    media_file: mediaFilePath ?? null,
+    chunks: result.chunks,
+    no_embed: noEmbed,
+  }, null, 2));
+}
+
+export async function runIngestMedia(engine: BrainEngine, args: string[]) {
+  const mediaFile = args[0] && !args[0].startsWith('--') ? args[0] : undefined;
+  const extractionFile = getFlag(args, '--extract');
+  const slug = getFlag(args, '--slug');
+  const title = getFlag(args, '--title');
+  const source = getFlag(args, '--source');
+  const type = getFlag(args, '--type');
+  const noEmbed = args.includes('--no-embed');
+  const contentFile = getFlag(args, '--content-file');
+
+  if (!mediaFile || !extractionFile || !existsSync(mediaFile)) ingestUsage();
+  assertJsonExtractionFile(extractionFile);
+  if (!existsSync(extractionFile) || (contentFile && !existsSync(contentFile))) ingestUsage();
+
+  await runImportMedia(engine, [
+    '--slug', slug || defaultMediaSlug(mediaFile),
+    '--extraction', extractionFile,
+    ...(contentFile ? ['--content-file', contentFile] : []),
+    '--media-file', mediaFile,
+    '--raw-data-source', 'gbrain.media-evidence.v1',
+    ...(title ? ['--title', title] : []),
+    ...(source ? ['--source', source] : []),
+    ...(type ? ['--type', type] : []),
+    ...(noEmbed ? ['--no-embed'] : []),
+  ]);
+}

--- a/src/commands/import-media.ts
+++ b/src/commands/import-media.ts
@@ -86,12 +86,13 @@ function readMediaFileMetadata(mediaFilePath: string | undefined): MediaFileMeta
   };
 }
 
-function existingPageContent(existing: Awaited<ReturnType<BrainEngine['getPage']>>): string | undefined {
+async function existingPageContent(engine: BrainEngine, slug: string, existing: Awaited<ReturnType<BrainEngine['getPage']>>): Promise<string | undefined> {
   if (!existing) return undefined;
+  const tags = await engine.getTags(slug);
   return serializeMarkdown(existing.frontmatter || {}, existing.compiled_truth, existing.timeline || '', {
     type: existing.type,
     title: existing.title,
-    tags: [],
+    tags,
   });
 }
 
@@ -131,7 +132,7 @@ export async function runImportMedia(engine: BrainEngine, args: string[]) {
   const existing = await engine.getPage(slug);
   const content = contentFile
     ? readFileSync(contentFile, 'utf-8')
-    : existingPageContent(existing) ?? defaultMediaContent(finalTitle, evidence);
+    : await existingPageContent(engine, slug, existing) ?? defaultMediaContent(finalTitle, evidence);
 
   const result = await importNormalizedMediaEvidence(engine, {
     slug,

--- a/src/core/import-media.ts
+++ b/src/core/import-media.ts
@@ -1,0 +1,194 @@
+import { createHash } from 'crypto';
+import type { BrainEngine } from './engine.ts';
+import type { ChunkInput, PageInput } from './types.ts';
+import { chunkText } from './chunkers/recursive.ts';
+import { embedBatch } from './embedding.ts';
+import { parseMarkdown, serializeMarkdown } from './markdown.ts';
+import type { MediaEvidence } from './media-extraction.ts';
+
+export interface MediaFileMetadata {
+  filename?: string;
+  mimeType?: string | null;
+  sizeBytes?: number;
+}
+
+export interface ImportNormalizedMediaEvidenceOptions {
+  slug: string;
+  content: string;
+  evidence: MediaEvidence;
+  rawDataSource?: string;
+  mediaFile?: MediaFileMetadata;
+  pageTitle?: string;
+  noEmbed?: boolean;
+}
+
+export interface ImportNormalizedMediaEvidenceResult {
+  slug: string;
+  status: 'imported' | 'skipped';
+  rawDataSource: string;
+  chunks: number;
+}
+
+export function defaultMediaContent(title: string, evidence: MediaEvidence): string {
+  return serializeMarkdown({}, evidence.text, '', {
+    type: 'media',
+    title,
+    tags: [],
+  });
+}
+
+function chunkMediaPage(page: PageInput, evidence: MediaEvidence): ChunkInput[] {
+  const parts = [page.compiled_truth, evidence.text]
+    .map(part => part.trim())
+    .filter(Boolean);
+  const searchableText = Array.from(new Set(parts)).join('\n\n');
+  return chunkText(searchableText).map((c, idx) => ({
+    chunk_index: idx,
+    chunk_text: c.text,
+    chunk_source: 'compiled_truth',
+  }));
+}
+
+function mediaEvidenceHash(page: PageInput, evidence: MediaEvidence): string {
+  return createHash('sha256')
+    .update(stableStringify({
+      title: page.title,
+      type: page.type,
+      compiled_truth: page.compiled_truth,
+      timeline: page.timeline || '',
+      frontmatter: page.frontmatter || {},
+      evidence,
+    }))
+    .digest('hex');
+}
+
+interface ParsedMediaPage {
+  page: PageInput;
+  tags: string[];
+}
+
+function parseMediaPageContent(content: string, slug: string, fallbackTitle: string, evidence: MediaEvidence): ParsedMediaPage {
+  const parsed = parseMarkdown(content, `${slug}.md`);
+  return {
+    page: {
+      title: parsed.title || fallbackTitle,
+      type: 'media',
+      compiled_truth: parsed.compiled_truth || evidence.text,
+      timeline: parsed.timeline || '',
+      frontmatter: {
+        ...parsed.frontmatter,
+        media_type: evidence.kind,
+        source_ref: evidence.sourceRef,
+        evidence_schema: evidence.schemaVersion,
+        ingestion: 'media-evidence-mvp',
+        media_tags: evidence.tags.map(tag => tag.value),
+      },
+    },
+    tags: parsed.tags,
+  };
+}
+
+function stableStringify(value: unknown): string {
+  if (value === undefined) return '';
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b));
+    return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function rawDataEqualsExisting(rows: Array<{ data: unknown }>, evidence: MediaEvidence): boolean {
+  if (rows.length !== 1) return false;
+  try {
+    const existing = typeof rows[0]?.data === 'string'
+      ? JSON.parse(rows[0].data as string)
+      : rows[0]?.data;
+    return stableStringify(existing) === stableStringify(evidence);
+  } catch {
+    return false;
+  }
+}
+
+function pageMatchesExisting(existing: Awaited<ReturnType<BrainEngine['getPage']>>, page: PageInput): boolean {
+  if (!existing) return false;
+  return existing.content_hash === page.content_hash;
+}
+
+async function maybeEmbedChunks(chunks: ChunkInput[], noEmbed: boolean | undefined): Promise<void> {
+  if (noEmbed || chunks.length === 0) return;
+  const embeddings = await embedBatch(chunks.map(c => c.chunk_text));
+  for (let i = 0; i < chunks.length; i++) {
+    chunks[i].embedding = embeddings[i];
+    chunks[i].token_count = Math.ceil(chunks[i].chunk_text.length / 4);
+  }
+}
+
+export async function importNormalizedMediaEvidence(
+  engine: BrainEngine,
+  opts: ImportNormalizedMediaEvidenceOptions,
+): Promise<ImportNormalizedMediaEvidenceResult> {
+  const pageTitle = opts.pageTitle || opts.evidence.sourceRef || opts.slug;
+  if (!opts.evidence.text.trim()) throw new Error('Normalized media evidence text is empty.');
+
+  const rawDataSource = opts.rawDataSource ?? 'gbrain.media-evidence.v1';
+  const parsed = parseMediaPageContent(opts.content, opts.slug, pageTitle, opts.evidence);
+  const page = parsed.page;
+  page.frontmatter = {
+    ...(page.frontmatter || {}),
+    ...(opts.mediaFile?.filename ? { filename: opts.mediaFile.filename } : {}),
+    ...(opts.mediaFile?.mimeType ? { mime_type: opts.mediaFile.mimeType } : {}),
+    ...(opts.mediaFile?.sizeBytes !== undefined ? { size_bytes: opts.mediaFile.sizeBytes } : {}),
+  };
+  page.content_hash = mediaEvidenceHash(page, opts.evidence);
+
+  const existing = await engine.getPage(opts.slug);
+  const existingRawData = existing ? await engine.getRawData(opts.slug, rawDataSource) : [];
+  const unchanged = pageMatchesExisting(existing, page) && rawDataEqualsExisting(existingRawData, opts.evidence);
+  const chunks = chunkMediaPage(page, opts.evidence);
+
+  if (unchanged) {
+    return {
+      slug: opts.slug,
+      status: 'skipped',
+      rawDataSource,
+      chunks: chunks.length,
+    };
+  }
+
+  await maybeEmbedChunks(chunks, opts.noEmbed);
+
+  await engine.transaction(async (tx) => {
+    if (existing) await tx.createVersion(opts.slug);
+    await tx.putPage(opts.slug, page);
+    await tx.putRawData(opts.slug, rawDataSource, opts.evidence as unknown as object);
+
+    const existingTags = await tx.getTags(opts.slug);
+    const newTags = new Set(parsed.tags);
+    for (const old of existingTags) {
+      if (!newTags.has(old)) await tx.removeTag(opts.slug, old);
+    }
+    for (const tag of parsed.tags) {
+      await tx.addTag(opts.slug, tag);
+    }
+
+    if (chunks.length > 0) await tx.upsertChunks(opts.slug, chunks);
+    else await tx.deleteChunks(opts.slug);
+  });
+
+  await engine.logIngest({
+    source_type: 'media',
+    source_ref: opts.evidence.sourceRef || opts.slug,
+    pages_updated: [opts.slug],
+    summary: `Imported normalized ${opts.evidence.kind} evidence for ${opts.slug}`,
+  });
+
+  return {
+    slug: opts.slug,
+    status: 'imported',
+    rawDataSource,
+    chunks: chunks.length,
+  };
+}

--- a/src/core/media-extraction.ts
+++ b/src/core/media-extraction.ts
@@ -1,0 +1,288 @@
+export type MediaExtractionKind = 'image' | 'pdf' | 'video' | 'audio';
+
+export type MediaSegmentKind = 'asset' | 'page' | 'frame' | 'transcript_segment' | 'audio_segment';
+
+export interface MediaLocator {
+  page?: number;
+  pageLabel?: string;
+  frame?: number;
+  timecode?: string;
+  startMs?: number;
+  endMs?: number;
+  bbox?: [number, number, number, number];
+  timestamp?: string;
+}
+
+export interface MediaEntity {
+  text: string;
+  type?: string;
+  confidence?: number;
+}
+
+export interface MediaTag {
+  value: string;
+  confidence?: number;
+}
+
+export interface MediaMatchReason {
+  kind: 'ocr' | 'caption' | 'summary' | 'transcript' | 'entity' | 'tag' | 'visual' | 'metadata' | 'other';
+  detail: string;
+  confidence?: number;
+}
+
+export interface MediaExtractionSegment {
+  id: string;
+  kind: MediaSegmentKind;
+  locator?: MediaLocator;
+  caption?: string;
+  summary?: string;
+  ocrText?: string;
+  transcriptText?: string;
+  entities?: MediaEntity[];
+  tags?: MediaTag[];
+  matchReasons?: MediaMatchReason[];
+  confidence?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MediaExtraction {
+  schemaVersion: 'gbrain.media-extraction.v1';
+  kind: MediaExtractionKind;
+  sourceRef?: string;
+  title?: string;
+  summary?: string;
+  caption?: string;
+  ocrText?: string;
+  transcriptText?: string;
+  segments: MediaExtractionSegment[];
+  entities?: MediaEntity[];
+  tags?: MediaTag[];
+  matchReasons?: MediaMatchReason[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface MediaEvidence {
+  schemaVersion: 'gbrain.media-evidence.v1';
+  kind: MediaExtractionKind;
+  sourceRef?: string;
+  text: string;
+  segments: MediaExtractionSegment[];
+  entities: MediaEntity[];
+  tags: MediaTag[];
+  matchReasons: MediaMatchReason[];
+  metadata?: Record<string, unknown>;
+}
+
+const MEDIA_KINDS = new Set<MediaExtractionKind>(['image', 'pdf', 'video', 'audio']);
+const SEGMENT_KINDS = new Set<MediaSegmentKind>(['asset', 'page', 'frame', 'transcript_segment', 'audio_segment']);
+const MATCH_REASON_KINDS = new Set<MediaMatchReason['kind']>([
+  'ocr',
+  'caption',
+  'summary',
+  'transcript',
+  'entity',
+  'tag',
+  'visual',
+  'metadata',
+  'other',
+]);
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normalizeConfidence(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  if (value < 0 || value > 1) return undefined;
+  return value;
+}
+
+function normalizeMediaKind(value: unknown): MediaExtractionKind | undefined {
+  const kind = normalizeString(value);
+  if (!kind || !MEDIA_KINDS.has(kind as MediaExtractionKind)) return undefined;
+  return kind as MediaExtractionKind;
+}
+
+function normalizeSegmentKind(value: unknown): MediaSegmentKind | undefined {
+  const kind = normalizeString(value);
+  if (!kind || !SEGMENT_KINDS.has(kind as MediaSegmentKind)) return undefined;
+  return kind as MediaSegmentKind;
+}
+
+function normalizeMatchReasonKind(value: unknown): MediaMatchReason['kind'] | undefined {
+  const kind = normalizeString(value);
+  if (!kind || !MATCH_REASON_KINDS.has(kind as MediaMatchReason['kind'])) return undefined;
+  return kind as MediaMatchReason['kind'];
+}
+
+function normalizeLocator(value: unknown): MediaLocator | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const loc = value as Record<string, unknown>;
+  const bbox = Array.isArray(loc.bbox) && loc.bbox.length === 4 && loc.bbox.every(n => typeof n === 'number' && Number.isFinite(n))
+    ? [loc.bbox[0] as number, loc.bbox[1] as number, loc.bbox[2] as number, loc.bbox[3] as number] as [number, number, number, number]
+    : undefined;
+  const out: MediaLocator = {
+    page: typeof loc.page === 'number' && Number.isFinite(loc.page) ? loc.page : undefined,
+    pageLabel: normalizeString(loc.pageLabel),
+    frame: typeof loc.frame === 'number' && Number.isFinite(loc.frame) ? loc.frame : undefined,
+    timecode: normalizeString(loc.timecode),
+    startMs: typeof loc.startMs === 'number' && Number.isFinite(loc.startMs) ? loc.startMs : undefined,
+    endMs: typeof loc.endMs === 'number' && Number.isFinite(loc.endMs) ? loc.endMs : undefined,
+    bbox,
+    timestamp: normalizeString(loc.timestamp),
+  };
+  return Object.values(out).some(v => v !== undefined) ? out : undefined;
+}
+
+function normalizeEntities(values: unknown): MediaEntity[] | undefined {
+  if (!Array.isArray(values)) return undefined;
+  const out: MediaEntity[] = [];
+  for (const value of values) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    const row = value as Record<string, unknown>;
+    const text = normalizeString(row.text);
+    if (!text) continue;
+    const entity: MediaEntity = { text };
+    const type = normalizeString(row.type);
+    const confidence = normalizeConfidence(row.confidence);
+    if (type) entity.type = type;
+    if (confidence !== undefined) entity.confidence = confidence;
+    out.push(entity);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function normalizeTags(values: unknown): MediaTag[] | undefined {
+  if (!Array.isArray(values)) return undefined;
+  const out: MediaTag[] = [];
+  for (const value of values) {
+    if (typeof value === 'string') {
+      const normalized = normalizeString(value);
+      if (normalized) out.push({ value: normalized });
+      continue;
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    const row = value as Record<string, unknown>;
+    const tag = normalizeString(row.value);
+    if (!tag) continue;
+    const normalizedTag: MediaTag = { value: tag };
+    const confidence = normalizeConfidence(row.confidence);
+    if (confidence !== undefined) normalizedTag.confidence = confidence;
+    out.push(normalizedTag);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function normalizeMatchReasons(values: unknown): MediaMatchReason[] | undefined {
+  if (!Array.isArray(values)) return undefined;
+  const out: MediaMatchReason[] = [];
+  for (const value of values) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    const row = value as Record<string, unknown>;
+    const kind = normalizeMatchReasonKind(row.kind);
+    const detail = normalizeString(row.detail);
+    if (!kind || !detail) continue;
+    const reason: MediaMatchReason = { kind, detail };
+    const confidence = normalizeConfidence(row.confidence);
+    if (confidence !== undefined) reason.confidence = confidence;
+    out.push(reason);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function normalizeSegment(value: unknown, index: number): MediaExtractionSegment {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Media extraction segment at index ${index} must be an object`);
+  }
+  const row = value as Record<string, unknown>;
+  const id = normalizeString(row.id) ?? `segment-${index}`;
+  const kind = normalizeSegmentKind(row.kind);
+  if (!kind) throw new Error(`Media extraction segment ${id} is missing or has invalid kind`);
+  return {
+    id,
+    kind,
+    locator: normalizeLocator(row.locator),
+    caption: normalizeString(row.caption),
+    summary: normalizeString(row.summary),
+    ocrText: normalizeString(row.ocrText),
+    transcriptText: normalizeString(row.transcriptText),
+    entities: normalizeEntities(row.entities),
+    tags: normalizeTags(row.tags),
+    matchReasons: normalizeMatchReasons(row.matchReasons),
+    confidence: normalizeConfidence(row.confidence),
+    metadata: row.metadata && typeof row.metadata === 'object' && !Array.isArray(row.metadata) ? row.metadata as Record<string, unknown> : undefined,
+  };
+}
+
+export function normalizeMediaExtraction(input: unknown): MediaExtraction {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Media extraction payload must be an object');
+  }
+  const row = input as Record<string, unknown>;
+  const kind = normalizeMediaKind(row.kind);
+  if (!kind) throw new Error('Media extraction payload is missing or has invalid kind');
+  const segmentsInput = row.segments;
+  if (!Array.isArray(segmentsInput) || segmentsInput.length === 0) {
+    throw new Error('Media extraction payload must include at least one segment');
+  }
+  return {
+    schemaVersion: 'gbrain.media-extraction.v1',
+    kind,
+    sourceRef: normalizeString(row.sourceRef),
+    title: normalizeString(row.title),
+    summary: normalizeString(row.summary),
+    caption: normalizeString(row.caption),
+    ocrText: normalizeString(row.ocrText),
+    transcriptText: normalizeString(row.transcriptText),
+    segments: segmentsInput.map((segment, index) => normalizeSegment(segment, index)),
+    entities: normalizeEntities(row.entities),
+    tags: normalizeTags(row.tags),
+    matchReasons: normalizeMatchReasons(row.matchReasons),
+    metadata: row.metadata && typeof row.metadata === 'object' && !Array.isArray(row.metadata) ? row.metadata as Record<string, unknown> : undefined,
+  };
+}
+
+function pushText(parts: string[], value: string | undefined) {
+  if (value) parts.push(value);
+}
+
+export function mediaExtractionToEvidence(extraction: MediaExtraction): MediaEvidence {
+  const parts: string[] = [];
+  pushText(parts, extraction.title);
+  pushText(parts, extraction.summary);
+  pushText(parts, extraction.caption);
+  pushText(parts, extraction.ocrText);
+  pushText(parts, extraction.transcriptText);
+
+  const entities: MediaEntity[] = [...(extraction.entities ?? [])];
+  const tags: MediaTag[] = [...(extraction.tags ?? [])];
+  const matchReasons: MediaMatchReason[] = [...(extraction.matchReasons ?? [])];
+
+  for (const segment of extraction.segments) {
+    pushText(parts, segment.caption);
+    pushText(parts, segment.summary);
+    pushText(parts, segment.ocrText);
+    pushText(parts, segment.transcriptText);
+    if (segment.entities) entities.push(...segment.entities);
+    if (segment.tags) tags.push(...segment.tags);
+    if (segment.matchReasons) matchReasons.push(...segment.matchReasons);
+  }
+
+  return {
+    schemaVersion: 'gbrain.media-evidence.v1',
+    kind: extraction.kind,
+    sourceRef: extraction.sourceRef,
+    text: parts.join('\n\n').trim(),
+    segments: extraction.segments,
+    entities,
+    tags,
+    matchReasons,
+    metadata: extraction.metadata,
+  };
+}
+
+export function buildMediaEvidenceRawData(input: unknown): MediaEvidence {
+  return mediaExtractionToEvidence(normalizeMediaExtraction(input));
+}

--- a/test/fixtures/media-extraction-image.json
+++ b/test/fixtures/media-extraction-image.json
@@ -1,0 +1,27 @@
+{
+  "kind": "image",
+  "sourceRef": "screenshots/stripe-error-login.png",
+  "title": "Stripe login error screenshot",
+  "caption": "Login form showing a Stripe API key error banner",
+  "ocrText": "Stripe API key invalid. Please update your environment variables.",
+  "tags": ["stripe", "error", "login"],
+  "matchReasons": [
+    { "kind": "ocr", "detail": "Detected API key error text", "confidence": 0.97 }
+  ],
+  "segments": [
+    {
+      "id": "image-root",
+      "kind": "asset",
+      "caption": "Dashboard screenshot with error banner",
+      "ocrText": "Stripe API key invalid. Please update your environment variables.",
+      "locator": { "bbox": [0.1, 0.2, 0.8, 0.35] },
+      "entities": [
+        { "text": "Stripe", "type": "product", "confidence": 0.99 }
+      ],
+      "tags": ["dashboard"],
+      "matchReasons": [
+        { "kind": "caption", "detail": "Screenshot contains dashboard UI", "confidence": 0.82 }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/media-extraction-pdf.json
+++ b/test/fixtures/media-extraction-pdf.json
@@ -1,0 +1,29 @@
+{
+  "kind": "pdf",
+  "sourceRef": "docs/pricing-overview.pdf",
+  "title": "Pricing overview PDF",
+  "summary": "Three pricing tiers with enterprise add-ons.",
+  "segments": [
+    {
+      "id": "page-1",
+      "kind": "page",
+      "locator": { "page": 1, "pageLabel": "1" },
+      "summary": "Cover page summarizing pricing tiers",
+      "ocrText": "Starter, Growth, Enterprise",
+      "tags": ["pricing", "tiers"],
+      "matchReasons": [
+        { "kind": "ocr", "detail": "Page lists pricing tiers", "confidence": 0.95 }
+      ]
+    },
+    {
+      "id": "page-2",
+      "kind": "page",
+      "locator": { "page": 2, "pageLabel": "2" },
+      "summary": "Enterprise add-ons and support levels",
+      "ocrText": "Dedicated support, SSO, audit logs",
+      "entities": [
+        { "text": "SSO", "type": "feature", "confidence": 0.88 }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/media-extraction-video.json
+++ b/test/fixtures/media-extraction-video.json
@@ -1,0 +1,29 @@
+{
+  "kind": "video",
+  "sourceRef": "recordings/login-demo.mp4",
+  "title": "Login demo recording",
+  "summary": "Walkthrough of a login failure and fix.",
+  "transcriptText": "At 12 seconds we hit the invalid API key error. At 26 seconds we confirm the env var fix.",
+  "segments": [
+    {
+      "id": "frame-12s",
+      "kind": "frame",
+      "locator": { "frame": 360, "timecode": "00:00:12.000", "startMs": 12000, "endMs": 12000 },
+      "caption": "Login form with red invalid API key error",
+      "ocrText": "Invalid API key",
+      "matchReasons": [
+        { "kind": "visual", "detail": "Error banner visible in frame", "confidence": 0.86 }
+      ]
+    },
+    {
+      "id": "transcript-26s",
+      "kind": "transcript_segment",
+      "locator": { "timecode": "00:00:26.000", "startMs": 26000, "endMs": 31000 },
+      "transcriptText": "We fixed the issue by rotating the Stripe API key and reloading the app.",
+      "entities": [
+        { "text": "Stripe API key", "type": "secret", "confidence": 0.91 }
+      ],
+      "tags": ["fix"]
+    }
+  ]
+}

--- a/test/media-cli-smoke.test.ts
+++ b/test/media-cli-smoke.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const repoRoot = new URL('..', import.meta.url).pathname;
+
+async function runCli(args: string[], env: Record<string, string>): Promise<{ stdout: string; stderr: string; code: number }> {
+  const proc = Bun.spawn([process.execPath, 'run', 'src/cli.ts', ...args], {
+    cwd: repoRoot,
+    env: { ...process.env, ...env, OPENAI_API_KEY: '', VOYAGE_API_KEY: '' },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, code };
+}
+
+describe('media evidence CLI smoke', () => {
+  test('init -> import-media -> ingest-media -> search keeps media evidence searchable without embeddings', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-media-cli-'));
+    const home = join(dir, 'home');
+    const env = { HOME: home, GBRAIN_HOME: home };
+    const mediaPath = join(dir, 'receipt.png');
+    const extractionPath = join(dir, 'receipt.extraction.json');
+    const contentPath = join(dir, 'custom.md');
+
+    try {
+      writeFileSync(mediaPath, 'fake-image-binary');
+      cpSync(join(repoRoot, 'test/fixtures/media-extraction-image.json'), extractionPath);
+      writeFileSync(contentPath, `---\ntype: media\ntitle: Custom Receipt Page\ncustom_flag: preserved\n---\n\nCurated custom receipt narrative.\n`);
+
+      let result = await runCli(['init', '--pglite'], env);
+      expect(result.code).toBe(0);
+
+      result = await runCli([
+        'import-media',
+        '--slug', 'media/evidence/receipt',
+        '--content-file', contentPath,
+        '--extraction', extractionPath,
+        '--media-file', mediaPath,
+        '--no-embed',
+      ], env);
+      expect(result.code).toBe(0);
+      const imported = JSON.parse(result.stdout);
+      expect(imported.status).toBe('imported');
+      expect(imported.slug).toBe('media/evidence/receipt');
+      expect(imported.raw_data_source).toBe('gbrain.media-evidence.v1');
+      expect(imported.no_embed).toBe(true);
+
+      result = await runCli([
+        'ingest-media',
+        mediaPath,
+        '--extract', extractionPath,
+        '--slug', 'media/evidence/receipt-ingested',
+        '--title', 'Custom Receipt Page',
+        '--no-embed',
+      ], env);
+      expect(result.code).toBe(0);
+      const ingested = JSON.parse(result.stdout);
+      expect(ingested.status).toBe('imported');
+      expect(ingested.slug).toBe('media/evidence/receipt-ingested');
+
+      result = await runCli(['search', 'Stripe'], env);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('media/evidence/receipt');
+      expect(result.stdout).toContain('Stripe login error screenshot');
+
+      result = await runCli(['search', 'Curated custom receipt narrative'], env);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('media/evidence/receipt');
+
+      result = await runCli(['stats'], env);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain('Pages:     2');
+      expect(result.stdout).toContain('Embedded:  0');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 60000);
+});

--- a/test/media-extraction.serial.test.ts
+++ b/test/media-extraction.serial.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { importNormalizedMediaEvidence } from '../src/core/import-media.ts';
+import { mediaExtractionToEvidence, normalizeMediaExtraction } from '../src/core/media-extraction.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runImportMedia } from '../src/commands/import-media.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+const FIXTURES = join(import.meta.dir, 'fixtures');
+
+describe('media extraction normalization', () => {
+  test('normalizes screenshot/pdf/video fixtures into evidence text', () => {
+    for (const name of ['media-extraction-image.json', 'media-extraction-pdf.json', 'media-extraction-video.json']) {
+      const raw = JSON.parse(readFileSync(join(FIXTURES, name), 'utf-8'));
+      const extraction = normalizeMediaExtraction(raw);
+      const evidence = mediaExtractionToEvidence(extraction);
+      expect(extraction.schemaVersion).toBe('gbrain.media-extraction.v1');
+      expect(evidence.schemaVersion).toBe('gbrain.media-evidence.v1');
+      expect(evidence.segments.length).toBeGreaterThan(0);
+      expect(evidence.text.length).toBeGreaterThan(10);
+    }
+  });
+
+  test('rejects payloads without segments or with unknown kinds', () => {
+    expect(() => normalizeMediaExtraction({ kind: 'image', segments: [] })).toThrow(/at least one segment/);
+    expect(() => normalizeMediaExtraction({ kind: 'spreadsheet', segments: [{ kind: 'asset' }] })).toThrow(/invalid kind/);
+    expect(() => normalizeMediaExtraction({ kind: 'image', segments: [{ kind: 'unknown' }] })).toThrow(/invalid kind/);
+  });
+});
+
+describe('media evidence import', () => {
+  const engine = new PGLiteEngine();
+
+  beforeAll(async () => {
+    await engine.connect({});
+    await engine.initSchema();
+  }, 30000);
+
+  beforeEach(async () => {
+    await resetPgliteState(engine);
+  }, 30000);
+
+  afterAll(async () => {
+    await engine.disconnect();
+  }, 30000);
+
+  test('stores normalized media evidence as searchable raw_data sidecar', async () => {
+    const content = `---\ntype: media\ntitle: Stripe login screenshot\n---\n\nCurated screenshot note.`;
+    const extraction = normalizeMediaExtraction(JSON.parse(readFileSync(join(FIXTURES, 'media-extraction-image.json'), 'utf-8')));
+    const evidence = mediaExtractionToEvidence(extraction);
+
+    const result = await importNormalizedMediaEvidence(engine, {
+      slug: 'media/stripe-login-screenshot',
+      content,
+      evidence,
+      noEmbed: true,
+    });
+    expect(result.status).toBe('imported');
+
+    const rows = await engine.getRawData('media/stripe-login-screenshot', 'gbrain.media-evidence.v1');
+    expect(rows.length).toBe(1);
+    const data = rows[0]?.data as any;
+    expect(data.schemaVersion).toBe('gbrain.media-evidence.v1');
+    expect(data.kind).toBe('image');
+    expect(data.text).toContain('Stripe API key invalid');
+    expect(data.segments[0].locator.bbox).toEqual([0.1, 0.2, 0.8, 0.35]);
+
+    const chunks = await engine.executeRaw<{ chunk_text: string }>(
+      `SELECT cc.chunk_text
+         FROM content_chunks cc
+         JOIN pages p ON p.id = cc.page_id
+        WHERE p.slug = $1`,
+      ['media/stripe-login-screenshot'],
+    );
+    expect(chunks.some(chunk => chunk.chunk_text.includes('Stripe API key invalid'))).toBe(true);
+  });
+
+  test('CLI import-media ingests extraction fixture', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-media-import-'));
+    const contentPath = join(dir, 'page.md');
+    const extractionPath = join(dir, 'evidence.json');
+    writeFileSync(contentPath, `---\ntype: media\ntitle: Demo video\n---\n\nDemo video evidence page.`);
+    writeFileSync(extractionPath, readFileSync(join(FIXTURES, 'media-extraction-video.json'), 'utf-8'));
+
+    try {
+      await runImportMedia(engine, [
+        '--slug', 'media/demo-video',
+        '--content-file', contentPath,
+        '--extraction', extractionPath,
+        '--no-embed',
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    const page = await engine.getPage('media/demo-video');
+    expect(page?.title).toBe('Demo video');
+    expect(page?.compiled_truth).toBe('Demo video evidence page.');
+    expect(page?.frontmatter.evidence_schema).toBe('gbrain.media-evidence.v1');
+
+    const raw = await engine.getRawData('media/demo-video', 'gbrain.media-evidence.v1');
+    expect(raw.length).toBe(1);
+    const data = raw[0]?.data as any;
+    expect(data.kind).toBe('video');
+    expect(data.segments.some((segment: any) => segment.kind === 'transcript_segment')).toBe(true);
+  });
+});

--- a/test/media-extraction.serial.test.ts
+++ b/test/media-extraction.serial.test.ts
@@ -107,4 +107,32 @@ describe('media evidence import', () => {
     expect(data.kind).toBe('video');
     expect(data.segments.some((segment: any) => segment.kind === 'transcript_segment')).toBe(true);
   });
+
+  test('CLI import-media without content file preserves existing page tags', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-media-import-tags-'));
+    const contentPath = join(dir, 'page.md');
+    const extractionPath = join(dir, 'evidence.json');
+    writeFileSync(contentPath, `---\ntype: media\ntitle: Tagged Screenshot\ntags: [receipt, stripe]\n---\n\nTagged evidence page.`);
+    writeFileSync(extractionPath, readFileSync(join(FIXTURES, 'media-extraction-image.json'), 'utf-8'));
+
+    try {
+      await runImportMedia(engine, [
+        '--slug', 'media/tagged-screenshot',
+        '--content-file', contentPath,
+        '--extraction', extractionPath,
+        '--no-embed',
+      ]);
+      expect(await engine.getTags('media/tagged-screenshot')).toEqual(['receipt', 'stripe']);
+
+      await runImportMedia(engine, [
+        '--slug', 'media/tagged-screenshot',
+        '--extraction', extractionPath,
+        '--no-embed',
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    expect(await engine.getTags('media/tagged-screenshot')).toEqual(['receipt', 'stripe']);
+  });
 });


### PR DESCRIPTION
Closes #645.
Refs #407.

## Plain-English Summary

This gives GBrain a neutral landing zone for media understanding.

Instead of making GBrain core choose one OCR service, image model, video model, or host runtime, this PR lets any extractor produce normalized evidence JSON. GBrain then stores that evidence as normal searchable pages/chunks.

```mermaid
flowchart LR
  A["image / PDF / audio / video"] --> B["external extractor or host adapter"]
  B --> C["gbrain.media-extraction.v1"]
  C --> D["gbrain import-media"]
  D --> E["gbrain.media-evidence.v1 page"]
  E --> F["searchable chunks"]
  E --> G["raw_data provenance"]
  F --> H["search/query with or without embeddings"]
```

## Why

GBrain has historically been excellent for markdown/text brains. Real users also have screenshots, PDFs, images, recordings, transcripts, and other media. This PR makes the first upstreamable step: store normalized media evidence in a provider-neutral way so it can be searched like the rest of the brain.

It complements #104 rather than replacing it. Multimodal providers can still own binary understanding; GBrain gets the stable import/storage/search surface.

## What Changed

- Adds `gbrain.media-extraction.v1` normalization.
- Adds `gbrain.media-evidence.v1` storage shape.
- Adds `gbrain import-media` and `gbrain ingest-media <file> --extract <json>` for extractor-agnostic media evidence import.
- Indexes caption/OCR/transcript evidence as searchable chunks, including `--no-embed` flows.
- Documents the boundary between core normalized evidence import and future binary/multimodal extraction adapters.
- Registers the new guide in `llms.txt` / `llms-full.txt` generation.

## Human Walkthrough

A photo can become a page that says what was seen, what text was detected, which people/objects/places were mentioned, and where that evidence came from. Search can then find the photo by the meaning of that evidence, even before full multimodal embeddings land.

## Non-goals

- No binary image/video understanding in this PR.
- No multimodal embeddings in this PR.
- No host-specific OpenClaw/Codex route in core.
- No API-key or hosted-provider assumptions.

## Review-Fix Pass

Latest review-fix commit: `f9f7aa1`.

Fixed Copilot review finding around preserving existing page tags when `import-media` reuses existing page content without `--content-file`.

## Validation

- `git diff --check`
- `bun run verify`
- `bun test test/media-extraction.serial.test.ts test/media-cli-smoke.test.ts`
- `bun test test/build-llms.test.ts`
- focused review-fix rerun: `bun test test/media-extraction.serial.test.ts test/media-cli-smoke.test.ts` -> `6 pass, 0 fail`
- prior full isolated run: `env -u GBRAIN_HOME HOME="$(mktemp -d)" PATH="/Users/lume/.bun/bin:$PATH" bun run test` -> `3834 pass, 0 fail`
