### PR TITLE
fix(dream): audit backlinks without mutating pages

### DIFF
--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -503,27 +503,28 @@ async function runPhaseLint(brainDir: string, dryRun: boolean): Promise<PhaseRes
 
 async function runPhaseBacklinks(brainDir: string, dryRun: boolean): Promise<PhaseResult> {
   try {
-    // Library function path — the v0.15 backlinks.ts exports
-    // runBacklinksCore when --fix is requested.
+    // Maintenance cycles must not rewrite tracked brain pages with generated
+    // "Referenced in" timeline bullets. The graph extractor/auto-link path is
+    // the canonical link store during sync/dream/autopilot; the legacy
+    // filesystem fixer remains available explicitly via `gbrain check-backlinks
+    // fix` for users who truly want markdown backlinks materialized.
     const { runBacklinksCore } = await import('../commands/backlinks.ts');
     const result = await runBacklinksCore({
-      action: 'fix',
+      action: 'check',
       dir: brainDir,
       dryRun,
     });
     const gaps = result.gaps_found ?? 0;
     const added = result.fixed ?? 0;
-    const remaining = Math.max(0, gaps - added);
-    const status: PhaseStatus =
-      gaps === 0 || (!dryRun && remaining === 0) ? 'ok' : 'warn';
+    const status: PhaseStatus = 'ok';
     return {
       phase: 'backlinks',
       status,
       duration_ms: 0,
-      summary: dryRun
-        ? `${gaps} missing back-link(s) (dry-run)`
-        : `${added} back-link(s) added, ${remaining} remaining`,
-      details: { gaps, added, pages_affected: result.pages_affected, dryRun },
+      summary: gaps === 0
+        ? 'no missing back-links found'
+        : `${gaps} missing back-link(s) found (audit-only; run gbrain check-backlinks fix to materialize)`,
+      details: { gaps, added, pages_affected: result.pages_affected, dryRun, mode: 'audit-only' },
     };
   } catch (e) {
     return {

--- a/test/core/cycle.serial.test.ts
+++ b/test/core/cycle.serial.test.ts
@@ -166,10 +166,16 @@ describe('runCycle — dryRun propagates to every phase', () => {
     expect(embedCalls.at(-1)?.dryRun).toBe(true);
   });
 
-  test('dryRun:false writes in every phase', async () => {
+  test('dryRun:false does not let maintenance append generated backlinks to tracked pages', async () => {
     await runCycle(sharedEngine,{ brainDir: '/tmp/brain', dryRun: false });
 
     expect(lintCalls.at(-1)?.dryRun).toBe(false);
+    // Maintenance should audit backlink gaps but not run the legacy fixer that
+    // appends "Referenced in" timeline entries into entity pages. The graph
+    // extractor/auto-link path is the canonical link store; filesystem backlink
+    // fixes are still available through `gbrain check-backlinks fix` when a
+    // human explicitly asks for them.
+    expect(backlinksCalls.at(-1)?.action).toBe('check');
     expect(backlinksCalls.at(-1)?.dryRun).toBe(false);
     expect(syncCalls.at(-1)?.dryRun).toBe(false);
     expect(embedCalls.at(-1)?.dryRun).toBe(false);


### PR DESCRIPTION
## Summary
- Change dream/autopilot backlink phase from legacy filesystem fix mode to audit-only check mode
- Keep explicit markdown backlink materialization available via `gbrain check-backlinks fix`
- Add regression coverage so maintenance does not append generated "Referenced in" timeline entries to tracked pages

## Test Plan
- `bun test test/core/cycle.serial.test.ts --timeout 60000`
- `bun test test/e2e/dream-cycle-phase-order-pglite.test.ts --timeout 60000`
- `bun run build`
- Local verification: `bun run src/cli.ts dream --phase backlinks --dir /Users/stas/Dropbox/gbrain --json` left the gbrain markdown repo at dirty_before=0 dirty_after=0