### PR TITLE
fix(http): bridge ChatGPT MCP connector + Claude confidential-client OAuth

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -12,6 +12,7 @@
 
 import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
+import { appendFileSync } from 'fs';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
@@ -164,6 +165,58 @@ interface ServeHttpOptions {
   logFullParams?: boolean;
 }
 
+// Project gbrain SearchResult[] / Page onto ChatGPT's spec shapes:
+//   search -> { results: [{ id, title, text, url }] }
+//   fetch  -> { id, title, text, url, metadata? }
+// `url` is synthesised from issuer + /page/<slug>; gbrain doesn't serve it.
+function toChatgptShape(
+  tool: 'search' | 'fetch',
+  result: unknown,
+  pageBaseUrl: URL,
+): { ok: true; data: Record<string, unknown> } | { ok: false; error: Record<string, unknown> } {
+  if (tool === 'search') {
+    const rows = Array.isArray(result) ? result : [];
+    const seen = new Set<string>();
+    const results: Array<{ id: string; title: string; url: string; text?: string }> = [];
+    for (const r of rows as Array<Record<string, unknown>>) {
+      const id = typeof r.slug === 'string' ? r.slug : '';
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      results.push({
+        id,
+        title: typeof r.title === 'string' && r.title ? r.title : id,
+        url: new URL(`/page/${encodeURIComponent(id)}`, pageBaseUrl).toString(),
+        text: typeof r.chunk_text === 'string' ? r.chunk_text : '',
+      });
+    }
+    return { ok: true, data: { results } };
+  }
+  // get_page error envelope -> MCP isError; never project as a fetch result.
+  if (!result || typeof result !== 'object' || (result as Record<string, unknown>).error) {
+    return { ok: false, error: (result as Record<string, unknown>) ?? { error: 'page_not_found' } };
+  }
+  const p = result as Record<string, unknown>;
+  const slug = typeof p.slug === 'string' ? p.slug : '';
+  const compiledTruth = typeof p.compiled_truth === 'string' ? p.compiled_truth : '';
+  const timeline = typeof p.timeline === 'string' ? p.timeline : '';
+  const text = [compiledTruth, timeline].filter(Boolean).join('\n\n---\n\n');
+  return {
+    ok: true,
+    data: {
+      id: slug,
+      title: typeof p.title === 'string' && p.title ? p.title : slug,
+      text,
+      url: new URL(`/page/${encodeURIComponent(slug)}`, pageBaseUrl).toString(),
+      metadata: {
+        type: p.type,
+        page_id: p.id,
+        created_at: p.created_at,
+        updated_at: p.updated_at,
+      },
+    },
+  };
+}
+
 export async function runServeHttp(engine: BrainEngine, options: ServeHttpOptions) {
   const { port, tokenTtl, enableDcr, publicUrl, logFullParams } = options;
   const config = loadConfig() || { engine: 'pglite' as const };
@@ -219,6 +272,23 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   const app = express();
   app.set('trust proxy', 'loopback'); // Caddy/Tailscale reverse proxy on localhost
 
+  // Collapse leading `//`. Issuer URL has a trailing slash (URL canonical
+  // form), so naive `issuer + "/register"` concat gives `//register` -> 404.
+  app.use((req, _res, next) => {
+    if (req.url.startsWith('//')) req.url = req.url.replace(/^\/+/, '/');
+    next();
+  });
+
+  // Sync edge log. Bun stdout is block-buffered under launchd StandardOutPath;
+  // appendFileSync flushes per request so live debug isn't blind.
+  app.use((req, _res, next) => {
+    try {
+      const line = `${new Date().toISOString()} ${req.method} ${req.url} ua=${(req.headers['user-agent'] || '').slice(0, 60)} cfray=${req.headers['cf-ray'] || ''}\n`;
+      appendFileSync('/Users/panda/.gbrain/logs/edge-trace.log', line);
+    } catch { /* never block on logging */ }
+    next();
+  });
+
   // ---------------------------------------------------------------------------
   // Cookie parsing — required for /admin auth (express 5 has no built-in)
   // ---------------------------------------------------------------------------
@@ -256,6 +326,18 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
     standardHeaders: true,
     legacyHeaders: false,
     message: 'Too many magic-link attempts. Wait a minute before trying again.',
+  });
+
+  // /token pre-hash. SDK clientAuth.js:45 strict-compares stored secret to
+  // request body. DB holds sha256 hex; clients hold plaintext from DCR. Hash
+  // the body so the SDK sees hash-vs-hash. Skip client_credentials — gbrain's
+  // own handler below hashes itself; pre-hashing would double-hash.
+  app.post('/token', express.urlencoded({ extended: false }), (req, _res, next) => {
+    if (req.body?.grant_type === 'client_credentials') return next();
+    if (req.body && typeof req.body.client_secret === 'string' && req.body.client_secret.length > 0) {
+      req.body.client_secret = createHash('sha256').update(req.body.client_secret).digest('hex');
+    }
+    next();
   });
 
   app.post('/token', ccRateLimiter, express.urlencoded({ extended: false }), async (req, res, next) => {
@@ -301,9 +383,14 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
     path: '/admin',
   });
 
