### PR TITLE
fix(postgres): prevent transient module engines from disconnecting a shared singleton

### DIFF
--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -232,6 +232,16 @@ export async function disconnect(): Promise<void> {
   }
 }
 
+/**
+ * Is the module-level connection currently open? Lets a PostgresEngine tell
+ * whether it opened the shared connection or merely attached to an already-open
+ * one, so a transient attaching engine doesn't end the connection out from
+ * under the holder that opened it.
+ */
+export function isConnected(): boolean {
+  return sql !== null;
+}
+
 export async function initSchema(): Promise<void> {
   const conn = getConnection();
   // Advisory lock prevents concurrent initSchema() calls from deadlocking

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -100,6 +100,11 @@ export class PostgresEngine implements BrainEngine {
    * db.disconnect() and clobber the unrelated module-level connection.
    */
   private _connectionStyle: 'instance' | 'module' | null = null;
+  // True only when this engine opened the module-level connection rather than
+  // attached to an already-open one. Gates whether disconnect() ends it, so a
+  // transient module-style engine can't clobber the shared connection a
+  // still-running holder depends on.
+  private _ownsModuleConnection = false;
 
   /**
    * v0.30.1 (Fix 1 + X1 + T5): instance-owned ConnectionManager.
@@ -174,8 +179,12 @@ export class PostgresEngine implements BrainEngine {
       this.connectionManager.setReadPool(this._sql);
     } else {
       // Module-level singleton (backward compat for CLI main engine)
+      // Capture ownership before connect: if the module connection is already
+      // open, we are only attaching and must not end it on our own disconnect.
+      const ownedModuleConnection = !db.isConnected();
       await db.connect(config);
       this._connectionStyle = 'module';
+      this._ownsModuleConnection = ownedModuleConnection;
 
       // v0.30.1: connection-manager wraps the module singleton.
       if (url) {
@@ -204,8 +213,14 @@ export class PostgresEngine implements BrainEngine {
       return;
     }
     if (this._connectionStyle === 'module') {
-      await db.disconnect();
+      // Only end the shared module connection if this engine opened it.
+      // Attaching engines just detach, preserving the connection for the
+      // holder that opened it.
+      if (this._ownsModuleConnection) {
+        await db.disconnect();
+      }
       this._connectionStyle = null;
+      this._ownsModuleConnection = false;
     }
     // else: nothing to disconnect (already done or never connected)
   }

--- a/test/e2e/postgres-engine-disconnect-idempotency.test.ts
+++ b/test/e2e/postgres-engine-disconnect-idempotency.test.ts
@@ -84,4 +84,35 @@ describe.skipIf(skip)('PostgresEngine.disconnect idempotency', () => {
     // _connectionStyle was reset to null.
     await expect(engine.disconnect()).resolves.toBeUndefined();
   });
+
+  // Regression: a transient module-style engine (such as the lint
+  // content-sanity config probe) can attach to an already-open shared module
+  // connection, then disconnect in a finally block. Pre-fix that disconnect()
+  // called db.disconnect() and ended the shared connection out from under the
+  // still-running holder; the next getConnection() threw "connect() has not
+  // been called". This pins the module-connection ownership contract on real
+  // Postgres.
+  test('attaching module engine does NOT clobber a connection opened by another holder', async () => {
+    // Holder A: the module connection is open (from beforeAll). This stands in
+    // for the inline worker's engine that's mid-job.
+    await db.connect({ database_url: DATABASE_URL! });
+    expect(db.isConnected()).toBe(true);
+
+    // Holder B: a transient probe (the content-sanity engine) ATTACHES to the
+    // already-open module connection, then disconnects when done.
+    const probe = new PostgresEngine();
+    await probe.connect({ database_url: DATABASE_URL! }); // module-style; attaches
+    await probe.disconnect();
+
+    // Pre-fix this getConnection() threw "connect() has not been called".
+    // Post-fix the attaching engine only detached; the holder's connection lives.
+    expect(db.isConnected()).toBe(true);
+    const alive = await db.getConnection().unsafe('SELECT 1 as ok');
+    expect((alive[0] as unknown as { ok: number }).ok).toBe(1);
+
+    // Balanced release / no PgBouncer slot leak: the opener can still close it,
+    // and after the last holder ends, the connection is gone (not stranded).
+    await db.disconnect();
+    expect(db.isConnected()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

This fixes a module-singleton ownership bug in `PostgresEngine.disconnect()`.

Today, a module-style `PostgresEngine` cannot tell whether it opened the shared `db.ts` singleton or merely attached to another holder had already opened. On disconnect, both cases call `db.disconnect()`. A transient probe can therefore close the shared module connection out from under a still-running cycle/worker.

Concrete path found while investigating #1413:

- `resolveLintContentSanity()` in `src/commands/lint.ts` creates a second Postgres engine to lift content-sanity config from the DB.
- With no `poolSize`, that second engine uses the module-singleton path.
- When the main cycle/worker already has the singleton open, the lint probe only attaches to it.
- The lint probe’s `finally { engine.disconnect() }` currently calls `db.disconnect()` anyway, nulling the shared singleton.
- Later consumers routed through `db.getConnection()` fail with `No database connection: connect() has not been called`.

This is a confirmed localization for #1413’s “something nulls the singleton mid-cycle” note. A second manifestation is `autopilot-cycle --follow`: the lint phase completes, then the inline worker fails while completing/failing the job because the shared singleton was disconnected mid-cycle.

## Fix

Make module-style `PostgresEngine` disconnect ownership-aware:

- Add `db.isConnected()` so a module-style `PostgresEngine` can capture ownership before `db.connect(config)`.
- On `PostgresEngine.connect()` in module mode, set `_ownsModuleConnection = !db.isConnected()` before connecting.
- On `PostgresEngine.disconnect()` in module mode, call `db.disconnect()` only when this engine opened the module singleton.
- Attaching engines only detach their own wrapper state; they do not close the shared singleton.

This keeps production defaults unchanged. It does not introduce a global ref-count, which would be easy to unbalance because module `db.connect()` is intentionally idempotent. The opener still closes the module singleton explicitly, so the fix avoids both premature close and stranded pool slots.

## Relationship to #1415

This PR is complementary to #1415, not a competing rewrite.

- #1415 moves autopilot’s main engine onto an instance-owned pool, removing that path’s dependence on the module singleton.
- This PR fixes the lower-level footgun: transient module-style engines should not be able to close a module singleton they only attached to.

Both can coexist. #1415 shields the autopilot daemon. This change protects any consumer that uses a long-lived module singleton while a transient module-style probe opens and disconnects during the same process.

## Test

Adds a real-Postgres regression to `test/e2e/postgres-engine-disconnect-idempotency.test.ts`:

1. Open the module-level connection as holder A.
2. Connect holder B as a module-style `PostgresEngine` so it attaches to the already-open singleton.
3. Disconnect holder B.
4. Assert `db.isConnected()` is still true and `db.getConnection().unsafe('SELECT 1 as ok')` succeeds.
5. Disconnect holder A and assert the module singleton is closed.

Pre-fix, step 4 fails with `connect() has not been called`. Post-fix, the attaching engine detaches without clobbering the holder’s connection.

## Validation

- `bun run typecheck` passes.
- Real-Postgres fail-before/pass-after was validated during triage.
- On upstream `main` (`6a10bad8`), an equivalent holder/probe reproduction fails with `CLOBBERED No database connection: connect() has not been called`.
- On this fix branch, the same reproduction prints `ALIVE 1` and exits 0.
- The new e2e regression passes on the fix branch: `3 pass, 0 fail`.
- On current upstream `master` (`ca68633f`), `bun test test/audit/audit-writer.test.ts` passes without an extra audit-writer patch, so this PR only carries the Postgres ownership fix.

Closes #1413.
