### PR TITLE
fix: reject partial embedding responses

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -908,12 +908,20 @@ async function embedSubBatch(
       providerOptions: providerOpts,
     });
 
-    const first = result.embeddings?.[0];
-    if (first && Array.isArray(first) && first.length !== expectedDims) {
+    if (!Array.isArray(result.embeddings) || result.embeddings.length !== texts.length) {
       throw new AIConfigError(
-        `Embedding dim mismatch: model ${modelId} returned ${first.length} but schema expects ${expectedDims}.`,
-        `Run \`gbrain migrate --embedding-model ${getEmbeddingModel()} --embedding-dimensions ${first.length}\` or change models.`,
+        `Embedding provider returned ${result.embeddings?.length ?? 0} embedding(s) for ${texts.length} input(s).`,
+        `Retry the import after checking provider health; partial embedding responses are not safe to index.`,
       );
+    }
+
+    for (const embedding of result.embeddings) {
+      if (Array.isArray(embedding) && embedding.length !== expectedDims) {
+        throw new AIConfigError(
+          `Embedding dim mismatch: model ${modelId} returned ${embedding.length} but schema expects ${expectedDims}.`,
+          `Run \`gbrain migrate --embedding-model ${getEmbeddingModel()} --embedding-dimensions ${embedding.length}\` or change models.`,
+        );
+      }
     }
 
     recordSubBatchSuccess(recipe);

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -3,6 +3,7 @@ import {
   configureGateway,
   resetGateway,
   isAvailable,
+  embed,
   getEmbeddingModel,
   getEmbeddingDimensions,
   getExpansionModel,
@@ -164,5 +165,76 @@ describe('dims.dimsProviderOptions', () => {
   test('Voyage model without flexible dimensions returns undefined', () => {
     const opts = dimsProviderOptions('openai-compatible', 'voyage-3-lite', 1024);
     expect(opts).toBeUndefined();
+  });
+});
+
+describe('embedding response integrity', () => {
+  beforeEach(() => resetGateway());
+
+  test('rejects partial embedding responses instead of silently dropping rows', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      object: 'list',
+      data: [
+        {
+          object: 'embedding',
+          index: 0,
+          embedding: new Array(1536).fill(0.01),
+        },
+      ],
+      model: 'text-embedding-3-large',
+      usage: { prompt_tokens: 3, total_tokens: 3 },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as unknown as typeof fetch;
+
+    try {
+      configureGateway({
+        embedding_model: 'openai:text-embedding-3-large',
+        embedding_dimensions: 1536,
+        env: { OPENAI_API_KEY: 'openai-fake' },
+      });
+
+      await expect(embed(['first', 'second'])).rejects.toThrow('1 embedding(s) for 2 input(s)');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('checks every returned vector dimension, not just the first one', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      object: 'list',
+      data: [
+        {
+          object: 'embedding',
+          index: 0,
+          embedding: new Array(1536).fill(0.01),
+        },
+        {
+          object: 'embedding',
+          index: 1,
+          embedding: new Array(768).fill(0.01),
+        },
+      ],
+      model: 'text-embedding-3-large',
+      usage: { prompt_tokens: 3, total_tokens: 3 },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as unknown as typeof fetch;
+
+    try {
+      configureGateway({
+        embedding_model: 'openai:text-embedding-3-large',
+        embedding_dimensions: 1536,
+        env: { OPENAI_API_KEY: 'openai-fake' },
+      });
+
+      await expect(embed(['first', 'second'])).rejects.toThrow('returned 768 but schema expects 1536');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });


### PR DESCRIPTION
## TL;DR

Fails closed when an embedding provider returns fewer vectors than requested or any returned vector has the wrong dimension. This prevents GBrain from silently misaligning chunk rows with provider output before data reaches `content_chunks.embedding`.

```mermaid
sequenceDiagram
  participant G as GBrain gateway
  participant P as Embedding provider
  participant DB as content_chunks
  G->>P: embedMany([text A, text B])
  P-->>G: [vector A only]
  G--xDB: reject before indexing
```

Closes #925.

## What Changed

- Verifies `result.embeddings` is an array with exactly one vector per input text.
- Verifies every returned vector matches the configured schema dimension, not just the first vector.
- Adds regression tests for partial responses and mixed-dimension responses.

## Why

Embeddings are positional. If two texts go into the provider, two vectors must come back in the same order. A partial response is not a degraded success; it is unsafe to index because downstream code cannot know which chunk was omitted.

Similarly, checking only the first vector lets a mixed-dimension response pass until a later write or query path fails in a less obvious place.

## Non-Goals

- No provider recipe changes.
- No retry-policy changes.
- No schema or migration changes.
- No batching changes.

## Validation

- `git diff --check`
- Attempted focused local test: `bun test test/ai/gateway.test.ts`
  - Could not run in the fresh upstream worktree because dependencies are not installed there: `Cannot find package 'ai'`.
  - GitHub Actions should run the full dependency-backed suite.

## Agent Review Notes

The critical invariant is that `recordSubBatchSuccess(recipe)` is called only after both checks pass:

1. returned vector count equals input text count
2. every returned vector width equals configured `embedding_dimensions`
