### PR TITLE
Fix dream synthesize subagent worker auth in PGLite mode

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -95,6 +95,7 @@ export function loadConfig(): GBrainConfig | null {
     engine: inferredEngine,
     ...(dbUrl ? { database_url: dbUrl } : {}),
     ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
+    ...(process.env.ANTHROPIC_API_KEY ? { anthropic_api_key: process.env.ANTHROPIC_API_KEY } : {}),
     ...(process.env.GBRAIN_EMBEDDING_MODEL ? { embedding_model: process.env.GBRAIN_EMBEDDING_MODEL } : {}),
     ...(process.env.GBRAIN_EMBEDDING_DIMENSIONS ? { embedding_dimensions: parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS, 10) } : {}),
     ...(process.env.GBRAIN_EXPANSION_MODEL ? { expansion_model: process.env.GBRAIN_EXPANSION_MODEL } : {}),

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -27,11 +27,14 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
+import { loadConfig } from '../config.ts';
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import type { BrainEngine } from '../engine.ts';
 import type { PhaseResult, PhaseError } from '../cycle.ts';
 import { MinionQueue } from '../minions/queue.ts';
+import { MinionWorker } from '../minions/worker.ts';
+import { makeSubagentHandler } from '../minions/handlers/subagent.ts';
 import { waitForCompletion, TimeoutError } from '../minions/wait-for-completion.ts';
 import type { MinionJobInput, SubagentHandlerData } from '../minions/types.ts';
 import { discoverTranscripts, type DiscoveredTranscript } from './transcript-discovery.ts';
