### PR TITLE
feat: --lock-duration and --low-pri-rate-cap flags on gbrain jobs work

### DIFF
--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -136,6 +136,7 @@ USAGE
   gbrain jobs smoke
   gbrain jobs work [--queue Q] [--concurrency N] [--max-rss MB]
                    [--health-interval MS] [--lock-duration MS]
+                   [--low-pri-rate-cap N]
   gbrain jobs supervisor [start] [--detach] [--json]
                          [--concurrency N] [--queue Q] [--pid-file PATH]
                          [--max-crashes N] [--health-interval N]
@@ -742,12 +743,33 @@ HANDLER TYPES (built in)
         lockDuration = parsed;
       }
 
+      // --low-pri-rate-cap: rolling-hour cap on starts of jobs with priority >= 0.
+      // Default unset (no cap). When > 0, the claim SQL gates low-priority jobs
+      // so they collectively never exceed N starts per hour, leaving headroom
+      // for `priority < 0` jobs (which are exempt and always claimable). This
+      // implements a "background tier shares leftover budget" policy against
+      // external rate limits — e.g. the Anthropic Max 5-hour message window
+      // (~900 msg/5h on the alt account). Setting this to 90 caps low-pri at
+      // 50% of that ceiling, preserving the remaining 50% for interactive
+      // / `priority < 0` work even when a background backlog is draining.
+      const lowPriRateCapRaw = parseFlag(args, '--low-pri-rate-cap');
+      let lowPriRateCap: number | undefined;
+      if (lowPriRateCapRaw !== undefined) {
+        const parsed = parseInt(lowPriRateCapRaw, 10);
+        if (!Number.isFinite(parsed) || parsed < 0) {
+          console.error(`Error: --low-pri-rate-cap must be a non-negative integer (jobs/hour), got "${lowPriRateCapRaw}"`);
+          process.exit(1);
+        }
+        lowPriRateCap = parsed;
+      }
+
       try { await queue.ensureSchema(); }
       catch (e) { console.error(e instanceof Error ? e.message : String(e)); process.exit(1); }
 
       const worker = new MinionWorker(engine, {
         queue: queueName, concurrency, maxRssMb, healthCheckInterval,
         ...(lockDuration !== undefined ? { lockDuration } : {}),
+        ...(lowPriRateCap !== undefined ? { lowPriRateCap } : {}),
       });
       await registerBuiltinHandlers(worker, engine);
 
@@ -778,7 +800,10 @@ HANDLER TYPES (built in)
       const lockNote = lockDuration !== undefined
         ? `, lock-duration: ${Math.round(lockDuration / 1000)}s`
         : '';
-      console.log(`Minion worker started (queue: ${queueName}, concurrency: ${concurrency}${watchdogNote}${healthNote}${lockNote})`);
+      const rateCapNote = lowPriRateCap !== undefined && lowPriRateCap > 0
+        ? `, low-pri-rate-cap: ${lowPriRateCap}/hr (priority >= 0)`
+        : '';
+      console.log(`Minion worker started (queue: ${queueName}, concurrency: ${concurrency}${watchdogNote}${healthNote}${lockNote}${rateCapNote})`);
       console.log(`Registered handlers: ${worker.registeredNames.join(', ')}`);
       try {
         await worker.start();

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -135,7 +135,7 @@ USAGE
   gbrain jobs stats
   gbrain jobs smoke
   gbrain jobs work [--queue Q] [--concurrency N] [--max-rss MB]
-                   [--health-interval MS]
+                   [--health-interval MS] [--lock-duration MS]
   gbrain jobs supervisor [start] [--detach] [--json]
                          [--concurrency N] [--queue Q] [--pid-file PATH]
                          [--max-crashes N] [--health-interval N]
@@ -713,11 +713,41 @@ HANDLER TYPES (built in)
         healthCheckInterval = parsed;
       }
 
