### PR TITLE
fix(extract): resolve fs wikilinks against synced slugs

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -17,7 +17,7 @@
  */
 
 import { readFileSync, readdirSync, lstatSync, existsSync } from 'fs';
-import { join, relative, dirname } from 'path';
+import { join, relative, dirname, basename } from 'path';
 import type { BrainEngine, LinkBatchInput, TimelineBatchInput } from '../core/engine.ts';
 import type { PageType } from '../core/types.ts';
 import { parseMarkdown } from '../core/markdown.ts';
@@ -53,6 +53,8 @@ export interface ExtractedTimelineEntry {
   summary: string;
   detail?: string;
 }
+
+export type FsSlugResolverIndex = Map<string, Set<string>>;
 
 interface ExtractResult {
   links_created: number;
@@ -121,6 +123,41 @@ export function extractMarkdownLinks(content: string): { name: string; relTarget
   return results;
 }
 
+function normalizeResolverKey(value: string): string {
+  const trimmed = value.trim().replace(/^['"]|['"]$/g, '').replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+  if (!trimmed) return '';
+  const noMd = trimmed.replace(/\.mdx?$/i, '');
+  return pathToSlug(`${noMd}.md`);
+}
+
+function addResolverKey(index: FsSlugResolverIndex, key: string, slug: string): void {
+  const normalized = normalizeResolverKey(key);
+  if (!normalized) return;
+  if (!index.has(normalized)) index.set(normalized, new Set());
+  index.get(normalized)!.add(slug);
+}
+
+function frontmatterStringList(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string');
+  return [];
+}
+
+function uniqueResolved(index: FsSlugResolverIndex | undefined, key: string): string | null {
+  const candidates = index?.get(key);
+  if (!candidates || candidates.size !== 1) return null;
+  return Array.from(candidates)[0];
+}
+
+function isNonPageRelTarget(relTarget: string): boolean {
+  const target = relTarget.replace(/\\/g, '/').replace(/\.mdx?$/i, '');
+  return /\.(base|css|png|jpe?g|gif|webp|pdf|svg|wav|mp3|m4a|mp4|mov)$/i.test(relTarget)
+    || target === '...'
+    || target === 'wikilinks'
+    || target === 'AGENTS'
+    || target.startsWith('system/');
+}
+
 /**
  * Resolve a wikilink target to a canonical slug, given the directory of the
  * containing page and the set of all known slugs in the brain.
@@ -133,18 +170,29 @@ export function extractMarkdownLinks(content: string): { name: string; relTarget
  *
  * Returns null when no matching slug is found (dangling link).
  */
-export function resolveSlug(fileDir: string, relTarget: string, allSlugs: Set<string>): string | null {
+export function resolveSlug(
+  fileDir: string,
+  relTarget: string,
+  allSlugs: Set<string>,
+  slugIndex?: FsSlugResolverIndex,
+): string | null {
+  if (isNonPageRelTarget(relTarget)) return null;
   const targetNoExt = relTarget.endsWith('.md') ? relTarget.slice(0, -3) : relTarget;
 
-  const s1 = join(fileDir, targetNoExt);
+  const s1 = pathToSlug(join(fileDir, `${targetNoExt}.md`));
   if (allSlugs.has(s1)) return s1;
 
   const parts = fileDir.split('/').filter(Boolean);
   for (let strip = 1; strip <= parts.length; strip++) {
     const ancestor = parts.slice(0, parts.length - strip).join('/');
-    const candidate = ancestor ? join(ancestor, targetNoExt) : targetNoExt;
+    const candidate = pathToSlug(`${ancestor ? join(ancestor, targetNoExt) : targetNoExt}.md`);
     if (allSlugs.has(candidate)) return candidate;
   }
+
+  const rootKey = normalizeResolverKey(relTarget);
+  if (allSlugs.has(rootKey)) return rootKey;
+  const viaIndex = uniqueResolved(slugIndex, rootKey) || uniqueResolved(slugIndex, basename(rootKey));
+  if (viaIndex) return viaIndex;
 
   return null;
 }
@@ -184,6 +232,21 @@ function parseFrontmatterFromContent(content: string, relPath: string): Record<s
   }
 }
 
+export function buildFsSlugResolverIndex(files: { path: string; relPath: string }[]): FsSlugResolverIndex {
+  const index: FsSlugResolverIndex = new Map();
+  for (const file of files) {
+    const slug = pathToSlug(file.relPath);
+    addResolverKey(index, slug, slug);
+    addResolverKey(index, basename(slug), slug);
+    try {
+      const fm = parseFrontmatterFromContent(readFileSync(file.path, 'utf-8'), file.relPath);
+      for (const title of frontmatterStringList(fm.title)) addResolverKey(index, title, slug);
+      for (const alias of frontmatterStringList(fm.aliases)) addResolverKey(index, alias, slug);
+    } catch { /* skip unreadable */ }
+  }
+  return index;
+}
+
 /**
  * Full link extraction from a single markdown file (FS-source path).
  *
@@ -195,7 +258,7 @@ function parseFrontmatterFromContent(content: string, relPath: string): Record<s
  */
 export async function extractLinksFromFile(
   content: string, relPath: string, allSlugs: Set<string>,
-  opts?: { includeFrontmatter?: boolean },
+  opts?: { includeFrontmatter?: boolean; slugIndex?: FsSlugResolverIndex },
 ): Promise<ExtractedLink[]> {
   const links: ExtractedLink[] = [];
   const slug = pathToSlug(relPath);
@@ -203,7 +266,7 @@ export async function extractLinksFromFile(
   const fm = parseFrontmatterFromContent(content, relPath);
 
   for (const { name, relTarget } of extractMarkdownLinks(content)) {
-    const resolved = resolveSlug(fileDir, relTarget, allSlugs);
+    const resolved = resolveSlug(fileDir, relTarget, allSlugs, opts?.slugIndex);
     if (resolved !== null) {
       links.push({
         from_slug: slug, to_slug: resolved,
@@ -581,6 +644,7 @@ async function extractLinksFromDir(
 ): Promise<{ created: number; pages: number }> {
   const files = walkMarkdownFiles(brainDir);
   const allSlugs = new Set(files.map(f => pathToSlug(f.relPath)));
+  const slugIndex = buildFsSlugResolverIndex(files);
 
   // Progress stream on stderr (separate from the action-events --json writes
   // to stdout, which tests grep for). Rate-gated; respects global --quiet /
@@ -613,7 +677,7 @@ async function extractLinksFromDir(
   for (let i = 0; i < files.length; i++) {
     try {
       const content = readFileSync(files[i].path, 'utf-8');
-      const links = await extractLinksFromFile(content, files[i].relPath, allSlugs);
+      const links = await extractLinksFromFile(content, files[i].relPath, allSlugs, { slugIndex });
       for (const link of links) {
         if (dryRunSeen) {
           const key = `${link.from_slug}::${link.to_slug}::${link.link_type}`;
@@ -707,6 +771,7 @@ export async function extractLinksForSlugs(
 ): Promise<number> {
   const allFiles = walkMarkdownFiles(repoPath);
   const allSlugs = new Set(allFiles.map(f => pathToSlug(f.relPath)));
+  const slugIndex = buildFsSlugResolverIndex(allFiles);
   // v0.18.0+ multi-source: post-sync extract reconciles same-source edges.
   // Markdown→markdown links within one repo always live in the caller's
   // sourceId. Cross-source extraction (rare) would need a per-repo source
@@ -720,7 +785,7 @@ export async function extractLinksForSlugs(
     if (!existsSync(filePath)) continue;
     try {
       const content = readFileSync(filePath, 'utf-8');
-      for (const link of await extractLinksFromFile(content, slug + '.md', allSlugs)) {
+      for (const link of await extractLinksFromFile(content, slug + '.md', allSlugs, { slugIndex })) {
         try { await engine.addLink(link.from_slug, link.to_slug, link.context, link.link_type, undefined, undefined, undefined, linkOpts); created++; } catch { /* skip */ }
       }
     } catch { /* skip */ }

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -4,6 +4,8 @@ import {
   extractLinksFromFile,
   extractTimelineFromContent,
   walkMarkdownFiles,
+  buildFsSlugResolverIndex,
+  resolveSlug,
 } from '../src/commands/extract.ts';
 
 describe('extractMarkdownLinks', () => {
@@ -97,6 +99,66 @@ describe('extractLinksFromFile', () => {
     const allSlugs = new Set(['deals/seed', 'companies/brex']);
     const links = await extractLinksFromFile(content, 'deals/seed.md', allSlugs);
     expect(links[0].link_type).toBe('deal_for');
+  });
+});
+
+describe('extractLinksFromFile — slug/title/alias wikilink resolution', () => {
+  it('resolves root-relative Obsidian wikilinks against synced slugified page slugs', async () => {
+    const content = 'See [[resources/templates/README|templates]].';
+    const allSlugs = new Set(['notes/meta/index', 'resources/templates/readme']);
+    const links = await extractLinksFromFile(content, 'notes/meta/index.md', allSlugs);
+    expect(links).toHaveLength(1);
+    expect(links[0].from_slug).toBe('notes/meta/index');
+    expect(links[0].to_slug).toBe('resources/templates/readme');
+  });
+
+  it('resolves title-only wikilinks through a slug resolver index', async () => {
+    const content = 'See [[Agentic AI Operations]].';
+    const allSlugs = new Set(['notes/meta/index', 'notes/meta/domains/agentic-ai-operations']);
+    const slugIndex = new Map<string, Set<string>>([
+      ['agentic-ai-operations', new Set(['notes/meta/domains/agentic-ai-operations'])],
+    ]);
+    const links = await extractLinksFromFile(content, 'notes/meta/index.md', allSlugs, { slugIndex });
+    expect(links).toHaveLength(1);
+    expect(links[0].to_slug).toBe('notes/meta/domains/agentic-ai-operations');
+  });
+
+  it('resolves aliases indexed from frontmatter', async () => {
+    const content = 'Related: [[Two Training Station]].';
+    const allSlugs = new Set(['journals/2026-05-11', 'notes/house-2-training-station-road']);
+    const slugIndex = new Map<string, Set<string>>([
+      ['two-training-station', new Set(['notes/house-2-training-station-road'])],
+    ]);
+    const links = await extractLinksFromFile(content, 'journals/2026-05-11.md', allSlugs, { slugIndex });
+    expect(links).toHaveLength(1);
+    expect(links[0].to_slug).toBe('notes/house-2-training-station-road');
+  });
+
+  it('does not guess when basename/title resolution is ambiguous', () => {
+    const allSlugs = new Set(['resources/research/readme', 'resources/templates/readme']);
+    const slugIndex = new Map<string, Set<string>>([
+      ['readme', new Set(['resources/research/readme', 'resources/templates/readme'])],
+    ]);
+    expect(resolveSlug('notes/meta', 'README.md', allSlugs, slugIndex)).toBeNull();
+  });
+
+  it('skips excluded system wikilink targets', async () => {
+    const content = 'See [[system/templates/Daily Journal Template]].';
+    const allSlugs = new Set(['journals/2026-05-11', 'system/templates/daily-journal-template']);
+    const links = await extractLinksFromFile(content, 'journals/2026-05-11.md', allSlugs);
+    expect(links).toHaveLength(0);
+  });
+
+  it('builds a resolver index from titles and aliases', async () => {
+    const tmp = await import('node:fs/promises');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const dir = await tmp.mkdtemp(path.join(os.tmpdir(), 'gbrain-extract-'));
+    const file = path.join(dir, 'notes', 'House - 2 Training Station Road.md');
+    await tmp.mkdir(path.dirname(file), { recursive: true });
+    await tmp.writeFile(file, '---\ntitle: House - 2 Training Station Road\naliases: [Two Training Station]\n---\nBody');
+    const slugIndex = buildFsSlugResolverIndex([{ path: file, relPath: 'notes/House - 2 Training Station Road.md' }]);
+    expect(resolveSlug('journals', 'Two Training Station.md', new Set(), slugIndex)).toBe('notes/house-2-training-station-road');
   });
 });
 


### PR DESCRIPTION
## Summary
- Resolves fs-discovered Obsidian wikilinks against canonical synced slugs, not only raw relative paths.
- Adds a per-run slug/title/alias resolver index for FS extraction.
- Skips non-page/system/media targets and avoids guessing on ambiguous basename/title matches.

## Why
Fixes #874.

Large Obsidian vaults often write links as `[[resources/templates/README]]`, title-only links, or aliases while `gbrain sync` stores page slugs as normalized lowercase paths like `resources/templates/readme`. Native fs extraction could discover the wikilinks but fail to insert graph edges because resolution did not use the synced slug/title/alias namespace.

## Test Plan
- `bun test test/extract.test.ts`

## Notes
- This PR keeps ambiguous basename/title matches unresolved instead of choosing arbitrarily.
- Direct markdown relative-path behavior remains covered by existing tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->