### PR TITLE
fix(bootstrap): cover files + oauth_clients forward-refs (closes #974, #1018)

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -227,13 +227,13 @@ export async function doctorReportRemote(engine: BrainEngine): Promise<DoctorRep
       checks.push({
         name: 'schema_version',
         status: 'fail',
-        message: `No schema version recorded. Migrations never ran. Run \`gbrain apply-migrations --yes\` on the host.`,
+        message: `No schema version recorded. Migrations never ran. Run \`gbrain init --migrate-only\` then \`gbrain apply-migrations --yes\` on the host.`,
       });
     } else {
       checks.push({
         name: 'schema_version',
         status: 'warn',
-        message: `Version ${version}, latest is ${LATEST_VERSION}. Run \`gbrain apply-migrations --yes\` on the host.`,
+        message: `Version ${version}, latest is ${LATEST_VERSION}. Run \`gbrain init --migrate-only\` then \`gbrain apply-migrations --yes\` on the host.`,
       });
     }
   } catch {

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -288,7 +288,19 @@ export class PGLiteEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.tables
                 WHERE table_schema='public' AND table_name='ingest_log') AS ingest_log_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema='public' AND table_name='ingest_log' AND column_name='source_id') AS ingest_log_source_id_exists
+                WHERE table_schema='public' AND table_name='ingest_log' AND column_name='source_id') AS ingest_log_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema='public' AND table_name='files') AS files_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='files' AND column_name='source_id') AS files_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='files' AND column_name='page_id') AS files_page_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema='public' AND table_name='oauth_clients') AS oauth_clients_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='oauth_clients' AND column_name='source_id') AS oauth_clients_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='oauth_clients' AND column_name='federated_read') AS oauth_clients_federated_read_exists
     `);
     const probe = rows[0] as {
       pages_exists: boolean;
@@ -309,6 +321,12 @@ export class PGLiteEngine implements BrainEngine {
       subagent_provider_id_exists: boolean;
       ingest_log_exists: boolean;
       ingest_log_source_id_exists: boolean;
+      files_exists: boolean;
+      files_source_id_exists: boolean;
+      files_page_id_exists: boolean;
+      oauth_clients_exists: boolean;
+      oauth_clients_source_id_exists: boolean;
+      oauth_clients_federated_read_exists: boolean;
     };
 
     const needsPagesBootstrap = probe.pages_exists && !probe.source_id_exists;
@@ -332,12 +350,28 @@ export class PGLiteEngine implements BrainEngine {
     // references source_id. Old brains have ingest_log without source_id;
     // bootstrap adds the column before SCHEMA_SQL replay creates the index.
     const needsIngestLogSourceId = probe.ingest_log_exists && !probe.ingest_log_source_id_exists;
+    // v0.18.0 Step 7: files gained source_id + page_id. PGLITE_SCHEMA_SQL
+    // declares idx_files_page_id and idx_files_source_id (mirrors
+    // src/schema.sql:498-499) without IF guard on columns; pre-v0.18.0
+    // brains wedge with `column "page_id" does not exist`. Closes #974
+    // and the column half of #820.
+    const needsFilesBootstrap = probe.files_exists
+      && (!probe.files_source_id_exists || !probe.files_page_id_exists);
+    // v0.34.1 (v60 + v61): oauth_clients gained source_id + federated_read.
+    // PGLITE_SCHEMA_SQL declares idx_oauth_clients_source_id +
+    // idx_oauth_clients_federated_read (mirrors src/schema.sql:434-437).
+    // Pre-v60 brains with the oauth_clients table wedge on SCHEMA_SQL
+    // replay. Closes #1018.
+    const needsOauthClientsBootstrap = probe.oauth_clients_exists
+      && (!probe.oauth_clients_source_id_exists || !probe.oauth_clients_federated_read_exists);
 
     // Fresh installs (no tables yet) and modern brains both no-op.
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
         && !needsPagesDeletedAt && !needsChunksEmbeddingImage
         && !needsMcpLogBootstrap && !needsSubagentProviderId
-        && !needsPagesRecency && !needsIngestLogSourceId) return;
+        && !needsPagesRecency && !needsIngestLogSourceId
+        && !needsFilesBootstrap
+        && !needsOauthClientsBootstrap) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
 
@@ -463,6 +497,48 @@ export class PGLiteEngine implements BrainEngine {
       // DEFAULT 'default' so the index can build cleanly.
       await this.db.exec(`
         ALTER TABLE ingest_log ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT 'default';
