### PR TITLE
Fix git submodule flag placement

### DIFF
--- a/src/core/git-remote.ts
+++ b/src/core/git-remote.ts
@@ -6,8 +6,9 @@
  * IPv6 loopback, IPv4-mapped IPv6, metadata hostnames, hex/octal bypass,
  * and CGNAT 100.64/10).
  *
- * cloneRepo and pullRepo both spread GIT_SSRF_FLAGS so a future flag added
- * to one path lands on both — single source of truth.
+ * cloneRepo and pullRepo both spread GIT_SSRF_FLAGS and
+ * GIT_SSRF_SUBCOMMAND_FLAGS so a future flag added to one path lands on both
+ * — single source of truth.
  *
  * Tailscale 100.64/10 trips the integrations.ts allowlist (CGNAT line in
  * url-safety.ts isPrivateIpv4). For self-hosted internal git servers
@@ -20,16 +21,23 @@ import { join } from 'path';
 import { isInternalUrl } from './url-safety.ts';
 
 /**
- * SSRF-defensive flag set. Used by both cloneRepo and pullRepo.
+ * SSRF-defensive top-level git config flag set. Used by both cloneRepo and pullRepo.
  * - http.followRedirects=false: closes DNS rebinding via redirect chains
  * - protocol.file.allow=never: no local-file URLs (defense in depth)
  * - protocol.ext.allow=never: no external helpers (`git-remote-foo`)
- * - --no-recurse-submodules: .gitmodules cannot become a second fetch surface
  */
 export const GIT_SSRF_FLAGS = [
   '-c', 'http.followRedirects=false',
   '-c', 'protocol.file.allow=never',
   '-c', 'protocol.ext.allow=never',
+] as const;
+
+/**
+ * SSRF-defensive git subcommand flags. These must appear after clone/pull,
+ * because git does not accept --no-recurse-submodules as a top-level option.
+ * - --no-recurse-submodules: .gitmodules cannot become a second fetch surface
+ */
+export const GIT_SSRF_SUBCOMMAND_FLAGS = [
   '--no-recurse-submodules',
 ] as const;
 
@@ -153,7 +161,7 @@ export function cloneRepo(url: string, destDir: string, opts: CloneOpts = {}): v
     }
   }
 
-  const args: string[] = [...GIT_SSRF_FLAGS, 'clone'];
+  const args: string[] = [...GIT_SSRF_FLAGS, 'clone', ...GIT_SSRF_SUBCOMMAND_FLAGS];
   if (opts.depth !== 0) {
     args.push(`--depth=${opts.depth ?? 1}`);
   }
@@ -179,7 +187,14 @@ export function cloneRepo(url: string, destDir: string, opts: CloneOpts = {}): v
 
 /** Pull a repo with --ff-only and the same SSRF-defensive flags as cloneRepo. */
 export function pullRepo(repoPath: string, opts: { timeoutMs?: number } = {}): void {
-  const args: string[] = ['-C', repoPath, ...GIT_SSRF_FLAGS, 'pull', '--ff-only'];
+  const args: string[] = [
+    '-C',
+    repoPath,
+    ...GIT_SSRF_FLAGS,
+    'pull',
+    '--ff-only',
+    ...GIT_SSRF_SUBCOMMAND_FLAGS,
+  ];
   try {
     execFileSync('git', args, {
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/test/git-remote.test.ts
+++ b/test/git-remote.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   GIT_SSRF_FLAGS,
+  GIT_SSRF_SUBCOMMAND_FLAGS,
   parseRemoteUrl,
   RemoteUrlError,
   cloneRepo,
@@ -81,11 +82,16 @@ const fakePath = (): string => `${FAKE_GIT_DIR}:${process.env.PATH ?? ''}`;
 // ---------------------------------------------------------------------------
 
 describe('GIT_SSRF_FLAGS', () => {
-  test('exact shape — codex SSRF lockdown', () => {
+  test('exact top-level git config shape — codex SSRF lockdown', () => {
     expect([...GIT_SSRF_FLAGS]).toEqual([
       '-c', 'http.followRedirects=false',
       '-c', 'protocol.file.allow=never',
       '-c', 'protocol.ext.allow=never',
+    ]);
+  });
+
+  test('exact subcommand flag shape', () => {
+    expect([...GIT_SSRF_SUBCOMMAND_FLAGS]).toEqual([
       '--no-recurse-submodules',
     ]);
   });
@@ -229,9 +235,13 @@ describe('cloneRepo', () => {
     const calls = readArgvLog();
     expect(calls.length).toBe(1);
     const argv = calls[0];
-    // Pin the SSRF flags before the 'clone' verb (codex Q2 invariant).
+    // Pin top-level config before the 'clone' verb and subcommand flags after it.
     expect(argv.slice(0, GIT_SSRF_FLAGS.length)).toEqual([...GIT_SSRF_FLAGS]);
-    expect(argv).toContain('clone');
+    const cloneIdx = argv.indexOf('clone');
+    expect(cloneIdx).toBe(GIT_SSRF_FLAGS.length);
+    expect(argv.slice(cloneIdx + 1, cloneIdx + 1 + GIT_SSRF_SUBCOMMAND_FLAGS.length)).toEqual([
+      ...GIT_SSRF_SUBCOMMAND_FLAGS,
+    ]);
     expect(argv).toContain('--depth=1');
     expect(argv).toContain('https://example.com/repo');
     expect(argv[argv.length - 1]).toBe(dest);
@@ -307,8 +317,12 @@ describe('pullRepo', () => {
     expect(argv[0]).toBe('-C');
     expect(argv[1]).toBe(repo);
     expect(argv.slice(2, 2 + GIT_SSRF_FLAGS.length)).toEqual([...GIT_SSRF_FLAGS]);
-    expect(argv).toContain('pull');
-    expect(argv).toContain('--ff-only');
+    const pullIdx = argv.indexOf('pull');
+    expect(pullIdx).toBe(2 + GIT_SSRF_FLAGS.length);
+    expect(argv[pullIdx + 1]).toBe('--ff-only');
+    expect(argv.slice(pullIdx + 2, pullIdx + 2 + GIT_SSRF_SUBCOMMAND_FLAGS.length)).toEqual([
+      ...GIT_SSRF_SUBCOMMAND_FLAGS,
+    ]);
     rmSync(repo, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
Fixes #813.

## Summary
- Split SSRF hardening into top-level git config flags and git subcommand flags.
- Keep `-c http.followRedirects=false`, `protocol.file.allow=never`, and `protocol.ext.allow=never` before `clone` / `pull`.
- Move `--no-recurse-submodules` after the `clone` / `pull` subcommand, where git accepts it.
- Add regression assertions for fake-git argv shape for both `cloneRepo` and `pullRepo`.

## Validation
- `bun test test/git-remote.test.ts` — 37 pass, 0 fail
- `git diff --check HEAD~1..HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