+      // --lock-duration: row-lock TTL in ms. Default: 30_000 (30s). The worker
+      // renews the lock every lockDuration/2 to keep long-running jobs alive,
+      // but this value is also a multiplier in the wall-clock dead-letter
+      // threshold (see handleWallClockTimeouts in queue.ts):
+      //   default cap = lockDuration * 2 * max_stalled
+      // For jobs without an explicit `timeout_ms`, the cap at defaults
+      // (30s × 2 × 3) is 180s — too tight for vision-heavy `claude --print`
+      // collectors that can legitimately run 5-10 minutes. Bumping
+      // --lock-duration 90000 raises the cap to 9 min and the resulting
+      // wall-clock to 27 min, with no impact on lock-renewal correctness.
+      // Validated identically to --health-interval.
+      const lockDurationRaw = parseFlag(args, '--lock-duration');
+      let lockDuration: number | undefined;
+      if (lockDurationRaw !== undefined) {
+        const parsed = parseInt(lockDurationRaw, 10);
+        if (!Number.isFinite(parsed) || parsed < 1) {
+          console.error(`Error: --lock-duration must be a positive integer (ms), got "${lockDurationRaw}"`);
+          process.exit(1);
+        }
+        if (parsed < 1000) {
+          console.error(
+            `Error: --lock-duration ${parsed} is suspiciously low (likely a unit-confusion typo). ` +
+            `The flag takes milliseconds; for a 90-second lock pass 90000.`,
+          );
+          process.exit(1);
+        }
+        lockDuration = parsed;
+      }
+
       try { await queue.ensureSchema(); }
       catch (e) { console.error(e instanceof Error ? e.message : String(e)); process.exit(1); }
 
       const worker = new MinionWorker(engine, {
         queue: queueName, concurrency, maxRssMb, healthCheckInterval,
+        ...(lockDuration !== undefined ? { lockDuration } : {}),
       });
       await registerBuiltinHandlers(worker, engine);
 
@@ -745,7 +775,10 @@ HANDLER TYPES (built in)
       const healthNote = !isSupervisedChild && healthCheckInterval > 0
         ? `, health-check: ${Math.round(healthCheckInterval / 1000)}s`
         : '';
