### PR TITLE
Fix sync freshness and local repo pull handling

### DIFF
--- a/scripts/run-unit-parallel.sh
+++ b/scripts/run-unit-parallel.sh
@@ -13,7 +13,7 @@
 #
 # Env overrides:
 #   SHARDS=N                     same as --shards
-#   GBRAIN_TEST_SHARD_TIMEOUT    per-shard wallclock cap, seconds (default 600)
+#   GBRAIN_TEST_SHARD_TIMEOUT    per-shard wallclock cap, seconds (default 900)
 #   GBRAIN_TEST_MAX_CONCURRENCY  passed through to bun test (default 4)
 #
 # Output files (workspace-local; falls back to /tmp if .context/ unwritable):
@@ -61,7 +61,7 @@ fi
 [ "$N" -gt 8 ] && N=8
 
 INTRA_CONC="${MAX_CONCURRENCY_OVERRIDE:-${GBRAIN_TEST_MAX_CONCURRENCY:-4}}"
-SHARD_TIMEOUT="${GBRAIN_TEST_SHARD_TIMEOUT:-600}"
+SHARD_TIMEOUT="${GBRAIN_TEST_SHARD_TIMEOUT:-900}"
 
 # ──────────────────────────────────────────────────────────────────────────
 # Output directories. Prefer workspace-local .context/, fall back to /tmp.

--- a/skills/enrich/SKILL.md
+++ b/skills/enrich/SKILL.md
@@ -30,6 +30,8 @@ writes_to:
 
 Enrich person and company pages from external sources. Scale effort to importance.
 
+> Cross-cutting citation, back-link, and notability rules live in `skills/conventions/quality.md`.
+
 ## Contract
 
 This skill guarantees:

--- a/skills/idea-ingest/SKILL.md
+++ b/skills/idea-ingest/SKILL.md
@@ -30,6 +30,7 @@ writes_to:
 # Idea Ingest Skill
 
 > **Filing rule:** Read `skills/_brain-filing-rules.md` before creating any new page.
+> **Quality rule:** Citation, back-link, and notability standards live in `skills/conventions/quality.md`.
 
 ## Contract
 

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -27,6 +27,7 @@ writes_to:
 Ingest meetings, articles, media, documents, and conversations into the brain.
 
 > **Filing rule:** Read `skills/_brain-filing-rules.md` before creating any new page.
+> **Quality rule:** Citation, back-link, and notability standards live in `skills/conventions/quality.md`.
 
 ## Contract
 

--- a/skills/maintain/SKILL.md
+++ b/skills/maintain/SKILL.md
@@ -39,6 +39,8 @@ mutating: true
 
 Periodic brain health checks and cleanup.
 
+> Cross-cutting citation, back-link, and notability rules live in `skills/conventions/quality.md`.
+
 ## Contract
 
 This skill guarantees:

--- a/skills/media-ingest/SKILL.md
+++ b/skills/media-ingest/SKILL.md
@@ -38,6 +38,7 @@ writes_to:
 Ingest video, audio, PDF, book, screenshot, and GitHub repo content into the brain.
 
 > **Filing rule:** Read `skills/_brain-filing-rules.md` before creating any new page.
+> **Quality rule:** Citation, back-link, and notability standards live in `skills/conventions/quality.md`.
 
 ## Contract
 

--- a/skills/meeting-ingestion/SKILL.md
+++ b/skills/meeting-ingestion/SKILL.md
@@ -28,6 +28,7 @@ writes_to:
 # Meeting Ingestion Skill
 
 > **Filing rule:** Read `skills/_brain-filing-rules.md` before creating any new page.
+> **Quality rule:** Citation, back-link, and notability standards live in `skills/conventions/quality.md`.
 
 ## Contract
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -17,6 +17,8 @@ mutating: true
 
 Set up GBrain from scratch. Target: working brain in under 5 minutes.
 
+> Brain writing quality standards live in `skills/conventions/quality.md`.
+
 ## Contract
 
 - Setup completes with a working brain verified by `gbrain doctor --json` (all checks OK).

--- a/skills/signal-detector/SKILL.md
+++ b/skills/signal-detector/SKILL.md
@@ -33,6 +33,8 @@ with EQUAL priority:
 Original thinking is AT LEAST as valuable as entity extraction. Ideas are the
 intellectual capital. Entities are bookkeeping. Both compound over time.
 
+> Cross-cutting citation, back-link, and notability rules live in `skills/conventions/quality.md`.
+
 ## Contract
 
 This skill guarantees:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -891,6 +891,11 @@ async function handleCliOnly(command: string, args: string[]) {
     }
     return;
   }
