### PR TITLE
fix(migrate): preserve embedding_model and embedding_dimensions on engine switch

### DIFF
--- a/src/commands/migrate-engine.ts
+++ b/src/commands/migrate-engine.ts
@@ -74,6 +74,32 @@ function clearManifest(): void {
   if (existsSync(path)) unlinkSync(path);
 }
 
+/**
+ * Build the post-migration file-plane config. Preserves every non-engine
+ * field from the source config (embedding_model, embedding_dimensions,
+ * expansion_model, chat_model, API keys, storage, eval, etc.) and swaps in
+ * the target engine + its connection field. Stale connection fields from the
+ * source engine are stripped so a migrated config never carries both
+ * database_url and database_path.
+ *
+ * Exported for unit testing; called from runMigrateEngine() right before
+ * saveConfig().
+ */
+export function buildMigratedConfig(
+  source: GBrainConfig,
+  targetEngine: 'postgres' | 'pglite',
+  targetConfig: EngineConfig,
+): GBrainConfig {
+  const { database_url: _u, database_path: _p, engine: _e, ...preserved } = source;
+  return {
+    ...preserved,
+    engine: targetEngine,
+    ...(targetEngine === 'postgres'
+      ? { database_url: targetConfig.database_url }
+      : { database_path: targetConfig.database_path }),
+  };
+}
+
 export async function runMigrateEngine(sourceEngine: BrainEngine, args: string[]): Promise<void> {
   const opts = parseArgs(args);
   const config = loadConfig();
@@ -251,13 +277,10 @@ export async function runMigrateEngine(sourceEngine: BrainEngine, args: string[]
     if (val) await targetEngine.setConfig(key, val);
   }
 
-  // Update local config
-  const newConfig: GBrainConfig = {
-    engine: opts.targetEngine,
-    ...(opts.targetEngine === 'postgres'
-      ? { database_url: targetConfig.database_url }
-      : { database_path: targetConfig.database_path }),
-  };
+  // Update local config. buildMigratedConfig() preserves every non-engine
+  // field (embedding_model, embedding_dimensions, API keys, etc.) so the
+  // migrate command doesn't silently drop user-configured settings.
+  const newConfig = buildMigratedConfig(config, opts.targetEngine, targetConfig);
   saveConfig(newConfig);
 
   // Clean up

--- a/test/migrate-engine-config.test.ts
+++ b/test/migrate-engine-config.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for buildMigratedConfig() in src/commands/migrate-engine.ts.
+ *
+ * Regression guard for the bug where `gbrain migrate --to ...` overwrote
+ * the file-plane config with `{ engine, database_url }` only, silently
+ * dropping every other GBrainConfig field — embedding_model,
+ * embedding_dimensions, expansion_model, chat_model, API keys, etc.
+ *
+ * Pure unit tests: no engine connection, no filesystem, no DATABASE_URL.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { buildMigratedConfig } from '../src/commands/migrate-engine.ts';
+import type { GBrainConfig } from '../src/core/config.ts';
+import type { EngineConfig } from '../src/core/types.ts';
+
+const PG_TARGET: EngineConfig = { engine: 'postgres', database_url: 'postgresql://host/db' };
+const PGLITE_TARGET: EngineConfig = { engine: 'pglite', database_path: '/tmp/new.pglite' };
+
+describe('buildMigratedConfig', () => {
+  test('pglite -> postgres preserves embedding_model and embedding_dimensions', () => {
+    const source: GBrainConfig = {
+      engine: 'pglite',
+      database_path: '/tmp/brain.pglite',
+      embedding_model: 'voyage:voyage-3-large',
+      embedding_dimensions: 1024,
+    };
+
+    const result = buildMigratedConfig(source, 'postgres', PG_TARGET);
+
+    expect(result.engine).toBe('postgres');
+    expect(result.database_url).toBe('postgresql://host/db');
+    expect(result.embedding_model).toBe('voyage:voyage-3-large');
+    expect(result.embedding_dimensions).toBe(1024);
+  });
+
+  test('postgres -> pglite preserves embedding_model and embedding_dimensions', () => {
+    const source: GBrainConfig = {
+      engine: 'postgres',
+      database_url: 'postgresql://host/db',
+      embedding_model: 'openai:text-embedding-3-large',
+      embedding_dimensions: 3072,
+    };
+
+    const result = buildMigratedConfig(source, 'pglite', PGLITE_TARGET);
+
+    expect(result.engine).toBe('pglite');
+    expect(result.database_path).toBe('/tmp/new.pglite');
+    expect(result.embedding_model).toBe('openai:text-embedding-3-large');
+    expect(result.embedding_dimensions).toBe(3072);
+  });
+
+  test('strips the old engine connection field (no dangling database_path on postgres)', () => {
+    const source: GBrainConfig = {
+      engine: 'pglite',
+      database_path: '/tmp/old.pglite',
+    };
+
+    const result = buildMigratedConfig(source, 'postgres', PG_TARGET);
+
+    expect(result.database_path).toBeUndefined();
+    expect(result.database_url).toBe('postgresql://host/db');
+  });
+
+  test('strips the old engine connection field (no dangling database_url on pglite)', () => {
+    const source: GBrainConfig = {
+      engine: 'postgres',
+      database_url: 'postgresql://host/db',
+    };
+
+    const result = buildMigratedConfig(source, 'pglite', PGLITE_TARGET);
+
+    expect(result.database_url).toBeUndefined();
+    expect(result.database_path).toBe('/tmp/new.pglite');
+  });
+
+  test('strips both connection fields when source has both set (engine-mismatched state)', () => {
+    // A previous failed migration could leave a config with both fields set.
+    // The migrated config must contain only the target engine's field.
+    const source: GBrainConfig = {
+      engine: 'pglite',
+      database_path: '/tmp/old.pglite',
+      database_url: 'postgresql://stale/db',
+      embedding_model: 'voyage:voyage-3-large',
+    };
+
+    const result = buildMigratedConfig(source, 'postgres', PG_TARGET);
+
+    expect(result.database_path).toBeUndefined();
+    expect(result.database_url).toBe('postgresql://host/db');
+    expect(result.embedding_model).toBe('voyage:voyage-3-large');
+  });
+
+  test('preserves expansion_model, chat_model, and API key fields', () => {
+    const source: GBrainConfig = {
+      engine: 'pglite',
+      database_path: '/tmp/brain.pglite',
+      embedding_model: 'voyage:voyage-3-large',
+      embedding_dimensions: 1024,
+      expansion_model: 'anthropic:claude-haiku-4-5',
+      chat_model: 'anthropic:claude-sonnet-4-6',
+      openai_api_key: 'sk-test-key',
+      anthropic_api_key: 'ant-test-key',
+    };
+
+    const result = buildMigratedConfig(source, 'postgres', PG_TARGET);
+
+    expect(result.expansion_model).toBe('anthropic:claude-haiku-4-5');
+    expect(result.chat_model).toBe('anthropic:claude-sonnet-4-6');
+    expect(result.openai_api_key).toBe('sk-test-key');
+    expect(result.anthropic_api_key).toBe('ant-test-key');
+  });
+
+  test('preserves nested fields (storage, eval, remote_mcp, provider_base_urls)', () => {
+    const source: GBrainConfig = {
+      engine: 'pglite',
+      database_path: '/tmp/brain.pglite',
+      storage: { db_tracked: ['people/'], db_only: ['media/'] },
+      eval: { capture: true, scrub_pii: false },
+      provider_base_urls: { voyage: 'https://api.voyageai.com/v1' },
+    };
+
+    const result = buildMigratedConfig(source, 'postgres', PG_TARGET);
+
+    expect(result.storage).toEqual({ db_tracked: ['people/'], db_only: ['media/'] });
+    expect(result.eval).toEqual({ capture: true, scrub_pii: false });
+    expect(result.provider_base_urls).toEqual({ voyage: 'https://api.voyageai.com/v1' });
+  });
+
+  test('minimal config (only engine + path) migrates cleanly', () => {
+    const source: GBrainConfig = {
+      engine: 'pglite',
+      database_path: '/tmp/brain.pglite',
+    };
+
+    const result = buildMigratedConfig(source, 'postgres', PG_TARGET);
+
+    expect(result.engine).toBe('postgres');
+    expect(result.database_url).toBe('postgresql://host/db');
+    expect(result.embedding_model).toBeUndefined();
+    expect(result.embedding_dimensions).toBeUndefined();
+  });
+
+  test('does not mutate the source config', () => {
+    const source: GBrainConfig = {
+      engine: 'pglite',
+      database_path: '/tmp/brain.pglite',
+      embedding_model: 'voyage:voyage-3-large',
+      embedding_dimensions: 1024,
+    };
+    const snapshot = JSON.parse(JSON.stringify(source));
+
+    buildMigratedConfig(source, 'postgres', PG_TARGET);
+
+    expect(source).toEqual(snapshot);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a silent config-stripping bug in `gbrain migrate --to <engine>`. Existing brains keep working after the migration but new content can't be embedded, because the migration wipes the embedding configuration. I found this last night running my own gbrain.

## Issue

`gbrain migrate --to <engine>` writes a new config that's just `{ engine, database_url }` (or `database_path`) and nothing else. Every other field is silently dropped: `embedding_model`, `embedding_dimensions`, `expansion_model`, `chat_model`, API keys, `storage`, `eval`, `provider_base_urls`.

The migration appears to succeed. The new database has all the pages and vectors. Search still works on existing content. The issue only shows up when you try to embed something new, or when you read `gbrain doctor` output carefully.

## Reproduce

1. Start with a brain on PGLite with custom embeddings:

```json
{
  "engine": "pglite",
  "database_path": "$HOME/.gbrain/brain.pglite",
  "embedding_model": "ollama:nomic-embed-text",
  "embedding_dimensions": 768
}
```

2. Migrate to Postgres:

```bash
gbrain migrate --to postgres --url postgresql://localhost/gbrain
```

3. Check the new config:

```json
{
  "engine": "postgres",
  "database_url": "postgresql://localhost/gbrain"
}
```

`embedding_model` and `embedding_dimensions` are gone. `gbrain doctor` reports:

```
[OK] embedding_provider: Skipped (no provider credentials). Model: openai:text-embedding-3-large.
```

Existing search keeps working because the 768-dim vectors are in place. But new content fails to embed: gbrain tries the OpenAI default model (1536-dim) and breaks either at the API (no key) or at insert (dimension mismatch with the `vector(768)` column).

## Fix

Extracted a pure `buildMigratedConfig()` helper in `src/commands/migrate-engine.ts`. It destructures the three engine-shape fields (`engine`, `database_url`, `database_path`) and spreads the rest of the source config into the new one before stamping the target engine and its connection field. The stale connection field from the source engine is stripped, so a migrated config never holds both `database_url` and `database_path`.

The production migration command calls the helper, so the tests exercise the real production function rather than a duplicate.

## Tests

New file: `test/migrate-engine-config.test.ts`. Nine unit cases:

- pglite ↔ postgres in both directions, embedding fields preserved
- stale connection field stripped on each target engine
- engine-mismatched source (both `database_url` and `database_path` set) gets cleaned up
- `expansion_model`, `chat_model`, and API keys preserved
- nested fields preserved (`storage`, `eval`, `provider_base_urls`)
- minimal config (engine + path only) migrates cleanly
- source config not mutated

9/9 pass. Typecheck clean. 153 tests pass across the broader migrate/config test suite.

## Environment

- macOS 26.3
- gbrain master (also reproducible on v0.34.4)
- Migrating PGLite → local Postgres 17 (also affects Postgres → PGLite)