+  // PRM `resource` must match the URL clients enter (working ChatGPT
+  // examples: Auth0, Ory Hydra both publish `/mcp`, not the issuer root).
+  const resourceServerUrl = new URL('/mcp', issuerUrl);
+
   const authRouterOptions: any = {
     provider: oauthProvider,
     issuerUrl,
+    resourceServerUrl,
     // v0.28: scopesSupported sourced from ALLOWED_SCOPES_LIST so MCP clients
     // (Claude Desktop, ChatGPT, Perplexity) can discover sources_admin and
     // users_admin via /.well-known/oauth-authorization-server. The legacy
@@ -319,23 +406,66 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
 
   const authRouter = mcpAuthRouter(authRouterOptions);
 
-  // Patch the SDK's OAuth metadata to include client_credentials grant type.
-  // The SDK hardcodes ['authorization_code', 'refresh_token'] — we intercept
-  // the response and add client_credentials before it reaches the client.
+  // ChatGPT probes 9 well-known variants (root / path-aware / path-suffix
+  // for AS metadata, OIDC config, and PRM). Any 404 surfaces as a misleading
+  // "DCR endpoint 404". Rewrite anything matching to the SDK's canonical
+  // path so the same metadata body answers every variant.
+  const WELLKNOWN_RE =
+    /^(?:\/mcp)?\/\.well-known\/(oauth-protected-resource|oauth-authorization-server|openid-configuration)(?:\/[^?]*)?$/;
+  app.use((req, _res, next) => {
+    if (req.method !== 'GET') return next();
+    const m = req.path.match(WELLKNOWN_RE);
+    if (m) {
+      req.url = m[1] === 'oauth-protected-resource'
+        ? '/.well-known/oauth-protected-resource/mcp'
+        : '/.well-known/oauth-authorization-server';
+    }
+    next();
+  });
+
+  // Patch AS metadata: (a) add client_credentials to grant_types_supported
+  // (SDK hardcodes auth_code+refresh); (b) UA-gate OIDC stub fields for
+  // ChatGPT only — non-ChatGPT clients keep clean OAuth 2.1 metadata.
   app.use((req, res, next) => {
     if (req.path === '/.well-known/oauth-authorization-server' && req.method === 'GET') {
+      const ua = String(req.headers['user-agent'] || '');
+      const isChatgptMcp = /aiohttp|openai-mcp/i.test(ua);
       const origJson = res.json.bind(res);
       (res as any).json = (body: any) => {
-        if (body?.grant_types_supported && !body.grant_types_supported.includes('client_credentials')) {
-          body.grant_types_supported.push('client_credentials');
+        // SDK metadata is a shared singleton; clone before mutating or
+        // ChatGPT's OIDC fields leak into every other client's response.
+        const out: any = body && typeof body === 'object' ? { ...body } : body;
+        if (Array.isArray(body?.grant_types_supported)) {
+          out.grant_types_supported = [...body.grant_types_supported];
+          if (!out.grant_types_supported.includes('client_credentials')) {
+            out.grant_types_supported.push('client_credentials');
+          }
         }
-        return origJson(body);
+        if (isChatgptMcp && out) {
+          if (!out.subject_types_supported) out.subject_types_supported = ['public'];
+          if (!out.id_token_signing_alg_values_supported) out.id_token_signing_alg_values_supported = ['RS256'];
+          if (!out.userinfo_endpoint) out.userinfo_endpoint = new URL('/userinfo', issuerUrl).toString();
+          if (!out.jwks_uri) out.jwks_uri = new URL('/.well-known/jwks.json', issuerUrl).toString();
+        }
+        return origJson(out);
       };
     }
     next();
   });
 
   app.use(authRouter);
+
+  // OIDC stubs back the userinfo_endpoint + jwks_uri pointers ChatGPT's
+  // discovery requires. gbrain doesn't issue ID tokens; soft 200 keeps
+  // ChatGPT's post-authorize validation from reading 401 as auth failure.
+  app.get('/userinfo', (req, res) => {
+    const auth = req.headers.authorization || '';
+    const sub = auth.startsWith('Bearer ') ? auth.slice(7, 23) : 'anonymous';
+    res.json({ sub });
+  });
+  app.get('/.well-known/jwks.json', (_req, res) => {
+    res.json({ keys: [] });
+  });
 
   // ---------------------------------------------------------------------------
   // Health check — liveness only. Full engine stats live at
@@ -767,7 +897,34 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   // ---------------------------------------------------------------------------
   const mcpOperations = operations.filter(op => !op.localOnly);
 
-  app.post('/mcp', requireBearerAuth({ verifier: oauthProvider }), async (req: Request, res: Response) => {
+  // RFC 9728: 401 WWW-Authenticate carries the path-aware PRM URL.
+  const resourceMetadataUrl = new URL('/.well-known/oauth-protected-resource/mcp', issuerUrl).toString();
+
+  // GET /mcp opens an idle SSE stream (heartbeat-only). Spec allows 405,
+  // but ChatGPT's openai-mcp/1.0.0 treats anything non-200 as fatal.
+  // Bearer-gated so unauth'd probes still get 401 with resource_metadata.
+  app.get('/mcp', requireBearerAuth({ verifier: oauthProvider, resourceMetadataUrl }), (_req: Request, res: Response) => {
+    res.status(200);
+    res.set('Content-Type', 'text/event-stream');
+    res.set('Cache-Control', 'no-cache, no-transform');
+    res.set('Connection', 'keep-alive');
+    res.set('X-Accel-Buffering', 'no');
+    res.flushHeaders();
+    res.write(': mcp-stream-open\n\n');
+    const heartbeat = setInterval(() => {
+      try { res.write(': heartbeat\n\n'); } catch { clearInterval(heartbeat); }
+    }, 15_000);
+    _req.on('close', () => {
+      clearInterval(heartbeat);
+      try { res.end(); } catch { /* already closed */ }
+    });
+  });
+  app.delete('/mcp', (_req: Request, res: Response) => {
+    res.set('Allow', 'POST, OPTIONS');
+    res.status(405).json({ jsonrpc: '2.0', error: { code: -32000, message: 'Method Not Allowed: session termination not supported' }, id: null });
+  });
+
+  app.post('/mcp', requireBearerAuth({ verifier: oauthProvider, resourceMetadataUrl }), async (req: Request, res: Response) => {
     const startTime = Date.now();
     const authInfo = (req as any).auth as AuthInfo;
 
@@ -776,6 +933,10 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
     // SELECT). No per-request DB roundtrip needed. Falls back to clientId
     // for legacy tokens or when the JOIN row's client_name is NULL.
     const agentName = authInfo.clientName ?? authInfo.clientId;
+
+    // ChatGPT Connector mode only surfaces tools named exactly `search` /
+    // `fetch`; expose a two-tool shim onto gbrain's search + get_page.
+    const chatgptCompat = typeof agentName === 'string' && agentName.startsWith('ChatGPT');
 
     // Create a fresh MCP server per request (stateless)
     const server = new Server(
@@ -806,6 +967,30 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
         status: 'success',
         timestamp: new Date().toISOString(),
       });
+      if (chatgptCompat) {
+        return {
+          tools: [
+            {
+              name: 'search',
+              description: 'Search the brain knowledge base. Returns up to 20 matching pages ranked by relevance, each with id (slug), title, and a snippet.',
+              inputSchema: {
+                type: 'object' as const,
+                properties: { query: { type: 'string', description: 'Free-text search query' } },
+                required: ['query'],
+              },
+            },
+            {
+              name: 'fetch',
+              description: 'Fetch the full content of a brain page by id (slug). Returns title, full text, and metadata.',
+              inputSchema: {
+                type: 'object' as const,
+                properties: { id: { type: 'string', description: 'Page slug returned from search' } },
+                required: ['id'],
+              },
+            },
+          ],
+        };
+      }
       return {
         tools: mcpOperations.map(op => ({
           name: op.name,
@@ -818,6 +1003,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
                 description: v.description,
                 ...(v.enum ? { enum: v.enum } : {}),
                 ...(v.default !== undefined ? { default: v.default } : {}),
+                ...(v.items ? { items: { type: v.items.type } } : {}),
               }]),
             ),
             required: Object.entries(op.params).filter(([, v]) => v.required).map(([k]) => k),
@@ -827,7 +1013,17 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
     });
 
     server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      const { name, arguments: params } = request.params;
+      let { name, arguments: params } = request.params;
+
+      // ChatGPT shim: fetch -> get_page (id == slug). Track original name
+      // so the post-dispatch projection picks the right output shape.
+      const chatgptTool: 'search' | 'fetch' | null =
+        chatgptCompat && (name === 'search' || name === 'fetch') ? name : null;
+      if (chatgptTool === 'fetch') {
+        name = 'get_page';
+        params = { slug: (params as { id?: string })?.id };
+      }
+
       const op = mcpOperations.find(o => o.name === name);
       if (!op) {
         // v0.28.10: persist unknown-op attempts. Operators investigating
@@ -1029,6 +1225,23 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
         status: 'success',
         timestamp: new Date().toISOString(),
       });
+
+      if (chatgptTool && toolResult.content[0]?.type === 'text') {
+        try {
+          const parsed = JSON.parse(toolResult.content[0].text);
+          const projected = toChatgptShape(chatgptTool, parsed, issuerUrl);
+          if (projected.ok) {
+            return {
+              content: [{ type: 'text', text: JSON.stringify(projected.data) }],
+              structuredContent: projected.data,
+            };
+          }
+          return {
+            content: [{ type: 'text', text: JSON.stringify(projected.error) }],
+            isError: true,
+          };
+        } catch { /* fall through to default */ }
+      }
       return toolResult;
     });
 

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -12,7 +12,6 @@
 
 import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
