### PR TITLE
fix(extract): don't split timeline bullets on bare hyphens

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -274,7 +274,7 @@ export function extractTimelineFromContent(content: string, slug: string): Extra
   const entries: ExtractedTimelineEntry[] = [];
 
   // Format 1: Bullet — - **YYYY-MM-DD** | Source — Summary
-  const bulletPattern = /^-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*(.+?)\s*[—–-]\s*(.+)$/gm;
+  const bulletPattern = /^-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*([^[\]()\n]{1,24}?) [—–] (.+)$/gm;
   let match;
   while ((match = bulletPattern.exec(content)) !== null) {
     entries.push({ slug, date: match[1], source: match[2].trim(), summary: match[3].trim() });

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -135,6 +135,22 @@ describe('extractTimelineFromContent', () => {
     const entries = extractTimelineFromContent(content, 'test');
     expect(entries).toHaveLength(1);
   });
+
+  it('does not split a hyphenated word in the bullet body (bare-hyphen regression)', () => {
+    // Regression: a hyphen inside a word (slug, compound) must not be read as the
+    // source/summary separator. Only a spaced em/en dash splits Source — Summary.
+    const content = `- **2025-05-13** | acme-consulting-group kickoff call`;
+    const entries = extractTimelineFromContent(content, 'test');
+    expect(entries.find((e) => e.source === 'acme')).toBeUndefined();
+  });
+
+  it('keeps hyphenated words intact in the summary when splitting on a spaced dash', () => {
+    const content = `- **2025-05-13** | Call — acme-consulting-group renewed`;
+    const entries = extractTimelineFromContent(content, 'test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].source).toBe('Call');
+    expect(entries[0].summary).toBe('acme-consulting-group renewed');
+  });
 });
 
 describe('walkMarkdownFiles', () => {


### PR DESCRIPTION
## Problem

`extractTimelineFromContent` (the `extract` / `sync` / dream-cycle timeline path) parses bullet timelines of the form:

    - **YYYY-MM-DD** | Source — Summary

The bullet regex split `Source — Summary` on the first `[—–-]` match. That character class includes the **bare hyphen**, and the source capture is non-greedy, so *any* hyphen in the bullet body triggered the split. Hyphenated words and slugs (`acme-consulting-group`, `architecture-fix`) got mangled into bogus `source` / `summary` pairs.

The `put_page` auto-timeline path uses a different parser that does not split this way, so a brain ingesting through both paths ends up with a mix of clean and mangled timeline rows.

## Fix

Split only on a **spaced em/en dash** (` — ` / ` – `), with a short bracket-free source guard so markdown links and long bodies can't trigger a mid-word split:

```
/^-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*([^[\]()\n]{1,24}?) [—–] (.+)$/gm
```

The intended `Source — Summary` convention (pinned at `test/extract.test.ts:104`) is preserved; only the bare-hyphen misfire is removed. The `### date — title` header pattern is unchanged (its dash must follow the date, so it never mis-splits mid-word).

## Tests

Two regression cases added to `test/extract.test.ts`:
- a hyphenated bullet body must not split mid-word;
- a real spaced-dash split keeps hyphenated words intact in the summary.

`bun test test/extract.test.ts` → 23 pass / 0 fail. Adjacent suites (`extract-fs`, `extract-db`, `link-extraction`) also green (116 pass).
