### PR TITLE
fix(migrations): harden v0.29.1 on PGLite + guard effective_date index creation

### DIFF
--- a/src/commands/migrations/v0_29_1.ts
+++ b/src/commands/migrations/v0_29_1.ts
@@ -45,10 +45,15 @@ async function phaseBBackfill(opts: OrchestratorOpts): Promise<OrchestratorPhase
   try {
     const { createEngine } = await import('../../core/engine-factory.ts');
     const { loadConfig, toEngineConfig } = await import('../../core/config.ts');
+    const { connectWithRetry } = await import('../../core/db.ts');
     const { backfillEffectiveDate } = await import('../../core/backfill-effective-date.ts');
     const cfg = loadConfig();
     if (!cfg) throw new Error('No gbrain config; run `gbrain init` first.');
-    const engine = await createEngine(toEngineConfig(cfg));
+    const engineCfg = toEngineConfig(cfg);
+    const engine = await createEngine(engineCfg);
+    await connectWithRetry(engine, engineCfg, {
+      noRetry: process.argv.includes('--no-retry-connect') || process.env.GBRAIN_NO_RETRY_CONNECT === '1',
+    });
 
     let totalExamined = 0;
     let totalUpdated = 0;
@@ -62,6 +67,8 @@ async function phaseBBackfill(opts: OrchestratorOpts): Promise<OrchestratorPhase
         }
       },
     });
+
+    await engine.disconnect();
 
     return {
       name: 'backfill_effective_date',
@@ -80,9 +87,14 @@ async function phaseCVerify(opts: OrchestratorOpts): Promise<OrchestratorPhaseRe
   try {
     const { createEngine } = await import('../../core/engine-factory.ts');
     const { loadConfig, toEngineConfig } = await import('../../core/config.ts');
+    const { connectWithRetry } = await import('../../core/db.ts');
     const cfg = loadConfig();
     if (!cfg) throw new Error('No gbrain config; run `gbrain init` first.');
-    const engine = await createEngine(toEngineConfig(cfg));
+    const engineCfg = toEngineConfig(cfg);
+    const engine = await createEngine(engineCfg);
+    await connectWithRetry(engine, engineCfg, {
+      noRetry: process.argv.includes('--no-retry-connect') || process.env.GBRAIN_NO_RETRY_CONNECT === '1',
+    });
     // Count rows where effective_date is still NULL but frontmatter HAS a
     // parseable date — those are the rows the backfill should have touched
     // but didn't. (Rows that fall through to 'fallback' have non-null
@@ -92,12 +104,14 @@ async function phaseCVerify(opts: OrchestratorOpts): Promise<OrchestratorPhaseRe
     );
     const remaining = Number(rows[0]?.count ?? 0);
     if (remaining > 0) {
+      await engine.disconnect();
       return {
         name: 'verify',
         status: 'failed',
         detail: `${remaining} pages still have NULL effective_date (backfill incomplete)`,
       };
     }
+    await engine.disconnect();
     return { name: 'verify', status: 'complete', detail: '0 pages with NULL effective_date' };
   } catch (e) {
     return { name: 'verify', status: 'failed', detail: e instanceof Error ? e.message : String(e) };

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -92,8 +92,16 @@ CREATE INDEX IF NOT EXISTS idx_pages_source_id ON pages(source_id);
 CREATE INDEX IF NOT EXISTS pages_deleted_at_purge_idx
   ON pages (deleted_at) WHERE deleted_at IS NOT NULL;
 -- v0.29.1: expression index for since/until date-range filters.
-CREATE INDEX IF NOT EXISTS pages_coalesce_date_idx
-  ON pages ((COALESCE(effective_date, updated_at)));
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'pages' AND column_name = 'effective_date'
+  ) THEN
+    EXECUTE 'CREATE INDEX IF NOT EXISTS pages_coalesce_date_idx ON pages ((COALESCE(effective_date, updated_at)))';
+  END IF;
+END $$;
 
 -- ============================================================
 -- content_chunks: chunked content with embeddings

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -124,8 +124,16 @@ CREATE INDEX IF NOT EXISTS pages_deleted_at_purge_idx
 -- COALESCE(effective_date, updated_at). A partial index on effective_date
 -- alone would NOT help — the planner can't use it for the negative side of
 -- the COALESCE. Expression index is what actually accelerates the filter.
-CREATE INDEX IF NOT EXISTS pages_coalesce_date_idx
-  ON pages ((COALESCE(effective_date, updated_at)));
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'pages' AND column_name = 'effective_date'
+  ) THEN
+    EXECUTE 'CREATE INDEX IF NOT EXISTS pages_coalesce_date_idx ON pages ((COALESCE(effective_date, updated_at)))';
+  END IF;
+END $$;
 
 -- ============================================================
 -- content_chunks: chunked content with embeddings

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -120,8 +120,16 @@ CREATE INDEX IF NOT EXISTS pages_deleted_at_purge_idx
 -- COALESCE(effective_date, updated_at). A partial index on effective_date
 -- alone would NOT help — the planner can't use it for the negative side of
 -- the COALESCE. Expression index is what actually accelerates the filter.
-CREATE INDEX IF NOT EXISTS pages_coalesce_date_idx
-  ON pages ((COALESCE(effective_date, updated_at)));
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'pages' AND column_name = 'effective_date'
+  ) THEN
+    EXECUTE 'CREATE INDEX IF NOT EXISTS pages_coalesce_date_idx ON pages ((COALESCE(effective_date, updated_at)))';
+  END IF;
+END $$;
 
 -- ============================================================
 -- content_chunks: chunked content with embeddings


### PR DESCRIPTION
## Summary

This fixes two migration hardening issues seen on PGLite upgrades:

1. **v0.29.1 orchestrator used an engine before connecting**
   - Could fail with: `PGLite not connected. Call connect() first.`
   - `phaseBBackfill` and `phaseCVerify` now call `connectWithRetry(...)` before DB work and `disconnect()` afterwards.

2. **Schema bootstrap could reference `effective_date` too early**
   - On partially-upgraded brains, creating `pages_coalesce_date_idx` could fail if `pages.effective_date` was not yet present.
   - Index creation is now guarded by a column-existence check in schema SQL.

## Files changed

- `src/commands/migrations/v0_29_1.ts`
- `src/core/schema-embedded.ts`
- `src/core/pglite-schema.ts`
- `src/schema.sql`

## Verification

- `bun run typecheck`
- Local reproduction previously stuck at partial `0.29.1`; with this change, migration completed and doctor advanced from `unhealthy` to `warnings` with schema at latest.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->