### PR TITLE
fix(recipes/openai): add max_batch_tokens to embedding touchpoint

### DIFF
--- a/src/core/ai/recipes/openai.ts
+++ b/src/core/ai/recipes/openai.ts
@@ -17,6 +17,12 @@ export const openai: Recipe = {
       dims_options: [256, 512, 768, 1024, 1536, 3072],
       cost_per_1m_tokens_usd: 0.13,
       price_last_verified: '2026-04-20',
+      // OpenAI per-request hard cap is 300K tokens. Free/Tier-1 TPM is 1M.
+      // Cap batches conservatively at 100K to handle token-dense content
+      // (Discord/Slack markdown+JSON tokenizes at ~chars/2.7, not the chars/4
+      // estimate the batcher uses). 100K estimated = ~150K real tokens worst-case,
+      // safely under both the 300K per-request and 1M TPM ceilings.
+      max_batch_tokens: 100_000,
     },
     expansion: {
       models: ['gpt-5.2', 'gpt-4o-mini'],


### PR DESCRIPTION
# PR: Add max_batch_tokens to OpenAI recipe

## Problem
`src/core/ai/recipes/openai.ts` is the only embedding recipe in the codebase
without a `max_batch_tokens` cap. Every other provider declares one
(voyage=120K, azure-openai=8K, dashscope=8K, zhipu=8K, minimax=4K).

Without `max_batch_tokens`, gbrain's recursive-halving safety net never engages.
The batcher dispatches whatever fits in its char-based estimator window —
typically ~150K-200K tokens per request — and any page with token-dense content
(Discord exports, JSON dumps, code-heavy pages) tips a single request past
OpenAI's 1M-token TPM ceiling. Retry storm follows. First-failed request blocks
the queue head; subsequent passes hit the same fat page first and never progress.

Reproduction:
1. Init brain with Postgres engine.
2. Sync a corpus containing a few discord-full chat exports (~800K chars each).
3. `gbrain embed --stale`.
4. Observe `Rate limit reached ... TPM: Limit 1000000, Used 1000000, Requested 150000`
   on the same 4-5 pages every pass.

## Fix
Add `max_batch_tokens: 100_000` to the OpenAI embedding touchpoint.

Why 100K and not 200K-250K (closer to OpenAI's 300K per-request cap):
- gbrain's batcher estimates tokens as `chars / 4`.
- Token-dense content (markdown+JSON, code blocks, timestamps in Discord/Slack
  dumps) tokenizes at ~chars/2.7. A 100K estimated batch can be ~150K real tokens.
- 100K estimated = ~150K worst-case real, safely under the 300K/request hard cap.
- Also gives recursive-halving room to work on outlier pages without thrashing.

## Diff
```diff
     embedding: {
       models: ['text-embedding-3-large', 'text-embedding-3-small'],
       default_dims: 1536,
       dims_options: [256, 512, 768, 1024, 1536, 3072],
       cost_per_1m_tokens_usd: 0.13,
       price_last_verified: '2026-04-20',
+      max_batch_tokens: 100_000,
     },
```

## Tested
- Local gbrain install (v0.33.0, Postgres+pgvector) cleared its embedding
  queue after the patch where 5 prior passes had been stuck.
- No regression on small batches — recursive-halving only engages when
  estimated batch tokens exceed cap.

## Related
The doctor warning `recipe "google" declares an embedding touchpoint without
max_batch_tokens; recursion is the only safety net for batch caps` is the
exact issue this PR fixes for OpenAI. Google recipe should get the same
treatment — happy to add that in a follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->