### PR TITLE
feat(frontmatter): add receipt document type for operational evidence corpora

### DIFF
--- a/src/core/frontmatter-inference.ts
+++ b/src/core/frontmatter-inference.ts
@@ -232,6 +232,14 @@ export const DIRECTORY_RULES: DirectoryRule[] = [
   { pathPrefix: 'events/', type: 'event', titleStrategy: 'heading', datePattern: 'filename' },
   { pathPrefix: 'meetings/', type: 'meeting', titleStrategy: 'heading', datePattern: 'filename' },
   { pathPrefix: 'media/', type: 'media', titleStrategy: 'heading' },
+  {
+    pathPrefix: 'receipts/',
+    type: 'receipt',
+    source: 'pitstop-truth',
+    tags: ['receipt', 'execution-failure', 'operational-evidence'],
+    datePattern: 'filename',
+    titleStrategy: 'filename-full',
+  },
 
   // Catch-all for any remaining files
   { pathPrefix: '', type: 'note', titleStrategy: 'heading' },

--- a/test/frontmatter-inference.test.ts
+++ b/test/frontmatter-inference.test.ts
@@ -199,6 +199,20 @@ describe('inferFrontmatter', () => {
     expect(result.type).toBe('note');
     expect(result.title).toBe('Empty');
   });
+
+  test('receipts/ directory: infers receipt type for operational evidence', () => {
+    const result = inferFrontmatter(
+      'receipts/2026-05-09-gstack-retry-after.md',
+      '# GStack Retry-After execution failure\n\nOperational receipt...',
+    );
+
+    expect(result.type).toBe('receipt');
+    expect(result.source).toBe('pitstop-truth');
+    expect(result.tags).toContain('receipt');
+    expect(result.tags).toContain('execution-failure');
+    expect(result.tags).toContain('operational-evidence');
+    expect(result.date).toBe('2026-05-09');
+  });
 });
 
 // ── Serialization ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds native frontmatter inference support for operational receipt corpora.

This introduces a new `receipts/` directory rule in `frontmatter-inference.ts` so receipt-style operational evidence can be typed consistently during import and sync workflows.

## Added rule

```ts
{
  pathPrefix: 'receipts/',
  type: 'receipt',
  source: 'pitstop-truth',
  tags: ['receipt', 'execution-failure', 'operational-evidence'],
  datePattern: 'filename',
  titleStrategy: 'filename-full',
}
```

## Includes

* new `receipts/` DIRECTORY_RULE
* inference test coverage
* preserves existing deterministic frontmatter behavior

## Motivation

Operational failure corpora benefit from:

* consistent document typing
* deterministic metadata inference
* semantic retrieval across execution failures

This enables receipt-style operational evidence to integrate cleanly into existing markdown-first GBrain workflows.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/garrytan/codesmith/gbrain/pr/973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->