### PR TITLE
fix: brainstorm/lsd judge truncation + slash-prefix pricing lookup

### DIFF
--- a/src/core/anthropic-pricing.ts
+++ b/src/core/anthropic-pricing.ts
@@ -57,6 +57,12 @@ export function estimateMaxCostUsd(
     const tail = modelId.split(':', 2)[1];
     if (tail) p = ANTHROPIC_PRICING[tail];
   }
+  // v0.37.1: also handle slash-prefixed ids (e.g. "anthropic/claude-sonnet-4-6")
+  // which arrive via --judge-model and other CLI overrides.
+  if (!p && modelId.includes('/')) {
+    const tail = modelId.split('/', 2)[1];
+    if (tail) p = ANTHROPIC_PRICING[tail];
+  }
   if (!p) return null;
   return (
     (estimatedInputTokens / 1_000_000) * p.input +

--- a/src/core/brainstorm/judges.ts
+++ b/src/core/brainstorm/judges.ts
@@ -448,7 +448,11 @@ async function runJudgeChunk(
     // knob isn't on ChatOpts (it's set per-provider in instantiateChat),
     // so we rely on the default. If we ever need temperature control here
     // we'd extend ChatOpts.
-    maxTokens: 4000,
+    // v0.37.1: scale maxTokens with idea count. Each idea produces ~100
+    // tokens of JSON (id, 5 axis scores, one-sentence note). The original
+    // hard-coded 4000 truncated responses for batches of 36+ ideas →
+    // parseJudgeJSON failure. 150 tokens/idea gives comfortable headroom.
+    maxTokens: Math.max(4000, ideas.length * 150 + 500),
     abortSignal: options.abortSignal,
   });
 

--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -181,10 +181,13 @@ function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
     }
     return null;
   }
-  // chat or rerank: try bare key first, then provider:model
+  // chat or rerank: try bare key first, then provider:model or provider/model
   const bare = ANTHROPIC_PRICING[modelId];
   if (bare) return bare;
-  const [providerId, modelTail] = modelId.includes(':') ? modelId.split(':', 2) : [null, modelId];
+  // v0.37.1: handle both colon-separated (anthropic:claude-sonnet-4-6) and
+  // slash-separated (anthropic/claude-sonnet-4-6) provider prefixes.
+  const sep = modelId.includes(':') ? ':' : modelId.includes('/') ? '/' : null;
+  const [providerId, modelTail] = sep ? modelId.split(sep, 2) as [string, string] : [null, modelId];
   if (modelTail) {
     const tailHit = ANTHROPIC_PRICING[modelTail];
     if (tailHit) return tailHit;


### PR DESCRIPTION
Two bugs causing `judge_failed` on every brainstorm/lsd run:

### Bug 1: maxTokens truncation
`maxTokens` hard-coded at 4000 in `judges.ts`. With 36-96 ideas per batch, each producing ~100 tokens of JSON output (id, 5 axis scores, note), the response was consistently truncated mid-JSON → `parseJudgeJSON` failure.

**Fix:** Scale maxTokens to `ideas.length * 150 + 500` (min 4000).

### Bug 2: Slash-prefix pricing lookup
Pricing lookup in `anthropic-pricing.ts` and `budget-tracker.ts` only split on `:` (`anthropic:claude-sonnet-4-6`) but not `/` (`anthropic/claude-sonnet-4-6`). CLI `--judge-model` passes slash-separated IDs → no pricing match → `BudgetExhausted` with reason `no_pricing` when `--max-cost` is set.

**Fix:** Fall through to slash-split when colon-split finds nothing.

### Tested
Brainstorm run with 72 ideas now scores **39 passing** (was 0 of 72, every run since calibration cold-start).