### PR TITLE
feat(schema): cathedral v2 — add-type, remove-type, stats, sync + withConnectedEngine fix

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,8 @@ const CLI_ONLY_SELF_HELP = new Set([
   'models',
   'cache',
   'brainstorm', 'lsd',
+  // schema has its own rich printHelp() covering 20+ verbs.
+  'schema',
   // v0.39.3.0 WARN-5: capture's detailed HELP constant
   // (src/commands/capture.ts:90+) was unreachable because the dispatcher's
   // generic short-circuit (printCliOnlyHelp at :204-208) fired before

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -1,20 +1,17 @@
-// v0.38 Phase C — `gbrain schema` CLI surface.
+// `gbrain schema` CLI surface.
 //
-// Five essential subcommands ship in v0.38:
-//   gbrain schema active                 — show resolved pack + tier source
-//   gbrain schema list                   — list installed packs
-//   gbrain schema show [<pack>]          — pretty-print manifest
-//   gbrain schema validate [<pack>]      — validate manifest shape
-//   gbrain schema use <pack>             — activate pack (file-plane)
+// The active schema pack drives type inference, link verbs, expert
+// routing, extractable types, enrichment rubrics, and per-source
+// closure for search. See `src/core/schema-pack/load-active.ts` for
+// the boundary helper that all engines + operations consume.
 //
-// Deferred to v0.39+:
-//   init, fork, edit, diff, detect, suggest, review-candidates,
-//   review-orphans, graph, lint, explain
-//
-// The active pack drives type inference, link verbs, expert routing,
-// extractable types, enrichment rubrics, and per-source closure for
-// search. See `src/core/schema-pack/load-active.ts` for the boundary
-// helper that all engines + operations consume.
+// Verbs are grouped by lifecycle:
+//   Read-only inspection: active, list, show, validate, graph, lint,
+//                         stats, explain, usage
+//   Activation:           use, downgrade
+//   Authoring:            init, fork, edit, diff, add-type, remove-type
+//   Discovery + repair:   detect, suggest, review-candidates,
+//                         review-orphans, sync
 
 import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -53,6 +50,10 @@ export async function runSchema(args: string[]): Promise<void> {
     case 'review-orphans': return runReviewOrphansCmd(args.slice(1));
     case 'downgrade': return runDowngradeCmd(args.slice(1));
     case 'usage':    return runUsageCmd(args.slice(1));
+    case 'stats':    return runStatsCmd(args.slice(1));
+    case 'sync':     return runSyncCmd(args.slice(1));
+    case 'add-type': return runAddTypeCmd(args.slice(1));
+    case 'remove-type': return runRemoveTypeCmd(args.slice(1));
     case undefined:
     case '--help':
     case '-h':
@@ -67,18 +68,47 @@ export async function runSchema(args: string[]): Promise<void> {
 function printHelp(): void {
   console.log(`gbrain schema — active schema pack management
 
-Subcommands:
+Inspection:
   active                  Show resolved pack + which tier provided it
   list                    List installed packs (bundled + ~/.gbrain/schema-packs/)
   show [<pack>]           Pretty-print a manifest (default: active pack)
-  validate [<pack>]       Validate manifest shape against the v0.38 schema
+  validate [<pack>]       Validate manifest shape against the v1 schema
+  graph                   Show type/primitive graph with link-verb edges
+  lint [<pack>]           Lint a pack for duplicates, dangling refs, etc.
+  stats                   Per-type page counts + typed-coverage from the DB
+  explain <type>          Print resolved settings for a single type
+  usage [--since N(d|w|m)] CLI invocation telemetry summary
+
+Activation:
   use <pack>              Activate pack (writes ~/.gbrain/config.json schema_pack)
+  downgrade [--to <pack>] Restore the previous active pack
 
-v0.38 ships the schema-pack engine + these five inspection/activation
-commands. detect, suggest, init, fork, edit, graph, lint, explain,
-review-candidates, review-orphans, and diff land in v0.39.
+Authoring:
+  init <name>             Scaffold a new pack (extends gbrain-base)
+  fork <src> <new>        Copy a pack to a new editable name
+  edit <name>             Print the on-disk pack file path
+  diff <a> <b>            Compare page_type sets across two packs
+  add-type <name>         Add a page_type to the active pack
+    --primitive <p>       One of entity|media|temporal|annotation|concept (required)
+    --prefix <dir/>       Path prefix bound to the type (required)
+    --extractable         Mark as facts-extraction eligible
+    --expert              Mark as expert/whoknows routable
+    --alias <a>           Alias name; repeatable
+    --pack <name>         Target pack (default: active pack)
+  remove-type <name>      Remove a page_type from the active pack
+    --pack <name>         Target pack (default: active pack)
 
-Resolution chain (D13 7-tier, tier 1 trust-gated):
+Discovery + repair:
+  detect                  Cluster pages by source_path → candidate page_types
+  suggest                 Heuristic refinement on detect output
+  review-candidates       Review disk-derived candidates; promote with --apply
+  review-orphans          List pages with no active-pack type match
+  sync [--apply]          Backfill page.type for rows matching pack prefixes
+                          (dry-run by default)
+
+All new verbs accept --json. Verbs scoped by source accept --source <id>.
+
+Resolution chain (7-tier, tier 1 trust-gated):
   1. Per-call --schema-pack flag (CLI only)
   2. GBRAIN_SCHEMA_PACK env var
   3. Per-source DB config schema_pack.source.<id>
@@ -361,11 +391,18 @@ async function withConnectedEngine<T>(fn: (engine: import('../core/engine.ts').B
   const { createEngine } = await import('../core/engine-factory.ts');
   const cfg = loadConfig() ?? {};
   const engineKind = (cfg as { engine?: string }).engine === 'postgres' ? 'postgres' : 'pglite';
-  const engine = await createEngine({
+  // Build the EngineConfig once and pass it to BOTH createEngine and
+  // engine.connect. The prior version passed `{}` to connect(), which
+  // silently caused PGLite to point at a stub path and Postgres to
+  // read DATABASE_URL out-of-band rather than honoring the resolved
+  // config — the cathedral verbs that issued real SQL (detect, suggest,
+  // review-*) were quietly running against an unconfigured engine.
+  const connectConfig: import('../core/types.ts').EngineConfig = {
     engine: engineKind,
     database_url: (cfg as { database_url?: string }).database_url,
-  });
-  await engine.connect({});
+  };
+  const engine = await createEngine(connectConfig);
+  await engine.connect(connectConfig);
   try {
     return await fn(engine);
   } finally {
@@ -599,24 +636,70 @@ async function runDiffCmd(args: string[]): Promise<void> {
 }
 
 async function runGraphCmd(args: string[]): Promise<void> {
-  const { json } = parseFlags(args);
+  const { json, positional } = parseFlags(args);
   const cfg = loadConfig();
-  const pack = await loadActivePack({ cfg, remote: false });
+  const packName = positional[0];
+  let manifest: SchemaPackManifest;
+  if (packName) {
+    const p = packPathByName(packName);
+    if (!p) {
+      console.error(`Unknown pack: ${packName}`);
+      process.exit(1);
+    }
+    manifest = loadPackFromFile(p);
+  } else {
+    manifest = (await loadActivePack({ cfg, remote: false })).manifest;
+  }
+  const typeNames = new Set(manifest.page_types.map((t) => t.name));
+  // Edge model: a link_type with inference.page_type points FROM that
+  // type via the verb. inference.target_type (when present) points to
+  // the destination; otherwise the destination is '*' (any type).
+  interface Edge { from: string; verb: string; to: string }
+  const edges: Edge[] = [];
+  for (const lt of manifest.link_types) {
+    const inf = lt.inference;
+    if (!inf || !inf.page_type) continue;
+    edges.push({ from: inf.page_type, verb: lt.name, to: inf.target_type ?? '*' });
+  }
+  // Frontmatter links are an additional edge source: page_type --(link_type)--> *
+  for (const fl of manifest.frontmatter_links ?? []) {
+    edges.push({ from: fl.page_type, verb: fl.link_type, to: '*' });
+  }
+  edges.sort((a, b) =>
+    a.from.localeCompare(b.from) || a.verb.localeCompare(b.verb) || a.to.localeCompare(b.to),
+  );
   if (json) {
     console.log(JSON.stringify({
       schema_version: 1,
-      pack: pack.manifest.name,
-      types: pack.manifest.page_types.map((t) => ({ name: t.name, primitive: t.primitive, aliases: t.aliases ?? [] })),
-      tier: 'experimental',
+      pack: manifest.name,
+      types: manifest.page_types.map((t) => ({
+        name: t.name,
+        primitive: t.primitive,
+        aliases: t.aliases ?? [],
+      })),
+      edges,
     }, null, 2));
     return;
   }
-  console.log(`(experimental) ASCII graph for pack \`${pack.manifest.name}\`:`);
+  console.log(`Schema graph for pack \`${manifest.name}\`:`);
   console.log('');
-  for (const t of pack.manifest.page_types) {
+  console.log('Types:');
+  for (const t of manifest.page_types) {
     const aliases = (t.aliases ?? []).length ? `  aliases: ${(t.aliases ?? []).join(', ')}` : '';
-    console.log(`  ${t.name.padEnd(20)} (${t.primitive})${aliases}`);
+    console.log(`  ${t.name.padEnd(24)} (${t.primitive})${aliases}`);
   }
+  console.log('');
+  if (edges.length === 0) {
+    console.log('Edges: (none — pack defines no link_type inferences)');
+    return;
+  }
+  console.log(`Edges (${edges.length}):`);
+  for (const e of edges) {
+    const fromMark = e.from !== '*' && !typeNames.has(e.from) ? '?' : '';
+    const toMark = e.to !== '*' && !typeNames.has(e.to) ? '?' : '';
+    console.log(`  ${fromMark}${e.from} --(${e.verb})--> ${toMark}${e.to}`);
+  }
+  // '?' prefix flags references to types not declared in this pack.
 }
 
 async function runLintCmd(args: string[]): Promise<void> {
@@ -636,11 +719,52 @@ async function runLintCmd(args: string[]): Promise<void> {
   }
   const warnings: string[] = [];
   const seenTypeNames = new Set<string>();
+  const aliasOwner = new Map<string, string>(); // alias → type that declared it
   for (const t of pack.page_types) {
     if (seenTypeNames.has(t.name)) warnings.push(`duplicate type name: ${t.name}`);
     seenTypeNames.add(t.name);
     if (!t.path_prefixes || t.path_prefixes.length === 0) {
       warnings.push(`type \`${t.name}\` has no path_prefixes — unreachable by inferType`);
+    }
+  }
+  // Alias collision: any alias that matches another type's name.
+  // (A type can alias ITSELF as a no-op; we ignore self-aliases.)
+  for (const t of pack.page_types) {
+    for (const a of t.aliases ?? []) {
+      if (a !== t.name && seenTypeNames.has(a)) {
+        warnings.push(`type \`${t.name}\` aliases \`${a}\` which is itself a declared type — query closure may shadow`);
+      }
+      const prev = aliasOwner.get(a);
+      if (prev && prev !== t.name) {
+        warnings.push(`alias \`${a}\` declared by both \`${prev}\` and \`${t.name}\` — closure direction will collide`);
+      } else if (!prev) {
+        aliasOwner.set(a, t.name);
+      }
+    }
+  }
+  // Enrichable types must point at declared page_types.
+  for (const e of pack.enrichable_types ?? []) {
+    if (!seenTypeNames.has(e.type)) {
+      warnings.push(`enrichable_types references unknown type \`${e.type}\``);
+    }
+  }
+  // Link inference referencing nonexistent page_types.
+  for (const lt of pack.link_types) {
+    if (lt.inference?.page_type && !seenTypeNames.has(lt.inference.page_type)) {
+      warnings.push(`link_type \`${lt.name}\` inference.page_type references unknown type \`${lt.inference.page_type}\``);
+    }
+    if (lt.inference?.target_type && lt.inference.target_type !== '*' && !seenTypeNames.has(lt.inference.target_type)) {
+      warnings.push(`link_type \`${lt.name}\` inference.target_type references unknown type \`${lt.inference.target_type}\``);
+    }
+  }
+  // Frontmatter links referencing unknown page_types or link_types.
+  const linkNames = new Set(pack.link_types.map((l) => l.name));
+  for (const fl of pack.frontmatter_links ?? []) {
+    if (!seenTypeNames.has(fl.page_type)) {
+      warnings.push(`frontmatter_links page_type \`${fl.page_type}\` is not a declared type`);
+    }
+    if (!linkNames.has(fl.link_type)) {
+      warnings.push(`frontmatter_links link_type \`${fl.link_type}\` is not a declared link verb`);
     }
   }
   if (json) {
@@ -778,6 +902,183 @@ async function runUsageCmd(args: string[]): Promise<void> {
   }
   console.log('');
   console.log('Experimental verbs are candidates for deprecation in v0.40+ if usage stays low.');
+}
+
+// ------------- Schema cathedral v2: stats / sync / add-type / remove-type
+
+import { runStats } from '../core/schema-pack/stats.ts';
+import { runSync } from '../core/schema-pack/sync.ts';
+import {
+  addTypeToPack,
+  removeTypeFromPack,
+  SchemaPackMutationError,
+} from '../core/schema-pack/mutate.ts';
+import type { PackPrimitive } from '../core/schema-pack/manifest-v1.ts';
+import { PACK_PRIMITIVES } from '../core/schema-pack/manifest-v1.ts';
+
+async function runStatsCmd(args: string[]): Promise<void> {
+  const { json, source } = parseFlags(args);
+  const result = await withConnectedEngine((engine) => runStats(engine, { sourceId: source }));
+  if (json) {
+    console.log(JSON.stringify({ schema_version: 1, ...result }, null, 2));
+    return;
+  }
+  console.log(`Schema stats${result.source_id ? ` (source: ${result.source_id})` : ''}:`);
+  console.log(`  Total pages:    ${result.total_pages}`);
+  console.log(`  Typed pages:    ${result.typed_pages}`);
+  console.log(`  Untyped pages:  ${result.untyped_pages}`);
+  const pct = (result.coverage * 100).toFixed(2);
+  console.log(`  Coverage:       ${pct}%`);
+  console.log('');
+  if (result.per_type.length === 0) {
+    console.log('(no pages — brain is empty)');
+    return;
+  }
+  console.log('Per-type:');
+  for (const row of result.per_type) {
+    console.log(`  ${row.type.padEnd(28)} ${String(row.count).padStart(8)}`);
+  }
+}
+
+async function runSyncCmd(args: string[]): Promise<void> {
+  const { json, source, positional } = parseFlags(args);
+  const apply = positional.includes('--apply');
+  const result = await withConnectedEngine((engine) =>
+    runSync(engine, { sourceId: source, apply }),
+  );
+  if (json) {
+    console.log(JSON.stringify({ schema_version: 1, ...result }, null, 2));
+    return;
+  }
+  const verb = result.applied ? 'Updated' : 'Would update';
+  console.log(`schema sync — pack: ${result.pack}${result.source_id ? `, source: ${result.source_id}` : ''}`);
+  console.log(`Mode: ${result.applied ? 'APPLY' : 'DRY-RUN (pass --apply to write)'}`);
+  console.log(`${verb} ${result.total_matched} page rows across ${result.per_type.length} types.`);
+  if (result.per_type.length === 0) {
+    console.log('No untyped pages matched any active-pack path_prefix.');
+    return;
+  }
+  console.log('');
+  for (const row of result.per_type) {
+    console.log(`  ${row.type.padEnd(24)} ${String(row.matched).padStart(8)}  (prefixes: ${row.prefixes.join(', ')})`);
+  }
+}
+
+interface AddTypeExtras {
+  pack: string | undefined;
+  primitive: PackPrimitive | undefined;
+  prefix: string | undefined;
+  extractable: boolean;
+  expert: boolean;
+  aliases: string[];
+}
+
+/**
+ * Layered flag parser for the authoring verbs. Defers --json / --source
+ * / positional capture to parseFlags(), then walks the positional list a
+ * second time to peel off authoring-specific flags. This preserves the
+ * CLI contract (every handler reads parseFlags()) while still supporting
+ * the richer flag surface add-type / remove-type need.
+ */
+function parseAddTypeExtras(positional: string[]): { extras: AddTypeExtras; remaining: string[] } {
+  let pack: string | undefined;
+  let primitive: PackPrimitive | undefined;
+  let prefix: string | undefined;
+  let extractable = false;
+  let expert = false;
+  const aliases: string[] = [];
+  const remaining: string[] = [];
+  for (let i = 0; i < positional.length; i++) {
+    const a = positional[i];
+    if (a === '--pack') { pack = positional[++i]; continue; }
+    if (a.startsWith('--pack=')) { pack = a.slice('--pack='.length); continue; }
+    if (a === '--primitive') { primitive = positional[++i] as PackPrimitive; continue; }
+    if (a.startsWith('--primitive=')) { primitive = a.slice('--primitive='.length) as PackPrimitive; continue; }
+    if (a === '--prefix') { prefix = positional[++i]; continue; }
+    if (a.startsWith('--prefix=')) { prefix = a.slice('--prefix='.length); continue; }
+    if (a === '--extractable') { extractable = true; continue; }
+    if (a === '--expert' || a === '--expert-routing') { expert = true; continue; }
+    if (a === '--alias') { const v = positional[++i]; if (v) aliases.push(v); continue; }
+    if (a.startsWith('--alias=')) { aliases.push(a.slice('--alias='.length)); continue; }
+    remaining.push(a);
+  }
+  return { extras: { pack, primitive, prefix, extractable, expert, aliases }, remaining };
+}
+
+async function resolveTargetPackName(explicit: string | undefined): Promise<string> {
+  if (explicit) return explicit;
+  const cfg = loadConfig();
+  const pack = await loadActivePack({ cfg, remote: false });
+  return pack.manifest.name;
+}
+
+async function runAddTypeCmd(args: string[]): Promise<void> {
+  // Honor the --json / --source contract via parseFlags() first.
+  const flags = parseFlags(args);
+  const { extras, remaining } = parseAddTypeExtras(flags.positional);
+  const name = remaining[0];
+  if (!name) {
+    console.error('Usage: gbrain schema add-type <name> --primitive <p> --prefix <dir/> [--extractable] [--expert] [--alias <a>]...');
+    process.exit(2);
+  }
+  if (!extras.primitive) {
+    console.error(`--primitive is required. One of: ${PACK_PRIMITIVES.join(', ')}`);
+    process.exit(2);
+  }
+  if (!extras.prefix) {
+    console.error('--prefix is required (e.g. --prefix media/photos/)');
+    process.exit(2);
+  }
+  const targetPack = await resolveTargetPackName(extras.pack);
+  try {
+    const result = addTypeToPack(targetPack, {
+      name,
+      primitive: extras.primitive,
+      prefix: extras.prefix,
+      extractable: extras.extractable,
+      expertRouting: extras.expert,
+      aliases: extras.aliases,
+    });
+    if (flags.json) {
+      console.log(JSON.stringify({ schema_version: 1, action: 'add-type', ...result }, null, 2));
+      return;
+    }
+    console.log(`✓ Added type \`${result.type}\` to pack \`${result.pack}\``);
+    console.log(`  File: ${result.path} (${result.format})`);
+    console.log(`  Next: gbrain schema validate ${result.pack}`);
+  } catch (e) {
+    if (e instanceof SchemaPackMutationError) {
+      console.error(`✗ ${e.message}`);
+      process.exit(1);
+    }
+    throw e;
+  }
+}
+
+async function runRemoveTypeCmd(args: string[]): Promise<void> {
+  const flags = parseFlags(args);
+  const { extras, remaining } = parseAddTypeExtras(flags.positional);
+  const name = remaining[0];
+  if (!name) {
+    console.error('Usage: gbrain schema remove-type <name> [--pack <name>]');
+    process.exit(2);
+  }
+  const targetPack = await resolveTargetPackName(extras.pack);
+  try {
+    const result = removeTypeFromPack(targetPack, { name });
+    if (flags.json) {
+      console.log(JSON.stringify({ schema_version: 1, action: 'remove-type', ...result }, null, 2));
+      return;
+    }
+    console.log(`✓ Removed type \`${result.type}\` from pack \`${result.pack}\``);
+    console.log(`  File: ${result.path} (${result.format})`);
+  } catch (e) {
+    if (e instanceof SchemaPackMutationError) {
+      console.error(`✗ ${e.message}`);
+      process.exit(1);
+    }
+    throw e;
+  }
 }
 
 function parseSinceDays(s: string): number {

--- a/src/core/schema-pack/index.ts
+++ b/src/core/schema-pack/index.ts
@@ -112,3 +112,30 @@ export {
   enrichableTypesFromPack,
   rubricNameForType,
 } from './enrichable.ts';
+
+export {
+  type AddTypeOpts,
+  type RemoveTypeOpts,
+  type MutateResult,
+  type PackFileFormat,
+  SchemaPackMutationError,
+  addTypeToPack,
+  removeTypeFromPack,
+  locateMutablePackFile,
+  readPackForMutation,
+  writePackManifest,
+} from './mutate.ts';
+
+export {
+  type StatsOpts,
+  type StatsResult,
+  type PerTypeCount,
+  runStats,
+} from './stats.ts';
+
+export {
+  type SyncOpts,
+  type SyncResult,
+  type SyncPerType,
+  runSync,
+} from './sync.ts';

--- a/src/core/schema-pack/mutate.ts
+++ b/src/core/schema-pack/mutate.ts
@@ -1,0 +1,368 @@
+// Schema cathedral v2 — pack mutation primitives.
+//
+// `gbrain schema add-type` and `gbrain schema remove-type` are the
+// authoring verbs that close the loop on `init`/`fork`: once a pack
+// exists, the operator needs first-class commands to add and remove
+// page_type entries without hand-editing YAML/JSON and risking shape
+// drift. These helpers:
+//
+//   1. Locate the active pack (or a named pack) on disk.
+//   2. Read it preserving format (pack.json | pack.yaml | pack.yml).
+//   3. Mutate the page_types list (add or remove by name).
+//   4. Validate the resulting manifest BEFORE writing — the pack file
+//      on disk is never left in a broken state.
+//   5. Write back in the original format.
+//
+// Bundled packs (gbrain-base, gbrain-recommended) are read-only by
+// design: their manifests are generated source and live inside the
+// distributed module. Attempting to mutate them throws explicitly so
+// downstream packagers don't accidentally clobber the source tree.
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { extname, join } from 'node:path';
+import {
+  loadPackFromFile,
+  parseSchemaPackManifest,
+  parseYamlMini,
+  type PackPrimitive,
+  type SchemaPackManifest,
+} from './index.ts';
+import { gbrainPath } from '../config.ts';
+import { PACK_PRIMITIVES } from './manifest-v1.ts';
+
+export type PackFileFormat = 'json' | 'yaml';
+
+export interface AddTypeOpts {
+  /** Type name to register on the pack. Required, must be unique. */
+  name: string;
+  /** Composable primitive backing the type. Must be one of PACK_PRIMITIVES. */
+  primitive: PackPrimitive;
+  /** Path prefix the type binds to (e.g. "media/photos/"). */
+  prefix: string;
+  /** Mark the type as eligible for facts extraction. */
+  extractable?: boolean;
+  /** Route the type through expert / whoknows queries. */
+  expertRouting?: boolean;
+  /** Optional alias list driving query closure. */
+  aliases?: string[];
+}
+
+export interface RemoveTypeOpts {
+  /** Type name to remove. Must already exist in the pack. */
+  name: string;
+}
+
+export interface MutateResult {
+  /** Disk path of the pack file that was mutated. */
+  path: string;
+  /** Pack name (from the manifest). */
+  pack: string;
+  /** Format the file was rewritten in. */
+  format: PackFileFormat;
+  /** Type name that was added or removed. */
+  type: string;
+}
+
+export class SchemaPackMutationError extends Error {
+  readonly code:
+    | 'PACK_NOT_FOUND'
+    | 'PACK_READONLY'
+    | 'TYPE_EXISTS'
+    | 'TYPE_NOT_FOUND'
+    | 'INVALID_PRIMITIVE'
+    | 'INVALID_RESULT';
+  constructor(
+    code: SchemaPackMutationError['code'],
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SchemaPackMutationError';
+    this.code = code;
+  }
+}
+
+const BUNDLED_PACK_NAMES = new Set(['gbrain-base', 'gbrain-recommended']);
+
+/**
+ * Locate a user-mutable pack file. Bundled packs are explicitly refused —
+ * they live inside the installed module and edits would be lost on
+ * upgrade. User packs live under ~/.gbrain/schema-packs/<name>/.
+ */
+export function locateMutablePackFile(name: string): { path: string; format: PackFileFormat } {
+  if (BUNDLED_PACK_NAMES.has(name)) {
+    throw new SchemaPackMutationError(
+      'PACK_READONLY',
+      `Pack '${name}' is bundled and read-only. Use 'gbrain schema fork ${name} <new-name>' to create a writable copy.`,
+    );
+  }
+  const baseDir = gbrainPath('schema-packs', name);
+  const candidates: Array<{ file: string; format: PackFileFormat }> = [
+    { file: 'pack.json', format: 'json' },
+    { file: 'pack.yaml', format: 'yaml' },
+    { file: 'pack.yml', format: 'yaml' },
+  ];
+  for (const c of candidates) {
+    const p = join(baseDir, c.file);
+    if (existsSync(p)) return { path: p, format: c.format };
+  }
+  throw new SchemaPackMutationError(
+    'PACK_NOT_FOUND',
+    `No pack file at ${baseDir}. Run 'gbrain schema init ${name}' or 'gbrain schema fork <source> ${name}' first.`,
+  );
+}
+
+/**
+ * Format-preserving read of a pack file. Returns the manifest and the
+ * detected file format so the writer can round-trip without coercion.
+ */
+export function readPackForMutation(path: string): { manifest: SchemaPackManifest; format: PackFileFormat } {
+  if (!existsSync(path)) {
+    throw new SchemaPackMutationError('PACK_NOT_FOUND', `pack file not found: ${path}`);
+  }
+  const ext = extname(path).toLowerCase();
+  const format: PackFileFormat = ext === '.json' ? 'json' : 'yaml';
+  const manifest = loadPackFromFile(path);
+  return { manifest, format };
+}
+
+/**
+ * Write a manifest back to disk in the requested format.
+ *
+ * Round-trip note: JSON is round-trip safe; the YAML mini-parser does
+ * not preserve comments or formatting. We emit a canonical YAML shape
+ * via JSON-to-YAML normalization so the file remains valid input to
+ * `parseYamlMini`. Authors who care about layout should pin pack.json.
+ */
+export function writePackManifest(
+  path: string,
+  manifest: SchemaPackManifest,
+  format: PackFileFormat,
+): void {
+  // Always validate before writing — the file on disk must parse.
+  parseSchemaPackManifest(manifest, { path });
+  // Confirm YAML round-trip too if we're emitting YAML, by serializing
+  // and re-parsing through the mini-parser. Belt-and-suspenders.
+  if (format === 'yaml') {
+    const yaml = manifestToYaml(manifest);
+    const reparsed = parseYamlMini(yaml);
+    parseSchemaPackManifest(reparsed, { path });
+    writeFileSync(path, yaml, 'utf-8');
+    return;
+  }
+  writeFileSync(path, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * Add a page_type to a pack. Validates the new manifest before
+ * committing. Throws SchemaPackMutationError on duplicate names,
+ * unknown primitives, or shape violations.
+ */
+export function addTypeToPack(packName: string, opts: AddTypeOpts): MutateResult {
+  if (!opts.name || !/^[a-z0-9._-]+$/i.test(opts.name)) {
+    throw new SchemaPackMutationError(
+      'INVALID_RESULT',
+      `type name must be a non-empty slug-shape string (got: ${JSON.stringify(opts.name)})`,
+    );
+  }
+  if (!PACK_PRIMITIVES.includes(opts.primitive)) {
+    throw new SchemaPackMutationError(
+      'INVALID_PRIMITIVE',
+      `primitive must be one of ${PACK_PRIMITIVES.join('|')} (got: ${opts.primitive})`,
+    );
+  }
+  if (!opts.prefix) {
+    throw new SchemaPackMutationError(
+      'INVALID_RESULT',
+      `--prefix is required (e.g. --prefix media/photos/)`,
+    );
+  }
+  const { path, format } = locateMutablePackFile(packName);
+  const { manifest } = readPackForMutation(path);
+  if (manifest.page_types.some((t) => t.name === opts.name)) {
+    throw new SchemaPackMutationError(
+      'TYPE_EXISTS',
+      `type '${opts.name}' already exists in pack '${packName}'. Use 'gbrain schema remove-type ${opts.name}' first.`,
+    );
+  }
+  const next: SchemaPackManifest = {
+    ...manifest,
+    page_types: [
+      ...manifest.page_types,
+      {
+        name: opts.name,
+        primitive: opts.primitive,
+        path_prefixes: [opts.prefix],
+        aliases: opts.aliases ?? [],
+        extractable: opts.extractable ?? false,
+        expert_routing: opts.expertRouting ?? false,
+      },
+    ],
+  };
+  writePackManifest(path, next, format);
+  return { path, pack: manifest.name, format, type: opts.name };
+}
+
+/**
+ * Remove a page_type from a pack. Throws if the type isn't present.
+ */
+export function removeTypeFromPack(packName: string, opts: RemoveTypeOpts): MutateResult {
+  const { path, format } = locateMutablePackFile(packName);
+  const { manifest } = readPackForMutation(path);
+  const idx = manifest.page_types.findIndex((t) => t.name === opts.name);
+  if (idx < 0) {
+    const known = manifest.page_types.map((t) => t.name).join(', ') || '<none>';
+    throw new SchemaPackMutationError(
+      'TYPE_NOT_FOUND',
+      `type '${opts.name}' not found in pack '${packName}'. Known types: ${known}`,
+    );
+  }
+  const next: SchemaPackManifest = {
+    ...manifest,
+    page_types: manifest.page_types.filter((_, i) => i !== idx),
+  };
+  writePackManifest(path, next, format);
+  return { path, pack: manifest.name, format, type: opts.name };
+}
+
+// ---------------------------------------------------------------
+// YAML emitter for the manifest subset our mini-parser accepts.
+// ---------------------------------------------------------------
+//
+// The mini-parser in loader.ts handles scalars, lists of scalars, lists
+// of maps, and nested maps. We emit only those shapes. Strings are
+// quoted defensively when they contain reserved chars (colon, hash,
+// brackets, leading dash, etc.); otherwise emitted bare.
+
+function manifestToYaml(m: SchemaPackManifest): string {
+  const out: string[] = [];
+  out.push(`api_version: ${m.api_version}`);
+  out.push(`name: ${m.name}`);
+  out.push(`version: ${m.version}`);
+  if (m.gbrain_min_version) out.push(`gbrain_min_version: ${m.gbrain_min_version}`);
+  out.push(`extends: ${m.extends ?? 'null'}`);
+  if (m.description) out.push(`description: ${quoteScalar(m.description)}`);
+
+  out.push('');
+  out.push('takes_kinds:');
+  if (!m.takes_kinds || m.takes_kinds.length === 0) {
+    // Trailing empty list — represent as flow.
+    out[out.length - 1] = 'takes_kinds: []';
+  } else {
+    for (const k of m.takes_kinds) out.push(`  - ${k}`);
+  }
+
+  out.push('');
+  out.push('borrow_from:');
+  if (!m.borrow_from || m.borrow_from.length === 0) {
+    out[out.length - 1] = 'borrow_from: []';
+  } else {
+    for (const b of m.borrow_from) {
+      out.push(`  - pack: ${b.pack}`);
+      if (b.types && b.types.length) {
+        out.push('    types:');
+        for (const t of b.types) out.push(`      - ${t}`);
+      }
+    }
+  }
+
+  out.push('');
+  if (!m.page_types || m.page_types.length === 0) {
+    out.push('page_types: []');
+  } else {
+    out.push('page_types:');
+    for (const t of m.page_types) {
+      out.push(`  - name: ${t.name}`);
+      out.push(`    primitive: ${t.primitive}`);
+      out.push('    path_prefixes:');
+      if (!t.path_prefixes || t.path_prefixes.length === 0) {
+        out[out.length - 1] = '    path_prefixes: []';
+      } else {
+        for (const p of t.path_prefixes) out.push(`      - ${quoteScalar(p)}`);
+      }
+      out.push('    aliases:');
+      if (!t.aliases || t.aliases.length === 0) {
+        out[out.length - 1] = '    aliases: []';
+      } else {
+        for (const a of t.aliases) out.push(`      - ${a}`);
+      }
+      out.push(`    extractable: ${t.extractable}`);
+      out.push(`    expert_routing: ${t.expert_routing}`);
+    }
+  }
+
+  out.push('');
+  if (!m.link_types || m.link_types.length === 0) {
+    out.push('link_types: []');
+  } else {
+    out.push('link_types:');
+    for (const l of m.link_types) {
+      out.push(`  - name: ${l.name}`);
+      if (l.inverse) out.push(`    inverse: ${l.inverse}`);
+      if (l.inference) {
+        out.push('    inference:');
+        if (l.inference.regex) out.push(`      regex: ${quoteScalar(l.inference.regex)}`);
+        if (l.inference.page_type) out.push(`      page_type: ${l.inference.page_type}`);
+        if (l.inference.target_type) out.push(`      target_type: ${l.inference.target_type}`);
+      }
+    }
+  }
+
+  out.push('');
+  if (!m.frontmatter_links || m.frontmatter_links.length === 0) {
+    out.push('frontmatter_links: []');
+  } else {
+    out.push('frontmatter_links:');
+    for (const f of m.frontmatter_links) {
+      out.push(`  - page_type: ${f.page_type}`);
+      out.push(`    link_type: ${f.link_type}`);
+      out.push('    fields:');
+      for (const fld of f.fields) out.push(`      - ${fld}`);
+    }
+  }
+
+  out.push('');
+  if (!m.enrichable_types || m.enrichable_types.length === 0) {
+    out.push('enrichable_types: []');
+  } else {
+    out.push('enrichable_types:');
+    for (const e of m.enrichable_types) {
+      out.push(`  - type: ${e.type}`);
+      if (e.rubric) out.push(`    rubric: ${e.rubric}`);
+    }
+  }
+
+  out.push('');
+  if (!m.filing_rules || m.filing_rules.length === 0) {
+    out.push('filing_rules: []');
+  } else {
+    out.push('filing_rules:');
+    for (const r of m.filing_rules) {
+      out.push(`  - kind: ${r.kind}`);
+      out.push(`    directory: ${quoteScalar(r.directory)}`);
+      if (r.description) out.push(`    description: ${quoteScalar(r.description)}`);
+      if (r.examples && r.examples.length) {
+        out.push('    examples:');
+        for (const ex of r.examples) out.push(`      - ${quoteScalar(ex)}`);
+      } else {
+        out.push('    examples: []');
+      }
+    }
+  }
+
+  return out.join('\n') + '\n';
+}
+
+function quoteScalar(s: string): string {
+  if (s === '') return '""';
+  // Quote if string contains characters the mini-parser treats specially
+  // at scalar boundaries, or could be confused with a literal.
+  if (/^[\s'"\-\[\]{}#,&*!|>%@`]/.test(s) || /[:#]/.test(s)) {
+    return JSON.stringify(s);
+  }
+  // Quote if it looks like a number, bool, or null so the parser doesn't
+  // coerce it.
+  if (/^(true|false|null|~|-?\d+(?:\.\d+)?)$/i.test(s)) {
+    return JSON.stringify(s);
+  }
+  return s;
+}

--- a/src/core/schema-pack/stats.ts
+++ b/src/core/schema-pack/stats.ts
@@ -1,0 +1,84 @@
+// Schema cathedral v2 — `gbrain schema stats`.
+//
+// Reports how the brain's actual content maps onto the active pack's
+// type system. Single SQL query against pages:
+//   SELECT COALESCE(type, '(untyped)') AS type, count(*) AS cnt
+//   FROM pages WHERE deleted_at IS NULL
+//   GROUP BY type ORDER BY cnt DESC
+//
+// Output is shaped for both human and machine consumption (matches the
+// --json contract used by detect/suggest/review-candidates).
+
+import type { BrainEngine } from '../engine.ts';
+
+export interface StatsOpts {
+  /** Restrict the count to a single source_id. Omit to count globally. */
+  sourceId?: string;
+}
+
+export interface PerTypeCount {
+  type: string;
+  count: number;
+}
+
+export interface StatsResult {
+  /** Total page rows considered (deleted_at IS NULL). */
+  total_pages: number;
+  /** Pages with a non-null, non-empty type. */
+  typed_pages: number;
+  /** Pages with NULL or '' type. */
+  untyped_pages: number;
+  /**
+   * Coverage = typed_pages / total_pages, rounded to 4 decimals.
+   * Reported as 0 when total_pages = 0 to avoid NaN.
+   */
+  coverage: number;
+  /** Per-type count, descending by count. Untyped reported as '(untyped)'. */
+  per_type: PerTypeCount[];
+  /** Source the count was scoped to, or null for global. */
+  source_id: string | null;
+}
+
+interface PerTypeRow {
+  type: string;
+  cnt: string | number;
+}
+
+export async function runStats(engine: BrainEngine, opts: StatsOpts = {}): Promise<StatsResult> {
+  const sourceId = opts.sourceId ?? null;
+  const where = sourceId
+    ? `WHERE deleted_at IS NULL AND source_id = $1`
+    : `WHERE deleted_at IS NULL`;
+  const params = sourceId ? [sourceId] : [];
+
+  const rows = await engine.executeRaw<PerTypeRow>(
+    `SELECT COALESCE(NULLIF(type, ''), '(untyped)') AS type, COUNT(*)::text AS cnt
+       FROM pages
+       ${where}
+       GROUP BY 1
+       ORDER BY 2 DESC, 1 ASC`,
+    params,
+  );
+
+  const per_type: PerTypeCount[] = rows.map((r) => ({
+    type: r.type,
+    count: Number(r.cnt ?? 0),
+  }));
+
+  const total_pages = per_type.reduce((acc, r) => acc + r.count, 0);
+  const untyped_pages =
+    per_type.find((r) => r.type === '(untyped)')?.count ?? 0;
+  const typed_pages = total_pages - untyped_pages;
+  const coverage = total_pages === 0
+    ? 0
+    : Math.round((typed_pages / total_pages) * 10000) / 10000;
+
+  return {
+    total_pages,
+    typed_pages,
+    untyped_pages,
+    coverage,
+    per_type,
+    source_id: sourceId,
+  };
+}

--- a/src/core/schema-pack/sync.ts
+++ b/src/core/schema-pack/sync.ts
@@ -1,0 +1,119 @@
+// Schema cathedral v2 — `gbrain schema sync`.
+//
+// Backfill page.type for rows whose source_path matches an active-pack
+// type's path_prefixes but whose `type` column is NULL or empty. This
+// closes the gap between filesystem state (which the brain wrote) and
+// the canonical typed view (which the schema pack defines).
+//
+// Defaults to dry-run. Pass `apply: true` to actually issue updates.
+// Each prefix is processed independently; the result reports how many
+// rows would (or did) move per type. The set of rows considered is
+// always deleted_at IS NULL.
+//
+// SQL safety:
+//   - Prefix is bound as a literal string parameter with `LIKE $2`.
+//   - The trailing '%' is appended inside the function, never accepted
+//     from caller input directly.
+//   - Pack manifest path_prefixes are constrained by the manifest schema
+//     (strings only), so injection surface is limited to whatever the
+//     pack author wrote into their own pack file.
+
+import type { BrainEngine } from '../engine.ts';
+import { loadActivePack } from './load-active.ts';
+import { loadConfig } from '../config.ts';
+
+export interface SyncOpts {
+  /** Restrict the update to a single source_id. Omit for all sources. */
+  sourceId?: string;
+  /** Default false — dry-run. Pass true to write. */
+  apply?: boolean;
+}
+
+export interface SyncPerType {
+  type: string;
+  prefixes: string[];
+  matched: number;
+}
+
+export interface SyncResult {
+  applied: boolean;
+  pack: string;
+  source_id: string | null;
+  total_matched: number;
+  per_type: SyncPerType[];
+}
+
+interface CountRow { cnt: string | number }
+
+export async function runSync(engine: BrainEngine, opts: SyncOpts = {}): Promise<SyncResult> {
+  const sourceId = opts.sourceId ?? null;
+  const apply = Boolean(opts.apply);
+
+  const cfg = loadConfig();
+  const pack = await loadActivePack({
+    cfg,
+    remote: false,
+    ...(sourceId ? { sourceId } : {}),
+  });
+
+  const per_type: SyncPerType[] = [];
+  let total_matched = 0;
+
+  for (const t of pack.manifest.page_types) {
+    if (!t.path_prefixes || t.path_prefixes.length === 0) continue;
+    let matched = 0;
+    for (const prefix of t.path_prefixes) {
+      const like = `${prefix}%`;
+      if (apply) {
+        // For Postgres we'd lean on RETURNING for atomic count; PGLite
+        // doesn't always surface RETURNING through executeRaw, so we
+        // run a count-then-update pair inside the same SQL plan.
+        const cntRows = await engine.executeRaw<CountRow>(
+          `SELECT COUNT(*)::text AS cnt FROM pages
+             WHERE deleted_at IS NULL
+               AND (type IS NULL OR type = '')
+               AND source_path LIKE $1
+               ${sourceId ? 'AND source_id = $2' : ''}`,
+          sourceId ? [like, sourceId] : [like],
+        );
+        const n = Number(cntRows[0]?.cnt ?? 0);
+        if (n > 0) {
+          await engine.executeRaw(
+            `UPDATE pages SET type = $1
+               WHERE deleted_at IS NULL
+                 AND (type IS NULL OR type = '')
+                 AND source_path LIKE $2
+                 ${sourceId ? 'AND source_id = $3' : ''}`,
+            sourceId ? [t.name, like, sourceId] : [t.name, like],
+          );
+        }
+        matched += n;
+      } else {
+        const cntRows = await engine.executeRaw<CountRow>(
+          `SELECT COUNT(*)::text AS cnt FROM pages
+             WHERE deleted_at IS NULL
+               AND (type IS NULL OR type = '')
+               AND source_path LIKE $1
+               ${sourceId ? 'AND source_id = $2' : ''}`,
+          sourceId ? [like, sourceId] : [like],
+        );
+        matched += Number(cntRows[0]?.cnt ?? 0);
+      }
+    }
+    if (matched > 0) {
+      per_type.push({ type: t.name, prefixes: t.path_prefixes, matched });
+      total_matched += matched;
+    }
+  }
+
+  // Sort descending by matched count for human-friendly output.
+  per_type.sort((a, b) => b.matched - a.matched);
+
+  return {
+    applied: apply,
+    pack: pack.manifest.name,
+    source_id: sourceId,
+    total_matched,
+    per_type,
+  };
+}

--- a/test/schema-cli-contract.test.ts
+++ b/test/schema-cli-contract.test.ts
@@ -22,6 +22,8 @@ const NEW_VERBS = [
   'detect', 'suggest', 'review-candidates',
   'init', 'fork', 'edit', 'diff', 'graph', 'lint', 'explain', 'review-orphans',
   'downgrade', 'usage',
+  // Schema cathedral v2: pack mutation + data-plane verbs.
+  'stats', 'sync', 'add-type', 'remove-type',
 ];
 
 describe('v0.39 T6 — schema CLI contract', () => {

--- a/test/schema-pack-mutate.test.ts
+++ b/test/schema-pack-mutate.test.ts
@@ -1,0 +1,230 @@
+// Schema cathedral v2 — mutate.ts unit tests.
+//
+// Verifies the add-type / remove-type primitives:
+//   - round-trip JSON pack
+//   - round-trip YAML pack (preserves shape, re-parses, re-validates)
+//   - duplicate name rejection
+//   - unknown type removal rejection
+//   - bundled pack read-only guard
+//   - validation gate before write
+
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  addTypeToPack,
+  removeTypeFromPack,
+  SchemaPackMutationError,
+  loadPackFromFile,
+} from '../src/core/schema-pack/index.ts';
+
+let home: string;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'gbrain-mutate-test-'));
+  prevHome = process.env.GBRAIN_HOME;
+  process.env.GBRAIN_HOME = home;
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.GBRAIN_HOME;
+  else process.env.GBRAIN_HOME = prevHome;
+  rmSync(home, { recursive: true, force: true });
+});
+
+function seedJsonPack(name: string): string {
+  const dir = join(home, '.gbrain', 'schema-packs', name);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, 'pack.json');
+  writeFileSync(path, JSON.stringify({
+    api_version: 'gbrain-schema-pack-v1',
+    name,
+    version: '0.0.1',
+    extends: 'gbrain-base',
+    description: 'unit test pack',
+    page_types: [
+      {
+        name: 'seed-type',
+        primitive: 'entity',
+        path_prefixes: ['seed/'],
+        aliases: [],
+        extractable: false,
+        expert_routing: false,
+      },
+    ],
+    link_types: [],
+    takes_kinds: ['fact', 'take', 'bet', 'hunch'],
+    borrow_from: [],
+    frontmatter_links: [],
+    enrichable_types: [],
+    filing_rules: [],
+  }, null, 2));
+  return path;
+}
+
+function seedYamlPack(name: string): string {
+  const dir = join(home, '.gbrain', 'schema-packs', name);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, 'pack.yaml');
+  writeFileSync(path, `api_version: gbrain-schema-pack-v1
+name: ${name}
+version: 0.0.1
+extends: gbrain-base
+description: yaml unit test pack
+
+takes_kinds:
+  - fact
+  - take
+
+borrow_from: []
+
+page_types:
+  - name: seed-type
+    primitive: entity
+    path_prefixes:
+      - seed/
+    aliases: []
+    extractable: false
+    expert_routing: false
+
+link_types: []
+frontmatter_links: []
+enrichable_types: []
+filing_rules: []
+`);
+  return path;
+}
+
+describe('schema-pack mutate', () => {
+  test('addTypeToPack appends a new type and re-validates', () => {
+    seedJsonPack('test-pack');
+    const result = addTypeToPack('test-pack', {
+      name: 'recipe',
+      primitive: 'media',
+      prefix: 'cooking/recipes/',
+      extractable: true,
+      aliases: ['food'],
+    });
+    expect(result.type).toBe('recipe');
+    expect(result.format).toBe('json');
+    const manifest = loadPackFromFile(result.path);
+    expect(manifest.page_types.map((t) => t.name)).toContain('recipe');
+    const recipe = manifest.page_types.find((t) => t.name === 'recipe');
+    expect(recipe?.primitive).toBe('media');
+    expect(recipe?.path_prefixes).toEqual(['cooking/recipes/']);
+    expect(recipe?.aliases).toEqual(['food']);
+    expect(recipe?.extractable).toBe(true);
+    expect(recipe?.expert_routing).toBe(false);
+  });
+
+  test('addTypeToPack rejects duplicate type name', () => {
+    seedJsonPack('test-pack');
+    expect(() => addTypeToPack('test-pack', {
+      name: 'seed-type',
+      primitive: 'entity',
+      prefix: 'x/',
+    })).toThrow(SchemaPackMutationError);
+  });
+
+  test('addTypeToPack rejects invalid primitive', () => {
+    seedJsonPack('test-pack');
+    expect(() => addTypeToPack('test-pack', {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      name: 'bogus',
+      primitive: 'not-a-primitive' as any,
+      prefix: 'x/',
+    })).toThrow(SchemaPackMutationError);
+  });
+
+  test('addTypeToPack rejects bundled packs', () => {
+    expect(() => addTypeToPack('gbrain-base', {
+      name: 'evil',
+      primitive: 'entity',
+      prefix: 'evil/',
+    })).toThrow(/read-only/);
+    expect(() => addTypeToPack('gbrain-recommended', {
+      name: 'evil',
+      primitive: 'entity',
+      prefix: 'evil/',
+    })).toThrow(/read-only/);
+  });
+
+  test('addTypeToPack errors when pack does not exist', () => {
+    expect(() => addTypeToPack('ghost', {
+      name: 'x',
+      primitive: 'entity',
+      prefix: 'x/',
+    })).toThrow(/PACK_NOT_FOUND|No pack file/);
+  });
+
+  test('removeTypeFromPack removes the named type', () => {
+    seedJsonPack('test-pack');
+    addTypeToPack('test-pack', {
+      name: 'recipe',
+      primitive: 'media',
+      prefix: 'cooking/recipes/',
+    });
+    const result = removeTypeFromPack('test-pack', { name: 'recipe' });
+    expect(result.type).toBe('recipe');
+    const manifest = loadPackFromFile(result.path);
+    expect(manifest.page_types.map((t) => t.name)).not.toContain('recipe');
+  });
+
+  test('removeTypeFromPack rejects unknown type', () => {
+    seedJsonPack('test-pack');
+    expect(() => removeTypeFromPack('test-pack', { name: 'never-existed' }))
+      .toThrow(SchemaPackMutationError);
+  });
+
+  test('YAML pack add → remove → add round-trips and revalidates', () => {
+    const path = seedYamlPack('yaml-pack');
+    addTypeToPack('yaml-pack', {
+      name: 'podcast',
+      primitive: 'media',
+      prefix: 'media/podcasts/',
+      aliases: ['audio', 'episode'],
+    });
+    // File on disk must still be valid YAML and parse through loader.
+    const afterAdd = loadPackFromFile(path);
+    expect(afterAdd.page_types.map((t) => t.name).sort()).toEqual(['podcast', 'seed-type']);
+    expect(afterAdd.page_types.find((t) => t.name === 'podcast')?.aliases).toEqual(['audio', 'episode']);
+
+    removeTypeFromPack('yaml-pack', { name: 'seed-type' });
+    const afterRemove = loadPackFromFile(path);
+    expect(afterRemove.page_types.map((t) => t.name)).toEqual(['podcast']);
+
+    addTypeToPack('yaml-pack', {
+      name: 'note',
+      primitive: 'annotation',
+      prefix: 'notes/',
+      expertRouting: true,
+    });
+    const afterAdd2 = loadPackFromFile(path);
+    expect(afterAdd2.page_types.find((t) => t.name === 'note')?.expert_routing).toBe(true);
+  });
+
+  test('addTypeToPack rejects malformed slugs', () => {
+    seedJsonPack('test-pack');
+    expect(() => addTypeToPack('test-pack', {
+      name: '',
+      primitive: 'entity',
+      prefix: 'x/',
+    })).toThrow(SchemaPackMutationError);
+    expect(() => addTypeToPack('test-pack', {
+      name: 'Spaces Bad',
+      primitive: 'entity',
+      prefix: 'x/',
+    })).toThrow(SchemaPackMutationError);
+  });
+
+  test('addTypeToPack requires a prefix', () => {
+    seedJsonPack('test-pack');
+    expect(() => addTypeToPack('test-pack', {
+      name: 'x',
+      primitive: 'entity',
+      prefix: '',
+    })).toThrow(SchemaPackMutationError);
+  });
+});


### PR DESCRIPTION
## Problem

The `gbrain schema` CLI surface shipped in v0.38 with five read-only verbs (active, list, show, validate, use). v0.39 wired up discovery verbs (detect, suggest, review-candidates, review-orphans) but two issues remained:

### Critical: `withConnectedEngine` passed `{}` to `engine.connect()`

Every DB-backed verb — detect, suggest, review-candidates, review-orphans — failed silently with "No database URL: database_url is missing from config." The bug: `withConnectedEngine` built a proper `EngineConfig` with `database_url` from `loadConfig()`, passed it to `createEngine()`, then threw it away and called `engine.connect({})`. Postgres engines need the URL at connect-time. The resolved config was one line away but never forwarded.

### No authoring verbs

Operators with custom schema packs had to hand-edit YAML/JSON to add or remove page types. No command existed to check how the DB's actual content mapped onto the pack (coverage, per-type counts), or to retroactively set `type` on existing pages that match pack prefixes but were ingested before the pack was created.

### Stale help text + incomplete lint/graph

Help text still read "detect, suggest, init, fork, edit... land in v0.39" even though those commands had been wired up for two minor versions. `schema lint` only checked duplicate names and missing prefixes. `schema graph` printed a flat type list with no relationship edges.

## Solution

### Bug fix (1 line, high leverage)

```diff
- await engine.connect({});
+ await engine.connect(connectConfig);
```

Pass the resolved `EngineConfig` (with `database_url`) to both `createEngine()` and `engine.connect()`. All DB-backed verbs now work out of the box.

### New commands

| Command | What it does |
|---------|-------------|
| `schema add-type <name> --primitive <p> --prefix <dir/>` | Append a page_type to the active pack. Validates the result before writing. Supports `--extractable`, `--expert`, `--alias <a>` (repeatable), `--pack <name>`. |
| `schema remove-type <name>` | Remove a page_type. Validates before write. |
| `schema stats` | Query the DB for per-type page counts, untyped count, and coverage percentage. |
| `schema sync [--apply]` | For each pack type's path_prefixes, find pages with NULL type matching those prefixes and backfill. Dry-run by default. |

### Improvements to existing commands

**lint** — Now catches:
- Alias that shadows another declared type name (query closure collision)
- Same alias declared by two different types
- `enrichable_types` referencing types not in the pack
- `link_types` inference.page_type / inference.target_type referencing unknown types
- `frontmatter_links` referencing undeclared types or link verbs

**graph** — Now shows link-verb edges derived from `link_types` inference and `frontmatter_links`:
```
person --(founded)--> *
meeting --(attended)--> *
image --(image_of)--> *
```

**help** — Complete rewrite: categorized into Inspection / Activation / Authoring / Discovery+repair. All 22 verbs documented with flags.

**cli.ts** — `schema` now routes to its own rich `printHelp()` instead of the generic CLI self-help short-circuit.

### File organization

| File | Purpose |
|------|---------|
| `src/core/schema-pack/mutate.ts` | add-type / remove-type library (format-preserving read/write, validation gate, bundled-pack guard, YAML emitter) |
| `src/core/schema-pack/stats.ts` | Stats query logic |
| `src/core/schema-pack/sync.ts` | Sync (prefix-match backfill) logic |
| `src/core/schema-pack/index.ts` | Re-exports for the three new modules |
| `src/commands/schema.ts` | CLI wiring for new commands + all improvements |

## Testing

**17 tests total, 0 failures:**

- 10 new mutate tests (`test/schema-pack-mutate.test.ts`): JSON round-trip, YAML round-trip, duplicate rejection, invalid primitive rejection, bundled pack read-only guard, unknown type removal, malformed slug rejection, missing prefix rejection, add→remove→add cycle
- 7 existing CLI contract tests (`test/schema-cli-contract.test.ts`): all pass, updated `NEW_VERBS` set

**Production validation (357K-page brain):**
- `schema stats`: 100% typed coverage, 357,560 pages, per-type breakdown correct
- `schema detect`: scanned 193K pages, generated candidate types
- `schema lint`: clean (3 pre-existing warnings for types without prefixes)
- `schema graph`: 10 edges derived from link_type inference
- `schema validate garry-brain`: still valid