### PR TITLE
fix(engine): bootstrap oauth_clients forward-reference columns before SCHEMA_SQL replay

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -243,6 +243,10 @@ export class PGLiteEngine implements BrainEngine {
    *     (indexed by `idx_mcp_log_agent_time`) — v0.26.3
    *   - `subagent_messages.provider_id` column (indexed by
    *     `idx_subagent_messages_provider`) — v0.27
+   *   - `oauth_clients.source_id` column (indexed by
+   *     `idx_oauth_clients_source_id`) — v0.34.1 (v60)
+   *   - `oauth_clients.federated_read` column (indexed by
+   *     `idx_oauth_clients_federated_read`) — v0.34.1 (v61)
    *
    * **Maintenance contract:** when a future migration adds a column-with-index
    * or new-table-with-FK referenced by PGLITE_SCHEMA_SQL, extend this method
@@ -288,7 +292,13 @@ export class PGLiteEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.tables
                 WHERE table_schema='public' AND table_name='ingest_log') AS ingest_log_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema='public' AND table_name='ingest_log' AND column_name='source_id') AS ingest_log_source_id_exists
+                WHERE table_schema='public' AND table_name='ingest_log' AND column_name='source_id') AS ingest_log_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema='public' AND table_name='oauth_clients') AS oauth_clients_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='oauth_clients' AND column_name='source_id') AS oauth_clients_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='oauth_clients' AND column_name='federated_read') AS oauth_clients_federated_read_exists
     `);
     const probe = rows[0] as {
       pages_exists: boolean;
@@ -309,6 +319,9 @@ export class PGLiteEngine implements BrainEngine {
       subagent_provider_id_exists: boolean;
       ingest_log_exists: boolean;
       ingest_log_source_id_exists: boolean;
+      oauth_clients_exists: boolean;
+      oauth_clients_source_id_exists: boolean;
+      oauth_clients_federated_read_exists: boolean;
     };
 
     const needsPagesBootstrap = probe.pages_exists && !probe.source_id_exists;
@@ -332,12 +345,23 @@ export class PGLiteEngine implements BrainEngine {
     // references source_id. Old brains have ingest_log without source_id;
     // bootstrap adds the column before SCHEMA_SQL replay creates the index.
     const needsIngestLogSourceId = probe.ingest_log_exists && !probe.ingest_log_source_id_exists;
+    // v0.34.1 (v60 + v61): idx_oauth_clients_source_id and
+    // idx_oauth_clients_federated_read in PGLITE_SCHEMA_SQL reference these
+    // columns. Old brains (oauth_clients existed since v0.30 / v45) have the
+    // table without source_id or federated_read; bootstrap adds the columns
+    // before SCHEMA_SQL replay creates the indexes. v60-v65 migrations run
+    // later via runMigrations and install the FK + backfill + RESTRICT flip
+    // + GIN index; bootstrap is intentionally lean (matches the v60 SQL
+    // shape and the v61 column add — no FK, no backfill, no validation).
+    const needsOauthClientsSourceId = probe.oauth_clients_exists && !probe.oauth_clients_source_id_exists;
+    const needsOauthClientsFederatedRead = probe.oauth_clients_exists && !probe.oauth_clients_federated_read_exists;
 
     // Fresh installs (no tables yet) and modern brains both no-op.
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
         && !needsPagesDeletedAt && !needsChunksEmbeddingImage
         && !needsMcpLogBootstrap && !needsSubagentProviderId
-        && !needsPagesRecency && !needsIngestLogSourceId) return;
+        && !needsPagesRecency && !needsIngestLogSourceId
+        && !needsOauthClientsSourceId && !needsOauthClientsFederatedRead) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
 
@@ -463,6 +487,27 @@ export class PGLiteEngine implements BrainEngine {
       // DEFAULT 'default' so the index can build cleanly.
       await this.db.exec(`
         ALTER TABLE ingest_log ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT 'default';
