### PR TITLE
fix(chunker): CJK-aware recursive prose chunker (closes #648)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,9 +1,15 @@
-import { existsSync, readFileSync, writeFileSync, statSync, readdirSync } from 'fs';
-import { execFileSync } from 'child_process';
-import { join, relative } from 'path';
-import type { BrainEngine } from '../core/engine.ts';
-import { importFile } from '../core/import-file.ts';
-import { createInterface } from 'readline';
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  statSync,
+  readdirSync,
+} from "fs";
+import { execFileSync } from "child_process";
+import { join, relative } from "path";
+import type { BrainEngine } from "../core/engine.ts";
+import { importFile } from "../core/import-file.ts";
+import { createInterface } from "readline";
 import {
   buildSyncManifest,
   isSyncable,
@@ -12,25 +18,37 @@ import {
   unacknowledgedSyncFailures,
   acknowledgeSyncFailures,
   formatCodeBreakdown,
-} from '../core/sync.ts';
-import { estimateTokens, CHUNKER_VERSION } from '../core/chunkers/code.ts';
-import { EMBEDDING_MODEL, estimateEmbeddingCostUsd } from '../core/embedding.ts';
-import { errorFor, serializeError } from '../core/errors.ts';
-import type { SyncManifest } from '../core/sync.ts';
-import { createProgress } from '../core/progress.ts';
-import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
-import { loadConfig } from '../core/config.ts';
+} from "../core/sync.ts";
+import { estimateTokens, CHUNKER_VERSION } from "../core/chunkers/code.ts";
+import { PROSE_CHUNKER_VERSION } from "../core/chunkers/recursive.ts";
+import {
+  EMBEDDING_MODEL,
+  estimateEmbeddingCostUsd,
+} from "../core/embedding.ts";
+import { errorFor, serializeError } from "../core/errors.ts";
+import type { SyncManifest } from "../core/sync.ts";
+import { createProgress } from "../core/progress.ts";
+import {
+  getCliOptions,
+  cliOptsToProgressOptions,
+} from "../core/cli-options.ts";
+import { loadConfig } from "../core/config.ts";
 import {
   autoConcurrency,
   shouldRunParallel,
   parseWorkers,
-} from '../core/sync-concurrency.ts';
-import { tryAcquireDbLock, SYNC_LOCK_ID } from '../core/db-lock.ts';
-import { loadStorageConfig } from '../core/storage-config.ts';
-import { getDefaultSourcePath } from '../core/source-resolver.ts';
+} from "../core/sync-concurrency.ts";
+import { tryAcquireDbLock, SYNC_LOCK_ID } from "../core/db-lock.ts";
+import { loadStorageConfig } from "../core/storage-config.ts";
+import { getDefaultSourcePath } from "../core/source-resolver.ts";
 
 export interface SyncResult {
-  status: 'up_to_date' | 'synced' | 'first_sync' | 'dry_run' | 'blocked_by_failures';
+  status:
+    | "up_to_date"
+    | "synced"
+    | "first_sync"
+    | "dry_run"
+    | "blocked_by_failures";
   fromCommit: string | null;
   toCommit: string;
   added: number;
@@ -55,7 +73,12 @@ export interface SyncResult {
  * intentional: a lower estimate that undersells the real bill would be
  * worse than one that oversells.
  */
-function estimateSyncAllCost(sources: Array<{ local_path: string | null; config: Record<string, unknown> }>): {
+function estimateSyncAllCost(
+  sources: Array<{
+    local_path: string | null;
+    config: Record<string, unknown>;
+  }>,
+): {
   totalTokens: number;
   totalFiles: number;
   activeSources: number;
@@ -68,16 +91,23 @@ function estimateSyncAllCost(sources: Array<{ local_path: string | null; config:
 
   for (const src of sources) {
     if (!src.local_path) continue;
-    const cfg = (src.config || {}) as { syncEnabled?: boolean; strategy?: 'markdown' | 'code' | 'auto' };
+    const cfg = (src.config || {}) as {
+      syncEnabled?: boolean;
+      strategy?: "markdown" | "code" | "auto";
+    };
     if (cfg.syncEnabled === false) continue;
     activeSources++;
     let sourceTokens = 0;
     let sourceFiles = 0;
     try {
-      walkSyncableFiles(src.local_path, (filePath: string, content: string) => {
-        sourceTokens += estimateTokens(content);
-        sourceFiles++;
-      }, cfg.strategy ?? 'markdown');
+      walkSyncableFiles(
+        src.local_path,
+        (filePath: string, content: string) => {
+          sourceTokens += estimateTokens(content);
+          sourceFiles++;
+        },
+        cfg.strategy ?? "markdown",
+      );
     } catch {
       // Best-effort: a source whose local_path is gone or unreadable just
       // contributes 0. The sync itself would have failed anyway; no point
@@ -85,7 +115,11 @@ function estimateSyncAllCost(sources: Array<{ local_path: string | null; config:
     }
     totalTokens += sourceTokens;
     totalFiles += sourceFiles;
-    perSource.push({ path: src.local_path, tokens: sourceTokens, files: sourceFiles });
+    perSource.push({
+      path: src.local_path,
+      tokens: sourceTokens,
+      files: sourceFiles,
+    });
   }
 
   return { totalTokens, totalFiles, activeSources, perSource };
@@ -99,21 +133,25 @@ function estimateSyncAllCost(sources: Array<{ local_path: string | null; config:
 function walkSyncableFiles(
   repoRoot: string,
   cb: (path: string, content: string) => void,
-  strategy: 'markdown' | 'code' | 'auto',
+  strategy: "markdown" | "code" | "auto",
 ): void {
   const stack: string[] = [repoRoot];
   while (stack.length > 0) {
     const dir = stack.pop()!;
-    let entries: import('fs').Dirent[];
+    let entries: import("fs").Dirent[];
     try {
-      entries = readdirSync(dir, { withFileTypes: true }) as unknown as import('fs').Dirent[];
+      entries = readdirSync(dir, {
+        withFileTypes: true,
+      }) as unknown as import("fs").Dirent[];
     } catch {
       continue;
     }
     for (const entry of entries) {
-      const name = typeof entry.name === 'string' ? entry.name : String(entry.name);
+      const name =
+        typeof entry.name === "string" ? entry.name : String(entry.name);
       // Skip hidden dirs, .git, node_modules (same rules isSyncable applies).
-      if (name.startsWith('.') || name === 'node_modules' || name === 'ops') continue;
+      if (name.startsWith(".") || name === "node_modules" || name === "ops")
+        continue;
       const fullPath = `${dir}/${name}`;
       if (entry.isDirectory()) {
         stack.push(fullPath);
@@ -123,7 +161,7 @@ function walkSyncableFiles(
         try {
           const stat = statSync(fullPath);
           if (stat.size > 5_000_000) continue; // skip large binaries
-          const content = readFileSync(fullPath, 'utf-8');
+          const content = readFileSync(fullPath, "utf-8");
           cb(fullPath, content);
         } catch {
           // Ignore files we can't read; consistent with sync's own tolerance.
@@ -136,12 +174,18 @@ function walkSyncableFiles(
 /** Interactive [y/N] prompt. Resolves false on non-y answers or EOF. */
 async function promptYesNo(question: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
     rl.question(question, (answer) => {
       rl.close();
-      resolve(answer.trim().toLowerCase() === 'y' || answer.trim().toLowerCase() === 'yes');
+      resolve(
+        answer.trim().toLowerCase() === "y" ||
+          answer.trim().toLowerCase() === "yes",
+      );
     });
-    rl.on('close', () => resolve(false));
+    rl.on("close", () => resolve(false));
   });
 }
 
@@ -165,7 +209,7 @@ export interface SyncOpts {
    */
   sourceId?: string;
   /** Multi-repo: sync strategy override (markdown, code, auto). */
-  strategy?: 'markdown' | 'code' | 'auto';
+  strategy?: "markdown" | "code" | "auto";
   /**
    * Number of parallel workers for the import phase. When > 1, each worker
    * gets its own small Postgres connection pool and files are dispatched via
@@ -190,8 +234,8 @@ export interface SyncOpts {
 }
 
 function git(repoPath: string, ...args: string[]): string {
-  return execFileSync('git', ['-C', repoPath, ...args], {
-    encoding: 'utf-8',
+  return execFileSync("git", ["-C", repoPath, ...args], {
+    encoding: "utf-8",
     timeout: 30000,
   }).trim();
 }
@@ -204,10 +248,10 @@ function git(repoPath: string, ...args: string[]): string {
 async function readSyncAnchor(
   engine: BrainEngine,
   sourceId: string | undefined,
-  which: 'repo_path' | 'last_commit',
+  which: "repo_path" | "last_commit",
 ): Promise<string | null> {
   if (sourceId) {
-    const col = which === 'repo_path' ? 'local_path' : 'last_commit';
+    const col = which === "repo_path" ? "local_path" : "last_commit";
     const rows = await engine.executeRaw<Record<string, string | null>>(
       `SELECT ${col} AS value FROM sources WHERE id = $1`,
       [sourceId],
@@ -220,22 +264,22 @@ async function readSyncAnchor(
 async function writeSyncAnchor(
   engine: BrainEngine,
   sourceId: string | undefined,
-  which: 'repo_path' | 'last_commit',
+  which: "repo_path" | "last_commit",
   value: string,
 ): Promise<void> {
   if (sourceId) {
-    const col = which === 'repo_path' ? 'local_path' : 'last_commit';
+    const col = which === "repo_path" ? "local_path" : "last_commit";
     // last_sync_at bookmarked on every last_commit advance.
-    if (which === 'last_commit') {
+    if (which === "last_commit") {
       await engine.executeRaw(
         `UPDATE sources SET last_commit = $1, last_sync_at = now() WHERE id = $2`,
         [value, sourceId],
       );
     } else {
-      await engine.executeRaw(
-        `UPDATE sources SET ${col} = $1 WHERE id = $2`,
-        [value, sourceId],
-      );
+      await engine.executeRaw(`UPDATE sources SET ${col} = $1 WHERE id = $2`, [
+        value,
+        sourceId,
+      ]);
     }
     return;
   }
@@ -254,7 +298,21 @@ async function writeSyncAnchor(
  * TEXT column from the v27 migration. No global fallback: non-source syncs
  * (pre-v0.17 brains with no sources table) never had CHUNKER_VERSION
  * version-gating, so they keep the v0.19.0 behavior.
+ *
+ * v0.27 (CJK chunker fix) — the gate now covers BOTH chunkers. Previously it
+ * stored just `String(CHUNKER_VERSION)` (e.g. "4"), so bumping the prose
+ * chunker (PROSE_CHUNKER_VERSION) had no effect on the up_to_date short
+ * circuit — markdown sources with unchanged HEAD never re-walked, and the
+ * `prose_chunker_version` field folded into `import-file.ts`'s content_hash
+ * was unreachable behind the early-return. Composite format `code:N|prose:M`
+ * picks up either-side bumps. Old "4" values mismatch the new
+ * `code:4|prose:2`, which is the desired migration behavior — every existing
+ * source re-walks once on first sync after upgrade and lands the new format.
  */
+function currentChunkerVersionTag(): string {
+  return `code:${CHUNKER_VERSION}|prose:${PROSE_CHUNKER_VERSION}`;
+}
+
 async function readChunkerVersion(
   engine: BrainEngine,
   sourceId: string | undefined,
@@ -279,7 +337,10 @@ async function writeChunkerVersion(
   );
 }
 
-export async function performSync(engine: BrainEngine, opts: SyncOpts): Promise<SyncResult> {
+export async function performSync(
+  engine: BrainEngine,
+  opts: SyncOpts,
+): Promise<SyncResult> {
   // CODEX-2 (v0.22.13): cross-process writer lock for performSync. Two
   // concurrent syncs can otherwise read the same last_commit anchor, both
   // write last_commit unconditionally, and the last writer wins — including
@@ -298,7 +359,7 @@ export async function performSync(engine: BrainEngine, opts: SyncOpts): Promise<
     if (!lockHandle) {
       throw new Error(
         `Another sync is in progress (lock ${SYNC_LOCK_ID} held). ` +
-        `Wait for it to finish, or run 'gbrain doctor' if it has been more than 30 minutes.`,
+          `Wait for it to finish, or run 'gbrain doctor' if it has been more than 30 minutes.`,
       );
     }
   }
@@ -307,14 +368,22 @@ export async function performSync(engine: BrainEngine, opts: SyncOpts): Promise<
     return await performSyncInner(engine, opts);
   } finally {
     if (lockHandle) {
-      try { await lockHandle.release(); } catch { /* best-effort release */ }
+      try {
+        await lockHandle.release();
+      } catch {
+        /* best-effort release */
+      }
     }
   }
 }
 
-async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<SyncResult> {
+async function performSyncInner(
+  engine: BrainEngine,
+  opts: SyncOpts,
+): Promise<SyncResult> {
   // Resolve repo path
-  const repoPath = opts.repoPath || await readSyncAnchor(engine, opts.sourceId, 'repo_path');
+  const repoPath =
+    opts.repoPath || (await readSyncAnchor(engine, opts.sourceId, "repo_path"));
   if (!repoPath) {
     const hint = opts.sourceId
       ? `Source "${opts.sourceId}" has no local_path. Run: gbrain sources add ${opts.sourceId} --path <path>`
@@ -323,18 +392,22 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   }
 
   // Validate git repo
-  if (!existsSync(join(repoPath, '.git'))) {
-    throw new Error(`Not a git repository: ${repoPath}. GBrain sync requires a git-initialized repo.`);
+  if (!existsSync(join(repoPath, ".git"))) {
+    throw new Error(
+      `Not a git repository: ${repoPath}. GBrain sync requires a git-initialized repo.`,
+    );
   }
 
   // Git pull (unless --no-pull)
   if (!opts.noPull) {
     try {
-      git(repoPath, 'pull', '--ff-only');
+      git(repoPath, "pull", "--ff-only");
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      if (msg.includes('non-fast-forward') || msg.includes('diverged')) {
-        console.error(`Warning: git pull failed (remote diverged). Syncing from local state.`);
+      if (msg.includes("non-fast-forward") || msg.includes("diverged")) {
+        console.error(
+          `Warning: git pull failed (remote diverged). Syncing from local state.`,
+        );
       } else {
         console.error(`Warning: git pull failed: ${msg.slice(0, 100)}`);
       }
@@ -344,28 +417,36 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // Get current HEAD
   let headCommit: string;
   try {
-    headCommit = git(repoPath, 'rev-parse', 'HEAD');
+    headCommit = git(repoPath, "rev-parse", "HEAD");
   } catch {
-    throw new Error(`No commits in repo ${repoPath}. Make at least one commit before syncing.`);
+    throw new Error(
+      `No commits in repo ${repoPath}. Make at least one commit before syncing.`,
+    );
   }
 
   // Read sync state (source-scoped when sourceId is set, global otherwise)
-  const lastCommit = opts.full ? null : await readSyncAnchor(engine, opts.sourceId, 'last_commit');
+  const lastCommit = opts.full
+    ? null
+    : await readSyncAnchor(engine, opts.sourceId, "last_commit");
 
   // Ancestry validation: if lastCommit exists, verify it's still in history
   if (lastCommit) {
     try {
-      git(repoPath, 'cat-file', '-t', lastCommit);
+      git(repoPath, "cat-file", "-t", lastCommit);
     } catch {
-      console.error(`Sync anchor commit ${lastCommit.slice(0, 8)} missing (force push?). Running full reimport.`);
+      console.error(
+        `Sync anchor commit ${lastCommit.slice(0, 8)} missing (force push?). Running full reimport.`,
+      );
       return performFullSync(engine, repoPath, headCommit, opts);
     }
 
     // Verify ancestry
     try {
-      git(repoPath, 'merge-base', '--is-ancestor', lastCommit, headCommit);
+      git(repoPath, "merge-base", "--is-ancestor", lastCommit, headCommit);
     } catch {
-      console.error(`Sync anchor ${lastCommit.slice(0, 8)} is not an ancestor of HEAD. Running full reimport.`);
+      console.error(
+        `Sync anchor ${lastCommit.slice(0, 8)} is not an ancestor of HEAD. Running full reimport.`,
+      );
       return performFullSync(engine, repoPath, headCommit, opts);
     }
   }
@@ -383,16 +464,20 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // population, etc.). Without this, upgraded brains silently stay on
   // the old chunks — the whole reason we bumped the version.
   const storedVersion = await readChunkerVersion(engine, opts.sourceId);
-  const currentVersion = String(CHUNKER_VERSION);
-  const versionMismatch = storedVersion !== null && storedVersion !== currentVersion;
+  const currentVersion = currentChunkerVersionTag();
+  const versionMismatch =
+    storedVersion !== null && storedVersion !== currentVersion;
   const versionNeverSet = storedVersion === null && opts.sourceId !== undefined;
 
   if (lastCommit === headCommit && !versionMismatch && !versionNeverSet) {
     return {
-      status: 'up_to_date',
+      status: "up_to_date",
       fromCommit: lastCommit,
       toCommit: headCommit,
-      added: 0, modified: 0, deleted: 0, renamed: 0,
+      added: 0,
+      modified: 0,
+      deleted: 0,
+      renamed: 0,
       chunksCreated: 0,
       embedded: 0,
       pagesAffected: [],
@@ -401,8 +486,8 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
 
   if ((versionMismatch || versionNeverSet) && lastCommit === headCommit) {
     console.log(
-      `[sync] chunker_version gate: stored=${storedVersion ?? 'unset'}, current=${currentVersion}. ` +
-      `Forcing full re-chunk pass (git HEAD unchanged but pipeline version advanced).`,
+      `[sync] chunker_version gate: stored=${storedVersion ?? "unset"}, current=${currentVersion}. ` +
+        `Forcing full re-chunk pass (git HEAD unchanged but pipeline version advanced).`,
     );
     const result = await performFullSync(engine, repoPath, headCommit, opts);
     await writeChunkerVersion(engine, opts.sourceId, currentVersion);
@@ -410,16 +495,22 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   }
 
   // Diff using git diff (net result, not per-commit)
-  const diffOutput = git(repoPath, 'diff', '--name-status', '-M', `${lastCommit}..${headCommit}`);
+  const diffOutput = git(
+    repoPath,
+    "diff",
+    "--name-status",
+    "-M",
+    `${lastCommit}..${headCommit}`,
+  );
   const manifest = buildSyncManifest(diffOutput);
 
   // Filter to syncable files (strategy-aware)
   const syncOpts = opts.strategy ? { strategy: opts.strategy } : undefined;
   const filtered: SyncManifest = {
-    added: manifest.added.filter(p => isSyncable(p, syncOpts)),
-    modified: manifest.modified.filter(p => isSyncable(p, syncOpts)),
-    deleted: manifest.deleted.filter(p => isSyncable(p, syncOpts)),
-    renamed: manifest.renamed.filter(r => isSyncable(r.to, syncOpts)),
+    added: manifest.added.filter((p) => isSyncable(p, syncOpts)),
+    modified: manifest.modified.filter((p) => isSyncable(p, syncOpts)),
+    deleted: manifest.deleted.filter((p) => isSyncable(p, syncOpts)),
+    renamed: manifest.renamed.filter((r) => isSyncable(r.to, syncOpts)),
   };
 
   // Delete pages that became un-syncable (modified but filtered out).
@@ -428,7 +519,9 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // became un-syncable (e.g., moved under `.gitignore` or filtered by
   // strategy=markdown) deletes the actual code-slug page, not a ghost
   // markdown-slug that never existed.
-  const unsyncableModified = manifest.modified.filter(p => !isSyncable(p, syncOpts));
+  const unsyncableModified = manifest.modified.filter(
+    (p) => !isSyncable(p, syncOpts),
+  );
   for (const path of unsyncableModified) {
     const slug = resolveSlugForPath(path);
     try {
@@ -437,22 +530,35 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
         await engine.deletePage(slug);
         console.log(`  Deleted un-syncable page: ${slug}`);
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
-  const totalChanges = filtered.added.length + filtered.modified.length +
-    filtered.deleted.length + filtered.renamed.length;
+  const totalChanges =
+    filtered.added.length +
+    filtered.modified.length +
+    filtered.deleted.length +
+    filtered.renamed.length;
 
   // Dry run
   if (opts.dryRun) {
-    console.log(`Sync dry run: ${lastCommit.slice(0, 8)}..${headCommit.slice(0, 8)}`);
-    if (filtered.added.length) console.log(`  Added: ${filtered.added.join(', ')}`);
-    if (filtered.modified.length) console.log(`  Modified: ${filtered.modified.join(', ')}`);
-    if (filtered.deleted.length) console.log(`  Deleted: ${filtered.deleted.join(', ')}`);
-    if (filtered.renamed.length) console.log(`  Renamed: ${filtered.renamed.map(r => `${r.from} -> ${r.to}`).join(', ')}`);
+    console.log(
+      `Sync dry run: ${lastCommit.slice(0, 8)}..${headCommit.slice(0, 8)}`,
+    );
+    if (filtered.added.length)
+      console.log(`  Added: ${filtered.added.join(", ")}`);
+    if (filtered.modified.length)
+      console.log(`  Modified: ${filtered.modified.join(", ")}`);
+    if (filtered.deleted.length)
+      console.log(`  Deleted: ${filtered.deleted.join(", ")}`);
+    if (filtered.renamed.length)
+      console.log(
+        `  Renamed: ${filtered.renamed.map((r) => `${r.from} -> ${r.to}`).join(", ")}`,
+      );
     if (totalChanges === 0) console.log(`  No syncable changes.`);
     return {
-      status: 'dry_run',
+      status: "dry_run",
       fromCommit: lastCommit,
       toCommit: headCommit,
       added: filtered.added.length,
@@ -467,14 +573,21 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
 
   if (totalChanges === 0) {
     // Update sync state even with no syncable changes (git advanced)
-    await writeSyncAnchor(engine, opts.sourceId, 'last_commit', headCommit);
-    await engine.setConfig('sync.last_run', new Date().toISOString());
-    await writeChunkerVersion(engine, opts.sourceId, String(CHUNKER_VERSION));
+    await writeSyncAnchor(engine, opts.sourceId, "last_commit", headCommit);
+    await engine.setConfig("sync.last_run", new Date().toISOString());
+    await writeChunkerVersion(
+      engine,
+      opts.sourceId,
+      currentChunkerVersionTag(),
+    );
     return {
-      status: 'up_to_date',
+      status: "up_to_date",
       fromCommit: lastCommit,
       toCommit: headCommit,
-      added: 0, modified: 0, deleted: 0, renamed: 0,
+      added: 0,
+      modified: 0,
+      deleted: 0,
+      renamed: 0,
       chunksCreated: 0,
       embedded: 0,
       pagesAffected: [],
@@ -483,7 +596,9 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
 
   const noEmbed = opts.noEmbed || totalChanges > 100;
   if (totalChanges > 100) {
-    console.log(`Large sync (${totalChanges} files). Importing text, deferring embeddings.`);
+    console.log(
+      `Large sync (${totalChanges} files). Importing text, deferring embeddings.`,
+    );
   }
 
   const pagesAffected: string[] = [];
@@ -497,7 +612,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // Process deletes first (prevents slug conflicts). SP-5: resolveSlugForPath
   // dispatches to the right slug shape so code file deletes hit the real page.
   if (filtered.deleted.length > 0) {
-    progress.start('sync.deletes', filtered.deleted.length);
+    progress.start("sync.deletes", filtered.deleted.length);
     for (const path of filtered.deleted) {
       const slug = resolveSlugForPath(path);
       await engine.deletePage(slug);
@@ -512,7 +627,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // rename (code→code), .md → .md (markdown→markdown), or cross-kind rename
   // all resolve to the right slug shape for each side.
   if (filtered.renamed.length > 0) {
-    progress.start('sync.renames', filtered.renamed.length);
+    progress.start("sync.renames", filtered.renamed.length);
     for (const { from, to } of filtered.renamed) {
       const oldSlug = resolveSlugForPath(from);
       const newSlug = resolveSlugForPath(to);
@@ -525,7 +640,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       const filePath = join(repoPath, to);
       if (existsSync(filePath)) {
         const result = await importFile(engine, filePath, to, { noEmbed });
-        if (result.status === 'imported') chunksCreated += result.chunks;
+        if (result.status === "imported") chunksCreated += result.chunks;
       }
       pagesAffected.push(newSlug);
       progress.tick(1, newSlug);
@@ -554,16 +669,27 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // engine.kind === 'pglite' → forced 1; explicit opts.concurrency wins;
   // auto path returns DEFAULT_PARALLEL_WORKERS only when fileCount > 100.
   const explicitConcurrency = opts.concurrency !== undefined;
-  const effectiveConcurrency = autoConcurrency(engine, addsAndMods.length, opts.concurrency);
-  const runParallel = shouldRunParallel(effectiveConcurrency, addsAndMods.length, explicitConcurrency);
+  const effectiveConcurrency = autoConcurrency(
+    engine,
+    addsAndMods.length,
+    opts.concurrency,
+  );
+  const runParallel = shouldRunParallel(
+    effectiveConcurrency,
+    addsAndMods.length,
+    explicitConcurrency,
+  );
 
   if (addsAndMods.length > 0) {
-    progress.start('sync.imports', addsAndMods.length);
+    progress.start("sync.imports", addsAndMods.length);
 
     // Core import logic shared by serial and parallel paths.
     // repoPath is validated non-null at the top of performSyncInner; narrow for TS.
     const syncRepoPath = repoPath!;
-    async function importOnePath(eng: BrainEngine, path: string): Promise<void> {
+    async function importOnePath(
+      eng: BrainEngine,
+      path: string,
+    ): Promise<void> {
       const filePath = join(syncRepoPath, path);
       if (!existsSync(filePath)) {
         // CODEX-3 (v0.22.13): a file the diff said exists at headCommit but
@@ -573,17 +699,18 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
         // the silent-skip-then-advance pathology was the bug.
         failedFiles.push({
           path,
-          error: 'file vanished mid-sync (working tree drifted from headCommit)',
+          error:
+            "file vanished mid-sync (working tree drifted from headCommit)",
         });
         progress.tick(1, `skip:${path}`);
         return;
       }
       try {
         const result = await importFile(eng, filePath, path, { noEmbed });
-        if (result.status === 'imported') {
+        if (result.status === "imported") {
           chunksCreated += result.chunks;
           pagesAffected.push(result.slug);
-        } else if (result.status === 'skipped' && (result as any).error) {
+        } else if (result.status === "skipped" && (result as any).error) {
           failedFiles.push({ path, error: String((result as any).error) });
         }
       } catch (e: unknown) {
@@ -600,19 +727,21 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       // back to serial when database_url is unset, so we never crash on a null
       // assertion if config is missing.
       const config = loadConfig();
-      if (engine.kind === 'pglite' || !config?.database_url) {
+      if (engine.kind === "pglite" || !config?.database_url) {
         for (const path of addsAndMods) {
           await importOnePath(engine, path);
         }
       } else {
-        const { PostgresEngine } = await import('../core/postgres-engine.ts');
-        const { resolvePoolSize } = await import('../core/db.ts');
+        const { PostgresEngine } = await import("../core/postgres-engine.ts");
+        const { resolvePoolSize } = await import("../core/db.ts");
         const workerPoolSize = Math.min(2, resolvePoolSize(2));
         const workerCount = Math.min(effectiveConcurrency, addsAndMods.length);
         const databaseUrl = config.database_url;
 
         // Q4 (v0.22.13): banner on stderr so stdout stays clean for --json.
-        console.error(`  Parallel sync: ${workerCount} workers for ${addsAndMods.length} files`);
+        console.error(
+          `  Parallel sync: ${workerCount} workers for ${addsAndMods.length} files`,
+        );
 
         const workerEngines: InstanceType<typeof PostgresEngine>[] = [];
         try {
@@ -622,7 +751,10 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
           // already-connected engines on any one failure.
           for (let i = 0; i < workerCount; i++) {
             const eng = new PostgresEngine();
-            await eng.connect({ database_url: databaseUrl, poolSize: workerPoolSize });
+            await eng.connect({
+              database_url: databaseUrl,
+              poolSize: workerPoolSize,
+            });
             workerEngines.push(eng);
           }
 
@@ -645,9 +777,13 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
           // disconnect must not strand the others.
           await Promise.all(
             workerEngines.map((e) =>
-              e.disconnect().catch((err: unknown) =>
-                console.error(`  worker disconnect failed: ${err instanceof Error ? err.message : String(err)}`),
-              ),
+              e
+                .disconnect()
+                .catch((err: unknown) =>
+                  console.error(
+                    `  worker disconnect failed: ${err instanceof Error ? err.message : String(err)}`,
+                  ),
+                ),
             ),
           );
         }
@@ -670,17 +806,17 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // prevents *this* gbrain process from stepping on itself; this gate
   // catches drift caused by external `git` commands the lock cannot see.
   try {
-    const currentHead = git(repoPath, 'rev-parse', 'HEAD');
+    const currentHead = git(repoPath, "rev-parse", "HEAD");
     if (currentHead !== headCommit) {
       failedFiles.push({
-        path: '<head>',
+        path: "<head>",
         error: `git HEAD drifted during sync: captured ${headCommit.slice(0, 8)}, now ${currentHead.slice(0, 8)}`,
       });
     }
   } catch (e) {
     // rev-parse failure is itself a drift signal (worktree disappeared).
     failedFiles.push({
-      path: '<head>',
+      path: "<head>",
       error: `git HEAD verification failed: ${e instanceof Error ? e.message : String(e)}`,
     });
   }
@@ -700,15 +836,15 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     if (!opts.skipFailed) {
       console.error(
         `\nSync blocked: ${failedFiles.length} file(s) failed to parse:\n` +
-        `${codeBreakdown}\n\n` +
-        `Fix the YAML frontmatter in the files above and re-run, or use ` +
-        `'gbrain sync --skip-failed' to acknowledge and move on.`,
+          `${codeBreakdown}\n\n` +
+          `Fix the YAML frontmatter in the files above and re-run, or use ` +
+          `'gbrain sync --skip-failed' to acknowledge and move on.`,
       );
       // Update last_run + repo_path (progress on infra) but NOT last_commit.
-      await engine.setConfig('sync.last_run', new Date().toISOString());
-      await writeSyncAnchor(engine, opts.sourceId, 'repo_path', repoPath);
+      await engine.setConfig("sync.last_run", new Date().toISOString());
+      await writeSyncAnchor(engine, opts.sourceId, "repo_path", repoPath);
       return {
-        status: 'blocked_by_failures',
+        status: "blocked_by_failures",
         fromCommit: lastCommit,
         toCommit: headCommit,
         added: filtered.added.length,
@@ -726,24 +862,24 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     if (acked.count > 0) {
       console.error(
         `  Acknowledged ${acked.count} failure(s) and advancing past them:\n` +
-        `${formatCodeBreakdown(acked.summary)}`,
+          `${formatCodeBreakdown(acked.summary)}`,
       );
     }
   }
 
   // Update sync state AFTER all changes succeed (source-scoped when
   // opts.sourceId is set, global config otherwise).
-  await writeSyncAnchor(engine, opts.sourceId, 'last_commit', headCommit);
-  await engine.setConfig('sync.last_run', new Date().toISOString());
-  await writeSyncAnchor(engine, opts.sourceId, 'repo_path', repoPath);
+  await writeSyncAnchor(engine, opts.sourceId, "last_commit", headCommit);
+  await engine.setConfig("sync.last_run", new Date().toISOString());
+  await writeSyncAnchor(engine, opts.sourceId, "repo_path", repoPath);
   // v0.20.0 Cathedral II Layer 12: persist the chunker version we just
   // finished with so the next sync's up_to_date gate respects it. Only
   // source-scoped syncs track this (see readChunkerVersion for rationale).
-  await writeChunkerVersion(engine, opts.sourceId, String(CHUNKER_VERSION));
+  await writeChunkerVersion(engine, opts.sourceId, currentChunkerVersionTag());
 
   // Log ingest
   await engine.logIngest({
-    source_type: 'git_sync',
+    source_type: "git_sync",
     source_ref: `${repoPath} @ ${headCommit.slice(0, 8)}`,
     pages_updated: pagesAffected,
     summary: `Sync: +${filtered.added.length} ~${filtered.modified.length} -${filtered.deleted.length} R${filtered.renamed.length}, ${chunksCreated} chunks, ${elapsed}ms`,
@@ -752,32 +888,49 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // Auto-extract links + timeline (always, extraction is cheap CPU)
   if (!opts.noExtract && pagesAffected.length > 0) {
     try {
-      const { extractLinksForSlugs, extractTimelineForSlugs } = await import('./extract.ts');
-      const linksCreated = await extractLinksForSlugs(engine, repoPath, pagesAffected);
-      const timelineCreated = await extractTimelineForSlugs(engine, repoPath, pagesAffected);
+      const { extractLinksForSlugs, extractTimelineForSlugs } =
+        await import("./extract.ts");
+      const linksCreated = await extractLinksForSlugs(
+        engine,
+        repoPath,
+        pagesAffected,
+      );
+      const timelineCreated = await extractTimelineForSlugs(
+        engine,
+        repoPath,
+        pagesAffected,
+      );
       if (linksCreated > 0 || timelineCreated > 0) {
-        console.log(`  Extracted: ${linksCreated} links, ${timelineCreated} timeline entries`);
+        console.log(
+          `  Extracted: ${linksCreated} links, ${timelineCreated} timeline entries`,
+        );
       }
-    } catch { /* extraction is best-effort */ }
+    } catch {
+      /* extraction is best-effort */
+    }
   }
 
   // Auto-embed (skip for large syncs — embedding calls OpenAI)
   let embedded = 0;
   if (!noEmbed && pagesAffected.length > 0 && pagesAffected.length <= 100) {
     try {
-      const { runEmbed } = await import('./embed.ts');
-      await runEmbed(engine, ['--slugs', ...pagesAffected]);
+      const { runEmbed } = await import("./embed.ts");
+      await runEmbed(engine, ["--slugs", ...pagesAffected]);
       // Before commit 2 lands: runEmbed is void. Best estimate is pagesAffected,
       // since runEmbed re-embeds every requested slug. Commit 2 sharpens this
       // with EmbedResult.embedded.
       embedded = pagesAffected.length;
-    } catch { /* embedding is best-effort */ }
+    } catch {
+      /* embedding is best-effort */
+    }
   } else if (noEmbed || totalChanges > 100) {
-    console.log(`Text imported. Run 'gbrain embed --stale' to generate embeddings.`);
+    console.log(
+      `Text imported. Run 'gbrain embed --stale' to generate embeddings.`,
+    );
   }
 
   return {
-    status: 'synced',
+    status: "synced",
     fromCommit: lastCommit,
     toCommit: headCommit,
     added: filtered.added.length,
@@ -800,17 +953,17 @@ async function performFullSync(
   // Fixes the silent-write-on-dry-run bug where performFullSync called
   // runImport unconditionally regardless of opts.dryRun.
   if (opts.dryRun) {
-    const { collectMarkdownFiles } = await import('./import.ts');
+    const { collectMarkdownFiles } = await import("./import.ts");
     const allFiles = collectMarkdownFiles(repoPath);
     const syncableRelPaths = allFiles
-      .map(abs => relative(repoPath, abs))
-      .filter(rel => isSyncable(rel));
+      .map((abs) => relative(repoPath, abs))
+      .filter((rel) => isSyncable(rel));
     console.log(
       `Full-sync dry run: ${syncableRelPaths.length} file(s) would be imported ` +
-      `from ${repoPath} @ ${headCommit.slice(0, 8)}.`,
+        `from ${repoPath} @ ${headCommit.slice(0, 8)}.`,
     );
     return {
-      status: 'dry_run',
+      status: "dry_run",
       fromCommit: null,
       toCommit: headCommit,
       added: syncableRelPaths.length,
@@ -829,12 +982,19 @@ async function performFullSync(
   // policy through autoConcurrency() so it stays consistent with incremental
   // sync and the jobs handler.
   const FULL_SYNC_LARGE_MARKER = Number.MAX_SAFE_INTEGER;
-  const fullConcurrency = autoConcurrency(engine, FULL_SYNC_LARGE_MARKER, opts.concurrency);
-  console.log(`Running full import of ${repoPath}${fullConcurrency > 1 ? ` (${fullConcurrency} workers)` : ''}...`);
-  const { runImport } = await import('./import.ts');
+  const fullConcurrency = autoConcurrency(
+    engine,
+    FULL_SYNC_LARGE_MARKER,
+    opts.concurrency,
+  );
+  console.log(
+    `Running full import of ${repoPath}${fullConcurrency > 1 ? ` (${fullConcurrency} workers)` : ""}...`,
+  );
+  const { runImport } = await import("./import.ts");
   const importArgs = [repoPath];
-  if (opts.noEmbed) importArgs.push('--no-embed');
-  if (fullConcurrency > 1) importArgs.push('--workers', String(fullConcurrency));
+  if (opts.noEmbed) importArgs.push("--no-embed");
+  if (fullConcurrency > 1)
+    importArgs.push("--workers", String(fullConcurrency));
   const result = await runImport(engine, importArgs, { commit: headCommit });
 
   // Bug 9 — gate the full-sync bookmark on success. runImport already
@@ -847,16 +1007,19 @@ async function performFullSync(
     if (!opts.skipFailed) {
       console.error(
         `\nFull sync blocked: ${result.failures.length} file(s) failed:\n` +
-        `${codeBreakdown}\n\n` +
-        `Fix the YAML in those files and re-run, or use '--skip-failed'.`,
+          `${codeBreakdown}\n\n` +
+          `Fix the YAML in those files and re-run, or use '--skip-failed'.`,
       );
-      await engine.setConfig('sync.last_run', new Date().toISOString());
-      await writeSyncAnchor(engine, opts.sourceId, 'repo_path', repoPath);
+      await engine.setConfig("sync.last_run", new Date().toISOString());
+      await writeSyncAnchor(engine, opts.sourceId, "repo_path", repoPath);
       return {
-        status: 'blocked_by_failures',
+        status: "blocked_by_failures",
         fromCommit: null,
         toCommit: headCommit,
-        added: 0, modified: 0, deleted: 0, renamed: 0,
+        added: 0,
+        modified: 0,
+        deleted: 0,
+        renamed: 0,
         chunksCreated: result.chunksCreated,
         embedded: 0,
         pagesAffected: [],
@@ -867,7 +1030,7 @@ async function performFullSync(
     if (acked.count > 0) {
       console.error(
         `  Acknowledged ${acked.count} failure(s) and advancing past them:\n` +
-        `${formatCodeBreakdown(acked.summary)}`,
+          `${formatCodeBreakdown(acked.summary)}`,
       );
     }
   }
@@ -875,11 +1038,11 @@ async function performFullSync(
   // Persist sync state so next sync is incremental (C1 fix: was missing).
   // v0.18.0 Step 5: routed through writeSyncAnchor so --source pins it
   // to the right sources row rather than the global config.
-  await writeSyncAnchor(engine, opts.sourceId, 'last_commit', headCommit);
-  await engine.setConfig('sync.last_run', new Date().toISOString());
-  await writeSyncAnchor(engine, opts.sourceId, 'repo_path', repoPath);
+  await writeSyncAnchor(engine, opts.sourceId, "last_commit", headCommit);
+  await engine.setConfig("sync.last_run", new Date().toISOString());
+  await writeSyncAnchor(engine, opts.sourceId, "repo_path", repoPath);
   // v0.20.0 Cathedral II Layer 12: persist chunker version for the gate.
-  await writeChunkerVersion(engine, opts.sourceId, String(CHUNKER_VERSION));
+  await writeChunkerVersion(engine, opts.sourceId, currentChunkerVersionTag());
 
   // Full sync doesn't track pagesAffected, so fall back to embed --stale.
   // Before commit 2: runEmbed is void; use result.imported as best estimate of
@@ -887,14 +1050,16 @@ async function performFullSync(
   let embedded = 0;
   if (!opts.noEmbed) {
     try {
-      const { runEmbed } = await import('./embed.ts');
-      await runEmbed(engine, ['--stale']);
+      const { runEmbed } = await import("./embed.ts");
+      await runEmbed(engine, ["--stale"]);
       embedded = result.imported;
-    } catch { /* embedding is best-effort */ }
+    } catch {
+      /* embedding is best-effort */
+    }
   }
 
   return {
-    status: 'first_sync',
+    status: "first_sync",
     fromCommit: null,
     toCommit: headCommit,
     added: result.imported,
@@ -908,21 +1073,25 @@ async function performFullSync(
 }
 
 export async function runSync(engine: BrainEngine, args: string[]) {
-  const repoPath = args.find((a, i) => args[i - 1] === '--repo') || undefined;
-  const watch = args.includes('--watch');
-  const intervalStr = args.find((a, i) => args[i - 1] === '--interval');
+  const repoPath = args.find((a, i) => args[i - 1] === "--repo") || undefined;
+  const watch = args.includes("--watch");
+  const intervalStr = args.find((a, i) => args[i - 1] === "--interval");
   const interval = intervalStr ? parseInt(intervalStr, 10) : 60;
-  const dryRun = args.includes('--dry-run');
-  const full = args.includes('--full');
-  const noPull = args.includes('--no-pull');
-  const noEmbed = args.includes('--no-embed');
-  const skipFailed = args.includes('--skip-failed');
-  const retryFailed = args.includes('--retry-failed');
-  const syncAll = args.includes('--all');
-  const jsonOut = args.includes('--json');
-  const yesFlag = args.includes('--yes');
-  const strategyArg = args.find((a, i) => args[i - 1] === '--strategy') as SyncOpts['strategy'] | undefined;
-  const concurrencyStr = args.find((a, i) => args[i - 1] === '--concurrency' || args[i - 1] === '--workers');
+  const dryRun = args.includes("--dry-run");
+  const full = args.includes("--full");
+  const noPull = args.includes("--no-pull");
+  const noEmbed = args.includes("--no-embed");
+  const skipFailed = args.includes("--skip-failed");
+  const retryFailed = args.includes("--retry-failed");
+  const syncAll = args.includes("--all");
+  const jsonOut = args.includes("--json");
+  const yesFlag = args.includes("--yes");
+  const strategyArg = args.find((a, i) => args[i - 1] === "--strategy") as
+    | SyncOpts["strategy"]
+    | undefined;
+  const concurrencyStr = args.find(
+    (a, i) => args[i - 1] === "--concurrency" || args[i - 1] === "--workers",
+  );
   // v0.22.13 (PR #490 Q2): parseWorkers throws on '0', '-3', 'foo', '1.5' instead
   // of silently falling through to auto-concurrency or NaN. Loud failure beats
   // a 4-worker spawn from a typo.
@@ -937,10 +1106,11 @@ export async function runSync(engine: BrainEngine, args: string[]) {
   // v0.18.0 Step 5: --source resolves to a sources(id) row. Falls back
   // to pre-v0.17 global config (sync.repo_path + sync.last_commit) when
   // no flag, no env, no dotfile is present.
-  const explicitSource = args.find((a, i) => args[i - 1] === '--source') || null;
+  const explicitSource =
+    args.find((a, i) => args[i - 1] === "--source") || null;
   let sourceId: string | undefined = undefined;
   if (explicitSource || process.env.GBRAIN_SOURCE) {
-    const { resolveSourceId } = await import('../core/source-resolver.ts');
+    const { resolveSourceId } = await import("../core/source-resolver.ts");
     sourceId = await resolveSourceId(engine, explicitSource);
   }
 
@@ -954,11 +1124,18 @@ export async function runSync(engine: BrainEngine, args: string[]) {
   // source (no checkout) has nothing for `sync` to pull. Sources with
   // syncEnabled=false in config.jsonb are skipped too.
   if (syncAll) {
-    const sources = await engine.executeRaw<{ id: string; name: string; local_path: string | null; config: Record<string, unknown> }>(
+    const sources = await engine.executeRaw<{
+      id: string;
+      name: string;
+      local_path: string | null;
+      config: Record<string, unknown>;
+    }>(
       `SELECT id, name, local_path, config FROM sources WHERE local_path IS NOT NULL`,
     );
     if (!sources || sources.length === 0) {
-      console.log('No sources with local_path configured. Use `gbrain sources add <id> --path <path>` first.');
+      console.log(
+        "No sources with local_path configured. Use `gbrain sources add <id> --path <path>` first.",
+      );
       return;
     }
 
@@ -982,39 +1159,59 @@ export async function runSync(engine: BrainEngine, args: string[]) {
 
       if (dryRun) {
         if (jsonOut) {
-          console.log(JSON.stringify({ status: 'dry_run', preview, costUsd, model: EMBEDDING_MODEL }));
+          console.log(
+            JSON.stringify({
+              status: "dry_run",
+              preview,
+              costUsd,
+              model: EMBEDDING_MODEL,
+            }),
+          );
         } else {
           console.log(previewMsg);
-          console.log('--dry-run: exit without syncing.');
+          console.log("--dry-run: exit without syncing.");
         }
         return;
       }
 
       if (!yesFlag) {
-        const isTTY = Boolean(process.stdout.isTTY) && Boolean(process.stdin.isTTY);
+        const isTTY =
+          Boolean(process.stdout.isTTY) && Boolean(process.stdin.isTTY);
         if (!isTTY || jsonOut) {
           // Agent-facing path: emit structured envelope, exit 2.
-          const envelope = serializeError(errorFor({
-            class: 'ConfirmationRequired',
-            code: 'cost_preview_requires_yes',
-            message: previewMsg,
-            hint: 'Pass --yes to proceed, or --dry-run to see the preview and exit 0.',
-          }));
-          console.log(JSON.stringify({ error: envelope, preview, costUsd, model: EMBEDDING_MODEL }));
+          const envelope = serializeError(
+            errorFor({
+              class: "ConfirmationRequired",
+              code: "cost_preview_requires_yes",
+              message: previewMsg,
+              hint: "Pass --yes to proceed, or --dry-run to see the preview and exit 0.",
+            }),
+          );
+          console.log(
+            JSON.stringify({
+              error: envelope,
+              preview,
+              costUsd,
+              model: EMBEDDING_MODEL,
+            }),
+          );
           process.exit(2);
         }
         // Interactive TTY path: prompt [y/N].
         console.log(previewMsg);
-        const answer = await promptYesNo('Proceed? [y/N] ');
+        const answer = await promptYesNo("Proceed? [y/N] ");
         if (!answer) {
-          console.log('Cancelled.');
+          console.log("Cancelled.");
           return;
         }
       }
     }
 
     for (const src of sources) {
-      const cfg = (src.config || {}) as { syncEnabled?: boolean; strategy?: 'markdown' | 'code' | 'auto' };
+      const cfg = (src.config || {}) as {
+        syncEnabled?: boolean;
+        strategy?: "markdown" | "code" | "auto";
+      };
       if (cfg.syncEnabled === false) {
         console.log(`Skipping disabled source: ${src.name}`);
         continue;
@@ -1022,7 +1219,12 @@ export async function runSync(engine: BrainEngine, args: string[]) {
       console.log(`\n--- Syncing source: ${src.name} ---`);
       const repoOpts: SyncOpts = {
         repoPath: src.local_path!,
-        dryRun, full, noPull, noEmbed, skipFailed, retryFailed,
+        dryRun,
+        full,
+        noPull,
+        noEmbed,
+        skipFailed,
+        retryFailed,
         sourceId: src.id,
         strategy: cfg.strategy,
         concurrency,
@@ -1034,17 +1236,33 @@ export async function runSync(engine: BrainEngine, args: string[]) {
         // this, multi-source users who rely on `gbrain sync --all` never get
         // the advertised db_only ignore rules unless they sync each repo
         // individually.
-        if (result.status !== 'dry_run' && result.status !== 'blocked_by_failures') {
+        if (
+          result.status !== "dry_run" &&
+          result.status !== "blocked_by_failures"
+        ) {
           manageGitignore(src.local_path!, engine.kind);
         }
       } catch (e: unknown) {
-        console.error(`Error syncing ${src.name}: ${e instanceof Error ? e.message : String(e)}`);
+        console.error(
+          `Error syncing ${src.name}: ${e instanceof Error ? e.message : String(e)}`,
+        );
       }
     }
     return;
   }
 
-  const opts: SyncOpts = { repoPath, dryRun, full, noPull, noEmbed, skipFailed, retryFailed, sourceId, strategy: strategyArg, concurrency };
+  const opts: SyncOpts = {
+    repoPath,
+    dryRun,
+    full,
+    noPull,
+    noEmbed,
+    skipFailed,
+    retryFailed,
+    sourceId,
+    strategy: strategyArg,
+    concurrency,
+  };
 
   // Bug 9 — --retry-failed: before running normal sync, clear acknowledgment
   // flags so the sync picks them up as fresh work. The actual re-attempt
@@ -1053,7 +1271,7 @@ export async function runSync(engine: BrainEngine, args: string[]) {
   if (retryFailed) {
     const failures = unacknowledgedSyncFailures();
     if (failures.length === 0) {
-      console.log('No unacknowledged sync failures to retry.');
+      console.log("No unacknowledged sync failures to retry.");
     } else {
       console.log(`Retrying ${failures.length} previously-failed file(s)...`);
       // Don't acknowledge them yet — they must succeed to clear.
@@ -1069,8 +1287,12 @@ export async function runSync(engine: BrainEngine, args: string[]) {
     // until next clean run). Resolve the effective repo path so the wire-up
     // fires in the common case where the user runs `gbrain sync` without
     // passing --repo every time.
-    if (result.status !== 'dry_run' && result.status !== 'blocked_by_failures') {
-      const effectiveRepoPath = opts.repoPath ?? (await getDefaultSourcePath(engine));
+    if (
+      result.status !== "dry_run" &&
+      result.status !== "blocked_by_failures"
+    ) {
+      const effectiveRepoPath =
+        opts.repoPath ?? (await getDefaultSourcePath(engine));
       if (effectiveRepoPath) {
         manageGitignore(effectiveRepoPath, engine.kind);
       }
@@ -1086,14 +1308,20 @@ export async function runSync(engine: BrainEngine, args: string[]) {
     try {
       const result = await performSync(engine, { ...opts, full: false });
       consecutiveErrors = 0;
-      if (result.status === 'synced') {
+      if (result.status === "synced") {
         const ts = new Date().toISOString().slice(11, 19);
-        console.log(`[${ts}] Synced: +${result.added} ~${result.modified} -${result.deleted} R${result.renamed}`);
+        console.log(
+          `[${ts}] Synced: +${result.added} ~${result.modified} -${result.deleted} R${result.renamed}`,
+        );
       }
       // Same gate as non-watch: only manage .gitignore on successful sync.
       // Same repo-resolution path so watch mode catches the implicit-resolved case.
-      if (result.status !== 'dry_run' && result.status !== 'blocked_by_failures') {
-        const effectiveRepoPath = opts.repoPath ?? (await getDefaultSourcePath(engine));
+      if (
+        result.status !== "dry_run" &&
+        result.status !== "blocked_by_failures"
+      ) {
+        const effectiveRepoPath =
+          opts.repoPath ?? (await getDefaultSourcePath(engine));
         if (effectiveRepoPath) {
           manageGitignore(effectiveRepoPath, engine.kind);
         }
@@ -1101,13 +1329,15 @@ export async function runSync(engine: BrainEngine, args: string[]) {
     } catch (e: unknown) {
       consecutiveErrors++;
       const msg = e instanceof Error ? e.message : String(e);
-      console.error(`[${new Date().toISOString().slice(11, 19)}] Sync error (${consecutiveErrors}/5): ${msg}`);
+      console.error(
+        `[${new Date().toISOString().slice(11, 19)}] Sync error (${consecutiveErrors}/5): ${msg}`,
+      );
       if (consecutiveErrors >= 5) {
         console.error(`5 consecutive sync failures. Stopping watch.`);
         process.exit(1);
       }
     }
-    await new Promise(r => setTimeout(r, interval * 1000));
+    await new Promise((r) => setTimeout(r, interval * 1000));
   }
 }
 
@@ -1140,15 +1370,15 @@ export function __resetPGLiteTierWarn(): void {
 
 export function manageGitignore(
   repoPath: string,
-  engineKind?: 'pglite' | 'postgres',
+  engineKind?: "pglite" | "postgres",
 ): void {
-  if (process.env.GBRAIN_NO_GITIGNORE === '1') {
+  if (process.env.GBRAIN_NO_GITIGNORE === "1") {
     return;
   }
 
   // D49: submodule detection. In a submodule, `.git` is a regular file
   // (containing `gitdir: ../path/to/parent.git/modules/x`), not a directory.
-  const dotGit = join(repoPath, '.git');
+  const dotGit = join(repoPath, ".git");
   if (existsSync(dotGit)) {
     try {
       if (statSync(dotGit).isFile()) {
@@ -1179,7 +1409,7 @@ export function manageGitignore(
 
   // D4 soft-warn: storage tiering has limited effect on PGLite, but the
   // .gitignore housekeeping still helps. Warn once per process; proceed.
-  if (engineKind === 'pglite' && !_pgliteTierWarned) {
+  if (engineKind === "pglite" && !_pgliteTierWarned) {
     _pgliteTierWarned = true;
     console.warn(
       `Note: storage tiering has limited effect on PGLite — pages live in your ` +
@@ -1187,12 +1417,12 @@ export function manageGitignore(
     );
   }
 
-  const gitignorePath = join(repoPath, '.gitignore');
-  let gitignoreContent = '';
+  const gitignorePath = join(repoPath, ".gitignore");
+  let gitignoreContent = "";
 
   if (existsSync(gitignorePath)) {
     try {
-      gitignoreContent = readFileSync(gitignorePath, 'utf-8');
+      gitignoreContent = readFileSync(gitignorePath, "utf-8");
     } catch (error) {
       console.warn(
         `Could not read ${gitignorePath} (${error instanceof Error ? error.message : String(error)}) — ` +
@@ -1202,7 +1432,9 @@ export function manageGitignore(
     }
   }
 
-  const existingLines = new Set(gitignoreContent.split('\n').map((line) => line.trim()));
+  const existingLines = new Set(
+    gitignoreContent.split("\n").map((line) => line.trim()),
+  );
   const linesToAdd: string[] = [];
 
   for (const dir of storageConfig.db_only) {
@@ -1213,42 +1445,58 @@ export function manageGitignore(
 
   if (linesToAdd.length === 0) return;
 
-  if (gitignoreContent && !gitignoreContent.endsWith('\n')) {
-    gitignoreContent += '\n';
+  if (gitignoreContent && !gitignoreContent.endsWith("\n")) {
+    gitignoreContent += "\n";
   }
-  gitignoreContent += '\n# Auto-managed by gbrain (db_only directories)\n';
-  gitignoreContent += linesToAdd.join('\n') + '\n';
+  gitignoreContent += "\n# Auto-managed by gbrain (db_only directories)\n";
+  gitignoreContent += linesToAdd.join("\n") + "\n";
 
   try {
     writeFileSync(gitignorePath, gitignoreContent);
   } catch (error) {
     console.warn(
       `Could not update ${gitignorePath} (${error instanceof Error ? error.message : String(error)}) — ` +
-        `please add db_only directories manually:\n  ${linesToAdd.join('\n  ')}`,
+        `please add db_only directories manually:\n  ${linesToAdd.join("\n  ")}`,
     );
   }
 }
 
 function printSyncResult(result: SyncResult) {
   switch (result.status) {
-    case 'up_to_date':
-      console.log('Already up to date.');
+    case "up_to_date":
+      console.log("Already up to date.");
       break;
-    case 'synced':
-      console.log(`Synced ${result.fromCommit?.slice(0, 8)}..${result.toCommit.slice(0, 8)}:`);
-      console.log(`  +${result.added} added, ~${result.modified} modified, -${result.deleted} deleted, R${result.renamed} renamed`);
-      console.log(`  ${result.chunksCreated} chunks created${result.embedded > 0 ? `, ${result.embedded} pages embedded` : ''}`);
+    case "synced":
+      console.log(
+        `Synced ${result.fromCommit?.slice(0, 8)}..${result.toCommit.slice(0, 8)}:`,
+      );
+      console.log(
+        `  +${result.added} added, ~${result.modified} modified, -${result.deleted} deleted, R${result.renamed} renamed`,
+      );
+      console.log(
+        `  ${result.chunksCreated} chunks created${result.embedded > 0 ? `, ${result.embedded} pages embedded` : ""}`,
+      );
       break;
-    case 'first_sync':
-      console.log(`First sync complete. Checkpoint: ${result.toCommit.slice(0, 8)}`);
-      console.log(`  ${result.added} file(s) imported, ${result.chunksCreated} chunks${result.embedded > 0 ? `, ${result.embedded} pages embedded` : ''}`);
+    case "first_sync":
+      console.log(
+        `First sync complete. Checkpoint: ${result.toCommit.slice(0, 8)}`,
+      );
+      console.log(
+        `  ${result.added} file(s) imported, ${result.chunksCreated} chunks${result.embedded > 0 ? `, ${result.embedded} pages embedded` : ""}`,
+      );
       break;
-    case 'dry_run':
+    case "dry_run":
       break; // already printed in performSync
-    case 'blocked_by_failures':
-      console.log(`Sync BLOCKED at ${result.toCommit.slice(0, 8)}: ${result.failedFiles ?? 0} file(s) failed to parse.`);
-      console.log(`  See ~/.gbrain/sync-failures.jsonl for details, or run 'gbrain doctor'.`);
-      console.log(`  Fix the files then re-run 'gbrain sync', or 'gbrain sync --skip-failed' to move on.`);
+    case "blocked_by_failures":
+      console.log(
+        `Sync BLOCKED at ${result.toCommit.slice(0, 8)}: ${result.failedFiles ?? 0} file(s) failed to parse.`,
+      );
+      console.log(
+        `  See ~/.gbrain/sync-failures.jsonl for details, or run 'gbrain doctor'.`,
+      );
+      console.log(
+        `  Fix the files then re-run 'gbrain sync', or 'gbrain sync --skip-failed' to move on.`,
+      );
       break;
   }
 }

--- a/src/core/chunkers/recursive.ts
+++ b/src/core/chunkers/recursive.ts
@@ -5,24 +5,92 @@
  * 5-level delimiter hierarchy:
  *   1. Paragraphs (\n\n)
  *   2. Lines (\n)
- *   3. Sentences (. ! ? followed by space or newline)
- *   4. Clauses (; : , )
- *   5. Words (whitespace)
+ *   3. Sentences (. ! ? followed by space or newline; CJK 。！？)
+ *   4. Clauses (; : , ; CJK ；：，、)
+ *   5. Words (whitespace; or codepoint slicing for CJK / no-space text)
  *
  * Config: 300-word chunks with 50-word sentence-aware overlap.
- * Lossless invariant: non-overlapping portions reassemble to original.
+ *
+ * Boundary trim: each emitted chunk's text is `.trim()`-ed (see chunkText
+ * tail and splitAtDelimiters), so delimiter whitespace at chunk boundaries
+ * — most commonly a trailing `\n` after a sentence-ending `。`/`!`/`?` —
+ * is dropped from chunk content. The chunk sequence still covers the
+ * original text modulo this whitespace; the invariant is "no semantic
+ * loss" (every non-whitespace token of the source appears in some chunk),
+ * NOT "byte-exact reassembly". Loss is bounded by O(chunks.length) outer
+ * whitespace chars, never per-character content drift.
+ *
+ * v2 (PROSE_CHUNKER_VERSION) — CJK awareness:
+ *   - countWords() counts each CJK char as 1 word, plus ASCII whitespace words
+ *   - DELIMITERS extended with CJK punctuation
+ *   - Level-4 fallback uses codepoint-slicing for CJK / no-space text so the
+ *     chunker can ALWAYS reduce a piece below the target word count.
+ *
+ * Why bump PROSE_CHUNKER_VERSION: importFromContent's content_hash
+ * short-circuits unchanged pages. Folding the version into that hash
+ * forces existing affected pages to re-chunk on next put_page (one-time
+ * mass re-embed cost; repairs the 158 pages where dense CJK paragraphs
+ * collapsed to a single 8192+ token chunk that OpenAI rejected).
  */
 
+/**
+ * Recursive prose chunker version. Folded into content_hash by
+ * import-file.ts so a bump forces re-chunking of every markdown page on
+ * its next put_page. Bump whenever the chunking *shape* changes (delimiter
+ * set, fallback strategy, word counting), not for cosmetic refactors.
+ */
+export const PROSE_CHUNKER_VERSION = 2;
+
+// CJK char range used everywhere in this module.
+// Mirrors src/core/search/expansion.ts so query-time and index-time
+// CJK detection stay consistent.
+const CJK_RE = /[一-鿿぀-ゟ゠-ヿ가-힯]/;
+const CJK_RE_GLOBAL = /[一-鿿぀-ゟ゠-ヿ가-힯]/g;
+
+// Ordering note: within each level, LONGER delimiters MUST appear before
+// shorter ones that are their prefix. splitAtDelimiters picks the earliest
+// match index and breaks ties by *array order* (first wins). If we listed
+// '。' before '。\n', a string like '甲乙。\n丙丁' matches '。' at index 2
+// and the trailing '\n' leaks into the *next* piece, where trim() drops it
+// — losing one char per CJK sentence boundary across the document. Same for
+// '！\n' / '？\n' on L2 and any '<punct>\n' shapes added in the future.
 const DELIMITERS: string[][] = [
-  ['\n\n'],                          // L0: paragraphs
-  ['\n'],                            // L1: lines
-  ['. ', '! ', '? ', '.\n', '!\n', '?\n'], // L2: sentences
-  ['; ', ': ', ', '],                // L3: clauses
-  [],                                // L4: words (whitespace split)
+  ["\n\n"], // L0: paragraphs
+  ["\n"], // L1: lines
+  // L2: sentence boundaries — '<punct>\n' BEFORE bare '<punct>' so the
+  // newline stays attached. '. ' / '! ' / '? ' don't share a prefix with
+  // any other entry, so their order is incidental.
+  [
+    "。\n",
+    "！\n",
+    "？\n",
+    ".\n",
+    "!\n",
+    "?\n", // L2: sentences w/ trailing newline
+    ". ",
+    "! ",
+    "? ", //     ASCII sentence + space
+    "。",
+    "！",
+    "？",
+  ], //     bare CJK sentence punct
+  // L3: clause boundaries. None of the entries are prefixes of another
+  // today, but we keep the longer-first convention so a future '，\n'
+  // addition slots in correctly without resurrecting the L2 bug.
+  [
+    "; ",
+    ": ",
+    ", ", // L3: ASCII clauses
+    "；",
+    "：",
+    "，",
+    "、",
+  ], //     CJK clauses
+  [], // L4: words (whitespace or codepoint split)
 ];
 
 export interface ChunkOptions {
-  chunkSize?: number;    // target words per chunk (default 300)
+  chunkSize?: number; // target words per chunk (default 300)
   chunkOverlap?: number; // overlap words (default 50)
 }
 
@@ -91,7 +159,7 @@ function splitAtDelimiters(text: string, delimiters: string[]): string[] {
 
   while (remaining.length > 0) {
     let earliest = -1;
-    let earliestDelim = '';
+    let earliestDelim = "";
 
     for (const delim of delimiters) {
       const idx = remaining.indexOf(delim);
@@ -119,19 +187,41 @@ function splitAtDelimiters(text: string, delimiters: string[]): string[] {
     // Already added above
   }
 
-  return pieces.filter(p => p.trim().length > 0);
+  return pieces.filter((p) => p.trim().length > 0);
 }
 
 /**
  * Fallback: split on whitespace boundaries to hit target word count.
+ *
+ * For CJK / no-space text, falls back to codepoint slicing — every `target`
+ * codepoints becomes a piece. Without this, dense CJK prose with no
+ * delimiters would return as one giant piece and blow OpenAI's 8192-token
+ * embedding limit (this is the bug repaired by PROSE_CHUNKER_VERSION=2).
  */
 function splitOnWhitespace(text: string, target: number): string[] {
+  // CJK or no-whitespace text: codepoint-slice.
+  // We use Array.from() to iterate codepoints (handles surrogate pairs);
+  // slicing by string indices would split astral characters mid-pair.
+  if (CJK_RE.test(text) || !/\s/.test(text.trim())) {
+    const codepoints = Array.from(text);
+    if (codepoints.length === 0) return [];
+    const pieces: string[] = [];
+    for (let i = 0; i < codepoints.length; i += target) {
+      const slice = codepoints.slice(i, i + target).join("");
+      if (slice.trim().length > 0) {
+        pieces.push(slice);
+      }
+    }
+    return pieces;
+  }
+
+  // Pure-ASCII / space-delimited: original whitespace behavior.
   const words = text.match(/\S+\s*/g) || [];
   if (words.length === 0) return [];
 
   const pieces: string[] = [];
   for (let i = 0; i < words.length; i += target) {
-    const slice = words.slice(i, i + target).join('');
+    const slice = words.slice(i, i + target).join("");
     if (slice.trim().length > 0) {
       pieces.push(slice);
     }
@@ -189,15 +279,17 @@ function applyOverlap(chunks: string[], overlapWords: number): string[] {
  */
 function extractTrailingContext(text: string, targetWords: number): string {
   const words = text.match(/\S+\s*/g) || [];
-  if (words.length <= targetWords) return '';
+  if (words.length <= targetWords) return "";
 
-  const trailing = words.slice(-targetWords).join('');
+  const trailing = words.slice(-targetWords).join("");
 
   // Try to find a sentence boundary to start from
   const sentenceStart = trailing.search(/[.!?]\s+/);
   if (sentenceStart !== -1 && sentenceStart < trailing.length / 2) {
     // Start after the sentence boundary
-    const afterSentence = trailing.slice(sentenceStart).replace(/^[.!?]\s+/, '');
+    const afterSentence = trailing
+      .slice(sentenceStart)
+      .replace(/^[.!?]\s+/, "");
     if (afterSentence.trim().length > 0) {
       return afterSentence;
     }
@@ -206,6 +298,59 @@ function extractTrailingContext(text: string, targetWords: number): string {
   return trailing;
 }
 
-function countWords(text: string): number {
-  return (text.match(/\S+/g) || []).length;
+/**
+ * Count "words" in a script-aware way:
+ *   - each CJK character (Han, Hiragana, Katakana, Hangul) counts as 1 word
+ *   - remaining text (after CJK chars are stripped) is counted by
+ *     whitespace-delimited tokens
+ *   - degenerate "long no-space, no-CJK" inputs (emoji ZWJ sequences,
+ *     combining marks like 'é', non-BMP CJK like Han Extension B that
+ *     falls outside the BMP CJK_RE block) get a codepoint-count floor
+ *     so they don't slip past chunkText's `wordCount <= chunkSize` early
+ *     exit as a single oversized chunk
+ *
+ * Mirrors the CJK detection used in src/core/search/expansion.ts so that
+ * query-time and index-time word counts stay aligned.
+ */
+export function countWords(text: string): number {
+  if (!text) return 0;
+  const cjkMatches = text.match(CJK_RE_GLOBAL);
+  const cjkCount = cjkMatches ? cjkMatches.length : 0;
+  const ascii = text.replace(CJK_RE_GLOBAL, " ");
+  const asciiCount = (ascii.match(/\S+/g) || []).length;
+  const base = cjkCount + asciiCount;
+
+  // Codepoint-count floor for degenerate inputs.
+  //
+  // The chunker's recursive pipeline relies on `wordCount > chunkSize` to
+  // decide a piece needs further splitting. Three input shapes silently
+  // defeat that signal pre-fix and return a single oversized chunk:
+  //
+  //   1. emoji ZWJ sequences ('👨‍👩‍👧‍👦'.repeat(1000)) — `\S+` matches the
+  //      whole 7000-codepoint blob as 1 token, no CJK_RE hits, base=1.
+  //   2. combining marks ('é'.repeat(2000)) — same shape, base=1.
+  //   3. Han Extension B ('𠀀'.repeat(1000)) — non-BMP, sits outside the
+  //      U+4E00-U+9FFF block CJK_RE matches, so cjkCount=0, base=1.
+  //
+  // All three blow OpenAI's 8192-token embedding ceiling on a single
+  // chunk. The floor below forces wordCount above chunkSize for any
+  // sufficiently long single-token, no-CJK input, so chunkText drops
+  // into recursiveSplit → splitOnWhitespace's codepoint-slicing branch.
+  //
+  // Constraint: must NOT regress ASCII baselines. We only apply the
+  // floor when the trimmed text is non-empty AND has NO whitespace AND
+  // no CJK match — i.e. it genuinely is one long codepoint blob. Short
+  // inputs ('hello', 'word') trivially pass `wordCount <= chunkSize`
+  // either way, so promoting their count from 1 to 5 is harmless.
+  // Whitespace-bearing ASCII ('word '.repeat(500)) keeps the original
+  // asciiCount path. Whitespace-only inputs ('   ') stay at 0 — the
+  // outer trim()-non-empty guard catches them so we don't accidentally
+  // count whitespace codepoints.
+  const trimmed = text.trim();
+  if (trimmed.length > 0 && cjkCount === 0 && !/\s/.test(trimmed)) {
+    const codepointCount = Array.from(text).length;
+    return Math.max(base, codepointCount);
+  }
+
+  return base;
 }

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -4,7 +4,7 @@ import { createHash } from 'crypto';
 import { marked } from 'marked';
 import type { BrainEngine } from './engine.ts';
 import { parseMarkdown } from './markdown.ts';
-import { chunkText } from './chunkers/recursive.ts';
+import { chunkText, PROSE_CHUNKER_VERSION } from './chunkers/recursive.ts';
 import { chunkCodeText, chunkCodeTextFull, detectCodeLanguage, CHUNKER_VERSION } from './chunkers/code.ts';
 import { findChunkForOffset } from './chunkers/edge-extractor.ts';
 import { extractCodeRefs } from './link-extraction.ts';
@@ -202,7 +202,11 @@ export async function importFromContent(
 
   const parsed = parseMarkdown(content, slug + '.md');
 
-  // Hash includes ALL fields for idempotency (not just compiled_truth + timeline)
+  // Hash includes ALL fields for idempotency (not just compiled_truth + timeline).
+  // PROSE_CHUNKER_VERSION is folded in so any bump forces existing markdown
+  // pages to re-chunk on next put_page (see chunkers/recursive.ts). Without
+  // this, fixes to the chunker only affect newly-edited pages — the 158
+  // already-broken CJK pages would stay broken until someone re-saves them.
   const hash = createHash('sha256')
     .update(JSON.stringify({
       title: parsed.title,
@@ -211,6 +215,7 @@ export async function importFromContent(
       timeline: parsed.timeline,
       frontmatter: parsed.frontmatter,
       tags: parsed.tags.sort(),
+      prose_chunker_version: PROSE_CHUNKER_VERSION,
     }))
     .digest('hex');
 

--- a/test/chunkers/recursive.test.ts
+++ b/test/chunkers/recursive.test.ts
@@ -1,29 +1,34 @@
-import { describe, test, expect } from 'bun:test';
-import { chunkText } from '../../src/core/chunkers/recursive.ts';
+import { describe, test, expect } from "bun:test";
+import {
+  chunkText,
+  countWords,
+  PROSE_CHUNKER_VERSION,
+} from "../../src/core/chunkers/recursive.ts";
+import { createHash } from "node:crypto";
 
-describe('Recursive Text Chunker', () => {
-  test('returns empty array for empty input', () => {
-    expect(chunkText('')).toEqual([]);
-    expect(chunkText('   ')).toEqual([]);
+describe("Recursive Text Chunker", () => {
+  test("returns empty array for empty input", () => {
+    expect(chunkText("")).toEqual([]);
+    expect(chunkText("   ")).toEqual([]);
   });
 
-  test('returns single chunk for short text', () => {
-    const text = 'Hello world. This is a short text.';
+  test("returns single chunk for short text", () => {
+    const text = "Hello world. This is a short text.";
     const chunks = chunkText(text);
     expect(chunks).toHaveLength(1);
     expect(chunks[0].text).toBe(text.trim());
     expect(chunks[0].index).toBe(0);
   });
 
-  test('splits at paragraph boundaries', () => {
-    const paragraph = 'word '.repeat(200).trim();
-    const text = paragraph + '\n\n' + paragraph;
+  test("splits at paragraph boundaries", () => {
+    const paragraph = "word ".repeat(200).trim();
+    const text = paragraph + "\n\n" + paragraph;
     const chunks = chunkText(text, { chunkSize: 250 });
     expect(chunks.length).toBeGreaterThanOrEqual(2);
   });
 
-  test('respects chunk size target', () => {
-    const text = 'word '.repeat(1000).trim();
+  test("respects chunk size target", () => {
+    const text = "word ".repeat(1000).trim();
     const chunks = chunkText(text, { chunkSize: 100 });
     for (const chunk of chunks) {
       const wordCount = chunk.text.split(/\s+/).length;
@@ -32,8 +37,8 @@ describe('Recursive Text Chunker', () => {
     }
   });
 
-  test('applies overlap between chunks', () => {
-    const text = 'word '.repeat(1000).trim();
+  test("applies overlap between chunks", () => {
+    const text = "word ".repeat(1000).trim();
     const chunks = chunkText(text, { chunkSize: 100, chunkOverlap: 20 });
     expect(chunks.length).toBeGreaterThan(1);
     // Second chunk should start with words from end of first chunk
@@ -41,10 +46,12 @@ describe('Recursive Text Chunker', () => {
     expect(chunks[1].text.length).toBeGreaterThan(0);
   });
 
-  test('splits at sentence boundaries', () => {
-    const sentences = Array.from({ length: 50 }, (_, i) =>
-      `This is sentence number ${i} with some content about topic ${i}.`
-    ).join(' ');
+  test("splits at sentence boundaries", () => {
+    const sentences = Array.from(
+      { length: 50 },
+      (_, i) =>
+        `This is sentence number ${i} with some content about topic ${i}.`,
+    ).join(" ");
     const chunks = chunkText(sentences, { chunkSize: 50 });
     expect(chunks.length).toBeGreaterThan(1);
     // Each chunk should end near a sentence boundary
@@ -54,37 +61,38 @@ describe('Recursive Text Chunker', () => {
     }
   });
 
-  test('assigns sequential indices', () => {
-    const text = 'word '.repeat(1000).trim();
+  test("assigns sequential indices", () => {
+    const text = "word ".repeat(1000).trim();
     const chunks = chunkText(text, { chunkSize: 100 });
     for (let i = 0; i < chunks.length; i++) {
       expect(chunks[i].index).toBe(i);
     }
   });
 
-  test('handles single word input', () => {
-    const chunks = chunkText('hello');
+  test("handles single word input", () => {
+    const chunks = chunkText("hello");
     expect(chunks).toHaveLength(1);
-    expect(chunks[0].text).toBe('hello');
+    expect(chunks[0].text).toBe("hello");
   });
 
-  test('handles unicode text', () => {
-    const text = 'Bonjour le monde. ' + 'Ceci est un texte en francais. '.repeat(100);
+  test("handles unicode text", () => {
+    const text =
+      "Bonjour le monde. " + "Ceci est un texte en francais. ".repeat(100);
     const chunks = chunkText(text, { chunkSize: 50 });
     expect(chunks.length).toBeGreaterThan(1);
-    expect(chunks[0].text).toContain('Bonjour');
+    expect(chunks[0].text).toContain("Bonjour");
   });
 
-  test('splits at single newline (line-level) when paragraphs are absent', () => {
+  test("splits at single newline (line-level) when paragraphs are absent", () => {
     // Lines without double newlines should still split at single newlines
-    const lines = Array(100).fill('This is a single line of text.').join('\n');
+    const lines = Array(100).fill("This is a single line of text.").join("\n");
     const chunks = chunkText(lines, { chunkSize: 20 });
     expect(chunks.length).toBeGreaterThan(1);
   });
 
-  test('handles text with only whitespace delimiters (word-level split)', () => {
+  test("handles text with only whitespace delimiters (word-level split)", () => {
     // No sentences, no newlines, just words
-    const words = Array(200).fill('word').join(' ');
+    const words = Array(200).fill("word").join(" ");
     const chunks = chunkText(words, { chunkSize: 50 });
     expect(chunks.length).toBeGreaterThan(1);
     for (const chunk of chunks) {
@@ -92,26 +100,31 @@ describe('Recursive Text Chunker', () => {
     }
   });
 
-  test('handles clause-level delimiters (semicolons, colons, commas)', () => {
+  test("handles clause-level delimiters (semicolons, colons, commas)", () => {
     // Text with clauses but no sentence endings
-    const text = Array(100).fill('clause one; clause two: clause three, clause four').join(' ');
+    const text = Array(100)
+      .fill("clause one; clause two: clause three, clause four")
+      .join(" ");
     const chunks = chunkText(text, { chunkSize: 30 });
     expect(chunks.length).toBeGreaterThan(1);
   });
 
-  test('preserves content across chunks (lossless)', () => {
-    const original = 'First paragraph.\n\nSecond paragraph.\n\nThird paragraph.';
+  test("preserves content across chunks (lossless)", () => {
+    const original =
+      "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.";
     const chunks = chunkText(original, { chunkSize: 5, chunkOverlap: 0 });
     // With no overlap, all text should appear in chunks
-    const reconstructed = chunks.map(c => c.text).join(' ');
-    expect(reconstructed).toContain('First paragraph');
-    expect(reconstructed).toContain('Second paragraph');
-    expect(reconstructed).toContain('Third paragraph');
+    const reconstructed = chunks.map((c) => c.text).join(" ");
+    expect(reconstructed).toContain("First paragraph");
+    expect(reconstructed).toContain("Second paragraph");
+    expect(reconstructed).toContain("Third paragraph");
   });
 
-  test('default options produce reasonable chunks', () => {
+  test("default options produce reasonable chunks", () => {
     // Large text with defaults (300 words, 50 overlap)
-    const text = Array(500).fill('This is a test sentence with several words.').join(' ');
+    const text = Array(500)
+      .fill("This is a test sentence with several words.")
+      .join(" ");
     const chunks = chunkText(text);
     expect(chunks.length).toBeGreaterThan(1);
     for (const chunk of chunks) {
@@ -121,15 +134,301 @@ describe('Recursive Text Chunker', () => {
     }
   });
 
-  test('handles mixed delimiter hierarchy', () => {
+  test("handles mixed delimiter hierarchy", () => {
     const text = [
-      'Paragraph one has sentences. And more sentences! Really?',
-      '',
-      'Paragraph two; with clauses: and more, clauses here.',
-      '',
-      'Paragraph three.\nWith line breaks.\nAnd more lines.',
-    ].join('\n');
+      "Paragraph one has sentences. And more sentences! Really?",
+      "",
+      "Paragraph two; with clauses: and more, clauses here.",
+      "",
+      "Paragraph three.\nWith line breaks.\nAnd more lines.",
+    ].join("\n");
     const chunks = chunkText(text, { chunkSize: 10 });
     expect(chunks.length).toBeGreaterThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// v2 — CJK-aware prose chunking
+// ---------------------------------------------------------------------------
+//
+// Why these tests exist: pre-v2 the chunker counted whitespace-delimited
+// tokens (\S+), so a CJK paragraph with no spaces returned wordCount=1 and
+// became a single chunk. For dense Chinese prose that single chunk routinely
+// blew past OpenAI's 8192-token embedding ceiling, so embedding=NULL and the
+// page fell out of vector search. v2 adds CJK char counting, CJK punctuation
+// delimiters, and a codepoint-slicing fallback so the chunker can ALWAYS
+// reduce a piece below the target word count.
+
+describe("countWords (CJK-aware)", () => {
+  test("ASCII whitespace-delimited", () => {
+    expect(countWords("hello world")).toBe(2);
+  });
+
+  test("pure CJK: each Han char counts as 1 word", () => {
+    expect(countWords("你好世界")).toBe(4);
+  });
+
+  test("mixed CJK + ASCII", () => {
+    // Han chars: 你, 好 (2). ASCII tokens after CJK is replaced by space:
+    // "hello   world" → 2. Total = 4.
+    expect(countWords("hello 你好 world")).toBe(4);
+  });
+
+  test("CJK punctuation is not in the CJK char range", () => {
+    // 。(U+3002) and ！(U+FF01) sit OUTSIDE 一-鿿, so they're not
+    // counted as CJK chars. After stripping the 6 Han chars, the leftover
+    // string "  。    ！  " contains 2 punctuation tokens picked up by \S+.
+    // Total = 6 Han + 2 standalone punctuation tokens = 8.
+    //
+    // This matches pre-v2 behavior for ASCII (lone "." would count as 1
+    // via \S+) and is intentional: punctuation drift in word count is
+    // tolerable; the chunker's correctness depends on CJK chars being
+    // counted, not on punctuation being excluded.
+    expect(countWords("你好。再見！謝謝")).toBe(8);
+  });
+
+  test("Japanese hiragana counts per char", () => {
+    // こ(U+3053) ん(U+3093) に(U+306B) ち(U+3061) は(U+306F) — all in 3040-309F.
+    expect(countWords("こんにちは")).toBe(5);
+  });
+
+  test("Korean hangul counts per char", () => {
+    // 안녕하세요 — all in AC00-D7AF.
+    expect(countWords("안녕하세요")).toBe(5);
+  });
+
+  test("empty / whitespace-only", () => {
+    expect(countWords("")).toBe(0);
+    expect(countWords("   ")).toBe(0);
+  });
+});
+
+describe("CJK delimiter splitting", () => {
+  test("splits long CJK paragraph at sentence boundaries (。)", () => {
+    // Repeat ~80 sentences of ~10 chars each → ~800 CJK chars, well above
+    // a chunkSize=50 target. Pre-v2 returned 1 chunk; v2 must split.
+    const sentence = "向量搜索系統正在初始化資料庫";
+    const text = Array.from({ length: 80 }, () => sentence + "。").join("");
+    const chunks = chunkText(text, { chunkSize: 50, chunkOverlap: 0 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    // Most chunks should end in 。 (sentence boundary), proving the L2
+    // CJK delimiter is doing the work.
+    const sentenceEndingChunks = chunks.filter((c) => c.text.endsWith("。"));
+    expect(sentenceEndingChunks.length).toBeGreaterThan(chunks.length / 2);
+  });
+
+  test("falls back to clause delimiters (，) when no sentence breaks exist", () => {
+    // No 。 — only commas. Should still split at L3.
+    const clause = "資料庫連線錯誤需要檢查環境變數";
+    const text = Array.from({ length: 60 }, () => clause).join("，");
+    const chunks = chunkText(text, { chunkSize: 30, chunkOverlap: 0 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+});
+
+describe("script-aware level-4 fallback", () => {
+  test("dense CJK with NO delimiters still splits via codepoint slicing", () => {
+    // 5000 Han chars, no spaces, no punctuation. Pre-v2: 1 chunk.
+    // v2: codepoint-slicing fallback at level 4 must produce many chunks,
+    // each <= chunkSize chars (since 1 CJK char == 1 word).
+    const text = "字".repeat(5000);
+    const chunks = chunkText(text, { chunkSize: 300, chunkOverlap: 0 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      // greedyMerge allows up to 1.5x target, so 450 codepoints is the
+      // practical ceiling. Use a generous bound to keep this stable
+      // across implementation tweaks.
+      expect(Array.from(chunk.text).length).toBeLessThanOrEqual(500);
+    }
+  });
+
+  test("8000-char CJK paragraph (the bug repro) produces small chunks", () => {
+    // This is the exact failure mode we saw in production: an 8000-char
+    // Chinese paragraph that the chunker returned as 1 chunk, which then
+    // exceeded OpenAI's 8192-token embedding limit.
+    const text = "一二三四五六七八九十".repeat(800); // 8000 chars
+    const chunks = chunkText(text, { chunkSize: 300, chunkOverlap: 50 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    // Each chunk should be well under 600 chars (which at ~1 token/char
+    // for Han is well under the 8192 limit with comfortable margin).
+    for (const chunk of chunks) {
+      expect(Array.from(chunk.text).length).toBeLessThan(600);
+    }
+  });
+});
+
+describe("script-aware fallback does not regress ASCII behavior", () => {
+  test("English-heavy text still splits on whitespace", () => {
+    // Pre-v2 behavior: long whitespace-delimited English splits cleanly.
+    // We must not regress this.
+    const text = "word ".repeat(500).trim();
+    const chunks = chunkText(text, { chunkSize: 50, chunkOverlap: 0 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    // Lossless: every original word should appear in some chunk.
+    const reconstructed = chunks.map((c) => c.text).join(" ");
+    expect(reconstructed.match(/word/g)?.length).toBe(500);
+  });
+
+  test("mixed CJK + English content chunks reasonably", () => {
+    const segment = "This is English text. 這是中文段落。";
+    const text = segment.repeat(100);
+    const chunks = chunkText(text, { chunkSize: 50, chunkOverlap: 0 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    // Lossless on the non-overlapping path: English words preserved.
+    const reconstructed = chunks.map((c) => c.text).join(" ");
+    expect(reconstructed).toContain("This is English");
+    expect(reconstructed).toContain("這是中文段落");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// v2 fix-on-review — codex caught two regressions in the v2 ship:
+//   1. CJK delimiter ordering (P1.1): '。' listed before '。\n' caused the
+//      trailing newline to leak into the next piece, where trim() dropped
+//      it. Symptom: rejoined chunks are shorter than the original by 1
+//      char per CJK sentence boundary.
+//   2. Token-budget miss for non-BMP / emoji / combining text (P1.2):
+//      countWords returned 1 for inputs like emoji ZWJ, decomposed
+//      Latin, and Han Extension B (non-BMP). chunkText's
+//      `wordCount <= chunkSize` early exit then returned a single
+//      multi-thousand-codepoint chunk, blowing the embedding limit.
+// ---------------------------------------------------------------------------
+
+describe("CJK lossless invariant (delimiter ordering)", () => {
+  test("CJK with '。\\n' separators: rejoined length within bounded trim() delta of original", () => {
+    // Pre-fix: '。' matched first at the boundary, the trailing '\n' became
+    // the head of the next piece, then trim() dropped it. Across 40
+    // sentences that's 20+ lost newlines on the non-overlap path.
+    const sentence = "甲乙丙丁戊己庚辛壬癸。\n";
+    const original = sentence.repeat(40);
+    const chunks = chunkText(original, { chunkSize: 30, chunkOverlap: 0 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+
+    const rejoined = chunks.map((c) => c.text).join("");
+
+    // Why this is a bounded-delta check, not strict equality:
+    //   chunkText runs `.trim()` on every emitted chunk (pre-existing,
+    //   independent of this fix). That always strips at most a small
+    //   constant of outer whitespace per chunk boundary — typically the
+    //   trailing `\n` of a sentence that landed at the chunk edge. So
+    //   per-chunk trim contributes O(chunks.length) chars of loss; the
+    //   docstring on src/core/chunkers/recursive.ts calls this out
+    //   explicitly ("no semantic loss", not "byte-exact reassembly").
+    //
+    //   The DELIMITER-ordering bug we're guarding against was different:
+    //   it leaked a `\n` from sentence N into the head of piece N+1,
+    //   where the *inner* trim in splitAtDelimiters dropped it before
+    //   the chunk was even formed — a once-per-sentence content drift,
+    //   far above the chunk-count budget. Hence the budget below.
+    const lossBudget = chunks.length * 2;
+    expect(original.length - rejoined.length).toBeLessThanOrEqual(lossBudget);
+
+    // Stronger assertion: every '。' in the original survives intact in
+    // the joined chunks (this is the load-bearing CJK boundary).
+    const originalSentenceTerminators = (original.match(/。/g) || []).length;
+    const rejoinedSentenceTerminators = (rejoined.match(/。/g) || []).length;
+    expect(rejoinedSentenceTerminators).toBe(originalSentenceTerminators);
+  });
+});
+
+describe("codepoint-budget floor for degenerate inputs", () => {
+  // Each repro pre-fix returned chunks=1 and a single 7000+ codepoint chunk
+  // that OpenAI rejects with "input array exceeds 8192 tokens". Post-fix:
+  // countWords' codepoint floor forces the chunker into splitOnWhitespace's
+  // codepoint-slicing branch, producing many small chunks.
+
+  test("emoji ZWJ sequences split into many small chunks", () => {
+    // U+1F468 U+200D U+1F469 U+200D U+1F467 U+200D U+1F466 — 7 codepoints
+    // per "family". 1000 reps = 7000 codepoints, no whitespace, no CJK.
+    const text = "\u{1F468}‍\u{1F469}‍\u{1F467}‍\u{1F466}".repeat(1000);
+    const chunks = chunkText(text, { chunkSize: 300, chunkOverlap: 0 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(Array.from(chunk.text).length).toBeLessThan(600);
+    }
+  });
+
+  test("combining marks (decomposed Latin) split", () => {
+    // 'é' as the decomposed pair e + U+0301 = 2 codepoints. 2000 reps =
+    // 4000 codepoints. No whitespace. No CJK. Pre-fix: 1 chunk.
+    const text = "é".repeat(2000);
+    const chunks = chunkText(text, { chunkSize: 300, chunkOverlap: 0 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(Array.from(chunk.text).length).toBeLessThan(600);
+    }
+  });
+
+  test("non-BMP CJK (Han Extension B) splits even though CJK_RE misses it", () => {
+    // U+20000 sits OUTSIDE the U+4E00-U+9FFF block CJK_RE matches, so
+    // cjkCount is 0. As a single token of 1000 codepoints with no
+    // whitespace, base count is 1 — the codepoint floor saves it.
+    const text = "\u{20000}".repeat(1000);
+    const chunks = chunkText(text, { chunkSize: 300, chunkOverlap: 0 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(Array.from(chunk.text).length).toBeLessThan(600);
+    }
+  });
+
+  test("countWords floor does not regress short ASCII inputs", () => {
+    // Sanity: 'hello' has no whitespace and no CJK, so the codepoint
+    // path applies. But 5 << default chunkSize=300, so the early-exit
+    // still fires and we get a single chunk. The floor is meant to
+    // promote DEGENERATE long inputs, not short words.
+    expect(chunkText("hello").length).toBe(1);
+    expect(chunkText("word").length).toBe(1);
+  });
+
+  test("countWords floor does not regress long whitespace ASCII", () => {
+    // 500 space-delimited words must still chunk via the whitespace
+    // branch (lossless reconstruction of every 'word' token). The floor
+    // is gated on `!/\s/.test(text.trim())`, so this path is untouched.
+    const text = "word ".repeat(500).trim();
+    const chunks = chunkText(text, { chunkSize: 50, chunkOverlap: 0 });
+    expect(chunks.length).toBeGreaterThan(1);
+    const rejoined = chunks.map((c) => c.text).join(" ");
+    expect((rejoined.match(/word/g) || []).length).toBe(500);
+  });
+});
+
+describe("PROSE_CHUNKER_VERSION + content_hash invalidation", () => {
+  test("PROSE_CHUNKER_VERSION is exported and >= 2", () => {
+    expect(typeof PROSE_CHUNKER_VERSION).toBe("number");
+    expect(PROSE_CHUNKER_VERSION).toBeGreaterThanOrEqual(2);
+  });
+
+  test("content_hash differs when PROSE_CHUNKER_VERSION changes", () => {
+    // Mirror import-file.ts hashing shape so we can prove the version
+    // participates in the hash (the actual import-file.ts hashing pulls
+    // in the live constant; here we simulate two values to show the
+    // hash function genuinely depends on it).
+    const sharedFields = {
+      title: "test page",
+      type: "page" as const,
+      compiled_truth: "你好世界",
+      timeline: "",
+      frontmatter: {},
+      tags: [],
+    };
+
+    const hashV1 = createHash("sha256")
+      .update(JSON.stringify({ ...sharedFields, prose_chunker_version: 1 }))
+      .digest("hex");
+    const hashV2 = createHash("sha256")
+      .update(JSON.stringify({ ...sharedFields, prose_chunker_version: 2 }))
+      .digest("hex");
+
+    expect(hashV1).not.toBe(hashV2);
   });
 });


### PR DESCRIPTION
Closes #648.

## Summary

`countWords` in `src/core/chunkers/recursive.ts` currently returns `(text.match(/\S+/g) || []).length`, treating any whitespace-free CJK paragraph as a single "word." With `chunkSize=300`, a 5000-character Chinese page returns 1 word ≤ 300, so `chunkText()` returns the entire content as **one chunk**. That single chunk goes to OpenAI embeddings, which hard-rejects input > 8192 tokens. Production brain hit this for ~158 markdown pages (mostly meeting transcripts / 逐字稿) — chunks created with `embedding = NULL`, vector search misses them, BM25 still works.

Even fixing `countWords` alone is insufficient: `DELIMITERS` is ASCII-only (`. `, `; `, `, `), so dense CJK prose still has no boundary to split on. And existing affected pages won't auto-recover unless a chunker version bump invalidates the old `chunker_version` row in `sources`.

## 4-piece fix

1. **`countWords` CJK-aware** — count CJK chars individually (regex matches existing `expansion.ts:56` byte-for-byte: `[一-鿿぀-ゟ゠-ヿ가-힯]`). Plus a codepoint-count floor for non-whitespace + non-CJK-regex text (emoji ZWJ, combining marks, Han Extension B) so degenerate inputs always reach the level-4 fallback.

2. **`DELIMITERS` add CJK punctuation** — level 2 sentences gain `。`, `！`, `？` + their `\n` variants; level 3 clauses gain `；`, `：`, `，`, `、`. Ordering: longer-first within each level (`。\n` before `。`) so `splitAtDelimiters`' tie-break doesn't leak `\n` into the next piece.

3. **Script-aware level-4 fallback** — `splitOnWhitespace` now uses `Array.from(text)` codepoint slicing for CJK / no-space text, preserving surrogate pairs (Han Ext-B, emoji ZWJ). ASCII baseline unchanged.

4. **Chunker version reach** — introduces `currentChunkerVersionTag()` returning `code:N|prose:M`. The four `writeChunkerVersion` call sites in `sync.ts` plus the `up_to_date` gate read this composite tag. Existing brains at `chunker_version="4"` mismatch new `code:4|prose:2` and re-walk once on next sync. `PROSE_CHUNKER_VERSION` is also folded into `import-file.ts`'s content_hash as belt-and-suspenders for the put_page path. **Note**: `sources.chunker_version` is `TEXT`, no schema migration needed; one-time mass re-embed cost on first sync after upgrade.

## Pre-existing trim() boundary behavior

The chunker's per-chunk `text.trim()` strips delimiter whitespace at chunk boundaries (e.g. trailing `\n` after a sentence-ending `。`). This is unchanged from before; the original "Lossless invariant" docstring overstated reality. Header is updated to honestly describe bounded outer-whitespace loss, distinct from the new delimiter ordering bug. The new lossless-invariant test asserts bounded delta (delta ≤ 2× chunk count) with an inline comment explaining the trim() distinction.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test test/chunkers/recursive.test.ts` — 36 pass / 0 fail / 176 expects (15 new tests + existing)
- [x] `bun test test/chunker-version-gate.test.ts` — 3 pass (existing CHUNKER_VERSION constant test still valid; composite tag is internal to sync.ts)
- [x] `bun test test/incremental-chunking.test.ts` subset green
- [x] Codex review thread `019df88a-33b6-7f22-aa25-ebee59788844`: round 1 ⛔ found 1 P0 (chunker version reach) + 2 P1 (DELIMITERS ordering, non-BMP miss) + 1 P2 (test gaps); round 2 ⛔ found 1 P1 (docstring honesty); round 3 ✅ Ready (1 stale test title fixed in round 4)
- [ ] (post-merge) `gbrain doctor --chunker-version` on a brain at v0.26 should report mismatch on first sync; subsequent syncs report `up_to_date`
- [ ] (post-merge) Chinese-only brains' `embedding IS NULL` chunk count drops to 0 after one full re-walk

## Repros (all now produce multiple chunks ≤ chunkSize codepoints)

```
'甲乙'.repeat(2500)         — was 1 chunk @ 5000 codepoints; now 17 chunks ≤ 300
'👨‍👩‍👧‍👦'.repeat(1000) — was 1 chunk; now 23 chunks ≤ 400 codepoints
'é'.repeat(2000)             — was 1 chunk; now 13 chunks ≤ 400 codepoints
'𠀀'.repeat(1000)            — was 1 chunk; now 3 chunks ≤ 400 codepoints
('甲乙丙丁戊己庚辛壬癸。\n').repeat(40) — every '。' preserved, bounded trim()-induced delta of one '\n' per chunk
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->