### PR TITLE
feat: add opt-in plain-text entity extraction for auto-link

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -13,6 +13,7 @@
 
 import type { BrainEngine } from './engine.ts';
 import type { PageType } from './types.ts';
+import { extractEntities } from './enrichment-service.ts';
 
 // ─── Entity references ──────────────────────────────────────────
 
@@ -932,4 +933,19 @@ export async function isAutoTimelineEnabled(engine: BrainEngine): Promise<boolea
   if (val == null) return true;
   const normalized = val.trim().toLowerCase();
   return !['false', '0', 'no', 'off'].includes(normalized);
+}
+
+/**
+ * Read the auto_link_plain_text config flag. Defaults to FALSE (opt-in).
+ * When enabled, extractPageLinks also runs regex-based NER on plain text
+ * to find capitalized names that might refer to existing people/company pages.
+ * Creates 'mentions' edges for resolved entities.
+ *
+ * Enable with: `gbrain config set auto_link_plain_text true`
+ */
+export async function isPlainTextEntityExtractionEnabled(engine: BrainEngine): Promise<boolean> {
+  const val = await engine.getConfig('auto_link_plain_text');
+  if (val == null) return false; // OFF by default (opt-in)
+  const normalized = val.trim().toLowerCase();
+  return ['true', '1', 'yes', 'on'].includes(normalized);
 }

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -15,7 +15,8 @@ import { expandQuery } from './search/expansion.ts';
 import { dedupResults } from './search/dedup.ts';
 import { captureEvalCandidate, isEvalCaptureEnabled, isEvalScrubEnabled } from './eval-capture.ts';
 import type { HybridSearchMeta } from './types.ts';
-import { extractPageLinks, isAutoLinkEnabled, isAutoTimelineEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef } from './link-extraction.ts';
+import { extractPageLinks, isAutoLinkEnabled, isAutoTimelineEnabled, isPlainTextEntityExtractionEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef } from './link-extraction.ts';
+import { extractEntities, slugifyEntity } from './enrichment-service.ts';
 import { isFactsBackstopEligible } from './facts/eligibility.ts';
 import { stripTakesFence } from './takes-fence.ts';
 import { stripFactsFence } from './facts-fence.ts';
@@ -767,6 +768,28 @@ async function runAutoLink(
     slug, fullContent, parsed.frontmatter, parsed.type, resolver,
   );
 
+  // v0.XX.X: Plain-text entity extraction (opt-in via config).
+  // When enabled, scans body text for capitalized names (regex NER) and
+  // resolves them to existing people/company pages. Creates 'mentions' edges.
+  const plainTextEnabled = await isPlainTextEntityExtractionEnabled(engine);
+  if (plainTextEnabled) {
+    const plainTextEntities = extractEntities(fullContent);
+    for (const entity of plainTextEntities) {
+      // Generate the expected slug for this entity
+      const expectedSlug = slugifyEntity(entity.name, entity.type);
+      // Only add if we haven't already linked to this target via explicit wikilink
+      const alreadyLinked = candidates.some(c => c.targetSlug === expectedSlug);
+      if (!alreadyLinked) {
+        candidates.push({
+          targetSlug: expectedSlug,
+          linkType: 'mentions',
+          context: entity.context,
+          linkSource: 'plain_text',
+        });
+      }
+    }
+  }
+
   // Resolve which targets exist (skip refs to non-existent pages to avoid FK
   // violation churn in addLink). One getAllSlugs call upfront, O(1) lookup.
   // v0.31.8 (D12): scoped to the source when opts.sourceId is set so wikilink
@@ -811,10 +834,10 @@ async function runAutoLink(
       l => l.link_source === 'frontmatter' && l.origin_slug === slug,
     );
 
-    // Reconcilable outgoing edges: markdown + our own frontmatter edges.
+    // Reconcilable outgoing edges: markdown + plain_text + our own frontmatter edges.
     // Manual edges (link_source='manual') are NEVER touched by reconciliation.
     const reconcilableOut = existingOut.filter(
-      l => l.link_source === 'markdown' || l.link_source == null ||
+      l => l.link_source === 'markdown' || l.link_source === 'plain_text' || l.link_source == null ||
            (l.link_source === 'frontmatter' && l.origin_slug === slug),
     );
 

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -829,3 +829,39 @@ describe("v0.18.0 migration v22 — links_resolution_type", () => {
   });
 });
 
+describe("isPlainTextEntityExtractionEnabled", () => {
+  const { isPlainTextEntityExtractionEnabled } = require("../src/core/link-extraction.ts");
+
+  const fakeEngine = (val: string | null) => ({
+    getConfig: async (k: string) => (k === "auto_link_plain_text" ? val : null),
+  }) as any;
+
+  test("default (null) -> false (opt-in)", async () => {
+    expect(await isPlainTextEntityExtractionEnabled(fakeEngine(null))).toBe(false);
+  });
+
+  test("'true' -> true", async () => {
+    expect(await isPlainTextEntityExtractionEnabled(fakeEngine("true"))).toBe(true);
+  });
+
+  test("'1' -> true", async () => {
+    expect(await isPlainTextEntityExtractionEnabled(fakeEngine("1"))).toBe(true);
+  });
+
+  test("'yes' -> true", async () => {
+    expect(await isPlainTextEntityExtractionEnabled(fakeEngine("yes"))).toBe(true);
+  });
+
+  test("'on' -> true", async () => {
+    expect(await isPlainTextEntityExtractionEnabled(fakeEngine("on"))).toBe(true);
+  });
+
+  test("'false' -> false", async () => {
+    expect(await isPlainTextEntityExtractionEnabled(fakeEngine("false"))).toBe(false);
+  });
+
+  test("garbage value -> false (opt-in default)", async () => {
+    expect(await isPlainTextEntityExtractionEnabled(fakeEngine("garbage"))).toBe(false);
+  });
+});
+


### PR DESCRIPTION
## Summary

Adds a new config flag `auto_link_plain_text` (default: `false`) that enables automatic extraction of plain-text entity names from markdown content during `runAutoLink`.

## Problem

Currently, auto-link only creates graph edges for explicit `[[wikilinks]]`. Content that mentions people by plain text (e.g., "Patrick Skinner mentioned that...") doesn't get linked to their person pages, even when those pages exist.

## Solution

When `auto_link_plain_text = true`:
1. After extracting explicit wikilinks, the system runs `extractEntities()` on the markdown body
2. This uses a regex NER approach to find capitalized multi-word names (e.g., "Patrick Skinner", "John Chen")
3. For each candidate, it generates an expected slug via `slugifyEntity()` (e.g., `people/patrick-skinner`)
4. If the slug resolves to an existing page, a `mentions` edge is created with `link_source='plain_text'`
5. Dedupes against explicit wikilinks to avoid double-linking

## Changes

- `src/core/link-extraction.ts`: Added `isPlainTextEntityExtractionEnabled()` config helper
- `src/core/operations.ts`: Wire `extractEntities` into `runAutoLink`, add `plain_text` to reconcilable sources
- `test/link-extraction.test.ts`: 7 new tests for config flag behavior

## Testing

```bash
bun test test/link-extraction.test.ts
# 105/105 pass
```

## Usage

```bash
gbrain config set auto_link_plain_text true
gbrain sync --source <source> --full  # re-process existing pages
```

## Notes

- Opt-in by default to preserve backward compatibility
- The regex pattern `/\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b/g` catches most Western-style names
- Could be extended with more sophisticated NER in the future