### PR TITLE
fix(entities): make tryPrefixExpansion symmetric with findPrefixCandidates

### DIFF
--- a/src/core/entities/resolve.ts
+++ b/src/core/entities/resolve.ts
@@ -241,12 +241,14 @@ export async function findPrefixCandidates(
 }
 
 /**
- * Look up pages whose slug starts with `<dir>/<token>-` for each known
- * entity directory. When multiple candidates match within a directory,
- * pick the one with the highest connection count (links_in + links_out +
- * chunk count) — the most-mentioned entity is the most likely canonical
- * target for a bare-name reference. When no candidates match in any
- * directory, returns null and the caller falls through to slugify.
+ * Look up pages whose slug matches `<dir>/<token>` (exact bare child)
+ * OR `<dir>/<token>-*` (suffixed child) for each known entity directory.
+ * When multiple candidates match within a directory, pick the one with
+ * the highest connection count (links_in + links_out + chunk count) —
+ * the most-mentioned entity is the most likely canonical target for a
+ * bare-name reference. When no candidates match in any directory,
+ * returns null and the caller falls through to slugify. Pattern set
+ * mirrors `findPrefixCandidates` above.
  */
 async function tryPrefixExpansion(
   engine: BrainEngine,
@@ -254,7 +256,18 @@ async function tryPrefixExpansion(
   token: string,
 ): Promise<string | null> {
   for (const dir of PREFIX_EXPANSION_DIRS) {
-    const pattern = `${dir}/${token}-%`;
+    // Two patterns per dir:
+    //   `<dir>/<token>`     — exact bare child (covers `people/alice`)
+    //   `<dir>/<token>-%`   — suffixed child  (covers `people/alice-example`)
+    // Mirrors the pattern set used by `findPrefixCandidates` above
+    // (lines 211-214) — that function got both forms in v0.35.5; this
+    // hot-path was missed during the same refactor. In the common case
+    // fuzzy match catches a bare `<dir>/<token>` slug before prefix
+    // expansion runs, so this is primarily a consistency / defensive
+    // fix: it guards against thin-band cases where multiple similar-name
+    // pages compete for fuzzy's LIMIT cutoff, or future threshold tuning
+    // pushes a bare slug below the fuzzy gate.
+    const patterns = [`${dir}/${token}`, `${dir}/${token}-%`];
     try {
       const rows = await engine.executeRaw<{
         slug: string;
@@ -285,10 +298,10 @@ async function tryPrefixExpansion(
          FROM pages p
          WHERE p.source_id = $1
            AND p.deleted_at IS NULL
-           AND p.slug LIKE $2
+           AND p.slug LIKE ANY($2::text[])
          ORDER BY connection_count DESC, p.slug ASC
          LIMIT 5`,
-        [source_id, pattern],
+        [source_id, patterns],
       );
       if (rows.length === 0) continue;
       // Single unambiguous match: return it.

--- a/test/entity-resolve-perf.slow.test.ts
+++ b/test/entity-resolve-perf.slow.test.ts
@@ -157,7 +157,11 @@ const OLD_SQL = `
   LIMIT 5
 `;
 
-// The T12 query shape — what tryPrefixExpansion now uses.
+// The T12 query shape — derived-table aggregation pattern introduced in
+// v0.35.5. Note: production now uses `LIKE ANY($2::text[])` for multi-
+// pattern matching, but this perf guard targets the correlated-subquery
+// vs derived-table shape difference (which dominates the >>5x speedup),
+// so the single-pattern `LIKE $2` form is fine for the benchmark.
 const NEW_SQL = `
   SELECT p.slug,
          ((SELECT COUNT(*)::int FROM links WHERE to_page_id = p.id)

--- a/test/phantom-redirect.test.ts
+++ b/test/phantom-redirect.test.ts
@@ -177,6 +177,20 @@ describe('resolvePhantomCanonical (codex #1 — bypasses exact-self-match)', () 
     expect(resolved).not.toBe('alice');
     expect(resolved).toBeNull();
   });
+
+  test('resolves a bare <dir>/<token> canonical via prefix expansion', async () => {
+    // Regression guard for this PR: tryPrefixExpansion must match the bare
+    // `people/grace` slug (no `-suffix`). resolvePhantomCanonical skips the
+    // exact-self path and only returns a prefix hit when it differs from the
+    // phantom and contains a slash — so reaching `people/grace` here proves
+    // tryPrefixExpansion's `<dir>/<token>` pattern fired. Before this fix the
+    // sole pattern was `people/grace-%`, which does not match the bare slug,
+    // so this returned null. Mirrors the findPrefixCandidates bare-prefix test.
+    await putPage('people/grace', '# grace\n', { type: 'person' });
+    await putPage('grace', STUB_BODY); // the phantom itself exists as exact slug
+    const resolved = await resolvePhantomCanonical(engine, 'default', 'grace');
+    expect(resolved).toBe('people/grace');
+  });
 });
 
 // ─── findPrefixCandidates (codex #11) ──────────────────────────────


### PR DESCRIPTION
`tryPrefixExpansion` matches `<dir>/<token>-%` only; the sibling
function `findPrefixCandidates` 40 lines above (resolve.ts:211-214)
matches both `<dir>/<token>` AND `<dir>/<token>-%`. Both target the
same resolution problem from opposite sides (hot-path top-1 vs
ambiguity-detector top-10) and should agree on which pages qualify
as candidates.

The bare form was added to `findPrefixCandidates` in v0.35.5 (codex
finding #11, phantom-redirect ambiguity detection) but this hot-path
query was never updated to match. This aligns them.

## Impact

In the common case, fuzzy match catches a bare `<dir>/<token>` slug
before prefix expansion runs â `similarity('people/alice', 'alice')`
clears the 0.4 threshold (â 0.417), so headline 'invisible to
resolver' behavior does NOT reproduce on a clean test fixture. The
fix is therefore primarily defensive consistency, biting in:

- Thin-band cases where multiple similar-name pages compete for
  fuzzy's LIMIT cutoff and the bare slug falls below it.
- Future fuzzy-threshold tuning that pushes bare slugs below the gate.
- Any explicit caller of `tryPrefixExpansion` (e.g. via the
  phantom-redirect path) that bypasses fuzzy entirely.

## Changes

- `src/core/entities/resolve.ts`: extend `tryPrefixExpansion` patterns
  to include the bare form; swap `LIKE $2` for `LIKE ANY($2::text[])`
  (already canonical elsewhere in this file).
- Updated function JSDoc to reflect both pattern forms.
- `test/entity-resolve-perf.slow.test.ts`: corrected stale comment
  noting that the perf benchmark's single-pattern `LIKE $2` form is
  intentional (it benchmarks the correlated-subquery vs derived-table
  shape, not the multi-pattern matching).

## Test plan

- `bun run typecheck` â clean.
- `bun test test/entity-resolve.test.ts` â 24/24 pass (no behavior
  regression on the 11 prefix-expansion cases that do bite the
  function, including Bob/Charlie/Dave fuzzy-fallthrough paths).
- `bun test test/phantom-redirect.test.ts` â 38/38 pass (covers
  `findPrefixCandidates`, the sibling function this aligns with).
- No new test cases added in this PR: the bare-form behavior is
  difficult to isolate from the fuzzy short-circuit on a realistic
  fixture without refactoring to export `tryPrefixExpansion` for
  direct testing, which is outside this PR's scope.

