### PR TITLE
Fix double-encoded jsonb breaking dream cycle slug lookup

### DIFF
--- a/src/core/cycle/patterns.ts
+++ b/src/core/cycle/patterns.ts
@@ -223,13 +223,15 @@ async function collectChildPutPageSlugs(
   childIds: number[],
 ): Promise<string[]> {
   if (childIds.length === 0) return [];
+  // Handle both properly-stored jsonb objects (input->>'slug') and
+  // double-encoded jsonb strings from pre-fix data ((input #>> '{}')::jsonb->>'slug').
   const rows = await engine.executeRaw<{ slug: string }>(
-    `SELECT DISTINCT input->>'slug' AS slug
+    `SELECT DISTINCT
+            COALESCE(input->>'slug', (input #>> '{}')::jsonb->>'slug') AS slug
        FROM subagent_tool_executions
       WHERE job_id = ANY($1::int[])
         AND tool_name = 'brain_put_page'
         AND status = 'complete'
-        AND input ? 'slug'
       ORDER BY 1`,
     [childIds],
   );

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -469,13 +469,15 @@ async function collectChildPutPageSlugs(
   childIds: number[],
 ): Promise<string[]> {
   if (childIds.length === 0) return [];
+  // Handle both properly-stored jsonb objects (input->>'slug') and
+  // double-encoded jsonb strings from pre-fix data ((input #>> '{}')::jsonb->>'slug').
   const rows = await engine.executeRaw<{ slug: string }>(
-    `SELECT DISTINCT input->>'slug' AS slug
+    `SELECT DISTINCT
+            COALESCE(input->>'slug', (input #>> '{}')::jsonb->>'slug') AS slug
        FROM subagent_tool_executions
       WHERE job_id = ANY($1::int[])
         AND tool_name = 'brain_put_page'
         AND status = 'complete'
-        AND input ? 'slug'
       ORDER BY 1`,
     [childIds],
   );

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -620,11 +620,15 @@ async function persistToolExecPending(
   toolName: string,
   input: unknown,
 ): Promise<void> {
+  // Serialize to JSON string for the ::jsonb cast. When `input` is already a
+  // string (e.g. pre-serialized), avoid double-encoding which produces a jsonb
+  // scalar string instead of a jsonb object — breaking `input->>'key'` lookups.
+  const jsonStr = typeof input === 'string' ? input : JSON.stringify(input);
   await engine.executeRaw(
     `INSERT INTO subagent_tool_executions (job_id, message_idx, tool_use_id, tool_name, input, status)
      VALUES ($1, $2, $3, $4, $5::jsonb, 'pending')
      ON CONFLICT (job_id, tool_use_id) DO NOTHING`,
-    [jobId, messageIdx, toolUseId, toolName, JSON.stringify(input)],
+    [jobId, messageIdx, toolUseId, toolName, jsonStr],
   );
 }
 
@@ -638,7 +642,7 @@ async function persistToolExecComplete(
     `UPDATE subagent_tool_executions
         SET status = 'complete', output = $3::jsonb, ended_at = now()
       WHERE job_id = $1 AND tool_use_id = $2`,
-    [jobId, toolUseId, JSON.stringify(output)],
+    [jobId, toolUseId, typeof output === 'string' ? output : JSON.stringify(output)],
   );
 }
 
@@ -658,7 +662,7 @@ async function persistToolExecFailed(
      VALUES ($1, $2, $3, $4, $5::jsonb, 'failed', $6, now())
      ON CONFLICT (job_id, tool_use_id) DO UPDATE
        SET status = 'failed', error = EXCLUDED.error, ended_at = now()`,
-    [jobId, messageIdx, toolUseId, toolName, JSON.stringify(input), error],
+    [jobId, messageIdx, toolUseId, toolName, typeof input === 'string' ? input : JSON.stringify(input), error],
   );
 }
 


### PR DESCRIPTION
## Summary

- **Bug**: `persistToolExecPending`/`Failed`/`Complete` in `subagent.ts` call `JSON.stringify(input)` before passing to a `$N::jsonb` parameter. When `input` is already an object, this produces a JSON *string* which `::jsonb` stores as a jsonb scalar — not a jsonb object. Downstream queries like `input->>'slug'` then return NULL.
- **Symptom**: Dream cycle synthesize phase always reports `pages_written: 0` even when subagents successfully write pages via `brain_put_page`. The summary page shows "Pages written: 0" despite pages existing in the DB.
- **Same bug** in `patterns.ts` slug collection query.

## Fix

1. **Root cause** (`subagent.ts`): Skip `JSON.stringify` when input/output is already a string, preventing future double-encoding.
2. **Query fix** (`synthesize.ts`, `patterns.ts`): Use `COALESCE(input->>'slug', (input #>> '{}')::jsonb->>'slug')` to handle both old double-encoded rows and new properly-encoded rows.

## Files changed

- `src/core/minions/handlers/subagent.ts` — persist functions
- `src/core/cycle/synthesize.ts` — `collectChildPutPageSlugs`
- `src/core/cycle/patterns.ts` — same query pattern

## Test plan

- [ ] Run `gbrain dream --date <date>` with existing double-encoded rows — summary should now show correct page count
- [ ] Run a new dream cycle — verify `subagent_tool_executions.input` is stored as jsonb object (not scalar string)
- [ ] Verify `input->>'slug'` returns the slug for both old and new rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->