### PR TITLE
fix: Windows compat — CRLF parser, relTarget posix, apply-migr leak, gbrainDir contract

### DIFF
--- a/src/commands/apply-migrations.ts
+++ b/src/commands/apply-migrations.ts
@@ -354,6 +354,40 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
     if (cli.forceAll) return; // both surfaces flushed
   }
 
+  const completed = loadCompletedMigrations();
+  const idx = indexCompleted(completed);
+  const plan = buildPlan(idx, installed, cli.specificMigration);
+
+  // Bug 3 — surface wedged migrations as a loud, actionable error.
+  if (plan.wedged.length > 0) {
+    for (const m of plan.wedged) {
+      console.error(
+        `\nMigration v${m.version} is WEDGED (${MAX_CONSECUTIVE_PARTIALS}+ consecutive partials with no completion). ` +
+        `Check ~/.gbrain/upgrade-errors.jsonl for the last failure reasons, fix the underlying issue, then run:\n` +
+        `  gbrain apply-migrations --force-retry ${m.version}\n` +
+        `Then re-run \`gbrain apply-migrations --yes\`.`,
+      );
+    }
+    // Don't exit — applied/partial/pending are still worth reporting and running.
+  }
+
+  if (cli.specificMigration && plan.applied.length + plan.partial.length + plan.pending.length + plan.skippedFuture.length === 0) {
+    console.error(`No migration registered with version "${cli.specificMigration}". Run \`gbrain apply-migrations --list\` to see registered versions.`);
+    process.exit(2);
+  }
+
+  // Read-only branches: --list and --dry-run print plan/state without
+  // touching anything. Skip the schema-drift pre-flight (which opens a DB
+  // connection) — its only purpose is to warn before APPLYING; for
+  // informational commands the connect+disconnect cycle is both wasted
+  // work and a portability hazard. On Windows the PGLite WASM teardown
+  // leaks worker handles in execFileSync contexts, surfacing as a spurious
+  // exit-1 to parent processes that shell out to `apply-migrations --list`
+  // (e.g. `skillpack-check`). The PGLite-specific skip below is preserved
+  // for non-read-only paths.
+  if (cli.list) { printList(plan, installed); process.exit(0); }
+  if (cli.dryRun) { printDryRun(plan, installed); process.exit(0); }
+
   // Pre-flight: warn if schema migrations (migrate.ts) are behind.
   // apply-migrations runs orchestrator migrations only; schema migrations
   // run via connectEngine() / initSchema(). Users often expect this CLI
@@ -391,31 +425,6 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
     // Non-fatal: if DB is unreachable, orchestrator migrations can still
     // run their filesystem-only phases.
   }
