### PR TITLE
fix(heavy-tests): unbreak frontmatter_scan_wallclock (Heavy Tests red since 2026-05-23)

### DIFF
--- a/tests/heavy/frontmatter_scan_wallclock.sh
+++ b/tests/heavy/frontmatter_scan_wallclock.sh
@@ -80,7 +80,9 @@ echo "[fm_wallclock] fixture seeded in ${SEED_ELAPSED}s" | tee -a "$LOG"
 
 # Step 2: init brain + register the source.
 echo "[fm_wallclock] init brain..." | tee -a "$LOG"
-timeout 120s bun run src/cli.ts init --pglite --yes >> "$LOG" 2>&1 || {
+# Test measures doctor's frontmatter scan wallclock — no embeddings needed,
+# and the CI runner doesn't have an embedding provider key configured.
+timeout 120s bun run src/cli.ts init --pglite --no-embedding --yes >> "$LOG" 2>&1 || {
   echo "[fm_wallclock] FAIL: gbrain init exited non-zero" >&2
   echo "Log tail:" >&2
   tail -30 "$LOG" >&2


### PR DESCRIPTION
## Summary

The Heavy Tests scheduled workflow has been failing every night since **2026-05-23** because `tests/heavy/frontmatter_scan_wallclock.sh` calls `gbrain init --pglite --yes`, and v0.37.10.0 (#1278, a55de712) made init require an embedding provider. The CI runner has no `OPENAI_API_KEY` / `VOYAGE_API_KEY` / `ZEROENTROPY_API_KEY` configured, so init exits non-zero and the heavy runner aborts on the first script.

The same PR that introduced the gate also shipped the `--no-embedding` D9 opt-in for exactly this case ("deferred setup, no embedding tier"). The test never embeds anything — it seeds raw `.md` files and measures doctor's frontmatter scan wallclock. `--no-embedding` is the canonical fix.

## Failing log excerpt (most recent run, 2026-05-27 11:50 UTC)

```
[fm_wallclock] init brain...
[fm_wallclock] FAIL: gbrain init exited non-zero

No embedding provider configured. Set one of:
  export OPENAI_API_KEY=sk-…
  export ZEROENTROPY_API_KEY=ze-…
  export VOYAGE_API_KEY=pa-…
Or defer setup: gbrain init --pglite --no-embedding
```

The error message literally suggests the fix this PR applies.

## Scope check

`grep "gbrain init" tests/heavy/*.sh` → only `frontmatter_scan_wallclock.sh` calls init. This PR is the full surface fix; no other heavy script needs touching.

## Why not configure an embedding key in CI

- Costs API spend on every nightly run for a test that doesn't embed.
- Adds a secret-management dependency for a test that doesn't need one.
- Hides intent — the test legitimately measures `doctor`, not embedding pipeline.

Using `--no-embedding` makes the test's actual scope explicit and keeps CI free.

## Test plan

Verified locally with a small fixture (full 60K fixture takes ~3min to seed):

```
$ REAL_PAGES=100 NODE_MODULES_PAGES=500 WALLCLOCK_BUDGET_S=60 \
    bash tests/heavy/frontmatter_scan_wallclock.sh
[fm_wallclock] fixture seeded in 3s
[fm_wallclock] init brain...
[fm_wallclock] running gbrain doctor (budget 60s)...
[fm_wallclock] doctor exit=0 wallclock=627ms
[fm_wallclock] frontmatter_integrity: status=ok msg=No registered sources to scan
[fm_wallclock] PASS (doctor=627ms < 60s budget, frontmatter_integrity=ok)
```

- [ ] Heavy Tests workflow goes green on next scheduled run (08:17 UTC) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)