### PR TITLE
orphan-metric: align find_orphans surfaces with get_health and tighten exclusions

### DIFF
--- a/src/commands/orphans.ts
+++ b/src/commands/orphans.ts
@@ -50,6 +50,14 @@ const DENY_PREFIXES = [
   'scripts/',
   'templates/',
   'openclaw/config/',
+  // Source-type ingestions: no inbound wikilinks is the healthy default.
+  // These pages are anchored via timeline entries / parent records, not by
+  // being cited from concept pages. Without exclusion they dominate orphan
+  // counts and crush no_orphans_score for reasons unrelated to graph rot.
+  'emails/',
+  'attachments/',
+  '0-daily/',
+  '4-archive/',
 ];
 
 /** First slug segments where no inbound links is expected */

--- a/src/commands/orphans.ts
+++ b/src/commands/orphans.ts
@@ -58,6 +58,13 @@ const DENY_PREFIXES = [
   'attachments/',
   '0-daily/',
   '4-archive/',
+  // Navigation pages are vault-level hub-target pages (Obsidian graph-view
+  // clustering anchors — body literally reads "Notes linking here appear in
+  // the graph view as connected to this hub"). They exist to organize the
+  // graph, not to carry content; missing inbound = sparse [[wikilink]] usage
+  // in the vault, not graph rot. Excluding them keeps brain_score focused on
+  // real content rot.
+  'navigation/',
 ];
 
 /** First slug segments where no inbound links is expected */

--- a/src/commands/orphans.ts
+++ b/src/commands/orphans.ts
@@ -1,15 +1,21 @@
 /**
- * gbrain orphans — Surface pages with no inbound wikilinks.
+ * gbrain orphans — Surface ISLANDED pages (no inbound AND no outbound).
  *
- * Deterministic: zero LLM calls. Queries the links table for pages with
- * no entries where to_page_id = pages.id. By default filters out
- * auto-generated pages and pseudo-pages where no inbound links is expected.
+ * Deterministic: zero LLM calls. Routes through `engine.findIslandedPages()`
+ * which shares its SQL predicate with `getHealth.orphan_pages`, so the
+ * count this command reports equals the `brain_score` orphan_pages count
+ * by construction (v0.33+ step-4 alignment).
+ *
+ * The JS-side `shouldExclude` filter is retained as an exported helper
+ * for backwards-compat tests + agent consumers that may inspect a slug
+ * outside the SQL path, but `findOrphans` no longer runs it — the SQL
+ * predicate is the runtime authority.
  *
  * Usage:
- *   gbrain orphans                  # list orphans grouped by domain
+ *   gbrain orphans                  # list islanded pages grouped by domain
  *   gbrain orphans --json           # JSON output for agent consumption
  *   gbrain orphans --count          # just the number
- *   gbrain orphans --include-pseudo # include auto-generated/pseudo pages
+ *   gbrain orphans --include-pseudo # relax exclusions; islanded predicate unchanged
  */
 
 import type { BrainEngine } from '../core/engine.ts';
