### PR TITLE
Use configured embedding dims in providers test

### DIFF
--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -137,6 +137,8 @@ async function runTest(args: string[]): Promise<void> {
 
   const tpIdx = args.indexOf('--touchpoint');
   const tpArg = (tpIdx >= 0 ? args[tpIdx + 1] : 'embedding') as TouchpointFilter;
+  let configuredModel: string | undefined;
+  let configuredEmbeddingDimensions: number | undefined;
 
   if (tpArg !== 'embedding' && tpArg !== 'chat') {
     console.error(`--touchpoint must be 'embedding' or 'chat' (got: ${tpArg}).`);
@@ -157,7 +159,8 @@ async function runTest(args: string[]): Promise<void> {
     // broken" trap.
     try {
       const cfg = loadConfig();
-      const configuredModel = tpArg === 'embedding' ? cfg?.embedding_model : cfg?.chat_model;
+      configuredModel = tpArg === 'embedding' ? cfg?.embedding_model : cfg?.chat_model;
+      configuredEmbeddingDimensions = cfg?.embedding_dimensions;
       if (!configuredModel) {
         console.error(
           `Note: tested ${modelArg} in isolation; this brain has no configured ${tpArg}_model yet. ` +
@@ -173,7 +176,10 @@ async function runTest(args: string[]): Promise<void> {
     } catch { /* loadConfig throws when no brain configured — first-time install path; the no-config branch above handles it. */ }
 
     if (tpArg === 'embedding') {
-      const dims = recipe?.touchpoints.embedding?.default_dims ?? 1536;
+      const dims =
+        configuredModel === modelArg && typeof configuredEmbeddingDimensions === 'number'
+          ? configuredEmbeddingDimensions
+          : (recipe?.touchpoints.embedding?.default_dims ?? 1536);
       configureGateway({
         embedding_model: modelArg,
         embedding_dimensions: dims,

--- a/test/providers-run-test.test.ts
+++ b/test/providers-run-test.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const configureGatewayCalls: Array<Record<string, unknown>> = [];
+
+mock.module('../src/core/config.ts', () => ({
+  loadConfig: () => ({
+    embedding_model: 'ollama:bge-m3',
+    embedding_dimensions: 1024,
+  }),
+}));
+
+mock.module('../src/core/ai/gateway.ts', () => ({
+  configureGateway: (opts: Record<string, unknown>) => {
+    configureGatewayCalls.push(opts);
+  },
+  embedOne: async () => new Array(1024).fill(0),
+  isAvailable: () => true,
+  chat: async () => ({
+    text: 'pong',
+    model: 'mock',
+    stopReason: 'stop',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }),
+}));
+
+mock.module('../src/core/ai/probes.ts', () => ({
+  probeOllama: async () => ({ ok: true }),
+  probeLMStudio: async () => ({ ok: true }),
+}));
+
+const { runProviders } = await import('../src/commands/providers.ts');
+
+describe('runProviders test --model embedding override', () => {
+  beforeEach(() => {
+    configureGatewayCalls.length = 0;
+  });
+
+  test('uses configured embedding dimensions when the override matches the active model', async () => {
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = () => {};
+    console.error = () => {};
+
+    try {
+      await runProviders('test', ['--model', 'ollama:bge-m3']);
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+    }
+
+    expect(configureGatewayCalls.at(-1)).toMatchObject({
+      embedding_model: 'ollama:bge-m3',
+      embedding_dimensions: 1024,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- preserve configured embedding dimensions when `runProviders test --model ...` targets the active embedding model
- add a regression test for the embedding override path

## Verification
- bun test test/providers-run-test.test.ts