### PR TITLE
fix: add items to array params for OpenAI strict tool schema compat

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -818,6 +818,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
                 description: v.description,
                 ...(v.enum ? { enum: v.enum } : {}),
                 ...(v.default !== undefined ? { default: v.default } : {}),
+                ...(v.items ? { items: { type: v.items.type } } : {}),
               }]),
             ),
             required: Object.entries(op.params).filter(([, v]) => v.required).map(([k]) => k),

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2434,7 +2434,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },


### PR DESCRIPTION
OpenAI Structured Outputs strict mode (used by Codex CLI / gpt-5.5 route) rejects JSON Schema arrays without an `items` clause:

```
Invalid schema for function gbrain__extract_facts: In context=('properties', 'entity_hints'), array schema missing items.
```

## Fixes

Two issues, two-line fix total:

1. **`src/core/operations.ts` line 2437** — `extract_facts.entity_hints` had `{ type: 'array', description: ... }` without `items`. Added `items: { type: 'string' }` to align with the established gbrain convention (e.g. `log_ingest.pages_updated` already specifies items the same way).

2. **`src/commands/serve-http.ts` line 821** — inline schema generator in `ListToolsRequestSchema` handler did not propagate `items` from `op.params` definitions, even though the parallel `buildToolDefs` in `src/mcp/tool-defs.ts` does. Added `...(v.items ? { items: { type: v.items.type } } : {})` spread to match.

## Why this matters

Bare `{ "type": "array" }` is valid per JSON Schema 2020-12 (mixed-type arrays are allowed), but OpenAI Structured Outputs strict mode requires `items`. Without this fix, any `gbrain serve --http` deployment is unusable from OpenAI strict-mode callers (Codex CLI, ChatGPT via OAuth, etc.).

## Reproducer

```bash
gbrain serve --http --port 3131
curl -H "Authorization: Bearer <token>" -X POST http://localhost:3131/mcp \
  -d '{"jsonrpc":"2.0","method":"tools/list","id":1}'
# entity_hints schema missing items, OpenAI strict-mode rejects on tools/call
```

## Test plan

- [x] Verified end-to-end: OpenAI Codex CLI agent successfully calls `gbrain__search` via MCP through gbrain HTTP server (was rejected with "array schema missing items" before fix)
- [x] No new tests required (existing tools-list contract upheld)

## References

- https://json-schema.org/understanding-json-schema/reference/array
- https://platform.openai.com/docs/guides/structured-outputs

🤖 Discovered + fixed during Phase C deployment of gbrain × OpenClaw integration. Generated with [Claude Code](https://claude.com/claude-code).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->