### PR TITLE
fix: configure AI gateway for hybrid search in LongMemEval benchmark

### DIFF
--- a/src/commands/eval-longmemeval.ts
+++ b/src/commands/eval-longmemeval.ts
@@ -21,8 +21,10 @@ import { resolveModel } from '../core/model-config.ts';
 import type { ThinkLLMClient } from '../core/think/index.ts';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
+import { loadConfig } from '../core/config.ts';
 import type { PGLiteEngine } from '../core/pglite-engine.ts';
 import type { SearchResult } from '../core/types.ts';
+import type { AIGatewayConfig } from '../core/ai/types.ts';
 
 const HUGGINGFACE_URL = 'https://huggingface.co/datasets/xiaowu0162/longmemeval';
 
@@ -282,6 +284,29 @@ export async function runEvalLongMemEval(args: string[], runOpts: RunOpts = {}):
   let runStart = Date.now();
   let errorCount = 0;
 
+  // Build AI gateway config from user's ~/.gbrain/config.json + process.env.
+  // The in-memory benchmark brain doesn't load config by itself — we bridge it
+  // so hybrid search (vector path) can resolve embedding providers.
+  let gatewayConfig: AIGatewayConfig | undefined;
+  if (!opts.keywordOnly) {
+    const userConfig = loadConfig();
+    if (userConfig && userConfig.embedding_model) {
+      const envFromConfig: Record<string, string> = {};
+      if (userConfig.openai_api_key) envFromConfig.OPENAI_API_KEY = userConfig.openai_api_key;
+      if (userConfig.anthropic_api_key) envFromConfig.ANTHROPIC_API_KEY = userConfig.anthropic_api_key;
+      gatewayConfig = {
+        embedding_model: userConfig.embedding_model,
+        embedding_dimensions: userConfig.embedding_dimensions,
+        base_urls: userConfig.provider_base_urls,
+        env: { ...envFromConfig, ...process.env as Record<string, string | undefined> },
+      };
+      process.stderr.write(`[longmemeval] gateway configured: ${gatewayConfig.embedding_model} (${gatewayConfig.embedding_dimensions}d)\n`);
+    } else {
+      process.stderr.write(`[longmemeval] no embedding_model in config.json — falling back to keyword-only\n`);
+      opts.keywordOnly = true;
+    }
+  }
+
   await withBenchmarkBrain(async (engine) => {
     for (const q of questions) {
       const qStart = Date.now();
@@ -303,7 +328,7 @@ export async function runEvalLongMemEval(args: string[], runOpts: RunOpts = {}):
         process.stderr.write(`[longmemeval] ${q.question_id} ${Date.now() - qStart}ms\n`);
       }
     }
-  });
+  }, gatewayConfig);
 
   progress.finish();
   emitter.close();

--- a/src/eval/longmemeval/harness.ts
+++ b/src/eval/longmemeval/harness.ts
@@ -11,6 +11,7 @@
  */
 
 import { PGLiteEngine } from '../../core/pglite-engine.ts';
+import type { AIGatewayConfig } from '../../core/ai/types.ts';
 
 interface PgTablesRow {
   tablename: string;
@@ -32,8 +33,15 @@ const PRESERVE_TABLES: ReadonlySet<string> = new Set([
   'subagent_rate_leases',
 ]);
 
-export async function createBenchmarkBrain(): Promise<PGLiteEngine> {
+export async function createBenchmarkBrain(gatewayConfig?: AIGatewayConfig): Promise<PGLiteEngine> {
   const engine = new PGLiteEngine();
+  // Configure gateway BEFORE connect+initSchema — initSchema reads embedding dims
+  // from the gateway to size the pgvector column. If we initSchema first with
+  // the default 1536d and then switch to a 1024d provider, every embed call fails.
+  if (gatewayConfig) {
+    const { configureGateway } = await import('../../core/ai/gateway.ts');
+    configureGateway(gatewayConfig);
+  }
   await engine.connect({}); // in-memory; no database_path, no file lock acquired
   await engine.initSchema();
   return engine;
@@ -54,8 +62,9 @@ export async function resetTables(engine: PGLiteEngine): Promise<void> {
 
 export async function withBenchmarkBrain<T>(
   fn: (engine: PGLiteEngine) => Promise<T>,
+  gatewayConfig?: AIGatewayConfig,
 ): Promise<T> {
-  const engine = await createBenchmarkBrain();
+  const engine = await createBenchmarkBrain(gatewayConfig);
   try {
     return await fn(engine);
   } finally {


### PR DESCRIPTION
## Summary

Fix the LongMemEval benchmark harness so it supports hybrid (keyword + vector) search instead of being limited to keyword-only mode.

## Problem

`gbrain eval longmemeval` without `--keyword-only` fails on every question with `AI gateway is not configured`. The benchmark harness (`harness.ts`) creates an in-memory PGLite but never calls `configureGateway()`, making vector search impossible.

## Fix

- `harness.ts`: Accept optional `AIGatewayConfig` in `createBenchmarkBrain()` and `withBenchmarkBrain()`. Call `configureGateway()` **before** `initSchema()` to ensure the pgvector column is sized correctly.
- `eval-longmemeval.ts`: Build `AIGatewayConfig` from user's `~/.gbrain/config.json` + `process.env`, pass to `withBenchmarkBrain()`. Gracefully fall back to `--keyword-only` when no embedding provider is configured.

## Verification

Tested with DashScope text-embedding-v3 (1024 dims), 50 LongMemEval temporal-reasoning questions:

| Mode | Recall |
|------|--------|
| keyword-only (before) | 22/50 (44.0%) |
| hybrid (after) | 50/50 (100.0%) |

Closes #940

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->