### PR TITLE
fix(sync): move --no-recurse-submodules after git verb

### DIFF
--- a/src/core/git-remote.ts
+++ b/src/core/git-remote.ts
@@ -6,8 +6,10 @@
  * IPv6 loopback, IPv4-mapped IPv6, metadata hostnames, hex/octal bypass,
  * and CGNAT 100.64/10).
  *
- * cloneRepo and pullRepo both spread GIT_SSRF_FLAGS so a future flag added
- * to one path lands on both — single source of truth.
+ * cloneRepo and pullRepo both spread GIT_SSRF_FLAGS and add
+ * GIT_NO_RECURSE_SUBMODULES_FLAG after the git verb so a future flag added
+ * to one path lands on both — single source of truth without mixing git
+ * global flags and subcommand flags.
  *
  * Tailscale 100.64/10 trips the integrations.ts allowlist (CGNAT line in
  * url-safety.ts isPrivateIpv4). For self-hosted internal git servers
@@ -24,14 +26,19 @@ import { isInternalUrl } from './url-safety.ts';
  * - http.followRedirects=false: closes DNS rebinding via redirect chains
  * - protocol.file.allow=never: no local-file URLs (defense in depth)
  * - protocol.ext.allow=never: no external helpers (`git-remote-foo`)
- * - --no-recurse-submodules: .gitmodules cannot become a second fetch surface
  */
 export const GIT_SSRF_FLAGS = [
   '-c', 'http.followRedirects=false',
   '-c', 'protocol.file.allow=never',
   '-c', 'protocol.ext.allow=never',
-  '--no-recurse-submodules',
 ] as const;
+
+/**
+ * Submodule fetch hardening. This must be passed after the git subcommand
+ * (`git clone --no-recurse-submodules ...`, `git pull --no-recurse-submodules ...`).
+ * Git rejects it as a global option before the verb.
+ */
+export const GIT_NO_RECURSE_SUBMODULES_FLAG = '--no-recurse-submodules' as const;
 
 export type RemoteUrlErrorCode =
   | 'invalid_url'
@@ -153,7 +160,7 @@ export function cloneRepo(url: string, destDir: string, opts: CloneOpts = {}): v
     }
   }
 
-  const args: string[] = [...GIT_SSRF_FLAGS, 'clone'];
+  const args: string[] = [...GIT_SSRF_FLAGS, 'clone', GIT_NO_RECURSE_SUBMODULES_FLAG];
   if (opts.depth !== 0) {
     args.push(`--depth=${opts.depth ?? 1}`);
   }
@@ -179,7 +186,14 @@ export function cloneRepo(url: string, destDir: string, opts: CloneOpts = {}): v
 
 /** Pull a repo with --ff-only and the same SSRF-defensive flags as cloneRepo. */
 export function pullRepo(repoPath: string, opts: { timeoutMs?: number } = {}): void {
-  const args: string[] = ['-C', repoPath, ...GIT_SSRF_FLAGS, 'pull', '--ff-only'];
+  const args: string[] = [
+    '-C',
+    repoPath,
+    ...GIT_SSRF_FLAGS,
+    'pull',
+    '--ff-only',
+    GIT_NO_RECURSE_SUBMODULES_FLAG,
+  ];
   try {
     execFileSync('git', args, {
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/test/git-remote.test.ts
+++ b/test/git-remote.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   GIT_SSRF_FLAGS,
+  GIT_NO_RECURSE_SUBMODULES_FLAG,
   parseRemoteUrl,
   RemoteUrlError,
   cloneRepo,
@@ -78,6 +79,7 @@ const fakePath = (): string => `${FAKE_GIT_DIR}:${process.env.PATH ?? ''}`;
 // GIT_SSRF_FLAGS — pinned shape (snapshot test). If a future flag is added,
 // update the expected list here AND verify both cloneRepo + pullRepo pick it
 // up via the GIT_SSRF_FLAGS spread (the codex finding that motivated this).
+// Keep git global flags separate from subcommand-only flags.
 // ---------------------------------------------------------------------------
 
 describe('GIT_SSRF_FLAGS', () => {
@@ -86,8 +88,11 @@ describe('GIT_SSRF_FLAGS', () => {
       '-c', 'http.followRedirects=false',
       '-c', 'protocol.file.allow=never',
       '-c', 'protocol.ext.allow=never',
-      '--no-recurse-submodules',
     ]);
+  });
+
+  test('submodule hardening is tracked as a subcommand flag', () => {
+    expect(GIT_NO_RECURSE_SUBMODULES_FLAG).toBe('--no-recurse-submodules');
   });
 });
 
@@ -231,7 +236,9 @@ describe('cloneRepo', () => {
     const argv = calls[0];
     // Pin the SSRF flags before the 'clone' verb (codex Q2 invariant).
     expect(argv.slice(0, GIT_SSRF_FLAGS.length)).toEqual([...GIT_SSRF_FLAGS]);
-    expect(argv).toContain('clone');
+    const cloneIdx = argv.indexOf('clone');
+    expect(cloneIdx).toBeGreaterThan(-1);
+    expect(argv[cloneIdx + 1]).toBe(GIT_NO_RECURSE_SUBMODULES_FLAG);
     expect(argv).toContain('--depth=1');
     expect(argv).toContain('https://example.com/repo');
     expect(argv[argv.length - 1]).toBe(dest);
@@ -306,9 +313,14 @@ describe('pullRepo', () => {
     const argv = readArgvLog()[0];
     expect(argv[0]).toBe('-C');
     expect(argv[1]).toBe(repo);
-    expect(argv.slice(2, 2 + GIT_SSRF_FLAGS.length)).toEqual([...GIT_SSRF_FLAGS]);
-    expect(argv).toContain('pull');
+    const ssrfStart = 2;
+    expect(argv.slice(ssrfStart, ssrfStart + GIT_SSRF_FLAGS.length)).toEqual([
+      ...GIT_SSRF_FLAGS,
+    ]);
+    const pullIdx = argv.indexOf('pull');
+    expect(pullIdx).toBeGreaterThan(-1);
     expect(argv).toContain('--ff-only');
+    expect(argv.indexOf(GIT_NO_RECURSE_SUBMODULES_FLAG)).toBeGreaterThan(pullIdx);
     rmSync(repo, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary

- `--no-recurse-submodules` is a **subcommand flag**, not a global git option. Placing it before the verb (`git --no-recurse-submodules pull`) causes git to reject it with `unknown option: --no-recurse-submodules`.
- `pullRepo` catches the error and silently retries without the flag, so syncs still succeed — but every sync logs a `sync.git_pull error` warning on the first attempt.
- This PR moves the flag into a dedicated `GIT_NO_RECURSE_SUBMODULES_FLAG` constant and inserts it **after** the `clone` / `pull` verb, where git expects it.

## Changes

| File | What changed |
|------|-------------|
| `src/core/git-remote.ts` | Extracted `--no-recurse-submodules` from `GIT_SSRF_FLAGS` into `GIT_NO_RECURSE_SUBMODULES_FLAG`; placed it after `clone` and after `pull --ff-only` |
| `test/git-remote.test.ts` | Updated snapshot test for `GIT_SSRF_FLAGS`; added assertion that the submodule flag appears after the git verb in both `cloneRepo` and `pullRepo` |

## Reproduction

```
gbrain sync   # observe "sync.git_pull error" warning in logs on every run
```

After this fix, `git pull` succeeds on the first attempt with no warning.

## Test plan

- [ ] Existing `bun test` suite passes (snapshot + positional assertions updated)
- [ ] `gbrain sync` no longer logs `sync.git_pull error`