### PR TITLE
feat: support OAuth bearer auth for AI providers

### DIFF
--- a/docs/integrations/embedding-providers.md
+++ b/docs/integrations/embedding-providers.md
@@ -19,6 +19,12 @@ As of v0.37, `gbrain init --pglite` auto-detects which provider to use from your
 
 The resolved provider + dimensions get persisted to `~/.gbrain/config.json` atomically, so subsequent runs are deterministic across releases.
 
+## API keys and OAuth bearer tokens
+
+Provider recipes accept the traditional `*_API_KEY` env vars and, where the provider or proxy accepts bearer auth, a pre-minted OAuth/OIDC access token env var such as `OPENAI_OAUTH_ACCESS_TOKEN`, `ANTHROPIC_AUTH_TOKEN`, `ZEROENTROPY_OAUTH_ACCESS_TOKEN`, or `AZURE_OPENAI_OAUTH_ACCESS_TOKEN`.
+
+GBrain does not run OAuth grant flows or refresh tokens itself. Put a valid access token into the env snapshot before starting GBrain and the gateway will prefer `Authorization: Bearer <token>` over API-key auth for embedding, query expansion, chat, multimodal embedding, and reranking. Non-auth config is still required: for example Azure OAuth replaces `AZURE_OPENAI_API_KEY`, but still requires `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_DEPLOYMENT`.
+
 ## TL;DR table
 
 | Provider | env vars | default dims | cost ($/1M tokens) | local? | multimodal? |

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -289,6 +289,15 @@ interface ReadyProvider {
   recipe: import('../core/ai/types.ts').Recipe;
 }
 
+function detectedAuthEnvName(
+  recipe: import('../core/ai/types.ts').Recipe,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const oauth = (recipe.auth_env?.oauth_access_token ?? []).find(k => !!env[k]);
+  if (oauth) return oauth;
+  return (recipe.auth_env?.required ?? []).find(k => !!env[k]) ?? recipe.id;
+}
+
 /**
  * Walk recipes and return providers env-ready for the given touchpoint.
  * Exported for unit tests (parameterizable via env arg).
@@ -368,6 +377,7 @@ function printNoEmbeddingProviderHint(typos: Array<{ userSet: string; suggested:
   console.error('  export OPENAI_API_KEY=sk-…        # openai:text-embedding-3-large (1536d)');
   console.error('  export ZEROENTROPY_API_KEY=ze-…   # zeroentropyai:zembed-1 (2560d, Matryoshka)');
   console.error('  export VOYAGE_API_KEY=pa-…        # voyage:voyage-3-large (1024d)');
+  console.error('  # Or provide a pre-minted bearer token, e.g. OPENAI_OAUTH_ACCESS_TOKEN=...');
   console.error('Then re-run: gbrain init --pglite');
   console.error('');
   console.error('Or pick explicitly:');
@@ -409,7 +419,7 @@ async function resolveEmbeddingByEnv(out: ResolvedAIOptions, nonInteractive: boo
       out.embedding_model = fullModel;
       out.embedding_dimensions = dims;
       console.error(
-        `Detected ${r.auth_env?.required?.[0] ?? r.id} env var. ` +
+        `Detected ${detectedAuthEnvName(r)} env var. ` +
         `Using ${fullModel} (${dims}d). ` +
         `Override with --embedding-model.`,
       );
@@ -461,7 +471,7 @@ async function resolveExpansionByEnv(out: ResolvedAIOptions): Promise<void> {
     const tp = r.touchpoints.expansion!;
     if (Array.isArray(tp.models) && tp.models.length > 0) {
       out.expansion_model = `${r.id}:${tp.models[0]}`;
-      console.error(`Detected ${r.auth_env?.required?.[0] ?? r.id} env var. Using ${out.expansion_model} for expansion.`);
+      console.error(`Detected ${detectedAuthEnvName(r)} env var. Using ${out.expansion_model} for expansion.`);
     }
   }
   // 0 or >1 → silent: gateway default (`anthropic:claude-haiku-4-5-…`) wins
@@ -475,7 +485,7 @@ async function resolveChatByEnv(out: ResolvedAIOptions): Promise<void> {
     const tp = r.touchpoints.chat!;
     if (Array.isArray(tp.models) && tp.models.length > 0) {
       out.chat_model = `${r.id}:${tp.models[0]}`;
-      console.error(`Detected ${r.auth_env?.required?.[0] ?? r.id} env var. Using ${out.chat_model} for chat.`);
+      console.error(`Detected ${detectedAuthEnvName(r)} env var. Using ${out.chat_model} for chat.`);
     }
   }
   // 0 or >1 → silent: gateway default (`anthropic:claude-sonnet-4-6`) wins.

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -6,7 +6,14 @@
  */
 
 import { listRecipes, getRecipe } from '../core/ai/recipes/index.ts';
-import { configureGateway, embedOne, isAvailable as gwIsAvailable, chat as gwChat } from '../core/ai/gateway.ts';
+import {
+  configureGateway,
+  embedOne,
+  formatAuthRequirement,
+  isAvailable as gwIsAvailable,
+  isRecipeAuthReady,
+  chat as gwChat,
+} from '../core/ai/gateway.ts';
 import { probeOllama, probeLMStudio } from '../core/ai/probes.ts';
 import { loadConfig } from '../core/config.ts';
 import { AIConfigError, AITransientError } from '../core/ai/errors.ts';
