### PR TITLE
fix(ai): route Ollama chat through native API

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -342,6 +342,10 @@ export function applyOpenAICompatConfig(
       recipe.setup_hint,
     );
   }
+  if (recipe.id === 'ollama') {
+    const normalized = normalizeOllamaOpenAIBaseURL(baseURL);
+    return { baseURL: normalized, fetch: makeOllamaNativeChatCompatFetch(normalized) };
+  }
   return { baseURL };
 }
 
@@ -951,6 +955,208 @@ const zeroEntropyCompatFetch = (async (input: RequestInfo | URL, init?: RequestI
     return resp;
   }
 }) as unknown as typeof fetch;
+
+/**
+ * Ollama exposes embeddings through the OpenAI-compatible `/v1/embeddings`
+ * route, but thinking controls for local chat models live on native
+ * `/api/chat`. The OpenAI-compatible `/v1/chat/completions` endpoint cannot
+ * reliably carry `think:false`, so chat/expansion calls are translated to the
+ * native endpoint while every other path passes through unchanged.
+ */
+function normalizeOllamaOpenAIBaseURL(baseURL: string): string {
+  const trimmed = baseURL.replace(/\/+$/, '');
+  return trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
+}
+
+function ollamaNativeChatURL(openAIBaseURL: string): string {
+  const u = new URL(openAIBaseURL);
+  const prefix = u.pathname.replace(/\/v1\/?$/, '').replace(/\/+$/, '');
+  u.pathname = prefix ? `${prefix}/api/chat` : '/api/chat';
+  u.search = '';
+  return u.toString();
+}
+
+function requestURLString(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+function isOpenAIChatCompletionsURL(input: RequestInfo | URL): boolean {
+  try {
+    const u = new URL(requestURLString(input));
+    return u.pathname.replace(/\/+$/, '').endsWith('/chat/completions');
+  } catch {
+    return false;
+  }
+}
+
+async function requestBodyText(input: RequestInfo | URL, init?: RequestInit): Promise<string | undefined> {
+  const body = init?.body;
+  if (typeof body === 'string') return body;
+  if (body instanceof URLSearchParams) return body.toString();
+  if (body instanceof Blob) return body.text();
+  if (body instanceof ArrayBuffer) return Buffer.from(body).toString('utf8');
+  if (ArrayBuffer.isView(body)) {
+    return Buffer.from(body.buffer, body.byteOffset, body.byteLength).toString('utf8');
+  }
+  if (input instanceof Request) {
+    return input.clone().text();
+  }
+  return undefined;
+}
+
+function openAIContentToOllamaContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (content == null) return '';
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      const b = block as Record<string, unknown>;
+      if (b.type === 'text' && typeof b.text === 'string') {
+        parts.push(b.text);
+      }
+    }
+    return parts.join('\n');
+  }
+  return String(content);
+}
+
+function ollamaFormatFromResponseFormat(responseFormat: unknown): unknown | undefined {
+  if (!responseFormat || typeof responseFormat !== 'object') return undefined;
+  const rf = responseFormat as Record<string, any>;
+  if (rf.type === 'json_object') return 'json';
+  if (rf.type === 'json_schema') {
+    return rf.json_schema?.schema && typeof rf.json_schema.schema === 'object'
+      ? rf.json_schema.schema
+      : 'json';
+  }
+  return undefined;
+}
+
+function buildOllamaChatBody(openaiBody: Record<string, any>): Record<string, any> {
+  const messages = Array.isArray(openaiBody.messages)
+    ? openaiBody.messages.map((m: any) => {
+        const mapped: Record<string, any> = {
+          role: typeof m?.role === 'string' ? m.role : 'user',
+          content: openAIContentToOllamaContent(m?.content),
+        };
+        if (Array.isArray(m?.tool_calls)) mapped.tool_calls = m.tool_calls;
+        if (typeof m?.tool_call_id === 'string') mapped.tool_call_id = m.tool_call_id;
+        return mapped;
+      })
+    : [];
+
+  const options: Record<string, any> = {};
+  if (typeof openaiBody.temperature === 'number') options.temperature = openaiBody.temperature;
+  if (typeof openaiBody.top_p === 'number') options.top_p = openaiBody.top_p;
+  const maxTokens = openaiBody.max_tokens ?? openaiBody.max_completion_tokens;
+  if (typeof maxTokens === 'number') options.num_predict = maxTokens;
+  if (openaiBody.stop !== undefined) options.stop = openaiBody.stop;
+  if (typeof openaiBody.seed === 'number') options.seed = openaiBody.seed;
+
+  const nativeBody: Record<string, any> = {
+    model: openaiBody.model,
+    messages,
+    stream: false,
+    think: false,
+  };
+  const format = ollamaFormatFromResponseFormat(openaiBody.response_format);
+  if (format !== undefined) nativeBody.format = format;
+  if (Array.isArray(openaiBody.tools)) nativeBody.tools = openaiBody.tools;
+  if (Object.keys(options).length > 0) nativeBody.options = options;
+  return nativeBody;
+}
+
+function ollamaFinishReason(doneReason: unknown, done: unknown): string {
+  if (doneReason === 'length') return 'length';
+  if (doneReason === 'stop') return 'stop';
+  return done === true ? 'stop' : 'stop';
+}
+
+function rewriteOllamaChatResponse(resp: Response, nativeJson: any, requestedModel: string): Response {
+  const promptTokens = typeof nativeJson?.prompt_eval_count === 'number' ? nativeJson.prompt_eval_count : 0;
+  const completionTokens = typeof nativeJson?.eval_count === 'number' ? nativeJson.eval_count : 0;
+  const createdAt = Date.parse(nativeJson?.created_at ?? '');
+  const message: Record<string, any> = {
+    role: nativeJson?.message?.role ?? 'assistant',
+    content: nativeJson?.message?.content ?? '',
+  };
+  if (Array.isArray(nativeJson?.message?.tool_calls)) {
+    message.tool_calls = nativeJson.message.tool_calls;
+  }
+
+  const json = {
+    id: `chatcmpl-ollama-${Date.now()}`,
+    object: 'chat.completion',
+    created: Number.isFinite(createdAt) ? Math.floor(createdAt / 1000) : Math.floor(Date.now() / 1000),
+    model: nativeJson?.model ?? requestedModel,
+    choices: [
+      {
+        index: 0,
+        message,
+        finish_reason: ollamaFinishReason(nativeJson?.done_reason, nativeJson?.done),
+      },
+    ],
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens,
+    },
+  };
+
+  const headers = new Headers(resp.headers);
+  headers.set('content-type', 'application/json');
+  headers.delete('content-length');
+  return new Response(JSON.stringify(json), {
+    status: resp.status,
+    statusText: resp.statusText,
+    headers,
+  });
+}
+
+function makeOllamaNativeChatCompatFetch(openAIBaseURL: string): typeof fetch {
+  const chatURL = ollamaNativeChatURL(openAIBaseURL);
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    if (!isOpenAIChatCompletionsURL(input)) {
+      return fetch(input, init);
+    }
+
+    const bodyText = await requestBodyText(input, init);
+    if (!bodyText) return fetch(input, init);
+
+    let openaiBody: Record<string, any>;
+    try {
+      openaiBody = JSON.parse(bodyText);
+    } catch {
+      return fetch(input, init);
+    }
+
+    // Streaming requires an SSE rewriter; gbrain's generateText/generateObject
+    // paths are non-streaming, so leave streaming callers on Ollama's /v1 path.
+    if (openaiBody.stream === true) return fetch(input, init);
+
+    const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined));
+    headers.delete('content-length');
+    headers.set('content-type', 'application/json');
+
+    const resp = await fetch(chatURL, {
+      ...(init ?? {}),
+      method: 'POST',
+      headers,
+      body: JSON.stringify(buildOllamaChatBody(openaiBody)),
+    });
+    if (!resp.ok) return resp;
+
+    try {
+      const nativeJson = await resp.clone().json();
+      return rewriteOllamaChatResponse(resp, nativeJson, String(openaiBody.model ?? ''));
+    } catch {
+      return resp;
+    }
+  }) as unknown as typeof fetch;
+}
 
 async function resolveEmbeddingProvider(modelStr: string): Promise<{ model: any; recipe: Recipe; modelId: string }> {
   const { parsed, recipe } = resolveRecipe(modelStr);
@@ -1892,6 +2098,7 @@ function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayCon
         name: recipe.id,
         baseURL: compat.baseURL,
         ...(compat.fetch ? { fetch: compat.fetch } : {}),
+        ...(recipe.id === 'ollama' ? { supportsStructuredOutputs: true } : {}),
         ...auth,
       }).languageModel(modelId);
     }
