### PR TITLE
feat: Voyage 4 embedding support + doctor eval

### DIFF
--- a/evals/embedding-provider-eval.json
+++ b/evals/embedding-provider-eval.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "description": "Embedding provider smoke test — verifies semantic search returns expected results for known brain content. Run after any embedding model change or migration.",
+  "queries": [
+    {
+      "id": "yc-labs-strategy",
+      "query": "YC Labs strategy and product team",
+      "relevant": [
+        "originals/yc-labs-internal-team",
+        "originals/harj-yc-labs-strategy-2026-05"
+      ]
+    },
+    {
+      "id": "garry-tan-person",
+      "query": "Who is Garry Tan",
+      "relevant": [
+        "people/garry-tan"
+      ]
+    },
+    {
+      "id": "gstack-project",
+      "query": "GStack open source AI coding framework",
+      "relevant": [
+        "projects/gstack/gstackbrain"
+      ]
+    },
+    {
+      "id": "yc-carry-compensation",
+      "query": "GP carry and compensation structure at YC",
+      "relevant": [
+        "originals/harj-yc-labs-strategy-2026-05"
+      ]
+    },
+    {
+      "id": "meeting-search",
+      "query": "recent office hours meeting notes",
+      "relevant": []
+    }
+  ]
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -572,6 +572,75 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
     checks.push({ name: 'embeddings', status: 'warn', message: 'Could not check embedding health' });
   }
 
+  // 8b. Embedding provider eval — live smoke test of the configured provider.
+  //     Verifies: correct model, API key works, dimensions match config, DB column matches.
+  progress.heartbeat('embedding_provider');
+  try {
+    const {
+      getEmbeddingModel,
+      getEmbeddingDimensions,
+      embedOne,
+      isAvailable,
+    } = await import('../core/ai/gateway.ts');
+
+    const configuredModel = getEmbeddingModel();
+    const configuredDims = getEmbeddingDimensions();
+    const available = isAvailable('embedding');
+
+    if (!available) {
+      checks.push({
+        name: 'embedding_provider',
+        status: 'fail',
+        message: `Embedding provider not available. Model: ${configuredModel}. Check API keys.`,
+      });
+    } else {
+      // Live embed test
+      const start = Date.now();
+      const vec = await embedOne('gbrain doctor embedding smoke test');
+      const ms = Date.now() - start;
+      const actualDims = vec.length;
+
+      const issues: string[] = [];
+
+      // Check dimensions match config
+      if (actualDims !== configuredDims) {
+        issues.push(`Dimension mismatch: provider returned ${actualDims} but config expects ${configuredDims}`);
+      }
+
+      // Check DB column dimensions match
+      try {
+        const dbDimRow = await engine.sql`
+          SELECT vector_dims(embedding) as dims
+          FROM content_chunks
+          WHERE embedding IS NOT NULL
+          LIMIT 1`;
+        if (dbDimRow.length > 0 && dbDimRow[0].dims !== actualDims) {
+          issues.push(`DB dimension mismatch: stored vectors are ${dbDimRow[0].dims}-dim but provider returns ${actualDims}-dim. Migration needed.`);
+        }
+      } catch { /* no chunks with embeddings yet, that's fine */ }
+
+      if (issues.length > 0) {
+        checks.push({
+          name: 'embedding_provider',
+          status: 'warn',
+          message: `${configuredModel} responds (${ms}ms, ${actualDims} dims) but: ${issues.join('; ')}`,
+        });
+      } else {
+        checks.push({
+          name: 'embedding_provider',
+          status: 'ok',
+          message: `${configuredModel} ✓ ${ms}ms, ${actualDims} dims, DB aligned`,
+        });
+      }
+    }
+  } catch (e: any) {
+    checks.push({
+      name: 'embedding_provider',
+      status: 'fail',
+      message: `Embedding provider probe failed: ${e.message?.slice(0, 200) ?? e}`,
+    });
+  }
+
   // 9. Graph health (link + timeline coverage on entity pages).
   // dead_links removed in v0.10.1: ON DELETE CASCADE on link FKs makes it always 0.
   progress.heartbeat('graph_coverage');

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -193,10 +193,47 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
           recipe.setup_hint,
         );
       }
