### PR TITLE
test(facts-engine): pin gateway to 1536d (fixes master shard-2 flake)

### DIFF
--- a/test/facts-engine.test.ts
+++ b/test/facts-engine.test.ts
@@ -13,17 +13,35 @@
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { configureGateway, resetGateway } from '../src/core/ai/gateway.ts';
 
 let engine: PGLiteEngine;
 
 beforeAll(async () => {
+  // v0.36.2.0: DEFAULT_EMBEDDING_DIMENSIONS flipped to 1280 (ZE Matryoshka).
+  // This test hardcodes Float32Array(1536) in `vec(...)` below for its
+  // embedding fixtures. If another test file in the same shard configured
+  // the gateway before us, initSchema() would size the facts.embedding
+  // column at vector(1280) and the cosine-ordering test would throw
+  // "expected 1280 dimensions, not 1536". Pin the gateway to 1536d
+  // explicitly so this file is hermetic regardless of cross-file state
+  // and matches the pattern from query-cache.test.ts +
+  // consolidate-valid-until.test.ts + search-types-filter.test.ts +
+  // operations-find-trajectory.test.ts.
+  resetGateway();
+  configureGateway({
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    env: { OPENAI_API_KEY: 'sk-fake' },
+  });
   engine = new PGLiteEngine();
   await engine.connect({});
   await engine.initSchema();
 });
 
 afterAll(async () => {
-  await engine.disconnect();
+  try { await engine.disconnect(); } catch { /* ignore */ }
+  resetGateway();
 });
 
 const vec = (...vals: number[]): Float32Array => {


### PR DESCRIPTION
## Summary

`test/facts-engine.test.ts` hardcodes `Float32Array(1536)` in its `vec(...)` helper. Since v0.36.2.0's ZE Matryoshka flip moved `DEFAULT_EMBEDDING_DIMENSIONS` to 1280, the `findCandidateDuplicates > embedding cosine ordering when both sides have embeddings` case throws `expected 1280 dimensions, not 1536` whenever another test file in the same shard configures the gateway before this one runs.

This is the same pattern that bit four sibling test files. Each was fixed by pinning the gateway to 1536d in `beforeAll()`:

- `test/query-cache.test.ts:82-94`
- `test/consolidate-valid-until.test.ts`
- `test/search-types-filter.test.ts`
- `test/operations-find-trajectory.test.ts`

`facts-engine.test.ts` was missed during that wave. Recent CI shard-2 ordering started exposing it.

## Reproducing the master failure

Master HEAD `a74e5d90` (v0.41.20.0) hits this in its own [master workflow run](https://github.com/garrytan/gbrain/actions/runs/26496783906) at `2026-05-27T06:47:46Z`:

```
test (2)  error: expected 1280 dimensions, not 1536
test (2)  (fail) findCandidateDuplicates > embedding cosine ordering when both sides have embeddings [3.00ms]
```

Every branch rebased onto `a74e5d90` inherits it, including PR #1546 (lint-disconnect fix) and PR #1401 (longmemeval strip-prefix). Neither PR touches embedding dims or `facts-engine.test.ts`; both block on this same master test bug.

## Fix

Copy the established pattern verbatim — `resetGateway()` + `configureGateway({embedding_model, embedding_dimensions: 1536, env})` at the top of `beforeAll()`, paired `resetGateway()` in `afterAll()`. Wrap the disconnect in try/catch to match query-cache.test.ts's shape.

## Test plan

- [x] Run `bun test test/facts-engine.test.ts` locally — 14/14 pass
- [x] `bun run typecheck` — clean
- [x] `bash scripts/check-privacy.sh` — clean
- [x] `bash scripts/check-jsonb-pattern.sh` — clean
- [x] `bash scripts/check-progress-to-stdout.sh` — clean
- [x] `bash scripts/check-wasm-embedded.sh` — clean
- [ ] CI Tier 1 + every test shard green on this PR
- [ ] After merge: PR #1546 and PR #1401 retrigger CI and go fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)