### PR TITLE
fix(operations): add items schema to extract_facts.entity_hints

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2573,7 +2573,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },

--- a/test/mcp-tool-defs.test.ts
+++ b/test/mcp-tool-defs.test.ts
@@ -64,4 +64,21 @@ describe('buildToolDefs', () => {
       expect(Array.isArray(def.inputSchema.required)).toBe(true);
     }
   });
+
+  // Strict OpenAI/Codex tool-schema validation rejects every tool in the
+  // payload (HTTP 400 invalid_function_parameters) when any array param
+  // lacks `items`. Hermes / OpenClaw / Claude Desktop fall back to a more
+  // lenient provider, masking the real bug. Pin the invariant.
+  test('every array param declares items', () => {
+    const offenders: string[] = [];
+    for (const def of buildToolDefs(operations)) {
+      const props = def.inputSchema.properties as Record<string, { type?: string; items?: unknown }>;
+      for (const [paramName, schema] of Object.entries(props)) {
+        if (schema.type === 'array' && !schema.items) {
+          offenders.push(`${def.name}.${paramName}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

`extract_facts.entity_hints` declared `type: 'array'` with no `items`, which JSON Schema requires. OpenAI/Codex's strict tool-schema validator rejects the entire tool list with HTTP 400 `invalid_function_parameters` when any tool has an array param missing `items`, so every agent wired to the Codex backend silently falls back to a more lenient provider on tool-bearing turns.

One-line fix + a structural regression test that walks every op and asserts no array param ever lacks `items`.

## Repro (before the fix)

Point any MCP client at `gbrain serve` while the upstream provider is OpenAI Codex (e.g. `https://chatgpt.com/backend-api/codex`), then trigger any tool-bearing chat. Logs show:

```
WARNING run_agent: API call failed (attempt 1/3) error_type=BadRequestError
  provider=openai-codex base_url=https://chatgpt.com/backend-api/codex model=gpt-5.5
  summary=HTTP 400: Invalid schema for function 'mcp_gbrain_extract_facts':
  In context=('properties', 'entity_hints'), array schema missing items.
⚠️ Non-retryable error (HTTP 400) — trying fallback...
🔄 Primary model failed — switching to fallback: deepseek-v4-pro via deepseek
```

The primary model never runs. Lenient providers (Deepseek, OpenRouter) accept the schema, so the bug is invisible there.

## Fix

- `src/core/operations.ts:2576` — add `items: { type: 'string' }` to `entity_hints`. Type already aligned: `operations.ts:2611` casts `p.entity_hints as string[]`.
- `test/mcp-tool-defs.test.ts` — new test walks every operation and pins the invariant "every array param declares items." Catches this bug class at test time instead of at provider-400 time.

## Test plan

- [x] `bun test test/mcp-tool-defs.test.ts` — 6 pass / 0 fail
- [x] `bun run typecheck` clean
- [x] Verified the MCP `tools/list` response over JSON-RPC stdio now ships `items: { type: 'string' }` on `extract_facts.entity_hints`
- [x] Codex backend (gpt-5.5 via `https://chatgpt.com/backend-api/codex`) accepts the tool list post-patch — zero HTTP 400 since the change landed in my deployment

## Notes

- Only two array params exist in `operations.ts` today: `ingest_log.pages_updated` (already correct) and `extract_facts.entity_hints` (this fix). The regression test guards both.
- No version/CHANGELOG bump — leaving release-time discipline to the maintainer per the repo's PR convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)