### PR TITLE
fix: drain last-retrieved writes before CLI disconnect

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import type { AIGatewayConfig } from './core/ai/types.ts';
 import type { BrainEngine } from './core/engine.ts';
 import { operations, OperationError } from './core/operations.ts';
 import type { Operation, OperationContext } from './core/operations.ts';
+import { awaitPendingLastRetrievedWrites } from './core/last-retrieved.ts';
 import { serializeMarkdown } from './core/markdown.ts';
 import { parseGlobalFlags, setCliOptions, getCliOptions } from './core/cli-options.ts';
 import type { CliOptions } from './core/cli-options.ts';
@@ -174,6 +175,11 @@ async function main() {
       const { awaitPendingSearchCacheWrites } = await import('./core/search/hybrid.ts');
       await awaitPendingSearchCacheWrites();
     }
+    // v0.37.5 (#1247): read ops may start a best-effort last_retrieved_at
+    // write-back after returning results. Drain it before disconnecting the
+    // short-lived CLI engine so PGLite does not keep the process alive after
+    // stdout has already been written.
+    await awaitPendingLastRetrievedWrites();
   } catch (e: unknown) {
     if (e instanceof OperationError) {
       console.error(`Error [${e.code}]: ${e.message}`);

--- a/src/core/last-retrieved.ts
+++ b/src/core/last-retrieved.ts
@@ -38,6 +38,27 @@ import { isUndefinedColumnError } from './utils.ts';
 
 let _trackRetrievalCache: { ts: number; enabled: boolean } | null = null;
 const TRACK_RETRIEVAL_CACHE_TTL_MS = 30_000;
+const pendingLastRetrievedWrites = new Set<Promise<unknown>>();
+
+/**
+ * CLI/test drain for fire-and-forget last_retrieved_at writes.
+ *
+ * `bumpLastRetrievedAt` intentionally does not add response latency to MCP or
+ * long-lived callers. Short-lived CLI processes are different: if they close
+ * the embedded PGLite engine while the background config read / UPDATE is in
+ * flight, Bun can keep the process alive after stdout has already printed.
+ * Draining here lets the CLI preserve fast visible output while still giving
+ * the background side-effect a clean chance to settle before disconnect().
+ */
+export async function awaitPendingLastRetrievedWrites(): Promise<void> {
+  if (pendingLastRetrievedWrites.size === 0) return;
+  await Promise.allSettled(Array.from(pendingLastRetrievedWrites));
+}
+
+function trackLastRetrievedWrite(promise: Promise<unknown>): void {
+  pendingLastRetrievedWrites.add(promise);
+  promise.finally(() => pendingLastRetrievedWrites.delete(promise)).catch(() => { /* swallow */ });
+}
 
 /**
  * Resolve `search.track_retrieval` config with a 30s in-process cache so
@@ -78,7 +99,7 @@ export function _resetTrackRetrievalCacheForTests(): void {
 export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): void {
   if (pageIds.length === 0) return;
   // Fire-and-forget on purpose. We deliberately do NOT return the promise.
-  void (async () => {
+  const promise = (async () => {
     try {
       const enabled = await isTrackingEnabled(engine);
       if (!enabled) return;
@@ -102,4 +123,5 @@ export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): voi
       console.warn(`[last-retrieved] write-back failed (best-effort): ${msg}`);
     }
   })();
+  trackLastRetrievedWrite(promise);
 }

--- a/test/fix-wave-structural.test.ts
+++ b/test/fix-wave-structural.test.ts
@@ -36,6 +36,21 @@ describe('v0.36.1.x #1125 — query drain cache writes before CLI exit', () => {
   });
 });
 
+describe('v0.37.5 #1247 — drain last-retrieved writes before CLI disconnect', () => {
+  test('cli.ts awaits awaitPendingLastRetrievedWrites after op output', () => {
+    const src = readFileSync('src/cli.ts', 'utf8');
+    expect(src).toMatch(/awaitPendingLastRetrievedWrites/);
+    expect(src).toMatch(/process\.stdout\.write\(output\)[\s\S]{0,500}await\s+awaitPendingLastRetrievedWrites\(\)/);
+  });
+
+  test('last-retrieved.ts tracks fire-and-forget promises and exports a drain', () => {
+    const src = readFileSync('src/core/last-retrieved.ts', 'utf8');
+    expect(src).toMatch(/export async function awaitPendingLastRetrievedWrites/);
+    expect(src).toMatch(/pendingLastRetrievedWrites\.add\(promise\)/);
+    expect(src).toMatch(/Promise\.allSettled\(Array\.from\(pendingLastRetrievedWrites\)\)/);
+  });
+});
+
 describe('v0.36.1.x #1090 — admin embed two-tier resolution', () => {
   test('serve-http.ts uses ADMIN_ASSETS manifest when admin/dist is not next to cwd', () => {
     const src = readFileSync('src/commands/serve-http.ts', 'utf8');


### PR DESCRIPTION
## Summary
- track `last_retrieved_at` fire-and-forget promises in `last-retrieved.ts`
- add `awaitPendingLastRetrievedWrites()` and drain it from the short-lived CLI before `engine.disconnect()`
- add structural regression coverage for the CLI drain and pending-promise tracking

## Root cause
`search` / `query` / `get_page` can call `bumpLastRetrievedAt()` after returning results. That helper intentionally starts a background config read / write-back without awaiting it. In a long-lived MCP process that is fine, but in the local CLI path stdout can be written and then `engine.disconnect()` can race the background PGLite work, leaving the Bun process alive after output.

## Verification
- Reproduced installed `gbrain 0.37.3.0`: `gbrain search AIAgent --limit 1` prints output and does not exit within 5s when run under the Hermes worktree source pin.
- Verified patched CLI from this branch in the same cwd exits successfully:
  - `bun run /Users/agentdeveloper/workspace/gbrain/src/cli.ts search AIAgent --limit 1` → exit 0 in ~1.2s
- Installed patched checkout locally with `bun install -g /Users/agentdeveloper/workspace/gbrain` and verified:
  - `gbrain search AIAgent --limit 1` → exit 0 in ~1.17s
  - no-hit search still exits normally
- `bun test test/fix-wave-structural.test.ts`
- `bun run typecheck`

Fixes #1247
