### PR TITLE
fix(frontmatter): use single quotes for tags to prevent NESTED_QUOTES errors

### DIFF
--- a/src/core/frontmatter-inference.ts
+++ b/src/core/frontmatter-inference.ts
@@ -408,7 +408,7 @@ export function serializeFrontmatter(fm: InferredFrontmatter): string {
   }
 
   if (fm.tags && fm.tags.length > 0) {
-    lines.push(`tags: [${fm.tags.map(t => JSON.stringify(t)).join(', ')}]`);
+    lines.push(`tags: [${fm.tags.map(t => t.includes("'") ? JSON.stringify(t) : `'${t}'`).join(', ')}]`);
   }
 
   lines.push('---');


### PR DESCRIPTION
## Problem

`serializeFrontmatter()` uses `JSON.stringify(t)` for tag values, producing:

```yaml
tags: ["yc", "w2025"]
```

This is ambiguous YAML — the double quotes nest with the implicit string context, triggering `NESTED_QUOTES` validation errors. In a real brain (105K+ pages), this caused **6,981 errors** — the single largest contributor to the frontmatter integrity health check.

## Fix

Switch to single-quoted YAML flow values by default:

```yaml
tags: ['yc', 'w2025']
```

Falls back to double quotes only when a tag itself contains an apostrophe (e.g. `"Men's Fashion"`).

## Impact

- One-line change in `src/core/frontmatter-inference.ts`
- Prevents ~7K validation errors per brain that uses inferred frontmatter
- Companion data fix already landed in garrytan/brain (11,819 files cleaned up)