### PR TITLE
fix(serve): admin register-client supports authorization_code + PKCE clients

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -714,11 +714,22 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   // Register client from admin dashboard
   app.post('/admin/api/register-client', requireAdmin, express.json(), async (req: Request, res: Response) => {
     try {
-      const { name, scopes, tokenTtl } = req.body;
+      const { name, scopes, tokenTtl, grantTypes, redirectUris, tokenEndpointAuthMethod } = req.body;
       if (!name) { res.status(400).json({ error: 'Name required' }); return; }
+      const grants = Array.isArray(grantTypes) && grantTypes.length > 0 ? grantTypes : ['client_credentials'];
+      const uris = Array.isArray(redirectUris) ? redirectUris : [];
       const result = await oauthProvider.registerClientManual(
-        name, ['client_credentials'], scopes || 'read', [],
+        name, grants, scopes || 'read', uris,
       );
+      // Public client (PKCE-only, no secret): NULL out client_secret_hash and
+      // set auth method so the SDK's clientAuth middleware skips the hash-vs-
+      // plaintext comparison that would otherwise reject the request. This is
+      // the supported pattern for browser-based OAuth (e.g. claude.ai's
+      // Custom Connector flow, which uses authorization_code + PKCE).
+      if (tokenEndpointAuthMethod === 'none') {
+        await sql`UPDATE oauth_clients SET client_secret_hash = NULL, token_endpoint_auth_method = 'none' WHERE client_id = ${result.clientId}`;
+        delete (result as any).clientSecret;
+      }
       // Set per-client TTL if specified
       if (tokenTtl && Number(tokenTtl) > 0) {
         await sql`UPDATE oauth_clients SET token_ttl = ${Number(tokenTtl)} WHERE client_id = ${result.clientId}`;


### PR DESCRIPTION
## Summary

The admin `POST /admin/api/register-client` endpoint hardcoded `grant_types: ['client_credentials']` and `redirect_uris: []`, so clients registered through the dashboard cannot be used with any browser-based OAuth client (claude.ai's Custom Connector, Cursor's `authorization_code` flow, etc).

Two issues, one endpoint:

1. No way to register a client with `authorization_code` grant or any redirect URI. Browser-based clients need both.
2. Even after fixing (1) to register a confidential client with `authorization_code`, the MCP SDK's `clientAuth` middleware compares the request's `client_secret` against `client.client_secret` from the provider's `getClient()` — but `GBrainClientsStore.getClient` (`src/core/oauth-provider.ts:150`) returns the SHA-256 **hash** in that field. The comparison `hash !== plaintext` always fails with `invalid_client / Invalid client_secret`. (`exchangeClientCredentials` hashes the input first, which is why the `client_credentials` grant works.)

## Fix

Add three optional fields to the request body:

- `grantTypes` — pass-through to `registerClientManual`
- `redirectUris` — pass-through to `registerClientManual`
- `tokenEndpointAuthMethod` — when set to `'none'`, NULL out `client_secret_hash` so the SDK's `if (client.client_secret)` guard short-circuits past the broken comparison. PKCE carries the full integrity of the flow — the standard OAuth 2.1 pattern for public browser-based clients.

Defaults preserve old behavior: omitting all three yields the `client_credentials`-only / no-redirect-URI client the endpoint produced before.

## Test plan

End-to-end verified against claude.ai's Custom Connector:
- [x] Register via `curl -X POST /admin/api/register-client -d '{\"name\":\"claude-ai\",\"grantTypes\":[\"authorization_code\",\"refresh_token\"],\"redirectUris\":[\"https://claude.ai/api/mcp/auth_callback\"],\"tokenEndpointAuthMethod\":\"none\"}'` → returns `clientId` only (no `clientSecret`)
- [x] `GET /authorize` → 302 to `claude.ai/api/mcp/auth_callback?code=...`
- [x] `POST /token` (no `client_secret`, PKCE `code_verifier`) → `access_token`
- [x] `POST /mcp initialize` with the token → valid MCP server info
- [x] claude.ai Custom Connector consent + tool calls work end-to-end from web and iOS

Without `tokenEndpointAuthMethod: 'none'`, the same flow fails at the token exchange with `invalid_client` regardless of whether the supplied secret is correct.

## Note

Fixing the SDK comparison properly (so manually-registered *confidential* clients also work with `authorization_code`) would be a separate, larger change — probably either custom token-handler middleware that hashes before comparing, or storing plaintext for compatibility. The PKCE-only path is the right answer for the browser-OAuth use case anyway, so this patch unblocks it without touching that broader question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)