### PR TITLE
[codex] add gbrain optimize command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture']);
+const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'optimize', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture']);
 // CLI-only commands whose handlers print their own --help text. These are
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
@@ -209,12 +209,6 @@ async function main() {
 
 function hasHelpFlag(args: string[]): boolean {
   return args.includes('--help') || args.includes('-h');
-}
-
-function printCliOnlyHelp(command: string) {
-  console.log(`Usage: gbrain ${command}`);
-  console.log('');
-  console.log(`gbrain ${command} - run gbrain --help for the full command list.`);
 }
 
 /**
@@ -1187,6 +1181,11 @@ async function handleCliOnly(command: string, args: string[]) {
         await runExtract(engine, args);
         break;
       }
+      case 'optimize': {
+        const { runOptimize } = await import('./commands/optimize.ts');
+        await runOptimize(engine, args);
+        break;
+      }
       case 'features': {
         const { runFeatures } = await import('./commands/features.ts');
         await runFeatures(engine, args);
@@ -1614,6 +1613,30 @@ function printOpHelp(op: Operation) {
   }
 }
 
+function printCliOnlyHelp(command: string): boolean {
+  switch (command) {
+    case 'optimize':
+      console.log(`Usage: gbrain optimize [--dry-run] [--json] [--type T] [--max-words N] [--overlap-words N] [--max-chars N] [--no-extract]
+
+Rechunk stale or oversized pages and enrich DB links/timeline.
+
+Options:
+  --dry-run                    Report work without writing changes
+  --json                       Print machine-readable JSON
+  --type T                     Only process pages of type T
+  --max-words N                Target max words per recursive chunk
+  --overlap-words N            Word overlap for recursive chunks
+  --max-chars N                Hard character budget per final chunk
+  --no-extract                 Skip link and timeline extraction`);
+      return true;
+    default:
+      console.log(`Usage: gbrain ${command}`);
+      console.log('');
+      console.log(`gbrain ${command} - run gbrain --help for the full command list.`);
+      return true;
+  }
+}
+
 function printHelp() {
   // Gather shared operations grouped by category
   const cliNames = Array.from(cliOps.entries())
@@ -1662,6 +1685,7 @@ FILES
 
 EMBEDDINGS
   embed [<slug>|--all|--stale]       Generate/refresh embeddings
+  optimize [--dry-run] [--json]      Rechunk stale/oversized pages + enrich graph/timeline
 
 LINKS
   link <from> <to> [--type T]        Create typed link

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -1,0 +1,293 @@
+import type { BrainEngine, LinkBatchInput, TimelineBatchInput } from '../core/engine.ts';
+import type { ChunkInput, PageType } from '../core/types.ts';
+import { chunkText } from '../core/chunkers/recursive.ts';
+import { extractPageLinks, makeResolver, parseTimelineEntries } from '../core/link-extraction.ts';
+
+const DEFAULT_MAX_WORDS = 300;
+const DEFAULT_OVERLAP_WORDS = 50;
+const DEFAULT_MAX_CHARS = 300;
+const BATCH_SIZE = 100;
+
+interface OptimizeOpts {
+  dryRun: boolean;
+  jsonMode: boolean;
+  maxWords: number;
+  overlapWords: number;
+  maxChars: number;
+  typeFilter?: PageType;
+  skipExtract: boolean;
+}
+
+interface OptimizeResult {
+  pages_processed: number;
+  pages_rechunked: number;
+  chunks_created: number;
+  links_created: number;
+  timeline_entries_created: number;
+}
+
+export async function runOptimize(engine: BrainEngine, args: string[]) {
+  const opts = parseArgs(args);
+  try {
+    const result = await runOptimizeCore(engine, opts);
+    if (opts.jsonMode) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log([
+        '',
+        `Optimized ${result.pages_processed} pages`,
+        `  rechunked pages: ${result.pages_rechunked}`,
+        `  chunks created: ${result.chunks_created}`,
+        `  links created: ${result.links_created}`,
+        `  timeline entries created: ${result.timeline_entries_created}`,
+        opts.dryRun ? 'Dry run only: no changes written.' : 'Done.',
+      ].join('\n'));
+    }
+  } catch (e) {
+    console.error(e instanceof Error ? e.message : String(e));
+    process.exit(1);
+  }
+}
+
+export async function runOptimizeCore(engine: BrainEngine, opts: OptimizeOpts): Promise<OptimizeResult> {
+  const result: OptimizeResult = {
+    pages_processed: 0,
+    pages_rechunked: 0,
+    chunks_created: 0,
+    links_created: 0,
+    timeline_entries_created: 0,
+  };
+
+  const slugs = Array.from(await engine.getAllSlugs());
+  const existingSlugs = new Set(slugs);
+  const pageTypes = new Map<string, PageType>();
+  for (const slug of slugs) {
+    const page = await engine.getPage(slug);
+    if (page) pageTypes.set(slug, page.type);
+  }
+  const resolver = makeResolver(engine, { mode: 'batch' });
+  const linkBatch: LinkBatchInput[] = [];
+  const timelineBatch: TimelineBatchInput[] = [];
+
+  const flushLinks = async () => {
+    if (linkBatch.length === 0) return;
+    result.links_created += await engine.addLinksBatch(linkBatch.splice(0));
+  };
+  const flushTimeline = async () => {
+    if (timelineBatch.length === 0) return;
+    result.timeline_entries_created += await engine.addTimelineEntriesBatch(timelineBatch.splice(0));
+  };
+
+  const dryRunLinks = new Set<string>();
+  const dryRunTimeline = new Set<string>();
+
+  for (const slug of slugs) {
+    const page = await engine.getPage(slug);
+    if (!page) continue;
+    if (opts.typeFilter && page.type !== opts.typeFilter) continue;
+    result.pages_processed++;
+
+    const chunks = await engine.getChunks(slug);
+    const shouldRechunk = chunks.length === 0
+      || chunks.some(c => !c.embedded_at)
+      || chunks.some(c => wordCount(c.chunk_text) > Math.ceil(opts.maxWords * 1.5))
+      || chunks.some(c => c.chunk_text.length > opts.maxChars);
+
+    if (shouldRechunk) {
+      const nextChunks = buildChunks(page.compiled_truth, page.timeline, opts.maxWords, opts.overlapWords, opts.maxChars);
+      result.pages_rechunked++;
+      result.chunks_created += nextChunks.length;
+      if (!opts.dryRun) {
+        await engine.upsertChunks(slug, nextChunks);
+      }
+    }
+
+    if (opts.skipExtract) continue;
+
+    const fullContent = `${page.compiled_truth}\n${page.timeline}`;
+    const extracted = await extractPageLinks(slug, fullContent, page.frontmatter, page.type, resolver);
+    const linkedEntities = new Set<string>();
+    for (const link of await engine.getLinks(slug)) {
+      if (isTimelineEntity(pageTypes.get(link.to_slug))) linkedEntities.add(link.to_slug);
+    }
+    for (const link of await engine.getBacklinks(slug)) {
+      if (isTimelineEntity(pageTypes.get(link.from_slug))) linkedEntities.add(link.from_slug);
+    }
+    for (const candidate of extracted.candidates) {
+      const fromSlug = candidate.fromSlug ?? slug;
+      if (!existingSlugs.has(fromSlug) || !existingSlugs.has(candidate.targetSlug)) continue;
+      if (fromSlug === slug && isTimelineEntity(pageTypes.get(candidate.targetSlug))) {
+        linkedEntities.add(candidate.targetSlug);
+      }
+      const input: LinkBatchInput = {
+        from_slug: fromSlug,
+        to_slug: candidate.targetSlug,
+        link_type: candidate.linkType,
+        context: candidate.context,
+        link_source: candidate.linkSource,
+        origin_slug: candidate.originSlug,
+        origin_field: candidate.originField,
+      };
+      if (opts.dryRun) {
+        const key = `${input.from_slug}::${input.to_slug}::${input.link_type}::${input.link_source ?? 'markdown'}`;
+        if (!dryRunLinks.has(key)) {
+          dryRunLinks.add(key);
+          result.links_created++;
+        }
+      } else {
+        linkBatch.push(input);
+        if (linkBatch.length >= BATCH_SIZE) await flushLinks();
+      }
+    }
+
+    for (const entry of parseTimelineEntries(fullContent)) {
+      const pageInput: TimelineBatchInput = {
+        slug,
+        date: entry.date,
+        summary: entry.summary,
+        detail: entry.detail || '',
+      };
+      const propagatedInputs: TimelineBatchInput[] = [...linkedEntities].map(entitySlug => ({
+        slug: entitySlug,
+        date: entry.date,
+        source: slug,
+        summary: entry.summary,
+        detail: entry.detail || `From ${slug}`,
+      }));
+      const inputs = [pageInput, ...propagatedInputs];
+      if (opts.dryRun) {
+        for (const input of inputs) {
+          const key = `${input.slug}::${input.date}::${input.summary}`;
+          if (!dryRunTimeline.has(key)) {
+            dryRunTimeline.add(key);
+            result.timeline_entries_created++;
+          }
+        }
+      } else {
+        timelineBatch.push(...inputs);
+        if (timelineBatch.length >= BATCH_SIZE) await flushTimeline();
+      }
+    }
+
+    for (const entry of await engine.getTimeline(slug)) {
+      if (linkedEntities.size === 0) continue;
+      const inputs: TimelineBatchInput[] = [...linkedEntities].map(entitySlug => ({
+        slug: entitySlug,
+        date: formatDate(entry.date),
+        source: slug,
+        summary: entry.summary,
+        detail: entry.detail || `From ${slug}`,
+      }));
+      if (opts.dryRun) {
+        for (const input of inputs) {
+          const key = `${input.slug}::${input.date}::${input.summary}`;
+          if (!dryRunTimeline.has(key)) {
+            dryRunTimeline.add(key);
+            result.timeline_entries_created++;
+          }
+        }
+      } else {
+        timelineBatch.push(...inputs);
+        if (timelineBatch.length >= BATCH_SIZE) await flushTimeline();
+      }
+    }
+  }
+
+  if (!opts.dryRun) {
+    await flushLinks();
+    await flushTimeline();
+  }
+
+  return result;
+}
+
+function buildChunks(compiledTruth: string, timeline: string, maxWords: number, overlapWords: number, maxChars: number): ChunkInput[] {
+  const chunks: ChunkInput[] = [];
+  if (compiledTruth.trim()) {
+    for (const c of chunkText(compiledTruth, { chunkSize: maxWords, chunkOverlap: overlapWords })) {
+      pushBoundedChunks(chunks, c.text, 'compiled_truth', maxChars);
+    }
+  }
+  if (timeline.trim()) {
+    for (const c of chunkText(timeline, { chunkSize: maxWords, chunkOverlap: overlapWords })) {
+      pushBoundedChunks(chunks, c.text, 'timeline', maxChars);
+    }
+  }
+  return chunks;
+}
+
+function pushBoundedChunks(chunks: ChunkInput[], text: string, source: 'compiled_truth' | 'timeline', maxChars: number) {
+  for (const part of splitByChars(text, maxChars)) {
+    chunks.push({
+      chunk_index: chunks.length,
+      chunk_text: part,
+      chunk_source: source,
+      token_count: wordCount(part),
+    });
+  }
+}
+
+function isTimelineEntity(type: PageType | undefined): boolean {
+  return type === 'person' || type === 'company';
+}
+
+function formatDate(value: string | Date): string {
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  return String(value).slice(0, 10);
+}
+
+function splitByChars(text: string, maxChars: number): string[] {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxChars) return [trimmed];
+
+  const parts: string[] = [];
+  let remaining = trimmed;
+  while (remaining.length > maxChars) {
+    let cut = Math.max(
+      remaining.lastIndexOf('\n\n', maxChars),
+      remaining.lastIndexOf('\n', maxChars),
+      remaining.lastIndexOf('. ', maxChars),
+      remaining.lastIndexOf(' ', maxChars),
+    );
+    if (cut < Math.floor(maxChars * 0.5)) cut = maxChars;
+    const head = remaining.slice(0, cut).trim();
+    if (head) parts.push(head);
+    remaining = remaining.slice(cut).trim();
+  }
+  if (remaining) parts.push(remaining);
+  return parts;
+}
+
+function parseArgs(args: string[]): OptimizeOpts {
+  const maxWords = numberFlag(args, '--max-words', DEFAULT_MAX_WORDS);
+  const overlapWords = numberFlag(args, '--overlap-words', Math.min(DEFAULT_OVERLAP_WORDS, Math.floor(maxWords / 6)));
+  const maxChars = numberFlag(args, '--max-chars', DEFAULT_MAX_CHARS);
+  if (maxWords < 50) throw new Error('--max-words must be >= 50.');
+  if (overlapWords < 0 || overlapWords >= maxWords) throw new Error('--overlap-words must be >= 0 and lower than --max-words.');
+  if (maxChars < 200) throw new Error('--max-chars must be >= 200.');
+
+  const typeIdx = args.indexOf('--type');
+  const typeFilter = typeIdx >= 0 && typeIdx + 1 < args.length ? args[typeIdx + 1] as PageType : undefined;
+  return {
+    dryRun: args.includes('--dry-run'),
+    jsonMode: args.includes('--json'),
+    maxWords,
+    overlapWords,
+    maxChars,
+    typeFilter,
+    skipExtract: args.includes('--no-extract'),
+  };
+}
+
+function numberFlag(args: string[], name: string, fallback: number): number {
+  const idx = args.indexOf(name);
+  if (idx < 0) return fallback;
+  const raw = args[idx + 1];
+  const value = Number(raw);
+  if (!Number.isFinite(value)) throw new Error(`Invalid ${name}: ${raw}`);
+  return Math.floor(value);
+}
+
+function wordCount(text: string): number {
+  return (text.match(/\S+/g) || []).length;
+}

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -3941,7 +3941,11 @@ export class PGLiteEngine implements BrainEngine {
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NOT NULL)::float /
           GREATEST((SELECT count(*) FROM content_chunks), 1)::float as embed_coverage,
         (SELECT count(*) FROM pages p
-         WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
+         WHERE EXISTS (
+           SELECT 1 FROM content_chunks cc
+           WHERE cc.page_id = p.id
+             AND (cc.embedded_at IS NULL OR cc.embedded_at < p.updated_at)
+         )
         ) as stale_pages,
         -- Bug 11 — orphan = islanded (no inbound AND no outbound).
         -- See BrainHealth.orphan_pages docstring; docs updated to match this.

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -3922,6 +3922,8 @@ export class PostgresEngine implements BrainEngine {
     // SQL required both — docs now match code so users can trust the
     // number. A hub page that links out to many but has no back-references
     // is working as intended, not an orphan.
+    // dead_links omitted (always 0 under ON DELETE CASCADE on link FKs).
+    // stale_pages tracks chunks whose embeddings are missing or older than the page content.
     const [h] = await sql`
       WITH entity_pages AS (
         SELECT id, slug FROM pages WHERE type IN ('person', 'company')
@@ -3931,7 +3933,11 @@ export class PostgresEngine implements BrainEngine {
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NOT NULL)::float /
           GREATEST((SELECT count(*) FROM content_chunks), 1)::float as embed_coverage,
         (SELECT count(*) FROM pages p
-         WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
+         WHERE EXISTS (
+           SELECT 1 FROM content_chunks cc
+           WHERE cc.page_id = p.id
+             AND (cc.embedded_at IS NULL OR cc.embedded_at < p.updated_at)
+         )
         ) as stale_pages,
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -34,6 +34,7 @@ describe('CLI structure', () => {
     expect(cliSource).toContain("'export'");
     expect(cliSource).toContain("'embed'");
     expect(cliSource).toContain("'files'");
+    expect(cliSource).toContain("'optimize'");
   });
 
   test('has formatResult function for CLI output', () => {
@@ -191,6 +192,19 @@ describe('CLI dispatch integration', () => {
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
+  });
+
+  test('optimize --help prints usage without DB connection', async () => {
+    const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', 'optimize', '--help'], {
+      cwd: new URL('..', import.meta.url).pathname,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    expect(stdout).toContain('Usage: gbrain optimize');
+    expect(stdout).toContain('Rechunk stale or oversized pages');
+    expect(exitCode).toBe(0);
   });
 
   test('--help prints global help', async () => {

--- a/test/optimize.test.ts
+++ b/test/optimize.test.ts
@@ -1,0 +1,192 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runOptimizeCore } from '../src/commands/optimize.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+async function truncateAll() {
+  for (const t of ['content_chunks', 'links', 'tags', 'raw_data', 'timeline_entries', 'page_versions', 'ingest_log', 'pages']) {
+    await (engine as any).db.exec(`DELETE FROM ${t}`);
+  }
+}
+
+describe('runOptimizeCore', () => {
+  beforeEach(truncateAll);
+
+  test('rebuilds stale oversized chunks into bounded chunks', async () => {
+    const body = Array.from({ length: 420 }, (_, i) => `word${i}`).join(' ');
+    await engine.putPage('sources/email-long', {
+      type: 'source',
+      title: 'Long email',
+      compiled_truth: body,
+      timeline: '',
+    });
+    await engine.upsertChunks('sources/email-long', [{
+      chunk_index: 0,
+      chunk_text: body,
+      chunk_source: 'compiled_truth',
+      token_count: 420,
+    }]);
+
+    const result = await runOptimizeCore(engine, {
+      dryRun: false,
+      jsonMode: false,
+      maxWords: 100,
+      overlapWords: 10,
+      maxChars: 1200,
+      skipExtract: true,
+    });
+
+    expect(result.pages_rechunked).toBe(1);
+    const chunks = await engine.getChunks('sources/email-long');
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every(c => (c.token_count ?? 0) <= 160)).toBe(true);
+  });
+
+  test('splits long single-token content by character budget', async () => {
+    const body = `prefix ${'x'.repeat(1500)} suffix`;
+    await engine.putPage('sources/long-token', {
+      type: 'source',
+      title: 'Long token',
+      compiled_truth: body,
+      timeline: '',
+    });
+
+    await runOptimizeCore(engine, {
+      dryRun: false,
+      jsonMode: false,
+      maxWords: 300,
+      overlapWords: 50,
+      maxChars: 500,
+      skipExtract: true,
+    });
+
+    const chunks = await engine.getChunks('sources/long-token');
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every(c => c.chunk_text.length <= 500)).toBe(true);
+  });
+
+  test('extracts db links and timeline as part of optimization', async () => {
+    await engine.putPage('people/alice', {
+      type: 'person',
+      title: 'Alice',
+      compiled_truth: '',
+      timeline: '',
+    });
+    await engine.putPage('companies/acme', {
+      type: 'company',
+      title: 'Acme',
+      compiled_truth: '[Alice](people/alice) joined as CEO.',
+      timeline: '- **2026-01-15** | Hired Alice',
+    });
+
+    const result = await runOptimizeCore(engine, {
+      dryRun: false,
+      jsonMode: false,
+      maxWords: 300,
+      overlapWords: 50,
+      maxChars: 1200,
+      skipExtract: false,
+    });
+
+    expect(result.links_created).toBe(1);
+    expect(result.timeline_entries_created).toBe(2);
+    const links = await engine.getLinks('companies/acme');
+    const timeline = await engine.getTimeline('companies/acme');
+    expect(links.map(l => l.to_slug)).toEqual(['people/alice']);
+    expect(timeline.map(t => t.summary)).toEqual(['Hired Alice']);
+  });
+
+  test('propagates dated source events to linked entity timelines', async () => {
+    await engine.putPage('people/alice', {
+      type: 'person',
+      title: 'Alice',
+      compiled_truth: '',
+      timeline: '',
+    });
+    await engine.putPage('meetings/acme-sync', {
+      type: 'meeting',
+      title: 'Acme Sync',
+      compiled_truth: '[Alice](people/alice) discussed pipeline.',
+      timeline: '- **2026-01-15** | Discussed pipeline',
+    });
+
+    const result = await runOptimizeCore(engine, {
+      dryRun: false,
+      jsonMode: false,
+      maxWords: 300,
+      overlapWords: 50,
+      maxChars: 1200,
+      skipExtract: false,
+    });
+
+    expect(result.links_created).toBe(1);
+    expect(result.timeline_entries_created).toBe(2);
+    expect((await engine.getTimeline('meetings/acme-sync')).map(t => t.summary)).toEqual(['Discussed pipeline']);
+    const entityTimeline = await engine.getTimeline('people/alice');
+    expect(entityTimeline.map(t => t.summary)).toEqual(['Discussed pipeline']);
+    expect(entityTimeline[0].source).toBe('meetings/acme-sync');
+  });
+
+  test('propagates structured timeline entries through entity backlinks', async () => {
+    await engine.putPage('people/alice', {
+      type: 'person',
+      title: 'Alice',
+      compiled_truth: '',
+      timeline: '',
+    });
+    await engine.putPage('meetings/acme-sync', {
+      type: 'meeting',
+      title: 'Acme Sync',
+      compiled_truth: 'Pipeline discussion.',
+      timeline: '',
+    });
+    await engine.addLink('people/alice', 'meetings/acme-sync', 'frontmatter.attendees: alice@example.com', 'attended', 'frontmatter', 'meetings/acme-sync', 'attendees');
+    await engine.addTimelineEntry('meetings/acme-sync', { date: '2026-01-15', summary: 'Discussed pipeline' });
+
+    const result = await runOptimizeCore(engine, {
+      dryRun: false,
+      jsonMode: false,
+      maxWords: 300,
+      overlapWords: 50,
+      maxChars: 1200,
+      skipExtract: false,
+    });
+
+    expect(result.timeline_entries_created).toBe(1);
+    const entityTimeline = await engine.getTimeline('people/alice');
+    expect(entityTimeline.map(t => t.summary)).toEqual(['Discussed pipeline']);
+    expect(entityTimeline[0].source).toBe('meetings/acme-sync');
+  });
+
+  test('dry-run reports work without writing', async () => {
+    await engine.putPage('people/alice', {
+      type: 'person',
+      title: 'Alice',
+      compiled_truth: '',
+      timeline: '- **2026-01-15** | Test',
+    });
+
+    const result = await runOptimizeCore(engine, {
+      dryRun: true,
+      jsonMode: true,
+      maxWords: 300,
+      overlapWords: 50,
+      maxChars: 1200,
+      skipExtract: false,
+    });
+
+    expect(result.timeline_entries_created).toBe(1);
+    expect(await engine.getTimeline('people/alice')).toHaveLength(0);
+  });
+});

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -1280,6 +1280,21 @@ describe('PGLiteEngine: getHealth graph metrics', () => {
     const h2 = await engine.getHealth();
     expect(h2.orphan_pages).toBe(1);
   });
+
+  test('stale_pages ignores newly created timeline entries', async () => {
+    await truncateAll();
+    await engine.putPage('people/alice', { ...testPage, type: 'person', title: 'Alice' });
+    await engine.upsertChunks('people/alice', [{
+      chunk_index: 0,
+      chunk_text: 'Alice embedded chunk',
+      chunk_source: 'compiled_truth',
+      embedding: new Float32Array(1536).fill(0.1),
+    }]);
+    await engine.addTimelineEntry('people/alice', { date: '2026-01-15', summary: 'Joined' });
+
+    const h = await engine.getHealth();
+    expect(h.stale_pages).toBe(0);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add official `gbrain optimize` command for rechunking stale/oversized pages
- enrich DB links and timeline entries during optimization
- fix stale page health metric so freshly-created timeline entries do not mark pages stale
- add focused CLI/PGLite/optimize tests

## Validation
- `bun run src/cli.ts optimize --help`
- `bun test test/cli.test.ts test/optimize.test.ts test/pglite-engine.test.ts` (125 pass, 0 fail)