### PR TITLE
fix(mcp): exit serve process on stdin-close/SIGTERM

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -32,6 +32,26 @@ export async function startMcpServer(engine: BrainEngine) {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
+
+  // Exit cleanly when MCP client disconnects (stdin EOF) or on signals.
+  // Without this, orphaned serve processes accumulate and contend for the
+  // PGLite write lock, causing ingest jobs (email-sync) to time out.
+  let shuttingDown = false;
+  const shutdown = (reason: string, code = 0) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    process.stderr.write(`[gbrain-serve] shutdown: ${reason}\n`);
+    Promise.resolve(engine.disconnect?.())
+      .catch(() => {})
+      .finally(() => process.exit(code));
+  };
+  process.stdin.on('end', () => shutdown('stdin end'));
+  process.stdin.on('close', () => shutdown('stdin close'));
+  // @ts-ignore — SDK exposes onclose on transport
+  transport.onclose = () => shutdown('transport close');
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGHUP', () => shutdown('SIGHUP'));
 }
 
 // Backward compat: used by `gbrain call` command (trusted local path).


### PR DESCRIPTION
## Summary

The MCP stdio server in `src/mcp/server.ts` doesn't exit when its client disconnects. The `bun` process keeps running, holding open the PGLite data directory.

## Symptom that surfaced this

Over days of normal use, 20+ orphaned `gbrain serve` processes accumulated. Because PGLite is single-writer, they contended for the write lock. Email sync hit its 15s per-put timeout on every page: 114 puts × 15s = 28.5min runs that wrote 0 emails. This was the root cause behind a "no gbrain run in 50h" alert in my setup.

## Fix

After `server.connect(transport)`, listen for the standard MCP stdio shutdown signals:
- `process.stdin` `end` and `close` (client disconnect → EOF on stdin)
- `transport.onclose` (MCP SDK's own signal)
- `SIGTERM` / `SIGINT` / `SIGHUP` (orchestrator shutdown)

Each path calls `engine.disconnect?.()` and `process.exit(0)`. A `shuttingDown` flag prevents double-execution if multiple signals fire.

## Test plan

- [x] Reproduced original behavior: `gbrain serve` left running after Claude Code disconnected; orphans stacked up across days
- [x] With fix: stdin EOF → `[gbrain-serve] shutdown: stdin end\n` on stderr → process exits cleanly
- [x] Verified `engine.disconnect()` is awaited before exit so PGLite lock releases
- [x] No change to dispatch path or tool call behavior

## Files

- `src/mcp/server.ts` — +20 lines, no removals

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->