### PR TITLE
Fix/user provided model validation

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -666,11 +666,14 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   }
 
   // Openai-compat recipes with empty models list require a user-provided model.
+  // Exception: if the user already specified a model name (parsed.modelId is non-empty),
+  // they have satisfied the requirement — proceed.
   const isUserProvided = (tp as any).user_provided_models === true;
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
-    (recipe.id === 'litellm' || isUserProvided)
+    (recipe.id === 'litellm' || isUserProvided) &&
+    !parsed.modelId
   ) {
     return {
       ok: false,
@@ -1261,12 +1264,19 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
   // clear AIConfigError when a Voyage flexible-dim model gets an
   // unsupported value (the existing v0.33.1.1 fail-loud path).
   const effectiveDims = opts?.dimensions ?? cfg.embedding_dimensions ?? DEFAULT_EMBEDDING_DIMENSIONS;
-  const providerOpts = dimsProviderOptions(
+  let providerOpts = dimsProviderOptions(
     recipe.implementation,
     modelId,
     effectiveDims,
     opts?.inputType,
   );
+  // user_provided_models recipes (llama-server, litellm) return undefined from
+  // dimsProviderOptions because their model IDs are unknown at library build time.
+  // If the brain was configured with explicit embedding_dimensions, send the
+  // `dimensions` param so the endpoint returns the right vector width.
+  if (!providerOpts && (recipe.touchpoints?.embedding as any)?.user_provided_models === true) {
+    providerOpts = { openaiCompatible: { dimensions: effectiveDims } };
+  }
   const expected = effectiveDims;
 
   const embedding = recipe.touchpoints?.embedding;

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -383,9 +383,14 @@ function validateDimAgainstTouchpoint(
 
   if (requestedDims !== undefined && requestedDims !== defaultDims) {
     // User asked for a non-default dim. Walk the precedence chain.
-    const customDimOk = isCustomDimValidForProvider(recipe, modelId, requestedDims, dimsOptions);
-    if (!customDimOk.valid) {
-      return { ok: false, error: customDimOk.error };
+    // Exception: user_provided_models recipes (llama-server, litellm) use
+    // default_dims=0 as a sentinel meaning "no default — user must supply".
+    // Any positive dim is valid; the model emits whatever size it was loaded with.
+    if (defaultDims !== 0) {
+      const customDimOk = isCustomDimValidForProvider(recipe, modelId, requestedDims, dimsOptions);
+      if (!customDimOk.valid) {
+        return { ok: false, error: customDimOk.error };
+      }
     }
   }
 

--- a/test/embedding-dim-check.test.ts
+++ b/test/embedding-dim-check.test.ts
@@ -273,6 +273,49 @@ describe('resolveSchemaEmbeddingDim', () => {
       expect(got.model).toBe('openai:text-embedding-3-large');
     }
   });
+
+  // user_provided_models recipes (llama-server, litellm): default_dims=0 is a
+  // sentinel meaning "user must supply". Any positive integer dim is valid
+  // because the model emits whatever size it was launched with. Bug: the
+  // Matryoshka allow-list check ran even when defaultDims===0, rejecting any
+  // dim that wasn't in the (empty) declared dims_options list.
+  test('llama-server accepts any positive dim (user_provided_models sentinel fix)', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:mlx-community/Qwen3-Embedding-8B-4bit-DWQ',
+      embedding_dimensions: 2048,
+    });
+    expect(got.ok).toBe(true);
+    if (got.ok) {
+      expect(got.dim).toBe(2048);
+      expect(got.provider).toBe('llama-server');
+    }
+  });
+
+  test('llama-server also accepts native output dims (e.g. 4096)', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:some-local-model',
+      embedding_dimensions: 4096,
+    });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(4096);
+  });
+
+  test('llama-server still rejects non-positive dims', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:some-local-model',
+      embedding_dimensions: 0,
+    });
+    expect(got.ok).toBe(false);
+  });
+
+  test('llama-server without explicit dimensions rejects (default_dims=0 means no implicit default)', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:some-local-model',
+    });
+    // default_dims=0 fails the positive-integer check — user must supply dims
+    expect(got.ok).toBe(false);
+    if (!got.ok) expect(got.error).toMatch(/positive integer/);
+  });
 });
 
 describe('resolveSchemaMultimodalDim', () => {


### PR DESCRIPTION
## Problem

Three independent bugs made `llama-server:` and `litellm:` recipes completely
unusable for the `--embedding-model` flag with a custom model name and explicit
`--embedding-dimensions`. Hitting all three in sequence was required to successfully
run `gbrain init --embedding-model llama-server:<id> --embedding-dimensions N`.

## Root causes

**Bug 1 — `embedding-dim-check.ts`: Matryoshka allow-list rejects all user-supplied dims**

`validateDimAgainstTouchpoint` has a guard for custom dimensions that walks the
recipe's `dims_options` list. `user_provided_models` recipes set `default_dims=0` as
a sentinel meaning "no default — user must supply any positive integer." The guard
didn't check for the sentinel, so every user-supplied dimension was rejected as
"does not appear in declared dims_options."

Fix: skip the allow-list check when `defaultDims === 0`.

**Bug 2 — `gateway.ts` `diagnoseEmbedding`: fires "model unset" error even when model IS set**

`diagnoseEmbedding` has a check intended to catch the case where the user forgot to
pass a model name to a `user_provided_models` recipe. The check fired whenever
`models: []` and `isUserProvided` were both true — it didn't verify that `parsed.modelId`
was actually absent. Users who passed a fully-specified model (e.g.
`llama-server:mlx-community/Qwen3-Embedding-8B-4bit-DWQ`) got the "model unset" error.

Fix: add `&& !parsed.modelId` to the guard condition.

**Bug 3 — `gateway.ts` embed: `dimensions` param not sent to the endpoint**

`dimsProviderOptions` returns `undefined` for model IDs it doesn't recognize (i.e.,
any user-supplied model name for a `user_provided_models` recipe). When it returns
`undefined`, the `dimensions` field is not injected into the embedding request body.
For models where native output size differs from the configured schema width — for
example, a 4096-dim model being used at 2048 dims via MRL truncation — the endpoint
returns full-size vectors and the insert fails with a dimension mismatch.

Fix: when `dimsProviderOptions` returns `undefined` and the recipe has
`user_provided_models: true`, inject `{ openaiCompatible: { dimensions: effectiveDims } }`.

## Tests

Adds four regression tests to `test/embedding-dim-check.test.ts` covering Bug 1:
the llama-server recipe's `default_dims=0` sentinel path (any positive dim accepted,
zero/missing dims still rejected correctly). All 30 tests in that file pass.

Existing gateway tests (`test/ai/gateway.test.ts`, `test/gateway-embed-model-override.test.ts`)
pass unchanged. TypeScript typecheck clean. Privacy, jsonb, and test-isolation checks pass.

## Scope

These bugs are not specific to any particular embedding model. They affect any user
of `llama-server:` or `litellm:` recipes who specifies a model name and explicit
embedding dimensions. The fixes are confined to the validation and gateway code paths
for `user_provided_models` recipes and have no effect on standard provider recipes.

---

## Commits

1. `9d8526d` — fix: user_provided_models recipes (llama-server/litellm) unusable end-to-end
2. `6f35a91` — test: regression coverage for user_provided_models dim validation (Bug 1)

## Files changed

- `src/core/embedding-dim-check.ts` — Bug 1 fix
- `src/core/ai/gateway.ts` — Bug 2 + Bug 3 fixes
- `test/embedding-dim-check.test.ts` — 4 new regression tests