### PR TITLE
docs: clarify takes holder semantics (holder ≠ subject)

### DIFF
--- a/src/core/takes-fence.ts
+++ b/src/core/takes-fence.ts
@@ -44,7 +44,24 @@ export interface ParsedTake {
   rowNum: number;
   claim: string;        // strikethrough markers stripped; inner text only
   kind: TakeKind;
-  holder: string;       // 'world' | 'garry' | 'brain' | <slug>
+  /**
+   * Who HOLDS this belief — the person asserting/endorsing it.
+   * NOT the person the belief is ABOUT (that's the subject, implicit in the claim).
+   *
+   * Common confusion (flagged by cross-modal eval 2026-05-10):
+   *   WRONG: holder=people/garry-tan claim="Garry has a hero/rescuer pattern"
+   *          (brain's analysis OF Garry, not Garry's own belief)
+   *   RIGHT: holder=brain claim="Garry has a hero/rescuer pattern"
+   *
+   *   WRONG: holder=people/diana-hu claim="Diana's repeated 2.5-3.0 scores imply cautious reads"
+   *          (brain's inference from Diana's behavior, not Diana's stated belief)
+   *   RIGHT: holder=brain claim="Diana's repeated 2.5-3.0 scores imply cautious reads"
+   *
+   * Values: 'world' (consensus fact) | 'people/<slug>' (individual's stated belief) |
+   *         'companies/<slug>' (institutional fact, no individual claimant) |
+   *         'brain' (AI-inferred when holder is genuinely ambiguous)
+   */
+  holder: string;
   weight: number;       // 0..1 (raw — may be out of range; engine clamps)
   sinceDate?: string;   // ISO 'YYYY-MM-DD' or 'YYYY-MM' (caller's choice)
   untilDate?: string;

--- a/test/takes-holder-semantics.test.ts
+++ b/test/takes-holder-semantics.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Validate takes holder semantics: holder = who HOLDS the belief, not who it's ABOUT.
+ *
+ * Cross-modal eval (2026-05-10) found that extraction prompts confuse holder
+ * (the person asserting a belief) with subject (the person the belief is about).
+ * These tests codify the correct semantics so future prompt iterations don't regress.
+ */
+import { describe, it, expect } from 'bun:test';
+import { parseTakesFence } from '../src/core/takes-fence.ts';
+
+describe('takes holder semantics', () => {
+  it('person stating their own belief → holder is that person', () => {
+    const fence = `<!--- gbrain:takes:begin -->
+| # | claim | kind | who | weight | since | source |
+|---|-------|------|-----|--------|-------|--------|
+| 1 | AI will replace 50% of coding by 2030 | bet | people/garry-tan | 0.75 | 2026-01 | Lightcone |
+<!--- gbrain:takes:end -->`;
+    const result = parseTakesFence(fence);
+    expect(result.takes[0].holder).toBe('people/garry-tan');
+  });
+
+  it('analysis ABOUT a person by brain → holder is brain, not the subject', () => {
+    const fence = `<!--- gbrain:takes:begin -->
+| # | claim | kind | who | weight | since | source |
+|---|-------|------|-----|--------|-------|--------|
+| 1 | Garry has a hero/rescuer pattern from childhood parentification | hunch | brain | 0.75 | 2026-04 | therapy analysis |
+<!--- gbrain:takes:end -->`;
+    const result = parseTakesFence(fence);
+    // Holder is brain (the analyst), NOT people/garry-tan (the subject)
+    expect(result.takes[0].holder).toBe('brain');
+    expect(result.takes[0].kind).toBe('hunch');
+  });
+
+  it('consensus fact → holder is world', () => {
+    const fence = `<!--- gbrain:takes:begin -->
+| # | claim | kind | who | weight | since | source |
+|---|-------|------|-----|--------|-------|--------|
+| 1 | Clipboard Health raised a $100M Series C | fact | world | 1.00 | 2026-03 | TechCrunch |
+<!--- gbrain:takes:end -->`;
+    const result = parseTakesFence(fence);
+    expect(result.takes[0].holder).toBe('world');
+    expect(result.takes[0].weight).toBe(1.0);
+  });
+
+  it('founder describing own company → holder is founder, not company', () => {
+    const fence = `<!--- gbrain:takes:begin -->
+| # | claim | kind | who | weight | since | source |
+|---|-------|------|-----|--------|-------|--------|
+| 1 | We can hit $10M ARR by Q3 | bet | people/bo-lu | 0.70 | 2026-04 | OH meeting |
+<!--- gbrain:takes:end -->`;
+    const result = parseTakesFence(fence);
+    // Bo Lu HOLDS this prediction; it's not a company fact
+    expect(result.takes[0].holder).toBe('people/bo-lu');
+    expect(result.takes[0].kind).toBe('bet');
+  });
+
+  it('institutional fact with no individual claimant → holder is companies/', () => {
+    const fence = `<!--- gbrain:takes:begin -->
+| # | claim | kind | who | weight | since | source |
+|---|-------|------|-----|--------|-------|--------|
+| 1 | Founded in 2019, incorporated in Delaware | fact | companies/clipboard-health | 1.00 | 2019-01 | SEC filing |
+<!--- gbrain:takes:end -->`;
+    const result = parseTakesFence(fence);
+    expect(result.takes[0].holder).toBe('companies/clipboard-health');
+  });
+
+  it('parser preserves weight values as-is (precision is prompt-side)', () => {
+    const fence = `<!--- gbrain:takes:begin -->
+| # | claim | kind | who | weight | since | source |
+|---|-------|------|-----|--------|-------|--------|
+| 1 | Strong technical founder | take | people/garry-tan | 0.85 | 2026-04 | OH |
+| 2 | Market timing is risky | hunch | people/garry-tan | 0.74 | 2026-04 | OH |
+<!--- gbrain:takes:end -->`;
+    const result = parseTakesFence(fence);
+    // Parser stores raw values; 0.05 rounding is a prompt/extraction concern
+    expect(result.takes[0].weight).toBeCloseTo(0.85, 2);
+    expect(result.takes[1].weight).toBeCloseTo(0.74, 2);
+  });
+});


### PR DESCRIPTION
## What

Cross-modal eval (2026-05-10, GPT-5.5 + Opus 4.6 + DeepSeek V4-Pro) on a 100K-take extraction run found that **holder/subject confusion** was the #1 attribution issue (6.5/10 avg on attribution dimension).

The confusion: extraction prompts assign `holder=people/garry-tan` to claims like "Garry has a hero/rescuer pattern" — but that's brain's analysis OF Garry, not Garry's own belief.

## Changes

- Expanded `ParsedTake.holder` JSDoc with concrete right/wrong examples from the eval
- 6 holder-semantics tests codifying the correct contract
- No runtime changes — documentation + tests for extraction prompt authors

## Eval Context

| Dimension | GPT-5.5 | Opus 4.6 | Avg |
|-----------|---------|----------|-----|
| Accuracy | 7 | 8 | 7.5 |
| Attribution | 6 | 7 | **6.5** |
| Weight calibration | 7 | 7 | 7.0 |
| Kind classification | 6 | 7 | 6.5 |
| Signal density | 7 | 6 | 6.5 |

Top improvements flagged:
1. Holder vs subject confusion (this PR)
2. Compound claims should be split into atomic takes
3. Amplification ≠ endorsement (retweet ≠ 0.85)
4. Round weights to 0.05 increments
5. Trivial extractions (Twitter handles) fail "so what" test

## Testing

```
bun test test/takes-holder-semantics.test.ts
# 6 pass, 0 fail
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->