### PR TITLE
fix: call initSchema() in connectEngine() to auto-apply migrations on serve

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -646,6 +646,7 @@ async function connectEngine(): Promise<BrainEngine> {
                   process.env.GBRAIN_NO_RETRY_CONNECT === '1';
   const { connectWithRetry } = await import('./core/db.ts');
   await connectWithRetry(engine, toEngineConfig(config), { noRetry });
+  await engine.initSchema(); // idempotent; fixes #651
   return engine;
 }
 


### PR DESCRIPTION
## Problem

When `gbrain serve` starts, it calls `connectEngine()` → `engine.connect()` but **never calls `initSchema()`**. This means schema migrations (including forward-reference bootstrap columns like `deleted_at`, `agent_name`, `source_id`) are never applied on serve startup.

If a brain was created with an older gbrain version, serving with a newer version causes runtime errors:
```
column "deleted_at" does not exist
```

## Root Cause

`initSchema()` was only called from `gbrain init` (3 call sites in `init.ts`), but not from the serve flow. The `connectEngine()` function in `cli.ts` creates the engine and connects, but skips schema initialization.

## Fix

Add `await engine.initSchema()` to `connectEngine()` in `cli.ts`, right after `connectWithRetry()`. 

This is safe because:
- `initSchema()` is **idempotent** — it uses `IF NOT EXISTS` for all DDL operations
- `applyForwardReferenceBootstrap()` is a no-op on fresh installs and modern brains
- `runMigrations()` skips already-applied migrations
- Commands like `gbrain init` that call `initSchema()` themselves use an early return path before reaching `connectEngine()`
- The overhead is minimal (one probe query + conditional ADD COLUMN IF NOT EXISTS)

## Testing

- Verified on an existing brain with v0.22 schema: 29 pending migrations applied successfully
- `gbrain stats` now returns correct data without errors
- `gbrain doctor` passes all checks

Fixes: #651

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->