### PR TITLE
Fix whoami over stdio MCP

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -934,6 +934,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
       try {
         toolResult = await dispatchToolCall(engine, name, params as Record<string, unknown> | undefined, {
           remote: true,
+          transport: 'http',
           takesHoldersAllowList: tokenAllowList,
           sourceId: tokenSourceId,
           metaHook: getBrainHotMemoryMeta,

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -226,6 +226,12 @@ export interface OperationContext {
   logger: Logger;
   dryRun: boolean;
   /**
+   * Optional transport discriminator for operation handlers that need to
+   * explain their caller shape. Stdio MCP is remote/untrusted for data access,
+   * but has no per-token auth because it is a local pipe.
+   */
+  transport?: 'local' | 'stdio' | 'http';
+  /**
    * OAuth auth info (v0.8+). Present when the caller authenticated via OAuth 2.1
    * through `gbrain serve --http`. Contains clientId and granted scopes for
    * per-operation scope enforcement.
@@ -2187,8 +2193,9 @@ const whoami: Operation = {
     'Introspect the calling identity. Returns one of three transport shapes: ' +
     '{transport: "oauth", client_id, client_name, scopes, expires_at}, ' +
     '{transport: "legacy", token_name, scopes, expires_at: null}, or ' +
-    '{transport: "local", scopes: []}. Throws unknown_transport when the ' +
-    'context is ambiguous (remote=true without auth) — fail-closed posture ' +
+    '{transport: "local", scopes: []}. Stdio MCP reports local because it is ' +
+    'a local pipe without per-token auth. Throws unknown_transport when the ' +
+    'remote context is otherwise ambiguous (remote=true without auth) — fail-closed posture ' +
     'mirroring the v0.26.9 trust-boundary contract.',
   params: {},
   scope: 'read',
@@ -2198,7 +2205,7 @@ const whoami: Operation = {
     // where code conditionally trusted on `scopes.includes('admin')` instead
     // of `ctx.remote === false`. Empty scopes array forces clients to
     // special-case `transport: 'local'` explicitly.
-    if (ctx.remote === false) {
+    if (ctx.remote === false || ctx.transport === 'stdio') {
       return { transport: 'local', scopes: [] };
     }
     if (!ctx.auth) {

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -30,6 +30,8 @@ export interface ToolResult {
 export interface DispatchOpts {
   /** Defaults to true (remote/untrusted). Local CLI callers (`gbrain call`) pass false. */
   remote?: boolean;
+  /** Optional caller transport label for ops like whoami. */
+  transport?: OperationContext['transport'];
   /** Override the default stderr logger (e.g. CLI uses console.* directly). */
   logger?: OperationContext['logger'];
   /**
@@ -203,6 +205,7 @@ export function buildOperationContext(
     logger: opts.logger || stderrLogger,
     dryRun: !!params.dry_run,
     remote: opts.remote ?? true,
+    transport: opts.transport ?? (opts.remote === false ? 'local' : undefined),
     takesHoldersAllowList: opts.takesHoldersAllowList,
     sourceId: opts.sourceId,
     auth: opts.auth,

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -330,6 +330,7 @@ export async function startHttpTransport(opts: HttpTransportOptions) {
         // takes_search / query (when it returns takes) can server-side filter.
         const result = await dispatchToolCall(engine, toolName, args, {
           remote: true,
+          transport: 'http',
           takesHoldersAllowList: auth.takesHoldersAllowList,
         });
         const status = result.isError ? 'error' : 'success';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -35,6 +35,7 @@ export async function startMcpServer(engine: BrainEngine) {
     // `gbrain call <op>` (sets remote=false in src/cli.ts).
     return dispatchToolCall(engine, name, params, {
       remote: true,
+      transport: 'stdio',
       takesHoldersAllowList: ['world'],
       // v0.31: source defaults to 'default' for stdio (no per-token scope).
       // Operators who want a different source on stdio MCP should set

--- a/test/whoami.test.ts
+++ b/test/whoami.test.ts
@@ -55,6 +55,15 @@ describe('whoami op contract', () => {
     expect(result.scopes).toEqual([]);
   });
 
+  test('stdio MCP transport returns local shape without per-token auth', async () => {
+    const result = (await whoami.handler(
+      ctxWith({ remote: true, transport: 'stdio', auth: undefined }),
+      {},
+    )) as any;
+    expect(result.transport).toBe('local');
+    expect(result.scopes).toEqual([]);
+  });
+
   test('oauth transport returns full client identity', async () => {
     const auth: AuthInfo = {
       token: 'gbrain_at_xxx',
@@ -94,10 +103,10 @@ describe('whoami op contract', () => {
     expect(result.expires_at).toBeNull();
   });
 
-  // Q3: ambiguous transport — fail-closed. The footgun this guards against
-  // is a future transport that lands without threading auth, where a buggy
-  // caller might trust whoami's output to gate sensitive ops.
-  test('unknown_transport throws when remote=true AND auth is missing', async () => {
+  // Q3: ambiguous non-stdio remote transport — fail-closed. The footgun this
+  // guards against is a future transport that lands without threading auth,
+  // where a buggy caller might trust whoami's output to gate sensitive ops.
+  test('unknown_transport throws when remote=true AND auth is missing outside stdio', async () => {
     try {
       await whoami.handler(ctxWith({ remote: true, auth: undefined }), {});
       throw new Error('expected throw');


### PR DESCRIPTION
# Fix whoami over stdio MCP

Closes #713.

## Summary

- Thread a lightweight `transport` label through MCP dispatch.
- Mark stdio MCP calls as `transport: 'stdio'` and HTTP MCP calls as `transport: 'http'`.
- Make `whoami` return the local shape for stdio MCP, where the caller is a local pipe without per-token auth.
- Preserve the fail-closed `unknown_transport` behavior for ambiguous non-stdio remote contexts.

## Why

Stdio MCP is intentionally `remote: true` for data access filtering, but it does not have OAuth or legacy token auth. `whoami` treated `remote: true` plus missing `ctx.auth` as a transport bug, so Claude Code / stdio clients saw `unknown_transport` even though other tools worked.

This keeps the trust boundary intact:

- `remote: false` local CLI still reports `{ transport: 'local', scopes: [] }`.
- `transport: 'stdio'` also reports the local shape because it is a local pipe.
- OAuth / legacy HTTP callers still report their auth identity.
- Unknown remote callers without auth still fail closed.

## Validation

- `/private/tmp/kage-oss/bun-runtime/bun-darwin-aarch64/bun test test/whoami.test.ts` — 10 pass, 0 fail.
- `/private/tmp/kage-oss/bun-runtime/bun-darwin-aarch64/bun run typecheck`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->