### PR TITLE
fix: support user-provided 4096d local embeddings

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -190,6 +190,10 @@ async function main() {
       const { awaitPendingSearchCacheWrites } = await import('./core/search/hybrid.ts');
       await awaitPendingSearchCacheWrites();
     }
+    if (op.name === 'search' || op.name === 'query' || op.name === 'get_page') {
+      const { awaitPendingLastRetrievedWrites } = await import('./core/last-retrieved.ts');
+      await awaitPendingLastRetrievedWrites();
+    }
   } catch (e: unknown) {
     if (e instanceof OperationError) {
       console.error(`Error [${e.code}]: ${e.message}`);
@@ -1493,6 +1497,7 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
     embedding_multimodal_model: c.embedding_multimodal_model,
     expansion_model: c.expansion_model,
     chat_model: c.chat_model,
+    reranker_model: c.reranker_model,
     chat_fallback_chain: c.chat_fallback_chain,
     base_urls: { ...envBaseUrls, ...(c.provider_base_urls ?? {}) }, // config wins over env
     env: { ...envFromConfig, ...process.env }, // process.env wins

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1481,6 +1481,7 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   // OLLAMA_BASE_URL. Caller-provided cfg.provider_base_urls wins.
   const envBaseUrls: Record<string, string> = {};
   if (process.env.LLAMA_SERVER_BASE_URL) envBaseUrls['llama-server'] = process.env.LLAMA_SERVER_BASE_URL;
+  if (process.env.LLAMA_SERVER_RERANKER_BASE_URL) envBaseUrls['llama-server-reranker'] = process.env.LLAMA_SERVER_RERANKER_BASE_URL;
   if (process.env.OLLAMA_BASE_URL) envBaseUrls['ollama'] = process.env.OLLAMA_BASE_URL;
   if (process.env.LMSTUDIO_BASE_URL) envBaseUrls['lmstudio'] = process.env.LMSTUDIO_BASE_URL;
   if (process.env.LITELLM_BASE_URL) envBaseUrls['litellm'] = process.env.LITELLM_BASE_URL;

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -633,9 +633,7 @@ export function isAvailable(touchpoint: TouchpointKind, modelOverride?: string):
     // EmbeddingTouchpoint.user_provided_models (D8=A), or the legacy
     // `recipe.id === 'litellm'` heuristic (back-compat for pre-v0.32 builds
     // where the field hadn't been declared yet).
-    const isUserProvided =
-      touchpoint === 'embedding' &&
-      (touchpointConfig as any).user_provided_models === true;
+    const isUserProvided = (touchpointConfig as any).user_provided_models === true;
     if (
       Array.isArray(touchpointConfig.models) &&
       touchpointConfig.models.length === 0 &&
@@ -2756,7 +2754,7 @@ export async function rerank(input: RerankInput): Promise<RerankResult[]> {
       'unknown',
     );
   }
-  if (tp.models.length > 0 && !tp.models.includes(parsed.modelId)) {
+  if (tp.models.length > 0 && !tp.models.includes(parsed.modelId) && !tp.user_provided_models) {
     throw new RerankError(
       `Model "${parsed.modelId}" is not listed for ${recipe.name} reranker. ` +
       `Known: ${tp.models.join(', ')}.`,
@@ -2767,7 +2765,8 @@ export async function rerank(input: RerankInput): Promise<RerankResult[]> {
   // Resolve base URL + auth from the recipe (same path Voyage/ZE embeddings use).
   const cfg = requireConfig();
   const compat = applyOpenAICompatConfig(recipe, cfg);
-  const url = `${compat.baseURL.replace(/\/$/, '')}/models/rerank`;
+  const rerankPath = tp.path ?? '/models/rerank';
+  const url = `${compat.baseURL.replace(/\/$/, '')}${rerankPath.startsWith('/') ? rerankPath : `/${rerankPath}`}`;
   const auth = applyResolveAuth(recipe, cfg, 'reranker');
   // applyResolveAuth returns { apiKey } for Bearer-style auth (SDK's native
   // path) or { headers } for custom-header providers (Azure). v0.37.6.0:
@@ -2776,7 +2775,7 @@ export async function rerank(input: RerankInput): Promise<RerankResult[]> {
   // materializes both shapes so static-default-headers ride on the reranker
   // wire path the same way they ride the SDK paths.
   const authHeaders: Record<string, string> = {
-    ...(auth.apiKey ? { Authorization: `Bearer ${auth.apiKey}` } : {}),
+    ...(auth.apiKey && auth.apiKey !== 'unauthenticated' ? { Authorization: `Bearer ${auth.apiKey}` } : {}),
     ...(auth.headers ?? {}),
   };
   const body = JSON.stringify({

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -639,7 +639,7 @@ export function isAvailable(touchpoint: TouchpointKind, modelOverride?: string):
     if (
       Array.isArray(touchpointConfig.models) &&
       touchpointConfig.models.length === 0 &&
-      (recipe.id === 'litellm' || isUserProvided)
+      !(recipe.id === 'litellm' || isUserProvided)
     ) return false;
 
     // For openai-compatible without auth requirements (Ollama local), treat as always-available.

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -17,6 +17,7 @@ import { deepseek } from './deepseek.ts';
 import { groq } from './groq.ts';
 import { together } from './together.ts';
 import { llamaServer } from './llama-server.ts';
+import { llamaServerReranker } from './llama-server-reranker.ts';
 import { minimax } from './minimax.ts';
 import { dashscope } from './dashscope.ts';
 import { zhipu } from './zhipu.ts';
@@ -35,6 +36,7 @@ const ALL: Recipe[] = [
   groq,
   together,
   llamaServer,
+  llamaServerReranker,
   minimax,
   dashscope,
   zhipu,

--- a/src/core/ai/recipes/llama-server-reranker.ts
+++ b/src/core/ai/recipes/llama-server-reranker.ts
@@ -1,0 +1,61 @@
+import type { Recipe } from '../types.ts';
+import { probeLlamaServer } from '../probes.ts';
+
+/**
+ * Dedicated llama.cpp llama-server reranker endpoint.
+ *
+ * Keep this separate from `llama-server` embeddings because local installs
+ * commonly run embeddings and reranking as two different llama-server
+ * processes on different ports. Reusing provider id `llama-server` would force
+ * both touchpoints through one `base_urls['llama-server']` value.
+ *
+ * Launch example:
+ *   llama-server --model <Qwen3-Reranker-4B.gguf> --reranking --pooling rank \
+ *     --alias qwen3-reranker-4b --host 127.0.0.1 --port 8081
+ */
+export const llamaServerReranker: Recipe = {
+  id: 'llama-server-reranker',
+  name: 'llama.cpp llama-server reranker (local)',
+  tier: 'openai-compat',
+  implementation: 'openai-compatible',
+  base_url_default: 'http://localhost:8081/v1',
+  auth_env: {
+    required: [],
+    optional: ['LLAMA_SERVER_RERANKER_BASE_URL', 'LLAMA_SERVER_RERANKER_API_KEY'],
+    setup_url:
+      'https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md',
+  },
+  touchpoints: {
+    reranker: {
+      models: [],
+      user_provided_models: true,
+      default_model: '',
+      cost_per_1m_tokens_usd: 0,
+      price_last_verified: '2026-05-23',
+      max_payload_bytes: 5_000_000,
+      path: '/rerank',
+    },
+  },
+  async probe(baseURL?: string) {
+    const url =
+      baseURL ??
+      process.env.LLAMA_SERVER_RERANKER_BASE_URL ??
+      'http://localhost:8081/v1';
+    const result = await probeLlamaServer(url);
+    if (!result.reachable) {
+      return {
+        ready: false,
+        hint: `llama-server reranker not reachable at ${url}. Start it with \`llama-server --model <reranker.gguf> --reranking --pooling rank\` or set LLAMA_SERVER_RERANKER_BASE_URL.`,
+      };
+    }
+    if (!result.models_endpoint_valid) {
+      return {
+        ready: false,
+        hint: `llama-server reranker reached but /v1/models returned an unexpected shape: ${result.error ?? 'unknown'}.`,
+      };
+    }
+    return { ready: true };
+  },
+  setup_hint:
+    'Build llama.cpp, then `llama-server --model <reranker.gguf> --reranking --pooling rank --port 8081`. Set reranker_model=llama-server-reranker:<id>.',
+};

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -182,10 +182,17 @@ export interface ExpansionTouchpoint {
  */
 export interface RerankerTouchpoint {
   models: string[];
+  /**
+   * Local/proxy rerankers may serve arbitrary operator-provided model ids.
+   * Same semantics as embedding touchpoint user_provided_models.
+   */
+  user_provided_models?: true;
   default_model: string;
   cost_per_1m_tokens_usd?: number;
   price_last_verified?: string;
   max_payload_bytes: number;
+  /** Endpoint path appended to base URL. Defaults to ZeroEntropy-compatible /models/rerank. */
+  path?: string;
 }
 
 export interface ChatTouchpoint {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -54,6 +54,8 @@ export interface GBrainConfig {
    */
   embedding_disabled?: boolean;
   expansion_model?: string;
+  /** Optional reranker model for hybrid search re-ranking (provider:model). */
+  reranker_model?: string;
   /**
    * Default chat model for `gateway.chat()` callers (v0.27+).
    * Default: "anthropic:claude-sonnet-4-6" (dateless per Anthropic's v0.31.12+ model-ID format).
@@ -410,6 +412,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'embedding_dimensions',
   'embedding_disabled',
   'expansion_model',
+  'reranker_model',
   'chat_model',
   'chat_fallback_chain',
   'provider_base_urls',

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -409,6 +409,20 @@ function isCustomDimValidForProvider(
   requestedDims: number,
   dimsOptions: number[] | undefined,
 ): CustomDimCheck {
+  const embedding = recipe.touchpoints.embedding;
+
+  // User-provided local/proxy embedding recipes (llama-server, LiteLLM, etc.)
+  // are different from fixed allow-listed providers. The model id and native
+  // dimension are supplied by the operator because GBrain cannot know the
+  // server-side model catalogue ahead of time. For these recipes an explicit
+  // dimension is not an unsupported Matryoshka truncation; it is the contract
+  // that sizes the pgvector column before the first embed call. The actual
+  // provider response is still validated later by gateway.embed(), so a wrong
+  // value fails loudly instead of corrupting the index.
+  if (embedding?.user_provided_models === true) {
+    return { valid: true, error: '' };
+  }
+
   // Tier 1: recipe-declared dims_options.
   if (dimsOptions && dimsOptions.length > 0) {
     if (dimsOptions.includes(requestedDims)) return { valid: true, error: '' };

--- a/src/core/last-retrieved.ts
+++ b/src/core/last-retrieved.ts
@@ -38,6 +38,7 @@ import { isUndefinedColumnError } from './utils.ts';
 
 let _trackRetrievalCache: { ts: number; enabled: boolean } | null = null;
 const TRACK_RETRIEVAL_CACHE_TTL_MS = 30_000;
+const _pendingBumps = new Set<Promise<void>>();
 
 /**
  * Resolve `search.track_retrieval` config with a 30s in-process cache so
@@ -65,6 +66,18 @@ async function isTrackingEnabled(engine: BrainEngine): Promise<boolean> {
 /** Test seam — drops the cache so subsequent calls re-read config. */
 export function _resetTrackRetrievalCacheForTests(): void {
   _trackRetrievalCache = null;
+  _pendingBumps.clear();
+}
+
+/**
+ * Drain best-effort retrieval write-backs before short-lived CLI processes
+ * disconnect their engine. MCP/server callers can keep using fire-and-forget;
+ * the CLI needs a bounded join so PGLite doesn't keep the event loop alive
+ * after results have already been printed.
+ */
+export async function awaitPendingLastRetrievedWrites(): Promise<void> {
+  if (_pendingBumps.size === 0) return;
+  await Promise.allSettled([..._pendingBumps]);
 }
 
 /**
@@ -78,7 +91,7 @@ export function _resetTrackRetrievalCacheForTests(): void {
 export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): void {
   if (pageIds.length === 0) return;
   // Fire-and-forget on purpose. We deliberately do NOT return the promise.
-  void (async () => {
+  const promise = (async () => {
     try {
       const enabled = await isTrackingEnabled(engine);
       if (!enabled) return;
@@ -102,4 +115,6 @@ export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): voi
       console.warn(`[last-retrieved] write-back failed (best-effort): ${msg}`);
     }
   })();
+  _pendingBumps.add(promise);
+  promise.finally(() => _pendingBumps.delete(promise));
 }

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -2277,6 +2277,12 @@ export const MIGRATIONS: Migration[] = [
       //   VECTOR(n)  → vector_cosine_ops
       //   HALFVEC(n) → halfvec_cosine_ops
       const opclass = useHalfvec ? 'halfvec_cosine_ops' : 'vector_cosine_ops';
+      const hnswDimCap = useHalfvec ? 4000 : 2000;
+      const factsEmbeddingHnswSql = embeddingDim <= hnswDimCap
+        ? `CREATE INDEX IF NOT EXISTS idx_facts_embedding_hnsw
+          ON facts USING hnsw (embedding ${opclass})
+          WHERE embedding IS NOT NULL AND expired_at IS NULL;`
+        : `-- idx_facts_embedding_hnsw skipped: ${vecType}(${embeddingDim}) exceeds pgvector HNSW cap ${hnswDimCap}; exact scans remain available.`;
       // FK to sources is added in a separate ALTER TABLE rather than inline
       // on the column. Inline `REFERENCES` worked on PGLite but silently
       // got dropped by postgres.js's `unsafe()` multi-statement path on
@@ -2350,9 +2356,7 @@ export const MIGRATIONS: Migration[] = [
           ON facts(source_id, entity_slug)
           WHERE consolidated_at IS NULL AND expired_at IS NULL;
 
-        CREATE INDEX IF NOT EXISTS idx_facts_embedding_hnsw
-          ON facts USING hnsw (embedding ${opclass})
-          WHERE embedding IS NOT NULL AND expired_at IS NULL;
+        ${factsEmbeddingHnswSql}
       `;
 
       await engine.runMigration(40, factsDDL);
@@ -2868,6 +2872,12 @@ export const MIGRATIONS: Migration[] = [
 
       const vecType = useHalfvec ? 'HALFVEC' : 'VECTOR';
       const opclass = useHalfvec ? 'halfvec_cosine_ops' : 'vector_cosine_ops';
+      const hnswDimCap = useHalfvec ? 4000 : 2000;
+      const queryCacheEmbeddingHnswSql = embeddingDim <= hnswDimCap
+        ? `CREATE INDEX IF NOT EXISTS idx_query_cache_embedding_hnsw
+          ON query_cache USING hnsw (embedding ${opclass})
+          WHERE embedding IS NOT NULL;`
+        : `-- idx_query_cache_embedding_hnsw skipped: ${vecType}(${embeddingDim}) exceeds pgvector HNSW cap ${hnswDimCap}; exact scans remain available.`;
 
       const ddl = `
         CREATE TABLE IF NOT EXISTS query_cache (
@@ -2886,9 +2896,7 @@ export const MIGRATIONS: Migration[] = [
         CREATE INDEX IF NOT EXISTS idx_query_cache_source_created
           ON query_cache(source_id, created_at DESC);
 
-        CREATE INDEX IF NOT EXISTS idx_query_cache_embedding_hnsw
-          ON query_cache USING hnsw (embedding ${opclass})
-          WHERE embedding IS NOT NULL;
+        ${queryCacheEmbeddingHnswSql}
       `;
 
       await engine.runMigration(55, ddl);

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -1,5 +1,7 @@
 import type { BrainEngine } from './engine.ts';
 import { slugifyPath } from './sync.ts';
+import { readContentChunksEmbeddingDim } from './embedding-dim-check.ts';
+import { chunkEmbeddingBinaryHnswIndexSql, PGVECTOR_HNSW_BIT_MAX_DIMS, PGVECTOR_HNSW_VECTOR_MAX_DIMS } from './vector-index.ts';
 
 /**
  * Schema migrations — run automatically on initSchema().
@@ -4059,6 +4061,39 @@ export const MIGRATIONS: Migration[] = [
     sql: `
       ALTER TABLE facts ADD COLUMN IF NOT EXISTS event_type TEXT;
     `,
+  },
+  {
+    version: 90,
+    name: 'content_chunks_binary_quantized_hnsw',
+    // v0.40.x scale guardrail: for high-dimensional local embeddings
+    // (Qwen3 4096d, OpenAI 3072d, etc.), pgvector cannot build native
+    // vector HNSW (cap 2000). Binary quantization indexes up to 64k dims,
+    // so use it as an ANN candidate generator and let searchVector re-rank
+    // candidates by exact full-dimensional cosine + optional reranker.
+    idempotent: true,
+    sql: '',
+    handler: async (engine: BrainEngine) => {
+      const { exists, dims } = await readContentChunksEmbeddingDim(engine);
+      if (!exists || !dims) return;
+      if (dims <= PGVECTOR_HNSW_VECTOR_MAX_DIMS) return;
+      if (dims > PGVECTOR_HNSW_BIT_MAX_DIMS) return;
+      await engine.executeRaw(chunkEmbeddingBinaryHnswIndexSql(dims));
+    },
+    verify: async (engine: BrainEngine) => {
+      const { exists, dims } = await readContentChunksEmbeddingDim(engine);
+      if (!exists || !dims) return true;
+      if (dims <= PGVECTOR_HNSW_VECTOR_MAX_DIMS) return true;
+      if (dims > PGVECTOR_HNSW_BIT_MAX_DIMS) return true;
+      const rows = await engine.executeRaw<{ exists: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1 FROM pg_indexes
+           WHERE schemaname = 'public'
+             AND tablename = 'content_chunks'
+             AND indexname = 'idx_chunks_embedding_binary_hnsw'
+         ) AS exists`,
+      );
+      return !!rows?.[0]?.exists;
+    },
   },
 ];
 

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -52,6 +52,7 @@ import {
   EmbeddingColumnNotRegisteredError,
 } from './search/embedding-column.ts';
 import { hasCJK, escapeLikePattern } from './cjk.ts';
+import { PGVECTOR_HNSW_BIT_MAX_DIMS, pgvectorHnswMaxDimsForType } from './vector-index.ts';
 
 type PGLiteDB = PGlite;
 
@@ -1562,6 +1563,14 @@ export class PGLiteEngine implements BrainEngine {
     // itself is the discriminator (only re-embedded rows have non-NULL).
     const resolvedCol = normalizeEngineColumn(opts?.embeddingColumn);
     const { col, castSql } = buildVectorCastFragment(resolvedCol);
+    const hnswDimCap = pgvectorHnswMaxDimsForType(resolvedCol.type);
+    const canUseBinaryAnn =
+      resolvedCol.dimensions > hnswDimCap &&
+      resolvedCol.dimensions <= PGVECTOR_HNSW_BIT_MAX_DIMS;
+    const candidateOrderSql = canUseBinaryAnn
+      ? `(binary_quantize(cc.${col})::bit(${resolvedCol.dimensions})) <~> (binary_quantize(${castSql})::bit(${resolvedCol.dimensions}))`
+      : `cc.${col} <=> ${castSql}`;
+
     let modalityFilter: string;
     if (resolvedCol.name === 'embedding_image') {
       modalityFilter = `AND cc.modality = 'image'`;
@@ -1582,7 +1591,7 @@ export class PGLiteEngine implements BrainEngine {
          JOIN pages p ON p.id = cc.page_id
          JOIN sources s ON s.id = p.source_id
          WHERE cc.${col} IS NOT NULL ${modalityFilter} ${detailFilter}${extraFilter} ${hardExcludeClause} ${visibilityClause}
-         ORDER BY cc.${col} <=> ${castSql}
+         ORDER BY ${candidateOrderSql}
          LIMIT $2
        )
        SELECT

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -21,7 +21,7 @@ import { normalizeWeightForStorage } from './takes-fence.ts';
 import { runMigrations } from './migrate.ts';
 import { SCHEMA_SQL } from './schema-embedded.ts';
 import { verifySchema } from './schema-verify.ts';
-import { applyChunkEmbeddingIndexPolicy, dropZombieIndexes } from './vector-index.ts';
+import { applyChunkEmbeddingIndexPolicy, dropZombieIndexes, PGVECTOR_HNSW_BIT_MAX_DIMS, pgvectorHnswMaxDimsForType } from './vector-index.ts';
 import {
   normalizeEngineColumn,
   buildVectorCastFragment,
@@ -1601,6 +1601,13 @@ export class PostgresEngine implements BrainEngine {
     // is the discriminator (rows without embedding_multimodal aren't searched).
     const resolvedCol = normalizeEngineColumn(opts?.embeddingColumn);
     const { col, castSql } = buildVectorCastFragment(resolvedCol);
+    const hnswDimCap = pgvectorHnswMaxDimsForType(resolvedCol.type);
+    const canUseBinaryAnn =
+      resolvedCol.dimensions > hnswDimCap &&
+      resolvedCol.dimensions <= PGVECTOR_HNSW_BIT_MAX_DIMS;
+    const candidateOrderSql = canUseBinaryAnn
+      ? `(binary_quantize(cc.${col})::bit(${resolvedCol.dimensions})) <~> (binary_quantize(${castSql})::bit(${resolvedCol.dimensions}))`
+      : `cc.${col} <=> ${castSql}`;
     let modalityFilter: string;
     if (resolvedCol.name === 'embedding_image') {
       modalityFilter = `AND cc.modality = 'image'`;
@@ -1632,7 +1639,7 @@ export class PostgresEngine implements BrainEngine {
           ${sourceClause}
           ${hardExcludeClause}
           ${visibilityClause}
-        ORDER BY cc.${col} <=> ${castSql}
+        ORDER BY ${candidateOrderSql}
         LIMIT ${innerLimitParam}
       )
       SELECT

--- a/src/core/vector-index.ts
+++ b/src/core/vector-index.ts
@@ -17,15 +17,37 @@
 import type { BrainEngine } from './engine.ts';
 
 export const PGVECTOR_HNSW_VECTOR_MAX_DIMS = 2000;
+export const PGVECTOR_HNSW_HALFVEC_MAX_DIMS = 4000;
+export const PGVECTOR_HNSW_BIT_MAX_DIMS = 64000;
+
+export function pgvectorHnswMaxDimsForType(type: 'vector' | 'halfvec'): number {
+  return type === 'halfvec' ? PGVECTOR_HNSW_HALFVEC_MAX_DIMS : PGVECTOR_HNSW_VECTOR_MAX_DIMS;
+}
 
 const CHUNK_EMBEDDING_HNSW_INDEX =
   'CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);';
 
+export function chunkEmbeddingBinaryHnswIndexSql(dims: number): string {
+  return [
+    'CREATE INDEX IF NOT EXISTS idx_chunks_embedding_binary_hnsw',
+    `  ON content_chunks USING hnsw ((binary_quantize(embedding)::bit(${dims})) bit_hamming_ops)`,
+    '  WHERE embedding IS NOT NULL;',
+  ].join('\n');
+}
+
 export function chunkEmbeddingIndexSql(dims: number): string {
   if (dims <= PGVECTOR_HNSW_VECTOR_MAX_DIMS) return CHUNK_EMBEDDING_HNSW_INDEX;
+  if (dims <= PGVECTOR_HNSW_BIT_MAX_DIMS) {
+    return [
+      '-- Full-dimensional vector HNSW skipped: pgvector vector indexes support',
+      `-- at most ${PGVECTOR_HNSW_VECTOR_MAX_DIMS} dimensions. Use binary-quantized HNSW`,
+      '-- as an ANN candidate generator, then exact cosine/reranker re-rank.',
+      chunkEmbeddingBinaryHnswIndexSql(dims),
+    ].join('\n');
+  }
   return [
-    '-- idx_chunks_embedding skipped: pgvector HNSW vector indexes support',
-    `-- at most ${PGVECTOR_HNSW_VECTOR_MAX_DIMS} dimensions; exact vector scans remain available.`,
+    '-- idx_chunks_embedding skipped: pgvector vector HNSW and binary HNSW indexes support',
+    `-- at most ${PGVECTOR_HNSW_VECTOR_MAX_DIMS} and ${PGVECTOR_HNSW_BIT_MAX_DIMS} dimensions respectively; exact vector scans remain available.`,
   ].join('\n');
 }
 

--- a/test/ai/build-gateway-config.test.ts
+++ b/test/ai/build-gateway-config.test.ts
@@ -25,6 +25,7 @@ import { withEnv } from '../helpers/with-env.ts';
 
 const PASSTHROUGHS: Array<{ envVar: string; recipeId: string }> = [
   { envVar: 'LLAMA_SERVER_BASE_URL', recipeId: 'llama-server' },
+  { envVar: 'LLAMA_SERVER_RERANKER_BASE_URL', recipeId: 'llama-server-reranker' },
   { envVar: 'OLLAMA_BASE_URL', recipeId: 'ollama' },
   { envVar: 'LMSTUDIO_BASE_URL', recipeId: 'lmstudio' },
   { envVar: 'LITELLM_BASE_URL', recipeId: 'litellm' },
@@ -83,5 +84,12 @@ describe('buildGatewayConfig env-baseURL passthrough', () => {
         expect(cfg.base_urls?.openrouter).toBe('http://config.example/v1');
       },
     );
+  });
+
+  test('reranker_model flows from config into gateway config', async () => {
+    const cfg = buildGatewayConfig({
+      reranker_model: 'llama-server-reranker:qwen3-reranker-4b',
+    } as unknown as GBrainConfig);
+    expect(cfg.reranker_model).toBe('llama-server-reranker:qwen3-reranker-4b');
   });
 });

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -8,6 +8,8 @@ import {
   getEmbeddingDimensions,
   getExpansionModel,
   VoyageResponseTooLargeError,
+  rerank,
+  __setRerankTransportForTests,
 } from '../../src/core/ai/gateway.ts';
 import { parseModelId, resolveRecipe } from '../../src/core/ai/model-resolver.ts';
 import {
@@ -93,6 +95,45 @@ describe('gateway.isAvailable (silent-drop regression surface)', () => {
       env: {},
     });
     expect(isAvailable('embedding')).toBe(true);
+  });
+
+  test('reranker supports dedicated no-auth llama-server endpoint/path', async () => {
+    let capturedUrl = '';
+    let capturedAuth: string | null = null;
+    let capturedBody: any = null;
+    __setRerankTransportForTests(async (url, init) => {
+      capturedUrl = url;
+      const headers = new Headers(init.headers as HeadersInit);
+      capturedAuth = headers.get('authorization');
+      capturedBody = JSON.parse(String(init.body));
+      return new Response(JSON.stringify({
+        results: [
+          { index: 1, relevance_score: 0.91 },
+          { index: 0, relevance_score: 0.12 },
+        ],
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    try {
+      configureGateway({
+        reranker_model: 'llama-server-reranker:qwen3-reranker-4b',
+        base_urls: { 'llama-server-reranker': 'http://127.0.0.1:8081/v1' },
+        env: {},
+      });
+      expect(isAvailable('reranker')).toBe(true);
+      const out = await rerank({
+        query: 'gbrain local reranker',
+        documents: ['irrelevant', 'local Qwen3 reranker document'],
+      });
+      expect(capturedUrl).toBe('http://127.0.0.1:8081/v1/rerank');
+      expect(capturedAuth).toBeNull();
+      expect(capturedBody.model).toBe('qwen3-reranker-4b');
+      expect(out).toEqual([
+        { index: 1, relevanceScore: 0.91 },
+        { index: 0, relevanceScore: 0.12 },
+      ]);
+    } finally {
+      __setRerankTransportForTests(null);
+    }
   });
 
   test('anthropic rejects embedding touchpoint (has no embedding model)', () => {

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -86,6 +86,15 @@ describe('gateway.isAvailable (silent-drop regression surface)', () => {
     expect(isAvailable('embedding')).toBe(true);
   });
 
+  test('embedding AVAILABLE for user-provided llama-server model with no API key', () => {
+    configureGateway({
+      embedding_model: 'llama-server:qwen3-embedding-8b',
+      embedding_dimensions: 4096,
+      env: {},
+    });
+    expect(isAvailable('embedding')).toBe(true);
+  });
+
   test('anthropic rejects embedding touchpoint (has no embedding model)', () => {
     configureGateway({
       embedding_model: 'anthropic:claude-haiku-4-5-20251001',

--- a/test/ai/schema-templating.test.ts
+++ b/test/ai/schema-templating.test.ts
@@ -34,13 +34,14 @@ describe('getPGLiteSchema', () => {
     expect(sql).toContain('idx_chunks_embedding ON content_chunks USING hnsw');
   });
 
-  test('Voyage 2048d skips unsupported HNSW index but keeps vector column', () => {
+  test('Voyage 2048d uses binary-quantized HNSW candidate index and keeps vector column', () => {
     const sql = getPGLiteSchema(2048, 'voyage-4-large');
     expect(sql).toMatch(/vector\(2048\)/);
     expect(sql).toMatch(/'voyage-4-large'/);
     expect(sql).toMatch(/\('embedding_dimensions', '2048'\)/);
     expect(sql).not.toContain('idx_chunks_embedding ON content_chunks USING hnsw');
-    expect(sql).toContain('exact vector scans remain available');
+    expect(sql).toContain('idx_chunks_embedding_binary_hnsw');
+    expect(sql).toContain('binary_quantize(embedding)::bit(2048)');
   });
 
   test('PGLITE_SCHEMA_SQL back-compat constant is the default-dim schema', () => {
@@ -49,12 +50,13 @@ describe('getPGLiteSchema', () => {
 });
 
 describe('getPostgresSchema', () => {
-  test('Voyage 2048d updates vector column and seeded config but skips HNSW', () => {
+  test('Voyage 2048d updates vector column and seeded config but uses binary HNSW', () => {
     const sql = getPostgresSchema(2048, 'voyage-4-large');
     expect(sql).toMatch(/vector\(2048\)/);
     expect(sql).toMatch(/\('embedding_model', 'voyage-4-large'\)/);
     expect(sql).toMatch(/\('embedding_dimensions', '2048'\)/);
     expect(sql).not.toContain('idx_chunks_embedding ON content_chunks USING hnsw');
+    expect(sql).toContain('idx_chunks_embedding_binary_hnsw');
   });
 
   test('escapes configured model before inserting into schema SQL literals', () => {

--- a/test/embedding-dim-check.test.ts
+++ b/test/embedding-dim-check.test.ts
@@ -265,6 +265,20 @@ describe('resolveSchemaEmbeddingDim', () => {
     if (!got.ok) expect(got.error).toMatch(/exceed pgvector's column cap/);
   });
 
+  test('user-provided llama-server model accepts explicit native dimensions', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:qwen3-embedding-8b',
+      embedding_dimensions: 4096,
+    });
+    expect(got).toEqual({
+      ok: true,
+      dim: 4096,
+      model: 'llama-server:qwen3-embedding-8b',
+      provider: 'llama-server',
+      recipeDefault: 0,
+    });
+  });
+
   test('regression: bug-reporter scenario — OpenAI auto-pick resolves at 1536', () => {
     const got = resolveSchemaEmbeddingDim({ embedding_model: 'openai:text-embedding-3-large' });
     expect(got.ok).toBe(true);

--- a/test/facts-migration-dim.test.ts
+++ b/test/facts-migration-dim.test.ts
@@ -11,6 +11,7 @@
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { configureGateway, resetGateway } from '../src/core/ai/gateway.ts';
 
 let engine: PGLiteEngine;
 
@@ -92,5 +93,42 @@ describe('migration v45 facts column shape', () => {
        WHERE table_name = 'facts' AND column_name = 'embedding'`,
     );
     expect(after[0].udt_name).toBe(before[0].udt_name);
+  });
+});
+
+describe('4096d local embeddings above HNSW caps', () => {
+  test('facts and query_cache skip HNSW indexes above pgvector caps', async () => {
+    resetGateway();
+    configureGateway({
+      embedding_model: 'llama-server:qwen3-embedding-8b',
+      embedding_dimensions: 4096,
+      env: {},
+    });
+
+    const local = new PGLiteEngine();
+    try {
+      await local.connect({});
+      await local.initSchema();
+
+      const dimRows = await local.executeRaw<{ value: string }>(
+        `SELECT value FROM config WHERE key = 'embedding_dimensions'`,
+      );
+      expect(dimRows[0].value).toBe('4096');
+
+      const factsIndexRows = await local.executeRaw<{ indexname: string }>(
+        `SELECT indexname FROM pg_indexes
+         WHERE tablename = 'facts' AND indexname = 'idx_facts_embedding_hnsw'`,
+      );
+      expect(factsIndexRows.length).toBe(0);
+
+      const queryCacheIndexRows = await local.executeRaw<{ indexname: string }>(
+        `SELECT indexname FROM pg_indexes
+         WHERE tablename = 'query_cache' AND indexname = 'idx_query_cache_embedding_hnsw'`,
+      );
+      expect(queryCacheIndexRows.length).toBe(0);
+    } finally {
+      await local.disconnect();
+      resetGateway();
+    }
   });
 });

--- a/test/facts-migration-dim.test.ts
+++ b/test/facts-migration-dim.test.ts
@@ -97,7 +97,7 @@ describe('migration v45 facts column shape', () => {
 });
 
 describe('4096d local embeddings above HNSW caps', () => {
-  test('facts and query_cache skip HNSW indexes above pgvector caps', async () => {
+  test('facts/query_cache skip native HNSW above caps; content_chunks gets binary HNSW', async () => {
     resetGateway();
     configureGateway({
       embedding_model: 'llama-server:qwen3-embedding-8b',
@@ -126,6 +126,14 @@ describe('4096d local embeddings above HNSW caps', () => {
          WHERE tablename = 'query_cache' AND indexname = 'idx_query_cache_embedding_hnsw'`,
       );
       expect(queryCacheIndexRows.length).toBe(0);
+
+      const binaryIndexRows = await local.executeRaw<{ indexdef: string }>(
+        `SELECT indexdef FROM pg_indexes
+         WHERE tablename = 'content_chunks' AND indexname = 'idx_chunks_embedding_binary_hnsw'`,
+      );
+      expect(binaryIndexRows.length).toBe(1);
+      expect(binaryIndexRows[0].indexdef).toContain('binary_quantize');
+      expect(binaryIndexRows[0].indexdef).toContain('bit(4096)');
     } finally {
       await local.disconnect();
       resetGateway();

--- a/test/last-retrieved.test.ts
+++ b/test/last-retrieved.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  awaitPendingLastRetrievedWrites,
+  bumpLastRetrievedAt,
+  _resetTrackRetrievalCacheForTests,
+} from '../src/core/last-retrieved.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('last_retrieved_at write-back draining', () => {
+  test('awaitPendingLastRetrievedWrites waits for fire-and-forget bumps', async () => {
+    _resetTrackRetrievalCacheForTests();
+    let executed = false;
+    const engine = {
+      getConfig: async () => undefined,
+      executeRaw: async () => {
+        await delay(25);
+        executed = true;
+      },
+    } as unknown as BrainEngine;
+
+    bumpLastRetrievedAt(engine, [1, 2]);
+    expect(executed).toBe(false);
+
+    await awaitPendingLastRetrievedWrites();
+    expect(executed).toBe(true);
+  });
+
+  test('disabled tracking bumps drain without executing update', async () => {
+    _resetTrackRetrievalCacheForTests();
+    let executed = false;
+    const engine = {
+      getConfig: async () => 'false',
+      executeRaw: async () => {
+        executed = true;
+      },
+    } as unknown as BrainEngine;
+
+    bumpLastRetrievedAt(engine, [1]);
+    await awaitPendingLastRetrievedWrites();
+    expect(executed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This fixes the local-first `llama-server` embedding path for user-provided 4096d models and prevents PGLite schema init from failing when pgvector HNSW caps are exceeded.

### What changed

- Treat `user_provided_models` embedding recipes as operator-supplied model catalogs:
  - accept explicit native dimensions at config/schema-init time
  - still validate actual returned vector width at provider-test/runtime
- Make `gateway.isAvailable('embedding')` return true for user-provided local recipes such as `llama-server:*` without requiring an API key or non-empty static model allowlist.
- Skip HNSW index creation for `facts.embedding` and `query_cache.embedding` when the configured embedding dimension exceeds pgvector index caps:
  - `VECTOR`: 2000
  - `HALFVEC`: 4000
  - exact scans remain available; schema init should not fail.
- Add regression tests for:
  - `llama-server:qwen3-embedding-8b` with explicit `4096` dimensions
  - local `llama-server` gateway availability
  - PGLite 4096d migrations skipping facts/query_cache HNSW indexes above caps

## Why

`llama-server` recipes already declare:

```ts
models: []
user_provided_models: true
default_dims: 0
```

That means GBrain does not own the model catalog; the operator launches whatever GGUF/server model they want and must declare its native width explicitly.

Stock `0.40.2.0` currently rejects a valid local setup before it can be tested:

```bash
gbrain init --pglite \
  --embedding-model llama-server:qwen3-embedding-8b \
  --embedding-dimensions 4096
```

After the dimension check is fixed, schema init hits a second failure because migrations create HNSW indexes over `HALFVEC(4096)`, but pgvector caps HNSW over halfvec at 4000 dimensions.

## Validation

Focused regression suite:

```text
bun test test/embedding-dim-check.test.ts test/ai/gateway.test.ts test/facts-migration-dim.test.ts
69 pass
0 fail
```

Local smoke against a real `llama-server` endpoint serving `qwen3-embedding-8b` at 4096d:

```text
gbrain init --pglite --embedding-model llama-server:qwen3-embedding-8b --embedding-dimensions 4096 ✅
gbrain import temp-brain ✅
gbrain providers test --touchpoint embedding ✅ 4096 dims
gbrain stats ✅ 1 page / 1 chunk / 1 embedded
gbrain doctor --json ✅ warnings only; embedding provider ok; schema width aligned
```

## Notes

This intentionally does not add approximate vector indexes above pgvector's caps. For 4096d local-first installs, the durable behavior is: schema initializes, exact scans still work, and future index strategies can be added separately without blocking install.
