### PR TITLE
docs: fix incorrect sources add --strategy code command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ gbrain code-refs BrainEngine                # all reference sites
 gbrain query "how does N+1 handling work" --near-symbol BrainEngine.searchKeyword --walk-depth 2
 ```
 
-All five auto-emit JSON on non-TTY (gh-CLI convention) so a GStack subagent shelling out via bash gets a clean parseable response. Run `gbrain sources add <repo> --strategy code` to index a repo, then your agent's brain-first lookup covers code, not just markdown. ([Cathedral II release notes](CHANGELOG.md#0210---2026-04-25))
+All five auto-emit JSON on non-TTY (gh-CLI convention) so a GStack subagent shelling out via bash gets a clean parseable response. Add a repo with `gbrain sources add <id> --path <path>`, then run `gbrain sync --strategy code` to index it — your agent's brain-first lookup covers code, not just markdown. ([Cathedral II release notes](CHANGELOG.md#0210---2026-04-25))
 
 ## The 34 Skills
 


### PR DESCRIPTION
## Summary

Fixes #456

The README suggested `gbrain sources add <repo> --strategy code` but `sources add` does not accept the `--strategy` flag. Strategy is a sync-level parameter, not a source-add parameter.

## Root Cause

The README was written during the Cathedral II release when code indexing was introduced, but the documented command combined two separate operations (source registration and strategy selection) into one invalid command. The `sources add` command (line 10 of `src/commands/sources.ts`) only accepts `--path`, `--name`, and `--federated` flags — no `--strategy`.

## Fix

Replace the incorrect single command with the correct two-step workflow: `gbrain sources add <id> --path <path>` to register the source, then `gbrain sync --strategy code` to index it.

## Changes

- `README.md`: fix line 141 — replace invalid `sources add --strategy code` with correct two-command workflow (`+1 -1` lines)

## Testing

- `gbrain sources add test --path /tmp` — succeeds without --strategy flag ✅
- `gbrain sources add test --path /tmp --strategy code` — correctly rejected as unknown flag ✅  
- `gbrain sync --strategy code` — documented as correct approach ✅

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->