### PR TITLE
Skip generated dirs in frontmatter scan

### DIFF
--- a/src/core/brain-writer.ts
+++ b/src/core/brain-writer.ts
@@ -49,6 +49,14 @@ export interface AuditReport {
 }
 
 const SAMPLE_PER_SOURCE = 20;
+const SKIP_SCAN_DIRS = new Set([
+  'node_modules',
+  'ops',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+]);
 
 // ---------------------------------------------------------------------------
 // autoFixFrontmatter
@@ -368,6 +376,7 @@ function walkDir(root: string, visit: (absPath: string) => boolean | void): void
       }
       if (st.isSymbolicLink()) continue; // matches sync's no-symlink policy
       if (st.isDirectory()) {
+        if (name.startsWith('.') || SKIP_SCAN_DIRS.has(name)) continue;
         const real = resolve(full);
         if (visited.has(real)) continue;
         visited.add(real);

--- a/test/brain-writer.test.ts
+++ b/test/brain-writer.test.ts
@@ -213,6 +213,21 @@ describe('scanBrainSources (PGLite)', () => {
     expect(report.per_source[0]!.total).toBe(0);
   });
 
+  test('skips dependency and build artifact directories', async () => {
+    mkdirSync(join(tmp, 'src'), { recursive: true });
+    mkdirSync(join(tmp, 'node_modules/pkg'), { recursive: true });
+    mkdirSync(join(tmp, 'dist'), { recursive: true });
+    mkdirSync(join(tmp, 'build'), { recursive: true });
+    writeFileSync(join(tmp, 'src', 'good.md'), `${fence}\ntype: x\ntitle: ok\n${fence}\n\nbody`);
+    writeFileSync(join(tmp, 'node_modules/pkg', 'package-notes.md'), '# vendored package');
+    writeFileSync(join(tmp, 'dist', 'generated-doc.md'), '# generated docs');
+    writeFileSync(join(tmp, 'build', 'generated-doc.md'), '# generated docs');
+    await registerSource('js-project', tmp);
+
+    const report = await scanBrainSources(engine);
+    expect(report.total).toBe(0);
+  });
+
   test('AbortSignal mid-scan stops walking', async () => {
     const src = join(tmp, 'big');
     mkdirSync(src, { recursive: true });


### PR DESCRIPTION
# Skip generated dirs in frontmatter scan

Closes #799.

## Summary

- Make the frontmatter scanner skip dependency and generated-output directories before recursing.
- Covered dirs include `node_modules`, `dist`, `build`, `out`, `coverage`, `ops`, and dot-prefixed directories.
- Add a regression test proving arbitrary markdown inside `node_modules`, `dist`, and `build` does not produce `frontmatter_integrity` warnings.

## Why

`gbrain doctor` uses `scanBrainSources()` for the `frontmatter_integrity` subcheck. The scanner filtered files with `isSyncable()`, but still recursed through dependency/build directories. That made doctor report `MISSING_OPEN` warnings for vendored or generated Markdown that sync would not treat as source content.

This prevents doctor from suggesting `gbrain frontmatter validate <source-path> --fix` on third-party or generated files.

## Validation

- `/private/tmp/kage-oss/bun-runtime/bun-darwin-aarch64/bun test test/brain-writer.test.ts` — 17 pass, 0 fail.
- `/private/tmp/kage-oss/bun-runtime/bun-darwin-aarch64/bun run typecheck`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->