### PR TITLE
test: cover eval gate provenance refs

### DIFF
--- a/src/commands/eval-gate.ts
+++ b/src/commands/eval-gate.ts
@@ -80,6 +80,8 @@ interface GateResult {
     ran: boolean;
     qrels_path?: string;
     summary?: CorrectnessResult['summary'];
+    /** Per-query retrieved source+slug provenance for citation/debug gates; included in JSON output. */
+    per_query?: CorrectnessResult['per_query'];
     thresholds?: {
       recall_at_k: number;
       first_relevant_hit: number;
@@ -366,6 +368,7 @@ function runCorrectnessGateDispatch(
       ran: true,
       qrels_path: qrelsPath,
       summary: result.summary,
+      per_query: result.per_query,
       thresholds,
       ...(breaches.length > 0 ? { breaches } : {}),
     };

--- a/src/core/bench/correctness-gate.ts
+++ b/src/core/bench/correctness-gate.ts
@@ -40,6 +40,13 @@ export interface CorrectnessGateOpts {
   searchFn?: (engine: BrainEngine, query: string, opts: { limit: number }) => Promise<Array<{ source_id?: string; slug: string }>>;
 }
 
+export interface RetrievedRef {
+  source_id: string;
+  slug: string;
+  /** Canonical compare/citation key: `${source_id}::${slug}`. */
+  ref: string;
+}
+
 export interface PerQueryResult {
   query_id: string;
   query: string;
@@ -47,6 +54,8 @@ export interface PerQueryResult {
   first_relevant_hit: 0 | 1;
   expected_top1_hit?: 0 | 1;
   retrieved_count: number;
+  /** Top-K provenance for debugging/citation gates. */
+  retrieved_refs: RetrievedRef[];
   /** When the query throws, recorded as a per-query failure. */
   errored?: true;
   error_message?: string;
@@ -69,10 +78,14 @@ export interface CorrectnessResult {
   per_query: PerQueryResult[];
 }
 
-/** Build the canonical `${source_id}::${slug}` set for a SearchResult-like array. */
-function toRefKeySet(results: Array<{ source_id?: string; slug: string }>): string[] {
-  return results.map(r => `${r.source_id ?? 'default'}::${r.slug}`);
+/** Build canonical provenance refs for a SearchResult-like array. */
+function toRetrievedRefs(results: Array<{ source_id?: string; slug: string }>): RetrievedRef[] {
+  return results.map(r => {
+    const source_id = r.source_id ?? 'default';
+    return { source_id, slug: r.slug, ref: `${source_id}::${r.slug}` };
+  });
 }
+
 
 async function runOneQuery(
   engine: BrainEngine,
@@ -81,9 +94,11 @@ async function runOneQuery(
   searchFn: NonNullable<CorrectnessGateOpts['searchFn']>,
 ): Promise<PerQueryResult> {
   let retrieved: string[];
+  let retrievedRefs: RetrievedRef[];
   try {
     const raw = await searchFn(engine, entry.query, { limit: k });
-    retrieved = toRefKeySet(raw);
+    retrievedRefs = toRetrievedRefs(raw);
+    retrieved = retrievedRefs.map(r => r.ref);
   } catch (err) {
     return {
       query_id: entry.query_id,
@@ -91,6 +106,7 @@ async function runOneQuery(
       recall_at_k: 0,
       first_relevant_hit: 0,
       retrieved_count: 0,
+      retrieved_refs: [],
       errored: true,
       error_message: (err as Error).message,
     };
@@ -106,6 +122,7 @@ async function runOneQuery(
     recall_at_k: recall,
     first_relevant_hit: firstRelevant,
     retrieved_count: retrieved.length,
+    retrieved_refs: retrievedRefs,
   };
 
   if (entry.expected_top1) {

--- a/test/bench/correctness-gate.test.ts
+++ b/test/bench/correctness-gate.test.ts
@@ -89,9 +89,10 @@ describe('correctness-gate: per-query iteration + aggregate math', () => {
     expect(result.summary.queries_errored).toBe(1);
     // Aggregate computed on non-errored only.
     expect(result.summary.mean_recall_at_k).toBe(1);
-    // Errored query surfaced in per_query list with error_message.
+    // Errored query surfaced in per_query list with error_message and stable refs shape.
     const errored = result.per_query.find(p => p.errored);
     expect(errored?.error_message).toMatch(/timeout/);
+    expect(errored?.retrieved_refs).toEqual([]);
   });
 
   test('missing brain page (slug not in retrieved) counted as miss', async () => {

--- a/test/bench/correctness-gate.test.ts
+++ b/test/bench/correctness-gate.test.ts
@@ -32,6 +32,31 @@ describe('correctness-gate: per-query iteration + aggregate math', () => {
     expect(result.summary.first_relevant_hit_rate).toBe(1);
     expect(result.summary.expected_top1_hit_rate).toBe(1);
     expect(result.summary.queries_errored).toBe(0);
+    expect(result.per_query[0]?.retrieved_refs).toEqual([
+      { source_id: 'default', slug: 'a', ref: 'default::a' },
+      { source_id: 'default', slug: 'b', ref: 'default::b' },
+    ]);
+  });
+
+  test('per-query exposes source+slug provenance for citation/debug gates', async () => {
+    const qrels = makeQrels([
+      {
+        query_id: 'q1',
+        query: 'Harbor Lantern',
+        relevant: [{ source_id: 'obsidian-cody-safe', slug: 'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture' }],
+      },
+    ]);
+    const result = await runCorrectnessGate(fakeEngine, qrels, {
+      k: 10,
+      searchFn: async () => [
+        { source_id: 'obsidian-cody-safe', slug: 'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture' },
+      ],
+    });
+    expect(result.per_query[0]?.retrieved_refs?.[0]).toEqual({
+      source_id: 'obsidian-cody-safe',
+      slug: 'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture',
+      ref: 'obsidian-cody-safe::context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture',
+    });
   });
 
   test('per-query throw → errored=true; query NOT counted in aggregates; gate flagged', async () => {

--- a/test/eval-gate.test.ts
+++ b/test/eval-gate.test.ts
@@ -227,6 +227,66 @@ describe('eval gate: JSON envelope shape', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test('--json includes per-query retrieved_refs for mixed-source citation gates', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'eval-gate-test-'));
+    const qrels = writeQrelsFile(dir, [
+      {
+        query_id: 'q-harbor-lantern',
+        query: 'Harbor Lantern operational fixture',
+        relevant: [
+          { source_id: 'obsidian-cody-safe', slug: 'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture' },
+        ],
+      },
+    ]);
+    try {
+      await engine.executeRaw(
+        `INSERT INTO sources (id, name) VALUES ('obsidian-cody-safe', 'obsidian-cody-safe') ON CONFLICT DO NOTHING`,
+      );
+      await engine.putPage(
+        'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture',
+        {
+          type: 'note',
+          title: 'Harbor Lantern recall fixture',
+          compiled_truth: 'Harbor Lantern operational fixture for provenance.',
+          timeline: '',
+        },
+        { sourceId: 'obsidian-cody-safe' },
+      );
+      await engine.upsertChunks(
+        'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture',
+        [{
+          chunk_index: 0,
+          chunk_text: 'Harbor Lantern operational fixture for provenance.',
+          chunk_source: 'compiled_truth',
+        }],
+        { sourceId: 'obsidian-cody-safe' },
+      );
+
+      const realLog = console.log;
+      let captured = '';
+      console.log = (msg: string) => { captured += msg + '\n'; };
+      try {
+        await withExitCapture(() => runEvalGate(engine, [
+          '--qrels', qrels,
+          '--json',
+          '--threshold-recall-at-k', '0',
+          '--threshold-first-relevant-hit', '0',
+        ]));
+      } finally {
+        console.log = realLog;
+      }
+      const envelope = JSON.parse(captured.trim());
+      const first = envelope.correctness_gate.per_query[0].retrieved_refs[0];
+      expect(first).toEqual({
+        source_id: 'obsidian-cody-safe',
+        slug: 'context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture',
+        ref: 'obsidian-cody-safe::context/cody/evals/gbrain-write-first-2026-05-25/recall-fixture',
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('eval gate: latency math (corrected per codex round-2 #2)', () => {


### PR DESCRIPTION
## Summary
- Adds source provenance refs to eval gate/correctness gate output.
- Covers provenance refs in focused unit tests, including the error-path `retrieved_refs: []` shape.
- Keeps this branch limited to qrels provenance reporting only.

## Verification
- `bun test test/eval-gate.test.ts test/bench/correctness-gate.test.ts` → 18 pass / 0 fail, 42 assertions
- `GBRAIN_SOURCE=obsidian-cody-safe bun run src/cli.ts eval gate --qrels /Users/codyclawford/obsidian-vault/context/cody/evals/gbrain-write-first-2026-05-25/qrels.json --threshold-recall-at-k 1 --threshold-first-relevant-hit 1 --threshold-expected-top1 1 --json` → pass, 5/5 queries, recall@10 1.0, first relevant hit 1.0, expected top-1 1.0
- `GBRAIN_SOURCE=obsidian-cody-safe bun run src/cli.ts eval gate --qrels /Users/codyclawford/obsidian-vault/context/cody/evals/memory-write-first-2026-05-22/mixed-qrels.json --threshold-recall-at-k 0.75 --threshold-first-relevant-hit 0.75 --json` → pass, 8/8 queries, mean recall@10 0.8354166667, first relevant hit 0.875
- Live provenance invariant: no qrels query returned empty `retrieved_refs`
- Claude Code read-only review: APPROVE

Replaces closed dirty PR #1480 with a clean focused head.
