### PR TITLE
fix: support hosted Perplexity embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,21 @@ FILES
 EMBEDDINGS
   gbrain embed [<slug>|--all|--stale]   Generate/refresh embeddings
 
+  Defaults: OpenAI text-embedding-3-large, 1536 dimensions.
+  OpenAI-compatible embedding providers can be configured with:
+    GBRAIN_EMBEDDING_MODEL
+    GBRAIN_EMBEDDING_DIMENSIONS
+    GBRAIN_EMBEDDING_BASE_URL
+    GBRAIN_EMBEDDING_API_KEY
+
+  Perplexity local embed example:
+    GBRAIN_EMBEDDING_MODEL=pplx-embed-context-v1-4b
+    GBRAIN_EMBEDDING_DIMENSIONS=2560
+    GBRAIN_EMBEDDING_BASE_URL=http://127.0.0.1:8790/v1
+
+  Note: pgvector HNSW indexes support up to 2000 dimensions. 2560-d
+  Perplexity brains work, but vector search runs without HNSW indexing.
+
 LINKS + GRAPH
   gbrain link|unlink|backlinks          Cross-reference management
   gbrain extract links|timeline|all     Batch backfill from existing pages

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -651,6 +651,10 @@ FILES
 
 EMBEDDINGS
   embed [<slug>|--all|--stale]       Generate/refresh embeddings
+                                      Configure provider with GBRAIN_EMBEDDING_MODEL,
+                                      GBRAIN_EMBEDDING_DIMENSIONS,
+                                      GBRAIN_EMBEDDING_BASE_URL,
+                                      GBRAIN_EMBEDDING_API_KEY
 
 LINKS
   link <from> <to> [--type T]        Create typed link

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,5 +1,5 @@
 import type { BrainEngine } from '../core/engine.ts';
-import { embedBatch } from '../core/embedding.ts';
+import { embedBatch, resolveEmbeddingConfig } from '../core/embedding.ts';
 import type { ChunkInput } from '../core/types.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
 import { createProgress, type ProgressReporter } from '../core/progress.ts';
@@ -142,6 +142,7 @@ async function embedPage(
   result: EmbedResult,
 ) {
   const page = await engine.getPage(slug);
+  const embeddingConfig = resolveEmbeddingConfig();
   if (!page) {
     throw new Error(`Page not found: ${slug}`);
   }
@@ -204,6 +205,7 @@ async function embedPage(
     chunk_text: c.chunk_text,
     chunk_source: c.chunk_source,
     embedding: embeddingMap.get(c.chunk_index),
+    model: embeddingMap.has(c.chunk_index) ? embeddingConfig.model : c.model,
     token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
   }));
 
@@ -238,6 +240,7 @@ async function embedAll(
   }
 
   const pages = await engine.listPages({ limit: 100000 });
+  const embeddingConfig = resolveEmbeddingConfig();
   let processed = 0;
 
   // Concurrency limit for parallel page embedding.
