### PR TITLE
fix(gateway): use recipe default_dims for ZE zembed-1 when embedding_dimensions unset

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -289,11 +289,39 @@ export function applyOpenAICompatConfig(
   return { baseURL };
 }
 
+/**
+ * Resolve the effective embedding dimension for a given model string.
+ *
+ * Priority:
+ *   1. Explicit `embedding_dimensions` from user config — always wins.
+ *   2. `recipe.touchpoints.embedding.default_dims` for the chosen model —
+ *      catches providers like ZeroEntropy whose valid dim sets don't include
+ *      the global DEFAULT_EMBEDDING_DIMENSIONS (1536).  Without this,
+ *      `zeroentropyai:zembed-1` with no explicit `embedding_dimensions` would
+ *      silently pass 1536 to ZE's API, which rejects it with HTTP 400.
+ *   3. DEFAULT_EMBEDDING_DIMENSIONS (1536) — preserved for all other models.
+ */
+function resolveEmbeddingDimensions(
+  embeddingModel: string,
+  explicitDims: number | undefined,
+): number {
+  if (explicitDims !== undefined) return explicitDims;
+  try {
+    const { recipe } = resolveRecipe(embeddingModel);
+    const recipeDims = recipe.touchpoints.embedding?.default_dims;
+    if (recipeDims && recipeDims > 0) return recipeDims;
+  } catch {
+    // Unknown provider — fall through to global default.
+  }
+  return DEFAULT_EMBEDDING_DIMENSIONS;
+}
+
 /** Configure the gateway. Called by cli.ts#connectEngine. Clears cached models. */
 export function configureGateway(config: AIGatewayConfig): void {
+  const embeddingModel = config.embedding_model ?? DEFAULT_EMBEDDING_MODEL;
   _config = {
-    embedding_model: config.embedding_model ?? DEFAULT_EMBEDDING_MODEL,
-    embedding_dimensions: config.embedding_dimensions ?? DEFAULT_EMBEDDING_DIMENSIONS,
+    embedding_model: embeddingModel,
+    embedding_dimensions: resolveEmbeddingDimensions(embeddingModel, config.embedding_dimensions),
     embedding_multimodal_model: config.embedding_multimodal_model,
     expansion_model: config.expansion_model ?? DEFAULT_EXPANSION_MODEL,
     chat_model: config.chat_model ?? DEFAULT_CHAT_MODEL,

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -38,6 +38,28 @@ describe('gateway configuration', () => {
     expect(getEmbeddingDimensions()).toBe(1536);
     expect(getExpansionModel()).toBe('anthropic:claude-haiku-4-5-20251001');
   });
+
+  test('zeroentropyai:zembed-1 without explicit dims defaults to recipe default_dims (2560), not 1536', () => {
+    // Regression: before this fix, configuring zembed-1 without
+    // embedding_dimensions would silently pass dims=1536 to the ZE API,
+    // which rejects it with HTTP 400 (valid ZE dims: 2560/1280/640/320/160/80/40).
+    // resolveEmbeddingDimensions() now picks up recipe.touchpoints.embedding.default_dims.
+    configureGateway({
+      embedding_model: 'zeroentropyai:zembed-1',
+      env: { ZEROENTROPY_API_KEY: 'fake' },
+    });
+    expect(getEmbeddingModel()).toBe('zeroentropyai:zembed-1');
+    expect(getEmbeddingDimensions()).toBe(2560);
+  });
+
+  test('explicit embedding_dimensions always wins over recipe default_dims', () => {
+    configureGateway({
+      embedding_model: 'zeroentropyai:zembed-1',
+      embedding_dimensions: 1280,
+      env: { ZEROENTROPY_API_KEY: 'fake' },
+    });
+    expect(getEmbeddingDimensions()).toBe(1280);
+  });
 });
 
 describe('gateway.isAvailable (silent-drop regression surface)', () => {


### PR DESCRIPTION
## Problem

Configuring `embedding_model: zeroentropyai:zembed-1` without an explicit `embedding_dimensions` causes `configureGateway()` to fall back to `DEFAULT_EMBEDDING_DIMENSIONS=1536`. ZeroEntropy's API rejects 1536 with HTTP 400 — valid dims for zembed-1 are `{2560, 1280, 640, 320, 160, 80, 40}`.

The same failure mode already had a guard in `dimsProviderOptions()` (the error message there even says: "ZeroEntropy model zembed-1 configured without `embedding_dimensions` falls back to DEFAULT_EMBEDDING_DIMENSIONS=1536") — but the guard fires *after* the dim is already baked in by `configureGateway()`. The root fix belongs at configuration time.

## Context: why users hit this

Users migrating from OpenAI `text-embedding-3-large` to `zeroentropyai:zembed-1` follow a natural upgrade path:

1. They were running OpenAI embeddings at 1536 dims (the gbrain default)
2. zembed-1 benchmarks consistently above OpenAI large across every domain ([+17.6% avg NDCG@10](https://huggingface.co/zeroentropy/zembed-1)), at 2.6× lower cost ($0.05 vs $0.13/1M tokens)
3. They switch `embedding_model` in their gbrain config — and reasonably expect the model default to kick in automatically, just as it does when switching between OpenAI models of different default dims

The migration also requires a Supabase/Postgres schema step before re-embedding (ZE's valid dims don't include 1536):

```sql
-- 1. Drop HNSW index (can't survive ALTER COLUMN TYPE)
DROP INDEX IF EXISTS idx_chunks_embedding;

-- 2. Change column to target dim (1280 = production sweet spot per ZE docs)
ALTER TABLE content_chunks ALTER COLUMN embedding TYPE vector(1280);

-- 3. Null out stale embeddings so re-embed regenerates them
UPDATE content_chunks SET embedding = NULL, embedded_at = NULL;

-- 4. Recreate HNSW index
CREATE INDEX IF NOT EXISTS idx_chunks_embedding
  ON content_chunks USING hnsw (embedding vector_cosine_ops);

COMMIT;
```

Then update config and re-embed:

```bash
gbrain config set embedding_model zeroentropyai:zembed-1
gbrain config set embedding_dimensions 1280   # or omit — this PR makes that safe
gbrain embed --stale
```

The schema migration is documented in `docs/embedding-migrations.md`. This PR makes step 2 of the config change safe to do without the explicit `embedding_dimensions` line.

## Fix

Add `resolveEmbeddingDimensions()` in `gateway.ts` that reads `recipe.touchpoints.embedding.default_dims` before falling back to the global default.

Priority:
1. Explicit `embedding_dimensions` from user config — always wins
2. `recipe.touchpoints.embedding.default_dims` for the chosen model
3. `DEFAULT_EMBEDDING_DIMENSIONS` (1536) — preserved for all other models

The `zeroentropyai` recipe already declares `default_dims: 2560`. No recipe file changes needed. The same safety net benefits any future recipe whose valid dim set does not include 1536.

## Tests

Two new regression tests in `test/ai/gateway.test.ts`:
- `zeroentropyai:zembed-1` without explicit dims → 2560 (recipe default, not 1536)
- explicit `embedding_dimensions: 1280` → 1280 (user override still wins)

All 36 gateway tests pass.

## Impact

Zero-risk for existing brains — the fallback chain preserves `DEFAULT_EMBEDDING_DIMENSIONS=1536` for every model whose recipe either has no `default_dims` or has `default_dims=0`.