### PR TITLE
fix: refresh source sync freshness on no-op sync

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -557,9 +557,11 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     // sync_freshness keys off sources.last_sync_at, so a successful source-scoped
     // no-op sync must still refresh the heartbeat even when the bookmark is
     // already aligned with HEAD.
-    await touchSyncFreshness(engine, opts.sourceId);
+    if (!opts.dryRun) {
+      await touchSyncFreshness(engine, opts.sourceId);
+    }
     return {
-      status: 'up_to_date',
+      status: opts.dryRun ? 'dry_run' : 'up_to_date',
       fromCommit: lastCommit,
       toCommit: headCommit,
       added: 0, modified: 0, deleted: 0, renamed: 0,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -320,6 +320,17 @@ async function writeSyncAnchor(
   await engine.setConfig(`sync.${which}`, value);
 }
 
+async function touchSyncFreshness(
+  engine: BrainEngine,
+  sourceId: string | undefined,
+): Promise<void> {
+  if (!sourceId) return;
+  await engine.executeRaw(
+    `UPDATE sources SET last_sync_at = now() WHERE id = $1`,
+    [sourceId],
+  );
+}
+
 /**
  * v0.20.0 Cathedral II Layer 12 (SP-1 fix) — read/write the chunker version
  * last used to sync a given source. When it mismatches CURRENT_CHUNKER_VERSION,
@@ -543,6 +554,10 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       detachedWorkingTreeManifest.renamed.length > 0);
 
   if (lastCommit === headCommit && !versionMismatch && !versionNeverSet && !hasDetachedWorkingTreeChanges) {
+    // sync_freshness keys off sources.last_sync_at, so a successful source-scoped
+    // no-op sync must still refresh the heartbeat even when the bookmark is
+    // already aligned with HEAD.
+    await touchSyncFreshness(engine, opts.sourceId);
     return {
       status: 'up_to_date',
       fromCommit: lastCommit,

--- a/test/performfullsync-source-id.test.ts
+++ b/test/performfullsync-source-id.test.ts
@@ -47,6 +47,15 @@ async function pageCountBySource(): Promise<Record<string, number>> {
   return out;
 }
 
+async function readSourceSyncState(sourceId: string): Promise<{ last_commit: string | null; last_sync_at: string | null }> {
+  const rows = await engine.executeRaw<{ last_commit: string | null; last_sync_at: string | null }>(
+    `SELECT last_commit, last_sync_at::text AS last_sync_at FROM sources WHERE id = $1`,
+    [sourceId],
+  );
+  expect(rows).toHaveLength(1);
+  return rows[0];
+}
+
 describe('performFullSync threads sourceId end-to-end', () => {
   beforeAll(async () => {
     engine = new PGLiteEngine();
@@ -135,5 +144,45 @@ describe('performFullSync threads sourceId end-to-end', () => {
     // Back-compat: callers that omit sourceId continue to target source 'default'.
     expect(counts['default']).toBeGreaterThan(0);
     expect(counts['testsrc-pfs'] ?? 0).toBe(0);
+  });
+
+  test('successful no-op source sync refreshes last_sync_at without forcing --full', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+
+    const first = await performSync(engine, {
+      repoPath,
+      sourceId: 'testsrc-pfs',
+      noPull: true,
+      noEmbed: true,
+    });
+    expect(['first_sync', 'synced']).toContain(first.status);
+
+    const seeded = await readSourceSyncState('testsrc-pfs');
+    expect(seeded.last_commit).toBeTruthy();
+    expect(seeded.last_sync_at).toBeTruthy();
+
+    await engine.executeRaw(
+      `UPDATE sources
+         SET last_sync_at = now() - interval '5 days'
+       WHERE id = 'testsrc-pfs'`,
+    );
+
+    const stale = await readSourceSyncState('testsrc-pfs');
+    expect(stale.last_commit).toBe(seeded.last_commit);
+    expect(stale.last_sync_at).not.toBeNull();
+
+    const second = await performSync(engine, {
+      repoPath,
+      sourceId: 'testsrc-pfs',
+      noPull: true,
+      noEmbed: true,
+    });
+
+    expect(second.status).toBe('up_to_date');
+
+    const refreshed = await readSourceSyncState('testsrc-pfs');
+    expect(refreshed.last_commit).toBe(seeded.last_commit);
+    expect(refreshed.last_sync_at).not.toBeNull();
+    expect(new Date(refreshed.last_sync_at!).getTime()).toBeGreaterThan(new Date(stale.last_sync_at!).getTime());
   });
 });

--- a/test/performfullsync-source-id.test.ts
+++ b/test/performfullsync-source-id.test.ts
@@ -185,4 +185,44 @@ describe('performFullSync threads sourceId end-to-end', () => {
     expect(refreshed.last_sync_at).not.toBeNull();
     expect(new Date(refreshed.last_sync_at!).getTime()).toBeGreaterThan(new Date(stale.last_sync_at!).getTime());
   });
+
+  test('source-scoped no-op dry-run does not refresh last_sync_at', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+
+    const first = await performSync(engine, {
+      repoPath,
+      sourceId: 'testsrc-pfs',
+      noPull: true,
+      noEmbed: true,
+    });
+    expect(['first_sync', 'synced']).toContain(first.status);
+
+    const seeded = await readSourceSyncState('testsrc-pfs');
+    expect(seeded.last_commit).toBeTruthy();
+    expect(seeded.last_sync_at).toBeTruthy();
+
+    await engine.executeRaw(
+      `UPDATE sources
+         SET last_sync_at = now() - interval '5 days'
+       WHERE id = 'testsrc-pfs'`,
+    );
+
+    const stale = await readSourceSyncState('testsrc-pfs');
+    expect(stale.last_commit).toBe(seeded.last_commit);
+    expect(stale.last_sync_at).not.toBeNull();
+
+    const second = await performSync(engine, {
+      repoPath,
+      sourceId: 'testsrc-pfs',
+      dryRun: true,
+      noPull: true,
+      noEmbed: true,
+    });
+
+    expect(second.status).toBe('dry_run');
+
+    const afterDryRun = await readSourceSyncState('testsrc-pfs');
+    expect(afterDryRun.last_commit).toBe(seeded.last_commit);
+    expect(afterDryRun.last_sync_at).toBe(stale.last_sync_at);
+  });
 });


### PR DESCRIPTION
## Problem
Kayako's maintainer path runs `gbrain sync --source kayako --no-pull` against an already-refreshed local wiki mirror. When that sync is a no-op, `performSync` returns `up_to_date` before refreshing `sources.last_sync_at`, so `doctor` can keep failing `sync_freshness` even though the source was checked successfully.

Paperclip issue: KAY-429.

## Root cause
The source-scoped sync freshness timestamp only advanced when `last_commit` advanced or a full sync ran. The fast path for `lastCommit === headCommit` skipped the `sources.last_sync_at` write entirely.

## Change summary
- add a source-scoped `touchSyncFreshness()` helper in `src/commands/sync.ts`
- call it before returning `up_to_date` from the successful no-op source-sync path
- add a regression test proving `gbrain sync --source <id>` refreshes `last_sync_at` on a no-change run without forcing `--full`

## Verification
- `/paperclip/gbrain/bun/bin/bun test test/performfullsync-source-id.test.ts`

## Risk
Low. The new write is limited to successful source-scoped no-op syncs. Global sync state, blocked syncs, failed syncs, and commit-advancing paths are unchanged.

## Maintainer guidance
The right fix is in incremental sync freshness handling, not by forcing `--full` for nightly wrapper runs. `--full` reimports unnecessarily and should remain an explicit recovery path.
