### PR TITLE
fix(sync): correct git flag positioning and update last_sync_at on up_to_date

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -303,6 +303,23 @@ async function writeSyncAnchor(
 }
 
 /**
+ * Update sources.last_sync_at without touching last_commit. Called on the
+ * up_to_date path so the doctor sync_freshness check reflects "sync ran
+ * successfully and confirmed nothing to do" rather than warning about
+ * staleness whenever a quiet hour passes upstream.
+ *
+ * No-op for the legacy (sourceId === undefined) global-config code path —
+ * that branch has no per-source last_sync_at column.
+ */
+async function touchLastSyncAt(engine: BrainEngine, sourceId: string | undefined): Promise<void> {
+  if (!sourceId) return;
+  await engine.executeRaw(
+    `UPDATE sources SET last_sync_at = now() WHERE id = $1`,
+    [sourceId],
+  );
+}
+
+/**
  * v0.20.0 Cathedral II Layer 12 (SP-1 fix) — read/write the chunker version
  * last used to sync a given source. When it mismatches CURRENT_CHUNKER_VERSION,
  * `performSync` forces a full walk regardless of git HEAD equality. Without
@@ -520,6 +537,10 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       detachedWorkingTreeManifest.renamed.length > 0);
 
   if (lastCommit === headCommit && !versionMismatch && !versionNeverSet && !hasDetachedWorkingTreeChanges) {
+    // Touch sources.last_sync_at so doctor's sync_freshness check reflects
+    // "sync ran and confirmed nothing to do" instead of warning whenever a
+    // quiet hour passes upstream. last_commit unchanged.
+    await touchLastSyncAt(engine, opts.sourceId);
     return {
       status: 'up_to_date',
       fromCommit: lastCommit,

--- a/src/core/git-remote.ts
+++ b/src/core/git-remote.ts
@@ -20,16 +20,33 @@ import { join } from 'path';
 import { isInternalUrl } from './url-safety.ts';
 
 /**
- * SSRF-defensive flag set. Used by both cloneRepo and pullRepo.
+ * SSRF-defensive flags applied to every git invocation. Split into two
+ * groups because git is positional about flag placement:
+ *
+ *   GLOBAL  → before the subcommand: `git -c k=v <subcommand> ...`
+ *   PER_CMD → after the subcommand:  `git <subcommand> --flag ...`
+ *
+ * `--no-recurse-submodules` is a per-subcommand flag (clone, pull, fetch
+ * accept it; git rejects it as a global flag with `unknown option` exit
+ * 129). When this list was a single flat array placed before the
+ * subcommand, every pullRepo and cloneRepo invocation failed silently —
+ * the catch branches in the callers logged a warning and let the outer
+ * caller fall through, so the SSRF protection on the .gitmodules surface
+ * was never actually applied AND `gbrain sync` couldn't pull updates on
+ * any machine that already had a clone.
+ *
  * - http.followRedirects=false: closes DNS rebinding via redirect chains
  * - protocol.file.allow=never: no local-file URLs (defense in depth)
  * - protocol.ext.allow=never: no external helpers (`git-remote-foo`)
  * - --no-recurse-submodules: .gitmodules cannot become a second fetch surface
  */
-export const GIT_SSRF_FLAGS = [
+export const GIT_SSRF_GLOBAL_FLAGS = [
   '-c', 'http.followRedirects=false',
   '-c', 'protocol.file.allow=never',
   '-c', 'protocol.ext.allow=never',
+] as const;
+
+export const GIT_SSRF_PER_COMMAND_FLAGS = [
   '--no-recurse-submodules',
 ] as const;
 
@@ -153,7 +170,11 @@ export function cloneRepo(url: string, destDir: string, opts: CloneOpts = {}): v
     }
   }
 
-  const args: string[] = [...GIT_SSRF_FLAGS, 'clone'];
+  const args: string[] = [
+    ...GIT_SSRF_GLOBAL_FLAGS,
+    'clone',
+    ...GIT_SSRF_PER_COMMAND_FLAGS,
+  ];
   if (opts.depth !== 0) {
     args.push(`--depth=${opts.depth ?? 1}`);
   }
