### PR TITLE
fix(extract_facts): add items schema to entity_hints array param

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2434,7 +2434,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },


### PR DESCRIPTION
## Problem

The `extract_facts` MCP tool declares `entity_hints` as `type: 'array'` with no `items` definition (`src/core/operations.ts`). Anthropic's API validates JSON Schema at the schema-validation layer before dispatching the request to the model, and rejects array properties that lack `items`. As a result, **any call to `mcp__gbrain__extract_facts` from a Claude client (Claude Code, the Anthropic API directly, etc.) fails with `InputValidationError` before the tool ever runs**.

### Repro

```
$ claude mcp call gbrain__extract_facts '{"turn_text": "..."}'
Error: InputValidationError: tools.N.input_schema:
  entity_hints.items: Field required
```

## Fix

One-line change: declare the array's element type as `string`. This matches the existing pattern used elsewhere in this file (`pages_updated` in the consolidate op) and matches what the implementation already treats them as:

```ts
entityHints: Array.isArray(p.entity_hints)
  ? (p.entity_hints as string[]) : undefined
```

After the patch, the schema validates and the tool dispatches normally.

## Test plan

- [x] No code logic change — schema-only correction
- [x] `bun test test/serve-http-health.test.ts test/serve-stdio-lifecycle.test.ts` — 30/30 pass
- [x] `tsc --noEmit` — clean
- [ ] Reviewer: invoke `mcp__gbrain__extract_facts` from any Claude client and confirm no `InputValidationError`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->