### PR TITLE
Fall back to npm for check-update

### DIFF
--- a/src/commands/check-update.ts
+++ b/src/commands/check-update.ts
@@ -40,22 +40,38 @@ function upgradeCommandForMethod(method: string): string {
   }
 }
 
-async function fetchLatestRelease(): Promise<{ tag: string; published_at: string; url: string } | null> {
+export async function fetchLatestRelease(fetchImpl: typeof fetch = fetch): Promise<{ tag: string; published_at: string; url: string } | null> {
   try {
-    const res = await fetch('https://api.github.com/repos/garrytan/gbrain/releases/latest', {
+    const res = await fetchImpl('https://api.github.com/repos/garrytan/gbrain/releases/latest', {
+      headers: { 'User-Agent': `gbrain/${VERSION}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (res.ok) {
+      const data = await res.json() as any;
+      if (data.tag_name) {
+        return {
+          tag: data.tag_name,
+          published_at: data.published_at || '',
+          url: data.html_url || '',
+        };
+      }
+    }
+  } catch { /* fall through to npm registry */ }
+
+  try {
+    const res = await fetchImpl('https://registry.npmjs.org/gbrain/latest', {
       headers: { 'User-Agent': `gbrain/${VERSION}` },
       signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) return null;
     const data = await res.json() as any;
+    if (!data.version) return null;
     return {
-      tag: data.tag_name || '',
-      published_at: data.published_at || '',
-      url: data.html_url || '',
+      tag: data.version,
+      published_at: data.time || '',
+      url: `https://www.npmjs.com/package/gbrain/v/${data.version}`,
     };
-  } catch {
-    return null;
-  }
+  } catch { return null; }
 }
 
 async function fetchChangelog(currentVersion: string, latestVersion: string): Promise<string> {
@@ -140,10 +156,10 @@ export async function runCheckUpdate(args: string[]) {
         release_url: '',
         changelog_diff: '',
         published_at: '',
-        error: 'no_releases',
+        error: 'api_unavailable',
       }, null, 2));
     } else {
-      console.log(`GBrain ${VERSION} — could not check for updates (no releases found or network unavailable).`);
+      console.log(`GBrain ${VERSION} — could not check for updates (GitHub releases and npm registry unavailable).`);
     }
     return;
   }

--- a/test/check-update.test.ts
+++ b/test/check-update.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { parseSemver, isMinorOrMajorBump, extractChangelogBetween } from '../src/commands/check-update.ts';
+import { parseSemver, isMinorOrMajorBump, extractChangelogBetween, fetchLatestRelease } from '../src/commands/check-update.ts';
 
 describe('parseSemver', () => {
   test('parses standard version', () => {
@@ -118,6 +118,32 @@ describe('extractChangelogBetween', () => {
     const result = extractChangelogBetween(crossMajor, '1.2.0', '2.0.0');
     expect(result).toContain('Major 2');
     expect(result).not.toContain('Minor 5');
+  });
+});
+
+describe('fetchLatestRelease', () => {
+  test('falls back to npm latest metadata when GitHub has no releases', async () => {
+    const seen: string[] = [];
+    const fakeFetch = async (url: string | URL | Request) => {
+      const href = String(url);
+      seen.push(href);
+      if (href.includes('api.github.com')) {
+        return new Response('not found', { status: 404 });
+      }
+      if (href.includes('registry.npmjs.org')) {
+        return Response.json({ version: '0.31.6' });
+      }
+      throw new Error(`unexpected url ${href}`);
+    };
+
+    const release = await fetchLatestRelease(fakeFetch as typeof fetch);
+    expect(seen.some(url => url.includes('api.github.com'))).toBe(true);
+    expect(seen.some(url => url.includes('registry.npmjs.org'))).toBe(true);
+    expect(release).toEqual({
+      tag: '0.31.6',
+      published_at: '',
+      url: 'https://www.npmjs.com/package/gbrain/v/0.31.6',
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #486.

## Summary
- Fall back to npm latest metadata when GitHub releases has no latest release.
- Return the npm package version URL as `release_url` for npm-sourced results.
- Report `api_unavailable` when both GitHub and npm checks fail.

## Validation
- `bun test test/check-update.test.ts` — 21 pass, 0 fail
- `bun run typecheck`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