+      `);
+    }
+
+    if (needsOauthClientsSourceId || needsOauthClientsFederatedRead) {
+      // v60 (oauth_clients_source_id_fk) adds source_id; v61
+      // (oauth_clients_federated_read_column) adds federated_read.
+      // PGLITE_SCHEMA_SQL's `CREATE INDEX idx_oauth_clients_source_id ON
+      // oauth_clients(source_id) WHERE source_id IS NOT NULL` and
+      // `CREATE INDEX idx_oauth_clients_federated_read ON oauth_clients USING
+      // GIN (federated_read)` both crash on brains that lack these columns
+      // (any brain at schema_version < 60 with oauth_clients already
+      // installed — oauth_clients itself dates back to v0.30 / v45).
+      //
+      // Bootstrap is intentionally lean: matches v60's leading
+      // `ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS source_id TEXT`
+      // and v61's column-add verbatim. The v60-v65 migrations run later via
+      // runMigrations and are idempotent — they handle backfill, FK install,
+      // federated_read backfill + validation, and the FK RESTRICT flip.
+      await this.db.exec(`
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS source_id TEXT;
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_read TEXT[] NOT NULL DEFAULT '{}';
       `);
     }
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -289,6 +289,10 @@ export class PostgresEngine implements BrainEngine {
    *     (indexed by `idx_mcp_log_agent_time`) — v0.26.3
    *   - `subagent_messages.provider_id` column (indexed by
    *     `idx_subagent_messages_provider`) — v0.27
+   *   - `oauth_clients.source_id` column (indexed by
+   *     `idx_oauth_clients_source_id`) — v0.34.1 (v60)
+   *   - `oauth_clients.federated_read` column (indexed by
+   *     `idx_oauth_clients_federated_read`) — v0.34.1 (v61)
    *
    * Keep this in sync with the PGLite version; covered by
    * `test/schema-bootstrap-coverage.test.ts` (PGLite side) and
@@ -319,6 +323,9 @@ export class PostgresEngine implements BrainEngine {
       subagent_provider_id_exists: boolean;
       ingest_log_exists: boolean;
       ingest_log_source_id_exists: boolean;
+      oauth_clients_exists: boolean;
+      oauth_clients_source_id_exists: boolean;
+      oauth_clients_federated_read_exists: boolean;
     }[]>`
       SELECT
         EXISTS (SELECT 1 FROM information_schema.tables
@@ -356,7 +363,13 @@ export class PostgresEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.tables
                 WHERE table_schema = current_schema() AND table_name = 'ingest_log') AS ingest_log_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema = current_schema() AND table_name = 'ingest_log' AND column_name = 'source_id') AS ingest_log_source_id_exists
+                WHERE table_schema = current_schema() AND table_name = 'ingest_log' AND column_name = 'source_id') AS ingest_log_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema() AND table_name = 'oauth_clients') AS oauth_clients_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'oauth_clients' AND column_name = 'source_id') AS oauth_clients_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'oauth_clients' AND column_name = 'federated_read') AS oauth_clients_federated_read_exists
     `;
     const probe = probeRows[0]!;
 
@@ -386,11 +399,22 @@ export class PostgresEngine implements BrainEngine {
     // source_id. Old brains have ingest_log without source_id; bootstrap adds
     // the column before SCHEMA_SQL replay creates the index.
     const needsIngestLogSourceId = probe.ingest_log_exists && !probe.ingest_log_source_id_exists;
+    // v0.34.1 (v60 + v61): idx_oauth_clients_source_id and
+    // idx_oauth_clients_federated_read in SCHEMA_SQL reference these columns.
+    // Old brains (oauth_clients existed since v0.30 / v45) have the table
+    // without source_id or federated_read; bootstrap adds the columns before
+    // SCHEMA_SQL replay creates the indexes. v60-v65 migrations run later
+    // via runMigrations and install the FK + backfill + RESTRICT flip + GIN
+    // index; bootstrap is intentionally lean (matches the v60 SQL shape and
+    // the v61 column add — no FK, no backfill, no validation).
+    const needsOauthClientsSourceId = probe.oauth_clients_exists && !probe.oauth_clients_source_id_exists;
+    const needsOauthClientsFederatedRead = probe.oauth_clients_exists && !probe.oauth_clients_federated_read_exists;
 
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
         && !needsPagesDeletedAt && !needsMcpLogBootstrap && !needsSubagentProviderId
         && !needsChunksEmbeddingImage && !needsPagesRecency
-        && !needsIngestLogSourceId) return;
+        && !needsIngestLogSourceId
+        && !needsOauthClientsSourceId && !needsOauthClientsFederatedRead) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
 
