### PR TITLE
fix: include items field in array param schemas for HTTP MCP server

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -818,6 +818,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
                 description: v.description,
                 ...(v.enum ? { enum: v.enum } : {}),
                 ...(v.default !== undefined ? { default: v.default } : {}),
+                ...(v.items ? { items: { type: v.items.type } } : {}),
               }]),
             ),
             required: Object.entries(op.params).filter(([, v]) => v.required).map(([k]) => k),

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2393,7 +2393,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },


### PR DESCRIPTION
## Problem

The HTTP MCP server (`serve-http.ts`) has its own inline schema builder that spreads `enum` and `default` from param definitions but omits `items`. This causes OpenAI-strict clients (gpt-4o, etc.) to reject `tools/list` with:

```
400 Invalid schema for function 'gbrain__extract_facts': In context=(properties', 'entity_hints'), array schema missing items.
```

The agent fails on every turn and surfaces an error to the user.

## Root cause

Two issues:

1. `serve-http.ts` inline schema builder does not spread `v.items` (unlike `tool-defs.ts` which handles it correctly)
2. The `entity_hints` param in `operations.ts` was missing `items` entirely

## Fix

- `serve-http.ts`: add `...(v.items ? { items: { type: v.items.type } } : {})` to the inline property mapper — matches the existing pattern for `enum` and `default`
- `operations.ts`: add `items: { type: 'string' }` to `entity_hints`

## Tested

Verified fix against GBrain HTTP MCP server connected to OpenClaw with gpt-4o. `tools/list` accepted, agent responds successfully.