### PR TITLE
feat(extract): add source: 'db' to runExtractCore + CycleOpts.extractSource

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -371,6 +371,22 @@ export interface ExtractOpts {
    * own pagination and stay serial in v0.41.15.0.
    */
   workers?: number;
+  /**
+   * Where to read pages from. Defaults to 'fs' for back-compat — every
+   * pre-existing caller of `runExtractCore` walks the filesystem.
+   *
+   * When set to 'db', dispatches to `extractLinksFromDB` /
+   * `extractTimelineFromDB` (the same path the CLI's `--source db` flag
+   * uses today). Required for brains whose pages live only in Postgres
+   * (e.g. the autopilot extract phase on a remote-DB brain where the
+   * checked-out repo has no matching .md files — that phase has been
+   * silently no-op'ing on DB-backed brains).
+   *
+   * The 'db' path ignores `opts.dir`, `opts.slugs`, and `opts.workers`
+   * (DB pagination is engine-side and serial); only `mode`, `dryRun`,
+   * and `jsonMode` are honored.
+   */
+  source?: 'fs' | 'db';
 }
 
 /**
@@ -383,13 +399,36 @@ export async function runExtractCore(engine: BrainEngine, opts: ExtractOpts): Pr
   if (!['links', 'timeline', 'all'].includes(opts.mode)) {
     throw new Error(`Invalid extract mode "${opts.mode}". Allowed: links, timeline, all.`);
   }
-  if (!existsSync(opts.dir)) {
+  const source: 'fs' | 'db' = opts.source ?? 'fs';
+  if (source !== 'fs' && source !== 'db') {
+    throw new Error(`Invalid extract source "${source}". Allowed: fs, db.`);
+  }
+  // FS source needs a real directory; DB source ignores opts.dir entirely.
+  if (source === 'fs' && !existsSync(opts.dir)) {
     throw new Error(`Directory not found: ${opts.dir}`);
   }
 
   const dryRun = !!opts.dryRun;
   const jsonMode = !!opts.jsonMode;
   const result: ExtractResult = { links_created: 0, timeline_entries_created: 0, pages_processed: 0 };
+
+  // DB source path: walk pages from the engine instead of the filesystem.
+  // Mirrors what `runExtract`'s CLI wrapper does for `--source db`, but
+  // exposed at the library level so cycle/autopilot callers can opt in
+  // without going through argv parsing.
+  if (source === 'db') {
+    if (opts.mode === 'links' || opts.mode === 'all') {
+      const r = await extractLinksFromDB(engine, dryRun, jsonMode, undefined, undefined, {});
+      result.links_created = r.created;
+      result.pages_processed = r.pages;
+    }
+    if (opts.mode === 'timeline' || opts.mode === 'all') {
+      const r = await extractTimelineFromDB(engine, dryRun, jsonMode, undefined, undefined, {});
+      result.timeline_entries_created = r.created;
+      result.pages_processed = Math.max(result.pages_processed, r.pages);
+    }
+    return result;
+  }
 
   // v0.41.15.0 (D9): resolve workers via the PGLite-clamp wrapper.
   // Page count unknown at this point — pass 0 so the auto-path falls

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -411,6 +411,17 @@ export interface CycleOpts {
    * Validated via `assertValidSourceId` in `cycleLockIdFor` (defense-in-depth).
    */
   sourceId?: string;
+  /**
+   * Where the extract phase reads pages from. Defaults to 'fs' for
+   * back-compat with every existing caller. Set to 'db' for brains whose
+   * pages live only in Postgres (autopilot on a remote-DB brain where
+   * the local checkout has no .md files matching the page slugs — the
+   * FS path returns 0 links in that case).
+   *
+   * Forwarded verbatim to `runExtractCore({ source })`. Ignored for
+   * any other phase.
+   */
+  extractSource?: 'fs' | 'db';
 }
 
 // ─── Lock primitives ───────────────────────────────────────────────
