### PR TITLE
fix(autopilot): switch main engine to instance-owned pool so mid-cycle singleton-null doesn't lose rows + break getHealth

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -21,6 +21,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, uti
 import { join } from 'path';
 import { execSync } from 'child_process';
 import type { BrainEngine } from '../core/engine.ts';
+import type { EngineConfig } from '../core/types.ts';
 import { loadPreferences } from '../core/preferences.ts';
 import { loadConfig, gbrainPath as gbrainHomePath } from '../core/config.ts';
 import { ChildWorkerSupervisor } from '../core/minions/child-worker-supervisor.ts';
@@ -176,6 +177,33 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
   } catch { /* best-effort */ }
 
   console.log(`Autopilot starting. Repo: ${repoPath}, interval: ${baseInterval}s`);
+
+  // Switch the autopilot's main engine onto an instance-owned pool so
+  // mid-cycle code paths that null the module-level `db.ts` singleton can't
+  // break later phases. See issue (filed companion) for the full bug class:
+  // `engine.connect(config)` without `poolSize` routes to the module-level
+  // singleton (`postgres-engine.ts:175-189`); the engine's own `_sql` stays
+  // null and `this.sql` falls back to `db.getConnection()`. Once anything
+  // nulls that singleton mid-cycle, every later engine call through the
+  // getter throws "connect() has not been called" — including the silent
+  // batch-error path in `extract.ts:614-628` (which loses rows on swallow)
+  // and the `engine.getHealth()` call later in this loop.
+  //
+  // Re-calling `engine.connect` with `poolSize` set is safe: it overwrites
+  // `_savedConfig`, creates a fresh instance pool, and the getter returns
+  // that pool first (`_sql ? _sql : db.getConnection()`). PGLite engines
+  // are unaffected — `poolSize` is ignored on that engine.
+  if (engine.kind === 'postgres') {
+    const savedCfg = (engine as unknown as { _savedConfig?: EngineConfig })._savedConfig;
+    const hasInstancePool = (engine as unknown as { _sql?: unknown })._sql != null;
+    if (savedCfg && !hasInstancePool) {
+      try {
+        await engine.connect({ ...savedCfg, poolSize: 5 } as EngineConfig & { poolSize: number });
+      } catch (e) {
+        console.error(`[autopilot] could not switch engine to instance pool: ${(e as Error).message}`);
+      }
+    }
+  }
 
   // Mode resolution: Minions dispatch when the user has opted in AND the
   // worker daemon can actually run (Postgres only; PGLite's exclusive file

