### PR TITLE
fix(sync): raise maxBuffer to 100 MiB to prevent silent ENOBUFS crash

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -211,10 +211,21 @@ export function buildGitInvocation(repoPath: string, args: string[], configs: st
   return [...cfg, '-C', repoPath, ...args];
 }
 
+/**
+ * Shell out to git with a generous maxBuffer.
+ *
+ * Node's default maxBuffer is 1 MiB.  `git diff --name-status -M` on a
+ * 60–100K file repo easily exceeds that, causing an ENOBUFS crash that
+ * kills the sync process with no error message in the log.
+ *
+ * 100 MiB is generous but still bounded — a 100K-file diff with long
+ * paths tops out around 10–20 MiB in practice.
+ */
 function git(repoPath: string, args: string[], configs: string[] = []): string {
   return execFileSync('git', buildGitInvocation(repoPath, args, configs), {
     encoding: 'utf-8',
     timeout: 30000,
+    maxBuffer: 100 * 1024 * 1024,
   }).trim();
 }
 


### PR DESCRIPTION
## What

`git()` helper in `sync.ts` uses `execFileSync` with Node's default 1 MiB `maxBuffer`. On repos with 60–100K files, `git diff --name-status -M` output exceeds this limit, killing the sync process silently — no error, no stack trace, just a dead PID.

## Root Cause

Observed on a 99K-file brain repo (62K tracked by git). Sync consistently died during the rename-detection phase at ~15% through `buildSyncManifest()`. The `ENOBUFS` error from `execFileSync` is not caught or logged — the process just vanishes.

## Fix

Raise `maxBuffer` to `100 * 1024 * 1024` (100 MiB). A 100K-file diff with long paths tops out around 10–20 MiB in practice, so 100 MiB is generous but bounded.

## Testing

- Survived 5+ full syncs on a 99K-file corpus (62K in git ls-files) without dying
- Previously failed at 15% on every attempt without the patch
- No behavioral change for repos under 1 MiB diff output (the vast majority)