### PR TITLE
fix: support root-level file references in ENTITY_REF_RE

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -56,7 +56,7 @@ const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|pr
  * `.md` suffix so the same function works for both filesystem and DB content.
  */
 const ENTITY_REF_RE = new RegExp(
-  `\\[([^\\]]+)\\]\\((?:\\.\\.\\/)*(${DIR_PATTERN}\\/[^)\\s]+?)(?:\\.md)?\\)`,
+  `\\[([^\\]]+)\\]\\((?:\\.\\.\\/|\\.\\/)*((?:${DIR_PATTERN}\\/[^)\\s]+?)|[^)\\s\\/:]+)(?:\\.md)?\\)`,
   'g',
 );
 


### PR DESCRIPTION
The Dir-prefix regex (ENTITY_REF_RE) only matched markdown links targeting dir-slugged paths like people/alice or companies/acme. Root-level files like action-tracker.md, decisions-log.md, and home.md — common in Obsidian and personal knowledge vaults — were silently skipped, leaving those pages unlinked in the knowledge graph.

This extends ENTITY_REF_RE with an alternation: after matching the optional ../ or ./ prefix, accept EITHER a dir-slugged path (the existing behavior) OR a bare filename without directory prefix. External URLs are still excluded (the [^)\\s\/:]+ class omits :, so https://... never matches).

The FS-source path (extractMarkdownLinks) already handled root-level files without restriction; this brings the DB-source path (ENTITY_REF_RE) to parity.

All 21 existing extract tests continue to pass.