### PR TITLE
fix(sync): record sync attempt timestamp on no-op + suppress on pull failure

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -601,22 +601,31 @@ async function writeSyncAnchor(
   // git-intrinsic committer time of the HEAD we just synced). `undefined` keeps
   // the legacy 2-column write; `null` clears the column (git unavailable).
   newestContentEpochMs?: number | null,
+  // #1430: when the upstream pull failed this run, advance last_commit (and
+  // newest_content_at — local import may have succeeded against the stale
+  // checkout) but do NOT stamp last_sync_at. doctor/autopilot's sync_freshness
+  // must not read the source as "fresh" when we never observed remote state
+  // (network partition, revoked credentials, diverged remote). Operator-skipped
+  // offline modes (--no-pull, detached HEAD, no origin) are NOT failures and
+  // pass pullFailed=false so freshness advances normally.
+  pullFailed = false,
 ): Promise<void> {
   if (sourceId) {
     const col = which === 'repo_path' ? 'local_path' : 'last_commit';
-    // last_sync_at bookmarked on every last_commit advance.
+    // last_sync_at bookmarked on every last_commit advance — gated by #1430.
     if (which === 'last_commit') {
+      const syncAt = pullFailed ? '' : ', last_sync_at = now()';
       if (newestContentEpochMs !== undefined) {
         const iso = newestContentEpochMs === null
           ? null
           : new Date(newestContentEpochMs).toISOString();
         await engine.executeRaw(
-          `UPDATE sources SET last_commit = $1, last_sync_at = now(), newest_content_at = $3 WHERE id = $2`,
+          `UPDATE sources SET last_commit = $1${syncAt}, newest_content_at = $3 WHERE id = $2`,
           [value, sourceId, iso],
         );
       } else {
         await engine.executeRaw(
-          `UPDATE sources SET last_commit = $1, last_sync_at = now() WHERE id = $2`,
+          `UPDATE sources SET last_commit = $1${syncAt} WHERE id = $2`,
           [value, sourceId],
         );
       }
@@ -1230,6 +1239,12 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     });
   }
 
+  // #1430: distinguishes a true pull FAILURE (network/credentials/diverged)
+  // from operator-skipped offline modes. Only a real failure suppresses the
+  // last_sync_at freshness bump on the anchor writes below; the pull_timeout
+  // path early-returns a partial before any anchor write.
+  let pullAttemptedAndFailed = false;
+
   if (!opts.noPull && !detachedHead && originRemotePresent) {
     const _t0 = Date.now();
     serr(`[gbrain phase] sync.git_pull start`);
@@ -1276,6 +1291,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       } else {
         serr(`Warning: git pull failed: ${msg.slice(0, 100)}`);
       }
+      pullAttemptedAndFailed = true; // #1430: suppress last_sync_at on the anchor writes below
     }
   }
 
@@ -1313,7 +1329,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       // back to the authoritative full reconcile (which now also purges stale
       // pages for deleted files; see performFullSync's delete-reconcile pass).
       serr(`Sync anchor ${lastCommit.slice(0, 8)} object missing (gc'd after history rewrite). Running full reimport.`);
-      return performFullSync(engine, repoPath, headCommit, opts);
+      return performFullSync(engine, repoPath, headCommit, opts, pullAttemptedAndFailed);
     }
 
     // Observability only — NOT control flow. A non-ancestor bookmark is still
@@ -1336,7 +1352,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
 
   // First sync
   if (!lastCommit) {
-    return performFullSync(engine, repoPath, headCommit, opts);
+    return performFullSync(engine, repoPath, headCommit, opts, pullAttemptedAndFailed);
   }
 
   // v0.42.x (#1794): resumable incremental sync — resolve the PINNED target.
