### PR TITLE
fix source routing for import and search

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ SEARCH
   gbrain query <question>              Hybrid search (vector + keyword + RRF)
 
 IMPORT
-  gbrain import <dir> [--no-embed] [--workers N]
+  gbrain import <dir> [--source <id>] [--no-embed] [--workers N]
                                         Import markdown (idempotent)
   gbrain sync [--repo <path>] [--workers N]
                                         Git-to-brain incremental sync

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2859,7 +2859,7 @@ SEARCH
   gbrain query <question>              Hybrid search (vector + keyword + RRF)
 
 IMPORT
-  gbrain import <dir> [--no-embed] [--workers N]
+  gbrain import <dir> [--source <id>] [--no-embed] [--workers N]
                                         Import markdown (idempotent)
   gbrain sync [--repo <path>] [--workers N]
                                         Git-to-brain incremental sync

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1477,7 +1477,8 @@ SEARCH
   ask <question> [--no-expand]       Alias for query
 
 IMPORT/EXPORT
-  import <dir> [--no-embed]          Import markdown directory
+  import <dir> [--source <id>] [--no-embed]
+                                      Import markdown directory
   sync [--repo <path>] [flags]       Git-to-brain incremental sync
   sync --watch [--interval N]        Continuous sync (loops until stopped)
   sync --install-cron                Install persistent sync daemon

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -5,6 +5,7 @@ import { cpus, totalmem } from 'os';
 import type { BrainEngine } from '../core/engine.ts';
 import { importFile, importImageFile, isImageFilePath } from '../core/import-file.ts';
 import { loadConfig, gbrainPath } from '../core/config.ts';
