### PR TITLE
fix: move --no-recurse-submodules after subcommand in GIT_SSRF_FLAGS

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -398,11 +398,11 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       console.error(`[gbrain phase] sync.git_pull done ${Date.now() - _t0}ms`);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
-      console.error(`[gbrain phase] sync.git_pull error ${Date.now() - _t0}ms (${msg.slice(0, 80)})`);
+      console.error(`[gbrain phase] sync.git_pull error ${Date.now() - _t0}ms (${msg.slice(0, 300)})`);
       if (msg.includes('non-fast-forward') || msg.includes('diverged')) {
         console.error(`Warning: git pull failed (remote diverged). Syncing from local state.`);
       } else {
-        console.error(`Warning: git pull failed: ${msg.slice(0, 100)}`);
+        console.error(`Warning: git pull failed: ${msg.slice(0, 300)}`);
       }
     }
   }

--- a/src/core/git-remote.ts
+++ b/src/core/git-remote.ts
@@ -20,16 +20,22 @@ import { join } from 'path';
 import { isInternalUrl } from './url-safety.ts';
 
 /**
- * SSRF-defensive flag set. Used by both cloneRepo and pullRepo.
+ * SSRF-defensive flag sets. Used by both cloneRepo and pullRepo.
  * - http.followRedirects=false: closes DNS rebinding via redirect chains
  * - protocol.file.allow=never: no local-file URLs (defense in depth)
  * - protocol.ext.allow=never: no external helpers (`git-remote-foo`)
- * - --no-recurse-submodules: .gitmodules cannot become a second fetch surface
+ *
+ * --no-recurse-submodules is split into GIT_SSRF_SUBCMD_FLAGS because it
+ * is only valid after a subcommand (clone/pull/fetch), not as a top-level
+ * git flag. Mixing it with -c flags causes "unknown option" (exit 129).
  */
 export const GIT_SSRF_FLAGS = [
   '-c', 'http.followRedirects=false',
   '-c', 'protocol.file.allow=never',
   '-c', 'protocol.ext.allow=never',
+] as const;
+
+export const GIT_SSRF_SUBCMD_FLAGS = [
   '--no-recurse-submodules',
 ] as const;
 
@@ -153,7 +159,7 @@ export function cloneRepo(url: string, destDir: string, opts: CloneOpts = {}): v
     }
   }
 
-  const args: string[] = [...GIT_SSRF_FLAGS, 'clone'];
+  const args: string[] = [...GIT_SSRF_FLAGS, 'clone', ...GIT_SSRF_SUBCMD_FLAGS];
   if (opts.depth !== 0) {
     args.push(`--depth=${opts.depth ?? 1}`);
   }
@@ -179,7 +185,7 @@ export function cloneRepo(url: string, destDir: string, opts: CloneOpts = {}): v
 
 /** Pull a repo with --ff-only and the same SSRF-defensive flags as cloneRepo. */
 export function pullRepo(repoPath: string, opts: { timeoutMs?: number } = {}): void {
-  const args: string[] = ['-C', repoPath, ...GIT_SSRF_FLAGS, 'pull', '--ff-only'];
+  const args: string[] = ['-C', repoPath, ...GIT_SSRF_FLAGS, 'pull', '--ff-only', ...GIT_SSRF_SUBCMD_FLAGS];
   try {
     execFileSync('git', args, {
       stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary

Fixes #813 — every `gbrain sync` silently no-ops the git pull phase because `--no-recurse-submodules` is placed before the subcommand in `GIT_SSRF_FLAGS`.

## Root Cause

`GIT_SSRF_FLAGS` mixes top-level `-c` flags with the subcommand-level `--no-recurse-submodules` flag in a single array. Both `cloneRepo` and `pullRepo` spread this array before the subcommand, producing:

```
git -C <repo> -c http.followRedirects=false ... --no-recurse-submodules pull --ff-only
```

Git rejects this with `unknown option: --no-recurse-submodules` (exit 129).

The error is masked at runtime by 80-char truncation in `src/commands/sync.ts`, so sync reports `Already up to date` while never actually pulling.

## Fix

1. Split `GIT_SSRF_FLAGS` into `GIT_SSRF_FLAGS` (`-c` flags only) and new `GIT_SSRF_SUBCMD_FLAGS` (`--no-recurse-submodules`)
2. Append subcommand flags after the subcommand in both `cloneRepo` and `pullRepo`
3. Bump error message truncation in `sync.ts` from 80/100 to 300 chars so underlying git errors are visible

## Testing

Manual verification of the corrected argument order:

```bash
# Before (broken): --no-recurse-submodules before pull
git -C <repo> -c http.followRedirects=false -c protocol.file.allow=never   -c protocol.ext.allow=never --no-recurse-submodules pull --ff-only
# → error: unknown option: --no-recurse-submodules (exit 129)

# After (fixed): --no-recurse-submodules after pull
git -C <repo> -c http.followRedirects=false -c protocol.file.allow=never   -c protocol.ext.allow=never pull --ff-only --no-recurse-submodules
# → Already up to date. (works)
```

## Files Changed

- `src/core/git-remote.ts` — Split flag arrays, update cloneRepo + pullRepo call sites
- `src/commands/sync.ts` — Increase error message truncation from 80/100 to 300 chars

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->