### PR TITLE
fix: pass no-recurse-submodules to git pull

### DIFF
--- a/src/core/git-remote.ts
+++ b/src/core/git-remote.ts
@@ -6,8 +6,8 @@
  * IPv6 loopback, IPv4-mapped IPv6, metadata hostnames, hex/octal bypass,
  * and CGNAT 100.64/10).
  *
- * cloneRepo and pullRepo both spread GIT_SSRF_FLAGS so a future flag added
- * to one path lands on both — single source of truth.
+ * cloneRepo and pullRepo both spread GIT_SSRF_FLAGS so a future config flag
+ * added to one path lands on both — single source of truth.
  *
  * Tailscale 100.64/10 trips the integrations.ts allowlist (CGNAT line in
  * url-safety.ts isPrivateIpv4). For self-hosted internal git servers
@@ -20,18 +20,19 @@ import { join } from 'path';
 import { isInternalUrl } from './url-safety.ts';
 
 /**
- * SSRF-defensive flag set. Used by both cloneRepo and pullRepo.
+ * SSRF-defensive git config flag set. Used by both cloneRepo and pullRepo.
  * - http.followRedirects=false: closes DNS rebinding via redirect chains
  * - protocol.file.allow=never: no local-file URLs (defense in depth)
  * - protocol.ext.allow=never: no external helpers (`git-remote-foo`)
- * - --no-recurse-submodules: .gitmodules cannot become a second fetch surface
  */
 export const GIT_SSRF_FLAGS = [
   '-c', 'http.followRedirects=false',
   '-c', 'protocol.file.allow=never',
   '-c', 'protocol.ext.allow=never',
-  '--no-recurse-submodules',
 ] as const;
+
+/** Subcommand option: .gitmodules cannot become a second fetch surface. */
+export const GIT_NO_RECURSE_SUBMODULES = '--no-recurse-submodules' as const;
 
 export type RemoteUrlErrorCode =
   | 'invalid_url'
@@ -153,7 +154,7 @@ export function cloneRepo(url: string, destDir: string, opts: CloneOpts = {}): v
     }
   }
 
-  const args: string[] = [...GIT_SSRF_FLAGS, 'clone'];
+  const args: string[] = [...GIT_SSRF_FLAGS, 'clone', GIT_NO_RECURSE_SUBMODULES];
   if (opts.depth !== 0) {
     args.push(`--depth=${opts.depth ?? 1}`);
   }
