### PR TITLE
feat(doctor): child-table orphan detection (closes #1063)

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -193,6 +193,97 @@ export async function takesWeightGridCheck(engine: BrainEngine): Promise<Check> 
   }
 }
 
+/**
+ * Child-table orphan detection (closes #1063).
+ *
+ * The autopilot `orphans` phase (src/core/cycle.ts:runPhaseOrphans) detects
+ * orphan PAGES (pages with no inbound links via the page-graph). It does NOT
+ * scan FK-child tables for orphan rows. When a bulk page delete leaves
+ * orphans in `content_chunks` / `page_versions` / `tags` / `takes` / etc.
+ * — whether from pre-FK migrations, race conditions, or a code path that
+ * bypassed cascade — they persist indefinitely until manual SQL cleanup.
+ *
+ * All ten FK-to-pages tables declare `ON DELETE CASCADE` in the live schema
+ * (verified via `pg_constraint` snapshot in the issue body), so finding any
+ * orphan row is by definition unexpected. The check ships paste-ready
+ * cleanup SQL when orphans surface.
+ *
+ * Excluded: `files.page_id` and `links.origin_page_id` — both declared as
+ * `ON DELETE SET NULL`, so a NULL value is a valid state (file/link survives
+ * after page deletion); only NOT-NULL-but-page-missing is an orphan there.
+ * The check encodes that distinction for the two SET NULL columns.
+ *
+ * Pure helper for parity with `takesWeightGridCheck` so tests can target it
+ * directly without driving the full `runDoctor` pipeline.
+ */
+export async function childTableOrphansCheck(engine: BrainEngine): Promise<Check> {
+  // (table, fk_column, allow_null). When allow_null=true, NULL is a valid
+  // state (FK was declared ON DELETE SET NULL); the orphan predicate filters
+  // out NULL values. When false, NULL is impossible by NOT NULL constraint;
+  // any value not in pages.id is an orphan.
+  const targets: Array<{ table: string; col: string; allowNull: boolean }> = [
+    { table: 'content_chunks',   col: 'page_id',          allowNull: false },
+    { table: 'page_versions',    col: 'page_id',          allowNull: false },
+    { table: 'tags',             col: 'page_id',          allowNull: false },
+    { table: 'takes',            col: 'page_id',          allowNull: false },
+    { table: 'raw_data',         col: 'page_id',          allowNull: false },
+    { table: 'timeline_entries', col: 'page_id',          allowNull: false },
+    { table: 'links',            col: 'from_page_id',     allowNull: false },
+    { table: 'links',            col: 'to_page_id',       allowNull: false },
+    { table: 'links',            col: 'origin_page_id',   allowNull: true  },
+    { table: 'files',            col: 'page_id',          allowNull: true  },
+  ];
+  let totalOrphans = 0;
+  const breakdown: string[] = [];
+  const cleanupSql: string[] = [];
+  const errors: string[] = [];
+  for (const { table, col, allowNull } of targets) {
+    try {
+      // NOT IN subquery is portable across postgres + PGLite. The `pages.id`
+      // subquery covers every existing parent row.
+      const nullFilter = allowNull ? `${col} IS NOT NULL AND ` : '';
+      const rows = await engine.executeRaw<{ n: string | number }>(
+        `SELECT COUNT(*)::int AS n FROM ${table} WHERE ${nullFilter}${col} NOT IN (SELECT id FROM pages)`,
+      );
+      const n = Number(rows[0]?.n ?? 0);
+      if (n > 0) {
+        totalOrphans += n;
+        breakdown.push(`${table}.${col}=${n}`);
+        cleanupSql.push(
+          `DELETE FROM ${table} WHERE ${nullFilter}${col} NOT IN (SELECT id FROM pages);`,
+        );
+      }
+    } catch (e) {
+      // Table or column may not exist on older schemas — skip and continue.
+      // Aggregate the errors so doctor surfaces "could not check N tables"
+      // when a real failure shape appears (network, lock, syntax).
+      const msg = e instanceof Error ? e.message : String(e);
+      errors.push(`${table}.${col}: ${msg.slice(0, 80)}`);
+    }
+  }
+  if (totalOrphans === 0 && errors.length === 0) {
+    return {
+      name: 'child_table_orphans',
+      status: 'ok',
+      message: 'All FK-child tables clean (10 tables checked)',
+    };
+  }
+  if (totalOrphans === 0 && errors.length > 0) {
+    return {
+      name: 'child_table_orphans',
+      status: 'warn',
+      message: `Could not check ${errors.length}/10 FK-child tables (older schema or transient error): ${errors.slice(0, 3).join('; ')}`,
+    };
+  }
+  return {
+    name: 'child_table_orphans',
+    status: 'warn',
+    message:
+      `${totalOrphans} orphan row(s) in FK-child tables (${breakdown.join(', ')}). ` +
+      `Cleanup: ${cleanupSql.join(' ')}`,
+  };
+}
+
 export async function doctorReportRemote(engine: BrainEngine): Promise<DoctorReport> {
   const checks: Check[] = [];
 
@@ -1747,6 +1838,15 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
   // directly rather than the full `runDoctor` pipeline (codex review #7).
   progress.heartbeat('takes_weight_grid');
   checks.push(await takesWeightGridCheck(engine));
+
+  // 10c. Child-table orphan detection (closes #1063).
+  // The autopilot `orphans` phase scans for orphan pages (no inbound links)
+  // but does NOT detect orphan rows in FK-child tables. After a bulk page
+  // delete, child rows can persist if cascade didn't fire (pre-FK rows,
+  // race during bulk cascade, code path that bypassed cascade). This
+  // surfaces them with paste-ready cleanup SQL.
+  progress.heartbeat('child_table_orphans');
+  checks.push(await childTableOrphansCheck(engine));
 
   // v0.33: whoknows_health — fixture presence + row count. The eval
   // gate itself runs via `gbrain eval whoknows`; this check is the

--- a/test/doctor-child-orphans.test.ts
+++ b/test/doctor-child-orphans.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Test: `childTableOrphansCheck` (closes #1063).
+ *
+ * Pure-helper test surface — the check function only consumes `engine.executeRaw`,
+ * so a structurally-typed mock satisfies the contract. This is faster and more
+ * focused than spinning up real PGLite, AND it doesn't require disabling FK
+ * constraints to seed orphans (which PGLite blocks at INSERT time anyway via
+ * the normal FK trigger).
+ *
+ * 10 FK-child tables checked. Six have NOT NULL FKs (orphan = any value not in
+ * pages.id). Four — wait, two — have nullable FKs (`files.page_id`, `links.origin_page_id`
+ * declared ON DELETE SET NULL); orphan check skips NULL via the `IS NOT NULL` filter.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { childTableOrphansCheck } from '../src/commands/doctor.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+/** Build a structurally-typed BrainEngine whose executeRaw returns per-SQL results. */
+function makeMockEngine(handler: (sql: string) => Promise<unknown[]>): BrainEngine {
+  return {
+    executeRaw: handler,
+  } as unknown as BrainEngine;
+}
+
+describe('childTableOrphansCheck (#1063)', () => {
+  test('all clean → status:ok with "10 tables checked"', async () => {
+    const engine = makeMockEngine(async () => [{ n: 0 }]);
+    const result = await childTableOrphansCheck(engine);
+    expect(result.name).toBe('child_table_orphans');
+    expect(result.status).toBe('ok');
+    expect(result.message).toContain('10 tables checked');
+  });
+
+  test('one orphan in content_chunks → status:warn with paste-ready cleanup SQL', async () => {
+    const engine = makeMockEngine(async (sql: string) => {
+      if (sql.includes('content_chunks')) return [{ n: 5 }];
+      return [{ n: 0 }];
+    });
+    const result = await childTableOrphansCheck(engine);
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('5 orphan row(s)');
+    expect(result.message).toContain('content_chunks.page_id=5');
+    expect(result.message).toContain('DELETE FROM content_chunks WHERE page_id NOT IN (SELECT id FROM pages)');
+  });
+
+  test('orphans in multiple tables → aggregated breakdown + multi-line cleanup', async () => {
+    const engine = makeMockEngine(async (sql: string) => {
+      if (sql.includes('content_chunks')) return [{ n: 234 }];
+      if (sql.includes('page_versions')) return [{ n: 12 }];
+      if (sql.includes('FROM tags')) return [{ n: 3 }];
+      return [{ n: 0 }];
+    });
+    const result = await childTableOrphansCheck(engine);
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('249 orphan row(s)'); // 234 + 12 + 3
+    expect(result.message).toContain('content_chunks.page_id=234');
+    expect(result.message).toContain('page_versions.page_id=12');
+    expect(result.message).toContain('tags.page_id=3');
+    expect(result.message).toContain('DELETE FROM content_chunks');
+    expect(result.message).toContain('DELETE FROM page_versions');
+    expect(result.message).toContain('DELETE FROM tags');
+  });
+
+  test('nullable FK (files.page_id, links.origin_page_id) filters IS NOT NULL', async () => {
+    // Capture the actual SQL strings issued so we can pin the filter behavior
+    const capturedSql: string[] = [];
+    const engine = makeMockEngine(async (sql: string) => {
+      capturedSql.push(sql);
+      return [{ n: 0 }];
+    });
+    await childTableOrphansCheck(engine);
+    // The nullable-FK tables MUST have `IS NOT NULL AND` in their predicate
+    // (NULL is a valid SET NULL outcome, not an orphan).
+    const filesSql = capturedSql.find((s) => s.includes('FROM files WHERE'));
+    expect(filesSql).toBeDefined();
+    expect(filesSql!).toContain('page_id IS NOT NULL AND page_id NOT IN');
+    const linksOrigSql = capturedSql.find((s) => s.includes('FROM links WHERE') && s.includes('origin_page_id'));
+    expect(linksOrigSql).toBeDefined();
+    expect(linksOrigSql!).toContain('origin_page_id IS NOT NULL AND origin_page_id NOT IN');
+    // NOT-NULL FK tables MUST NOT have the IS NOT NULL filter (it'd be redundant)
+    const ccSql = capturedSql.find((s) => s.includes('FROM content_chunks WHERE'));
+    expect(ccSql).toBeDefined();
+    expect(ccSql!).not.toContain('IS NOT NULL');
+  });
+
+  test('executeRaw throws on N tables → warn with error summary, no false-ok', async () => {
+    // Simulate older schema where some tables don't exist (pre-v0.34 ish).
+    // The check must not return "ok" when it couldn't actually check.
+    const engine = makeMockEngine(async (sql: string) => {
+      if (sql.includes('synthesis_evidence') || sql.includes('timeline_entries')) {
+        throw new Error('relation does not exist');
+      }
+      return [{ n: 0 }];
+    });
+    const result = await childTableOrphansCheck(engine);
+    // synthesis_evidence isn't in the target list (it FKs synthesis_page_id, not page_id)
+    // — but timeline_entries IS. So one error in this test.
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('Could not check');
+    expect(result.message).toContain('FK-child tables');
+  });
+
+  test('orphans + some skipped tables → still reports orphans (errors don\'t mask findings)', async () => {
+    // Mixed case: real orphans in one table, older schema missing another.
+    // The check should report the real orphans, not get overridden by the
+    // "could not check" warning shape.
+    const engine = makeMockEngine(async (sql: string) => {
+      if (sql.includes('content_chunks')) return [{ n: 234 }];
+      if (sql.includes('timeline_entries')) throw new Error('relation does not exist');
+      return [{ n: 0 }];
+    });
+    const result = await childTableOrphansCheck(engine);
+    expect(result.status).toBe('warn');
+    // The orphan branch wins over the error-only branch when both exist
+    expect(result.message).toContain('234 orphan row(s)');
+    expect(result.message).toContain('content_chunks.page_id=234');
+  });
+
+  test('all 10 target tables are queried (no silent drops)', async () => {
+    const queriedTables = new Set<string>();
+    const engine = makeMockEngine(async (sql: string) => {
+      // Extract `FROM <table>` to verify every target gets visited
+      const m = sql.match(/FROM (\w+) WHERE/);
+      if (m) queriedTables.add(m[1]);
+      return [{ n: 0 }];
+    });
+    await childTableOrphansCheck(engine);
+    // 10 target rows, but links appears 3 times (from/to/origin) — so 8 unique tables
+    const expectedTables = new Set([
+      'content_chunks',
+      'page_versions',
+      'tags',
+      'takes',
+      'raw_data',
+      'timeline_entries',
+      'links',
+      'files',
+    ]);
+    expect(queriedTables.size).toBe(expectedTables.size);
+    for (const t of expectedTables) {
+      expect(queriedTables.has(t)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`gbrain doctor` now surfaces orphan rows in FK-child tables (`content_chunks`, `page_versions`, `tags`, `takes`, `raw_data`, `timeline_entries`, `links`, `files`). Before this PR, the autopilot `orphans` phase only detected orphan PAGES; orphan child rows persisted indefinitely after a bulk page delete that bypassed cascade, until manual SQL cleanup.

Closes #1063.

## Why

All ten FK-to-pages columns declare `ON DELETE CASCADE` in live schema — so any orphan row is unexpected by definition. But pre-FK historical rows, races during large cascade batches, or code paths that bypass cascade can leave child orphans that the existing `orphans` phase (page-graph only) and `find_orphans` MCP op don't catch.

Discovered after a real bulk `sources_remove default --confirm-destructive` left 234 orphan `content_chunks` rows on a real brain. Live FK constraint verified correct via `pg_constraint`:

```
content_chunks: FOREIGN KEY (page_id) REFERENCES pages(id) ON DELETE CASCADE
page_versions:  FOREIGN KEY (page_id) REFERENCES pages(id) ON DELETE CASCADE
takes:          FOREIGN KEY (page_id) REFERENCES pages(id) ON DELETE CASCADE
... (10 total)
```

Cascade SHOULD have fired. It didn't. Without a doctor check, the orphans would have sat unnoticed for weeks (or forever).

## What

New `childTableOrphansCheck(engine: BrainEngine): Promise<Check>` helper in `src/commands/doctor.ts`, modeled after `takesWeightGridCheck` and the `jsonb_integrity` pattern:

- Scans 8 unique tables (10 FK-column slots; `links` has 3 FKs to pages)
- Two FKs declared `ON DELETE SET NULL` (`files.page_id`, `links.origin_page_id`) — NULL is a valid post-cascade state there, so the orphan predicate filters `IS NOT NULL AND col NOT IN (SELECT id FROM pages)` for those
- Per-table failure (older schema missing a table) is captured into a `warn` with "Could not check N/10 tables" — NEVER silently masked as `ok`
- Surfaces paste-ready cleanup SQL for every table that has orphans

## Sample output

Clean brain:
```
[ok] child_table_orphans: All FK-child tables clean (10 tables checked)
```

Brain with orphans:
```
[warn] child_table_orphans: 234 orphan row(s) in FK-child tables (content_chunks.page_id=234).
Cleanup: DELETE FROM content_chunks WHERE page_id NOT IN (SELECT id FROM pages);
```

## Tests

`test/doctor-child-orphans.test.ts` — 7 cases (36 expect calls) covering:

1. All clean → status:ok with "10 tables checked"
2. One orphan in content_chunks → status:warn with paste-ready cleanup SQL
3. Multi-table orphans → aggregated breakdown + per-table cleanup
4. Nullable-FK tables filter `IS NOT NULL` (regression guard)
5. `executeRaw` throws on older schemas → warn (no false-ok)
6. Orphans + skipped tables together → orphans branch wins (not masked)
7. All 8 unique target tables get queried (no silent drops)

Structurally-typed `BrainEngine` mock (no `mock.module`, no `*.serial.test.ts` rename) — the check's logic gets exercised cleanly. The full `gbrain doctor` integration with a live engine is covered by the existing 39 cases in `test/doctor.test.ts` (re-ran, all pass).

## Verification

- `bun run typecheck` — clean
- `bun run verify` — clean
- `bun test test/doctor-child-orphans.test.ts` — 7 pass, 0 fail
- `bun test test/doctor.test.ts` — 39 pass, 0 fail (the new check fires `ok` on the clean fixture brain)

## Reviewer notes

The check is read-only — no auto-repair. The fix-hint message gives paste-ready cleanup SQL but the user runs it. Reasoning: bulk DELETEs against a brain database are not the kind of thing doctor should auto-fire even with `--fix`. Operators should see the orphan counts, decide whether they're expected, and run the cleanup themselves. Same posture as `jsonb_integrity` (which points at `gbrain repair-jsonb` but doesn't auto-call it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)