### PR TITLE
feat: server-enforced memory groups (v93)

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -552,15 +552,33 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   app.get('/admin/api/agents', requireAdmin, async (_req: Request, res: Response) => {
     try {
       // Unified view: OAuth clients + legacy API keys
-      const oauthClients = await sql`
-        SELECT c.client_id as id, c.client_name as name, 'oauth' as auth_type,
-          c.grant_types, c.scope, c.created_at, c.token_ttl,
-          CASE WHEN c.deleted_at IS NOT NULL THEN 'revoked' ELSE 'active' END as status,
-          (SELECT max(created_at) FROM mcp_request_log WHERE token_name = c.client_id) as last_used_at,
-          (SELECT count(*)::int FROM mcp_request_log WHERE token_name = c.client_id) as total_requests,
-          (SELECT count(*)::int FROM mcp_request_log WHERE token_name = c.client_id AND created_at > now() - interval '24 hours') as requests_today
-        FROM oauth_clients c ORDER BY c.created_at DESC
-      `;
+      let oauthClients: Record<string, unknown>[];
+      try {
+        oauthClients = await sql`
+          SELECT c.client_id as id, c.client_name as name, 'oauth' as auth_type,
+            c.grant_types, c.scope, c.created_at, c.token_ttl,
+            CASE WHEN c.deleted_at IS NOT NULL THEN 'revoked' ELSE 'active' END as status,
+            m.group_id as memory_group_id,
+            g.name as memory_group_name,
+            (SELECT max(created_at) FROM mcp_request_log WHERE token_name = c.client_id) as last_used_at,
+            (SELECT count(*)::int FROM mcp_request_log WHERE token_name = c.client_id) as total_requests,
+            (SELECT count(*)::int FROM mcp_request_log WHERE token_name = c.client_id AND created_at > now() - interval '24 hours') as requests_today
+          FROM oauth_clients c
+          LEFT JOIN oauth_client_memory_groups m ON m.client_id = c.client_id
+          LEFT JOIN memory_groups g ON g.id = m.group_id
+          ORDER BY c.created_at DESC
+        `;
+      } catch {
+        oauthClients = await sql`
+          SELECT c.client_id as id, c.client_name as name, 'oauth' as auth_type,
+            c.grant_types, c.scope, c.created_at, c.token_ttl,
+            CASE WHEN c.deleted_at IS NOT NULL THEN 'revoked' ELSE 'active' END as status,
+            (SELECT max(created_at) FROM mcp_request_log WHERE token_name = c.client_id) as last_used_at,
+            (SELECT count(*)::int FROM mcp_request_log WHERE token_name = c.client_id) as total_requests,
+            (SELECT count(*)::int FROM mcp_request_log WHERE token_name = c.client_id AND created_at > now() - interval '24 hours') as requests_today
+          FROM oauth_clients c ORDER BY c.created_at DESC
+        `;
+      }
       const legacyKeys = await sql`
         SELECT a.id, a.name, 'api_key' as auth_type,
           '{"bearer"}' as grant_types, 'read write admin' as scope, a.created_at, null as token_ttl,
@@ -712,12 +730,117 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   });
 
   // Register client from admin dashboard
+  app.get('/admin/api/memory-groups', requireAdmin, async (_req: Request, res: Response) => {
+    try {
+      const { listMemoryGroups } = await import('../core/memory-groups.ts');
+      const groups = await listMemoryGroups(sql);
+      res.json(groups);
+    } catch (e) {
+      res.status(503).json({ error: e instanceof Error ? e.message : 'service_unavailable' });
+    }
+  });
+
+  app.post('/admin/api/memory-groups', requireAdmin, express.json(), async (req: Request, res: Response) => {
+    try {
+      const { createMemoryGroup } = await import('../core/memory-groups.ts');
+      const { randomUUID } = await import('crypto');
+      const body = req.body ?? {};
+      if (!body.name) { res.status(400).json({ error: 'name required' }); return; }
+      const group = await createMemoryGroup(sql, `mg_${randomUUID().replace(/-/g, '').slice(0, 12)}`, {
+        name: body.name,
+        description: body.description,
+        readAudiences: body.readAudiences ?? body.read_audiences ?? [],
+        writeAudiences: body.writeAudiences ?? body.write_audiences ?? [],
+        readSlugPrefixes: body.readSlugPrefixes ?? body.read_slug_prefixes ?? [],
+        writeSlugPrefixes: body.writeSlugPrefixes ?? body.write_slug_prefixes ?? [],
+        deniedAudiences: body.deniedAudiences ?? body.denied_audiences ?? [],
+        bypassPolicy: body.bypassPolicy === true || body.bypass_policy === true,
+      });
+      res.json(group);
+    } catch (e) {
+      res.status(500).json({ error: e instanceof Error ? e.message : 'Failed to create group' });
+    }
+  });
+
+  app.put('/admin/api/memory-groups/:id', requireAdmin, express.json(), async (req: Request, res: Response) => {
+    try {
+      const { updateMemoryGroup } = await import('../core/memory-groups.ts');
+      const id = req.params.id;
+      const body = req.body ?? {};
+      if (!body.name) { res.status(400).json({ error: 'name required' }); return; }
+      const group = await updateMemoryGroup(sql, id, {
+        name: body.name,
+        description: body.description,
+        readAudiences: body.readAudiences ?? body.read_audiences ?? [],
+        writeAudiences: body.writeAudiences ?? body.write_audiences ?? [],
+        readSlugPrefixes: body.readSlugPrefixes ?? body.read_slug_prefixes ?? [],
+        writeSlugPrefixes: body.writeSlugPrefixes ?? body.write_slug_prefixes ?? [],
+        deniedAudiences: body.deniedAudiences ?? body.denied_audiences ?? [],
+        bypassPolicy: body.bypassPolicy === true || body.bypass_policy === true,
+      });
+      if (!group) { res.status(404).json({ error: 'Group not found' }); return; }
+      res.json(group);
+    } catch (e) {
+      res.status(500).json({ error: e instanceof Error ? e.message : 'Failed to update group' });
+    }
+  });
+
+  app.delete('/admin/api/memory-groups/:id', requireAdmin, async (req: Request, res: Response) => {
+    try {
+      const { deleteMemoryGroup } = await import('../core/memory-groups.ts');
+      const result = await deleteMemoryGroup(sql, req.params.id);
+      if (!result.deleted) {
+        res.status(409).json({ error: result.reason ?? 'cannot_delete' });
+        return;
+      }
+      res.json({ deleted: true });
+    } catch (e) {
+      res.status(500).json({ error: e instanceof Error ? e.message : 'Failed to delete group' });
+    }
+  });
+
+  app.put('/admin/api/agents/:clientId/group', requireAdmin, express.json(), async (req: Request, res: Response) => {
+    try {
+      const { assignClientToMemoryGroup, getMemoryGroupById } = await import('../core/memory-groups.ts');
+      const clientId = req.params.clientId;
+      const groupId = req.body?.groupId ?? req.body?.group_id;
+      if (!groupId) { res.status(400).json({ error: 'groupId required' }); return; }
+      const group = await getMemoryGroupById(sql, groupId);
+      if (!group) { res.status(404).json({ error: 'Group not found' }); return; }
+      await assignClientToMemoryGroup(sql, clientId, groupId);
+      res.json({ clientId, groupId, memory_group_name: group.name });
+    } catch (e) {
+      res.status(500).json({ error: e instanceof Error ? e.message : 'Failed to assign group' });
+    }
+  });
+
+  app.put('/admin/api/agents/:clientId/name', requireAdmin, express.json(), async (req: Request, res: Response) => {
+    try {
+      const clientId = req.params.clientId;
+      const raw = req.body?.name ?? req.body?.client_name;
+      const name = typeof raw === 'string' ? raw.trim() : '';
+      if (!name) { res.status(400).json({ error: 'name required' }); return; }
+      if (name.length > 200) { res.status(400).json({ error: 'name too long (max 200)' }); return; }
+      const rows = await sql`
+        UPDATE oauth_clients
+        SET client_name = ${name}
+        WHERE client_id = ${clientId} AND deleted_at IS NULL
+        RETURNING client_id, client_name
+      `;
+      if (!rows.length) { res.status(404).json({ error: 'Client not found' }); return; }
+      res.json({ clientId: rows[0].client_id, name: rows[0].client_name });
+    } catch (e) {
+      res.status(500).json({ error: e instanceof Error ? e.message : 'Failed to rename client' });
+    }
+  });
+
   app.post('/admin/api/register-client', requireAdmin, express.json(), async (req: Request, res: Response) => {
     try {
-      const { name, scopes, tokenTtl } = req.body;
+      const { name, scopes, tokenTtl, memoryGroupName, memory_group_name } = req.body;
       if (!name) { res.status(400).json({ error: 'Name required' }); return; }
       const result = await oauthProvider.registerClientManual(
-        name, ['client_credentials'], scopes || 'read', [],
+        name, ['client_credentials'], scopes || 'read', [], 'default', undefined,
+        memoryGroupName ?? memory_group_name,
       );
       // Set per-client TTL if specified
       if (tokenTtl && Number(tokenTtl) > 0) {

--- a/src/core/memory-groups-migrate.ts
+++ b/src/core/memory-groups-migrate.ts
@@ -1,0 +1,96 @@
+/**
+ * Migration-time seed/backfill using BrainEngine.executeRaw (no tagged sql).
+ */
+
+import type { BrainEngine } from './engine.ts';
+import { DEFAULT_GROUP_IDS } from './memory-groups.ts';
+
+const SEED_GROUPS: Array<{
+  id: string;
+  name: string;
+  description: string;
+  read: string[];
+  write: string[];
+  bypass: boolean;
+}> = [
+  {
+    id: DEFAULT_GROUP_IDS.admin,
+    name: 'Admin',
+    description: 'Full access for portal and operators',
+    read: ['*'],
+    write: ['*'],
+    bypass: true,
+  },
+  {
+    id: DEFAULT_GROUP_IDS.coding,
+    name: 'Coding',
+    description: 'Coding agents and dev workspaces',
+    read: ['coding', 'project:*', 'public', 'research'],
+    write: ['coding', 'project:*', 'public', 'research'],
+    bypass: false,
+  },
+  {
+    id: DEFAULT_GROUP_IDS.management,
+    name: 'Management',
+    description: 'Manager agents with broad read/write',
+    read: ['*'],
+    write: ['personal', 'work', 'coding', 'research', 'public', 'project:*'],
+    bypass: false,
+  },
+  {
+    id: DEFAULT_GROUP_IDS.personal,
+    name: 'Personal',
+    description: 'Private personal context only',
+    read: ['personal', 'public'],
+    write: ['personal', 'public'],
+    bypass: false,
+  },
+];
+
+export async function seedAndBackfillMemoryGroups(engine: BrainEngine): Promise<void> {
+  for (const g of SEED_GROUPS) {
+    await engine.executeRaw(
+      `INSERT INTO memory_groups (
+        id, name, description, read_audiences, write_audiences,
+        read_slug_prefixes, write_slug_prefixes, denied_audiences, bypass_policy
+      ) VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, $6)
+      ON CONFLICT (id) DO NOTHING`,
+      [
+        g.id,
+        g.name,
+        g.description,
+        JSON.stringify(g.read),
+        JSON.stringify(g.write),
+        g.bypass,
+      ],
+    );
+  }
+
+  const clients = await engine.executeRaw<{ client_id: string; client_name: string; scope: string }>(
+    `SELECT client_id, client_name, scope FROM oauth_clients WHERE deleted_at IS NULL`,
+  );
+
+  for (const row of clients) {
+    const existing = await engine.executeRaw(
+      `SELECT 1 FROM oauth_client_memory_groups WHERE client_id = $1`,
+      [row.client_id],
+    );
+    if (existing.length) continue;
+
+    let groupId = DEFAULT_GROUP_IDS.coding;
+    const scope = String(row.scope ?? '');
+    const name = row.client_name ?? '';
+    if (scope.includes('admin') || /memory-portal/i.test(name)) {
+      groupId = DEFAULT_GROUP_IDS.admin;
+    } else if (/personal/i.test(name) || name.includes('-cursor-personal')) {
+      groupId = DEFAULT_GROUP_IDS.personal;
+    } else if (/management|manager/i.test(name)) {
+      groupId = DEFAULT_GROUP_IDS.management;
+    }
+
+    await engine.executeRaw(
+      `INSERT INTO oauth_client_memory_groups (client_id, group_id) VALUES ($1, $2)`,
+      [row.client_id, groupId],
+    );
+  }
+}

--- a/src/core/memory-groups.ts
+++ b/src/core/memory-groups.ts
@@ -1,0 +1,306 @@
+/**
+ * Memory groups persistence and admin helpers (v0.35 memory ACL).
+ */
+
+import type { SqlQuery } from './sql-query.ts';
+import type { MemoryGroupPolicy } from './memory-policy.ts';
+
+export const DEFAULT_GROUP_IDS = {
+  admin: 'mg_admin',
+  coding: 'mg_coding',
+  management: 'mg_management',
+  personal: 'mg_personal',
+} as const;
+
+export interface MemoryGroupRow {
+  id: string;
+  name: string;
+  description: string | null;
+  read_audiences: string[];
+  write_audiences: string[];
+  read_slug_prefixes: string[];
+  write_slug_prefixes: string[];
+  denied_audiences: string[];
+  bypass_policy: boolean;
+  created_at: string;
+  client_count?: number;
+}
+
+function parseJsonArray(val: unknown): string[] {
+  if (Array.isArray(val)) return val.map(String);
+  if (typeof val === 'string') {
+    try {
+      const parsed = JSON.parse(val);
+      return Array.isArray(parsed) ? parsed.map(String) : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+export function rowToPolicy(row: MemoryGroupRow): MemoryGroupPolicy {
+  return {
+    id: row.id,
+    name: row.name,
+    readAudiences: parseJsonArray(row.read_audiences),
+    writeAudiences: parseJsonArray(row.write_audiences),
+    readSlugPrefixes: parseJsonArray(row.read_slug_prefixes),
+    writeSlugPrefixes: parseJsonArray(row.write_slug_prefixes),
+    deniedAudiences: parseJsonArray(row.denied_audiences),
+    bypassPolicy: Boolean(row.bypass_policy),
+  };
+}
+
+export function isMemoryGroupsSchemaMissing(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /memory_groups|oauth_client_memory_groups|relation.*does not exist/i.test(msg);
+}
+
+export async function loadMemoryGroupForClient(
+  sql: SqlQuery,
+  clientId: string,
+): Promise<MemoryGroupPolicy | null | undefined> {
+  try {
+    const rows = await sql`
+      SELECT g.id, g.name, g.description,
+             g.read_audiences, g.write_audiences,
+             g.read_slug_prefixes, g.write_slug_prefixes,
+             g.denied_audiences, g.bypass_policy, g.created_at
+      FROM oauth_client_memory_groups m
+      JOIN memory_groups g ON g.id = m.group_id
+      WHERE m.client_id = ${clientId}
+      LIMIT 1
+    `;
+    if (!rows.length) return null;
+    return rowToPolicy(rows[0] as MemoryGroupRow);
+  } catch (err) {
+    if (isMemoryGroupsSchemaMissing(err)) return undefined;
+    throw err;
+  }
+}
+
+export async function listMemoryGroups(sql: SqlQuery): Promise<MemoryGroupRow[]> {
+  const rows = await sql`
+    SELECT g.id, g.name, g.description,
+           g.read_audiences, g.write_audiences,
+           g.read_slug_prefixes, g.write_slug_prefixes,
+           g.denied_audiences, g.bypass_policy, g.created_at,
+           (SELECT count(*)::int FROM oauth_client_memory_groups m WHERE m.group_id = g.id) as client_count
+    FROM memory_groups g
+    ORDER BY g.name
+  `;
+  return rows as MemoryGroupRow[];
+}
+
+export async function getMemoryGroupById(sql: SqlQuery, id: string): Promise<MemoryGroupRow | null> {
+  const rows = await sql`
+    SELECT g.id, g.name, g.description,
+           g.read_audiences, g.write_audiences,
+           g.read_slug_prefixes, g.write_slug_prefixes,
+           g.denied_audiences, g.bypass_policy, g.created_at
+    FROM memory_groups g WHERE g.id = ${id}
+  `;
+  return rows.length ? (rows[0] as MemoryGroupRow) : null;
+}
+
+export async function getMemoryGroupByName(sql: SqlQuery, name: string): Promise<MemoryGroupRow | null> {
+  const rows = await sql`
+    SELECT g.id, g.name, g.description,
+           g.read_audiences, g.write_audiences,
+           g.read_slug_prefixes, g.write_slug_prefixes,
+           g.denied_audiences, g.bypass_policy, g.created_at
+    FROM memory_groups g WHERE g.name = ${name}
+  `;
+  return rows.length ? (rows[0] as MemoryGroupRow) : null;
+}
+
+export interface UpsertMemoryGroupInput {
+  name: string;
+  description?: string;
+  readAudiences: string[];
+  writeAudiences: string[];
+  readSlugPrefixes?: string[];
+  writeSlugPrefixes?: string[];
+  deniedAudiences?: string[];
+  bypassPolicy?: boolean;
+}
+
+export async function createMemoryGroup(
+  sql: SqlQuery,
+  id: string,
+  input: UpsertMemoryGroupInput,
+): Promise<MemoryGroupRow> {
+  await sql`
+    INSERT INTO memory_groups (
+      id, name, description, read_audiences, write_audiences,
+      read_slug_prefixes, write_slug_prefixes, denied_audiences, bypass_policy
+    ) VALUES (
+      ${id}, ${input.name}, ${input.description ?? null},
+      ${JSON.stringify(input.readAudiences)},
+      ${JSON.stringify(input.writeAudiences)},
+      ${JSON.stringify(input.readSlugPrefixes ?? [])},
+      ${JSON.stringify(input.writeSlugPrefixes ?? [])},
+      ${JSON.stringify(input.deniedAudiences ?? [])},
+      ${input.bypassPolicy === true}
+    )
+  `;
+  const row = await getMemoryGroupById(sql, id);
+  if (!row) throw new Error('Failed to create memory group');
+  return row;
+}
+
+export async function updateMemoryGroup(
+  sql: SqlQuery,
+  id: string,
+  input: UpsertMemoryGroupInput,
+): Promise<MemoryGroupRow | null> {
+  await sql`
+    UPDATE memory_groups SET
+      name = ${input.name},
+      description = ${input.description ?? null},
+      read_audiences = ${JSON.stringify(input.readAudiences)},
+      write_audiences = ${JSON.stringify(input.writeAudiences)},
+      read_slug_prefixes = ${JSON.stringify(input.readSlugPrefixes ?? [])},
+      write_slug_prefixes = ${JSON.stringify(input.writeSlugPrefixes ?? [])},
+      denied_audiences = ${JSON.stringify(input.deniedAudiences ?? [])},
+      bypass_policy = ${input.bypassPolicy === true}
+    WHERE id = ${id}
+  `;
+  return getMemoryGroupById(sql, id);
+}
+
+export async function deleteMemoryGroup(sql: SqlQuery, id: string): Promise<{ deleted: boolean; reason?: string }> {
+  const [count] = await sql`
+    SELECT count(*)::int as n FROM oauth_client_memory_groups WHERE group_id = ${id}
+  `;
+  if ((count as { n: number }).n > 0) {
+    return { deleted: false, reason: 'clients_assigned' };
+  }
+  await sql`DELETE FROM memory_groups WHERE id = ${id}`;
+  return { deleted: true };
+}
+
+export async function assignClientToMemoryGroup(
+  sql: SqlQuery,
+  clientId: string,
+  groupId: string,
+): Promise<void> {
+  await sql`
+    INSERT INTO oauth_client_memory_groups (client_id, group_id)
+    VALUES (${clientId}, ${groupId})
+    ON CONFLICT (client_id) DO UPDATE SET group_id = ${groupId}
+  `;
+}
+
+export async function seedDefaultMemoryGroups(sql: SqlQuery): Promise<void> {
+  const defaults: Array<{ id: string; input: UpsertMemoryGroupInput }> = [
+    {
+      id: DEFAULT_GROUP_IDS.admin,
+      input: {
+        name: 'Admin',
+        description: 'Full access for portal and operators',
+        readAudiences: ['*'],
+        writeAudiences: ['*'],
+        bypassPolicy: true,
+      },
+    },
+    {
+      id: DEFAULT_GROUP_IDS.coding,
+      input: {
+        name: 'Coding',
+        description: 'Coding agents and dev workspaces',
+        readAudiences: ['coding', 'project:*', 'public', 'research'],
+        writeAudiences: ['coding', 'project:*', 'public', 'research'],
+      },
+    },
+    {
+      id: DEFAULT_GROUP_IDS.management,
+      input: {
+        name: 'Management',
+        description: 'Manager agents with broad read/write',
+        readAudiences: ['*'],
+        writeAudiences: ['personal', 'work', 'coding', 'research', 'public', 'project:*'],
+      },
+    },
+    {
+      id: DEFAULT_GROUP_IDS.personal,
+      input: {
+        name: 'Personal',
+        description: 'Private personal context only',
+        readAudiences: ['personal', 'public'],
+        writeAudiences: ['personal', 'public'],
+      },
+    },
+  ];
+
+  for (const { id, input } of defaults) {
+    const existing = await getMemoryGroupById(sql, id);
+    if (!existing) {
+      await createMemoryGroup(sql, id, input);
+    }
+  }
+}
+
+export function inferGroupIdFromClientName(name: string): string | null {
+  if (/memory-portal|admin/i.test(name)) return DEFAULT_GROUP_IDS.admin;
+  if (/-cursor-personal|personal/i.test(name)) return DEFAULT_GROUP_IDS.personal;
+  if (/management|manager/i.test(name)) return DEFAULT_GROUP_IDS.management;
+  if (/-cursor-coding|coding/i.test(name)) return DEFAULT_GROUP_IDS.coding;
+  if (/-forgetmenot-cursor/.test(name)) return DEFAULT_GROUP_IDS.coding;
+  return null;
+}
+
+export async function tryAutoAssignClientGroup(
+  sql: SqlQuery,
+  clientId: string,
+  clientName: string,
+): Promise<void> {
+  try {
+    const groupId = inferGroupIdFromClientName(clientName);
+    if (!groupId) return;
+    const existing = await sql`
+      SELECT 1 FROM oauth_client_memory_groups WHERE client_id = ${clientId}
+    `;
+    if (existing.length) return;
+    await assignClientToMemoryGroup(sql, clientId, groupId);
+  } catch (err) {
+    if (isMemoryGroupsSchemaMissing(err)) return;
+    throw err;
+  }
+}
+
+export async function backfillClientMemoryGroups(sql: SqlQuery): Promise<number> {
+  const clients = await sql`
+    SELECT client_id, client_name, scope
+    FROM oauth_clients
+    WHERE deleted_at IS NULL
+  `;
+  let assigned = 0;
+  for (const row of clients) {
+    const clientId = row.client_id as string;
+    const name = (row.client_name as string) ?? '';
+    const scope = String(row.scope ?? '');
+    const existing = await sql`
+      SELECT 1 FROM oauth_client_memory_groups WHERE client_id = ${clientId}
+    `;
+    if (existing.length) continue;
+
+    let groupId = DEFAULT_GROUP_IDS.coding;
+    if (
+      scope.includes('admin')
+      || /memory-portal/i.test(name)
+      || name.endsWith('-admin')
+    ) {
+      groupId = DEFAULT_GROUP_IDS.admin;
+    } else if (/personal/i.test(name) || name.includes('-cursor-personal')) {
+      groupId = DEFAULT_GROUP_IDS.personal;
+    } else if (/management|manager/i.test(name)) {
+      groupId = DEFAULT_GROUP_IDS.management;
+    }
+
+    await assignClientToMemoryGroup(sql, clientId, groupId);
+    assigned++;
+  }
+  return assigned;
+}

--- a/src/core/memory-policy.ts
+++ b/src/core/memory-policy.ts
@@ -1,0 +1,104 @@
+/**
+ * Memory group audience policy — server-side enforcement for page access.
+ *
+ * Pages declare `audience: [coding, project:gbrain]` in YAML frontmatter
+ * (stored in pages.frontmatter JSONB). Groups declare which audiences they
+ * may read/write. Unassigned OAuth clients are denied reads (fail closed).
+ */
+
+export interface MemoryGroupPolicy {
+  id: string;
+  name: string;
+  readAudiences: string[];
+  writeAudiences: string[];
+  readSlugPrefixes: string[];
+  writeSlugPrefixes: string[];
+  deniedAudiences: string[];
+  bypassPolicy: boolean;
+}
+
+/** Default when frontmatter has no audience field. */
+export const DEFAULT_PAGE_AUDIENCES = ['public'] as const;
+
+export function normalizePageAudiences(frontmatter: Record<string, unknown> | undefined | null): string[] {
+  if (!frontmatter || typeof frontmatter !== 'object') {
+    return [...DEFAULT_PAGE_AUDIENCES];
+  }
+  const raw = frontmatter.audience;
+  if (raw == null) return [...DEFAULT_PAGE_AUDIENCES];
+  if (Array.isArray(raw)) {
+    const list = raw.map((v) => String(v).trim()).filter(Boolean);
+    return list.length ? list : [...DEFAULT_PAGE_AUDIENCES];
+  }
+  if (typeof raw === 'string' && raw.trim()) {
+    return [raw.trim()];
+  }
+  return [...DEFAULT_PAGE_AUDIENCES];
+}
+
+/** Match policy pattern against a single page audience tag (supports `*` and `project:*`). */
+export function audiencePatternMatches(pattern: string, pageAudience: string): boolean {
+  if (pattern === '*') return true;
+  if (pattern.endsWith(':*')) {
+    const prefix = pattern.slice(0, -2);
+    return pageAudience === prefix || pageAudience.startsWith(`${prefix}:`);
+  }
+  return pattern === pageAudience;
+}
+
+export function audiencesAllowed(policyAudiences: string[], pageAudiences: string[]): boolean {
+  if (policyAudiences.some((p) => p === '*')) return true;
+  for (const pattern of policyAudiences) {
+    for (const pageAud of pageAudiences) {
+      if (audiencePatternMatches(pattern, pageAud)) return true;
+    }
+  }
+  return false;
+}
+
+export function slugMatchesPrefixes(slug: string, prefixes: string[]): boolean {
+  if (!prefixes.length) return true;
+  return prefixes.some((p) => slug === p || slug.startsWith(p.endsWith('/') ? p : `${p}/`) || slug.startsWith(p));
+}
+
+export function canReadPage(
+  group: MemoryGroupPolicy | null | undefined,
+  pageAudiences: string[],
+  slug: string,
+): boolean {
+  if (!group) return false;
+  if (group.bypassPolicy) return true;
+  if (group.deniedAudiences.length && audiencesAllowed(group.deniedAudiences, pageAudiences)) {
+    return false;
+  }
+  if (!audiencesAllowed(group.readAudiences, pageAudiences)) return false;
+  return slugMatchesPrefixes(slug, group.readSlugPrefixes);
+}
+
+export function canWritePage(
+  group: MemoryGroupPolicy | null | undefined,
+  pageAudiences: string[],
+  slug: string,
+): boolean {
+  if (!group) return false;
+  if (group.bypassPolicy) return true;
+  if (group.deniedAudiences.length && audiencesAllowed(group.deniedAudiences, pageAudiences)) {
+    return false;
+  }
+  if (!audiencesAllowed(group.writeAudiences, pageAudiences)) return false;
+  return slugMatchesPrefixes(slug, group.writeSlugPrefixes);
+}
+
+export function parseAudiencesFromMarkdown(content: string): string[] {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return [...DEFAULT_PAGE_AUDIENCES];
+  const block = match[1];
+  const line = block.split(/\r?\n/).find((l) => /^audience:\s*\[/.test(l));
+  if (!line) return [...DEFAULT_PAGE_AUDIENCES];
+  const inner = line.replace(/^audience:\s*\[|\]\s*$/g, '');
+  const tags = inner
+    .split(',')
+    .map((t) => t.trim().replace(/^['"]|['"]$/g, ''))
+    .filter(Boolean);
+  return tags.length ? tags : [...DEFAULT_PAGE_AUDIENCES];
+}

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -3210,6 +3210,38 @@ export const MIGRATIONS: Migration[] = [
       }
     },
   },
+  {
+    version: 93,
+    name: 'memory_groups_v0_35',
+    idempotent: true,
+    sql: `
+      CREATE TABLE IF NOT EXISTS memory_groups (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        description TEXT,
+        read_audiences JSONB NOT NULL DEFAULT '[]',
+        write_audiences JSONB NOT NULL DEFAULT '[]',
+        read_slug_prefixes JSONB NOT NULL DEFAULT '[]',
+        write_slug_prefixes JSONB NOT NULL DEFAULT '[]',
+        denied_audiences JSONB NOT NULL DEFAULT '[]',
+        bypass_policy BOOLEAN NOT NULL DEFAULT false,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+
+      CREATE TABLE IF NOT EXISTS oauth_client_memory_groups (
+        client_id TEXT PRIMARY KEY REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
+        group_id TEXT NOT NULL REFERENCES memory_groups(id) ON DELETE RESTRICT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_oauth_client_memory_groups_group
+        ON oauth_client_memory_groups(group_id);
+    `,
+    handler: async (engine) => {
+      const { seedAndBackfillMemoryGroups } = await import('./memory-groups-migrate.ts');
+      await seedAndBackfillMemoryGroups(engine);
+      console.log('  [93] Seeded memory groups and backfilled OAuth client assignments');
+    },
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -266,6 +266,10 @@ class GBrainClientsStore implements OAuthRegisteredClientsStore {
       client_id_issued_at: now,
     };
     if (clientSecret) response.client_secret = clientSecret;
+
+    const { tryAutoAssignClientGroup } = await import('./memory-groups.ts');
+    await tryAutoAssignClientGroup(this.sql, clientId, client.client_name || 'unnamed');
+
     return response;
   }
 }
@@ -549,6 +553,8 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
       const allowedSources = Array.isArray(federatedRaw)
         ? (federatedRaw as string[])
         : undefined;
+      const { loadMemoryGroupForClient } = await import('./memory-groups.ts');
+      const memoryGroup = await loadMemoryGroupForClient(this.sql, row.client_id as string);
       return {
         token,
         clientId: row.client_id as string,
@@ -564,6 +570,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
         // operations.ts prefers this array over scalar sourceId when set
         // and non-empty.
         allowedSources,
+        memoryGroup,
       } as AuthInfo;
     }
 
@@ -587,6 +594,16 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
         clientName: name,
         scopes: ['read', 'write', 'admin'],
         expiresAt: Math.floor(Date.now() / 1000) + 365 * 24 * 3600, // Legacy tokens never expire — set 1yr future
+        memoryGroup: {
+          id: 'legacy',
+          name: 'Legacy',
+          readAudiences: ['*'],
+          writeAudiences: ['*'],
+          readSlugPrefixes: [],
+          writeSlugPrefixes: [],
+          deniedAudiences: [],
+          bypassPolicy: true,
+        },
         // v0.34.1 (#861, D13): legacy bearer tokens default to 'default'
         // source — matches the pre-v0.34 effective behavior where the
         // serve-http transport fell back to GBRAIN_SOURCE/'default' for
@@ -713,6 +730,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     redirectUris: string[] = [],
     sourceId: string = 'default',
     federatedRead?: string[],
+    memoryGroupName?: string,
   ): Promise<{ clientId: string; clientSecret: string }> {
     // v0.28: ALLOWED_SCOPES allowlist. Reject `--scopes "read flying-unicorn"`
     // at registration so meaningless scope strings can't pile up in the DB.
@@ -774,6 +792,30 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
       } else {
         throw err;
       }
+    }
+
+    try {
+      const {
+        getMemoryGroupByName,
+        assignClientToMemoryGroup,
+        DEFAULT_GROUP_IDS,
+        tryAutoAssignClientGroup,
+      } = await import('./memory-groups.ts');
+      if (memoryGroupName) {
+        const group = await getMemoryGroupByName(this.sql, memoryGroupName);
+        if (group) {
+          await assignClientToMemoryGroup(this.sql, clientId, group.id);
+        } else if (memoryGroupName === 'Admin') {
+          await assignClientToMemoryGroup(this.sql, clientId, DEFAULT_GROUP_IDS.admin);
+        } else if (memoryGroupName === 'Coding') {
+          await assignClientToMemoryGroup(this.sql, clientId, DEFAULT_GROUP_IDS.coding);
+        }
+      } else {
+        await tryAutoAssignClientGroup(this.sql, clientId, name);
+      }
+    } catch (err) {
+      const { isMemoryGroupsSchemaMissing } = await import('./memory-groups.ts');
+      if (!isMemoryGroupsSchemaMissing(err)) throw err;
     }
 
     return { clientId, clientSecret };

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -36,6 +36,13 @@ import {
   CODE_DEF_DESCRIPTION,
   CODE_REFS_DESCRIPTION,
 } from './operations-descriptions.ts';
+import {
+  canReadPage,
+  canWritePage,
+  normalizePageAudiences,
+  parseAudiencesFromMarkdown,
+  type MemoryGroupPolicy,
+} from './memory-policy.ts';
 
 // --- Types ---
 
@@ -263,6 +270,13 @@ export interface AuthInfo {
    * case (back-compat).
    */
   allowedSources?: string[];
+  /**
+   * v0.35 memory ACL: audience policy for this OAuth client.
+   * - undefined: schema not migrated yet — skip enforcement (backward compat)
+   * - null: client has no group assignment — deny reads (fail closed)
+   * - object: enforce read/write audience rules
+   */
+  memoryGroup?: import('./memory-policy.ts').MemoryGroupPolicy | null;
 }
 
 export interface OperationContext {
@@ -405,6 +419,47 @@ export interface OperationContext {
  * Helper rather than inline so every read-side handler routes through the
  * same precedence ladder — drift between sites is the bug class.
  */
+
+/** Resolve memory group for enforcement. Local CLI bypasses; undefined schema bypasses. */
+function memoryGroupForCtx(ctx: OperationContext): MemoryGroupPolicy | null | undefined {
+  if (ctx.remote === false) return undefined;
+  return ctx.auth?.memoryGroup;
+}
+
+function assertMemoryRead(
+  ctx: OperationContext,
+  slug: string,
+  frontmatter: Record<string, unknown> | undefined | null,
+): void {
+  const group = memoryGroupForCtx(ctx);
+  if (group === undefined) return;
+  const audiences = normalizePageAudiences(frontmatter ?? undefined);
+  if (!canReadPage(group, audiences, slug)) {
+    const name = group?.name ?? 'unassigned';
+    throw new OperationError(
+      'permission_denied',
+      `Memory group "${name}" cannot read this page (audiences: ${audiences.join(', ')})`,
+    );
+  }
+}
+
+function assertMemoryWrite(
+  ctx: OperationContext,
+  slug: string,
+  content: string,
+): void {
+  const group = memoryGroupForCtx(ctx);
+  if (group === undefined) return;
+  const audiences = parseAudiencesFromMarkdown(content);
+  if (!canWritePage(group, audiences, slug)) {
+    const name = group?.name ?? 'unassigned';
+    throw new OperationError(
+      'permission_denied',
+      `Memory group "${name}" cannot write this page (audiences: ${audiences.join(', ')})`,
+    );
+  }
+}
+
 export function sourceScopeOpts(ctx: OperationContext): { sourceId?: string; sourceIds?: string[] } {
   const allowed = ctx.auth?.allowedSources;
   // Treat an empty `allowedSources: []` as "no federated read scope" — the
@@ -479,6 +534,8 @@ const get_page: Operation = {
     if (!page) {
       throw new OperationError('page_not_found', `Page not found: ${slug}`, includeDeleted ? 'Check the slug or use fuzzy: true' : 'Page may be soft-deleted; pass include_deleted: true to verify');
     }
+
+    assertMemoryRead(ctx, page.slug, page.frontmatter);
 
     const tags = await ctx.engine.getTags(page.slug, sourceOpts);
     // Privacy boundary for the per-token allow-list (v0.28.6 for takes,
@@ -566,6 +623,9 @@ const put_page: Operation = {
     }
 
     if (ctx.dryRun) return { dry_run: true, action: 'put_page', slug: p.slug };
+
+    assertMemoryWrite(ctx, slug, p.content as string);
+
     // Skip embedding when the AI gateway has no embedding provider configured.
     // Checks all auth env vars for the resolved provider, not just OPENAI_API_KEY,
     // so Gemini / Ollama / Voyage brains don't silently drop embeddings (Codex C2).
@@ -905,9 +965,23 @@ const delete_page: Operation = {
   handler: async (ctx, p) => {
     const slug = p.slug as string;
     if (ctx.dryRun) return { dry_run: true, action: 'soft_delete_page', slug };
+    const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
+    const existingForPolicy = await ctx.engine.getPage(slug, { includeDeleted: true, ...sourceOpts });
+    if (existingForPolicy) {
+      assertMemoryRead(ctx, slug, existingForPolicy.frontmatter);
+      const group = memoryGroupForCtx(ctx);
+      if (group !== undefined) {
+        const aud = normalizePageAudiences(existingForPolicy.frontmatter);
+        if (!canWritePage(group, aud, slug)) {
+          throw new OperationError(
+            'permission_denied',
+            `Memory group "${group?.name ?? 'unassigned'}" cannot delete this page`,
+          );
+        }
+      }
+    }
     // v0.31.8 (D7): thread ctx.sourceId so multi-source brains soft-delete the
     // intended row instead of always targeting (default, slug).
-    const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
     // v0.26.5: rewired from hard-delete to soft-delete. The hard-delete primitive
     // (engine.deletePage) is now reserved for purgeDeletedPages and explicit
     // tests. softDeletePage returns null when the slug is unknown OR already
@@ -1011,17 +1085,23 @@ const list_pages: Operation = {
     const pages = await ctx.engine.listPages({
       type: p.type as any,
       tag: p.tag as string,
-      limit: clampSearchLimit(p.limit as number | undefined, 50, 100),
+      limit: clampSearchLimit(p.limit as number | undefined, 50, 200),
       includeDeleted: (p.include_deleted as boolean) === true,
       updated_after: typeof p.updated_after === 'string' ? p.updated_after : undefined,
       sort,
       ...scope,
     });
-    return pages.map(pg => ({
+    const group = memoryGroupForCtx(ctx);
+    const filtered = group === undefined
+      ? pages
+      : pages.filter((pg) => canReadPage(group, normalizePageAudiences(pg.frontmatter), pg.slug));
+    const limit = clampSearchLimit(p.limit as number | undefined, 50, 100);
+    return filtered.slice(0, limit).map(pg => ({
       slug: pg.slug,
       type: pg.type,
       title: pg.title,
       updated_at: pg.updated_at,
+      audiences: normalizePageAudiences(pg.frontmatter),
       ...(pg.deleted_at ? { deleted_at: pg.deleted_at } : {}),
     }));
   },
@@ -1045,12 +1125,24 @@ const search: Operation = {
     // v0.34.1 (#861 — P0 leak seal): thread caller's source scope into
     // searchKeyword. Pre-fix this op silently returned cross-source hits
     // for any auth'd OAuth client.
+    const scope = sourceScopeOpts(ctx);
     const raw = await ctx.engine.searchKeyword(queryText, {
       limit: (p.limit as number) || 20,
       offset: (p.offset as number) || 0,
-      ...sourceScopeOpts(ctx),
+      ...scope,
     });
-    const results = dedupResults(raw);
+    let results = dedupResults(raw);
+    const group = memoryGroupForCtx(ctx);
+    if (group !== undefined) {
+      const kept = [];
+      for (const r of results) {
+        const page = await ctx.engine.getPage(r.slug, scope);
+        if (page && canReadPage(group, normalizePageAudiences(page.frontmatter), r.slug)) {
+          kept.push(r);
+        }
+      }
+      results = kept;
+    }
     const latency_ms = Date.now() - startedAt;
 
     // Op-layer capture (v0.25.0). Fire-and-forget — no await on the
@@ -2517,12 +2609,26 @@ const whoami: Operation = {
     // at oauth-provider.ts:417-430). Detect by inspecting the prefix.
     const isOauth = ctx.auth.clientId.startsWith('gbrain_cl_');
     if (isOauth) {
+      const mg = ctx.auth.memoryGroup;
       return {
         transport: 'oauth',
         client_id: ctx.auth.clientId,
         client_name: ctx.auth.clientName ?? ctx.auth.clientId,
         scopes: ctx.auth.scopes,
         expires_at: ctx.auth.expiresAt ?? null,
+        ...(mg
+          ? {
+              memory_group: {
+                id: mg.id,
+                name: mg.name,
+                read_audiences: mg.readAudiences,
+                write_audiences: mg.writeAudiences,
+                bypass_policy: mg.bypassPolicy,
+              },
+            }
+          : mg === null
+            ? { memory_group: null, memory_group_unassigned: true }
+            : {}),
       };
     }
     return {

--- a/test/memory-policy.test.ts
+++ b/test/memory-policy.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  audiencesAllowed,
+  audiencePatternMatches,
+  canReadPage,
+  canWritePage,
+  normalizePageAudiences,
+  parseAudiencesFromMarkdown,
+  type MemoryGroupPolicy,
+} from '../src/core/memory-policy.ts';
+
+const codingGroup: MemoryGroupPolicy = {
+  id: 'mg_coding',
+  name: 'Coding',
+  readAudiences: ['coding', 'project:*', 'public'],
+  writeAudiences: ['coding', 'project:*', 'public'],
+  readSlugPrefixes: [],
+  writeSlugPrefixes: [],
+  deniedAudiences: [],
+  bypassPolicy: false,
+};
+
+const managementGroup: MemoryGroupPolicy = {
+  id: 'mg_management',
+  name: 'Management',
+  readAudiences: ['*'],
+  writeAudiences: ['personal', 'work', 'coding', 'public', 'project:*'],
+  readSlugPrefixes: [],
+  writeSlugPrefixes: [],
+  deniedAudiences: [],
+  bypassPolicy: false,
+};
+
+describe('memory-policy', () => {
+  test('normalizePageAudiences defaults to public', () => {
+    expect(normalizePageAudiences({})).toEqual(['public']);
+    expect(normalizePageAudiences(undefined)).toEqual(['public']);
+  });
+
+  test('audiencePatternMatches glob project:*', () => {
+    expect(audiencePatternMatches('project:*', 'project:gbrain')).toBe(true);
+    expect(audiencePatternMatches('project:*', 'coding')).toBe(false);
+  });
+
+  test('coding cannot read personal audience', () => {
+    expect(canReadPage(codingGroup, ['personal'], 'decision-pay')).toBe(false);
+    expect(canReadPage(managementGroup, ['personal'], 'decision-pay')).toBe(true);
+  });
+
+  test('coding can read project pages', () => {
+    expect(canReadPage(codingGroup, ['coding', 'project:gbrain'], 'project-gbrain-arch')).toBe(true);
+  });
+
+  test('unassigned group denies read', () => {
+    expect(canReadPage(null, ['public'], 'any')).toBe(false);
+  });
+
+  test('bypass policy allows all', () => {
+    const admin: MemoryGroupPolicy = { ...codingGroup, bypassPolicy: true };
+    expect(canReadPage(admin, ['personal'], 'secret')).toBe(true);
+    expect(canWritePage(admin, ['personal'], 'secret')).toBe(true);
+  });
+
+  test('parseAudiencesFromMarkdown', () => {
+    const md = `---
+title: Test
+audience: [personal, work]
+---
+body`;
+    expect(parseAudiencesFromMarkdown(md)).toEqual(['personal', 'work']);
+  });
+
+  test('audiencesAllowed with star', () => {
+    expect(audiencesAllowed(['*'], ['personal'])).toBe(true);
+  });
+});

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -1508,3 +1508,15 @@ describe('resolveSessionTimeouts — env var overrides', () => {
     expect(Object.keys(t)).toHaveLength(0);
   });
 });
+
+describe('migrate v93 — memory_groups_v0_35', () => {
+  const v93 = MIGRATIONS.find((m) => m.version === 93);
+
+  test('v93 exists with memory group tables', () => {
+    expect(v93).toBeDefined();
+    expect(v93!.name).toBe('memory_groups_v0_35');
+    expect(v93!.sql).toContain('CREATE TABLE IF NOT EXISTS memory_groups');
+    expect(v93!.sql).toContain('oauth_client_memory_groups');
+    expect(v93!.handler).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds migration v93 (memory_groups, oauth_client_memory_groups) with seeded Admin/Coding/Management/Personal groups
- Enforces audience-based read/write on get_page, list_pages, search, put_page, delete_page
- Extends whoami with memory_group metadata
- Admin API: memory groups CRUD, client→group assignment, OAuth client rename

## Test plan
- [x] Cloud deploy via local sync; migration v93 applied on forgetmenot-server
- [x] Coding client denied on audience: [personal] pages
- [x] Management client allowed read/write on personal pages
- [x] E2E matrix script validated across all group/audience combinations

Deployed and verified on a test tenant (Fly forgetmenot-server + gateway).

Made with [Cursor](https://cursor.com)