### PR TITLE
fix(serve-http): gate CORS preflight headers behind the Origin allowlist

### DIFF
--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -139,15 +139,23 @@ export async function startHttpTransport(opts: HttpTransportOptions) {
   }
 
   function corsPreflightHeaders(origin: string | null): Record<string, string> {
-    const headers: Record<string, string> = {
+    // Mirror corsHeaders' default-deny posture for the preflight surface
+    // (OPTIONS requests). When the request Origin isn't in the allowlist,
+    // return Vary: Origin only so cached preflights stay cache-correct,
+    // and emit zero CORS-permission headers. Previously the preflight
+    // unconditionally returned Allow-Methods + Allow-Headers regardless
+    // of Origin, which let an unallowed caller learn the method + header
+    // surface even though the actual request would be blocked by the
+    // missing Allow-Origin. Same default-deny posture, applied symmetrically.
+    if (!corsAllowlist || !origin || !corsAllowlist.has(origin)) {
+      return { 'Vary': 'Origin' };
+    }
+    return {
+      'Access-Control-Allow-Origin': origin,
       'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type, Authorization, Accept',
+      'Vary': 'Origin',
     };
-    if (corsAllowlist && origin && corsAllowlist.has(origin)) {
-      headers['Access-Control-Allow-Origin'] = origin;
-      headers['Vary'] = 'Origin';
-    }
-    return headers;
   }
 
   async function validateToken(authHeader: string | null): Promise<AuthResult> {

--- a/test/http-transport.test.ts
+++ b/test/http-transport.test.ts
@@ -371,6 +371,60 @@ describe('http-transport: CORS', () => {
       expect(r.headers.get('access-control-allow-origin')).toBeNull();
     } finally { srv.stop(); }
   });
+
+  // --------------------------------------------------------------------
+  // CORS preflight (OPTIONS) — default-deny on Methods + Headers too.
+  //
+  // Pre-fix: corsPreflightHeaders unconditionally returned Allow-Methods
+  // + Allow-Headers even for non-allowlisted origins. The actual request
+  // was still blocked (no Allow-Origin → browser refuses), but the
+  // preflight leaked the API surface to any caller probing OPTIONS.
+  // These tests pin the consolidated default-deny posture: zero
+  // permission headers unless the Origin is allowlisted.
+  // --------------------------------------------------------------------
+
+  test('12a. OPTIONS, no GBRAIN_HTTP_CORS_ORIGIN → no Allow-Methods/Headers leak', async () => {
+    const srv = await startTest({});
+    try {
+      const r = await fetch(`${srv.url}/mcp`, {
+        method: 'OPTIONS',
+        headers: { 'Origin': 'https://evil.example' },
+      });
+      expect(r.headers.get('access-control-allow-origin')).toBeNull();
+      expect(r.headers.get('access-control-allow-methods')).toBeNull();
+      expect(r.headers.get('access-control-allow-headers')).toBeNull();
+    } finally { srv.stop(); }
+  });
+
+  test('12b. OPTIONS, env set + matching Origin → full preflight headers', async () => {
+    const srv = await startTest({ corsOrigin: 'https://claude.ai' });
+    try {
+      const r = await fetch(`${srv.url}/mcp`, {
+        method: 'OPTIONS',
+        headers: { 'Origin': 'https://claude.ai' },
+      });
+      expect(r.headers.get('access-control-allow-origin')).toBe('https://claude.ai');
+      expect(r.headers.get('access-control-allow-methods')).toContain('POST');
+      expect(r.headers.get('access-control-allow-headers')).toContain('Authorization');
+      expect(r.headers.get('vary')).toBe('Origin');
+    } finally { srv.stop(); }
+  });
+
+  test('12c. OPTIONS, env set + non-matching Origin → no Allow-Methods/Headers leak', async () => {
+    const srv = await startTest({ corsOrigin: 'https://claude.ai' });
+    try {
+      const r = await fetch(`${srv.url}/mcp`, {
+        method: 'OPTIONS',
+        headers: { 'Origin': 'https://evil.example' },
+      });
+      expect(r.headers.get('access-control-allow-origin')).toBeNull();
+      expect(r.headers.get('access-control-allow-methods')).toBeNull();
+      expect(r.headers.get('access-control-allow-headers')).toBeNull();
+      // Vary: Origin is still emitted so cached preflights stay cache-correct
+      // when the same path is re-fetched from an allowlisted origin.
+      expect(r.headers.get('vary')).toBe('Origin');
+    } finally { srv.stop(); }
+  });
 });
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`corsPreflightHeaders()` in `src/mcp/http-transport.ts` returns

