### PR TITLE
Make capture default to inbox source

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import type { CliOptions } from './core/cli-options.ts';
 import { callRemoteTool, RemoteMcpError, unpackToolResult } from './core/mcp-client.ts';
 import { maybePromptForUpgrade } from './core/thin-client-upgrade-prompt.ts';
 import { VERSION } from './version.ts';
+import { awaitPendingLastRetrievedWrites } from './core/last-retrieved.ts';
 
 // Build CLI name -> operation lookup
 const cliOps = new Map<string, Operation>();
@@ -194,6 +195,7 @@ async function main() {
       const { awaitPendingSearchCacheWrites } = await import('./core/search/hybrid.ts');
       await awaitPendingSearchCacheWrites();
     }
+    await awaitPendingLastRetrievedWrites();
   } catch (e: unknown) {
     if (e instanceof OperationError) {
       console.error(`Error [${e.code}]: ${e.message}`);

--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -103,11 +103,11 @@ Options:
   --slug SLUG          Override the default inbox/YYYY-MM-DD-<hash6> slug
   --type TYPE          Override the page type (default: note)
   --source ID          Multi-source brains: write under a non-default source.
-                       Resolution: --source flag > GBRAIN_SOURCE env >
-                       .gbrain-source dotfile (walk-up) > local_path >
-                       brain_default > 'default'. NOT supported on
-                       thin-client installs (server-side OAuth client
-                       registration scopes the source).
+                       Capture is inbox-first: without --source or
+                       GBRAIN_SOURCE it writes to 'default' and intentionally
+                       ignores .gbrain-source, local_path, and brain_default.
+                       NOT supported on thin-client installs (server-side
+                       OAuth client registration scopes the source).
   --quiet, -q          Print just the slug on stdout (for shell pipelines)
   --json               JSON output for agents
   --help, -h           Show this help
@@ -414,10 +414,11 @@ export async function runCapture(engine: BrainEngine | null, args: string[]): Pr
     process.exit(1);
   }
 
-  // CV15: route source resolution through the canonical 6-tier chain
-  // (flag → env → dotfile → local_path → brain_default → seed_default).
-  // resolveSourceWithTier handles the assertSourceExists check and throws
-  // a friendly error BEFORE put_page is called if the source is missing.
+  // Capture is human inbox-first. It honors explicit operator intent via
+  // --source or GBRAIN_SOURCE, but intentionally ignores cwd-derived source
+  // hints (.gbrain-source/local_path) and brain_default. Those are correct for
+  // repo/source operations; they are surprising for "save this thought".
+  // resolveSourceWithTier is still used for explicit/env validation.
   // Only run on the LOCAL path — thin-client has no engine handle to
   // probe the sources table; CV7 above already rejected explicit --source
   // on thin-client. Implicit source resolution on thin-client uses
@@ -425,8 +426,10 @@ export async function runCapture(engine: BrainEngine | null, args: string[]): Pr
   let resolvedSourceId = 'default';
   if (!isThinClient(cfg) && engine) {
     try {
-      const { source_id } = await resolveSourceWithTier(engine, parsed.source ?? null);
-      resolvedSourceId = source_id;
+      if (parsed.source || process.env.GBRAIN_SOURCE) {
+        const { source_id } = await resolveSourceWithTier(engine, parsed.source ?? null);
+        resolvedSourceId = source_id;
+      }
     } catch (e) {
       // assertSourceExists throws "Source 'X' not found. Available sources: ..."
       console.error(`gbrain capture: ${e instanceof Error ? e.message : String(e)}`);
@@ -522,10 +525,9 @@ export async function runCapture(engine: BrainEngine | null, args: string[]): Pr
     },
     dryRun: false,
     remote: false,
-    // v0.39.3.0 CV15: thread the resolved source from the canonical 6-tier
-    // chain (was `parsed.source ?? 'default'` pre-fix, which silently
-    // ignored env / dotfile / local_path / brain_default tiers — divergent
-    // from every other CLI op's behavior).
+    // Capture-specific source policy: explicit --source and GBRAIN_SOURCE are
+    // honored; cwd-derived source hints are ignored so plain capture remains a
+    // general inbox command.
     sourceId: resolvedSourceId,
   };
   try {

--- a/src/core/last-retrieved.ts
+++ b/src/core/last-retrieved.ts
@@ -38,6 +38,7 @@ import { isUndefinedColumnError } from './utils.ts';
 
 let _trackRetrievalCache: { ts: number; enabled: boolean } | null = null;
 const TRACK_RETRIEVAL_CACHE_TTL_MS = 30_000;
+const pendingWrites = new Set<Promise<void>>();
 
 /**
  * Resolve `search.track_retrieval` config with a 30s in-process cache so
@@ -78,7 +79,7 @@ export function _resetTrackRetrievalCacheForTests(): void {
 export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): void {
   if (pageIds.length === 0) return;
   // Fire-and-forget on purpose. We deliberately do NOT return the promise.
-  void (async () => {
+  const write = (async () => {
     try {
       const enabled = await isTrackingEnabled(engine);
       if (!enabled) return;
@@ -102,4 +103,13 @@ export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): voi
       console.warn(`[last-retrieved] write-back failed (best-effort): ${msg}`);
     }
   })();
+  pendingWrites.add(write);
+  void write.finally(() => {
+    pendingWrites.delete(write);
+  });
+}
+
+export async function awaitPendingLastRetrievedWrites(): Promise<void> {
+  if (pendingWrites.size === 0) return;
+  await Promise.allSettled([...pendingWrites]);
 }

--- a/test/commands/capture.test.ts
+++ b/test/commands/capture.test.ts
@@ -20,6 +20,7 @@ import { runCapture, __testing } from '../../src/commands/capture.ts';
 let engine: PGLiteEngine;
 let tmpRoot: string;
 let brainDir: string;
+const originalCwd = process.cwd();
 
 beforeAll(async () => {
   engine = new PGLiteEngine();
@@ -28,10 +29,12 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  process.chdir(originalCwd);
   await engine.disconnect();
 });
 
 beforeEach(async () => {
+  process.chdir(originalCwd);
   await resetPgliteState(engine);
   tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gbrain-capture-'));
   brainDir = path.join(tmpRoot, 'brain');
@@ -204,6 +207,109 @@ describe('capture — local install integration', () => {
     const page = await engine.getPage('inbox/from-file');
     expect(page).not.toBeNull();
     expect(page?.compiled_truth).toContain('body content here');
+  });
+
+  test('plain capture ignores cwd .gbrain-source and writes to default inbox', async () => {
+    const repoDir = path.join(tmpRoot, 'repo');
+    const repoMirror = path.join(brainDir, '.sources', 'repo-src');
+    fs.mkdirSync(repoDir, { recursive: true });
+    fs.mkdirSync(repoMirror, { recursive: true });
+    fs.writeFileSync(path.join(repoDir, '.gbrain-source'), 'repo-src\n');
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path) VALUES ('repo-src', 'repo-src', $1)
+       ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path`,
+      [repoMirror],
+    );
+
+    const logCaptured: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logCaptured.push(args.map(String).join(' '));
+    try {
+      process.chdir(repoDir);
+      await runCapture(engine, ['--slug', 'inbox/plain-default', '--quiet', 'plain capture']);
+    } finally {
+      console.log = origLog;
+      process.chdir(originalCwd);
+    }
+
+    expect(logCaptured[0]).toBe('inbox/plain-default');
+    const defaultPage = await engine.getPage('inbox/plain-default', { sourceId: 'default' });
+    const sourcePage = await engine.getPage('inbox/plain-default', { sourceId: 'repo-src' });
+    expect(defaultPage).not.toBeNull();
+    expect(sourcePage).toBeNull();
+    expect(fs.existsSync(path.join(brainDir, 'inbox/plain-default.md'))).toBe(true);
+    expect(fs.existsSync(path.join(repoMirror, 'inbox/plain-default.md'))).toBe(false);
+  });
+
+  test('--source still routes capture to the explicit source', async () => {
+    const explicitMirror = path.join(brainDir, '.sources', 'explicit-src');
+    fs.mkdirSync(explicitMirror, { recursive: true });
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path) VALUES ('explicit-src', 'explicit-src', $1)
+       ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path`,
+      [explicitMirror],
+    );
+
+    const logCaptured: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logCaptured.push(args.map(String).join(' '));
+    try {
+      await runCapture(engine, [
+        '--source',
+        'explicit-src',
+        '--slug',
+        'inbox/explicit-source',
+        '--quiet',
+        'explicit capture',
+      ]);
+    } finally {
+      console.log = origLog;
+    }
+
+    expect(logCaptured[0]).toBe('inbox/explicit-source');
+    const defaultPage = await engine.getPage('inbox/explicit-source', { sourceId: 'default' });
+    const sourcePage = await engine.getPage('inbox/explicit-source', { sourceId: 'explicit-src' });
+    expect(defaultPage).toBeNull();
+    expect(sourcePage).not.toBeNull();
+    expect(fs.existsSync(path.join(explicitMirror, 'inbox/explicit-source.md'))).toBe(true);
+  });
+
+  test('GBRAIN_SOURCE still routes capture to the operator-selected source', async () => {
+    const envMirror = path.join(brainDir, '.sources', 'env-src');
+    fs.mkdirSync(envMirror, { recursive: true });
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path) VALUES ('env-src', 'env-src', $1)
+       ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path`,
+      [envMirror],
+    );
+
+    const logCaptured: string[] = [];
+    const origLog = console.log;
+    const previousEnv = process.env.GBRAIN_SOURCE;
+    console.log = (...args: unknown[]) => logCaptured.push(args.map(String).join(' '));
+    try {
+      process.env.GBRAIN_SOURCE = 'env-src';
+      await runCapture(engine, [
+        '--slug',
+        'inbox/env-source',
+        '--quiet',
+        'env capture',
+      ]);
+    } finally {
+      console.log = origLog;
+      if (previousEnv === undefined) {
+        delete process.env.GBRAIN_SOURCE;
+      } else {
+        process.env.GBRAIN_SOURCE = previousEnv;
+      }
+    }
+
+    expect(logCaptured[0]).toBe('inbox/env-source');
+    const defaultPage = await engine.getPage('inbox/env-source', { sourceId: 'default' });
+    const sourcePage = await engine.getPage('inbox/env-source', { sourceId: 'env-src' });
+    expect(defaultPage).toBeNull();
+    expect(sourcePage).not.toBeNull();
+    expect(fs.existsSync(path.join(envMirror, 'inbox/env-source.md'))).toBe(true);
   });
 
   test('--json emits structured output', async () => {


### PR DESCRIPTION
## Objective

Make `gbrain capture "thought"` safe as a human inbox command when run from inside repos that have `.gbrain-source`, while preserving explicit source routing for operators.

## Changes

- Plain capture now writes to the default inbox source unless `--source` or `GBRAIN_SOURCE` is set.
- `--source <id>` still routes capture to the explicit source.
- `GBRAIN_SOURCE=<id>` still routes capture to the operator-selected source.
- Capture help now documents the inbox-first policy.
- Existing local branch also includes the CLI hang fix for pending `last_retrieved_at` writebacks.

## Verification

- `bun test test/commands/capture.test.ts test/source-resolver-with-tier.test.ts`: 35 pass, 0 fail
- `git diff --check`

## Context

This came from Axiom issue #9: plain capture from `/Users/mike/axiom` inherited `.gbrain-source` and wrote to the Axiom source mirror instead of the general inbox. For human-facing quick capture, cwd source inheritance is surprising; repo/source writes should be explicit.
