### PR TITLE
fix: bridge shared provider env into gbrain CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { installSigchldHandler } from './core/zombie-reap.ts';
 installSigchldHandler();
 
 import { readFileSync } from 'fs';
-import { loadConfig, loadConfigWithEngine, toEngineConfig, isThinClient } from './core/config.ts';
+import { loadConfig, loadConfigWithEngine, toEngineConfig, isThinClient, loadSharedProviderEnvFiles } from './core/config.ts';
 import type { GBrainConfig } from './core/config.ts';
 import type { AIGatewayConfig } from './core/ai/types.ts';
 import type { BrainEngine } from './core/engine.ts';
@@ -27,6 +27,11 @@ for (const op of operations) {
 const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'remote']);
 
 async function main() {
+  // Load provider credentials before command dispatch so gbrain works when it is
+  // launched by Hermes/cron/non-login shells. loadConfig() itself remains
+  // pure/read-only; this is the CLI bootstrap boundary.
+  loadSharedProviderEnvFiles();
+
   // Parse global flags (--quiet / --progress-json / --progress-interval)
   // BEFORE command dispatch, so `gbrain --progress-json doctor` works.
   // The stripped argv is what the command sees.
@@ -805,6 +810,11 @@ async function handleCliOnly(command: string, args: string[]) {
 // but not the other previously required remembering to mirror the change;
 // the helper makes that structural.
 function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
+  const env = { ...process.env };
+  // Env vars remain highest precedence; config-file credentials are the
+  // durable fallback for non-login shells and cron-launched gbrain runs.
+  if (!env.OPENAI_API_KEY && c.openai_api_key) env.OPENAI_API_KEY = c.openai_api_key;
+  if (!env.ANTHROPIC_API_KEY && c.anthropic_api_key) env.ANTHROPIC_API_KEY = c.anthropic_api_key;
   return {
     embedding_model: c.embedding_model,
     embedding_dimensions: c.embedding_dimensions,
@@ -813,7 +823,7 @@ function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
     chat_model: c.chat_model,
     chat_fallback_chain: c.chat_fallback_chain,
     base_urls: c.provider_base_urls,
-    env: { ...process.env },
+    env,
   };
 }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -108,6 +108,129 @@ export interface GBrainConfig {
   };
 }
 
