### PR TITLE
fix(recipes): add max_batch_tokens to google embedding recipe

### DIFF
--- a/src/core/ai/recipes/google.ts
+++ b/src/core/ai/recipes/google.ts
@@ -16,6 +16,12 @@ export const google: Recipe = {
       dims_options: [768, 1536, 3072],
       cost_per_1m_tokens_usd: 0.15,
       price_last_verified: '2026-04-20',
+      // Google publishes an 8K token per-input limit for Gemini embeddings;
+      // keep batch pre-splitting conservative so recursive retry is a backup,
+      // not the primary protection.
+      max_batch_tokens: 8_000,
+      chars_per_token: 4,
+      safety_factor: 0.8,
     },
     expansion: {
       models: ['gemini-2.0-flash', 'gemini-2.0-flash-lite'],


### PR DESCRIPTION
The Gemini embedding API enforces an 8K-token per-input limit. Without `max_batch_tokens` declared on the recipe, the gateway can only fall back to recursive halving when a batch is too big. That works, but every large import pays a wasted round-trip + rate-limit pressure before the split fires.

Adding `max_batch_tokens: 8000` + `chars_per_token: 4` + `safety_factor: 0.8` pre-splits at a 25.6K-character budget (8000 x 0.8 / 4) so the gateway ships correctly-sized batches in the first place. Same fields are already declared for Voyage (with `chars_per_token=1`, `safety_factor=0.5` because Voyage handles dense payloads differently) in `src/core/ai/recipes/voyage.ts`.

Also silences the once-per-process stderr warn fired by `configureGateway()` when a recipe declares an embedding touchpoint without `max_batch_tokens`:

> [ai.gateway] recipe "google" declares an embedding touchpoint without max_batch_tokens; recursion is the only safety net for batch caps.

Litellm-proxy and ollama recipes already declare `no_batch_cap: true` (opt-out for cases where the backend cap is unknowable); google has a known cap and should declare it.

### Verification
- `gbrain --version` works post-patch
- Warning no longer fires on `gbrain sources list` (or any other CLI invocation)
- Single-file diff, 6 insertions