### PR TITLE
fix(bootstrap): cover v0.34.1 oauth_clients.{source_id, federated_read} columns

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -243,6 +243,8 @@ export class PGLiteEngine implements BrainEngine {
    *     (indexed by `idx_mcp_log_agent_time`) — v0.26.3
    *   - `subagent_messages.provider_id` column (indexed by
    *     `idx_subagent_messages_provider`) — v0.27
+   *   - `oauth_clients.source_id` + `federated_read` columns (indexed by
+   *     `idx_oauth_clients_source_id` and `idx_oauth_clients_federated_read`) — v0.34.1
    *
    * **Maintenance contract:** when a future migration adds a column-with-index
    * or new-table-with-FK referenced by PGLITE_SCHEMA_SQL, extend this method
@@ -288,7 +290,13 @@ export class PGLiteEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.tables
                 WHERE table_schema='public' AND table_name='ingest_log') AS ingest_log_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema='public' AND table_name='ingest_log' AND column_name='source_id') AS ingest_log_source_id_exists
+                WHERE table_schema='public' AND table_name='ingest_log' AND column_name='source_id') AS ingest_log_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema='public' AND table_name='oauth_clients') AS oauth_clients_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='oauth_clients' AND column_name='source_id') AS oauth_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='oauth_clients' AND column_name='federated_read') AS oauth_federated_read_exists
     `);
     const probe = rows[0] as {
       pages_exists: boolean;
@@ -309,6 +317,9 @@ export class PGLiteEngine implements BrainEngine {
       subagent_provider_id_exists: boolean;
       ingest_log_exists: boolean;
       ingest_log_source_id_exists: boolean;
+      oauth_clients_exists: boolean;
+      oauth_source_id_exists: boolean;
+      oauth_federated_read_exists: boolean;
     };
 
     const needsPagesBootstrap = probe.pages_exists && !probe.source_id_exists;
@@ -332,12 +343,20 @@ export class PGLiteEngine implements BrainEngine {
     // references source_id. Old brains have ingest_log without source_id;
     // bootstrap adds the column before SCHEMA_SQL replay creates the index.
     const needsIngestLogSourceId = probe.ingest_log_exists && !probe.ingest_log_source_id_exists;
+    // v0.34.1 (#861 + #876): idx_oauth_clients_source_id (partial) and
+    // idx_oauth_clients_federated_read (GIN) in PGLITE_SCHEMA_SQL reference
+    // these two columns. Pre-v0.34 brains have oauth_clients without them;
+    // bootstrap adds both before SCHEMA_SQL replay so the CREATE INDEX
+    // statements don't crash with `column "source_id" does not exist`.
+    const needsOauthClientsBootstrap = probe.oauth_clients_exists
+      && (!probe.oauth_source_id_exists || !probe.oauth_federated_read_exists);
 
     // Fresh installs (no tables yet) and modern brains both no-op.
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
         && !needsPagesDeletedAt && !needsChunksEmbeddingImage
         && !needsMcpLogBootstrap && !needsSubagentProviderId
-        && !needsPagesRecency && !needsIngestLogSourceId) return;
+        && !needsPagesRecency && !needsIngestLogSourceId
+        && !needsOauthClientsBootstrap) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
 
@@ -463,6 +482,24 @@ export class PGLiteEngine implements BrainEngine {
       // DEFAULT 'default' so the index can build cleanly.
       await this.db.exec(`
         ALTER TABLE ingest_log ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT 'default';
