### PR TITLE
feat(link-extraction): consult active schema pack for DIR_PATTERN

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -13,6 +13,10 @@
 
 import type { BrainEngine } from './engine.ts';
 import type { PageType } from './types.ts';
+// PATCH:link-extractor-schema-pack-aware v1
+import { resolveActivePackNameOnly } from './schema-pack/load-active.ts';
+import { tryCachedPack, type ResolvedPack } from './schema-pack/registry.ts';
+import { loadConfig } from './config.ts';
 
 // ─── Entity references ──────────────────────────────────────────
 
@@ -36,14 +40,56 @@ export interface EntityRef {
 /** v0.17.0: how a link's target source was pinned at extraction time. */
 export type LinkResolutionType = 'qualified' | 'unqualified';
 
-/**
- * Directory prefix whitelist. These are the top-level slug dirs the extractor
- * recognizes as entity references. Upstream canonical + our extensions:
- *   - Gbrain canonical: people, companies, meetings, concepts, deal, civic, project, source, media, yc, projects
- *   - Our domain extensions: tech, finance, personal, openclaw (domain-organized wikis)
- *   - Our entity prefix: entities (we kept some legacy entities/projects/ pages)
- */
-const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities)';
+// Canonical fallback prefix list. Used when no schema pack is active
+// OR when the registry cache is cold. Once warm, getDirPattern() unions
+// these with the active pack's path_prefixes (leaf manifest only per v0.38;
+// extends-chain merging is upstream T20).
+const CANONICAL_DIR_PREFIXES = [
+  'people', 'companies', 'meetings', 'concepts', 'deal', 'civic',
+  'project', 'projects', 'source', 'media', 'yc', 'tech', 'finance',
+  'personal', 'openclaw', 'entities',
+] as const;
+
+interface DirPatternCache {
+  packIdentity: string | null;
+  pattern: string;
+}
+
+let _dirPatternCache: DirPatternCache | null = null;
+
+function buildDirPatternFromPack(pack: ResolvedPack | null): string {
+  const set = new Set<string>(CANONICAL_DIR_PREFIXES);
+  if (pack) {
+    for (const t of pack.manifest.page_types ?? []) {
+      for (const p of (t.path_prefixes ?? [])) {
+        const cleaned = p.replace(/^\/+|\/+$/g, '');
+        const top = cleaned.split('/')[0];
+        if (top && /^[a-z][a-z0-9-]*$/.test(top)) {
+          set.add(top);
+        }
+      }
+    }
+  }
+  return `(?:${[...set].sort().join('|')})`;
+}
+
+function getDirPattern(): string {
+  let pack: ResolvedPack | null = null;
+  try {
+    const cfg = loadConfig();
+    const r = resolveActivePackNameOnly({ cfg, remote: false });
+    pack = tryCachedPack(r.pack_name);
+  } catch {
+    pack = null;
+  }
+  const identity = pack?.identity ?? null;
+  if (_dirPatternCache && _dirPatternCache.packIdentity === identity) {
+    return _dirPatternCache.pattern;
+  }
+  const pattern = buildDirPatternFromPack(pack);
+  _dirPatternCache = { packIdentity: identity, pattern };
+  return pattern;
+}
 
 /**
  * Match `[Name](path)` markdown links pointing to entity directories.
@@ -55,10 +101,12 @@ const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|pr
  * The regex permits an optional `../` prefix (any number) and an optional
  * `.md` suffix so the same function works for both filesystem and DB content.
  */
-const ENTITY_REF_RE = new RegExp(
-  `\\[([^\\]]+)\\]\\((?:\\.\\.\\/)*(${DIR_PATTERN}\\/[^)\\s]+?)(?:\\.md)?\\)`,
-  'g',
-);
+function buildEntityRefRe(): RegExp {
+  return new RegExp(
+    `\\[([^\\]]+)\\]\\((?:\\.\\.\\/)*(${getDirPattern()}\\/[^)\\s]+?)(?:\\.md)?\\)`,
+    'g',
+  );
+}
 
 /**
  * Match Obsidian-style `[[path]]` or `[[path|Display Text]]` wikilinks.
@@ -68,10 +116,12 @@ const ENTITY_REF_RE = new RegExp(
  * anchors (`#heading`), skips external URLs. Wiki KBs use this format almost
  * exclusively so missing it leaves the graph empty.
  */
