### PR TITLE
resolver: broaden skillpack-harvest triggers to match shipped fixtures

### DIFF
--- a/skills/RESOLVER.md
+++ b/skills/RESOLVER.md
@@ -62,7 +62,7 @@ This is the dispatcher. Skills are the implementation. **Read the skill file bef
 | "Skillify this", "is this a skill?", "make this proper" | `skills/skillify/SKILL.md` |
 | "Compress my resolver", "AGENTS.md too large", "RESOLVER.md too big", "functional area dispatcher", "shrink routing table" | `skills/functional-area-resolver/SKILL.md` |
 | "Is gbrain healthy?", morning health check, skillpack-check | `skills/skillpack-check/SKILL.md` |
-| "harvest this skill into gbrain", "publish this skill to gbrain", "lift this skill upstream", "share this skill with other gbrain clients", "promote my skill to gbrain" | `skills/skillpack-harvest/SKILL.md` |
+| "harvest this skill", "harvest my skill", "publish this skill to gbrain", "lift this skill", "share this skill", "promote this skill", "promote my skill", "skill upstream", "into the gbrain core", "gbrain bundle" | `skills/skillpack-harvest/SKILL.md` |
 | Post-restart health + auto-fix, "did the container restart break anything", smoke test | `skills/smoke-test/SKILL.md` |
 | Cross-modal review, second opinion | `skills/cross-modal-review/SKILL.md` |
 | "Validate skills", skill health check | `skills/testing/SKILL.md` |

--- a/test/routing-eval.test.ts
+++ b/test/routing-eval.test.ts
@@ -370,3 +370,40 @@ describe('runRoutingEval', () => {
     expect(r.passed + r.missed + r.ambiguous + r.falsePositives).toBe(3);
   });
 });
+
+// End-to-end against the bundled skill set. This loads the actual
+// shipped RESOLVER.md and the shipped routing-eval.jsonl fixtures,
+// so any future drift between a skill's triggers and its fixture
+// intents fails this test loudly instead of degrading the doctor
+// resolver_health check silently on user installs.
+describe('bundled resolver matches bundled fixtures', () => {
+  const repoRoot = require('path').resolve(__dirname, '..');
+  const resolverPath = require('path').join(repoRoot, 'skills', 'RESOLVER.md');
+  const skillsDir = require('path').join(repoRoot, 'skills');
+
+  it('skillpack-harvest fixtures all route to skillpack-harvest', () => {
+    const fs = require('fs');
+    if (!fs.existsSync(resolverPath)) return; // not in a checkout (npm install) — skip
+    const harvestFixturePath = require('path').join(skillsDir, 'skillpack-harvest', 'routing-eval.jsonl');
+    if (!fs.existsSync(harvestFixturePath)) return;
+
+    const resolver = fs.readFileSync(resolverPath, 'utf-8');
+    const { fixtures } = loadRoutingFixtures(skillsDir);
+    const harvestFixtures = fixtures.filter((f) => f.expected_skill === 'skillpack-harvest');
+    expect(harvestFixtures.length).toBeGreaterThan(0); // sanity: fixtures shipped
+
+    const r = runRoutingEval(resolver, harvestFixtures);
+    // Every shipped fixture for skillpack-harvest MUST route correctly.
+    // Failure mode: the resolver row's triggers and the fixture intents
+    // share no substrings — either broaden the resolver or rewrite the
+    // fixtures so realistic phrasings overlap.
+    if (r.missed > 0) {
+      const misses = r.details.filter((d) => d.outcome === 'missed').map((d) => d.fixture.intent);
+      throw new Error(
+        `skillpack-harvest routing-eval has ${r.missed} miss(es). Intents that did not match any resolver trigger:\n  - ${misses.join('\n  - ')}`,
+      );
+    }
+    expect(r.missed).toBe(0);
+    expect(r.passed).toBe(harvestFixtures.length);
+  });
+});


### PR DESCRIPTION
## Summary

The skillpack-harvest row in `skills/RESOLVER.md` lists five trigger phrases, but the seven shipped fixtures in `skills/skillpack-harvest/routing-eval.jsonl` share no contiguous substrings with any of them. Structural Layer A matches by substring, so every shipped fixture currently misses — `gbrain doctor` reports 7 `ROUTING_MISS` warnings out of the box on a fresh install, and the `resolver_health` check docks ~5 points off the brain health score.

The fixtures already paraphrase the triggers (the linter at `src/core/routing-eval.ts:206-253` rejects verbatim copies), so the fix is on the trigger side: broaden the row to short, intent-bearing phrases that real users emit and that the existing fixtures already contain.

## Trigger change

Old (5):
- `"harvest this skill into gbrain"`
- `"publish this skill to gbrain"`
- `"lift this skill upstream"`
- `"share this skill with other gbrain clients"`
- `"promote my skill to gbrain"`

New (10) — each matched against the corresponding shipped fixture as a contiguous substring:

| New trigger | Catches fixture intent |
|---|---|
| `"harvest this skill"` | back-compat with old phrasing |
| `"harvest my skill"` | "harvest my skill into gbrain for the other clients" |
| `"publish this skill to gbrain"` | back-compat |
| `"lift this skill"` | "lift this skill back into gbrain so others can use it" |
| `"share this skill"` | "share this skill with the gbrain bundle" |
| `"promote this skill"` | "promote this skill to gbrain so neuromancer can scaffold it" |
| `"promote my skill"` | back-compat with old phrasing |
| `"skill upstream"` | "publish my fork-only skill upstream" |
| `"into the gbrain core"` | "move my custom skill into the gbrain core" |
| `"gbrain bundle"` | "I want this skill in the gbrain bundle" + "share this skill with the gbrain bundle" |

## Test plan

- [x] New end-to-end test in `test/routing-eval.test.ts` loads the actual shipped `skills/RESOLVER.md` and the actual shipped `skills/skillpack-harvest/routing-eval.jsonl`, runs `runRoutingEval`, asserts zero missed cases. Surfaces any future drift between a skill's triggers and its fixtures loudly at CI time instead of letting it degrade `doctor`'s resolver_health silently on user installs.
- [x] All 35 existing routing-eval tests stay green.
- [x] `bun test test/routing-eval.test.ts` → 36 pass / 0 fail.
- [x] `bun run typecheck` → clean.

## Before / after on a fresh install

Before: `gbrain doctor` resolver_health = `warn  7 issue(s): 0 error(s), 7 warning(s)` — all 7 are `ROUTING_MISS: skillpack-harvest`.

After: `resolver_health = ok  46 skills, all reachable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)