### PR TITLE
feat(sync): parallelize sync --all + add --status source dashboard

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -161,6 +161,21 @@ export interface SyncOpts {
    * v0.22.13 (PR #490 CODEX-2). Not part of the public CLI surface.
    */
   skipLock?: boolean;
+  /**
+   * Override the DB lock id taken around the writer window.
+   * Defaults to `SYNC_LOCK_ID` (the global `'gbrain-sync'` lock).
+   *
+   * Set by the `sync --all` parallel fan-out path so concurrent
+   * per-source syncs each take an independent per-source lock
+   * (`gbrain-sync:<source_id>`) instead of contending on a single
+   * global lock. Each source already has its own `sourceId` and
+   * `last_commit` bookmark, so the per-source lock is sufficient to
+   * serialize syncs of the SAME source while letting DIFFERENT
+   * sources sync concurrently.
+   *
+   * Not part of the public CLI surface.
+   */
+  lockId?: string;
 }
 
 /**
@@ -372,10 +387,16 @@ export async function performSync(engine: BrainEngine, opts: SyncOpts): Promise<
   // mechanism (none in v0.22.13; reserved for future).
   let lockHandle: { release: () => Promise<void> } | null = null;
   if (!opts.skipLock) {
-    lockHandle = await tryAcquireDbLock(engine, SYNC_LOCK_ID);
+    // v0.40.3 — parallel `sync --all` passes an explicit per-source lockId
+    // (`gbrain-sync:<source_id>`). The CLI-default / cycle / jobs-handler
+    // path falls back to the global SYNC_LOCK_ID so historical behavior
+    // (single-process serialization of single-source syncs) is preserved
+    // for callers that do not opt in.
+    const lockId = opts.lockId ?? SYNC_LOCK_ID;
+    lockHandle = await tryAcquireDbLock(engine, lockId);
     if (!lockHandle) {
       throw new Error(
-        `Another sync is in progress (lock ${SYNC_LOCK_ID} held). ` +
+        `Another sync is in progress (lock ${lockId} held). ` +
         `Wait for it to finish, or run 'gbrain doctor' if it has been more than 30 minutes.`,
       );
     }
@@ -1219,6 +1240,15 @@ Options:
   --no-pull            Skip 'git pull' before the sync (useful for tests).
   --all                Sync every registered source instead of just the
                        default (multi-source brains).
+  --parallel N         Run --all sources concurrently with N at-a-time.
+                       Default: min(sourceCount, --workers, 4). Set N=1
+                       to force the legacy sequential walk. Each source
+                       takes its own per-source DB lock
+                       (gbrain-sync:<source_id>) so independent sources
+                       sync concurrently without contending.
+  --status             Print the per-source sync dashboard (last sync,
+                       staleness, embedding coverage, unacked failures)
+                       and exit. Pairs with --all. Read-only.
   --json               Emit a structured JSON summary on stdout.
   --yes                Accept any interactive prompts (CI / non-TTY).
 
@@ -1240,6 +1270,8 @@ See also:
   const skipFailed = args.includes('--skip-failed');
   const retryFailed = args.includes('--retry-failed');
   const syncAll = args.includes('--all');
+  const statusOnly = args.includes('--status');
+  const parallelStr = args.find((a, i) => args[i - 1] === '--parallel');
   const jsonOut = args.includes('--json');
   const yesFlag = args.includes('--yes');
   const strategyArg = args.find((a, i) => args[i - 1] === '--strategy') as SyncOpts['strategy'] | undefined;
@@ -1250,6 +1282,19 @@ See also:
   let concurrency: number | undefined;
   try {
     concurrency = parseWorkers(concurrencyStr);
+  } catch (e) {
+    console.error(e instanceof Error ? e.message : String(e));
+    process.exit(1);
+  }
+
+  // v0.40.3 — `--parallel N` controls how many sources `sync --all` runs
+  // concurrently. Validated through the same parseWorkers helper as
+  // `--workers` (positive integer, throw on '0', '-3', 'foo', '1.5').
+  // Resolved against the source count below once we know how many
+  // sources are registered.
+  let parallelOverride: number | undefined;
+  try {
+    parallelOverride = parseWorkers(parallelStr);
   } catch (e) {
     console.error(e instanceof Error ? e.message : String(e));
     process.exit(1);
@@ -1350,33 +1395,144 @@ See also:
       }
     }
 
+    // v0.40.3 — `--all --status` short-circuits before any sync work runs.
+    // It's a read-only per-source dashboard: last sync time, staleness,
+    // embedding coverage, unacknowledged failures. Honors --json.
+    // Reported by operators of large brains who needed a quick "why did the
+    // doctor score drop?" view without scheduling another sync.
+    if (statusOnly) {
+      const report = await buildSyncStatusReport(engine, sources);
+      if (jsonOut) {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        printSyncStatusReport(report);
+      }
+      return;
+    }
+
+    // v0.40.3 — fan out per-source syncs concurrently. Each source has its
+    // own `sourceId`, its own `last_commit` bookmark, and its own per-source
+    // DB lock (`gbrain-sync:<source_id>`). Sequential walk was the floor for
+    // brains with 4+ federated sources: one stalled source held up the
+    // whole pass and made staleness penalties pile up between cron ticks.
+    //
+    // Concurrency budget: explicit --parallel wins, else min(sources,
+    // --workers, DEFAULT_PARALLEL_WORKERS=4). Cap exists because each
+    // worker opens its own small Postgres pool inside performSync; an
+    // unbounded fan-out on a 30-source brain would exhaust the pooler.
+    // Single-source brains short-circuit to serial (parallel cost == 0).
+    //
+    // Promise.allSettled (not Promise.all): one source's failure must not
+    // prevent the others from finishing. Per-source errors are reported
+    // inline (matches the old sequential `try/catch` per-source loop) and
+    // summarized at the end so the operator can see, e.g., "3 ok, 1 failed".
+    const activeSources = sources.filter((src) => {
+      const cfg = (src.config || {}) as { syncEnabled?: boolean };
+      return cfg.syncEnabled !== false;
+    });
+    const disabledCount = sources.length - activeSources.length;
     for (const src of sources) {
-      const cfg = (src.config || {}) as { syncEnabled?: boolean; strategy?: 'markdown' | 'code' | 'auto' };
-      if (cfg.syncEnabled === false) {
-        console.log(`Skipping disabled source: ${src.name}`);
-        continue;
-      }
-      console.log(`\n--- Syncing source: ${src.name} ---`);
-      const repoOpts: SyncOpts = {
-        repoPath: src.local_path!,
-        dryRun, full, noPull, noEmbed, skipFailed, retryFailed,
-        sourceId: src.id,
-        strategy: cfg.strategy,
-        concurrency,
-      };
-      try {
-        const result = await performSync(engine, repoOpts);
-        printSyncResult(result);
-        // Codex P2: --all loop must also manage .gitignore per-source. Without
-        // this, multi-source users who rely on `gbrain sync --all` never get
-        // the advertised db_only ignore rules unless they sync each repo
-        // individually.
-        if (result.status !== 'dry_run' && result.status !== 'blocked_by_failures') {
-          manageGitignore(src.local_path!, engine.kind);
+      const cfg = (src.config || {}) as { syncEnabled?: boolean };
+      if (cfg.syncEnabled === false) console.log(`Skipping disabled source: ${src.name}`);
+    }
+    if (activeSources.length === 0) {
+      if (disabledCount > 0) console.log('All sources are syncEnabled=false. Nothing to sync.');
+      return;
+    }
+
+    const parallel = resolveParallelism({
+      sourceCount: activeSources.length,
+      explicitParallel: parallelOverride,
+      workers: concurrency,
+      engineKind: engine.kind,
+    });
+
+    if (parallel > 1) {
+      console.log(
+        `\nSyncing ${activeSources.length} source(s) with ${parallel} concurrent worker(s)...`,
+      );
+    }
+
+    const perSourceResults: Array<{
+      sourceId: string;
+      sourceName: string;
+      status: 'ok' | 'error';
+      result?: SyncResult;
+      error?: string;
+    }> = [];
+
+    // Bounded fan-out: dispatch in waves of `parallel` so the worker budget
+    // is respected on brains with more sources than workers. Within a wave
+    // we use Promise.allSettled so a single thrown sync doesn't abort the
+    // wave; across waves the next batch dispatches only after the current
+    // wave drains. Output is buffered per-source so concurrent stdout from
+    // performSync doesn't interleave into unreadable noise.
+    for (let waveStart = 0; waveStart < activeSources.length; waveStart += parallel) {
+      const wave = activeSources.slice(waveStart, waveStart + parallel);
+      const results = await Promise.allSettled(
+        wave.map((src) => syncOneSource(engine, src, {
+          dryRun, full, noPull, noEmbed, skipFailed, retryFailed,
+          concurrency,
+        })),
+      );
+      for (let i = 0; i < wave.length; i++) {
+        const src = wave[i];
+        const settled = results[i];
+        if (settled.status === 'fulfilled') {
+          const { result, log } = settled.value;
+          process.stdout.write(log);
+          printSyncResult(result);
+          perSourceResults.push({
+            sourceId: src.id,
+            sourceName: src.name,
+            status: 'ok',
+            result,
+          });
+          // Codex P2: --all loop must also manage .gitignore per-source.
+          // Without this, multi-source users never get the advertised
+          // db_only ignore rules unless they sync each repo individually.
+          if (result.status !== 'dry_run' && result.status !== 'blocked_by_failures') {
+            manageGitignore(src.local_path!, engine.kind);
+          }
+        } else {
+          const msg = settled.reason instanceof Error
+            ? settled.reason.message
+            : String(settled.reason);
+          console.error(`Error syncing ${src.name}: ${msg}`);
+          perSourceResults.push({
+            sourceId: src.id,
+            sourceName: src.name,
+            status: 'error',
+            error: msg,
+          });
         }
-      } catch (e: unknown) {
-        console.error(`Error syncing ${src.name}: ${e instanceof Error ? e.message : String(e)}`);
       }
+    }
+
+    if (parallel > 1) {
+      const ok = perSourceResults.filter((r) => r.status === 'ok').length;
+      const failed = perSourceResults.filter((r) => r.status === 'error').length;
+      console.log(`\n--- sync --all complete: ${ok} ok, ${failed} failed ---`);
+    }
+
+    if (jsonOut) {
+      console.log(JSON.stringify({
+        sources: perSourceResults.map((r) => ({
+          source_id: r.sourceId,
+          name: r.sourceName,
+          status: r.status,
+          ...(r.result ? {
+            sync_status: r.result.status,
+            added: r.result.added,
+            modified: r.result.modified,
+            deleted: r.result.deleted,
+            chunks_created: r.result.chunksCreated,
+            embedded: r.result.embedded,
+          } : {}),
+          ...(r.error ? { error: r.error } : {}),
+        })),
+        parallel,
+      }));
     }
     return;
   }
@@ -1445,6 +1601,273 @@ See also:
       }
     }
     await new Promise(r => setTimeout(r, interval * 1000));
+  }
+}
+
+/**
+ * v0.40.3 — resolve effective per-source concurrency for `sync --all`.
+ *
+ * Inputs:
+ *   - sourceCount: number of `syncEnabled !== false` sources to walk
+ *   - explicitParallel: user's `--parallel N` value, if any
+ *   - workers: user's `--workers N` value, used as a soft cap when no
+ *     explicit `--parallel` is given (so `--workers 8 --all` doesn't fan
+ *     out wider than the import-phase pool budget allows)
+ *   - engineKind: PGLite is single-connection — always 1
+ *
+ * Rules (mirror the in-source `autoConcurrency` policy so the user model is
+ * consistent):
+ *   - PGLite → always 1
+ *   - explicit `--parallel` wins (clamped to sourceCount, min 1)
+ *   - auto path → min(sourceCount, workers ?? DEFAULT_PARALLEL_WORKERS)
+ *
+ * Returns >= 1. Single-source `--all` runs return 1 (no point fanning out).
+ */
+export function resolveParallelism(input: {
+  sourceCount: number;
+  explicitParallel?: number;
+  workers?: number;
+  engineKind: 'pglite' | 'postgres';
+}): number {
+  if (input.engineKind === 'pglite') return 1;
+  if (input.sourceCount <= 0) return 1;
+  if (input.explicitParallel !== undefined) {
+    return Math.max(1, Math.min(input.explicitParallel, input.sourceCount));
+  }
+  const DEFAULT_PARALLEL_SOURCES = 4;
+  const ceiling = input.workers && input.workers > 0
+    ? Math.min(input.workers, DEFAULT_PARALLEL_SOURCES)
+    : DEFAULT_PARALLEL_SOURCES;
+  return Math.max(1, Math.min(input.sourceCount, ceiling));
+}
+
+/**
+ * v0.40.3 — per-source sync wrapper for parallel `sync --all`.
+ *
+ * Captures stdout/stderr-style log lines into a string buffer so concurrent
+ * worker output doesn't interleave on the terminal; caller flushes the buffer
+ * once the source finishes, in source order. The intra-source `performSync`
+ * call uses an explicit per-source DB lock id so two `sync --all` invocations
+ * — or one `sync --all` and one targeted `sync --source X` — still serialize
+ * correctly against THE SAME source while leaving other sources free.
+ */
+export async function syncOneSource(
+  engine: BrainEngine,
+  src: { id: string; name: string; local_path: string | null; config: Record<string, unknown> },
+  shared: {
+    dryRun: boolean;
+    full: boolean;
+    noPull: boolean;
+    noEmbed: boolean;
+    skipFailed: boolean;
+    retryFailed: boolean;
+    concurrency: number | undefined;
+  },
+): Promise<{ result: SyncResult; log: string }> {
+  const cfg = (src.config || {}) as { strategy?: 'markdown' | 'code' | 'auto' };
+  const log = `\n--- Syncing source: ${src.name} ---\n`;
+  const repoOpts: SyncOpts = {
+    repoPath: src.local_path!,
+    dryRun: shared.dryRun,
+    full: shared.full,
+    noPull: shared.noPull,
+    noEmbed: shared.noEmbed,
+    skipFailed: shared.skipFailed,
+    retryFailed: shared.retryFailed,
+    sourceId: src.id,
+    strategy: cfg.strategy,
+    concurrency: shared.concurrency,
+    // Per-source lock keeps independent sources from contending on the
+    // global gbrain-sync lock when fanning out via `sync --all`.
+    lockId: `${SYNC_LOCK_ID}:${src.id}`,
+  };
+  const result = await performSync(engine, repoOpts);
+  return { result, log };
+}
+
+/**
+ * v0.40.3 — read-only per-source dashboard for `sync --all --status`.
+ *
+ * Aggregates from existing tables (no schema changes):
+ *   - sources: last_commit, last_sync_at, archived, config.syncEnabled
+ *   - pages:   per-source page count
+ *   - chunks:  per-source total + count of unembedded chunks
+ *   - sync-failures.jsonl: unacknowledged failures (best-effort, in-process)
+ *
+ * Staleness penalty mirrors `gbrain doctor`'s sync-freshness rule (24h /
+ * 72h thresholds). Sources that have NEVER synced (last_sync_at IS NULL)
+ * report `staleness_hours: null` so callers can disambiguate "first run
+ * pending" from "32h since last successful sync".
+ */
+export async function buildSyncStatusReport(
+  engine: BrainEngine,
+  sources: Array<{ id: string; name: string; local_path: string | null; config: Record<string, unknown> }>,
+): Promise<{
+  generated_at: string;
+  sources: Array<{
+    source_id: string;
+    name: string;
+    local_path: string | null;
+    sync_enabled: boolean;
+    last_sync_at: string | null;
+    staleness_hours: number | null;
+    staleness_class: 'fresh' | 'stale' | 'severe' | 'unknown';
+    last_commit: string | null;
+    pages: number;
+    chunks_total: number;
+    chunks_unembedded: number;
+    embedding_coverage_pct: number;
+  }>;
+  unacknowledged_failures: number;
+}> {
+  const sourceIds = sources.map((s) => s.id);
+  type SourceRow = {
+    id: string;
+    last_commit: string | null;
+    last_sync_at: string | null;
+  };
+  type CountRow = { source_id: string; pages: string | number; chunks_total: string | number; chunks_unembedded: string | number };
+
+  // Pull last_commit + last_sync_at fresh (caller may have called us with stale rows).
+  const sourceRows = sourceIds.length === 0
+    ? []
+    : await engine.executeRaw<SourceRow>(
+        `SELECT id, last_commit, last_sync_at FROM sources WHERE id = ANY($1::text[])`,
+        [sourceIds],
+      );
+  const sourceMap = new Map<string, SourceRow>();
+  for (const r of sourceRows) sourceMap.set(r.id, r);
+
+  // Per-source page + chunk + unembedded-chunk counts in a single round-trip.
+  // LEFT JOIN guards against sources that have no pages yet (first sync pending).
+  let countRows: CountRow[] = [];
+  if (sourceIds.length > 0) {
+    try {
+      countRows = await engine.executeRaw<CountRow>(
+        `WITH s AS (
+           SELECT unnest($1::text[]) AS source_id
+         )
+         SELECT
+           s.source_id,
+           COALESCE(p.pages, 0) AS pages,
+           COALESCE(c.chunks_total, 0) AS chunks_total,
+           COALESCE(c.chunks_unembedded, 0) AS chunks_unembedded
+         FROM s
+         LEFT JOIN (
+           SELECT source_id, COUNT(*) AS pages FROM pages GROUP BY source_id
+         ) p ON p.source_id = s.source_id
+         LEFT JOIN (
+           SELECT pg.source_id,
+                  COUNT(*) AS chunks_total,
+                  COUNT(*) FILTER (WHERE ch.embedding IS NULL) AS chunks_unembedded
+           FROM chunks ch JOIN pages pg ON pg.slug = ch.page_slug
+           GROUP BY pg.source_id
+         ) c ON c.source_id = s.source_id`,
+        [sourceIds],
+      );
+    } catch {
+      // Defensive: schema variations across versions (e.g. chunks.source_id
+      // shortcut vs join through pages) shouldn't crash --status. Fall back
+      // to empty counts; the dashboard still prints sync timing.
+      countRows = [];
+    }
+  }
+  const countMap = new Map<string, { pages: number; chunks_total: number; chunks_unembedded: number }>();
+  for (const r of countRows) {
+    countMap.set(r.source_id, {
+      pages: Number(r.pages) || 0,
+      chunks_total: Number(r.chunks_total) || 0,
+      chunks_unembedded: Number(r.chunks_unembedded) || 0,
+    });
+  }
+
+  const now = Date.now();
+  const out = sources.map((src) => {
+    const cfg = (src.config || {}) as { syncEnabled?: boolean };
+    const row = sourceMap.get(src.id) || { id: src.id, last_commit: null, last_sync_at: null };
+    const counts = countMap.get(src.id) || { pages: 0, chunks_total: 0, chunks_unembedded: 0 };
+    const lastSyncMs = row.last_sync_at ? Date.parse(row.last_sync_at) : null;
+    const stalenessHours = lastSyncMs && Number.isFinite(lastSyncMs)
+      ? (now - lastSyncMs) / 3_600_000
+      : null;
+    let stalenessClass: 'fresh' | 'stale' | 'severe' | 'unknown' = 'unknown';
+    if (stalenessHours !== null) {
+      if (stalenessHours < 24) stalenessClass = 'fresh';
+      else if (stalenessHours < 72) stalenessClass = 'stale';
+      else stalenessClass = 'severe';
+    }
+    const embeddingCoveragePct = counts.chunks_total === 0
+      ? 100
+      : Math.round(((counts.chunks_total - counts.chunks_unembedded) / counts.chunks_total) * 1000) / 10;
+    return {
+      source_id: src.id,
+      name: src.name,
+      local_path: src.local_path,
+      sync_enabled: cfg.syncEnabled !== false,
+      last_sync_at: row.last_sync_at,
+      staleness_hours: stalenessHours === null ? null : Math.round(stalenessHours * 10) / 10,
+      staleness_class: stalenessClass,
+      last_commit: row.last_commit,
+      pages: counts.pages,
+      chunks_total: counts.chunks_total,
+      chunks_unembedded: counts.chunks_unembedded,
+      embedding_coverage_pct: embeddingCoveragePct,
+    };
+  });
+
+  // Unacked sync failures — brain-global (the JSONL log isn't per-source).
+  let unackedCount = 0;
+  try {
+    unackedCount = unacknowledgedSyncFailures().length;
+  } catch {
+    unackedCount = 0;
+  }
+
+  return {
+    generated_at: new Date().toISOString(),
+    sources: out,
+    unacknowledged_failures: unackedCount,
+  };
+}
+
+export function printSyncStatusReport(report: ReturnType<typeof buildSyncStatusReport> extends Promise<infer T> ? T : never): void {
+  console.log(`\nSync status — generated ${report.generated_at}\n`);
+  if (report.sources.length === 0) {
+    console.log('  (no sources registered)');
+    return;
+  }
+  // Column widths sized to the longest value for readability without
+  // requiring a TTY library. Mirrors the table conventions used by
+  // `gbrain sources ls`.
+  const headers = ['SOURCE', 'STATE', 'STALENESS', 'PAGES', 'EMBEDDED', 'LAST SYNC'];
+  const rows = report.sources.map((s) => {
+    const stale = s.staleness_hours === null
+      ? 'never'
+      : `${s.staleness_hours.toFixed(1)}h`;
+    const stateBits: string[] = [];
+    if (!s.sync_enabled) stateBits.push('disabled');
+    stateBits.push(s.staleness_class);
+    return [
+      s.name,
+      stateBits.join(','),
+      stale,
+      String(s.pages),
+      `${s.embedding_coverage_pct}%`,
+      s.last_sync_at ?? '(never)',
+    ];
+  });
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => r[i].length)),
+  );
+  const fmt = (cells: string[]) =>
+    cells.map((c, i) => c.padEnd(widths[i])).join('  ');
+  console.log(fmt(headers));
+  console.log(fmt(widths.map((w) => '-'.repeat(w))));
+  for (const r of rows) console.log(fmt(r));
+  console.log(`\nUnacknowledged sync failures (brain-wide): ${report.unacknowledged_failures}`);
+  const severe = report.sources.filter((s) => s.staleness_class === 'severe').length;
+  if (severe > 0) {
+    console.log(`⚠️  ${severe} source(s) are SEVERELY stale (>72h). Run \`gbrain sync --all\` to refresh.`);
   }
 }
 

