### PR TITLE
fix(lint): preserve shared Postgres connection during config lift

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -312,7 +312,10 @@ async function resolveLintContentSanity(): Promise<LintContentOpts['contentSanit
         database_path: base!.database_path,
       });
       try {
-        await engine.connect({});
+        // Use an instance-owned pool for this short-lived config probe so
+        // disconnecting the temporary engine cannot tear down a shared
+        // module-level Postgres connection used by an active dream cycle.
+        await engine.connect({ poolSize: 1 });
         const lifted = await loadConfigWithEngine(engine, base);
         cs = lifted?.content_sanity ?? cs;
       } finally {

--- a/test/e2e/lint-does-not-clobber-shared-postgres.test.ts
+++ b/test/e2e/lint-does-not-clobber-shared-postgres.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression: runLintCore's config-lift helper must not disconnect the
+ * module-level Postgres singleton that another live PostgresEngine is using.
+ *
+ * Field failure shape:
+ *   1. A shared PostgresEngine is connected via db.ts's module singleton.
+ *   2. lint opens a temporary engine just to read DB-backed config.
+ *   3. The temporary engine disconnects and calls db.disconnect().
+ *   4. The shared engine's next getConfig() explodes with
+ *      "connect() has not been called".
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { setupDB, teardownDB, getEngine } from './helpers.ts';
+import { runLintCore } from '../../src/commands/lint.ts';
+
+describe('E2E: lint DB-config lift preserves shared Postgres connection', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    await setupDB();
+    dir = mkdtempSync(join(tmpdir(), 'gbrain-e2e-lint-'));
+    writeFileSync(
+      join(dir, 'sample.md'),
+      '# Sample\n\nPlain markdown body.\n',
+    );
+  }, 30_000);
+
+  afterAll(async () => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    await teardownDB();
+  });
+
+  test('runLintCore returns without disconnecting the shared engine', async () => {
+    const shared = getEngine();
+
+    await expect(runLintCore({ target: dir, fix: true, dryRun: false })).resolves.toBeTruthy();
+    await expect(shared.getConfig('schema_version')).resolves.toBe('1');
+  });
+});


### PR DESCRIPTION
## Summary

Use an instance-owned Postgres pool for lint's temporary DB-backed config lift.

## Problem

`runLintCore()` can open a short-lived engine to read DB-backed content-sanity
config. On Postgres, that temporary engine was using the module-level singleton
connection and disconnecting it on cleanup.

In long-running workflows that share a `PostgresEngine` instance, this could
tear down the caller's connection mid-run.

Observed downstream symptom:
- `gbrain dream` reached later phases and then failed with
  `No database connection: connect() has not been called`

## Fix

- connect the temporary lint probe engine with `poolSize: 1`
- keep the connection instance-owned so cleanup cannot clobber the shared
  module-level singleton

## Tests

- add E2E regression coverage proving `runLintCore()` does not disconnect a
  shared `PostgresEngine`
