### PR TITLE
fix(connection-manager): cancel in-flight init on disconnect to stop pool resurrection

### DIFF
--- a/src/core/connection-manager.ts
+++ b/src/core/connection-manager.ts
@@ -192,6 +192,15 @@ export class ConnectionManager {
   private _killSwitch: boolean;
   private _directUrl: string | null;
   private _isSupabase: boolean;
+  /**
+   * Set by disconnect() so any in-flight initDirectPool() chain that
+   * resolves AFTER disconnect can detect the cancellation, close its
+   * now-orphaned pool, and skip writing to `_directPool`. Without this,
+   * the .then() callback in getDirectPool() resurrects `_directPool`
+   * after disconnect has nulled it — the pool comes back to life and
+   * leaks its underlying socket.
+   */
+  private _disconnected = false;
 
   constructor(opts: ConnectionManagerOpts) {
     this.opts = opts;
@@ -302,9 +311,23 @@ export class ConnectionManager {
 
   private async getDirectPool(): Promise<Sql> {
     if (this._directPool) return this._directPool;
+    if (this._disconnected) {
+      // Post-disconnect: do not silently re-init. Callers that need a
+      // fresh pool after disconnect should construct a new manager.
+      throw new Error('connection-manager: disconnect() was called; create a new instance to reconnect');
+    }
     // A1: cache the Promise so concurrent first callers await the same init.
     if (!this._directInit) {
       this._directInit = this.initDirectPool().then(pool => {
+        // Disconnect may have raced ahead of init. If so, the field this
+        // promise was meant to populate is no longer ours to write — close
+        // the now-orphaned pool so its socket doesn't leak, and resolve
+        // null so any other awaiter throws the same "disconnected" error
+        // the disconnect path would have produced.
+        if (this._disconnected) {
+          pool.end().catch(() => { /* best-effort cleanup */ });
+          return null;
+        }
         this._directPool = pool;
         return pool;
       }).catch(err => {
@@ -315,7 +338,8 @@ export class ConnectionManager {
     }
     const pool = await this._directInit;
     if (!pool) {
-      // Defensive — initDirectPool should have thrown.
+      // Defensive — initDirectPool should have thrown, OR disconnect()
+      // raced ahead of us and the .then callback closed the orphan.
       throw new Error('connection-manager: direct pool init returned null');
     }
     return pool;
@@ -394,11 +418,30 @@ export class ConnectionManager {
    * (db.ts singleton path). Direct pool is always ours.
    */
   async disconnect(): Promise<void> {
+    // Flip _disconnected FIRST so any in-flight initDirectPool().then()
+    // callback that races with us sees the cancellation and closes its
+    // orphan pool instead of writing to _directPool after we null it.
+    this._disconnected = true;
+
+    // Capture and clear the pending init reference unconditionally —
+    // previously this was nested inside `if (this._directPool)`, which
+    // meant a disconnect during init left _directInit pointing at a
+    // stale, settled Promise that would never be retried.
+    const pendingInit = this._directInit;
+    this._directInit = null;
+
     if (this._directPool) {
       try { await this._directPool.end(); } catch { /* idempotent */ }
       this._directPool = null;
-      this._directInit = null;
     }
+
+    // Wait for any in-flight init to settle. The .then callback above
+    // already closes its orphan pool when _disconnected is true, so
+    // we just need to drain the promise so the close call actually fires.
+    if (pendingInit) {
+      try { await pendingInit; } catch { /* init may have rejected; nothing to clean */ }
+    }
+
     if (this._readPool && !this._readPoolOwnedExternally) {
       try { await this._readPool.end(); } catch { /* idempotent */ }
       this._readPool = null;

--- a/test/connection-manager-disconnect-race.test.ts
+++ b/test/connection-manager-disconnect-race.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression: `disconnect()` must cancel an in-flight `initDirectPool()`
+ * chain so a pool that finishes initializing *after* disconnect can't
+ * resurrect `_directPool` and leak its socket.
+ *
+ * Pre-fix shape (commit 7 of dual-pool work, pre-this-PR):
+ *
+ *     async disconnect(): Promise<void> {
+ *       if (this._directPool) {                // ← guard
+ *         try { await this._directPool.end(); } catch { … }
+ *         this._directPool = null;
+ *         this._directInit = null;             // ← only cleared inside guard
+ *       }
+ *       …
+ *     }
+ *
+ * Two race holes the pre-fix code allowed:
+ *
+ *  1. `disconnect()` runs while `getDirectPool()` is mid-init. The
+ *     `if (this._directPool)` guard fails (pool not assigned yet), so
+ *     `_directInit` stays pointing at the in-flight Promise. When the
+ *     Promise resolves, its `.then(pool => { this._directPool = pool; ... })`
+ *     callback fires and **resurrects `_directPool` after disconnect**.
+ *
+ *  2. The resurrected pool's socket is now held by `_directPool` without
+ *     anyone tracking it for shutdown — a clean fd leak across rapid
+ *     reconnect cycles (the kind tests + Conductor worktrees + worker
+ *     pools all exhibit).
+ *
+ * Fix wires three pieces:
+ *
+ *   - a `_disconnected` flag flipped in `disconnect()` before anything else
+ *   - the `.then()` callback in `getDirectPool` checks the flag, closes
+ *     the orphan pool (`pool.end()`), and resolves `null`
+ *   - `disconnect()` always clears `_directInit` (lifted out of the guard)
+ *     and awaits the pending init Promise so the orphan close actually
+ *     completes before disconnect resolves
+ *
+ * This test exercises the exact race: spy on the private `initDirectPool`
+ * to return a delayable Promise, start the caller, kick `disconnect()`
+ * before the init resolves, then resolve the init and assert (a) no
+ * pool resurrection, (b) the orphan pool's `.end()` got called, (c) any
+ * subsequent `getDirectPool()` throws cleanly instead of silently
+ * starting a fresh init.
+ *
+ * spyOn on a method via `as any` is parallel-safe (instance-level
+ * monkey-patching, never touches process globals). No `mock.module`,
+ * no `.serial` rename needed under R2 of scripts/check-test-isolation.sh.
+ */
+
+import { describe, test, expect, spyOn } from 'bun:test';
+import { ConnectionManager } from '../src/core/connection-manager.ts';
+
+// Minimal duck-typed mock that mimics a `postgres.js` Sql handle for the
+// fields ConnectionManager touches during init + disconnect. The real
+// postgres.js Sql object has many more members; we only need `.end()`
+// for the lifecycle path under test.
+function makeMockPool() {
+  const endCalls: number[] = [];
+  const handle = {
+    end: () => {
+      endCalls.push(Date.now());
+      return Promise.resolve();
+    },
+  };
+  return { handle, endCalls };
+}
+
+describe('ConnectionManager — disconnect cancels in-flight init', () => {
+  test('orphan pool from racing init is closed, _directPool stays null', async () => {
+    const cm = new ConnectionManager({
+      url: 'postgresql://postgres.abc:p@aws.pooler.supabase.com:6543/db',
+    });
+
+    const { handle, endCalls } = makeMockPool();
+
+    // Build a controllable Promise the spied init returns. We hold the
+    // resolver so we can fire it *after* disconnect has run, exercising
+    // the exact race the fix addresses.
+    let resolveInit!: (pool: unknown) => void;
+    const initPromise = new Promise<unknown>((res) => {
+      resolveInit = res;
+    });
+
+    const initSpy = spyOn(
+      cm as unknown as { initDirectPool: () => Promise<unknown> },
+      'initDirectPool',
+    ).mockImplementation(() => initPromise);
+
+    // Caller starts requesting the direct pool. This kicks initDirectPool
+    // and stores the chained Promise in _directInit.
+    const callerPromise = (
+      cm as unknown as { getDirectPool: () => Promise<unknown> }
+    )
+      .getDirectPool()
+      .then(
+        () => 'unexpectedly resolved',
+        (err: Error) => err.message,
+      );
+
+    // Yield once so the spy actually fires + _directInit gets stored.
+    await Promise.resolve();
+    expect(
+      (cm as unknown as { _directInit: unknown })._directInit,
+    ).not.toBeNull();
+
+    // Race: disconnect BEFORE init resolves.
+    const disconnectPromise = cm.disconnect();
+
+    // Yield so disconnect runs to its `await pendingInit` point. The
+    // init Promise is still pending here, so disconnect parks on it.
+    await Promise.resolve();
+
+    // Now let init complete. The .then callback in getDirectPool sees
+    // _disconnected === true, calls pool.end() to clean up the orphan,
+    // and resolves to null. Disconnect's await pendingInit unblocks
+    // and finishes.
+    resolveInit(handle);
+
+    await disconnectPromise;
+    const callerResult = await callerPromise;
+
+    // (a) The orphan pool got closed — exactly once.
+    expect(endCalls).toHaveLength(1);
+
+    // (b) No pool resurrection — _directPool stays null after disconnect.
+    expect(
+      (cm as unknown as { _directPool: unknown })._directPool,
+    ).toBeNull();
+
+    // (c) _directInit is cleared regardless of whether the pool ever
+    // landed (pre-fix this was only cleared inside the if-guard).
+    expect(
+      (cm as unknown as { _directInit: unknown })._directInit,
+    ).toBeNull();
+
+    // (d) The original caller surfaced a clean "init returned null" /
+    // disconnect error rather than a silently-leaked pool reference.
+    expect(callerResult).toMatch(/disconnect|returned null/);
+
+    initSpy.mockRestore();
+  });
+
+  test('post-disconnect getDirectPool throws instead of silently re-initializing', async () => {
+    const cm = new ConnectionManager({
+      url: 'postgresql://postgres.abc:p@aws.pooler.supabase.com:6543/db',
+    });
+
+    await cm.disconnect();
+
+    // Without the fix, this would silently call initDirectPool() again
+    // and try to bring up a brand-new direct pool against the Supabase
+    // URL — a "disconnected" handle springing back to life. The fix
+    // makes the contract explicit: post-disconnect, the manager is dead.
+    await expect(
+      (cm as unknown as { getDirectPool: () => Promise<unknown> }).getDirectPool(),
+    ).rejects.toThrow(/disconnect\(\) was called/);
+  });
+
+  test('disconnect with no pending init + no pool is still idempotent', async () => {
+    // Sanity: the trivial path — disconnect a fresh manager that never
+    // initialized a direct pool — still works and remains idempotent.
+    const cm = new ConnectionManager({ url: 'postgresql://u:p@localhost:5432/db' });
+    await cm.disconnect();
+    await cm.disconnect(); // second call must not throw
+  });
+});


### PR DESCRIPTION
## Summary

`ConnectionManager.disconnect()` (src/core/connection-manager.ts:396) has two race holes when a caller is mid-flight in `getDirectPool()`:

1. The `_directInit = null` line lives **inside** the `if (this._directPool)` guard. If disconnect runs while init is still pending (pool not assigned yet), the guard fails and `_directInit` stays pointing at the in-flight Promise. When that Promise resolves, its `.then(pool => { this._directPool = pool; ... })` callback fires and **resurrects `_directPool` after disconnect has supposedly torn everything down**.

2. The resurrected pool's socket is now held by `_directPool` with no tracking — a clean fd leak across rapid reconnect cycles (tests, Conductor worktrees, worker shutdown flows).

Pre-fix shape:

```ts
async disconnect(): Promise<void> {
  if (this._directPool) {                              // ← guard fails when
    try { await this._directPool.end(); } catch {}     //   init is in flight
    this._directPool = null;
    this._directInit = null;                           // ← only cleared inside guard
  }
  ...
}
```

## Repro

Spying on private `initDirectPool` to return a controllable Promise (no DB needed):

1. Caller A starts `getDirectPool()` → `_directInit` set to chained Promise
2. Caller B calls `disconnect()` BEFORE init resolves → guard fails → `_directInit` stays pointing at the live Promise
3. Init Promise resolves → `.then` callback fires → `_directPool = pool`
4. Final state: `_directPool` SET (resurrected), `_directInit` SET (stale), but disconnect was supposed to tear everything down. The pool's socket is now an orphan fd.

Pinned in `test/connection-manager-disconnect-race.test.ts`. Pre-fix: 2 of 3 tests fail (orphan pool's `.end()` was never called; post-disconnect `getDirectPool()` silently tried to reach the real Supabase URL and ENOTFOUNDs).

## Fix

Three coordinated pieces:

```diff
 export class ConnectionManager {
   ...
+  /**
+   * Set by disconnect() so any in-flight initDirectPool() chain that
+   * resolves AFTER disconnect can detect the cancellation, close its
+   * now-orphaned pool, and skip writing to `_directPool`.
+   */
+  private _disconnected = false;
 
   private async getDirectPool(): Promise<Sql> {
     if (this._directPool) return this._directPool;
+    if (this._disconnected) {
+      throw new Error('connection-manager: disconnect() was called; create a new instance to reconnect');
+    }
     if (!this._directInit) {
       this._directInit = this.initDirectPool().then(pool => {
+        if (this._disconnected) {
+          pool.end().catch(() => { /* best-effort cleanup */ });
+          return null;
+        }
         this._directPool = pool;
         return pool;
       }).catch(err => { ... });
     }
     ...
   }
 
   async disconnect(): Promise<void> {
+    this._disconnected = true;
+    const pendingInit = this._directInit;
+    this._directInit = null;                      // ← lifted out of the guard
     if (this._directPool) {
       try { await this._directPool.end(); } catch {}
       this._directPool = null;
-      this._directInit = null;                    // ← was here
     }
+    if (pendingInit) {
+      try { await pendingInit; } catch {}         // ← orphan closes inside .then
+    }
     if (this._readPool && !this._readPoolOwnedExternally) { ... }
   }
```

## Behavior change

`getDirectPool()` after `disconnect()` now throws `connection-manager: disconnect() was called; create a new instance to reconnect` instead of silently starting a fresh init. Matches the engine-ownership invariant `test/worker-shutdown-disconnect.test.ts` already pins — callers construct their own engine; once disposed, it stays disposed.

## Test plan

New `test/connection-manager-disconnect-race.test.ts` (3 cases, all passing):

- **Race case** — orphan pool closed exactly once, `_directPool` null after race, `_directInit` null, caller surfaces a clean error instead of silently holding a leaked pool
- **Post-disconnect guard** — `getDirectPool()` after disconnect throws instead of silently re-initializing
- **Trivial idempotency** — repeated disconnect on a fresh manager doesn't throw

RED-verified by stashing the fix and re-running: tests 1 and 2 fail on pre-fix code with the exact symptoms above.

Verification:
- [x] `bun test test/connection-manager-disconnect-race.test.ts` — **3 pass / 0 fail**
- [x] `bun test test/connection-manager.serial.test.ts` — **24 existing pass / 0 fail** (happy-path unchanged)
- [x] `bun run verify` — all 11 invariant gates green
- [x] Parallel-safe: spyOn on instance method (no `mock.module`, no env mutation) — meets R2 of `scripts/check-test-isolation.sh` without needing the `.serial` suffix
- [x] No new dependencies, no API surface change for happy-path callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)