@@ -45,9 +52,7 @@ function configureFromEnv(): void {
 }
 
 export function envReady(recipe: Recipe, env: NodeJS.ProcessEnv = process.env): boolean {
-  const required = recipe.auth_env?.required ?? [];
-  if (required.length === 0) return true; // e.g. local Ollama
-  return required.every(k => !!env[k]);
+  return isRecipeAuthReady(recipe, env);
 }
 
 /**
@@ -67,7 +72,7 @@ export function formatRecipeTable(recipes: Recipe[], env: NodeJS.ProcessEnv = pr
     const hasExpand = !!r.touchpoints.expansion;
     const hasChat = !!r.touchpoints.chat && r.touchpoints.chat.models.length > 0;
     const ready = envReady(r, env);
-    const status = ready ? '✓ ready' : `✗ missing ${r.auth_env?.required?.[0] ?? 'setup'}`;
+    const status = ready ? '✓ ready' : `✗ missing ${formatAuthRequirement(r)}`;
     rows.push(
       r.id.padEnd(14) +
       r.tier.padEnd(18) +
@@ -242,6 +247,7 @@ function runEnv(args: string[]): void {
   console.log('');
   const required = recipe.auth_env?.required ?? [];
   const optional = recipe.auth_env?.optional ?? [];
+  const oauth = recipe.auth_env?.oauth_access_token ?? [];
   if (required.length > 0) {
     console.log('Required:');
     for (const k of required) {
@@ -258,6 +264,13 @@ function runEnv(args: string[]): void {
       console.log(`  ${k.padEnd(32)} ${set ? '✓ set' : '✗ not set'}`);
     }
   }
+  if (oauth.length > 0) {
+    console.log('\nOAuth access token alternatives:');
+    for (const k of oauth) {
+      const set = !!process.env[k];
+      console.log(`  ${k.padEnd(32)} ${set ? '✓ set' : '✗ not set'}`);
+    }
+  }
   if (recipe.auth_env?.setup_url) {
     console.log(`\nSetup: ${recipe.auth_env.setup_url}`);
   }
@@ -270,15 +283,13 @@ async function runExplain(args: string[]): Promise<void> {
   const asJson = args.includes('--json') || args.includes('-j');
 
   const recipes = listRecipes();
-  const env_detected = {
-    OPENAI_API_KEY: !!process.env.OPENAI_API_KEY,
-    GOOGLE_GENERATIVE_AI_API_KEY: !!process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-    ANTHROPIC_API_KEY: !!process.env.ANTHROPIC_API_KEY,
-    VOYAGE_API_KEY: !!process.env.VOYAGE_API_KEY,
-    DEEPSEEK_API_KEY: !!process.env.DEEPSEEK_API_KEY,
-    GROQ_API_KEY: !!process.env.GROQ_API_KEY,
-    TOGETHER_API_KEY: !!process.env.TOGETHER_API_KEY,
-  };
+  const authEnvNames = Array.from(new Set(recipes.flatMap(r => [
+    ...(r.auth_env?.required ?? []),
+    ...(r.auth_env?.oauth_access_token ?? []),
+  ]))).sort();
+  const env_detected: Record<string, boolean> = Object.fromEntries(
+    authEnvNames.map(k => [k, !!process.env[k]]),
+  );
 
   // Parallel probes for local providers (1s timeout each)
   const [ollama, lmstudio] = await Promise.all([probeOllama(), probeLMStudio()]);
@@ -416,21 +427,21 @@ function consFor(r: Recipe): string[] {
 function pickRecommended(options: ProviderOption[], env: Record<string, boolean>, ollamaReady: boolean): { id: string; reason: string } {
   // Embedding recommendation: prefer env-ready native providers in this order.
   const embOpts = options.filter(o => o.touchpoint === 'embedding');
-  if (env.OPENAI_API_KEY) {
-    const openai = embOpts.find(o => o.id.startsWith('openai:'));
-    if (openai) return { id: openai.id, reason: 'OPENAI_API_KEY set — OpenAI default is high-quality and preserves existing 1536-dim schema.' };
+  if (env.OPENAI_API_KEY || env.OPENAI_OAUTH_ACCESS_TOKEN || env.OPENAI_ACCESS_TOKEN) {
+    const openai = embOpts.find(o => o.id.startsWith('openai:') && o.env_ready);
+    if (openai) return { id: openai.id, reason: 'OpenAI credentials detected — OpenAI default is high-quality and preserves existing 1536-dim schema.' };
   }
   if (ollamaReady) {
     const ollama = embOpts.find(o => o.id.startsWith('ollama:'));
     if (ollama) return { id: ollama.id, reason: 'Ollama detected locally — zero cost + private.' };
   }
-  if (env.GOOGLE_GENERATIVE_AI_API_KEY) {
-    const google = embOpts.find(o => o.id.startsWith('google:'));
-    if (google) return { id: google.id, reason: 'GOOGLE_GENERATIVE_AI_API_KEY set — Gemini embedding at 768 dims.' };
+  if (env.GOOGLE_GENERATIVE_AI_API_KEY || env.GOOGLE_GENERATIVE_AI_OAUTH_ACCESS_TOKEN || env.GOOGLE_GENERATIVE_AI_ACCESS_TOKEN || env.GOOGLE_OAUTH_ACCESS_TOKEN) {
+    const google = embOpts.find(o => o.id.startsWith('google:') && o.env_ready);
+    if (google) return { id: google.id, reason: 'Google credentials detected — Gemini embedding at 768 dims.' };
   }
-  if (env.VOYAGE_API_KEY) {
-    const voyage = embOpts.find(o => o.id.startsWith('voyage:'));
-    if (voyage) return { id: voyage.id, reason: 'VOYAGE_API_KEY set — Voyage at 1024 dims.' };
+  if (env.VOYAGE_API_KEY || env.VOYAGE_OAUTH_ACCESS_TOKEN || env.VOYAGE_ACCESS_TOKEN) {
+    const voyage = embOpts.find(o => o.id.startsWith('voyage:') && o.env_ready);
+    if (voyage) return { id: voyage.id, reason: 'Voyage credentials detected — Voyage at 1024 dims.' };
   }
   // Nothing ready. Recommend OpenAI as the lowest-friction path.
   return {

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -211,6 +211,68 @@ export class ZeroEntropyResponseTooLargeError extends Error {
 // so existing recipes need zero code changes; only deviating recipes (Azure
 // with `api-key:` instead of `Authorization: Bearer`) override.
 
+type AuthTouchpoint = 'embedding' | 'expansion' | 'chat' | 'reranker';
+
+type EnvSnapshot = Record<string, string | undefined>;
+
+/**
+ * Resolve a pre-minted OAuth/OIDC access token declared by a recipe.
+ *
+ * This deliberately does NOT mint or refresh tokens. OAuth grant flows vary by
+ * provider and deployment (device flow, service account, Entra ID, workforce
+ * identity, etc.); the gateway only needs a stable place to consume the access
+ * token once an external helper has placed it in the env snapshot.
+ *
+ * @internal exported for tests; not part of the public gateway API.
+ */
+export function resolveOAuthAccessToken(
+  recipe: Recipe,
+  env: EnvSnapshot,
+): { envName: string; token: string } | null {
+  for (const envName of recipe.auth_env?.oauth_access_token ?? []) {
+    const token = env[envName];
+    if (typeof token === 'string' && token.length > 0) {
+      return { envName, token };
+    }
+  }
+  return null;
+}
+
+function oauthReplacesRequired(recipe: Recipe): Set<string> {
+  const required = recipe.auth_env?.required ?? [];
+  const explicit = recipe.auth_env?.oauth_replaces;
+  if (explicit) return new Set(explicit);
+  return required.length > 0 && (recipe.auth_env?.oauth_access_token?.length ?? 0) > 0
+    ? new Set([required[0]])
+    : new Set();
+}
+
+/**
+ * Return missing required auth/config env vars after accounting for an OAuth
+ * bearer token replacing the recipe's API-key slot. Used by isAvailable() and
+ * the provider CLI so every touchpoint agrees on readiness.
+ */
+export function missingRequiredAuthEnv(recipe: Recipe, env: EnvSnapshot): string[] {
+  const required = recipe.auth_env?.required ?? [];
+  if (required.length === 0) return [];
+  const oauth = resolveOAuthAccessToken(recipe, env);
+  const replaced = oauth ? oauthReplacesRequired(recipe) : new Set<string>();
+  return required.filter(k => !env[k] && !replaced.has(k));
+}
+
+export function isRecipeAuthReady(recipe: Recipe, env: EnvSnapshot): boolean {
+  return missingRequiredAuthEnv(recipe, env).length === 0;
+}
+
+export function formatAuthRequirement(recipe: Recipe): string {
+  const required = recipe.auth_env?.required ?? [];
+  if (required.length === 0) return 'setup';
+  const oauth = recipe.auth_env?.oauth_access_token ?? [];
+  return oauth.length > 0
+    ? `${required[0]} or ${oauth[0]}`
+    : required[0];
+}
+
 /**
  * Default auth resolver: returns `{headerName: 'Authorization', token: 'Bearer
  * <key>'}` where `<key>` is the first present env var from `auth_env.required`,
@@ -225,9 +287,14 @@ export class ZeroEntropyResponseTooLargeError extends Error {
  */
 export function defaultResolveAuth(
   recipe: Recipe,
-  env: Record<string, string | undefined>,
-  touchpoint: 'embedding' | 'expansion' | 'chat' | 'reranker',
+  env: EnvSnapshot,
+  touchpoint: AuthTouchpoint,
 ): { headerName: string; token: string } {
+  const oauth = resolveOAuthAccessToken(recipe, env);
+  if (oauth) {
+    return { headerName: 'Authorization', token: `Bearer ${oauth.token}` };
+  }
+
   const required = recipe.auth_env?.required ?? [];
   const optional = recipe.auth_env?.optional ?? [];
 
@@ -246,12 +313,53 @@ export function defaultResolveAuth(
 
   const key = env[required[0]];
   if (!key) {
+    const oauthVars = recipe.auth_env?.oauth_access_token ?? [];
+    const requirement = oauthVars.length > 0
+      ? `${required[0]} or ${oauthVars.join(' / ')}`
+      : required[0];
     throw new AIConfigError(
-      `${recipe.name} ${touchpoint} requires ${required[0]}.`,
+      `${recipe.name} ${touchpoint} requires ${requirement}.`,
       recipe.setup_hint,
     );
   }
   return { headerName: 'Authorization', token: `Bearer ${key}` };
+}
+
+function resolveRecipeDefaultHeaders(
+  recipe: Recipe,
+  env: EnvSnapshot,
+  authHeaderName: string,
+): Record<string, string> | undefined {
+  // v0.37.6.0 — resolve default_headers (static or env-templated). Mutually
+  // exclusive; declaring both is a config error.
+  if (recipe.default_headers && recipe.resolveDefaultHeaders) {
+    throw new AIConfigError(
+      `Recipe "${recipe.id}" declares both default_headers and resolveDefaultHeaders. Pick one.`,
+      recipe.setup_hint,
+    );
+  }
+  const defaults = recipe.resolveDefaultHeaders
+    ? recipe.resolveDefaultHeaders(env)
+    : recipe.default_headers;
+
+  // v0.37.6.0 — defaults MUST NOT shadow the resolved auth header. SDK applies
+  // headers after apiKey, so an `Authorization` entry in defaults would replace
+  // the Bearer the SDK adds. Custom-header recipes (Azure: api-key) are
+  // protected the same way.
+  if (defaults) {
+    const lcResolved = authHeaderName.toLowerCase();
+    for (const k of Object.keys(defaults)) {
+      const lc = k.toLowerCase();
+      if (lc === 'authorization' || lc === lcResolved) {
+        throw new AIConfigError(
+          `Recipe "${recipe.id}" default_headers contains "${k}" which would shadow the auth header. Remove it.`,
+          recipe.setup_hint,
+        );
+      }
+    }
+  }
+
+  return defaults;
 }
 
 /**
@@ -265,40 +373,13 @@ export function defaultResolveAuth(
 export function applyResolveAuth(
   recipe: Recipe,
   cfg: AIGatewayConfig,
-  touchpoint: 'embedding' | 'expansion' | 'chat' | 'reranker',
+  touchpoint: AuthTouchpoint,
 ): { apiKey?: string; headers?: Record<string, string> } {
   const resolved = recipe.resolveAuth
     ? recipe.resolveAuth(cfg.env)
     : defaultResolveAuth(recipe, cfg.env, touchpoint);
 
-  // v0.37.6.0 — resolve default_headers (static or env-templated). Mutually
-  // exclusive; declaring both is a config error.
-  if (recipe.default_headers && recipe.resolveDefaultHeaders) {
-    throw new AIConfigError(
-      `Recipe "${recipe.id}" declares both default_headers and resolveDefaultHeaders. Pick one.`,
-      recipe.setup_hint,
-    );
-  }
-  const defaults = recipe.resolveDefaultHeaders
-    ? recipe.resolveDefaultHeaders(cfg.env)
-    : recipe.default_headers;
-
-  // v0.37.6.0 — defaults MUST NOT shadow the resolved auth header. SDK applies
-  // headers after apiKey, so an `Authorization` entry in defaults would replace
-  // the Bearer the SDK adds. Custom-header recipes (Azure: api-key) are
-  // protected the same way.
-  if (defaults) {
-    const lcResolved = resolved.headerName.toLowerCase();
-    for (const k of Object.keys(defaults)) {
-      const lc = k.toLowerCase();
-      if (lc === 'authorization' || lc === lcResolved) {
-        throw new AIConfigError(
-          `Recipe "${recipe.id}" default_headers contains "${k}" which would shadow the auth header. Remove it.`,
-          recipe.setup_hint,
-        );
-      }
-    }
-  }
+  const defaults = resolveRecipeDefaultHeaders(recipe, cfg.env, resolved.headerName);
 
   // Bearer-via-Authorization: use the SDK's native apiKey path (which sets
   // Authorization: Bearer <key> internally). Strip the 'Bearer ' prefix the
@@ -317,6 +398,15 @@ export function applyResolveAuth(
   // Defaults merge in first, resolver wins on key conflict (the shadow guard
   // above already rejects conflicts, so this is defense-in-depth).
   return { headers: { ...(defaults ?? {}), [resolved.headerName]: resolved.token } };
+}
+
+function authOptionsToHeaders(
+  auth: { apiKey?: string; headers?: Record<string, string> },
+): Record<string, string> {
+  return {
+    ...(auth.apiKey ? { Authorization: `Bearer ${auth.apiKey}` } : {}),
+    ...(auth.headers ?? {}),
+  };
 }
 
 /**
@@ -343,6 +433,97 @@ export function applyOpenAICompatConfig(
     );
   }
   return { baseURL };
+}
+
+function requireApiKeyAuth(
+  recipe: Recipe,
+  cfg: AIGatewayConfig,
+  touchpoint: AuthTouchpoint,
+): string {
+  const keyName = recipe.auth_env?.required[0];
+  if (!keyName || !cfg.env[keyName]) {
+    throw new AIConfigError(
+      `${recipe.name} ${touchpoint} requires ${formatAuthRequirement(recipe)}.`,
+      recipe.setup_hint,
+    );
+  }
+  return cfg.env[keyName]!;
+}
+
+function fetchWithoutRequestHeaders(headerNames: string[]): typeof fetch {
+  const names = headerNames.map(h => h.toLowerCase());
+  return (async (input: any, init?: any) => {
+    const headers = new Headers(
+      init?.headers ?? (input instanceof Request ? input.headers : undefined),
+    );
+    for (const name of names) headers.delete(name);
+    return fetch(input, { ...(init ?? {}), headers });
+  }) as unknown as typeof fetch;
+}
+
+function nativeOpenAIOptions(
+  recipe: Recipe,
+  cfg: AIGatewayConfig,
+  touchpoint: AuthTouchpoint,
+): Record<string, unknown> {
+  const oauth = resolveOAuthAccessToken(recipe, cfg.env);
+  const defaults = resolveRecipeDefaultHeaders(recipe, cfg.env, 'Authorization');
+  const apiKey = oauth?.token ?? requireApiKeyAuth(recipe, cfg, touchpoint);
+  return {
+    apiKey,
+    ...(cfg.env.OPENAI_ORG_ID ? { organization: cfg.env.OPENAI_ORG_ID } : {}),
+    ...(cfg.env.OPENAI_PROJECT ? { project: cfg.env.OPENAI_PROJECT } : {}),
+    ...(defaults ? { headers: defaults } : {}),
+  };
+}
+
+function nativeGoogleOptions(
+  recipe: Recipe,
+  cfg: AIGatewayConfig,
+  touchpoint: AuthTouchpoint,
+): Record<string, unknown> {
+  const oauth = resolveOAuthAccessToken(recipe, cfg.env);
+  if (oauth) {
+    const defaults = resolveRecipeDefaultHeaders(recipe, cfg.env, 'Authorization');
+    return {
+      // @ai-sdk/google always adds x-goog-api-key from apiKey/process.env.
+      // Passing an empty string plus a tiny fetch wrapper keeps the gateway's
+      // "env snapshot only" contract while allowing Bearer-token auth.
+      apiKey: '',
+      headers: {
+        ...(defaults ?? {}),
+        Authorization: `Bearer ${oauth.token}`,
+      },
+      fetch: fetchWithoutRequestHeaders(['x-goog-api-key']),
+    };
+  }
+
+  const defaults = resolveRecipeDefaultHeaders(recipe, cfg.env, 'x-goog-api-key');
+  return {
+    apiKey: requireApiKeyAuth(recipe, cfg, touchpoint),
+    ...(defaults ? { headers: defaults } : {}),
+  };
+}
+
+function nativeAnthropicOptions(
+  recipe: Recipe,
+  cfg: AIGatewayConfig,
+  touchpoint: AuthTouchpoint,
+): Record<string, unknown> {
+  const oauth = resolveOAuthAccessToken(recipe, cfg.env);
+  if (oauth) {
+    const defaults = resolveRecipeDefaultHeaders(recipe, cfg.env, 'Authorization');
+    return {
+      authToken: oauth.token,
+      ...(defaults ? { headers: defaults } : {}),
+    };
+  }
+
+  const defaults = resolveRecipeDefaultHeaders(recipe, cfg.env, 'x-api-key');
+  return {
+    apiKey: requireApiKeyAuth(recipe, cfg, touchpoint),
+    ...(defaults ? { headers: defaults } : {}),
+  };
 }
 
 /** Configure the gateway. Called by cli.ts#connectEngine. Clears cached models. */
@@ -642,10 +823,7 @@ export function isAvailable(touchpoint: TouchpointKind, modelOverride?: string):
       (recipe.id === 'litellm' || isUserProvided)
     ) return false;
 
