### PR TITLE
fix: drain last-retrieved writes before CLI disconnect

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -199,6 +199,12 @@ async function main() {
     console.error(e instanceof Error ? e.message : String(e));
     process.exit(1);
   } finally {
+    try {
+      const { awaitPendingLastRetrievedWrites } = await import('./core/last-retrieved.ts');
+      await awaitPendingLastRetrievedWrites();
+    } catch {
+      // Best-effort shutdown drain only. Never mask the original command result.
+    }
     await engine.disconnect();
   }
 }

--- a/src/core/last-retrieved.ts
+++ b/src/core/last-retrieved.ts
@@ -38,6 +38,49 @@ import { isUndefinedColumnError } from './utils.ts';
 
 let _trackRetrievalCache: { ts: number; enabled: boolean } | null = null;
 const TRACK_RETRIEVAL_CACHE_TTL_MS = 30_000;
+const pendingLastRetrievedWrites = new Set<Promise<unknown>>();
+const LAST_RETRIEVED_SHUTDOWN_DRAIN_TIMEOUT_MS = 2_000;
+
+function trackLastRetrievedWrite(promise: Promise<unknown>): void {
+  pendingLastRetrievedWrites.add(promise);
+  promise.finally(() => pendingLastRetrievedWrites.delete(promise)).catch(() => {
+    /* swallow: write-back is best-effort */
+  });
+}
+
+/**
+ * Wait briefly for best-effort retrieval write-backs before closing the CLI
+ * engine.
+ *
+ * The visible op path still does not await `bumpLastRetrievedAt()`. This
+ * shutdown hook only prevents short-lived CLI processes from racing
+ * `engine.disconnect()` against a write-back that is already in flight. The
+ * timeout preserves the best-effort contract: a stuck write-back must not keep
+ * the CLI alive forever.
+ */
+export async function awaitPendingLastRetrievedWrites(
+  timeoutMs = LAST_RETRIEVED_SHUTDOWN_DRAIN_TIMEOUT_MS,
+): Promise<void> {
+  if (pendingLastRetrievedWrites.size === 0) return;
+  const pending = Promise.allSettled([...pendingLastRetrievedWrites]);
+  if (timeoutMs <= 0) {
+    await pending;
+    return;
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      pending,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs);
+        (timer as unknown as { unref?: () => void }).unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
 
 /**
  * Resolve `search.track_retrieval` config with a 30s in-process cache so
@@ -78,7 +121,7 @@ export function _resetTrackRetrievalCacheForTests(): void {
 export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): void {
   if (pageIds.length === 0) return;
   // Fire-and-forget on purpose. We deliberately do NOT return the promise.
-  void (async () => {
+  trackLastRetrievedWrite((async () => {
     try {
       const enabled = await isTrackingEnabled(engine);
       if (!enabled) return;
@@ -101,5 +144,5 @@ export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): voi
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`[last-retrieved] write-back failed (best-effort): ${msg}`);
     }
-  })();
+  })());
 }

--- a/test/last-retrieved.test.ts
+++ b/test/last-retrieved.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+import {
+  _resetTrackRetrievalCacheForTests,
+  awaitPendingLastRetrievedWrites,
+  bumpLastRetrievedAt,
+} from '../src/core/last-retrieved.ts';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('last retrieved write-back shutdown drain', () => {
+  beforeEach(async () => {
+    _resetTrackRetrievalCacheForTests();
+    await awaitPendingLastRetrievedWrites();
+  });
+
+  test('drains in-flight write-backs before CLI engine disconnect', async () => {
+    const gate = deferred();
+    const calls: Array<{ sql: string; params?: unknown[] }> = [];
+    const engine = {
+      getConfig: async () => null,
+      executeRaw: async (sql: string, params?: unknown[]) => {
+        calls.push({ sql, params });
+        await gate.promise;
+      },
+    } as unknown as BrainEngine;
+
+    bumpLastRetrievedAt(engine, [1, 2]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sql).toContain('UPDATE pages');
+    expect(calls[0].params).toEqual([[1, 2]]);
+
+    let drained = false;
+    const drain = awaitPendingLastRetrievedWrites().then(() => {
+      drained = true;
+    });
+    await Promise.resolve();
+    expect(drained).toBe(false);
+
+    gate.resolve();
+    await drain;
+    expect(drained).toBe(true);
+  });
+
+  test('does not surface best-effort write-back failures during drain', async () => {
+    const engine = {
+      getConfig: async () => null,
+      executeRaw: async () => {
+        throw new Error('simulated write-back failure');
+      },
+    } as unknown as BrainEngine;
+
+    bumpLastRetrievedAt(engine, [3]);
+    await expect(awaitPendingLastRetrievedWrites()).resolves.toBeUndefined();
+  });
+
+  test('times out instead of hanging forever on a stuck write-back', async () => {
+    const gate = deferred();
+    const engine = {
+      getConfig: async () => null,
+      executeRaw: async () => {
+        await gate.promise;
+      },
+    } as unknown as BrainEngine;
+
+    bumpLastRetrievedAt(engine, [4]);
+    await expect(awaitPendingLastRetrievedWrites(1)).resolves.toBeUndefined();
+
+    gate.resolve();
+    await awaitPendingLastRetrievedWrites(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Track in-flight `last_retrieved_at` write-back promises from `bumpLastRetrievedAt()`.
- Drain those best-effort writes briefly during CLI shutdown before `engine.disconnect()`.
- Add regression coverage for normal drain behavior, swallowed write-back failures, and bounded timeout behavior.

## Why

During isolated PGLite smoke testing, `gbrain get`, `gbrain search`, and `gbrain query --no-expand` could print their results and then fail to exit. The common path was retrieval tracking: `bumpLastRetrievedAt()` starts a fire-and-forget write-back, then the CLI closes the engine while that write is still in flight.

This keeps the visible operation path fire-and-forget, but gives short-lived CLI commands a shutdown drain so they do not race PGLite disconnect. The drain has a 2s default timeout so a stuck best-effort write-back cannot keep the CLI alive forever.

## Verification

- `bun test test/last-retrieved.test.ts`
- `bun run typecheck`
- Isolated CLI smoke with `GBRAIN_HOME=/tmp/...`:
  - `bun run src/cli.ts init --pglite --no-embedding --yes`
  - `bun run src/cli.ts put last-retrieved-smoke < /tmp/gbrain-pr-smoke-page.md`
  - `bun run src/cli.ts get last-retrieved-smoke`
  - `bun run src/cli.ts search 'last retrieved smoke'`
  - `bun run src/cli.ts query --no-expand 'last retrieved smoke'`
- `bun run check:test-names`
- Static scan of staged added lines for hardcoded secrets / shell injection / eval / unsafe deserialization / SQL string-formatting patterns: no findings.
- Independent reviewer pass: no blocking security or logic concerns.

Note: I also attempted `bun run verify`; it passed through privacy/proposal-PII/test-names/jsonb/source-id/progress/test-isolation checks, then local `check:wasm` was killed with exit 137 in this environment.
