### PR TITLE
fix: reuse connected engine for frontmatter reindex

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1179,8 +1179,8 @@ async function handleCliOnly(command: string, args: string[]) {
         // v0.30.1: still works; canonical entrypoint is now `gbrain backfill
         // effective_date`. This command stays as a thin alias for back-compat.
         const { reindexFrontmatterCli } = await import('./commands/reindex-frontmatter.ts');
-        await reindexFrontmatterCli(args);
-        return; // reindexFrontmatterCli handles its own engine lifecycle
+        await reindexFrontmatterCli(args, engine);
+        break;
       }
       case 'backfill': {
         // v0.30.1: first-class generic backfill command. Subcommand dispatch

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1847,7 +1847,11 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
        SELECT 'fallback_with_fm_date' AS kind, COUNT(*)::text AS count
          FROM sample
         WHERE effective_date_source = 'fallback'
-          AND (frontmatter ? 'event_date' OR frontmatter ? 'date' OR frontmatter ? 'published')
+          AND (
+            (frontmatter ? 'event_date' AND NULLIF(frontmatter->>'event_date', '') IS NOT NULL)
+            OR (frontmatter ? 'date' AND NULLIF(frontmatter->>'date', '') IS NOT NULL)
+            OR (frontmatter ? 'published' AND NULLIF(frontmatter->>'published', '') IS NOT NULL)
+          )
        UNION ALL
        SELECT 'future_dated', COUNT(*)::text FROM sample
         WHERE effective_date IS NOT NULL AND effective_date > NOW() + INTERVAL '1 year'

--- a/src/commands/reindex-frontmatter.ts
+++ b/src/commands/reindex-frontmatter.ts
@@ -141,7 +141,7 @@ export async function runReindexFrontmatter(
 }
 
 /** CLI entrypoint. Argv shape matches reindex-code for consistency. */
-export async function reindexFrontmatterCli(args: string[]): Promise<void> {
+export async function reindexFrontmatterCli(args: string[], existingEngine?: BrainEngine): Promise<void> {
   const opts: ReindexFrontmatterOpts = {};
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
@@ -157,14 +157,23 @@ export async function reindexFrontmatterCli(args: string[]): Promise<void> {
     }
   }
 
-  const { createEngine } = await import('../core/engine-factory.ts');
-  const { loadConfig, toEngineConfig } = await import('../core/config.ts');
-  const cfg = loadConfig();
-  if (!cfg) {
-    console.error('No gbrain config; run `gbrain init` first.');
-    process.exit(1);
+  let ownsEngine = false;
+  let engine = existingEngine;
+  if (!engine) {
+    const { createEngine } = await import('../core/engine-factory.ts');
+    const { loadConfig, toEngineConfig } = await import('../core/config.ts');
+    const cfg = loadConfig();
+    if (!cfg) {
+      console.error('No gbrain config; run `gbrain init` first.');
+      process.exit(1);
+    }
+    const engineConfig = toEngineConfig(cfg);
+    engine = await createEngine(engineConfig);
+    if ('connect' in engine && typeof engine.connect === 'function') {
+      await engine.connect(engineConfig);
+    }
+    ownsEngine = true;
   }
-  const engine = await createEngine(toEngineConfig(cfg));
 
   try {
     const result = await runReindexFrontmatter(engine, opts);
@@ -179,7 +188,7 @@ export async function reindexFrontmatterCli(args: string[]): Promise<void> {
     }
     if (result.status === 'cancelled') process.exit(1);
   } finally {
-    if ('disconnect' in engine && typeof engine.disconnect === 'function') {
+    if (ownsEngine && engine && 'disconnect' in engine && typeof engine.disconnect === 'function') {
       await engine.disconnect();
     }
   }

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -101,6 +101,18 @@ describe('doctor command', () => {
     expect(source).toMatch(/table:\s*'files'.*col:\s*'metadata'/);
   });
 
+  test('effective_date_health ignores empty frontmatter date fields', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    const block = source.slice(
+      source.indexOf('// 11a-2. effective_date_health'),
+      source.indexOf('// 11a-3.'),
+    );
+    expect(block.length).toBeGreaterThan(0);
+    expect(block).toContain("NULLIF(frontmatter->>'event_date', '') IS NOT NULL");
+    expect(block).toContain("NULLIF(frontmatter->>'date', '') IS NOT NULL");
+    expect(block).toContain("NULLIF(frontmatter->>'published', '') IS NOT NULL");
+  });
+
   // v0.31.2 — facts_extraction_health check added in PR1 commit 12.
   // Reads ingest_log rows with source_type='facts:absorb' (written by
   // writeFactsAbsorbLog from src/core/facts/absorb-log.ts), groups by

--- a/test/reindex-frontmatter.test.ts
+++ b/test/reindex-frontmatter.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+
+describe('gbrain reindex-frontmatter command wiring', () => {
+  test('CLI passes the already-connected engine into reindex-frontmatter', async () => {
+    const source = await Bun.file(new URL('../src/cli.ts', import.meta.url)).text();
+    const block = source.slice(
+      source.indexOf("case 'reindex-frontmatter'"),
+      source.indexOf("case 'backfill'"),
+    );
+
+    expect(block.length).toBeGreaterThan(0);
+    expect(block).toContain('reindexFrontmatterCli(args, engine)');
+    expect(block).not.toContain('reindexFrontmatterCli(args);');
+  });
+
+  test('reindex-frontmatter CLI only owns/disconnects engines it creates', async () => {
+    const source = await Bun.file(new URL('../src/commands/reindex-frontmatter.ts', import.meta.url)).text();
+
+    expect(source).toContain('existingEngine?: BrainEngine');
+    expect(source).toContain('let ownsEngine = false');
+    expect(source).toContain('let engine = existingEngine');
+    expect(source).toContain('ownsEngine = true');
+    expect(source).toContain('ownsEngine && engine');
+  });
+});


### PR DESCRIPTION
## Summary

- Pass the already-connected CLI engine into `reindex-frontmatter` instead of constructing a second, disconnected PGLite engine.
- Make `reindexFrontmatterCli` own/disconnect only engines it creates itself.
- Avoid false-positive `effective_date_health` warnings for empty date-like frontmatter fields.
- Add regression coverage for CLI wiring and doctor effective-date checks.

## Why

In PGLite installs, `gbrain reindex-frontmatter` could fail with `PGLite not connected. Call connect() first.` because the CLI had already initialized an engine, but `reindex-frontmatter` created/used its own unconnected engine path. This also made downstream Hermes installs carry a local compatibility patch across upgrades.

`doctor` also treated the mere presence of `event_date`, `date`, or `published` frontmatter keys as evidence of parseable date metadata even when the values were empty, producing noisy effective-date warnings.

## Test plan

```bash
bun test test/reindex-frontmatter.test.ts
bun test test/doctor.test.ts -t "effective_date_health ignores empty frontmatter date fields"
```

Both pass locally.

Note: running the full `test/doctor.test.ts` file in this container hits pre-existing 5s timeouts in unrelated `takes_weight_grid` tests while fresh PGLite migrations run; the new focused tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->