-    // For openai-compatible without auth requirements (Ollama local), treat as always-available.
-    const required = recipe.auth_env?.required ?? [];
-    if (required.length === 0) return true;
-    return required.every(k => !!_config!.env[k]);
+    return isRecipeAuthReady(recipe, _config!.env);
   } catch {
     return false;
   }
@@ -969,24 +1147,14 @@ async function resolveEmbeddingProvider(modelStr: string): Promise<{ model: any;
 function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
   switch (recipe.implementation) {
     case 'native-openai': {
-      const apiKey = cfg.env.OPENAI_API_KEY;
-      if (!apiKey) throw new AIConfigError(
-        `OpenAI embedding requires OPENAI_API_KEY.`,
-        recipe.setup_hint,
-      );
-      const client = createOpenAI({ apiKey });
+      const client = createOpenAI(nativeOpenAIOptions(recipe, cfg, 'embedding') as any);
       // AI SDK v6: use .textEmbeddingModel() for embeddings
       return (client as any).textEmbeddingModel
         ? (client as any).textEmbeddingModel(modelId)
         : (client as any).embedding(modelId);
     }
     case 'native-google': {
-      const apiKey = cfg.env.GOOGLE_GENERATIVE_AI_API_KEY;
-      if (!apiKey) throw new AIConfigError(
-        `Google embedding requires GOOGLE_GENERATIVE_AI_API_KEY.`,
-        recipe.setup_hint,
-      );
-      const client = createGoogleGenerativeAI({ apiKey });
+      const client = createGoogleGenerativeAI(nativeGoogleOptions(recipe, cfg, 'embedding') as any);
       return (client as any).textEmbeddingModel
         ? (client as any).textEmbeddingModel(modelId)
         : (client as any).embedding(modelId);
@@ -1472,13 +1640,7 @@ export async function embedMultimodal(
     );
   }
 
-  const apiKey = cfg.env[recipe.auth_env?.required[0] ?? 'VOYAGE_API_KEY'];
-  if (!apiKey) {
-    throw new AIConfigError(
-      `${recipe.name} requires ${recipe.auth_env?.required[0]} for multimodal embedding.`,
-      recipe.setup_hint,
-    );
-  }
+  const authHeaders = authOptionsToHeaders(applyResolveAuth(recipe, cfg, 'embedding'));
   const baseUrl = cfg.base_urls?.[recipe.id] ?? recipe.base_url_default;
   if (!baseUrl) {
     throw new AIConfigError(
@@ -1528,7 +1690,7 @@ export async function embedMultimodal(
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
+          ...authHeaders,
         },
         body: JSON.stringify(body),
       });
@@ -1541,7 +1703,7 @@ export async function embedMultimodal(
       if (res.status === 401 || res.status === 403) {
         throw new AIConfigError(
           `Voyage multimodal returned ${res.status}: ${text || 'auth failed'}.`,
-          `Re-export ${recipe.auth_env?.required[0]} or rotate the key at ${recipe.auth_env?.setup_url}.`,
+          `Re-export ${formatAuthRequirement(recipe)} or rotate credentials at ${recipe.auth_env?.setup_url ?? recipe.setup_hint}.`,
         );
       }
       // 429 / 5xx are transient; let the caller retry.
@@ -1614,9 +1776,7 @@ async function embedMultimodalOpenAICompat(
   // hard-required-auth recipes (OpenAI Authorization: Bearer
   // OPENAI_API_KEY) both work via the same code path. Throws AIConfigError
   // when required env is missing.
-  const authResult = recipe.resolveAuth
-    ? recipe.resolveAuth(cfg.env)
-    : defaultResolveAuth(recipe, cfg.env, 'embedding');
+  const authHeaders = authOptionsToHeaders(applyResolveAuth(recipe, cfg, 'embedding'));
   const baseUrl = cfg.base_urls?.[recipe.id] ?? recipe.base_url_default;
   if (!baseUrl) {
     throw new AIConfigError(
@@ -1670,7 +1830,7 @@ async function embedMultimodalOpenAICompat(
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          [authResult.headerName]: authResult.token,
+          ...authHeaders,
         },
         body: JSON.stringify(body),
       });
@@ -1685,7 +1845,7 @@ async function embedMultimodalOpenAICompat(
         throw new AIConfigError(
           `${recipe.name} multimodal returned ${res.status}: ${text || 'auth failed'}.`,
           requiredKey
-            ? `Re-export ${requiredKey} or rotate the key at ${recipe.auth_env?.setup_url ?? recipe.setup_hint}.`
+            ? `Re-export ${formatAuthRequirement(recipe)} or rotate credentials at ${recipe.auth_env?.setup_url ?? recipe.setup_hint}.`
             : recipe.setup_hint,
         );
       }
@@ -1869,19 +2029,13 @@ async function resolveExpansionProvider(modelStr: string): Promise<{ model: any;
 function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
   switch (recipe.implementation) {
     case 'native-openai': {
-      const apiKey = cfg.env.OPENAI_API_KEY;
-      if (!apiKey) throw new AIConfigError(`OpenAI expansion requires OPENAI_API_KEY.`, recipe.setup_hint);
-      return createOpenAI({ apiKey }).languageModel(modelId);
+      return createOpenAI(nativeOpenAIOptions(recipe, cfg, 'expansion') as any).languageModel(modelId);
     }
     case 'native-google': {
-      const apiKey = cfg.env.GOOGLE_GENERATIVE_AI_API_KEY;
-      if (!apiKey) throw new AIConfigError(`Google expansion requires GOOGLE_GENERATIVE_AI_API_KEY.`, recipe.setup_hint);
-      return createGoogleGenerativeAI({ apiKey }).languageModel(modelId);
+      return createGoogleGenerativeAI(nativeGoogleOptions(recipe, cfg, 'expansion') as any).languageModel(modelId);
     }
     case 'native-anthropic': {
-      const apiKey = cfg.env.ANTHROPIC_API_KEY;
-      if (!apiKey) throw new AIConfigError(`Anthropic expansion requires ANTHROPIC_API_KEY.`, recipe.setup_hint);
-      return createAnthropic({ apiKey }).languageModel(modelId);
+      return createAnthropic(nativeAnthropicOptions(recipe, cfg, 'expansion') as any).languageModel(modelId);
     }
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
@@ -2114,19 +2268,13 @@ async function resolveChatProvider(modelStr: string): Promise<{ model: any; reci
 function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
   switch (recipe.implementation) {
     case 'native-openai': {
-      const apiKey = cfg.env.OPENAI_API_KEY;
-      if (!apiKey) throw new AIConfigError(`OpenAI chat requires OPENAI_API_KEY.`, recipe.setup_hint);
-      return createOpenAI({ apiKey }).languageModel(modelId);
+      return createOpenAI(nativeOpenAIOptions(recipe, cfg, 'chat') as any).languageModel(modelId);
     }
     case 'native-google': {
-      const apiKey = cfg.env.GOOGLE_GENERATIVE_AI_API_KEY;
-      if (!apiKey) throw new AIConfigError(`Google chat requires GOOGLE_GENERATIVE_AI_API_KEY.`, recipe.setup_hint);
-      return createGoogleGenerativeAI({ apiKey }).languageModel(modelId);
+      return createGoogleGenerativeAI(nativeGoogleOptions(recipe, cfg, 'chat') as any).languageModel(modelId);
     }
     case 'native-anthropic': {
-      const apiKey = cfg.env.ANTHROPIC_API_KEY;
-      if (!apiKey) throw new AIConfigError(`Anthropic chat requires ANTHROPIC_API_KEY.`, recipe.setup_hint);
-      return createAnthropic({ apiKey }).languageModel(modelId);
+      return createAnthropic(nativeAnthropicOptions(recipe, cfg, 'chat') as any).languageModel(modelId);
     }
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
@@ -2775,10 +2923,7 @@ export async function rerank(input: RerankInput): Promise<RerankResult[]> {
   // through `auth.headers` alongside Bearer-style apiKey. The merge below
   // materializes both shapes so static-default-headers ride on the reranker
   // wire path the same way they ride the SDK paths.
-  const authHeaders: Record<string, string> = {
-    ...(auth.apiKey ? { Authorization: `Bearer ${auth.apiKey}` } : {}),
-    ...(auth.headers ?? {}),
-  };
+  const authHeaders: Record<string, string> = authOptionsToHeaders(auth);
   const body = JSON.stringify({
     model: parsed.modelId,
     query: input.query,

--- a/src/core/ai/recipes/anthropic.ts
+++ b/src/core/ai/recipes/anthropic.ts
@@ -12,6 +12,8 @@ export const anthropic: Recipe = {
   implementation: 'native-anthropic',
   auth_env: {
     required: ['ANTHROPIC_API_KEY'],
+    oauth_access_token: ['ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_OAUTH_ACCESS_TOKEN'],
+    oauth_replaces: ['ANTHROPIC_API_KEY'],
     setup_url: 'https://console.anthropic.com/settings/keys',
   },
   touchpoints: {

--- a/src/core/ai/recipes/azure-openai.ts
+++ b/src/core/ai/recipes/azure-openai.ts
@@ -35,6 +35,8 @@ export const azureOpenAI: Recipe = {
       'AZURE_OPENAI_DEPLOYMENT',
     ],
     optional: ['AZURE_OPENAI_API_VERSION'],
+    oauth_access_token: ['AZURE_OPENAI_OAUTH_ACCESS_TOKEN', 'AZURE_OPENAI_ACCESS_TOKEN'],
+    oauth_replaces: ['AZURE_OPENAI_API_KEY'],
     setup_url:
       'https://learn.microsoft.com/en-us/azure/ai-services/openai/quickstart',
   },
@@ -54,10 +56,17 @@ export const azureOpenAI: Recipe = {
     },
   },
   resolveAuth(env) {
+    const oauthToken =
+      env.AZURE_OPENAI_OAUTH_ACCESS_TOKEN ??
+      env.AZURE_OPENAI_ACCESS_TOKEN;
+    if (oauthToken) {
+      return { headerName: 'Authorization', token: `Bearer ${oauthToken}` };
+    }
+
     const key = env.AZURE_OPENAI_API_KEY;
     if (!key) {
       throw new AIConfigError(
-        `Azure OpenAI requires AZURE_OPENAI_API_KEY.`,
+        `Azure OpenAI requires AZURE_OPENAI_API_KEY or AZURE_OPENAI_OAUTH_ACCESS_TOKEN.`,
         'Get a key from your Azure portal: https://learn.microsoft.com/en-us/azure/ai-services/openai/quickstart',
       );
     }

--- a/src/core/ai/recipes/dashscope.ts
+++ b/src/core/ai/recipes/dashscope.ts
@@ -20,6 +20,8 @@ export const dashscope: Recipe = {
   base_url_default: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
   auth_env: {
     required: ['DASHSCOPE_API_KEY'],
+    oauth_access_token: ['DASHSCOPE_OAUTH_ACCESS_TOKEN', 'DASHSCOPE_ACCESS_TOKEN'],
+    oauth_replaces: ['DASHSCOPE_API_KEY'],
     setup_url: 'https://help.aliyun.com/zh/model-studio/getting-started/',
   },
   touchpoints: {

--- a/src/core/ai/recipes/deepseek.ts
+++ b/src/core/ai/recipes/deepseek.ts
@@ -14,6 +14,8 @@ export const deepseek: Recipe = {
   base_url_default: 'https://api.deepseek.com/v1',
   auth_env: {
     required: ['DEEPSEEK_API_KEY'],
+    oauth_access_token: ['DEEPSEEK_OAUTH_ACCESS_TOKEN', 'DEEPSEEK_ACCESS_TOKEN'],
+    oauth_replaces: ['DEEPSEEK_API_KEY'],
     setup_url: 'https://platform.deepseek.com/api_keys',
   },
   touchpoints: {

--- a/src/core/ai/recipes/google.ts
+++ b/src/core/ai/recipes/google.ts
@@ -7,6 +7,12 @@ export const google: Recipe = {
   implementation: 'native-google',
   auth_env: {
     required: ['GOOGLE_GENERATIVE_AI_API_KEY'],
+    oauth_access_token: [
+      'GOOGLE_GENERATIVE_AI_OAUTH_ACCESS_TOKEN',
+      'GOOGLE_GENERATIVE_AI_ACCESS_TOKEN',
+      'GOOGLE_OAUTH_ACCESS_TOKEN',
+    ],
+    oauth_replaces: ['GOOGLE_GENERATIVE_AI_API_KEY'],
     setup_url: 'https://aistudio.google.com/apikey',
   },
   touchpoints: {

--- a/src/core/ai/recipes/groq.ts
+++ b/src/core/ai/recipes/groq.ts
@@ -13,6 +13,8 @@ export const groq: Recipe = {
   base_url_default: 'https://api.groq.com/openai/v1',
   auth_env: {
     required: ['GROQ_API_KEY'],
+    oauth_access_token: ['GROQ_OAUTH_ACCESS_TOKEN', 'GROQ_ACCESS_TOKEN'],
+    oauth_replaces: ['GROQ_API_KEY'],
     setup_url: 'https://console.groq.com/keys',
   },
   touchpoints: {

--- a/src/core/ai/recipes/litellm-proxy.ts
+++ b/src/core/ai/recipes/litellm-proxy.ts
@@ -17,6 +17,7 @@ export const litellmProxy: Recipe = {
   auth_env: {
     required: [], // LITELLM_API_KEY is optional (users may run proxy unauthenticated locally)
     optional: ['LITELLM_BASE_URL', 'LITELLM_API_KEY'],
+    oauth_access_token: ['LITELLM_OAUTH_ACCESS_TOKEN', 'LITELLM_ACCESS_TOKEN'],
     setup_url: 'https://docs.litellm.ai/docs/proxy/quick_start',
   },
   touchpoints: {

--- a/src/core/ai/recipes/llama-server.ts
+++ b/src/core/ai/recipes/llama-server.ts
@@ -24,6 +24,7 @@ export const llamaServer: Recipe = {
   auth_env: {
     required: [],
     optional: ['LLAMA_SERVER_BASE_URL', 'LLAMA_SERVER_API_KEY'],
+    oauth_access_token: ['LLAMA_SERVER_OAUTH_ACCESS_TOKEN', 'LLAMA_SERVER_ACCESS_TOKEN'],
     setup_url:
       'https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md',
   },

--- a/src/core/ai/recipes/minimax.ts
+++ b/src/core/ai/recipes/minimax.ts
@@ -24,6 +24,8 @@ export const minimax: Recipe = {
   auth_env: {
     required: ['MINIMAX_API_KEY'],
     optional: ['MINIMAX_GROUP_ID'],
+    oauth_access_token: ['MINIMAX_OAUTH_ACCESS_TOKEN', 'MINIMAX_ACCESS_TOKEN'],
+    oauth_replaces: ['MINIMAX_API_KEY'],
     setup_url: 'https://www.minimaxi.com/document/guides/embeddings',
   },
   touchpoints: {

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -9,6 +9,7 @@ export const ollama: Recipe = {
   auth_env: {
     required: [], // Ollama runs unauthenticated locally; users pass `ollama` as the key.
     optional: ['OLLAMA_BASE_URL', 'OLLAMA_API_KEY'],
+    oauth_access_token: ['OLLAMA_OAUTH_ACCESS_TOKEN', 'OLLAMA_ACCESS_TOKEN'],
     setup_url: 'https://ollama.ai',
   },
   touchpoints: {

--- a/src/core/ai/recipes/openai.ts
+++ b/src/core/ai/recipes/openai.ts
@@ -8,6 +8,8 @@ export const openai: Recipe = {
   auth_env: {
     required: ['OPENAI_API_KEY'],
     optional: ['OPENAI_ORG_ID', 'OPENAI_PROJECT'],
+    oauth_access_token: ['OPENAI_OAUTH_ACCESS_TOKEN', 'OPENAI_ACCESS_TOKEN'],
+    oauth_replaces: ['OPENAI_API_KEY'],
     setup_url: 'https://platform.openai.com/api-keys',
   },
   touchpoints: {

--- a/src/core/ai/recipes/openrouter.ts
+++ b/src/core/ai/recipes/openrouter.ts
@@ -46,6 +46,8 @@ export const openrouter: Recipe = {
   auth_env: {
     required: ['OPENROUTER_API_KEY'],
     optional: ['OPENROUTER_BASE_URL', 'OPENROUTER_REFERER', 'OPENROUTER_TITLE'],
+    oauth_access_token: ['OPENROUTER_OAUTH_ACCESS_TOKEN', 'OPENROUTER_ACCESS_TOKEN'],
+    oauth_replaces: ['OPENROUTER_API_KEY'],
     setup_url: 'https://openrouter.ai/settings/keys',
   },
   resolveDefaultHeaders(env) {

--- a/src/core/ai/recipes/together.ts
+++ b/src/core/ai/recipes/together.ts
@@ -13,6 +13,8 @@ export const together: Recipe = {
   base_url_default: 'https://api.together.xyz/v1',
   auth_env: {
     required: ['TOGETHER_API_KEY'],
+    oauth_access_token: ['TOGETHER_OAUTH_ACCESS_TOKEN', 'TOGETHER_ACCESS_TOKEN'],
+    oauth_replaces: ['TOGETHER_API_KEY'],
     setup_url: 'https://api.together.ai/settings/api-keys',
   },
   touchpoints: {

--- a/src/core/ai/recipes/voyage.ts
+++ b/src/core/ai/recipes/voyage.ts
@@ -26,6 +26,8 @@ export const voyage: Recipe = {
   base_url_default: 'https://api.voyageai.com/v1',
   auth_env: {
     required: ['VOYAGE_API_KEY'],
+    oauth_access_token: ['VOYAGE_OAUTH_ACCESS_TOKEN', 'VOYAGE_ACCESS_TOKEN'],
+    oauth_replaces: ['VOYAGE_API_KEY'],
     setup_url: 'https://dash.voyageai.com/api-keys',
   },
   touchpoints: {

--- a/src/core/ai/recipes/zeroentropyai.ts
+++ b/src/core/ai/recipes/zeroentropyai.ts
@@ -36,6 +36,8 @@ export const zeroentropyai: Recipe = {
   base_url_default: 'https://api.zeroentropy.dev/v1',
   auth_env: {
     required: ['ZEROENTROPY_API_KEY'],
+    oauth_access_token: ['ZEROENTROPY_OAUTH_ACCESS_TOKEN', 'ZEROENTROPY_ACCESS_TOKEN'],
+    oauth_replaces: ['ZEROENTROPY_API_KEY'],
     setup_url: 'https://dashboard.zeroentropy.dev',
   },
   touchpoints: {

--- a/src/core/ai/recipes/zhipu.ts
+++ b/src/core/ai/recipes/zhipu.ts
@@ -22,6 +22,8 @@ export const zhipu: Recipe = {
   base_url_default: 'https://open.bigmodel.cn/api/paas/v4',
   auth_env: {
     required: ['ZHIPUAI_API_KEY'],
+    oauth_access_token: ['ZHIPUAI_OAUTH_ACCESS_TOKEN', 'ZHIPUAI_ACCESS_TOKEN'],
+    oauth_replaces: ['ZHIPUAI_API_KEY'],
     setup_url: 'https://open.bigmodel.cn/',
   },
   touchpoints: {

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -220,6 +220,24 @@ export interface Recipe {
   auth_env?: {
     required: string[];
     optional?: string[];
+    /**
+     * Env var name(s) containing a pre-minted OAuth/OIDC access token that can
+     * be sent as `Authorization: Bearer <token>`.
+     *
+     * gbrain does not mint or refresh these tokens; it only consumes a token
+     * provided by the operator or an external credential helper. When present,
+     * this token is preferred over API-key auth for all gateway touchpoints
+     * (embedding, expansion, chat, reranker).
+     */
+    oauth_access_token?: string[];
+    /**
+     * Which `required` env vars are satisfied by `oauth_access_token`.
+     * Defaults to the first required env var, which is the API-key slot for
+     * current recipes. Recipes that also require non-auth config (Azure's
+     * endpoint/deployment) should leave those entries out so readiness checks
+     * still require them.
+     */
+    oauth_replaces?: string[];
     setup_url?: string;
   };
   touchpoints: {

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -170,6 +170,11 @@ describe('chat touchpoint — gateway config plumbing', () => {
     expect(isAvailable('chat')).toBe(true);
   });
 
+  test('isAvailable("chat") returns true when Anthropic bearer token is present', () => {
+    configureGateway({ env: { ANTHROPIC_AUTH_TOKEN: 'oauth-anthropic-token' } });
+    expect(isAvailable('chat')).toBe(true);
+  });
+
   test('isAvailable("chat") returns false when configured provider has no key', () => {
     configureGateway({ chat_model: 'openai:gpt-5.2', env: {} });
     expect(isAvailable('chat')).toBe(false);

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -68,6 +68,15 @@ describe('gateway.isAvailable (silent-drop regression surface)', () => {
     expect(isAvailable('embedding')).toBe(false);
   });
 
+  test('embedding available when OPENAI_OAUTH_ACCESS_TOKEN replaces OPENAI_API_KEY', () => {
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-large',
+      embedding_dimensions: 1536,
+      env: { OPENAI_OAUTH_ACCESS_TOKEN: 'oauth-openai-token' },
+    });
+    expect(isAvailable('embedding')).toBe(true);
+  });
+
   test('embedding AVAILABLE for google when GOOGLE_GENERATIVE_AI_API_KEY set even if OPENAI_API_KEY is NOT (Codex silent-drop regression)', () => {
     configureGateway({
       embedding_model: 'google:gemini-embedding-001',
@@ -99,6 +108,14 @@ describe('gateway.isAvailable (silent-drop regression surface)', () => {
     configureGateway({
       expansion_model: 'anthropic:claude-haiku-4-5-20251001',
       env: { ANTHROPIC_API_KEY: 'fake' },
+    });
+    expect(isAvailable('expansion')).toBe(true);
+  });
+
+  test('expansion available when ANTHROPIC_AUTH_TOKEN replaces ANTHROPIC_API_KEY', () => {
+    configureGateway({
+      expansion_model: 'anthropic:claude-haiku-4-5-20251001',
+      env: { ANTHROPIC_AUTH_TOKEN: 'oauth-anthropic-token' },
     });
     expect(isAvailable('expansion')).toBe(true);
   });
@@ -184,6 +201,78 @@ describe('dims.dimsProviderOptions', () => {
   test('voyage-4-nano returns undefined (open-weight, fixed-dim)', () => {
     const opts = dimsProviderOptions('openai-compatible', 'voyage-4-nano', 512);
     expect(opts).toBeUndefined();
+  });
+});
+
+describe('gateway OAuth bearer auth', () => {
+  beforeEach(() => resetGateway());
+
+  test('native OpenAI embedding sends OAuth token as Authorization Bearer', async () => {
+    const originalFetch = globalThis.fetch;
+    let authHeader = '';
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers ?? (_url instanceof Request ? _url.headers : undefined));
+      authHeader = headers.get('authorization') ?? '';
+      return new Response(JSON.stringify({
+        object: 'list',
+        data: [
+          {
+            object: 'embedding',
+            index: 0,
+            embedding: new Array(1536).fill(0.01),
+          },
+        ],
+        model: 'text-embedding-3-large',
+        usage: { prompt_tokens: 1, total_tokens: 1 },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      configureGateway({
+        embedding_model: 'openai:text-embedding-3-large',
+        embedding_dimensions: 1536,
+        env: { OPENAI_OAUTH_ACCESS_TOKEN: 'oauth-native-openai' },
+      });
+
+      await embed(['oauth probe']);
+      expect(authHeader).toBe('Bearer oauth-native-openai');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('native Google embedding sends OAuth Bearer without x-goog-api-key', async () => {
+    const originalFetch = globalThis.fetch;
+    let authHeader = '';
+    let googleApiKeyHeader: string | null = null;
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers ?? (_url instanceof Request ? _url.headers : undefined));
+      authHeader = headers.get('authorization') ?? '';
+      googleApiKeyHeader = headers.get('x-goog-api-key');
+      return new Response(JSON.stringify({
+        embedding: { values: new Array(768).fill(0.01) },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      configureGateway({
+        embedding_model: 'google:gemini-embedding-001',
+        embedding_dimensions: 768,
+        env: { GOOGLE_GENERATIVE_AI_OAUTH_ACCESS_TOKEN: 'oauth-google' },
+      });
+
+      await embed(['oauth probe']);
+      expect(authHeader).toBe('Bearer oauth-google');
+      expect(googleApiKeyHeader).toBeNull();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/test/ai/recipe-azure-openai.test.ts
+++ b/test/ai/recipe-azure-openai.test.ts
@@ -2,13 +2,13 @@
  * Azure OpenAI recipe smoke (Commit 8 of the v0.32 wave).
  *
  * Azure is the first recipe to exercise BOTH new seams:
- *   - resolveAuth → custom header (api-key, NOT Authorization Bearer)
+ *   - resolveAuth → custom header (api-key) or OAuth Bearer token
  *   - resolveOpenAICompatConfig → templated baseURL + fetch wrapper that
  *     splices `?api-version=` onto every request
  *
  * Coverage:
  *  - Recipe registered with expected shape
- *  - resolveAuth returns api-key header; missing key → AIConfigError
+ *  - resolveAuth returns api-key header, or Authorization Bearer for OAuth
  *  - resolveOpenAICompatConfig templates baseURL from endpoint + deployment
  *  - resolveOpenAICompatConfig throws when endpoint or deployment missing
  *  - fetch wrapper splices api-version query param (default + override)
@@ -44,6 +44,8 @@ describe('recipe: azure-openai', () => {
       'AZURE_OPENAI_DEPLOYMENT',
     ]);
     expect(r!.auth_env?.optional).toContain('AZURE_OPENAI_API_VERSION');
+    expect(r!.auth_env?.oauth_access_token).toContain('AZURE_OPENAI_OAUTH_ACCESS_TOKEN');
+    expect(r!.auth_env?.oauth_replaces).toEqual(['AZURE_OPENAI_API_KEY']);
   });
 
   test('embedding touchpoint declares 3 models + 1536 default + Matryoshka options', () => {
@@ -71,11 +73,35 @@ describe('recipe: azure-openai', () => {
     expect(() => r.resolveAuth!({})).toThrow(AIConfigError);
   });
 
+  test('resolveAuth returns Authorization Bearer when OAuth access token is set', () => {
+    const r = getRecipe('azure-openai')!;
+    const auth = r.resolveAuth!({
+      AZURE_OPENAI_OAUTH_ACCESS_TOKEN: 'az-oauth-token',
+    });
+    expect(auth).toEqual({
+      headerName: 'Authorization',
+      token: 'Bearer az-oauth-token',
+    });
+  });
+
   test('applyResolveAuth puts the key in headers (NOT apiKey) — no double-auth', () => {
     const r = getRecipe('azure-openai')!;
     const result = applyResolveAuth(r, { env: FULL_ENV } as any, 'embedding');
     expect(result.apiKey, 'apiKey must be undefined to avoid double-auth').toBeUndefined();
     expect(result.headers).toEqual({ 'api-key': 'az-fake-key' });
+  });
+
+  test('applyResolveAuth uses SDK apiKey path for Azure OAuth Bearer token', () => {
+    const r = getRecipe('azure-openai')!;
+    const result = applyResolveAuth(r, {
+      env: {
+        ...FULL_ENV,
+        AZURE_OPENAI_API_KEY: undefined,
+        AZURE_OPENAI_OAUTH_ACCESS_TOKEN: 'az-oauth-token',
+      },
+    } as any, 'embedding');
+    expect(result.apiKey).toBe('az-oauth-token');
+    expect(result.headers).toBeUndefined();
   });
 
   test('resolveOpenAICompatConfig templates baseURL from endpoint + deployment', () => {

--- a/test/ai/recipes-existing-regression.test.ts
+++ b/test/ai/recipes-existing-regression.test.ts
@@ -21,7 +21,12 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { defaultResolveAuth, applyResolveAuth } from '../../src/core/ai/gateway.ts';
+import {
+  defaultResolveAuth,
+  applyResolveAuth,
+  missingRequiredAuthEnv,
+  resolveOAuthAccessToken,
+} from '../../src/core/ai/gateway.ts';
 import { listRecipes, getRecipe } from '../../src/core/ai/recipes/index.ts';
 import { AIConfigError } from '../../src/core/ai/errors.ts';
 import type { Recipe } from '../../src/core/ai/types.ts';
@@ -143,6 +148,33 @@ describe('IRON RULE: existing 9 recipes survive the v0.32 resolveAuth refactor',
     const auth = applyResolveAuth(voyage, { env } as any, 'embedding');
     expect(auth.apiKey).toBe('fake-voyage-key');
     expect(auth.headers).toBeUndefined();
+  });
+
+  test('OAuth access token is preferred over API key for Bearer auth', () => {
+    const voyage = getRecipe('voyage')!;
+    const env = {
+      VOYAGE_API_KEY: 'fake-voyage-key',
+      VOYAGE_OAUTH_ACCESS_TOKEN: 'oauth-voyage-token',
+    };
+    const resolved = resolveOAuthAccessToken(voyage, env);
+    expect(resolved).toEqual({
+      envName: 'VOYAGE_OAUTH_ACCESS_TOKEN',
+      token: 'oauth-voyage-token',
+    });
+    const auth = defaultResolveAuth(voyage, env, 'embedding');
+    expect(auth).toEqual({
+      headerName: 'Authorization',
+      token: 'Bearer oauth-voyage-token',
+    });
+    const applied = applyResolveAuth(voyage, { env } as any, 'embedding');
+    expect(applied.apiKey).toBe('oauth-voyage-token');
+  });
+
+  test('OAuth token satisfies only the API-key slot, not other required config', () => {
+    const azure = getRecipe('azure-openai')!;
+    expect(missingRequiredAuthEnv(azure, {
+      AZURE_OPENAI_OAUTH_ACCESS_TOKEN: 'oauth-azure-token',
+    })).toEqual(['AZURE_OPENAI_ENDPOINT', 'AZURE_OPENAI_DEPLOYMENT']);
   });
 
   test('applyResolveAuth respects a recipe.resolveAuth override that returns a custom header', () => {

--- a/test/ai/rerank.test.ts
+++ b/test/ai/rerank.test.ts
@@ -100,6 +100,21 @@ describe('gateway.rerank() — happy path', () => {
     expect(authHeader).toBe('Bearer sk-test-zerokey');
   });
 
+  test('uses OAuth Bearer token when ZEROENTROPY_API_KEY is absent', async () => {
+    configureGateway({
+      reranker_model: 'zeroentropyai:zerank-2',
+      env: { ZEROENTROPY_OAUTH_ACCESS_TOKEN: 'oauth-zeroentropy' },
+    });
+    let authHeader = '';
+    __setRerankTransportForTests(async (_url, init) => {
+      const headers = new Headers(init.headers as HeadersInit);
+      authHeader = headers.get('authorization') ?? '';
+      return mockResp({ results: [{ index: 0, relevance_score: 1.0 }] });
+    });
+    await rerank({ query: 'q', documents: ['d'] });
+    expect(authHeader).toBe('Bearer oauth-zeroentropy');
+  });
+
   test('Content-Type: application/json', async () => {
     let contentType = '';
     __setRerankTransportForTests(async (_url, init) => {

--- a/test/init-env-detection.test.ts
+++ b/test/init-env-detection.test.ts
@@ -20,6 +20,13 @@ describe('groupReadyByProvider — embedding touchpoint', () => {
     expect(got.map(p => p.recipeId)).toContain('openai');
   });
 
+  test('OPENAI_OAUTH_ACCESS_TOKEN alone → openai is ready', async () => {
+    const got = await groupReadyByProvider('embedding', {
+      OPENAI_OAUTH_ACCESS_TOKEN: 'oauth-openai-token',
+    });
+    expect(got.map(p => p.recipeId)).toContain('openai');
+  });
+
   test('VOYAGE_API_KEY alone → voyage is ready', async () => {
     const got = await groupReadyByProvider('embedding', { VOYAGE_API_KEY: 'pa-test' });
     expect(got.map(p => p.recipeId)).toContain('voyage');
@@ -82,6 +89,11 @@ describe('groupReadyByProvider — chat touchpoint', () => {
 
   test('ANTHROPIC_API_KEY → anthropic chat ready', async () => {
     const got = await groupReadyByProvider('chat', { ANTHROPIC_API_KEY: 'sk-ant-test' });
+    expect(got.map(p => p.recipeId)).toContain('anthropic');
+  });
+
+  test('ANTHROPIC_AUTH_TOKEN → anthropic chat ready', async () => {
+    const got = await groupReadyByProvider('chat', { ANTHROPIC_AUTH_TOKEN: 'oauth-ant-test' });
     expect(got.map(p => p.recipeId)).toContain('anthropic');
   });
 });

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -22,6 +22,12 @@ describe('envReady', () => {
     expect(envReady(openai!, {})).toBe(false);
   });
 
+  test('true when OAuth access token alternative is set', () => {
+    const openai = getRecipe('openai');
+    expect(openai).toBeDefined();
+    expect(envReady(openai!, { OPENAI_OAUTH_ACCESS_TOKEN: 'oauth-token' })).toBe(true);
+  });
+
   test('false on empty-string env var', () => {
     const openai = getRecipe('openai');
     expect(envReady(openai!, { OPENAI_API_KEY: '' })).toBe(false);
@@ -59,7 +65,7 @@ describe('formatRecipeTable', () => {
     // openai should show missing OPENAI_API_KEY
     const openaiLine = out.split('\n').find(line => line.startsWith('openai'));
     expect(openaiLine).toBeDefined();
-    expect(openaiLine).toContain('✗ missing OPENAI_API_KEY');
+    expect(openaiLine).toContain('✗ missing OPENAI_API_KEY or OPENAI_OAUTH_ACCESS_TOKEN');
   });
 
   test('each recipe appears at most once', () => {
@@ -91,6 +97,14 @@ describe('formatRecipeTable', () => {
     expect(lines[2]).toContain('openai');
     expect(lines[2]).toContain('✓ ready');
     expect(lines[3]).toContain('zeroentropyai');
-    expect(lines[3]).toContain('✗ missing ZEROENTROPY_API_KEY');
+    expect(lines[3]).toContain('✗ missing ZEROENTROPY_API_KEY or ZEROENTROPY_OAUTH_ACCESS_TOKEN');
+  });
+
+  test('shows ready when OAuth token satisfies provider auth', () => {
+    const openai = getRecipe('openai');
+    expect(openai).toBeDefined();
+    const out = formatRecipeTable([openai!], { OPENAI_OAUTH_ACCESS_TOKEN: 'oauth-token' });
+    const line = out.split('\n').find(row => row.startsWith('openai'));
+    expect(line).toContain('✓ ready');
   });
 });


### PR DESCRIPTION
﻿## Summary

Adds a recipe-level OAuth bearer-token auth path for AI providers without removing existing API-key support.

- Extends `auth_env` with `oauth_access_token` and `oauth_replaces` so recipes can declare pre-minted bearer token env vars.
- Teaches the gateway to prefer OAuth bearer tokens across embedding, multimodal embedding, query expansion, chat, and rerank.
- Wires native OpenAI, Google, and Anthropic SDK paths through the same readiness/auth model while preserving API-key behavior.
- Adds Azure OpenAI bearer support where OAuth replaces only `AZURE_OPENAI_API_KEY`; endpoint/deployment remain required.
- Updates provider/env/init detection and docs so OAuth credentials are treated as ready.

GBrain does not mint or refresh tokens in this PR; it consumes access tokens supplied by an external OAuth/identity helper.

## Tests

- `bun run typecheck`
- `bun test test/providers.test.ts test/init-env-detection.test.ts test/ai/gateway.test.ts test/ai/gateway-chat.test.ts test/ai/recipes-existing-regression.test.ts test/ai/recipe-azure-openai.test.ts test/ai/rerank.test.ts test/ai/header-transport.test.ts`
- `bun test test/e2e/init-fresh-pglite.test.ts`
- `bun test test/ai/recipe-openrouter.test.ts test/ai/recipe-dashscope.test.ts test/ai/recipe-minimax.test.ts test/ai/recipe-zhipu.test.ts test/ai/recipe-llama-server.test.ts test/ai/zeroentropy-recipe.test.ts`