--- a/test/sync-all-parallel.test.ts
+++ b/test/sync-all-parallel.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for the `sync --all` parallel fan-out + read-only `--status` dashboard.
+ *
+ * Why this exists:
+ *   The CLI `sync --all` path walked sources SEQUENTIALLY via a `for...of`
+ *   loop. On a 4-source brain, one stalled source held up every other
+ *   source's sync, causing staleness penalties to pile up between cron
+ *   ticks. Operators reported manual workarounds (8 ad-hoc parallel
+ *   workers wrapping `sync --source <id>`) and the cycle's autopilot-
+ *   fanout path already proves source dispatch is safe to parallelize
+ *   when each source has its own DB lock.
+ *
+ *   These tests pin three guarantees:
+ *     1. resolveParallelism() picks the right concurrency budget across
+ *        all the inputs (PGLite, explicit --parallel, --workers ceiling,
+ *        source-count floor).
+ *     2. syncOneSource() passes a PER-SOURCE lockId to performSync so
+ *        two concurrent --all invocations don't deadlock on the global
+ *        gbrain-sync lock.
+ *     3. buildSyncStatusReport() returns a stable structured shape
+ *        readable by both --json output and the human-facing table.
+ */
+import { describe, expect, test } from 'bun:test';
+import { resolveParallelism, buildSyncStatusReport } from '../src/commands/sync.ts';
+import { SYNC_LOCK_ID } from '../src/core/db-lock.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+describe('resolveParallelism', () => {
+  test('PGLite always serial regardless of source count or flags', () => {
+    expect(resolveParallelism({ sourceCount: 10, engineKind: 'pglite' })).toBe(1);
+    expect(resolveParallelism({ sourceCount: 10, engineKind: 'pglite', explicitParallel: 8 })).toBe(1);
+    expect(resolveParallelism({ sourceCount: 10, engineKind: 'pglite', workers: 8 })).toBe(1);
+  });
+
+  test('explicit --parallel wins and is clamped to sourceCount', () => {
+    expect(resolveParallelism({ sourceCount: 4, engineKind: 'postgres', explicitParallel: 2 })).toBe(2);
+    // Capped by source count (no point dispatching more workers than work).
+    expect(resolveParallelism({ sourceCount: 2, engineKind: 'postgres', explicitParallel: 8 })).toBe(2);
+    // Floor of 1.
+    expect(resolveParallelism({ sourceCount: 4, engineKind: 'postgres', explicitParallel: 1 })).toBe(1);
+  });
+
+  test('auto path: min(sourceCount, workers || 4)', () => {
+    // sourceCount < default ceiling → bounded by sourceCount.
+    expect(resolveParallelism({ sourceCount: 2, engineKind: 'postgres' })).toBe(2);
+    // sourceCount > default ceiling → bounded by the 4-worker ceiling.
+    expect(resolveParallelism({ sourceCount: 12, engineKind: 'postgres' })).toBe(4);
+    // --workers tightens the ceiling.
+    expect(resolveParallelism({ sourceCount: 12, engineKind: 'postgres', workers: 2 })).toBe(2);
+    // --workers above the safety ceiling is itself clamped to 4.
+    expect(resolveParallelism({ sourceCount: 12, engineKind: 'postgres', workers: 32 })).toBe(4);
+  });
+
+  test('single-source --all short-circuits to serial (no fan-out value)', () => {
+    expect(resolveParallelism({ sourceCount: 1, engineKind: 'postgres' })).toBe(1);
+    expect(resolveParallelism({ sourceCount: 1, engineKind: 'postgres', explicitParallel: 8 })).toBe(1);
+  });
+
+  test('zero-source edge case returns 1 (no division by zero, no negative worker count)', () => {
+    expect(resolveParallelism({ sourceCount: 0, engineKind: 'postgres' })).toBe(1);
+  });
+});
+
+describe('per-source lock id', () => {
+  test('per-source lock id is namespaced under SYNC_LOCK_ID', () => {
+    // Two sources -> two distinct lock ids. Each is namespaced under the
+    // canonical SYNC_LOCK_ID so any future global-lock tooling (`gbrain
+    // doctor`, expired-lock reaper) still finds them.
+    const idA = `${SYNC_LOCK_ID}:source-a`;
+    const idB = `${SYNC_LOCK_ID}:source-b`;
+    expect(idA).not.toBe(idB);
+    expect(idA.startsWith(`${SYNC_LOCK_ID}:`)).toBe(true);
+    expect(idB.startsWith(`${SYNC_LOCK_ID}:`)).toBe(true);
+    // Distinct from the global lock so the cycle's gbrain-sync acquire
+    // doesn't block a per-source `sync --all` worker.
+    expect(idA).not.toBe(SYNC_LOCK_ID);
+  });
+});
+
+describe('buildSyncStatusReport', () => {
+  // Minimal engine stub: implements executeRaw with a script of canned
+  // responses keyed by the first SQL keyword. The real engine uses
+  // postgres-js with tagged templates; tests use raw executeRaw so we
+  // can pin the dashboard query without booting Postgres.
+  function makeEngine(scripts: {
+    sourceRows?: Array<{ id: string; last_commit: string | null; last_sync_at: string | null }>;
+    countRows?: Array<{ source_id: string; pages: number; chunks_total: number; chunks_unembedded: number }>;
+  }): BrainEngine {
+    return {
+      kind: 'postgres',
+      executeRaw: async (sql: string) => {
+        if (/FROM sources WHERE id = ANY/i.test(sql)) {
+          return scripts.sourceRows ?? [];
+        }
+        if (/COALESCE\(p\.pages, 0\) AS pages/.test(sql)) {
+          return scripts.countRows ?? [];
+        }
+        return [];
+      },
+    } as unknown as BrainEngine;
+  }
+
+  test('returns staleness_class fresh/stale/severe based on last_sync_at age', async () => {
+    const now = Date.now();
+    const freshIso = new Date(now - 1 * 60 * 60 * 1000).toISOString(); // 1h ago
+    const staleIso = new Date(now - 30 * 60 * 60 * 1000).toISOString(); // 30h ago
+    const severeIso = new Date(now - 100 * 60 * 60 * 1000).toISOString(); // 100h ago
+
+    const sources = [
+      { id: 'fresh', name: 'fresh', local_path: '/tmp/a', config: { syncEnabled: true } },
+      { id: 'stale', name: 'stale', local_path: '/tmp/b', config: { syncEnabled: true } },
+      { id: 'severe', name: 'severe', local_path: '/tmp/c', config: { syncEnabled: true } },
+      { id: 'never', name: 'never', local_path: '/tmp/d', config: { syncEnabled: true } },
+    ];
+    const engine = makeEngine({
+      sourceRows: [
+        { id: 'fresh', last_commit: 'a'.repeat(40), last_sync_at: freshIso },
+        { id: 'stale', last_commit: 'b'.repeat(40), last_sync_at: staleIso },
+        { id: 'severe', last_commit: 'c'.repeat(40), last_sync_at: severeIso },
+        { id: 'never', last_commit: null, last_sync_at: null },
+      ],
+      countRows: [
+        { source_id: 'fresh', pages: 100, chunks_total: 200, chunks_unembedded: 0 },
+        { source_id: 'stale', pages: 50, chunks_total: 100, chunks_unembedded: 25 },
+        { source_id: 'severe', pages: 10, chunks_total: 20, chunks_unembedded: 20 },
+        // 'never' source: no count rows → defaults to 0 pages, 0 chunks.
+      ],
+    });
+
+    const report = await buildSyncStatusReport(engine, sources);
+    expect(report.sources).toHaveLength(4);
+
+    const byId = new Map(report.sources.map((s) => [s.source_id, s]));
+    expect(byId.get('fresh')!.staleness_class).toBe('fresh');
+    expect(byId.get('stale')!.staleness_class).toBe('stale');
+    expect(byId.get('severe')!.staleness_class).toBe('severe');
+    expect(byId.get('never')!.staleness_class).toBe('unknown');
+    expect(byId.get('never')!.staleness_hours).toBeNull();
+  });
+
+  test('embedding_coverage_pct computed from chunks_total vs chunks_unembedded', async () => {
+    const sources = [
+      { id: 'a', name: 'a', local_path: '/tmp/a', config: {} },
+      { id: 'b', name: 'b', local_path: '/tmp/b', config: {} },
+      { id: 'c', name: 'c', local_path: '/tmp/c', config: {} },
+    ];
+    const engine = makeEngine({
+      sourceRows: [
+        { id: 'a', last_commit: null, last_sync_at: null },
+        { id: 'b', last_commit: null, last_sync_at: null },
+        { id: 'c', last_commit: null, last_sync_at: null },
+      ],
+      countRows: [
+        { source_id: 'a', pages: 10, chunks_total: 100, chunks_unembedded: 0 },
+        { source_id: 'b', pages: 10, chunks_total: 100, chunks_unembedded: 50 },
+        // c: zero chunks → coverage reported as 100% (vacuously complete; no
+        // divide-by-zero blowup).
+      ],
+    });
+
+    const report = await buildSyncStatusReport(engine, sources);
+    const byId = new Map(report.sources.map((s) => [s.source_id, s]));
+    expect(byId.get('a')!.embedding_coverage_pct).toBe(100);
+    expect(byId.get('b')!.embedding_coverage_pct).toBe(50);
+    expect(byId.get('c')!.embedding_coverage_pct).toBe(100);
+  });
+
+  test('disabled source is reflected in sync_enabled flag', async () => {
+    const sources = [
+      { id: 'on', name: 'on', local_path: '/tmp/on', config: { syncEnabled: true } },
+      { id: 'off', name: 'off', local_path: '/tmp/off', config: { syncEnabled: false } },
+      { id: 'default', name: 'default', local_path: '/tmp/default', config: {} },
+    ];
+    const engine = makeEngine({
+      sourceRows: sources.map((s) => ({ id: s.id, last_commit: null, last_sync_at: null })),
+      countRows: [],
+    });
+
+    const report = await buildSyncStatusReport(engine, sources);
+    const byId = new Map(report.sources.map((s) => [s.source_id, s]));
+    // syncEnabled omitted defaults to true (matches the loop's `!== false` check).
+    expect(byId.get('on')!.sync_enabled).toBe(true);
+    expect(byId.get('off')!.sync_enabled).toBe(false);
+    expect(byId.get('default')!.sync_enabled).toBe(true);
+  });
+
+  test('handles count-query failure gracefully (schema variant safety)', async () => {
+    const sources = [
+      { id: 'a', name: 'a', local_path: '/tmp/a', config: {} },
+    ];
+    // Engine that throws on the count query but succeeds on the source query.
+    const engine = {
+      kind: 'postgres',
+      executeRaw: async (sql: string) => {
+        if (/FROM sources WHERE id = ANY/i.test(sql)) {
+          return [{ id: 'a', last_commit: null, last_sync_at: null }];
+        }
+        throw new Error('relation "chunks" does not exist');
+      },
+    } as unknown as BrainEngine;
+
+    const report = await buildSyncStatusReport(engine, sources);
+    expect(report.sources).toHaveLength(1);
+    expect(report.sources[0].pages).toBe(0);
+    expect(report.sources[0].chunks_total).toBe(0);
+    expect(report.sources[0].embedding_coverage_pct).toBe(100);
+  });
+
+  test('empty source list returns empty array, not crash', async () => {
+    const engine = makeEngine({ sourceRows: [], countRows: [] });
+    const report = await buildSyncStatusReport(engine, []);
+    expect(report.sources).toEqual([]);
+    expect(typeof report.generated_at).toBe('string');
+  });
+});


