### PR TITLE
feat: GBRAIN_EXPOSED_TOOLS env var for MCP tool filtering

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -13,11 +13,29 @@ export async function startMcpServer(engine: BrainEngine) {
     { capabilities: { tools: {} } },
   );
 
+  // Optional tool filtering via GBRAIN_EXPOSED_TOOLS env var.
+  // Comma-separated list of operation names to expose (e.g. "get_page,put_page,search").
+  // When unset, all operations are exposed (backward-compatible default).
+  const exposedToolsEnv = process.env.GBRAIN_EXPOSED_TOOLS;
+  const allowedOps = exposedToolsEnv
+    ? (() => {
+        const allowed = new Set(exposedToolsEnv.split(',').map(s => s.trim()).filter(Boolean));
+        const filtered = operations.filter(op => allowed.has(op.name));
+        if (filtered.length > 0) {
+          process.stderr.write(`[mcp] GBRAIN_EXPOSED_TOOLS: exposing ${filtered.length} of ${operations.length} tools\n`);
+        } else {
+          process.stderr.write(`[mcp] GBRAIN_EXPOSED_TOOLS set but matched 0 operations — exposing all ${operations.length}\n`);
+          return operations;
+        }
+        return filtered;
+      })()
+    : operations;
+
   // Generate tool definitions from operations. Extracted to buildToolDefs so
   // the subagent tool registry (v0.15+) can call the same mapper against a
   // filtered OPERATIONS subset instead of duplicating this shape.
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: buildToolDefs(operations),
+    tools: buildToolDefs(allowedOps),
   }));
 
   // Dispatch tool calls via shared dispatch.ts (parity with HTTP transport).


### PR DESCRIPTION
## Problem

GBrain MCP server exposes all 51 operations to every consumer. For chatbot integrations (OpenClaw, Claude Desktop, etc.), this creates prompt bloat (~10K+ tokens of tool schemas per LLM call) and tool confusion (LLM sees job management, source management, file upload tools it will never use in conversation).

## Solution

A single env var `GBRAIN_EXPOSED_TOOLS` that filters which operations the MCP server registers.

```
GBRAIN_EXPOSED_TOOLS=get_page,put_page,search,query,list_pages,add_timeline_entry
```

- **Unset** = all operations exposed (backward-compatible default)
- **Set but matches 0** = falls back to all operations with stderr warning
- Logs on startup: `[mcp] GBRAIN_EXPOSED_TOOLS: exposing 12 of 51 tools`

CLI commands (`gbrain call`, `gbrain dream`, etc.) are unaffected -- they use operations directly, not the MCP server.

## Use case

OpenClaw passes env vars to the MCP server process. Same GBrain install serves both a lean chatbot MCP (12 tools) and the full CLI/dream-cycle toolset (51 tools).

## Changes

- `src/mcp/server.ts`: 19 lines added

## Test plan

- [ ] Env var unset -> all tools exposed (no behavior change)
- [ ] `GBRAIN_EXPOSED_TOOLS=get_page,search` -> only 2 tools in tools/list
- [ ] `GBRAIN_EXPOSED_TOOLS=nonexistent` -> falls back to all tools with warning
- [ ] CLI commands still work with full tool set regardless of env var

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->