### PR TITLE
fix(autopilot): translate positional subcommands (closes #1525)

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -147,7 +147,11 @@ const AUTOPILOT_POSITIONAL_ALIASES: Record<string, string | null> = {
 
 export type PositionalTranslation =
   | { ok: true; args: string[] }
-  | { ok: false; error: string };
+  | {
+      ok: false;
+      reason: 'unknown_subcommand' | 'multiple_subcommands';
+      message: string;
+    };
 
 export function translatePositionalSubcommands(args: string[]): PositionalTranslation {
   const out: string[] = [];
@@ -178,7 +182,8 @@ export function translatePositionalSubcommands(args: string[]): PositionalTransl
       const known = Object.keys(AUTOPILOT_POSITIONAL_ALIASES).join(', ');
       return {
         ok: false,
-        error: `Multiple subcommands given. Use only one of: ${known}.`,
+        reason: 'multiple_subcommands',
+        message: `Multiple subcommands given. Use only one of: ${known}.`,
       };
     }
     positionalSeen = true;
@@ -191,7 +196,8 @@ export function translatePositionalSubcommands(args: string[]): PositionalTransl
     const known = Object.keys(AUTOPILOT_POSITIONAL_ALIASES).join(', ');
     return {
       ok: false,
-      error:
+      reason: 'unknown_subcommand',
+      message:
         `Unknown subcommand: \`${a}\`.\n` +
         `Allowed subcommands: ${known}.\n` +
         `Or use the flag form: --status, --install, --uninstall.\n` +
@@ -226,7 +232,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
   // the daemon.
   const translated = translatePositionalSubcommands(args);
   if (!translated.ok) {
-    console.error(translated.error);
+    console.error(translated.message);
     process.exit(2);
   }
   args = translated.args;

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -116,6 +116,91 @@ export function shouldSpawnAutopilotWorker(args: string[]): boolean {
   return !args.includes('--no-worker');
 }
 
+/**
+ * v0.41.x #1525 — positional subcommand translation.
+ *
+ * Pre-fix, `gbrain autopilot status` silently fell through to "start daemon"
+ * because `runAutopilot()` only branched on flag forms (`--status`, etc.).
+ * `status` was treated as a stray positional and ignored.
+ *
+ * This translator maps known positional subcommands to their flag form so
+ * `autopilot status` is equivalent to `autopilot --status`, then rejects
+ * any unrecognized positional with a fail-loud error before any side
+ * effect (lockfile, daemon spawn, sync dispatch) runs.
+ *
+ * Scope decisions:
+ *   - Known aliases: `status` → `--status`, `install` → `--install`,
+ *     `uninstall` → `--uninstall`, `start` → (drop; default daemon launch).
+ *   - `stop` is intentionally NOT aliased here. Stopping a running daemon
+ *     is a new behavior (read PID from lock, SIGTERM, drain) that deserves
+ *     its own design and PR. Users typing `gbrain autopilot stop` today get
+ *     the unknown-positional error with the canonical alternatives.
+ *   - At most one positional allowed; multiple positionals fail loud.
+ */
+const AUTOPILOT_VALUE_FLAGS = new Set(['--repo', '--interval']);
+const AUTOPILOT_POSITIONAL_ALIASES: Record<string, string | null> = {
+  status: '--status',
+  install: '--install',
+  uninstall: '--uninstall',
+  start: null, // drop the positional; default behavior is daemon launch
+};
+
+export type PositionalTranslation =
+  | { ok: true; args: string[] }
+  | { ok: false; error: string };
+
+export function translatePositionalSubcommands(args: string[]): PositionalTranslation {
+  const out: string[] = [];
+  let positionalSeen = false;
+  let i = 0;
+  while (i < args.length) {
+    const a = args[i];
+    if (AUTOPILOT_VALUE_FLAGS.has(a)) {
+      // Pass through the flag and its value untouched. If the value is
+      // missing at end-of-argv, fall through so the existing parseArg
+      // path can report the broken usage.
+      out.push(a);
+      if (i + 1 < args.length) {
+        out.push(args[i + 1]);
+        i += 2;
+      } else {
+        i += 1;
+      }
+      continue;
+    }
+    if (a.startsWith('-')) {
+      out.push(a);
+      i += 1;
+      continue;
+    }
+    // Positional subcommand.
+    if (positionalSeen) {
+      const known = Object.keys(AUTOPILOT_POSITIONAL_ALIASES).join(', ');
+      return {
+        ok: false,
+        error: `Multiple subcommands given. Use only one of: ${known}.`,
+      };
+    }
+    positionalSeen = true;
+    if (a in AUTOPILOT_POSITIONAL_ALIASES) {
+      const alias = AUTOPILOT_POSITIONAL_ALIASES[a];
+      if (alias) out.push(alias);
+      i += 1;
+      continue;
+    }
+    const known = Object.keys(AUTOPILOT_POSITIONAL_ALIASES).join(', ');
+    return {
+      ok: false,
+      error:
+        `Unknown subcommand: \`${a}\`.\n` +
+        `Allowed subcommands: ${known}.\n` +
+        `Or use the flag form: --status, --install, --uninstall.\n` +
+        `Run \`gbrain autopilot --help\` for full usage.`,
+    };
+  }
+  return { ok: true, args: out };
+}
+
 export async function runAutopilot(engine: BrainEngine, args: string[]) {
   if (args.includes('--help') || args.includes('-h')) {
     console.log(
@@ -123,12 +208,28 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
       '       gbrain autopilot --install [--repo <path>]\n' +
       '       gbrain autopilot --uninstall\n' +
       '       gbrain autopilot --status [--json]\n\n' +
+      'Subcommand aliases:\n' +
+      '       gbrain autopilot status     → --status\n' +
+      '       gbrain autopilot install    → --install\n' +
+      '       gbrain autopilot uninstall  → --uninstall\n' +
+      '       gbrain autopilot start      → (default daemon launch)\n\n' +
       'Self-maintaining brain daemon. Runs the full maintenance cycle\n' +
       '(lint + backlinks + sync + extract + embed + orphans) on an interval.\n\n' +
       'For a one-shot cron-triggered cycle, see `gbrain dream`.',
     );
     return;
   }
+
+  // v0.41.x #1525: translate positional subcommands to their flag form
+  // BEFORE any side effect (lockfile, daemon spawn, sync dispatch).
+  // Unknown positionals fail loud here rather than silently starting
+  // the daemon.
+  const translated = translatePositionalSubcommands(args);
+  if (!translated.ok) {
+    console.error(translated.error);
+    process.exit(2);
+  }
+  args = translated.args;
 
   if (args.includes('--install')) {
     await installDaemon(engine, args);

--- a/test/autopilot-positional-subcommands.test.ts
+++ b/test/autopilot-positional-subcommands.test.ts
@@ -110,59 +110,74 @@ describe('translatePositionalSubcommands — pass-through cases', () => {
 });
 
 describe('translatePositionalSubcommands — rejection of unknown positionals', () => {
-  test('unknown positional `foo` fails with structured error', () => {
+  test('unknown positional `foo` fails with reason=unknown_subcommand + structured message', () => {
     const r = translatePositionalSubcommands(['foo']);
     expect(r.ok).toBe(false);
     if (!r.ok) {
-      expect(r.error).toContain('Unknown subcommand: `foo`');
-      expect(r.error).toContain('status');
-      expect(r.error).toContain('install');
-      expect(r.error).toContain('uninstall');
-      expect(r.error).toContain('--help');
+      expect(r.reason).toBe('unknown_subcommand');
+      expect(r.message).toContain('Unknown subcommand: `foo`');
+      expect(r.message).toContain('status');
+      expect(r.message).toContain('install');
+      expect(r.message).toContain('uninstall');
+      expect(r.message).toContain('--help');
     }
   });
 
-  test('unknown positional `stop` fails with structured error (NOT silently aliased)', () => {
+  test('unknown positional `stop` fails with reason=unknown_subcommand (NOT silently aliased)', () => {
     // Stop is mentioned in the ticket but deliberately NOT aliased in this
     // PR — stopping a running daemon is a new behavior, not just an alias.
     // Until that feature lands separately, `stop` must fail loud rather
     // than starting the daemon (the bug we're fixing).
     const r = translatePositionalSubcommands(['stop']);
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.error).toContain('Unknown subcommand: `stop`');
+    if (!r.ok) {
+      expect(r.reason).toBe('unknown_subcommand');
+      expect(r.message).toContain('Unknown subcommand: `stop`');
+    }
   });
 
   test('unknown positional `status-detail` (close-but-not-matching) fails', () => {
     const r = translatePositionalSubcommands(['status-detail']);
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.error).toContain('Unknown subcommand: `status-detail`');
+    if (!r.ok) {
+      expect(r.reason).toBe('unknown_subcommand');
+      expect(r.message).toContain('Unknown subcommand: `status-detail`');
+    }
   });
 
-  test('multiple positionals fail loud (`start install`)', () => {
+  test('multiple positionals fail with reason=multiple_subcommands (`start install`)', () => {
     const r = translatePositionalSubcommands(['start', 'install']);
     expect(r.ok).toBe(false);
     if (!r.ok) {
-      expect(r.error).toContain('Multiple subcommands');
+      expect(r.reason).toBe('multiple_subcommands');
+      expect(r.message).toContain('Multiple subcommands');
     }
   });
 
   test('multiple positionals fail even when both are known aliases (`status install`)', () => {
     const r = translatePositionalSubcommands(['status', 'install']);
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.error).toContain('Multiple subcommands');
+    if (!r.ok) {
+      expect(r.reason).toBe('multiple_subcommands');
+      expect(r.message).toContain('Multiple subcommands');
+    }
   });
 
-  test('positional + unknown positional still rejects on the unknown', () => {
+  test('known-then-unknown rejects with multiple_subcommands (first-positional-wins)', () => {
     // First positional is known, second is not. Rejection comes from the
     // multiple-positional rule, which fires before the unknown check; the
     // intent is "only one subcommand allowed."
     const r = translatePositionalSubcommands(['status', 'garbage']);
     expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('multiple_subcommands');
   });
 
-  test('unknown positional before known positional rejects on unknown', () => {
+  test('unknown-then-known rejects on the unknown (unknown fires before second-positional check)', () => {
     const r = translatePositionalSubcommands(['garbage', 'status']);
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.error).toContain('garbage');
+    if (!r.ok) {
+      expect(r.reason).toBe('unknown_subcommand');
+      expect(r.message).toContain('garbage');
+    }
   });
 });

--- a/test/autopilot-positional-subcommands.test.ts
+++ b/test/autopilot-positional-subcommands.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for translatePositionalSubcommands() — the v0.41.x #1525 fix that
+ * prevents `gbrain autopilot status` from silently starting the daemon.
+ *
+ * IRON RULE regression guard: the exact ticket repro (`gbrain autopilot
+ * status`) MUST translate to `--status`, not fall through to the default
+ * daemon launch. Verified by the "ticket-exact repro" case below.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { translatePositionalSubcommands } from '../src/commands/autopilot.ts';
+
+describe('translatePositionalSubcommands — known aliases', () => {
+  test('IRON RULE — `autopilot status` translates to `--status` (ticket #1525 repro)', () => {
+    const r = translatePositionalSubcommands(['status']);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(['--status']);
+  });
+
+  test('`install` translates to `--install`', () => {
+    const r = translatePositionalSubcommands(['install']);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(['--install']);
+  });
+
+  test('`uninstall` translates to `--uninstall`', () => {
+    const r = translatePositionalSubcommands(['uninstall']);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(['--uninstall']);
+  });
+
+  test('`start` drops the positional (default daemon launch)', () => {
+    const r = translatePositionalSubcommands(['start']);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual([]);
+  });
+
+  test('`start --json` drops only the positional, keeps the flag', () => {
+    const r = translatePositionalSubcommands(['start', '--json']);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(['--json']);
+  });
+});
+
+describe('translatePositionalSubcommands — flag/positional interleaving', () => {
+  test('`status --json` preserves the trailing flag', () => {
+    const r = translatePositionalSubcommands(['status', '--json']);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(['--status', '--json']);
+  });
+
+  test('`--json status` preserves the leading flag', () => {
+    const r = translatePositionalSubcommands(['--json', 'status']);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(['--json', '--status']);
+  });
+
+  test('`--repo /foo status` does not mis-classify the path as positional', () => {
+    const r = translatePositionalSubcommands(['--repo', '/foo', 'status']);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(['--repo', '/foo', '--status']);
+  });
+
+  test('`--interval 300 install` does not mis-classify the number as positional', () => {
+    const r = translatePositionalSubcommands(['--interval', '300', 'install']);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(['--interval', '300', '--install']);
+  });
+
+  test('value-flag at end of argv with missing value passes through (so parseArg can report it)', () => {
+    const r = translatePositionalSubcommands(['--repo']);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(['--repo']);
+  });
+
+  test('value-flag whose value looks like an alias is NOT translated', () => {
+    // `--repo status` means "use repo path 'status'", not "show status".
+    // Translator must not destructure the value of --repo.
+    const r = translatePositionalSubcommands(['--repo', 'status']);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(['--repo', 'status']);
+  });
+});
+
+describe('translatePositionalSubcommands — pass-through cases', () => {
+  test('empty args returns empty args', () => {
+    const r = translatePositionalSubcommands([]);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual([]);
+  });
+
+  test('flag-only invocation passes through unchanged', () => {
+    const r = translatePositionalSubcommands(['--status', '--json']);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(['--status', '--json']);
+  });
+
+  test('short flag `-h` passes through unchanged', () => {
+    const r = translatePositionalSubcommands(['-h']);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(['-h']);
+  });
+
+  test('all known bare flags pass through unchanged', () => {
+    const flags = ['--help', '--install', '--uninstall', '--status', '--json', '--inline', '--no-worker'];
+    const r = translatePositionalSubcommands(flags);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.args).toEqual(flags);
+  });
+});
+
+describe('translatePositionalSubcommands — rejection of unknown positionals', () => {
+  test('unknown positional `foo` fails with structured error', () => {
+    const r = translatePositionalSubcommands(['foo']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toContain('Unknown subcommand: `foo`');
+      expect(r.error).toContain('status');
+      expect(r.error).toContain('install');
+      expect(r.error).toContain('uninstall');
+      expect(r.error).toContain('--help');
+    }
+  });
+
+  test('unknown positional `stop` fails with structured error (NOT silently aliased)', () => {
+    // Stop is mentioned in the ticket but deliberately NOT aliased in this
+    // PR — stopping a running daemon is a new behavior, not just an alias.
+    // Until that feature lands separately, `stop` must fail loud rather
+    // than starting the daemon (the bug we're fixing).
+    const r = translatePositionalSubcommands(['stop']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('Unknown subcommand: `stop`');
+  });
+
+  test('unknown positional `status-detail` (close-but-not-matching) fails', () => {
+    const r = translatePositionalSubcommands(['status-detail']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('Unknown subcommand: `status-detail`');
+  });
+
+  test('multiple positionals fail loud (`start install`)', () => {
+    const r = translatePositionalSubcommands(['start', 'install']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toContain('Multiple subcommands');
+    }
+  });
+
+  test('multiple positionals fail even when both are known aliases (`status install`)', () => {
+    const r = translatePositionalSubcommands(['status', 'install']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('Multiple subcommands');
+  });
+
+  test('positional + unknown positional still rejects on the unknown', () => {
+    // First positional is known, second is not. Rejection comes from the
+    // multiple-positional rule, which fires before the unknown check; the
+    // intent is "only one subcommand allowed."
+    const r = translatePositionalSubcommands(['status', 'garbage']);
+    expect(r.ok).toBe(false);
+  });
+
+  test('unknown positional before known positional rejects on unknown', () => {
+    const r = translatePositionalSubcommands(['garbage', 'status']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('garbage');
+  });
+});


### PR DESCRIPTION
## Summary

- `gbrain autopilot status` silently started the daemon instead of reporting status. `runAutopilot()` only branched on flag forms, so positionals fell through to the default "start daemon" path.
- This PR adds a pure `translatePositionalSubcommands()` function that runs before any side effect (lockfile, daemon spawn, sync dispatch). Known positionals (`status`, `install`, `uninstall`, `start`) translate to their flag equivalents; unknown positionals fail loud with a structured error.
- Closes #1525.

## What's in the patch

`src/commands/autopilot.ts`:
- New exported pure function `translatePositionalSubcommands(args)` returning a discriminated `{ ok: true, args } | { ok: false, error }` so it's trivially testable without IO.
- Value-flag aware: `--repo /foo status` correctly treats `/foo` as the repo path and `status` as the positional, not vice versa. `--repo status` (literal path) passes through unchanged.
- Wired in `runAutopilot` right after the `--help` short-circuit and BEFORE the lockfile/daemon paths, so the fix-loud rejection happens before any side effect.
- `--help` text gains a "Subcommand aliases" block so the canonical flag forms are discoverable from the CLI itself, not just JSDoc.

`test/autopilot-positional-subcommands.test.ts` (new, 22 cases):
- Pure-function tests, no env mutation, no `mock.module` — passes `check-test-isolation.sh`.
- Iron-rule regression guard: first case is the exact ticket repro (`['status']` -> `['--status']`).

## Scope notes

- **`stop` is intentionally NOT aliased.** The ticket lists it as a potential alias, but stopping a running daemon is a new behavior (read PID from lock, send SIGTERM, await drain) that deserves its own design pass. Users typing `gbrain autopilot stop` today get the unknown-positional error rather than the silent daemon-start. Happy to land `stop` as a separate PR if there's interest.
- **Deprecation hints not added.** The ticket suggests a hint when positional form is used; I left it off because it's unclear whether the maintainer wants the positional form to eventually go away or stay supported indefinitely (consistent with modern CLI grammar). Easy to add in review if desired.
- **`--repo VALUE` and `--interval VALUE` only.** Those are the only value-flags in this command. Other autopilot flags are bare. If a future flag needs a value, add it to the `AUTOPILOT_VALUE_FLAGS` set.

## Test plan

- [x] `bun test test/autopilot-positional-subcommands.test.ts` — 22/22 pass
- [x] `bun test test/autopilot-*.test.ts` — all 109 existing autopilot tests pass (no regression)
- [x] `bun run typecheck` — clean
- [x] `bash scripts/check-test-isolation.sh` — clean (file passes R1/R2/R3/R4 isolation rules)
- [x] `bash scripts/check-jsonb-pattern.sh` — clean
- [x] `bash scripts/check-progress-to-stdout.sh` — clean
- [ ] Manual repro of the original bug pre-fix and post-fix:
  - `gbrain autopilot status` pre-fix → starts daemon (the ticket's bug)
  - `gbrain autopilot status` post-fix → routes to `showStatus()`, prints state, returns
- [ ] Manual `gbrain autopilot stop` post-fix → fails loud with "Unknown subcommand: \`stop\`" + list of allowed subcommands (does NOT start the daemon)

## Related

- Companion data-loss issue: #1526 (independent fix; targeting a separate PR after this one lands so each fix gets its own clean review surface).
- Family parent: #578 (partially fixed by #634 for the `--help` surface; this PR closes the unknown-positional surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)