### PR TITLE
fix(ingest): prevent silent duplicate pages on overlapping ingest roo…

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -299,6 +299,21 @@ export async function importFromContent(
     tags: parsed.tags,
   };
 
+  // Check if a page with the same content hash already exists in this source under a different slug.
+  const duplicateRows = await engine.executeRaw<{ slug: string }>(
+    `SELECT slug FROM pages 
+     WHERE source_id = $1 AND content_hash = $2 AND deleted_at IS NULL LIMIT 1`,
+    [sourceId ?? 'default', hash]
+  );
+  const existingDuplicate = duplicateRows?.[0];
+
+  if (existingDuplicate && existingDuplicate.slug !== slug) {
+    console.warn(
+      `[warning] "${slug}" is a duplicate of existing page "${existingDuplicate.slug}" (same content hash). Skipping.`
+    );
+    return { slug, status: 'skipped', chunks: 0, parsedPage };
+  }
+
   const existing = await engine.getPage(slug, sourceId ? { sourceId } : undefined);
   if (existing?.content_hash === hash && !opts.forceRechunk) {
     return { slug, status: 'skipped', chunks: 0, parsedPage };

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -702,3 +702,53 @@ body unchanged
     expect(shortCircuited).toBe(true);
   });
 });
+
+describe('importFromContent — duplicate slug detection (#1309)', () => {
+  test('skips and warns when identical content hash exists under a different slug', async () => {
+    const content = `---
+type: concept
+title: Unique Content
+---
+
+This content is unique and will be duplicate-checked.
+`;
+
+    // 1. Calculate the hash using identical logic
+    const { createHash } = await import('crypto');
+    const { parseMarkdown } = await import('../src/core/markdown.ts');
+    const parsed = parseMarkdown(content, 'concepts/a.md');
+    const hash = createHash('sha256')
+      .update(JSON.stringify({
+        title: parsed.title,
+        type: parsed.type,
+        compiled_truth: parsed.compiled_truth,
+        timeline: parsed.timeline,
+        frontmatter: parsed.frontmatter,
+        tags: parsed.tags.sort(),
+      }))
+      .digest('hex');
+
+    // 2. Setup mock engine returning a row representing the duplicate slug 'concepts/old-slug'
+    const engine = mockEngine({
+      executeRaw: (sql: string, params?: unknown[]) => {
+        expect(sql).toContain('SELECT slug FROM pages');
+        expect(params).toEqual(['default', hash]);
+        return Promise.resolve([{ slug: 'concepts/old-slug' }]);
+      },
+    });
+
+    // 3. Attempt importing to a new slug 'concepts/new-slug'
+    const result = await importFromContent(engine, 'concepts/new-slug', content, { noEmbed: true });
+
+    // 4. Verify duplicate detection skipped the import
+    expect(result.status).toBe('skipped');
+    expect(result.slug).toBe('concepts/new-slug');
+    expect(result.chunks).toBe(0);
+
+    // Verify putPage was NOT called because of the early return
+    const calls = (engine as any)._calls;
+    const putCall = calls.find((c: any) => c.method === 'putPage');
+    expect(putCall).toBeUndefined();
+  });
+});
+


### PR DESCRIPTION

### **Problem**
Ingesting a nested directory followed by its parent directory creates duplicate database pages for identical files. Since slugs are derived relative to the import root (e.g., `check` vs. `subdir/check`), the database uniqueness constraint on `(source_id, slug)` is bypassed, leading to search clutter, bloated storage, and inflated backlinks.

### **Solution**
* Added a pre-import safeguard in `importFromContent` (`src/core/import-file.ts`) to look up pages by `(source_id, content_hash)`.
* If a match exists under a different slug, it logs a warning and short-circuits with `status: 'skipped'` (saving embedding costs).
* Used optional chaining (`duplicateRows?.[0]`) to maintain compatibility with test suite mock engines.

### **Verification**
* **Automated**: Added a new unit test suite to `test/import-file.test.ts` verifying the skip and short-circuit logic.
* **Manual**: Confirmed that sequential overlapping imports cleanly skip duplicate creations with a logged warning.

**Closes #1309**
