### PR TITLE
fix(bootstrap): cover v0.26.3 + v0.27 forward references in init

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -218,6 +218,8 @@ export class PGLiteEngine implements BrainEngine {
    *   - `content_chunks.symbol_name` column (indexed by `idx_chunks_symbol_name`) — v0.19
    *   - `content_chunks.language` column (indexed by `idx_chunks_language`) — v0.19
    *   - `pages.deleted_at` column (indexed by `pages_deleted_at_purge_idx`) — v0.26.5
+   *   - `mcp_request_log.agent_name` column (indexed by `idx_mcp_log_agent_time`) — v0.26.3
+   *   - `subagent_messages.provider_id` column (indexed by `idx_subagent_messages_provider`) — v0.27
    *
    * **Maintenance contract:** when a future migration adds a column-with-index
    * or new-table-with-FK referenced by PGLITE_SCHEMA_SQL, extend this method
@@ -245,7 +247,15 @@ export class PGLiteEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema='public' AND table_name='content_chunks' AND column_name='symbol_name') AS symbol_name_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema='public' AND table_name='content_chunks' AND column_name='language') AS language_exists
+                WHERE table_schema='public' AND table_name='content_chunks' AND column_name='language') AS language_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema='public' AND table_name='mcp_request_log') AS mcp_request_log_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='mcp_request_log' AND column_name='agent_name') AS mcp_agent_name_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema='public' AND table_name='subagent_messages') AS subagent_messages_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='subagent_messages' AND column_name='provider_id') AS subagent_provider_id_exists
     `);
     const probe = rows[0] as {
       pages_exists: boolean;
@@ -257,6 +267,10 @@ export class PGLiteEngine implements BrainEngine {
       chunks_exists: boolean;
       symbol_name_exists: boolean;
       language_exists: boolean;
+      mcp_request_log_exists: boolean;
+      mcp_agent_name_exists: boolean;
+      subagent_messages_exists: boolean;
+      subagent_provider_id_exists: boolean;
     };
 
     const needsPagesBootstrap = probe.pages_exists && !probe.source_id_exists;
@@ -265,9 +279,15 @@ export class PGLiteEngine implements BrainEngine {
     const needsChunksBootstrap = probe.chunks_exists
       && (!probe.symbol_name_exists || !probe.language_exists);
     const needsPagesDeletedAt = probe.pages_exists && !probe.deleted_at_exists;
+    // v0.26.3: idx_mcp_log_agent_time references mcp_request_log.agent_name.
+    // Migration v33 adds it; bootstrap runs first.
+    const needsMcpAgentName = probe.mcp_request_log_exists && !probe.mcp_agent_name_exists;
+    // v0.27: idx_subagent_messages_provider references subagent_messages.provider_id.
+    // Migration v36 adds it; bootstrap runs first.
+    const needsSubagentProviderId = probe.subagent_messages_exists && !probe.subagent_provider_id_exists;
 
     // Fresh installs (no tables yet) and modern brains both no-op.
-    if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap && !needsPagesDeletedAt) return;
+    if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap && !needsPagesDeletedAt && !needsMcpAgentName && !needsSubagentProviderId) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
 
@@ -323,6 +343,27 @@ export class PGLiteEngine implements BrainEngine {
       // not to crash. v34 runs later via runMigrations and is idempotent.
       await this.db.exec(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsMcpAgentName) {
+      // v33 (admin_dashboard_columns_v0_26_3) adds agent_name + params + error_message
+      // and backfills agent_name. Bootstrap only adds enough for PGLITE_SCHEMA_SQL's
+      // `CREATE INDEX idx_mcp_log_agent_time ON mcp_request_log(agent_name, ...)`
+      // not to crash. v33 runs later via runMigrations and is idempotent.
+      await this.db.exec(`
+        ALTER TABLE mcp_request_log ADD COLUMN IF NOT EXISTS agent_name TEXT;
+      `);
+    }
+
+    if (needsSubagentProviderId) {
+      // v36 (subagent_provider_neutral_persistence_v0_27) adds schema_version +
+      // provider_id on subagent_messages and subagent_tool_executions. Bootstrap
+      // only adds enough for PGLITE_SCHEMA_SQL's `CREATE INDEX idx_subagent_messages_provider
+      // ON subagent_messages(job_id, provider_id)` not to crash. v36 runs later
+      // via runMigrations and is idempotent.
+      await this.db.exec(`
+        ALTER TABLE subagent_messages ADD COLUMN IF NOT EXISTS provider_id TEXT;
       `);
     }
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -162,6 +162,8 @@ export class PostgresEngine implements BrainEngine {
    *   - `content_chunks.symbol_name` column (indexed by `idx_chunks_symbol_name`) — v0.19
    *   - `content_chunks.language` column (indexed by `idx_chunks_language`) — v0.19
    *   - `pages.deleted_at` column (indexed by `pages_deleted_at_purge_idx`) — v0.26.5
+   *   - `mcp_request_log.agent_name` column (indexed by `idx_mcp_log_agent_time`) — v0.26.3
+   *   - `subagent_messages.provider_id` column (indexed by `idx_subagent_messages_provider`) — v0.27
    *
    * Keep this in sync with the PGLite version; covered by
    * `test/schema-bootstrap-coverage.test.ts` (PGLite side) and
@@ -183,6 +185,10 @@ export class PostgresEngine implements BrainEngine {
       chunks_exists: boolean;
       symbol_name_exists: boolean;
       language_exists: boolean;
+      mcp_request_log_exists: boolean;
+      mcp_agent_name_exists: boolean;
+      subagent_messages_exists: boolean;
+      subagent_provider_id_exists: boolean;
     }[]>`
       SELECT
         EXISTS (SELECT 1 FROM information_schema.tables
@@ -202,7 +208,15 @@ export class PostgresEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema = current_schema() AND table_name = 'content_chunks' AND column_name = 'symbol_name') AS symbol_name_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema = current_schema() AND table_name = 'content_chunks' AND column_name = 'language') AS language_exists
+                WHERE table_schema = current_schema() AND table_name = 'content_chunks' AND column_name = 'language') AS language_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema() AND table_name = 'mcp_request_log') AS mcp_request_log_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'mcp_request_log' AND column_name = 'agent_name') AS mcp_agent_name_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema() AND table_name = 'subagent_messages') AS subagent_messages_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'subagent_messages' AND column_name = 'provider_id') AS subagent_provider_id_exists
     `;
     const probe = probeRows[0]!;
 
@@ -214,8 +228,16 @@ export class PostgresEngine implements BrainEngine {
     // v0.26.5: pages_deleted_at_purge_idx in SCHEMA_SQL crashes if the column
     // doesn't exist yet. Migration v34 also adds it, but bootstrap runs first.
     const needsPagesDeletedAt = probe.pages_exists && !probe.deleted_at_exists;
+    // v0.26.3: idx_mcp_log_agent_time in SCHEMA_SQL references mcp_request_log.agent_name.
+    // Older brains created mcp_request_log before agent_name was a column. Migration v33
+    // adds it, but the bootstrap runs first.
+    const needsMcpAgentName = probe.mcp_request_log_exists && !probe.mcp_agent_name_exists;
+    // v0.27: idx_subagent_messages_provider in SCHEMA_SQL references subagent_messages.provider_id.
+    // Older brains created subagent_messages before provider_id was a column. Migration v36
+    // adds it, but the bootstrap runs first.
+    const needsSubagentProviderId = probe.subagent_messages_exists && !probe.subagent_provider_id_exists;
 
-    if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap && !needsPagesDeletedAt) return;
+    if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap && !needsPagesDeletedAt && !needsMcpAgentName && !needsSubagentProviderId) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
 
