### PR TITLE
[codex] Fix dream provenance and AI SDK v6 tool loop

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -21,7 +21,7 @@
  *     rotation (via configureGateway()) invalidates stale entries.
  */
 
-import { embed as aiEmbed, embedMany, generateObject, generateText } from 'ai';
+import { embed as aiEmbed, embedMany, generateObject, generateText, jsonSchema } from 'ai';
 import { listRecipes } from './recipes/index.ts';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
@@ -844,6 +844,7 @@ export type ChatRole = 'system' | 'user' | 'assistant' | 'tool';
 
 export type ChatBlock =
   | { type: 'text'; text: string }
+  | { type: 'reasoning'; text: string }
   | { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown }
   | { type: 'tool-result'; toolCallId: string; toolName: string; output: unknown; isError?: boolean };
 
@@ -896,6 +897,12 @@ export interface ChatOpts {
    */
   cacheSystem?: boolean;
 }
+
+type AiSdkToolResultOutput =
+  | { type: 'text'; value: string }
+  | { type: 'json'; value: unknown }
+  | { type: 'error-text'; value: string }
+  | { type: 'error-json'; value: unknown };
 
 async function resolveChatProvider(modelStr: string): Promise<{ model: any; recipe: Recipe; modelId: string }> {
   const { parsed, recipe } = resolveRecipe(modelStr);
@@ -988,7 +995,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
   const tools = (opts.tools ?? []).reduce((acc, t) => {
     acc[t.name] = {
       description: t.description,
-      inputSchema: { jsonSchema: t.inputSchema } as any,
+      inputSchema: jsonSchema(t.inputSchema as any),
     };
     return acc;
   }, {} as Record<string, any>);
@@ -1002,7 +1009,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
     const result = await generateText({
       model,
       system: opts.system,
-      messages: opts.messages as any,
+      messages: toAiSdkMessages(opts.messages) as any,
       tools: opts.tools && opts.tools.length > 0 ? tools : undefined,
       maxOutputTokens: opts.maxTokens ?? 4096,
       abortSignal: opts.abortSignal,
@@ -1016,6 +1023,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
     if (Array.isArray(rawContent) && rawContent.length > 0) {
       for (const part of rawContent) {
         if (part.type === 'text') blocks.push({ type: 'text', text: part.text });
+        else if (part.type === 'reasoning') blocks.push({ type: 'reasoning', text: part.text ?? '' });
         else if (part.type === 'tool-call') {
           blocks.push({
             type: 'tool-call',
@@ -1062,6 +1070,45 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
     throw normalizeAIError(err, `chat(${recipe.id}:${modelId})`);
   }
 }
+
+function toAiSdkMessages(messages: ChatMessage[]): ChatMessage[] {
+  return messages.map(message => {
+    if (!Array.isArray(message.content)) return message;
+    return {
+      ...message,
+      content: message.content.map(block => {
+        if (block.type !== 'tool-result') return block;
+        return {
+          ...block,
+          output: toAiSdkToolResultOutput(block.output, block.isError),
+        };
+      }),
+    };
+  });
+}
+
+function toAiSdkToolResultOutput(output: unknown, isError?: boolean): AiSdkToolResultOutput {
+  if (isError) {
+    if (typeof output === 'string') return { type: 'error-text', value: output };
+    return { type: 'error-json', value: toJsonValue(output) };
+  }
+  if (typeof output === 'string') return { type: 'text', value: output };
+  return { type: 'json', value: toJsonValue(output) };
+}
+
+function toJsonValue(value: unknown): unknown {
+  if (value === undefined) return null;
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return String(value);
+  }
+}
+
+export const __testing = {
+  toAiSdkMessages,
+  toAiSdkToolResultOutput,
+};
 
 // ---- Future touchpoint stubs ----
 

--- a/src/core/cycle/patterns.ts
+++ b/src/core/cycle/patterns.ts
@@ -27,6 +27,7 @@ import { waitForCompletion, TimeoutError } from '../minions/wait-for-completion.
 import type { MinionJobInput, SubagentHandlerData } from '../minions/types.ts';
 import { serializeMarkdown } from '../markdown.ts';
 import type { Page, PageType } from '../types.ts';
+import { collectChildPutPageSlugs } from './tool-provenance.ts';
 
 export interface PatternsPhaseOpts {
   brainDir: string;
@@ -217,24 +218,6 @@ When done, briefly list the pattern slugs you wrote/updated in your final messag
 }
 
 // ── Provenance via put_page tool execution rows ─────────────────────
-
-async function collectChildPutPageSlugs(
-  engine: BrainEngine,
-  childIds: number[],
-): Promise<string[]> {
-  if (childIds.length === 0) return [];
-  const rows = await engine.executeRaw<{ slug: string }>(
-    `SELECT DISTINCT input->>'slug' AS slug
-       FROM subagent_tool_executions
-      WHERE job_id = ANY($1::int[])
-        AND tool_name = 'brain_put_page'
-        AND status = 'complete'
-        AND input ? 'slug'
-      ORDER BY 1`,
-    [childIds],
-  );
-  return rows.map(r => r.slug).filter((s): s is string => typeof s === 'string' && s.length > 0);
-}
 
 // ── Reverse-write ────────────────────────────────────────────────────
 

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -37,6 +37,7 @@ import type { MinionJobInput, SubagentHandlerData } from '../minions/types.ts';
 import { discoverTranscripts, type DiscoveredTranscript } from './transcript-discovery.ts';
 import { serializeMarkdown } from '../markdown.ts';
 import type { Page, PageType } from '../types.ts';
+import { collectChildPutPageSlugs } from './tool-provenance.ts';
 
 // Slug regex from validatePageSlug — kept in sync.
 // Used for the orchestrator-written summary index slug.
@@ -467,24 +468,6 @@ function sanitizeForSlug(s: string): string {
 }
 
 // ── Slug collection from child put_page calls (codex #2) ────────────
-
-async function collectChildPutPageSlugs(
-  engine: BrainEngine,
-  childIds: number[],
-): Promise<string[]> {
-  if (childIds.length === 0) return [];
-  const rows = await engine.executeRaw<{ slug: string }>(
-    `SELECT DISTINCT input->>'slug' AS slug
-       FROM subagent_tool_executions
-      WHERE job_id = ANY($1::int[])
-        AND tool_name = 'brain_put_page'
-        AND status = 'complete'
-        AND input ? 'slug'
-      ORDER BY 1`,
-    [childIds],
-  );
-  return rows.map(r => r.slug).filter((s): s is string => typeof s === 'string' && s.length > 0);
-}
 
 // ── Reverse-write DB rows → markdown files ───────────────────────────
 

--- a/src/core/cycle/tool-provenance.ts
+++ b/src/core/cycle/tool-provenance.ts
@@ -1,0 +1,42 @@
+import type { BrainEngine } from '../engine.ts';
+
+export function extractPutPageSlugFromToolInput(input: unknown): string | null {
+  let value = input;
+  for (let i = 0; i < 3; i++) {
+    if (typeof value !== 'string') break;
+    try {
+      value = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const slug = (value as { slug?: unknown }).slug;
+    return typeof slug === 'string' && slug.length > 0 ? slug : null;
+  }
+  return null;
+}
+
+export async function collectChildPutPageSlugs(
+  engine: BrainEngine,
+  childIds: number[],
+): Promise<string[]> {
+  if (childIds.length === 0) return [];
+  const rows = await engine.executeRaw<{ input: unknown }>(
+    `SELECT input
+       FROM subagent_tool_executions
+      WHERE job_id = ANY($1::int[])
+        AND tool_name = 'brain_put_page'
+        AND status = 'complete'
+      ORDER BY id`,
+    [childIds],
+  );
+
+  const slugs = new Set<string>();
+  for (const row of rows) {
+    const slug = extractPutPageSlugFromToolInput(row.input);
+    if (slug) slugs.add(slug);
+  }
+  return Array.from(slugs).sort();
+}

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -207,4 +207,37 @@ describe('chat touchpoint — chat() smoke + stop-reason mapping (Codex D8)', ()
     const mod = await import('../../src/core/ai/gateway.ts');
     expect(mod).toBeDefined();
   });
+
+  test('tool-result ChatBlocks are converted to AI SDK output envelopes', async () => {
+    const mod = await import('../../src/core/ai/gateway.ts');
+    const messages = (mod as any).__testing.toAiSdkMessages([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'tc_1',
+            toolName: 'brain_search',
+            output: [{ slug: 'wiki/example' }],
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'tc_2',
+            toolName: 'broken',
+            output: 'tool failed',
+            isError: true,
+          },
+        ],
+      },
+    ]);
+
+    expect(messages[0]!.content[0]!.output).toEqual({
+      type: 'json',
+      value: [{ slug: 'wiki/example' }],
+    });
+    expect(messages[0]!.content[1]!.output).toEqual({
+      type: 'error-text',
+      value: 'tool failed',
+    });
+  });
 });

