### PR TITLE
fix: ze-switch preserves embedding_image column dimensions

### DIFF
--- a/src/core/retrieval-upgrade-planner.ts
+++ b/src/core/retrieval-upgrade-planner.ts
@@ -440,19 +440,40 @@ export async function undoRetrievalUpgrade(engine: BrainEngine): Promise<
  * `--resume`.
  */
 async function runSchemaTransition(engine: BrainEngine, targetDim: number): Promise<void> {
+  // v0.41 fix: only transition the primary text embedding column.
+  // The embedding_image column uses a separate multimodal model (e.g.
+  // voyage-multimodal-3 at 1024d) whose dimensions are independent of
+  // the text embedding model. Dropping and recreating it at targetDim
+  // silently breaks multimodal search by creating a dimension mismatch
+  // between the column and the multimodal provider's output.
+  //
+  // Before this fix, switching text embeddings from OpenAI (1536d) to
+  // ZeroEntropy (1280d) would also change embedding_image from 1024d
+  // to 1280d, making voyage-multimodal-3 unable to write to it.
   await engine.transaction(async (tx) => {
+    // Text embedding column — transition to target dim.
     await tx.executeRaw(`DROP INDEX IF EXISTS idx_chunks_embedding`);
-    await tx.executeRaw(`DROP INDEX IF EXISTS idx_chunks_embedding_image`);
     await tx.executeRaw(`ALTER TABLE content_chunks DROP COLUMN IF EXISTS embedding`);
     await tx.executeRaw(`ALTER TABLE content_chunks ADD COLUMN embedding vector(${targetDim})`);
-    await tx.executeRaw(`ALTER TABLE content_chunks DROP COLUMN IF EXISTS embedding_image`);
-    await tx.executeRaw(`ALTER TABLE content_chunks ADD COLUMN embedding_image vector(${targetDim})`);
     await tx.executeRaw(
       `CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops)`,
     );
-    await tx.executeRaw(
-      `CREATE INDEX IF NOT EXISTS idx_chunks_embedding_image ON content_chunks USING hnsw (embedding_image vector_cosine_ops)`,
+
+    // Image/multimodal embedding column — rebuild index but preserve
+    // existing dimension. Only create it if it doesn't already exist
+    // (fresh brains may not have it yet).
+    const hasImageCol = await tx.executeRaw<{ exists: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_name = 'content_chunks' AND column_name = 'embedding_image'
+       ) AS exists`,
     );
+    if (hasImageCol[0]?.exists) {
+      await tx.executeRaw(`DROP INDEX IF EXISTS idx_chunks_embedding_image`);
+      await tx.executeRaw(
+        `CREATE INDEX IF NOT EXISTS idx_chunks_embedding_image ON content_chunks USING hnsw (embedding_image vector_cosine_ops)`,
+      );
+    }
   });
 }
 


### PR DESCRIPTION
## Problem

`runSchemaTransition` drops and recreates **both** `embedding` and `embedding_image` columns at the target dimension. But `embedding_image` uses a separate multimodal model (e.g. `voyage-multimodal-3` at 1024d) whose dimensions are independent of the text embedding model.

Switching from OpenAI `text-embedding-3-large` (1536d) to ZeroEntropy `zembed-1` (1280d) also changes `embedding_image` from `vector(1024)` → `vector(1280)`, creating a silent dimension mismatch that prevents the multimodal provider from writing image embeddings.

## Fix

Only transition the primary `embedding` column. Leave `embedding_image` dimensions untouched — just rebuild its HNSW index for safety.

## Impact

Without this fix, every `ze-switch` run silently breaks multimodal search for brains using a separate image embedding model with different dimensions.