### PR TITLE
Fix source-linked upgrades and MCP array schema

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -27,12 +27,13 @@ export async function runUpgrade(args: string[]) {
       }
       console.log(`Upgrading bun-link source clone at ${linkInfo.repoRoot}...`);
       try {
-        execFileSync('git', ['-C', linkInfo.repoRoot, 'pull', '--ff-only'], { stdio: 'inherit', timeout: 120_000 });
-        execFileSync('bun', ['install'], { cwd: linkInfo.repoRoot, stdio: 'inherit', timeout: 120_000 });
+        upgradeBunLinkSourceClone(linkInfo.repoRoot);
         upgraded = true;
-      } catch {
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.error(`Auto-upgrade failed: ${msg}`);
         console.error('Auto-upgrade failed. Try manually:');
-        console.error(`  cd ${linkInfo.repoRoot} && git pull && bun install`);
+        console.error(`  cd ${linkInfo.repoRoot} && git fetch --all --tags --prune && git merge <default-remote>/HEAD && bun install`);
       }
       break;
     }
@@ -105,6 +106,111 @@ export async function runUpgrade(args: string[]) {
     } catch {
       // features scan is best-effort
     }
+  }
+}
+
+export function upgradeBunLinkSourceClone(repoRoot: string): void {
+  ensureCleanWorktree(repoRoot);
+
+  const upstream = resolveUpstreamRef(repoRoot);
+  execFileSync('git', ['-C', repoRoot, 'fetch', upstream.remote, '--tags', '--prune'], {
+    stdio: 'inherit',
+    timeout: 120_000,
+  });
+
+  const upstreamRef = upstream.ref;
+  if (isAncestor(repoRoot, upstreamRef, 'HEAD')) {
+    console.log(`Source clone already includes ${upstreamRef}.`);
+  } else if (isAncestor(repoRoot, 'HEAD', upstreamRef)) {
+    execFileSync('git', ['-C', repoRoot, 'merge', '--ff-only', upstreamRef], {
+      stdio: 'inherit',
+      timeout: 120_000,
+    });
+  } else {
+    assertMergeClean(repoRoot, upstreamRef);
+    execFileSync('git', ['-C', repoRoot, 'merge', '--no-edit', upstreamRef], {
+      stdio: 'inherit',
+      timeout: 120_000,
+    });
+  }
+
+  execFileSync('bun', ['install'], { cwd: repoRoot, stdio: 'inherit', timeout: 120_000 });
+}
+
+function ensureCleanWorktree(repoRoot: string): void {
+  const status = execFileSync('git', ['-C', repoRoot, 'status', '--porcelain'], {
+    encoding: 'utf-8',
+    timeout: 10_000,
+  }).trim();
+  if (status) {
+    throw new Error('source clone has uncommitted changes; commit/stash them before upgrading');
+  }
+}
+
+function resolveUpstreamRef(repoRoot: string): { remote: string; ref: string } {
+  const tracked = gitOutput(repoRoot, ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}']);
+  if (tracked) {
+    return { remote: tracked.split('/')[0] || 'origin', ref: tracked };
+  }
+
+  // Source-linked agent installs often run on custom integration branches with
+  // no tracking branch. Use the repository's default upstream branch instead
+  // of raw `git pull`, which fails with "no tracking information".
+  const remote = resolveDefaultRemote(repoRoot) || 'origin';
+  const remoteHead = gitOutput(repoRoot, ['rev-parse', '--abbrev-ref', `${remote}/HEAD`]);
+  return {
+    remote,
+    ref: remoteHead && !remoteHead.endsWith('/HEAD') ? remoteHead : `${remote}/master`,
+  };
+}
+
+function assertMergeClean(repoRoot: string, upstreamRef: string): void {
+  try {
+    execFileSync('git', ['-C', repoRoot, 'merge-tree', '--write-tree', 'HEAD', upstreamRef], {
+      stdio: 'pipe',
+      timeout: 60_000,
+    });
+  } catch {
+    throw new Error(`local branch and ${upstreamRef} diverged with conflicts; resolve a manual merge first`);
+  }
+}
+
+function resolveDefaultRemote(repoRoot: string): string | null {
+  const remotes = gitOutput(repoRoot, ['remote']);
+  if (!remotes) return null;
+
+  const names = remotes.split('\n').map(remote => remote.trim()).filter(Boolean);
+  for (const remote of names) {
+    const url = gitOutput(repoRoot, ['remote', 'get-url', remote]);
+    if (url?.toLowerCase().includes(GBRAIN_GITHUB_REPO)) {
+      return remote;
+    }
+  }
+
+  return names[0] || null;
+}
+
+function isAncestor(repoRoot: string, maybeAncestor: string, descendant: string): boolean {
+  try {
+    execFileSync('git', ['-C', repoRoot, 'merge-base', '--is-ancestor', maybeAncestor, descendant], {
+      stdio: 'pipe',
+      timeout: 10_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function gitOutput(repoRoot: string, args: string[]): string | null {
+  try {
+    return execFileSync('git', ['-C', repoRoot, ...args], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 10_000,
+    }).trim() || null;
+  } catch {
+    return null;
   }
 }
 

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2530,7 +2530,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },

--- a/test/mcp-tool-defs.test.ts
+++ b/test/mcp-tool-defs.test.ts
@@ -64,4 +64,14 @@ describe('buildToolDefs', () => {
       expect(Array.isArray(def.inputSchema.required)).toBe(true);
     }
   });
+
+  test('array parameters include items schemas for OpenAI function compatibility', () => {
+    for (const def of buildToolDefs(operations)) {
+      for (const [name, prop] of Object.entries(def.inputSchema.properties)) {
+        if (prop && typeof prop === 'object' && (prop as { type?: unknown }).type === 'array') {
+          expect((prop as { items?: unknown }).items, `${def.name}.${name}`).toBeDefined();
+        }
+      }
+    }
+  });
 });