-
-  const completed = loadCompletedMigrations();
-  const idx = indexCompleted(completed);
-  const plan = buildPlan(idx, installed, cli.specificMigration);
-
-  // Bug 3 — surface wedged migrations as a loud, actionable error.
-  if (plan.wedged.length > 0) {
-    for (const m of plan.wedged) {
-      console.error(
-        `\nMigration v${m.version} is WEDGED (${MAX_CONSECUTIVE_PARTIALS}+ consecutive partials with no completion). ` +
-        `Check ~/.gbrain/upgrade-errors.jsonl for the last failure reasons, fix the underlying issue, then run:\n` +
-        `  gbrain apply-migrations --force-retry ${m.version}\n` +
-        `Then re-run \`gbrain apply-migrations --yes\`.`,
-      );
-    }
-    // Don't exit — applied/partial/pending are still worth reporting and running.
-  }
-
-  if (cli.specificMigration && plan.applied.length + plan.partial.length + plan.pending.length + plan.skippedFuture.length === 0) {
-    console.error(`No migration registered with version "${cli.specificMigration}". Run \`gbrain apply-migrations --list\` to see registered versions.`);
-    process.exit(2);
-  }
-
-  if (cli.list) { printList(plan, installed); process.exit(0); }
-  if (cli.dryRun) { printDryRun(plan, installed); process.exit(0); }
 
   const toRun: Migration[] = [...plan.partial, ...plan.pending];
   if (toRun.length === 0) {

--- a/src/commands/skillpack.ts
+++ b/src/commands/skillpack.ts
@@ -29,6 +29,7 @@ import { runMigrateFence } from '../core/skillpack/migrate-fence.ts';
 import { runScrubLegacy } from '../core/skillpack/scrub-legacy.ts';
 import { runHarvest, HarvestError } from '../core/skillpack/harvest.ts';
 import { autoDetectSkillsDir } from '../core/repo-root.ts';
+import { extractFrontmatterBlock } from '../core/markdown.ts';
 import {
   RemoteSourceError,
   classifySpec,
@@ -216,9 +217,9 @@ async function cmdList(args: string[]): Promise<void> {
       let description: string | null = null;
       if (existsSync(skillMd)) {
         const body = readFileSync(skillMd, 'utf-8');
-        const fm = body.match(/^---\n([\s\S]*?)\n---/);
-        if (fm) {
-          const descMatch = fm[1].match(/^description:\s*["']?([^\n"']+)/m);
+        const fm = extractFrontmatterBlock(body);
+        if (fm !== null) {
+          const descMatch = fm.match(/^description:\s*["']?([^\n"']+)/m);
           if (descMatch) description = descMatch[1].trim();
         }
       }

--- a/src/core/check-resolvable.ts
+++ b/src/core/check-resolvable.ts
@@ -12,6 +12,7 @@
 
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { join, relative } from 'path';
+import { extractFrontmatterBlock } from './markdown.ts';
 import { findResolverFile, findAllResolverFiles, RESOLVER_FILENAMES_LABEL } from './resolver-filenames.ts';
 import { loadOrDeriveManifest } from './skill-manifest.ts';
 import {
@@ -163,9 +164,8 @@ export function parseResolverEntries(resolverContent: string): ResolverEntry[] {
 
 /** Simple YAML frontmatter parser — extracts triggers array if present. */
 function extractTriggers(skillContent: string): string[] {
-  const fmMatch = skillContent.match(/^---\n([\s\S]*?)\n---/);
-  if (!fmMatch) return [];
-  const fm = fmMatch[1];
+  const fm = extractFrontmatterBlock(skillContent);
+  if (fm === null) return [];
   const triggersMatch = fm.match(/^triggers:\s*\n((?:\s+-\s+.+\n?)*)/m);
   if (!triggersMatch) return [];
   return triggersMatch[1]

--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -3,6 +3,24 @@ import { safeLoad as yamlSafeLoad } from 'js-yaml';
 import type { PageType } from './types.ts';
 import { slugifyPath } from './sync.ts';
 
+/**
+ * Extract the raw YAML frontmatter body between leading `---` fences.
+ *
+ * Returns the body string (LF-normalized) or `null` when no frontmatter is
+ * present. Tolerant of CRLF line endings — input is normalized before
+ * matching so the same call works on files authored on Windows.
+ *
+ * Use this when you only need to run a few targeted regexes against the
+ * frontmatter (e.g. extracting `name:` or `triggers:`); prefer
+ * `parseMarkdown` when you need the full body + timeline split + gray-matter
+ * YAML parsing, and `parseSkillFrontmatter` for SKILL.md-specific fields.
+ */
+export function extractFrontmatterBlock(content: string): string | null {
+  const normalized = content.replace(/\r\n/g, '\n');
+  const match = normalized.match(/^---\n([\s\S]*?)\n---/);
+  return match ? match[1] : null;
+}
+
 export type ParseValidationCode =
   | 'MISSING_OPEN'
   | 'MISSING_CLOSE'

--- a/src/core/preferences.ts
+++ b/src/core/preferences.ts
@@ -11,6 +11,7 @@
 import { readFileSync, writeFileSync, renameSync, chmodSync, mkdtempSync, rmSync, existsSync, mkdirSync, appendFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { configDir } from './config.ts';
 
 function home(): string {
   // `os.homedir()` in Bun caches its initial value and ignores later
@@ -26,23 +27,18 @@ function home(): string {
 }
 
 /**
- * GBRAIN_HOME-aware override for the .gbrain directory. When the env var
- * is set, this returns it directly (so the directory is GBRAIN_HOME itself,
- * matching the convention `src/core/config.ts:gbrainPath` enforces).
- * When unset, falls back to `<home>/.gbrain` so legacy callers and the
- * doctor's filesystem-only checks keep working.
- *
- * Without this, `~/.gbrain/migrations/completed.jsonl` is the only path
- * doctor reads on filesystem checks — the test isolation contract that
- * `gbrainPath()` provides for everywhere else doesn't extend here.
+ * GBRAIN_HOME-aware override for the .gbrain directory. Delegates to
+ * `configDir()` so the GBRAIN_HOME contract is defined in exactly one
+ * place — pre-this-fix, this helper diverged from `configDir()` by
+ * returning `GBRAIN_HOME` directly instead of `GBRAIN_HOME/.gbrain`,
+ * which meant `~/.gbrain/migrations/completed.jsonl` (read by doctor)
+ * and `~/.gbrain/config.json` (read by loadConfig) lived in different
+ * directories whenever a test or operator set GBRAIN_HOME. The
+ * documented convention is "GBRAIN_HOME is a parent dir; we append
+ * `.gbrain`" — see configDir() docstring in src/core/config.ts.
  */
 function gbrainDir(): string {
-  const override = process.env.GBRAIN_HOME;
-  if (override) {
-    const trimmed = override.trim();
-    if (trimmed) return trimmed;
-  }
-  return join(home(), '.gbrain');
+  return configDir();
 }
 
 export type MinionMode = 'always' | 'pain_triggered' | 'off';

--- a/src/core/skill-frontmatter.ts
+++ b/src/core/skill-frontmatter.ts
@@ -82,7 +82,13 @@ export interface ParsedFrontmatter {
  * `readFileSync(path, 'utf-8')` at the boundary.
  */
 export function parseSkillFrontmatter(content: string): ParsedFrontmatter | null {
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  // Normalize CRLF → LF before matching. The literal `\n` after the opening
+  // `---` fence cannot match `\r`, so a Windows-authored SKILL.md (CRLF)
+  // would fall through with raw=='' and silently lose every parsed field.
+  // Normalizing here also gives downstream value parsers an LF-only body so
+  // `[^"'\n]+?` character classes don't accidentally swallow a trailing `\r`.
+  const normalized = content.replace(/\r\n/g, '\n');
+  const fmMatch = normalized.match(/^---\n([\s\S]*?)\n---/);
   if (!fmMatch) return null;
   const raw = fmMatch[1];
   const out: ParsedFrontmatter = { raw };

--- a/src/core/skill-manifest.ts
+++ b/src/core/skill-manifest.ts
@@ -27,6 +27,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
+import { extractFrontmatterBlock } from './markdown.ts';
 
 export interface ManifestEntry {
   name: string;
@@ -47,9 +48,8 @@ export interface ManifestLoadResult {
 function parseSkillName(skillMdPath: string): string | null {
   try {
     const content = readFileSync(skillMdPath, 'utf-8');
-    const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-    if (!fmMatch) return null;
-    const fm = fmMatch[1];
+    const fm = extractFrontmatterBlock(content);
+    if (fm === null) return null;
     // Match `name: foo` or `name: "foo"` or `name: 'foo'`
     const nameMatch = fm.match(/^name:\s*["']?([^"'\n]+?)["']?\s*$/m);
     if (!nameMatch) return null;

--- a/src/core/skillpack/bundle.ts
+++ b/src/core/skillpack/bundle.ts
@@ -8,7 +8,7 @@
  */
 
 import { existsSync, readFileSync, statSync, readdirSync } from 'fs';
-import { join, dirname, isAbsolute, resolve } from 'path';
+import { join, dirname, isAbsolute, resolve, posix } from 'path';
 
 import { parseMarkdown } from '../markdown.ts';
 
@@ -142,9 +142,12 @@ function walkFiles(absDir: string, prefix: string, out: BundleEntry[], sharedDep
       continue;
     }
     if (stat.isDirectory()) {
-      walkFiles(abs, join(prefix, e), out, sharedDep);
+      // relTarget is a portable bundle path; always use forward-slash
+      // joining so Windows installs produce the same manifest shape as
+      // Linux/macOS (callers downstream string-match on `alpha/SKILL.md`).
+      walkFiles(abs, posix.join(prefix, e), out, sharedDep);
     } else if (stat.isFile()) {
-      out.push({ source: abs, relTarget: join(prefix, e), sharedDep });
+      out.push({ source: abs, relTarget: posix.join(prefix, e), sharedDep });
     }
   }
 }

--- a/test/check-resolvable.test.ts
+++ b/test/check-resolvable.test.ts
@@ -282,6 +282,38 @@ describe("v0.22.4 regression — actual repo skills/ has 0 errors", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// CRLF tolerance — Windows-authored SKILL.md must not cause mece_gap
+// false-positives. The frontmatter parser used to anchor on literal `\n`
+// after the leading `---`, which failed silently on `\r\n`-terminated files
+// and made every skill on Windows look like it was missing a triggers: array.
+// ---------------------------------------------------------------------------
+describe("checkResolvable — CRLF line endings", () => {
+  let dir: string;
+  afterEachCleanup(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("does not flag mece_gap for skills with CRLF-terminated frontmatter", () => {
+    const lfBody = `---\nname: alpha\ndescription: alpha skill\ntriggers:\n  - "alpha trigger"\n---\n\n# Alpha\n`;
+    dir = mkdtempSync(join(tmpdir(), "gbrain-crlf-"));
+    writeFileSync(
+      join(dir, "RESOLVER.md"),
+      `## Test\n| Trigger | Skill |\n|-----|-----|\n| "alpha trigger" | \`skills/alpha/SKILL.md\` |\n`,
+    );
+    writeFileSync(
+      join(dir, "manifest.json"),
+      JSON.stringify({ skills: [{ name: "alpha", path: "alpha/SKILL.md" }] }, null, 2),
+    );
+    mkdirSync(join(dir, "alpha"), { recursive: true });
+    // Convert the otherwise-valid SKILL.md to CRLF — this is the actual
+    // on-disk shape produced by editors on Windows.
+    writeFileSync(join(dir, "alpha", "SKILL.md"), lfBody.replace(/\n/g, "\r\n"));
+
+    const report = checkResolvable(dir);
+    const gaps = report.issues.filter(i => i.type === "mece_gap");
+    expect(gaps).toEqual([]);
+  });
+});
+
 // bun:test has no beforeEach/afterEach at module scope cleanly interacting
 // with closures; a small helper keeps cleanup readable and per-test.
 function afterEachCleanup(fn: () => void) {

--- a/test/preferences.test.ts
+++ b/test/preferences.test.ts
@@ -21,12 +21,15 @@ beforeEach(() => {
   origHome = process.env.HOME;
   origGbrainHome = process.env.GBRAIN_HOME;
   tmp = mkdtempSync(join(tmpdir(), 'gbrain-prefs-test-'));
-  // preferences.ts's gbrainDir() returns `$HOME/.gbrain` when GBRAIN_HOME
-  // is unset. Test fixtures write to `$tmp/.gbrain/...`, so set HOME only
-  // and clear GBRAIN_HOME — setting GBRAIN_HOME would route prefs to $tmp
-  // directly (no .gbrain suffix), which doesn't match the fixture layout.
+  // Both gbrainDir() (preferences) and configDir() (config) now share the
+  // same contract via configDir(): GBRAIN_HOME is the parent dir, and they
+  // always append `.gbrain`. So setting GBRAIN_HOME=$tmp routes prefs to
+  // `$tmp/.gbrain/...`, matching the fixture layout used in this file.
+  //
+  // HOME alone is unreliable for isolation: os.homedir() reads USERPROFILE
+  // on Windows, ignoring HOME. GBRAIN_HOME is the platform-neutral hook.
   process.env.HOME = tmp;
-  delete process.env.GBRAIN_HOME;
+  process.env.GBRAIN_HOME = tmp;
 });
 
 afterEach(() => {

--- a/test/skillpack-check.test.ts
+++ b/test/skillpack-check.test.ts
@@ -26,7 +26,11 @@ let tmp: string;
 let origHome: string | undefined;
 
 function run(args: string[]): { exitCode: number; stdout: string; stderr: string } {
-  const env = { ...process.env, HOME: tmp } as Record<string, string | undefined>;
+  // HOME alone doesn't redirect gbrain config on Windows: os.homedir() reads
+  // USERPROFILE on Win32. GBRAIN_HOME is the platform-neutral override that
+  // configDir() honors uniformly — set both so the test fixture isolates
+  // from the real user's `.gbrain/` directory on every platform.
+  const env = { ...process.env, HOME: tmp, GBRAIN_HOME: tmp } as Record<string, string | undefined>;
   delete env.DATABASE_URL;
   delete env.GBRAIN_DATABASE_URL;
   try {
@@ -56,6 +60,12 @@ afterEach(() => {
   try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
 });
 
+// Each test below spawns `bun run cli.ts skillpack-check`, which itself
+// spawns child `doctor` + `apply-migrations --list` processes. On Windows
+// subprocess cold-start is ~600ms each; the default 5s bun:test timeout
+// is too tight for the chained spawns. 30s leaves headroom for slower CI.
+const SUBPROCESS_TIMEOUT = 30_000;
+
 describe('gbrain skillpack-check', () => {
   test('healthy fresh install → exit 0, healthy:true, empty actions', () => {
     const result = run(['skillpack-check']);
@@ -66,7 +76,7 @@ describe('gbrain skillpack-check', () => {
     expect(report.summary).toBe('gbrain skillpack healthy');
     expect(report.version).toBeTruthy();
     expect(report.ts).toBeTruthy();
-  });
+  }, SUBPROCESS_TIMEOUT);
 
   test('half-migrated (partial completed.jsonl) → exit 1, apply-migrations in actions', () => {
     const migrationsDir = join(tmp, '.gbrain', 'migrations');
@@ -88,7 +98,7 @@ describe('gbrain skillpack-check', () => {
     const minions = doctorChecks.find(c => c.name === 'minions_migration');
     expect(minions).toBeDefined();
     expect(minions!.status).toBe('fail');
-  });
+  }, SUBPROCESS_TIMEOUT);
 
   test('--quiet → no stdout, same exit code', () => {
     // Healthy path quiet
@@ -106,7 +116,7 @@ describe('gbrain skillpack-check', () => {
     const broken = run(['skillpack-check', '--quiet']);
     expect(broken.exitCode).toBe(1);
     expect(broken.stdout).toBe('');
-  });
+  }, SUBPROCESS_TIMEOUT);
 
   test('--help → exit 0, prints usage', () => {
     const result = run(['skillpack-check', '--help']);
@@ -114,7 +124,7 @@ describe('gbrain skillpack-check', () => {
     expect(result.stdout).toContain('skillpack-check');
     expect(result.stdout).toContain('healthy');
     expect(result.stdout).toContain('Exit codes');
-  });
+  }, SUBPROCESS_TIMEOUT);
 
   test('summary includes top action when multiple present', () => {
     // Partial record creates apply-migrations action + the migrations count
@@ -130,5 +140,5 @@ describe('gbrain skillpack-check', () => {
     const report = JSON.parse(result.stdout);
     expect(report.summary).toMatch(/\d+ action\(s\)/);
     expect(report.summary).toContain(report.actions[0]);
-  });
+  }, SUBPROCESS_TIMEOUT);
 });

--- a/test/skillpack-install.test.ts
+++ b/test/skillpack-install.test.ts
@@ -175,6 +175,17 @@ describe('enumerateBundle (D-CX-10 dependency closure)', () => {
     expect(targets.some(t => t.startsWith('alpha/'))).toBe(true);
     expect(targets.some(t => t.startsWith('beta/'))).toBe(true);
   });
+  it('emits forward-slash relTarget paths on every platform', () => {
+    // relTarget is a portable bundle key consumed by string-matching
+    // callers (managed-block writer, install-plan diffs); Windows-style
+    // backslashes silently break them. This test fails fast if anyone
+    // re-introduces `path.join` for relTarget construction.
+    const { gbrainRoot } = scratchGbrain();
+    const m = loadBundleManifest(gbrainRoot);
+    const entries = enumerateBundle({ gbrainRoot, manifest: m });
+    const offending = entries.filter(e => e.relTarget.includes('\\'));
+    expect(offending).toEqual([]);
+  });
 });
 
 describe('buildManagedBlock + updateManagedBlock', () => {


### PR DESCRIPTION
## Summary

Four independent Windows-only bugs surfaced by `gbrain doctor` and the `skillpack-{install,check}` test sweep on a Win11 / bun 1.3.13 install. All four still reproduce on current `master` (v0.37.11.0).

* **Bug A** — CRLF frontmatter parser failure at 4 sites (`skill-frontmatter.ts`, `check-resolvable.ts`, `skill-manifest.ts`, `skillpack.ts`). The literal `\n` after the opening `---` fence can't match `\r`, so every Windows-authored `SKILL.md` silently fell through with no frontmatter. Surfaced as **38 false-positive `mece_gap` warnings** on a 41-skill workspace.
* **Bug C** — `enumerateBundle()` in `bundle.ts` used `path.join` for `relTarget`, but `relTarget` is a portable bundle key — Win32 produced `alpha\SKILL.md` while string-matching callers (managed-block writer, install-plan diffs) expected `alpha/SKILL.md`.
* **Bug D** — `apply-migrations --list` / `--dry-run` ran an engine-connect pre-flight just to print an advisory schema-drift warning. The PGLite WASM teardown leaks worker handles under `execFileSync`, surfacing as spurious **exit-1** to parents like `skillpack-check`. v0.36 papered over the symptom with a PGLite-specific `skipPreflight` + explicit `process.exit(0)`; the architectural fix moves the pre-flight after the read-only early returns so informational subcommands skip the connect+disconnect cycle entirely.
* **Bug F** — `preferences.gbrainDir()` and `config.configDir()` disagreed on `GBRAIN_HOME` semantics: configDir treats it as a parent dir (appends `.gbrain`), preferences returned it directly. Same env var, two paths — meant the doctor's migration ledger and `loadConfig` landed in different directories whenever a test or operator set `GBRAIN_HOME`. The preferences docstring even claimed to match `gbrainPath` but didn't. Unify by delegating to `configDir()`.

## What's new

* `extractFrontmatterBlock()` exported from `src/core/markdown.ts` — content-based, CRLF-tolerant. Routes through `\r\n→\n` normalization once at the top, returns LF-only body so downstream `[^"'\n]+?` value parsers don't swallow trailing `\r`.
* `parseSkillFrontmatter()` in `src/core/skill-frontmatter.ts` gets the same one-line normalization at its entry point.
* `bundle.walkFiles()` uses `posix.join` for `relTarget` only; native `join` stays for absolute filesystem paths.
* `runApplyMigrations` reorders: `--list`/`--dry-run` early-return before the schema-drift pre-flight. PGLite skip preserved for the apply path.
* `preferences.gbrainDir()` is now `return configDir()`.

## Test plan

- [x] New regression: `test/check-resolvable.test.ts` — CRLF-terminated `SKILL.md` must not emit `mece_gap`.
- [x] New regression: `test/skillpack-install.test.ts` — `relTarget` must never contain backslashes.
- [x] `test/preferences.test.ts` + `test/skillpack-check.test.ts` fixtures switched from \`HOME\`-only (broken on Windows because \`os.homedir()\` reads \`USERPROFILE\`) to also setting \`GBRAIN_HOME\` (the platform-neutral hook).
- [x] `test/skillpack-check.test.ts` per-test timeout bumped to 30s — the tests spawn `bun run cli.ts skillpack-check`, which itself spawns child `doctor` + `apply-migrations --list` processes; on Windows each cold-start is ~600ms, blowing the default 5s timeout.

Verified on Windows 11 / bun 1.3.13:

| Suite | Before | After |
|---|---|---|
| `gbrain doctor` mece_gap count | 38 | 0 |
| `gbrain doctor` resolver_health | warn | ok |
| `skillpack-check.test.ts` | 1 pass / 4 fail | 5 / 0 |
| `skillpack-install.test.ts` | 29 / 2 fail | 32 / 0 |
| `check-resolvable.test.ts` | 25 pass | 26 (added CRLF test) |
| 8-file affected sweep | 156 pass / 18 fail | 173 / 1 |

The one remaining failure across the sweep is `savePreferences > writes file with 0o600 perms` — a pre-existing POSIX-only chmod test that's unfixable on Windows by nature.

## Scope notes

* Bug E from the same audit (the `GBRAIN_HOME` POSIX-only `startsWith('/')` check) was already fixed upstream between v0.32 and v0.37 — no action needed.
* The `[ai.gateway] recipe "google" declares an embedding touchpoint without max_batch_tokens` advisory is left untouched — per the gateway comments it's intentional (OpenAI/Google recipes use recursive fallback by design).
* No VERSION / CHANGELOG bump — leaving release plumbing to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)