### PR TITLE
fix: drain last_retrieved writes before CLI exit

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { parseGlobalFlags, setCliOptions, getCliOptions } from './core/cli-optio
 import type { CliOptions } from './core/cli-options.ts';
 import { callRemoteTool, RemoteMcpError, unpackToolResult } from './core/mcp-client.ts';
 import { maybePromptForUpgrade } from './core/thin-client-upgrade-prompt.ts';
+import { awaitPendingLastRetrievedWrites } from './core/last-retrieved.ts';
 import { VERSION } from './version.ts';
 
 // Build CLI name -> operation lookup
@@ -190,6 +191,7 @@ async function main() {
     const result = JSON.parse(JSON.stringify(rawResult));
     const output = formatResult(op.name, result);
     if (output) process.stdout.write(output);
+    await awaitPendingLastRetrievedWrites();
     if (op.name === 'query') {
       const { awaitPendingSearchCacheWrites } = await import('./core/search/hybrid.ts');
       await awaitPendingSearchCacheWrites();

--- a/src/core/last-retrieved.ts
+++ b/src/core/last-retrieved.ts
@@ -38,6 +38,7 @@ import { isUndefinedColumnError } from './utils.ts';
 
 let _trackRetrievalCache: { ts: number; enabled: boolean } | null = null;
 const TRACK_RETRIEVAL_CACHE_TTL_MS = 30_000;
+const pendingWrites = new Set<Promise<void>>();
 
 /**
  * Resolve `search.track_retrieval` config with a 30s in-process cache so
@@ -67,6 +68,12 @@ export function _resetTrackRetrievalCacheForTests(): void {
   _trackRetrievalCache = null;
 }
 
+/** Test/CLI seam: wait for best-effort write-backs that were already started. */
+export async function awaitPendingLastRetrievedWrites(): Promise<void> {
+  if (pendingWrites.size === 0) return;
+  await Promise.allSettled(Array.from(pendingWrites));
+}
+
 /**
  * Bump `last_retrieved_at` on the given page_ids. Fire-and-forget — caller
  * MUST NOT await this for the op response. Empty ids list is a no-op.
@@ -78,7 +85,7 @@ export function _resetTrackRetrievalCacheForTests(): void {
 export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): void {
   if (pageIds.length === 0) return;
   // Fire-and-forget on purpose. We deliberately do NOT return the promise.
-  void (async () => {
+  const write = (async () => {
     try {
       const enabled = await isTrackingEnabled(engine);
       if (!enabled) return;
@@ -101,5 +108,8 @@ export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): voi
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`[last-retrieved] write-back failed (best-effort): ${msg}`);
     }
-  })();
+  })().finally(() => {
+    pendingWrites.delete(write);
+  });
+  pendingWrites.add(write);
 }

--- a/test/cli-last-retrieved-lifecycle.test.ts
+++ b/test/cli-last-retrieved-lifecycle.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression: short-lived read commands must print their result and then exit.
+ *
+ * `get`/`search` start a best-effort last_retrieved_at write-back after the
+ * visible result is known. The CLI must drain that already-started write before
+ * disconnecting PGLite; otherwise wrappers that wait for process exit hang.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { importFromContent } from '../src/core/import-file.ts';
+
+let tmpHome: string;
+let dbPath: string;
+
+function runCli(args: string[]) {
+  const result = spawnSync('bun', ['run', 'src/cli.ts', ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    timeout: 3000,
+    env: {
+      ...process.env,
+      GBRAIN_HOME: tmpHome,
+      GBRAIN_NO_BANNER: '1',
+    },
+  });
+  return {
+    status: result.status,
+    signal: result.signal,
+    error: result.error,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+beforeAll(async () => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'gbrain-cli-lifecycle-'));
+  const configDir = join(tmpHome, '.gbrain');
+  mkdirSync(configDir, { recursive: true });
+  dbPath = join(configDir, 'brain.pglite');
+  writeFileSync(
+    join(configDir, 'config.json'),
+    JSON.stringify({ engine: 'pglite', database_path: dbPath }, null, 2),
+  );
+
+  const engine = new PGLiteEngine();
+  await engine.connect({ engine: 'pglite', database_path: dbPath });
+  await engine.initSchema();
+  await importFromContent(
+    engine,
+    '20-wiki/brain-operating-contract',
+    '---\ntype: wiki\ntitle: Brain Operating Contract\n---\n# Brain Operating Contract\n\nbrain operating contract lifecycle fixture.\n',
+    { noEmbed: true, sourceId: 'default' },
+  );
+  await engine.disconnect();
+});
+
+afterAll(() => {
+  if (tmpHome) rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe('CLI last_retrieved_at lifecycle', () => {
+  test('search emits output and exits cleanly', () => {
+    const result = runCli(['search', 'brain operating contract', '--source', 'default', '--limit', '1']);
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('20-wiki/brain-operating-contract');
+  });
+
+  test('get emits output and exits cleanly', () => {
+    const result = runCli(['get', '20-wiki/brain-operating-contract', '--source', 'default']);
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Brain Operating Contract');
+  });
+});


### PR DESCRIPTION
## Summary
- Track pending last_retrieved_at write-backs started by read operations.
- Drain those already-started writes before the local CLI disconnects its engine.
- Add a regression test proving search/get print output and exit cleanly.

## Why
Short-lived CLI commands can print their result but keep the process alive because best-effort last_retrieved_at write-backs are still racing engine disconnect. Callers that wait for process exit then see a hang even though stdout is already present.

## Tests
- bun test test/cli-last-retrieved-lifecycle.test.ts test/search-telemetry.test.ts
- bun run typecheck
- git diff --check
- timeout 5 bun src/cli.ts search 'brain operating contract' --source moeed-brain --limit 1
- timeout 5 bun src/cli.ts get '20-wiki/brain-operating-contract' --source moeed-brain