### PR TITLE
feat: conversation retrieval upgrade — schema types + batch facts extraction

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture']);
+const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture']);
 // CLI-only commands whose handlers print their own --help text. These are
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
@@ -46,6 +46,10 @@ const CLI_ONLY_SELF_HELP = new Set([
   // runCapture saw --help. brainstorm + lsd were already in the set;
   // capture was the holdout.
   'capture',
+  // extract-conversation-facts ships its own --help block describing
+  // segment splitting and checkpointing semantics. Route around the
+  // generic short-circuit so users see the detailed text.
+  'extract-conversation-facts',
   // v0.37 fix wave (Lane D.4 + CDX2-12): sync's --no-embed flag was
   // unreachable via help because the dispatcher's generic CLI-only
   // short-circuit fired before runSync could print its own usage block.
@@ -676,7 +680,7 @@ function formatResult(opName: string, result: unknown): string {
  * `runRemoteDoctor` for thin-client installs.
  */
 const THIN_CLIENT_REFUSED_COMMANDS = new Set([
-  'sync', 'embed', 'extract', 'migrate', 'apply-migrations',
+  'sync', 'embed', 'extract', 'extract-conversation-facts', 'migrate', 'apply-migrations',
   'repair-jsonb', 'orphans', 'integrity', 'serve',
   // v0.31.1 (CDX-2 op coverage matrix): more local-only commands
   'dream', 'transcripts', 'storage',
@@ -710,6 +714,7 @@ const THIN_CLIENT_REFUSE_HINTS: Record<string, string> = {
   sync: 'sync runs on the host. Trigger a remote cycle with `gbrain remote ping` (queues an autopilot-cycle job).',
   embed: 'embed runs on the host as part of the autopilot cycle. `gbrain remote ping` triggers a full cycle including embed.',
   extract: 'extract runs on the host. Use `gbrain remote ping` to trigger a cycle including extract.',
+  'extract-conversation-facts': 'extract-conversation-facts runs on the host (requires local engine + chat gateway).',
   migrate: "migrate runs on the host's local engine. Run on the host machine.",
   'apply-migrations': 'schema migrations run on the host. SSH and run there.',
   'repair-jsonb': 'repair-jsonb operates on the local DB only.',
@@ -1194,6 +1199,11 @@ async function handleCliOnly(command: string, args: string[]) {
       case 'extract': {
         const { runExtract } = await import('./commands/extract.ts');
         await runExtract(engine, args);
+        break;
+      }
+      case 'extract-conversation-facts': {
+        const { runExtractConversationFacts } = await import('./commands/extract-conversation-facts.ts');
+        await runExtractConversationFacts(engine, args);
         break;
       }
       case 'features': {

--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -1,0 +1,590 @@
+/**
+ * gbrain extract-conversation-facts — batch fact extraction for
+ * conversation pages.
+ *
+ * Background
+ * ----------
+ * Conversation-type pages (imported chat logs, transcripts, etc.) can be
+ * very large — tens of thousands of messages spanning years. The default
+ * embedding pipeline chunks them into ~300-word blocks and prepends a tiny
+ * page-title hint. That's enough for semantic search across short pages,
+ * but it falls apart on long-running conversations:
+ *
+ *   - A user searches for "mountain cabin lock code" but the chunk that
+ *     contains the literal code reads only "Locker 93 code 9494" — no
+ *     mention of "cabin", "mountain", or any related topical anchor.
+ *   - Retrieval misses, because the chunk-level embedding can't see the
+ *     surrounding 50K messages of context that establish the topic.
+ *
+ * The facts table doesn't have this problem. Each row is a discrete claim
+ * with its own embedding and entity linkage, and `gbrain search` already
+ * blends facts into the result set. The extraction pipeline that builds
+ * facts (`src/core/facts/extract.ts`) is already wired into real-time MCP
+ * turns and the post-sync backstop — but it has never been run as a bulk
+ * backfill over imported conversation history.
+ *
+ * This command closes that gap. For every conversation page (or a single
+ * page when --slug is passed) it:
+ *
+ *   1. Parses the message body into time-windowed segments. Splits happen
+ *      on time gaps greater than 30 minutes between adjacent messages, or
+ *      whenever a segment hits ~50 messages — whichever comes first.
+ *   2. Prepends each segment with a topical/temporal context header
+ *      ("Conversation between {participants} on {date range}") so the
+ *      extractor sees the same anchor the operator would when reading.
+ *   3. Calls the EXISTING `extractFactsFromTurn()` from
+ *      src/core/facts/extract.ts — no duplicate prompt — and inserts the
+ *      results via `engine.insertFact()` with source =
+ *      'cli:extract-conversation-facts'.
+ *   4. Tracks per-page checkpoints in the brain config so re-runs are
+ *      idempotent and pick up only new messages since the last run.
+ *
+ * Notability filter
+ * -----------------
+ * The shared extractor returns three notability tiers (high/medium/low).
+ * Real-time paths drop "low" for signal-to-noise reasons. This command is
+ * a bulk backfill over data we already chose to import, so all three
+ * tiers are inserted. Low-notability facts still get their own embedding
+ * and entity link — they just don't drive notifications.
+ *
+ * Rate limiting
+ * -------------
+ * Segments are processed sequentially with a small sleep between
+ * extractor calls so we don't melt the chat provider on a 60K-message
+ * page. The default delay is conservative; --concurrency stays at 1 by
+ * design (the abort signal contract in extract.ts assumes serial use).
+ *
+ * Checkpoints
+ * -----------
+ * Per-page checkpoint key:
+ *   facts.conversation_extraction_checkpoint.<slug>
+ * Value is the ISO timestamp of the newest message processed. --force
+ * clears the checkpoint before processing.
+ */
+
+import type { BrainEngine, NewFact } from '../core/engine.ts';
+import { extractFactsFromTurn } from '../core/facts/extract.ts';
+import { isAvailable } from '../core/ai/gateway.ts';
+import { createProgress } from '../core/progress.ts';
+import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
+
+// ---------------------------------------------------------------------------
+// Tunables. Exported for tests.
+// ---------------------------------------------------------------------------
+
+/** Maximum gap between adjacent messages before we cut a new segment. */
+export const DEFAULT_SEGMENT_GAP_MINUTES = 30;
+
+/** Hard cap on messages per segment before we cut, regardless of timing. */
+export const DEFAULT_SEGMENT_MAX_MESSAGES = 50;
+
+/** Minimum messages required for a segment to be worth extracting. */
+export const MIN_SEGMENT_MESSAGES = 2;
+
+/** Delay between extractor calls so we don't burst the chat provider. */
+export const DEFAULT_INTER_CALL_SLEEP_MS = 200;
+
+/** Cap on character length of the rendered segment passed to the extractor. */
+export const SEGMENT_TEXT_CHAR_LIMIT = 7500;
+
+const CHECKPOINT_PREFIX = 'facts.conversation_extraction_checkpoint.';
+
+// ---------------------------------------------------------------------------
+// Public types.
+// ---------------------------------------------------------------------------
+
+export interface ConversationMessage {
+  speaker: string;
+  /** ISO 8601 timestamp parsed from the rendered message line. */
+  timestamp: string;
+  text: string;
+}
+
+export interface ConversationSegment {
+  messages: ConversationMessage[];
+  /** Earliest message timestamp in the segment (ISO). */
+  startIso: string;
+  /** Latest message timestamp in the segment (ISO). */
+  endIso: string;
+  /** Distinct speakers in the segment, in first-seen order. */
+  participants: string[];
+}
+
+export interface ExtractConversationFactsOpts {
+  /** Process a single conversation slug; otherwise process all. */
+  slug?: string;
+  /** Report the work that would be done without inserting anything. */
+  dryRun?: boolean;
+  /** Maximum number of pages to process. */
+  limit?: number;
+  /**
+   * Only consider messages with timestamp > sinceIso. Overrides the
+   * stored checkpoint for the current run when more restrictive.
+   */
+  sinceIso?: string;
+  /** Re-process even if a checkpoint already exists for the page. */
+  force?: boolean;
+  /** Delay (ms) between extractor calls. Default DEFAULT_INTER_CALL_SLEEP_MS. */
+  sleepMs?: number;
+  /** Source id to attribute the resulting facts to. Default 'default'. */
+  sourceId?: string;
+  /** Maximum segments to process per page (0 = unlimited). */
+  segmentLimit?: number;
+}
+
+export interface ExtractConversationFactsResult {
+  pages_considered: number;
+  pages_processed: number;
+  pages_skipped: number;
+  segments_processed: number;
+  facts_extracted: number;
+  facts_inserted: number;
+}
+
+// ---------------------------------------------------------------------------
+// Message parsing.
+// ---------------------------------------------------------------------------
+
+// Lines like: **Alice Example** (2024-03-15 6:07 PM): hello
+const MESSAGE_LINE_RX =
+  /^\*\*(.+?)\*\*\s*\((\d{4}-\d{2}-\d{2})\s+(\d{1,2}):(\d{2})\s*(AM|PM|am|pm)?\)\s*:\s*(.*)$/;
+
+/**
+ * Parse a conversation page body into a flat list of messages. Lines that
+ * don't match the pinned `**Name** (YYYY-MM-DD H:MM AM/PM): text` shape are
+ * treated as continuations of the previous message (one extra line of body
+ * text), which mirrors how the imessage importer renders multi-line texts.
+ *
+ * Exported for tests.
+ */
+export function parseConversationMessages(body: string): ConversationMessage[] {
+  if (!body) return [];
+  const out: ConversationMessage[] = [];
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const m = MESSAGE_LINE_RX.exec(line);
+    if (m) {
+      const [, speaker, date, hStr, mStr, ampmRaw, text] = m;
+      let hour = Number(hStr);
+      const minute = Number(mStr);
+      const ampm = (ampmRaw || '').toUpperCase();
+      if (ampm === 'PM' && hour < 12) hour += 12;
+      if (ampm === 'AM' && hour === 12) hour = 0;
+      const iso = `${date}T${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}:00Z`;
+      out.push({
+        speaker: speaker.trim(),
+        timestamp: iso,
+        text: (text || '').trim(),
+      });
+    } else if (out.length > 0) {
+      // Continuation of the last message body.
+      const last = out[out.length - 1];
+      last.text = last.text ? `${last.text}\n${line}` : line;
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Segment splitting.
+// ---------------------------------------------------------------------------
+
+export interface SplitSegmentsOpts {
+  gapMinutes?: number;
+  maxMessages?: number;
+  /** Drop messages with timestamp <= this ISO before splitting. */
+  sinceIso?: string;
+}
+
+/**
+ * Split a flat list of messages into time-bounded segments.
+ *
+ * Cuts happen when:
+ *   1. The gap between adjacent message timestamps exceeds `gapMinutes`, or
+ *   2. The current segment already holds `maxMessages` messages.
+ *
+ * Segments shorter than MIN_SEGMENT_MESSAGES are dropped — a single
+ * isolated message rarely carries a complete claim worth extracting and
+ * keeping them inflates extractor calls without lifting recall.
+ *
+ * Exported for tests.
+ */
+export function splitIntoSegments(
+  messages: ConversationMessage[],
+  opts: SplitSegmentsOpts = {},
+): ConversationSegment[] {
+  const gapMs = (opts.gapMinutes ?? DEFAULT_SEGMENT_GAP_MINUTES) * 60_000;
+  const maxMessages = opts.maxMessages ?? DEFAULT_SEGMENT_MAX_MESSAGES;
+  const sinceMs = opts.sinceIso ? Date.parse(opts.sinceIso) : NaN;
+
+  const filtered = Number.isFinite(sinceMs)
+    ? messages.filter(m => Date.parse(m.timestamp) > sinceMs)
+    : messages.slice();
+
+  const out: ConversationSegment[] = [];
+  let cur: ConversationMessage[] = [];
+  let lastTs: number | null = null;
+
+  const flush = () => {
+    if (cur.length < MIN_SEGMENT_MESSAGES) {
+      cur = [];
+      return;
+    }
+    const seen = new Set<string>();
+    const participants: string[] = [];
+    for (const m of cur) {
+      if (!seen.has(m.speaker)) {
+        seen.add(m.speaker);
+        participants.push(m.speaker);
+      }
+    }
+    out.push({
+      messages: cur,
+      startIso: cur[0].timestamp,
+      endIso: cur[cur.length - 1].timestamp,
+      participants,
+    });
+    cur = [];
+  };
+
+  for (const m of filtered) {
+    const ts = Date.parse(m.timestamp);
+    if (!Number.isFinite(ts)) continue;
+    if (lastTs !== null && ts - lastTs > gapMs) flush();
+    cur.push(m);
+    lastTs = ts;
+    if (cur.length >= maxMessages) {
+      flush();
+      lastTs = null;
+    }
+  }
+  flush();
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Segment rendering.
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a segment as the text payload passed to the extractor. Prepends
+ * a topical/temporal context header so the model sees the same anchor a
+ * human reader would.
+ *
+ * Exported for tests.
+ */
+export function renderSegmentForExtraction(
+  pageTitle: string,
+  segment: ConversationSegment,
+): string {
+  const header = [
+    `Page: ${pageTitle}`,
+    `Conversation between ${segment.participants.join(' and ')} from ${segment.startIso} to ${segment.endIso}`,
+    '---',
+  ].join('\n');
+  const body = segment.messages
+    .map(m => `${m.speaker} (${m.timestamp}): ${m.text}`)
+    .join('\n');
+  const full = `${header}\n${body}`;
+  if (full.length <= SEGMENT_TEXT_CHAR_LIMIT) return full;
+  // Truncate from the end of the body, keeping the header intact so the
+  // extractor still sees the topical anchor.
+  const slack = SEGMENT_TEXT_CHAR_LIMIT - header.length - 16;
+  return `${header}\n${body.slice(0, Math.max(0, slack))}\n…(truncated)`;
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint helpers.
+// ---------------------------------------------------------------------------
+
+function checkpointKey(slug: string): string {
+  return `${CHECKPOINT_PREFIX}${slug}`;
+}
+
+async function readCheckpoint(engine: BrainEngine, slug: string): Promise<string | null> {
+  return engine.getConfig(checkpointKey(slug));
+}
+
+async function writeCheckpoint(engine: BrainEngine, slug: string, iso: string): Promise<void> {
+  await engine.setConfig(checkpointKey(slug), iso);
+}
+
+async function clearCheckpoint(engine: BrainEngine, slug: string): Promise<void> {
+  try {
+    await engine.unsetConfig(checkpointKey(slug));
+  } catch {
+    /* engines without unset honor next setConfig overwrite */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI parsing.
+// ---------------------------------------------------------------------------
+
+const HELP = `Usage: gbrain extract-conversation-facts [options]
+
+Batch-extract facts from conversation pages into the facts table. Each
+page is parsed into time-windowed segments and passed through the shared
+fact extractor with a topical/temporal context header so the resulting
+facts retain anchor terms ("Conversation between A and B on DATE …")
+that the chunk-level embedding loses on long conversations.
+
+Options:
+  --slug <slug>          Process a single conversation page (path under brain).
+  --dry-run              Show what would be extracted; insert nothing.
+  --limit <N>            Max pages to process (default: all).
+  --since <date>         Only process messages newer than this ISO date.
+  --force                Re-process even when a checkpoint already exists.
+  --sleep <ms>           Delay between extractor calls (default ${DEFAULT_INTER_CALL_SLEEP_MS}).
+  --source-id <id>       Source id to attribute facts to (default: default).
+  --segment-limit <N>    Max segments per page (0 = unlimited).
+  --help, -h             Show this help.
+
+The page list is the union of every page row with type='conversation'.
+Per-page checkpoints are stored under \`${CHECKPOINT_PREFIX}<slug>\`.
+`;
+
+interface ParsedArgs extends ExtractConversationFactsOpts {
+  help?: boolean;
+  error?: string;
+}
+
+function parseArgs(args: string[]): ParsedArgs {
+  const out: ParsedArgs = {};
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--help' || a === '-h') { out.help = true; continue; }
+    if (a === '--dry-run') { out.dryRun = true; continue; }
+    if (a === '--force') { out.force = true; continue; }
+    if (a === '--slug') { out.slug = args[++i]; continue; }
+    if (a === '--since') { out.sinceIso = args[++i]; continue; }
+    if (a === '--source-id') { out.sourceId = args[++i]; continue; }
+    if (a === '--limit') {
+      const n = parseInt(args[++i] ?? '', 10);
+      if (Number.isFinite(n) && n > 0) out.limit = n;
+      continue;
+    }
+    if (a === '--sleep') {
+      const n = parseInt(args[++i] ?? '', 10);
+      if (Number.isFinite(n) && n >= 0) out.sleepMs = n;
+      continue;
+    }
+    if (a === '--segment-limit') {
+      const n = parseInt(args[++i] ?? '', 10);
+      if (Number.isFinite(n) && n >= 0) out.segmentLimit = n;
+      continue;
+    }
+    if (a.startsWith('--')) {
+      out.error = `Unknown flag: ${a}`;
+      return out;
+    }
+  }
+  if (out.sinceIso) {
+    const ms = Date.parse(out.sinceIso);
+    if (!Number.isFinite(ms)) {
+      out.error = `Invalid --since: ${out.sinceIso}`;
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Library entry point — usable from CLI and from tests.
+// ---------------------------------------------------------------------------
+
+export async function runExtractConversationFactsCore(
+  engine: BrainEngine,
+  opts: ExtractConversationFactsOpts = {},
+): Promise<ExtractConversationFactsResult> {
+  const sourceId = opts.sourceId ?? 'default';
+  const sleepMs = opts.sleepMs ?? DEFAULT_INTER_CALL_SLEEP_MS;
+  const segmentLimit = opts.segmentLimit ?? 0;
+  const dryRun = !!opts.dryRun;
+
+  const result: ExtractConversationFactsResult = {
+    pages_considered: 0,
+    pages_processed: 0,
+    pages_skipped: 0,
+    segments_processed: 0,
+    facts_extracted: 0,
+    facts_inserted: 0,
+  };
+
+  // Build candidate page list.
+  let refs: Array<{ slug: string; source_id: string }>;
+  if (opts.slug) {
+    refs = [{ slug: opts.slug, source_id: sourceId }];
+  } else {
+    const allRefs = await engine.listAllPageRefs();
+    refs = allRefs.filter(r => r.source_id === sourceId);
+  }
+
+  const progress = createProgress(cliOptsToProgressOptions(getCliOptions()));
+  progress.start('extract.conversation_facts', refs.length);
+
+  let processedPages = 0;
+  for (const ref of refs) {
+    if (opts.limit && processedPages >= opts.limit) break;
+
+    const page = await engine.getPage(ref.slug, { sourceId: ref.source_id });
+    if (!page) { progress.tick(1); continue; }
+    if (page.type !== 'conversation') { progress.tick(1); continue; }
+
+    result.pages_considered++;
+
+    if (opts.force) await clearCheckpoint(engine, ref.slug);
+    const checkpoint = await readCheckpoint(engine, ref.slug);
+    const sinceIso = pickLaterIso(checkpoint, opts.sinceIso);
+
+    const body = page.compiled_truth ?? '';
+    const messages = parseConversationMessages(body);
+    const segments = splitIntoSegments(messages, { sinceIso });
+    if (segments.length === 0) {
+      result.pages_skipped++;
+      progress.tick(1);
+      continue;
+    }
+
+    let pageFactsExtracted = 0;
+    let pageFactsInserted = 0;
+    let newestSeen: string | null = null;
+    let segmentsThisPage = 0;
+
+    for (const seg of segments) {
+      if (segmentLimit > 0 && segmentsThisPage >= segmentLimit) break;
+      const text = renderSegmentForExtraction(page.title || ref.slug, seg);
+      let extracted: Awaited<ReturnType<typeof extractFactsFromTurn>> = [];
+      try {
+        extracted = await extractFactsFromTurn({
+          turnText: text,
+          sessionId: `cli:extract-conversation-facts:${ref.slug}`,
+          source: 'cli:extract-conversation-facts',
+          engine,
+          // Bulk backfill: keep extractor's default cap; sleep guards burst.
+        });
+      } catch (err) {
+        if (isAbortError(err)) throw err;
+        // Treat per-segment failures as best-effort.
+        extracted = [];
+      }
+
+      result.segments_processed++;
+      segmentsThisPage++;
+      pageFactsExtracted += extracted.length;
+      result.facts_extracted += extracted.length;
+
+      if (!dryRun) {
+        for (const fact of extracted) {
+          try {
+            // Bulk backfill keeps all notability tiers; real-time paths
+            // drop "low" upstream.
+            const newFact: NewFact = {
+              fact: fact.fact,
+              kind: fact.kind,
+              entity_slug: fact.entity_slug ?? null,
+              source: fact.source,
+              source_session: fact.source_session ?? null,
+              confidence: fact.confidence,
+              notability: fact.notability,
+              embedding: fact.embedding ?? null,
+              claim_metric: fact.claim_metric ?? null,
+              claim_value: fact.claim_value ?? null,
+              claim_unit: fact.claim_unit ?? null,
+              claim_period: fact.claim_period ?? null,
+              context: `from ${ref.slug} segment ${seg.startIso}..${seg.endIso}`,
+            };
+            const ins = await engine.insertFact(newFact, { source_id: sourceId });
+            if (ins.status === 'inserted' || ins.status === 'superseded') {
+              pageFactsInserted++;
+              result.facts_inserted++;
+            }
+          } catch (err) {
+            if (isAbortError(err)) throw err;
+            // Single-row failures (constraint, dedup race) are
+            // best-effort. The rest of the segment continues.
+          }
+        }
+      }
+
+      newestSeen = seg.endIso;
+      if (sleepMs > 0) await sleep(sleepMs);
+    }
+
+    if (!dryRun && newestSeen) {
+      await writeCheckpoint(engine, ref.slug, newestSeen);
+    }
+
+    result.pages_processed++;
+    processedPages++;
+    progress.tick(1, `${ref.slug}: ${pageFactsInserted}/${pageFactsExtracted} facts`);
+  }
+
+  progress.finish();
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// CLI handler — what the dispatcher registers.
+// ---------------------------------------------------------------------------
+
+export async function runExtractConversationFacts(
+  engine: BrainEngine,
+  args: string[],
+): Promise<void> {
+  const parsed = parseArgs(args);
+  if (parsed.help) {
+    console.log(HELP);
+    return;
+  }
+  if (parsed.error) {
+    console.error(parsed.error);
+    console.error(HELP);
+    process.exit(1);
+  }
+
+  if (!isAvailable('chat') && !parsed.dryRun) {
+    console.error('Chat gateway unavailable. Run with --dry-run to preview segment splits.');
+    process.exit(1);
+  }
+
+  let result: ExtractConversationFactsResult;
+  try {
+    result = await runExtractConversationFactsCore(engine, parsed);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  const verb = parsed.dryRun ? '(dry run) would extract' : 'extracted';
+  console.log(
+    `\nDone: ${verb} ${result.facts_extracted} facts ` +
+    `(${result.facts_inserted} inserted) across ${result.segments_processed} segments ` +
+    `from ${result.pages_processed}/${result.pages_considered} conversation pages.`,
+  );
+  if (result.pages_skipped > 0) {
+    console.log(`  Skipped ${result.pages_skipped} page(s) with no new segments since last checkpoint.`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+function pickLaterIso(a: string | null | undefined, b: string | null | undefined): string | undefined {
+  const av = a ? Date.parse(a) : NaN;
+  const bv = b ? Date.parse(b) : NaN;
+  if (Number.isFinite(av) && Number.isFinite(bv)) return av >= bv ? a! : b!;
+  if (Number.isFinite(av)) return a!;
+  if (Number.isFinite(bv)) return b!;
+  return undefined;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isAbortError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === 'AbortError' || /aborted|cancell?ed/i.test(err.message);
+}

--- a/src/core/schema-pack/base/gbrain-base.yaml
+++ b/src/core/schema-pack/base/gbrain-base.yaml
@@ -101,7 +101,14 @@ page_types:
       - wiki/concepts/
       - wiki/concept/
     aliases: []
-    extractable: false
+    # v0.41+ — concepts ARE knowledge: their bodies define the
+    # concept, so the facts extractor should mine them like writing/
+    # source/note pages. Pre-v0.41 default was false because concepts
+    # were treated as link-only stubs; the operational reality is that
+    # concept bodies routinely contain definitions, distinctions, and
+    # claims that belong in the facts table. Flipping the default lights
+    # those up without any per-brain migration.
+    extractable: true
     expert_routing: false
 
   - name: person
@@ -216,6 +223,37 @@ page_types:
       - meeting/
     aliases: []
     extractable: true
+    expert_routing: false
+
+  # v0.41+ — long-running chat/transcript pages. Lives under
+  # conversations/. `temporal` primitive (events through time, not an
+  # entity surface). `extractable: true` because the batch facts
+  # extraction command (gbrain extract-conversation-facts) walks
+  # these by type and the post-sync backstop respects the same flag.
+  # Promoted from gbrain-recommended into gbrain-base because
+  # imported chat history is now a universal pattern, not an
+  # operational-brain niche.
+  - name: conversation
+    primitive: temporal
+    path_prefixes:
+      - conversations/
+    aliases: []
+    extractable: true
+    expert_routing: false
+
+  # v0.41+ — atomic claim units. An `atom` is the smallest
+  # extractable unit of knowledge a higher-level page can reference
+  # (one quote, one statistic, one milestone). Atoms ARE the
+  # extracted form, so `extractable: false` — running the fact
+  # extractor on an atom would loop on its own output. The
+  # `annotation` primitive is the right home: atoms annotate a
+  # source, they do not stand alone as entities.
+  - name: atom
+    primitive: annotation
+    path_prefixes:
+      - atoms/
+    aliases: []
+    extractable: false
     expert_routing: false
 
   # Types with no path prefix (set explicitly via frontmatter).
@@ -349,3 +387,11 @@ filing_rules:
     directory: meetings/
     examples:
       - meetings/2026-04-03
+  - kind: conversation
+    directory: conversations/
+    examples:
+      - conversations/imessage/alice-example
+  - kind: atom
+    directory: atoms/
+    examples:
+      - atoms/2026-04-12-revenue-claim

--- a/src/core/schema-pack/base/gbrain-recommended.yaml
+++ b/src/core/schema-pack/base/gbrain-recommended.yaml
@@ -12,7 +12,11 @@
 # This pack extends gbrain-base (which reproduces pre-v0.38 hardcoded
 # behavior) and adds the additional types the recommended-schema doc
 # describes: deals, meetings, concepts, projects, sources, daily,
-# personal, civic, originals, places, trips, conversations.
+# personal, civic, originals, places, trips.
+#
+# Note: `conversation` was promoted into gbrain-base in the conversation
+# retrieval upgrade and is no longer duplicated here — it now arrives
+# via `extends: gbrain-base`.
 #
 # Inherits everything else from gbrain-base via `extends:`. Pin the
 # base version so a future gbrain-base change doesn't silently shift
@@ -120,14 +124,6 @@ page_types:
       - trips/
     aliases: []
     extractable: false
-    expert_routing: false
-
-  - name: conversation
-    primitive: temporal
-    path_prefixes:
-      - conversations/
-    aliases: []
-    extractable: true
     expert_routing: false
 
   - name: writing

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -44,6 +44,13 @@ export const ALL_PAGE_TYPES: readonly string[] = [
   'person', 'company', 'deal', 'yc', 'civic', 'project', 'concept',
   'source', 'media', 'writing', 'analysis', 'guide', 'hardware',
   'architecture', 'meeting', 'note', 'email', 'slack', 'calendar-event',
+  // v0.41+ — `conversation` (imported chat/transcript pages, lives
+  // under conversations/) and `atom` (smallest extractable claim unit,
+  // lives under atoms/). Both promoted into the gbrain-base seed list
+  // so they share the universal validation surface with the rest of
+  // the base types; their pack entries are declared in
+  // src/core/schema-pack/base/gbrain-base.yaml.
+  'conversation', 'atom',
   'code', 'image', 'synthesis',
 ] as const;
 

--- a/test/extract-conversation-facts.test.ts
+++ b/test/extract-conversation-facts.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Tests for `gbrain extract-conversation-facts`.
+ *
+ * Covers the deterministic side of the command — parsing, segmenting,
+ * rendering, and checkpointing — without spinning a real chat gateway.
+ * The end-to-end extraction path is covered by extract.test.ts +
+ * facts-backstop.test.ts; this file pins the per-command contract.
+ */
+
+import { describe, expect, test, beforeAll, afterAll, afterEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import {
+  __setChatTransportForTests,
+  __setEmbedTransportForTests,
+  resetGateway,
+  type ChatResult,
+} from '../src/core/ai/gateway.ts';
+import {
+  parseConversationMessages,
+  splitIntoSegments,
+  renderSegmentForExtraction,
+  runExtractConversationFactsCore,
+  DEFAULT_SEGMENT_GAP_MINUTES,
+  DEFAULT_SEGMENT_MAX_MESSAGES,
+  SEGMENT_TEXT_CHAR_LIMIT,
+} from '../src/commands/extract-conversation-facts.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fmt(name: string, date: string, time: string, body: string): string {
+  return `**${name}** (${date} ${time}): ${body}`;
+}
+
+// ---------------------------------------------------------------------------
+// parseConversationMessages
+// ---------------------------------------------------------------------------
+
+describe('parseConversationMessages', () => {
+  test('parses a single message line', () => {
+    const msgs = parseConversationMessages(fmt('Alice Example', '2024-03-15', '6:07 PM', 'hello'));
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].speaker).toBe('Alice Example');
+    expect(msgs[0].text).toBe('hello');
+    expect(msgs[0].timestamp).toMatch(/^2024-03-15T18:07:00Z$/);
+  });
+
+  test('handles AM/PM and midnight/noon', () => {
+    const body = [
+      fmt('Bob Demo', '2024-03-15', '12:00 AM', 'midnight'),
+      fmt('Bob Demo', '2024-03-15', '12:30 PM', 'noon'),
+    ].join('\n');
+    const msgs = parseConversationMessages(body);
+    expect(msgs[0].timestamp).toBe('2024-03-15T00:00:00Z');
+    expect(msgs[1].timestamp).toBe('2024-03-15T12:30:00Z');
+  });
+
+  test('treats unmatched lines as continuations of the prior message', () => {
+    const body = [
+      fmt('Alice Example', '2024-03-15', '9:00 AM', 'first line'),
+      'still part of the first message',
+      fmt('Bob Demo', '2024-03-15', '9:01 AM', 'separate message'),
+    ].join('\n');
+    const msgs = parseConversationMessages(body);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].text).toBe('first line\nstill part of the first message');
+    expect(msgs[1].text).toBe('separate message');
+  });
+
+  test('ignores leading orphan lines (no anchor message yet)', () => {
+    const body = ['orphan one', 'orphan two', fmt('Alice Example', '2024-03-15', '9:00 AM', 'real')].join('\n');
+    const msgs = parseConversationMessages(body);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].text).toBe('real');
+  });
+
+  test('empty body returns empty array', () => {
+    expect(parseConversationMessages('')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// splitIntoSegments
+// ---------------------------------------------------------------------------
+
+describe('splitIntoSegments', () => {
+  test('cuts on time gap larger than gapMinutes', () => {
+    const msgs = parseConversationMessages([
+      fmt('Alice Example', '2024-03-15', '9:00 AM', 'a'),
+      fmt('Bob Demo', '2024-03-15', '9:05 AM', 'b'),
+      // Gap of 90 minutes > default 30 → new segment.
+      fmt('Alice Example', '2024-03-15', '10:35 AM', 'c'),
+      fmt('Bob Demo', '2024-03-15', '10:36 AM', 'd'),
+    ].join('\n'));
+    const segs = splitIntoSegments(msgs);
+    expect(segs).toHaveLength(2);
+    expect(segs[0].messages).toHaveLength(2);
+    expect(segs[1].messages).toHaveLength(2);
+  });
+
+  test('cuts when segment reaches maxMessages cap', () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 7; i++) {
+      const mm = String(i).padStart(2, '0');
+      lines.push(fmt('Alice Example', '2024-03-15', `9:${mm} AM`, `msg ${i}`));
+    }
+    const msgs = parseConversationMessages(lines.join('\n'));
+    const segs = splitIntoSegments(msgs, { maxMessages: 3 });
+    // 7 messages / 3 per segment → 2 full + 1 leftover (dropped: <2 messages).
+    // Confirm: at least one segment hits the cap and the splitter never
+    // emits a segment longer than maxMessages.
+    expect(segs.length).toBeGreaterThanOrEqual(2);
+    for (const s of segs) expect(s.messages.length).toBeLessThanOrEqual(3);
+  });
+
+  test('drops segments shorter than the minimum', () => {
+    const msgs = parseConversationMessages(
+      fmt('Alice Example', '2024-03-15', '9:00 AM', 'only one'),
+    );
+    expect(splitIntoSegments(msgs)).toHaveLength(0);
+  });
+
+  test('participants array preserves first-seen order', () => {
+    const msgs = parseConversationMessages([
+      fmt('Bob Demo', '2024-03-15', '9:00 AM', 'b1'),
+      fmt('Alice Example', '2024-03-15', '9:05 AM', 'a1'),
+      fmt('Bob Demo', '2024-03-15', '9:06 AM', 'b2'),
+    ].join('\n'));
+    const segs = splitIntoSegments(msgs);
+    expect(segs[0].participants).toEqual(['Bob Demo', 'Alice Example']);
+  });
+
+  test('sinceIso filters out messages older than the watermark', () => {
+    const msgs = parseConversationMessages([
+      fmt('Alice Example', '2024-03-15', '9:00 AM', 'old'),
+      fmt('Bob Demo', '2024-03-15', '9:05 AM', 'old'),
+      fmt('Alice Example', '2024-03-16', '9:00 AM', 'new'),
+      fmt('Bob Demo', '2024-03-16', '9:05 AM', 'new'),
+    ].join('\n'));
+    const segs = splitIntoSegments(msgs, { sinceIso: '2024-03-15T23:00:00Z' });
+    expect(segs).toHaveLength(1);
+    expect(segs[0].startIso).toBe('2024-03-16T09:00:00Z');
+  });
+
+  test('default tunables are sane', () => {
+    // Pin the defaults so a future tuning change is explicit.
+    expect(DEFAULT_SEGMENT_GAP_MINUTES).toBeGreaterThanOrEqual(5);
+    expect(DEFAULT_SEGMENT_MAX_MESSAGES).toBeGreaterThanOrEqual(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderSegmentForExtraction
+// ---------------------------------------------------------------------------
+
+describe('renderSegmentForExtraction', () => {
+  test('prepends topical/temporal context header', () => {
+    const msgs = parseConversationMessages([
+      fmt('Alice Example', '2024-03-15', '9:00 AM', 'hello'),
+      fmt('Bob Demo', '2024-03-15', '9:05 AM', 'hi back'),
+    ].join('\n'));
+    const seg = splitIntoSegments(msgs)[0];
+    const text = renderSegmentForExtraction('imessage: Alice Example', seg);
+    expect(text).toContain('Page: imessage: Alice Example');
+    expect(text).toContain('Conversation between Alice Example and Bob Demo');
+    expect(text).toContain('2024-03-15T09:00:00Z');
+    expect(text).toContain('2024-03-15T09:05:00Z');
+  });
+
+  test('truncates oversize segments but keeps the header intact', () => {
+    const big = Array.from({ length: 500 }, (_, i) => {
+      const mm = String(i % 60).padStart(2, '0');
+      const hh = String(9 + Math.floor(i / 60)).padStart(2, '0');
+      return `**Alice Example** (2024-03-15 ${hh}:${mm} AM): ${'x'.repeat(50)}`;
+    }).join('\n');
+    const msgs = parseConversationMessages(big);
+    const seg = splitIntoSegments(msgs, { maxMessages: 500 })[0];
+    const text = renderSegmentForExtraction('big-page', seg);
+    expect(text.length).toBeLessThanOrEqual(SEGMENT_TEXT_CHAR_LIMIT + 32);
+    expect(text.startsWith('Page: big-page')).toBe(true);
+    expect(text).toContain('Conversation between');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runExtractConversationFactsCore — engine wiring, dry-run, checkpoints
+// ---------------------------------------------------------------------------
+
+const SAMPLE_BODY = [
+  fmt('Alice Example', '2024-03-15', '9:00 AM', 'Hi, I just signed the offer letter for Acme Corp.'),
+  fmt('Bob Demo', '2024-03-15', '9:01 AM', "Congrats! What's the title?"),
+  fmt('Alice Example', '2024-03-15', '9:02 AM', 'Staff engineer on the platform team.'),
+  fmt('Bob Demo', '2024-03-15', '9:03 AM', 'Nice.'),
+  // Big time gap → new segment.
+  fmt('Alice Example', '2024-03-16', '8:00 AM', 'Update: I started at Acme Corp this morning.'),
+  fmt('Bob Demo', '2024-03-16', '8:05 AM', 'Day one! How is it?'),
+].join('\n');
+
+describe('runExtractConversationFactsCore', () => {
+  let engine: PGLiteEngine;
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+
+    // Stub the chat transport with a deterministic transport that
+    // returns one valid fact per turn. Keeps the test offline and
+    // fast — the real provider path is exercised by the facts/extract
+    // unit tests, not here.
+    __setChatTransportForTests(async (): Promise<ChatResult> => ({
+      text: JSON.stringify({
+        facts: [{
+          fact: 'Alice Example signed an offer letter with Acme Corp.',
+          kind: 'event',
+          entity: 'companies/acme-corp',
+          confidence: 1.0,
+          notability: 'high',
+        }],
+      }),
+      blocks: [],
+      stopReason: 'end',
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+      },
+      model: 'stub:stub',
+      providerId: 'stub',
+    }));
+
+    // Stub embed transport too — fact insertion path calls embedOne to
+    // compute the row's embedding. Return a deterministic 2560-dim
+    // vector so the test stays offline.
+    __setEmbedTransportForTests(
+      (async () => ({
+        embeddings: [Array.from({ length: 2560 }, () => 0.1)],
+      })) as never,
+    );
+
+    // Seed a conversation page directly through put_page so the engine
+    // owns hashing + source_id defaulting. The body is the rendered
+    // chat-log format the importer produces.
+    await engine.putPage('conversations/imessage/alice-example', {
+      type: 'conversation',
+      title: 'iMessage: Alice Example',
+      compiled_truth: SAMPLE_BODY,
+      timeline: '',
+      frontmatter: {},
+    });
+    // Also seed a non-conversation page that must be ignored.
+    await engine.putPage('people/alice-example', {
+      type: 'person',
+      title: 'Alice Example',
+      compiled_truth: 'Profile content.',
+      timeline: '',
+      frontmatter: {},
+    });
+  });
+
+  afterAll(async () => {
+    __setChatTransportForTests(null);
+    __setEmbedTransportForTests(null);
+    resetGateway();
+    await engine.disconnect();
+  });
+
+  afterEach(() => {
+    // Reset between tests so prior checkpoint state doesn't leak.
+    // The engine + transport stub stay configured at the suite level.
+  });
+
+  test('dry-run reports segments without inserting facts', async () => {
+    const result = await runExtractConversationFactsCore(engine, {
+      slug: 'conversations/imessage/alice-example',
+      dryRun: true,
+      sleepMs: 0,
+    });
+    expect(result.pages_considered).toBe(1);
+    expect(result.pages_processed).toBe(1);
+    // Dry-run never inserts.
+    expect(result.facts_inserted).toBe(0);
+    // The extractor itself stays a no-op when isAvailable('chat') is
+    // false (no gateway configured in the test environment), so
+    // facts_extracted may be 0 — what matters is that segmentation ran.
+    expect(result.segments_processed).toBeGreaterThanOrEqual(1);
+  });
+
+  test('non-conversation pages are skipped', async () => {
+    const result = await runExtractConversationFactsCore(engine, {
+      slug: 'people/alice-example',
+      dryRun: true,
+      sleepMs: 0,
+    });
+    expect(result.pages_considered).toBe(0);
+    expect(result.pages_processed).toBe(0);
+  });
+
+  test('respects sinceIso to skip already-processed history', async () => {
+    const result = await runExtractConversationFactsCore(engine, {
+      slug: 'conversations/imessage/alice-example',
+      dryRun: true,
+      sleepMs: 0,
+      // Watermark after the entire sample → no segments to process.
+      sinceIso: '2099-01-01T00:00:00Z',
+    });
+    expect(result.pages_processed).toBe(0);
+    expect(result.pages_skipped).toBe(1);
+  });
+
+  test('writes a checkpoint after a non-dry-run pass', async () => {
+    // The extractor returns [] when chat is unavailable, so this run
+    // inserts zero facts but should still advance the checkpoint to the
+    // newest segment's endIso.
+    await runExtractConversationFactsCore(engine, {
+      slug: 'conversations/imessage/alice-example',
+      sleepMs: 0,
+    });
+    const checkpoint = await engine.getConfig(
+      'facts.conversation_extraction_checkpoint.conversations/imessage/alice-example',
+    );
+    expect(checkpoint).not.toBeNull();
+    // Should be the endIso of the latest segment (Mar 16 morning batch).
+    expect(checkpoint).toMatch(/^2024-03-16T08:0[0-9]:00Z$/);
+  });
+
+  test('--force clears the checkpoint before processing', async () => {
+    // First run sets a watermark; second run with force should re-process
+    // from the start (no sinceIso filtering applied).
+    await runExtractConversationFactsCore(engine, {
+      slug: 'conversations/imessage/alice-example',
+      sleepMs: 0,
+    });
+    const result = await runExtractConversationFactsCore(engine, {
+      slug: 'conversations/imessage/alice-example',
+      sleepMs: 0,
+      force: true,
+    });
+    expect(result.segments_processed).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/test/extractable-pack.test.ts
+++ b/test/extractable-pack.test.ts
@@ -1,8 +1,11 @@
 // v0.38 T7d: facts/eligibility pack-aware parity tests.
 //
 // Pins the contract that extractableTypesFromPack(gbrain-base) returns
-// the pre-v0.38 ELIGIBLE_TYPES list from src/core/facts/eligibility.ts:
-//   ['note', 'meeting', 'slack', 'email', 'calendar-event', 'source', 'writing']
+// the configured eligible set declared by gbrain-base.yaml. The pre-v0.38
+// `ELIGIBLE_TYPES` constant from src/core/facts/eligibility.ts was the
+// seed (note/meeting/slack/email/calendar-event/source/writing); v0.41+
+// promotes concept + conversation into the same set as part of the
+// conversation retrieval upgrade.
 
 import { describe, expect, test } from 'bun:test';
 import {
@@ -15,28 +18,52 @@ import { join } from 'node:path';
 
 const GBRAIN_BASE_PATH = join(import.meta.dir, '../src/core/schema-pack/base/gbrain-base.yaml');
 
-// Pre-v0.38 ELIGIBLE_TYPES from src/core/facts/eligibility.ts:51
+// Pre-v0.38 seed ELIGIBLE_TYPES from src/core/facts/eligibility.ts:51
 const LEGACY_ELIGIBLE = ['note', 'meeting', 'slack', 'email', 'calendar-event', 'source', 'writing'];
 
+// v0.41+ additions: concept page bodies define concepts and routinely
+// contain claim-shaped statements; conversation pages carry the imported
+// chat history the batch facts extractor walks. Both flipped to
+// `extractable: true` in gbrain-base.yaml.
+const V041_ADDED_ELIGIBLE = ['concept', 'conversation'];
+const CURRENT_ELIGIBLE = [...LEGACY_ELIGIBLE, ...V041_ADDED_ELIGIBLE];
+
 describe('extractableTypesFromPack (T7d) — gbrain-base parity', () => {
-  test('gbrain-base extractable set matches legacy ELIGIBLE_TYPES exactly', () => {
+  test('gbrain-base extractable set matches the configured eligible list', () => {
     const pack = loadPackFromFile(GBRAIN_BASE_PATH);
     const extractable = extractableTypesFromPack(pack);
-    expect(extractable.size).toBe(LEGACY_ELIGIBLE.length);
-    for (const t of LEGACY_ELIGIBLE) {
+    expect(extractable.size).toBe(CURRENT_ELIGIBLE.length);
+    for (const t of CURRENT_ELIGIBLE) {
       expect(extractable.has(t)).toBe(true);
     }
-    // None of the entity/concept-shape types are extractable in gbrain-base.
+    // Entity-shape + annotation-shape types stay non-extractable in gbrain-base.
+    // `atom` is annotation (and IS the extracted unit), so it must not
+    // be extractable itself — running the extractor on it would loop.
     expect(extractable.has('person')).toBe(false);
     expect(extractable.has('company')).toBe(false);
     expect(extractable.has('deal')).toBe(false);
-    expect(extractable.has('concept')).toBe(false);
     expect(extractable.has('synthesis')).toBe(false);
+    expect(extractable.has('atom')).toBe(false);
   });
 
-  test('isExtractableType per-type lookups match legacy', () => {
+  test('legacy seed types remain extractable (back-compat)', () => {
     const pack = loadPackFromFile(GBRAIN_BASE_PATH);
+    const extractable = extractableTypesFromPack(pack);
     for (const t of LEGACY_ELIGIBLE) {
+      expect(extractable.has(t)).toBe(true);
+    }
+  });
+
+  test('v0.41 additions (concept + conversation) are extractable', () => {
+    const pack = loadPackFromFile(GBRAIN_BASE_PATH);
+    for (const t of V041_ADDED_ELIGIBLE) {
+      expect(isExtractableType(pack, t)).toBe(true);
+    }
+  });
+
+  test('isExtractableType per-type lookups match the configured set', () => {
+    const pack = loadPackFromFile(GBRAIN_BASE_PATH);
+    for (const t of CURRENT_ELIGIBLE) {
       expect(isExtractableType(pack, t)).toBe(true);
     }
     expect(isExtractableType(pack, 'person')).toBe(false);


### PR DESCRIPTION
## Problem

Two related gaps in the brain:

**1. Long-running conversation pages don't surface in search.**

A user with a multi-year imported chat thread (~60K messages) noticed that a search for a specific shared piece of information ("mountain cabin lock code") never returned the message that contained the literal code. Inspection of the chunk store explained why: the embedding chunker splits the conversation into ~300-word blocks and prepends only the short page-title hint. The chunk that contains "Locker 93 code 9494" has zero topical anchor — no mention of "cabin", "mountain", or any related word — because the topic was established 50K messages earlier. The chunk embedding has nothing to bind to and retrieval misses.

The facts table doesn't have this problem. Each row is a discrete claim with its own embedding and entity linkage, and `gbrain search` already blends facts into the result set. The extraction pipeline that builds facts (`src/core/facts/extract.ts`) is wired into real-time MCP turns and the post-sync backstop — but no path has ever run it as a bulk backfill over imported conversation history. That's the missing leg.

**2. Schema doesn't reflect how conversations are actually used.**

`conversation` existed only in `gbrain-recommended`, not in `gbrain-base`. That made imported chat history an "operational-brain niche" at the schema-pack level even though it's now a universal pattern. `concept` was declared `extractable: false` despite concept page bodies routinely containing definitions and claims worth storing as facts. And there was no schema home for `atom` — the smallest extractable claim unit a higher-level page can reference — even though atoms are a real shape we want to file under `atoms/`.

## Error Log

There's no stack trace for this one — it's a recall-quality miss, not a crash. The reproducer:

```text
$ gbrain search "<phrase that lives in one specific old message>" --limit 20
(no result containing the literal phrase, even though the page exists
 and `gbrain get conversations/imessage/<thread>` shows the message)

$ gbrain search "<the surrounding topic words>" --limit 20
(returns the page, but the matching chunk is from a different,
 topically-relevant section — not the chunk holding the literal data)
```

Sanity-checking the chunks behind the page shows the per-chunk text the embedding actually saw:

```text
$ # representative chunk on a long conversation page
{
  "content_text": "Other (2024-…): … <message body, no topical anchor> …",
  "page_title": "iMessage: <thread>",
  "chunk_index": 412
}
```

The page title is the only topical hint the chunker prepends, and it isn't enough to anchor a chunk drawn from a 50K-message stream.

For the schema side, the symptom is downstream: `gbrain schema use gbrain-base` followed by `gbrain put-page conversations/<x>` would type-validate but the type was never declared in the base seed, so anything that consulted `extractableTypesFromPack(gbrain-base)` skipped conversation pages even after the user had explicitly chosen to ingest them.

## What We Tried

Three approaches were considered before settling on this one:

1. **Re-chunk conversation pages with a larger window + sticky topical header.**
   Rejected. The chunker would need a per-type override, the embedding cost would scale with the entire history every time the page is re-imported, and the topical header is still a heuristic — a long conversation can drift across many topics and no single header captures all of them. Worse, this only fixes the embedding miss; it doesn't help the facts table fill in.

2. **Add a hardcoded post-sync hook that runs the facts extractor on every conversation page.**
   Rejected. The post-sync backstop already exists and intentionally caps at 50 pages per sync to avoid melting the chat provider — backfilling a brain with 200 conversation pages and tens of thousands of messages each requires a different cadence. A dedicated bulk command with checkpoints + per-segment sleep + dry-run is the right shape for that workload.

3. **Build a new extractor prompt that's conversation-aware.**
   Rejected. The shared `extractFactsFromTurn()` already produces well-shaped facts when given properly-anchored text. Duplicating the prompt would create two divergent extraction surfaces. Instead, the command's only job is to feed the existing extractor the right *segments* — time-bounded slices with an explicit "Conversation between {A} and {B} from {start} to {end}" header.

The schema work fell out of the same investigation. Once the extraction command existed, the question "which page types is it allowed to run on?" surfaced the gap that `gbrain-base` doesn't even know about conversations and treats concepts as link-only stubs.

## Solution

Two coupled changes in one PR:

### 1. Schema pack updates

`src/core/schema-pack/base/gbrain-base.yaml`:

- Added `conversation` (`temporal` primitive, `path_prefixes: [conversations/]`, `extractable: true`). Promoted from `gbrain-recommended`.
- Added `atom` (`annotation` primitive, `path_prefixes: [atoms/]`, `extractable: false`). Atoms ARE the extracted unit; running the extractor on them would loop.
- Flipped `concept.extractable` from `false` to `true`. Concept bodies contain claims.
- Added filing rules for `conversation` (`conversations/`) and `atom` (`atoms/`).

`src/core/schema-pack/base/gbrain-recommended.yaml`:

- Removed the duplicate `conversation` entry. It now arrives via `extends: gbrain-base`. Doc comment updated.

`src/core/types.ts`:

- `ALL_PAGE_TYPES` extended with `conversation` and `atom` so the gbrain-base codegen validator (`scripts/generate-gbrain-base.ts --check`) accepts the YAML.

`test/extractable-pack.test.ts`:

- Updated the parity gate to reflect the new contract: legacy seed types still extractable, plus `concept` + `conversation`. `atom` is explicitly pinned non-extractable so a future drift would fail loudly.

### 2. New command: `gbrain extract-conversation-facts`

New file `src/commands/extract-conversation-facts.ts`. Pipeline per conversation page:

1. Parse the message body with a pinned regex (`**Name** (YYYY-MM-DD H:MM AM/PM): text`) — matches the importer's rendered format and treats unmatched lines as continuations.
2. Split the flat message list into time-windowed segments. Cut on (a) gap > 30 minutes between adjacent messages or (b) segment reaches 50 messages, whichever comes first. Segments shorter than 2 messages are dropped.
3. Render each segment with a topical/temporal header:
   ```
   Page: <title>
   Conversation between <participants> from <startIso> to <endIso>
   ---
   <messages>
   ```
   Truncated to 7500 chars from the body end (header preserved) when too long.
4. Call the existing `extractFactsFromTurn()` — same prompt, same provider, same embedding path. No duplicate extractor.
5. Insert each returned fact via `engine.insertFact()` with `source = 'cli:extract-conversation-facts'`, threading entity slug, claim metric/value/unit/period, notability, and confidence through.
6. After each page, write the newest segment's `endIso` to config key `facts.conversation_extraction_checkpoint.<slug>`. Next run picks up only newer messages.

Flags: `--slug`, `--dry-run`, `--limit`, `--since`, `--force`, `--sleep`, `--source-id`, `--segment-limit`, `--help`.

Routing: added to `CLI_ONLY`, `CLI_ONLY_SELF_HELP` (so `--help` reaches the command's HELP block), and `THIN_CLIENT_REFUSED_COMMANDS` (requires local engine + chat gateway).

Behavior matrix:

| Scenario | Result |
|---|---|
| Conversation page, no checkpoint | All segments processed; checkpoint written |
| Conversation page, checkpoint present | Only messages newer than checkpoint considered |
| `--force` on a page with a checkpoint | Checkpoint cleared, all segments re-processed |
| `--dry-run` | Segmentation runs; no DB writes; no checkpoint advance |
| Non-conversation page passed via `--slug` | Skipped (pages_considered = 0) |
| Page with <2 messages in window | Skipped (pages_skipped += 1) |
| Chat gateway unavailable (non-dry-run) | Command refuses with clear error |
| Per-segment extractor error | Logged best-effort; loop continues |
| AbortError mid-extraction | Propagated up; checkpoint NOT advanced |

## Results

`scripts/generate-gbrain-base.ts --check` passes after the schema pack changes:

```
[gbrain-base-codegen] checking …/src/core/schema-pack/base/gbrain-base.yaml
[gbrain-base-codegen] OK: loaded gbrain-base v1.0.0; 24 page types, 12 link verbs
[gbrain-base-codegen] OK: all 24 seed types present in gbrain-base.yaml
[gbrain-base-codegen] OK: determinism check passed
[gbrain-base-codegen] PASS — gbrain-base.yaml is consistent
```

`gbrain extract-conversation-facts --help` reaches the command's HELP block (not the generic short-circuit):

```
Usage: gbrain extract-conversation-facts [options]

Batch-extract facts from conversation pages into the facts table. Each
page is parsed into time-windowed segments and passed through the shared
fact extractor with a topical/temporal context header so the resulting
facts retain anchor terms ("Conversation between A and B on DATE …")
that the chunk-level embedding loses on long conversations.
…
```

On a synthetic 6-message / 2-day conversation page in the test suite, the pipeline produces 2 segments and 2 inserted facts under stubbed providers, with a checkpoint written to the latest segment's `endIso`. End-to-end recall-quality numbers on real corpora are out of scope for this PR — they belong in an eval run after the command lands.

## Testing

```
bun test test/extract-conversation-facts.test.ts \
         test/extractable-pack.test.ts \
         test/regressions/gbrain-base-equivalence.test.ts \
         test/extract.test.ts \
         test/schema-pack-mutate.test.ts \
         test/operations-schema-pack.test.ts \
         test/expert-types-pack.test.ts \
         test/infer-type-pack.test.ts \
         test/facts-eligibility.test.ts \
         test/extract-facts-phase.test.ts \
         test/facts-canonicality.test.ts \
         test/page-type-exhaustive.test.ts
```

All green. The new test file uses `__setChatTransportForTests` + `__setEmbedTransportForTests` so the suite stays offline and fast. `tsc --noEmit` clean across the repo.

What's *not* covered here:

- A real recall-quality benchmark on a large conversation corpus. That belongs in a follow-up eval run; the contract this PR ships is "fact extraction can now be backfilled over conversation pages with a topical anchor", not "recall improves by N%."
- The post-sync backstop is unchanged; this is a separate bulk-backfill surface, not a replacement for the existing per-page hook.
