### PR TITLE
feat: support bracket-time format in conversation facts parser

### DIFF
--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -231,21 +231,64 @@ export interface ExtractConversationFactsResult {
 }
 
 // ---------------------------------------------------------------------------
-// Message parsing — lines like:
-//   **Name** (YYYY-MM-DD H:MM AM/PM): text
+// Message parsing — two supported formats:
+//
+//   Format 1 (full-date): **Name** (YYYY-MM-DD H:MM AM/PM): text
+//     Used by iMessage/Slack importers. Each line carries an absolute date.
+//
+//   Format 2 (bracket-time, v0.41.12): **[HH:MM] 👤 Name:** text
+//     Used by Telegram conversation syncs. Time-only; date comes from page
+//     frontmatter (fallbackDate parameter). The emoji prefix (👤 🤖 etc.)
+//     is stripped from the speaker name.
+//
 // Unmatched lines become continuations of the prior message (multi-line
-// imessage bodies).
+// bodies).
 // ---------------------------------------------------------------------------
 
+/** Format 1: full-date inline — **Speaker** (2026-05-25 6:30 PM): text */
 const MESSAGE_LINE_RX =
   /^\*\*(.+?)\*\*\s*\((\d{4}-\d{2}-\d{2})\s+(\d{1,2}):(\d{2})\s*(AM|PM|am|pm)?\)\s*:\s*(.*)$/;
 
-export function parseConversationMessages(body: string): ConversationMessage[] {
+/**
+ * Format 2: bracket-time — **[18:37] 👤 G T:** text
+ *
+ * Captures:
+ *   1 = HH        (24-hour)
+ *   2 = MM
+ *   3 = speaker   (may start with emoji + space; cleaned below)
+ *   4 = text      (rest of line after colon; may be empty → next lines)
+ */
+const BRACKET_TIME_RX =
+  /^\*\*\[(\d{1,2}):(\d{2})\]\s+(.+?):\*\*\s*(.*)$/;
+
+/** Strip leading emoji + optional space from a speaker token. */
+function cleanSpeaker(raw: string): string {
+  // Unicode emoji can be multi-codepoint; strip the leading grapheme
+  // cluster when it isn't alphanumeric or CJK.
+  return raw.replace(/^[^\p{L}\p{N}]+\s*/u, '').trim() || raw.trim();
+}
+
+export interface ParseConversationOpts {
+  /**
+   * Fallback ISO date (YYYY-MM-DD) for formats that carry time-only
+   * (bracket-time). When omitted, bracket-time lines are still parsed
+   * but the timestamp defaults to 1970-01-01.
+   */
+  fallbackDate?: string;
+}
+
+export function parseConversationMessages(
+  body: string,
+  opts: ParseConversationOpts = {},
+): ConversationMessage[] {
   if (!body) return [];
+  const fallbackDate = opts.fallbackDate ?? '1970-01-01';
   const out: ConversationMessage[] = [];
   for (const rawLine of body.split(/\r?\n/)) {
     const line = rawLine.trim();
     if (!line) continue;
+
+    // Try Format 1 first (full-date).
     const m = MESSAGE_LINE_RX.exec(line);
     if (m) {
       const [, speaker, date, hStr, mStr, ampmRaw, text] = m;
@@ -260,7 +303,26 @@ export function parseConversationMessages(body: string): ConversationMessage[] {
         timestamp: iso,
         text: (text || '').trim(),
       });
-    } else if (out.length > 0) {
+      continue;
+    }
+
+    // Try Format 2 (bracket-time).
+    const b = BRACKET_TIME_RX.exec(line);
+    if (b) {
+      const [, hStr, mStr, rawSpeaker, text] = b;
+      const hour = Number(hStr);
+      const minute = Number(mStr);
+      const iso = `${fallbackDate}T${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}:00Z`;
+      out.push({
+        speaker: cleanSpeaker(rawSpeaker),
+        timestamp: iso,
+        text: (text || '').trim(),
+      });
+      continue;
+    }
+
+    // Continuation line for the previous message.
+    if (out.length > 0) {
       const last = out[out.length - 1];
       last.text = last.text ? `${last.text}\n${line}` : line;
     }
@@ -510,7 +572,15 @@ async function processPage(
   }
 
   const body = readPageBody(page);
-  const messages = parseConversationMessages(body);
+  // Derive fallback date from frontmatter or effective_date for bracket-time
+  // pages (Format 2) that carry time-only timestamps.
+  const fmDate =
+    typeof page.frontmatter?.date === 'string'
+      ? page.frontmatter.date.slice(0, 10)  // handle 'YYYY-MM-DD' or full ISO
+      : page.effective_date
+        ? page.effective_date.toISOString().slice(0, 10)
+        : undefined;
+  const messages = parseConversationMessages(body, { fallbackDate: fmDate });
   const segments = splitIntoSegments(messages, { sinceIso });
   if (segments.length === 0) {
     state.result.pages_skipped++;

--- a/test/extract-conversation-facts.test.ts
+++ b/test/extract-conversation-facts.test.ts
@@ -88,6 +88,64 @@ describe('parseConversationMessages', () => {
   test('empty body returns empty array', () => {
     expect(parseConversationMessages('')).toEqual([]);
   });
+
+  // Format 2: bracket-time (v0.41.12).
+  test('parses bracket-time format with emoji speaker prefix', () => {
+    const body = '**[18:37] \ud83d\udc64 G T:** hello world';
+    const msgs = parseConversationMessages(body, { fallbackDate: '2026-05-24' });
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].speaker).toBe('G T');
+    expect(msgs[0].text).toBe('hello world');
+    expect(msgs[0].timestamp).toBe('2026-05-24T18:37:00Z');
+  });
+
+  test('parses bracket-time format with robot emoji', () => {
+    const body = '**[06:00] \ud83e\udd16 Zion:** On it.';
+    const msgs = parseConversationMessages(body, { fallbackDate: '2026-05-25' });
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].speaker).toBe('Zion');
+    expect(msgs[0].text).toBe('On it.');
+    expect(msgs[0].timestamp).toBe('2026-05-25T06:00:00Z');
+  });
+
+  test('bracket-time multi-line continuation', () => {
+    const body = [
+      '**[09:00] \ud83d\udc64 Alice:** first line',
+      'second line of same message',
+      '**[09:05] \ud83d\udc64 Bob:** separate message',
+    ].join('\n');
+    const msgs = parseConversationMessages(body, { fallbackDate: '2026-05-20' });
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].text).toBe('first line\nsecond line of same message');
+    expect(msgs[1].text).toBe('separate message');
+  });
+
+  test('bracket-time falls back to 1970-01-01 without fallbackDate', () => {
+    const body = '**[14:30] \ud83d\udc64 Alice:** test';
+    const msgs = parseConversationMessages(body);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].timestamp).toBe('1970-01-01T14:30:00Z');
+  });
+
+  test('mixed formats in one body: full-date + bracket-time', () => {
+    const body = [
+      fmt('Alice Example', '2024-03-15', '9:00 AM', 'format 1'),
+      '**[10:30] \ud83d\udc64 Bob:** format 2',
+    ].join('\n');
+    const msgs = parseConversationMessages(body, { fallbackDate: '2024-03-15' });
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].speaker).toBe('Alice Example');
+    expect(msgs[1].speaker).toBe('Bob');
+    expect(msgs[1].timestamp).toBe('2024-03-15T10:30:00Z');
+  });
+
+  test('bracket-time without emoji prefix', () => {
+    const body = '**[22:15] Plain Name:** no emoji';
+    const msgs = parseConversationMessages(body, { fallbackDate: '2026-01-01' });
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].speaker).toBe('Plain Name');
+    expect(msgs[0].text).toBe('no emoji');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`extract-conversation-facts` only recognizes one message format:

