### PR TITLE
fix(sync): scope auto-embed to source

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -212,6 +212,10 @@ export function buildGitInvocation(repoPath: string, args: string[], configs: st
   return [...cfg, '-C', repoPath, ...args];
 }
 
+export function buildAutoEmbedArgs(slugs: string[], sourceId?: string): string[] {
+  return sourceId ? ['--source', sourceId, '--slugs', ...slugs] : ['--slugs', ...slugs];
+}
+
 /**
  * Shell out to git with a generous maxBuffer.
  *
@@ -962,19 +966,13 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   }
 
   // Auto-embed (skip for large syncs — embedding calls OpenAI).
-  // TODO(multi-source): runEmbed → src/commands/embed.ts:175 + :418 call
-  // upsertChunks defaulting to source='default'. For non-default-source syncs
-  // the page row lives at (sourceId, slug) so this fails with "Page not found"
-  // OR (when a same-slug 'default' row coexists) updates the wrong source's
-  // chunks. Data R1 MED 2 — deferred to a follow-up PR; threading sourceId
-  // through embed.ts is a larger refactor than this fix's scope. The current
-  // try/catch swallows the failure as best-effort, so the sync result still
-  // reports `embedded: 0` for the right reason.
+  // Thread sourceId so incremental source syncs embed the page row they just
+  // imported instead of falling back to the default source.
   let embedded = 0;
   if (!noEmbed && pagesAffected.length > 0 && pagesAffected.length <= 100) {
     try {
       const { runEmbed } = await import('./embed.ts');
-      await runEmbed(engine, ['--slugs', ...pagesAffected]);
+      await runEmbed(engine, buildAutoEmbedArgs(pagesAffected, opts.sourceId));
       // Before commit 2 lands: runEmbed is void. Best estimate is pagesAffected,
       // since runEmbed re-embeds every requested slug. Commit 2 sharpens this
       // with EmbedResult.embedded.

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
 import { buildSyncManifest, isSyncable, pathToSlug } from '../src/core/sync.ts';
-import { buildGitInvocation } from '../src/commands/sync.ts';
+import { buildAutoEmbedArgs, buildGitInvocation } from '../src/commands/sync.ts';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
@@ -558,5 +558,20 @@ describe('git() helper invocation order (CJK wave v0.32.7)', () => {
       '-c', 'core.quotepath=false',
       '-C', '/repo',
     ]);
+  });
+});
+
+describe('sync auto-embed arguments', () => {
+  test('scopes incremental source sync embedding to the same source', () => {
+    expect(buildAutoEmbedArgs(['hello-js'], 'source-a')).toEqual([
+      '--source',
+      'source-a',
+      '--slugs',
+      'hello-js',
+    ]);
+  });
+
+  test('keeps default-source sync embed arguments unchanged', () => {
+    expect(buildAutoEmbedArgs(['people/alice'])).toEqual(['--slugs', 'people/alice']);
   });
 });


### PR DESCRIPTION
## Summary

Dogfooding incremental code sync against a registered local source exposed that sync imported the changed page under the correct source, then the auto-embed step tried to embed the slug without passing `--source`.

That falls back to `source=default`, which can print:

```
Error embedding hello-js: Page not found: hello-js (source=default)
```

This threads `sourceId` into the auto-embed call so incremental source sync embeds the same source row it just imported.

## Dogfood evidence

Before:

```
[sync.imports] 1/1 (100%) hello.js
  Error embedding hello-js: Page not found: hello-js (source=default)
Synced bb58d793..f0f41e36:
  +0 added, ~1 modified, -0 deleted, R0 renamed
  2 chunks created, 1 pages embedded
```

After:

```
[sync.imports] 1/1 (100%) hello.js
hello-js: all 2 chunks already embedded
Synced f0f41e36..86977128:
  +0 added, ~1 modified, -0 deleted, R0 renamed
  2 chunks created, 1 pages embedded
```

## Tests

```
bun test test/sync.test.ts --timeout 120000
```

47 passing.
