### PR TITLE
fix: unblock v0.29.1 effective date migration

### DIFF
--- a/src/commands/migrations/v0_29_1.ts
+++ b/src/commands/migrations/v0_29_1.ts
@@ -48,7 +48,9 @@ async function phaseBBackfill(opts: OrchestratorOpts): Promise<OrchestratorPhase
     const { backfillEffectiveDate } = await import('../../core/backfill-effective-date.ts');
     const cfg = loadConfig();
     if (!cfg) throw new Error('No gbrain config; run `gbrain init` first.');
-    const engine = await createEngine(toEngineConfig(cfg));
+    const engineConfig = toEngineConfig(cfg);
+    const engine = await createEngine(engineConfig);
+    await engine.connect(engineConfig);
 
     let totalExamined = 0;
     let totalUpdated = 0;
@@ -82,7 +84,9 @@ async function phaseCVerify(opts: OrchestratorOpts): Promise<OrchestratorPhaseRe
     const { loadConfig, toEngineConfig } = await import('../../core/config.ts');
     const cfg = loadConfig();
     if (!cfg) throw new Error('No gbrain config; run `gbrain init` first.');
-    const engine = await createEngine(toEngineConfig(cfg));
+    const engineConfig = toEngineConfig(cfg);
+    const engine = await createEngine(engineConfig);
+    await engine.connect(engineConfig);
     // Count rows where effective_date is still NULL but frontmatter HAS a
     // parseable date — those are the rows the backfill should have touched
     // but didn't. (Rows that fall through to 'fallback' have non-null

--- a/src/core/backfill-effective-date.ts
+++ b/src/core/backfill-effective-date.ts
@@ -10,9 +10,6 @@
  * batch. A killed process can re-run and pick up where it left off without
  * re-doing rows. Idempotent: even a full re-walk produces the same writes.
  *
