### PR TITLE
Fix upgrade fails to find package.json 

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -37,15 +37,33 @@ export async function runUpgrade(args: string[]) {
       break;
     }
 
-    case 'bun':
+    case 'bun': {
+      // Find the install root (`~/.bun/install/global/` for bun globals)
+      // and run `bun update gbrain` from there. Without setting cwd, the
+      // command inherits the user's shell cwd — typically `~` — which has
+      // no package.json, so bun no-ops with "No package.json, so nothing
+      // to update" and the user gets a misleading "Upgrade failed" line.
+      const installRoot = detectBunGlobalInstallRoot();
       console.log('Upgrading via bun...');
       try {
-        execSync('bun update gbrain', { stdio: 'inherit', timeout: 120_000 });
+        execFileSync('bun', ['update', 'gbrain'], {
+          stdio: 'inherit',
+          timeout: 120_000,
+          cwd: installRoot ?? undefined,
+        });
         upgraded = true;
       } catch {
-        console.error('Upgrade failed. Try running manually: bun update gbrain');
+        if (installRoot) {
+          console.error('Upgrade failed. Try running manually:');
+          console.error(`  cd ${installRoot} && bun update gbrain`);
+        } else {
+          console.error('Upgrade failed and the bun global install root could not be located.');
+          console.error('Try running manually from your bun global install directory:');
+          console.error('  cd $(dirname $(dirname $(realpath $(which gbrain)))) && bun update gbrain');
+        }
       }
       break;
+    }
 
     case 'binary':
       console.log('Binary self-update not yet implemented.');
