### PR TITLE
fix(operations): add items schema to entity_hints array param

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2434,7 +2434,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },


### PR DESCRIPTION
## Summary

`extract_facts.entity_hints` is declared as `type: 'array'` but lacks the `items` schema. JSON Schema strictly requires `items` on array types; MCP clients that validate tool definitions (caught downstream by OpenClaw) reject the `extract_facts` tool def at handshake.

The fix is a one-liner: add `items: { type: 'string' }`.

## Why this slipped through silently

`buildToolDefs` at `src/mcp/tool-defs.ts:24` already guards: `...(v.items ? { items: { type: v.items.type } } : {})`. With no `items` on the op param, the builder simply drops the field from the wire schema, producing a spec-violating tool def. The Anthropic SDK accepts it; strict validators reject it. Hence "works on dev box, fails downstream" pattern.

## Spot-check the rest of the codebase

Grepped all `type: 'array'` declarations:

- `src/core/operations.ts:1733` `ingest_log.pages_updated` — already has `items: { type: 'string' }` ✓
- `src/core/operations.ts:2443` `extract_facts.entity_hints` — **this PR**
- `src/core/resolvers/builtin/x-api/handle-to-tweet.ts:102` `candidates` in `outputSchema` — pure documentation surface (only consumed by `console.log(JSON.stringify(...))` in `commands/resolvers.ts:162`), not wire-validated. Out of scope for this fix.

## Test plan

- [x] `bun run typecheck` clean
- [x] No behavior change — `entity_hints` was already array-of-strings semantically; the patch only declares it so MCP clients accept it

## Credit

Schema mismatch caught by OpenClaw downstream during MCP tool-def validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->