### PR TITLE
feat(mcp): add source_id param to put_page and get_page

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -136,7 +136,7 @@ export interface BrainEngine {
    * by `restore_page` flow, and by operator diagnostics.
    */
   getPage(slug: string, opts?: GetPageOpts): Promise<Page | null>;
-  putPage(slug: string, page: PageInput): Promise<Page>;
+  putPage(slug: string, page: PageInput, sourceId?: string): Promise<Page>;
   /**
    * Hard-delete a page row. Cascades to content_chunks, page_links,
    * chunk_relations via existing FK ON DELETE CASCADE.

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -185,7 +185,7 @@ export async function importFromContent(
   engine: BrainEngine,
   slug: string,
   content: string,
-  opts: { noEmbed?: boolean } = {},
+  opts: { noEmbed?: boolean; sourceId?: string } = {},
 ): Promise<ImportResult> {
   // Reject oversized payloads before any parsing, chunking, or embedding happens.
   // Uses Buffer.byteLength to count UTF-8 bytes the same way disk size would,
@@ -223,7 +223,7 @@ export async function importFromContent(
     tags: parsed.tags,
   };
 
-  const existing = await engine.getPage(slug);
+  const existing = await engine.getPage(slug, { sourceId: opts.sourceId });
   if (existing?.content_hash === hash) {
     return { slug, status: 'skipped', chunks: 0, parsedPage };
   }
@@ -270,7 +270,7 @@ export async function importFromContent(
       timeline: parsed.timeline || '',
       frontmatter: parsed.frontmatter,
       content_hash: hash,
-    });
+    }, opts.sourceId);
 
     // Tag reconciliation: remove stale, add current
     const existingTags = await tx.getTags(slug);

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -294,6 +294,33 @@ export interface Operation {
 
 // --- Page CRUD ---
 
+async function assertSourceExists(ctx: OperationContext, sourceId: string): Promise<void> {
+  const rows = await ctx.engine.executeRaw<{ id: string }>(
+    'SELECT id FROM sources WHERE id = $1 LIMIT 1',
+    [sourceId],
+  );
+  if (rows.length === 0) {
+    throw new OperationError(
+      'invalid_params',
+      `Unknown source_id: ${sourceId}`,
+      `Register the source first with: gbrain sources add ${sourceId} --path <path>`,
+    );
+  }
+}
+
+async function getPageTags(ctx: OperationContext, slug: string, sourceId?: string): Promise<string[]> {
+  if (!sourceId) return ctx.engine.getTags(slug);
+  const rows = await ctx.engine.executeRaw<{ tag: string }>(
+    `SELECT t.tag
+     FROM tags t
+     JOIN pages p ON p.id = t.page_id
+     WHERE p.slug = $1 AND p.source_id = $2
+     ORDER BY t.tag`,
+    [slug, sourceId],
+  );
+  return rows.map(r => r.tag);
+}
+
 const get_page: Operation = {
   name: 'get_page',
   description: 'Read a page by slug (supports optional fuzzy matching). Soft-deleted pages are hidden by default; pass include_deleted: true to surface them with deleted_at populated (see v0.26.5 recovery window).',
@@ -301,19 +328,21 @@ const get_page: Operation = {
     slug: { type: 'string', required: true, description: 'Page slug' },
     fuzzy: { type: 'boolean', description: 'Enable fuzzy slug resolution (default: false)' },
     include_deleted: { type: 'boolean', description: 'v0.26.5: surface soft-deleted pages with deleted_at populated (default: false). Used by restore workflows.' },
+    source_id: { type: 'string', required: false, description: 'Source to read from. Defaults to "default". Must be a registered source.' },
   },
   handler: async (ctx, p) => {
     const slug = p.slug as string;
     const fuzzy = (p.fuzzy as boolean) || false;
     const includeDeleted = (p.include_deleted as boolean) === true;
+    const sourceId = ((p.source_id || p.source) as string | undefined) || undefined;
 
-    let page = await ctx.engine.getPage(slug, { includeDeleted });
+    let page = await ctx.engine.getPage(slug, { includeDeleted, sourceId });
     let resolved_slug: string | undefined;
 
     if (!page && fuzzy) {
       const candidates = await ctx.engine.resolveSlugs(slug);
       if (candidates.length === 1) {
-        page = await ctx.engine.getPage(candidates[0], { includeDeleted });
+        page = await ctx.engine.getPage(candidates[0], { includeDeleted, sourceId });
         resolved_slug = candidates[0];
       } else if (candidates.length > 1) {
         return { error: 'ambiguous_slug', candidates };
@@ -324,7 +353,7 @@ const get_page: Operation = {
       throw new OperationError('page_not_found', `Page not found: ${slug}`, includeDeleted ? 'Check the slug or use fuzzy: true' : 'Page may be soft-deleted; pass include_deleted: true to verify');
     }
 
-    const tags = await ctx.engine.getTags(page.slug);
+    const tags = await getPageTags(ctx, page.slug, sourceId);
     return { ...page, tags, ...(resolved_slug ? { resolved_slug } : {}) };
   },
   scope: 'read',
@@ -337,11 +366,13 @@ const put_page: Operation = {
   params: {
     slug: { type: 'string', required: true, description: 'Page slug' },
     content: { type: 'string', required: true, description: 'Full markdown content with YAML frontmatter' },
+    source_id: { type: 'string', required: false, description: 'Source to write into. Defaults to "default". Must be a registered source.' },
   },
   mutating: true,
   scope: 'write',
   handler: async (ctx, p) => {
     const slug = p.slug as string;
+    const sourceId = ((p.source_id || p.source) as string | undefined) || undefined;
 
     // Subagent namespace enforcement (v0.15+). Runs BEFORE the dry-run
     // short-circuit so preview calls surface the same rejection. Confines
@@ -377,12 +408,13 @@ const put_page: Operation = {
     }
 
     if (ctx.dryRun) return { dry_run: true, action: 'put_page', slug: p.slug };
+    if (sourceId) await assertSourceExists(ctx, sourceId);
     // Skip embedding when the AI gateway has no embedding provider configured.
     // Checks all auth env vars for the resolved provider, not just OPENAI_API_KEY,
     // so Gemini / Ollama / Voyage brains don't silently drop embeddings (Codex C2).
     const { isAvailable } = await import('./ai/gateway.ts');
     const noEmbed = !isAvailable('embedding');
-    const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed });
+    const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed, sourceId });
 
     // Auto-link post-hook: runs AFTER importFromContent (which is its own
     // transaction). Runs even on status='skipped' so reconciliation catches drift

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -371,10 +371,11 @@ export class PGLiteEngine implements BrainEngine {
     return rowToPage(rows[0] as Record<string, unknown>);
   }
 
-  async putPage(slug: string, page: PageInput): Promise<Page> {
+  async putPage(slug: string, page: PageInput, sourceId?: string): Promise<Page> {
     slug = validateSlug(slug);
     const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
+    const sid = sourceId || 'default';
 
     // v0.18.0 Step 2: source_id relies on the schema DEFAULT 'default' so
     // existing callers still target the default source without threading
@@ -383,8 +384,8 @@ export class PGLiteEngine implements BrainEngine {
     // surface an explicit sourceId param on putPage for multi-source sync.
     const pageKind = page.page_kind || 'markdown';
     const { rows } = await this.db.query(
-      `INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, now())
+      `INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, source_id, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, now())
        ON CONFLICT (source_id, slug) DO UPDATE SET
          type = EXCLUDED.type,
          page_kind = EXCLUDED.page_kind,
@@ -395,7 +396,7 @@ export class PGLiteEngine implements BrainEngine {
          content_hash = EXCLUDED.content_hash,
          updated_at = now()
        RETURNING id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at`,
-      [slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash]
+      [slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash, sid]
     );
     return rowToPage(rows[0] as Record<string, unknown>);
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -322,11 +322,12 @@ export class PostgresEngine implements BrainEngine {
     return rowToPage(rows[0]);
   }
 
-  async putPage(slug: string, page: PageInput): Promise<Page> {
+  async putPage(slug: string, page: PageInput, sourceId?: string): Promise<Page> {
     slug = validateSlug(slug);
     const sql = this.sql;
     const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
+    const sid = sourceId || 'default';
 
     // v0.18.0 Step 2: source_id relies on schema DEFAULT 'default'. ON
     // CONFLICT target becomes (source_id, slug) since global UNIQUE(slug)
@@ -334,8 +335,8 @@ export class PostgresEngine implements BrainEngine {
     // notes; multi-source sync (Step 5) will surface an explicit sourceId.
     const pageKind = page.page_kind || 'markdown';
     const rows = await sql`
-      INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
-      VALUES (${slug}, ${page.type}, ${pageKind}, ${page.title}, ${page.compiled_truth}, ${page.timeline || ''}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now())
+      INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, source_id, updated_at)
+      VALUES (${slug}, ${page.type}, ${pageKind}, ${page.title}, ${page.compiled_truth}, ${page.timeline || ''}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, ${sid}, now())
       ON CONFLICT (source_id, slug) DO UPDATE SET
         type = EXCLUDED.type,
         page_kind = EXCLUDED.page_kind,

--- a/test/source-id-mcp.test.ts
+++ b/test/source-id-mcp.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect, beforeAll, beforeEach, afterAll } from 'bun:test';
+import { operationsByName, OperationError, type OperationContext } from '../src/core/operations.ts';
+import { setupDB, teardownDB, getConn, getEngine } from './e2e/helpers.ts';
+
+const DATABASE_URL = process.env.DATABASE_URL || '';
+const SAFE_TEST_DB = /localhost:5434\/gbrain_test(?:\?|$)/.test(DATABASE_URL);
+
+if (DATABASE_URL && !SAFE_TEST_DB) {
+  throw new Error(`Refusing to run source-id MCP tests against non-test DATABASE_URL: ${DATABASE_URL}`);
+}
+
+const describeDb = SAFE_TEST_DB ? describe : describe.skip;
+
+function makeCtx(): OperationContext {
+  return {
+    engine: getEngine(),
+    config: { engine: 'postgres' } as any,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    dryRun: false,
+    remote: true,
+  };
+}
+
+describeDb('MCP source_id routing for put_page/get_page', () => {
+  beforeAll(async () => {
+    await setupDB();
+  });
+
+  beforeEach(async () => {
+    const conn = getConn();
+    await conn.unsafe(`DELETE FROM pages`);
+    await conn.unsafe(`DELETE FROM sources WHERE id != 'default'`);
+    await conn.unsafe(
+      `INSERT INTO sources (id, name) VALUES ('testsrc', 'testsrc') ON CONFLICT (id) DO NOTHING`,
+    );
+  });
+
+  afterAll(async () => {
+    await teardownDB();
+  });
+
+  test('put_page with explicit source_id writes to that source', async () => {
+    const putPage = operationsByName.put_page;
+    await putPage.handler(makeCtx(), {
+      slug: 'test/source-explicit',
+      content: '# Explicit Source\n\nbody',
+      source_id: 'testsrc',
+    });
+
+    const rows = await getConn().unsafe(
+      `SELECT source_id, slug FROM pages WHERE slug = 'test/source-explicit'`,
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].source_id).toBe('testsrc');
+  });
+
+  test('get_page with source_id returns the page from that source', async () => {
+    const engine = getEngine();
+    await engine.putPage('test/shared', {
+      type: 'note' as any,
+      title: 'Default',
+      compiled_truth: 'default body',
+      timeline: '',
+      frontmatter: {},
+    });
+    await engine.putPage('test/shared', {
+      type: 'note' as any,
+      title: 'Source',
+      compiled_truth: 'source body',
+      timeline: '',
+      frontmatter: {},
+    }, 'testsrc');
+
+    const getPage = operationsByName.get_page;
+    const result = await getPage.handler(makeCtx(), {
+      slug: 'test/shared',
+      source_id: 'testsrc',
+    }) as { title: string; compiled_truth: string };
+
+    expect(result.title).toBe('Source');
+    expect(result.compiled_truth).toBe('source body');
+  });
+
+  test('put_page without source_id preserves default-source behavior', async () => {
+    const putPage = operationsByName.put_page;
+    await putPage.handler(makeCtx(), {
+      slug: 'test/default-source',
+      content: '# Default Source\n\nbody',
+    });
+
+    const rows = await getConn().unsafe(
+      `SELECT source_id FROM pages WHERE slug = 'test/default-source'`,
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].source_id).toBe('default');
+  });
+
+  test('put_page with unknown source_id throws OperationError', async () => {
+    const putPage = operationsByName.put_page;
+    const promise = putPage.handler(makeCtx(), {
+      slug: 'test/bad-source',
+      content: '# Bad Source\n\nbody',
+      source_id: 'missing-source',
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(OperationError);
+    await expect(promise).rejects.toThrow(/Unknown source_id: missing-source/);
+  });
+});


### PR DESCRIPTION
## Problem
MCP callers cannot specify which source to write to. put_page always writes to source_id='default' even when other sources are registered.

## Solution
Add optional source_id param to put_page and get_page. Backward compatible — omitting source_id preserves existing behavior.

## Testing
New test file: test/source-id-mcp.test.ts

Validated against an isolated local Postgres test cluster on localhost:5434/gbrain_test (not the production database):
- DATABASE_URL="postgresql://postgres:postgres@localhost:5434/gbrain_test" bun test test/source-id-mcp.test.ts --timeout=60000 — 4 pass / 0 fail
- bun run typecheck — pass
- bun run build — pass
- CLI smoke against localhost:5434/gbrain_test: sources add, put --source, get --source — pass

Notes:
- The requested Docker setup was unavailable in this environment (docker/docker-compose not installed), so the Postgres test DB was created with a temporary local cluster on port 5434.
- Full suite with DATABASE_URL set is not clean in this local environment due unrelated environment-sensitive tests (BrainRegistry host init with DATABASE_URL and check-resolvable detecting ~/.openclaw/workspace).
- The compiled PGLite smoke is blocked before this patch path by the existing PGLite WASM bundle error: ENOENT //root/pglite.data.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->