-      console.log(`Minion worker started (queue: ${queueName}, concurrency: ${concurrency}${watchdogNote}${healthNote})`);
+      const lockNote = lockDuration !== undefined
+        ? `, lock-duration: ${Math.round(lockDuration / 1000)}s`
+        : '';
+      console.log(`Minion worker started (queue: ${queueName}, concurrency: ${concurrency}${watchdogNote}${healthNote}${lockNote})`);
       console.log(`Registered handlers: ${worker.registeredNames.join(', ')}`);
       try {
         await worker.start();

--- a/src/core/minions/queue.ts
+++ b/src/core/minions/queue.ts
@@ -538,12 +538,35 @@ export class MinionQueue {
    *
    * Sets timeout_at = now() + timeout_ms when the job has a per-job deadline,
    * so handleTimeouts() can dead-letter expired jobs without rereading timeout_ms.
+   *
+   * `lowPriRateCap` (optional): if set, jobs with `priority >= 0` are only
+   * claimable when fewer than `lowPriRateCap` such jobs have started in the
+   * last rolling hour. Jobs with `priority < 0` always claim regardless of
+   * this cap — they're considered "interactive/important" and reserve their
+   * own headroom against external rate limits (e.g. Anthropic 5h window).
+   * When unset, no rate limit is applied (preserves prior behavior).
+   *
+   * The cap check runs in the same statement as the UPDATE via a CTE, so
+   * there's no TOCTOU between counting and claiming.
    */
-  async claim(lockToken: string, lockDurationMs: number, queue: string, registeredNames: string[]): Promise<MinionJob | null> {
+  async claim(
+    lockToken: string,
+    lockDurationMs: number,
+    queue: string,
+    registeredNames: string[],
+    lowPriRateCap?: number,
+  ): Promise<MinionJob | null> {
     if (registeredNames.length === 0) return null;
 
     const rows = await this.engine.executeRaw<Record<string, unknown>>(
-      `UPDATE minion_jobs SET
+      `WITH low_pri_starts AS (
+         SELECT COUNT(*)::int AS cnt
+         FROM minion_jobs
+         WHERE started_at IS NOT NULL
+           AND started_at > now() - INTERVAL '1 hour'
+           AND priority >= 0
+       )
+       UPDATE minion_jobs SET
         status = 'active',
         lock_token = $1,
         lock_until = now() + ($2::double precision * interval '1 millisecond'),
@@ -556,12 +579,17 @@ export class MinionQueue {
        WHERE id = (
          SELECT id FROM minion_jobs
          WHERE queue = $3 AND status = 'waiting' AND name = ANY($4)
+           AND (
+             priority < 0
+             OR $5::int IS NULL
+             OR (SELECT cnt FROM low_pri_starts) < $5::int
+           )
          ORDER BY priority ASC, created_at ASC
          FOR UPDATE SKIP LOCKED
          LIMIT 1
        )
        RETURNING *`,
-      [lockToken, lockDurationMs, queue, registeredNames]
+      [lockToken, lockDurationMs, queue, registeredNames, lowPriRateCap ?? null]
     );
     return rows.length > 0 ? rowToMinionJob(rows[0]) : null;
   }

--- a/src/core/minions/types.ts
+++ b/src/core/minions/types.ts
@@ -189,6 +189,14 @@ export interface MinionWorkerOpts {
    *  hung probe would wedge the recursive setTimeout chain forever and
    *  silently disable the health monitor. Default: 10000 (10 seconds). */
   dbProbeTimeoutMs?: number;
+  /** Rolling-hour rate cap for low-priority jobs (priority >= 0). When > 0,
+   *  the claim query gates `priority >= 0` jobs to at most N starts per
+   *  rolling hour, computed across the whole `minion_jobs` table (all queues).
+   *  Jobs with `priority < 0` are exempt and always claimable. 0 or unset =
+   *  no rate limit (default behavior — matches the maxRssMb convention).
+   *  Pairs with the convention that negative priority means "interactive /
+   *  reserve budget" and positive means "background / share remaining headroom." */
+  lowPriRateCap?: number;
 }
 
 // --- Job Context (passed to handlers) ---

--- a/src/core/minions/worker.ts
+++ b/src/core/minions/worker.ts
@@ -163,6 +163,7 @@ export class MinionWorker extends EventEmitter {
       stallExitAfterMs: opts?.stallExitAfterMs ?? 10 * 60_000,
       dbFailExitAfter: opts?.dbFailExitAfter ?? 3,
       dbProbeTimeoutMs: opts?.dbProbeTimeoutMs ?? 10_000,
+      lowPriRateCap: opts?.lowPriRateCap ?? 0,
     };
     // Stall thresholds contract: exit MUST be strictly greater than warn.
     // If exit <= warn, the warn-then-exit semantics break: a single tick at
@@ -442,6 +443,7 @@ export class MinionWorker extends EventEmitter {
             this.opts.lockDuration,
             this.opts.queue,
             this.registeredNames,
+            this.opts.lowPriRateCap > 0 ? this.opts.lowPriRateCap : undefined,
           );
 
           if (job) {

--- a/test/minions.test.ts
+++ b/test/minions.test.ts
@@ -570,6 +570,48 @@ describe('MinionQueue: Claim Mechanics', () => {
     expect(third!.name).toBe('low'); // priority 10
   });
 
+  test('lowPriRateCap gates priority >= 0 jobs while exempting priority < 0', async () => {
+    // 3 low-pri (priority 5) and 2 high-pri (priority -5) jobs queued
+    await queue.add('low-a', {}, { priority: 5 });
+    await queue.add('low-b', {}, { priority: 5 });
+    await queue.add('low-c', {}, { priority: 5 });
+    await queue.add('high-a', {}, { priority: -5 });
+    await queue.add('high-b', {}, { priority: -5 });
+
+    // With cap of 2 and no starts yet, first low-pri claim succeeds (0 < 2).
+    // After it claims, started_at is set so the next low-pri claim sees count=1.
+    // After the second, count=2, the cap, so the third low-pri claim must yield
+    // the next negative-priority job instead.
+    const names = ['low-a', 'low-b', 'low-c', 'high-a', 'high-b'];
+    const c1 = await queue.claim('t1', 30000, 'default', names, 2);
+    const c2 = await queue.claim('t2', 30000, 'default', names, 2);
+    const c3 = await queue.claim('t3', 30000, 'default', names, 2);
+    const c4 = await queue.claim('t4', 30000, 'default', names, 2);
+    const c5 = await queue.claim('t5', 30000, 'default', names, 2);
+
+    // Highest priority (lowest number) jumps to the front, then low-pri until
+    // cap hits, then the remaining high-pri, then nothing claimable.
+    expect(c1!.name).toBe('high-a'); // priority -5 — exempt
+    expect(c2!.name).toBe('high-b'); // priority -5 — exempt
+    expect(c3!.name).toBe('low-a');  // low-pri start #1 (cnt 0 < 2)
+    expect(c4!.name).toBe('low-b');  // low-pri start #2 (cnt 1 < 2)
+    expect(c5).toBeNull();           // cnt 2 = cap, low-c blocked; no exempt left
+  });
+
+  test('lowPriRateCap unset = no rate limit (backward compat)', async () => {
+    await queue.add('low-a', {}, { priority: 5 });
+    await queue.add('low-b', {}, { priority: 5 });
+    await queue.add('low-c', {}, { priority: 5 });
+
+    const c1 = await queue.claim('t1', 30000, 'default', ['low-a', 'low-b', 'low-c']);
+    const c2 = await queue.claim('t2', 30000, 'default', ['low-a', 'low-b', 'low-c']);
+    const c3 = await queue.claim('t3', 30000, 'default', ['low-a', 'low-b', 'low-c']);
+
+    expect(c1).not.toBeNull();
+    expect(c2).not.toBeNull();
+    expect(c3).not.toBeNull();
+  });
+
   test('claim only claims registered names', async () => {
     await queue.add('sync', {});
     await queue.add('embed', {});


### PR DESCRIPTION
Closes #1014.

Adds two CLI flags to `gbrain jobs work` for tuning the wall-clock dead-letter behavior and low-priority pacing.

## `--lock-duration MS`

Exposes the row-lock TTL as a CLI flag (was hardcoded `30_000` in `worker.ts`). The wall-clock dead-letter cap is computed as `lockDuration * 2 * max_stalled`, so at defaults the cap is `30s × 2 × 3 = 180s` — too tight for vision-heavy `claude --print` collectors that legitimately run 5–10 minutes.

Bumping `--lock-duration 90000` raises the cap to 9 min and the wall-clock to 27 min for jobs without an explicit `timeout_ms`. No impact on lock-renewal correctness (worker still renews every `lockDuration / 2`).

Validation mirrors `--health-interval`: rejects NaN, non-positive, and sub-1000ms values (with a unit-confusion error message).

## `--low-pri-rate-cap N`

Rolling-hour cap on starts of jobs with `priority >= 0`. Default unset (no cap). When set, the claim SQL gates low-priority jobs so they collectively never exceed N starts per hour, leaving headroom for `priority < 0` jobs (always claimable, exempt from the cap).

Use case: shared external rate limit where background work shouldn't starve interactive paths. We hit this against the Anthropic Max 5-hour message window (~900 msg/5h on the alt account). Setting `--low-pri-rate-cap 90` caps background at ~50% of that ceiling.

## Compatibility

Both flags are additive and default-unset. `gbrain jobs work` with no new flags behaves exactly as before. No schema changes.

Worker banner now reports both values when set:

```
Minion worker started (queue: default, concurrency: 3, watchdog: 2048MB,
  health-check: 60s, lock-duration: 90s, low-pri-rate-cap: 90/hr (priority >= 0))
```

Validated end-to-end on a Supabase-backed brain (v0.35.8.0) running alongside ~13 launchd-managed wrappers that submit jobs.