### PR TITLE
Fix v0.29.1 migration bootstrap safety

### DIFF
--- a/src/commands/migrations/v0_29_1.ts
+++ b/src/commands/migrations/v0_29_1.ts
@@ -48,26 +48,31 @@ async function phaseBBackfill(opts: OrchestratorOpts): Promise<OrchestratorPhase
     const { backfillEffectiveDate } = await import('../../core/backfill-effective-date.ts');
     const cfg = loadConfig();
     if (!cfg) throw new Error('No gbrain config; run `gbrain init` first.');
-    const engine = await createEngine(toEngineConfig(cfg));
+    const engineConfig = toEngineConfig(cfg);
+    const engine = await createEngine(engineConfig);
+    await engine.connect(engineConfig);
+    try {
+      let totalExamined = 0;
+      let totalUpdated = 0;
 
-    let totalExamined = 0;
-    let totalUpdated = 0;
+      const result = await backfillEffectiveDate(engine, {
+        onBatch: ({ batch, lastId, rowsTouched, cumulative }) => {
+          totalExamined = cumulative;
+          totalUpdated += rowsTouched;
+          if (batch % 10 === 0) {
+            process.stderr.write(`  [backfill] batch ${batch} | last_id=${lastId} | examined=${cumulative} | updated_so_far=${totalUpdated}\n`);
+          }
+        },
+      });
 
-    const result = await backfillEffectiveDate(engine, {
-      onBatch: ({ batch, lastId, rowsTouched, cumulative }) => {
-        totalExamined = cumulative;
-        totalUpdated += rowsTouched;
-        if (batch % 10 === 0) {
-          process.stderr.write(`  [backfill] batch ${batch} | last_id=${lastId} | examined=${cumulative} | updated_so_far=${totalUpdated}\n`);
-        }
-      },
-    });
-
-    return {
-      name: 'backfill_effective_date',
-      status: 'complete',
-      detail: `examined=${result.examined} updated=${result.updated} fallback=${result.fallback} dur=${result.durationSec.toFixed(1)}s`,
-    };
+      return {
+        name: 'backfill_effective_date',
+        status: 'complete',
+        detail: `examined=${result.examined} updated=${result.updated} fallback=${result.fallback} dur=${result.durationSec.toFixed(1)}s`,
+      };
+    } finally {
+      try { await engine.disconnect(); } catch { /* best-effort */ }
+    }
   } catch (e) {
     return { name: 'backfill_effective_date', status: 'failed', detail: e instanceof Error ? e.message : String(e) };
   }
@@ -82,23 +87,29 @@ async function phaseCVerify(opts: OrchestratorOpts): Promise<OrchestratorPhaseRe
     const { loadConfig, toEngineConfig } = await import('../../core/config.ts');
     const cfg = loadConfig();
     if (!cfg) throw new Error('No gbrain config; run `gbrain init` first.');
