### PR TITLE
fix: redact config secrets and support source-id sync

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1338,7 +1338,7 @@ SOURCES (multi-repo / multi-brain)
   sources add <id> --path <p>        Register a source (id = short name, e.g. 'wiki')
   sources remove <id>                Remove a source + its pages
   sync --all                         Sync all sources with a local_path
-  sync --source <id>                 Sync one specific source
+  sync --source <id>                 Sync one specific source (--source-id alias supported)
   repos ...                          DEPRECATED alias for 'sources' (v0.19.0)
 
 CODE INDEXING (v0.19.0 / v0.20.0 Cathedral II)

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,12 +1,25 @@
 import type { BrainEngine } from '../core/engine.ts';
 import { loadConfig } from '../core/config.ts';
 
-function redactUrl(url: string): string {
+export function redactUrl(url: string): string {
   // Redact password in postgresql:// URLs
   return url.replace(
     /(postgresql:\/\/[^:]+:)([^@]+)(@)/,
     '$1***$3',
   );
+}
+
+export function isSensitiveConfigKey(key: string): boolean {
+  const normalized = key.toLowerCase();
+  return /(^|[_.-])(api[_-]?key|token|secret|password|passwd|pwd|pat)([_.-]|$)/.test(normalized)
+    || normalized.includes('password')
+    || normalized.endsWith('_key')
+    || normalized.endsWith('.key');
+}
+
+export function redactConfigValue(key: string, value: string): string {
+  if (value.includes('postgresql://')) return redactUrl(value);
+  return isSensitiveConfigKey(key) ? '<REDACTED>' : value;
 }
 
 export async function runConfig(engine: BrainEngine, args: string[]) {
@@ -42,7 +55,7 @@ export async function runConfig(engine: BrainEngine, args: string[]) {
     }
   } else if (action === 'set' && key && value) {
     await engine.setConfig(key, value);
-    console.log(`Set ${key} = ${value}`);
+    console.log(`Set ${key} = ${redactConfigValue(key, value)}`);
   } else {
     console.error('Usage: gbrain config [show|get|set] <key> [value]');
     process.exit(1);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -106,6 +106,17 @@ function estimateSyncAllCost(sources: Array<{ local_path: string | null; config:
   return { totalTokens, totalFiles, activeSources, perSource };
 }
 
+export function getFlagValue(args: string[], names: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    for (const name of names) {
+      if (arg === name) return args[i + 1]?.startsWith('--') ? undefined : args[i + 1];
+      if (arg.startsWith(`${name}=`)) return arg.slice(name.length + 1);
+    }
+  }
+  return undefined;
+}
+
 /** Interactive [y/N] prompt. Resolves false on non-y answers or EOF. */
 async function promptYesNo(question: string): Promise<boolean> {
   return new Promise((resolve) => {
@@ -1032,9 +1043,9 @@ async function performFullSync(
 }
 
 export async function runSync(engine: BrainEngine, args: string[]) {
-  const repoPath = args.find((a, i) => args[i - 1] === '--repo') || undefined;
+  const repoPath = getFlagValue(args, ['--repo']);
   const watch = args.includes('--watch');
-  const intervalStr = args.find((a, i) => args[i - 1] === '--interval');
+  const intervalStr = getFlagValue(args, ['--interval']);
   const interval = intervalStr ? parseInt(intervalStr, 10) : 60;
   const dryRun = args.includes('--dry-run');
   const full = args.includes('--full');
@@ -1045,8 +1056,8 @@ export async function runSync(engine: BrainEngine, args: string[]) {
   const syncAll = args.includes('--all');
   const jsonOut = args.includes('--json');
   const yesFlag = args.includes('--yes');
-  const strategyArg = args.find((a, i) => args[i - 1] === '--strategy') as SyncOpts['strategy'] | undefined;
-  const concurrencyStr = args.find((a, i) => args[i - 1] === '--concurrency' || args[i - 1] === '--workers');
+  const strategyArg = getFlagValue(args, ['--strategy']) as SyncOpts['strategy'] | undefined;
+  const concurrencyStr = getFlagValue(args, ['--concurrency', '--workers']);
   // v0.22.13 (PR #490 Q2): parseWorkers throws on '0', '-3', 'foo', '1.5' instead
   // of silently falling through to auto-concurrency or NaN. Loud failure beats
   // a 4-worker spawn from a typo.
@@ -1077,7 +1088,7 @@ export async function runSync(engine: BrainEngine, args: string[]) {
   // v0.18.0 Step 5: --source resolves to a sources(id) row. Falls back
   // to pre-v0.17 global config (sync.repo_path + sync.last_commit) when
   // no flag, no env, no dotfile is present.
-  const explicitSource = args.find((a, i) => args[i - 1] === '--source') || null;
+  const explicitSource = getFlagValue(args, ['--source', '--source-id']) || null;
   let sourceId: string | undefined = undefined;
   if (explicitSource || process.env.GBRAIN_SOURCE) {
     const { resolveSourceId } = await import('../core/source-resolver.ts');

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect } from 'bun:test';
 import { readFileSync } from 'fs';
+import { isSensitiveConfigKey, redactConfigValue } from '../src/commands/config.ts';
 
-// redactUrl is not exported, so we test it by reading the source and
-// reimplementing the regex to verify the pattern, then test via CLI
+// Keep a local regex check for backwards-compatible URL redaction behavior.
 
 // Extract the redactUrl regex pattern from source
 const configSource = readFileSync(
@@ -49,6 +49,25 @@ describe('redactUrl', () => {
 
   test('handles empty string', () => {
     expect(redactUrl('')).toBe('');
+  });
+});
+
+describe('config set output redaction', () => {
+  test('redacts API keys, tokens, secrets, PATs, and passwords', () => {
+    for (const key of ['openai_api_key', 'github.token', 'client-secret', 'db_password', 'github_pat']) {
+      expect(isSensitiveConfigKey(key)).toBe(true);
+      expect(redactConfigValue(key, 'sk-test-1234567890abcdef')).toBe('<REDACTED>');
+    }
+  });
+
+  test('leaves non-sensitive values visible', () => {
+    expect(isSensitiveConfigKey('sync.repo_path')).toBe(false);
+    expect(redactConfigValue('sync.repo_path', '/tmp/repo')).toBe('/tmp/repo');
+  });
+
+  test('redacts postgresql passwords even for non-sensitive key names', () => {
+    expect(redactConfigValue('database_url', 'postgresql://user:pass@host/db'))
+      .toBe('postgresql://user:***@host/db');
   });
 });
 

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -1,11 +1,25 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
 import { buildSyncManifest, isSyncable, pathToSlug } from '../src/core/sync.ts';
+import { getFlagValue } from '../src/commands/sync.ts';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+describe('sync CLI flag parsing', () => {
+  test('supports --source and --source-id aliases', () => {
+    expect(getFlagValue(['--source', 'named-src'], ['--source', '--source-id'])).toBe('named-src');
+    expect(getFlagValue(['--source-id', 'named-src'], ['--source', '--source-id'])).toBe('named-src');
+    expect(getFlagValue(['--source-id=named-src'], ['--source', '--source-id'])).toBe('named-src');
+  });
+
+  test('supports equals form for common sync flags', () => {
+    expect(getFlagValue(['--repo=/tmp/repo'], ['--repo'])).toBe('/tmp/repo');
+    expect(getFlagValue(['--workers=3'], ['--concurrency', '--workers'])).toBe('3');
+  });
+});
 
 describe('buildSyncManifest', () => {
   test('parses A/M/D entries from single commit', () => {


### PR DESCRIPTION
Fixes two v0.32 bugs:\n\n- Redacts sensitive values in `gbrain config set` confirmation output (API keys/tokens/secrets/passwords/PATs).\n- Supports `gbrain sync --source-id <id>` as an alias for `--source <id>`, including equals form, so named-source sync routes pages to the intended source.\n\nValidation:\n- `bun test test/config.test.ts test/sync.test.ts`\n- `bun run typecheck`\n\nRefs #892, #891

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->