+      `);
+    }
+
+    if (needsOauthClientsBootstrap) {
+      // v0.34.1 (#861 + #876) adds source_id (write-source scope) and
+      // federated_read (read-source array) to oauth_clients. PGLITE_SCHEMA_SQL's
+      //   CREATE INDEX idx_oauth_clients_source_id ON oauth_clients(source_id)
+      //     WHERE source_id IS NOT NULL;
+      //   CREATE INDEX idx_oauth_clients_federated_read ON oauth_clients USING GIN(federated_read);
+      // both crash on pre-v0.34 brains without the columns. Migrations v60-v65
+      // backfill both alongside the rest of the federated-OAuth wave; bootstrap
+      // only adds enough state for SCHEMA_SQL replay to land cleanly. The
+      // migration chain runs later via runMigrations and is idempotent.
+      await this.db.exec(`
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS source_id TEXT
+          REFERENCES sources(id) ON DELETE RESTRICT;
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_read TEXT[]
+          NOT NULL DEFAULT '{}';
       `);
     }
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -289,6 +289,8 @@ export class PostgresEngine implements BrainEngine {
    *     (indexed by `idx_mcp_log_agent_time`) — v0.26.3
    *   - `subagent_messages.provider_id` column (indexed by
    *     `idx_subagent_messages_provider`) — v0.27
+   *   - `oauth_clients.source_id` + `federated_read` columns (indexed by
+   *     `idx_oauth_clients_source_id` and `idx_oauth_clients_federated_read`) — v0.34.1
    *
    * Keep this in sync with the PGLite version; covered by
    * `test/schema-bootstrap-coverage.test.ts` (PGLite side) and
@@ -319,6 +321,9 @@ export class PostgresEngine implements BrainEngine {
       subagent_provider_id_exists: boolean;
       ingest_log_exists: boolean;
       ingest_log_source_id_exists: boolean;
+      oauth_clients_exists: boolean;
+      oauth_source_id_exists: boolean;
+      oauth_federated_read_exists: boolean;
     }[]>`
       SELECT
         EXISTS (SELECT 1 FROM information_schema.tables
@@ -356,7 +361,13 @@ export class PostgresEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.tables
                 WHERE table_schema = current_schema() AND table_name = 'ingest_log') AS ingest_log_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema = current_schema() AND table_name = 'ingest_log' AND column_name = 'source_id') AS ingest_log_source_id_exists
+                WHERE table_schema = current_schema() AND table_name = 'ingest_log' AND column_name = 'source_id') AS ingest_log_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema() AND table_name = 'oauth_clients') AS oauth_clients_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'oauth_clients' AND column_name = 'source_id') AS oauth_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'oauth_clients' AND column_name = 'federated_read') AS oauth_federated_read_exists
     `;
     const probe = probeRows[0]!;
 
@@ -386,11 +397,18 @@ export class PostgresEngine implements BrainEngine {
     // source_id. Old brains have ingest_log without source_id; bootstrap adds
     // the column before SCHEMA_SQL replay creates the index.
     const needsIngestLogSourceId = probe.ingest_log_exists && !probe.ingest_log_source_id_exists;
+    // v0.34.1 (#861 + #876): idx_oauth_clients_source_id (partial) and
+    // idx_oauth_clients_federated_read (GIN) in SCHEMA_SQL reference these
+    // two columns. Pre-v0.34 brains have oauth_clients without them;
+    // bootstrap adds both before SCHEMA_SQL replay so the CREATE INDEX
+    // statements don't crash with `column "source_id" does not exist`.
+    const needsOauthClientsBootstrap = probe.oauth_clients_exists
+      && (!probe.oauth_source_id_exists || !probe.oauth_federated_read_exists);
 
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
         && !needsPagesDeletedAt && !needsMcpLogBootstrap && !needsSubagentProviderId
         && !needsChunksEmbeddingImage && !needsPagesRecency
-        && !needsIngestLogSourceId) return;
+        && !needsIngestLogSourceId && !needsOauthClientsBootstrap) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
 
@@ -516,6 +534,24 @@ export class PostgresEngine implements BrainEngine {
       // so the index can build cleanly.
       await conn.unsafe(`
         ALTER TABLE ingest_log ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT 'default';
+      `);
+    }
+
+    if (needsOauthClientsBootstrap) {
+      // v0.34.1 (#861 + #876) adds source_id (write-source scope) and
+      // federated_read (read-source array) to oauth_clients. SCHEMA_SQL's
+      //   CREATE INDEX idx_oauth_clients_source_id ON oauth_clients(source_id)
+      //     WHERE source_id IS NOT NULL;
+      //   CREATE INDEX idx_oauth_clients_federated_read ON oauth_clients USING GIN(federated_read);
+      // both crash on pre-v0.34 brains without the columns. Migrations v60-v65
+      // backfill both alongside the rest of the federated-OAuth wave; bootstrap
+      // only adds enough state for SCHEMA_SQL replay to land cleanly. The
+      // migration chain runs later via runMigrations and is idempotent.
+      await conn.unsafe(`
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS source_id TEXT
+          REFERENCES sources(id) ON DELETE RESTRICT;
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_read TEXT[]
+          NOT NULL DEFAULT '{}';
       `);
     }
   }

--- a/test/schema-bootstrap-coverage.test.ts
+++ b/test/schema-bootstrap-coverage.test.ts
@@ -108,6 +108,16 @@ const REQUIRED_BOOTSTRAP_COVERAGE: ForwardReference[] = [
   // created_at DESC)`. Old brains have ingest_log without source_id; bootstrap
   // adds the column before SCHEMA_SQL replay creates the index.
   { kind: 'column', table: 'ingest_log', column: 'source_id' },
