### PR TITLE
fix(extract): opt-in skipMetaFiles so meta-file wikilinks get harvested

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -83,7 +83,10 @@ export function walkMarkdownFiles(dir: string): { path: string; relPath: string 
           walk(full);
         } else if (entry.endsWith('.md') && !entry.startsWith('_')) {
           const rel = relative(dir, full);
-          if (!isSyncable(rel, { strategy: 'markdown' })) continue;
+          // skipMetaFiles: false — extract treats index.md / log.md / README.md / schema.md
+          // as real pages so their outbound wikilinks get harvested. The default-true
+          // exclusion still applies to remote sync (push), which has its own callers.
+          if (!isSyncable(rel, { strategy: 'markdown', skipMetaFiles: false })) continue;
           files.push({ path: full, relPath: rel });
         }
       } catch { /* skip unreadable */ }

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -37,6 +37,14 @@ interface SyncableOptions {
   strategy?: SyncStrategy;
   include?: string[];
   exclude?: string[];
+  /**
+   * Skip meta-pages (`index.md`, `log.md`, `README.md`, `schema.md`) by basename.
+   * Default `true` to preserve historical behavior — sync to remote shouldn't push
+   * project boilerplate. Pass `false` from local-only walkers (extract, link
+   * reconciliation, frontmatter) where these files ARE legitimate pages and their
+   * outbound wikilinks must be captured.
+   */
+  skipMetaFiles?: boolean;
 }
 
 // v0.19.0 shipped a 9-extension allowlist (ts/tsx/js/jsx/mjs/cjs/py/rb/go). The
@@ -301,10 +309,14 @@ export function isSyncable(path: string, opts: SyncableOptions = {}): boolean {
   const segments = path.split('/');
   if (segments.some(p => !pruneDir(p))) return false;
 
-  // Skip meta files that aren't pages
-  const skipFiles = ['schema.md', 'index.md', 'log.md', 'README.md'];
-  const basename = segments[segments.length - 1] || '';
-  if (skipFiles.includes(basename)) return false;
+  // Skip meta files that aren't pages (opt-in via skipMetaFiles, default true).
+  // Local walkers that treat these as real pages (extract, link reconciliation)
+  // should pass skipMetaFiles: false so their outbound wikilinks get harvested.
+  if (opts.skipMetaFiles !== false) {
+    const skipFiles = ['schema.md', 'index.md', 'log.md', 'README.md'];
+    const basename = segments[segments.length - 1] || '';
+    if (skipFiles.includes(basename)) return false;
+  }
 
   if (opts.include && opts.include.length > 0 && !matchesAnyGlob(path, opts.include)) return false;
   if (opts.exclude && opts.exclude.length > 0 && matchesAnyGlob(path, opts.exclude)) return false;


### PR DESCRIPTION
## Summary

**`gbrain extract links --source fs` silently drops every outbound wikilink from any file named `index.md`, `log.md`, `README.md`, or `schema.md`** — at every depth in the vault. The walker calls `isSyncable()`, which hard-skips those four basenames. But `gbrain import` *has* created those files as pages via a separate code path. The result is asymmetric: those pages exist in `pages`, get embedded, show up in search — but their outbound edges never make it into the `links` table. They're zombie pages.

This bites hardest when those meta-files are the actual hubs of the brain rather than project boilerplate. On the brain I'm running, `vault/index.md` carries ~70 wikilinks (equipo, productos, clientes, fuentes tables) and `vault/data_room_pre-seed/*/README.md` is the entry point for nine sub-folders. Every one of those was orphan in the graph despite being visibly central in the content.

## Repro

```bash
mkdir -p /tmp/v/wiki
printf '# hub\n- [[wiki/foo]]\n' > /tmp/v/index.md
printf '# foo\n' > /tmp/v/wiki/foo.md

gbrain import /tmp/v
gbrain extract links --source fs --dir /tmp/v
gbrain graph index --depth 1
# → links: []   (expected: 1 → wiki/foo)
```

Same outcome for `log.md`, any `README.md`, or `schema.md`.

## Fix

Add `skipMetaFiles?: boolean` to `SyncableOptions` (default `true` preserves the current remote-sync behavior — `gbrain sync` callers in `commands/sync.ts` should keep skipping these basenames so project boilerplate isn't pushed). Pass `false` from the shared `walkMarkdownFiles` in `commands/extract.ts` so the local link harvester treats them as the pages they really are.

No call-site changes required for downstream consumers — they continue to get the default-true behavior. The flag is purely additive.

## Why opt-in rather than removing the skip entirely

The skip is correct for `gbrain sync`'s push-to-remote path: you don't want every project's `README.md` and `index.md` pushed to a shared sync target as if they were content pages. The skip is wrong only for *local* walkers that treat the brain dir as the source of truth and need every page's edges. `skipMetaFiles: false` lets each caller declare its own intent.

## Observed impact

305-page personal brain, single `extract links --source fs` run after the patch:

| metric | before | after |
|---|---|---|
| pages_processed | 267 | **280** (+13 meta-files) |
| links_created (one run) | 0 (idempotent) | **436** |
| outbound from `index` | 18 (manual `gbrain link`) | **243** |
| outbound from `log` | 0 | **118** |
| orphans | 26 | **10** (remaining are bitácora timestamp leaves) |
| brain_score | 84 | 84 (orphans 14/15, link coverage entities 100%) |

## Test plan

- [x] `bun run typecheck` — no new errors in `src/` (pre-existing fuzz / chokidar / js-yaml issues unrelated)
- [x] End-to-end on a real 305-page brain: import → extract → graph queries show outbound from `index.md` / `log.md` / data-room READMEs (previously all 0)
- [x] Sanity-checked that `gbrain sync` path is unaffected (only `extract.ts` walker opts in)
- [ ] Maintainer to confirm no other call-site should also opt in (frontmatter command? brain-writer? would value a second look)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
