### PR TITLE
fix(sources): stop double-encoding source config on Postgres

### DIFF
--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -26,6 +26,7 @@
 import { writeFileSync, unlinkSync, existsSync } from 'fs';
 import { join } from 'path';
 import type { BrainEngine } from '../core/engine.ts';
+import { PostgresEngine } from '../core/postgres-engine.ts';
 import {
   assessDestructiveImpact,
   checkDestructiveConfirmation,
@@ -540,10 +541,7 @@ async function runFederate(engine: BrainEngine, args: string[], value: boolean):
   }
   const config = parseConfig(src.config);
   config.federated = value;
-  await engine.executeRaw(
-    `UPDATE sources SET config = $1::jsonb WHERE id = $2`,
-    [JSON.stringify(config), id],
-  );
+  await writeSourceConfig(engine, id, config);
   console.log(`Source "${id}" is now ${value ? 'federated (appears in cross-source default search)' : 'isolated (only searched when explicitly named)'}.`);
 
   // v0.40 D19: auto-submit embed-backfill when coverage < 100%. Federation
@@ -640,6 +638,27 @@ function formatLag(seconds: number): string {
   return `${Math.floor(seconds / 86400)}d`;
 }
 
+async function writeSourceConfig(
+  engine: BrainEngine,
+  id: string,
+  config: Record<string, unknown>,
+): Promise<void> {
+  if (engine instanceof PostgresEngine) {
+    const sql = engine.sql as typeof engine.sql & { json: (value: unknown) => unknown };
+    await sql`
+      UPDATE sources
+         SET config = ${sql.json(config)}
+       WHERE id = ${id}
+    `;
+    return;
+  }
+
+  await engine.executeRaw(
+    `UPDATE sources SET config = $1::jsonb WHERE id = $2`,
+    [JSON.stringify(config), id],
+  );
+}
+
 // ── v0.40 sources webhook (D8) ──────────────────────────────
 async function runWebhook(engine: BrainEngine, args: string[]): Promise<void> {
   const sub = args[0];
@@ -693,10 +712,7 @@ async function runWebhookSet(engine: BrainEngine, args: string[]): Promise<void>
   const cfg = parseConfig(src.config);
   cfg.webhook_secret = secret;
   cfg.github_repo = githubRepo;
-  await engine.executeRaw(
-    `UPDATE sources SET config = $1::jsonb WHERE id = $2`,
-    [JSON.stringify(cfg), id],
-  );
+  await writeSourceConfig(engine, id, cfg);
 
   console.log(`Webhook configured for source "${id}":`);
   console.log(`  github_repo:    ${githubRepo}`);
@@ -749,10 +765,7 @@ async function runWebhookRotate(engine: BrainEngine, args: string[]): Promise<vo
   const secret = randomBytes(32).toString('hex');
   const cfg = parseConfig(src.config);
   cfg.webhook_secret = secret;
-  await engine.executeRaw(
-    `UPDATE sources SET config = $1::jsonb WHERE id = $2`,
-    [JSON.stringify(cfg), id],
-  );
+  await writeSourceConfig(engine, id, cfg);
   console.log(`New webhook secret for source "${id}":`);
   console.log(`  ${secret}`);
   console.log('');
@@ -773,10 +786,7 @@ async function runWebhookClear(engine: BrainEngine, args: string[]): Promise<voi
   const cfg = parseConfig(src.config);
   delete cfg.webhook_secret;
   delete cfg.github_repo;
-  await engine.executeRaw(
-    `UPDATE sources SET config = $1::jsonb WHERE id = $2`,
-    [JSON.stringify(cfg), id],
-  );
+  await writeSourceConfig(engine, id, cfg);
   console.log(`Webhook configuration cleared for source "${id}".`);
 }
 
@@ -798,10 +808,7 @@ async function runTrackedBranch(engine: BrainEngine, args: string[]): Promise<vo
 
   if (setArg) {
     cfg.tracked_branch = setArg;
-    await engine.executeRaw(
-      `UPDATE sources SET config = $1::jsonb WHERE id = $2`,
-      [JSON.stringify(cfg), id],
-    );
+    await writeSourceConfig(engine, id, cfg);
     console.log(`Tracked branch for source "${id}" set to "${setArg}".`);
     return;
   }
@@ -814,10 +821,7 @@ async function runTrackedBranch(engine: BrainEngine, args: string[]): Promise<vo
       const { execFileSync } = await import('node:child_process');
       const branch = execFileSync('git', ['-C', src.local_path, 'rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf8' }).trim();
       cfg.tracked_branch = branch;
