### PR TITLE
fix: keep DashScope embedding requests within limits

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1466,6 +1466,7 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   const envFromConfig: Record<string, string> = {};
   if (c.openai_api_key) envFromConfig.OPENAI_API_KEY = c.openai_api_key;
   if (c.anthropic_api_key) envFromConfig.ANTHROPIC_API_KEY = c.anthropic_api_key;
+  if (c.dashscope_api_key) envFromConfig.DASHSCOPE_API_KEY = c.dashscope_api_key;
   // v0.37 fix wave (CDX2-5+6): ZE became the default provider in v0.36 but
   // the env-mapping at this seam never picked it up. `gbrain config set
   // zeroentropy_api_key X` wrote DB plane (ignored by gateway). The file-

--- a/src/core/chunkers/recursive.ts
+++ b/src/core/chunkers/recursive.ts
@@ -10,9 +10,8 @@
  *   5. Words (whitespace + CJK char-slice fallback)
  *
  * Config: 300-word chunks with 50-word sentence-aware overlap.
- * v0.32.7: maxChars hard cap (default 6000) sliding-window safety belt
- * guarantees no chunk overflows OpenAI's 8192-token embedding limit even
- * on pathological CJK / whitespace-less text.
+ * maxChars hard cap (default 1500) keeps provider inputs conservative for
+ * embedding models with low per-item ceilings such as DashScope text-embedding-v2.
  *
  * Lossless invariant: non-overlapping portions reassemble to original.
  */
@@ -25,7 +24,7 @@ import { countCJKAwareWords, CJK_SENTENCE_DELIMITERS, CJK_CLAUSE_DELIMITERS } fr
  * rebuild them on the new shape. Bump on any change that affects chunk
  * boundaries (delimiters, word counting, maxChars cap).
  */
