### PR TITLE
feat: add Codex Desktop plugin package

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ GBrain exposes 30+ MCP tools via stdio:
 
 Add to `~/.claude/server.json` (Claude Code), Settings > MCP Servers (Cursor), or your client's MCP config.
 
+### Codex Desktop plugin
+
+GBrain also ships a thin local Codex Desktop plugin package at
+[`plugins/gbrain-codex`](plugins/gbrain-codex/). It launches the canonical
+`gbrain serve` stdio MCP server; it does not embed a second runtime.
+
+```bash
+bun install
+bun link
+node scripts/install-codex-plugin.mjs
+```
+
+Then restart Codex Desktop. The installer creates `~/plugins/gbrain-codex`,
+links the repo skill tree, and updates `~/.agents/plugins/marketplace.json`.
+Run `node plugins/gbrain-codex/scripts/rehearsal.mjs` from the repo root for a
+local smoke test.
+
 ### Remote MCP with OAuth 2.1 (ChatGPT, Claude Desktop, Cowork, Perplexity)
 
 `gbrain serve --http` starts a production-grade OAuth 2.1 server with an embedded admin dashboard. Zero external infrastructure. Every major AI client connects, every request is scoped, every action is logged.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1954,6 +1954,23 @@ GBrain exposes 30+ MCP tools via stdio:
 
 Add to `~/.claude/server.json` (Claude Code), Settings > MCP Servers (Cursor), or your client's MCP config.
 
+### Codex Desktop plugin
+
+GBrain also ships a thin local Codex Desktop plugin package at
+[`plugins/gbrain-codex`](plugins/gbrain-codex/). It launches the canonical
+`gbrain serve` stdio MCP server; it does not embed a second runtime.
+
+```bash
+bun install
+bun link
+node scripts/install-codex-plugin.mjs
+```
+
+Then restart Codex Desktop. The installer creates `~/plugins/gbrain-codex`,
+links the repo skill tree, and updates `~/.agents/plugins/marketplace.json`.
+Run `node plugins/gbrain-codex/scripts/rehearsal.mjs` from the repo root for a
+local smoke test.
+
 ### Remote MCP with OAuth 2.1 (ChatGPT, Claude Desktop, Cowork, Perplexity)
 
 `gbrain serve --http` starts a production-grade OAuth 2.1 server with an embedded admin dashboard. Zero external infrastructure. Every major AI client connects, every request is scoped, every action is logged.

--- a/plugins/gbrain-codex/.codex-plugin/plugin.json
+++ b/plugins/gbrain-codex/.codex-plugin/plugin.json
@@ -1,0 +1,46 @@
+{
+  "name": "gbrain-codex",
+  "version": "0.33.0",
+  "description": "Full-surface Codex Desktop adapter for a local GBrain install.",
+  "author": {
+    "name": "GBrain",
+    "url": "https://github.com/garrytan/gbrain"
+  },
+  "homepage": "https://github.com/garrytan/gbrain",
+  "repository": "https://github.com/garrytan/gbrain",
+  "license": "MIT",
+  "keywords": [
+    "gbrain",
+    "codex",
+    "mcp",
+    "knowledge-base",
+    "search",
+    "agent"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "GBrain",
+    "shortDescription": "Use a local GBrain from Codex Desktop",
+    "longDescription": "GBrain for Codex Desktop is a thin local adapter over an already-installed GBrain CLI. It launches `gbrain serve`, exposes the same MCP tools GBrain already serves to other hosts, and uses the repo's current skillpack so Codex can search, write, sync, and operate the brain with upstream behavior.",
+    "developerName": "GBrain",
+    "category": "Engineering",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/garrytan/gbrain",
+    "privacyPolicyURL": "https://github.com/garrytan/gbrain/blob/master/SECURITY.md",
+    "termsOfServiceURL": "https://github.com/garrytan/gbrain/blob/master/LICENSE",
+    "defaultPrompt": [
+      "Search my GBrain for prior context on this topic",
+      "Write this note into GBrain and link it correctly",
+      "Sync the brain and tell me what changed"
+    ],
+    "brandColor": "#2563EB",
+    "composerIcon": "./assets/gbrain-codex.svg",
+    "logo": "./assets/gbrain-codex.svg",
+    "screenshots": []
+  }
+}

