### PR TITLE
fix(ai): warn only for configured embedding provider

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -398,18 +398,27 @@ function prefixWithProviderFrom(original: string, bare: string): string {
 const _warnedRecipes = new Set<string>();
 
 /**
- * Walk every registered recipe with an `embedding` touchpoint. Each one
- * missing `max_batch_tokens` gets exactly one stderr line per process for
- * its first appearance. Recipes WITH the field stay quiet. The
+ * Walk the configured embedding recipes. Each one missing `max_batch_tokens`
+ * gets exactly one stderr line per process for its first appearance. Recipes
+ * WITH the field stay quiet. The
  * recursive-halving safety net only fires when `max_batch_tokens` is set,
  * so a recipe that forgets it has no protection if the provider has a
  * batch cap. Loud-fail over silent-skip per CLAUDE.md; a future
  * Cohere/Mistral/Jina recipe that inherits the embedding-touchpoint
  * pattern but forgets the cap re-creates the v0.27 Voyage backfill loop.
- * The warning calls that out before production traffic hits it.
+ * The warning calls that out before production traffic hits it, while avoiding
+ * unrelated startup noise from recipes the current brain is not using.
  */
 function warnRecipesMissingBatchTokens(): void {
+  const configuredProviderIds = new Set<string>();
+  for (const model of [_config?.embedding_model, _config?.embedding_multimodal_model]) {
+    if (!model) continue;
+    const providerId = model.split(':')[0];
+    if (providerId) configuredProviderIds.add(providerId);
+  }
+
   for (const recipe of listRecipes()) {
+    if (!configuredProviderIds.has(recipe.id)) continue;
     const embedding = recipe.touchpoints?.embedding;
     if (!embedding || embedding.max_batch_tokens !== undefined) continue;
     // OpenAI is the canonical "no cap declared, fast path is intentional"

--- a/test/ai/adaptive-embed-batch.test.ts
+++ b/test/ai/adaptive-embed-batch.test.ts
@@ -23,9 +23,9 @@
  *      after SHRINK_HEAL_AFTER successes the factor heals back toward the
  *      recipe-declared safety_factor.
  *
- *   7. Startup warning (D9-B) — gateway construction warns once per recipe
- *      with an embedding touchpoint missing max_batch_tokens (excluding the
- *      OpenAI canonical fast-path recipe).
+ *   7. Startup warning (D9-B) — gateway construction warns once for the
+ *      configured embedding recipe when it is missing max_batch_tokens
+ *      (excluding the OpenAI canonical fast-path recipe).
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
@@ -73,6 +73,14 @@ function configureOpenAI(): void {
     embedding_model: 'openai:text-embedding-3-large',
     embedding_dimensions: 1536,
     env: { OPENAI_API_KEY: 'sk-fake' },
+  });
+}
+
+function configureGoogle(): void {
+  configureGateway({
+    embedding_model: 'google:gemini-embedding-001',
+    embedding_dimensions: 768,
+    env: { GOOGLE_GENERATIVE_AI_API_KEY: 'fake' },
   });
 }
 
@@ -360,16 +368,18 @@ describe('shrink-on-miss adaptive cache', () => {
 describe('startup warning for recipes missing max_batch_tokens', () => {
   beforeEach(() => resetGateway());
 
-  test('first configureGateway call warns about each missing-cap recipe; subsequent calls suppressed', () => {
+  test('configured missing-cap recipe warns once; unrelated recipes stay quiet', () => {
     const warnings: string[] = [];
     const original = console.warn;
     console.warn = (msg: string) => warnings.push(String(msg));
     try {
       configureOpenAI();
+      expect(warnings.length).toBe(0);
+      configureGoogle();
       const firstCallCount = warnings.length;
       // Reconfigure: the warning should NOT re-fire for the same recipes
       // within one process (we already told the operator).
-      configureOpenAI();
+      configureGoogle();
       expect(warnings.length).toBe(firstCallCount);
     } finally {
       console.warn = original;
@@ -379,12 +389,13 @@ describe('startup warning for recipes missing max_batch_tokens', () => {
     const contractMatch = warnings.filter(w =>
       w.includes('[ai.gateway]') && w.includes('declares an embedding touchpoint'),
     );
-    expect(contractMatch.length).toBeGreaterThan(0);
+    expect(contractMatch.length).toBe(1);
 
     // Voyage declares max_batch_tokens → suppressed. OpenAI is the
     // canonical fast-path recipe → also suppressed by id. Both must be
     // absent from the warnings.
     expect(warnings.find(w => w.includes('"voyage"'))).toBeUndefined();
     expect(warnings.find(w => w.includes('"openai"'))).toBeUndefined();
+    expect(warnings.find(w => w.includes('"google"'))).toBeDefined();
   });
 });

--- a/test/ai/no-batch-cap-suppression.serial.test.ts
+++ b/test/ai/no-batch-cap-suppression.serial.test.ts
@@ -52,14 +52,27 @@ describe('v0.32 #779: no_batch_cap suppresses the missing-max_batch_tokens warni
     }
   });
 
-  test('configureGateway STILL warns for google (real provider, no cap declared)', () => {
+  test('configureGateway warns for google only when google embedding is configured', () => {
     warnSpy.mockClear();
     resetGateway();
     configureGateway({ env: {} });
-    const messages = warnSpy.mock.calls.map(c => String(c[0] ?? ''));
+    let messages = warnSpy.mock.calls.map(c => String(c[0] ?? ''));
     expect(
       messages.some(m => m.includes('"google"') && m.includes('without max_batch_tokens')),
-      'google should warn (it has fixed-cap models)',
+      'google should not warn while OpenAI default is configured',
+    ).toBe(false);
+
+    warnSpy.mockClear();
+    resetGateway();
+    configureGateway({
+      embedding_model: 'google:gemini-embedding-001',
+      embedding_dimensions: 768,
+      env: { GOOGLE_GENERATIVE_AI_API_KEY: 'fake' },
+    });
+    messages = warnSpy.mock.calls.map(c => String(c[0] ?? ''));
+    expect(
+      messages.some(m => m.includes('"google"') && m.includes('without max_batch_tokens')),
+      'google should warn when configured because it has fixed-cap models',
     ).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- Limit missing `max_batch_tokens` startup diagnostics to the configured embedding provider.
- Keep the existing warning behavior when a brain actually configures a missing-cap provider such as Google.
- Avoid unrelated stderr noise for local Ollama brains and other non-Google setups.

## Why
Dogfooding the local Ollama embedding setup from gstack showed every gbrain CLI call printing:

```
[ai.gateway] recipe "google" declares an embedding touchpoint without max_batch_tokens; recursion is the only safety net for batch caps.
```

The brain was configured for `ollama:nomic-embed-text`, not Google. The warning is useful when Google is the selected embedding provider, but noisy and misleading when it fires for recipes the current brain is not using.

## Test plan
- `bun test test/ai/adaptive-embed-batch.test.ts test/ai/no-batch-cap-suppression.serial.test.ts`
- Dogfood fixture with `embedding_model=ollama:nomic-embed-text`: `bun src/cli.ts providers test --model ollama:nomic-embed-text` and `bun src/cli.ts search "summarizeDogfoodFinding"` no longer print the Google warning.