@@ -516,6 +540,27 @@ export class PostgresEngine implements BrainEngine {
       // so the index can build cleanly.
       await conn.unsafe(`
         ALTER TABLE ingest_log ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT 'default';
+      `);
+    }
+
+    if (needsOauthClientsSourceId || needsOauthClientsFederatedRead) {
+      // v60 (oauth_clients_source_id_fk) adds source_id; v61
+      // (oauth_clients_federated_read_column) adds federated_read.
+      // SCHEMA_SQL's `CREATE INDEX idx_oauth_clients_source_id ON
+      // oauth_clients(source_id) WHERE source_id IS NOT NULL` and
+      // `CREATE INDEX idx_oauth_clients_federated_read ON oauth_clients USING
+      // GIN (federated_read)` both crash on brains that lack these columns
+      // (any brain at schema_version < 60 with oauth_clients already
+      // installed — oauth_clients itself dates back to v0.30 / v45).
+      //
+      // Bootstrap is intentionally lean: matches v60's leading
+      // `ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS source_id TEXT`
+      // and v61's column-add verbatim. The v60-v65 migrations run later via
+      // runMigrations and are idempotent — they handle backfill, FK install,
+      // federated_read backfill + validation, and the FK RESTRICT flip.
+      await conn.unsafe(`
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS source_id TEXT;
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_read TEXT[] NOT NULL DEFAULT '{}';
       `);
     }
   }