-    const engine = await createEngine(toEngineConfig(cfg));
-    // Count rows where effective_date is still NULL but frontmatter HAS a
-    // parseable date — those are the rows the backfill should have touched
-    // but didn't. (Rows that fall through to 'fallback' have non-null
-    // effective_date already; this catches genuine misses.)
-    const rows = await engine.executeRaw<{ count: string }>(
-      `SELECT COUNT(*)::text AS count FROM pages WHERE effective_date IS NULL`,
-    );
-    const remaining = Number(rows[0]?.count ?? 0);
-    if (remaining > 0) {
-      return {
-        name: 'verify',
-        status: 'failed',
-        detail: `${remaining} pages still have NULL effective_date (backfill incomplete)`,
-      };
+    const engineConfig = toEngineConfig(cfg);
+    const engine = await createEngine(engineConfig);
+    await engine.connect(engineConfig);
+    try {
+      // Count rows where effective_date is still NULL but frontmatter HAS a
+      // parseable date — those are the rows the backfill should have touched
+      // but didn't. (Rows that fall through to 'fallback' have non-null
+      // effective_date already; this catches genuine misses.)
+      const rows = await engine.executeRaw<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM pages WHERE effective_date IS NULL`,
+      );
+      const remaining = Number(rows[0]?.count ?? 0);
+      if (remaining > 0) {
+        return {
+          name: 'verify',
+          status: 'failed',
+          detail: `${remaining} pages still have NULL effective_date (backfill incomplete)`,
+        };
+      }
+      return { name: 'verify', status: 'complete', detail: '0 pages with NULL effective_date' };
+    } finally {
+      try { await engine.disconnect(); } catch { /* best-effort */ }
     }
-    return { name: 'verify', status: 'complete', detail: '0 pages with NULL effective_date' };
   } catch (e) {
     return { name: 'verify', status: 'failed', detail: e instanceof Error ? e.message : String(e) };
   }

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -235,6 +235,8 @@ export class PGLiteEngine implements BrainEngine {
    *     + `symbol_name_qualified` columns (indexed by `idx_chunks_search_vector`
    *     and `idx_chunks_symbol_qualified`) — v0.20 Cathedral II
    *   - `pages.deleted_at` column (indexed by `pages_deleted_at_purge_idx`) — v0.26.5
+   *   - `pages.effective_date` + sibling recency/salience columns (indexed by
+   *     `pages_coalesce_date_idx`) — v0.29.1
    *   - `mcp_request_log.agent_name` + `params` + `error_message` columns
    *     (indexed by `idx_mcp_log_agent_time`) — v0.26.3
    *   - `subagent_messages.provider_id` column (indexed by
@@ -255,6 +257,14 @@ export class PGLiteEngine implements BrainEngine {
                 WHERE table_schema='public' AND table_name='pages' AND column_name='source_id') AS source_id_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema='public' AND table_name='pages' AND column_name='deleted_at') AS deleted_at_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='pages' AND column_name='effective_date') AS effective_date_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='pages' AND column_name='effective_date_source') AS effective_date_source_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='pages' AND column_name='import_filename') AS import_filename_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='pages' AND column_name='salience_touched_at') AS salience_touched_at_exists,
         EXISTS (SELECT 1 FROM information_schema.tables
                 WHERE table_schema='public' AND table_name='links') AS links_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
@@ -284,6 +294,10 @@ export class PGLiteEngine implements BrainEngine {
       pages_exists: boolean;
       source_id_exists: boolean;
       deleted_at_exists: boolean;
+      effective_date_exists: boolean;
+      effective_date_source_exists: boolean;
+      import_filename_exists: boolean;
+      salience_touched_at_exists: boolean;
       links_exists: boolean;
       link_source_exists: boolean;
       origin_page_id_exists: boolean;
@@ -304,6 +318,11 @@ export class PGLiteEngine implements BrainEngine {
     const needsChunksBootstrap = probe.chunks_exists
       && (!probe.symbol_name_exists || !probe.language_exists || !probe.search_vector_exists);
     const needsPagesDeletedAt = probe.pages_exists && !probe.deleted_at_exists;
+    const needsPagesEffectiveDate = probe.pages_exists
+      && (!probe.effective_date_exists
+        || !probe.effective_date_source_exists
+        || !probe.import_filename_exists
+        || !probe.salience_touched_at_exists);
     // v0.27.1 — partial HNSW idx_chunks_embedding_image references this column.
     const needsChunksEmbeddingImage = probe.chunks_exists && !probe.embedding_image_exists;
     // v0.26.3 (v33): idx_mcp_log_agent_time in PGLITE_SCHEMA_SQL needs agent_name col.
@@ -314,7 +333,7 @@ export class PGLiteEngine implements BrainEngine {
 
     // Fresh installs (no tables yet) and modern brains both no-op.
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
-        && !needsPagesDeletedAt && !needsChunksEmbeddingImage
+        && !needsPagesDeletedAt && !needsPagesEffectiveDate && !needsChunksEmbeddingImage
         && !needsMcpLogBootstrap && !needsSubagentProviderId) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
@@ -376,6 +395,20 @@ export class PGLiteEngine implements BrainEngine {
       // not to crash. v34 runs later via runMigrations and is idempotent.
       await this.db.exec(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsPagesEffectiveDate) {
+      // v38 (salience_recency_v0_29_1) adds these nullable recency/salience
+      // columns and PGLITE_SCHEMA_SQL immediately creates
+      // `pages_coalesce_date_idx` over COALESCE(effective_date, updated_at).
+      // Bootstrap only adds enough state for that schema blob not to crash;
+      // v38 still runs later via runMigrations and remains idempotent.
+      await this.db.exec(`
+        ALTER TABLE pages ADD COLUMN IF NOT EXISTS effective_date        TIMESTAMPTZ;
+        ALTER TABLE pages ADD COLUMN IF NOT EXISTS effective_date_source TEXT;
+        ALTER TABLE pages ADD COLUMN IF NOT EXISTS import_filename       TEXT;
+        ALTER TABLE pages ADD COLUMN IF NOT EXISTS salience_touched_at   TIMESTAMPTZ;
       `);
     }
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -282,6 +282,8 @@ export class PostgresEngine implements BrainEngine {
    *     + `symbol_name_qualified` columns (indexed by `idx_chunks_search_vector`
    *     and `idx_chunks_symbol_qualified`) — v0.20 Cathedral II
    *   - `pages.deleted_at` column (indexed by `pages_deleted_at_purge_idx`) — v0.26.5
+   *   - `pages.effective_date` + sibling recency/salience columns (indexed by
+   *     `pages_coalesce_date_idx`) — v0.29.1
    *   - `mcp_request_log.agent_name` + `params` + `error_message` columns
    *     (indexed by `idx_mcp_log_agent_time`) — v0.26.3
    *   - `subagent_messages.provider_id` column (indexed by
@@ -301,6 +303,10 @@ export class PostgresEngine implements BrainEngine {
       pages_exists: boolean;
       source_id_exists: boolean;
       deleted_at_exists: boolean;
+      effective_date_exists: boolean;
+      effective_date_source_exists: boolean;
+      import_filename_exists: boolean;
+      salience_touched_at_exists: boolean;
       links_exists: boolean;
       link_source_exists: boolean;
       origin_page_id_exists: boolean;
@@ -320,6 +326,14 @@ export class PostgresEngine implements BrainEngine {
                 WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'source_id') AS source_id_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'deleted_at') AS deleted_at_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'effective_date') AS effective_date_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'effective_date_source') AS effective_date_source_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'import_filename') AS import_filename_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'salience_touched_at') AS salience_touched_at_exists,
         EXISTS (SELECT 1 FROM information_schema.tables
                 WHERE table_schema = current_schema() AND table_name = 'links') AS links_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
@@ -353,13 +367,20 @@ export class PostgresEngine implements BrainEngine {
     // v0.26.5: pages_deleted_at_purge_idx in SCHEMA_SQL crashes if the column
     // doesn't exist yet. Migration v34 also adds it, but bootstrap runs first.
     const needsPagesDeletedAt = probe.pages_exists && !probe.deleted_at_exists;
+    const needsPagesEffectiveDate = probe.pages_exists
+      && (!probe.effective_date_exists
+        || !probe.effective_date_source_exists
+        || !probe.import_filename_exists
+        || !probe.salience_touched_at_exists);
     // v0.26.3 (v33): idx_mcp_log_agent_time in SCHEMA_SQL needs agent_name col.
     const needsMcpLogBootstrap = probe.mcp_log_exists && !probe.agent_name_exists;
     // v0.27 (v36): idx_subagent_messages_provider in SCHEMA_SQL needs provider_id
     // (the SECOND column in the composite index `(job_id, provider_id)`).
     const needsSubagentProviderId = probe.subagent_messages_exists && !probe.subagent_provider_id_exists;
 
-    if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap && !needsPagesDeletedAt && !needsMcpLogBootstrap && !needsSubagentProviderId) return;
+    if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
+        && !needsPagesDeletedAt && !needsPagesEffectiveDate
+        && !needsMcpLogBootstrap && !needsSubagentProviderId) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
 
@@ -420,6 +441,20 @@ export class PostgresEngine implements BrainEngine {
       // not to crash. v34 runs later via runMigrations and is idempotent.
       await conn.unsafe(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsPagesEffectiveDate) {
+      // v38 (salience_recency_v0_29_1) adds these nullable recency/salience
+      // columns and SCHEMA_SQL immediately creates `pages_coalesce_date_idx`
+      // over COALESCE(effective_date, updated_at). Bootstrap only adds enough
+      // state for that schema blob not to crash; v38 still runs later via
+      // runMigrations and remains idempotent.
+      await conn.unsafe(`
+        ALTER TABLE pages ADD COLUMN IF NOT EXISTS effective_date        TIMESTAMPTZ;
+        ALTER TABLE pages ADD COLUMN IF NOT EXISTS effective_date_source TEXT;
+        ALTER TABLE pages ADD COLUMN IF NOT EXISTS import_filename       TEXT;
+        ALTER TABLE pages ADD COLUMN IF NOT EXISTS salience_touched_at   TIMESTAMPTZ;
       `);
     }
 

--- a/test/schema-bootstrap-coverage.test.ts
+++ b/test/schema-bootstrap-coverage.test.ts
@@ -73,6 +73,13 @@ const REQUIRED_BOOTSTRAP_COVERAGE: ForwardReference[] = [
   // v0.26.5 — forward-referenced by `CREATE INDEX pages_deleted_at_purge_idx
   // ON pages (deleted_at) WHERE deleted_at IS NOT NULL`.
   { kind: 'column', table: 'pages', column: 'deleted_at' },
+  // v0.29.1 — forward-referenced by `CREATE INDEX pages_coalesce_date_idx
+  // ON pages (COALESCE(effective_date, updated_at))` and used by the recency
+  // backfill/importer path.
+  { kind: 'column', table: 'pages', column: 'effective_date' },
+  { kind: 'column', table: 'pages', column: 'effective_date_source' },
+  { kind: 'column', table: 'pages', column: 'import_filename' },
+  { kind: 'column', table: 'pages', column: 'salience_touched_at' },
   // v0.27.1 — forward-referenced by `CREATE INDEX idx_chunks_embedding_image
   // ON content_chunks USING hnsw (embedding_image vector_cosine_ops)
   // WHERE embedding_image IS NOT NULL`.
@@ -126,6 +133,12 @@ test('applyForwardReferenceBootstrap covers every forward reference declared in 
 
       DROP INDEX IF EXISTS pages_deleted_at_purge_idx;
       ALTER TABLE pages DROP COLUMN IF EXISTS deleted_at;
+
+      DROP INDEX IF EXISTS pages_coalesce_date_idx;
+      ALTER TABLE pages DROP COLUMN IF EXISTS effective_date;
+      ALTER TABLE pages DROP COLUMN IF EXISTS effective_date_source;
+      ALTER TABLE pages DROP COLUMN IF EXISTS import_filename;
+      ALTER TABLE pages DROP COLUMN IF EXISTS salience_touched_at;
 
       DROP INDEX IF EXISTS idx_chunks_embedding_image;
       ALTER TABLE content_chunks DROP COLUMN IF EXISTS embedding_image;
@@ -194,6 +207,12 @@ test('after bootstrap, PGLITE_SCHEMA_SQL replays without crashing on missing for
       ALTER TABLE links DROP COLUMN IF EXISTS origin_page_id;
       DROP INDEX IF EXISTS pages_deleted_at_purge_idx;
       ALTER TABLE pages DROP COLUMN IF EXISTS deleted_at;
+
+      DROP INDEX IF EXISTS pages_coalesce_date_idx;
+      ALTER TABLE pages DROP COLUMN IF EXISTS effective_date;
+      ALTER TABLE pages DROP COLUMN IF EXISTS effective_date_source;
+      ALTER TABLE pages DROP COLUMN IF EXISTS import_filename;
+      ALTER TABLE pages DROP COLUMN IF EXISTS salience_touched_at;
 
       DROP INDEX IF EXISTS idx_chunks_embedding_image;
       ALTER TABLE content_chunks DROP COLUMN IF EXISTS embedding_image;
@@ -359,21 +378,29 @@ function parseIndexColumnReferences(sql: string): Array<{ table: string; column:
       //   `col`                        — plain identifier
       //   `col vector_cosine_ops`      — column followed by operator class (HNSW)
       //   `col COLLATE "C"`            — column with collation
-      //   `lower(col)`                 — function-wrapped
-      // For shapes 1-3, the column is the LEADING identifier. For shape 4,
-      // the column is the LAST identifier before a close paren.
-      let col: string | null = null;
+      //   `lower(col)` / `COALESCE(a, b)` — function/expression-wrapped
+      // For shapes 1-3, the column is the LEADING identifier. For expression
+      // wrappers, every non-function identifier is treated as a referenced
+      // column so composite expressions don't hide forward references.
+      const cols: string[] = [];
       if (partClean.includes('(')) {
-        // Function-wrapped: `lower(col)` → grab the last identifier inside.
-        const fnMatch = partClean.match(/(\w+)\s*\)\s*$/);
-        if (fnMatch) col = fnMatch[1];
+        // Function/expression-wrapped: `lower(col)` or
+        // `COALESCE(effective_date, updated_at)` → grab identifier arguments,
+        // excluding common SQL function names and literals.
+        const identifiers = partClean.match(/\b[a-zA-Z_]\w*\b/g) ?? [];
+        for (const ident of identifiers) {
+          if (/^(coalesce|lower|upper|true|false|null|asc|desc)$/i.test(ident)) continue;
+          cols.push(ident);
+        }
       } else {
         // Plain or operator-class-suffixed: leading identifier wins.
         const leadMatch = partClean.match(/^["`]?(\w+)["`]?/);
-        if (leadMatch) col = leadMatch[1];
+        if (leadMatch) cols.push(leadMatch[1]);
       }
-      if (col && !/^(true|false|null|asc|desc)$/i.test(col)) {
-        result.push({ table, column: col.toLowerCase() });
+      for (const col of cols) {
+        if (!/^(true|false|null|asc|desc)$/i.test(col)) {
+          result.push({ table, column: col.toLowerCase() });
+        }
       }
     }
   }
@@ -481,6 +508,11 @@ test('every CREATE INDEX column in PGLITE_SCHEMA_SQL is covered by CREATE TABLE 
   expect(indexRefs).toContainEqual({ table: 'subagent_messages', column: 'provider_id' });
   expect(bootstrapAdds).toContainEqual({ table: 'subagent_messages', column: 'provider_id' });
   expect(covered('subagent_messages', 'provider_id')).toBe(true);
+  // Regression for v0.29.1: expression indexes must unwrap COALESCE(...) and
+  // require bootstrap coverage for older brains missing effective_date.
+  expect(indexRefs).toContainEqual({ table: 'pages', column: 'effective_date' });
+  expect(bootstrapAdds).toContainEqual({ table: 'pages', column: 'effective_date' });
+  expect(covered('pages', 'effective_date')).toBe(true);
 
   // The actual contract: every index column reference must be covered.
   const uncovered: Array<{ table: string; column: string }> = [];


### PR DESCRIPTION
## Summary

Fixes two migration-safety issues found while rehearsing an older PGLite brain upgrade into the current schema:

- bootstrap v0.29.1 recency/salience columns before replaying schema SQL that creates `pages_coalesce_date_idx`
- connect/disconnect the migration engine used by the v0.29.1 `effective_date` backfill/verify phases
- extend bootstrap coverage tests so expression indexes like `COALESCE(effective_date, updated_at)` are parsed and covered

## Why

Older brains can fail before migrations get a chance to run because the schema blob creates an expression index over `effective_date` before the v0.29.1 migration adds that column. After that is patched, the v0.29.1 orchestrator path can still fail because it creates an engine for the backfill but does not connect it before use.

## Validation

- `bun test test/schema-bootstrap-coverage.test.ts`
- `bun run typecheck`
- copied-DB rehearsal in an isolated temporary `GBRAIN_HOME`
  - `gbrain apply-migrations --yes --mode off --no-autopilot-install`
  - `gbrain apply-migrations --list` reports all migrations up to date
  - `select count(*) from pages where effective_date is null` returns `0`
  - `launchctl print gui/$(id -u)/com.gbrain.autopilot` reports not loaded

## Notes

The rehearsal used a wrapper `gbrain` on PATH pointing at the patched worktree so nested migration commands did not hit the live install. No live DB migration was run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
