### PR TITLE
fix(doctor): guard getConfig() returns against non-string values

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -27,6 +27,17 @@ import { dirname, isAbsolute, join, resolve as resolvePath } from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 
+/**
+ * Safely coerce a getConfig() return value to a lowercase trimmed string.
+ * getConfig() is typed as `string | null` but can return non-string values
+ * (boolean, number) when config was stored via JSON / `--force`. Calling
+ * `.trim()` on a boolean crashes with "undefined is not an object".
+ */
+function cfgToString(val: unknown): string {
+  if (val === null || val === undefined) return '';
+  return typeof val === 'string' ? val.trim().toLowerCase() : String(val).toLowerCase();
+}
+
 export interface Check {
   name: string;
   status: 'ok' | 'warn' | 'fail';
@@ -985,7 +996,7 @@ export async function checkVoiceGateHealth(engine: BrainEngine): Promise<Check> 
 export async function checkRerankerHealth(engine: BrainEngine): Promise<Check> {
   try {
     const { readRecentRerankFailures } = await import('../core/rerank-audit.ts');
-    const cfg = await engine.getConfig('search.reranker.enabled');
+    const cfg = cfgToString(await engine.getConfig('search.reranker.enabled'));
     const rerankerEnabled = cfg === 'true' || cfg === '1';
 
     const failures = readRecentRerankFailures(7);
@@ -1080,7 +1091,7 @@ export async function checkGraphSignalsCoverage(engine: BrainEngine): Promise<Ch
       // loadOverridesFromConfig in src/core/search/mode.ts. Without
       // this, `gbrain config set search.graph_signals TRUE` enables
       // the feature in production but doctor reports "disabled".
-      const v = cfgVal.trim().toLowerCase();
+      const v = cfgToString(cfgVal);
       enabled = v === 'true' || v === '1';
     } else {
       // Mode bundle default. Read search.mode (case-insensitive + trim
@@ -1203,7 +1214,7 @@ export async function checkBrainstormHealth(engine: BrainEngine): Promise<Check>
 
   // (2) search.track_retrieval — explicit-off surfaces as a warning.
   try {
-    const trackCfg = await engine.getConfig('search.track_retrieval');
+    const trackCfg = cfgToString(await engine.getConfig('search.track_retrieval'));
     if (trackCfg === 'false' || trackCfg === '0' || trackCfg === 'off' || trackCfg === 'no') {
       return {
         name: 'brainstorm_health',
@@ -3632,8 +3643,8 @@ export async function buildChecks(
   // Source-aware: a global 95% can hide 0% coverage for a specific source.
   progress.heartbeat('unified_multimodal_coverage');
   try {
-    const unifiedFlag = await engine.getConfig('search.unified_multimodal').catch(() => null);
-    const unifiedOnlyFlag = await engine.getConfig('search.unified_multimodal_only').catch(() => null);
+    const unifiedFlag = cfgToString(await engine.getConfig('search.unified_multimodal').catch(() => null));
+    const unifiedOnlyFlag = cfgToString(await engine.getConfig('search.unified_multimodal_only').catch(() => null));
     const unifiedOn = unifiedFlag === 'true' || unifiedFlag === '1';
     const unifiedOnlyOn = unifiedOnlyFlag === 'true' || unifiedOnlyFlag === '1';
 


### PR DESCRIPTION
## Problem

`gbrain doctor` crashes on v0.41.2 with:

```
undefined is not an object (evaluating 's.toLowerCase')
```

Reproduced on a production brain (~16K pages, Supabase Postgres) with a custom schema pack. The crash is intermittent — it depends on how config values were stored (JSON vs string).

## Error Log

```
$ gbrain doctor
undefined is not an object (evaluating 's.toLowerCase')
```

No stack trace printed. The entire doctor command aborts — no health checks are reported.

## Root Cause

`engine.getConfig()` is typed as `Promise<string | null>` but can return non-string values (boolean `true`, number `1`) when:
- Config was stored via `gbrain config set key value --force`
- Config was set programmatically with a JSON value
- The underlying config table stores JSONB and the value isn't a string

The crash site is `checkGraphSignalsCoverage()` at line 1083:

```typescript
const cfgVal = await engine.getConfig('search.graph_signals');
// cfgVal is boolean `true`, not string "true"
const v = cfgVal.trim().toLowerCase();  // 💥 boolean has no .trim()
```

The guard `if (cfgVal !== null && cfgVal !== undefined)` passes for boolean `true`, then `.trim()` is undefined on booleans.

## What We Tried

1. Checked all `getConfig()` call sites in doctor.ts — found 4 vulnerable patterns
2. Noted that line 1089 already had the correct pattern: `typeof modeRaw === 'string' ? ...`
3. Considered inline fixes vs a shared helper — chose the helper to prevent future regressions

## Solution

Added `cfgToString()` helper that safely coerces any `getConfig()` return value:

```typescript
function cfgToString(val: unknown): string {
  if (val === null || val === undefined) return '';
  return typeof val === 'string' ? val.trim().toLowerCase() : String(val).toLowerCase();
}
```

Applied to all 4 vulnerable doctor checks:

| Check | Config key | Before | After |
|---|---|---|---|
| `graph_signals_coverage` | `search.graph_signals` | `cfgVal.trim().toLowerCase()` 💥 | `cfgToString(cfgVal)` |
| `reranker_health` | `search.reranker.enabled` | `cfg === 'true'` (silent mismatch) | `cfgToString(cfg) === 'true'` |
| `brainstorm_health` | `search.track_retrieval` | `trackCfg === 'false'` (silent mismatch) | `cfgToString(trackCfg) === 'false'` |
| `unified_multimodal_coverage` | `search.unified_multimodal` | `flag === 'true'` (silent mismatch) | `cfgToString(flag) === 'true'` |

The `graph_signals_coverage` fix prevents the crash. The other 3 fixes prevent silent logic errors where boolean config values would never match string comparisons.

## Testing

- Verified `gbrain doctor` completes successfully after the fix on the same production brain that previously crashed
- Confirmed all 55+ health checks pass through to completion
- The helper handles: string → trim+lower, boolean/number → String()+lower, null/undefined → empty string