+      `);
+    }
+
+    if (needsFilesBootstrap) {
+      // v0.18.0 Step 7: files gained source_id + page_id. PGLITE_SCHEMA_SQL
+      // declares CREATE INDEX idx_files_page_id and idx_files_source_id
+      // (mirrors src/schema.sql:498-499) without IF guard on the column,
+      // so any pre-v0.18.0 brain wedges with `column "page_id" does not
+      // exist` before runMigrations gets a chance to add them. Closes #974
+      // and the column half of #820. NOT NULL DEFAULT 'default' on
+      // source_id mirrors schema.sql:480-481; page_id stays nullable per
+      // ON DELETE SET NULL semantics. Ordering: this block runs AFTER
+      // needsPagesBootstrap so sources(id) FK target exists.
+      await this.db.exec(`
+        ALTER TABLE files ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT 'default'
+          REFERENCES sources(id) ON DELETE CASCADE;
+        ALTER TABLE files ADD COLUMN IF NOT EXISTS page_id INTEGER
+          REFERENCES pages(id) ON DELETE SET NULL;
+      `);
+    }
+
+    if (needsOauthClientsBootstrap) {
+      // v0.34.1 (#861 + #876, v60 + v61): oauth_clients gained source_id
+      // (write-source scope) + federated_read (read-source array).
+      // PGLITE_SCHEMA_SQL declares idx_oauth_clients_source_id +
+      // idx_oauth_clients_federated_read (mirrors src/schema.sql:434-437).
+      // Pre-v60 brains with the oauth_clients table wedge on SCHEMA_SQL
+      // replay. Closes #1018.
+      //
+      // ON DELETE RESTRICT matches the current schema.sql:427 declaration
+      // and v64's final intent. v60's original migration used SET NULL
+      // but v64 tightened it; bootstrapping at the final state avoids a
+      // redundant subsequent ALTER and matches the schema-blob's
+      // source-of-truth posture.
+      //
+      // federated_read default '{}' (empty array) mirrors schema.sql:428;
+      // v62's backfill migration handles non-empty rows post-bootstrap.
+      await this.db.exec(`
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS source_id TEXT
+          REFERENCES sources(id) ON DELETE RESTRICT;
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_read TEXT[]
+          NOT NULL DEFAULT '{}';
       `);
     }
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -319,6 +319,12 @@ export class PostgresEngine implements BrainEngine {
       subagent_provider_id_exists: boolean;
       ingest_log_exists: boolean;
       ingest_log_source_id_exists: boolean;
+      files_exists: boolean;
+      files_source_id_exists: boolean;
+      files_page_id_exists: boolean;
+      oauth_clients_exists: boolean;
+      oauth_clients_source_id_exists: boolean;
+      oauth_clients_federated_read_exists: boolean;
     }[]>`
       SELECT
         EXISTS (SELECT 1 FROM information_schema.tables
@@ -356,7 +362,19 @@ export class PostgresEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.tables
                 WHERE table_schema = current_schema() AND table_name = 'ingest_log') AS ingest_log_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema = current_schema() AND table_name = 'ingest_log' AND column_name = 'source_id') AS ingest_log_source_id_exists
+                WHERE table_schema = current_schema() AND table_name = 'ingest_log' AND column_name = 'source_id') AS ingest_log_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema() AND table_name = 'files') AS files_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'files' AND column_name = 'source_id') AS files_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'files' AND column_name = 'page_id') AS files_page_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema() AND table_name = 'oauth_clients') AS oauth_clients_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'oauth_clients' AND column_name = 'source_id') AS oauth_clients_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'oauth_clients' AND column_name = 'federated_read') AS oauth_clients_federated_read_exists
     `;
     const probe = probeRows[0]!;
 
