### PR TITLE
fix(gateway): preflight honors user-supplied modelId for user_provided_models recipes

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -666,11 +666,16 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   }
 
   // Openai-compat recipes with empty models list require a user-provided model.
+  // The user IS providing one when they configure embedding_model as
+  // `provider:modelId` with a non-empty modelId (e.g. `llama-server:qwen3-embed`).
+  // Only fail when modelId is missing — the recipe's empty `models` array means
+  // "user-driven", not "user hasn't picked one yet".
   const isUserProvided = (tp as any).user_provided_models === true;
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
-    (recipe.id === 'litellm' || isUserProvided)
+    (recipe.id === 'litellm' || isUserProvided) &&
+    !parsed.modelId
   ) {
     return {
       ok: false,

--- a/test/embed-preflight.test.ts
+++ b/test/embed-preflight.test.ts
@@ -149,3 +149,56 @@ describe('formatEmbeddingCredsError', () => {
     })).toBe('');
   });
 });
+
+describe('validateEmbeddingCreds — user_provided_models recipes', () => {
+  beforeEach(() => { resetGateway(); });
+
+  // Regression for the second half of the user_provided_models bug class:
+  // recipes that declare `models: []` + `user_provided_models: true` (llama-server,
+  // litellm-proxy) were rejecting EVERY init with `user_provided_model_unset`,
+  // including those where the user had clearly supplied a modelId via the
+  // `provider:modelId` string (e.g. `llama-server:qwen3-embed`). The preflight
+  // gate was reading recipe-level intent instead of looking at whether the user
+  // had actually provided a modelId.
+  test('llama-server passes preflight when user supplies modelId (llama-server:qwen3-embed)', () => {
+    configureGateway(baseConfig({
+      embedding_model: 'llama-server:qwen3-embed',
+      embedding_dimensions: 1024,
+      env: {},
+    }));
+    expect(() => validateEmbeddingCreds()).not.toThrow();
+  });
+
+  test('litellm passes preflight when user supplies modelId (litellm:custom-model)', () => {
+    configureGateway(baseConfig({
+      embedding_model: 'litellm:custom-model',
+      embedding_dimensions: 1024,
+      env: {},
+    }));
+    expect(() => validateEmbeddingCreds()).not.toThrow();
+  });
+
+  // The two cases below pin "empty modelId is still rejected" without locking
+  // the specific reason — `parseModelId` rejects `provider:` (empty modelId) at
+  // an earlier stage with `unknown_provider`, so `user_provided_model_unset` is
+  // a dead branch in practice. The `&& !parsed.modelId` guard in the fix is
+  // defense-in-depth: it expresses correct intent at the touchpoint check even
+  // if parseModelId's upstream guard would catch it first.
+  test('llama-server with empty modelId is still rejected (via earlier parseModelId guard)', () => {
+    configureGateway(baseConfig({
+      embedding_model: 'llama-server:',
+      embedding_dimensions: 1024,
+      env: {},
+    }));
+    expect(() => validateEmbeddingCreds()).toThrow(EmbeddingCredentialError);
+  });
+
+  test('litellm with empty modelId is still rejected (via earlier parseModelId guard)', () => {
+    configureGateway(baseConfig({
+      embedding_model: 'litellm:',
+      embedding_dimensions: 1024,
+      env: {},
+    }));
+    expect(() => validateEmbeddingCreds()).toThrow(EmbeddingCredentialError);
+  });
+});


### PR DESCRIPTION
## Summary

Companion to #1496 — same bug class (`user_provided_models: true` not respected), different file, distinct surface.

After landing #1496, `gbrain init --pglite --embedding-model llama-server:qwen3-embed --embedding-dimensions 1024` succeeds. But the next step (`gbrain sync` / `gbrain embed --stale`) fails immediately at the gateway preflight:

> Provider "llama-server" requires a specific model name to be configured.
>
>   Set one: gbrain config set embedding_model llama-server:\<model-name\>

…even though `embedding_model` IS already set to `llama-server:qwen3-embed`. Same dead-end for `litellm:<id>`.

## Root cause

`src/core/ai/gateway.ts:670-674` in `isAvailable('embedding')`:

```ts
const isUserProvided = (tp as any).user_provided_models === true;
if (
  Array.isArray(tp.models) &&
  tp.models.length === 0 &&
  (recipe.id === 'litellm' || isUserProvided)
) {
  return { ok: false, reason: 'user_provided_model_unset', ... };
}
```

The condition reads recipe-level intent (`models: []` + `user_provided_models: true`) but never looks at whether the user has actually supplied a modelId. For `llama-server` and `litellm-proxy`, `models: []` means "the model is whatever the user launched the server with" — NOT "the user hasn't picked one yet." If `embedding_model` is `llama-server:qwen3-embed`, `parsed.modelId` is `qwen3-embed`, and the gate should pass.

The downstream user-facing fix instruction (`Set one: gbrain config set embedding_model llama-server:<model-name>`) is exactly what the user already did, so the error message becomes a riddle.

## Fix

Add `&& !parsed.modelId` to the guard:

```ts
if (
  Array.isArray(tp.models) &&
  tp.models.length === 0 &&
  (recipe.id === 'litellm' || isUserProvided) &&
  !parsed.modelId
) {
```

`parseModelId` already rejects empty modelIds (`provider:`) at an earlier stage via `unknown_provider`, so the strengthened guard is defense-in-depth at the touchpoint check rather than load-bearing. But the pre-fix unconditional refusal blocked every legitimate local-llama-server / litellm-proxy deployment.

The companion PR #1496 patches the same bug class in `embedding-dim-check.ts` (init-time dim validation). Together, the two fixes restore the full local-llama-server flow:

```bash
gbrain init --pglite --embedding-model llama-server:qwen3-embed --embedding-dimensions 1024   # fixed by #1496
gbrain sync --repo ~/coding/personal-brain                                                    # fixed by this PR
# → 7 pages imported, 11 chunks embedded via Qwen3-Embedding-0.6B on llama-server:8080
```

## Test plan

- [x] `bun test test/embed-preflight.test.ts` — 15 pass / 0 fail (existing 11 + 4 new)
- [x] `bun run typecheck` — clean
- [x] Smoke test: `gbrain sync --repo ~/coding/personal-brain` + `gbrain embed --stale` now succeed end-to-end against Qwen3-Embedding-0.6B running on `llama-server :8080`

New cases in `test/embed-preflight.test.ts`:

| Case | Before | After |
|---|---|---|
| `llama-server:qwen3-embed`, no env | `user_provided_model_unset` (wrong) | passes (correct) |
| `litellm:custom-model`, no env | `user_provided_model_unset` (wrong) | passes (correct) |
| `llama-server:` (empty modelId) | rejected | still rejected (`unknown_provider` via parseModelId) |
| `litellm:` (empty modelId) | rejected | still rejected (same) |

The fail-loud cases use `toThrow(EmbeddingCredentialError)` rather than locking the specific `reason` field — the strengthened guard is defense-in-depth, the actual rejection path is `parseModelId`'s `unknown_provider`. Test comments document this explicitly.

## Why a separate PR

#1496 fixes init-time dim validation; this fixes sync/embed-time preflight. Same root cause class but distinct surfaces and distinct call sites. Reviewers can land them independently; tests and patches don't overlap. If only one ships, the other still has standalone value (each unblocks a different stage of the local-llama-server flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)