### PR TITLE
fix(doctor): classify supervisor crashes vs clean restarts + auto-heal spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ export/
 # Tier 3 PGLite snapshot fixture (built on demand by build:pglite-snapshot)
 test/fixtures/pglite-snapshot.tar
 test/fixtures/pglite-snapshot.version
+
+# Private brain reports — never check these in (per CLAUDE.md privacy rule)
+reports/network-intelligence/

--- a/docs/issues/doctor-auto-heal-and-scoring.md
+++ b/docs/issues/doctor-auto-heal-and-scoring.md
@@ -1,0 +1,224 @@
+# Doctor Auto-Heal and Scoring Improvements
+
+## Summary
+
+The `gbrain doctor` health score system has several false-positive patterns and missing auto-heal capabilities. After the crash classification fix (shipped in this PR), these are the remaining improvements ranked by impact.
+
+---
+
+## 1. Frontmatter severity levels
+
+### Problem
+
+`NESTED_QUOTES` warnings dominate the frontmatter check (6,900+ of ~7,100 total issues). These are cosmetic YAML style issues — values like `title: "foo"` where the quotes are technically unnecessary. They don't affect sync, search, embedding, or any functionality.
+
+By counting them the same as `YAML_PARSE` (actual parse failures) or `MISSING_OPEN` (missing frontmatter delimiters), the frontmatter check is perpetually WARN and the real issues are lost.
+
+### Evidence
+
+```
+frontmatter_integrity: 7131 issues across 3 sources
+  default: 7012 (NESTED_QUOTES=6922, YAML_PARSE=90)
+  media-corpus: 16 (MISSING_OPEN=15, YAML_PARSE=1)
+  zion-brain: 103 (MISSING_OPEN=14, NESTED_QUOTES=89)
+```
+
+Only 280 of 7,131 issues are real problems. 96% are cosmetic noise.
+
+### Proposed Fix
+
+- Introduce severity levels: `error` (YAML_PARSE, MISSING_OPEN) vs `info` (NESTED_QUOTES)
+- Doctor WARN/FAIL only on error-level issues
+- Report info-level in the message text but don't affect check status
+- Optional `--pedantic` flag includes info-level in status
+
+### Test Cases
+
+| Frontmatter issues | Severity breakdown | Expected status |
+|---|---|---|
+| 0 issues | n/a | OK |
+| 50 NESTED_QUOTES only | 0 error, 50 info | OK (with note) |
+| 3 YAML_PARSE | 3 error | WARN |
+| 6900 NESTED_QUOTES + 3 YAML_PARSE | 3 error, 6900 info | WARN (mentions 3 errors) |
+
+---
+
+## 2. Temporal contradiction awareness
+
+### Problem
+
+The contradiction probe flags temporal evolutions as contradictions. Example:
+
+- Page A (April): "Considering option X"
+- Page B (May): "Decided on option Y"
+
+These aren't contradictions — they're the same topic evolving over time. The probe has no time awareness.
+
+### Evidence
+
+From a probe run on 50 queries with top-k=15:
+- 120 contradictions detected (112 high, 8 medium)
+- After manual review: ~60% were temporal evolutions, not real conflicts
+- Pages have `effective_date` or `created` timestamps that could disambiguate
+
+### Proposed Fix
+
+- Pass `effective_date` / `created` to the judge prompt
+- Add verdict: `temporal_supersession` (later claim supersedes earlier)
+- When both pages have dates and claims overlap, bias toward temporal interpretation
+- Already designed in PR #993
+
+### Test Cases
+
+| Page A date | Page A claim | Page B date | Page B claim | Expected verdict |
+|---|---|---|---|---|
+| 2026-04 | "Considering X" | 2026-05 | "Chose Y" | temporal_supersession |
+| 2026-04 | "Revenue is $1M" | 2026-04 | "Revenue is $500K" | contradiction |
+| null | "X is true" | null | "X is false" | contradiction |
+| 2025-01 | "CEO of Company" | 2026-01 | "Former CEO" | temporal_supersession |
+
+---
+
+## 3. Multi-source drift baseline
+
+### Problem
+
+4,791 pages show "multi-source drift" due to a pre-v0.30.3 `putPage` routing bug. These pages exist at the `default` source but should be at a named source. The `sources rehome` command to fix this hasn't shipped yet.
+
+Every doctor run shows WARN for ~4,800 pages nobody can fix.
+
+### Proposed Fix
+
+Allow `doctor.baselines` config to acknowledge known-unfixable counts:
+
+```yaml
+doctor:
+  baselines:
+    multi_source_drift: 4800
+```
+
+When actual drift ≤ baseline: OK. When drift exceeds baseline: WARN (new drift).
+
+Store in `.gbrain/doctor-baselines.json` so it works without config too:
+
+```json
+{
+  "multi_source_drift": { "count": 4800, "acknowledged_at": "2026-05-15", "reason": "pre-v0.30.3 putPage misroutes" }
+}
+```
+
+### Test Cases
+
+| Actual drift | Baseline | Expected |
+|---|---|---|
+| 4791 | 4800 | OK |
+| 4900 | 4800 | WARN ("100 new drift beyond baseline") |
+| 4791 | 0 (no baseline) | WARN (current behavior) |
+
+---
+
+## 4. Image assets acknowledgment
+
+### Problem
+
+When image files are missing from disk (stored externally, purged from git), the check permanently warns. No way to say "these are intentionally external."
+
+### Proposed Fix
+
+- `doctor --acknowledge image_assets` marks current missing count as accepted
+- Stored in `.gbrain/doctor-baselines.json`
+- WARN only for NEW missing images beyond acknowledged count
+- Optional `image_assets.external_storage: true` config to skip disk check entirely
+
+---
+
+## 5. Auto-heal mode
+
+### Problem
+
+Many doctor warnings have known fixes that are safe to auto-apply:
+
+| Warning | Auto-fix |
+|---|---|
+| Supervisor not running | Start supervisor |
+| Stale embeddings | Submit `embed --stale` job |
+| Extract coverage < 70% | Submit `extract all --skip-existing` job |
+| Stale sync | Submit sync job |
+| Effective date drift | Run `reindex-frontmatter` |
+
+### Proposed Fix
+
+`doctor --auto-heal` mode:
+
+1. Run all checks
+2. For fixable WARNs: submit fix as a job (not inline — via job queue)
+3. Report what was fixed vs needs manual attention
+4. Idempotent: check queue first, don't submit duplicates
+5. Safety gate: never auto-heals FAILs, only WARNs
+
+Config:
+
+```yaml
+doctor:
+  autoHeal:
+    enabled: true
+    minInterval: "6h"
+    skip:
+      - image_assets
+      - multi_source_drift
+```
+
+### Test Cases
+
+| Check status | Auto-heal enabled | Job already queued | Expected |
+|---|---|---|---|
+| WARN: stale embeds | yes | no | Submit embed job |
+| WARN: stale embeds | yes | yes | Skip (idempotent) |
+| FAIL: max_crashes | yes | n/a | Don't auto-fix FAILs |
+| WARN: stale embeds | no | n/a | Report only |
+| WARN: image_assets | yes (but skipped) | n/a | Report only |
+
+---
+
+## 6. Score delta tracking
+
+### Problem
+
+No history — each `doctor` run is a snapshot. Can't tell if score is improving or degrading.
+
+### Proposed Fix
+
+- Write each run to `.gbrain/doctor-history.jsonl`:
+  ```json
+  {"ts":"2026-05-15T12:00:00Z","score":60,"brain_score":79,"checks":{"supervisor":"ok","embeddings":"ok",...}}
+  ```
+- `doctor --trend` shows last N scores with deltas
+- `doctor --json` includes `previous_score` and `delta` fields
+
+---
+
+## 7. Weighted scoring
+
+### Problem
+
+Going from 99% → 100% embed coverage weighs the same as 50% → 51%. But the last percent is the hardest (oversized pages, rate limits).
+
+### Proposed Fix
+
+Threshold-based scoring:
+- 100% = full points
+- ≥95% = 90% of points
+- ≥80% = 70% of points
+- <80% = proportional
+
+---
+
+## Priority Order
+
+1. Frontmatter severity levels (highest noise reduction)
+2. Temporal contradiction awareness (highest false positive reduction, already designed)
+3. Auto-heal mode (biggest long-term value)
+4. Score delta tracking (enables monitoring)
+5. Multi-source drift baseline (quality of life)
+6. Image assets acknowledgment (quality of life)
+7. Weighted scoring (nice to have)

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1010,7 +1010,12 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
 
     const events = readSupervisorEvents({ sinceMs: 24 * 60 * 60 * 1000 });
     const lastStart = events.filter(e => e.event === 'started').pop()?.ts ?? null;
-    const crashes24h = events.filter(e => e.event === 'worker_exited').length;
+    // Only count non-zero exits as crashes; clean restarts (code 0) are normal
+    // worker lifecycle — the worker finishes its queue and exits cleanly.
+    const allExits = events.filter(e => e.event === 'worker_exited');
+    const realCrashes = allExits.filter(e => (e as any).code !== 0 && (e as any).code !== undefined);
+    const cleanRestarts = allExits.length - realCrashes.length;
+    const crashes24h = realCrashes.length;
     const maxCrashesEvent = events.filter(e => e.event === 'max_crashes_exceeded').pop() ?? null;
 
     // Only surface a Check if the supervisor was ever observed (stops the
@@ -1032,13 +1037,13 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
         checks.push({
           name: 'supervisor',
           status: 'warn',
-          message: `Supervisor running but worker crashed ${crashes24h}x in last 24h. Check ~/.gbrain/audit/supervisor-*.jsonl for causes.`,
+          message: `Supervisor running but worker crashed ${crashes24h}x in last 24h (${cleanRestarts} clean restarts excluded). Check ~/.gbrain/audit/supervisor-*.jsonl for causes.`,
         });
       } else {
         checks.push({
           name: 'supervisor',
           status: 'ok',
-          message: `running=true pid=${supervisorPid} last_start=${lastStart ?? 'unknown'} crashes_24h=${crashes24h}`,
+          message: `running=true pid=${supervisorPid} last_start=${lastStart ?? 'unknown'} crashes=${crashes24h}${cleanRestarts > 0 ? ` clean_restarts=${cleanRestarts}` : ''}`,
         });
       }
     }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -8,6 +8,7 @@ import { loadCompletedMigrations } from '../core/preferences.ts';
 import { compareVersions } from './migrations/index.ts';
 import { createProgress, startHeartbeat, type ProgressReporter } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
+import { classifyWorkerExit } from '../core/minions/exit-classification.ts';
 import type { DbUrlSource } from '../core/config.ts';
 import { join } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
@@ -1013,7 +1014,7 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
     // Only count non-zero exits as crashes; clean restarts (code 0) are normal
     // worker lifecycle — the worker finishes its queue and exits cleanly.
     const allExits = events.filter(e => e.event === 'worker_exited');
-    const realCrashes = allExits.filter(e => (e as any).code !== 0 && (e as any).code !== undefined);
+    const realCrashes = allExits.filter(e => classifyWorkerExit(e as { code?: number | null }) === 'crash');
     const cleanRestarts = allExits.length - realCrashes.length;
     const crashes24h = realCrashes.length;
     const maxCrashesEvent = events.filter(e => e.event === 'max_crashes_exceeded').pop() ?? null;

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1052,6 +1052,51 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
     // Audit read / import failure is best-effort; skip silently.
   }
 
