### PR TITLE
fix(oauth): clamp authorize() requested scopes against client.scope (RFC 6749 §3.3)

### DIFF
--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -241,11 +241,24 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     const codeHash = hashToken(code);
     const expiresAt = Math.floor(Date.now() / 1000) + 600; // 10 minute TTL
 
+    // Scope clamp (RFC 6749 §3.3): the SDK's authorize handler splits
+    // `?scope=...` verbatim and forwards the raw list to the provider, so
+    // the provider MUST clamp against the client's registered grant. Without
+    // this, a `read`-registered client requesting `?scope=admin` would have
+    // `['admin']` stored in oauth_codes and returned by exchangeAuthorizationCode
+    // as a fully-admin access token. Mirrors the filter pattern already used
+    // by exchangeClientCredentials (this file) and exchangeRefreshToken's F3
+    // subset enforcement (RFC 6749 §6) so all three grant entry points clamp
+    // consistently. Empty/omitted requested scope inherits the empty-stored
+    // shape (existing behavior; not a security boundary).
+    const allowedScopes = parseScopeString(client.scope);
+    const grantedScopes = (params.scopes || []).filter(s => hasScope(allowedScopes, s));
+
     await this.sql`
       INSERT INTO oauth_codes (code_hash, client_id, scopes, code_challenge,
                                 code_challenge_method, redirect_uri, state, resource, expires_at)
       VALUES (${codeHash}, ${client.client_id},
-              ${pgArray(params.scopes || [])},
+              ${pgArray(grantedScopes)},
               ${params.codeChallenge}, ${'S256'},
               ${params.redirectUri}, ${params.state || null},
               ${params.resource?.toString() || null}, ${expiresAt})

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -388,6 +388,62 @@ describe('authorization code flow', () => {
     await expect(provider.exchangeAuthorizationCode(client, expiredCode)).rejects.toThrow();
   });
 
+  // F-AUTHZ regression. The MCP SDK's authorize handler splits `?scope=...`
+  // verbatim and forwards the raw list to the provider, so the provider must
+  // clamp against the client's registered grant. Pre-fix the INSERT into
+  // oauth_codes used `params.scopes || []` raw, so a `read`-registered client
+  // requesting `?scope=admin` got an admin access token at /token exchange.
+  // This pins the parallel posture to client_credentials' filter pattern
+  // (line 513-515) and refresh's F3 subset enforcement (RFC 6749 §6).
+  test('authorize clamps requested scopes against client.scope (RFC 6749 §3.3)', async () => {
+    const { clientId } = await provider.registerClientManual(
+      'authz-clamp-test', ['authorization_code'], 'read',
+      ['http://localhost:3000/callback'],
+    );
+    const client = (await provider.clientsStore.getClient(clientId))!;
+
+    let redirectUrl = '';
+    const mockRes = { redirect: (url: string) => { redirectUrl = url; } } as any;
+
+    // Read-only client requests admin via the SDK's parsed scopes array.
+    await provider.authorize(client, {
+      codeChallenge: 'challenge',
+      redirectUri: 'http://localhost:3000/callback',
+      scopes: ['read', 'write', 'admin'],
+    }, mockRes);
+
+    const code = new URL(redirectUrl).searchParams.get('code')!;
+    const tokens = await provider.exchangeAuthorizationCode(client, code);
+
+    // The token's stored scopes must equal the clamped subset.
+    const auth = await provider.verifyAccessToken(tokens.access_token);
+    expect(auth.scopes).toEqual(['read']);
+    expect(auth.scopes).not.toContain('write');
+    expect(auth.scopes).not.toContain('admin');
+  });
+
+  test('authorize subset request returns subset', async () => {
+    const { clientId } = await provider.registerClientManual(
+      'authz-subset-test', ['authorization_code'], 'read write',
+      ['http://localhost:3000/callback'],
+    );
+    const client = (await provider.clientsStore.getClient(clientId))!;
+
+    let redirectUrl = '';
+    const mockRes = { redirect: (url: string) => { redirectUrl = url; } } as any;
+
+    await provider.authorize(client, {
+      codeChallenge: 'challenge',
+      redirectUri: 'http://localhost:3000/callback',
+      scopes: ['read'],
+    }, mockRes);
+
+    const code = new URL(redirectUrl).searchParams.get('code')!;
+    const tokens = await provider.exchangeAuthorizationCode(client, code);
+    const auth = await provider.verifyAccessToken(tokens.access_token);
+    expect(auth.scopes).toEqual(['read']);
+  });
+
   // CSO finding #2 regression. The pre-fix SELECT-then-DELETE pattern let two
   // concurrent token requests with the same code both pass the SELECT, both
   // running DELETE (no-op on second) and both calling issueTokens. The fix is


### PR DESCRIPTION
## Summary

`GBrainOAuthProvider.authorize()` (`src/core/oauth-provider.ts:235-259`) inserted `params.scopes || []` raw into `oauth_codes`. The MCP SDK's authorize handler (`@modelcontextprotocol/sdk/.../auth/handlers/authorize.js`) splits `?scope=...` verbatim and forwards the parsed list to the provider, so the provider has to clamp against the client's registered grant. v0.28.11 didn't, which means a `read`-registered client requesting `?scope=admin` had `['admin']` stored on the auth code and `exchangeAuthorizationCode` issued a fully-admin access token at /token exchange.

The asymmetry is the bug: the other two grant entry points already clamp.

- `exchangeClientCredentials` (line 513-515) filters requested scopes through `hasScope(allowedScopes, s)`.
- `exchangeRefreshToken`'s F3 (line 372-380, landed in v0.26.9) enforces RFC 6749 §6 subset against the **original** grant.

`authorize()` lined up with neither. This patch mirrors the client_credentials filter shape so all three grant entry points clamp consistently:

```ts
const allowedScopes = parseScopeString(client.scope);
const grantedScopes = (params.scopes || []).filter(s => hasScope(allowedScopes, s));
```

Empty/omitted requested scope keeps storing `[]` (existing shape, not a security boundary). The clamped subset is what the client sees in the `scope` field of the token response, which is the spec-compliant signal that the grant was reduced.

## Tests

Added two pinning tests in `test/oauth.test.ts`:

- `authorize clamps requested scopes against client.scope (RFC 6749 §3.3)` — read-only client requests `['read','write','admin']`, the issued token carries only `['read']`.
- `authorize subset request returns subset` — `read write` client requesting `['read']` gets `['read']` (regression guard against over-clamping).

The existing v0.26.9 `oauth.test.ts` pins F3 (refresh clamp) but had no authorize-side coverage, which is why the regression survived.

```
$ bun test test/oauth.test.ts
 64 pass
 0 fail
 228 expect() calls
```

`bun run typecheck` clean.

## Test plan

- [x] `bun test test/oauth.test.ts` green (64/64)
- [x] `bun run typecheck` clean
- [x] Pre-fix R12 PoC reported `admin scope present? YES (still vulnerable)`; post-fix the same PoC reports `admin scope present? no (FIXED)`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->