### PR TITLE
fix(migrations): v0_29_1 backfill misses connect() and uses BEGIN/COMMIT outside transaction

### DIFF
--- a/src/commands/migrations/v0_29_1.ts
+++ b/src/commands/migrations/v0_29_1.ts
@@ -48,26 +48,32 @@ async function phaseBBackfill(opts: OrchestratorOpts): Promise<OrchestratorPhase
     const { backfillEffectiveDate } = await import('../../core/backfill-effective-date.ts');
     const cfg = loadConfig();
     if (!cfg) throw new Error('No gbrain config; run `gbrain init` first.');
-    const engine = await createEngine(toEngineConfig(cfg));
+    const engineCfg = toEngineConfig(cfg);
+    const engine = await createEngine(engineCfg);
+    await engine.connect(engineCfg);
 
     let totalExamined = 0;
     let totalUpdated = 0;
 
-    const result = await backfillEffectiveDate(engine, {
-      onBatch: ({ batch, lastId, rowsTouched, cumulative }) => {
-        totalExamined = cumulative;
-        totalUpdated += rowsTouched;
-        if (batch % 10 === 0) {
-          process.stderr.write(`  [backfill] batch ${batch} | last_id=${lastId} | examined=${cumulative} | updated_so_far=${totalUpdated}\n`);
-        }
-      },
-    });
+    try {
+      const result = await backfillEffectiveDate(engine, {
+        onBatch: ({ batch, lastId, rowsTouched, cumulative }) => {
+          totalExamined = cumulative;
+          totalUpdated += rowsTouched;
+          if (batch % 10 === 0) {
+            process.stderr.write(`  [backfill] batch ${batch} | last_id=${lastId} | examined=${cumulative} | updated_so_far=${totalUpdated}\n`);
+          }
+        },
+      });
 
-    return {
-      name: 'backfill_effective_date',
-      status: 'complete',
-      detail: `examined=${result.examined} updated=${result.updated} fallback=${result.fallback} dur=${result.durationSec.toFixed(1)}s`,
-    };
+      return {
+        name: 'backfill_effective_date',
+        status: 'complete',
+        detail: `examined=${result.examined} updated=${result.updated} fallback=${result.fallback} dur=${result.durationSec.toFixed(1)}s`,
+      };
+    } finally {
+      try { await engine.disconnect(); } catch { /* best-effort */ }
+    }
   } catch (e) {
     return { name: 'backfill_effective_date', status: 'failed', detail: e instanceof Error ? e.message : String(e) };
   }
@@ -82,23 +88,29 @@ async function phaseCVerify(opts: OrchestratorOpts): Promise<OrchestratorPhaseRe
     const { loadConfig, toEngineConfig } = await import('../../core/config.ts');
     const cfg = loadConfig();
     if (!cfg) throw new Error('No gbrain config; run `gbrain init` first.');