-import { appendFileSync } from 'fs';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
@@ -276,16 +275,6 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   // form), so naive `issuer + "/register"` concat gives `//register` -> 404.
   app.use((req, _res, next) => {
     if (req.url.startsWith('//')) req.url = req.url.replace(/^\/+/, '/');
-    next();
-  });
-
-  // Sync edge log. Bun stdout is block-buffered under launchd StandardOutPath;
-  // appendFileSync flushes per request so live debug isn't blind.
-  app.use((req, _res, next) => {
-    try {
-      const line = `${new Date().toISOString()} ${req.method} ${req.url} ua=${(req.headers['user-agent'] || '').slice(0, 60)} cfray=${req.headers['cf-ray'] || ''}\n`;
-      appendFileSync('/Users/panda/.gbrain/logs/edge-trace.log', line);
-    } catch { /* never block on logging */ }
     next();
   });
 

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -139,14 +139,18 @@ class GBrainClientsStore implements OAuthRegisteredClientsStore {
     `;
     if (rows.length === 0) return undefined;
     const r = rows[0];
+    // SDK clientAuth.js:45 demands secret whenever client.client_secret is
+    // truthy, regardless of token_endpoint_auth_method. Hide the stored hash
+    // for `none` clients so the PKCE-only path passes.
+    const authMethod = r.token_endpoint_auth_method as string | undefined;
     return {
       client_id: r.client_id as string,
-      client_secret: r.client_secret_hash as string | undefined,
+      client_secret: authMethod === 'none' ? undefined : (r.client_secret_hash as string | undefined),
       client_name: r.client_name as string,
       redirect_uris: (r.redirect_uris as string[]) || [],
       grant_types: (r.grant_types as string[]) || ['client_credentials'],
       scope: r.scope as string | undefined,
-      token_endpoint_auth_method: r.token_endpoint_auth_method as string | undefined,
+      token_endpoint_auth_method: authMethod,
       client_id_issued_at: coerceTimestamp(r.client_id_issued_at),
       client_secret_expires_at: coerceTimestamp(r.client_secret_expires_at),
     };


### PR DESCRIPTION
**ChatGPT's Custom MCP Connector and Claude (`client_secret_post`) OAuth both fail end-to-end against `gbrain serve --http --enable-dcr` today. Twelve targeted patches in `serve-http.ts` + `oauth-provider.ts` close the gaps.**

Hit while wiring a self-hosted gbrain MCP server (v0.30.0) into ChatGPT's Custom Connector and verifying Claude.ai web + Claude Code stayed working. Each patch was triaged from real edge traces + Postgres `oauth_clients`/`oauth_codes`/`oauth_tokens` introspection rather than guessing from client-side error messages — those messages are systematically misleading (one root cause cycled through "doesn't support DCR" → "DCR endpoint 404" → "doesn't implement OAuth" → "invalid_mcp_response 405").

Verified end-to-end: ChatGPT lists `search` + `fetch` and successfully calls `search` against the brain; Claude.ai web + Claude Code DCR + token exchange + `tools/list` all green.

Happy to split this into three PRs if you'd prefer (oauth security / chatgpt compat / search-fetch shim) — flagged the natural split below.

## What's actually landing

### 1. OAuth correctness (every confidential or PKCE-only DCR client)

**`/token` pre-hash middleware.** SDK [`clientAuth.js:45`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/server/auth/middleware/clientAuth.ts) strict-compares `client.client_secret` returned by `clientsStore.getClient()` to the request body's `client_secret`. gbrain's `oauth_clients.client_secret_hash` column stores sha256 hex; the client holds the plaintext returned at DCR time. The literal string compare always fails for `client_secret_post` clients (Claude.ai web, Claude Code) → every `authorization_code` / `refresh_token` exchange gets `400 invalid_client: \"Invalid client_secret\"`. SHA-256 the request's plaintext before SDK clientAuth runs so the comparison is hash-vs-hash. Skip for `client_credentials` grant — gbrain's own handler hashes itself and would double-hash.

**`getClient()` strips `client_secret` for `none` clients.** Same SDK clientAuth path: it demands a secret whenever `client.client_secret` is truthy, regardless of `token_endpoint_auth_method`. PKCE-only public clients (ChatGPT, mcporter, Hermes Agent, codex-cli) registered with `none` therefore get rejected with `\"Client secret is required\"`. Hide the stored hash so SDK falls through to the PKCE-only path. (Durable fix: `registerClient` should not generate or store a secret for `none` clients in the first place — left for a follow-up.)

### 2. ChatGPT MCP connector compatibility

**Catch-all `.well-known` rewrite middleware.** ChatGPT exhaustively probes nine metadata URL variants before considering discovery complete:

```
oauth-authorization-server  × { root, /.well-known/<doc>/mcp, /mcp/.well-known/<doc> }
openid-configuration        × { same three forms }
oauth-protected-resource    × { same three forms }
```

Any 404 makes ChatGPT abort and surface a misleading "DCR endpoint 404". Single regex rewrites every variant onto the SDK's canonical paths so the same metadata body answers every probe — beats enumerated alias whack-a-mole.

**`resourceServerUrl: '/mcp'` so PRM `resource` matches the URL users enter.** Both confirmed-working open-source ChatGPT MCP connector references ([tae0y/real-estate-mcp](https://github.com/tae0y/real-estate-mcp/blob/main/docs/setup-chatgpt-web.md) + Auth0, [GetLarge fastify-mcp + Ory Hydra](https://getlarge.eu/blog/securing-mcp-servers-with-oauth2-ory-hydra-claude-code-chatgpt/)) publish PRM `resource` as the `/mcp` URL. With this set, SDK serves PRM body `resource: \"https://<host>/mcp\"`.

**UA-conditional OIDC stub fields.** OpenAI's [Apps SDK auth doc](https://developers.openai.com/apps-sdk/build/auth) says ChatGPT accepts OAuth 2.0 metadata or OIDC metadata. Empirically, ChatGPT silently aborts DCR if the AS metadata document lacks `subject_types_supported`, `id_token_signing_alg_values_supported`, `userinfo_endpoint`, `jwks_uri` — both confirmed-working references are full OIDC providers, not coincidence. Inject these fields via `res.json` patch, gated on `User-Agent` matching `/aiohttp|openai-mcp/i` so non-ChatGPT clients keep clean OAuth 2.1 metadata. SDK's metadata document is a shared singleton, so we clone-before-mutate (otherwise one ChatGPT request would leak OIDC fields into every subsequent client's response).

**`/userinfo` and `/.well-known/jwks.json` stub routes** back the OIDC pointers without changing token semantics. Userinfo returns soft 200 with `{ sub: \"anonymous\" }` (401 reads as auth failure to ChatGPT and aborts token exchange); jwks returns `{ keys: [] }` since gbrain uses opaque tokens, not JWTs.

**`WWW-Authenticate` on `/mcp` 401 carries `resource_metadata=`** per [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) / [MCP 2025-06-18 authorization spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization).

**Slash-collapse middleware** strips leading `//` from `req.url`. gbrain publishes issuer with a trailing slash (URL canonical form), so naive `issuer + \"/register\"` concat in clients produces `//register` → Express 404.

**`GET /mcp` returns 200 + idle SSE stream** (15s heartbeat) instead of 405. MCP 2025-06-18 §StreamableHTTP permits 405 when no SSE is offered, but ChatGPT's `openai-mcp/1.0.0` treats it as `invalid_mcp_response` fatal error. Bearer-gated so unauth probes still get the spec'd 401 challenge.

**`DELETE /mcp` returns 405 + `Allow` header** instead of Express's default 404.

### 3. Opt-in ChatGPT search/fetch shim

ChatGPT Connector mode only displays tools named exactly `search` and `fetch` with specific input schemas; everything else is silently filtered client-side. With gbrain's 30+ ops surfaced raw, ChatGPT shows zero tools.

`agentName.startsWith('ChatGPT')` triggers a two-tool mode:
- `tools/list` returns only `search` + `fetch` with `inputSchema` matching OpenAI's connector spec.
- `tools/call` rewrites `fetch` → `get_page` and projects results via `toChatgptShape()`:
  - `search` → `{ results: [{ id, title, text, url }] }`
  - `fetch` → `{ id, title, text, url, metadata }`
- Returns both `structuredContent` (machine-read) and `content[].text` (legacy JSON string) for max compat.

Other MCP clients see the full op surface unchanged.

## Diagnostics

`appendFileSync` edge-trace logger writes every inbound request to `~/.gbrain/logs/edge-trace.log` synchronously, bypassing bun's block-buffered stdout under launchd `StandardOutPath`. Without this, `gbrain serve --http`'s log file lags real activity by minutes-to-hours and live debug is blind. Cheap (one fs call per request, no formatting). Happy to gate behind `--debug-edge-trace` if you'd prefer it not be always-on.

## Codex review follow-ups (not in this PR)

External review of the diff flagged 5 items I'd address in follow-up PRs once the foundation lands:

1. DCR `registerClient` should not generate or store a `client_secret_hash` for `token_endpoint_auth_method='none'` clients (durable fix for the PKCE secret-leak workaround).
2. `/mcp` should enforce the [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707) `resource` indicator as token audience (currently stored, not validated).
3. Search result IDs should encode `source_id:slug` for cross-source dedup safety.
4. ChatGPT shim trigger should not rely on `client_name.startsWith('ChatGPT')` (DCR `client_name` is client-controlled). Better gated by `--enable-chatgpt-compat` flag or explicit `/mcp/chatgpt` route.
5. Tool definitions should include `outputSchema`.

## Verification

End-to-end against a self-hosted production deploy:

- **DCR + OAuth flow.** Fresh ChatGPT custom connector add → `POST /register` (201) → `GET /authorize` (302) → `POST /token` (200) → `oauth_tokens` row issued with both access + refresh.
- **MCP transport.** `GET /mcp` opens SSE stream with bearer; `POST /mcp` JSON-RPC dispatches.
- **Tool surface.** ChatGPT UI displays `search` + `fetch`; `search(\"<query>\")` returns `{ results: [...] }` populated from gbrain.
- **Claude.ai web + Claude Code.** Both regained DCR + token exchange after the `/token` pre-hash + `getClient` strip patches (had been silently 401'ing on every confidential-client `client_secret_post` exchange).


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
