### PR TITLE
fix: allow user-provided embedding dimensions

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -628,18 +628,17 @@ export function isAvailable(touchpoint: TouchpointKind, modelOverride?: string):
     // embedding from an anthropic-configured brain is unavailable regardless of auth.
     const touchpointConfig = recipe.touchpoints[touchpoint as 'embedding' | 'expansion' | 'chat' | 'reranker'];
     if (!touchpointConfig) return false;
-    // Openai-compat recipes with empty models list require a user-provided
-    // model. Either the recipe explicitly opts in via
-    // EmbeddingTouchpoint.user_provided_models (D8=A), or the legacy
-    // `recipe.id === 'litellm'` heuristic (back-compat for pre-v0.32 builds
-    // where the field hadn't been declared yet).
+    // Empty model allow-lists normally mean the touchpoint is not usable.
+    // `user_provided_models` recipes are the exception: parseModelId already
+    // proved the caller supplied a concrete model id, and the provider/server
+    // will validate it at request time.
     const isUserProvided =
       touchpoint === 'embedding' &&
       (touchpointConfig as any).user_provided_models === true;
     if (
       Array.isArray(touchpointConfig.models) &&
       touchpointConfig.models.length === 0 &&
-      (recipe.id === 'litellm' || isUserProvided)
+      !isUserProvided
     ) return false;
 
     // For openai-compatible without auth requirements (Ollama local), treat as always-available.

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -21,6 +21,20 @@ export const ollama: Recipe = {
       // OLLAMA_NUM_PARALLEL config; no static cap to declare. v0.32 (#779).
       no_batch_cap: true,
     },
+    expansion: {
+      models: ['qwen3.6:27b', 'qwen3.5:27b', 'llama3.1', 'mistral'],
+      cost_per_1m_tokens_usd: 0,
+      price_last_verified: '2026-05-22',
+    },
+    chat: {
+      models: ['qwen3.6:27b', 'qwen3.5:27b', 'llama3.1', 'mistral'],
+      supports_tools: false,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      cost_per_1m_input_usd: 0,
+      cost_per_1m_output_usd: 0,
+      price_last_verified: '2026-05-22',
+    },
   },
-  setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` and `ollama serve`.',
+  setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` for embeddings or `ollama pull qwen3.6:27b` for local chat/expansion, and run `ollama serve`.',
 };

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -282,7 +282,14 @@ export function resolveSchemaEmbeddingDim(opts: ResolveSchemaEmbeddingDimOpts): 
           `Pick a recipe with an embedding touchpoint (gbrain providers list).`,
       };
     }
-    return validateDimAgainstTouchpoint(parsed.modelId, recipe, tp.default_dims, tp.dims_options, opts.embedding_dimensions);
+    return validateDimAgainstTouchpoint(
+      parsed.modelId,
+      recipe,
+      tp.default_dims,
+      tp.dims_options,
+      opts.embedding_dimensions,
+      tp.user_provided_models === true,
+    );
   } catch (err) {
     return { ok: false, error: err instanceof AIConfigError ? err.message : String(err) };
   }
@@ -333,7 +340,14 @@ export function resolveSchemaMultimodalDim(opts: ResolveSchemaMultimodalDimOpts)
           `Pick a multimodal-capable model from this provider.`,
       };
     }
-    return validateDimAgainstTouchpoint(parsed.modelId, recipe, tp.default_dims, tp.dims_options, opts.embedding_multimodal_dimensions);
+    return validateDimAgainstTouchpoint(
+      parsed.modelId,
+      recipe,
+      tp.default_dims,
+      tp.dims_options,
+      opts.embedding_multimodal_dimensions,
+      tp.user_provided_models === true,
+    );
   } catch (err) {
     return { ok: false, error: err instanceof AIConfigError ? err.message : String(err) };
   }
@@ -363,6 +377,7 @@ function validateDimAgainstTouchpoint(
   defaultDims: number,
   dimsOptions: number[] | undefined,
   requestedDims: number | undefined,
+  userProvidedModels = false,
 ): ResolveSchemaDimResult {
   const dim = requestedDims ?? defaultDims;
 
@@ -381,7 +396,7 @@ function validateDimAgainstTouchpoint(
     };
   }
 
