### PR TITLE
fix: classify contextual synopsis transient errors

### DIFF
--- a/src/core/page-summary.ts
+++ b/src/core/page-summary.ts
@@ -209,7 +209,7 @@ function buildUserPrompt(
  * Gateway throws Anthropic-flavored errors with HTTP status info; we
  * pattern-match on those for the classification.
  */
-function classifyChatError(err: unknown): {
+export function classifyChatError(err: unknown): {
   kind: SynopsisFailureKind;
   detail: string;
 } {
@@ -218,12 +218,16 @@ function classifyChatError(err: unknown): {
   }
   const e = err as { status?: number; message?: string; code?: string; name?: string };
   const msg = (e.message ?? String(err)).slice(0, 200);
+  const msgLower = msg.toLowerCase();
 
   if (e.status === 401 || e.status === 403) {
     return { kind: 'auth_failure', detail: `status=${e.status} msg=${msg}` };
   }
-  if (e.status === 429) {
-    return { kind: 'rate_limit', detail: `status=429 msg=${msg}` };
+  if (
+    e.status === 429 ||
+    /rate limit|too many requests|cooling down|quota exceeded|temporarily unavailable/.test(msgLower)
+  ) {
+    return { kind: 'rate_limit', detail: `status=${e.status ?? '?'} msg=${msg}` };
   }
   if (e.status != null && e.status >= 500 && e.status < 600) {
     return { kind: 'provider_5xx', detail: `status=${e.status} msg=${msg}` };
@@ -231,7 +235,7 @@ function classifyChatError(err: unknown): {
   if (
     e.name === 'AbortError' ||
     e.code === 'ETIMEDOUT' ||
-    /timeout/i.test(msg)
+    /timeout|timed out|deadline exceeded|context canceled|context cancelled/.test(msgLower)
   ) {
     return { kind: 'timeout', detail: msg };
   }
@@ -239,7 +243,7 @@ function classifyChatError(err: unknown): {
     e.code === 'ENOTFOUND' ||
     e.code === 'ECONNREFUSED' ||
     e.code === 'ECONNRESET' ||
-    /network|fetch/i.test(msg)
+    /network|fetch|socket|eof|lock-lost|connection reset/.test(msgLower)
   ) {
     return { kind: 'network', detail: `code=${e.code ?? '?'} msg=${msg}` };
   }

--- a/test/page-summary-classify.test.ts
+++ b/test/page-summary-classify.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { classifyChatError } from '../src/core/page-summary.ts';
+
+describe('classifyChatError', () => {
+  test('treats provider cooldown text as rate_limit', () => {
+    expect(classifyChatError(new Error('All credentials for model gpt-5.5 are cooling down via provider codex')).kind).toBe('rate_limit');
+  });
+
+  test('treats timeout-shaped messages as timeout', () => {
+    expect(classifyChatError(new Error('The operation timed out.')).kind).toBe('timeout');
+    expect(classifyChatError(new Error('context deadline exceeded')).kind).toBe('timeout');
+  });
+
+  test('treats lock-lost and EOF as network transients', () => {
+    expect(classifyChatError(new Error('lock-lost')).kind).toBe('network');
+    expect(classifyChatError(new Error('Post "https://example.test": EOF')).kind).toBe('network');
+  });
+});


### PR DESCRIPTION
## Summary
- Classify provider cooldown text as rate_limit instead of malformed
- Classify timeout/deadline messages as timeout
- Classify lock-lost/EOF/socket errors as network transients

## Why
Contextual retrieval synopsis jobs can currently fall back to title-only when OpenAI-compatible providers return transient strings such as `All credentials ... cooling down`, `The operation timed out`, `lock-lost`, or EOF. These should be retryable/transient categories, not malformed output.

## Test Plan
- `bun --check src/core/page-summary.ts`
- `bun test test/page-summary-classify.test.ts`