@@ -285,6 +288,7 @@ async function embedAll(
         chunk_text: c.chunk_text,
         chunk_source: c.chunk_source,
         embedding: embeddingMap.get(c.chunk_index) ?? undefined,
+        model: embeddingMap.has(c.chunk_index) ? embeddingConfig.model : c.model,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
       await engine.upsertChunks(page.slug, updated);
@@ -389,6 +393,7 @@ async function embedAllStale(
   }
 
   const CONCURRENCY = parseInt(process.env.GBRAIN_EMBED_CONCURRENCY || '20', 10);
+  const embeddingConfig = resolveEmbeddingConfig();
   let processed = 0;
 
   async function embedOneSlug(slug: string) {
@@ -413,6 +418,7 @@ async function embedAllStale(
         // For stale chunks: pass the new embedding.
         // For non-stale chunks: pass undefined → COALESCE preserves existing embedding.
         embedding: staleIdxToEmbedding.get(c.chunk_index) ?? undefined,
+        model: staleIdxToEmbedding.has(c.chunk_index) ? embeddingConfig.model : c.model,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
       await engine.upsertChunks(slug, merged);

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -9,19 +9,56 @@
 
 import OpenAI from 'openai';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
+const DEFAULT_MODEL = 'text-embedding-3-large';
+const DEFAULT_DIMENSIONS = 1536;
 const MAX_CHARS = 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
 const BATCH_SIZE = 100;
 
-let client: OpenAI | null = null;
+export interface EmbeddingConfig {
+  model: string;
+  dimensions: number;
+  baseURL?: string;
+  apiKey?: string;
+}
 
-function getClient(): OpenAI {
-  if (!client) {
-    client = new OpenAI();
+export function resolveEmbeddingConfig(env: NodeJS.ProcessEnv = process.env): EmbeddingConfig {
+  const model = env.GBRAIN_EMBEDDING_MODEL || DEFAULT_MODEL;
+  const rawDimensions = env.GBRAIN_EMBEDDING_DIMENSIONS || String(DEFAULT_DIMENSIONS);
+  const dimensions = Number.parseInt(rawDimensions, 10);
+
+  if (!Number.isInteger(dimensions) || dimensions <= 0) {
+    throw new Error('GBRAIN_EMBEDDING_DIMENSIONS must be a positive integer');
+  }
+
+  const baseURL = env.GBRAIN_EMBEDDING_BASE_URL || undefined;
+  const isPerplexityConfig = model.toLowerCase().includes('pplx') || model.toLowerCase().includes('perplexity') || (baseURL?.toLowerCase().includes('perplexity') ?? false);
+  const apiKey = env.GBRAIN_EMBEDDING_API_KEY
+    || (isPerplexityConfig ? (env.PERPLEXITY_API_KEY || env.PPLX_API_KEY) : undefined)
+    || env.OPENAI_API_KEY
+    || (baseURL ? 'not-needed' : undefined);
+
+  return {
+    model,
+    dimensions,
+    baseURL,
+    apiKey,
+  };
+}
+
+let client: OpenAI | null = null;
+let clientCacheKey: string | null = null;
+
+function getClient(config: EmbeddingConfig): OpenAI {
+  const cacheKey = JSON.stringify({ baseURL: config.baseURL, apiKey: config.apiKey });
+  if (!client || clientCacheKey !== cacheKey) {
+    client = new OpenAI({
+      apiKey: config.apiKey,
+      baseURL: config.baseURL,
+    });
+    clientCacheKey = cacheKey;
   }
   return client;
 }
@@ -62,10 +99,12 @@ export async function embedBatch(
 async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const response = await getClient().embeddings.create({
-        model: MODEL,
+      const config = resolveEmbeddingConfig();
+      const response = await getClient(config).embeddings.create({
+        model: config.model,
         input: texts,
-        dimensions: DIMENSIONS,
+        dimensions: config.dimensions,
+        encoding_format: 'float',
       });
 
       // Sort by index to maintain order
@@ -104,7 +143,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
+export { DEFAULT_MODEL as EMBEDDING_MODEL, DEFAULT_DIMENSIONS as EMBEDDING_DIMENSIONS };
 
 /**
  * v0.20.0 Cathedral II Layer 8 (D1): USD cost per 1k tokens for

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -22,6 +22,19 @@ export interface EmbeddingConfig {
   dimensions: number;
   baseURL?: string;
   apiKey?: string;
+  provider: 'openai-compatible' | 'perplexity-hosted';
+}
+
+function isPerplexityConfig(model: string, baseURL?: string): boolean {
+  const modelLower = model.toLowerCase();
+  const baseLower = baseURL?.toLowerCase() || '';
+  return modelLower.includes('pplx') || modelLower.includes('perplexity') || baseLower.includes('perplexity');
+}
+
+function isHostedPerplexity(model: string, baseURL?: string): boolean {
+  const modelLower = model.toLowerCase();
+  const baseLower = baseURL?.toLowerCase() || '';
+  return baseLower.includes('api.perplexity.ai') || modelLower.startsWith('pplx-embed-v1-');
 }
 
 export function resolveEmbeddingConfig(env: NodeJS.ProcessEnv = process.env): EmbeddingConfig {
@@ -34,17 +47,19 @@ export function resolveEmbeddingConfig(env: NodeJS.ProcessEnv = process.env): Em
   }
 
   const baseURL = env.GBRAIN_EMBEDDING_BASE_URL || undefined;
-  const isPerplexityConfig = model.toLowerCase().includes('pplx') || model.toLowerCase().includes('perplexity') || (baseURL?.toLowerCase().includes('perplexity') ?? false);
+  const perplexityConfig = isPerplexityConfig(model, baseURL);
+  const hostedPerplexity = isHostedPerplexity(model, baseURL);
   const apiKey = env.GBRAIN_EMBEDDING_API_KEY
-    || (isPerplexityConfig ? (env.PERPLEXITY_API_KEY || env.PPLX_API_KEY) : undefined)
-    || env.OPENAI_API_KEY
-    || (baseURL ? 'not-needed' : undefined);
+    || (perplexityConfig ? (env.PERPLEXITY_API_KEY || env.PPLX_API_KEY) : undefined)
+    || (!perplexityConfig ? env.OPENAI_API_KEY : undefined)
+    || (baseURL && !hostedPerplexity ? 'not-needed' : undefined);
 
   return {
     model,
     dimensions,
     baseURL,
     apiKey,
+    provider: hostedPerplexity ? 'perplexity-hosted' : 'openai-compatible',
   };
 }
 
@@ -100,16 +115,17 @@ async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
       const config = resolveEmbeddingConfig();
-      const response = await getClient(config).embeddings.create({
+      const request: OpenAI.Embeddings.EmbeddingCreateParams = {
         model: config.model,
         input: texts,
         dimensions: config.dimensions,
-        encoding_format: 'float',
-      });
+        encoding_format: config.provider === 'perplexity-hosted' ? 'base64_int8' : 'float',
+      } as OpenAI.Embeddings.EmbeddingCreateParams;
+      const response = await getClient(config).embeddings.create(request);
 
       // Sort by index to maintain order
       const sorted = response.data.sort((a, b) => a.index - b.index);
-      return sorted.map(d => new Float32Array(d.embedding));
+      return sorted.map(d => coerceEmbedding(d.embedding, config));
     } catch (e: unknown) {
       if (attempt === MAX_RETRIES - 1) throw e;
 
@@ -132,6 +148,27 @@ async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
 
   // Should not reach here
   throw new Error('Embedding failed after all retries');
+}
+
+function coerceEmbedding(embedding: number[] | string, config: EmbeddingConfig): Float32Array {
+  const vector = typeof embedding === 'string'
+    ? decodeBase64Int8Embedding(embedding)
+    : new Float32Array(embedding);
+
+  if (vector.length !== config.dimensions) {
+    throw new Error(`Embedding provider returned ${vector.length} dimensions; expected ${config.dimensions}`);
+  }
+
+  return vector;
+}
+
+function decodeBase64Int8Embedding(value: string): Float32Array {
+  const bytes = Buffer.from(value, 'base64');
+  const vector = new Float32Array(bytes.length);
+  for (let i = 0; i < bytes.length; i += 1) {
+    vector[i] = bytes[i] > 127 ? bytes[i] - 256 : bytes[i];
+  }
+  return vector;
 }
 
 function exponentialDelay(attempt: number): number {

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -6,6 +6,7 @@ import type { BrainEngine, LinkBatchInput, TimelineBatchInput, ReservedConnectio
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
 import { runMigrations } from './migrate.ts';
 import { PGLITE_SCHEMA_SQL } from './pglite-schema.ts';
+import { resolveEmbeddingConfig } from './embedding.ts';
 import { acquireLock, releaseLock, type LockHandle } from './pglite-lock.ts';
 import type {
   Page, PageInput, PageFilters, PageType,
@@ -102,6 +103,55 @@ export class PGLiteEngine implements BrainEngine {
     if (applied > 0) {
       console.log(`  ${applied} migration(s) applied`);
     }
+
+    await this.ensureEmbeddingConfiguration();
+  }
+
+  /**
+   * Align the physical vector column with the active embedding model.
+   * pgvector HNSW indexes only support <=2000 dimensions; Perplexity's
+   * pplx-embed-context-v1-4b emits 2560-d vectors, so those brains run
+   * vector search without HNSW instead of failing schema init.
+   *
+   * Changing dimensions invalidates existing embeddings. We clear them,
+   * alter the column, and let `gbrain embed --stale` rebuild with the
+   * active provider.
+   */
+  private async ensureEmbeddingConfiguration(): Promise<void> {
+    const config = resolveEmbeddingConfig();
+    const desiredType = `vector(${config.dimensions})`;
+    const { rows } = await this.db.query(
+      `SELECT format_type(a.atttypid, a.atttypmod) AS typ
+         FROM pg_attribute a
+         JOIN pg_class c ON c.oid = a.attrelid
+        WHERE c.relname = 'content_chunks'
+          AND a.attname = 'embedding'
+          AND NOT a.attisdropped`,
+    );
+    const currentType = (rows[0] as { typ?: string } | undefined)?.typ;
+
+    if (currentType !== desiredType) {
+      await this.db.exec(`DROP INDEX IF EXISTS idx_chunks_embedding;`);
+      console.log(`  Reconfiguring embeddings: ${currentType || 'unknown'} → ${desiredType}; existing embeddings marked stale`);
+      await this.db.exec(`
+        UPDATE content_chunks SET embedding = NULL, embedded_at = NULL;
+        ALTER TABLE content_chunks ALTER COLUMN embedding TYPE ${desiredType} USING NULL;
+      `);
+    }
+
+    if (config.dimensions <= 2000) {
+      await this.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);`);
+    } else {
+      await this.db.exec(`DROP INDEX IF EXISTS idx_chunks_embedding;`);
+    }
+
+    await this.db.query(`
+      INSERT INTO config (key, value) VALUES
+        ('embedding_model', $1),
+        ('embedding_dimensions', $2),
+        ('embedding_base_url', $3)
+      ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+    `, [config.model, String(config.dimensions), config.baseURL || '']);
   }
 
   /**

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -89,7 +89,7 @@ CREATE TABLE IF NOT EXISTS content_chunks (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_chunks_page_index ON content_chunks(page_id, chunk_index);
 CREATE INDEX IF NOT EXISTS idx_chunks_page ON content_chunks(page_id);
-CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);
+-- idx_chunks_embedding is created dynamically by engine init when embedding dimensions support HNSW.
 -- v0.19.0: partial indexes for code chunk lookups.
 CREATE INDEX IF NOT EXISTS idx_chunks_symbol_name ON content_chunks(symbol_name) WHERE symbol_name IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_chunks_language ON content_chunks(language) WHERE language IS NOT NULL;

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -3,6 +3,7 @@ import type { BrainEngine, LinkBatchInput, TimelineBatchInput, ReservedConnectio
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
 import { runMigrations } from './migrate.ts';
 import { SCHEMA_SQL } from './schema-embedded.ts';
+import { resolveEmbeddingConfig } from './embedding.ts';
 import { verifySchema } from './schema-verify.ts';
 import type {
   Page, PageInput, PageFilters, PageType,
@@ -127,6 +128,8 @@ export class PostgresEngine implements BrainEngine {
         console.log(`  ${applied} migration(s) applied`);
       }
 
+      await this.ensureEmbeddingConfiguration();
+
       // Post-migration schema verification: catches columns that migrations
       // defined but PgBouncer transaction-mode silently failed to create.
       // Self-heals missing columns via ALTER TABLE ADD COLUMN IF NOT EXISTS.
@@ -137,6 +140,45 @@ export class PostgresEngine implements BrainEngine {
     } finally {
       await conn`SELECT pg_advisory_unlock(42)`;
     }
+  }
+
+  /** Align vector column type/index with the active embedding config. */
+  private async ensureEmbeddingConfiguration(): Promise<void> {
+    const config = resolveEmbeddingConfig();
+    const desiredType = `vector(${config.dimensions})`;
+    const conn = this.sql;
+    const rows = await conn<{ typ: string }[]>`
+      SELECT format_type(a.atttypid, a.atttypmod) AS typ
+        FROM pg_attribute a
+        JOIN pg_class c ON c.oid = a.attrelid
+       WHERE c.relname = 'content_chunks'
+         AND a.attname = 'embedding'
+         AND NOT a.attisdropped
+    `;
+    const currentType = rows[0]?.typ;
+
+    if (currentType !== desiredType) {
+      await conn.unsafe(`DROP INDEX IF EXISTS idx_chunks_embedding;`);
+      console.log(`  Reconfiguring embeddings: ${currentType || 'unknown'} → ${desiredType}; existing embeddings marked stale`);
+      await conn.unsafe(`
+        UPDATE content_chunks SET embedding = NULL, embedded_at = NULL;
+        ALTER TABLE content_chunks ALTER COLUMN embedding TYPE ${desiredType} USING NULL;
+      `);
+    }
+
+    if (config.dimensions <= 2000) {
+      await conn.unsafe(`CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);`);
+    } else {
+      await conn.unsafe(`DROP INDEX IF EXISTS idx_chunks_embedding;`);
+    }
+
+    await conn`
+      INSERT INTO config (key, value) VALUES
+        ('embedding_model', ${config.model}),
+        ('embedding_dimensions', ${String(config.dimensions)}),
+        ('embedding_base_url', ${config.baseURL || ''})
+      ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+    `;
   }
 
   /**

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -145,7 +145,10 @@ export class PostgresEngine implements BrainEngine {
   /** Align vector column type/index with the active embedding config. */
   private async ensureEmbeddingConfiguration(): Promise<void> {
     const config = resolveEmbeddingConfig();
-    const desiredType = `vector(${config.dimensions})`;
+    // pgvector HNSW supports vector up to 2000 dims, but halfvec up to 4000 dims.
+    // Perplexity pplx-embed-v1-4b is 2560 dims, so store it as halfvec to keep ANN.
+    const embeddingType = config.dimensions > 2000 ? 'halfvec' : 'vector';
+    const desiredType = `${embeddingType}(${config.dimensions})`;
     const conn = this.sql;
     const rows = await conn<{ typ: string }[]>`
       SELECT format_type(a.atttypid, a.atttypmod) AS typ
@@ -166,11 +169,8 @@ export class PostgresEngine implements BrainEngine {
       `);
     }
 
-    if (config.dimensions <= 2000) {
-      await conn.unsafe(`CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);`);
-    } else {
-      await conn.unsafe(`DROP INDEX IF EXISTS idx_chunks_embedding;`);
-    }
+    const indexOpclass = embeddingType === 'halfvec' ? 'halfvec_cosine_ops' : 'vector_cosine_ops';
+    await conn.unsafe(`CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding ${indexOpclass});`);
 
     await conn`
       INSERT INTO config (key, value) VALUES
@@ -660,12 +660,13 @@ export class PostgresEngine implements BrainEngine {
     params.push(offset);
     const offsetParam = `$${params.length}`;
 
-    const rawQuery = `
+      const vectorCast = embedding.length > 2000 ? 'halfvec' : 'vector';
+      const rawQuery = `
       WITH hnsw_candidates AS (
         SELECT
           p.slug, p.id as page_id, p.title, p.type, p.source_id,
           cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
-          1 - (cc.embedding <=> $1::vector) AS raw_score
+          1 - (cc.embedding <=> $1::${vectorCast}) AS raw_score
         FROM content_chunks cc
         JOIN pages p ON p.id = cc.page_id
         WHERE cc.embedding IS NOT NULL
@@ -675,7 +676,7 @@ export class PostgresEngine implements BrainEngine {
           ${languageClause}
           ${symbolKindClause}
           ${hardExcludeClause}
-        ORDER BY cc.embedding <=> $1::vector
+        ORDER BY cc.embedding <=> $1::${vectorCast}
         LIMIT ${innerLimitParam}
       )
       SELECT
@@ -741,6 +742,9 @@ export class PostgresEngine implements BrainEngine {
     const params: unknown[] = [];
     let paramIdx = 1;
 
+    const embeddingConfig = resolveEmbeddingConfig();
+    const embeddingCast = embeddingConfig.dimensions > 2000 ? 'halfvec' : 'vector';
+
     for (const chunk of chunks) {
       const embeddingStr = chunk.embedding
         ? '[' + Array.from(chunk.embedding).join(',') + ']'
@@ -750,7 +754,7 @@ export class PostgresEngine implements BrainEngine {
         : null;
 
       if (embeddingStr) {
-        rows.push(`($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}::vector, $${paramIdx++}, $${paramIdx++}, now(), $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}::text[], $${paramIdx++}, $${paramIdx++})`);
+        rows.push(`($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}::${embeddingCast}, $${paramIdx++}, $${paramIdx++}, now(), $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}::text[], $${paramIdx++}, $${paramIdx++})`);
         params.push(
           pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source,
           embeddingStr, chunk.model || 'text-embedding-3-large', chunk.token_count || null,

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -117,7 +117,7 @@ CREATE TABLE IF NOT EXISTS content_chunks (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_chunks_page_index ON content_chunks(page_id, chunk_index);
 CREATE INDEX IF NOT EXISTS idx_chunks_page ON content_chunks(page_id);
-CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);
+-- idx_chunks_embedding is created dynamically by engine init when embedding dimensions support HNSW.
 -- v0.19.0: partial indexes — only code chunks populate these columns.
 CREATE INDEX IF NOT EXISTS idx_chunks_symbol_name ON content_chunks(symbol_name) WHERE symbol_name IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_chunks_language ON content_chunks(language) WHERE language IS NOT NULL;

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -12,7 +12,7 @@
 import type { BrainEngine } from '../engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../engine.ts';
 import type { SearchResult, SearchOpts } from '../types.ts';
-import { embed } from '../embedding.ts';
+import { embed, resolveEmbeddingConfig } from '../embedding.ts';
 import { dedupResults } from './dedup.ts';
 import { autoDetectDetail } from './intent.ts';
 import { expandAnchors, hydrateChunks } from './two-pass.ts';
@@ -85,8 +85,9 @@ export async function hybridSearch(
   // Run keyword search (always available, no API key needed)
   const keywordResults = await engine.searchKeyword(query, searchOpts);
 
-  // Skip vector search entirely if no OpenAI key is configured
-  if (!process.env.OPENAI_API_KEY) {
+  // Skip vector search entirely if no embedding API key/base URL is configured
+  const embeddingConfig = resolveEmbeddingConfig();
+  if (!embeddingConfig.apiKey && !embeddingConfig.baseURL) {
     // Apply backlink boost in keyword-only path too. One getBacklinkCounts query
     // per search request; not N+1.
     if (keywordResults.length > 0) {

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -113,7 +113,7 @@ CREATE TABLE IF NOT EXISTS content_chunks (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_chunks_page_index ON content_chunks(page_id, chunk_index);
 CREATE INDEX IF NOT EXISTS idx_chunks_page ON content_chunks(page_id);
-CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);
+-- idx_chunks_embedding is created dynamically by engine init when embedding dimensions support HNSW.
 -- v0.19.0: partial indexes — only code chunks populate these columns.
 CREATE INDEX IF NOT EXISTS idx_chunks_symbol_name ON content_chunks(symbol_name) WHERE symbol_name IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_chunks_language ON content_chunks(language) WHERE language IS NOT NULL;

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -9,6 +9,27 @@ let maxConcurrentEmbedCalls = 0;
 let totalEmbedCalls = 0;
 
 mock.module('../src/core/embedding.ts', () => ({
+  resolveEmbeddingConfig: (env: Record<string, string | undefined> = process.env) => {
+    const model = env.GBRAIN_EMBEDDING_MODEL || 'text-embedding-3-large';
+    const dimensions = Number.parseInt(env.GBRAIN_EMBEDDING_DIMENSIONS || '1536', 10);
+    if (!Number.isInteger(dimensions) || dimensions <= 0) {
+      throw new Error('GBRAIN_EMBEDDING_DIMENSIONS must be a positive integer');
+    }
+    const baseURL = env.GBRAIN_EMBEDDING_BASE_URL || undefined;
+    const isPerplexityConfig = model.toLowerCase().includes('pplx') || model.toLowerCase().includes('perplexity') || (baseURL?.toLowerCase().includes('perplexity') ?? false);
+    return {
+      model,
+      dimensions,
+      baseURL,
+      apiKey: env.GBRAIN_EMBEDDING_API_KEY
+        || (isPerplexityConfig ? (env.PERPLEXITY_API_KEY || env.PPLX_API_KEY) : undefined)
+        || env.OPENAI_API_KEY
+        || (baseURL ? 'not-needed' : undefined),
+    };
+  },
+  EMBEDDING_MODEL: 'text-embedding-3-large',
+  EMBEDDING_DIMENSIONS: 1536,
+  EMBEDDING_COST_PER_1K_TOKENS: 0.00013,
   embedBatch: async (texts: string[]) => {
     activeEmbedCalls++;
     totalEmbedCalls++;

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -16,15 +16,19 @@ mock.module('../src/core/embedding.ts', () => ({
       throw new Error('GBRAIN_EMBEDDING_DIMENSIONS must be a positive integer');
     }
     const baseURL = env.GBRAIN_EMBEDDING_BASE_URL || undefined;
-    const isPerplexityConfig = model.toLowerCase().includes('pplx') || model.toLowerCase().includes('perplexity') || (baseURL?.toLowerCase().includes('perplexity') ?? false);
+    const modelLower = model.toLowerCase();
+    const baseLower = baseURL?.toLowerCase() || '';
+    const isPerplexityConfig = modelLower.includes('pplx') || modelLower.includes('perplexity') || baseLower.includes('perplexity');
+    const isHostedPerplexity = baseLower.includes('api.perplexity.ai') || modelLower.startsWith('pplx-embed-v1-');
     return {
       model,
       dimensions,
       baseURL,
       apiKey: env.GBRAIN_EMBEDDING_API_KEY
         || (isPerplexityConfig ? (env.PERPLEXITY_API_KEY || env.PPLX_API_KEY) : undefined)
-        || env.OPENAI_API_KEY
-        || (baseURL ? 'not-needed' : undefined),
+        || (!isPerplexityConfig ? env.OPENAI_API_KEY : undefined)
+        || (baseURL && !isHostedPerplexity ? 'not-needed' : undefined),
+      provider: isHostedPerplexity ? 'perplexity-hosted' : 'openai-compatible',
     };
   },
   EMBEDDING_MODEL: 'text-embedding-3-large',

--- a/test/embedding-config.test.ts
+++ b/test/embedding-config.test.ts
@@ -7,6 +7,8 @@ const ENV_KEYS = [
   'GBRAIN_EMBEDDING_BASE_URL',
   'GBRAIN_EMBEDDING_API_KEY',
   'OPENAI_API_KEY',
+  'PERPLEXITY_API_KEY',
+  'PPLX_API_KEY',
 ];
 
 afterEach(() => {
@@ -21,6 +23,7 @@ describe('embedding configuration', () => {
     expect(config.dimensions).toBe(1536);
     expect(config.baseURL).toBeUndefined();
     expect(config.apiKey).toBeUndefined();
+    expect(config.provider).toBe('openai-compatible');
   });
 
   test('reads OpenAI-compatible model, dimensions, base URL, and key from env', () => {
@@ -53,6 +56,32 @@ describe('embedding configuration', () => {
     });
 
     expect(config.apiKey).toBe('pplx-key');
+    expect(config.provider).toBe('openai-compatible');
+  });
+
+  test('does not leak OPENAI_API_KEY into explicit Perplexity configs', () => {
+    const config = resolveEmbeddingConfig({
+      GBRAIN_EMBEDDING_MODEL: 'pplx-embed-v1-4b',
+      GBRAIN_EMBEDDING_BASE_URL: 'https://api.perplexity.ai/v1',
+      OPENAI_API_KEY: 'wrong-openai-key',
+    });
+
+    expect(config.apiKey).toBeUndefined();
+    expect(config.provider).toBe('perplexity-hosted');
+  });
+
+  test('detects hosted Perplexity endpoint with migrated key', () => {
+    const config = resolveEmbeddingConfig({
+      GBRAIN_EMBEDDING_MODEL: 'pplx-embed-v1-4b',
+      GBRAIN_EMBEDDING_DIMENSIONS: '2560',
+      GBRAIN_EMBEDDING_BASE_URL: 'https://api.perplexity.ai/v1',
+      PERPLEXITY_API_KEY: 'pplx-key',
+    });
+
+    expect(config.model).toBe('pplx-embed-v1-4b');
+    expect(config.dimensions).toBe(2560);
+    expect(config.apiKey).toBe('pplx-key');
+    expect(config.provider).toBe('perplexity-hosted');
   });
 
   test('uses a harmless placeholder key for local OpenAI-compatible base URLs', () => {

--- a/test/embedding-config.test.ts
+++ b/test/embedding-config.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { resolveEmbeddingConfig } from '../src/core/embedding.ts';
+
+const ENV_KEYS = [
+  'GBRAIN_EMBEDDING_MODEL',
+  'GBRAIN_EMBEDDING_DIMENSIONS',
+  'GBRAIN_EMBEDDING_BASE_URL',
+  'GBRAIN_EMBEDDING_API_KEY',
+  'OPENAI_API_KEY',
+];
+
+afterEach(() => {
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+describe('embedding configuration', () => {
+  test('defaults to OpenAI text-embedding-3-large at 1536 dimensions', () => {
+    const config = resolveEmbeddingConfig({});
+
+    expect(config.model).toBe('text-embedding-3-large');
+    expect(config.dimensions).toBe(1536);
+    expect(config.baseURL).toBeUndefined();
+    expect(config.apiKey).toBeUndefined();
+  });
+
+  test('reads OpenAI-compatible model, dimensions, base URL, and key from env', () => {
+    const config = resolveEmbeddingConfig({
+      GBRAIN_EMBEDDING_MODEL: 'custom-embed-model',
+      GBRAIN_EMBEDDING_DIMENSIONS: '768',
+      GBRAIN_EMBEDDING_BASE_URL: 'http://127.0.0.1:8790/v1',
+      GBRAIN_EMBEDDING_API_KEY: 'local-key',
+      OPENAI_API_KEY: 'wrong-key',
+    });
+
+    expect(config.model).toBe('custom-embed-model');
+    expect(config.dimensions).toBe(768);
+    expect(config.baseURL).toBe('http://127.0.0.1:8790/v1');
+    expect(config.apiKey).toBe('local-key');
+  });
+
+  test('falls back to OPENAI_API_KEY when no embedding-specific key is set', () => {
+    const config = resolveEmbeddingConfig({ OPENAI_API_KEY: 'openai-key' });
+
+    expect(config.apiKey).toBe('openai-key');
+  });
+
+  test('uses migrated Perplexity keys for explicit Perplexity embedding configs', () => {
+    const config = resolveEmbeddingConfig({
+      GBRAIN_EMBEDDING_MODEL: 'pplx-embed-context-v1-4b',
+      GBRAIN_EMBEDDING_BASE_URL: 'http://127.0.0.1:8790/v1',
+      PERPLEXITY_API_KEY: 'pplx-key',
+      OPENAI_API_KEY: 'wrong-openai-key',
+    });
+
+    expect(config.apiKey).toBe('pplx-key');
+  });
+
+  test('uses a harmless placeholder key for local OpenAI-compatible base URLs', () => {
+    const config = resolveEmbeddingConfig({
+      GBRAIN_EMBEDDING_BASE_URL: 'http://127.0.0.1:8790/v1',
+    });
+
+    expect(config.apiKey).toBe('not-needed');
+  });
+
+  test('rejects non-positive embedding dimensions', () => {
+    expect(() => resolveEmbeddingConfig({ GBRAIN_EMBEDDING_DIMENSIONS: '0' })).toThrow(
+      'GBRAIN_EMBEDDING_DIMENSIONS must be a positive integer',
+    );
+  });
+});

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const tempFiles: string[] = [];
+
+afterEach(() => {
+  for (const path of tempFiles.splice(0)) {
+    try { unlinkSync(path); } catch { /* best effort cleanup */ }
+  }
+});
+
+describe('OpenAI-compatible embedding providers', () => {
+  test('sends 2560-dim Perplexity config to a local OpenAI-compatible endpoint', () => {
+    const scriptPath = join(tmpdir(), `gbrain-embedding-provider-${Date.now()}-${Math.random().toString(16).slice(2)}.ts`);
+    tempFiles.push(scriptPath);
+    writeFileSync(scriptPath, `
+      import { serve } from 'bun';
+      import { embedBatch } from '${process.cwd()}/src/core/embedding.ts';
+
+      const dimensions = 2560;
+      let requestBody: any = null;
+      let authorization = '';
+      const server = serve({
+        port: 0,
+        async fetch(req) {
+          const url = new URL(req.url);
+          if (url.pathname !== '/v1/embeddings') return new Response('not found', { status: 404 });
+          authorization = req.headers.get('authorization') || '';
+          requestBody = await req.json();
+          const input = Array.isArray(requestBody.input) ? requestBody.input : [requestBody.input];
+          return Response.json({
+            object: 'list',
+            data: input.map((_text: string, index: number) => ({
+              object: 'embedding',
+              index,
+              embedding: Array.from({ length: dimensions }, (_unused, i) => (i === index ? 1 : 0)),
+            })),
+            model: requestBody.model,
+            usage: { prompt_tokens: input.length, total_tokens: input.length },
+          });
+        },
+      });
+
+      process.env.GBRAIN_EMBEDDING_MODEL = 'pplx-embed-context-v1-4b';
+      process.env.GBRAIN_EMBEDDING_DIMENSIONS = String(dimensions);
+      process.env.GBRAIN_EMBEDDING_BASE_URL = \`http://127.0.0.1:\${server.port}/v1\`;
+      process.env.PERPLEXITY_API_KEY = 'test-perplexity-key';
+      delete process.env.GBRAIN_EMBEDDING_API_KEY;
+      delete process.env.OPENAI_API_KEY;
+
+      try {
+        const embeddings = await embedBatch(['alpha', 'beta']);
+        console.log(JSON.stringify({
+          requestBody,
+          authorization,
+          length0: embeddings[0]?.length,
+          length1: embeddings[1]?.length,
+          isFloat32: embeddings[0] instanceof Float32Array,
+        }));
+      } finally {
+        server.stop(true);
+      }
+    `);
+
+    const result = Bun.spawnSync({
+      cmd: ['bun', scriptPath],
+      cwd: process.cwd(),
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env },
+    });
+
+    expect(result.exitCode).toBe(0);
+    const output = new TextDecoder().decode(result.stdout).trim();
+    const stderr = new TextDecoder().decode(result.stderr).trim();
+    expect(stderr).toBe('');
+    const parsed = JSON.parse(output);
+
+    expect(parsed.requestBody.model).toBe('pplx-embed-context-v1-4b');
+    expect(parsed.requestBody.dimensions).toBe(2560);
+    expect(parsed.requestBody.encoding_format).toBe('float');
+    expect(parsed.requestBody.input).toEqual(['alpha', 'beta']);
+    expect(parsed.authorization).toBe('Bearer test-perplexity-key');
+    expect(parsed.isFloat32).toBe(true);
+    expect(parsed.length0).toBe(2560);
+    expect(parsed.length1).toBe(2560);
+  });
+});

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -87,4 +87,66 @@ describe('OpenAI-compatible embedding providers', () => {
     expect(parsed.length0).toBe(2560);
     expect(parsed.length1).toBe(2560);
   });
+
+  test('decodes hosted Perplexity base64_int8 embeddings', () => {
+    const scriptPath = join(tmpdir(), `gbrain-hosted-perplexity-${Date.now()}-${Math.random().toString(16).slice(2)}.ts`);
+    tempFiles.push(scriptPath);
+    writeFileSync(scriptPath, `
+      import { serve } from 'bun';
+      import { embedBatch } from '${process.cwd()}/src/core/embedding.ts';
+
+      const dimensions = 4;
+      let requestBody: any = null;
+      const raw = Int8Array.from([-2, -1, 0, 127]);
+      const encoded = Buffer.from(raw.buffer).toString('base64');
+      const server = serve({
+        port: 0,
+        async fetch(req) {
+          const url = new URL(req.url);
+          if (url.pathname !== '/v1/embeddings') return new Response('not found', { status: 404 });
+          requestBody = await req.json();
+          const input = Array.isArray(requestBody.input) ? requestBody.input : [requestBody.input];
+          return Response.json({
+            object: 'list',
+            data: input.map((_text: string, index: number) => ({ object: 'embedding', index, embedding: encoded })),
+            model: requestBody.model,
+            usage: { prompt_tokens: input.length, total_tokens: input.length },
+          });
+        },
+      });
+
+      process.env.GBRAIN_EMBEDDING_MODEL = 'pplx-embed-v1-4b';
+      process.env.GBRAIN_EMBEDDING_DIMENSIONS = String(dimensions);
+      process.env.GBRAIN_EMBEDDING_BASE_URL = \`http://127.0.0.1:\${server.port}/v1\`;
+      process.env.PERPLEXITY_API_KEY = 'test-perplexity-key';
+      delete process.env.GBRAIN_EMBEDDING_API_KEY;
+      delete process.env.OPENAI_API_KEY;
+
+      try {
+        const embeddings = await embedBatch(['alpha']);
+        console.log(JSON.stringify({ requestBody, values: Array.from(embeddings[0]) }));
+      } finally {
+        server.stop(true);
+      }
+    `);
+
+    const result = Bun.spawnSync({
+      cmd: ['bun', scriptPath],
+      cwd: process.cwd(),
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { ...process.env },
+    });
+
+    expect(result.exitCode).toBe(0);
+    const output = new TextDecoder().decode(result.stdout).trim();
+    const stderr = new TextDecoder().decode(result.stderr).trim();
+    expect(stderr).toBe('');
+    const parsed = JSON.parse(output);
+
+    expect(parsed.requestBody.model).toBe('pplx-embed-v1-4b');
+    expect(parsed.requestBody.dimensions).toBe(4);
+    expect(parsed.requestBody.encoding_format).toBe('base64_int8');
+    expect(parsed.values).toEqual([-2, -1, 0, 127]);
+  });
 });

--- a/test/pglite-embedding-config.test.ts
+++ b/test/pglite-embedding-config.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+
+const ENV_KEYS = [
+  'GBRAIN_EMBEDDING_MODEL',
+  'GBRAIN_EMBEDDING_DIMENSIONS',
+  'GBRAIN_EMBEDDING_BASE_URL',
+  'GBRAIN_EMBEDDING_API_KEY',
+];
+
+afterEach(() => {
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+function basis(dim: number): Float32Array {
+  const v = new Float32Array(dim);
+  v[0] = 1;
+  return v;
+}
+
+describe('PGLite embedding dimension configuration', () => {
+  test('initializes a 2560-dimension Perplexity brain without HNSW index', async () => {
+    process.env.GBRAIN_EMBEDDING_MODEL = 'pplx-embed-context-v1-4b';
+    process.env.GBRAIN_EMBEDDING_DIMENSIONS = '2560';
+    process.env.GBRAIN_EMBEDDING_BASE_URL = 'http://127.0.0.1:8790/v1';
+
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    try {
+      await engine.initSchema();
+
+      const typeRows = await (engine as any).db.query(
+        `SELECT format_type(a.atttypid, a.atttypmod) AS typ
+           FROM pg_attribute a
+           JOIN pg_class c ON c.oid = a.attrelid
+          WHERE c.relname = 'content_chunks'
+            AND a.attname = 'embedding'
+            AND NOT a.attisdropped`,
+      );
+      expect(typeRows.rows[0].typ).toBe('vector(2560)');
+
+      const indexRows = await (engine as any).db.query(
+        `SELECT indexname FROM pg_indexes WHERE tablename = 'content_chunks' AND indexname = 'idx_chunks_embedding'`,
+      );
+      expect(indexRows.rows).toHaveLength(0);
+
+      const configRows = await (engine as any).db.query(
+        `SELECT key, value FROM config WHERE key IN ('embedding_model', 'embedding_dimensions', 'embedding_base_url')`,
+      );
+      const config = Object.fromEntries(configRows.rows.map((r: any) => [r.key, r.value]));
+      expect(config.embedding_model).toBe('pplx-embed-context-v1-4b');
+      expect(config.embedding_dimensions).toBe('2560');
+      expect(config.embedding_base_url).toBe('http://127.0.0.1:8790/v1');
+
+      await engine.putPage('perplexity/test', {
+        type: 'concept',
+        title: 'Perplexity Test',
+        compiled_truth: 'Perplexity embeddings are 2560 dimensional.',
+      });
+      await engine.upsertChunks('perplexity/test', [{
+        chunk_index: 0,
+        chunk_text: 'Perplexity embeddings are 2560 dimensional.',
+        chunk_source: 'compiled_truth',
+        embedding: basis(2560),
+        model: 'pplx-embed-context-v1-4b',
+        token_count: 8,
+      }]);
+
+      const results = await engine.searchVector(basis(2560), { limit: 5 });
+      expect(results[0]?.slug).toBe('perplexity/test');
+    } finally {
+      await engine.disconnect();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- supports hosted Perplexity embedding configs without falling back to `OPENAI_API_KEY`
- requests and decodes hosted Perplexity `base64_int8` embeddings
- stores/searches >2000-dimensional embeddings as `halfvec` with the matching HNSW opclass
- adds regression coverage for config resolution, hosted Perplexity decoding, and stale embed behavior

Closes #1046
Related #771

## Test Plan
- `bun run typecheck` ✅
- `bun test test/embedding-config.test.ts test/embedding-provider.test.ts test/embed.test.ts` ✅ — 21 pass
- `bun test` attempted locally; suite progressed through broad unit coverage but hit the 600s local timeout while running `test/minions-shell.test.ts`, not a reported assertion failure. CI should run the full suite in a clean runner.