@@ -386,11 +404,26 @@ export class PostgresEngine implements BrainEngine {
     // source_id. Old brains have ingest_log without source_id; bootstrap adds
     // the column before SCHEMA_SQL replay creates the index.
     const needsIngestLogSourceId = probe.ingest_log_exists && !probe.ingest_log_source_id_exists;
+    // v0.18.0 Step 7: files gained source_id + page_id. SCHEMA_SQL declares
+    // `CREATE INDEX idx_files_page_id ON files(page_id)` and
+    // `CREATE INDEX idx_files_source_id ON files(source_id)` (schema.sql:498-499)
+    // unguarded, so any pre-v0.18.0 brain wedges with `column "page_id" does
+    // not exist`. Closes #974 + the column half of #820.
+    const needsFilesBootstrap = probe.files_exists
+        && (!probe.files_source_id_exists || !probe.files_page_id_exists);
+    // v0.34.1 (v60 + v61): oauth_clients gained source_id + federated_read.
+    // SCHEMA_SQL declares idx_oauth_clients_source_id +
+    // idx_oauth_clients_federated_read (schema.sql:434-437). Pre-v60 brains
+    // with oauth_clients (post-v0.26 OAuth, pre-v0.34.1) wedge on SCHEMA_SQL
+    // replay before v60+v61 can run. Closes #1018.
+    const needsOauthClientsBootstrap = probe.oauth_clients_exists
+        && (!probe.oauth_clients_source_id_exists || !probe.oauth_clients_federated_read_exists);
 
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
         && !needsPagesDeletedAt && !needsMcpLogBootstrap && !needsSubagentProviderId
         && !needsChunksEmbeddingImage && !needsPagesRecency
-        && !needsIngestLogSourceId) return;
+        && !needsIngestLogSourceId
+        && !needsFilesBootstrap && !needsOauthClientsBootstrap) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
 
@@ -516,6 +549,54 @@ export class PostgresEngine implements BrainEngine {
       // so the index can build cleanly.
       await conn.unsafe(`
         ALTER TABLE ingest_log ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT 'default';
+      `);
+    }
+
+
+    if (needsFilesBootstrap) {
+      // v0.18.0 Step 7: files gained source_id + page_id alongside the
+      // pages.source_id wave. SCHEMA_SQL declares
+      //   CREATE INDEX idx_files_page_id ON files(page_id);
+      //   CREATE INDEX idx_files_source_id ON files(source_id);
+      // (schema.sql:498-499) without IF guard on the columns themselves,
+      // so any pre-v0.18.0 brain wedges with `column "page_id" does not
+      // exist` before runMigrations gets a chance to add them. Closes
+      // #974 + the column half of #820. NOT NULL DEFAULT 'default' on
+      // source_id mirrors schema.sql:480-481 (back-compat for legacy
+      // unscoped rows). page_id is nullable per ON DELETE SET NULL.
+      // Ordering: this block runs AFTER needsPagesBootstrap so the
+      // sources(id) FK target exists; pages is a v1 primitive.
+      await conn.unsafe(`
+        ALTER TABLE files ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT 'default'
+          REFERENCES sources(id) ON DELETE CASCADE;
+        ALTER TABLE files ADD COLUMN IF NOT EXISTS page_id INTEGER
+          REFERENCES pages(id) ON DELETE SET NULL;
+      `);
+    }
+
+    if (needsOauthClientsBootstrap) {
+      // v0.34.1 (#861 + #876, v60 + v61): oauth_clients gained source_id
+      // (write-source scope) + federated_read (read-source array).
+      // SCHEMA_SQL declares idx_oauth_clients_source_id (partial) +
+      // idx_oauth_clients_federated_read (GIN) at schema.sql:434-437.
+      // Pre-v60 brains with the oauth_clients table (post-v0.26 OAuth
+      // introduction but not yet upgraded past v0.34.1) wedge on
+      // SCHEMA_SQL replay before v60 + v61 can run. Closes #1018.
+      //
+      // ON DELETE RESTRICT matches the current schema.sql:427 declaration
+      // and v64's final intent (per TODOS.md "v0.34.x: gbrain sources
+      // purge FK error UX" item). v60's original migration used SET NULL
+      // but v64 tightened it; bootstrapping at the final state avoids
+      // a redundant subsequent ALTER and matches the schema-blob's
+      // source-of-truth posture.
+      //
+      // federated_read default '{}' (empty array) mirrors schema.sql:428;
+      // v62's backfill migration handles non-empty rows post-bootstrap.
+      await conn.unsafe(`
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS source_id TEXT
+          REFERENCES sources(id) ON DELETE RESTRICT;
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_read TEXT[]
+          NOT NULL DEFAULT '{}';
       `);
     }
   }

