### PR TITLE
feat(serve): --bind HOST flag for loopback-only HTTP MCP deployments

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1483,6 +1483,7 @@ ADMIN
     --token-ttl N                    Access token TTL in seconds (default: 3600)
     --enable-dcr                     Enable Dynamic Client Registration
     --public-url URL                 Public issuer URL (required behind proxy/tunnel)
+    --bind HOST                      Bind address (default 0.0.0.0; pass 127.0.0.1 for loopback-only)
   call <tool> '<json>'               Raw tool invocation
   version                            Version info
   --tools-json                       Tool discovery (JSON)

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -162,10 +162,22 @@ interface ServeHttpOptions {
    * at startup so the privacy posture change is visible.
    */
   logFullParams?: boolean;
+  /**
+   * Host the HTTP server binds to. Defaults to '0.0.0.0' (all interfaces) to
+   * preserve prior behavior for users behind a reverse proxy / cloud LB.
+   *
+   * Set to '127.0.0.1' (or '::1') for a loopback-only deployment where the
+   * brain is consumed by on-host agents (cron jobs, local Codex sessions,
+   * desktop clients tunneling through SSH) and must not be reachable from
+   * any other interface. Reverse-proxy / tunnel users keep the default and
+   * front the server with TLS + auth at the proxy.
+   */
+  bind?: string;
 }
 
 export async function runServeHttp(engine: BrainEngine, options: ServeHttpOptions) {
   const { port, tokenTtl, enableDcr, publicUrl, logFullParams } = options;
+  const bind = options.bind ?? '0.0.0.0';
   const config = loadConfig() || { engine: 'pglite' as const };
 
   if (logFullParams) {
@@ -1058,11 +1070,12 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   // ---------------------------------------------------------------------------
   const clientCount = await sql`SELECT count(*)::int as count FROM oauth_clients`;
 
-  app.listen(port, () => {
+  app.listen(port, bind, () => {
     console.error(`
 ╔══════════════════════════════════════════════════════╗
 ║  GBrain MCP Server v${VERSION.padEnd(37)}║
 ╠══════════════════════════════════════════════════════╣
+║  Bind:      ${`${bind}:${port}`.padEnd(40)}║
 ║  Port:      ${String(port).padEnd(40)}║
 ║  Engine:    ${(config.engine || 'pglite').padEnd(40)}║
 ║  Issuer:    ${issuerUrl.origin.padEnd(40)}║

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -90,8 +90,16 @@ export async function runServe(
     // when set so the posture change is visible in stderr.
     const logFullParams = args.includes('--log-full-params');
 
+    // --bind <host>: address app.listen() binds to. Defaults to '0.0.0.0' (all
+    // interfaces) to preserve historical behavior. Pass '127.0.0.1' (or '::1')
+    // for a loopback-only deployment where the brain is consumed by on-host
+    // agents and must not be reachable from the network. Reverse-proxy users
+    // keep the default and front the server with TLS + auth at the proxy.
+    const bindIdx = args.indexOf('--bind');
+    const bind = bindIdx >= 0 ? args[bindIdx + 1] : undefined;
+
     const { runServeHttp } = await import('./serve-http.ts');
-    await runServeHttp(engine, { port, tokenTtl, enableDcr, publicUrl, logFullParams });
+    await runServeHttp(engine, { port, tokenTtl, enableDcr, publicUrl, logFullParams, bind });
     return;
   }
 


### PR DESCRIPTION
## Problem

`gbrain serve --http` calls `app.listen(port)` with no host, so Express/Node binds to `0.0.0.0` — every interface on the box. That's the right default behind a reverse proxy or cloud LB, but it's the wrong default when the brain is meant to be consumed only by on-host agents (cron jobs, local Codex sessions, desktop clients tunneling through SSH). Today the only way to lock those deployments down is to patch the source.

## Fix

Add a `--bind <host>` flag that threads through `serve.ts` → `serve-http.ts` → `app.listen(port, host)`:

- Default stays `0.0.0.0` to preserve historical behavior.
- Operators opt in to loopback-only with `--bind 127.0.0.1` (or `::1` for IPv6).
- The startup banner gains a `Bind:` line so the posture is visible in stderr at boot.
- `runServeHttp`'s new `bind?` field is optional and defaults to `'0.0.0.0'` inside the function, so any existing programmatic caller continues to work unchanged.

```
$ gbrain serve --http --port 7878 --bind 127.0.0.1
╔══════════════════════════════════════════════════════╗
║  GBrain MCP Server vX.Y.Z                            ║
╠══════════════════════════════════════════════════════╣
║  Bind:      127.0.0.1:7878                           ║
║  Port:      7878                                     ║
║  ...
```

## Test plan

- [x] `bun test test/serve-http-health.test.ts test/serve-stdio-lifecycle.test.ts` — 30/30 pass
- [x] `tsc --noEmit` — clean
- [x] Running as a systemd user unit with `--bind 127.0.0.1` for the last several days on a personal node; loopback-only confirmed (`ss -ltn` only shows `127.0.0.1:7878`, no `*:7878`).
- [ ] Reviewer: run with no flag and confirm `0.0.0.0` bind (no behavior change vs. main).
- [ ] Reviewer: run with `--bind 127.0.0.1` and confirm external interface is not listening.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->