### PR TITLE
feat(link-extraction): add incidents, releases, adrs, retros, postmortems to DIR_PATTERN

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -44,7 +44,7 @@ export type LinkResolutionType = 'qualified' | 'unqualified';
  *   - Our domain extensions: tech, finance, personal, openclaw (domain-organized wikis)
  *   - Our entity prefix: entities (we kept some legacy entities/projects/ pages)
  */
-const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities)';
+const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities|incidents|releases|adrs|retros|postmortems)';
 
 /**
  * Match `[Name](path)` markdown links pointing to entity directories.


### PR DESCRIPTION
## Summary

- Extends `DIR_PATTERN` in `src/core/link-extraction.ts` with five SRE / release-engineering page-type prefixes: `incidents`, `releases`, `adrs`, `retros`, `postmortems`
- Without this, wikilinks like `[[incidents/2026-05-06-some-slug]]` parse via the wikilink regex but the slug fails the directory whitelist used by `ENTITY_REF_RE`, the wikilink resolver, and the bare-slug matcher inside `extractPageLinks` — so `extract links` silently drops them
- One-line change; no new exports, no schema impact, no perf change (regex alternation widens by 5 alternatives)

## Motivation

I'm using gbrain as a project knowledge base and started writing SRE-style postmortem pages and Keep-a-Changelog release notes under `incidents/` and `releases/` slugs. Both pages cross-referenced each other via wikilinks, but `gbrain extract links --source db --include-frontmatter` reported `Links: created 0 from 251 pages`. Tracing through `link-extraction.ts:47`, the issue is the directory whitelist — these are common page-type prefixes that other gbrain users will likely hit too.

## Test plan

- [x] `bun test test/link-extraction.test.ts test/extract.test.ts test/extract-fs.test.ts test/extract-db.test.ts test/backlinks.test.ts` → 119 pass / 0 fail
- [x] `bun run typecheck` → clean
- [x] Live verification: ran `gbrain extract links --source db --include-frontmatter` against a 251-page brain with one `incidents/...` page and one `releases/...` page cross-referencing each other; both directions extracted as `mentions` edges (vs 0 before the patch)
- [ ] Maintainer review — happy to add unit-test fixtures under `test/link-extraction.test.ts` covering the five new dirs if you'd like before merging

## Notes

- Five existing manual MCP-created edges between the same two pages survived re-extraction (extract uses `(from, to, link_type)` as natural key), so the patch is idempotent for already-populated graphs
- Open to renaming/dropping any of the five if some don't fit your taxonomy — `postmortems` in particular overlaps with `incidents` for some teams; happy to drop it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->