### PR TITLE
fix(jobs): retry resets started_at + attempts counters

### DIFF
--- a/src/core/minions/queue.ts
+++ b/src/core/minions/queue.ts
@@ -450,12 +450,25 @@ export class MinionQueue {
     });
   }
 
-  /** Re-queue a failed or dead job for retry. */
+  /**
+   * Re-queue a failed or dead job for retry.
+   *
+   * Resets `started_at` and the attempts counters so the user-initiated retry
+   * gets a fresh wall-clock budget and a fresh max_attempts round. Without
+   * resetting `started_at`, the DB-side wall-clock detector
+   * (handleWallClockTimeouts) compares `now() - started_at` against
+   * `timeout_ms * 2` and immediately dead-letters any retry where more time
+   * has elapsed since the original start than the timeout window — which is
+   * always true for a job dead long enough that an operator notices and
+   * retries it. Preserving `stacktrace` retains debug history.
+   */
   async retryJob(id: number): Promise<MinionJob | null> {
     const rows = await this.engine.executeRaw<Record<string, unknown>>(
       `UPDATE minion_jobs SET status = 'waiting', error_text = NULL,
         lock_token = NULL, lock_until = NULL, delay_until = NULL,
-        finished_at = NULL, updated_at = now()
+        finished_at = NULL, started_at = NULL,
+        attempts_made = 0, attempts_started = 0,
+        updated_at = now()
        WHERE id = $1 AND status IN ('failed', 'dead')
        RETURNING *`,
       [id]

--- a/test/minions.test.ts
+++ b/test/minions.test.ts
@@ -640,6 +640,26 @@ describe('MinionQueue: Cancel & Retry', () => {
     expect(retried!.status).toBe('waiting');
     expect(retried!.error_text).toBeNull();
   });
+
+  test('retry resets started_at and attempts counters', async () => {
+    // Regression: pre-fix, retryJob left started_at populated from the
+    // original run. handleWallClockTimeouts then immediately dead-lettered
+    // the retry on the next worker tick because elapsed > timeout_ms * 2.
+    const job = await queue.add('sync', {}, { max_attempts: 1 });
+    await queue.claim('tok1', 30000, 'default', ['sync']);
+    await queue.failJob(job.id, 'tok1', 'error', 'dead');
+
+    const beforeRetry = await queue.getJob(job.id);
+    expect(beforeRetry!.started_at).not.toBeNull();
+    expect(beforeRetry!.attempts_made).toBe(1);
+    expect(beforeRetry!.attempts_started).toBe(1);
+
+    const retried = await queue.retryJob(job.id);
+    expect(retried!.status).toBe('waiting');
+    expect(retried!.started_at).toBeNull();
+    expect(retried!.attempts_made).toBe(0);
+    expect(retried!.attempts_started).toBe(0);
+  });
 });
 
 // --- Pause / Resume (5 tests) ---


### PR DESCRIPTION
## What

`gbrain jobs retry <id>` now resets `started_at`, `attempts_made`, and `attempts_started`. Pre-fix, those fields kept the original run's values, which made retries of long-dead jobs unrecoverable.

## Why

`handleWallClockTimeouts` (queue.ts) dead-letters any active job where `now() - started_at > timeout_ms * 2`. For a retry of a dead job, that elapsed time is essentially always exceeded — the operator only retries jobs they've noticed are dead, which by definition is well after the original timeout window.

Symptom pre-fix: `gbrain jobs retry 123` flips status `dead → waiting`, then the next worker tick (≤60s later) flips it `waiting → dead` again with `error_text="wall-clock timeout exceeded"` and `attempts_made` unchanged. No handler ever runs.

Validated locally on a Supabase brain: retried 9 dead jobs (from 2-4 days old), all 9 got re-dead-lettered within 60 seconds without the underlying scripts being invoked.

## The three resets

- `started_at = NULL` — the actual bug fix. The claim path does `started_at = COALESCE(started_at, now())` so a fresh start is recorded only when the retry is claimed.
- `attempts_made = 0` — gives the retry a fresh `max_attempts` round. Otherwise a 3/3 dead job would dead-letter again on first failure of the retry, defeating the explicit operator intent of "try this again."
- `attempts_started = 0` — consistency with `attempts_made`. Both track per-job attempt counters; resetting one but not the other would leave the job in an inconsistent state on the next dashboard render.

`stacktrace` is preserved across retries to retain debug history.

## Test

Extended the existing `retry dead job re-queues` test in `test/minions.test.ts` with a `retry resets started_at and attempts counters` case that asserts all three fields are reset and that pre-retry they hold the post-failure values. Original test still passes.

## Compat

The fields being reset are all already valid `NULL`/`0` states (set on insert), so existing consumers reading these fields see no new shapes. No schema change. No CLI signature change.

## Adjacent

Surfaced while operating on the alt-account-shared Postgres brain — same install where #1177 (`--lock-duration` / `--low-pri-rate-cap`) and #1185 (doctor dead-jobs surface) came from. Branch rooted on v0.35.8.0 to match those PRs' shape; happy to rebase forward if it would help land.