@@ -199,24 +202,44 @@ export async function runPhaseSynthesize(
 
     // Wait for every child to reach a terminal state. Tick yieldDuringPhase
     // every 5 min so the cycle lock TTL refreshes.
+    // PGLite has no separate worker process; jobs must be executed inline in
+    // this process. Without this, the queue stays at "waiting" forever and
+    // no Anthropic Sonnet calls are made. Postgres deployments can keep using
+    // their persistent worker/supervisor.
+    let inlineWorker: MinionWorker | null = null;
+    let inlineWorkerPromise: Promise<void> | null = null;
+    if (engine.kind === 'pglite') {
+      process.stderr.write('[cycle.synthesize] PGLite detected; running subagent worker inline\n');
+      inlineWorker = new MinionWorker(engine, { queue: 'default', pollInterval: 100, healthCheckInterval: 0 });
+      inlineWorker.register('subagent', makeSubagentHandler({ engine }));
+      inlineWorkerPromise = inlineWorker.start();
+    }
+
     const childOutcomes: Array<{ jobId: number; status: string }> = [];
-    for (const jobId of childIds) {
-      try {
-        const job = await waitForCompletion(queue, jobId, {
-          timeoutMs: 35 * 60 * 1000,
-          pollMs: 5 * 1000,
-        });
-        childOutcomes.push({ jobId, status: job.status });
-      } catch (e) {
-        if (e instanceof TimeoutError) {
-          childOutcomes.push({ jobId, status: 'timeout' });
-        } else {
-          throw e;
+    try {
+      for (const jobId of childIds) {
+        try {
+          const job = await waitForCompletion(queue, jobId, {
+            timeoutMs: 35 * 60 * 1000,
+            pollMs: 5 * 1000,
+          });
+          childOutcomes.push({ jobId, status: job.status });
+        } catch (e) {
+          if (e instanceof TimeoutError) {
+            childOutcomes.push({ jobId, status: 'timeout' });
+          } else {
+            throw e;
+          }
+        }
+        // After each child terminal, give the cycle lock + worker job lock a chance.
+        if (opts.yieldDuringPhase) {
+          try { await opts.yieldDuringPhase(); } catch { /* best-effort */ }
         }
       }
-      // After each child terminal, give the cycle lock + worker job lock a chance.
-      if (opts.yieldDuringPhase) {
-        try { await opts.yieldDuringPhase(); } catch { /* best-effort */ }
+    } finally {
+      if (inlineWorker) {
+        inlineWorker.stop();
+        if (inlineWorkerPromise) await inlineWorkerPromise;
       }
     }
 
@@ -341,8 +364,9 @@ export interface JudgeClient {
 }
 
 function makeHaikuClient(): JudgeClient | null {
-  if (!process.env.ANTHROPIC_API_KEY) return null;
-  const client = new Anthropic();
+  const config = loadConfig();
+  if (!config?.anthropic_api_key) return null;
+  const client = new Anthropic({ apiKey: config.anthropic_api_key });
   return { create: client.messages.create.bind(client.messages) };
 }
 

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -131,9 +131,12 @@ export function makeSubagentHandler(deps: SubagentDeps) {
   // lives at sdk.messages.create. Assigning sdk.messages directly gets the
   // right object; JS method-call semantics preserve `this` at the call
   // site (subagent.ts invokes client.create(...) with client === sdk.messages).
-  const makeAnthropic = deps.makeAnthropic ?? (() => new Anthropic());
-  const client: MessagesClient = deps.client ?? makeAnthropic().messages;
   const config = deps.config ?? loadConfig() ?? ({ engine: 'postgres' } as GBrainConfig);
+  const makeAnthropic = deps.makeAnthropic ?? (() => {
+    if (config.anthropic_api_key) return new Anthropic({ apiKey: config.anthropic_api_key });
+    return new Anthropic();
+  });
+  const client: MessagesClient = deps.client ?? makeAnthropic().messages;
   const rateLeaseKey = deps.rateLeaseKey ?? DEFAULT_RATE_KEY;
   const maxConcurrent = deps.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
   const leaseTtlMs = deps.leaseTtlMs ?? DEFAULT_LEASE_TTL_MS;

--- a/test/e2e/dream-synthesize-pglite.test.ts
+++ b/test/e2e/dream-synthesize-pglite.test.ts
@@ -45,18 +45,25 @@ async function setupRig(): Promise<TestRig> {
 }
 
 /**
- * Run `body` with ANTHROPIC_API_KEY temporarily cleared, restoring the
- * prior value (set or unset) on return — even on throw — so this never
- * leaks state to sibling test files in the suite.
+ * Run `body` with Anthropic credentials temporarily cleared from both env
+ * and file-plane config. `loadConfig()` reads ~/.gbrain/config.json, so on a
+ * developer machine with `anthropic_api_key` configured, clearing only
+ * ANTHROPIC_API_KEY is not enough to exercise the no-key path.
  */
 async function withoutAnthropicKey<T>(body: () => Promise<T>): Promise<T> {
   const saved = process.env.ANTHROPIC_API_KEY;
+  const savedGbrainHome = process.env.GBRAIN_HOME;
+  const tempHome = mkdtempSync(join(tmpdir(), 'gbrain-no-anthropic-home-'));
   delete process.env.ANTHROPIC_API_KEY;
+  process.env.GBRAIN_HOME = tempHome;
   try {
     return await body();
   } finally {
     if (saved === undefined) delete process.env.ANTHROPIC_API_KEY;
     else process.env.ANTHROPIC_API_KEY = saved;
+    if (savedGbrainHome === undefined) delete process.env.GBRAIN_HOME;
+    else process.env.GBRAIN_HOME = savedGbrainHome;
+    try { rmSync(tempHome, { recursive: true, force: true }); } catch { /* best-effort */ }
   }
 }
 


### PR DESCRIPTION
## Summary
- add file-plane Anthropic API key loading to config
- run synthesize subagent jobs inline when the minion worker pool is unavailable
- pass Anthropic credentials into subagent model config and preserve no-key test isolation

## Verification
- bun test test/e2e/dream-synthesize-pglite.test.ts test/dream.test.ts test/dream-cli-flags.test.ts
- bun run typecheck

## Context
PGLite dream synthesize could enqueue 17 subagent jobs that stayed waiting with worker count 0, so Claude was never called. Forcing inline execution exposed missing subagent auth propagation; this patch wires configured Anthropic credentials into the subagent model config.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->