### PR TITLE
Fix dream/synthesize pipeline for large transcripts

### DIFF
--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -175,7 +175,24 @@ export async function runPhaseSynthesize(
 
     const queue = new MinionQueue(engine);
     const childIds: number[] = [];
+    
+    // Split oversized transcripts into chunks
+    const processable: Array<{ transcript: DiscoveredTranscript; chunkIndex?: number }> = [];
     for (const t of worthProcessing) {
+      const estimatedTokens = Math.ceil(t.content.length / 3.5);
+      if (estimatedTokens <= config.maxPromptTokens) {
+        processable.push({ transcript: t });
+      } else {
+        // Split at natural boundaries
+        const chunks = splitTranscriptAtBoundaries(t.content, config.maxPromptTokens);
+        for (let i = 0; i < chunks.length; i++) {
+          const chunked = { ...t, content: chunks[i] };
+          processable.push({ transcript: chunked, chunkIndex: i });
+        }
+      }
+    }
+    
+    for (const { transcript: t, chunkIndex } of processable) {
       const childData: SubagentHandlerData = {
         prompt: buildSynthesisPrompt(t),
         model: config.model,
@@ -185,7 +202,9 @@ export async function runPhaseSynthesize(
       const submitOpts: Partial<MinionJobInput> = {
         max_stalled: 3,
         on_child_fail: 'continue',
-        idempotency_key: `dream:synth:${t.filePath}:${t.contentHash.slice(0, 16)}`,
+        idempotency_key: chunkIndex !== undefined 
+          ? `dream:synth:${t.filePath}:${t.contentHash.slice(0, 16)}:chunk${chunkIndex}`
+          : `dream:synth:${t.filePath}:${t.contentHash.slice(0, 16)}`,
         timeout_ms: 30 * 60 * 1000, // 30 min per transcript
       };
       const child = await queue.add(
@@ -269,6 +288,7 @@ interface SynthConfig {
   model: string;
   verdictModel: string;
   cooldownHours: number;
+  maxPromptTokens: number;
 }
 
 async function loadSynthConfig(engine: BrainEngine): Promise<SynthConfig> {
@@ -290,6 +310,7 @@ async function loadSynthConfig(engine: BrainEngine): Promise<SynthConfig> {
     fallback: 'haiku',
   });
   const cooldownHoursStr = await engine.getConfig('dream.synthesize.cooldown_hours');
+  const maxPromptTokensStr = await engine.getConfig('dream.synthesize.max_prompt_tokens');
 
   let excludePatterns: string[] = ['medical', 'therapy'];
   if (excludeStr) {
@@ -308,6 +329,7 @@ async function loadSynthConfig(engine: BrainEngine): Promise<SynthConfig> {
     model,
     verdictModel,
     cooldownHours: cooldownHoursStr ? Math.max(0, parseInt(cooldownHoursStr, 10) || 12) : 12,
+    maxPromptTokens: maxPromptTokensStr ? Math.max(100_000, parseInt(maxPromptTokensStr, 10) || 800_000) : 800_000,
   };
 }
 
@@ -619,6 +641,49 @@ function loadAdHocTranscript(
 
 function today(): string {
   return new Date().toISOString().slice(0, 10);
+}
+
+function splitTranscriptAtBoundaries(content: string, maxTokens: number): string[] {
+  const maxChars = maxTokens * 3.5; // rough token-to-char ratio
+  if (content.length <= maxChars) return [content];
+  
+  const chunks: string[] = [];
+  let remaining = content;
+  
+  while (remaining.length > maxChars) {
+    // Find a natural break point: topic separator, hour boundary, or ---
+    let splitAt = maxChars;
+    
+    // Look for topic separators (## Topic: ...) near the boundary
+    const topicRegex = /\n## Topic:/g;
+    let lastGoodSplit = -1;
+    let match;
+    while ((match = topicRegex.exec(remaining)) !== null) {
+      if (match.index <= maxChars && match.index > maxChars * 0.5) {
+        lastGoodSplit = match.index;
+      }
+      if (match.index > maxChars) break;
+    }
+    
+    if (lastGoodSplit > 0) {
+      splitAt = lastGoodSplit;
+    } else {
+      // Fall back to --- separators
+      const hrIdx = remaining.lastIndexOf('\n---\n', maxChars);
+      if (hrIdx > maxChars * 0.5) splitAt = hrIdx;
+      else {
+        // Last resort: split at nearest newline
+        const nlIdx = remaining.lastIndexOf('\n', maxChars);
+        if (nlIdx > maxChars * 0.5) splitAt = nlIdx;
+      }
+    }
+    
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt);
+  }
+  
+  if (remaining.length > 0) chunks.push(remaining);
+  return chunks;
 }
 
 function ok(summary: string, details: Record<string, unknown> = {}): PhaseResult {


### PR DESCRIPTION
## Problem

The dream/synthesize phase submits one subagent job per transcript file. Daily aggregated transcripts (2.7-4.5MB each, ~1-2M tokens) exceed Claude's 1M token context limit, causing every subagent to permanently fail with `prompt is too long: 1707509 tokens > 1000000 maximum`. The synthesizer has been stalled since May 2 (6 days).

## Root cause

`src/core/cycle/synthesize.ts` calls `buildSynthesisPrompt(t)` which includes the full transcript content. No size check, no chunking, no graceful degradation for large files.

## Solution

- **Add token estimation** — rough estimate: `Math.ceil(transcript.content.length / 3.5)` tokens
- **Add configurable max prompt size** — via `dream.synthesize.max_prompt_tokens` (default 800K)
- **For transcripts that exceed the limit** — split into chunks at natural boundaries:
  - Topic separators (`## Topic:`)
  - HR markers (`---`)
  - Newlines (last resort)
- **Each chunk gets unique idempotency key** — `dream:synth:file:hash:chunkN`
- **Never silently fail** — no more burning API credits on guaranteed-to-fail requests

## Testing

Verified with `/data/brain/daily/transcripts/2026/2026-04-07.md`:
- File size: 4,677,235 chars
- Estimated tokens: 1,336,353 (exceeds 800K limit)
- Would split into 2 chunks
- Chunking function tested and working correctly

## Changes

- Added `maxPromptTokens` to `SynthConfig` interface
- Added config loading for `dream.synthesize.max_prompt_tokens`
- Added `splitTranscriptAtBoundaries()` function with natural boundary detection
- Updated fan-out loop to pre-process transcripts and chunk oversized ones
- Updated idempotency keys to include chunk index when applicable

Fixes the synthesizer stall and prevents future large transcript failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->