### PR TITLE
fix(connection-manager): strip .<project-ref> suffix from username when deriving direct URL

### DIFF
--- a/src/core/connection-manager.ts
+++ b/src/core/connection-manager.ts
@@ -142,16 +142,22 @@ export function deriveDirectUrl(url: string): string | null {
     const decodedUser = decodeURIComponent(user);
     const refMatch = decodedUser.match(/^postgres\.([a-z0-9]+)$/i);
     let directHost = hostname;
+    let directUser = parsed.username;
     if (refMatch && refMatch[1] && isPoolerHost) {
       directHost = `db.${refMatch[1]}.supabase.co`;
+      // Supabase direct connections use bare `postgres`; the `postgres.<ref>`
+      // form is pooler-only (Supavisor uses the suffix for tenant routing).
+      // Without this strip, direct auth fails with `password authentication
+      // failed for user "postgres.<ref>"` even though the password is correct.
+      directUser = 'postgres';
     }
     // Compose direct URL by swapping host + port. Preserve auth, db, query.
     parsed.hostname = directHost;
     parsed.port = '5432';
     // Reconstruct with the original scheme.
     const scheme = url.match(/^postgres(?:ql)?:\/\//i)?.[0] ?? 'postgres://';
-    const auth = parsed.username
-      ? `${parsed.username}${parsed.password ? `:${parsed.password}` : ''}@`
+    const auth = directUser
+      ? `${directUser}${parsed.password ? `:${parsed.password}` : ''}@`
       : '';
     const search = parsed.search ?? '';
     const path = parsed.pathname ?? '';

--- a/test/connection-manager.serial.test.ts
+++ b/test/connection-manager.serial.test.ts
@@ -44,6 +44,18 @@ describe('deriveDirectUrl', () => {
     expect(direct).toContain(':secret@'); // creds preserved
   });
 
+  test('strips .<project-ref> suffix from username when going pooler→direct', () => {
+    // Supabase direct connections require bare `postgres`; the `postgres.<ref>`
+    // form is pooler-only (Supavisor uses the suffix for tenant routing).
+    // Without the strip, direct auth fails with "password authentication
+    // failed for user postgres.<ref>" even with the correct password.
+    const direct = deriveDirectUrl(
+      'postgresql://postgres.abcxyz:secret@aws-0-us-east-1.pooler.supabase.com:6543/postgres'
+    );
+    expect(direct).toContain('postgres:secret@'); // bare username
+    expect(direct).not.toContain('postgres.abcxyz:secret@'); // no pooler suffix
+  });
+
   test('falls back to port-only swap when project-ref unparseable', () => {
     const direct = deriveDirectUrl(
       'postgresql://customuser:secret@some.pooler.supabase.com:6543/db'
@@ -51,6 +63,7 @@ describe('deriveDirectUrl', () => {
     expect(direct).toBeTruthy();
     expect(direct).toContain(':5432');
     expect(direct).toContain('some.pooler.supabase.com'); // host preserved
+    expect(direct).toContain('customuser:secret@'); // non-pooler username preserved
   });
 
   test('returns null for non-pooler URL', () => {


### PR DESCRIPTION
## Summary

`deriveDirectUrl()` correctly rewrites the host (`aws-0-us-east-1.pooler.supabase.com` → `db.abcxyz.supabase.co`) but preserves the full pooler-form username (`postgres.abcxyz`). Supabase direct connections expect bare `postgres` — Supavisor uses the `.<ref>` suffix for tenant routing only, not as a real database user. The auto-derived URL therefore fails authentication with the correct password:

```
password authentication failed for user "postgres.abcxyz"
```

## Repro

```ts
import { deriveDirectUrl } from './src/core/connection-manager.ts';
const url = 'postgresql://postgres.abcxyz:pwd@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
const direct = deriveDirectUrl(url);
// Before: postgresql://postgres.abcxyz:pwd@db.abcxyz.supabase.co:5432/postgres
// After:  postgresql://postgres:pwd@db.abcxyz.supabase.co:5432/postgres
```

Tested on a real Supabase project. Bare `postgres` authenticates; `postgres.abcxyz` does not (password is correct in both cases).

## Fix

Strip the `.<project-ref>` suffix to `postgres` whenever the project-ref was successfully extracted — the same condition that already triggers the host rewrite. The non-pooler-username branch (port-only fallback) keeps the username as-is, so custom-username deployments are unaffected.

## Why it matters

Without this, every Supabase user with a stock pooler URL silently falls through to single-pool routing the first time v0.30.1's dual-pool logic tries to use the direct port. The user has to either pay for the IPv4 add-on AND hand-set `GBRAIN_DIRECT_DATABASE_URL`, or set `GBRAIN_DISABLE_DIRECT_POOL=1` and lose the dual-pool benefit. With this fix, the canonical Supabase shape works out of the box.

(Note: a separate networking concern — direct connections at `db.<ref>.supabase.co:5432` are now IPv6-only by default unless the user has Supabase's IPv4 add-on. That's outside this PR's scope. This fix makes the URL derivation correct so users with working IPv6 / IPv4 add-on get the dual-pool benefit immediately.)

## Test plan

- [x] `bun run typecheck` clean
- [x] New test case asserts bare `postgres:secret@` in the derived URL when project-ref is parseable
- [x] Extended existing "falls back to port-only" case with assertion that non-pooler usernames are preserved
- [x] `deriveDirectUrl` test block: 5 pass, 0 fail

## Backwards compatibility

The non-pooler-username branch is byte-identical to before. Only the project-ref-extracted Supabase pooler→direct path changes. Anyone explicitly setting `GBRAIN_DIRECT_DATABASE_URL` continues to bypass derivation entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->