### PR TITLE
feat(embeddings): add Mistral codestral-embed recipe

### DIFF
--- a/docs/integrations/embedding-providers.md
+++ b/docs/integrations/embedding-providers.md
@@ -30,6 +30,7 @@ The resolved provider + dimensions get persisted to `~/.gbrain/config.json` atom
 | `google` | `GOOGLE_GENERATIVE_AI_API_KEY` | 768 | 0.025 | no | no |
 | `azure-openai` | `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_DEPLOYMENT` | 1536 | 0.13 | no | no |
 | `minimax` | `MINIMAX_API_KEY` | 1536 | 0.07 | no | no |
+| `mistral` | `MISTRAL_API_KEY` | 1536 | 0.15 | no | no |
 | `dashscope` | `DASHSCOPE_API_KEY` | 1024 | varies | no | no |
 | `zhipu` | `ZHIPUAI_API_KEY` | 1024 | varies | no | no |
 | `ollama` | (none — runs locally) | 768 | 0 | yes | no |

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -23,6 +23,7 @@ import { zhipu } from './zhipu.ts';
 import { azureOpenAI } from './azure-openai.ts';
 import { zeroentropyai } from './zeroentropyai.ts';
 import { llamaServerReranker } from './llama-server-reranker.ts';
+import { mistral } from './mistral.ts';
 
 const ALL: Recipe[] = [
   openai,
@@ -42,6 +43,7 @@ const ALL: Recipe[] = [
   zhipu,
   azureOpenAI,
   zeroentropyai,
+  mistral,
 ];
 
 /** Map from `provider:id` key to recipe. */

--- a/src/core/ai/recipes/mistral.ts
+++ b/src/core/ai/recipes/mistral.ts
@@ -1,0 +1,52 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * Mistral AI. OpenAI-compatible /embeddings endpoint at api.mistral.ai/v1.
+ *
+ * The flagship code embedder is `codestral-embed` (alias for the dated
+ * `codestral-embed-2505`): default 1536 dims, Matryoshka-truncatable, 8192-token
+ * context per input, code-optimized. Mistral's embeddings response is
+ * OpenAI-shaped (`data[].embedding` as number[], `usage.prompt_tokens` present),
+ * so this rides the AI SDK's standard openai-compatible adapter with NO gateway
+ * fetch shim — same path as deepseek / minimax / dashscope.
+ *
+ * Dimension caveat (why this recipe is fixed at 1536): Mistral takes
+ * `output_dimension` for non-default sizes, not OpenAI's `dimensions`. The
+ * standard adapter would send `dimensions`, which Mistral ignores, so requesting
+ * a non-default dim is a no-op without a translation shim. v1 ships the 1536
+ * default only. Flexible dims (up to 3072) + `mistral-embed` (fixed 1024) are a
+ * follow-up that adds a `mistralCompatFetch` (dimensions → output_dimension)
+ * mirroring `voyageCompatFetch` in gateway.ts.
+ *
+ * Reference: https://docs.mistral.ai/capabilities/embeddings/code_embeddings
+ */
+export const mistral: Recipe = {
+  id: 'mistral',
+  name: 'Mistral AI',
+  tier: 'openai-compat',
+  implementation: 'openai-compatible',
+  base_url_default: 'https://api.mistral.ai/v1',
+  auth_env: {
+    required: ['MISTRAL_API_KEY'],
+    setup_url: 'https://console.mistral.ai/api-keys',
+  },
+  touchpoints: {
+    embedding: {
+      models: ['codestral-embed', 'codestral-embed-2505'],
+      default_dims: 1536,
+      cost_per_1m_tokens_usd: 0.15,
+      price_last_verified: '2026-05-26',
+      // codestral-embed caps each input at 8192 tokens. Mistral publishes no
+      // hard batch-token total, so declare a conservative budget and let the
+      // gateway's recursive halving catch token-limit errors at runtime.
+      // chars_per_token=3 (code runs denser than prose's ~4) + safety 0.5 is
+      // the dense-content hedge Voyage / ZeroEntropy use.
+      max_batch_tokens: 16_384,
+      chars_per_token: 3,
+      safety_factor: 0.5,
+      supports_multimodal: false,
+    },
+  },
+  setup_hint:
+    'Get an API key at https://console.mistral.ai/api-keys, then `export MISTRAL_API_KEY=...`',
+};

--- a/src/core/embedding-pricing.ts
+++ b/src/core/embedding-pricing.ts
@@ -37,6 +37,9 @@ export const EMBEDDING_PRICING: Record<string, EmbeddingPricing> = {
   'voyage:voyage-4-large':         { pricePerMTok: 0.18 },
   // ZeroEntropy (https://zeroentropy.dev/pricing — zembed-1)
   'zeroentropyai:zembed-1':        { pricePerMTok: 0.05 },
+  // Mistral (https://mistral.ai/pricing — codestral-embed, verified 2026-05-26)
+  'mistral:codestral-embed':       { pricePerMTok: 0.15 },
+  'mistral:codestral-embed-2505':  { pricePerMTok: 0.15 },
 };
 
 export type PriceLookupResult =

--- a/test/ai/recipe-mistral.test.ts
+++ b/test/ai/recipe-mistral.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Mistral recipe shape tests. Mistral's /v1/embeddings is OpenAI-shaped on the
+ * response, so it ships as a pure openai-compatible provider (file + register,
+ * no gateway shim) per the rule in src/core/ai/recipes/index.ts.
+ *
+ * Pins:
+ *  - implementation literal is 'openai-compatible' (not the 'openai-compat' typo).
+ *  - registered in ALL[] via index.ts.
+ *  - codestral-embed declared at 1536 default dims, text-only.
+ *  - pricing entries resolve for both the alias and dated model ids.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { mistral } from '../../src/core/ai/recipes/mistral.ts';
+import { RECIPES, getRecipe } from '../../src/core/ai/recipes/index.ts';
+import { lookupEmbeddingPrice } from '../../src/core/embedding-pricing.ts';
+
+describe('mistral recipe shape', () => {
+  test('implementation literal is "openai-compatible"', () => {
+    expect(mistral.implementation).toBe('openai-compatible');
+  });
+
+  test('base_url_default points at Mistral v1', () => {
+    expect(mistral.base_url_default).toBe('https://api.mistral.ai/v1');
+  });
+
+  test('registered in ALL[] via index.ts', () => {
+    expect(RECIPES.has('mistral')).toBe(true);
+    expect(getRecipe('mistral')).toBe(mistral);
+  });
+
+  test('embedding touchpoint declares codestral-embed at 1536 dims, text-only', () => {
+    const e = mistral.touchpoints.embedding!;
+    expect(e.models).toContain('codestral-embed');
+    expect(e.models).toContain('codestral-embed-2505');
+    expect(e.default_dims).toBe(1536);
+    expect(e.supports_multimodal).toBe(false);
+    // Dense-content (code) batch hedge.
+    expect(e.chars_per_token).toBe(3);
+    expect(e.safety_factor).toBe(0.5);
+    expect(e.max_batch_tokens).toBe(16_384);
+  });
+
+  test('auth_env declares MISTRAL_API_KEY + setup URL', () => {
+    expect(mistral.auth_env!.required).toEqual(['MISTRAL_API_KEY']);
+    expect(mistral.auth_env!.setup_url).toBe('https://console.mistral.ai/api-keys');
+  });
+
+  test('pricing resolves for both alias and dated model ids', () => {
+    const alias = lookupEmbeddingPrice('mistral:codestral-embed');
+    const dated = lookupEmbeddingPrice('mistral:codestral-embed-2505');
+    expect(alias.kind).toBe('known');
+    expect(dated.kind).toBe('known');
+    if (alias.kind === 'known') expect(alias.pricePerMTok).toBe(0.15);
+    if (dated.kind === 'known') expect(dated.pricePerMTok).toBe(0.15);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a native Mistral embedding recipe for `codestral-embed`. Mistral's `/v1/embeddings` is OpenAI-shaped on the response, so this ships as a pure openai-compatible provider (recipe file + register, no gateway shim) per the rule in `src/core/ai/recipes/index.ts`.

- `codestral-embed` / `codestral-embed-2505`, 1536d default, code-optimized, `MISTRAL_API_KEY` auth
- pricing entries (`$0.15/1M`) + a row in `docs/integrations/embedding-providers.md`
- hermetic recipe-shape test (mirrors `recipe-minimax` / `zeroentropy-recipe`)

Left VERSION/CHANGELOG to the maintainer per the fix-wave process.

## Verified end-to-end against the live Mistral API

- Raw `/v1/embeddings`: OpenAI-shaped response, **1536d** default.
- Through gbrain's gateway: `init` at 1536d + `put` + `embed` → chunks embedded, **no 422** (the standard openai-compatible path sends a clean request for this recipe).
- Semantic retrieval: query *"what compensates a shipowner for port delay?"* returned the charter-party doc at **0.865** (true vector match, not keyword overlap).
- Confirmed Mistral **rejects** OpenAI's `dimensions` (HTTP 422) and **honors** `output_dimension`. That is why flexible dims (up to 3072) + `mistral-embed` (1024d) are scoped as a follow-up that adds a `mistralCompatFetch` (mirroring `voyageCompatFetch`) rather than shipped in v1. v1 is fixed at the 1536 default.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test test/ai/recipe-mistral.test.ts` (6 cases) + `recipes-existing-regression` green (17 pass / 0 fail)
- [x] Live embed + semantic query against `api.mistral.ai` (1536d, 0.865 retrieval)
- [ ] CI on a fork PR will not have `MISTRAL_API_KEY`; the bundled test is hermetic by design (recipe shape + pricing lookup, no live call)