-    const engine = await createEngine(toEngineConfig(cfg));
-    // Count rows where effective_date is still NULL but frontmatter HAS a
-    // parseable date — those are the rows the backfill should have touched
-    // but didn't. (Rows that fall through to 'fallback' have non-null
-    // effective_date already; this catches genuine misses.)
-    const rows = await engine.executeRaw<{ count: string }>(
-      `SELECT COUNT(*)::text AS count FROM pages WHERE effective_date IS NULL`,
-    );
-    const remaining = Number(rows[0]?.count ?? 0);
-    if (remaining > 0) {
-      return {
-        name: 'verify',
-        status: 'failed',
-        detail: `${remaining} pages still have NULL effective_date (backfill incomplete)`,
-      };
+    const engineCfg = toEngineConfig(cfg);
+    const engine = await createEngine(engineCfg);
+    await engine.connect(engineCfg);
+    try {
+      // Count rows where effective_date is still NULL but frontmatter HAS a
+      // parseable date — those are the rows the backfill should have touched
+      // but didn't. (Rows that fall through to 'fallback' have non-null
+      // effective_date already; this catches genuine misses.)
+      const rows = await engine.executeRaw<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM pages WHERE effective_date IS NULL`,
+      );
+      const remaining = Number(rows[0]?.count ?? 0);
+      if (remaining > 0) {
+        return {
+          name: 'verify',
+          status: 'failed',
+          detail: `${remaining} pages still have NULL effective_date (backfill incomplete)`,
+        };
+      }
+      return { name: 'verify', status: 'complete', detail: '0 pages with NULL effective_date' };
+    } finally {
+      try { await engine.disconnect(); } catch { /* best-effort */ }
     }
-    return { name: 'verify', status: 'complete', detail: '0 pages with NULL effective_date' };
   } catch (e) {
     return { name: 'verify', status: 'failed', detail: e instanceof Error ? e.message : String(e) };
   }

--- a/src/core/backfill-effective-date.ts
+++ b/src/core/backfill-effective-date.ts
@@ -175,14 +175,14 @@ export async function backfillEffectiveDate(
     if (!opts.dryRun) {
       // Compute effective_date for each row, then UPDATE in a batch wrapped
       // in its own transaction (so SET LOCAL statement_timeout scopes to it).
-      // postgres.js's `transaction` would be cleaner but we're using executeRaw
-      // for engine portability; explicit BEGIN/COMMIT does the same on both.
-      if (isPostgres) {
-        await engine.executeRaw(`BEGIN`);
-        await engine.executeRaw(`SET LOCAL statement_timeout = '600s'`);
-      }
-
-      try {
+      // postgres.js v3 refuses ad-hoc BEGIN/COMMIT spread across executeRaw
+      // calls on pooled connections (UNSAFE_TRANSACTION) — must go through
+      // engine.transaction() so all statements share one backend. PGLite path
+      // skips the wrapper (single-writer; no SET LOCAL scoping needed).
+      const applyBatch = async (exec: BrainEngine) => {
+        if (isPostgres) {
+          await exec.executeRaw(`SET LOCAL statement_timeout = '600s'`);
+        }
         for (const r of rows) {
           const fm = parseFrontmatter(r.frontmatter);
           const filename = r.import_filename
@@ -204,20 +204,19 @@ export async function backfillEffectiveDate(
 
           if (!opts.force && datesMatch && sourcesMatch) continue;
 
-          await engine.executeRaw(
+          await exec.executeRaw(
             `UPDATE pages SET effective_date = $1::timestamptz, effective_date_source = $2 WHERE id = $3`,
             [computed.date ? computed.date.toISOString() : null, computed.source, r.id],
           );
           touched++;
           if (computed.source === 'fallback') fallback++;
         }
+      };
 
-        if (isPostgres) await engine.executeRaw(`COMMIT`);
-      } catch (e) {
-        if (isPostgres) {
-          try { await engine.executeRaw(`ROLLBACK`); } catch { /* ignore */ }
-        }
-        throw e;
+      if (isPostgres) {
+        await engine.transaction(applyBatch);
+      } else {
+        await applyBatch(engine);
       }
     } else {
       // Dry run: still count what WOULD change.


### PR DESCRIPTION
## Summary

Two real bugs that prevent the v0.29.1 effective_date backfill from running on Postgres / Supabase brains. Found while upgrading a real ~10.7K-page Supabase brain that was wedged at `v0.29.1 PARTIAL` for hours.

## Bug 1 — `v0_29_1.ts` phase B + phase C never call `engine.connect()`

`phaseBBackfill` and `phaseCVerify` create an engine via `createEngine()` but never call `await engine.connect(cfg)`. Every other migration orchestrator does this (`v0_28_0.ts:208`, `v0_22_4.ts:84`, `v0_18_0.ts:50`, `v0_14_0.ts:55`, `v0_13_1.ts:68`).

Failure surface on a real Supabase brain:

```
Migration v0.29.1 reported status=failed.
backfill_effective_date status: failed
detail: "No database connection: connect() has not been called.
 Fix: Run gbrain init --supabase or gbrain init --url ..."
```

Wrapped the engine usage in try/finally so `disconnect()` always fires (matches the pattern in `v0_22_4.ts`).

## Bug 2 — `backfill-effective-date.ts` ad-hoc `BEGIN`/`COMMIT` via separate `executeRaw` calls

The current code wraps each batch in:

```ts
await engine.executeRaw(`BEGIN`);
await engine.executeRaw(`SET LOCAL statement_timeout = '600s'`);
// ... 1000 UPDATEs ...
await engine.executeRaw(`COMMIT`);
```

with a comment that already acknowledges the intended alternative:

```
// postgres.js's `transaction` would be cleaner but we're using executeRaw
// for engine portability; explicit BEGIN/COMMIT does the same on both.
```

On real pooled Postgres it does NOT do the same. postgres.js v3 refuses this pattern on pooled connections:

```
UNSAFE_TRANSACTION: Only use sql.begin, sql.reserved or max: 1
```

The reason is that pgbouncer / Supavisor in transaction mode may route each `executeRaw` call to a different backend, so `BEGIN` lands on backend-A and `COMMIT` lands on backend-B — the protected updates aren't atomic, statement_timeout SET LOCAL is silently dropped, and postgres.js detects the structural smell.

Replaced with `engine.transaction(async (tx) => { ... })` (which uses `sql.begin` under the hood) for the Postgres path. PGLite path stays direct since it has a single writer and no pooler.

## Note on overlap with v0.30.1's `backfill-base.ts`

v0.30.1 introduced `src/core/backfill-base.ts` as the forward-looking pattern for new backfills (with `withReservedConnection` + adaptive batching). This PR keeps the OLD `backfill-effective-date.ts` path working for existing v0.29.1 brains mid-upgrade rather than migrating the v0.29.1 orchestrator to `backfill-base.ts`. Happy to do that migration in a follow-up PR if preferred.

## Verification

Tested on a ~10.7K-page real Supabase brain that was wedged at `v0.29.1 PARTIAL`. With both fixes:

- Phase A (schema): complete
- Phase B (backfill_effective_date): `examined=10666, updated=10666, fallback=535, dur=484s` (about 8 min)
- Phase C (verify): `0 pages with NULL effective_date`
- Final ledger entry: `status: complete`
- `gbrain doctor` `effective_date_health` reports clean.

## Test plan

- [ ] `bun run typecheck` clean
- [ ] Run `gbrain apply-migrations --yes` against an existing v0.29.0/v0.29.1 brain on Supabase pooler (port 6543) — should reach status=complete
- [ ] Run on PGLite — should still work (PGLite path unchanged)
- [ ] No new tests added; happy to add `test/migrations-v0_29_1.serial.test.ts` mirroring `test/migration-orchestrator-v0_21_0.test.ts` if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->