### PR TITLE
fix(check-backlinks): dedupe (source, target) pairs within a single source

### DIFF
--- a/src/commands/backlinks.ts
+++ b/src/commands/backlinks.ts
@@ -100,9 +100,20 @@ export function findBacklinkGaps(brainDir: string): BacklinkGap[] {
   for (const page of allPages) {
     const refs = extractEntityRefs(page.content, page.relPath);
     const sourceFilename = basename(page.relPath);
+    // LOCAL PATCH (paolo, 2026-05-12): dedupe (source, target) pairs within
+    // a single source page. extractEntityRefs returns one EntityRef per
+    // occurrence, so a source page that mentions the same target N times
+    // produced N identical gaps → N duplicate "Referenced in" lines on the
+    // target. The per-ref `hasBacklink(target.content, ...)` check reads a
+    // stale snapshot (target.content is frozen at this scope), so every
+    // iteration sees the same "no backlink yet" state and pushes another
+    // gap. Tracking seen target slugs per source caps gaps at one per pair.
+    const seen = new Set<string>();
 
     for (const ref of refs) {
       const targetSlug = `${ref.dir}/${ref.slug}`;
+      if (seen.has(targetSlug)) continue;
+      seen.add(targetSlug);
       const target = pagesBySlug.get(targetSlug);
       if (!target) continue; // target page doesn't exist
 


### PR DESCRIPTION
## Problem

`findBacklinkGaps` pushes one gap per `EntityRef` occurrence, not per `(source, target)` pair. When a source page mentions a target N times, `extractEntityRefs` returns N refs. The per-ref `hasBacklink(target.content, ...)` check reads a snapshot of `target.content` frozen at the top of `findBacklinkGaps`, so every iteration sees "no backlink yet" and pushes another identical gap. `fixBacklinkGaps` then appends N identical "Referenced in" lines in a single write.

Concrete symptom: a meeting page with 6 markdown links to the same person produced 6 duplicate "Referenced in" lines on that person's page after the first autopilot cycle that saw the meeting. After that, `hasBacklink` returns true and subsequent cycles correctly skip — which is why the count is bounded to (mentions-in-source) and doesn't grow on every cycle.

## Fix

Track seen target slugs in a per-source `Set`. Each `(source, target)` pair now contributes at most one gap.

## Verification

Applied locally; affected pages no longer accumulate duplicate back-link lines. Existing duplicates from before the fix can be cleaned manually or via `gbrain integrity`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->