### PR TITLE
feat(dream): support .md files in transcript discovery

### DIFF
--- a/src/core/cycle/transcript-discovery.ts
+++ b/src/core/cycle/transcript-discovery.ts
@@ -127,7 +127,7 @@ function listTextFiles(dir: string): string[] {
   }
   const out: string[] = [];
   for (const name of entries) {
-    if (!name.endsWith('.txt')) continue;
+    if (!name.endsWith('.txt') && !name.endsWith('.md')) continue;
     const full = join(dir, name);
     try {
       if (statSync(full).isFile()) out.push(full);
@@ -161,7 +161,8 @@ export function discoverTranscripts(opts: DiscoverOpts): DiscoveredTranscript[] 
   const results: DiscoveredTranscript[] = [];
   for (const dir of dirs) {
     for (const filePath of listTextFiles(dir)) {
-      const baseName = basename(filePath, '.txt');
+      const ext = filePath.endsWith('.md') ? '.md' : '.txt';
+      const baseName = basename(filePath, ext);
       const dateMatch = DATE_RE.exec(baseName);
       const inferredDate = dateMatch ? dateMatch[1] : null;
       if (!isInDateRange(inferredDate, opts)) continue;
@@ -214,12 +215,14 @@ export function readSingleTranscript(
   }
   if (content.length < minChars) return null;
   if (isDreamOutput(content, bypass)) {
-    const baseName = basename(filePath, '.txt');
+    const ext = filePath.endsWith('.md') ? '.md' : '.txt';
+      const baseName = basename(filePath, ext);
     process.stderr.write(`[dream] readSingleTranscript skipped ${baseName}: dream_generated marker (self-consumption guard)\n`);
     return null;
   }
   if (matchesAnyExclude(content, excludeRes)) return null;
-  const baseName = basename(filePath, '.txt');
+  const ext = filePath.endsWith('.md') ? '.md' : '.txt';
+      const baseName = basename(filePath, ext);
   const dateMatch = DATE_RE.exec(baseName);
   return {
     filePath,


### PR DESCRIPTION
## Summary

Transcript discovery only accepts `.txt` files. Many brain repos store meeting transcripts and conversation logs as `.md` (markdown), which is the natural format for brain content.

- `listTextFiles()` now accepts both `.txt` and `.md`
- `basename` extraction handles both extensions for date inference
- `readSingleTranscript()` handles both extensions

No behavior change for existing `.txt`-only setups.

## Context

We run NineClaws (a personal executive assistant) on GBrain. Voice call transcripts are saved as `.md` by our Twilio voice agent. The dream synthesize phase was silently skipping all of them because of the `.txt` filter.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->