### PR TITLE
fix: stop PGLite CLI commands from hanging

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,9 @@ const CLI_ONLY_SELF_HELP = new Set([
 ]);
 
 async function main() {
+  if (shouldForceExitAfterMain()) {
+    process.env.GBRAIN_PGLITE_SKIP_CLOSE_ON_DISCONNECT ??= '1';
+  }
   // Parse global flags (--quiet / --progress-json / --progress-interval)
   // BEFORE command dispatch, so `gbrain --progress-json doctor` works.
   // The stripped argv is what the command sees.
@@ -1759,7 +1762,22 @@ Run gbrain <command> --help for command-specific help.
 `);
 }
 
-main().catch(e => {
+function shouldForceExitAfterMain(argv = process.argv.slice(2)): boolean {
+  const command = argv.find(arg => !arg.startsWith('-'));
+  // `serve --http` returns after binding the server and relies on the HTTP
+  // listener to keep the process alive. Do not turn the PGLite one-shot exit
+  // workaround into a daemon killer.
+  return command !== 'serve';
+}
+
+// PGLite/WASM can leave runtime handles open after a successful one-shot CLI
+// command even after engine.disconnect(). That makes foreground reads print
+// results but hang indefinitely, and it makes launchd-launched maintenance look
+// like a stuck daemon. Force one-shot CLI lifecycles closed after main resolves,
+// while preserving commands that intentionally leave listeners/watchers running.
+main().then(() => {
+  if (shouldForceExitAfterMain()) process.exit(0);
+}).catch(e => {
   console.error(e.message || e);
   process.exit(1);
 });

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -196,13 +196,14 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   async disconnect(): Promise<void> {
-    if (this._db) {
-      await this._db.close();
-      this._db = null;
-    }
+    const db = this._db;
+    this._db = null;
     if (this._lock?.acquired) {
       await releaseLock(this._lock);
       this._lock = null;
+    }
+    if (db && process.env.GBRAIN_PGLITE_SKIP_CLOSE_ON_DISCONNECT !== '1') {
+      await db.close();
     }
   }
 


### PR DESCRIPTION
## Summary
- release the PGLite advisory/file lock before optional close during disconnect
- let one-shot CLI commands skip the hanging PGLite close path and force-exit after successful completion
- preserve daemon/server behavior by not force-exiting `serve --http`

## Verification
- `bun run typecheck`
- fresh PGLite temp brain: `gbrain list` and `gbrain config show` both exit in <1s instead of hanging
- fresh PGLite temp brain: `gbrain serve --http --port <free>` remains running and serves OAuth metadata
- `bun test test/cycle-pglite-lock-ordering.serial.test.ts test/admin-embed-spawn.serial.test.ts`

## Notes
- Full local `bun run test` was attempted before narrowing; it still has unrelated environment-sensitive serial failures around embedding/provider setup. The regression surfaces touched here are covered by the focused checks above.
