### PR TITLE
fix: return success for migration list commands

### DIFF
--- a/src/commands/apply-migrations.ts
+++ b/src/commands/apply-migrations.ts
@@ -328,13 +328,13 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
     process.exit(2);
   }
 
-  if (cli.list) { printList(plan, installed); return; }
-  if (cli.dryRun) { printDryRun(plan, installed); return; }
+  if (cli.list) { printList(plan, installed); process.exit(0); }
+  if (cli.dryRun) { printDryRun(plan, installed); process.exit(0); }
 
   const toRun: Migration[] = [...plan.partial, ...plan.pending];
   if (toRun.length === 0) {
     console.log('All migrations up to date.');
-    return;
+    process.exit(0);
   }
 
   // Run each orchestrator in registry order. An orchestrator failure aborts


### PR DESCRIPTION
## Summary
- Make apply-migrations --list exit 0 after printing an up-to-date migration list
- Make --dry-run and no-op success paths exit 0 explicitly
- Fixes skillpack-check falsely reporting apply-migrations failure when migrations are already applied

## Verification
- gbrain apply-migrations --list exits successfully
- gbrain skillpack-check reports healthy: true locally