### PR TITLE
lint: skip placeholder-date false positives on documentation pages

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -105,13 +105,35 @@ export function lintContent(content: string, filePath: string): LintIssue[] {
   }
 
   // Rule: Placeholder dates
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].match(/\bYYYY-MM-DD\b/) || lines[i].match(/\bXX-XX\b/) || lines[i].match(/\b\d{4}-XX-XX\b/)) {
-      issues.push({
-        file: filePath, line: i + 1, rule: 'placeholder-date',
-        message: `Placeholder date found: ${lines[i].trim().slice(0, 60)}`,
-        fixable: false,
-      });
+  // Skip three false-positive sources that documentation pages legitimately
+  // contain: (1) lines inside fenced code blocks (e.g., shell examples showing
+  // a date pattern), (2) YYYY-MM-DD inside `inline backticks` (literal format
+  // spec, not an unfilled blank), and (3) pages whose frontmatter type is
+  // template/convention/resolver/schema/log, where the literal YYYY-MM-DD IS
+  // the documented format users should follow.
+  const PLACEHOLDER_DOC_TYPES = new Set(['template', 'convention', 'resolver', 'schema', 'log']);
+  const fmTypeMatch = content.match(/^---\n[\s\S]*?\ntype:\s*['"]?([^\s'"\n]+)/);
+  const fmType = fmTypeMatch ? fmTypeMatch[1].trim() : '';
+  const isDocPage = PLACEHOLDER_DOC_TYPES.has(fmType);
+
+  if (!isDocPage) {
+    let inFence = false;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.match(/^\s*```/)) {
+        inFence = !inFence;
+        continue;
+      }
+      if (inFence) continue;
+      // Strip inline code spans before testing so `YYYY-MM-DD` in backticks doesn't trip.
+      const stripped = line.replace(/`[^`]*`/g, '');
+      if (stripped.match(/\bYYYY-MM-DD\b/) || stripped.match(/\bXX-XX\b/) || stripped.match(/\b\d{4}-XX-XX\b/)) {
+        issues.push({
+          file: filePath, line: i + 1, rule: 'placeholder-date',
+          message: `Placeholder date found: ${line.trim().slice(0, 60)}`,
+          fixable: false,
+        });
+      }
     }
   }
 

--- a/test/lint.test.ts
+++ b/test/lint.test.ts
@@ -44,6 +44,37 @@ describe('lintContent', () => {
     expect(issues.some(i => i.rule === 'placeholder-date')).toBe(true);
   });
 
+  test('skips placeholder dates inside fenced code blocks', () => {
+    const content = '---\ntitle: Test\ntype: person\ncreated: 2026-04-11\n---\n\n# Test\n\n```\nbriefings/YYYY-MM-DD-morning.md\n```\n';
+    const issues = lintContent(content, 'test.md');
+    expect(issues.some(i => i.rule === 'placeholder-date')).toBe(false);
+  });
+
+  test('skips placeholder dates inside inline backticks', () => {
+    const content = '---\ntitle: Test\ntype: person\ncreated: 2026-04-11\n---\n\n# Test\n\nFilename pattern: `YYYY-MM-DD-slug.md`.\n';
+    const issues = lintContent(content, 'test.md');
+    expect(issues.some(i => i.rule === 'placeholder-date')).toBe(false);
+  });
+
+  test('skips placeholder dates on documentation pages (type: convention)', () => {
+    const content = '---\ntitle: Citation Format\ntype: convention\ncreated: 2026-04-11\n---\n\n# Citation Format\n\nUse `[Source: User, {context}, YYYY-MM-DD]` for user statements.\nTimeline entries: - **YYYY-MM-DD** | Event description.\n';
+    const issues = lintContent(content, 'test.md');
+    expect(issues.some(i => i.rule === 'placeholder-date')).toBe(false);
+  });
+
+  test('skips placeholder dates on documentation pages (type: template)', () => {
+    const content = '---\ntitle: Person Template\ntype: template\ncreated: 2026-04-11\n---\n\ncreated: YYYY-MM-DD\nupdated: YYYY-MM-DD\n';
+    const issues = lintContent(content, 'test.md');
+    expect(issues.some(i => i.rule === 'placeholder-date')).toBe(false);
+  });
+
+  test('still detects placeholder dates in prose on non-doc pages', () => {
+    // Regression guard: the fix must NOT silently relax the rule on regular brain pages.
+    const content = '---\ntitle: Test\ntype: person\ncreated: 2026-04-11\n---\n\n# Test\n\nLast assessed: YYYY-MM-DD by the team.\n';
+    const issues = lintContent(content, 'test.md');
+    expect(issues.some(i => i.rule === 'placeholder-date')).toBe(true);
+  });
+
   test('detects missing frontmatter title', () => {
     const content = '---\ntype: person\ncreated: 2026-04-11\n---\n\n# Test';
     const issues = lintContent(content, 'test.md');


### PR DESCRIPTION
## Summary

The `placeholder-date` lint rule currently fires on any line containing `YYYY-MM-DD` / `XX-XX`, regardless of context. This produces a false-positive class on documentation pages (filing-rule READMEs, citation conventions, filename patterns, frontmatter templates) where the literal `YYYY-MM-DD` IS the documented format users should follow, not an unfilled blank.

A freshly-initialized brain from `docs/GBRAIN_RECOMMENDED_SCHEMA.md` hits this ~40+ times, and there's currently no per-rule disable, no `.gbrainignore`, no frontmatter `lint_ignore` field — leaving users a choice between living with persistent warnings or corrupting their documentation.

## Fix

Three context-aware skips inside the `placeholder-date` rule in `src/commands/lint.ts`:

1. **Fenced code blocks** — toggle `inFence` per `` ``` `` line, skip while inside. Documentation regularly shows date patterns inside shell-example fences.
2. **Inline code spans** — strip `` `...` `` regions before running the regex. Documenting a path pattern with backticks is standard markdown.
3. **Documentation page types** — when frontmatter declares `type: template | convention | resolver | schema | log`, skip the rule entirely. These types exist to document formats other pages should follow.

## Test plan

- [x] 4 new positive cases: fenced block, inline backticks, `type: convention` page, `type: template` page — each MUST emit no `placeholder-date` issue.
- [x] 1 new regression guard: `type: person` prose page with `Last assessed: YYYY-MM-DD by the team` MUST still flag the rule. The fix cannot silently relax detection on regular brain pages.
- [x] All 18 existing tests stay green (use `type: person` + frontmatter-positioned placeholders, neither affected by the new logic).
- [x] `bun test test/lint.test.ts` → 23 pass / 0 fail.
- [x] `bun run typecheck` → clean.

## Notes

- No CHANGELOG/VERSION bump — leaving that for the maintainer's release cycle per the contribution guide.
- Real-world before/after on a brain freshly scaffolded from the recommended schema: 44 `placeholder-date` warnings → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)