### PR TITLE
fix(serve): clean up stdio MCP server on client disconnect

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,7 +1,58 @@
+import { spawnSync } from 'node:child_process';
 import type { BrainEngine } from '../core/engine.ts';
 import { startMcpServer } from '../mcp/server.ts';
 
-export async function runServe(engine: BrainEngine, args: string[] = []) {
+// Maximum time the stdio path will wait for engine.disconnect() (PGLite
+// close + advisory lock release) before forcing exit. Keeps a wedged
+// disconnect from trapping the process forever; the abandoned lock dir is
+// already covered by the in-process stale-lock check (acquireLock walks
+// the dir, sees a dead PID, and removes it).
+const CLEANUP_DEADLINE_MS = 5_000;
+
+// How often the parent-process watchdog polls the live kernel parent PID
+// (via `readLiveParentPid`, NOT the cached `process.ppid` — see that
+// helper's comment). We don't receive a signal when our parent dies (the
+// kernel just re-parents us to init / launchd), so polling is the only
+// reliable way to detect "parent went away without closing stdin". 5s
+// matches the cadence in the concurrent #591 PR; faster polling has no
+// benefit, slower would extend the lock-leak window.
+const PARENT_WATCHDOG_INTERVAL_MS = 5_000;
+
+export interface ServeOptions {
+  // Test seam — defaults to the live process. The lifecycle plumbing reads
+  // these for stdin EOF detection, signal handlers, and exit, so unit
+  // tests can drive end-to-end shutdown via mocked streams without
+  // spawning a real Bun process. `exit` is typed as `void` (not `never`)
+  // so test stubs that record + return are accepted without casts;
+  // `process.exit`'s `never` return is assignable to `void`.
+  stdin?: NodeJS.ReadableStream & { isTTY?: boolean };
+  signals?: Pick<NodeJS.Process, 'on'>;
+  exit?: (code?: number) => void;
+  log?: (msg: string) => void;
+  // Test seam: replace startMcpServer to avoid booting the real MCP SDK
+  // (which unconditionally attaches a 'data' listener to real
+  // process.stdin and would pollute the test runner's stdin handle).
+  // Defaults to the real implementation when omitted.
+  startMcpServer?: (engine: BrainEngine) => Promise<void>;
+  // Test seam for the parent-process watchdog. The default
+  // (`readLiveParentPid`) reads the live kernel PPID via `ps` because
+  // `process.ppid` is captured at process creation and does not refresh
+  // on re-parent (Node/Bun parity). Tests inject a stub so they can
+  // simulate the parent dying without spawning ps or re-parenting any
+  // real process.
+  getParentPid?: () => number;
+  // Test seam: replace setInterval/clearInterval so the watchdog can
+  // fire deterministically in tests instead of waiting 5s. Defaults to
+  // the global timer functions.
+  setInterval?: (fn: () => void, ms: number) => unknown;
+  clearInterval?: (handle: unknown) => void;
+}
+
+export async function runServe(
+  engine: BrainEngine,
+  args: string[] = [],
+  opts: ServeOptions = {},
+) {
   // v0.26+: --http dispatches to the full OAuth 2.1 server (serve-http.ts)
   // with admin dashboard, scope enforcement, SSE feed, and the requireBearerAuth
   // middleware. Master's simpler startHttpTransport from v0.22.7 is superseded
@@ -24,8 +75,223 @@ export async function runServe(engine: BrainEngine, args: string[] = []) {
 
     const { runServeHttp } = await import('./serve-http.ts');
     await runServeHttp(engine, { port, tokenTtl, enableDcr, publicUrl });
-  } else {
-    console.error('Starting GBrain MCP server (stdio)...');
-    await startMcpServer(engine);
+    return;
   }
+
+  // stdio path — install lifecycle handlers BEFORE startMcpServer so that
+  // an early stdin EOF (parent died before our first read) can still
+  // trigger graceful release of the PGLite write lock held by `engine`.
+  // The HTTP / OAuth path above has its own lifecycle in serve-http.ts
+  // and is intentionally NOT wired into this stdio plumbing.
+  console.error('Starting GBrain MCP server (stdio)...');
+
+  installStdioLifecycle(engine, args, opts);
+
+  const start = opts.startMcpServer ?? startMcpServer;
+  await start(engine);
+  // startMcpServer's `await server.connect(transport)` resolves once the
+  // SDK has wired up its stdin 'data' listener; that listener keeps the
+  // event loop alive. We deliberately do NOT add `await new Promise(() =>
+  // {})` here — it would block this async frame and stop the lifecycle
+  // hooks from being able to call process.exit() cleanly.
+}
+
+interface StdioLifecycleDeps {
+  stdin: NodeJS.ReadableStream & { isTTY?: boolean };
+  signals: Pick<NodeJS.Process, 'on'>;
+  exit: (code?: number) => void;
+  log: (msg: string) => void;
+  getParentPid: () => number;
+  setInterval: (fn: () => void, ms: number) => unknown;
+  clearInterval: (handle: unknown) => void;
+}
+
+function installStdioLifecycle(
+  engine: BrainEngine,
+  args: string[],
+  opts: ServeOptions,
+): void {
+  const deps: StdioLifecycleDeps = {
+    stdin: opts.stdin ?? process.stdin,
+    signals: opts.signals ?? process,
+    exit: opts.exit ?? ((code?: number) => { process.exit(code); }),
+    log: opts.log ?? ((msg: string) => console.error(msg)),
+    getParentPid: opts.getParentPid ?? readLiveParentPid,
+    setInterval: opts.setInterval ?? ((fn, ms) => setInterval(fn, ms)),
+    clearInterval: opts.clearInterval ?? ((h) => clearInterval(h as ReturnType<typeof setInterval>)),
+  };
+
+  let shuttingDown = false;
+  let parentWatchdog: unknown = null;
+  const beginShutdown = (reason: string): void => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+
+    // Stop the parent-watchdog interval as soon as a shutdown begins so
+    // it cannot fire a redundant 'parent-died' shutdown while the first
+    // one is still draining the cleanup chain.
+    if (parentWatchdog !== null) {
+      deps.clearInterval(parentWatchdog);
+      parentWatchdog = null;
+    }
+
+    deps.log(`GBrain MCP server: graceful exit (${reason})`);
+
+    // Race the cleanup against a deadline. engine.disconnect() does a
+    // PGLite WASM close + a synchronous rmSync on the lock dir; both
+    // should be sub-second, but a wedged WASM runtime shouldn't be able
+    // to trap us forever. If we hit the deadline we still exit; the
+    // lock dir is advisory and the next process's stale-lock check
+    // (process.kill(pid, 0) → ESRCH) will reclaim it.
+    const deadline = setTimeout(() => {
+      deps.log(
+        `GBrain MCP server: cleanup deadline (${CLEANUP_DEADLINE_MS}ms) exceeded — forcing exit`,
+      );
+      deps.exit(0);
+    }, CLEANUP_DEADLINE_MS);
+    deadline.unref?.();
+
+    Promise.resolve()
+      .then(() => engine.disconnect())
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        deps.log(`GBrain MCP server: cleanup error: ${msg}`);
+      })
+      .finally(() => {
+        clearTimeout(deadline);
+        deps.exit(0);
+      });
+  };
+
+  // Signal-based termination. SIGTERM: daemon ask. SIGINT: user Ctrl-C.
+  // SIGHUP: terminal disconnect / daemon-style "reload" channels — Aragorn
+  // observed real-world hosts (Claude Desktop on macOS, hermes-agent
+  // restart) send these instead of closing stdin. All three get the same
+  // graceful path; the idempotency guard absorbs duplicate signals.
+  deps.signals.on('SIGTERM', () => beginShutdown('SIGTERM'));
+  deps.signals.on('SIGINT', () => beginShutdown('SIGINT'));
+  deps.signals.on('SIGHUP', () => beginShutdown('SIGHUP'));
+
+  // Stdin EOF — the parent closes the pipe but the MCP SDK's
+  // StdioServerTransport only listens for 'data'/'error', not 'end' or
+  // 'close', so without these hooks the process keeps the engine (and its
+  // PGLite write lock) live indefinitely after the parent disconnects.
+  // 'end' fires on a clean EOF; 'close' fires when the underlying handle
+  // is destroyed (e.g. parent SIGKILL'd while pipe still open). Both
+  // converge on the same idempotent shutdown.
+  // Skip when stdin is a TTY: interactive `gbrain serve` use shouldn't
+  // terminate just because the user hasn't typed anything. Signal /
+  // watchdog paths still cover that case if needed.
+  if (!deps.stdin.isTTY) {
+    deps.stdin.once('end', () => beginShutdown('stdin-end'));
+    deps.stdin.once('close', () => beginShutdown('stdin-close'));
+  }
+
+  // Parent-process watchdog. Some hosts (launchd, cron, certain MCP
+  // gateways) terminate without closing stdin and without sending a
+  // signal — the kernel just re-parents us to init (PID 1). Polling
+  // is the only portable way to notice; see `readLiveParentPid` for why
+  // we cannot rely on `process.ppid` (cached at process creation and
+  // never refreshed on re-parent in Node or Bun). We capture the initial
+  // parent at install time so a process that was *legitimately* started
+  // under PID 1 (e.g. a systemd service) doesn't immediately shut itself
+  // down. `unref()` keeps the interval from blocking other
+  // exit paths.
+  const initialParentPid = deps.getParentPid();
+  if (initialParentPid !== 1) {
+    parentWatchdog = deps.setInterval(() => {
+      if (deps.getParentPid() === 1) {
+        beginShutdown('parent-died');
+      }
+    }, PARENT_WATCHDOG_INTERVAL_MS);
+    (parentWatchdog as { unref?: () => void } | null)?.unref?.();
+  }
+
+  // Optional idle-timeout safety net. Default OFF; opt-in via
+  // `--stdio-idle-timeout <seconds>`. The flag is for the rare case where
+  // the parent leaks the stdin pipe but never closes it (so 'end' never
+  // fires) and never sends another message — we'd otherwise sit on the
+  // PGLite lock forever. Off by default because most parents close
+  // properly and an over-eager idle timeout would surprise long-poll
+  // workloads.
+  const idleTimeoutSec = parseStdioIdleTimeout(args);
+  if (idleTimeoutSec > 0) {
+    let idleTimer: ReturnType<typeof setTimeout> | null = null;
+    const armIdle = (): void => {
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(
+        () => beginShutdown(`stdio-idle-timeout (${idleTimeoutSec}s)`),
+        idleTimeoutSec * 1000,
+      );
+      idleTimer.unref?.();
+    };
+    armIdle();
+    // Reset on every chunk. We can't observe SDK-parsed messages from
+    // here, but every JSON-RPC frame causes a 'data' event on stdin, so
+    // chunk-level granularity is sufficient.
+    deps.stdin.on('data', armIdle);
+    deps.log(`GBrain MCP server: stdio idle timeout = ${idleTimeoutSec}s`);
+  }
+}
+
+/**
+ * Resolve the live parent PID from the kernel (not the cached startup
+ * value). Both Node and Bun expose `process.ppid` as a property captured
+ * at process creation, so it does NOT update when the kernel re-parents
+ * us to PID 1 after the original parent dies — which is the exact event
+ * the watchdog needs to detect. Empirical evidence on macOS / Bun 1.3.12:
+ * `process.ppid` stays at the original parent ID indefinitely while
+ * `ps -o ppid= -p $$` reports `1` within one tick.
+ *
+ * Cost: ~10ms per spawn. Called every 5s (PARENT_WATCHDOG_INTERVAL_MS),
+ * so amortized < 0.5% CPU. Falls back to `process.ppid` if `ps` fails
+ * (best-effort safety net for stripped-down containers, etc.).
+ */
+function readLiveParentPid(): number {
+  try {
+    const r = spawnSync('ps', ['-o', 'ppid=', '-p', String(process.pid)], {
+      encoding: 'utf8',
+      timeout: 1000,
+    });
+    if (r.status === 0 && typeof r.stdout === 'string') {
+      const n = parseInt(r.stdout.trim(), 10);
+      if (Number.isInteger(n) && n >= 0) return n;
+    }
+  } catch {
+    /* fall through */
+  }
+  return process.ppid;
+}
+
+function parseStdioIdleTimeout(args: string[]): number {
+  const idx = args.indexOf('--stdio-idle-timeout');
+  if (idx < 0) return 0;
+  const raw = args[idx + 1];
+  // Strict parsing — silent fallback to 0 turns an opt-in safety net into
+  // a no-op when an operator typos the value (e.g. `--stdio-idle-timeout
+  // 30s`). `Number()` rejects partial parses like `30junk` (returns NaN),
+  // unlike `parseInt` which would silently accept it. A missing value
+  // (`--stdio-idle-timeout` at end of args) and any non-integer / negative
+  // value are surfaced as a CLI error before we install the timer.
+  if (raw === undefined) {
+    throw new Error(
+      '--stdio-idle-timeout requires a non-negative integer (seconds). Got: (missing value)',
+    );
+  }
+  // Reject empty / whitespace-only explicitly: `Number('')` is 0 in JS,
+  // which would silently turn `--stdio-idle-timeout ""` into the
+  // documented opt-out — the exact silent-fallback failure mode this
+  // strict parser exists to prevent.
+  if (raw.trim() === '') {
+    throw new Error(
+      '--stdio-idle-timeout requires a non-negative integer (seconds). Got: (blank value)',
+    );
+  }
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new Error(
+      `--stdio-idle-timeout requires a non-negative integer (seconds). Got: ${JSON.stringify(raw)}`,
+    );
+  }
+  return n;
 }