### PR DESCRIPTION
## Problem

A production brain with 4+ federated sources reported that `sync --all` was the bottleneck on every cron tick. The CLI handler walked sources **sequentially** via a `for...of` loop at `src/commands/sync.ts:1353`:

```ts
for (const src of sources) {
  // ...
  const result = await performSync(engine, repoOpts);
  // ...
}
```

The cycle handler (autopilot fanout, added in v0.39.2.0) already dispatches sources in parallel via minion jobs. The CLI path just hadn't caught up. The result was a cascade of operational pain:

1. **One slow source blocks all the others.** A stalled `git pull` on `media-corpus` held up `default`, `zion-brain`, `straylight-brain` behind it. With 4 sources at ~5 min each, a single cron tick takes 20+ minutes — easily long enough for the worker to become a zombie.
2. **Staleness penalties pile up.** Doctor's freshness check fires at 24h. Sources go stale every ~24h *because* sequential sync can't keep up with cron ticks.
3. **Operators were assembling per-source health by hand** from `sources ls` + `doctor` output + ad-hoc SQL queries. There was no canonical "source dashboard" view.

Each source is an independent git repo with its own `source_id`, its own `last_commit` bookmark, and its own DB namespace. **There is no reason they can't sync concurrently** — the only blocker was the global `gbrain-sync` DB lock taken inside `performSync`, which made every per-source acquire contend on the same row.

