### PR TITLE
fix(embedding-dim-check): honor user_provided_models recipes (llama-server, litellm-proxy)

### DIFF
--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -449,6 +449,14 @@ function isCustomDimValidForProvider(
     };
   }
 
+  // user_provided_models recipes (llama-server, litellm-proxy) declare
+  // default_dims=0 because the dim is whatever model the user launched.
+  // The Tier 3 reject below would block them; honor the recipe's intent.
+  const embTp = (recipe.touchpoints as { embedding?: { user_provided_models?: boolean } } | undefined)?.embedding;
+  if (embTp?.user_provided_models === true) {
+    return { valid: true, error: '' };
+  }
+
   // Tier 3: provider not known to support custom dims at all.
   return {
     valid: false,

--- a/test/embedding-dim-check.test.ts
+++ b/test/embedding-dim-check.test.ts
@@ -220,6 +220,42 @@ describe('resolveSchemaEmbeddingDim', () => {
     if (got.ok) expect(got.dim).toBe(768);
   });
 
+  // user_provided_models recipes (llama-server, litellm-proxy) ship
+  // default_dims=0 by design — the dim is whatever model the user launched
+  // llama-server with. The Tier-3 reject in isCustomDimValidForProvider
+  // was firing on these because 0 != requested, so users could never init
+  // a brain pointed at a local Qwen3-Embedding / nomic-embed / etc.
+  test('llama-server user_provided_models accepts arbitrary dim (1024 for Qwen3-Embedding-0.6B)', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:qwen3-embed',
+      embedding_dimensions: 1024,
+    });
+    expect(got.ok).toBe(true);
+    if (got.ok) {
+      expect(got.dim).toBe(1024);
+      expect(got.provider).toBe('llama-server');
+      expect(got.model).toBe('llama-server:qwen3-embed');
+    }
+  });
+
+  test('llama-server user_provided_models accepts a different dim (4096 for Qwen3-Embedding-8B)', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:qwen3-embed-8b',
+      embedding_dimensions: 4096,
+    });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(4096);
+  });
+
+  test('litellm-proxy user_provided_models accepts arbitrary dim', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'litellm:custom-model',
+      embedding_dimensions: 1024,
+    });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(1024);
+  });
+
   test('unknown provider rejected with provider list hint', () => {
     const got = resolveSchemaEmbeddingDim({ embedding_model: 'notarealprovider:foo' });
     expect(got.ok).toBe(false);


### PR DESCRIPTION
## Summary

`gbrain init --pglite --embedding-model llama-server:<id> --embedding-dimensions <N>` currently fails with:

> Refusing to init: Provider "llama-server" model "..." does not support custom dimensions N (this model only emits its default vector size). Either drop --embedding-dimensions or pick a Matryoshka-aware model.

The same hard-refuse hits `litellm:<id>`. Every local llama.cpp / LiteLLM-proxy install is blocked from initializing.

## Root cause

`src/core/ai/recipes/llama-server.ts` and `litellm-proxy.ts` declare:

```ts
touchpoints: {
  embedding: {
    models: [],
    user_provided_models: true,   // "user owns model id"
    default_dims: 0,               // "user owns dim"
  },
}
```

But `src/core/embedding-dim-check.ts:isCustomDimValidForProvider` never reads `user_provided_models`. Its three-tier validation chain:

1. recipe-declared `dims_options` — `llama-server` declares none ➜ skip
2. provider-specific allow-lists (`openai` / `voyage` / `zeroentropyai`) — `recipe.id` doesn't match ➜ skip
3. fall through to "this model only emits its default vector size" reject

So any `requestedDims != 0` triggers Tier-3 reject. And dropping `--embedding-dimensions` doesn't help either — `default_dims=0` gets rejected one branch up by the `dim > 0` check at line 369.

The recipe author and the dim-check author had opposite intents:

- `llama-server.ts:43` setup_hint: *"Build llama.cpp, then `llama-server --model <gguf-path> --embeddings`. Set --embedding-model llama-server:<id> + --embedding-dimensions <N>."*
- `embedding-dim-check.ts:458` error: *"Either drop --embedding-dimensions or pick a Matryoshka-aware model."*

The setup hint tells you to pass `--embedding-dimensions`. The dim-check tells you not to. Both can't be right.

## Fix

Short-circuit Tier 3 when the recipe's embedding touchpoint declares `user_provided_models: true`. The recipe author already said "user owns the dim" — honor that. 4 lines:

```ts
const embTp = (recipe.touchpoints as { embedding?: { user_provided_models?: boolean } } | undefined)?.embedding;
if (embTp?.user_provided_models === true) {
  return { valid: true, error: '' };
}
```

Placed AFTER the existing Tier-2 provider-specific allow-lists so OpenAI / Voyage / ZE recipes (which DON'T set `user_provided_models`) still get their tight Matryoshka validation.

## Test plan

- [x] `bun test test/embedding-dim-check.test.ts` — 29 pass / 0 fail (existing 26 + 3 new regression cases)
- [x] `bun run typecheck` — clean
- [x] Smoke-test: `gbrain init --pglite --embedding-model llama-server:qwen3-embed --embedding-dimensions 1024` now succeeds against a real `llama-server` process on :8080

New cases in `test/embedding-dim-check.test.ts` cover the real-world scenarios this unblocks:

- `llama-server:qwen3-embed` @ 1024 dims (Qwen3-Embedding-0.6B native, what motivated this PR)
- `llama-server:qwen3-embed-8b` @ 4096 dims (Qwen3-Embedding-8B native)
- `litellm:custom-model` @ 1024 dims (proves the fix isn't llama-server-specific)

## Motivation

Setting up a local-only gbrain with Qwen3-Embedding + Qwen3-Reranker via llama.cpp on a 16GB M4 — no API spend, no cloud calls. The `llama-server-reranker.ts` recipe note at L:32 explicitly mentions Qwen3-Reranker as a target use case, and `llama-server.ts` exists for exactly this kind of deployment. The Tier-3 reject just made the embedding side unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)