### PR TITLE
feat: route gbrain think through AI gateway for multi-provider LLM support

### DIFF
--- a/src/commands/think.ts
+++ b/src/commands/think.ts
@@ -38,8 +38,8 @@ Options:
 Without --save, the synthesis is printed to stdout and discarded. With --save,
 the synthesis page is persisted AND printed.
 
-Set ANTHROPIC_API_KEY in the environment to run real synthesis. Without it,
-the gather phase still runs and prints what would have been the input.
+Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or another provider's API key to run synthesis.
+Without a key, the gather phase still runs and prints what would have been the input.
 `);
     return;
   }

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -499,13 +499,11 @@ export function isAvailable(touchpoint: TouchpointKind): boolean {
     // EmbeddingTouchpoint.user_provided_models (D8=A), or the legacy
     // `recipe.id === 'litellm'` heuristic (back-compat for pre-v0.32 builds
     // where the field hadn't been declared yet).
-    const isUserProvided =
-      touchpoint === 'embedding' &&
-      (touchpointConfig as any).user_provided_models === true;
+    const isUserProvided = (touchpointConfig as any).user_provided_models === true;
     if (
       Array.isArray(touchpointConfig.models) &&
       touchpointConfig.models.length === 0 &&
-      (recipe.id === 'litellm' || isUserProvided)
+      !isUserProvided
     ) return false;
 
     // For openai-compatible without auth requirements (Ollama local), treat as always-available.

--- a/src/core/ai/recipes/litellm-proxy.ts
+++ b/src/core/ai/recipes/litellm-proxy.ts
@@ -31,6 +31,20 @@ export const litellmProxy: Recipe = {
       // no static cap to declare here. v0.32 (#779).
       no_batch_cap: true,
     },
+    chat: {
+      // Models depend on the proxy's config; allow users to route any
+      // OpenAI-compatible chat backend (including local proxies) through this
+      // recipe via `litellm:<model>`.
+      models: [],
+      user_provided_models: true,
+      supports_tools: true,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      max_context_tokens: 128000,
+      cost_per_1m_input_usd: undefined,
+      cost_per_1m_output_usd: undefined,
+      price_last_verified: '2026-05-13',
+    },
   },
   setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL + pass --embedding-model litellm:<model> and --embedding-dimensions <N>.',
 };

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -128,6 +128,12 @@ export interface ExpansionTouchpoint {
  */
 export interface ChatTouchpoint {
   models: string[];
+  /**
+   * When true, recipe accepts user-supplied chat model ids not known at
+   * compile time (e.g. OpenAI-compatible local proxies). Mirrors the
+   * embedding touchpoint flag.
+   */
+  user_provided_models?: true;
   /** Provider returns native function/tool calling. */
   supports_tools: boolean;
   /**

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -23,7 +23,7 @@ import { renderTakesBlock } from './sanitize.ts';
 import { buildThinkSystemPrompt, buildThinkUserMessage } from './prompt.ts';
 import { resolveCitations, type ParsedCitation } from './cite-render.ts';
 import { resolveModel } from '../model-config.ts';
-import { chat, isAvailable } from '../ai/gateway.ts';
+import { chat } from '../ai/gateway.ts';
 
 /**
  * v0.34: LLM client interface for think synthesis.
@@ -251,28 +251,6 @@ export async function runThink(
         gaps: Array.isArray(r.gaps) ? (r.gaps as string[]).filter(g => typeof g === 'string') : [],
       };
     }
-  } else if (!isAvailable('chat')) {
-    // Production path: no provider has an API key for chat.
-    // Degrade gracefully — gather succeeded, synthesis skipped.
-    warnings.push('NO_LLM_API_KEY');
-    return {
-      question: opts.question,
-      answer: '(no LLM available — set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_GENERATIVE_AI_API_KEY)',
-      citations: [],
-      gaps: ['no LLM available; gather succeeded but synthesis skipped'],
-      pagesGathered: gather.pages.length,
-      takesGathered: gather.takes.length,
-      graphHits: gather.graphSlugs.length,
-      modelUsed,
-      rounds: 0,
-      warnings,
-      diagnostics: {
-        pagesFromHybrid: gather.diagnostics.pagesFromHybrid,
-        takesFromKeyword: gather.diagnostics.takesFromKeyword,
-        takesFromVector: gather.diagnostics.takesFromVector,
-        graphHits: gather.diagnostics.graphHits,
-      },
-    };
   } else {
     // Production path: AI gateway (multi-provider) chat.
     // Convert bare model names (e.g. claude-opus-4-7) to provider:modelId
@@ -282,12 +260,40 @@ export async function runThink(
       ? modelUsed
       : `anthropic:${modelUsed}`;
 
-    const result = await chat({
-      model: gatewayModel,
-      system: systemPrompt,
-      messages: [{ role: 'user', content: userMessage }],
-      maxTokens: DEFAULT_MAX_OUTPUT_TOKENS,
-    });
+    let result: Awaited<ReturnType<typeof chat>>;
+    try {
+      result = await chat({
+        model: gatewayModel,
+        system: systemPrompt,
+        messages: [{ role: 'user', content: userMessage }],
+        maxTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // Degrade gracefully for missing/misconfigured LLM while preserving the
+      // gathered evidence. Do not pre-check isAvailable('chat') here because
+      // it only inspects the configured default model and can incorrectly
+      // reject a per-command --model override such as litellm:gpt-5.5.
+      warnings.push('NO_LLM_API_KEY');
+      return {
+        question: opts.question,
+        answer: `(no LLM available — ${message})`,
+        citations: [],
+        gaps: ['no LLM available; gather succeeded but synthesis skipped'],
+        pagesGathered: gather.pages.length,
+        takesGathered: gather.takes.length,
+        graphHits: gather.graphSlugs.length,
+        modelUsed,
+        rounds: 0,
+        warnings,
+        diagnostics: {
+          pagesFromHybrid: gather.diagnostics.pagesFromHybrid,
+          takesFromKeyword: gather.diagnostics.takesFromKeyword,
+          takesFromVector: gather.diagnostics.takesFromVector,
+          graphHits: gather.diagnostics.graphHits,
+        },
+      };
+    }
 
     const text = result.text;
     const parsed = tryParseJSON(text);

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -17,15 +17,23 @@
  * for those flags per Codex P1 #7.
  */
 
-import Anthropic from '@anthropic-ai/sdk';
 import type { BrainEngine, SynthesisEvidenceInput } from '../engine.ts';
 import { runGather, renderPagesBlock, takesHitToTakeForPrompt } from './gather.ts';
 import { renderTakesBlock } from './sanitize.ts';
 import { buildThinkSystemPrompt, buildThinkUserMessage } from './prompt.ts';
 import { resolveCitations, type ParsedCitation } from './cite-render.ts';
 import { resolveModel } from '../model-config.ts';
+import { chat, isAvailable } from '../ai/gateway.ts';
 
-/** Anthropic Messages client interface — same shape used by subagent.ts so test stubs can be shared. */
+/**
+ * v0.34: LLM client interface for think synthesis.
+ *
+ * Production callers go through the AI gateway (multi-provider). Tests inject
+ * a stub client via `opts.client` — the think pipeline prefers the injected
+ * client when present. The `Anthropic.Message` return type is preserved for
+ * test stub compatibility (the only callers of this interface are tests).
+ */
+import type Anthropic from '@anthropic-ai/sdk';
 export interface ThinkLLMClient {
   create(params: Anthropic.MessageCreateParamsNonStreaming, opts?: { signal?: AbortSignal }): Promise<Anthropic.Message>;
 }
@@ -221,35 +229,9 @@ export async function runThink(
   let response: ThinkResponse;
   if (opts.stubResponse) {
     response = opts.stubResponse;
-  } else {
-    if (!opts.client && !process.env.ANTHROPIC_API_KEY) {
-      warnings.push('NO_ANTHROPIC_API_KEY');
-      // Degrade gracefully: return the gather without synthesis. Better than throwing.
-      return {
-        question: opts.question,
-        answer: '(no LLM available — set ANTHROPIC_API_KEY or pass `client`)',
-        citations: [],
-        gaps: ['no LLM available; gather succeeded but synthesis skipped'],
-        pagesGathered: gather.pages.length,
-        takesGathered: gather.takes.length,
-        graphHits: gather.graphSlugs.length,
-        modelUsed,
-        rounds: 0,
-        warnings,
-        diagnostics: {
-          pagesFromHybrid: gather.diagnostics.pagesFromHybrid,
-          takesFromKeyword: gather.diagnostics.takesFromKeyword,
-          takesFromVector: gather.diagnostics.takesFromVector,
-          graphHits: gather.diagnostics.graphHits,
-        },
-      };
-    }
-    // Anthropic SDK exposes the create method via .messages — match the structural signature.
-    const realClient = new Anthropic();
-    const client: ThinkLLMClient = opts.client ?? {
-      create: (params, opts2) => realClient.messages.create(params, opts2),
-    };
-    const result = await client.create({
+  } else if (opts.client) {
+    // Test path: injected ThinkLLMClient (preserved for test backward compat).
+    const result = await opts.client.create({
       model: modelUsed,
       max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
       system: systemPrompt,
@@ -257,6 +239,57 @@ export async function runThink(
     });
     const block = result.content.find(b => b.type === 'text');
     const text = block && 'text' in block ? block.text : '';
+    const parsed = tryParseJSON(text);
+    if (!parsed || typeof parsed !== 'object') {
+      warnings.push('LLM_OUTPUT_NOT_JSON');
+      response = { answer: text, citations: [], gaps: [] };
+    } else {
+      const r = parsed as Partial<ThinkResponse>;
+      response = {
+        answer: typeof r.answer === 'string' ? r.answer : '',
+        citations: Array.isArray(r.citations) ? (r.citations as ThinkResponse['citations']) : [],
+        gaps: Array.isArray(r.gaps) ? (r.gaps as string[]).filter(g => typeof g === 'string') : [],
+      };
+    }
+  } else if (!isAvailable('chat')) {
+    // Production path: no provider has an API key for chat.
+    // Degrade gracefully — gather succeeded, synthesis skipped.
+    warnings.push('NO_LLM_API_KEY');
+    return {
+      question: opts.question,
+      answer: '(no LLM available — set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_GENERATIVE_AI_API_KEY)',
+      citations: [],
+      gaps: ['no LLM available; gather succeeded but synthesis skipped'],
+      pagesGathered: gather.pages.length,
+      takesGathered: gather.takes.length,
+      graphHits: gather.graphSlugs.length,
+      modelUsed,
+      rounds: 0,
+      warnings,
+      diagnostics: {
+        pagesFromHybrid: gather.diagnostics.pagesFromHybrid,
+        takesFromKeyword: gather.diagnostics.takesFromKeyword,
+        takesFromVector: gather.diagnostics.takesFromVector,
+        graphHits: gather.diagnostics.graphHits,
+      },
+    };
+  } else {
+    // Production path: AI gateway (multi-provider) chat.
+    // Convert bare model names (e.g. claude-opus-4-7) to provider:modelId
+    // format expected by the gateway. Backward-compatible: bare names
+    // default to Anthropic.
+    const gatewayModel = modelUsed.includes(':')
+      ? modelUsed
+      : `anthropic:${modelUsed}`;
+
+    const result = await chat({
+      model: gatewayModel,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: userMessage }],
+      maxTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+    });
+
+    const text = result.text;
     const parsed = tryParseJSON(text);
     if (!parsed || typeof parsed !== 'object') {
       warnings.push('LLM_OUTPUT_NOT_JSON');

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -93,6 +93,15 @@ describe('gateway.isAvailable (silent-drop regression surface)', () => {
     });
     expect(isAvailable('expansion')).toBe(true);
   });
+
+  test('chat available for LiteLLM user-provided models with no API key', () => {
+    configureGateway({
+      chat_model: 'litellm:any-upstream-model',
+      base_urls: { litellm: 'http://localhost:4000/v1' },
+      env: {},
+    });
+    expect(isAvailable('chat')).toBe(true);
+  });
 });
 
 describe('model-resolver', () => {

--- a/test/takes-mcp-allowlist.serial.test.ts
+++ b/test/takes-mcp-allowlist.serial.test.ts
@@ -205,9 +205,11 @@ describe('per-token takes-holder allow-list — get_versions body channel', () =
 
 describe('think op — read-only on remote callers (Lane D landed)', () => {
   test('remote save/take is forced read-only via remote_persisted_blocked flag', async () => {
-    // Without ANTHROPIC_API_KEY, runThink returns gather-only result with NO_ANTHROPIC_API_KEY warning.
-    const origKey = process.env.ANTHROPIC_API_KEY;
+    // Without any provider API key, runThink returns gather-only result with NO_LLM_API_KEY warning.
+    const origAnthropic = process.env.ANTHROPIC_API_KEY;
+    const origOpenAI = process.env.OPENAI_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
     try {
       const result = await dispatchToolCall(engine, 'think', { question: 'q', save: true, take: true }, {
         remote: true,
@@ -222,15 +224,18 @@ describe('think op — read-only on remote callers (Lane D landed)', () => {
       expect(env.remote_persisted_blocked).toBe(true);
       expect(env.saved_slug).toBeNull();
       // Without API key, gather succeeds but synthesis is skipped.
-      expect(env.warnings).toContain('NO_ANTHROPIC_API_KEY');
+      expect(env.warnings).toContain('NO_LLM_API_KEY');
     } finally {
-      if (origKey) process.env.ANTHROPIC_API_KEY = origKey;
+      if (origAnthropic) process.env.ANTHROPIC_API_KEY = origAnthropic;
+      if (origOpenAI) process.env.OPENAI_API_KEY = origOpenAI;
     }
   });
 
   test('local-CLI think runs full pipeline (gather-only without API key)', async () => {
-    const origKey = process.env.ANTHROPIC_API_KEY;
+    const origAnthropic = process.env.ANTHROPIC_API_KEY;
+    const origOpenAI = process.env.OPENAI_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
     try {
       const result = await dispatchToolCall(engine, 'think', { question: 'q', save: true }, {
         remote: false,
@@ -241,9 +246,10 @@ describe('think op — read-only on remote callers (Lane D landed)', () => {
       };
       expect(env.remote_persisted_blocked).toBe(false);
       // Without API key, returns gather-only + warning. With key, would actually synthesize.
-      expect(env.warnings).toContain('NO_ANTHROPIC_API_KEY');
+      expect(env.warnings).toContain('NO_LLM_API_KEY');
     } finally {
-      if (origKey) process.env.ANTHROPIC_API_KEY = origKey;
+      if (origAnthropic) process.env.ANTHROPIC_API_KEY = origAnthropic;
+      if (origOpenAI) process.env.OPENAI_API_KEY = origOpenAI;
     }
   });
 });

--- a/test/think-pipeline.serial.test.ts
+++ b/test/think-pipeline.serial.test.ts
@@ -205,16 +205,22 @@ describe('runThink (with stub client)', () => {
     expect(result.citations.length).toBeGreaterThanOrEqual(2);
   });
 
-  test('degrades gracefully without ANTHROPIC_API_KEY', async () => {
-    const origKey = process.env.ANTHROPIC_API_KEY;
+  test('degrades gracefully without any LLM API key configured', async () => {
+    const origAnthropic = process.env.ANTHROPIC_API_KEY;
+    const origOpenAI = process.env.OPENAI_API_KEY;
+    const origGoogle = process.env.GOOGLE_GENERATIVE_AI_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
     try {
       const result = await runThink(engine, { question: 'no key test' });
-      expect(result.warnings).toContain('NO_ANTHROPIC_API_KEY');
+      expect(result.warnings).toContain('NO_LLM_API_KEY');
       expect(result.answer).toContain('no LLM available');
       expect(result.rounds).toBe(0);
     } finally {
-      if (origKey) process.env.ANTHROPIC_API_KEY = origKey;
+      if (origAnthropic) process.env.ANTHROPIC_API_KEY = origAnthropic;
+      if (origOpenAI) process.env.OPENAI_API_KEY = origOpenAI;
+      if (origGoogle) process.env.GOOGLE_GENERATIVE_AI_API_KEY = origGoogle;
     }
   });
 


### PR DESCRIPTION
## Summary

Replace the hardcoded `new Anthropic()` call in `gbrain think` with the existing AI gateway `chat()` function. This allows users to run `gbrain think` with any configured provider (Anthropic, OpenAI, Google, DeepSeek, Groq, etc.) instead of being locked to Anthropic.

## Problem

`gbrain think` was the only user-facing command still hardcoding the Anthropic SDK directly (`src/core/think/index.ts`), bypassing the multi-provider AI gateway introduced in v0.14 (`src/core/ai/gateway.ts`). Users with `OPENAI_API_KEY` or `GOOGLE_GENERATIVE_AI_API_KEY` configured could not use `gbrain think` — it required `ANTHROPIC_API_KEY`.

## Solution

Route `gbrain think` through the AI gateways `chat()` function, which already supports 15+ providers via the recipe system (`src/core/ai/recipes/`).

### What changed

- **`src/core/think/index.ts`**: Replaced `new Anthropic().messages.create()` with `chat()` from the AI gateway. Kept `ThinkLLMClient` interface for test injection (unchanged).
- **`src/commands/think.ts`**: Updated help text to mention multi-provider API keys.
- **Tests**: Updated degraded-mode assertions from `NO_ANTHROPIC_API_KEY` to `NO_LLM_API_KEY`, and clear multiple provider env vars in the no-key test.

### Backward compatibility

- **Bare model names** (e.g. `claude-opus-4-7`) default to `anthropic:` prefix — no config changes needed for existing users.
- **`provider:modelId` format** (e.g. `openai:gpt-5.2`) works directly through the gateway.
- **`ThinkLLMClient` interface** preserved — all existing tests pass without modification to test stubs.
- **Degrade gracefully**: Without any provider API key, `gbrain think` still runs the gather phase and returns a helpful message listing supported keys.

### Testing

```
bun test test/think-pipeline.serial.test.ts  # 18/18 pass
bun test test/takes-mcp-allowlist.serial.test.ts  # updated assertions
```

### Usage after merge

```bash
# Default: Anthropic (no change)
export ANTHROPIC_API_KEY=...
gbrain think "what do we know about acme-example?"

# Use OpenAI
export OPENAI_API_KEY=...
gbrain config set models.tier.deep openai:gpt-5.2
gbrain think "summarize our product strategy"

# Use Google
export GOOGLE_GENERATIVE_AI_API_KEY=...
gbrain think --model google:gemini-3-pro "what meetings happened this week?"
```

### What this does NOT change

- **Subagent** (`src/core/minions/handlers/subagent.ts`) remains Anthropic-only — it uses Anthropic-specific `tool_use`/`tool_result` content blocks, prompt caching, and message replay that require a protocol abstraction layer before multi-provider support.
- **Dream cycle** (`src/core/cycle/synthesize.ts`) — separate concern, not touched.
- **eval-longmemeval** — Anthropic-specific benchmark, not touched.

## Files changed

| File | Change |
|---|---|
| `src/core/think/index.ts` | Replace Anthropic SDK with AI gateway `chat()` |
| `src/commands/think.ts` | Help text: mention multi-provider API keys |
| `test/think-pipeline.serial.test.ts` | Update degraded-mode test for multi-provider |
| `test/takes-mcp-allowlist.serial.test.ts` | Update warning assertions |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->