### PR TITLE
feat(operations): list_pages accepts offset

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -275,8 +275,8 @@ export interface BrainEngine {
   resolveSlugs(partial: string): Promise<string[]>;
   /**
    * Returns the slug of every page in the brain. Used by batch commands as a
-   * mutation-immune iteration source (alternative to listPages OFFSET pagination,
-   * which is unstable when ordering by updated_at and writes are happening).
+   * mutation-immune iteration source when callers need a full snapshot that
+   * cannot skip/duplicate under concurrent writes.
    */
   getAllSlugs(): Promise<Set<string>>;
 

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -728,11 +728,12 @@ const purge_deleted_pages: Operation = {
 
 const list_pages: Operation = {
   name: 'list_pages',
-  description: 'List pages with optional filters. Soft-deleted pages are hidden by default; pass include_deleted: true to surface them with deleted_at populated.',
+  description: 'List pages with optional filters. Results are stable ascending by slug ASC. Pagination snapshots at request time; concurrent writes during pagination may produce skip/duplicate. Soft-deleted pages are hidden by default; pass include_deleted: true to surface them with deleted_at populated.',
   params: {
     type: { type: 'string', description: 'Filter by page type' },
     tag: { type: 'string', description: 'Filter by tag' },
     limit: { type: 'number', description: 'Max results (default 50)' },
+    offset: { type: 'number', description: 'Skip first N results (default 0)' },
     include_deleted: { type: 'boolean', description: 'v0.26.5: include soft-deleted pages (default: false). Used by restore workflows and operator diagnostics.' },
   },
   handler: async (ctx, p) => {
@@ -740,6 +741,7 @@ const list_pages: Operation = {
       type: p.type as any,
       tag: p.tag as string,
       limit: clampSearchLimit(p.limit as number | undefined, 50, 100),
+      offset: Math.max(0, Math.floor((p.offset as number | undefined) ?? 0)),
       includeDeleted: (p.include_deleted as boolean) === true,
     });
     return pages.map(pg => ({

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -555,7 +555,7 @@ export class PGLiteEngine implements BrainEngine {
 
     const { rows } = await this.db.query(
       `SELECT p.* FROM pages p ${tagJoin} ${whereSql}
-       ORDER BY p.updated_at DESC ${limitSql}`,
+       ORDER BY p.slug ASC ${limitSql}`,
       params
     );
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -525,7 +525,7 @@ export class PostgresEngine implements BrainEngine {
       SELECT p.* FROM pages p
       ${tagJoin}
       WHERE 1=1 ${typeCondition} ${tagCondition} ${updatedCondition} ${slugCondition} ${deletedCondition}
-      ORDER BY p.updated_at DESC LIMIT ${limit} OFFSET ${offset}
+      ORDER BY p.slug ASC LIMIT ${limit} OFFSET ${offset}
     `;
 
     return rows.map(rowToPage);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -48,6 +48,7 @@ export interface PageFilters {
   type?: PageType;
   tag?: string;
   limit?: number;
+  /** Skip the first N rows after stable slug-ascending ordering. */
   offset?: number;
   /** ISO date string (YYYY-MM-DD or full ISO timestamp). Filter to pages updated_at > value. */
   updated_after?: string;

--- a/test/operations-list-pages-offset.test.ts
+++ b/test/operations-list-pages-offset.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { operations, type OperationContext } from '../src/core/operations.ts';
+import type { GBrainConfig } from '../src/core/config.ts';
+import type { PageInput } from '../src/core/types.ts';
+
+const listPagesOp = operations.find((op) => op.name === 'list_pages');
+
+if (!listPagesOp) {
+  throw new Error('list_pages operation missing');
+}
+
+const pageInput: PageInput = {
+  type: 'concept',
+  title: 'Offset Test Page',
+  compiled_truth: 'Offset pagination test content.',
+};
+
+type ListedPage = {
+  slug: string;
+  type: string;
+  title: string;
+  updated_at: unknown;
+};
+
+function makeConfig(): GBrainConfig {
+  return { engine: 'pglite' };
+}
+
+function makeCtx(engine: PGLiteEngine): OperationContext {
+  return {
+    engine,
+    config: makeConfig(),
+    logger: console,
+    dryRun: false,
+    remote: true,
+  };
+}
+
+describe('list_pages operation offset pagination', () => {
+  let engine: PGLiteEngine;
+
+  beforeEach(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+
+    for (const slug of ['wiki/c', 'wiki/a', 'wiki/e', 'wiki/b', 'wiki/d']) {
+      await engine.putPage(slug, { ...pageInput, title: slug });
+    }
+    await engine.addTag('wiki/b', 'offset-tag');
+    await engine.addTag('wiki/d', 'offset-tag');
+  });
+
+  afterEach(async () => {
+    await engine.disconnect();
+  });
+
+  test('schema documents offset and stable pagination semantics', () => {
+    expect(listPagesOp.params.offset).toEqual({
+      type: 'number',
+      description: 'Skip first N results (default 0)',
+    });
+    expect(listPagesOp.description).toContain('stable ascending by slug ASC');
+    expect(listPagesOp.description).toContain('concurrent writes during pagination may produce skip/duplicate');
+  });
+
+  test('offset=0 matches omitted offset', async () => {
+    const ctx = makeCtx(engine);
+    const noOffset = await listPagesOp.handler(ctx, { limit: 3 }) as ListedPage[];
+    const zeroOffset = await listPagesOp.handler(ctx, { limit: 3, offset: 0 }) as ListedPage[];
+
+    expect(zeroOffset).toEqual(noOffset);
+    expect(zeroOffset.map((page) => page.slug)).toEqual(['wiki/a', 'wiki/b', 'wiki/c']);
+  });
+
+  test('offset=N skips N stable slug-ordered rows', async () => {
+    const ctx = makeCtx(engine);
+    const page = await listPagesOp.handler(ctx, { limit: 1, offset: 2 }) as ListedPage[];
+
+    expect(page.map((item) => item.slug)).toEqual(['wiki/c']);
+  });
+
+  test('offset plus limit returns the requested window', async () => {
+    const ctx = makeCtx(engine);
+    const page = await listPagesOp.handler(ctx, { limit: 2, offset: 1 }) as ListedPage[];
+
+    expect(page.map((item) => item.slug)).toEqual(['wiki/b', 'wiki/c']);
+  });
+
+  test('windowed pagination has no duplicates within a snapshot', async () => {
+    const ctx = makeCtx(engine);
+    const first = await listPagesOp.handler(ctx, { limit: 2, offset: 0 }) as ListedPage[];
+    const second = await listPagesOp.handler(ctx, { limit: 2, offset: 2 }) as ListedPage[];
+    const third = await listPagesOp.handler(ctx, { limit: 2, offset: 4 }) as ListedPage[];
+    const slugs = [...first, ...second, ...third].map((item) => item.slug);
+
+    expect(slugs).toEqual(['wiki/a', 'wiki/b', 'wiki/c', 'wiki/d', 'wiki/e']);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  test('tag-filtered windows honor offset', async () => {
+    const ctx = makeCtx(engine);
+    const page = await listPagesOp.handler(ctx, { tag: 'offset-tag', limit: 1, offset: 1 }) as ListedPage[];
+
+    expect(page.map((item) => item.slug)).toEqual(['wiki/d']);
+  });
+});


### PR DESCRIPTION
## Summary
- expose offset on the list_pages operation schema
- document stable slug-ascending pagination semantics and concurrent mutation caveat
- make listPages ordering stable by slug ASC in both engines
- add operation tests for offset=0, offset=N, offset+limit windows, tag-filtered offset, and duplicate-free window reconstruction

## Verification
- bun test test/operations-list-pages-offset.test.ts
- bun run typecheck

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->