--- a/test/bootstrap.test.ts
+++ b/test/bootstrap.test.ts
@@ -196,4 +196,138 @@ describe('PGLiteEngine#applyForwardReferenceBootstrap', () => {
       await engine.disconnect();
     }
   }, 30000);
+
+  test('pre-v0.18 files shape: bootstrap adds source_id + page_id (closes #974)', async () => {
+    // Repro of #974: pre-v0.18 brains have `files` without source_id/page_id.
+    // PGLITE_SCHEMA_SQL declares idx_files_source_id and idx_files_page_id
+    // unguarded, so SCHEMA_SQL replay crashes with `column "page_id" does not exist`.
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    try {
+      await engine.initSchema();
+      const db = (engine as any).db;
+
+      await db.exec(`
+        DROP INDEX IF EXISTS idx_files_source_id;
+        DROP INDEX IF EXISTS idx_files_page_id;
+        ALTER TABLE files DROP COLUMN IF EXISTS source_id;
+        ALTER TABLE files DROP COLUMN IF EXISTS page_id;
+      `);
+
+      await (engine as any).applyForwardReferenceBootstrap();
+
+      const { rows: srcCol } = await db.query(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'files' AND column_name = 'source_id'
+      `);
+      expect(srcCol).toHaveLength(1);
+
+      const { rows: pageCol } = await db.query(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'files' AND column_name = 'page_id'
+      `);
+      expect(pageCol).toHaveLength(1);
+
+      // SCHEMA_SQL replay must now succeed (the actual bug surface).
+      const { PGLITE_SCHEMA_SQL } = await import('../src/core/pglite-schema.ts');
+      await db.exec(PGLITE_SCHEMA_SQL);
+    } finally {
+      await engine.disconnect();
+    }
+  }, 30000);
+
+  test('pre-v60 oauth_clients shape: bootstrap adds source_id + federated_read (closes #1018)', async () => {
+    // Repro of #1018: brains at config.version=54 (pre-v60) have oauth_clients
+    // without source_id/federated_read. PGLITE_SCHEMA_SQL declares both
+    // idx_oauth_clients_source_id and idx_oauth_clients_federated_read
+    // unguarded, so SCHEMA_SQL replay crashes with `column "source_id" does not exist`.
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    try {
+      await engine.initSchema();
+      const db = (engine as any).db;
+
+      await db.exec(`
+        DROP INDEX IF EXISTS idx_oauth_clients_source_id;
+        DROP INDEX IF EXISTS idx_oauth_clients_federated_read;
+        ALTER TABLE oauth_clients DROP COLUMN IF EXISTS source_id;
+        ALTER TABLE oauth_clients DROP COLUMN IF EXISTS federated_read;
+      `);
+
+      await (engine as any).applyForwardReferenceBootstrap();
+
+      const { rows: srcCol } = await db.query(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'oauth_clients' AND column_name = 'source_id'
+      `);
+      expect(srcCol).toHaveLength(1);
+
+      const { rows: frCol } = await db.query(`
+        SELECT column_name, data_type FROM information_schema.columns
+        WHERE table_name = 'oauth_clients' AND column_name = 'federated_read'
+      `);
+      expect(frCol).toHaveLength(1);
+      // Must be array type (TEXT[]) per src/schema.sql:428.
+      expect(frCol[0].data_type).toBe('ARRAY');
+
+      // SCHEMA_SQL replay must now succeed (the actual #1018 bug surface).
+      const { PGLITE_SCHEMA_SQL } = await import('../src/core/pglite-schema.ts');
+      await db.exec(PGLITE_SCHEMA_SQL);
+    } finally {
+      await engine.disconnect();
+    }
+  }, 30000);
+
+  test('absent oauth_clients table (very old brain): bootstrap no-ops the oauth branch', async () => {
+    // Defense-in-depth: brains created before v0.26's OAuth introduction
+    // have no oauth_clients table at all. The probe must detect this and
+    // skip the ALTER (which would otherwise crash with `relation does not exist`).
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    try {
+      await engine.initSchema();
+      const db = (engine as any).db;
+
+      // Drop the entire oauth_clients table to simulate a pre-v0.26 brain.
+      // CASCADE drops dependent oauth_tokens.client_id FK rows too.
+      await db.exec(`DROP TABLE IF EXISTS oauth_clients CASCADE;`);
+
+      // Bootstrap must not throw — the oauth_clients_exists probe catches absence.
+      await (engine as any).applyForwardReferenceBootstrap();
+
+      // The table is genuinely gone (bootstrap doesn't recreate it; SCHEMA_SQL
+      // replay on the next initSchema() does that).
+      const { rows } = await db.query(`
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'oauth_clients'
+      `);
+      expect(rows).toHaveLength(0);
+    } finally {
+      await engine.disconnect();
+    }
+  }, 30000);
+
+  test('absent files table (very old brain): bootstrap no-ops the files branch', async () => {
+    // Same defense-in-depth as the oauth_clients case. files table existed
+    // since pre-v0.13 in practice, but the probe should still gate cleanly.
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    try {
+      await engine.initSchema();
+      const db = (engine as any).db;
+
+      await db.exec(`DROP TABLE IF EXISTS files CASCADE;`);
+
+      // Bootstrap must not throw.
+      await (engine as any).applyForwardReferenceBootstrap();
+
+      const { rows } = await db.query(`
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'files'
+      `);
+      expect(rows).toHaveLength(0);
+    } finally {
+      await engine.disconnect();
+    }
+  }, 30000);
 });

--- a/test/e2e/postgres-bootstrap.test.ts
+++ b/test/e2e/postgres-bootstrap.test.ts
@@ -90,4 +90,88 @@ describe.skipIf(skip)('PostgresEngine forward-reference bootstrap (E2E)', () => 
     await engine.initSchema();
     expect(await engine.getConfig('version')).toBe(String(LATEST_VERSION));
   });
+
+  test('rewound-brain: pre-v0.18 files + pre-v60 oauth_clients all bootstrap → SCHEMA_SQL → LATEST', async () => {
+    // Coverage for the bootstrap-gap fix wave that closes #974 + #1018 +
+    // the column-half of #820. This single test exercises both new probe paths
+    // together — same pattern as commit 336597c's rewound-brain E2E for
+    // the v39-v41 wave.
+    //
+    // The test asserts: from a brain that lacks every newly-probed column,
+    // PostgresEngine.initSchema() (bootstrap → SCHEMA_SQL → runMigrations)
+    // produces a brain at LATEST_VERSION with each column present and
+    // index built. If any branch is misordered (e.g. files/oauth_clients
+    // ALTER fires before sources is created), the FK ADD CONSTRAINT crashes
+    // here and the test fails loud.
+    await engine.initSchema(); // start clean
+
+    const conn = (engine as any).sql;
+    await conn.unsafe(`TRUNCATE pages, content_chunks, links, tags, raw_data, timeline_entries, page_versions, ingest_log RESTART IDENTITY CASCADE`);
+
+    // Strip the columns added in this fix-wave's coverage. The pages.source_id
+    // strip is intentionally repeated so the fix-wave columns and the original
+    // pages bootstrap path are exercised together — proves ordering is right.
+    await conn.unsafe(`
+      ALTER TABLE pages DROP CONSTRAINT IF EXISTS pages_source_slug_key;
+      ALTER TABLE pages ADD CONSTRAINT pages_slug_key UNIQUE (slug);
+      DROP INDEX IF EXISTS idx_pages_source_id;
+      ALTER TABLE pages DROP COLUMN IF EXISTS source_id CASCADE;
+
+
+      DROP INDEX IF EXISTS idx_files_page_id;
+      DROP INDEX IF EXISTS idx_files_source_id;
+      ALTER TABLE files DROP COLUMN IF EXISTS source_id CASCADE;
+      ALTER TABLE files DROP COLUMN IF EXISTS page_id CASCADE;
+
+      -- v0.34.1 (v60+v61) columns missing from the original bootstrap.
+      DROP INDEX IF EXISTS idx_oauth_clients_source_id;
+      DROP INDEX IF EXISTS idx_oauth_clients_federated_read;
+      ALTER TABLE oauth_clients DROP COLUMN IF EXISTS source_id CASCADE;
+      ALTER TABLE oauth_clients DROP COLUMN IF EXISTS federated_read CASCADE;
+
+      -- sources MUST go last so the column drops above don't trip CASCADE
+      -- on FKs we're about to recreate via bootstrap.
+      DROP TABLE IF EXISTS sources CASCADE;
+    `);
+    await engine.setConfig('version', '17');
+
+    // The path under test: full PostgresEngine.initSchema() through bootstrap,
+    // SCHEMA_SQL replay, and runMigrations. Any ordering bug crashes here.
+    await engine.initSchema();
+
+    expect(await engine.getConfig('version')).toBe(String(LATEST_VERSION));
+
+    // Verify each previously-missing column now exists.
+    const expectations: Array<{ table: string; column: string }> = [
+      { table: 'files', column: 'source_id' },
+      { table: 'files', column: 'page_id' },
+      { table: 'oauth_clients', column: 'source_id' },
+      { table: 'oauth_clients', column: 'federated_read' },
+    ];
+    for (const exp of expectations) {
+      const rows = await conn`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = ${exp.table}
+          AND column_name = ${exp.column}
+      `;
+      expect(rows).toHaveLength(1);
+    }
+
+    // Verify the indexes that were the original wedge surface are present.
+    const indexes: string[] = [
+      'idx_files_page_id',
+      'idx_files_source_id',
+      'idx_oauth_clients_source_id',
+      'idx_oauth_clients_federated_read',
+    ];
+    for (const idx of indexes) {
+      const rows = await conn`
+        SELECT indexname FROM pg_indexes
+        WHERE schemaname = current_schema()
+          AND indexname = ${idx}
+      `;
+      expect(rows).toHaveLength(1);
+    }
+  }, 60_000);
 });

--- a/test/schema-bootstrap-coverage.test.ts
+++ b/test/schema-bootstrap-coverage.test.ts
@@ -108,6 +108,21 @@ const REQUIRED_BOOTSTRAP_COVERAGE: ForwardReference[] = [
   // created_at DESC)`. Old brains have ingest_log without source_id; bootstrap
   // adds the column before SCHEMA_SQL replay creates the index.
   { kind: 'column', table: 'ingest_log', column: 'source_id' },
+  // v0.18.0 Step 7 — files.source_id forward-referenced by
+  // `CREATE INDEX idx_files_source_id ON files(source_id)`. Closes #974.
+  { kind: 'column', table: 'files', column: 'source_id' },
+  // v0.18.0 Step 7 — files.page_id forward-referenced by
+  // `CREATE INDEX idx_files_page_id ON files(page_id)`. Closes #974 + the
+  // column half of #820.
+  { kind: 'column', table: 'files', column: 'page_id' },
+  // v0.34.1 (v60) — oauth_clients.source_id forward-referenced by
+  // `CREATE INDEX idx_oauth_clients_source_id ON oauth_clients(source_id)
+  //  WHERE source_id IS NOT NULL`. Closes #1018.
+  { kind: 'column', table: 'oauth_clients', column: 'source_id' },
+  // v0.34.1 (v61) — oauth_clients.federated_read forward-referenced by
+  // `CREATE INDEX idx_oauth_clients_federated_read ON oauth_clients
+  //  USING GIN (federated_read)`. Closes #1018.
+  { kind: 'column', table: 'oauth_clients', column: 'federated_read' },
 ];
 
 test('applyForwardReferenceBootstrap covers every forward reference declared in REQUIRED_BOOTSTRAP_COVERAGE', async () => {
@@ -168,6 +183,17 @@ test('applyForwardReferenceBootstrap covers every forward reference declared in 
       ALTER TABLE pages DROP COLUMN IF EXISTS import_filename;
       ALTER TABLE pages DROP COLUMN IF EXISTS salience_touched_at;
       ALTER TABLE pages DROP COLUMN IF EXISTS emotional_weight;
+
+      -- Bootstrap-gap fix-wave (closes #974, #1018, partial #820).
+      DROP INDEX IF EXISTS idx_files_page_id;
+      DROP INDEX IF EXISTS idx_files_source_id;
+      ALTER TABLE files DROP COLUMN IF EXISTS source_id;
+      ALTER TABLE files DROP COLUMN IF EXISTS page_id;
+
+      DROP INDEX IF EXISTS idx_oauth_clients_source_id;
+      DROP INDEX IF EXISTS idx_oauth_clients_federated_read;
+      ALTER TABLE oauth_clients DROP COLUMN IF EXISTS source_id;
+      ALTER TABLE oauth_clients DROP COLUMN IF EXISTS federated_read;
     `);
 
     // Run bootstrap in isolation (NOT initSchema). This is what we're testing.
@@ -234,6 +260,17 @@ test('after bootstrap, PGLITE_SCHEMA_SQL replays without crashing on missing for
       ALTER TABLE pages DROP COLUMN IF EXISTS import_filename;
       ALTER TABLE pages DROP COLUMN IF EXISTS salience_touched_at;
       ALTER TABLE pages DROP COLUMN IF EXISTS emotional_weight;
+
+      -- Bootstrap-gap fix-wave (closes #974, #1018, partial #820).
+      DROP INDEX IF EXISTS idx_files_page_id;
+      DROP INDEX IF EXISTS idx_files_source_id;
+      ALTER TABLE files DROP COLUMN IF EXISTS source_id;
+      ALTER TABLE files DROP COLUMN IF EXISTS page_id;
+
+      DROP INDEX IF EXISTS idx_oauth_clients_source_id;
+      DROP INDEX IF EXISTS idx_oauth_clients_federated_read;
+      ALTER TABLE oauth_clients DROP COLUMN IF EXISTS source_id;
+      ALTER TABLE oauth_clients DROP COLUMN IF EXISTS federated_read;
     `);
 
     // Bootstrap, then schema replay. Either step crashing fails the test.


### PR DESCRIPTION
## Summary

Fix-wave that closes a class of upgrade-path bootstrap-gap bugs. Adds 4 missing forward-reference probes to `applyForwardReferenceBootstrap` (both engines), updates `REQUIRED_BOOTSTRAP_COVERAGE`, adds rewound-brain unit + E2E coverage, and fixes the misleading doctor hint #1018 called out.

**Closes:**

- Closes #974 — `files.source_id` + `files.page_id`
- Closes #1018 — `oauth_clients.source_id` + `oauth_clients.federated_read` + the doctor hint suggestion
- Partial #820 — column half of `files.page_id` reference

## What's broken

Brains at schema version pre-v0.18 (or pre-v60 for the oauth_clients case) wedge on `gbrain init --migrate-only` and `gbrain apply-migrations --yes` with a one-line `column "<name>" does not exist` error. No stack trace. The wedge fires inside SCHEMA_SQL apply when the embedded schema blob's `CREATE INDEX` references a column the brain's table predates.

`applyForwardReferenceBootstrap` is supposed to add these forward-referenced columns BEFORE SCHEMA_SQL replay so the indexes can build. It probes 18 columns but missed:

| Column | Migration | Issue | SCHEMA_SQL forward ref |
|---|---|---|---|
| `files.source_id` | v0.18 Step 7 | #974 | `CREATE INDEX idx_files_source_id ON files(source_id)` (schema.sql:499) |
| `files.page_id` | v0.18 Step 7 | #974 (+ column half of #820) | `CREATE INDEX idx_files_page_id ON files(page_id)` (schema.sql:498) |
| `oauth_clients.source_id` | v60 (#861) | #1018 | partial `CREATE INDEX idx_oauth_clients_source_id ON oauth_clients(source_id) WHERE source_id IS NOT NULL` (schema.sql:434-435) |
| `oauth_clients.federated_read` | v61 (#876) | #1018 | GIN `CREATE INDEX idx_oauth_clients_federated_read ON oauth_clients USING GIN (federated_read)` (schema.sql:436-437) |

## Changes

### `src/core/postgres-engine.ts` + `src/core/pglite-engine.ts`

- 4 new EXISTS probes added to the round-trip detection SELECT (mirrors existing 18-probe pattern)
- 2 new `needsXBootstrap` flags + corresponding ALTER blocks (`needsFilesBootstrap` + `needsOauthClientsBootstrap`)
- Branch ordering preserved: `files` and `oauth_clients` ALTERs run AFTER the `needsPagesBootstrap` block (which creates `sources`) so the FK targets exist
- `oauth_clients.source_id` uses `ON DELETE RESTRICT` to match `src/schema.sql:427` and v64's final intent (avoids redundant subsequent ALTER; per the `TODOS.md` "v60 idempotency guard" note)
- All ALTER statements use `IF NOT EXISTS` for idempotency (matches existing pattern)

### `src/commands/doctor.ts` (per #1018 secondary suggestion)

- `schema_version` check now points users at `gbrain init --migrate-only` first, then `gbrain apply-migrations --yes`. When bootstrap is wedged, `apply-migrations` itself can't proceed (its Phase A calls `init --migrate-only`), so the original hint was a dead-end. Two-line message change in two sites.

### `test/schema-bootstrap-coverage.test.ts`

- 4 new entries in `REQUIRED_BOOTSTRAP_COVERAGE` — exercised automatically by the existing assertion loop
- 4 corresponding DROP statements in both DROP setup blocks (the per-target asserts test + the SCHEMA_SQL replay test)

### `test/bootstrap.test.ts`

4 new unit cases:

- `pre-v0.18 files shape: bootstrap adds source_id + page_id (closes #974)` — also asserts SCHEMA_SQL replay succeeds afterward
- `pre-v60 oauth_clients shape: bootstrap adds source_id + federated_read (closes #1018)` — also asserts `federated_read` is `TEXT[]` per schema, and that SCHEMA_SQL replay succeeds afterward (the actual #1018 bug surface)
- `absent oauth_clients table (very old brain): bootstrap no-ops the oauth branch` — defense against pre-v0.26 brains that have no oauth_clients table at all
- `absent files table (very old brain): bootstrap no-ops the files branch` — same defense pattern

### `test/e2e/postgres-bootstrap.test.ts`

New rewound-brain E2E that strips ALL 4 newly-probed columns + `pages.source_id` together, then runs `PostgresEngine.initSchema()` and asserts:

- `config.version` reaches `LATEST_VERSION`
- Each newly-probed column exists post-bootstrap
- Every newly-built index (`idx_files_page_id`, `idx_files_source_id`, `idx_oauth_clients_source_id`, `idx_oauth_clients_federated_read`) is present

This is the contract test for branch ordering. If `files` or `oauth_clients` ALTER fires before the `sources` table is created (FK target missing), the test fails loud.

Mirrors commit `336597c`'s pattern (rewound-brain E2E for v39-v41 forward-reference bootstrap).

## What's NOT in scope

- **Structural upgrade-path test** — the class of bug that keeps recurring needs a structural fix, not just another column added to the hand-maintained list. Filed as #1044 with two design sketches (snapshot-based vs replay-based) for a separate PR.
- **VERSION + CHANGELOG bump** — leaving for maintainer's fix-wave packaging (matches the `7d39527` pattern for prior bootstrap fixes).
- **`v60 idempotency guard against --force-retry race with v64`** (per `TODOS.md`) — directly relevant to this PR's `ON DELETE RESTRICT` decision but a separate code change in `migrate.ts`. Documented here for context.
- **`content_chunks.source_id`** — initially included in the PR draft but trimmed after verification: the column is in `src/schema.sql:218` but NOT in `src/core/schema-embedded.ts` (the runtime SQL Postgres replays), so it isn't a SCHEMA_SQL forward-reference. Adding it via bootstrap created real schema drift vs PGLite that the `schema-drift.test.ts` gate caught. The `schema.sql` ↔ `schema-embedded.ts` discrepancy is a separate concern for a different PR.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test test/bootstrap.test.ts test/schema-bootstrap-coverage.test.ts` — **15/15 pass** (4 new cases + the array test exercising 4 new entries)
- [x] `bun test test/e2e/schema-drift.test.ts test/e2e/postgres-bootstrap.test.ts` against fresh Postgres — **9/9 pass** including the new rewound-brain E2E and the schema-drift parity gate
- Targeted unit suite (9 files, 297 tests): 294 pass / 3 fail. The 3 failures are pre-existing Windows Git-Bash environment issues (`Bun.spawn(['bun', ...])` ENOENT — the spawned process can't find `bun` via bare name). Unrelated to this PR.

## Diagnosis context

I hit `oauth_clients.source_id` first on my own brain (the federation-attribution bug PR #776 fixed already, then needed schema migration to unlock `--strategy code` indexing for Cathedral II). Searching the issue tracker surfaced the recurring pattern across #974, #1018, #820 — same shape every time. Bundling all four columns into one PR closes 3 issues at once and signals the pattern recognition the bootstrap docstring asks for ("11 wedge incidents and counting").