### PR TITLE
feat(oauth): federated_read column + AuthInfo.allowedSources

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -360,15 +360,22 @@ async function embedAllStale(
 
   // Pull only the stale chunks (no embedding column).
   const staleRows = await engine.listStaleChunks();
-  // Group by slug so each slug → array of stale chunks for batched embedding.
-  const bySlug = new Map<string, typeof staleRows>();
+  // Group by (source_id, slug) so each page → array of stale chunks for batched embedding.
+  // Keyed by "source_id\0slug" to avoid collisions when the same slug exists in multiple sources.
+  type StaleKey = { source_id: string; slug: string };
+  const byKey = new Map<string, typeof staleRows>();
+  const keyMeta = new Map<string, StaleKey>();
   for (const row of staleRows) {
-    const list = bySlug.get(row.slug);
+    const key = `${row.source_id}\0${row.slug}`;
+    const list = byKey.get(key);
     if (list) list.push(row);
-    else bySlug.set(row.slug, [row]);
+    else {
+      byKey.set(key, [row]);
+      keyMeta.set(key, { source_id: row.source_id, slug: row.slug });
+    }
   }
 
-  const slugs = Array.from(bySlug.keys());
+  const keys = Array.from(byKey.keys());
   const totalStaleChunks = staleRows.length;
   result.total_chunks += totalStaleChunks;
   // skipped is "chunks we considered and skipped due to having an embedding".
@@ -378,21 +385,23 @@ async function embedAllStale(
 
   if (dryRun) {
     result.would_embed += totalStaleChunks;
-    result.pages_processed += slugs.length;
+    result.pages_processed += keys.length;
     if (onProgress) {
       // Emit a single tick to satisfy the contract (CLI progress reporters
       // expect at least one start/finish pair).
-      onProgress(slugs.length, slugs.length, 0);
+      onProgress(keys.length, keys.length, 0);
     }
-    console.log(`[dry-run] Would embed ${totalStaleChunks} chunks across ${slugs.length} pages`);
+    console.log(`[dry-run] Would embed ${totalStaleChunks} chunks across ${keys.length} pages`);
     return;
   }
 
   const CONCURRENCY = parseInt(process.env.GBRAIN_EMBED_CONCURRENCY || '20', 10);
   let processed = 0;
 
-  async function embedOneSlug(slug: string) {
-    const stale = bySlug.get(slug)!;
+  async function embedOneKey(key: string) {
+    const stale = byKey.get(key)!;
+    const meta = keyMeta.get(key)!;
+    const { slug, source_id } = meta;
     try {
       const embeddings = await embedBatch(stale.map(c => c.chunk_text));
       // CRITICAL: passing ONLY the stale indices to upsertChunks would
@@ -401,7 +410,9 @@ async function embedAllStale(
       // re-fetch existing chunks for this page and merge. Bounded by the
       // stale slug count, not by total slugs — autopilot common case
       // is 0 stale (pre-flight short-circuit, never reaches this path).
-      const existing = await engine.getChunks(slug);
+      // Pass sourceId from the staleRow → fixes "Page not found (source=default)"
+      // when stale chunks live in non-default sources (federated brain).
+      const existing = await engine.getChunks(slug, { sourceId: source_id });
       const staleIdxToEmbedding = new Map<number, Float32Array>();
       for (let j = 0; j < stale.length; j++) {
         staleIdxToEmbedding.set(stale[j].chunk_index, embeddings[j]);
@@ -415,26 +426,26 @@ async function embedAllStale(
         embedding: staleIdxToEmbedding.get(c.chunk_index) ?? undefined,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
-      await engine.upsertChunks(slug, merged);
+      await engine.upsertChunks(slug, merged, { sourceId: source_id });
       result.embedded += stale.length;
     } catch (e: unknown) {
-      console.error(`\n  Error embedding ${slug}: ${e instanceof Error ? e.message : e}`);
+      console.error(`\n  Error embedding ${slug} (source=${source_id}): ${e instanceof Error ? e.message : e}`);
     }
     processed++;
     result.pages_processed++;
-    onProgress?.(processed, slugs.length, result.embedded);
+    onProgress?.(processed, keys.length, result.embedded);
   }
 
   let nextIdx = 0;
   async function worker() {
-    while (nextIdx < slugs.length) {
+    while (nextIdx < keys.length) {
       const idx = nextIdx++;
-      await embedOneSlug(slugs[idx]);
+      await embedOneKey(keys[idx]);
     }
   }
 
-  const numWorkers = Math.min(CONCURRENCY, slugs.length);
+  const numWorkers = Math.min(CONCURRENCY, keys.length);
   await Promise.all(Array.from({ length: numWorkers }, () => worker()));
 
-  console.log(`Embedded ${result.embedded} chunks across ${slugs.length} pages`);
+  console.log(`Embedded ${result.embedded} chunks across ${keys.length} pages`);
 }

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -926,9 +926,25 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
       // ToolResult and we read isError + _meta to pick the right branch.
       const tokenAllowList = (authInfo as AuthInfo & { takesHoldersAllowList?: string[] }).takesHoldersAllowList
         ?? ['world'];
-      const tokenSourceId = (authInfo as AuthInfo & { sourceId?: string }).sourceId
-        ?? process.env.GBRAIN_SOURCE
-        ?? 'default';
+      // v0.31.4 fix/mcp-source-isolation-read-side:
+      //   authInfo.sourceId is populated from oauth_clients.source_id (migration v47).
+      //
+      //   - SET   → strict source isolation. Engine WHERE-filters reads on
+      //             pages.source_id; put_page rejects cross-source writes.
+      //   - NULL  → federated/super-reader. No WHERE filter, callers see every
+      //             source. This matches Robin's stdio CLI (no token = no scope)
+      //             and gives admin/Robin-class OAuth clients full federated reach.
+      //
+      //   Why NULL = federated (not 'default'):
+      //   Pre-v0.31.4, EVERY OAuth client silently collapsed onto source 'default'
+      //   because authInfo carried no real scope and the engine ignored opts.sourceId.
+      //   That was a bug, not a feature. The fix wires real auth-derived scoping
+      //   when set, and gives unscoped clients the same federated behavior as the
+      //   unauthenticated stdio path — no silent partial-view footgun.
+      //
+      //   `GBRAIN_SOURCE` env var is a deployment-level escape hatch for
+      //   unauthenticated callers only — it never overrides a populated token claim.
+      const tokenSourceId = authInfo.sourceId ?? undefined;
 
       let toolResult: Awaited<ReturnType<typeof dispatchToolCall>>;
       try {

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -952,6 +952,13 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
           remote: true,
           takesHoldersAllowList: tokenAllowList,
           sourceId: tokenSourceId,
+          // v0.32.x (feat/oauth-federated-read): forward the per-client
+          // READ scope from oauth_clients.federated_read so engine read
+          // paths use `source_id = ANY($allowedSources)` for filtering.
+          // Without this, OAuth clients silently fell back to the
+          // single-source filter (sourceId only) — wecare-dept-* tokens
+          // saw their own source but never the federated 'shared' set.
+          allowedSources: (authInfo as AuthInfo & { allowedSources?: string[] }).allowedSources,
           metaHook: getBrainHotMemoryMeta,
           // v0.31 follow-up fix: thread auth so the whoami op (and any
           // future scope-aware handlers) can introspect the caller. The

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -485,7 +485,11 @@ export interface BrainEngine {
    * `filters.includeDeleted: true` to surface them.
    */
   listPages(filters?: PageFilters): Promise<Page[]>;
-  resolveSlugs(partial: string): Promise<string[]>;
+  /**
+   * v0.31.4: optional `sourceId` scopes both exact and fuzzy matching to a
+   * single source. Unset = federated (matches local CLI + Robin super-reader).
+   */
+  resolveSlugs(partial: string, opts?: { sourceId?: string }): Promise<string[]>;
   /**
    * Returns the slug of every page in the brain. Used by batch commands as a
    * mutation-immune iteration source (alternative to listPages OFFSET pagination,
@@ -615,18 +619,25 @@ export interface BrainEngine {
     dirPrefix?: string,
     minSimilarity?: number,
   ): Promise<{ slug: string; similarity: number } | null>;
-  traverseGraph(slug: string, depth?: number): Promise<GraphNode[]>;
+  /**
+   * v0.31.4 (P0/leak-2026-05-11): `opts.sourceId` constrains visited nodes to a
+   * single source. When omitted (federated/super-reader), all sources visible.
+   * MCP-bound callers MUST pass `{ sourceId: ctx.sourceId }` so cross-source
+   * pages can't be discovered via graph metadata even when get_page denies them.
+   */
+  traverseGraph(slug: string, depth?: number, opts?: { sourceId?: string }): Promise<GraphNode[]>;
   /**
    * Edge-based graph traversal with optional type and direction filters.
    * Returns a list of edges (GraphPath[]) instead of nodes. Supports:
    * - linkType: per-edge filter, only follows matching edges (per-edge semantics)
    * - direction: 'in' (follow to->from), 'out' (follow from->to), 'both'
    * - depth: max depth from root (default 5)
+   * - sourceId: v0.31.4, see traverseGraph note above
    * Uses cycle prevention (visited array in recursive CTE).
    */
   traversePaths(
     slug: string,
-    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both' },
+    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both'; sourceId?: string },
   ): Promise<GraphPath[]>;
   /**
    * For a list of slugs, return how many inbound links each has.

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -2596,6 +2596,140 @@ export const MIGRATIONS: Migration[] = [
         ON oauth_clients(source_id) WHERE source_id IS NOT NULL;
     `,
   },
+  {
+    version: 52,
+    name: 'oauth_clients_federated_read',
+    idempotent: true,
+    // v0.32.x feat/oauth-federated-read. Adds federated_read TEXT[] so MCP
+    // HTTP clients can read from multiple sources without being super-readers.
+    //
+    // Pre-v52 read model:
+    //   source_id IS NULL    -> federated super-reader (reads ALL sources)
+    //   source_id = '<id>'   -> reads + writes scoped to that one source
+    //
+    // The NULL=super-reader leg is a footgun. The v51 FK
+    // (ON DELETE SET NULL) silently super-promotes any client whose source
+    // is dropped. There's also no middle ground — a client either sees one
+    // source or every source. WeCare L3 dept clients legitimately need to
+    // read `dept-<x>` + `wecare` (parent L2 canon) + `shared` (org canon)
+    // but write only to `dept-<x>`.
+    //
+    // Post-v52 read model:
+    //   federated_read TEXT[]      -> set of source ids the client may READ
+    //   source_id      TEXT NOT NULL -> single source the client WRITES to
+    //
+    // The two columns decouple read scope from write target. Engine read
+    // paths use `source_id = ANY($allowedSources)`; engine writes still pin
+    // to `source_id = $sourceId` (the write-target column).
+    //
+    // NULL super-reader retired entirely for OAuth callers. Super-reader
+    // privilege survives only on the CLI path (no auth, GBRAIN_SOURCE-
+    // controlled). The CLI never goes through verifyAccessToken so this
+    // migration cannot affect it.
+    //
+    // Backfill convention:
+    //   * Every non-NULL client gets [source_id, 'shared'] minimum.
+    //   * wecare-dept-* clients additionally get 'wecare' so depts can read
+    //     Augustus's L2 canon. (Matches existing org hierarchy: L3 reads up
+    //     into parent L2, L2 reads into shared.)
+    //   * NULL source_id rows are illegal post-migration — audit-oauth-
+    //     bindings.sh treats any NULL as a P0 drift. Migration aborts loudly
+    //     if it finds one (caller must bind it before re-running).
+    //
+    // Index: GIN on federated_read for ANY()/array membership at scale.
+    sql: `
+      -- 1. Refuse to migrate if any client still has NULL source_id.
+      --    These should have been bound before v52 lands; see skill
+      --    devops/gbrain-oauth-client-binding for the audit procedure.
+      DO $$
+      DECLARE
+        n_nulls INTEGER;
+      BEGIN
+        SELECT COUNT(*) INTO n_nulls
+        FROM oauth_clients
+        WHERE source_id IS NULL AND deleted_at IS NULL;
+
+        IF n_nulls > 0 THEN
+          RAISE EXCEPTION 'v52 abort: % oauth_clients row(s) still have NULL source_id. Bind them (UPDATE oauth_clients SET source_id=...) before re-running this migration. See skill: gbrain-oauth-client-binding.', n_nulls;
+        END IF;
+      END $$;
+
+      -- 2. Add the federated_read column.
+      ALTER TABLE oauth_clients
+        ADD COLUMN IF NOT EXISTS federated_read TEXT[] NOT NULL DEFAULT '{}';
+
+      -- 3. Backfill — only rows whose federated_read is still empty (== never
+      --    touched by a previous run of this migration).
+      --
+      --    Pattern: [source_id, 'shared'] + 'wecare' for dept-* clients.
+      --    de-dup via the OR predicate; final array is unique by construction.
+      UPDATE oauth_clients
+      SET federated_read =
+        ARRAY(
+          SELECT DISTINCT unnest(arr)
+          FROM (
+            SELECT ARRAY[source_id, 'shared']
+              || CASE WHEN client_name LIKE 'wecare-dept-%'
+                      THEN ARRAY['wecare']
+                      ELSE ARRAY[]::TEXT[]
+                 END AS arr
+          ) sub
+        )
+      WHERE federated_read = '{}' AND source_id IS NOT NULL;
+
+      -- 4. Make source_id NOT NULL — write target is now required.
+      --    Step 3 enforced that no live row is NULL, so this is safe.
+      DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1
+          FROM information_schema.columns
+          WHERE table_name = 'oauth_clients'
+            AND column_name = 'source_id'
+            AND is_nullable = 'YES'
+        ) THEN
+          ALTER TABLE oauth_clients
+            ALTER COLUMN source_id SET NOT NULL;
+        END IF;
+      END $$;
+
+      -- 5. Drop the ON DELETE SET NULL FK and replace with RESTRICT so a
+      --    source drop can no longer silently corrupt a client.
+      DO $$
+      BEGIN
+        IF EXISTS (
+          SELECT 1 FROM pg_constraint
+          WHERE conname = 'oauth_clients_source_id_fkey'
+        ) THEN
+          ALTER TABLE oauth_clients
+            DROP CONSTRAINT oauth_clients_source_id_fkey;
+        END IF;
+
+        ALTER TABLE oauth_clients
+          ADD CONSTRAINT oauth_clients_source_id_fkey
+          FOREIGN KEY (source_id) REFERENCES sources(id) ON DELETE RESTRICT;
+      END $$;
+
+      -- 6. GIN index for ANY()/array containment lookups (5 read paths).
+      CREATE INDEX IF NOT EXISTS idx_oauth_clients_federated_read
+        ON oauth_clients USING GIN (federated_read);
+
+      -- 7. Sanity invariant: a client's own source must be in its read set.
+      --    Implemented as a CHECK constraint so future bad UPDATEs fail
+      --    rather than corrupting silently.
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint
+          WHERE conname = 'oauth_clients_own_source_in_read'
+        ) THEN
+          ALTER TABLE oauth_clients
+            ADD CONSTRAINT oauth_clients_own_source_in_read
+            CHECK (source_id = ANY(federated_read));
+        END IF;
+      END $$;
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -2548,6 +2548,54 @@ export const MIGRATIONS: Migration[] = [
         ON ingest_log (source_id, source_type, created_at DESC);
     `,
   },
+  {
+    version: 51,
+    name: 'oauth_clients_source_isolation',
+    idempotent: true,
+    // v0.32.x fix/mcp-source-isolation-read-side. Renumbered from v47 to v51
+    // after rebasing onto master which already claimed v47 (facts_notability),
+    // v48 (takes_weight_round_to_grid), v49 (eval_takes_quality_runs), and
+    // v50 (ingest_log_source_id).
+    //
+    // Adds oauth_clients.source_id so MCP HTTP callers can be scoped to a
+    // single brain source at the auth layer. Before this column, every
+    // OAuth client fell back to source_id='default' in serve-http.ts and
+    // engine reads silently ignored opts.sourceId, leaking pages across
+    // sources on list_pages / search / query.
+    //
+    // Semantics:
+    //   source_id IS NULL                -> federated read (super-reader /
+    //                                        admin clients; matches stdio CLI
+    //                                        with no auth)
+    //   source_id = '<id>' (FK sources)  -> reads + writes are scoped to that
+    //                                        source only; engine WHERE-filters
+    //                                        on it; put_page rejects cross-source
+    //
+    // FK uses ON DELETE SET NULL so dropping a source doesn't cascade-kill
+    // OAuth clients (they fall back to federated, fail-open at auth layer).
+    // The auth-layer scope decision then prevents writes via the put_page
+    // operation-level guard already in operations.ts (ctx.remote &&
+    // ctx.sourceId).
+    sql: `
+      ALTER TABLE oauth_clients
+        ADD COLUMN IF NOT EXISTS source_id TEXT;
+
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint
+          WHERE conname = 'oauth_clients_source_id_fkey'
+        ) THEN
+          ALTER TABLE oauth_clients
+            ADD CONSTRAINT oauth_clients_source_id_fkey
+            FOREIGN KEY (source_id) REFERENCES sources(id) ON DELETE SET NULL;
+        END IF;
+      END $$;
+
+      CREATE INDEX IF NOT EXISTS idx_oauth_clients_source_id
+        ON oauth_clients(source_id) WHERE source_id IS NOT NULL;
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -409,9 +409,11 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     // v0.31.4: pull c.source_id alongside client_name so MCP HTTP requests
     // can be scoped to the caller's brain source at dispatch time.
     // source_id IS NULL = federated/super-reader (legacy default behavior).
+    // v0.32.x (feat/oauth-federated-read): also pull c.federated_read — the
+    // read-scope array. Engine read paths use this for `source_id = ANY()`.
     const oauthRows = await this.sql`
       SELECT t.client_id, t.scopes, t.expires_at, t.resource,
-             c.client_name, c.source_id
+             c.client_name, c.source_id, c.federated_read
       FROM oauth_tokens t
       LEFT JOIN oauth_clients c ON c.client_id = t.client_id
       WHERE t.token_hash = ${tokenHash} AND t.token_type = 'access'
@@ -426,6 +428,15 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
       if (expiresAt === undefined || expiresAt < now) {
         throw new Error('Token expired');
       }
+      // v0.32.x: federated_read is TEXT[] NOT NULL DEFAULT '{}'. On a
+      // freshly-migrated DB it's always populated. On an un-migrated DB
+      // (LEFT JOIN miss or pre-v52 schema) it comes back undefined/null —
+      // we coerce to undefined so engines fall back to scalar sourceId.
+      const fedReadRaw = row.federated_read;
+      const allowedSources =
+        Array.isArray(fedReadRaw) && fedReadRaw.length > 0
+          ? (fedReadRaw as unknown[]).filter((s): s is string => typeof s === 'string')
+          : undefined;
       return {
         token,
         clientId: row.client_id as string,
@@ -435,6 +446,9 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
         resource: row.resource ? new URL(row.resource as string) : undefined,
         // v0.31.4: source-isolation. Undefined => federated read.
         sourceId: (row.source_id as string | null) ?? undefined,
+        // v0.32.x: explicit read-scope set (post-v52). Engines prefer this
+        // over sourceId for read filters; writes still go to sourceId.
+        allowedSources,
       } as AuthInfo;
     }
 

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -406,8 +406,12 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     // verifyAccessToken returns client_name in AuthInfo — eliminates the
     // separate per-request lookup at serve-http.ts that was the N+1 hot
     // path (see PR #586 review D14=B).
+    // v0.31.4: pull c.source_id alongside client_name so MCP HTTP requests
+    // can be scoped to the caller's brain source at dispatch time.
+    // source_id IS NULL = federated/super-reader (legacy default behavior).
     const oauthRows = await this.sql`
-      SELECT t.client_id, t.scopes, t.expires_at, t.resource, c.client_name
+      SELECT t.client_id, t.scopes, t.expires_at, t.resource,
+             c.client_name, c.source_id
       FROM oauth_tokens t
       LEFT JOIN oauth_clients c ON c.client_id = t.client_id
       WHERE t.token_hash = ${tokenHash} AND t.token_type = 'access'
@@ -429,6 +433,8 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
         scopes: (row.scopes as string[]) || [],
         expiresAt,
         resource: row.resource ? new URL(row.resource as string) : undefined,
+        // v0.31.4: source-isolation. Undefined => federated read.
+        sourceId: (row.source_id as string | null) ?? undefined,
       } as AuthInfo;
     }
 

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -190,6 +190,33 @@ export function validateFilename(name: string): void {
   }
 }
 
+/**
+ * v0.32.x feat/oauth-federated-read: build the source-scope opts bag for
+ * READ-side engine calls. Resolution order:
+ *
+ *   1. `ctx.allowedSources` set & non-empty  →  `{ allowedSources }`
+ *      (engine uses `WHERE source_id = ANY($1::text[])`)
+ *   2. `ctx.sourceId` set                    →  `{ sourceId }`
+ *      (engine uses `WHERE source_id = $1` — legacy single-source path)
+ *   3. neither set                           →  `{}`
+ *      (engine applies no source filter — super-reader: local CLI,
+ *      legacy admin tokens, Robin's privileged token)
+ *
+ * This helper exists so the same read filter shape (engine-side: prefer
+ * ANY over scalar over no-filter) is computed in exactly one place. Write
+ * ops MUST NOT use this — they pin to `ctx.sourceId` directly so federated
+ * read never silently expands write authority across sources.
+ */
+export function readScopeOpts(ctx: OperationContext): { allowedSources?: string[]; sourceId?: string } {
+  if (ctx.allowedSources && ctx.allowedSources.length > 0) {
+    return { allowedSources: ctx.allowedSources };
+  }
+  if (ctx.sourceId) {
+    return { sourceId: ctx.sourceId };
+  }
+  return {};
+}
+
 export interface ParamDef {
   type: 'string' | 'number' | 'boolean' | 'object' | 'array';
   required?: boolean;
@@ -229,8 +256,26 @@ export interface AuthInfo {
    * Populated by `OAuthProvider.verifyAccessToken` from `oauth_clients.source_id`.
    * For legacy bearer tokens (access_tokens table) it falls back to
    * `permissions.source_id`.
+   *
+   * Post-v52 (federated-read): this is the WRITE-target source (1:1 with
+   * `oauth_clients.source_id`). `allowedSources` below is the READ set.
    */
   sourceId?: string;
+  /**
+   * v0.32.x feat/oauth-federated-read: the set of source ids this client is
+   * allowed to READ from. Populated by `OAuthProvider.verifyAccessToken`
+   * from `oauth_clients.federated_read`. Always non-empty for v52+ clients
+   * (CHECK constraint enforces `source_id = ANY(federated_read)`).
+   *
+   * When set, engine read paths use `source_id = ANY($allowedSources::text[])`
+   * for filtering. When unset (legacy/CLI callers / pre-v52 clients that
+   * haven't been migrated), engines fall back to scalar `sourceId` filter
+   * or no filter (super-reader) per pre-v52 semantics.
+   *
+   * Writes still scope to scalar `sourceId` — federated_read does NOT grant
+   * write privilege across sources.
+   */
+  allowedSources?: string[];
 }
 
 export interface OperationContext {
@@ -344,8 +389,25 @@ export interface OperationContext {
    *
    * Pre-v0.31 callers (pages/links/etc.) keep working without change —
    * sourceId here is purely additive context for the new ops.
+   *
+   * Post-v52 (federated-read, pages-side): for HTTP-MCP callers this is the
+   * WRITE-target source (used by put_page / delete_page / restore_page).
+   * The READ scope is in `allowedSources` below.
    */
   sourceId?: string;
+  /**
+   * v0.32.x feat/oauth-federated-read: the set of source ids the current
+   * caller may READ from. Threaded by HTTP transport from
+   * `AuthInfo.allowedSources`. Engine read paths (getPage, listPages,
+   * getAllSlugs, resolveSlugs, traverseGraph, query/search) prefer this
+   * over `sourceId` when set:
+   *   - `allowedSources` set & non-empty → `WHERE source_id = ANY($1::text[])`
+   *   - `allowedSources` unset & `sourceId` set → `WHERE source_id = $1` (legacy)
+   *   - both unset → no filter (super-reader / CLI default)
+   *
+   * Writes never consult this field; they pin to `sourceId`.
+   */
+  allowedSources?: string[];
 }
 
 export interface Operation {
@@ -388,12 +450,10 @@ const get_page: Operation = {
     const slug = p.slug as string;
     const fuzzy = (p.fuzzy as boolean) || false;
     const includeDeleted = (p.include_deleted as boolean) === true;
-    // v0.31.8 (D20): thread ctx.sourceId through read-side ops. Only pass
-    // sourceId when it's set on ctx — when unset (local CLI default chain
-    // resolves to no source), the engine two-branch query falls through to
-    // the cross-source view, preserving pre-v0.31.8 behavior. MCP callers
-    // (stdio + HTTP) populate ctx.sourceId via the transport layer.
-    const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
+    // v0.31.8 (D20) + v0.32.x (federated-read): thread the caller's read
+    // scope through. readScopeOpts prefers ctx.allowedSources (post-v52
+    // OAuth set) over scalar ctx.sourceId (legacy) over no-filter (CLI).
+    const sourceOpts = readScopeOpts(ctx);
 
     let page = await ctx.engine.getPage(slug, { includeDeleted, ...sourceOpts });
     let resolved_slug: string | undefined;
@@ -920,10 +980,10 @@ const list_pages: Operation = {
       includeDeleted: (p.include_deleted as boolean) === true,
       updated_after: typeof p.updated_after === 'string' ? p.updated_after : undefined,
       sort,
-      // v0.31.4 (mcp-source-isolation fix): scope listing to the caller's
-      // source when the dispatch context carries one. Tokens without a
-      // sourceId (Robin super-reader, local CLI) keep federated listing.
-      sourceId: ctx.sourceId,
+      // v0.31.4 + v0.32.x (federated-read): scope listing to the caller's
+      // read set. allowedSources (post-v52) takes precedence; falls back to
+      // scalar sourceId (legacy); unset = super-reader.
+      ...readScopeOpts(ctx),
     });
     return pages.map(pg => ({
       slug: pg.slug,
@@ -953,10 +1013,9 @@ const search: Operation = {
     const raw = await ctx.engine.searchKeyword(queryText, {
       limit: (p.limit as number) || 20,
       offset: (p.offset as number) || 0,
-      // v0.31.4: thread token-scoped sourceId for read isolation. Engine
-      // applies the WHERE clause when set; undefined = federated/super-reader.
-      // See fix/mcp-source-isolation-read-side.
-      sourceId: ctx.sourceId,
+      // v0.31.4 + v0.32.x (federated-read): allowedSources (post-v52) wins
+      // over scalar sourceId; both unset = federated/super-reader.
+      ...readScopeOpts(ctx),
     });
     const results = dedupResults(raw);
     const latency_ms = Date.now() - startedAt;
@@ -1066,9 +1125,8 @@ const query: Operation = {
         limit: (p.limit as number) || 20,
         offset: (p.offset as number) || 0,
         embeddingColumn: 'embedding_image',
-        // v0.31.4: thread token-scoped sourceId for read isolation.
-        // See fix/mcp-source-isolation-read-side.
-        sourceId: ctx.sourceId,
+        // v0.31.4 + v0.32.x (federated-read): read scope from ctx.
+        ...readScopeOpts(ctx),
       });
       return results;
     }
@@ -1097,11 +1155,9 @@ const query: Operation = {
       since: typeof p.since === 'string' ? p.since : undefined,
       until: typeof p.until === 'string' ? p.until : undefined,
       onMeta: (m) => { capturedMeta = m; },
-      // v0.31.4 (mcp-source-isolation read-side fix): thread token-scoped
-      // sourceId so vector/keyword/hybrid search honors caller isolation.
-      // hybridSearch already accepts + threads this to engine.searchVector
-      // and engine.searchKeyword; the op handler just wasn't passing it.
-      sourceId: ctx.sourceId,
+      // v0.31.4 + v0.32.x (federated-read): hybridSearch threads this on
+      // to searchVector + searchKeyword. allowedSources (post-v52) preferred.
+      ...readScopeOpts(ctx),
     });
     const latency_ms = Date.now() - startedAt;
 
@@ -1343,8 +1399,8 @@ const get_tags: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
-    // v0.31.8 (D20): thread ctx.sourceId for read-side ops on multi-source brains.
-    const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
+    // v0.31.8 (D20) + v0.32.x (federated-read): read scope from ctx.
+    const sourceOpts = readScopeOpts(ctx);
     return ctx.engine.getTags(p.slug as string, sourceOpts);
   },
   scope: 'read',
@@ -1410,9 +1466,8 @@ const get_links: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
-    // v0.31.8 (D16): thread ctx.sourceId. When unset, engine falls through
-    // to cross-source view (back-compat).
-    const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
+    // v0.31.8 (D16) + v0.32.x (federated-read): read scope from ctx.
+    const sourceOpts = readScopeOpts(ctx);
     return ctx.engine.getLinks(p.slug as string, sourceOpts);
   },
   scope: 'read',
@@ -1425,7 +1480,8 @@ const get_backlinks: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
-    const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
+    // v0.32.x federated-read: read scope from ctx.
+    const sourceOpts = readScopeOpts(ctx);
     return ctx.engine.getBacklinks(p.slug as string, sourceOpts);
   },
   scope: 'read',
@@ -1462,10 +1518,13 @@ const traverse_graph: Operation = {
     const direction = p.direction as 'in' | 'out' | 'both' | undefined;
     // Backward compat: when neither link_type nor direction is provided, return
     // the legacy GraphNode[] shape. Once either is set, switch to GraphPath[].
+    // v0.32.x (federated-read): thread caller's read scope. allowedSources
+    // (post-v52) wins; falls back to scalar sourceId (legacy); unset = super-reader.
+    const scope = readScopeOpts(ctx);
     if (linkType === undefined && direction === undefined) {
-      return ctx.engine.traverseGraph(slug, depth, { sourceId: ctx.sourceId });
+      return ctx.engine.traverseGraph(slug, depth, scope);
     }
-    return ctx.engine.traversePaths(slug, { depth, linkType, direction, sourceId: ctx.sourceId });
+    return ctx.engine.traversePaths(slug, { depth, linkType, direction, ...scope });
   },
   scope: 'read',
   cliHints: { name: 'graph', positional: ['slug'] },
@@ -1523,9 +1582,9 @@ const get_timeline: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
-    // v0.31.8 (D20): thread ctx.sourceId.
-    const sourceId = ctx.sourceId;
-    return ctx.engine.getTimeline(p.slug as string, sourceId ? { sourceId } : undefined);
+    // v0.31.8 (D20) + v0.32.x (federated-read): thread caller's read scope.
+    const scope = readScopeOpts(ctx);
+    return ctx.engine.getTimeline(p.slug as string, Object.keys(scope).length ? scope : undefined);
   },
   scope: 'read',
   cliHints: { name: 'timeline', positional: ['slug'] },
@@ -1622,8 +1681,8 @@ const get_versions: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
-    // v0.31.8 (D20): thread ctx.sourceId.
-    const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
+    // v0.31.8 (D20) + v0.32.x (federated-read): thread caller's read scope.
+    const sourceOpts = readScopeOpts(ctx);
     const versions = await ctx.engine.getVersions(p.slug as string, sourceOpts);
     // Same takes-allow-list privacy boundary as get_page. Snapshots persist
     // historical compiled_truth verbatim, including the takes fence, so
@@ -1715,8 +1774,8 @@ const get_raw_data: Operation = {
     source: { type: 'string', description: 'Filter by source' },
   },
   handler: async (ctx, p) => {
-    // v0.31.8 (D20 + D21): thread ctx.sourceId.
-    const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
+    // v0.31.8 (D20 + D21) + v0.32.x (federated-read): thread caller's read scope.
+    const sourceOpts = readScopeOpts(ctx);
     return ctx.engine.getRawData(p.slug as string, p.source as string | undefined, sourceOpts);
   },
   scope: 'read',
@@ -1743,8 +1802,8 @@ const get_chunks: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
-    // v0.31.8 (D20): thread ctx.sourceId.
-    const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
+    // v0.31.8 (D20) + v0.32.x (federated-read): thread caller's read scope.
+    const sourceOpts = readScopeOpts(ctx);
     return ctx.engine.getChunks(p.slug as string, sourceOpts);
   },
   scope: 'read',

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1097,6 +1097,11 @@ const query: Operation = {
       since: typeof p.since === 'string' ? p.since : undefined,
       until: typeof p.until === 'string' ? p.until : undefined,
       onMeta: (m) => { capturedMeta = m; },
+      // v0.31.4 (mcp-source-isolation read-side fix): thread token-scoped
+      // sourceId so vector/keyword/hybrid search honors caller isolation.
+      // hybridSearch already accepts + threads this to engine.searchVector
+      // and engine.searchKeyword; the op handler just wasn't passing it.
+      sourceId: ctx.sourceId,
     });
     const latency_ms = Date.now() - startedAt;
 

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1463,9 +1463,9 @@ const traverse_graph: Operation = {
     // Backward compat: when neither link_type nor direction is provided, return
     // the legacy GraphNode[] shape. Once either is set, switch to GraphPath[].
     if (linkType === undefined && direction === undefined) {
-      return ctx.engine.traverseGraph(slug, depth);
+      return ctx.engine.traverseGraph(slug, depth, { sourceId: ctx.sourceId });
     }
-    return ctx.engine.traversePaths(slug, { depth, linkType, direction });
+    return ctx.engine.traversePaths(slug, { depth, linkType, direction, sourceId: ctx.sourceId });
   },
   scope: 'read',
   cliHints: { name: 'graph', positional: ['slug'] },

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -219,6 +219,18 @@ export interface AuthInfo {
   clientName?: string;
   scopes: string[];
   expiresAt?: number;
+  /**
+   * v0.31.4 fix/mcp-source-isolation-read-side: scope this caller's reads
+   * and writes to a single brain source. NULL/undefined = federated read
+   * (legacy super-reader behavior); a non-null value = strict source isolation
+   * — engines filter `pages.source_id` and writes to other sources are rejected
+   * at the operation layer.
+   *
+   * Populated by `OAuthProvider.verifyAccessToken` from `oauth_clients.source_id`.
+   * For legacy bearer tokens (access_tokens table) it falls back to
+   * `permissions.source_id`.
+   */
+  sourceId?: string;
 }
 
 export interface OperationContext {
@@ -908,6 +920,10 @@ const list_pages: Operation = {
       includeDeleted: (p.include_deleted as boolean) === true,
       updated_after: typeof p.updated_after === 'string' ? p.updated_after : undefined,
       sort,
+      // v0.31.4 (mcp-source-isolation fix): scope listing to the caller's
+      // source when the dispatch context carries one. Tokens without a
+      // sourceId (Robin super-reader, local CLI) keep federated listing.
+      sourceId: ctx.sourceId,
     });
     return pages.map(pg => ({
       slug: pg.slug,
@@ -937,6 +953,10 @@ const search: Operation = {
     const raw = await ctx.engine.searchKeyword(queryText, {
       limit: (p.limit as number) || 20,
       offset: (p.offset as number) || 0,
+      // v0.31.4: thread token-scoped sourceId for read isolation. Engine
+      // applies the WHERE clause when set; undefined = federated/super-reader.
+      // See fix/mcp-source-isolation-read-side.
+      sourceId: ctx.sourceId,
     });
     const results = dedupResults(raw);
     const latency_ms = Date.now() - startedAt;
@@ -1046,6 +1066,9 @@ const query: Operation = {
         limit: (p.limit as number) || 20,
         offset: (p.offset as number) || 0,
         embeddingColumn: 'embedding_image',
+        // v0.31.4: thread token-scoped sourceId for read isolation.
+        // See fix/mcp-source-isolation-read-side.
+        sourceId: ctx.sourceId,
       });
       return results;
     }

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -638,6 +638,12 @@ export class PGLiteEngine implements BrainEngine {
     if (filters?.includeDeleted !== true) {
       where.push('p.deleted_at IS NULL');
     }
+    // v0.31.4 (mcp-source-isolation read-side fix): scope listing to caller's
+    // source when the dispatch context carries one. See operations.ts list_pages.
+    if (filters?.sourceId) {
+      params.push(filters.sourceId);
+      where.push(`p.source_id = $${params.length}`);
+    }
 
     const whereSql = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
     params.push(limit, offset);

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -679,20 +679,35 @@ export class PGLiteEngine implements BrainEngine {
     return new Set((rows as { slug: string }[]).map(r => r.slug));
   }
 
-  async resolveSlugs(partial: string): Promise<string[]> {
+  async resolveSlugs(partial: string, opts?: { sourceId?: string }): Promise<string[]> {
+    // v0.31.4 (mcp-source-isolation read-side fix): scope to caller's source
+    // when present. NULL = federated (Robin super-reader / local CLI).
+    const scoped = opts?.sourceId !== undefined;
+
     // Try exact match first
-    const exact = await this.db.query('SELECT slug FROM pages WHERE slug = $1', [partial]);
+    const exact = scoped
+      ? await this.db.query('SELECT slug FROM pages WHERE slug = $1 AND source_id = $2', [partial, opts!.sourceId])
+      : await this.db.query('SELECT slug FROM pages WHERE slug = $1', [partial]);
     if (exact.rows.length > 0) return [(exact.rows[0] as { slug: string }).slug];
 
     // Fuzzy match via pg_trgm
-    const { rows } = await this.db.query(
-      `SELECT slug, similarity(title, $1) AS sim
-       FROM pages
-       WHERE title % $1 OR slug ILIKE $2
-       ORDER BY sim DESC
-       LIMIT 5`,
-      [partial, '%' + partial + '%']
-    );
+    const { rows } = scoped
+      ? await this.db.query(
+          `SELECT slug, similarity(title, $1) AS sim
+           FROM pages
+           WHERE (title % $1 OR slug ILIKE $2) AND source_id = $3
+           ORDER BY sim DESC
+           LIMIT 5`,
+          [partial, '%' + partial + '%', opts!.sourceId]
+        )
+      : await this.db.query(
+          `SELECT slug, similarity(title, $1) AS sim
+           FROM pages
+           WHERE title % $1 OR slug ILIKE $2
+           ORDER BY sim DESC
+           LIMIT 5`,
+          [partial, '%' + partial + '%']
+        );
     return (rows as { slug: string }[]).map(r => r.slug);
   }
 
@@ -1340,20 +1355,25 @@ export class PGLiteEngine implements BrainEngine {
     return { slug: row.slug, similarity: row.sim };
   }
 
-  async traverseGraph(slug: string, depth: number = 5): Promise<GraphNode[]> {
+  async traverseGraph(slug: string, depth: number = 5, opts?: { sourceId?: string }): Promise<GraphNode[]> {
     // Cycle prevention: visited array tracks page IDs already in the path.
     // Prevents exponential blowup on cyclic subgraphs (e.g., A->B->A).
+    const sourceId = opts?.sourceId ?? null;
+    const scoped = sourceId !== null;
+    const params: unknown[] = [slug, depth];
+    const sourceIdx = scoped ? params.push(sourceId) : 0;
+    const source_idWhere = (alias: string) => scoped ? `AND ${alias}.source_id = $${sourceIdx}` : '';
     const { rows } = await this.db.query(
       `WITH RECURSIVE graph AS (
         SELECT p.id, p.slug, p.title, p.type, 0 as depth, ARRAY[p.id] as visited
-        FROM pages p WHERE p.slug = $1
+        FROM pages p WHERE p.slug = $1 ${source_idWhere('p')}
 
         UNION ALL
 
         SELECT p2.id, p2.slug, p2.title, p2.type, g.depth + 1, g.visited || p2.id
         FROM graph g
         JOIN links l ON l.from_page_id = g.id
-        JOIN pages p2 ON p2.id = l.to_page_id
+        JOIN pages p2 ON p2.id = l.to_page_id ${source_idWhere('p2')}
         WHERE g.depth < $2
           AND NOT (p2.id = ANY(g.visited))
       )
@@ -1366,13 +1386,13 @@ export class PGLiteEngine implements BrainEngine {
           -- plan Bug 6/10.
           (SELECT jsonb_agg(DISTINCT jsonb_build_object('to_slug', p3.slug, 'link_type', l2.link_type))
            FROM links l2
-           JOIN pages p3 ON p3.id = l2.to_page_id
+           JOIN pages p3 ON p3.id = l2.to_page_id ${source_idWhere('p3')}
            WHERE l2.from_page_id = g.id),
           '[]'::jsonb
         ) as links
       FROM graph g
       ORDER BY g.depth, g.slug`,
-      [slug, depth]
+      params
     );
 
     return (rows as Record<string, unknown>[]).map(r => ({
@@ -1386,26 +1406,37 @@ export class PGLiteEngine implements BrainEngine {
 
   async traversePaths(
     slug: string,
-    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both' },
+    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both'; sourceId?: string },
   ): Promise<GraphPath[]> {
     const depth = opts?.depth ?? 5;
     const direction = opts?.direction ?? 'out';
     const linkType = opts?.linkType ?? null;
-    const linkTypeWhere = linkType !== null ? 'AND l.link_type = $3' : '';
+    const sourceId = opts?.sourceId ?? null;
+    const scoped = sourceId !== null;
+
     const params: unknown[] = [slug, depth];
-    if (linkType !== null) params.push(linkType);
+    let nextParam = 3;
+
+    let linkTypeWhere = '';
+    if (linkType !== null) {
+      linkTypeWhere = `AND l.link_type = $${nextParam++}`;
+      params.push(linkType);
+    }
+
+    const sourceIdx = scoped ? params.push(sourceId) : 0;
+    const source_idWhere = (alias: string) => scoped ? `AND ${alias}.source_id = $${sourceIdx}` : '';
 
     let sql: string;
     if (direction === 'out') {
       sql = `
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int AS depth, ARRAY[p.id] AS visited
-          FROM pages p WHERE p.slug = $1
+          FROM pages p WHERE p.slug = $1 ${source_idWhere('p')}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON l.from_page_id = w.id
-          JOIN pages p2 ON p2.id = l.to_page_id
+          JOIN pages p2 ON p2.id = l.to_page_id ${source_idWhere('p2')}
           WHERE w.depth < $2
             AND NOT (p2.id = ANY(w.visited))
             ${linkTypeWhere}
@@ -1414,7 +1445,7 @@ export class PGLiteEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 AS depth
         FROM walk w
         JOIN links l ON l.from_page_id = w.id
-        JOIN pages p2 ON p2.id = l.to_page_id
+        JOIN pages p2 ON p2.id = l.to_page_id ${source_idWhere('p2')}
         WHERE w.depth < $2
           ${linkTypeWhere}
         ORDER BY depth, from_slug, to_slug
@@ -1423,12 +1454,12 @@ export class PGLiteEngine implements BrainEngine {
       sql = `
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int AS depth, ARRAY[p.id] AS visited
-          FROM pages p WHERE p.slug = $1
+          FROM pages p WHERE p.slug = $1 ${source_idWhere('p')}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON l.to_page_id = w.id
-          JOIN pages p2 ON p2.id = l.from_page_id
+          JOIN pages p2 ON p2.id = l.from_page_id ${source_idWhere('p2')}
           WHERE w.depth < $2
             AND NOT (p2.id = ANY(w.visited))
             ${linkTypeWhere}
@@ -1437,7 +1468,7 @@ export class PGLiteEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 AS depth
         FROM walk w
         JOIN links l ON l.to_page_id = w.id
-        JOIN pages p2 ON p2.id = l.from_page_id
+        JOIN pages p2 ON p2.id = l.from_page_id ${source_idWhere('p2')}
         WHERE w.depth < $2
           ${linkTypeWhere}
         ORDER BY depth, from_slug, to_slug
@@ -1448,12 +1479,12 @@ export class PGLiteEngine implements BrainEngine {
       sql = `
         WITH RECURSIVE walk AS (
           SELECT p.id, 0::int AS depth, ARRAY[p.id] AS visited
-          FROM pages p WHERE p.slug = $1
+          FROM pages p WHERE p.slug = $1 ${source_idWhere('p')}
           UNION ALL
           SELECT p2.id, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON (l.from_page_id = w.id OR l.to_page_id = w.id)
-          JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END
+          JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END ${source_idWhere('p2')}
           WHERE w.depth < $2
             AND NOT (p2.id = ANY(w.visited))
             ${linkTypeWhere}
@@ -1462,8 +1493,8 @@ export class PGLiteEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 AS depth
         FROM walk w
         JOIN links l ON (l.from_page_id = w.id OR l.to_page_id = w.id)
-        JOIN pages pf ON pf.id = l.from_page_id
-        JOIN pages pt ON pt.id = l.to_page_id
+        JOIN pages pf ON pf.id = l.from_page_id ${source_idWhere('pf')}
+        JOIN pages pt ON pt.id = l.to_page_id ${source_idWhere('pt')}
         WHERE w.depth < $2
           ${linkTypeWhere}
         ORDER BY depth, from_slug, to_slug

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1200,7 +1200,7 @@ export class PGLiteEngine implements BrainEngine {
 
   async listStaleChunks(): Promise<StaleChunkRow[]> {
     const { rows } = await this.db.query(
-      `SELECT p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+      `SELECT p.slug, p.source_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
               cc.model, cc.token_count
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -488,13 +488,18 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Pages CRUD
-  async getPage(slug: string, opts?: { sourceId?: string; includeDeleted?: boolean }): Promise<Page | null> {
+  async getPage(slug: string, opts?: { sourceId?: string; allowedSources?: string[]; includeDeleted?: boolean }): Promise<Page | null> {
     // v0.26.5: hide soft-deleted by default; opt-in via opts.includeDeleted.
+    // v0.32.x federated-read: allowedSources (post-v52) wins over scalar sourceId;
+    // both unset = federated (super-reader / local CLI).
     const includeDeleted = opts?.includeDeleted === true;
     const sourceId = opts?.sourceId;
     const where: string[] = ['slug = $1'];
     const params: unknown[] = [slug];
-    if (sourceId) {
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      params.push(opts.allowedSources);
+      where.push(`source_id = ANY($${params.length}::text[])`);
+    } else if (sourceId) {
       params.push(sourceId);
       where.push(`source_id = $${params.length}`);
     }
@@ -638,9 +643,16 @@ export class PGLiteEngine implements BrainEngine {
     if (filters?.includeDeleted !== true) {
       where.push('p.deleted_at IS NULL');
     }
-    // v0.31.4 (mcp-source-isolation read-side fix): scope listing to caller's
-    // source when the dispatch context carries one. See operations.ts list_pages.
-    if (filters?.sourceId) {
+    // v0.31.4 (mcp-source-isolation read-side fix) + v0.32.x (federated-read):
+    // allowedSources (post-v52) wins over scalar sourceId; both unset =
+    // federated. PageFilters doesn't carry allowedSources in its declared
+    // type yet, so cast the filters bag to read the optional field without
+    // modifying types.ts. See operations.ts list_pages.
+    const scopeFilters = filters as { sourceId?: string; allowedSources?: string[] } | undefined;
+    if (scopeFilters?.allowedSources && scopeFilters.allowedSources.length > 0) {
+      params.push(scopeFilters.allowedSources);
+      where.push(`p.source_id = ANY($${params.length}::text[])`);
+    } else if (filters?.sourceId) {
       params.push(filters.sourceId);
       where.push(`p.source_id = $${params.length}`);
     }
@@ -662,12 +674,18 @@ export class PGLiteEngine implements BrainEngine {
     return (rows as Record<string, unknown>[]).map(rowToPage);
   }
 
-  async getAllSlugs(opts?: { sourceId?: string }): Promise<Set<string>> {
-    // v0.31.8 (D12): when opts.sourceId is set, return only that source's
-    // slugs (used by reconcileLinks so wikilink resolution doesn't span
-    // unrelated sources). Without opts, returns the union across sources
-    // (pre-v0.31.8 behavior — preserved for callers that still expect the
-    // brain-wide slug index, e.g. extract.ts's link resolver).
+  async getAllSlugs(opts?: { sourceId?: string; allowedSources?: string[] }): Promise<Set<string>> {
+    // v0.31.8 (D12) + v0.32.x (federated-read): allowedSources (post-v52)
+    // wins over scalar sourceId. Without opts, returns the union across
+    // sources (pre-v0.31.8 behavior — preserved for callers that still
+    // expect the brain-wide slug index, e.g. extract.ts's link resolver).
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      const { rows } = await this.db.query(
+        'SELECT slug FROM pages WHERE source_id = ANY($1::text[])',
+        [opts.allowedSources]
+      );
+      return new Set((rows as { slug: string }[]).map(r => r.slug));
+    }
     if (opts?.sourceId) {
       const { rows } = await this.db.query(
         'SELECT slug FROM pages WHERE source_id = $1',
@@ -679,36 +697,55 @@ export class PGLiteEngine implements BrainEngine {
     return new Set((rows as { slug: string }[]).map(r => r.slug));
   }
 
-  async resolveSlugs(partial: string, opts?: { sourceId?: string }): Promise<string[]> {
-    // v0.31.4 (mcp-source-isolation read-side fix): scope to caller's source
-    // when present. NULL = federated (Robin super-reader / local CLI).
-    const scoped = opts?.sourceId !== undefined;
+  async resolveSlugs(partial: string, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<string[]> {
+    // v0.31.4 (mcp-source-isolation read-side fix) + v0.32.x (federated-read):
+    // allowedSources (post-v52) wins; falls back to scalar sourceId; both
+    // unset = federated (Robin super-reader / local CLI).
+    const allowed = opts?.allowedSources && opts.allowedSources.length > 0 ? opts.allowedSources : null;
+    const scoped = allowed !== null || opts?.sourceId !== undefined;
 
     // Try exact match first
-    const exact = scoped
-      ? await this.db.query('SELECT slug FROM pages WHERE slug = $1 AND source_id = $2', [partial, opts!.sourceId])
-      : await this.db.query('SELECT slug FROM pages WHERE slug = $1', [partial]);
+    let exact;
+    if (allowed) {
+      exact = await this.db.query('SELECT slug FROM pages WHERE slug = $1 AND source_id = ANY($2::text[])', [partial, allowed]);
+    } else if (opts?.sourceId !== undefined) {
+      exact = await this.db.query('SELECT slug FROM pages WHERE slug = $1 AND source_id = $2', [partial, opts.sourceId]);
+    } else {
+      exact = await this.db.query('SELECT slug FROM pages WHERE slug = $1', [partial]);
+    }
     if (exact.rows.length > 0) return [(exact.rows[0] as { slug: string }).slug];
 
     // Fuzzy match via pg_trgm
-    const { rows } = scoped
-      ? await this.db.query(
-          `SELECT slug, similarity(title, $1) AS sim
-           FROM pages
-           WHERE (title % $1 OR slug ILIKE $2) AND source_id = $3
-           ORDER BY sim DESC
-           LIMIT 5`,
-          [partial, '%' + partial + '%', opts!.sourceId]
-        )
-      : await this.db.query(
-          `SELECT slug, similarity(title, $1) AS sim
-           FROM pages
-           WHERE title % $1 OR slug ILIKE $2
-           ORDER BY sim DESC
-           LIMIT 5`,
-          [partial, '%' + partial + '%']
-        );
-    return (rows as { slug: string }[]).map(r => r.slug);
+    let result;
+    if (allowed) {
+      result = await this.db.query(
+        `SELECT slug, similarity(title, $1) AS sim
+         FROM pages
+         WHERE (title % $1 OR slug ILIKE $2) AND source_id = ANY($3::text[])
+         ORDER BY sim DESC
+         LIMIT 5`,
+        [partial, '%' + partial + '%', allowed]
+      );
+    } else if (scoped) {
+      result = await this.db.query(
+        `SELECT slug, similarity(title, $1) AS sim
+         FROM pages
+         WHERE (title % $1 OR slug ILIKE $2) AND source_id = $3
+         ORDER BY sim DESC
+         LIMIT 5`,
+        [partial, '%' + partial + '%', opts!.sourceId]
+      );
+    } else {
+      result = await this.db.query(
+        `SELECT slug, similarity(title, $1) AS sim
+         FROM pages
+         WHERE title % $1 OR slug ILIKE $2
+         ORDER BY sim DESC
+         LIMIT 5`,
+        [partial, '%' + partial + '%']
+      );
+    }
+    return (result.rows as { slug: string }[]).map(r => r.slug);
   }
 
   // Search
@@ -767,6 +804,17 @@ export class PGLiteEngine implements BrainEngine {
       extraFilter += ` AND COALESCE(p.effective_date, p.updated_at, p.created_at) < $${params.length}::timestamptz`;
     }
 
+    // v0.32.x federated-read: allowedSources (post-v52) preferred over scalar
+    // sourceId. Falls back to scalar sourceId when not '__all__'.
+    let sourceClause = '';
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      params.push(opts.allowedSources);
+      sourceClause = `AND p.source_id = ANY($${params.length}::text[])`;
+    } else if (opts?.sourceId && opts.sourceId !== '__all__') {
+      params.push(opts.sourceId);
+      sourceClause = `AND p.source_id = $${params.length}`;
+    }
+
     // v0.26.5: visibility filter (soft-deleted + archived-source).
     const visibilityClause = buildVisibilityClause('p', 's');
 
@@ -782,7 +830,7 @@ export class PGLiteEngine implements BrainEngine {
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id
          JOIN sources s ON s.id = p.source_id
-         WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
+         WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause} ${sourceClause}
            -- v0.27.1: hide image rows from default text-keyword search so
            -- OCR text doesn't drown text-page hits. Image-similarity queries
            -- run a separate vector path on embedding_image.
@@ -855,6 +903,17 @@ export class PGLiteEngine implements BrainEngine {
     // v0.26.5: visibility filter for the chunk-grain anchor primitive.
     const visibilityClause = buildVisibilityClause('p', 's');
 
+    // v0.32.x federated-read: allowedSources (post-v52) preferred over scalar
+    // sourceId. Falls back to scalar sourceId when not '__all__'.
+    let sourceClause = '';
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      params.push(opts.allowedSources);
+      sourceClause = `AND p.source_id = ANY($${params.length}::text[])`;
+    } else if (opts?.sourceId && opts.sourceId !== '__all__') {
+      params.push(opts.sourceId);
+      sourceClause = `AND p.source_id = $${params.length}`;
+    }
+
     const { rows } = await this.db.query(
       `SELECT
          p.slug, p.id as page_id, p.title, p.type, p.source_id,
@@ -866,7 +925,7 @@ export class PGLiteEngine implements BrainEngine {
        FROM content_chunks cc
        JOIN pages p ON p.id = cc.page_id
        JOIN sources s ON s.id = p.source_id
-       WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
+       WHERE cc.search_vector @@ websearch_to_tsquery('english', $1) ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause} ${sourceClause}
        ORDER BY score DESC
        LIMIT $2 OFFSET $3`,
       params
@@ -927,6 +986,16 @@ export class PGLiteEngine implements BrainEngine {
     // same candidate count it always did. See postgres-engine.ts for rationale.
     const visibilityClause = buildVisibilityClause('p', 's');
 
+    // v0.32.x federated-read: allowedSources (post-v52) preferred over scalar.
+    let sourceClause = '';
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      params.push(opts.allowedSources);
+      sourceClause = `AND p.source_id = ANY($${params.length}::text[])`;
+    } else if (opts?.sourceId && opts.sourceId !== '__all__') {
+      params.push(opts.sourceId);
+      sourceClause = `AND p.source_id = $${params.length}`;
+    }
+
     // v0.27.1: column routing. Default 'embedding' targets the brain's
     // primary text-embedding column; 'embedding_image' targets the
     // multimodal column populated by importImageFile. Image-similarity
@@ -946,7 +1015,7 @@ export class PGLiteEngine implements BrainEngine {
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id
          JOIN sources s ON s.id = p.source_id
-         WHERE cc.${col} IS NOT NULL ${modalityFilter} ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
+         WHERE cc.${col} IS NOT NULL ${modalityFilter} ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause} ${sourceClause}
          ORDER BY cc.${col} <=> $1::vector
          LIMIT $2
        )
@@ -1096,7 +1165,18 @@ export class PGLiteEngine implements BrainEngine {
     );
   }
 
-  async getChunks(slug: string, opts?: { sourceId?: string }): Promise<Chunk[]> {
+  async getChunks(slug: string, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<Chunk[]> {
+    // v0.32.x federated-read: allowedSources wins over scalar sourceId.
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      const { rows } = await this.db.query(
+        `SELECT cc.* FROM content_chunks cc
+         JOIN pages p ON p.id = cc.page_id
+         WHERE p.slug = $1 AND p.source_id = ANY($2::text[])
+         ORDER BY cc.chunk_index`,
+        [slug, opts.allowedSources]
+      );
+      return (rows as Record<string, unknown>[]).map(r => rowToChunk(r));
+    }
     const sourceId = opts?.sourceId ?? 'default';
     const { rows } = await this.db.query(
       `SELECT cc.* FROM content_chunks cc
@@ -1266,12 +1346,30 @@ export class PGLiteEngine implements BrainEngine {
     }
   }
 
-  async getLinks(slug: string, opts?: { sourceId?: string }): Promise<Link[]> {
+  async getLinks(slug: string, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<Link[]> {
     // v0.31.8 (D16): two-branch query. Without opts.sourceId, no source filter
     // (preserves pre-v0.31.8 cross-source semantics for back-link validators
     // and read-side op handlers that haven't threaded sourceId yet). With
     // opts.sourceId, scope to that source — used by reconcileLinks and any
     // ctx.sourceId-aware read op (D20).
+    // v0.32.x federated-read: allowedSources wins over scalar sourceId and
+    // scopes BOTH endpoints to the allowed set.
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      const { rows } = await this.db.query(
+        `SELECT f.slug as from_slug, t.slug as to_slug,
+                l.link_type, l.context, l.link_source,
+                o.slug as origin_slug, l.origin_field
+         FROM links l
+         JOIN pages f ON f.id = l.from_page_id
+         JOIN pages t ON t.id = l.to_page_id
+         LEFT JOIN pages o ON o.id = l.origin_page_id
+         WHERE f.slug = $1
+           AND f.source_id = ANY($2::text[])
+           AND t.source_id = ANY($2::text[])`,
+        [slug, opts.allowedSources]
+      );
+      return rows as unknown as Link[];
+    }
     if (opts?.sourceId) {
       const { rows } = await this.db.query(
         `SELECT f.slug as from_slug, t.slug as to_slug,
@@ -1300,8 +1398,25 @@ export class PGLiteEngine implements BrainEngine {
     return rows as unknown as Link[];
   }
 
-  async getBacklinks(slug: string, opts?: { sourceId?: string }): Promise<Link[]> {
+  async getBacklinks(slug: string, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<Link[]> {
     // v0.31.8 (D16): two-branch query. See getLinks() comment.
+    // v0.32.x federated-read: allowedSources wins and scopes both endpoints.
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      const { rows } = await this.db.query(
+        `SELECT f.slug as from_slug, t.slug as to_slug,
+                l.link_type, l.context, l.link_source,
+                o.slug as origin_slug, l.origin_field
+         FROM links l
+         JOIN pages f ON f.id = l.from_page_id
+         JOIN pages t ON t.id = l.to_page_id
+         LEFT JOIN pages o ON o.id = l.origin_page_id
+         WHERE t.slug = $1
+           AND t.source_id = ANY($2::text[])
+           AND f.source_id = ANY($2::text[])`,
+        [slug, opts.allowedSources]
+      );
+      return rows as unknown as Link[];
+    }
     if (opts?.sourceId) {
       const { rows } = await this.db.query(
         `SELECT f.slug as from_slug, t.slug as to_slug,
@@ -1355,14 +1470,25 @@ export class PGLiteEngine implements BrainEngine {
     return { slug: row.slug, similarity: row.sim };
   }
 
-  async traverseGraph(slug: string, depth: number = 5, opts?: { sourceId?: string }): Promise<GraphNode[]> {
+  async traverseGraph(slug: string, depth: number = 5, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<GraphNode[]> {
     // Cycle prevention: visited array tracks page IDs already in the path.
     // Prevents exponential blowup on cyclic subgraphs (e.g., A->B->A).
-    const sourceId = opts?.sourceId ?? null;
-    const scoped = sourceId !== null;
+    // v0.32.x federated-read: allowedSources wins over scalar sourceId.
     const params: unknown[] = [slug, depth];
-    const sourceIdx = scoped ? params.push(sourceId) : 0;
-    const source_idWhere = (alias: string) => scoped ? `AND ${alias}.source_id = $${sourceIdx}` : '';
+    const useAllowed = !!(opts?.allowedSources && opts.allowedSources.length > 0);
+    const useScalar = !useAllowed && opts?.sourceId !== undefined && opts?.sourceId !== null;
+    let allowedIdx = 0;
+    let scalarIdx = 0;
+    if (useAllowed) {
+      allowedIdx = params.push(opts!.allowedSources);
+    } else if (useScalar) {
+      scalarIdx = params.push(opts!.sourceId);
+    }
+    const source_idWhere = (alias: string) => {
+      if (useAllowed) return `AND ${alias}.source_id = ANY($${allowedIdx}::text[])`;
+      if (useScalar) return `AND ${alias}.source_id = $${scalarIdx}`;
+      return '';
+    };
     const { rows } = await this.db.query(
       `WITH RECURSIVE graph AS (
         SELECT p.id, p.slug, p.title, p.type, 0 as depth, ARRAY[p.id] as visited
@@ -1406,13 +1532,11 @@ export class PGLiteEngine implements BrainEngine {
 
   async traversePaths(
     slug: string,
-    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both'; sourceId?: string },
+    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both'; sourceId?: string; allowedSources?: string[] },
   ): Promise<GraphPath[]> {
     const depth = opts?.depth ?? 5;
     const direction = opts?.direction ?? 'out';
     const linkType = opts?.linkType ?? null;
-    const sourceId = opts?.sourceId ?? null;
-    const scoped = sourceId !== null;
 
     const params: unknown[] = [slug, depth];
     let nextParam = 3;
@@ -1423,8 +1547,21 @@ export class PGLiteEngine implements BrainEngine {
       params.push(linkType);
     }
 
-    const sourceIdx = scoped ? params.push(sourceId) : 0;
-    const source_idWhere = (alias: string) => scoped ? `AND ${alias}.source_id = $${sourceIdx}` : '';
+    // v0.32.x federated-read: allowedSources wins over scalar sourceId.
+    const useAllowed = !!(opts?.allowedSources && opts.allowedSources.length > 0);
+    const useScalar = !useAllowed && opts?.sourceId !== undefined && opts?.sourceId !== null;
+    let allowedIdx = 0;
+    let scalarIdx = 0;
+    if (useAllowed) {
+      allowedIdx = params.push(opts!.allowedSources);
+    } else if (useScalar) {
+      scalarIdx = params.push(opts!.sourceId);
+    }
+    const source_idWhere = (alias: string) => {
+      if (useAllowed) return `AND ${alias}.source_id = ANY($${allowedIdx}::text[])`;
+      if (useScalar) return `AND ${alias}.source_id = $${scalarIdx}`;
+      return '';
+    };
 
     let sql: string;
     if (direction === 'out') {
@@ -1637,7 +1774,18 @@ export class PGLiteEngine implements BrainEngine {
     );
   }
 
-  async getTags(slug: string, opts?: { sourceId?: string }): Promise<string[]> {
+  async getTags(slug: string, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<string[]> {
+    // v0.32.x federated-read: allowedSources (post-v52) preferred over scalar.
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      const { rows } = await this.db.query(
+        `SELECT t.tag FROM tags t
+         JOIN pages p ON p.id = t.page_id
+         WHERE p.slug = $1 AND p.source_id = ANY($2::text[])
+         ORDER BY t.tag`,
+        [slug, opts.allowedSources]
+      );
+      return (rows as { tag: string }[]).map(r => r.tag);
+    }
     const sourceId = opts?.sourceId ?? 'default';
     // Source-qualify the page-id subquery; slugs are only unique per source.
     const { rows } = await this.db.query(
@@ -1713,7 +1861,10 @@ export class PGLiteEngine implements BrainEngine {
       params.push(opts.before);
       where.push(`te.date <= $${params.length}::date`);
     }
-    if (opts?.sourceId) {
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      params.push(opts.allowedSources);
+      where.push(`p.source_id = ANY($${params.length}::text[])`);
+    } else if (opts?.sourceId) {
       params.push(opts.sourceId);
       where.push(`p.source_id = $${params.length}`);
     }
@@ -1766,9 +1917,10 @@ export class PGLiteEngine implements BrainEngine {
   async getRawData(
     slug: string,
     source?: string,
-    opts?: { sourceId?: string },
+    opts?: { sourceId?: string; allowedSources?: string[] },
   ): Promise<RawData[]> {
-    // v0.31.8 (D21): build WHERE clause dynamically. Without opts.sourceId,
+    // v0.32.x federated-read: allowedSources (post-v52) preferred over scalar.
+    // v0.31.8 (D21): build WHERE clause dynamically. Without either,
     // no source filter (preserves pre-v0.31.8 cross-source read).
     const where: string[] = ['p.slug = $1'];
     const params: unknown[] = [slug];
@@ -1776,7 +1928,10 @@ export class PGLiteEngine implements BrainEngine {
       params.push(source);
       where.push(`rd.source = $${params.length}`);
     }
-    if (opts?.sourceId) {
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      params.push(opts.allowedSources);
+      where.push(`p.source_id = ANY($${params.length}::text[])`);
+    } else if (opts?.sourceId) {
       params.push(opts.sourceId);
       where.push(`p.source_id = $${params.length}`);
     }
@@ -2531,9 +2686,20 @@ export class PGLiteEngine implements BrainEngine {
     return rows[0] as unknown as PageVersion;
   }
 
-  async getVersions(slug: string, opts?: { sourceId?: string }): Promise<PageVersion[]> {
-    // v0.31.8 (D16): two-branch. Without opts.sourceId, joins return versions
+  async getVersions(slug: string, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<PageVersion[]> {
+    // v0.32.x federated-read: allowedSources (post-v52) preferred over scalar.
+    // v0.31.8 (D16): two-branch. Without either, joins return versions
     // for every same-slug page (preserves pre-v0.31.8 cross-source view).
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      const { rows } = await this.db.query(
+        `SELECT pv.* FROM page_versions pv
+         JOIN pages p ON p.id = pv.page_id
+         WHERE p.slug = $1 AND p.source_id = ANY($2::text[])
+         ORDER BY pv.snapshot_at DESC`,
+        [slug, opts.allowedSources]
+      );
+      return rows as unknown as PageVersion[];
+    }
     if (opts?.sourceId) {
       const { rows } = await this.db.query(
         `SELECT pv.* FROM page_versions pv

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -549,6 +549,8 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
   client_secret_expires_at BIGINT,
   token_ttl               INTEGER,
   deleted_at              TIMESTAMPTZ,
+  -- v0.31.4: source-isolation scope for MCP HTTP callers. NULL = federated/super-reader.
+  source_id               TEXT REFERENCES sources(id) ON DELETE SET NULL,
   created_at              TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -549,8 +549,12 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
   client_secret_expires_at BIGINT,
   token_ttl               INTEGER,
   deleted_at              TIMESTAMPTZ,
-  -- v0.31.4: source-isolation scope for MCP HTTP callers. NULL = federated/super-reader.
-  source_id               TEXT REFERENCES sources(id) ON DELETE SET NULL,
+  -- v0.31.4 / v0.32.x: source-isolation scope for MCP HTTP callers.
+  -- source_id      = the single source this client WRITES into (NOT NULL post-v52).
+  -- federated_read = the set of source ids this client may READ from. Must contain source_id.
+  source_id               TEXT NOT NULL REFERENCES sources(id) ON DELETE RESTRICT,
+  federated_read          TEXT[] NOT NULL DEFAULT '{}',
+  CONSTRAINT oauth_clients_own_source_in_read CHECK (source_id = ANY(federated_read)),
   created_at              TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -69,6 +69,37 @@ export function getPostgresSchema(dims: number = 1536, model: string = 'text-emb
 // See TODOS.md item: "err.code-based connection-error matching" for the
 // follow-up that will reintroduce a typed retry mechanism.
 
+/**
+ * v0.32.x federated-read helper. Compose the source-scope WHERE fragment
+ * from a read opts object. Precedence:
+ *
+ *   1. opts.allowedSources (non-empty) → `AND <alias>.source_id = ANY($n)`
+ *      Post-v52 OAuth callers set this when their client has federated_read.
+ *      A single-element array is intentional: even the "own source only"
+ *      case flows through ANY() for uniformity.
+ *   2. opts.sourceId (truthy) → `AND <alias>.source_id = $n` (legacy scalar).
+ *   3. neither set → empty fragment (super-reader / local CLI).
+ *
+ * Writes MUST NOT use this — they pin to opts.sourceId only. Federated
+ * writes would silently expand caller authority beyond what was granted.
+ */
+function sourceFilter(
+  sql: ReturnType<typeof postgres>,
+  opts: { sourceId?: string; allowedSources?: string[] } | undefined,
+  alias: string = '',
+): ReturnType<ReturnType<typeof postgres>> {
+  const prefix = alias ? `${alias}.` : '';
+  // sql.unsafe is OK for the alias prefix because we only emit it when the
+  // caller passed a static string literal (verified at call sites).
+  if (opts?.allowedSources && opts.allowedSources.length > 0) {
+    return sql`AND ${sql.unsafe(prefix + 'source_id')} = ANY(${opts.allowedSources})`;
+  }
+  if (opts?.sourceId) {
+    return sql`AND ${sql.unsafe(prefix + 'source_id')} = ${opts.sourceId}`;
+  }
+  return sql``;
+}
+
 export class PostgresEngine implements BrainEngine {
   readonly kind = 'postgres' as const;
   private _sql: ReturnType<typeof postgres> | null = null;
@@ -550,13 +581,12 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Pages CRUD
-  async getPage(slug: string, opts?: { sourceId?: string; includeDeleted?: boolean }): Promise<Page | null> {
+  async getPage(slug: string, opts?: { sourceId?: string; allowedSources?: string[]; includeDeleted?: boolean }): Promise<Page | null> {
     const sql = this.sql;
     const includeDeleted = opts?.includeDeleted === true;
-    const sourceId = opts?.sourceId;
-    // v0.26.5: default hides soft-deleted rows. Compose with optional sourceId
-    // filter via fragment chaining (postgres.js supports sql`` composition).
-    const sourceCondition = sourceId ? sql`AND source_id = ${sourceId}` : sql``;
+    // v0.26.5: default hides soft-deleted rows. v0.32.x: federated-read
+    // helper unifies allowedSources/sourceId/none into one fragment.
+    const sourceCondition = sourceFilter(sql, opts);
     const deletedCondition = includeDeleted ? sql`` : sql`AND deleted_at IS NULL`;
     const rows = await sql`
       SELECT id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at, deleted_at
@@ -684,12 +714,9 @@ export class PostgresEngine implements BrainEngine {
     const deletedCondition = filters?.includeDeleted === true
       ? sql``
       : sql`AND p.deleted_at IS NULL`;
-    // v0.31.4 (mcp-source-isolation read-side fix): scope listing when the
-    // caller carries an auth-derived sourceId. Unset = federated (matches
-    // local CLI + Robin super-reader semantics). See operations.ts list_pages.
-    const sourceCondition = filters?.sourceId
-      ? sql`AND p.source_id = ${filters.sourceId}`
-      : sql``;
+    // v0.31.4 + v0.32.x (federated-read): allowedSources (post-v52) wins
+    // over scalar sourceId; both unset = federated. See operations.ts list_pages.
+    const sourceCondition = sourceFilter(sql, filters as { sourceId?: string; allowedSources?: string[] } | undefined, 'p');
 
     // v0.29: ORDER BY threading via PAGE_SORT_SQL whitelist (no SQL injection).
     // postgres.js sql.unsafe lets us splice the literal fragment safely.
@@ -706,9 +733,13 @@ export class PostgresEngine implements BrainEngine {
     return rows.map(rowToPage);
   }
 
-  async getAllSlugs(opts?: { sourceId?: string }): Promise<Set<string>> {
+  async getAllSlugs(opts?: { sourceId?: string; allowedSources?: string[] }): Promise<Set<string>> {
     const sql = this.sql;
-    // v0.31.8 (D12): two-branch. See pglite-engine.ts:getAllSlugs for context.
+    // v0.31.8 (D12) + v0.32.x (federated-read): unified source-scope filter.
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      const rows = await sql`SELECT slug FROM pages WHERE source_id = ANY(${opts.allowedSources})`;
+      return new Set(rows.map((r) => r.slug as string));
+    }
     if (opts?.sourceId) {
       const rows = await sql`SELECT slug FROM pages WHERE source_id = ${opts.sourceId}`;
       return new Set(rows.map((r) => r.slug as string));
@@ -717,13 +748,10 @@ export class PostgresEngine implements BrainEngine {
     return new Set(rows.map((r) => r.slug as string));
   }
 
-  async resolveSlugs(partial: string, opts?: { sourceId?: string }): Promise<string[]> {
+  async resolveSlugs(partial: string, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<string[]> {
     const sql = this.sql;
-    // v0.31.4 (mcp-source-isolation read-side fix): scope to caller's source
-    // when present. NULL = federated (Robin super-reader / local CLI).
-    const sourceCondition = opts?.sourceId
-      ? sql`AND source_id = ${opts.sourceId}`
-      : sql``;
+    // v0.31.4 + v0.32.x (federated-read): unified source-scope filter.
+    const sourceCondition = sourceFilter(sql, opts);
 
     // Try exact match first
     const exact = await sql`SELECT slug FROM pages WHERE slug = ${partial} ${sourceCondition}`;
@@ -803,7 +831,12 @@ export class PostgresEngine implements BrainEngine {
     // Otherwise (federated/super-reader) no filter applied. Fix:
     // fix/mcp-source-isolation-read-side.
     let sourceClause = '';
-    if (opts?.sourceId && opts.sourceId !== '__all__') {
+    // v0.32.x federated-read: allowedSources (post-v52) preferred — pushes
+    // the array as one param and emits ANY(); falls back to scalar sourceId.
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      params.push(opts.allowedSources);
+      sourceClause = `AND p.source_id = ANY($${params.length}::text[])`;
+    } else if (opts?.sourceId && opts.sourceId !== '__all__') {
       params.push(opts.sourceId);
       sourceClause = `AND p.source_id = $${params.length}`;
     }
@@ -939,7 +972,12 @@ export class PostgresEngine implements BrainEngine {
     // Otherwise (federated/super-reader) no filter applied. Fix:
     // fix/mcp-source-isolation-read-side.
     let sourceClause = '';
-    if (opts?.sourceId && opts.sourceId !== '__all__') {
+    // v0.32.x federated-read: allowedSources (post-v52) preferred — pushes
+    // the array as one param and emits ANY(); falls back to scalar sourceId.
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      params.push(opts.allowedSources);
+      sourceClause = `AND p.source_id = ANY($${params.length}::text[])`;
+    } else if (opts?.sourceId && opts.sourceId !== '__all__') {
       params.push(opts.sourceId);
       sourceClause = `AND p.source_id = $${params.length}`;
     }
@@ -1050,7 +1088,12 @@ export class PostgresEngine implements BrainEngine {
     // Otherwise (federated/super-reader) no filter applied. Fix:
     // fix/mcp-source-isolation-read-side.
     let sourceClause = '';
-    if (opts?.sourceId && opts.sourceId !== '__all__') {
+    // v0.32.x federated-read: allowedSources (post-v52) preferred — pushes
+    // the array as one param and emits ANY(); falls back to scalar sourceId.
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      params.push(opts.allowedSources);
+      sourceClause = `AND p.source_id = ANY($${params.length}::text[])`;
+    } else if (opts?.sourceId && opts.sourceId !== '__all__') {
       params.push(opts.sourceId);
       sourceClause = `AND p.source_id = $${params.length}`;
     }
@@ -1243,7 +1286,7 @@ export class PostgresEngine implements BrainEngine {
     );
   }
 
-  async getChunks(slug: string, opts?: { sourceId?: string }): Promise<Chunk[]> {
+  async getChunks(slug: string, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<Chunk[]> {
     const sql = this.sql;
     const sourceId = opts?.sourceId ?? 'default';
     const rows = await sql`
@@ -1420,11 +1463,26 @@ export class PostgresEngine implements BrainEngine {
     }
   }
 
-  async getLinks(slug: string, opts?: { sourceId?: string }): Promise<Link[]> {
+  async getLinks(slug: string, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<Link[]> {
     const sql = this.sql;
-    // v0.31.8 (D16): two-branch query. Without opts.sourceId, no source filter
-    // (preserves pre-v0.31.8 cross-source semantics). With opts.sourceId,
-    // scope the from-page lookup. See pglite-engine.ts:getLinks for context.
+    // v0.31.8 (D16) + v0.32.x federated-read: three-branch. allowedSources
+    // (post-v52) scopes both endpoints to that set; sourceId scopes both
+    // to that one source; neither = federated cross-source view.
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      const rows = await sql`
+        SELECT f.slug as from_slug, t.slug as to_slug,
+               l.link_type, l.context, l.link_source,
+               o.slug as origin_slug, l.origin_field
+        FROM links l
+        JOIN pages f ON f.id = l.from_page_id
+        JOIN pages t ON t.id = l.to_page_id
+        LEFT JOIN pages o ON o.id = l.origin_page_id
+        WHERE f.slug = ${slug}
+          AND f.source_id = ANY(${opts.allowedSources})
+          AND t.source_id = ANY(${opts.allowedSources})
+      `;
+      return rows as unknown as Link[];
+    }
     if (opts?.sourceId) {
       const rows = await sql`
         SELECT f.slug as from_slug, t.slug as to_slug,
@@ -1451,9 +1509,24 @@ export class PostgresEngine implements BrainEngine {
     return rows as unknown as Link[];
   }
 
-  async getBacklinks(slug: string, opts?: { sourceId?: string }): Promise<Link[]> {
+  async getBacklinks(slug: string, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<Link[]> {
     const sql = this.sql;
-    // v0.31.8 (D16): two-branch query, mirrors getLinks above.
+    // v0.31.8 (D16) + v0.32.x federated-read: three-branch on read scope.
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      const rows = await sql`
+        SELECT f.slug as from_slug, t.slug as to_slug,
+               l.link_type, l.context, l.link_source,
+               o.slug as origin_slug, l.origin_field
+        FROM links l
+        JOIN pages f ON f.id = l.from_page_id
+        JOIN pages t ON t.id = l.to_page_id
+        LEFT JOIN pages o ON o.id = l.origin_page_id
+        WHERE t.slug = ${slug}
+          AND t.source_id = ANY(${opts.allowedSources})
+          AND f.source_id = ANY(${opts.allowedSources})
+      `;
+      return rows as unknown as Link[];
+    }
     if (opts?.sourceId) {
       const rows = await sql`
         SELECT f.slug as from_slug, t.slug as to_slug,
@@ -1510,24 +1583,33 @@ export class PostgresEngine implements BrainEngine {
     return { slug: row.slug, similarity: row.sim };
   }
 
-  async traverseGraph(slug: string, depth: number = 5, opts?: { sourceId?: string }): Promise<GraphNode[]> {
+  async traverseGraph(slug: string, depth: number = 5, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<GraphNode[]> {
     const sql = this.sql;
+    // v0.32.x federated-read: allowedSources (post-v52) preferred over scalar.
+    const allowedSources = opts?.allowedSources && opts.allowedSources.length > 0
+      ? opts.allowedSources
+      : null;
     const sourceId = opts?.sourceId ?? null;
-    const scoped = sourceId !== null;
+    const scoped = allowedSources !== null || sourceId !== null;
+    const sourceMatchSql = (alias: string) => {
+      if (!scoped) return sql`TRUE`;
+      if (allowedSources) return sql`${sql.unsafe(alias + '.source_id')} = ANY(${allowedSources})`;
+      return sql`${sql.unsafe(alias + '.source_id')} = ${sourceId ?? ''}`;
+    };
     // Cycle prevention: visited array tracks page IDs already in the path.
-    // v0.31.4 P0 source-isolation: when sourceId is set, both the seed page and every
-    // visited neighbor must match. Federated callers (sourceId=null) see all sources.
+    // v0.31.4 P0 source-isolation: when scoped, both the seed page and every
+    // visited neighbor must match. Federated callers (no scope) see all sources.
     const rows = await sql`
       WITH RECURSIVE graph AS (
         SELECT p.id, p.slug, p.title, p.type, 0 as depth, ARRAY[p.id] as visited
-        FROM pages p WHERE p.slug = ${slug} AND (${!scoped} OR p.source_id = ${sourceId ?? ''})
+        FROM pages p WHERE p.slug = ${slug} AND ${sourceMatchSql('p')}
 
         UNION ALL
 
         SELECT p2.id, p2.slug, p2.title, p2.type, g.depth + 1, g.visited || p2.id
         FROM graph g
         JOIN links l ON l.from_page_id = g.id
-        JOIN pages p2 ON p2.id = l.to_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
+        JOIN pages p2 ON p2.id = l.to_page_id AND ${sourceMatchSql('p2')}
         WHERE g.depth < ${depth}
           AND NOT (p2.id = ANY(g.visited))
       )
@@ -1542,7 +1624,7 @@ export class PostgresEngine implements BrainEngine {
           -- different layer. See plan Bug 6/10.
           (SELECT jsonb_agg(DISTINCT jsonb_build_object('to_slug', p3.slug, 'link_type', l2.link_type))
            FROM links l2
-           JOIN pages p3 ON p3.id = l2.to_page_id AND (${!scoped} OR p3.source_id = ${sourceId ?? ''})
+           JOIN pages p3 ON p3.id = l2.to_page_id AND ${sourceMatchSql('p3')}
            WHERE l2.from_page_id = g.id),
           '[]'::jsonb
         ) as links
@@ -1561,7 +1643,7 @@ export class PostgresEngine implements BrainEngine {
 
   async traversePaths(
     slug: string,
-    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both'; sourceId?: string },
+    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both'; sourceId?: string; allowedSources?: string[] },
   ): Promise<GraphPath[]> {
     const sql = this.sql;
     const depth = opts?.depth ?? 5;
@@ -1569,21 +1651,31 @@ export class PostgresEngine implements BrainEngine {
     const linkType = opts?.linkType ?? null;
     const linkTypeMatches = linkType !== null;
     // v0.31.4 P0 source-isolation: seed + every visited neighbor must match
-    // when sourceId is set. Federated callers (sourceId=null) see all sources.
+    // v0.32.x federated-read: allowedSources (post-v52) preferred; scoped
+    // means "any non-null restriction is active". When allowedSources is set,
+    // sourceId is overridden — all per-alias matches use ANY(allowedSources).
+    const allowedSources = opts?.allowedSources && opts.allowedSources.length > 0
+      ? opts.allowedSources
+      : null;
     const sourceId = opts?.sourceId ?? null;
-    const scoped = sourceId !== null;
+    const scoped = allowedSources !== null || sourceId !== null;
+    const sourceMatchSql = (alias: string) => {
+      if (!scoped) return sql`TRUE`;
+      if (allowedSources) return sql`${sql.unsafe(alias + '.source_id')} = ANY(${allowedSources})`;
+      return sql`${sql.unsafe(alias + '.source_id')} = ${sourceId ?? ''}`;
+    };
 
     let rows;
     if (direction === 'out') {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug} AND (${!scoped} OR p.source_id = ${sourceId ?? ''})
+          FROM pages p WHERE p.slug = ${slug} AND ${sourceMatchSql('p')}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON l.from_page_id = w.id
-          JOIN pages p2 ON p2.id = l.to_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
+          JOIN pages p2 ON p2.id = l.to_page_id AND ${sourceMatchSql('p2')}
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
@@ -1592,7 +1684,7 @@ export class PostgresEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 as depth
         FROM walk w
         JOIN links l ON l.from_page_id = w.id
-        JOIN pages p2 ON p2.id = l.to_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
+        JOIN pages p2 ON p2.id = l.to_page_id AND ${sourceMatchSql('p2')}
         WHERE w.depth < ${depth}
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
         ORDER BY depth, from_slug, to_slug
@@ -1601,12 +1693,12 @@ export class PostgresEngine implements BrainEngine {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug} AND (${!scoped} OR p.source_id = ${sourceId ?? ''})
+          FROM pages p WHERE p.slug = ${slug} AND ${sourceMatchSql('p')}
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON l.to_page_id = w.id
-          JOIN pages p2 ON p2.id = l.from_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
+          JOIN pages p2 ON p2.id = l.from_page_id AND ${sourceMatchSql('p2')}
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
@@ -1615,7 +1707,7 @@ export class PostgresEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 as depth
         FROM walk w
         JOIN links l ON l.to_page_id = w.id
-        JOIN pages p2 ON p2.id = l.from_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
+        JOIN pages p2 ON p2.id = l.from_page_id AND ${sourceMatchSql('p2')}
         WHERE w.depth < ${depth}
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
         ORDER BY depth, from_slug, to_slug
@@ -1624,12 +1716,12 @@ export class PostgresEngine implements BrainEngine {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug} AND (${!scoped} OR p.source_id = ${sourceId ?? ''})
+          FROM pages p WHERE p.slug = ${slug} AND ${sourceMatchSql('p')}
           UNION ALL
           SELECT p2.id, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON (l.from_page_id = w.id OR l.to_page_id = w.id)
-          JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
+          JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END AND ${sourceMatchSql('p2')}
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
@@ -1638,12 +1730,12 @@ export class PostgresEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 as depth
         FROM walk w
         JOIN links l ON (l.from_page_id = w.id OR l.to_page_id = w.id)
-        JOIN pages pf ON pf.id = l.from_page_id AND (${!scoped} OR pf.source_id = ${sourceId ?? ''})
-        JOIN pages pt ON pt.id = l.to_page_id AND (${!scoped} OR pt.source_id = ${sourceId ?? ''})
+        JOIN pages pf ON pf.id = l.from_page_id AND ${sourceMatchSql('pf')}
+        JOIN pages pt ON pt.id = l.to_page_id AND ${sourceMatchSql('pt')}
         WHERE w.depth < ${depth}
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
-          AND (${!scoped} OR pf.source_id = ${sourceId ?? ''})
-          AND (${!scoped} OR pt.source_id = ${sourceId ?? ''})
+          AND ${sourceMatchSql('pf')}
+          AND ${sourceMatchSql('pt')}
         ORDER BY depth, from_slug, to_slug
       `;
     }
@@ -1788,8 +1880,18 @@ export class PostgresEngine implements BrainEngine {
     `;
   }
 
-  async getTags(slug: string, opts?: { sourceId?: string }): Promise<string[]> {
+  async getTags(slug: string, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<string[]> {
     const sql = this.sql;
+    // v0.32.x federated-read: allowedSources (post-v52) preferred over scalar.
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      const rows = await sql`
+        SELECT t.tag FROM tags t
+        JOIN pages p ON p.id = t.page_id
+        WHERE p.slug = ${slug} AND p.source_id = ANY(${opts.allowedSources})
+        ORDER BY t.tag
+      `;
+      return rows.map((r) => r.tag as string);
+    }
     const sourceId = opts?.sourceId ?? 'default';
     const rows = await sql`
       SELECT tag FROM tags
@@ -1850,13 +1952,38 @@ export class PostgresEngine implements BrainEngine {
   async getTimeline(slug: string, opts?: TimelineOpts): Promise<TimelineEntry[]> {
     const sql = this.sql;
     const limit = opts?.limit || 100;
+    // v0.32.x federated-read: allowedSources (post-v52) wins over scalar sourceId.
     // v0.31.8 (D16): branch on every combination of (after, before, sourceId).
     // 8 cases is too many — use an explicit branch on sourceId, then nested
     // branches on after/before. Mirrors pglite-engine but stays in postgres.js
     // template-literal idiom (which doesn't compose fragment WHERE chains
     // cleanly).
-    const sourceId = opts?.sourceId;
     let rows;
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      const allowed = opts.allowedSources;
+      if (opts?.after && opts?.before) {
+        rows = await sql`SELECT te.* FROM timeline_entries te JOIN pages p ON p.id = te.page_id
+          WHERE p.slug = ${slug} AND p.source_id = ANY(${allowed})
+            AND te.date >= ${opts.after}::date AND te.date <= ${opts.before}::date
+          ORDER BY te.date DESC LIMIT ${limit}`;
+      } else if (opts?.after) {
+        rows = await sql`SELECT te.* FROM timeline_entries te JOIN pages p ON p.id = te.page_id
+          WHERE p.slug = ${slug} AND p.source_id = ANY(${allowed})
+            AND te.date >= ${opts.after}::date
+          ORDER BY te.date DESC LIMIT ${limit}`;
+      } else if (opts?.before) {
+        rows = await sql`SELECT te.* FROM timeline_entries te JOIN pages p ON p.id = te.page_id
+          WHERE p.slug = ${slug} AND p.source_id = ANY(${allowed})
+            AND te.date <= ${opts.before}::date
+          ORDER BY te.date DESC LIMIT ${limit}`;
+      } else {
+        rows = await sql`SELECT te.* FROM timeline_entries te JOIN pages p ON p.id = te.page_id
+          WHERE p.slug = ${slug} AND p.source_id = ANY(${allowed})
+          ORDER BY te.date DESC LIMIT ${limit}`;
+      }
+      return rows as unknown as TimelineEntry[];
+    }
+    const sourceId = opts?.sourceId;
     if (sourceId) {
       if (opts?.after && opts?.before) {
         rows = await sql`SELECT te.* FROM timeline_entries te JOIN pages p ON p.id = te.page_id
@@ -1939,14 +2066,28 @@ export class PostgresEngine implements BrainEngine {
   async getRawData(
     slug: string,
     source?: string,
-    opts?: { sourceId?: string },
+    opts?: { sourceId?: string; allowedSources?: string[] },
   ): Promise<RawData[]> {
     const sql = this.sql;
+    // v0.32.x federated-read: allowedSources (post-v52) wins over scalar sourceId.
     // v0.31.8 (D21): four-branch shape on (source provided, sourceId provided).
     // Postgres.js template-literal style doesn't compose fragments cleanly so
     // we enumerate.
-    const sourceId = opts?.sourceId;
     let rows;
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      const allowed = opts.allowedSources;
+      if (source) {
+        rows = await sql`SELECT rd.source, rd.data, rd.fetched_at FROM raw_data rd
+          JOIN pages p ON p.id = rd.page_id
+          WHERE p.slug = ${slug} AND rd.source = ${source} AND p.source_id = ANY(${allowed})`;
+      } else {
+        rows = await sql`SELECT rd.source, rd.data, rd.fetched_at FROM raw_data rd
+          JOIN pages p ON p.id = rd.page_id
+          WHERE p.slug = ${slug} AND p.source_id = ANY(${allowed})`;
+      }
+      return rows as unknown as RawData[];
+    }
+    const sourceId = opts?.sourceId;
     if (source && sourceId) {
       rows = await sql`SELECT rd.source, rd.data, rd.fetched_at FROM raw_data rd
         JOIN pages p ON p.id = rd.page_id
@@ -2660,9 +2801,19 @@ export class PostgresEngine implements BrainEngine {
     return rows[0] as unknown as PageVersion;
   }
 
-  async getVersions(slug: string, opts?: { sourceId?: string }): Promise<PageVersion[]> {
+  async getVersions(slug: string, opts?: { sourceId?: string; allowedSources?: string[] }): Promise<PageVersion[]> {
     const sql = this.sql;
+    // v0.32.x federated-read: allowedSources (post-v52) preferred over scalar.
     // v0.31.8 (D16): two-branch.
+    if (opts?.allowedSources && opts.allowedSources.length > 0) {
+      const rows = await sql`
+        SELECT pv.* FROM page_versions pv
+        JOIN pages p ON p.id = pv.page_id
+        WHERE p.slug = ${slug} AND p.source_id = ANY(${opts.allowedSources})
+        ORDER BY pv.snapshot_at DESC
+      `;
+      return rows as unknown as PageVersion[];
+    }
     if (opts?.sourceId) {
       const rows = await sql`
         SELECT pv.* FROM page_versions pv

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1311,7 +1311,7 @@ export class PostgresEngine implements BrainEngine {
   async listStaleChunks(): Promise<StaleChunkRow[]> {
     const sql = this.sql;
     const rows = await sql`
-      SELECT p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+      SELECT p.slug, p.source_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
              cc.model, cc.token_count
       FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -717,18 +717,23 @@ export class PostgresEngine implements BrainEngine {
     return new Set(rows.map((r) => r.slug as string));
   }
 
-  async resolveSlugs(partial: string): Promise<string[]> {
+  async resolveSlugs(partial: string, opts?: { sourceId?: string }): Promise<string[]> {
     const sql = this.sql;
+    // v0.31.4 (mcp-source-isolation read-side fix): scope to caller's source
+    // when present. NULL = federated (Robin super-reader / local CLI).
+    const sourceCondition = opts?.sourceId
+      ? sql`AND source_id = ${opts.sourceId}`
+      : sql``;
 
     // Try exact match first
-    const exact = await sql`SELECT slug FROM pages WHERE slug = ${partial}`;
+    const exact = await sql`SELECT slug FROM pages WHERE slug = ${partial} ${sourceCondition}`;
     if (exact.length > 0) return [exact[0].slug];
 
     // Fuzzy match via pg_trgm
     const fuzzy = await sql`
       SELECT slug, similarity(title, ${partial}) AS sim
       FROM pages
-      WHERE title % ${partial} OR slug ILIKE ${'%' + partial + '%'}
+      WHERE (title % ${partial} OR slug ILIKE ${'%' + partial + '%'}) ${sourceCondition}
       ORDER BY sim DESC
       LIMIT 5
     `;
@@ -1505,20 +1510,24 @@ export class PostgresEngine implements BrainEngine {
     return { slug: row.slug, similarity: row.sim };
   }
 
-  async traverseGraph(slug: string, depth: number = 5): Promise<GraphNode[]> {
+  async traverseGraph(slug: string, depth: number = 5, opts?: { sourceId?: string }): Promise<GraphNode[]> {
     const sql = this.sql;
+    const sourceId = opts?.sourceId ?? null;
+    const scoped = sourceId !== null;
     // Cycle prevention: visited array tracks page IDs already in the path.
+    // v0.31.4 P0 source-isolation: when sourceId is set, both the seed page and every
+    // visited neighbor must match. Federated callers (sourceId=null) see all sources.
     const rows = await sql`
       WITH RECURSIVE graph AS (
         SELECT p.id, p.slug, p.title, p.type, 0 as depth, ARRAY[p.id] as visited
-        FROM pages p WHERE p.slug = ${slug}
+        FROM pages p WHERE p.slug = ${slug} AND (${!scoped} OR p.source_id = ${sourceId ?? ''})
 
         UNION ALL
 
         SELECT p2.id, p2.slug, p2.title, p2.type, g.depth + 1, g.visited || p2.id
         FROM graph g
         JOIN links l ON l.from_page_id = g.id
-        JOIN pages p2 ON p2.id = l.to_page_id
+        JOIN pages p2 ON p2.id = l.to_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
         WHERE g.depth < ${depth}
           AND NOT (p2.id = ANY(g.visited))
       )
@@ -1533,7 +1542,7 @@ export class PostgresEngine implements BrainEngine {
           -- different layer. See plan Bug 6/10.
           (SELECT jsonb_agg(DISTINCT jsonb_build_object('to_slug', p3.slug, 'link_type', l2.link_type))
            FROM links l2
-           JOIN pages p3 ON p3.id = l2.to_page_id
+           JOIN pages p3 ON p3.id = l2.to_page_id AND (${!scoped} OR p3.source_id = ${sourceId ?? ''})
            WHERE l2.from_page_id = g.id),
           '[]'::jsonb
         ) as links
@@ -1552,25 +1561,29 @@ export class PostgresEngine implements BrainEngine {
 
   async traversePaths(
     slug: string,
-    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both' },
+    opts?: { depth?: number; linkType?: string; direction?: 'in' | 'out' | 'both'; sourceId?: string },
   ): Promise<GraphPath[]> {
     const sql = this.sql;
     const depth = opts?.depth ?? 5;
     const direction = opts?.direction ?? 'out';
     const linkType = opts?.linkType ?? null;
     const linkTypeMatches = linkType !== null;
+    // v0.31.4 P0 source-isolation: seed + every visited neighbor must match
+    // when sourceId is set. Federated callers (sourceId=null) see all sources.
+    const sourceId = opts?.sourceId ?? null;
+    const scoped = sourceId !== null;
 
     let rows;
     if (direction === 'out') {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug}
+          FROM pages p WHERE p.slug = ${slug} AND (${!scoped} OR p.source_id = ${sourceId ?? ''})
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON l.from_page_id = w.id
-          JOIN pages p2 ON p2.id = l.to_page_id
+          JOIN pages p2 ON p2.id = l.to_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
@@ -1579,7 +1592,7 @@ export class PostgresEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 as depth
         FROM walk w
         JOIN links l ON l.from_page_id = w.id
-        JOIN pages p2 ON p2.id = l.to_page_id
+        JOIN pages p2 ON p2.id = l.to_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
         WHERE w.depth < ${depth}
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
         ORDER BY depth, from_slug, to_slug
@@ -1588,12 +1601,12 @@ export class PostgresEngine implements BrainEngine {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, p.slug, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug}
+          FROM pages p WHERE p.slug = ${slug} AND (${!scoped} OR p.source_id = ${sourceId ?? ''})
           UNION ALL
           SELECT p2.id, p2.slug, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON l.to_page_id = w.id
-          JOIN pages p2 ON p2.id = l.from_page_id
+          JOIN pages p2 ON p2.id = l.from_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
@@ -1602,7 +1615,7 @@ export class PostgresEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 as depth
         FROM walk w
         JOIN links l ON l.to_page_id = w.id
-        JOIN pages p2 ON p2.id = l.from_page_id
+        JOIN pages p2 ON p2.id = l.from_page_id AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
         WHERE w.depth < ${depth}
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
         ORDER BY depth, from_slug, to_slug
@@ -1611,12 +1624,12 @@ export class PostgresEngine implements BrainEngine {
       rows = await sql`
         WITH RECURSIVE walk AS (
           SELECT p.id, 0::int as depth, ARRAY[p.id] as visited
-          FROM pages p WHERE p.slug = ${slug}
+          FROM pages p WHERE p.slug = ${slug} AND (${!scoped} OR p.source_id = ${sourceId ?? ''})
           UNION ALL
           SELECT p2.id, w.depth + 1, w.visited || p2.id
           FROM walk w
           JOIN links l ON (l.from_page_id = w.id OR l.to_page_id = w.id)
-          JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END
+          JOIN pages p2 ON p2.id = CASE WHEN l.from_page_id = w.id THEN l.to_page_id ELSE l.from_page_id END AND (${!scoped} OR p2.source_id = ${sourceId ?? ''})
           WHERE w.depth < ${depth}
             AND NOT (p2.id = ANY(w.visited))
             AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
@@ -1625,10 +1638,12 @@ export class PostgresEngine implements BrainEngine {
                l.link_type, l.context, w.depth + 1 as depth
         FROM walk w
         JOIN links l ON (l.from_page_id = w.id OR l.to_page_id = w.id)
-        JOIN pages pf ON pf.id = l.from_page_id
-        JOIN pages pt ON pt.id = l.to_page_id
+        JOIN pages pf ON pf.id = l.from_page_id AND (${!scoped} OR pf.source_id = ${sourceId ?? ''})
+        JOIN pages pt ON pt.id = l.to_page_id AND (${!scoped} OR pt.source_id = ${sourceId ?? ''})
         WHERE w.depth < ${depth}
           AND (${!linkTypeMatches} OR l.link_type = ${linkType ?? ''})
+          AND (${!scoped} OR pf.source_id = ${sourceId ?? ''})
+          AND (${!scoped} OR pt.source_id = ${sourceId ?? ''})
         ORDER BY depth, from_slug, to_slug
       `;
     }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -787,6 +787,15 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    // v0.31.4: source-isolation filter for token-scoped reads. When
+    // opts.sourceId is set and not '__all__', restrict to that source_id.
+    // Otherwise (federated/super-reader) no filter applied. Fix:
+    // fix/mcp-source-isolation-read-side.
+    let sourceClause = '';
+    if (opts?.sourceId && opts.sourceId !== '__all__') {
+      params.push(opts.sourceId);
+      sourceClause = `AND p.source_id = $${params.length}`;
+    }
     // v0.27.0: date filtering support
     let afterDateClause = '';
     if (opts?.afterDate) {
@@ -826,6 +835,7 @@ export class PostgresEngine implements BrainEngine {
           ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
           ${languageClause}
           ${symbolKindClause}
+          ${sourceClause}
           ${afterDateClause}
           ${beforeDateClause}
           ${hardExcludeClause}
@@ -913,6 +923,15 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    // v0.31.4: source-isolation filter for token-scoped reads. When
+    // opts.sourceId is set and not '__all__', restrict to that source_id.
+    // Otherwise (federated/super-reader) no filter applied. Fix:
+    // fix/mcp-source-isolation-read-side.
+    let sourceClause = '';
+    if (opts?.sourceId && opts.sourceId !== '__all__') {
+      params.push(opts.sourceId);
+      sourceClause = `AND p.source_id = $${params.length}`;
+    }
     // v0.27.0: date filtering support
     let afterDateClause = '';
     if (opts?.afterDate) {
@@ -947,6 +966,7 @@ export class PostgresEngine implements BrainEngine {
         ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
         ${languageClause}
         ${symbolKindClause}
+        ${sourceClause}
         ${afterDateClause}
         ${beforeDateClause}
         ${hardExcludeClause}
@@ -1014,6 +1034,15 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
+    // v0.31.4: source-isolation filter for token-scoped reads. When
+    // opts.sourceId is set and not '__all__', restrict to that source_id.
+    // Otherwise (federated/super-reader) no filter applied. Fix:
+    // fix/mcp-source-isolation-read-side.
+    let sourceClause = '';
+    if (opts?.sourceId && opts.sourceId !== '__all__') {
+      params.push(opts.sourceId);
+      sourceClause = `AND p.source_id = $${params.length}`;
+    }
     // v0.27.0: date filtering support
     let afterDateClause = '';
     if (opts?.afterDate) {
@@ -1057,6 +1086,7 @@ export class PostgresEngine implements BrainEngine {
           ${excludeSlugsClause}
           ${languageClause}
           ${symbolKindClause}
+          ${sourceClause}
           ${afterDateClause}
           ${beforeDateClause}
           ${hardExcludeClause}

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -684,6 +684,12 @@ export class PostgresEngine implements BrainEngine {
     const deletedCondition = filters?.includeDeleted === true
       ? sql``
       : sql`AND p.deleted_at IS NULL`;
+    // v0.31.4 (mcp-source-isolation read-side fix): scope listing when the
+    // caller carries an auth-derived sourceId. Unset = federated (matches
+    // local CLI + Robin super-reader semantics). See operations.ts list_pages.
+    const sourceCondition = filters?.sourceId
+      ? sql`AND p.source_id = ${filters.sourceId}`
+      : sql``;
 
     // v0.29: ORDER BY threading via PAGE_SORT_SQL whitelist (no SQL injection).
     // postgres.js sql.unsafe lets us splice the literal fragment safely.
@@ -693,7 +699,7 @@ export class PostgresEngine implements BrainEngine {
     const rows = await sql`
       SELECT p.* FROM pages p
       ${tagJoin}
-      WHERE 1=1 ${typeCondition} ${tagCondition} ${updatedCondition} ${slugCondition} ${deletedCondition}
+      WHERE 1=1 ${typeCondition} ${tagCondition} ${updatedCondition} ${slugCondition} ${deletedCondition} ${sourceCondition}
       ORDER BY ${orderBy} LIMIT ${limit} OFFSET ${offset}
     `;
 

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -428,8 +428,12 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
   client_secret_expires_at BIGINT,
   token_ttl               INTEGER,
   deleted_at              TIMESTAMPTZ,
-  -- v0.31.4: source-isolation scope for MCP HTTP callers. NULL = federated/super-reader.
-  source_id               TEXT REFERENCES sources(id) ON DELETE SET NULL,
+  -- v0.31.4 / v0.32.x: source-isolation scope for MCP HTTP callers.
+  -- source_id      = the single source this client WRITES into (NOT NULL post-v52).
+  -- federated_read = the set of source ids this client may READ from. Must contain source_id.
+  source_id               TEXT NOT NULL REFERENCES sources(id) ON DELETE RESTRICT,
+  federated_read          TEXT[] NOT NULL DEFAULT '{}',
+  CONSTRAINT oauth_clients_own_source_in_read CHECK (source_id = ANY(federated_read)),
   created_at              TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -428,6 +428,8 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
   client_secret_expires_at BIGINT,
   token_ttl               INTEGER,
   deleted_at              TIMESTAMPTZ,
+  -- v0.31.4: source-isolation scope for MCP HTTP callers. NULL = federated/super-reader.
+  source_id               TEXT REFERENCES sources(id) ON DELETE SET NULL,
   created_at              TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -232,6 +232,13 @@ export async function hybridSearch(
     // PR #618 callers compiling while the new names are the public surface.
     afterDate: opts?.since ?? opts?.afterDate,
     beforeDate: opts?.until ?? opts?.beforeDate,
+    // v0.31.4 (fix/mcp-source-isolation-read-side): thread sourceId so
+    // engine.searchKeyword AND engine.searchVector both apply the
+    // pages.source_id WHERE filter. Without this, the op-layer hands
+    // sourceId to hybridSearch but it gets dropped before reaching the
+    // engine — Tier 3 (`query` tool) returns cross-source rows even
+    // when the auth-mapped sourceId is set.
+    sourceId: opts?.sourceId,
   };
   // Track what actually ran for the optional onMeta callback (v0.25.0).
   // Caller leaves onMeta undefined → these flags are computed but never

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -421,6 +421,13 @@ export interface SearchOpts {
    */
   sourceId?: string;
   /**
+   * v0.32.x federated-read: scope search to a SET of sources (e.g. ['augustus',
+   * 'wecare', 'shared']). Takes precedence over `sourceId`. Used by OAuth
+   * tokens whose client has a `federated_read` list (post-v52 schema).
+   * Empty/undefined = fall back to `sourceId` precedence, or fully federated.
+   */
+  allowedSources?: string[];
+  /**
    * v0.27.1: target column for vector search. 'embedding' (default) hits
    * the brain's primary text-embedding column. 'embedding_image' targets
    * the multimodal column populated by importImageFile. The two columns
@@ -580,9 +587,12 @@ export interface TimelineOpts {
    * (pre-v0.31.8 behavior; preserved by the two-branch query in both engines).
    */
   sourceId?: string;
+  /**
+   * v0.32.x federated-read: scope timeline to a set of sources. Takes
+   * precedence over sourceId. Used by OAuth tokens with federated_read.
+   */
+  allowedSources?: string[];
 }
-
-// Raw data
 export interface RawData {
   source: string;
   data: Record<string, unknown>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -307,6 +307,7 @@ export interface Chunk {
  */
 export interface StaleChunkRow {
   slug: string;
+  source_id: string;
   chunk_index: number;
   chunk_text: string;
   chunk_source: 'compiled_truth' | 'timeline';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -163,6 +163,13 @@ export interface PageFilters {
    * Whitelisted enum — no SQL-injection risk; engines map to literal SQL fragments.
    */
   sort?: 'updated_desc' | 'updated_asc' | 'created_desc' | 'slug';
+  /**
+   * v0.31.4 (mcp-source-isolation read-side fix): scope the listing to a
+   * single source. Unset = federated/cross-source (matches local CLI and
+   * Robin super-reader semantics). Engines apply this as `WHERE p.source_id = ?`.
+   * Wired from `authInfo.sourceId` → `OperationContext.sourceId` → handler.
+   */
+  sourceId?: string;
 }
 
 /** v0.26.5 — opts for getPage / softDeletePage / restorePage. */

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -46,8 +46,20 @@ export interface DispatchOpts {
    * matching `sourceId`. CLI dispatch resolves this from --source flag /
    * GBRAIN_SOURCE / .gbrain-source / 'default'; HTTP MCP transport
    * resolves it from the per-token allow-list (eE3).
+   *
+   * Post-v52 (federated-read, pages-side): for HTTP-MCP callers this is the
+   * WRITE-target source; reads consult `allowedSources` below.
    */
   sourceId?: string;
+  /**
+   * v0.32.x feat/oauth-federated-read: per-caller READ scope. Threaded onto
+   * `OperationContext.allowedSources`. HTTP transport sets this from
+   * `AuthInfo.allowedSources` (OAuth) or `AuthResult.allowedSources` (legacy
+   * access_tokens). CLI dispatch leaves it unset — local CLI is implicit
+   * super-reader. When unset, engines fall back to scalar `sourceId`
+   * (legacy single-source semantics).
+   */
+  allowedSources?: string[];
   /**
    * v0.31 (eD3): hook called by the dispatcher AFTER op.handler succeeds
    * to compute `_meta.brain_hot_memory` for the response. Wrapped in its
@@ -205,6 +217,7 @@ export function buildOperationContext(
     remote: opts.remote ?? true,
     takesHoldersAllowList: opts.takesHoldersAllowList,
     sourceId: opts.sourceId,
+    allowedSources: opts.allowedSources,
     auth: opts.auth,
   };
 }

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -66,6 +66,19 @@ interface AuthResult {
   tokenName?: string;
   /** v0.28: per-token allow-list for takes.holder. Default ['world'] when permissions row absent. */
   takesHoldersAllowList?: string[];
+  /**
+   * v0.31.4 (mcp-source-isolation fix): per-token primary source. When set,
+   * threaded onto OperationContext.sourceId and used by engines to scope
+   * reads (list_pages, get_page, query, search, searchKeyword) to that
+   * source only. Closes the read-side cross-source leak documented in
+   * shared/wecare/bugs/2026-05-11-mcp-read-isolation-verification-failed.
+   *
+   * Stored as `access_tokens.permissions.source_id` (string).
+   * When undefined, engines fall back to current behavior (no scope filter)
+   * — which is how trusted local CLI callers and Robin's super-reader token
+   * keep working.
+   */
+  sourceId?: string;
 }
 
 /** Read up to `cap` bytes off req.body. Returns null if cap exceeded. */
@@ -171,15 +184,25 @@ export async function startHttpTransport(opts: HttpTransportOptions) {
         .catch(() => { /* fire-and-forget */ });
       // v0.28: extract per-token takes-holder allow-list. Fail-safe default
       // is ['world'] — a token with no permissions row sees public claims only.
-      const perms = (row as { permissions?: { takes_holders?: unknown } }).permissions;
+      const perms = (row as { permissions?: { takes_holders?: unknown; source_id?: unknown } }).permissions;
       const allowList = Array.isArray(perms?.takes_holders)
         ? (perms!.takes_holders as unknown[]).filter(h => typeof h === 'string') as string[]
         : ['world'];
+      // v0.31.4 (mcp-source-isolation fix): per-token primary source claim.
+      // When `permissions.source_id` is a non-empty string, the HTTP transport
+      // forwards it as `OperationContext.sourceId` so engines scope reads
+      // (list_pages, get_page, query, search, searchKeyword) to that source.
+      // Tokens without `source_id` retain pre-fix behavior (no scope filter)
+      // — used by Robin's super-reader and any operator-managed admin token.
+      const sourceId = typeof perms?.source_id === 'string' && (perms!.source_id as string).length > 0
+        ? (perms!.source_id as string)
+        : undefined;
       return {
         ok: true,
         tokenId: rowId,
         tokenName: rowName,
         takesHoldersAllowList: allowList,
+        sourceId,
       };
     } catch {
       return { ok: false };
@@ -328,9 +351,12 @@ export async function startHttpTransport(opts: HttpTransportOptions) {
         const args: Record<string, unknown> = params?.arguments ?? {};
         // v0.28: thread per-token takes-holder allow-list so takes_list /
         // takes_search / query (when it returns takes) can server-side filter.
+        // v0.31.4 (mcp-source-isolation fix): also forward per-token sourceId
+        // so engines scope reads to the caller's source. See AuthResult docs.
         const result = await dispatchToolCall(engine, toolName, args, {
           remote: true,
           takesHoldersAllowList: auth.takesHoldersAllowList,
+          sourceId: auth.sourceId,
         });
         const status = result.isError ? 'error' : 'success';
         logRequest(auth.tokenName!, `tools/call:${toolName}`, status, Date.now() - startedMs);

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -77,8 +77,19 @@ interface AuthResult {
    * When undefined, engines fall back to current behavior (no scope filter)
    * — which is how trusted local CLI callers and Robin's super-reader token
    * keep working.
+   *
+   * Post-v52 (federated-read): for OAuth tokens this is the WRITE-target
+   * source. The READ scope is in `allowedSources`.
    */
   sourceId?: string;
+  /**
+   * v0.32.x (feat/oauth-federated-read): per-token READ scope. Threaded onto
+   * `OperationContext.allowedSources`. Engine read paths prefer this over
+   * `sourceId` for filtering. Sourced from `oauth_clients.federated_read`
+   * (OAuth path) or `access_tokens.permissions.federated_read` (legacy
+   * path). Undefined preserves pre-v52 scalar-sourceId semantics.
+   */
+  allowedSources?: string[];
 }
 
 /** Read up to `cap` bytes off req.body. Returns null if cap exceeded. */
@@ -184,7 +195,7 @@ export async function startHttpTransport(opts: HttpTransportOptions) {
         .catch(() => { /* fire-and-forget */ });
       // v0.28: extract per-token takes-holder allow-list. Fail-safe default
       // is ['world'] — a token with no permissions row sees public claims only.
-      const perms = (row as { permissions?: { takes_holders?: unknown; source_id?: unknown } }).permissions;
+      const perms = (row as { permissions?: { takes_holders?: unknown; source_id?: unknown; federated_read?: unknown } }).permissions;
       const allowList = Array.isArray(perms?.takes_holders)
         ? (perms!.takes_holders as unknown[]).filter(h => typeof h === 'string') as string[]
         : ['world'];
@@ -197,12 +208,22 @@ export async function startHttpTransport(opts: HttpTransportOptions) {
       const sourceId = typeof perms?.source_id === 'string' && (perms!.source_id as string).length > 0
         ? (perms!.source_id as string)
         : undefined;
+      // v0.32.x (feat/oauth-federated-read): per-token READ scope from
+      // `permissions.federated_read`. When set, the HTTP transport forwards
+      // it as `OperationContext.allowedSources` so engines use
+      // `source_id = ANY($allowedSources)` for filtering. Legacy tokens
+      // without this field retain scalar-sourceId behavior.
+      const fedRead = Array.isArray(perms?.federated_read)
+        ? (perms!.federated_read as unknown[]).filter((s): s is string => typeof s === 'string')
+        : undefined;
+      const allowedSources = fedRead && fedRead.length > 0 ? fedRead : undefined;
       return {
         ok: true,
         tokenId: rowId,
         tokenName: rowName,
         takesHoldersAllowList: allowList,
         sourceId,
+        allowedSources,
       };
     } catch {
       return { ok: false };
@@ -357,6 +378,7 @@ export async function startHttpTransport(opts: HttpTransportOptions) {
           remote: true,
           takesHoldersAllowList: auth.takesHoldersAllowList,
           sourceId: auth.sourceId,
+          allowedSources: auth.allowedSources,
         });
         const status = result.isError ? 'error' : 'success';
         logRequest(auth.tokenName!, `tools/call:${toolName}`, status, Date.now() - startedMs);


### PR DESCRIPTION
## Summary

Replaces the `oauth_clients.source_id NULL = super-reader` pattern with explicit, per-client read scope. Each row now carries both a single **write target** (`source_id NOT NULL`) and a **read scope** (`federated_read TEXT[]`), giving fine-grained federation without the silent super-reader trap.

**Stacked on #861** (read-side source isolation v2). Targets the same base branch.

## Why

The single-column `source_id` shape conflates two concerns:

- `source_id = 'X'` → writes go to X **and** reads are scoped to X
- `source_id IS NULL` → super-reader (reads everything)

Real federation needs the middle ground: write to ONE source, read from N. Today the only way to give a client that shape is `source_id IS NULL`, which also grants unconstrained write privilege and silently survives source deletes (FK was `ON DELETE SET NULL`).

This PR splits write target and read scope into two columns, lets dept-style clients federate cleanly across `own + shared + wecare`, and closes the silent-super-reader-on-source-delete leak.

## Schema changes

Migrations v47–v52, applied across `src/core/migrate.ts`, `src/core/schema-embedded.ts` (fresh postgres installs), and `src/core/pglite-schema.ts` (fresh pglite installs).

| Version | Change |
|---|---|
| v47 | `ALTER TABLE oauth_clients ADD COLUMN federated_read text[]` (nullable) |
| v48 | Backfill `federated_read = ARRAY[source_id]` for non-NULL `source_id` rows; **`RAISE EXCEPTION` if any NULL `source_id` row exists** (refuse to repair silently — operator must fix via audit skill before retry) |
| v49 | `ALTER COLUMN source_id SET NOT NULL` |
| v50 | `ALTER COLUMN federated_read SET NOT NULL` + `CHECK (source_id = ANY(federated_read))` |
| v51 | Drop FK + recreate with `ON DELETE RESTRICT` (was `SET NULL` — closed silent super-reader promotion) |
| v52 | `CREATE INDEX ON oauth_clients USING GIN (federated_read)` (read-scope lookups) |

`AuthInfo` gains `allowedSources?: string[]` populated from `federated_read`. Engines prefer `allowedSources` (ANY()) over scalar `sourceId` (=) when both are present. Write paths remain scoped to scalar `sourceId`.

## Code path wiring

```
oauth_clients.federated_read
    └─> AuthInfo.allowedSources               (src/core/oauth-provider.ts:verifyAccessToken)
          ├─> OAuth path                      (src/commands/serve-http.ts /mcp handler)
          └─> Legacy access_tokens path       (src/mcp/http-transport.ts validateToken)
                └─> DispatchOpts              (src/mcp/dispatch.ts)
                      └─> readScopeOpts       (src/core/operations.ts)
                            └─> sourceFilter  (postgres-engine.ts + pglite-engine.ts)
```

Both transport paths forward the new field. Engine read methods prefer `allowedSources` when present.

## Verification

Verified live with a dept-hr OAuth client (`source_id=dept-hr`, `federated_read={dept-hr,wecare,shared}`) hitting an MCP HTTP server on `:8765`. 8/8 probes pass:

| # | Call | Expected | Result |
|---|---|---|---|
| 1 | `get_page` own (dept-hr) | allow | ✅ |
| 2 | `get_page` own (dept-hr) | allow | ✅ |
| 3 | `get_page` federated (shared/policy/...) | allow | ✅ |
| 4 | `get_page` federated (shared/federated-mind) | allow | ✅ |
| 5 | `get_page` federated (shared/incidents/...) | allow | ✅ |
| 6 | `get_page` cross-source (augustus/wecare/roster) | page_not_found | ✅ |
| 7 | `get_page` cross-source (augustus/resolver) | page_not_found | ✅ |
| 8 | `get_page` cross-source (robin/nonexistent) | page_not_found | ✅ |

Same-slug-across-sources resolves within scope (no cross-source bleed): a slug present in both `dept-hr` and `dept-logistics` correctly returned the `dept-hr` row for the dept-hr token.

## Migration safety

- v48 backfill is idempotent (re-runs no-op on already-backfilled rows).
- v48 explicit `RAISE EXCEPTION` on any pre-migration NULL `source_id` row. The exception message names the audit skill (`gbrain-oauth-client-binding`) so the operator knows where to look. Refusing > silent repair.
- v51 FK swap runs in the same transaction as v50's `NOT NULL` flip — pg won't complain about `SET NULL` on `NOT NULL` mid-migration.
- v52 GIN index uses `IF NOT EXISTS`.

## Mid-PR fix

The second commit (`af5bf48`) fixes a wiring miss caught during the live rollout: `serve-http.ts` OAuth path was setting `sourceId: tokenSourceId` in `dispatchToolCall` opts but dropping `allowedSources`. Result: OAuth-token callers silently fell back to scalar-only filter, ignored `federated_read`, and got `page_not_found` on federated reads they should have allowed.

Class-level lesson: any new `AuthInfo` field has to be wired through **two independent transport call sites** — `serve-http.ts` (OAuth) and `http-transport.ts` (legacy access_tokens). No DRY shortcut exists as of v0.32.0. Documented in the deployer's runbook so the next field doesn't ship half-wired.

## Files changed

- `src/core/migrate.ts` — v47–v52 migrations
- `src/core/schema-embedded.ts` — fresh postgres install schema
- `src/core/pglite-schema.ts` — fresh pglite install schema
- `src/core/types.ts` — `AuthInfo.allowedSources?: string[]`
- `src/core/oauth-provider.ts` — `verifyAccessToken` SELECT + return
- `src/core/operations.ts` — `readScopeOpts` helper threads `allowedSources`
- `src/core/postgres-engine.ts` — `sourceFilter` prefers `allowedSources`
- `src/core/pglite-engine.ts` — same, for pglite
- `src/mcp/dispatch.ts` — `DispatchOpts.allowedSources?: string[]`
- `src/mcp/http-transport.ts` — legacy path forwards from `permissions`
- `src/commands/serve-http.ts` — OAuth path forwards from `authInfo`

## Backward compatibility

- Existing single-source clients keep working (their `federated_read` is backfilled to `ARRAY[source_id]`, behavior unchanged).
- Tokens issued before v48 still verify; `AuthInfo.allowedSources` is populated from the live `oauth_clients` row at verify time (no token re-mint required).
- Engines fall back to scalar `sourceId` filter if `allowedSources` is absent (older engines / dispatch paths from forks not yet on v0.32.x stay functional).

## Notes

- Tests: not adding new test scaffolding here; this codebase doesn't have a test framework set up for the MCP HTTP path. Verified empirically via the probe matrix above. Happy to add fixture-based tests if the project wants them.
- The audit + probe scripts I run on my fleet live in a private skill; the SQL invariants are documented in the migration comments. If the project wants a `gbrain` CLI verb like `gbrain auth audit` that runs the equivalent check, happy to follow up with a separate PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->