### PR TITLE
fix: code-source first-sync (#744) + class-method code-def

### DIFF
--- a/src/commands/code-def.ts
+++ b/src/commands/code-def.ts
@@ -32,7 +32,13 @@ export async function findCodeDef(
   opts: { limit?: number; language?: string } = {},
 ): Promise<CodeDefResult[]> {
   const limit = opts.limit ?? 20;
-  const DEF_TYPES = ['function', 'class', 'interface', 'type', 'enum', 'struct', 'trait', 'module', 'contract'];
+  const DEF_TYPES = [
+    'function', 'class', 'interface', 'type', 'enum', 'struct', 'trait', 'module', 'contract',
+    // tree-sitter emits multi-word symbol_types for class members; without these
+    // any class method (~3200 chunks in a typical brain) returns 0 results
+    // even though chunks exist with the correct symbol_name.
+    'method definition', 'method signature', 'field definition', 'public field definition',
+  ];
   const params: unknown[] = [symbol, limit];
   let whereLang = '';
   if (opts.language) {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -4,6 +4,7 @@ import { join, relative } from 'path';
 import { cpus, totalmem } from 'os';
 import type { BrainEngine } from '../core/engine.ts';
 import { importFile, importImageFile, isImageFilePath } from '../core/import-file.ts';
+import { isCodeFilePath } from '../core/sync.ts';
 import { loadConfig, gbrainPath } from '../core/config.ts';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
@@ -28,7 +29,11 @@ export interface RunImportResult {
   failures: Array<{ path: string; error: string }>;
 }
 
-export async function runImport(engine: BrainEngine, args: string[], opts: { commit?: string } = {}): Promise<RunImportResult> {
+export async function runImport(
+  engine: BrainEngine,
+  args: string[],
+  opts: { commit?: string; strategy?: 'markdown' | 'code' | 'auto' } = {},
+): Promise<RunImportResult> {
   const noEmbed = args.includes('--no-embed');
   const fresh = args.includes('--fresh');
   const jsonOutput = args.includes('--json');
@@ -56,9 +61,16 @@ export async function runImport(engine: BrainEngine, args: string[], opts: { com
   }
   const dir: string = dirArg;  // narrowed; survives closure capture
 
-  // Collect all .md files
-  const allFiles = collectMarkdownFiles(dir);
-  console.log(`Found ${allFiles.length} markdown files`);
+  // Collect files per strategy. Default 'markdown' preserves pre-strategy
+  // behavior; sync.ts:performFullSync now passes strategy through so
+  // `gbrain sync --strategy code` actually walks code files on first sync.
+  const walkStrategy = opts.strategy || 'markdown';
+  const allFiles = walkStrategy === 'code'
+    ? collectCodeFiles(dir)
+    : walkStrategy === 'auto'
+      ? collectFilesAuto(dir)
+      : collectMarkdownFiles(dir);
+  console.log(`Found ${allFiles.length} ${walkStrategy} file(s)`);
 
   // Resume from checkpoint if available
   const checkpointPath = gbrainPath('import-checkpoint.json');
@@ -292,7 +304,28 @@ export async function runImport(engine: BrainEngine, args: string[], opts: { com
 }
 
 export function collectMarkdownFiles(dir: string): string[] {
+  return collectFiles(dir, 'markdown');
+}
+
+/**
+ * Collect every code file under `dir` per `isCodeFilePath`. Mirrors
+ * `collectMarkdownFiles`'s symlink-skip security guard. Used by
+ * `runImport` when invoked with `strategy: 'code'`.
+ */
+export function collectCodeFiles(dir: string): string[] {
+  return collectFiles(dir, 'code');
+}
+
+/** Collect markdown + code (+ images when multimodal). */
+export function collectFilesAuto(dir: string): string[] {
+  return collectFiles(dir, 'auto');
+}
+
+type WalkStrategy = 'markdown' | 'code' | 'auto';
+
+function collectFiles(dir: string, strategy: WalkStrategy): string[] {
   const files: string[] = [];
+  const multimodalEnabled = process.env.GBRAIN_EMBEDDING_MULTIMODAL === 'true';
 
   function walk(d: string) {
     for (const entry of readdirSync(d)) {
@@ -328,17 +361,23 @@ export function collectMarkdownFiles(dir: string): string[] {
 
       if (stat.isDirectory()) {
         walk(full);
-      } else if (entry.endsWith('.md') || entry.endsWith('.mdx')) {
+        continue;
+      }
+
+      const isMarkdown = entry.endsWith('.md') || entry.endsWith('.mdx');
+      const isCode = isCodeFilePath(entry);
+      const isImage = multimodalEnabled && isImageFilePath(entry);
+
+      if (strategy === 'markdown' && (isMarkdown || isImage)) {
         files.push(full);
-      } else if (multimodalEnabled && isImageFilePath(entry)) {
-        // v0.27.1 (F2): images join the walker only when multimodal is on.
-        // Pre-v0.27.1 brains keep their existing markdown-only walk.
+      } else if (strategy === 'code' && (isCode || isImage)) {
+        files.push(full);
+      } else if (strategy === 'auto' && (isMarkdown || isCode || isImage)) {
         files.push(full);
       }
     }
   }
 
-  const multimodalEnabled = process.env.GBRAIN_EMBEDDING_MULTIMODAL === 'true';
   walk(dir);
   return files.sort();
 }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -858,7 +858,7 @@ async function performFullSync(
     const allFiles = collectMarkdownFiles(repoPath);
     const syncableRelPaths = allFiles
       .map(abs => relative(repoPath, abs))
-      .filter(rel => isSyncable(rel));
+      .filter(rel => isSyncable(rel, { strategy: opts.strategy }));
     console.log(
       `Full-sync dry run: ${syncableRelPaths.length} file(s) would be imported ` +
       `from ${repoPath} @ ${headCommit.slice(0, 8)}.`,
@@ -889,7 +889,7 @@ async function performFullSync(
   const importArgs = [repoPath];
   if (opts.noEmbed) importArgs.push('--no-embed');
   if (fullConcurrency > 1) importArgs.push('--workers', String(fullConcurrency));
-  const result = await runImport(engine, importArgs, { commit: headCommit });
+  const result = await runImport(engine, importArgs, { commit: headCommit, strategy: opts.strategy });
 
   // Bug 9 — gate the full-sync bookmark on success. runImport already
   // writes its own sync.last_commit conditionally (import.ts), but


### PR DESCRIPTION
## Summary

Two atomic commits that together make `gbrain sync --strategy code` actually work end-to-end on first sync, and `gbrain code-def` resolve class methods that the existing tree-sitter chunker already extracts.

Discovered while upgrading a real PlanetScale Postgres brain from `v0.26.6` → `v0.30.0` (companion to #740, #741, #744).

### 1. `commands/sync.ts` + `commands/import.ts` — strategy threading (closes #744)

Reproduces issue #744 directly. `performFullSync` called `runImport(repoPath)` without the strategy flag; `runImport` then walked markdown only via `collectMarkdownFiles`. First-sync of a fresh `gstack-code-*` source reported "X pages imported" but persisted **zero** code files. Three different repos on the same brain showed identical broken state.

Three small changes, all additive:

- Extract a shared `collectFiles(dir, strategy)` walker in `commands/import.ts` that branches on strategy. Add `collectCodeFiles` and `collectFilesAuto` wrappers. `collectMarkdownFiles` keeps its current behavior + signature for backward compat (no caller changes needed).
- `runImport` accepts `strategy` in opts and picks the right walker. Default `'markdown'` preserves pre-strategy callers.
- `performFullSync` threads `opts.strategy` through to `runImport` (and into the dry-run filter at line 861, which dropped strategy too).

Verified end-to-end across three repos:

| Repo | Code files imported | Status |
|---|---|---|
| conquest-lpr (a 5-app monorepo) | 858 | ✅ |
| rv-helper (Expo + Supabase) | 360 | ✅ |
| trashtastic-helix | partial — 2 legitimate failures (5.6MB minified `dist/` JS; Supabase types.ts with NUL bytes — both correctly refused, not bugs) | ✅ |

### 2. `commands/code-def.ts` — extend `DEF_TYPES` for class members

`gbrain code-def <symbol>` returned 0 results for any class method even when chunks existed with the correct `symbol_name`, because the WHERE filter only allowed:

```js
['function', 'class', 'interface', 'type', 'enum', 'struct', 'trait', 'module', 'contract', 'export statement']
```

The tree-sitter chunker emits more granular `symbol_type` values than that. Real distribution on my brain after a full sync:

```
function                  | 10897
declaration               |  5926
method definition         |  3201   ← was filtered out
export statement          |   818
import                    |   375
class                     |   343
interface                 |   215
field definition          |   124   ← was filtered out
variable assignment       |   108
struct specifier          |    60
public field definition   |    57   ← was filtered out
type                      |    40
method signature          |    14   ← was filtered out
```

Concretely: `Database.calculateDeviceStatuses` (a TypeScript class method) returned `{count: 0}` from `code-def` even though the chunk existed at `apps/worker/src/db.ts` with the right `symbol_name` and `symbol_type='method definition'`.

Fix: add four multi-word symbol_types representing class members. Additive only:

```diff
   const DEF_TYPES = [
     'function', 'class', 'interface', 'type', 'enum', 'struct', 'trait', 'module', 'contract',
+    'method definition', 'method signature', 'field definition', 'public field definition',
   ];
```

`'declaration'` is left out (too generic — covers imports, type aliases, plain bindings).

After: `gbrain code-def calculateDeviceStatuses` returns 3 hits (the real source plus a couple of compiled-JS build artifacts that are themselves a separate walker concern).

## Test plan

- [x] Build: `bun install && bun run build` — passes.
- [x] Typecheck: `bun run typecheck` — passes.
- [x] Existing tests: `bun test test/schema-bootstrap-coverage.test.ts` — 5/5 pass (unchanged).
- [x] Smoke test: fresh `gstack-code-*` source on Postgres → `gbrain sync --strategy code --source <id>` actually imports code files; `gbrain code-def <classMethod>` returns hits.
- [ ] CI on this PR — open to suggestions if there's a specific test you'd want for either fix.

## Notes on follow-up bugs surfaced during this dig

Not in this PR; flagging for future:
- The walker doesn't respect `.gitignore` — `tmp/`, `dist/`, build artifacts get indexed alongside source. Worth a `.gitignore`-aware skip-list or an explicit `--ignore` glob.
- `--source <id>` is recorded on `sources.last_commit/last_sync_at` but pages still land under `source_id='default'` rather than the named source. That's why `gbrain sources list` shows `page_count=0` on the new sources even after a successful sync. Reasonable next dig — happy to PR if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->