### PR TITLE
feat(sync): sort files newest-first for faster salience on recent content

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -86,6 +86,11 @@ export async function runImport(
     : strategy === 'auto' ? 'syncable' : 'markdown';
   console.log(`Found ${allFiles.length} ${fileTypeLabel} files`);
 
+  // v0.33.1: sort newest-first so recent pages get processed before older ones.
+  // Brain paths are typically date-prefixed (meetings/2026-05-13-*, daily/2026-05-13.md)
+  // so a descending lexicographic sort naturally prioritizes recent content.
+  allFiles.sort((a, b) => b.localeCompare(a));
+
   // Resume from checkpoint if available
   const checkpointPath = gbrainPath('import-checkpoint.json');
   let files = allFiles;

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -689,6 +689,13 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   const failedFiles: Array<{ path: string; error: string; line?: number }> = [];
   const addsAndMods = [...filtered.added, ...filtered.modified];
 
+  // v0.33.1: sort newest-first so recent pages get embedded before older ones.
+  // Brain paths are typically date-prefixed (meetings/2026-05-13-*, daily/2026-05-13.md)
+  // so a descending lexicographic sort naturally prioritizes recent content.
+  // This ensures that after a burst of writes, the most relevant pages become
+  // searchable first instead of waiting behind alphabetically-earlier backlog.
+  addsAndMods.sort((a, b) => b.localeCompare(a));
+
   // v0.22.13 (PR #490 Q5): one source of truth for the concurrency decision.
   // engine.kind === 'pglite' → forced 1; explicit opts.concurrency wins;
   // auto path returns DEFAULT_PARALLEL_WORKERS only when fileCount > 100.


### PR DESCRIPTION
## Problem

Sync processes files in `git diff` order (alphabetical), so `meetings/2020-*` gets embedded before `meetings/2026-*`. After a burst of writes, new pages can be invisible to search for hours while older pages in the alphabet process first.

Real-world impact: divorce attorney consultation pages written on May 11 were never found by gbrain search because the sync lock got stuck, and when sync finally ran, it would have processed them last (alphabetically after thousands of older pages).

## Fix

Sort `addsAndMods` descending in both:
- **Incremental sync** (`sync.ts` line 690) — the git-diff path
- **Full import** (`import.ts`) — the `runImport` walker

Brain paths are date-prefixed by convention (`meetings/2026-05-13-*`, `daily/2026-05-13.md`), so lexicographic descending naturally prioritizes recent content.

## Impact

- Zero behavior change for completed syncs (same pages processed, just different order)
- Massive salience improvement for interrupted/slow syncs — newest pages become searchable first
- Two lines of actual logic (`.sort()` calls), rest is comments

## Testing

- Verified sort order with sample brain paths
- No existing tests assert processing order (order was undefined/alphabetical before)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->