@@ -270,6 +292,27 @@ export class PostgresEngine implements BrainEngine {
       // not to crash. v34 runs later via runMigrations and is idempotent.
       await conn.unsafe(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsMcpAgentName) {
+      // v33 (admin_dashboard_columns_v0_26_3) adds agent_name + params + error_message
+      // and backfills agent_name. Bootstrap only adds enough for SCHEMA_SQL's
+      // `CREATE INDEX idx_mcp_log_agent_time ON mcp_request_log(agent_name, ...)`
+      // not to crash. v33 runs later via runMigrations and is idempotent.
+      await conn.unsafe(`
+        ALTER TABLE mcp_request_log ADD COLUMN IF NOT EXISTS agent_name TEXT;
+      `);
+    }
+
+    if (needsSubagentProviderId) {
+      // v36 (subagent_provider_neutral_persistence_v0_27) adds schema_version +
+      // provider_id on subagent_messages and subagent_tool_executions. Bootstrap
+      // only adds enough for SCHEMA_SQL's `CREATE INDEX idx_subagent_messages_provider
+      // ON subagent_messages(job_id, provider_id)` not to crash. v36 runs later
+      // via runMigrations and is idempotent.
+      await conn.unsafe(`
+        ALTER TABLE subagent_messages ADD COLUMN IF NOT EXISTS provider_id TEXT;
       `);
     }
   }