@@ -1918,7 +2125,9 @@ export async function expand(query: string): Promise<string[]> {
       schema: ExpansionSchema,
       prompt: [
         'Rewrite the search query below into 3-4 different, related queries that would help find relevant documents.',
-        'Return ONLY the JSON object. Do NOT include the original query in the result.',
+        'Return ONLY a JSON object with exactly one key named "queries".',
+        'The value of "queries" MUST be an array of strings. Do NOT use any other key name.',
+        'Do NOT include the original query in the result.',
         'Each rewrite should emphasize different aspects, synonyms, or framings.',
         '',
         `Query: ${query}`,
@@ -2137,6 +2346,7 @@ function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig):
         name: recipe.id,
         baseURL: compat.baseURL,
         ...(compat.fetch ? { fetch: compat.fetch } : {}),
+        ...(recipe.id === 'ollama' ? { supportsStructuredOutputs: true } : {}),
         ...auth,
       }).languageModel(modelId);
     }

--- a/src/core/ai/model-resolver.ts
+++ b/src/core/ai/model-resolver.ts
@@ -94,7 +94,7 @@ export function assertTouchpoint(
       `Provider "${recipe.id}" does not support touchpoint "${touchpoint}".`,
       touchpoint === 'embedding' && recipe.id === 'anthropic'
         ? 'Anthropic has no embedding model. Use openai or google for embeddings.'
-        : touchpoint === 'chat' && (recipe.id === 'voyage' || recipe.id === 'ollama')
+        : touchpoint === 'chat' && recipe.id === 'voyage'
           ? `${recipe.name} is configured here only for embeddings. Use openai/anthropic/google/deepseek/groq/together for chat.`
           : undefined,
     );

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -21,6 +21,27 @@ export const ollama: Recipe = {
       // OLLAMA_NUM_PARALLEL config; no static cap to declare. v0.32 (#779).
       no_batch_cap: true,
     },
