### PR TITLE
fix(orphans): exclude soft-deleted pages and inbound links from soft-deleted sources (closes #1021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ ZeroEntropy ships two specialized small models that target the two weakest retri
 - New tests: `test/ai/zeroentropy-recipe.test.ts`, `test/ai/dims-zeroentropy.test.ts`, `test/search/rerank.test.ts`, `test/rerank-audit.test.ts` — 42 cases pinning recipe shape, dim allowlist, 4th-arg inputType plumbing, reranker fail-open across every error class, null-vs-undefined topNOut semantics, and the no-success-logging contract.
 - The plan that drove this release went through two Codex rounds (47 source-grounded findings across consult + adversarial challenge) before any code was written. Every must-fix landed; nine deferred bugs (the cache-wrapper double-embed, MiniMax embo-01 asymmetry, openai-compat allowlist gap, cache-hit limit/budget divergence) are documented in the plan file at `~/.claude/plans/system-instruction-you-are-working-linked-moonbeam.md`.
 
+### Fixed
+
+- `gbrain orphans` no longer counts pages you've soft-deleted, and inbound links from soft-deleted pages no longer hide downstream pages that are now effectively orphaned.
+
 ## To take advantage of v0.35.0.0
 
 `gbrain upgrade` does NOT auto-switch your embedding or reranker model. ZeroEntropy is opt-in; you choose when to flip. To try it:

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1882,9 +1882,14 @@ export class PGLiteEngine implements BrainEngine {
          COALESCE(p.title, p.slug) AS title,
          p.frontmatter->>'domain' AS domain
        FROM pages p
-       WHERE NOT EXISTS (
-         SELECT 1 FROM links l WHERE l.to_page_id = p.id
-       )
+       WHERE p.deleted_at IS NULL
+         AND NOT EXISTS (
+           SELECT 1
+             FROM links l
+             JOIN pages from_p ON from_p.id = l.from_page_id
+            WHERE l.to_page_id = p.id
+              AND from_p.deleted_at IS NULL
+         )
        ORDER BY p.slug`
     );
     return rows as Array<{ slug: string; title: string; domain: string | null }>;
@@ -3162,7 +3167,14 @@ export class PGLiteEngine implements BrainEngine {
         -- Bug 11 — orphan = islanded (no inbound AND no outbound).
         -- See BrainHealth.orphan_pages docstring; docs updated to match this.
         (SELECT count(*) FROM pages p
-         WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
+         WHERE p.deleted_at IS NULL
+           AND NOT EXISTS (
+             SELECT 1
+               FROM links l
+               JOIN pages from_p ON from_p.id = l.from_page_id
+              WHERE l.to_page_id = p.id
+                AND from_p.deleted_at IS NULL
+           )
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
         ) as orphan_pages,
         (SELECT count(*) FROM links l

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1902,9 +1902,14 @@ export class PostgresEngine implements BrainEngine {
         COALESCE(p.title, p.slug) AS title,
         p.frontmatter->>'domain' AS domain
       FROM pages p
-      WHERE NOT EXISTS (
-        SELECT 1 FROM links l WHERE l.to_page_id = p.id
-      )
+      WHERE p.deleted_at IS NULL
+        AND NOT EXISTS (
+          SELECT 1
+            FROM links l
+            JOIN pages from_p ON from_p.id = l.from_page_id
+           WHERE l.to_page_id = p.id
+             AND from_p.deleted_at IS NULL
+        )
       ORDER BY p.slug
     `;
     return rows as unknown as Array<{ slug: string; title: string; domain: string | null }>;
@@ -3175,7 +3180,14 @@ export class PostgresEngine implements BrainEngine {
          WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
         ) as stale_pages,
         (SELECT count(*) FROM pages p
-         WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
+         WHERE p.deleted_at IS NULL
+           AND NOT EXISTS (
+             SELECT 1
+               FROM links l
+               JOIN pages from_p ON from_p.id = l.from_page_id
+              WHERE l.to_page_id = p.id
+                AND from_p.deleted_at IS NULL
+           )
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
         ) as orphan_pages,
         (SELECT count(*) FROM links l

--- a/test/orphans.test.ts
+++ b/test/orphans.test.ts
@@ -283,6 +283,73 @@ describe('findOrphans (engine-injected)', () => {
     expect(slugs).toContain('topic/standalone');
   });
 
+  test('excludes soft-deleted pages from orphan scan and totals', async () => {
+    await engine.putPage('topic/deleted-orphan', {
+      type: 'concept',
+      title: 'Deleted Orphan',
+      compiled_truth: 'no inbound links',
+      timeline: '',
+    });
+    await engine.putPage('topic/live-orphan', {
+      type: 'concept',
+      title: 'Live Orphan',
+      compiled_truth: 'no inbound links',
+      timeline: '',
+    });
+    await engine.softDeletePage('topic/deleted-orphan');
+
+    const result = await findOrphans(engine);
+    const slugs = result.orphans.map(o => o.slug).sort();
+
+    expect(slugs).toEqual(['topic/live-orphan']);
+    expect(result.total_orphans).toBe(1);
+    expect(result.total_pages).toBe(1);
+  });
+
+  test('ignores inbound links from soft-deleted source pages', async () => {
+    await engine.putPage('topic/source', {
+      type: 'concept',
+      title: 'Source',
+      compiled_truth: 'links to target',
+      timeline: '',
+    });
+    await engine.putPage('topic/target', {
+      type: 'concept',
+      title: 'Target',
+      compiled_truth: 'target page',
+      timeline: '',
+    });
+    await engine.addLink('topic/source', 'topic/target', 'mentions', 'references', 'markdown');
+
+    expect((await findOrphans(engine)).orphans.map(o => o.slug).sort()).toEqual(['topic/source']);
+
+    await engine.softDeletePage('topic/source');
+
+    expect((await findOrphans(engine)).orphans.map(o => o.slug).sort()).toEqual(['topic/target']);
+  });
+
+  test('health orphan_pages ignores soft-deleted pages and their outbound links', async () => {
+    await engine.putPage('topic/deleted-source', {
+      type: 'concept',
+      title: 'Deleted Source',
+      compiled_truth: 'links to target',
+      timeline: '',
+    });
+    await engine.putPage('topic/target', {
+      type: 'concept',
+      title: 'Target',
+      compiled_truth: 'target page',
+      timeline: '',
+    });
+    await engine.addLink('topic/deleted-source', 'topic/target', 'mentions', 'references', 'markdown');
+
+    expect((await engine.getHealth()).orphan_pages).toBe(0);
+
+    await engine.softDeletePage('topic/deleted-source');
+
+    expect((await engine.getHealth()).orphan_pages).toBe(1);
+  });
+
   test('zero pages: empty result (no crash on empty brain)', async () => {
     const result = await findOrphans(engine);
     expect(result.orphans).toEqual([]);


### PR DESCRIPTION
## Summary

`gbrain orphans` no longer counts soft-deleted pages, and inbound links from soft-deleted source pages no longer hide downstream pages that have become effectively orphaned. Both engines move together; same fix lands in the `orphan_pages` stats subquery.

## Why this matters

> `gbrain orphans` counts soft-deleted pages in its orphan scan. When you soft-delete a page with `gbrain delete <slug>`, the row remains in the `pages` table (recoverable for 72h), and the orphan query does not filter out soft-deleted rows.

That's @Simona-digital-ops in [#1021](https://github.com/garrytan/gbrain/issues/1021). The reporter pinpointed the SQL and named the missing filter; this PR adds it.

The pages.deleted_at column was introduced in v0.26.5 with `softDeletePage` semantics. CLAUDE.md notes `buildVisibilityClause` in `src/core/search/sql-ranking.ts` is the canonical "hide soft-deleted" pattern that `searchKeyword` / `searchKeywordChunks` / `searchVector` consume. The orphan query and the orphan_pages stats subquery predate soft-delete and were never updated. Result: every `gbrain delete <slug>` increments the orphan count instead of decrementing it, and soft-deleting any linking page silently orphans its downstream neighbors.

## Changes

- `src/core/postgres-engine.ts` and `src/core/pglite-engine.ts` `findOrphanPages` add `WHERE p.deleted_at IS NULL` plus a `JOIN pages from_p ON from_p.id = l.from_page_id WHERE from_p.deleted_at IS NULL` on the inbound-link subquery. The cascade fix is the second half: a target's "inbound link" from a deleted source page is no longer a real link from the rest of the system's perspective.
- The `orphan_pages` count in the stats query (`postgres-engine.ts:3175+`, `pglite-engine.ts:3162+`) gets the same two filters so health-dashboard numbers match what `gbrain orphans` reports.

## Testing

`bun test test/orphans.test.ts`: 38 pass / 0 fail. Two new cases cover (a) soft-deleted pages don't count as orphans and (b) targets linked only from a soft-deleted source DO show up as orphans (the cascade case the reporter named).

Both engines covered. Cross-engine parity gate stays clean.

Fixes #1021.

AI was used for assistance.
