### PR TITLE
fix(dream): propagate --source flag to runCycle (closes #1452)

### DIFF
--- a/src/commands/dream.ts
+++ b/src/commands/dream.ts
@@ -39,6 +39,14 @@ interface DreamArgs {
   pull: boolean;
   phase: CyclePhase | null;
   dir: string | null;
+  /**
+   * v0.41.x: scope cycle marker writes to one source on multi-source brains.
+   * Doctor's `cycle_freshness` check recommends `gbrain dream --source <id>`
+   * but pre-fix the flag was silently dropped here AND in the runCycle()
+   * call below, so the cycle marker (cycle.ts:1738 gate on opts.sourceId)
+   * was never written and the warning could never be cleared. Closes #1452.
+   */
+  source: string | null;
   help: boolean;
   /** v0.21: ad-hoc transcript file path; implies --phase synthesize. */
   inputFile: string | null;
@@ -71,6 +79,9 @@ function parseArgs(args: string[]): DreamArgs {
 
   const dirIdx = args.indexOf('--dir');
   const dir = dirIdx !== -1 ? args[dirIdx + 1] : null;
+
+  const sourceIdx = args.indexOf('--source');
+  const source = sourceIdx !== -1 ? args[sourceIdx + 1] ?? null : null;
 
   const inputIdx = args.indexOf('--input');
   const inputFile = inputIdx !== -1 ? args[inputIdx + 1] ?? null : null;
@@ -116,6 +127,7 @@ function parseArgs(args: string[]): DreamArgs {
     pull: args.includes('--pull'),
     phase,
     dir,
+    source,
     help: args.includes('--help') || args.includes('-h'),
     inputFile,
     date,
@@ -283,6 +295,7 @@ export async function runDream(engine: BrainEngine | null, args: string[]): Prom
     dryRun: opts.dryRun,
     pull: opts.pull,
     phases,
+    sourceId: opts.source ?? undefined,
     synthInputFile: opts.inputFile ?? undefined,
     synthDate: opts.date ?? undefined,
     synthFrom: opts.from ?? undefined,


### PR DESCRIPTION
## Problem

`gbrain doctor` reports per-source `cycle_freshness` warnings and recommends the fix:

```
[WARN] cycle_freshness: Source 'foo' has never completed a full cycle
       (no entry in source.config->>'last_full_cycle_at').

  ACTION: Run 'gbrain dream --source <id> --dir <brain>' for each stale source
```

But following the recommendation has no effect. The warning never clears even after a full successful dream completes (32 minutes, 2478 chunks embedded, status=partial, exit 0).

`SELECT id, config->>'last_full_cycle_at' FROM sources` still returns NULL for the source.

## Root cause

Verified by reading master @ v0.41.14.0 (`32f8be96`):

`src/commands/dream.ts:36-57` `DreamArgs` interface had no `source` field:

```typescript
interface DreamArgs {
  json: boolean;
  dryRun: boolean;
  pull: boolean;
  phase: CyclePhase | null;
  dir: string | null;
  // ... no 'source' field
}
```

`src/commands/dream.ts:281-291` `runCycle` call missing `sourceId` propagation:

```typescript
const report = await runCycle(engine, {
  brainDir,
  dryRun: opts.dryRun,
  pull: opts.pull,
  phases,
  synthInputFile: opts.inputFile ?? undefined,
  // <-- no sourceId here
  // ...
});
```

`src/core/cycle.ts:1738` gates the marker write on `opts.sourceId` being truthy:

```typescript
if (opts.sourceId && engine && !dryRun &&
    (status === 'ok' || status === 'clean' || status === 'partial')) {
  await engine.updateSourceConfig(opts.sourceId, {
    last_full_cycle_at: new Date().toISOString(),
  });
}
```

With `opts.sourceId === undefined`, the gate silently skips. No warning. No write. No marker. So the warning loops forever.

`gbrain sync` accepts `--source` correctly; `gbrain dream` is the odd one out. Likely missed during the v0.38+ per-source cycle-tracking refactor.

## Fix

Four surgical edits to `src/commands/dream.ts`, all mirroring existing patterns:

1. Add `source: string | null` to `DreamArgs` interface (mirrors `dir: string | null`)
2. Parse `--source <value>` in `parseArgs` (mirrors `--dir` parsing)
3. Include `source` in the returned `DreamArgs` object
4. Pass `sourceId: opts.source ?? undefined` to `runCycle()`

13 lines added.

## Verification

Applied locally + tested on v0.41.14.0:

```bash
$ bun src/cli.ts dream --source foo --dry-run
No brain directory found. Pass --dir <path> or configure one via 'gbrain init'.
```

Pre-fix the same command would silently accept --source as garbage argv (`args.includes('--source')` returns true, `args.indexOf('--source')` would return a positive index but `parseArgs` never read it).

Post-fix:
- `--source` is parsed into `opts.source`
- threads through the returned DreamArgs
- reaches `runCycle({sourceId: opts.source ?? undefined, ...})`
- which threads to `cycle.ts:1738`'s gate
- which writes `source.config->>'last_full_cycle_at'`
- which clears the doctor warning

Closes #1452.

(Filed by Mr-B-1 — same v0.40.8 → v0.41.14 upgrade audit that produced sibling PR #1476 and issues #1452-1455, #1474, #1475.)