### PR TITLE
fix: pass Ollama qwen3 embedding dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to GBrain will be documented in this file.
 
+## Unreleased
+
+- Ollama `qwen3-embedding` models now pass Matryoshka `embedding_dimensions` through the OpenAI-compatible provider options path. For example, `gbrain init --pglite --embedding-model ollama:qwen3-embedding:4B --embedding-dimensions 1536` creates a 1536d local PGLite brain and embeds through Ollama with the requested output width.
+
 ## [0.40.9.0] - 2026-05-24
 
 **`gbrain sync` now indexes your `.sql` files, and `gbrain code-def` works on SQL tables, functions, views, and indexes the same way it works on TypeScript.**

--- a/docs/integrations/embedding-providers.md
+++ b/docs/integrations/embedding-providers.md
@@ -140,7 +140,24 @@ Set `ZHIPUAI_API_KEY`. Models: `embedding-3` (current; Matryoshka 256-2048 dims)
 
 No env required — Ollama runs unauthenticated locally. Optional `OLLAMA_BASE_URL` (default `http://localhost:11434/v1`) and `OLLAMA_API_KEY` (for auth-enabled deployments).
 
-Recipe ships with `nomic-embed-text` (768d, recommended), `mxbai-embed-large` (1024d), `all-minilm` (384d). `gbrain providers test --model ollama:nomic-embed-text` smoke-tests the local install.
+Recipe ships with `nomic-embed-text` (768d, recommended), `qwen3-embedding:4B` (2560d native, Matryoshka-capable), `mxbai-embed-large` (1024d), `all-minilm` (384d). `gbrain providers test --model ollama:nomic-embed-text` smoke-tests the local install.
+
+For a local Qwen3 brain with a smaller pgvector column, request the Matryoshka output width at init time:
+
+```bash
+export OLLAMA_BASE_URL=http://localhost:11434/v1
+gbrain init --pglite \
+  --embedding-model ollama:qwen3-embedding:4B \
+  --embedding-dimensions 1536
+```
+
+Existing PGLite brains need a reinit because the pgvector column width is part of the schema:
+
+```bash
+gbrain reinit-pglite \
+  --embedding-model ollama:qwen3-embedding:4B \
+  --embedding-dimensions 1536
+```
 
 ### llama-server (local, llama.cpp)
 

--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -114,6 +114,7 @@ export function dimsProviderOptions(
   modelId: string,
   dims: number,
   inputType?: 'query' | 'document',
+  recipeId?: string,
 ): Record<string, any> | undefined {
   switch (implementation) {
     case 'native-openai': {
@@ -145,6 +146,15 @@ export function dimsProviderOptions(
       // Anthropic has no embedding model.
       return undefined;
     case 'openai-compatible':
+      // Ollama's OpenAI-compatible /v1/embeddings endpoint accepts
+      // `dimensions` for Matryoshka-capable local models such as
+      // qwen3-embedding:4B. The AI SDK forwards that field through the
+      // openai-compatible providerOptions namespace used by this recipe.
+      // The key is `openaiCompatible` because Ollama is registered through
+      // the openai-compatible adapter, not a dedicated Ollama adapter.
+      if (recipeId === 'ollama' && isOllamaQwen3EmbeddingModel(modelId)) {
+        return { openaiCompatible: { dimensions: dims } };
+      }
       // ZE zembed-1 — flexible Matryoshka dims + asymmetric input_type.
       // Lives BEFORE the generic openai-compatible fall-through to avoid
       // sending input_type to providers (Azure/DashScope/Zhipu) that
@@ -230,4 +240,8 @@ export function dimsProviderOptions(
       }
       return undefined;
   }
+}
+
+function isOllamaQwen3EmbeddingModel(modelId: string): boolean {
+  return /^qwen3-embedding(?::|$)/i.test(modelId);
 }

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -1161,6 +1161,7 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
     modelId,
     effectiveDims,
     opts?.inputType,
+    recipe.id,
   );
   const expected = effectiveDims;
 

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -13,7 +13,7 @@ export const ollama: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['nomic-embed-text', 'mxbai-embed-large', 'all-minilm'],
+      models: ['nomic-embed-text', 'qwen3-embedding:4B', 'mxbai-embed-large', 'all-minilm'],
       default_dims: 768, // nomic-embed-text native dim
       cost_per_1m_tokens_usd: 0,
       price_last_verified: '2026-04-20',

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -448,6 +448,18 @@ function isCustomDimValidForProvider(
         `OpenAI ${modelId} accepts dimensions 1..${maxDim}, got ${requestedDims}.`,
     };
   }
+  if (recipe.id === 'ollama') {
+    const maxQwen3Dim = ollamaQwen3EmbeddingMaxDim(modelId);
+    if (maxQwen3Dim !== null) {
+      if (requestedDims > 0 && requestedDims <= maxQwen3Dim) return { valid: true, error: '' };
+      return {
+        valid: false,
+        error:
+          `Ollama Qwen3 embedding model "${modelId}" accepts dimensions 1..${maxQwen3Dim}, ` +
+          `got ${requestedDims}.`,
+      };
+    }
+  }
 
   // Tier 3: provider not known to support custom dims at all.
   return {
@@ -457,4 +469,13 @@ function isCustomDimValidForProvider(
       `(this model only emits its default vector size). ` +
       `Either drop --embedding-dimensions or pick a Matryoshka-aware model.`,
   };
+}
+
+function ollamaQwen3EmbeddingMaxDim(modelId: string): number | null {
+  const normalized = modelId.toLowerCase();
+  if (!normalized.startsWith('qwen3-embedding')) return null;
+  if (normalized.includes('0.6b')) return 1024;
+  if (normalized.includes('4b')) return 2560;
+  if (normalized.includes('8b')) return 4096;
+  return null;
 }

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -173,6 +173,44 @@ describe('dims.dimsProviderOptions', () => {
     expect(opts).toBeUndefined();
   });
 
