### PR TITLE
docs: add Hermes Tweet X-to-Brain route

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ GBrain ships integration recipes that your agent sets up for you. Each recipe te
 | [Credential Gateway](recipes/credential-gateway.md) | — | Gmail + Calendar access |
 | [Voice-to-Brain](recipes/twilio-voice-brain.md) | ngrok-tunnel | Phone calls to brain pages (Twilio + OpenAI Realtime) |
 | [Email-to-Brain](recipes/email-to-brain.md) | credential-gateway | Gmail to entity pages |
-| [X-to-Brain](recipes/x-to-brain.md) | — | Twitter timeline + mentions + deletions |
+| [X-to-Brain](recipes/x-to-brain.md) | X API v2 or Hermes Tweet | Twitter timeline + mentions + deletions |
 | [Calendar-to-Brain](recipes/calendar-to-brain.md) | credential-gateway | Google Calendar to searchable daily pages |
 | [Meeting Sync](recipes/meeting-sync.md) | — | Circleback transcripts to brain pages with attendees |
 | [Restart Sweep](recipes/restart-sweep.md) | OpenClaw + Telegram | Detect dropped Telegram messages after OpenClaw gateway restarts |

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -32,7 +32,7 @@ These are integration recipes your agent can set up for you. Run
 | [credential-gateway](../../recipes/credential-gateway.md) | Infra | — | Gmail + Calendar access (ClawVisor or Google OAuth) | 15 min |
 | [voice-to-brain](../../recipes/twilio-voice-brain.md) | Sense | ngrok-tunnel | Phone calls create brain pages via Twilio + OpenAI Realtime | 30 min |
 | [email-to-brain](../../recipes/email-to-brain.md) | Sense | credential-gateway | Gmail messages flow into entity pages via deterministic collector | 20 min |
-| [x-to-brain](../../recipes/x-to-brain.md) | Sense | — | Twitter timeline, mentions, keyword monitoring with deletion detection | 15 min |
+| [x-to-brain](../../recipes/x-to-brain.md) | Sense | X API v2 or Hermes Tweet | Twitter timeline, mentions, keyword monitoring with deletion detection | 15 min |
 | [calendar-to-brain](../../recipes/calendar-to-brain.md) | Sense | credential-gateway | Google Calendar events become searchable daily brain pages | 20 min |
 | [meeting-sync](../../recipes/meeting-sync.md) | Sense | — | Circleback meeting transcripts auto-import with attendee propagation | 15 min |
 

--- a/recipes/x-to-brain.md
+++ b/recipes/x-to-brain.md
@@ -95,7 +95,31 @@ Agent reads collected data
 
 1. **GBrain installed and configured** (`gbrain doctor` passes)
 2. **Node.js 18+** (for the collector script)
-3. **X Developer account** with API access
+3. **X Developer account** with API access, or Hermes Tweet with
+   `XQUIK_API_KEY`
+
+### Optional Hermes Tweet Route
+
+If the user already runs Hermes Agent and wants a native plugin path instead of
+calling X API v2 directly, install
+[Hermes Tweet](https://github.com/Xquik-dev/hermes-tweet):
+
+```bash
+hermes plugins install Xquik-dev/hermes-tweet --enable
+```
+
+Set `XQUIK_API_KEY` in `~/.hermes/.env`, then use `tweet_explore` before
+`tweet_read` to find routes for scrape/search tweets, search Twitter/X, read
+tweet replies, look up users, monitor tweets, export followers, and capture
+account or trend state.
+
+Keep `HERMES_TWEET_ENABLE_ACTIONS=false` for unattended cron collection. Enable
+`tweet_action` only for explicit, reviewed workflows such as post tweets, send
+replies, send DMs, or automate X actions.
+
+This does not change the GBrain contract. Persist normalized JSON under
+`x-collector/data/...`, keep deletion and engagement ledgers idempotent, and let
+the agent perform enrichment in Step 5.
 
 ## Setup Flow
 


### PR DESCRIPTION
## Summary

- Add Hermes Tweet as an optional native Hermes Agent plugin path for the X-to-Brain recipe.
- Keep the existing X API v2 collector and GBrain normalized JSON contract intact.
- Update the integration tables to show X API v2 or Hermes Tweet as supported setup routes.

## Validation

- Reviewed README, AGENTS, CONTRIBUTING, PR template, workflows, open and closed PRs, and open and closed issues.
- Checked for existing Hermes Tweet, Xquik, and TweetClaw routes before editing.
- `git diff --check`
- `curl -I -L -s https://github.com/Xquik-dev/hermes-tweet`
- Added-line secret pattern scan
- Added-line dash scan
- `bun run check:privacy`
- `bun run check:newlines`
- `bun run check:system-of-record`
- `bun run check:exports-count`
- `bun run check:admin-build`
- `bun run check:admin-scope-drift`
- `bun run check:cli-exec`

Not run: `bun run check:all` / `bun run check:wasm`. After dependency install, the local compiled WASM smoke test exits 137 while building `scripts/chunker-smoketest.ts`; this docs-only change does not touch the WASM or chunker path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->