### PR TITLE
fix(SUP-1681): cap Ollama embedding inputs

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -747,14 +747,15 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
 const MIN_SUB_BATCH = 1;
 
 /**
- * Embed many texts. Truncates to MAX_CHARS, then dispatches based on whether
- * the recipe declares a per-batch token budget.
+ * Embed many texts. Truncates each item to the recipe's per-input cap (or the
+ * legacy MAX_CHARS ceiling), then dispatches based on whether the recipe
+ * declares a per-batch token budget.
  *
  * Flow:
  * ```
  * embed(texts)
  *   ├─ resolve recipe + model
- *   ├─ truncate each text to MAX_CHARS (8000)
+ *   ├─ truncate each text to the recipe's per-input cap, else MAX_CHARS (8000)
  *   ├─ read recipe.touchpoints.embedding.{max_batch_tokens, chars_per_token, safety_factor}
  *   │
  *   ├─ if max_batch_tokens declared (Voyage path):
@@ -790,13 +791,13 @@ export async function embed(texts: string[]): Promise<Float32Array[]> {
 
   const cfg = requireConfig();
   const { model, recipe, modelId } = await resolveEmbeddingProvider(getEmbeddingModel());
-  const truncated = texts.map(t => (t ?? '').slice(0, MAX_CHARS));
   const providerOpts = dimsProviderOptions(recipe.implementation, modelId, cfg.embedding_dimensions ?? DEFAULT_EMBEDDING_DIMENSIONS);
   const expected = cfg.embedding_dimensions ?? DEFAULT_EMBEDDING_DIMENSIONS;
 
   const embedding = recipe.touchpoints?.embedding;
   const maxBatchTokens = embedding?.max_batch_tokens;
   const charsPerToken = embedding?.chars_per_token ?? DEFAULT_CHARS_PER_TOKEN;
+  const truncated = texts.map(t => truncateEmbeddingInput(t ?? '', embedding, charsPerToken));
 
   // Pre-split is gated on max_batch_tokens. Recipes without it (e.g. OpenAI)
   // ride the fast path: one embedMany call, no recursion safety net.
@@ -852,6 +853,20 @@ export function splitByTokenBudget(
   return batches;
 }
 
+function truncateEmbeddingInput(
+  text: string,
+  embedding: Recipe['touchpoints']['embedding'],
+  charsPerToken: number,
+): string {
+  const ratio = charsPerToken > 0 ? charsPerToken : DEFAULT_CHARS_PER_TOKEN;
+  const declaredInputTokens = embedding?.max_input_tokens;
+  const perInputChars = declaredInputTokens && declaredInputTokens > 0
+    ? Math.floor(declaredInputTokens * effectiveInputSafetyFactor(embedding) * ratio)
+    : MAX_CHARS;
+  const limit = Math.max(1, Math.min(MAX_CHARS, perInputChars));
+  return text.slice(0, limit);
+}
+
 /**
  * Returns true if the error looks like a provider batch-token-limit error.
  *
@@ -862,7 +877,10 @@ export function isTokenLimitError(err: unknown): boolean {
   return (
     /max.*allowed.*tokens.*batch/i.test(msg) ||
     /batch.*too.*many.*tokens/i.test(msg) ||
-    /token.*limit.*exceeded/i.test(msg)
+    /token.*limit.*exceeded/i.test(msg) ||
+    /exceeds?.*context.*length/i.test(msg) ||
+    /context.*length.*exceeds?/i.test(msg) ||
+    /input.*too.*long/i.test(msg)
   );
 }
 
@@ -874,6 +892,10 @@ function effectiveSafetyFactor(recipe: Recipe): number {
   const declared = recipe.touchpoints?.embedding?.safety_factor ?? DEFAULT_SAFETY_FACTOR;
   const entry = _shrinkState.get(recipe.id);
   return entry?.factor ?? declared;
+}
+
+function effectiveInputSafetyFactor(embedding: Recipe['touchpoints']['embedding']): number {
+  return embedding?.safety_factor ?? DEFAULT_SAFETY_FACTOR;
 }
 
 /** Tighten the recipe's effective safety factor on a token-limit miss. */

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -17,6 +17,13 @@ export const ollama: Recipe = {
       default_dims: 768, // nomic-embed-text native dim
       cost_per_1m_tokens_usd: 0,
       price_last_verified: '2026-04-20',
+      // Local Ollama embedding models can reject a single oversized input
+      // even when batch size is 1 (mxbai/all-minilm commonly run with a
+      // 512-token context). Keep imports moving by bounding each item before
+      // it reaches the local server; page content is still stored losslessly.
+      max_input_tokens: 512,
+      chars_per_token: 1,
+      safety_factor: 0.75,
       // Ollama's batch capacity depends on the locally loaded model + the
       // OLLAMA_NUM_PARALLEL config; no static cap to declare. v0.32 (#779).
       no_batch_cap: true,

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -39,6 +39,14 @@ export interface EmbeddingTouchpoint {
    */
   max_batch_tokens?: number;
   /**
+   * Maximum tokens for a single embedding input. This is separate from
+   * max_batch_tokens: some local embedding servers accept tiny batches but
+   * still reject one oversized string because it exceeds the model context.
+   * The gateway applies `safety_factor * max_input_tokens * chars_per_token`
+   * as a per-item character cap before dispatching to the provider.
+   */
+  max_input_tokens?: number;
+  /**
    * Expected character density for this provider's tokenizer (chars per
    * token). OpenAI tiktoken averages ~4 on English text; Voyage averages
    * ~1 on mixed content (code/JSON/CJK). Defaults to 4 if omitted.

--- a/test/ai/adaptive-embed-batch.test.ts
+++ b/test/ai/adaptive-embed-batch.test.ts
@@ -147,6 +147,12 @@ describe('isTokenLimitError (pure helper)', () => {
     expect(isTokenLimitError(new Error('Batch contains too many tokens'))).toBe(true);
   });
 
+  test('matches local embedding context-length variants', () => {
+    expect(isTokenLimitError(new Error('input length 621 exceeds maximum context length 512'))).toBe(true);
+    expect(isTokenLimitError(new Error('context length exceeded for embedding input'))).toBe(true);
+    expect(isTokenLimitError(new Error('input too long for model context'))).toBe(true);
+  });
+
   test('does not match unrelated errors', () => {
     expect(isTokenLimitError(new Error('Connection refused'))).toBe(false);
     expect(isTokenLimitError(new Error('Invalid API key'))).toBe(false);
@@ -270,6 +276,47 @@ describe('embed() OpenAI fast path (no max_batch_tokens)', () => {
     await embed(['x', 'y']);
     expect(openaiStub).toHaveBeenCalledTimes(1);
     expect(__getShrinkStateForTests('voyage')).toBeUndefined();
+  });
+});
+
+describe('embed() per-input provider cap', () => {
+  beforeEach(() => resetGateway());
+  afterEach(() => __setEmbedTransportForTests(null));
+
+  test('ollama truncates oversized single inputs before local transport', async () => {
+    configureGateway({
+      embedding_model: 'ollama:mxbai-embed-large',
+      embedding_dimensions: 1024,
+      env: {},
+    });
+
+    let observed = '';
+    const stub = mock(async ({ values }: { values: string[] }) => {
+      observed = values[0] ?? '';
+      return fakeEmbeddings(values, 1024);
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    await embed(['x'.repeat(5000)]);
+
+    expect(stub).toHaveBeenCalledTimes(1);
+    expect(observed.length).toBe(384);
+  });
+
+  test('openai keeps the legacy MAX_CHARS cap', async () => {
+    configureOpenAI();
+
+    let observed = '';
+    const stub = mock(async ({ values }: { values: string[] }) => {
+      observed = values[0] ?? '';
+      return fakeEmbeddings(values, 1536);
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    await embed(['x'.repeat(9000)]);
+
+    expect(stub).toHaveBeenCalledTimes(1);
+    expect(observed.length).toBe(8000);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add a recipe-level max_input_tokens cap for embedding providers
- Apply the per-input cap in the gateway before provider dispatch while preserving the legacy OpenAI 8000-character ceiling
- Configure Ollama with a conservative local 512-token input cap and cover context-length errors in tests

## Verification
- bun test test/ai/adaptive-embed-batch.test.ts test/ai/gateway.test.ts test/ai/recipes-existing-regression.test.ts
- bunx tsc --noEmit --pretty false
- bun test test/chunkers/recursive.test.ts test/import-file.test.ts
- bun run src/cli.ts sync --repo /Users/andrew/brain --no-pull --full
- bun run src/cli.ts embed --stale -> Embedded 0 chunks (0 stale found)

Paperclip: SUP-1681