-      await engine.executeRaw(
-        `UPDATE sources SET config = $1::jsonb WHERE id = $2`,
-        [JSON.stringify(cfg), id],
-      );
+      await writeSourceConfig(engine, id, cfg);
       console.log(`Detected branch "${branch}" for source "${id}"; persisted to config.tracked_branch.`);
     } catch (e) {
       console.error(`git rev-parse failed: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -41,6 +41,7 @@ import { realpathSync } from 'fs';
 import { join, dirname, resolve as resolvePath } from 'path';
 import { randomBytes } from 'crypto';
 import type { BrainEngine } from './engine.ts';
+import { PostgresEngine } from './postgres-engine.ts';
 import {
   parseRemoteUrl,
   cloneRepo,
@@ -168,6 +169,26 @@ function validateSourceId(id: string): void {
       `Invalid source id "${id}". Must be 1-32 lowercase alnum chars with optional interior hyphens.`,
     );
   }
+}
+
+async function insertSourceRow(
+  engine: BrainEngine,
+  row: { id: string; name: string; localPath: string | null; config: Record<string, unknown> },
+): Promise<void> {
+  if (engine instanceof PostgresEngine) {
+    const sql = engine.sql as typeof engine.sql & { json: (value: unknown) => unknown };
+    await sql`
+      INSERT INTO sources (id, name, local_path, config)
+      VALUES (${row.id}, ${row.name}, ${row.localPath}, ${sql.json(row.config)})
+    `;
+    return;
+  }
+
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, local_path, config)
+         VALUES ($1, $2, $3, $4::jsonb)`,
+    [row.id, row.name, row.localPath, JSON.stringify(row.config)],
+  );
 }
 
 function parseConfig(config: unknown): Record<string, unknown> {
@@ -333,11 +354,12 @@ export async function addSource(
     const displayName = opts.name ?? opts.id;
 
     try {
-      await engine.executeRaw(
-        `INSERT INTO sources (id, name, local_path, config)
-             VALUES ($1, $2, $3, $4::jsonb)`,
-        [opts.id, displayName, finalPath, JSON.stringify(config)],
-      );
+      await insertSourceRow(engine, {
+        id: opts.id,
+        name: displayName,
+        localPath: finalPath,
+        config,
+      });
     } catch (e) {
       rmSync(tempDir, { recursive: true, force: true });
       throw new SourceOpError(
@@ -379,11 +401,12 @@ export async function addSource(
       config.federated = opts.federated;
     }
     const displayName = opts.name ?? opts.id;
-    await engine.executeRaw(
-      `INSERT INTO sources (id, name, local_path, config)
-           VALUES ($1, $2, $3, $4::jsonb)`,
-      [opts.id, displayName, finalPath, JSON.stringify(config)],
-    );
+    await insertSourceRow(engine, {
+      id: opts.id,
+      name: displayName,
+      localPath: finalPath,
+      config,
+    });
   }
 
   const created = await fetchSourceRow(engine, opts.id);

--- a/test/e2e/list-all-sources-postgres.test.ts
+++ b/test/e2e/list-all-sources-postgres.test.ts
@@ -160,4 +160,17 @@ describeIfDB('Postgres parity — updateSourceConfig', () => {
     expect(rows[0]?.typeof).toBe('object');
     expect(rows[0]?.value).toBe('2026-05-22T12:00:00.000Z');
   });
+
+  test('merging into existing object stays an object, not an array', async () => {
+    await seedSource('echo', { config: { federated: true } });
+    await engine.updateSourceConfig('echo', { last_full_cycle_at: '2026-05-28T01:40:57.176Z' });
+    const rows = await engine.executeRaw<{ typeof: string; value: string | null; raw: unknown }>(
+      `SELECT jsonb_typeof(config) AS typeof,
+              config->>'last_full_cycle_at' AS value,
+              config AS raw
+         FROM sources WHERE id = 'echo'`,
+    );
+    expect(rows[0]?.typeof).toBe('object');
+    expect(rows[0]?.value).toBe('2026-05-28T01:40:57.176Z');
+  });
 });


### PR DESCRIPTION
## Summary

Write `sources.config` as real JSON on Postgres instead of
`JSON.stringify(...)+::jsonb`.

## Problem

Several source-management write paths persisted config through
`JSON.stringify(config)` into a `::jsonb` cast.

On Postgres this can store a JSON string shape instead of an object. Later
config merges then degrade into arrays, and object-path reads like
`config->>'last_full_cycle_at'` stop working.

This breaks doctor/autopilot freshness checks and corrupts source metadata.

## Fix

- add a safe Postgres config-write path using `sql.json(...)`
- use it in:
  - `sources` command config updates
  - `sources-ops` source creation paths
- preserve the existing PGLite behavior

## Tests

- extend Postgres parity coverage for `updateSourceConfig()`
- keep `sources-ops` coverage on add/create paths
- assert merged config stays a JSON object, not an array
