### PR TITLE
fix(auth): create command works when --takes-holders is omitted

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -469,7 +469,8 @@ export async function runAuth(args: string[]): Promise<void> {
       const takesHolders = takesIdx >= 0 && rest[takesIdx + 1]
         ? rest[takesIdx + 1].split(',').map(s => s.trim()).filter(Boolean)
         : undefined;
-      const positional = rest.find(a => !a.startsWith('--') && a !== rest[takesIdx + 1]);
+      const takesValue = takesIdx >= 0 ? rest[takesIdx + 1] : undefined;
+      const positional = rest.find(a => !a.startsWith('--') && a !== takesValue);
       await create(positional || '', { takesHolders });
       return;
     }


### PR DESCRIPTION
## Summary

`gbrain auth create <name>` exits 1 with the usage line when `--takes-holders` is not provided. The positional-name parser at `src/commands/auth.ts:472` uses `rest[takesIdx + 1]` as an exclusion value, but when the flag is absent `takesIdx` is `-1` and that expression evaluates to `rest[0]` — the actual name. The `find` filter then excludes the legitimate name and `positional` ends up `undefined`.

## Repro

```bash
$ gbrain auth create my-client
Usage: auth create <name> [--takes-holders world,garry]
$ echo $?
1
```

With `--takes-holders` present, the bug is masked:

```bash
$ gbrain auth create my-client --takes-holders world
Token created for "my-client" (takes_holders=["world"]):
gbrain_...
```

## Fix

Guard the lookup so the filter only excludes the takes-holders VALUE when the flag is actually present.

```diff
-      const positional = rest.find(a => !a.startsWith('--') && a !== rest[takesIdx + 1]);
+      const takesValue = takesIdx >= 0 ? rest[takesIdx + 1] : undefined;
+      const positional = rest.find(a => !a.startsWith('--') && a !== takesValue);
```

After:

```bash
$ gbrain auth create my-client
Token created for "my-client" (takes_holders=["world"]):
gbrain_...
```

## Test plan

- [x] `gbrain auth create my-client` succeeds and creates a token with default `["world"]` takes-holders
- [x] `gbrain auth create my-client --takes-holders world,garry` still works
- [x] `gbrain auth create my-client --takes-holders world,garry,brain` still parses the list correctly
- [x] `gbrain auth create` (no name) still surfaces the usage error

Caught while wiring gbrain HTTP MCP into a 4-agent OpenClaw deployment — the create call is hit on every per-agent token registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)