### PR TITLE
feat(integrations/doctor): surface dead-jobs from minions queue

### DIFF
--- a/src/commands/integrations.ts
+++ b/src/commands/integrations.ts
@@ -695,6 +695,20 @@ async function cmdDoctor(args: string[]): Promise<void> {
     }
   }
 
+  // Cross-cutting check: dead jobs in the minions queue. Shell jobs submitted
+  // by collectors (signal-detect, email-collector, art-signals, etc.) die
+  // silently from the per-integration perspective \u2014 the collector's drain
+  // sees the submit succeed and stays green, while the worker job dies on
+  // the queue side. Without this check, an entire collector pipeline can
+  // be broken for days before anyone notices. Empirically validated 2026-05-18
+  // when 3,561 email-collector batches died with "empty result from codex"
+  // and no surface flagged it.
+  //
+  // Implementation deliberately shells out to `gbrain jobs list` to preserve
+  // this file's "no DB connection" design \u2014 see file-level comment.
+  const deadJobsCheck = checkDeadJobs();
+  if (deadJobsCheck) results.push(deadJobsCheck);
+
   if (jsonMode) {
     const fails = results.filter(r => r.status !== 'ok');
     console.log(JSON.stringify({
@@ -714,8 +728,66 @@ async function cmdDoctor(args: string[]): Promise<void> {
     }
   }
 
+  // Surface cross-cutting [queue] checks below per-integration sections.
+  const queueChecks = results.filter(r => r.integration === '[queue]');
+  if (queueChecks.length > 0) {
+    console.log(`  [queue]: ${queueChecks.every(c => c.status === 'ok') ? 'OK' : 'ISSUES'}`);
+    for (const c of queueChecks) {
+      const icon = c.status === 'ok' ? '  \u2713' : c.status === 'timeout' ? '  \u23F1' : '  \u2717';
+      console.log(`${icon} ${c.output}`);
+    }
+  }
+
   const totalFails = results.filter(r => r.status !== 'ok').length;
   console.log(`\n  OVERALL: ${totalFails === 0 ? 'All checks passed' : `${totalFails} issue(s) found`}`);
+}
+
+/**
+ * Count dead minion jobs and group by job name. Returns a CheckResult only
+ * if dead jobs exist (silent when healthy, per doctor's ISSUES-only model).
+ *
+ * Shell-outs to `gbrain jobs list --status dead` instead of opening a DB
+ * connection \u2014 preserves this file's standalone-CLI design.
+ */
+function checkDeadJobs(): CheckResult | null {
+  try {
+    // Limit caps memory; if a real pipeline is dying you'll see thousands.
+    // 99999 is generous and parses in well under 1s for typical sizes.
+    const out = execSync('gbrain jobs list --status dead --limit 99999', {
+      encoding: 'utf8',
+      timeout: 10_000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    // Output format: header line, separator, then rows. Each row has the
+    // shape "  <id>  <name>  <status>  <queue>  <time>  <created>".
+    // Status column is always "dead" for our filter \u2014 count lines with it.
+    const byName: Record<string, number> = {};
+    let total = 0;
+    for (const line of out.split('\n')) {
+      // Match rows: leading whitespace, integer id, name, "dead".
+      const m = line.match(/^\s+\d+\s+(\S+)\s+dead\b/);
+      if (m) {
+        byName[m[1]] = (byName[m[1]] || 0) + 1;
+        total++;
+      }
+    }
+    if (total === 0) return null;
+    // Order names by count desc for readability.
+    const breakdown = Object.entries(byName)
+      .sort((a, b) => b[1] - a[1])
+      .map(([n, c]) => `${n}:${c}`)
+      .join(', ')
+    return {
+      integration: '[queue]',
+      check: 'dead_jobs',
+      status: 'fail',
+      output: `${total} dead job(s) in minions queue (${breakdown}). Inspect: gbrain jobs list --status dead | head; details: gbrain jobs get <id>`,
+    };
+  } catch {
+    // DB unreachable / gbrain jobs unavailable \u2014 skip silently. Doctor still
+    // surfaces the per-recipe checks; this one is best-effort.
+    return null;
+  }
 }
 
 function cmdStats(args: string[]): void {


### PR DESCRIPTION
## Why

`gbrain integrations doctor` currently only runs the per-recipe `health_checks:` declared in each integration's YAML frontmatter. It has zero visibility into the minions job queue, which means any pipeline that submits shell or subagent jobs has a structural blind spot:

1. Cron fires the collector
2. Collector submits a job to the queue → submission succeeds
3. Collector's heartbeat writes `status:ok exit_code:0`
4. Worker picks up the job, runs it, dies
5. Job ends up in `dead` state
6. Nobody knows — the collector stayed green, the doctor didn't surface it

I hit this in the wild: 3,561 shell jobs from one collector had silently died over several days with `{"signal":"error","reason":"empty result from codex"}`. The collector itself was happily heartbeating green the whole time.

## What

Adds one cross-cutting check to `cmdDoctor()` in `src/commands/integrations.ts`. Shells out to `gbrain jobs list --status dead` and counts results grouped by job name. Surfaces under a new `[queue]` section alongside the per-recipe sections:

```
  x-to-brain: ISSUES
  ✗ X API: HTTP 403
  [queue]: ISSUES
  ✗ 3561 dead job(s) in minions queue (shell:3560, autopilot-cycle:1).
    Inspect: gbrain jobs list --status dead | head; details: gbrain jobs get <id>

  OVERALL: 2 issue(s) found
```

JSON mode includes the same check with `integration: "[queue]"`.

## Design notes

- **Shells out instead of opening a DB connection.** The file's top-level comment explicitly states it's a standalone CLI command with no DB connection. I preserved that by piping through the existing `gbrain jobs list` CLI rather than executing SQL directly. Slightly slower (subprocess vs query) but architecturally aligned.
- **Best-effort, silent skip on failure.** If `gbrain jobs` is unavailable (DB unreachable, etc.) the check is dropped and the per-recipe checks still run. Doctor never becomes flakier than before.
- **Global count, not per-integration.** `MinionJob` has no `integration_id` field today, so we can't attribute dead jobs to specific recipes. The name-based breakdown (`shell:N, subagent:M, autopilot-cycle:K`) gives the operator enough to find the broken pipeline. A future enhancement could add `integration_id` to the job schema for proper per-integration attribution — this PR is a stop-gap that gets most of the value at none of the schema-migration risk.
- **Output capped at `--limit 99999`.** Memory-bounded, well above realistic dead-pool sizes; parses in under 1s for typical queues.

## Test plan

- [x] Run `gbrain integrations doctor` with no dead jobs → check is silent, no `[queue]` section appears
- [x] Run with 3,561 real dead jobs → check surfaces under `[queue]: ISSUES` with the breakdown
- [x] JSON mode includes the new check with `integration: "[queue]"`
- [x] No regression to per-recipe checks (X-to-brain still flagged as before)

## Out of scope

- Per-integration job attribution (requires schema migration)
- Stalled-job detection (already covered by `queue_health` check in `doctor.ts`)
- Auto-replay or auto-cleanup of dead jobs

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>