### PR TITLE
docs(cli): surface EVAL subcommand family in top-level --help

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1651,6 +1651,14 @@ JOBS (Minions)
   jobs stats                          Job health dashboard
   jobs work [--queue Q]               Start worker daemon (Postgres only)
 
+EVAL
+  eval cross-modal                    Multi-model quality gate (3 frontier providers)
+  eval takes-quality                  Takes-vs-facts classifier eval (3-model panel)
+  eval longmemeval <dataset.jsonl>    Longitudinal memory eval (LongMemEval adapter)
+  eval whoknows                       Expertise-routing eval (findExperts hit-rate)
+  eval trajectory <entity-slug>       Typed-claim trajectory + drift score
+  eval run-all                        Run all eval suites (mode x suite sweep)
+
 ADMIN
   stats                              Brain statistics
   health                             Brain health dashboard


### PR DESCRIPTION
## Summary

Adds an `EVAL` section to `gbrain --help` that lists the six most useful `eval ...` subcommands that already ship in the binary. Pure help-text addition in `src/cli.ts` — no logic changes, backwards compatible by construction.

## Why

The top-level `gbrain --help` advertises CORE / PAGES / SEARCH / TOOLS / JOBS / ADMIN / etc., but omits the `eval` family entirely. The actual subcommands (`eval cross-modal`, `eval takes-quality`, `eval longmemeval`, `eval whoknows`, `eval trajectory`, `eval run-all`, plus several others — `eval brainstorm`, `eval replay`, `eval export`, `eval prune`, `eval code-retrieval`, `eval compare`, `eval suspected-contradictions`) all exist as routed commands with their own files under `src/commands/eval-*.ts`.

The discoverability gap: when someone runs `gbrain eval --help` (the bare dispatcher) they get the generic "run gbrain --help for the full command list" message, then `gbrain --help` doesn't mention `eval` anywhere, and they reasonably conclude the family doesn't exist. We just hit this misdiagnosis in our own rollout — the CLI was there all along, the help text just didn't say so.

This PR is scoped narrowly to the discoverability fix. The `gbrain eval` dispatcher behavior when called without a subcommand is a separate concern and not touched here.

## What changed

`src/cli.ts` — 8 inserted lines, placed between `JOBS (Minions)` and `ADMIN`, following the same heading + 2-space-indent + column-38 description format used by every other section:

```
EVAL
  eval cross-modal                    Multi-model quality gate (3 frontier providers)
  eval takes-quality                  Takes-vs-facts classifier eval (3-model panel)
  eval longmemeval <dataset.jsonl>    Longitudinal memory eval (LongMemEval adapter)
  eval whoknows                       Expertise-routing eval (findExperts hit-rate)
  eval trajectory <entity-slug>       Typed-claim trajectory + drift score
  eval run-all                        Run all eval suites (mode x suite sweep)
```

Picked the six most user-facing entries; the more internal ones (`eval export`, `eval prune`, `eval replay`, `eval compare`, `eval suspected-contradictions`, `eval code-retrieval`, `eval brainstorm`) are left off the top-level surface to keep the section scannable, but remain reachable via `gbrain eval <name>`.

## Test plan

- [ ] Visually diff the new section against neighboring sections (JOBS, ADMIN) — column alignment matches at col 38.
- [ ] Run `gbrain --help` after build and confirm the EVAL section renders with all six commands.
- [ ] Confirm no behavioral change: this is a string-literal addition inside the existing top-level help template; no command routing is touched.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>