### PR TITLE
Fix MCP array schema for extract_facts

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2393,7 +2393,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },

--- a/test/mcp-tool-defs.test.ts
+++ b/test/mcp-tool-defs.test.ts
@@ -64,4 +64,14 @@ describe('buildToolDefs', () => {
       expect(Array.isArray(def.inputSchema.required)).toBe(true);
     }
   });
+
+  test('array parameters always declare item schemas for OpenAI-compatible clients', () => {
+    for (const def of buildToolDefs(operations)) {
+      for (const [name, schema] of Object.entries(def.inputSchema.properties) as Array<[string, any]>) {
+        if (schema.type !== 'array') continue;
+        expect(schema.items, `${def.name}.${name} is missing items`).toBeDefined();
+        expect(typeof schema.items.type, `${def.name}.${name}.items.type`).toBe('string');
+      }
+    }
+  });
 });


### PR DESCRIPTION
Fixes an OpenAI-compatible MCP tool schema rejection where `extract_facts.entity_hints` was declared as an array without `items`.

OpenAI rejects this with:

`Invalid schema for function 'mcp_gbrain_extract_facts': In context=('properties', 'entity_hints'), array schema missing items.`

Changes:
- Add `items: { type: 'string' }` to `entity_hints`
- Add a regression test requiring all MCP array parameters to declare item schemas

Tested:
- `bun test test/mcp-tool-defs.test.ts test/facts-mcp-allowlist.serial.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->