### PR TITLE
fix(query): drain cache writes before cli exit

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -169,6 +169,10 @@ async function main() {
     const result = JSON.parse(JSON.stringify(rawResult));
     const output = formatResult(op.name, result);
     if (output) process.stdout.write(output);
+    if (op.name === 'query') {
+      const { awaitPendingSearchCacheWrites } = await import('./core/search/hybrid.ts');
+      await awaitPendingSearchCacheWrites();
+    }
   } catch (e: unknown) {
     if (e instanceof OperationError) {
       console.error(`Error [${e.code}]: ${e.message}`);

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -31,6 +31,17 @@ import {
 
 const RRF_K = 60;
 const COMPILED_TRUTH_BOOST = 2.0;
+const pendingCacheWrites = new Set<Promise<unknown>>();
+
+export async function awaitPendingSearchCacheWrites(): Promise<void> {
+  if (pendingCacheWrites.size === 0) return;
+  await Promise.allSettled([...pendingCacheWrites]);
+}
+
+function trackCacheWrite(promise: Promise<unknown>): void {
+  pendingCacheWrites.add(promise);
+  promise.finally(() => pendingCacheWrites.delete(promise)).catch(() => { /* swallow */ });
+}
 /**
  * Backlink boost coefficient. Score is multiplied by (1 + BACKLINK_BOOST_COEF * log(1 + count)).
  * - 0 backlinks: factor = 1.0 (no boost).
@@ -752,9 +763,11 @@ export async function hybridSearchCached(
     results.length > 0 &&
     (innerMeta?.vector_enabled ?? false)
   ) {
-    void cache
-      .store(query, queryEmbedding, results, finalMeta, { sourceId: opts?.sourceId, knobsHash: cacheKnobsHash })
-      .catch(() => { /* swallow */ });
+    trackCacheWrite(
+      cache
+        .store(query, queryEmbedding, results, finalMeta, { sourceId: opts?.sourceId, knobsHash: cacheKnobsHash })
+        .catch(() => { /* swallow */ }),
+    );
   }
 
   return budgeted;


### PR DESCRIPTION
## Summary

Local-Ollama dogfooding showed that `gbrain query` could print results and then keep the CLI process alive until externally killed. The same path exited cleanly when cache writes were disabled.

Root cause: `hybridSearchCached` starts query-cache writeback as fire-and-forget work. That is fine for long-running MCP/server processes, but for a one-shot CLI invocation it can keep the process alive while the local engine is already moving toward disconnect.

This keeps cache writeback non-blocking for the search hot path, but tracks pending cache writes and lets the CLI query path drain them before disconnecting.

## Dogfood evidence

Before:

```
timeout 12s gbrain query "freshEmbedSourceScope code source" ...
# prints results, exits via timeout: 124
```

After:

```
EXIT:0
[0.8660] hello-js -- [JavaScript] hello.js:1-9 export statement summarizeDogfoodFinding
[0.5216] package-json -- [JSON] package.json:1-1 module
```

## Tests

```
bun test test/query-cache-knobs-hash.test.ts --timeout 120000
```

9 passing.
