### PR TITLE
fix(mcp): seal source-isolation leak on read path (P0)

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -926,9 +926,25 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
       // ToolResult and we read isError + _meta to pick the right branch.
       const tokenAllowList = (authInfo as AuthInfo & { takesHoldersAllowList?: string[] }).takesHoldersAllowList
         ?? ['world'];
-      const tokenSourceId = (authInfo as AuthInfo & { sourceId?: string }).sourceId
-        ?? process.env.GBRAIN_SOURCE
-        ?? 'default';
+      // v0.31.4 fix/mcp-source-isolation-read-side:
+      //   authInfo.sourceId is populated from oauth_clients.source_id (migration v47).
+      //
+      //   - SET   → strict source isolation. Engine WHERE-filters reads on
+      //             pages.source_id; put_page rejects cross-source writes.
+      //   - NULL  → federated/super-reader. No WHERE filter, callers see every
+      //             source. This matches Robin's stdio CLI (no token = no scope)
+      //             and gives admin/Robin-class OAuth clients full federated reach.
+      //
+      //   Why NULL = federated (not 'default'):
+      //   Pre-v0.31.4, EVERY OAuth client silently collapsed onto source 'default'
+      //   because authInfo carried no real scope and the engine ignored opts.sourceId.
+      //   That was a bug, not a feature. The fix wires real auth-derived scoping
+      //   when set, and gives unscoped clients the same federated behavior as the
+      //   unauthenticated stdio path — no silent partial-view footgun.
+      //
+      //   `GBRAIN_SOURCE` env var is a deployment-level escape hatch for
+      //   unauthenticated callers only — it never overrides a populated token claim.
+      const tokenSourceId = authInfo.sourceId ?? undefined;
 
       let toolResult: Awaited<ReturnType<typeof dispatchToolCall>>;
       try {

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -485,7 +485,11 @@ export interface BrainEngine {
    * `filters.includeDeleted: true` to surface them.
    */
   listPages(filters?: PageFilters): Promise<Page[]>;
-  resolveSlugs(partial: string): Promise<string[]>;
+  /**
+   * v0.31.4: optional `sourceId` scopes both exact and fuzzy matching to a
+   * single source. Unset = federated (matches local CLI + Robin super-reader).
+   */
+  resolveSlugs(partial: string, opts?: { sourceId?: string }): Promise<string[]>;
   /**
    * Returns the slug of every page in the brain. Used by batch commands as a
    * mutation-immune iteration source (alternative to listPages OFFSET pagination,
@@ -615,18 +619,25 @@ export interface BrainEngine {
     dirPrefix?: string,
     minSimilarity?: number,
   ): Promise<{ slug: string; similarity: number } | null>;
-  traverseGraph(slug: string, depth?: number): Promise<GraphNode[]>;
+  /**
+   * v0.31.4 (P0/leak-2026-05-11): `opts.sourceId` constrains visited nodes to a
+   * single source. When omitted (federated/super-reader), all sources visible.
+   * MCP-bound callers MUST pass `{ sourceId: ctx.sourceId }` so cross-source
+   * pages can't be discovered via graph metadata even when get_page denies them.
+   */
+  traverseGraph(slug: string, depth?: number, opts?: { sourceId?: string }): Promise<GraphNode[]>;
   /**
    * Edge-based graph traversal with optional type and direction filters.
    * Returns a list of edges (GraphPath[]) instead of nodes. Supports:
    * - linkType: per-edge filter, only follows matching edges (per-edge semantics)
    * - direction: 'in' (follow to->from), 'out' (follow from->to), 'both'
    * - depth: max depth from root (default 5)
+   * - sourceId: v0.31.4, see traverseGraph note above
    * Uses cycle prevention (visited array in recursive CTE).
    */
   traversePaths(
     slug: string,
-    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both' },
+    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both'; sourceId?: string },
   ): Promise<GraphPath[]>;
   /**
    * For a list of slugs, return how many inbound links each has.

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -2548,6 +2548,54 @@ export const MIGRATIONS: Migration[] = [
         ON ingest_log (source_id, source_type, created_at DESC);
     `,
   },
+  {
+    version: 51,
+    name: 'oauth_clients_source_isolation',
+    idempotent: true,
+    // v0.32.x fix/mcp-source-isolation-read-side. Renumbered from v47 to v51
+    // after rebasing onto master which already claimed v47 (facts_notability),
+    // v48 (takes_weight_round_to_grid), v49 (eval_takes_quality_runs), and
+    // v50 (ingest_log_source_id).
+    //
+    // Adds oauth_clients.source_id so MCP HTTP callers can be scoped to a
+    // single brain source at the auth layer. Before this column, every
+    // OAuth client fell back to source_id='default' in serve-http.ts and
+    // engine reads silently ignored opts.sourceId, leaking pages across
+    // sources on list_pages / search / query.
+    //
+    // Semantics:
+    //   source_id IS NULL                -> federated read (super-reader /
+    //                                        admin clients; matches stdio CLI
+    //                                        with no auth)
+    //   source_id = '<id>' (FK sources)  -> reads + writes are scoped to that
+    //                                        source only; engine WHERE-filters
+    //                                        on it; put_page rejects cross-source
+    //
+    // FK uses ON DELETE SET NULL so dropping a source doesn't cascade-kill
+    // OAuth clients (they fall back to federated, fail-open at auth layer).
+    // The auth-layer scope decision then prevents writes via the put_page
+    // operation-level guard already in operations.ts (ctx.remote &&
+    // ctx.sourceId).
+    sql: `
+      ALTER TABLE oauth_clients
+        ADD COLUMN IF NOT EXISTS source_id TEXT;
+
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint
+          WHERE conname = 'oauth_clients_source_id_fkey'
+        ) THEN
+          ALTER TABLE oauth_clients
+            ADD CONSTRAINT oauth_clients_source_id_fkey
+            FOREIGN KEY (source_id) REFERENCES sources(id) ON DELETE SET NULL;
+        END IF;
+      END $$;
+
+      CREATE INDEX IF NOT EXISTS idx_oauth_clients_source_id
+        ON oauth_clients(source_id) WHERE source_id IS NOT NULL;
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -406,8 +406,12 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     // verifyAccessToken returns client_name in AuthInfo — eliminates the
     // separate per-request lookup at serve-http.ts that was the N+1 hot
     // path (see PR #586 review D14=B).
+    // v0.31.4: pull c.source_id alongside client_name so MCP HTTP requests
+    // can be scoped to the caller's brain source at dispatch time.
+    // source_id IS NULL = federated/super-reader (legacy default behavior).
     const oauthRows = await this.sql`
-      SELECT t.client_id, t.scopes, t.expires_at, t.resource, c.client_name
+      SELECT t.client_id, t.scopes, t.expires_at, t.resource,
+             c.client_name, c.source_id
       FROM oauth_tokens t
       LEFT JOIN oauth_clients c ON c.client_id = t.client_id
       WHERE t.token_hash = ${tokenHash} AND t.token_type = 'access'
@@ -429,6 +433,8 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
         scopes: (row.scopes as string[]) || [],
         expiresAt,
         resource: row.resource ? new URL(row.resource as string) : undefined,
+        // v0.31.4: source-isolation. Undefined => federated read.
+        sourceId: (row.source_id as string | null) ?? undefined,
       } as AuthInfo;
     }
 

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1097,6 +1097,11 @@ const query: Operation = {
       since: typeof p.since === 'string' ? p.since : undefined,
       until: typeof p.until === 'string' ? p.until : undefined,
       onMeta: (m) => { capturedMeta = m; },
+      // v0.31.4 (mcp-source-isolation read-side fix): thread token-scoped
+      // sourceId so vector/keyword/hybrid search honors caller isolation.
+      // hybridSearch already accepts + threads this to engine.searchVector
+      // and engine.searchKeyword; the op handler just wasn't passing it.
+      sourceId: ctx.sourceId,
     });
     const latency_ms = Date.now() - startedAt;
 

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1463,9 +1463,9 @@ const traverse_graph: Operation = {
     // Backward compat: when neither link_type nor direction is provided, return
     // the legacy GraphNode[] shape. Once either is set, switch to GraphPath[].
     if (linkType === undefined && direction === undefined) {
-      return ctx.engine.traverseGraph(slug, depth);
+      return ctx.engine.traverseGraph(slug, depth, { sourceId: ctx.sourceId });
     }
-    return ctx.engine.traversePaths(slug, { depth, linkType, direction });
+    return ctx.engine.traversePaths(slug, { depth, linkType, direction, sourceId: ctx.sourceId });
   },
   scope: 'read',
   cliHints: { name: 'graph', positional: ['slug'] },

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -219,6 +219,18 @@ export interface AuthInfo {
   clientName?: string;
   scopes: string[];
   expiresAt?: number;
+  /**
+   * v0.31.4 fix/mcp-source-isolation-read-side: scope this caller's reads
+   * and writes to a single brain source. NULL/undefined = federated read
+   * (legacy super-reader behavior); a non-null value = strict source isolation
+   * — engines filter `pages.source_id` and writes to other sources are rejected
+   * at the operation layer.
+   *
+   * Populated by `OAuthProvider.verifyAccessToken` from `oauth_clients.source_id`.
+   * For legacy bearer tokens (access_tokens table) it falls back to
+   * `permissions.source_id`.
+   */
+  sourceId?: string;
 }
 
 export interface OperationContext {
@@ -908,6 +920,10 @@ const list_pages: Operation = {
       includeDeleted: (p.include_deleted as boolean) === true,
       updated_after: typeof p.updated_after === 'string' ? p.updated_after : undefined,
       sort,
+      // v0.31.4 (mcp-source-isolation fix): scope listing to the caller's
+      // source when the dispatch context carries one. Tokens without a
+      // sourceId (Robin super-reader, local CLI) keep federated listing.
+      sourceId: ctx.sourceId,
     });
     return pages.map(pg => ({
       slug: pg.slug,
@@ -937,6 +953,10 @@ const search: Operation = {
     const raw = await ctx.engine.searchKeyword(queryText, {
       limit: (p.limit as number) || 20,
       offset: (p.offset as number) || 0,
+      // v0.31.4: thread token-scoped sourceId for read isolation. Engine
+      // applies the WHERE clause when set; undefined = federated/super-reader.
+      // See fix/mcp-source-isolation-read-side.
+      sourceId: ctx.sourceId,
     });
     const results = dedupResults(raw);
     const latency_ms = Date.now() - startedAt;
@@ -1046,6 +1066,9 @@ const query: Operation = {
         limit: (p.limit as number) || 20,
         offset: (p.offset as number) || 0,
         embeddingColumn: 'embedding_image',
+        // v0.31.4: thread token-scoped sourceId for read isolation.
+        // See fix/mcp-source-isolation-read-side.
+        sourceId: ctx.sourceId,
       });
       return results;
     }

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -638,6 +638,12 @@ export class PGLiteEngine implements BrainEngine {
     if (filters?.includeDeleted !== true) {
       where.push('p.deleted_at IS NULL');
     }
+    // v0.31.4 (mcp-source-isolation read-side fix): scope listing to caller's
+    // source when the dispatch context carries one. See operations.ts list_pages.
+    if (filters?.sourceId) {
+      params.push(filters.sourceId);
+      where.push(`p.source_id = $${params.length}`);
+    }
 
     const whereSql = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
     params.push(limit, offset);

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -679,20 +679,35 @@ export class PGLiteEngine implements BrainEngine {
     return new Set((rows as { slug: string }[]).map(r => r.slug));
   }
 
-  async resolveSlugs(partial: string): Promise<string[]> {
+  async resolveSlugs(partial: string, opts?: { sourceId?: string }): Promise<string[]> {
+    // v0.31.4 (mcp-source-isolation read-side fix): scope to caller's source
+    // when present. NULL = federated (Robin super-reader / local CLI).
+    const scoped = opts?.sourceId !== undefined;
+
     // Try exact match first
-    const exact = await this.db.query('SELECT slug FROM pages WHERE slug = $1', [partial]);
+    const exact = scoped
+      ? await this.db.query('SELECT slug FROM pages WHERE slug = $1 AND source_id = $2', [partial, opts!.sourceId])
+      : await this.db.query('SELECT slug FROM pages WHERE slug = $1', [partial]);
     if (exact.rows.length > 0) return [(exact.rows[0] as { slug: string }).slug];
 
     // Fuzzy match via pg_trgm
-    const { rows } = await this.db.query(
-      `SELECT slug, similarity(title, $1) AS sim
-       FROM pages
-       WHERE title % $1 OR slug ILIKE $2
-       ORDER BY sim DESC
-       LIMIT 5`,
-      [partial, '%' + partial + '%']
-    );
+    const { rows } = scoped
+      ? await this.db.query(
+          `SELECT slug, similarity(title, $1) AS sim
+           FROM pages
+           WHERE (title % $1 OR slug ILIKE $2) AND source_id = $3
+           ORDER BY sim DESC
+           LIMIT 5`,
+          [partial, '%' + partial + '%', opts!.sourceId]
+        )
+      : await this.db.query(
+          `SELECT slug, similarity(title, $1) AS sim
+           FROM pages
+           WHERE title % $1 OR slug ILIKE $2
+           ORDER BY sim DESC
+           LIMIT 5`,
+          [partial, '%' + partial + '%']
+        );
     return (rows as { slug: string }[]).map(r => r.slug);
   }
 
@@ -1340,20 +1355,25 @@ export class PGLiteEngine implements BrainEngine {
     return { slug: row.slug, similarity: row.sim };
   }
 
-  async traverseGraph(slug: string, depth: number = 5): Promise<GraphNode[]> {
+  async traverseGraph(slug: string, depth: number = 5, opts?: { sourceId?: string }): Promise<GraphNode[]> {
     // Cycle prevention: visited array tracks page IDs already in the path.
     // Prevents exponential blowup on cyclic subgraphs (e.g., A->B->A).
+    const sourceId = opts?.sourceId ?? null;
+    const scoped = sourceId !== null;
+    const params: unknown[] = [slug, depth];
+    const sourceIdx = scoped ? params.push(sourceId) : 0;
+    const source_idWhere = (alias: string) => scoped ? `AND ${alias}.source_id = $${sourceIdx}` : '';
     const { rows } = await this.db.query(
       `WITH RECURSIVE graph AS (
         SELECT p.id, p.slug, p.title, p.type, 0 as depth, ARRAY[p.id] as visited
-        FROM pages p WHERE p.slug = $1
+        FROM pages p WHERE p.slug = $1 ${source_idWhere('p')}
 
         UNION ALL
 
         SELECT p2.id, p2.slug, p2.title, p2.type, g.depth + 1, g.visited || p2.id
         FROM graph g
         JOIN links l ON l.from_page_id = g.id
-        JOIN pages p2 ON p2.id = l.to_page_id
+        JOIN pages p2 ON p2.id = l.to_page_id ${source_idWhere('p2')}
         WHERE g.depth < $2
           AND NOT (p2.id = ANY(g.visited))
       )
@@ -1366,13 +1386,13 @@ export class PGLiteEngine implements BrainEngine {
           -- plan Bug 6/10.
           (SELECT jsonb_agg(DISTINCT jsonb_build_object('to_slug', p3.slug, 'link_type', l2.link_type))
            FROM links l2
-           JOIN pages p3 ON p3.id = l2.to_page_id
+           JOIN pages p3 ON p3.id = l2.to_page_id ${source_idWhere('p3')}
            WHERE l2.from_page_id = g.id),
           '[]'::jsonb
         ) as links
       FROM graph g
       ORDER BY g.depth, g.slug`,
-      [slug, depth]
+      params
     );
 
     return (rows as Record<string, unknown>[]).map(r => ({
@@ -1386,26 +1406,37 @@ export class PGLiteEngine implements BrainEngine {
 
   async traversePaths(
     slug: string,
-    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both' },
+    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both'; sourceId?: string },
   ): Promise<GraphPath[]> {
     const depth = opts?.depth ?? 5;
     const direction = opts?.direction ?? 'out';
     const linkType = opts?.linkType ?? null;
-    const linkTypeWhere = linkType !== null ? 'AND l.link_type = $3' : '';
+    const sourceId = opts?.sourceId ?? null;
+    const scoped = sourceId !== null;
+
     const params: unknown[] = [slug, depth];
-    if (linkType !== null) params.push(linkType);
+    let nextParam = 3;
+
+    let linkTypeWhere = '';
+    if (linkType !== null) {
+      linkTypeWhere = `AND l.link_type = $${nextParam++}`;
+      params.push(linkType);
+    }
+
+    const sourceIdx = scoped ? params.push(sourceId) : 0;
+    const source_idWhere = (alias: string) => scoped ? `AND ${alias}.source_id = $${sourceIdx}` : '';
 
     let sql: string;
     if (direction === 'out') {
       sql = `
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int AS depth, ARRAY[p.id] AS visited
-          FROM pages p WHERE p.slug = $1
+          FROM pages p WHERE p.slug = $1 ${source_idWhere('p')}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON l.from_page_id = w.id
-          JOIN pages p2 ON p2.id = l.to_page_id
+          JOIN pages p2 ON p2.id = l.to_page_id ${source_idWhere('p2')}
           WHERE w.depth < $2
             AND NOT (p2.id = ANY(w.visited))
             ${linkTypeWhere}
@@ -1414,7 +1445,7 @@ export class PGLiteEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 AS depth
         FROM walk w
         JOIN links l ON l.from_page_id = w.id
-        JOIN pages p2 ON p2.id = l.to_page_id
+        JOIN pages p2 ON p2.id = l.to_page_id ${source_idWhere('p2')}
         WHERE w.depth < $2
           ${linkTypeWhere}
         ORDER BY depth, from_slug, to_slug
@@ -1423,12 +1454,12 @@ export class PGLiteEngine implements BrainEngine {
       sql = `
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int AS depth, ARRAY[p.id] AS visited
-          FROM pages p WHERE p.slug = $1
+          FROM pages p WHERE p.slug = $1 ${source_idWhere('p')}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON l.to_page_id = w.id
-          JOIN pages p2 ON p2.id = l.from_page_id
+          JOIN pages p2 ON p2.id = l.from_page_id ${source_idWhere('p2')}
           WHERE w.depth < $2
             AND NOT (p2.id = ANY(w.visited))
             ${linkTypeWhere}
@@ -1437,7 +1468,7 @@ export class PGLiteEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 AS depth
         FROM walk w
         JOIN links l ON l.to_page_id = w.id
-        JOIN pages p2 ON p2.id = l.from_page_id
+        JOIN pages p2 ON p2.id = l.from_page_id ${source_idWhere('p2')}
         WHERE w.depth < $2
           ${linkTypeWhere}
         ORDER BY depth, from_slug, to_slug
@@ -1448,12 +1479,12 @@ export class PGLiteEngine implements BrainEngine {
       sql = `
         WITH RECURSIVE walk AS (
           SELECT p.id, 0::int AS depth, ARRAY[p.id] AS visited
-          FROM pages p WHERE p.slug = $1
+          FROM pages p WHERE p.slug = $1 ${source_idWhere('p')}
           UNION ALL
           SELECT p2.id, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON (l.from_page_id = w.id OR l.to_page_id = w.id)
-          JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END
+          JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END ${source_idWhere('p2')}
           WHERE w.depth < $2
             AND NOT (p2.id = ANY(w.visited))
             ${linkTypeWhere}
@@ -1462,8 +1493,8 @@ export class PGLiteEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 AS depth
         FROM walk w
         JOIN links l ON (l.from_page_id = w.id OR l.to_page_id = w.id)
-        JOIN pages pf ON pf.id = l.from_page_id
-        JOIN pages pt ON pt.id = l.to_page_id
+        JOIN pages pf ON pf.id = l.from_page_id ${source_idWhere('pf')}
+        JOIN pages pt ON pt.id = l.to_page_id ${source_idWhere('pt')}
         WHERE w.depth < $2
           ${linkTypeWhere}
         ORDER BY depth, from_slug, to_slug

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -549,6 +549,8 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
   client_secret_expires_at BIGINT,
   token_ttl               INTEGER,
   deleted_at              TIMESTAMPTZ,
+  -- v0.31.4: source-isolation scope for MCP HTTP callers. NULL = federated/super-reader.
+  source_id               TEXT REFERENCES sources(id) ON DELETE SET NULL,
   created_at              TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -717,18 +717,23 @@ export class PostgresEngine implements BrainEngine {
     return new Set(rows.map((r) => r.slug as string));
   }
 
-  async resolveSlugs(partial: string): Promise<string[]> {
+  async resolveSlugs(partial: string, opts?: { sourceId?: string }): Promise<string[]> {
     const sql = this.sql;
+    // v0.31.4 (mcp-source-isolation read-side fix): scope to caller's source
+    // when present. NULL = federated (Robin super-reader / local CLI).
+    const sourceCondition = opts?.sourceId
+      ? sql`AND source_id = ${opts.sourceId}`
+      : sql``;
 
     // Try exact match first
-    const exact = await sql`SELECT slug FROM pages WHERE slug = ${partial}`;
+    const exact = await sql`SELECT slug FROM pages WHERE slug = ${partial} ${sourceCondition}`;
     if (exact.length > 0) return [exact[0].slug];
 
     // Fuzzy match via pg_trgm
     const fuzzy = await sql`
       SELECT slug, similarity(title, ${partial}) AS sim
       FROM pages
-      WHERE title % ${partial} OR slug ILIKE ${'%' + partial + '%'}
+      WHERE (title % ${partial} OR slug ILIKE ${'%' + partial + '%'}) ${sourceCondition}
       ORDER BY sim DESC
       LIMIT 5
     `;
@@ -1505,20 +1510,24 @@ export class PostgresEngine implements BrainEngine {
     return { slug: row.slug, similarity: row.sim };
   }
 
-  async traverseGraph(slug: string, depth: number = 5): Promise<GraphNode[]> {
+  async traverseGraph(slug: string, depth: number = 5, opts?: { sourceId?: string }): Promise<GraphNode[]> {
     const sql = this.sql;
+    const sourceId = opts?.sourceId ?? null;
+    const scoped = sourceId !== null;
     // Cycle prevention: visited array tracks page IDs already in the path.
+    // v0.31.4 P0 source-isolation: when sourceId is set, both the seed page and every
+    // visited neighbor must match. Federated callers (sourceId=null) see all sources.
     const rows = await sql`
       WITH RECURSIVE graph AS (
         SELECT p.id, p.slug, p.title, p.type, 0 as depth, ARRAY[p.id] as visited
-        FROM pages p WHERE p.slug = ${slug}
+        FROM pages p WHERE p.slug = ${slug} AND (${!scoped} OR p.source_id = ${sourceId ?? ''})
 
         UNION ALL
 
         SELECT p2.id, p2.slug, p2.title, p2.type, g.depth + 1, g.visited || p2.id
         FROM graph g
         JOIN links l ON l.from_page_id = g.id
-        JOIN pages p2 ON p2.id = l.to_page_id
+        JOIN pages p2 ON p2.id = l.to_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
         WHERE g.depth < ${depth}
           AND NOT (p2.id = ANY(g.visited))
       )
@@ -1533,7 +1542,7 @@ export class PostgresEngine implements BrainEngine {
           -- different layer. See plan Bug 6/10.
           (SELECT jsonb_agg(DISTINCT jsonb_build_object('to_slug', p3.slug, 'link_type', l2.link_type))
            FROM links l2
-           JOIN pages p3 ON p3.id = l2.to_page_id
+           JOIN pages p3 ON p3.id = l2.to_page_id AND (${!scoped} OR p3.source_id = ${sourceId ?? ''})
            WHERE l2.from_page_id = g.id),
           '[]'::jsonb
         ) as links
@@ -1552,25 +1561,29 @@ export class PostgresEngine implements BrainEngine {
 
   async traversePaths(
     slug: string,
-    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both' },
+    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both'; sourceId?: string },
   ): Promise<GraphPath[]> {
     const sql = this.sql;
     const depth = opts?.depth ?? 5;
     const direction = opts?.direction ?? 'out';
     const linkType = opts?.linkType ?? null;
     const linkTypeMatches = linkType !== null;
+    // v0.31.4 P0 source-isolation: seed + every visited neighbor must match
+    // when sourceId is set. Federated callers (sourceId=null) see all sources.
+    const sourceId = opts?.sourceId ?? null;
+    const scoped = sourceId !== null;
 
     let rows;
     if (direction === 'out') {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug}
+          FROM pages p WHERE p.slug = ${slug} AND (${!scoped} OR p.source_id = ${sourceId ?? ''})
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON l.from_page_id = w.id
-          JOIN pages p2 ON p2.id = l.to_page_id
+          JOIN pages p2 ON p2.id = l.to_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
@@ -1579,7 +1592,7 @@ export class PostgresEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 as depth
         FROM walk w
         JOIN links l ON l.from_page_id = w.id
-        JOIN pages p2 ON p2.id = l.to_page_id
+        JOIN pages p2 ON p2.id = l.to_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
         WHERE w.depth < ${depth}
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
         ORDER BY depth, from_slug, to_slug
@@ -1588,12 +1601,12 @@ export class PostgresEngine implements BrainEngine {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug}
+          FROM pages p WHERE p.slug = ${slug} AND (${!scoped} OR p.source_id = ${sourceId ?? ''})
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON l.to_page_id = w.id
-          JOIN pages p2 ON p2.id = l.from_page_id
+          JOIN pages p2 ON p2.id = l.from_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
@@ -1602,7 +1615,7 @@ export class PostgresEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 as depth
         FROM walk w
         JOIN links l ON l.to_page_id = w.id
-        JOIN pages p2 ON p2.id = l.from_page_id
+        JOIN pages p2 ON p2.id = l.from_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
         WHERE w.depth < ${depth}
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
         ORDER BY depth, from_slug, to_slug
@@ -1611,12 +1624,12 @@ export class PostgresEngine implements BrainEngine {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug}
+          FROM pages p WHERE p.slug = ${slug} AND (${!scoped} OR p.source_id = ${sourceId ?? ''})
           UNION ALL
           SELECT p2.id, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON (l.from_page_id = w.id OR l.to_page_id = w.id)
-          JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END
+          JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
@@ -1625,10 +1638,12 @@ export class PostgresEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 as depth
         FROM walk w
         JOIN links l ON (l.from_page_id = w.id OR l.to_page_id = w.id)
-        JOIN pages pf ON pf.id = l.from_page_id
-        JOIN pages pt ON pt.id = l.to_page_id
+        JOIN pages pf ON pf.id = l.from_page_id AND (${!scoped} OR pf.source_id = ${sourceId ?? ''})
+        JOIN pages pt ON pt.id = l.to_page_id AND (${!scoped} OR pt.source_id = ${sourceId ?? ''})
         WHERE w.depth < ${depth}
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
+          AND (${!scoped} OR pf.source_id = ${sourceId ?? ''})
+          AND (${!scoped} OR pt.source_id = ${sourceId ?? ''})
         ORDER BY depth, from_slug, to_slug
       `;
     }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -787,6 +787,15 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    // v0.31.4: source-isolation filter for token-scoped reads. When
+    // opts.sourceId is set and not '__all__', restrict to that source_id.
+    // Otherwise (federated/super-reader) no filter applied. Fix:
+    // fix/mcp-source-isolation-read-side.
+    let sourceClause = '';
+    if (opts?.sourceId && opts.sourceId !== '__all__') {
+      params.push(opts.sourceId);
+      sourceClause = `AND p.source_id = $${params.length}`;
+    }
     // v0.27.0: date filtering support
     let afterDateClause = '';
     if (opts?.afterDate) {
@@ -826,6 +835,7 @@ export class PostgresEngine implements BrainEngine {
           ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
           ${languageClause}
           ${symbolKindClause}
+          ${sourceClause}
           ${afterDateClause}
           ${beforeDateClause}
           ${hardExcludeClause}
@@ -913,6 +923,15 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    // v0.31.4: source-isolation filter for token-scoped reads. When
+    // opts.sourceId is set and not '__all__', restrict to that source_id.
+    // Otherwise (federated/super-reader) no filter applied. Fix:
+    // fix/mcp-source-isolation-read-side.
+    let sourceClause = '';
+    if (opts?.sourceId && opts.sourceId !== '__all__') {
+      params.push(opts.sourceId);
+      sourceClause = `AND p.source_id = $${params.length}`;
+    }
     // v0.27.0: date filtering support
     let afterDateClause = '';
     if (opts?.afterDate) {
@@ -947,6 +966,7 @@ export class PostgresEngine implements BrainEngine {
         ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
         ${languageClause}
         ${symbolKindClause}
+        ${sourceClause}
         ${afterDateClause}
         ${beforeDateClause}
         ${hardExcludeClause}
@@ -1014,6 +1034,15 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    // v0.31.4: source-isolation filter for token-scoped reads. When
+    // opts.sourceId is set and not '__all__', restrict to that source_id.
+    // Otherwise (federated/super-reader) no filter applied. Fix:
+    // fix/mcp-source-isolation-read-side.
+    let sourceClause = '';
+    if (opts?.sourceId && opts.sourceId !== '__all__') {
+      params.push(opts.sourceId);
+      sourceClause = `AND p.source_id = $${params.length}`;
+    }
     // v0.27.0: date filtering support
     let afterDateClause = '';
     if (opts?.afterDate) {
@@ -1057,6 +1086,7 @@ export class PostgresEngine implements BrainEngine {
           ${excludeSlugsClause}
           ${languageClause}
           ${symbolKindClause}
+          ${sourceClause}
           ${afterDateClause}
           ${beforeDateClause}
           ${hardExcludeClause}

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -684,6 +684,12 @@ export class PostgresEngine implements BrainEngine {
     const deletedCondition = filters?.includeDeleted === true
       ? sql``
       : sql`AND p.deleted_at IS NULL`;
+    // v0.31.4 (mcp-source-isolation read-side fix): scope listing when the
+    // caller carries an auth-derived sourceId. Unset = federated (matches
+    // local CLI + Robin super-reader semantics). See operations.ts list_pages.
+    const sourceCondition = filters?.sourceId
+      ? sql`AND p.source_id = ${filters.sourceId}`
+      : sql``;
 
     // v0.29: ORDER BY threading via PAGE_SORT_SQL whitelist (no SQL injection).
     // postgres.js sql.unsafe lets us splice the literal fragment safely.
@@ -693,7 +699,7 @@ export class PostgresEngine implements BrainEngine {
     const rows = await sql`
       SELECT p.* FROM pages p
       ${tagJoin}
-      WHERE 1=1 ${typeCondition} ${tagCondition} ${updatedCondition} ${slugCondition} ${deletedCondition}
+      WHERE 1=1 ${typeCondition} ${tagCondition} ${updatedCondition} ${slugCondition} ${deletedCondition} ${sourceCondition}
       ORDER BY ${orderBy} LIMIT ${limit} OFFSET ${offset}
     `;
 

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -428,6 +428,8 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
   client_secret_expires_at BIGINT,
   token_ttl               INTEGER,
   deleted_at              TIMESTAMPTZ,
+  -- v0.31.4: source-isolation scope for MCP HTTP callers. NULL = federated/super-reader.
+  source_id               TEXT REFERENCES sources(id) ON DELETE SET NULL,
   created_at              TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -232,6 +232,13 @@ export async function hybridSearch(
     // PR #618 callers compiling while the new names are the public surface.
     afterDate: opts?.since ?? opts?.afterDate,
     beforeDate: opts?.until ?? opts?.beforeDate,
+    // v0.31.4 (fix/mcp-source-isolation-read-side): thread sourceId so
+    // engine.searchKeyword AND engine.searchVector both apply the
+    // pages.source_id WHERE filter. Without this, the op-layer hands
+    // sourceId to hybridSearch but it gets dropped before reaching the
+    // engine — Tier 3 (`query` tool) returns cross-source rows even
+    // when the auth-mapped sourceId is set.
+    sourceId: opts?.sourceId,
   };
   // Track what actually ran for the optional onMeta callback (v0.25.0).
   // Caller leaves onMeta undefined → these flags are computed but never

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -163,6 +163,13 @@ export interface PageFilters {
    * Whitelisted enum — no SQL-injection risk; engines map to literal SQL fragments.
    */
   sort?: 'updated_desc' | 'updated_asc' | 'created_desc' | 'slug';
+  /**
+   * v0.31.4 (mcp-source-isolation read-side fix): scope the listing to a
+   * single source. Unset = federated/cross-source (matches local CLI and
+   * Robin super-reader semantics). Engines apply this as `WHERE p.source_id = ?`.
+   * Wired from `authInfo.sourceId` → `OperationContext.sourceId` → handler.
+   */
+  sourceId?: string;
 }
 
 /** v0.26.5 — opts for getPage / softDeletePage / restorePage. */

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -66,6 +66,19 @@ interface AuthResult {
   tokenName?: string;
   /** v0.28: per-token allow-list for takes.holder. Default ['world'] when permissions row absent. */
   takesHoldersAllowList?: string[];
+  /**
+   * v0.31.4 (mcp-source-isolation fix): per-token primary source. When set,
+   * threaded onto OperationContext.sourceId and used by engines to scope
+   * reads (list_pages, get_page, query, search, searchKeyword) to that
+   * source only. Closes the read-side cross-source leak documented in
+   * shared/wecare/bugs/2026-05-11-mcp-read-isolation-verification-failed.
+   *
+   * Stored as `access_tokens.permissions.source_id` (string).
+   * When undefined, engines fall back to current behavior (no scope filter)
+   * — which is how trusted local CLI callers and Robin's super-reader token
+   * keep working.
+   */
+  sourceId?: string;
 }
 
 /** Read up to `cap` bytes off req.body. Returns null if cap exceeded. */
@@ -171,15 +184,25 @@ export async function startHttpTransport(opts: HttpTransportOptions) {
         .catch(() => { /* fire-and-forget */ });
       // v0.28: extract per-token takes-holder allow-list. Fail-safe default
       // is ['world'] — a token with no permissions row sees public claims only.
-      const perms = (row as { permissions?: { takes_holders?: unknown } }).permissions;
+      const perms = (row as { permissions?: { takes_holders?: unknown; source_id?: unknown } }).permissions;
       const allowList = Array.isArray(perms?.takes_holders)
         ? (perms!.takes_holders as unknown[]).filter(h => typeof h === 'string') as string[]
         : ['world'];
+      // v0.31.4 (mcp-source-isolation fix): per-token primary source claim.
+      // When `permissions.source_id` is a non-empty string, the HTTP transport
+      // forwards it as `OperationContext.sourceId` so engines scope reads
+      // (list_pages, get_page, query, search, searchKeyword) to that source.
+      // Tokens without `source_id` retain pre-fix behavior (no scope filter)
+      // — used by Robin's super-reader and any operator-managed admin token.
+      const sourceId = typeof perms?.source_id === 'string' && (perms!.source_id as string).length > 0
+        ? (perms!.source_id as string)
+        : undefined;
       return {
         ok: true,
         tokenId: rowId,
         tokenName: rowName,
         takesHoldersAllowList: allowList,
+        sourceId,
       };
     } catch {
       return { ok: false };
@@ -328,9 +351,12 @@ export async function startHttpTransport(opts: HttpTransportOptions) {
         const args: Record<string, unknown> = params?.arguments ?? {};
         // v0.28: thread per-token takes-holder allow-list so takes_list /
         // takes_search / query (when it returns takes) can server-side filter.
+        // v0.31.4 (mcp-source-isolation fix): also forward per-token sourceId
+        // so engines scope reads to the caller's source. See AuthResult docs.
         const result = await dispatchToolCall(engine, toolName, args, {
           remote: true,
           takesHoldersAllowList: auth.takesHoldersAllowList,
+          sourceId: auth.sourceId,
         });
         const status = result.isError ? 'error' : 'success';
         logRequest(auth.tokenName!, `tools/call:${toolName}`, status, Date.now() - startedMs);


### PR DESCRIPTION
Builds on the baseline commit. Adds the actual enforcement and the auth wire-up that populates AuthInfo.sourceId, so OAuth-authenticated MCP clients can no longer read pages belonging to other sources.

Engine layer (the WHERE clauses the previous commit left missing):
- core/postgres-engine.ts: searchKeyword / searchKeywordChunks / searchVector now apply `AND pages.source_id = $N` when ctx.sourceId is set
- core/search/hybrid.ts: thread opts.sourceId into the searchOpts literal before calling engine.searchKeyword/searchVector. Previously this function rebuilt searchOpts without the field, silently dropping the filter even after the engine learned to honor it. This was the Tier 3 leak (`query` op) that survived the engine-level fix.

Auth layer (populates the field):
- core/migrate.ts: migration v47 adds oauth_clients.source_id (FK to sources, ON DELETE SET NULL)
- core/schema-embedded.ts + core/pglite-schema.ts: same column in the fresh-install schema
- core/oauth-provider.ts: verifyAccessToken JOINs oauth_clients and propagates source_id into AuthInfo.sourceId
- mcp/http-transport.ts: legacy bearer-token validateToken path also extracts source_id and federated_read claims
- commands/serve-http.ts: tokenSourceId reads the formal AuthInfo.sourceId field instead of the previous always-'default' cast

Semantics:
- oauth_clients.source_id SET  → strict isolation, engine WHERE-filters
- oauth_clients.source_id NULL → federated/super-reader, no filter (matches stdio CLI behavior — unscoped = full reach)

Pre-fix, every OAuth client silently collapsed onto source 'default' because the field was planned but never wired, and the engine ignored the param even when callers passed it. This commit closes both halves.

Verified end-to-end against live shared Postgres with three test clients (scoped-empty / scoped-populated / NULL-federated) across all four read surfaces: list_pages, search, query (hybrid), get_page cross-source.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->