### PR TITLE
fix(schema): bootstrap oauth_clients.source_id + federated_read on upgrade

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -288,7 +288,13 @@ export class PGLiteEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.tables
                 WHERE table_schema='public' AND table_name='ingest_log') AS ingest_log_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema='public' AND table_name='ingest_log' AND column_name='source_id') AS ingest_log_source_id_exists
+                WHERE table_schema='public' AND table_name='ingest_log' AND column_name='source_id') AS ingest_log_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema='public' AND table_name='oauth_clients') AS oauth_clients_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='oauth_clients' AND column_name='source_id') AS oauth_clients_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='oauth_clients' AND column_name='federated_read') AS oauth_clients_federated_read_exists
     `);
     const probe = rows[0] as {
       pages_exists: boolean;
@@ -309,6 +315,9 @@ export class PGLiteEngine implements BrainEngine {
       subagent_provider_id_exists: boolean;
       ingest_log_exists: boolean;
       ingest_log_source_id_exists: boolean;
+      oauth_clients_exists: boolean;
+      oauth_clients_source_id_exists: boolean;
+      oauth_clients_federated_read_exists: boolean;
     };
 
     const needsPagesBootstrap = probe.pages_exists && !probe.source_id_exists;
@@ -332,12 +341,22 @@ export class PGLiteEngine implements BrainEngine {
     // references source_id. Old brains have ingest_log without source_id;
     // bootstrap adds the column before SCHEMA_SQL replay creates the index.
     const needsIngestLogSourceId = probe.ingest_log_exists && !probe.ingest_log_source_id_exists;
+    // v0.34.1 (#861, #876): oauth_clients gained source_id (v60) and
+    // federated_read (v61). PGLITE_SCHEMA_SQL declares both columns inline
+    // in CREATE TABLE oauth_clients AND emits CREATE INDEX statements that
+    // reference them. CREATE TABLE IF NOT EXISTS is a no-op on existing
+    // tables so upgrade brains skip the column adds and crash on the index
+    // creation. Bootstrap adds them; v60-v62 backfill and install FK + GIN
+    // index later via runMigrations (all ADD COLUMN IF NOT EXISTS, idempotent).
+    const needsOauthClientsBootstrap = probe.oauth_clients_exists
+      && (!probe.oauth_clients_source_id_exists || !probe.oauth_clients_federated_read_exists);
 
     // Fresh installs (no tables yet) and modern brains both no-op.
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
         && !needsPagesDeletedAt && !needsChunksEmbeddingImage
         && !needsMcpLogBootstrap && !needsSubagentProviderId
-        && !needsPagesRecency && !needsIngestLogSourceId) return;
+        && !needsPagesRecency && !needsIngestLogSourceId
+        && !needsOauthClientsBootstrap) return;
 
     console.log('  Pre-v0.21 brain detected, applying forward-reference bootstrap');
 
@@ -463,6 +482,19 @@ export class PGLiteEngine implements BrainEngine {
       // DEFAULT 'default' so the index can build cleanly.
       await this.db.exec(`
         ALTER TABLE ingest_log ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT 'default';
+      `);
+    }
+
+    if (needsOauthClientsBootstrap) {
+      // v60-v61: oauth_clients.source_id + federated_read. See the
+      // `needsOauthClientsBootstrap` declaration above for the upgrade-path
+      // explanation. v60 later backfills source_id='default' and installs the
+      // FK; v62 backfills federated_read=ARRAY[source_id]; both run via
+      // runMigrations with ADD COLUMN IF NOT EXISTS so this bootstrap is
+      // idempotent.
+      await this.db.exec(`
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS source_id TEXT;
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_read TEXT[] NOT NULL DEFAULT '{}';
       `);
     }
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -319,6 +319,9 @@ export class PostgresEngine implements BrainEngine {
       subagent_provider_id_exists: boolean;
       ingest_log_exists: boolean;
       ingest_log_source_id_exists: boolean;
+      oauth_clients_exists: boolean;
+      oauth_clients_source_id_exists: boolean;
+      oauth_clients_federated_read_exists: boolean;
     }[]>`
       SELECT
         EXISTS (SELECT 1 FROM information_schema.tables
@@ -356,7 +359,13 @@ export class PostgresEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.tables
                 WHERE table_schema = current_schema() AND table_name = 'ingest_log') AS ingest_log_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema = current_schema() AND table_name = 'ingest_log' AND column_name = 'source_id') AS ingest_log_source_id_exists
