### PR TITLE
[fix] Preserve shared Postgres connection during lint probes

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -97,12 +97,19 @@ export class PostgresEngine implements BrainEngine {
   /**
    * Tracks which connection path this engine is using so disconnect() is
    * idempotent. 'instance' = own _sql pool (poolSize was set);
-   * 'module' = the module-level db singleton (backward compat path).
+   * 'module' = the module-level db singleton (owned or borrowed).
    * null = never connected, or already disconnected. Without this, a second
    * disconnect() on an instance-pool engine would fall through to
    * db.disconnect() and clobber the unrelated module-level connection.
    */
   private _connectionStyle: 'instance' | 'module' | null = null;
+  /**
+   * True only for the module-style engine instance that created the db.ts
+   * singleton. Other module-style engines are borrowers and must not tear down
+   * the shared pool in disconnect(). Borrowers assume the owner manages the
+   * module singleton lifetime, as in the CLI main-engine plus helper-probe flow.
+   */
+  private _ownsModuleConnection = false;
 
   /**
    * v0.30.1 (Fix 1 + X1 + T5): instance-owned ConnectionManager.
@@ -165,6 +172,7 @@ export class PostgresEngine implements BrainEngine {
       await this._sql`SELECT 1`;
       await db.setSessionDefaults(this._sql);
       this._connectionStyle = 'instance';
+      this._ownsModuleConnection = false;
 
       // v0.30.1: instance-owned ConnectionManager wraps the read pool we just
       // built. Parent inheritance (T5/X1): worker engines pass their parent's
@@ -177,8 +185,16 @@ export class PostgresEngine implements BrainEngine {
       this.connectionManager.setReadPool(this._sql);
     } else {
       // Module-level singleton (backward compat for CLI main engine)
+      let moduleConnectionExists = true;
+      try {
+        db.getConnection();
+      } catch {
+        moduleConnectionExists = false;
+      }
+      const alreadyOwnsModuleConnection = this._connectionStyle === 'module' && this._ownsModuleConnection;
       await db.connect(config);
       this._connectionStyle = 'module';
+      this._ownsModuleConnection = alreadyOwnsModuleConnection || !moduleConnectionExists;
 
       // v0.30.1: connection-manager wraps the module singleton.
       if (url) {
@@ -201,14 +217,18 @@ export class PostgresEngine implements BrainEngine {
     if (this._sql) {
       await this._sql.end();
       this._sql = null;
+      this._ownsModuleConnection = false;
       // After this point, _connectionStyle stays 'instance' so a second
       // disconnect() is a no-op rather than falling through and clearing
       // the unrelated module-level db singleton.
       return;
     }
     if (this._connectionStyle === 'module') {
-      await db.disconnect();
+      if (this._ownsModuleConnection) {
+        await db.disconnect();
+      }
       this._connectionStyle = null;
+      this._ownsModuleConnection = false;
     }
     // else: nothing to disconnect (already done or never connected)
   }

--- a/test/e2e/postgres-engine-disconnect-idempotency.test.ts
+++ b/test/e2e/postgres-engine-disconnect-idempotency.test.ts
@@ -11,21 +11,29 @@
  * connection" on the next beforeEach).
  *
  * The fix: PostgresEngine tracks `_connectionStyle` ('instance' | 'module')
- * and only calls db.disconnect() when it actually owns the module-level
- * connection. Second disconnect on an instance-pool engine is a no-op.
+ * plus module-singleton ownership. Only the engine that created the module-level
+ * connection calls db.disconnect(); borrowers leave the shared pool alive.
+ * Second disconnect on an instance-pool engine is a no-op.
  *
  * This test pins the contract so future refactors of disconnect() can't
  * silently regress (it's exactly the bug class that took an hour of E2E
- * debugging to find). Two cases:
+ * debugging to find). Four cases:
  *   1. instance-pool engine: connect → disconnect → disconnect must NOT
  *      affect the module-level connection.
- *   2. module-singleton engine: connect → disconnect → disconnect is safe
- *      (second call no-ops).
+ *   2. module-singleton borrower: connect → disconnect must NOT affect the
+ *      owning module-level connection.
+ *   3. lint's DB-config probe must leave the owner alive.
+ *   4. module-singleton owner: connect → disconnect → disconnect is safe
+ *      (first call closes the singleton; second call no-ops).
  */
 
-import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { PostgresEngine } from '../../src/core/postgres-engine.ts';
 import * as db from '../../src/core/db.ts';
+import { runLintCore } from '../../src/commands/lint.ts';
 
 const DATABASE_URL = process.env.DATABASE_URL;
 const skip = !DATABASE_URL;
@@ -36,18 +44,19 @@ if (skip) {
 }
 
 describe.skipIf(skip)('PostgresEngine.disconnect idempotency', () => {
-  beforeAll(async () => {
-    // Establish the module-level connection so we can verify it survives
-    // the instance-pool engine's double-disconnect.
+  beforeEach(async () => {
     await db.disconnect();
-    await db.connect({ database_url: DATABASE_URL! });
   }, 30_000);
 
-  afterAll(async () => {
+  afterEach(async () => {
     await db.disconnect();
   });
 
   test('instance-pool engine: second disconnect() does NOT clobber module singleton', async () => {
+    // Establish the module-level connection so we can verify it survives
+    // the instance-pool engine's double-disconnect.
+    await db.connect({ database_url: DATABASE_URL! });
+
     const engine = new PostgresEngine();
     await engine.connect({ database_url: DATABASE_URL!, poolSize: 2 });
 
@@ -68,17 +77,62 @@ describe.skipIf(skip)('PostgresEngine.disconnect idempotency', () => {
     expect((after[0] as unknown as { ok: number }).ok).toBe(1);
   });
 
-  test('module-singleton engine: second disconnect() is a no-op', async () => {
-    // Re-establish module-level connection (idempotent; no-op if still
-    // connected from beforeAll).
-    await db.connect({ database_url: DATABASE_URL! });
+  test('module-singleton borrower: disconnect() does NOT clobber owner singleton', async () => {
+    const owner = new PostgresEngine();
+    await owner.connect({ database_url: DATABASE_URL! });
 
+    const borrower = new PostgresEngine();
+    // No poolSize → uses the already-open module-level singleton as a borrower.
+    await borrower.connect({ database_url: DATABASE_URL! });
+
+    // Pre-fix, this called db.disconnect() and killed the owner's singleton.
+    await borrower.disconnect();
+
+    const afterBorrowerDisconnect = await db.getConnection().unsafe('SELECT 1 as ok');
+    expect((afterBorrowerDisconnect[0] as unknown as { ok: number }).ok).toBe(1);
+
+    // The owner still tears down the singleton it created.
+    await owner.disconnect();
+    expect(() => db.getConnection()).toThrow('No database connection');
+  });
+
+  test('lint DB-config probe: borrower disconnect() does NOT clobber owner singleton', async () => {
+    const owner = new PostgresEngine();
+    await owner.connect({ database_url: DATABASE_URL! });
+
+    // This smoke test covers runLintCore's current DB-plane config probe. The
+    // direct borrower test above pins the engine-level lifecycle contract.
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-lint-probe-'));
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    const previousGbrainDatabaseUrl = process.env.GBRAIN_DATABASE_URL;
+
+    try {
+      writeFileSync(join(dir, 'note.md'), '# Note\n\nClean content.\n');
+      process.env.DATABASE_URL = DATABASE_URL!;
+      delete process.env.GBRAIN_DATABASE_URL;
+
+      await runLintCore({ target: dir, dryRun: true });
+
+      const afterLintProbe = await db.getConnection().unsafe('SELECT 1 as ok');
+      expect((afterLintProbe[0] as unknown as { ok: number }).ok).toBe(1);
+    } finally {
+      if (previousDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+      else process.env.DATABASE_URL = previousDatabaseUrl;
+      if (previousGbrainDatabaseUrl === undefined) delete process.env.GBRAIN_DATABASE_URL;
+      else process.env.GBRAIN_DATABASE_URL = previousGbrainDatabaseUrl;
+      rmSync(dir, { recursive: true, force: true });
+      await owner.disconnect().catch(() => { /* already closed by a failing assertion path */ });
+    }
+  });
+
+  test('module-singleton owner: second disconnect() is a no-op', async () => {
     const engine = new PostgresEngine();
-    // No poolSize → uses the module-level singleton.
+    // No poolSize and no pre-existing singleton → this engine owns it.
     await engine.connect({ database_url: DATABASE_URL! });
 
-    // First disconnect closes module-level singleton (this engine owned it).
+    // First disconnect closes the module-level singleton.
     await engine.disconnect();
+    expect(() => db.getConnection()).toThrow('No database connection');
 
     // Second disconnect must NOT throw — should be a no-op since
     // _connectionStyle was reset to null.


### PR DESCRIPTION
## Summary

This fixes a Postgres connection-lifecycle bug where short-lived helper engines could tear down the shared module-level database pool that the main `gbrain dream` cycle still needed.

In the dream cycle, lint runs early and briefly opens an engine to lift DB-backed content-sanity config. On Postgres, that helper can reuse the existing module-level singleton. Before this change, its `disconnect()` path always called `db.disconnect()` for module-mode engines, even when the helper did not create the singleton. That leaves later phases with `No database connection` / `connect() has not been called`.

## Issue cluster

Fixes #1492.
Fixes #1471.
Fixes #1499.

Those reports converge on the same root cause: an early lint/config helper borrows the shared Postgres module singleton, then disconnects it out from under the still-running dream cycle or worker pool.

This also targets the same Postgres "later phase loses the DB connection after an earlier helper phase ran" symptom cluster reported in #1491, #1515, #1531, #1462, and #1422. I am not marking every adjacent report as auto-closed because some include follow-on error-reporting, worker-startup, idle-timeout, or phase-specific details, but this PR removes the shared-pool teardown bug they converge on.

Related but likely separate: #1426 appears to involve PGLite pending-write lifecycle behavior, so this PR does not claim to fix it. #1404 and #1413 have overlapping `connect() has not been called` evidence, but their later comments also discuss additional lifecycle paths outside this narrow ownership fix.

## Why this matters

This is a small lifecycle fix with high operational impact:

- Keeps long-running dream cycles from losing their Postgres connection after the lint/config probe.
- Preserves the existing module-singleton compatibility path for CLI flows.
- Keeps instance-owned worker pools unchanged.
- Makes ownership explicit: only the engine that created the module singleton can close it; borrower engines clean up their own routing manager but leave the shared pool alive.

For Postgres users, this turns a whole class of hard-to-diagnose dream-cycle crashes back into stable multi-phase runs without changing query semantics or pool setup.

## What changed

- Added module-singleton ownership tracking to `PostgresEngine`.
- Updated `disconnect()` so module-mode borrowers do not call `db.disconnect()`.
- Expanded the Postgres disconnect E2E coverage to pin:
  - instance-pool double-disconnect safety,
  - module-borrower disconnect safety,
  - the lint DB-config probe path,
  - module-owner disconnect idempotency.

## Validation

- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/<scratch-db> bun test test/e2e/postgres-engine-disconnect-idempotency.test.ts`
- `bun test test/cli-dream-engine-warn.test.ts test/dream.test.ts`
- `bun run typecheck`
- `git diff --check`
- `git show --check HEAD`
- `scripts/check-no-double-retry.sh && scripts/check-batch-audit-site.sh && scripts/check-test-isolation.sh`
- `gitleaks dir . --redact --no-banner`
- `gitleaks git . --redact --no-banner --log-opts="origin/master..HEAD"`
- CodeRabbit local review: 0 findings
- Claude Code prompt review: no blockers; low-severity comment/test-context nits addressed
