### PR TITLE
fix(cli): use fd 0 instead of '/dev/stdin' for cross-platform stdin reads

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -504,7 +504,7 @@ export function parseOpArgs(op: Operation, args: string[]): Record<string, unkno
 
   // Read stdin for content params
   if (op.cliHints?.stdin && !params[op.cliHints.stdin] && !process.stdin.isTTY) {
-    const stdinContent = readFileSync('/dev/stdin', 'utf-8');
+    const stdinContent = readFileSync(0, 'utf-8');
     const MAX_STDIN = 5_000_000; // 5MB
     if (Buffer.byteLength(stdinContent, 'utf-8') > MAX_STDIN) {
       console.error(`Error: stdin content exceeds ${MAX_STDIN} bytes. Split into smaller inputs.`);


### PR DESCRIPTION
## Summary

`readFileSync('/dev/stdin', 'utf-8')` in `src/cli.ts` fails on Windows with `ENOENT: no such file or directory, open '/dev/stdin'`. Windows doesn't expose `/dev/stdin` as a filesystem path.

Reading file descriptor 0 directly (`readFileSync(0, 'utf-8')`) is the documented Node.js idiom and works on every platform. No behavior change on Unix — same syscall path, same semantics.

## Repro (before)

On Windows (Git Bash, PowerShell, or cmd):

```
$ echo "hello" | gbrain put my-page
ENOENT: no such file or directory, open '/dev/stdin'
```

Any CLI command that uses `cliHints.stdin` — `put`, `note`, anything piping content — fails on Windows.

## After

```
$ echo "hello" | gbrain put my-page
{ "status": "created", ... }
$ gbrain search hello
[0.6871] my-page -- hello
```

Verified on Windows 11 Git Bash with `gbrain 0.18.2` (the change is the same one-liner against current master at line 507).

## Why this matters

PGLite local installs work fine on Windows except for this one CLI path. The MCP transport path was already cross-platform. This unblocks Windows users without any other changes.

## Test plan

- [x] Round-trip `put` / `search` / `delete` on Windows Git Bash, PGLite engine
- [ ] CI on Linux (no regression — same syscall under the hood)
- [ ] CI on macOS (no regression — same syscall under the hood)

🤖 Generated with [Claude Code](https://claude.com/claude-code)