### PR TITLE
fix: guard against missing intent field in routing-eval fixtures

### DIFF
--- a/src/core/routing-eval.ts
+++ b/src/core/routing-eval.ts
@@ -96,6 +96,7 @@ export interface RoutingCaseResult {
  * variants that agents emit in practice.
  */
 export function normalizeText(s: string): string {
+  if (!s) return '';
   return s.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
 }
 
@@ -298,6 +299,10 @@ export function loadRoutingFixtures(skillsDir: string): LoadResult {
       if (raw.startsWith('//') || raw.startsWith('#')) continue;
       try {
         const obj = JSON.parse(raw) as RoutingFixture;
+        if (typeof obj.intent !== 'string') {
+          malformed.push({ file: fixturePath, line: i + 1, raw, error: `missing required field 'intent' (found keys: ${Object.keys(obj).join(', ')})` });
+          continue;
+        }
         fixtures.push({ ...obj, source: fixturePath });
       } catch (err) {
         malformed.push({


### PR DESCRIPTION
## Problem

`gbrain doctor` crashes with `undefined is not an object (evaluating s.toLowerCase)` when any `routing-eval.jsonl` fixture uses wrong field names (e.g. `input` instead of `intent`).

The JSON parses fine but the TypeScript cast to `RoutingFixture` is unchecked, so `fixture.intent` is `undefined`. `normalizeText(undefined)` then crashes, making `gbrain doctor` completely unusable.

## Fix

1. **`normalizeText()`**: return empty string on null/undefined input
2. **`loadRoutingFixtures()`**: validate `intent` field exists before adding to fixtures array. Bad fixtures are reported as malformed with helpful error listing actual keys found.

## Impact

- `gbrain doctor` no longer crashes on malformed fixtures
- Malformed fixtures are surfaced in the doctor report instead of silently breaking
- Zero risk to correctly-formatted fixtures