### PR TITLE
feat: add skill_brain_first doctor check

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1332,6 +1332,16 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
     checks.push(conformanceResult);
   }
 
+  // 2b. Skill brain-first coverage — detect skills that do external lookups
+  // without a brain/gbrain search step. The brain has 100K+ pages; external
+  // APIs should never be the first call when the brain likely has the answer.
+  {
+    const workspaceSkillsDir = process.env.OPENCLAW_WORKSPACE
+      ? join(process.env.OPENCLAW_WORKSPACE, 'skills')
+      : join(process.env.HOME || '', '.openclaw', 'workspace', 'skills');
+    checks.push(skillBrainFirstCheck(workspaceSkillsDir));
+  }
+
   // 3. Half-migrated Minions detection (filesystem-only).
   // If completed.jsonl has any status:"partial" entry with no later
   // status:"complete" for the same version, the install is mid-migration.
@@ -3285,6 +3295,138 @@ function checkSkillConformance(skillsDir: string): Check {
     };
   } catch {
     return { name: 'skill_conformance', status: 'warn', message: 'Could not parse manifest.json' };
+  }
+}
+
+/**
+ * Skill brain-first coverage check.
+ *
+ * Scans SKILL.md files in the OpenClaw workspace and detects skills that
+ * reference external lookup tools (web_search, Exa, Perplexity, Happenstance,
+ * Crustdata, Captain API, etc.) without also including a brain/gbrain search
+ * step. The brain has 100K+ pages — external APIs should never be the first
+ * call when the brain likely has the answer.
+ *
+ * The tweet-shield incident (2026-05-19) is the motivating case: cross-modal
+ * eval flagged Garry’s Palantir tweet as risky because the models didn’t know
+ * he built it — but the brain already had “designed the entire Finance product
+ * UI” and “150+ PSDs from April-December 2006.” If the shield had checked
+ * brain first, it would never have flagged.
+ *
+ * Pure filesystem check — no DB needed.
+ */
+export function skillBrainFirstCheck(workspaceSkillsDir: string): Check {
+  try {
+    if (!existsSync(workspaceSkillsDir)) {
+      return {
+        name: 'skill_brain_first',
+        status: 'ok',
+        message: `OpenClaw workspace skills dir not found at ${workspaceSkillsDir} — skipped`,
+      };
+    }
+
+    // Patterns that indicate external lookups
+    const EXTERNAL_LOOKUP_PATTERNS = [
+      /\bweb_search\b/i,
+      /\bweb_fetch\b/i,
+      /\bexa[\s._]/i,
+      /\bperplexity/i,
+      /\bhappenstance/i,
+      /\bcrustdata/i,
+      /\bcaptain[\s._-]?api/i,
+      /\bfirecrawl/i,
+      /\bcurl\b.*api/i,
+    ];
+
+    // Patterns that indicate a brain-first search step
+    const BRAIN_FIRST_PATTERNS = [
+      /\bgbrain\s+search\b/i,
+      /\bbrain\s+search\b/i,
+      /\bbrain[\s-]first\b/i,
+      /\bsearch\s+(the\s+)?brain\b/i,
+      /step\s*0.*brain/i,
+      /brain\s*context/i,
+      /\bgbrain\s+get\b/i,
+      /\bgbrain\s+query\b/i,
+      /check\s+(the\s+)?brain/i,
+      /query\s+(the\s+)?brain/i,
+      /\bbrain\s+lookup\b/i,
+    ];
+
+    // Skills that are inherently brain-internal or infrastructure and don't
+    // need a brain-first step (they ARE the brain, or they're pure infra).
+    const EXEMPT_SKILLS = new Set([
+      'brain-ops', 'brain-commit', 'brain-enrichment-pipeline', 'brain-export',
+      'brain-ingest-gate', 'brain-librarian', 'brain-link-refs', 'brain-link-report',
+      'brain-pdf', 'brain-pdf-auto', 'brain-plan', 'brain-publish', 'brain-storage',
+      'brain-storage-links', 'brain-taxonomist', 'gbrain', 'gbrain-pr', 'gbrain-upgrade',
+      'benchmark-gbrain', 'exa', 'happenstance', 'crustdata', 'captain-api',
+      'healthcheck', 'backblaze', 'browser', 'browser-use', 'binary-deps',
+      'captcha-solver', 'container-restart', 'durable-service', 'data-loss-gate',
+      'channel-discovery', 'clawvisor', 'clawvisor-shield', 'cron-scheduler',
+      'cronify', 'correction-pipeline', 'acknowledge', 'ask-user', 'backoff',
+      'acp-coding', 'code-pr', 'skill-creator', 'ingest', 'freshness-monitor',
+    ]);
+
+    const entries = readdirSync(workspaceSkillsDir, { withFileTypes: true });
+    const missing: string[] = [];
+    let scanned = 0;
+    let withExternal = 0;
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const skillName = entry.name;
+      if (EXEMPT_SKILLS.has(skillName)) continue;
+      if (skillName.startsWith('_') || skillName.startsWith('.')) continue;
+
+      const skillPath = join(workspaceSkillsDir, skillName, 'SKILL.md');
+      if (!existsSync(skillPath)) continue;
+
+      let content: string;
+      try {
+        content = readFileSync(skillPath, 'utf-8');
+      } catch {
+        continue;
+      }
+
+      scanned++;
+
+      // Check if skill references external lookups
+      const hasExternalLookup = EXTERNAL_LOOKUP_PATTERNS.some(p => p.test(content));
+      if (!hasExternalLookup) continue;
+
+      withExternal++;
+
+      // Check if skill also has a brain-first step
+      const hasBrainFirst = BRAIN_FIRST_PATTERNS.some(p => p.test(content));
+      if (!hasBrainFirst) {
+        missing.push(skillName);
+      }
+    }
+
+    if (missing.length === 0) {
+      return {
+        name: 'skill_brain_first',
+        status: 'ok',
+        message: `${withExternal} skill(s) with external lookups all include brain-first checks (${scanned} scanned)`,
+      };
+    }
+
+    return {
+      name: 'skill_brain_first',
+      status: 'warn',
+      message:
+        `${missing.length} skill(s) do external lookups without a brain-first search step: ` +
+        `${missing.sort().join(', ')}. ` +
+        `Fix: add a "Step 0: Brain Context" section that runs gbrain search before external APIs.`,
+    };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      name: 'skill_brain_first',
+      status: 'warn',
+      message: `Could not scan skills for brain-first coverage: ${msg}`,
+    };
   }
 }
 

