### PR TITLE
feat(serve): multi-client MCP via socket multiplexer + stdio proxy

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1102,6 +1102,47 @@ async function handleCliOnly(command: string, args: string[]) {
     return;
   }
 
+  // Pre-connect proxy fallback for `gbrain serve` (stdio path only).
+  //
+  // Problem: PGLite is single-process-per-data-dir. When Claude.app spawns
+  // `gbrain serve` from claude_desktop_config.json AND its claude-code-spawn
+  // child sessions ALSO pass `--mcp-config '...gbrain serve...'`, every
+  // child invocation tries to acquire the same PGLite lock and dies. The
+  // child sessions end up with no `mcp__gbrain__*` tools.
+  //
+  // Fix: if another live `gbrain serve` already holds the lock, become a
+  // stdio proxy to its multiplexer (src/mcp/multiplexer.ts) instead of
+  // failing on the lock. The owner sees us as a new MCP client on a
+  // socket transport; our parent (the client that spawned us) sees a
+  // working `gbrain serve` over stdio.
+  //
+  // Only triggers when: command === 'serve', not --http, PGLite engine
+  // with a configured data_dir, lock present, lock command contains
+  // 'serve', and the holder PID is still alive. Any miss falls through
+  // to the normal acquire path, which will surface a clean error or
+  // reclaim a stale lock as before.
+  if (command === 'serve' && !args.includes('--http')) {
+    const cfgForProxy = loadConfig();
+    const dataDir = cfgForProxy?.database_path;
+    if (dataDir) {
+      const { readLockInfo } = await import('./core/pglite-lock.ts');
+      const lockInfo = readLockInfo(dataDir);
+      if (lockInfo?.command?.includes('serve')) {
+        let holderAlive = false;
+        try { process.kill(lockInfo.pid, 0); holderAlive = true; } catch { /* dead */ }
+        if (holderAlive) {
+          const { runProxy } = await import('./mcp/proxy.ts');
+          const { serveSocketPath } = await import('./mcp/multiplexer.ts');
+          console.error(
+            `[gbrain serve] another serve (pid ${lockInfo.pid}) holds the PGLite lock — running as stdio proxy`,
+          );
+          await runProxy(serveSocketPath(dataDir));
+          return;
+        }
+      }
+    }
+  }
+
   // All remaining CLI-only commands need a DB connection
   const engine = await connectEngine();
   try {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import type { BrainEngine } from '../core/engine.ts';
 import { startMcpServer } from '../mcp/server.ts';
+import { startMultiplexer, serveSocketPath, type MultiplexerHandle } from '../mcp/multiplexer.ts';
 
 // Maximum time the stdio path will wait for engine.disconnect() (PGLite
 // close + advisory lock release) before forcing exit. Keeps a wedged
@@ -125,7 +126,13 @@ export async function runServe(
   // and is intentionally NOT wired into this stdio plumbing.
   console.error('Starting GBrain MCP server (stdio)...');
 
-  installStdioLifecycle(engine, args, opts);
+  // The multiplexer (created below, after startMcpServer) is fed to the
+  // lifecycle via a getter so beginShutdown can close it BEFORE
+  // engine.disconnect() rm-rf's the lock dir (which contains the socket
+  // file). Without the close-first order, in-flight proxy clients would
+  // see their socket disappear under them mid-write and emit ENOENT.
+  let multiplexer: MultiplexerHandle | null = null;
+  installStdioLifecycle(engine, args, opts, () => multiplexer);
 
   const start = opts.startMcpServer ?? startMcpServer;
   await start(engine);
@@ -134,6 +141,26 @@ export async function runServe(
   // event loop alive. We deliberately do NOT add `await new Promise(() =>
   // {})` here — it would block this async frame and stop the lifecycle
   // hooks from being able to call process.exit() cleanly.
+
+  // Start the Unix-socket multiplexer so secondary `gbrain serve`
+  // invocations (e.g., claude-code-spawn child sessions whose
+  // --mcp-config also points to `gbrain serve`) can proxy through us
+  // instead of dying on PGLite lock contention. Only applies to PGLite
+  // (single-process); Postgres engines support multi-client natively.
+  // Failure to start the multiplexer is non-fatal: primary stdio keeps
+  // working, only multi-client proxying is unavailable.
+  if (engine.kind === 'pglite') {
+    const dataDir = (engine as { dataDir?: string }).dataDir;
+    if (dataDir) {
+      try {
+        multiplexer = await startMultiplexer(engine, serveSocketPath(dataDir));
+        console.error(`[gbrain serve] multi-client socket: ${multiplexer.socketPath}`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[gbrain serve] multi-client socket disabled: ${msg}`);
+      }
+    }
+  }
 }
 
 interface StdioLifecycleDeps {
@@ -151,6 +178,7 @@ function installStdioLifecycle(
   engine: BrainEngine,
   args: string[],
   opts: ServeOptions,
+  getMultiplexer?: () => MultiplexerHandle | null,
 ): void {
   const deps: StdioLifecycleDeps = {
     stdin: opts.stdin ?? process.stdin,
@@ -193,7 +221,18 @@ function installStdioLifecycle(
     }, CLEANUP_DEADLINE_MS);
     deadline.unref?.();
 
+    // Cleanup order matters: close the multiplexer FIRST so its listener
+    // stops accepting new proxies and active per-client sockets get a
+    // clean socket.close() (which their proxy peers detect as EOF). THEN
+    // disconnect the engine, which rm-rf's the lock dir (containing the
+    // socket file). Reversing the order would leave proxies writing into
+    // a soon-to-be-deleted socket.
     Promise.resolve()
+      .then(() => getMultiplexer?.()?.close())
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        deps.log(`GBrain MCP server: multiplexer close error: ${msg}`);
+      })
       .then(() => engine.disconnect())
       .catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -2,6 +2,8 @@ import { PGlite } from '@electric-sql/pglite';
 import { vector } from '@electric-sql/pglite/vector';
 import { pg_trgm } from '@electric-sql/pglite/contrib/pg_trgm';
 import type { Transaction } from '@electric-sql/pglite';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 import type {
   BrainEngine,
   LinkBatchInput, TimelineBatchInput,
@@ -127,6 +129,51 @@ export function computeSnapshotSchemaHash(
   return hash.digest('hex');
 }
 
+/**
+ * Detect if another process is currently holding the PGLite data directory.
+ * Returns the conflicting PID + command if detected, or null if safe to open.
+ *
+ * Checks two markers:
+ *   1. postmaster.pid — PGLite/Postgres internal lock (most reliable indicator
+ *      that PGLite is actively initialized in another process).
+ *   2. .gbrain-lock/lock — gbrain advisory lock (set by acquireLock in this file).
+ *
+ * Either marker, if it points to a live process that isn't us, means opening
+ * here would corrupt the database. Stale markers (dead PIDs) are ignored — the
+ * existing acquireLock cleanup path handles those.
+ */
+function detectConcurrentGBrain(dataDir: string): { pid: number; command?: string } | null {
+  const checkAlive = (pid: number): boolean => {
+    if (!pid || pid === process.pid) return false;
+    try { process.kill(pid, 0); return true; } catch { return false; }
+  };
+
+  // Check 1: PGLite's own postmaster.pid (first line is the PID)
+  const postmasterPath = join(dataDir, 'postmaster.pid');
+  if (existsSync(postmasterPath)) {
+    try {
+      const firstLine = readFileSync(postmasterPath, 'utf-8').split('\n')[0].trim();
+      const pid = parseInt(firstLine, 10);
+      if (checkAlive(pid)) {
+        return { pid, command: 'pglite postmaster' };
+      }
+    } catch { /* unreadable / corrupt — skip and let downstream handle */ }
+  }
+
+  // Check 2: gbrain advisory lock (set by acquireLock)
+  const lockPath = join(dataDir, '.gbrain-lock', 'lock');
+  if (existsSync(lockPath)) {
+    try {
+      const lockData = JSON.parse(readFileSync(lockPath, 'utf-8')) as { pid?: number; command?: string };
+      if (lockData.pid && checkAlive(lockData.pid)) {
+        return { pid: lockData.pid, command: lockData.command };
+      }
+    } catch { /* corrupt lock file — skip */ }
+  }
+
+  return null;
+}
+
 export class PGLiteEngine implements BrainEngine {
   readonly kind = 'pglite' as const;
   private _db: PGLiteDB | null = null;
@@ -144,6 +191,40 @@ export class PGLiteEngine implements BrainEngine {
   // Lifecycle
   async connect(config: EngineConfig): Promise<void> {
     const dataDir = config.database_path || undefined; // undefined = in-memory
+
+    // PREVENTIVE CHECK: detect concurrent gbrain processes BEFORE attempting
+    // PGlite.create(). PGLite is single-process; if another process has the
+    // database open, calling create() corrupts the on-disk state in a way
+    // that survives process death AND lock-file removal — recovering requires
+    // recreating the database from scratch (and re-paying any embedding costs).
+    // The acquireLock call below would catch this IF the other process used
+    // it, but gbrain serve in some paths doesn't acquire the advisory lock
+    // before holding the DB connection. Postmaster.pid is PGLite's own marker
+    // and is more reliable as a "someone has this open right now" signal.
+    if (dataDir) {
+      const conflict = detectConcurrentGBrain(dataDir);
+      if (conflict) {
+        throw new Error(
+          `Cannot open PGLite database at ${dataDir}: another process has it open.\n` +
+          `  Holding process: PID ${conflict.pid}${conflict.command ? ` (${conflict.command})` : ''}\n` +
+          `  PGLite supports only one process per data directory. Opening from a\n` +
+          `  second process leaves the on-disk state corrupted and unrecoverable.\n` +
+          `\n` +
+          `  Most common cause: a 'gbrain serve' MCP server is running (e.g., inside\n` +
+          `  Claude Code) while you tried to run a 'gbrain' command from the terminal.\n` +
+          `\n` +
+          `  Fix:\n` +
+          `    1. Close Claude Code (or whatever runs gbrain as an MCP server)\n` +
+          `    2. Verify no gbrain processes remain: ps aux | grep gbrain | grep -v grep\n` +
+          `    3. If any remain, kill them: kill <PID>\n` +
+          `    4. Retry your command\n` +
+          `\n` +
+          `  If you're certain no other process is using the database (e.g., the PID\n` +
+          `  is stale), remove the marker files and retry:\n` +
+          `    rm -f ${dataDir}/postmaster.pid && rm -rf ${dataDir}/.gbrain-lock`
+        );
+      }
+    }
 
     // Acquire file lock to prevent concurrent PGLite access (crashes with Aborted())
     this._lock = await acquireLock(dataDir);

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -182,10 +182,23 @@ export class PGLiteEngine implements BrainEngine {
   // PGlite.create(loadDataDir), initSchema is a no-op (schema is already
   // present + migrations already applied). Saves ~1-3s per fresh test PGLite.
   private _snapshotLoaded = false;
+  // Resolved persistent data directory (undefined for in-memory engines).
+  // Captured at connect() so downstream consumers like the MCP multiplexer
+  // (src/mcp/multiplexer.ts) can locate the per-data-dir Unix socket
+  // without having to re-thread EngineConfig everywhere.
+  private _dataDir: string | undefined = undefined;
 
   get db(): PGLiteDB {
     if (!this._db) throw new Error('PGLite not connected. Call connect() first.');
     return this._db;
+  }
+
+  /**
+   * Persistent data dir this engine was connected to, or undefined for an
+   * in-memory engine. Stable for the lifetime of the connection.
+   */
+  get dataDir(): string | undefined {
+    return this._dataDir;
   }
 
   // Lifecycle
@@ -232,6 +245,11 @@ export class PGLiteEngine implements BrainEngine {
     if (!this._lock.acquired) {
       throw new Error('Could not acquire PGLite lock. Another gbrain process is using the database.');
     }
+
+    // Capture dataDir so the MCP multiplexer can locate the per-brain Unix
+    // socket without re-threading EngineConfig. Mirrors the lock lifecycle:
+    // populated when the lock is held, cleared on disconnect().
+    this._dataDir = dataDir;
 
     // Tier 3: optional snapshot fast-restore. Only applies to in-memory
     // engines (no persistent dataDir). The snapshot was built from a fresh
@@ -285,6 +303,7 @@ export class PGLiteEngine implements BrainEngine {
       await releaseLock(this._lock);
       this._lock = null;
     }
+    this._dataDir = undefined;
   }
 
   async initSchema(): Promise<void> {

--- a/src/core/pglite-lock.ts
+++ b/src/core/pglite-lock.ts
@@ -146,3 +146,42 @@ export async function releaseLock(lock: LockHandle): Promise<void> {
     // Lock file already removed (e.g., by stale cleanup) — that's fine
   }
 }
+
+export interface LockInfo {
+  pid: number;
+  acquired_at: number;
+  command?: string;
+}
+
+/**
+ * Pure read of the current lock file. Does NOT check process liveness, does
+ * NOT touch the lock, does NOT block. Returns null if no lock dir / file
+ * present, or if the file is unreadable / corrupt.
+ *
+ * Used by callers that need to decide pre-connect whether to attempt an
+ * acquire or fall back to a different strategy. In particular, `gbrain
+ * serve` uses this to detect "another serve is already running" and become
+ * a stdio proxy to that existing server instead of failing on the lock —
+ * PGLite is single-process, so two serves would otherwise collide.
+ *
+ * Callers that care about staleness should pair this with a process.kill(pid, 0)
+ * liveness check; this function intentionally doesn't do that so it stays
+ * a pure read and reusable by tooling that just wants to inspect the lock.
+ */
+export function readLockInfo(dataDir: string | undefined): LockInfo | null {
+  if (!dataDir) return null;
+  const lockPath = join(dataDir, LOCK_DIR_NAME, LOCK_FILE);
+  if (!existsSync(lockPath)) return null;
+  try {
+    const raw = readFileSync(lockPath, 'utf-8');
+    const data = JSON.parse(raw) as { pid?: unknown; acquired_at?: unknown; command?: unknown };
+    if (typeof data.pid !== 'number' || typeof data.acquired_at !== 'number') return null;
+    return {
+      pid: data.pid,
+      acquired_at: data.acquired_at,
+      command: typeof data.command === 'string' ? data.command : undefined,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/mcp/multiplexer.ts
+++ b/src/mcp/multiplexer.ts
@@ -1,0 +1,155 @@
+/**
+ * MCP multiplexer — Unix socket fan-in for the primary `gbrain serve`.
+ *
+ * Problem this solves: PGLite is single-process-per-data-directory. When
+ * Claude.app runs `gbrain serve` from its claude_desktop_config.json AND
+ * spawns claude-code-spawn child sessions that ALSO pass
+ * `--mcp-config '...gbrain serve...'`, the child sessions each try to start
+ * their own `gbrain serve`, hit the lock contention on the PGLite data
+ * directory, and die. The MCP tools `mcp__gbrain__*` end up unavailable in
+ * every child session even though gbrain is "configured" there.
+ *
+ * Solution: the first `gbrain serve` (the owner of the PGLite lock) ALSO
+ * opens a Unix socket alongside the lock. Subsequent `gbrain serve`
+ * invocations detect the lock-already-held-by-another-serve condition and
+ * become STDIO PROXIES (see ./proxy.ts) that bidi-pipe their stdin/stdout
+ * to the owner's socket. From the perspective of each MCP client (Claude.app,
+ * each claude-code-spawn), they got a working `gbrain serve` over stdio;
+ * from the owner's perspective, it just has N concurrent MCP clients on
+ * different transports.
+ *
+ * Architecture:
+ *
+ *   Owner process:
+ *     - StdioServerTransport on real process.stdin/stdout (primary client)
+ *     - net.createServer listening at <dataDir>/.gbrain-lock/serve.sock
+ *       → per-connection: new Server() + StdioServerTransport(socket, socket)
+ *
+ *   Proxy process (see ./proxy.ts):
+ *     - net.connect(<same socket path>)
+ *     - bidi: process.stdin → socket, socket → process.stdout
+ *
+ * Trust boundary: each per-connection Server uses startMcpServerWithTransport,
+ * which dispatches with `remote: true` — identical to the primary stdio
+ * path. A proxied client gets exactly the same untrusted treatment as a
+ * direct stdio client, which is correct (claude-code-spawn child sessions
+ * are the same trust class as the parent Claude.app session).
+ */
+
+import { createServer, type Socket } from 'node:net';
+import { join, dirname } from 'node:path';
+import { mkdirSync, existsSync, unlinkSync } from 'node:fs';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { BrainEngine } from '../core/engine.ts';
+import { startMcpServerWithTransport } from './server.ts';
+
+const SOCKET_FILE = 'serve.sock';
+const LOCK_DIR_NAME = '.gbrain-lock';
+
+/**
+ * Resolve the Unix socket path for a given PGLite data directory. Lives
+ * inside the same `.gbrain-lock` dir as the advisory lock so socket
+ * lifecycle is naturally bounded by lock lifecycle (when the owner
+ * releases the lock, the lock dir is rm-rf'd and any leftover socket file
+ * goes with it).
+ */
+export function serveSocketPath(dataDir: string): string {
+  return join(dataDir, LOCK_DIR_NAME, SOCKET_FILE);
+}
+
+export interface MultiplexerHandle {
+  socketPath: string;
+  /** Active client connection count (for tests / introspection). */
+  readonly clientCount: number;
+  /**
+   * Close the listener, destroy active per-client sockets, and remove the
+   * socket file. Idempotent. Called from the owner's shutdown sequence
+   * BEFORE engine.disconnect() so the socket file is gone before the lock
+   * dir is rm-rf'd (avoids a race where a late-arriving proxy connects to
+   * a half-dead listener).
+   */
+  close: () => Promise<void>;
+}
+
+/**
+ * Start the multiplexer listener. Returns once the socket is bound and
+ * accepting connections. Errors during bind reject the returned promise
+ * (e.g. EADDRINUSE if a stale socket file exists AND the previous owner
+ * is still alive — which shouldn't happen because the PGLite lock would
+ * have prevented us getting this far, but we surface it cleanly anyway).
+ */
+export async function startMultiplexer(
+  engine: BrainEngine,
+  socketPath: string,
+): Promise<MultiplexerHandle> {
+  mkdirSync(dirname(socketPath), { recursive: true });
+
+  // Defensive: remove a stale socket file from a previous crashed owner.
+  // The atomic lock ownership upstream (acquireLock via mkdir) guarantees
+  // we're the only writer here, so this is safe — if the previous owner
+  // had really still been alive, acquireLock would have blocked.
+  if (existsSync(socketPath)) {
+    try { unlinkSync(socketPath); } catch { /* will surface as EADDRINUSE below */ }
+  }
+
+  const sockets = new Set<Socket>();
+
+  const server = createServer((socket: Socket) => {
+    sockets.add(socket);
+    socket.on('close', () => { sockets.delete(socket); });
+    socket.on('error', (err: Error) => {
+      // Per-connection errors are not fatal to the listener. Log to stderr
+      // (NOT stdout — stdout is the primary client's JSON-RPC channel).
+      process.stderr.write(`[gbrain-multiplexer] client socket error: ${err.message}\n`);
+    });
+
+    // The MCP SDK's StdioServerTransport reads from any Readable and writes
+    // to any Writable. A net.Socket is Duplex (both), so we can reuse the
+    // SDK's transport verbatim and get the exact same line-delimited
+    // JSON-RPC framing as the primary stdio path. Zero custom transport.
+    const transport = new StdioServerTransport(socket, socket);
+
+    startMcpServerWithTransport(engine, transport).catch((err: Error) => {
+      process.stderr.write(`[gbrain-multiplexer] per-client server failed: ${err.message}\n`);
+      socket.destroy();
+    });
+  });
+
+  server.on('error', (err: Error) => {
+    process.stderr.write(`[gbrain-multiplexer] listener error: ${err.message}\n`);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error): void => {
+      server.off('listening', onListen);
+      reject(err);
+    };
+    const onListen = (): void => {
+      server.off('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListen);
+    server.listen(socketPath);
+  });
+
+  return {
+    socketPath,
+    get clientCount() { return sockets.size; },
+    close: async () => {
+      // Close listener first so no new connections accumulate while we
+      // tear down the active ones. server.close() resolves once the
+      // listener is shut AND all active connections have closed — but
+      // since we destroy() sockets ourselves below, the resolve fires
+      // promptly even if a client was mid-stream.
+      const closed = new Promise<void>((resolve) => server.close(() => resolve()));
+      for (const s of sockets) s.destroy();
+      sockets.clear();
+      await closed;
+      // Best-effort cleanup of the socket file. On graceful shutdown the
+      // lock-dir rm-rf in engine.disconnect() would have taken it anyway,
+      // but doing it here too keeps a post-mortem fs in a clean state.
+      try { if (existsSync(socketPath)) unlinkSync(socketPath); } catch { /* ignore */ }
+    },
+  };
+}

--- a/src/mcp/proxy.ts
+++ b/src/mcp/proxy.ts
@@ -1,0 +1,91 @@
+/**
+ * MCP stdio→Unix-socket proxy. The counterpart to ./multiplexer.ts.
+ *
+ * Used when `gbrain serve` is invoked but another `gbrain serve` already
+ * holds the PGLite lock. Instead of failing with the lock-contention
+ * error, we connect to the owner's multiplexer socket and bidi-pipe our
+ * stdin/stdout to it. The MCP client that spawned us (Claude.app via
+ * claude_desktop_config.json, claude-code-spawn via --mcp-config, etc.)
+ * sees a transparently working `gbrain serve` over stdio; the owner sees
+ * a new MCP client on its socket transport.
+ *
+ * No JSON-RPC parsing happens here — it's a pure byte pipe. That keeps
+ * the proxy trivial AND preserves the trust boundary by accident-proof
+ * construction: we cannot modify the messages even if we wanted to,
+ * because we don't parse them. The owner's per-connection Server still
+ * dispatches with remote=true via startMcpServerWithTransport.
+ */
+
+import { connect, type Socket } from 'node:net';
+
+export interface ProxyOptions {
+  /** Timeout for the initial connect attempt (ms). Default 5000. */
+  connectTimeoutMs?: number;
+  /**
+   * Test seam: where to pipe FROM (defaults to process.stdin). The MCP
+   * client speaks JSON-RPC to us via this stream; we forward bytes to
+   * the socket without parsing.
+   */
+  stdin?: NodeJS.ReadableStream;
+  /**
+   * Test seam: where to pipe TO (defaults to process.stdout). The owner's
+   * Server writes JSON-RPC replies to the socket; we forward bytes here
+   * without parsing.
+   */
+  stdout?: NodeJS.WritableStream;
+}
+
+/**
+ * Connect to `socketPath` and bidi-pipe stdin↔socket↔stdout. Resolves
+ * when the socket closes (clean owner shutdown, owner crash, client
+ * stdin EOF). Rejects if the initial connect fails — the caller decides
+ * whether to retry as an owner (e.g. stale socket from a crashed owner
+ * means the lock should also be stale and a fresh acquire would succeed).
+ */
+export async function runProxy(
+  socketPath: string,
+  opts: ProxyOptions = {},
+): Promise<void> {
+  const connectTimeoutMs = opts.connectTimeoutMs ?? 5000;
+  const stdin = opts.stdin ?? process.stdin;
+  const stdout = opts.stdout ?? process.stdout;
+
+  const socket: Socket = await new Promise((resolve, reject) => {
+    const sock = connect(socketPath);
+    const timer = setTimeout(() => {
+      sock.destroy();
+      reject(new Error(`gbrain proxy: connect timeout (${connectTimeoutMs}ms) on ${socketPath}`));
+    }, connectTimeoutMs);
+    sock.once('connect', () => {
+      clearTimeout(timer);
+      resolve(sock);
+    });
+    sock.once('error', (err: Error) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+
+  // Bidi byte pipe. .pipe() handles backpressure for us. When the source
+  // ends, the destination is NOT auto-closed by default for stdin→socket
+  // (we want to keep the socket open if the client just paused), and
+  // socket→stdout DOES end stdout on close — but stdout is process-global
+  // so we suppress that with { end: false } and let the caller exit().
+  stdin.pipe(socket);
+  socket.pipe(stdout, { end: false });
+
+  // Surface socket-level errors to stderr (NOT stdout — stdout is the
+  // client's JSON-RPC channel and a stray line would corrupt the next
+  // frame the client tries to parse).
+  socket.on('error', (err: Error) => {
+    process.stderr.write(`[gbrain-proxy] socket error: ${err.message}\n`);
+  });
+
+  // Resolve when the socket closes for any reason (owner shut down, owner
+  // crashed, stdin EOF propagated through). The caller is responsible for
+  // process.exit() — keeping that out of here lets this function be
+  // unit-tested without exiting the test runner.
+  await new Promise<void>((resolve) => {
+    socket.once('close', () => resolve());
+  });
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,5 +1,6 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { BrainEngine } from '../core/engine.ts';
 import { operations } from '../core/operations.ts';
@@ -8,7 +9,23 @@ import { buildToolDefs } from './tool-defs.ts';
 import { dispatchToolCall, validateParams, buildOperationContext } from './dispatch.ts';
 import { getBrainHotMemoryMeta } from '../core/facts/meta-hook.ts';
 
-export async function startMcpServer(engine: BrainEngine) {
+/**
+ * Wire a new MCP `Server` to the given transport, registering tool defs +
+ * dispatch handlers against the shared engine. Pure construction — does NOT
+ * install process-wide stdio shutdown hooks (the caller decides whether
+ * those apply: yes for the primary stdio path in `startMcpServer`, no for
+ * per-connection socket transports created by the multiplexer).
+ *
+ * Trust boundary: handler always dispatches with `remote: true` — see
+ * AGENTS.md trust-boundary section. The multiplexer reuses this verbatim,
+ * so a client coming in via Unix socket gets the same untrusted treatment
+ * as a stdio client (which is correct: Claude Code's child claude-code-spawn
+ * sessions are the same trust class as the parent Claude.app session).
+ */
+export async function startMcpServerWithTransport(
+  engine: BrainEngine,
+  transport: Transport,
+): Promise<Server> {
   const server = new Server(
     { name: 'gbrain', version: VERSION },
     { capabilities: { tools: {} } },
@@ -47,35 +64,22 @@ export async function startMcpServer(engine: BrainEngine) {
     });
   });
 
-  const transport = new StdioServerTransport();
   await server.connect(transport);
+  return server;
+}
 
-  // Exit cleanly when MCP client disconnects (stdin EOF) or on signals.
-  // Without this, orphaned serve processes accumulate and contend for the
-  // PGLite write lock, causing ingest jobs (email-sync) to time out.
-  let shuttingDown = false;
-  const shutdown = (reason: string, code = 0) => {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    process.stderr.write(`[gbrain-serve] shutdown: ${reason}\n`);
-    Promise.resolve(engine.disconnect?.())
-      .catch(() => {})
-      .finally(() => process.exit(code));
-  };
-  // v0.34.1 (#870): when MCP_STDIO=1, the wrapping gateway (OpenClaw's
-  // bundle-mcp layer, others) often pipes the JSON-RPC handshake then
-  // closes its stdin half. Treating that as a permanent disconnect kills
-  // the server before the first tool call arrives. Signal handlers and
-  // transport.onclose still cover the legitimate shutdown paths.
-  if (process.env.MCP_STDIO !== '1') {
-    process.stdin.on('end', () => shutdown('stdin end'));
-    process.stdin.on('close', () => shutdown('stdin close'));
-  }
-  // @ts-ignore — SDK exposes onclose on transport
-  transport.onclose = () => shutdown('transport close');
-  process.on('SIGTERM', () => shutdown('SIGTERM'));
-  process.on('SIGINT', () => shutdown('SIGINT'));
-  process.on('SIGHUP', () => shutdown('SIGHUP'));
+export async function startMcpServer(engine: BrainEngine) {
+  const transport = new StdioServerTransport();
+  await startMcpServerWithTransport(engine, transport);
+  // Process-wide shutdown handling (SIGTERM/SIGINT/SIGHUP, stdin EOF,
+  // parent-process watchdog, cleanup deadline) is installed by the caller
+  // via installStdioLifecycle() in src/commands/serve.ts. That lifecycle
+  // is strictly a superset of the per-server hooks that used to live here
+  // — and crucially, it also closes the multiplexer (src/mcp/multiplexer.ts)
+  // before engine.disconnect(), which the inline version did not. Keeping
+  // both led to two concurrent shutdown chains racing on engine.disconnect()
+  // and surfacing "PGlite is closing" cleanup errors when shutdown was
+  // triggered by stdin-end (bash background, stdin-half-close gateways).
 }
 
 // Backward compat: used by `gbrain call` command (trusted local path).

--- a/test/serve-proxy.test.ts
+++ b/test/serve-proxy.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for the multi-client `gbrain serve` proxy: src/mcp/multiplexer.ts +
+ * src/mcp/proxy.ts + the readLockInfo() helper exported from
+ * src/core/pglite-lock.ts.
+ *
+ * Background: PGLite is single-process-per-data-dir. Multiple `gbrain serve`
+ * invocations against the same brain (Claude.app's primary serve + each
+ * claude-code-spawn child session that passes --mcp-config) used to collide
+ * on the lock and die. The multiplexer + proxy let the first serve become
+ * the owner and subsequent serves stream through it over a Unix socket.
+ *
+ * Test isolation: CONTRIBUTING.md R3 + R4 — the PGLite engine is created
+ * inside beforeAll() and disconnected in afterAll(). No process.env mutation
+ * (R1) and no module-level mocks (R2), so this file stays parallel-safe
+ * and out of the *.serial.test.ts quarantine.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable, Writable } from 'node:stream';
+
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import {
+  startMultiplexer,
+  serveSocketPath,
+  type MultiplexerHandle,
+} from '../src/mcp/multiplexer.ts';
+import { runProxy } from '../src/mcp/proxy.ts';
+import { readLockInfo } from '../src/core/pglite-lock.ts';
+
+let engine: PGLiteEngine;
+let dataDir: string;
+let activeMultiplexer: MultiplexerHandle | null = null;
+
+// 30s timeout: PGLite cold-start + 88 migrations against a fresh tmpdir
+// takes ~7s; the default 5s beforeAll cap times out before initSchema
+// completes. Other PGLite-backed test files run inside the *.serial.test.ts
+// quarantine OR reuse a snapshot via GBRAIN_PGLITE_SNAPSHOT; this suite
+// stays parallel-safe by paying the cold-start cost honestly.
+beforeAll(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), 'gbrain-serve-proxy-test-'));
+  engine = new PGLiteEngine();
+  await engine.connect({ database_path: dataDir });
+  await engine.initSchema();
+}, 30_000);
+
+afterAll(async () => {
+  if (activeMultiplexer) {
+    try { await activeMultiplexer.close(); } catch { /* idempotent */ }
+    activeMultiplexer = null;
+  }
+  await engine.disconnect();
+  try { rmSync(dataDir, { recursive: true, force: true }); } catch { /* ignore */ }
+}, 10_000);
+
+/**
+ * Drive a single JSON-RPC `initialize` through runProxy and return the parsed
+ * reply. Caller controls socket path so we can point at owner / stale / etc.
+ */
+async function proxyInitialize(socketPath: string, id = 1): Promise<unknown> {
+  const initialize = JSON.stringify({
+    jsonrpc: '2.0',
+    id,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-11-25',
+      capabilities: {},
+      clientInfo: { name: 'serve-proxy-test', version: '0.0.0' },
+    },
+  }) + '\n';
+
+  const stdin = new Readable({ read() {} });
+  stdin.push(initialize);
+
+  const captured: Buffer[] = [];
+  const stdout = new Writable({
+    write(chunk: Buffer, _enc, cb) {
+      captured.push(chunk);
+      cb();
+    },
+  });
+
+  const proxyDone = runProxy(socketPath, { stdin, stdout });
+
+  // Poll for a reply (PGLite-backed server is fast but not instant).
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline && captured.length === 0) {
+    await new Promise((r) => setTimeout(r, 25));
+  }
+
+  stdin.push(null);
+  await Promise.race([
+    proxyDone.catch(() => {}),
+    new Promise((r) => setTimeout(r, 500)),
+  ]);
+
+  const text = Buffer.concat(captured).toString('utf8');
+  const firstLine = text.split('\n').filter(Boolean)[0];
+  if (!firstLine) throw new Error(`no reply received from ${socketPath}`);
+  return JSON.parse(firstLine);
+}
+
+describe('serve proxy + multiplexer', () => {
+  test('roundtrips JSON-RPC initialize through proxy→multiplexer→server', async () => {
+    // Use a per-test socket path so this stays isolated from the suite's
+    // shared engine's lock dir.
+    const socketPath = join(dataDir, '.gbrain-lock', `roundtrip-${Date.now()}.sock`);
+    activeMultiplexer = await startMultiplexer(engine, socketPath);
+
+    const reply = await proxyInitialize(socketPath) as {
+      jsonrpc: string;
+      id: number;
+      result: { protocolVersion: string; serverInfo: { name: string } };
+    };
+
+    expect(reply.jsonrpc).toBe('2.0');
+    expect(reply.id).toBe(1);
+    expect(reply.result.serverInfo.name).toBe('gbrain');
+    expect(reply.result.protocolVersion).toBeTruthy();
+
+    await activeMultiplexer.close();
+    activeMultiplexer = null;
+  });
+
+  test('serves N concurrent proxies on one multiplexer (multi-client core promise)', async () => {
+    // The whole point of the fix: Claude.app's primary serve + N
+    // claude-code-spawn sub-sessions all multiplexed into one engine.
+    // We simulate 3 concurrent proxies sending initialize at once.
+    const socketPath = join(dataDir, '.gbrain-lock', `concurrent-${Date.now()}.sock`);
+    activeMultiplexer = await startMultiplexer(engine, socketPath);
+
+    const N = 3;
+    const replies = await Promise.all(
+      Array.from({ length: N }, (_, i) => proxyInitialize(socketPath, i + 100)),
+    );
+
+    expect(replies).toHaveLength(N);
+    for (let i = 0; i < N; i++) {
+      const r = replies[i] as { jsonrpc: string; id: number; result?: unknown };
+      expect(r.jsonrpc).toBe('2.0');
+      expect(r.id).toBe(i + 100);
+      expect(r.result).toBeTruthy();
+    }
+    // The multiplexer should have seen all N connections and shed them.
+    // clientCount goes back to 0 once proxies hang up (proxyInitialize
+    // closes its stdin which propagates through to socket close).
+    // Give a beat for the close events to drain.
+    await new Promise((r) => setTimeout(r, 200));
+    expect(activeMultiplexer.clientCount).toBe(0);
+
+    await activeMultiplexer.close();
+    activeMultiplexer = null;
+  });
+
+  test('startMultiplexer removes a stale socket file from a crashed owner', async () => {
+    // Simulates the post-kill-9 state: owner crashed without releasing
+    // anything, lock got reclaimed (acquireLock has its own stale-PID
+    // cleanup, covered in test/pglite-lock.test.ts), but the orphan
+    // socket file from `net.createServer().listen(path)` is still on disk.
+    // A fresh owner's startMultiplexer must unlink it or `listen()` would
+    // fail with EADDRINUSE.
+    const lockDir = join(dataDir, '.gbrain-lock');
+    mkdirSync(lockDir, { recursive: true });
+    const socketPath = join(lockDir, `stale-${Date.now()}.sock`);
+
+    // Plant a stale file at the socket path (not a real socket — just a
+    // regular file, same as what a crashed listener leaves behind on macOS
+    // when the process is SIGKILL'd before its own cleanup hook runs).
+    writeFileSync(socketPath, '');
+    expect(existsSync(socketPath)).toBe(true);
+
+    // Should not throw — the multiplexer is responsible for clearing the
+    // stale path before bind.
+    activeMultiplexer = await startMultiplexer(engine, socketPath);
+
+    // After bind, the path exists again (now as a real socket inode). We
+    // verify by running a roundtrip — if the listener weren't bound, the
+    // proxy would fail to connect.
+    const reply = await proxyInitialize(socketPath) as { result?: unknown };
+    expect(reply.result).toBeTruthy();
+
+    await activeMultiplexer.close();
+    activeMultiplexer = null;
+  });
+});
+
+describe('readLockInfo()', () => {
+  // These are scoped to a tmp dir that's NOT the shared engine's dataDir,
+  // so we can write arbitrary lock files without breaking the suite.
+  let infoDir: string;
+  beforeAll(() => {
+    infoDir = mkdtempSync(join(tmpdir(), 'gbrain-lockinfo-test-'));
+  });
+  afterAll(() => {
+    try { rmSync(infoDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  test('returns null when no lock file present', () => {
+    expect(readLockInfo(infoDir)).toBe(null);
+  });
+
+  test('returns null for undefined dataDir (in-memory engine)', () => {
+    expect(readLockInfo(undefined)).toBe(null);
+  });
+
+  test('parses a well-formed lock file', () => {
+    const lockDir = join(infoDir, '.gbrain-lock');
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(
+      join(lockDir, 'lock'),
+      JSON.stringify({
+        pid: 12345,
+        acquired_at: 1779000000000,
+        command: '/path/to/gbrain serve',
+      }),
+    );
+
+    const info = readLockInfo(infoDir);
+    expect(info).not.toBe(null);
+    expect(info!.pid).toBe(12345);
+    expect(info!.acquired_at).toBe(1779000000000);
+    expect(info!.command).toBe('/path/to/gbrain serve');
+
+    rmSync(lockDir, { recursive: true, force: true });
+  });
+
+  test('returns null on corrupt lock file (does not throw)', () => {
+    const lockDir = join(infoDir, '.gbrain-lock');
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, 'lock'), 'this is not json');
+
+    expect(readLockInfo(infoDir)).toBe(null);
+
+    rmSync(lockDir, { recursive: true, force: true });
+  });
+
+  test('returns null on lock file missing required fields', () => {
+    const lockDir = join(infoDir, '.gbrain-lock');
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(
+      join(lockDir, 'lock'),
+      JSON.stringify({ command: 'only-command-no-pid' }),
+    );
+
+    expect(readLockInfo(infoDir)).toBe(null);
+
+    rmSync(lockDir, { recursive: true, force: true });
+  });
+});
+
+describe('serveSocketPath()', () => {
+  test('returns a path inside the per-brain lock dir', () => {
+    const result = serveSocketPath('/tmp/some-brain');
+    expect(result).toBe('/tmp/some-brain/.gbrain-lock/serve.sock');
+  });
+});


### PR DESCRIPTION
## Problem

When Claude.app spawns `gbrain serve` from `claude_desktop_config.json` AND
its claude-code-spawn child sessions also pass `--mcp-config '...gbrain
serve...'`, each invocation tries to acquire the same PGLite lock. PGLite
is single-process-per-data-dir, so the losers die on contention and their
MCP clients end up without `mcp__gbrain__*` tools.

Real-world impact (this PR's origin): Claude.app's main chat window has
gbrain working, but every claude-code-spawn child session opened from
inside the app has no gbrain tools — even though gbrain is "configured"
there via `--mcp-config`.

## Solution — fan-in over a Unix socket

The first `gbrain serve` to win the lock becomes the **owner** and also
listens on a Unix socket alongside the lock dir. Subsequent `gbrain serve`
invocations detect the lock-held-by-another-serve condition via the new
`readLockInfo()` helper, and become **stdio proxies** that bidi-pipe their
stdin/stdout to the owner's socket. Each proxied client lands as a
per-connection MCP `Server` on the owner side, sharing the single PGLite
engine.

```
Owner process (first serve):
  - StdioServerTransport on real stdin/stdout (primary client)
  - net.createServer at <dataDir>/.gbrain-lock/serve.sock
    → per-connection: new Server() + StdioServerTransport(socket, socket)

Proxy process (every subsequent serve):
  - readLockInfo() + process.kill(pid, 0) detect lock-by-live-serve
  - runProxy() bidi-pipes stdin/socket/stdout (no JSON-RPC parsing)
```

**Trust boundary preserved verbatim**: the proxy does pure byte forwarding
(can't modify messages even if it wanted to), and the owner's
per-connection `Server` uses the existing `startMcpServerWithTransport`
that always dispatches with `remote: true`.

## Commits (5)

- `feat(pglite): preventive concurrent-process detection in connect()` —
  surfaces a clear error on collision instead of letting PGLite corrupt
  itself with a second WASM connection.
- `feat(pglite): expose dataDir + readLockInfo helper` — two read-only
  helpers downstream consumers need.
- `refactor(mcp): pluggable transport in startMcpServer + drop duplicate
  shutdown` — extracts `startMcpServerWithTransport`; removes a shutdown
  handler that raced with `installStdioLifecycle` (manifested as `PGlite
  is closing` cleanup errors on `stdin-end`).
- `feat(serve): multi-client MCP via Unix socket multiplexer + stdio proxy` —
  the feature: `multiplexer.ts` + `proxy.ts` + wire in `serve.ts` +
  pre-connect branch in `cli.ts`.
- `test(serve-proxy): roundtrip, multi-client, stale socket, readLockInfo` —
  9 tests / 26 expects covering happy path + multi-client concurrency +
  stale-socket recovery + helper edge cases. R3+R4 isolation compliant.

## Validation

- `bun run verify` clean (19 checks + typecheck)
- `bun test test/serve-proxy.test.ts` — 9/9 pass
- Smoke test against `~/.gbrain/brain.pglite` with two real `gbrain serve`
  processes: owner accepts proxy on socket, proxy forwards `initialize`,
  owner returns valid `serverInfo` JSON-RPC result, both clean shutdown
  via SIGTERM with no zombie lock.
- Live in production locally: Claude.app's main chat + the authoring
  claude-code-spawn session both have working `mcp__gbrain__*` tools
  through the multiplexer right now.

## Test plan

- [ ] Reviewer reproduces lock-collision pre-patch: open Claude.app, open
      a claude-code-spawn child session, observe missing `mcp__gbrain__*`
      tools and `Cannot open PGLite database` errors in
      `~/Library/Logs/Claude/mcp-server-gbrain.log`.
- [ ] Apply this branch, restart Claude.app so it relaunches `gbrain
      serve` with the new code, open a claude-code-spawn child session,
      observe `mcp__gbrain__*` works in BOTH places.
- [ ] `bun test test/serve-proxy.test.ts` passes locally.
- [ ] `bun run verify` clean.

## Out of scope (follow-ups)

- `serve --http` unaffected — HTTP supports multi-client natively.
- Owner-crash recovery: proxies currently exit on socket close; their
  parent MCP client retries and a new owner is elected by `acquireLock`'s
  atomic `mkdir`. "Convert me to owner" in-place inside the proxy would
  avoid the parent-reconnect round-trip but doubles complexity for
  marginal gain.
- Per-connection metrics on the multiplexer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
