### PR TITLE
fix(doctor): use autoDetectSkillsDir so OpenClaw workspaces are reachable

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3,7 +3,7 @@ import * as db from '../core/db.ts';
 import { LATEST_VERSION, getIdleBlockers } from '../core/migrate.ts';
 import { checkResolvable } from '../core/check-resolvable.ts';
 import { autoFixDryViolations, type AutoFixReport, type FixOutcome } from '../core/dry-fix.ts';
-import { findRepoRoot } from '../core/repo-root.ts';
+import { autoDetectSkillsDir } from '../core/repo-root.ts';
 import { loadCompletedMigrations } from '../core/preferences.ts';
 import { compareVersions } from './migrations/index.ts';
 import { createProgress, startHeartbeat, type ProgressReporter } from '../core/progress.ts';
@@ -59,9 +59,12 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
   // --- Filesystem checks (always run, no DB needed) ---
 
   // 1. Resolver health
-  const repoRoot = findRepoRoot();
-  if (repoRoot) {
-    const skillsDir = join(repoRoot, 'skills');
+  // Use the same auto-detect as `check-resolvable` so doctor sees a
+  // workspace/skills dir reachable via $OPENCLAW_WORKSPACE or
+  // ~/.openclaw/workspace, not just a `skills/` walked up from cwd.
+  const detected = autoDetectSkillsDir();
+  const skillsDir = detected.dir;
+  if (skillsDir) {
 
     // --fix: run auto-repair BEFORE checkResolvable so the post-fix scan
     // reflects the new state. Auto-fix only targets DRY violations today;
@@ -99,8 +102,7 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
   }
 
   // 2. Skill conformance
-  if (repoRoot) {
-    const skillsDir = join(repoRoot, 'skills');
+  if (skillsDir) {
     const conformanceResult = checkSkillConformance(skillsDir);
     checks.push(conformanceResult);
   }


### PR DESCRIPTION
## What

`gbrain doctor` is the only consumer of `findRepoRoot()` from `core/repo-root.ts`. Every other consumer (`check-resolvable.ts:145`, `skillify.ts`, etc.) uses `autoDetectSkillsDir()`, which has the full detection chain:

1. `\$OPENCLAW_WORKSPACE`
2. `~/.openclaw/workspace`
3. `findRepoRoot()` walk from cwd
4. `./skills`

`findRepoRoot` only does step 3. Result: when the user runs `gbrain doctor` from any directory outside the gbrain repo or the OpenClaw workspace tree (e.g., a project checkout), `resolver_health` reports `Could not find skills directory` even though the dispatcher exists at `~/.openclaw/workspace/skills/RESOLVER.md`.

## Repro

In any directory other than `~/gbrain` or its descendants, on a system with `~/.openclaw/workspace/skills/RESOLVER.md` present:

\`\`\`
\$ cd ~/Documents
\$ gbrain doctor
  [WARN] resolver_health: Could not find skills directory   # before
\`\`\`

But:

\`\`\`
\$ gbrain check-resolvable --verbose
Auto-detected skills directory from ~/.openclaw/workspace/skills: /Users/.../.openclaw/workspace/skills
\`\`\`

Same machine, same setup, two different commands disagree on whether the skills dir exists. The disagreement is the bug.

## Fix

Switch doctor to `autoDetectSkillsDir`. Brings it inline with the rest of the codebase. The detected dir is now also passed to `checkSkillConformance` (step 2 of the resolver_health block), which previously rebuilt the path from `repoRoot` — now uses the same detected path for consistency.

## Test

All 15 existing tests in `test/doctor.test.ts` continue to pass.

\`\`\`
\$ bun test test/doctor.test.ts
15 pass, 0 fail, 39 expect() calls
\`\`\`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->