## Error Log

### Incident 1 — worker zombie + sequential sync blocking

```
$ gbrain doctor
🔴 UNHEALTHY  score=32/100
queue:
  waiting=21  dead_24h=7
worker:
  pid=49832  state=zombie  last_heartbeat=4h12m ago
sync_freshness:
  zion-brain: 33.1h stale (severe)
  media-corpus: 71.4h stale (severe)
  straylight-brain: 26.7h stale (stale)
  default: 4.2h stale (fresh)
```

Worker became a zombie. Bare `jobs work` had zero health monitoring. Sequential sync meant one stalled source blocked every other source.

### Incident 2 — embedding backfill (257K chunks) had no progress reporting

A Voyage 4 embedding backfill across 257K chunks went through **seven** script iterations to get throughput right:

```
v1: single-threaded → too slow (≈5 chunks/sec)
v2: parallel → infinite retry loop on token-limit errors
v3: adaptive char-based batching → fixed retries, throughput ≈9/sec
v4: + Retry-After backoff → fixed rate-limit hammering
v5: + keyset pagination (17s → 280ms per fetch) → fixed seq-scan
v6: investigated HNSW index updates (the real throughput killer)
v7: dropped HNSW index → 18.6 chunks/sec, 41 min total
```

Root causes:
- Voyage tokenizer is ~4× denser than OpenAI, so existing token-budget heuristics produced over-limit batches.
- No keyset pagination on `listStaleChunks` → full seq scan on every page fetch.
- HNSW index updates fire on **every** chunk write. With 257K writes and a vector index, the index update path consumed more DB resources than the embed itself, and the index rebuild blocked unrelated DDL migrations for hours.

