### PR TITLE
Honor positional check-backlinks directory

### DIFF
--- a/src/commands/backlinks.ts
+++ b/src/commands/backlinks.ts
@@ -5,8 +5,8 @@
  * checks if back-links exist, and optionally creates them.
  *
  * Usage:
- *   gbrain check-backlinks check [--dir <brain-dir>]     # report missing back-links
- *   gbrain check-backlinks fix [--dir <brain-dir>]        # create missing back-links
+ *   gbrain check-backlinks check [dir] [--dir <brain-dir>] # report missing back-links
+ *   gbrain check-backlinks fix [dir] [--dir <brain-dir>]   # create missing back-links
  *   gbrain check-backlinks fix --dry-run                  # preview fixes
  */
 
@@ -190,6 +190,40 @@ export interface BacklinksResult {
   dryRun: boolean;
 }
 
+export interface ParsedBacklinksArgs {
+  subcommand: string | undefined;
+  brainDir: string;
+  dryRun: boolean;
+}
+
+export function parseBacklinksArgs(args: string[]): ParsedBacklinksArgs {
+  const subcommand = args[0];
+  const dryRun = args.includes('--dry-run');
+  const dirIdx = args.indexOf('--dir');
+  const flagDir = dirIdx >= 0 && args[dirIdx + 1] && !args[dirIdx + 1].startsWith('--')
+    ? args[dirIdx + 1]
+    : undefined;
+
+  let positionalDir: string | undefined;
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--dir') {
+      i++;
+      continue;
+    }
+    if (arg === '--dry-run') continue;
+    if (arg.startsWith('--')) continue;
+    positionalDir = arg;
+    break;
+  }
+
+  return {
+    subcommand,
+    brainDir: flagDir ?? positionalDir ?? '.',
+    dryRun,
+  };
+}
+
 /**
  * Library-level backlinks check/fix. Throws on validation errors; returns a
  * structured result so Minions handlers + autopilot-cycle can surface counts.
@@ -225,16 +259,14 @@ export async function runBacklinksCore(opts: BacklinksOpts): Promise<BacklinksRe
 }
 
 export async function runBacklinks(args: string[]) {
-  const subcommand = args[0];
-  const dirIdx = args.indexOf('--dir');
-  const brainDir = dirIdx >= 0 ? args[dirIdx + 1] : '.';
-  const dryRun = args.includes('--dry-run');
+  const { subcommand, brainDir, dryRun } = parseBacklinksArgs(args);
 
   if (!subcommand || !['check', 'fix'].includes(subcommand)) {
-    console.error('Usage: gbrain check-backlinks <check|fix> [--dir <brain-dir>] [--dry-run]');
+    console.error('Usage: gbrain check-backlinks <check|fix> [dir] [--dir <brain-dir>] [--dry-run]');
     console.error('  check    Report missing back-links');
     console.error('  fix      Create missing back-links (appends to Timeline)');
-    console.error('  --dir    Brain directory (default: current directory)');
+    console.error('  dir      Brain directory (default: current directory)');
+    console.error('  --dir    Brain directory override');
     console.error('  --dry-run  Preview fixes without writing');
     process.exit(1);
   }

--- a/test/backlinks.test.ts
+++ b/test/backlinks.test.ts
@@ -4,6 +4,7 @@ import {
   extractPageTitle,
   hasBacklink,
   buildBacklinkEntry,
+  parseBacklinksArgs,
 } from '../src/commands/backlinks.ts';
 
 describe('extractEntityRefs', () => {
@@ -76,5 +77,19 @@ describe('buildBacklinkEntry', () => {
   test('builds properly formatted entry', () => {
     const entry = buildBacklinkEntry('Q1 Review', '../../meetings/q1-review.md', '2026-04-11');
     expect(entry).toBe('- **2026-04-11** | Referenced in [Q1 Review](../../meetings/q1-review.md)');
+  });
+});
+
+describe('parseBacklinksArgs', () => {
+  test('uses positional dir for check and fix subcommands', () => {
+    expect(parseBacklinksArgs(['check', '/tmp/brain']).brainDir).toBe('/tmp/brain');
+    expect(parseBacklinksArgs(['fix', '/tmp/brain']).brainDir).toBe('/tmp/brain');
+  });
+
+  test('--dir overrides positional dir and preserves dry-run', () => {
+    const parsed = parseBacklinksArgs(['fix', '/tmp/ignored', '--dir', '/tmp/brain', '--dry-run']);
+    expect(parsed.subcommand).toBe('fix');
+    expect(parsed.brainDir).toBe('/tmp/brain');
+    expect(parsed.dryRun).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #485.

## Summary
- parse the documented positional [dir] for check-backlinks check/fix
- keep --dir as an explicit override when both forms are present
- update usage text and parser coverage

## Tests
- bun test test/backlinks.test.ts
- bun run typecheck
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->