### PR TITLE
fix: lint phase engine.disconnect() kills worker shared DB pool

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -312,7 +312,12 @@ async function resolveLintContentSanity(): Promise<LintContentOpts['contentSanit
         database_path: base!.database_path,
       });
       try {
-        await engine.connect({});
+        // poolSize: 2 forces an instance-level pool so engine.disconnect()
+        // does NOT clobber the module-level db singleton that the worker
+        // (or any other caller sharing the process) relies on.
+        // Without this, a lint phase inside an autopilot cycle kills the
+        // worker's shared DB connection and every subsequent phase fails.
+        await engine.connect({ poolSize: 2 });
         const lifted = await loadConfigWithEngine(engine, base);
         cs = lifted?.content_sanity ?? cs;
       } finally {

--- a/src/core/retry-matcher.ts
+++ b/src/core/retry-matcher.ts
@@ -20,11 +20,13 @@ const CONN_PATTERNS = [
   /connection.*closed/i,
   /server closed the connection/i,
   /could not connect to server/i,
-  // v0.41.2.1: gbrain's own GBrainError thrown by getConnection() when
-  // the singleton pool was nulled (engine.disconnect mid-cycle, or
-  // postgres.js's auto-recovery between queries). Matches the literal
-  // message shape from PR #1416's reported batch-loss incident.
-  /No database connection/i,
+  // NOTE: gbrain's own 'No database connection' error (thrown by
+  // getConnection() when the module-level sql singleton is null) is
+  // NOT retryable — it means the pool was destroyed by an idempotent
+  // disconnect() and will not recover without an explicit reconnect().
+  // Treating it as retryable produces misleading "connection blip"
+  // log messages and wastes a 500ms retry. The root cause of pool
+  // destruction should be fixed instead (see PR for lint.ts fix).
 ];
 
 interface PgError {


### PR DESCRIPTION
## Problem

During autopilot cycle execution, the lint phase creates a second PostgresEngine and shares the module-level db.sql singleton via engine.connect({}) (no poolSize). When the phase completes, engine.disconnect() in the finally block destroys the shared pool, rendering the MinionWorker unable to operate.

Impact: All 9 sources never completed a full cycle. Brain score stuck at 51. Worker crash-loops with 51 crash records.

## Root Cause

src/commands/lint.ts:298-319 - resolveLintContentSanity(). engine.connect({}) without poolSize routes through the module-level db.sql singleton. The subsequent engine.disconnect() kills the shared pool for ALL callers in the process.

## Changes

1. lint.ts: pass poolSize: 2 so the lint engine gets its own instance-level pool
2. retry-matcher.ts: remove /No database connection/i from retryable patterns

Closes #1499