### PR TITLE
fix(import-file): skip empty code files so reindex-code stops failing on them

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -485,6 +485,15 @@ export async function importCodeFile(
   if (byteLength > MAX_FILE_SIZE) {
     return { slug, status: 'skipped', chunks: 0, error: `Code file too large (${byteLength} bytes)` };
   }
+  // Skip empty code files. With zero bytes there's nothing to chunk and no
+  // compiled_truth to derive, but without this guard the page row is still
+  // written with NULL compiled_truth — which then fails every subsequent
+  // `reindex-code` pass with `missing compiled_truth`. Empty files are
+  // legitimate in real repos (stub/placeholder files committed during
+  // refactors); skipping mirrors the symmetric MAX_FILE_SIZE branch above.
+  if (byteLength === 0) {
+    return { slug, status: 'skipped', chunks: 0, error: 'empty code file' };
+  }
 
   // Hash for idempotency. CHUNKER_VERSION is folded in so chunker shape
   // changes across releases force clean re-chunks without sync --force.

--- a/test/import-empty-code-file.test.ts
+++ b/test/import-empty-code-file.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression test for `importCodeFile` skipping empty (0-byte) code files.
+ *
+ * Before this guard, an empty file produced a page row with NULL
+ * compiled_truth, which then failed every subsequent `gbrain reindex-code`
+ * pass with `missing compiled_truth`. Empty files are legitimate in real
+ * repos (stub/placeholder files committed during refactors); the importer
+ * should skip them cleanly the same way it skips files over MAX_FILE_SIZE.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { importCodeFile } from '../src/core/import-file.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+describe('importCodeFile — empty file guard', () => {
+  test('zero-byte content is skipped, not inserted', async () => {
+    const result = await importCodeFile(engine, 'src/empty.ts', '');
+
+    expect(result.status).toBe('skipped');
+    expect(result.chunks).toBe(0);
+    expect(result.error).toBe('empty code file');
+
+    // The skip must short-circuit before any page row is written, otherwise
+    // reindex-code will still trip on the NULL compiled_truth.
+    const page = await engine.getPage(result.slug);
+    expect(page).toBeNull();
+  });
+
+  test('non-empty content still imports normally', async () => {
+    const result = await importCodeFile(
+      engine,
+      'src/non-empty.ts',
+      'export const x = 1;\n',
+    );
+
+    expect(result.status).toBe('imported');
+    expect(result.chunks).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

`importCodeFile` had no guard for zero-byte content. An empty file got a page row inserted with NULL `compiled_truth`, then every subsequent `gbrain reindex-code` pass failed on that slug with `missing compiled_truth` (the early-return at `src/commands/reindex-code.ts:193-196`).

Empty files are legitimate in real repos — stub/placeholder files committed during refactors (e.g., a Kotlin class temporarily emptied while the API surface is being reworked). Skipping them at import is the same shape as the existing `MAX_FILE_SIZE` branch directly above the new code, so the diff is one symmetric `if`.

## Repro

Before this fix on an Android KMP repo with three empty tracked code files:

```
$ gbrain reindex-code --source gstack-code-bile-... --yes
reindex-code: 0 reindexed, 1781 skipped, 3 failed (1784 total code pages).

3 failure(s):
  games-head-to-head-...-playerandchallengerprofile-kt: missing compiled_truth
  games-head-to-head-...-profilewithscoreandname-kt: missing compiled_truth
  ios-jeopardycoresample-logstore-swift: missing compiled_truth
```

After this fix + one-time `gbrain purge-deleted --older-than-hours 0` to clear the stuck rows:

```
$ gbrain reindex-code --source gstack-code-bile-... --yes
reindex-code: 0 reindexed, 1781 skipped, 0 failed (1781 total code pages).
```

## Test

`test/import-empty-code-file.test.ts` adds two cases against PGLite:

- Empty content → `status: 'skipped'`, `error: 'empty code file'`, and `getPage(slug)` returns `null`. The short-circuit must happen before any page row is written, otherwise reindex-code still trips on NULL `compiled_truth`.
- Non-empty content still imports normally.

Follows the canonical PGLite test pattern from `CONTRIBUTING.md` (single `beforeAll(connect+initSchema)` / `afterAll(disconnect)`, no `process.env` mutation, no `mock.module`).

## Test plan

- [x] `bun test test/import-empty-code-file.test.ts` — 2/2 pass
- [x] `bun test test/incremental-chunking.test.ts test/reindex-code.test.ts test/sync-failures.test.ts test/code-def-refs.test.ts` — 59/59 pass (no regression in `importCodeFile` callers)
- [x] `bun run typecheck` — clean
- [x] `bun run check:wasm` / `check:admin-build` / `check:cli-exec` — OK
- [x] `check:test-isolation` on the new test — passes R1-R4
- [ ] Note: `bun run verify` fails on a pre-existing isolation violation in `test/migration-orchestrator-v0_31_0.test.ts` (R1, `process.env` mutation). Not part of this PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->