### PR TITLE
fix(oauth): throw InvalidTokenError so bearerAuth returns 401, not 500

### DIFF
--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -22,6 +22,7 @@ import type {
 import type { OAuthServerProvider, AuthorizationParams } from '@modelcontextprotocol/sdk/server/auth/provider.js';
 import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { hashToken, generateToken, isUndefinedColumnError } from './utils.ts';
 import { hasScope, assertAllowedScopes, parseScopeString, InvalidScopeError } from './scope.ts';
 import type { SqlQuery, SqlValue } from './sql-query.ts';
@@ -538,7 +539,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
       // throw here rather than return an undefined-bearing AuthInfo.
       const expiresAt = coerceTimestamp(row.expires_at);
       if (expiresAt === undefined || expiresAt < now) {
-        throw new Error('Token expired');
+        throw new InvalidTokenError('Token expired');
       }
       // v0.34.1 (#876): federated_read normalization. SELECT returns
       // either a JS array (Postgres / PGLite text[] driver mapping) or
@@ -596,7 +597,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
       } as AuthInfo;
     }
 
-    throw new Error('Invalid token');
+    throw new InvalidTokenError('Invalid token');
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`verifyAccessToken` in `src/core/oauth-provider.ts` throws plain `Error` for expired/invalid tokens:

```ts
throw new Error('Token expired')
throw new Error('Invalid token')
```

The MCP SDK's `requireBearerAuth` middleware uses `instanceof` checks to map errors to HTTP responses — only `InvalidTokenError`/`InsufficientScopeError`/`OAuthError` map to proper status codes. Plain `Error` falls through to the catch-all, yielding a **500** with an OAuth-shaped body:

```json
{"error":"server_error","error_description":"Internal Server Error"}
```

## Impact for clients

MCP clients (e.g. rmcp / codex CLI) cannot deserialize that as JSON-RPC and surface cryptic errors like:

`Deserialize error: data did not match any variant of untagged enum JsonRpcMessage, when send initialize request`

This looks like a server crash, not an auth issue. Diagnosed during a real incident where a stale bearer token cost ~6h of debugging before the underlying cause (token expiry) was identified.

## Reproduction

```bash
curl -X POST -H "Authorization: Bearer expired_or_invalid_token" \\
     -H "Content-Type: application/json" \\
     -H "Accept: application/json, text/event-stream" \\
     --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"x","version":"0"}}}' \\
     https://<your-gbrain>/mcp
# Currently: HTTP 500 {"error":"server_error","error_description":"Internal Server Error"}
# After fix: HTTP 401 with WWW-Authenticate: Bearer error="invalid_token", error_description="Token expired"
```

## Fix

Two lines + one import (see diff). Replace `new Error` with `new InvalidTokenError` from `@modelcontextprotocol/sdk/server/auth/errors.js`.

## No behaviour change for valid tokens

Only error paths affected. Tested against a live v0.31.3 deployment.