### PR TITLE
README: add self-hosted option (Reefy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ GBrain is designed to be installed and operated by an AI agent. If you don't hav
 
 - **[OpenClaw](https://openclaw.ai)** ... Deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/alphaclaw) (one click, 8GB+ RAM)
 - **[Hermes Agent](https://github.com/NousResearch/hermes-agent)** ... Deploy on [Railway](https://github.com/praveen-ks-2001/hermes-agent-template) (one click)
+- **Self-hosted** ... Run OpenClaw or Hermes on your own hardware via [Reefy](https://reefy.ai) (flash USB, one click)
 
 Paste this into your agent:
 


### PR DESCRIPTION
Adds a self-hosted option via [Reefy](https://reefy.ai) for users who
want to run OpenClaw or Hermes on their own PC: one-click install,
private, open-source ([reefyai/reefy](https://github.com/reefyai/reefy)),
no monthly cloud bills.

Reefy OS isn't another shell on top of Ubuntu or Debian with a web UI
bolted on - reimagined OS, built bottom-up for the AI era.

Disclosure: I work on Reefy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->