### PR TITLE
fix(doctor): run PGLite probes through active engine

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -146,6 +146,70 @@ export async function whoknowsHealthCheck(_engine: BrainEngine): Promise<Check> 
   }
 }
 
+/**
+ * Doctor check: pgvector availability.
+ *
+ * Use the active engine instead of the module-level Postgres singleton.
+ * PGLite exposes pg_extension through its engine connection, but does not
+ * connect db.ts's Postgres singleton; using db.getConnection() here turns a
+ * healthy PGLite brain into a false warning.
+ */
+export async function pgvectorCheck(engine: BrainEngine): Promise<Check> {
+  try {
+    const ext = await engine.executeRaw<{ extname: string }>(
+      `SELECT extname FROM pg_extension WHERE extname = 'vector'`,
+    );
+    if (ext.length > 0) {
+      return { name: 'pgvector', status: 'ok', message: 'Extension installed' };
+    }
+    return { name: 'pgvector', status: 'fail', message: 'Extension not found. Run: CREATE EXTENSION vector;' };
+  } catch {
+    return { name: 'pgvector', status: 'warn', message: 'Could not check pgvector extension' };
+  }
+}
+
+/**
+ * Doctor check: JSONB columns are not double-encoded as strings.
+ *
+ * This check is valid on both Postgres and PGLite. Route through
+ * engine.executeRaw() so embedded PGLite brains are checked through their
+ * actual connection instead of the unrelated Postgres singleton.
+ */
+export async function jsonbIntegrityCheck(
+  engine: BrainEngine,
+  progress?: Pick<ProgressReporter, 'heartbeat'>,
+): Promise<Check> {
+  try {
+    const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
+      { table: 'pages',         col: 'frontmatter',    expected: 'object' },
+      { table: 'raw_data',      col: 'data',           expected: 'object' },
+      { table: 'ingest_log',    col: 'pages_updated',  expected: 'array'  },
+      { table: 'files',         col: 'metadata',       expected: 'object' },
+      { table: 'page_versions', col: 'frontmatter',    expected: 'object' },
+    ];
+    let totalBad = 0;
+    const breakdown: string[] = [];
+    for (const { table, col } of targets) {
+      progress?.heartbeat(`jsonb_integrity.${table}.${col}`);
+      const rows = await engine.executeRaw<{ n: number }>(
+        `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
+      );
+      const n = Number(rows[0]?.n ?? 0);
+      if (n > 0) { totalBad += n; breakdown.push(`${table}.${col}=${n}`); }
+    }
+    if (totalBad === 0) {
+      return { name: 'jsonb_integrity', status: 'ok', message: 'All JSONB columns store objects/arrays' };
+    }
+    return {
+      name: 'jsonb_integrity',
+      status: 'warn',
+      message: `${totalBad} row(s) double-encoded (${breakdown.join(', ')}). Fix: gbrain repair-jsonb`,
+    };
+  } catch {
+    return { name: 'jsonb_integrity', status: 'warn', message: 'Could not check JSONB integrity' };
+  }
+}
+
 export async function takesWeightGridCheck(engine: BrainEngine): Promise<Check> {
   try {
     const rows = await engine.executeRaw<{ off_grid: string | number; total: string | number }>(
@@ -1314,17 +1378,7 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
 
   // 4. pgvector extension
   progress.heartbeat('pgvector');
-  try {
-    const sql = db.getConnection();
-    const ext = await sql`SELECT extname FROM pg_extension WHERE extname = 'vector'`;
-    if (ext.length > 0) {
-      checks.push({ name: 'pgvector', status: 'ok', message: 'Extension installed' });
-    } else {
-      checks.push({ name: 'pgvector', status: 'fail', message: 'Extension not found. Run: CREATE EXTENSION vector;' });
-    }
-  } catch {
-    checks.push({ name: 'pgvector', status: 'warn', message: 'Could not check pgvector extension' });
-  }
+  checks.push(await pgvectorCheck(engine));
 
   // 4b. PgBouncer / prepared-statement compatibility.
   // URL-only inspection — no DB roundtrip — so this is cheap and works
@@ -1772,37 +1826,7 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
   // surface matches `repair-jsonb` (the previous 4-target scan missed a
   // repair target, per #254/Codex review).
   progress.heartbeat('jsonb_integrity');
-  try {
-    const sql = db.getConnection();
-    const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
-      { table: 'pages',         col: 'frontmatter',    expected: 'object' },
-      { table: 'raw_data',      col: 'data',           expected: 'object' },
-      { table: 'ingest_log',    col: 'pages_updated',  expected: 'array'  },
-      { table: 'files',         col: 'metadata',       expected: 'object' },
-      { table: 'page_versions', col: 'frontmatter',    expected: 'object' },
-    ];
-    let totalBad = 0;
-    const breakdown: string[] = [];
-    for (const { table, col } of targets) {
-      progress.heartbeat(`jsonb_integrity.${table}.${col}`);
-      const rows = await sql.unsafe(
-        `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
-      );
-      const n = Number((rows as any)[0]?.n ?? 0);
-      if (n > 0) { totalBad += n; breakdown.push(`${table}.${col}=${n}`); }
-    }
-    if (totalBad === 0) {
-      checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'All JSONB columns store objects/arrays' });
-    } else {
-      checks.push({
-        name: 'jsonb_integrity',
-        status: 'warn',
-        message: `${totalBad} row(s) double-encoded (${breakdown.join(', ')}). Fix: gbrain repair-jsonb`,
-      });
-    }
-  } catch {
-    checks.push({ name: 'jsonb_integrity', status: 'warn', message: 'Could not check JSONB integrity' });
-  }
+  checks.push(await jsonbIntegrityCheck(engine, progress));
 
   // 10b. Takes weight grid integrity (v0.32 — EXP-2).
   //

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -101,6 +101,25 @@ describe('doctor command', () => {
     expect(source).toMatch(/table:\s*'files'.*col:\s*'metadata'/);
   });
 
