### PR TITLE
fix(sync): skip git pull when no origin remote

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -230,6 +230,19 @@ function git(repoPath: string, args: string[], configs: string[] = []): string {
   }).trim();
 }
 
+function hasOriginRemote(repoPath: string): boolean {
+  try {
+    execFileSync('git', buildGitInvocation(repoPath, ['remote', 'get-url', 'origin']), {
+      encoding: 'utf-8',
+      timeout: 30000,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function isDetachedHead(repoPath: string): boolean {
   try {
     git(repoPath, ['symbolic-ref', '--quiet', 'HEAD']);
@@ -450,7 +463,12 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // hardening that cloneRepo applies. Route through pullRepo from
   // git-remote.ts so the flag set is consistent across initial clone and
   // ongoing pulls — single source of truth for the defensive flags.
-  if (!opts.noPull && !detachedHead) {
+  const originRemotePresent = !opts.noPull && !detachedHead ? hasOriginRemote(repoPath) : false;
+  if (!opts.noPull && !detachedHead && !originRemotePresent) {
+    console.error(`No origin remote on ${repoPath}; skipping git pull. Syncing from local working tree.`);
+  }
+
+  if (!opts.noPull && !detachedHead && originRemotePresent) {
     const _t0 = Date.now();
     console.error(`[gbrain phase] sync.git_pull start`);
     try {

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -272,6 +272,26 @@ describe('performSync dry-run never writes', () => {
     expect(await engine.getConfig('sync.repo_path')).toBeNull();
   });
 
+  test('first sync without origin skips git pull noise and uses local working tree', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const messages: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => { messages.push(args.map(String).join(' ')); };
+    try {
+      const result = await performSync(engine, {
+        repoPath,
+        noEmbed: true,
+      });
+      expect(result.status).toBe('first_sync');
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(messages.some(m => m.includes('No origin remote') && m.includes('skipping git pull'))).toBe(true);
+    expect(messages.some(m => m.includes('sync.git_pull start'))).toBe(false);
+    expect(messages.some(m => m.includes('git pull failed'))).toBe(false);
+  });
+
   test('incremental dry-run does NOT write to DB or advance the bookmark', async () => {
     const { performSync } = await import('../src/commands/sync.ts');
     // First do a real sync to seed the bookmark.


### PR DESCRIPTION
## Summary

Dogfooding the local gstack -> gbrain setup against a brand-new local repo showed that sync succeeds, but it prints noisy git-pull failures when the repo has no `origin` remote.

This keeps the existing pull behavior when `origin` exists, but checks for it first and skips pull cleanly for local-only repos:

- detect missing `origin` before `pullRepo()`
- print one explicit "skipping git pull" message
- continue syncing from the local working tree
- add regression coverage that verifies the noisy pull path is not entered

## Dogfood evidence

Against the isolated local-Ollama fixture:

```
No origin remote on .../repo; skipping git pull. Syncing from local working tree.
Already up to date.
```

Before this fix, the same path emitted raw Git errors like:

```
error: No such remote 'origin'
[gbrain phase] sync.git_pull error ...
Warning: git pull failed ...
```

## Tests

```
bun test test/sync.test.ts --timeout 120000
```

46 passing.
