### PR TITLE
fix(oauth): honor `token_endpoint_auth_method: "none"` for DCR public clients (PKCE-only)

### DIFF
--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -170,8 +170,14 @@ class GBrainClientsStore implements OAuthRegisteredClientsStore {
     assertAllowedScopes(parseScopeString(client.scope));
 
     const clientId = generateToken('gbrain_cl_');
-    const clientSecret = generateToken('gbrain_cs_');
-    const secretHash = hashToken(clientSecret);
+    // RFC 7591 §2: clients registering with token_endpoint_auth_method "none"
+    // are public clients and MUST NOT receive a client_secret. Without this
+    // gate, the MCP SDK's clientAuth middleware (which checks the stored
+    // client.client_secret to decide whether to require one at /token) demands
+    // a secret on PKCE-only exchanges and rejects valid public-client flows.
+    const isPublicClient = client.token_endpoint_auth_method === 'none';
+    const clientSecret = isPublicClient ? undefined : generateToken('gbrain_cs_');
+    const secretHash = clientSecret ? hashToken(clientSecret) : null;
     const now = Math.floor(Date.now() / 1000);
 
     await this.sql`
@@ -188,7 +194,7 @@ class GBrainClientsStore implements OAuthRegisteredClientsStore {
     return {
       ...client,
       client_id: clientId,
-      client_secret: clientSecret,
+      ...(clientSecret ? { client_secret: clientSecret } : {}),
       client_id_issued_at: now,
     };
   }

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -131,6 +131,46 @@ describe('client registration', () => {
       sql`INSERT INTO oauth_clients (client_id, client_name, scope) VALUES (${clientId}, ${'dup'}, ${'read'})`,
     ).rejects.toThrow();
   });
+
+  // RFC 7591 §2: a DCR client registering with token_endpoint_auth_method "none"
+  // is a public client and MUST NOT receive a client_secret. Before this fix,
+  // gbrain unconditionally generated a secret, which caused the MCP SDK's
+  // clientAuth middleware to demand client_secret_post auth at /token and
+  // reject every PKCE-only public-client exchange (Claude Code, Cursor, etc.).
+  test('DCR with token_endpoint_auth_method "none" issues no client_secret', async () => {
+    const registered = await provider.clientsStore.registerClient({
+      client_name: 'public-pkce-client',
+      redirect_uris: ['https://example.com/callback'],
+      grant_types: ['authorization_code', 'refresh_token'],
+      scope: 'read',
+      token_endpoint_auth_method: 'none',
+    });
+
+    expect(registered.client_id).toStartWith('gbrain_cl_');
+    expect(registered.client_secret).toBeUndefined();
+
+    const stored = await provider.clientsStore.getClient(registered.client_id);
+    expect(stored).toBeDefined();
+    // Postgres NULL surfaces as null on read; MCP SDK's clientAuth middleware
+    // uses a truthy check (`if (client.client_secret)`), so falsy is the
+    // contract that matters for the PKCE-only flow to succeed.
+    expect(stored!.client_secret).toBeFalsy();
+    expect(stored!.token_endpoint_auth_method).toBe('none');
+  });
+
+  test('DCR without token_endpoint_auth_method defaults to confidential client', async () => {
+    const registered = await provider.clientsStore.registerClient({
+      client_name: 'confidential-default',
+      redirect_uris: ['https://example.com/callback'],
+      grant_types: ['authorization_code'],
+      scope: 'read',
+    });
+
+    expect(registered.client_secret).toStartWith('gbrain_cs_');
+
+    const stored = await provider.clientsStore.getClient(registered.client_id);
+    expect(stored!.client_secret).toBeDefined();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`registerClient` (DCR) unconditionally generates a `client_secret` even when the client requests `token_endpoint_auth_method: "none"`. The MCP SDK's `clientAuth` middleware then requires a secret on every `/token` exchange because `client.client_secret` is truthy from the stored row — which rejects every valid PKCE-only public-client flow (Claude Code, Cursor, MCP Inspector, …).

This PR makes `registerClient` honor `"none"` per RFC 7591 §2: no secret generated, NULL stored, no secret in the DCR response.

## Repro

```bash
gbrain serve --http --enable-dcr --public-url https://<your-domain>
```

From a public-client MCP host (Claude Code shown — same behavior on Cursor):

```bash
claude mcp add --scope user --transport http gbrain "https://<your-domain>/mcp"
# trigger auth → browser opens → user clicks Allow → callback returns code
```

**Before this PR:** the `/token` exchange fails. The MCP SDK then surfaces:

> `Existing OAuth client information is required when exchanging an authorization code`

**After this PR:** the same flow lands on a green ✓ Connected.

## Root cause

`src/core/oauth-provider.ts:172-194` always emits a fresh `client_secret`:

```ts
const clientSecret = generateToken('gbrain_cs_');
const secretHash = hashToken(clientSecret);
// ...
INSERT INTO oauth_clients (..., client_secret_hash, ...) VALUES (..., ${secretHash}, ...)
```

`getClient` reads `client_secret_hash` back as `client.client_secret`. The MCP SDK's middleware (`@modelcontextprotocol/sdk/server/auth/middleware/clientAuth.js:19`) then gates:

```js
if (client.client_secret) {
  if (!client_secret) throw new InvalidClientError('Client secret is required');
  // ...
}
```

Public clients (per RFC 7591) cannot safely store a secret, so they send `client_id` + `code_verifier` only — and get rejected.

## Fix

Gate secret generation on `token_endpoint_auth_method`:

```ts
const isPublicClient = client.token_endpoint_auth_method === 'none';
const clientSecret = isPublicClient ? undefined : generateToken('gbrain_cs_');
const secretHash = clientSecret ? hashToken(clientSecret) : null;
```

And omit `client_secret` from the DCR response for public clients. The `oauth_clients.client_secret_hash` column was already nullable — no schema migration needed. Confidential-client behavior is unchanged.

## Tests

Two new cases in `test/oauth.test.ts` under `client registration`:

- `DCR with token_endpoint_auth_method "none" issues no client_secret` — response has no secret, stored row's `client_secret` is falsy
- `DCR without token_endpoint_auth_method defaults to confidential client` — regression guard so the default path still mints + stores a secret

```
$ bun test test/oauth.test.ts
 66 pass
 0 fail
 257 expect() calls
```

## Spec references

- RFC 7591 §2 — Client Metadata, `token_endpoint_auth_method` values including `"none"`
- RFC 6749 §2.1, §10.1 — public vs confidential client classification
- RFC 7636 — PKCE (the auth method public clients use instead of a secret)

## Affected clients

Any MCP host that uses DCR with PKCE-only auth — i.e., any public OAuth 2.1 client. Confirmed in the wild for Claude Code and Cursor; the same break-mode applies to MCP Inspector and the reference clients in `@modelcontextprotocol/sdk`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->