### PR TITLE
Add plugin job handler loading

### DIFF
--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -183,6 +183,9 @@ HANDLER TYPES (built in)
   shell             Run a command or argv. Requires GBRAIN_ALLOW_SHELL_JOBS=1
                     on the worker. Params: {cmd?, argv?, cwd, env?}.
                     See: docs/guides/minions-shell-jobs.md
+  plugin handlers   Optional local job handlers loaded from GBRAIN_PLUGIN_PATH.
+                    Plugins must be absolute local directories with
+                    gbrain.plugin.json and job_handlers modules.
 `);
     return;
   }
@@ -899,7 +902,7 @@ HANDLER TYPES (built in)
       if (detach) {
         const { spawn } = await import('child_process');
         const childArgs = process.argv.slice(2).filter(a => a !== '--detach');
-        const child = spawn(process.execPath, [process.argv[1], ...childArgs], {
+        const child = spawn(cliPath, childArgs, {
           detached: true,
           stdio: ['ignore', 'ignore', 'inherit'],
           env: process.env,
@@ -1129,7 +1132,7 @@ export async function registerBuiltinHandlers(worker: MinionWorker, engine: Brai
   // openclaw-seam startup line convention from v0.11+). Loaded
   // unconditionally; empty GBRAIN_PLUGIN_PATH is a no-op.
   try {
-    const { loadPluginsFromEnv } = await import('../core/minions/plugin-loader.ts');
+    const { loadPluginsFromEnv, registerPluginJobHandlersFromEnv } = await import('../core/minions/plugin-loader.ts');
     const { BRAIN_TOOL_ALLOWLIST } = await import('../core/minions/tools/brain-allowlist.ts');
     const validNames = new Set<string>();
     for (const n of BRAIN_TOOL_ALLOWLIST) validNames.add(`brain_${n}`);
@@ -1137,7 +1140,18 @@ export async function registerBuiltinHandlers(worker: MinionWorker, engine: Brai
     for (const w of loaded.warnings) process.stderr.write(w + '\n');
     for (const p of loaded.plugins) {
       process.stderr.write(
-        `[plugin-loader] loaded '${p.manifest.name}' v${p.manifest.version} (${p.subagents.length} subagents)\n`,
+        `[plugin-loader] loaded '${p.manifest.name}' v${p.manifest.version} ` +
+        `(${p.subagents.length} subagents, ${p.jobHandlers.length} job-handler modules)\n`,
+      );
+    }
+    const jobHandlerResult = await registerPluginJobHandlersFromEnv(worker, engine, {
+      validAgentToolNames: validNames,
+    });
+    for (const w of jobHandlerResult.warnings) process.stderr.write(w + '\n');
+    for (const entry of jobHandlerResult.registered) {
+      process.stderr.write(
+        `[plugin-loader] registered job handlers from '${entry.plugin}/${entry.module}': ` +
+        `${entry.handlers.length > 0 ? entry.handlers.join(', ') : '(none)'}\n`,
       );
     }
   } catch (e) {

--- a/src/core/minions/plugin-loader.ts
+++ b/src/core/minions/plugin-loader.ts
@@ -32,7 +32,10 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import matter from 'gray-matter';
+import type { BrainEngine } from '../engine.ts';
+import type { MinionHandler } from './types.ts';
 
 export const SUPPORTED_PLUGIN_VERSION = 'gbrain-plugin-v1';
 
@@ -41,6 +44,7 @@ export interface PluginManifest {
   version: string;
   plugin_version: string;
   subagents?: string;
+  job_handlers?: string;
   description?: string;
 }
 
@@ -58,9 +62,23 @@ export interface SubagentDefinition {
   allowed_tools?: string[];
 }
 
+export interface JobHandlerDefinition {
+  /** The plugin that shipped this job-handler module. */
+  plugin_name: string;
+  /** Stable module name, derived from the handler filename. */
+  name: string;
+  /** Full path to the JS/TS module on disk. */
+  source_path: string;
+}
+
 export interface PluginLoadResult {
   /** Successfully loaded plugins with their subagents. */
-  plugins: Array<{ manifest: PluginManifest; rootDir: string; subagents: SubagentDefinition[] }>;
+  plugins: Array<{
+    manifest: PluginManifest;
+    rootDir: string;
+    subagents: SubagentDefinition[];
+    jobHandlers: JobHandlerDefinition[];
+  }>;
   /** Per-path warnings (rejected, missing, malformed) collected during load. */
   warnings: string[];
 }
@@ -119,7 +137,12 @@ export function loadPluginsFromEnv(opts: LoadOpts = {}): PluginLoadResult {
         accepted.push(sa);
       }
 
-      result.plugins.push({ manifest: loaded.manifest, rootDir: p, subagents: accepted });
+      result.plugins.push({
+        manifest: loaded.manifest,
+        rootDir: p,
+        subagents: accepted,
+        jobHandlers: loaded.jobHandlers,
+      });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       result.warnings.push(`[plugin-loader] unexpected error loading ${p}: ${msg}`);
@@ -145,6 +168,7 @@ function rejectIfNotAbsolute(p: string): string | null {
 export interface LoadedPlugin {
   manifest: PluginManifest;
   subagents: SubagentDefinition[];
+  jobHandlers: JobHandlerDefinition[];
 }
 
 /**
@@ -225,11 +249,112 @@ export function loadSinglePlugin(
     }
   }
 
-  return { manifest, subagents };
+  let jobHandlers: JobHandlerDefinition[];
+  try {
+    jobHandlers = loadJobHandlerDefinitions(rootDir, manifest);
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : String(e) };
+  }
+
+  return { manifest, subagents, jobHandlers };
+}
+
+function loadJobHandlerDefinitions(rootDir: string, manifest: PluginManifest): JobHandlerDefinition[] | never {
+  if (manifest.job_handlers === undefined) return [];
+  if (typeof manifest.job_handlers !== 'string' || manifest.job_handlers.trim().length === 0) {
+    throw new Error('manifest "job_handlers" must be a non-empty relative directory path');
+  }
+
+  const handlersDir = path.resolve(rootDir, manifest.job_handlers);
+  if (!handlersDir.startsWith(rootDir + path.sep) && handlersDir !== rootDir) {
+    throw new Error(`job_handlers path escapes plugin root: ${manifest.job_handlers}`);
+  }
+  if (!fs.existsSync(handlersDir)) return [];
+  if (!fs.statSync(handlersDir).isDirectory()) {
+    throw new Error(`job_handlers path is not a directory: ${manifest.job_handlers}`);
+  }
+
+  const supported = new Set(['.js', '.mjs', '.ts']);
+  return fs.readdirSync(handlersDir)
+    .filter(entry => supported.has(path.extname(entry)))
+    .sort()
+    .map(entry => ({
+      plugin_name: manifest.name,
+      name: entry.replace(/\.(mjs|js|ts)$/, ''),
+      source_path: path.join(handlersDir, entry),
+    }));
+}
+
+export interface JobHandlerRegistrar {
+  readonly registeredNames: string[];
+  register(name: string, handler: MinionHandler): void;
+}
+
+export interface RegisterPluginJobHandlersResult {
+  registered: Array<{ plugin: string; module: string; handlers: string[] }>;
+  warnings: string[];
+}
+
+export async function registerPluginJobHandlersFromEnv(
+  worker: JobHandlerRegistrar,
+  engine: BrainEngine,
+  opts: LoadOpts = {},
+): Promise<RegisterPluginJobHandlersResult> {
+  const loaded = loadPluginsFromEnv(opts);
+  const warnings = [...loaded.warnings];
+  const registered: Array<{ plugin: string; module: string; handlers: string[] }> = [];
+
+  for (const plugin of loaded.plugins) {
+    for (const def of plugin.jobHandlers) {
+      const before = new Set(worker.registeredNames);
+      const handlersForModule: string[] = [];
+      const registrar: JobHandlerRegistrar = {
+        get registeredNames() {
+          return worker.registeredNames;
+        },
+        register(name: string, handler: MinionHandler) {
+          const normalized = (name || '').trim();
+          if (!normalized) {
+            throw new Error('job handler name cannot be empty');
+          }
+          if (before.has(normalized) || handlersForModule.includes(normalized)) {
+            throw new Error(`job handler '${normalized}' is already registered`);
+          }
+          worker.register(normalized, handler);
+          handlersForModule.push(normalized);
+        },
+      };
+
+      try {
+        const moduleUrl = pathToFileURL(def.source_path).href;
+        const mod = await import(moduleUrl);
+        const registerFn = mod.registerJobHandlers ?? mod.register ?? mod.default;
+        if (typeof registerFn !== 'function') {
+          warnings.push(
+            `[plugin-loader] job handler module ${def.source_path} has no registerJobHandlers/register/default export`,
+          );
+          continue;
+        }
+        await registerFn(registrar, engine, {
+          pluginName: plugin.manifest.name,
+          pluginRoot: plugin.rootDir,
+          manifest: plugin.manifest,
+          modulePath: def.source_path,
+        });
+        registered.push({ plugin: plugin.manifest.name, module: def.name, handlers: handlersForModule });
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        warnings.push(`[plugin-loader] rejected job handler ${def.source_path}: ${msg}`);
+      }
+    }
+  }
+
+  return { registered, warnings };
 }
 
 /** Testing surface. */
 export const __testing = {
   rejectIfNotAbsolute,
   SUPPORTED_PLUGIN_VERSION,
+  loadJobHandlerDefinitions,
 };

--- a/test/plugin-loader-job-handlers.test.ts
+++ b/test/plugin-loader-job-handlers.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { MinionQueue } from '../src/core/minions/queue.ts';
+import { MinionWorker } from '../src/core/minions/worker.ts';
+import {
+  loadSinglePlugin,
+  registerPluginJobHandlersFromEnv,
+} from '../src/core/minions/plugin-loader.ts';
+
+const tempDirs: string[] = [];
+
+function tempPluginDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-plugin-job-handlers-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop()!;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+async function waitTerminal(queue: MinionQueue, id: number, timeoutMs = 10000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const job = await queue.getJob(id);
+    if (job && ['completed', 'failed', 'dead', 'cancelled'].includes(job.status)) {
+      return job.status;
+    }
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+  const job = await queue.getJob(id);
+  throw new Error(`job ${id} did not reach terminal state; last status=${job?.status}`);
+}
+
+describe('GBRAIN_PLUGIN_PATH job handler loading', () => {
+  test('rejects job_handlers paths that escape the plugin root', () => {
+    const root = tempPluginDir();
+    writeFileSync(join(root, 'gbrain.plugin.json'), JSON.stringify({
+      name: 'bad-job-plugin',
+      version: '1.0.0',
+      plugin_version: 'gbrain-plugin-v1',
+      job_handlers: '../outside',
+    }));
+
+    const loaded = loadSinglePlugin(root);
+    expect('error' in loaded).toBe(true);
+    if ('error' in loaded) {
+      expect(loaded.error).toContain('job_handlers path escapes plugin root');
+    }
+  });
+
+  test('registers a local job handler module and executes it through MinionWorker', async () => {
+    const root = tempPluginDir();
+    const handlersDir = join(root, 'job-handlers');
+    mkdirSync(handlersDir);
+    writeFileSync(join(root, 'gbrain.plugin.json'), JSON.stringify({
+      name: 'aios-test-plugin',
+      version: '1.0.0',
+      plugin_version: 'gbrain-plugin-v1',
+      job_handlers: 'job-handlers',
+    }));
+    writeFileSync(join(handlersDir, 'aios-task.mjs'), `
+      export function registerJobHandlers(worker) {
+        worker.register('aios-task-test', async (job) => {
+          await job.updateProgress({ phase: 'smoke', task_id: job.data.task_id });
+          return { ok: true, task_id: job.data.task_id };
+        });
+      }
+    `);
+
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+    try {
+      const worker = new MinionWorker(engine, { pollInterval: 50, lockDuration: 30000 });
+      const result = await registerPluginJobHandlersFromEnv(worker, engine, { envPath: root });
+      expect(result.warnings).toEqual([]);
+      expect(worker.registeredNames).toContain('aios-task-test');
+
+      const queue = new MinionQueue(engine);
+      const job = await queue.add('aios-task-test', { task_id: 'task-smoke' }, { queue: 'default' });
+      const runPromise = worker.start();
+      try {
+        const status = await waitTerminal(queue, job.id);
+        expect(status).toBe('completed');
+        const final = await queue.getJob(job.id);
+        expect(final?.result).toEqual({ ok: true, task_id: 'task-smoke' });
+        expect(final?.progress).toEqual({ phase: 'smoke', task_id: 'task-smoke' });
+      } finally {
+        worker.stop();
+        await runPromise;
+      }
+    } finally {
+      await engine.disconnect();
+    }
+  }, 20000);
+});


### PR DESCRIPTION
## Summary
- extend `GBRAIN_PLUGIN_PATH` plugin loading with manifest-declared local job handler modules
- register plugin job handlers in Minions workers/supervisor without enabling arbitrary shell execution
- fix detached supervisor re-exec path for compiled gbrain binaries
- add PGLite-backed plugin handler execution coverage

## Verification
- `bun test test/plugin-loader*.test.ts`
- `bun run typecheck`

## Local gate note
- `git push` pre-push hook ran full `bash scripts/run-unit-parallel.sh` and failed outside this PR scope: PGLite search/stats, frontmatter hook, GBRAIN_HOME write-side isolation, warm-create speed gate, brain registry, and v0.29.1 migration tests. The current local worktree also has unrelated dirty changes not included in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->