+  // 3b-tris. Stub-guard fire count (last 24h). The v0.34.5 stub guard in
+  // fence-write.ts refuses to spawn unprefixed entity pages (e.g. bare
+  // `alice.md` at brain root). Each fire is appended to
+  // ~/.gbrain/audit/stub-guard-YYYY-Www.jsonl. This check is the operator
+  // visibility surface for the guard's v0.36 sunset criterion: when the
+  // 24h count is consistently low, the prefix-expansion in
+  // resolveEntitySlug is doing its job and the guard can be removed.
+  //
+  // WARN at >10 fires/24h — at that rate the resolver is probably missing
+  // a case (typo prefix, alias, non-Latin script). Operators should grep
+  // the audit log for the slugs that hit it and either add the missing
+  // resolver branch or document them as legitimate bare-slug ingestion.
+  try {
+    const { readRecentStubGuardEvents } = await import('../core/facts/stub-guard-audit.ts');
+    const events = readRecentStubGuardEvents({ sinceMs: 24 * 60 * 60 * 1000 });
+    if (events.length > 10) {
+      // Surface the top 3 slugs that hit it so operators have somewhere to start.
+      const slugCounts = new Map<string, number>();
+      for (const e of events) slugCounts.set(e.slug, (slugCounts.get(e.slug) ?? 0) + 1);
+      const topSlugs = [...slugCounts.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(([slug, n]) => `${slug}(${n})`)
+        .join(', ');
+      checks.push({
+        name: 'stub_guard_24h',
+        status: 'warn',
+        message:
+          `Stub guard fired ${events.length}x in last 24h (top: ${topSlugs}). ` +
+          `If this stays elevated, the prefix-expansion in resolveEntitySlug is ` +
+          `missing a case. Check ~/.gbrain/audit/stub-guard-*.jsonl for the slugs ` +
+          `that hit it.`,
+      });
+    } else if (events.length > 0) {
+      checks.push({
+        name: 'stub_guard_24h',
+        status: 'ok',
+        message: `Stub guard fired ${events.length}x in last 24h (below WARN threshold of 10).`,
+      });
+    }
+    // Zero hits is the goal — emit no check at all so the doctor output stays clean.
+  } catch {
+    // Audit read failure is best-effort; skip silently.
+  }
+
   // 3c. Sync failure trail (Bug 9). sync.ts gates the `sync.last_commit`
   // bookmark when per-file parse errors happen, and appends each failure
   // to ~/.gbrain/sync-failures.jsonl with the commit hash + exact error.

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -802,7 +802,10 @@ HANDLER TYPES (built in)
 
         const events = readSupervisorEvents({ sinceMs: 24 * 60 * 60 * 1000 });
         const lastStart = events.filter(e => e.event === 'started').pop()?.ts ?? null;
-        const crashes24h = events.filter(e => e.event === 'worker_exited').length;
+        const allExits = events.filter(e => e.event === 'worker_exited');
+        const realCrashes = allExits.filter(e => (e as any).code !== 0 && (e as any).code !== undefined);
+        const cleanRestarts = allExits.length - realCrashes.length;
+        const crashes24h = realCrashes.length;
         const maxCrashesEvent = events.filter(e => e.event === 'max_crashes_exceeded').pop() ?? null;
 
         const status = {
@@ -811,6 +814,7 @@ HANDLER TYPES (built in)
           pid_file: pidFile,
           last_start: lastStart,
           crashes_24h: crashes24h,
+          clean_restarts_24h: cleanRestarts,
           max_crashes_exceeded: !!maxCrashesEvent,
         };
 
@@ -821,7 +825,7 @@ HANDLER TYPES (built in)
           if (supervisorPid) console.log(`  PID:           ${supervisorPid}`);
           console.log(`  PID file:      ${pidFile}`);
           if (lastStart) console.log(`  Last start:    ${lastStart}`);
-          console.log(`  Crashes (24h): ${crashes24h}`);
+          console.log(`  Crashes (24h): ${crashes24h}${cleanRestarts > 0 ? ` (${cleanRestarts} clean restarts excluded)` : ''}`);
           if (maxCrashesEvent) console.log(`  ⚠ Max crashes exceeded at ${maxCrashesEvent.ts}`);
         }
         process.exit(running ? 0 : 1);

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -6,6 +6,7 @@
 import type { BrainEngine } from '../core/engine.ts';
 import { MinionQueue } from '../core/minions/queue.ts';
 import { MinionWorker } from '../core/minions/worker.ts';
+import { classifyWorkerExit } from '../core/minions/exit-classification.ts';
 import type { MinionJob, MinionJobStatus } from '../core/minions/types.ts';
 import { loadConfig, isThinClient } from '../core/config.ts';
 import { callRemoteTool, unpackToolResult } from '../core/mcp-client.ts';
@@ -803,7 +804,7 @@ HANDLER TYPES (built in)
         const events = readSupervisorEvents({ sinceMs: 24 * 60 * 60 * 1000 });
         const lastStart = events.filter(e => e.event === 'started').pop()?.ts ?? null;
         const allExits = events.filter(e => e.event === 'worker_exited');
-        const realCrashes = allExits.filter(e => (e as any).code !== 0 && (e as any).code !== undefined);
+        const realCrashes = allExits.filter(e => classifyWorkerExit(e as { code?: number | null }) === 'crash');
         const cleanRestarts = allExits.length - realCrashes.length;
         const crashes24h = realCrashes.length;
         const maxCrashesEvent = events.filter(e => e.event === 'max_crashes_exceeded').pop() ?? null;

