### PR TITLE
refactor: read embedding model from config and save to table

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,5 +1,5 @@
 import type { BrainEngine } from '../core/engine.ts';
-import { embedBatch } from '../core/embedding.ts';
+import { embedBatch, getEmbeddingModelName } from '../core/embedding.ts';
 import type { ChunkInput } from '../core/types.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
 import { createProgress, type ProgressReporter } from '../core/progress.ts';
@@ -215,6 +215,7 @@ async function embedPage(
     chunk_text: c.chunk_text,
     chunk_source: c.chunk_source,
     embedding: embeddingMap.get(c.chunk_index),
+    model: getEmbeddingModelName(),
     token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
   }));
 

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -8,7 +8,7 @@ import { chunkText } from './chunkers/recursive.ts';
 import { chunkCodeText, chunkCodeTextFull, detectCodeLanguage, CHUNKER_VERSION } from './chunkers/code.ts';
 import { findChunkForOffset } from './chunkers/edge-extractor.ts';
 import { extractCodeRefs, imageOfCandidates } from './link-extraction.ts';
-import { embedBatch, embedMultimodal } from './embedding.ts';
+import { embedBatch, embedMultimodal, getEmbeddingModelName } from './embedding.ts';
 import { slugifyPath, slugifyCodePath, isCodeFilePath } from './sync.ts';
 import type { ChunkInput, PageInput, PageType } from './types.ts';
 import { computeEffectiveDate } from './effective-date.ts';
@@ -290,6 +290,7 @@ export async function importFromContent(
     const embeddings = await embedBatch(chunks.map(c => c.chunk_text));
     for (let i = 0; i < chunks.length; i++) {
       chunks[i].embedding = embeddings[i];
+      chunks[i].model = getEmbeddingModelName();
       chunks[i].token_count = Math.ceil(chunks[i].chunk_text.length / 4);
     }
   }
@@ -606,6 +607,7 @@ export async function importCodeFile(
     if (matched && matched.embedding) {
       // Reuse the existing embedding verbatim. No API call, no cost.
       chunks[i]!.embedding = matched.embedding as Float32Array;
+      chunks[i]!.model = matched.model ?? undefined;
       chunks[i]!.token_count = matched.token_count ?? undefined;
     } else {
       needsEmbedIndexes.push(i);
@@ -620,6 +622,7 @@ export async function importCodeFile(
       for (let j = 0; j < needsEmbedIndexes.length; j++) {
         const i = needsEmbedIndexes[j]!;
         chunks[i]!.embedding = embeddings[j]!;
+        chunks[i]!.model = getEmbeddingModelName();
         chunks[i]!.token_count = Math.ceil(chunks[i]!.chunk_text.length / 4);
       }
     } catch (e: unknown) {


### PR DESCRIPTION
This PR get model name from config env and save to table, otherwise the model field is not same as env value.
