### PR TITLE
fix: parse skill frontmatter with CRLF newlines

### DIFF
--- a/src/core/check-resolvable.ts
+++ b/src/core/check-resolvable.ts
@@ -163,7 +163,8 @@ export function parseResolverEntries(resolverContent: string): ResolverEntry[] {
 
 /** Simple YAML frontmatter parser — extracts triggers array if present. */
 function extractTriggers(skillContent: string): string[] {
-  const fmMatch = skillContent.match(/^---\n([\s\S]*?)\n---/);
+  const normalized = skillContent.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n');
+  const fmMatch = normalized.match(/^---\n([\s\S]*?)\n---/);
   if (!fmMatch) return [];
   const fm = fmMatch[1];
   const triggersMatch = fm.match(/^triggers:\s*\n((?:\s+-\s+.+\n?)*)/m);

--- a/test/check-resolvable.test.ts
+++ b/test/check-resolvable.test.ts
@@ -196,6 +196,19 @@ describe("DRY detection — checkResolvable", () => {
   let dir: string;
   afterEachCleanup(() => dir && rmSync(dir, { recursive: true, force: true }));
 
+  test("parses triggers from CRLF frontmatter on Windows checkouts", () => {
+    dir = makeSkillsFixture({ win: "# WinSkill\n" });
+    const skillPath = join(dir, "win", "SKILL.md");
+    writeFileSync(
+      skillPath,
+      "---\r\nname: win\r\ndescription: test\r\ntriggers:\r\n  - \"win\"\r\n---\r\n# WinSkill\r\n",
+    );
+
+    const report = checkResolvable(dir);
+    const gaps = report.issues.filter(i => i.type === "mece_gap");
+    expect(gaps).toHaveLength(0);
+  });
+
   test("flags inlined notability rule with no reference", () => {
     dir = makeSkillsFixture({
       bad: "# BadSkill\n\nCheck the notability gate every time.\n",


### PR DESCRIPTION
## Summary
- Normalize optional UTF-8 BOM and CRLF line endings before parsing skill YAML frontmatter in check-resolvable.
- Add a Windows checkout regression test so CRLF SKILL.md files still expose their triggers.

## Why
On Windows checkouts, SKILL.md files may use CRLF endings. The existing parser only matched LF-delimited frontmatter, so check-resolvable and doctor could report false mece_gap warnings even when triggers were present.

## Test plan
- bun test test/check-resolvable.test.ts
- bun run typecheck
- gbrain check-resolvable --json
- gbrain doctor --json