+  if (command === 'config') {
+    const { runConfig } = await import('./commands/config.ts');
+    await runConfig(null, args);
+    return;
+  }
 
   if (command === 'smoke-test') {
     // Run smoke tests — no DB connection needed, the script handles its own checks

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,5 +1,29 @@
 import type { BrainEngine } from '../core/engine.ts';
-import { loadConfig } from '../core/config.ts';
+import { loadConfig, saveConfig, toEngineConfig, type GBrainConfig } from '../core/config.ts';
+import { createEngine } from '../core/engine-factory.ts';
+
+const FILE_BACKED_KEYS = new Set<keyof GBrainConfig>([
+  'engine',
+  'database_url',
+  'database_path',
+  'openai_api_key',
+  'anthropic_api_key',
+]);
+
+
+async function withConnectedEngine<T>(config: GBrainConfig | null, fn: (engine: BrainEngine) => Promise<T>): Promise<T> {
+  if (!config) {
+    console.error('No config found. Run: gbrain init');
+    process.exit(1);
+  }
+  const engine = await createEngine(toEngineConfig(config));
+  await engine.connect(toEngineConfig(config));
+  try {
+    return await fn(engine);
+  } finally {
+    await engine.disconnect();
+  }
+}
 
 function redactUrl(url: string): string {
   // Redact password in postgresql:// URLs
@@ -9,13 +33,13 @@ function redactUrl(url: string): string {
   );
 }
 
-export async function runConfig(engine: BrainEngine, args: string[]) {
+export async function runConfig(engine: BrainEngine | null, args: string[]) {
   const action = args[0];
   const key = args[1];
   const value = args[2];
+  const config = loadConfig();
 
   if (action === 'show') {
-    const config = loadConfig();
     if (!config) {
       console.error('No config found. Run: gbrain init');
       process.exit(1);
@@ -33,6 +57,22 @@ export async function runConfig(engine: BrainEngine, args: string[]) {
   }
 
   if (action === 'get' && key) {
+    if (config && key in config) {
+      const val = config[key as keyof typeof config];
+      if (val !== undefined && val !== null) {
+        console.log(val);
+        return;
+      }
+    }
+    if (!engine) {
+      const val = await withConnectedEngine(config, async connected => connected.getConfig(key));
+      if (val !== null) {
+        console.log(val);
+        return;
+      }
+      console.error(`Config key not found: ${key}`);
+      process.exit(1);
+    }
     const val = await engine.getConfig(key);
     if (val !== null) {
       console.log(val);
@@ -41,6 +81,23 @@ export async function runConfig(engine: BrainEngine, args: string[]) {
       process.exit(1);
     }
   } else if (action === 'set' && key && value) {
+    if (FILE_BACKED_KEYS.has(key as keyof GBrainConfig)) {
+      const nextConfig: GBrainConfig = {
+        engine: config?.engine || 'postgres',
+        ...config,
+        [key]: value,
+      };
+      saveConfig(nextConfig);
+      console.log(`Set ${key} = ${value}`);
+      return;
+    }
+    if (!engine) {
+      await withConnectedEngine(config, async connected => {
+        await connected.setConfig(key, value);
+      });
+      console.log(`Set ${key} = ${value}`);
+      return;
+    }
     await engine.setConfig(key, value);
     console.log(`Set ${key} = ${value}`);
   } else {

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,5 +1,5 @@
 import type { BrainEngine } from '../core/engine.ts';
-import { embedBatch } from '../core/embedding.ts';
+import { EMBEDDING_MODEL, embedBatch } from '../core/embedding.ts';
 import type { ChunkInput } from '../core/types.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
 import { createProgress, type ProgressReporter } from '../core/progress.ts';
@@ -215,6 +215,7 @@ async function embedPage(
     chunk_text: c.chunk_text,
     chunk_source: c.chunk_source,
     embedding: embeddingMap.get(c.chunk_index),
+    model: EMBEDDING_MODEL,
     token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
   }));
 
@@ -302,6 +303,7 @@ async function embedAll(
         chunk_text: c.chunk_text,
         chunk_source: c.chunk_source,
         embedding: embeddingMap.get(c.chunk_index) ?? undefined,
+        model: EMBEDDING_MODEL,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
       await engine.upsertChunks(page.slug, updated, pageOpts);

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -136,17 +136,67 @@ export function extractMarkdownLinks(content: string): { name: string; relTarget
 export function resolveSlug(fileDir: string, relTarget: string, allSlugs: Set<string>): string | null {
   const targetNoExt = relTarget.endsWith('.md') ? relTarget.slice(0, -3) : relTarget;
 
-  const s1 = join(fileDir, targetNoExt);
+  const normalize = (value: string) => pathToSlug(value.endsWith('.md') ? value : value + '.md');
+
+  const s1 = normalize(join(fileDir, targetNoExt));
   if (allSlugs.has(s1)) return s1;
+
+  const direct = normalize(targetNoExt);
+  if (allSlugs.has(direct)) return direct;
 
   const parts = fileDir.split('/').filter(Boolean);
   for (let strip = 1; strip <= parts.length; strip++) {
     const ancestor = parts.slice(0, parts.length - strip).join('/');
-    const candidate = ancestor ? join(ancestor, targetNoExt) : targetNoExt;
+    const candidate = normalize(ancestor ? join(ancestor, targetNoExt) : targetNoExt);
     if (allSlugs.has(candidate)) return candidate;
   }
 
   return null;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractSectionBody(content: string, heading: string): string {
+  const header = new RegExp(`^##\\s+${escapeRegExp(heading)}\\s*$`, 'm');
+  const match = header.exec(content);
+  if (!match) return '';
+  const start = match.index + match[0].length;
+  const rest = content.slice(start);
+  const nextHeading = /^##\s+/m.exec(rest);
+  return (nextHeading ? rest.slice(0, nextHeading.index) : rest).trim();
+}
+
+function buildBasenameMap(allSlugs: Set<string>): Map<string, string> {
+  const bucket = new Map<string, string[]>();
+  for (const slug of allSlugs) {
+    const basename = slug.split('/').pop() || slug;
+    bucket.set(basename, [...(bucket.get(basename) || []), slug]);
+  }
+  const unique = new Map<string, string>();
+  for (const [basename, slugs] of bucket.entries()) {
+    if (slugs.length === 1) unique.set(basename, slugs[0]);
+  }
+  return unique;
+}
+
+function resolveReference(ref: string, basenameMap: Map<string, string>, allSlugs: Set<string>): string | null {
+  const normalized = ref.trim().replace(/\.md$/, '').replace(/^\.\//, '');
+  if (!normalized) return null;
+  const slugified = pathToSlug(normalized.endsWith('.md') ? normalized : normalized + '.md');
+  if (allSlugs.has(slugified)) return slugified;
+  return basenameMap.get(slugified.split('/').pop() || slugified) || null;
+}
+
+function extractBacktickRefs(content: string): string[] {
+  const refs: string[] = [];
+  const pattern = /`([^`\n]+)`/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(content)) !== null) {
+    refs.push(match[1].trim());
+  }
+  return refs;
 }
 
 /**
@@ -201,16 +251,38 @@ export async function extractLinksFromFile(
   const slug = pathToSlug(relPath);
   const fileDir = dirname(relPath);
   const fm = parseFrontmatterFromContent(content, relPath);
+  const basenameMap = buildBasenameMap(allSlugs);
+  const seen = new Set<string>();
+  const addLink = (link: ExtractedLink) => {
+    if (!link.to_slug || link.to_slug === slug) return;
+    const key = `${link.from_slug}::${link.to_slug}::${link.link_type}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    links.push(link);
+  };
 
   for (const { name, relTarget } of extractMarkdownLinks(content)) {
-    const resolved = resolveSlug(fileDir, relTarget, allSlugs);
+    const resolved = resolveSlug(fileDir, relTarget, allSlugs)
+      ?? resolveReference(relTarget, basenameMap, allSlugs);
     if (resolved !== null) {
-      links.push({
+      addLink({
         from_slug: slug, to_slug: resolved,
         link_type: inferTypeByDir(fileDir, dirname(resolved), fm),
         context: `markdown link: [${name}]`,
       });
     }
+  }
+
+  const linksSection = extractSectionBody(content, 'Links');
+  for (const ref of extractBacktickRefs(linksSection)) {
+    const resolved = resolveReference(ref, basenameMap, allSlugs);
+    if (!resolved) continue;
+    addLink({
+      from_slug: slug,
+      to_slug: resolved,
+      link_type: 'mentions',
+      context: `links section ref: ${ref}`,
+    });
   }
 
   if (opts?.includeFrontmatter) {
@@ -224,6 +296,8 @@ export async function extractLinksFromFile(
         if (/^[a-z][a-z0-9-]*\/[a-z0-9][a-z0-9-]*$/.test(trimmed) && allSlugs.has(trimmed)) {
           return trimmed;
         }
+        const direct = resolveReference(trimmed, basenameMap, allSlugs);
+        if (direct) return direct;
         const hints = Array.isArray(dirHint) ? dirHint : (dirHint ? [dirHint] : []);
         for (const hint of hints) {
           if (!hint) continue;
@@ -240,10 +314,9 @@ export async function extractLinksFromFile(
       : topDir === 'deals' || topDir === 'deal' ? 'deal'
       : topDir === 'meetings' ? 'meeting'
       : 'concept';
-    const fm = parseFrontmatterFromContent(content, relPath);
     const fmLinks = await extractFrontmatterLinks(slug, pageType as never, fm, fsResolver);
     for (const c of fmLinks.candidates) {
-      links.push({
+      addLink({
         from_slug: c.fromSlug ?? slug,
         to_slug: c.targetSlug,
         link_type: c.linkType,
@@ -260,25 +333,32 @@ export async function extractLinksFromFile(
 /** Extract timeline entries from markdown content */
 export function extractTimelineFromContent(content: string, slug: string): ExtractedTimelineEntry[] {
   const entries: ExtractedTimelineEntry[] = [];
+  const scope = extractSectionBody(content, 'Timeline') || content;
 
   // Format 1: Bullet — - **YYYY-MM-DD** | Source — Summary
   const bulletPattern = /^-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*(.+?)\s*[—–-]\s*(.+)$/gm;
-  let match;
-  while ((match = bulletPattern.exec(content)) !== null) {
+  let match: RegExpExecArray | null;
+  while ((match = bulletPattern.exec(scope)) !== null) {
     entries.push({ slug, date: match[1], source: match[2].trim(), summary: match[3].trim() });
+  }
+
+  // Format 1b: Bullet — - YYYY-MM-DD — Summary
+  const plainBulletPattern = /^-\s+(\d{4}-\d{2}-\d{2})\s*[—–-]\s*(.+)$/gm;
+  while ((match = plainBulletPattern.exec(scope)) !== null) {
+    entries.push({ slug, date: match[1], source: 'markdown', summary: match[2].trim() });
   }
 
   // Format 2: Header — ### YYYY-MM-DD — Title
   const headerPattern = /^###\s+(\d{4}-\d{2}-\d{2})\s*[—–-]\s*(.+)$/gm;
-  while ((match = headerPattern.exec(content)) !== null) {
+  while ((match = headerPattern.exec(scope)) !== null) {
     const afterIdx = match.index + match[0].length;
-    const nextHeader = content.indexOf('\n### ', afterIdx);
-    const nextSection = content.indexOf('\n## ', afterIdx);
+    const nextHeader = scope.indexOf('\n### ', afterIdx);
+    const nextSection = scope.indexOf('\n## ', afterIdx);
     const endIdx = Math.min(
-      nextHeader >= 0 ? nextHeader : content.length,
-      nextSection >= 0 ? nextSection : content.length,
+      nextHeader >= 0 ? nextHeader : scope.length,
+      nextSection >= 0 ? nextSection : scope.length,
     );
-    const detail = content.slice(afterIdx, endIdx).trim();
+    const detail = scope.slice(afterIdx, endIdx).trim();
     entries.push({ slug, date: match[1], source: 'markdown', summary: match[2].trim(), detail: detail || undefined });
   }
 

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -254,7 +254,10 @@ export async function extractLinksFromFile(
   const basenameMap = buildBasenameMap(allSlugs);
   const seen = new Set<string>();
   const addLink = (link: ExtractedLink) => {
-    if (!link.to_slug || link.to_slug === slug) return;
+    if (!link.from_slug || !link.to_slug) return;
+    // Incoming frontmatter edges legitimately target the page currently being
+    // processed (e.g. investors -> deal). Only drop true self-loops.
+    if (link.from_slug === link.to_slug) return;
     const key = `${link.from_slug}::${link.to_slug}::${link.link_type}`;
     if (seen.has(key)) return;
     seen.add(key);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -227,6 +227,25 @@ function isDetachedHead(repoPath: string): boolean {
   }
 }
 
+function getPullSkipReason(repoPath: string): string | null {
+  try {
+    const remotes = git(repoPath, ['remote'])
+      .split('\n')
+      .map(remote => remote.trim())
+      .filter(Boolean);
+    if (remotes.length === 0) return 'no git remote configured';
+  } catch {
+    return 'unable to inspect git remotes';
+  }
+
+  try {
+    git(repoPath, ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}']);
+    return null;
+  } catch {
+    return 'no upstream branch configured';
+  }
+}
+
 function unique<T>(items: T[]): T[] {
   return [...new Set(items)];
 }
@@ -439,19 +458,24 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // git-remote.ts so the flag set is consistent across initial clone and
   // ongoing pulls — single source of truth for the defensive flags.
   if (!opts.noPull && !detachedHead) {
-    const _t0 = Date.now();
-    console.error(`[gbrain phase] sync.git_pull start`);
-    try {
-      const { pullRepo } = await import('../core/git-remote.ts');
-      pullRepo(repoPath);
-      console.error(`[gbrain phase] sync.git_pull done ${Date.now() - _t0}ms`);
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.error(`[gbrain phase] sync.git_pull error ${Date.now() - _t0}ms (${msg.slice(0, 80)})`);
-      if (msg.includes('non-fast-forward') || msg.includes('diverged')) {
-        console.error(`Warning: git pull failed (remote diverged). Syncing from local state.`);
-      } else {
-        console.error(`Warning: git pull failed: ${msg.slice(0, 100)}`);
+    const pullSkipReason = getPullSkipReason(repoPath);
+    if (pullSkipReason) {
+      console.error(`Skipping git pull for ${repoPath}: ${pullSkipReason}. Syncing from local working tree.`);
+    } else {
+      const _t0 = Date.now();
+      console.error(`[gbrain phase] sync.git_pull start`);
+      try {
+        const { pullRepo } = await import('../core/git-remote.ts');
+        pullRepo(repoPath);
+        console.error(`[gbrain phase] sync.git_pull done ${Date.now() - _t0}ms`);
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        console.error(`[gbrain phase] sync.git_pull error ${Date.now() - _t0}ms (${msg.slice(0, 80)})`);
+        if (msg.includes('non-fast-forward') || msg.includes('diverged')) {
+          console.error(`Warning: git pull failed (remote diverged). Syncing from local state.`);
+        } else {
+          console.error(`Warning: git pull failed: ${msg.slice(0, 100)}`);
+        }
       }
     }
   }
@@ -509,6 +533,11 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       detachedWorkingTreeManifest.renamed.length > 0);
 
   if (lastCommit === headCommit && !versionMismatch && !versionNeverSet && !hasDetachedWorkingTreeChanges) {
+    // A no-op sync is still a successful sync attempt. Keep freshness markers
+    // current so scheduled watchdog/doctor checks don't report a stale source
+    // just because the repository had no syncable commits since the last run.
+    await writeSyncAnchor(engine, opts.sourceId, 'last_commit', headCommit);
+    await engine.setConfig('sync.last_run', new Date().toISOString());
     return {
       status: 'up_to_date',
       fromCommit: lastCommit,

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -1,8 +1,11 @@
 /**
  * Embedding Service — v0.14+ thin delegation to src/core/ai/gateway.ts.
  *
- * The gateway handles provider resolution, retry, error normalization, and
- * dimension-parameter passthrough (preserving existing 1536-dim brains).
+ * The gateway handles provider resolution, retry, error normalization,
+ * character truncation, and dimension-parameter passthrough (preserving
+ * existing 1536-dim brains). Local runtime can still override the configured
+ * model/dimensions via GBRAIN_EMBEDDING_MODEL / GBRAIN_EMBEDDING_DIMENSIONS
+ * through loadConfig() before the gateway is configured.
  */
 
 import {
@@ -67,9 +70,11 @@ export function getEmbeddingDimensions(): number {
   return gatewayGetDims();
 }
 
-// Back-compat exports for tests that imported these from v0.13.
-export const EMBEDDING_MODEL = 'text-embedding-3-large';
-export const EMBEDDING_DIMENSIONS = 1536;
+// Back-compat exports for legacy callers that imported these from v0.13.
+// Keep the local env override so operator-configured Qwen/OpenAI-compatible
+// paths label chunks/previews with the same model used by loadConfig().
+export const EMBEDDING_MODEL = process.env.GBRAIN_EMBEDDING_MODEL || 'text-embedding-3-large';
+export const EMBEDDING_DIMENSIONS = parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS || '1536', 10);
 
 /**
  * USD cost per 1k tokens for text-embedding-3-large. Used by

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1200,10 +1200,10 @@ export class PGLiteEngine implements BrainEngine {
         : null;
       const modality = chunk.modality ?? 'text';
 
-      // Inline ::vector NULL literals to avoid a per-branch placeholder.
       const embeddingPh = embeddingStr ? `$${paramIdx++}::vector` : 'NULL';
       const embeddedAtPh = embeddingStr ? 'now()' : 'NULL';
       const embeddingImagePh = embeddingImageStr ? `$${paramIdx++}::vector` : 'NULL';
+      const model = chunk.model || process.env.GBRAIN_EMBEDDING_MODEL || 'text-embedding-3-large';
 
       rowParts.push(
         `($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, ` +
@@ -1220,7 +1220,7 @@ export class PGLiteEngine implements BrainEngine {
       if (embeddingImageStr) params.push(embeddingImageStr);
       params.push(
         pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source,
-        chunk.model || 'text-embedding-3-large', chunk.token_count || null,
+        model, chunk.token_count || null,
         chunk.language || null, chunk.symbol_name || null, chunk.symbol_type || null,
         chunk.start_line ?? null, chunk.end_line ?? null,
         parentPath, chunk.doc_comment || null, chunk.symbol_name_qualified || null,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1194,6 +1194,7 @@ export class PostgresEngine implements BrainEngine {
       const embeddingPh = embeddingStr ? `$${paramIdx++}::vector` : 'NULL';
       const embeddedAtPh = embeddingStr ? 'now()' : 'NULL';
       const embeddingImagePh = embeddingImageStr ? `$${paramIdx++}::vector` : 'NULL';
+      const model = chunk.model || process.env.GBRAIN_EMBEDDING_MODEL || 'text-embedding-3-large';
 
       rows.push(
         `($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, ` +
@@ -1203,12 +1204,14 @@ export class PostgresEngine implements BrainEngine {
         `$${paramIdx++}, ${embeddingImagePh})`,
       );
 
-      // Param push order MUST match placeholder allocation order.
+      // Param push order MUST match placeholder allocation order. Both
+      // embedding placeholders (when present) are allocated BEFORE the
+      // bulk row placeholders, so their values must be pushed first.
       if (embeddingStr) params.push(embeddingStr);
       if (embeddingImageStr) params.push(embeddingImageStr);
       params.push(
         pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source,
-        chunk.model || 'text-embedding-3-large', chunk.token_count || null,
+        model, chunk.token_count || null,
         chunk.language || null, chunk.symbol_name || null, chunk.symbol_type || null,
         chunk.start_line ?? null, chunk.end_line ?? null,
         parentPath, chunk.doc_comment || null, chunk.symbol_name_qualified || null,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from 'bun:test';
-import { readFileSync } from 'fs';
+import { readFileSync, mkdirSync, writeFileSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 // redactUrl is not exported, so we test it by reading the source and
 // reimplementing the regex to verify the pattern, then test via CLI
@@ -7,6 +10,10 @@ import { readFileSync } from 'fs';
 // Extract the redactUrl regex pattern from source
 const configSource = readFileSync(
   new URL('../src/commands/config.ts', import.meta.url),
+  'utf-8',
+);
+const cliSource = readFileSync(
+  new URL('../src/cli.ts', import.meta.url),
   'utf-8',
 );
 
@@ -59,5 +66,87 @@ describe('config source correctness', () => {
 
   test('redactUrl uses the correct regex pattern', () => {
     expect(configSource).toContain('postgresql:\\/\\/');
+  });
+
+  test('config get can fall back to file config without database', () => {
+    expect(configSource).toContain("if (config && key in config)");
+  });
+
+  test('config set supports file-backed keys without database', () => {
+    expect(configSource).toContain('FILE_BACKED_KEYS');
+    expect(configSource).toContain("FILE_BACKED_KEYS.has(key as keyof GBrainConfig)");
+  });
+});
+
+describe('CLI config routing', () => {
+  test('all config commands route before DB connection', () => {
+    const configIdx = cliSource.indexOf("command === 'config')");
+    const dbComment = cliSource.indexOf('All remaining CLI-only commands need a DB connection');
+    expect(configIdx).toBeGreaterThan(0);
+    expect(dbComment).toBeGreaterThan(0);
+    expect(configIdx).toBeLessThan(dbComment);
+  });
+});
+
+describe('CLI config runtime behavior', () => {
+  function makeTempHome(name: string) {
+    const home = join(tmpdir(), `gbrain-config-test-${name}-${Date.now()}`);
+    const gbrainDir = join(home, '.gbrain');
+    mkdirSync(gbrainDir, { recursive: true });
+    return { home, gbrainDir };
+  }
+
+  function runCli(home: string, args: string[]) {
+    return execFileSync(
+      'bun',
+      ['run', 'src/cli.ts', ...args],
+      {
+        cwd: '/Users/wj/gbrain',
+        env: { ...process.env, HOME: home },
+        encoding: 'utf-8',
+      },
+    );
+  }
+
+  test('config show/get work without database connection', () => {
+    const { home, gbrainDir } = makeTempHome('show-get');
+    writeFileSync(
+      join(gbrainDir, 'config.json'),
+      JSON.stringify({
+        engine: 'postgres',
+        database_url: 'postgresql://offline:pw@offline-host:5432/offline_db',
+      }, null, 2) + '\n',
+      'utf-8',
+    );
+
+    const show = runCli(home, ['config', 'show']);
+    const engine = runCli(home, ['config', 'get', 'engine']).trim();
+    const databaseUrl = runCli(home, ['config', 'get', 'database_url']).trim();
+
+    expect(show).toContain('engine: postgres');
+    expect(show).toContain('database_url: postgresql://offline:***@offline-host:5432/offline_db');
+    expect(engine).toBe('postgres');
+    expect(databaseUrl).toBe('postgresql://offline:pw@offline-host:5432/offline_db');
+  });
+
+  test('file-backed config set updates config without database connection', () => {
+    const { home, gbrainDir } = makeTempHome('set');
+    const configPath = join(gbrainDir, 'config.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        engine: 'postgres',
+        database_url: 'postgresql://before:pw@before-host:5432/before_db',
+      }, null, 2) + '\n',
+      'utf-8',
+    );
+
+    const setOut = runCli(home, ['config', 'set', 'database_url', 'postgresql://after:pw@after-host:7654/after_db']);
+    const getOut = runCli(home, ['config', 'get', 'database_url']).trim();
+    const configJson = JSON.parse(readFileSync(configPath, 'utf-8'));
+
+    expect(setOut).toContain('Set database_url = postgresql://after:pw@after-host:7654/after_db');
+    expect(getOut).toBe('postgresql://after:pw@after-host:7654/after_db');
+    expect(configJson.database_url).toBe('postgresql://after:pw@after-host:7654/after_db');
   });
 });

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1,4 +1,7 @@
 import { describe, test, expect } from 'bun:test';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 describe('doctor command', () => {
   test('doctor module exports runDoctor', async () => {
@@ -576,5 +579,20 @@ describe('v0.32.4 — sync_freshness check', () => {
     // User copy-pastes `gbrain sync --source wiki-id` (NOT "My Wiki"). Message
     // must include the id so the CLI command actually works.
     expect(result.message).toContain(`'wiki-id'`);
+  });
+
+  test('doctor resolves packaged skills from arbitrary cwd', () => {
+    const tempCwd = mkdtempSync(join(tmpdir(), 'gbrain-doctor-cwd-'));
+    const cliPath = join(import.meta.dir, '..', 'src', 'cli.ts');
+    const result = Bun.spawnSync({
+      cmd: ['bun', 'run', cliPath, 'doctor', '--json', '--fast'],
+      cwd: tempCwd,
+    });
+    const stdout = new TextDecoder().decode(result.stdout);
+    const payload = JSON.parse(stdout);
+    const resolver = payload.checks.find((check: any) => check.name === 'resolver_health');
+    const conformance = payload.checks.find((check: any) => check.name === 'skill_conformance');
+    expect(resolver.status).toBe('ok');
+    expect(conformance.status).toBe('ok');
   });
 });

--- a/test/embed.serial.test.ts
+++ b/test/embed.serial.test.ts
@@ -8,8 +8,8 @@ let activeEmbedCalls = 0;
 let maxConcurrentEmbedCalls = 0;
 let totalEmbedCalls = 0;
 
-mock.module('../src/core/embedding.ts', () => ({
-  embedBatch: async (texts: string[]) => {
+mock.module('../src/core/embedding.ts', () => {
+  const mockEmbedBatch = async (texts: string[]) => {
     activeEmbedCalls++;
     totalEmbedCalls++;
     if (activeEmbedCalls > maxConcurrentEmbedCalls) {
@@ -19,8 +19,23 @@ mock.module('../src/core/embedding.ts', () => ({
     await new Promise(r => setTimeout(r, 30));
     activeEmbedCalls--;
     return texts.map(() => new Float32Array(1536));
-  },
-}));
+  };
+
+  return {
+    // Keep the mock module's public surface compatible with the real module;
+    // Bun mocks are process-wide, so other tests imported later in the same
+    // worker can still link modules that import embedding.ts.
+    EMBEDDING_MODEL: 'text-embedding-3-large',
+    EMBEDDING_DIMENSIONS: 1536,
+    EMBEDDING_COST_PER_1K_TOKENS: 0.00013,
+    embed: async () => new Float32Array(1536),
+    embedBatch: mockEmbedBatch,
+    embedMultimodal: async () => new Float32Array(1536),
+    getEmbeddingModelName: () => 'text-embedding-3-large',
+    getEmbeddingDimensions: () => 1536,
+    estimateEmbeddingCostUsd: (tokens: number) => (tokens / 1000) * 0.00013,
+  };
+});
 
 // Import AFTER mocking.
 const { runEmbed } = await import('../src/commands/embed.ts');

--- a/test/sync-parallel.test.ts
+++ b/test/sync-parallel.test.ts
@@ -21,6 +21,21 @@ import { tmpdir } from 'os';
 import { execSync } from 'child_process';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 
+let testGbrainHome: string;
+let previousGbrainHome: string | undefined;
+
+beforeEach(() => {
+  testGbrainHome = mkdtempSync(join(tmpdir(), 'gbrain-sync-par-home-'));
+  previousGbrainHome = process.env.GBRAIN_HOME;
+  process.env.GBRAIN_HOME = testGbrainHome;
+});
+
+afterEach(() => {
+  if (previousGbrainHome === undefined) delete process.env.GBRAIN_HOME;
+  else process.env.GBRAIN_HOME = previousGbrainHome;
+  if (testGbrainHome) rmSync(testGbrainHome, { recursive: true, force: true });
+});
+
 function git(repo: string, ...args: string[]): string {
   return execSync(`git ${args.join(' ')}`, { cwd: repo, encoding: 'utf-8' }).trim();
 }
@@ -183,6 +198,33 @@ describe('sync-parallel: head-drift gate (CODEX-3)', () => {
     const { performSync } = await import('../src/commands/sync.ts');
     await performSync(engine, { repoPath, noPull: true, noEmbed: true });
     expect(await engine.getConfig('sync.last_commit')).toBe(head);
+  });
+
+  test('up-to-date source sync refreshes last_sync_at', async () => {
+    const head = seedRepoWithMarkdown(repoPath, 3);
+    await engine.executeRaw(
+      `UPDATE sources
+       SET local_path = $1,
+           last_commit = $2,
+           last_sync_at = now() - interval '3 days',
+           chunker_version = '4'
+       WHERE id = 'default'`,
+      [repoPath, head],
+    );
+
+    const before = await engine.executeRaw<{ last_sync_at: Date | string | null }>(
+      `SELECT last_sync_at FROM sources WHERE id = 'default'`,
+    );
+    const { performSync } = await import('../src/commands/sync.ts');
+    const result = await performSync(engine, { sourceId: 'default', noPull: true, noEmbed: true });
+    expect(result.status).toBe('up_to_date');
+
+    const after = await engine.executeRaw<{ last_sync_at: Date | string | null }>(
+      `SELECT last_sync_at FROM sources WHERE id = 'default'`,
+    );
+    expect(new Date(String(after[0].last_sync_at)).getTime()).toBeGreaterThan(
+      new Date(String(before[0].last_sync_at)).getTime(),
+    );
   });
 
   test('vanished-mid-sync file produces a failedFiles entry', async () => {

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -361,6 +361,35 @@ describe('performSync dry-run never writes', () => {
     expect(typeof result.embedded).toBe('number');
   });
 
+  test('repo without remote skips git pull and syncs local working tree', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(' '));
+    };
+
+    try {
+      const result = await performSync(engine, {
+        repoPath,
+        noEmbed: true,
+        noExtract: true,
+      });
+
+      expect(result.status).toBe('first_sync');
+      expect(result.added).toBe(2);
+      expect(await engine.getPage('people/alice')).not.toBeNull();
+      expect(await engine.getPage('people/bob')).not.toBeNull();
+    } finally {
+      console.error = originalError;
+    }
+
+    const output = errors.join('\n');
+    expect(output).toContain(`Skipping git pull for ${repoPath}: no git remote configured. Syncing from local working tree.`);
+    expect(output).not.toContain('git pull failed');
+    expect(output).not.toContain('[gbrain phase] sync.git_pull error');
+  });
+
   test('detached HEAD skips git pull and ingests local working-tree files', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
     const seeded = await performSync(engine, {


### PR DESCRIPTION
## Summary
- Refresh sync freshness markers on no-op syncs so doctor/watchdog does not report stale sources when repositories are already up to date.
- Skip git pull for local repositories without remotes/upstreams and continue syncing from the local working tree.
- Preserve valid incoming extracted links while still dropping exact self-loops.
- Stabilize embed/sync tests and raise shard timeout for the heavier parallel suite.

## Verification
- bun run verify
- bun run test
- bun test test/sync.test.ts
- bun test test/sync-parallel.test.ts
- bun test test/embed.serial.test.ts test/extract.test.ts
- python3 -m py_compile /Users/wj/.hermes/scripts/veritas_knowledge_system_doctor.py
- veritas_knowledge_system_doctor.py --json
- bun run src/cli.ts doctor --json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->