+import { resolveSourceId } from '../core/source-resolver.ts';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
 import {
@@ -49,11 +50,17 @@ export async function runImport(
   const noEmbed = args.includes('--no-embed');
   const fresh = args.includes('--fresh');
   const jsonOutput = args.includes('--json');
-  // v0.30.x follow-up to PR #707: programmatic sourceId support so internal
-  // callers (performFullSync, future Step 6 paths) can route to a named
-  // source. The CLI `gbrain import` deliberately has no --source flag per
-  // PR #707's design intent — only programmatic callers thread sourceId.
-  const sourceId = opts.sourceId;
+  // Source routing for trusted local CLI callers. Programmatic callers may
+  // pass opts.sourceId directly; otherwise resolve the documented CLI chain:
+  // --source, GBRAIN_SOURCE, .gbrain-source, registered local_path prefix,
+  // brain-level sources.default, then literal default.
+  const sourceIdx = args.indexOf('--source');
+  const explicitSource = sourceIdx !== -1 ? args[sourceIdx + 1] : null;
+  if (sourceIdx !== -1 && (!explicitSource || explicitSource.startsWith('--'))) {
+    console.error('Usage: gbrain import <dir> [--source <id>] [--no-embed] [--workers N] [--fresh] [--json]');
+    process.exit(1);
+  }
+  const sourceId = opts.sourceId ?? await resolveSourceId(engine, explicitSource, process.cwd());
   const workersIdx = args.indexOf('--workers');
   const workersArg = workersIdx !== -1 ? args[workersIdx + 1] : null;
   // v0.22.13 (PR #490 Q2): shared parseWorkers helper rejects bad input
@@ -70,10 +77,11 @@ export async function runImport(
   // Find dir: first non-flag arg that isn't a value for --workers
   const flagValues = new Set<number>();
   if (workersIdx !== -1) flagValues.add(workersIdx + 1);
+  if (sourceIdx !== -1) flagValues.add(sourceIdx + 1);
   const dirArg = args.find((a, i) => !a.startsWith('--') && !flagValues.has(i));
 
   if (!dirArg) {
-    console.error('Usage: gbrain import <dir> [--no-embed] [--workers N] [--fresh] [--json]');
+    console.error('Usage: gbrain import <dir> [--source <id>] [--no-embed] [--workers N] [--fresh] [--json]');
     process.exit(1);
   }
   const dir: string = dirArg;  // narrowed; survives closure capture

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1039,6 +1039,7 @@ const search: Operation = {
     query: { type: 'string', required: true },
     limit: { type: 'number', description: 'Max results (default 20)' },
     offset: { type: 'number', description: 'Skip first N results (for pagination)' },
+    source: { type: 'string', description: 'Restrict keyword search to one source id; use __all__ for all sources' },
   },
   handler: async (ctx, p) => {
     const startedAt = Date.now();
@@ -1046,10 +1047,12 @@ const search: Operation = {
     // v0.34.1 (#861 — P0 leak seal): thread caller's source scope into
     // searchKeyword. Pre-fix this op silently returned cross-source hits
     // for any auth'd OAuth client.
+    const explicitSource = typeof p.source === 'string' ? p.source : undefined;
+    const scope = sourceScopeOpts(ctx);
     const raw = await ctx.engine.searchKeyword(queryText, {
       limit: (p.limit as number) || 20,
       offset: (p.offset as number) || 0,
-      ...sourceScopeOpts(ctx),
+      ...(scope.sourceIds ? scope : explicitSource ? { sourceId: explicitSource } : scope),
     });
     const results = dedupResults(raw);
     const latency_ms = Date.now() - startedAt;

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -943,7 +943,7 @@ export class PGLiteEngine implements BrainEngine {
     if (opts?.sourceIds && opts.sourceIds.length > 0) {
       params.push(opts.sourceIds);
       extraFilter += ` AND p.source_id = ANY($${params.length}::text[])`;
-    } else if (opts?.sourceId) {
+    } else if (opts?.sourceId && opts.sourceId !== '__all__') {
       params.push(opts.sourceId);
       extraFilter += ` AND p.source_id = $${params.length}`;
     }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1003,7 +1003,7 @@ export class PostgresEngine implements BrainEngine {
     if (opts?.sourceIds && opts.sourceIds.length > 0) {
       params.push(opts.sourceIds);
       sourceClause = `AND p.source_id = ANY($${params.length}::text[])`;
-    } else if (opts?.sourceId) {
+    } else if (opts?.sourceId && opts.sourceId !== '__all__') {
       params.push(opts.sourceId);
       sourceClause = `AND p.source_id = $${params.length}`;
     }
@@ -1037,6 +1037,7 @@ export class PostgresEngine implements BrainEngine {
           ${detailLow ? `AND cc.chunk_source = 'compiled_truth'` : ''}
           ${languageClause}
           ${symbolKindClause}
+          ${sourceClause}
           ${afterDateClause}
           ${beforeDateClause}
           ${sourceClause}

--- a/test/source-id-tx-regression.test.ts
+++ b/test/source-id-tx-regression.test.ts
@@ -169,6 +169,40 @@ describe('Per-page tx methods source-qualify their bare-slug subqueries', () => 
   });
 });
 
+describe('searchKeyword honors opts.sourceId', () => {
+  test('source filter excludes same-token pages from other sources', async () => {
+    const token = 'uniquesourcefiltertoken';
+    await engine.putPage('topics/source-search-default', {
+      type: 'concept',
+      title: 'Default search source',
+      compiled_truth: `${token} default-only`,
+    }, { sourceId: 'default' });
+    await engine.upsertChunks('topics/source-search-default', [
+      { chunk_index: 0, chunk_text: `${token} default-only`, chunk_source: 'compiled_truth' },
+    ], { sourceId: 'default' });
+
+    await engine.putPage('topics/source-search-testsrc', {
+      type: 'concept',
+      title: 'Testsrc search source',
+      compiled_truth: `${token} testsrc-only`,
+    }, { sourceId: 'testsrc' });
+    await engine.upsertChunks('topics/source-search-testsrc', [
+      { chunk_index: 0, chunk_text: `${token} testsrc-only`, chunk_source: 'compiled_truth' },
+    ], { sourceId: 'testsrc' });
+
+    const defaultResults = await engine.searchKeyword(token, { sourceId: 'default', limit: 10 });
+    expect(defaultResults.map(r => r.source_id)).toEqual(['default']);
+    expect(defaultResults.map(r => r.slug)).toEqual(['topics/source-search-default']);
+
+    const testsrcResults = await engine.searchKeyword(token, { sourceId: 'testsrc', limit: 10 });
+    expect(testsrcResults.map(r => r.source_id)).toEqual(['testsrc']);
+    expect(testsrcResults.map(r => r.slug)).toEqual(['topics/source-search-testsrc']);
+
+    const allResults = await engine.searchKeyword(token, { sourceId: '__all__', limit: 10 });
+    expect(allResults.map(r => r.source_id).sort()).toEqual(['default', 'testsrc']);
+  });
+});
+
 describe('addLink rewrites the cross-product into a source-qualified JOIN', () => {
   const FROM_SLUG = 'topics/regression-link-from';
   const TO_SLUG = 'topics/regression-link-to';


### PR DESCRIPTION
## Summary

Fixes two source-routing bugs:

- `gbrain import --source <id>` now routes imported pages/chunks to the requested source using the existing `resolveSourceId` chain.
- `gbrain search --source <id>` now applies a source filter in both PGLite and Postgres keyword search paths.

Also:

- Preserves programmatic `opts.sourceId` compatibility.
- Guards missing `--source` values.
- Updates CLI/docs help text.
- Adds regression coverage for source-filtered keyword search.

Fixes #1167.

## Test Plan

Local focused verification:

```text
./bin/bun run typecheck
PATH="$PWD/bin:$PATH" ./bin/bun test test/source-id-tx-regression.test.ts test/build-llms.test.ts
# 27 pass / 0 fail
PATH="$PWD/bin:$PATH" ./bin/bun run build
```

Manual end-to-end smoke:

- isolated temp `GBRAIN_HOME`
- create sources `alpha`, `beta`
- import vault A with `--source alpha`
- import vault B with `--source beta`
- verify `search --source alpha` only returns alpha
- verify `search --source beta` only returns beta
- verify `search --source default` does not return imported alpha/beta hits
- verify missing `--source` value fails loudly

Real acceptance verification against local HermesClaude vault:

```text
default               federated          0 pages
hermes-local-wiki     isolated           0 pages
hermesclaude-main     federated        567 pages
hermesintake          isolated           0 pages
openclaw-wiki         isolated           0 pages
```

Search query `HermesClaude`:

- `--source hermesclaude-main`: returns hits
- `--source hermesintake`: No results
- `--source openclaw-wiki`: No results
- `--source default`: No results
- `--source __all__`: returns hits
