### PR TITLE
fix(serve): return 405 on GET /mcp instead of 404

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -794,6 +794,15 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   // ---------------------------------------------------------------------------
   const mcpOperations = operations.filter(op => !op.localOnly);
 
+  // MCP Streamable HTTP spec: GET /mcp opens an optional SSE backchannel for
+  // server-initiated messages. gbrain's transport is stateless and doesn't push
+  // server-initiated messages, so per spec we MUST return 405 (not 404) here so
+  // probing clients (claude.ai, others) recognize this as an MCP endpoint.
+  app.get('/mcp', (_req: Request, res: Response) => {
+    res.set('Allow', 'POST, DELETE');
+    res.status(405).json({ jsonrpc: '2.0', error: { code: -32000, message: 'Method not allowed' }, id: null });
+  });
+
   app.post('/mcp', requireBearerAuth({ verifier: oauthProvider }), async (req: Request, res: Response) => {
     const startTime = Date.now();
     const authInfo = (req as any).auth as AuthInfo;


### PR DESCRIPTION
## Summary

Per the MCP Streamable HTTP spec, servers that don't support the SSE backchannel MUST respond `405 Method Not Allowed` (with an `Allow` header) on `GET /mcp`. gbrain's transport is stateless and only registers `POST /mcp`, so unhandled `GET /mcp` falls through to Express's default 404 HTML handler.

This breaks claude.ai's Custom Connector flow: its initial reachability probe is a `GET` to the MCP URL, and a 404 makes it conclude the URL isn't an MCP server — surfaced as "Couldn't reach the MCP server" in the UI.

## Fix

Add a no-auth `GET /mcp` handler that returns 405 with a JSON-RPC error body and `Allow: POST, DELETE`. Auth still gates the `POST` path.

## Test plan

- [x] `curl https://server/mcp` returns `405` (was `404`)
- [x] `curl -X POST https://server/mcp ...` still returns `401` without bearer auth
- [x] Authenticated `POST /mcp initialize` still returns valid server info
- [x] claude.ai Custom Connector now reaches gbrain through `/.well-known/oauth-authorization-server` discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)