### PR TITLE
fix(init): --help should not mutate config or scan filesystem

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,6 +11,20 @@ import { createEngine } from '../core/engine-factory.ts';
 import { discoverOAuth, mintClientCredentialsToken, smokeTestMcp } from '../core/remote-mcp-probe.ts';
 
 export async function runInit(args: string[]) {
+  // Help guard: cli.ts only routes --help to printOpHelp() for shared-op
+  // commands; CLI_ONLY commands (init, embed, etc.) fall through to their
+  // handler with --help in argv. Without this guard, `gbrain init --help`
+  // proceeds into the smart-detection branch below, scans cwd for .md files,
+  // and on a directory with 1000+ files (e.g. $HOME for someone whose brain
+  // and notes share a root) silently overwrites the existing Supabase config
+  // with a fresh PGLite brain at ~/.gbrain/brain.pglite. Confirmed in the
+  // wild — flipped a working `engine: postgres` config to `engine: pglite`
+  // on a brain with 10K+ pages. Help should never mutate state.
+  if (args.includes('--help') || args.includes('-h')) {
+    printInitHelp();
+    return;
+  }
+
   const isSupabase = args.includes('--supabase');
   const isPGLite = args.includes('--pglite');
   const isMcpOnly = args.includes('--mcp-only');
@@ -728,4 +742,49 @@ export function reportModStatus(): void {
   console.log('Resolver: skills/RESOLVER.md');
   console.log('Soul audit: run `gbrain soul-audit` to customize agent identity');
   console.log('');
+}
+
+function printInitHelp() {
+  console.log(`
+gbrain init — initialize a brain (PGLite or Supabase Postgres)
+
+USAGE
+  gbrain init [flags]
+
+ENGINE SELECTION (mutually exclusive)
+  --pglite              Use embedded PGLite (zero-config, default for <1000 .md files)
+  --supabase            Use Supabase Postgres (recommended for 1000+ files)
+  --url <URL>           Use a manual Postgres connection string
+  --mcp-only            Thin-client mode: connect to a remote gbrain MCP, no local engine
+
+OPTIONS
+  --force               Overwrite an existing config (gated by default)
+  --non-interactive     Don't prompt; use defaults
+  --migrate-only        Apply pending schema migrations against the configured engine
+                        without re-saving config (used by post-upgrade and orchestrators)
+  --json                JSON output for status reporting
+  --path <DIR>          Override default brain path (PGLite only)
+  --key <APIKEY>        Provide an API key non-interactively (Supabase only)
+  --embedding-model <PROVIDER:MODEL>
+                        e.g. openai:text-embedding-3-large, voyage:voyage-multimodal-3
+  --model <PROVIDER>    Shorthand: pick recipe default for a provider
+  --embedding-dimensions <N>
+                        Embedding dimensions (must match the model)
+  --expansion-model <PROVIDER:MODEL>
+                        Model for query expansion (default: anthropic:claude-haiku)
+  --chat-model <PROVIDER:MODEL>
+                        Default subagent driver (v0.27+)
+
+EXAMPLES
+  gbrain init --pglite                      # Local-only, no API keys
+  gbrain init --supabase                    # Interactive Supabase setup
+  gbrain init --url postgresql://...        # Use a custom Postgres
+  gbrain init --mcp-only --url https://...  # Thin-client mode
+
+NOTES
+  - Bare \`gbrain init\` in a directory with 1000+ .md files defaults to Supabase
+    interactive setup. With <1000 files (or with --pglite explicitly), defaults
+    to PGLite at ~/.gbrain/brain.pglite.
+  - Existing config is preserved unless --force is passed.
+`.trim());
 }


### PR DESCRIPTION
## Summary

`gbrain init --help` currently falls through to the smart-detection branch in `runInit()` instead of printing help. From a directory with 1000+ `.md` files, that path scans cwd, prints \"Found ~N .md files. For a brain this size, Supabase gives faster search...\", and then defaults to PGLite — calling `saveConfig()` and **overwriting any existing Postgres config**.

## Repro

Confirmed on a real install:

```bash
$ cat ~/.gbrain/config.json
{ \"engine\": \"postgres\", \"database_url\": \"postgresql://postgres.<ref>:<pwd>@aws-1-us-west-2.pooler.supabase.com:6543/postgres\" }

$ cd ~ && gbrain init --help    # ~ has 1000+ .md files
Found ~1500 .md files. For a brain this size, Supabase gives faster
search and remote access ($25/mo). PGLite works too but search will be slower at scale.

  gbrain init --supabase   Set up with Supabase (recommended for large brains)
  gbrain init --pglite     Use local PGLite anyway

Setting up local brain with PGLite (no server needed)...
[migration output...]

$ cat ~/.gbrain/config.json
{ \"engine\": \"pglite\", \"database_path\": \"/Users/<user>/.gbrain/brain.pglite\" }
```

The Supabase data was intact, but gbrain stopped pointing at it until config was manually restored from a backup. On a 10K+ page brain that's a several-minute incident at best, a data-loss-shaped scare at worst (\"did `gbrain init` just nuke my brain?\").

## Root cause

`cli.ts:62-69` only routes `--help` → `printOpHelp()` for shared-op commands:

```ts
if (subArgs.includes('--help') || subArgs.includes('-h')) {
  const op = cliOps.get(command);
  if (op) {
    printOpHelp(op);
    return;
  }
}
```

CLI_ONLY commands (`init`, `embed`, `serve`, etc.) skip this branch — they fall through to `handleCliOnly` with `--help` still in argv. None of the CLI_ONLY handlers check for it.

## Fix

Add a `--help` / `-h` guard at the top of `runInit()` that prints help text and returns. **Help should never mutate state** — Postel's robustness principle for CLI tools.

Help text covers all flags (engine selection, AI provider options, thin-client mode) so users running `--help` get the canonical list rather than reading the source.

## Why per-command, not cli.ts-level

A wider architectural fix — adding `--help` routing for all CLI_ONLY commands in `cli.ts` — is plausible follow-up, but each CLI_ONLY command would still need its own help text. This per-command pattern matches how shared ops do it via `printOpHelp()`. Init is the highest-stakes case because it's the only CLI_ONLY command that calls `saveConfig()`.

If the maintainer prefers the wider fix, happy to extend; flagging here as the local-minimum patch.

## Smoke test

From a directory with 1500 `.md` files, with `GBRAIN_HOME` pointed at a fresh tempdir:
- **Before fix**: `~/.gbrain/config.json` materialized with `engine: 'pglite'`
- **After fix**: help text printed, no config dir created

## Test plan

- [x] `bun run typecheck` clean
- [x] Smoke-tested `gbrain init --help` from a 1500-file directory — no config mutation
- [ ] No automated test added (init.ts has no existing test coverage; happy to add `test/init-help-guard.test.ts` if desired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->