### PR TITLE
fix(think): route synthesis through AI gateway

### DIFF
--- a/src/commands/think.ts
+++ b/src/commands/think.ts
@@ -2,8 +2,8 @@
  * v0.28: `gbrain think <question>` CLI.
  *
  * Thin wrapper around runThink + persistSynthesis. Local CLI = remote=false,
- * so --save and --take are honored. Reads ANTHROPIC_API_KEY from the env;
- * degrades to gather-only output with a warning if missing.
+ * so --save and --take are honored. Synthesis routes through the AI gateway;
+ * degrades to gather-only output with a warning if no chat provider is configured.
  */
 import type { BrainEngine } from '../core/engine.ts';
 import { runThink, persistSynthesis } from '../core/think/index.ts';
@@ -38,8 +38,9 @@ Options:
 Without --save, the synthesis is printed to stdout and discarded. With --save,
 the synthesis page is persisted AND printed.
 
-Set ANTHROPIC_API_KEY in the environment to run real synthesis. Without it,
-the gather phase still runs and prints what would have been the input.
+Set a chat-capable AI gateway model/key (for example OPENAI_API_KEY with
+--model openai:gpt-4o-mini, or ANTHROPIC_API_KEY with the default Claude tier)
+to run real synthesis. Without one, the gather phase still runs.
 `);
     return;
   }

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -1,9 +1,9 @@
 /**
  * v0.28: `gbrain think` — INTENT → GATHER → SYNTHESIZE → (optional) COMMIT.
  *
- * v0.28.0 ships the full pipeline. The Anthropic call is dependency-injected
- * (MessagesClient interface) so tests can stub it without an API key. Live
- * runs require ANTHROPIC_API_KEY in the environment.
+ * v0.28.0 ships the full pipeline. The synthesis call is dependency-injected
+ * so tests can stub it without an API key. Live runs route through the
+ * provider-neutral AI gateway unless a legacy test client is supplied.
  *
  * --rounds scaffolding: round 1 is the only round actually exercised in
  * v0.28. Round N+1 fed by gaps from round N is the v0.29 follow-up; the
@@ -17,15 +17,16 @@
  * for those flags per Codex P1 #7.
  */
 
-import Anthropic from '@anthropic-ai/sdk';
 import type { BrainEngine, SynthesisEvidenceInput } from '../engine.ts';
+import type Anthropic from '@anthropic-ai/sdk';
+import { chat } from '../ai/gateway.ts';
 import { runGather, renderPagesBlock, takesHitToTakeForPrompt } from './gather.ts';
 import { renderTakesBlock } from './sanitize.ts';
 import { buildThinkSystemPrompt, buildThinkUserMessage } from './prompt.ts';
 import { resolveCitations, type ParsedCitation } from './cite-render.ts';
 import { resolveModel } from '../model-config.ts';
 
-/** Anthropic Messages client interface — same shape used by subagent.ts so test stubs can be shared. */
+/** Legacy Messages-style client interface retained for tests and custom callers. */
 export interface ThinkLLMClient {
   create(params: Anthropic.MessageCreateParamsNonStreaming, opts?: { signal?: AbortSignal }): Promise<Anthropic.Message>;
 }
@@ -47,7 +48,7 @@ export interface RunThinkOpts {
   until?: string;
   /** When set, MCP-bound calls forward this to the gather phase (server-side filter). */
   takesHoldersAllowList?: string[];
-  /** Inject an LLM client (for tests). Defaults to a fresh Anthropic SDK client. */
+  /** Inject an LLM client (for tests). Defaults to provider-neutral gateway chat. */
   client?: ThinkLLMClient;
   /** Inject a question-embedding function. When omitted, vector takes search is skipped. */
   embedQuestion?: (q: string) => Promise<Float32Array | null>;
@@ -107,6 +108,15 @@ function tryParseJSON(text: string): unknown {
     }
     return null;
   }
+}
+
+function modelForGatewayChat(model: string): string {
+  const trimmed = model.trim();
+  // resolveModel() returns bare model ids for built-in aliases/tier defaults
+  // (claude-opus-4-7, claude-sonnet-4-6, ...). gateway.chat() requires the
+  // provider:model form, so preserve explicit provider overrides and treat
+  // legacy bare defaults as Anthropic.
+  return trimmed.includes(':') ? trimmed : `anthropic:${trimmed}`;
 }
 
 /**
@@ -222,41 +232,48 @@ export async function runThink(
   if (opts.stubResponse) {
     response = opts.stubResponse;
   } else {
-    if (!opts.client && !process.env.ANTHROPIC_API_KEY) {
-      warnings.push('NO_ANTHROPIC_API_KEY');
-      // Degrade gracefully: return the gather without synthesis. Better than throwing.
-      return {
-        question: opts.question,
-        answer: '(no LLM available — set ANTHROPIC_API_KEY or pass `client`)',
-        citations: [],
-        gaps: ['no LLM available; gather succeeded but synthesis skipped'],
-        pagesGathered: gather.pages.length,
-        takesGathered: gather.takes.length,
-        graphHits: gather.graphSlugs.length,
-        modelUsed,
-        rounds: 0,
-        warnings,
-        diagnostics: {
-          pagesFromHybrid: gather.diagnostics.pagesFromHybrid,
-          takesFromKeyword: gather.diagnostics.takesFromKeyword,
-          takesFromVector: gather.diagnostics.takesFromVector,
-          graphHits: gather.diagnostics.graphHits,
-        },
-      };
+    let text = '';
+    if (opts.client) {
+      const result = await opts.client.create({
+        model: modelUsed,
+        max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+        system: systemPrompt,
+        messages: [{ role: 'user', content: userMessage }],
+      });
+      const block = result.content.find(b => b.type === 'text');
+      text = block && typeof block.text === 'string' ? block.text : '';
+    } else {
+      try {
+        const result = await chat({
+          model: modelForGatewayChat(modelUsed),
+          maxTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+          system: systemPrompt,
+          messages: [{ role: 'user', content: userMessage }],
+        });
+        text = result.text;
+      } catch (err) {
+        warnings.push(`LLM_UNAVAILABLE: ${err instanceof Error ? err.message : String(err)}`);
+        // Degrade gracefully: return the gather without synthesis. Better than throwing.
+        return {
+          question: opts.question,
+          answer: '(no LLM available — configure an AI gateway chat provider or pass `client`)',
+          citations: [],
+          gaps: ['no LLM available; gather succeeded but synthesis skipped'],
+          pagesGathered: gather.pages.length,
+          takesGathered: gather.takes.length,
+          graphHits: gather.graphSlugs.length,
+          modelUsed,
+          rounds: 0,
+          warnings,
+          diagnostics: {
+            pagesFromHybrid: gather.diagnostics.pagesFromHybrid,
+            takesFromKeyword: gather.diagnostics.takesFromKeyword,
+            takesFromVector: gather.diagnostics.takesFromVector,
+            graphHits: gather.diagnostics.graphHits,
+          },
+        };
+      }
     }
-    // Anthropic SDK exposes the create method via .messages — match the structural signature.
-    const realClient = new Anthropic();
-    const client: ThinkLLMClient = opts.client ?? {
-      create: (params, opts2) => realClient.messages.create(params, opts2),
-    };
-    const result = await client.create({
-      model: modelUsed,
-      max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
-      system: systemPrompt,
-      messages: [{ role: 'user', content: userMessage }],
-    });
-    const block = result.content.find(b => b.type === 'text');
-    const text = block && 'text' in block ? block.text : '';
     const parsed = tryParseJSON(text);
     if (!parsed || typeof parsed !== 'object') {
       warnings.push('LLM_OUTPUT_NOT_JSON');

--- a/test/think-pipeline.serial.test.ts
+++ b/test/think-pipeline.serial.test.ts
@@ -1,6 +1,7 @@
-import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runThink, persistSynthesis, type ThinkLLMClient } from '../src/core/think/index.ts';
+import { __setChatTransportForTests, resetGateway, type ChatResult } from '../src/core/ai/gateway.ts';
 import { sanitizeTakeForPrompt, renderTakesBlock } from '../src/core/think/sanitize.ts';
 import { resolveCitations, parseInlineCitations, normalizeStructuredCitations } from '../src/core/think/cite-render.ts';
 import { runGather } from '../src/core/think/gather.ts';
@@ -25,6 +26,11 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await engine.disconnect();
+});
+
+afterEach(() => {
+  __setChatTransportForTests(null);
+  resetGateway();
 });
 
 describe('sanitizeTakeForPrompt', () => {
@@ -177,6 +183,51 @@ describe('runThink (with stub client)', () => {
     expect(result.warnings).not.toContain('LLM_OUTPUT_NOT_JSON');
   });
 
+  test('uses provider-neutral gateway chat when no injected client is provided', async () => {
+    let capturedModel: string | undefined;
+    let capturedSystem: string | undefined;
+    let capturedUser: string | undefined;
+    __setChatTransportForTests(async (opts): Promise<ChatResult> => {
+      capturedModel = opts.model;
+      capturedSystem = opts.system;
+      capturedUser = typeof opts.messages[0]?.content === 'string'
+        ? opts.messages[0].content
+        : JSON.stringify(opts.messages[0]?.content ?? '');
+      return {
+        text: JSON.stringify({
+          answer: 'Gateway synthesis says Alice is a strong technical founder [people/alice-example#2].',
+          citations: [{ page_slug: 'people/alice-example', row_num: 2, citation_index: 1 }],
+          gaps: [],
+        }),
+        blocks: [{ type: 'text', text: 'unused' }],
+        stopReason: 'end',
+        usage: { input_tokens: 10, output_tokens: 10, cache_read_tokens: 0, cache_creation_tokens: 0 },
+        model: 'openai:gpt-4o-mini',
+        providerId: 'openai',
+      };
+    });
+
+    const origKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      const result = await runThink(engine, {
+        question: 'technical founder',
+        model: 'openai:gpt-4o-mini',
+      });
+
+      expect(result.answer).toContain('Gateway synthesis');
+      expect(result.citations).toHaveLength(1);
+      expect(result.modelUsed).toBe('openai:gpt-4o-mini');
+      expect(result.rounds).toBe(1);
+      expect(result.warnings).not.toContain('NO_ANTHROPIC_API_KEY');
+      expect(capturedModel).toBe('openai:gpt-4o-mini');
+      expect(capturedSystem).toContain("gbrain's synthesis engine");
+      expect(capturedUser).toContain('Strong technical founder');
+    } finally {
+      if (origKey) process.env.ANTHROPIC_API_KEY = origKey;
+    }
+  });
+
   test('handles malformed LLM output gracefully (regex citation fallback)', async () => {
     const stubClient: ThinkLLMClient = {
       create: async () => ({
@@ -205,17 +256,12 @@ describe('runThink (with stub client)', () => {
     expect(result.citations.length).toBeGreaterThanOrEqual(2);
   });
 
-  test('degrades gracefully without ANTHROPIC_API_KEY', async () => {
-    const origKey = process.env.ANTHROPIC_API_KEY;
-    delete process.env.ANTHROPIC_API_KEY;
-    try {
-      const result = await runThink(engine, { question: 'no key test' });
-      expect(result.warnings).toContain('NO_ANTHROPIC_API_KEY');
-      expect(result.answer).toContain('no LLM available');
-      expect(result.rounds).toBe(0);
-    } finally {
-      if (origKey) process.env.ANTHROPIC_API_KEY = origKey;
-    }
+  test('degrades gracefully when gateway chat is unavailable', async () => {
+    resetGateway();
+    const result = await runThink(engine, { question: 'no key test' });
+    expect(result.warnings.some(w => w.startsWith('LLM_UNAVAILABLE:'))).toBe(true);
+    expect(result.answer).toContain('no LLM available');
+    expect(result.rounds).toBe(0);
   });
 
   test('persistSynthesis writes synthesis page + evidence rows', async () => {


### PR DESCRIPTION
## Summary
- route `gbrain think` synthesis through the provider-neutral AI gateway instead of constructing an Anthropic SDK client directly
- preserve injected legacy Messages-style clients for tests/custom callers
- update CLI help to describe gateway-backed chat providers instead of Anthropic-only runtime behavior
- add regression coverage proving OpenAI-style `openai:gpt-4o-mini` routes through gateway chat without `ANTHROPIC_API_KEY`

## Test Plan
- `bun test --timeout=60000 test/think-pipeline.serial.test.ts`
- `bun run verify`
