### PR TITLE
feat(sync): repo-local code index filters

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1525,7 +1525,7 @@ CODE INDEXING (v0.19.0 / v0.20.0 Cathedral II)
   query <q> --symbol-kind <k>        Filter to symbol type (function|class|method|...) (v0.20.0)
   reconcile-links [--dry-run]        Batch-recompute doc↔impl edges (v0.20.0)
   reindex-code [--source id] [--yes] Explicit code-page reindex (v0.20.0)
-  sync --strategy code               Sync code files into the brain
+  sync --strategy code               Sync code files into the brain (honors gbrain.yml code_index filters)
 
 JOBS (Minions)
   jobs submit <name> [--params JSON]  Submit background job [--follow] [--dry-run]

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -11,6 +11,7 @@ import {
   isCodeFilePath,
   isMarkdownFilePath,
   isImageFilePath as isImageFilePathFromSync,
+  matchesPathFilters,
   type SyncStrategy,
 } from '../core/sync.ts';
 import { sortNewestFirst } from '../core/sort-newest-first.ts';
@@ -20,6 +21,7 @@ import {
   clearCheckpoint,
   resumeFilter,
 } from '../core/import-checkpoint.ts';
+import { loadCodeIndexConfig } from '../core/code-index-config.ts';
 
 function defaultWorkers(): number {
   const cpuCount = cpus().length;
@@ -83,15 +85,28 @@ export async function runImport(
   // silently no-op'd because no code file ever made it through walker
   // enumeration (codex C11 confirms dispatch was correct; bug was here).
   const strategy: SyncStrategy = opts.strategy ?? 'markdown';
+  const codeIndexConfig = strategy === 'code' ? loadCodeIndexConfig(dir) : null;
   const _walkT0 = Date.now();
   console.error(`[gbrain phase] import.collect_files start dir=${dir} strategy=${strategy}`);
-  const allFiles = collectSyncableFiles(dir, { strategy });
+  const allFiles = collectSyncableFiles(dir, {
+    strategy,
+    include: codeIndexConfig?.include,
+    exclude: codeIndexConfig?.exclude,
+  });
   console.error(
     `[gbrain phase] import.collect_files done ${Date.now() - _walkT0}ms files=${allFiles.length}`,
   );
   const fileTypeLabel = strategy === 'code' ? 'code'
     : strategy === 'auto' ? 'syncable' : 'markdown';
-  console.log(`Found ${allFiles.length} ${fileTypeLabel} files`);
+  if (strategy === 'code') {
+    console.log(
+      `Code import filters: ${codeIndexConfig?.include.length ?? 0} include globs, ` +
+      `${codeIndexConfig?.exclude.length ?? 0} exclude globs`,
+    );
+    console.log(`Found ${allFiles.length} code files after filtering`);
+  } else {
+    console.log(`Found ${allFiles.length} ${fileTypeLabel} files`);
+  }
 
   // Sort newest-first so date-prefixed brain paths get embedded before older ones.
   // See src/core/sort-newest-first.ts for the policy.
@@ -358,6 +373,8 @@ function resolveMaxWalkDepth(): number {
 
 interface CollectOpts {
   strategy?: SyncStrategy;
+  include?: string[];
+  exclude?: string[];
 }
 
 /**
@@ -452,6 +469,8 @@ export function collectSyncableFiles(dir: string, opts: CollectOpts = {}): strin
         walk(full, depth + 1);
       } else if (stat.isFile()) {
         if (!isCollectibleForWalker(entry, strategy, multimodalOn)) continue;
+        const rel = relative(dir, full).replace(/\\/g, '/');
+        if (!matchesPathFilters(rel, opts)) continue;
         files.push(full);
       }
     }

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -30,6 +30,7 @@ import { tryAcquireDbLock, SYNC_LOCK_ID } from '../core/db-lock.ts';
 import { loadStorageConfig } from '../core/storage-config.ts';
 import { getDefaultSourcePath } from '../core/source-resolver.ts';
 import { sortNewestFirst } from '../core/sort-newest-first.ts';
+import { loadCodeIndexConfig } from '../core/code-index-config.ts';
 
 export interface SyncResult {
   status: 'up_to_date' | 'synced' | 'first_sync' | 'dry_run' | 'blocked_by_failures';
@@ -76,12 +77,19 @@ function estimateSyncAllCost(sources: Array<{ local_path: string | null; config:
     let sourceTokens = 0;
     let sourceFiles = 0;
     try {
+      const codeIndexConfig = (cfg.strategy ?? 'markdown') === 'code'
+        ? loadCodeIndexConfig(src.local_path)
+        : null;
       // v0.31.2: cost preview routed through collectSyncableFiles
       // (single hardened walker; see import.ts). Previously
       // walkSyncableFiles used statSync (followed symlinks). New walker
       // uses lstat + inode-cycle + max-depth so the preview matches
       // what the real sync will actually walk.
-      const files = collectSyncableFiles(src.local_path, { strategy: cfg.strategy ?? 'markdown' });
+      const files = collectSyncableFiles(src.local_path, {
+        strategy: cfg.strategy ?? 'markdown',
+        include: codeIndexConfig?.include,
+        exclude: codeIndexConfig?.exclude,
+      });
       for (const fullPath of files) {
         try {
           const stat = statSync(fullPath);
@@ -542,6 +550,8 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     return result;
   }
 
+  const codeIndexConfig = opts.strategy === 'code' ? loadCodeIndexConfig(repoPath) : null;
+
   // Diff using git diff (net result, not per-commit)
   const diffOutput = git(repoPath, ['diff', '--name-status', '-M', `${lastCommit}..${headCommit}`]);
   const manifest = buildSyncManifest(diffOutput);
@@ -553,7 +563,11 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   }
 
   // Filter to syncable files (strategy-aware)
-  const syncOpts = opts.strategy ? { strategy: opts.strategy } : undefined;
+  const syncOpts = opts.strategy ? {
+    strategy: opts.strategy,
+    include: codeIndexConfig?.include,
+    exclude: codeIndexConfig?.exclude,
+  } : undefined;
   const filtered: SyncManifest = {
     added: manifest.added.filter(p => isSyncable(p, syncOpts)),
     modified: manifest.modified.filter(p => isSyncable(p, syncOpts)),
@@ -585,6 +599,14 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
 
   const totalChanges = filtered.added.length + filtered.modified.length +
     filtered.deleted.length + filtered.renamed.length;
+
+  if (opts.strategy === 'code') {
+    console.log(
+      `Code import filters: ${codeIndexConfig?.include.length ?? 0} include globs, ` +
+      `${codeIndexConfig?.exclude.length ?? 0} exclude globs`,
+    );
+    console.log(`Found ${totalChanges} code files after filtering`);
+  }
 
   // Dry run
   if (opts.dryRun) {
@@ -1014,7 +1036,19 @@ async function performFullSync(
   // code --dry-run` always reported zero files even when ~1500 code
   // files were waiting.
   if (opts.dryRun) {
-    const allFiles = collectSyncableFiles(repoPath, { strategy: opts.strategy ?? 'markdown' });
+    const codeIndexConfig = opts.strategy === 'code' ? loadCodeIndexConfig(repoPath) : null;
+    const allFiles = collectSyncableFiles(repoPath, {
+      strategy: opts.strategy ?? 'markdown',
+      include: codeIndexConfig?.include,
+      exclude: codeIndexConfig?.exclude,
+    });
+    if (opts.strategy === 'code') {
+      console.log(
+        `Code import filters: ${codeIndexConfig?.include.length ?? 0} include globs, ` +
+        `${codeIndexConfig?.exclude.length ?? 0} exclude globs`,
+      );
+      console.log(`Found ${allFiles.length} code files after filtering`);
+    }
     console.log(
       `Full-sync dry run (strategy=${opts.strategy ?? 'markdown'}): ` +
       `${allFiles.length} file(s) would be imported ` +

--- a/src/core/code-index-config.ts
+++ b/src/core/code-index-config.ts
@@ -1,0 +1,89 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export interface CodeIndexConfig {
+  include: string[];
+  exclude: string[];
+}
+
+interface RawCodeIndexConfig {
+  include?: string[];
+  exclude?: string[];
+}
+
+const CODE_INDEX_KEYS = new Set(['include', 'exclude']);
+
+function parseCodeIndexYaml(content: string): RawCodeIndexConfig | null {
+  const lines = content.split('\n').map((line) => line.replace(/\r$/, ''));
+
+  let inSection = false;
+  let currentList: keyof RawCodeIndexConfig | null = null;
+  let sawSection = false;
+  const raw: RawCodeIndexConfig = {};
+
+  for (const line of lines) {
+    const noComment = line.replace(/\s+#.*$/, '').replace(/^#.*$/, '');
+    if (noComment.trim() === '') continue;
+
+    if (!noComment.startsWith(' ') && !noComment.startsWith('\t')) {
+      const colon = noComment.indexOf(':');
+      if (colon === -1) continue;
+      const key = noComment.slice(0, colon).trim();
+      if (key === 'code_index' || key === 'code-index') {
+        inSection = true;
+        sawSection = true;
+        currentList = null;
+        continue;
+      }
+      inSection = false;
+      currentList = null;
+      continue;
+    }
+
+    if (!inSection) continue;
+
+    const indented = noComment.replace(/^\s+/, '');
+
+    if (indented.startsWith('-')) {
+      if (!currentList) continue;
+      const value = indented.slice(1).trim().replace(/^["']|["']$/g, '');
+      if (value) {
+        if (!raw[currentList]) raw[currentList] = [];
+        raw[currentList]!.push(value);
+      }
+      continue;
+    }
+
+    const colon = indented.indexOf(':');
+    if (colon === -1) continue;
+    const key = indented.slice(0, colon).trim();
+    if (CODE_INDEX_KEYS.has(key)) {
+      currentList = key as keyof RawCodeIndexConfig;
+      const remainder = indented.slice(colon + 1).trim();
+      if (remainder === '[]' && !raw[currentList]) {
+        raw[currentList] = [];
+      }
+      continue;
+    }
+    currentList = null;
+  }
+
+  if (!sawSection) return null;
+  return raw;
+}
+
+export function loadCodeIndexConfig(repoPath?: string | null): CodeIndexConfig | null {
+  if (!repoPath) return null;
+
+  const yamlPath = join(repoPath, 'gbrain.yml');
+  if (!existsSync(yamlPath)) return null;
+
+  const content = readFileSync(yamlPath, 'utf-8');
+  const raw = parseCodeIndexYaml(content);
+  if (raw === null) return null;
+
+  return {
+    include: raw.include ?? [],
+    exclude: raw.exclude ?? [],
+  };
+}

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -208,6 +208,19 @@ function matchesAnyGlob(path: string, patterns?: string[]): boolean {
   return patterns.some((pattern) => globToRegex(pattern).test(normalized));
 }
 
+export function matchesPathFilters(
+  path: string,
+  filters: { include?: string[]; exclude?: string[] } = {},
+): boolean {
+  if (filters.exclude && filters.exclude.length > 0 && matchesAnyGlob(path, filters.exclude)) {
+    return false;
+  }
+  if (filters.include && filters.include.length > 0) {
+    return matchesAnyGlob(path, filters.include);
+  }
+  return true;
+}
+
 /**
  * Filter a file path to determine if it should be synced to GBrain.
  * Strategy-aware: 'markdown' (default) = .md/.mdx only, 'code' = code files only, 'auto' = both.
@@ -231,8 +244,7 @@ export function isSyncable(path: string, opts: SyncableOptions = {}): boolean {
   // Skip ops/ directory
   if (path.startsWith('ops/')) return false;
 
-  if (opts.include && opts.include.length > 0 && !matchesAnyGlob(path, opts.include)) return false;
-  if (opts.exclude && opts.exclude.length > 0 && matchesAnyGlob(path, opts.exclude)) return false;
+  if (!matchesPathFilters(path, opts)) return false;
 
   return true;
 }

--- a/test/code-index-config.test.ts
+++ b/test/code-index-config.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { loadCodeIndexConfig } from '../src/core/code-index-config.ts';
+
+describe('loadCodeIndexConfig', () => {
+  test('returns null when gbrain.yml is missing or has no code_index section', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'gbrain-code-index-'));
+    try {
+      expect(loadCodeIndexConfig(tmp)).toBeNull();
+      writeFileSync(join(tmp, 'gbrain.yml'), 'storage:\n  db_tracked:\n    - people/\n');
+      expect(loadCodeIndexConfig(tmp)).toBeNull();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('loads include/exclude globs from code_index', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'gbrain-code-index-'));
+    try {
+      writeFileSync(join(tmp, 'gbrain.yml'), `code_index:
+  include:
+    - "**/*.kt"
+    - '**/*.kts'
+  exclude:
+    - "**/build/**"
+    - "keyboard/**/dictionary/**"
+`);
+      expect(loadCodeIndexConfig(tmp)).toEqual({
+        include: ['**/*.kt', '**/*.kts'],
+        exclude: ['**/build/**', 'keyboard/**/dictionary/**'],
+      });
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('loads empty inline lists', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'gbrain-code-index-'));
+    try {
+      writeFileSync(join(tmp, 'gbrain.yml'), `code_index:
+  include: []
+  exclude: []
+`);
+      expect(loadCodeIndexConfig(tmp)).toEqual({ include: [], exclude: [] });
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/sync-code-filters.test.ts
+++ b/test/sync-code-filters.test.ts
@@ -1,0 +1,110 @@
+import { beforeAll, afterAll, describe, expect, test } from 'bun:test';
+import { execSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { performSync } from '../src/commands/sync.ts';
+
+function createCodeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-code-sync-'));
+  execSync('git init', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: 'pipe' });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: 'pipe' });
+
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  mkdirSync(join(dir, 'build/generated'), { recursive: true });
+  mkdirSync(join(dir, 'keyboard/ask-core/addons/languages/en/dictionary'), { recursive: true });
+
+  writeFileSync(join(dir, 'gbrain.yml'), `code_index:
+  include:
+    - "**/*.kt"
+    - "**/*.kts"
+  exclude:
+    - "**/build/**"
+    - "**/generated/**"
+    - "keyboard/ask-core/addons/languages/**/dictionary/**"
+`);
+  writeFileSync(join(dir, 'src/main.kt'), 'class MainKeyboard\n');
+  writeFileSync(join(dir, 'src/gradle.kts'), 'println("keep")\n');
+  writeFileSync(join(dir, 'build/generated/skip.kt'), 'class GeneratedSkip\n');
+  writeFileSync(
+    join(dir, 'keyboard/ask-core/addons/languages/en/dictionary/huge.kt'),
+    'class DictionaryBlob\n',
+  );
+  execSync('git add -A && git commit -m "initial"', { cwd: dir, stdio: 'pipe' });
+
+  return dir;
+}
+
+async function captureLogs<T>(fn: () => Promise<T>): Promise<{ result: T; logs: string[] }> {
+  const logs: string[] = [];
+  const orig = console.log;
+  console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+  try {
+    const result = await fn();
+    return { result, logs };
+  } finally {
+    console.log = orig;
+  }
+}
+
+describe('performSync code_index filters', () => {
+  let engine: PGLiteEngine;
+  let repoPath: string;
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+    repoPath = createCodeRepo();
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+    rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  test('full code sync honors repo-local include/exclude filters and logs summary', async () => {
+    const { result, logs } = await captureLogs(() =>
+      performSync(engine, {
+        repoPath,
+        noPull: true,
+        noEmbed: true,
+        strategy: 'code',
+      }),
+    );
+
+    expect(result.status).toBe('first_sync');
+    expect(result.added).toBe(2);
+    expect(await engine.getPage('src-main-kt')).not.toBeNull();
+    expect(await engine.getPage('src-gradle-kts')).not.toBeNull();
+    expect(await engine.getPage('build-generated-skip-kt')).toBeNull();
+    expect(await engine.getPage('keyboard-ask-core-addons-languages-en-dictionary-huge-kt')).toBeNull();
+    expect(logs).toContain('Code import filters: 2 include globs, 3 exclude globs');
+    expect(logs).toContain('Found 2 code files after filtering');
+  });
+
+  test('incremental code sync applies the same filters to git diff changes', async () => {
+    writeFileSync(join(repoPath, 'src/feature.kt'), 'class FeatureKeyboard\n');
+    writeFileSync(join(repoPath, 'build/generated/ignored.kt'), 'class Ignored\n');
+    execSync('git add -A && git commit -m "incremental"', { cwd: repoPath, stdio: 'pipe' });
+
+    const { result, logs } = await captureLogs(() =>
+      performSync(engine, {
+        repoPath,
+        noPull: true,
+        noEmbed: true,
+        strategy: 'code',
+      }),
+    );
+
+    expect(result.status).toBe('synced');
+    expect(result.added).toBe(1);
+    expect(result.pagesAffected).toContain('src-feature-kt');
+    expect(await engine.getPage('src-feature-kt')).not.toBeNull();
+    expect(await engine.getPage('build-generated-ignored-kt')).toBeNull();
+    expect(logs).toContain('Code import filters: 2 include globs, 3 exclude globs');
+    expect(logs).toContain('Found 1 code files after filtering');
+  });
+});

--- a/test/sync-walker-symlink.test.ts
+++ b/test/sync-walker-symlink.test.ts
@@ -161,4 +161,27 @@ describe('collectSyncableFiles symlink + cycle hardening', () => {
       ]);
     });
   });
+
+  test('8. code_index include/exclude filters apply before file collection', async () => {
+    await withEnv({ GBRAIN_EMBEDDING_MULTIMODAL: undefined }, () => {
+      mkdirSync(join(tmp, 'src'), { recursive: true });
+      mkdirSync(join(tmp, 'build/generated'), { recursive: true });
+      mkdirSync(join(tmp, 'keyboard/lang/en/dictionary'), { recursive: true });
+      writeFileSync(join(tmp, 'src/keep.kt'), 'class Keep\n');
+      writeFileSync(join(tmp, 'src/keep.kts'), 'println("keep")\n');
+      writeFileSync(join(tmp, 'build/generated/skip.kt'), 'class Skip\n');
+      writeFileSync(join(tmp, 'keyboard/lang/en/dictionary/skip.kt'), 'class Skip\n');
+
+      const files = collectSyncableFiles(tmp, {
+        strategy: 'code',
+        include: ['**/*.kt', '**/*.kts'],
+        exclude: ['**/build/**', 'keyboard/**/dictionary/**'],
+      });
+
+      expect(files.map(f => f.replace(tmp, '')).sort()).toEqual([
+        '/src/keep.kt',
+        '/src/keep.kts',
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

  Add repo-local `gbrain.yml` support for code indexing filters during `gbrain sync --strategy code`.

  This change:
  - loads `code_index.include` and `code_index.exclude` from repo-local `gbrain.yml`
  - applies those globs during full-tree code file collection and incremental git-diff sync
  - makes exclude globs win over include globs
  - filters files before reading contents or embedding
  - prints a short filter summary during code sync
  - adds parser, walker, and end-to-end sync tests

  ## Test plan

  - [x] `bun test test/code-index-config.test.ts`
  - [x] `bun test test/sync-walker-symlink.test.ts`
  - [x] `bun test test/sync-code-filters.test.ts`
  - [x] `bun run typecheck`

- **feat: add repo-local code index filters**
- **chore: bump version to 0.33.1.2**
