### PR TITLE
fix: run pages recency migration as v41

### DIFF
--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -1953,7 +1953,7 @@ export const MIGRATIONS: Migration[] = [
     handler: async (engine) => {
       // 1. ADD COLUMN x4. ALTER TABLE ADD COLUMN IF NOT EXISTS is idempotent.
       //    No defaults, all nullable, all metadata-only on PG 11+ and PGLite.
-      await engine.runMigration(38, `
+      await engine.runMigration(41, `
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS effective_date        TIMESTAMPTZ;
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS effective_date_source TEXT;
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS import_filename       TEXT;
@@ -1963,7 +1963,7 @@ export const MIGRATIONS: Migration[] = [
       // 2. Expression index for since/until date-range filters.
       if (engine.kind === 'postgres') {
         // Pre-drop any invalid index from a prior CONCURRENTLY failure.
-        await engine.runMigration(38, `
+        await engine.runMigration(41, `
           DO $$ BEGIN
             IF EXISTS (
               SELECT 1 FROM pg_index i
@@ -1974,12 +1974,12 @@ export const MIGRATIONS: Migration[] = [
             END IF;
           END $$;
         `);
-        await engine.runMigration(38, `
+        await engine.runMigration(41, `
           CREATE INDEX CONCURRENTLY IF NOT EXISTS pages_coalesce_date_idx
             ON pages ((COALESCE(effective_date, updated_at)));
         `);
       } else {
-        await engine.runMigration(38, `
+        await engine.runMigration(41, `
           CREATE INDEX IF NOT EXISTS pages_coalesce_date_idx
             ON pages ((COALESCE(effective_date, updated_at)));
         `);

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -1172,6 +1172,30 @@ describe('migration v31 — eval_capture_tables', () => {
   });
 });
 
+describe('migration v41 — pages_recency_columns (v0.29.1)', () => {
+  test('runs its DDL under migration version 41, not an older completed version', async () => {
+    const v41 = MIGRATIONS.find(m => m.version === 41);
+    expect(v41).toBeDefined();
+    expect(v41?.name).toBe('pages_recency_columns');
+    expect(v41?.handler).toBeDefined();
+
+    const calls: Array<{ version: number; sql: string }> = [];
+    const fakeEngine = {
+      kind: 'pglite',
+      runMigration: async (version: number, sql: string) => {
+        calls.push({ version, sql });
+      },
+    } as unknown as BrainEngine;
+
+    await v41!.handler!(fakeEngine);
+
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    expect(calls.every(call => call.version === 41)).toBe(true);
+    expect(calls.map(call => call.sql).join('\n')).toContain('effective_date');
+    expect(calls.map(call => call.sql).join('\n')).toContain('pages_coalesce_date_idx');
+  });
+});
+
 describe('migration v40 — pages_emotional_weight (v0.29)', () => {
   // v0.29 ships off master. Master is at v39 (multimodal_dual_column_v0_27_1);
   // v0.29 lands at v40. Idempotent ADD COLUMN IF NOT EXISTS, so brains that


### PR DESCRIPTION
## Summary
- fixes `pages_recency_columns` so its handler records/applies DDL under migration version 41 instead of the older v38
- adds a regression test that executes the v41 handler against a fake engine and asserts every internal `runMigration` call uses version 41
- keeps the existing PGLite bootstrap coverage contract intact for `effective_date` / `pages_coalesce_date_idx`

## Root cause
The v0.29.1 pages recency migration was registered as version 41, but the handler's internal `engine.runMigration(...)` calls used version 38. Brains already past v38 could skip the additive columns/index work, then later fail when the embedded PGLite schema tried to create `pages_coalesce_date_idx` against missing `pages.effective_date`.

## Verification
- `bun test test/migrate.test.ts test/schema-bootstrap-coverage.test.ts` ✅, 97 pass
- `bun run ci:local:diff` ⚠️ blocked locally because Docker is not installed (`docker: command not found`)
- `bun run test` ⚠️ unrelated existing failures in resolver/doctor/brain-registry tests, targeted migration/bootstrap tests pass

## Notes
This is additive and idempotent. The SQL already uses `IF NOT EXISTS`; this patch only aligns the migration ledger version used by the handler with the registered migration version.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->