### PR TITLE
fix(cli): drain search retrieval writes before exit

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,7 @@ const CLI_ONLY_SELF_HELP = new Set([
   // generic short-circuit's one-line stub.
   'schema',
 ]);
+const SEARCH_NAMESPACE_SUBCOMMANDS = new Set(['modes', 'stats', 'tune']);
 
 async function main() {
   // Parse global flags (--quiet / --progress-json / --progress-interval)
@@ -93,6 +94,14 @@ async function main() {
   // DX alias: `ask` is a natural-language alias for `query`
   if (command === 'ask') {
     command = 'query';
+  }
+
+  // `gbrain search` is both a legacy operation (`gbrain search <query>`) and
+  // a newer command namespace (`gbrain search modes/stats/tune`). Route only
+  // the known namespace verbs here; all other invocations stay on the op path.
+  if (command === 'search' && (SEARCH_NAMESPACE_SUBCOMMANDS.has(subArgs[0] ?? '') || hasHelpFlag(subArgs))) {
+    await handleCliOnly(command, subArgs);
+    return;
   }
 
   // Per-command --help
@@ -190,6 +199,10 @@ async function main() {
     const result = JSON.parse(JSON.stringify(rawResult));
     const output = formatResult(op.name, result);
     if (output) process.stdout.write(output);
+    if (op.name === 'search' || op.name === 'query' || op.name === 'get_page') {
+      const { awaitPendingLastRetrievedWrites } = await import('./core/last-retrieved.ts');
+      await awaitPendingLastRetrievedWrites();
+    }
     if (op.name === 'query') {
       const { awaitPendingSearchCacheWrites } = await import('./core/search/hybrid.ts');
       await awaitPendingSearchCacheWrites();
@@ -1099,6 +1112,11 @@ async function handleCliOnly(command: string, args: string[]) {
   if (command === 'capture' && (args.includes('--help') || args.includes('-h'))) {
     const { runCapture } = await import('./commands/capture.ts');
     await runCapture(null, args);
+    return;
+  }
+  if (command === 'search' && (args.includes('--help') || args.includes('-h'))) {
+    const { runSearch } = await import('./commands/search.ts');
+    await runSearch(null as any, args);
     return;
   }
 

--- a/src/core/last-retrieved.ts
+++ b/src/core/last-retrieved.ts
@@ -38,6 +38,17 @@ import { isUndefinedColumnError } from './utils.ts';
 
 let _trackRetrievalCache: { ts: number; enabled: boolean } | null = null;
 const TRACK_RETRIEVAL_CACHE_TTL_MS = 30_000;
+const pendingRetrievalWrites = new Set<Promise<unknown>>();
+
+export async function awaitPendingLastRetrievedWrites(): Promise<void> {
+  if (pendingRetrievalWrites.size === 0) return;
+  await Promise.allSettled([...pendingRetrievalWrites]);
+}
+
+function trackRetrievalWrite(promise: Promise<unknown>): void {
+  pendingRetrievalWrites.add(promise);
+  promise.finally(() => pendingRetrievalWrites.delete(promise)).catch(() => { /* swallow */ });
+}
 
 /**
  * Resolve `search.track_retrieval` config with a 30s in-process cache so
@@ -78,7 +89,7 @@ export function _resetTrackRetrievalCacheForTests(): void {
 export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): void {
   if (pageIds.length === 0) return;
   // Fire-and-forget on purpose. We deliberately do NOT return the promise.
-  void (async () => {
+  trackRetrievalWrite((async () => {
     try {
       const enabled = await isTrackingEnabled(engine);
       if (!enabled) return;
@@ -101,5 +112,5 @@ export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): voi
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`[last-retrieved] write-back failed (best-effort): ${msg}`);
     }
-  })();
+  })());
 }

--- a/test/fix-wave-structural.test.ts
+++ b/test/fix-wave-structural.test.ts
@@ -4,6 +4,10 @@
  *
  *  - #1125 query drain cache writes — assert cli.ts awaits the drain after
  *    the query op completes.
+ *  - search CLI exit — assert cli.ts drains last_retrieved_at writes before
+ *    disconnecting after search/query/get_page.
+ *  - search namespace dispatch — assert `gbrain search modes/stats/tune`
+ *    routes before the legacy `search <query>` operation.
  *  - #1090 admin embed — assert the two-tier resolution (cwd path + embedded
  *    manifest fallback) is in serve-http.ts and consumes ADMIN_ASSETS.
  *  - #1077 admin register-client PKCE — assert the admin endpoint honors
@@ -33,6 +37,30 @@ describe('v0.36.1.x #1125 — query drain cache writes before CLI exit', () => {
     expect(src).toMatch(/export async function awaitPendingSearchCacheWrites/);
     expect(src).toMatch(/pendingCacheWrites\.add\(promise\)/);
     expect(src).toMatch(/trackCacheWrite\(/);
+  });
+});
+
+describe('search CLI one-shot cleanup', () => {
+  test('cli.ts drains last_retrieved_at write-backs before disconnecting', () => {
+    const src = readFileSync('src/cli.ts', 'utf8');
+    expect(src).toMatch(/op\.name\s*===\s*'search'[\s\S]{0,220}awaitPendingLastRetrievedWrites/);
+    expect(src).toMatch(/await\s+awaitPendingLastRetrievedWrites\(\)/);
+  });
+
+  test('last-retrieved.ts tracks pending write-back promises', () => {
+    const src = readFileSync('src/core/last-retrieved.ts', 'utf8');
+    expect(src).toContain('pendingRetrievalWrites');
+    expect(src).toMatch(/export async function awaitPendingLastRetrievedWrites/);
+    expect(src).toMatch(/trackRetrievalWrite\(/);
+  });
+});
+
+describe('search namespace dispatch', () => {
+  test('cli.ts routes search modes/stats/tune before the legacy search op', () => {
+    const src = readFileSync('src/cli.ts', 'utf8');
+    expect(src).toMatch(/SEARCH_NAMESPACE_SUBCOMMANDS\s*=\s*new Set\(\[['"]modes['"], ['"]stats['"], ['"]tune['"]\]\)/);
+    expect(src).toMatch(/command\s*===\s*'search'[\s\S]{0,180}SEARCH_NAMESPACE_SUBCOMMANDS\.has/);
+    expect(src).toMatch(/await handleCliOnly\(command,\s*subArgs\)/);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #1343.

- Drain pending `last_retrieved_at` write-backs before disconnecting one-shot `search`, `query`, and `get_page` CLI operations.
- Route `gbrain search modes|stats|tune` through the search namespace before the legacy `search <query>` operation.
- Add structural regression coverage for the cleanup drain and search namespace dispatch.

## Test Plan

- [x] `bun run src/cli.ts search "GBrain setup smoke test"` exits 0 without hanging
- [x] `bun run src/cli.ts search modes` exits 0 and prints the search mode dashboard
- [x] `bun run src/cli.ts query "GBrain setup smoke test" --no-expand` exits 0
- [x] `bun test test/fix-wave-structural.test.ts`
- [x] `bun run verify`

## Notes

The root cause was a fire-and-forget retrieval metadata write racing with PGLite disconnect in the one-shot CLI path. The command could print results successfully while leaving pending async work around the same engine. This PR tracks those write-back promises and drains them before disconnecting.
