### PR TITLE
fix(embed): per-batch token cap for OpenAI + opt-in for LiteLLM

### DIFF
--- a/docs/integrations/embedding-providers.md
+++ b/docs/integrations/embedding-providers.md
@@ -102,6 +102,8 @@ Run [LiteLLM](https://docs.litellm.ai/docs/proxy/quick_start) in front of any pr
 
 This is the catch-all for "my provider isn't in the list above." Set up LiteLLM, then `gbrain init --embedding-model litellm:<your-model-id> --embedding-dimensions <N>`.
 
+**Large-page handling.** LiteLLM ships without a static batch cap because the proxy can front any backend, and the per-request token limit depends on which backend is wired up. For brains that index large files (vendored Unicode tables, generated code, etc.), pin the downstream backend's cap via `LITELLM_MAX_BATCH_TOKENS=<N>` so gbrain pre-splits each embed batch under that ceiling. Typical values: `300000` when LiteLLM fronts OpenAI, `120000` when fronting Voyage. Without this env var the recipe stays uncapped (current default behavior).
+
 ## Choosing dimensions
 
 Three numbers matter:

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -31,6 +31,7 @@ import { z } from 'zod';
 
 import type {
   AIGatewayConfig,
+  EmbeddingTouchpoint,
   MultimodalInput,
   Recipe,
   TouchpointKind,
@@ -412,13 +413,12 @@ function warnRecipesMissingBatchTokens(): void {
   for (const recipe of listRecipes()) {
     const embedding = recipe.touchpoints?.embedding;
     if (!embedding || embedding.max_batch_tokens !== undefined) continue;
-    // OpenAI is the canonical "no cap declared, fast path is intentional"
-    // recipe; suppress the warning for it. Every other recipe missing the
-    // field is suspicious.
-    if (recipe.id === 'openai') continue;
     // v0.32 (#779): explicit opt-out for dynamic-cap recipes (Ollama,
     // LiteLLM proxy, llama-server) — they ship without a static cap because
     // the cap depends on a user-launched server. Warning is noise for them.
+    // (OpenAI used to be suppressed by id here as the "intentional no-cap
+    // fast path"; #1080 closed that gap by declaring max_batch_tokens, so
+    // OpenAI now exits at the earlier line above.)
     if (embedding.no_batch_cap === true) continue;
     if (_warnedRecipes.has(recipe.id)) continue;
     _warnedRecipes.add(recipe.id);
@@ -966,13 +966,15 @@ const MIN_SUB_BATCH = 1;
  *   ├─ resolve recipe + model
  *   ├─ truncate each text to MAX_CHARS (8000)
  *   ├─ read recipe.touchpoints.embedding.{max_batch_tokens, chars_per_token, safety_factor}
+ *   ├─ resolveMaxBatchTokens(recipe, embedding, env) — recipe field, plus
+ *   │     env override for the litellm proxy recipe (LITELLM_MAX_BATCH_TOKENS)
  *   │
- *   ├─ if max_batch_tokens declared (Voyage path):
+ *   ├─ if effective max_batch_tokens > 0 (Voyage / OpenAI / Azure / capped litellm):
  *   │     budget = max_batch_tokens × shrinkState[recipe].factor (default = recipe.safety_factor)
  *   │     splitByTokenBudget(texts, budget, recipe.chars_per_token)
  *   │     for each sub-batch: embedSubBatch(...)
  *   │
- *   └─ else (OpenAI fast path):
+ *   └─ else (uncapped litellm / Ollama / llama-server):
  *         embedSubBatch(texts, ...) once  // no pre-split, no token-limit safety net
  *
  * embedSubBatch(texts, ...)
@@ -1046,11 +1048,13 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
   const expected = cfg.embedding_dimensions ?? DEFAULT_EMBEDDING_DIMENSIONS;
 
   const embedding = recipe.touchpoints?.embedding;
-  const maxBatchTokens = embedding?.max_batch_tokens;
+  const maxBatchTokens = resolveMaxBatchTokens(recipe, embedding, cfg.env);
   const charsPerToken = embedding?.chars_per_token ?? DEFAULT_CHARS_PER_TOKEN;
 
-  // Pre-split is gated on max_batch_tokens. Recipes without it (e.g. OpenAI)
-  // ride the fast path: one embedMany call, no recursion safety net.
+  // Pre-split is gated on max_batch_tokens. Recipes without it ride the fast
+  // path: one embedMany call, no recursion safety net. After #1080, OpenAI
+  // and Azure declare caps; litellm picks up an optional env-driven cap when
+  // users know their proxy's downstream backend.
   const batches = maxBatchTokens
     ? splitByTokenBudget(truncated, Math.floor(maxBatchTokens * effectiveSafetyFactor(recipe)), charsPerToken)
     : [truncated];
@@ -1115,6 +1119,36 @@ export function isTokenLimitError(err: unknown): boolean {
     /batch.*too.*many.*tokens/i.test(msg) ||
     /token.*limit.*exceeded/i.test(msg)
   );
+}
+
+/**
+ * Resolve the effective batch-token cap for a recipe, consulting env-driven
+ * overrides where applicable.
+ *
+ * The `litellm` recipe declares `no_batch_cap: true` because the proxy can
+ * front any provider — we can't know the downstream cap statically. But in
+ * practice users do know (their proxy fronts OpenAI, Bedrock, etc.), and
+ * without a cap a single oversize page is rejected wholesale by the
+ * downstream API. `LITELLM_MAX_BATCH_TOKENS` lets the user pin a cap that
+ * matches their backend. Closes #1080 for litellm-fronted deployments.
+ *
+ * For other recipes, this is a passthrough of the declared cap.
+ *
+ * @internal exported for tests; not part of the public gateway API.
+ */
+export function resolveMaxBatchTokens(
+  recipe: Recipe,
+  embedding: EmbeddingTouchpoint | undefined,
+  env: Record<string, string | undefined>,
+): number | undefined {
+  if (recipe.id === 'litellm') {
+    const raw = env.LITELLM_MAX_BATCH_TOKENS;
+    if (raw !== undefined && raw !== '') {
+      const parsed = Number(raw);
+      if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
+    }
+  }
+  return embedding?.max_batch_tokens;
 }
 
 /**

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -1117,7 +1117,14 @@ export function isTokenLimitError(err: unknown): boolean {
   return (
     /max.*allowed.*tokens.*batch/i.test(msg) ||
     /batch.*too.*many.*tokens/i.test(msg) ||
-    /token.*limit.*exceeded/i.test(msg)
+    /token.*limit.*exceeded/i.test(msg) ||
+    // OpenAI/Azure/litellm-proxied-OpenAI report oversize embed requests as
+    // `Invalid 'input': maximum request size is N tokens per request.`
+    // Real-world hit: vendored chip-register .h files at >300K tokens
+    // (verified against in-cluster litellm proxy). Recursive halving in
+    // embedSubBatch needs to recognize this so the page isn't dropped.
+    /maximum request size.*tokens/i.test(msg) ||
+    /max.*request size.*tokens/i.test(msg)
   );
 }
 

--- a/src/core/ai/recipes/litellm-proxy.ts
+++ b/src/core/ai/recipes/litellm-proxy.ts
@@ -16,7 +16,7 @@ export const litellmProxy: Recipe = {
   base_url_default: 'http://localhost:4000', // LiteLLM default
   auth_env: {
     required: [], // LITELLM_API_KEY is optional (users may run proxy unauthenticated locally)
-    optional: ['LITELLM_BASE_URL', 'LITELLM_API_KEY'],
+    optional: ['LITELLM_BASE_URL', 'LITELLM_API_KEY', 'LITELLM_MAX_BATCH_TOKENS'],
     setup_url: 'https://docs.litellm.ai/docs/proxy/quick_start',
   },
   touchpoints: {
@@ -29,6 +29,13 @@ export const litellmProxy: Recipe = {
       price_last_verified: '2026-04-20',
       // LiteLLM's batch capacity is determined by the backend it proxies;
       // no static cap to declare here. v0.32 (#779).
+      //
+      // Operators who know their downstream (e.g. proxy fronts OpenAI) can
+      // opt into pre-split + recursive-halving by setting
+      // `LITELLM_MAX_BATCH_TOKENS=<N>` in the environment. The gateway reads
+      // it in `resolveMaxBatchTokens` and treats it as the effective
+      // `max_batch_tokens` for this recipe. Closes #1080 for litellm-fronted
+      // deployments. Without the env var, behavior is unchanged.
       no_batch_cap: true,
       // v0.34.1 (#875): LiteLLM can forward to multimodal providers (OpenAI,
       // Gemini, Voyage etc.). embedMultimodal routes openai-compatible
@@ -41,5 +48,5 @@ export const litellmProxy: Recipe = {
       supports_multimodal: true,
     },
   },
-  setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL + pass --embedding-model litellm:<model> and --embedding-dimensions <N>.',
+  setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL + pass --embedding-model litellm:<model> and --embedding-dimensions <N>. Optional: set LITELLM_MAX_BATCH_TOKENS=<N> to pre-split embed batches at your downstream backend\'s cap (e.g. 300000 for an OpenAI-proxying setup).',
 };

--- a/src/core/ai/recipes/openai.ts
+++ b/src/core/ai/recipes/openai.ts
@@ -17,6 +17,14 @@ export const openai: Recipe = {
       dims_options: [256, 512, 768, 1024, 1536, 3072],
       cost_per_1m_tokens_usd: 0.13,
       price_last_verified: '2026-04-20',
+      // OpenAI's documented per-request embedding token cap is 300K. Without
+      // a declared batch cap, a single page whose chunks sum past 300K
+      // tokens (e.g. vendored Unicode tables, large generated code) is
+      // rejected by the API and the whole page is dropped from indexing.
+      // Closes #1080: gateway-level pre-split is the safety net. The shrink-
+      // on-miss fallback in embedSubBatch handles tokenizer-density variance.
+      max_batch_tokens: 300_000,
+      chars_per_token: 4, // tiktoken English avg
     },
     expansion: {
       models: ['gpt-5.2', 'gpt-4o-mini'],

--- a/test/ai/adaptive-embed-batch.test.ts
+++ b/test/ai/adaptive-embed-batch.test.ts
@@ -230,13 +230,13 @@ describe('embed() recursion via stubbed transport', () => {
   });
 });
 
-// --------- 5. OpenAI fast path (D3) ---------
+// --------- 5. OpenAI batch-cap pre-split (closes #1080) ---------
 
-describe('embed() OpenAI fast path (no max_batch_tokens)', () => {
+describe('embed() OpenAI pre-split at declared max_batch_tokens (closes #1080)', () => {
   beforeEach(() => resetGateway());
   afterEach(() => __setEmbedTransportForTests(null));
 
-  test('recipe without max_batch_tokens calls transport exactly once with no partition', async () => {
+  test('small batch under the cap calls transport exactly once', async () => {
     configureOpenAI();
 
     const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 1536));
@@ -251,7 +251,42 @@ describe('embed() OpenAI fast path (no max_batch_tokens)', () => {
     expect(result).toHaveLength(100);
   });
 
-  test('OpenAI fast path is unaffected by Voyage shrink state', async () => {
+  test('batch exceeding 300K-token cap is pre-split before transport is called', async () => {
+    configureOpenAI();
+
+    const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 1536));
+    __setEmbedTransportForTests(stub as any);
+
+    // OpenAI declares max_batch_tokens=300_000, chars_per_token=4, default
+    // safety_factor=0.8. Budget = 240K tokens per sub-batch. The gateway
+    // truncates each input to MAX_CHARS=8000 chars = 2000 tokens, so 150
+    // texts × 2000 = 300K tokens total — guaranteed >1 sub-batch.
+    const big = 'x'.repeat(8000);
+    const texts = Array.from({ length: 150 }, () => big);
+    const result = await embed(texts);
+
+    expect(stub.mock.calls.length).toBeGreaterThan(1);
+    expect(result).toHaveLength(150);
+
+    // Every sub-batch must stay under the 240K-token budget.
+    for (const [arg] of stub.mock.calls) {
+      const { values } = arg as { values: string[] };
+      const totalTokens = values.reduce(
+        (sum, t) => sum + Math.ceil(t.length / 4),
+        0,
+      );
+      expect(totalTokens).toBeLessThanOrEqual(240_000);
+    }
+
+    // Concatenated lengths must equal the input length (no dropped texts).
+    const totalReturned = stub.mock.calls.reduce(
+      (sum, [arg]) => sum + (arg as { values: string[] }).values.length,
+      0,
+    );
+    expect(totalReturned).toBe(150);
+  });
+
+  test('OpenAI is unaffected by Voyage shrink state', async () => {
     // Configure Voyage first and trigger a shrink…
     configureVoyage();
     const voyageStub = mock(async ({ values }: { values: string[] }) => {
@@ -270,6 +305,77 @@ describe('embed() OpenAI fast path (no max_batch_tokens)', () => {
     await embed(['x', 'y']);
     expect(openaiStub).toHaveBeenCalledTimes(1);
     expect(__getShrinkStateForTests('voyage')).toBeUndefined();
+  });
+});
+
+// --------- 5b. LiteLLM env-driven cap (closes #1080 for proxy users) ---------
+
+describe('embed() LiteLLM LITELLM_MAX_BATCH_TOKENS env override (closes #1080)', () => {
+  beforeEach(() => resetGateway());
+  afterEach(() => __setEmbedTransportForTests(null));
+
+  function configureLitellmWithEnv(env: Record<string, string | undefined>): void {
+    configureGateway({
+      embedding_model: 'litellm:text-embedding-3-large',
+      embedding_dimensions: 1536,
+      env: { LITELLM_BASE_URL: 'http://localhost:4000', ...env },
+    });
+  }
+
+  test('without env override, litellm preserves its no-cap fast-path behavior', async () => {
+    configureLitellmWithEnv({});
+
+    const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 1536));
+    __setEmbedTransportForTests(stub as any);
+
+    const big = 'y'.repeat(8000);
+    const texts = Array.from({ length: 30 }, () => big);
+    await embed(texts);
+
+    // 30 texts × 8000 chars = 240K chars = 60K tokens at chars_per_token=4.
+    // Without a cap there's a single transport call regardless of size.
+    expect(stub).toHaveBeenCalledTimes(1);
+  });
+
+  test('LITELLM_MAX_BATCH_TOKENS triggers pre-split at the declared cap', async () => {
+    // Set a small cap so we can force a split with a modest payload.
+    configureLitellmWithEnv({ LITELLM_MAX_BATCH_TOKENS: '40000' });
+
+    const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 1536));
+    __setEmbedTransportForTests(stub as any);
+
+    // 30 × 8000 chars at chars_per_token=4 default = 60K tokens total.
+    // Cap 40K × safety_factor 0.8 = 32K token budget per sub-batch. With
+    // each text ≈ 2000 tokens, ~16 fit per sub-batch; expect ≥2 batches.
+    const big = 'z'.repeat(8000);
+    const texts = Array.from({ length: 30 }, () => big);
+    await embed(texts);
+
+    expect(stub.mock.calls.length).toBeGreaterThan(1);
+    for (const [arg] of stub.mock.calls) {
+      const { values } = arg as { values: string[] };
+      const totalTokens = values.reduce(
+        (sum, t) => sum + Math.ceil(t.length / 4),
+        0,
+      );
+      expect(totalTokens).toBeLessThanOrEqual(32_000);
+    }
+  });
+
+  test('invalid LITELLM_MAX_BATCH_TOKENS values fall back to no-cap behavior', async () => {
+    for (const value of ['', 'not-a-number', '0', '-5']) {
+      resetGateway();
+      configureLitellmWithEnv({ LITELLM_MAX_BATCH_TOKENS: value });
+
+      const stub = mock(async ({ values }: { values: string[] }) => fakeEmbeddings(values, 1536));
+      __setEmbedTransportForTests(stub as any);
+
+      const big = 'q'.repeat(8000);
+      await embed(Array.from({ length: 30 }, () => big));
+
+      expect(stub, `value=${JSON.stringify(value)} should fall back to no-cap`).toHaveBeenCalledTimes(1);
+      __setEmbedTransportForTests(null);
+    }
   });
 });
 

--- a/test/ai/adaptive-embed-batch.test.ts
+++ b/test/ai/adaptive-embed-batch.test.ts
@@ -147,6 +147,20 @@ describe('isTokenLimitError (pure helper)', () => {
     expect(isTokenLimitError(new Error('Batch contains too many tokens'))).toBe(true);
   });
 
+  test('matches OpenAI/litellm "maximum request size" variant', () => {
+    // Real error format from in-cluster litellm proxy fronting OpenAI; this
+    // is the failure mode that prompted #1080. The wrapper text
+    // ("litellm.BadRequestError: OpenAIException - Error code: 400 - ...")
+    // surrounds the JSON body which contains the matched phrase.
+    const litellmError = new Error(
+      "litellm.BadRequestError: OpenAIException - Error code: 400 - {'error': {'message': \"Invalid 'input': maximum request size is 300000 tokens per request.\"}}",
+    );
+    expect(isTokenLimitError(litellmError)).toBe(true);
+
+    // The shorter native-OpenAI form.
+    expect(isTokenLimitError(new Error('maximum request size is 300000 tokens per request'))).toBe(true);
+  });
+
   test('does not match unrelated errors', () => {
     expect(isTokenLimitError(new Error('Connection refused'))).toBe(false);
     expect(isTokenLimitError(new Error('Invalid API key'))).toBe(false);


### PR DESCRIPTION
Closes #1080. The gateway pre-split was gated on a recipe declaring `max_batch_tokens`. OpenAI was the documented "fast path" with no cap, so a single page whose chunks sum past OpenAI's 300K-tokens-per-request limit was rejected wholesale and dropped from indexing (we hit this on vendored Unicode tables in code-strategy syncs).

Three changes:

1. `recipes/openai.ts`: declare `max_batch_tokens: 300_000`, `chars_per_token: 4`. With the default `safety_factor: 0.8` this gives a 240K-token sub-batch budget, well under OpenAI's documented per-request ceiling. The existing shrink-on-miss recursive halving handles tokenizer-density variance.

2. `gateway.ts`: new `resolveMaxBatchTokens(recipe, embedding, env)` helper. For the `litellm` recipe (which can't ship a static cap — the proxy fronts arbitrary backends), users who know their backend can pin `LITELLM_MAX_BATCH_TOKENS=<N>` to opt into pre-split. Other recipes pass through their declared cap unchanged.

3. Dead warning-suppression branch cleanup: with OpenAI now declaring `max_batch_tokens`, the `id === 'openai'` special-case in `warnRecipesMissingBatchTokens()` is dead code. Removed + updated the surrounding comment.

Tests: updated "OpenAI fast path (D3)" → "OpenAI pre-split at declared max_batch_tokens" to assert the new behavior (large batches pre-split, small batches still single-call). Added a litellm env-override suite covering on/off and invalid-value fallback. 31 pass, 0 fail in the two affected files; 210 pass in test/ai/.

Docs: documented LITELLM_MAX_BATCH_TOKENS in
docs/integrations/embedding-providers.md and the litellm recipe setup_hint.