### PR TITLE
fix: use jsonSchema() wrapper and 'parameters' key for AI SDK tool definitions

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -21,7 +21,7 @@
  *     rotation (via configureGateway()) invalidates stale entries.
  */
 
-import { embed as aiEmbed, embedMany, generateObject, generateText } from 'ai';
+import { embed as aiEmbed, embedMany, generateObject, generateText, jsonSchema } from 'ai';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { listRecipes } from './recipes/index.ts';
 import { createOpenAI } from '@ai-sdk/openai';
@@ -2357,7 +2357,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
   const tools = (opts.tools ?? []).reduce((acc, t) => {
     acc[t.name] = {
       description: t.description,
-      inputSchema: { jsonSchema: t.inputSchema } as any,
+      parameters: jsonSchema(t.inputSchema),
     };
     return acc;
   }, {} as Record<string, any>);


### PR DESCRIPTION
## Summary

Fixes #1487 - the gateway chat() function passes tool schemas in a format incompatible with the Vercel AI SDK for non-Anthropic providers.

## Problem

When agent.use_gateway_loop=true, the subagent handler routes through gateway.toolLoop(), which calls gateway.chat(). The chat() function passes tool schemas as { inputSchema: { jsonSchema: rawObject } } to generateText(). The AI SDK expects { parameters: jsonSchema(rawObject) } where jsonSchema is imported from the ai package.

This causes all non-Anthropic subagent tool loops to fail with: [chat(deepseek:...)] schema is not a function

## Changes

2 lines changed in src/core/ai/gateway.ts. Import jsonSchema from ai, and use parameters: jsonSchema(t.inputSchema) instead of inputSchema: { jsonSchema: t.inputSchema }.

## Testing

Tested with DeepSeek v4 Flash as the subagent model. The Anthropic-direct path is unaffected.

## Affected versions

All releases with agent.use_gateway_loop support (v0.38+ through current HEAD).