### PR TITLE
Fix providers test base URL override

### DIFF
--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -151,6 +151,8 @@ async function runTest(args: string[]): Promise<void> {
     process.exit(1);
   }
 
+  let cfg: ReturnType<typeof loadConfig> | undefined;
+
   // If --model passed, override gateway for this test (touchpoint-aware).
   if (modelArg) {
     const [providerId, ...modelParts] = modelArg.split(':');
@@ -164,7 +166,7 @@ async function runTest(args: string[]): Promise<void> {
     // doesn't repeat the bug-reporter's "providers test ✓ but import still
     // broken" trap.
     try {
-      const cfg = loadConfig();
+      cfg = loadConfig();
       const configuredModel = tpArg === 'embedding' ? cfg?.embedding_model : cfg?.chat_model;
       if (!configuredModel) {
         console.error(
@@ -185,11 +187,13 @@ async function runTest(args: string[]): Promise<void> {
       configureGateway({
         embedding_model: modelArg,
         embedding_dimensions: dims,
+        base_urls: cfg?.provider_base_urls,
         env: { ...process.env },
       });
     } else {
       configureGateway({
         chat_model: modelArg,
+        base_urls: cfg?.provider_base_urls,
         env: { ...process.env },
       });
     }

--- a/test/providers-cli-base-url.serial.test.ts
+++ b/test/providers-cli-base-url.serial.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression coverage for `gbrain providers test --model`.
+ *
+ * The command intentionally overrides the active model for an isolated smoke
+ * test, but it must still honor file-plane provider_base_urls. Otherwise China
+ * DashScope users get a false "incorrect API key" from the international
+ * endpoint even though their configured regional endpoint works.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+async function runProvidersTest(gbrainHome: string, baseUrl: string): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
+  mkdirSync(join(gbrainHome, '.gbrain'), { recursive: true });
+  writeFileSync(
+    join(gbrainHome, '.gbrain', 'config.json'),
+    JSON.stringify({
+      engine: 'pglite',
+      database_path: join(gbrainHome, '.gbrain', 'brain.pglite'),
+      embedding_model: 'openai:text-embedding-3-small',
+      embedding_dimensions: 1024,
+      provider_base_urls: {
+        dashscope: baseUrl,
+      },
+    }),
+  );
+
+  const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', 'providers', 'test', '--touchpoint', 'embedding', '--model', 'dashscope:text-embedding-v4'], {
+    cwd: new URL('..', import.meta.url).pathname,
+    env: {
+      ...process.env,
+      GBRAIN_HOME: gbrainHome,
+      DASHSCOPE_API_KEY: 'sk-test',
+      OPENAI_API_KEY: undefined,
+      DATABASE_URL: undefined,
+      GBRAIN_DATABASE_URL: undefined,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { exitCode, stdout, stderr };
+}
+
+describe('providers test --model base URL routing', () => {
+  test('honors provider_base_urls when probing an isolated embedding model', async () => {
+    const gbrainHome = mkdtempSync(join(tmpdir(), 'gbrain-providers-cli-'));
+    const seenUrls: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        seenUrls.push(req.url);
+        return Response.json({
+          data: [{ embedding: Array.from({ length: 1024 }, () => 0) }],
+          model: 'text-embedding-v4',
+        });
+      },
+    });
+
+    try {
+      const result = await runProvidersTest(gbrainHome, server.url.href.replace(/\/$/, ''));
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('1024 dims');
+      expect(result.stderr).toContain('tested dashscope:text-embedding-v4 in isolation');
+      expect(seenUrls).toEqual([`${server.url.href.replace(/\/$/, '')}/embeddings`]);
+    } finally {
+      server.stop(true);
+      rmSync(gbrainHome, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve configured `provider_base_urls` when `gbrain providers test --model ...` reconfigures the gateway for an isolated provider smoke test.
- Add a hermetic CLI regression test that proves the isolated DashScope model probe uses the configured base URL instead of the recipe default.

## Why
China-region DashScope users configure `provider_base_urls.dashscope` to use `https://dashscope.aliyuncs.com/compatible-mode/v1`. Before this change, passing `--model dashscope:text-embedding-v4` discarded that override and silently fell back to the international endpoint, producing a misleading `Incorrect API key` error even when the key was valid for the configured regional endpoint.

## Verification
- `bun test test/providers-cli-base-url.serial.test.ts`
- `bun test test/providers.test.ts test/ai/recipe-dashscope.test.ts`
- `gbrain providers test --touchpoint embedding --model dashscope:text-embedding-v4`
