### PR TITLE
fix(migrations): propagate GBRAIN_DATABASE_URL + GBRAIN_DISABLE_DIRECT_POOL to migration subprocesses (IPv6 band-aid)

### DIFF
--- a/src/commands/migrations/v0_11_0.ts
+++ b/src/commands/migrations/v0_11_0.ts
@@ -39,6 +39,24 @@ function home(): string { return process.env.HOME || ''; }
 function gbrainDir(): string { return join(home(), '.gbrain'); }
 function pendingHostWorkPath(): string { return join(gbrainDir(), 'migrations', 'pending-host-work.jsonl'); }
 
+// Read the configured database URL from ~/.gbrain/config.json so subprocess
+// calls (gbrain init --migrate-only) use the pooler URL instead of attempting
+// a direct IPv6 connection. Falls back to process.env.GBRAIN_DATABASE_URL.
+function configuredDatabaseUrl(): string | undefined {
+  try {
+    const cfg = JSON.parse(readFileSync(join(gbrainDir(), 'config.json'), 'utf8'));
+    return cfg.database_url || process.env.GBRAIN_DATABASE_URL;
+  } catch {
+    return process.env.GBRAIN_DATABASE_URL;
+  }
+}
+
+function childEnv(): NodeJS.ProcessEnv {
+  const dbUrl = configuredDatabaseUrl();
+  if (!dbUrl) return process.env;
+  return { ...process.env, GBRAIN_DATABASE_URL: dbUrl, GBRAIN_DISABLE_DIRECT_POOL: '1' };
+}
+
 export interface PendingHostWorkEntry {
   type: 'cron-handler-needs-host-registration' | 'agents-md-dispatcher-needs-host-review';
   status: 'pending' | 'complete';
@@ -61,7 +79,7 @@ export interface PendingHostWorkEntry {
 function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'schema', status: 'skipped', detail: 'dry-run' };
   try {
-    execSync('gbrain init --migrate-only' + childGlobalFlags(), { stdio: 'inherit', timeout: 60_000, env: process.env });
+    execSync('gbrain init --migrate-only' + childGlobalFlags(), { stdio: 'inherit', timeout: 60_000, env: childEnv() });
     return { name: 'schema', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -76,7 +94,7 @@ function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
 function phaseBSmoke(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'smoke', status: 'skipped', detail: 'dry-run' };
   try {
-    execSync('gbrain jobs smoke', { stdio: 'inherit', timeout: 30_000, env: process.env });
+    execSync('gbrain jobs smoke', { stdio: 'inherit', timeout: 30_000, env: childEnv() });
     return { name: 'smoke', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -397,7 +415,7 @@ function phaseFInstall(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'install', status: 'skipped', detail: 'dry-run' };
   if (opts.noAutopilotInstall) return { name: 'install', status: 'skipped', detail: '--no-autopilot-install' };
   try {
-    execSync('gbrain autopilot --install --yes', { stdio: 'inherit', timeout: 60_000, env: process.env });
+    execSync('gbrain autopilot --install --yes', { stdio: 'inherit', timeout: 60_000, env: childEnv() });
     return { name: 'install', status: 'complete' };
   } catch (e) {
     // Install is best-effort — log but don't fail the whole migration. User

--- a/src/commands/migrations/v0_12_0.ts
+++ b/src/commands/migrations/v0_12_0.ts
@@ -33,6 +33,19 @@
 import { execSync } from 'child_process';
 import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhaseResult } from './types.ts';
 import { childGlobalFlags } from '../../core/cli-options.ts';
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Use pooler URL from config so subprocess calls skip the direct IPv6 connection.
+function _childEnv(): NodeJS.ProcessEnv {
+  try {
+    const cfg = JSON.parse(readFileSync(join(process.env.HOME || '', '.gbrain', 'config.json'), 'utf8'));
+    const u = cfg.database_url || process.env.GBRAIN_DATABASE_URL;
+    return { ...process.env, ...(u ? { GBRAIN_DATABASE_URL: u } : {}), GBRAIN_DISABLE_DIRECT_POOL: '1' };
+  } catch { return process.env; }
+}
+
 // Bug 3 — ledger writes moved to the runner (apply-migrations.ts).
 
 // ── Phase A — Schema ────────────────────────────────────────
@@ -43,7 +56,7 @@ function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
     // 10-minute budget. Migrations v8/v9 dedup with helper-index should be sub-second
     // even on 80K-duplicate brains, but the outer wall-clock cap shouldn't be the
     // failure mode (the prior 60s ceiling tripped Garry's production upgrade).
-    execSync('gbrain init --migrate-only' + childGlobalFlags(), { stdio: 'inherit', timeout: 600_000, env: process.env });
+    execSync('gbrain init --migrate-only' + childGlobalFlags(), { stdio: 'inherit', timeout: 600_000, env: _childEnv() });
     return { name: 'schema', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -67,7 +80,7 @@ function phaseBConfigCheck(opts: OrchestratorOpts): OrchestratorPhaseResult & { 
   // Default behavior when unset = enabled (per isAutoLinkEnabled).
   let raw = '';
   try {
-    raw = execSync('gbrain config get auto_link', { encoding: 'utf-8', timeout: 10_000, env: process.env }).trim();
+    raw = execSync('gbrain config get auto_link', { encoding: 'utf-8', timeout: 10_000, env: _childEnv() }).trim();
   } catch {
     // get exits non-zero when the key isn't set — that's fine, defaults to enabled.
     raw = '';
@@ -93,7 +106,7 @@ function phaseCBackfillLinks(opts: OrchestratorOpts): OrchestratorPhaseResult {
     // --source db is idempotent: the UNIQUE constraint on
     // (from_page_id, to_page_id, link_type) and ON CONFLICT DO NOTHING
     // make re-runs cheap. Empty brains return 0/0 quickly.
-    execSync('gbrain extract links --source db' + childGlobalFlags(), { stdio: 'inherit', timeout: 600_000, env: process.env });
+    execSync('gbrain extract links --source db' + childGlobalFlags(), { stdio: 'inherit', timeout: 600_000, env: _childEnv() });
     return { name: 'backfill_links', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -104,7 +117,7 @@ function phaseCBackfillLinks(opts: OrchestratorOpts): OrchestratorPhaseResult {
 function phaseDBackfillTimeline(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'backfill_timeline', status: 'skipped', detail: 'dry-run' };
   try {
-    execSync('gbrain extract timeline --source db' + childGlobalFlags(), { stdio: 'inherit', timeout: 600_000, env: process.env });
+    execSync('gbrain extract timeline --source db' + childGlobalFlags(), { stdio: 'inherit', timeout: 600_000, env: _childEnv() });
     return { name: 'backfill_timeline', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -123,7 +136,7 @@ interface StatsSnapshot {
 function readStats(): StatsSnapshot | null {
   try {
     const out = execSync('gbrain get_stats --json 2>/dev/null || gbrain stats', {
-      encoding: 'utf-8', timeout: 30_000, env: process.env,
+      encoding: 'utf-8', timeout: 30_000, env: _childEnv(),
     });
     // The fallback `gbrain stats` prints human-readable output; parse loosely.
     const pages = parseInt((out.match(/Pages:\s+(\d+)/) || ['', '0'])[1], 10);

--- a/src/commands/migrations/v0_12_2.ts
+++ b/src/commands/migrations/v0_12_2.ts
@@ -21,8 +21,20 @@
  */
 
 import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhaseResult } from './types.ts';
 import { childGlobalFlags } from '../../core/cli-options.ts';
+
+// Use pooler URL from config so subprocess calls skip the direct IPv6 connection.
+function _childEnv(): NodeJS.ProcessEnv {
+  try {
+    const cfg = JSON.parse(readFileSync(join(process.env.HOME || '', '.gbrain', 'config.json'), 'utf8'));
+    const u = cfg.database_url || process.env.GBRAIN_DATABASE_URL;
+    return { ...process.env, ...(u ? { GBRAIN_DATABASE_URL: u } : {}), GBRAIN_DISABLE_DIRECT_POOL: '1' };
+  } catch { return process.env; }
+}
+
 // Bug 3 — ledger writes moved to the runner (apply-migrations.ts).
 
 // ── Phase A — Schema ────────────────────────────────────────
@@ -32,7 +44,7 @@ function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
   try {
     // Propagate global progress flags so the child shows the same mode the
     // parent orchestrator is running in.
-    execSync('gbrain init --migrate-only' + childGlobalFlags(), { stdio: 'inherit', timeout: 60_000, env: process.env });
+    execSync('gbrain init --migrate-only' + childGlobalFlags(), { stdio: 'inherit', timeout: 60_000, env: _childEnv() });
     return { name: 'schema', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -46,7 +58,7 @@ function phaseBRepair(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'jsonb_repair', status: 'skipped', detail: 'dry-run' };
   try {
     // stdio: 'inherit' — child's stderr progress streams straight through.
-    execSync('gbrain repair-jsonb' + childGlobalFlags(), { stdio: 'inherit', timeout: 600_000, env: process.env });
+    execSync('gbrain repair-jsonb' + childGlobalFlags(), { stdio: 'inherit', timeout: 600_000, env: _childEnv() });
     return { name: 'jsonb_repair', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -65,7 +77,7 @@ function phaseCVerify(opts: OrchestratorOpts): OrchestratorPhaseResult {
     // (per Codex review #12). NOTE: we deliberately do NOT pass
     // --progress-json here — this child is parsed, not watched.
     const out = execSync('gbrain repair-jsonb --dry-run --json', {
-      encoding: 'utf-8', timeout: 60_000, env: process.env,
+      encoding: 'utf-8', timeout: 60_000, env: _childEnv(),
       stdio: ['ignore', 'pipe', 'inherit'],
     });
     const parsed = JSON.parse(out) as { total_repaired?: number; engine?: string };

--- a/src/commands/migrations/v0_13_0.ts
+++ b/src/commands/migrations/v0_13_0.ts
@@ -27,6 +27,9 @@
 
 import { execSync } from 'child_process';
 import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhaseResult } from './types.ts';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
 // Bug 3 — ledger writes moved to the runner (apply-migrations.ts). The
 // orchestrator returns its result and the runner persists it.
 
@@ -44,10 +47,18 @@ import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhase
 // upgrade mid-migration. The shim is already the canonical wrapper; trust
 // it. Regression guarded by test/migrations-v0_13_0.test.ts.
 
+
+function _childEnv(): NodeJS.ProcessEnv {
+  try {
+    const cfg = JSON.parse(readFileSync(join(process.env.HOME || '', '.gbrain', 'config.json'), 'utf8'));
+    const u = cfg.database_url || process.env.GBRAIN_DATABASE_URL;
+    return { ...process.env, ...(u ? { GBRAIN_DATABASE_URL: u } : {}), GBRAIN_DISABLE_DIRECT_POOL: '1' };
+  } catch { return process.env; }
+}
 function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'schema', status: 'skipped', detail: 'dry-run' };
   try {
-    execSync('gbrain init --migrate-only', { stdio: 'inherit', timeout: 600_000, env: process.env });
+    execSync('gbrain init --migrate-only', { stdio: 'inherit', timeout: 600_000, env: _childEnv() });
     return { name: 'schema', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
@@ -67,7 +78,7 @@ function phaseBBackfill(opts: OrchestratorOpts): OrchestratorPhaseResult {
     execSync('gbrain extract links --source db --include-frontmatter', {
       stdio: 'inherit',
       timeout: 1_800_000,  // 30 min hard cap; typical 2-5 min on 46K pages
-      env: process.env,
+      env: _childEnv(),
     });
     return { name: 'frontmatter_backfill', status: 'complete' };
   } catch (e) {
@@ -90,7 +101,7 @@ function phaseCVerify(opts: OrchestratorOpts): OrchestratorPhaseResult {
     // produce 0. Phase B's own stdout shows `Links: created N` which is
     // the authoritative signal — user sees it during upgrade.
     const out = execSync('gbrain call get_stats', {
-      encoding: 'utf-8', timeout: 60_000, env: process.env,
+      encoding: 'utf-8', timeout: 60_000, env: _childEnv(),
     });
     const parsed = JSON.parse(out) as { link_count?: number; page_count?: number };
     const linkCount = parsed.link_count ?? 0;

--- a/src/commands/migrations/v0_16_0.ts
+++ b/src/commands/migrations/v0_16_0.ts
@@ -23,15 +23,26 @@ import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhase
 import { appendCompletedMigration } from '../../core/preferences.ts';
 import { loadConfig, toEngineConfig } from '../../core/config.ts';
 import { createEngine } from '../../core/engine-factory.ts';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
 
 const REQUIRED_TABLES = ['subagent_messages', 'subagent_tool_executions', 'subagent_rate_leases'] as const;
 
 // ── Phase A — Schema ────────────────────────────────────────
 
+
+function _childEnv(): NodeJS.ProcessEnv {
+  try {
+    const cfg = JSON.parse(readFileSync(join(process.env.HOME || '', '.gbrain', 'config.json'), 'utf8'));
+    const u = cfg.database_url || process.env.GBRAIN_DATABASE_URL;
+    return { ...process.env, ...(u ? { GBRAIN_DATABASE_URL: u } : {}), GBRAIN_DISABLE_DIRECT_POOL: '1' };
+  } catch { return process.env; }
+}
 function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'schema', status: 'skipped', detail: 'dry-run' };
   try {
-    execSync('gbrain init --migrate-only', { stdio: 'inherit', timeout: 60_000, env: process.env });
+    execSync('gbrain init --migrate-only', { stdio: 'inherit', timeout: 60_000, env: _childEnv() });
     return { name: 'schema', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/src/commands/migrations/v0_18_0.ts
+++ b/src/commands/migrations/v0_18_0.ts
@@ -24,13 +24,24 @@ import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhase
 import { appendCompletedMigration } from '../../core/preferences.ts';
 import { loadConfig, toEngineConfig } from '../../core/config.ts';
 import { createEngine } from '../../core/engine-factory.ts';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
 
 // ── Phase A — Schema ────────────────────────────────────────
 
+
+function _childEnv(): NodeJS.ProcessEnv {
+  try {
+    const cfg = JSON.parse(readFileSync(join(process.env.HOME || '', '.gbrain', 'config.json'), 'utf8'));
+    const u = cfg.database_url || process.env.GBRAIN_DATABASE_URL;
+    return { ...process.env, ...(u ? { GBRAIN_DATABASE_URL: u } : {}), GBRAIN_DISABLE_DIRECT_POOL: '1' };
+  } catch { return process.env; }
+}
 function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'schema', status: 'skipped', detail: 'dry-run' };
   try {
-    execSync('gbrain init --migrate-only', { stdio: 'inherit', timeout: 600_000, env: process.env });
+    execSync('gbrain init --migrate-only', { stdio: 'inherit', timeout: 600_000, env: _childEnv() });
     return { name: 'schema', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/src/commands/migrations/v0_18_1.ts
+++ b/src/commands/migrations/v0_18_1.ts
@@ -18,13 +18,24 @@
 
 import { execSync } from 'child_process';
 import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhaseResult } from './types.ts';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
 
 // ── Phase A — Schema ────────────────────────────────────────
 
+
+function _childEnv(): NodeJS.ProcessEnv {
+  try {
+    const cfg = JSON.parse(readFileSync(join(process.env.HOME || '', '.gbrain', 'config.json'), 'utf8'));
+    const u = cfg.database_url || process.env.GBRAIN_DATABASE_URL;
+    return { ...process.env, ...(u ? { GBRAIN_DATABASE_URL: u } : {}), GBRAIN_DISABLE_DIRECT_POOL: '1' };
+  } catch { return process.env; }
+}
 function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'schema', status: 'skipped', detail: 'dry-run' };
   try {
-    execSync('gbrain init --migrate-only', { stdio: 'inherit', timeout: 600_000, env: process.env });
+    execSync('gbrain init --migrate-only', { stdio: 'inherit', timeout: 600_000, env: _childEnv() });
     return { name: 'schema', status: 'complete' };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/src/commands/migrations/v0_21_0.ts
+++ b/src/commands/migrations/v0_21_0.ts
@@ -28,16 +28,26 @@
 import { execSync } from 'child_process';
 import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhaseResult } from './types.ts';
 import { childGlobalFlags } from '../../core/cli-options.ts';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 // ── Phase A — Schema ────────────────────────────────────────
 
+
+function _childEnv(): NodeJS.ProcessEnv {
+  try {
+    const cfg = JSON.parse(readFileSync(join(process.env.HOME || '', '.gbrain', 'config.json'), 'utf8'));
+    const u = cfg.database_url || process.env.GBRAIN_DATABASE_URL;
+    return { ...process.env, ...(u ? { GBRAIN_DATABASE_URL: u } : {}), GBRAIN_DISABLE_DIRECT_POOL: '1' };
+  } catch { return process.env; }
+}
 function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'schema', status: 'skipped', detail: 'dry-run' };
   try {
     execSync('gbrain init --migrate-only' + childGlobalFlags(), {
       stdio: 'inherit',
       timeout: 600_000,
-      env: process.env,
+      env: _childEnv(),
     });
     return { name: 'schema', status: 'complete' };
   } catch (e) {

--- a/src/commands/migrations/v0_29_1.ts
+++ b/src/commands/migrations/v0_29_1.ts
@@ -22,16 +22,26 @@ import { execSync } from 'child_process';
 import type { BrainEngine } from '../../core/engine.ts';
 import type { Migration, OrchestratorOpts, OrchestratorResult, OrchestratorPhaseResult } from './types.ts';
 import { childGlobalFlags } from '../../core/cli-options.ts';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 // ── Phase A — Schema ────────────────────────────────────────
 
+
+function _childEnv(): NodeJS.ProcessEnv {
+  try {
+    const cfg = JSON.parse(readFileSync(join(process.env.HOME || '', '.gbrain', 'config.json'), 'utf8'));
+    const u = cfg.database_url || process.env.GBRAIN_DATABASE_URL;
+    return { ...process.env, ...(u ? { GBRAIN_DATABASE_URL: u } : {}), GBRAIN_DISABLE_DIRECT_POOL: '1' };
+  } catch { return process.env; }
+}
 function phaseASchema(opts: OrchestratorOpts): OrchestratorPhaseResult {
   if (opts.dryRun) return { name: 'schema', status: 'skipped', detail: 'dry-run' };
   try {
     execSync('gbrain init --migrate-only' + childGlobalFlags(), {
       stdio: 'inherit',
       timeout: 600_000, // 10 min — duplicate-heavy installs can be slow
-      env: process.env,
+      env: _childEnv(),
     });
     return { name: 'schema', status: 'complete' };
   } catch (e) {


### PR DESCRIPTION
## Problem

`gbrain apply-migrations --yes` fails on networks where Supabase's **direct connection** (`db.<ref>.supabase.co:5432`) is IPv6-only — which is the default for most Supabase projects.

### Root cause chain

1. User configures gbrain with a **Session Pooler URL** (port 6543, IPv4-accessible)
2. `connection-manager.ts:deriveDirectUrl()` detects a pooler URL and auto-derives `db.<ref>.supabase.co:5432` for DDL operations
3. `apply-migrations.ts` runs orchestrators; orchestrators spawn child subprocesses via `execSync('gbrain init --migrate-only', { env: process.env })`
4. Child subprocesses inherit `process.env` — but this may **not** contain `GBRAIN_DATABASE_URL` (it was loaded from `~/.gbrain/config.json` at parent startup, not re-exported to env)
5. Child processes re-connect using the config file URL, `connection-manager.ts` derives the IPv6-only direct URL, and `ddl()` calls fail with `ECONNREFUSED`

```
parent process (gbrain apply-migrations)
  └─ reads config.json → GBRAIN_DATABASE_URL = pooler:6543 (IPv4) ✓
  └─ spawns: execSync('gbrain init --migrate-only', { env: process.env })
               └─ child reads config.json → derives db.<ref>.supabase.co:5432
               └─ ddl() → connect to port 5432 → ECONNREFUSED (IPv6-only) ✗
```

### Repro

- Supabase project (Session Pooler on port 6543)
- IPv4-only or IPv4-preferred network (most home/office networks)
- `gbrain apply-migrations --yes` → ECONNREFUSED on all orchestrator-spawned subprocesses

Related: https://github.com/garrytan/gstack/issues/1301
See also: https://github.com/garrytan/gstack/pull/1249 (similar IPv6-avoidance pattern in browse module)

## This fix (band-aid)

Add `_childEnv()` to each migration orchestrator that:
1. Reads `~/.gbrain/config.json` → guarantees `GBRAIN_DATABASE_URL` is the pooler URL in child env
2. Sets `GBRAIN_DISABLE_DIRECT_POOL=1` → suppresses `deriveDirectUrl()` in the child's `connection-manager`

```typescript
function _childEnv(): NodeJS.ProcessEnv {
  try {
    const cfg = JSON.parse(readFileSync(join(process.env.HOME || '', '.gbrain', 'config.json'), 'utf8'));
    const u = cfg.database_url || process.env.GBRAIN_DATABASE_URL;
    return { ...process.env, ...(u ? { GBRAIN_DATABASE_URL: u } : {}), GBRAIN_DISABLE_DIRECT_POOL: '1' };
  } catch { return process.env; }
}
// All execSync calls changed from: { env: process.env }
//                              to: { env: _childEnv() }
```

**Files changed:** v0.11.0, v0.12.0, v0.12.2, v0.13.0, v0.16.0, v0.18.0, v0.18.1, v0.21.0, v0.29.1

## Why this is a band-aid

- `_childEnv()` is duplicated across 9 files
- Future migration orchestrators won't have it unless added manually
- Re-reads config.json instead of using already-parsed parent state
- `GBRAIN_DISABLE_DIRECT_POOL=1` is a blunt instrument (affects ALL operations in the child, not just DDL)

## The principled fix

`deriveDirectUrl()` should not derive a direct URL when the primary URL is already a **Session Pooler** (port 6543). Session Pooler maintains session state and supports DDL natively — the whole reason for the dual-pool architecture was to work around *Transaction Pooler*'s statelessness and 2-minute statement timeout. Session Pooler has neither of those constraints.

A companion PR with that 4-line fix to `connection-manager.ts` makes this 126-line band-aid unnecessary.

## Happy to PR the band-aid fix if useful

Verified working on:
- macOS 26.x (Darwin 25.5.0)  
- gbrain v0.33.2.1  
- Supabase Session Pooler (port 6543, `aws-1-ap-northeast-1.pooler.supabase.com`)
- Schema upgrade v24 → v57 completed successfully after this fix