-  if (requestedDims !== undefined && requestedDims !== defaultDims) {
+  if (requestedDims !== undefined && requestedDims !== defaultDims && !userProvidedModels) {
     // User asked for a non-default dim. Walk the precedence chain.
     const customDimOk = isCustomDimValidForProvider(recipe, modelId, requestedDims, dimsOptions);
     if (!customDimOk.valid) {

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -1,5 +1,6 @@
 import type { BrainEngine } from './engine.ts';
 import { slugifyPath } from './sync.ts';
+import { PGVECTOR_HNSW_HALFVEC_MAX_DIMS, PGVECTOR_HNSW_VECTOR_MAX_DIMS } from './vector-index.ts';
 
 /**
  * Schema migrations — run automatically on initSchema().
@@ -2277,6 +2278,12 @@ export const MIGRATIONS: Migration[] = [
       //   VECTOR(n)  → vector_cosine_ops
       //   HALFVEC(n) → halfvec_cosine_ops
       const opclass = useHalfvec ? 'halfvec_cosine_ops' : 'vector_cosine_ops';
+      const hnswMaxDims = useHalfvec ? PGVECTOR_HNSW_HALFVEC_MAX_DIMS : PGVECTOR_HNSW_VECTOR_MAX_DIMS;
+      const factsEmbeddingHnswDDL = embeddingDim <= hnswMaxDims
+        ? `CREATE INDEX IF NOT EXISTS idx_facts_embedding_hnsw
+          ON facts USING hnsw (embedding ${opclass})
+          WHERE embedding IS NOT NULL AND expired_at IS NULL;`
+        : `-- idx_facts_embedding_hnsw skipped: ${vecType} HNSW supports at most ${hnswMaxDims} dimensions.`;
       // FK to sources is added in a separate ALTER TABLE rather than inline
       // on the column. Inline `REFERENCES` worked on PGLite but silently
       // got dropped by postgres.js's `unsafe()` multi-statement path on
@@ -2350,9 +2357,7 @@ export const MIGRATIONS: Migration[] = [
           ON facts(source_id, entity_slug)
           WHERE consolidated_at IS NULL AND expired_at IS NULL;
 
-        CREATE INDEX IF NOT EXISTS idx_facts_embedding_hnsw
-          ON facts USING hnsw (embedding ${opclass})
-          WHERE embedding IS NOT NULL AND expired_at IS NULL;
+        ${factsEmbeddingHnswDDL}
       `;
 
       await engine.runMigration(40, factsDDL);
@@ -2868,6 +2873,12 @@ export const MIGRATIONS: Migration[] = [
 
       const vecType = useHalfvec ? 'HALFVEC' : 'VECTOR';
       const opclass = useHalfvec ? 'halfvec_cosine_ops' : 'vector_cosine_ops';
+      const hnswMaxDims = useHalfvec ? PGVECTOR_HNSW_HALFVEC_MAX_DIMS : PGVECTOR_HNSW_VECTOR_MAX_DIMS;
+      const queryCacheEmbeddingHnswDDL = embeddingDim <= hnswMaxDims
+        ? `CREATE INDEX IF NOT EXISTS idx_query_cache_embedding_hnsw
+          ON query_cache USING hnsw (embedding ${opclass})
+          WHERE embedding IS NOT NULL;`
+        : `-- idx_query_cache_embedding_hnsw skipped: ${vecType} HNSW supports at most ${hnswMaxDims} dimensions.`;
 
       const ddl = `
         CREATE TABLE IF NOT EXISTS query_cache (
@@ -2886,9 +2897,7 @@ export const MIGRATIONS: Migration[] = [
         CREATE INDEX IF NOT EXISTS idx_query_cache_source_created
           ON query_cache(source_id, created_at DESC);
 
-        CREATE INDEX IF NOT EXISTS idx_query_cache_embedding_hnsw
-          ON query_cache USING hnsw (embedding ${opclass})
-          WHERE embedding IS NOT NULL;
+        ${queryCacheEmbeddingHnswDDL}
       `;
 
       await engine.runMigration(55, ddl);

--- a/src/core/vector-index.ts
+++ b/src/core/vector-index.ts
@@ -17,6 +17,7 @@
 import type { BrainEngine } from './engine.ts';
 
 export const PGVECTOR_HNSW_VECTOR_MAX_DIMS = 2000;
+export const PGVECTOR_HNSW_HALFVEC_MAX_DIMS = 4000;
 
 const CHUNK_EMBEDDING_HNSW_INDEX =
   'CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);';

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -29,7 +29,7 @@ import { AIConfigError } from '../../src/core/ai/errors.ts';
 import { listRecipes, getRecipe } from '../../src/core/ai/recipes/index.ts';
 
 describe('chat touchpoint — recipe registry', () => {
-  test('all six chat-capable providers ship a chat touchpoint with supports_subagent_loop', () => {
+  test('hosted chat-capable providers ship a chat touchpoint with supports_subagent_loop', () => {
     const expected = ['anthropic', 'openai', 'google', 'deepseek', 'groq', 'together'];
     for (const id of expected) {
       const r = getRecipe(id);
@@ -38,6 +38,14 @@ describe('chat touchpoint — recipe registry', () => {
       expect(r!.touchpoints.chat!.models.length, `${id} chat models empty`).toBeGreaterThan(0);
       expect(r!.touchpoints.chat!.supports_subagent_loop, `${id} should support subagent loop`).toBe(true);
     }
+  });
+
+  test('Ollama declares local chat/expansion but not subagent-loop support', () => {
+    const r = getRecipe('ollama');
+    expect(r).toBeDefined();
+    expect(r!.touchpoints.expansion?.models).toContain('qwen3.6:27b');
+    expect(r!.touchpoints.chat?.models).toContain('qwen3.6:27b');
+    expect(r!.touchpoints.chat!.supports_subagent_loop).toBe(false);
   });
 
   test('only Anthropic claims supports_prompt_cache=true', () => {
@@ -51,9 +59,8 @@ describe('chat touchpoint — recipe registry', () => {
     }
   });
 
-  test('embedding-only providers (voyage, ollama) do NOT declare chat', () => {
+  test('embedding-only provider voyage does NOT declare chat', () => {
     expect(getRecipe('voyage')!.touchpoints.chat).toBeUndefined();
-    expect(getRecipe('ollama')!.touchpoints.chat).toBeUndefined();
   });
 
   test('openai-compat chat recipes have base_url_default', () => {
@@ -110,8 +117,8 @@ describe('chat touchpoint — model resolver + aliases (Codex F-OV-5)', () => {
   test('assertTouchpoint rejects chat on embedding-only providers with a fix hint', () => {
     expect(() => assertTouchpoint(getRecipe('voyage')!, 'chat', 'voyage-3'))
       .toThrow(AIConfigError);
-    expect(() => assertTouchpoint(getRecipe('ollama')!, 'chat', 'nomic-embed-text'))
-      .toThrow(AIConfigError);
+    expect(() => assertTouchpoint(getRecipe('ollama')!, 'chat', 'qwen3.6:27b'))
+      .not.toThrow();
   });
 
   test('assertTouchpoint rejects unknown native model with the model list in the fix hint', () => {
@@ -179,6 +186,11 @@ describe('chat touchpoint — gateway config plumbing', () => {
     // Voyage doesn't expose a chat touchpoint; isAvailable should refuse.
     configureGateway({ chat_model: 'voyage:voyage-3', env: { VOYAGE_API_KEY: 'fake' } });
     expect(isAvailable('chat')).toBe(false);
+  });
+
+  test('isAvailable("chat") returns true for local Ollama with no API key', () => {
+    configureGateway({ chat_model: 'ollama:qwen3.6:27b', env: {} });
+    expect(isAvailable('chat')).toBe(true);
   });
 });
 

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -86,6 +86,24 @@ describe('gateway.isAvailable (silent-drop regression surface)', () => {
     expect(isAvailable('embedding')).toBe(true);
   });
 
+  test('embedding AVAILABLE for llama-server user-provided model with no API key (local)', () => {
+    configureGateway({
+      embedding_model: 'llama-server:qwen3-embedding-8b',
+      embedding_dimensions: 4096,
+      env: {},
+    });
+    expect(isAvailable('embedding')).toBe(true);
+  });
+
+  test('embedding AVAILABLE for LiteLLM user-provided model with no API key (local proxy)', () => {
+    configureGateway({
+      embedding_model: 'litellm:any-local-embedder',
+      embedding_dimensions: 2048,
+      env: {},
+    });
+    expect(isAvailable('embedding')).toBe(true);
+  });
+
   test('anthropic rejects embedding touchpoint (has no embedding model)', () => {
     configureGateway({
       embedding_model: 'anthropic:claude-haiku-4-5-20251001',
@@ -99,6 +117,14 @@ describe('gateway.isAvailable (silent-drop regression surface)', () => {
     configureGateway({
       expansion_model: 'anthropic:claude-haiku-4-5-20251001',
       env: { ANTHROPIC_API_KEY: 'fake' },
+    });
+    expect(isAvailable('expansion')).toBe(true);
+  });
+
+  test('expansion available for local Ollama with no API key', () => {
+    configureGateway({
+      expansion_model: 'ollama:qwen3.6:27b',
+      env: {},
     });
     expect(isAvailable('expansion')).toBe(true);
   });

--- a/test/e2e/v0_28_5-fix-wave.test.ts
+++ b/test/e2e/v0_28_5-fix-wave.test.ts
@@ -214,6 +214,42 @@ describe('v0.28.5 cluster B — embedding dim corruption regression', () => {
       configureGateway({ env: { ...process.env } });
     }
   }, 60000);
+
+  test('4096-dim init skips every embedding HNSW index that exceeds pgvector caps', async () => {
+    const { configureGateway } = await import('../../src/core/ai/gateway.ts');
+    configureGateway({
+      embedding_model: 'llama-server:qwen3-embedding-8b',
+      embedding_dimensions: 4096,
+      env: { ...process.env },
+    });
+
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    try {
+      await engine.initSchema();
+      const dim = await readContentChunksEmbeddingDim(engine);
+      expect(dim.exists).toBe(true);
+      expect(dim.dims).toBe(4096);
+
+      const indexes = await engine.executeRaw<{ indexname: string }>(
+        `SELECT indexname
+         FROM pg_indexes
+         WHERE schemaname = 'public'
+           AND indexname = ANY($1::text[])`,
+        [
+          [
+            'idx_chunks_embedding',
+            'idx_facts_embedding_hnsw',
+            'idx_query_cache_embedding_hnsw',
+          ],
+        ],
+      );
+      expect(indexes.map(r => r.indexname).sort()).toEqual([]);
+    } finally {
+      await engine.disconnect();
+      configureGateway({ env: { ...process.env } });
+    }
+  }, 60000);
 });
 
 describe('v0.28.5 A4 — existing-brain dim mismatch loud failure', () => {

--- a/test/embedding-dim-check.test.ts
+++ b/test/embedding-dim-check.test.ts
@@ -220,6 +220,41 @@ describe('resolveSchemaEmbeddingDim', () => {
     if (got.ok) expect(got.dim).toBe(768);
   });
 
+  test('llama-server user-provided model accepts explicit schema dim', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:qwen3-embedding-8b',
+      embedding_dimensions: 4096,
+    });
+    expect(got).toEqual({
+      ok: true,
+      dim: 4096,
+      model: 'llama-server:qwen3-embedding-8b',
+      provider: 'llama-server',
+      recipeDefault: 0,
+    });
+  });
+
+  test('llama-server user-provided model still requires explicit dimensions', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:qwen3-embedding-8b',
+    });
+    expect(got.ok).toBe(false);
+    if (!got.ok) expect(got.error).toMatch(/positive integer/);
+  });
+
+  test('LiteLLM user-provided model accepts explicit schema dim', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'litellm:any-local-embedder',
+      embedding_dimensions: 2048,
+    });
+    expect(got.ok).toBe(true);
+    if (got.ok) {
+      expect(got.dim).toBe(2048);
+      expect(got.provider).toBe('litellm');
+      expect(got.recipeDefault).toBe(0);
+    }
+  });
+
   test('unknown provider rejected with provider list hint', () => {
     const got = resolveSchemaEmbeddingDim({ embedding_model: 'notarealprovider:foo' });
     expect(got.ok).toBe(false);


### PR DESCRIPTION
## Summary
- allow `user_provided_models` embedding recipes (for example `llama-server:<model>` and `litellm:<model>`) to use explicit schema dimensions instead of being rejected as unsupported custom dimensions
- keep requiring explicit dimensions when a user-provided recipe has no default dimension
- treat configured user-provided local/proxy embeddings as available so `providers test`, doctor/provider health, and vector-search gates do not falsely report them unavailable
- skip embedding HNSW indexes for facts/query_cache when the configured dimension exceeds pgvector's HNSW caps (`VECTOR` 2000d, `HALFVEC` 4000d), matching the existing content_chunks behavior
- add Ollama local chat + query-expansion touchpoints for OpenAI-compatible local models such as `ollama:qwen3.6:27b` without claiming subagent-loop support

## Validation
- `bun test test/ai/gateway.test.ts test/embedding-dim-check.test.ts test/e2e/v0_28_5-fix-wave.test.ts`
- `bun test test/ai/gateway.test.ts test/ai/gateway-chat.test.ts test/ai/recipes-existing-regression.test.ts test/providers.test.ts`
- `bun run typecheck`
- local smoke test with `llama-server:qwen3-embedding-8b` at 4096d:
  - `gbrain init --force --pglite --embedding-model llama-server:qwen3-embedding-8b --embedding-dimensions 4096 --json`
  - imported one markdown page and confirmed stats showed `Pages: 1`, `Chunks: 1`, `Embedded: 1`
- local smoke test with `ollama:qwen3.6:27b` chat via Ollama OpenAI-compatible endpoint