--- a/test/tool-provenance.test.ts
+++ b/test/tool-provenance.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+import {
+  collectChildPutPageSlugs,
+  extractPutPageSlugFromToolInput,
+} from '../src/core/cycle/tool-provenance.ts';
+
+describe('tool provenance slug collection', () => {
+  test('extracts put_page slugs from object and JSON-string inputs', () => {
+    expect(extractPutPageSlugFromToolInput({ slug: 'wiki/a' })).toBe('wiki/a');
+    expect(extractPutPageSlugFromToolInput('{"slug":"wiki/b"}')).toBe('wiki/b');
+    expect(extractPutPageSlugFromToolInput('"{\\"slug\\":\\"wiki/c\\"}"')).toBe('wiki/c');
+    expect(extractPutPageSlugFromToolInput({ slug: '' })).toBeNull();
+    expect(extractPutPageSlugFromToolInput('{"content":"missing slug"}')).toBeNull();
+    expect(extractPutPageSlugFromToolInput('not json')).toBeNull();
+  });
+
+  test('collects distinct slugs without relying on jsonb object operators', async () => {
+    const engine = {
+      async executeRaw<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]> {
+        expect(sql).toContain('SELECT input');
+        expect(sql).not.toContain("input ? 'slug'");
+        expect(params).toEqual([[8]]);
+        return [
+          { input: '{"slug":"wiki/a"}' },
+          { input: '"{\\"slug\\":\\"wiki/b\\"}"' },
+          { input: { slug: 'wiki/a' } },
+          { input: '{"content":"missing slug"}' },
+        ] as T[];
+      },
+    } as Pick<BrainEngine, 'executeRaw'> as BrainEngine;
+
+    await expect(collectChildPutPageSlugs(engine, [8])).resolves.toEqual(['wiki/a', 'wiki/b']);
+  });
+});


### PR DESCRIPTION
﻿## Summary

- Make dream provenance slug collection robust when `subagent_tool_executions.input` is stored as either JSONB objects or JSON strings.
- Adapt the chat gateway tool-loop plumbing to AI SDK v6 by using `jsonSchema(...)`, converting persisted `tool-result` blocks into SDK output envelopes, and preserving reasoning blocks.

## Why

The dream synthesize/patterns flow previously queried `input ? 'slug'`, which misses production rows where tool input is a JSON string. That can make `brain_put_page` provenance look empty even after pages were written.

The chat gateway also still passed v5-style tool schema and raw persisted tool-result blocks into `generateText`, which breaks the v6 tool loop contract.

## Validation

- `/home/hermes/.bun/bin/bun test test/ai/gateway-chat.test.ts`
- `/home/hermes/.bun/bin/bun run typecheck`
- `/home/hermes/.bun/bin/bun test test/tool-provenance.test.ts test/ai/gateway-chat.test.ts test/cycle-synthesize.test.ts test/e2e/dream-synthesize-pglite.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->