### PR TITLE
feat(audit): destructive-op JSONL trail for hard-deletes

### DIFF
--- a/src/core/destructive-audit.ts
+++ b/src/core/destructive-audit.ts
@@ -1,0 +1,164 @@
+/**
+ * Destructive-op audit log (forensic trace for hard-deletes).
+ *
+ * Writes a JSONL line per hard-delete of source or page rows to
+ * `~/.gbrain/audit/destructive-ops-YYYY-Www.jsonl` (ISO-week rotation, override
+ * via `GBRAIN_AUDIT_DIR`).
+ *
+ * The motivating bug class: an operator running `gbrain sources remove default
+ * --confirm-destructive` (or any hard-delete path) leaves no on-disk trail
+ * outside of Claude Code session JSONL transcripts. When the action happens
+ * via the CLI in a terminal, there's no record. The next mystery — "what
+ * deleted those 229 pages?" — becomes unsolvable without time-correlated
+ * cross-referencing of cron logs, git reflog, and shell history (which is
+ * usually disabled or rotated out).
+ *
+ * Wired into the four hard-delete primitives that exist on both engines:
+ *
+ *   1. `pglite-engine.ts:deletePage`         — raw delete primitive
+ *   2. `postgres-engine.ts:deletePage`       — same, Postgres path
+ *   3. `pglite-engine.ts:purgeDeletedPages`  — autopilot purge phase + manual
+ *   4. `postgres-engine.ts:purgeDeletedPages` — same, Postgres path
+ *   5. `destructive-guard.ts:purgeExpiredSources` — source-level cascade
+ *
+ * Soft-deletes (`softDeletePage`) are intentionally NOT logged — they're
+ * reversible within 72h and don't lose data. Only operations that hard-delete
+ * data get the audit line.
+ *
+ * Best-effort: write failures emit a stderr warning but never block the op.
+ * A disk-full attacker can silently disable the trail; CHANGELOG should call
+ * this out as an operational trace, not a security primitive.
+ *
+ * Modeled after `src/core/minions/handlers/shell-audit.ts` (shell-job audit)
+ * and `src/core/rerank-audit.ts` (reranker failure audit) — same file-naming
+ * convention, same `GBRAIN_AUDIT_DIR` override, same best-effort posture.
+ *
+ * Closes #1063 follow-up (the orphan-detection PR surfaces existing orphans;
+ * this PR makes future ones reconstructible).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { gbrainPath } from './config.ts';
+
+export type DestructiveOp = 'deletePage' | 'purgeDeletedPages' | 'purgeExpiredSources';
+
+export interface DestructiveAuditEvent {
+  ts: string;
+  op: DestructiveOp;
+  engine: 'pglite' | 'postgres';
+  // op-specific fields (sparse — only set what's relevant per op)
+  slug?: string;                  // deletePage
+  source_id?: string;             // deletePage
+  older_than_hours?: number;      // purgeDeletedPages
+  pages_purged?: number;          // purgeDeletedPages result count
+  page_slugs?: string[];          // purgeDeletedPages result slugs (truncated to first 50 for readability)
+  page_slugs_truncated?: boolean; // true if page_slugs was truncated
+  sources_purged?: number;        // purgeExpiredSources result count
+  source_ids?: string[];          // purgeExpiredSources result IDs
+}
+
+/**
+ * Compute `destructive-ops-YYYY-Www.jsonl` using ISO-8601 week numbering.
+ * Same algorithm as `shell-audit.ts:computeAuditFilename` — kept inline rather
+ * than DRYed so a future change to one rotation cadence doesn't silently
+ * flip another audit's filename shape.
+ */
+export function computeDestructiveAuditFilename(now: Date = new Date()): string {
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const dayNum = (d.getUTCDay() + 6) % 7;
+  d.setUTCDate(d.getUTCDate() - dayNum + 3);
+  const isoYear = d.getUTCFullYear();
+  const firstThursday = new Date(Date.UTC(isoYear, 0, 4));
+  const firstThursdayDayNum = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstThursdayDayNum + 3);
+  const weekNum = Math.round((d.getTime() - firstThursday.getTime()) / (7 * 86400000)) + 1;
+  const ww = String(weekNum).padStart(2, '0');
+  return `destructive-ops-${isoYear}-W${ww}.jsonl`;
+}
+
+/**
+ * Resolve the audit dir. Honors `GBRAIN_AUDIT_DIR` for container/sandbox
+ * deployments where `$HOME` is read-only. Defaults to `~/.gbrain/audit/`.
+ */
+export function resolveAuditDir(): string {
+  const override = process.env.GBRAIN_AUDIT_DIR;
+  if (override && override.trim().length > 0) return override;
+  return gbrainPath('audit');
+}
+
+const MAX_SLUGS_IN_AUDIT = 50;
+
+/**
+ * Append a destructive-op event to the audit log. Best-effort: write failures
+ * emit a stderr warning and return without throwing, so a destructive op never
+ * fails because the audit log is unwritable.
+ *
+ * Truncates `page_slugs` to 50 entries with a `page_slugs_truncated: true`
+ * marker — a single hard-delete of 10K stale pages shouldn't bloat one JSONL
+ * line to 10K slug strings. The `pages_purged` count is the ground truth.
+ */
+export function logDestructiveOp(event: Omit<DestructiveAuditEvent, 'ts'>): void {
+  const dir = resolveAuditDir();
+  const filename = computeDestructiveAuditFilename();
+  const fullPath = path.join(dir, filename);
+
+  // Truncate page_slugs if oversized; preserve the count as ground truth.
+  let finalEvent: Omit<DestructiveAuditEvent, 'ts'> = event;
+  if (event.page_slugs && event.page_slugs.length > MAX_SLUGS_IN_AUDIT) {
+    finalEvent = {
+      ...event,
+      page_slugs: event.page_slugs.slice(0, MAX_SLUGS_IN_AUDIT),
+      page_slugs_truncated: true,
+    };
+  }
+
+  const line = JSON.stringify({ ...finalEvent, ts: new Date().toISOString() }) + '\n';
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.appendFileSync(fullPath, line, { encoding: 'utf8' });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[destructive-audit] write failed (${msg}); op continues\n`);
+  }
+}
+
+/**
+ * Read the last N days of destructive-ops audit entries. Used by future doctor
+ * checks and operator forensic queries. Tolerates missing files (returns empty
+ * array) and malformed JSONL lines (skips them silently).
+ */
+export function readRecentDestructiveOps(days: number = 7): DestructiveAuditEvent[] {
+  const dir = resolveAuditDir();
+  if (!fs.existsSync(dir)) return [];
+  const cutoffMs = Date.now() - days * 86400 * 1000;
+  const events: DestructiveAuditEvent[] = [];
+  // Walk only files matching our prefix so a coincident sibling audit file
+  // (shell-jobs, rerank-failures, slug-fallback) doesn't trip the parser.
+  const entries = fs.readdirSync(dir).filter((f) => f.startsWith('destructive-ops-') && f.endsWith('.jsonl'));
+  for (const filename of entries) {
+    let content: string;
+    try {
+      content = fs.readFileSync(path.join(dir, filename), 'utf8');
+    } catch {
+      continue;
+    }
+    for (const rawLine of content.split('\n')) {
+      const line = rawLine.trim();
+      if (!line) continue;
+      try {
+        const ev = JSON.parse(line) as DestructiveAuditEvent;
+        if (!ev.ts) continue;
+        const eventMs = Date.parse(ev.ts);
+        if (Number.isFinite(eventMs) && eventMs >= cutoffMs) {
+          events.push(ev);
+        }
+      } catch {
+        // Skip malformed line — partial-write or crash mid-append
+      }
+    }
+  }
+  // Sort newest-first by ts
+  events.sort((a, b) => b.ts.localeCompare(a.ts));
+  return events;
+}

--- a/src/core/destructive-guard.ts
+++ b/src/core/destructive-guard.ts
@@ -292,7 +292,22 @@ export async function purgeExpiredSources(
        AND archive_expires_at <= now()
      RETURNING id`,
   );
