### PR TITLE
fix: match plugin entry.id to openclaw.plugin.json id

### DIFF
--- a/src/openclaw-context-engine.ts
+++ b/src/openclaw-context-engine.ts
@@ -50,7 +50,11 @@ interface PluginCtx {
 }
 
 const entry: PluginEntry = {
-  id: 'gbrain-context-engine',
+  // Plugin id. Must match `openclaw.plugin.json:id` ("gbrain") so the
+  // OpenClaw plugin validator accepts the load. The engine TYPE this plugin
+  // registers is a separate concept tracked by ENGINE_ID ('gbrain-context'),
+  // passed to registerContextEngine below.
+  id: 'gbrain',
   name: 'GBrain Context Engine',
   description: 'Deterministic temporal/spatial context injection on every turn',
 


### PR DESCRIPTION
## Summary

The OpenClaw plugin validator (openclaw 2026.5.12+) flags a mismatch between the source-level `entry.id` and the manifest id:

```
gbrain [validation]: plugin id mismatch (config uses "gbrain", export uses "gbrain-context-engine")
```

`openclaw.plugin.json:id` is `"gbrain"` and is what every OpenClaw config field refers to (`plugins.entries.gbrain`, `plugins.allow: [..., "gbrain"]`). But `src/openclaw-context-engine.ts:53` was setting `id: 'gbrain-context-engine'`, which appears to have conflated the plugin's identity with the context engine TYPE id (which is a separate concept tracked by `ENGINE_ID = 'gbrain-context'` from `core/context-engine.ts:104` and passed to `api.registerContextEngine(ENGINE_ID, ...)`).

This PR realigns `entry.id` to `'gbrain'` so it matches the manifest, with an inline comment clarifying the two concepts.

## Behavioral impact

None. The context engine still registers as `'gbrain-context'`, which is the slot id consumed by `plugins.slots.contextEngine`. Only the plugin's own identity gets corrected.

## Verification

On garrytan/gbrain v0.35.4.0 against openclaw 2026.5.12:

Before:
```
$ openclaw plugins doctor
Plugin errors:
- gbrain [validation]: plugin id mismatch (config uses "gbrain", export uses "gbrain-context-engine")
```

After:
```
$ openclaw plugins doctor
No plugin issues detected.
```

## Test plan

- [x] `openclaw plugins doctor` reports "No plugin issues detected"
- [x] `openclaw plugins list` shows `gbrain ... enabled ... global:gbrain/src/openclaw-context-engine.ts`
- [x] Gateway startup banner counts gbrain in the active plugin set
- [x] gbrain context engine still injects on turns (engine slot binding via `ENGINE_ID` unchanged)