### PR TITLE
fix: scope stale embedding queries by source

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -98,23 +98,21 @@ export async function runEmbedCore(engine: BrainEngine, opts: EmbedOpts): Promis
 }
 
 export async function runEmbed(engine: BrainEngine, args: string[]): Promise<EmbedResult | undefined> {
-  const slugsIdx = args.indexOf('--slugs');
-  const all = args.includes('--all');
-  const stale = args.includes('--stale');
-  const dryRun = args.includes('--dry-run');
-  // v0.31.12: --source <id> scopes to a single source.
-  const sourceIdx = args.indexOf('--source');
-  const sourceId = sourceIdx >= 0 ? args[sourceIdx + 1] : undefined;
+  const { args: filteredArgs, value: sourceId } = extractValueOption(args, '--source');
+  const slugsIdx = filteredArgs.indexOf('--slugs');
+  const all = filteredArgs.includes('--all');
+  const stale = filteredArgs.includes('--stale');
+  const dryRun = filteredArgs.includes('--dry-run');
 
   let opts: EmbedOpts;
   if (slugsIdx >= 0) {
-    opts = { slugs: args.slice(slugsIdx + 1).filter(a => !a.startsWith('--')), dryRun, sourceId };
+    opts = { slugs: filteredArgs.slice(slugsIdx + 1).filter(a => !a.startsWith('--')), dryRun, sourceId };
   } else if (all || stale) {
     opts = { all, stale, dryRun, sourceId };
   } else {
-    const slug = args.find(a => !a.startsWith('--'));
+    const slug = filteredArgs.find(a => !a.startsWith('--'));
     if (!slug) {
-      console.error('Usage: gbrain embed [<slug>|--all|--stale|--slugs s1 s2 ...] [--dry-run]');
+      console.error('Usage: gbrain embed [<slug>|--all|--stale|--slugs s1 s2 ...] [--source id] [--dry-run]');
       process.exit(1);
     }
     opts = { slug, dryRun, sourceId };
@@ -142,6 +140,20 @@ export async function runEmbed(engine: BrainEngine, args: string[]): Promise<Emb
     console.error(e instanceof Error ? e.message : String(e));
     process.exit(1);
   }
+}
+
+function extractValueOption(args: string[], flag: string): { args: string[]; value?: string } {
+  const filtered: string[] = [];
+  let value: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === flag) {
+      value = args[i + 1];
+      i++;
+      continue;
+    }
+    filtered.push(args[i]);
+  }
+  return { args: filtered, value };
 }
 
 async function embedPage(
@@ -246,7 +258,7 @@ async function embedAll(
   // chunks that already have embeddings.
   // ─────────────────────────────────────────────────────────────
   if (staleOnly) {
-    return await embedAllStale(engine, dryRun, result, onProgress);
+    return await embedAllStale(engine, dryRun, result, onProgress, sourceId);
   }
 
   // v0.31.12: when sourceId is set, scope listPages to that source.
@@ -362,10 +374,11 @@ async function embedAllStale(
   dryRun: boolean,
   result: EmbedResult,
   onProgress?: (done: number, total: number, embedded: number) => void,
+  sourceId?: string,
 ) {
   // Pre-flight: 0 stale chunks → nothing to do, no further DB reads.
   // Cheapest possible exit on the autopilot common case.
-  const staleCount = await engine.countStaleChunks();
+  const staleCount = await engine.countStaleChunks(sourceId ? { sourceId } : undefined);
   if (staleCount === 0) {
     if (dryRun) {
       console.log('[dry-run] Would embed 0 chunks (0 stale found)');
@@ -376,18 +389,17 @@ async function embedAllStale(
   }
 
   // Pull only the stale chunks (no embedding column).
-  const staleRows = await engine.listStaleChunks();
-  // v0.31.12: group by composite key (source_id::slug) so same-slug pages
-  // in different sources are embedded independently with correct source_id.
-  const byKey = new Map<string, typeof staleRows>();
+  const staleRows = await engine.listStaleChunks(sourceId ? { sourceId } : undefined);
+  const byPage = new Map<string, { sourceId: string; slug: string; rows: typeof staleRows }>();
   for (const row of staleRows) {
-    const key = `${row.source_id}::${row.slug}`;
-    const list = byKey.get(key);
-    if (list) list.push(row);
-    else byKey.set(key, [row]);
+    const rowSourceId = row.source_id || 'default';
+    const key = `${rowSourceId}\0${row.slug}`;
+    const group = byPage.get(key);
+    if (group) group.rows.push(row);
+    else byPage.set(key, { sourceId: rowSourceId, slug: row.slug, rows: [row] });
   }
 
-  const keys = Array.from(byKey.keys());
+  const groups = Array.from(byPage.values());
   const totalStaleChunks = staleRows.length;
   result.total_chunks += totalStaleChunks;
   // skipped is "chunks we considered and skipped due to having an embedding".
@@ -397,27 +409,21 @@ async function embedAllStale(
 
   if (dryRun) {
     result.would_embed += totalStaleChunks;
-    result.pages_processed += keys.length;
+    result.pages_processed += groups.length;
     if (onProgress) {
       // Emit a single tick to satisfy the contract (CLI progress reporters
       // expect at least one start/finish pair).
-      onProgress(keys.length, keys.length, 0);
+      onProgress(groups.length, groups.length, 0);
     }
-    console.log(`[dry-run] Would embed ${totalStaleChunks} chunks across ${keys.length} pages`);
+    console.log(`[dry-run] Would embed ${totalStaleChunks} chunks across ${groups.length} pages`);
     return;
   }
 
   const CONCURRENCY = parseInt(process.env.GBRAIN_EMBED_CONCURRENCY || '20', 10);
   let processed = 0;
 
-  async function embedOneKey(key: string) {
-    const stale = byKey.get(key)!;
-    // v0.31.12: extract source_id + slug from the stale row so getChunks
-    // and upsertChunks target the correct (source_id, slug) row. Pre-fix,
-    // both calls defaulted to source_id='default', silently discarding
-    // embeddings for every non-default source (e.g. media-corpus).
-    const sourceId = stale[0]?.source_id ?? 'default';
-    const slug = stale[0].slug;
+  async function embedOneGroup(group: { sourceId: string; slug: string; rows: typeof staleRows }) {
+    const stale = group.rows;
     try {
       const embeddings = await embedBatch(stale.map(c => c.chunk_text));
       // CRITICAL: passing ONLY the stale indices to upsertChunks would
@@ -426,7 +432,7 @@ async function embedAllStale(
       // re-fetch existing chunks for this page and merge. Bounded by the
       // stale slug count, not by total slugs — autopilot common case
       // is 0 stale (pre-flight short-circuit, never reaches this path).
-      const existing = await engine.getChunks(slug, { sourceId });
+      const existing = await engine.getChunks(group.slug, { sourceId: group.sourceId });
       const staleIdxToEmbedding = new Map<number, Float32Array>();
       for (let j = 0; j < stale.length; j++) {
         staleIdxToEmbedding.set(stale[j].chunk_index, embeddings[j]);
@@ -440,26 +446,26 @@ async function embedAllStale(
         embedding: staleIdxToEmbedding.get(c.chunk_index) ?? undefined,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
-      await engine.upsertChunks(slug, merged, { sourceId });
+      await engine.upsertChunks(group.slug, merged, { sourceId: group.sourceId });
       result.embedded += stale.length;
     } catch (e: unknown) {
-      console.error(`\n  Error embedding ${slug}: ${e instanceof Error ? e.message : e}`);
+      console.error(`\n  Error embedding ${group.sourceId}:${group.slug}: ${e instanceof Error ? e.message : e}`);
     }
     processed++;
     result.pages_processed++;
-    onProgress?.(processed, keys.length, result.embedded);
+    onProgress?.(processed, groups.length, result.embedded);
   }
 
   let nextIdx = 0;
   async function worker() {
-    while (nextIdx < keys.length) {
+    while (nextIdx < groups.length) {
       const idx = nextIdx++;
-      await embedOneKey(keys[idx]);
+      await embedOneGroup(groups[idx]);
     }
   }
 
-  const numWorkers = Math.min(CONCURRENCY, keys.length);
+  const numWorkers = Math.min(CONCURRENCY, groups.length);
   await Promise.all(Array.from({ length: numWorkers }, () => worker()));
 
-  console.log(`Embedded ${result.embedded} chunks across ${keys.length} pages`);
+  console.log(`Embedded ${result.embedded} chunks across ${groups.length} pages`);
 }

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -537,7 +537,7 @@ export interface BrainEngine {
    * Pre-flight short-circuit for `embed --stale` so a 100%-embedded brain
    * does no further work after a single SELECT count(*) (~50 bytes wire).
    */
-  countStaleChunks(): Promise<number>;
+  countStaleChunks(opts?: { sourceId?: string }): Promise<number>;
   /**
    * Return every chunk where embedded_at IS NULL, with the metadata needed
    * to call embedBatch + upsertChunks. The `embedding` column is omitted
@@ -546,7 +546,7 @@ export interface BrainEngine {
    *
    * Bounded by an internal LIMIT of 100000 to mirror listPages.
    */
-  listStaleChunks(): Promise<StaleChunkRow[]>;
+  listStaleChunks(opts?: { sourceId?: string }): Promise<StaleChunkRow[]>;
   /**
    * Delete every chunk for a page. Internal page-id lookup is sourceId-scoped
    * when `opts.sourceId` is given; otherwise the bare-slug subquery returns

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1257,25 +1257,39 @@ export class PGLiteEngine implements BrainEngine {
     return (rows as Record<string, unknown>[]).map(r => rowToChunk(r));
   }
 
-  async countStaleChunks(): Promise<number> {
+  async countStaleChunks(opts?: { sourceId?: string }): Promise<number> {
+    const params: unknown[] = [];
+    const sourceJoin = opts?.sourceId ? 'JOIN pages p ON p.id = cc.page_id' : '';
+    const sourceWhere = opts?.sourceId ? 'AND p.source_id = $1' : '';
+    if (opts?.sourceId) params.push(opts.sourceId);
     const { rows } = await this.db.query(
       `SELECT count(*)::int AS count
-         FROM content_chunks
-        WHERE embedding IS NULL`,
+         FROM content_chunks cc
+         ${sourceJoin}
+        WHERE cc.embedding IS NULL
+          AND COALESCE(cc.modality, 'text') <> 'image'
+          ${sourceWhere}`,
+      params,
     );
     const count = (rows[0] as { count: number } | undefined)?.count ?? 0;
     return Number(count);
   }
 
-  async listStaleChunks(): Promise<StaleChunkRow[]> {
+  async listStaleChunks(opts?: { sourceId?: string }): Promise<StaleChunkRow[]> {
+    const params: unknown[] = [];
+    const sourceWhere = opts?.sourceId ? 'AND p.source_id = $1' : '';
+    if (opts?.sourceId) params.push(opts.sourceId);
     const { rows } = await this.db.query(
-      `SELECT p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
-              cc.model, cc.token_count, p.source_id
+      `SELECT p.slug, p.source_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+              cc.model, cc.token_count
          FROM content_chunks cc
          JOIN pages p ON p.id = cc.page_id
         WHERE cc.embedding IS NULL
+          AND COALESCE(cc.modality, 'text') <> 'image'
+          ${sourceWhere}
         ORDER BY p.id, cc.chunk_index
         LIMIT 100000`,
+      params,
     );
     return rows as unknown as StaleChunkRow[];
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1237,24 +1237,32 @@ export class PostgresEngine implements BrainEngine {
     return rows.map((r) => rowToChunk(r as Record<string, unknown>));
   }
 
-  async countStaleChunks(): Promise<number> {
+  async countStaleChunks(opts?: { sourceId?: string }): Promise<number> {
     const sql = this.sql;
+    const sourceJoin = opts?.sourceId ? sql`JOIN pages p ON p.id = cc.page_id` : sql``;
+    const sourceCondition = opts?.sourceId ? sql`AND p.source_id = ${opts.sourceId}` : sql``;
     const [row] = await sql`
       SELECT count(*)::int AS count
-      FROM content_chunks
-      WHERE embedding IS NULL
+      FROM content_chunks cc
+      ${sourceJoin}
+      WHERE cc.embedding IS NULL
+        AND COALESCE(cc.modality, 'text') <> 'image'
+        ${sourceCondition}
     `;
     return Number((row as { count?: number } | undefined)?.count ?? 0);
   }
 
-  async listStaleChunks(): Promise<StaleChunkRow[]> {
+  async listStaleChunks(opts?: { sourceId?: string }): Promise<StaleChunkRow[]> {
     const sql = this.sql;
+    const sourceCondition = opts?.sourceId ? sql`AND p.source_id = ${opts.sourceId}` : sql``;
     const rows = await sql`
-      SELECT p.slug, cc.chunk_index, cc.chunk_text, cc.chunk_source,
-             cc.model, cc.token_count, p.source_id
+      SELECT p.slug, p.source_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+             cc.model, cc.token_count
       FROM content_chunks cc
       JOIN pages p ON p.id = cc.page_id
       WHERE cc.embedding IS NULL
+        AND COALESCE(cc.modality, 'text') <> 'image'
+        ${sourceCondition}
       ORDER BY p.id, cc.chunk_index
       LIMIT 100000
     `;

--- a/test/embed-stale-source.test.ts
+++ b/test/embed-stale-source.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+mock.module('../src/core/embedding.ts', () => ({
+  embedBatch: async (texts: string[]) => texts.map(() => new Float32Array(1536)),
+}));
+
+describe('embed --stale source scoping', () => {
+  test('runEmbedCore threads stale source_id into chunk reads and writes', async () => {
+    const { runEmbedCore } = await import('../src/commands/embed.ts');
+    const calls: Array<{ method: string; slug: string; sourceId?: string }> = [];
+    const chunks = [{
+      chunk_index: 0,
+      chunk_text: 'support kb text',
+      chunk_source: 'compiled_truth' as const,
+      embedded_at: null,
+      token_count: 4,
+    }];
+    const engine = {
+      countStaleChunks: async () => 1,
+      listStaleChunks: async () => [{
+        source_id: 'openclaw-support-kb',
+        slug: 'shared-slug',
+        chunk_index: 0,
+        chunk_text: 'support kb text',
+        chunk_source: 'compiled_truth' as const,
+        model: null,
+        token_count: 4,
+      }],
+      getChunks: async (slug: string, opts?: { sourceId?: string }) => {
+        calls.push({ method: 'getChunks', slug, sourceId: opts?.sourceId });
+        return chunks;
+      },
+      upsertChunks: async (slug: string, _chunks: unknown[], opts?: { sourceId?: string }) => {
+        calls.push({ method: 'upsertChunks', slug, sourceId: opts?.sourceId });
+      },
+    };
+
+    await runEmbedCore(engine as never, { stale: true });
+
+    expect(calls).toEqual([
+      { method: 'getChunks', slug: 'shared-slug', sourceId: 'openclaw-support-kb' },
+      { method: 'upsertChunks', slug: 'shared-slug', sourceId: 'openclaw-support-kb' },
+    ]);
+  });
+
+  test('runEmbedCore scopes stale count/list queries when sourceId is provided', async () => {
+    const { runEmbedCore } = await import('../src/commands/embed.ts');
+    const staleQueryOpts: Array<{ sourceId?: string } | undefined> = [];
+    const engine = {
+      countStaleChunks: async (opts?: { sourceId?: string }) => {
+        staleQueryOpts.push(opts);
+        return 0;
+      },
+      listStaleChunks: async (opts?: { sourceId?: string }) => {
+        staleQueryOpts.push(opts);
+        return [];
+      },
+    };
+
+    await runEmbedCore(engine as never, { stale: true, sourceId: 'openclaw-support-kb' });
+
+    expect(staleQueryOpts).toEqual([{ sourceId: 'openclaw-support-kb' }]);
+  });
+});


### PR DESCRIPTION
## TL;DR

Makes `gbrain embed --stale --source <id>` actually source-scoped from SQL preflight through chunk writes. The stale fast path now counts/lists only stale chunks for the requested source, excludes image rows from text embedding staleness, and groups work by `(source_id, slug)` before calling `getChunks`/`upsertChunks`.

```mermaid
sequenceDiagram
  participant CLI as embed --stale --source kb
  participant DB as content_chunks + pages
  participant Emb as embedBatch
  CLI->>DB: countStaleChunks({sourceId:"kb"})
  CLI->>DB: listStaleChunks({sourceId:"kb"})
  CLI->>DB: getChunks(slug,{sourceId:"kb"})
  CLI->>Emb: embed stale text chunks
  CLI->>DB: upsertChunks(slug,chunks,{sourceId:"kb"})
```

Closes #929.

## What Changed

- Adds optional `{ sourceId }` to `BrainEngine.countStaleChunks()` and `BrainEngine.listStaleChunks()`.
- Implements source filters in Postgres and PGLite stale chunk queries.
- Filters out image-modality rows from text stale embedding checks.
- Threads `sourceId` through `embedAllStale()`.
- Groups stale rows by composite `(source_id, slug)` identity.
- Adds a focused test proving stale rows from `openclaw-support-kb` write back to that source, not `default`.

## Why

`--source` should be a cost and correctness boundary. If a support KB refresh runs every few minutes, it should not scan or touch unrelated user sources. And because GBrain supports duplicate slugs across sources, stale embedding must never use bare slug as the page identity.

## Non-Goals

- Does not change `sync` behavior.
- Does not change full `embed --all` semantics.
- Does not change provider or batching behavior.
- Does not attempt to solve every open source-isolation issue.

## Validation

- `git diff --check`
- `bun test test/embed-stale-source.test.ts`

## Agent Review Notes

Review the boundary from SQL to write:

1. source filter is applied in count/list queries
2. stale rows retain `source_id`
3. groups are keyed by `source_id + slug`
4. `getChunks()` and `upsertChunks()` receive that same source ID

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->