### PR TITLE
fix: thread voyage_api_key from config.json to gateway env

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1444,6 +1444,7 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   // plane field now exists (GBrainConfig type) and gets mapped here, so
   // setting it via `~/.gbrain/config.json` propagates into the gateway.
   if (c.zeroentropy_api_key) envFromConfig.ZEROENTROPY_API_KEY = c.zeroentropy_api_key;
+  if (c.voyage_api_key) envFromConfig.VOYAGE_API_KEY = c.voyage_api_key;
 
   // v0.32 codex finding #4+#5 fix: thread local-server _BASE_URL env vars
   // into base_urls so the gateway hits the user's configured port. Without

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -41,6 +41,15 @@ export interface GBrainConfig {
    * merge → buildGatewayConfig env dict → recipe reads ZEROENTROPY_API_KEY.
    */
   zeroentropy_api_key?: string;
+  /**
+   * Voyage AI API key. Parallel slot to zeroentropy_api_key above —
+   * the v0.37.11.0 fix wave only wired ZE; this closes the same gap
+   * for Voyage users (voyage-3-large, voyage-code-3, etc). Recipe
+   * declares VOYAGE_API_KEY in auth_env.required, so loadConfig
+   * merges the env var here and buildGatewayConfig maps this field
+   * back to VOYAGE_API_KEY in the gateway env dict.
+   */
+  voyage_api_key?: string;
   /** AI gateway config (v0.14+). v0.36+ default: "zeroentropyai:zembed-1" / 1280 / "anthropic:claude-haiku-4-5-20251001". */
   embedding_model?: string;
   embedding_dimensions?: number;
@@ -240,6 +249,7 @@ export function loadConfig(): GBrainConfig | null {
     ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
     ...(process.env.ANTHROPIC_API_KEY ? { anthropic_api_key: process.env.ANTHROPIC_API_KEY } : {}),
     ...(process.env.ZEROENTROPY_API_KEY ? { zeroentropy_api_key: process.env.ZEROENTROPY_API_KEY } : {}),
+    ...(process.env.VOYAGE_API_KEY ? { voyage_api_key: process.env.VOYAGE_API_KEY } : {}),
     ...(process.env.GBRAIN_EMBEDDING_MODEL ? { embedding_model: process.env.GBRAIN_EMBEDDING_MODEL } : {}),
     ...(process.env.GBRAIN_EMBEDDING_DIMENSIONS ? { embedding_dimensions: parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS, 10) } : {}),
     ...(process.env.GBRAIN_EXPANSION_MODEL ? { expansion_model: process.env.GBRAIN_EXPANSION_MODEL } : {}),


### PR DESCRIPTION
Symmetric follow-up to the v0.37.11.0 fix wave (#1286). That wave wired `ZEROENTROPY_API_KEY` from `~/.gbrain/config.json` through `buildGatewayConfig` into the AI gateway env. Voyage users hit the same gap.

Voyage's recipe declares `VOYAGE_API_KEY` in `auth_env.required`, so this PR closes the read-side symmetry in three matching spots:

- `GBrainConfig.voyage_api_key?: string` in `src/core/config.ts`
- `process.env.VOYAGE_API_KEY` merge in `loadConfig()`
- Config field → `envFromConfig.VOYAGE_API_KEY` in `buildGatewayConfig()`

12-line mechanical patch, no behavior change for users who export `VOYAGE_API_KEY` as an env var. Only affects the config.json path.