--- a/test/upgrade.test.ts
+++ b/test/upgrade.test.ts
@@ -100,8 +100,23 @@ describe('detectInstallMethod heuristic (source analysis)', () => {
     // execFileSync with array args bypasses the shell (same pattern as
     // dry-fix.ts:172). execSync with template strings is vulnerable to
     // paths containing shell metacharacters.
-    expect(source).toContain("execFileSync('git', ['-C', linkInfo.repoRoot, 'pull', '--ff-only']");
+    expect(source).toContain('function upgradeBunLinkSourceClone');
+    expect(source).toContain("execFileSync('git', ['-C', repoRoot, 'fetch'");
     expect(source).toContain("execFileSync('bun', ['install']");
+  });
+
+  test('bun-link upgrade handles source clones without tracking branches', () => {
+    expect(source).toContain('resolveUpstreamRef');
+    expect(source).toContain("'@{u}'");
+    expect(source).toContain('resolveDefaultRemote');
+    expect(source).toContain("'remote', 'get-url', remote");
+    expect(source).toContain('no tracking branch');
+  });
+
+  test('bun-link upgrade preflights non-ff custom branch merges', () => {
+    expect(source).toContain('assertMergeClean');
+    expect(source).toContain("'merge-tree', '--write-tree', 'HEAD', upstreamRef");
+    expect(source).toContain("'merge', '--no-edit', upstreamRef");
   });
 
   test('classifyBunInstall checks repository.url AND src/cli.ts marker', () => {


### PR DESCRIPTION
## Summary
- replace source-linked upgrade `git pull --ff-only` with explicit clean-worktree fetch/merge handling for tracked, no-tracking, fast-forward, and clean custom-branch merge cases
- keep git/bun subprocess calls on `execFileSync` array args and surface the actual auto-upgrade error before manual recovery guidance
- add the missing `items: { type: 'string' }` schema for `extract_facts.entity_hints` so OpenAI-compatible function schema validation accepts the MCP tool definition

## Tests
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test test/mcp-tool-defs.test.ts test/upgrade.test.ts`
- `HOME=/private/tmp/gbrain-test-home bun run test` (repo tests write to `~/.gbrain`, so HOME is redirected to writable temp space)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->