-const WIKILINK_RE = new RegExp(
-  `\\[\\[(${DIR_PATTERN}\\/[^|\\]#]+?)(?:#[^|\\]]*?)?(?:\\|([^\\]]+?))?\\]\\]`,
-  'g',
-);
+function buildWikilinkRe(): RegExp {
+  return new RegExp(
+    `\\[\\[(${getDirPattern()}\\/[^|\\]#]+?)(?:#[^|\\]]*?)?(?:\\|([^\\]]+?))?\\]\\]`,
+    'g',
+  );
+}
 
 /**
  * v0.17.0: qualified wikilink `[[source-id:dir/slug]]` or
@@ -85,10 +135,12 @@ const WIKILINK_RE = new RegExp(
  * the unqualified regex (the source prefix would not satisfy DIR_PATTERN
  * anyway, but the two-pass approach keeps intent crystal-clear).
  */
-const QUALIFIED_WIKILINK_RE = new RegExp(
-  `\\[\\[([a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?):(${DIR_PATTERN}\\/[^|\\]#]+?)(?:#[^|\\]]*?)?(?:\\|([^\\]]+?))?\\]\\]`,
-  'g',
-);
+function buildQualifiedWikilinkRe(): RegExp {
+  return new RegExp(
+    `\\[\\[([a-z0-9](?:[a-z0-9-]{0,30}[a-z0-9])?):(${getDirPattern()}\\/[^|\\]#]+?)(?:#[^|\\]]*?)?(?:\\|([^\\]]+?))?\\]\\]`,
+    'g',
+  );
+}
 
 /**
  * Strip fenced code blocks (```...```) and inline code (`...`) from markdown,
@@ -235,7 +287,7 @@ export function extractEntityRefs(content: string): EntityRef[] {
   //    Markdown links have no source-qualification syntax — they're
   //    always unqualified. Omit sourceId so the shape stays compatible
   //    with pre-v0.17 consumers doing strict equality.
-  const mdPattern = new RegExp(ENTITY_REF_RE.source, ENTITY_REF_RE.flags);
+  const mdPattern = buildEntityRefRe();
   while ((match = mdPattern.exec(stripped)) !== null) {
     const name = match[1];
     const fullPath = match[2];
@@ -248,7 +300,7 @@ export function extractEntityRefs(content: string): EntityRef[] {
   //     Must run BEFORE the unqualified pass or we'd double-emit. We also
   //     mask out the matched spans so pass 2b can't grab them.
   const qualifiedRanges: Array<[number, number]> = [];
-  const qualPattern = new RegExp(QUALIFIED_WIKILINK_RE.source, QUALIFIED_WIKILINK_RE.flags);
+  const qualPattern = buildQualifiedWikilinkRe();
   while ((match = qualPattern.exec(stripped)) !== null) {
     const sourceId = match[1];
     let slug = match[2].trim();
@@ -264,7 +316,7 @@ export function extractEntityRefs(content: string): EntityRef[] {
   // 2b. Unqualified Obsidian wikilinks: [[path]] or [[path|Display Text]]
   //     Same shape rule: omit sourceId when unqualified.
   const unmasked = maskRanges(stripped, qualifiedRanges);
-  const wikiPattern = new RegExp(WIKILINK_RE.source, WIKILINK_RE.flags);
+  const wikiPattern = buildWikilinkRe();
   while ((match = wikiPattern.exec(unmasked)) !== null) {
     let slug = match[1].trim();
     if (!slug) continue;
@@ -385,7 +437,7 @@ export async function extractPageLinks(
   // Code blocks are stripped first — slugs in code samples are not real refs.
   const strippedContent = stripCodeBlocks(content);
   const bareRe = new RegExp(
-    `\\b(${DIR_PATTERN}\\/[a-z0-9][a-z0-9/-]*[a-z0-9])\\b`,
+    `\\b(${getDirPattern()}\\/[a-z0-9][a-z0-9/-]*[a-z0-9])\\b`,
     'g',
   );
   let m: RegExpExecArray | null;


### PR DESCRIPTION
## What this fixes

The Schema Cathedral v3 (v0.40.7+) made schema packs the canonical source of truth for "what path prefixes are entity-bearing in this brain." Every other gbrain code path honors that — `parseMarkdown` infers page type from `page_types[].path_prefixes`, `whoknows` / `find_experts` scopes to declared expert types, `extract_facts` gates on declared extractable types, `enrichment-service` routes per primitive.

The link extractor never got wired up. Its `DIR_PATTERN` regex at `src/core/link-extraction.ts:46` is a frozen 16-prefix hardcoded list:

```typescript
const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities)';
```

This silently ignores prefixes that gbrain's OWN bundled schema packs declare. Examples from `gbrain-base.yaml`:

| Declared in gbrain-base.yaml | In DIR_PATTERN? |
|---|---|
| `person/` (singular) | ❌ |
| `company/` (singular) | ❌ |
| `writing/` | ❌ |
| `wiki/analysis/`, `wiki/guides/`, `wiki/hardware/`, etc | ❌ |

So a fresh gbrain install with the default `gbrain-base` pack active loses every `[[wiki/analysis/...]]`, `[[wiki/guides/...]]`, `[[writing/...]]`, `[[person/...]]`, `[[company/...]]` wikilink. User-installed packs hit the same gap.

## The fix

Replace the frozen `DIR_PATTERN` const with a lazy resolver that reads the active schema pack via `tryCachedPack()` (sync, documented ~10ns hot path when warm) and unions its declared `path_prefixes` with the canonical fallback list.

The 3 module-level const regexes (`ENTITY_REF_RE`, `WIKILINK_RE`, `QUALIFIED_WIKILINK_RE`) become builder functions that construct fresh regexes per call from the resolved pattern. Existing call sites at `extractEntityRefs` already cloned via `.source`/`.flags` to reset `lastIndex`, so the per-call construction cost is unchanged.

The pattern follows the same `tryCachedPack` + cold-cache fallback shape established by other Schema Cathedral consumers (`whoknows`, `find_experts`, `extract_facts`).

## Behavior

| Condition | Effective DIR_PATTERN |
|---|---|
| No active pack OR registry cache cold | Canonical fallback only (byte-identical to upstream) |
| Active pack with declared `path_prefixes` | Union of canonical + top-level segments of declared prefixes |
| Pack hot-swap | Cache invalidates by pack identity → next call rebuilds |

Cold-cache fallback to canonical preserves byte-identical behavior for fresh installs and pre-warm boundary. Once another code path warms the schema-pack cache via `loadActivePack` (typically the engine's first schema-pack-aware operation), subsequent link-extraction calls pick up the warm cache. Cache key is pack identity (sha8-stable); mismatch on swap triggers a fresh build.

## Limitation (T20)

Per the v0.38 `ResolvedPack` contract, this PR reads ONLY the leaf pack's `manifest.page_types`. Extends-chain merging (so a pack declaring `extends: gbrain-base` would also see base's `wiki/`, `writing/`, etc) is the T20 follow-up. For most users this is fine — they declare what their vault uses at the leaf. The edge case is a custom pack that extends gbrain-base but doesn't redeclare base's prefixes; that case still falls back to the canonical list.

## Verification

Smoke-tested against a production-shape brain with an active user pack (19 declared types). Pre-patch `DIR_PATTERN` had 16 prefixes; post-patch resolved to 29 prefixes (canonical + 13 from the active pack). All 98 cases in `test/link-extraction.test.ts` pass; full `tsc --noEmit` clean.

## Files

- `src/core/link-extraction.ts` — adds 4 imports, replaces 3 const regexes with builder functions, adds `getDirPattern()` resolver with identity-keyed cache (+76 / -24 lines)

## Risk

Subtractive on the hot path — falls back to byte-identical upstream behavior when no pack is active or cache is cold. Cannot newly break anything that previously worked. Strictly adds more wikilink resolution in the warm-cache case (when the user's pack declares more prefixes than canonical alone).