### PR TITLE
fix(postgres-engine): pair pg_advisory_lock acquire+release on same backend via pool.reserve()

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -271,9 +271,8 @@ export class PostgresEngine implements BrainEngine {
     // is in dual-pool mode. The pooler's 2-min statement_timeout truncates
     // SCHEMA_SQL replays + migrations on Supabase; the direct pool gets
     // 30min. Lane B replaces the lock primitive with a TTL+heartbeat table
-    // lock; Lane A does the routing and keeps pg_advisory_lock(42) on the
-    // SAME connection so the lock is correct.
-    const conn = this.connectionManager
+    // lock; Lane A does the routing.
+    const pool = this.connectionManager
       ? await this.connectionManager.ddl()
       : this.sql;
 
@@ -295,62 +294,86 @@ export class PostgresEngine implements BrainEngine {
     // Advisory lock prevents concurrent initSchema() calls from deadlocking
     // on DDL statements (DROP TRIGGER + CREATE TRIGGER acquire AccessExclusiveLock).
     //
-    // v0.30.1 honest limitation: pg_advisory_lock(42) is session-scoped to
-    // `conn`. When dual-pool routing is active, conn is a direct-pool reserved
-    // backend, so the lock is held for the duration of initSchema. Lane B
-    // replaces this with a TTL+heartbeat table lock that survives pooler-side
-    // session resets.
-    const t0 = Date.now();
-    logConnectionEvent({
-      pool: this.connectionManager?.isDualPoolActive() ? 'ddl' : 'read',
-      op: 'acquire',
-      caller: 'PostgresEngine.initSchema',
-    });
-    await conn`SELECT pg_advisory_lock(42)`;
+    // pg_advisory_lock(42) is session-scoped: the lock is held by ONE physical
+    // Postgres backend, not by the whole pool. postgres.js's tag-template
+    // syntax pulls a fresh connection from the pool on each call by default,
+    // so a bare `pool`SELECT pg_advisory_lock(42)`` + `pool`SELECT
+    // pg_advisory_unlock(42)`` pair runs against TWO DIFFERENT backends.
+    // Acquire succeeds on backend A; unlock fires against backend B and
+    // returns false silently ("not held by current session"). Backend A's
+    // session sits in the pool idle, still holding the lock indefinitely.
+    // Every subsequent initSchema() then blocks on `SELECT pg_advisory_lock`
+    // until statement_timeout fires — symptom: CLI cold-start hangs ~5 min
+    // on large brains. Diagnosed against a real 440K-page brain where one
+    // backend had been holding lock 42 idle for 14h since the autopilot
+    // worker's first initSchema call.
+    //
+    // Fix: pool.reserve() pins the lock acquire + release pair to the same
+    // physical connection so the unlock actually fires on the session that
+    // holds the lock. Same pattern executeRaw uses elsewhere in this file.
+    const reserved = await pool.reserve();
     try {
-      // Pre-schema bootstrap: add forward-referenced state the embedded schema
-      // blob requires but that older brains don't have yet (issues #366/#375/
-      // #378/#396 + #266/#357). Idempotent on fresh installs and modern brains.
-      // Threads the DDL connection (same one holding the advisory lock above)
-      // so bootstrap probes run on the locked connection — without this, the
-      // probes ran through `this.sql` (the pooler/instance pool) outside the
-      // lock, opening a concurrent-bootstrap race for Supabase users on the
-      // transaction pooler. Codex P1 finding from v0.36 dreamy-thompson wave.
-      await this.applyForwardReferenceBootstrap(conn);
-
-      await conn.unsafe(sqlText);
-
-      // Run any pending migrations automatically
-      const { applied } = await runMigrations(this);
-      if (applied > 0) {
-        process.stderr.write(`  ${applied} migration(s) applied\n`);
-      }
-
-      // Post-migration schema verification: catches columns that migrations
-      // defined but PgBouncer transaction-mode silently failed to create.
-      // Self-heals missing columns via ALTER TABLE ADD COLUMN IF NOT EXISTS.
-      const verify = await verifySchema(this);
-      if (verify.healed.length > 0) {
-        process.stderr.write(`  Schema verify: self-healed ${verify.healed.length} missing column(s)\n`);
-      }
-
-      // v0.30.1 (Fix 5): sweep zombie HNSW indexes (indisvalid=false) from
-      // crashed CREATE INDEX CONCURRENTLY calls. Best-effort; errors logged
-      // to stderr but never block engine.connect.
-      try {
-        const result = await dropZombieIndexes(this);
-        if (result.dropped.length > 0) {
-          process.stderr.write(`  HNSW sweep: dropped ${result.dropped.length} zombie index(es)\n`);
-        }
-      } catch { /* best-effort */ }
-    } finally {
-      await conn`SELECT pg_advisory_unlock(42)`;
+      const t0 = Date.now();
       logConnectionEvent({
         pool: this.connectionManager?.isDualPoolActive() ? 'ddl' : 'read',
-        op: 'release',
+        op: 'acquire',
         caller: 'PostgresEngine.initSchema',
-        duration_ms: Date.now() - t0,
       });
+      await reserved`SELECT pg_advisory_lock(42)`;
+      try {
+        // Pre-schema bootstrap: add forward-referenced state the embedded schema
+        // blob requires but that older brains don't have yet (issues #366/#375/
+        // #378/#396 + #266/#357). Idempotent on fresh installs and modern brains.
+        // Threads the reserved connection (same one holding the advisory lock
+        // above) so bootstrap probes run on the locked connection — without
+        // this, the probes ran through `this.sql` (the pooler/instance pool)
+        // outside the lock, opening a concurrent-bootstrap race for Supabase
+        // users on the transaction pooler. Codex P1 finding from v0.36
+        // dreamy-thompson wave.
+        await this.applyForwardReferenceBootstrap(reserved);
+
+        await reserved.unsafe(sqlText);
+
+        // Run any pending migrations automatically
+        const { applied } = await runMigrations(this);
+        if (applied > 0) {
+          process.stderr.write(`  ${applied} migration(s) applied\n`);
+        }
+
+        // Post-migration schema verification: catches columns that migrations
+        // defined but PgBouncer transaction-mode silently failed to create.
+        // Self-heals missing columns via ALTER TABLE ADD COLUMN IF NOT EXISTS.
+        const verify = await verifySchema(this);
+        if (verify.healed.length > 0) {
+          process.stderr.write(`  Schema verify: self-healed ${verify.healed.length} missing column(s)\n`);
+        }
+
+        // v0.30.1 (Fix 5): sweep zombie HNSW indexes (indisvalid=false) from
+        // crashed CREATE INDEX CONCURRENTLY calls. Best-effort; errors logged
+        // to stderr but never block engine.connect.
+        try {
+          const result = await dropZombieIndexes(this);
+          if (result.dropped.length > 0) {
+            process.stderr.write(`  HNSW sweep: dropped ${result.dropped.length} zombie index(es)\n`);
+          }
+        } catch { /* best-effort */ }
+      } finally {
+        // Unlock fires on the SAME reserved connection — pair invariant.
+        await reserved`SELECT pg_advisory_unlock(42)`;
+        logConnectionEvent({
+          pool: this.connectionManager?.isDualPoolActive() ? 'ddl' : 'read',
+          op: 'release',
+          caller: 'PostgresEngine.initSchema',
+          duration_ms: Date.now() - t0,
+        });
+      }
+    } finally {
+      // Always return the reserved backend to the pool. Even if the unlock
+      // above threw (or never ran due to a process kill mid-finally), this
+      // releases our reservation; the underlying session continues to hold
+      // the advisory lock only until TCP eventually closes, but no new
+      // reservation will collide with it.
+      reserved.release();
     }
   }
 

--- a/test/e2e/postgres-initschema-advisory-lock.test.ts
+++ b/test/e2e/postgres-initschema-advisory-lock.test.ts
@@ -1,0 +1,105 @@
+/**
+ * E2E regression test for the v0.41.x initSchema advisory-lock leak fix.
+ *
+ * Pre-fix bug: `PostgresEngine.initSchema()` ran `pool`SELECT
+ * pg_advisory_lock(42)`` to acquire the lock and `pool`SELECT
+ * pg_advisory_unlock(42)`` in the finally block to release. postgres.js
+ * pulls a fresh physical connection from the pool on each tag-template
+ * call, so the acquire ran on backend A and the unlock fired on backend B.
+ * Postgres returned `false` from the unlock (lock not held by current
+ * session) and the lock stayed held on backend A's session indefinitely.
+ *
+ * Symptom in production: CLI cold-start hangs ~5 min on every subsequent
+ * `initSchema()` because `SELECT pg_advisory_lock(42)` blocks until
+ * `statement_timeout` fires. Observed against a 440K-page brain where one
+ * backend had been holding lock 42 idle for 14h since the autopilot
+ * worker's first call.
+ *
+ * Fix: wrap the lock acquire + release pair in `pool.reserve()` so both
+ * queries hit the same physical connection.
+ *
+ * This test:
+ *   1. Connects + runs initSchema (acquires + releases lock 42 on backend A)
+ *   2. Asserts lock 42 is NOT held after initSchema returns
+ *   3. Connects a second engine + runs initSchema again
+ *   4. Asserts the second initSchema completes promptly (no 5-min hang)
+ *
+ * Pre-fix this test would either hang on step 3 (until statement_timeout)
+ * or show lock 42 still held in step 2's assertion. Either way: red.
+ *
+ * Run: DATABASE_URL=postgresql://... bun run test:e2e \
+ *      test/e2e/postgres-initschema-advisory-lock.test.ts
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import postgres from 'postgres';
+import { PostgresEngine } from '../../src/core/postgres-engine.ts';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const skip = !DATABASE_URL;
+
+describe.skipIf(skip)('PostgresEngine.initSchema advisory-lock pair invariant (E2E)', () => {
+  let sql: postgres.Sql;
+
+  beforeAll(async () => {
+    sql = postgres(DATABASE_URL!, { max: 2 });
+  });
+
+  afterAll(async () => {
+    await sql.end();
+  });
+
+  test('initSchema does not leak advisory lock 42', async () => {
+    const engine = new PostgresEngine();
+    await engine.connect({ database_url: DATABASE_URL! });
+    try {
+      await engine.initSchema();
+
+      // Lock 42 MUST be released by the time initSchema returns. Pre-fix
+      // this assertion failed because acquire + release fired on different
+      // pool connections; the original session retained the lock.
+      const held = await sql<{ pid: number }[]>`
+        SELECT pid FROM pg_locks
+        WHERE locktype = 'advisory'
+          AND objid = 42
+          AND granted = true
+      `;
+      expect(held.length).toBe(0);
+    } finally {
+      await engine.disconnect();
+    }
+  }, 60_000);
+
+  test('two consecutive initSchema calls do not block each other', async () => {
+    // Pre-fix: the FIRST initSchema would leak lock 42 (acquire on conn A,
+    // unlock on conn B). The SECOND initSchema would block on `SELECT
+    // pg_advisory_lock(42)` until statement_timeout fired (~5 min default).
+    // Post-fix: both calls complete in <1s typical, well under our 30s gate.
+    const e1 = new PostgresEngine();
+    await e1.connect({ database_url: DATABASE_URL! });
+    try {
+      const t0 = Date.now();
+      await e1.initSchema();
+      const firstCallMs = Date.now() - t0;
+
+      const e2 = new PostgresEngine();
+      await e2.connect({ database_url: DATABASE_URL! });
+      try {
+        const t1 = Date.now();
+        await e2.initSchema();
+        const secondCallMs = Date.now() - t1;
+
+        // Generous wall-clock gate: <30s on each call. Pre-fix the second
+        // call hung the full statement_timeout window (default 5 min) and
+        // failed loud. Post-fix typical wallclock is <1s; we leave headroom
+        // for CI machines + cold-cache effects.
+        expect(firstCallMs).toBeLessThan(30_000);
+        expect(secondCallMs).toBeLessThan(30_000);
+      } finally {
+        await e2.disconnect();
+      }
+    } finally {
+      await e1.disconnect();
+    }
+  }, 90_000);
+});


### PR DESCRIPTION
## Problem

`PostgresEngine.initSchema()` acquires advisory lock 42 and later releases it via bare tag-template calls on the pool. postgres.js pulls a fresh physical connection from the pool on each call, so in **single-pool mode** (`conn = this.sql`) the acquire lands on backend A and the unlock fires on backend B — which silently returns `false` ("not held by current session"). Backend A's session then sits idle in the pool still holding lock 42 indefinitely.

Every subsequent `initSchema()` blocks on `SELECT pg_advisory_lock(42)` until `statement_timeout` fires. Symptom: **CLI cold-start hangs ~5 min** on every command that connects to the engine. Diagnosed against a real 440K-page Postgres brain where one backend had held lock 42 idle for 14h since the autopilot worker's first `initSchema()` call; killing the stale backend dropped cold-start from 5+ min to 1.28s.

## Fix

`pool.reserve()` pins the lock acquire + release pair (and the threaded bootstrap + `SCHEMA_SQL` replay) to the same physical connection, so the unlock actually fires on the session holding the lock. Same pattern `executeRaw` uses elsewhere in this file. `runMigrations`/`verifySchema`/`dropZombieIndexes` keep their own connection management. Postgres-only (the PGLite half is #1337), so engine-parity is unaffected.

## Test

`test/e2e/postgres-initschema-advisory-lock.test.ts` — asserts (1) after one `initSchema()`, lock 42 is held by no backend; (2) two consecutive `initSchema()` calls each complete in <30s (pre-fix the second blocked until statement_timeout).

---
*Rebased onto current `master` (post-`f3ade6c0` ownership-token + `ec5fed29` reconnect rework). The split-backend bug persists in today's `initSchema`, so the fix still applies.*