- * Postgres only sets `SET LOCAL statement_timeout = '600s'` per batch (does
- * NOT refuse the migration on low session settings — codex pass-2 #16).
- *
  * Pure library function — same code path used by the v0_29_1 orchestrator
  * AND the `gbrain reindex-frontmatter` CLI command (added in commit 4).
  *
@@ -136,11 +133,6 @@ export async function backfillEffectiveDate(
   let fallback = 0;
   let batchNum = 0;
 
-  // Per-engine statement_timeout boost. Postgres can wedge on a slow
-  // batch otherwise; PGLite ignores SET LOCAL outside transactions but
-  // doesn't have the timeout problem in the first place (single writer).
-  const isPostgres = engine.kind === 'postgres';
-
   while (true) {
     if (opts.maxRows && examined >= opts.maxRows) break;
 
@@ -173,51 +165,39 @@ export async function backfillEffectiveDate(
     let touched = 0;
 
     if (!opts.dryRun) {
-      // Compute effective_date for each row, then UPDATE in a batch wrapped
-      // in its own transaction (so SET LOCAL statement_timeout scopes to it).
-      // postgres.js's `transaction` would be cleaner but we're using executeRaw
-      // for engine portability; explicit BEGIN/COMMIT does the same on both.
-      if (isPostgres) {
-        await engine.executeRaw(`BEGIN`);
-        await engine.executeRaw(`SET LOCAL statement_timeout = '600s'`);
-      }
+      // Compute effective_date for each row, then UPDATE independently.
+      // This backfill is idempotent and resumable via CHECKPOINT_KEY, so a
+      // batch-level transaction is unnecessary. More importantly, postgres.js
+      // rejects raw BEGIN/COMMIT on pooled connections; callers that need a
+      // transaction must use sql.begin/sql.reserved, which is not exposed by
+      // the portable BrainEngine interface used here.
+      for (const r of rows) {
+        const fm = parseFrontmatter(r.frontmatter);
+        const filename = r.import_filename
+          || (r.slug.includes('/') ? r.slug.split('/').pop()! : r.slug);
+        const computed = computeEffectiveDate({
+          slug: r.slug,
+          frontmatter: fm,
+          filename,
+          updatedAt: new Date(r.updated_at),
+          createdAt: new Date(r.created_at),
+        });
 
-      try {
-        for (const r of rows) {
-          const fm = parseFrontmatter(r.frontmatter);
-          const filename = r.import_filename
-            || (r.slug.includes('/') ? r.slug.split('/').pop()! : r.slug);
-          const computed = computeEffectiveDate({
-            slug: r.slug,
-            frontmatter: fm,
-            filename,
-            updatedAt: new Date(r.updated_at),
-            createdAt: new Date(r.created_at),
-          });
+        // No-op-on-equal: skip the UPDATE if existing matches (saves write
+        // amplification on re-runs). `force: true` bypasses.
+        const existingMs = r.effective_date ? new Date(r.effective_date).getTime() : null;
+        const computedMs = computed.date ? computed.date.getTime() : null;
+        const datesMatch = existingMs === computedMs;
+        const sourcesMatch = (r.effective_date_source ?? null) === (computed.source ?? null);
 
-          // No-op-on-equal: skip the UPDATE if existing matches (saves write
-          // amplification on re-runs). `force: true` bypasses.
-          const existingMs = r.effective_date ? new Date(r.effective_date).getTime() : null;
-          const computedMs = computed.date ? computed.date.getTime() : null;
-          const datesMatch = existingMs === computedMs;
-          const sourcesMatch = (r.effective_date_source ?? null) === (computed.source ?? null);
+        if (!opts.force && datesMatch && sourcesMatch) continue;
 
-          if (!opts.force && datesMatch && sourcesMatch) continue;
-
-          await engine.executeRaw(
-            `UPDATE pages SET effective_date = $1::timestamptz, effective_date_source = $2 WHERE id = $3`,
-            [computed.date ? computed.date.toISOString() : null, computed.source, r.id],
-          );
-          touched++;
-          if (computed.source === 'fallback') fallback++;
-        }
-
-        if (isPostgres) await engine.executeRaw(`COMMIT`);
-      } catch (e) {
-        if (isPostgres) {
-          try { await engine.executeRaw(`ROLLBACK`); } catch { /* ignore */ }
-        }
-        throw e;
+        await engine.executeRaw(
+          `UPDATE pages SET effective_date = $1::timestamptz, effective_date_source = $2 WHERE id = $3`,
+          [computed.date ? computed.date.toISOString() : null, computed.source, r.id],
+        );
+        touched++;
+        if (computed.source === 'fallback') fallback++;
       }
     } else {
       // Dry run: still count what WOULD change.


### PR DESCRIPTION
## Summary
- connect the v0.29.1 migration's Phase B/Phase C engines before calling `executeRaw`
- remove raw `BEGIN`/`COMMIT`/`ROLLBACK` from the effective-date backfill loop
- rely on the existing idempotent, checkpointed row updates instead of a batch-level transaction

## Why
On a Postgres install, `gbrain apply-migrations --yes` can remain permanently `PARTIAL` for v0.29.1:

1. `createEngine(...)` returns an unconnected engine, so Phase B/Phase C can fail with `No database connection: connect() has not been called`.
2. After connecting manually, the backfill's raw `BEGIN` on the postgres.js pooled connection can fail with `UNSAFE_TRANSACTION: Only use sql.begin, sql.reserved or max: 1`.

The backfill is already safe to run as independent updates: it is deterministic, idempotent, skips equal rows, and checkpoints by `backfill.effective_date.last_id` after each batch.

## Verification
Run locally against a Postgres-backed gbrain install that was stuck on v0.29.1 partial:

```bash
bun run typecheck
gbrain apply-migrations --yes
gbrain doctor --json
```

Results:
- `bun run typecheck` passed
- `gbrain apply-migrations --yes` changed v0.29.1 from `PARTIAL` to `complete`
- `gbrain doctor --json` no longer reports `minions_migration` failure
- remaining doctor warning is unrelated `sync_failures` FK noise from stale source IDs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->