### PR TITLE
fix(cli): wire gbrain bench publish dispatcher (closes #1474)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture']);
+const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'bench', 'sync', 'extract', 'extract-conversation-facts', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture']);
 // CLI-only commands whose handlers print their own --help text. These are
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
@@ -1287,6 +1287,19 @@ async function handleCliOnly(command: string, args: string[]) {
         const { runEvalCommand } = await import('./commands/eval.ts');
         await runEvalCommand(engine, args);
         break;
+      }
+      case 'bench': {
+        // v0.41.1 wave shipped bench-publish.ts + docs/eval-bench.md + CHANGELOG
+        // advertising `gbrain bench publish` but the cli.ts dispatcher case was
+        // never added. Mirrors the existing `case 'eval':` sub-dispatch pattern.
+        if (args[0] === 'publish') {
+          const { runBenchPublish } = await import('./commands/bench-publish.ts');
+          await runBenchPublish(args.slice(1));
+          break;
+        }
+        console.error('Usage: gbrain bench publish --from <captured.ndjson> --to <baseline.ndjson> [flags]');
+        console.error('  See docs/eval-bench.md for the full LOOP: eval export → bench publish → eval gate');
+        process.exit(2);
       }
       case 'jobs': {
         const { runJobs } = await import('./commands/jobs.ts');


### PR DESCRIPTION
## Problem

The v0.41.1 wave shipped `src/commands/bench-publish.ts` (exporting `runBenchPublish`), documented `gbrain bench publish` in [`docs/eval-bench.md`](docs/eval-bench.md), and advertised the verb in [CHANGELOG.md v0.41.1.0](CHANGELOG.md), but `src/cli.ts` was never updated with the dispatcher case.

On master @ 32f8be96 (v0.41.14.0):

```bash
$ gbrain bench publish --from /tmp/captured.ndjson --to /tmp/baseline.ndjson
Unknown command: bench
Run gbrain --help for available commands.

$ grep "command === 'bench'" src/cli.ts
# (no matches)
```

The eval-loop documented in v0.41.1 CHANGELOG (`eval export → bench publish → eval gate`) is broken end-to-end on a fresh install.

## Fix

Two surgical edits to `src/cli.ts` mirroring the existing `case 'eval':` pattern:

1. Add `'bench'` to the `CLI_ONLY` set so the dispatcher reaches the case statement instead of rejecting at the cliOps lookup
2. Add a `case 'bench':` block that sub-dispatches `publish` to `runBenchPublish` (mirrors `case 'eval':` at cli.ts:1287-1290)

14 lines added, 1 deleted.

## Verification

Applied locally + tested on a v0.41.14.0 install:

```bash
$ gbrain bench publish
Error: --from FILE is required

gbrain bench publish — write a baseline file from captured queries
[full usage text follows...]

$ gbrain bench publish --from /tmp/captured.ndjson --to /tmp/baseline.ndjson --label test
Wrote /tmp/baseline.ndjson
  Label:    test
  Rows:     17
  [...]
$ gbrain eval gate --baseline /tmp/baseline.ndjson
[runs the regression gate to completion]
```

Closes #1474.

(Filed by Mr-B-1 — same v0.40.8 → v0.41.14 upgrade audit that produced sibling issues #1452-1455, #1475.)