### PR TITLE
Improve facts extraction observability

### DIFF
--- a/src/core/entities/resolve.ts
+++ b/src/core/entities/resolve.ts
@@ -47,11 +47,14 @@ export async function resolveEntitySlug(
   const trimmed = raw.trim();
   if (!trimmed) return null;
 
-  // 1. Exact match on slug. If raw already looks like a slug (or matches
-  //    a row exactly), use it.
+  // 1. Exact match on slug. If raw already carries a directory prefix
+  //    (`people/alice`, `projects/gbrain`), preserve it even before a page
+  //    row exists so fact extraction can fence-write to the intended page
+  //    instead of collapsing `/` to `-` via slugify fallback.
   if (looksLikeSlug(trimmed)) {
     const exact = await tryExactSlug(engine, source_id, trimmed);
     if (exact) return exact;
+    if (trimmed.includes('/')) return trimmed;
   }
 
   // 2. Fuzzy match against existing pages within the source. Match either

--- a/src/core/facts/absorb-log.ts
+++ b/src/core/facts/absorb-log.ts
@@ -17,6 +17,8 @@
  *   - 'queue_overflow'  — getFactsQueue() cap hit; oldest entry dropped.
  *   - 'queue_shutdown'  — queue rejected the enqueue because shutdown is in progress.
  *   - 'embed_failure'   — gateway down on embedOne; row inserts with NULL embedding.
+ *   - 'gateway_unavailable' — no configured chat gateway, so extractor cannot run.
+ *   - 'no_candidates'    — extractor ran successfully but returned/retained no facts.
  *   - 'pipeline_error'  — anything else absorbed inside runFactsBackstop's catch.
  *   - eligibility_skip is intentionally NOT logged (high cardinality, low signal).
  *
@@ -33,6 +35,8 @@ export const FACTS_ABSORB_REASONS = [
   'queue_overflow',
   'queue_shutdown',
   'embed_failure',
+  'gateway_unavailable',
+  'no_candidates',
   'pipeline_error',
 ] as const;
 

--- a/src/core/facts/backstop.ts
+++ b/src/core/facts/backstop.ts
@@ -296,6 +296,7 @@ async function runPipelineWithBody(
     sessionId: ctx.sessionId,
     entityHints: ctx.entityHints,
     source: ctx.source,
+    sourceId: ctx.sourceId,
     isDreamGenerated: input.isDreamGenerated,
     engine: ctx.engine,
     abortSignal,

--- a/src/core/facts/extract.ts
+++ b/src/core/facts/extract.ts
@@ -27,6 +27,7 @@ import { INJECTION_PATTERNS } from '../think/sanitize.ts';
 import { resolveModel } from '../model-config.ts';
 import type { BrainEngine, NewFact, FactKind } from '../engine.ts';
 import { normalizeMetricLabel } from './extract-from-fence.ts';
+import { classifyFactsAbsorbError, writeFactsAbsorbLog } from './absorb-log.ts';
 
 /**
  * v0.31 (D15): kill-switch for fact extraction.
@@ -77,6 +78,8 @@ export interface ExtractInput {
   entityHints?: string[];
   /** Source identifier for provenance — e.g. 'mcp:put_page' or 'mcp:extract_facts'. */
   source: string;
+  /** Brain source_id for observability rows. Defaults to 'default'. */
+  sourceId?: string;
   /**
    * Set by the caller when this turn is a dream-generated page body.
    * If true, extraction is skipped to break the consume-own-output loop.
@@ -154,14 +157,19 @@ export async function extractFactsFromTurn(input: ExtractInput): Promise<Extract
   cleaned = cleaned.trim();
   if (!cleaned) return [];
 
-  if (!isAvailable('chat')) {
-    // No chat gateway → no extraction. Caller still inserts facts via direct
-    // `gbrain take add` paths.
-    return [];
-  }
-
   const cap = Math.max(1, Math.min(input.maxFactsPerTurn ?? 10, 25));
   const defaultModel = await getFactsExtractionModel(input.engine);
+
+  if (!isAvailable('chat', input.model ?? defaultModel)) {
+    // No chat gateway for the facts extraction model → no extraction. Caller
+    // still inserts facts via direct `gbrain take add` paths.
+    await logExtractionAbsorb(
+      input,
+      'gateway_unavailable',
+      `chat gateway unavailable for ${input.model ?? defaultModel}`,
+    );
+    return [];
+  }
   let result: ChatResult;
   try {
     result = await chat({
@@ -184,13 +192,17 @@ export async function extractFactsFromTurn(input: ExtractInput): Promise<Extract
     // Re-throw aborts; absorb other errors as "no extraction" — caller's
     // `put_page` backstop will still record the page itself.
     if (isAbort(err)) throw err;
+    await logExtractionAbsorb(input, classifyFactsAbsorbError(err), err instanceof Error ? err.message : String(err));
     return [];
   }
 
   if (result.stopReason === 'refusal' || result.stopReason === 'content_filter') return [];
 
   const parsedRaw = parseExtractorJson(result.text);
-  if (!parsedRaw) return [];
+  if (!parsedRaw) {
+    await logExtractionAbsorb(input, 'parse_failure', `unparseable extractor response from ${result.model ?? 'unknown-model'}`);
+    return [];
+  }
 
   const facts: ExtractedFact[] = [];
   for (const candidate of parsedRaw.slice(0, cap)) {
@@ -220,6 +232,7 @@ export async function extractFactsFromTurn(input: ExtractInput): Promise<Extract
       if (isAbort(err)) throw err;
       // Gateway-down → NULL embedding; classifier still runs without
       // fast-path. (eE8 distinction.)
+      await logExtractionAbsorb(input, 'embed_failure', err instanceof Error ? err.message : String(err));
       embedding = null;
     }
 
@@ -248,7 +261,25 @@ export async function extractFactsFromTurn(input: ExtractInput): Promise<Extract
     });
   }
 
+  if (facts.length === 0) {
+    await logExtractionAbsorb(
+      input,
+      'no_candidates',
+      `extractor candidates=${parsedRaw.length}; retained=0`,
+    );
+  }
+
   return facts;
+}
+
+async function logExtractionAbsorb(
+  input: ExtractInput,
+  reason: Parameters<typeof writeFactsAbsorbLog>[2],
+  detail: string,
+): Promise<void> {
+  if (!input.engine) return;
+  const ref = input.sessionId ?? input.source ?? 'facts-extract';
+  await writeFactsAbsorbLog(input.engine, ref, reason, detail, input.sourceId ?? 'default');
 }
 
 interface RawExtracted {

--- a/test/facts-backstop-integration.test.ts
+++ b/test/facts-backstop-integration.test.ts
@@ -97,7 +97,7 @@ describe('runFactsPipeline (extract_facts MCP op path) — response shape stabil
     }
   });
 
-  test('empty extraction → zero counts (no NaN, no undefined)', async () => {
+  test('empty extraction → zero counts plus observable no_candidates log', async () => {
     chatStub([]);
     const r = await runFactsPipeline('nothing claim-worthy here', {
       engine,
@@ -109,6 +109,15 @@ describe('runFactsPipeline (extract_facts MCP op path) — response shape stabil
     expect(r.duplicate).toBe(0);
     expect(r.superseded).toBe(0);
     expect(r.fact_ids).toEqual([]);
+
+    const logs = await engine.getIngestLog({ limit: 100 });
+    const matching = logs.filter(row =>
+      row.source_type === 'facts:absorb'
+      && row.source_id === 'default'
+      && row.source_ref === 'empty-test'
+      && row.summary.startsWith('no_candidates:'),
+    );
+    expect(matching.length).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -252,8 +261,15 @@ describe('queue-mode → drains successfully on happy path', () => {
       expect(r.duplicate).toBe(0);
     }
 
-    // Note for future work: writeFactsAbsorbLog from extract.ts itself
-    // would close this visibility gap — surface gateway errors via
-    // ingest_log without changing extract's "best-effort" return contract.
+    // extract.ts now logs absorbed gateway errors so zero-count envelopes
+    // are observable in doctor/admin surfaces instead of going silent.
+    const logs = await engine.getIngestLog({ limit: 100 });
+    const matching = logs.filter(row =>
+      row.source_type === 'facts:absorb'
+      && row.source_id === 'silent-source'
+      && row.source_ref === 'silent-session'
+      && row.summary.startsWith('gateway_error:'),
+    );
+    expect(matching.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/test/facts-canonicality.test.ts
+++ b/test/facts-canonicality.test.ts
@@ -53,7 +53,12 @@ describe('resolveEntitySlug', () => {
     expect(result).toBe('people/alice-example');
   });
 
-  test('non-matching but slug-shaped → falls through to slugify', async () => {
+  test('prefixed slug-shaped input is preserved even before a page exists', async () => {
+    const result = await resolveEntitySlug(engine, 'default', 'projects/gbrain');
+    expect(result).toBe('projects/gbrain');
+  });
+
+  test('non-matching bare slug-shaped input still falls through to slugify', async () => {
     // Doesn't match a row but is slug-shaped: still goes through fuzzy
     // pipeline; without a match, slugify normalizes.
     const result = await resolveEntitySlug(engine, 'default', 'unknown-thing-xyz');


### PR DESCRIPTION
## Summary

- make facts extraction check availability for the configured extraction model instead of the default chat model
- log absorbed zero-insert paths (`gateway_unavailable`, `no_candidates`) to `ingest_log` via `facts:absorb`
- pass `sourceId` through the facts backstop path so observability rows are source-scoped
- preserve prefixed slug-shaped entity hints like `projects/gbrain` so facts can fence-write to the intended slug instead of collapsing to `projects-gbrain`

## Why

When the default chat model is unavailable but `facts.extraction_model` is configured to an available model, extraction currently short-circuits and returns zero facts silently. That makes hot-memory failures look like conservative extraction rather than an observable config/runtime issue.

The prefixed-slug fix addresses another hot-memory routing issue: callers can provide a canonical entity hint such as `projects/gbrain`, but the resolver falls through to `slugify()` when no page exists yet, producing `projects-gbrain` and missing the intended fence path.

## Tests

```bash
bun test test/facts-canonicality.test.ts test/facts-backstop-integration.test.ts
```

Result: 17 pass, 0 fail, 47 expectations.

Also live-smoked locally with `facts.extraction_model=openai:gpt-4o-mini`: `extract_facts` inserted and recalled a temporary fact under `entity_slug=projects/gbrain`; cleanup used `forget_fact` and active recall returned no facts.
