### PR TITLE
fix(auth): allow `auth create <name>` without `--takes-holders`

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -390,7 +390,11 @@ export async function runAuth(args: string[]): Promise<void> {
       const takesHolders = takesIdx >= 0 && rest[takesIdx + 1]
         ? rest[takesIdx + 1].split(',').map(s => s.trim()).filter(Boolean)
         : undefined;
-      const positional = rest.find(a => !a.startsWith('--') && a !== rest[takesIdx + 1]);
+      // When `--takes-holders` is absent, `takesIdx` is -1 and
+      // `rest[takesIdx + 1]` is `rest[0]` — the positional we're trying to
+      // extract — so the unguarded inequality used to filter it out and
+      // `positional` became undefined. Guard with `takesIdx < 0`.
+      const positional = rest.find(a => !a.startsWith('--') && (takesIdx < 0 || a !== rest[takesIdx + 1]));
       await create(positional || '', { takesHolders });
       return;
     }


### PR DESCRIPTION
## Summary

`gbrain auth create <name>` without the optional `--takes-holders` flag fails with the generic usage error, even though `<name>` is clearly provided. One-line fix in [`src/commands/auth.ts:393`](src/commands/auth.ts).

## Repro (current master, v0.37.5.0)

```bash
$ gbrain auth create foo
Usage: auth create <name> [--takes-holders world,garry]
$ echo $?
1
```

## Root cause

When `--takes-holders` is absent:
- `rest.indexOf('--takes-holders')` returns `-1`
- `rest[takesIdx + 1]` then evaluates to `rest[0]` — the positional `<name>` we're trying to extract
- The unguarded inequality in the positional-find filter (`a !== rest[takesIdx + 1]`) excludes the only positional arg
- `positional` becomes `undefined`, falls through to `create('', ...)`, and the `if (!name)` gate in `create()` prints the usage and exits 1

## Fix

Guard the inequality with `takesIdx < 0` so the filter only excludes the `--takes-holders` value when the flag is actually present.

```ts
const positional = rest.find(a => !a.startsWith('--') && (takesIdx < 0 || a !== rest[takesIdx + 1]));
```

## Verification

Both cases pass after the fix:

```bash
$ gbrain auth create foo                                        # was broken
Token created for "foo" (takes_holders=["world"]):
  gbrain_<64hex>

$ gbrain auth create foo --takes-holders world,garry            # still works
Token created for "foo" (takes_holders=["world","garry"]):
  gbrain_<64hex>
```

## Context

Hit this while wiring an openclaw container to gbrain via remote-HTTP MCP — `gbrain auth create <name>` is exactly the canonical credential-mint step in that flow, and it tripped on the first call. Workaround was `--takes-holders world` (the documented default value). This patch removes the workaround need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)