--- a/src/core/entities/resolve.ts
+++ b/src/core/entities/resolve.ts
@@ -118,25 +118,27 @@ async function tryPrefixExpansion(
       }>(
         // Connection count is a simple proxy for canonicality:
         // (incoming links) + (outgoing links) + (content chunks).
-        // No graph traversal, just three indexed counts per page.
-        // Filter is applied AFTER the aggregate so pages with zero
-        // connections still show up (a stub page is still a real page).
+        //
+        // SQL shape: correlated subqueries scoped to the slug-LIKE
+        // candidates. The pre-v0.34.5 version used derived-table JOINs
+        // (SELECT FROM links GROUP BY to_page_id, etc.) which forced the
+        // planner to aggregate the FULL links + content_chunks tables on
+        // every prefix-expansion call — O(N) per call where N is total
+        // links/chunks in the brain. On a 100K-link / 50K-chunk brain
+        // that's slow.
+        //
+        // The slug LIKE filter is already selective in practice (typical
+        // brain has 0-5 pages per prefix), so the correlated subqueries
+        // run N=3 times per matched row, hitting the indexes on
+        // links.to_page_id, links.from_page_id, and content_chunks.page_id
+        // directly. Even on a pathological prefix matching 1000+ pages,
+        // work is bounded per-candidate, not whole-table.
         `SELECT p.slug,
-                (COALESCE(li.in_count, 0) + COALESCE(lo.out_count, 0) + COALESCE(cc.chunk_count, 0))
+                ((SELECT COUNT(*)::int FROM links WHERE to_page_id = p.id)
+                 + (SELECT COUNT(*)::int FROM links WHERE from_page_id = p.id)
+                 + (SELECT COUNT(*)::int FROM content_chunks WHERE page_id = p.id))
                   AS connection_count
          FROM pages p
-         LEFT JOIN (
-           SELECT to_page_id AS pid, COUNT(*)::int AS in_count
-           FROM links GROUP BY to_page_id
-         ) li ON li.pid = p.id
-         LEFT JOIN (
-           SELECT from_page_id AS pid, COUNT(*)::int AS out_count
-           FROM links GROUP BY from_page_id
-         ) lo ON lo.pid = p.id
-         LEFT JOIN (
-           SELECT page_id AS pid, COUNT(*)::int AS chunk_count
-           FROM content_chunks GROUP BY page_id
-         ) cc ON cc.pid = p.id
          WHERE p.source_id = $1
            AND p.deleted_at IS NULL
            AND p.slug LIKE $2

--- a/src/core/entities/resolve.ts
+++ b/src/core/entities/resolve.ts
@@ -2,7 +2,7 @@
  * v0.31 Hot Memory — entity slug canonicalization.
  *
  * Per /plan-eng-review D4: at extract time, resolve a free-form entity name
- * (e.g. "Sam") against `pages.slug` so that hot memory + the existing graph
+ * (e.g. "Alice") against `pages.slug` so that hot memory + the existing graph
  * see the same canonical id. Falls back to a slugified form when no page
  * matches.
  *
@@ -10,12 +10,12 @@
  * Lives under `src/core/entities/` so signal-detector can reuse it for the
  * Sonnet pass too without circular import through facts/.
  *
- * v0.34.5 — added a prefix-expansion step between fuzzy
- * match and slugify fallback. Bare first names like "Jared" scored too
- * low on pg_trgm (short strings have terrible trigram overlap), so they
- * fell through to slugify("Jared") → "jared", which then spawned a
- * phantom `people/jared.md` stub instead of resolving to the existing
- * `people/jared-friedman` page. The fix queries `slug LIKE 'people/X-%'`
+ * Prefix-expansion step lives between fuzzy match and slugify fallback.
+ * Bare first names like "Alice" score too low on pg_trgm (short strings
+ * have terrible trigram overlap), so without this step they fall through
+ * to slugify("Alice") → "alice", which spawns a phantom `people/alice.md`
+ * stub at brain root instead of resolving to the existing
+ * `people/alice-example` page. The fix queries `slug LIKE 'people/X-%'`
  * (then `companies/X-%`) when fuzzy fails on a single-word bare name, and
  * uses connection count (links + chunks) as the tiebreaker when multiple
  * candidates match.
@@ -62,10 +62,10 @@ export async function resolveEntitySlug(
   // 3. Prefix-expansion match: when the input looks like a bare first name
   //    (no slash, no prefix, slugifies to a single short token), try
   //    `people/<token>-%` then `companies/<token>-%`. Short bare names
-  //    score terribly on pg_trgm — similarity('jared', 'jared-friedman')
+  //    score terribly on pg_trgm — similarity('alice', 'alice-example')
   //    is below the 0.4 threshold — so this is the layer that catches
-  //    `"Jared"` → `people/jared-friedman` before we phantom-stub a
-  //    bare `people/jared.md`.
+  //    `"Alice"` → `people/alice-example` before we phantom-stub a bare
+  //    `people/alice.md`.
   if (isBareName(trimmed)) {
     const expanded = await tryPrefixExpansion(engine, source_id, slugify(trimmed));
     if (expanded) return expanded;
@@ -78,17 +78,17 @@ export async function resolveEntitySlug(
 /**
  * "Bare name" detector — true when the input is a single word with no
  * slash, no embedded prefix marker, and slugifies to a non-empty token.
- * Multi-word inputs (e.g. "Jared Friedman") are handled by fuzzy match;
+ * Multi-word inputs (e.g. "Alice Example") are handled by fuzzy match;
  * this gate only fires for short first-name-shaped tokens.
  */
 function isBareName(raw: string): boolean {
   if (raw.includes('/')) return false;
-  // One-token input. Whitespace-tokenize: "Jared" → 1, "Jared Friedman" → 2.
+  // One-token input. Whitespace-tokenize: "Alice" → 1, "Alice Example" → 2.
   const tokens = raw.trim().split(/\s+/).filter(Boolean);
   if (tokens.length !== 1) return false;
   const slug = slugify(raw);
   if (!slug) return false;
-  // Reject hyphenated multi-token slugs like "jared-friedman" — those
+  // Reject hyphenated multi-token slugs like "alice-example" — those
   // should hit the exact-slug or fuzzy path, not prefix expansion.
   if (slug.includes('-')) return false;
   return true;

--- a/src/core/entities/resolve.ts
+++ b/src/core/entities/resolve.ts
@@ -9,6 +9,16 @@
  * Pure helper; the engine layer is the data dependency injected by callers.
  * Lives under `src/core/entities/` so signal-detector can reuse it for the
  * Sonnet pass too without circular import through facts/.
+ *
+ * v0.34.5 — added a prefix-expansion step between fuzzy
+ * match and slugify fallback. Bare first names like "Jared" scored too
+ * low on pg_trgm (short strings have terrible trigram overlap), so they
+ * fell through to slugify("Jared") → "jared", which then spawned a
+ * phantom `people/jared.md` stub instead of resolving to the existing
+ * `people/jared-friedman` page. The fix queries `slug LIKE 'people/X-%'`
+ * (then `companies/X-%`) when fuzzy fails on a single-word bare name, and
+ * uses connection count (links + chunks) as the tiebreaker when multiple
+ * candidates match.
  */
 
 import type { BrainEngine } from '../engine.ts';
@@ -49,8 +59,105 @@ export async function resolveEntitySlug(
   const fuzzy = await tryFuzzyMatch(engine, source_id, trimmed);
   if (fuzzy) return fuzzy;
 
-  // 3. Fallback: deterministic slugify.
+  // 3. Prefix-expansion match: when the input looks like a bare first name
+  //    (no slash, no prefix, slugifies to a single short token), try
+  //    `people/<token>-%` then `companies/<token>-%`. Short bare names
+  //    score terribly on pg_trgm — similarity('jared', 'jared-friedman')
+  //    is below the 0.4 threshold — so this is the layer that catches
+  //    `"Jared"` → `people/jared-friedman` before we phantom-stub a
+  //    bare `people/jared.md`.
+  if (isBareName(trimmed)) {
+    const expanded = await tryPrefixExpansion(engine, source_id, slugify(trimmed));
+    if (expanded) return expanded;
+  }
+
+  // 4. Fallback: deterministic slugify.
   return slugify(trimmed);
+}
+
+/**
+ * "Bare name" detector — true when the input is a single word with no
+ * slash, no embedded prefix marker, and slugifies to a non-empty token.
+ * Multi-word inputs (e.g. "Jared Friedman") are handled by fuzzy match;
+ * this gate only fires for short first-name-shaped tokens.
+ */
+function isBareName(raw: string): boolean {
+  if (raw.includes('/')) return false;
+  // One-token input. Whitespace-tokenize: "Jared" → 1, "Jared Friedman" → 2.
+  const tokens = raw.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length !== 1) return false;
+  const slug = slugify(raw);
+  if (!slug) return false;
+  // Reject hyphenated multi-token slugs like "jared-friedman" — those
+  // should hit the exact-slug or fuzzy path, not prefix expansion.
+  if (slug.includes('-')) return false;
+  return true;
+}
+
+const PREFIX_EXPANSION_DIRS = ['people', 'companies'] as const;
+
+/**
+ * Look up pages whose slug starts with `<dir>/<token>-` for each known
+ * entity directory. When multiple candidates match within a directory,
+ * pick the one with the highest connection count (links_in + links_out +
+ * chunk count) — the most-mentioned entity is the most likely canonical
+ * target for a bare-name reference. When no candidates match in any
+ * directory, returns null and the caller falls through to slugify.
+ */
+async function tryPrefixExpansion(
+  engine: BrainEngine,
+  source_id: string,
+  token: string,
+): Promise<string | null> {
+  for (const dir of PREFIX_EXPANSION_DIRS) {
+    const pattern = `${dir}/${token}-%`;
+    try {
+      const rows = await engine.executeRaw<{
+        slug: string;
+        connection_count: number;
+      }>(
+        // Connection count is a simple proxy for canonicality:
+        // (incoming links) + (outgoing links) + (content chunks).
+        // No graph traversal, just three indexed counts per page.
+        // Filter is applied AFTER the aggregate so pages with zero
+        // connections still show up (a stub page is still a real page).
+        `SELECT p.slug,
+                (COALESCE(li.in_count, 0) + COALESCE(lo.out_count, 0) + COALESCE(cc.chunk_count, 0))
+                  AS connection_count
+         FROM pages p
+         LEFT JOIN (
+           SELECT to_page_id AS pid, COUNT(*)::int AS in_count
+           FROM links GROUP BY to_page_id
+         ) li ON li.pid = p.id
+         LEFT JOIN (
+           SELECT from_page_id AS pid, COUNT(*)::int AS out_count
+           FROM links GROUP BY from_page_id
+         ) lo ON lo.pid = p.id
+         LEFT JOIN (
+           SELECT page_id AS pid, COUNT(*)::int AS chunk_count
+           FROM content_chunks GROUP BY page_id
+         ) cc ON cc.pid = p.id
+         WHERE p.source_id = $1
+           AND p.deleted_at IS NULL
+           AND p.slug LIKE $2
+         ORDER BY connection_count DESC, p.slug ASC
+         LIMIT 5`,
+        [source_id, pattern],
+      );
+      if (rows.length === 0) continue;
+      // Single unambiguous match: return it.
+      if (rows.length === 1) return rows[0].slug;
+      // Multiple matches: the top row (sorted by connection_count desc)
+      // wins. The slug-ASC secondary key makes ties deterministic when
+      // connection counts collide — important for test pinning.
+      return rows[0].slug;
+    } catch {
+      // Defensive: a missing table or index shouldn't crash extraction.
+      // Try the next directory (or fall through to slugify).
+      continue;
+    }
+  }
+  return null;
 }
 
 function looksLikeSlug(s: string): boolean {

--- a/src/core/facts/backstop.ts
+++ b/src/core/facts/backstop.ts
@@ -455,6 +455,32 @@ async function runPipelineWithBody(
       // would write rows to a DB index whose fence is broken.
       continue;
     }
+    if (result.stubGuardBlocked) {
+      // v0.34.5: writeFactsToFence refused to spawn a phantom
+      // unprefixed entity page (e.g. `jared.md` at brain root).
+      // Route these facts to the legacy DB-only path so they
+      // aren't dropped — the slug stays attached but no markdown
+      // file is created.
+      for (const { f } of group) {
+        const newFact: NewFact = {
+          fact: f.fact,
+          kind: f.kind,
+          entity_slug: slug,
+          visibility,
+          notability: f.notability,
+          source: f.source,
+          source_session: f.source_session ?? null,
+          confidence: f.confidence,
+          embedding: f.embedding ?? null,
+        };
+        const legacyResult = await ctx.engine.insertFact(newFact, { source_id: ctx.sourceId }); // gbrain-allow-direct-insert: stub-guard fallback for unprefixed entity slugs (no fenceable page)
+        fact_ids.push(legacyResult.id);
+        if (legacyResult.status === 'inserted') inserted += 1;
+        else if ((legacyResult.status as FactInsertStatus) === 'duplicate') duplicate += 1;
+        else superseded += 1;
+      }
+      continue;
+    }
     if (result.legacyFallback) {
       // Defensive: writeFactsToFence sees localPath as null. We
       // checked above so this shouldn't fire — log loud + skip.

--- a/src/core/facts/fence-write.ts
+++ b/src/core/facts/fence-write.ts
@@ -76,6 +76,16 @@ export interface FenceWriteResult {
   legacyFallback?: true;
   /** True when fence parse-validate failed; rows were NOT inserted, .tmp quarantined. */
   fenceWriteFailed?: true;
+  /**
+   * True when the stub-creation guard refused to spawn a phantom entity
+   * page for an unprefixed bare slug (e.g. `jared` with no `people/`
+   * directory). Rows were NOT inserted; the caller is expected to route
+   * the facts to the legacy DB-only path so they aren't silently dropped.
+   *
+   * This is the v0.34.5 fix for the entity-resolution bug where `"Jared"`
+   * fell through resolution and produced a top-level `jared.md` stub.
+   */
+  stubGuardBlocked?: true;
 }
 
 const FAILURE_LOG_PATH = (): string => gbrainPath('facts.write_failures.jsonl');
@@ -166,6 +176,24 @@ export async function writeFactsToFence(
       if (existsSync(filePath)) {
         body = readFileSync(filePath, 'utf-8');
       } else {
+        // v0.34.5 stub-creation guard. Phantom entity pages like
+        // `jared.md` at the brain root were being spawned when
+        // resolveEntitySlug fell through to slugify("Jared") because
+        // pg_trgm scored too low on short bare names. The resolver
+        // now has a prefix-expansion step that catches most of those,
+        // but this guard is the second wall: refuse to stub-create a
+        // page whose slug has no directory prefix (people/, companies/,
+        // deals/, topics/, etc.). The caller routes these facts to the
+        // legacy DB-only path so they aren't silently dropped — the
+        // fact still gets recorded, it just doesn't spawn a phantom
+        // entity page on disk.
+        if (!target.slug.includes('/')) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[facts] refusing to stub-create unprefixed entity page slug=${target.slug} — routing to legacy DB-only path. Provide a directory prefix (people/, companies/, etc.) to opt into fence writes.`,
+          );
+          return { inserted: 0, ids: [], stubGuardBlocked: true };
+        }
         // Stub-create the parent directory if it doesn't exist.
         mkdirSync(dirname(filePath), { recursive: true });
         body = stubEntityPage(target.slug);

--- a/src/core/facts/fence-write.ts
+++ b/src/core/facts/fence-write.ts
@@ -41,6 +41,7 @@ import { withPageLock } from '../page-lock.ts';
 import { gbrainPath } from '../config.ts';
 import { upsertFactRow, parseFactsFence } from '../facts-fence.ts';
 import { extractFactsFromFenceText } from './extract-from-fence.ts';