--- a/test/schema-bootstrap-coverage.test.ts
+++ b/test/schema-bootstrap-coverage.test.ts
@@ -63,6 +63,12 @@ const REQUIRED_BOOTSTRAP_COVERAGE: ForwardReference[] = [
   // v0.26.5 — forward-referenced by `CREATE INDEX pages_deleted_at_purge_idx
   // ON pages (deleted_at) WHERE deleted_at IS NOT NULL`.
   { kind: 'column', table: 'pages', column: 'deleted_at' },
+  // v0.26.3 — forward-referenced by `CREATE INDEX idx_mcp_log_agent_time
+  // ON mcp_request_log(agent_name, created_at DESC)`.
+  { kind: 'column', table: 'mcp_request_log', column: 'agent_name' },
+  // v0.27 — forward-referenced by `CREATE INDEX idx_subagent_messages_provider
+  // ON subagent_messages (job_id, provider_id)`.
+  { kind: 'column', table: 'subagent_messages', column: 'provider_id' },
 ];
 
 test('applyForwardReferenceBootstrap covers every forward reference declared in REQUIRED_BOOTSTRAP_COVERAGE', async () => {
@@ -95,6 +101,12 @@ test('applyForwardReferenceBootstrap covers every forward reference declared in 
 
       DROP INDEX IF EXISTS pages_deleted_at_purge_idx;
       ALTER TABLE pages DROP COLUMN IF EXISTS deleted_at;
+
+      DROP INDEX IF EXISTS idx_mcp_log_agent_time;
+      ALTER TABLE mcp_request_log DROP COLUMN IF EXISTS agent_name;
+
+      DROP INDEX IF EXISTS idx_subagent_messages_provider;
+      ALTER TABLE subagent_messages DROP COLUMN IF EXISTS provider_id;
     `);
 
     // Run bootstrap in isolation (NOT initSchema). This is what we're testing.
@@ -150,6 +162,10 @@ test('after bootstrap, PGLITE_SCHEMA_SQL replays without crashing on missing for
       ALTER TABLE links DROP COLUMN IF EXISTS origin_page_id;
       DROP INDEX IF EXISTS pages_deleted_at_purge_idx;
       ALTER TABLE pages DROP COLUMN IF EXISTS deleted_at;
+      DROP INDEX IF EXISTS idx_mcp_log_agent_time;
+      ALTER TABLE mcp_request_log DROP COLUMN IF EXISTS agent_name;
+      DROP INDEX IF EXISTS idx_subagent_messages_provider;
+      ALTER TABLE subagent_messages DROP COLUMN IF EXISTS provider_id;
     `);
 
     // Bootstrap, then schema replay. Either step crashing fails the test.


### PR DESCRIPTION
## Summary

`gbrain init` against a brain at schema_version <32 crashes with `column "agent_name" does not exist`. Two forward references in the embedded schema blob run before `runMigrations()` gets a chance to add the columns:

- `src/schema.sql:420` indexes `mcp_request_log.agent_name` (added by migration v33)
- `src/schema.sql:638` indexes `subagent_messages.provider_id` (added by migration v36)

Same incident class as #239 / #243 / #266 / #357 / #366 / #374 / #375 / #378 / #395 / #396. Every release that adds a column-with-index in the schema blob without extending `applyForwardReferenceBootstrap` re-trips the wedge.

## Fix

Extends `applyForwardReferenceBootstrap` in both `PGLiteEngine` and `PostgresEngine` to probe for and add `mcp_request_log.agent_name` and `subagent_messages.provider_id` when the table exists but the column does not. Migrations v33 and v36 still run afterward and remain idempotent (`ADD COLUMN IF NOT EXISTS`).

## Test plan

- [x] `REQUIRED_BOOTSTRAP_COVERAGE` in `test/schema-bootstrap-coverage.test.ts` now includes the two new forward references.
- [x] Both tests' strip blocks drop the new columns + indexes so the bootstrap is actually exercised against a brain that lacks them.
- [x] `bun run typecheck` passes locally.
- [ ] PGLite bootstrap test (CI) — local run blocked by macOS 26.3 PGLite WASM bug (#223 / #391).
- [ ] Postgres e2e bootstrap test (CI).

## Discovery context

Surfaced upgrading a v0.25.0 brain (schema_version=31) to v0.27.0 on Supabase Postgres. The brain landed in a wedged state where every `gbrain init --migrate-only` invocation aborted on the schema-replay step before any v32-v36 migration ran. After applying this patch (and running through the same upgrade path on a freshly-rebuilt brain), the failure mode goes away.

## Future direction (out of scope here)

The deeper architectural fix is to run `runMigrations()` *before* `SCHEMA_SQL` (with a special path for fresh installs that have nothing to migrate yet). That removes the maintenance burden of keeping the bootstrap list in sync with new column-with-index additions. Worth a separate issue/PR — happy to write it up if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->