### PR TITLE
fix(gateway): constrain query expansion JSON key to "queries"

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -1624,7 +1624,7 @@ export async function expand(query: string): Promise<string[]> {
       model,
       schema: ExpansionSchema,
       prompt: [
-        'Rewrite the search query below into 3-4 different, related queries that would help find relevant documents.',
+        'Rewrite the search query below into 3-4 different, related queries that would help find relevant documents. Respond with a JSON object in exactly this shape: {"queries": ["rewrite1", "rewrite2", "rewrite3"]}. The JSON key MUST be exactly "queries" (not "rewrites" or any other variation).',
         'Return ONLY the JSON object. Do NOT include the original query in the result.',
         'Each rewrite should emphasize different aspects, synonyms, or framings.',
         '',


### PR DESCRIPTION
Closes #1156

## Problem

`gbrain query` with expansion enabled silently behaves the same as
`--no-expand` on OpenAI-compatible endpoints. No warning in stderr,
no error surface — the user sees the un-expanded result set and has
no signal that expansion failed.

## Root cause

`src/core/ai/gateway.ts` (master, file SHA `e65b0894`) defines at line 1608:

```ts
const ExpansionSchema = z.object({
  queries: z.array(z.string()).min(1).max(5),
});
```

…and the prompt at lines 1623–1633:

```ts
const result = await generateObject({
  model,
  schema: ExpansionSchema,
  prompt: [
    'Rewrite the search query below into 3-4 different, related queries that would help find relevant documents.',
    'Return ONLY the JSON object. Do NOT include the original query in the result.',
    'Each rewrite should emphasize different aspects, synonyms, or framings.',
    '',
    `Query: ${query}`,
  ].join('\n'),
});
```

The prompt repeats the word "rewrite" but never names the required JSON
key. `generateObject` tries strict modes (`response_format: json_schema`
or forced tool calling) first, but those are not universally supported
across OpenAI-compatible providers. When the call degrades to
`response_format: { type: "json_object" }`, the server only enforces
JSON validity, not the key names — so the prompt is the only signal.
The model picks the most prompt-salient noun and emits
`{"rewrites": [...]}`. Schema validation fails, and the `catch` at
lines 1645–1652 silently returns `[query]` because it only warns for
`AIConfigError`, not for schema-validation errors.

## Reproduction

Two unrelated OpenAI-compatible providers, identical failure mode:

| Endpoint | Model |
|---|---|
| `http://127.0.0.1:8888/v1` (oMLX) | `Qwen3.6-35B-A3B-6bit` |
| `https://api.deepseek.com/v1` | `deepseek-v4-flash` |

Pre-fix `curl` with the in-tree prompt and
`"response_format": {"type": "json_object"}` against both endpoints:

```json
{"rewrites": ["...", "...", "..."]}
```

End-to-end, before fix:

```
$ time gbrain query "test query"            # tokenmax / expansion enabled
$ time gbrain query "test query" --no-expand
# Latencies identical, stderr clean, no [ai.gateway] warning emitted.
```

Note on `deepseek-v4-flash` specifically: it rejects
`response_format: { type: "json_schema" }` with
`"This response_format type is unavailable now"`, and rejects
`tool_choice: required` with
`"deepseek-reasoner does not support this tool_choice"`. That forces
the AI SDK into `json_object` mode, where the prompt is the only key signal.

## Fix

One-line addition to the prompt naming the required key.

```diff
- 'Rewrite the search query below into 3-4 different, related queries that would help find relevant documents.',
+ 'Rewrite the search query below into 3-4 different, related queries that would help find relevant documents. Respond with a JSON object in exactly this shape: {"queries": ["rewrite1", "rewrite2", "rewrite3"]}. The JSON key MUST be exactly "queries" (not "rewrites" or any other variation).',
```

## Verification

**Post-fix curl, same two endpoints, `response_format: json_object`:**

```json
{"queries": ["...", "...", "..."]}
```

Key name is `queries` on both providers. `ExpansionSchema.parse(...)` passes.

**End-to-end timing** (Apple Silicon, oMLX serving Qwen3.6-35B-A3B-6bit
on loopback):

| Mode | `real` |
|---|---|
| `gbrain query` (expansion enabled) | 0.406 s |
| `gbrain query --no-expand` | 0.249 s |
| Δ | **+157 ms** |

The +157 ms is the expansion inference on the local model. Pre-fix this
delta was ~0 because the call short-circuited through the silent catch.
The delta confirms expansion now executes end-to-end.

I did not run the repo test suite locally because the package's
`postinstall` hook would invoke `gbrain apply-migrations` against my
live brain database. The change is a one-line string-literal edit not
covered by any existing snapshot or regression test, so CI on this PR
is the appropriate gate.

## Scope

Strictly the prompt constraint. The silent-catch behavior at lines
1645–1652 (which only warns for `AIConfigError`, swallowing
schema-validation errors) is the reason this bug went undiagnosed for
so long and may warrant a separate look, but it is out of scope for
this PR.

## Adjacent context

PR #1135 (open) — *Allow explicit `expansion_model` to fall back to
chat-capable providers* — touches the same expansion code path. The two
changes are independent (different layers: capability gate vs. prompt),
but together they widen who can successfully use expansion on
OpenAI-compatible providers.

---

Investigation assisted by Claude (Anthropic) and Hermes.