--- a/plugins/gbrain-codex/.mcp.json
+++ b/plugins/gbrain-codex/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "gbrain-codex": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "./scripts/launch-gbrain-serve.mjs"
+      ],
+      "cwd": "."
+    }
+  }
+}

--- a/plugins/gbrain-codex/README.md
+++ b/plugins/gbrain-codex/README.md
@@ -1,0 +1,84 @@
+# GBrain for Codex Desktop
+
+This package makes GBrain available to Codex Desktop as a local plugin.
+
+It is intentionally thin:
+
+- Codex launches `node ./scripts/launch-gbrain-serve.mjs`
+- that launcher resolves a local `gbrain` executable
+- then it runs the canonical server via `gbrain serve`
+
+There is no second MCP server here, and no forked search or write logic inside
+the plugin package. Codex sees the same GBrain MCP surface that other stdio
+hosts see.
+
+## What You Get
+
+- the current GBrain MCP tool surface
+- the current repo skill tree, linked into the installed plugin by
+  `scripts/install-codex-plugin.mjs`
+- the same remote/untrusted MCP behavior GBrain already applies to stdio calls
+
+## Resolution Order
+
+The launcher resolves `gbrain` in this order:
+
+1. `GBRAIN_CODEX_BIN`
+2. repo-local `bin/gbrain`
+3. `gbrain` on `PATH` with `$HOME/.bun/bin` prepended
+
+If none resolve, the launcher fails with an install hint. This plugin is an
+adapter over a local GBrain install, not a standalone runtime bundle.
+
+## Install In Codex Desktop
+
+From the GBrain repo root:
+
+```bash
+bun install
+bun link
+node scripts/install-codex-plugin.mjs
+```
+
+Then restart Codex Desktop.
+
+The installer creates `~/plugins/gbrain-codex`, links this package plus the
+repo's current `skills/` tree, and updates
+`~/.agents/plugins/marketplace.json`.
+
+For a fresh checkout:
+
+```bash
+git clone https://github.com/garrytan/gbrain.git ~/gbrain
+cd ~/gbrain
+bun install
+bun link
+node scripts/install-codex-plugin.mjs
+```
+
+Restart Codex Desktop after install so the local marketplace entry reloads.
+
+## Local Repo Smoke
+
+From the GBrain repo root:
+
+```bash
+bun install
+test -x "$HOME/.bun/bin/gbrain" || bun link
+node plugins/gbrain-codex/scripts/rehearsal.mjs
+```
+
+The rehearsal script creates a temp `GBRAIN_HOME`, initializes PGLite, connects
+to the plugin over stdio MCP, checks `tools/list`, and exercises `put_page`,
+`get_page`, `search`, `query`, `sync_brain`, and the `whoami` fail-closed path.
+
+## Safety Boundary
+
+This plugin does not add or loosen GBrain permissions.
+
+- Codex calls arrive through MCP stdio
+- GBrain treats those calls as `remote: true`
+- operation-level guards stay inside GBrain core
+
+That means Codex gets the full tool surface, but the same stdio-MCP trust
+boundary and restrictions still apply.

--- a/plugins/gbrain-codex/assets/gbrain-codex.svg
+++ b/plugins/gbrain-codex/assets/gbrain-codex.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="GBrain">
+  <rect width="128" height="128" rx="28" fill="#0f172a"/>
+  <path d="M36 71c-10-4-16-12-16-23 0-15 12-27 28-27 6 0 12 2 17 6 5-4 11-6 17-6 16 0 28 12 28 27 0 11-6 19-16 23" fill="none" stroke="#60a5fa" stroke-width="8" stroke-linecap="round"/>
+  <path d="M35 75c4 18 16 29 29 29s25-11 29-29" fill="none" stroke="#34d399" stroke-width="8" stroke-linecap="round"/>
+  <path d="M45 48h38M45 64h38M53 80h22" fill="none" stroke="#e2e8f0" stroke-width="7" stroke-linecap="round"/>
+</svg>

--- a/plugins/gbrain-codex/package.json
+++ b/plugins/gbrain-codex/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "gbrain-codex",
+  "version": "0.33.0",
+  "description": "Codex Desktop local plugin adapter for GBrain.",
+  "type": "module",
+  "private": true,
+  "files": [
+    ".codex-plugin/plugin.json",
+    ".mcp.json",
+    "README.md",
+    "assets",
+    "scripts"
+  ],
+  "scripts": {
+    "rehearsal": "node ./scripts/rehearsal.mjs"
+  },
+  "license": "MIT"
+}