+                WHERE table_schema = current_schema() AND table_name = 'ingest_log' AND column_name = 'source_id') AS ingest_log_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema() AND table_name = 'oauth_clients') AS oauth_clients_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'oauth_clients' AND column_name = 'source_id') AS oauth_clients_source_id_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'oauth_clients' AND column_name = 'federated_read') AS oauth_clients_federated_read_exists
     `;
     const probe = probeRows[0]!;
 
@@ -386,6 +395,19 @@ export class PostgresEngine implements BrainEngine {
     // source_id. Old brains have ingest_log without source_id; bootstrap adds
     // the column before SCHEMA_SQL replay creates the index.
     const needsIngestLogSourceId = probe.ingest_log_exists && !probe.ingest_log_source_id_exists;
+
+    // v0.34.1 (#861, #876): oauth_clients gained `source_id` (v60) and
+    // `federated_read` (v61). schema.sql / schema-embedded.ts now declare both
+    // columns inline in CREATE TABLE oauth_clients AND emit `CREATE INDEX
+    // idx_oauth_clients_source_id ON oauth_clients(source_id)` +
+    // `idx_oauth_clients_federated_read ON oauth_clients USING GIN (federated_read)`
+    // as standalone statements. Upgrade brains skip the inline column adds
+    // because CREATE TABLE IF NOT EXISTS is a no-op on the existing table, and
+    // the standalone CREATE INDEX statements then crash with "column source_id
+    // does not exist". Bootstrap adds the columns so initSchema completes; v60-v62
+    // run later via runMigrations and are idempotent (ADD COLUMN IF NOT EXISTS).
+    const needsOauthClientsBootstrap = probe.oauth_clients_exists
+      && (!probe.oauth_clients_source_id_exists || !probe.oauth_clients_federated_read_exists);
 
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
         && !needsPagesDeletedAt && !needsMcpLogBootstrap && !needsSubagentProviderId
@@ -516,6 +538,20 @@ export class PostgresEngine implements BrainEngine {
       // so the index can build cleanly.
       await conn.unsafe(`
         ALTER TABLE ingest_log ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT 'default';
+      `);
+    }
+
+    if (needsOauthClientsBootstrap) {
+      // v60-v61 (oauth_clients_source_id_fk + oauth_clients_federated_read_column)
+      // add the two columns and standalone CREATE INDEX statements that
+      // reference them. SCHEMA_SQL replay fails on upgrade because
+      // CREATE TABLE IF NOT EXISTS is a no-op on the pre-existing table while
+      // the CREATE INDEX statements run unconditionally. Add the columns
+      // here so initSchema completes; v60 backfills source_id='default' and
+      // v62 backfills federated_read=ARRAY[source_id] later via runMigrations.
+      await conn.unsafe(`
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS source_id TEXT;
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_read TEXT[] NOT NULL DEFAULT '{}';
       `);
     }
   }

