### PR TITLE
fix(search): honor SearchOpts.sourceId in keyword + vector engines

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -655,6 +655,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
               description: v.description,
               ...(v.enum ? { enum: v.enum } : {}),
               ...(v.default !== undefined ? { default: v.default } : {}),
+              ...(v.items ? { items: { type: (v.items as { type: string }).type } } : {}),
             }]),
           ),
           required: Object.entries(op.params).filter(([, v]) => v.required).map(([k]) => k),

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -13,7 +13,7 @@ export const ollama: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['nomic-embed-text', 'mxbai-embed-large', 'all-minilm'],
+      models: ['nomic-embed-text', 'mxbai-embed-large', 'all-minilm', 'bge-m3', 'nomic-embed'],
       default_dims: 768, // nomic-embed-text native dim
       cost_per_1m_tokens_usd: 0,
       price_last_verified: '2026-04-20',

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -562,6 +562,10 @@ export class PGLiteEngine implements BrainEngine {
       params.push(opts.symbolKind);
       extraFilter += ` AND cc.symbol_type = $${params.length}`;
     }
+    if (opts?.sourceId) {
+      params.push(opts.sourceId);
+      extraFilter += ` AND p.source_id = $${params.length}`;
+    }
 
     // v0.26.5: visibility filter (soft-deleted + archived-source).
     const visibilityClause = buildVisibilityClause('p', 's');
@@ -634,6 +638,10 @@ export class PGLiteEngine implements BrainEngine {
       params.push(opts.symbolKind);
       extraFilter += ` AND cc.symbol_type = $${params.length}`;
     }
+    if (opts?.sourceId) {
+      params.push(opts.sourceId);
+      extraFilter += ` AND p.source_id = $${params.length}`;
+    }
 
     // v0.26.5: visibility filter for the chunk-grain anchor primitive.
     const visibilityClause = buildVisibilityClause('p', 's');
