### PR TITLE
Fix source-scoped dream cycles

### DIFF
--- a/src/commands/dream.ts
+++ b/src/commands/dream.ts
@@ -30,6 +30,7 @@ import {
   type CyclePhase,
   type CycleReport,
 } from '../core/cycle.ts';
+import { isValidSourceId } from '../core/source-id.ts';
 import { existsSync } from 'fs';
 import { resolve } from 'node:path';
 
@@ -39,6 +40,7 @@ interface DreamArgs {
   pull: boolean;
   phase: CyclePhase | null;
   dir: string | null;
+  sourceId: string | null;
   help: boolean;
   /** v0.21: ad-hoc transcript file path; implies --phase synthesize. */
   inputFile: string | null;
@@ -71,6 +73,13 @@ function parseArgs(args: string[]): DreamArgs {
 
   const dirIdx = args.indexOf('--dir');
   const dir = dirIdx !== -1 ? args[dirIdx + 1] : null;
+
+  const sourceIdx = args.indexOf('--source');
+  const sourceId = sourceIdx !== -1 ? args[sourceIdx + 1] ?? null : null;
+  if (sourceIdx !== -1 && !isValidSourceId(sourceId)) {
+    console.error(`--source must be a valid source_id; got ${JSON.stringify(sourceId)}`);
+    process.exit(2);
+  }
 
   const inputIdx = args.indexOf('--input');
   const inputFile = inputIdx !== -1 ? args[inputIdx + 1] ?? null : null;
@@ -116,6 +125,7 @@ function parseArgs(args: string[]): DreamArgs {
     pull: args.includes('--pull'),
     phase,
     dir,
+    sourceId,
     help: args.includes('--help') || args.includes('-h'),
     inputFile,
     date,
@@ -139,15 +149,57 @@ function parseArgs(args: string[]): DreamArgs {
 async function resolveBrainDir(
   engine: BrainEngine | null,
   explicit: string | null,
+  sourceId: string | null,
 ): Promise<string> {
   if (explicit) {
     if (!existsSync(explicit)) {
       console.error(`--dir path does not exist: ${explicit}`);
       process.exit(1);
     }
+    if (engine && sourceId) {
+      const { fetchSource } = await import('../core/sources-load.ts');
+      const source = await fetchSource(engine, sourceId);
+      if (!source || source.archived === true) {
+        console.error(`Source "${sourceId}" not found. List with: gbrain sources list`);
+        process.exit(1);
+      }
+      if (!source.local_path) {
+        console.error(`Source "${sourceId}" has no local_path; cannot run a filesystem dream cycle.`);
+        process.exit(1);
+      }
+      if (resolve(source.local_path) !== resolve(explicit)) {
+        console.error(
+          `--dir does not match source "${sourceId}" local_path (${source.local_path}). ` +
+          `Use --dir ${source.local_path} or omit --dir.`,
+        );
+        process.exit(1);
+      }
+    }
     // Resolve to absolute so downstream writeFileSync(join(brainDir, slug))
     // can't silently land at cwd when explicit is `.` / `./brain` / etc.
     return resolve(explicit);
+  }
+
+  if (sourceId) {
+    if (!engine) {
+      console.error('--source requires a configured database so the source local_path can be resolved.');
+      process.exit(1);
+    }
+    const { fetchSource } = await import('../core/sources-load.ts');
+    const source = await fetchSource(engine, sourceId);
+    if (!source || source.archived === true) {
+      console.error(`Source "${sourceId}" not found. List with: gbrain sources list`);
+      process.exit(1);
+    }
+    if (!source.local_path) {
+      console.error(`Source "${sourceId}" has no local_path; cannot run a filesystem dream cycle.`);
+      process.exit(1);
+    }
+    if (!existsSync(source.local_path)) {
+      console.error(`Source "${sourceId}" local_path does not exist: ${source.local_path}`);
+      process.exit(1);
+    }
+    return resolve(source.local_path);
   }
 
   if (engine) {
@@ -181,6 +233,7 @@ Options:
   --json              Emit the CycleReport as JSON (agent-readable)
   --phase <name>      Run a single phase: ${ALL_PHASES.join(' | ')}
   --pull              git pull the brain repo before syncing (default: no pull)
+  --source <id>       Source id whose local_path should be cycled
   --dir <path>        Brain directory (default: configured brain)
 
   --input <file>      Synthesize a specific transcript file (implies
@@ -200,6 +253,7 @@ Options:
 Examples:
   gbrain dream
   gbrain dream --dry-run --json
+  gbrain dream --source default
   gbrain dream --phase lint
   gbrain dream --phase synthesize --input ~/transcripts/2026-04-25.txt
   gbrain dream --phase synthesize --from 2026-04-01 --to 2026-04-25
@@ -275,11 +329,12 @@ export async function runDream(engine: BrainEngine | null, args: string[]): Prom
     return;
   }
 
-  const brainDir = await resolveBrainDir(engine, opts.dir);
+  const brainDir = await resolveBrainDir(engine, opts.dir, opts.sourceId);
   const phases: CyclePhase[] | undefined = opts.phase ? [opts.phase] : undefined;
 
   const report = await runCycle(engine, {
     brainDir,
+    ...(opts.sourceId ? { sourceId: opts.sourceId } : {}),
     dryRun: opts.dryRun,
     pull: opts.pull,
     phases,

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4206,7 +4206,7 @@ export class PGLiteEngine implements BrainEngine {
     // dashboard, v0.10.3 metrics give entity-page-level granularity.
     const { rows: [h] } = await this.db.query(`
       WITH entity_pages AS (
-        SELECT id, slug FROM pages WHERE type IN ('person', 'company')
+        SELECT id, slug FROM pages WHERE type IN ('entity', 'person', 'company', 'organization')
       )
       SELECT
         (SELECT count(*) FROM pages) as page_count,
@@ -4240,7 +4240,7 @@ export class PGLiteEngine implements BrainEngine {
       SELECT p.slug,
              (SELECT count(*) FROM links l WHERE l.from_page_id = p.id OR l.to_page_id = p.id)::int as link_count
       FROM pages p
-      WHERE p.type IN ('person', 'company')
+      WHERE p.type IN ('entity', 'person', 'company', 'organization')
       ORDER BY link_count DESC
       LIMIT 5
     `);

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4221,7 +4221,7 @@ export class PostgresEngine implements BrainEngine {
     // is working as intended, not an orphan.
     const [h] = await sql`
       WITH entity_pages AS (
-        SELECT id, slug FROM pages WHERE type IN ('person', 'company')
+        SELECT id, slug FROM pages WHERE type IN ('entity', 'person', 'company', 'organization')
       )
       SELECT
         (SELECT count(*) FROM pages) as page_count,
@@ -4252,7 +4252,7 @@ export class PostgresEngine implements BrainEngine {
       SELECT p.slug,
              (SELECT count(*) FROM links l WHERE l.from_page_id = p.id OR l.to_page_id = p.id)::int as link_count
       FROM pages p
-      WHERE p.type IN ('person', 'company')
+      WHERE p.type IN ('entity', 'person', 'company', 'organization')
       ORDER BY link_count DESC
       LIMIT 5
     `;

--- a/test/dream.test.ts
+++ b/test/dream.test.ts
@@ -76,6 +76,25 @@ describe('runDream — brainDir resolution', () => {
     if (report) expect(report.brain_dir).toBe(repo);
   });
 
+  test('no --dir + --source: uses the source local_path and records source freshness', async () => {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config)
+       VALUES ('alpha', 'alpha', $1, '{}'::jsonb)
+       ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path`,
+      [repo],
+    );
+
+    const report = await runDream(engine, ['--source', 'alpha', '--phase', 'lint', '--json']);
+
+    expect(report).toBeTruthy();
+    if (report) expect(report.brain_dir).toBe(repo);
+    const rows = await engine.executeRaw<{ config: Record<string, unknown> | string }>(
+      `SELECT config FROM sources WHERE id = 'alpha'`,
+    );
+    const config = typeof rows[0]?.config === 'string' ? JSON.parse(rows[0].config) : rows[0]?.config;
+    expect(typeof config?.last_full_cycle_at).toBe('string');
+  });
+
   test('no --dir + engine=null exits 1', async () => {
     const spy = spyOn(process, 'exit').mockImplementation(() => { throw new Error('EXIT'); });
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -1261,6 +1261,30 @@ describe('PGLiteEngine: getHealth graph metrics', () => {
     expect(h.timeline_coverage).toBeCloseTo(1 / 3, 2);
   });
 
+  test('entity coverage includes generic entity and organization pages', async () => {
+    await engine.putPage('entities/topics/deadlines', {
+      ...testPage,
+      type: 'entity',
+      title: 'Deadlines',
+    });
+    await engine.putPage('organizations/example-labs', {
+      ...testPage,
+      type: 'organization',
+      title: 'Example Labs',
+    });
+
+    await engine.addLink('people/alice', 'entities/topics/deadlines', '', 'mentions');
+    await engine.addTimelineEntry('organizations/example-labs', {
+      date: '2026-01-15',
+      summary: 'Created',
+    });
+
+    const h = await engine.getHealth();
+    expect(h.link_coverage).toBeCloseTo(1 / 5, 2);
+    expect(h.timeline_coverage).toBeCloseTo(1 / 5, 2);
+    expect(h.most_connected.some((row) => row.slug === 'entities/topics/deadlines')).toBe(true);
+  });
+
   test('most_connected lists top entities by link count', async () => {
     await engine.addLink('people/alice', 'companies/acme', '', 'works_at');
     await engine.addLink('people/bob', 'companies/acme', '', 'invested_in');


### PR DESCRIPTION
## Summary
- add `gbrain dream --source <id>` so doctor remediation can run a source-scoped cycle and update `last_full_cycle_at`
- resolve `--source` through `sources.local_path` and reject mismatched `--dir`/`--source`
- include generic `entity` and `organization` pages in graph health entity coverage metrics

## Tested
- `bun test --timeout 30000 test/pglite-engine.test.ts --grep "getHealth graph metrics"`
- `bun test test/dream.test.ts --grep "no --dir"`
- `bun run typecheck`
