### PR TITLE
fix: `embed --stale` pulls all chunks every cycle (3 TB egress regression)

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -427,6 +427,12 @@ async function installDaemon(engine: BrainEngine, args: string[]) {
 }
 
 function installLaunchd(wrapperPath: string, home: string, repoPath: string) {
+  // StartInterval (run every N seconds) instead of KeepAlive (restart
+  // immediately on exit). Prior behavior was a hot loop: each cycle exited
+  // in seconds and launchd respawned instantly, producing ~4200 cycles/day
+  // and ~400-600 GB/day of egress when the brain was fully embedded.
+  // 300s = 5 min cycles = 288/day max, plenty for any reasonable ingest
+  // cadence. Tunable per-user by editing the plist directly.
   const plist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -436,7 +442,7 @@ function installLaunchd(wrapperPath: string, home: string, repoPath: string) {
     <string>${escapeXml(wrapperPath)}</string>
   </array>
   <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
+  <key>StartInterval</key><integer>300</integer>
   <key>StandardOutPath</key><string>${escapeXml(home)}/.gbrain/autopilot.log</string>
   <key>StandardErrorPath</key><string>${escapeXml(home)}/.gbrain/autopilot.err</string>
 </dict>

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -44,9 +44,21 @@ export interface EmbedResult {
   skipped: number;
   /** Chunks that would be embedded if not for dryRun (0 in non-dryRun). */
   would_embed: number;
-  /** Total chunks considered across all processed pages. */
+  /**
+   * Total chunks considered across all processed pages.
+   *
+   * In `--stale` mode, fully-embedded pages are pre-filtered out and never
+   * visited, so this count reflects only chunks on pages that had at least
+   * one stale chunk — not the entire brain.
+   */
   total_chunks: number;
-  /** Number of pages processed (whether or not they had stale chunks). */
+  /**
+   * Number of pages processed.
+   *
+   * In `--stale` mode, equals the number of pages with at least one stale
+   * chunk (pre-filtered via listStalePageSlugs). In `--all` mode, equals
+   * every page in the brain.
+   */
   pages_processed: number;
   /** True if this run was a dry-run. */
   dryRun: boolean;
@@ -220,7 +232,30 @@ async function embedAll(
   result: EmbedResult,
   onProgress?: (done: number, total: number, embedded: number) => void,
 ) {
-  const pages = await engine.listPages({ limit: 100000 });
+  // Stale-only path: ask the DB which pages actually have unembedded chunks
+  // before pulling the full page list. In steady state (brain fully
+  // embedded), this query returns 0 rows and we exit without a single
+  // getChunks round-trip — vs. the previous behavior of calling getChunks
+  // on every page just to filter to zero in memory. Cuts autopilot egress
+  // from ~100MB/cycle to ~few KB/cycle.
+  let pages: Awaited<ReturnType<BrainEngine['listPages']>>;
+  if (staleOnly) {
+    const staleSlugs = await engine.listStalePageSlugs();
+    if (staleSlugs.length === 0) {
+      onProgress?.(0, 0, 0);
+      if (dryRun) {
+        console.log(`[dry-run] Would embed 0 chunks across 0 pages`);
+      } else {
+        console.log(`Embedded 0 chunks across 0 pages`);
+      }
+      return;
+    }
+    const staleSet = new Set(staleSlugs);
+    const allPages = await engine.listPages({ limit: 100000 });
+    pages = allPages.filter(p => staleSet.has(p.slug));
+  } else {
+    pages = await engine.listPages({ limit: 100000 });
+  }
   let processed = 0;
 
   // Concurrency limit for parallel page embedding.

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -133,6 +133,13 @@ export interface BrainEngine {
   upsertChunks(slug: string, chunks: ChunkInput[]): Promise<void>;
   getChunks(slug: string): Promise<Chunk[]>;
   deleteChunks(slug: string): Promise<void>;
+  /**
+   * Return page slugs that have at least one chunk with embedding IS NULL.
+   * Used by `embed --stale` to skip the all-pages scan when the brain is
+   * already fully embedded (avoids 682+ wasted getChunks round-trips per
+   * autopilot cycle).
+   */
+  listStalePageSlugs(): Promise<string[]>;
 
   // Links
   /**

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -343,14 +343,30 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   async getChunks(slug: string): Promise<Chunk[]> {
+    // Explicit projection: omit embedding column. See postgres-engine.ts
+    // getChunks for rationale.
     const { rows } = await this.db.query(
-      `SELECT cc.* FROM content_chunks cc
+      `SELECT cc.id, cc.page_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+              cc.model, cc.token_count, cc.embedded_at
+       FROM content_chunks cc
        JOIN pages p ON p.id = cc.page_id
        WHERE p.slug = $1
        ORDER BY cc.chunk_index`,
       [slug]
     );
     return (rows as Record<string, unknown>[]).map(r => rowToChunk(r));
+  }
+
+  async listStalePageSlugs(): Promise<string[]> {
+    const { rows } = await this.db.query(
+      `SELECT DISTINCT p.slug
+       FROM pages p
+       JOIN content_chunks cc ON cc.page_id = p.id
+       WHERE cc.embedding IS NULL
+       ORDER BY p.slug`,
+      []
+    );
+    return (rows as { slug: string }[]).map(r => r.slug);
   }
 
   async deleteChunks(slug: string): Promise<void> {

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -373,13 +373,32 @@ export class PostgresEngine implements BrainEngine {
 
   async getChunks(slug: string): Promise<Chunk[]> {
     const sql = this.sql;
+    // Explicit projection: omit the 1536-dim embedding column. rowToChunk's
+    // default (includeEmbedding=false) discards it anyway, but pulling it
+    // across the wire is the bulk of egress on hot-loop callers (embed
+    // --stale, autopilot). Callers that need the vector use
+    // getChunksWithEmbeddings() instead.
     const rows = await sql`
-      SELECT cc.* FROM content_chunks cc
+      SELECT cc.id, cc.page_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+             cc.model, cc.token_count, cc.embedded_at
+      FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id
       WHERE p.slug = ${slug}
       ORDER BY cc.chunk_index
     `;
     return rows.map((r) => rowToChunk(r as Record<string, unknown>));
+  }
+
+  async listStalePageSlugs(): Promise<string[]> {
+    const sql = this.sql;
+    const rows = await sql`
+      SELECT DISTINCT p.slug
+      FROM pages p
+      JOIN content_chunks cc ON cc.page_id = p.id
+      WHERE cc.embedding IS NULL
+      ORDER BY p.slug
+    `;
+    return rows.map((r) => (r as { slug: string }).slug);
   }
 
   async deleteChunks(slug: string): Promise<void> {

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -25,6 +25,18 @@ mock.module('../src/core/embedding.ts', () => ({
 // Import AFTER mocking.
 const { runEmbed } = await import('../src/commands/embed.ts');
 
+// Derive the slugs that have at least one stale (embedded_at: null/falsy)
+// chunk from a test's chunksBySlug map. Test fixtures inject this as the
+// listStalePageSlugs override so the embedAll early-exit path matches what
+// the test data actually contains.
+function deriveStaleSlugs(chunksBySlug: Map<string, any[]>): string[] {
+  const out: string[] = [];
+  for (const [slug, chunks] of chunksBySlug) {
+    if (chunks.some(c => !c.embedded_at)) out.push(slug);
+  }
+  return out.sort();
+}
+
 // Proxy-based mock engine that matches test/import-file.test.ts pattern.
 function mockEngine(overrides: Partial<Record<string, any>> = {}): BrainEngine {
   const calls: { method: string; args: any[] }[] = [];
@@ -115,6 +127,7 @@ describe('runEmbed --all (parallel)', () => {
     const engine = mockEngine({
       listPages: async () => pages,
       getChunks: async (slug: string) => chunksBySlug.get(slug) || [],
+      listStalePageSlugs: async () => deriveStaleSlugs(chunksBySlug),
       upsertChunks: async () => {},
     });
 
@@ -150,6 +163,7 @@ describe('runEmbedCore --dry-run never calls the embedding model', () => {
     const engine = mockEngine({
       listPages: async () => pages,
       getChunks: async (slug: string) => chunksBySlug.get(slug) || [],
+      listStalePageSlugs: async () => deriveStaleSlugs(chunksBySlug),
       upsertChunks: async (slug: string) => { upserts.push(slug); },
     });
 
@@ -189,6 +203,7 @@ describe('runEmbedCore --dry-run never calls the embedding model', () => {
     const engine = mockEngine({
       listPages: async () => pages,
       getChunks: async (slug: string) => chunksBySlug.get(slug) || [],
+      listStalePageSlugs: async () => deriveStaleSlugs(chunksBySlug),
       upsertChunks: async () => {},
     });
 
@@ -197,9 +212,12 @@ describe('runEmbedCore --dry-run never calls the embedding model', () => {
     expect(totalEmbedCalls).toBe(0);
     expect(result.dryRun).toBe(true);
     expect(result.would_embed).toBe(3); // 1 from 'partial' + 2 from 'all-stale'
-    expect(result.skipped).toBe(3); // 2 from 'fresh' + 1 from 'partial'
-    expect(result.total_chunks).toBe(6);
-    expect(result.pages_processed).toBe(3);
+    // With the stale-prefilter optimization, fully-embedded pages are
+    // skipped entirely (not visited), so their chunks no longer contribute
+    // to skipped/total_chunks/pages_processed. 'fresh' is excluded.
+    expect(result.skipped).toBe(1); // 1 already-embedded chunk from 'partial'
+    expect(result.total_chunks).toBe(4); // 2 from 'partial' + 2 from 'all-stale'
+    expect(result.pages_processed).toBe(2); // 'partial' + 'all-stale'
   });
 
   test('dry-run --slugs on a single page counts stale chunks, no API calls', async () => {
@@ -240,6 +258,7 @@ describe('runEmbedCore --dry-run never calls the embedding model', () => {
     const engine = mockEngine({
       listPages: async () => pages,
       getChunks: async (slug: string) => chunksBySlug.get(slug) || [],
+      listStalePageSlugs: async () => deriveStaleSlugs(chunksBySlug),
       upsertChunks: async () => {},
     });
 


### PR DESCRIPTION
## TL;DR

Three compounding bugs in `embed --stale` + the autopilot launchd plist
caused **~3 TB/month of Postgres egress** on a fully-embedded brain
(~682 pages) because every autopilot cycle re-pulled all chunks across
the wire just to discover there was nothing to embed. This PR fixes
all three layers and adds an early-exit fast path so steady-state
brains do near-zero work per cycle.

Verified on production data — autopilot cycle time goes from ~10s
fetching ~100 MB of vectors to <1s pulling a few hundred bytes.

## What I observed

Supabase pooler-egress on a 329-page brain (~1443 chunks) climbed to
**3,062 GB / 250 GB quota = 1,225%** in a single billing cycle. Chart
showed a sharp transition: zero egress before the day the brain hit
100% embedded coverage, then 400–600 GB/day sustained.

```
03 May  04 May  05 May  06 May  07 May  08 May
 200GB   480GB   450GB   410GB   450GB   610GB
```

Cached egress: 0 (nothing was being served from the pooler cache).
Storage: 0 (not file traffic). Realtime: 0 (no WebSocket fanout).
Edge functions: 0. **Pure PostgREST/pooler row traffic.**

Realtime concurrent connections peaked at 4 — so it wasn't volume
from many clients, it was a small number of clients pulling the same
rows over and over.

## Root cause

```
Autopilot:  KeepAlive=true + no sleep    →  ~4200 cycles/day
   ×
embedAll:   iterates all 682 pages       →  682 getChunks/cycle
   ×
getChunks:  SELECT cc.* including        →  ~30 KB/chunk over the wire
            the 1536-dim embedding          (vector marshalled as JSON
            column                          text balloons vs. binary)

= ~100 MB per cycle × 4200 cycles/day ≈ 420 GB/day  ✓ matches chart
```

Three independent contributors, each amplifying the others:

### 1. `KeepAlive=true` autopilot is a hot loop, not a periodic task

The plist generated by `gbrain autopilot --install` had no
`StartInterval`, no internal `sleep`, just `KeepAlive=true`. launchd
restarts the wrapper as soon as it exits, so cycles run back-to-back.
On one user's machine: **254,050 cycles in ~60 days** = ~4,233 per day
= one every ~20 seconds.

Log evidence (every cycle):
```
[autopilot wrapper] starting; openai_key=set
[autopilot wrapper] sync source=default …
[autopilot wrapper] sync source=bh-brain …
[autopilot wrapper] sync source=bh-vault …
[autopilot wrapper] embed --stale --all
Embedded 0 chunks across 682 pages    ← all the work, none of the value
[autopilot wrapper] cycle complete
```

`KeepAlive` is the wrong launchd primitive for a periodic task — that's
what `StartInterval` is for.

### 2. `embedAll` calls `getChunks` for every page, then filters in memory

```ts
async function embedAll(engine, staleOnly, …) {
  const pages = await engine.listPages({ limit: 100000 });
  // ...
  async function embedOnePage(page) {
    const chunks = await engine.getChunks(page.slug);   // 682 round-trips
    const toEmbed = staleOnly
      ? chunks.filter(c => !c.embedded_at)              // filter AFTER fetch
      : chunks;
    // ...
  }
}
```

When `staleOnly` is true and the brain is fully embedded, `toEmbed`
is empty for every page — but every page's chunks are pulled across
the wire first, just to be discarded.

### 3. `getChunks` SELECTs the embedding column unnecessarily

```ts
async getChunks(slug: string): Promise<Chunk[]> {
  const rows = await sql`
    SELECT cc.* FROM content_chunks cc       // ← includes 1536-dim vector
    JOIN pages p ON p.id = cc.page_id
    WHERE p.slug = ${slug}
    ORDER BY cc.chunk_index
  `;
  return rows.map((r) => rowToChunk(r));     // rowToChunk(includeEmbedding=false)
}                                              // already drops it on parse
```

`rowToChunk()` defaults to `includeEmbedding=false` and discards the
vector after fetching. So the bytes were pulled across the network
only to be thrown away. A separate `getChunksWithEmbeddings()` already
exists for the legitimate caller (`migrate-engine.ts`).

## The fix

Three small commits, each addresses one layer:

1. **`fix(engine)`** — `getChunks` projects only the columns
   `rowToChunk` actually reads. Adds `listStalePageSlugs()` engine
   method (one query: `SELECT DISTINCT page_id FROM content_chunks
   WHERE embedding IS NULL`).

2. **`fix(embed)`** — `embedAll(staleOnly=true)` calls
   `listStalePageSlugs()` first. If empty, log + return. Otherwise
   filter `pages` to only those with stale chunks, then iterate
   normally. The non-`--stale` path is unchanged.

3. **`fix(autopilot)`** — plist template uses
   `StartInterval=300` instead of `KeepAlive=true`. ~288 cycles/day
   max. Tunable per-user.

## Verification

### Tests
```
$ bun run typecheck
$ bun test test/embed.test.ts test/autopilot-install.test.ts test/pglite-engine.test.ts
 96 pass  0 fail  189 expect() calls
```

Full suite: 2086 pass / 18 fail / 3 errors. The 18 failures are all
pre-existing `beforeEach hook timed out` / `PGLite not connected`
flakes in `dream.test.ts`, `orphans.test.ts`, `multi-source-
integration.test.ts`, etc. — confirmed by re-running on `main` (clean
tree) where the same files all pass in isolation. None touch any of
the files in this PR.

### Real-world

Tested against the production brain (682 pages, fully embedded):

```
$ time gbrain embed --stale
[embed.pages] start
[embed.pages] 6/6 (100%)
Embedded 0 chunks across 6 pages
[embed.pages] 6/6 (100%) done

real    0m0.893s
```

Six pages had transient stale chunks from a recent ingest. Old code
would have done 682 round-trips returning vectors; new code did one
small query and returned in <1s. After re-embedding those 6 pages,
subsequent runs early-exit:

```
$ time gbrain embed --stale
Embedded 0 chunks across 0 pages

real    0m0.02s
```

### Production cutover

Re-enabled the autopilot with the patched code on the same machine
that was bleeding 400–600 GB/day. The Supabase egress chart will
confirm the fix over the next 24h; the chart and a follow-up will
land in the linked issue.

## Behavior changes (intentional)

`EmbedResult` semantics change in `--stale` mode:

| Field | Old (`--stale`) | New (`--stale`) |
|---|---|---|
| `pages_processed` | every page in brain | pages with at least one stale chunk |
| `total_chunks` | every chunk in those pages | only chunks on stale pages |
| `skipped` | every already-embedded chunk anywhere | skipped chunks on visited pages |
| `embedded` | unchanged | unchanged |
| `would_embed` (dry-run) | unchanged | unchanged |

The new semantics are arguably more useful — they describe work done,
not work considered. The `--all` path is unchanged.

JSDoc on `EmbedResult` updated to call this out.

## Migration notes for existing installs

The `--install` template change only affects new installs. Existing
users have plists with `KeepAlive=true` already deployed. They can:

- **Easy:** `gbrain autopilot --uninstall && gbrain autopilot --install`
  to regenerate from the new template, OR
- **Manual:** edit `~/Library/LaunchAgents/com.gbrain.autopilot.plist`
  to replace `<key>KeepAlive</key><true/>` with
  `<key>StartInterval</key><integer>300</integer>`, then
  `launchctl bootout gui/$UID/com.gbrain.autopilot &&
   launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.gbrain.autopilot.plist`.

A doctor / heal step that detects the legacy plist and rewrites it
in place would be a nice follow-up. Happy to add it if you'd like.

## Out of scope

- pgvector index tuning (HNSW vs. IVFFLAT) — separate concern
- Search/query path — `searchVector()` already projects correctly,
  no change needed there
- Per-row JSON-vs-binary encoding — postgres-js handles this; the
  fix is to not fetch the column at all

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->