--- a/plugins/gbrain-codex/scripts/launch-gbrain-serve.mjs
+++ b/plugins/gbrain-codex/scripts/launch-gbrain-serve.mjs
@@ -1,0 +1,148 @@
+import { spawn } from 'node:child_process';
+import { accessSync, constants, existsSync } from 'node:fs';
+import { userInfo } from 'node:os';
+import { delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const PLUGIN_ROOT = resolve(dirname(SCRIPT_PATH), '..');
+
+function isExecutable(path) {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolvePathCandidate(candidate) {
+  if (!candidate) return null;
+  return isAbsolute(candidate) ? candidate : resolve(candidate);
+}
+
+function resolveOnPath(binaryName, pathValue) {
+  for (const dir of String(pathValue || '').split(delimiter).filter(Boolean)) {
+    const candidate = join(dir, binaryName);
+    if (isExecutable(candidate)) return candidate;
+  }
+  return null;
+}
+
+export function prependBunBinToPath(pathValue = '', home = '') {
+  const existing = String(pathValue || '').split(delimiter).filter(Boolean);
+  const candidates = [];
+  if (home) candidates.push(join(home, '.bun', 'bin'));
+
+  try {
+    const realHome = userInfo().homedir;
+    if (realHome) candidates.push(join(realHome, '.bun', 'bin'));
+  } catch {
+    // Best effort only; PATH fallback still applies below.
+  }
+
+  const seen = new Set();
+  const bunBins = candidates.filter(entry => {
+    if (!entry || seen.has(entry)) return false;
+    seen.add(entry);
+    return true;
+  });
+
+  const deduped = existing.filter(entry => !seen.has(entry));
+  return [...bunBins, ...deduped].join(delimiter);
+}
+
+export function buildServeArgs(extraArgs = []) {
+  return ['serve', ...extraArgs];
+}
+
+function gbrainConfigPath(home) {
+  return home ? join(home, '.gbrain', 'config.json') : '';
+}
+
+export function resolveGbrainHome(env = process.env) {
+  const explicit = env.GBRAIN_HOME;
+  if (explicit) return explicit;
+
+  const envHome = env.HOME || '';
+  if (envHome && existsSync(gbrainConfigPath(envHome))) return envHome;
+
+  try {
+    const realHome = userInfo().homedir;
+    if (realHome && existsSync(gbrainConfigPath(realHome))) return realHome;
+  } catch {
+    // Best effort only; gbrain will surface its own config error if absent.
+  }
+
+  return undefined;
+}
+
+export function resolveGbrainExecutable({
+  pluginRoot = PLUGIN_ROOT,
+  env = process.env,
+} = {}) {
+  const pathValue = prependBunBinToPath(env.PATH || '', env.HOME || '');
+  const envOverride = resolvePathCandidate(env.GBRAIN_CODEX_BIN);
+  if (envOverride) {
+    if (!isExecutable(envOverride)) {
+      throw new Error(
+        `GBRAIN_CODEX_BIN points to a non-executable path: ${envOverride}\n` +
+        `The Codex GBrain plugin is an adapter over a local GBrain install. ` +
+        `Set GBRAIN_CODEX_BIN to a working gbrain binary, build ./bin/gbrain in this repo, or put gbrain on PATH.`,
+      );
+    }
+    return { command: envOverride, source: 'env', envPath: pathValue };
+  }
+
+  const repoCandidate = resolve(pluginRoot, '..', '..', 'bin', 'gbrain');
+  if (isExecutable(repoCandidate)) {
+    return { command: repoCandidate, source: 'repo', envPath: pathValue };
+  }
+
+  const pathCandidate = resolveOnPath('gbrain', pathValue);
+  if (pathCandidate) {
+    return { command: pathCandidate, source: 'path', envPath: pathValue };
+  }
+
+  throw new Error(
+    `Could not resolve a local gbrain executable.\n` +
+    `The Codex GBrain plugin is an adapter over a local GBrain install.\n` +
+    `Tried, in order:\n` +
+    `  1. GBRAIN_CODEX_BIN\n` +
+    `  2. ${repoCandidate}\n` +
+    `  3. gbrain on PATH (with $HOME/.bun/bin prepended)\n` +
+    `Fix one of these and try again. Typical local setup is:\n` +
+    `  bun install && bun run build && bun link`,
+  );
+}
+
+export async function main(argv = process.argv.slice(2), env = process.env) {
+  const resolved = resolveGbrainExecutable({ pluginRoot: PLUGIN_ROOT, env });
+  const gbrainHome = resolveGbrainHome(env);
+  const child = spawn(resolved.command, buildServeArgs(argv), {
+    cwd: process.cwd(),
+    env: {
+      ...env,
+      ...(gbrainHome ? { GBRAIN_HOME: gbrainHome } : {}),
+      PATH: resolved.envPath,
+    },
+    stdio: 'inherit',
+  });
+
+  child.on('error', err => {
+    process.stderr.write(`[gbrain-codex] failed to launch gbrain: ${err.message}\n`);
+    process.exit(1);
+  });
+
+  child.on('exit', (code, signal) => {
+    if (signal) process.kill(process.pid, signal);
+    process.exit(code ?? 0);
+  });
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === SCRIPT_PATH) {
+  main().catch(err => {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/plugins/gbrain-codex/scripts/rehearsal.mjs
+++ b/plugins/gbrain-codex/scripts/rehearsal.mjs
@@ -1,0 +1,184 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+import { resolveGbrainExecutable } from './launch-gbrain-serve.mjs';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const PLUGIN_ROOT = resolve(dirname(SCRIPT_PATH), '..');
+const REPO_ROOT = resolve(PLUGIN_ROOT, '..', '..');
+
+function textContent(result) {
+  const first = Array.isArray(result?.content) ? result.content[0] : null;
+  return first && first.type === 'text' ? first.text : '';
+}
+
+function runAndCapture(command, args, env) {
+  const result = spawnSync(command, args, {
+    env,
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `Command failed: ${command} ${args.join(' ')}\n` +
+      `${result.stderr || result.stdout || '(no output)'}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function ensureTempBrain(command, env) {
+  runAndCapture(command, ['init', '--pglite', '--non-interactive', '--json'], env);
+}
+
+function expectedToolNames(command, env) {
+  const raw = runAndCapture(command, ['--tools-json'], env);
+  return JSON.parse(raw).map(tool => tool.name);
+}
+
+function createSourceTreeWrapper() {
+  const wrapperDir = mkdtempSync(join(tmpdir(), 'gbrain-codex-wrapper-'));
+  const wrapperPath = join(wrapperDir, 'gbrain');
+  writeFileSync(
+    wrapperPath,
+    `#!/bin/sh
+cd ${JSON.stringify(REPO_ROOT)}
+exec bun run src/cli.ts "$@"
+`,
+  );
+  chmodSync(wrapperPath, 0o755);
+  return { wrapperDir, wrapperPath };
+}
+
+export async function runRehearsal({ env = process.env } = {}) {
+  const wrapper = !env.GBRAIN_CODEX_BIN ? createSourceTreeWrapper() : null;
+  const resolvedEnv = wrapper
+    ? { ...env, GBRAIN_CODEX_BIN: wrapper.wrapperPath }
+    : env;
+  const resolvedBin = resolveGbrainExecutable({ pluginRoot: PLUGIN_ROOT, env: resolvedEnv });
+  const rehearsalHome = mkdtempSync(join(tmpdir(), 'gbrain-codex-home-'));
+  const runtimeEnv = {
+    ...resolvedEnv,
+    PATH: resolvedBin.envPath,
+    GBRAIN_HOME: rehearsalHome,
+  };
+
+  try {
+    ensureTempBrain(resolvedBin.command, runtimeEnv);
+    const expectedNames = expectedToolNames(resolvedBin.command, runtimeEnv);
+
+    const transport = new StdioClientTransport({
+      command: 'node',
+      args: ['./scripts/launch-gbrain-serve.mjs'],
+      cwd: PLUGIN_ROOT,
+      env: runtimeEnv,
+      stderr: 'pipe',
+    });
+    const client = new Client(
+      { name: 'gbrain-codex-rehearsal', version: '1.0.0' },
+      { capabilities: {} },
+    );
+
+    const stderrLines = [];
+    if (transport.stderr) {
+      transport.stderr.on('data', chunk => stderrLines.push(String(chunk)));
+    }
+
+    await client.connect(transport);
+    try {
+      const listed = await client.listTools();
+      const actualNames = listed.tools.map(tool => tool.name);
+      if (actualNames.length !== expectedNames.length) {
+        throw new Error(`tools/list count mismatch: expected ${expectedNames.length}, got ${actualNames.length}`);
+      }
+      if (JSON.stringify(actualNames) !== JSON.stringify(expectedNames)) {
+        throw new Error('tools/list names do not match gbrain --tools-json exactly');
+      }
+
+      const put = await client.callTool({
+        name: 'put_page',
+        arguments: {
+          slug: 'notes/codex-plugin-rehearsal',
+          content: [
+            '---',
+            'title: Codex Plugin Rehearsal',
+            'type: note',
+            '---',
+            '',
+            'Codex plugin rehearsal page.',
+          ].join('\n'),
+        },
+      });
+      if (put.isError) throw new Error(`put_page failed: ${textContent(put)}`);
+
+      const get = await client.callTool({
+        name: 'get_page',
+        arguments: { slug: 'notes/codex-plugin-rehearsal' },
+      });
+      if (get.isError || !textContent(get).includes('codex-plugin-rehearsal')) {
+        throw new Error(`get_page failed: ${textContent(get)}`);
+      }
+
+      const search = await client.callTool({
+        name: 'search',
+        arguments: { query: 'Codex plugin rehearsal page' },
+      });
+      if (search.isError) throw new Error(`search failed: ${textContent(search)}`);
+
+      const query = await client.callTool({
+        name: 'query',
+        arguments: { query: 'What page mentions Codex plugin rehearsal?' },
+      });
+      if (query.isError) throw new Error(`query failed: ${textContent(query)}`);
+
+      const sync = await client.callTool({
+        name: 'sync_brain',
+        arguments: {
+          repo: REPO_ROOT,
+          dry_run: true,
+          no_pull: true,
+          no_embed: true,
+        },
+      });
+      if (sync.isError) throw new Error(`sync_brain dry-run failed: ${textContent(sync)}`);
+
+      const whoami = await client.callTool({
+        name: 'whoami',
+        arguments: {},
+      });
+      if (!whoami.isError || !textContent(whoami).includes('unknown_transport')) {
+        throw new Error(`whoami should fail closed over stdio MCP, got: ${textContent(whoami)}`);
+      }
+
+      return {
+        ok: true,
+        toolCount: actualNames.length,
+        sampleTools: ['put_page', 'get_page', 'search', 'query', 'sync_brain', 'whoami'],
+        stderr: stderrLines.join('').trim(),
+      };
+    } finally {
+      try {
+        await client.close();
+      } catch {
+        // best-effort
+      }
+    }
+  } finally {
+    rmSync(rehearsalHome, { recursive: true, force: true });
+    if (wrapper) rmSync(wrapper.wrapperDir, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === SCRIPT_PATH) {
+  runRehearsal().then(result => {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  }).catch(err => {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/install-codex-plugin.mjs
+++ b/scripts/install-codex-plugin.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(SCRIPT_PATH), '..');
+
+function usage() {
+  process.stdout.write(`Usage: node scripts/install-codex-plugin.mjs [options]
+
+Installs or updates the repo-owned gbrain-codex plugin for Codex Desktop by
+creating ~/plugins/gbrain-codex and updating ~/.agents/plugins/marketplace.json.
+
+Options:
+  --repo-dir <path>       GBrain checkout root (default: current repo)
+  --home <path>           Home directory to update (default: $HOME)
+  --dry-run               Print intended actions without writing
+  --force                 Replace an existing non-GBrain gbrain-codex directory
+  -h, --help              Show this help
+`);
+}
+
+function parseArgs(argv) {
+  const requireValue = (flag, value) => {
+    if (!value || value.startsWith('-')) {
+      throw new Error(`Missing value for ${flag}`);
+    }
+    return value;
+  };
+
+  const opts = {
+    repoDir: REPO_ROOT,
+    home: process.env.HOME || '',
+    dryRun: false,
+    force: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--repo-dir') opts.repoDir = resolve(requireValue('--repo-dir', argv[++i]));
+    else if (arg === '--home') opts.home = resolve(requireValue('--home', argv[++i]));
+    else if (arg === '--dry-run') opts.dryRun = true;
+    else if (arg === '--force') opts.force = true;
+    else if (arg === '-h' || arg === '--help') {
+      usage();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  if (!opts.home) throw new Error('Could not resolve home directory. Pass --home <path>.');
+  return opts;
+}
+
+function log(message) {
+  process.stderr.write(`[gbrain-codex:install] ${message}\n`);
+}
+
+function runStep(opts, message, fn) {
+  log(message);
+  if (!opts.dryRun) fn();
+}
+
+function assertRepoShape(repoDir) {
+  const pluginRoot = join(repoDir, 'plugins', 'gbrain-codex');
+  const manifest = join(pluginRoot, '.codex-plugin', 'plugin.json');
+  const mcp = join(pluginRoot, '.mcp.json');
+  const skills = join(repoDir, 'skills');
+  for (const path of [manifest, mcp, skills]) {
+    if (!existsSync(path)) throw new Error(`Required path is missing: ${path}`);
+  }
+  const parsed = JSON.parse(readFileSync(manifest, 'utf8'));
+  if (parsed.name !== 'gbrain-codex') {
+    throw new Error(`Unexpected Codex plugin name in ${manifest}: ${parsed.name}`);
+  }
+  return { pluginRoot, manifest, mcp, skills };
+}
+
+function safeRemovePluginDir(pluginDir, force) {
+  let stat;
+  try {
+    stat = lstatSync(pluginDir);
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') return;
+    throw error;
+  }
+  if (stat.isSymbolicLink()) {
+    rmSync(pluginDir, { force: true });
+    return;
+  }
+
+  const manifest = join(pluginDir, '.codex-plugin', 'plugin.json');
+  if (!force && existsSync(manifest)) {
+    try {
+      const parsed = JSON.parse(readFileSync(manifest, 'utf8'));
+      if (parsed.name === 'gbrain-codex') {
+        rmSync(pluginDir, { recursive: true, force: true });
+        return;
+      }
+    } catch {
+      // Fall through to the guarded error below.
+    }
+  }
+
+  if (!force) {
+    throw new Error(
+      `Refusing to replace existing plugin directory: ${pluginDir}\n` +
+      `Pass --force if this directory is safe to replace.`,
+    );
+  }
+  rmSync(pluginDir, { recursive: true, force: true });
+}
+
+function linkEntry(src, dest) {
+  mkdirSync(dirname(dest), { recursive: true });
+  symlinkSync(src, dest);
+}
+
+function installPluginTree(opts, paths) {
+  const pluginsDir = join(opts.home, 'plugins');
+  const pluginDir = join(pluginsDir, 'gbrain-codex');
+  runStep(opts, `Installing Codex plugin into ${pluginDir}`, () => {
+    mkdirSync(pluginsDir, { recursive: true });
+    safeRemovePluginDir(pluginDir, opts.force);
+    mkdirSync(pluginDir, { recursive: true });
+    linkEntry(join(paths.pluginRoot, '.codex-plugin'), join(pluginDir, '.codex-plugin'));
+    linkEntry(join(paths.pluginRoot, '.mcp.json'), join(pluginDir, '.mcp.json'));
+    linkEntry(join(paths.pluginRoot, 'README.md'), join(pluginDir, 'README.md'));
+    linkEntry(join(paths.pluginRoot, 'assets'), join(pluginDir, 'assets'));
+    linkEntry(join(paths.pluginRoot, 'scripts'), join(pluginDir, 'scripts'));
+    linkEntry(paths.skills, join(pluginDir, 'skills'));
+  });
+  return pluginDir;
+}
+
+function marketplacePath(home) {
+  return join(home, '.agents', 'plugins', 'marketplace.json');
+}
+
+function updateMarketplace(opts) {
+  const path = marketplacePath(opts.home);
+  runStep(opts, `Updating Codex marketplace ${path}`, () => {
+    mkdirSync(dirname(path), { recursive: true });
+    let doc = { name: 'local', interface: { displayName: 'Local Plugins' }, plugins: [] };
+    if (existsSync(path)) {
+      doc = JSON.parse(readFileSync(path, 'utf8'));
+    }
+    if (!Array.isArray(doc.plugins)) doc.plugins = [];
+    doc.name = doc.name || 'local';
+    doc.interface = doc.interface || { displayName: 'Local Plugins' };
+    doc.interface.displayName = doc.interface.displayName || 'Local Plugins';
+    const entry = {
+      name: 'gbrain-codex',
+      source: { source: 'local', path: './plugins/gbrain-codex' },
+      policy: { installation: 'AVAILABLE', authentication: 'ON_INSTALL' },
+      category: 'Engineering',
+    };
+    const idx = doc.plugins.findIndex(plugin => plugin && plugin.name === entry.name);
+    if (idx >= 0) doc.plugins[idx] = { ...doc.plugins[idx], ...entry };
+    else doc.plugins.push(entry);
+    writeFileSync(path, `${JSON.stringify(doc, null, 2)}\n`);
+  });
+  return path;
+}
+
+export function installCodexPlugin(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv);
+  const paths = assertRepoShape(opts.repoDir);
+  const pluginDir = installPluginTree(opts, paths);
+  const market = updateMarketplace(opts);
+  const rel = relative(opts.home, pluginDir) || pluginDir;
+  log(`Installed ${rel}; restart Codex Desktop to reload plugins.`);
+  return { pluginDir, marketplace: market, dryRun: opts.dryRun };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === SCRIPT_PATH) {
+  try {
+    const result = installCodexPlugin();
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## TL;DR

This PR adds a thin, repo-owned Codex Desktop plugin package so Codex users can install local GBrain without hand-editing MCP JSON. It is adapted from the working downstream Eva Brain package, but upstream-branded as plain GBrain and intentionally keeps all runtime behavior inside the canonical `gbrain serve` MCP server.

```mermaid
flowchart LR
  User["User / agent"] --> Install["node scripts/install-codex-plugin.mjs"]
  Install --> Plugin["~/plugins/gbrain-codex"]
  Codex["Codex Desktop"] --> Plugin
  Plugin --> Launcher["launch-gbrain-serve.mjs"]
  Launcher --> Server["gbrain serve"]
  Server --> Core["GBrain MCP tools + database"]
```

## Why This Matters

Codex Desktop already supports local plugins, and GBrain already exposes the right MCP surface. The missing piece is packaging: users and agents should have one maintainer-owned install path that wires the two together safely and repeatably.

This gives GBrain:

- a first-class Codex Desktop install target
- no duplicated MCP server or forked runtime
- a launcher that handles GUI PATH issues and local checkout binaries
- a rehearsal smoke that proves Codex can start the local server and call tools
- docs that make the trust boundary clear

## What Changed

- Adds `plugins/gbrain-codex/` with:
  - `.codex-plugin/plugin.json`
  - `.mcp.json`
  - package README
  - launcher script for `gbrain serve`
  - rehearsal script using stdio MCP against a temp `GBRAIN_HOME`
  - small SVG icon
- Adds `scripts/install-codex-plugin.mjs` to install/update `~/plugins/gbrain-codex` and `~/.agents/plugins/marketplace.json`.
- Adds a README section under MCP setup.
- Regenerates `llms-full.txt` after README changes.

## Boundaries

- This does not add a second GBrain runtime.
- This does not change core MCP tools.
- This does not add host-specific auth behavior.
- This does not loosen operation guards.
- Codex calls still enter through stdio MCP and then the existing GBrain server.

## Validation

Ran in `/Volumes/LEXAR/repos/gbrain-upstream-prs/codex-plugin`:

- `bun install --frozen-lockfile`
- `git diff --check`
- `node scripts/install-codex-plugin.mjs --dry-run --home /tmp/gbrain-codex-install-smoke`
- `node plugins/gbrain-codex/scripts/rehearsal.mjs`
  - result: `ok: true`
  - MCP tool count: `62`
  - exercised `put_page`, `get_page`, `search`, `query`, `sync_brain`, and `whoami` fail-closed behavior
- `bun run build:llms`
- `bun test test/build-llms.test.ts`
  - result: 7 pass / 0 fail
- `node --check scripts/install-codex-plugin.mjs`
- `node --check plugins/gbrain-codex/scripts/launch-gbrain-serve.mjs`
- `node --check plugins/gbrain-codex/scripts/rehearsal.mjs`
- `bun run check:privacy`

Closes #931.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->