### PR TITLE
feat(ai/recipes): add llama-server recipe for local embeddings

### DIFF
--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -10,6 +10,7 @@ import { openai } from './openai.ts';
 import { google } from './google.ts';
 import { anthropic } from './anthropic.ts';
 import { ollama } from './ollama.ts';
+import { llamaServer } from './llama-server.ts';
 import { voyage } from './voyage.ts';
 import { litellmProxy } from './litellm-proxy.ts';
 import { deepseek } from './deepseek.ts';
@@ -21,6 +22,7 @@ const ALL: Recipe[] = [
   google,
   anthropic,
   ollama,
+  llamaServer,
   voyage,
   litellmProxy,
   deepseek,

--- a/src/core/ai/recipes/llama-server.ts
+++ b/src/core/ai/recipes/llama-server.ts
@@ -1,0 +1,37 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * llama.cpp server (`llama-server --embeddings`) exposes an OpenAI-compatible
+ * /embeddings endpoint. Used for fully-local, zero-cost embeddings (e.g.
+ * Qwen3-Embedding-0.6B Q4_K_M GGUF on Apple Silicon via MPS).
+ *
+ * Distinct from the `ollama` recipe: ollama defaults to port 11434 and ships
+ * its own model catalog; llama-server defaults to 8080 and runs whatever GGUF
+ * you point it at.
+ */
+export const llamaServer: Recipe = {
+  id: 'llama-server',
+  name: 'llama.cpp server (local)',
+  tier: 'openai-compat',
+  implementation: 'openai-compatible',
+  base_url_default: 'http://localhost:8080/v1',
+  auth_env: {
+    required: [], // Local server is unauthenticated; users pass `local` as the key.
+    optional: ['GBRAIN_EMBEDDING_BASE_URL', 'GBRAIN_EMBEDDING_API_KEY'],
+    setup_url: 'https://github.com/ggml-org/llama.cpp',
+  },
+  touchpoints: {
+    embedding: {
+      models: [
+        'Qwen/Qwen3-Embedding-0.6B',
+        'Qwen/Qwen3-Embedding-4B',
+        'Qwen/Qwen3-Embedding-8B',
+      ],
+      default_dims: 1024, // Qwen3-Embedding-0.6B native dim
+      cost_per_1m_tokens_usd: 0,
+      price_last_verified: '2026-05-07',
+    },
+  },
+  setup_hint:
+    'Install llama.cpp, download a Qwen3-Embedding GGUF, then `llama-server --embeddings -m <model.gguf>` (default port 8080).',
+};


### PR DESCRIPTION
## Summary

Adds `llama.cpp`'s `llama-server --embeddings` as a registered openai-compatible provider, sitting alongside the existing `ollama` recipe.

|              | `ollama`              | `llama-server` (new) |
|--------------|-----------------------|----------------------|
| Default port | 11434                 | 8080                 |
| Catalog      | Ships own model store | Any GGUF you load    |
| Auth         | Optional `OLLAMA_*`   | Optional `GBRAIN_EMBEDDING_*` |
| Cost         | $0                    | $0                   |

Lets users pin a fully-local, zero-cost embedding stack — e.g. **Qwen3-Embedding-0.6B Q4_K_M** GGUF (385 MB, 1024d) reaches ~260 embeddings/s on Apple Silicon via MPS.

## Why a separate recipe

`ollama` and `llama-server` collide on neither port nor configuration env, and serve genuinely different workflows: ollama is one-binary-pulls-models; llama-server is bring-your-own-GGUF for users who want to swap quantizations or run models that don't ship via `ollama pull`. Folding both under one recipe would force per-user `OLLAMA_BASE_URL` overrides for what is functionally a different process.

## Touchpoints

Only `embedding` declared. The recipe lists the three Qwen3-Embedding sizes (0.6B / 4B / 8B) since those are the dominant local-embedding workloads on consumer GPUs / Apple Silicon today. `default_dims: 1024` matches Qwen3-Embedding-0.6B's native output.

## Verification

- `bun test test/ai/` → 60 pass / 0 fail (recipe registry resolves cleanly, no shadowing of existing entries).
- Confirmed schema templating still works with `(1024, 'Qwen/Qwen3-Embedding-0.6B')` substitutions via `getPGLiteSchema()`.

## Out of scope (intentional)

- No gateway-level switching: gateway already dispatches openai-compat recipes uniformly via `OpenAI` SDK with custom `baseURL` — no recipe-specific code needed.
- No env autoconfiguration / "if `GBRAIN_EMBEDDING_BASE_URL` looks like 8080, pick this recipe": users wire it explicitly via `gbrain config set embedding_model llama-server:Qwen/Qwen3-Embedding-0.6B`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->