### PR TITLE
fix(extract): dry-run reports net-new rows, not raw candidates (closes #397)

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -1111,6 +1111,45 @@ async function extractLinksFromDB(
 
   // Dedup in dry-run only — DB enforces uniqueness via ON CONFLICT in batch writes.
   const dryRunSeen = dryRun ? new Set<string>() : null;
+  // Cross-PR-#397 reconcile (v0.32.7+ multi-source aware): dry-run should
+  // report net-new rows, not raw candidate count. On the second extract run,
+  // every candidate already lives in `links` and "would create N" is
+  // misleading by exactly N. Cache per (fromSourceId, fromSlug) — Link rows
+  // are scoped to the from-page, so cardinality stays low. Inline SQL
+  // because engine.getLinks() does not return f.source_id / t.source_id;
+  // adding those columns to the Link interface would ripple to 6 callers
+  // outside extract.ts, so the inline query keeps the blast radius zero.
+  const existingLinksByFromSrc = dryRun ? new Map<string, Set<string>>() : null;
+  async function existingLinkKeysForFrom(fromSlug: string, fromSourceId: string): Promise<Set<string>> {
+    if (!existingLinksByFromSrc) return new Set();
+    const cacheKey = `${fromSourceId}::${fromSlug}`;
+    const cached = existingLinksByFromSrc.get(cacheKey);
+    if (cached) return cached;
+    const rows = await engine.executeRaw<{
+      from_slug: string;
+      to_slug: string;
+      link_type: string;
+      link_source: string | null;
+      from_source_id: string;
+      to_source_id: string;
+    }>(
+      `SELECT f.slug AS from_slug, t.slug AS to_slug,
+              l.link_type, l.link_source,
+              f.source_id AS from_source_id, t.source_id AS to_source_id
+       FROM links l
+       JOIN pages f ON f.id = l.from_page_id
+       JOIN pages t ON t.id = l.to_page_id
+       WHERE f.slug = $1 AND f.source_id = $2`,
+      [fromSlug, fromSourceId],
+    );
+    const keys = new Set<string>();
+    for (const r of rows) {
+      // Key shape MUST match the candidate dryRunSeen key (line ~872) byte for byte.
+      keys.add(`${r.from_source_id}::${r.from_slug}::${r.to_source_id}::${r.to_slug}::${r.link_type}::${r.link_source ?? 'markdown'}`);
+    }
+    existingLinksByFromSrc.set(cacheKey, keys);
+    return keys;
+  }
 
   const batch: LinkBatchInput[] = [];
   async function flush() {
@@ -1184,6 +1223,11 @@ async function extractLinksFromDB(
         const key = `${fromSourceId}::${fromSlug}::${toSourceId}::${c.targetSlug}::${c.linkType}::${c.linkSource ?? 'markdown'}`;
         if (dryRunSeen.has(key)) continue;
         dryRunSeen.add(key);
+        // PR-#397 reconcile: also skip candidates that already exist in `links`.
+        // ON CONFLICT in addLinksBatch would no-op these on a real run, so
+        // dry-run should report 0 not N. Cache is per (fromSourceId, fromSlug).
+        const existingForFrom = await existingLinkKeysForFrom(fromSlug, fromSourceId);
+        if (existingForFrom.has(key)) continue;
         if (jsonMode) {
           process.stdout.write(JSON.stringify({
             action: 'add_link', from: fromSlug, from_source_id: fromSourceId,
@@ -1265,6 +1309,31 @@ async function extractTimelineFromDB(
 
   // Dedup in dry-run only — DB enforces uniqueness via ON CONFLICT in batch writes.
   const dryRunSeen = dryRun ? new Set<string>() : null;
+  // PR-#397 reconcile: cache existing timeline rows per (sourceId, slug) so
+  // dry-run reports net-new entries, not raw candidates. Inline SQL because
+  // engine.getTimeline() returns TimelineEntry without source_id, and adding
+  // source_id to TimelineEntry would ripple beyond extract.ts.
+  const existingTimelineBySrcSlug = dryRun ? new Map<string, Set<string>>() : null;
+  async function existingTimelineKeysForSlug(slug: string, sourceId: string): Promise<Set<string>> {
+    if (!existingTimelineBySrcSlug) return new Set();
+    const cacheKey = `${sourceId}::${slug}`;
+    const cached = existingTimelineBySrcSlug.get(cacheKey);
+    if (cached) return cached;
+    const rows = await engine.executeRaw<{ date: string; summary: string; source_id: string }>(
+      `SELECT te.date::text AS date, te.summary, p.source_id
+       FROM timeline_entries te
+       JOIN pages p ON p.id = te.page_id
+       WHERE p.slug = $1 AND p.source_id = $2`,
+      [slug, sourceId],
+    );
+    const keys = new Set<string>();
+    for (const r of rows) {
+      // Key shape MUST match the candidate dryRunSeen key (line ~982) byte for byte.
+      keys.add(`${r.source_id}::${slug}::${r.date}::${r.summary}`);
+    }
+    existingTimelineBySrcSlug.set(cacheKey, keys);
+    return keys;
+  }
 
   const batch: TimelineBatchInput[] = [];
   async function flush() {
@@ -1301,6 +1370,10 @@ async function extractTimelineFromDB(
         const key = `${source_id}::${slug}::${entry.date}::${entry.summary}`;
         if (dryRunSeen.has(key)) continue;
         dryRunSeen.add(key);
+        // PR-#397 reconcile: also skip candidates already in timeline_entries.
+        // ON CONFLICT in addTimelineEntriesBatch would no-op these on real run.
+        const existingForSlug = await existingTimelineKeysForSlug(slug, source_id);
+        if (existingForSlug.has(key)) continue;
         if (jsonMode) {
           process.stdout.write(JSON.stringify({
             action: 'add_timeline', slug, source_id, date: entry.date,

--- a/test/extract-db.test.ts
+++ b/test/extract-db.test.ts
@@ -249,3 +249,112 @@ describe('gbrain extract all --source db', () => {
     expect(entries.length).toBe(1);
   });
 });
+
+// Restores PR #397's intent on master's multi-source code shape: dry-run
+// should report net-new candidates, not raw candidates. Two cases per
+// extractor — one proves zero-net-new after a real run, one proves a
+// genuinely new candidate still surfaces.
+describe('gbrain extract --dry-run reports net-new rows (PR #397 reconcile)', () => {
+  beforeEach(truncateAll);
+
+  function captureStdoutLines<T>(fn: () => Promise<T>): Promise<{ result: T; lines: string[] }> {
+    const lines: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+      const str = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8');
+      lines.push(str);
+      return true;
+    }) as any;
+    return fn()
+      .then(result => ({ result, lines }))
+      .finally(() => {
+        process.stdout.write = originalWrite;
+      });
+  }
+
+  test('links: dry-run after a real run reports zero new add_link rows', async () => {
+    await engine.putPage('people/alice', personPage('Alice'));
+    await engine.putPage('companies/acme', companyPage(
+      'Acme',
+      '[Alice](people/alice) joined as CEO.',
+    ));
+
+    // Real run populates `links`. ON CONFLICT enforces uniqueness.
+    await runExtract(engine, ['links', '--source', 'db']);
+    const linksAfterReal = await engine.getLinks('companies/acme');
+    expect(linksAfterReal.length).toBeGreaterThan(0);
+
+    // Second dry-run sees the same candidates AND the existing rows.
+    // Pre-#397-reconcile: emits "would add N". Post: 0.
+    const { lines } = await captureStdoutLines(() =>
+      runExtract(engine, ['links', '--source', 'db', '--dry-run', '--json']),
+    );
+    const addLinkLines = lines.filter(l => l.includes('"action":"add_link"'));
+    expect(addLinkLines.length).toBe(0);
+  });
+
+  test('links: dry-run reports a newly-added candidate after the page body changes', async () => {
+    await engine.putPage('people/alice', personPage('Alice'));
+    await engine.putPage('people/bob', personPage('Bob'));
+    await engine.putPage('companies/acme', companyPage(
+      'Acme',
+      '[Alice](people/alice) joined as CEO.',
+    ));
+    await runExtract(engine, ['links', '--source', 'db']);
+
+    // Now the page body gains a new candidate (Bob).
+    await engine.putPage('companies/acme', companyPage(
+      'Acme',
+      '[Alice](people/alice) joined as CEO. [Bob](people/bob) joined as CTO.',
+    ));
+
+    const { lines } = await captureStdoutLines(() =>
+      runExtract(engine, ['links', '--source', 'db', '--dry-run', '--json']),
+    );
+    const addLinkLines = lines.filter(l => l.includes('"action":"add_link"'));
+    // Exactly one new edge (companies/acme → people/bob); the alice edge is suppressed.
+    expect(addLinkLines.length).toBe(1);
+    const parsed = JSON.parse(addLinkLines[0].trim());
+    expect(parsed.to).toBe('people/bob');
+  });
+
+  test('timeline: dry-run after a real run reports zero new add_timeline rows', async () => {
+    await engine.putPage('people/alice', {
+      type: 'person', title: 'Alice', compiled_truth: '',
+      timeline: '- **2026-01-15** | Joined as CEO',
+    });
+
+    await runExtract(engine, ['timeline', '--source', 'db']);
+    const entriesAfterReal = await engine.getTimeline('people/alice');
+    expect(entriesAfterReal.length).toBe(1);
+
+    const { lines } = await captureStdoutLines(() =>
+      runExtract(engine, ['timeline', '--source', 'db', '--dry-run', '--json']),
+    );
+    const addLines = lines.filter(l => l.includes('"action":"add_timeline"'));
+    expect(addLines.length).toBe(0);
+  });
+
+  test('timeline: dry-run reports a newly-added entry after timeline section changes', async () => {
+    await engine.putPage('people/alice', {
+      type: 'person', title: 'Alice', compiled_truth: '',
+      timeline: '- **2026-01-15** | Joined as CEO',
+    });
+    await runExtract(engine, ['timeline', '--source', 'db']);
+
+    await engine.putPage('people/alice', {
+      type: 'person', title: 'Alice', compiled_truth: '',
+      timeline: `- **2026-01-15** | Joined as CEO
+- **2026-02-20** | Closed Series A`,
+    });
+
+    const { lines } = await captureStdoutLines(() =>
+      runExtract(engine, ['timeline', '--source', 'db', '--dry-run', '--json']),
+    );
+    const addLines = lines.filter(l => l.includes('"action":"add_timeline"'));
+    expect(addLines.length).toBe(1);
+    const parsed = JSON.parse(addLines[0].trim());
+    expect(parsed.date).toBe('2026-02-20');
+    expect(parsed.summary).toBe('Closed Series A');
+  });
+});


### PR DESCRIPTION
## Summary

`gbrain extract links|timeline --source db --dry-run` reports the candidate count, not the would-be net-new row count. On the second run after a real extract has populated `links` / `timeline_entries`, every candidate already exists in the DB, but dry-run still reports them all as "would create N." `ON CONFLICT DO NOTHING` in `addLinksBatch` / `addTimelineEntriesBatch` would silently no-op the lot on a real run.

This is the problem [#397](https://github.com/garrytan/gbrain/pull/397) set out to fix. That PR landed before v0.32.8's multi-source threading (#860) reshaped both extractors, so the old patch can't be cherry-picked onto master:

- Candidate dedup keys now carry source ids (6 segments: `from_source_id::from_slug::to_source_id::to_slug::link_type::link_source`).
- `engine.getLinks()` does not return `f.source_id` / `t.source_id`, and `Link` has no source-id fields. Comparing a 6-segment candidate key against a 5-segment DB row key would false-positive cross-source rows.

This PR closes #397.

## Approach

Per-extractor inline SQL that returns source ids alongside the link / timeline shape, plus a per-(from-page, source) cache:

```ts
async function existingLinkKeysForFrom(fromSlug, fromSourceId) {
  const rows = await engine.executeRaw(\`
    SELECT f.slug AS from_slug, t.slug AS to_slug,
           l.link_type, l.link_source,
           f.source_id AS from_source_id, t.source_id AS to_source_id
    FROM links l
    JOIN pages f ON f.id = l.from_page_id
    JOIN pages t ON t.id = l.to_page_id
    WHERE f.slug = \$1 AND f.source_id = \$2
  \`, [fromSlug, fromSourceId]);
  return new Set(rows.map(r =>
    \`\${r.from_source_id}::\${r.from_slug}::\${r.to_source_id}::\${r.to_slug}::\${r.link_type}::\${r.link_source ?? 'markdown'}\`
  ));
}
```

The key shape is **byte-for-byte identical** to the candidate dedup key the extractor already builds (extract.ts line ~872), so the existing/seen sets compose cleanly.

### Why inline SQL instead of extending `engine.getLinks()`

The cleaner-looking alternative is to add `from_source_id` / `to_source_id` to `Link` and to `getLinks`' SELECT. That ripples to 6 callers outside extract.ts:

- `src/core/operations.ts:734` (auto-link reconciliation)
- `src/core/operations.ts:1418` (per-page link API)
- `src/core/output/validators/back-link.ts:27` (back-link validator)
- `src/core/output/validators/back-link.ts:37` (back-link validator)
- `src/commands/migrate-engine.ts:234` (engine migration)

None of those need the source ids. Widening the interface across all five callers for a feature only `extract --dry-run` consumes is the wrong shape. Inline SQL keeps the blast radius at the two extractor functions.

## Test plan

4 new cases in `test/extract-db.test.ts`:

- [x] `links: dry-run after a real run reports zero new add_link rows`
- [x] `links: dry-run reports a newly-added candidate after the page body changes`
- [x] `timeline: dry-run after a real run reports zero new add_timeline rows`
- [x] `timeline: dry-run reports a newly-added entry after timeline section changes`

Each pair pins both halves of the contract — the dedup must remove "already in DB" candidates AND must not eat genuinely new candidates.

Run results:

```
$ bun run typecheck
$ tsc --noEmit
(clean)

$ bun test test/extract-db.test.ts
 16 pass
 0 fail
 36 expect() calls
Ran 16 tests across 1 file. [1.79s]
```

## Scope

Unchanged: real-run output, JSON shape, command-line surface, engine APIs.

Only changes:

- `src/commands/extract.ts` — adds 2 cached helpers (`existingLinkKeysForFrom`, `existingTimelineKeysForSlug`) and a 4-line `continue` guard inside each extractor's dry-run branch.
- `test/extract-db.test.ts` — 4 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->