### PR TITLE
Add Astro files to code sync

### DIFF
--- a/src/core/chunkers/code.ts
+++ b/src/core/chunkers/code.ts
@@ -436,6 +436,7 @@ export function detectCodeLanguage(filePath: string, content?: string): Supporte
   if (lower.endsWith('.css')) return 'css';
   if (lower.endsWith('.html') || lower.endsWith('.htm')) return 'html';
   if (lower.endsWith('.vue')) return 'vue';
+  if (lower.endsWith('.astro')) return 'html';
   if (lower.endsWith('.json')) return 'json';
   if (lower.endsWith('.yaml') || lower.endsWith('.yml')) return 'yaml';
   if (lower.endsWith('.toml')) return 'toml';

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -58,6 +58,7 @@ const FENCE_TAG_TO_PSEUDO_PATH: Record<string, string> = {
   css: 'fence.css',
   html: 'fence.html',
   vue: 'fence.vue',
+  astro: 'fence.astro',
   json: 'fence.json',
   yaml: 'fence.yaml', yml: 'fence.yaml',
   toml: 'fence.toml',

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -148,7 +148,7 @@ export interface CodeRef {
 // The extension list is aligned with detectCodeLanguage in chunkers/code.ts.
 // Paths NOT matching these extensions are ignored because they wouldn't
 // have a code page to edge to anyway.
-const CODE_REF_REGEX = /\b((?:src|lib|app|test|tests|scripts|docs|packages|internal|cmd|examples)\/[\w\-./]+\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|go|rs|java|cs|cpp|cc|hpp|c|h|php|swift|kt|scala|lua|ex|exs|elm|ml|dart|zig|sol|sh|bash|css|html|vue|json|yaml|yml|toml))(?::(\d+))?\b/g;
+const CODE_REF_REGEX = /\b((?:src|lib|app|test|tests|scripts|docs|packages|internal|cmd|examples)\/[\w\-./]+\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|go|rs|java|cs|cpp|cc|hpp|c|h|php|swift|kt|scala|lua|ex|exs|elm|ml|dart|zig|sol|sh|bash|css|html|vue|astro|json|yaml|yml|toml))(?::(\d+))?\b/g;
 
 /**
  * Extract code-path references (e.g. 'src/core/sync.ts:42') from markdown

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -69,6 +69,7 @@ const CODE_EXTENSIONS = new Set<string>([
   '.css',
   '.html', '.htm',
   '.vue',
+  '.astro',
   '.json',
   '.yaml', '.yml',
   '.toml',

--- a/test/chunkers/code.test.ts
+++ b/test/chunkers/code.test.ts
@@ -28,7 +28,7 @@ describe('detectCodeLanguage', () => {
       'foo.scala': 'scala', 'foo.lua': 'lua', 'foo.ex': 'elixir',
       'foo.elm': 'elm', 'foo.ml': 'ocaml', 'foo.dart': 'dart',
       'foo.zig': 'zig', 'foo.sol': 'solidity', 'foo.sh': 'bash',
-      'foo.css': 'css', 'foo.html': 'html', 'foo.vue': 'vue',
+      'foo.css': 'css', 'foo.html': 'html', 'foo.vue': 'vue', 'foo.astro': 'html',
       'foo.json': 'json', 'foo.yaml': 'yaml', 'foo.toml': 'toml',
     };
     for (const [path, expected] of Object.entries(cases)) {

--- a/test/link-extraction-code-refs.test.ts
+++ b/test/link-extraction-code-refs.test.ts
@@ -43,7 +43,7 @@ describe('extractCodeRefs — basic patterns', () => {
       'cpp', 'cc', 'hpp', 'c', 'h',
       'php', 'swift', 'kt', 'scala', 'lua',
       'ex', 'exs', 'elm', 'ml', 'dart', 'zig', 'sol',
-      'sh', 'bash', 'css', 'html', 'vue',
+      'sh', 'bash', 'css', 'html', 'vue', 'astro',
       'json', 'yaml', 'yml', 'toml',
     ];
     for (const ext of exts) {

--- a/test/sync-classifier-widening.test.ts
+++ b/test/sync-classifier-widening.test.ts
@@ -66,10 +66,11 @@ describe('Layer 2 — isCodeFilePath widening', () => {
     expect(isCodeFilePath('contracts/Token.sol')).toBe(true);
   });
 
-  test('Web + config extensions (CSS, HTML, Vue, JSON, YAML, TOML)', () => {
+  test('Web + config extensions (CSS, HTML, Vue, Astro, JSON, YAML, TOML)', () => {
     expect(isCodeFilePath('src/app.css')).toBe(true);
     expect(isCodeFilePath('public/index.html')).toBe(true);
     expect(isCodeFilePath('src/App.vue')).toBe(true);
+    expect(isCodeFilePath('src/pages/index.astro')).toBe(true);
     expect(isCodeFilePath('package.json')).toBe(true);
     expect(isCodeFilePath('config.yaml')).toBe(true);
     expect(isCodeFilePath('config.yml')).toBe(true);

--- a/test/sync-strategy.test.ts
+++ b/test/sync-strategy.test.ts
@@ -12,6 +12,7 @@ describe('isCodeFilePath', () => {
     expect(isCodeFilePath('script.py')).toBe(true);
     expect(isCodeFilePath('class.rb')).toBe(true);
     expect(isCodeFilePath('main.go')).toBe(true);
+    expect(isCodeFilePath('src/pages/index.astro')).toBe(true);
   });
 
   test('rejects non-code extensions', () => {
@@ -20,7 +21,7 @@ describe('isCodeFilePath', () => {
     expect(isCodeFilePath('README')).toBe(false);
     // v0.20.0 Cathedral II Layer 2 widens the classifier to include
     // config formats (.json, .yaml, .toml) and web formats (.css, .html,
-    // .vue) because the chunker supports them — they were dropped by the
+    // .vue, .astro) because the chunker supports them — they were dropped by the
     // 9-extension v0.19.0 allowlist. `.json` is NO LONGER rejected.
     expect(isCodeFilePath('image.svg')).toBe(false);
     expect(isCodeFilePath('archive.zip')).toBe(false);
@@ -43,6 +44,7 @@ describe('isSyncable with strategy', () => {
     expect(isSyncable('src/foo.ts', { strategy: 'code' })).toBe(true);
     expect(isSyncable('src/foo.py', { strategy: 'code' })).toBe(true);
     expect(isSyncable('src/foo.go', { strategy: 'code' })).toBe(true);
+    expect(isSyncable('src/pages/index.astro', { strategy: 'code' })).toBe(true);
     expect(isSyncable('notes.md', { strategy: 'code' })).toBe(false);
   });
 

--- a/test/sync-walker-symlink.test.ts
+++ b/test/sync-walker-symlink.test.ts
@@ -91,14 +91,15 @@ describe('collectSyncableFiles symlink + cycle hardening', () => {
       writeFileSync(join(tmp, 'README.md'), '# r\n');
       writeFileSync(join(tmp, 'foo.ts'), '// f\n');
       writeFileSync(join(tmp, 'bar.py'), '# b\n');
+      writeFileSync(join(tmp, 'page.astro'), '---\nconst title = "x";\n---\n<h1>{title}</h1>\n');
 
       const code = collectSyncableFiles(tmp, { strategy: 'code' });
       const markdown = collectSyncableFiles(tmp, { strategy: 'markdown' });
       const auto = collectSyncableFiles(tmp, { strategy: 'auto' });
 
-      expect(code.map(f => f.split('/').pop()).sort()).toEqual(['bar.py', 'foo.ts']);
+      expect(code.map(f => f.split('/').pop()).sort()).toEqual(['bar.py', 'foo.ts', 'page.astro']);
       expect(markdown.map(f => f.split('/').pop())).toEqual(['README.md']);
-      expect(auto.map(f => f.split('/').pop()).sort()).toEqual(['README.md', 'bar.py', 'foo.ts']);
+      expect(auto.map(f => f.split('/').pop()).sort()).toEqual(['README.md', 'bar.py', 'foo.ts', 'page.astro']);
     });
   });
 


### PR DESCRIPTION
Fixes #709.

## Summary
- include .astro in the code sync extension allowlist
- detect .astro files as HTML-backed code chunks
- include Astro in code-reference extraction and fenced-code pseudo paths

## Tests
- bun test test/sync-strategy.test.ts test/sync-walker-symlink.test.ts test/chunkers/code.test.ts test/link-extraction-code-refs.test.ts test/sync-classifier-widening.test.ts
- bun run typecheck
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->