### PR TITLE
fix: scope v0.32.2 facts migration dirty checks

### DIFF
--- a/src/commands/migrations/v0_32_2.ts
+++ b/src/commands/migrations/v0_32_2.ts
@@ -137,14 +137,34 @@ function isLocalPathDirty(localPath: string): boolean {
   try {
     const out = execFileSync('git', ['-C', localPath, 'status', '--porcelain'], {
       encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 10_000,
     });
     return out.trim().length > 0;
-  } catch {
+  } catch (err) {
     // Not a git repo OR git not on PATH → treat as "not dirty" (the
     // user opted out of git tracking, which is allowed). The fence
-    // writes are still atomic via .tmp + rename.
-    return false;
+    // writes are still atomic via .tmp + rename. Unknown git failures
+    // fail closed by bubbling up to Phase B.
+    const error = err as {
+      code?: unknown;
+      status?: unknown;
+      stderr?: unknown;
+      message?: unknown;
+    };
+    const code = typeof error.code === 'string' ? error.code : '';
+    const status = typeof error.status === 'number' ? error.status : undefined;
+    const stderr = Buffer.isBuffer(error.stderr)
+      ? error.stderr.toString('utf-8')
+      : typeof error.stderr === 'string'
+        ? error.stderr
+        : '';
+    const message = typeof error.message === 'string' ? error.message : '';
+    const text = `${message}\n${stderr}`;
+    if (code === 'ENOENT' || (status === 128 && /not a git repository/i.test(text))) {
+      return false;
+    }
+    throw err;
   }
 }
 
