### PR TITLE
fix: declare entity_hints array item schema

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2696,7 +2696,7 @@ const extract_facts: Operation = {
   params: {
     turn_text: { type: 'string', required: true, description: 'The user message or page body to extract facts from. Sanitized via INJECTION_PATTERNS before the LLM call.' },
     session_id: { type: 'string', description: 'Opaque session id (e.g. topic-id from MCP _meta.session_id, or CLI --session). Stored on each fact for the recall --session filter. Not an auth surface.' },
-    entity_hints: { type: 'array', description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
+    entity_hints: { type: 'array', items: { type: 'string' }, description: 'Existing canonical entity slugs the agent has already resolved. Helps the extractor pick the right slug.' },
     is_dream_generated: { type: 'boolean', description: 'When true, extraction is skipped (anti-loop). Caller flips this on for pages with dream_generated:true frontmatter.' },
     visibility: { type: 'string', description: 'Default visibility for extracted facts. private (default) | world.' },
   },


### PR DESCRIPTION
## Summary
- Adds `items: { type: "string" }` to the `extract_facts.params.entity_hints` MCP schema.
- Fixes strict tool-schema validation failures in OpenAI/Codex-compatible clients.

## Context
Without `items`, clients reject the entire tool payload before any model response with:

```
Invalid schema for function mcp_gbrain_extract_facts: In context=('properties', 'entity_hints'), array schema missing items.
```

## Test plan
- `bun run typecheck`
- `hermes mcp test gbrain` locally discovers 70 tools after this patch.