@@ -1400,6 +1416,25 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       detachedWorkingTreeManifest.renamed.length > 0);
 
   if (lastCommit === headCommit && !versionMismatch && !versionNeverSet && !hasDetachedWorkingTreeChanges) {
+    // #1430: even on a pure no-op (no new commits, chunker matches, no
+    // working-tree changes), record the sync attempt timestamp. Without this,
+    // sources.last_sync_at only advances when sync actually imports new pages,
+    // so doctor's sync_freshness check misreads quiet sources (no upstream
+    // commits in N days) as "stale" even when every cron tick polls them. The
+    // metric users intuit from "last sync" is "last time we attempted a sync",
+    // not "last time we had new data". Suppress when the pull was attempted AND
+    // failed — we never observed remote state, so advancing freshness would
+    // mask the failure. Operator-skipped offline modes (--no-pull, detached
+    // HEAD, no origin) are not failures and DO advance. --dry-run must stay
+    // side-effect free. The legacy non-federated path (no opts.sourceId) writes
+    // config.sync.last_run elsewhere and isn't reached by sync_freshness's
+    // `WHERE local_path IS NOT NULL` filter, so leave it alone.
+    if (opts.sourceId && !pullAttemptedAndFailed && !opts.dryRun) {
+      await engine.executeRaw(
+        `UPDATE sources SET last_sync_at = now() WHERE id = $1`,
+        [opts.sourceId],
+      );
+    }
     return {
       status: 'up_to_date',
       fromCommit: lastCommit,
@@ -1416,7 +1451,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       `[sync] chunker_version gate: stored=${storedVersion ?? 'unset'}, current=${currentVersion}. ` +
       `Forcing full re-chunk pass (git HEAD unchanged but pipeline version advanced).`,
     );
-    const result = await performFullSync(engine, repoPath, headCommit, opts);
+    const result = await performFullSync(engine, repoPath, headCommit, opts, pullAttemptedAndFailed);
     await writeChunkerVersion(engine, opts.sourceId, currentVersion);
     return result;
   }
@@ -1440,7 +1475,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       `(${msg.slice(0, 80)}) — likely an oversized post-rewrite diff; ` +
       `falling back to full reconcile.`,
     );
