### PR TITLE
test(frontmatter-install-hook): isolate hooksPath assertion from developer global config

### DIFF
--- a/test/frontmatter-install-hook.test.ts
+++ b/test/frontmatter-install-hook.test.ts
@@ -31,9 +31,26 @@ describe('frontmatter install-hook (B13)', () => {
     const content = readFileSync(hookPath, 'utf8');
     expect(content).toContain('gbrain frontmatter');
     expect(content).toContain('git diff --cached');
-    // Configured hooksPath
-    const hooksPath = execFileSync('git', ['-C', tmp, 'config', '--get', 'core.hooksPath'], { encoding: 'utf8' }).trim();
-    expect(hooksPath).toBe('.githooks');
+    // installHook's contract is "set core.hooksPath unless it's already set
+    // elsewhere". Test BOTH branches deterministically by reading the local
+    // scope only: clean CI → local should be `.githooks`; developer with a
+    // global core.hooksPath (e.g. dotfiles → ~/.config/git/hooks) → local
+    // should be empty because installHook correctly skipped clobbering.
+    // Reading via `--get` without `--local` falls back to global scope when
+    // local is unset, which made this test environmentally fragile.
+    let globalHooksPath = '';
+    try {
+      globalHooksPath = execFileSync('git', ['config', '--global', '--get', 'core.hooksPath'], { encoding: 'utf8' }).trim();
+    } catch { /* unset is the expected clean-env case */ }
+    let localHooksPath = '';
+    try {
+      localHooksPath = execFileSync('git', ['-C', tmp, 'config', '--local', '--get', 'core.hooksPath'], { encoding: 'utf8' }).trim();
+    } catch { /* unset is fine when global was present */ }
+    if (globalHooksPath) {
+      expect(localHooksPath).toBe('');
+    } else {
+      expect(localHooksPath).toBe('.githooks');
+    }
   });
 
   test('installHook refuses to clobber existing hook without --force', () => {


### PR DESCRIPTION
## Summary

The `installHook writes executable .githooks/pre-commit and sets core.hooksPath` test in `test/frontmatter-install-hook.test.ts` asserts `git config --get core.hooksPath` returns `.githooks`. `--get` falls back to the **global** scope when local is unset.

Developers who set `core.hooksPath` globally (common with dotfiles managers pointing at `~/.config/git/hooks`) see a deterministic FAIL because `installHook` intentionally respects an existing global value and skips writing the local one — exactly its documented contract: _"Set core.hooksPath unless the user has set it to something else already."_

CI passes because CI containers carry no `~/.gitconfig`. Any developer running `bun run test` locally with a global hooksPath sees this one failure.

## Diff scope

```
test/frontmatter-install-hook.test.ts | 23 +++++++++++++++++++----
1 file changed, 20 insertions(+), 3 deletions(-)
```

No source changes. No API change. `installHook` behavior unchanged.

## What the fix does

Read via `git config --local --get core.hooksPath` (scope-locked, no fallback) and branch the assertion on whether a global is already set:
- **Clean env (CI)** → local should be `.githooks` (installHook wrote it)
- **Developer with global** → local should be empty (installHook correctly didn't clobber)

Both branches now test the actual contract deterministically.

## Why not `process.env.GIT_CONFIG_GLOBAL = '/dev/null'`?

First attempt. Doesn't work under Bun: Bun snapshots `process.env` at process start and doesn't propagate JS-side mutations to child processes spawned via `execFileSync`. Verified by direct probe — works in Node, fails in Bun. Only the explicit `env: {...}` option on `execFileSync` propagates, which would require either changing `installHook`'s API to accept an env override (test-shaped knob on a production function) or spawning the test in a subprocess. The scope-locked-read approach avoids both and stays in the test file.

## Verification

```
$ bun run typecheck
$ tsc --noEmit
(exit 0)

$ bun run verify
OK: no JSON.stringify(x)::jsonb interpolation pattern in src/
OK: max_stalled defaults are 5 in all schema sources
OK: all rowToPage feeder projections include source_id
check-progress-to-stdout: OK (no banned stdout \r patterns)
check-test-isolation: OK (367 non-serial unit files scanned)
[check-wasm-embedded] OK — compiled binary produced real semantic chunks.
[check-admin-scope-drift] ok: 5 scopes match
OK: src/cli.ts is git-tracked as executable (100755)
OK: no direct derived-table writes outside the reconcile layer in src/ + scripts/
(all 11 checks pass)

$ bun test test/frontmatter-install-hook.test.ts
(pass) frontmatter install-hook (B13) > installHook writes executable .githooks/pre-commit and sets core.hooksPath
(pass) frontmatter install-hook (B13) > installHook refuses to clobber existing hook without --force
(pass) frontmatter install-hook (B13) > installHook with force overwrites and saves .bak
(pass) frontmatter install-hook (B13) > installHook on existing gbrain hook refreshes silently (no .bak)
(pass) frontmatter install-hook (B13) > uninstallHook removes the gbrain hook and restores .bak when present
(pass) frontmatter install-hook (B13) > uninstallHook on a non-gbrain hook returns false (does not remove user hook)
 6 pass / 0 fail / 20 expect()

$ bun run test
[unit-parallel] elapsed=389s | pass=5960 fail=0 skip=0
```

## Real-behavior proof

**Environment:** macOS 14, Bun 1.3.8, developer machine with `~/.gitconfig` containing `[core] hooksPath = ~/.config/git/hooks`.

**Before this fix** (on `origin/master`):
```
$ bun test test/frontmatter-install-hook.test.ts
expect(received).toBe(expected)
  Expected: ".githooks"
  Received: "/Users/watson/.config/git/hooks"
(fail) frontmatter install-hook (B13) > installHook writes executable .githooks/pre-commit and sets core.hooksPath
5 pass / 1 fail
```

**After this fix** (on `fix/frontmatter-hook-test-env-isolation`):
```
$ bun test test/frontmatter-install-hook.test.ts
6 pass / 0 fail
```

`installHook` itself is unchanged across these runs; the failure was an environmental fragility in the test, not a bug in the function.

## What was NOT tested

- The clean-env branch (where `installHook` actually writes local config) ran successfully in CI patterns before this PR — this fix preserves that. I did not stand up a clean container locally to independently verify the `local === '.githooks'` branch; the existing-test-with-no-developer-global-config evidence is the upstream CI suite passing.

## Test plan

- [ ] CI runs full suite green (clean env hits the `local === '.githooks'` branch)
- [ ] Maintainer with no global `core.hooksPath`: `bun test test/frontmatter-install-hook.test.ts` → 6 pass
- [ ] Maintainer with global `core.hooksPath` set: `bun test test/frontmatter-install-hook.test.ts` → 6 pass (also)

## Commits

1. `0e4da2c` test(frontmatter-install-hook): isolate hooksPath assertion from developer global config — scope-lock the read; branch the assertion on global presence.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->