### PR TITLE
fix(lint): content-sanity probe clobbers the cycle's DB singleton, killing extract

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -312,7 +312,16 @@ async function resolveLintContentSanity(): Promise<LintContentOpts['contentSanit
         database_path: base!.database_path,
       });
       try {
-        await engine.connect({});
+        // poolSize forces an INSTANCE-style connection (own _sql pool) instead
+        // of the module singleton. Without it, connect({}) reuses the shared
+        // module-level connection and the disconnect() below falls through to
+        // db.disconnect(), clobbering the cycle's connection — which made the
+        // later extract phase fail with "connect() has not been called".
+        await engine.connect({
+          database_url: base!.database_url,
+          database_path: base!.database_path,
+          poolSize: 1,
+        });
         const lifted = await loadConfigWithEngine(engine, base);
         cs = lifted?.content_sanity ?? cs;
       } finally {


### PR DESCRIPTION
## Summary

The lint phase's content-sanity probe disconnects the **shared module DB singleton**, so every later phase in the autopilot/dream cycle — notably `extract` — fails with `No database connection: connect() has not been called`. Link/timeline writes are silently dropped, `cycle_freshness` stalls, and `doctor` health drops.

## Root cause

`resolveLintContentSanity()` (`src/commands/lint.ts`) opens a short-lived probe engine to lift the DB-plane `content_sanity` config, then disconnects it in a `finally`:

```ts
const engine = await createEngine({ ... });
try {
  await engine.connect({});        // poolSize unset
  ...
} finally {
  await engine.disconnect()...     // tears down the singleton
}
```

Per `src/core/postgres-engine.ts`, `connect()` with **`poolSize` unset** takes the *"module-level singleton (backward compat)"* path (`db.connect`) instead of building an instance `_sql` pool. So the `finally`'s `disconnect()` routes to `db.disconnect()` and tears down the **shared** connection.

`lint` runs first in the autopilot/dream cycle, so it kills the connection the rest of the cycle depends on. `extract` (run later) then can't write — exactly the hazard the `_connectionStyle` doc-comment in `postgres-engine.ts` already warns about:

> Without this, a second `disconnect()` on an instance-pool engine would fall through to `db.disconnect()` and clobber the unrelated module-level connection.

## Fix

Pass `{ database_url, database_path, poolSize: 1 }` so the probe gets its **own** instance `_sql` pool (`_connectionStyle='instance'`). Its `disconnect()` closes only that pool; the module singleton survives for `extract`.

This mirrors the existing precedent in `src/core/brain-registry.ts`, which already passes `poolSize` to force the instance pool for the same reason ("so it doesn't clobber the singleton").

## Impact / validation

- One call site, lint-only, best-effort probe path. No behavior change when no brain is configured (CI lint still falls through file/env).
- Running in production on a Supabase-backed brain (v0.41.x autopilot): `extract` errors **0** across many cycles, `cycle_freshness` OK, `doctor` health restored. Pre-patch the extract phase failed every cycle.