### PR TITLE
Fix extract_facts MCP array schema

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2393,7 +2393,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },

--- a/test/mcp-tool-defs.test.ts
+++ b/test/mcp-tool-defs.test.ts
@@ -64,4 +64,19 @@ describe('buildToolDefs', () => {
       expect(Array.isArray(def.inputSchema.required)).toBe(true);
     }
   });
+
+  test('every array property declares an items schema for strict tool validators', () => {
+    for (const def of buildToolDefs(operations)) {
+      for (const [paramName, paramSchema] of Object.entries(def.inputSchema.properties)) {
+        if (
+          paramSchema &&
+          typeof paramSchema === 'object' &&
+          'type' in paramSchema &&
+          paramSchema.type === 'array'
+        ) {
+          expect(paramSchema, `${def.name}.${paramName}`).toHaveProperty('items');
+        }
+      }
+    }
+  });
 });


### PR DESCRIPTION
# Fix extract_facts MCP array schema

Closes #806.

## Summary

- Add `items: { type: 'string' }` to the `extract_facts.entity_hints` array param schema.
- Add a regression test that every MCP-facing array property declares an `items` schema.

## Why

Strict OpenAI-compatible tool validators reject array schemas that omit `items`. Because `src/mcp/tool-defs.ts` only emits `items` when the operation param declares it, `extract_facts.entity_hints` produced an invalid MCP tool schema.

## Validation

- `/private/tmp/kage-oss/bun-runtime/bun-darwin-aarch64/bun test test/mcp-tool-defs.test.ts` — 6 pass, 0 fail.
- `/private/tmp/kage-oss/bun-runtime/bun-darwin-aarch64/bun run typecheck`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->