@@ -810,6 +821,7 @@ async function runPhaseExtract(
   brainDir: string,
   dryRun: boolean,
   changedSlugs?: string[],
+  source?: 'fs' | 'db',
 ): Promise<PhaseResult> {
   try {
     const { runExtractCore } = await import('../commands/extract.ts');
@@ -825,28 +837,34 @@ async function runPhaseExtract(
         details: { dryRun: true, reason: 'no_dry_run_support' },
       };
     }
+    // DB source ignores per-slug incremental hints — engine pagination
+    // already scopes the walk, and the slug list is FS-relative.
+    const resolvedSource = source ?? 'fs';
+    const slugs = resolvedSource === 'db' ? undefined : changedSlugs;
     // Incremental path: if sync told us which slugs changed, only extract those.
     // On a 54K-page brain this turns a 10-minute full walk into a sub-second pass.
     const result = await runExtractCore(engine, {
       mode: 'all',
       dir: brainDir,
-      slugs: changedSlugs,  // undefined = full walk (first run / manual)
+      slugs,  // undefined = full walk (first run / manual / DB source)
+      source: resolvedSource,
     });
     const linksCreated = result?.links_created ?? 0;
     const timelineCreated = result?.timeline_entries_created ?? 0;
-    const incremental = changedSlugs !== undefined;
+    const incremental = slugs !== undefined;
     return {
       phase: 'extract',
       status: 'ok',
       duration_ms: 0,
       summary: incremental
-        ? `${linksCreated} link(s), ${timelineCreated} timeline entries (incremental: ${changedSlugs.length} slugs)`
-        : `${linksCreated} link(s), ${timelineCreated} timeline entries`,
+        ? `${linksCreated} link(s), ${timelineCreated} timeline entries (incremental: ${slugs.length} slugs, source: ${resolvedSource})`
+        : `${linksCreated} link(s), ${timelineCreated} timeline entries (source: ${resolvedSource})`,
       details: {
         linksCreated, timelineCreated,
         pages_processed: result?.pages_processed ?? 0,
         incremental,
-        ...(incremental ? { slugs_targeted: changedSlugs.length } : {}),
+        source: resolvedSource,
+        ...(incremental ? { slugs_targeted: slugs.length } : {}),
       },
     };
   } catch (e) {
@@ -1461,7 +1479,7 @@ export async function runCycle(
         // If sync didn't run (phases exclude it) or failed, syncPagesAffected
         // is undefined → extract falls back to full walk (safe default).
         progress.start('cycle.extract');
-        const { result, duration_ms } = await timePhase(() => runPhaseExtract(engine, opts.brainDir, dryRun, syncPagesAffected));
+        const { result, duration_ms } = await timePhase(() => runPhaseExtract(engine, opts.brainDir, dryRun, syncPagesAffected, opts.extractSource));
         result.duration_ms = duration_ms;
         phaseResults.push(result);
         progress.finish();

--- a/test/extract-source-db-library.test.ts
+++ b/test/extract-source-db-library.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression guards for the DB-source library path on `runExtractCore`.
+ *
+ * Before this change, `runExtractCore` always walked the filesystem — even
+ * though the CLI's `runExtract` wrapper supported `--source db`. That gap
+ * meant the autopilot extract phase silently returned 0 links on brains
+ * whose pages live only in Postgres (the checkout has no matching .md
+ * files for transcript/code/concept slugs that were ingested via
+ * `gbrain import`).
+ *
+ * This file pins the new `source: 'db'` option on `runExtractCore`:
+ *  1. `source: 'db'` extracts wikilinks from compiled_truth in the DB,
+ *     not the filesystem.
+ *  2. `source: 'db'` ignores `opts.dir` (so the autopilot can pass any
+ *     valid path — or none — and the DB walk still works).
+ *  3. `source: 'fs'` and the default both keep the old FS-walk behavior.
+ *  4. Invalid `source` values throw with a clear message.
+ *
+ * All tests use PGLite/in-memory — no DB connection required.
+ */
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { runExtractCore } from '../src/commands/extract.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+let tempDir: string;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ engine: 'pglite' });
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  // tempDir intentionally empty — DB path must not touch it.
+  tempDir = mkdtempSync(join(tmpdir(), 'gbrain-extract-db-test-'));
+});
+
+async function seedPage(slug: string, body: string): Promise<void> {
+  const [type, name] = slug.split('/');
+  await engine.putPage(slug, {
+    type: type as 'person' | 'company',
+    title: name,
+    compiled_truth: body,
+    timeline: '',
+    frontmatter: {},
+    content_hash: 'h-' + slug,
+  });
+}
+
+describe('runExtractCore — source: db library path', () => {
+  test('1. source: db extracts wikilinks from compiled_truth (no FS files)', async () => {
+    await seedPage('people/alice', 'Met [[people/bob]] last week.');
+    await seedPage('people/bob', 'Friend of [[people/alice]].');
+
+    const result = await runExtractCore(engine as unknown as BrainEngine, {
+      mode: 'links',
+      dir: tempDir,         // empty dir — DB path must not require .md files
+      source: 'db',
+    });
+
+    expect(result.links_created).toBeGreaterThanOrEqual(2);
+    expect(result.pages_processed).toBe(2);
+  });
+
+  test('2. default source is fs (back-compat: omit source ⇒ FS walk over empty dir ⇒ 0)', async () => {
+    await seedPage('people/alice', 'Met [[people/bob]] last week.');
+    await seedPage('people/bob', 'Friend of [[people/alice]].');
+
+    // No `source` passed; empty FS dir; pages exist only in DB.
+    const result = await runExtractCore(engine as unknown as BrainEngine, {
+      mode: 'links',
+      dir: tempDir,
+    });
+
+    expect(result.links_created).toBe(0);
+    expect(result.pages_processed).toBe(0);
+  });
+
+  test('3. explicit source: fs matches the default behavior', async () => {
+    await seedPage('people/alice', 'Met [[people/bob]] last week.');
+
+    const result = await runExtractCore(engine as unknown as BrainEngine, {
+      mode: 'links',
+      dir: tempDir,
+      source: 'fs',
+    });
+
+    expect(result.links_created).toBe(0);
+    expect(result.pages_processed).toBe(0);
+  });
+
+  test('4. invalid source value throws', async () => {
+    await expect(
+      runExtractCore(engine as unknown as BrainEngine, {
+        mode: 'links',
+        dir: tempDir,
+        // @ts-expect-error — testing runtime validation of an invalid literal
+        source: 'http',
+      }),
+    ).rejects.toThrow(/Invalid extract source/);
+  });
+
+  test('5. source: db ignores opts.dir entirely (non-existent path still works)', async () => {
+    await seedPage('people/alice', '[[people/bob]]');
+    await seedPage('people/bob', '# bob');
+
+    const result = await runExtractCore(engine as unknown as BrainEngine, {
+      mode: 'links',
+      dir: '/does/not/exist/anywhere',  // would throw under source: 'fs'
+      source: 'db',
+    });
+
+    expect(result.links_created).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// Cleanup empty temp dirs created for the FS-path safety guards.
+afterAll(() => {
+  try { rmSync(tempDir, { recursive: true, force: true }); } catch { /* ok */ }
+});


### PR DESCRIPTION
## Summary

`runCycle → runPhaseExtract → runExtractCore` is hard-wired to the filesystem walker, even though the DB-source helpers (`extractLinksFromDB` / `extractTimelineFromDB`) exist and have been exposed via the CLI's `--source db` flag for several releases.

On a brain whose pages live only in Postgres (e.g. transcripts ingested through `gbrain import`, or a remote-DB brain whose local repo checkout has no `.md` files matching the slugs), the autopilot's extract phase silently returns `0 link(s), 0 timeline entries` every cycle. `link_count` stays at 0 forever, and `brain_score` is capped well below what the brain's content actually supports.

## Changes

- **`ExtractOpts.source?: 'fs' | 'db'`** — default `'fs'`. When `'db'`, `runExtractCore` dispatches to the existing DB helpers (same path `runExtract` CLI takes for `--source db`).
- **`CycleOpts.extractSource?: 'fs' | 'db'`** — threads the choice from `runCycle` → `runPhaseExtract` → `runExtractCore`. Defaults to `undefined` (→ `'fs'`).
- DB source ignores `opts.dir`, `opts.slugs`, and `opts.workers`: DB pagination is engine-side and serial. The validation guard for missing `opts.dir` is now scoped to `source === 'fs'`.
- Phase summary now includes `source: <fs|db>` so cycle reports surface which path ran.

**No default behavior changes.** Every existing caller — CLI, autopilot, jobs handler — continues to walk the filesystem. Callers that want the DB path opt in explicitly via `extractSource: 'db'` on `CycleOpts` or `source: 'db'` on `ExtractOpts`.

## How users would opt in

```ts
// Library:
await runExtractCore(engine, { mode: 'all', dir: brainDir, source: 'db' });

// Cycle:
await runCycle(engine, { brainDir, pull: false, extractSource: 'db' });
```

A future PR can add an env var / `gbrain autopilot --install` flag if it makes sense, but that's deliberately out of scope here — keeping the change surgical.

## Test plan

- [x] 5 new PGLite unit tests in `test/extract-source-db-library.test.ts`:
  1. `source: 'db'` extracts wikilinks from `compiled_truth` with no `.md` files on disk
  2. Default (no `source`) walks FS — empty dir → 0 links (back-compat)
  3. Explicit `source: 'fs'` matches default behavior
  4. Invalid `source` value throws with a clear message
  5. `source: 'db'` ignores `opts.dir` (non-existent path still works)
- [x] All 12 existing tests in `extract-incremental.test.ts` and `extract-source-aware.test.ts` still pass
- [x] `bun test test/extract-source-db-library.test.ts test/extract-incremental.test.ts test/extract-source-aware.test.ts` — green

## Why I hit this

Running gbrain v0.18.2 against a remote Postgres brain on Hetzner. ~2,400 pages (mostly Claude Code + Codex transcripts ingested via `gbrain import`), 100% embed coverage, but `link_count: 0` and `brain_score: 45/100` no matter how many autopilot cycles ran. The autopilot wrapper was correctly invoking `gbrain autopilot --repo <path>` per repo, and the log dutifully reported `Links: created 0 from 9 pages` every cycle — the 9 being README.md / CLAUDE.md / a few plans/*.md in the repo. The 2,400 DB pages were never seen by the extract phase.

Patched locally first (custom `~/.gbrain/auto-link-cycle.sh` that fills the `links` table from the existing code-edge graph, embedding similarity, and tag co-occurrence — got us to brain_score 100/100). But the upstream gap deserves a fix so the next person doesn't have to discover this the hard way.