### PR TITLE
feat(subagent): honor subagent_def at runtime — load def.body + def.allowed_tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to GBrain will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Subagent handler honors `data.subagent_def` at runtime. When set AND the
+  named def exists in the plugin registry (populated at worker startup by
+  `loadPluginsFromEnv`):
+  - `def.body` is used as the default system prompt — overridable by
+    explicit `data.system`
+  - `def.allowed_tools` is used as the default allowed tool set — overridable
+    by explicit `data.allowed_tools` (data wins fully when set; def is the
+    convenience default)
+  
+  Closes the doctrine-vs-implementation gap where the plugin-loader validated
+  defs at startup (catching typos in `allowed_tools` etc.) but the handler
+  ignored the loaded def at job-dispatch time. Callers previously had to
+  embed the full system body and tool list in every job submission for the
+  named def to take effect.
+  
+  Backward compatible: when `data.subagent_def` is absent, behavior is
+  unchanged. When `data.subagent_def` names a def NOT in the loaded
+  registry (worker has a stale plugin path), the handler logs a warning
+  and falls through to current behavior (fail open, not closed). Empty or
+  whitespace-only `def.body` is treated as no-body and falls through to
+  `DEFAULT_SYSTEM`.
+  
+  Required to establish the registry: `loadPluginsFromEnv` in
+  `plugin-loader.ts` now populates a module-level `_subagentRegistry` Map
+  alongside its existing log-only behavior; lookup-only public access via
+  exported `getSubagentDef(name)`.
+
 ## [0.37.9.0] - 2026-05-20
 
 **Tags get written the same way everywhere now.**

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -48,6 +48,7 @@ import {
   logSubagentHeartbeat,
 } from './subagent-audit.ts';
 import { resolveModel, isAnthropicProvider, TIER_DEFAULTS } from '../../model-config.ts';
+import { getSubagentDef } from '../plugin-loader.ts';
 
 // ── Defaults ────────────────────────────────────────────────
 
@@ -166,7 +167,34 @@ export function makeSubagentHandler(deps: SubagentDeps) {
         fallback: TIER_DEFAULTS.subagent,
       });
     const maxTurns = data.max_turns ?? DEFAULT_MAX_TURNS;
-    const systemPrompt = data.system ?? DEFAULT_SYSTEM;
+
+    // Resolve subagent_def → registered plugin def, if any. Used as a
+    // fallback source for systemPrompt and allowed_tools when data.system
+    // / data.allowed_tools are not explicitly set. Closes the doctrine-
+    // vs-implementation gap where plugin-loader validated defs at startup
+    // but the handler ignored them at job-dispatch.
+    //
+    // Resolution order:
+    //   systemPrompt: data.system → def.body (when non-empty) → DEFAULT_SYSTEM
+    //   allowed_tools: data.allowed_tools → def.allowed_tools → full registry
+    //
+    // Override semantics: data fields ALWAYS win when explicitly provided.
+    // Callers retain full control; def is a convenience default.
+    //
+    // Failure mode: data.subagent_def set but def not in registry (caller's
+    // worker has a stale plugin path) → warn + fall through to current
+    // behavior. Fail open, not closed.
+    const def = data.subagent_def
+      ? getSubagentDef(data.subagent_def)
+      : undefined;
+    if (data.subagent_def && !def) {
+      console.warn(
+        `[subagent] subagent_def '${data.subagent_def}' not found in plugin registry; ` +
+        `falling back to data fields (data.system or DEFAULT_SYSTEM; data.allowed_tools or full registry)`,
+      );
+    }
+    const defBody = def?.body && def.body.trim().length > 0 ? def.body : undefined;
+    const systemPrompt = data.system ?? defBody ?? DEFAULT_SYSTEM;
 
     // Build the tool registry bound to THIS job as the owning subagent.
     // brain_id (per-call brain override; children inherit parent's unless
