### PR TITLE
fix: redact sensitive values in `config set` confirmation output

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -42,7 +42,13 @@ export async function runConfig(engine: BrainEngine, args: string[]) {
     }
   } else if (action === 'set' && key && value) {
     await engine.setConfig(key, value);
-    console.log(`Set ${key} = ${value}`);
+    const isSensitive = key.includes('key') || key.includes('secret') || key.includes('token') || key.includes('password');
+    const displayValue = typeof value === 'string' && value.includes('postgresql://')
+      ? redactUrl(value)
+      : isSensitive
+        ? '***'
+        : value;
+    console.log(`Set ${key} = ${displayValue}`);
   } else {
     console.error('Usage: gbrain config [show|get|set] <key> [value]');
     process.exit(1);

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -52,12 +52,20 @@ export function walkMarkdownFiles(dir: string): { path: string; relPath: string 
   const files: { path: string; relPath: string }[] = [];
   function walk(d: string) {
     for (const entry of readdirSync(d)) {
+      // Skip `.`-prefixed entries (hidden / dotfiles) and `_`-prefixed entries
+      // (user-quarantine convention — e.g. `_pending/` ambient captures) at
+      // BOTH file and directory level. Previously the file-level check
+      // skipped `_foo.md` but the directory recursion still walked into
+      // `_pending/originals/foo.md`, so extract counted quarantined content
+      // that `sync` correctly excluded — "N pages walked" ballooned from 61
+      // to 154 on brains with large `_pending/` trees (issue #202).
       if (entry.startsWith('.')) continue;
+      if (entry.startsWith('_')) continue;
       const full = join(d, entry);
       try {
         if (lstatSync(full).isDirectory()) {
           walk(full);
-        } else if (entry.endsWith('.md') && !entry.startsWith('_')) {
+        } else if (entry.endsWith('.md')) {
           files.push({ path: full, relPath: relative(dir, full) });
         }
       } catch { /* skip unreadable */ }

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -122,4 +122,30 @@ describe('walkMarkdownFiles', () => {
   it('is a function', () => {
     expect(typeof walkMarkdownFiles).toBe('function');
   });
+
+  it('skips _-prefixed directories, matching the _-prefixed file behavior', async () => {
+    // Quarantine convention (e.g. `_pending/` for signal-detector ambient
+    // captures): users extend exclusions to skip these paths on sync. The
+    // walker already skipped `_foo.md` files but still recursed into
+    // `_pending/originals/`, so extract counted quarantined content that
+    // sync excluded (issue #202).
+    const { mkdtempSync, writeFileSync, mkdirSync, rmSync } = await import('fs');
+    const { tmpdir } = await import('os');
+    const { join } = await import('path');
+
+    const root = mkdtempSync(join(tmpdir(), 'gbrain-walk-test-'));
+    try {
+      mkdirSync(join(root, 'concepts'));
+      mkdirSync(join(root, '_pending', 'originals'), { recursive: true });
+      writeFileSync(join(root, 'concepts', 'alpha.md'), '# alpha');
+      writeFileSync(join(root, '_pending', 'ambient.md'), '# ambient');
+      writeFileSync(join(root, '_pending', 'originals', 'buried.md'), '# buried');
+      writeFileSync(join(root, '_skip-me.md'), '# file-level skip');
+
+      const files = walkMarkdownFiles(root).map(f => f.relPath).sort();
+      expect(files).toEqual(['concepts/alpha.md']);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- `gbrain config set openai_api_key <key>` now redacts the value in its confirmation message, matching the redaction logic already used by `config show`
- Keys containing `key`, `secret`, `token`, or `password` print as `***`
- PostgreSQL URLs have their password component redacted

Closes #892

## Test plan

- [x] `bun test test/config.test.ts` passes (8/8)
- [ ] Manual: `gbrain config set openai_api_key sk-test123` should print `Set openai_api_key = ***`
- [ ] Manual: `gbrain config set some_flag true` should print `Set some_flag = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->