```
**Speaker** (2026-05-25 6:30 PM): message text
```

Conversation pages synced from Telegram use a different bracket-time format:

```
**[18:37] 👤 G T:** message text
**[18:38] 🤖 Bot:** response text
```

A production brain with 134 conversation pages typed correctly as `conversation` shows 0 eligible segments because every line fails the regex match. Doctor reports the pages as backlog, but the extractor silently skips them all.

## Solution

Add a second regex (`BRACKET_TIME_RX`) that matches the bracket-time format:

| Component | Format 1 (existing) | Format 2 (new) |
|---|---|---|
| Pattern | `**Name** (YYYY-MM-DD H:MM AM/PM): text` | `**[HH:MM] 👤 Name:** text` |
| Date source | Inline in each line | Page frontmatter `date` field |
| Time format | 12-hour with AM/PM | 24-hour |
| Speaker prefix | None | Optional emoji (stripped) |

### Changes

**`src/commands/extract-conversation-facts.ts`**
- New `BRACKET_TIME_RX` regex: `/^\*\*\[(\d{1,2}):(\d{2})\]\s+(.+?):\*\*\s*(.*)$/`
- `cleanSpeaker()` helper strips leading emoji + whitespace from speaker names using Unicode property escapes
- `ParseConversationOpts.fallbackDate` parameter supplies the date for time-only lines
- `processPage()` derives `fallbackDate` from `page.frontmatter.date` (preferred) or `page.effective_date` (fallback)
- Parser tries Format 1 first, then Format 2, then treats the line as a continuation — preserving full backward compatibility

**`test/extract-conversation-facts.test.ts`**
- 6 new test cases:
  - Bracket-time with 👤 emoji speaker prefix
  - Bracket-time with 🤖 robot emoji
  - Multi-line continuation after bracket-time anchor
  - Fallback to 1970-01-01 when no `fallbackDate` provided
  - Mixed Format 1 + Format 2 in the same body
  - Bracket-time without emoji prefix

## Testing

33/33 tests pass (`bun test test/extract-conversation-facts.test.ts`). All 27 existing tests unchanged; 6 new tests added.

## Behavior Matrix

| Input | Before | After |
|---|---|---|
| `**Alice** (2024-03-15 9:00 AM): hi` | ✅ Parsed | ✅ Parsed (unchanged) |
| `**[18:37] 👤 G T:** hello` | ❌ Orphan line | ✅ Parsed, speaker=`G T` |
| `**[06:00] 🤖 Bot:** response` | ❌ Orphan line | ✅ Parsed, speaker=`Bot` |
| `**[22:15] Plain Name:** text` | ❌ Orphan line | ✅ Parsed, speaker=`Plain Name` |
| Continuation lines after any format | ✅ Appended | ✅ Appended (unchanged) |