@@ -179,7 +180,14 @@ export function cloneRepo(url: string, destDir: string, opts: CloneOpts = {}): v
 
 /** Pull a repo with --ff-only and the same SSRF-defensive flags as cloneRepo. */
 export function pullRepo(repoPath: string, opts: { timeoutMs?: number } = {}): void {
-  const args: string[] = ['-C', repoPath, ...GIT_SSRF_FLAGS, 'pull', '--ff-only'];
+  const args: string[] = [
+    '-C',
+    repoPath,
+    ...GIT_SSRF_FLAGS,
+    'pull',
+    '--ff-only',
+    GIT_NO_RECURSE_SUBMODULES,
+  ];
   try {
     execFileSync('git', args, {
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/test/git-remote.test.ts
+++ b/test/git-remote.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   GIT_SSRF_FLAGS,
+  GIT_NO_RECURSE_SUBMODULES,
   parseRemoteUrl,
   RemoteUrlError,
   cloneRepo,
@@ -75,9 +76,9 @@ beforeEach(() => {
 const fakePath = (): string => `${FAKE_GIT_DIR}:${process.env.PATH ?? ''}`;
 
 // ---------------------------------------------------------------------------
-// GIT_SSRF_FLAGS — pinned shape (snapshot test). If a future flag is added,
-// update the expected list here AND verify both cloneRepo + pullRepo pick it
-// up via the GIT_SSRF_FLAGS spread (the codex finding that motivated this).
+// GIT_SSRF_FLAGS — pinned shape (snapshot test). If a future config flag is
+// added, update the expected list here AND verify both cloneRepo + pullRepo
+// pick it up via the GIT_SSRF_FLAGS spread.
 // ---------------------------------------------------------------------------
 
 describe('GIT_SSRF_FLAGS', () => {
@@ -86,8 +87,12 @@ describe('GIT_SSRF_FLAGS', () => {
       '-c', 'http.followRedirects=false',
       '-c', 'protocol.file.allow=never',
       '-c', 'protocol.ext.allow=never',
-      '--no-recurse-submodules',
     ]);
+  });
+
+  test('submodule recursion guard is a subcommand option', () => {
+    expect(GIT_NO_RECURSE_SUBMODULES).toBe('--no-recurse-submodules');
+    expect([...GIT_SSRF_FLAGS]).not.toContain(GIT_NO_RECURSE_SUBMODULES);
   });
 });
 
@@ -229,9 +234,11 @@ describe('cloneRepo', () => {
     const calls = readArgvLog();
     expect(calls.length).toBe(1);
     const argv = calls[0];
-    // Pin the SSRF flags before the 'clone' verb (codex Q2 invariant).
+    // Pin the SSRF config flags before the 'clone' verb (codex Q2 invariant).
     expect(argv.slice(0, GIT_SSRF_FLAGS.length)).toEqual([...GIT_SSRF_FLAGS]);
-    expect(argv).toContain('clone');
+    const cloneIdx = GIT_SSRF_FLAGS.length;
+    expect(argv[cloneIdx]).toBe('clone');
+    expect(argv[cloneIdx + 1]).toBe(GIT_NO_RECURSE_SUBMODULES);
     expect(argv).toContain('--depth=1');
     expect(argv).toContain('https://example.com/repo');
     expect(argv[argv.length - 1]).toBe(dest);
@@ -297,7 +304,7 @@ describe('cloneRepo', () => {
 // ---------------------------------------------------------------------------
 
 describe('pullRepo', () => {
-  test('happy path: invokes git -C path with GIT_SSRF_FLAGS + pull --ff-only', async () => {
+  test('happy path: invokes git -C path with config flags + pull subcommand options', async () => {
     const repo = join(FAKE_GIT_DIR, 'pull-target');
     mkdirSync(repo, { recursive: true });
     await withEnv({ PATH: fakePath() }, async () => {
@@ -307,8 +314,11 @@ describe('pullRepo', () => {
     expect(argv[0]).toBe('-C');
     expect(argv[1]).toBe(repo);
     expect(argv.slice(2, 2 + GIT_SSRF_FLAGS.length)).toEqual([...GIT_SSRF_FLAGS]);
-    expect(argv).toContain('pull');
+    const pullIdx = 2 + GIT_SSRF_FLAGS.length;
+    expect(argv.slice(0, pullIdx)).not.toContain(GIT_NO_RECURSE_SUBMODULES);
+    expect(argv[pullIdx]).toBe('pull');
     expect(argv).toContain('--ff-only');
+    expect(argv.slice(pullIdx + 1)).toContain(GIT_NO_RECURSE_SUBMODULES);
     rmSync(repo, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary

Fixes `pullRepo()` so `--no-recurse-submodules` is passed as a `git pull` subcommand option instead of a top-level `git` option.

## Problem

`pullRepo()` previously built an argv shape equivalent to:

```bash
git -C <repo> -c http.followRedirects=false -c protocol.file.allow=never -c protocol.ext.allow=never --no-recurse-submodules pull --ff-only
```

On Git versions that do not accept `--no-recurse-submodules` as a top-level option, this fails before `pull` runs:

```text
unknown option: --no-recurse-submodules
```

That causes `gbrain sync` / dream-cycle maintenance to warn and continue from local state instead of pulling cleanly.

## Fix

- Keep SSRF hardening config flags in `GIT_SSRF_FLAGS`.
- Split the submodule recursion guard into `GIT_NO_RECURSE_SUBMODULES`.
- Pass it after the relevant subcommand:
  - `git ... clone --no-recurse-submodules ...`
  - `git -C <repo> ... pull --ff-only --no-recurse-submodules`

## Verification

- `bun test test/git-remote.test.ts` — 37 passed
- `bun run typecheck` — passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->