### PR TITLE
fix: accept configured user-provided embedding models

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -671,7 +671,8 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
-    (recipe.id === 'litellm' || isUserProvided)
+    (recipe.id === 'litellm' || isUserProvided) &&
+    !parsed.modelId
   ) {
     return {
       ok: false,

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -382,6 +382,15 @@ function validateDimAgainstTouchpoint(
   }
 
   if (requestedDims !== undefined && requestedDims !== defaultDims) {
+    if (recipe.touchpoints.embedding?.user_provided_models === true) {
+      return {
+        ok: true,
+        dim,
+        model: `${recipe.id}:${modelId}`,
+        provider: recipe.id,
+        recipeDefault: defaultDims,
+      };
+    }
     // User asked for a non-default dim. Walk the precedence chain.
     const customDimOk = isCustomDimValidForProvider(recipe, modelId, requestedDims, dimsOptions);
     if (!customDimOk.valid) {

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -49,6 +49,22 @@ describe('gateway configuration', () => {
     expect(getEmbeddingDimensions()).toBe(1280);
     expect(getExpansionModel()).toBe('anthropic:claude-haiku-4-5-20251001');
   });
+
+  test('diagnoseEmbedding accepts configured user-provided model ids', async () => {
+    const { diagnoseEmbedding } = await import('../../src/core/ai/gateway.ts');
+    configureGateway({
+      embedding_model: 'llama-server:hf.co/Qwen/Qwen3-Embedding-0.6B-GGUF:Q8_0',
+      embedding_dimensions: 1024,
+      env: {},
+    });
+
+    expect(diagnoseEmbedding()).toEqual({
+      ok: true,
+      model: 'llama-server:hf.co/Qwen/Qwen3-Embedding-0.6B-GGUF:Q8_0',
+      provider: 'llama-server',
+      recipeId: 'llama-server',
+    });
+  });
 });
 
 describe('gateway.isAvailable (silent-drop regression surface)', () => {

--- a/test/embedding-dim-check.test.ts
+++ b/test/embedding-dim-check.test.ts
@@ -237,6 +237,20 @@ describe('resolveSchemaEmbeddingDim', () => {
     if (got.ok) expect(got.dim).toBe(768);
   });
 
+  test('user-provided embedding providers accept explicit dimensions for arbitrary model ids', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:hf.co/Qwen/Qwen3-Embedding-0.6B-GGUF:Q8_0',
+      embedding_dimensions: 1024,
+    });
+    expect(got).toEqual({
+      ok: true,
+      dim: 1024,
+      model: 'llama-server:hf.co/Qwen/Qwen3-Embedding-0.6B-GGUF:Q8_0',
+      provider: 'llama-server',
+      recipeDefault: 0,
+    });
+  });
+
   test('unknown provider rejected with provider list hint', () => {
     const got = resolveSchemaEmbeddingDim({ embedding_model: 'notarealprovider:foo' });
     expect(got.ok).toBe(false);


### PR DESCRIPTION
## Summary
  Fix GBrain embedding preflight for user-provided embedding models.

  When a recipe has `user_provided_models: true`, GBrain should accept an explicitly configured custom embedding model id and dimension, for example:

  - provider: `llama-server`
  - model: `hf.co/Qwen/Qwen3-Embedding-0.6B-GGUF:Q8_0`
  - dimension: `1024`

  Before this change, diagnostics and dimension validation could still treat custom model ids as unset/unknown.

  ## Changes
  - Do not report `user_provided_model_unset` when a configured model id is present.
  - Allow explicit embedding dimensions for user-provided model recipes.
  - Add focused tests for gateway diagnostics and embedding dimension checks.

  ## Verification
  - `bun test test/embedding-dim-check.test.ts test/ai/gateway.test.ts`
  - `bun run typecheck`
  - `bun test test/embedding-dim-check.test.ts test/ai/gateway.test.ts test/embed-preflight.test.ts test/doctor-ze-checks.test.ts`

  Note: `bun run verify` was attempted locally, but this machine terminated verify subprocesses with `rc=143/SIGTERM`; focused tests and typecheck passed.