### PR TITLE
fix(doctor): only count non-zero exit codes as worker crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ export/
 # Tier 3 PGLite snapshot fixture (built on demand by build:pglite-snapshot)
 test/fixtures/pglite-snapshot.tar
 test/fixtures/pglite-snapshot.version
+ze-*.ts
+embedding-benchmark.ts
+reports/

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1010,7 +1010,10 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
 
     const events = readSupervisorEvents({ sinceMs: 24 * 60 * 60 * 1000 });
     const lastStart = events.filter(e => e.event === 'started').pop()?.ts ?? null;
-    const crashes24h = events.filter(e => e.event === 'worker_exited').length;
+    const allExits = events.filter(e => e.event === 'worker_exited');
+    // Only count non-zero exit codes as crashes. Code 0 = clean shutdown/drain.
+    const crashes24h = allExits.filter(e => e.code !== 0 && e.code !== undefined).length;
+    const cleanExits24h = allExits.length - crashes24h;
     const maxCrashesEvent = events.filter(e => e.event === 'max_crashes_exceeded').pop() ?? null;
 
     // Only surface a Check if the supervisor was ever observed (stops the
@@ -1032,13 +1035,13 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
         checks.push({
           name: 'supervisor',
           status: 'warn',
-          message: `Supervisor running but worker crashed ${crashes24h}x in last 24h. Check ~/.gbrain/audit/supervisor-*.jsonl for causes.`,
+          message: `Supervisor running but worker crashed ${crashes24h}x in last 24h (${cleanExits24h} clean exits filtered). Check ~/.gbrain/audit/supervisor-*.jsonl for causes.`,
         });
       } else {
         checks.push({
           name: 'supervisor',
           status: 'ok',
-          message: `running=true pid=${supervisorPid} last_start=${lastStart ?? 'unknown'} crashes_24h=${crashes24h}`,
+          message: `running=true pid=${supervisorPid} last_start=${lastStart ?? 'unknown'} crashes_24h=${crashes24h} clean_exits_24h=${cleanExits24h}`,
         });
       }
     }


### PR DESCRIPTION
## Problem

The doctor's supervisor health check counts ALL `worker_exited` audit events as crashes, including code=0 clean exits (drain after queue empty, health-check restart, etc.). This inflates the crash count to 100+ per day when the actual crash count is 0.

PR #1002 already fixed the supervisor's own crash counting (`crashCount = 0` for code=0). This patch applies the same logic to the doctor's independent audit-log probe.

## Fix

- Filter `worker_exited` events by exit code: only `code !== 0` counts as a crash
- Show clean exit count separately in status message for visibility
- Crash threshold (>3) now only applies to real crashes

## Evidence

Production audit log shows 102 `worker_exited` events in 24h, ALL with `code: 0`. Doctor reports "102 crashes" when actual crashes = 0.

```
worker_exited { code: 0, signal: null, crash_count: 0, reason: "code 0" }
```

Companion to PR #1002 (supervisor side) and PR #1004 (RSS accuracy).