### PR TITLE
Refresh source sync timestamp when unchanged

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -509,6 +509,10 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       detachedWorkingTreeManifest.renamed.length > 0);
 
   if (lastCommit === headCommit && !versionMismatch && !versionNeverSet && !hasDetachedWorkingTreeChanges) {
+    if (opts.sourceId && !opts.dryRun) {
+      // A successful source check is fresh even when git HEAD did not advance.
+      await writeSyncAnchor(engine, opts.sourceId, 'last_commit', headCommit);
+    }
     return {
       status: 'up_to_date',
       fromCommit: lastCommit,

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -319,6 +319,47 @@ describe('performSync dry-run never writes', () => {
     expect(bookmarkAfterDry).toBe(bookmarkAfterReal);
   });
 
+  test('source sync refreshes last_sync_at when HEAD is unchanged', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const sourceId = 'stale-source';
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config)
+       VALUES ($1, $1, $2, '{}'::jsonb)`,
+      [sourceId, repoPath],
+    );
+
+    const first = await performSync(engine, {
+      repoPath,
+      sourceId,
+      noPull: true,
+      noEmbed: true,
+      noExtract: true,
+    });
+    expect(first.status).toBe('first_sync');
+
+    const staleIso = '2000-01-01T00:00:00.000Z';
+    await engine.executeRaw(
+      `UPDATE sources SET last_sync_at = $1 WHERE id = $2`,
+      [staleIso, sourceId],
+    );
+
+    const second = await performSync(engine, {
+      repoPath,
+      sourceId,
+      noPull: true,
+      noEmbed: true,
+      noExtract: true,
+    });
+    expect(second.status).toBe('up_to_date');
+
+    const rows = await engine.executeRaw<{ last_sync_at: string | Date | null }>(
+      `SELECT last_sync_at FROM sources WHERE id = $1`,
+      [sourceId],
+    );
+    expect(rows[0].last_sync_at).not.toBeNull();
+    expect(new Date(rows[0].last_sync_at!).getTime()).toBeGreaterThan(new Date(staleIso).getTime());
+  });
+
   test('full-sync (--full) dry-run does NOT write to DB or advance the bookmark', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
     // Seed the bookmark so we hit the full-sync-with-bookmark path when --full is set.


### PR DESCRIPTION
## Summary
- refresh source-scoped `last_sync_at` when sync reaches unchanged HEAD successfully
- keep dry-run behavior unchanged
- add regression coverage for stale source freshness on up-to-date syncs

## Validation
- `bun test test/sync.test.ts` -> 46 pass, 0 fail
- `bun run typecheck` -> exit 0

## Context
`gbrain doctor` asks users to run `gbrain sync --source <id>` for stale sources. When the source repo was already at HEAD, sync returned `up_to_date` before writing `sources.last_sync_at`, so the recommended command exited 0 but left `sync_freshness` failing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->