@@ -429,6 +447,51 @@ function detectBunLink(): { repoRoot: string } | null {
           }
         } catch { /* unreadable config — not our case */ }
         return null;
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Locate the bun global-install root that owns this gbrain binary.
+ *
+ * `bun install -g github:garrytan/gbrain` produces:
+ *
+ *   ~/.bun/install/global/                  ← INSTALL ROOT
+ *   ├── package.json                        (lists gbrain as a dep)
+ *   ├── bun.lock
+ *   └── node_modules/
+ *       └── gbrain/                         (the package itself)
+ *           └── src/cli.ts                  ← symlinked from ~/.bun/bin/gbrain
+ *
+ * `bun update gbrain` MUST be run from the install root, otherwise bun
+ * looks for a package.json in the inherited cwd (typically the user's
+ * shell home), finds none, and silently no-ops with:
+ *
+ *   No package.json, so nothing to update
+ *
+ * We walk up from `realpath(argv1)` and return the first ancestor that
+ * has BOTH `package.json` AND a `node_modules/` subdir — the package.json
+ * inside `node_modules/gbrain/` is rejected by the second predicate.
+ *
+ * Exported for test use. Returns null when the walk doesn't find a
+ * matching directory within 8 levels; the caller falls back to a
+ * paste-ready manual recovery hint.
+ */
+export function detectBunGlobalInstallRoot(): string | null {
+  try {
+    const argv1 = process.argv[1];
+    if (!argv1) return null;
+    let dir = dirname(realpathSync(argv1));
+    for (let i = 0; i < 8; i++) {
+      if (existsSync(join(dir, 'package.json')) && existsSync(join(dir, 'node_modules'))) {
+        return dir;
       }
       const parent = dirname(dir);
       if (parent === dir) break;

--- a/test/upgrade-bun-cwd.serial.test.ts
+++ b/test/upgrade-bun-cwd.serial.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, symlinkSync, rmSync, realpathSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { detectBunGlobalInstallRoot } from '../src/commands/upgrade.ts';
+
+/**
+ * detectBunGlobalInstallRoot is the cwd source for `bun update gbrain`.
+ *
+ * Pre-fix, the upgrade command spawned `bun update gbrain` with the
+ * inherited cwd (typically `~`), which has no package.json — so bun
+ * silently no-ops with "No package.json, so nothing to update" and the
+ * upgrade was reported as failed against a perfectly working install.
+ *
+ * The fixtures below stand up a faithful replica of bun's global install
+ * layout in a tmpdir and assert that the detector reaches the right
+ * level (the dir with both package.json AND node_modules).
+ */
+describe('detectBunGlobalInstallRoot', () => {
+  let workDir: string;
+  let origArgv1: string | undefined;
+
+  beforeEach(() => {
+    // realpathSync resolves macOS's /tmp → /private/tmp symlink, matching
+    // what the detector sees after its own realpathSync call.
+    const rawDir = join(tmpdir(), `gbrain-upgrade-cwd-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(rawDir, { recursive: true });
+    workDir = realpathSync(rawDir);
+    origArgv1 = process.argv[1];
+  });
+
+  afterEach(() => {
+    if (origArgv1 !== undefined) process.argv[1] = origArgv1;
+    else delete (process.argv as unknown as { [k: number]: unknown })[1];
+    try { rmSync(workDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  test('walks up to the install root when argv[1] points inside node_modules/gbrain', () => {
+    // Mirror `bun install -g`:
+    //   <root>/package.json   (lists gbrain as a dep)
+    //   <root>/node_modules/
+    //   <root>/node_modules/gbrain/package.json   (gbrain's own)
+    //   <root>/node_modules/gbrain/src/cli.ts
+    const root = join(workDir, 'install-root');
+    const pkgDir = join(root, 'node_modules', 'gbrain');
+    const srcDir = join(pkgDir, 'src');
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      dependencies: { gbrain: 'github:garrytan/gbrain' },
+    }));
+    writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: 'gbrain' }));
+    const cliPath = join(srcDir, 'cli.ts');
+    writeFileSync(cliPath, '#!/usr/bin/env bun\n');
+
+    process.argv[1] = cliPath;
+    expect(detectBunGlobalInstallRoot()).toBe(root);
+  });
+
+  test('returns null when argv[1] is missing', () => {
+    delete (process.argv as unknown as { [k: number]: unknown })[1];
+    expect(detectBunGlobalInstallRoot()).toBeNull();
+  });
+
+  test('returns null when no ancestor has both package.json AND node_modules', () => {
+    // Plain script in a directory tree with no install-root signal.
+    const lone = join(workDir, 'lonely', 'sub');
+    mkdirSync(lone, { recursive: true });
+    const cliPath = join(lone, 'cli.ts');
+    writeFileSync(cliPath, '#!/usr/bin/env bun\n');
+    process.argv[1] = cliPath;
+    expect(detectBunGlobalInstallRoot()).toBeNull();
+  });
+
+  test('does NOT return the gbrain package dir (package.json without node_modules sibling)', () => {
+    // If we naively stopped at the FIRST package.json walking up, we'd
+    // land on node_modules/gbrain/package.json — the wrong dir, since
+    // running `bun update gbrain` there still has no notion of the user's
+    // top-level dep manifest. This test pins the second predicate.
+    const root = join(workDir, 'install-root');
+    const pkgDir = join(root, 'node_modules', 'gbrain');
+    const srcDir = join(pkgDir, 'src');
+    mkdirSync(srcDir, { recursive: true });
+    // Owner package.json exists, but no node_modules sibling — so
+    // detector must keep walking. We simulate that by deleting the
+    // node_modules dir (it would normally hold gbrain itself, but for
+    // this test we want to force the package.json-only fail path).
+    writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: 'gbrain' }));
+    writeFileSync(join(srcDir, 'cli.ts'), '#!/usr/bin/env bun\n');
+    process.argv[1] = join(srcDir, 'cli.ts');
+    // Note: no <root>/package.json AND no <root>/node_modules-as-sibling,
+    // so the walk should return null instead of falsely landing inside
+    // node_modules/gbrain.
+    expect(detectBunGlobalInstallRoot()).toBeNull();
+  });
+
+  test('resolves through symlinked argv[1] (mirrors ~/.bun/bin/gbrain → install/global/node_modules/gbrain/src/cli.ts)', () => {
+    const root = join(workDir, 'install-root');
+    const pkgDir = join(root, 'node_modules', 'gbrain');
+    const srcDir = join(pkgDir, 'src');
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(join(root, 'package.json'), JSON.stringify({
+      dependencies: { gbrain: 'github:garrytan/gbrain' },
+    }));
+    writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: 'gbrain' }));
+    const realCli = join(srcDir, 'cli.ts');
+    writeFileSync(realCli, '#!/usr/bin/env bun\n');
+
+    const binDir = join(workDir, 'bin');
+    mkdirSync(binDir, { recursive: true });
+    const link = join(binDir, 'gbrain');
+    symlinkSync(realCli, link);
+
+    process.argv[1] = link;
+    // realpathSync inside the detector should resolve through the symlink
+    // back to the real cli.ts under the install root.
+    expect(detectBunGlobalInstallRoot()).toBe(root);
+  });
+});


### PR DESCRIPTION
## Fixes Issue 1029

  - Added detectBunGlobalInstallRoot() helper that walks up from realpath(process.argv[1]) and returns the first ancestor with both package.json AND a node_modules/ subdir.
  - case 'bun': now calls it and passes the result as cwd to execFileSync('bun', ['update', 'gbrain'], ...).
  - Switched from execSync to execFileSync (no shell needed, tighter surface).
  - When detection fails, prints a paste-ready manual recovery line instead of the misleading "Upgrade failed" message.

Test (test/upgrade-bun-cwd.serial.test.ts, 5 cases): walks up correctly inside a faithful ~/.bun/install/global/ replica; returns null on missing
  argv[1]; returns null on no install-root signal; rejects node_modules/gbrain/package.json as a false positive (the "first package.json wins" trap);
  resolves through the symlinked-bin shape (~/.bun/bin/gbrain → real cli.ts). Marked .serial.test.ts because it mutates process.argv[1], which is
  process-global. macOS /tmp → /private/tmp symlink handled by realpath'ing the workDir in beforeEach.


Fixes [#1029](https://github.com/garrytan/gbrain/issues/1029)