### PR TITLE
feat(sync): opt-in --respect-gitignore for the full-import walker (#1073)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1549,6 +1549,7 @@ CODE INDEXING (v0.19.0 / v0.20.0 Cathedral II)
   reconcile-links [--dry-run]        Batch-recompute doc↔impl edges (v0.20.0)
   reindex-code [--source id] [--yes] Explicit code-page reindex (v0.20.0)
   sync --strategy code               Sync code files into the brain
+  sync --respect-gitignore           Prune git-ignored paths from the walker (#1073, opt-in)
 
 JOBS (Minions)
   jobs submit <name> [--params JSON]  Submit background job [--follow] [--dry-run]

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -44,11 +44,14 @@ export interface RunImportResult {
 export async function runImport(
   engine: BrainEngine,
   args: string[],
-  opts: { commit?: string; strategy?: SyncStrategy; sourceId?: string } = {},
+  opts: { commit?: string; strategy?: SyncStrategy; sourceId?: string; respectGitignore?: boolean } = {},
 ): Promise<RunImportResult> {
   const noEmbed = args.includes('--no-embed');
   const fresh = args.includes('--fresh');
   const jsonOutput = args.includes('--json');
+  // #1073: opt-in. Honored either programmatically (opts.respectGitignore,
+  // threaded from `gbrain sync`) or directly on the `gbrain import` CLI.
+  const respectGitignore = opts.respectGitignore === true || args.includes('--respect-gitignore');
   // v0.30.x follow-up to PR #707: programmatic sourceId support so internal
   // callers (performFullSync, future Step 6 paths) can route to a named
   // source. The CLI `gbrain import` deliberately has no --source flag per
@@ -73,7 +76,7 @@ export async function runImport(
   const dirArg = args.find((a, i) => !a.startsWith('--') && !flagValues.has(i));
 
   if (!dirArg) {
-    console.error('Usage: gbrain import <dir> [--no-embed] [--workers N] [--fresh] [--json]');
+    console.error('Usage: gbrain import <dir> [--no-embed] [--workers N] [--fresh] [--json] [--respect-gitignore]');
     process.exit(1);
   }
   const dir: string = dirArg;  // narrowed; survives closure capture
@@ -85,7 +88,7 @@ export async function runImport(
   const strategy: SyncStrategy = opts.strategy ?? 'markdown';
   const _walkT0 = Date.now();
   console.error(`[gbrain phase] import.collect_files start dir=${dir} strategy=${strategy}`);
-  const allFiles = collectSyncableFiles(dir, { strategy });
+  const allFiles = collectSyncableFiles(dir, { strategy, respectGitignore });
   console.error(
     `[gbrain phase] import.collect_files done ${Date.now() - _walkT0}ms files=${allFiles.length}`,
   );
@@ -358,6 +361,16 @@ function resolveMaxWalkDepth(): number {
 
 interface CollectOpts {
   strategy?: SyncStrategy;
+  /**
+   * Opt-in (#1073): when true and the walk root is inside a git work tree,
+   * only files git would track or that are untracked-but-not-ignored are
+   * admitted — i.e. anything matched by `.gitignore` / `.git/info/exclude`
+   * / global excludes is pruned. Default `false` preserves legacy behavior
+   * (gitignored content stays indexable; required by dotfile/secret brains
+   * that deliberately keep notes out of git but want them brain-searchable).
+   * No effect for non-git roots (falls back to the legacy walker).
+   */
+  respectGitignore?: boolean;
 }
 
 /**
@@ -387,6 +400,39 @@ function isCollectibleForWalker(
 }
 
 /**
+ * #1073: build the set of absolute paths git would ignore at `root`.
+ *
+ * `git ls-files -o -i --exclude-standard --directory` lists untracked files
+ * matched by `.gitignore` / `.git/info/exclude` / global excludes, and (via
+ * `--directory`) collapses a fully-ignored directory to a single entry. We
+ * key on those entries so the walker can prune at *descent* time — avoiding
+ * the IO of recursing into a gitignored `dist/` / `out/` / `coverage/` tree
+ * that may hold tens of thousands of files (the stall #1073 reports), not
+ * just filter them out at emit time.
+ *
+ * Returns an empty set (→ legacy behavior) when `root` is not inside a git
+ * work tree or git is unavailable. Membership is exact-path; both the
+ * collapsed directory entry and any explicitly-listed ignored file match.
+ */
+function gitIgnoredAbsPaths(root: string): Set<string> {
+  try {
+    const out = execFileSync(
+      'git',
+      ['-C', root, 'ls-files', '-o', '-i', '--exclude-standard', '--directory'],
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    const set = new Set<string>();
+    for (const line of out.split('\n')) {
+      const trimmed = line.trim().replace(/\/+$/, '');
+      if (trimmed) set.add(join(root, trimmed));
+    }
+    return set;
+  } catch {
+    return new Set<string>();
+  }
+}
+
+/**
  * v0.31.2 (codex C4 + C5 + C8): unified walker with five hardenings:
  *
  * 1. `lstatSync` + explicit `isSymbolicLink()` skip — never follow symlinks.
@@ -402,12 +448,19 @@ function isCollectibleForWalker(
  * 5. `.sort()` output — `runImport`'s checkpoint-resume at line 68–74 is
  *    index-based against a sorted list. Unstable order skips the wrong
  *    files on resume.
+ *
+ * #1073: when `opts.respectGitignore` is set, paths git ignores at `dir`
+ * are pruned (default off — preserves legacy behavior for dotfile/secret
+ * brains that deliberately keep content out of git but want it indexed).
  */
 export function collectSyncableFiles(dir: string, opts: CollectOpts = {}): string[] {
   const strategy: SyncStrategy = opts.strategy ?? 'markdown';
   const multimodalOn = process.env.GBRAIN_EMBEDDING_MULTIMODAL === 'true';
   const maxDepth = resolveMaxWalkDepth();
   const visitedInodes = new Map<string, true>();
+  const ignoredAbsPaths = opts.respectGitignore === true
+    ? gitIgnoredAbsPaths(dir)
+    : new Set<string>();
   const files: string[] = [];
 
   function walk(d: string, depth: number): void {
@@ -429,6 +482,9 @@ export function collectSyncableFiles(dir: string, opts: CollectOpts = {}): strin
       if (entry === 'node_modules' || entry === 'ops') continue;
 
       const full = join(d, entry);
+      // #1073 (opt-in): prune git-ignored entries before lstat/recurse.
+      // Empty set when respectGitignore is off → zero overhead, legacy path.
+      if (ignoredAbsPaths.has(full)) continue;
       let stat;
       try {
         stat = lstatSync(full);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -57,7 +57,10 @@ export interface SyncResult {
  * intentional: a lower estimate that undersells the real bill would be
  * worse than one that oversells.
  */
-function estimateSyncAllCost(sources: Array<{ local_path: string | null; config: Record<string, unknown> }>): {
+function estimateSyncAllCost(
+  sources: Array<{ local_path: string | null; config: Record<string, unknown> }>,
+  respectGitignore = false,
+): {
   totalTokens: number;
   totalFiles: number;
   activeSources: number;
@@ -81,7 +84,7 @@ function estimateSyncAllCost(sources: Array<{ local_path: string | null; config:
       // walkSyncableFiles used statSync (followed symlinks). New walker
       // uses lstat + inode-cycle + max-depth so the preview matches
       // what the real sync will actually walk.
-      const files = collectSyncableFiles(src.local_path, { strategy: cfg.strategy ?? 'markdown' });
+      const files = collectSyncableFiles(src.local_path, { strategy: cfg.strategy ?? 'markdown', respectGitignore });
       for (const fullPath of files) {
         try {
           const stat = statSync(fullPath);
@@ -161,6 +164,12 @@ export interface SyncOpts {
    * v0.22.13 (PR #490 CODEX-2). Not part of the public CLI surface.
    */
   skipLock?: boolean;
+  /**
+   * #1073 (opt-in): prune files git ignores at the source root from the
+   * full-import walker. Default off. CLI `--respect-gitignore` or config
+   * `sync.respect_gitignore: true`; the flag wins when both are present.
+   */
+  respectGitignore?: boolean;
 }
 
 /**
@@ -1014,7 +1023,7 @@ async function performFullSync(
   // code --dry-run` always reported zero files even when ~1500 code
   // files were waiting.
   if (opts.dryRun) {
-    const allFiles = collectSyncableFiles(repoPath, { strategy: opts.strategy ?? 'markdown' });
+    const allFiles = collectSyncableFiles(repoPath, { strategy: opts.strategy ?? 'markdown', respectGitignore: opts.respectGitignore });
     console.log(
       `Full-sync dry run (strategy=${opts.strategy ?? 'markdown'}): ` +
       `${allFiles.length} file(s) would be imported ` +
@@ -1056,6 +1065,7 @@ async function performFullSync(
     commit: headCommit,
     strategy: opts.strategy,
     sourceId: opts.sourceId,
+    respectGitignore: opts.respectGitignore,
   });
   console.error(
     `[gbrain phase] sync.fullsync.import done ${Date.now() - _fullImportT0}ms ` +
@@ -1159,6 +1169,15 @@ export async function runSync(engine: BrainEngine, args: string[]) {
     process.exit(1);
   }
 
+  // #1073: opt-in gitignore-aware full-import walker. Precedence:
+  // explicit --no-respect-gitignore (off) > --respect-gitignore (on) >
+  // `sync.respect_gitignore` config. Default off preserves legacy behavior.
+  const respectGitignore = args.includes('--no-respect-gitignore')
+    ? false
+    : args.includes('--respect-gitignore')
+      ? true
+      : (await engine.getConfig('sync.respect_gitignore')) === 'true';
+
   // --skip-failed: acknowledge pre-existing unacked failures BEFORE the sync
   // runs, not only ones the current run produces. Without this, the common
   // recovery flow — fix the YAML, re-run sync, then run --skip-failed to
@@ -1215,7 +1234,7 @@ export async function runSync(engine: BrainEngine, args: string[]) {
     // Skipped entirely when --no-embed is set (user already opted out of
     // the cost and will run `embed --stale` later).
     if (!noEmbed) {
-      const preview = estimateSyncAllCost(sources);
+      const preview = estimateSyncAllCost(sources, respectGitignore);
       const costUsd = estimateEmbeddingCostUsd(preview.totalTokens);
       const previewMsg =
         `sync --all preview: ${preview.totalFiles} files across ${preview.activeSources} source(s), ` +
@@ -1267,6 +1286,7 @@ export async function runSync(engine: BrainEngine, args: string[]) {
         sourceId: src.id,
         strategy: cfg.strategy,
         concurrency,
+        respectGitignore,
       };
       try {
         const result = await performSync(engine, repoOpts);
@@ -1285,7 +1305,7 @@ export async function runSync(engine: BrainEngine, args: string[]) {
     return;
   }
 
-  const opts: SyncOpts = { repoPath, dryRun, full, noPull, noEmbed, skipFailed, retryFailed, sourceId, strategy: strategyArg, concurrency };
+  const opts: SyncOpts = { repoPath, dryRun, full, noPull, noEmbed, skipFailed, retryFailed, sourceId, strategy: strategyArg, concurrency, respectGitignore };
 
   // Bug 9 — --retry-failed: before running normal sync, clear acknowledgment
   // flags so the sync picks them up as fresh work. The actual re-attempt

--- a/test/import-walker.test.ts
+++ b/test/import-walker.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, writeFileSync, symlinkSync, rmSync, mkdtempSync } from 'fs';
+import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { collectMarkdownFiles } from '../src/commands/import.ts';
+import { collectMarkdownFiles, collectSyncableFiles } from '../src/commands/import.ts';
 
 // These tests exercise the filesystem walker that feeds `gbrain import`.
 // They target L002 (report/findings.md): a malicious symlink inside a shared
@@ -85,5 +86,68 @@ describe('collectMarkdownFiles — symlink containment', () => {
     const files = collectMarkdownFiles(root);
     expect(files).toContain(join(root, 'legit.md'));
     expect(files).not.toContain(join(root, 'dangling.md'));
+  });
+});
+
+// #1073: opt-in gitignore-aware walker. Default off must preserve legacy
+// behavior (gitignored content stays indexable — required by dotfile/secret
+// brains); opt-in must prune anything git ignores at the root.
+describe('collectSyncableFiles — respectGitignore (#1073)', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'gbrain-gitignore-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function gitInit(dir: string): void {
+    const env = { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' };
+    execFileSync('git', ['-C', dir, 'init', '-q'], { stdio: 'ignore', env });
+  }
+
+  test('default (off) still admits gitignored build output', () => {
+    gitInit(root);
+    writeFileSync(join(root, '.gitignore'), 'dist/\n');
+    mkdirSync(join(root, 'src'));
+    writeFileSync(join(root, 'src', 'app.ts'), 'export const a = 1;\n');
+    mkdirSync(join(root, 'dist'));
+    writeFileSync(join(root, 'dist', 'bundle.js'), 'var x=1;\n');
+
+    const files = collectSyncableFiles(root, { strategy: 'code' });
+    expect(files).toContain(join(root, 'src', 'app.ts'));
+    // Legacy behavior preserved: gitignored file is NOT pruned when off.
+    expect(files).toContain(join(root, 'dist', 'bundle.js'));
+  });
+
+  test('opt-in prunes gitignored paths but keeps tracked source', () => {
+    gitInit(root);
+    writeFileSync(join(root, '.gitignore'), 'dist/\ncoverage/\n');
+    mkdirSync(join(root, 'src'));
+    writeFileSync(join(root, 'src', 'app.ts'), 'export const a = 1;\n');
+    mkdirSync(join(root, 'dist'));
+    writeFileSync(join(root, 'dist', 'bundle.js'), 'var x=1;\n');
+    mkdirSync(join(root, 'coverage'));
+    writeFileSync(join(root, 'coverage', 'lcov.info'), 'TN:\n');
+
+    const files = collectSyncableFiles(root, { strategy: 'code', respectGitignore: true });
+    expect(files).toContain(join(root, 'src', 'app.ts'));
+    expect(files).not.toContain(join(root, 'dist', 'bundle.js'));
+    expect(files).not.toContain(join(root, 'coverage', 'lcov.info'));
+  });
+
+  test('opt-in on a non-git directory falls back gracefully (no prune, no throw)', () => {
+    // No git init — gitIgnoredAbsPaths returns an empty set, walker behaves
+    // as legacy. Must not crash and must still collect code files.
+    mkdirSync(join(root, 'src'));
+    writeFileSync(join(root, 'src', 'app.ts'), 'export const a = 1;\n');
+    mkdirSync(join(root, 'dist'));
+    writeFileSync(join(root, 'dist', 'bundle.js'), 'var x=1;\n');
+
+    const files = collectSyncableFiles(root, { strategy: 'code', respectGitignore: true });
+    expect(files).toContain(join(root, 'src', 'app.ts'));
+    expect(files).toContain(join(root, 'dist', 'bundle.js'));
   });
 });


### PR DESCRIPTION
Closes #1073.

## Problem

`collectSyncableFiles` (`src/commands/import.ts`) only skips dot-dirs / `node_modules` / `ops`. The full / first / `--full` import therefore walks gitignored build output (`dist/`, `out/`, `coverage/`, `__pycache__/`, …) and admits every file in there as "code" — `CODE_EXTENSIONS` covers `.json` / `.yaml` / `.toml` / `.html` / `.css`. On repos with large gitignored trees this bloats the DB, raises embedding cost, pollutes `code-def` / semantic search with stale fixtures/bundles, and can wedge the chunker on a pathological file (e.g. a single-line giant JSON). This is the stall reported in #1073. The incremental sync path is already git-based (`git ls-files --exclude-standard`, `sync.ts`) and excludes these — only the full-import walker diverges.

## Change (opt-in, default off)

- `collectSyncableFiles` gains `respectGitignore` in `CollectOpts`. When set **and** the root is a git work tree, `git ls-files -o -i --exclude-standard --directory` builds the ignored set; entries are pruned at **descent** time so a fully-ignored directory is never recursed into — addressing the walk-stall, not just emit-time filtering. Non-git root / git unavailable → empty set → **zero overhead, exact legacy behavior**.
- **Default OFF.** Preserves behavior for dotfile/secret brains that deliberately keep content out of git but want it brain-searchable (the explicit "why not just default-on" case in #1073).
- Surface area:
  - `gbrain sync --respect-gitignore` (and `--no-respect-gitignore` to override an enabled config)
  - `sync.respect_gitignore` config knob (CLI flag wins)
  - `gbrain import --respect-gitignore`
  - threaded into the `sync --all` cost preview so the estimate matches what will actually be walked
  - documented in `gbrain --help`

## Mechanism note

#1073 suggested `git ls-files --cached --others --exclude-standard` (an allowlist gated at emit time). I used the **ignored set with `--directory`** instead so whole gitignored trees are pruned *before* recursing — the issue's core pain is the walker stalling on tens of thousands of files, which directory-level pruning avoids and emit-time allowlisting does not. All existing walker hardenings (symlink/inode-cycle/max-depth) are untouched. Happy to switch to the allowlist shape if you'd rather.

## Tests

`test/import-walker.test.ts`:
- default (off) still admits gitignored `dist/bundle.js` — legacy behavior preserved
- opt-in prunes `dist/` + `coverage/` while keeping `src/app.ts`
- opt-in on a non-git dir falls back gracefully (no prune, no throw)

`bun run typecheck` clean; `bun test test/import-walker.test.ts` → 7 pass / 0 fail.

## Follow-ups (intentionally out of scope)

`--ignore-from FILE` and `.gbrainignore` / `sync.exclude` (#449) — this PR lands the easy win for repos that already express the intent in `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)