### PR TITLE
fix(serve): skip stdin EOF handlers when MCP_STDIO=1

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -201,7 +201,10 @@ function installStdioLifecycle(
   // Skip when stdin is a TTY: interactive `gbrain serve` use shouldn't
   // terminate just because the user hasn't typed anything. Signal /
   // watchdog paths still cover that case if needed.
-  if (!deps.stdin.isTTY) {
+  // Also skip stdin-end shutdown when MCP_STDIO=1: the gateway bundle-mcp
+  // layer spawns us with piped stdin that stays open for the session.
+  const skipStdinEndShutdown = deps.stdin.isTTY || process.env.MCP_STDIO === '1';
+  if (!skipStdinEndShutdown) {
     deps.stdin.once('end', () => beginShutdown('stdin-end'));
     deps.stdin.once('close', () => beginShutdown('stdin-close'));
   }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -62,8 +62,12 @@ export async function startMcpServer(engine: BrainEngine) {
       .catch(() => {})
       .finally(() => process.exit(code));
   };
-  process.stdin.on('end', () => shutdown('stdin end'));
-  process.stdin.on('close', () => shutdown('stdin close'));
+  // Skip stdin handlers when MCP_STDIO=1 (OpenClaw gateway spawns us with
+  // piped stdin that stays open for the session lifetime).
+  if (process.env.MCP_STDIO !== '1') {
+    process.stdin.on('end', () => shutdown('stdin end'));
+    process.stdin.on('close', () => shutdown('stdin close'));
+  }
   // @ts-ignore — SDK exposes onclose on transport
   transport.onclose = () => shutdown('transport close');
   process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/test/serve-stdio-lifecycle.test.ts
+++ b/test/serve-stdio-lifecycle.test.ts
@@ -440,3 +440,27 @@ describe('runServe stdio lifecycle', () => {
     expect(h.logs.some(l => l.includes('cleanup error: synthetic disconnect failure'))).toBe(true);
   });
 });
+
+  test('MCP_STDIO=1 skips stdin end watcher (gateway bundle-mcp mode)', async () => {
+    // When MCP_STDIO=1, the OpenClaw gateway spawns gbrain with a piped
+    // stdin that closes after the initial JSON-RPC handshake. We must NOT
+    // treat that pipe-EOF as a permanent client disconnect.
+    process.env.MCP_STDIO = '1';
+    try {
+      const h = makeHarness();
+      await startInBackground(h.engine, [], h.opts);
+
+      // Emit stdin 'end' — with MCP_STDIO=1, no listener was registered, so
+      // this is a no-op. The process must stay alive.
+      h.stdin.emit('end');
+      await new Promise(r => setTimeout(r, 10));
+      expect(h.engine.disconnectCalls).toBe(0);
+
+      // Signal handlers still work — process exits via SIGTERM
+      h.signals.emit('SIGTERM');
+      await h.exited;
+      expect(h.engine.disconnectCalls).toBe(1);
+    } finally {
+      delete process.env.MCP_STDIO;
+    }
+  });


### PR DESCRIPTION
## Bug

When `gbrain serve` is spawned by OpenClaw's gateway with `MCP_STDIO=1`, the
gateway's `bundle-mcp` layer creates a piped stdin that delivers EOF immediately
after the initial JSON-RPC handshake. This triggers premature `engine.disconnect()`
and process exit, preventing the MCP server from handling any tool calls.

Error seen in gateway logs:
```
failed to start server "gbrain" ... MCP error -32000: Connection closed
```

## Root cause

Two locations listen for stdin `'end'`/`'close'` to trigger graceful shutdown:

1. **`src/mcp/server.ts:startMcpServer()`** — the MCP SDK lifecycle handler
2. **`src/commands/serve.ts:installStdioLifecycle()`** — the parent watchdog (v0.32)

Both treat stdin EOF as "client disconnected permanently." With `MCP_STDIO=1`, the
pipe EOF fires at handshake completion but the session continues.

## Fix

Guard both stdin EOF handlers with `process.env.MCP_STDIO !== '1'`. Signal
handlers (SIGTERM/SIGINT/SIGHUP) and `transport.onclose` remain active so the
process still exits cleanly when appropriate.

**Files changed:**
- `src/mcp/server.ts` — guard stdin handlers
- `src/commands/serve.ts` — extend `skipStdinEndShutdown` check
- `test/serve-stdio-lifecycle.test.ts` — add regression test

## Verification

```bash
# Without fix: gbrain exits immediately with "Connection closed"
# With fix: gbrain stays alive and handles tool calls
MCP_STDIO=1 DATA_DIR=/root/.gbrain bun run src/cli.ts serve
```

All 23 stdio lifecycle tests pass (22 existing + 1 new).

---

**Testing**: `bun test test/serve-stdio-lifecycle.test.ts` — 23 pass, 0 fail

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->