-export const MARKDOWN_CHUNKER_VERSION = 2;
+export const MARKDOWN_CHUNKER_VERSION = 3;
 
 const DELIMITERS: string[][] = [
   ['\n\n'],                          // L0: paragraphs
@@ -38,7 +37,7 @@ const DELIMITERS: string[][] = [
 export interface ChunkOptions {
   chunkSize?: number;    // target words per chunk (default 300)
   chunkOverlap?: number; // overlap words (default 50)
-  maxChars?: number;     // hard cap on any chunk's char length (default 6000)
+  maxChars?: number;     // hard cap on any chunk's char length (default 1500)
 }
 
 export interface TextChunk {
@@ -63,7 +62,7 @@ import { stripFactsFence } from '../facts-fence.ts';
 export function chunkText(text: string, opts?: ChunkOptions): TextChunk[] {
   const chunkSize = opts?.chunkSize || 300;
   const chunkOverlap = opts?.chunkOverlap || 50;
-  const maxChars = opts?.maxChars || 6000;
+  const maxChars = opts?.maxChars || 1500;
 
   if (!text || text.trim().length === 0) return [];
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -41,6 +41,8 @@ export interface GBrainConfig {
    * merge → buildGatewayConfig env dict → recipe reads ZEROENTROPY_API_KEY.
    */
   zeroentropy_api_key?: string;
+  /** DashScope API key for Alibaba-compatible embeddings/chat recipes. */
+  dashscope_api_key?: string;
   /** AI gateway config (v0.14+). v0.36+ default: "zeroentropyai:zembed-1" / 1280 / "anthropic:claude-haiku-4-5-20251001". */
   embedding_model?: string;
   embedding_dimensions?: number;
@@ -406,6 +408,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'database_path',
   'openai_api_key',
   'anthropic_api_key',
+  'dashscope_api_key',
+  'zeroentropy_api_key',
   'embedding_model',
   'embedding_dimensions',
   'embedding_disabled',

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -81,12 +81,13 @@ export interface EmbedBatchOptions {
 }
 
 /**
- * Embed a batch of texts via the gateway. Sub-batches of 100 so upstream
- * progress callbacks fire incrementally on large imports. The gateway owns
- * adaptive batch splitting and per-recipe token-budget logic; this paginator
- * is purely about progress-callback granularity.
+ * Embed a batch of texts via the gateway. Sub-batches of 25 so OpenAI-compatible
+ * providers with low per-request item ceilings (notably DashScope) never see an
+ * oversized embedMany request before the gateway's token-budget splitter runs.
+ * The gateway still owns adaptive token splitting and provider-specific retries;
+ * this paginator is about item-count safety and progress-callback granularity.
  */
-const BATCH_SIZE = 100;
+const BATCH_SIZE = 25;
 export async function embedBatch(
   texts: string[],
   options: EmbedBatchOptions = {},

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -177,9 +177,9 @@ export interface PageInput {
   /** v0.29.1: basename without extension captured at import. */
   import_filename?: string | null;
   /**
-   * v0.32.7 CJK wave: bumped to MARKDOWN_CHUNKER_VERSION (2) on import so the
+   * v0.32.7+: bumped to MARKDOWN_CHUNKER_VERSION on import so the
    * post-upgrade `gbrain reindex --markdown` sweep can find pre-bump pages
-   * via `WHERE chunker_version < 2`. Defaults to 1 at the schema level when
+   * via `WHERE chunker_version < current`. Defaults to 1 at the schema level when
    * omitted (existing rows pre-migration inherit 1; new imports overwrite
    * with the current version).
    */

--- a/test/ai/build-gateway-config.test.ts
+++ b/test/ai/build-gateway-config.test.ts
@@ -85,3 +85,23 @@ describe('buildGatewayConfig env-baseURL passthrough', () => {
     );
   });
 });
+
+describe('buildGatewayConfig provider API key mapping', () => {
+  test('dashscope_api_key maps into DASHSCOPE_API_KEY when env is unset', async () => {
+    await withEnv({ DASHSCOPE_API_KEY: undefined }, async () => {
+      const cfg = buildGatewayConfig({
+        dashscope_api_key: 'sk-dashscope-from-config',
+      } as unknown as GBrainConfig);
+      expect(cfg.env?.DASHSCOPE_API_KEY).toBe('sk-dashscope-from-config');
+    });
+  });
+
+  test('DASHSCOPE_API_KEY env wins over dashscope_api_key config', async () => {
+    await withEnv({ DASHSCOPE_API_KEY: 'sk-dashscope-from-env' }, async () => {
+      const cfg = buildGatewayConfig({
+        dashscope_api_key: 'sk-dashscope-from-config',
+      } as unknown as GBrainConfig);
+      expect(cfg.env?.DASHSCOPE_API_KEY).toBe('sk-dashscope-from-env');
+    });
+  });
+});

--- a/test/chunkers/recursive.test.ts
+++ b/test/chunkers/recursive.test.ts
@@ -134,10 +134,10 @@ describe('Recursive Text Chunker', () => {
   });
 });
 
-describe('CJK chunking (v0.32.7)', () => {
-  test('MARKDOWN_CHUNKER_VERSION is 2', async () => {
+describe('CJK chunking (v0.32.7+)', () => {
+  test('MARKDOWN_CHUNKER_VERSION is 3', async () => {
     const mod = await import('../../src/core/chunkers/recursive.ts');
-    expect(mod.MARKDOWN_CHUNKER_VERSION).toBe(2);
+    expect(mod.MARKDOWN_CHUNKER_VERSION).toBe(3);
   });
 
   test('long pure-Chinese paragraph splits into multiple chunks', () => {
@@ -201,6 +201,15 @@ describe('CJK chunking (v0.32.7)', () => {
     expect(chunks.length).toBeGreaterThanOrEqual(2);
     for (const c of chunks) {
       expect(c.text.length).toBeLessThanOrEqual(6000);
+    }
+  });
+
+  test('default maxChars caps whitespace-less inputs at 1500 chars', () => {
+    const text = 'a'.repeat(5000);
+    const chunks = chunkText(text, { chunkSize: 100000, chunkOverlap: 0 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.text.length).toBeLessThanOrEqual(1500);
     }
   });
 

--- a/test/embedding-batch-size.serial.test.ts
+++ b/test/embedding-batch-size.serial.test.ts
@@ -1,0 +1,40 @@
+/**
+ * embedBatch item-count pagination. Quarantined as serial because mock.module
+ * replaces the gateway module for this process.
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+
+const gatewayEmbed = mock(async (texts: string[]) =>
+  texts.map(() => new Float32Array(1536)),
+);
+
+mock.module('../src/core/ai/gateway.ts', () => ({
+  embed: gatewayEmbed,
+  embedOne: async () => new Float32Array(1536),
+  embedQuery: async () => new Float32Array(1536),
+  getEmbeddingModel: () => 'dashscope:text-embedding-v2',
+  getEmbeddingDimensions: () => 1536,
+  embedMultimodal: async () => [],
+  embedMultimodalSafe: async () => ({ embeddings: [], failedIndices: [] }),
+  embedQueryMultimodal: async () => new Float32Array(1536),
+  embedQueryMultimodalImage: async () => new Float32Array(1536),
+}));
+
+describe('embedBatch item-count pagination', () => {
+  test('splits 26 texts into 25 + 1 before calling the gateway', async () => {
+    gatewayEmbed.mockClear();
+    const { embedBatch } = await import('../src/core/embedding.ts');
+    const progress: Array<[number, number]> = [];
+
+    const texts = Array.from({ length: 26 }, (_, i) => `text-${i}`);
+    const result = await embedBatch(texts, {
+      onBatchComplete: (done, total) => progress.push([done, total]),
+    });
+
+    expect(result).toHaveLength(26);
+    expect(gatewayEmbed).toHaveBeenCalledTimes(2);
+    expect(gatewayEmbed.mock.calls.map(([textsArg]) => textsArg.length)).toEqual([25, 1]);
+    expect(progress).toEqual([[25, 26], [26, 26]]);
+  });
+});


### PR DESCRIPTION
## Summary
- map dashscope_api_key from GBrain config into DASHSCOPE_API_KEY
- cap embedBatch item pagination at 25 to avoid DashScope/OpenAI-compatible request item limits
- reduce default markdown chunk maxChars to 1500 and bump MARKDOWN_CHUNKER_VERSION to 3

## Tests
- bun test test/chunkers/recursive.test.ts test/ai/build-gateway-config.test.ts test/embedding-batch-size.serial.test.ts
- bun test test/ai/recipe-dashscope.test.ts test/ai/adaptive-embed-batch.test.ts
- bun run typecheck
- scripts/check-test-isolation.sh