### PR TITLE
fix: add items to extract_facts array schema

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2573,7 +2573,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },

--- a/test/e2e/mcp.test.ts
+++ b/test/e2e/mcp.test.ts
@@ -44,6 +44,11 @@ describe('E2E: MCP Tool Generation', () => {
       expect(tool.inputSchema.type).toBe('object');
       expect(typeof tool.inputSchema.properties).toBe('object');
       expect(Array.isArray(tool.inputSchema.required)).toBe(true);
+      for (const prop of Object.values(tool.inputSchema.properties) as Array<Record<string, unknown>>) {
+        if (prop.type === 'array') {
+          expect(prop.items).toBeTruthy();
+        }
+      }
     }
 
     // Verify specific tools exist


### PR DESCRIPTION
## Problem

`extract_facts` exported an MCP array parameter without an `items` schema:

```ts
entity_hints: { type: "array", description: "Existing canonical entity slugs..." }
```

That shape is tolerated by some clients, but stricter OpenAI Codex tool validation rejects it as an invalid function schema:

```
Invalid schema for function "mcp_gbrain_extract_facts": array schema missing items
```

In practice this caused a Hermes Kanban worker on the primary Codex path to fail its first model call and fall back to a secondary model.

## Reproduction

1. Start GBrain as an MCP server with the pre-fix schema.
2. Expose its tools to a strict OpenAI-compatible tool consumer.
3. Inspect the generated tool definition for `extract_facts.entity_hints` or run a worker that loads the toolset.

Observed invalid emitted schema:

```json
{
  "type": "array",
  "description": "Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug."
}
```

Expected shape:

```json
{
  "type": "array",
  "items": { "type": "string" },
  "description": "Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug."
}
```

## Fix

- add `items: { type: "string" }` to `extract_facts.entity_hints` in `src/core/operations.ts`
- add a regression assertion in `test/e2e/mcp.test.ts` so every exported MCP array property must include `items`

No runtime behavior change for valid callers beyond making the MCP tool schema compliant for strict clients.

## Test Plan

- [x] `bun test ./test/e2e/mcp.test.ts`
- [x] `bun run verify`
- [x] post-fix generated MCP tool defs inspected locally: zero exported array properties missing `items`
- [x] post-fix Hermes Kanban worker smoke test completed without the prior Codex schema error