### PR TITLE
fix: use canonical Anthropic model IDs (claude-sonnet-4-6, not -20250929)

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -43,7 +43,7 @@ const MAX_CHARS = 8000;
 const DEFAULT_EMBEDDING_MODEL = 'openai:text-embedding-3-large';
 const DEFAULT_EMBEDDING_DIMENSIONS = 1536;
 const DEFAULT_EXPANSION_MODEL = 'anthropic:claude-haiku-4-5-20251001';
-const DEFAULT_CHAT_MODEL = 'anthropic:claude-sonnet-4-6-20250929';
+const DEFAULT_CHAT_MODEL = 'anthropic:claude-sonnet-4-6';
 
 let _config: AIGatewayConfig | null = null;
 const _modelCache = new Map<string, any>();

--- a/src/core/ai/recipes/anthropic.ts
+++ b/src/core/ai/recipes/anthropic.ts
@@ -17,14 +17,14 @@ export const anthropic: Recipe = {
   touchpoints: {
     // No embedding model available.
     expansion: {
-      models: ['claude-haiku-4-5-20251001', 'claude-sonnet-4-6-20250929'],
+      models: ['claude-haiku-4-5-20251001', 'claude-sonnet-4-6'],
       cost_per_1m_tokens_usd: 0.25,
       price_last_verified: '2026-04-20',
     },
     chat: {
       models: [
         'claude-opus-4-7',
-        'claude-sonnet-4-6-20250929',
+        'claude-sonnet-4-6',
         'claude-haiku-4-5-20251001',
       ],
       supports_tools: true,
@@ -36,9 +36,10 @@ export const anthropic: Recipe = {
       price_last_verified: '2026-04-20',
     },
   },
-  // Friendly undated aliases (Codex F-OV-5).
+  // Friendly undated aliases.
+  // Starting with Claude 4.6, Anthropic API IDs are dateless and pinned.
+  // Only pre-4.6 models need date-suffixed aliases.
   aliases: {
-    'claude-sonnet-4-6': 'claude-sonnet-4-6-20250929',
     'claude-haiku-4-5': 'claude-haiku-4-5-20251001',
   },
   setup_hint: 'Get an API key at https://console.anthropic.com/settings/keys, then `export ANTHROPIC_API_KEY=...`',

--- a/test/anthropic-model-ids.test.ts
+++ b/test/anthropic-model-ids.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'bun:test';
+import { anthropic } from '../src/core/ai/recipes/anthropic.ts';
+
+describe('Anthropic recipe model IDs', () => {
+  it('chat models use canonical Anthropic API IDs (no phantom dates)', () => {
+    const chatModels = anthropic.touchpoints?.chat?.models ?? [];
+    // claude-sonnet-4-6 is the correct API ID per Anthropic docs.
+    // The dated form claude-sonnet-4-6-20250929 returns 404 on the API.
+    expect(chatModels).toContain('claude-sonnet-4-6');
+    expect(chatModels).not.toContain('claude-sonnet-4-6-20250929');
+  });
+
+  it('expansion models use canonical IDs', () => {
+    const expansionModels = anthropic.touchpoints?.expansion?.models ?? [];
+    expect(expansionModels).toContain('claude-sonnet-4-6');
+    expect(expansionModels).not.toContain('claude-sonnet-4-6-20250929');
+  });
+
+  it('does not alias dateless 4.6+ models (they ARE the canonical ID)', () => {
+    // Starting with Claude 4.6, Anthropic API IDs are dateless and pinned.
+    // No alias needed — the dateless form IS the model ID.
+    expect(anthropic.aliases?.['claude-sonnet-4-6']).toBeUndefined();
+    expect(anthropic.aliases?.['claude-opus-4-7']).toBeUndefined();
+  });
+
+  it('pre-4.6 models still have date-based aliases', () => {
+    // Haiku 4.5 predates the dateless convention, keeps its alias
+    expect(anthropic.aliases?.['claude-haiku-4-5']).toBe('claude-haiku-4-5-20251001');
+  });
+
+  it('all listed models follow naming conventions', () => {
+    const allModels = [
+      ...(anthropic.touchpoints?.chat?.models ?? []),
+      ...(anthropic.touchpoints?.expansion?.models ?? []),
+    ];
+    for (const m of allModels) {
+      // No model should contain a date that doesn't exist on the Anthropic API
+      expect(m).not.toMatch(/claude-sonnet-4-6-\d{8}/);
+    }
+  });
+});


### PR DESCRIPTION
Superseded by #844 which absorbed this fix and expanded it into a full tier routing system + regression tests. Closing.