### PR TITLE
fix(autopilot,cycle): stop respawn-storm from steady-state 'partial' cycles

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -355,7 +355,13 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
             await new Promise(r => setImmediate(r));
           },
         });
-        if (report.status === 'failed' || report.status === 'partial') {
+        // Only 'failed' (every attempted phase failed) trips the autopilot
+        // circuit breaker. 'partial' means at least one phase warned or
+        // failed while others ran — that's a soft signal, not a fatal
+        // condition. Treating 'partial' as failure here caused respawn
+        // storms under KeepAlive=true on brains where a single phase
+        // (typically `orphans`) emits a 'warn' every cycle in steady state.
+        if (report.status === 'failed') {
           cycleOk = false;
         }
         if (jsonMode) {

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -934,9 +934,19 @@ async function runPhaseOrphans(engine: BrainEngine): Promise<PhaseResult> {
     const { findOrphans } = await import('../commands/orphans.ts');
     const result = await findOrphans(engine);
     const count = result.total_orphans;
+    // Orphans are a code-smell signal, not a fatal condition. The
+    // original `count > 20` cutoff was tuned for small dev brains; on
+    // any corpus past a few hundred pages it fires 'warn' every cycle
+    // in steady state. Combined with the autopilot circuit-breaker
+    // historically tripping on cycle.status='partial', that produced
+    // respawn storms under KeepAlive=true. Switch to a ratio: warn
+    // only when more than half the corpus is orphaned (the real "your
+    // graph fell apart" signal). total_pages=0 is a defensive 'ok'.
+    const status: PhaseStatus =
+      result.total_pages > 0 && count / result.total_pages > 0.5 ? 'warn' : 'ok';
     return {
       phase: 'orphans',
-      status: count > 20 ? 'warn' : 'ok',
+      status,
       duration_ms: 0,
       summary: `${count} orphan page(s) out of ${result.total_pages} total`,
       details: {

--- a/test/autopilot-cycle-failure-classification.test.ts
+++ b/test/autopilot-cycle-failure-classification.test.ts
@@ -1,0 +1,108 @@
+/**
+ * test/autopilot-cycle-failure-classification.test.ts
+ *
+ * Regression guards for two design-bugs that interact under
+ * `KeepAlive=true` autopilot to produce a respawn storm:
+ *
+ *   1. autopilot.ts inline-cycle path treated `report.status === 'partial'`
+ *      as a circuit-breaker trip. `partial` is documented in CycleReport
+ *      as "at least one phase warned or failed, others ran" — a soft
+ *      signal, not a fatal condition. 5 consecutive 'partial' cycles
+ *      killed the autopilot.
+ *
+ *   2. runPhaseOrphans used a fixed absolute threshold `count > 20` to
+ *      emit `status: 'warn'`. For any non-trivial brain (~hundreds of
+ *      pages) that fires every cycle in steady state, which —
+ *      combined with bug #1 — caused the autopilot to give up after
+ *      5 normal cycles. Threshold is now ratio-based: warn only if more
+ *      than half the corpus is orphaned.
+ *
+ * Both fixes are tiny but the production blast-radius is large
+ * (LaunchAgent respawn loop, 9 MB error log in 2h), so they get
+ * explicit guards.
+ *
+ * Source-level guards follow the established pattern from
+ * `cycle-abort.test.ts` (autopilot loop is hard to unit-test without
+ * a full engine, so we assert on source text).
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+
+const autopilotSource = readFileSync(
+  new URL('../src/commands/autopilot.ts', import.meta.url),
+  'utf8',
+);
+const cycleSource = readFileSync(
+  new URL('../src/core/cycle.ts', import.meta.url),
+  'utf8',
+);
+
+describe("autopilot cycle-failure classification — only 'failed' trips the circuit breaker", () => {
+  test("the inline-cycle path does NOT treat 'partial' as cycleOk=false", () => {
+    // Find the inline-cycle block (the catch-and-inspect on `report`)
+    const inlineBlockStart = autopilotSource.indexOf("event: 'cycle-inline'");
+    expect(inlineBlockStart).toBeGreaterThan(0);
+
+    // Look at the 800 chars before the JSON event line — that's where the
+    // cycleOk classification happens.
+    const inlineContext = autopilotSource.slice(
+      Math.max(0, inlineBlockStart - 800),
+      inlineBlockStart,
+    );
+
+    // Regression guard #1: the OR-with-'partial' branch must be gone.
+    expect(inlineContext).not.toMatch(/report\.status\s*===\s*['"]partial['"]/);
+
+    // Positive guard: the breaker still trips on 'failed'.
+    expect(inlineContext).toMatch(/report\.status\s*===\s*['"]failed['"]/);
+  });
+
+  test("the 5-consecutive-error give-up is still wired (regression-safety)", () => {
+    // The fix narrows the trigger; it doesn't remove the breaker.
+    // If someone later wholesale deletes the give-up branch we want to
+    // notice — autopilot still needs a way to stop after sustained
+    // real failures (e.g., DB unreachable for 5 cycles).
+    expect(autopilotSource).toMatch(/consecutiveErrors\s*\+\+/);
+    expect(autopilotSource).toMatch(/consecutiveErrors\s*>=\s*5/);
+  });
+});
+
+describe('runPhaseOrphans ratio threshold — no more absolute count > 20', () => {
+  test('the legacy `count > 20 ? "warn" : "ok"` ternary is gone', () => {
+    // The literal that produced the steady-state warn-storm on any
+    // brain past a few hundred pages.
+    expect(cycleSource).not.toMatch(/count\s*>\s*20\s*\?\s*['"]warn['"]/);
+  });
+
+  test('the new threshold is ratio-based against total_pages', () => {
+    // Must look at result.total_pages, not a magic absolute. The
+    // exact comparator (0.5 today) can move, but the *kind* of
+    // comparison must be a ratio so big brains don't always warn.
+    // Slice the runPhaseOrphans function body.
+    const fnIdx = cycleSource.indexOf('async function runPhaseOrphans');
+    expect(fnIdx).toBeGreaterThan(0);
+    const fnEnd = cycleSource.indexOf('\n}', fnIdx);
+    const fnBody = cycleSource.slice(fnIdx, fnEnd);
+
+    // Must reference total_pages in the threshold decision.
+    expect(fnBody).toMatch(/total_pages/);
+    // Must contain a division or multiplication against total_pages
+    // (ratio comparison). Accept either `count / result.total_pages` or
+    // `count > result.total_pages * X` framing.
+    expect(fnBody).toMatch(
+      /count\s*\/\s*result\.total_pages|result\.total_pages\s*\*/,
+    );
+  });
+
+  test('the warn branch still exists (we narrowed, did not remove)', () => {
+    // If the threshold is moved to "never warn", we want a deliberate
+    // signal. Today the warn path is still there — orphans > 50% of
+    // corpus is a real signal. This guard catches accidental removal.
+    const fnIdx = cycleSource.indexOf('async function runPhaseOrphans');
+    const fnEnd = cycleSource.indexOf('\n}', fnIdx);
+    const fnBody = cycleSource.slice(fnIdx, fnEnd);
+    expect(fnBody).toMatch(/['"]warn['"]/);
+    expect(fnBody).toMatch(/['"]ok['"]/);
+  });
+});


### PR DESCRIPTION
## Summary

Two interacting design-bugs cause gbrain autopilot to give up — and under
LaunchAgent/systemd `KeepAlive=true` to respawn-storm — every five normal
cycles on any non-trivial brain. Both are one-liner fixes plus source-level
regression guards.

### Bug 1 — autopilot circuit-breaker trips on `'partial'`

`src/commands/autopilot.ts:358` (inline-cycle path):

```ts
if (report.status === 'failed' || report.status === 'partial') {
  cycleOk = false;
}
```

But the `CycleReport` docstring is explicit on the meaning of these statuses:

> - 'partial' : at least one phase warned or failed, others ran
> - 'failed'  : lock acquired but all attempted phases failed

`partial` is a soft signal, not a fatal condition. Treating it as a failure
means a single `warn`-emitting phase trips the consecutive-error counter
every cycle, and after 5 cycles the autopilot gives up. The dispatch path
(`event: 'dispatched'` above) doesn't have this bug — it only looks at
explicit `throw`s from the dispatcher.

**Fix:** only `'failed'` sets `cycleOk = false`. The
`consecutiveErrors >= 5` give-up branch remains as the real-failure
backstop, so the autopilot still stops itself when the DB is unreachable
for 5 cycles in a row.

### Bug 2 — orphan threshold is absolute, not ratio

`src/core/cycle.ts:939`:

```ts
status: count > 20 ? 'warn' : 'ok',
```

The orphans phase is the most common producer of a per-phase warn. On
any brain past a few hundred pages a steady-state orphan count of
50–2000 is normal — entity pages, single-pass syntheses, raw sources
that legitimately have no inbound links yet. A fixed `20`-absolute
floor fires `warn` every cycle, the `cycle.status` rolls up to
`partial`, and combined with Bug 1 above the autopilot stops itself.

In the field repro: 2068 orphans on 5786 pages (≈36% — steady state)
produced a 9 MB respawn-error log inside 2 h under
`KeepAlive=true`.

**Fix:** ratio-based threshold. Warn only when more than half the
corpus is orphaned (the real "your graph fell apart" signal):

```ts
const status: PhaseStatus =
  result.total_pages > 0 && count / result.total_pages > 0.5 ? 'warn' : 'ok';
```

`total_pages == 0` is a defensive `'ok'` (no corpus, nothing to warn
about).

## Tests

`test/autopilot-cycle-failure-classification.test.ts` (new) — 5
source-level regression guards in the same style as `cycle-abort.test.ts`
(autopilot's main loop is hard to unit-test against a real engine; the
existing codebase uses source-grep tests for this layer):

- inline-cycle block must not OR-against `'partial'`
- `consecutiveErrors >= 5` breaker must still exist (we narrowed; we
  didn't remove)
- `runPhaseOrphans` must not use a literal `count > 20` ternary
- `runPhaseOrphans` must reference `total_pages` in its threshold
- both `'warn'` and `'ok'` branches still reachable

Local verification:

```
$ bun test test/autopilot-*.test.ts test/cycle-abort.test.ts test/orphans.test.ts
 47 pass / 0 fail

$ bun run verify
... all gates green incl. typecheck + admin-build ...
```

## Backwards compatibility

- Public API of `CycleReport` / `PhaseResult` / `CyclePhase` unchanged.
- Behaviour change is strictly in the loosening direction: cycles
  previously classified `'partial'` no longer trip the autopilot
  circuit breaker; orphan counts below 50% of total pages no longer
  emit `'warn'`. Brains that genuinely fall apart (`status === 'failed'`
  or orphan ratio > 50%) keep the same signal.
- No migration; no config knob added. The previous absolute threshold
  was undocumented.

## Why one PR, not two

The two fixes are deliberately coupled. Either bug in isolation is
survivable: Bug 1 alone never trips because no phase reaches `partial`
in practice without the orphan-warn; Bug 2 alone just makes
`cycle-inline` log `[partial]` without consequence. Together they
produce the respawn-storm. The new test file documents both arms of
the failure mode in one place.