### PR TITLE
Support put --file and reject unknown op flags

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -446,17 +446,52 @@ function parseOpArgs(op: Operation, args: string[]): Record<string, unknown> {
   const params: Record<string, unknown> = {};
   const positional = op.cliHints?.positional || [];
   let posIdx = 0;
+  const cliName = op.cliHints?.name || op.name;
+  const MAX_STDIN = 5_000_000; // 5MB
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg.startsWith('--')) {
       const key = arg.slice(2).replace(/-/g, '_');
+      if (op.name === 'put_page' && key === 'file') {
+        if (i + 1 >= args.length || args[i + 1].startsWith('--')) {
+          console.error('Error: --file requires a path.');
+          process.exit(1);
+        }
+        if (params.content !== undefined) {
+          console.error('Error: use only one of --file, --content, or stdin for gbrain put content.');
+          process.exit(1);
+        }
+        const content = readFileSync(args[++i], 'utf-8');
+        if (Buffer.byteLength(content, 'utf-8') > MAX_STDIN) {
+          console.error(`Error: file content exceeds ${MAX_STDIN} bytes. Split into smaller inputs.`);
+          process.exit(1);
+        }
+        params.content = content;
+        continue;
+      }
+
       const paramDef = op.params[key];
+      if (!paramDef) {
+        if (op.mutating && key === 'dry_run') {
+          params.dry_run = true;
+          continue;
+        }
+        console.error(`Unknown option for gbrain ${cliName}: ${arg}`);
+        process.exit(1);
+      }
       if (paramDef?.type === 'boolean') {
         params[key] = true;
       } else if (i + 1 < args.length) {
+        if (op.name === 'put_page' && key === 'content' && params.content !== undefined) {
+          console.error('Error: use only one of --file, --content, or stdin for gbrain put content.');
+          process.exit(1);
+        }
         params[key] = args[++i];
         if (paramDef?.type === 'number') params[key] = Number(params[key]);
+      } else {
+        console.error(`Error: ${arg} requires a value.`);
+        process.exit(1);
       }
     } else if (posIdx < positional.length) {
       const key = positional[posIdx++];
@@ -468,7 +503,6 @@ function parseOpArgs(op: Operation, args: string[]): Record<string, unknown> {
   // Read stdin for content params
   if (op.cliHints?.stdin && !params[op.cliHints.stdin] && !process.stdin.isTTY) {
     const stdinContent = readFileSync('/dev/stdin', 'utf-8');
-    const MAX_STDIN = 5_000_000; // 5MB
     if (Buffer.byteLength(stdinContent, 'utf-8') > MAX_STDIN) {
       console.error(`Error: stdin content exceeds ${MAX_STDIN} bytes. Split into smaller inputs.`);
       process.exit(1);
@@ -1294,6 +1328,9 @@ function printOpHelp(op: Operation) {
       const req = def.required ? ' (required)' : '';
       const prefix = isPos ? `  <${key}>` : `  --${key.replace(/_/g, '-')}`;
       console.log(`${prefix.padEnd(28)} ${def.description || ''}${req}`);
+    }
+    if (op.name === 'put_page') {
+      console.log(`${'  --file <path>'.padEnd(28)} Read markdown content from a file instead of --content or stdin`);
     }
   }
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -108,6 +108,85 @@ describe('CLI dispatch integration', () => {
     const exitCode = await proc.exited;
     expect(stdout).toContain('Usage: gbrain get');
     expect(exitCode).toBe(0);
+  });
+
+  test('put --help documents --file input', async () => {
+    const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', 'put', '--help'], {
+      cwd: repoRoot,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    expect(stdout).toContain('Usage: gbrain put');
+    expect(stdout).toContain('--file <path>');
+    expect(exitCode).toBe(0);
+  });
+
+  test('unknown shared-op flags fail before DB connection', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-cli-unknown-flag-'));
+    try {
+      const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', 'get', 'people/alice', '--bogus'], {
+        cwd: repoRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: isolatedEnv(home),
+      });
+      const stderr = await new Response(proc.stderr).text();
+      const exitCode = await proc.exited;
+      expect(stderr).toContain('Unknown option for gbrain get: --bogus');
+      expect(stderr).not.toContain('No brain configured');
+      expect(exitCode).toBe(1);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  test('put --file writes markdown content from the file', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-cli-put-file-'));
+    const pagePath = join(home, 'page.md');
+    writeFileSync(pagePath, `---
+type: concept
+title: File Flag Page
+tags: [cli-file]
+---
+
+Body loaded from --file.
+`);
+    try {
+      const init = Bun.spawn(['bun', 'run', 'src/cli.ts', 'init'], {
+        cwd: repoRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: isolatedEnv(home),
+      });
+      expect(await init.exited).toBe(0);
+
+      const put = Bun.spawn(['bun', 'run', 'src/cli.ts', 'put', 'concepts/file-flag-page', '--file', pagePath], {
+        cwd: repoRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: isolatedEnv(home),
+      });
+      const putStdout = await new Response(put.stdout).text();
+      const putStderr = await new Response(put.stderr).text();
+      expect(await put.exited).toBe(0);
+      expect(putStderr).not.toContain('Error');
+      expect(putStdout).toContain('concepts/file-flag-page');
+
+      const get = Bun.spawn(['bun', 'run', 'src/cli.ts', 'get', 'concepts/file-flag-page'], {
+        cwd: repoRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: isolatedEnv(home),
+      });
+      const getStdout = await new Response(get.stdout).text();
+      expect(await get.exited).toBe(0);
+      expect(getStdout).toContain('File Flag Page');
+      expect(getStdout).toContain('Body loaded from --file.');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   test('upgrade --help prints usage without running upgrade', async () => {


### PR DESCRIPTION
Fixes #380.

## Summary
- Add `gbrain put <slug> --file <path>` as a real file-input path for markdown content.
- Reject unknown shared-operation flags before opening a DB connection.
- Document `--file <path>` in `gbrain put --help`.

## Validation
- `bun test test/cli.test.ts`
- `bun run typecheck`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