-  return rows.map((r) => r.id);
+  const sourceIds = rows.map((r) => r.id);
+  // Audit trail (#1063 follow-up): source DELETE cascades through pages
+  // (FK ON DELETE CASCADE), which in turn cascades through 8 child tables.
+  // The single audit line per call captures every source the autopilot
+  // purge phase hard-deleted, so a future "what swept default away?"
+  // becomes one grep against ~/.gbrain/audit/destructive-ops-*.jsonl.
+  if (sourceIds.length > 0) {
+    const { logDestructiveOp } = await import('./destructive-audit.ts');
+    logDestructiveOp({
+      op: 'purgeExpiredSources',
+      engine: engine.kind,
+      sources_purged: sourceIds.length,
+      source_ids: sourceIds,
+    });
+  }
+  return sourceIds;
 }
 
 // ── Display Helpers ─────────────────────────────────────────

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -563,6 +563,11 @@ export class PGLiteEngine implements BrainEngine {
       'DELETE FROM pages WHERE slug = $1 AND source_id = $2',
       [slug, sourceId]
     );
+    // Audit trail: every hard-delete leaves a JSONL line so the next mystery
+    // ("what deleted X?") becomes a single grep, not forensic excavation.
+    // Best-effort; never blocks the op. See src/core/destructive-audit.ts.
+    const { logDestructiveOp } = await import('./destructive-audit.ts');
+    logDestructiveOp({ op: 'deletePage', engine: 'pglite', slug, source_id: sourceId });
   }
 
   async softDeletePage(slug: string, opts?: { sourceId?: string }): Promise<{ slug: string } | null> {
@@ -610,6 +615,19 @@ export class PGLiteEngine implements BrainEngine {
       [hours]
     );
     const slugs = (rows as { slug: string }[]).map((r) => r.slug);
+    // Audit trail (#1063 follow-up): log every bulk hard-delete with the
+    // older-than-hours cutoff + the actual slugs removed. Page-slug list
+    // truncates to 50 in the audit log; the count stays accurate.
+    if (slugs.length > 0) {
+      const { logDestructiveOp } = await import('./destructive-audit.ts');
+      logDestructiveOp({
+        op: 'purgeDeletedPages',
+        engine: 'pglite',
+        older_than_hours: hours,
+        pages_purged: slugs.length,
+        page_slugs: slugs,
+      });
+    }
     return { slugs, count: slugs.length };
   }
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -620,6 +620,11 @@ export class PostgresEngine implements BrainEngine {
     const sql = this.sql;
     const sourceId = opts?.sourceId ?? 'default';
     await sql`DELETE FROM pages WHERE slug = ${slug} AND source_id = ${sourceId}`;
+    // Audit trail: every hard-delete leaves a JSONL line so the next mystery
+    // ("what deleted X?") becomes a single grep, not forensic excavation.
+    // Best-effort; never blocks the op. See src/core/destructive-audit.ts.
+    const { logDestructiveOp } = await import('./destructive-audit.ts');
+    logDestructiveOp({ op: 'deletePage', engine: 'postgres', slug, source_id: sourceId });
   }
 
   async softDeletePage(slug: string, opts?: { sourceId?: string }): Promise<{ slug: string } | null> {
@@ -661,6 +666,18 @@ export class PostgresEngine implements BrainEngine {
       RETURNING slug
     `;
     const slugs = rows.map((r) => r.slug as string);
+    // Audit trail (#1063 follow-up): log every bulk hard-delete with the
+    // older-than-hours cutoff + the actual slugs removed.
+    if (slugs.length > 0) {
+      const { logDestructiveOp } = await import('./destructive-audit.ts');
+      logDestructiveOp({
+        op: 'purgeDeletedPages',
+        engine: 'postgres',
+        older_than_hours: hours,
+        pages_purged: slugs.length,
+        page_slugs: slugs,
+      });
+    }
     return { slugs, count: slugs.length };
   }
 

--- a/test/destructive-audit.test.ts
+++ b/test/destructive-audit.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Test: destructive-op audit log.
+ *
+ * Pure-helper tests for the audit module (filename, dir resolution, write+read
+ * roundtrip, truncation, best-effort posture) + end-to-end coverage that the
+ * pglite engine actually emits audit lines on `deletePage` and
+ * `purgeDeletedPages`. The latter exercises the real wire-in via a temp
+ * GBRAIN_AUDIT_DIR so the test never touches the operator's real audit dir.
+ *
+ * Closes #1063 follow-up — makes future hard-deletes reconstructible without
+ * the Claude Code JSONL transcript dependency.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { mkdtempSync, rmSync, readdirSync, readFileSync, writeFileSync, mkdirSync, chmodSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { withEnv } from './helpers/with-env.ts';
+import {
+  computeDestructiveAuditFilename,
+  resolveAuditDir,
+  logDestructiveOp,
+  readRecentDestructiveOps,
+} from '../src/core/destructive-audit.ts';
+
+describe('destructive-audit: filename + dir helpers', () => {
+  test('ISO-week filename — 2026-W20 lands at expected boundary', () => {
+    // 2026-05-16 is in ISO week 20 of 2026.
+    const filename = computeDestructiveAuditFilename(new Date(Date.UTC(2026, 4, 16, 12, 0, 0)));
+    expect(filename).toBe('destructive-ops-2026-W20.jsonl');
+  });
+
+  test('ISO-year boundary — Dec 31 may belong to W01 of next year', () => {
+    // 2024-12-31 is ISO week 01 of 2025 (week containing Jan 1 2025 is W01).
+    const filename = computeDestructiveAuditFilename(new Date(Date.UTC(2024, 11, 31, 12, 0, 0)));
+    expect(filename).toBe('destructive-ops-2025-W01.jsonl');
+  });
+
+  test('resolveAuditDir honors GBRAIN_AUDIT_DIR override', async () => {
+    const override = '/tmp/gbrain-test-audit-override-' + Date.now();
+    await withEnv({ GBRAIN_AUDIT_DIR: override }, async () => {
+      expect(resolveAuditDir()).toBe(override);
+    });
+  });
+
+  test('resolveAuditDir defaults to ~/.gbrain/audit when override unset', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: undefined }, async () => {
+      const resolved = resolveAuditDir();
+      expect(resolved).toContain('audit');
+      // Defaults to gbrainPath('audit') — could be GBRAIN_HOME-overridden in CI
+      expect(resolved.endsWith('/audit') || resolved.endsWith('audit')).toBe(true);
+    });
+  });
+});
+
+describe('destructive-audit: write + read roundtrip', () => {
+  let auditDir: string;
+
+  beforeAll(() => {
+    auditDir = mkdtempSync(join(tmpdir(), 'gbrain-destructive-audit-'));
+  });
+
+  afterAll(() => {
+    try { rmSync(auditDir, { recursive: true, force: true }); } catch { /* swallow */ }
+  });
+
+  beforeEach(() => {
+    // Clean the audit dir between tests so each test sees only its own writes.
+    if (existsSync(auditDir)) {
+      for (const f of readdirSync(auditDir)) {
+        try { rmSync(join(auditDir, f), { force: true }); } catch { /* swallow */ }
+      }
+    }
+  });
+
+  test('logDestructiveOp writes a JSONL line + readRecentDestructiveOps reads it back', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      logDestructiveOp({
+        op: 'deletePage',
+        engine: 'pglite',
+        slug: 'people/alice',
+        source_id: 'default',
+      });
+      const events = readRecentDestructiveOps(1);
+      expect(events.length).toBe(1);
+      expect(events[0].op).toBe('deletePage');
+      expect(events[0].engine).toBe('pglite');
+      expect(events[0].slug).toBe('people/alice');
+      expect(events[0].source_id).toBe('default');
+      expect(events[0].ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+  });
+
+  test('readRecentDestructiveOps returns newest-first', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      logDestructiveOp({ op: 'deletePage', engine: 'pglite', slug: 'a' });
+      // Tiny delay so timestamps differ deterministically
+      await new Promise((r) => setTimeout(r, 5));
+      logDestructiveOp({ op: 'deletePage', engine: 'pglite', slug: 'b' });
+      await new Promise((r) => setTimeout(r, 5));
+      logDestructiveOp({ op: 'deletePage', engine: 'pglite', slug: 'c' });
+      const events = readRecentDestructiveOps(1);
+      expect(events.length).toBe(3);
+      expect(events[0].slug).toBe('c');
+      expect(events[1].slug).toBe('b');
+      expect(events[2].slug).toBe('a');
+    });
+  });
+
+  test('logDestructiveOp truncates page_slugs > 50 with truncated marker', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      const manySlugs = Array.from({ length: 100 }, (_, i) => `wiki/page-${i}`);
+      logDestructiveOp({
+        op: 'purgeDeletedPages',
+        engine: 'pglite',
+        older_than_hours: 72,
+        pages_purged: 100,
+        page_slugs: manySlugs,
+      });
+      const events = readRecentDestructiveOps(1);
+      expect(events.length).toBe(1);
+      expect(events[0].pages_purged).toBe(100); // count is ground truth
+      expect(events[0].page_slugs?.length).toBe(50); // capped
+      expect(events[0].page_slugs_truncated).toBe(true);
+      // First 50 preserved in order
+      expect(events[0].page_slugs?.[0]).toBe('wiki/page-0');
+      expect(events[0].page_slugs?.[49]).toBe('wiki/page-49');
+    });
+  });
+
+  test('page_slugs <= 50 stays untruncated, no truncated marker', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      const fewSlugs = ['a', 'b', 'c'];
+      logDestructiveOp({
+        op: 'purgeDeletedPages',
+        engine: 'pglite',
+        older_than_hours: 72,
+        pages_purged: 3,
+        page_slugs: fewSlugs,
+      });
+      const events = readRecentDestructiveOps(1);
+      expect(events[0].page_slugs).toEqual(['a', 'b', 'c']);
+      expect(events[0].page_slugs_truncated).toBeUndefined();
+    });
+  });
+
+  test('readRecentDestructiveOps skips malformed JSONL lines (partial-write tolerance)', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      mkdirSync(auditDir, { recursive: true });
+      const filename = computeDestructiveAuditFilename();
+      const filePath = join(auditDir, filename);
+      // Mix valid + invalid lines — readRecentDestructiveOps must skip the invalid ones
+      const content = [
+        JSON.stringify({ ts: new Date().toISOString(), op: 'deletePage', engine: 'pglite', slug: 'good-1' }),
+        '{ this is not valid json',
+        JSON.stringify({ ts: new Date().toISOString(), op: 'deletePage', engine: 'pglite', slug: 'good-2' }),
+        '',
+        '   ',
+        JSON.stringify({ ts: new Date().toISOString(), op: 'deletePage', engine: 'pglite', slug: 'good-3' }),
+      ].join('\n');
+      writeFileSync(filePath, content);
+      const events = readRecentDestructiveOps(1);
+      expect(events.length).toBe(3);
+      // Ordering: newest-first; all 3 have nearly-identical timestamps so any order is fine
+      const slugs = events.map((e) => e.slug).sort();
+      expect(slugs).toEqual(['good-1', 'good-2', 'good-3']);
+    });
+  });
+
+  test('readRecentDestructiveOps filters by days window', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      mkdirSync(auditDir, { recursive: true });
+      const filename = computeDestructiveAuditFilename();
+      const filePath = join(auditDir, filename);
+      // One event in the past (10 days ago), one recent
+      const oldTs = new Date(Date.now() - 10 * 86400 * 1000).toISOString();
+      const recentTs = new Date().toISOString();
+      const content = [
+        JSON.stringify({ ts: oldTs, op: 'deletePage', engine: 'pglite', slug: 'old' }),
+        JSON.stringify({ ts: recentTs, op: 'deletePage', engine: 'pglite', slug: 'recent' }),
+      ].join('\n');
+      writeFileSync(filePath, content);
+      const events7 = readRecentDestructiveOps(7);
+      expect(events7.length).toBe(1);
+      expect(events7[0].slug).toBe('recent');
+      const events14 = readRecentDestructiveOps(14);
+      expect(events14.length).toBe(2);
+    });
+  });
+
+  test('best-effort: logDestructiveOp does NOT throw when audit dir is unwritable', async () => {
+    // Point at a path that fs.mkdirSync will refuse — a file masquerading as a dir
+    const dummy = mkdtempSync(join(tmpdir(), 'gbrain-destructive-audit-fail-'));
+    const blockingFile = join(dummy, 'blocker');
+    writeFileSync(blockingFile, 'this is a file, not a dir');
+    try {
+      await withEnv({ GBRAIN_AUDIT_DIR: blockingFile }, async () => {
+        // mkdirSync of a path whose parent is a file will throw — log should swallow it
+        expect(() => {
+          logDestructiveOp({ op: 'deletePage', engine: 'pglite', slug: 'whatever' });
+        }).not.toThrow();
+      });
+    } finally {
+      rmSync(dummy, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('destructive-audit: end-to-end through pglite engine', () => {
+  let engine: PGLiteEngine;
+  let auditDir: string;
+
+  beforeAll(async () => {
+    auditDir = mkdtempSync(join(tmpdir(), 'gbrain-destructive-audit-e2e-'));
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+    try { rmSync(auditDir, { recursive: true, force: true }); } catch { /* swallow */ }
+  });
+
+  beforeEach(async () => {
+    await resetPgliteState(engine);
+    // Clean the audit dir between tests
+    if (existsSync(auditDir)) {
+      for (const f of readdirSync(auditDir)) {
+        try { rmSync(join(auditDir, f), { force: true }); } catch { /* swallow */ }
+      }
+    }
+  });
+
+  test('engine.deletePage emits a deletePage audit line', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      // Seed a page first
+      await engine.putPage('wiki/test-page', {
+        type: 'concept',
+        title: 'Test Page',
+        compiled_truth: 'body',
+        chunker_version: 2,
+        page_kind: 'markdown',
+      });
+      // Hard-delete it
+      await engine.deletePage('wiki/test-page');
+      const events = readRecentDestructiveOps(1);
+      expect(events.length).toBe(1);
+      expect(events[0].op).toBe('deletePage');
+      expect(events[0].engine).toBe('pglite');
+      expect(events[0].slug).toBe('wiki/test-page');
+      expect(events[0].source_id).toBe('default');
+    });
+  });
+
+  test('engine.purgeDeletedPages emits a purgeDeletedPages audit line when rows are purged', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      // Seed + soft-delete two pages
+      await engine.putPage('wiki/p1', {
+        type: 'concept', title: 'P1', compiled_truth: 'a',
+        chunker_version: 2, page_kind: 'markdown',
+      });
+      await engine.putPage('wiki/p2', {
+        type: 'concept', title: 'P2', compiled_truth: 'b',
+        chunker_version: 2, page_kind: 'markdown',
+      });
+      await engine.softDeletePage('wiki/p1');
+      await engine.softDeletePage('wiki/p2');
+      // Purge with 0h threshold (immediate)
+      const result = await engine.purgeDeletedPages(0);
+      expect(result.count).toBe(2);
+      const events = readRecentDestructiveOps(1);
+      expect(events.length).toBe(1);
+      expect(events[0].op).toBe('purgeDeletedPages');
+      expect(events[0].engine).toBe('pglite');
+      expect(events[0].older_than_hours).toBe(0);
+      expect(events[0].pages_purged).toBe(2);
+      expect(events[0].page_slugs?.sort()).toEqual(['wiki/p1', 'wiki/p2']);
+    });
+  });
+
+  test('engine.purgeDeletedPages with zero rows purged does NOT emit an audit line (avoid no-op churn)', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditDir }, async () => {
+      // No soft-deleted pages exist
+      const result = await engine.purgeDeletedPages(72);
+      expect(result.count).toBe(0);
+      const events = readRecentDestructiveOps(1);
+      expect(events.length).toBe(0); // no audit line — saves disk on clean autopilot runs
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Every hard-delete of a source or page row now leaves a forensic JSONL trace at `~/.gbrain/audit/destructive-ops-YYYY-Www.jsonl` (ISO-week rotation, override via `GBRAIN_AUDIT_DIR`). The next \"what deleted X?\" investigation becomes one grep, not forensic excavation across cron logs + shell history.

Sibling of `shell-audit.ts` (shell-job submissions) and `rerank-audit.ts` (reranker failures). Same naming convention, same env override, same best-effort posture.

## Why

When an operator runs `gbrain sources remove --confirm-destructive`, or any destructive code path fires (autopilot purge phase, `pages purge-deleted`, source-archive cascade), the only existing record of \"what got deleted, when, from where\" lives in agent session transcripts. That works when the action happens inside an agent harness. It fails — silently and permanently — when the action happens from a terminal, a cron, or an MCP client that doesn't persist per-call.

Concrete trigger: a 2026-05-15 cleanup pass cascade-hard-deleted 229 pages via `sources_remove default --confirm-destructive`. Reconstructing \"what just happened?\" required manually grepping a downstream agent's session transcripts the next day. Had the operation happened from a terminal, the event would have been permanently unknowable.

This PR closes that bug class. Operator-facing CHANGELOG framing: \"destructive ops now leave a JSONL trail so you can answer 'what did I delete last Tuesday?' without rebuilding from cron logs.\"

## What changed

New `src/core/destructive-audit.ts` module (mirrors `shell-audit.ts` + `rerank-audit.ts`). Exports:

- `computeDestructiveAuditFilename(now)` — pure ISO-8601 week naming
- `resolveAuditDir()` — env-override-aware
- `logDestructiveOp(event)` — best-effort append with stderr warning on write failure
- `readRecentDestructiveOps(days)` — newest-first reader, tolerates malformed JSONL

Wired into **five hard-delete sites**:

| Site | Op kind |
|---|---|
| `pglite-engine.ts:deletePage` | raw delete primitive |
| `pglite-engine.ts:purgeDeletedPages` | autopilot purge phase + manual `pages purge-deleted` |
| `postgres-engine.ts:deletePage` | same on Postgres |
| `postgres-engine.ts:purgeDeletedPages` | same on Postgres |
| `destructive-guard.ts:purgeExpiredSources` | source-level cascade |

**Intentionally NOT wired:** `softDeletePage`. Soft-deletes are reversible within the 72h recovery window and don't lose data; auditing them would be operational noise.

**`purgeDeletedPages` with zero rows purged also skips the audit line.** The autopilot cycle runs the purge phase every cycle; writing \"purged 0 pages\" 24+ times per day on a clean brain is pure disk churn.

**Page-slug truncation:** when `page_slugs.length > 50`, the array is sliced to the first 50 with a `page_slugs_truncated: true` marker. The `pages_purged` count remains accurate as ground truth. Stops one bulk-delete of 10K rows from producing a 10K-string JSONL line.

## Sample output

```jsonl
{\"ts\":\"2026-05-16T05:30:12Z\",\"op\":\"deletePage\",\"engine\":\"pglite\",\"slug\":\"wiki/people/alice\",\"source_id\":\"default\"}
{\"ts\":\"2026-05-16T05:35:21Z\",\"op\":\"purgeDeletedPages\",\"engine\":\"pglite\",\"older_than_hours\":72,\"pages_purged\":7,\"page_slugs\":[\"wiki/a\",\"wiki/b\",\"...\"]}
{\"ts\":\"2026-05-16T05:40:01Z\",\"op\":\"purgeExpiredSources\",\"engine\":\"pglite\",\"sources_purged\":1,\"source_ids\":[\"default\"]}
```

Operator forensic query: `tail ~/.gbrain/audit/destructive-ops-$(date +%Y-W%V).jsonl` answers \"what got destroyed this week?\" instantly.

## Tests

`test/destructive-audit.test.ts` — **14 cases, 43 expect calls**, all passing:

**Pure helpers:** ISO-week filename W20 + cross-year W01 boundary; `resolveAuditDir` env override + default.

**Write+read roundtrip** (tmpdir `GBRAIN_AUDIT_DIR`): single roundtrip; newest-first ordering; truncation at 50 with marker; <=50 untruncated; malformed JSONL skipping; days-window filter.

**Best-effort posture:** unwritable audit dir → no throw (op continues).

**End-to-end through PGLite engine:** `engine.deletePage` emits expected line; `engine.purgeDeletedPages` emits expected line with all slugs; **zero-row purge emits NO line** (no churn regression guard).

**Regression:** existing 100 `pglite-engine.test.ts` + 35 `orphans.test.ts` + 24 `sources-ops.test.ts` cases all still pass.

## Verification

- `bun run typecheck` — clean
- `bun run verify` — clean
- `bun test test/destructive-audit.test.ts` — 14 pass / 0 fail
- `bun test test/pglite-engine.test.ts` — 100 pass / 0 fail
- `bun test test/orphans.test.ts` — 35 pass / 0 fail
- `bun test test/sources-ops.test.ts` — 24 pass / 0 fail

## Reviewer notes

- **Privacy:** the audit log writes slugs but never page content, frontmatter, or chunk text. The slug is the smallest identifier that lets an operator reconstruct what happened.
- **Disk pressure:** a single hard-delete = ~150 bytes JSONL. Even at 1000 deletes/week that's 150KB/year per brain — trivial.
- **No new dependencies.** Pure Node fs + path.
- **Sibling pattern proof:** `shell-audit.ts` has been in production since v0.20.4+ with this exact write/rotation shape; `rerank-audit.ts` joined in v0.35.0.0. This PR is the third audit-log file using the same idiom.

## Follow-ups (NOT in this PR)

- Optional doctor check `destructive_ops_summary` that surfaces \"N hard-deletes in last 7 days\" — opt-in; the audit file alone is enough for operator forensics.
- Caller-context fields (auth.client_id, remote flag) require threading OperationContext below the engine layer — separate concern. Current trace has enough information for the bug class motivating this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)