### PR TITLE
feat(serve-http): GBRAIN_TRUST_PROXY env var + Supabase deploy docs

### DIFF
--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -216,6 +216,57 @@ paths outside cwd are rejected. Page slugs and filenames are allowlist-validated
 CLI callers (`gbrain file upload ...`) keep unrestricted filesystem access since
 the user owns the machine.
 
+## Supabase Deployment Caveat
+
+If your brain is backed by Supabase and you are deploying `gbrain serve --http`
+to an external host (Fly.io, Render, Railway, your own VPS), set:
+
+```bash
+GBRAIN_DISABLE_DIRECT_POOL=1
+GBRAIN_POOL_SIZE=1
+GBRAIN_TRUST_PROXY=1
+```
+
+**Why `GBRAIN_DISABLE_DIRECT_POOL=1`:** GBrain's dual-pool routing tries to open
+a direct connection to the Postgres host (port 5432) alongside the standard
+pooler connection. On Supabase that direct host is only reachable from inside
+Supabase's VPC — not accessible from external deployments. Without this flag the
+startup sequence attempts an IPv6 connection to the direct host, times out (or
+receives connection-refused), and either crashes or falls back to a degraded
+state.
+
+**Why `GBRAIN_TRUST_PROXY=1`:** Express defaults to `trust proxy: 'loopback'`
+which only trusts proxies on `127.0.0.1`. PaaS load balancers (Fly, Render,
+Railway, Vercel) terminate TLS one network hop in front of your app, so the
+real client IP arrives in `X-Forwarded-For` after **exactly 1 hop**. Setting
+`GBRAIN_TRUST_PROXY=1` tells Express to trust that one hop, which is required
+for both rate limiting (correct client IPs) and `req.secure` detection
+(needed for OAuth flows that require HTTPS).
+
+**Connection string:** use the **Transaction Pooler** URL (port **6543**, not
+5432):
+
+```
+postgresql://postgres.<project-ref>:<password>@aws-0-<region>.pooler.supabase.com:6543/<db>
+```
+
+The Session Pooler (port 5432 on the pooler host) also works but has higher
+per-connection overhead. The **direct** connection string
+(`db.<project-ref>.supabase.co:5432`) will not work from outside the Supabase
+VPC and should not be used for externally-deployed servers.
+
+**Minimal Fly.io `fly.toml` env block example:**
+
+```toml
+[env]
+  GBRAIN_DISABLE_DIRECT_POOL = "1"
+  GBRAIN_POOL_SIZE = "1"
+  GBRAIN_TRUST_PROXY = "1"
+```
+
+Set `DATABASE_URL` as a secret (`fly secrets set DATABASE_URL=...`) — never
+commit it to `fly.toml`.
+
 ## Deployment Options
 
 See [ALTERNATIVES.md](ALTERNATIVES.md) for a comparison of ngrok, Tailscale

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -217,7 +217,15 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
 
   // Express 5 app
   const app = express();
-  app.set('trust proxy', 'loopback'); // Caddy/Tailscale reverse proxy on localhost
+  // Trust-proxy default is 'loopback' (works for local Caddy/Tailscale reverse proxies).
+  // Set GBRAIN_TRUST_PROXY=1 (or any positive integer) when deploying behind a PaaS
+  // load balancer (Fly.io, Render, Railway, Vercel) where the actual client IP
+  // arrives in X-Forwarded-For after exactly N hops. See docs/mcp/DEPLOY.md.
+  const trustProxyEnv = process.env.GBRAIN_TRUST_PROXY;
+  const trustProxyValue = trustProxyEnv
+    ? (/^\d+$/.test(trustProxyEnv) ? parseInt(trustProxyEnv, 10) : trustProxyEnv)
+    : 'loopback';
+  app.set('trust proxy', trustProxyValue);
 
   // ---------------------------------------------------------------------------
   // Cookie parsing — required for /admin auth (express 5 has no built-in)


### PR DESCRIPTION
## Summary

Two small changes for `gbrain serve --http` users deploying behind PaaS load balancers:

1. **`GBRAIN_TRUST_PROXY` env var** — `src/commands/serve-http.ts` makes the Express trust-proxy setting configurable. Default unchanged (`'loopback'`); set `GBRAIN_TRUST_PROXY=1` for Fly.io/Render/Railway/Vercel where the real client IP arrives after exactly one hop. Required for both rate-limiting (correct client IPs) and `req.secure` detection (OAuth flows).

2. **Supabase Deployment Caveat docs** — `docs/mcp/DEPLOY.md` adds a new section covering the three env vars external Supabase deployments need (`GBRAIN_DISABLE_DIRECT_POOL=1`, `GBRAIN_POOL_SIZE=1`, `GBRAIN_TRUST_PROXY=1`), the pooler URL gotcha (port 6543 not 5432), and a minimal Fly.io `fly.toml` example.

## Why

Tested against a Supabase-backed brain on a self-hosted VPS. Without these flags + docs, the startup sequence wedges on an IPv6 connect to `db.<project-ref>.supabase.co:5432` (unreachable from outside Supabase's VPC), and rate-limiting silently misclassifies clients because `app.set('trust proxy', 'loopback')` only trusts `127.0.0.1`. After applying both, `gbrain serve --http` runs cleanly.

## Replaces #759

This is the focused remainder of #759. That PR also bundled DCR `/register` rate-limiter changes; those landed independently via the v0.31 fix-wave (#776 et al). #760 also got incidentally fixed by the same fix-wave (the `engine.connect()` call you added to `phaseBBackfill`/`phaseCVerify` covers what we'd patched). So #759 is closed and only the trust-proxy + Supabase docs remain — narrower scope, cleaner review.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Default behavior unchanged when `GBRAIN_TRUST_PROXY` is unset
- [x] Manual smoke test: setting `GBRAIN_TRUST_PROXY=1` correctly resolves to integer `1` (not the string)
- [x] Docs render cleanly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->