### PR TITLE
fix: add timeout to doctor frontmatter_integrity check

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2972,9 +2972,13 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
   // backups so it works for both git and non-git brain repos.
   progress.heartbeat('frontmatter_integrity');
   const fmHb = startHeartbeat(progress, 'scanning frontmatter…');
+  // Guard against full-brain FS walks hanging on large brains (200K+ pages).
+  // AbortSignal.timeout fires after 30s; scanBrainSources respects opts.signal.
+  const fmTimeoutMs = parseInt(process.env.GBRAIN_DOCTOR_FM_TIMEOUT_MS || '30000', 10);
   try {
     const { scanBrainSources } = await import('../core/brain-writer.ts');
-    const report = await scanBrainSources(engine);
+    const fmAbort = AbortSignal.timeout(fmTimeoutMs);
+    const report = await scanBrainSources(engine, { signal: fmAbort });
     if (report.total === 0) {
       const sources = report.per_source.length;
       checks.push({
@@ -3002,10 +3006,14 @@ export async function runDoctor(engine: BrainEngine | null, args: string[], dbSo
       });
     }
   } catch (e) {
+    const isTimeout = e instanceof DOMException && e.name === 'AbortError';
     checks.push({
       name: 'frontmatter_integrity',
       status: 'warn',
-      message: `Could not scan frontmatter: ${e instanceof Error ? e.message : String(e)}`,
+      message: isTimeout
+        ? `Frontmatter scan timed out after ${fmTimeoutMs / 1000}s (brain too large for full walk). ` +
+          `Run \`gbrain frontmatter validate <source-path>\` directly, or raise GBRAIN_DOCTOR_FM_TIMEOUT_MS.`
+        : `Could not scan frontmatter: ${e instanceof Error ? e.message : String(e)}`,
     });
   } finally {
     fmHb();


### PR DESCRIPTION
## Problem

On brains with 200K+ pages, `gbrain doctor` hangs indefinitely during the `frontmatter_integrity` check. The check calls `scanBrainSources`, which synchronously walks every `.md` file on disk across all registered federated sources. On a production brain with 216K pages and 3 sources (default + zion-brain + media-corpus), this walk takes >60s and makes the doctor command appear hung.

The monitoring system that calls `gbrain doctor` on a cron has a 60s timeout — so the frontmatter check causes the entire health report to fail, masking all other checks.

## Root Cause

`scanBrainSources` already supports an `AbortSignal` via `opts.signal` — the `walkDir` callback checks `signal.aborted` on every file (line 430 of brain-writer.ts), and the source loop breaks on abort (line 382). However, the doctor caller in `doctor.ts` never passes a signal, so the scan runs unbounded.

## Solution

Pass `AbortSignal.timeout(30000)` from the doctor caller to `scanBrainSources`. When the timeout fires:
- The walk stops cleanly at the next file boundary
- Doctor reports a `warn` status with instructions to run the full scan directly
- All other doctor checks continue normally

The timeout is configurable via `GBRAIN_DOCTOR_FM_TIMEOUT_MS` (default: 30s) for brains that need more or less time.

### Changes

**`src/commands/doctor.ts`** (frontmatter_integrity section):
- Create `AbortSignal.timeout(fmTimeoutMs)` before the scan
- Pass it to `scanBrainSources(engine, { signal: fmAbort })`
- Detect `AbortError` in catch block and report actionable message

## Results

| Metric | Before | After |
|--------|--------|-------|
| Doctor with 216K pages | Hangs >60s, killed by monitoring timeout | Completes in ~45s, frontmatter reports warn |
| Doctor with <50K pages | ~30s (no issue) | ~30s (timeout never fires) |
| `gbrain frontmatter validate` directly | Unaffected | Unaffected |

## Testing

- Verified on a production brain with 216K pages across 3 federated sources
- Doctor completes in <50s with the timeout
- Frontmatter check reports warn with actionable fix instructions
- Full `gbrain frontmatter validate <path>` still works independently for targeted repair