--- a/test/autopilot-instance-pool.test.ts
+++ b/test/autopilot-instance-pool.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression guards for the autopilot's "switch to instance-owned pool" step.
+ *
+ * Bug class (companion issue): when `connectEngine()` calls
+ * `engine.connect(config)` WITHOUT `poolSize`, PostgresEngine routes through
+ * the module-level singleton in `db.ts` and the engine's own `_sql` stays
+ * null. Any mid-cycle code path that nulls that singleton makes every later
+ * engine call through the `this.sql` getter throw "connect() has not been
+ * called" — silently losing rows in `extract.ts`'s catch-and-swallow batch
+ * path AND breaking the post-cycle `engine.getHealth()` call.
+ *
+ * The fix re-calls `engine.connect({ ...savedConfig, poolSize: N })` at
+ * autopilot startup so the engine owns its own pool and is immune to
+ * singleton dropouts. PGLite engines are unaffected (poolSize is ignored).
+ *
+ * runAutopilot's startup path is deep enough that a full behavioral test
+ * needs a Postgres fixture. These static-shape regressions pin the
+ * load-bearing pieces so the fix can't silently regress in a future
+ * refactor.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const AUTOPILOT_SRC = readFileSync(
+  join(import.meta.dir, '..', 'src', 'commands', 'autopilot.ts'),
+  'utf8',
+);
+
+describe('autopilot.ts instance-pool switch (companion to issue)', () => {
+  it('imports EngineConfig for the connect-config widening cast', () => {
+    expect(AUTOPILOT_SRC).toContain(
+      "import type { EngineConfig } from '../core/types.ts';",
+    );
+  });
+
+  it("gates the switch on engine.kind === 'postgres'", () => {
+    // PGLite engines must NOT enter this branch — poolSize is ignored on
+    // PGLite and the file-lock model makes a second connect() unsafe.
+    expect(AUTOPILOT_SRC).toMatch(/engine\.kind\s*===\s*'postgres'/);
+  });
+
+  it("reads _savedConfig from the engine (private-field cast)", () => {
+    // The field is private on PostgresEngine. The narrow `as unknown as
+    // { _savedConfig?: EngineConfig }` cast is intentional — going through
+    // a structural shape rather than `as any` keeps the type-check coverage
+    // for the rest of the block.
+    expect(AUTOPILOT_SRC).toMatch(
+      /_savedConfig\?:\s*EngineConfig\s*\}\)\._savedConfig/,
+    );
+  });
+
+  it("skips the switch when _sql is already set (instance pool already owned)", () => {
+    // If a future caller wires the autopilot engine with poolSize directly,
+    // _sql will be non-null and the second connect() is unnecessary work.
+    // The guard prevents that wasted reconnect.
+    expect(AUTOPILOT_SRC).toMatch(/_sql\?:\s*unknown\s*\}\)\._sql\s*!=\s*null/);
+  });
+
+  it("calls engine.connect with poolSize: 5 cast to the widened type", () => {
+    // The exact shape `{ ...savedCfg, poolSize: 5 } as EngineConfig & ...`
+    // is load-bearing — `EngineConfig` alone doesn't have `poolSize` so
+    // the cast is required.
+    expect(AUTOPILOT_SRC).toMatch(
+      /engine\.connect\(\{\s*\.\.\.savedCfg,\s*poolSize:\s*5\s*\}\s*as\s*EngineConfig\s*&\s*\{\s*poolSize:\s*number\s*\}/,
+    );
+  });
+
+  it("guards the connect call in try/catch so a single-pool startup error doesn't abort the daemon", () => {
+    // If the fresh pool can't be created (transient network, DB down), the
+    // daemon should log and continue, not crash. The launchd respawn path
+    // would kick in if continued operation also fails, but a one-shot
+    // pool-init blip shouldn't take down the supervisor.
+    expect(AUTOPILOT_SRC).toMatch(
+      /try\s*\{[\s\S]{0,300}engine\.connect\(\{[\s\S]{0,80}poolSize:\s*5[\s\S]{0,80}\}[\s\S]{0,300}catch[\s\S]{0,200}could not switch engine to instance pool/,
+    );
+  });
+
+  it("runs the switch BEFORE mode-resolution + worker spawn", () => {
+    // The switch must happen before any phase tries to use this.sql. Source
+    // ordering: instance-pool block appears before `const mode = loadPreferences`
+    // and before `if (spawnManagedWorker)`.
+    const switchIdx = AUTOPILOT_SRC.indexOf('could not switch engine to instance pool');
+    const modeIdx = AUTOPILOT_SRC.indexOf('loadPreferences().minion_mode');
+    const spawnIdx = AUTOPILOT_SRC.indexOf('if (spawnManagedWorker)');
+    expect(switchIdx).toBeGreaterThan(-1);
+    expect(modeIdx).toBeGreaterThan(switchIdx);
+    expect(spawnIdx).toBeGreaterThan(switchIdx);
+  });
+});


### PR DESCRIPTION
## The bug

Companion to issue #1413.

On Postgres engine, `gbrain autopilot` silently loses link rows during the `extract.links_fs` phase, and `engine.getHealth()` post-cycle throws `No database connection: connect() has not been called` on every tick.

Root cause: `connectEngine()` in cli.ts calls `engine.connect(config)` without a `poolSize` arg, which routes `PostgresEngine.connect()` to the module-level singleton branch (`postgres-engine.ts:175-189`). The engine's own `_sql` stays null and `this.sql` falls back to `db.getConnection()`. Something in the cycle's call graph nulls that singleton mid-tick, after which every later `this.sql` access throws.

Confirmed reproducible on v0.41.0.0 with `gbrain dream --dir <repo> --json`. The log shows:

```
[cycle.extract] start
[extract.links_fs] 3/3 (100%)
  batch error (2 link rows lost): No database connection: connect() has not been called. Fix: Run gbrain init --supabase or gbrain init --url <connection_string>
[extract.links_fs] 3/3 (100%) done
```

The reported `extracted=N` count in the human log line looks healthy because it reflects intent, not actual rows persisted. `extract.ts:614-628`'s `flush()` catches the throw, logs the line, and `batch.length = 0` in the `finally` clears the un-inserted rows.

Same bug class as the source comment at `src/commands/auth.ts:52` — auth-command instance was fixed by having `withConfiguredSql` call `engine.connect()`; this PR closes the autopilot instance.

## The fix

Re-call `engine.connect({ ...savedConfig, poolSize: 5 })` at autopilot startup so the engine moves to instance-owned pool (`postgres-engine.ts:127-174`). With `poolSize` set, `_sql` is created and the getter returns it directly; the module singleton is no longer load-bearing for this daemon.

PGLite engines are unaffected — `poolSize` is ignored on that engine.

The switch is gated on `engine.kind === 'postgres'` and skipped when `_sql` is already non-null (a future caller could wire the engine with `poolSize` upstream of autopilot; the guard avoids a wasted reconnect). The connect call is wrapped in try/catch so a transient pool-init blip logs and continues rather than killing the supervisor.

```diff
+  if (engine.kind === 'postgres') {
+    const savedCfg = (engine as unknown as { _savedConfig?: EngineConfig })._savedConfig;
+    const hasInstancePool = (engine as unknown as { _sql?: unknown })._sql != null;
+    if (savedCfg && !hasInstancePool) {
+      try {
+        await engine.connect({ ...savedCfg, poolSize: 5 } as EngineConfig & { poolSize: number });
+      } catch (e) {
+        console.error(`[autopilot] could not switch engine to instance pool: ${(e as Error).message}`);
+      }
+    }
+  }
```

Private-field access goes through a narrow structural cast rather than `as any` so the rest of the block keeps its type coverage. If you'd prefer a public method on `BrainEngine` (e.g. `ensureInstancePool(size: number)`), happy to split that into a follow-up — the broader interface change felt out of scope for the first fix.

## Tests

New `test/autopilot-instance-pool.test.ts` follows the static-shape style of `test/autopilot-supervisor-wiring.test.ts` (7 cases): kind gate, `_savedConfig` read shape, `_sql !=  null` guard, `poolSize: 5` cast shape, try/catch wrap, source-ordering before mode/spawn, import of `EngineConfig`. Full behavioral test would need a Postgres fixture; the static guards catch refactor regressions cheaply.

All 94 existing autopilot tests still pass.

## Verified locally

Applied to v0.41.0.0 against a Postgres-engine brain. Every cycle phase runs end-to-end (16 phases including extract_facts / consolidate / propose_takes / grade_takes / calibration_profile / orphans / schema_suggest / purge). No `batch error` lines. No `[health] ERROR` lines. `engine.getHealth()` returns a real `brain_score`. `extract.links_fs` writes real rows.

## Relationship to PR #465

PR #465 (open, ~1 month no review) fixes the `(engine as any).connect?.()` no-config-arg bug in the autopilot reconnect path. It's a real fix and lands when this lands. But #465 alone leaves THIS bug fully present — the daemon stays alive (good — that's what #465 ships) but every cycle still loses rows and `getHealth` still throws.

Independent fixes; can land in either order.
