### PR TITLE
fix(doctor): emit accurate --break-lock hint for non-sync stale locks

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1920,6 +1920,29 @@ export function checkAutopilotLockScope(): Check {
 }
 
 /**
+ * Format a precise --break-lock recovery hint for a stale lock id.
+ *
+ * v0.41.6.0 D3 ships `gbrain sync --break-lock` which handles `gbrain-sync:*`
+ * keys only. Other lock kinds (notably `gbrain-cycle` and per-source
+ * `gbrain-cycle:<source>`) do not have a corresponding shipped CLI handler,
+ * so blindly suggesting `gbrain sync --break-lock` for them is wrong and
+ * misleads operators down a dead-end (issue #1534). Until a kind-agnostic
+ * breaker ships, point at the SQL fallback for unsupported kinds so the
+ * hint stays honest.
+ */
+function formatStaleLockBreakHint(lockId: string): string {
+  if (lockId.startsWith('gbrain-sync:')) {
+    return `gbrain sync --break-lock --source ${lockId.slice('gbrain-sync:'.length)}`;
+  }
+  if (lockId === 'gbrain-sync') {
+    return `gbrain sync --break-lock`;
+  }
+  // Cycle / unrecognized kinds: no shipped CLI breaker. Be explicit instead of
+  // suggesting a command that silently no-ops.
+  return `manual clear required (no CLI breaker for ${lockId}): DELETE FROM gbrain_cycle_locks WHERE id = '${lockId.replace(/'/g, "''")}';`;
+}
+
+/**
  * v0.41.6.0 D3 — stale_locks doctor check.
  *
  * Surfaces every row in `gbrain_cycle_locks` whose `ttl_expires_at < NOW()`.
@@ -1947,8 +1970,7 @@ export async function checkStaleLocks(engine: BrainEngine): Promise<Check> {
     }
     const lines = stale.slice(0, 10).map(s => {
       const ageH = Math.floor(s.age_ms / 3600_000);
-      const source = s.id.startsWith('gbrain-sync:') ? s.id.slice('gbrain-sync:'.length) : null;
-      const breakHint = source ? `gbrain sync --break-lock --source ${source}` : `gbrain sync --break-lock`;
+      const breakHint = formatStaleLockBreakHint(s.id);
       return `  ${s.id} (pid ${s.holder_pid} on ${s.holder_host}, age ${ageH}h) → ${breakHint}`;
     });
     const tail = stale.length > 10 ? `  ... and ${stale.length - 10} more.` : null;


### PR DESCRIPTION
## Summary

Fixes #1534.

`doctor`'s `stale_locks` check hard-coded `gbrain sync --break-lock` as the recovery hint for every stale row. But that command, per `sync.ts`, only handles `gbrain-sync:*` keys — it silently no-ops on `gbrain-cycle` (and per-source `gbrain-cycle:<source>`) locks with `Lock gbrain-sync:default is not held (nothing to break).`, leaving operators with no shipped path to clear the lock.

## Fix

Extracted a small `formatStaleLockBreakHint(lockId)` helper that branches on the lock-id prefix:

- `gbrain-sync:<src>` → `gbrain sync --break-lock --source <src>`
- `gbrain-sync` → `gbrain sync --break-lock`
- anything else (notably `gbrain-cycle`, `gbrain-cycle:<src>`, future kinds) → an honest SQL-fallback hint:  
  `manual clear required (no CLI breaker for <id>): DELETE FROM gbrain_cycle_locks WHERE id = '<id>';`

The `id` is single-quote-escaped so the printed snippet is safe to copy verbatim.

## Why this shape instead of shipping a new CLI breaker

The issue suggests also adding `gbrain dream --break-lock` or `gbrain admin break-lock <name>`. That's the right next step but it's a CLI-surface decision (PID liveness, force-break semantics, cross-host guards) that's better landed on its own with proper tests. This PR is the minimum honest-hint change so that `doctor` stops actively misleading operators today.

## Risk

Pure formatter change inside the doctor output builder. No DB writes, no new CLI surface, no behavior change for the existing `gbrain-sync:*` cases. Output text changes for cycle locks only.

## Test plan

No unit tests target this string today. Verified the helper output by extracting it into a Node REPL (covers sync, sync-with-source, cycle, cycle-with-source, and single-quote-in-id):

```
gbrain sync --break-lock --source default
gbrain sync --break-lock
manual clear required (no CLI breaker for gbrain-cycle): DELETE FROM gbrain_cycle_locks WHERE id = 'gbrain-cycle';
manual clear required (no CLI breaker for gbrain-cycle:notes): DELETE FROM gbrain_cycle_locks WHERE id = 'gbrain-cycle:notes';
manual clear required (no CLI breaker for weird's-lock): DELETE FROM gbrain_cycle_locks WHERE id = 'weird''s-lock';
```

Did not run the full `bun test` / `bun run verify` suite locally (no Postgres + Bun on this machine); CI will cover.
