### PR TITLE
fix(query): honor source id with no-expand

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -450,7 +450,7 @@ export function resolveQueryImage(
   return { path: imagePath, base64, mime };
 }
 
-function parseOpArgs(op: Operation, args: string[]): Record<string, unknown> {
+export function parseOpArgs(op: Operation, args: string[]): Record<string, unknown> {
   const params: Record<string, unknown> = {};
   const positional = op.cliHints?.positional || [];
   let posIdx = 0;
@@ -458,6 +458,14 @@ function parseOpArgs(op: Operation, args: string[]): Record<string, unknown> {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg.startsWith('--')) {
+      if (arg.startsWith('--no-')) {
+        const positiveKey = arg.slice(5).replace(/-/g, '_');
+        const positiveDef = op.params[positiveKey];
+        if (positiveDef?.type === 'boolean') {
+          params[positiveKey] = false;
+          continue;
+        }
+      }
       const key = arg.slice(2).replace(/-/g, '_');
       const paramDef = op.params[key];
       if (paramDef?.type === 'boolean') {

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1150,6 +1150,15 @@ const query: Operation = {
     const queryText = p.query as string | undefined;
     const imageData = p.image as string | undefined;
     const imageMime = (p.image_mime as string) || 'image/jpeg';
+    // Explicit per-call source_id must win over ctx.sourceId. The special
+    // __all__ value opts out of source filtering for local cross-source search.
+    const sourceIdParam = typeof p.source_id === 'string' ? p.source_id : undefined;
+    const querySourceScope =
+      sourceIdParam !== undefined
+        ? sourceIdParam === '__all__'
+          ? {}
+          : { sourceId: sourceIdParam }
+        : sourceScopeOpts(ctx);
 
     // v0.27.1: image-similarity branch. Bypasses hybridSearch (which is
     // text-only); embeds the image via embedMultimodal and runs a direct
@@ -1167,7 +1176,7 @@ const query: Operation = {
         limit: (p.limit as number) || 20,
         offset: (p.offset as number) || 0,
         embeddingColumn: 'embedding_image',
-        ...sourceScopeOpts(ctx),
+        ...querySourceScope,
       });
       return results;
     }
@@ -1186,16 +1195,6 @@ const query: Operation = {
     // search). When the param is the literal '__all__', force-allow
     // cross-source mode (matches SearchOpts.sourceId contract).
     let capturedMeta: HybridSearchMeta | null = null;
-    // v0.34 (Codex finding #2): thread ctx.sourceId so multi-source brains
-    // get source-scoped retrieval. Explicit `source_id` param wins over
-    // ctx.sourceId; literal `__all__` opts out (cross-source).
-    const sourceIdParam = typeof p.source_id === 'string' ? p.source_id : undefined;
-    const resolvedSourceId =
-      sourceIdParam !== undefined
-        ? sourceIdParam === '__all__'
-          ? undefined
-          : sourceIdParam
-        : ctx.sourceId;
     // v0.32.x search-lite: route the query op through hybridSearchCached so
     // semantic cache + token budget + intent weighting fire automatically.
     // Plain hybridSearch remains the bare API for callers that opt out.
@@ -1209,7 +1208,7 @@ const query: Operation = {
       symbolKind: (p.symbol_kind as string) || undefined,
       nearSymbol: (p.near_symbol as string) || undefined,
       walkDepth: typeof p.walk_depth === 'number' ? (p.walk_depth as number) : undefined,
-      sourceId: resolvedSourceId,
+      ...querySourceScope,
       // v0.29.1 — agent-explicit recency + salience. Omitted = heuristic defaults.
       salience: p.salience as 'off' | 'on' | 'strong' | undefined,
       recency: p.recency as 'off' | 'on' | 'strong' | undefined,
@@ -1220,10 +1219,6 @@ const query: Operation = {
       useCache: typeof p.use_cache === 'boolean' ? (p.use_cache as boolean) : undefined,
       intentWeighting: typeof p.intent_weighting === 'boolean' ? (p.intent_weighting as boolean) : undefined,
       onMeta: (m) => { capturedMeta = m; },
-      // v0.34.1 (#861 — P0 leak seal): thread caller's source scope. The
-      // hybridSearch internal searchOpts rebuild (hybrid.ts:223) was
-      // dropping these fields pre-fix even when callers passed them.
-      ...sourceScopeOpts(ctx),
     });
     const latency_ms = Date.now() - startedAt;
 

--- a/test/cli-args.test.ts
+++ b/test/cli-args.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { parseOpArgs } from '../src/cli.ts';
+import { operationsByName } from '../src/core/operations.ts';
+
+describe('parseOpArgs', () => {
+  test('--no-<boolean> maps to false without consuming the next flag', () => {
+    const params = parseOpArgs(operationsByName.query, [
+      'freshEmbedSourceScope code source',
+      '--limit',
+      '8',
+      '--no-expand',
+      '--source-id',
+      'gstack-code-repo-0e4763c9',
+    ]);
+
+    expect(params).toEqual({
+      query: 'freshEmbedSourceScope code source',
+      limit: 8,
+      expand: false,
+      source_id: 'gstack-code-repo-0e4763c9',
+    });
+  });
+});
+

--- a/test/mcp-eval-capture.test.ts
+++ b/test/mcp-eval-capture.test.ts
@@ -36,6 +36,33 @@ beforeAll(async () => {
     compiled_truth: 'Alice Example for op-layer capture tests.',
   };
   await engine.putPage('people/alice-example', page);
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name) VALUES ('testsrc', 'Test Source') ON CONFLICT DO NOTHING`,
+  );
+  await engine.putPage('notes/source-override-default', {
+    type: 'note',
+    title: 'Default Source Override',
+    compiled_truth: 'sourceoverrideunique belongs to the default source.',
+  });
+  await engine.upsertChunks('notes/source-override-default', [
+    {
+      chunk_index: 0,
+      chunk_text: 'sourceoverrideunique belongs to the default source.',
+      chunk_source: 'compiled_truth',
+    },
+  ]);
+  await engine.putPage('notes/source-override-testsrc', {
+    type: 'note',
+    title: 'Test Source Override',
+    compiled_truth: 'sourceoverrideunique belongs to the explicit source.',
+  }, { sourceId: 'testsrc' });
+  await engine.upsertChunks('notes/source-override-testsrc', [
+    {
+      chunk_index: 0,
+      chunk_text: 'sourceoverrideunique belongs to the explicit source.',
+      chunk_source: 'compiled_truth',
+    },
+  ], { sourceId: 'testsrc' });
 });
 
 afterAll(async () => {
@@ -146,6 +173,23 @@ describe('op-layer capture — query', () => {
 
     const rows = await engine.listEvalCandidates();
     expect(rows).toHaveLength(0);
+  });
+
+  test('explicit source_id overrides ctx.sourceId for query retrieval', async () => {
+    const ctx = makeCtx({
+      sourceId: 'default',
+      config: makeConfig({ capture: false }),
+    });
+
+    const results = await queryOp.handler(ctx, {
+      query: 'sourceoverrideunique',
+      source_id: 'testsrc',
+      expand: false,
+      use_cache: false,
+    }) as Array<{ slug: string }>;
+
+    expect(results.map(r => r.slug)).toContain('notes/source-override-testsrc');
+    expect(results.map(r => r.slug)).not.toContain('notes/source-override-default');
   });
 });
 


### PR DESCRIPTION
## Summary

Multi-source dogfooding exposed two related CLI/query issues:

1. `gbrain query ... --no-expand --source-id <id>` did not actually set `expand=false`.
2. Because `--no-expand` was not recognized as the negated form of the boolean `expand` param, the CLI parser consumed `--source-id` as the value for an unknown `no_expand` flag. That meant `source_id` never reached the query op.

There was also an op-layer ordering bug: explicit `source_id` was computed, but then `sourceScopeOpts(ctx)` was spread later and could overwrite the explicit per-call source.

This patch:

- supports `--no-<boolean>` in the shared CLI arg parser
- keeps `--no-expand` from consuming the next flag
- makes explicit `source_id` win over `ctx.sourceId`
- preserves `source_id=__all__` as the cross-source escape hatch
- applies the same explicit source scope to text and image query paths

## Dogfood evidence

Before, from inside a notes source:

```
gbrain query "freshEmbedSourceScope code source" --no-expand --source-id gstack-code-repo-0e4763c9
```

returned notes results because `--source-id` was swallowed.

After:

```
[0.8660] hello-js -- [JavaScript] hello.js:1-9 export statement summarizeDogfoodFinding
[0.5216] package-json -- [JSON] package.json:1-1 module
```

and the same query scoped to `ren-notes` returns the notes pages.

## Tests

```
bun test test/cli-args.test.ts test/mcp-eval-capture.test.ts test/search-lang-symbol-kind.test.ts --timeout 120000
```

22 passing.
