### PR TITLE
fix: warn when env vars override ze-switch embedding config

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3212,6 +3212,38 @@ export async function buildChecks(
     });
   }
 
+  // 8b+. Env-vs-DB embedding config mismatch detector (v0.41 env-override guard).
+  //       If GBRAIN_EMBEDDING_MODEL env var is set and disagrees with the DB config,
+  //       the user likely ran ze-switch but forgot to update their .env / shell env.
+  //       This is the #1 cause of "doctor says wrong model" confusion.
+  try {
+    const envEmbedModel = process.env.GBRAIN_EMBEDDING_MODEL;
+    if (envEmbedModel) {
+      const dbEmbedModel = await engine.getConfig('embedding_model');
+      if (dbEmbedModel && envEmbedModel !== dbEmbedModel) {
+        checks.push({
+          name: 'embedding_env_override',
+          status: 'warn',
+          message:
+            `GBRAIN_EMBEDDING_MODEL env var (${envEmbedModel}) overrides DB config (${dbEmbedModel}). ` +
+            `Env vars take highest precedence in loadConfig(). ` +
+            `Update your .env or shell environment to match: GBRAIN_EMBEDDING_MODEL=${dbEmbedModel}`,
+        });
+      }
+      const envDims = process.env.GBRAIN_EMBEDDING_DIMENSIONS;
+      const dbDims = await engine.getConfig('embedding_dimensions');
+      if (envDims && dbDims && envDims !== dbDims) {
+        checks.push({
+          name: 'embedding_env_override',
+          status: 'warn',
+          message:
+            `GBRAIN_EMBEDDING_DIMENSIONS env var (${envDims}) overrides DB config (${dbDims}). ` +
+            `Update your .env: GBRAIN_EMBEDDING_DIMENSIONS=${dbDims}`,
+        });
+      }
+    }
+  } catch { /* config table may not exist yet */ }
+
   // 8c. Alternative provider advisory (v0.32 D11=C / Codex finding #2 wire-through).
   // Walks listRecipes() and surfaces any recipe whose required env vars are ALL
   // set in the process env but is not the currently configured provider. Helps

--- a/src/core/retrieval-upgrade-planner.ts
+++ b/src/core/retrieval-upgrade-planner.ts
@@ -313,6 +313,37 @@ export async function applyRetrievalUpgrade(
     await engine.setConfig(KEY_APPLIED, 'true');
     await engine.setConfig(KEY_PROMPT_SHOWN, 'true');
 
+    // 6. Warn if env vars will override the switch (v0.41 env-override guard).
+    //    process.env takes highest precedence in loadConfig(). If the user has
+    //    GBRAIN_EMBEDDING_MODEL baked into their environment (e.g. .env file
+    //    loaded at shell/gateway startup), the switch silently does nothing
+    //    at runtime because env wins over DB + file config.
+    const envModel = process.env.GBRAIN_EMBEDDING_MODEL;
+    const envDims = process.env.GBRAIN_EMBEDDING_DIMENSIONS;
+    const targetModel = plan.target_embedding_model ?? ZE_TARGET_EMBEDDING_MODEL;
+    if (envModel && envModel !== targetModel) {
+      const stderr = process.stderr;
+      stderr.write('\n');
+      stderr.write('╔══════════════════════════════════════════════════════════════╗\n');
+      stderr.write('║  ⚠️  ENV OVERRIDE DETECTED — ACTION REQUIRED                ║\n');
+      stderr.write('╠══════════════════════════════════════════════════════════════╣\n');
+      stderr.write(`║  GBRAIN_EMBEDDING_MODEL is set in your environment:         ║\n`);
+      stderr.write(`║    Current env: ${(envModel || '').padEnd(42)}║\n`);
+      stderr.write(`║    Switch target: ${(targetModel).padEnd(40)}║\n`);
+      stderr.write('║                                                              ║\n');
+      stderr.write('║  The env var takes HIGHEST PRECEDENCE and will override      ║\n');
+      stderr.write('║  this switch. Update your .env file or shell environment:    ║\n');
+      stderr.write(`║                                                              ║\n`);
+      stderr.write(`║    GBRAIN_EMBEDDING_MODEL=${targetModel.padEnd(33)}║\n`);
+      stderr.write(`║    GBRAIN_EMBEDDING_DIMENSIONS=${String(targetDim).padEnd(28)}║\n`);
+      stderr.write('║                                                              ║\n');
+      stderr.write('║  Without this change, the switch has NO EFFECT at runtime.   ║\n');
+      stderr.write('╚══════════════════════════════════════════════════════════════╝\n');
+      stderr.write('\n');
+    } else if (envDims && parseInt(envDims, 10) !== targetDim) {
+      process.stderr.write(`\n⚠️  GBRAIN_EMBEDDING_DIMENSIONS=${envDims} in env does not match target ${targetDim}. Update your .env.\n\n`);
+    }
+
     return { status: 'applied', plan };
   } catch (err) {
     return {


### PR DESCRIPTION
## Problem

`ze-switch` writes the new embedding model to DB config and `~/.gbrain/config.json`, but `loadConfig()` gives **highest precedence** to `process.env.GBRAIN_EMBEDDING_MODEL`. If the user has this env var set (common in `.env` files loaded at gateway/shell startup), the switch silently does nothing at runtime.

The user sees `Switch status: applied` and thinks it worked. But every gbrain command still uses the old OpenAI model because the env var overrides DB + file config.

**Real-world impact:** 716K chunks had to be re-embedded because the env override meant the switch to ZeroEntropy silently didn't take effect. Doctor reported `openai:text-embedding-3-large` dimension mismatch for hours before the root cause was traced to stale env vars.

## Fix

### 1. `ze-switch` env override warning

After applying the switch, checks if `GBRAIN_EMBEDDING_MODEL` or `GBRAIN_EMBEDDING_DIMENSIONS` are set in the process environment and differ from the target. Prints a prominent warning box:

```
╔══════════════════════════════════════════════════════════════╗
║  ⚠️  ENV OVERRIDE DETECTED — ACTION REQUIRED                ║
╠══════════════════════════════════════════════════════════════╣
║  GBRAIN_EMBEDDING_MODEL is set in your environment:         ║
║    Current env: openai:text-embedding-3-large               ║
║    Switch target: zeroentropyai:zembed-1                    ║
║                                                              ║
║  The env var takes HIGHEST PRECEDENCE and will override      ║
║  this switch. Update your .env file or shell environment.    ║
║                                                              ║
║  Without this change, the switch has NO EFFECT at runtime.   ║
╚══════════════════════════════════════════════════════════════╝
```

### 2. `doctor` env/DB mismatch detector

New `embedding_env_override` check: if the env var disagrees with DB config, warns with the exact fix. Surfaces the mismatch on every doctor run instead of reporting a confusing dimension error.

## Testing

- Set `GBRAIN_EMBEDDING_MODEL=openai:text-embedding-3-large` in env
- Run `gbrain ze-switch --non-interactive --force`
- Verify warning box appears after "Switch status: applied"
- Run `gbrain doctor --fast`
- Verify `embedding_env_override` warning appears