### PR TITLE
fix(ai): claude-sonnet-4-6 alias maps to non-existent dated model

### DIFF
--- a/src/core/ai/recipes/anthropic.ts
+++ b/src/core/ai/recipes/anthropic.ts
@@ -17,14 +17,14 @@ export const anthropic: Recipe = {
   touchpoints: {
     // No embedding model available.
     expansion: {
-      models: ['claude-haiku-4-5-20251001', 'claude-sonnet-4-6-20250929'],
+      models: ['claude-haiku-4-5-20251001', 'claude-sonnet-4-6'],
       cost_per_1m_tokens_usd: 0.25,
       price_last_verified: '2026-04-20',
     },
     chat: {
       models: [
         'claude-opus-4-7',
-        'claude-sonnet-4-6-20250929',
+        'claude-sonnet-4-6',
         'claude-haiku-4-5-20251001',
       ],
       supports_tools: true,
@@ -38,7 +38,6 @@ export const anthropic: Recipe = {
   },
   // Friendly undated aliases (Codex F-OV-5).
   aliases: {
-    'claude-sonnet-4-6': 'claude-sonnet-4-6-20250929',
     'claude-haiku-4-5': 'claude-haiku-4-5-20251001',
   },
   setup_hint: 'Get an API key at https://console.anthropic.com/settings/keys, then `export ANTHROPIC_API_KEY=...`',


### PR DESCRIPTION
## What

The anthropic recipe alias `claude-sonnet-4-6` → `claude-sonnet-4-6-20250929` points at a model ID that does not exist at the Anthropic API. Direct curl confirms:

| Model ID                          | Anthropic API response       |
|-----------------------------------|------------------------------|
| `claude-sonnet-4-6`               | 200 OK                       |
| `claude-sonnet-4-6-20250929`      | 404 not_found_error          |
| `claude-sonnet-4-5-20250929`      | 200 OK                       |
| `claude-haiku-4-5-20251001`       | 200 OK                       |

## Impact

Most visible for v0.31 facts extraction. `getFactsExtractionModel()` defaults to `'anthropic:claude-sonnet-4-6-20250929'` (`src/core/facts/extract.ts:53`). The gateway recipe rewrites the friendly alias to the dated form, the API rejects it, and the gateway swallows the error. End result: `gbrain call extract_facts` returns `{inserted: 0}` on every input for users who don't override the model.

This affects every v0.31+ install on the default model setting. Visible to the user as: "hot memory feature shipped but facts table never gets rows."

Same alias path also affects `gbrain providers test --touchpoint chat` which surfaces the 404 as `config error: model: claude-sonnet-4-6-20250929`.

## Fix

Replace the dated form with the working alias throughout the recipe (3 occurrences in `expansion.models`, `chat.models`, and as the alias target) and drop the now-redundant alias entry. The haiku alias stays unchanged because its dated form is valid at the API.

## Verification

Local, against v0.31.10:

- Before: `gbrain providers test --touchpoint chat` → `not_found_error`
- After: 200 OK
- Before: `gbrain call extract_facts '{turn_text:"..."}'` → `{inserted: 0}`
- After: `{inserted: 3, fact_ids: [1,2,3]}` with correct kinds (`event`, `commitment`, `preference`) and entity resolution on a one-paragraph input

## Note

No unit test added — the model IDs in this file are config values and the verification is "does Anthropic accept this string", which a unit test can't cleanly assert without hitting the live API. A `providers test` E2E in CI with a fake `ANTHROPIC_API_KEY=test` would catch the 404 path generically but is out of scope for this fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->