### PR TITLE
fix: harden gbrain upgrade and repair flows

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1701,7 +1701,7 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
       checks.push({
         name: 'graph_coverage',
         status: 'warn',
-        message: `Entity link coverage ${linkPct}%, timeline ${timelinePct}% (${entityCount} entity pages). Run: gbrain extract all`,
+        message: `Entity link coverage ${linkPct}%, timeline ${timelinePct}% (${entityCount} entity pages). Run: gbrain extract all --source db`,
       });
     }
 

--- a/src/commands/frontmatter.ts
+++ b/src/commands/frontmatter.ts
@@ -15,7 +15,7 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, lstatSync, readdirSync, copyFileSync } from 'fs';
-import { join, relative, resolve } from 'path';
+import { basename, dirname, join, relative, resolve } from 'path';
 import type { BrainEngine } from '../core/engine.ts';
 import { loadConfig, toEngineConfig } from '../core/config.ts';
 import { createEngine } from '../core/engine-factory.ts';
@@ -26,6 +26,7 @@ import {
   type AuditReport,
   type AuditFix,
 } from '../core/brain-writer.ts';
+import { inferFrontmatter, serializeFrontmatter } from '../core/frontmatter-inference.ts';
 import { isSyncable, slugifyPath } from '../core/sync.ts';
 
 export async function runFrontmatter(args: string[]): Promise<void> {
@@ -166,6 +167,8 @@ async function runValidate(rest: string[]): Promise<void> {
 
   const files = collectFiles(resolved);
   const results: FileValidation[] = [];
+  const targetIsFile = lstatSync(resolved).isFile();
+  const inferenceRoot = targetIsFile ? dirname(resolved) : resolved;
 
   for (const file of files) {
     const content = readFileSync(file, 'utf8');
@@ -178,9 +181,22 @@ async function runValidate(rest: string[]): Promise<void> {
     };
 
     if (flags.fix && errs.length > 0) {
-      const { content: fixed, fixes } = autoFixFrontmatter(content, { filePath: file });
-      result.fixesApplied = fixes;
-      if (fixes.length > 0 && !flags.dryRun) {
+      let fixed = content;
+      const fixList: AuditFix[] = [];
+      const hasMissingOpen = errs.some(e => e.code === 'MISSING_OPEN');
+      if (hasMissingOpen) {
+        const relPath = relative(inferenceRoot, file) || basename(file);
+        const inferred = inferFrontmatter(relPath, fixed);
+        if (!inferred.skipped) {
+          fixed = serializeFrontmatter(inferred) + '\n' + fixed;
+          fixList.push({ code: 'MISSING_OPEN', description: 'Generated frontmatter for file with none' });
+        }
+      }
+      const auto = autoFixFrontmatter(fixed, { filePath: file });
+      fixed = auto.content;
+      fixList.push(...auto.fixes);
+      result.fixesApplied = fixList;
+      if (fixList.length > 0 && !flags.dryRun) {
         copyFileSync(file, file + '.bak');
         writeFileSync(file, fixed, 'utf8');
       }

--- a/src/commands/skillpack.ts
+++ b/src/commands/skillpack.ts
@@ -122,8 +122,8 @@ function resolveAbs(p: string): string {
   return isAbsolute(p) ? p : resolvePath(process.cwd(), p);
 }
 
-function findGbrainOrDie(): string {
-  const root = findGbrainRoot();
+function findGbrainOrDie(opts?: { allowInstallPathFallback?: boolean }): string {
+  const root = findGbrainRoot(undefined, opts);
   if (!root) {
     console.error('Error: could not find gbrain repo root.');
     process.exit(2);
@@ -152,7 +152,7 @@ async function cmdList(args: string[]): Promise<void> {
     process.exit(0);
   }
   const json = args.includes('--json');
-  const gbrainRoot = findGbrainOrDie();
+  const gbrainRoot = findGbrainOrDie({ allowInstallPathFallback: true });
   let manifest;
   try {
     manifest = loadBundleManifest(gbrainRoot);
@@ -292,7 +292,7 @@ async function cmdReference(args: string[]): Promise<void> {
     process.exit(2);
   }
 
-  const gbrainRoot = findGbrainOrDie();
+  const gbrainRoot = findGbrainOrDie({ allowInstallPathFallback: true });
   const targetWorkspace = resolveWorkspace({ workspace });
 
   try {
@@ -602,7 +602,7 @@ async function cmdDiff(args: string[]): Promise<void> {
     console.error('Error: pass a skill name.');
     process.exit(2);
   }
-  const gbrainRoot = findGbrainOrDie();
+  const gbrainRoot = findGbrainOrDie({ allowInstallPathFallback: true });
   const targetSkillsDir = skillsDir
     ? resolveAbs(skillsDir)
     : join(resolveWorkspace({ workspace }), 'skills');

--- a/src/core/brain-writer.ts
+++ b/src/core/brain-writer.ts
@@ -62,9 +62,12 @@ const SAMPLE_PER_SOURCE = 20;
  *                          the YAML zone
  *   - SLUG_MISMATCH     — remove `slug:` line (gbrain derives slug from path)
  *
- * Idempotent: running twice is a no-op on already-clean input. Any error class
- * not in the list above is left untouched (e.g. EMPTY_FRONTMATTER, YAML_PARSE,
- * MISSING_OPEN — those need human review).
+ * Idempotent: running twice is a no-op on already-clean input. This now also
+ * repairs the common YAML_PARSE patterns we actually see in the wild:
+ *   - Obsidian wikilink CSV values (`related: [[A]], [[B]]`) → YAML string arrays
+ *   - Plain scalar values containing `: ` (e.g. unquoted titles) → quoted scalars
+ *
+ * Truly ambiguous cases are still left untouched (e.g. EMPTY_FRONTMATTER).
  */
 export function autoFixFrontmatter(
   content: string,
@@ -156,7 +159,60 @@ export function autoFixFrontmatter(
     }
   }
 
-  // 4. SLUG_MISMATCH — remove `slug:` line if filePath is provided and the
+  // 4. YAML_PARSE — repair the common plain-scalar mistakes seen in curated
+  //    HQ sources: Obsidian wikilink CSVs and unquoted values containing `: `.
+  {
+    const lines = working.split('\n');
+    let firstNonEmpty = -1;
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].trim().length > 0) { firstNonEmpty = i; break; }
+    }
+    if (firstNonEmpty >= 0 && lines[firstNonEmpty].trim() === '---') {
+      let closeIdx = lines.length;
+      for (let i = firstNonEmpty + 1; i < lines.length; i++) {
+        if (lines[i].trim() === '---') { closeIdx = i; break; }
+      }
+      let fixedAny = false;
+      for (let i = firstNonEmpty + 1; i < closeIdx; i++) {
+        const m = lines[i].match(/^(\s*[A-Za-z_][\w-]*\s*:\s*)(.+?)\s*$/);
+        if (!m) continue;
+        const [, prefix, rawValue] = m;
+        const value = rawValue.trim();
+        if (!value) continue;
+
+        const wikilinks = Array.from(value.matchAll(/\[\[[^\]]+\]\]/g)).map(match => match[0]);
+        if (wikilinks.length > 0) {
+          const remainder = value.replace(/\[\[[^\]]+\]\]/g, '').replace(/[\s,]/g, '');
+          if (remainder.length === 0) {
+            if (wikilinks.length === 1 && value === wikilinks[0]) {
+              lines[i] = `${prefix}"${wikilinks[0].replace(/"/g, '\\"')}"`;
+            } else {
+              const rendered = wikilinks.map(link => `"${link.replace(/"/g, '\\"')}"`).join(', ');
+              lines[i] = `${prefix}[${rendered}]`;
+            }
+            fixedAny = true;
+            continue;
+          }
+        }
+
+        if (/^["'\[{]|^[>|]/.test(value)) continue;
+
+        if (value.includes(': ') && !value.includes('://')) {
+          lines[i] = `${prefix}"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+          fixedAny = true;
+        }
+      }
+      if (fixedAny) {
+        working = lines.join('\n');
+        fixes.push({
+          code: 'YAML_PARSE',
+          description: 'Repaired common YAML plain-scalar parse failures',
+        });
+      }
+    }
+  }
+
+  // 5. SLUG_MISMATCH — remove `slug:` line if filePath is provided and the
   //    declared slug doesn't match the path-derived one. Per PR #392 spec,
   //    gbrain derives slug from path; the field shouldn't be in frontmatter.
   if (opts?.filePath) {

--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -223,7 +223,8 @@ function collectValidationErrors(
     const line = lines[i];
     const m = line.match(/^\s*[A-Za-z_][\w-]*\s*:\s*(.*)$/);
     if (!m) continue;
-    const value = m[1];
+    const value = m[1].trim();
+    if (value.startsWith('[')) continue; // valid YAML arrays often contain many quoted items
     let count = 0;
     for (let j = 0; j < value.length; j++) {
       if (value[j] === '"' && (j === 0 || value[j - 1] !== '\\')) count++;

--- a/src/core/skillpack/bundle.ts
+++ b/src/core/skillpack/bundle.ts
@@ -9,6 +9,7 @@
 
 import { existsSync, readFileSync, statSync, readdirSync } from 'fs';
 import { join, dirname, isAbsolute, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
 import { parseMarkdown } from '../markdown.ts';
 
@@ -38,8 +39,16 @@ export class BundleError extends Error {
 /**
  * Walk up from `start` (default cwd) looking for an `openclaw.plugin.json`
  * sibling to `src/cli.ts`. That pair identifies a gbrain repo root.
+ *
+ * For read-only callers, an optional install-path fallback walks up from
+ * this module's location. That lets commands like `gbrain skillpack list`
+ * work from outside the repo checkout without letting write paths silently
+ * target the bundled source tree.
  */
-export function findGbrainRoot(start: string = process.cwd()): string | null {
+export function findGbrainRoot(
+  start: string = process.cwd(),
+  opts?: { allowInstallPathFallback?: boolean },
+): string | null {
   let dir = resolve(start);
   for (let i = 0; i < 10; i++) {
     if (
@@ -52,6 +61,22 @@ export function findGbrainRoot(start: string = process.cwd()): string | null {
     if (parent === dir) break;
     dir = parent;
   }
+
+  if (opts?.allowInstallPathFallback) {
+    let installDir = dirname(fileURLToPath(import.meta.url));
+    for (let i = 0; i < 10; i++) {
+      if (
+        existsSync(join(installDir, 'openclaw.plugin.json')) &&
+        existsSync(join(installDir, 'src', 'cli.ts'))
+      ) {
+        return installDir;
+      }
+      const parent = dirname(installDir);
+      if (parent === installDir) break;
+      installDir = parent;
+    }
+  }
+
   return null;
 }
 

--- a/src/core/skillpack/post-install-advisory.ts
+++ b/src/core/skillpack/post-install-advisory.ts
@@ -141,8 +141,8 @@ export function buildAdvisory(opts: {
     missing,
     installCommand:
       missing.length === V0_25_1_RECOMMENDED.length
-        ? 'gbrain skillpack install --all'
-        : `gbrain skillpack install ${missing.map((s) => s.slug).join(' ')}`,
+        ? 'gbrain skillpack scaffold --all'
+        : `gbrain skillpack scaffold ${missing.map((s) => s.slug).join(' ')}`,
   });
 }
 
@@ -154,7 +154,7 @@ function buildAdvisoryWithoutWorkspace(
     version,
     context,
     missing: V0_25_1_RECOMMENDED,
-    installCommand: 'gbrain skillpack install --all',
+    installCommand: 'gbrain skillpack scaffold --all',
     workspaceNotDetected: true,
   });
 }
@@ -184,7 +184,7 @@ function renderAdvisory(opts: {
   if (opts.workspaceNotDetected) {
     lines.push(
       '(NOTE: No OpenClaw workspace was detected at the default location. ' +
-        'Set $OPENCLAW_WORKSPACE or pass --skills-dir to gbrain skillpack install.)',
+        'Set $OPENCLAW_WORKSPACE or pass --workspace to gbrain skillpack scaffold.)',
     );
     lines.push('');
   }
@@ -206,8 +206,8 @@ function renderAdvisory(opts: {
   lines.push('');
   lines.push('  4. If NO, tell them they can install any time with:');
   lines.push('');
-  lines.push('         gbrain skillpack install <name>      # one skill');
-  lines.push('         gbrain skillpack install --all       # all bundled');
+  lines.push('         gbrain skillpack scaffold <name>     # one skill');
+  lines.push('         gbrain skillpack scaffold --all      # all bundled');
   lines.push('         gbrain skillpack list                # see all options');
   lines.push('');
   lines.push('  Do NOT install without asking. The user owns this decision.');

--- a/test/brain-writer.test.ts
+++ b/test/brain-writer.test.ts
@@ -55,6 +55,20 @@ describe('autoFixFrontmatter', () => {
     expect(second.fixes).toEqual([]);
   });
 
+  test('repairs Obsidian wikilink CSV into a YAML string array', () => {
+    const input = `${fence}\ntags: [concept]\nrelated: [[AI-as-Audience]], [[Pilot Impact Measurement]]\n${fence}\n\nbody`;
+    const { content, fixes } = autoFixFrontmatter(input);
+    expect(fixes.some(f => f.code === 'YAML_PARSE')).toBe(true);
+    expect(content).toContain('related: ["[[AI-as-Audience]]", "[[Pilot Impact Measurement]]"]');
+  });
+
+  test('quotes plain scalar values that contain colon-space', () => {
+    const input = `${fence}\ntitle: The Drum — From GEO to GEM: why CMOs need to think bigger\n${fence}\n\nbody`;
+    const { content, fixes } = autoFixFrontmatter(input);
+    expect(fixes.some(f => f.code === 'YAML_PARSE')).toBe(true);
+    expect(content).toContain('title: "The Drum — From GEO to GEM: why CMOs need to think bigger"');
+  });
+
   test('clean input: no fixes, content unchanged', () => {
     const input = `${fence}\ntype: concept\ntitle: ok\n${fence}\n\nbody`;
     const { content, fixes } = autoFixFrontmatter(input);

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -210,11 +210,12 @@ describe('doctor command', () => {
   // PR #376 (FUSED-ID) flagged the stale hint; PR #536 (mayazbay) replaced it
   // with the canonical `gbrain extract all`. Pin the user-facing copy so a
   // future edit can't silently re-regress to a stale verb.
-  test('graph_coverage hint uses canonical `gbrain extract all`, not removed verbs', async () => {
+  test('graph_coverage hint uses canonical DB-backed extract command, not removed verbs', async () => {
     const fs = await import('fs');
     const src = fs.readFileSync('src/commands/doctor.ts', 'utf8');
-    // Canonical form (post-v0.16 single-verb consolidation).
-    expect(src).toContain('Run: gbrain extract all');
+    // Canonical form for doctor-driven remediation: health is measured in the DB,
+    // so the hint must point at the DB-backed extractor.
+    expect(src).toContain('Run: gbrain extract all --source db');
     // Stale verb names removed in v0.16 must not return.
     expect(src).not.toContain('gbrain link-extract');
     expect(src).not.toContain('gbrain timeline-extract');

--- a/test/frontmatter-cli.test.ts
+++ b/test/frontmatter-cli.test.ts
@@ -95,6 +95,28 @@ describe('gbrain frontmatter CLI (B4)', () => {
     expect(existsSync(f + '.bak')).toBe(true);
   });
 
+  test('validate --fix generates frontmatter for files with none', () => {
+    const f = join(tmp, 'founder-note.md');
+    const original = '# Founder Note\n\nA short memo.';
+    writeFileSync(f, original);
+    const { code } = runCli(['validate', f, '--fix']);
+    expect(code).toBe(0);
+    expect(existsSync(f + '.bak')).toBe(true);
+    const rewritten = readFileSync(f, 'utf8');
+    expect(rewritten).toMatch(/^---\n/);
+    expect(rewritten).toContain('title: Founder Note');
+    expect(rewritten).toContain(original);
+  });
+
+  test('validate --fix repairs common YAML parse failures', () => {
+    const f = join(tmp, 'broken-yaml.md');
+    writeFileSync(f, `${fence}\ntype: concept\nrelated: [[AI-as-Audience]], [[Pilot Impact Measurement]]\n${fence}\n\nbody`);
+    const { code } = runCli(['validate', f, '--fix']);
+    expect(code).toBe(0);
+    expect(existsSync(f + '.bak')).toBe(true);
+    expect(readFileSync(f, 'utf8')).toContain('related: ["[[AI-as-Audience]]", "[[Pilot Impact Measurement]]"]');
+  });
+
   test('validate scans a directory recursively, skips non-.md files', () => {
     mkdirSync(join(tmp, 'subdir'), { recursive: true });
     writeFileSync(join(tmp, 'a.md'), `${fence}\ntype: concept\ntitle: A\n${fence}\n\nbody`);

--- a/test/markdown-validation.test.ts
+++ b/test/markdown-validation.test.ts
@@ -133,6 +133,12 @@ describe('parseMarkdown validation surface', () => {
       const parsed = parseMarkdown(md, undefined, { validate: true });
       expect(parsed.errors!.map(e => e.code)).not.toContain('NESTED_QUOTES');
     });
+
+    test('quoted YAML arrays do not trigger', () => {
+      const md = `${fence}\ntype: concept\nrelated: ["[[AI-as-Audience]]", "[[Machine-Targeted Content]]"]\n${fence}\n\nbody`;
+      const parsed = parseMarkdown(md, undefined, { validate: true });
+      expect(parsed.errors!.map(e => e.code)).not.toContain('NESTED_QUOTES');
+    });
   });
 
   describe('EMPTY_FRONTMATTER', () => {

--- a/test/post-install-advisory.test.ts
+++ b/test/post-install-advisory.test.ts
@@ -113,7 +113,7 @@ describe('buildAdvisory — partial-install path', () => {
     expect(advisory).toContain('book-mirror');
     expect(advisory).not.toContain('article-enrichment');
     expect(advisory).not.toContain('strategic-reading');
-    expect(advisory).toContain('gbrain skillpack install book-mirror');
+    expect(advisory).toContain('gbrain skillpack scaffold book-mirror');
   });
 
   it('uses --all command when ALL recommended are missing (fresh workspace)', () => {
@@ -125,7 +125,7 @@ describe('buildAdvisory — partial-install path', () => {
       targetSkillsDir: skillsDir,
     });
     expect(advisory).not.toBeNull();
-    expect(advisory).toContain('gbrain skillpack install --all');
+    expect(advisory).toContain('gbrain skillpack scaffold --all');
     expect(advisory).toContain('book-mirror');
     expect(advisory).toContain('article-enrichment');
     expect(advisory).toContain('strategic-reading');
@@ -213,7 +213,7 @@ describe('buildAdvisory — agent-readable framing', () => {
       targetWorkspace: workspace,
       targetSkillsDir: skillsDir,
     })!;
-    expect(advisory).toContain('gbrain skillpack install --all');
+    expect(advisory).toContain('gbrain skillpack scaffold --all');
     expect(advisory).toContain('gbrain skillpack list');
   });
 });
@@ -228,6 +228,6 @@ describe('buildAdvisory — no workspace detected', () => {
     });
     expect(advisory).not.toBeNull();
     // No workspace -> empty installed set -> all recommended treated as missing.
-    expect(advisory).toContain('gbrain skillpack install --all');
+    expect(advisory).toContain('gbrain skillpack scaffold --all');
   });
 });

--- a/test/skillpack-install.test.ts
+++ b/test/skillpack-install.test.ts
@@ -122,6 +122,13 @@ describe('findGbrainRoot', () => {
     mkdirSync(nested, { recursive: true });
     expect(findGbrainRoot(nested)).toBe(gbrainRoot);
   });
+
+  it('can fall back to the installed module path for read-only callers', () => {
+    expect(
+      findGbrainRoot('/tmp/definitely-not-a-gbrain-repo-XYZ', { allowInstallPathFallback: true }),
+    ).toBe('/Users/prashantagarwal/gbrain');
+  });
+
   it('returns null when no gbrain root above', () => {
     expect(findGbrainRoot('/tmp/definitely-not-a-gbrain-repo-XYZ')).toBeNull();
   });


### PR DESCRIPTION
## Summary
- fix read-only skillpack commands so they work outside the repo root using an install-path fallback
- update post-upgrade advisory text to recommend `gbrain skillpack scaffold` instead of the removed `install` flow
- make `gbrain frontmatter validate --fix` actually repair missing frontmatter and common YAML parse failures
- stop false-positive `NESTED_QUOTES` warnings for valid quoted YAML arrays
- point doctor graph-coverage remediation at the DB-backed extractor command it actually means

## Verification
- `bun test test/brain-writer.test.ts test/frontmatter-cli.test.ts test/markdown-validation.test.ts test/post-install-advisory.test.ts test/skillpack-install.test.ts test/doctor.test.ts`
- `gbrain frontmatter validate /Users/prashantagarwal/gbrain-sources/hq-curated --fix --json`
- `gbrain frontmatter validate /Users/prashantagarwal/gbrain-sources/hq-curated --json`
- `gbrain doctor --json || true`
- `gbrain extract all --source db`

## Notes
- Direct push to upstream `garrytan/gbrain` was blocked with HTTP 403, so this ships via fork + PR.