@@ -693,6 +701,10 @@ export class PGLiteEngine implements BrainEngine {
     if (opts?.symbolKind) {
       params.push(opts.symbolKind);
       extraFilter += ` AND cc.symbol_type = $${params.length}`;
+    }
+    if (opts?.sourceId) {
+      params.push(opts.sourceId);
+      extraFilter += ` AND p.source_id = $${params.length}`;
     }
 
     // v0.26.5: visibility filter applied in the inner CTE so HNSW sees the

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -471,6 +471,7 @@ export class PostgresEngine implements BrainEngine {
     const excludeSlugs = opts?.exclude_slugs;
     const language = opts?.language;
     const symbolKind = opts?.symbolKind;
+    const sourceId = opts?.sourceId;
 
     if (opts?.limit && opts.limit > MAX_SEARCH_LIMIT) {
       console.warn(`[gbrain] Warning: search limit clamped from ${opts.limit} to ${MAX_SEARCH_LIMIT}`);
@@ -515,6 +516,11 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    let sourceClause = '';
+    if (sourceId) {
+      params.push(sourceId);
+      sourceClause = `AND p.source_id = $${params.length}`;
+    }
     params.push(innerLimit);
     const innerLimitParam = `$${params.length}`;
     params.push(limit);
@@ -543,6 +549,7 @@ export class PostgresEngine implements BrainEngine {
           ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
           ${languageClause}
           ${symbolKindClause}
+          ${sourceClause}
           ${hardExcludeClause}
           ${visibilityClause}
         ORDER BY score DESC
@@ -589,6 +596,7 @@ export class PostgresEngine implements BrainEngine {
     const detailLow = opts?.detail === 'low';
     const language = opts?.language;
     const symbolKind = opts?.symbolKind;
+    const sourceId = opts?.sourceId;
 
     if (opts?.limit && opts.limit > MAX_SEARCH_LIMIT) {
       console.warn(`[gbrain] Warning: search limit clamped from ${opts.limit} to ${MAX_SEARCH_LIMIT}`);
@@ -624,6 +632,11 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    let sourceClause = '';
+    if (sourceId) {
+      params.push(sourceId);
+      sourceClause = `AND p.source_id = $${params.length}`;
+    }
     params.push(limit);
     const limitParam = `$${params.length}`;
     params.push(offset);
@@ -647,6 +660,7 @@ export class PostgresEngine implements BrainEngine {
         ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
         ${languageClause}
         ${symbolKindClause}
+        ${sourceClause}
         ${hardExcludeClause}
         ${visibilityClause}
       ORDER BY score DESC
@@ -670,6 +684,7 @@ export class PostgresEngine implements BrainEngine {
     const detailLow = opts?.detail === 'low';
     const language = opts?.language;
     const symbolKind = opts?.symbolKind;
+    const sourceId = opts?.sourceId;
 
     if (opts?.limit && opts.limit > MAX_SEARCH_LIMIT) {
       console.warn(`[gbrain] Warning: search limit clamped from ${opts.limit} to ${MAX_SEARCH_LIMIT}`);
@@ -712,6 +727,11 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    let sourceClause = '';
+    if (sourceId) {
+      params.push(sourceId);
+      sourceClause = `AND p.source_id = $${params.length}`;
+    }
     params.push(innerLimit);
     const innerLimitParam = `$${params.length}`;
     params.push(limit);
@@ -740,6 +760,7 @@ export class PostgresEngine implements BrainEngine {
           ${excludeSlugsClause}
           ${languageClause}
           ${symbolKindClause}
+          ${sourceClause}
           ${hardExcludeClause}
           ${visibilityClause}
         ORDER BY cc.embedding <=> $1::vector

--- a/src/mcp/tool-defs.ts
+++ b/src/mcp/tool-defs.ts
@@ -1,4 +1,4 @@
-import type { Operation } from '../core/operations.ts';
+import type { Operation, ParamDef } from '../core/operations.ts';
 
 export interface McpToolDef {
   name: string;
@@ -10,6 +10,17 @@ export interface McpToolDef {
   };
 }
 
+/** Convert a ParamDef to a valid MCP JSON Schema object (recursive for nested items). */
+function paramDefToMcpSchema(def: ParamDef): Record<string, unknown> {
+  const schema: Record<string, unknown> = { type: def.type };
+  if (def.description) schema.description = def.description;
+  if (def.enum) schema.enum = def.enum;
+  if (def.items) {
+    schema.items = paramDefToMcpSchema(def.items);
+  }
+  return schema;
+}
+
 export function buildToolDefs(ops: Operation[]): McpToolDef[] {
   return ops.map(op => ({
     name: op.name,
@@ -17,12 +28,15 @@ export function buildToolDefs(ops: Operation[]): McpToolDef[] {
     inputSchema: {
       type: 'object' as const,
       properties: Object.fromEntries(
-        Object.entries(op.params).map(([k, v]) => [k, {
-          type: v.type === 'array' ? 'array' : v.type,
-          ...(v.description ? { description: v.description } : {}),
-          ...(v.enum ? { enum: v.enum } : {}),
-          ...(v.items ? { items: { type: v.items.type } } : {}),
-        }]),
+        Object.entries(op.params).map(([k, v]) => {
+          const base: Record<string, unknown> = { type: v.type };
+          if (v.description) base.description = v.description;
+          if (v.enum) base.enum = v.enum;
+          if (v.items) {
+            base.items = paramDefToMcpSchema(v.items);
+          }
+          return [k, base];
+        }),
       ),
       required: Object.entries(op.params)
         .filter(([, v]) => v.required)


### PR DESCRIPTION
## Problem

`SearchOpts.sourceId` is declared in `src/core/types.ts` (Cathedral II) and operations.ts (`search`, `query`) forwards it from `resolveReadScope(ctx, params)` when a token is source-pinned (PR #659). But the engines (`postgres-engine.ts` and `pglite-engine.ts`) silently dropped it — none of `searchKeyword`, `searchKeywordChunks`, or `searchVector` referenced `opts.sourceId` in their SQL.

This made hard-scope token isolation broken in practice: a token pinned to source 'reisponde' calling `search('rafael')` got 0 results, because the engine returned the top-N chunks from any source, and `filterBySourceScope` (the post-fetch filter) saturated on default-source rows.

### Repro (token pinned to 'reisponde', 1613 chunks indexed)

```
search('rafael')          → 0 results        (expected: ~7 reisponde chunks)
filterBySourceScope post: 30 default in / 0 out  ← saturated
```

## Fix

Thread `opts.sourceId` through to the WHERE clause in all 6 search methods:

| Engine | Method | Status |
|--------|--------|--------|
| postgres | `searchKeyword` | Added `AND p.source_id = $X` to inner CTE |
| postgres | `searchKeywordChunks` | Same |
| postgres | `searchVector` | Same (in `hnsw_candidates` CTE) |
| pglite | `searchKeyword` | Same (in `extraFilter`) |
| pglite | `searchKeywordChunks` | Same |
| pglite | `searchVector` | Same |

`SearchOpts.sourceId` was already declared — only engine plumbing was missing.

## Validation

End-to-end via Bearer-token MCP at http://127.0.0.1:3131/mcp:

```
reisponde token + search('reisponde') → 3 reisponde / 0 default ✓
default token   + search('reisponde') → 5 default   / 0 reisponde ✓
```

Postgres + PGLite parity preserved. Type-check clean.

## Bonus commit

`feat(ollama): allowlist bge-m3 + nomic-embed` — Adds bge-m3 (1024-dim, multilingual) to ollama recipe touchpoints.embedding.models. Without this, AI SDK rejects `ollama:bge-m3` at recipe validation even when the model is served correctly via OpenAI-compat `/v1/embeddings`. Tested with llama-swap on local VM (1024-dim vectors, ~23ms/embed).

## Related

- Builds on #659 (token-level source pinning) — that PR introduces the read-scope pipeline; this PR closes the engine-side gap.
- Validated on production deploy (`deploy/local-v0.27-plus-patches`) with 6126 chunks across 2 sources.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->