### PR TITLE
fix(salience): exclude soft-deleted pages from getRecentSalience

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4612,7 +4612,8 @@ export class PGLiteEngine implements BrainEngine {
                 AS score
          FROM pages p
          LEFT JOIN takes t ON t.page_id = p.id AND t.active = TRUE
-        WHERE GREATEST(p.updated_at, COALESCE(p.salience_touched_at, p.updated_at)) >= $1::timestamptz
+        WHERE p.deleted_at IS NULL
+          AND GREATEST(p.updated_at, COALESCE(p.salience_touched_at, p.updated_at)) >= $1::timestamptz
           ${prefixCondition}
         GROUP BY p.id
         ORDER BY score DESC

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4554,7 +4554,8 @@ export class PostgresEngine implements BrainEngine {
                AS score
         FROM pages p
         LEFT JOIN takes t ON t.page_id = p.id AND t.active = TRUE
-       WHERE GREATEST(p.updated_at, COALESCE(p.salience_touched_at, p.updated_at)) >= ${boundaryIso}::timestamptz
+       WHERE p.deleted_at IS NULL
+         AND GREATEST(p.updated_at, COALESCE(p.salience_touched_at, p.updated_at)) >= ${boundaryIso}::timestamptz
          ${prefixCondition}
        GROUP BY p.id
        ORDER BY score DESC


### PR DESCRIPTION
## What

`getRecentSalience()` returns rows where `deleted_at IS NOT NULL` because the `WHERE` clause only filters by `updated_at + salience_touched_at + slug prefix`.

## Reproduce

```bash
gbrain capture "test page content" --slug reports/test-salience-bug
gbrain delete reports/test-salience-bug
gbrain salience --days 90 --limit 10
```

The deleted page still appears in the salience ranking even though it's been soft-deleted.

## Why this matters

The 72-hour recovery window means a deleted page can keep appearing in `salience` output for three days, where the user is actively trying to identify "what's been meaningful lately" (the documented purpose of the command). Soft-deleted pages should not weight an active-state ranking — that's effectively the contract every other read path is already enforcing.

## Fix

Add `p.deleted_at IS NULL` to the `WHERE` clause in both `PostgresEngine.getRecentSalience()` and `PGLiteEngine.getRecentSalience()`.

This matches the existing pattern in 19 other query call sites in `postgres-engine.ts` (e.g. `getPage`, `listPages`, `searchKeyword`, `findOrphans`, `traverseGraph` — all already gate on `deleted_at IS NULL`).

## Verification

After patch on a brain with one soft-deleted page in the window:

Before:
```
1   0.989   ...   技能库/hermes-gbrain-诊断与修复经验
2   0.987   ...   技能库/第二大脑设计原则与决策
3   0.964   ...   概念/gbrain-vault-index
4   0.928   ...   reports/2026-05-26-hermes-gbrain-maintenance-pm  ← soft-deleted
5   0.924   ...   技术文档/创业者手册构建-ai-原生创业公司
```

After:
```
1   0.975   ...   技能库/hermes-gbrain-诊断与修复经验
2   0.973   ...   技能库/第二大脑设计原则与决策
3   0.951   ...   概念/gbrain-vault-index
4   0.912   ...   技术文档/创业者手册构建-ai-原生创业公司    ← shifted up
```

## Notes

- No new option exposed; this is a defense-in-depth fix matching the rest of the codebase.
- If a future caller wants to surface deleted pages (parallel to `list_pages --include-deleted`), a separate `include_deleted` flag could be added — but that's out of scope here.
- I considered also touching `findAnomalies` (right below in the same file) but its query semantics differ (counting page activity per cohort rather than ranking pages), so leaving as a follow-up if anyone confirms the desired behavior there.

## Environment where caught

- gbrain `0.41.14.0`
- Postgres engine, vault size ~1400 pages.