@@ -27,9 +33,7 @@ export interface OrphanPage {
 export interface OrphanResult {
   orphans: OrphanPage[];
   total_orphans: number;
-  total_linkable: number;
   total_pages: number;
-  excluded: number;
 }
 
 // --- Filter constants ---
@@ -73,8 +77,13 @@ const FIRST_SEGMENT_EXCLUSIONS = new Set(['scratch', 'thoughts', 'catalog', 'ent
 // --- Filter logic ---
 
 /**
- * Returns true if a slug should be excluded from orphan reporting by default.
- * These are pages where having no inbound links is expected / not a content problem.
+ * @deprecated v0.33+ step-4 alignment: SQL is now the runtime authority for
+ * orphan exclusion (see `findIslandedPages` in both engines). This helper is
+ * retained only for backwards-compat unit tests + any out-of-band JS-side
+ * consumer inspecting a single slug. New code should not call it from the
+ * runtime path — the engine's predicate is single-source-of-truth.
+ *
+ * Returns true if a slug would be excluded by the SQL predicate.
  */
 export function shouldExclude(slug: string): boolean {
   // Pseudo-pages (exact match)
@@ -114,11 +123,11 @@ export function deriveDomain(frontmatterDomain: string | null | undefined, slug:
 
 /**
  * Find pages with no inbound links via the engine's built-in helper.
- * Returns raw rows (all pages regardless of filter).
+ * Returns raw rows (all pages with zero inbound, soft-deleted excluded).
  *
- * As of v0.17: takes an engine argument. Composes with runCycle which
- * passes an explicit engine. No more db.getConnection() global — fixes
- * the PGLite-vs-Postgres + test-fixture coupling codex flagged.
+ * Kept for backwards-compat tests + enrichment-pattern consumers.
+ * v0.33+ step-4 alignment: the user-visible orphan surface now uses
+ * `findIslandedPages` via `findOrphans` below.
  */
 export async function queryOrphanPages(
   engine: BrainEngine,
@@ -127,55 +136,51 @@ export async function queryOrphanPages(
 }
 
 /**
- * Find orphan pages, with optional pseudo-page filtering.
+ * Find islanded pages, with optional pseudo-page surfacing.
  * Returns structured OrphanResult with totals.
  *
- * As of v0.17: `engine` is required. See queryOrphanPages for rationale.
+ * v0.33+ step-4 alignment: routes through `engine.findIslandedPages()`
+ * whose SQL predicate matches `getHealth.orphan_pages` by construction,
+ * so `result.total_orphans === (await engine.getHealth()).orphan_pages`.
+ *
+ * `opts.includePseudo=true` relaxes the SQL exclusion set (surfaces
+ * auto-generated / pseudo-page slugs) but does NOT change the islanded
+ * graph predicate. Per Codex pre-impl: --include-pseudo means "show me
+ * more rows", never "redefine what an orphan is".
  */
 export async function findOrphans(
   engine: BrainEngine,
   opts: { includePseudo?: boolean } = {},
 ): Promise<OrphanResult> {
   const includePseudo = !!opts.includePseudo;
-  // The NOT EXISTS anti-join over pages × links can take seconds on 50K-page
-  // brains. Heartbeat every second so agents see the scan is alive. Keyset
-  // pagination was considered and rejected: without an index on
-  // links.to_page_id it does no useful work. Adding that index is a
-  // follow-up (v0.14.3 schema migration).
+  // The two NOT EXISTS anti-joins over pages × links can take seconds on
+  // 50K-page brains. Heartbeat every second so agents see the scan is
+  // alive. links indexes (to_page_id, from_page_id) keep this responsive
+  // on Colin's 10K-page brain (~600ms).
   const progress = createProgress(cliOptsToProgressOptions(getCliOptions()));
   progress.start('orphans.scan');
-  const stopHb = startHeartbeat(progress, 'scanning pages for missing inbound links…');
-  let allOrphans: { slug: string; title: string; domain: string | null }[];
+  const stopHb = startHeartbeat(progress, 'scanning pages for islanded (no in + no out) links…');
+  let islandedRows: { slug: string; title: string; domain: string | null }[];
   let total: number;
   try {
-    allOrphans = await engine.findOrphanPages();
-    // Count total pages in DB for the summary line
+    islandedRows = await engine.findIslandedPages({ includePseudo });
     const stats = await engine.getStats();
     total = stats.page_count;
   } finally {
     stopHb();
     progress.finish();
   }
-  const _totalPages = allOrphans.length; // pages with no inbound links (preserved for ref)
 
-  const filtered = includePseudo
-    ? allOrphans
-    : allOrphans.filter(row => !shouldExclude(row.slug));
-
-  const orphans: OrphanPage[] = filtered.map(row => ({
+  const orphans: OrphanPage[] = islandedRows.map(row => ({
     slug: row.slug,
     title: row.title,
     domain: deriveDomain(row.domain, row.slug),
   }));
 
-  const excluded = allOrphans.length - filtered.length;
-
   return {
     orphans,
     total_orphans: orphans.length,
-    total_linkable: filtered.length + (total - allOrphans.length),
     total_pages: total,
-    excluded,
   };
 }
 
@@ -184,9 +189,9 @@ export async function findOrphans(
 export function formatOrphansText(result: OrphanResult): string {
   const lines: string[] = [];
 
-  const { orphans, total_orphans, total_linkable, total_pages, excluded } = result;
+  const { orphans, total_orphans, total_pages } = result;
   lines.push(
-    `${total_orphans} orphans out of ${total_linkable} linkable pages (${total_pages} total; ${excluded} excluded)\n`,
+    `${total_orphans} islanded pages out of ${total_pages} total\n`,
   );
 
   if (orphans.length === 0) {
@@ -226,16 +231,22 @@ export async function runOrphans(engine: BrainEngine, args: string[]) {
   if (args.includes('--help') || args.includes('-h')) {
     console.log(`Usage: gbrain orphans [options]
 
-Find pages with no inbound wikilinks.
+Find ISLANDED pages — no inbound AND no outbound wikilinks. By default the
+authoritative exclusion set (source-type ingestions, vault wayfinding,
+pseudo-page slugs, suffix/segment patterns, first-segment exclusions) is
+applied at the SQL layer, so this count equals get_health.orphan_pages.
 
 Options:
   --json            Output as JSON (for agent consumption)
-  --count           Output just the number of orphans
-  --include-pseudo  Include auto-generated and pseudo pages in results
+  --count           Output just the number of islanded pages
+  --include-pseudo  Relax the exclusion set (surface auto-generated and
+                    pseudo pages). The islanded graph predicate is
+                    unchanged — this flag never widens beyond "no in AND
+                    no out".
   --help, -h        Show this help
 
 Output (default): grouped by domain, sorted alphabetically within each group
-Summary line: N orphans out of M linkable pages (K total; K-M excluded)
+Summary line: N islanded pages out of K total
 `);
     return;
   }

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -938,11 +938,10 @@ async function runPhaseOrphans(engine: BrainEngine): Promise<PhaseResult> {
       phase: 'orphans',
       status: count > 20 ? 'warn' : 'ok',
       duration_ms: 0,
-      summary: `${count} orphan page(s) out of ${result.total_pages} total`,
+      summary: `${count} islanded page(s) out of ${result.total_pages} total`,
       details: {
         total_orphans: count,
         total_pages: result.total_pages,
-        excluded: result.excluded,
       },
     };
   } catch (e) {

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -711,10 +711,32 @@ export interface BrainEngine {
   /**
    * Return every page with no inbound links (from any source).
    * Domain comes from the frontmatter `domain` field (null if unset).
-   * The caller filters pseudo-pages + derives display domain.
-   * Used by `gbrain orphans` and `runCycle`'s orphan sweep phase.
+   *
+   * NOTE (v0.33+ step-4 alignment): this is the "no-inbound candidate"
+   * surface, kept for enrichment/sweep use (runCycle reachability checks,
+   * future link-recovery tools). The user-facing `gbrain orphans` /
+   * `find_orphans` MCP no longer routes through here — they call
+   * `findIslandedPages()` so their count == `getHealth.orphan_pages`.
+   * Soft-deleted pages excluded.
    */
   findOrphanPages(): Promise<Array<{ slug: string; title: string; domain: string | null }>>;
+
+  /**
+   * Return every "islanded" page — no inbound AND no outbound links —
+   * after applying the authoritative exclusion set (source-type prefixes,
+   * vault wayfinding, pseudo-page slugs, suffix/segment patterns,
+   * first-segment exclusions). The SQL predicate is the SAME as
+   * `getHealth.orphan_pages`, so the user-visible `find_orphans` count
+   * equals `get_health.orphan_pages` by construction.
+   *
+   * `opts.includePseudo=true` relaxes the exclusion set (returns ALL
+   * islanded pages including pseudo/source/wayfinding slugs) but does
+   * NOT change the islanded graph predicate — surface auto-generated
+   * pages without redefining what counts as an orphan.
+   *
+   * Used by `gbrain orphans` and the `find_orphans` MCP operation.
+   */
+  findIslandedPages(opts?: { includePseudo?: boolean }): Promise<Array<{ slug: string; title: string; domain: string | null }>>;
 
   // Tags
   /**

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2254,11 +2254,11 @@ const send_job_message: Operation = {
 
 const find_orphans: Operation = {
   name: 'find_orphans',
-  description: 'Find pages with no inbound wikilinks. Essential for content enrichment cycles.',
+  description: 'Find islanded pages (no inbound AND no outbound wikilinks). Count matches get_health.orphan_pages by construction. Essential for content-enrichment cycles and graph-rot triage.',
   params: {
     include_pseudo: {
       type: 'boolean',
-      description: 'Include auto-generated and pseudo pages (default: false)',
+      description: 'Relax the exclusion set to surface auto-generated/pseudo pages. Does NOT change the islanded predicate (default: false).',
     },
   },
   scope: 'read',

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -3161,9 +3161,16 @@ export class PGLiteEngine implements BrainEngine {
         ) as stale_pages,
         -- Bug 11 — orphan = islanded (no inbound AND no outbound).
         -- See BrainHealth.orphan_pages docstring; docs updated to match this.
+        -- Source-type ingestions (emails/attachments/0-daily/4-archive) are
+        -- anchored via timeline/parent record, not wikilinks — excluded so
+        -- brain_score reflects real graph rot.
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+           AND p.slug NOT LIKE 'emails/%'
+           AND p.slug NOT LIKE 'attachments/%'
+           AND p.slug NOT LIKE '0-daily/%'
+           AND p.slug NOT LIKE '4-archive/%'
         ) as orphan_pages,
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1891,6 +1891,56 @@ export class PGLiteEngine implements BrainEngine {
     return rows as Array<{ slug: string; title: string; domain: string | null }>;
   }
 
+  async findIslandedPages(opts?: { includePseudo?: boolean }): Promise<Array<{ slug: string; title: string; domain: string | null }>> {
+    // Mirrors postgres-engine.ts:findIslandedPages. See that method for
+    // rationale. Both engines + both surfaces (getHealth + findIslandedPages)
+    // share this predicate.
+    if (opts?.includePseudo) {
+      const { rows } = await this.db.query(
+        `SELECT
+           p.slug,
+           COALESCE(p.title, p.slug) AS title,
+           p.frontmatter->>'domain' AS domain
+         FROM pages p
+         WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
+           AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+           AND p.deleted_at IS NULL
+         ORDER BY p.slug`
+      );
+      return rows as Array<{ slug: string; title: string; domain: string | null }>;
+    }
+    const { rows } = await this.db.query(
+      `SELECT
+         p.slug,
+         COALESCE(p.title, p.slug) AS title,
+         p.frontmatter->>'domain' AS domain
+       FROM pages p
+       WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
+         AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+         AND p.deleted_at IS NULL
+         AND p.slug NOT IN ('_atlas', '_index', '_stats', '_orphans', '_scratch', 'claude')
+         AND p.slug NOT LIKE '%/#_index' ESCAPE '#'
+         AND p.slug NOT LIKE '%/log'
+         AND p.slug NOT LIKE '%/raw/%'
+         AND p.slug NOT LIKE 'emails/%'
+         AND p.slug NOT LIKE 'attachments/%'
+         AND p.slug NOT LIKE '0-daily/%'
+         AND p.slug NOT LIKE '4-archive/%'
+         AND p.slug NOT LIKE 'templates/%'
+         AND p.slug NOT LIKE 'navigation/%'
+         AND p.slug NOT LIKE 'output/%'
+         AND p.slug NOT LIKE 'dashboards/%'
+         AND p.slug NOT LIKE 'scripts/%'
+         AND p.slug NOT LIKE 'openclaw/config/%'
+         AND p.slug NOT LIKE 'scratch/%' AND p.slug != 'scratch'
+         AND p.slug NOT LIKE 'thoughts/%' AND p.slug != 'thoughts'
+         AND p.slug NOT LIKE 'catalog/%' AND p.slug != 'catalog'
+         AND p.slug NOT LIKE 'entities/%' AND p.slug != 'entities'
+       ORDER BY p.slug`
+    );
+    return rows as Array<{ slug: string; title: string; domain: string | null }>;
+  }
+
   // Tags
   async addTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void> {
     const sourceId = opts?.sourceId ?? 'default';
@@ -3160,27 +3210,37 @@ export class PGLiteEngine implements BrainEngine {
         (SELECT count(*) FROM pages p
          WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
         ) as stale_pages,
-        -- Bug 11 — orphan = islanded (no inbound AND no outbound).
-        -- See BrainHealth.orphan_pages docstring; docs updated to match this.
-        -- Soft-deleted pages (v0.26.5 recovery window) aren't visible to
-        -- consumers; they shouldn't crush brain_score.
-        -- Source-type ingestions (emails/attachments/0-daily/4-archive) are
-        -- anchored via timeline/parent record, not wikilinks — excluded so
-        -- brain_score reflects real graph rot.
+        -- Islanded orphan predicate (v0.33+ step-4 alignment).
+        -- Mirrors postgres-engine.ts. Both engines and both surfaces
+        -- (getHealth + findIslandedPages) share this WHERE so the CLI
+        -- find_orphans count == get_health.orphan_pages by construction.
+        -- JS mirror lives at shouldExclude in commands/orphans.ts and is
+        -- now backwards-compat only.
+        --
+        -- LIKE escape note: %/#_index ESCAPE # matches literal _index
+        -- suffix. Bare _ is a single-char wildcard in LIKE.
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
            AND p.deleted_at IS NULL
+           AND p.slug NOT IN ('_atlas', '_index', '_stats', '_orphans', '_scratch', 'claude')
+           AND p.slug NOT LIKE '%/#_index' ESCAPE '#'
+           AND p.slug NOT LIKE '%/log'
+           AND p.slug NOT LIKE '%/raw/%'
            AND p.slug NOT LIKE 'emails/%'
            AND p.slug NOT LIKE 'attachments/%'
            AND p.slug NOT LIKE '0-daily/%'
            AND p.slug NOT LIKE '4-archive/%'
-           -- Pseudo-pages: templates/ are vault sources (already in CLI DENY,
-           -- aligned here); navigation/ are graph-view hub-target pages
-           -- (intentionally wayfinding, not content). Missing inbound on a
-           -- nav page reflects vault [[wikilink]] sparsity, not graph rot.
            AND p.slug NOT LIKE 'templates/%'
            AND p.slug NOT LIKE 'navigation/%'
+           AND p.slug NOT LIKE 'output/%'
+           AND p.slug NOT LIKE 'dashboards/%'
+           AND p.slug NOT LIKE 'scripts/%'
+           AND p.slug NOT LIKE 'openclaw/config/%'
+           AND p.slug NOT LIKE 'scratch/%' AND p.slug != 'scratch'
+           AND p.slug NOT LIKE 'thoughts/%' AND p.slug != 'thoughts'
+           AND p.slug NOT LIKE 'catalog/%' AND p.slug != 'catalog'
+           AND p.slug NOT LIKE 'entities/%' AND p.slug != 'entities'
         ) as orphan_pages,
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1885,6 +1885,7 @@ export class PGLiteEngine implements BrainEngine {
        WHERE NOT EXISTS (
          SELECT 1 FROM links l WHERE l.to_page_id = p.id
        )
+         AND p.deleted_at IS NULL
        ORDER BY p.slug`
     );
     return rows as Array<{ slug: string; title: string; domain: string | null }>;
@@ -3161,12 +3162,15 @@ export class PGLiteEngine implements BrainEngine {
         ) as stale_pages,
         -- Bug 11 — orphan = islanded (no inbound AND no outbound).
         -- See BrainHealth.orphan_pages docstring; docs updated to match this.
+        -- Soft-deleted pages (v0.26.5 recovery window) aren't visible to
+        -- consumers; they shouldn't crush brain_score.
         -- Source-type ingestions (emails/attachments/0-daily/4-archive) are
         -- anchored via timeline/parent record, not wikilinks — excluded so
         -- brain_score reflects real graph rot.
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+           AND p.deleted_at IS NULL
            AND p.slug NOT LIKE 'emails/%'
            AND p.slug NOT LIKE 'attachments/%'
            AND p.slug NOT LIKE '0-daily/%'

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -3175,6 +3175,12 @@ export class PGLiteEngine implements BrainEngine {
            AND p.slug NOT LIKE 'attachments/%'
            AND p.slug NOT LIKE '0-daily/%'
            AND p.slug NOT LIKE '4-archive/%'
+           -- Pseudo-pages: templates/ are vault sources (already in CLI DENY,
+           -- aligned here); navigation/ are graph-view hub-target pages
+           -- (intentionally wayfinding, not content). Missing inbound on a
+           -- nav page reflects vault [[wikilink]] sparsity, not graph rot.
+           AND p.slug NOT LIKE 'templates/%'
+           AND p.slug NOT LIKE 'navigation/%'
         ) as orphan_pages,
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1911,6 +1911,62 @@ export class PostgresEngine implements BrainEngine {
     return rows as unknown as Array<{ slug: string; title: string; domain: string | null }>;
   }
 
+  async findIslandedPages(opts?: { includePseudo?: boolean }): Promise<Array<{ slug: string; title: string; domain: string | null }>> {
+    // Single authoritative predicate — keep parallel to getHealth.orphan_pages
+    // SQL above and pglite-engine.ts:findIslandedPages. Both surfaces use this
+    // so find_orphans count == get_health.orphan_pages.
+    //
+    // includePseudo=true relaxes the exclusion set (sources/wayfinding/pseudo
+    // slugs/suffix patterns/first-segment) but does NOT change the islanded
+    // graph predicate (per Codex pre-impl P1: --include-pseudo relaxes
+    // filters, not graph semantics).
+    const sql = this.sql;
+    if (opts?.includePseudo) {
+      const rows = await sql`
+        SELECT
+          p.slug,
+          COALESCE(p.title, p.slug) AS title,
+          p.frontmatter->>'domain' AS domain
+        FROM pages p
+        WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
+          AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+          AND p.deleted_at IS NULL
+        ORDER BY p.slug
+      `;
+      return rows as unknown as Array<{ slug: string; title: string; domain: string | null }>;
+    }
+    const rows = await sql`
+      SELECT
+        p.slug,
+        COALESCE(p.title, p.slug) AS title,
+        p.frontmatter->>'domain' AS domain
+      FROM pages p
+      WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
+        AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+        AND p.deleted_at IS NULL
+        AND p.slug NOT IN ('_atlas', '_index', '_stats', '_orphans', '_scratch', 'claude')
+        AND p.slug NOT LIKE '%/#_index' ESCAPE '#'
+        AND p.slug NOT LIKE '%/log'
+        AND p.slug NOT LIKE '%/raw/%'
+        AND p.slug NOT LIKE 'emails/%'
+        AND p.slug NOT LIKE 'attachments/%'
+        AND p.slug NOT LIKE '0-daily/%'
+        AND p.slug NOT LIKE '4-archive/%'
+        AND p.slug NOT LIKE 'templates/%'
+        AND p.slug NOT LIKE 'navigation/%'
+        AND p.slug NOT LIKE 'output/%'
+        AND p.slug NOT LIKE 'dashboards/%'
+        AND p.slug NOT LIKE 'scripts/%'
+        AND p.slug NOT LIKE 'openclaw/config/%'
+        AND p.slug NOT LIKE 'scratch/%' AND p.slug != 'scratch'
+        AND p.slug NOT LIKE 'thoughts/%' AND p.slug != 'thoughts'
+        AND p.slug NOT LIKE 'catalog/%' AND p.slug != 'catalog'
+        AND p.slug NOT LIKE 'entities/%' AND p.slug != 'entities'
+      ORDER BY p.slug
+    `;
+    return rows as unknown as Array<{ slug: string; title: string; domain: string | null }>;
+  }
+
   // Tags
   async addTag(slug: string, tag: string, opts?: { sourceId?: string }): Promise<void> {
     const sql = this.sql;
@@ -3175,25 +3231,50 @@ export class PostgresEngine implements BrainEngine {
         (SELECT count(*) FROM pages p
          WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
         ) as stale_pages,
+        -- Islanded orphan predicate (v0.33+ step-4 alignment):
+        -- Single authoritative WHERE used by BOTH getHealth.orphan_pages
+        -- AND findIslandedPages(). The CLI/MCP find_orphans surface uses
+        -- findIslandedPages so its count == get_health.orphan_pages by
+        -- construction. The JS mirror lives at shouldExclude in
+        -- commands/orphans.ts (kept exported for backwards-compat tests
+        -- only — SQL is the runtime authority).
+        --
+        -- Predicate components:
+        --   • Graph: no inbound AND no outbound (islanded)
+        --   • Visibility: soft-deleted (v0.26.5) excluded
+        --   • Source-type ingestions (emails/attachments/0-daily/4-archive):
+        --     anchored via timeline/parent record, not wikilinks
+        --   • Vault wayfinding (templates/navigation/output/dashboards/
+        --     scripts/openclaw-config): intentionally non-content
+        --   • Pseudo-page exact slugs + suffix/segment patterns
+        --   • First-segment exclusions (scratch/thoughts/catalog/entities)
+        --
+        -- LIKE escape note: '%/#_index' ESCAPE '#' matches literal '_index'
+        -- suffix. Bare '_' is a single-char wildcard in LIKE and would
+        -- otherwise match e.g. '_zindex'. Same trap that bit the
+        -- 1-projects/_% migration on 2026-05-15.
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
-           -- Soft-deleted pages (v0.26.5 recovery window) aren't visible to
-           -- consumers; they shouldn't crush brain_score.
            AND p.deleted_at IS NULL
-           -- Source-type ingestions: anchored via timeline/parent record, not
-           -- wikilinks. Exclude from orphan count so brain_score reflects
-           -- real graph rot, not ingestion-by-design pages.
+           AND p.slug NOT IN ('_atlas', '_index', '_stats', '_orphans', '_scratch', 'claude')
+           AND p.slug NOT LIKE '%/#_index' ESCAPE '#'
+           AND p.slug NOT LIKE '%/log'
+           AND p.slug NOT LIKE '%/raw/%'
            AND p.slug NOT LIKE 'emails/%'
            AND p.slug NOT LIKE 'attachments/%'
            AND p.slug NOT LIKE '0-daily/%'
            AND p.slug NOT LIKE '4-archive/%'
-           -- Pseudo-pages: templates/ are vault sources (already in CLI DENY,
-           -- aligned here); navigation/ are graph-view hub-target pages
-           -- (intentionally wayfinding, not content). Missing inbound on a
-           -- nav page reflects vault [[wikilink]] sparsity, not graph rot.
            AND p.slug NOT LIKE 'templates/%'
            AND p.slug NOT LIKE 'navigation/%'
+           AND p.slug NOT LIKE 'output/%'
+           AND p.slug NOT LIKE 'dashboards/%'
+           AND p.slug NOT LIKE 'scripts/%'
+           AND p.slug NOT LIKE 'openclaw/config/%'
+           AND p.slug NOT LIKE 'scratch/%' AND p.slug != 'scratch'
+           AND p.slug NOT LIKE 'thoughts/%' AND p.slug != 'thoughts'
+           AND p.slug NOT LIKE 'catalog/%' AND p.slug != 'catalog'
+           AND p.slug NOT LIKE 'entities/%' AND p.slug != 'entities'
         ) as orphan_pages,
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -3188,6 +3188,12 @@ export class PostgresEngine implements BrainEngine {
            AND p.slug NOT LIKE 'attachments/%'
            AND p.slug NOT LIKE '0-daily/%'
            AND p.slug NOT LIKE '4-archive/%'
+           -- Pseudo-pages: templates/ are vault sources (already in CLI DENY,
+           -- aligned here); navigation/ are graph-view hub-target pages
+           -- (intentionally wayfinding, not content). Missing inbound on a
+           -- nav page reflects vault [[wikilink]] sparsity, not graph rot.
+           AND p.slug NOT LIKE 'templates/%'
+           AND p.slug NOT LIKE 'navigation/%'
         ) as orphan_pages,
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1905,6 +1905,7 @@ export class PostgresEngine implements BrainEngine {
       WHERE NOT EXISTS (
         SELECT 1 FROM links l WHERE l.to_page_id = p.id
       )
+        AND p.deleted_at IS NULL
       ORDER BY p.slug
     `;
     return rows as unknown as Array<{ slug: string; title: string; domain: string | null }>;
@@ -3177,6 +3178,9 @@ export class PostgresEngine implements BrainEngine {
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+           -- Soft-deleted pages (v0.26.5 recovery window) aren't visible to
+           -- consumers; they shouldn't crush brain_score.
+           AND p.deleted_at IS NULL
            -- Source-type ingestions: anchored via timeline/parent record, not
            -- wikilinks. Exclude from orphan count so brain_score reflects
            -- real graph rot, not ingestion-by-design pages.

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -3177,6 +3177,13 @@ export class PostgresEngine implements BrainEngine {
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+           -- Source-type ingestions: anchored via timeline/parent record, not
+           -- wikilinks. Exclude from orphan count so brain_score reflects
+           -- real graph rot, not ingestion-by-design pages.
+           AND p.slug NOT LIKE 'emails/%'
+           AND p.slug NOT LIKE 'attachments/%'
+           AND p.slug NOT LIKE '0-daily/%'
+           AND p.slug NOT LIKE '4-archive/%'
         ) as orphan_pages,
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -717,12 +717,23 @@ export interface BrainHealth {
   embed_coverage: number;
   stale_pages: number;
   /**
-   * Islanded pages — zero inbound AND zero outbound links. A hub page
-   * that has references out but no back-references is NOT an orphan under
-   * this definition (it's working as intended as an index). The metric
-   * aims at "pages I forgot to connect to anything", not the stricter
-   * graph-theory "no inbound" definition. Both engines share this
-   * semantics after Bug 11 doc-drift fix.
+   * Islanded pages — zero inbound AND zero outbound links — after applying
+   * the authoritative exclusion set: soft-deleted; source-type ingestions
+   * (emails/attachments/0-daily/4-archive); vault wayfinding (templates/
+   * navigation/output/dashboards/scripts/openclaw-config); pseudo-page
+   * exact slugs (_atlas/_index/_stats/_orphans/_scratch/claude); suffix
+   * and segment patterns (`/_index`, `/log`, `/raw/`); first-segment
+   * exclusions (scratch/thoughts/catalog/entities).
+   *
+   * A hub page with outbound but no inbound links is NOT an orphan under
+   * this definition — it's working as intended as an index. The metric
+   * aims at "pages I forgot to connect to anything", not graph-theory
+   * "no inbound".
+   *
+   * v0.33+ step-4 alignment: this SQL predicate is now shared with
+   * `findIslandedPages()` so `find_orphans` MCP/CLI count equals this
+   * value by construction. The CLI's JS-side `shouldExclude` helper is
+   * a backwards-compat re-export of the same exclusion list.
    */
   orphan_pages: number;
   missing_embeddings: number;

--- a/test/core/cycle.serial.test.ts
+++ b/test/core/cycle.serial.test.ts
@@ -103,9 +103,7 @@ mock.module('../../src/commands/orphans.ts', () => ({
     return {
       orphans: [],
       total_orphans: 1,
-      total_linkable: 20,
       total_pages: 20,
-      excluded: 0,
     };
   },
   queryOrphanPages: async () => [],

--- a/test/orphans.test.ts
+++ b/test/orphans.test.ts
@@ -66,6 +66,10 @@ describe('shouldExclude', () => {
     expect(shouldExclude('templates/meeting-note')).toBe(true);
   });
 
+  test('excludes deny-prefix: navigation/', () => {
+    expect(shouldExclude('navigation/ai')).toBe(true);
+  });
+
   test('excludes deny-prefix: openclaw/config/', () => {
     expect(shouldExclude('openclaw/config/agent')).toBe(true);
   });

--- a/test/orphans.test.ts
+++ b/test/orphans.test.ts
@@ -134,9 +134,7 @@ describe('formatOrphansText', () => {
     return {
       orphans,
       total_orphans: orphans.length,
-      total_linkable: orphans.length + 50,
       total_pages: orphans.length + 60,
-      excluded: 10,
       ...overrides,
     };
   }
@@ -144,9 +142,8 @@ describe('formatOrphansText', () => {
   test('shows summary line', () => {
     const result = makeResult([]);
     const out = formatOrphansText(result);
-    expect(out).toContain('0 orphans out of');
+    expect(out).toContain('0 islanded pages out of');
     expect(out).toContain('total');
-    expect(out).toContain('excluded');
   });
 
   test('shows "No orphan pages found." when empty', () => {
@@ -200,12 +197,10 @@ describe('formatOrphansText', () => {
     const result: OrphanResult = {
       orphans,
       total_orphans: 2,
-      total_linkable: 100,
       total_pages: 120,
-      excluded: 20,
     };
     const out = formatOrphansText(result);
-    expect(out).toContain('2 orphans out of 100 linkable pages (120 total; 20 excluded)');
+    expect(out).toContain('2 islanded pages out of 120 total');
   });
 });
 
@@ -213,7 +208,7 @@ describe('formatOrphansText', () => {
 // findOrphans + queryOrphanPages with explicit engine (v0.17 change)
 // ────────────────────────────────────────────────────────────────
 
-describe('findOrphans (engine-injected)', () => {
+describe('findOrphans (engine-injected, islanded semantics)', () => {
   let engine: PGLiteEngine;
 
   beforeEach(async () => {
@@ -226,10 +221,12 @@ describe('findOrphans (engine-injected)', () => {
     if (engine) await engine.disconnect();
   }, 60_000);
 
-  test('returns pages with no inbound links, excluding pseudo-pages', async () => {
-    // Build a tiny brain: alice links to bob. alice is an orphan (nothing
-    // points to her), bob is not (alice points to him). _atlas is a pseudo
-    // page that should be excluded by default.
+  test('returns islanded pages — neither alice (outbound-only) nor bob (inbound-only) qualify', async () => {
+    // Under islanded semantics (v0.33+ step-4 alignment) "orphan" means
+    // no in AND no out. alice→bob makes alice a hub (has outbound, fine)
+    // and bob a leaf (has inbound, fine). Neither is islanded.
+    // carol is a true islanded page — added to confirm at least one
+    // result so we're testing for inclusion, not just emptiness.
     await engine.putPage('people/alice', {
       type: 'person',
       title: 'Alice',
@@ -242,49 +239,190 @@ describe('findOrphans (engine-injected)', () => {
       compiled_truth: 'Bob.',
       timeline: '',
     });
-    await engine.putPage('_atlas', {
-      type: 'concept',
-      title: 'Atlas',
-      compiled_truth: 'pseudo-page',
+    await engine.putPage('people/carol', {
+      type: 'person',
+      title: 'Carol',
+      compiled_truth: 'Carol — no links to or from her.',
       timeline: '',
     });
-    // Create the link alice -> bob.
     await engine.addLink('people/alice', 'people/bob', 'mentioned', 'references', 'markdown');
 
     const result = await findOrphans(engine);
 
     const slugs = result.orphans.map(o => o.slug).sort();
-    expect(slugs).toEqual(['people/alice']); // _atlas excluded by default; bob has a backlink
+    expect(slugs).toEqual(['people/carol']);
     expect(result.total_orphans).toBe(1);
     expect(result.total_pages).toBe(3);
-    expect(result.excluded).toBeGreaterThanOrEqual(1); // _atlas was filtered
   });
 
-  test('includePseudo: true surfaces pseudo-pages too', async () => {
+  test('outbound-only hub is NOT counted as orphan', async () => {
+    await engine.putPage('hub/index', {
+      type: 'concept',
+      title: 'Index Hub',
+      compiled_truth: 'Links out to many.',
+      timeline: '',
+    });
+    await engine.putPage('leaf/one', {
+      type: 'concept',
+      title: 'Leaf One',
+      compiled_truth: 'A leaf.',
+      timeline: '',
+    });
+    await engine.addLink('hub/index', 'leaf/one', 'references', 'references', 'markdown');
+
+    const result = await findOrphans(engine);
+
+    const slugs = result.orphans.map(o => o.slug);
+    expect(slugs).not.toContain('hub/index'); // has outbound — not islanded
+    expect(slugs).not.toContain('leaf/one'); // has inbound — not islanded
+    expect(result.total_orphans).toBe(0);
+  });
+
+  test('soft-deleted page is excluded from orphan count (and row still exists with deleted_at)', async () => {
+    await engine.putPage('topic/will-delete', {
+      type: 'concept',
+      title: 'Soon Deleted',
+      compiled_truth: 'islanded, then soft-deleted',
+      timeline: '',
+    });
+    const sd = await engine.softDeletePage('topic/will-delete');
+    expect(sd).not.toBeNull();
+
+    // Verify the row is actually soft-deleted (not hard-deleted) — the
+    // predicate's `deleted_at IS NULL` clause is what does the exclusion.
+    // Defensive check: codex post-impl flagged that prior fixture used
+    // hard-delete and tests would pass even with deleted_at predicate
+    // removed. Probe directly.
+    const { rows } = await (engine as unknown as { db: { query: (s: string) => Promise<{ rows: Array<{ deleted_at: unknown }> }> } })
+      .db.query("SELECT deleted_at FROM pages WHERE slug = 'topic/will-delete'");
+    expect(rows.length).toBe(1);
+    expect(rows[0].deleted_at).not.toBeNull();
+
+    const result = await findOrphans(engine);
+    const slugs = result.orphans.map(o => o.slug);
+    expect(slugs).not.toContain('topic/will-delete');
+  });
+
+  test.each([
+    ['_atlas'],
+    ['_index'],
+    ['claude'],
+    ['emails/2026-05-01-foo'],
+    ['attachments/abc'],
+    ['0-daily/2026-05-17'],
+    ['4-archive/old-notes'],
+    ['templates/meeting-note'],
+    ['navigation/ai'],
+    ['output/2026-q1'],
+    ['dashboards/metrics'],
+    ['scripts/ingest-runner'],
+    ['openclaw/config/agent'],
+    ['scratch/idea'],
+    ['thoughts/2026-04-17'],
+    ['catalog/tools'],
+    ['entities/product-hunt'],
+    ['some/page/_index'], // suffix /_index — note the LIKE escape on _
+    ['projects/acme/log'], // suffix /log
+    ['companies/acme/raw/crustdata'], // contains /raw/
+  ])('SQL excludes %s when islanded (default mode)', async (slug) => {
+    await engine.putPage(slug, {
+      type: 'concept',
+      title: slug,
+      compiled_truth: 'islanded test fixture',
+      timeline: '',
+    });
+    const result = await findOrphans(engine);
+    expect(result.orphans.map(o => o.slug)).not.toContain(slug);
+  });
+
+  test('LIKE escape: bare _index is excluded (exact), but /_zindex is NOT excluded by the suffix pattern', async () => {
+    // Defensive: '%/#_index' ESCAPE '#' must match LITERAL '_index'.
+    // Without the escape, the bare '_' wildcard would also match
+    // '/_zindex' which is wrong. Build both fixtures and verify.
+    await engine.putPage('weird/_zindex', { type: 'concept', title: 'Weird zindex', compiled_truth: 'islanded', timeline: '' });
+    // also seed a 2nd page so weird/_zindex is islanded (and not the only row)
+    await engine.putPage('weird/something-else', { type: 'concept', title: 'Other', compiled_truth: 'islanded', timeline: '' });
+
+    const result = await findOrphans(engine);
+    const slugs = result.orphans.map(o => o.slug);
+    // weird/_zindex is NOT '/_index' suffix; should pass through as islanded
+    expect(slugs).toContain('weird/_zindex');
+  });
+
+  test('includePseudo=true surfaces pseudo slugs but only if they are islanded', async () => {
     await engine.putPage('_atlas', {
       type: 'concept',
       title: 'Atlas',
-      compiled_truth: 'pseudo',
+      compiled_truth: 'pseudo (islanded)',
       timeline: '',
     });
+    await engine.putPage('_index', {
+      type: 'concept',
+      title: 'Index',
+      compiled_truth: 'pseudo with outbound',
+      timeline: '',
+    });
+    await engine.putPage('topic/real', {
+      type: 'concept',
+      title: 'Real Topic',
+      compiled_truth: 'pseudo target',
+      timeline: '',
+    });
+    await engine.addLink('_index', 'topic/real', 'references', 'references', 'markdown');
 
     const result = await findOrphans(engine, { includePseudo: true });
-
-    const slugs = result.orphans.map(o => o.slug).sort();
-    expect(slugs).toContain('_atlas');
+    const slugs = result.orphans.map(o => o.slug);
+    expect(slugs).toContain('_atlas'); // pseudo, islanded — surfaced
+    expect(slugs).not.toContain('_index'); // pseudo but has outbound — still not islanded
   });
 
-  test('queryOrphanPages delegates to the passed engine (no global db)', async () => {
+  test('CRITICAL: findOrphans count equals getHealth.orphan_pages (alignment regression)', async () => {
+    // The headline guarantee of v0.33+ step-4 alignment: the two surfaces
+    // share an SQL predicate, so their counts must match by construction.
+    // Mix islanded + non-islanded + soft-deleted + excluded-prefix pages
+    // to make the assertion meaningful.
+    await engine.putPage('people/islanded-1', { type: 'person', title: 'Islanded 1', compiled_truth: 'lone', timeline: '' });
+    await engine.putPage('people/islanded-2', { type: 'person', title: 'Islanded 2', compiled_truth: 'lone', timeline: '' });
+    await engine.putPage('people/hub', { type: 'person', title: 'Hub', compiled_truth: 'has outbound', timeline: '' });
+    await engine.putPage('people/leaf', { type: 'person', title: 'Leaf', compiled_truth: 'has inbound', timeline: '' });
+    await engine.addLink('people/hub', 'people/leaf', 'references', 'references', 'markdown');
+    await engine.putPage('emails/excluded-by-prefix', { type: 'concept', title: 'Excluded', compiled_truth: 'source-type', timeline: '' });
+    await engine.putPage('people/soft-delete-me', { type: 'person', title: 'To soft-delete', compiled_truth: 'will be hidden', timeline: '' });
+    await engine.softDeletePage('people/soft-delete-me');
+
+    const findResult = await findOrphans(engine);
+    const health = await engine.getHealth();
+
+    expect(findResult.total_orphans).toBe(health.orphan_pages);
+    // also sanity-check we counted the two real islanded pages
+    expect(findResult.total_orphans).toBe(2);
+  });
+
+  test('queryOrphanPages still returns no-inbound rows (unchanged contract)', async () => {
+    // v0.33+ step-4: queryOrphanPages stays on findOrphanPages for
+    // enrichment-pattern consumers. It returns ALL no-inbound pages
+    // (including hubs with outbound), which is the right semantic for
+    // "candidates needing inbound links".
     await engine.putPage('topic/standalone', {
       type: 'concept',
       title: 'Standalone',
       compiled_truth: 'no inbound links',
       timeline: '',
     });
+    await engine.putPage('topic/hub', {
+      type: 'concept',
+      title: 'Hub',
+      compiled_truth: 'outbound only',
+      timeline: '',
+    });
+    await engine.addLink('topic/hub', 'topic/standalone', 'references', 'references', 'markdown');
 
     const rows = await queryOrphanPages(engine);
     const slugs = rows.map(r => r.slug);
-    expect(slugs).toContain('topic/standalone');
+    // topic/hub has no inbound — included.
+    // topic/standalone has inbound from hub — excluded.
+    expect(slugs).toContain('topic/hub');
+    expect(slugs).not.toContain('topic/standalone');
   });
 
   test('zero pages: empty result (no crash on empty brain)', async () => {

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -1280,6 +1280,15 @@ describe('PGLiteEngine: getHealth graph metrics', () => {
     const h2 = await engine.getHealth();
     expect(h2.orphan_pages).toBe(1);
   });
+
+  test('orphan_pages excludes templates/ and navigation/ pseudo-pages', async () => {
+    // Adding pseudo-pages should not bump orphan_pages — they are wayfinding /
+    // source pages by design, not graph rot.
+    await engine.putPage('templates/meeting-note', { ...testPage, type: 'concept', title: 'Meeting Template' });
+    await engine.putPage('navigation/ai', { ...testPage, type: 'note', title: 'AI Hub' });
+    const h = await engine.getHealth();
+    expect(h.orphan_pages).toBe(3);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Four-commit chain that gives `get_health.orphan_pages` honest, accurate semantics and aligns the user-visible orphan surfaces (`gbrain orphans` CLI + `find_orphans` MCP) with it.

| Commit | What | |
|---|---|---|
| 6a945560 | Exclude source-type ingestions (`emails/`, `attachments/`, `0-daily/`, `4-archive/`) from `orphan_pages` SQL | Was: ingestion-by-design pages dominated the count and crushed `brain_score`. |
| a70ef64b | Exclude soft-deleted pages (`deleted_at IS NULL`) from `orphan_pages` SQL | Was: soft-deleted pages still consumed by the SQL count, distorting `no_orphans_score`. |
| 54d349a1 | Exclude pseudo-page hub prefixes (`templates/`, `navigation/`) from `orphan_pages` SQL | Was: vault wayfinding pages reflect `[[wikilink]]` sparsity, not graph rot. |
| 7e6cb77b | Align `find_orphans` (CLI + MCP) with `getHealth.orphan_pages` via shared islanded predicate; add `engine.findIslandedPages()` | Was: CLI used a no-inbound JS filter; MCP get_health used SQL islanded. Different counts. |

Net effect: one authoritative SQL predicate, shared between `getHealth` (`orphan_pages`/`no_orphans_score`/`brain_score`) and `find_orphans` (CLI + MCP). The two surfaces agree by construction.

## The headline alignment fix (#7e6cb77b)

`find_orphans` used to scan for "no inbound wikilinks" then apply a JS-side `shouldExclude` filter. `getHealth.orphan_pages` used an SQL islanded predicate (no in **and** no out) with only the 4–6 source/wayfinding prefixes from earlier commits. Two different definitions → two different counts.

This commit:
- Promotes the full `shouldExclude` set to SQL inside `getHealth.orphan_pages` (both engines): pseudo-page exact slugs (`_atlas`, `_index`, `_stats`, `_orphans`, `_scratch`, `claude`), suffix patterns (`/_index`, `/log`), segment patterns (`/raw/`), additional deny prefixes (`output/`, `dashboards/`, `scripts/`, `openclaw/config/`), and first-segment exclusions (`scratch/`, `thoughts/`, `catalog/`, `entities/`). LIKE escape `'%/#_index' ESCAPE '#'` for the literal `_index` suffix match (bare `_` is a single-char wildcard in LIKE).
- Adds `engine.findIslandedPages(opts?: { includePseudo?: boolean })` to the interface (both engines) sharing the same SQL predicate. `includePseudo=true` relaxes the exclusion set but does **not** change the islanded graph predicate.
- Routes `gbrain orphans` CLI + `find_orphans` MCP through `findIslandedPages`. The JS `shouldExclude` is `@deprecated` and kept exported only for backwards-compat unit tests.
- Keeps `findOrphanPages()` (no-inbound) as the engine-level helper for enrichment-pattern consumers (`queryOrphanPages`, future link-recovery tooling).
- Updates docstrings on `BrainHealth.orphan_pages`, the engine interface, CLI help text + summary line ("N orphans" → "N islanded pages out of K total"), `find_orphans` MCP description, and the runCycle orphans phase summary.
- Drops the post-hoc `total_linkable` + `excluded` fields from `OrphanResult` — they were JS computations over the no-inbound set; with SQL authoritative they degenerate to misleading values (`excluded` = 0, `total_linkable` = `total`). Cycle phase details + cycle.serial.test.ts mock updated accordingly.

## Tests

- Replace fixtures that no longer match islanded semantics (an `alice→bob` link makes neither islanded under the new definition).
- 20-row `test.each` covering every prefix/exact/suffix/segment exclusion.
- LIKE-escape defense: `weird/_zindex` must NOT match the `%/_index` suffix pattern (regression guard for the bare `_` wildcard trap).
- Soft-delete fixture now uses `softDeletePage` and asserts `deleted_at IS NOT NULL` (codex post-impl caught that prior fixture used hard-delete, which would pass even with the `deleted_at IS NULL` predicate removed — false-positive coverage).
- **Critical alignment regression**: `findOrphans(engine).total_orphans === (await engine.getHealth()).orphan_pages`.

60/60 orphan tests pass; 143/143 in adjacent regression files (brain-score-breakdown, doctor, pglite-engine); 28/28 in cycle.serial; typecheck clean.

## Live impact (one brain, ~10K pages, gbrain.colin)

| Metric | Pre | Post | Δ |
|---|---:|---:|---|
| CLI `gbrain orphans --count` | 2722 | 2656 | **-66** |
| `get_health.orphan_pages` | 2699 | **2656** | **-43 (aligned)** |
| `brain_score` | 67 | 67 | 0 |
| `no_orphans_score` | 11/15 | 11/15 | 0 |

`no_orphans_score` coincidentally lands on the same rounding boundary so `brain_score` is unchanged — the fix is **structural alignment**, not metric movement.

## Out of scope (deliberately)

- A shared SQL fragment/helper across both engines. Codex flagged "drift risk" (P2) — predicate is duplicated 4× now (getHealth + findIslandedPages × 2 engines). Worth doing in a follow-up but not a blocker; both engines already keep their getHealth + getStats SQL fully parallel, this is the established pattern.
- Postgres E2E parity test. The SQL is duplicated verbatim between engines; PGLite tests cover the semantics. Postgres-specific test costs vs. confidence is a judgment call best made by maintainer.
- `findOrphanPages` rename. Codex pre-impl agreed keeping it as-is (with updated docstring) avoids churn while metric semantics are changing.

## Test plan

- [x] `bun test test/orphans.test.ts` — 60/60 pass
- [x] `bun test test/pglite-engine.test.ts test/brain-score-breakdown.test.ts test/doctor.test.ts` — 143/143 pass
- [x] `bun test test/core/cycle.serial.test.ts` — 28/28 pass
- [x] `bun run typecheck` — clean
- [x] Live verification: `gbrain orphans --count` (2656) == `get_health.orphan_pages` (2656)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)