--- a/test/schema-bootstrap-coverage.test.ts
+++ b/test/schema-bootstrap-coverage.test.ts
@@ -108,6 +108,16 @@ const REQUIRED_BOOTSTRAP_COVERAGE: ForwardReference[] = [
   // created_at DESC)`. Old brains have ingest_log without source_id; bootstrap
   // adds the column before SCHEMA_SQL replay creates the index.
   { kind: 'column', table: 'ingest_log', column: 'source_id' },
+  // v0.34.1 (v60) — forward-referenced by `CREATE INDEX
+  // idx_oauth_clients_source_id ON oauth_clients(source_id) WHERE source_id
+  // IS NOT NULL`. oauth_clients dates back to v0.30 / v45 — any brain at
+  // schema_version < 60 with oauth_clients already installed (e.g. v0.31.x
+  // brains) hits the wedge before migrations can run.
+  { kind: 'column', table: 'oauth_clients', column: 'source_id' },
+  // v0.34.1 (v61) — forward-referenced by `CREATE INDEX
+  // idx_oauth_clients_federated_read ON oauth_clients USING GIN (federated_read)`.
+  // Sibling-column case to v60 source_id above; same wedge class.
+  { kind: 'column', table: 'oauth_clients', column: 'federated_read' },
 ];
 
 test('applyForwardReferenceBootstrap covers every forward reference declared in REQUIRED_BOOTSTRAP_COVERAGE', async () => {
@@ -168,6 +178,12 @@ test('applyForwardReferenceBootstrap covers every forward reference declared in 
       ALTER TABLE pages DROP COLUMN IF EXISTS import_filename;
       ALTER TABLE pages DROP COLUMN IF EXISTS salience_touched_at;
       ALTER TABLE pages DROP COLUMN IF EXISTS emotional_weight;
+
+      DROP INDEX IF EXISTS idx_oauth_clients_source_id;
+      DROP INDEX IF EXISTS idx_oauth_clients_federated_read;
+      ALTER TABLE oauth_clients DROP CONSTRAINT IF EXISTS oauth_clients_source_id_fkey;
+      ALTER TABLE oauth_clients DROP COLUMN IF EXISTS source_id;
+      ALTER TABLE oauth_clients DROP COLUMN IF EXISTS federated_read;
     `);
 
     // Run bootstrap in isolation (NOT initSchema). This is what we're testing.
@@ -234,6 +250,12 @@ test('after bootstrap, PGLITE_SCHEMA_SQL replays without crashing on missing for
       ALTER TABLE pages DROP COLUMN IF EXISTS import_filename;
       ALTER TABLE pages DROP COLUMN IF EXISTS salience_touched_at;
       ALTER TABLE pages DROP COLUMN IF EXISTS emotional_weight;
+
+      DROP INDEX IF EXISTS idx_oauth_clients_source_id;
+      DROP INDEX IF EXISTS idx_oauth_clients_federated_read;
+      ALTER TABLE oauth_clients DROP CONSTRAINT IF EXISTS oauth_clients_source_id_fkey;
+      ALTER TABLE oauth_clients DROP COLUMN IF EXISTS source_id;
+      ALTER TABLE oauth_clients DROP COLUMN IF EXISTS federated_read;
     `);
 
     // Bootstrap, then schema replay. Either step crashing fails the test.


### PR DESCRIPTION
## Problem

`applyForwardReferenceBootstrap()` in both `src/core/postgres-engine.ts` and `src/core/pglite-engine.ts` is the contract that lets `initSchema()` safely replay `(PGLITE_)SCHEMA_SQL` on brains older than the latest schema version. It pre-creates every table/column the latest blob references so the blob's `CREATE INDEX` and FK statements don't crash before the numbered migration chain has a chance to install the real state.

Two columns were missing from that coverage at v0.34.4.0:

- `oauth_clients.source_id` — forward-referenced by `idx_oauth_clients_source_id ON oauth_clients(source_id) WHERE source_id IS NOT NULL` (added v60).
- `oauth_clients.federated_read` — forward-referenced by `idx_oauth_clients_federated_read ON oauth_clients USING GIN (federated_read)` (added v61).

`oauth_clients` itself dates back to v0.30 / v45. Any brain at `schema_version < 60` with the table already installed (so: any v0.30 / v0.31 / v0.32 / v0.33 brain that has the OAuth schema) wedges on the SCHEMA_SQL replay: the `CREATE INDEX` statements reference columns that don't exist yet, the engine throws, and the operator cannot run `gbrain apply-migrations` to install v60-v65 because every command path through `connectEngine()` runs `initSchema()` first.

## Reproduction

Caught upgrading our FortiumClaw deployment from v0.31.3 (schema 46) → v0.34.4.0 (schema 66). On the failing run, `initSchema()` aborted on the `CREATE INDEX idx_oauth_clients_source_id` statement with `column "source_id" does not exist`. The CLI's `--help`, `doctor`, `apply-migrations` — all blocked by the same code path. Manually `ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS source_id TEXT; ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_read TEXT[] NOT NULL DEFAULT '{}';` unblocked the upgrade and let the v60-v65 migrations run cleanly.

Fresh installs and brains already at v60+ both no-op through the new branches.

## Fix

In both engines:

- Add `oauth_clients_*_exists` probes to the existence-check SELECT (mirrors the existing pattern for `ingest_log`, `mcp_log`, `subagent_messages.provider_id`, etc.).
- Extend the early-return short-circuit so brains that don't need the new bootstrap continue to no-op.
- Add an `ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS ...` block at the bottom of each bootstrap function.

The added bootstrap SQL is **intentionally lean** — matches v60's leading `ALTER TABLE ... ADD COLUMN IF NOT EXISTS source_id TEXT` and v61's column add **verbatim**. No FK install, no backfill, no validation; those run later via the numbered migrations (v60-v65) which are already idempotent and handle:

- v60: source_id FK install (NOT VALID) + backfill
- v61: federated_read column add (this PR matches exactly)
- v62: federated_read backfill from existing scopes
- v63: federated_read NOT NULL validation
- v64: source_id FK RESTRICT flip
- v65: source_id FK validation

## Test coverage

`test/schema-bootstrap-coverage.test.ts` is the CI guard that asserts every forward reference declared in `REQUIRED_BOOTSTRAP_COVERAGE` is actually covered by the bootstrap. This PR:

- Adds the two new column entries to `REQUIRED_BOOTSTRAP_COVERAGE` (with comments explaining v60/v61 source).
- Extends the simulator block (pre-bootstrap "old brain" prep) to drop the v60/v61 indexes + FK + columns so the test exercises the new branch.
- Extends the post-bootstrap replay block to do the same.

All 5 tests pass locally (`bun test test/schema-bootstrap-coverage.test.ts`):
```
 5 pass
 0 fail
 37 expect() calls
```

`bun run typecheck` (`tsc --noEmit`) clean.

## Maintenance contract

Both engines kept in sync per the "Keep this in sync with the PGLite version" comment at the top of `applyForwardReferenceBootstrap`. The doc-comment in pglite-engine.ts is also extended to list the new forward references (matches the existing format for prior additions).

## Wedge class

This closes the v60+v61 instance of the recurring wedge class tracked in #239, #243, #266, #357, #366, #374, #375, #378, #395, #396 — same shape, same fix pattern. The structural CI test was added to prevent this class; this PR uses the contract that test enforces.