--- a/test/doctor-brain-first.test.ts
+++ b/test/doctor-brain-first.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { skillBrainFirstCheck } from '../src/commands/doctor.ts';
+
+const TMP_DIR = join(import.meta.dir, '.tmp-brain-first-test');
+
+function makeSkill(name: string, content: string): void {
+  const dir = join(TMP_DIR, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'SKILL.md'), content);
+}
+
+describe('skillBrainFirstCheck', () => {
+  beforeEach(() => {
+    mkdirSync(TMP_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TMP_DIR, { recursive: true, force: true });
+  });
+
+  test('returns ok when no skills directory exists', () => {
+    const result = skillBrainFirstCheck('/nonexistent/path/skills');
+    expect(result.name).toBe('skill_brain_first');
+    expect(result.status).toBe('ok');
+    expect(result.message).toContain('skipped');
+  });
+
+  test('returns ok when all external-lookup skills have brain-first steps', () => {
+    makeSkill('good-skill', `---
+name: good-skill
+---
+# Good Skill
+
+## Step 0: Brain Context
+Search the brain first with \`gbrain search\` for relevant context.
+
+## Step 1: External Lookup
+Use web_search to find additional information.
+`);
+    const result = skillBrainFirstCheck(TMP_DIR);
+    expect(result.status).toBe('ok');
+    expect(result.message).toContain('brain-first checks');
+  });
+
+  test('returns warn when skill has external lookup without brain-first', () => {
+    makeSkill('bad-skill', `---
+name: bad-skill
+---
+# Bad Skill
+
+## Step 1: Research
+Use web_search to find information about the entity.
+Then use Perplexity for deeper research.
+`);
+    const result = skillBrainFirstCheck(TMP_DIR);
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('bad-skill');
+    expect(result.message).toContain('brain-first search step');
+  });
+
+  test('detects multiple external lookup patterns', () => {
+    // Exa
+    makeSkill('exa-user', `---\nname: exa-user\n---\nUse exa.search for lookups.`);
+    // Happenstance
+    makeSkill('hap-user', `---\nname: hap-user\n---\nQuery happenstance API.`);
+    // Crustdata
+    makeSkill('crust-user', `---\nname: crust-user\n---\nUse crustdata for LinkedIn data.`);
+
+    const result = skillBrainFirstCheck(TMP_DIR);
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('3 skill(s)');
+  });
+
+  test('skills with brain search are not flagged', () => {
+    makeSkill('brain-first-skill', `---
+name: brain-first-skill
+---
+# Brain-First Skill
+
+First, search the brain for existing context.
+Then use web_search for anything missing.
+`);
+    const result = skillBrainFirstCheck(TMP_DIR);
+    expect(result.status).toBe('ok');
+  });
+
+  test('exempt skills are skipped even with external lookups', () => {
+    // brain-ops is exempt
+    makeSkill('brain-ops', `---\nname: brain-ops\n---\nUse web_search for research.`);
+    const result = skillBrainFirstCheck(TMP_DIR);
+    expect(result.status).toBe('ok');
+  });
+
+  test('skills without external lookups are not flagged', () => {
+    makeSkill('internal-skill', `---
+name: internal-skill
+---
+# Internal Skill
+This skill only operates on local files. No external lookups.
+`);
+    const result = skillBrainFirstCheck(TMP_DIR);
+    expect(result.status).toBe('ok');
+    expect(result.message).toContain('0 skill(s)');
+  });
+
+  test('recognizes various brain-first patterns', () => {
+    // "brain-first" keyword
+    makeSkill('s1', `---\nname: s1\n---\nBrain-first lookup required.\nUse web_search.`);
+    // "gbrain get" 
+    makeSkill('s2', `---\nname: s2\n---\nRun gbrain get entity.\nUse web_fetch for enrichment.`);
+    // "check the brain"
+    makeSkill('s3', `---\nname: s3\n---\nCheck the brain before calling Perplexity.`);
+    // "query the brain"
+    makeSkill('s4', `---\nname: s4\n---\nQuery the brain for context. Use exa.search for rest.`);
+
+    const result = skillBrainFirstCheck(TMP_DIR);
+    expect(result.status).toBe('ok');
+  });
+
+  test('hidden directories and underscore-prefixed dirs are skipped', () => {
+    makeSkill('.hidden', `---\nname: hidden\n---\nUse web_search.`);
+    makeSkill('_internal', `---\nname: internal\n---\nUse web_search.`);
+    const result = skillBrainFirstCheck(TMP_DIR);
+    expect(result.status).toBe('ok');
+  });
+
+  test('mix of good and bad skills reports only the bad ones', () => {
+    makeSkill('good', `---\nname: good\n---\nSearch brain first. Then web_search.`);
+    makeSkill('bad', `---\nname: bad\n---\nJust use web_search directly.`);
+    const result = skillBrainFirstCheck(TMP_DIR);
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('bad');
+    expect(result.message).not.toContain('good');
+  });
+});


