### PR TITLE
feat(auth): per-API-key default source pinning

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -64,24 +64,94 @@ async function create(name: string) {
 async function list() {
   const sql = postgres(getDatabaseUrl(true)!);
   try {
-    const rows = await sql`
-      SELECT name, created_at, last_used_at, revoked_at
-      FROM access_tokens
-      ORDER BY created_at DESC
-    `;
+    // v39: surface default_source_id so operators can audit per-API-key
+    // source pins without dropping into psql. Pre-v39 brains lack the
+    // column — fall back to the legacy SELECT shape.
+    let rows: any[];
+    try {
+      rows = await sql`
+        SELECT name, created_at, last_used_at, revoked_at, default_source_id
+        FROM access_tokens
+        ORDER BY created_at DESC
+      `;
+    } catch (e: any) {
+      if (e?.code === '42703') {
+        rows = await sql`
+          SELECT name, created_at, last_used_at, revoked_at
+          FROM access_tokens
+          ORDER BY created_at DESC
+        `;
+      } else {
+        throw e;
+      }
+    }
     if (rows.length === 0) {
       console.log('No tokens found. Create one: bun run src/commands/auth.ts create "my-client"');
       return;
     }
-    console.log('Name                  Created              Last Used            Status');
-    console.log('─'.repeat(80));
+    console.log('Name                  Created              Last Used            Default Source        Status');
+    console.log('─'.repeat(110));
     for (const r of rows) {
       const name = (r.name as string).padEnd(20);
       const created = new Date(r.created_at as string).toISOString().slice(0, 19);
       const lastUsed = r.last_used_at ? new Date(r.last_used_at as string).toISOString().slice(0, 19) : 'never'.padEnd(19);
+      const src = ((r.default_source_id as string | null) ?? '—').padEnd(20);
       const status = r.revoked_at ? 'REVOKED' : 'active';
-      console.log(`${name}  ${created}  ${lastUsed}  ${status}`);
+      console.log(`${name}  ${created}  ${lastUsed}  ${src}  ${status}`);
     }
+  } finally {
+    await sql.end();
+  }
+}
+
+/**
+ * Pin a legacy API key (access_tokens row) to a default source.
+ *
+ * Mirror of `setSource` (OAuth clients) for the legacy access_tokens table.
+ * Pass a real `source_id` to pin: subsequent put_page / get_page calls
+ * authenticated with that API key default to the pinned source unless the
+ * request supplies an explicit `source_id` param. Pass the literal string
+ * `none` (or an empty string) to clear the pin and fall back to source
+ * 'default'.
+ *
+ * Validates that the source exists before writing, so a typo can't silently
+ * pin to a nonexistent source. The schema FK has ON DELETE SET NULL, so a
+ * later source-delete unpins automatically.
+ */
+async function setSourceKey(name: string, sourceId: string) {
+  if (!name || sourceId === undefined) {
+    console.error('Usage: gbrain auth set-source-key <name> <source_id|none>');
+    process.exit(1);
+  }
+  const sql = postgres(getDatabaseUrl(true)!);
+  try {
+    const clear = sourceId === 'none' || sourceId === '';
+    if (!clear) {
+      const [src] = await sql`SELECT id FROM sources WHERE id = ${sourceId} LIMIT 1`;
+      if (!src) {
+        console.error(`No source found with id "${sourceId}". Use \`gbrain sources list\` to see available sources.`);
+        process.exit(1);
+      }
+    }
+    const newValue = clear ? null : sourceId;
+    const rows = await sql`
+      UPDATE access_tokens SET default_source_id = ${newValue}
+      WHERE name = ${name} AND revoked_at IS NULL
+      RETURNING name, default_source_id
+    `;
+    if (rows.length === 0) {
+      console.error(`No active API key found with name "${name}".`);
+      process.exit(1);
+    }
+    if (clear) {
+      console.log(`Cleared default source for API key "${name}".`);
+      console.log('Subsequent requests fall back to source \'default\' (or explicit params.source_id).');
+    } else {
+      console.log(`API key "${name}" now defaults to source "${sourceId}".`);
+    }
+  } catch (e: any) {
+    console.error('Error:', e.message);
+    process.exit(1);
   } finally {
     await sql.end();
   }
@@ -378,6 +448,7 @@ export async function runAuth(args: string[]): Promise<void> {
     case 'list': await list(); return;
     case 'list-clients': await listClients(); return;
     case 'set-source': await setSource(rest[0], rest[1]); return;
+    case 'set-source-key': await setSourceKey(rest[0], rest[1]); return;
     case 'revoke': await revoke(rest[0]); return;
     case 'register-client': await registerClient(rest[0], rest.slice(1)); return;
     case 'revoke-client': await revokeClient(rest[0]); return;
@@ -395,7 +466,8 @@ Usage:
   gbrain auth create <name>                                Create a legacy bearer token
   gbrain auth list                                         List all legacy tokens
   gbrain auth list-clients                                 List OAuth clients with default source pins (v37)
-  gbrain auth set-source <client_id> <source_id|none>      Pin OAuth client to a default source (v37). Use 'none' to clear.
+  gbrain auth set-source <client_id> <source_id|none>      Pin OAuth client to a default source (v38). Use 'none' to clear.
+  gbrain auth set-source-key <name> <source_id|none>       Pin legacy API key to a default source (v39). Use 'none' to clear.
   gbrain auth revoke <name>                                Revoke a legacy token
   gbrain auth register-client <name> [options]            Register an OAuth 2.1 client
      --grant-types <client_credentials,authorization_code> (default: client_credentials)

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -285,6 +285,88 @@ async function registerClient(name: string, args: string[]) {
 }
 
 /**
+ * Set (or clear) a per-OAuth-client default source pin (v37 migration).
+ *
+ * Pass a real `source_id` to pin: subsequent put_page / get_page calls from
+ * that OAuth client default to the pinned source unless the request supplies
+ * an explicit `source_id` param. Pass the literal string `none` (or an empty
+ * string) to clear the pin and fall back to source 'default'.
+ *
+ * Validates that the source exists before writing, so a typo can't silently
+ * pin to a nonexistent source. The schema FK has ON DELETE SET NULL, so a
+ * later source-delete unpins automatically.
+ */
+async function setSource(clientId: string, sourceId: string) {
+  if (!clientId || sourceId === undefined) {
+    console.error('Usage: gbrain auth set-source <client_id> <source_id|none>');
+    process.exit(1);
+  }
+  const sql = postgres(getDatabaseUrl(true)!);
+  try {
+    const clear = sourceId === 'none' || sourceId === '';
+    if (!clear) {
+      const [src] = await sql`SELECT id FROM sources WHERE id = ${sourceId} LIMIT 1`;
+      if (!src) {
+        console.error(`No source found with id "${sourceId}". Use \`gbrain sources list\` to see available sources.`);
+        process.exit(1);
+      }
+    }
+    const newValue = clear ? null : sourceId;
+    const rows = await sql`
+      UPDATE oauth_clients SET default_source_id = ${newValue}
+      WHERE client_id = ${clientId}
+      RETURNING client_id, client_name, default_source_id
+    `;
+    if (rows.length === 0) {
+      console.error(`No OAuth client found with id "${clientId}".`);
+      process.exit(1);
+    }
+    if (clear) {
+      console.log(`Cleared default source for OAuth client "${rows[0].client_name}" (${clientId}).`);
+      console.log('Subsequent requests fall back to source \'default\' (or explicit params.source_id).');
+    } else {
+      console.log(`OAuth client "${rows[0].client_name}" (${clientId}) now defaults to source "${sourceId}".`);
+    }
+  } catch (e: any) {
+    console.error('Error:', e.message);
+    process.exit(1);
+  } finally {
+    await sql.end();
+  }
+}
+
+/**
+ * List both legacy access_tokens and OAuth clients in a single table.
+ * Surfaces `default_source_id` (v37) so operators can audit per-client
+ * source pins without dropping into psql.
+ */
+async function listClients() {
+  const sql = postgres(getDatabaseUrl(true)!);
+  try {
+    const oauthRows = await sql`
+      SELECT client_id, client_name, default_source_id, created_at, deleted_at
+      FROM oauth_clients
+      ORDER BY created_at DESC
+    `;
+    if (oauthRows.length === 0) {
+      console.log('No OAuth clients registered. Create one: gbrain auth register-client "my-agent"');
+      return;
+    }
+    console.log('Client ID                                 Name                  Default Source        Status');
+    console.log('─'.repeat(110));
+    for (const r of oauthRows) {
+      const id = (r.client_id as string).padEnd(40);
+      const name = (r.client_name as string).slice(0, 20).padEnd(20);
+      const src = ((r.default_source_id as string | null) ?? '—').padEnd(20);
+      const status = r.deleted_at ? 'REVOKED' : 'active';
+      console.log(`${id}  ${name}  ${src}  ${status}`);
+    }
+  } finally {
+    await sql.end();
+  }
+}
+
+/**
  * Entry point for the `gbrain auth` CLI subcommand. Also reused by the
  * direct-script path (see bottom of file) so `bun run src/commands/auth.ts`
  * still works.
@@ -294,6 +376,8 @@ export async function runAuth(args: string[]): Promise<void> {
   switch (cmd) {
     case 'create': await create(rest[0]); return;
     case 'list': await list(); return;
+    case 'list-clients': await listClients(); return;
+    case 'set-source': await setSource(rest[0], rest[1]); return;
     case 'revoke': await revoke(rest[0]); return;
     case 'register-client': await registerClient(rest[0], rest.slice(1)); return;
     case 'revoke-client': await revokeClient(rest[0]); return;
@@ -309,7 +393,9 @@ export async function runAuth(args: string[]): Promise<void> {
 
 Usage:
   gbrain auth create <name>                                Create a legacy bearer token
-  gbrain auth list                                         List all tokens
+  gbrain auth list                                         List all legacy tokens
+  gbrain auth list-clients                                 List OAuth clients with default source pins (v37)
+  gbrain auth set-source <client_id> <source_id|none>      Pin OAuth client to a default source (v37). Use 'none' to clear.
   gbrain auth revoke <name>                                Revoke a legacy token
   gbrain auth register-client <name> [options]            Register an OAuth 2.1 client
      --grant-types <client_credentials,authorization_code> (default: client_credentials)

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -702,6 +702,12 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
         // belt; this is the suspenders.
         remote: true,
         auth: authInfo,
+        // v37: thread per-OAuth-client default source pin into the op context.
+        // Resolved by GBrainOAuthProvider.verifyAccessToken (above) from
+        // oauth_clients.default_source_id, so no extra DB roundtrip here.
+        // Source-aware ops (get_page, put_page) apply precedence:
+        //   params.source_id > ctx.defaultSourceId > 'default'
+        defaultSourceId: authInfo.defaultSourceId,
       };
 
       // F8: redact request payload by default (declared keys only via the

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -185,7 +185,7 @@ export async function importFromContent(
   engine: BrainEngine,
   slug: string,
   content: string,
-  opts: { noEmbed?: boolean } = {},
+  opts: { noEmbed?: boolean; sourceId?: string } = {},
 ): Promise<ImportResult> {
   // Reject oversized payloads before any parsing, chunking, or embedding happens.
   // Uses Buffer.byteLength to count UTF-8 bytes the same way disk size would,
@@ -223,7 +223,10 @@ export async function importFromContent(
     tags: parsed.tags,
   };
 
-  const existing = await engine.getPage(slug);
+  // v37: scope the dedupe lookup to the same source we'll write to. Without
+  // this, a put_page with sourceId='agent-A' would short-circuit on a
+  // matching hash from sourceId='default' and skip writing the agent-A row.
+  const existing = await engine.getPage(slug, opts.sourceId ? { sourceId: opts.sourceId } : undefined);
   if (existing?.content_hash === hash) {
     return { slug, status: 'skipped', chunks: 0, parsedPage };
   }
@@ -270,6 +273,7 @@ export async function importFromContent(
       timeline: parsed.timeline || '',
       frontmatter: parsed.frontmatter,
       content_hash: hash,
+      ...(opts.sourceId ? { source_id: opts.sourceId } : {}),
     });
 
     // Tag reconciliation: remove stale, add current

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -1535,6 +1535,28 @@ export const MIGRATIONS: Migration[] = [
         ON subagent_messages (job_id, provider_id);
     `,
   },
+  {
+    version: 38,
+    name: 'oauth_client_default_source_id',
+    // Per-OAuth-client default source pinning. When an OAuth client has a
+    // default_source_id configured, page writes/reads from that client are
+    // routed to that source unless the request explicitly overrides via
+    // params.source_id. Multi-agent deployments use this to give each agent
+    // its own brain-source without per-call configuration.
+    //
+    // FK with ON DELETE SET NULL: deleting a source clears the pin (request
+    // falls back to 'default') rather than orphaning the OAuth client.
+    // Idempotent (ADD COLUMN IF NOT EXISTS).
+    sql: `
+      ALTER TABLE oauth_clients
+        ADD COLUMN IF NOT EXISTS default_source_id TEXT
+        REFERENCES sources(id) ON DELETE SET NULL;
+
+      CREATE INDEX IF NOT EXISTS idx_oauth_clients_default_source
+        ON oauth_clients(default_source_id)
+        WHERE default_source_id IS NOT NULL;
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -1557,6 +1557,27 @@ export const MIGRATIONS: Migration[] = [
         WHERE default_source_id IS NOT NULL;
     `,
   },
+  {
+    version: 39,
+    name: 'access_token_default_source_id',
+    // Per-API-key default source pinning. Mirror of v38 (oauth_clients) for
+    // the legacy access_tokens table. API keys (no TTL) are preferred over
+    // OAuth tokens (TTL) for headless agent setups, so the same source-pin
+    // ergonomics need to land on the legacy path.
+    //
+    // FK with ON DELETE SET NULL: deleting a source clears the pin (request
+    // falls back to 'default') rather than orphaning the API key.
+    // Idempotent (ADD COLUMN IF NOT EXISTS).
+    sql: `
+      ALTER TABLE access_tokens
+        ADD COLUMN IF NOT EXISTS default_source_id TEXT
+        REFERENCES sources(id) ON DELETE SET NULL;
+
+      CREATE INDEX IF NOT EXISTS idx_access_tokens_default_source
+        ON access_tokens(default_source_id)
+        WHERE default_source_id IS NOT NULL;
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -429,11 +429,29 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
       } as AuthInfo;
     }
 
-    // Fallback: legacy access_tokens table (backward compat)
-    const legacyRows = await this.sql`
-      SELECT name FROM access_tokens
-      WHERE token_hash = ${tokenHash} AND revoked_at IS NULL
-    `;
+    // Fallback: legacy access_tokens table (backward compat).
+    // v39: include default_source_id so per-API-key source pinning is
+    // resolved at token-verify time without an extra request-time roundtrip.
+    // The column is nullable + ON DELETE SET NULL, so a deleted source
+    // surfaces as NULL here and the request falls back to 'default'.
+    let legacyRows: Record<string, unknown>[];
+    try {
+      legacyRows = await this.sql`
+        SELECT name, default_source_id FROM access_tokens
+        WHERE token_hash = ${tokenHash} AND revoked_at IS NULL
+      `;
+    } catch (e) {
+      // Pre-v39 brains lack default_source_id. Fall back to the legacy
+      // shape so verifyAccessToken keeps working before the migration runs.
+      if (isUndefinedColumnError(e, 'default_source_id')) {
+        legacyRows = await this.sql`
+          SELECT name FROM access_tokens
+          WHERE token_hash = ${tokenHash} AND revoked_at IS NULL
+        `;
+      } else {
+        throw e;
+      }
+    }
 
     if (legacyRows.length > 0) {
       // Legacy tokens get full admin access (grandfather in).
@@ -449,6 +467,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
         clientName: name,
         scopes: ['read', 'write', 'admin'],
         expiresAt: Math.floor(Date.now() / 1000) + 365 * 24 * 3600, // Legacy tokens never expire — set 1yr future
+        defaultSourceId: (legacyRows[0].default_source_id as string | null) ?? undefined,
       } as AuthInfo;
     }
 

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -381,12 +381,33 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     // verifyAccessToken returns client_name in AuthInfo — eliminates the
     // separate per-request lookup at serve-http.ts that was the N+1 hot
     // path (see PR #586 review D14=B).
-    const oauthRows = await this.sql`
-      SELECT t.client_id, t.scopes, t.expires_at, t.resource, c.client_name
-      FROM oauth_tokens t
-      LEFT JOIN oauth_clients c ON c.client_id = t.client_id
-      WHERE t.token_hash = ${tokenHash} AND t.token_type = 'access'
-    `;
+    // v37: include c.default_source_id so per-client source pinning is
+    // resolved at token-verify time without an extra request-time roundtrip.
+    // The column is nullable + ON DELETE SET NULL, so a deleted source
+    // surfaces as NULL here and the request falls back to 'default'.
+    let oauthRows: Record<string, unknown>[];
+    try {
+      oauthRows = await this.sql`
+        SELECT t.client_id, t.scopes, t.expires_at, t.resource,
+               c.client_name, c.default_source_id
+        FROM oauth_tokens t
+        LEFT JOIN oauth_clients c ON c.client_id = t.client_id
+        WHERE t.token_hash = ${tokenHash} AND t.token_type = 'access'
+      `;
+    } catch (e) {
+      // Pre-v37 brains lack default_source_id. Fall back to the legacy
+      // shape so verifyAccessToken keeps working before the migration runs.
+      if (isUndefinedColumnError(e, 'default_source_id')) {
+        oauthRows = await this.sql`
+          SELECT t.client_id, t.scopes, t.expires_at, t.resource, c.client_name
+          FROM oauth_tokens t
+          LEFT JOIN oauth_clients c ON c.client_id = t.client_id
+          WHERE t.token_hash = ${tokenHash} AND t.token_type = 'access'
+        `;
+      } else {
+        throw e;
+      }
+    }
 
     if (oauthRows.length > 0) {
       const row = oauthRows[0];
@@ -404,6 +425,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
         scopes: (row.scopes as string[]) || [],
         expiresAt,
         resource: row.resource ? new URL(row.resource as string) : undefined,
+        defaultSourceId: (row.default_source_id as string | null) ?? undefined,
       } as AuthInfo;
     }
 

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -193,6 +193,16 @@ export interface AuthInfo {
   clientName?: string;
   scopes: string[];
   expiresAt?: number;
+  /**
+   * Per-OAuth-client default source pin (v37 migration). When set, page
+   * writes/reads from this client are routed to this source unless the
+   * request supplies an explicit `source_id`. Resolved by
+   * `verifyAccessToken` from `oauth_clients.default_source_id` so the
+   * dispatcher doesn't pay an extra DB roundtrip per request.
+   *
+   * NULL/undefined means: fall back to legacy 'default' source.
+   */
+  defaultSourceId?: string;
 }
 
 export interface OperationContext {
@@ -274,6 +284,17 @@ export interface OperationContext {
    * working without change).
    */
   brainId?: string;
+  /**
+   * Per-OAuth-client default source pin (v37 migration). Threaded by
+   * `serve-http.ts` from `AuthInfo.defaultSourceId` after the OAuth
+   * verifier resolves the token. Consumed by source-aware operations
+   * (`get_page`, `put_page`) with the precedence:
+   *
+   *   params.source_id > ctx.defaultSourceId > 'default'
+   *
+   * Local CLI invocations leave this undefined (no OAuth client → no pin).
+   */
+  defaultSourceId?: string;
 }
 
 export interface Operation {
@@ -301,19 +322,30 @@ const get_page: Operation = {
     slug: { type: 'string', required: true, description: 'Page slug' },
     fuzzy: { type: 'boolean', description: 'Enable fuzzy slug resolution (default: false)' },
     include_deleted: { type: 'boolean', description: 'v0.26.5: surface soft-deleted pages with deleted_at populated (default: false). Used by restore workflows.' },
+    source_id: { type: 'string', description: 'v37: scope read to a specific source. Precedence: params.source_id > ctx.defaultSourceId (OAuth client pin) > unscoped (first match across sources).' },
   },
   handler: async (ctx, p) => {
     const slug = p.slug as string;
     const fuzzy = (p.fuzzy as boolean) || false;
     const includeDeleted = (p.include_deleted as boolean) === true;
 
-    let page = await ctx.engine.getPage(slug, { includeDeleted });
+    // v37 source precedence: params.source_id > ctx.defaultSourceId > undefined.
+    // undefined means "first match across sources" (pre-v37 semantics) so
+    // single-source brains and untagged OAuth clients keep working unchanged.
+    const sourceId = (typeof p.source_id === 'string' && p.source_id) ? p.source_id
+      : ctx.defaultSourceId;
+
+    const opts = sourceId
+      ? { includeDeleted, sourceId }
+      : { includeDeleted };
+
+    let page = await ctx.engine.getPage(slug, opts);
     let resolved_slug: string | undefined;
 
     if (!page && fuzzy) {
       const candidates = await ctx.engine.resolveSlugs(slug);
       if (candidates.length === 1) {
-        page = await ctx.engine.getPage(candidates[0], { includeDeleted });
+        page = await ctx.engine.getPage(candidates[0], opts);
         resolved_slug = candidates[0];
       } else if (candidates.length > 1) {
         return { error: 'ambiguous_slug', candidates };
@@ -337,6 +369,7 @@ const put_page: Operation = {
   params: {
     slug: { type: 'string', required: true, description: 'Page slug' },
     content: { type: 'string', required: true, description: 'Full markdown content with YAML frontmatter' },
+    source_id: { type: 'string', description: 'v37: target a specific source. Precedence: params.source_id > ctx.defaultSourceId (OAuth client pin) > schema DEFAULT (\'default\').' },
   },
   mutating: true,
   scope: 'write',
@@ -382,7 +415,13 @@ const put_page: Operation = {
     // so Gemini / Ollama / Voyage brains don't silently drop embeddings (Codex C2).
     const { isAvailable } = await import('./ai/gateway.ts');
     const noEmbed = !isAvailable('embedding');
-    const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed });
+    // v37 source precedence: explicit param > ctx pin (OAuth client) > undefined
+    // (engine applies schema DEFAULT 'default'). Resolved here so the import
+    // path, dedupe lookup, and downstream auto-link all see the same source.
+    const resolvedSourceId = (typeof p.source_id === 'string' && p.source_id) ? p.source_id
+      : ctx.defaultSourceId;
+    const result = await importFromContent(ctx.engine, slug, p.content as string,
+      resolvedSourceId ? { noEmbed, sourceId: resolvedSourceId } : { noEmbed });
 
     // Auto-link post-hook: runs AFTER importFromContent (which is its own
     // transaction). Runs even on status='skipped' so reconciliation catches drift

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -382,9 +382,19 @@ export class PGLiteEngine implements BrainEngine {
     // global UNIQUE(slug) was dropped in migration v17. Step 5+ will
     // surface an explicit sourceId param on putPage for multi-source sync.
     const pageKind = page.page_kind || 'markdown';
+    // v37: explicit source_id ($9) overrides the schema DEFAULT 'default'.
+    // Branching on placeholder vs DEFAULT keeps positional params clean and
+    // preserves byte-for-byte parity with pre-v37 calls when source_id is
+    // omitted (DEFAULT path).
+    const sourceIdSql = page.source_id ? '$9' : 'DEFAULT';
+    const params: unknown[] = [
+      slug, page.type, pageKind, page.title, page.compiled_truth,
+      page.timeline || '', JSON.stringify(frontmatter), hash,
+    ];
+    if (page.source_id) params.push(page.source_id);
     const { rows } = await this.db.query(
-      `INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, now())
+      `INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at, source_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, now(), ${sourceIdSql})
        ON CONFLICT (source_id, slug) DO UPDATE SET
          type = EXCLUDED.type,
          page_kind = EXCLUDED.page_kind,
@@ -395,7 +405,7 @@ export class PGLiteEngine implements BrainEngine {
          content_hash = EXCLUDED.content_hash,
          updated_at = now()
        RETURNING id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at`,
-      [slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash]
+      params
     );
     return rowToPage(rows[0] as Record<string, unknown>);
   }

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -459,6 +459,7 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
   client_secret_expires_at BIGINT,
   token_ttl               INTEGER,
   deleted_at              TIMESTAMPTZ,
+  default_source_id       TEXT REFERENCES sources(id) ON DELETE SET NULL,
   created_at              TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -415,16 +415,18 @@ CREATE INDEX IF NOT EXISTS idx_eval_capture_failures_ts ON eval_capture_failures
 -- access_tokens: legacy bearer tokens for remote MCP access
 -- ============================================================
 CREATE TABLE IF NOT EXISTS access_tokens (
-  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  name         TEXT NOT NULL,
-  token_hash   TEXT NOT NULL UNIQUE,
-  scopes       TEXT[],
-  created_at   TIMESTAMPTZ DEFAULT now(),
-  last_used_at TIMESTAMPTZ,
-  revoked_at   TIMESTAMPTZ
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name              TEXT NOT NULL,
+  token_hash        TEXT NOT NULL UNIQUE,
+  scopes            TEXT[],
+  created_at        TIMESTAMPTZ DEFAULT now(),
+  last_used_at      TIMESTAMPTZ,
+  revoked_at        TIMESTAMPTZ,
+  default_source_id TEXT REFERENCES sources(id) ON DELETE SET NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_access_tokens_hash ON access_tokens (token_hash) WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_access_tokens_default_source ON access_tokens (default_source_id) WHERE default_source_id IS NOT NULL;
 
 -- ============================================================
 -- mcp_request_log: usage logging for MCP requests

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -330,12 +330,20 @@ export class PostgresEngine implements BrainEngine {
 
     // v0.18.0 Step 2: source_id relies on schema DEFAULT 'default'. ON
     // CONFLICT target becomes (source_id, slug) since global UNIQUE(slug)
-    // was dropped in migration v17. See pglite-engine.ts for matching
-    // notes; multi-source sync (Step 5) will surface an explicit sourceId.
+    // was dropped in migration v17.
+    //
+    // v37: when page.source_id is set, INSERT writes that explicit value
+    // (and the upsert key is still (source_id, slug)). Omitted → schema
+    // DEFAULT 'default' applies. The DEFAULT-vs-explicit fork is done with
+    // a sql fragment so the param list stays positional and the DEFAULT
+    // path keeps byte-for-byte parity with pre-v37 behaviour.
     const pageKind = page.page_kind || 'markdown';
+    const sourceIdFragment = page.source_id
+      ? sql`, ${page.source_id}`
+      : sql`, DEFAULT`;
     const rows = await sql`
-      INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at)
-      VALUES (${slug}, ${page.type}, ${pageKind}, ${page.title}, ${page.compiled_truth}, ${page.timeline || ''}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now())
+      INSERT INTO pages (slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at, source_id)
+      VALUES (${slug}, ${page.type}, ${pageKind}, ${page.title}, ${page.compiled_truth}, ${page.timeline || ''}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now()${sourceIdFragment})
       ON CONFLICT (source_id, slug) DO UPDATE SET
         type = EXCLUDED.type,
         page_kind = EXCLUDED.page_kind,

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -349,16 +349,18 @@ ON CONFLICT (key) DO NOTHING;
 -- access_tokens: bearer tokens for remote MCP access
 -- ============================================================
 CREATE TABLE IF NOT EXISTS access_tokens (
-  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  name         TEXT NOT NULL,
-  token_hash   TEXT NOT NULL UNIQUE,
-  scopes       TEXT[],
-  created_at   TIMESTAMPTZ DEFAULT now(),
-  last_used_at TIMESTAMPTZ,
-  revoked_at   TIMESTAMPTZ
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name              TEXT NOT NULL,
+  token_hash        TEXT NOT NULL UNIQUE,
+  scopes            TEXT[],
+  created_at        TIMESTAMPTZ DEFAULT now(),
+  last_used_at      TIMESTAMPTZ,
+  revoked_at        TIMESTAMPTZ,
+  default_source_id TEXT REFERENCES sources(id) ON DELETE SET NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_access_tokens_hash ON access_tokens (token_hash) WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_access_tokens_default_source ON access_tokens (default_source_id) WHERE default_source_id IS NOT NULL;
 
 -- ============================================================
 -- mcp_request_log: usage logging for remote MCP requests

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -390,6 +390,7 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
   client_secret_expires_at BIGINT,
   token_ttl               INTEGER,
   deleted_at              TIMESTAMPTZ,
+  default_source_id       TEXT REFERENCES sources(id) ON DELETE SET NULL,
   created_at              TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -42,6 +42,14 @@ export interface PageInput {
    * `query --lang` filtering.
    */
   page_kind?: PageKind;
+  /**
+   * v37: optional explicit source_id for multi-source brains. When omitted,
+   * Postgres applies the schema DEFAULT 'default'. When set, the row is
+   * inserted (or upserted) into that source's namespace — ON CONFLICT key
+   * is (source_id, slug). Threaded by put_page when the OAuth client has a
+   * `default_source_id` pin (v37 migration).
+   */
+  source_id?: string;
 }
 
 export interface PageFilters {

--- a/test/api-key-source-pinning.test.ts
+++ b/test/api-key-source-pinning.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Per-API-key default source pinning (v39 migration).
+ *
+ * Mirror of test/oauth-source-pinning.test.ts for the legacy access_tokens
+ * table. API keys (no TTL) are preferred over OAuth tokens (TTL) for headless
+ * agent setups, so the same source-pin ergonomics need to land here.
+ *
+ * Coverage:
+ *   1. verifyAccessToken populates AuthInfo.defaultSourceId from the legacy
+ *      access_tokens row (no extra DB roundtrip).
+ *   2. API key without default_source_id → AuthInfo.defaultSourceId is
+ *      undefined → put_page writes to 'default'.
+ *   3. API key with default_source_id → put_page with no source_id param
+ *      writes to the pinned source.
+ *   4. Explicit params.source_id always overrides ctx.defaultSourceId.
+ *   5. Source deleted while pinned → FK ON DELETE SET NULL clears the pin;
+ *      subsequent verifyAccessToken returns undefined and writes fall back
+ *      to 'default'.
+ *
+ * Uses PGLite in-memory (matches test/oauth-source-pinning.test.ts pattern).
+ * No Docker required, no DATABASE_URL needed.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { GBrainOAuthProvider } from '../src/core/oauth-provider.ts';
+import { hashToken, generateToken } from '../src/core/utils.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+
+let sql: (strings: TemplateStringsArray, ...values: unknown[]) => Promise<any>;
+let provider: GBrainOAuthProvider;
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  // Stand up a real engine via the production lifecycle (connect + initSchema)
+  // so all migrations — including the new v39 we're testing — are applied.
+  engine = new PGLiteEngine();
+  await engine.connect({ engine: 'pglite' } as any);
+  await engine.initSchema();
+
+  // Wrap the engine's underlying PGLite so the OAuth provider and our test
+  // assertions can speak raw SQL against the same DB the engine writes to.
+  const db = (engine as any).db;
+  sql = async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const query = strings.reduce(
+      (acc, str, i) => acc + str + (i < values.length ? `$${i + 1}` : ''),
+      '',
+    );
+    const result = await db.query(query, values as any[]);
+    return result.rows;
+  };
+
+  provider = new GBrainOAuthProvider({ sql, tokenTtl: 60, refreshTtl: 300 });
+
+  // Seed two non-default sources so we can pin/unpin between them.
+  await sql`INSERT INTO sources (id, name, config) VALUES ('agent-a', 'Agent A', '{}'::jsonb) ON CONFLICT DO NOTHING`;
+  await sql`INSERT INTO sources (id, name, config) VALUES ('agent-b', 'Agent B', '{}'::jsonb) ON CONFLICT DO NOTHING`;
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 15_000);
+
+beforeEach(async () => {
+  // Wipe pages + access tokens between tests so token reuse doesn't leak.
+  await sql`DELETE FROM pages`;
+  await sql`DELETE FROM access_tokens`;
+});
+
+// ---------------------------------------------------------------------------
+// Helper: insert a legacy API key row and return the raw bearer token.
+// Mirrors the production CLI path (`gbrain auth create <name>`) without going
+// through postgres.js / cli.ts.
+// ---------------------------------------------------------------------------
+async function makeApiKey(
+  name: string,
+  defaultSourceId: string | null = null,
+): Promise<{ name: string; token: string }> {
+  const token = generateToken('gbrain_');
+  const hash = hashToken(token);
+  await sql`
+    INSERT INTO access_tokens (name, token_hash, default_source_id)
+    VALUES (${name}, ${hash}, ${defaultSourceId})
+  `;
+  return { name, token };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: stand up a minimal OperationContext for direct handler invocation.
+// Matches the shape serve-http.ts builds, minus logger noise.
+// ---------------------------------------------------------------------------
+function makeCtx(defaultSourceId?: string) {
+  return {
+    engine: engine as any,
+    config: {} as any,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    dryRun: false,
+    remote: true as const,
+    auth: undefined,
+    defaultSourceId,
+  };
+}
+
+const PAGE_CONTENT = `---
+type: concept
+title: Test Page
+---
+
+# Test Page
+
+Body content for source-pinning tests.
+`;
+
+// ===========================================================================
+// 1. verifyAccessToken populates AuthInfo.defaultSourceId via legacy path
+// ===========================================================================
+
+describe('verifyAccessToken (legacy API key) returns defaultSourceId', () => {
+  test('populates defaultSourceId when API key has a pin', async () => {
+    const { token } = await makeApiKey('pinned-key', 'agent-a');
+    const auth = await provider.verifyAccessToken(token);
+    expect((auth as any).defaultSourceId).toBe('agent-a');
+    // Legacy tokens still get full admin scopes.
+    expect((auth as any).scopes).toEqual(['read', 'write', 'admin']);
+    // clientId == clientName == name for legacy tokens (single identifier).
+    expect((auth as any).clientId).toBe('pinned-key');
+    expect((auth as any).clientName).toBe('pinned-key');
+  });
+
+  test('defaultSourceId is undefined when API key is unpinned', async () => {
+    const { token } = await makeApiKey('free-key', null);
+    const auth = await provider.verifyAccessToken(token);
+    expect((auth as any).defaultSourceId).toBeUndefined();
+  });
+
+  test('revoked API key still rejects (revoked_at filter intact)', async () => {
+    const { token } = await makeApiKey('revoked-key', 'agent-a');
+    await sql`UPDATE access_tokens SET revoked_at = now() WHERE name = 'revoked-key'`;
+    await expect(provider.verifyAccessToken(token)).rejects.toThrow(/Invalid token/);
+  });
+});
+
+// ===========================================================================
+// 2. Source-pinning precedence (params > ctx.defaultSourceId > 'default')
+//    — same handler precedence as OAuth, exercised via API-key-issued ctx.
+// ===========================================================================
+
+describe('put_page handler precedence (API key path)', () => {
+  async function getOps() {
+    const ops = await import('../src/core/operations.ts');
+    return ops.operations;
+  }
+
+  test('ctx.defaultSourceId from API key routes write when no param given', async () => {
+    const { token } = await makeApiKey('writer-pinned', 'agent-a');
+    const auth = await provider.verifyAccessToken(token);
+    const ctx = makeCtx((auth as any).defaultSourceId);
+
+    const ops = await getOps();
+    const putPage = ops.find((o: any) => o.name === 'put_page')!;
+    await putPage.handler(ctx as any, {
+      slug: 'concepts/api-key-pinned',
+      content: PAGE_CONTENT,
+    });
+    const [row] = await sql`SELECT source_id FROM pages WHERE slug = 'concepts/api-key-pinned'`;
+    expect(row.source_id).toBe('agent-a');
+  });
+
+  test('unpinned API key → ctx pin undefined → falls back to default source', async () => {
+    const { token } = await makeApiKey('writer-free', null);
+    const auth = await provider.verifyAccessToken(token);
+    const ctx = makeCtx((auth as any).defaultSourceId);
+
+    const ops = await getOps();
+    const putPage = ops.find((o: any) => o.name === 'put_page')!;
+    await putPage.handler(ctx as any, {
+      slug: 'concepts/api-key-free',
+      content: PAGE_CONTENT,
+    });
+    const [row] = await sql`SELECT source_id FROM pages WHERE slug = 'concepts/api-key-free'`;
+    expect(row.source_id).toBe('default');
+  });
+
+  test('explicit params.source_id overrides API-key pin', async () => {
+    const { token } = await makeApiKey('writer-override', 'agent-a');
+    const auth = await provider.verifyAccessToken(token);
+    const ctx = makeCtx((auth as any).defaultSourceId);
+
+    const ops = await getOps();
+    const putPage = ops.find((o: any) => o.name === 'put_page')!;
+    await putPage.handler(ctx as any, {
+      slug: 'concepts/api-key-override',
+      content: PAGE_CONTENT,
+      source_id: 'agent-b',
+    });
+    const [row] = await sql`SELECT source_id FROM pages WHERE slug = 'concepts/api-key-override'`;
+    expect(row.source_id).toBe('agent-b');
+  });
+});
+
+// ===========================================================================
+// 3. Source deletion clears the pin (FK ON DELETE SET NULL)
+// ===========================================================================
+
+describe('orphaned API-key source pin', () => {
+  test('deleting the pinned source clears default_source_id', async () => {
+    await sql`INSERT INTO sources (id, name, config) VALUES ('throwaway-k', 'Throwaway K', '{}'::jsonb) ON CONFLICT DO NOTHING`;
+    await makeApiKey('orphan-key-test', 'throwaway-k');
+
+    // Sanity: pin landed.
+    const [before] = await sql`SELECT default_source_id FROM access_tokens WHERE name = 'orphan-key-test'`;
+    expect(before.default_source_id).toBe('throwaway-k');
+
+    // Delete the source — pages-FK cascade fires first; we have no rows there.
+    await sql`DELETE FROM pages WHERE source_id = 'throwaway-k'`;
+    await sql`DELETE FROM sources WHERE id = 'throwaway-k'`;
+
+    const [after] = await sql`SELECT default_source_id FROM access_tokens WHERE name = 'orphan-key-test'`;
+    expect(after.default_source_id).toBeNull();
+  });
+
+  test('verifyAccessToken after orphan returns undefined defaultSourceId; write falls back to default', async () => {
+    await sql`INSERT INTO sources (id, name, config) VALUES ('temp-src-k', 'Temp K', '{}'::jsonb) ON CONFLICT DO NOTHING`;
+    const { token } = await makeApiKey('fallback-key-test', 'temp-src-k');
+    await sql`DELETE FROM sources WHERE id = 'temp-src-k'`;
+
+    // Re-verify the token: defaultSourceId should now be undefined (FK SET NULL).
+    const auth = await provider.verifyAccessToken(token);
+    expect((auth as any).defaultSourceId).toBeUndefined();
+
+    // Simulate the dispatcher: ctx.defaultSourceId is undefined →
+    // put_page lands in 'default'.
+    const ctx = makeCtx((auth as any).defaultSourceId);
+    const ops = (await import('../src/core/operations.ts')).operations;
+    const putPage = ops.find((o: any) => o.name === 'put_page')!;
+    await putPage.handler(ctx as any, {
+      slug: 'concepts/api-key-post-orphan',
+      content: PAGE_CONTENT,
+    });
+    const [row] = await sql`SELECT source_id FROM pages WHERE slug = 'concepts/api-key-post-orphan'`;
+    expect(row.source_id).toBe('default');
+  });
+});

--- a/test/oauth-source-pinning.test.ts
+++ b/test/oauth-source-pinning.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Per-OAuth-client default source pinning (v37 migration).
+ *
+ * Coverage:
+ *   1. Client with default_source_id → put_page with no source_id param
+ *      writes to the pinned source.
+ *   2. Client without default_source_id → put_page writes to 'default'.
+ *   3. Explicit params.source_id always overrides ctx.defaultSourceId.
+ *   4. Source deleted while pinned → FK ON DELETE SET NULL clears the pin;
+ *      subsequent put_page falls back to 'default'.
+ *   5. verifyAccessToken populates AuthInfo.defaultSourceId from the JOIN
+ *      (no extra DB roundtrip).
+ *
+ * Uses PGLite in-memory (matches test/oauth.test.ts pattern). No Docker
+ * required, no DATABASE_URL needed.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { GBrainOAuthProvider } from '../src/core/oauth-provider.ts';
+import { hashToken, generateToken } from '../src/core/utils.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { importFromContent } from '../src/core/import-file.ts';
+
+let sql: (strings: TemplateStringsArray, ...values: unknown[]) => Promise<any>;
+let provider: GBrainOAuthProvider;
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  // Stand up a real engine via the production lifecycle (connect + initSchema)
+  // so all migrations — including the new v37 we're testing AND prior
+  // schema-shape migrations like v36 (parent_symbol_path) — are applied.
+  // Skipping initSchema and using PGLITE_SCHEMA_SQL alone leaves later
+  // ALTER columns missing and content_chunks INSERTs blow up.
+  engine = new PGLiteEngine();
+  await engine.connect({ engine: 'pglite' } as any);
+  await engine.initSchema();
+
+  // Wrap the engine's underlying PGLite so the OAuth provider and our test
+  // assertions can speak raw SQL against the same DB the engine writes to.
+  const db = (engine as any).db;
+  sql = async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const query = strings.reduce(
+      (acc, str, i) => acc + str + (i < values.length ? `$${i + 1}` : ''),
+      '',
+    );
+    const result = await db.query(query, values as any[]);
+    return result.rows;
+  };
+
+  provider = new GBrainOAuthProvider({ sql, tokenTtl: 60, refreshTtl: 300 });
+
+  // Seed two non-default sources so we can pin/unpin between them.
+  await sql`INSERT INTO sources (id, name, config) VALUES ('agent-a', 'Agent A', '{}'::jsonb) ON CONFLICT DO NOTHING`;
+  await sql`INSERT INTO sources (id, name, config) VALUES ('agent-b', 'Agent B', '{}'::jsonb) ON CONFLICT DO NOTHING`;
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 15_000);
+
+beforeEach(async () => {
+  // Wipe pages + oauth state between tests so token reuse doesn't leak.
+  await sql`DELETE FROM pages`;
+  await sql`DELETE FROM oauth_tokens`;
+  await sql`DELETE FROM oauth_clients`;
+});
+
+// ---------------------------------------------------------------------------
+// Helper: register an OAuth client + issue an access token in one shot.
+// Mirrors the production path (registerClientManual → issueTokens) without
+// going through HTTP. Returns the access token string + clientId.
+// ---------------------------------------------------------------------------
+async function makeAuthedClient(
+  name: string,
+  defaultSourceId: string | null = null,
+): Promise<{ clientId: string; accessToken: string }> {
+  const { clientId } = await provider.registerClientManual(
+    name,
+    ['client_credentials'],
+    'read write',
+    [],
+  );
+  if (defaultSourceId) {
+    await sql`UPDATE oauth_clients SET default_source_id = ${defaultSourceId} WHERE client_id = ${clientId}`;
+  }
+  // Issue a raw access token (mirrors issueTokens internals; bypasses the
+  // public exchange flow which validates client_secret).
+  const accessToken = generateToken('gbrain_at_');
+  const accessHash = hashToken(accessToken);
+  const expiresAt = Math.floor(Date.now() / 1000) + 60;
+  await sql`
+    INSERT INTO oauth_tokens (token_hash, token_type, client_id, scopes, expires_at)
+    VALUES (${accessHash}, 'access', ${clientId}, '{read,write}', ${expiresAt})
+  `;
+  return { clientId, accessToken };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: stand up a minimal OperationContext for direct handler invocation.
+// Matches the shape serve-http.ts builds, minus logger noise.
+// ---------------------------------------------------------------------------
+function makeCtx(defaultSourceId?: string) {
+  return {
+    engine: engine as any,
+    config: {} as any,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    dryRun: false,
+    remote: true as const,
+    auth: undefined,
+    defaultSourceId,
+  };
+}
+
+const PAGE_CONTENT = `---
+type: concept
+title: Test Page
+---
+
+# Test Page
+
+Body content for source-pinning tests.
+`;
+
+// ===========================================================================
+// 1. verifyAccessToken populates AuthInfo.defaultSourceId
+// ===========================================================================
+
+describe('verifyAccessToken returns defaultSourceId', () => {
+  test('populates defaultSourceId when client has a pin', async () => {
+    const { accessToken } = await makeAuthedClient('pinned-agent', 'agent-a');
+    const auth = await provider.verifyAccessToken(accessToken);
+    expect((auth as any).defaultSourceId).toBe('agent-a');
+  });
+
+  test('defaultSourceId is undefined when client is unpinned', async () => {
+    const { accessToken } = await makeAuthedClient('free-agent', null);
+    const auth = await provider.verifyAccessToken(accessToken);
+    expect((auth as any).defaultSourceId).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// 2. importFromContent honors opts.sourceId (engine-level contract)
+// ===========================================================================
+
+describe('importFromContent honors sourceId', () => {
+  test('writes page to pinned source when sourceId is supplied', async () => {
+    await importFromContent(engine as any, 'concepts/pinned-write', PAGE_CONTENT, {
+      noEmbed: true,
+      sourceId: 'agent-a',
+    });
+    const [row] = await sql`SELECT source_id FROM pages WHERE slug = 'concepts/pinned-write'`;
+    expect(row.source_id).toBe('agent-a');
+  });
+
+  test('writes page to default source when sourceId is omitted', async () => {
+    await importFromContent(engine as any, 'concepts/unpinned-write', PAGE_CONTENT, {
+      noEmbed: true,
+    });
+    const [row] = await sql`SELECT source_id FROM pages WHERE slug = 'concepts/unpinned-write'`;
+    expect(row.source_id).toBe('default');
+  });
+
+  test('same slug can co-exist across sources (multi-source upsert key)', async () => {
+    // Use engine.putPage directly to bypass importFromContent's tag
+    // reconciliation — tx.getTags(slug) currently uses a slug-only subquery
+    // that returns multiple rows when the same slug exists across sources
+    // (a pre-existing engine limitation outside this PR's scope). The DB
+    // upsert key (source_id, slug) is what's under test here.
+    await (engine as any).putPage('concepts/dual', {
+      type: 'concept', title: 'Dual A', compiled_truth: 'A body', timeline: '',
+      frontmatter: {}, content_hash: 'hash-a', source_id: 'agent-a',
+    });
+    await (engine as any).putPage('concepts/dual', {
+      type: 'concept', title: 'Dual B', compiled_truth: 'B body', timeline: '',
+      frontmatter: {}, content_hash: 'hash-b', source_id: 'agent-b',
+    });
+    const rows = await sql`SELECT source_id, title FROM pages WHERE slug = 'concepts/dual' ORDER BY source_id`;
+    expect(rows.map((r: any) => r.source_id)).toEqual(['agent-a', 'agent-b']);
+    expect(rows.map((r: any) => r.title)).toEqual(['Dual A', 'Dual B']);
+  });
+});
+
+// ===========================================================================
+// 3. Source-pinning precedence (params > ctx.defaultSourceId > 'default')
+// ===========================================================================
+
+describe('put_page / get_page handler precedence', () => {
+  // Lazy import to avoid hoisting issues when operations.ts module-loads
+  // its own dependencies.
+  async function getOps() {
+    const ops = await import('../src/core/operations.ts');
+    return ops.operations;
+  }
+
+  test('ctx.defaultSourceId routes write when no param given', async () => {
+    const ctx = makeCtx('agent-a');
+    const ops = await getOps();
+    const putPage = ops.find((o: any) => o.name === 'put_page')!;
+    await putPage.handler(ctx as any, {
+      slug: 'concepts/ctx-pinned',
+      content: PAGE_CONTENT,
+    });
+    const [row] = await sql`SELECT source_id FROM pages WHERE slug = 'concepts/ctx-pinned'`;
+    expect(row.source_id).toBe('agent-a');
+  });
+
+  test('no ctx pin → falls back to default source', async () => {
+    const ctx = makeCtx(undefined);
+    const ops = await getOps();
+    const putPage = ops.find((o: any) => o.name === 'put_page')!;
+    await putPage.handler(ctx as any, {
+      slug: 'concepts/no-pin',
+      content: PAGE_CONTENT,
+    });
+    const [row] = await sql`SELECT source_id FROM pages WHERE slug = 'concepts/no-pin'`;
+    expect(row.source_id).toBe('default');
+  });
+
+  test('explicit params.source_id overrides ctx pin', async () => {
+    const ctx = makeCtx('agent-a');
+    const ops = await getOps();
+    const putPage = ops.find((o: any) => o.name === 'put_page')!;
+    await putPage.handler(ctx as any, {
+      slug: 'concepts/override',
+      content: PAGE_CONTENT,
+      source_id: 'agent-b',
+    });
+    const [row] = await sql`SELECT source_id FROM pages WHERE slug = 'concepts/override'`;
+    expect(row.source_id).toBe('agent-b');
+  });
+
+  test('get_page with ctx pin reads from the pinned source only', async () => {
+    // Seed two pages with the same slug in different sources via engine.putPage
+    // (skips importFromContent's tag reconciliation — see dual-source test note).
+    await (engine as any).putPage('concepts/scoped-read', {
+      type: 'concept', title: 'Scoped A', compiled_truth: 'A side', timeline: '',
+      frontmatter: {}, content_hash: 'sr-a', source_id: 'agent-a',
+    });
+    await (engine as any).putPage('concepts/scoped-read', {
+      type: 'concept', title: 'Scoped B', compiled_truth: 'B side', timeline: '',
+      frontmatter: {}, content_hash: 'sr-b', source_id: 'agent-b',
+    });
+
+    // get_page handler still calls getTags(slug) which trips the dual-source
+    // subquery limitation. Verify the engine.getPage(slug, {sourceId}) contract
+    // directly — that's the precedence-bearing call.
+    const fromB = await (engine as any).getPage('concepts/scoped-read', { sourceId: 'agent-b' });
+    expect(fromB?.title).toBe('Scoped B');
+    expect(fromB?.compiled_truth).toContain('B side');
+
+    const fromA = await (engine as any).getPage('concepts/scoped-read', { sourceId: 'agent-a' });
+    expect(fromA?.title).toBe('Scoped A');
+  });
+});
+
+// ===========================================================================
+// 4. Source deletion clears the pin (FK ON DELETE SET NULL)
+// ===========================================================================
+
+describe('orphaned source pin', () => {
+  test('deleting the pinned source clears default_source_id', async () => {
+    // Stand up a throwaway source we can delete safely.
+    await sql`INSERT INTO sources (id, name, config) VALUES ('throwaway', 'Throwaway', '{}'::jsonb) ON CONFLICT DO NOTHING`;
+    const { clientId } = await makeAuthedClient('orphan-test', 'throwaway');
+
+    // Sanity: pin landed.
+    const [before] = await sql`SELECT default_source_id FROM oauth_clients WHERE client_id = ${clientId}`;
+    expect(before.default_source_id).toBe('throwaway');
+
+    // Delete the source — pages-FK cascade fires first; we have no rows there.
+    await sql`DELETE FROM pages WHERE source_id = 'throwaway'`;
+    await sql`DELETE FROM sources WHERE id = 'throwaway'`;
+
+    const [after] = await sql`SELECT default_source_id FROM oauth_clients WHERE client_id = ${clientId}`;
+    expect(after.default_source_id).toBeNull();
+  });
+
+  test('write after pin is cleared falls back to default', async () => {
+    await sql`INSERT INTO sources (id, name, config) VALUES ('temp-src', 'Temp', '{}'::jsonb) ON CONFLICT DO NOTHING`;
+    const { clientId } = await makeAuthedClient('fallback-test', 'temp-src');
+    await sql`DELETE FROM sources WHERE id = 'temp-src'`;
+
+    // Re-verify the token: defaultSourceId should now be undefined.
+    const [tok] = await sql`SELECT token_hash FROM oauth_tokens WHERE client_id = ${clientId}`;
+    expect(tok).toBeDefined();
+    const [client] = await sql`SELECT default_source_id FROM oauth_clients WHERE client_id = ${clientId}`;
+    expect(client.default_source_id).toBeNull();
+
+    // Simulate the dispatcher: ctx.defaultSourceId would be undefined →
+    // put_page lands in 'default'.
+    const ctx = makeCtx(undefined);
+    const ops = (await import('../src/core/operations.ts')).operations;
+    const putPage = ops.find((o: any) => o.name === 'put_page')!;
+    await putPage.handler(ctx as any, {
+      slug: 'concepts/post-orphan',
+      content: PAGE_CONTENT,
+    });
+    const [row] = await sql`SELECT source_id FROM pages WHERE slug = 'concepts/post-orphan'`;
+    expect(row.source_id).toBe('default');
+  });
+});


### PR DESCRIPTION
Companion to #653. API keys (no TTL) are preferred over OAuth tokens (TTL) for headless agent setups; this mirrors the OAuth source-pinning behavior on the legacy `access_tokens` path.

## Changes

**Schema (migration v39)**
- `access_tokens.default_source_id TEXT REFERENCES sources(id) ON DELETE SET NULL` — deleting the source clears the pin rather than orphaning the API key.
- Idempotent (ADD COLUMN IF NOT EXISTS); also added to `schema-embedded` + `pglite-schema` for fresh installs.

**Plumbing**
- `GBrainOAuthProvider.verifyAccessToken` legacy fallback now SELECTs `default_source_id` from `access_tokens` and returns it in `AuthInfo`. Falls back gracefully on pre-v39 brains via `isUndefinedColumnError`.
- HTTP middleware (`serve-http /mcp`) already threads `authInfo.defaultSourceId` into `ctx.defaultSourceId` from #653 — the same code path now serves the legacy bearer-token route.

**CLI**
- `gbrain auth set-source-key <name> <source_id|none>` — pin or clear (validates source exists; uses `none` or `''` to clear). Separate from `oauth set-source` to avoid confusion.
- `gbrain auth list` surfaces `default_source_id` alongside token metadata; backward-compatible against pre-v39 brains.

## Source precedence (unchanged)

`params.source_id  >  ctx.defaultSourceId  >  schema DEFAULT 'default'`

## Tests

`test/api-key-source-pinning.test.ts` (8 tests, all passing) covers:
- `verifyAccessToken` returns `defaultSourceId` from legacy `access_tokens` JOIN
- revoked tokens still rejected (`revoked_at` filter intact)
- `put_page` handler precedence: param > ctx pin > 'default'
- source deletion clears `default_source_id` (FK ON DELETE SET NULL)
- verify-after-orphan returns undefined; write falls back to default

PGLite in-memory pattern (no Docker, no `DATABASE_URL`).

Builds on #653.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->