### PR TITLE
fix: align brain ingestion run counters

### DIFF
--- a/.env.testing.example
+++ b/.env.testing.example
@@ -3,9 +3,14 @@
 #
 # Tier 1 (required for E2E tests)
 # Option A: Local Docker Postgres (default)
-DATABASE_URL=postgresql://postgres:postgres@localhost:5433/gbrain_test
+DATABASE_URL=postgresql://postgres:***@localhost:5433/gbrain_test
 # Option B: Real Supabase instance (tests the actual production path)
-# DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-0-us-east-1.pooler.supabase.com:6543/postgres
+# DATABASE_URL=postgresql://postgres.[project-ref]:***@aws-0-us-east-1.pooler.supabase.com:6543/postgres
+
+# Brain ingestion pilot storage (key names only; never commit real values)
+SUPABASE_URL=[REDACTED]
+SUPABASE_SERVICE_ROLE_KEY=[REDACTED]
+GBRAIN_BRAIN_INGESTION_ALLOW_WRITES=0
 
 # Tier 2 (required for skill tests, optional for mechanical tests)
 OPENAI_API_KEY=sk-...

--- a/docs/brain-ingestion-pilot.md
+++ b/docs/brain-ingestion-pilot.md
@@ -1,0 +1,63 @@
+# Brain Ingestion Pilot
+
+Status: operator skeleton for Phase 3 controlled backfill. This path is dry-run by default and only supports the Quant pilot sources approved in the Phase 2 runbook.
+
+## Scope
+
+Allowed pilot sources:
+
+- `afirebrand` / `quant_x:afirebrand`
+- `MoneyPrinter0x` / `quant_x:MoneyPrinter0x`
+- `Taiki Madea`, `Humble Farmer Army`, or `quant_x:TaikiMadea`
+
+Storage bucket:
+
+- `brain-archive`
+
+Universe and SF Hunter are not touched by this command.
+
+## Dry-run
+
+```bash
+gbrain brain-ingest --source afirebrand --storage brain-archive --limit 500 --json
+```
+
+Manifest form:
+
+```json
+{
+  "sources": ["afirebrand", "MoneyPrinter0x", "Taiki Madea"],
+  "bucket": "brain-archive",
+  "mode": "pilot",
+  "limit": 500
+}
+```
+
+```bash
+gbrain brain-ingest --manifest /tmp/brain-pilot-manifest.json --json
+```
+
+Dry-run lists and parses archive objects, computes idempotency keys, and prints quality gates without writing database rows.
+
+## Write mode
+
+Persistent writes require both the CLI flag and an environment opt-in:
+
+```bash
+SUPABASE_URL=[REDACTED] \
+SUPABASE_SERVICE_ROLE_KEY=[REDACTED] \
+GBRAIN_BRAIN_INGESTION_ALLOW_WRITES=1 \
+gbrain brain-ingest --manifest /tmp/brain-pilot-manifest.json --write --json
+```
+
+The command uses Supabase Storage through the existing storage backend. It upserts into the proposed Phase 1 `brain_*` tables by `idempotency_key` and records an ingestion run. Do not run write mode until the Phase 1 schema has been dry-run and applied to the target Supabase project.
+
+## Quality gates
+
+The output includes:
+
+- parse success rate, target `>= 95%`
+- duplicate idempotency key count, target `0`
+- storage/database consistency, deferred in dry-run and checked from write counters in write mode
+
+Any failed gate means stop the backfill and do not expand beyond the pilot.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd']);
+const CLI_ONLY = new Set(['init', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'brain-ingest', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd']);
 // CLI-only commands whose handlers print their own --help text. These are
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
@@ -39,6 +39,7 @@ const CLI_ONLY_SELF_HELP = new Set([
   'frontmatter', 'check-resolvable',
   'models',
   'cache',
+  'brain-ingest',
   'brainstorm', 'lsd',
 ]);
 
@@ -743,6 +744,20 @@ async function handleCliOnly(command: string, args: string[]) {
   if (command === 'auth') {
     const { runAuth } = await import('./commands/auth.ts');
     await runAuth(args);
+    return;
+  }
+  if (command === 'brain-ingest') {
+    const { runBrainIngest } = await import('./commands/brain-ingest.ts');
+    if (hasHelpFlag(args)) {
+      await runBrainIngest({} as BrainEngine, args);
+      return;
+    }
+    const engine = await connectEngine();
+    try {
+      await runBrainIngest(engine, args);
+    } finally {
+      await engine.disconnect();
+    }
     return;
   }
   if (command === 'remote') {

--- a/src/commands/brain-ingest.ts
+++ b/src/commands/brain-ingest.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from 'fs';
+import type { BrainEngine } from '../core/engine.ts';
+import { createStorage, type StorageConfig } from '../core/storage.ts';
+import {
+  BRAIN_ARCHIVE_BUCKET,
+  buildBrainIngestionPlan,
+  runBrainIngestion,
+  type BrainIngestionOptions,
+} from '../core/brain-ingestion.ts';
+
+interface BrainIngestManifest {
+  sources?: string[];
+  bucket?: string;
+  mode?: 'pilot' | 'staged';
+  limit?: number;
+  prefix?: string;
+}
+
+export async function runBrainIngest(engine: BrainEngine, args: string[]): Promise<void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const manifest = loadManifest(flag(args, '--manifest'));
+  const sources = listFlag(args, '--source');
+  const bucket = flag(args, '--storage') ?? flag(args, '--bucket') ?? manifest.bucket ?? BRAIN_ARCHIVE_BUCKET;
+  const mode = (flag(args, '--mode') ?? manifest.mode ?? 'pilot') as 'pilot' | 'staged';
+  const limit = parseInt(flag(args, '--limit') ?? String(manifest.limit ?? 500), 10);
+  const prefix = flag(args, '--prefix') ?? manifest.prefix;
+  const dryRun = !args.includes('--write');
+  const allowWrites = args.includes('--write') && process.env.GBRAIN_BRAIN_INGESTION_ALLOW_WRITES === '1';
+  const json = args.includes('--json');
+
+  const opts: BrainIngestionOptions = {
+    bucket,
+    mode,
+    sources: sources.length ? sources : (manifest.sources ?? []),
+    dryRun,
+    allowWrites,
+    limit,
+    prefix,
+  };
+
+  if (!opts.sources.length) {
+    console.error('Usage: gbrain brain-ingest --source afirebrand [--source MoneyPrinter0x] [--source "Taiki Madea"] [--dry-run|--write]');
+    process.exit(1);
+  }
+
+  // Validate before creating a storage client so allowlist errors never need credentials.
+  const plan = buildBrainIngestionPlan(opts);
+  const storage = await createStorage(readStorageConfig(bucket));
+  const result = await runBrainIngestion(engine, storage, { ...opts, sources: plan.sources.map(s => s.sourceKey) });
+
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  console.log(formatBrainIngestionResult(result));
+}
+
+function loadManifest(path: string | undefined): BrainIngestManifest {
+  if (!path) return {};
+  const parsed = JSON.parse(readFileSync(path, 'utf8')) as BrainIngestManifest;
+  return parsed;
+}
+
+function readStorageConfig(bucket: string): StorageConfig {
+  const projectUrl = process.env.SUPABASE_URL ?? process.env.GBRAIN_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.GBRAIN_SUPABASE_SERVICE_ROLE_KEY;
+  if (!projectUrl || !serviceRoleKey) {
+    throw new Error('Brain ingestion storage requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (or GBRAIN_* equivalents); values are never logged.');
+  }
+  return { backend: 'supabase', bucket, projectUrl, serviceRoleKey };
+}
+
+function flag(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  return idx === -1 ? undefined : args[idx + 1];
+}
+
+function listFlag(args: string[], name: string): string[] {
+  const values: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === name && args[i + 1]) values.push(args[++i]);
+  }
+  return values;
+}
+
+function formatBrainIngestionResult(result: Awaited<ReturnType<typeof runBrainIngestion>>): string {
+  const lines = [
+    'Brain Ingestion',
+    '===============',
+    `Mode: ${result.mode}`,
+    `Bucket: ${result.bucket}`,
+    `Dry run: ${result.dryRun ? 'yes' : 'no'}`,
+    `Sources: ${result.sources.join(', ')}`,
+    '',
+    `Listed: ${result.counters.listed}`,
+    `Parsed: ${result.counters.parsed}`,
+    `Written: ${result.counters.written}`,
+    `Failed: ${result.counters.failed}`,
+    `Duplicates: ${result.counters.duplicates}`,
+    '',
+    'Quality gates:',
+  ];
+  for (const [name, gate] of Object.entries(result.qualityGates)) {
+    lines.push(`- ${name}: ${gate.passed ? 'PASS' : 'FAIL'} (${gate.detail})`);
+  }
+  if (result.failures.length) {
+    lines.push('', 'Failures:');
+    for (const failure of result.failures.slice(0, 10)) {
+      lines.push(`- ${failure.storagePath}: ${failure.error}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function printUsage(): void {
+  console.log(`Usage:
+  gbrain brain-ingest --source afirebrand --dry-run
+  gbrain brain-ingest --manifest /tmp/brain-pilot-manifest.json --json
+  GBRAIN_BRAIN_INGESTION_ALLOW_WRITES=1 gbrain brain-ingest --manifest /tmp/brain-pilot-manifest.json --write
+
+Defaults:
+  --storage ${BRAIN_ARCHIVE_BUCKET}
+  --mode pilot
+  --limit 500
+
+Write safety:
+  Dry-run is the default. Persistent writes require both --write and GBRAIN_BRAIN_INGESTION_ALLOW_WRITES=1.`);
+}

--- a/src/commands/brain-ingest.ts
+++ b/src/commands/brain-ingest.ts
@@ -107,6 +107,12 @@ function formatBrainIngestionResult(result: Awaited<ReturnType<typeof runBrainIn
   for (const [name, gate] of Object.entries(result.qualityGates)) {
     lines.push(`- ${name}: ${gate.passed ? 'PASS' : 'FAIL'} (${gate.detail})`);
   }
+  if (result.samples.length) {
+    lines.push('', 'Samples:');
+    for (const sample of result.samples) {
+      lines.push(`- ${sample.sourceKey} ${sample.storagePath}: ${sample.title ?? sample.bodyPreview} [quality_status=${sample.qualityStatus}]`);
+    }
+  }
   if (result.failures.length) {
     lines.push('', 'Failures:');
     for (const failure of result.failures.slice(0, 10)) {

--- a/src/core/brain-ingestion.ts
+++ b/src/core/brain-ingestion.ts
@@ -41,6 +41,7 @@ export interface BrainIngestionSourcePlan {
   sourceKey: typeof BRAIN_QUANT_PILOT_SOURCE_KEYS[number];
   sourceType: BrainSourceType;
   storagePrefix: string;
+  storagePrefixes: string[];
 }
 
 export interface BrainIngestionPlan {
@@ -90,6 +91,14 @@ export interface BrainIngestionResult {
     written: number;
     duplicates: number;
   };
+  samples: Array<{
+    sourceKey: string;
+    storagePath: string;
+    title: string | null;
+    authorHandle: string | null;
+    bodyPreview: string;
+    qualityStatus: 'new';
+  }>;
   qualityGates: {
     parseSuccess: BrainQualityGateResult;
     idempotency: BrainQualityGateResult;
@@ -97,6 +106,12 @@ export interface BrainIngestionResult {
   };
   failures: Array<{ storagePath: string; error: string }>;
 }
+
+const REAL_ARCHIVE_LAYOUT_PREFIXES: Record<typeof BRAIN_QUANT_PILOT_SOURCE_KEYS[number], string[]> = {
+  'quant_x:afirebrand': ['13f'],
+  'quant_x:MoneyPrinter0x': ['poi/all-in-podcast'],
+  'quant_x:TaikiMadea': ['poi/dylan-patel', 'poi/jensen-huang', 'poi/moonshots-podcast'],
+};
 
 export function normalizeBrainPilotSource(input: string): typeof BRAIN_QUANT_PILOT_SOURCE_KEYS[number] {
   const direct = PILOT_SOURCE_ALIASES[input] ?? PILOT_SOURCE_ALIASES[input.trim()];
@@ -122,11 +137,17 @@ export function buildBrainIngestionPlan(opts: BrainIngestionOptions): BrainInges
     mode: opts.mode,
     dryRun: opts.dryRun,
     limit: opts.limit ?? 500,
-    sources: uniqueSources.map(sourceKey => ({
-      sourceKey,
-      sourceType: 'quant_x',
-      storagePrefix: `${prefixRoot}/quant_x/${sourceKey.slice('quant_x:'.length)}`,
-    })),
+    sources: uniqueSources.map(sourceKey => {
+      const storagePrefix = `${prefixRoot}/quant_x/${sourceKey.slice('quant_x:'.length)}`;
+      return {
+        sourceKey,
+        sourceType: 'quant_x',
+        storagePrefix,
+        storagePrefixes: prefixRoot === 'pilot'
+          ? [storagePrefix, ...REAL_ARCHIVE_LAYOUT_PREFIXES[sourceKey]]
+          : [storagePrefix],
+      };
+    }),
   };
 }
 
@@ -179,6 +200,20 @@ export function parseBrainArchiveObject(
   };
 }
 
+export function parseBrainArchiveBytes(
+  sourceKey: string,
+  storagePath: string,
+  buf: Buffer,
+  bucket = BRAIN_ARCHIVE_BUCKET,
+): ParsedBrainSourceItem {
+  const text = buf.toString('utf8');
+  const trimmed = text.trimStart();
+  if (storagePath.endsWith('.json') || trimmed.startsWith('{')) {
+    return parseBrainArchiveObject(sourceKey, storagePath, JSON.parse(text), bucket);
+  }
+  return parseBrainArchiveObject(sourceKey, storagePath, parseTextArchivePayload(storagePath, text), bucket);
+}
+
 export async function runBrainIngestion(
   engine: BrainEngine,
   storage: StorageBackend,
@@ -196,15 +231,26 @@ export async function runBrainIngestion(
   let skipped = 0;
   let written = 0;
   let duplicates = 0;
+  const samples: BrainIngestionResult['samples'] = [];
 
   for (const source of plan.sources) {
-    const paths = (await storage.list(source.storagePrefix)).slice(0, plan.limit);
+    const paths = await listSourcePaths(storage, source, plan.limit);
     listed += paths.length;
     for (const storagePath of paths) {
       try {
         const buf = await storage.download(storagePath);
-        const item = parseBrainArchiveObject(source.sourceKey, storagePath, JSON.parse(buf.toString('utf8')), plan.bucket);
+        const item = parseBrainArchiveBytes(source.sourceKey, storagePath, buf, plan.bucket);
         parsed++;
+        if (samples.length < 5) {
+          samples.push({
+            sourceKey: item.sourceKey,
+            storagePath: item.storagePath,
+            title: item.title,
+            authorHandle: item.authorHandle,
+            bodyPreview: item.bodyText.slice(0, 160),
+            qualityStatus: 'new',
+          });
+        }
         if (seenKeys.has(item.idempotencyKey)) {
           duplicates++;
           skipped++;
@@ -229,6 +275,7 @@ export async function runBrainIngestion(
     mode: plan.mode,
     sources: plan.sources.map(s => s.sourceKey),
     counters: { listed, parsed, skipped, failed, written, duplicates },
+    samples,
     qualityGates: {
       parseSuccess: {
         passed: parseRate >= 0.95,
@@ -323,6 +370,39 @@ async function writeBrainSourceItem(
       [runId],
     );
   }
+}
+
+async function listSourcePaths(storage: StorageBackend, source: BrainIngestionSourcePlan, limit: number): Promise<string[]> {
+  const seen = new Set<string>();
+  const paths: string[] = [];
+  for (const prefix of source.storagePrefixes ?? [source.storagePrefix]) {
+    for (const path of await storage.list(prefix)) {
+      if (seen.has(path)) continue;
+      seen.add(path);
+      paths.push(path);
+      if (paths.length >= limit) return paths;
+    }
+  }
+  return paths;
+}
+
+function parseTextArchivePayload(storagePath: string, text: string): Record<string, unknown> {
+  const title = storagePath.endsWith('.md')
+    ? text.match(/^#\s+(.+)$/m)?.[1]
+    : storagePath.split('/').pop()?.replace(/\.[^.]+$/, '').replace(/[_-]+/g, ' ');
+  return {
+    id: storagePath,
+    title,
+    text: storagePath.endsWith('.xml') ? xmlToText(text) : text,
+    raw_format: storagePath.endsWith('.xml') ? 'xml' : 'markdown',
+  };
+}
+
+function xmlToText(text: string): string {
+  return text
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 function stringValue(value: unknown): string | null {

--- a/src/core/brain-ingestion.ts
+++ b/src/core/brain-ingestion.ts
@@ -1,0 +1,341 @@
+import { createHash } from 'crypto';
+import type { BrainEngine } from './engine.ts';
+import type { StorageBackend } from './storage.ts';
+
+export type BrainSourceType = 'youtube' | 'quant_x' | 'news' | 'person' | 'manual';
+export type BrainIngestionMode = 'pilot' | 'staged';
+export type BrainItemType = 'youtube_video' | 'youtube_comment' | 'x_post' | 'news_article' | 'person_profile' | 'manual_note' | 'manual_doc';
+
+export const BRAIN_ARCHIVE_BUCKET = 'brain-archive';
+export const BRAIN_QUANT_PILOT_SOURCE_KEYS = [
+  'quant_x:afirebrand',
+  'quant_x:MoneyPrinter0x',
+  'quant_x:TaikiMadea',
+] as const;
+
+const PILOT_SOURCE_ALIASES: Record<string, typeof BRAIN_QUANT_PILOT_SOURCE_KEYS[number]> = {
+  afirebrand: 'quant_x:afirebrand',
+  'quant_x:afirebrand': 'quant_x:afirebrand',
+  moneyprinter0x: 'quant_x:MoneyPrinter0x',
+  MoneyPrinter0x: 'quant_x:MoneyPrinter0x',
+  'quant_x:MoneyPrinter0x': 'quant_x:MoneyPrinter0x',
+  taikimadea: 'quant_x:TaikiMadea',
+  TaikiMadea: 'quant_x:TaikiMadea',
+  'Taiki Madea': 'quant_x:TaikiMadea',
+  'Humble Farmer Army': 'quant_x:TaikiMadea',
+  'Taiki Madea / Humble Farmer Army': 'quant_x:TaikiMadea',
+  'quant_x:TaikiMadea': 'quant_x:TaikiMadea',
+};
+
+export interface BrainIngestionOptions {
+  bucket: string;
+  mode: BrainIngestionMode;
+  sources: string[];
+  dryRun: boolean;
+  allowWrites?: boolean;
+  limit?: number;
+  prefix?: string;
+}
+
+export interface BrainIngestionSourcePlan {
+  sourceKey: typeof BRAIN_QUANT_PILOT_SOURCE_KEYS[number];
+  sourceType: BrainSourceType;
+  storagePrefix: string;
+}
+
+export interface BrainIngestionPlan {
+  bucket: string;
+  mode: BrainIngestionMode;
+  dryRun: boolean;
+  limit: number;
+  sources: BrainIngestionSourcePlan[];
+}
+
+export interface ParsedBrainSourceItem {
+  sourceKey: string;
+  itemType: BrainItemType;
+  externalId: string;
+  idempotencyKey: string;
+  title: string | null;
+  bodyText: string;
+  summary: string | null;
+  authorHandle: string | null;
+  authorDisplayName: string | null;
+  canonicalUrl: string | null;
+  sourceUrl: string | null;
+  publishedAt: string | null;
+  rawPayload: Record<string, unknown>;
+  storageBucket: string;
+  storagePath: string;
+  contentSha256: string;
+}
+
+export interface BrainQualityGateResult {
+  passed: boolean;
+  detail: string;
+  value?: number;
+  threshold?: number;
+}
+
+export interface BrainIngestionResult {
+  dryRun: boolean;
+  bucket: string;
+  mode: BrainIngestionMode;
+  sources: string[];
+  counters: {
+    listed: number;
+    parsed: number;
+    skipped: number;
+    failed: number;
+    written: number;
+    duplicates: number;
+  };
+  qualityGates: {
+    parseSuccess: BrainQualityGateResult;
+    idempotency: BrainQualityGateResult;
+    storageDatabaseConsistency: BrainQualityGateResult;
+  };
+  failures: Array<{ storagePath: string; error: string }>;
+}
+
+export function normalizeBrainPilotSource(input: string): typeof BRAIN_QUANT_PILOT_SOURCE_KEYS[number] {
+  const direct = PILOT_SOURCE_ALIASES[input] ?? PILOT_SOURCE_ALIASES[input.trim()];
+  if (direct) return direct;
+  const compact = input.trim().replace(/^@/, '').replace(/[\s_-]/g, '').toLowerCase();
+  const normalized = PILOT_SOURCE_ALIASES[compact];
+  if (normalized) return normalized;
+  throw new Error(`Source ${input} is not in the Quant pilot allowlist`);
+}
+
+export function buildBrainIngestionPlan(opts: BrainIngestionOptions): BrainIngestionPlan {
+  if (opts.bucket !== BRAIN_ARCHIVE_BUCKET) {
+    throw new Error(`Brain ingestion pilot expects Supabase Storage bucket ${BRAIN_ARCHIVE_BUCKET}`);
+  }
+  if (opts.mode !== 'pilot') {
+    throw new Error('Only pilot mode is enabled for Brain ingestion until quality gates pass');
+  }
+
+  const uniqueSources = Array.from(new Set(opts.sources.map(normalizeBrainPilotSource)));
+  const prefixRoot = (opts.prefix ?? 'pilot').replace(/^\/+|\/+$/g, '');
+  return {
+    bucket: opts.bucket,
+    mode: opts.mode,
+    dryRun: opts.dryRun,
+    limit: opts.limit ?? 500,
+    sources: uniqueSources.map(sourceKey => ({
+      sourceKey,
+      sourceType: 'quant_x',
+      storagePrefix: `${prefixRoot}/quant_x/${sourceKey.slice('quant_x:'.length)}`,
+    })),
+  };
+}
+
+export function createBrainIngestionIdempotencyKey(sourceKey: string, externalId: string, contentSha256: string): string {
+  return createHash('sha256')
+    .update(`${sourceKey}\0${externalId}\0${contentSha256}`)
+    .digest('hex');
+}
+
+export function parseBrainArchiveObject(
+  sourceKey: string,
+  storagePath: string,
+  payload: unknown,
+  bucket = BRAIN_ARCHIVE_BUCKET,
+): ParsedBrainSourceItem {
+  if (!sourceKey.startsWith('quant_x:')) {
+    throw new Error(`No Brain ingestion adapter registered for ${sourceKey}`);
+  }
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error(`Archive object ${storagePath} must be a JSON object`);
+  }
+  const rawPayload = payload as Record<string, unknown>;
+  const text = stringValue(rawPayload.text) ?? stringValue(rawPayload.body_text) ?? stringValue(rawPayload.body) ?? '';
+  if (!text.trim()) throw new Error(`Archive object ${storagePath} has no text/body_text`);
+
+  const externalId = stringValue(rawPayload.id)
+    ?? stringValue(rawPayload.external_id)
+    ?? stringValue(rawPayload.post_id)
+    ?? createHash('sha256').update(storagePath).digest('hex');
+  const serialized = stableJson(rawPayload);
+  const contentSha256 = createHash('sha256').update(serialized).digest('hex');
+
+  return {
+    sourceKey,
+    itemType: 'x_post',
+    externalId,
+    idempotencyKey: createBrainIngestionIdempotencyKey(sourceKey, externalId, contentSha256),
+    title: stringValue(rawPayload.title),
+    bodyText: text,
+    summary: stringValue(rawPayload.summary),
+    authorHandle: stringValue(rawPayload.author) ?? stringValue(rawPayload.author_handle) ?? sourceKey.slice('quant_x:'.length),
+    authorDisplayName: stringValue(rawPayload.author_name) ?? stringValue(rawPayload.author_display_name),
+    canonicalUrl: stringValue(rawPayload.url) ?? stringValue(rawPayload.canonical_url),
+    sourceUrl: stringValue(rawPayload.source_url) ?? stringValue(rawPayload.url),
+    publishedAt: stringValue(rawPayload.created_at) ?? stringValue(rawPayload.published_at),
+    rawPayload,
+    storageBucket: bucket,
+    storagePath,
+    contentSha256,
+  };
+}
+
+export async function runBrainIngestion(
+  engine: BrainEngine,
+  storage: StorageBackend,
+  opts: BrainIngestionOptions,
+): Promise<BrainIngestionResult> {
+  const plan = buildBrainIngestionPlan(opts);
+  if (!plan.dryRun && !opts.allowWrites) {
+    throw new Error('Brain ingestion write mode requires --write plus GBRAIN_BRAIN_INGESTION_ALLOW_WRITES=1');
+  }
+
+  const failures: Array<{ storagePath: string; error: string }> = [];
+  const seenKeys = new Set<string>();
+  let listed = 0;
+  let parsed = 0;
+  let skipped = 0;
+  let written = 0;
+  let duplicates = 0;
+
+  for (const source of plan.sources) {
+    const paths = (await storage.list(source.storagePrefix)).slice(0, plan.limit);
+    listed += paths.length;
+    for (const storagePath of paths) {
+      try {
+        const buf = await storage.download(storagePath);
+        const item = parseBrainArchiveObject(source.sourceKey, storagePath, JSON.parse(buf.toString('utf8')), plan.bucket);
+        parsed++;
+        if (seenKeys.has(item.idempotencyKey)) {
+          duplicates++;
+          skipped++;
+          continue;
+        }
+        seenKeys.add(item.idempotencyKey);
+        if (!plan.dryRun) {
+          await writeBrainSourceItem(engine, source, item);
+          written++;
+        }
+      } catch (err) {
+        failures.push({ storagePath, error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+  }
+
+  const failed = failures.length;
+  const parseRate = listed === 0 ? 1 : parsed / listed;
+  return {
+    dryRun: plan.dryRun,
+    bucket: plan.bucket,
+    mode: plan.mode,
+    sources: plan.sources.map(s => s.sourceKey),
+    counters: { listed, parsed, skipped, failed, written, duplicates },
+    qualityGates: {
+      parseSuccess: {
+        passed: parseRate >= 0.95,
+        value: parseRate,
+        threshold: 0.95,
+        detail: `${parsed}/${listed} archive objects parsed`,
+      },
+      idempotency: {
+        passed: duplicates === 0,
+        value: duplicates,
+        threshold: 0,
+        detail: `${duplicates} duplicate idempotency keys seen in this run`,
+      },
+      storageDatabaseConsistency: {
+        passed: plan.dryRun ? true : written === parsed - duplicates,
+        value: plan.dryRun ? parsed : written,
+        detail: plan.dryRun ? 'dry-run: database consistency check deferred' : `${written} rows written for ${parsed - duplicates} parsed unique items`,
+      },
+    },
+    failures,
+  };
+}
+
+async function writeBrainSourceItem(
+  engine: BrainEngine,
+  source: BrainIngestionSourcePlan,
+  item: ParsedBrainSourceItem,
+): Promise<void> {
+  const sourceRows = await engine.executeRaw<{ id: string; enabled: boolean }>(
+    `SELECT id, enabled FROM brain_sources WHERE source_key = $1 LIMIT 1`,
+    [source.sourceKey],
+  );
+  const sourceRow = sourceRows[0];
+  if (!sourceRow) throw new Error(`Missing brain_sources row for ${source.sourceKey}`);
+  if (!sourceRow.enabled) throw new Error(`Brain source ${source.sourceKey} is disabled`);
+
+  const runRows = await engine.executeRaw<{ id: string }>(
+    `INSERT INTO brain_ingestion_runs (source_id, run_type, status, idempotency_key, items_seen, items_succeeded, items_failed)
+     VALUES ($1, 'backfill', 'running', $2, 0, 0, 0)
+     ON CONFLICT (idempotency_key) DO UPDATE SET updated_at = now()
+     RETURNING id`,
+    [sourceRow.id, `pilot:${item.idempotencyKey}`],
+  );
+  const runId = runRows[0]?.id;
+
+  await engine.executeRaw(
+    `INSERT INTO brain_source_items (
+       source_id, ingestion_run_id, item_type, external_id, canonical_url, source_url,
+       title, body_text, summary, author_handle, author_display_name, published_at,
+       raw_payload, storage_bucket, storage_path, content_sha256, idempotency_key,
+       quality_status, visibility
+     ) VALUES (
+       $1, $2, $3, $4, $5, $6,
+       $7, $8, $9, $10, $11, $12,
+       $13::jsonb, $14, $15, $16, $17,
+       'new', 'private'
+     )
+     ON CONFLICT (idempotency_key) DO UPDATE SET
+       ingestion_run_id = EXCLUDED.ingestion_run_id,
+       body_text = EXCLUDED.body_text,
+       raw_payload = EXCLUDED.raw_payload,
+       storage_bucket = EXCLUDED.storage_bucket,
+       storage_path = EXCLUDED.storage_path,
+       content_sha256 = EXCLUDED.content_sha256,
+       updated_at = now()`,
+    [
+      sourceRow.id,
+      runId,
+      item.itemType,
+      item.externalId,
+      item.canonicalUrl,
+      item.sourceUrl,
+      item.title,
+      item.bodyText,
+      item.summary,
+      item.authorHandle,
+      item.authorDisplayName,
+      item.publishedAt,
+      stableJson(item.rawPayload),
+      item.storageBucket,
+      item.storagePath,
+      item.contentSha256,
+      item.idempotencyKey,
+    ],
+  );
+
+  if (runId) {
+    await engine.executeRaw(
+      `UPDATE brain_ingestion_runs
+       SET status = 'succeeded', items_seen = 1, items_succeeded = 1, items_failed = 0, finished_at = now(), updated_at = now()
+       WHERE id = $1`,
+      [runId],
+    );
+  }
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!value || typeof value !== 'object') return value;
+  const obj = value as Record<string, unknown>;
+  return Object.fromEntries(Object.keys(obj).sort().map(k => [k, sortJson(obj[k])]));
+}

--- a/src/core/brain-ingestion.ts
+++ b/src/core/brain-ingestion.ts
@@ -313,8 +313,13 @@ async function writeBrainSourceItem(
   if (!sourceRow.enabled) throw new Error(`Brain source ${source.sourceKey} is disabled`);
 
   const runRows = await engine.executeRaw<{ id: string }>(
-    `INSERT INTO brain_ingestion_runs (source_id, run_type, status, idempotency_key, items_seen, items_succeeded, items_failed)
-     VALUES ($1, 'backfill', 'running', $2, 0, 0, 0)
+    `INSERT INTO brain_ingestion_runs (
+       source_id, run_type, status, idempotency_key,
+       started_at, items_seen, items_inserted, items_updated, items_skipped, error_count
+     ) VALUES (
+       $1, 'backfill', 'running', $2,
+       now(), 0, 0, 0, 0, 0
+     )
      ON CONFLICT (idempotency_key) DO UPDATE SET updated_at = now()
      RETURNING id`,
     [sourceRow.id, `pilot:${item.idempotencyKey}`],
@@ -324,7 +329,7 @@ async function writeBrainSourceItem(
   await engine.executeRaw(
     `INSERT INTO brain_source_items (
        source_id, ingestion_run_id, item_type, external_id, canonical_url, source_url,
-       title, body_text, summary, author_handle, author_display_name, published_at,
+       title, body_text, summary, author_handle, author_name, published_at,
        raw_payload, storage_bucket, storage_path, content_sha256, idempotency_key,
        quality_status, visibility
      ) VALUES (
@@ -365,7 +370,14 @@ async function writeBrainSourceItem(
   if (runId) {
     await engine.executeRaw(
       `UPDATE brain_ingestion_runs
-       SET status = 'succeeded', items_seen = 1, items_succeeded = 1, items_failed = 0, finished_at = now(), updated_at = now()
+       SET status = 'succeeded',
+           items_seen = 1,
+           items_inserted = 1,
+           items_updated = 0,
+           items_skipped = 0,
+           error_count = 0,
+           finished_at = now(),
+           updated_at = now()
        WHERE id = $1`,
       [runId],
     );

--- a/test/brain-ingestion.test.ts
+++ b/test/brain-ingestion.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+import type { StorageBackend } from '../src/core/storage.ts';
+import {
+  BRAIN_QUANT_PILOT_SOURCE_KEYS,
+  buildBrainIngestionPlan,
+  createBrainIngestionIdempotencyKey,
+  parseBrainArchiveObject,
+  runBrainIngestion,
+} from '../src/core/brain-ingestion.ts';
+
+function makeStorage(objects: Record<string, unknown>): StorageBackend {
+  return {
+    upload: async () => {},
+    download: async (path: string) => Buffer.from(JSON.stringify(objects[path])),
+    delete: async () => {},
+    exists: async (path: string) => Object.prototype.hasOwnProperty.call(objects, path),
+    list: async (prefix: string) => Object.keys(objects).filter(path => path.startsWith(prefix)),
+    getUrl: async (path: string) => `local://${path}`,
+  };
+}
+
+function makeEngine(): { engine: BrainEngine; calls: Array<{ sql: string; params?: unknown[] }> } {
+  const calls: Array<{ sql: string; params?: unknown[] }> = [];
+  const engine = {
+    kind: 'postgres' as const,
+    executeRaw: async <T>(sql: string, params?: unknown[]): Promise<T[]> => {
+      calls.push({ sql, params });
+      if (sql.includes('FROM brain_sources')) {
+        return [{ id: 'source-row-1', enabled: true }] as T[];
+      }
+      if (sql.includes('INSERT INTO brain_ingestion_runs')) {
+        return [{ id: 'run-row-1' }] as T[];
+      }
+      if (sql.includes('INSERT INTO brain_source_items')) {
+        return [{ id: 'item-row-1' }] as T[];
+      }
+      return [];
+    },
+  } as unknown as BrainEngine;
+  return { engine, calls };
+}
+
+describe('brain ingestion pilot allowlist', () => {
+  test('accepts only the three Quant pilot sources', () => {
+    expect(BRAIN_QUANT_PILOT_SOURCE_KEYS).toEqual([
+      'quant_x:afirebrand',
+      'quant_x:MoneyPrinter0x',
+      'quant_x:TaikiMadea',
+    ]);
+
+    const plan = buildBrainIngestionPlan({
+      bucket: 'brain-archive',
+      mode: 'pilot',
+      sources: ['afirebrand', 'MoneyPrinter0x', 'Taiki Madea'],
+      dryRun: true,
+    });
+
+    expect(plan.sources.map(s => s.sourceKey)).toEqual([...BRAIN_QUANT_PILOT_SOURCE_KEYS]);
+    expect(() => buildBrainIngestionPlan({
+      bucket: 'brain-archive',
+      mode: 'pilot',
+      sources: ['afirebrand', 'not-allowed'],
+      dryRun: true,
+    })).toThrow('not in the Quant pilot allowlist');
+  });
+});
+
+describe('brain archive parser routing', () => {
+  test('routes Quant archive objects to x_post source items', () => {
+    const item = parseBrainArchiveObject('quant_x:afirebrand', 'pilot/quant_x/afirebrand/post-1.json', {
+      id: 'post-1',
+      text: '$NVDA setup still intact',
+      author: 'afirebrand',
+      url: 'https://x.example/post-1',
+      created_at: '2026-05-21T00:00:00Z',
+    });
+
+    expect(item.itemType).toBe('x_post');
+    expect(item.externalId).toBe('post-1');
+    expect(item.bodyText).toBe('$NVDA setup still intact');
+    expect(item.authorHandle).toBe('afirebrand');
+    expect(item.storageBucket).toBe('brain-archive');
+  });
+
+  test('rejects unsupported source adapter paths instead of guessing', () => {
+    expect(() => parseBrainArchiveObject('youtube:channel', 'pilot/youtube/video.json', { id: 'v1' }))
+      .toThrow('No Brain ingestion adapter registered');
+  });
+});
+
+describe('brain ingestion idempotency and dry-run safety', () => {
+  test('builds stable idempotency keys from source and content hash', () => {
+    const a = createBrainIngestionIdempotencyKey('quant_x:afirebrand', 'post-1', 'abc');
+    const b = createBrainIngestionIdempotencyKey('quant_x:afirebrand', 'post-1', 'abc');
+    const c = createBrainIngestionIdempotencyKey('quant_x:afirebrand', 'post-2', 'abc');
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+  });
+
+  test('dry-run reads storage and emits quality gates without database writes', async () => {
+    const { engine, calls } = makeEngine();
+    const storage = makeStorage({
+      'pilot/quant_x/afirebrand/post-1.json': { id: 'post-1', text: 'one', author: 'afirebrand' },
+    });
+
+    const result = await runBrainIngestion(engine, storage, {
+      bucket: 'brain-archive',
+      mode: 'pilot',
+      sources: ['afirebrand'],
+      dryRun: true,
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.counters.parsed).toBe(1);
+    expect(result.counters.written).toBe(0);
+    expect(result.qualityGates.parseSuccess.passed).toBe(true);
+    expect(result.qualityGates.idempotency.passed).toBe(true);
+    expect(calls.length).toBe(0);
+  });
+
+  test('write mode requires explicit opt-in and records idempotent rows', async () => {
+    const { engine, calls } = makeEngine();
+    const storage = makeStorage({
+      'pilot/quant_x/afirebrand/post-1.json': { id: 'post-1', text: 'one', author: 'afirebrand' },
+    });
+
+    await expect(runBrainIngestion(engine, storage, {
+      bucket: 'brain-archive',
+      mode: 'pilot',
+      sources: ['afirebrand'],
+      dryRun: false,
+      allowWrites: false,
+    })).rejects.toThrow('Brain ingestion write mode requires');
+
+    const result = await runBrainIngestion(engine, storage, {
+      bucket: 'brain-archive',
+      mode: 'pilot',
+      sources: ['afirebrand'],
+      dryRun: false,
+      allowWrites: true,
+    });
+
+    expect(result.counters.written).toBe(1);
+    expect(calls.some(c => c.sql.includes('INSERT INTO brain_ingestion_runs'))).toBe(true);
+    expect(calls.some(c => c.sql.includes('ON CONFLICT'))).toBe(true);
+  });
+});

--- a/test/brain-ingestion.test.ts
+++ b/test/brain-ingestion.test.ts
@@ -12,7 +12,10 @@ import {
 function makeStorage(objects: Record<string, unknown>): StorageBackend {
   return {
     upload: async () => {},
-    download: async (path: string) => Buffer.from(JSON.stringify(objects[path])),
+    download: async (path: string) => {
+      const object = objects[path];
+      return Buffer.from(typeof object === 'string' ? object : JSON.stringify(object));
+    },
     delete: async () => {},
     exists: async (path: string) => Object.prototype.hasOwnProperty.call(objects, path),
     list: async (prefix: string) => Object.keys(objects).filter(path => path.startsWith(prefix)),
@@ -24,6 +27,11 @@ function makeEngine(): { engine: BrainEngine; calls: Array<{ sql: string; params
   const calls: Array<{ sql: string; params?: unknown[] }> = [];
   const engine = {
     kind: 'postgres' as const,
+    connect: async () => {},
+    disconnect: async () => {},
+    initSchema: async () => {},
+    transaction: async <T>(fn: (engine: BrainEngine) => Promise<T>) => fn(engine),
+    withReservedConnection: async <T>(fn: (conn: never) => Promise<T>) => fn({} as never),
     executeRaw: async <T>(sql: string, params?: unknown[]): Promise<T[]> => {
       calls.push({ sql, params });
       if (sql.includes('FROM brain_sources')) {
@@ -116,6 +124,41 @@ describe('brain ingestion idempotency and dry-run safety', () => {
     expect(result.counters.written).toBe(0);
     expect(result.qualityGates.parseSuccess.passed).toBe(true);
     expect(result.qualityGates.idempotency.passed).toBe(true);
+    expect(calls.length).toBe(0);
+  });
+
+  test('dry-run routes approved Quant pilot objects from the existing archive layout', async () => {
+    const { engine, calls } = makeEngine();
+    const storage = makeStorage({
+      '13f/SALP_13F_2026Q1_period-2026-03-31.xml': '<informationTable><infoTable><nameOfIssuer>NVIDIA CORP</nameOfIssuer><cusip>67066G104</cusip><value>1234</value><sshPrnamt>100</sshPrnamt></infoTable></informationTable>',
+      'poi/all-in-podcast/All-In_2026-01-23_Coinbase-CEO-s-Top-3-Crypto-Trends-for.md': '# Coinbase CEO\n\nBrian Armstrong discussed stablecoins, Bitcoin, and crypto market structure.',
+    });
+
+    const result = await runBrainIngestion(engine, storage, {
+      bucket: 'brain-archive',
+      mode: 'pilot',
+      sources: ['afirebrand', 'MoneyPrinter0x'],
+      dryRun: true,
+    });
+
+    expect(result.counters.listed).toBe(2);
+    expect(result.counters.parsed).toBe(2);
+    expect(result.counters.written).toBe(0);
+    expect(result.samples).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        sourceKey: 'quant_x:afirebrand',
+        storagePath: '13f/SALP_13F_2026Q1_period-2026-03-31.xml',
+        qualityStatus: 'new',
+      }),
+      expect.objectContaining({
+        sourceKey: 'quant_x:MoneyPrinter0x',
+        storagePath: 'poi/all-in-podcast/All-In_2026-01-23_Coinbase-CEO-s-Top-3-Crypto-Trends-for.md',
+        title: 'Coinbase CEO',
+        qualityStatus: 'new',
+      }),
+    ]));
+    expect(result.qualityGates.parseSuccess.passed).toBe(true);
+    expect(result.qualityGates.storageDatabaseConsistency.detail).toBe('dry-run: database consistency check deferred');
     expect(calls.length).toBe(0);
   });
 

--- a/test/brain-ingestion.test.ts
+++ b/test/brain-ingestion.test.ts
@@ -185,7 +185,16 @@ describe('brain ingestion idempotency and dry-run safety', () => {
     });
 
     expect(result.counters.written).toBe(1);
-    expect(calls.some(c => c.sql.includes('INSERT INTO brain_ingestion_runs'))).toBe(true);
+    const ingestionRunSql = calls
+      .filter(c => c.sql.includes('brain_ingestion_runs'))
+      .map(c => c.sql)
+      .join('\n');
+    expect(ingestionRunSql).toContain('items_inserted');
+    expect(ingestionRunSql).toContain('items_updated');
+    expect(ingestionRunSql).toContain('items_skipped');
+    expect(ingestionRunSql).toContain('error_count');
+    expect(ingestionRunSql).not.toContain('items_succeeded');
+    expect(ingestionRunSql).not.toContain('items_failed');
     expect(calls.some(c => c.sql.includes('ON CONFLICT'))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Align Brain ingestion write-mode run inserts/updates with the applied Phase 1 schema: items_inserted/items_updated/items_skipped/error_count.
- Preserve dry-run default and existing double opt-in for writes.
- Tighten write-mode test coverage so stale items_succeeded/items_failed cannot regress.

## Test plan
- bun test test/brain-ingestion.test.ts
- bun test (timed out after 300s after many passing tests; no failure observed before timeout)
- bun run build
- live smallest write smoke against Quant Supabase via /root/.hermes/kanban/workspaces/t_9c0f3d02/run-smallest-write.ts -> counters written=1 failed=0, storageDatabaseConsistency passed

## Notes
- No Universe/SF Hunter files touched.
- npm run lint equivalent is unavailable in this repo: bun reports Script not found "lint".