### PR TITLE
fix(initSchema): introspect live vector column dim to defend HNSW-2000 cap (#1141, #1189)

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -18,6 +18,7 @@ import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
 import { runMigrations } from './migrate.ts';
 import { PGLITE_SCHEMA_SQL, getPGLiteSchema } from './pglite-schema.ts';
 import { DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_DIMENSIONS } from './ai/defaults.ts';
+import { getLiveVectorColumnDims, resolveSchemaDims } from './vector-introspect.ts';
 import { acquireLock, releaseLock, type LockHandle } from './pglite-lock.ts';
 import type {
   Page, PageInput, PageFilters, PageType,
@@ -230,6 +231,29 @@ export class PGLiteEngine implements BrainEngine {
       dims = gw.getEmbeddingDimensions();
       model = gw.getEmbeddingModel() || model;
     } catch { /* gateway not configured — use defaults */ }
+
+    // #1141/#1189 guard: see the matching block in PostgresEngine.initSchema
+    // for the full rationale. When the gateway isn't configured (the
+    // `apply-migrations` Phase A path inside `gbrain upgrade`) and the
+    // live content_chunks.embedding column is wider than 2000 dims from
+    // a previous switch to a high-dim embedder, the schema replay would
+    // otherwise emit `idx_chunks_embedding USING hnsw` and pgvector would
+    // reject before any v47+ migration runs. resolveSchemaDims() only
+    // overrides when the HNSW-2000 decision flips, so this can't mask
+    // genuine config drift.
+    const liveDims = await getLiveVectorColumnDims(
+      async (sql, params) => {
+        const result = await this.db.query(sql, params ? Array.from(params) : []);
+        return result.rows as ReadonlyArray<Record<string, unknown>>;
+      },
+      'content_chunks',
+      'embedding',
+    );
+    const resolved = resolveSchemaDims(dims, liveDims);
+    if (resolved.overridden) {
+      process.stderr.write(`[initSchema] ${resolved.reason}\n`);
+      dims = resolved.dims;
+    }
 
     await this.db.exec(getPGLiteSchema(dims, model));
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -21,6 +21,7 @@ import { runMigrations } from './migrate.ts';
 import { SCHEMA_SQL } from './schema-embedded.ts';
 import { verifySchema } from './schema-verify.ts';
 import { applyChunkEmbeddingIndexPolicy, dropZombieIndexes } from './vector-index.ts';
+import { getLiveVectorColumnDims, resolveSchemaDims } from './vector-introspect.ts';
 import {
   normalizeEngineColumn,
   buildVectorCastFragment,
@@ -227,6 +228,37 @@ export class PostgresEngine implements BrainEngine {
       dims = gw.getEmbeddingDimensions();
       model = gw.getEmbeddingModel() || model;
     } catch { /* gateway not yet configured — use defaults */ }
+
+    // #1141/#1189 guard: when the gateway isn't configured (the
+    // `gbrain init --migrate-only` path inside `gbrain upgrade`'s Phase A),
+    // `dims` falls back to DEFAULT_EMBEDDING_DIMENSIONS. If the live
+    // content_chunks.embedding column was dimensioned for a high-dim
+    // embedder (zembed-1 2560d, Qwen3-Embedding-4B 2560d, etc.), the
+    // gateway value disagrees with what's actually on disk. Schema replay
+    // then emits `idx_chunks_embedding USING hnsw` via the
+    // applyChunkEmbeddingIndexPolicy at the gateway dim — pgvector
+    // rejects with `column cannot have more than 2000 dimensions for hnsw
+    // index` and Phase A aborts before any subsequent migration runs.
+    //
+    // The defensive read: introspect the column via format_type() and
+    // override `dims` when the live value crosses the HNSW-2000 boundary
+    // in the other direction from the gateway value. resolveSchemaDims()
+    // intentionally only fires the override when the override would
+    // change the HNSW policy decision — otherwise we'd silently mask
+    // genuine model/config drift.
+    const liveDims = await getLiveVectorColumnDims(
+      async (sql, params) => {
+        const rows = await conn.unsafe(sql, (params ? Array.from(params) : []) as never[]);
+        return rows as ReadonlyArray<Record<string, unknown>>;
+      },
+      'content_chunks',
+      'embedding',
+    );
+    const resolved = resolveSchemaDims(dims, liveDims);
+    if (resolved.overridden) {
+      process.stderr.write(`[initSchema] ${resolved.reason}\n`);
+      dims = resolved.dims;
+    }
 
     const sqlText = getPostgresSchema(dims, model);
 

--- a/src/core/vector-introspect.ts
+++ b/src/core/vector-introspect.ts
@@ -1,0 +1,124 @@
+/**
+ * Live introspection of pgvector column widths via `pg_attribute.atttypmod` +
+ * `format_type()`. Used at `initSchema` time to detect when the gateway-
+ * resolved embedding dimension disagrees with the actual on-disk column —
+ * the failure mode behind upstream gbrain #1141 and #1189.
+ *
+ * Closes the bug class where `gbrain init --migrate-only` (Phase A of
+ * `gbrain upgrade`) starts before the gateway has been configured from
+ * `~/.gbrain/config.json`. The gateway falls back to
+ * `DEFAULT_EMBEDDING_DIMENSIONS` (currently 1536); the live column for a
+ * brain previously switched to a high-dim embedder (ZeroEntropy zembed-1
+ * 2560d, Qwen3-Embedding-4B 2560d, etc.) is `vector(N>2000)`; the schema-
+ * replay emits the unconditional `idx_chunks_embedding` HNSW; pgvector
+ * rejects with `column cannot have more than 2000 dimensions for hnsw
+ * index`; Phase A aborts; `schema_version` never advances.
+ *
+ * The helper is engine-agnostic: it takes a `QueryRunner` callback so both
+ * `PostgresEngine` and `PGLiteEngine` can call it with their own driver.
+ * Best-effort by design — any probe failure returns `null` and the caller
+ * falls through to its existing gateway-resolved value.
+ */
+
+export const PGVECTOR_HNSW_VECTOR_MAX_DIMS = 2000;
+
+/**
+ * Minimal query interface: takes SQL + positional params, returns rows.
+ * Both engines can adapt to this shape with a 1-line lambda.
+ */
+export type VectorIntrospectQuery = (
+  sql: string,
+  params?: ReadonlyArray<unknown>,
+) => Promise<ReadonlyArray<Record<string, unknown>>>;
+
+/**
+ * Look up the declared width of a pgvector column on a live database.
+ *
+ * Returns the dimension (a positive integer) when the column exists AND
+ * its type is `vector(N)`. Returns `null` when:
+ *   - the table or column doesn't exist (fresh install)
+ *   - the column is not a `vector(...)` type
+ *   - the probe query throws for any reason
+ *
+ * Implementation note: `format_type(atttypid, atttypmod)` returns the
+ * canonical textual rendering of the type — e.g. `'vector(2560)'`. We
+ * parse the parenthesized count rather than reaching into pgvector's
+ * `atttypmod` bit-packing convention, which has changed across releases.
+ * Postgres' built-in `format_type` is stable.
+ *
+ * @param query  driver-specific query runner
+ * @param table  unqualified table name (must be a-z 0-9 _ — refuses anything else)
+ * @param column unqualified column name (same shape gate)
+ */
+export async function getLiveVectorColumnDims(
+  query: VectorIntrospectQuery,
+  table: string,
+  column: string,
+): Promise<number | null> {
+  if (!/^[a-z_][a-z0-9_]*$/.test(table) || !/^[a-z_][a-z0-9_]*$/.test(column)) {
+    return null;
+  }
+  try {
+    const rows = await query(
+      `SELECT format_type(a.atttypid, a.atttypmod) AS column_type
+         FROM pg_attribute a
+         JOIN pg_class c ON c.oid = a.attrelid
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = $1
+          AND a.attname = $2
+          AND NOT a.attisdropped`,
+      [table, column],
+    );
+    if (rows.length === 0) return null;
+    const raw = rows[0]?.column_type;
+    if (typeof raw !== 'string') return null;
+    const match = raw.match(/^vector\((\d+)\)$/i);
+    if (!match) return null;
+    const dim = Number(match[1]);
+    if (!Number.isInteger(dim) || dim <= 0) return null;
+    return dim;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Engine-agnostic "do we need to override the gateway dim?" decision.
+ *
+ * Returns the dim that `getPostgresSchema` / `getPGLiteSchema` should be
+ * called with. Prefers the live column dim when it disagrees with the
+ * gateway-resolved value AND the live value would change the HNSW-policy
+ * outcome (either side of `PGVECTOR_HNSW_VECTOR_MAX_DIMS`). Otherwise
+ * falls through to the gateway value untouched.
+ *
+ * The narrow override condition (only when the HNSW boundary is in play)
+ * is intentional: silently overriding the gateway on every initSchema
+ * would mask genuine misconfigurations. The boundary is exactly where
+ * the cap-2000 bug bites.
+ *
+ * @param gatewayDims dim resolved by the gateway (or default fallback)
+ * @param liveDims    dim probed from the live DB, or null if column absent
+ * @returns           dim to pass to the schema templater
+ */
+export function resolveSchemaDims(
+  gatewayDims: number,
+  liveDims: number | null,
+): { dims: number; overridden: boolean; reason?: string } {
+  if (liveDims === null) {
+    return { dims: gatewayDims, overridden: false };
+  }
+  if (liveDims === gatewayDims) {
+    return { dims: gatewayDims, overridden: false };
+  }
+  const gatewayWouldEmitHnsw = gatewayDims <= PGVECTOR_HNSW_VECTOR_MAX_DIMS;
+  const liveWouldEmitHnsw = liveDims <= PGVECTOR_HNSW_VECTOR_MAX_DIMS;
+  if (gatewayWouldEmitHnsw === liveWouldEmitHnsw) {
+    return { dims: gatewayDims, overridden: false };
+  }
+  return {
+    dims: liveDims,
+    overridden: true,
+    reason: `content_chunks.embedding is vector(${liveDims}) on disk but the gateway resolved ${gatewayDims}; using live dim so the HNSW-2000-cap policy fires correctly`,
+  };
+}

--- a/test/vector-introspect.test.ts
+++ b/test/vector-introspect.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression suite for the SQL-layer guard against pgvector's
+ * 2000-dim HNSW cap (upstream gbrain #1141 / #1189).
+ *
+ * Covers two layers:
+ *   1. `resolveSchemaDims` — pure decision function, no I/O.
+ *   2. `getLiveVectorColumnDims` against a real PGLite engine where we
+ *      manually pre-seed a `content_chunks` table at a non-default dim
+ *      and then assert the helper returns that dim. End-to-end proof
+ *      that `format_type()` round-trips on PGLite for the wide-dim case
+ *      that triggers the bug.
+ */
+
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import {
+  getLiveVectorColumnDims,
+  resolveSchemaDims,
+  PGVECTOR_HNSW_VECTOR_MAX_DIMS,
+  type VectorIntrospectQuery,
+} from '../src/core/vector-introspect.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+
+describe('resolveSchemaDims — HNSW boundary override decision', () => {
+  test('no override when live dim is null (column absent / fresh install)', () => {
+    const r = resolveSchemaDims(1536, null);
+    expect(r.dims).toBe(1536);
+    expect(r.overridden).toBe(false);
+  });
+
+  test('no override when live dim matches gateway dim', () => {
+    const r = resolveSchemaDims(1536, 1536);
+    expect(r.dims).toBe(1536);
+    expect(r.overridden).toBe(false);
+  });
+
+  test('no override when both sides are below the cap (drift but no policy flip)', () => {
+    // Gateway thinks 1024, live is 1536. Both <= 2000, both want HNSW.
+    // The override would mask genuine config drift without preventing a
+    // policy mistake; leave it alone.
+    const r = resolveSchemaDims(1024, 1536);
+    expect(r.dims).toBe(1024);
+    expect(r.overridden).toBe(false);
+  });
+
+  test('no override when both sides are above the cap (drift but no policy flip)', () => {
+    // Gateway thinks 3072, live is 2560. Both > 2000, both skip HNSW.
+    // Same logic — drift exists but the cap policy is unaffected.
+    const r = resolveSchemaDims(3072, 2560);
+    expect(r.dims).toBe(3072);
+    expect(r.overridden).toBe(false);
+  });
+
+  test('OVERRIDE: gateway under cap, live over cap (the #1141 bug path)', () => {
+    // The signature failure mode: gateway falls back to 1536 because the
+    // `gbrain init --migrate-only` subprocess hasn't read
+    // ~/.gbrain/config.json yet, but the live column is vector(2560)
+    // from a previous zembed-1 switch. Schema replay would otherwise
+    // emit the HNSW index and pgvector would reject.
+    const r = resolveSchemaDims(1536, 2560);
+    expect(r.dims).toBe(2560);
+    expect(r.overridden).toBe(true);
+    expect(r.reason).toContain('vector(2560)');
+    expect(r.reason).toContain('1536');
+  });
+
+  test('OVERRIDE: gateway over cap, live under cap (reverse drift)', () => {
+    // Hypothetical inverse: brain was high-dim, user re-embedded
+    // to 1024-dim, gateway not yet refreshed (still thinks 2560). The
+    // live column is now 1024 and HNSW should be emitted; gateway-
+    // dictated SKIP would leave the brain without an HNSW index it
+    // could legitimately have.
+    const r = resolveSchemaDims(2560, 1024);
+    expect(r.dims).toBe(1024);
+    expect(r.overridden).toBe(true);
+  });
+
+  test('boundary: live exactly at 2000 + gateway at 2001 flips', () => {
+    const r = resolveSchemaDims(2001, PGVECTOR_HNSW_VECTOR_MAX_DIMS);
+    expect(r.dims).toBe(PGVECTOR_HNSW_VECTOR_MAX_DIMS);
+    expect(r.overridden).toBe(true);
+  });
+
+  test('boundary: live exactly at 2001 + gateway at 2000 flips', () => {
+    const r = resolveSchemaDims(PGVECTOR_HNSW_VECTOR_MAX_DIMS, 2001);
+    expect(r.dims).toBe(2001);
+    expect(r.overridden).toBe(true);
+  });
+});
+
+describe('getLiveVectorColumnDims — identifier-shape gate', () => {
+  const neverCalled: VectorIntrospectQuery = async () => {
+    throw new Error('query should not run when identifier gate trips');
+  };
+
+  test('rejects table names with semicolons (injection probe)', async () => {
+    const r = await getLiveVectorColumnDims(neverCalled, 'content_chunks; DROP TABLE pages--', 'embedding');
+    expect(r).toBe(null);
+  });
+
+  test('rejects column names with quotes', async () => {
+    const r = await getLiveVectorColumnDims(neverCalled, 'content_chunks', "embedding'");
+    expect(r).toBe(null);
+  });
+
+  test('rejects mixed-case (production schema is lowercase)', async () => {
+    const r = await getLiveVectorColumnDims(neverCalled, 'ContentChunks', 'embedding');
+    expect(r).toBe(null);
+  });
+
+  test('rejects empty string', async () => {
+    const r = await getLiveVectorColumnDims(neverCalled, '', 'embedding');
+    expect(r).toBe(null);
+  });
+});
+
+describe('getLiveVectorColumnDims — parse contract', () => {
+  test('parses vector(N) from format_type output', async () => {
+    const fakeQuery: VectorIntrospectQuery = async () => [{ column_type: 'vector(2560)' }];
+    const r = await getLiveVectorColumnDims(fakeQuery, 'content_chunks', 'embedding');
+    expect(r).toBe(2560);
+  });
+
+  test('returns null when type is not vector', async () => {
+    const fakeQuery: VectorIntrospectQuery = async () => [{ column_type: 'text' }];
+    const r = await getLiveVectorColumnDims(fakeQuery, 'content_chunks', 'embedding');
+    expect(r).toBe(null);
+  });
+
+  test('returns null when row missing column_type', async () => {
+    const fakeQuery: VectorIntrospectQuery = async () => [{}];
+    const r = await getLiveVectorColumnDims(fakeQuery, 'content_chunks', 'embedding');
+    expect(r).toBe(null);
+  });
+
+  test('returns null when zero rows (column absent)', async () => {
+    const fakeQuery: VectorIntrospectQuery = async () => [];
+    const r = await getLiveVectorColumnDims(fakeQuery, 'content_chunks', 'embedding');
+    expect(r).toBe(null);
+  });
+
+  test('returns null when query throws (managed-pg permissions, etc.)', async () => {
+    const fakeQuery: VectorIntrospectQuery = async () => { throw new Error('insufficient privilege'); };
+    const r = await getLiveVectorColumnDims(fakeQuery, 'content_chunks', 'embedding');
+    expect(r).toBe(null);
+  });
+});
+
+describe('getLiveVectorColumnDims — live PGLite round-trip', () => {
+  let engine: PGLiteEngine;
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    // Don't call initSchema — we want to control the column shape
+    // ourselves so this test exercises the exact 2560-dim wedge case.
+    await engine.executeRaw('CREATE EXTENSION IF NOT EXISTS vector');
+    await engine.executeRaw('CREATE TABLE content_chunks (id BIGSERIAL PRIMARY KEY, embedding vector(2560))');
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+  });
+
+  test('returns the live dim for a vector(2560) column', async () => {
+    const dim = await getLiveVectorColumnDims(
+      async (sql, params) => {
+        const result = await (engine as unknown as { db: { query(s: string, p?: unknown[]): Promise<{ rows: unknown[] }> } }).db.query(sql, params ? Array.from(params) : []);
+        return result.rows as ReadonlyArray<Record<string, unknown>>;
+      },
+      'content_chunks',
+      'embedding',
+    );
+    expect(dim).toBe(2560);
+  });
+
+  test('returns null for a column that does not exist on the live table', async () => {
+    const dim = await getLiveVectorColumnDims(
+      async (sql, params) => {
+        const result = await (engine as unknown as { db: { query(s: string, p?: unknown[]): Promise<{ rows: unknown[] }> } }).db.query(sql, params ? Array.from(params) : []);
+        return result.rows as ReadonlyArray<Record<string, unknown>>;
+      },
+      'content_chunks',
+      'this_column_does_not_exist',
+    );
+    expect(dim).toBe(null);
+  });
+
+  test('returns null for a table that does not exist', async () => {
+    const dim = await getLiveVectorColumnDims(
+      async (sql, params) => {
+        const result = await (engine as unknown as { db: { query(s: string, p?: unknown[]): Promise<{ rows: unknown[] }> } }).db.query(sql, params ? Array.from(params) : []);
+        return result.rows as ReadonlyArray<Record<string, unknown>>;
+      },
+      'nonexistent_table',
+      'embedding',
+    );
+    expect(dim).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1141, #1189.

Adds a defensive SQL-layer guard at `initSchema` time so the upgrade chain stops wedging when the gateway hasn't been configured yet but the live `content_chunks.embedding` column is wider than 2000 dims (zembed-1 2560d, Qwen3-Embedding-4B 2560d, etc.).

## The bug

When `gbrain init --migrate-only` runs inside `gbrain upgrade`'s Phase A, the gateway hasn't read `~/.gbrain/config.json` yet. `getEmbeddingDimensions()` throws and falls through to `DEFAULT_EMBEDDING_DIMENSIONS` (1536). On brains previously switched to a high-dim embedder, the live column is `vector(2560)`. Schema replay emits the unconditional `idx_chunks_embedding USING hnsw` at the gateway dim, pgvector rejects with `column cannot have more than 2000 dimensions for hnsw index`, and Phase A aborts before any v47+ migration runs. `schema_version` stays where it was; upgrade is wedged forever.

Independent repro confirmed by @Moutonc in #1141 against v0.36.3.0 with `Qwen3-Embedding-4B-mxfp8` (same 2560-dim, different provider): the wedge is **not** specific to ZeroEntropy `zembed-1`. The sibling issue #1189 hits the same root cause on the PGLite fresh-install path. This fix closes both.

## The fix

Two layers, both narrow:

1. **`src/core/vector-introspect.ts` (new)** — pure helper that probes `pg_attribute.format_type(atttypid, atttypmod)` for a live vector column. Returns the dim from `vector(N)` or `null` for any failure mode (column absent, type not vector, query throws). Engine-agnostic via a `QueryRunner` callback. Identifier inputs are gated by a strict regex so the table/column names can never reach the wire as injection.

2. **`resolveSchemaDims(gatewayDims, liveDims)`** — pure decision function. Returns the dim to pass to `getPostgresSchema` / `getPGLiteSchema`. **Only overrides when the HNSW-2000 boundary would flip in the opposite direction from the gateway value.** Silently overriding on every call would mask genuine config drift; the override fires exactly where the cap-2000 bug bites and nowhere else.

3. **Both engines' `initSchema`** now call the probe BEFORE `getPostgresSchema(dims, model)` / `getPGLiteSchema(dims, model)`. When the override fires, a single stderr line documents the substitution.

This layers on top of the existing `applyChunkEmbeddingIndexPolicy` (which already skips HNSW when `dims > 2000`) — the policy was already correct; what was missing was making sure the policy got called with the right `dims`. The schema.sql HNSW emission and the migrate.ts emissions for `idx_takes_embedding_hnsw` / `idx_facts_embedding_hnsw` / `idx_query_cache_embedding_hnsw` are unchanged (those columns are hardcoded `VECTOR(1536)`, never trip the cap).

## Test plan

`test/vector-introspect.test.ts` — 20 cases:

- [x] 8-case `resolveSchemaDims` decision matrix (boundary flips both ways, no override when both sides are above-or-both-below cap, no override when null/equal)
- [x] Identifier-shape gates: rejects semicolons, quotes, mixed-case, empty
- [x] `format_type()` parse contract: `vector(N)` round-trip, `text` returns null, missing column returns null, throw-on-query returns null
- [x] Live PGLite round-trip: creates a real `vector(2560)` column, asserts the helper returns 2560 — the exact failure shape from this issue's repro
- [x] All 133 neighbouring tests (`vector-index-lifecycle`, `bootstrap`, `schema-bootstrap-coverage`, `pglite-engine`) still pass
- [x] `bun run typecheck` clean

## Out of scope

The deeper "gateway should be configured before initSchema in Phase A" fix that #1141 also hypothesizes (fix #1) is orthogonal and would require threading the config-read into the migrate-only entry. This PR is the SQL-layer guard (fix #2 from the issue) that makes the contract fail-closed regardless of when gateway configuration races against schema replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