+export type EnvFileSource = 'gbrain' | 'hermes';
+export interface EnvFileLoadResult {
+  source: EnvFileSource;
+  path: string;
+  keys: string[];
+}
+
+const SHARED_PROVIDER_ENV_KEYS = new Set([
+  // Native providers
+  'OPENAI_API_KEY',
+  'OPENAI_ORG_ID',
+  'OPENAI_PROJECT',
+  'ANTHROPIC_API_KEY',
+  'GOOGLE_GENERATIVE_AI_API_KEY',
+  'VOYAGE_API_KEY',
+  // OpenAI-compatible providers with auth
+  'DEEPSEEK_API_KEY',
+  'GROQ_API_KEY',
+  'TOGETHER_API_KEY',
+  // Local/proxy providers where auth/base-url may be optional but useful.
+  'LITELLM_BASE_URL',
+  'LITELLM_API_KEY',
+  'OLLAMA_BASE_URL',
+  'OLLAMA_API_KEY',
+]);
+
+function parseDotenv(raw: string): Array<[string, string]> {
+  const entries: Array<[string, string]> = [];
+  for (const originalLine of raw.split(/\r?\n/)) {
+    let line = originalLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    if (line.startsWith('export ')) line = line.slice('export '.length).trim();
+
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+
+    let value = line.slice(eq + 1).trim();
+    const quote = value[0];
+    if ((quote === '"' || quote === "'") && value.endsWith(quote)) {
+      value = value.slice(1, -1);
+      if (quote === '"') {
+        value = value
+          .replace(/\\n/g, '\n')
+          .replace(/\\r/g, '\r')
+          .replace(/\\t/g, '\t')
+          .replace(/\\"/g, '"')
+          .replace(/\\\\/g, '\\');
+      }
+    }
+    entries.push([key, value]);
+  }
+  return entries;
+}
+
+function loadEnvFile(path: string, onlyKeys?: ReadonlySet<string>): string[] {
+  if (!existsSync(path)) return [];
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch {
+    return [];
+  }
+
+  const loaded: string[] = [];
+  for (const [key, value] of parseDotenv(raw)) {
+    if (onlyKeys && !onlyKeys.has(key)) continue;
+    if (process.env[key] !== undefined) continue;
+    process.env[key] = value;
+    loaded.push(key);
+  }
+  return loaded;
+}
+
+/**
+ * Load key=value pairs from ~/.gbrain/.env into process.env.
+ *
+ * This is intentionally separate from loadConfig(): loadConfig remains a pure
+ * reader of the current environment/config file, while the CLI may opt in to
+ * a one-time dotenv-style bootstrap before command dispatch. Values already
+ * present in the process environment win over the file.
+ */
+export function loadGbrainEnvFile(path = configEnvPath()): string[] {
+  return loadEnvFile(path);
+}
+
+export function hermesEnvPath(): string {
+  const home = process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes');
+  return join(home, '.env');
+}
+
+/**
+ * Bridge provider credentials from local env files into CLI-launched gbrain.
+ *
+ * Precedence is explicit and narrow:
+ *   process.env > ~/.gbrain/.env > ${HERMES_HOME:-~/.hermes}/.env
+ *
+ * The Hermes file is treated as a shared provider-credential source only. We do
+ * not wholesale import unrelated Hermes secrets (Telegram tokens, gateway
+ * webhooks, etc.) into gbrain's process.
+ */
+export function loadSharedProviderEnvFiles(opts: {
+  gbrainEnvPath?: string;
+  hermesEnvPath?: string;
+} = {}): EnvFileLoadResult[] {
+  const results: EnvFileLoadResult[] = [];
+
+  const gbrainPath = opts.gbrainEnvPath ?? configEnvPath();
+  const gbrainKeys = loadGbrainEnvFile(gbrainPath);
+  if (gbrainKeys.length > 0) {
+    results.push({ source: 'gbrain', path: gbrainPath, keys: gbrainKeys });
+  }
+
+  const hermesPath = opts.hermesEnvPath ?? hermesEnvPath();
+  const hermesKeys = loadEnvFile(hermesPath, SHARED_PROVIDER_ENV_KEYS);
+  if (hermesKeys.length > 0) {
+    results.push({ source: 'hermes', path: hermesPath, keys: hermesKeys });
+  }
+
+  return results;
+}
+
 /**
  * True when this install is configured as a thin client of a remote
  * `gbrain serve --http`. Single source of truth for the "is this a
@@ -144,6 +267,7 @@ export function loadConfig(): GBrainConfig | null {
     engine: inferredEngine,
     ...(dbUrl ? { database_url: dbUrl } : {}),
     ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
+    ...(process.env.ANTHROPIC_API_KEY ? { anthropic_api_key: process.env.ANTHROPIC_API_KEY } : {}),
     ...(process.env.GBRAIN_EMBEDDING_MODEL ? { embedding_model: process.env.GBRAIN_EMBEDDING_MODEL } : {}),
     ...(process.env.GBRAIN_EMBEDDING_DIMENSIONS ? { embedding_dimensions: parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS, 10) } : {}),
     ...(process.env.GBRAIN_EXPANSION_MODEL ? { expansion_model: process.env.GBRAIN_EXPANSION_MODEL } : {}),
@@ -275,6 +399,10 @@ export function configDir(): string {
 
 export function configPath(): string {
   return join(configDir(), 'config.json');
+}
+
+export function configEnvPath(): string {
+  return join(configDir(), '.env');
 }
 
 /**

--- a/test/ai/gbrain-env-file.test.ts
+++ b/test/ai/gbrain-env-file.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression: CLI-launched gbrain must be able to discover provider secrets
+ * from gbrain's own env file and, when embedded in Hermes workflows, from the
+ * Hermes env file where the operator may already keep shared provider keys.
+ * loadConfig() itself must remain pure/read-only.
+ */
+
+import { afterEach, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadConfig, loadGbrainEnvFile, loadSharedProviderEnvFiles } from '../../src/core/config.ts';
+import { withEnv } from '../helpers/with-env.ts';
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+  while (cleanup.length > 0) rmSync(cleanup.pop()!, { recursive: true, force: true });
+});
+
+function tempEnvFile(prefix: string, lines: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanup.push(dir);
+  const envPath = join(dir, '.env');
+  writeFileSync(envPath, lines.join('\n'));
+  return envPath;
+}
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanup.push(dir);
+  return dir;
+}
+
+test('loadGbrainEnvFile loads dotenv-style keys without overriding env', async () => {
+  const envPath = tempEnvFile('gbrain-env-file-', [
+    '# comment',
+    'export OPENAI_API_KEY=openai-from-file',
+    'ANTHROPIC_API_KEY="anthropic-from-file"',
+    'BAD KEY=ignored',
+    '',
+  ]);
+
+  await withEnv({ OPENAI_API_KEY: 'openai-from-env', ANTHROPIC_API_KEY: undefined }, async () => {
+    const loaded = loadGbrainEnvFile(envPath);
+
+    expect(process.env.OPENAI_API_KEY).toBe('openai-from-env');
+    const anthropic = (process.env as Record<string, string | undefined>)['ANTHROPIC_API_KEY'];
+    expect(anthropic).toBe('anthropic-from-file');
+    expect(loaded).toEqual(['ANTHROPIC_API_KEY']);
+  });
+});
+
+test('loadConfig stays read-only even when env files exist', async () => {
+  const gbrainHome = tempDir('gbrain-home-');
+  const hermesHome = tempDir('hermes-home-');
+  const gbrainDir = join(gbrainHome, '.gbrain');
+  mkdirSync(gbrainDir, { recursive: true });
+  writeFileSync(join(gbrainDir, 'config.json'), JSON.stringify({
+    engine: 'pglite',
+    database_path: join(gbrainDir, 'brain.db'),
+  }));
+  writeFileSync(join(gbrainDir, '.env'), 'OPENAI_API_KEY=openai-from-gbrain\n');
+  writeFileSync(join(hermesHome, '.env'), 'ANTHROPIC_API_KEY=anthropic-from-hermes\n');
+
+  await withEnv({
+    GBRAIN_HOME: gbrainHome,
+    HERMES_HOME: hermesHome,
+    OPENAI_API_KEY: undefined,
+    ANTHROPIC_API_KEY: undefined,
+  }, async () => {
+    const config = loadConfig();
+
+    expect(config?.openai_api_key).toBeUndefined();
+    expect(config?.anthropic_api_key).toBeUndefined();
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+});
+
+test('loadSharedProviderEnvFiles bridges Hermes provider keys with narrow precedence', async () => {
+  const gbrainEnvPath = tempEnvFile('gbrain-provider-env-', [
+    'OPENAI_API_KEY=openai-from-gbrain',
+    'ANTHROPIC_API_KEY=anthropic-from-gbrain',
+  ]);
+  const hermesEnvPath = tempEnvFile('hermes-provider-env-', [
+    'OPENAI_API_KEY=openai-from-hermes',
+    'ANTHROPIC_API_KEY=anthropic-from-hermes',
+    'VOYAGE_API_KEY=voyage-from-hermes',
+    'TELEGRAM_BOT_TOKEN=not-shared-with-gbrain',
+  ]);
+
+  await withEnv({
+    OPENAI_API_KEY: 'openai-from-process',
+    ANTHROPIC_API_KEY: undefined,
+    VOYAGE_API_KEY: undefined,
+    TELEGRAM_BOT_TOKEN: undefined,
+  }, async () => {
+    const loaded = loadSharedProviderEnvFiles({ gbrainEnvPath, hermesEnvPath });
+
+    expect(process.env.OPENAI_API_KEY).toBe('openai-from-process');
+    expect(process.env.ANTHROPIC_API_KEY).toBe('anthropic-from-gbrain');
+    expect(process.env.VOYAGE_API_KEY).toBe('voyage-from-hermes');
+    expect(process.env.TELEGRAM_BOT_TOKEN).toBeUndefined();
+    expect(loaded).toEqual([
+      { source: 'gbrain', path: gbrainEnvPath, keys: ['ANTHROPIC_API_KEY'] },
+      { source: 'hermes', path: hermesEnvPath, keys: ['VOYAGE_API_KEY'] },
+    ]);
+  });
+});

--- a/test/cli-multimodal-integration.test.ts
+++ b/test/cli-multimodal-integration.test.ts
@@ -25,6 +25,9 @@ import type { AIGatewayConfig } from '../src/core/ai/types.ts';
 // e2e behavior these tests care about (DB-set value lands in gateway) still
 // holds, but a helper-shape test would also catch the drift in PR review.
 function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
+  const env = { ...process.env };
+  if (!env.OPENAI_API_KEY && c.openai_api_key) env.OPENAI_API_KEY = c.openai_api_key;
+  if (!env.ANTHROPIC_API_KEY && c.anthropic_api_key) env.ANTHROPIC_API_KEY = c.anthropic_api_key;
   return {
     embedding_model: c.embedding_model,
     embedding_dimensions: c.embedding_dimensions,
@@ -33,7 +36,7 @@ function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
     chat_model: c.chat_model,
     chat_fallback_chain: c.chat_fallback_chain,
     base_urls: c.provider_base_urls,
-    env: { ...process.env },
+    env,
   };
 }
 


### PR DESCRIPTION
## Summary

Make `gbrain` work correctly when it is launched from Hermes workflows but provider credentials live in Hermes' env file.

The failure mode was not that users simply forgot to set `OPENAI_API_KEY`. In this topology there are two local tools with two config homes:

- Hermes stores provider credentials in `${HERMES_HOME:-~/.hermes}/.env`
- gbrain reads from its own config/env home, `${GBRAIN_HOME:-~}/.gbrain/`

When Hermes or cron launched `gbrain`, the shell process did not necessarily export the provider keys, and gbrain did not know how to consult Hermes' env file. That made embedding/AI gateway calls fail with errors such as:

```text
OpenAI embedding requires OPENAI_API_KEY.
```

This PR adds a narrow provider-env connector instead of requiring duplicated secrets or changing `loadConfig()` semantics.

## What changed

- Add CLI bootstrap `loadSharedProviderEnvFiles()`:
  - loads gbrain's own `~/.gbrain/.env` first
  - then loads shared provider credentials from `${HERMES_HOME:-~/.hermes}/.env`
  - preserves explicit process env precedence
- Restrict Hermes env imports to provider-related keys only, so unrelated Hermes secrets are not copied into gbrain's process.
- Keep `loadConfig()` pure/read-only. Env-file loading remains a CLI startup side effect, not a config-reader side effect.
- Pass config-file OpenAI/Anthropic credentials into gateway env as fallback when process env does not already contain them.
- Add regression tests for:
  - dotenv parsing and env precedence
  - `loadConfig()` remaining read-only even when env files exist
  - Hermes provider env fallback
  - excluding unrelated Hermes secrets such as gateway/messaging tokens

## Precedence

The connector uses this order:

```text
process.env > ~/.gbrain/.env > ${HERMES_HOME:-~/.hermes}/.env
```

Rationale:

1. `process.env` remains the operator escape hatch for one-off overrides and CI.
2. `~/.gbrain/.env` remains gbrain's native/local configuration source.
3. Hermes' env file is a fallback for embedded/Hermes-launched gbrain workflows where provider keys are already configured in Hermes.

## Security / privacy

- No provider key values are logged or exposed.
- Hermes env loading is allowlisted to AI provider variables used by gbrain recipes.
- Hermes-only credentials, gateway tokens, and unrelated secrets are not imported.
- Existing privacy checks pass.

## Validation

Required repo gate:

```text
bun run verify
```

Targeted regression tests:

```text
bun test test/ai/config-no-env-mutation.test.ts test/ai/gbrain-env-file.test.ts test/cli-multimodal-integration.test.ts
```

Runtime validation of the actual topology:

- temporarily made `~/.gbrain/.env` absent
- ran gbrain from this branch with only `HERMES_HOME` pointing at Hermes' config home
- confirmed `providers explain --json` detected OpenAI and Anthropic provider keys via Hermes env
- confirmed `gbrain embed --slugs projects/auto-research/multiplayer-research-game-context` did not fail with provider-key errors
- confirmed `gbrain features --auto-fix` completed without the original `OPENAI_API_KEY` failure

No secret values were printed during validation.
