### PR TITLE
fix(mcp): add items clause to extract_facts.entity_hints schema

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2696,7 +2696,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },

--- a/test/mcp-tool-defs.test.ts
+++ b/test/mcp-tool-defs.test.ts
@@ -64,4 +64,20 @@ describe('buildToolDefs', () => {
       expect(Array.isArray(def.inputSchema.required)).toBe(true);
     }
   });
+
+  test('every array property has an items clause (strict JSON Schema)', () => {
+    // OpenAI's tool API and other strict JSON Schema validators reject an
+    // "array" property that lacks "items". An offender causes the entire
+    // toolset to fail upload with HTTP 400 before any tool is invoked.
+    const violations: string[] = [];
+    for (const def of buildToolDefs(operations)) {
+      for (const [propName, propSchema] of Object.entries(def.inputSchema.properties)) {
+        const s = propSchema as { type?: unknown; items?: unknown };
+        if (s && typeof s === 'object' && s.type === 'array' && !s.items) {
+          violations.push(`${def.name}.${propName}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
 });


### PR DESCRIPTION
Fixes #1042

## Summary

`extract_facts.entity_hints` declares `{ type: 'array' }` with no `items`
clause. OpenAI's tool API and other strict JSON Schema validators reject the
toolset upload with HTTP 400, taking every gbrain tool offline on those
providers.

This adds `items: { type: 'string' }` to match:

- the runtime handler at line 2733 which already casts to `string[]`
- the existing `pages_updated` precedent at line 1888

## Test

A property test in `test/mcp-tool-defs.test.ts` walks every
`buildToolDefs(operations)` entry and asserts that any `array` property has an
`items` clause:

```ts
test('every array property has an items clause (strict JSON Schema)', () => {
  const violations: string[] = [];
  for (const def of buildToolDefs(operations)) {
    for (const [propName, propSchema] of Object.entries(def.inputSchema.properties)) {
      const s = propSchema as { type?: unknown; items?: unknown };
      if (s && typeof s === 'object' && s.type === 'array' && !s.items) {
        violations.push(`${def.name}.${propName}`);
      }
    }
  }
  expect(violations).toEqual([]);
});
```

Verified manually: revert the schema fix, the test fails with
`["extract_facts.entity_hints"]`; re-apply and it passes. With the fix applied
the suite is green (`bun test test/mcp-tool-defs.test.ts`: 6 pass / 0 fail
across all 63 operations). `bun run typecheck` and
`scripts/check-test-isolation.sh` both pass.

## Blast radius

Pre-fix the param was already a `string[]` at the runtime layer; the schema was
just under-specified. Lenient providers accepted it, strict providers rejected
the whole toolset. The fix tightens the schema to match the runtime cast — no
behavior change for accepting clients, fixes HTTP 400 for strict clients.

No new dependencies. No changes outside the schema line and the test.

## Alternatives considered

- A more specific schema (slug pattern, length cap) — opted to mirror
  `pages_updated` for consistency; tightening can land separately.
- A single-case assertion just for `extract_facts.entity_hints` — opted for the
  property test instead so future array params can't regress the same way
  silently.