+    expansion: {
+      // Advisory local-model entry points. Ollama accepts arbitrary installed
+      // model ids on the openai-compatible tier; users can still configure
+      // ollama:<any-local-model>.
+      models: ['qwen3.6:27b', 'qwen3.6:8b', 'llama3.2', 'mistral'],
+      cost_per_1m_tokens_usd: 0,
+      price_last_verified: '2026-05-25',
+    },
+    chat: {
+      // Same advisory list as expansion. The gateway routes chat through
+      // Ollama's native /api/chat endpoint so thinking models can run with
+      // think:false; the /v1 OpenAI-compatible endpoint does not expose that
+      // knob reliably.
+      models: ['qwen3.6:27b', 'qwen3.6:8b', 'llama3.2', 'mistral'],
+      supports_tools: false,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      cost_per_1m_input_usd: 0,
+      cost_per_1m_output_usd: 0,
+      price_last_verified: '2026-05-25',
+    },
   },
-  setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` and `ollama serve`.',
+  setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` for embeddings and `ollama pull qwen3.6:27b` (or another local chat model) for chat/expansion. Run `ollama serve`.',
 };

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -29,7 +29,7 @@ import { AIConfigError } from '../../src/core/ai/errors.ts';
 import { listRecipes, getRecipe } from '../../src/core/ai/recipes/index.ts';
 
 describe('chat touchpoint — recipe registry', () => {
-  test('all six chat-capable providers ship a chat touchpoint with supports_subagent_loop', () => {
+  test('core subagent-capable providers ship a chat touchpoint with supports_subagent_loop', () => {
     const expected = ['anthropic', 'openai', 'google', 'deepseek', 'groq', 'together'];
     for (const id of expected) {
       const r = getRecipe(id);
@@ -51,9 +51,15 @@ describe('chat touchpoint — recipe registry', () => {
     }
   });
 
-  test('embedding-only providers (voyage, ollama) do NOT declare chat', () => {
+  test('embedding-only provider Voyage does NOT declare chat', () => {
     expect(getRecipe('voyage')!.touchpoints.chat).toBeUndefined();
-    expect(getRecipe('ollama')!.touchpoints.chat).toBeUndefined();
+  });
+
+  test('Ollama declares local chat without subagent-loop support', () => {
+    const ollama = getRecipe('ollama')!;
+    expect(ollama.touchpoints.chat).toBeDefined();
+    expect(ollama.touchpoints.chat!.models).toContain('qwen3.6:27b');
+    expect(ollama.touchpoints.chat!.supports_subagent_loop).toBe(false);
   });
 
   test('openai-compat chat recipes have base_url_default', () => {
@@ -109,8 +115,6 @@ describe('chat touchpoint — model resolver + aliases (Codex F-OV-5)', () => {
 
   test('assertTouchpoint rejects chat on embedding-only providers with a fix hint', () => {
     expect(() => assertTouchpoint(getRecipe('voyage')!, 'chat', 'voyage-3'))
-      .toThrow(AIConfigError);
-    expect(() => assertTouchpoint(getRecipe('ollama')!, 'chat', 'nomic-embed-text'))
       .toThrow(AIConfigError);
   });
 

--- a/test/ai/recipe-ollama.test.ts
+++ b/test/ai/recipe-ollama.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Ollama recipe and native-chat compatibility shim.
+ *
+ * Ollama embeddings are OpenAI-compatible, but chat/expansion for thinking
+ * models need the native /api/chat `think:false` knob. These tests pin the
+ * recipe surface and the gateway fetch wrapper without requiring a live
+ * Ollama daemon.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  applyOpenAICompatConfig,
+  configureGateway,
+  expand,
+  isAvailable,
+  resetGateway,
+} from '../../src/core/ai/gateway.ts';
+import { assertTouchpoint } from '../../src/core/ai/model-resolver.ts';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+
+const originalFetch = globalThis.fetch;
+
+describe('recipe: ollama', () => {
+  beforeEach(() => resetGateway());
+  afterEach(() => {
+    resetGateway();
+    globalThis.fetch = originalFetch;
+  });
+
+  test('declares local embedding, expansion, and chat touchpoints', () => {
+    const r = getRecipe('ollama');
+    expect(r).toBeDefined();
+    expect(r!.tier).toBe('openai-compat');
+    expect(r!.implementation).toBe('openai-compatible');
+    expect(r!.base_url_default).toBe('http://localhost:11434/v1');
+    expect(r!.touchpoints.embedding?.models).toContain('nomic-embed-text');
+    expect(r!.touchpoints.expansion?.models).toContain('qwen3.6:27b');
+    expect(r!.touchpoints.chat?.models).toContain('qwen3.6:27b');
+    expect(r!.touchpoints.chat?.supports_tools).toBe(false);
+    expect(r!.touchpoints.chat?.supports_subagent_loop).toBe(false);
+  });
+
+  test('resolver accepts Ollama chat and expansion model ids', () => {
+    const r = getRecipe('ollama')!;
+    expect(() => assertTouchpoint(r, 'chat', 'qwen3.6:27b')).not.toThrow();
+    expect(() => assertTouchpoint(r, 'expansion', 'qwen3.6:27b')).not.toThrow();
+    // OpenAI-compatible recipes accept arbitrary installed model ids.
+    expect(() => assertTouchpoint(r, 'chat', 'local-model-not-in-recipe')).not.toThrow();
+  });
+
+  test('chat and expansion are available without an API key', () => {
+    configureGateway({
+      chat_model: 'ollama:qwen3.6:27b',
+      expansion_model: 'ollama:qwen3.6:27b',
+      env: {},
+    });
+    expect(isAvailable('chat')).toBe(true);
+    expect(isAvailable('expansion')).toBe(true);
+  });
+
+  test('OpenAI-compatible base URL is normalized when OLLAMA_BASE_URL omits /v1', () => {
+    const r = getRecipe('ollama')!;
+    const cfg = applyOpenAICompatConfig(r, {
+      env: {},
+      base_urls: { ollama: 'http://ollama.example.test:11434' },
+    } as any);
+    expect(cfg.baseURL).toBe('http://ollama.example.test:11434/v1');
+    expect(typeof cfg.fetch).toBe('function');
+  });
+
+  test('chat completions are translated to native /api/chat with think:false', async () => {
+    const r = getRecipe('ollama')!;
+    const calls: Array<{ url: string; body: any }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      const body = init?.body && typeof init.body === 'string'
+        ? JSON.parse(init.body)
+        : null;
+      calls.push({ url, body });
+      return new Response(JSON.stringify({
+        model: body?.model,
+        created_at: '2026-05-25T12:00:00Z',
+        message: { role: 'assistant', content: '{"queries":["local search"]}' },
+        done: true,
+        done_reason: 'stop',
+        prompt_eval_count: 12,
+        eval_count: 8,
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const cfg = applyOpenAICompatConfig(r, {
+      env: {},
+      base_urls: { ollama: 'http://127.0.0.1:11434/v1' },
+    } as any);
+    const resp = await cfg.fetch!(
+      'http://127.0.0.1:11434/v1/chat/completions',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          model: 'qwen3.6:27b',
+          messages: [{ role: 'user', content: 'expand local search' }],
+          max_tokens: 64,
+          temperature: 0.1,
+          response_format: { type: 'json_object' },
+        }),
+      },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://127.0.0.1:11434/api/chat');
+    expect(calls[0].body).toMatchObject({
+      model: 'qwen3.6:27b',
+      stream: false,
+      think: false,
+      format: 'json',
+      options: { num_predict: 64, temperature: 0.1 },
+    });
+    expect(calls[0].body.messages).toEqual([
+      { role: 'user', content: 'expand local search' },
+    ]);
+
+    const json = await resp.json();
+    expect(json.object).toBe('chat.completion');
+    expect(json.model).toBe('qwen3.6:27b');
+    expect(json.choices[0].message.content).toBe('{"queries":["local search"]}');
+    expect(json.choices[0].finish_reason).toBe('stop');
+    expect(json.usage).toEqual({
+      prompt_tokens: 12,
+      completion_tokens: 8,
+      total_tokens: 20,
+    });
+  });
+
+  test('gateway expand uses structured native Ollama format and parses queries', async () => {
+    const calls: Array<{ url: string; body: any }> = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      const body = init?.body && typeof init.body === 'string'
+        ? JSON.parse(init.body)
+        : null;
+      calls.push({ url, body });
+      return new Response(JSON.stringify({
+        model: body?.model,
+        created_at: '2026-05-25T12:00:00Z',
+        message: {
+          role: 'assistant',
+          content: '{"queries":["local semantic search","private embeddings"]}',
+        },
+        done: true,
+        done_reason: 'stop',
+        prompt_eval_count: 20,
+        eval_count: 10,
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    configureGateway({
+      expansion_model: 'ollama:qwen3.6:27b',
+      chat_model: 'ollama:qwen3.6:27b',
+      env: {},
+    });
+
+    const expanded = await expand('local search');
+    expect(expanded).toEqual([
+      'local search',
+      'local semantic search',
+      'private embeddings',
+    ]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://localhost:11434/api/chat');
+    expect(calls[0].body.think).toBe(false);
+    expect(calls[0].body.format).toEqual(expect.objectContaining({
+      type: 'object',
+    }));
+  });
+
+  test('non-chat OpenAI-compatible paths pass through unchanged', async () => {
+    const r = getRecipe('ollama')!;
+    let seenUrl = '';
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      seenUrl = typeof input === 'string'
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const cfg = applyOpenAICompatConfig(r, { env: {} } as any);
+    await cfg.fetch!('http://localhost:11434/v1/embeddings', {
+      method: 'POST',
+      body: JSON.stringify({ model: 'nomic-embed-text', input: 'hello' }),
+    });
+    expect(seenUrl).toBe('http://localhost:11434/v1/embeddings');
+  });
+});


### PR DESCRIPTION
## Summary
- declare Ollama as a local chat and expansion provider, not only embeddings
- route Ollama `/v1/chat/completions` calls through native `/api/chat` with `think:false` so thinking models return visible content for GBrain chat/expansion
- enable structured outputs for Ollama's openai-compatible client so `generateObject()` sends JSON schema requests, then map that schema to Ollama native `format`
- keep embeddings on Ollama's OpenAI-compatible `/v1/embeddings` path and normalize `OLLAMA_BASE_URL` when it omits `/v1`
- tighten the expansion prompt to require the exact `queries` key used by the schema
- update chat/provider tests and add an Ollama-specific compatibility test suite

## Verification
- `bun run typecheck`
- `bun test test/ai/recipe-ollama.test.ts test/ai/gateway-chat.test.ts test/ai/recipes-existing-regression.test.ts test/providers.test.ts test/ai/build-gateway-config.test.ts test/ai/no-batch-cap-suppression.serial.test.ts test/ai/recipe-llama-server.test.ts` (75 pass)
- `bun run src/cli.ts providers list | Select-String -Pattern '^ollama\\s'` shows Ollama with EMBED/EXPAND/CHAT enabled
- local smoke against `ollama:qwen3.6:27b`: `expand('GBrain local embeddings reranker status')` returned 4 rewrites in ~23s with `think:false`