+  test('Ollama openai-compatible embeddings return dimensions', () => {
+    const opts = dimsProviderOptions(
+      'openai-compatible',
+      'qwen3-embedding:4B',
+      1536,
+      undefined,
+      'ollama',
+    );
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1536 } });
+  });
+
+  test('Ollama fixed-dim embeddings keep the previous no-dim fallback', () => {
+    const opts = dimsProviderOptions(
+      'openai-compatible',
+      'nomic-embed-text',
+      768,
+      undefined,
+      'ollama',
+    );
+    expect(opts).toBeUndefined();
+  });
+
+  test('openai-compatible without recipeId keeps the previous no-dim fallback', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'unknown-embed-model', 1536);
+    expect(opts).toBeUndefined();
+  });
+
+  test('non-Ollama openai-compatible recipes keep their provider-specific dimension routing', () => {
+    const opts = dimsProviderOptions(
+      'openai-compatible',
+      'voyage-3-large',
+      1024,
+      undefined,
+      'voyage',
+    );
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1024 } });
+  });
+
   test('Voyage flexible-dim models return dimensions for the SDK shim', () => {
     const opts = dimsProviderOptions('openai-compatible', 'voyage-3-large', 1024);
     expect(opts).toEqual({ openaiCompatible: { dimensions: 1024 } });

--- a/test/ai/recipes-existing-regression.test.ts
+++ b/test/ai/recipes-existing-regression.test.ts
@@ -96,6 +96,11 @@ describe('IRON RULE: existing 9 recipes survive the v0.32 resolveAuth refactor',
     expect(auth.token).toBe('Bearer unauthenticated');
   });
 
+  test('Ollama recipe advertises qwen3-embedding as an explicit model option', () => {
+    const ollama = getRecipe('ollama');
+    expect(ollama!.touchpoints.embedding?.models).toContain('qwen3-embedding:4B');
+  });
+
   test('URL-shaped optional env (OLLAMA_BASE_URL, LLAMA_SERVER_BASE_URL) does NOT become the Bearer token', () => {
     // Regression for the v0.32 default-fallback design: optional entries
     // ending in _URL or _BASE_URL are config (cfg.base_urls), not auth.
@@ -335,4 +340,3 @@ describe('default_headers / resolveDefaultHeaders contract (v0.37.2.0)', () => {
     expect(e.headers).toEqual({ 'X-Static': 'static-val' });
   });
 });
-

--- a/test/embedding-dim-check.test.ts
+++ b/test/embedding-dim-check.test.ts
@@ -220,6 +220,28 @@ describe('resolveSchemaEmbeddingDim', () => {
     if (got.ok) expect(got.dim).toBe(768);
   });
 
+  test('Ollama qwen3-embedding accepts explicit Matryoshka dimensions', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'ollama:qwen3-embedding:4B',
+      embedding_dimensions: 1536,
+    });
+    expect(got.ok).toBe(true);
+    if (got.ok) {
+      expect(got.provider).toBe('ollama');
+      expect(got.model).toBe('ollama:qwen3-embedding:4B');
+      expect(got.dim).toBe(1536);
+    }
+  });
+
+  test('Ollama qwen3-embedding rejects dimensions above the model native width', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'ollama:qwen3-embedding:4B',
+      embedding_dimensions: 4096,
+    });
+    expect(got.ok).toBe(false);
+    if (!got.ok) expect(got.error).toContain('accepts dimensions 1..2560');
+  });
+
   test('unknown provider rejected with provider list hint', () => {
     const got = resolveSchemaEmbeddingDim({ embedding_model: 'notarealprovider:foo' });
     expect(got.ok).toBe(false);


### PR DESCRIPTION
Summary:
- Thread recipe id into dimsProviderOptions so the Ollama recipe can pass Matryoshka dimensions through the OpenAI-compatible provider options namespace.
- Allow Ollama qwen3-embedding models through init-time embedding dimension preflight with model-size bounds.
- Document qwen3-embedding:4B setup with --embedding-dimensions 1536.

Why:
Ollama qwen3 embedding models support Matryoshka output dimensions, but gbrain previously dropped embedding_dimensions before the request reached the OpenAI-compatible embeddings adapter. Separately, init with ollama:qwen3-embedding:4B and --embedding-dimensions 1536 failed before runtime because the schema dimension preflight did not know qwen3 was Matryoshka-capable.

Verification:
- Focused Bun tests: 141 passed.
- Local runtime smoke: init 1536, import one Markdown page, query returned the imported page.
- Downstream UDKB readiness preflight observed Ollama direct embedding dimensions = 1536 and passed the gbrain source patch check.

Note:
For existing PGLite brains, use reinit-pglite with --embedding-model ollama:qwen3-embedding:4B --embedding-dimensions 1536 because pgvector column width is schema state.