@@ -179,7 +200,12 @@ export function cloneRepo(url: string, destDir: string, opts: CloneOpts = {}): v
 
 /** Pull a repo with --ff-only and the same SSRF-defensive flags as cloneRepo. */
 export function pullRepo(repoPath: string, opts: { timeoutMs?: number } = {}): void {
-  const args: string[] = ['-C', repoPath, ...GIT_SSRF_FLAGS, 'pull', '--ff-only'];
+  const args: string[] = [
+    '-C', repoPath,
+    ...GIT_SSRF_GLOBAL_FLAGS,
+    'pull', '--ff-only',
+    ...GIT_SSRF_PER_COMMAND_FLAGS,
+  ];
   try {
     execFileSync('git', args, {
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/test/git-remote.test.ts
+++ b/test/git-remote.test.ts
@@ -1,9 +1,11 @@
 import { test, expect, describe, beforeAll, afterAll, beforeEach } from 'bun:test';
-import { mkdirSync, writeFileSync, rmSync, readFileSync, existsSync, chmodSync } from 'fs';
+import { mkdirSync, writeFileSync, rmSync, readFileSync, existsSync, chmodSync, mkdtempSync } from 'fs';
+import { execFileSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
-  GIT_SSRF_FLAGS,
+  GIT_SSRF_GLOBAL_FLAGS,
+  GIT_SSRF_PER_COMMAND_FLAGS,
   parseRemoteUrl,
   RemoteUrlError,
   cloneRepo,
@@ -75,19 +77,38 @@ beforeEach(() => {
 const fakePath = (): string => `${FAKE_GIT_DIR}:${process.env.PATH ?? ''}`;
 
 // ---------------------------------------------------------------------------
-// GIT_SSRF_FLAGS — pinned shape (snapshot test). If a future flag is added,
-// update the expected list here AND verify both cloneRepo + pullRepo pick it
-// up via the GIT_SSRF_FLAGS spread (the codex finding that motivated this).
+// GIT_SSRF_GLOBAL_FLAGS / GIT_SSRF_PER_COMMAND_FLAGS — pinned shape (snapshot
+// tests). The split is load-bearing: git is positional about flag placement.
+// `-c k=v` global options must precede the subcommand; per-subcommand flags
+// like `--no-recurse-submodules` must follow it. When this list was a single
+// flat array placed before the subcommand, every pullRepo + cloneRepo
+// invocation failed with `unknown option: --no-recurse-submodules` exit 129.
+// If you add a future flag, decide its group and verify both cloneRepo +
+// pullRepo pick it up via the right spread.
 // ---------------------------------------------------------------------------
 
-describe('GIT_SSRF_FLAGS', () => {
-  test('exact shape — codex SSRF lockdown', () => {
-    expect([...GIT_SSRF_FLAGS]).toEqual([
+describe('GIT_SSRF_*_FLAGS', () => {
+  test('GIT_SSRF_GLOBAL_FLAGS exact shape', () => {
+    expect([...GIT_SSRF_GLOBAL_FLAGS]).toEqual([
       '-c', 'http.followRedirects=false',
       '-c', 'protocol.file.allow=never',
       '-c', 'protocol.ext.allow=never',
+    ]);
+  });
+
+  test('GIT_SSRF_PER_COMMAND_FLAGS exact shape', () => {
+    expect([...GIT_SSRF_PER_COMMAND_FLAGS]).toEqual([
       '--no-recurse-submodules',
     ]);
+  });
+
+  test('regression: --no-recurse-submodules is per-subcommand, not global', () => {
+    // git rejects --no-recurse-submodules as a global flag with `unknown
+    // option` exit 129. If a contributor moves it back into GIT_SSRF_GLOBAL_FLAGS
+    // (where it lived through 2026-05), this assertion catches it before
+    // CI even runs the real-git regression below.
+    expect([...GIT_SSRF_GLOBAL_FLAGS]).not.toContain('--no-recurse-submodules');
+    expect([...GIT_SSRF_PER_COMMAND_FLAGS]).toContain('--no-recurse-submodules');
   });
 });
 
@@ -220,7 +241,7 @@ describe('parseRemoteUrl — CGNAT 100.64/10 (Tailscale)', () => {
 // ---------------------------------------------------------------------------
 
 describe('cloneRepo', () => {
-  test('happy path: invokes git with GIT_SSRF_FLAGS + --depth=1 + url + dest', async () => {
+  test('happy path: global SSRF flags before clone, per-cmd SSRF flags after', async () => {
     const dest = join(FAKE_GIT_DIR, 'clone-target');
     rmSync(dest, { recursive: true, force: true });
     await withEnv({ PATH: fakePath() }, async () => {
@@ -229,9 +250,21 @@ describe('cloneRepo', () => {
     const calls = readArgvLog();
     expect(calls.length).toBe(1);
     const argv = calls[0];
-    // Pin the SSRF flags before the 'clone' verb (codex Q2 invariant).
-    expect(argv.slice(0, GIT_SSRF_FLAGS.length)).toEqual([...GIT_SSRF_FLAGS]);
-    expect(argv).toContain('clone');
+
+    // Global -c flags lead.
+    expect(argv.slice(0, GIT_SSRF_GLOBAL_FLAGS.length)).toEqual([...GIT_SSRF_GLOBAL_FLAGS]);
+
+    // 'clone' verb sits between global flags and per-subcommand flags.
+    const cloneIdx = argv.indexOf('clone');
+    expect(cloneIdx).toBe(GIT_SSRF_GLOBAL_FLAGS.length);
+
+    // Per-subcommand SSRF flags (e.g. --no-recurse-submodules) must be AFTER
+    // the subcommand or git rejects them with `unknown option` exit 129.
+    for (const flag of GIT_SSRF_PER_COMMAND_FLAGS) {
+      const flagIdx = argv.indexOf(flag);
+      expect(flagIdx).toBeGreaterThan(cloneIdx);
+    }
+
     expect(argv).toContain('--depth=1');
     expect(argv).toContain('https://example.com/repo');
     expect(argv[argv.length - 1]).toBe(dest);
@@ -297,7 +330,7 @@ describe('cloneRepo', () => {
 // ---------------------------------------------------------------------------
 
 describe('pullRepo', () => {
-  test('happy path: invokes git -C path with GIT_SSRF_FLAGS + pull --ff-only', async () => {
+  test('happy path: -C path, global SSRF flags, then pull subcommand, then per-cmd SSRF flags', async () => {
     const repo = join(FAKE_GIT_DIR, 'pull-target');
     mkdirSync(repo, { recursive: true });
     await withEnv({ PATH: fakePath() }, async () => {
@@ -306,10 +339,62 @@ describe('pullRepo', () => {
     const argv = readArgvLog()[0];
     expect(argv[0]).toBe('-C');
     expect(argv[1]).toBe(repo);
-    expect(argv.slice(2, 2 + GIT_SSRF_FLAGS.length)).toEqual([...GIT_SSRF_FLAGS]);
-    expect(argv).toContain('pull');
+
+    // Global -c flags follow `-C path`.
+    expect(argv.slice(2, 2 + GIT_SSRF_GLOBAL_FLAGS.length)).toEqual([...GIT_SSRF_GLOBAL_FLAGS]);
+
+    // 'pull' subcommand is next.
+    const pullIdx = argv.indexOf('pull');
+    expect(pullIdx).toBe(2 + GIT_SSRF_GLOBAL_FLAGS.length);
+
+    // Per-subcommand flags AFTER 'pull' (positional requirement).
+    for (const flag of GIT_SSRF_PER_COMMAND_FLAGS) {
+      const flagIdx = argv.indexOf(flag);
+      expect(flagIdx).toBeGreaterThan(pullIdx);
+    }
+
     expect(argv).toContain('--ff-only');
     rmSync(repo, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // Real-git regression: the fake-git harness above accepts any argv shape, so
+  // it cannot detect the "unknown option" failure that real git produces when
+  // --no-recurse-submodules is positioned wrong. Run REAL git against a
+  // local-only fixture so this regression surfaces in CI exactly the way it
+  // would on a user's machine.
+  // -------------------------------------------------------------------------
+
+  test('regression: real git accepts the assembled argv (--no-recurse-submodules positioned correctly)', () => {
+    const fixture = mkdtempSync(join(tmpdir(), 'gbrain-pull-real-'));
+    try {
+      // Init a local-only repo with one commit. No remote configured, so
+      // pullRepo will fail — but the failure must NOT be `unknown option`,
+      // which is what git emits when --no-recurse-submodules is mis-placed.
+      execFileSync('git', ['init', '-q', '-b', 'master', fixture]);
+      execFileSync('git', ['-C', fixture, 'config', 'user.email', 'test@example.com']);
+      execFileSync('git', ['-C', fixture, 'config', 'user.name', 'Test']);
+      execFileSync('git', ['-C', fixture, 'config', 'commit.gpgsign', 'false']);
+      execFileSync('git', ['-C', fixture, 'commit', '-q', '--allow-empty', '-m', 'init']);
+
+      let caught: unknown;
+      try {
+        pullRepo(fixture);
+      } catch (e) {
+        caught = e;
+      }
+
+      // pullRepo MUST throw (no remote configured).
+      expect(caught).toBeInstanceOf(GitOperationError);
+      const msg = (caught as Error).message;
+      // The bug we are guarding against: `unknown option: --no-recurse-submodules`.
+      // Any message that includes that string means git rejected the flag set
+      // before doing anything, which is the exact regression that motivated
+      // the GIT_SSRF_GLOBAL_FLAGS / GIT_SSRF_PER_COMMAND_FLAGS split.
+      expect(msg).not.toMatch(/unknown option/i);
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
   });
 
   test('throws GitOperationError when git exits non-zero', async () => {

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -560,3 +560,101 @@ describe('git() helper invocation order (CJK wave v0.32.7)', () => {
     ]);
   });
 });
+
+// ────────────────────────────────────────────────────────────────
+// up_to_date freshness regression: when sync confirms there's nothing
+// new to import, sources.last_sync_at must still advance so doctor's
+// sync_freshness check reflects "sync ran, all clear" rather than
+// warning whenever a quiet hour passes upstream. Pre-fix, the
+// up_to_date early-return path skipped writing last_sync_at because
+// last_commit was unchanged, so freshness drifted indefinitely.
+// ────────────────────────────────────────────────────────────────
+
+describe('up_to_date path advances sources.last_sync_at', () => {
+  let engine: PGLiteEngine;
+  let repoPath: string;
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+  });
+
+  beforeEach(async () => {
+    await resetPgliteState(engine);
+    repoPath = mkdtempSync(join(tmpdir(), 'gbrain-sync-uptodate-'));
+    execSync('git init -q -b master', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git config user.email "test@test.com"', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git config user.name "Test"', { cwd: repoPath, stdio: 'pipe' });
+    execSync('git config commit.gpgsign false', { cwd: repoPath, stdio: 'pipe' });
+    mkdirSync(join(repoPath, 'people'), { recursive: true });
+    writeFileSync(join(repoPath, 'people/alice.md'), [
+      '---',
+      'type: person',
+      'title: Alice',
+      '---',
+      '',
+      'Alice.',
+    ].join('\n'));
+    execSync('git add -A && git commit -q -m "initial"', { cwd: repoPath, stdio: 'pipe' });
+  });
+
+  afterEach(() => {
+    if (repoPath) rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  test('up_to_date result also touches last_sync_at on the source row', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+
+    // Register a source pointed at our local fixture repo.
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path) VALUES ('test-src', 'Test', $1)`,
+      [repoPath],
+    );
+
+    // First sync — establishes last_commit anchor and writes last_sync_at.
+    const first = await performSync(engine, {
+      sourceId: 'test-src',
+      noPull: true,
+      noEmbed: true,
+    });
+    expect(['first_sync', 'synced']).toContain(first.status);
+
+    // Force last_sync_at well into the past so the touch is observable.
+    const oldTimestamp = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000); // 7 days ago
+    await engine.executeRaw(
+      `UPDATE sources SET last_sync_at = $1 WHERE id = $2`,
+      [oldTimestamp, 'test-src'],
+    );
+
+    // Sanity: confirm the staleness was actually written.
+    const beforeRows = await engine.executeRaw<{ last_sync_at: string }>(
+      `SELECT last_sync_at FROM sources WHERE id = $1`,
+      ['test-src'],
+    );
+    const beforeTs = new Date(beforeRows[0].last_sync_at).getTime();
+    expect(Date.now() - beforeTs).toBeGreaterThan(6 * 24 * 60 * 60 * 1000);
+
+    // Second sync — repo HEAD unchanged, so this lands on the up_to_date
+    // early return. Pre-fix, last_sync_at would stay 7 days stale.
+    const second = await performSync(engine, {
+      sourceId: 'test-src',
+      noPull: true,
+      noEmbed: true,
+    });
+    expect(second.status).toBe('up_to_date');
+
+    // The fix: last_sync_at must reflect the just-completed sync attempt,
+    // not the original 7-day-stale value.
+    const afterRows = await engine.executeRaw<{ last_sync_at: string }>(
+      `SELECT last_sync_at FROM sources WHERE id = $1`,
+      ['test-src'],
+    );
+    const afterTs = new Date(afterRows[0].last_sync_at).getTime();
+    expect(Date.now() - afterTs).toBeLessThan(60 * 1000); // within the last minute
+  });
+});


### PR DESCRIPTION
## Why

Two compounding bugs caused `gbrain doctor`'s `sync_freshness` check to warn indefinitely on healthy installs. Found while diagnosing an hourly orchestrator deployment that succeeded every run but stayed flagged 48-54h stale.

### Bug 1: `--no-recurse-submodules` positioned as a global flag

`src/core/git-remote.ts` assembled:

```
git -c k=v ... --no-recurse-submodules <subcommand> ...
```

git accepts `-c key=val` before the subcommand but rejects `--no-recurse-submodules` there:

```
$ git -c http.followRedirects=false --no-recurse-submodules pull --ff-only
unknown option: --no-recurse-submodules
exit 129
```

Every `cloneRepo` / `pullRepo` invocation failed silently — the catch branches in `src/commands/sync.ts:448-455` log a warning and let sync fall through to local-state-only import. So the SSRF protection on the `.gitmodules` surface was never actually applied **AND** `gbrain sync` cannot pull remote updates on any machine that already has a clone — only fresh `gbrain init` clones see remote content.

### Bug 2: `up_to_date` early return skipped `last_sync_at` update

`src/commands/sync.ts`'s `lastCommit === headCommit` short-circuit returned `{status: 'up_to_date'}` without updating any `sources` column. Correct for `last_commit` (nothing to advance), wrong for `last_sync_at` — doctor's `sync_freshness` check warns whenever a quiet hour passes upstream, even though sync ran successfully.

## What

### Bug 1 fix

Split `GIT_SSRF_FLAGS` into two positional groups:

```ts
export const GIT_SSRF_GLOBAL_FLAGS = [
  '-c', 'http.followRedirects=false',
  '-c', 'protocol.file.allow=never',
  '-c', 'protocol.ext.allow=never',
] as const;

export const GIT_SSRF_PER_COMMAND_FLAGS = [
  '--no-recurse-submodules',
] as const;
```

`cloneRepo` and `pullRepo` both updated to spread the global group before the subcommand and the per-command group after.

### Bug 2 fix

New private helper `touchLastSyncAt(engine, sourceId)` called on the up_to_date path. No-op for the legacy `sourceId === undefined` global-config code path (that branch has no per-source column).

## Regression tests

| File | Test | What it pins |
|---|---|---|
| `test/git-remote.test.ts` | `GIT_SSRF_*_FLAGS exact shape` × 2 + `regression: --no-recurse-submodules is per-subcommand` | Snapshot tests on the new split + an assertion that anyone who moves the flag back to the global group fails fast |
| `test/git-remote.test.ts` | Updated `cloneRepo` / `pullRepo` happy-path tests | Assert global flags before subcommand, per-cmd flags after |
| `test/git-remote.test.ts` | NEW: `pullRepo > regression: real git accepts the assembled argv` | Runs **actual** git (not the fake-git harness) against a local-only fixture. Fake-git accepts any argv so it couldn't have caught the original bug. This one would have |
| `test/sync.test.ts` | NEW: `up_to_date result also touches last_sync_at on the source row` | PGLite regression: registers a source, anchors last_commit, forces last_sync_at 7 days stale, re-runs sync, asserts result.status === 'up_to_date' AND last_sync_at landed within the last minute |

## Impact

| Surface | Before | After |
|---|---|---|
| `gbrain init` HTTPS remote | Fails — git rejects clone | Works |
| Steady-state `gbrain sync` against an existing local clone | Logs warning, falls through to local-only state. Silent staleness if other machine pushed | Real `git pull` runs, picks up upstream commits |
| SSRF lockdown on `.gitmodules` surface | Never applied (git rejected the flag before doing work) | Actually applied |
| `gbrain doctor sync_freshness` on hourly-cron deployments | Warns indefinitely after quiet hours | Reflects "sync ran and confirmed nothing to do" |

## Test plan

- [x] `bun run typecheck` clean
- [x] Local unit tests (Windows): 7 pre-existing fake-git PATH failures, **0 new failures from this change**, all new regression tests pass
- [ ] CI: Linux fake-git harness fully functional; expecting clean run

## Discovery context

Reported via the `donogeme/gbrain-orchestrator` deployment (hourly GH Actions cycle against three repos). Every run reported success but `sync_freshness` warned 48-54h. Workflow logs showed `[gbrain phase] sync.git_pull error 3ms (git pull failed in ...)` immediately followed by `Already up to date.` — the smoking gun was the `--no-recurse-submodules` rejection. Investigation traced both bugs.