### PR DESCRIPTION
## What

Adds a new `skill_brain_first` check to `gbrain doctor` that scans SKILL.md files in the workspace and detects skills doing external lookups without a brain-first search step.

## Why

A content evaluation skill ran cross-modal analysis on user-authored content without first checking the brain for relevant context. All 3 evaluation models flagged the content as risky because they relied on incomplete public knowledge — but the brain already had first-person records confirming the claim. If the skill had searched the brain first, it would never have false-flagged.

The brain can have 100K+ pages of verified context. External APIs should never be the first call when the brain likely has the answer. This doctor check enforces that pattern systematically.

## How

The check runs in the filesystem-only section of `runDoctor` (no DB needed):

1. Scans all `SKILL.md` files in the workspace (`$OPENCLAW_WORKSPACE/skills` or `~/.openclaw/workspace/skills`)
2. Detects external lookup patterns: `web_search`, `web_fetch`, Exa, Perplexity, Happenstance, Crustdata, Captain API, Firecrawl
3. Checks if those skills also include a brain-first search step (`gbrain search`, `brain search`, `brain-first`, `Step 0: Brain Context`, etc.)
4. Reports `[WARN]` with a sorted list of non-compliant skills
5. Exempts brain-internal skills (brain-ops, gbrain, etc.) and pure-infra skills

### Example output
```
[WARN] skill_brain_first: 42 skill(s) do external lookups without a brain-first search step
```

## Tests

10 unit tests in `test/doctor-brain-first.test.ts`:
- Directory not found → ok (skipped)
- All external-lookup skills have brain-first → ok
- Missing brain-first → warn with skill names
- Multiple external patterns detected
- Various brain-first pattern recognition
- Exempt skills skipped
- Hidden/underscore dirs skipped
- Mix of good/bad reports only bad

All passing.