### PR TITLE
fix(longmemeval): strip provider prefix before passing to Anthropic SDK

### DIFF
--- a/src/commands/eval-longmemeval.ts
+++ b/src/commands/eval-longmemeval.ts
@@ -17,7 +17,7 @@ import { renderChatBlock, type ChatSessionForPrompt } from '../eval/longmemeval/
 import { importFromContent } from '../core/import-file.ts';
 import { hybridSearch } from '../core/search/hybrid.ts';
 import { expandQuery } from '../core/search/expansion.ts';
-import { resolveModel } from '../core/model-config.ts';
+import { resolveModel, stripProviderPrefix } from '../core/model-config.ts';
 import type { ThinkLLMClient } from '../core/think/index.ts';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
@@ -351,8 +351,12 @@ async function generateAnswer(
   const userText =
     `Question:\n${question}\n\n${trajectorySection}Retrieved sessions:\n${rendered}`;
 
+  // resolveModel() returns 'anthropic:claude-sonnet-4-6' with the provider
+  // prefix, but the Anthropic SDK only accepts bare model ids. Without
+  // this strip, every answer-gen call HTTP 404s. Mirrored at the
+  // trajectory-extractor SDK call site in extract.ts.
   const response = await client.create({
-    model,
+    model: stripProviderPrefix(model),
     max_tokens: 512,
     system: systemText,
     messages: [{ role: 'user', content: userText }],

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -47,7 +47,7 @@ import {
   logSubagentSubmission,
   logSubagentHeartbeat,
 } from './subagent-audit.ts';
-import { resolveModel, isAnthropicProvider, TIER_DEFAULTS } from '../../model-config.ts';
+import { resolveModel, isAnthropicProvider, TIER_DEFAULTS, stripProviderPrefix } from '../../model-config.ts';
 import { buildSystemPrompt, DEFAULT_SUBAGENT_SYSTEM } from '../system-prompt.ts';
 import { toolLoop as gatewayToolLoop } from '../../ai/gateway.ts';
 import type { ChatToolDef, ChatMessage, ChatBlock, ChatResult, ToolHandler } from '../../ai/gateway.ts';
@@ -939,27 +939,13 @@ function recipeIdFromModel(modelString: string): string {
   return idx > 0 ? modelString.slice(0, idx) : 'anthropic';
 }
 
-/**
- * Strip the `provider:` prefix from a model string. Returns the bare
- * model id the Anthropic Messages API expects. Idempotent on already-bare
- * strings.
- *
- *   stripProviderPrefix('anthropic:claude-sonnet-4-6') === 'claude-sonnet-4-6'
- *   stripProviderPrefix('claude-sonnet-4-6') === 'claude-sonnet-4-6'
- *
- * v0.41 Bug 3 — pre-fix, `gbrain agent run --model anthropic:claude-sonnet-4-6`
- * sent the prefixed string straight into `client.messages.create()`, which
- * Anthropic rejects with "model not found." Omitting `--model` worked because
- * `resolveModel()` returns the bare id; explicit-model users hit the bug.
- *
- * Used ONLY at the SDK call site. The wider `model` variable stays
- * qualified everywhere else (persistence, recipe lookup, capability gate)
- * because those readers want the provider info.
- */
-export function stripProviderPrefix(modelString: string): string {
-  const idx = modelString.indexOf(':');
-  return idx > 0 ? modelString.slice(idx + 1) : modelString;
-}
+// stripProviderPrefix moved to src/core/model-config.ts so the helper has one
+// canonical home. Originated here during the v0.41 Bug 3 fix; lifted out
+// when longmemeval needed the same strip (eval-longmemeval.ts answer-gen +
+// extract.ts trajectory extractor) and inline-duplication felt wrong.
+// Re-exported for back-compat with any external callers that imported from
+// here pre-refactor.
+export { stripProviderPrefix };
 
 /**
  * D5 — adapt v1 Anthropic content blocks to v2 ChatBlock shape on read.

--- a/src/core/model-config.ts
+++ b/src/core/model-config.ts
@@ -87,6 +87,31 @@ export const TIER_DEFAULTS: Record<ModelTier, string> = {
  * breaks. When `tier === 'subagent'` resolves to a non-Anthropic provider,
  * we log a stderr warn AND fall back to `TIER_DEFAULTS.subagent`.
  */
+/**
+ * Strip the `provider:` prefix from a `provider:model` string for passing to
+ * a provider-specific SDK that doesn't recognize the prefix. resolveModel()
+ * returns qualified strings like `anthropic:claude-sonnet-4-6`, but the
+ * Anthropic SDK only accepts bare model ids (`claude-sonnet-4-6`); same
+ * pattern for OpenAI / Voyage / etc when the call bypasses the gbrain
+ * gateway and goes through the vendor SDK directly.
+ *
+ *   stripProviderPrefix('anthropic:claude-sonnet-4-6') === 'claude-sonnet-4-6'
+ *   stripProviderPrefix('claude-sonnet-4-6')           === 'claude-sonnet-4-6'
+ *   stripProviderPrefix('openai:gpt-4o')               === 'gpt-4o'
+ *
+ * Originated at subagent.ts during the v0.41 Bug 3 fix; lifted here so other
+ * direct-SDK call sites (longmemeval, future synthesize-via-Anthropic, etc.)
+ * import from one canonical home instead of reaching into minions/handlers.
+ *
+ * Used ONLY at SDK call sites. The wider `model` variable stays qualified
+ * everywhere else (persistence, recipe lookup, capability gate) because
+ * those readers want the provider info.
+ */
+export function stripProviderPrefix(modelString: string): string {
+  const idx = modelString.indexOf(':');
+  return idx > 0 ? modelString.slice(idx + 1) : modelString;
+}
+
 export function isAnthropicProvider(modelString: string): boolean {
   if (!modelString) return false;
   const trimmed = modelString.trim();

--- a/src/eval/longmemeval/extract.ts
+++ b/src/eval/longmemeval/extract.ts
@@ -37,6 +37,7 @@ import {
   type ResolutionSource,
 } from '../../core/entities/resolve.ts';
 import type { BrainEngine, NewFact } from '../../core/engine.ts';
+import { stripProviderPrefix } from '../../core/model-config.ts';
 
 /**
  * Parse a JSON array from LLM output. The cross-modal `parseModelJSON`
@@ -254,8 +255,10 @@ async function callExtractor(
 ): Promise<ExtractedClaim[] | null> {
   let response;
   try {
+    // Strip the provider prefix before passing to the Anthropic SDK — see
+    // eval-longmemeval.ts's answer-gen call site for the same rationale.
     response = await client.create({
-      model,
+      model: stripProviderPrefix(model),
       max_tokens: 2000,
       system: EXTRACTOR_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: body }],


### PR DESCRIPTION
# PR Draft #2: `fix(longmemeval): strip provider prefix before passing to Anthropic SDK`

**Branch:** `billy-armstrong/gbrain:fix/longmemeval-strip-provider-prefix` → `garrytan/gbrain:master`
**Files touched:** 4 files, +43 / -25
**Commit:** `dfa56801`
**Status:** ready for your review; held off `gh pr create` per your instructions.

---

## Title (for the PR form)

```
fix(longmemeval): strip provider prefix before passing to Anthropic SDK
```

## Description

`resolveModel()` returns qualified strings like `anthropic:claude-sonnet-4-6` so internal callers can route to the right provider. But provider-specific SDKs only accept bare model ids — the Anthropic SDK rejects the prefixed form with HTTP 404:

```json
{"type":"error","error":{"type":"not_found_error","message":"model: anthropic:claude-sonnet-4-6"}}
```

`stripProviderPrefix()` was originally added during the v0.41 Bug 3 fix to solve this in the subagent path. longmemeval has two more SDK-direct call sites with the same bug:

- `src/commands/eval-longmemeval.ts:354` — answer-gen
- `src/eval/longmemeval/extract.ts:257` — trajectory extractor (v0.40.2.0)

Both hit the same 404 on every call. Result: `gbrain eval longmemeval` returns `hypothesis: ""` and `error: "..."` for every question.

## Fix

Three changes:

1. **Move `stripProviderPrefix` to `src/core/model-config.ts`** — sibling to `resolveModel`, `isAnthropicProvider`. Same implementation, same JSDoc. Canonical home for model-string utilities.

2. **`subagent.ts`** — import from the new home; re-export for back-compat:
   ```ts
   import { ..., stripProviderPrefix } from '../../model-config.ts';
   export { stripProviderPrefix };  // preserves test/subagent-handler.test.ts import path
   ```

3. **`eval-longmemeval.ts` + `extract.ts`** — import + apply at both SDK call sites:
   ```ts
   const response = await client.create({
     model: stripProviderPrefix(model),
     // ...
   });
   ```

## Reproduction

```sh
gbrain eval longmemeval test/fixtures/longmemeval-nightly.jsonl \
  --output /tmp/out.jsonl --by-type --limit 2
head -2 /tmp/out.jsonl
```

**Pre-fix output** (every row):
```json
{"question_id":"nightly-1", ..., "hypothesis":"",
 "error":"404 {\"type\":\"error\",\"error\":{\"type\":\"not_found_error\",
          \"message\":\"model: anthropic:claude-sonnet-4-6\"}}"}
```

**Post-fix output** (real LLM-generated answers for every question):
```json
{"question_id":"nightly-1","question":"Where did alice-example say she lived last year?",
 "hypothesis":"Based on the retrieved session, **alice-example** said she lived in
                **widget-co** last year.",
 "recall_hit":true, ...}
```

10/10 questions return real hypotheses on the public `longmemeval-nightly.jsonl` fixture.

## Test coverage

`test/subagent-handler.test.ts` imports `stripProviderPrefix` from `subagent.ts` and exercises:

- Strips `anthropic:` prefix
- Idempotent on bare names
- Edge inputs: empty string, lone colon, multi-colon

These tests continue to pass via the re-export. No new tests added — the existing suite verifies the helper's contract; this PR is "apply the helper at two more sites."

## Why this stayed broken

The helper lived in `src/core/minions/handlers/subagent.ts` (a handler-specific file) and was never imported outside that file. When longmemeval grew two new direct-SDK call sites in v0.40.1.0 and v0.40.2.0, the helper wasn't discoverable from the canonical location, so the same fix wasn't applied. Moving it to `model-config.ts` (next to `resolveModel`) puts the helper where future contributors will look for it.

## Cost recovery

Anyone running `gbrain eval longmemeval` on a fresh install was burning embedding spend (longmemeval embeds the fixture's haystack sessions into PGLite before each question) and getting zero answer-gen tokens of value. Post-fix, the same embedding spend produces real hypotheses + cross-modal verdicts.