--- a/test/serve-stdio-lifecycle.test.ts
+++ b/test/serve-stdio-lifecycle.test.ts
@@ -1,0 +1,388 @@
+import { describe, test, expect } from 'bun:test';
+import { EventEmitter } from 'events';
+import { runServe, type ServeOptions } from '../src/commands/serve';
+import type { BrainEngine } from '../src/core/engine';
+
+// These tests cover the stdio lifecycle hooks added to runServe so that the
+// PGLite write lock is released when the parent disconnects. We don't spawn
+// a real Bun child or boot the real MCP SDK; we inject a stub `engine`, a
+// fake stdin Readable (EventEmitter is enough — only on/once/emit are
+// touched), an injected exit() that resolves a promise instead of
+// terminating the process, and (per Codex Layer 2 review feedback) a
+// no-op startMcpServer stub so the real MCP SDK never attaches a 'data'
+// listener to the test runner's actual process.stdin.
+
+class StubEngine implements Partial<BrainEngine> {
+  // Track whether disconnect was called; the lock-release behavior we care
+  // about here is "did the lifecycle path actually invoke disconnect?".
+  disconnectCalls = 0;
+  disconnect = async (): Promise<void> => {
+    this.disconnectCalls += 1;
+  };
+}
+
+class StubSignals {
+  private handlers = new Map<string, Array<(...a: unknown[]) => void>>();
+  on(signal: string, handler: (...a: unknown[]) => void): this {
+    const list = this.handlers.get(signal) ?? [];
+    list.push(handler);
+    this.handlers.set(signal, list);
+    return this;
+  }
+  emit(signal: string): void {
+    for (const h of this.handlers.get(signal) ?? []) h();
+  }
+}
+
+// Stub timer pair: `setInterval` returns a numeric handle; `tickAll()`
+// fires every registered fn once, mirroring 1 real-time tick. Lets the
+// test drive the parent-watchdog deterministically without 5s of wall
+// clock and without leaving real timers active across the suite.
+interface TimerStub {
+  setInterval: (fn: () => void, ms: number) => unknown;
+  clearInterval: (h: unknown) => void;
+  tickAll: () => void;
+  active: () => number;
+}
+
+function makeTimerStub(): TimerStub {
+  const fns = new Map<number, () => void>();
+  let next = 1;
+  return {
+    setInterval(fn) {
+      const id = next++;
+      fns.set(id, fn);
+      return id;
+    },
+    clearInterval(h) {
+      if (typeof h === 'number') fns.delete(h);
+    },
+    tickAll() {
+      for (const fn of fns.values()) fn();
+    },
+    active() {
+      return fns.size;
+    },
+  };
+}
+
+interface Harness {
+  engine: StubEngine;
+  stdin: EventEmitter & { isTTY?: boolean; on: any; once: any };
+  signals: StubSignals;
+  logs: string[];
+  exited: Promise<number>;
+  opts: ServeOptions;
+  timers: TimerStub;
+  setParentPid: (pid: number) => void;
+}
+
+function makeHarness(opts: {
+  isTTY?: boolean;
+  initialParentPid?: number;
+} = {}): Harness {
+  const engine = new StubEngine();
+  const stdin = new EventEmitter() as EventEmitter & { isTTY?: boolean };
+  if (opts.isTTY) stdin.isTTY = true;
+  const signals = new StubSignals();
+  const logs: string[] = [];
+
+  let resolveExit!: (code: number) => void;
+  const exited = new Promise<number>(r => { resolveExit = r; });
+  let exitCalled = false;
+
+  // Mutable parent-pid the test can flip; defaults to a non-1 sentinel
+  // so the watchdog *will* install (`initialParentPid !== 1` guard).
+  // Tests that want "we were spawned under PID 1" pass `initialParentPid: 1`.
+  let parentPid = opts.initialParentPid ?? 12345;
+  const timers = makeTimerStub();
+
+  const serveOpts: ServeOptions = {
+    stdin: stdin as any,
+    signals: signals as any,
+    exit: (code?: number) => {
+      if (exitCalled) return;
+      exitCalled = true;
+      resolveExit(code ?? 0);
+    },
+    log: (msg: string) => { logs.push(msg); },
+    // Replace the real MCP SDK boot with a no-op so we never touch the
+    // test runner's real process.stdin. The lifecycle hooks under test
+    // are installed *before* this is awaited, so all behaviors are still
+    // exercised end-to-end.
+    startMcpServer: async () => {},
+    getParentPid: () => parentPid,
+    setInterval: timers.setInterval,
+    clearInterval: timers.clearInterval,
+  };
+
+  return {
+    engine,
+    stdin: stdin as any,
+    signals,
+    logs,
+    exited,
+    opts: serveOpts,
+    timers,
+    setParentPid: (pid: number) => { parentPid = pid; },
+  };
+}
+
+// runServe in tests resolves quickly because the injected startMcpServer
+// is a no-op. The lifecycle hooks were installed synchronously before
+// that no-op was awaited, so they're already wired by the time runServe
+// returns. We start runServe and `await` it (so any setup error surfaces
+// immediately), then drive the test-controlled events.
+async function startInBackground(
+  engine: StubEngine,
+  args: string[],
+  opts: ServeOptions,
+): Promise<void> {
+  await runServe(engine as unknown as BrainEngine, args, opts);
+}
+
+describe('runServe stdio lifecycle', () => {
+  test('stdin end triggers engine.disconnect() and process exit(0)', async () => {
+    const h = makeHarness();
+    await startInBackground(h.engine, [], h.opts);
+
+    h.stdin.emit('end');
+    const code = await h.exited;
+
+    expect(code).toBe(0);
+    expect(h.engine.disconnectCalls).toBe(1);
+    expect(h.logs.some(l => l.includes('graceful exit (stdin-end)'))).toBe(true);
+  });
+
+  test('SIGTERM triggers graceful exit', async () => {
+    const h = makeHarness();
+    await startInBackground(h.engine, [], h.opts);
+
+    h.signals.emit('SIGTERM');
+    const code = await h.exited;
+
+    expect(code).toBe(0);
+    expect(h.engine.disconnectCalls).toBe(1);
+    expect(h.logs.some(l => l.includes('graceful exit (SIGTERM)'))).toBe(true);
+  });
+
+  test('SIGINT triggers graceful exit', async () => {
+    const h = makeHarness();
+    await startInBackground(h.engine, [], h.opts);
+
+    h.signals.emit('SIGINT');
+    const code = await h.exited;
+
+    expect(code).toBe(0);
+    expect(h.engine.disconnectCalls).toBe(1);
+    expect(h.logs.some(l => l.includes('graceful exit (SIGINT)'))).toBe(true);
+  });
+
+  test('SIGHUP triggers graceful exit (terminal disconnect / daemon reload)', async () => {
+    // Per Aragorn (#591): real-world hosts (Claude Desktop on macOS,
+    // hermes-agent restart) sometimes send SIGHUP instead of closing
+    // stdin or sending SIGTERM. The handler converges on the same
+    // graceful path as the other signals.
+    const h = makeHarness();
+    await startInBackground(h.engine, [], h.opts);
+
+    h.signals.emit('SIGHUP');
+    const code = await h.exited;
+
+    expect(code).toBe(0);
+    expect(h.engine.disconnectCalls).toBe(1);
+    expect(h.logs.some(l => l.includes('graceful exit (SIGHUP)'))).toBe(true);
+  });
+
+  test('stdin close (parent SIGKILL leaves pipe destroyed) triggers graceful exit', async () => {
+    // 'end' fires on a clean EOF; 'close' fires when the underlying
+    // handle is destroyed (e.g. parent SIGKILL'd while pipe still open).
+    // We must observe both — observing only 'end' would miss the
+    // hard-kill path that #591's reporter hit on macOS.
+    const h = makeHarness();
+    await startInBackground(h.engine, [], h.opts);
+
+    h.stdin.emit('close');
+    const code = await h.exited;
+
+    expect(code).toBe(0);
+    expect(h.engine.disconnectCalls).toBe(1);
+    expect(h.logs.some(l => l.includes('graceful exit (stdin-close)'))).toBe(true);
+  });
+
+  test('parent watchdog fires shutdown when ppid flips to 1 (orphaned to init)', async () => {
+    // Some hosts (launchd, cron, certain MCP gateways) terminate
+    // without closing stdin and without sending a signal — the kernel
+    // re-parents us to PID 1. The watchdog polls `process.ppid` on an
+    // interval; when the captured initial ppid (non-1) becomes 1, we
+    // detect "parent died" and shut down.
+    const h = makeHarness({ initialParentPid: 4242 });
+    await startInBackground(h.engine, [], h.opts);
+
+    // Watchdog should have installed (we passed initialParentPid !== 1).
+    expect(h.timers.active()).toBe(1);
+
+    // Simulate parent death: our process gets re-parented to init.
+    h.setParentPid(1);
+    h.timers.tickAll();
+
+    const code = await h.exited;
+    expect(code).toBe(0);
+    expect(h.engine.disconnectCalls).toBe(1);
+    expect(h.logs.some(l => l.includes('graceful exit (parent-died)'))).toBe(true);
+
+    // beginShutdown clears the watchdog interval as part of cleanup so
+    // a duplicate tick can't queue a redundant shutdown.
+    expect(h.timers.active()).toBe(0);
+  });
+
+  test('parent watchdog NOT installed when initial ppid is already 1 (legitimate init child)', async () => {
+    // Spawned directly under PID 1 (e.g. systemd unit, Docker entrypoint):
+    // ppid=1 is the documented steady state, not "parent died". We must
+    // NOT install the watchdog or we'd shut down immediately.
+    const h = makeHarness({ initialParentPid: 1 });
+    await startInBackground(h.engine, [], h.opts);
+
+    expect(h.timers.active()).toBe(0);
+
+    // Sanity: the other lifecycle paths still work.
+    h.signals.emit('SIGTERM');
+    await h.exited;
+    expect(h.engine.disconnectCalls).toBe(1);
+  });
+
+  test('parent watchdog tick with ppid still alive does NOT fire shutdown', async () => {
+    // The watchdog must only fire on the *transition* to ppid=1; a
+    // healthy tick (ppid still equal to the original) is a no-op.
+    const h = makeHarness({ initialParentPid: 4242 });
+    await startInBackground(h.engine, [], h.opts);
+
+    expect(h.timers.active()).toBe(1);
+    // Tick with ppid unchanged.
+    h.timers.tickAll();
+    h.timers.tickAll();
+    h.timers.tickAll();
+    expect(h.engine.disconnectCalls).toBe(0);
+
+    // ... and signal-driven shutdown still works after several quiet ticks.
+    h.signals.emit('SIGTERM');
+    await h.exited;
+    expect(h.engine.disconnectCalls).toBe(1);
+  });
+
+  test('shutdown is idempotent — multiple signals only disconnect once', async () => {
+    const h = makeHarness();
+    await startInBackground(h.engine, [], h.opts);
+
+    h.signals.emit('SIGTERM');
+    h.signals.emit('SIGTERM');
+    h.signals.emit('SIGINT');
+    h.stdin.emit('end');
+
+    await h.exited;
+    expect(h.engine.disconnectCalls).toBe(1);
+  });
+
+  test('TTY stdin does NOT install end watcher (interactive use unaffected)', async () => {
+    const h = makeHarness({ isTTY: true });
+    await startInBackground(h.engine, [], h.opts);
+
+    // Emit 'end' on TTY stdin — no listener should be wired so this is a
+    // no-op. The test passes by simply not exiting; we give the runtime a
+    // beat to confirm nothing fires. Signals must still work.
+    h.stdin.emit('end');
+    await new Promise(r => setTimeout(r, 10));
+    expect(h.engine.disconnectCalls).toBe(0);
+
+    // Sanity: signals still wired regardless of TTY-ness.
+    h.signals.emit('SIGTERM');
+    await h.exited;
+    expect(h.engine.disconnectCalls).toBe(1);
+  });
+
+  test('--stdio-idle-timeout 0 disarms the idle hook (sanity)', async () => {
+    const h = makeHarness();
+    await startInBackground(h.engine, ['--stdio-idle-timeout', '0'], h.opts);
+
+    // 0 is the documented opt-out. No idle hook should be armed; drive a
+    // different exit path to confirm flow still works.
+    h.signals.emit('SIGTERM');
+    await h.exited;
+    expect(h.engine.disconnectCalls).toBe(1);
+    expect(h.logs.every(l => !l.includes('idle timeout'))).toBe(true);
+  });
+
+  test('--stdio-idle-timeout > 0 logs the configured value', async () => {
+    const h = makeHarness();
+    await startInBackground(h.engine, ['--stdio-idle-timeout', '60'], h.opts);
+
+    expect(h.logs.some(l => l.includes('stdio idle timeout = 60s'))).toBe(true);
+
+    h.signals.emit('SIGTERM');
+    await h.exited;
+    expect(h.engine.disconnectCalls).toBe(1);
+  });
+
+  test('idle timer is reset on every stdin data chunk', async () => {
+    const h = makeHarness();
+    // Use a very short timeout so we can observe the firing/resetting
+    // without slowing the suite. 50ms is enough to be measurable but
+    // short enough that the suite finishes promptly.
+    await startInBackground(
+      h.engine,
+      ['--stdio-idle-timeout', '1'], // 1 second; we reset it before it fires
+      h.opts,
+    );
+
+    // Pulse 'data' a few times to keep the timer reset.
+    for (let i = 0; i < 3; i++) {
+      h.stdin.emit('data', Buffer.from('{"jsonrpc":"2.0"}'));
+      await new Promise(r => setTimeout(r, 100));
+    }
+    expect(h.engine.disconnectCalls).toBe(0);
+
+    // Now stop pulsing and wait for the timer to actually fire end-to-end
+    // (it ought to elapse within ~1s of the last reset). Awaiting
+    // h.exited rather than a wall-clock race makes this deterministic.
+    await h.exited;
+    expect(h.engine.disconnectCalls).toBe(1);
+    expect(h.logs.some(l => l.includes('stdio-idle-timeout (1s)'))).toBe(true);
+  }, 5000);
+
+  test.each([
+    ['abc', /--stdio-idle-timeout/],
+    ['30junk', /--stdio-idle-timeout/],
+    ['-1', /--stdio-idle-timeout/],
+    ['1.5', /--stdio-idle-timeout/],
+    ['', /--stdio-idle-timeout/],
+  ])('--stdio-idle-timeout rejects invalid value %p (typo is a CLI error)', async (bad, msgRe) => {
+    // Per Codex Layer 2 review P1: silent fallback on typo turns the
+    // opt-in safety net into a no-op. Strict parsing throws so the
+    // operator sees the mistake immediately.
+    const h = makeHarness();
+    expect(
+      runServe(h.engine as unknown as BrainEngine, ['--stdio-idle-timeout', bad], h.opts),
+    ).rejects.toThrow(msgRe);
+  });
+
+  test('--stdio-idle-timeout with no following value also throws', async () => {
+    const h = makeHarness();
+    // Flag at end of args — no value to consume.
+    expect(
+      runServe(h.engine as unknown as BrainEngine, ['--stdio-idle-timeout'], h.opts),
+    ).rejects.toThrow(/missing value/);
+  });
+
+  test('engine.disconnect throwing still results in exit(0) and logged error', async () => {
+    const h = makeHarness();
+    h.engine.disconnect = async () => {
+      throw new Error('synthetic disconnect failure');
+    };
+    await startInBackground(h.engine, [], h.opts);
+
+    h.signals.emit('SIGTERM');
+    const code = await h.exited;
+    expect(code).toBe(0);
+    expect(h.logs.some(l => l.includes('cleanup error: synthetic disconnect failure'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`gbrain serve` (stdio mode) leaks the PGLite write lock when the parent process disconnects. Three structural gaps:

1. `src/commands/serve.ts` never calls `engine.disconnect()` after `startMcpServer(engine)` resolves.
2. `src/cli.ts:case 'serve'` short-circuits with `// serve doesn't disconnect`.
3. The MCP SDK's `StdioServerTransport` (`@modelcontextprotocol/sdk`) only registers `'data'` / `'error'` listeners on stdin — never `'end'` / `'close'` — so even a clean stdin EOF never reaches the SDK.

Net effect: the server keeps the engine and its `<datadir>/.gbrain-lock/lock` acquired indefinitely after the parent disconnects. The next `gbrain serve` either times out or waits for the in-process 5-minute stale-lock check.

## Scope

Stdio path only. The v0.26+ HTTP / OAuth path (`runServeHttp` in `serve-http.ts`) is preserved verbatim.

## Patch

`src/commands/serve.ts`:

- **Stdin EOF + close watchers** — `once('end')` and `once('close')`, gated on `!isTTY` so interactive `gbrain serve` in a terminal is unaffected. `'end'` covers clean parent disconnect; `'close'` covers a SIGKILL'd parent leaving the handle destroyed.
- **`SIGTERM` / `SIGINT` / `SIGHUP` handlers** — funneled into the same idempotent shutdown path. SIGHUP coverage matters in real deployments (Claude Desktop on macOS, MCP gateway restarts).
- **Parent-process watchdog** — 5s polling, gated on `initialParentPid !== 1` (so a process legitimately spawned under PID 1 like a systemd unit doesn't immediately self-terminate). Detects launchd / cron / orphan scenarios where the parent dies without closing stdin or sending a signal.
- **5-second cleanup deadline** — if `engine.disconnect()` wedges (PGLite WASM stall, etc.), the process still calls `process.exit(0)`. Any abandoned lock dir is reclaimed on the next attempt by the existing `process.kill(pid, 0)` stale-lock check in `pglite-lock.ts`.
- **Optional `--stdio-idle-timeout <sec>`** — default OFF safety net for parents that leak the pipe but never close it and never send another message. Strict parsing: typos / blank values throw immediately instead of silently disabling the safety net (closes #446).

Test seam: `ServeOptions { stdin, signals, exit, log, startMcpServer, getParentPid, setInterval, clearInterval }` lets the lifecycle be unit-tested without spawning a real Bun child or booting the real MCP SDK. Fake timers drive the watchdog deterministically without 5s of wall clock.

## `process.ppid` is cached on Bun (and never updates on re-parent)

While building real-process repro evidence, I found that `process.ppid` in Bun (and Node — see [oven-sh/bun#30305](https://github.com/oven-sh/bun/issues/30305) filed by @Aragorn2046) is captured at process creation and never refreshed when the kernel re-parents the child to PID 1. The kernel re-parents correctly within one second (`ps -o ppid= -p $$` returns `1`), but `process.ppid` stays at the original parent's PID for the entire process lifetime.

```
startup process.ppid=87589
tick    process.ppid=87589  live(ps)=87589
tick    process.ppid=87589  live(ps)=1     ← kernel re-parented; process.ppid did NOT update
tick    process.ppid=87589  live(ps)=1
tick    process.ppid=87589  live(ps)=1
```

So a naive `if (process.ppid === 1)` watchdog will not actually fire in a real launchd / cron / orphaned-PPID scenario. The patch routes through a `readLiveParentPid()` helper that calls `spawnSync('ps', ['-o', 'ppid=', '-p', String(process.pid)])` per tick (~10ms / 5s, falls back to `process.ppid` if `ps` fails). This was the difference between the watchdog firing and not firing in the harness below.

## Tests

`test/serve-stdio-lifecycle.test.ts` — 20 cases, all passing on the rebased branch:

- Signals: `SIGTERM` / `SIGINT` / `SIGHUP` each trigger graceful exit (3).
- Stdin EOF: `'end'` and `'close'` each trigger graceful exit (2).
- TTY stdin does NOT install end watcher (interactive use unaffected) (1).
- Idempotency: multiple racing signals only `engine.disconnect()` once (1).
- Cleanup deadline: when `engine.disconnect()` rejects, exit still happens with `code=0` and a logged error (1).
- Watchdog: fires on ppid `0 → 1`, NOT installed when initial ppid is already 1, no false fire on healthy ticks (3).
- `--stdio-idle-timeout`: arms / resets on data / fires on idle / 0 disarms / strict parse rejects `abc` / `30junk` / `-1` / `1.5` / blank / missing (9).

Adjacent unit suites (`cli`, `cli-options`, `mcp-tool-defs`, `pglite-lock`, `mcp-eval-capture`): 77/77 unchanged.

Full `bun test` on the rebased branch: 3864 pass / 341 skip / 4 fail. The 4 failures (`brain-registry.serial`, `cli-options skillpack-check timeout`, two `e2e/dream-cycle-eight-phase-pglite` cases) all reproduce identically on `9c2dc4c` master without this patch — pre-existing on upstream, no regression introduced by this PR.

`bun run typecheck`: clean.

## Real-process repro

Harness (`run.sh` + `parent.py`) drives 4 disconnect cases against two builds — baseline = upstream `9c2dc4c`, patched = this branch — with `GBRAIN_HOME` pointing at a fresh PGLite per case. Lock state is captured BEFORE running `gbrain stats` so `stats`'s own stale-lock cleanup can't skew the snapshot. Primary signal = child liveness + lock dir's PID JSON + `kill -0`; `gbrain stats` latency is secondary.

| case | side | child PID | lock state (pre-stats) | `stats` (latency) | lifecycle reason |
|------|------|-----------|------------------------|--------------------|------------------|
| stdin-close | baseline | alive | live-lock pid=88224 | timeout-8s (8s) | (none) |
| stdin-close | patched | alive | no-lock-dir | ok (0s) | graceful exit (stdin-end) |
| sigterm | baseline | alive | live-lock pid=88331 | timeout-8s (8s) | (none) |
| sigterm | patched | alive | no-lock-dir | ok (0s) | graceful exit (SIGTERM) |
| sigkill-parent | baseline | dead | stale-lock pid=88415 | ok (0s) | (none) |
| sigkill-parent | patched | dead | no-lock-dir | ok (1s) | graceful exit (stdin-end) |
| watchdog-fifo | baseline | alive | live-lock pid=88573 | timeout-8s (8s) | (none) |
| watchdog-fifo | patched | dead | no-lock-dir | ok (1s) | graceful exit (parent-died) |

`watchdog-fifo` is the launchd / orphan case — child's stdin is held open by an external keeper (named FIFO) so the patch cannot fall through to stdin EOF; only the watchdog can detect parent death. That row was the one that would have silently failed without the `process.ppid` → `spawnSync('ps')` fix.

Environment: macOS arm64, Bun 1.3.12.

## Cross-references

- **Supersedes #591** (per @Aragorn2046's request — see [#591 (comment)](https://github.com/garrytan/gbrain/pull/591#issuecomment-4377041986) and follow-ups). SIGHUP / stdin `'close'` / parent-process watchdog credit stays with @Aragorn2046's three features in the commit message.
- Closes #413 — "MCP serve: stdin=/dev/null causes lock contention after gateway restart".
- Closes #446 — "Feature request: `gbrain serve` idle timeout".
- Related to [oven-sh/bun#30305](https://github.com/oven-sh/bun/issues/30305) — `process.ppid` Bun-cache bug that motivates the `readLiveParentPid()` fallback (filed by @Aragorn2046 with confirmation that Node.js refreshes ppid correctly in the same scenario).

cc @Aragorn2046

---

*Patch, repro harness, and PR body drafted in a [Claude Code](https://claude.com/claude-code) (Opus 4.7) session. Submitted by @seungsu-kr after sign-off.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->