+import { logStubGuardEvent } from './stub-guard-audit.ts';
 
 /** Resolved source binding for the entity page. */
 export interface FenceTarget {
@@ -176,18 +177,29 @@ export async function writeFactsToFence(
       if (existsSync(filePath)) {
         body = readFileSync(filePath, 'utf-8');
       } else {
-        // v0.34.5 stub-creation guard. Phantom entity pages like
-        // `jared.md` at the brain root were being spawned when
-        // resolveEntitySlug fell through to slugify("Jared") because
-        // pg_trgm scored too low on short bare names. The resolver
-        // now has a prefix-expansion step that catches most of those,
-        // but this guard is the second wall: refuse to stub-create a
-        // page whose slug has no directory prefix (people/, companies/,
+        // Stub-creation guard. Phantom entity pages at the brain root were
+        // being spawned when resolveEntitySlug fell through to a bare
+        // slugify because pg_trgm scored too low on short bare names. The
+        // resolver now has a prefix-expansion step that catches most of
+        // those, but this guard is the second wall: refuse to stub-create
+        // a page whose slug has no directory prefix (people/, companies/,
         // deals/, topics/, etc.). The caller routes these facts to the
-        // legacy DB-only path so they aren't silently dropped — the
-        // fact still gets recorded, it just doesn't spawn a phantom
-        // entity page on disk.
+        // legacy DB-only path so they aren't silently dropped — the fact
+        // still gets recorded, it just doesn't spawn a phantom entity
+        // page on disk.
+        //
+        // Sunset target: v0.36. Once `stub_guard_24h` (the gbrain doctor
+        // surface backed by the audit log written here) reads <5 hits/week
+        // for 3 consecutive weeks on production brains, the prefix-expansion
+        // in resolveEntitySlug is sufficient and this guard can be removed.
+        // The audit log under `~/.gbrain/audit/stub-guard-YYYY-Www.jsonl`
+        // is the operator visibility surface for that retirement decision.
         if (!target.slug.includes('/')) {
+          logStubGuardEvent({
+            slug: target.slug,
+            source_id: target.sourceId,
+            fact_count: facts.length,
+          });
           // eslint-disable-next-line no-console
           console.warn(
             `[facts] refusing to stub-create unprefixed entity page slug=${target.slug} — routing to legacy DB-only path. Provide a directory prefix (people/, companies/, etc.) to opt into fence writes.`,

--- a/src/core/facts/stub-guard-audit.ts
+++ b/src/core/facts/stub-guard-audit.ts
@@ -1,0 +1,143 @@
+/**
+ * Stub-guard audit log. JSONL, ISO-week-rotated, best-effort.
+ *
+ * Writes one line per stub-guard fire to
+ *   `${GBRAIN_AUDIT_DIR:-~/.gbrain/audit}/stub-guard-YYYY-Www.jsonl`
+ * when `writeFactsToFence` refuses to spawn an unprefixed entity page. The
+ * audit log is the operator visibility surface for the v0.34.5+ stub guard
+ * sunset criterion: when this reads <5 hits/week for 3 consecutive weeks
+ * on production brains, the guard can be removed in v0.36 (the prefix
+ * expansion in resolveEntitySlug is sufficient).
+ *
+ * Best-effort: write failures go to stderr and never block the legacy DB-only
+ * fallback path. A disk-full attacker could silently disable the trail.
+ *
+ * Reader pattern (READ THIS):
+ *
+ * `readRecentStubGuardEvents({ sinceMs: 24h })` reads BOTH the current AND
+ * the previous ISO-week file before filtering by `ts >= now - sinceMs`.
+ * The DELIBERATE divergence from `supervisor-audit.ts:readSupervisorEvents`
+ * is the whole reason this module exists separately: that reader reads only
+ * the current week file, which loses 24h-window correctness across Monday
+ * 00:00 UTC (a Sunday 23:55 event is in last week's file). When the doctor's
+ * 24h check runs on Monday 00:01 UTC against a brain that fired the guard
+ * Sunday at 23:55, the supervisor pattern would silently miss it. The
+ * 2-file read costs nothing (cheap fs read; misses are still cheap when
+ * the file doesn't exist) and makes the window correct.
+ *
+ * Follow-up TODO (filed separately, not in this PR): fix
+ * `readSupervisorEvents` to use the same 2-file pattern.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { resolveAuditDir } from '../minions/handlers/shell-audit.ts';
+
+export interface StubGuardEvent {
+  /** ISO-8601 timestamp of when the guard fired. */
+  ts: string;
+  /** The slug that triggered the guard. */
+  slug: string;
+  /** The source the fact was being written into. */
+  source_id: string;
+  /** How many facts were in the rejected batch (informational). */
+  fact_count: number;
+}
+
+/**
+ * Compute the ISO-8601 week filename `stub-guard-YYYY-Www.jsonl`.
+ * Year-boundary edge: 2027-01-01 falls in ISO week 53 of year 2026, so the
+ * filename is `stub-guard-2026-W53.jsonl`. Logic mirrors shell-audit.ts
+ * verbatim; can't import the helper because shell-audit.ts hardcodes its
+ * own `shell-jobs-` prefix.
+ */
+export function computeStubGuardAuditFilename(now: Date = new Date()): string {
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const dayNum = (d.getUTCDay() + 6) % 7; // Mon=0, Sun=6
+  d.setUTCDate(d.getUTCDate() - dayNum + 3); // shift to Thursday (ISO week anchor)
+  const isoYear = d.getUTCFullYear();
+  const firstThursday = new Date(Date.UTC(isoYear, 0, 4));
+  const firstThursdayDayNum = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstThursdayDayNum + 3);
+  const weekNum = Math.round((d.getTime() - firstThursday.getTime()) / (7 * 86400000)) + 1;
+  const ww = String(weekNum).padStart(2, '0');
+  return `stub-guard-${isoYear}-W${ww}.jsonl`;
+}
+
+/**
+ * Append a stub-guard fire to the ISO-week rotated JSONL file. Best-effort:
+ * write failures emit a stderr warning and never throw — the legacy
+ * DB-only fallback path in `backstop.ts` must keep working even when the
+ * audit log can't be written.
+ */
+export function logStubGuardEvent(event: Omit<StubGuardEvent, 'ts'>): void {
+  const dir = resolveAuditDir();
+  const filename = computeStubGuardAuditFilename();
+  const fullPath = path.join(dir, filename);
+  const line = JSON.stringify({ ts: new Date().toISOString(), ...event }) + '\n';
+
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.appendFileSync(fullPath, line, { encoding: 'utf8' });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[stub-guard-audit] write failed (${msg}); continuing\n`);
+  }
+}
+
+/**
+ * Read recent stub-guard events. Reads BOTH the current AND the previous
+ * ISO-week file, then filters by `ts >= now - sinceMs`. The 2-file read is
+ * the difference between this reader and `supervisor-audit.ts` — see the
+ * module-level JSDoc for why.
+ *
+ * `now` is injectable for unit tests that need to simulate "Monday 00:01
+ * UTC just after a Sunday 23:55 fire" without monkey-patching the clock.
+ *
+ * Returns events sorted oldest-first. Missing files / parse errors return []
+ * for that file (still reads the other one).
+ */
+export function readRecentStubGuardEvents(opts: { sinceMs: number; now?: Date } = { sinceMs: 24 * 60 * 60 * 1000 }): StubGuardEvent[] {
+  const now = opts.now ?? new Date();
+  const dir = resolveAuditDir();
+
+  // Compute current and previous ISO-week filenames. 7 days back from `now`
+  // lands in the previous ISO week (modulo daylight-saving boundary, which
+  // doesn't shift ISO-week boundaries since they're UTC-anchored).
+  const prevWeekDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const currentFile = computeStubGuardAuditFilename(now);
+  const prevFile = computeStubGuardAuditFilename(prevWeekDate);
+
+  // Dedup if current and prev computed the same name (shouldn't, but defensive).
+  const files = currentFile === prevFile ? [currentFile] : [prevFile, currentFile];
+
+  const cutoffMs = now.getTime() - opts.sinceMs;
+  const events: StubGuardEvent[] = [];
+
+  for (const filename of files) {
+    const fullPath = path.join(dir, filename);
+    let raw: string;
+    try {
+      raw = fs.readFileSync(fullPath, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const obj = JSON.parse(line) as StubGuardEvent;
+        if (!obj.ts || !obj.slug) continue;
+        const eventMs = Date.parse(obj.ts);
+        if (isNaN(eventMs)) continue;
+        if (eventMs < cutoffMs) continue;
+        events.push(obj);
+      } catch {
+        // Ignore malformed lines (truncated writes, disk-full corruption).
+      }
+    }
+  }
+
+  // Sort by timestamp ascending so doctor's count + recent-slug list is stable.
+  events.sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts));
+  return events;
+}

--- a/src/core/minions/child-worker-supervisor.ts
+++ b/src/core/minions/child-worker-supervisor.ts
@@ -38,6 +38,7 @@
 
 import { spawn, type ChildProcess } from 'child_process';
 import { buildSpawnInvocation, detectTini } from './spawn-helpers.ts';
+import { classifyWorkerExit } from './exit-classification.ts';
 import { calculateBackoffMs } from './supervisor.ts';
 
 export type ChildSupervisorEvent =
@@ -286,9 +287,11 @@ export class ChildWorkerSupervisor {
         // D1: code=0 is a clean exit (watchdog drain, graceful stop, etc.).
         // Don't touch crashCount — preserves flap detection across mixed
         // exit sequences. D2: record the clean-restart timestamp for budget
-        // tracking and prune entries outside the sliding window.
+        // tracking and prune entries outside the sliding window. Routes
+        // through the shared `classifyWorkerExit` helper so doctor.ts and
+        // jobs.ts (audit-log consumers) read the same rule.
         this._lastExitCode = code;
-        if (code === 0) {
+        if (classifyWorkerExit({ code }) === 'clean_exit') {
           const nowMs = this.now();
           this._cleanRestartTimestamps.push(nowMs);
           const windowMs = this.opts.cleanRestartWindowMs ?? DEFAULTS.cleanRestartWindowMs;

--- a/src/core/minions/exit-classification.ts
+++ b/src/core/minions/exit-classification.ts
@@ -1,0 +1,38 @@
+/**
+ * Worker exit classifier — single source of truth for "is this exit a crash?"
+ *
+ * Three call sites consume this rule:
+ *   1. `ChildWorkerSupervisor` (in-process, restart-policy decision)
+ *   2. `gbrain doctor` (audit-log read, supervisor health surface)
+ *   3. `gbrain jobs supervisor status` (audit-log read, CLI status)
+ *
+ * The supervisor reads Node's `child.on('exit', (code, signal) => …)` callback
+ * shape; doctor and jobs read the audit-log JSON shape. JSON.stringify drops
+ * `undefined` keys, so audit events surface missing exit codes as `code: null`
+ * (or with the key absent). The helper signature accepts the audit-shape;
+ * call sites that have Node's raw shape must normalize first (see
+ * `child-worker-supervisor.ts` for the wrapping pattern).
+ *
+ * Rule: `code === 0` is a clean exit (graceful shutdown, watchdog drain,
+ * queue completion). Everything else — non-zero integer, null, undefined,
+ * missing key — counts as a crash. The default is "crash" so a corrupted
+ * or pre-schema event row doesn't get silently demoted into the clean-restart
+ * bucket.
+ *
+ * Pure function. No side effects, no I/O.
+ */
+
+export type WorkerExitEvent = {
+  /**
+   * The worker process's numeric exit code, as serialized in the audit JSON.
+   * `null` means the process was killed by a signal (no exit code), or the
+   * field was missing from the event row. Both are treated as crashes.
+   */
+  code?: number | null;
+};
+
+export type WorkerExitClassification = 'crash' | 'clean_exit';
+
+export function classifyWorkerExit(event: WorkerExitEvent): WorkerExitClassification {
+  return event.code === 0 ? 'clean_exit' : 'crash';
+}

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -578,3 +578,41 @@ describe('v0.32.4 — sync_freshness check', () => {
     expect(result.message).toContain(`'wiki-id'`);
   });
 });
+
+describe('stub_guard_24h check (v0.34.5)', () => {
+  test('doctor source defines the stub_guard_24h check', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    expect(source).toContain("name: 'stub_guard_24h'");
+  });
+
+  test('WARN threshold is >10 hits/24h', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    // The WARN gate must fire above 10, not at or below — that's the threshold
+    // the v0.36 sunset criterion is calibrated against.
+    expect(source).toMatch(/events\.length\s*>\s*10/);
+  });
+
+  test('fix hint points operators at the audit log', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    expect(source).toContain('stub-guard-*.jsonl');
+    expect(source).toContain('prefix-expansion in resolveEntitySlug');
+  });
+
+  test('check reads via the dual-week-aware reader (NOT supervisor-audit pattern)', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    // The point of the divergence from supervisor-audit.ts is this reader
+    // reads both current and previous ISO-week files. If the check ever
+    // gets re-pointed at readSupervisorEvents-style single-week, this test
+    // fails — protecting the cross-week-boundary correctness.
+    expect(source).toContain('readRecentStubGuardEvents');
+    expect(source).not.toMatch(/from .*\/stub-guard-audit\.ts.*readSupervisorEvents/);
+  });
+
+  test('zero hits emits no check (keeps doctor output clean on healthy brains)', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    // The implementation falls through silently when events.length === 0.
+    // Codify this in source-grep form so a future refactor doesn't add an
+    // "ok: 0 hits" line that pollutes every doctor run.
+    expect(source).toMatch(/events\.length === 0|Zero hits is the goal/);
+  });
+});

--- a/test/entity-resolve-perf.slow.test.ts
+++ b/test/entity-resolve-perf.slow.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Perf regression guard for tryPrefixExpansion (T12 of the kinshasa-v3 wave).
+ *
+ * Asserts that the new correlated-subquery shape is at least 5x faster than
+ * the pre-fix derived-table shape on the same seeded brain. Baseline-ratio,
+ * not absolute wall-clock — different machines / Bun versions / PGLite
+ * builds / CI load can shift absolute timings by 10x without indicating a
+ * real regression, but the SHAPE difference between "aggregate full tables"
+ * and "correlated subquery per candidate" is what we actually care about.
+ *
+ * The old SQL is embedded verbatim below as the regression baseline. If
+ * a future refactor accidentally re-introduces full-table aggregation
+ * (LEFT JOIN against a SELECT ... GROUP BY ... over the whole `links` or
+ * `content_chunks` table), this test fails.
+ *
+ * .slow.test.ts suffix keeps it out of the fast loop. Run via
+ * `bun run test:slow`.
+ *
+ * PGLite-only. Postgres E2E is intentionally skipped — PG's planner can
+ * shape the OLD query's derived tables differently enough that the 5x
+ * ratio could be noise on a 5K-page fixture. The structural correctness
+ * of the rewrite is the same on both engines; this is purely a planner-
+ * shape regression guard.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+
+let engine: PGLiteEngine;
+
+// Seed sizes tuned to make the OLD shape visibly slow while keeping the
+// cold-start fixture under ~10s. Numbers below match the kinshasa-v3 plan.
+const PAGES = 5_000;
+const LINKS = 50_000;
+const CHUNKS = 25_000;
+const RUNS = 5; // median of 5 runs per shape
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+
+  // Seed pages. The Alice prefix has exactly 3 candidates (the case we
+  // want both shapes to actually evaluate); the rest are random fillers
+  // that contribute to the OLD shape's O(N) aggregation cost.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const db = (engine as any).db;
+
+  // Insert 3 target pages (people/alice-*).
+  for (const slug of ['people/alice-example', 'people/alice-research', 'people/alice-engineer']) {
+    await engine.putPage(slug, {
+      type: 'person',
+      title: slug.split('/').pop()!,
+      compiled_truth: `# ${slug}`,
+      frontmatter: { type: 'person', title: slug, slug },
+    }, { sourceId: 'default' });
+  }
+
+  // Bulk-insert filler pages. Use a single executeRaw with generate_series
+  // for speed; PGLite handles this fine.
+  await db.query(
+    `INSERT INTO pages (slug, type, title, compiled_truth, frontmatter, source_id, created_at, updated_at)
+     SELECT 'filler/page-' || gs::text,
+            'note',
+            'Filler ' || gs::text,
+            '# Filler',
+            '{}',
+            'default',
+            NOW(),
+            NOW()
+     FROM generate_series(1, ${PAGES}) gs`,
+  );
+
+  // Capture id range for link + chunk inserts.
+  const fillerIds = await db.query(`SELECT id FROM pages WHERE slug LIKE 'filler/%' LIMIT ${PAGES}`);
+  const aliceIds = await db.query(`SELECT id FROM pages WHERE slug LIKE 'people/alice-%'`);
+  const allIds = [...fillerIds.rows.map((r: { id: string }) => r.id), ...aliceIds.rows.map((r: { id: string }) => r.id)];
+
+  // Spread LINKS across filler pages (filler→filler). The OLD shape will
+  // aggregate ALL of these on every prefix-expansion call; the NEW shape
+  // touches only the alice rows via index.
+  const linkBatch = 5_000;
+  for (let i = 0; i < LINKS; i += linkBatch) {
+    const tuples: string[] = [];
+    const params: string[] = [];
+    let p = 1;
+    for (let j = 0; j < linkBatch && i + j < LINKS; j++) {
+      const from = allIds[Math.floor(Math.random() * allIds.length)];
+      const to = allIds[Math.floor(Math.random() * allIds.length)];
+      if (from === to) continue;
+      tuples.push(`($${p++}, $${p++}, 'mentions')`);
+      params.push(from, to);
+    }
+    if (tuples.length === 0) continue;
+    // ON CONFLICT DO NOTHING — the links table has a unique index across
+    // (from, to, type, source, origin); random pairs occasionally collide.
+    // Test seeding doesn't care if a few inserts are skipped; the order of
+    // magnitude is what matters for the perf comparison.
+    await db.query(
+      `INSERT INTO links (from_page_id, to_page_id, link_type) VALUES ${tuples.join(',')}
+       ON CONFLICT DO NOTHING`,
+      params,
+    );
+  }
+
+  // Spread CHUNKS across all pages. Use a per-page counter so each
+  // (page_id, chunk_index) pair is unique — there's a unique index on
+  // content_chunks(page_id, chunk_index) so random chunk_index values
+  // would collide.
+  const chunkCounts = new Map<string, number>();
+  const chunkBatch = 5_000;
+  for (let i = 0; i < CHUNKS; i += chunkBatch) {
+    const tuples: string[] = [];
+    const params: (string | number)[] = [];
+    let p = 1;
+    for (let j = 0; j < chunkBatch && i + j < CHUNKS; j++) {
+      const pid = allIds[Math.floor(Math.random() * allIds.length)];
+      const idx = chunkCounts.get(pid) ?? 0;
+      chunkCounts.set(pid, idx + 1);
+      tuples.push(`($${p++}, $${p++}, $${p++})`);
+      params.push(pid, idx, `chunk ${i + j}`);
+    }
+    await db.query(
+      `INSERT INTO content_chunks (page_id, chunk_index, chunk_text) VALUES ${tuples.join(',')}`,
+      params,
+    );
+  }
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+// The pre-T12 query shape, embedded verbatim as the regression baseline.
+// If a future refactor re-introduces this shape, the test fails.
+const OLD_SQL = `
+  SELECT p.slug,
+         (COALESCE(li.in_count, 0) + COALESCE(lo.out_count, 0) + COALESCE(cc.chunk_count, 0))
+           AS connection_count
+  FROM pages p
+  LEFT JOIN (
+    SELECT to_page_id AS pid, COUNT(*)::int AS in_count
+    FROM links GROUP BY to_page_id
+  ) li ON li.pid = p.id
+  LEFT JOIN (
+    SELECT from_page_id AS pid, COUNT(*)::int AS out_count
+    FROM links GROUP BY from_page_id
+  ) lo ON lo.pid = p.id
+  LEFT JOIN (
+    SELECT page_id AS pid, COUNT(*)::int AS chunk_count
+    FROM content_chunks GROUP BY page_id
+  ) cc ON cc.pid = p.id
+  WHERE p.source_id = $1
+    AND p.deleted_at IS NULL
+    AND p.slug LIKE $2
+  ORDER BY connection_count DESC, p.slug ASC
+  LIMIT 5
+`;
+
+// The T12 query shape — what tryPrefixExpansion now uses.
+const NEW_SQL = `
+  SELECT p.slug,
+         ((SELECT COUNT(*)::int FROM links WHERE to_page_id = p.id)
+          + (SELECT COUNT(*)::int FROM links WHERE from_page_id = p.id)
+          + (SELECT COUNT(*)::int FROM content_chunks WHERE page_id = p.id))
+           AS connection_count
+  FROM pages p
+  WHERE p.source_id = $1
+    AND p.deleted_at IS NULL
+    AND p.slug LIKE $2
+  ORDER BY connection_count DESC, p.slug ASC
+  LIMIT 5
+`;
+
+async function timeQuery(sql: string): Promise<number> {
+  const start = performance.now();
+  const rows = await engine.executeRaw<{ slug: string; connection_count: number }>(
+    sql,
+    ['default', 'people/alice-%'],
+  );
+  const elapsed = performance.now() - start;
+  // Sanity: both shapes must return the same result set so the timing is
+  // comparing apples to apples.
+  if (rows.length === 0) throw new Error('Query returned no rows — fixture seeding broke');
+  return elapsed;
+}
+
+function median(xs: number[]): number {
+  const sorted = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+describe('tryPrefixExpansion perf regression — NEW shape >= 5x faster than OLD', () => {
+  it('correlated subqueries beat derived-table aggregation by 5x or more', async () => {
+    // Warm both shapes once so the planner caches its plan, then measure.
+    await timeQuery(OLD_SQL);
+    await timeQuery(NEW_SQL);
+
+    const oldTimes: number[] = [];
+    const newTimes: number[] = [];
+    for (let i = 0; i < RUNS; i++) oldTimes.push(await timeQuery(OLD_SQL));
+    for (let i = 0; i < RUNS; i++) newTimes.push(await timeQuery(NEW_SQL));
+
+    const oldMedian = median(oldTimes);
+    const newMedian = median(newTimes);
+    const speedup = oldMedian / newMedian;
+
+    // Emit timing data to stderr so a regression review can see the actual
+    // numbers, not just pass/fail.
+    process.stderr.write(
+      `[entity-resolve-perf] fixture=${PAGES}p+${LINKS}l+${CHUNKS}c ` +
+      `old_median=${oldMedian.toFixed(2)}ms new_median=${newMedian.toFixed(2)}ms ` +
+      `speedup=${speedup.toFixed(2)}x\n`,
+    );
+
+    expect(speedup).toBeGreaterThanOrEqual(5);
+  }, 60_000);
+});

--- a/test/entity-resolve.test.ts
+++ b/test/entity-resolve.test.ts
@@ -4,10 +4,15 @@ import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 
 /**
- * v0.34.5 — entity resolution prefix expansion tests.
+ * Entity resolution prefix expansion tests.
  *
  * Validates that bare first names resolve to existing pages via prefix
  * expansion, preventing phantom stub creation.
+ *
+ * Fixture names use the `alice-example` / `bob-example` / `charlie-example`
+ * / `dave-example` placeholder pattern per CLAUDE.md privacy rule.
+ * `stripe` and `stripe-atlas` are intentional — household-brand exception
+ * exercises the two-word company prefix case.
  */
 
 let engine: PGLiteEngine;
@@ -17,14 +22,18 @@ beforeAll(async () => {
   await engine.connect({ database_url: '' });
   await engine.initSchema();
 
-  // Seed test pages.
+  // Seed test pages. Naming pattern:
+  //   - alice-example: single-match case (only people/alice-*)
+  //   - bob-example vs bob-rosenstein: multi-match tiebreaker (bob-example wins on connections)
+  //   - charlie-example vs charlie-bankcroft: multi-match tiebreaker (charlie-example wins on connections)
+  //   - dave-example: single-match case
   const pages = [
-    { slug: 'people/jared-friedman', title: 'Jared Friedman', type: 'person' },
-    { slug: 'people/diana-hu', title: 'Diana Hu', type: 'person' },
-    { slug: 'people/diana-ross', title: 'Diana Ross', type: 'person' },
-    { slug: 'people/sam-altman', title: 'Sam Altman', type: 'person' },
-    { slug: 'people/sam-bankman-fried', title: 'Sam Bankman-Fried', type: 'person' },
-    { slug: 'people/garry-tan', title: 'Garry Tan', type: 'person' },
+    { slug: 'people/alice-example', title: 'Alice Example', type: 'person' },
+    { slug: 'people/bob-example', title: 'Bob Example', type: 'person' },
+    { slug: 'people/bob-rosenstein', title: 'Bob Rosenstein', type: 'person' },
+    { slug: 'people/charlie-example', title: 'Charlie Example', type: 'person' },
+    { slug: 'people/charlie-bankcroft', title: 'Charlie Bankcroft', type: 'person' },
+    { slug: 'people/dave-example', title: 'Dave Example', type: 'person' },
     { slug: 'companies/stripe', title: 'Stripe', type: 'company' },
     { slug: 'companies/stripe-atlas', title: 'Stripe Atlas', type: 'company' },
   ];
@@ -38,47 +47,47 @@ beforeAll(async () => {
     }, { sourceId: 'default' });
   }
 
-  // Give jared-friedman more connections (chunks) to win tiebreakers
-  const jaredPage = await engine.executeRaw<{ id: string }>(
-    `SELECT id FROM pages WHERE slug = 'people/jared-friedman' AND source_id = 'default'`,
+  // Give alice-example 10 chunks (single match, ensures it's the resolved target)
+  const alicePage = await engine.executeRaw<{ id: string }>(
+    `SELECT id FROM pages WHERE slug = 'people/alice-example' AND source_id = 'default'`,
     [],
   );
-  if (jaredPage.length > 0) {
+  if (alicePage.length > 0) {
     for (let i = 0; i < 10; i++) {
       await engine.executeRaw(
         `INSERT INTO content_chunks (page_id, chunk_index, chunk_text)
          VALUES ($1, $2, $3)`,
-        [jaredPage[0].id, i, `Chunk ${i} about Jared Friedman`],
+        [alicePage[0].id, i, `Chunk ${i} about Alice Example`],
       );
     }
   }
 
-  // Give sam-altman more connections than sam-bankman-fried
-  const samPage = await engine.executeRaw<{ id: string }>(
-    `SELECT id FROM pages WHERE slug = 'people/sam-altman' AND source_id = 'default'`,
+  // Give charlie-example more connections than charlie-bankcroft (20 vs 0)
+  const charliePage = await engine.executeRaw<{ id: string }>(
+    `SELECT id FROM pages WHERE slug = 'people/charlie-example' AND source_id = 'default'`,
     [],
   );
-  if (samPage.length > 0) {
+  if (charliePage.length > 0) {
     for (let i = 0; i < 20; i++) {
       await engine.executeRaw(
         `INSERT INTO content_chunks (page_id, chunk_index, chunk_text)
          VALUES ($1, $2, $3)`,
-        [samPage[0].id, i, `Chunk ${i} about Sam Altman`],
+        [charliePage[0].id, i, `Chunk ${i} about Charlie Example`],
       );
     }
   }
 
-  // Give diana-hu more connections than diana-ross
-  const dianaPage = await engine.executeRaw<{ id: string }>(
-    `SELECT id FROM pages WHERE slug = 'people/diana-hu' AND source_id = 'default'`,
+  // Give bob-example more connections than bob-rosenstein (15 vs 0)
+  const bobPage = await engine.executeRaw<{ id: string }>(
+    `SELECT id FROM pages WHERE slug = 'people/bob-example' AND source_id = 'default'`,
     [],
   );
-  if (dianaPage.length > 0) {
+  if (bobPage.length > 0) {
     for (let i = 0; i < 15; i++) {
       await engine.executeRaw(
         `INSERT INTO content_chunks (page_id, chunk_index, chunk_text)
          VALUES ($1, $2, $3)`,
-        [dianaPage[0].id, i, `Chunk ${i} about Diana Hu`],
+        [bobPage[0].id, i, `Chunk ${i} about Bob Example`],
       );
     }
   }
@@ -88,30 +97,30 @@ afterAll(async () => {
   await engine.disconnect();
 });
 
-describe('resolveEntitySlug — prefix expansion (v0.34.5)', () => {
-  it('resolves "Jared" to people/jared-friedman', async () => {
-    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Jared');
-    expect(result).toBe('people/jared-friedman');
+describe('resolveEntitySlug — prefix expansion', () => {
+  it('resolves "Alice" to people/alice-example', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Alice');
+    expect(result).toBe('people/alice-example');
   });
 
-  it('resolves "jared" (lowercase) to people/jared-friedman', async () => {
-    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'jared');
-    expect(result).toBe('people/jared-friedman');
+  it('resolves "alice" (lowercase) to people/alice-example', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'alice');
+    expect(result).toBe('people/alice-example');
   });
 
-  it('resolves "Diana" to people/diana-hu (more connections)', async () => {
-    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Diana');
-    expect(result).toBe('people/diana-hu');
+  it('resolves "Bob" to people/bob-example (more connections)', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Bob');
+    expect(result).toBe('people/bob-example');
   });
 
-  it('resolves "Sam" to people/sam-altman (more connections)', async () => {
-    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Sam');
-    expect(result).toBe('people/sam-altman');
+  it('resolves "Charlie" to people/charlie-example (more connections)', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Charlie');
+    expect(result).toBe('people/charlie-example');
   });
 
-  it('resolves "Garry" to people/garry-tan (single match)', async () => {
-    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Garry');
-    expect(result).toBe('people/garry-tan');
+  it('resolves "Dave" to people/dave-example (single match)', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Dave');
+    expect(result).toBe('people/dave-example');
   });
 
   it('falls through to slugify for unknown names', async () => {
@@ -120,20 +129,20 @@ describe('resolveEntitySlug — prefix expansion (v0.34.5)', () => {
   });
 
   it('exact match still works for fully-qualified slugs', async () => {
-    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'people/jared-friedman');
-    expect(result).toBe('people/jared-friedman');
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'people/alice-example');
+    expect(result).toBe('people/alice-example');
   });
 
   it('multi-word input does NOT trigger prefix expansion', async () => {
-    // "Jared Friedman" should go through fuzzy match, not prefix expansion
-    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Jared Friedman');
+    // "Alice Example" should go through fuzzy match, not prefix expansion
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Alice Example');
     // Should resolve via fuzzy match to the same page
-    expect(result).toContain('jared-friedman');
+    expect(result).toContain('alice-example');
   });
 
   it('hyphenated input does NOT trigger prefix expansion', async () => {
-    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'jared-friedman');
-    expect(result).toBe('people/jared-friedman');
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'alice-example');
+    expect(result).toBe('people/alice-example');
   });
 
   it('returns null for empty input', async () => {
@@ -144,11 +153,11 @@ describe('resolveEntitySlug — prefix expansion (v0.34.5)', () => {
 
 describe('slugify', () => {
   it('lowercases and hyphenates', () => {
-    expect(slugify('Jared Friedman')).toBe('jared-friedman');
+    expect(slugify('Alice Example')).toBe('alice-example');
   });
 
   it('handles single word', () => {
-    expect(slugify('Jared')).toBe('jared');
+    expect(slugify('Alice')).toBe('alice');
   });
 
   it('strips accents', () => {

--- a/test/entity-resolve.test.ts
+++ b/test/entity-resolve.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { resolveEntitySlug, slugify } from '../src/core/entities/resolve.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+/**
+ * v0.34.5 — entity resolution prefix expansion tests.
+ *
+ * Validates that bare first names resolve to existing pages via prefix
+ * expansion, preventing phantom stub creation.
+ */
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ database_url: '' });
+  await engine.initSchema();
+
+  // Seed test pages.
+  const pages = [
+    { slug: 'people/jared-friedman', title: 'Jared Friedman', type: 'person' },
+    { slug: 'people/diana-hu', title: 'Diana Hu', type: 'person' },
+    { slug: 'people/diana-ross', title: 'Diana Ross', type: 'person' },
+    { slug: 'people/sam-altman', title: 'Sam Altman', type: 'person' },
+    { slug: 'people/sam-bankman-fried', title: 'Sam Bankman-Fried', type: 'person' },
+    { slug: 'people/garry-tan', title: 'Garry Tan', type: 'person' },
+    { slug: 'companies/stripe', title: 'Stripe', type: 'company' },
+    { slug: 'companies/stripe-atlas', title: 'Stripe Atlas', type: 'company' },
+  ];
+
+  for (const p of pages) {
+    await engine.putPage(p.slug, {
+      type: p.type as any,
+      title: p.title,
+      compiled_truth: `# ${p.title}`,
+      frontmatter: { type: p.type, title: p.title, slug: p.slug },
+    }, { sourceId: 'default' });
+  }
+
+  // Give jared-friedman more connections (chunks) to win tiebreakers
+  const jaredPage = await engine.executeRaw<{ id: string }>(
+    `SELECT id FROM pages WHERE slug = 'people/jared-friedman' AND source_id = 'default'`,
+    [],
+  );
+  if (jaredPage.length > 0) {
+    for (let i = 0; i < 10; i++) {
+      await engine.executeRaw(
+        `INSERT INTO content_chunks (page_id, chunk_index, chunk_text)
+         VALUES ($1, $2, $3)`,
+        [jaredPage[0].id, i, `Chunk ${i} about Jared Friedman`],
+      );
+    }
+  }
+
+  // Give sam-altman more connections than sam-bankman-fried
+  const samPage = await engine.executeRaw<{ id: string }>(
+    `SELECT id FROM pages WHERE slug = 'people/sam-altman' AND source_id = 'default'`,
+    [],
+  );
+  if (samPage.length > 0) {
+    for (let i = 0; i < 20; i++) {
+      await engine.executeRaw(
+        `INSERT INTO content_chunks (page_id, chunk_index, chunk_text)
+         VALUES ($1, $2, $3)`,
+        [samPage[0].id, i, `Chunk ${i} about Sam Altman`],
+      );
+    }
+  }
+
+  // Give diana-hu more connections than diana-ross
+  const dianaPage = await engine.executeRaw<{ id: string }>(
+    `SELECT id FROM pages WHERE slug = 'people/diana-hu' AND source_id = 'default'`,
+    [],
+  );
+  if (dianaPage.length > 0) {
+    for (let i = 0; i < 15; i++) {
+      await engine.executeRaw(
+        `INSERT INTO content_chunks (page_id, chunk_index, chunk_text)
+         VALUES ($1, $2, $3)`,
+        [dianaPage[0].id, i, `Chunk ${i} about Diana Hu`],
+      );
+    }
+  }
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+describe('resolveEntitySlug — prefix expansion (v0.34.5)', () => {
+  it('resolves "Jared" to people/jared-friedman', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Jared');
+    expect(result).toBe('people/jared-friedman');
+  });
+
+  it('resolves "jared" (lowercase) to people/jared-friedman', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'jared');
+    expect(result).toBe('people/jared-friedman');
+  });
+
+  it('resolves "Diana" to people/diana-hu (more connections)', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Diana');
+    expect(result).toBe('people/diana-hu');
+  });
+
+  it('resolves "Sam" to people/sam-altman (more connections)', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Sam');
+    expect(result).toBe('people/sam-altman');
+  });
+
+  it('resolves "Garry" to people/garry-tan (single match)', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Garry');
+    expect(result).toBe('people/garry-tan');
+  });
+
+  it('falls through to slugify for unknown names', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Zyxwvut');
+    expect(result).toBe('zyxwvut');
+  });
+
+  it('exact match still works for fully-qualified slugs', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'people/jared-friedman');
+    expect(result).toBe('people/jared-friedman');
+  });
+
+  it('multi-word input does NOT trigger prefix expansion', async () => {
+    // "Jared Friedman" should go through fuzzy match, not prefix expansion
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'Jared Friedman');
+    // Should resolve via fuzzy match to the same page
+    expect(result).toContain('jared-friedman');
+  });
+
+  it('hyphenated input does NOT trigger prefix expansion', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', 'jared-friedman');
+    expect(result).toBe('people/jared-friedman');
+  });
+
+  it('returns null for empty input', async () => {
+    const result = await resolveEntitySlug(engine as unknown as BrainEngine, 'default', '');
+    expect(result).toBeNull();
+  });
+});
+
+describe('slugify', () => {
+  it('lowercases and hyphenates', () => {
+    expect(slugify('Jared Friedman')).toBe('jared-friedman');
+  });
+
+  it('handles single word', () => {
+    expect(slugify('Jared')).toBe('jared');
+  });
+
+  it('strips accents', () => {
+    expect(slugify('José García')).toBe('jose-garcia');
+  });
+});

--- a/test/exit-classification.test.ts
+++ b/test/exit-classification.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { classifyWorkerExit } from '../src/core/minions/exit-classification.ts';
 
 describe('classifyWorkerExit', () => {
@@ -23,5 +25,91 @@ describe('classifyWorkerExit', () => {
     // Both must classify as crash so a corrupted/legacy row doesn't get
     // silently demoted into the clean-restart bucket.
     expect(classifyWorkerExit({})).toBe('crash');
+  });
+});
+
+describe('consumer wire-up — helper used by all 3 sites (no inline filters left)', () => {
+  // The whole point of T7 (DRY) is replacing three inline filters with one
+  // helper. These tests pin the wire-up so a future refactor that
+  // accidentally inlines the rule again gets caught at test time, not at
+  // production-divergence time.
+
+  const SITES = [
+    { label: 'doctor.ts', path: 'src/commands/doctor.ts' },
+    { label: 'jobs.ts', path: 'src/commands/jobs.ts' },
+    { label: 'child-worker-supervisor.ts', path: 'src/core/minions/child-worker-supervisor.ts' },
+  ];
+
+  for (const site of SITES) {
+    it(`${site.label} imports classifyWorkerExit`, () => {
+      const source = readFileSync(join(import.meta.dir, '..', site.path), 'utf8');
+      // Either named import OR import-from of the helper file — both count.
+      expect(source).toMatch(/(import\s+\{[^}]*classifyWorkerExit[^}]*\}|from\s+['"][^'"]*exit-classification)/);
+    });
+
+    it(`${site.label} calls classifyWorkerExit at least once`, () => {
+      const source = readFileSync(join(import.meta.dir, '..', site.path), 'utf8');
+      expect(source).toMatch(/classifyWorkerExit\s*\(/);
+    });
+  }
+
+  it('doctor.ts no longer has the inline `code !== 0 && code !== undefined` filter', () => {
+    const source = readFileSync(join(import.meta.dir, '..', 'src/commands/doctor.ts'), 'utf8');
+    // The pre-T7 inline filter; if this regex matches, the refactor leaked back.
+    expect(source).not.toMatch(/code !== 0\s*&&\s*\(?\s*\w+\s+as\s+any\s*\)?\.\s*code !== undefined/);
+  });
+
+  it('jobs.ts no longer has the inline filter', () => {
+    const source = readFileSync(join(import.meta.dir, '..', 'src/commands/jobs.ts'), 'utf8');
+    expect(source).not.toMatch(/code !== 0\s*&&\s*\(?\s*\w+\s+as\s+any\s*\)?\.\s*code !== undefined/);
+  });
+
+  it('child-worker-supervisor.ts uses helper to decide clean_exit vs crash branch', () => {
+    const source = readFileSync(join(import.meta.dir, '..', 'src/core/minions/child-worker-supervisor.ts'), 'utf8');
+    // The exit-handler branch should compare the helper result, not the raw code.
+    expect(source).toMatch(/classifyWorkerExit\(\s*\{\s*code\s*\}\s*\)\s*===\s*['"]clean_exit['"]/);
+  });
+});
+
+describe('audit-log shape integration — `code: 0` event is NOT counted as a crash', () => {
+  // Sanity round-trip: simulate the exact event shape that supervisor-audit
+  // writes (and that doctor + jobs read), classify it through the helper,
+  // and confirm the result. This catches future changes to the audit event
+  // shape (e.g. renaming `code` to `exit_code`) that would silently break
+  // the consumers' crash counting.
+  it('audit event { event: "worker_exited", code: 0, signal: null } → clean_exit', () => {
+    const auditEvent = {
+      event: 'worker_exited',
+      ts: '2026-05-15T12:00:00Z',
+      code: 0,
+      signal: null,
+      runDurationMs: 30000,
+      likelyCause: 'clean_exit',
+    };
+    expect(classifyWorkerExit(auditEvent as { code?: number | null })).toBe('clean_exit');
+  });
+
+  it('audit event { event: "worker_exited", code: 1, signal: null } → crash', () => {
+    const auditEvent = {
+      event: 'worker_exited',
+      ts: '2026-05-15T12:00:00Z',
+      code: 1,
+      signal: null,
+      runDurationMs: 250,
+      likelyCause: 'runtime_error',
+    };
+    expect(classifyWorkerExit(auditEvent as { code?: number | null })).toBe('crash');
+  });
+
+  it('audit event { event: "worker_exited", code: null, signal: "SIGKILL" } → crash', () => {
+    const auditEvent = {
+      event: 'worker_exited',
+      ts: '2026-05-15T12:00:00Z',
+      code: null,
+      signal: 'SIGKILL',
+      runDurationMs: 0,
+      likelyCause: 'oom_or_external_kill',
+    };
+    expect(classifyWorkerExit(auditEvent as { code?: number | null })).toBe('crash');
   });
 });

--- a/test/exit-classification.test.ts
+++ b/test/exit-classification.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'bun:test';
+import { classifyWorkerExit } from '../src/core/minions/exit-classification.ts';
+
+describe('classifyWorkerExit', () => {
+  it('code=0 → clean_exit', () => {
+    expect(classifyWorkerExit({ code: 0 })).toBe('clean_exit');
+  });
+
+  it('code=1 (runtime error) → crash', () => {
+    expect(classifyWorkerExit({ code: 1 })).toBe('crash');
+  });
+
+  it('code=137 (SIGKILL) → crash', () => {
+    expect(classifyWorkerExit({ code: 137 })).toBe('crash');
+  });
+
+  it('code=null (signal-only exit, audit JSON shape) → crash', () => {
+    expect(classifyWorkerExit({ code: null })).toBe('crash');
+  });
+
+  it('missing code (older audit shape with undefined key) → crash', () => {
+    // JSON.stringify drops undefined keys; reader may see {} or {code: null}.
+    // Both must classify as crash so a corrupted/legacy row doesn't get
+    // silently demoted into the clean-restart bucket.
+    expect(classifyWorkerExit({})).toBe('crash');
+  });
+});

--- a/test/facts-backstop.test.ts
+++ b/test/facts-backstop.test.ts
@@ -238,3 +238,66 @@ describe('runFactsBackstop — dedup fast-path', () => {
     }
   });
 });
+
+describe('runFactsBackstop — stub guard routing (v0.34.5)', () => {
+  test('bare-name entity routes to legacy DB-only path (no phantom page)', async () => {
+    // Set up: configure default source with a real local_path so the
+    // backstop reaches Phase 5 (fence write) instead of Phase 4 (legacy).
+    // This is the scenario where the stub guard actually fires.
+    const { mkdtempSync, rmSync, existsSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+
+    const brainDir = mkdtempSync(join(tmpdir(), 'backstop-stub-guard-'));
+    try {
+      // Point the default source at the tempdir so localPath is non-null.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (engine as any).db.query(
+        `UPDATE sources SET local_path = $1 WHERE id = 'default'`,
+        [brainDir],
+      );
+
+      // Stub the chat to return a fact with a bare-name entity. The
+      // resolver will:
+      //   1. exact slug match → miss (no 'noresolvable' row)
+      //   2. fuzzy match → miss (no title contains noresolvable)
+      //   3. prefix expansion → miss (no people/noresolvable-* rows)
+      //   4. slugify fallback → 'noresolvable' (bare)
+      // The bare slug then trips the stub guard in writeFactsToFence,
+      // which returns stubGuardBlocked: true, and backstop routes the
+      // fact to engine.insertFact (DB-only).
+      chatStub([
+        { fact: 'said hello at the meeting', kind: 'event', notability: 'high', entity: 'noresolvable' },
+      ]);
+
+      const r = await runFactsBackstop(meetingPage(), makeCtx({ mode: 'inline' }));
+
+      expect(r.mode).toBe('inline');
+      if (r.mode === 'inline') {
+        // The fact MUST be persisted via the DB-only fallback, not dropped.
+        expect(r.inserted).toBe(1);
+        expect(r.fact_ids.length).toBe(1);
+
+        // No phantom file at the brain root (this is the whole point of the guard).
+        expect(existsSync(join(brainDir, 'noresolvable.md'))).toBe(false);
+
+        // The fact is in the DB with the bare entity_slug. Query directly to
+        // confirm — the routing is the contract under test.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const rows = await (engine as any).db.query(
+          `SELECT entity_slug, fact, source_markdown_slug FROM facts WHERE id = $1`,
+          [r.fact_ids[0]],
+        );
+        expect(rows.rows[0].entity_slug).toBe('noresolvable');
+        expect(rows.rows[0].fact).toBe('said hello at the meeting');
+        // source_markdown_slug is the fence-tracking column; under DB-only
+        // fallback it stays null (no .md file backs the row).
+        expect(rows.rows[0].source_markdown_slug).toBeNull();
+      }
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (engine as any).db.query(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
+      rmSync(brainDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/fence-write.test.ts
+++ b/test/fence-write.test.ts
@@ -223,6 +223,56 @@ describe('writeFactsToFence — atomic recovery', () => {
   });
 });
 
+describe('writeFactsToFence — stub guard (v0.34.5)', () => {
+  test('refuses to stub-create an unprefixed entity page (bare slug)', async () => {
+    const result = await writeFactsToFence(
+      engine,
+      { sourceId: 'default', localPath: brainDir, slug: 'alice' },
+      [baseInput()],
+    );
+
+    // Result shape: no facts inserted, guard flag set, no ids.
+    expect(result.inserted).toBe(0);
+    expect(result.ids).toHaveLength(0);
+    expect(result.stubGuardBlocked).toBe(true);
+
+    // No phantom file at brain root.
+    expect(existsSync(join(brainDir, 'alice.md'))).toBe(false);
+    // No phantom .tmp either.
+    expect(existsSync(join(brainDir, 'alice.md.tmp'))).toBe(false);
+  });
+
+  test('prefixed slugs (people/, companies/, etc.) bypass the guard', async () => {
+    // Sanity: re-prove the happy path right next to the guard test so a
+    // future refactor that breaks the guard's slug.includes('/') check
+    // can't silently pass by only running the guard case.
+    const result = await writeFactsToFence(
+      engine,
+      { sourceId: 'default', localPath: brainDir, slug: 'people/zelda' },
+      [baseInput({ fact: 'Founded Hyrule Labs in 2024' })],
+    );
+
+    expect(result.inserted).toBe(1);
+    expect(result.stubGuardBlocked).toBeUndefined();
+    expect(existsSync(join(brainDir, 'people/zelda.md'))).toBe(true);
+  });
+
+  test('empty facts array is a no-op (does NOT trigger the guard)', async () => {
+    // Empty input short-circuits BEFORE the guard runs — confirming the
+    // guard only fires when there's actual work the caller wants to do.
+    const result = await writeFactsToFence(
+      engine,
+      { sourceId: 'default', localPath: brainDir, slug: 'alice' },
+      [],
+    );
+
+    expect(result.inserted).toBe(0);
+    expect(result.stubGuardBlocked).toBeUndefined();
+    expect(result.legacyFallback).toBeUndefined();
+    expect(existsSync(join(brainDir, 'alice.md'))).toBe(false);
+  });
+});
+
 describe('lookupSourceLocalPath', () => {
   test('returns the configured local_path for an existing source', async () => {
     const got = await lookupSourceLocalPath(engine, 'default');

--- a/test/stub-guard-audit.test.ts
+++ b/test/stub-guard-audit.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'bun:test';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { withEnv } from './helpers/with-env.ts';
+import {
+  computeStubGuardAuditFilename,
+  readRecentStubGuardEvents,
+  logStubGuardEvent,
+} from '../src/core/facts/stub-guard-audit.ts';
+
+/** Make a fresh tempdir for one test's audit files. Caller is responsible for cleanup. */
+function freshTmpDir(): string {
+  const dir = join(tmpdir(), `stub-guard-audit-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('computeStubGuardAuditFilename', () => {
+  it('produces ISO-week filename for a mid-week date', () => {
+    // 2026-05-13 is a Wednesday in ISO week 20 of 2026.
+    const filename = computeStubGuardAuditFilename(new Date('2026-05-13T12:00:00Z'));
+    expect(filename).toBe('stub-guard-2026-W20.jsonl');
+  });
+
+  it('handles ISO year-boundary correctly (2027-01-01 is W53 of 2026)', () => {
+    // The ISO-week standard: 2027-01-01 (Friday) belongs to W53 of 2026
+    // because W1 of 2027 starts on Monday 2027-01-04.
+    const filename = computeStubGuardAuditFilename(new Date('2027-01-01T12:00:00Z'));
+    expect(filename).toBe('stub-guard-2026-W53.jsonl');
+  });
+});
+
+describe('logStubGuardEvent', () => {
+  it('appends a JSONL line to the current ISO-week file', async () => {
+    const tmpAuditDir = freshTmpDir();
+    try {
+      await withEnv({ GBRAIN_AUDIT_DIR: tmpAuditDir }, async () => {
+        logStubGuardEvent({ slug: 'alice', source_id: 'default', fact_count: 3 });
+        const filename = computeStubGuardAuditFilename();
+        const fullPath = join(tmpAuditDir, filename);
+        expect(existsSync(fullPath)).toBe(true);
+        const content = readFileSync(fullPath, 'utf8');
+        const lines = content.trim().split('\n');
+        expect(lines.length).toBe(1);
+        const obj = JSON.parse(lines[0]);
+        expect(obj.slug).toBe('alice');
+        expect(obj.source_id).toBe('default');
+        expect(obj.fact_count).toBe(3);
+        expect(typeof obj.ts).toBe('string');
+        expect(obj.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      });
+    } finally {
+      if (existsSync(tmpAuditDir)) rmSync(tmpAuditDir, { recursive: true, force: true });
+    }
+  });
+
+  it('never throws when audit dir is unwritable', async () => {
+    // Point GBRAIN_AUDIT_DIR at a file (not a directory) — mkdirSync will fail,
+    // appendFileSync will fail. Both should be swallowed.
+    const blockerFile = join(tmpdir(), `stub-guard-blocker-${Date.now()}.txt`);
+    writeFileSync(blockerFile, 'this is a regular file');
+    try {
+      await withEnv({ GBRAIN_AUDIT_DIR: blockerFile }, async () => {
+        expect(() => logStubGuardEvent({ slug: 'bob', source_id: 'default', fact_count: 1 })).not.toThrow();
+      });
+    } finally {
+      if (existsSync(blockerFile)) rmSync(blockerFile);
+    }
+  });
+});
+
+describe('readRecentStubGuardEvents — cross-week-boundary correctness', () => {
+  it('reads events from BOTH current and previous ISO-week files', async () => {
+    // Simulate "Monday 00:01 UTC just after a Sunday 23:55 UTC fire."
+    // The Sunday event is in last week's file; the Monday read window
+    // must surface it. This is the case readSupervisorEvents misses.
+    const tmpAuditDir = freshTmpDir();
+    try {
+      await withEnv({ GBRAIN_AUDIT_DIR: tmpAuditDir }, async () => {
+        const fakeNow = new Date('2026-05-11T00:01:00Z'); // Monday W20 2026
+        const prevSunday = new Date('2026-05-10T23:55:00Z'); // Sunday W19 2026
+        const earlierInWindow = new Date('2026-05-10T00:30:00Z'); // earlier in 24h window, W19
+        const outsideWindow = new Date('2026-05-09T12:00:00Z'); // outside 24h window, W19
+        const earlyMonday = new Date('2026-05-11T00:00:30Z'); // current week, in window
+
+        const prevWeekFile = computeStubGuardAuditFilename(prevSunday);
+        const currentFile = computeStubGuardAuditFilename(fakeNow);
+
+        // Sanity: they MUST be different files for this regression test to mean anything.
+        expect(prevWeekFile).not.toBe(currentFile);
+
+        // Manually write to both files (bypass writer to control timestamps).
+        const prevPath = join(tmpAuditDir, prevWeekFile);
+        const currentPath = join(tmpAuditDir, currentFile);
+        writeFileSync(prevPath, [
+          JSON.stringify({ ts: outsideWindow.toISOString(), slug: 'too-old', source_id: 'default', fact_count: 1 }),
+          JSON.stringify({ ts: earlierInWindow.toISOString(), slug: 'monday-prev-week', source_id: 'default', fact_count: 1 }),
+          JSON.stringify({ ts: prevSunday.toISOString(), slug: 'sunday-late', source_id: 'default', fact_count: 1 }),
+        ].join('\n') + '\n');
+        writeFileSync(currentPath, [
+          JSON.stringify({ ts: earlyMonday.toISOString(), slug: 'monday-current-week', source_id: 'default', fact_count: 1 }),
+        ].join('\n') + '\n');
+
+        // Read with a 24h window relative to fakeNow.
+        const events = readRecentStubGuardEvents({ sinceMs: 24 * 60 * 60 * 1000, now: fakeNow });
+        const slugs = events.map(e => e.slug);
+
+        expect(slugs).toContain('sunday-late');
+        expect(slugs).toContain('monday-prev-week');
+        expect(slugs).toContain('monday-current-week');
+        expect(slugs).not.toContain('too-old');
+      });
+    } finally {
+      if (existsSync(tmpAuditDir)) rmSync(tmpAuditDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns events sorted oldest-first', async () => {
+    const tmpAuditDir = freshTmpDir();
+    try {
+      await withEnv({ GBRAIN_AUDIT_DIR: tmpAuditDir }, async () => {
+        const now = new Date('2026-05-13T12:00:00Z');
+        const filename = computeStubGuardAuditFilename(now);
+        const fullPath = join(tmpAuditDir, filename);
+
+        writeFileSync(fullPath, [
+          JSON.stringify({ ts: '2026-05-13T11:00:00Z', slug: 'second', source_id: 'default', fact_count: 1 }),
+          JSON.stringify({ ts: '2026-05-13T10:00:00Z', slug: 'first', source_id: 'default', fact_count: 1 }),
+          JSON.stringify({ ts: '2026-05-13T11:30:00Z', slug: 'third', source_id: 'default', fact_count: 1 }),
+        ].join('\n') + '\n');
+
+        const events = readRecentStubGuardEvents({ sinceMs: 24 * 60 * 60 * 1000, now });
+        expect(events.map(e => e.slug)).toEqual(['first', 'second', 'third']);
+      });
+    } finally {
+      if (existsSync(tmpAuditDir)) rmSync(tmpAuditDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns empty array when no files exist', async () => {
+    const tmpAuditDir = freshTmpDir();
+    try {
+      await withEnv({ GBRAIN_AUDIT_DIR: tmpAuditDir }, async () => {
+        const events = readRecentStubGuardEvents({ sinceMs: 24 * 60 * 60 * 1000 });
+        expect(events).toEqual([]);
+      });
+    } finally {
+      if (existsSync(tmpAuditDir)) rmSync(tmpAuditDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips malformed JSON lines without crashing', async () => {
+    const tmpAuditDir = freshTmpDir();
+    try {
+      await withEnv({ GBRAIN_AUDIT_DIR: tmpAuditDir }, async () => {
+        const now = new Date('2026-05-13T12:00:00Z');
+        const filename = computeStubGuardAuditFilename(now);
+        const fullPath = join(tmpAuditDir, filename);
+
+        writeFileSync(fullPath, [
+          JSON.stringify({ ts: '2026-05-13T11:00:00Z', slug: 'valid', source_id: 'default', fact_count: 1 }),
+          'this is not JSON',
+          '{"ts":"truncated',
+          '',
+        ].join('\n') + '\n');
+
+        const events = readRecentStubGuardEvents({ sinceMs: 24 * 60 * 60 * 1000, now });
+        expect(events.length).toBe(1);
+        expect(events[0].slug).toBe('valid');
+      });
+    } finally {
+      if (existsSync(tmpAuditDir)) rmSync(tmpAuditDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips rows missing required fields (ts, slug)', async () => {
+    const tmpAuditDir = freshTmpDir();
+    try {
+      await withEnv({ GBRAIN_AUDIT_DIR: tmpAuditDir }, async () => {
+        const now = new Date('2026-05-13T12:00:00Z');
+        const filename = computeStubGuardAuditFilename(now);
+        const fullPath = join(tmpAuditDir, filename);
+
+        writeFileSync(fullPath, [
+          JSON.stringify({ ts: '2026-05-13T11:00:00Z', source_id: 'default' }), // missing slug
+          JSON.stringify({ slug: 'no-ts', source_id: 'default', fact_count: 1 }), // missing ts
+          JSON.stringify({ ts: '2026-05-13T11:30:00Z', slug: 'valid', source_id: 'default', fact_count: 1 }),
+        ].join('\n') + '\n');
+
+        const events = readRecentStubGuardEvents({ sinceMs: 24 * 60 * 60 * 1000, now });
+        expect(events.length).toBe(1);
+        expect(events[0].slug).toBe('valid');
+      });
+    } finally {
+      if (existsSync(tmpAuditDir)) rmSync(tmpAuditDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Two-tier PR

### Tier 1: Code fix (~20 lines)

The supervisor health check counted ALL `worker_exited` events as crashes, including clean exits (code 0). A stable supervisor showed "62 crashes in 24h" when there were only 1-2 real errors.

**Fix:** Filter on `code !== 0`. Clean restarts shown separately for visibility.

**Before:**
```
[WARN] supervisor: Supervisor running but worker crashed 62x in last 24h.
```

**After:**
```
[OK] supervisor: running=true pid=578679 crashes=2 clean_restarts=60
```

Files: `src/commands/doctor.ts`, `src/commands/jobs.ts`

### Tier 2: Spec for Claude Code implementation

`docs/issues/doctor-auto-heal-and-scoring.md` — comprehensive issue doc with 7 improvements:

1. Frontmatter severity levels (6,900 cosmetic warnings drowning 280 real issues)
2. Temporal contradiction awareness (60% false positive reduction)
3. Multi-source drift baseline (acknowledge unfixable pre-v0.30.3 pages)
4. Image assets acknowledgment
5. Auto-heal mode (`doctor --auto-heal` via job queue)
6. Score delta tracking (history + trend)
7. Weighted scoring

Each improvement includes evidence, root cause, proposed fix, and test cases for red-test-first implementation.