### PR TITLE
fix(gateway): accept explicit litellm embedding model ids

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -670,7 +670,8 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
-    (recipe.id === 'litellm' || isUserProvided)
+    (recipe.id === 'litellm' || isUserProvided) &&
+    parsed.modelId.trim().length === 0
   ) {
     return {
       ok: false,

--- a/test/embed-preflight.test.ts
+++ b/test/embed-preflight.test.ts
@@ -87,6 +87,16 @@ describe('validateEmbeddingCreds', () => {
     }
   });
 
+  test('passes for litellm when a concrete model id is present', () => {
+    configureGateway(baseConfig({
+      embedding_model: 'litellm:bge-m3-emb',
+      embedding_dimensions: 1024,
+      env: { LITELLM_BASE_URL: 'http://emb.example/v1', LITELLM_API_KEY: 'sk-test' },
+      base_urls: { litellm: 'http://emb.example/v1' },
+    }));
+    expect(() => validateEmbeddingCreds()).not.toThrow();
+  });
+
   test('throws unknown_provider when embedding_model uses unknown provider', () => {
     configureGateway(baseConfig({ embedding_model: 'fakeprovider:embed-1', env: {} }));
     let caught: unknown;


### PR DESCRIPTION
## Summary

Do not reject `litellm:<model>` embedding configs when the model id is already
explicitly present.

## Problem

Embedding preflight treated LiteLLM's empty allowlist as equivalent to
"no model specified", even when the configured embedding model already had a
concrete suffix like `litellm:bge-m3-emb`.

That caused embedding preflight to fail with the user-provided-model-unset
diagnosis even though the configuration was valid.

## Fix

- keep the user-provided-model guard
- only fire it when the parsed model id is actually empty
- allow explicit `provider:model` strings through

## Tests

- add regression coverage for `litellm:bge-m3-emb`