-    return performFullSync(engine, repoPath, headCommit, opts);
+    return performFullSync(engine, repoPath, headCommit, opts, pullAttemptedAndFailed);
   }
   const manifest = buildSyncManifest(diffOutput);
   if (detachedWorkingTreeManifest) {
@@ -1541,7 +1576,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     // (#1794): advance to the PINNED target, and clear any checkpoint (a resume
     // whose remaining range turned out to have no syncable changes still
     // completes cleanly here).
-    await writeSyncAnchor(engine, opts.sourceId, 'last_commit', pin, commitTimeMs(repoPath, pin));
+    await writeSyncAnchor(engine, opts.sourceId, 'last_commit', pin, commitTimeMs(repoPath, pin), pullAttemptedAndFailed);
     await engine.setConfig('sync.last_run', new Date().toISOString());
     await writeChunkerVersion(engine, opts.sourceId, String(CHUNKER_VERSION));
     await clearOpCheckpoint(engine, ckpt.paths);
@@ -2242,7 +2277,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     // "fresh". The checkpoint rows clear here — CONVERGENCE CONTRACT: sync
     // convergence == IMPORT convergence; downstream extract/facts/embed is
     // decoupled (its own resumable stale sweeps).
-    await writeSyncAnchor(engine, opts.sourceId, 'last_commit', pin, commitTimeMs(repoPath, pin));
+    await writeSyncAnchor(engine, opts.sourceId, 'last_commit', pin, commitTimeMs(repoPath, pin), pullAttemptedAndFailed);
     await engine.setConfig('sync.last_run', new Date().toISOString());
     await writeSyncAnchor(engine, opts.sourceId, 'repo_path', repoPath);
     await writeChunkerVersion(engine, opts.sourceId, String(CHUNKER_VERSION));
@@ -2473,6 +2508,9 @@ async function performFullSync(
   repoPath: string,
   headCommit: string,
   opts: SyncOpts,
+  // #1430: gate last_sync_at on the full-import anchor write — a full reimport
+  // triggered after a failed pull still must not mark the source "fresh".
+  pullFailed = false,
 ): Promise<SyncResult> {
   // Dry-run: walk the repo, count syncable files, return without writing.
   // Fixes the silent-write-on-dry-run bug where performFullSync called
@@ -2549,7 +2587,7 @@ async function performFullSync(
   const advanceFull = async (): Promise<void> => {
     // Persist sync state so the next sync is incremental. Routed through
     // writeSyncAnchor so --source pins the right sources row.
-    await writeSyncAnchor(engine, opts.sourceId, 'last_commit', headCommit, newestCommitMs(repoPath));
+    await writeSyncAnchor(engine, opts.sourceId, 'last_commit', headCommit, newestCommitMs(repoPath), pullFailed);
     await engine.setConfig('sync.last_run', new Date().toISOString());
     await writeSyncAnchor(engine, opts.sourceId, 'repo_path', repoPath);
     await writeChunkerVersion(engine, opts.sourceId, String(CHUNKER_VERSION));

--- a/test/sync-no-op-touches-last-sync-at.test.ts
+++ b/test/sync-no-op-touches-last-sync-at.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Regression test for the sync_freshness no-op miss.
+ *
+ * Pre-fix bug: when `performSync` returned early via the `up_to_date` path
+ * (git HEAD unchanged AND chunker version current AND no detached working-tree
+ * changes), `sources.last_sync_at` was never updated. Doctor's
+ * `sync_freshness` check reads `last_sync_at` and was misreading quiet sources
+ * (no upstream commits in N days) as "stale 16d" even though every cron tick
+ * was attempting to sync them and getting "Already up to date" back.
+ *
+ * Post-fix: the no-op path UPDATEs `last_sync_at = now()` when `opts.sourceId`
+ * is set, so doctor sees an accurate "last attempted sync" timestamp.
+ *
+ * The legacy non-federated path (no `opts.sourceId`) still writes to
+ * `config.sync.last_run` elsewhere and isn't reached by sync_freshness's
+ * `WHERE local_path IS NOT NULL` filter, so the fix is targeted to the
+ * federated-source path only. We test both paths explicitly.
+ */
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execSync } from 'child_process';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+
+function git(repo: string, ...args: string[]): string {
+  return execSync(`git ${args.join(' ')}`, { cwd: repo, encoding: 'utf-8' }).trim();
+}
+
+function seedRepoWithMarkdown(repoPath: string, fileCount: number): string {
+  execSync('git init', { cwd: repoPath, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: repoPath, stdio: 'pipe' });
+  execSync('git config user.name "Test"', { cwd: repoPath, stdio: 'pipe' });
+  mkdirSync(join(repoPath, 'people'), { recursive: true });
+  for (let i = 0; i < fileCount; i++) {
+    writeFileSync(join(repoPath, `people/p${i}.md`), [
+      '---',
+      'type: person',
+      `title: Person ${i}`,
+      '---',
+      '',
+      `This is person ${i}.`,
+    ].join('\n'));
+  }
+  execSync('git add -A && git commit -m "initial"', { cwd: repoPath, stdio: 'pipe' });
+  return git(repoPath, 'rev-parse', 'HEAD');
+}
+
+describe('sync no-op touches last_sync_at (federated source)', () => {
+  let engine: PGLiteEngine;
+  let repoPath: string;
+  const sourceId = 'test-source-noop';
+
+  beforeEach(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+    repoPath = mkdtempSync(join(tmpdir(), 'gbrain-sync-noop-'));
+  });
+
+  afterEach(async () => {
+    await engine.disconnect();
+    if (repoPath) rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  test('no-op sync (git HEAD unchanged) UPDATEs last_sync_at on the source row', async () => {
+    seedRepoWithMarkdown(repoPath, 3);
+
+    // Register the source so writeSyncAnchor/UPDATE finds the row.
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path) VALUES ($1, $2, $3)`,
+      [sourceId, 'Test Source', repoPath],
+    );
+
+    const { performSync } = await import('../src/commands/sync.ts');
+
+    // First sync imports the files and sets last_sync_at via the
+    // writeSyncAnchor('last_commit', ...) path.
+    await performSync(engine, {
+      repoPath,
+      sourceId,
+      noPull: true,
+      noEmbed: true,
+    });
+
+    const after1 = await engine.executeRaw<{ last_sync_at: Date }>(
+      `SELECT last_sync_at FROM sources WHERE id = $1`,
+      [sourceId],
+    );
+    const firstTs = new Date(after1[0].last_sync_at).getTime();
+    expect(firstTs).toBeGreaterThan(0);
+
+    // Sleep ~25ms to make the post-no-op timestamp distinguishable from
+    // the post-first-sync timestamp.
+    await new Promise(r => setTimeout(r, 25));
+
+    // Second sync: git HEAD unchanged, chunker version matches. Pre-fix
+    // this would return without touching last_sync_at.
+    const result = await performSync(engine, {
+      repoPath,
+      sourceId,
+      noPull: true,
+      noEmbed: true,
+    });
+    expect(result.status).toBe('up_to_date');
+
+    const after2 = await engine.executeRaw<{ last_sync_at: Date }>(
+      `SELECT last_sync_at FROM sources WHERE id = $1`,
+      [sourceId],
+    );
+    const secondTs = new Date(after2[0].last_sync_at).getTime();
+
+    // Post-fix: timestamp MUST have advanced even though no work was done.
+    expect(secondTs).toBeGreaterThan(firstTs);
+  });
+
+  test('no-op sync without opts.sourceId does NOT touch sources rows (legacy path)', async () => {
+    seedRepoWithMarkdown(repoPath, 3);
+
+    // Seed a sources row that we will use to detect any accidental write.
+    // last_sync_at deliberately starts NULL.
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path) VALUES ($1, $2, $3)`,
+      ['unrelated-source', 'Unrelated', '/some/other/path'],
+    );
+
+    const { performSync } = await import('../src/commands/sync.ts');
+
+    // Two syncs on the legacy path (no sourceId).
+    await performSync(engine, { repoPath, noPull: true, noEmbed: true });
+    const result = await performSync(engine, { repoPath, noPull: true, noEmbed: true });
+    expect(result.status).toBe('up_to_date');
+
+    // The unrelated sources row was never targeted — last_sync_at stays NULL.
+    const row = await engine.executeRaw<{ last_sync_at: Date | null }>(
+      `SELECT last_sync_at FROM sources WHERE id = $1`,
+      ['unrelated-source'],
+    );
+    expect(row[0].last_sync_at).toBeNull();
+  });
+
+  test('--dry-run on a head-unchanged source does NOT mutate last_sync_at', async () => {
+    // Dry-run preview must be side-effect free. The freshness write would
+    // otherwise mislead doctor/autopilot into treating a preview run as a
+    // real sync.
+    const sid = 'dryrun-source';
+    seedRepoWithMarkdown(repoPath, 2);
+
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path) VALUES ($1, $2, $3)`,
+      [sid, 'Dry Run', repoPath],
+    );
+
+    const { performSync } = await import('../src/commands/sync.ts');
+
+    // First sync seeds the source. last_sync_at populated.
+    await performSync(engine, { repoPath, sourceId: sid, noPull: true, noEmbed: true });
+    const after1 = await engine.executeRaw<{ last_sync_at: Date }>(
+      `SELECT last_sync_at FROM sources WHERE id = $1`, [sid],
+    );
+    const beforeTs = new Date(after1[0].last_sync_at).getTime();
+
+    await new Promise(r => setTimeout(r, 25));
+
+    // Dry-run on head-unchanged source. Status should still be 'up_to_date'
+    // (the no-op early-return fires) but last_sync_at MUST NOT advance.
+    const result = await performSync(engine, {
+      repoPath,
+      sourceId: sid,
+      noPull: true,
+      noEmbed: true,
+      dryRun: true,
+    });
+    expect(result.status).toBe('up_to_date');
+
+    const after2 = await engine.executeRaw<{ last_sync_at: Date }>(
+      `SELECT last_sync_at FROM sources WHERE id = $1`, [sid],
+    );
+    const afterTs = new Date(after2[0].last_sync_at).getTime();
+
+    expect(afterTs).toBe(beforeTs);
+  });
+
+  test('incremental sync (local commits, pull failed) does NOT advance last_sync_at', async () => {
+    // Codex finding scope-2: the pull-failure suppression must cover the
+    // incremental path too, not just the no-op early-return. Scenario: pull
+    // fails (network/auth gone), but a local commit advanced HEAD beforehand,
+    // so sync enters the diff+import branch and ends at writeSyncAnchor at
+    // the bottom of performSyncInner. That site also receives the flag and
+    // must keep last_sync_at frozen even though last_commit advances.
+    const sourceIdLocal = 'pull-fail-incremental';
+    seedRepoWithMarkdown(repoPath, 2);
+
+    // Configure invalid origin BEFORE first sync, but use --no-pull on
+    // the first sync so it succeeds and seeds last_sync_at + last_commit.
+    execSync(`git remote add origin /nonexistent/incremental.git`, {
+      cwd: repoPath, stdio: 'pipe',
+    });
+
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path) VALUES ($1, $2, $3)`,
+      [sourceIdLocal, 'Incremental Pull-Fail', repoPath],
+    );
+
+    const { performSync } = await import('../src/commands/sync.ts');
+    await performSync(engine, {
+      repoPath,
+      sourceId: sourceIdLocal,
+      noPull: true,
+      noEmbed: true,
+    });
+
+    const after1 = await engine.executeRaw<{ last_sync_at: Date; last_commit: string }>(
+      `SELECT last_sync_at, last_commit FROM sources WHERE id = $1`,
+      [sourceIdLocal],
+    );
+    const firstTs = new Date(after1[0].last_sync_at).getTime();
+    const firstCommit = after1[0].last_commit;
+
+    // Add a local commit so the next sync has work to do (forces it
+    // through the incremental import path, not the no-op early-return).
+    writeFileSync(join(repoPath, 'people/added.md'), [
+      '---', 'type: person', 'title: Added', '---', '', 'Added.',
+    ].join('\n'));
+    execSync('git add -A && git commit -m "add"', { cwd: repoPath, stdio: 'pipe' });
+    const newHead = git(repoPath, 'rev-parse', 'HEAD');
+    expect(newHead).not.toBe(firstCommit);
+
+    await new Promise(r => setTimeout(r, 25));
+
+    // Second sync: pull is ATTEMPTED (no --no-pull, origin remote present)
+    // and FAILS. The local diff still gets imported.
+    const result = await performSync(engine, {
+      repoPath,
+      sourceId: sourceIdLocal,
+      noEmbed: true,
+    });
+    expect(result.status).toBe('synced');
+
+    const after2 = await engine.executeRaw<{ last_sync_at: Date; last_commit: string }>(
+      `SELECT last_sync_at, last_commit FROM sources WHERE id = $1`,
+      [sourceIdLocal],
+    );
+    const secondTs = new Date(after2[0].last_sync_at).getTime();
+
+    // last_commit advances (local import succeeded) but last_sync_at
+    // does NOT (pull failed, no observed upstream).
+    expect(after2[0].last_commit).toBe(newHead);
+    expect(secondTs).toBe(firstTs);
+  });
+
+  test('no-op sync does NOT advance last_sync_at when git pull was attempted and failed', async () => {
+    // This case pins the codex-finding fix: if the pull was attempted (origin
+    // remote present, no --no-pull, no detached HEAD) and threw, we never
+    // observed upstream state, so advancing freshness would mask the failure
+    // for doctor + autopilot's sync_freshness check. The UPDATE must be
+    // suppressed in that path.
+    const initialHead = seedRepoWithMarkdown(repoPath, 3);
+
+    // Configure an origin remote pointing at a non-existent path so git pull
+    // throws. This avoids needing the network to test the failure path.
+    execSync(`git remote add origin /nonexistent/repo/that/does/not/exist.git`, {
+      cwd: repoPath,
+      stdio: 'pipe',
+    });
+
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path) VALUES ($1, $2, $3)`,
+      ['pull-fail-source', 'Pull Fail', repoPath],
+    );
+
+    const { performSync } = await import('../src/commands/sync.ts');
+
+    // First sync seeds the brain. We do NOT pull on the first sync (avoid
+    // failure during initial import) so the bookmark advances cleanly.
+    await performSync(engine, {
+      repoPath,
+      sourceId: 'pull-fail-source',
+      noPull: true,
+      noEmbed: true,
+    });
+
+    const after1 = await engine.executeRaw<{ last_sync_at: Date }>(
+      `SELECT last_sync_at FROM sources WHERE id = $1`,
+      ['pull-fail-source'],
+    );
+    const firstTs = new Date(after1[0].last_sync_at).getTime();
+    expect(firstTs).toBeGreaterThan(0);
+
+    // Pause so a clock-tick-collision can't accidentally satisfy the assertion.
+    await new Promise(r => setTimeout(r, 25));
+
+    // Second sync: attempt the pull. With the non-existent origin URL, the
+    // pull throws inside the try/catch. lastCommit === headCommit still, so
+    // we hit the no-op early-return. Pre-fix this would still advance
+    // last_sync_at. Post-fix it must NOT.
+    const result = await performSync(engine, {
+      repoPath,
+      sourceId: 'pull-fail-source',
+      // NOTE: omitting noPull — we WANT the pull to be attempted so we
+      // exercise the failure-suppression branch.
+      noEmbed: true,
+    });
+    expect(result.status).toBe('up_to_date');
+
+    const after2 = await engine.executeRaw<{ last_sync_at: Date }>(
+      `SELECT last_sync_at FROM sources WHERE id = $1`,
+      ['pull-fail-source'],
+    );
+    const secondTs = new Date(after2[0].last_sync_at).getTime();
+
+    // Pull failed → timestamp must NOT have advanced.
+    expect(secondTs).toBe(firstTs);
+
+    // Sanity: confirm headCommit didn't change either (pure no-op).
+    expect(git(repoPath, 'rev-parse', 'HEAD')).toBe(initialHead);
+  });
+});


### PR DESCRIPTION
## Problem

doctor's `sync_freshness` check reads `sources.last_sync_at` to decide whether a source is stale. Two gaps:

**(A) No-op syncs never advanced `last_sync_at`.** When `performSync` returns early via the `up_to_date` path (git HEAD unchanged, chunker current, no detached working-tree changes), the column was never touched. So a quiet source (no upstream commits in N days) was misreported as "stale 16d" even though every cron tick polled it and got "Already up to date". The metric users intuit from "last sync" is *last time we attempted a sync*, not *last time we imported new data*.

**(B) `last_sync_at` advanced even when the git pull failed.** A network partition / revoked credential / diverged remote means we never observed remote state — but freshness still advanced, telling doctor/autopilot the source was healthy when it wasn't.

## Fix

- Advance `last_sync_at = now()` on the no-op `up_to_date` early-return (federated `opts.sourceId` path only; legacy `config.sync.last_run` path untouched).
- Gate every `last_commit` write site on `pullAttemptedAndFailed` (threaded through `writeSyncAnchor` + `performFullSync`): `last_commit`/`newest_content_at` still advance against the stale checkout, but the freshness signal is suppressed.
- Operator-skipped offline modes (`--no-pull`, detached HEAD, no origin) are NOT failures and DO advance. `--dry-run` stays side-effect free.

## Test

`test/sync-no-op-touches-last-sync-at.test.ts` (PGLite, 5 cases): no-op advances freshness; no-op without `sourceId` is a no-write; `--dry-run` mutates nothing; no-op + pull-failure does NOT advance; incremental + pull-failure advances `last_commit` but not `last_sync_at`. **5/5 green** on current master.

---
*Rebased onto current `master`. Upstream `#1794` (resumable incremental sync) reworked this path but covers **neither** gap — the no-op early-return at the `up_to_date` branch still skips the freshness write, and there's no pull-failure gate. Both halves of this fix still apply.*