--- a/test/schema-bootstrap-coverage.test.ts
+++ b/test/schema-bootstrap-coverage.test.ts
@@ -108,6 +108,15 @@ const REQUIRED_BOOTSTRAP_COVERAGE: ForwardReference[] = [
   // created_at DESC)`. Old brains have ingest_log without source_id; bootstrap
   // adds the column before SCHEMA_SQL replay creates the index.
   { kind: 'column', table: 'ingest_log', column: 'source_id' },
+
+  // v0.34.1 (#861, #876) — oauth_clients.source_id + federated_read.
+  // Declared inline in CREATE TABLE oauth_clients in PGLITE_SCHEMA_SQL but
+  // CREATE TABLE IF NOT EXISTS is a no-op on upgrade so the new columns are
+  // not added by schema replay. Standalone CREATE INDEX statements that
+  // reference both columns crash without bootstrap. v60-v62 add them via
+  // ADD COLUMN IF NOT EXISTS, so bootstrap is idempotent.
+  { kind: 'column', table: 'oauth_clients', column: 'source_id' },
+  { kind: 'column', table: 'oauth_clients', column: 'federated_read' },
 ];
 
 test('applyForwardReferenceBootstrap covers every forward reference declared in REQUIRED_BOOTSTRAP_COVERAGE', async () => {


### PR DESCRIPTION
## Symptom

Upgrading a v0.31.0 brain to v0.34.x or later fails on `initSchema` with:

```
Schema probe/migrate failed: column "source_id" does not exist
  Try: gbrain init --migrate-only
```

`gbrain init --migrate-only` reports the same error. `runMigrations` never gets a chance to apply v60+ because the schema replay aborts first.

## Root cause

`v0.34.1` (#861, #876) added `oauth_clients.source_id` (migration v60) and `oauth_clients.federated_read` (v61), and inlined both columns into `CREATE TABLE IF NOT EXISTS oauth_clients` across `src/schema.sql`, `src/core/schema-embedded.ts`, and `src/core/pglite-schema.ts`. The same schema files emit two standalone `CREATE INDEX` statements that reference the new columns:

```sql
CREATE INDEX IF NOT EXISTS idx_oauth_clients_source_id
  ON oauth_clients(source_id) WHERE source_id IS NOT NULL;
CREATE INDEX IF NOT EXISTS idx_oauth_clients_federated_read
  ON oauth_clients USING GIN (federated_read);
```

On a fresh install everything lands. On an upgrade brain, `CREATE TABLE IF NOT EXISTS` is a no-op so the inline column adds are silently skipped — and the standalone `CREATE INDEX` crashes referencing the missing column. `initSchema` aborts before `runMigrations` runs.

This is the same upgrade-path class already handled for `pages.source_id` (v18), `links.link_source` (v13), `content_chunks.embedding_image` (v39), `pages.effective_date` (v41), and `ingest_log.source_id` (v50) — all bootstrapped via `applyForwardReferenceBootstrap` on both engines. `oauth_clients` was just missed.

## Fix

Extend `applyForwardReferenceBootstrap` in both `PostgresEngine` and `PGLiteEngine` to probe for `oauth_clients.source_id` and `oauth_clients.federated_read` and `ALTER TABLE ADD COLUMN IF NOT EXISTS` them before the schema replay. Migrations v60-v62 then run idempotently through `runMigrations` and pick up the columns this bootstrap provided (they backfill, install the FK, and add the GIN index).

The coverage contract in `test/schema-bootstrap-coverage.test.ts` gains the two new `REQUIRED_BOOTSTRAP_COVERAGE` entries so the static A2 check (covered-by-CREATE-TABLE-OR-bootstrap) fails loudly if anyone removes either `ALTER` from `applyForwardReferenceBootstrap`. The existing PGLite test passed at HEAD because `PGLITE_SCHEMA_SQL` declares both columns inline in `CREATE TABLE` (which the parser accepts as coverage) - that satisfies the fresh-install scenario, but the bootstrap is the actual upgrade-path invariant.

## Verification

Reproduced and fixed on a real v0.31.0 Supabase brain.

Before:
```
$ bun ./src/cli.ts init --migrate-only
... initial schema replay ...
column "source_id" does not exist
```

After (with this patch):
```
$ bun ./src/cli.ts init --migrate-only
Schema version 45 -> 66 (21 migration(s) pending)
[46] mcp_request_log_params_jsonb_normalize... ✓
[47] facts_notability_alter... ✓
...
[66] embed_stale_partial_index... ✓
21 migration(s) applied
```

Tests:

```
bun test test/schema-bootstrap-coverage.test.ts                  # 5 pass
bun test test/mcp-tool-defs.test.ts test/http-transport.test.ts          test/facts-meta-cache.test.ts          test/facts-mcp-allowlist.serial.test.ts                 # 44 pass
```

## Scope

3 files, +80/-3. No public API change. No new migration. Bootstrap-only.

## Notes

Detected during a real v0.31.0 → v0.35.4.0 upgrade. The pre-existing `applyForwardReferenceBootstrap` already follows the exact pattern this PR extends. The maintenance contract in the comment above the function explicitly says:

> when a future migration adds a column-with-index or new-table-with-FK referenced by PGLITE_SCHEMA_SQL, extend this method AND `test/schema-bootstrap-coverage.test.ts`'s `REQUIRED_BOOTSTRAP_COVERAGE`.

`v0.34.1` shipped without that extension. This PR closes that gap.