+      // Voyage AI compatibility shim:
+      // 1. Rejects `encoding_format: "float"` (only accepts "base64" or omit).
+      //    The AI SDK hardcodes encoding_format: "float" for openai-compatible.
+      // 2. Returns `usage.total_tokens` instead of `usage.prompt_tokens`.
+      //    The AI SDK Zod schema requires `prompt_tokens` when usage is present.
+      const voyageFetch = recipe.id === 'voyage'
+        ? async (url: string | URL | Request, init?: RequestInit) => {
+            if (init?.body && typeof init.body === 'string') {
+              try {
+                const parsed = JSON.parse(init.body);
+                delete parsed.encoding_format;
+                init = { ...init, body: JSON.stringify(parsed) };
+              } catch { /* not JSON, pass through */ }
+            }
+            const resp = await globalThis.fetch(url, init);
+            // Patch response to add prompt_tokens from total_tokens
+            const text = await resp.text();
+            try {
+              const json = JSON.parse(text);
+              if (json.usage && json.usage.total_tokens != null && json.usage.prompt_tokens == null) {
+                json.usage.prompt_tokens = json.usage.total_tokens;
+              }
+              return new Response(JSON.stringify(json), {
+                status: resp.status,
+                statusText: resp.statusText,
+                headers: resp.headers,
+              });
+            } catch {
+              return new Response(text, {
+                status: resp.status,
+                statusText: resp.statusText,
+                headers: resp.headers,
+              });
+            }
+          }
+        : undefined;
       const client = createOpenAICompatible({
         name: recipe.id,
         baseURL: baseUrl,
         apiKey: apiKey ?? 'unauthenticated',
+        ...(voyageFetch ? { fetch: voyageFetch } : {}),
       });
       return client.textEmbeddingModel(modelId);
     }

--- a/src/core/ai/recipes/voyage.ts
+++ b/src/core/ai/recipes/voyage.ts
@@ -3,6 +3,10 @@ import type { Recipe } from '../types.ts';
 /**
  * Voyage AI exposes an OpenAI-compatible /embeddings endpoint.
  * Base URL: https://api.voyageai.com/v1
+ *
+ * Voyage 4 family (Jan 2026): shared embedding space across all v4 variants,
+ * flexible dims (256/512/1024/2048), 32K context, MoE architecture (large).
+ * You can index with voyage-4-large and query with voyage-4-lite — no reindex.
  */
 export const voyage: Recipe = {
   id: 'voyage',
@@ -16,10 +20,14 @@ export const voyage: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['voyage-3-large', 'voyage-3', 'voyage-3-lite'],
+      models: [
+        'voyage-4-large', 'voyage-4', 'voyage-4-lite', 'voyage-4-nano',
+        'voyage-3-large', 'voyage-3', 'voyage-3-lite',
+        'voyage-code-3', 'voyage-finance-2', 'voyage-law-2',
+      ],
       default_dims: 1024,
       cost_per_1m_tokens_usd: 0.18,
-      price_last_verified: '2026-04-20',
+      price_last_verified: '2026-05-06',
     },
   },
   setup_hint: 'Get an API key at https://dash.voyageai.com/api-keys, then `export VOYAGE_API_KEY=...`',


### PR DESCRIPTION
## What

Adds full Voyage AI voyage-4-large embedding support to gbrain.

### Changes

1. **Voyage recipe** (`src/core/ai/recipes/voyage.ts`): Added voyage-4-large, voyage-4, voyage-4-lite, voyage-4-nano + domain-specific models (code-3, finance-2, law-2)

2. **AI SDK compatibility shim** (`src/core/ai/gateway.ts`): Voyage's API rejects `encoding_format: "float"` (only accepts `base64` or omit) and returns `total_tokens` instead of `prompt_tokens`. Added a custom fetch wrapper for Voyage that strips unsupported fields and patches the response schema.

3. **Doctor embedding_provider check** (`src/commands/doctor.ts`): New check 8b that:
   - Live-probes the configured embedding provider
   - Verifies API key works
   - Checks returned dimensions match config
   - Checks DB stored vector dimensions match provider output
   - Reports mismatches as warnings with migration guidance

4. **Embedding eval qrels** (`evals/embedding-provider-eval.json`): Ground truth queries for validating search quality after embedding model changes.

## Testing

- `gbrain providers test --model voyage:voyage-4-large` → ✓ 198ms, 1024 dims
- `gbrain doctor` → embedding_provider check detects dimension mismatch (1536 stored vs 1024 new) and reports it correctly
- Verified raw Voyage API works with curl

## Context

Switching from OpenAI text-embedding-3-large (1536d) to Voyage voyage-4-large (1024d). Voyage 4 outperforms OpenAI by ~14% NDCG@10 on RTEB benchmarks. DB migration (ALTER vector column + full reindex) is a separate step.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->