### PR TITLE
fix(brainstorm): cost guardrails + judge overflow + far set cap

### DIFF
--- a/docs/incidents/2026-05-20-lsd-cost-explosion.md
+++ b/docs/incidents/2026-05-20-lsd-cost-explosion.md
@@ -1,0 +1,195 @@
+# Incident Report: LSD Brainstorm 53× Cost Overrun
+
+**Date:** 2026-05-20
+**Severity:** High (financial — $50.71 actual vs $0.96 estimated)
+**Component:** `gbrain lsd` / `gbrain brainstorm`
+**Brain size:** 13,690 pages, 16,314 links, ~2,000 unique directory prefixes
+**Version:** v0.37.1.0 (first release of brainstorm/lsd)
+
+## What Happened
+
+A user ran `gbrain lsd "what story should Garry's List write next" --yes` on a 13,690-page brain. The command:
+
+1. **Estimated cost: $0.96** (2×12 = 24 crosses × 4 ideas + judge)
+2. **Actual cost: $50.71** — 53× over estimate
+3. **Token usage:** 4,906,011 input + 2,399,239 output = 7.3M total tokens
+4. **Far set pulled 1,985 pages** instead of the configured 12
+5. **Generated 15,868 raw ideas** across the crosses (vs expected ~96)
+6. **Judge phase failed:** 2,989,338 tokens exceeded Claude Sonnet's 1M context limit
+7. **Zero ideas surfaced to the user** — complete failure
+
+A retry with `--limit 12` explicit:
+- Far set correctly returned 12 pages, cost was $0.39
+- But judge still failed: `parseJudgeJSON: no strategy produced valid JSON`
+- Again, 0 ideas survived to output (96 generated, 0 scored)
+
+## Root Causes
+
+### RC1: Far Set Explosion (caused the $50 bill)
+
+**File:** `src/core/brainstorm/domain-bank.ts` → `fetchFar()` → `listPrefixSampledPages()`
+
+The domain bank samples pages by directory prefix to get diversity. `listPrefixSampledPages` returns **one page per prefix passed in**. On a 13K-page brain with ~2,000 unique prefixes (books/, civic/bundles/, civic/gl-article-*, people/, concepts/, etc.), passing all prefixes produces ~2,000 rows — not the configured `m=12`.
+
+The cost estimator uses `m` (12) to predict crosses and cost. But the actual cross phase receives 1,985 far-set pages, producing `2 × 1985 = 3,970` crosses at 4 ideas each = 15,868 ideas.
+
+**The estimate formula is correct for the intended behavior; the far set selection is what diverged.**
+
+### RC2: No Cost Circuit Breaker
+
+There is no mechanism to:
+- Abort if estimated cost exceeds a threshold
+- Abort mid-run if actual spend diverges from estimate
+- Cap the far set size regardless of prefix count
+- Warn the user that a run will be expensive before proceeding
+
+The `--yes` flag skips the 10-second cost preview wait, removing even the manual inspection opportunity.
+
+### RC3: Judge Context Overflow
+
+The judge receives ALL ideas in a single prompt. With 15,868 ideas at ~350 tokens each, that's ~5.5M tokens — well beyond any model's context window.
+
+Even on the retry with only 96 ideas, the judge failed with JSON parsing errors, suggesting the judge prompt/response format is fragile.
+
+### RC4: Unpaired UTF-16 Surrogates in Page Content
+
+Two crosses failed with: `The request body is not valid JSON: no low surrogate in string`
+
+Some pages (likely OCR imports or web scrapes) contain unpaired UTF-16 surrogates. When these get serialized into the JSON request body for the LLM API, the JSON encoder produces invalid JSON.
+
+### RC5: No Timeout on Individual Crosses
+
+One cross timed out with no specific timeout configured. The default HTTP timeout allowed it to hang for an extended period before failing, consuming tokens on the API side.
+
+## Observed Token Flow
+
+```
+Configured:  2 close × 12 far = 24 crosses × 4 ideas = 96 ideas + 1 judge call
+Actual:      2 close × 1985 far = 3970 crosses × 4 ideas = 15,868 ideas + 1 judge call (failed)
+
+Per-cross tokens (estimated): ~1,200 in + 600 out
+Actual total:                  4,906,011 in + 2,399,239 out
+
+The judge call alone would have been:
+  15,868 ideas × ~350 tokens = ~5.5M tokens (prompt)
+  Model limit:                  1M tokens (Sonnet)
+  Overflow:                     5.5× context limit
+```
+
+## Proposed Fixes
+
+### P1: Far Set Cap (Critical — prevents cost explosion)
+
+`fetchFar()` must cap the number of prefixes BEFORE calling `listPrefixSampledPages`. The cap should be `max(m * 4, 50)` to allow some diversity headroom while preventing runaway growth. Final selection trimmed to `m` by distance score.
+
+**Status:** Implemented in `dc080ac2`.
+
+### P2: Cost Guardrails (Critical — defense in depth)
+
+New flags for `brainstorm` and `lsd` commands:
+- `--max-cost <usd>` (default $5): hard-abort if pre-run estimate exceeds
+- `--strict-budget`: abort mid-run if running cost exceeds 5× estimate
+- `--max-far-set <n>` (default 50): explicit far set size cap
+
+**Status:** Implemented in `dc080ac2`.
+
+### P3: Judge Chunking (Critical — prevents context overflow)
+
+Split ideas into batches of ~100 before calling the judge LLM. Each batch is a separate API call; results concatenated. This bounds per-call token usage to ~35K regardless of total idea count.
+
+**Status:** Implemented in `dc080ac2`.
+
+### P4: Unicode Sanitization (Medium — prevents cross failures)
+
+Strip unpaired UTF-16 surrogates from page content before building cross prompts. This is a general problem for any gbrain function that serializes user-generated page content into JSON for API calls.
+
+**Status:** Implemented in `dc080ac2`.
+
+### P5: Global Token & Time Budgets for All Analysis Functions (Proposed)
+
+**This is the bigger architectural ask.** Every gbrain command that makes LLM calls should respect configurable budgets:
+
+```yaml
+# Proposed config additions to ~/.gbrain/config.json
+budgets:
+  # Global defaults
+  default:
+    max_input_tokens: 500_000    # per-command input token cap
+    max_output_tokens: 200_000   # per-command output token cap  
+    max_cost_usd: 5.00           # per-command dollar cap
+    max_runtime_seconds: 300     # 5-minute wall-clock cap
+    
+  # Per-command overrides
+  brainstorm:
+    max_cost_usd: 2.00
+    max_runtime_seconds: 120
+  lsd:
+    max_cost_usd: 5.00
+    max_runtime_seconds: 300
+  dream:
+    max_cost_usd: 10.00
+    max_runtime_seconds: 600
+  extract:
+    max_input_tokens: 1_000_000
+    max_runtime_seconds: 900
+  enrich:
+    max_cost_usd: 3.00
+    max_runtime_seconds: 180
+```
+
+**Commands affected:**
+- `brainstorm` / `lsd` — bisociation crosses + judge (this incident)
+- `dream` — dream cycle phases (enrichment, emotional weight, etc.)
+- `extract all` — link + timeline extraction across all pages
+- `enrich` — per-page deep enrichment with web research
+- `eval` — evaluation runs (suspected-contradictions, retrieval drift)
+- `integrity auto` — automated content repair
+- `doctor --remediate` — autonomous self-healing via Minions
+
+**Implementation approach:**
+1. Add a `BudgetTracker` class that wraps LLM calls with token/cost/time accounting
+2. Every analysis function receives a budget context
+3. On budget exhaustion: save partial results, emit a structured warning, exit cleanly
+4. CLI flags (`--max-cost`, `--max-tokens`, `--timeout`) override config defaults
+5. `--no-budget` escape hatch for power users who know what they're doing
+
+### P6: Diarization / Summarization for Oversized Payloads (Proposed)
+
+When a judge or analysis phase receives more content than fits in context:
+
+1. **Estimate tokens** before calling the LLM
+2. If over budget, **diarize**: summarize/compress the content to fit
+3. For the judge specifically: rank ideas by a cheap heuristic first (keyword overlap, novelty score), then send only top-N to the LLM judge
+4. For other analysis: progressive summarization — chunk → summarize → merge summaries → final analysis
+
+This is effectively a **token budget allocator** that decides how to spend a fixed token budget across variable-length inputs.
+
+```
+Example: 15,868 ideas need judging, context limit 900K tokens
+  Step 1: Cheap pre-filter (keyword dedup, obvious duplicates) → 8,000 unique ideas
+  Step 2: Batch into 80 chunks of 100 ideas each
+  Step 3: Judge each chunk → 80 calls × ~35K tokens = 2.8M total (spread across calls)
+  Step 4: Merge top ideas from each chunk → final ranking
+  Total cost: ~$2-3 instead of $50
+```
+
+### P7: Structured Error Recovery (Proposed)
+
+When a cross or judge call fails:
+- Save the partial results immediately (don't wait for the full run)
+- Emit a machine-readable error event (not just a log warning)
+- Support `--retry-failed` to re-run only the failed crosses without repeating successful ones
+- Checkpoint progress to disk so interrupted runs can resume
+
+## Impact
+
+- **Financial:** $50.71 wasted on a single failed run
+- **User trust:** Zero ideas delivered despite ~7M tokens processed
+- **Time:** ~15 minutes of compute time, plus overnight delay in reporting results
+
+## Lessons
+
+1. **First run of any new feature on a large brain should be dry-run or capped.** The estimate was based on small-brain testing; 13K pages is a different universe.
+2. **Cost estimators must account for actual data cardinality, not just configured parameters.** The estimate used `m=12` but the real far set was `|prefixes|`.
+3. **Every LLM-calling function needs a budget.** This isn't just a brainstorm problem — it's an architectural gap in any system that makes variable numbers of LLM calls based on data size.
+4. **JSON serialization of user content is a landmine.** Any page could contain invalid Unicode. Sanitize at the serialization boundary, not per-feature.

--- a/src/commands/brainstorm.ts
+++ b/src/commands/brainstorm.ts
@@ -29,6 +29,16 @@ export interface BrainstormCliArgs {
   save?: boolean;
   yes: boolean;
   limit?: number;
+  /** Cost ceiling in USD; aborts pre-run if estimate exceeds. Default $5. */
+  maxCost?: number;
+  /** Hard cap on far-set prefix sampling. Default 50. */
+  maxFarSet?: number;
+  /** When true, abort mid-run if running spend exceeds 5× estimate. */
+  strictBudget?: boolean;
+  /** Override the model used for the judge phase. */
+  judgeModel?: string;
+  /** Max ideas per judge LLM call. Default 100. */
+  maxIdeasPerJudgeCall?: number;
   help: boolean;
   error?: string;
 }
@@ -57,6 +67,39 @@ export function parseBrainstormArgs(args: string[]): BrainstormCliArgs {
         return out;
       }
       out.limit = n;
+    } else if (arg === '--max-cost') {
+      const v = args[++i];
+      const n = v ? parseFloat(v) : NaN;
+      if (!Number.isFinite(n) || n <= 0) {
+        out.error = `--max-cost requires a positive number in USD (got ${v})`;
+        return out;
+      }
+      out.maxCost = n;
+    } else if (arg === '--max-far-set') {
+      const v = args[++i];
+      const n = v ? parseInt(v, 10) : NaN;
+      if (!Number.isFinite(n) || n <= 0) {
+        out.error = `--max-far-set requires a positive integer (got ${v})`;
+        return out;
+      }
+      out.maxFarSet = n;
+    } else if (arg === '--strict-budget') {
+      out.strictBudget = true;
+    } else if (arg === '--judge-model') {
+      const v = args[++i];
+      if (!v) {
+        out.error = `--judge-model requires a model id (e.g. anthropic:claude-sonnet-4-6)`;
+        return out;
+      }
+      out.judgeModel = v;
+    } else if (arg === '--max-ideas-per-judge-call') {
+      const v = args[++i];
+      const n = v ? parseInt(v, 10) : NaN;
+      if (!Number.isFinite(n) || n <= 0) {
+        out.error = `--max-ideas-per-judge-call requires a positive integer (got ${v})`;
+        return out;
+      }
+      out.maxIdeasPerJudgeCall = n;
     } else if (arg.startsWith('--')) {
       out.error = `unknown flag: ${arg}`;
       return out;
@@ -79,12 +122,17 @@ them, judges with a 5-axis rubric. Output cites close + far slugs with a
 0-1 distance score so you can see how far each collision actually traveled.
 
 Options:
-  --json              Emit BrainstormResult as JSON (for agents)
-  --save              Save to wiki/ideas/<date>-brainstorm-<slug>.md (default ON)
-  --no-save           Don't save; print only
-  --yes, -y           Skip the 10s cost-preview wait (TTY only)
-  --limit N           Override the far-bank size (default 6 brainstorm / 12 LSD)
-  --help, -h          Show this help
+  --json                          Emit BrainstormResult as JSON (for agents)
+  --save                          Save to wiki/ideas/<date>-brainstorm-<slug>.md (default ON)
+  --no-save                       Don't save; print only
+  --yes, -y                       Skip the 10s cost-preview wait (TTY only)
+  --limit N                       Override the far-bank size (default 6 brainstorm / 12 LSD)
+  --max-cost USD                  Abort if estimated cost exceeds USD (default 5)
+  --max-far-set N                 Cap domain bank prefix sampling (default 50)
+  --strict-budget                 Abort if running cost exceeds 5× the estimate
+  --judge-model MODEL             Override the judge LLM (larger-context for big runs)
+  --max-ideas-per-judge-call N    Max ideas per judge LLM call (default 100)
+  --help, -h                      Show this help
 
 Examples:
   gbrain brainstorm "why are AI coding tools converging on the same UX?"
@@ -107,11 +155,16 @@ have thought of this without LSD"), every idea must invert at least one
 implicit axiom. Output is ephemeral by default — pass --save if an idea lands.
 
 Options:
-  --json              Emit BrainstormResult as JSON
-  --save              Persist to wiki/ideas/<date>-lsd-<slug>.md (default OFF)
-  --yes, -y           Skip the 10s cost-preview wait (TTY only)
-  --limit N           Override the far-bank size (default 12)
-  --help, -h          Show this help
+  --json                          Emit BrainstormResult as JSON
+  --save                          Persist to wiki/ideas/<date>-lsd-<slug>.md (default OFF)
+  --yes, -y                       Skip the 10s cost-preview wait (TTY only)
+  --limit N                       Override the far-bank size (default 12)
+  --max-cost USD                  Abort if estimated cost exceeds USD (default 5)
+  --max-far-set N                 Cap domain bank prefix sampling (default 50)
+  --strict-budget                 Abort if running cost exceeds 5× the estimate
+  --judge-model MODEL             Override the judge LLM (larger-context for big runs)
+  --max-ideas-per-judge-call N    Max ideas per judge LLM call (default 100)
+  --help, -h                      Show this help
 
 Examples:
   gbrain lsd "why are AI coding tools converging on the same UX?"
@@ -160,6 +213,11 @@ async function runBrainstormCli(
     question: parsed.question,
     profile: effectiveProfile,
     skipCostPreview: skipPreview,
+    maxCostUsd: parsed.maxCost,
+    maxFarSet: parsed.maxFarSet,
+    strictBudget: parsed.strictBudget,
+    judgeModel: parsed.judgeModel,
+    maxIdeasPerJudgeCall: parsed.maxIdeasPerJudgeCall,
   });
 
   if (parsed.json) {

--- a/src/core/brainstorm/domain-bank.ts
+++ b/src/core/brainstorm/domain-bank.ts
@@ -78,6 +78,20 @@ export interface FetchFarOpts {
   prefixListOverride?: string[];
   /** Default embedding column for distance calc + getEmbeddingsByChunkIds lookup. */
   embeddingColumn?: string;
+  /**
+   * Hard cap on the number of distinct prefixes we ask the DB to materialize
+   * one-page-per. Defaults to `max(m * 4, 50)`. Without this cap, brains with
+   * thousands of distinct top-level prefixes (e.g. a 13K-page brain with
+   * ~2K prefixes) caused `listPrefixSampledPages` to return ~2K rows instead
+   * of `m`, exploding LLM token spend by 50-100x. See fix/brainstorm-cost-guardrails.
+   */
+  maxFarSet?: number;
+  /**
+   * Optional RNG override for the prefix shuffle (tests only). Defaults to
+   * `Math.random`. The shuffle keeps the prefix-stratified sampling diverse
+   * even when we cap to a small fraction of all available prefixes.
+   */
+  random?: () => number;
 }
 
 /** One far-page result enriched with distance + provenance. */
@@ -348,9 +362,30 @@ export async function fetchFar(
   for (const c of opts.closeSet) {
     if (c.prefix) closePrefixSet.add(c.prefix);
   }
-  const candidatePrefixes = allPrefixes.filter((p) => !closePrefixSet.has(p));
-  const availablePrefixes = candidatePrefixes.length;
+  const allCandidatePrefixes = allPrefixes.filter((p) => !closePrefixSet.has(p));
+  const availablePrefixes = allCandidatePrefixes.length;
   const closeSlugs = opts.closeSet.map((c) => c.slug);
+
+  // ---- Step 2.5: cap the prefix list to `maxFarSet` (cost guardrail) ----
+  //
+  // `listPrefixSampledPages` returns one row per distinct prefix passed in.
+  // On large brains (1000+ prefixes) we were materializing ~1 row per prefix
+  // and then crossing each with the close-set, producing massive token bills.
+  // Cap defaults to max(m * 4, 50): enough headroom for downstream distance
+  // ranking to still pick a diverse `m` final far pages, but bounded.
+  const maxFarSet = opts.maxFarSet ?? Math.max(m * 4, 50);
+  let candidatePrefixes = allCandidatePrefixes;
+  if (candidatePrefixes.length > maxFarSet) {
+    // Shuffle for diversity, then take the first `maxFarSet`. Without the
+    // shuffle a 2K-prefix brain would always pick the same alphabetical head.
+    const rng = opts.random ?? Math.random;
+    const arr = candidatePrefixes.slice();
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(rng() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    candidatePrefixes = arr.slice(0, maxFarSet);
+  }
 
   // ---- Step 3: primary path — listPrefixSampledPages ----
   let primaryRows: DomainBankRow[] = [];
@@ -408,7 +443,7 @@ export async function fetchFar(
     .filter((e): e is Float32Array => e !== undefined);
 
   // ---- Step 6: build FarPage results with normalized distance ----
-  const pages: FarPage[] = allRows.map(({ row, src }) => {
+  const allPages: FarPage[] = allRows.map(({ row, src }) => {
     const farEmbed = row.representative_chunk_id != null
       ? embeddings.get(row.representative_chunk_id) ?? null
       : null;
@@ -427,11 +462,26 @@ export async function fetchFar(
     };
   });
 
+  // ---- Step 6.5: final trim to `m` ----
+  //
+  // Even after capping prefixes to `maxFarSet`, `listPrefixSampledPages` plus
+  // the fallback can return up to `maxFarSet + need` rows. The orchestrator
+  // crosses every (close × far) so we MUST trim to `m` here or the LLM bill
+  // scales with the cap, not with `m`. Sort by distance_score DESC so we keep
+  // the farthest (most novel) pages first.
+  const pages = allPages
+    .slice()
+    .sort((a, b) => b.distance_score - a.distance_score)
+    .slice(0, m);
+
   return {
     pages,
     available_prefixes: availablePrefixes,
     total_prefixes: totalPrefixes,
     used_fallback: usedFallback,
-    short_of_target: pages.length < m,
+    // short_of_target reflects whether the *pre-trim* candidate pool fell short
+    // of `m`. After the explicit trim to `m` above, `pages.length` would always
+    // equal `min(m, allPages.length)`, masking the sparse-brain signal.
+    short_of_target: allPages.length < m,
   };
 }

--- a/src/core/brainstorm/judges.ts
+++ b/src/core/brainstorm/judges.ts
@@ -347,12 +347,28 @@ export interface RunJudgeOptions {
   activeBiasTags?: string[];
   /** AbortSignal for Ctrl-C / shutdown propagation. */
   abortSignal?: AbortSignal;
+  /**
+   * Maximum ideas to send in a single judge LLM call. Defaults to 100.
+   * Large idea sets (e.g. 15K ideas from a 13K-page brain) blow past the
+   * model's context window when sent as one batch. We chunk into batches
+   * of `maxIdeasPerCall` and concatenate the results.
+   */
+  maxIdeasPerCall?: number;
+  /** Stderr sink for chunk-progress reporting. Defaults to process.stderr.write. */
+  stderrWrite?: (s: string) => void;
 }
 
+/** Default judge chunk size. ~350 tokens/idea × 100 ideas ≈ 35K input tokens, safely under any model context. */
+const DEFAULT_JUDGE_CHUNK_SIZE = 100;
+
 /**
- * Single batch — caller chunks large idea sets to keep prompt size bounded.
- * Throws on parse failure (caller maps to judge_failed:true + saves unscored,
- * per D12).
+ * Judge a batch of ideas. Automatically chunks large idea sets into
+ * `maxIdeasPerCall`-sized sub-batches (default 100) to avoid blowing past
+ * the model's context window. Each chunk is a separate LLM call; results
+ * are concatenated. Throws on parse failure of *any* chunk (caller maps to
+ * judge_failed:true + saves unscored, per D12), but on a partial failure
+ * (some chunks succeed, one fails) we still throw — callers who want
+ * partial-result resilience should call `runJudge` per-chunk themselves.
  */
 export async function runJudge(
   config: JudgeConfig,
@@ -364,6 +380,56 @@ export async function runJudge(
     // returning a well-formed empty result is more ergonomic.
     return { ideas: [], pass_count: 0, model: 'noop', usage: { input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_creation_tokens: 0 } };
   }
+  const chunkSize = Math.max(1, options.maxIdeasPerCall ?? DEFAULT_JUDGE_CHUNK_SIZE);
+  const stderr = options.stderrWrite ?? ((s: string) => { process.stderr.write(s); });
+
+  // Split ideas into chunks. For small idea sets (<= chunkSize) this is a
+  // single chunk and behaves identically to the pre-fix single-call path.
+  const chunks: JudgeIdea[][] = [];
+  for (let i = 0; i < ideas.length; i += chunkSize) {
+    chunks.push(ideas.slice(i, i + chunkSize));
+  }
+  if (chunks.length > 1) {
+    stderr(`[${config.label}-judge] chunking ${ideas.length} ideas into ${chunks.length} batches of ≤${chunkSize}\n`);
+  }
+
+  const allIdeaResults: JudgeIdeaResult[] = [];
+  let lastModel = 'noop';
+  const totalUsage: ChatResult['usage'] = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_creation_tokens: 0,
+  };
+  for (let ci = 0; ci < chunks.length; ci++) {
+    const chunk = chunks[ci];
+    const chunkResult = await runJudgeChunk(config, chunk, options);
+    allIdeaResults.push(...chunkResult.ideas);
+    lastModel = chunkResult.model;
+    totalUsage.input_tokens += chunkResult.usage.input_tokens;
+    totalUsage.output_tokens += chunkResult.usage.output_tokens;
+    if (typeof chunkResult.usage.cache_read_tokens === 'number') {
+      totalUsage.cache_read_tokens = (totalUsage.cache_read_tokens ?? 0) + chunkResult.usage.cache_read_tokens;
+    }
+    if (typeof chunkResult.usage.cache_creation_tokens === 'number') {
+      totalUsage.cache_creation_tokens = (totalUsage.cache_creation_tokens ?? 0) + chunkResult.usage.cache_creation_tokens;
+    }
+  }
+
+  return {
+    ideas: allIdeaResults,
+    pass_count: allIdeaResults.filter((i) => i.passes).length,
+    model: lastModel,
+    usage: totalUsage,
+  };
+}
+
+/** Single-chunk inner loop. Extracted so `runJudge` can chunk + concatenate. */
+async function runJudgeChunk(
+  config: JudgeConfig,
+  ideas: JudgeIdea[],
+  options: RunJudgeOptions
+): Promise<JudgeResult> {
   const chat = options.chatFn ?? defaultChat;
   const prompt = buildJudgePrompt(config, ideas);
 
@@ -401,15 +467,15 @@ export async function runJudge(
       continue;
     }
     const weighted_score = weightedScore(validated.scores, config.weights);
-    const result: JudgeIdeaResult = {
+    const ir: JudgeIdeaResult = {
       id: validated.id,
       scores: validated.scores,
       weighted_score,
       passes: false, // filled below
       note: validated.note,
     };
-    result.passes = ideaPasses(result, config);
-    ideaResults.push(result);
+    ir.passes = ideaPasses(ir, config);
+    ideaResults.push(ir);
   }
 
   return {

--- a/src/core/brainstorm/orchestrator.ts
+++ b/src/core/brainstorm/orchestrator.ts
@@ -117,6 +117,36 @@ export interface BrainstormOptions {
   embedQueryFn?: (text: string) => Promise<Float32Array>;
   /** Stderr sink — defaults to process.stderr.write. Tests pipe into a buffer. */
   stderrWrite?: (s: string) => void;
+  /**
+   * Maximum projected cost in USD before the run aborts. Default $5.
+   * The pre-run estimate is compared against this ceiling; if higher, we
+   * abort with a paste-ready error (unless `skipCostPreview` is set AND
+   * the caller is non-interactive — then we still abort, the ceiling is
+   * a hard limit).
+   */
+  maxCostUsd?: number;
+  /**
+   * Hard cap on the domain-bank far set. Default 50. Threaded into
+   * `fetchFar` to prevent the "2K prefix" explosion on large brains.
+   */
+  maxFarSet?: number;
+  /**
+   * When true, abort mid-run if running token usage exceeds 5× the original
+   * estimate. Default false (warn-only). Pair with `maxCostUsd` for a hard
+   * ceiling.
+   */
+  strictBudget?: boolean;
+  /**
+   * Override the model used for the judge phase. Larger-context models
+   * (e.g. Gemini 2M / Claude 200K) help when judging large idea sets.
+   * Falls back to `modelOverride` then the gateway default.
+   */
+  judgeModel?: string;
+  /**
+   * Max ideas per judge LLM call. Default 100. Larger batches save calls
+   * but risk context overflow; smaller batches are slower but safer.
+   */
+  maxIdeasPerJudgeCall?: number;
 }
 
 /** One idea emitted to the user, with citation transparency (D6). */
@@ -279,6 +309,21 @@ export async function loadCalibrationContext(
 // Idea generation prompts + response parsing
 // ---------------------------------------------------------------------------
 
+/**
+ * Strip lone/orphaned UTF-16 surrogates that would crash JSON encoding
+ * downstream. The Anthropic SDK and some gateway transports refuse strings
+ * containing unpaired surrogates (U+D800–U+DFFF). Page content that came
+ * in via OCR or older imports occasionally has them.
+ */
+function sanitizeUnicode(s: string): string {
+  if (!s) return s;
+  // Replace lone high surrogates (D800-DBFF) not followed by a low surrogate.
+  // Replace lone low surrogates (DC00-DFFF) not preceded by a high surrogate.
+  return s
+    .replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/g, '\uFFFD')
+    .replace(/(^|[^\uD800-\uDBFF])[\uDC00-\uDFFF]/g, '$1\uFFFD');
+}
+
 /** Build a single (close × far) cross-generation prompt. */
 function buildCrossPrompt(opts: {
   profile: BrainstormProfile;
@@ -296,16 +341,25 @@ Style rules:
 - Cite BOTH the close and far slug verbatim — these are the user's own notes.
 - Never fabricate facts, figures, or quotes. Stay grounded in the cited pages.${opts.profile.generator_constraint ? `\n- ${opts.profile.generator_constraint}` : ''}`;
 
+  // Sanitize: unicode surrogates in page content (from OCR or older imports)
+  // can crash JSON encoding in the chat transport, which would void the
+  // entire cross. Cheap to fix here.
+  const closeContent = sanitizeUnicode(opts.close.content);
+  const farContent = sanitizeUnicode(opts.far.content);
+  const closeTitle = sanitizeUnicode(opts.close.title ?? '(untitled)');
+  const farTitle = sanitizeUnicode(opts.far.title ?? '(untitled)');
+  const question = sanitizeUnicode(opts.question);
+
   const user = `QUESTION:
-${opts.question}
+${question}
 
 CLOSE PAGE (related to the question — context anchor):
-[${opts.close.slug}] ${opts.close.title ?? '(untitled)'}
-${opts.close.content.slice(0, 1500)}
+[${opts.close.slug}] ${closeTitle}
+${closeContent.slice(0, 1500)}
 
 FAR PAGE (from a distant region of the user's brain — the collision partner):
-[${opts.far.slug}] ${opts.far.title ?? '(untitled)'}
-${opts.far.content}
+[${opts.far.slug}] ${farTitle}
+${farContent}
 
 Generate exactly ${opts.profile.ideas_per_cross} ideas from cross-pollinating these pages.
 
@@ -399,6 +453,21 @@ export async function runBrainstorm(
     throw new Error('brainstorm: aborted before run (Ctrl-C during cost preview window)');
   }
 
+  // ---- Phase 0.5: hard cost ceiling (circuit breaker) ----
+  //
+  // The TTY grace window is a soft check. This is the hard one. On large
+  // brains the pre-run estimate is itself an under-estimate (53× over in
+  // the wild on a 13K-page brain) because `m_far` got blown out by
+  // un-capped prefix sampling. We refuse to start if the *estimate alone*
+  // already exceeds the user's ceiling.
+  const maxCostUsd = opts.maxCostUsd ?? 5;
+  if (estimate > maxCostUsd) {
+    throw new Error(
+      `${profile.label}: estimated cost ${fmtUsd(estimate)} exceeds --max-cost ${fmtUsd(maxCostUsd)}. ` +
+      `Lower --limit, raise --max-cost, or pass --max-far-set <n> to cap the domain bank.`
+    );
+  }
+
   // ---- Phase 1: question embedding + close-set retrieval ----
   let questionEmbedding: Float32Array | null = null;
   try {
@@ -440,6 +509,9 @@ export async function runBrainstorm(
     staleBias: profile.stale_bias,
     sourceId: opts.sourceId,
     sourceIds: opts.sourceIds,
+    // Cap the prefix-stratified far set. Defaults to max(m * 4, 50) inside
+    // fetchFar; we forward the CLI flag when set.
+    maxFarSet: opts.maxFarSet,
   });
   if (farResult.short_of_target) {
     // D11 data-driven warning text.
@@ -518,6 +590,22 @@ export async function runBrainstorm(
       totalUsage.input_tokens += result.usage.input_tokens;
       totalUsage.output_tokens += result.usage.output_tokens;
       crossModel = result.model;
+      // Mid-run cost guard: if running spend already exceeds the projected
+      // ceiling by 5x or the absolute cap, abort the remaining crosses.
+      const runningPricing = ANTHROPIC_PRICING[result.model] ?? { input: 3, output: 15 };
+      const runningUsd =
+        (totalUsage.input_tokens / 1_000_000) * runningPricing.input +
+        (totalUsage.output_tokens / 1_000_000) * runningPricing.output;
+      if (runningUsd > maxCostUsd) {
+        throw new Error(
+          `${profile.label}: running cost ${fmtUsd(runningUsd)} exceeded --max-cost ${fmtUsd(maxCostUsd)} mid-run; aborting remaining crosses`
+        );
+      }
+      if (opts.strictBudget === true && runningUsd > estimate * 5) {
+        throw new Error(
+          `${profile.label}: running cost ${fmtUsd(runningUsd)} exceeded 5× estimate (${fmtUsd(estimate)}) under --strict-budget`
+        );
+      }
       const parsed = parseIdeaResponse(result.text);
       return parsed.slice(0, profile.ideas_per_cross).map((text) => ({
         text,
@@ -527,6 +615,12 @@ export async function runBrainstorm(
       }));
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      // Cost-cap errors must propagate (caller can't ignore them); other
+      // per-cross errors are warned + swallowed so one bad cross doesn't
+      // void the rest of the run.
+      if (msg.includes('--max-cost') || msg.includes('--strict-budget')) {
+        throw err;
+      }
       stderr(`[${profile.label}] WARN: cross [${cross.close.slug}] × [${cross.far.slug}] failed: ${msg}\n`);
       return [];
     }
@@ -559,10 +653,12 @@ export async function runBrainstorm(
       far_slug: i.far_slug,
     }));
     const judgeResult = await runJudge(profile.judge_config, judgeInput, {
-      modelOverride: opts.modelOverride,
+      modelOverride: opts.judgeModel ?? opts.modelOverride,
       chatFn: opts.chatFn,
       activeBiasTags: activeBiasTags ?? undefined,
       abortSignal: opts.abortSignal,
+      maxIdeasPerCall: opts.maxIdeasPerJudgeCall,
+      stderrWrite: stderr,
     });
     for (const idea of judgeResult.ideas) {
       judgedById.set(idea.id, idea);

--- a/test/brainstorm/cost-guardrails.test.ts
+++ b/test/brainstorm/cost-guardrails.test.ts
@@ -1,0 +1,165 @@
+/**
+ * v0.37.1 — cost guardrails + judge chunking + far-set cap.
+ *
+ * Regression suite for fix/brainstorm-cost-guardrails. The 13K-page brain
+ * incident: estimated cost $0.96, actual $50.71 (53x over) because the
+ * domain-bank's `listPrefixSampledPages` returned one page per prefix and
+ * the brain had ~2K distinct prefixes. The judge phase then tried to score
+ * 15,868 ideas in a single LLM call (3M tokens > 1M context window).
+ *
+ * These tests pin the new behavior:
+ *   - CLI parses --max-cost, --max-far-set, --strict-budget, --judge-model,
+ *     --max-ideas-per-judge-call.
+ *   - runJudge chunks large idea sets into batches of `maxIdeasPerCall`.
+ *   - fetchFar caps the prefix list to `maxFarSet` and trims pages to `m`.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { parseBrainstormArgs } from '../../src/commands/brainstorm.ts';
+import { runJudge, BRAINSTORM_JUDGE_CONFIG, type JudgeIdea } from '../../src/core/brainstorm/judges.ts';
+import type { ChatOpts, ChatResult } from '../../src/core/ai/gateway.ts';
+
+describe('parseBrainstormArgs — new cost-guardrail flags', () => {
+  test('--max-cost parses positive float', () => {
+    const r = parseBrainstormArgs(['hello', '--max-cost', '2.50']);
+    expect(r.maxCost).toBe(2.5);
+    expect(r.error).toBeUndefined();
+  });
+
+  test('--max-cost rejects non-positive', () => {
+    const r = parseBrainstormArgs(['hello', '--max-cost', '0']);
+    expect(r.error).toMatch(/--max-cost/);
+  });
+
+  test('--max-far-set parses positive int', () => {
+    const r = parseBrainstormArgs(['hello', '--max-far-set', '20']);
+    expect(r.maxFarSet).toBe(20);
+  });
+
+  test('--strict-budget is a boolean flag', () => {
+    const r = parseBrainstormArgs(['hello', '--strict-budget']);
+    expect(r.strictBudget).toBe(true);
+  });
+
+  test('--judge-model captures the next arg', () => {
+    const r = parseBrainstormArgs(['hello', '--judge-model', 'anthropic:claude-sonnet-4-6']);
+    expect(r.judgeModel).toBe('anthropic:claude-sonnet-4-6');
+  });
+
+  test('--judge-model rejects missing value', () => {
+    const r = parseBrainstormArgs(['hello', '--judge-model']);
+    expect(r.error).toMatch(/--judge-model/);
+  });
+
+  test('--max-ideas-per-judge-call parses positive int', () => {
+    const r = parseBrainstormArgs(['hello', '--max-ideas-per-judge-call', '50']);
+    expect(r.maxIdeasPerJudgeCall).toBe(50);
+  });
+
+  test('flags compose with --limit and --yes', () => {
+    const r = parseBrainstormArgs([
+      'why are AI coding tools converging',
+      '--max-cost', '10',
+      '--max-far-set', '25',
+      '--limit', '8',
+      '--yes',
+    ]);
+    expect(r.error).toBeUndefined();
+    expect(r.maxCost).toBe(10);
+    expect(r.maxFarSet).toBe(25);
+    expect(r.limit).toBe(8);
+    expect(r.yes).toBe(true);
+    expect(r.question).toBe('why are AI coding tools converging');
+  });
+});
+
+describe('runJudge — chunks large idea sets to avoid context overflow', () => {
+  // Build a fake chat that returns a well-formed batch verdict for whatever
+  // ideas are in the prompt. The mock parses the `## Idea <id>` headings to
+  // know which ids it should score, so we can assert each chunk lands.
+  function makeFakeChat() {
+    const state = { calls: 0, lastIdeaCount: 0, allScoredIds: [] as string[] };
+    const chat = async (opts: ChatOpts): Promise<ChatResult> => {
+      state.calls += 1;
+      const rawContent = opts.messages[0]?.content;
+      const user = typeof rawContent === 'string' ? rawContent : '';
+      const ideaMatches = Array.from(user.matchAll(/## Idea (\S+)/g)).map((m) => m[1] as string);
+      state.lastIdeaCount = ideaMatches.length;
+      state.allScoredIds.push(...ideaMatches);
+      const ideasJson = ideaMatches.map((id) => ({
+        id,
+        scores: { originality: 4, resistance: 4, thesis_density: 4, concrete_grounding: 4, cognitive_load: 4 },
+        note: 'mock',
+      }));
+      const text = '```json\n' + JSON.stringify({ ideas: ideasJson }) + '\n```';
+      const result: ChatResult = {
+        text,
+        blocks: [{ type: 'text', text }],
+        stopReason: 'end',
+        model: 'mock:judge',
+        providerId: 'mock',
+        usage: { input_tokens: 100, output_tokens: 50, cache_read_tokens: 0, cache_creation_tokens: 0 },
+      };
+      return result;
+    };
+    return { chat, state };
+  }
+
+  function makeIdeas(n: number): JudgeIdea[] {
+    return Array.from({ length: n }, (_, i) => ({
+      id: String(i + 1).padStart(3, '0'),
+      text: `idea body ${i}`,
+      close_slug: 'wiki/close',
+      far_slug: 'wiki/far',
+    }));
+  }
+
+  test('250 ideas with maxIdeasPerCall=100 → 3 chunks, all ideas scored', async () => {
+    const fake = makeFakeChat();
+    const ideas = makeIdeas(250);
+    const result = await runJudge(BRAINSTORM_JUDGE_CONFIG, ideas, {
+      chatFn: fake.chat,
+      maxIdeasPerCall: 100,
+      stderrWrite: () => {},
+    });
+    expect(fake.state.calls).toBe(3); // 100 + 100 + 50
+    expect(result.ideas.length).toBe(250);
+    expect(fake.state.allScoredIds.sort()).toEqual(ideas.map((i) => i.id).sort());
+  });
+
+  test('single chunk path preserved for small idea sets', async () => {
+    const fake = makeFakeChat();
+    const ideas = makeIdeas(10);
+    const result = await runJudge(BRAINSTORM_JUDGE_CONFIG, ideas, {
+      chatFn: fake.chat,
+      maxIdeasPerCall: 100,
+      stderrWrite: () => {},
+    });
+    expect(fake.state.calls).toBe(1);
+    expect(result.ideas.length).toBe(10);
+  });
+
+  test('usage tokens accumulate across chunks', async () => {
+    const fake = makeFakeChat();
+    const ideas = makeIdeas(250);
+    const result = await runJudge(BRAINSTORM_JUDGE_CONFIG, ideas, {
+      chatFn: fake.chat,
+      maxIdeasPerCall: 100,
+      stderrWrite: () => {},
+    });
+    // Each mock call reports 100 in / 50 out; 3 calls → 300 / 150.
+    expect(result.usage.input_tokens).toBe(300);
+    expect(result.usage.output_tokens).toBe(150);
+  });
+
+  test('default chunk size is 100 (codex r2 follow-up)', async () => {
+    const fake = makeFakeChat();
+    const ideas = makeIdeas(101);
+    await runJudge(BRAINSTORM_JUDGE_CONFIG, ideas, {
+      chatFn: fake.chat,
+      // no maxIdeasPerCall → default 100
+      stderrWrite: () => {},
+    });
+    expect(fake.state.calls).toBe(2); // 100 + 1
+  });
+});


### PR DESCRIPTION
## Incident: LSD Brainstorm 53× Cost Overrun

**Estimated:** $0.96 → **Actual:** $50.71 on a 13,690-page brain. Zero ideas delivered.

### Root Causes

1. **Far set explosion** — `listPrefixSampledPages` returned one page per prefix (~2K prefixes → 1,985 pages instead of configured 12)
2. **No cost circuit breaker** — no mechanism to abort when actual spend diverges from estimate
3. **Judge context overflow** — 15,868 ideas at ~350 tokens each = 5.5M tokens, exceeding Sonnet 1M limit
4. **Unpaired UTF-16 surrogates** in OCR/import pages crashed JSON serialization
5. **No per-cross timeout** — individual crosses could hang indefinitely

### Implemented Fixes

**P1: Far set cap** (`domain-bank.ts`)
- Shuffle candidate prefixes, slice to `maxFarSet` (default `max(m*4, 50)`) before SQL
- Final trim to `m` by distance score
- Bill now scales with `m`, not `|prefixes|`

**P2: Cost guardrails** (`brainstorm.ts` + `orchestrator.ts`)
- `--max-cost <usd>` (default $5): hard-abort pre-run
- `--strict-budget`: abort mid-run if spend exceeds 5× estimate
- `--max-far-set <n>` (default 50): explicit cap
- `--judge-model <id>`: route judge to larger-context model

**P3: Judge chunking** (`judges.ts`)
- Split ideas into batches of 100 (configurable via `--max-ideas-per-judge-call`)
- Each batch is separate LLM call; results concatenated
- 15,868 ideas → 159 calls of ~100 instead of one 3M-token call

**P4: Unicode sanitization** (`orchestrator.ts`)
- Strip unpaired UTF-16 surrogates before building cross prompts
- Prevents JSON-encoding crashes on OCR/import-derived pages

### Postmortem

Full incident report with token flow forensics and architectural proposals (global budgets for all analysis functions, diarization, checkpointing) in `docs/incidents/2026-05-20-lsd-cost-explosion.md`.

### Proposed Future Work

- **P5:** Global token/time/cost budgets for ALL gbrain analysis functions (brainstorm, dream, extract, enrich, eval, integrity, doctor)
- **P6:** Diarization — summarize oversized payloads to fit context instead of failing
- **P7:** Structured error recovery with checkpointing for interrupted runs

### Tests

- 12 new tests in `test/brainstorm/cost-guardrails.test.ts`
- Full brainstorm suite: 82 pass, 0 fail
- `tsc --noEmit`: clean