### PR TITLE
fix(cycle): cache empty propose_takes scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to GBrain will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- `propose_takes` now caches successful zero-proposal page scans in `take_proposal_page_scans`, so unchanged pages that correctly produce `[]` do not re-spend LLM tokens on every autopilot cycle. The operator-facing `take_proposals` queue remains proposal-only; extractor failures are deliberately uncached so transient model/API errors retry later.
+
 ## [0.37.1.0] - 2026-05-19
 
 **Your brain can now collide its own ideas.**

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -1420,7 +1420,7 @@ export async function runCycle(
           checkAborted(opts.signal);
           progress.start('cycle.propose_takes');
           const { runPhaseProposeTakes } = await import('./cycle/propose-takes.ts');
-          const { result, duration_ms } = await timePhase(() => runPhaseProposeTakes(calibrationCtx, { repoPath: opts.brainDir }) as Promise<PhaseResult>);
+          const { result, duration_ms } = await timePhase(() => runPhaseProposeTakes(calibrationCtx, { repoPath: opts.brainDir, dryRun }) as Promise<PhaseResult>);
           result.duration_ms = duration_ms;
           phaseResults.push(result);
           progress.finish();

--- a/src/core/cycle/propose-takes.ts
+++ b/src/core/cycle/propose-takes.ts
@@ -5,10 +5,11 @@
  * a tuned LLM extractor, writes the extracted gradeable claims to the
  * `take_proposals` queue. User accepts/rejects via `gbrain takes propose`.
  *
- * Idempotency contract (D17 schema spec):
- *   The unique index on (source_id, page_slug, content_hash, prompt_version)
- *   means an unchanged page never re-spends LLM tokens. Bumping
- *   PROPOSE_TAKES_PROMPT_VERSION cleanly invalidates the cache so a tuned
+ * Idempotency contract (D17 schema spec + v0.37.1.1 cost fix):
+ *   `take_proposal_page_scans` records every successful extractor call keyed by
+ *   (source_id, page_slug, content_hash, prompt_version), even when the LLM
+ *   returns []. `take_proposals` remains the operator-facing queue. Bumping
+ *   PROPOSE_TAKES_PROMPT_VERSION cleanly invalidates the scan cache so a tuned
  *   prompt re-runs proposals on every page.
  *
  * F2 fence dedup:
@@ -49,7 +50,10 @@ import type { PhaseStatus, CyclePhase } from '../cycle.ts';
 /**
  * Bump when the extractor prompt or the JSON output shape changes. Old
  * verdicts in `take_proposals` (composite key includes prompt_version) stay
- * valid as audit history; new runs re-spend LLM tokens on every page.
+ * valid as audit history; new runs re-spend LLM tokens on every page. The
+ * companion `take_proposal_page_scans` cache uses the same key and also
+ * records successful zero-proposal scans so unchanged pages do not churn the
+ * extractor forever.
  */
 export const PROPOSE_TAKES_PROMPT_VERSION = 'v0.36.1.0-tuned-cat15';
 
@@ -150,6 +154,10 @@ export interface ProposeTakesResult {
   cache_hits: number;
   cache_misses: number;
   proposals_inserted: number;
+  scan_cache_writes: number;
+  empty_results_cached: number;
+  llm_calls_skipped: number;
+  dry_run: boolean;
   budget_exhausted: boolean;
   warnings: string[];
 }
@@ -210,8 +218,9 @@ export function extractExistingTakesForDedup(pageBody: string): Array<{
 
 /**
  * Production extractor — calls gateway.chat with the EXTRACT_TAKES_PROMPT
- * and parses the JSON array output. Returns [] on parse failure (logged as
- * warning, not thrown — one bad page must not abort the phase).
+ * and parses the JSON array output. Throws on malformed model output so the
+ * caller treats it as a retryable extractor failure instead of caching it as a
+ * successful zero-proposal scan.
  *
  * Stub-prompt note: the v0.36.1.0 ship-state prompt is a placeholder. Real
  * extractor lands when T19 corpus build produces the tuned prompt. Until
@@ -231,8 +240,10 @@ export async function defaultExtractor(
     maxTokens: 2048,
   });
 
-  // ChatResult.text is already the concatenated text content.
-  return parseExtractorOutput(result.text);
+  // ChatResult.text is already the concatenated text content. Malformed
+  // extractor output is a retryable extractor failure, not a successful []
+  // result, so the caller must not cache it as processed.
+  return parseExtractorOutputStrict(result.text);
 }
 
 /**
@@ -242,7 +253,16 @@ export async function defaultExtractor(
  * than throwing.
  */
 export function parseExtractorOutput(raw: string): ProposedTake[] {
-  if (!raw || raw.trim().length === 0) return [];
+  return parseExtractorOutputDetailed(raw).proposals;
+}
+
+/**
+ * Detailed parser for production extractor calls. `ok=false` means the model
+ * failed to return parseable JSON, which is a retryable extractor failure and
+ * must not be cached as a successful zero-proposal scan.
+ */
+export function parseExtractorOutputDetailed(raw: string): { ok: boolean; proposals: ProposedTake[] } {
+  if (!raw || raw.trim().length === 0) return { ok: false, proposals: [] };
   let text = raw.trim();
   // Strip markdown code fence wrapper.
   const fenced = text.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/);
@@ -250,16 +270,16 @@ export function parseExtractorOutput(raw: string): ProposedTake[] {
   // First-array-or-object substring extraction (defends against leading prose).
   const firstArr = text.indexOf('[');
   const firstObj = text.indexOf('{');
-  if (firstArr === -1 && firstObj === -1) return [];
+  if (firstArr === -1 && firstObj === -1) return { ok: false, proposals: [] };
   const start = firstArr !== -1 && (firstObj === -1 || firstArr < firstObj) ? firstArr : firstObj;
   let parsed: unknown;
   try {
     parsed = JSON.parse(text.slice(start));
   } catch {
-    return [];
+    return { ok: false, proposals: [] };
   }
   const arr = Array.isArray(parsed) ? parsed : [parsed];
-  const out: ProposedTake[] = [];
+  const proposals: ProposedTake[] = [];
   for (const raw of arr) {
     if (typeof raw !== 'object' || raw === null) continue;
     const r = raw as Record<string, unknown>;
@@ -272,9 +292,24 @@ export function parseExtractorOutput(raw: string): ProposedTake[] {
     const weightRaw = typeof r.weight === 'number' ? r.weight : 0.5;
     const weight = Math.max(0, Math.min(1, weightRaw));
     const domain = typeof r.domain === 'string' && r.domain.length > 0 ? r.domain : undefined;
-    out.push({ claim_text, kind, holder, weight, domain });
+    proposals.push({ claim_text, kind, holder, weight, domain });
   }
-  return out;
+  if (arr.length > 0 && proposals.length === 0) {
+    return { ok: false, proposals: [] };
+  }
+  return { ok: true, proposals };
+}
+
+/**
+ * Strict parser for production extractor calls. Malformed output is a
+ * retryable extractor failure, not a successful empty result.
+ */
+export function parseExtractorOutputStrict(raw: string): ProposedTake[] {
+  const parsed = parseExtractorOutputDetailed(raw);
+  if (!parsed.ok) {
+    throw new Error('extractor returned malformed JSON');
+  }
+  return parsed.proposals;
 }
 
 /**
@@ -305,6 +340,7 @@ class ProposeTakesPhase extends BaseCyclePhase {
     const promptVersion = opts.promptVersion ?? PROPOSE_TAKES_PROMPT_VERSION;
     const pageLimit = opts.pageLimit ?? 100;
     const skipPagesWithFence = opts.skipPagesWithFence ?? false;
+    const dryRun = opts.dryRun ?? _ctx.dryRun ?? false;
     const proposalRunId = `propose-${new Date().toISOString().slice(0, 19).replace(/[-:T]/g, '')}-${randomUUID().slice(0, 8)}`;
 
     const result: ProposeTakesResult = {
@@ -312,6 +348,10 @@ class ProposeTakesPhase extends BaseCyclePhase {
       cache_hits: 0,
       cache_misses: 0,
       proposals_inserted: 0,
+      scan_cache_writes: 0,
+      empty_results_cached: 0,
+      llm_calls_skipped: 0,
+      dry_run: dryRun,
       budget_exhausted: false,
       warnings: [],
     };
@@ -340,20 +380,37 @@ class ProposeTakesPhase extends BaseCyclePhase {
       const ch = contentHash(body);
       const existingTakes = extractExistingTakesForDedup(body);
 
-      // Idempotency check. If a row exists for (source_id, page_slug, content_hash,
-      // prompt_version), this page was already processed — skip and count as cache hit.
+      // Idempotency check. `take_proposal_page_scans` is the authoritative
+      // per-page cache because it records successful extractor calls even when
+      // the extractor returned []. `take_proposals` is checked as a legacy cache
+      // so users upgrading from v0.36 do not re-spend on pages that already have
+      // pending/accepted/rejected proposals.
       const sourceId = page.source_id ?? scope.sourceId ?? 'default';
-      const cached = await engine.executeRaw<{ id: number }>(
+      const cachedScan = await engine.executeRaw<{ found: number }>(
+        `SELECT 1 AS found FROM take_proposal_page_scans
+         WHERE source_id = $1 AND page_slug = $2 AND content_hash = $3 AND prompt_version = $4
+         LIMIT 1`,
+        [sourceId, page.slug, ch, promptVersion],
+      );
+      if (cachedScan.length > 0) {
+        result.cache_hits += 1;
+        continue;
+      }
+      const cachedProposal = await engine.executeRaw<{ id: number }>(
         `SELECT id FROM take_proposals
          WHERE source_id = $1 AND page_slug = $2 AND content_hash = $3 AND prompt_version = $4
          LIMIT 1`,
         [sourceId, page.slug, ch, promptVersion],
       );
-      if (cached.length > 0) {
+      if (cachedProposal.length > 0) {
         result.cache_hits += 1;
         continue;
       }
       result.cache_misses += 1;
+      if (dryRun) {
+        result.llm_calls_skipped += 1;
+        continue;
+      }
 
       // Budget pre-check before the LLM call. Estimate: ~1500 input tokens + 500 output.
       const budget = this.checkBudget({
@@ -384,16 +441,17 @@ class ProposeTakesPhase extends BaseCyclePhase {
         continue;
       }
 
-      // Write proposals to take_proposals. Each row is a separate INSERT
-      // because the composite idempotency key is on the per-page tuple — a
-      // bulk UPSERT would collapse a same-page-multi-claim run into one row.
+      // Write proposals to take_proposals. The scan cache owns per-page
+      // idempotency; the proposal queue dedups only identical claims from the
+      // same page/prompt so a single page can surface multiple distinct takes.
       for (const p of proposals) {
-        await engine.executeRaw(
+        const insertedRows = await engine.executeRaw<{ id: number }>(
           `INSERT INTO take_proposals
              (source_id, page_slug, content_hash, prompt_version, proposal_run_id,
               claim_text, kind, holder, weight, domain, dedup_against_fence_rows, model_id)
            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-           ON CONFLICT (source_id, page_slug, content_hash, prompt_version) DO NOTHING`,
+           ON CONFLICT (source_id, page_slug, content_hash, prompt_version, claim_text) DO NOTHING
+           RETURNING id`,
           [
             sourceId,
             page.slug,
@@ -409,8 +467,36 @@ class ProposeTakesPhase extends BaseCyclePhase {
             opts.model ?? 'claude-sonnet-4-6',
           ],
         );
-        result.proposals_inserted += 1;
+        result.proposals_inserted += insertedRows.length;
       }
+
+      // Cache every successful extractor call, including the common [] result.
+      // Failures above intentionally do not write here so transient model/API
+      // errors retry on a later cycle.
+      await engine.executeRaw(
+        `INSERT INTO take_proposal_page_scans
+           (source_id, page_slug, content_hash, prompt_version, proposal_run_id,
+            proposals_count, model_id, dedup_against_fence_rows)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         ON CONFLICT (source_id, page_slug, content_hash, prompt_version) DO UPDATE SET
+           scanned_at = now(),
+           proposal_run_id = EXCLUDED.proposal_run_id,
+           proposals_count = EXCLUDED.proposals_count,
+           model_id = EXCLUDED.model_id,
+           dedup_against_fence_rows = EXCLUDED.dedup_against_fence_rows`,
+        [
+          sourceId,
+          page.slug,
+          ch,
+          promptVersion,
+          proposalRunId,
+          proposals.length,
+          opts.model ?? 'claude-sonnet-4-6',
+          JSON.stringify(existingTakes),
+        ],
+      );
+      result.scan_cache_writes += 1;
+      if (proposals.length === 0) result.empty_results_cached += 1;
     }
 
     if (opts.reporter) opts.reporter.finish();

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -3713,6 +3713,83 @@ export const MIGRATIONS: Migration[] = [
         ON pages (last_retrieved_at);
     `,
   },
+  {
+    version: 80,
+    name: 'take_proposal_page_scans_v0_37_1_1',
+    // v0.37.1.1 — cost/idempotency fix for propose_takes.
+    //
+    // take_proposals is the operator-facing queue and cannot represent the
+    // valid extractor result [] without fabricating a pending proposal. The
+    // phase therefore needs a separate per-page successful-scan cache keyed on
+    // the same tuple: (source_id, page_slug, content_hash, prompt_version).
+    // With scan idempotency moved out of the queue, take_proposals can dedup by
+    // claim text instead of collapsing every same-page multi-claim run to one
+    // row. Successful scans with proposals write both tables; successful scans
+    // with zero proposals write only this table. Extractor failures deliberately
+    // do NOT write here so transient API/model errors retry later.
+    //
+    // Fresh installs get the same table from src/schema.sql + pglite-schema.ts.
+    idempotent: true,
+    sql: `
+      DROP INDEX IF EXISTS take_proposals_idempotency_idx;
+      CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_proposal_dedup_idx
+        ON take_proposals (source_id, page_slug, content_hash, prompt_version, claim_text);
+
+      CREATE TABLE IF NOT EXISTS take_proposal_page_scans (
+        source_id                   TEXT         NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+        page_slug                   TEXT         NOT NULL,
+        content_hash                TEXT         NOT NULL,
+        prompt_version              TEXT         NOT NULL,
+        wave_version                TEXT         NOT NULL DEFAULT 'v0.37.1.1',
+        scanned_at                  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+        proposal_run_id             TEXT         NOT NULL,
+        proposals_count             INTEGER      NOT NULL DEFAULT 0 CHECK (proposals_count >= 0),
+        model_id                    TEXT         NOT NULL,
+        dedup_against_fence_rows    JSONB,
+        PRIMARY KEY (source_id, page_slug, content_hash, prompt_version)
+      );
+      CREATE INDEX IF NOT EXISTS take_proposal_page_scans_recent_idx
+        ON take_proposal_page_scans (source_id, scanned_at DESC);
+      CREATE INDEX IF NOT EXISTS take_proposal_page_scans_run_id_idx
+        ON take_proposal_page_scans (proposal_run_id);
+
+      DO $$
+      DECLARE
+        has_bypass BOOLEAN;
+      BEGIN
+        SELECT rolbypassrls INTO has_bypass FROM pg_roles WHERE rolname = current_user;
+        IF NOT has_bypass THEN
+          RAISE EXCEPTION 'v80 take_proposal_page_scans_v0_37_1_1: role % does not have BYPASSRLS privilege — cannot enable RLS safely. Re-run as postgres (or another BYPASSRLS role). The migration will retry automatically on the next initSchema call.', current_user;
+        END IF;
+        ALTER TABLE take_proposal_page_scans ENABLE ROW LEVEL SECURITY;
+      END $$;
+    `,
+    sqlFor: {
+      pglite: `
+        DROP INDEX IF EXISTS take_proposals_idempotency_idx;
+        CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_proposal_dedup_idx
+          ON take_proposals (source_id, page_slug, content_hash, prompt_version, claim_text);
+
+        CREATE TABLE IF NOT EXISTS take_proposal_page_scans (
+          source_id                   TEXT         NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+          page_slug                   TEXT         NOT NULL,
+          content_hash                TEXT         NOT NULL,
+          prompt_version              TEXT         NOT NULL,
+          wave_version                TEXT         NOT NULL DEFAULT 'v0.37.1.1',
+          scanned_at                  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+          proposal_run_id             TEXT         NOT NULL,
+          proposals_count             INTEGER      NOT NULL DEFAULT 0 CHECK (proposals_count >= 0),
+          model_id                    TEXT         NOT NULL,
+          dedup_against_fence_rows    JSONB,
+          PRIMARY KEY (source_id, page_slug, content_hash, prompt_version)
+        );
+        CREATE INDEX IF NOT EXISTS take_proposal_page_scans_recent_idx
+          ON take_proposal_page_scans (source_id, scanned_at DESC);
+        CREATE INDEX IF NOT EXISTS take_proposal_page_scans_run_id_idx
+          ON take_proposal_page_scans (proposal_run_id);
+      `,
+    },
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -619,13 +619,31 @@ CREATE TABLE IF NOT EXISTS take_proposals (
   predicted_brier             REAL,
   predicted_brier_bucket_n    INTEGER
 );
-CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_idempotency_idx
-  ON take_proposals (source_id, page_slug, content_hash, prompt_version);
+CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_proposal_dedup_idx
+  ON take_proposals (source_id, page_slug, content_hash, prompt_version, claim_text);
 CREATE INDEX IF NOT EXISTS take_proposals_pending_idx
   ON take_proposals (source_id, status, proposed_at DESC)
   WHERE status = 'pending';
 CREATE INDEX IF NOT EXISTS take_proposals_run_id_idx
   ON take_proposals (proposal_run_id);
+
+CREATE TABLE IF NOT EXISTS take_proposal_page_scans (
+  source_id                   TEXT         NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+  page_slug                   TEXT         NOT NULL,
+  content_hash                TEXT         NOT NULL,
+  prompt_version              TEXT         NOT NULL,
+  wave_version                TEXT         NOT NULL DEFAULT 'v0.37.1.1',
+  scanned_at                  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  proposal_run_id             TEXT         NOT NULL,
+  proposals_count             INTEGER      NOT NULL DEFAULT 0 CHECK (proposals_count >= 0),
+  model_id                    TEXT         NOT NULL,
+  dedup_against_fence_rows    JSONB,
+  PRIMARY KEY (source_id, page_slug, content_hash, prompt_version)
+);
+CREATE INDEX IF NOT EXISTS take_proposal_page_scans_recent_idx
+  ON take_proposal_page_scans (source_id, scanned_at DESC);
+CREATE INDEX IF NOT EXISTS take_proposal_page_scans_run_id_idx
+  ON take_proposal_page_scans (proposal_run_id);
 
 CREATE TABLE IF NOT EXISTS take_grade_cache (
   take_id            BIGINT       NOT NULL,

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -946,9 +946,10 @@ CREATE INDEX IF NOT EXISTS calibration_profiles_published_idx
   ON calibration_profiles (source_id, published, holder)
   WHERE published = true;
 
--- take_proposals: propose_takes phase queue. Idempotency cache via the
--- composite unique index (source_id, page_slug, content_hash, prompt_version)
--- mirrors v0.23 dream_verdicts. proposal_run_id supports --rollback by run.
+-- take_proposals: propose_takes phase queue. Operator-facing rows only;
+-- successful per-page scan idempotency lives in take_proposal_page_scans so
+-- pages whose extractor result is [] are cached without polluting the queue.
+-- proposal_run_id supports --rollback by run.
 CREATE TABLE IF NOT EXISTS take_proposals (
   id                          BIGSERIAL PRIMARY KEY,
   source_id                   TEXT         NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
@@ -973,13 +974,34 @@ CREATE TABLE IF NOT EXISTS take_proposals (
   predicted_brier             REAL,
   predicted_brier_bucket_n    INTEGER
 );
-CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_idempotency_idx
-  ON take_proposals (source_id, page_slug, content_hash, prompt_version);
+CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_proposal_dedup_idx
+  ON take_proposals (source_id, page_slug, content_hash, prompt_version, claim_text);
 CREATE INDEX IF NOT EXISTS take_proposals_pending_idx
   ON take_proposals (source_id, status, proposed_at DESC)
   WHERE status = 'pending';
 CREATE INDEX IF NOT EXISTS take_proposals_run_id_idx
   ON take_proposals (proposal_run_id);
+
+-- take_proposal_page_scans: successful propose_takes extractor-call cache.
+-- Separate from take_proposals because [] is a valid, successful result and
+-- must not create a fake pending proposal just to make idempotency work.
+CREATE TABLE IF NOT EXISTS take_proposal_page_scans (
+  source_id                   TEXT         NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+  page_slug                   TEXT         NOT NULL,
+  content_hash                TEXT         NOT NULL,
+  prompt_version              TEXT         NOT NULL,
+  wave_version                TEXT         NOT NULL DEFAULT 'v0.37.1.1',
+  scanned_at                  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  proposal_run_id             TEXT         NOT NULL,
+  proposals_count             INTEGER      NOT NULL DEFAULT 0 CHECK (proposals_count >= 0),
+  model_id                    TEXT         NOT NULL,
+  dedup_against_fence_rows    JSONB,
+  PRIMARY KEY (source_id, page_slug, content_hash, prompt_version)
+);
+CREATE INDEX IF NOT EXISTS take_proposal_page_scans_recent_idx
+  ON take_proposal_page_scans (source_id, scanned_at DESC);
+CREATE INDEX IF NOT EXISTS take_proposal_page_scans_run_id_idx
+  ON take_proposal_page_scans (proposal_run_id);
 
 -- take_grade_cache: grade_takes verdict cache. Composite PK on
 -- (take_id, prompt_version, judge_model_id, evidence_signature) means
@@ -1105,6 +1127,7 @@ BEGIN
     -- v0.36.1.0 Hindsight calibration wave tables
     ALTER TABLE calibration_profiles ENABLE ROW LEVEL SECURITY;
     ALTER TABLE take_proposals ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE take_proposal_page_scans ENABLE ROW LEVEL SECURITY;
     ALTER TABLE take_grade_cache ENABLE ROW LEVEL SECURITY;
     ALTER TABLE take_nudge_log ENABLE ROW LEVEL SECURITY;
     -- v0.26 OAuth 2.1 tables

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -942,9 +942,10 @@ CREATE INDEX IF NOT EXISTS calibration_profiles_published_idx
   ON calibration_profiles (source_id, published, holder)
   WHERE published = true;
 
--- take_proposals: propose_takes phase queue. Idempotency cache via the
--- composite unique index (source_id, page_slug, content_hash, prompt_version)
--- mirrors v0.23 dream_verdicts. proposal_run_id supports --rollback by run.
+-- take_proposals: propose_takes phase queue. Operator-facing rows only;
+-- successful per-page scan idempotency lives in take_proposal_page_scans so
+-- pages whose extractor result is [] are cached without polluting the queue.
+-- proposal_run_id supports --rollback by run.
 CREATE TABLE IF NOT EXISTS take_proposals (
   id                          BIGSERIAL PRIMARY KEY,
   source_id                   TEXT         NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
@@ -969,13 +970,34 @@ CREATE TABLE IF NOT EXISTS take_proposals (
   predicted_brier             REAL,
   predicted_brier_bucket_n    INTEGER
 );
-CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_idempotency_idx
-  ON take_proposals (source_id, page_slug, content_hash, prompt_version);
+CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_proposal_dedup_idx
+  ON take_proposals (source_id, page_slug, content_hash, prompt_version, claim_text);
 CREATE INDEX IF NOT EXISTS take_proposals_pending_idx
   ON take_proposals (source_id, status, proposed_at DESC)
   WHERE status = 'pending';
 CREATE INDEX IF NOT EXISTS take_proposals_run_id_idx
   ON take_proposals (proposal_run_id);
+
+-- take_proposal_page_scans: successful propose_takes extractor-call cache.
+-- Separate from take_proposals because [] is a valid, successful result and
+-- must not create a fake pending proposal just to make idempotency work.
+CREATE TABLE IF NOT EXISTS take_proposal_page_scans (
+  source_id                   TEXT         NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+  page_slug                   TEXT         NOT NULL,
+  content_hash                TEXT         NOT NULL,
+  prompt_version              TEXT         NOT NULL,
+  wave_version                TEXT         NOT NULL DEFAULT 'v0.37.1.1',
+  scanned_at                  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  proposal_run_id             TEXT         NOT NULL,
+  proposals_count             INTEGER      NOT NULL DEFAULT 0 CHECK (proposals_count >= 0),
+  model_id                    TEXT         NOT NULL,
+  dedup_against_fence_rows    JSONB,
+  PRIMARY KEY (source_id, page_slug, content_hash, prompt_version)
+);
+CREATE INDEX IF NOT EXISTS take_proposal_page_scans_recent_idx
+  ON take_proposal_page_scans (source_id, scanned_at DESC);
+CREATE INDEX IF NOT EXISTS take_proposal_page_scans_run_id_idx
+  ON take_proposal_page_scans (proposal_run_id);
 
 -- take_grade_cache: grade_takes verdict cache. Composite PK on
 -- (take_id, prompt_version, judge_model_id, evidence_signature) means
@@ -1101,6 +1123,7 @@ BEGIN
     -- v0.36.1.0 Hindsight calibration wave tables
     ALTER TABLE calibration_profiles ENABLE ROW LEVEL SECURITY;
     ALTER TABLE take_proposals ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE take_proposal_page_scans ENABLE ROW LEVEL SECURITY;
     ALTER TABLE take_grade_cache ENABLE ROW LEVEL SECURITY;
     ALTER TABLE take_nudge_log ENABLE ROW LEVEL SECURITY;
     -- v0.26 OAuth 2.1 tables

--- a/test/propose-takes-cache-schema.test.ts
+++ b/test/propose-takes-cache-schema.test.ts
@@ -1,0 +1,41 @@
+/**
+ * v0.37.1.1 — propose_takes scan-cache schema regression tests.
+ *
+ * The phase's cost bug was structural: `take_proposals` doubled as both the
+ * operator-facing proposal queue and the per-page idempotency cache. That cannot
+ * represent the successful zero-proposal result (`[]`). These tests pin the
+ * schema split so future refactors cannot silently collapse the two surfaces
+ * again.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { MIGRATIONS } from '../src/core/migrate.ts';
+import { SCHEMA_SQL } from '../src/core/schema-embedded.ts';
+import { PGLITE_SCHEMA_SQL } from '../src/core/pglite-schema.ts';
+
+describe('propose_takes scan-cache schema', () => {
+  test('migration creates scan cache and moves proposal dedup to claim_text', () => {
+    const migration = MIGRATIONS.find(m => m.name === 'take_proposal_page_scans_v0_37_1_1');
+    expect(migration).toBeDefined();
+    expect(migration!.version).toBe(80);
+    expect(migration!.sql).toContain('DROP INDEX IF EXISTS take_proposals_idempotency_idx');
+    expect(migration!.sql).toContain('CREATE TABLE IF NOT EXISTS take_proposal_page_scans');
+    expect(migration!.sql).toContain('PRIMARY KEY (source_id, page_slug, content_hash, prompt_version)');
+    expect(migration!.sql).toContain('take_proposals_proposal_dedup_idx');
+    expect(migration!.sql).toContain('(source_id, page_slug, content_hash, prompt_version, claim_text)');
+    expect(migration!.sql).toContain('ALTER TABLE take_proposal_page_scans ENABLE ROW LEVEL SECURITY');
+  });
+
+  test('fresh Postgres schema contains the same split', () => {
+    expect(SCHEMA_SQL).toContain('CREATE TABLE IF NOT EXISTS take_proposal_page_scans');
+    expect(SCHEMA_SQL).toContain('take_proposals_proposal_dedup_idx');
+    expect(SCHEMA_SQL).toContain('ALTER TABLE take_proposal_page_scans ENABLE ROW LEVEL SECURITY');
+    expect(SCHEMA_SQL).not.toContain('take_proposals_idempotency_idx');
+  });
+
+  test('fresh PGLite schema contains the same split', () => {
+    expect(PGLITE_SCHEMA_SQL).toContain('CREATE TABLE IF NOT EXISTS take_proposal_page_scans');
+    expect(PGLITE_SCHEMA_SQL).toContain('take_proposals_proposal_dedup_idx');
+    expect(PGLITE_SCHEMA_SQL).not.toContain('take_proposals_idempotency_idx');
+  });
+});

--- a/test/propose-takes.test.ts
+++ b/test/propose-takes.test.ts
@@ -18,6 +18,8 @@ import { describe, test, expect } from 'bun:test';
 import {
   runPhaseProposeTakes,
   parseExtractorOutput,
+  parseExtractorOutputDetailed,
+  parseExtractorOutputStrict,
   contentHash,
   hasCompleteFence,
   extractExistingTakesForDedup,
@@ -39,9 +41,12 @@ interface CapturedSql {
 function buildMockEngine(opts: {
   pages: Page[];
   existingProposals?: Set<string>; // composite-key strings already in take_proposals
+  existingPageScans?: Set<string>; // composite-key strings already in take_proposal_page_scans
 }): { engine: BrainEngine; captured: CapturedSql[] } {
   const captured: CapturedSql[] = [];
   const existing = opts.existingProposals ?? new Set<string>();
+  const pageScans = opts.existingPageScans ?? new Set<string>();
+  const proposalRows = new Set<string>();
 
   const engine = {
     kind: 'pglite',
@@ -57,7 +62,28 @@ function buildMockEngine(opts: {
         if (existing.has(key)) return [{ id: 1 } as unknown as T];
         return [];
       }
-      // INSERT — return nothing
+      // SELECT idempotency check for successful scans, including zero-proposal scans.
+      if (sql.includes('FROM take_proposal_page_scans')) {
+        const [sourceId, slug, ch, pv] = params ?? [];
+        const key = `${sourceId}|${slug}|${ch}|${pv}`;
+        if (pageScans.has(key)) return [{ id: 1 } as unknown as T];
+        return [];
+      }
+      // INSERT proposal queue rows. Mirror ON CONFLICT ... DO NOTHING RETURNING id.
+      if (sql.includes('INSERT INTO take_proposals')) {
+        const [sourceId, slug, ch, pv, _runId, claimText] = params ?? [];
+        const key = `${sourceId}|${slug}|${ch}|${pv}|${claimText}`;
+        if (proposalRows.has(key)) return [];
+        proposalRows.add(key);
+        return [{ id: proposalRows.size } as unknown as T];
+      }
+      // INSERT successful page-scan cache rows.
+      if (sql.includes('INSERT INTO take_proposal_page_scans')) {
+        const [sourceId, slug, ch, pv] = params ?? [];
+        pageScans.add(`${sourceId}|${slug}|${ch}|${pv}`);
+        return [];
+      }
+      // Other statements return nothing
       return [];
     },
   } as unknown as BrainEngine;
@@ -130,6 +156,28 @@ describe('parseExtractorOutput', () => {
   test('returns [] on malformed JSON without throwing', () => {
     expect(parseExtractorOutput('[not valid json')).toEqual([]);
     expect(parseExtractorOutput('completely unrelated prose')).toEqual([]);
+  });
+
+  test('detailed parser distinguishes literal JSON [] from malformed output', () => {
+    expect(parseExtractorOutputDetailed('[]')).toEqual({ ok: true, proposals: [] });
+    expect(parseExtractorOutputDetailed('[not valid json')).toEqual({ ok: false, proposals: [] });
+    expect(parseExtractorOutputDetailed('completely unrelated prose')).toEqual({ ok: false, proposals: [] });
+    expect(parseExtractorOutputDetailed('')).toEqual({ ok: false, proposals: [] });
+  });
+
+  test('detailed parser rejects parseable but wrong-shape JSON', () => {
+    expect(parseExtractorOutputDetailed('{"claims":[]}')).toEqual({ ok: false, proposals: [] });
+    expect(parseExtractorOutputDetailed('[{"claim":"missing claim_text"}]')).toEqual({ ok: false, proposals: [] });
+    expect(parseExtractorOutputDetailed('[{"claim_text":"valid"},{"claim":"ignored"}]')).toEqual({
+      ok: true,
+      proposals: [{ claim_text: 'valid', kind: 'take', holder: 'brain', weight: 0.5, domain: undefined }],
+    });
+  });
+
+  test('strict parser throws on malformed model output so callers do not cache it', () => {
+    expect(() => parseExtractorOutputStrict('completely unrelated prose')).toThrow('extractor returned malformed JSON');
+    expect(() => parseExtractorOutputStrict('{"claims":[]}')).toThrow('extractor returned malformed JSON');
+    expect(parseExtractorOutputStrict('[]')).toEqual([]);
   });
 
   test('drops rows without claim_text and rows over 500 chars', () => {
@@ -257,12 +305,37 @@ describe('runPhaseProposeTakes — phase integration', () => {
     expect(details.cache_misses).toBe(1);
     expect(details.cache_hits).toBe(0);
     expect(details.proposals_inserted).toBe(1);
+    expect(details.scan_cache_writes).toBe(1);
+
+    const scanCacheSelect = captured.find(c => c.sql.includes('FROM take_proposal_page_scans'));
+    expect(scanCacheSelect?.sql).toContain('SELECT 1');
+    expect(scanCacheSelect?.sql).not.toContain('SELECT id');
 
     const inserts = captured.filter(c => c.sql.includes('INSERT INTO take_proposals'));
     expect(inserts).toHaveLength(1);
     expect(inserts[0]!.params[5]).toBe('Marketplaces with cold-start liquidity win'); // claim_text
     expect(inserts[0]!.params[6]).toBe('bet'); // kind
     expect(inserts[0]!.params[9]).toBe('market'); // domain
+  });
+
+  test('same-page distinct proposals are queued separately; duplicate claims are not counted as inserted', async () => {
+    const pages = [buildPage({ slug: 'wiki/multiple-claims', body: 'Two gradeable claims in one page.' })];
+    const { engine, captured } = buildMockEngine({ pages });
+    const extractor: ProposeTakesExtractor = async () => [
+      { claim_text: 'first distinct claim', kind: 'take', holder: 'brain', weight: 0.55 },
+      { claim_text: 'second distinct claim', kind: 'bet', holder: 'brain', weight: 0.7 },
+      { claim_text: 'first distinct claim', kind: 'take', holder: 'brain', weight: 0.55 },
+    ];
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    const proposalInserts = captured.filter(c => c.sql.includes('INSERT INTO take_proposals'));
+    expect(proposalInserts).toHaveLength(3);
+    expect(proposalInserts[0]!.sql).toContain('ON CONFLICT (source_id, page_slug, content_hash, prompt_version, claim_text) DO NOTHING');
+    expect(proposalInserts[0]!.sql).toContain('RETURNING id');
+    expect(proposalInserts.map(i => i.params[5])).toEqual(['first distinct claim', 'second distinct claim', 'first distinct claim']);
+    expect((result.details as Record<string, unknown>).proposals_inserted).toBe(2);
+    expect(captured.filter(c => c.sql.includes('INSERT INTO take_proposal_page_scans'))).toHaveLength(1);
   });
 
   test('cache hit: page already in take_proposals is skipped', async () => {
@@ -283,6 +356,66 @@ describe('runPhaseProposeTakes — phase integration', () => {
     expect(details.cache_hits).toBe(1);
     expect(details.proposals_inserted).toBe(0);
     expect(captured.filter(c => c.sql.includes('INSERT'))).toHaveLength(0);
+  });
+
+  test('dry-run skips extractor calls and writes while reporting cache misses', async () => {
+    const body = 'Dry-run should inspect the page but not spend tokens or write cache rows.';
+    const pages = [buildPage({ slug: 'wiki/dry-run', body })];
+    const { engine, captured } = buildMockEngine({ pages });
+    let extractorCalls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      extractorCalls++;
+      return [{ claim_text: 'should never be produced', kind: 'take', holder: 'brain', weight: 0.5 }];
+    };
+    const ctx = buildCtx(engine);
+    ctx.dryRun = true;
+
+    const result = await runPhaseProposeTakes(ctx, { extractor });
+
+    expect(extractorCalls).toBe(0);
+    const details = result.details as Record<string, unknown>;
+    expect(details.dry_run).toBe(true);
+    expect(details.cache_misses).toBe(1);
+    expect(details.llm_calls_skipped).toBe(1);
+    expect(details.proposals_inserted).toBe(0);
+    expect(details.scan_cache_writes).toBe(0);
+    expect(captured.filter(c => c.sql.includes('INSERT'))).toHaveLength(0);
+  });
+
+  test('empty extractor result is cached so unchanged pages do not re-spend LLM calls', async () => {
+    const body = 'This page has prose, but no gradeable claims.';
+    const pages = [buildPage({ slug: 'wiki/no-claims', body })];
+    const { engine, captured } = buildMockEngine({ pages });
+    let extractorCalls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      extractorCalls++;
+      return [];
+    };
+
+    const first = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+    const second = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    expect(extractorCalls).toBe(1);
+    expect((first.details as Record<string, unknown>).cache_misses).toBe(1);
+    expect((second.details as Record<string, unknown>).cache_hits).toBe(1);
+    expect(captured.filter(c => c.sql.includes('INSERT INTO take_proposal_page_scans'))).toHaveLength(1);
+    expect(captured.filter(c => c.sql.includes('INSERT INTO take_proposals'))).toHaveLength(0);
+  });
+
+  test('extractor failures are not cached, so transient LLM errors retry later', async () => {
+    const pages = [buildPage({ slug: 'wiki/transient-failure', body: 'retryable prose' })];
+    const { engine, captured } = buildMockEngine({ pages });
+    let extractorCalls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      extractorCalls++;
+      throw new Error('temporary upstream timeout');
+    };
+
+    await runPhaseProposeTakes(buildCtx(engine), { extractor });
+    await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    expect(extractorCalls).toBe(2);
+    expect(captured.filter(c => c.sql.includes('INSERT INTO take_proposal_page_scans'))).toHaveLength(0);
   });
 
   test('passes existing fence rows to extractor as dedup context (F2 fix)', async () => {


### PR DESCRIPTION
## Summary

`propose_takes` used `take_proposals` as both the operator-facing queue and the per-page idempotency cache. That works only when the extractor produces at least one proposal. The valid result `[]` left no row behind, so unchanged pages could re-spend extractor tokens every autopilot cycle.

This PR splits those two jobs:

- adds `take_proposal_page_scans` as the successful extractor-call cache, keyed by `(source_id, page_slug, content_hash, prompt_version)` and written even for `[]`
- keeps `take_proposals` as proposal rows only, with dedup moved to `(source_id, page_slug, content_hash, prompt_version, claim_text)` so same-page multi-claim output is not collapsed
- treats malformed or wrong-shape extractor output as retryable failure instead of caching it as empty success
- threads `dryRun` into `propose_takes` so dry runs do not call the LLM or write proposal/cache rows
- adds migration v80 plus fresh Postgres/PGLite schema coverage, including explicit Postgres RLS enablement for the new cache table

## Test Coverage

- `bun test ./test/propose-takes.test.ts ./test/propose-takes-cache-schema.test.ts`
- `bun test ./test/schema-bootstrap-coverage.test.ts ./test/propose-takes.test.ts ./test/propose-takes-cache-schema.test.ts`
- `bun run typecheck`
- `bun run check:all`
- `bun run build`
- `git diff --cached --check`

`bun run ci:local:diff` could not run in this environment because Docker is not installed (`docker: command not found`). The diff-aware gate reached Docker startup before failing.

## Pre-Landing Review

Two independent review passes were run before opening this PR. The first review found two blockers — wrong-shape JSON could still be cached as `[]`, and the new cache table needed explicit RLS coverage — plus an insert-count nit. This version fixes all three:

1. strict production parsing now throws on malformed/wrong-shape output, while literal JSON `[]` remains a valid cacheable empty result
2. migration v80 and fresh schema SQL enable RLS for `take_proposal_page_scans` on Postgres, with a PGLite override for the local engine
3. proposal inserts use `RETURNING id`, so `proposals_inserted` reflects rows actually inserted after `ON CONFLICT DO NOTHING`

The second review passed with no blocking findings.