+  test('pgvector and jsonb_integrity checks use the active PGLite engine', async () => {
+    const { PGLiteEngine } = await import('../src/core/pglite-engine.ts');
+    const { pgvectorCheck, jsonbIntegrityCheck } = await import('../src/commands/doctor.ts');
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+    try {
+      const pgvector = await pgvectorCheck(engine);
+      expect(pgvector.name).toBe('pgvector');
+      expect(pgvector.status).toBe('ok');
+
+      const jsonb = await jsonbIntegrityCheck(engine);
+      expect(jsonb.name).toBe('jsonb_integrity');
+      expect(jsonb.status).toBe('ok');
+    } finally {
+      await engine.disconnect();
+    }
+  });
+
   // v0.31.2 — facts_extraction_health check added in PR1 commit 12.
   // Reads ingest_log rows with source_type='facts:absorb' (written by
   // writeFactsAbsorbLog from src/core/facts/absorb-log.ts), groups by


### PR DESCRIPTION
## Summary

Fix two false-positive `gbrain doctor` warnings for PGLite-backed brains:

- route the `pgvector` probe through the active `BrainEngine`
- route the `jsonb_integrity` probe through the active `BrainEngine`
- add focused PGLite regression coverage for both checks

## Root Cause

The doctor had two remaining direct calls to the module-level Postgres singleton:

- `db.getConnection()` for `pg_extension`
- `db.getConnection().unsafe(...)` for JSONB integrity scanning

That works for Postgres-backed brains, but PGLite uses `PGLiteEngine` and does not initialize the Postgres singleton. The result was a false warning on healthy embedded brains:

```text
[WARN] pgvector: Could not check pgvector extension
[WARN] jsonb_integrity: Could not check JSONB integrity
```

The underlying PGLite engine can answer both SQL probes correctly; the doctor was just bypassing it.

## Real Behavior Proof

- **Behavior addressed:** embedded PGLite brains no longer warn on `pgvector` and `jsonb_integrity` solely because no external Postgres singleton is connected.
- **Real environment tested:** local GBrain checkout with an embedded PGLite engine, plus a PGLite-backed brain used for doctor smoke verification.
- **Exact commands run after this patch:**

```bash
bun test test/doctor.test.ts
bun run typecheck
bash scripts/check-no-legacy-getconnection.sh
bun run check:jsonb
gbrain doctor
```

- **Evidence after fix:**

```text
(pass) doctor command > pgvector and jsonb_integrity checks use the active PGLite engine
49 pass
0 fail

[OK] pgvector: Extension installed
[OK] jsonb_integrity: All JSONB columns store objects/arrays
```

- **Observed result after fix:** the two PGLite-specific false warnings are gone. The local doctor smoke still surfaced an unrelated resolver warning from the checkout, but `pgvector` and `jsonb_integrity` both report OK.
- **What was not tested:** live Supabase/self-hosted Postgres doctor output. The SQL and status semantics are unchanged for Postgres; this PR only routes the probes through the active engine abstraction.

## Regression Test Plan

- **Coverage level that should have caught this:** focused doctor unit coverage against a real PGLite engine.
- **Target test:** `test/doctor.test.ts`
- **Scenario locked in:** `pgvectorCheck(PGLiteEngine)` and `jsonbIntegrityCheck(PGLiteEngine)` both return OK after schema initialization.
- **Why this is the smallest reliable guardrail:** the bug was not pgvector or JSONB behavior; it was the doctor using the wrong connection path.

## Verification

- `bun test test/doctor.test.ts`
- `bun run typecheck`
- `bash scripts/check-no-legacy-getconnection.sh`
- `bun run check:jsonb`

## User-visible Behavior

PGLite users should see fewer false `gbrain doctor` warnings. No CLI flags, config keys, migrations, or data-shape changes.

