### PR TITLE
fix(ai/embed): recognize OpenAI 'maximum request size' error so recursive halving fires

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -862,7 +862,10 @@ export function isTokenLimitError(err: unknown): boolean {
   return (
     /max.*allowed.*tokens.*batch/i.test(msg) ||
     /batch.*too.*many.*tokens/i.test(msg) ||
-    /token.*limit.*exceeded/i.test(msg)
+    /token.*limit.*exceeded/i.test(msg) ||
+    // OpenAI embeddings: "Invalid 'input': maximum request size is 300000 tokens per request."
+    /maximum request size.*tokens/i.test(msg) ||
+    /max.*tokens.*per.*request/i.test(msg)
   );
 }
 

--- a/test/ai/adaptive-embed-batch.test.ts
+++ b/test/ai/adaptive-embed-batch.test.ts
@@ -147,6 +147,21 @@ describe('isTokenLimitError (pure helper)', () => {
     expect(isTokenLimitError(new Error('Batch contains too many tokens'))).toBe(true);
   });
 
+  test('matches OpenAI embeddings "maximum request size" error (regression: PR ###)', () => {
+    // Real error string returned by OpenAI's /v1/embeddings endpoint when the
+    // sum of all input items exceeds 300k tokens. Without this match, gbrain's
+    // recursive-halving safety net never engages on OpenAI and the queue stalls
+    // forever on token-dense pages.
+    const openaiErr = new Error(
+      "Invalid 'input': maximum request size is 300000 tokens per request.",
+    );
+    expect(isTokenLimitError(openaiErr)).toBe(true);
+  });
+
+  test('matches generic "max tokens per request" phrasing', () => {
+    expect(isTokenLimitError(new Error('Exceeded 300000 max tokens per request'))).toBe(true);
+  });
+
   test('does not match unrelated errors', () => {
     expect(isTokenLimitError(new Error('Connection refused'))).toBe(false);
     expect(isTokenLimitError(new Error('Invalid API key'))).toBe(false);


### PR DESCRIPTION
## Problem

`isTokenLimitError` in `src/core/ai/gateway.ts` is what tells `embedSubBatch` whether to engage the recursive-halving safety net on a batch-too-big failure. It currently matches three error shapes (Voyage's "max allowed tokens per batch", generic "too many tokens", "token limit exceeded") — but **none of them match OpenAI's actual error string**, which is:

```
Invalid 'input': maximum request size is 300000 tokens per request.
```

Result: the recursive-halving recovery path **never fires on OpenAI**. A page whose chunk batch tokenizes past the 300k per-request hard cap fails the same way on every pass. The queue head stays blocked, every `gbrain embed --stale` run reports `Embedded 0 chunks`, and the only way out is to manually shrink the offending page (or hit it with a smaller model).

## Reproduction

```bash
# On any brain with a token-dense markdown page > ~280k tokens
gbrain embed --stale
# → "Error embedding <slug>: [embed(openai:text-embedding-3-large)]
#    Invalid 'input': maximum request size is 300000 tokens per request."
# → Embedded 0 chunks across N pages
# Re-run the same command 30 times: same result, no progress.
```

Locally I had a 31,129-chunk Postgres brain with 2,125 chunks (spread across 17 transcript-style pages) stuck across **30+ retry passes** with sleeps and concurrency tuning. The recursive halving in `embedSubBatch` would have walked each fat batch down to a passable size — but `isTokenLimitError(err)` returned `false`, so the catch clause fell straight through to `throw normalizeAIError(...)`.

## Fix

Add two patterns to `isTokenLimitError`:

```ts
// OpenAI embeddings: "Invalid 'input': maximum request size is 300000 tokens per request."
/maximum request size.*tokens/i.test(msg) ||
/max.*tokens.*per.*request/i.test(msg)
```

The first matches OpenAI's exact phrasing. The second is a defensive catch for the same intent worded slightly differently (e.g. "exceeded 300000 max tokens per request"), which would also be a halving-recoverable error.

## Verification

After applying just this patch (no other changes), the same 2,125-chunk backlog that had survived 30+ passes cleared in **one pass, under 60 seconds**:

```
=== pass 1 08:41:07 ===
[embed.pages] 17/17 (100%)
Embedded 2125 chunks across 17 pages
remaining: 0
DONE
```

Brain went from 93% → 100% embedding coverage (31,129 / 31,129 chunks).

## Tests

Added two regression cases in `test/ai/adaptive-embed-batch.test.ts`:

1. Exact OpenAI error string match
2. Generic "max tokens per request" phrasing

All 25 tests in `adaptive-embed-batch.test.ts` still pass (`bun test test/ai/adaptive-embed-batch.test.ts`).

## Relationship to PR #924

PR #924 (already open from me) adds `max_batch_tokens` to the OpenAI recipe so the pre-split path partitions batches before they hit the wire. That's the right fix for **fresh** ingests — it prevents most oversize requests from ever being constructed.

This PR fixes the **recovery path** for cases where pre-split isn't enough (token-density estimator underestimates a page's real tokens, or `max_batch_tokens` is left high). The two PRs are complementary:

- #924 = belt (cap batches up front)
- this PR = suspenders (let halving rescue any batch that still trips the cap)

A brain that has #924 alone will still get stuck on the same outlier pages that triggered this investigation; only the regex fix unblocks them.

## Risk

- Behavior change is strictly opt-in: the two added regexes only matter when an error message contains those token strings. Existing matching errors still match.
- No provider returns these strings as part of a non-recoverable error (e.g. auth, rate limit, network) — verified against OpenAI, Voyage, Azure OpenAI, DashScope, Zhipu, Minimax error catalogs.
- The `MIN_SUB_BATCH = 1` terminal guard already prevents infinite recursion on a single-text-too-big edge case (covered by an existing test).
