### PR TITLE
fix(ai): respect user-provided embedding models

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -487,25 +487,25 @@ export function isAvailable(touchpoint: TouchpointKind): boolean {
         ? getChatModel()
         : null;
     if (!modelStr) return false;
-    const { recipe } = resolveRecipe(modelStr);
+    const { parsed, recipe } = resolveRecipe(modelStr);
 
     // Recipe must actually support the requested touchpoint.
     // Anthropic declares only expansion + chat (no embedding model); requesting
     // embedding from an anthropic-configured brain is unavailable regardless of auth.
     const touchpointConfig = recipe.touchpoints[touchpoint as 'embedding' | 'expansion' | 'chat'];
     if (!touchpointConfig) return false;
-    // Openai-compat recipes with empty models list require a user-provided
-    // model. Either the recipe explicitly opts in via
-    // EmbeddingTouchpoint.user_provided_models (D8=A), or the legacy
-    // `recipe.id === 'litellm'` heuristic (back-compat for pre-v0.32 builds
-    // where the field hadn't been declared yet).
-    const isUserProvided =
+    // BYO-backend recipes intentionally declare an empty model list. When the
+    // user already supplied `provider:model`, availability should depend on
+    // auth/readiness rather than the static list containing the model id.
+    const acceptsUserProvidedModel =
       touchpoint === 'embedding' &&
-      (touchpointConfig as any).user_provided_models === true;
+      'user_provided_models' in touchpointConfig &&
+      touchpointConfig.user_provided_models === true &&
+      parsed.modelId.length > 0;
     if (
       Array.isArray(touchpointConfig.models) &&
       touchpointConfig.models.length === 0 &&
-      (recipe.id === 'litellm' || isUserProvided)
+      !acceptsUserProvidedModel
     ) return false;
 
     // For openai-compatible without auth requirements (Ollama local), treat as always-available.

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -77,6 +77,16 @@ describe('gateway.isAvailable (silent-drop regression surface)', () => {
     expect(isAvailable('embedding')).toBe(true);
   });
 
+  test('embedding AVAILABLE for user-provided proxy model ids', () => {
+    configureGateway({
+      embedding_model: 'litellm:custom-embedding-model',
+      embedding_dimensions: 1024,
+      base_urls: { litellm: 'https://example.test/v1' },
+      env: { LITELLM_API_KEY: 'fake-litellm' },
+    });
+    expect(isAvailable('embedding')).toBe(true);
+  });
+
   test('anthropic rejects embedding touchpoint (has no embedding model)', () => {
     configureGateway({
       embedding_model: 'anthropic:claude-haiku-4-5-20251001',


### PR DESCRIPTION
## Summary

Fixes the AI gateway availability check for BYO embedding backends whose recipes intentionally declare `models: []` and `embedding.user_provided_models: true`.

`litellm` and other user-provided embedding recipes do not have a static model allowlist because the proxy/backend decides what model IDs are valid. When a user configures an explicit `provider:model` value, `isAvailable('embedding')` should continue to auth/readiness checks instead of treating the empty recipe model list as unavailable.

This keeps the fix generic: no default LiteLLM model, no provider-specific model recommendation, and no changes to init defaults.

## Root Cause

`isAvailable('embedding')` returned `false` for empty `touchpoint.models` before considering `EmbeddingTouchpoint.user_provided_models`. That made explicitly configured proxy models look unavailable even when the recipe advertises that user-provided model IDs are expected.

## Test Coverage

Added a focused regression case in `test/ai/gateway.test.ts`:

- `embedding AVAILABLE for user-provided proxy model ids`
- uses neutral `litellm:custom-embedding-model`
- verifies the empty recipe model list no longer suppresses availability when `user_provided_models` is true

TDD evidence: the new test failed before the implementation change with `Expected: true / Received: false`, then passed after the gateway fix.

## Test plan

- [x] `bun test test/ai/gateway.test.ts` — 23 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run verify` — clean (privacy/jsonb/progress/test-isolation/wasm/admin build/admin scope/cli executable/typecheck)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->