### PR TITLE
fix(extract_facts): add items to entity_hints array schema

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2573,7 +2573,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },


### PR DESCRIPTION
## Summary

Add `items: { type: 'string' }` to the `entity_hints` array param on the `extract_facts` MCP tool.

## Why

OpenAI's Responses API function-call validator rejects array parameters that don't include an `items` sub-schema. When an agent connects to gbrain via remote MCP and registers tools into the OpenAI Responses API, registration fails with `invalid_function_parameters` and the entire MCP server is unusable for that agent.

## Repro

Observed 2026-05-14 with paperclip's `opencode_k8s` Staff Engineer agent. Adding gbrain to the agent's MCP baseline (`http://gbrain-mcp-internal.../mcp`) caused `adapter_failed` on every spawn until gbrain was removed from the baseline. The other 5 array-typed params on other gbrain tools already include `items` — `entity_hints` was the one outlier.

## Test plan

- [x] 1-line schema fix; `git diff` confirms no other params touched
- [ ] Manual: register the patched server with an OpenAI-Responses-API-backed agent and confirm tool list loads without `invalid_function_parameters`