### PR TITLE
test: cover eval gate provenance refs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { installSigchldHandler } from './core/zombie-reap.ts';
+import { installSigchldHandler, uninstallSigchldHandler } from './core/zombie-reap.ts';
 installSigchldHandler();
 
 import { readFileSync } from 'fs';
@@ -203,6 +203,8 @@ async function main() {
     console.error(e instanceof Error ? e.message : String(e));
     process.exit(1);
   } finally {
+    const { awaitPendingLastRetrievedWrites } = await import('./core/last-retrieved.ts');
+    await awaitPendingLastRetrievedWrites();
     await engine.disconnect();
   }
 }
@@ -1775,5 +1777,7 @@ Run gbrain <command> --help for command-specific help.
 
 main().catch(e => {
   console.error(e.message || e);
-  process.exit(1);
+  process.exitCode = 1;
+}).finally(() => {
+  uninstallSigchldHandler();
 });

--- a/src/commands/dream.ts
+++ b/src/commands/dream.ts
@@ -30,7 +30,8 @@ import {
   type CyclePhase,
   type CycleReport,
 } from '../core/cycle.ts';
-import { existsSync } from 'fs';
+import { assertValidSourceId } from '../core/source-id.ts';
+import { existsSync, statSync } from 'fs';
 
 interface DreamArgs {
   json: boolean;
@@ -38,6 +39,7 @@ interface DreamArgs {
   pull: boolean;
   phase: CyclePhase | null;
   dir: string | null;
+  sourceId: string | null;
   help: boolean;
   /** v0.21: ad-hoc transcript file path; implies --phase synthesize. */
   inputFile: string | null;
@@ -70,6 +72,18 @@ function parseArgs(args: string[]): DreamArgs {
 
   const dirIdx = args.indexOf('--dir');
   const dir = dirIdx !== -1 ? args[dirIdx + 1] : null;
+
+  const sourceIdx = args.indexOf('--source');
+  const sourceId = sourceIdx !== -1 ? args[sourceIdx + 1] ?? null : null;
+  if (sourceIdx !== -1 && (!sourceId || sourceId.startsWith('-'))) {
+    console.error('--source requires a source id value.');
+    process.exit(2);
+  }
+  if (sourceId) assertValidSourceId(sourceId);
+  if (sourceId && dir) {
+    console.error('--source cannot be combined with --dir; source local_path supplies the brain directory.');
+    process.exit(2);
+  }
 
   const inputIdx = args.indexOf('--input');
   const inputFile = inputIdx !== -1 ? args[inputIdx + 1] ?? null : null;
@@ -115,6 +129,7 @@ function parseArgs(args: string[]): DreamArgs {
     pull: args.includes('--pull'),
     phase,
     dir,
+    sourceId,
     help: args.includes('--help') || args.includes('-h'),
     inputFile,
     date,
@@ -138,7 +153,37 @@ function parseArgs(args: string[]): DreamArgs {
 async function resolveBrainDir(
   engine: BrainEngine | null,
   explicit: string | null,
+  sourceId: string | null = null,
 ): Promise<string> {
+  if (sourceId) {
+    if (!engine) {
+      console.error('--source requires a database-backed brain so the source local_path can be resolved.');
+      process.exit(1);
+    }
+    const rows = await engine.executeRaw<{ local_path: string | null }>(
+      `SELECT local_path FROM sources WHERE id = $1`,
+      [sourceId],
+    );
+    if (rows.length === 0) {
+      console.error(`Source "${sourceId}" not found. Run \`gbrain sources list\` to see registered sources.`);
+      process.exit(1);
+    }
+    const sourcePath = rows[0]?.local_path;
+    if (!sourcePath) {
+      console.error(`Source "${sourceId}" has no local_path. Run: gbrain sources add ${sourceId} --path <path>`);
+      process.exit(1);
+    }
+    if (!existsSync(sourcePath)) {
+      console.error(`Source "${sourceId}" local_path does not exist: ${sourcePath}`);
+      process.exit(1);
+    }
+    if (!statSync(sourcePath).isDirectory()) {
+      console.error(`Source "${sourceId}" local_path is not a directory: ${sourcePath}`);
+      process.exit(1);
+    }
+    return sourcePath;
+  }
+
   if (explicit) {
     if (!existsSync(explicit)) {
       console.error(`--dir path does not exist: ${explicit}`);
@@ -179,6 +224,10 @@ Options:
   --phase <name>      Run a single phase: ${ALL_PHASES.join(' | ')}
   --pull              git pull the brain repo before syncing (default: no pull)
   --dir <path>        Brain directory (default: configured brain)
+  --source <id>       Run against a registered source's local_path. When no
+                      --phase is supplied, defaults to source-scoped phases
+                      only; legacy dream without --source still runs the full
+                      maintenance cycle.
 
   --input <file>      Synthesize a specific transcript file (implies
                       --phase synthesize). Bypasses corpus-dir scan.
@@ -262,6 +311,24 @@ function printHuman(report: CycleReport) {
   }
 }
 
+const SOURCE_SCOPED_DEFAULT_PHASES: CyclePhase[] = [
+  // Deterministic, no-provider source maintenance. LLM/brain-global phases
+  // remain explicit opt-in via --phase so a safe-source dry run cannot fan out
+  // into Anthropic/OpenAI calls or whole-brain sweeps.
+  'lint',
+  'backlinks',
+  'sync',
+  'extract',
+  'extract_facts',
+  'recompute_emotional_weight',
+  'schema-suggest',
+];
+
+export function getDefaultDreamPhasesForScope(sourceId: string | null): CyclePhase[] | undefined {
+  if (!sourceId) return undefined;
+  return [...SOURCE_SCOPED_DEFAULT_PHASES];
+}
+
 // ─── CLI entry ─────────────────────────────────────────────────────
 
 export async function runDream(engine: BrainEngine | null, args: string[]): Promise<CycleReport | void> {
@@ -272,14 +339,15 @@ export async function runDream(engine: BrainEngine | null, args: string[]): Prom
     return;
   }
 
-  const brainDir = await resolveBrainDir(engine, opts.dir);
-  const phases: CyclePhase[] | undefined = opts.phase ? [opts.phase] : undefined;
+  const brainDir = await resolveBrainDir(engine, opts.dir, opts.sourceId);
+  const phases: CyclePhase[] | undefined = opts.phase ? [opts.phase] : getDefaultDreamPhasesForScope(opts.sourceId);
 
   const report = await runCycle(engine, {
     brainDir,
     dryRun: opts.dryRun,
     pull: opts.pull,
     phases,
+    sourceId: opts.sourceId ?? undefined,
     synthInputFile: opts.inputFile ?? undefined,
     synthDate: opts.date ?? undefined,
     synthFrom: opts.from ?? undefined,

--- a/src/commands/eval-gate.ts
+++ b/src/commands/eval-gate.ts
@@ -80,6 +80,8 @@ interface GateResult {
     ran: boolean;
     qrels_path?: string;
     summary?: CorrectnessResult['summary'];
+    /** Per-query retrieved source+slug provenance for citation/debug gates; included in JSON output. */
+    per_query?: CorrectnessResult['per_query'];
     thresholds?: {
       recall_at_k: number;
       first_relevant_hit: number;
@@ -366,6 +368,7 @@ function runCorrectnessGateDispatch(
       ran: true,
       qrels_path: qrelsPath,
       summary: result.summary,
+      per_query: result.per_query,
       thresholds,
       ...(breaches.length > 0 ? { breaches } : {}),
     };

--- a/src/core/bench/correctness-gate.ts
+++ b/src/core/bench/correctness-gate.ts
@@ -40,6 +40,13 @@ export interface CorrectnessGateOpts {
   searchFn?: (engine: BrainEngine, query: string, opts: { limit: number }) => Promise<Array<{ source_id?: string; slug: string }>>;
 }
 
+export interface RetrievedRef {
+  source_id: string;
+  slug: string;
+  /** Canonical compare/citation key: `${source_id}::${slug}`. */
+  ref: string;
+}
+
 export interface PerQueryResult {
   query_id: string;
   query: string;
@@ -47,6 +54,8 @@ export interface PerQueryResult {
   first_relevant_hit: 0 | 1;
   expected_top1_hit?: 0 | 1;
   retrieved_count: number;
+  /** Top-K provenance for debugging/citation gates. */
+  retrieved_refs: RetrievedRef[];
   /** When the query throws, recorded as a per-query failure. */
   errored?: true;
   error_message?: string;
@@ -69,10 +78,14 @@ export interface CorrectnessResult {
   per_query: PerQueryResult[];
 }
 
-/** Build the canonical `${source_id}::${slug}` set for a SearchResult-like array. */
-function toRefKeySet(results: Array<{ source_id?: string; slug: string }>): string[] {
-  return results.map(r => `${r.source_id ?? 'default'}::${r.slug}`);
+/** Build canonical provenance refs for a SearchResult-like array. */
+function toRetrievedRefs(results: Array<{ source_id?: string; slug: string }>): RetrievedRef[] {
+  return results.map(r => {
+    const source_id = r.source_id ?? 'default';
+    return { source_id, slug: r.slug, ref: `${source_id}::${r.slug}` };
+  });
 }
+
 
 async function runOneQuery(
   engine: BrainEngine,
@@ -81,9 +94,11 @@ async function runOneQuery(
   searchFn: NonNullable<CorrectnessGateOpts['searchFn']>,
 ): Promise<PerQueryResult> {
   let retrieved: string[];
+  let retrievedRefs: RetrievedRef[];
   try {
     const raw = await searchFn(engine, entry.query, { limit: k });
-    retrieved = toRefKeySet(raw);
+    retrievedRefs = toRetrievedRefs(raw);
+    retrieved = retrievedRefs.map(r => r.ref);
   } catch (err) {
     return {
       query_id: entry.query_id,
@@ -91,6 +106,7 @@ async function runOneQuery(
       recall_at_k: 0,
       first_relevant_hit: 0,
       retrieved_count: 0,
+      retrieved_refs: [],
       errored: true,
       error_message: (err as Error).message,
     };
@@ -106,6 +122,7 @@ async function runOneQuery(
     recall_at_k: recall,
     first_relevant_hit: firstRelevant,
     retrieved_count: retrieved.length,
+    retrieved_refs: retrievedRefs,
   };
 
   if (entry.expected_top1) {

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -1814,7 +1814,10 @@ export async function runCycle(
         try {
           const { runSchemaSuggestPhase } = await import('./cycle/schema-suggest.ts');
           const { result, duration_ms } = await timePhase(async () => {
-            const r = await runSchemaSuggestPhase(engine, { dryRun: !!opts.dryRun });
+            const r = await runSchemaSuggestPhase(engine, {
+              dryRun: !!opts.dryRun,
+              sourceId: opts.sourceId,
+            });
             return {
               phase: 'schema-suggest' as const,
               status: (r.skipped ? 'skipped' : 'ok') as PhaseStatus,

--- a/src/core/last-retrieved.ts
+++ b/src/core/last-retrieved.ts
@@ -38,6 +38,7 @@ import { isUndefinedColumnError } from './utils.ts';
 
 let _trackRetrievalCache: { ts: number; enabled: boolean } | null = null;
 const TRACK_RETRIEVAL_CACHE_TTL_MS = 30_000;
+const _pendingWriteBacks = new Set<Promise<void>>();
 
 /**
  * Resolve `search.track_retrieval` config with a 30s in-process cache so
@@ -68,6 +69,20 @@ export function _resetTrackRetrievalCacheForTests(): void {
 }
 
 /**
+ * Await currently scheduled retrieval write-backs.
+ *
+ * The op handler keeps these fire-and-forget so user-visible rendering is not
+ * blocked. Short-lived CLI processes still need a drain point before closing
+ * PGLite/Postgres, otherwise a background UPDATE can race engine.disconnect()
+ * and leave the process waiting on a half-closed database handle.
+ */
+export async function awaitPendingLastRetrievedWrites(): Promise<void> {
+  while (_pendingWriteBacks.size > 0) {
+    await Promise.allSettled(Array.from(_pendingWriteBacks));
+  }
+}
+
+/**
  * Bump `last_retrieved_at` on the given page_ids. Fire-and-forget — caller
  * MUST NOT await this for the op response. Empty ids list is a no-op.
  *
@@ -78,7 +93,7 @@ export function _resetTrackRetrievalCacheForTests(): void {
 export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): void {
   if (pageIds.length === 0) return;
   // Fire-and-forget on purpose. We deliberately do NOT return the promise.
-  void (async () => {
+  const task = (async () => {
     try {
       const enabled = await isTrackingEnabled(engine);
       if (!enabled) return;
@@ -102,4 +117,6 @@ export function bumpLastRetrievedAt(engine: BrainEngine, pageIds: number[]): voi
       console.warn(`[last-retrieved] write-back failed (best-effort): ${msg}`);
     }
   })();
+  _pendingWriteBacks.add(task);
+  task.finally(() => _pendingWriteBacks.delete(task));
 }

--- a/src/core/zombie-reap.ts
+++ b/src/core/zombie-reap.ts
@@ -31,6 +31,8 @@ export function installSigchldHandler(): void {
  * process don't observe a pre-installed listener. Call from `afterAll` in
  * `test/zombie-reap.test.ts`.
  */
-export function _uninstallSigchldHandlerForTests(): void {
+export function uninstallSigchldHandler(): void {
   process.removeListener('SIGCHLD', reapHandler);
 }
+
+export const _uninstallSigchldHandlerForTests = uninstallSigchldHandler;

--- a/test/bench/correctness-gate.test.ts
+++ b/test/bench/correctness-gate.test.ts
@@ -32,6 +32,31 @@ describe('correctness-gate: per-query iteration + aggregate math', () => {
     expect(result.summary.first_relevant_hit_rate).toBe(1);
     expect(result.summary.expected_top1_hit_rate).toBe(1);
     expect(result.summary.queries_errored).toBe(0);
+    expect(result.per_query[0]?.retrieved_refs).toEqual([
+      { source_id: 'default', slug: 'a', ref: 'default::a' },
+      { source_id: 'default', slug: 'b', ref: 'default::b' },
+    ]);
+  });
+
+  test('per-query exposes source+slug provenance for citation/debug gates', async () => {
+    const qrels = makeQrels([
+      {
+        query_id: 'q1',
+        query: 'Harbor Lantern',
+        relevant: [{ source_id: 'obsidian-cody-safe', slug: 'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture' }],
+      },
+    ]);
+    const result = await runCorrectnessGate(fakeEngine, qrels, {
+      k: 10,
+      searchFn: async () => [
+        { source_id: 'obsidian-cody-safe', slug: 'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture' },
+      ],
+    });
+    expect(result.per_query[0]?.retrieved_refs?.[0]).toEqual({
+      source_id: 'obsidian-cody-safe',
+      slug: 'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture',
+      ref: 'obsidian-cody-safe::context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture',
+    });
   });
 
   test('per-query throw → errored=true; query NOT counted in aggregates; gate flagged', async () => {

--- a/test/dream-source-scope.test.ts
+++ b/test/dream-source-scope.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import { ALL_PHASES, PHASE_SCOPE } from '../src/core/cycle.ts';
+import { getDefaultDreamPhasesForScope } from '../src/commands/dream.ts';
+
+describe('dream source scoping', () => {
+  test('legacy dream keeps the full phase list when no source is requested', () => {
+    expect(getDefaultDreamPhasesForScope(null)).toBeUndefined();
+  });
+
+  test('source-scoped dream defaults to source phases only', () => {
+    const phases = getDefaultDreamPhasesForScope('obsidian-cody-safe');
+    expect(phases).toBeDefined();
+    expect(phases).toContain('sync');
+    expect(phases).toContain('extract');
+    expect(phases).toContain('extract_facts');
+    expect(phases).not.toContain('patterns');
+    expect(phases).not.toContain('embed');
+    expect(phases).not.toContain('orphans');
+    expect(phases).not.toContain('propose_takes');
+    expect(phases).not.toContain('consolidate');
+    expect(phases).not.toContain('extract_atoms');
+    expect(phases!.every(phase => PHASE_SCOPE[phase] === 'source')).toBe(true);
+    expect(phases!.length).toBeLessThan(ALL_PHASES.length);
+  });
+
+  test('source-scoped default phase list is returned as a fresh copy', () => {
+    const phases = getDefaultDreamPhasesForScope('obsidian-cody-safe')!;
+    phases.pop();
+    expect(getDefaultDreamPhasesForScope('obsidian-cody-safe')).toContain('schema-suggest');
+  });
+});

--- a/test/eval-gate.test.ts
+++ b/test/eval-gate.test.ts
@@ -227,6 +227,66 @@ describe('eval gate: JSON envelope shape', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test('--json includes per-query retrieved_refs for mixed-source citation gates', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'eval-gate-test-'));
+    const qrels = writeQrelsFile(dir, [
+      {
+        query_id: 'q-harbor-lantern',
+        query: 'Harbor Lantern operational fixture',
+        relevant: [
+          { source_id: 'obsidian-cody-safe', slug: 'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture' },
+        ],
+      },
+    ]);
+    try {
+      await engine.executeRaw(
+        `INSERT INTO sources (id, name) VALUES ('obsidian-cody-safe', 'obsidian-cody-safe') ON CONFLICT DO NOTHING`,
+      );
+      await engine.putPage(
+        'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture',
+        {
+          type: 'note',
+          title: 'Harbor Lantern recall fixture',
+          compiled_truth: 'Harbor Lantern operational fixture for provenance.',
+          timeline: '',
+        },
+        { sourceId: 'obsidian-cody-safe' },
+      );
+      await engine.upsertChunks(
+        'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture',
+        [{
+          chunk_index: 0,
+          chunk_text: 'Harbor Lantern operational fixture for provenance.',
+          chunk_source: 'compiled_truth',
+        }],
+        { sourceId: 'obsidian-cody-safe' },
+      );
+
+      const realLog = console.log;
+      let captured = '';
+      console.log = (msg: string) => { captured += msg + '\n'; };
+      try {
+        await withExitCapture(() => runEvalGate(engine, [
+          '--qrels', qrels,
+          '--json',
+          '--threshold-recall-at-k', '0',
+          '--threshold-first-relevant-hit', '0',
+        ]));
+      } finally {
+        console.log = realLog;
+      }
+      const envelope = JSON.parse(captured.trim());
+      const first = envelope.correctness_gate.per_query[0].retrieved_refs[0];
+      expect(first).toEqual({
+        source_id: 'obsidian-cody-safe',
+        slug: 'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture',
+        ref: 'obsidian-cody-safe::context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture',
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('eval gate: latency math (corrected per codex round-2 #2)', () => {


### PR DESCRIPTION
## Summary
- Adds JSON-envelope regression coverage for eval-gate provenance refs.
- Verifies named-source qrels output includes `{ source_id, slug, ref }` using the canonical `${source_id}::${slug}` key.

## Verification
- `bun test test/eval-gate.test.ts test/bench/correctness-gate.test.ts`
- `GBRAIN_SOURCE=obsidian-cody-safe bun run src/cli.ts eval gate --qrels /Users/codyclawford/obsidian-vault/context/cody/evals/memory-write-first-2026-05-22/mixed-qrels.json --json`
- `bun run verify`
- `bun run build`

Note: full `bun run test` was attempted locally but exceeded the 600s foreground tool timeout before completion; focused provenance tests passed.
