### PR TITLE
fix(SUP-1564): align GBrain resolver triggers

### DIFF
--- a/skills/RESOLVER.md
+++ b/skills/RESOLVER.md
@@ -28,7 +28,7 @@ This is the dispatcher. Skills are the implementation. **Read the skill file bef
 | Trigger | Skill |
 |---------|-------|
 | User shares a link, article, tweet, or idea | `skills/idea-ingest/SKILL.md` |
-| Video, audio, PDF, book, YouTube, screenshot | `skills/media-ingest/SKILL.md` |
+| "watch this video", "process this YouTube link", "ingest this PDF", "save this podcast", "process this book", "summarize this book", "what's in this screenshot", "check out this repo" | `skills/media-ingest/SKILL.md` |
 | Meeting transcript received | `skills/meeting-ingestion/SKILL.md` |
 | Generic "ingest this" (auto-routes to above) | `skills/ingest/SKILL.md` |
 
@@ -109,20 +109,20 @@ These apply to ALL brain-writing skills:
 
 | Trigger | Skill |
 |---------|-------|
-| "personalized version of this book" | `skills/book-mirror/SKILL.md` |
+| "personalized version of this book", "mirror this book", "two-column book analysis", "apply this book to my life", "how does this book apply to me" | `skills/book-mirror/SKILL.md` |
 
-| "enrich this article" | `skills/article-enrichment/SKILL.md` |
+| "enrich this article", "enrich brain pages", "batch enrich", "make brain pages useful" | `skills/article-enrichment/SKILL.md` |
 
-| "strategic reading" | `skills/strategic-reading/SKILL.md` |
+| "strategic reading", "read this through the lens of", "apply this to my problem", "what can I learn from this about", "extract a playbook from" | `skills/strategic-reading/SKILL.md` |
 
-| "concept synthesis" | `skills/concept-synthesis/SKILL.md` |
+| "concept synthesis", "synthesize my concepts", "find patterns across my notes", "build my intellectual map", "trace idea evolution" | `skills/concept-synthesis/SKILL.md` |
 
-| "perplexity research" | `skills/perplexity-research/SKILL.md` |
+| "perplexity research", "what's new about", "current state of", "web research", "what changed about" | `skills/perplexity-research/SKILL.md` |
 
-| "crawl my archive" | `skills/archive-crawler/SKILL.md` |
+| "crawl my archive", "find gold in my archive", "archive crawler", "scan my dropbox for", "mine my old files for" | `skills/archive-crawler/SKILL.md` |
 
-| "verify this academic claim" | `skills/academic-verify/SKILL.md` |
+| "verify this academic claim", "check this study", "academic verify", "validate citation", "is this study real" | `skills/academic-verify/SKILL.md` |
 
-| "make pdf from brain" | `skills/brain-pdf/SKILL.md` |
+| "make pdf from brain", "brain pdf", "convert brain page to pdf", "publish this page as pdf", "export brain page" | `skills/brain-pdf/SKILL.md` |
 
-| "voice note" | `skills/voice-note-ingest/SKILL.md` |
+| "voice note", "ingest this voice memo", "transcribe and file", "voice note ingest", "save this audio note" | `skills/voice-note-ingest/SKILL.md` |

--- a/skills/media-ingest/SKILL.md
+++ b/skills/media-ingest/SKILL.md
@@ -11,6 +11,7 @@ triggers:
   - "ingest this PDF"
   - "save this podcast"
   - "process this book"
+  - "summarize this book"
   - "what's in this screenshot"
   - "check out this repo"
 tools:

--- a/skills/perplexity-research/routing-eval.jsonl
+++ b/skills/perplexity-research/routing-eval.jsonl
@@ -3,5 +3,5 @@
 {"intent":"Run perplexity-research on Brex and surface NEW developments","expected_skill":"perplexity-research","ambiguous_with":["data-research"]}
 {"intent":"What's new about this company that the brain doesn't already cover","expected_skill":"perplexity-research"}
 {"intent":"Tell me the current state of the YC W26 batch announcements","expected_skill":"perplexity-research"}
-{"intent":"Do a web research pass on this person — focus on the delta","expected_skill":"perplexity-research"}
+{"intent":"Do a web research pass on this person — focus on the delta","expected_skill":"perplexity-research","ambiguous_with":["data-research"]}
 {"intent":"What changed about this funding round since I last looked","expected_skill":"perplexity-research"}


### PR DESCRIPTION
## Summary
- align RESOLVER.md quoted trigger phrases with existing skill routing fixtures/frontmatter
- add the missing media-ingest trigger for book-summary requests
- mark one web-research fixture as intentionally ambiguous with data-research

## Verification
- bun run src/cli.ts routing-eval --json: ok, 58/58 passed, 0 missed, 0 ambiguous, 0 false positives, 0 lint issues, 0 malformed fixtures
- bun run src/cli.ts doctor --fast --json: health_score 95; resolver health ok; skill conformance 39/39; only expected --fast DB-skip warning
- bun test test/routing-eval.test.ts test/resolver.test.ts test/check-resolvable.test.ts: 140 pass, 0 fail
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->