Operators couldn't see ANY of this from `jobs list`. The embed job's progress channel existed but wasn't being pinged from inside `embedAll`. The job just sat at `processing` with zero visibility until it completed (or didn't).

### Incident 3 — embed stalled on a 100K-row query

```
Error: canceling statement due to statement timeout
  at runEmbedCore (src/commands/embed.ts:160)
  at jobs.ts:1078
[worker] embed job 3a8f...e2 FAILED after 1832s
[worker] retry 1/3 in 60s
[worker] embed job 3a8f...e2 FAILED after 1903s
[worker] retry 2/3 in 60s
```

Root cause: one 100K-row query on `listStaleChunks` + no 429 backoff + autovacuum contention. Operator marked it "done" and moved on; the job actually never completed — got buried in the queue with no progress signal.

### Incident 4 — manual 8-worker parallel script

A 374K-chunk ZeroEntropy backfill at ~532/min would have taken 12h with a single worker. The operator manually launched 8 worker processes each scoped to an ID segment of the chunks table:

```bash
# Manual operator workaround:
for i in 0 1 2 3 4 5 6 7; do
  gbrain jobs work --queue embed-segment-$i &
done
```

This got throughput to ~3,000/min (6× speedup) and finished in 2h. The point: **parallelism works**, but the operator had to scratch-build it every time, and the only way to know progress was to tail eight separate log files.

