### PR TITLE
fix: send Voyage output_dimension on embedding requests

### DIFF
--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -15,19 +15,26 @@ const VOYAGE_OUTPUT_DIMENSION_MODELS = new Set([
   'voyage-4-large',
   'voyage-4',
   'voyage-4-lite',
+  'voyage-4-nano',
   'voyage-3-large',
   'voyage-3.5',
   'voyage-3.5-lite',
   'voyage-code-3',
 ]);
 
+export function supportsVoyageOutputDimension(modelId: string): boolean {
+  return VOYAGE_OUTPUT_DIMENSION_MODELS.has(modelId);
+}
+
 /**
  * Build the providerOptions blob for embedMany() that pins output dimensions.
  *
  * Matryoshka providers (OpenAI text-embedding-3, Gemini embedding-001) can be
  * asked to return reduced-dim vectors. Anthropic does not take a dimension
- * parameter. Most openai-compatible providers do not either, but Voyage's
- * OpenAI-compatible embeddings endpoint accepts `output_dimension`.
+ * parameter. Most openai-compatible providers do not either. Voyage's
+ * endpoint accepts `output_dimension`, but the AI SDK openai-compatible
+ * adapter only forwards `dimensions`; gateway.ts translates that field to
+ * Voyage's wire name in voyageCompatFetch.
  */
 export function dimsProviderOptions(
   implementation: Implementation,
@@ -53,10 +60,11 @@ export function dimsProviderOptions(
       return undefined;
     case 'openai-compatible':
       // Most openai-compatible providers (Ollama, LM Studio, vLLM, LiteLLM)
-      // do not expose a standard dimensions knob. Voyage's compat endpoint is
-      // the exception: it accepts output_dimension and defaults to 1024 dims.
-      if (VOYAGE_OUTPUT_DIMENSION_MODELS.has(modelId)) {
-        return { openaiCompatible: { output_dimension: dims } };
+      // do not expose a standard dimensions knob. Voyage is the exception,
+      // but it needs the SDK-supported field here so voyageCompatFetch can
+      // translate it to `output_dimension` before the HTTP request is sent.
+      if (supportsVoyageOutputDimension(modelId)) {
+        return { openaiCompatible: { dimensions: dims } };
       }
       // OpenAI text-embedding-3 family on the openai-compatible adapter
       // (Azure OpenAI hosts these via its OpenAI-compatible /embeddings

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -3,6 +3,7 @@ import {
   configureGateway,
   resetGateway,
   isAvailable,
+  embed,
   getEmbeddingModel,
   getEmbeddingDimensions,
   getExpansionModel,
@@ -156,13 +157,60 @@ describe('dims.dimsProviderOptions', () => {
     expect(opts).toBeUndefined();
   });
 
-  test('Voyage openai-compatible returns output_dimension', () => {
-    const opts = dimsProviderOptions('openai-compatible', 'voyage-4-large', 2048);
-    expect(opts).toEqual({ openaiCompatible: { output_dimension: 2048 } });
+  test('Voyage openai-compatible returns dimensions for the SDK shim', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'voyage-3-large', 1024);
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1024 } });
+    const v4Opts = dimsProviderOptions('openai-compatible', 'voyage-4-large', 2048);
+    expect(v4Opts).toEqual({ openaiCompatible: { dimensions: 2048 } });
+    const v4NanoOpts = dimsProviderOptions('openai-compatible', 'voyage-4-nano', 512);
+    expect(v4NanoOpts).toEqual({ openaiCompatible: { dimensions: 512 } });
   });
 
   test('Voyage model without flexible dimensions returns undefined', () => {
     const opts = dimsProviderOptions('openai-compatible', 'voyage-3-lite', 1024);
     expect(opts).toBeUndefined();
+  });
+});
+
+describe('Voyage openai-compatible request shim', () => {
+  beforeEach(() => resetGateway());
+
+  test('sends output_dimension on the actual Voyage embedding request body', async () => {
+    const originalFetch = globalThis.fetch;
+    let requestBody: Record<string, unknown> | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      requestBody = JSON.parse(String(init?.body ?? '{}'));
+      return new Response(JSON.stringify({
+        object: 'list',
+        data: [
+          {
+            object: 'embedding',
+            index: 0,
+            embedding: new Array(2048).fill(0.01),
+          },
+        ],
+        model: 'voyage-4-large',
+        usage: { total_tokens: 3 },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      configureGateway({
+        embedding_model: 'voyage:voyage-4-large',
+        embedding_dimensions: 2048,
+        env: { VOYAGE_API_KEY: 'voyage-fake' },
+      });
+
+      const vectors = await embed(['dimension probe']);
+
+      expect(vectors[0].length).toBe(2048);
+      expect(requestBody?.output_dimension).toBe(2048);
+      expect(requestBody?.encoding_format).toBe('base64');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });


### PR DESCRIPTION
## TL;DR

Fixes Voyage 2048-dimensional embeddings by passing `dimensions` into the AI SDK, then letting GBrain's existing Voyage fetch shim translate that to Voyage's real wire field, `output_dimension`. Without this, GBrain can initialize a `vector(2048)` brain but the first Voyage embed request omits the dimension instruction and receives the wrong vector width.

```mermaid
flowchart LR
  A["embedding_dimensions=2048"] --> B["dimsProviderOptions"]
  B --> C["AI SDK openai-compatible"]
  C --> D["voyageCompatFetch"]
  D --> E["Voyage /embeddings"]

  B -->|"SDK key"| C
  C -->|"dimensions"| D
  D -->|"output_dimension"| E
```

## What Changed

- Changes Voyage OpenAI-compatible provider options from `output_dimension` to SDK-forwarded `dimensions`.
- Keeps the existing `voyageCompatFetch` rewrite as the single wire-compatibility point.
- Adds `voyage-4-nano` to the flexible-dimension Voyage model set.
- Adds a wire-level regression test proving the actual Voyage request body contains `output_dimension: 2048`.

## Why This Is The Small Fix

GBrain already has the right architecture: provider dimension knowledge lives in `dims.ts`, and Voyage wire differences live in the gateway fetch wrapper. The bug is just that `dims.ts` was bypassing the SDK contract by passing Voyage's final wire key too early.

This PR keeps the boundary intact:

- `dims.ts`: says "this model needs dimensions"
- AI SDK: receives the supported `dimensions` option
- `voyageCompatFetch`: translates to Voyage's `output_dimension`

## Non-Goals

- No schema changes.
- No HNSW changes.
- No pricing/default-dimension changes.
- No changes to unrelated OpenAI-compatible providers.

## Validation

- `git diff --check`
- Attempted focused local test: `bun test test/ai/gateway.test.ts`
  - Could not run in the fresh upstream worktree because dependencies are not installed there: `Cannot find package 'ai'`.
  - Full validation should run in GitHub Actions on this PR branch.
