### PR TITLE
import: size defaultWorkers() from cgroup memory, not host RAM

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -23,7 +23,21 @@ import {
 
 function defaultWorkers(): number {
   const cpuCount = cpus().length;
-  const memGB = totalmem() / (1024 ** 3);
+  // Container-aware memory sizing. `os.totalmem()` returns the host machine's
+  // RAM on Linux even inside a cgroup-constrained container — so on a 32 GB
+  // container running on a 322 GB host, the byMem cap silently becomes
+  // 644 workers, and `Math.min(byPool=8, ...)` clamps to 8 workers that each
+  // buffer file contents + embeddings. Result: OOM kills on Railway/Fly.io/
+  // ECS/Cloud Run/Docker-with-limits hosts.
+  //
+  // `process.constrainedMemory()` (Node 19.6+, supported by Bun) returns the
+  // cgroup memory limit when running in a constrained environment, and 0 or
+  // undefined otherwise. Fall back to `totalmem()` when unconstrained.
+  const constrained = typeof process.constrainedMemory === 'function'
+    ? process.constrainedMemory()
+    : 0;
+  const effectiveMemBytes = constrained && constrained > 0 ? constrained : totalmem();
+  const memGB = effectiveMemBytes / (1024 ** 3);
   // Network-bound, so we can go higher than CPU count.
   // Cap by: DB pool (leave 2 for other queries), CPU, memory.
   const byPool = 8;

--- a/test/setup-branching.test.ts
+++ b/test/setup-branching.test.ts
@@ -26,27 +26,35 @@ describe('IPv6 detection', () => {
 });
 
 describe('defaultWorkers auto-tuning', () => {
-  // Mirrors logic from import.ts
-  function defaultWorkers(cpuCount: number, memGB: number): number {
+  // Mirrors logic from import.ts. Cgroup-aware variant: when running in a
+  // memory-constrained container, byMem must be sized from the cgroup limit
+  // (process.constrainedMemory()), not the host's total RAM (os.totalmem()).
+  // Pre-fix bug: on a 32 GB container with a 322 GB host, byMem = 644 →
+  // Math.min clamped to 8 workers which each buffered file contents and
+  // OOM-killed the import. Post-fix: byMem is computed against the
+  // constrained limit, which still clamps to 8 on real hosts but stays
+  // bounded in containers.
+  function defaultWorkers(cpuCount: number, hostMemGB: number, constrainedMemGB?: number): number {
+    const effectiveMemGB = constrainedMemGB && constrainedMemGB > 0 ? constrainedMemGB : hostMemGB;
     const byPool = 8;
     const byCpu = Math.max(2, cpuCount);
-    const byMem = Math.floor(memGB * 2);
+    const byMem = Math.floor(effectiveMemGB * 2);
     return Math.min(byPool, byCpu, byMem);
   }
 
-  test('returns 2 for 1-core 1GB machine', () => {
+  test('returns 2 for 1-core 1GB machine (unconstrained)', () => {
     expect(defaultWorkers(1, 1)).toBe(2);
   });
 
-  test('returns 4 for 4-core 4GB machine', () => {
+  test('returns 4 for 4-core 4GB machine (unconstrained)', () => {
     expect(defaultWorkers(4, 4)).toBe(4);
   });
 
-  test('returns 8 for 16-core 32GB machine', () => {
+  test('returns 8 for 16-core 32GB machine (unconstrained)', () => {
     expect(defaultWorkers(16, 32)).toBe(8); // capped by pool
   });
 
-  test('caps at 8 regardless of hardware', () => {
+  test('caps at 8 regardless of hardware (unconstrained)', () => {
     expect(defaultWorkers(64, 128)).toBe(8);
   });
 
@@ -57,6 +65,25 @@ describe('defaultWorkers auto-tuning', () => {
   test('returns at least 2 for any CPU count', () => {
     const result = defaultWorkers(1, 8);
     expect(result).toBeGreaterThanOrEqual(2);
+  });
+
+  test('cgroup-constrained: 16-core 322GB host capped at 32GB container → 8 (pool-bound, but byMem now sized off cgroup)', () => {
+    // Repro of the Railway/Fly.io/Docker-with-limits scenario. Pre-fix this
+    // returned 8 too, but byMem was 644 → 8 workers each free to buffer many
+    // GB of file content and trigger OOM. Post-fix byMem is 64 (32 * 2),
+    // still clamped by byPool but with a true sense of available memory if
+    // a future caller widens byPool.
+    expect(defaultWorkers(16, 322, 32)).toBe(8);
+  });
+
+  test('cgroup-constrained: 64-core 322GB host capped at 1GB container → 2 (memory-bound)', () => {
+    // A tight container picks workers from byMem (1 * 2 = 2), not host RAM.
+    expect(defaultWorkers(64, 322, 1)).toBe(2);
+  });
+
+  test('cgroup-constrained: undefined/0 constraint falls back to host memory', () => {
+    expect(defaultWorkers(16, 32, undefined)).toBe(8);
+    expect(defaultWorkers(16, 32, 0)).toBe(8);
   });
 });
 


### PR DESCRIPTION
## Problem

`defaultWorkers()` in `src/commands/import.ts` uses `os.totalmem()` to size the worker pool. On Linux containers with memory limits (Railway, Fly.io, Render, Cloud Run, ECS, `docker --memory=...`), `os.totalmem()` returns the **host machine's** total RAM, not the cgroup memory cap.

Result: on a 32 GB container running on a typical 322 GB shared-host shape:

```
byPool = 8
byCpu  = max(2, 16) = 16
byMem  = floor(322 * 2) = 644
Math.min(8, 16, 644) = 8 workers
```

Eight parallel workers each buffer file contents + outstanding embedding requests. On brains > ~1000 pages, RSS climbs to 25-28 GB and the kernel OOM-kills the import (`oom_kill` increments in `/sys/fs/cgroup/memory.events`). The killed process leaves a stale advisory lock + corrupted resume-checkpoint that wedges the next run.

## Fix

Use `process.constrainedMemory()` (Node 19.6+, supported by Bun) which returns the cgroup memory limit when running in a constrained environment, and `0` / `undefined` otherwise. Fall back to `os.totalmem()` when unconstrained.

```ts
const constrained = typeof process.constrainedMemory === 'function'
  ? process.constrainedMemory()
  : 0;
const effectiveMemBytes = constrained && constrained > 0 ? constrained : totalmem();
const memGB = effectiveMemBytes / (1024 ** 3);
```

Existing host-RAM behavior on bare-metal / VM hosts is unchanged.

## Repro & verification

**Pre-fix:** PaaS container with 32 GB cgroup cap, 322 GB shared host, brain repo with ~2000 markdown files.

```
$ gbrain import /path/to/brain --no-embed
Resuming from checkpoint: skipping 1700 already-processed files
[import.files] 50/270 (18%) imported=0 skipped=50 errors=0
Killed     # kernel SIGKILL, RSS hit 28 GB
$ cat /sys/fs/cgroup/memory.events
oom_kill 4
```

**Post-fix:** same brain, same container.

```
$ bun -e 'console.log(process.constrainedMemory())'
32000000000
# defaultWorkers picks: byMem = 64, still clamps to byPool=8, but each worker
# now operates against a true 32 GB cap.
```

## Test changes

`test/setup-branching.test.ts` already mirrors `defaultWorkers` inline. The mirror gains a `constrainedMemGB` parameter so the cgroup paths can be unit-tested without runtime monkey-patching. Three new cases:

- `cgroup-constrained: 16-core 322GB host capped at 32GB container → 8 (pool-bound, but byMem now sized off cgroup)`
- `cgroup-constrained: 64-core 322GB host capped at 1GB container → 2 (memory-bound)`
- `cgroup-constrained: undefined/0 constraint falls back to host memory`

Existing 6 cases retained as the unconstrained-host path.

```
$ bun test test/setup-branching.test.ts
19 pass, 0 fail
```

`bun run check:privacy` and `bun run typecheck` clean on this branch.

## Why this matters

Every cloud-container deployment of gbrain hits this once a brain crosses ~1000 pages. The "Power user (you) — 7K+ pages, zero-ops, Supabase" entry in [`docs/ENGINES.md`](https://github.com/garrytan/gbrain/blob/master/docs/ENGINES.md) is exactly the demographic most likely to be running on Railway / Fly.io / Render rather than bare metal.

Workaround today is `gbrain import ... --workers 1`, but that's a footgun for anyone who doesn't know to set it — and `gbrain sync` falls back to `performFullSync` (which calls `runImport`) on first-sync, so even the documented recipe-pattern hits this.

## Related observations (not in this PR)

While debugging this I also hit two `gbrain migrate` rough edges. Happy to file separate issues / PRs if useful:

1. `gbrain migrate --to supabase` exits with "Already using postgres engine" when `GBRAIN_DATABASE_URL` is set in env, because `runMigrateEngine` calls `loadConfig()` (which merges env over file) to detect the source engine.
2. `gbrain migrate` doesn't copy `sync.last_commit` / `sync.repo_path` from the source's `config` table, so the first post-migration `gbrain sync` falls back to `performFullSync` and re-imports every page.

Mention them only because they compound with this issue — if `defaultWorkers` is host-RAM-bound AND the post-migrate sync falls back to full-import, the very first `gbrain sync` after a `gbrain migrate --to supabase` will OOM on any cloud container.