```
Access-Control-Allow-Methods: POST, GET, OPTIONS
Access-Control-Allow-Headers: Content-Type, Authorization, Accept
```

**unconditionally** on every OPTIONS request, regardless of whether the request `Origin` is in `GBRAIN_HTTP_CORS_ORIGIN`. Only `Access-Control-Allow-Origin` and `Vary: Origin` get the allowlist gate.

Compare to the actual-request path (`corsHeaders()`, lines 132-139), which gates **everything** behind the allowlist:

```ts
function corsHeaders(origin: string | null, extra: Record<string, string> = {}): Record<string, string> {
  const headers: Record<string, string> = { ...extra };
  if (corsAllowlist && origin && corsAllowlist.has(origin)) {
    headers['Access-Control-Allow-Origin'] = origin;
    headers['Vary'] = 'Origin';
  }
  return headers;
}
```

The asymmetry: a CORS preflight from a non-allowlisted origin (`Origin: https://evil.example`) still receives the full method + header surface in the response, even though the actual request that would follow gets blocked by the missing `Access-Control-Allow-Origin`. The **data path stays safe** — browsers refuse to read a response without matching `Access-Control-Allow-Origin` — but the **API surface is leaked** to anyone probing the preflight, which is asymmetric to the default-deny posture documented in `SECURITY.md`:

> *Default-deny: no `Access-Control-Allow-Origin` header is sent unless an allowlist is configured.*

This fix applies the same default-deny posture symmetrically to the preflight surface.

## Fix

```diff
 function corsPreflightHeaders(origin: string | null): Record<string, string> {
-  const headers: Record<string, string> = {
+  if (!corsAllowlist || !origin || !corsAllowlist.has(origin)) {
+    return { 'Vary': 'Origin' };
+  }
+  return {
+    'Access-Control-Allow-Origin': origin,
     'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization, Accept',
+    'Vary': 'Origin',
   };
-  if (corsAllowlist && origin && corsAllowlist.has(origin)) {
-    headers['Access-Control-Allow-Origin'] = origin;
-    headers['Vary'] = 'Origin';
-  }
-  return headers;
 }
```

## Behavior

| `GBRAIN_HTTP_CORS_ORIGIN` | Request `Origin` | Pre-fix | Post-fix |
|---|---|---|---|
| unset | any | Allow-Methods + Allow-Headers leak | `Vary: Origin` only |
| set | matches allowlist | full preflight headers | full preflight headers (unchanged) |
| set | doesn't match | Allow-Methods + Allow-Headers leak | `Vary: Origin` only |

`Vary: Origin` is retained even on the deny path so cached preflights stay cache-correct if the same path is later re-fetched from an allowlisted Origin.

## Test plan

Three new test cases in `test/http-transport.test.ts` (slotted into the existing `describe('http-transport: CORS', ...)` block right after test 12):

- **12a** — no `GBRAIN_HTTP_CORS_ORIGIN` + OPTIONS request: asserts no `Allow-Origin`, no `Allow-Methods`, no `Allow-Headers`
- **12b** — env set + matching Origin: asserts full preflight headers including `Vary: Origin`
- **12c** — env set + non-matching Origin: asserts no `Allow-Methods` / `Allow-Headers` leak, but `Vary: Origin` still present (cache-correctness)

Verification:
- [x] `bun test test/http-transport.test.ts` — **27 pass / 0 fail** (24 existing + 3 new)
- [x] `bun run verify` — all 11 invariant gates pass (privacy, jsonb, source-id projection, progress, test-isolation, wasm, admin-build, admin-scope-drift, cli-exec, system-of-record, eval-glossary, typecheck)
- [x] No new dependencies, no breaking changes for existing allowlisted clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)