### PR TITLE
fix(lint): only unwrap whole-page code fences, not mid-document blocks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "gbrain",
+  "version": "0.25.1",
+  "description": "Personal knowledge brain skillpack — semantic + keyword retrieval over Postgres + pgvector. Skills include signal-detector, daily-task-prep, concept-synthesis, perplexity-research, briefing, and 60+ others under skills/."
+}

--- a/skills/perplexity-research/SKILL.md
+++ b/skills/perplexity-research/SKILL.md
@@ -203,8 +203,9 @@ trailing whitespace is allowed after the closing fence.
 ````markdown
 ```json
 {
-  "envelope_version": 1,
+  "envelope_version": 2,
   "brain_page_slug": "research/<exact-slug-you-wrote>",
+  "summary": "<2-3 sentence executive summary — same content as the `> Executive summary:` block at the top of the brain page>",
   "citations": [
     {"title": "<source title>", "url": "<source URL>", "accessed": "YYYY-MM-DD"}
   ],
@@ -219,10 +220,24 @@ trailing whitespace is allowed after the closing fence.
 
 Schema rules:
 
-- `envelope_version` — integer, currently `1`. Bump only via a
-  coordinated SKILL.md + caller change.
+- `envelope_version` — integer, currently `2`. Bump only via a
+  coordinated SKILL.md + caller change. v1 (without `summary`) is
+  still accepted by callers but is deprecated; emit `2`.
 - `brain_page_slug` — **exact** slug of the page you wrote. No leading
   slash, no `.md` extension. Must match `^[a-zA-Z0-9_\-/]+$`.
+- `summary` — **v2-only.** 2-3 sentences of executive summary
+  describing what the research found. Same content as the
+  `> Executive summary:` block at the top of the brain-page
+  markdown body. This field exists because the caller can only
+  cheaply parse the JSON envelope — without it, the caller falls
+  back to the FIRST LINE of your stdout, which is normally your
+  natural preamble ("Page written. Here's the final output…")
+  rather than substantive content. **NOT a status confirmation;
+  NOT "Page written"; NOT "Emitting envelope".** A caller
+  validator (mirror of the SRW UI's `isEnvelopeChatter`) rejects
+  preamble-shaped summaries and triggers a retry.
+  - Positive example: `"summary": "Three independent sources confirm B2B SaaS marketing leaders are shifting 15-30% of search budget to AI-visibility work. Buyer archetype consistent across editorial, commercial, and technical sources."`
+  - Negative example (rejected): `"summary": "Page written. Emitting the output envelope per --output-envelope."`
 - `citations[]` — one entry per source you cited in the markdown above.
   Every URL in the markdown body must appear here. Do not invent
   citations that aren't in the markdown.

--- a/skills/perplexity-research/SKILL.md
+++ b/skills/perplexity-research/SKILL.md
@@ -158,6 +158,28 @@ the agent doesn't re-narrate already-known facts.
 Pass `recency_filter` to Perplexity: `hour | day | week | month`. Useful
 for news-cycle topics; omit for evergreen research.
 
+## Recognized flags
+
+When invoked via `claude -p "/perplexity-research <args>"` (or the
+equivalent slash invocation), treat these tokens as parameters, not
+as topic text:
+
+- `--topic <text>` — the topic to research (required if no positional
+  argument).
+- `--context-slugs <slug,slug,...>` — comma-separated gbrain page
+  slugs to load as brain-context (alternative to inline embedding).
+- `--inline-context <text>` — additional inline context. Used in
+  addition to any `--context-slugs` content, not instead of.
+- `--recency <hour|day|week|month|none>` — recency filter passed to
+  Perplexity. Default: omit (no filter).
+- `--model <sonar|sonar-pro>` — Perplexity model. Default: `sonar-pro`.
+- `--run-id <id>` — caller-provided ID used in the brain page slug:
+  `research/<run-id>-<topic-slug>` (no `.md` suffix; `put_page`
+  appends `.md` for the on-disk file). If omitted, fall back to the
+  date-based slug (existing behavior).
+- `--output-envelope` — emit the trailing JSON block per the
+  "Output envelope" section below.
+
 ## Anti-Patterns
 
 - ❌ Sending NO brain context. Then it's just a search — use `web_fetch`
@@ -166,6 +188,55 @@ for news-cycle topics; omit for evergreen research.
   know." Send dense context.
 - ❌ Discarding citations. Every claim in the output must have a URL.
 - ❌ Skipping the cross-link step when entities are mentioned. Iron Law.
+
+## Output envelope (programmatic callers)
+
+When invoked with `--output-envelope` (e.g. by SRW's `RunSkillActivity`
+dispatch in `agentic-temporal-os`), **end your output with a single
+fenced JSON block** in addition to the normal brain-page markdown.
+This block is parsed by the caller; do not omit it, paraphrase it,
+or embed it in prose.
+
+The block MUST be the last content in your output. Only optional
+trailing whitespace is allowed after the closing fence.
+
+````markdown
+```json
+{
+  "envelope_version": 1,
+  "brain_page_slug": "research/<exact-slug-you-wrote>",
+  "citations": [
+    {"title": "<source title>", "url": "<source URL>", "accessed": "YYYY-MM-DD"}
+  ],
+  "key_deltas": [
+    "<one-line summary of each Recommended Brain Update>"
+  ],
+  "cost_cents": 4,
+  "latency_ms": 8200
+}
+```
+````
+
+Schema rules:
+
+- `envelope_version` — integer, currently `1`. Bump only via a
+  coordinated SKILL.md + caller change.
+- `brain_page_slug` — **exact** slug of the page you wrote. No leading
+  slash, no `.md` extension. Must match `^[a-zA-Z0-9_\-/]+$`.
+- `citations[]` — one entry per source you cited in the markdown above.
+  Every URL in the markdown body must appear here. Do not invent
+  citations that aren't in the markdown.
+- `key_deltas[]` — one-line summary per item in the "Recommended Brain
+  Updates" section. Empty array allowed.
+- `cost_cents` — integer, best-effort. If unsure, report the Perplexity
+  model's known per-call price (`sonar-pro` = 4, `sonar` = 1) rounded
+  up to integer.
+- `latency_ms` — integer milliseconds. If unsure, set to 0.
+
+If `--output-envelope` is **not** passed, do not emit the block —
+existing freeform behavior is unchanged. The mining cron callers
+(`signal-detector`, `daily-task-prep`, `concept-synthesis`) don't pass
+the flag and must keep their current output shape.
 
 ## Environment
 

--- a/skills/perplexity-research/SKILL.md
+++ b/skills/perplexity-research/SKILL.md
@@ -85,6 +85,34 @@ Each item: which page, what to add or change, source URL.
 - [Source title](URL) — accessed YYYY-MM-DD
 - [Source title](URL) — accessed YYYY-MM-DD
 - ...
+
+## Facts
+3-8 typed `key=value` claims anchored in the cited sources above. Format:
+one claim per line, kebab-case-or-snake_case keys, scalar or quoted-string
+values. These feed gbrain's claim-trajectory machinery (`extract_facts`
+runs on `put_page`) and downstream consumers like the Solution-Research
+Workflow that read accumulated typed claims back into Phase 5/6/7 prompts.
+
+Rules:
+- Keys lowercase `[a-z][a-z0-9_]*` (snake_case) — gbrain's metric-ID
+  contract. The Solution-Research Workflow's facts validator
+  (`internal/temporal/solution_research_facts_validator.go`) rejects
+  kebab-case, leading-digit, or mixed-case keys.
+- Values: scalars (numbers, ISO dates, booleans) or short quoted
+  strings. Prefer verifiable, time-bounded, comparable claims — these
+  survive cross-run comparison.
+- 3 claims minimum; ~8 is plenty. Avoid prose claims.
+
+Examples:
+- `mid_market_saas_mrr_floor_usd=50000`
+- `legal_ai_overview_trigger_rate_pct=75`
+- `competitor_citation_share_pct_source="vendor-anecdote"`
+- `reference_year=2026`
+
+A research page WITHOUT a `## Facts` block still ingests fine, but the
+trajectory / scorecard / SRW facts-loader paths have nothing to consume
+for this run. Consumers degrade gracefully (empty-snapshot), but
+emitting the block is strictly better.
 ```
 
 ## Invocation

--- a/skills/perplexity-research/SKILL.md
+++ b/skills/perplexity-research/SKILL.md
@@ -221,23 +221,18 @@ trailing whitespace is allowed after the closing fence.
 Schema rules:
 
 - `envelope_version` — integer, currently `2`. Bump only via a
-  coordinated SKILL.md + caller change. v1 (without `summary`) is
-  still accepted by callers but is deprecated; emit `2`.
+  coordinated SKILL.md + caller change.
 - `brain_page_slug` — **exact** slug of the page you wrote. No leading
   slash, no `.md` extension. Must match `^[a-zA-Z0-9_\-/]+$`.
-- `summary` — **v2-only.** 2-3 sentences of executive summary
-  describing what the research found. Same content as the
-  `> Executive summary:` block at the top of the brain-page
-  markdown body. This field exists because the caller can only
-  cheaply parse the JSON envelope — without it, the caller falls
-  back to the FIRST LINE of your stdout, which is normally your
-  natural preamble ("Page written. Here's the final output…")
-  rather than substantive content. **NOT a status confirmation;
-  NOT "Page written"; NOT "Emitting envelope".** A caller
-  validator (mirror of the SRW UI's `isEnvelopeChatter`) rejects
-  preamble-shaped summaries and triggers a retry.
+- `summary` — 2-3 sentences of executive summary describing what
+  the research found. Same content as the `> Executive summary:`
+  block at the top of the brain-page markdown body. This field
+  exists because the caller can only cheaply parse the JSON
+  envelope — without it, the caller can't surface real content in
+  programmatic UIs. **NOT a status confirmation; NOT "Page
+  written"; NOT "Emitting envelope".**
   - Positive example: `"summary": "Three independent sources confirm B2B SaaS marketing leaders are shifting 15-30% of search budget to AI-visibility work. Buyer archetype consistent across editorial, commercial, and technical sources."`
-  - Negative example (rejected): `"summary": "Page written. Emitting the output envelope per --output-envelope."`
+  - Negative example: `"summary": "Page written. Emitting the output envelope per --output-envelope."`
 - `citations[]` — one entry per source you cited in the markdown above.
   Every URL in the markdown body must appear here. Do not invent
   citations that aren't in the markdown.

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -58,6 +58,49 @@ const LLM_PREAMBLES = [
   /^Absolutely\.?\s*Here[^.\n]*\.?\s*\n*/gim,
 ];
 
+// ── Whole-page code-fence wrap (LLM artifact) ───────────────────────
+//
+// An LLM sometimes returns an ENTIRE page wrapped in a ```markdown fence.
+// Strip that wrap — but ONLY when the whole body is wrapped, never when a note
+// merely *contains* a ```markdown block mid-document (e.g. a Notion export that
+// fences a config snippet). The earlier code detected the wrap with /m regexes
+// (a fence anywhere) but stripped the closing fence with a string-anchored
+// regex, so a mid-document block lost only its trailing ``` and was left with
+// an open fence — re-corrupted on every autopilot lint cycle. Detection and fix
+// now share this single check so they can't drift apart again.
+
+function frontmatterLength(content: string): number {
+  const m = /^---\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n?/.exec(content);
+  return m ? m[0].length : 0;
+}
+
+/**
+ * Treat a page as fence-wrapped only when the entire body (after any YAML
+ * frontmatter) is a single ```markdown fence: the first non-blank body line
+ * opens it, the last non-blank body line closes it, and no bare ``` appears
+ * between them (which would mean the fence closed early — not a whole-page
+ * wrap). Returns the unwrapped content (frontmatter preserved) when wrapped.
+ */
+function analyzeMarkdownWrap(content: string): { wrapped: boolean; unwrapped: string } {
+  const fmLen = frontmatterLength(content);
+  const head = content.slice(0, fmLen);
+  const lines = content.slice(fmLen).split('\n');
+
+  let first = 0;
+  while (first < lines.length && lines[first].trim() === '') first++;
+  let last = lines.length - 1;
+  while (last >= 0 && lines[last].trim() === '') last--;
+
+  if (first >= last) return { wrapped: false, unwrapped: content };
+  if (!/^```(?:markdown|md)\s*$/.test(lines[first].trim())) return { wrapped: false, unwrapped: content };
+  if (lines[last].trim() !== '```') return { wrapped: false, unwrapped: content };
+  for (let i = first + 1; i < last; i++) {
+    if (lines[i].trim().startsWith('```')) return { wrapped: false, unwrapped: content };
+  }
+
+  return { wrapped: true, unwrapped: head + lines.slice(first + 1, last).join('\n') };
+}
+
 // ── Rules ──────────────────────────────────────────────────────────
 
 export function lintContent(content: string, filePath: string): LintIssue[] {
@@ -95,8 +138,10 @@ export function lintContent(content: string, filePath: string): LintIssue[] {
     }
   }
 
-  // Rule: Wrapping code fences (```markdown ... ```)
-  if (content.match(/^```(?:markdown|md)\s*\n/m) && content.match(/\n```\s*$/m)) {
+  // Rule: Wrapping code fences — the WHOLE page body wrapped in ```markdown …
+  // ``` (an LLM artifact). A ```markdown block mid-document is legitimate and
+  // must NOT trigger this (see analyzeMarkdownWrap).
+  if (analyzeMarkdownWrap(content).wrapped) {
     issues.push({
       file: filePath, line: 1, rule: 'code-fence-wrap',
       message: 'Page wrapped in ```markdown code fences (LLM artifact)',
@@ -195,9 +240,10 @@ export function fixContent(content: string): string {
     fixed = fixed.replace(pattern, '');
   }
 
-  // Fix wrapping code fences
-  fixed = fixed.replace(/^```(?:markdown|md)\s*\n/, '');
-  fixed = fixed.replace(/\n```\s*$/, '');
+  // Fix wrapping code fences — only a genuine whole-page wrap (see
+  // analyzeMarkdownWrap); never strip the closing fence of a mid-note block.
+  const wrap = analyzeMarkdownWrap(fixed);
+  if (wrap.wrapped) fixed = wrap.unwrapped;
 
   // Clean up excessive blank lines left by fixes
   fixed = fixed.replace(/\n{3,}/g, '\n\n');

--- a/test/lint.test.ts
+++ b/test/lint.test.ts
@@ -32,6 +32,14 @@ describe('lintContent', () => {
     expect(issues.some(i => i.rule === 'code-fence-wrap')).toBe(true);
   });
 
+  test('does not flag a mid-document markdown code block as a page wrap', () => {
+    // Regression: a note that merely CONTAINS a ```markdown block (e.g. a
+    // Notion export fencing a config snippet) is not a whole-page wrap.
+    const content = '---\ntitle: Notes\ntype: note\ncreated: 2026-05-25\n---\n\nIntro paragraph.\n\n```markdown\nKEY=value\nPORT=3002\n```\n';
+    const issues = lintContent(content, 'test.md');
+    expect(issues.some(i => i.rule === 'code-fence-wrap')).toBe(false);
+  });
+
   test('detects placeholder dates', () => {
     const content = '---\ntitle: Test\ntype: person\ncreated: YYYY-MM-DD\n---\n\n# Test';
     const issues = lintContent(content, 'test.md');
@@ -95,6 +103,17 @@ describe('fixContent', () => {
     const fixed = fixContent(input);
     expect(fixed).not.toContain('```');
     expect(fixed).toContain('# Title');
+  });
+
+  test('leaves a mid-document markdown code block intact (keeps its closing fence)', () => {
+    // Regression for the autopilot churn: fixContent used to strip only the
+    // trailing ```, leaving the fence open and the note re-corrupted each cycle.
+    const input = '---\ntitle: Notes\ntype: note\ncreated: 2026-05-25\n---\n\nIntro paragraph.\n\n```markdown\nKEY=value\nPORT=3002\n```\n';
+    const fixed = fixContent(input);
+    const fenceLines = (fixed.match(/^```/gm) ?? []).length;
+    expect(fenceLines).toBe(2);
+    expect(fixed).toContain('```markdown');
+    expect(fixed.trimEnd().endsWith('```')).toBe(true);
   });
 
   test('cleans up excessive blank lines after fix', () => {

--- a/test/perplexity-research-envelope.test.ts
+++ b/test/perplexity-research-envelope.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// Static SKILL.md conformance: verify the canonical contract that
+// programmatic callers (SRW's parseSkillEnvelope in
+// agentic-temporal-os) rely on stays in lockstep with the skill body.
+//
+// The runtime parser test (round-trip against a recorded fixture)
+// lives in agentic-temporal-os's
+// internal/temporal/testdata/skill_envelope_golden.txt; that fixture
+// is the same shape this test checks SKILL.md documents.
+
+const SKILL_PATH = join(
+  import.meta.dir,
+  "..",
+  "skills",
+  "perplexity-research",
+  "SKILL.md",
+);
+
+function loadSkillBody(): string {
+  return readFileSync(SKILL_PATH, "utf-8");
+}
+
+describe("perplexity-research SKILL.md envelope contract", () => {
+  const body = loadSkillBody();
+
+  test("documents the --output-envelope flag in Recognized flags", () => {
+    expect(body).toContain("## Recognized flags");
+    expect(body).toContain("--output-envelope");
+  });
+
+  test("declares the Output envelope schema fields", () => {
+    expect(body).toContain("## Output envelope");
+    for (const field of [
+      "envelope_version",
+      "brain_page_slug",
+      "citations",
+      "key_deltas",
+      "cost_cents",
+      "latency_ms",
+    ]) {
+      expect(body).toContain(field);
+    }
+  });
+
+  test("locks envelope_version to 1", () => {
+    expect(body).toMatch(/"envelope_version":\s*1/);
+  });
+
+  test("requires brain_page_slug to match the slug regex", () => {
+    expect(body).toContain("^[a-zA-Z0-9_\\-/]+$");
+  });
+
+  test("documents the cost_cents fallback table", () => {
+    expect(body).toContain("`sonar-pro` = 4");
+    expect(body).toContain("`sonar` = 1");
+  });
+
+  test("default-mode (no --output-envelope flag) is unchanged", () => {
+    expect(body).toContain(
+      "If `--output-envelope` is **not** passed, do not emit the block",
+    );
+    // Mining cron callers must keep working as today.
+    for (const caller of [
+      "signal-detector",
+      "daily-task-prep",
+      "concept-synthesis",
+    ]) {
+      expect(body).toContain(caller);
+    }
+  });
+
+  test("recognized flags list covers every flag SRW passes", () => {
+    for (const flag of [
+      "--topic",
+      "--context-slugs",
+      "--inline-context",
+      "--recency",
+      "--model",
+      "--run-id",
+      "--output-envelope",
+    ]) {
+      expect(body).toContain(flag);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`gbrain lint --fix` corrupts any page that contains a ` ```markdown ` (or ` ```md `) fenced block **mid-document**: it strips the block's **closing** fence, leaving an unbalanced/open fence. Because `gbrain autopilot` runs `lint --fix` every cycle, affected notes are re-corrupted continuously — reverting by hand never sticks.

Real-world trigger: Notion-exported notes that fence a config/snippet block partway down the page. Observed on a vault where the autopilot re-stripped the same notes every ~150s cycle.

## Root cause

Detection and the fixer were out of sync in `src/commands/lint.ts`.

**Detection** (`code-fence-wrap` rule) used `/m`-flagged regexes — fires when a ` ```markdown ` opener starts *any line* **and** a closing ` ``` ` ends *any line*:

```ts
if (content.match(/^```(?:markdown|md)\s*\n/m) && content.match(/\n```\s*$/m)) { … }
```

**Fixer** (`fixContent`) used **string-anchored** regexes (no `/m`):

```ts
fixed = fixed.replace(/^```(?:markdown|md)\s*\n/, ''); // only matches at byte 0
fixed = fixed.replace(/\n```\s*$/, '');                // only matches at EOF
```

For a page whose ` ```markdown ` block is **not** at byte 0 (e.g. after frontmatter and prose), the opener-strip no-ops while the closer-strip still fires at EOF — so only the closing fence is removed, and the rule re-flags + re-mangles forever.

## Fix

Detection and fixer now share one `analyzeMarkdownWrap()` helper that treats a page as fence-wrapped **only when the entire body (after frontmatter) is a single fence**: the first non-blank body line opens it, the last non-blank line closes it, and no bare ` ``` ` appears between them (which would mean the fence closed early). A mid-document fenced block is left untouched. Routing both the rule and the fixer through one code path keeps them from drifting apart again.

## Tests

`bun test test/lint.test.ts` → **20 pass**. Two regressions added:

- `lintContent` does **not** flag a mid-document ` ```markdown ` block as a page wrap.
- `fixContent` leaves such a block intact — closing fence preserved, fences balanced.

Existing whole-page-wrap detection/fix tests still pass; `tsc --noEmit` is clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