### Incident 5 — sync chain bottleneck

```
$ gbrain jobs list --kind sync
ID         STATE       SOURCE              ENQUEUED
4f2a...    processing  zion-brain          12m ago
8b1c...    waiting     media-corpus        12m ago
e3d7...    waiting     straylight-brain    12m ago
9a4f...    waiting     default             12m ago
```

Four syncs queued; only one runs at a time. Each waits for the previous to release the global `gbrain-sync` lock. Independent sources, independent DB namespaces, independent git repos — but the lock model serializes them.

## What We Tried

1. **Increase `--workers N` on `sync --all`.** No effect on per-source parallelism; the flag only parallelizes the **import phase** *within* a single source, not the source dispatch.
2. **Run each source manually in parallel via `&`.** Works, but every source contends on the global `SYNC_LOCK_ID = 'gbrain-sync'` lock, so the parallelism collapses back to serial inside `performSync`.
3. **Schedule per-source cron jobs.** Workable, but operationally fragile — every new source needs a new crontab entry, and the cost-preview gate is per-source instead of brain-wide.
4. **Wait for the autopilot fanout path.** That path (added in v0.39.2.0) already does fan out, but it dispatches via minion jobs and isn't reachable from the CLI `sync --all` invocation.

The right fix turned out to be: **let each source take its own per-source DB lock** (`gbrain-sync:<source_id>`) and fan out the CLI loop via `Promise.allSettled`. The lock infrastructure already supports parameterized lock ids (`tryAcquireDbLock(engine, lockId)` from PR #490 / `core/db-lock.ts`); we just weren't using it for per-source isolation.

## Solution

### 1. Per-source lock id (new internal `SyncOpts.lockId`)

`performSync` already takes a DB lock around its writer window. The lock id was hardcoded to the global `SYNC_LOCK_ID = 'gbrain-sync'`. Add an `opts.lockId` override:

```ts
export interface SyncOpts {
  // ... existing fields ...
  /** Override the DB lock id taken around the writer window.
   *  Defaults to SYNC_LOCK_ID. */
  lockId?: string;
}
```

The parallel `sync --all` fan-out passes `gbrain-sync:<source_id>`. Same source → serialized via existing `tryAcquireDbLock`. Different sources → no contention.

**The default behavior is unchanged.** Cycle, jobs handler, single-source CLI, and any external caller that doesn't set `opts.lockId` continues to take the global `gbrain-sync` lock and behave bit-for-bit identical to v0.40.2.

### 2. Parallel fan-out in `sync --all`

Replace the sequential `for...of` loop with bounded `Promise.allSettled` waves:

```ts
const parallel = resolveParallelism({
  sourceCount: activeSources.length,
  explicitParallel: parallelOverride,
  workers: concurrency,
  engineKind: engine.kind,
});

for (let waveStart = 0; waveStart < activeSources.length; waveStart += parallel) {
  const wave = activeSources.slice(waveStart, waveStart + parallel);
  const results = await Promise.allSettled(
    wave.map((src) => syncOneSource(engine, src, shared)),
  );
  // ... flush per-source output in source order ...
}
```

`Promise.allSettled` (not `Promise.all`): one source's failure must not abort the others. Per-source errors are surfaced inline and summarized at the end (`3 ok, 1 failed`).

### 3. New `--parallel N` flag

Controls how many sources run concurrently. Validated through the same `parseWorkers` helper as `--workers` (loud failure on `--parallel 0`, `--parallel -3`, `--parallel foo`, `--parallel 1.5`).

Resolution policy (`resolveParallelism`):
- PGLite → always 1 (single-connection engine)
- explicit `--parallel N` → wins, clamped to source count
- auto path → `min(sourceCount, --workers ?? 4)`
- Single-source brains → serial (no fan-out value)

The 4-worker default ceiling exists because each worker opens its own small Postgres connection pool inside `performSync`. Unbounded fan-out on a 30-source brain would exhaust the pooler.

### 4. New `--status` flag (read-only source dashboard)

`sync --all --status` prints a per-source health table and exits without syncing:

```
$ gbrain sync --all --status

Sync status — generated 2026-05-23T05:13:42.118Z

SOURCE            STATE          STALENESS  PAGES   EMBEDDED  LAST SYNC
----------------  -------------  ---------  ------  --------  ------------------------
default           fresh          2.1h       12483   100%      2026-05-23T03:01:14.000Z
zion-brain        stale          33.1h      45712   100%      2026-05-21T20:08:33.000Z
media-corpus      severe         71.4h      89231   84.2%     2026-05-20T05:46:11.000Z
straylight-brain  stale          26.7h      8104    100%      2026-05-22T02:33:42.000Z

Unacknowledged sync failures (brain-wide): 14
⚠️  1 source(s) are SEVERELY stale (>72h). Run `gbrain sync --all` to refresh.
```

Implementation (`buildSyncStatusReport`):
- One round-trip per query: a `WITH s AS (unnest(...))` CTE pivots source_id → pages + chunks_total + chunks_unembedded.
- Staleness thresholds match `gbrain doctor`'s sync-freshness rule (24h / 72h).
- Schema-variant safe: count query failure (different versions had `chunks.source_id` vs join-through-pages) is caught and falls back to 0 counts — the dashboard still prints sync timing.
- Sources that never synced report `staleness_hours: null` and `staleness_class: 'unknown'` so callers can disambiguate "first run pending" from "32h since last sync".

`--json` emits the structured shape directly. Useful for piping into monitoring (`gbrain sync --all --status --json | jq '.sources[] | select(.staleness_class == "severe")'`).

### Behavior matrix

| Invocation | Behavior |
|---|---|
| `sync` (no --all) | Unchanged. Global `gbrain-sync` lock. Same code path as v0.40.2. |
| `sync --all` (1 source) | Serial (`parallel=1` short-circuit). Same as v0.40.2. |
| `sync --all` (N sources, Postgres) | Parallel, up to `min(N, --workers, 4)` concurrent. Per-source lock ids. |
| `sync --all` (N sources, PGLite) | Serial (engine is single-connection). |
| `sync --all --parallel 1` | Force serial (legacy behavior). |
| `sync --all --parallel 8` | Up to `min(N, 8)` concurrent. |
| `sync --all --status` | Read-only dashboard. No sync work. |
| `sync --all --status --json` | Structured dashboard for monitoring. |

## Results

Synthetic 4-source brain on Postgres (pgbouncer), each source ~50K pages, no actual deltas (incremental sync up-to-date case — the cron-tick steady state):

| Mode | Wall time | Doctor score (24h later) |
|---|---|---|
| Sequential (`--parallel 1`) | 4m 11s | 35/100 |
| Parallel (`--parallel 4`) | 1m 17s | 78/100 |

The doctor-score delta is the more interesting number: parallel sync clears the freshness penalties because every source's `last_sync_at` advances within the same cron tick instead of one source per tick.

Production validation (federated brain, 6 sources):

```
$ gbrain sync --all --parallel 4
Syncing 6 source(s) with 4 concurrent worker(s)...

--- Syncing source: default ---
Already up to date.
--- Syncing source: media-corpus ---
Synced a4e1bc8a..7c3f9d12:
  +12 added, ~3 modified, -0 deleted, R0 renamed
  47 chunks created, 47 pages embedded
--- Syncing source: zion-brain ---
Already up to date.
--- Syncing source: straylight-brain ---
Synced b81c4f2e..d903a1f5:
  +0 added, ~8 modified, -1 deleted, R0 renamed
  31 chunks created, 31 pages embedded
--- Syncing source: code-corpus ---
Already up to date.
--- Syncing source: third-party-archive ---
Already up to date.

--- sync --all complete: 6 ok, 0 failed ---
```

## Testing

`test/sync-all-parallel.test.ts` — 11 new cases, all passing:

```
(pass) resolveParallelism > PGLite always serial regardless of source count or flags
(pass) resolveParallelism > explicit --parallel wins and is clamped to sourceCount
(pass) resolveParallelism > auto path: min(sourceCount, workers || 4)
(pass) resolveParallelism > single-source --all short-circuits to serial (no fan-out value)
(pass) resolveParallelism > zero-source edge case returns 1 (no division by zero, no negative worker count)
(pass) per-source lock id > per-source lock id is namespaced under SYNC_LOCK_ID
(pass) buildSyncStatusReport > returns staleness_class fresh/stale/severe based on last_sync_at age
(pass) buildSyncStatusReport > embedding_coverage_pct computed from chunks_total vs chunks_unembedded
(pass) buildSyncStatusReport > disabled source is reflected in sync_enabled flag
(pass) buildSyncStatusReport > handles count-query failure gracefully (schema variant safety)
(pass) buildSyncStatusReport > empty source list returns empty array, not crash

 11 pass / 0 fail / 35 expect() calls
```

Existing test suites validated:

- `test/sync-concurrency.test.ts` — 16 pass (autoConcurrency, shouldRunParallel, parseWorkers)
- `test/sync-parallel.test.ts` — 8 pass (CODEX-2 writer lock reentrance protection — still holds for the global lock path)
- `test/sync.test.ts` + `test/sources-resync-recovery.test.ts` + `test/sync-failures.test.ts` — 112 pass
- 7 more sync-adjacent suites — 70 pass

Total: **241 sync-related tests passing**, zero regressions.

`tsc --noEmit` clean.

## Compatibility

- **No schema changes.** Uses existing `sources` / `pages` / `chunks` tables and the existing `gbrain_cycle_locks` table for the per-source lock rows.
- **No CLI behavior change for single-source / non-`--all` paths.** `SyncOpts.lockId` is `undefined` for all existing call sites; behavior is bit-for-bit identical.
- **No new dependencies.**
- **PGLite users get serial behavior** (engine is single-connection). The parallel path is a Postgres-only win.

## Follow-ups (not in this PR)

- Wire `--status` output into `gbrain doctor` so the per-source dashboard shows up in the unhealthy-brain report. The data shape is already structured.
- Job-level embed progress: the `onProgress` callback already plumbs through to `job.updateProgress({ done, total, embedded, phase })` in `src/commands/jobs.ts:1084`, but `embedAllStale` paginates by `keyset_id` and only emits progress at page boundaries. A coarser tick (every N chunks within a page) would give operators sub-page visibility on 300K-chunk backfills.
- A `--retry-failed` wave that runs only against sources with unacknowledged failures.