@@ -181,9 +209,11 @@ export function makeSubagentHandler(deps: SubagentDeps) {
       brainId: data.brain_id,
       allowedSlugPrefixes: data.allowed_slug_prefixes,
     });
-    const toolDefs = data.allowed_tools && data.allowed_tools.length > 0
+    const toolDefs = (data.allowed_tools && data.allowed_tools.length > 0)
       ? filterAllowedTools(registry, data.allowed_tools)
-      : registry;
+      : (def?.allowed_tools && def.allowed_tools.length > 0)
+        ? filterAllowedTools(registry, def.allowed_tools)
+        : registry;
 
     logSubagentSubmission({
       caller: 'worker',

--- a/src/core/minions/plugin-loader.ts
+++ b/src/core/minions/plugin-loader.ts
@@ -117,6 +117,11 @@ export function loadPluginsFromEnv(opts: LoadOpts = {}): PluginLoadResult {
         }
         subagentByName.set(sa.name, { pluginName: loaded.manifest.name, pathLeft: p });
         accepted.push(sa);
+        // Register into the runtime registry so the subagent handler can
+        // resolve data.subagent_def → def at job-dispatch time. Left-wins
+        // collision policy (above) means the first plugin to declare a name
+        // wins, matching the warning text.
+        _subagentRegistry.set(sa.name, sa);
       }
 
       result.plugins.push({ manifest: loaded.manifest, rootDir: p, subagents: accepted });
@@ -127,6 +132,29 @@ export function loadPluginsFromEnv(opts: LoadOpts = {}): PluginLoadResult {
   }
 
   return result;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Runtime subagent-def registry
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Populated by loadPluginsFromEnv at worker startup. Read by the subagent
+// handler (handlers/subagent.ts) when a job specifies data.subagent_def.
+// Lookup-only public API; mutation happens only via loadPluginsFromEnv.
+//
+// Lifetime: lives for the worker process lifetime. Re-running
+// loadPluginsFromEnv (e.g., on plugin path changes) does NOT clear stale
+// entries — collisions are resolved left-wins per the existing policy, but
+// removed plugins linger until process restart. Acceptable for v1; plugin
+// hot-reload is out of scope.
+
+const _subagentRegistry = new Map<string, SubagentDefinition>();
+
+/** Look up a registered subagent def by name. Returns undefined if not
+ *  found in the registry — caller decides fallback behavior (the subagent
+ *  handler logs a warning and falls through to DEFAULT_SYSTEM). */
+export function getSubagentDef(name: string): SubagentDefinition | undefined {
+  return _subagentRegistry.get(name);
 }
 
 function rejectIfNotAbsolute(p: string): string | null {
@@ -232,4 +260,15 @@ export function loadSinglePlugin(
 export const __testing = {
   rejectIfNotAbsolute,
   SUPPORTED_PLUGIN_VERSION,
+  /** Seed a def into the registry. Used by subagent handler tests that
+   *  need to verify the runtime lookup path without going through
+   *  filesystem plugin discovery. */
+  _seedSubagentDef(def: SubagentDefinition): void {
+    _subagentRegistry.set(def.name, def);
+  },
+  /** Clear the registry. Tests should call this in afterEach/beforeEach
+   *  to keep state isolated. */
+  _clearSubagentRegistry(): void {
+    _subagentRegistry.clear();
+  },
 };

--- a/test/subagent-def-runtime-contract.test.ts
+++ b/test/subagent-def-runtime-contract.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Subagent def-as-runtime-contract tests.
+ *
+ * Verifies the resolution path added so that when a job specifies
+ * `data.subagent_def`, the plugin-registered def's body becomes the
+ * default system prompt and the def's allowed_tools become the default
+ * allowed set — both overridable by explicit data fields. Backward-
+ * compatible: when subagent_def is absent OR names an unknown def, the
+ * handler falls through to current behavior (data.system or
+ * DEFAULT_SYSTEM; data.allowed_tools or full registry).
+ *
+ * Inspection strategy: FakeMessagesClient captures the params handed to
+ * Anthropic.Messages.create; tests assert client.calls[0].system and
+ * client.calls[0].tools matches the expected resolution.
+ *
+ * Registry seeding goes through plugin-loader's __testing surface so we
+ * don't need on-disk plugin fixtures to verify the in-process lookup.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { MinionQueue } from '../src/core/minions/queue.ts';
+import {
+  makeSubagentHandler,
+  type MessagesClient,
+} from '../src/core/minions/handlers/subagent.ts';
+import { __testing as pluginLoaderTesting } from '../src/core/minions/plugin-loader.ts';
+import type { ToolDef, MinionJobContext } from '../src/core/minions/types.ts';
+import type Anthropic from '@anthropic-ai/sdk';
+
+const DEFAULT_SYSTEM = 'You are a helpful assistant running as a gbrain subagent.';
+
+let engine: PGLiteEngine;
+let queue: MinionQueue;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ database_url: '' });
+  await engine.initSchema();
+  queue = new MinionQueue(engine);
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await engine.executeRaw('DELETE FROM subagent_tool_executions');
+  await engine.executeRaw('DELETE FROM subagent_messages');
+  await engine.executeRaw('DELETE FROM subagent_rate_leases');
+  await engine.executeRaw('DELETE FROM minion_jobs');
+  pluginLoaderTesting._clearSubagentRegistry();
+});
+
+// ── Helpers ────────────────────────────────────────────────
+
+type FakeResponse = Partial<Anthropic.Message> & { content: Anthropic.Message['content'] };
+
+class FakeMessagesClient implements MessagesClient {
+  public calls: Anthropic.MessageCreateParamsNonStreaming[] = [];
+  constructor(private responses: FakeResponse[]) {}
+  async create(
+    params: Anthropic.MessageCreateParamsNonStreaming,
+  ): Promise<Anthropic.Message> {
+    this.calls.push(params);
+    if (this.responses.length === 0) throw new Error('FakeMessagesClient: out of scripted responses');
+    const r = this.responses.shift()!;
+    return {
+      id: `msg_${this.calls.length}`,
+      type: 'message',
+      role: 'assistant',
+      model: params.model,
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } as any,
+      ...r,
+    } as Anthropic.Message;
+  }
+}
+
+async function makeCtx(input: unknown): Promise<MinionJobContext> {
+  const job = await queue.add(
+    'subagent',
+    input as Record<string, unknown>,
+    {},
+    { allowProtectedSubmit: true },
+  );
+  return {
+    id: job.id,
+    name: job.name,
+    data: (input as Record<string, unknown>) ?? {},
+    attempts_made: 0,
+    signal: new AbortController().signal,
+    shutdownSignal: new AbortController().signal,
+    async updateProgress() {},
+    async updateTokens() {},
+    async log() {},
+    async isActive() { return true; },
+    async readInbox() { return []; },
+  };
+}
+
+function makeNoopTool(name: string): ToolDef {
+  return {
+    name,
+    description: `noop ${name}`,
+    input_schema: { type: 'object', properties: {}, required: [] },
+    idempotent: true,
+    async execute() { return {}; },
+  };
+}
+
+// One canonical "OK" response — every test that doesn't care about tool flow uses this
+function makeOkClient(): FakeMessagesClient {
+  return new FakeMessagesClient([
+    { content: [{ type: 'text', text: 'OK' }] as any, stop_reason: 'end_turn' },
+  ]);
+}
+
+// Pull the system-prompt string out of params.system (may be string or
+// content-block array depending on cache markers).
+function systemText(params: Anthropic.MessageCreateParamsNonStreaming): string {
+  if (typeof params.system === 'string') return params.system;
+  if (Array.isArray(params.system)) {
+    return params.system.map(b => (typeof b === 'string' ? b : (b as any).text ?? '')).join('');
+  }
+  return '';
+}
+
+function toolNames(params: Anthropic.MessageCreateParamsNonStreaming): string[] {
+  return (params.tools ?? []).map(t => (t as any).name);
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe('subagent def-as-runtime-contract — resolution paths', () => {
+
+  test('def.body becomes system prompt when subagent_def set and no data.system override', async () => {
+    pluginLoaderTesting._seedSubagentDef({
+      plugin_name: 'test-plugin',
+      name: 'test-def-1',
+      source_path: '/tmp/test-def-1.md',
+      frontmatter: {},
+      body: 'CUSTOM SYSTEM PROMPT FROM DEF',
+      allowed_tools: undefined,
+    });
+    const client = makeOkClient();
+    const handler = makeSubagentHandler({ engine, client, toolRegistry: [] });
+    const ctx = await makeCtx({ prompt: 'hi', subagent_def: 'test-def-1' });
+
+    await handler(ctx);
+
+    expect(client.calls.length).toBe(1);
+    expect(systemText(client.calls[0]!)).toBe('CUSTOM SYSTEM PROMPT FROM DEF');
+    expect(systemText(client.calls[0]!)).not.toBe(DEFAULT_SYSTEM);
+  });
+
+  test('data.system overrides def.body when both provided (data wins)', async () => {
+    pluginLoaderTesting._seedSubagentDef({
+      plugin_name: 'test-plugin',
+      name: 'test-def-2',
+      source_path: '/tmp/test-def-2.md',
+      frontmatter: {},
+      body: 'DEF BODY SHOULD BE IGNORED',
+      allowed_tools: undefined,
+    });
+    const client = makeOkClient();
+    const handler = makeSubagentHandler({ engine, client, toolRegistry: [] });
+    const ctx = await makeCtx({
+      prompt: 'hi',
+      subagent_def: 'test-def-2',
+      system: 'EXPLICIT DATA OVERRIDE',
+    });
+
+    await handler(ctx);
+
+    expect(systemText(client.calls[0]!)).toBe('EXPLICIT DATA OVERRIDE');
+  });
+
+  test('def.allowed_tools used when data.allowed_tools absent', async () => {
+    pluginLoaderTesting._seedSubagentDef({
+      plugin_name: 'test-plugin',
+      name: 'test-def-3',
+      source_path: '/tmp/test-def-3.md',
+      frontmatter: {},
+      body: 'sys',
+      allowed_tools: ['alpha'],
+    });
+    const client = makeOkClient();
+    const registry = [makeNoopTool('alpha'), makeNoopTool('beta'), makeNoopTool('gamma')];
+    const handler = makeSubagentHandler({ engine, client, toolRegistry: registry });
+    const ctx = await makeCtx({ prompt: 'hi', subagent_def: 'test-def-3' });
+
+    await handler(ctx);
+
+    expect(toolNames(client.calls[0]!)).toEqual(['alpha']);
+  });
+
+  test('data.allowed_tools fully overrides def.allowed_tools (data wins)', async () => {
+    pluginLoaderTesting._seedSubagentDef({
+      plugin_name: 'test-plugin',
+      name: 'test-def-4',
+      source_path: '/tmp/test-def-4.md',
+      frontmatter: {},
+      body: 'sys',
+      allowed_tools: ['alpha'],
+    });
+    const client = makeOkClient();
+    const registry = [makeNoopTool('alpha'), makeNoopTool('beta'), makeNoopTool('gamma')];
+    const handler = makeSubagentHandler({ engine, client, toolRegistry: registry });
+    const ctx = await makeCtx({
+      prompt: 'hi',
+      subagent_def: 'test-def-4',
+      allowed_tools: ['beta'],
+    });
+
+    await handler(ctx);
+
+    // Data wins fully: only beta (NOT alpha from def, NOT gamma from registry)
+    expect(toolNames(client.calls[0]!)).toEqual(['beta']);
+  });
+
+  test('subagent_def names unknown def → warn + fall through to DEFAULT_SYSTEM + full registry', async () => {
+    // Capture console.warn output
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args.join(' '));
+
+    try {
+      const client = makeOkClient();
+      const registry = [makeNoopTool('alpha'), makeNoopTool('beta')];
+      const handler = makeSubagentHandler({ engine, client, toolRegistry: registry });
+      const ctx = await makeCtx({ prompt: 'hi', subagent_def: 'nonexistent-def' });
+
+      // Must NOT throw — fail open
+      const result = await handler(ctx);
+
+      expect(result.stop_reason).toBe('end_turn');
+      expect(systemText(client.calls[0]!)).toBe(DEFAULT_SYSTEM);
+      expect(toolNames(client.calls[0]!).sort()).toEqual(['alpha', 'beta']);
+      expect(warnings.some(w => /subagent_def 'nonexistent-def' not found/.test(w))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
+  test('subagent_def absent → existing behavior unchanged (backward compat)', async () => {
+    const client = makeOkClient();
+    const registry = [makeNoopTool('alpha'), makeNoopTool('beta')];
+    const handler = makeSubagentHandler({ engine, client, toolRegistry: registry });
+    const ctx = await makeCtx({ prompt: 'hi' });
+
+    await handler(ctx);
+
+    expect(systemText(client.calls[0]!)).toBe(DEFAULT_SYSTEM);
+    expect(toolNames(client.calls[0]!).sort()).toEqual(['alpha', 'beta']);
+  });
+
+  test('def.body empty/whitespace-only → treated as no body, falls to DEFAULT_SYSTEM', async () => {
+    pluginLoaderTesting._seedSubagentDef({
+      plugin_name: 'test-plugin',
+      name: 'test-def-7',
+      source_path: '/tmp/test-def-7.md',
+      frontmatter: {},
+      body: '   \n  \n',
+      allowed_tools: undefined,
+    });
+    const client = makeOkClient();
+    const handler = makeSubagentHandler({ engine, client, toolRegistry: [] });
+    const ctx = await makeCtx({ prompt: 'hi', subagent_def: 'test-def-7' });
+
+    await handler(ctx);
+
+    expect(systemText(client.calls[0]!)).toBe(DEFAULT_SYSTEM);
+  });
+});


### PR DESCRIPTION
## Summary

Wires `data.subagent_def` to be load-bearing at job-dispatch time: when set AND the named def exists in the plugin registry, `def.body` becomes the default system prompt and `def.allowed_tools` becomes the default allowed tool set. Both overridable by explicit `data.system` / `data.allowed_tools`. Backward compatible.

## Motivation

The plugin-loader at `src/core/minions/plugin-loader.ts` does substantive work at worker startup:
- Discovers `gbrain.plugin.json` manifests under each `GBRAIN_PLUGIN_PATH` entry
- Validates each subagent def's `allowed_tools` is a subset of the brain-allowlist (fails loudly on typos)
- Resolves left-wins collisions across multiple plugins
- Logs `[plugin-loader] loaded 'plugin-name' v1.0.0 (N subagents)` per discovered plugin

But the loaded `SubagentDefinition[]` data was **never consumed at runtime**: the subagent handler (`src/core/minions/handlers/subagent.ts:170`) reads `data.system ?? DEFAULT_SYSTEM` and `data.allowed_tools ?? registry` directly from job data, with no fallback to whatever the named def specified. The `data.subagent_def` field was set + persisted but never read.

Practical impact: callers had to re-embed the entire system body + allowed_tools list in every `queue.add('subagent', { ... })` submission to get the def's behavior. For a 4,583-byte subagent body, that's ~4.5 KB per job in `minion_jobs.data` plus the per-call complexity on the calling side.

Discovered while building a BAG-side subagent (`aaron-nl-to-shell-ctx`) under an internal stay-close-to-gbrain doctrine — the caller code in our TG dispatcher (Moses) was re-embedding the full subagent body on every submission, defeating the plugin system's stated purpose of letting operators declare reusable subagent contracts.

## Behavior

When `data.subagent_def` is set AND a matching def exists in the plugin registry (populated at worker startup by `loadPluginsFromEnv`):

| Field | Resolution order |
|-------|------------------|
| `systemPrompt` | `data.system` → `def.body` (when non-empty) → `DEFAULT_SYSTEM` |
| `allowed_tools` | `data.allowed_tools` → `def.allowed_tools` → full registry |

Override semantics: **data fields ALWAYS win when explicitly provided.** Callers retain full control; the def is a convenience default.

Fail-open behavior (handler never throws on these):
- `data.subagent_def` set but def not in registry (e.g., worker has a stale plugin path while caller has a newer one) → warn to stderr + fall through to current behavior
- `def.body` empty or whitespace-only → treat as no-body, fall through to `DEFAULT_SYSTEM`
- `data.subagent_def` absent → behavior unchanged (backward compatible)

## Required infrastructure: register the registry

To enable lookup, `loadPluginsFromEnv` now ALSO populates a module-level `_subagentRegistry: Map<string, SubagentDefinition>` alongside its existing log output. Lookup-only public API:

```typescript
export function getSubagentDef(name: string): SubagentDefinition | undefined
```

Registry lives for the worker process lifetime. Left-wins collision policy (already enforced by plugin-loader's existing `subagentByName` Map) is honored on registration.

## Testing

New file `test/subagent-def-runtime-contract.test.ts` — **7 test cases, all PASS in 2.72s**:

| # | Case |
|---|------|
| 1 | `def.body` becomes system prompt when subagent_def set + no data.system override |
| 2 | `data.system` overrides def.body (data wins) |
| 3 | `def.allowed_tools` used when data.allowed_tools absent |
| 4 | `data.allowed_tools` fully overrides def.allowed_tools (NOT intersection — data wins fully) |
| 5 | subagent_def names unknown def → warn + fall through to DEFAULT_SYSTEM + full registry (fail-open) |
| 6 | subagent_def absent → existing behavior unchanged (backward compat) |
| 7 | def.body empty/whitespace-only → treated as no-body, falls to DEFAULT_SYSTEM |

Tests use the same pattern as existing `test/subagent-handler.test.ts` (PGLite in-memory + FakeMessagesClient capturing `params.system` and `params.tools` from the Messages API call). Registry seeding via a new `__testing._seedSubagentDef(def)` + `__testing._clearSubagentRegistry()` surface so tests don't need on-disk plugin fixtures.

`bun run test`: **7967 pass / 15 fail** — 15 failures are the same pre-existing baseline (skillpack-check, check-resolvable, BrainRegistry, ConnectionManager, apply-migrations). Zero failures in plugin-loader / subagent / handler paths.

## Backward Compatibility

Purely additive surface. Existing callers without `data.subagent_def` see no behavior change. The `MinionJobContext` type, the `SubagentHandlerData` shape, and the `SubagentDefinition` shape all unchanged — only the handler's resolution logic + the addition of the registry export.

## Out of Scope

- **Plugin hot-reload.** Registry lives for the worker process lifetime; removed plugins linger until restart. Acceptable for v1; hot-reload deserves its own design discussion.
- **Per-job def versioning.** A future enhancement could pin `data.subagent_def_version`; this PR doesn't add it.
- **Intersection semantics on allowed_tools.** This PR chose "data wins fully" over "intersect" — happy to flip if you prefer; let me know.

## Notes

This is the second BAG → gbrain contribution under our internal stay-close-to-gbrain doctrine. First PR (queued separately) added `--poll-interval` flag to `gbrain jobs work`. Both came out of measurement work for a multi-host agent fleet that uses gbrain's MinionQueue + subagent + plugin systems heavily.

Happy to adjust per repo conventions — the `Co-Authored-By: Claude` trailer is on the commit but easily droppable, intersection-vs-override semantics easily swappable, CHANGELOG entry shape easily adjustable.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — happy to adjust attribution as preferred.