+  // v0.34.1 (#861 + #876) — forward-referenced by
+  // `CREATE INDEX idx_oauth_clients_source_id ON oauth_clients(source_id)
+  //   WHERE source_id IS NOT NULL` (partial) and
+  // `CREATE INDEX idx_oauth_clients_federated_read ON oauth_clients
+  //   USING GIN(federated_read)` (GIN). Pre-v0.34 brains have oauth_clients
+  // without either column; bootstrap adds both before SCHEMA_SQL replay so
+  // the CREATE INDEX statements land cleanly. Migrations v60-v65 cover the
+  // backfill + RLS-policy side of the federated-OAuth wave.
+  { kind: 'column', table: 'oauth_clients', column: 'source_id' },
+  { kind: 'column', table: 'oauth_clients', column: 'federated_read' },
 ];
 
 test('applyForwardReferenceBootstrap covers every forward reference declared in REQUIRED_BOOTSTRAP_COVERAGE', async () => {


### PR DESCRIPTION
## Why

`applyForwardReferenceBootstrap` in both `PostgresEngine` and `PGLiteEngine` covers 9 forward-reference targets that `schema-embedded.ts` makes (pages.source_id, pages.deleted_at, links.*, content_chunks.*, mcp_request_log.*, subagent_messages.provider_id, ingest_log.source_id, …) — but missed v0.34.1's `oauth_clients.{source_id, federated_read}` additions.

Result: brains upgrading from a pre-v0.34 schema (which has `oauth_clients` but neither column) crash at `schema-embedded.ts` during SCHEMA_SQL replay with:

```
column "source_id" does not exist
```

…on the partial-index `CREATE INDEX idx_oauth_clients_source_id ON oauth_clients(source_id) WHERE source_id IS NOT NULL` and on the parallel `idx_oauth_clients_federated_read` GIN-index DDL. Migrations v60-v65 backfill both columns + RLS policies later, but they can't run until SCHEMA_SQL replay succeeds, so the bootstrap must add enough state up front.

## Patch shape

Same pattern as #627 (superseded by upstream fixwave #682+#741 for `mcp_request_log` v0.26.3 columns):

1. **Probe** rows in the existing `information_schema` EXISTS round-trip — `oauth_clients_exists`, `oauth_source_id_exists`, `oauth_federated_read_exists`.
2. **`needsOauthClientsBootstrap`** when the table exists but either column is missing.
3. **Early-return guard** extended so fresh installs and modern brains still no-op.
4. **`ALTER TABLE` block** at the end of the function alongside the other missing-column bootstraps. `source_id` picks up its FK to `sources(id)` and `federated_read` its `NOT NULL DEFAULT '{}'`.

Mirrored across `src/core/postgres-engine.ts` and `src/core/pglite-engine.ts`. Doc comments at the top of each function updated to list the new coverage.

## Test follow-through

`test/schema-bootstrap-coverage.test.ts` gains two entries in `REQUIRED_BOOTSTRAP_COVERAGE` (`oauth_clients.source_id`, `oauth_clients.federated_read`). The existing contract test strips both columns, runs the bootstrap, then asserts they exist after SCHEMA_SQL replay — same loop as every other v33+ column the test already covers.

E2E test (`test/e2e/postgres-bootstrap.test.ts`) was not extended in this PR — its single "pre-v0.18" mutation scenario is structurally identical for any forward-reference target, and the contract test already validates the per-column bootstrap. Happy to add an oauth-specific E2E case if maintainers prefer.

## Validation

- `bun run typecheck` clean
- `bun test test/schema-bootstrap-coverage.test.ts test/bootstrap.test.ts`:
  - **11 pass / 0 fail** (was 11 pass with 48 `expect()` calls; now 50 — the +2 new probes)

## Field repro

Hit during the Jarvis KOS v2 fork's v0.31.2 → v0.34.4 sync (commit `1b6acd77`):

- `bun install` postinstall ran `gbrain apply-migrations` (requires schema_version ≥ 51 for the v0.32.2 facts orchestrator).
- Schema was at v45. Running `gbrain init --migrate-only` to bump v45 → v66 failed at the `idx_oauth_clients_source_id` DDL.
- Worked around with one manual `ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS source_id … / federated_read …`; migrations v60-v65 then ran clean in under a minute.
- Same shape as the `mcp_request_log` trap that produced #627 in our v0.26.7 sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)