### PR TITLE
fix(operations): add items to extract_facts.entity_hints array schema

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2696,7 +2696,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },


### PR DESCRIPTION
## What

One-line fix in `src/core/operations.ts:2699`. The `entity_hints` parameter on `extract_facts` is declared as `{ type: 'array' }` without an `items` field. Add `items: { type: 'string' }`.

## Why

JSON Schema requires `items` on every `array` type, and as of early 2026 OpenAI's tool-validation pipeline enforces this. Sending the gbrain MCP tool list to a Codex / OpenAI-backed agent returns HTTP 400 at session start:

```
Invalid schema for function 'mcp_gbrain_extract_facts':
In context=('properties', 'entity_hints'), array schema missing items.
```

Because the validation runs against the **entire** tool list at the start of every session, the agent can't make **any** tool call until the schema is corrected — not just `extract_facts`. Every agent in a fleet running gbrain + Codex hits this together.

## Verifying the correct shape

Line 2733 in the same operation handler already casts the parameter to `string[]`:

```ts
entityHints: Array.isArray(p.entity_hints) ? (p.entity_hints as string[]) : undefined,
```

So `items: { type: 'string' }` is the annotation that matches the existing runtime contract — no behavior change, just truthful schema.

## Test

The bug reproduces against any agent runtime that forwards the gbrain MCP tool list to OpenAI's tool-validation endpoint (Codex CLI, ChatGPT desktop, anything Hermes-shaped on the openai-codex provider). Post-fix the same flow validates cleanly. No new test added in this PR — the existing `test/parity.test.ts` covers tool-shape parity, but the JSON-Schema-strictness check is downstream-validator-specific.

## Diff

```diff
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
```

Caught while running gbrain v0.35.0.0 against a Codex-backed Hermes fleet. Thanks for gbrain — it's load-bearing for us.

From the team at BoxNCase.