### PR TITLE
fix(migrations): run stale schema migrations from apply-migrations

### DIFF
--- a/src/commands/apply-migrations.ts
+++ b/src/commands/apply-migrations.ts
@@ -354,17 +354,19 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
     if (cli.forceAll) return; // both surfaces flushed
   }
 
-  // Pre-flight: warn if schema migrations (migrate.ts) are behind.
-  // apply-migrations runs orchestrator migrations only; schema migrations
-  // run via connectEngine() / initSchema(). Users often expect this CLI
-  // to handle everything (Issue 1 from v0.18.0 field report).
+  // Pre-flight: handle core schema migrations (migrate.ts) before the
+  // orchestrator-migration plan. Users run `apply-migrations --yes` during
+  // upgrades expecting one command to land both surfaces; warning and then
+  // printing "All migrations up to date" when only schema is stale is a
+  // misleading success signal (#1530).
+  let appliedSchemaMigrations = 0;
   try {
-    const { LATEST_VERSION } = await import('../core/migrate.ts');
+    const { LATEST_VERSION, runMigrations } = await import('../core/migrate.ts');
     const { loadConfig: lc, toEngineConfig } = await import('../core/config.ts');
     const { createEngine } = await import('../core/engine-factory.ts');
     const cfg = lc();
     if (cfg) {
-      // v0.36.x #1100: skip the pre-flight warning on PGLite. The probe
+      // v0.36.x #1100: skip the pre-flight probe on PGLite. The probe
       // briefly holds the single-writer lock; if a downstream orchestrator
       // phase spawns `gbrain init --migrate-only` as a subprocess (the
       // legacy v0.11.0 phase A path), the child can race the parent's
@@ -373,23 +375,33 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
       // so the warning here adds no information for PGLite users.
       const skipPreflight = cfg.engine === 'pglite';
       if (!skipPreflight) {
-        const eng = await createEngine(toEngineConfig(cfg));
-        await eng.connect(toEngineConfig(cfg));
-        const verStr = await eng.getConfig('version');
-        const schemaVer = parseInt(verStr || '1', 10);
-        await eng.disconnect();
-        if (schemaVer < LATEST_VERSION) {
-          console.warn(
-            `\n⚠️  Schema version ${schemaVer} is behind latest ${LATEST_VERSION}.\n` +
-            `   Schema migrations run automatically on next connectEngine() / initSchema().\n` +
-            `   To run them now: gbrain init --migrate-only\n`,
-          );
+        const engineConfig = toEngineConfig(cfg);
+        const eng = await createEngine(engineConfig);
+        try {
+          await eng.connect(engineConfig);
+          const verStr = await eng.getConfig('version');
+          const schemaVer = parseInt(verStr || '1', 10);
+          if (schemaVer < LATEST_VERSION) {
+            if (cli.list || cli.dryRun) {
+              console.warn(
+                `\n⚠️  Schema version ${schemaVer} is behind latest ${LATEST_VERSION}.\n` +
+                `   Would run schema migrations before applying orchestrator migrations.\n`,
+              );
+            } else {
+              console.warn(`\n⚠️  Schema version ${schemaVer} is behind latest ${LATEST_VERSION}. Running schema migrations now...`);
+              const result = await runMigrations(eng);
+              appliedSchemaMigrations = result.applied;
+              console.log(`Applied ${result.applied} schema migration(s); now at v${result.current}.`);
+            }
+          }
+        } finally {
+          await eng.disconnect().catch(() => undefined);
         }
       }
     }
-  } catch {
-    // Non-fatal: if DB is unreachable, orchestrator migrations can still
-    // run their filesystem-only phases.
+  } catch (err) {
+    console.warn(`Schema migration pre-flight failed: ${(err as Error).message}`);
+    console.warn('Continuing with orchestrator migrations only. Re-run `gbrain apply-migrations --force-schema --yes` if schema remains behind.');
   }
 
   const completed = loadCompletedMigrations();
@@ -419,7 +431,11 @@ export async function runApplyMigrations(args: string[]): Promise<void> {
 
   const toRun: Migration[] = [...plan.partial, ...plan.pending];
   if (toRun.length === 0) {
-    console.log('All migrations up to date.');
+    if (appliedSchemaMigrations > 0) {
+      console.log('Schema migrations applied; orchestrator migrations up to date.');
+    } else {
+      console.log('All migrations up to date.');
+    }
     process.exit(0);
   }
 

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -1204,17 +1204,20 @@ describe('PR #356 — 57014 catch path emits actionable 4-part diagnostic', () =
   });
 });
 
-describe('PR #356 — apply-migrations pre-flight schema-version warning', () => {
-  test('source contains the pre-flight check branch before plan execution', () => {
+describe('PR #356 / #1530 — apply-migrations schema pre-flight', () => {
+  test('source runs schema migrations when stale instead of only warning', () => {
     // Structural check: the pre-flight block compares the engine's
-    // reported schema version against LATEST_VERSION and warns if
-    // behind. If someone removes this branch, users who run
-    // apply-migrations expecting it to handle schema migrations get
-    // the silent-gaslight experience from the field report.
+    // reported schema version against LATEST_VERSION and, for non-dry-run
+    // Postgres installs, calls runMigrations before reporting the
+    // orchestrator plan. This prevents the field bug where
+    // `apply-migrations --yes` printed both "schema behind" and
+    // "All migrations up to date" without landing core schema migrations.
     const source = readFileSync(resolve('src/commands/apply-migrations.ts'), 'utf-8');
     expect(source).toContain('LATEST_VERSION');
-    expect(source).toContain('Schema version');
-    expect(source).toContain('is behind latest');
+    expect(source).toContain('runMigrations');
+    expect(source).toContain('Running schema migrations now');
+    expect(source).toContain('Schema migrations applied; orchestrator migrations up to date.');
+    expect(source).toContain('Would run schema migrations');
   });
 });
 


### PR DESCRIPTION
## Summary
- run core schema migrations from `gbrain apply-migrations` when the non-PGLite pre-flight detects schema drift
- keep `--dry-run` and `--list` read-only by reporting that schema migrations would run
- avoid the misleading success path where the command says schema is behind and then prints `All migrations up to date`

## Why
In production on a Supabase/PgBouncer-backed brain, upgrading from v0.40.5.0 to v0.41.18.0 left `brain_config.version` at 92 while `LATEST_VERSION` was 103.

`gbrain apply-migrations --yes --non-interactive` printed a schema-behind warning but did not run the schema migrations; because the orchestrator ledger was already complete, it then printed `All migrations up to date` and exited 0. Running `gbrain apply-migrations --force-schema --yes --non-interactive` applied v93-v103.

That made the normal upgrade command look successful while schema was still stale.

## Test plan
- `bun run typecheck`
- `bun test test/migrate.test.ts --test-name-pattern 'apply-migrations schema pre-flight'`
- `bun test test/migrate.test.ts`

Closes #1530
