### PR TITLE
fix(mcp): extract_facts entity_hints add items:string for OpenAI strict validator

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2434,7 +2434,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },


### PR DESCRIPTION
## Problem

OpenAI's strict tool-schema validator (used by `gpt-5.5` / `gpt-5-codex` and any client that runs `tools/list` through the official validator) rejects the entire MCP tool list with:

```
LLM request rejected: Invalid schema for function 'gbrain__extract_facts':
In context=('properties', 'entity_hints'), array schema missing items.
```

When this fires, **every** gbrain MCP tool becomes unavailable to that agent — not just `extract_facts` — because the validator rejects the entire tool list when any single tool def is invalid. Per JSON Schema (and OpenAI's strict mode), an `array` MUST declare `items`.

## Root cause

`src/core/operations.ts` declares `entity_hints` as `{ type: 'array', ... }` with no `items` field. The handler already treats the value as `string[]`:

```ts
entityHints: Array.isArray(p.entity_hints) ? (p.entity_hints as string[]) : undefined,
```

so `items: { type: 'string' }` matches the implementation. `ParamDef` already supports `items?: ParamDef`, and `pages_updated` (same file) already declares it correctly:

```ts
pages_updated: { type: 'array', required: true, items: { type: 'string' } },
```

`buildToolDefs` in `src/mcp/tool-defs.ts` already passes `items` through to the emitted JSON schema when present, so the fix is purely at the operation declaration site.

## Patch

```diff
-    entity_hints: { type: 'array', description: '...' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: '...' },
```

## Scope check

I scanned `src/core/operations.ts` and `src/mcp/` for `type: 'array'` props missing `items:` and found only this one in MCP-exposed tool definitions. The only other hit (`candidates: { type: 'array' }` in `src/core/resolvers/builtin/x-api/handle-to-tweet.ts:102`) is an internal resolver `outputSchema` that doesn't go through `buildToolDefs`, so it doesn't reach the OpenAI tool validator. Left it out of this PR to keep scope tight — happy to send a follow-up if you'd like a clean sweep.

## Verified

I patched our pinned install (commit `9c60b3a`, v0.31.3) on a live pod, restarted the MCP server, ran `tools/list`, and confirmed:
- The emitted `extract_facts.inputSchema.properties.entity_hints` now has `"items": {"type": "string"}`.
- All 61 gbrain tools pass a recursive "every `type: array` has `items`" check.
- The OpenAI strict-validator rejection no longer reproduces — agents can use gbrain tools again.

Closes #831

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->