### PR TITLE
fix(extract): timeline bullet parser splits on hyphens inside slugs/prose

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -273,11 +273,28 @@ export async function extractLinksFromFile(
 export function extractTimelineFromContent(content: string, slug: string): ExtractedTimelineEntry[] {
   const entries: ExtractedTimelineEntry[] = [];
 
-  // Format 1: Bullet — - **YYYY-MM-DD** | Source — Summary
-  const bulletPattern = /^-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*(.+?)\s*[—–-]\s*(.+)$/gm;
+  // Format 1: Bullet — `- **YYYY-MM-DD** | [Source — ]Summary`
+  // Capture everything after `|`, then peel off an optional leading "Source"
+  // label ONLY when it is unambiguous: a short label (<=24 chars), containing
+  // no markdown link/bracket syntax, followed by a SPACED em-dash or en-dash.
+  // A bare hyphen — or a dash inside a slug or word like `eos-consulting-group`
+  // or `architecture-fix` — is NOT a source delimiter.
+  //
+  // The previous pattern `(.+?)\s*[—–-]\s*(.+)` split greedily on the first
+  // em/en/hyphen anywhere after `|`, so it chopped ordinary prose and markdown
+  // link slugs at the wrong place and rendered the two halves reordered in the
+  // timeline readout. This guarded form also matches the behavior of
+  // `parseTimelineEntries` (link-extraction.ts), the other timeline parser,
+  // which already treats the whole line as the summary.
+  const bulletPattern = /^-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*(.+)$/gm;
+  const sourceLabel = /^([^[\]()\n]{1,24}?) [—–] (.+)$/;
   let match;
   while ((match = bulletPattern.exec(content)) !== null) {
-    entries.push({ slug, date: match[1], source: match[2].trim(), summary: match[3].trim() });
+    const text = match[2].trim();
+    const labeled = text.match(sourceLabel);
+    entries.push(labeled
+      ? { slug, date: match[1], source: labeled[1].trim(), summary: labeled[2].trim() }
+      : { slug, date: match[1], source: '', summary: text });
   }
 
   // Format 2: Header — ### YYYY-MM-DD — Title

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -135,6 +135,30 @@ describe('extractTimelineFromContent', () => {
     const entries = extractTimelineFromContent(content, 'test');
     expect(entries).toHaveLength(1);
   });
+
+  it('does not split a markdown link slug containing hyphens', () => {
+    const content = `- **2026-05-11** | Referenced in [Acme Consulting Group](../companies/acme-consulting-group.md)`;
+    const entries = extractTimelineFromContent(content, 'test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('');
+    expect(entries[0].summary).toBe('Referenced in [Acme Consulting Group](../companies/acme-consulting-group.md)');
+  });
+
+  it('does not split prose on a bare hyphen', () => {
+    const content = `- **2026-05-03** | Created during architecture-fix session after 6 violations`;
+    const entries = extractTimelineFromContent(content, 'test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('');
+    expect(entries[0].summary).toBe('Created during architecture-fix session after 6 violations');
+  });
+
+  it('does not split a long prose clause that precedes a spaced em dash', () => {
+    const content = `- **2026-05-19** | Reviewed the long range roadmap — initial planning notes`;
+    const entries = extractTimelineFromContent(content, 'test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('');
+    expect(entries[0].summary).toBe('Reviewed the long range roadmap — initial planning notes');
+  });
 });
 
 describe('walkMarkdownFiles', () => {


### PR DESCRIPTION
## Problem

`extractTimelineFromContent` (the parser used by `gbrain extract`, sync, and the autopilot cycle) splits `- **YYYY-MM-DD** | …` bullets into `source` + `summary` on the first em-dash, en-dash, **or bare hyphen**:

```ts
const bulletPattern = /^-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*(.+?)\s*[—–-]\s*(.+)$/gm;
```

Because a bare hyphen counts as a delimiter, any bullet whose text contains a hyphen inside a word or a markdown-link slug is chopped at the wrong place, and the two halves render reordered in the timeline readout (`${summary} [${source}]`). Examples that mis-split today:

- `| Referenced in [Acme Consulting Group](../companies/acme-consulting-group.md)` → `source = "Referenced in [Acme Consulting Group](../companies/acme"`, `summary = "consulting-group.md)"`
- `| Created during architecture-fix session` → `source = "Created during architecture"`, `summary = "fix session"`

Most real-world bullets are free-form `| text`, not the intended `| Source — Summary`, so the split misfires constantly and silently accumulates scrambled `timeline_entries` via the autopilot/sync path.

This also diverges from the project's *other* timeline parser, `parseTimelineEntries` (`src/core/link-extraction.ts`), used by the `put_page` auto-timeline hook, which already treats the whole line as the summary. The same bullet therefore produces different `timeline_entries` depending on which code path wrote it.

## Fix

Keep the intended `Source — Summary` feature, but only peel off a source label when it is unambiguous: a short label (≤24 chars) containing no markdown bracket/paren syntax, followed by a **spaced** em-dash or en-dash. A bare hyphen is never treated as a delimiter.

This keeps every existing test green (`| Meeting — Discussed partnership` still yields `source: "Meeting"`) and stops the slug/prose mangling.

## Tests

Existing `extractTimelineFromContent` tests unchanged; 3 regressions added (hyphenated link slug, bare-hyphen prose, long prose clause before a spaced em-dash). `bun test test/extract.test.ts` → 24 pass / 0 fail.

## Alternative

A fully equivalent option is to drop the source-split from `extractTimelineFromContent` entirely and unify on `parseTimelineEntries`' whole-line behavior (one parser instead of two). Happy to take that direction instead if you'd prefer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
