### PR TITLE
fix(tests): raise per-shard cap 600s → 1200s + rename WEDGED → OVERTIME

### DIFF
--- a/scripts/run-unit-parallel.sh
+++ b/scripts/run-unit-parallel.sh
@@ -13,7 +13,11 @@
 #
 # Env overrides:
 #   SHARDS=N                     same as --shards
-#   GBRAIN_TEST_SHARD_TIMEOUT    per-shard wallclock cap, seconds (default 600)
+#   GBRAIN_TEST_SHARD_TIMEOUT    per-shard wallclock cap, seconds (default 1200).
+#                                Raised from 600s in 2026-05-16 — the suite legitimately
+#                                takes 700-900s per shard on the heaviest 2 of 4 by
+#                                stable-hash distribution (verified on Apple M-series).
+#                                The 600s default silently marked clean runs as OVERTIME.
 #   GBRAIN_TEST_MAX_CONCURRENCY  passed through to bun test (default 4)
 #
 # Output files (workspace-local; falls back to /tmp if .context/ unwritable):
@@ -61,7 +65,7 @@ fi
 [ "$N" -gt 8 ] && N=8
 
 INTRA_CONC="${MAX_CONCURRENCY_OVERRIDE:-${GBRAIN_TEST_MAX_CONCURRENCY:-4}}"
-SHARD_TIMEOUT="${GBRAIN_TEST_SHARD_TIMEOUT:-600}"
+SHARD_TIMEOUT="${GBRAIN_TEST_SHARD_TIMEOUT:-1200}"
 
 # ──────────────────────────────────────────────────────────────────────────
 # Output directories. Prefer workspace-local .context/, fall back to /tmp.
@@ -78,7 +82,7 @@ else
   mkdir -p "$LOG_DIR" || { echo "ERROR: cannot create log dir" >&2; exit 2; }
 fi
 # Clear from prior run.
-rm -f "$LOG_DIR"/shard-*.log "$LOG_DIR"/shard-*.exit "$LOG_DIR"/shard-*.wedged 2>/dev/null
+rm -f "$LOG_DIR"/shard-*.log "$LOG_DIR"/shard-*.exit "$LOG_DIR"/shard-*.overtime 2>/dev/null
 : > "$FAILURES_LOG"
 : > "$SUMMARY_FILE"
 
@@ -130,7 +134,7 @@ for i in $(seq 1 "$N"); do
     fi
     rc=$?
     echo "$rc" > "$LOG_DIR/shard-$i.exit"
-    [ "$rc" = "124" ] && echo "WEDGED" > "$LOG_DIR/shard-$i.wedged"
+    [ "$rc" = "124" ] && echo "OVERTIME" > "$LOG_DIR/shard-$i.overtime"
   ) &
   SHARD_PIDS+=($!)
 done
@@ -215,7 +219,7 @@ TOTAL_RC=0
 for i in $(seq 1 "$N"); do
   SHARD_LOG="$LOG_DIR/shard-$i.log"
   EXIT_FILE="$LOG_DIR/shard-$i.exit"
-  WEDGED_FILE="$LOG_DIR/shard-$i.wedged"
+  OVERTIME_FILE="$LOG_DIR/shard-$i.overtime"
   rc=1
   [ -f "$EXIT_FILE" ] && rc=$(cat "$EXIT_FILE" 2>/dev/null || echo 1)
 
@@ -226,14 +230,14 @@ for i in $(seq 1 "$N"); do
   TOTAL_FAILURES=$((TOTAL_FAILURES + fail_count))
   TOTAL_SKIP=$((TOTAL_SKIP + skip_count))
 
-  if [ -f "$WEDGED_FILE" ]; then
+  if [ -f "$OVERTIME_FILE" ]; then
     TOTAL_RC=1
     {
-      echo "--- shard $i: WEDGED after ${SHARD_TIMEOUT}s ---"
+      echo "--- shard $i: OVERTIME after ${SHARD_TIMEOUT}s (shard did not finish within cap; partial output below) ---"
       [ -f "$SHARD_LOG" ] && tail -50 "$SHARD_LOG"
       echo ""
     } >> "$FAILURES_LOG"
-    echo "shard $i/$N: WEDGED after ${SHARD_TIMEOUT}s (rc=$rc)" >> "$SUMMARY_FILE"
+    echo "shard $i/$N: OVERTIME after ${SHARD_TIMEOUT}s (rc=$rc)" >> "$SUMMARY_FILE"
     continue
   fi
 


### PR DESCRIPTION
## Summary

The 4-shard parallel unit test runner's per-shard wallclock cap (`GBRAIN_TEST_SHARD_TIMEOUT`) defaults to 600s. The suite has grown past that. Two of four shards routinely exceed 600s on clean passes and get marked \"WEDGED\" — a label that implies the run hung, when actually it just took longer than the cap allowed.

Verified on a fresh Apple M-series box, 2026-05-16:

| Shard | Wallclock | Tests | Status |
|---|---|---|---|
| 1 | 700.65s | 1256 pass / 0 fail | clean, past cap |
| 3 | 856.25s | 1875 pass / 0 fail | clean, past cap |

Both shards complete normally. The 600s default is what's wrong.

## Why

Two problems:

1. **The cap is too tight.** Setting it to 1200s gives ~40% headroom above shard 3's current 856s peak.
2. **The label \"WEDGED\" is misleading.** When the runner kills a shard at the cap, it writes \"WEDGED\" to a sentinel file and prints \"WEDGED after Ns\" in the banner. That word strongly implies the shard hung — which sends every reviewer down a wedged-process-investigation rabbit hole. The correct meaning is \"shard didn't finish within the cap\" which is what \"OVERTIME\" conveys.

`wedged` is reserved elsewhere in the codebase for honest \"stuck forever\" semantics — `src/core/migrate.ts` migration-runner stalls, `src/commands/doctor.ts` queue-health stalled-worker detection, `src/core/minions/types.ts` worker-hang detection. Keeping those uses intact and removing the test-runner false-positive is the cleanest disambiguation.

## What changed

One file: `scripts/run-unit-parallel.sh`.

- `SHARD_TIMEOUT` default: `600` → `1200`
- Sentinel file extension: `.wedged` → `.overtime`
- Banner string: \"WEDGED after Ns\" → \"OVERTIME after Ns (shard did not finish within cap; partial output below)\"
- Summary line: \"shard N/M: WEDGED after Ns\" → \"shard N/M: OVERTIME after Ns\"
- Header comment block updated to explain the rationale + cite the 2026-05-16 measurement

Env var override `GBRAIN_TEST_SHARD_TIMEOUT=N` continues to work for boxes that need it tighter or wider.

## Verification

- `bash -n scripts/run-unit-parallel.sh` — clean
- No other file in the repo reads the `.wedged` sentinel (verified via `grep -rn wedged scripts/ src/ test/ docs/`). The `wedged` matches in other files refer to migration / worker / pool hangs and intentionally stay as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)