### PR TITLE
feat(auth): add --redirect-uri + --token-endpoint-auth-method to register-client

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -329,26 +329,53 @@ async function revokeClient(clientId: string) {
 }
 
 async function registerClient(name: string, args: string[]) {
-  if (!name) { console.error('Usage: auth register-client <name> [--grant-types G] [--scopes S]'); process.exit(1); }
+  if (!name) {
+    console.error(
+      'Usage: auth register-client <name> [--grant-types G] [--scopes S] '
+      + '[--redirect-uri URI ...] [--token-endpoint-auth-method client_secret_post|none]',
+    );
+    process.exit(1);
+  }
   const grantsIdx = args.indexOf('--grant-types');
   const scopesIdx = args.indexOf('--scopes');
+  const authMethodIdx = args.indexOf('--token-endpoint-auth-method');
   const grantTypes = grantsIdx >= 0 && args[grantsIdx + 1]
     ? args[grantsIdx + 1].split(',').map(s => s.trim()).filter(Boolean)
     : ['client_credentials'];
   const scopes = scopesIdx >= 0 && args[scopesIdx + 1] ? args[scopesIdx + 1] : 'read';
+
+  // --redirect-uri is repeatable: collect every occurrence's value. Required
+  // for authorization_code clients (Claude.ai, ChatGPT, etc.) — registering
+  // without one yields "invalid_request: Unregistered redirect_uri" at the
+  // /authorize step, forcing operators to UPDATE oauth_clients by hand.
+  const redirectUris: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--redirect-uri' && args[i + 1]) {
+      redirectUris.push(args[i + 1]);
+      i++;
+    }
+  }
+
+  const tokenEndpointAuthMethod = authMethodIdx >= 0 && args[authMethodIdx + 1]
+    ? args[authMethodIdx + 1]
+    : undefined;
 
   try {
     await withConfiguredSql(async (sql) => {
       const { GBrainOAuthProvider } = await import('../core/oauth-provider.ts');
       const provider = new GBrainOAuthProvider({ sql });
       const { clientId, clientSecret } = await provider.registerClientManual(
-        name, grantTypes, scopes, [],
+        name, grantTypes, scopes, redirectUris, tokenEndpointAuthMethod,
       );
       console.log(`OAuth client registered: "${name}"\n`);
       console.log(`  Client ID:     ${clientId}`);
       console.log(`  Client Secret: ${clientSecret}\n`);
       console.log(`  Grant types: ${grantTypes.join(', ')}`);
-      console.log(`  Scopes:      ${scopes}\n`);
+      console.log(`  Scopes:      ${scopes}`);
+      if (redirectUris.length > 0) {
+        console.log(`  Redirect URIs: ${redirectUris.join(', ')}`);
+      }
+      console.log(`  Token endpoint auth: ${tokenEndpointAuthMethod || 'client_secret_post'}\n`);
       console.log('Save the client secret — it will not be shown again.');
       console.log(`Revoke with: gbrain auth revoke-client "${clientId}"`);
     });
@@ -408,6 +435,12 @@ Usage:
   gbrain auth register-client <name> [options]             Register an OAuth 2.1 client (v0.26+)
      --grant-types <client_credentials,authorization_code> (default: client_credentials)
      --scopes "<read write admin>"                         (default: read)
+     --redirect-uri <uri>                                  (repeatable; required for
+                                                            authorization_code clients
+                                                            — Claude.ai, ChatGPT, etc.)
+     --token-endpoint-auth-method <method>                 (client_secret_post | none;
+                                                            default: client_secret_post.
+                                                            ChatGPT connectors use `none`.)
   gbrain auth revoke-client <client_id>                   Hard-delete an OAuth 2.1 client (cascades to tokens + codes)
   gbrain auth test <url> --token <token>                  Smoke-test a remote MCP server
 `);

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -28,6 +28,21 @@ import type { SqlQuery, SqlValue } from './sql-query.ts';
 export type { SqlQuery, SqlValue };
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Allowed values for `oauth_clients.token_endpoint_auth_method`. Mirrors the
+ * MCP SDK's mcpAuthRouter metadata default (`token_endpoint_auth_methods_supported`
+ * = `["client_secret_post", "none"]`). Adjust here if the SDK upgrade ever
+ * advertises additional methods (e.g. `client_secret_basic`).
+ */
+export const ALLOWED_TOKEN_ENDPOINT_AUTH_METHODS: ReadonlySet<string> = new Set<string>([
+  'client_secret_post',
+  'none',
+]);
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -570,12 +585,24 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     grantTypes: string[],
     scopes: string,
     redirectUris: string[] = [],
+    tokenEndpointAuthMethod?: string,
   ): Promise<{ clientId: string; clientSecret: string }> {
     // v0.28: ALLOWED_SCOPES allowlist. Reject `--scopes "read flying-unicorn"`
     // at registration so meaningless scope strings can't pile up in the DB.
     // Pre-allowlist clients keep working (allowlist is registration-time;
     // existing rows aren't re-validated).
     assertAllowedScopes(parseScopeString(scopes));
+
+    // Validate token_endpoint_auth_method against what /.well-known advertises.
+    // Keeps the set in sync with token_endpoint_auth_methods_supported in
+    // serve-http.ts so clients can't register a method the server won't honor.
+    if (tokenEndpointAuthMethod !== undefined
+        && !ALLOWED_TOKEN_ENDPOINT_AUTH_METHODS.has(tokenEndpointAuthMethod)) {
+      throw new Error(
+        `Invalid token_endpoint_auth_method "${tokenEndpointAuthMethod}". `
+        + `Allowed: ${[...ALLOWED_TOKEN_ENDPOINT_AUTH_METHODS].join(', ')}.`,
+      );
+    }
 
     const clientId = generateToken('gbrain_cl_');
     const clientSecret = generateToken('gbrain_cs_');
@@ -584,9 +611,11 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
 
     await this.sql`
       INSERT INTO oauth_clients (client_id, client_secret_hash, client_name, redirect_uris,
-                                  grant_types, scope, client_id_issued_at)
+                                  grant_types, scope, token_endpoint_auth_method,
+                                  client_id_issued_at)
       VALUES (${clientId}, ${secretHash}, ${name},
-              ${pgArray(redirectUris)}, ${pgArray(grantTypes)}, ${scopes}, ${now})
+              ${pgArray(redirectUris)}, ${pgArray(grantTypes)}, ${scopes},
+              ${tokenEndpointAuthMethod || 'client_secret_post'}, ${now})
     `;
 
     return { clientId, clientSecret };

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -131,6 +131,46 @@ describe('client registration', () => {
       sql`INSERT INTO oauth_clients (client_id, client_name, scope) VALUES (${clientId}, ${'dup'}, ${'read'})`,
     ).rejects.toThrow();
   });
+
+  test('redirectUris persist (authorization_code clients need this)', async () => {
+    // Pre-flag default was [], which meant Claude.ai / ChatGPT failed at /authorize
+    // with "Unregistered redirect_uri" and forced an UPDATE oauth_clients by hand.
+    const uris = [
+      'https://claude.ai/api/mcp/auth_callback',
+      'https://claude.com/api/mcp/auth_callback',
+    ];
+    const { clientId } = await provider.registerClientManual(
+      'redirect-test', ['authorization_code', 'refresh_token'], 'read write', uris,
+    );
+    const client = await provider.clientsStore.getClient(clientId);
+    expect(client!.redirect_uris).toEqual(uris);
+  });
+
+  test('tokenEndpointAuthMethod="none" persists (PKCE-only clients)', async () => {
+    // ChatGPT custom connectors set this to `none` and never send a client_secret.
+    const { clientId } = await provider.registerClientManual(
+      'pkce-only', ['authorization_code', 'refresh_token'], 'read',
+      ['https://chatgpt.com/connector/oauth/test'], 'none',
+    );
+    const client = await provider.clientsStore.getClient(clientId);
+    expect(client!.token_endpoint_auth_method).toBe('none');
+  });
+
+  test('tokenEndpointAuthMethod defaults to "client_secret_post"', async () => {
+    const { clientId } = await provider.registerClientManual(
+      'default-auth-method', ['client_credentials'], 'read',
+    );
+    const client = await provider.clientsStore.getClient(clientId);
+    expect(client!.token_endpoint_auth_method).toBe('client_secret_post');
+  });
+
+  test('unsupported tokenEndpointAuthMethod is rejected', async () => {
+    await expect(
+      provider.registerClientManual(
+        'bad-auth', ['client_credentials'], 'read', [], 'private_key_jwt',
+      ),
+    ).rejects.toThrow(/Invalid token_endpoint_auth_method/);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`gbrain auth register-client` previously hard-coded `redirect_uris = []` and `token_endpoint_auth_method = NULL`, which made the CLI unusable for the case `SECURITY.md` itself recommends it for — pre-registering Claude.ai / ChatGPT custom connectors so operators can run with `--enable-dcr` off.

New flags:

- `--redirect-uri <uri>` (repeatable; required for `authorization_code` clients)
- `--token-endpoint-auth-method <method>` (`client_secret_post` | `none`; ChatGPT custom connectors use `none`)

Auth-method values are validated against a new `ALLOWED_TOKEN_ENDPOINT_AUTH_METHODS` set that mirrors what the MCP SDK's `mcpAuthRouter` advertises in `token_endpoint_auth_methods_supported`. Unknown values fail loud at registration.

## The failure mode this fixes

Before this PR, the SECURITY.md-recommended hardening path falls apart at step 2:

1. Operator drops `--enable-dcr`, runs `gbrain auth register-client claude-ai --grant-types authorization_code,refresh_token --scopes "read write"`.
2. Pastes the client_id/secret into Claude.ai → `/authorize` returns `{\"error\":\"invalid_request\",\"error_description\":\"Unregistered redirect_uri\"}`.
3. Operator UPDATEs `oauth_clients` by hand to add the callback URLs, and again for `token_endpoint_auth_method = 'none'` to make ChatGPT's PKCE-only flow work.

## Worked example after this PR

\`\`\`bash
gbrain auth register-client claude-ai \\
  --grant-types authorization_code,refresh_token \\
  --scopes \"read write\" \\
  --redirect-uri https://claude.ai/api/mcp/auth_callback \\
  --redirect-uri https://claude.com/api/mcp/auth_callback

gbrain auth register-client chatgpt \\
  --grant-types authorization_code,refresh_token \\
  --scopes \"read write\" \\
  --redirect-uri https://chatgpt.com/connector/oauth/<HASH> \\
  --token-endpoint-auth-method none
\`\`\`

## Test plan

- [x] \`bun test test/oauth.test.ts\` — 68 pass (4 new: redirect_uris persistence, \`none\` persistence, default \`client_secret_post\` fallback, unsupported-method rejection)
- [x] Tested live against \`https://brain.pdzeng.com\` (DCR disabled) with both Claude.ai and ChatGPT custom-connector flows — both reach \`/authorize\`, complete consent, and get \`read,write\` tokens.

## Notes

- No DB schema change. \`oauth_clients.token_endpoint_auth_method TEXT\` already exists; the INSERT now sets it instead of leaving it NULL.
- Backward compatible: omitting both new flags reproduces today's behavior, except \`token_endpoint_auth_method\` defaults to \`'client_secret_post'\` explicitly instead of NULL — matching the DCR path (\`oauth-provider.ts\` line ~184).
- The CLI usage block + the typed signature on \`registerClientManual\` both expose the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->