### PR TITLE
ai/dims: forward `dimensions` for Qwen3-Embedding on openai-compat

### DIFF
--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -220,6 +220,17 @@ export function dimsProviderOptions(
       if (modelId === 'text-embedding-v3' || modelId === 'embedding-3') {
         return { openaiCompatible: { dimensions: dims } };
       }
+      // Qwen3-Embedding (commonly served via Ollama / llama.cpp on the
+      // openai-compatible adapter) is a Matryoshka model with a large native
+      // dim — 1024 for 0.6B, 2560 for 4B, 4096 for 8B. Brains configured for
+      // a narrower width — e.g. 1024 to fit pgvector HNSW's 2000-dim index
+      // cap — must forward `dimensions`, otherwise the endpoint returns the
+      // full native vector and the embed fails the dim-consistency check.
+      // Ollama's /v1/embeddings honors `dimensions` (MRL truncation +
+      // renormalize). Symmetric retrieval — inputType ignored.
+      if (modelId.startsWith('qwen3-embedding')) {
+        return { openaiCompatible: { dimensions: dims } };
+      }
       // MiniMax embo-01 takes a `type: 'db' | 'query'` field for asymmetric
       // retrieval. Today still hardcoded to 'db' for back-compat — opting
       // into the new inputType seam is a follow-up (see plan's deferred

--- a/test/ai/dims-ollama.test.ts
+++ b/test/ai/dims-ollama.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Qwen3-Embedding dimension passthrough on the openai-compatible adapter.
+ *
+ * Qwen3-Embedding (commonly served via Ollama / llama.cpp) is a Matryoshka
+ * model with a large native dim — 4096 for the 8B. Without forwarding
+ * `dimensions`, the endpoint returns the full native vector and the embed
+ * fails the dim-consistency check against a narrower schema width.
+ *
+ * Pins:
+ *  - dimsProviderOptions forwards `dimensions` for qwen3-embedding* model ids
+ *  - the Ollama tag-suffixed id form (`qwen3-embedding:8b-q4_K_M`) is matched
+ *  - a non-default width is honored verbatim
+ *  - no input_type leaks (symmetric model)
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { dimsProviderOptions } from '../../src/core/ai/dims.ts';
+
+describe('dimsProviderOptions — Qwen3-Embedding branch', () => {
+  test('forwards dimensions for a bare qwen3-embedding id', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'qwen3-embedding-8b', 1024);
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1024 } });
+  });
+
+  test('matches the Ollama tag-suffixed id form', () => {
+    // A configured `ollama:qwen3-embedding:8b-q4_K_M` has its provider
+    // stripped, leaving modelId `qwen3-embedding:8b-q4_K_M`.
+    const opts = dimsProviderOptions('openai-compatible', 'qwen3-embedding:8b-q4_K_M', 1024);
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1024 } });
+  });
+
+  test('honors a non-default width (4B native 2560)', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'qwen3-embedding:4b', 2560);
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 2560 } });
+  });
+
+  test('does not leak input_type (symmetric model)', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'qwen3-embedding-8b', 1024, 'query');
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1024 } });
+    expect(JSON.stringify(opts)).not.toContain('input_type');
+  });
+});


### PR DESCRIPTION
## Problem

The `ollama` recipe declares an embedding touchpoint, but `dimsProviderOptions` (`src/core/ai/dims.ts`) has no branch matching Qwen3-Embedding model ids. On the `openai-compatible` path it falls through to `return undefined`, so the adapter sends no `dimensions` field.

Qwen3-Embedding is a Matryoshka model with a large native dim (1024 for 0.6B, 2560 for 4B, **4096 for 8B**). Without `dimensions`, the endpoint returns the full native vector, and every embed then fails the dim-consistency check:

```
Error embedding <page>: Embedding dim mismatch:
  model qwen3-embedding:8b-q4_K_M returned 4096 but schema expects 1024.
```

This bites any brain sized to 1024 dims — the natural choice to stay under pgvector HNSW's 2000-dim index cap — when pointed at `ollama:qwen3-embedding:*`. The misconfiguration is silent until first embed: `gbrain config`, `providers list`, and `doctor` all look healthy.

## Fix

Add a `qwen3-embedding*` branch to the `openai-compatible` case, alongside the existing DashScope `text-embedding-v3` / Zhipu `embedding-3` Matryoshka branches:

```ts
if (modelId.startsWith('qwen3-embedding')) {
  return { openaiCompatible: { dimensions: dims } };
}
```

`startsWith` matches both the bare id (`qwen3-embedding-8b`) and the Ollama tag-suffixed form (`qwen3-embedding:8b-q4_K_M`, after the provider prefix is stripped). Ollama's `/v1/embeddings` honors `dimensions` (Matryoshka truncation + renormalize) — verified against ollama 0.24.0. Qwen3-Embedding is symmetric, so `inputType` is ignored.

## Tests

New `test/ai/dims-ollama.test.ts` (4 cases) pins: dimensions forwarded for bare + tag-suffixed ids, a non-default width honored, no `input_type` leak. New + existing `dims-*` / `gateway` tests pass; `tsc --noEmit` and `check-privacy.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)