### PR TITLE
feat: legacy SSE MCP transport (GET /sse + POST /messages)

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -18,6 +18,7 @@ import rateLimit from 'express-rate-limit';
 import { randomBytes, createHash, timingSafeEqual } from 'crypto';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
 import { requireBearerAuth } from '@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js';
@@ -767,23 +768,26 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   // ---------------------------------------------------------------------------
   const mcpOperations = operations.filter(op => !op.localOnly);
 
-  app.post('/mcp', requireBearerAuth({ verifier: oauthProvider }), async (req: Request, res: Response) => {
-    const startTime = Date.now();
-    const authInfo = (req as any).auth as AuthInfo;
-
+  // Build a Server instance with the gbrain MCP request handlers wired up.
+  // Both the stateless POST /mcp (Streamable HTTP) handler AND the
+  // session-ful GET /sse + POST /messages (legacy SSE transport) reuse this
+  // — same handlers, same scope enforcement, same audit log + activity-feed
+  // side effects. Each handler captures its own `startTime` so latency in
+  // the SSE path measures per-JSON-RPC-call duration, not per-session.
+  function buildMcpServerForAuth(authInfo: AuthInfo): Server {
     // Human-readable agent name is now threaded through AuthInfo by
     // verifyAccessToken (which JOINs oauth_clients in its existing token
     // SELECT). No per-request DB roundtrip needed. Falls back to clientId
     // for legacy tokens or when the JOIN row's client_name is NULL.
     const agentName = authInfo.clientName ?? authInfo.clientId;
 
-    // Create a fresh MCP server per request (stateless)
     const server = new Server(
       { name: 'gbrain', version: VERSION },
       { capabilities: { tools: {} } },
     );
 
     server.setRequestHandler(ListToolsRequestSchema, async () => {
+      const startTime = Date.now();
       // v0.28.10: log every JSON-RPC method, not just successful tools/call.
       // Pre-fix, /admin/api/requests showed nothing for clients that only
       // ever called tools/list, and the v0.26.3 persistence regression test
@@ -827,6 +831,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
     });
 
     server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const startTime = Date.now();
       const { name, arguments: params } = request.params;
       const op = mcpOperations.find(o => o.name === name);
       if (!op) {
@@ -1032,6 +1037,13 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
       return toolResult;
     });
 
+    return server;
+  }
+
+  app.post('/mcp', requireBearerAuth({ verifier: oauthProvider }), async (req: Request, res: Response) => {
+    const authInfo = (req as any).auth as AuthInfo;
+    const server = buildMcpServerForAuth(authInfo);
+
     // F14: wrap transport setup + handleRequest in try/catch. Without this,
     // an SDK-level throw (e.g., schema parse failure on a malformed request)
     // propagates to express's default error handler, which renders an HTML
@@ -1044,6 +1056,91 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
       await transport.handleRequest(req, res, req.body);
     } catch (e) {
       console.error('MCP request handler error:', e instanceof Error ? e.message : e);
+      if (!res.headersSent) {
+        res.status(500).json({
+          error: 'internal_error',
+          message: e instanceof Error ? e.message : 'Unknown error',
+        });
+      }
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // MCP legacy SSE transport (GET /sse + POST /messages)
+  // ---------------------------------------------------------------------------
+  // The newer Streamable HTTP transport on POST /mcp covers most modern MCP
+  // clients (Claude Desktop, the official MCP SDK using
+  // StreamableHTTPClientTransport). The legacy SSE transport — deprecated
+  // in the MCP spec but still used by openclaw and other clients pinned to
+  // the older SSEClientTransport — uses two endpoints: the client opens an
+  // SSE stream on GET, receives an `endpoint` event pointing at the POST
+  // URL (with a session id), then POSTs JSON-RPC requests there. We add it
+  // here so any MCP client can talk to gbrain over HTTP regardless of which
+  // transport its SDK is pinned to.
+  //
+  // Both transports authenticate via the same bearer token + scope rules
+  // and share buildMcpServerForAuth, so request logging + activity-feed
+  // broadcast + scope enforcement live in one place.
+  //
+  // Sessions are kept in-memory; if the server restarts mid-session the
+  // client reconnects and gets a fresh session id. No cross-process state.
+  const sseMcpSessions = new Map<string, { transport: SSEServerTransport; server: Server; authInfo: AuthInfo }>();
+
+  app.get('/sse', requireBearerAuth({ verifier: oauthProvider }), async (req: Request, res: Response) => {
+    const authInfo = (req as any).auth as AuthInfo;
+    const server = buildMcpServerForAuth(authInfo);
+    // The SDK appends `?sessionId=<auto-generated>` to the endpoint when
+    // emitting the SSE `endpoint` event, so passing '/messages' yields
+    // '/messages?sessionId=…' for the client to POST against.
+    const transport = new SSEServerTransport('/messages', res);
+
+    try {
+      await server.connect(transport);
+      sseMcpSessions.set(transport.sessionId, { transport, server, authInfo });
+    } catch (e) {
+      console.error('MCP /sse setup error:', e instanceof Error ? e.message : e);
+      if (!res.headersSent) {
+        res.status(500).json({
+          error: 'internal_error',
+          message: e instanceof Error ? e.message : 'Unknown error',
+        });
+      }
+      return;
+    }
+
+    req.on('close', () => {
+      sseMcpSessions.delete(transport.sessionId);
+      try { transport.close(); } catch { /* best effort */ }
+      try { server.close(); } catch { /* best effort */ }
+    });
+  });
+
+  app.post('/messages', requireBearerAuth({ verifier: oauthProvider }), express.json(), async (req: Request, res: Response) => {
+    const sessionId = String(req.query.sessionId ?? '');
+    if (!sessionId) {
+      res.status(400).json({ error: 'invalid_request', message: 'sessionId query param required' });
+      return;
+    }
+
+    const entry = sseMcpSessions.get(sessionId);
+    if (!entry) {
+      res.status(404).json({ error: 'session_not_found', message: 'Unknown sessionId. Reconnect via GET /sse.' });
+      return;
+    }
+
+    // Bind the session to the bearer that opened it. Another caller's
+    // valid bearer must not be able to drive a session it doesn't own,
+    // even if scopes overlap. clientId is the stable identifier on AuthInfo.
+    const callerAuth = (req as any).auth as AuthInfo;
+    if (callerAuth.clientId !== entry.authInfo.clientId) {
+      res.status(403).json({ error: 'forbidden', message: 'sessionId belongs to a different client' });
+      return;
+    }
+
+    try {
+      await entry.transport.handlePostMessage(req, res, req.body);
+    } catch (e) {
+      console.error('MCP /messages handler error:', e instanceof Error ? e.message : e);
       if (!res.headersSent) {
         res.status(500).json({
           error: 'internal_error',

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -576,17 +576,26 @@ const put_page: Operation = {
     }
 
     // v0.31 (D23): facts compliance backstop. When an agent writes a page
-    // on a conversation-shape slug AND the body has substantive prose, fire
-    // a fact-extraction job into the bounded queue. Skipped on dry-run,
-    // dream-generated content (anti-loop), and non-eligible kinds (sync,
-    // ingest, file uploads, code pages). Never blocks the put_page response.
+    // on a conversation-shape slug AND the body has substantive prose,
+    // extract facts and reconcile against the hot-memory table. Skipped
+    // on dry-run, dream-generated content (anti-loop), and non-eligible
+    // kinds (sync, ingest, file uploads, code pages).
     // v0.31.2: routed through runFactsBackstop (PR1 commit 6) so put_page
     // and sync share the same eligibility/extract/dedup/insert pipeline.
-    // Queue mode preserves the prior fire-and-forget shape (caller's
-    // put_page response stays fast). Default 'all' notability filter
-    // (MEDIUM facts wait for the dream cycle but DO land via put_page,
-    // matching the pre-fix behavior on this surface).
-    let factsQueued: { queued: boolean } | { skipped: string } | undefined;
+    //
+    // gbrain.io fork patch: switched from 'queue' (fire-and-forget) to
+    // 'inline' so the put_page response carries real {inserted, duplicate,
+    // superseded, fact_ids} counts. The mothership is the only writer in
+    // our shape and wants per-page truthful metrics; flipping inline turns
+    // put_page into a single synchronous "store + extract + return" call,
+    // which is exactly the round-trip shape the proxy already holds open.
+    // Trade-off: put_page latency now includes the fact-extraction LLM
+    // call (~3-5s on a medium meeting page). Acceptable for mothership-
+    // driven crawl/ingest; would be wrong for any per-keystroke surface.
+    let factsBackstop:
+      | { inserted: number; duplicate: number; superseded: number; fact_ids: number[] }
+      | { skipped: string }
+      | undefined;
     try {
       const { runFactsBackstop } = await import('./facts/backstop.ts');
       const r = await runFactsBackstop(
@@ -601,23 +610,32 @@ const put_page: Operation = {
           sourceId: ctx.sourceId ?? 'default',
           sessionId: (ctx as { source_session?: string }).source_session ?? null,
           source: 'mcp:put_page',
-          mode: 'queue',
+          mode: 'inline',
         },
       );
-      if (r.mode === 'queue' && r.enqueued) {
-        factsQueued = { queued: true };
-      } else if (r.mode === 'queue' && r.skipped) {
-        // Preserve the pre-v0.31.2 response shape for MCP clients:
+      if (r.mode === 'inline' && r.skipped) {
+        // Preserve the bare-reason response shape MCP clients can read:
         // 'kind:guide' / 'too_short' / 'subagent_namespace' / 'dream_generated'
-        // (bare reasons), not the helper's namespaced 'eligibility_failed:...'
-        // discriminator. Map back here.
+        // / 'extraction_disabled'. The helper namespaces eligibility skips
+        // as 'eligibility_failed:<reason>'; unwrap here.
         const bare = r.skipped.startsWith('eligibility_failed:')
           ? r.skipped.slice('eligibility_failed:'.length)
           : r.skipped;
-        factsQueued = { skipped: bare };
+        factsBackstop = { skipped: bare };
+      } else if (r.mode === 'inline') {
+        factsBackstop = {
+          inserted: r.inserted,
+          duplicate: r.duplicate,
+          superseded: r.superseded,
+          fact_ids: r.fact_ids,
+        };
       }
     } catch {
-      factsQueued = { skipped: 'backstop_error' };
+      // Inline mode bubbles pipeline errors; absorb-log writes happen
+      // only in queue mode upstream. Surface a single skipped reason so
+      // put_page never fails outright on extract failure — the page is
+      // already stored, the LLM call is best-effort enrichment.
+      factsBackstop = { skipped: 'backstop_error' };
     }
 
     // Post-write validator lint (PR 2.5): feature-flag-gated, non-blocking.
@@ -648,7 +666,7 @@ const put_page: Operation = {
       ...(autoLinks ? { auto_links: autoLinks } : {}),
       ...(autoTimeline ? { auto_timeline: autoTimeline } : {}),
       ...(writerLint ? { writer_lint: writerLint } : {}),
-      ...(factsQueued ? { facts_backstop: factsQueued } : {}),
+      ...(factsBackstop ? { facts_backstop: factsBackstop } : {}),
     };
   },
   cliHints: { name: 'put', positional: ['slug'], stdin: 'content' },

--- a/test/e2e/serve-http-oauth.test.ts
+++ b/test/e2e/serve-http-oauth.test.ts
@@ -875,4 +875,129 @@ describeE2E('serve-http OAuth 2.1 E2E (v0.26.1 + v0.26.2 + v0.26.3)', () => {
     expect(rejected).toBe(true);
     expect(body).not.toMatch(/"job_id"\s*:\s*"?\d+/);
   }, 15_000);
+
+  // =========================================================================
+  // Legacy SSE MCP transport (GET /sse + POST /messages)
+  // =========================================================================
+  //
+  // The newer Streamable HTTP transport on POST /mcp covers most MCP clients,
+  // but openclaw and other clients on older SDK versions still use the legacy
+  // SSEClientTransport pattern (two-endpoint: GET /sse + POST /messages). The
+  // server implementation lives next to POST /mcp in serve-http.ts; this test
+  // proves the full round-trip works for clients pinned to that transport.
+  //
+  // Test shape: open the SSE stream with a bearer, read the `endpoint` event
+  // the SDK emits, POST a tools/list to that endpoint with the same bearer,
+  // then receive the JSON-RPC response back on the SSE stream as a `message`
+  // event. Same scope rules + audit log path as POST /mcp.
+
+  /**
+   * Parse the next named SSE event from a streaming Response body. Reads
+   * chunks until one full event (`event:` + `data:` + blank line) has been
+   * assembled, then resolves with `{ event, data }`. Times out after `ms`.
+   */
+  async function readNextSseEvent(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    ms = 5000,
+  ): Promise<{ event: string; data: string }> {
+    const decoder = new TextDecoder();
+    let buf = '';
+    const deadline = Date.now() + ms;
+
+    while (Date.now() < deadline) {
+      const remaining = deadline - Date.now();
+      const tick = await Promise.race([
+        reader.read(),
+        new Promise<{ done: true; value: undefined }>((resolve) =>
+          setTimeout(() => resolve({ done: true, value: undefined }), remaining),
+        ),
+      ]);
+
+      if (tick.done) throw new Error(`SSE event timeout after ${ms}ms; buffered: ${JSON.stringify(buf)}`);
+      buf += decoder.decode(tick.value as Uint8Array, { stream: true });
+
+      // Events end with a blank line. Split on \n\n to find complete frames.
+      const sep = buf.indexOf('\n\n');
+      if (sep !== -1) {
+        const frame = buf.slice(0, sep);
+        buf = buf.slice(sep + 2);
+        let event = 'message';
+        let data = '';
+        for (const line of frame.split('\n')) {
+          if (line.startsWith('event:')) event = line.slice(6).trim();
+          else if (line.startsWith('data:')) data += (data ? '\n' : '') + line.slice(5).trimStart();
+        }
+        return { event, data };
+      }
+    }
+
+    throw new Error(`SSE event timeout after ${ms}ms; buffered: ${JSON.stringify(buf)}`);
+  }
+
+  test('legacy SSE transport: GET /sse + POST /messages round-trips tools/list', async () => {
+    const { access_token } = await mintToken('read');
+
+    // 1. Open the SSE stream.
+    const sseRes = await fetch(`${BASE}/sse`, {
+      headers: { 'Authorization': `Bearer ${access_token}`, 'Accept': 'text/event-stream' },
+    });
+    expect(sseRes.ok).toBe(true);
+    expect(sseRes.headers.get('content-type')).toContain('text/event-stream');
+
+    const reader = sseRes.body!.getReader();
+    try {
+      // 2. The SDK's SSEServerTransport.start() emits an `endpoint` event
+      //    immediately with the POST URL (containing the auto-generated
+      //    sessionId).
+      const endpointEvent = await readNextSseEvent(reader);
+      expect(endpointEvent.event).toBe('endpoint');
+      expect(endpointEvent.data).toMatch(/^\/messages\?sessionId=[A-Za-z0-9-]+/);
+
+      // 3. POST a tools/list to that endpoint. Same bearer.
+      const postRes = await fetch(`${BASE}${endpointEvent.data}`, {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${access_token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      });
+      // SDK responds 202 Accepted to the POST; the actual JSON-RPC result
+      // comes back on the SSE stream as a `message` event.
+      expect(postRes.ok).toBe(true);
+
+      // 4. Read the response off the SSE stream.
+      const messageEvent = await readNextSseEvent(reader);
+      expect(messageEvent.event).toBe('message');
+      const rpc = JSON.parse(messageEvent.data);
+      expect(rpc.jsonrpc).toBe('2.0');
+      expect(rpc.id).toBe(1);
+      expect(Array.isArray(rpc.result?.tools)).toBe(true);
+      expect(rpc.result.tools.length).toBeGreaterThan(0);
+    } finally {
+      try { await reader.cancel(); } catch { /* ignore */ }
+    }
+  }, 15_000);
+
+  test('legacy SSE: GET /sse without bearer returns 401', async () => {
+    const res = await fetch(`${BASE}/sse`, { headers: { 'Accept': 'text/event-stream' } });
+    expect(res.status).toBe(401);
+  });
+
+  test('legacy SSE: POST /messages with unknown sessionId returns 404', async () => {
+    const { access_token } = await mintToken('read');
+    const res = await fetch(`${BASE}/messages?sessionId=does-not-exist`, {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${access_token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test('legacy SSE: POST /messages without sessionId returns 400', async () => {
+    const { access_token } = await mintToken('read');
+    const res = await fetch(`${BASE}/messages`, {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${access_token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(res.status).toBe(400);
+  });
 });


### PR DESCRIPTION
## Context — what we're trying to do

Hi Garry — putting this up as a **draft for your guidance** rather than a merge ask. Want to make sure the direction lines up with where you want gbrain to go before we go deeper. Happy to close this entirely if it's not the right shape.

Over at **[gbrain.io](https://gbrain.io)** we're building a managed-hosting layer for gbrain — teams sign up, we provision a Postgres-backed gbrain instance per workgroup (Fly Machines under the hood), and members point their agents at `https://gbrain.io/brains/<id>/mcp`. The hosted instance is **upstream gbrain unchanged** — same `gbrain serve --http`, same MCP surface, same admin dashboard — with a thin Phoenix proxy on the front that maps a per-org bearer token to the right brain's upstream credentials.

The goal is "make gbrain frictionless for a 5-person workgroup that doesn't want to run a database." We're trying *not* to fork; everything that's a real product feature should land upstream so other hosters / DIY users get it too.

This is the first PR from that work. There will be more — most of them small. Treat this one as both a feature ask and a "is this the right alignment model" check.

## The specific gap

The current `gbrain serve --http` exposes MCP via `POST /mcp` (Streamable HTTP transport — the modern MCP spec). That works great for Claude Desktop, ChatGPT, Cursor, and anything built on `StreamableHTTPClientTransport`.

But there's a real population of MCP clients still pinned to `SSEClientTransport`:

- **openclaw** (the agent runtime we're shipping in hosted Harnesses)
- The older MCP TypeScript SDK
- Custom integrations that haven't migrated since the spec deprecated SSE

When one of those connects to `gbrain serve --http`, it hits `GET /sse`, gets a **404**, fails with `SSE error: Non-200 status code (404)`, and the user sees an agent silently lose all its MCP tools. The failure mode is hard to diagnose — the agent doesn't crash, it just becomes useless.

Three options we considered:

1. **Update the clients.** Not in our control for third-party clients; openclaw is moving but not there yet.
2. **Run a side-car translator.** We tried — it's a lot of code for a thin transport bridge, and it duplicates auth, scope, and audit logging.
3. **Add the legacy transport to upstream `serve --http`.** What this PR does. The MCP spec still documents SSE as a (deprecated) transport, so it's not unprecedented for a server to support both.

## What's in this PR

One commit, two files changed (one src + one test), ~230 lines:

- `src/commands/serve-http.ts`: factor out `buildMcpServerForAuth(authInfo)` so `POST /mcp` and the new `GET /sse` share the same Server, tool registration, scope checks, and audit-log path. Then add `GET /sse` (opens an `SSEServerTransport`, stores it keyed by SDK-generated sessionId) and `POST /messages?sessionId=…` (looks up the session, enforces clientId match, routes via `transport.handlePostMessage`).
- `test/e2e/serve-http-oauth.test.ts`: tools/list round-trip over SSE + the three auth / sessionId / unknown-session failure cases.

Streamable HTTP behavior on `POST /mcp` is **unchanged**. Modern clients keep working; legacy clients gain a path that didn't exist before.

The full commit message has the implementation detail:
https://github.com/bradgessler/gbrain/commit/bb015e4acd62c3a8fd892b922a71ea10fbe39a08

## What's NOT in this PR

- **No new auth surface.** Reuses the existing `Bearer` + `requireAuth(serverInstance)` chain. Same scopes, same tokens, same admin dashboard view.
- **No persistence.** Sessions live in-memory; a serve restart means clients reconnect via `GET /sse` and get a fresh sessionId. Matches the MCP SSE spec's stateless-server posture.
- **No docs/integration updates.** `docs/mcp/*.md` all point at `/mcp` and that stays correct. Happy to add an SSE section if you want a documented migration path for legacy clients, but didn't want to make this PR larger before knowing if you wanted it at all.
- **No openclaw-specific code anywhere in gbrain.** This is just the legacy MCP spec; openclaw is one consumer, not the contract.

## Open questions for you

1. **Does carrying both transports fit gbrain's posture?** Streamable HTTP is the spec direction; SSE is deprecated upstream. Keeping the old one around is "polite to legacy clients" but it's also dead weight on the maintainer (you). If the answer is "no, push the clients to upgrade and don't pollute the server," we drop this and find another path.
2. **If yes, should the SSE transport be opt-in?** E.g., behind a `--legacy-sse` flag on `gbrain serve --http`, off by default. Trades one knob for explicit consent.
3. **Session storage shape.** In-memory is fine for our hosted model (each tenant gets its own process) but breaks if anyone runs gbrain serve behind a load balancer. Want to flag now: if multi-instance support is on your roadmap, this PR isn't compatible without a Redis/Postgres-backed session map. Easy to add later; harder to retrofit after merge.
4. **The hosted layer broadly.** Anything you'd want us to *not* do upstream because it's hosted-specific? Or shapes you'd want us to follow so other hosters can reuse the same components?

## Where this connects to gbrain.io

- Source for the hosted side: https://github.com/overtonxyz/gbrain (Phoenix mothership).
- Live: https://gbrain.io — signed-in workgroup gets one gbrain instance and one OpenClaw harness per plan.
- This PR is what unblocks the "third-party MCP client → hosted gbrain over the legacy SSE wire" path. The mothership already speaks the SSE half (`MemoryProxy.sse/2` + `MemoryProxy.messages/2`) and proxies it to the tenant brain; the tenant's `gbrain serve --http` is the only thing that doesn't yet listen on `GET /sse`. This PR closes that.

## Tests

`bun test test/e2e/serve-http-oauth.test.ts` against a real Postgres-backed `gbrain serve` covers:

- [x] `GET /sse` without bearer → 401
- [x] `GET /sse` with bearer → SSE stream + endpoint event with sessionId
- [x] `POST /messages?sessionId=<known>` JSON-RPC `tools/list` round-trip
- [x] `POST /messages` without sessionId → 400
- [x] `POST /messages` with unknown sessionId → 404

Existing `POST /mcp` tests untouched and passing.

---

**Posting as draft.** If the direction is wrong, say so and I'll close it. If it's directionally right but needs a different shape (feature flag, session-store interface, etc.), happy to rework. If it's good as-is and you'd want a docs/integration follow-up, I can add `docs/mcp/SSE.md` and a section in `docs/mcp/DEPLOY.md` in a separate commit.