### PR TITLE
[codex] Add Microsoft Graph drive sources

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -43,6 +43,7 @@ These require manual setup (no self-installing recipe yet):
 | Guide | What It Does |
 |-------|-------------|
 | [Credential Gateway](credential-gateway.md) | Set up ClawVisor or Hermes for Gmail, Calendar, Contacts access |
+| [Microsoft Graph Drives](microsoft-graph-drives.md) | OneDrive and SharePoint document libraries as source-scoped GBrain inputs |
 | [Meeting & Call Webhooks](meeting-webhooks.md) | Circleback meeting transcripts + Quo/OpenPhone SMS/calls |
 
 ## How to Read a Recipe

--- a/docs/integrations/microsoft-graph-drives.md
+++ b/docs/integrations/microsoft-graph-drives.md
@@ -1,0 +1,101 @@
+# Microsoft Graph Drives
+
+GBrain can register OneDrive and SharePoint document libraries as source-scoped
+Microsoft Graph drives.
+
+## Why this connector exists
+
+OneDrive and SharePoint expose the same Microsoft Graph file model:
+
+- A `drive` is a user's OneDrive or a SharePoint document library.
+- A `driveItem` is a file or folder inside that drive.
+- Delta sync tracks creates, updates, renames, and deletes without re-walking
+  every file on each run.
+
+References:
+
+- Microsoft Graph delta API: https://learn.microsoft.com/en-us/graph/api/driveitem-delta
+- Working with files in Microsoft Graph: https://learn.microsoft.com/en-us/graph/api/resources/onedrive
+- Microsoft Graph permissions reference: https://learn.microsoft.com/en-us/graph/permissions-reference
+
+## Authentication
+
+Set a Microsoft Graph bearer token in one of these environment variables:
+
+```sh
+export MICROSOFT_GRAPH_TOKEN=...
+```
+
+Aliases also supported: `MS_GRAPH_TOKEN`, `GRAPH_ACCESS_TOKEN`.
+
+Least-privilege delegated permissions are:
+
+- OneDrive: `Files.Read`
+- SharePoint libraries: `Files.Read` for files the signed-in user can access,
+  or `Sites.Read.All` / `Files.Read.All` when the tenant policy requires it.
+
+The token is never written into `sources.config`; only drive/site ids and delta
+cursors are stored.
+
+## Register Sources
+
+Register the signed-in user's default OneDrive:
+
+```sh
+gbrain microsoft-drives add-onedrive onedrive
+```
+
+Register a specific OneDrive drive id:
+
+```sh
+gbrain microsoft-drives add-onedrive onedrive-work --drive-id <drive-id>
+```
+
+Discover SharePoint document libraries for a site:
+
+```sh
+gbrain microsoft-drives list-sharepoint-drives --site-url https://contoso.sharepoint.com/sites/team
+```
+
+Register a SharePoint document library:
+
+```sh
+gbrain microsoft-drives add-sharepoint sp-team \
+  --site-url https://contoso.sharepoint.com/sites/team \
+  --drive-name Documents
+```
+
+## Sync
+
+Initial sync defaults to metadata/text import without inline embeddings:
+
+```sh
+gbrain microsoft-drives sync sp-team
+gbrain embed --stale
+```
+
+Use `--embed` for inline embedding on small drives:
+
+```sh
+gbrain microsoft-drives sync sp-team --embed
+```
+
+Use `--limit` for bounded passes:
+
+```sh
+gbrain microsoft-drives sync sp-team --limit 500
+```
+
+If a pass stops with a continuation cursor, rerun the same command. Once the
+delta is complete, GBrain stores `delta_link` and subsequent runs only request
+new changes.
+
+## Current Extraction Behavior
+
+Text-like files (`.md`, `.txt`, `.csv`, `.json`, source code, HTML, SQL, logs,
+and other `text/*` MIME types) are downloaded and imported as searchable pages.
+
+Office files, PDFs, and other binary formats are imported as metadata-only pages
+with Microsoft 365 links, item ids, MIME type, size, and modified-by metadata.
+This avoids corrupting the brain with binary bytes while leaving a stable page
+to enrich later when document text extraction is added.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture']);
+const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'microsoft-drives']);
 // CLI-only commands whose handlers print their own --help text. These are
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
@@ -47,6 +47,7 @@ const CLI_ONLY_SELF_HELP = new Set([
   'frontmatter', 'check-resolvable',
   'models',
   'cache',
+  'microsoft-drives',
   'brainstorm', 'lsd',
   // v0.39.3.0 WARN-5: capture's detailed HELP constant
   // (src/commands/capture.ts:90+) was unreachable because the dispatcher's
@@ -746,7 +747,7 @@ const THIN_CLIENT_REFUSED_COMMANDS = new Set([
   // edit local .md files). v0.31.1 refuses both at the top level with a
   // hint pointing at the routable MCP tools; per-subcommand splits are
   // a v0.31.x follow-up TODO.
-  'takes', 'sources',
+  'takes', 'sources', 'microsoft-drives',
   // v0.32 thin-client routing audit (Codex round 2 findings #2, #4):
   // - `pages` purge-deleted is admin+localOnly (operations.ts:856-864)
   // - `files` list / file_url MCP ops are localOnly (operations.ts:1769-1879)
@@ -782,6 +783,7 @@ const THIN_CLIENT_REFUSE_HINTS: Record<string, string> = {
   storage: 'storage operates on the local repo on disk. Run on the host.',
   takes: 'takes mutate subcommands edit local .md files; routing the read subcommands lands in v0.31.x. For now: use `takes_list` and `takes_search` MCP tools from your agent, or run on the host.',
   sources: 'sources commands manage local DB + config rows. Per-subcommand thin-client routing lands in v0.31.x. For now: use `sources_list` / `sources_status` MCP tools, or run on the host.',
+  'microsoft-drives': 'microsoft-drives imports external OneDrive/SharePoint files into the host DB. Run it on the host machine.',
   // v0.32 audit additions
   pages: '`pages purge-deleted` is admin+localOnly (hard-deletes from the local DB). Run on the host.',
   files: '`files list` and `files url` MCP ops are localOnly (paths live on the host filesystem). Use `gbrain files` on the host machine.',
@@ -933,6 +935,11 @@ async function handleCliOnly(command: string, args: string[]) {
     // own engine connection.
     const { runCache } = await import('./commands/cache.ts');
     await runCache(args);
+    return;
+  }
+  if (command === 'microsoft-drives' && (args.length === 0 || hasHelpFlag(args))) {
+    const { printMicrosoftDrivesHelp } = await import('./commands/microsoft-drives.ts');
+    printMicrosoftDrivesHelp();
     return;
   }
   if (command === 'routing-eval') {
@@ -1306,6 +1313,11 @@ async function handleCliOnly(command: string, args: string[]) {
       case 'sync': {
         const { runSync } = await import('./commands/sync.ts');
         await runSync(engine, args);
+        break;
+      }
+      case 'microsoft-drives': {
+        const { runMicrosoftDrives } = await import('./commands/microsoft-drives.ts');
+        await runMicrosoftDrives(engine, args);
         break;
       }
       case 'extract': {
@@ -1884,6 +1896,10 @@ BRAIN (capture / ideate / explore — v0.37/v0.38)
 SOURCES (multi-repo / multi-brain)
   sources list                       Show registered sources
   sources add <id> --path <p>        Register a source (id = short name, e.g. 'wiki')
+  microsoft-drives add-onedrive <id> Register OneDrive as a source
+  microsoft-drives add-sharepoint <id>
+                                     Register SharePoint library as a source
+  microsoft-drives sync <id>         Delta-sync OneDrive/SharePoint files
   sources remove <id>                Remove a source + its pages
   sync --all                         Sync all sources with a local_path
   sync --source <id>                 Sync one specific source

--- a/src/commands/microsoft-drives.ts
+++ b/src/commands/microsoft-drives.ts
@@ -1,0 +1,203 @@
+import type { BrainEngine } from '../core/engine.ts';
+import {
+  chooseSharePointDrive,
+  getOneDrive,
+  getSharePointSite,
+  GraphDriveError,
+  listSharePointDrives,
+  registerGraphDriveSource,
+  resolveGraphToken,
+  syncGraphDriveSource,
+  type GraphDrive,
+} from '../core/microsoft-graph-drive.ts';
+
+function flagValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+function hasFlag(args: string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+function parseFederated(args: string[]): boolean | undefined {
+  if (hasFlag(args, '--federated')) return true;
+  if (hasFlag(args, '--no-federated')) return false;
+  return undefined;
+}
+
+function parseLimit(args: string[]): number | undefined {
+  const raw = flagValue(args, '--limit');
+  if (!raw) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new GraphDriveError('--limit must be a positive number.', 'invalid_limit');
+  }
+  return Math.floor(n);
+}
+
+function printDrive(drive: GraphDrive): void {
+  console.log(`${drive.id}\t${drive.name ?? '(unnamed)'}\t${drive.driveType ?? '?'}\t${drive.webUrl ?? ''}`);
+}
+
+async function runAddOneDrive(engine: BrainEngine, args: string[]): Promise<void> {
+  const sourceId = args[0];
+  if (!sourceId) {
+    console.error('Usage: gbrain microsoft-drives add-onedrive <source-id> [--drive-id <id>] [--name <display>] [--federated|--no-federated]');
+    process.exit(2);
+  }
+  const token = resolveGraphToken();
+  const drive = await getOneDrive(token, flagValue(args, '--drive-id'));
+  const config = await registerGraphDriveSource(engine, {
+    sourceId,
+    name: flagValue(args, '--name') ?? drive.name ?? sourceId,
+    provider: 'onedrive',
+    drive,
+    federated: parseFederated(args),
+  });
+  console.log(`Registered OneDrive source "${sourceId}" (${config.drive_name ?? config.drive_id}).`);
+  console.log('Sync it with: gbrain microsoft-drives sync ' + sourceId);
+}
+
+async function resolveSharePointSelection(args: string[]): Promise<{
+  site: Awaited<ReturnType<typeof getSharePointSite>>;
+  drive: GraphDrive;
+}> {
+  const token = resolveGraphToken();
+  const site = await getSharePointSite(token, {
+    siteId: flagValue(args, '--site-id'),
+    siteUrl: flagValue(args, '--site-url'),
+  });
+  const drives = await listSharePointDrives(token, site.id);
+  const drive = chooseSharePointDrive(drives, {
+    driveId: flagValue(args, '--drive-id'),
+    driveName: flagValue(args, '--drive-name'),
+  });
+  return { site, drive };
+}
+
+async function runAddSharePoint(engine: BrainEngine, args: string[]): Promise<void> {
+  const sourceId = args[0];
+  if (!sourceId) {
+    console.error('Usage: gbrain microsoft-drives add-sharepoint <source-id> (--site-url <url>|--site-id <id>) [--drive-id <id>|--drive-name <name>] [--name <display>] [--federated|--no-federated]');
+    process.exit(2);
+  }
+  const { site, drive } = await resolveSharePointSelection(args);
+  const config = await registerGraphDriveSource(engine, {
+    sourceId,
+    name: flagValue(args, '--name') ?? `${site.displayName ?? site.name ?? 'SharePoint'} / ${drive.name ?? 'Documents'}`,
+    provider: 'sharepoint',
+    drive,
+    site,
+    federated: parseFederated(args),
+  });
+  console.log(`Registered SharePoint source "${sourceId}" (${config.site_name ?? config.site_id} / ${config.drive_name ?? config.drive_id}).`);
+  console.log('Sync it with: gbrain microsoft-drives sync ' + sourceId);
+}
+
+async function runListSharePointDrives(args: string[]): Promise<void> {
+  const token = resolveGraphToken();
+  const site = await getSharePointSite(token, {
+    siteId: flagValue(args, '--site-id'),
+    siteUrl: flagValue(args, '--site-url'),
+  });
+  const drives = await listSharePointDrives(token, site.id);
+  if (hasFlag(args, '--json')) {
+    console.log(JSON.stringify({ site, drives }, null, 2));
+    return;
+  }
+  console.log(`Drives for ${site.displayName ?? site.name ?? site.id}`);
+  for (const drive of drives) printDrive(drive);
+}
+
+async function runSync(engine: BrainEngine, args: string[]): Promise<void> {
+  const sourceId = args[0];
+  if (!sourceId) {
+    console.error('Usage: gbrain microsoft-drives sync <source-id> [--limit N] [--no-embed|--embed] [--dry-run] [--reset-delta] [--json]');
+    process.exit(2);
+  }
+  const noEmbed = hasFlag(args, '--no-embed') || !hasFlag(args, '--embed');
+  const result = await syncGraphDriveSource(engine, {
+    sourceId,
+    token: resolveGraphToken(),
+    noEmbed,
+    dryRun: hasFlag(args, '--dry-run'),
+    resetDelta: hasFlag(args, '--reset-delta'),
+    limit: parseLimit(args),
+  });
+  if (hasFlag(args, '--json')) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  console.log(
+    `Microsoft drive sync ${result.status}: imported=${result.imported} metadata_only=${result.metadata_only} ` +
+    `deleted=${result.deleted} folders=${result.skipped_folders} errors=${result.errors}`,
+  );
+  if (result.next_link_saved) {
+    console.log('  Saved a continuation cursor; rerun the same sync command to continue.');
+  } else if (result.delta_complete) {
+    console.log('  Delta cursor saved.');
+  }
+  if (noEmbed && (result.imported > 0 || result.metadata_only > 0)) {
+    console.log('  Embeddings deferred. Run: gbrain embed --stale');
+  }
+}
+
+export async function runMicrosoftDrives(engine: BrainEngine, args: string[]): Promise<void> {
+  const sub = args[0];
+  const rest = args.slice(1);
+  try {
+    switch (sub) {
+      case 'add-onedrive':
+        return runAddOneDrive(engine, rest);
+      case 'add-sharepoint':
+        return runAddSharePoint(engine, rest);
+      case 'list-sharepoint-drives':
+        return runListSharePointDrives(rest);
+      case 'sync':
+        return runSync(engine, rest);
+      case undefined:
+      case '--help':
+      case '-h':
+        printMicrosoftDrivesHelp();
+        return;
+      default:
+        console.error(`Unknown microsoft-drives subcommand: ${sub}`);
+        printMicrosoftDrivesHelp();
+        process.exit(2);
+    }
+  } catch (err) {
+    if (err instanceof GraphDriveError) {
+      console.error(`Error [${err.code}]: ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
+  }
+}
+
+export function printMicrosoftDrivesHelp(): void {
+  console.log(`gbrain microsoft-drives - OneDrive and SharePoint document-library sources
+
+Environment:
+  MICROSOFT_GRAPH_TOKEN             Microsoft Graph bearer token.
+                                    MS_GRAPH_TOKEN and GRAPH_ACCESS_TOKEN also work.
+
+Subcommands:
+  add-onedrive <source-id> [--drive-id <id>] [--name <display>]
+                                    Register a OneDrive source.
+
+  add-sharepoint <source-id> (--site-url <url>|--site-id <id>)
+      [--drive-id <id>|--drive-name <name>] [--name <display>]
+                                    Register a SharePoint document library.
+
+  list-sharepoint-drives (--site-url <url>|--site-id <id>) [--json]
+                                    Show document libraries for a site.
+
+  sync <source-id> [--limit N] [--no-embed|--embed] [--dry-run] [--reset-delta] [--json]
+                                    Delta-sync files into the source.
+
+Notes:
+  Initial sync defaults to --no-embed so large drives do not surprise-spend.
+  Run 'gbrain embed --stale' after import, or pass --embed for inline embedding.
+`);
+}

--- a/src/core/microsoft-graph-drive.ts
+++ b/src/core/microsoft-graph-drive.ts
@@ -1,0 +1,781 @@
+import { createHash } from 'crypto';
+import { posix as pathPosix } from 'path';
+import type { BrainEngine } from './engine.ts';
+import { importFromContent } from './import-file.ts';
+import { serializeMarkdown } from './markdown.ts';
+import { executeRawJsonb } from './sql-query.ts';
+import { slugifyPath } from './sync.ts';
+
+export type GraphDriveProvider = 'onedrive' | 'sharepoint';
+
+const GRAPH_BASE = 'https://graph.microsoft.com/v1.0';
+const SOURCE_ID_RE = /^[a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?$/;
+const MAX_TEXT_BYTES = 5_000_000;
+
+const DELTA_SELECT_FIELDS = [
+  'id',
+  'name',
+  'webUrl',
+  'eTag',
+  'cTag',
+  'size',
+  'file',
+  'folder',
+  'deleted',
+  'parentReference',
+  'lastModifiedDateTime',
+  'createdDateTime',
+  'createdBy',
+  'lastModifiedBy',
+  '@microsoft.graph.downloadUrl',
+];
+
+const TEXT_EXTENSIONS = new Set([
+  '.md', '.mdx', '.txt', '.csv', '.tsv', '.json', '.jsonl', '.yaml', '.yml',
+  '.toml', '.xml', '.html', '.htm', '.css', '.sql', '.log',
+  '.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs',
+  '.py', '.rb', '.go', '.rs', '.java', '.cs', '.cpp', '.cc', '.cxx',
+  '.hpp', '.hxx', '.hh', '.c', '.h', '.php', '.swift', '.kt', '.kts',
+  '.scala', '.sc', '.lua', '.ex', '.exs', '.elm', '.ml', '.mli',
+  '.dart', '.zig', '.sol', '.sh', '.bash', '.ps1',
+]);
+
+const CODE_FENCE_LANGUAGE: Record<string, string> = {
+  '.ts': 'ts', '.tsx': 'tsx', '.mts': 'ts', '.cts': 'ts',
+  '.js': 'js', '.jsx': 'jsx', '.mjs': 'js', '.cjs': 'js',
+  '.py': 'python', '.rb': 'ruby', '.go': 'go', '.rs': 'rust',
+  '.java': 'java', '.cs': 'csharp', '.cpp': 'cpp', '.cc': 'cpp',
+  '.cxx': 'cpp', '.hpp': 'cpp', '.hxx': 'cpp', '.hh': 'cpp',
+  '.c': 'c', '.h': 'c', '.php': 'php', '.swift': 'swift',
+  '.kt': 'kotlin', '.kts': 'kotlin', '.scala': 'scala', '.sc': 'scala',
+  '.lua': 'lua', '.ex': 'elixir', '.exs': 'elixir', '.elm': 'elm',
+  '.ml': 'ocaml', '.mli': 'ocaml', '.dart': 'dart', '.zig': 'zig',
+  '.sol': 'solidity', '.sh': 'bash', '.bash': 'bash', '.ps1': 'powershell',
+  '.css': 'css', '.html': 'html', '.htm': 'html', '.json': 'json',
+  '.jsonl': 'json', '.yaml': 'yaml', '.yml': 'yaml', '.toml': 'toml',
+  '.xml': 'xml', '.sql': 'sql', '.csv': 'csv', '.tsv': 'tsv',
+};
+
+export interface GraphIdentitySet {
+  user?: { displayName?: string; email?: string; id?: string };
+  application?: { displayName?: string; id?: string };
+  device?: { displayName?: string; id?: string };
+}
+
+export interface GraphDriveItem {
+  id: string;
+  name?: string;
+  webUrl?: string;
+  eTag?: string;
+  cTag?: string;
+  size?: number;
+  file?: { mimeType?: string; hashes?: Record<string, string> };
+  folder?: Record<string, unknown>;
+  deleted?: Record<string, unknown>;
+  parentReference?: { id?: string; path?: string; driveId?: string; siteId?: string };
+  lastModifiedDateTime?: string;
+  createdDateTime?: string;
+  createdBy?: GraphIdentitySet;
+  lastModifiedBy?: GraphIdentitySet;
+  '@microsoft.graph.downloadUrl'?: string;
+}
+
+export interface GraphDrive {
+  id: string;
+  name?: string;
+  driveType?: string;
+  webUrl?: string;
+}
+
+export interface GraphSite {
+  id: string;
+  name?: string;
+  displayName?: string;
+  webUrl?: string;
+}
+
+export interface GraphDriveSourceConfig {
+  connector: 'microsoft-graph-drive';
+  provider: GraphDriveProvider;
+  drive_id: string;
+  drive_name?: string;
+  drive_type?: string;
+  drive_web_url?: string;
+  site_id?: string;
+  site_name?: string;
+  site_web_url?: string;
+  delta_link?: string;
+  delta_next_link?: string;
+  federated?: boolean;
+  last_sync_at?: string;
+}
+
+export interface RegisterGraphDriveSourceOpts {
+  sourceId: string;
+  name?: string;
+  provider: GraphDriveProvider;
+  drive: GraphDrive;
+  site?: GraphSite;
+  federated?: boolean;
+}
+
+export interface GraphDriveSyncOpts {
+  sourceId: string;
+  token: string;
+  noEmbed?: boolean;
+  dryRun?: boolean;
+  limit?: number;
+  resetDelta?: boolean;
+  fetchImpl?: typeof fetch;
+}
+
+export interface GraphDriveSyncResult {
+  source_id: string;
+  provider: GraphDriveProvider;
+  drive_id: string;
+  status: 'synced' | 'dry_run';
+  imported: number;
+  metadata_only: number;
+  deleted: number;
+  skipped_folders: number;
+  skipped_unsupported: number;
+  errors: number;
+  pages_affected: string[];
+  delta_complete: boolean;
+  next_link_saved: boolean;
+  resyncs: number;
+}
+
+export class GraphDriveError extends Error {
+  constructor(message: string, public code: string, public status?: number) {
+    super(message);
+    this.name = 'GraphDriveError';
+  }
+}
+
+class GraphDriveResyncError extends GraphDriveError {
+  constructor(public location: string | null) {
+    super('Microsoft Graph delta token expired; a full delta resync is required.', 'delta_resync_required', 410);
+    this.name = 'GraphDriveResyncError';
+  }
+}
+
+interface DeltaResponse {
+  value?: GraphDriveItem[];
+  '@odata.nextLink'?: string;
+  '@odata.deltaLink'?: string;
+}
+
+interface ExistingGraphPage {
+  slug: string;
+  source_path: string | null;
+}
+
+function validateSourceId(id: string): void {
+  if (!SOURCE_ID_RE.test(id)) {
+    throw new GraphDriveError(
+      `Invalid source id "${id}". Must be 1-32 lowercase alnum chars with optional interior hyphens.`,
+      'invalid_source_id',
+    );
+  }
+}
+
+export function resolveGraphToken(env: Record<string, string | undefined> = process.env): string {
+  const token = env.MICROSOFT_GRAPH_TOKEN ?? env.MS_GRAPH_TOKEN ?? env.GRAPH_ACCESS_TOKEN;
+  if (!token) {
+    throw new GraphDriveError(
+      'Microsoft Graph token missing. Set MICROSOFT_GRAPH_TOKEN, MS_GRAPH_TOKEN, or GRAPH_ACCESS_TOKEN.',
+      'missing_token',
+    );
+  }
+  return token;
+}
+
+function graphUrl(pathOrUrl: string): string {
+  if (/^https?:\/\//i.test(pathOrUrl)) return pathOrUrl;
+  return GRAPH_BASE + (pathOrUrl.startsWith('/') ? pathOrUrl : '/' + pathOrUrl);
+}
+
+async function graphFetch(
+  pathOrUrl: string,
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  const url = graphUrl(pathOrUrl);
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (new URL(url).hostname === 'graph.microsoft.com') {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return fetchImpl(url, { headers });
+}
+
+export async function graphGetJson<T>(
+  pathOrUrl: string,
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<T> {
+  const res = await graphFetch(pathOrUrl, token, fetchImpl);
+  if (res.status === 410) {
+    throw new GraphDriveResyncError(res.headers.get('Location'));
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new GraphDriveError(
+      `Microsoft Graph request failed: ${res.status} ${res.statusText}${body ? ` ${body.slice(0, 500)}` : ''}`,
+      'graph_request_failed',
+      res.status,
+    );
+  }
+  return res.json() as Promise<T>;
+}
+
+async function graphGetBuffer(
+  pathOrUrl: string,
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Buffer> {
+  const url = graphUrl(pathOrUrl);
+  const headers: Record<string, string> = {};
+  if (new URL(url).hostname === 'graph.microsoft.com') {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const res = await fetchImpl(url, { headers });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new GraphDriveError(
+      `Microsoft Graph download failed: ${res.status} ${res.statusText}${body ? ` ${body.slice(0, 500)}` : ''}`,
+      'graph_download_failed',
+      res.status,
+    );
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+function parseConfig(config: unknown): Record<string, unknown> {
+  if (typeof config === 'string') {
+    try { return JSON.parse(config) as Record<string, unknown>; } catch { return {}; }
+  }
+  if (typeof config === 'object' && config !== null) return config as Record<string, unknown>;
+  return {};
+}
+
+function withoutUndefined<T extends Record<string, unknown>>(obj: T): T {
+  for (const key of Object.keys(obj)) {
+    if (obj[key] === undefined) delete obj[key];
+  }
+  return obj;
+}
+
+function sourceConfigFromRow(config: unknown): GraphDriveSourceConfig {
+  const parsed = parseConfig(config);
+  if (parsed.connector !== 'microsoft-graph-drive') {
+    throw new GraphDriveError('Source is not a Microsoft Graph drive source.', 'not_graph_drive_source');
+  }
+  if (parsed.provider !== 'onedrive' && parsed.provider !== 'sharepoint') {
+    throw new GraphDriveError('Microsoft Graph drive source has invalid provider.', 'invalid_provider');
+  }
+  if (typeof parsed.drive_id !== 'string' || parsed.drive_id.length === 0) {
+    throw new GraphDriveError('Microsoft Graph drive source is missing drive_id.', 'missing_drive_id');
+  }
+  return parsed as unknown as GraphDriveSourceConfig;
+}
+
+export async function registerGraphDriveSource(
+  engine: BrainEngine,
+  opts: RegisterGraphDriveSourceOpts,
+): Promise<GraphDriveSourceConfig> {
+  validateSourceId(opts.sourceId);
+  if (!opts.drive.id) {
+    throw new GraphDriveError('Drive id is required.', 'missing_drive_id');
+  }
+
+  const existing = await engine.executeRaw<{ id: string; config: unknown }>(
+    `SELECT id, config FROM sources WHERE id = $1`,
+    [opts.sourceId],
+  );
+  if (existing.length > 0) {
+    const cfg = parseConfig(existing[0].config);
+    if (cfg.connector !== 'microsoft-graph-drive') {
+      throw new GraphDriveError(
+        `Source "${opts.sourceId}" already exists and is not a Microsoft Graph drive source.`,
+        'source_id_taken',
+      );
+    }
+  }
+
+  const federated = opts.federated ?? true;
+  const config: GraphDriveSourceConfig = withoutUndefined({
+    connector: 'microsoft-graph-drive',
+    provider: opts.provider,
+    drive_id: opts.drive.id,
+    drive_name: opts.drive.name,
+    drive_type: opts.drive.driveType,
+    drive_web_url: opts.drive.webUrl,
+    federated,
+    ...(opts.site ? {
+      site_id: opts.site.id,
+      site_name: opts.site.displayName ?? opts.site.name,
+      site_web_url: opts.site.webUrl,
+    } : {}),
+  }) as GraphDriveSourceConfig;
+
+  const displayName = opts.name ?? opts.drive.name ?? opts.sourceId;
+  await executeRawJsonb(
+    engine,
+    `INSERT INTO sources (id, name, local_path, config, archived, archived_at, archive_expires_at)
+       VALUES ($1, $2, NULL, $3::jsonb, false, NULL, NULL)
+       ON CONFLICT (id) DO UPDATE SET
+         name = EXCLUDED.name,
+         local_path = NULL,
+         config = EXCLUDED.config,
+         archived = false,
+         archived_at = NULL,
+         archive_expires_at = NULL`,
+    [opts.sourceId, displayName],
+    [config],
+  );
+  return config;
+}
+
+export async function getOneDrive(
+  token: string,
+  driveId?: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<GraphDrive> {
+  return graphGetJson<GraphDrive>(
+    driveId ? `/drives/${encodeURIComponent(driveId)}` : '/me/drive',
+    token,
+    fetchImpl,
+  );
+}
+
+export function sitePathFromUrl(siteUrl: string): { hostname: string; relativePath: string } {
+  const url = new URL(siteUrl);
+  const relativePath = decodeURIComponent(url.pathname.replace(/\/+$/, ''));
+  return {
+    hostname: url.hostname,
+    relativePath: relativePath === '' ? '/' : relativePath,
+  };
+}
+
+export async function getSharePointSite(
+  token: string,
+  opts: { siteId?: string; siteUrl?: string },
+  fetchImpl: typeof fetch = fetch,
+): Promise<GraphSite> {
+  if (opts.siteId) {
+    return graphGetJson<GraphSite>(`/sites/${encodeURIComponent(opts.siteId)}`, token, fetchImpl);
+  }
+  if (!opts.siteUrl) {
+    throw new GraphDriveError('Pass --site-id or --site-url.', 'missing_site');
+  }
+  const { hostname, relativePath } = sitePathFromUrl(opts.siteUrl);
+  if (relativePath === '/') {
+    return graphGetJson<GraphSite>(`/sites/${hostname}:/`, token, fetchImpl);
+  }
+  return graphGetJson<GraphSite>(`/sites/${hostname}:${relativePath}`, token, fetchImpl);
+}
+
+export async function listSharePointDrives(
+  token: string,
+  siteId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<GraphDrive[]> {
+  const res = await graphGetJson<{ value?: GraphDrive[] }>(
+    `/sites/${encodeURIComponent(siteId)}/drives`,
+    token,
+    fetchImpl,
+  );
+  return res.value ?? [];
+}
+
+export function chooseSharePointDrive(
+  drives: GraphDrive[],
+  opts: { driveId?: string; driveName?: string } = {},
+): GraphDrive {
+  if (opts.driveId) {
+    const drive = drives.find(d => d.id === opts.driveId);
+    if (!drive) throw new GraphDriveError(`Drive id "${opts.driveId}" not found on site.`, 'drive_not_found');
+    return drive;
+  }
+  if (opts.driveName) {
+    const wanted = opts.driveName.toLowerCase();
+    const drive = drives.find(d => (d.name ?? '').toLowerCase() === wanted);
+    if (!drive) throw new GraphDriveError(`Drive name "${opts.driveName}" not found on site.`, 'drive_not_found');
+    return drive;
+  }
+  if (drives.length === 1) return drives[0];
+  const documents = drives.find(d => (d.name ?? '').toLowerCase() === 'documents');
+  if (documents) return documents;
+  throw new GraphDriveError(
+    `Site has ${drives.length} drives. Pass --drive-id or --drive-name.`,
+    'ambiguous_drive',
+  );
+}
+
+export function buildInitialDeltaUrl(driveId: string, top?: number): string {
+  const params = new URLSearchParams();
+  params.set('$select', DELTA_SELECT_FIELDS.join(','));
+  if (top && top > 0) params.set('$top', String(top));
+  return `/drives/${encodeURIComponent(driveId)}/root/delta?${params.toString()}`;
+}
+
+function identityLabel(identity?: GraphIdentitySet): string | undefined {
+  return (
+    identity?.user?.displayName ??
+    identity?.user?.email ??
+    identity?.application?.displayName ??
+    identity?.device?.displayName
+  );
+}
+
+export function driveItemRelativePath(item: GraphDriveItem, existingPath?: string | null): string {
+  const name = item.name || item.id;
+  const graphPath = item.parentReference?.path;
+  if (graphPath) {
+    const marker = ':/';
+    const idx = graphPath.indexOf(marker);
+    if (idx >= 0) {
+      const parent = graphPath.slice(idx + marker.length).replace(/^\/+|\/+$/g, '');
+      return parent ? `${parent}/${name}` : name;
+    }
+  }
+  if (existingPath && existingPath.includes('/')) {
+    return `${pathPosix.dirname(existingPath)}/${name}`;
+  }
+  return name;
+}
+
+function shortItemHash(itemId: string): string {
+  return createHash('sha1').update(itemId).digest('hex').slice(0, 8);
+}
+
+export function slugForDriveItem(relPath: string, itemId: string): string {
+  const base = slugifyPath(relPath);
+  const suffix = shortItemHash(itemId);
+  return base ? `${base}-${suffix}` : `microsoft-graph/${suffix}`;
+}
+
+export function isTextLikeDriveItem(item: GraphDriveItem): boolean {
+  const ext = pathPosix.extname(item.name ?? '').toLowerCase();
+  const mime = item.file?.mimeType?.toLowerCase() ?? '';
+  return TEXT_EXTENSIONS.has(ext) || mime.startsWith('text/');
+}
+
+function fencedContentForPath(relPath: string, text: string): string {
+  const ext = pathPosix.extname(relPath).toLowerCase();
+  if (ext === '.md' || ext === '.mdx' || ext === '.txt' || ext === '') return text;
+  const lang = CODE_FENCE_LANGUAGE[ext] ?? '';
+  return `\`\`\`${lang}\n${text.replace(/```/g, '`\\`\\`')}\n\`\`\``;
+}
+
+export function buildGraphDriveMarkdown(
+  item: GraphDriveItem,
+  relPath: string,
+  opts: {
+    provider: GraphDriveProvider;
+    driveId: string;
+    driveName?: string;
+    siteId?: string;
+    siteName?: string;
+    contentText?: string;
+    metadataOnlyReason?: string;
+  },
+): string {
+  const title = item.name ?? relPath;
+  const tags = ['microsoft-graph', opts.provider];
+  const frontmatter: Record<string, unknown> = {
+    source: 'microsoft-graph',
+    graph_provider: opts.provider,
+    graph_drive_id: opts.driveId,
+    graph_drive_name: opts.driveName,
+    graph_site_id: opts.siteId,
+    graph_site_name: opts.siteName,
+    graph_item_id: item.id,
+    graph_item_path: relPath,
+    graph_item_web_url: item.webUrl,
+    graph_parent_id: item.parentReference?.id,
+    graph_etag: item.eTag,
+    graph_ctag: item.cTag,
+    graph_mime_type: item.file?.mimeType,
+    graph_size: item.size,
+    graph_created_at: item.createdDateTime,
+    graph_modified_at: item.lastModifiedDateTime,
+    graph_created_by: identityLabel(item.createdBy),
+    graph_modified_by: identityLabel(item.lastModifiedBy),
+  };
+  for (const key of Object.keys(frontmatter)) {
+    if (frontmatter[key] === undefined) delete frontmatter[key];
+  }
+
+  const facts = [
+    `Microsoft Graph source: ${opts.provider}`,
+    `Drive: ${opts.driveName ?? opts.driveId}`,
+    opts.siteName ? `Site: ${opts.siteName}` : null,
+    `Path: ${relPath}`,
+    item.webUrl ? `Open in Microsoft 365: ${item.webUrl}` : null,
+    item.lastModifiedDateTime ? `Modified: ${item.lastModifiedDateTime}` : null,
+    identityLabel(item.lastModifiedBy) ? `Modified by: ${identityLabel(item.lastModifiedBy)}` : null,
+    item.file?.mimeType ? `MIME type: ${item.file.mimeType}` : null,
+    typeof item.size === 'number' ? `Size: ${item.size} bytes` : null,
+  ].filter((line): line is string => Boolean(line));
+
+  const bodyParts = [
+    `# ${title}`,
+    facts.join('\n'),
+  ];
+
+  if (opts.contentText !== undefined) {
+    bodyParts.push('## Content', fencedContentForPath(relPath, opts.contentText));
+  } else {
+    bodyParts.push(
+      '## Content',
+      `Metadata indexed only. ${opts.metadataOnlyReason ?? 'Text extraction is not available for this file type yet.'}`,
+    );
+  }
+
+  return serializeMarkdown(frontmatter, bodyParts.join('\n\n'), '', {
+    type: 'note',
+    title,
+    tags,
+  });
+}
+
+async function findExistingGraphPage(
+  engine: BrainEngine,
+  sourceId: string,
+  itemId: string,
+): Promise<ExistingGraphPage | null> {
+  const rows = await engine.executeRaw<ExistingGraphPage>(
+    `SELECT slug, source_path
+       FROM pages
+      WHERE source_id = $1
+        AND frontmatter->>'graph_item_id' = $2
+        AND deleted_at IS NULL
+      LIMIT 1`,
+    [sourceId, itemId],
+  );
+  return rows[0] ?? null;
+}
+
+async function deleteGraphItemPage(
+  engine: BrainEngine,
+  sourceId: string,
+  itemId: string,
+): Promise<string | null> {
+  const existing = await findExistingGraphPage(engine, sourceId, itemId);
+  if (!existing) return null;
+  await engine.deletePage(existing.slug, { sourceId });
+  return existing.slug;
+}
+
+async function downloadTextForItem(
+  item: GraphDriveItem,
+  driveId: string,
+  token: string,
+  fetchImpl: typeof fetch,
+): Promise<string> {
+  const size = item.size ?? 0;
+  if (size > MAX_TEXT_BYTES) {
+    throw new GraphDriveError(`File too large for text import (${size} bytes).`, 'file_too_large');
+  }
+  const downloadUrl =
+    item['@microsoft.graph.downloadUrl'] ??
+    `/drives/${encodeURIComponent(driveId)}/items/${encodeURIComponent(item.id)}/content`;
+  const buf = await graphGetBuffer(downloadUrl, token, fetchImpl);
+  if (buf.byteLength > MAX_TEXT_BYTES) {
+    throw new GraphDriveError(`File too large for text import (${buf.byteLength} bytes).`, 'file_too_large');
+  }
+  return buf.toString('utf8').replace(/\u0000/g, '');
+}
+
+async function importGraphDriveItem(
+  engine: BrainEngine,
+  sourceId: string,
+  cfg: GraphDriveSourceConfig,
+  item: GraphDriveItem,
+  opts: GraphDriveSyncOpts,
+): Promise<{ slug: string; status: 'imported' | 'metadata_only' | 'skipped' }> {
+  const existing = await findExistingGraphPage(engine, sourceId, item.id);
+  const relPath = driveItemRelativePath(item, existing?.source_path);
+  const slug = slugForDriveItem(relPath, item.id);
+  let contentText: string | undefined;
+  let metadataOnlyReason: string | undefined;
+
+  if (isTextLikeDriveItem(item)) {
+    try {
+      contentText = await downloadTextForItem(item, cfg.drive_id, opts.token, opts.fetchImpl ?? fetch);
+    } catch (err) {
+      if (err instanceof GraphDriveError && err.code === 'file_too_large') {
+        metadataOnlyReason = err.message;
+      } else {
+        throw err;
+      }
+    }
+  } else {
+    metadataOnlyReason = `Unsupported content type for text extraction: ${(item.file?.mimeType ?? pathPosix.extname(relPath)) || 'unknown'}.`;
+  }
+
+  const markdown = buildGraphDriveMarkdown(item, relPath, {
+    provider: cfg.provider,
+    driveId: cfg.drive_id,
+    driveName: cfg.drive_name,
+    siteId: cfg.site_id,
+    siteName: cfg.site_name,
+    contentText,
+    metadataOnlyReason,
+  });
+
+  if (opts.dryRun) {
+    return { slug, status: contentText === undefined ? 'metadata_only' : 'imported' };
+  }
+
+  if (existing && existing.slug !== slug) {
+    await engine.deletePage(existing.slug, { sourceId });
+  }
+
+  const result = await importFromContent(engine, slug, markdown, {
+    sourceId,
+    noEmbed: opts.noEmbed,
+    filename: pathPosix.basename(relPath, pathPosix.extname(relPath)),
+    sourcePath: relPath,
+  });
+  if (result.status === 'skipped') return { slug, status: 'skipped' };
+  return { slug, status: contentText === undefined ? 'metadata_only' : 'imported' };
+}
+
+async function readGraphDriveSource(
+  engine: BrainEngine,
+  sourceId: string,
+): Promise<{ name: string; config: GraphDriveSourceConfig }> {
+  const rows = await engine.executeRaw<{ name: string; config: unknown }>(
+    `SELECT name, config FROM sources WHERE id = $1 AND archived IS NOT TRUE`,
+    [sourceId],
+  );
+  if (rows.length === 0) {
+    throw new GraphDriveError(`Source "${sourceId}" not found.`, 'source_not_found');
+  }
+  return { name: rows[0].name, config: sourceConfigFromRow(rows[0].config) };
+}
+
+async function writeGraphDriveSourceConfig(
+  engine: BrainEngine,
+  sourceId: string,
+  config: GraphDriveSourceConfig,
+): Promise<void> {
+  await executeRawJsonb(
+    engine,
+    `UPDATE sources
+        SET config = $2::jsonb,
+            last_sync_at = now()
+      WHERE id = $1`,
+    [sourceId],
+    [config],
+  );
+}
+
+export async function syncGraphDriveSource(
+  engine: BrainEngine,
+  opts: GraphDriveSyncOpts,
+): Promise<GraphDriveSyncResult> {
+  validateSourceId(opts.sourceId);
+  const { config } = await readGraphDriveSource(engine, opts.sourceId);
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const result: GraphDriveSyncResult = {
+    source_id: opts.sourceId,
+    provider: config.provider,
+    drive_id: config.drive_id,
+    status: opts.dryRun ? 'dry_run' : 'synced',
+    imported: 0,
+    metadata_only: 0,
+    deleted: 0,
+    skipped_folders: 0,
+    skipped_unsupported: 0,
+    errors: 0,
+    pages_affected: [],
+    delta_complete: false,
+    next_link_saved: false,
+    resyncs: 0,
+  };
+
+  let url = opts.resetDelta
+    ? buildInitialDeltaUrl(config.drive_id, opts.limit)
+    : config.delta_next_link ?? config.delta_link ?? buildInitialDeltaUrl(config.drive_id, opts.limit);
+  let nextLinkToSave: string | undefined;
+  let deltaLinkToSave: string | undefined;
+  let processed = 0;
+
+  while (url) {
+    let page: DeltaResponse;
+    try {
+      page = await graphGetJson<DeltaResponse>(url, opts.token, fetchImpl);
+    } catch (err) {
+      if (err instanceof GraphDriveResyncError) {
+        result.resyncs++;
+        url = err.location || buildInitialDeltaUrl(config.drive_id, opts.limit);
+        continue;
+      }
+      throw err;
+    }
+
+    for (const item of page.value ?? []) {
+      if (!item.id) continue;
+      if (item.folder) {
+        result.skipped_folders++;
+        continue;
+      }
+      if (item.deleted) {
+        if (!opts.dryRun) {
+          const slug = await deleteGraphItemPage(engine, opts.sourceId, item.id);
+          if (slug) result.pages_affected.push(slug);
+        }
+        result.deleted++;
+        processed++;
+        continue;
+      }
+      if (!item.file) {
+        result.skipped_unsupported++;
+        continue;
+      }
+      try {
+        const imported = await importGraphDriveItem(engine, opts.sourceId, config, item, { ...opts, fetchImpl });
+        if (imported.status === 'imported') result.imported++;
+        if (imported.status === 'metadata_only') result.metadata_only++;
+        if (imported.status !== 'skipped') result.pages_affected.push(imported.slug);
+      } catch (err) {
+        result.errors++;
+        console.error(`[microsoft-drives] skipped ${item.name ?? item.id}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      processed++;
+    }
+
+    if (page['@odata.nextLink']) {
+      if (opts.limit && processed >= opts.limit) {
+        nextLinkToSave = page['@odata.nextLink'];
+        break;
+      }
+      url = page['@odata.nextLink'];
+    } else {
+      deltaLinkToSave = page['@odata.deltaLink'];
+      url = '';
+    }
+  }
+
+  result.delta_complete = Boolean(deltaLinkToSave);
+  result.next_link_saved = Boolean(nextLinkToSave);
+  if (!opts.dryRun) {
+    const nextConfig: GraphDriveSourceConfig = {
+      ...config,
+      last_sync_at: new Date().toISOString(),
+    };
+    if (deltaLinkToSave) {
+      nextConfig.delta_link = deltaLinkToSave;
+      delete nextConfig.delta_next_link;
+    } else if (nextLinkToSave) {
+      nextConfig.delta_next_link = nextLinkToSave;
+    }
+    await writeGraphDriveSourceConfig(engine, opts.sourceId, nextConfig);
+  }
+
+  return result;
+}

--- a/test/microsoft-graph-drive.test.ts
+++ b/test/microsoft-graph-drive.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from 'bun:test';
+import { parseMarkdown } from '../src/core/markdown.ts';
+import {
+  buildGraphDriveMarkdown,
+  buildInitialDeltaUrl,
+  chooseSharePointDrive,
+  driveItemRelativePath,
+  isTextLikeDriveItem,
+  sitePathFromUrl,
+  slugForDriveItem,
+  syncGraphDriveSource,
+  type GraphDriveItem,
+} from '../src/core/microsoft-graph-drive.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+import type { PageInput } from '../src/core/types.ts';
+
+function makeFakeEngine() {
+  const source: { name: string; config: Record<string, unknown> } = {
+    name: 'SharePoint Docs',
+    config: {
+      connector: 'microsoft-graph-drive',
+      provider: 'sharepoint',
+      drive_id: 'drive-1',
+      drive_name: 'Documents',
+      site_id: 'site-1',
+      site_name: 'Team Site',
+      federated: true,
+    },
+  };
+  const pages = new Map<string, { slug: string; source_id: string; source_path: string | null; frontmatter: Record<string, unknown>; compiled_truth: string }>();
+  const engine = {
+    kind: 'pglite',
+    async executeRaw(sql: string, params: unknown[] = []) {
+      if (sql.includes('SELECT name, config FROM sources')) {
+        return [source];
+      }
+      if (sql.includes("frontmatter->>'graph_item_id'")) {
+        const sourceId = params[0];
+        const itemId = params[1];
+        return Array.from(pages.values())
+          .filter(p => p.source_id === sourceId && p.frontmatter.graph_item_id === itemId)
+          .map(p => ({ slug: p.slug, source_path: p.source_path }))
+          .slice(0, 1);
+      }
+      if (sql.includes('UPDATE sources')) {
+        source.config = params[1] as typeof source.config;
+        return [];
+      }
+      throw new Error(`unexpected SQL in fake engine: ${sql}`);
+    },
+    async getPage(slug: string, opts?: { sourceId?: string }) {
+      const page = pages.get(`${opts?.sourceId ?? 'default'}:${slug}`);
+      if (!page) return null;
+      return {
+        id: 1,
+        slug,
+        type: 'note',
+        title: slug,
+        compiled_truth: page.compiled_truth,
+        timeline: '',
+        frontmatter: page.frontmatter,
+        created_at: new Date(),
+        updated_at: new Date(),
+        source_id: page.source_id,
+      };
+    },
+    async transaction<T>(fn: (tx: BrainEngine) => Promise<T>) {
+      return fn(engine as unknown as BrainEngine);
+    },
+    async createVersion() {},
+    async putPage(slug: string, page: PageInput, opts?: { sourceId?: string }) {
+      const sourceId = opts?.sourceId ?? 'default';
+      pages.set(`${sourceId}:${slug}`, {
+        slug,
+        source_id: sourceId,
+        source_path: page.source_path ?? null,
+        frontmatter: page.frontmatter ?? {},
+        compiled_truth: page.compiled_truth,
+      });
+      return (await engine.getPage(slug, { sourceId }))!;
+    },
+    async getTags() { return []; },
+    async addTag() {},
+    async removeTag() {},
+    async upsertChunks() {},
+    async deleteChunks() {},
+    async addLink() { throw new Error('no target'); },
+    async deletePage(slug: string, opts?: { sourceId?: string }) {
+      pages.delete(`${opts?.sourceId ?? 'default'}:${slug}`);
+    },
+  };
+  return { engine: engine as unknown as BrainEngine, source, pages };
+}
+
+describe('microsoft graph drive connector helpers', () => {
+  test('derives a relative path from Graph parentReference.path', () => {
+    const item: GraphDriveItem = {
+      id: 'item-1',
+      name: 'Plan.md',
+      parentReference: { path: '/drives/drive-1/root:/General/Projects' },
+      file: { mimeType: 'text/markdown' },
+    };
+    expect(driveItemRelativePath(item)).toBe('General/Projects/Plan.md');
+  });
+
+  test('reuses existing directory when delta omits parent path', () => {
+    const item: GraphDriveItem = {
+      id: 'item-1',
+      name: 'Renamed.md',
+      parentReference: { id: 'parent-1' },
+      file: { mimeType: 'text/markdown' },
+    };
+    expect(driveItemRelativePath(item, 'General/Projects/Old.md')).toBe('General/Projects/Renamed.md');
+  });
+
+  test('keeps slugs readable while adding an item-id hash for collision safety', () => {
+    const slug = slugForDriveItem('General Projects/Quarterly Plan.md', 'drive-item-123');
+    expect(slug).toMatch(/^general-projects\/quarterly-plan-[a-f0-9]{8}$/);
+    expect(slugForDriveItem('🚀.md', 'drive-item-123')).toMatch(/^microsoft-graph\/[a-f0-9]{8}$/);
+  });
+
+  test('classifies text-like files by extension or mime type', () => {
+    expect(isTextLikeDriveItem({ id: '1', name: 'notes.md', file: {} })).toBe(true);
+    expect(isTextLikeDriveItem({ id: '2', name: 'export.bin', file: { mimeType: 'text/plain' } })).toBe(true);
+    expect(isTextLikeDriveItem({ id: '3', name: 'deck.pptx', file: { mimeType: 'application/vnd.openxmlformats-officedocument.presentationml.presentation' } })).toBe(false);
+  });
+
+  test('builds parseable markdown with Graph metadata in frontmatter', () => {
+    const md = buildGraphDriveMarkdown(
+      {
+        id: 'abc123',
+        name: 'Notes.txt',
+        webUrl: 'https://contoso.sharepoint.com/sites/team/Shared%20Documents/Notes.txt',
+        size: 42,
+        file: { mimeType: 'text/plain' },
+        parentReference: { id: 'parent' },
+        lastModifiedDateTime: '2026-05-26T12:00:00Z',
+        lastModifiedBy: { user: { displayName: 'Test User' } },
+      },
+      'Shared Documents/Notes.txt',
+      {
+        provider: 'sharepoint',
+        driveId: 'drive-1',
+        driveName: 'Documents',
+        siteId: 'site-1',
+        siteName: 'Team Site',
+        contentText: 'hello from graph',
+      },
+    );
+    const parsed = parseMarkdown(md, 'notes.md');
+    expect(parsed.title).toBe('Notes.txt');
+    expect(parsed.type).toBe('note');
+    expect(parsed.tags).toContain('microsoft-graph');
+    expect(parsed.frontmatter.graph_item_id).toBe('abc123');
+    expect(parsed.compiled_truth).toContain('hello from graph');
+  });
+
+  test('builds initial delta URL with select fields and top', () => {
+    const url = buildInitialDeltaUrl('drive!id', 25);
+    expect(url).toStartWith('/drives/drive!id/root/delta?');
+    expect(decodeURIComponent(url)).toContain('$select=');
+    expect(decodeURIComponent(url)).toContain('@microsoft.graph.downloadUrl');
+    expect(decodeURIComponent(url)).toContain('$top=25');
+  });
+
+  test('chooses SharePoint document library by id, name, singleton, or Documents default', () => {
+    const drives = [
+      { id: 'a', name: 'Assets', driveType: 'documentLibrary' },
+      { id: 'b', name: 'Documents', driveType: 'documentLibrary' },
+    ];
+    expect(chooseSharePointDrive(drives, { driveId: 'a' }).id).toBe('a');
+    expect(chooseSharePointDrive(drives, { driveName: 'documents' }).id).toBe('b');
+    expect(chooseSharePointDrive(drives).id).toBe('b');
+    expect(chooseSharePointDrive([{ id: 'only', name: 'Library' }]).id).toBe('only');
+  });
+
+  test('parses SharePoint site URLs for Graph site lookup', () => {
+    expect(sitePathFromUrl('https://contoso.sharepoint.com/sites/Team%20Site/')).toEqual({
+      hostname: 'contoso.sharepoint.com',
+      relativePath: '/sites/Team Site',
+    });
+  });
+
+  test('sync imports a text item and saves the returned delta cursor', async () => {
+    const fake = makeFakeEngine();
+    const fetchImpl = async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('/root/delta')) {
+        return new Response(JSON.stringify({
+          value: [
+            {
+              id: 'item-1',
+              name: 'Notes.txt',
+              webUrl: 'https://contoso/Notes.txt',
+              size: 11,
+              file: { mimeType: 'text/plain' },
+              parentReference: { path: '/drives/drive-1/root:/General' },
+            },
+          ],
+          '@odata.deltaLink': 'https://graph.microsoft.com/v1.0/drives/drive-1/root/delta(token=abc)',
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url.includes('/content')) {
+        return new Response('hello graph', { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    };
+
+    const result = await syncGraphDriveSource(fake.engine, {
+      sourceId: 'spdocs',
+      token: 'token',
+      noEmbed: true,
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(result.imported).toBe(1);
+    expect(result.delta_complete).toBe(true);
+    expect(fake.source.config.delta_link).toContain('token=abc');
+    const stored = Array.from(fake.pages.values())[0];
+    expect(stored.source_path).toBe('General/Notes.txt');
+    expect(stored.frontmatter.graph_item_id).toBe('item-1');
+    expect(stored.compiled_truth).toContain('hello graph');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Microsoft Graph drive connector so OneDrive and SharePoint document libraries can be registered as source-scoped GBrain inputs.

## Changes

- Adds `gbrain microsoft-drives` commands for OneDrive registration, SharePoint library registration/listing, and bounded delta sync.
- Adds Graph delta sync support that imports text-like files through the normal GBrain import pipeline and indexes unsupported binary/Office/PDF files as metadata-only pages.
- Stores Graph drive configuration and delta cursors in `sources.config` without storing bearer tokens.
- Documents setup, token requirements, sync behavior, and source registration.

## Validation

- `bun test test/microsoft-graph-drive.test.ts`
- `bun run typecheck`
- `bun run src/cli.ts microsoft-drives --help`

Note: `bun install` succeeded in installing missing local dependencies, but the Windows postinstall shell snippet failed on redirection syntax; no tracked files changed from install.