@@ -179,24 +199,6 @@ async function phaseBFenceFacts(
   }
 
   try {
-    // Look up all sources + their local_paths.
-    const sources = await engine.executeRaw<SourceLookup>(
-      `SELECT id, local_path FROM sources`,
-    );
-    const localPathById = new Map<string, string | null>();
-    for (const s of sources) localPathById.set(s.id, s.local_path);
-
-    // Dirty-tree refusal: check every source's local_path before writing.
-    for (const [id, localPath] of localPathById) {
-      if (localPath && isLocalPathDirty(localPath)) {
-        return {
-          name: 'fence_facts',
-          status: 'failed',
-          detail: `source "${id}" has uncommitted changes in ${localPath}. Commit or stash, then re-run.`,
-        };
-      }
-    }
-
     // Walk legacy rows in (source_id, entity_slug) groups for per-page
     // atomic writes.
     const legacy = await engine.executeRaw<LegacyFactRow>(
@@ -206,7 +208,6 @@ async function phaseBFenceFacts(
         WHERE row_num IS NULL
         ORDER BY source_id, entity_slug, id`,
     );
-
     const outcome: PhaseBOutcome = {
       scanned: legacy.length,
       fenced: 0,
@@ -215,6 +216,24 @@ async function phaseBFenceFacts(
       pages_touched: 0,
       failed_pages: [],
     };
+
+    if (legacy.length === 0) {
+      return {
+        name: 'fence_facts',
+        status: 'complete',
+        detail: `scanned=${outcome.scanned} fenced=${outcome.fenced} ` +
+          `pages=${outcome.pages_touched} skipped_no_entity=${outcome.skipped_no_entity} ` +
+          `skipped_no_local_path=${outcome.skipped_no_local_path}`,
+      };
+    }
+
+    // Look up sources after confirming there is legacy work. Dirty-tree
+    // refusal only applies to source worktrees that will actually be written.
+    const sources = await engine.executeRaw<SourceLookup>(
+      `SELECT id, local_path FROM sources`,
+    );
+    const localPathById = new Map<string, string | null>();
+    for (const s of sources) localPathById.set(s.id, s.local_path);
 
     // Group by (source_id, entity_slug) so each page's fence is updated
     // atomically with all its legacy rows.
@@ -233,6 +252,20 @@ async function phaseBFenceFacts(
       const list = groups.get(key) ?? [];
       list.push(row);
       groups.set(key, list);
+    }
+
+    const sourceIdsToCheck = new Set<string>();
+    for (const key of groups.keys()) sourceIdsToCheck.add(key.split('\0', 1)[0]);
+
+    for (const sourceId of sourceIdsToCheck) {
+      const localPath = localPathById.get(sourceId);
+      if (localPath && isLocalPathDirty(localPath)) {
+        return {
+          name: 'fence_facts',
+          status: 'failed',
+          detail: `source "${sourceId}" has uncommitted changes in ${localPath}. Commit or stash, then re-run.`,
+        };
+      }
     }
 
     for (const [key, group] of groups) {

--- a/test/migrations-v0_32_2.test.ts
+++ b/test/migrations-v0_32_2.test.ts
@@ -72,6 +72,17 @@ async function seedLegacyFact(input: {
   return r.rows[0].id;
 }
 
+function makeDirtyGitWorktree(dir: string): void {
+  const init = Bun.spawnSync({
+    cmd: ['git', 'init'],
+    cwd: dir,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  expect(init.exitCode).toBe(0);
+  writeFileSync(join(dir, 'uncommitted.md'), 'dirty', 'utf-8');
+}
+
 describe('phaseASchema', () => {
   test('passes when schema is at v51', async () => {
     // initSchema ran v51, so the version config + columns are set.
@@ -89,6 +100,19 @@ describe('phaseASchema', () => {
     const r = await __testing.phaseASchema(null, OPTS);
     expect(r.status).toBe('skipped');
     expect(r.detail).toBe('no_brain_configured');
+  });
+});
+
+describe('isLocalPathDirty', () => {
+  test('treats non-git source directories as untracked rather than dirty', () => {
+    expect(__testing.isLocalPathDirty(brainDir)).toBe(false);
+  });
+
+  test('fails closed on unexpected git probe errors', () => {
+    const notDirectory = join(brainDir, 'not-a-directory');
+    writeFileSync(notDirectory, 'file, not directory', 'utf-8');
+
+    expect(() => __testing.isLocalPathDirty(notDirectory)).toThrow();
   });
 });
 
@@ -235,6 +259,59 @@ describe('phaseBFenceFacts — happy path backfill', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const rows = await (engine as any).db.query('SELECT row_num FROM facts');
     expect(rows.rows[0].row_num).toBeNull();
+  });
+
+  test('does not refuse a dirty source when there are no legacy facts to write', async () => {
+    makeDirtyGitWorktree(brainDir);
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('complete');
+    expect(r.detail).toContain('scanned=0');
+    expect(r.detail).toContain('fenced=0');
+  });
+
+  test('does not refuse a dirty source when all legacy facts are structurally unfenceable', async () => {
+    makeDirtyGitWorktree(brainDir);
+    await seedLegacyFact({ entity_slug: null, fact: 'Unparented claim' });
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('complete');
+    expect(r.detail).toContain('skipped_no_entity=1');
+    expect(r.detail).toContain('fenced=0');
+  });
+
+  test('does not refuse a dirty source that has no fenceable writes in this migration', async () => {
+    const unusedDir = mkdtempSync(join(tmpdir(), 'mig-v0_32_2-unused-source-'));
+    try {
+      makeDirtyGitWorktree(unusedDir);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (engine as any).db.query(
+        `INSERT INTO sources (id, name, local_path, config)
+         VALUES ('unused-dirty', 'unused-dirty', $1, '{}'::jsonb)
+         ON CONFLICT (id) DO UPDATE SET local_path = excluded.local_path`,
+        [unusedDir],
+      );
+      await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Default source write only' });
+
+      const r = await __testing.phaseBFenceFacts(engine, OPTS);
+      expect(r.status).toBe('complete');
+      expect(r.detail).toContain('fenced=1');
+      expect(existsSync(join(brainDir, 'people/alice.md'))).toBe(true);
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (engine as any).db.query(`DELETE FROM sources WHERE id = 'unused-dirty'`);
+      rmSync(unusedDir, { recursive: true, force: true });
+    }
+  });
+
+  test('still refuses a dirty source before writing fenceable facts', async () => {
+    makeDirtyGitWorktree(brainDir);
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Needs a fenced write' });
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('failed');
+    expect(r.detail).toContain('source "default" has uncommitted changes');
+    expect(existsSync(join(brainDir, 'people/alice.md'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## TL;DR

Fixes a false-failure path in migration `v0.32.2`: Phase B now queries legacy facts first and dirty-checks only the source worktrees it would actually write. A dirty unrelated source no longer blocks a no-op facts migration or a migration whose fenced writes touch another source.

```mermaid
flowchart LR
  A["legacy facts"] --> B{"fenceable groups?"}
  B -->|"none"| C["complete no-op"]
  B -->|"yes"| D["collect touched source_ids"]
  D --> E["dirty-check touched sources only"]
  E --> F["write fences"]
```

Closes #927. Complements #921 by removing one concrete false-failure case before the CLI error-surface work.

## What Changed

- `isLocalPathDirty()` still treats non-git sources as allowed, but now fails closed on unexpected git probe errors.
- Phase B reads legacy fact rows before dirty-checking source trees.
- Phase B returns complete immediately when there is no legacy work.
- Dirty-tree refusal now applies only to source IDs that have fenceable writes in this migration.
- Adds regression tests for:
  - no legacy facts
  - structurally unfenceable facts
  - unrelated dirty source
  - targeted dirty source refusal
  - unexpected git probe failure

## Why

Dirty-tree refusal is a safety guard for filesystem writes. It should fire when the migration is about to mutate a source, not when a registered source happens to be dirty but irrelevant to this migration pass.

The old order could wedge a healthy install that had nothing to migrate.

## Non-Goals

- Does not change facts schema.
- Does not weaken targeted dirty-tree refusal.
- Does not change #921's CLI detail rendering; this PR removes a false-failure path but does not redesign migration output.

## Validation

- `git diff --check`
- Attempted focused local test: `bun test test/migrations-v0_32_2.test.ts`
  - Could not run in the fresh upstream worktree because dependencies are not installed there: missing `@electric-sql/pglite`.
  - GitHub Actions should run full dependency-backed validation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->