### PR TITLE
fix: stabilize PGLite CLI query and migration checks

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1768,7 +1768,9 @@ Run gbrain <command> --help for command-specific help.
 `);
 }
 
-main().catch(e => {
+main().then(() => {
+  process.exit(0);
+}).catch(e => {
   console.error(e.message || e);
   process.exit(1);
 });

--- a/src/commands/migrations/v0_32_2.ts
+++ b/src/commands/migrations/v0_32_2.ts
@@ -186,17 +186,6 @@ async function phaseBFenceFacts(
     const localPathById = new Map<string, string | null>();
     for (const s of sources) localPathById.set(s.id, s.local_path);
 
-    // Dirty-tree refusal: check every source's local_path before writing.
-    for (const [id, localPath] of localPathById) {
-      if (localPath && isLocalPathDirty(localPath)) {
-        return {
-          name: 'fence_facts',
-          status: 'failed',
-          detail: `source "${id}" has uncommitted changes in ${localPath}. Commit or stash, then re-run.`,
-        };
-      }
-    }
-
     // Walk legacy rows in (source_id, entity_slug) groups for per-page
     // atomic writes.
     const legacy = await engine.executeRaw<LegacyFactRow>(
@@ -233,6 +222,22 @@ async function phaseBFenceFacts(
       const list = groups.get(key) ?? [];
       list.push(row);
       groups.set(key, list);
+    }
+
+    // Dirty-tree refusal: check only sources we are about to write. A brain
+    // can register many sources; unrelated dirty repos must not wedge this
+    // migration when there are no fence writes for that source.
+    const sourcesToWrite = new Set<string>();
+    Array.from(groups.keys()).forEach(key => sourcesToWrite.add(key.split('\0')[0]));
+    for (const id of Array.from(sourcesToWrite)) {
+      const localPath = localPathById.get(id);
+      if (localPath && isLocalPathDirty(localPath)) {
+        return {
+          name: 'fence_facts',
+          status: 'failed',
+          detail: `source "${id}" has uncommitted changes in ${localPath}. Commit or stash, then re-run.`,
+        };
+      }
     }
 
     for (const [key, group] of groups) {

--- a/src/commands/migrations/v0_32_2.ts
+++ b/src/commands/migrations/v0_32_2.ts
@@ -138,6 +138,7 @@ function isLocalPathDirty(localPath: string): boolean {
     const out = execFileSync('git', ['-C', localPath, 'status', '--porcelain'], {
       encoding: 'utf-8',
       timeout: 10_000,
+      stdio: ['ignore', 'pipe', 'ignore'],
     });
     return out.trim().length > 0;
   } catch {

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -197,7 +197,14 @@ export class PGLiteEngine implements BrainEngine {
 
   async disconnect(): Promise<void> {
     if (this._db) {
-      await this._db.close();
+      // PGLite's close() can deadlock on persistent data dirs after some read
+      // queries (observed after FTS/vector search). For CLI/local persistent
+      // brains the important cleanup is releasing gbrain's interprocess lock;
+      // the process exit will reclaim the embedded WASM runtime. Keep close()
+      // for in-memory engines/tests where no file lock exists.
+      if (!this._lock?.acquired) {
+        await this._db.close();
+      }
       this._db = null;
     }
     if (this._lock?.acquired) {

--- a/test/migrations-v0_32_2.test.ts
+++ b/test/migrations-v0_32_2.test.ts
@@ -14,6 +14,7 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:tes
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { v0_32_2, __setTestEngineOverride, __testing } from '../src/commands/migrations/v0_32_2.ts';
@@ -235,6 +236,26 @@ describe('phaseBFenceFacts — happy path backfill', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const rows = await (engine as any).db.query('SELECT row_num FROM facts');
     expect(rows.rows[0].row_num).toBeNull();
+  });
+
+  test('does not block on dirty unrelated source with no legacy rows to fence', async () => {
+    const dirtyDir = mkdtempSync(join(tmpdir(), 'mig-v0_32_2-dirty-source-'));
+    execFileSync('git', ['init'], { cwd: dirtyDir, stdio: 'ignore' });
+    writeFileSync(join(dirtyDir, 'scratch.md'), 'uncommitted note\n', 'utf-8');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO sources (id, name, local_path, config) VALUES ('dirty-unused', 'dirty-unused', $1, '{}'::jsonb)
+       ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path`,
+      [dirtyDir],
+    );
+    await seedLegacyFact({ entity_slug: 'people/alice', fact: 'Fenceable from default source' });
+
+    const r = await __testing.phaseBFenceFacts(engine, OPTS);
+    expect(r.status).toBe('complete');
+    expect(r.detail).toContain('fenced=1');
+
+    rmSync(dirtyDir, { recursive: true, force: true });
   });
 });
 


### PR DESCRIPTION
## Summary
- Prevent PGLite-backed CLI queries from hanging after output
- Ignore dirty unused sources in facts migration
- Silence noisy git status probes for non-git paths in migration tests

## Test plan
- bun test test/migrations-v0_32_2.test.ts reports 15 pass / 0 fail, but Bun still exits code 99 locally (pre-existing unresolved runner/teardown issue noted)
- gbrain query smoke tests completed and returned results
