### PR TITLE
feat(search): opt-in floor-ratio gate for post-fusion boost stages

### DIFF
--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -47,14 +47,72 @@ const DEBUG = process.env.GBRAIN_SEARCH_DEBUG === '1';
  * Apply backlink boost to a result list in place. Mutates each result's score
  * by (1 + BACKLINK_BOOST_COEF * log(1 + count)). Pure data transform; no DB call.
  * Caller fetches counts via engine.getBacklinkCounts.
+ *
+ * `floorRatio` (optional, opt-in): when set, the boost only fires for
+ * results whose pre-boost score is ≥ `floorRatio * topScore`. Pages
+ * below the gate keep their unboosted score. Default undefined → no gate
+ * (preserves existing behavior). See `computeFloorThreshold` for rationale.
  */
-export function applyBacklinkBoost(results: SearchResult[], counts: Map<string, number>): void {
+export function applyBacklinkBoost(
+  results: SearchResult[],
+  counts: Map<string, number>,
+  floorRatio?: number,
+): void {
+  const threshold = computeFloorThreshold(results, floorRatio);
   for (const r of results) {
+    if (r.score < threshold) continue;
     const count = counts.get(r.slug) ?? 0;
     if (count > 0) {
       r.score *= (1.0 + BACKLINK_BOOST_COEF * Math.log(1 + count));
     }
   }
+}
+
+/**
+ * Floor-ratio gate (opt-in, default off).
+ *
+ * Returns `-Infinity` when `floorRatio` is undefined → the gate never
+ * fires (existing behavior preserved). When provided → returns
+ * `topScore * floorRatio`; callers skip the boost for any result with
+ * `r.score < threshold`.
+ *
+ * **Why this exists.** gbrain's bounded boosts (the `[1.0, ~1.6]` clip
+ * range from log-compressed salience, the log-scaled backlink factor,
+ * the half-life-decayed recency factor) keep any single boost from
+ * catastrophically flipping rankings. That guarantee holds for small
+ * curated corpora.
+ *
+ * On larger corpora indexed with real high-dimensional embedders
+ * (text-embedding-3-large, Voyage 3-large, Voyage 4, etc.) the baseline
+ * vector similarity between topically-unrelated "professional content"
+ * is non-trivial. Weak-overlap pages land in a query's top-K via vector
+ * overlap alone, receive the multiplicative boost, and leapfrog the
+ * legitimate primary hit. The boost magnitudes are small enough that
+ * any single comparison still feels "safe," but in the long tail of
+ * top-K shuffles the regression is visible.
+ *
+ * The gate cuts each boost's reach. With `floorRatio: 0.85`, only
+ * results within 85% of `topScore` are eligible; the long tail keeps
+ * its unboosted score and original rank. A truly-strong primary
+ * always wins regardless of boost magnitude on weaker candidates.
+ *
+ * Empirical motivation comes from a labeled-retrieval ablation we ran
+ * in the SkyTwin twin-memory layer that consumes gbrain
+ * (https://github.com/jayzalowitz/skytwin/pull/272 — switched to a
+ * real OpenAI-shape embedder, observed weak-overlap authored pages
+ * climbing into top-K via vector overlap, added the floor-ratio gate
+ * to fix it). Default-off because we cannot reproduce the failure mode
+ * from outside on gbrain's own eval fixtures — surfacing it as an
+ * opt-in lets adopters with large dense corpora opt in without
+ * changing the default behavior anyone else relies on.
+ */
+function computeFloorThreshold(results: SearchResult[], floorRatio?: number): number {
+  if (floorRatio === undefined) return Number.NEGATIVE_INFINITY;
+  let top = Number.NEGATIVE_INFINITY;
+  for (const r of results) {
+    if (r.score > top) top = r.score;
+  }
+  return top * floorRatio;
 }
 
 /**
@@ -72,9 +130,12 @@ export function applySalienceBoost(
   results: SearchResult[],
   scores: Map<string, number>,
   strength: 'on' | 'strong',
+  floorRatio?: number,
 ): void {
   const k = strength === 'strong' ? 0.30 : 0.15;
+  const threshold = computeFloorThreshold(results, floorRatio);
   for (const r of results) {
+    if (r.score < threshold) continue;
     const key = `${r.source_id ?? 'default'}::${r.slug}`;
     const score = scores.get(key);
     if (!score || score <= 0) continue;
@@ -101,12 +162,15 @@ export function applyRecencyBoost(
   decayMap: import('./recency-decay.ts').RecencyDecayMap,
   fallback: import('./recency-decay.ts').RecencyDecayConfig,
   nowMs: number = Date.now(),
+  floorRatio?: number,
 ): void {
   const strengthMul = strength === 'strong' ? 1.5 : 1.0;
+  const threshold = computeFloorThreshold(results, floorRatio);
   // Sort prefixes longest-first so 'media/articles/' matches before 'media/'.
   const prefixes = Object.keys(decayMap).sort((a, b) => b.length - a.length);
 
   for (const r of results) {
+    if (r.score < threshold) continue;
     const key = `${r.source_id ?? 'default'}::${r.slug}`;
     const d = dates.get(key);
     if (!d) continue;
@@ -143,6 +207,18 @@ export interface PostFusionOpts {
   recency: 'off' | 'on' | 'strong';
   decayMap?: import('./recency-decay.ts').RecencyDecayMap;
   fallback?: import('./recency-decay.ts').RecencyDecayConfig;
+  /**
+   * Opt-in floor-ratio gate applied to every boost stage. When set, each
+   * stage skips results whose pre-boost score is below
+   * `floorRatio * topScore` *at the moment that stage runs* (so stages
+   * compose: salience-boosted scores set the floor for the recency stage,
+   * etc). Default undefined → no gate, exact prior behavior.
+   *
+   * Sensible values: 0.85–0.95 for dense embedder corpora; undefined
+   * (default) for everything else. See `computeFloorThreshold` for
+   * empirical motivation.
+   */
+  floorRatio?: number;
 }
 
 export async function runPostFusionStages(
@@ -157,7 +233,7 @@ export async function runPostFusionStages(
     try {
       const slugs = Array.from(new Set(results.map(r => r.slug)));
       const counts = await engine.getBacklinkCounts(slugs);
-      applyBacklinkBoost(results, counts);
+      applyBacklinkBoost(results, counts, opts.floorRatio);
     } catch {
       // Non-fatal; preserves the existing pre-v0.29.1 contract.
     }
@@ -174,7 +250,7 @@ export async function runPostFusionStages(
   if (opts.salience !== 'off') {
     try {
       const scores = await engine.getSalienceScores(refs);
-      applySalienceBoost(results, scores, opts.salience);
+      applySalienceBoost(results, scores, opts.salience, opts.floorRatio);
     } catch {
       // Non-fatal.
     }
@@ -191,6 +267,8 @@ export async function runPostFusionStages(
         opts.recency,
         opts.decayMap ?? DEFAULT_RECENCY_DECAY,
         opts.fallback ?? DEFAULT_FALLBACK,
+        Date.now(),
+        opts.floorRatio,
       );
     } catch {
       // Non-fatal.

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { rrfFusion, cosineSimilarity, applyBacklinkBoost } from '../src/core/search/hybrid.ts';
+import { rrfFusion, cosineSimilarity, applyBacklinkBoost, applySalienceBoost } from '../src/core/search/hybrid.ts';
 import type { SearchResult } from '../src/core/types.ts';
 
 function makeResult(overrides: Partial<SearchResult> = {}): SearchResult {
@@ -237,5 +237,95 @@ describe('applyBacklinkBoost (v0.10.1)', () => {
     expect(results[0].score).toBe(1.0);
     expect(results[1].score).toBeGreaterThan(1.0);
     expect(results[2].score).toBeGreaterThan(results[1].score);
+  });
+});
+
+describe('floor-ratio gate (opt-in, default off)', () => {
+  test('floorRatio undefined: no gate, all eligible pages get boost (existing behavior)', () => {
+    const results: SearchResult[] = [
+      makeResult({ slug: 'top', score: 1.0 }),
+      makeResult({ slug: 'weak', score: 0.3 }),
+    ];
+    applyBacklinkBoost(results, new Map([['top', 10], ['weak', 10]]));
+    const expectedFactor = 1 + 0.05 * Math.log(11);
+    expect(results[0].score).toBeCloseTo(1.0 * expectedFactor, 6);
+    expect(results[1].score).toBeCloseTo(0.3 * expectedFactor, 6);
+  });
+
+  test('floorRatio 0.85: weak page (score 0.3, topScore 1.0) gets no boost', () => {
+    const results: SearchResult[] = [
+      makeResult({ slug: 'top', score: 1.0 }),
+      makeResult({ slug: 'weak', score: 0.3 }),
+    ];
+    applyBacklinkBoost(results, new Map([['top', 10], ['weak', 10]]), 0.85);
+    const expectedFactor = 1 + 0.05 * Math.log(11);
+    expect(results[0].score).toBeCloseTo(1.0 * expectedFactor, 6);
+    expect(results[1].score).toBe(0.3); // gated out, unchanged
+  });
+
+  test('floorRatio 0.85: borderline page (score 0.85, topScore 1.0) is eligible', () => {
+    const results: SearchResult[] = [
+      makeResult({ slug: 'top', score: 1.0 }),
+      makeResult({ slug: 'edge', score: 0.85 }),
+    ];
+    applyBacklinkBoost(results, new Map([['top', 10], ['edge', 10]]), 0.85);
+    const expectedFactor = 1 + 0.05 * Math.log(11);
+    expect(results[1].score).toBeCloseTo(0.85 * expectedFactor, 6);
+  });
+
+  test('regression scenario: weak-overlap page cannot leapfrog strong primary', () => {
+    // Models the failure mode the gate exists to prevent: a weak-overlap
+    // page (low raw score, high metadata signal) climbing above a strong
+    // primary hit (high raw score, no metadata signal). Without the gate
+    // the weak page's metadata boost is enough to overtake; with the gate
+    // it isn't eligible for the boost at all.
+    const withoutGate: SearchResult[] = [
+      makeResult({ slug: 'strong-primary', score: 1.0 }),
+      makeResult({ slug: 'weak-with-signal', score: 0.5 }),
+    ];
+    applyBacklinkBoost(withoutGate, new Map([['weak-with-signal', 1000]]));
+    // Even though strong-primary started 2x higher, weak's huge backlink
+    // count is enough to push it close (or potentially past) on score —
+    // sort the array to inspect rank order.
+    withoutGate.sort((a, b) => b.score - a.score);
+
+    const withGate: SearchResult[] = [
+      makeResult({ slug: 'strong-primary', score: 1.0 }),
+      makeResult({ slug: 'weak-with-signal', score: 0.5 }),
+    ];
+    applyBacklinkBoost(withGate, new Map([['weak-with-signal', 1000]]), 0.85);
+    withGate.sort((a, b) => b.score - a.score);
+    // With the gate, strong-primary is unambiguously first; weak's score
+    // is unchanged from its raw 0.5 since it's below 0.85 * 1.0.
+    expect(withGate[0].slug).toBe('strong-primary');
+    expect(withGate[1].slug).toBe('weak-with-signal');
+    expect(withGate[1].score).toBe(0.5);
+  });
+
+  test('applySalienceBoost honors floorRatio gate', () => {
+    const results: SearchResult[] = [
+      makeResult({ slug: 'top', score: 1.0, source_id: undefined }),
+      makeResult({ slug: 'weak', score: 0.3, source_id: undefined }),
+    ];
+    const scores = new Map([
+      ['default::top', 5],
+      ['default::weak', 5],
+    ]);
+    applySalienceBoost(results, scores, 'on', 0.85);
+    const expectedFactor = 1 + 0.15 * Math.log(6);
+    expect(results[0].score).toBeCloseTo(1.0 * expectedFactor, 6);
+    expect(results[1].score).toBe(0.3); // gated out
+  });
+
+  test('empty results: gate is a no-op (no divide-by-zero)', () => {
+    const results: SearchResult[] = [];
+    expect(() => applyBacklinkBoost(results, new Map(), 0.85)).not.toThrow();
+  });
+
+  test('single result: gate eligibility is trivially true (page is its own top)', () => {
+    const results: SearchResult[] = [makeResult({ slug: 'only', score: 0.5 })];
+    applyBacklinkBoost(results, new Map([['only', 10]]), 0.85);
+    const expectedFactor = 1 + 0.05 * Math.log(11);
+    expect(results[0].score).toBeCloseTo(0.5 * expectedFactor, 6);
   });
 });


### PR DESCRIPTION
## What

Adds an optional `floorRatio?: number` to `applyBacklinkBoost`, `applySalienceBoost`, `applyRecencyBoost`, and `PostFusionOpts`. When set, each boost stage skips results whose pre-boost score is below `floorRatio * topScore` at the moment that stage runs — only the head of the candidate pool receives the multiplicative bonus. Default `undefined` preserves exact prior behavior bit-for-bit.

## The failure mode this addresses

gbrain's bounded boosts (log-compressed salience clipped to `[1.0, ~1.6]`, log-scaled backlink factor, half-life-decayed recency) work as designed on curated test corpora. The existing comments in `hybrid.ts:69` make the design intent explicit: *"a strong boost can't catastrophically flip rankings."*

That guarantee weakens on larger corpora indexed with real high-dimensional embedders (`text-embedding-3-large`, `voyage-3-large`, `voyage-4-large`, `zembed-1`). Baseline vector similarity between topically-unrelated "professional content" is non-trivial — weak-overlap pages routinely land in a query's top-K via vector overlap alone, each receives the multiplicative boost, and on a non-trivial fraction of queries a weak page with high metadata signal climbs above the legitimate primary hit. The per-boost factor still looks harmless in isolation; the compound effect across the long tail of top-K candidates is what shifts ranks.

Concrete example from the new test suite:

| page              | raw RRF score | backlink count | post-boost score |
|-------------------|--------------:|---------------:|-----------------:|
| `strong-primary`  | 1.00          | 0              | 1.000            |
| `weak-with-signal`| 0.50          | 1000           | 0.673            |

`strong-primary` still wins in that pair, but the gap is now ~50% of what the raw text+vector signal said it should be. Drop `strong-primary`'s raw score below ~1.35× the weak page (common in the long tail) and rank flips, even though every component signal said the strong page was the unambiguous match.

## The fix

A boost only fires for results within `floorRatio × topScore` at the moment that stage runs. The long tail keeps its unboosted score and original rank. Stages compose naturally — salience boosts against its own top, then recency runs against the post-salience top, etc. A truly-strong primary always wins regardless of boost magnitude on weaker candidates.

`0.85` is a reasonable starting point for dense embedder corpora — it covers the head of a typical RRF candidate pool while excluding weak-overlap distractors. The value comes from a labeled-retrieval ablation in the [SkyTwin](https://github.com/jayzalowitz/skytwin) twin-memory layer (which consumes gbrain as its default memory backend via [skytwin#250](https://github.com/jayzalowitz/skytwin/pull/250)): `0.85` is the largest ratio that fully eliminated the leapfrog regression on our labeled corpus while preserving baseline rankings on queries that don't have a metadata signal to bias. The relevant ablation is in [skytwin#272](https://github.com/jayzalowitz/skytwin/pull/272).

## Backward compatibility

`floorRatio` defaults to `undefined` → no gate, no threshold computation, exact prior behavior. Existing call sites are untouched; the new parameter is positional-last and optional on each function. `PostFusionOpts.floorRatio` is similarly optional and unset by default.

The gate is opt-in by design — it changes ranking behavior, and existing adopters have tuned around the current post-fusion stack. Surfacing it as a flag lets each consumer evaluate against their own corpus before flipping it on, rather than landing a behavior change in a patch release.

## Tests

7 new cases in `test/search.test.ts`:

- `floorRatio` undefined preserves existing behavior bit-for-bit
- weak page gated out, top page boosted as before
- borderline page at exactly the threshold is eligible (inclusive boundary)
- regression scenario: weak page with strong metadata signal cannot leapfrog strong primary
- `applySalienceBoost` honors the gate (parity with `applyBacklinkBoost`)
- empty results no-op without divide-by-zero
- single-result trivially eligible (page is its own top)

`bun test test/search.test.ts`: **33/33 pass** (was 26/26).
`bun run verify`: pass (typecheck + 12 guard scripts).

## Why I'm sending this

We've been running gbrain as the production memory backend in SkyTwin for the last week, and this came out of the labeled-retrieval ablation we did on top of it. The gate is general-purpose — the shape applies to any per-result boost on metadata orthogonal to the raw text+vector signal — so it seemed worth offering upstream rather than keeping it forked. The opt-in framing makes it cheap to merge if it lands cleanly and equally cheap to leave un-flipped if your shootout corpus doesn't surface the same regression.