### PR TITLE
fix: refresh sync freshness on no-op sync

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -543,6 +543,20 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       detachedWorkingTreeManifest.renamed.length > 0);
 
   if (lastCommit === headCommit && !versionMismatch && !versionNeverSet && !hasDetachedWorkingTreeChanges) {
+    if (opts.dryRun) {
+      console.log(`Sync dry run: ${lastCommit.slice(0, 8)}..${headCommit.slice(0, 8)}`);
+      console.log('  No syncable changes.');
+      return {
+        status: 'dry_run',
+        fromCommit: lastCommit,
+        toCommit: headCommit,
+        added: 0, modified: 0, deleted: 0, renamed: 0,
+        chunksCreated: 0,
+        embedded: 0,
+        pagesAffected: [],
+      };
+    }
+
     // A successful no-op sync still proves the source is current. Refresh
     // last_sync_at so doctor's freshness check reflects the maintainer run.
     await writeSyncAnchor(engine, opts.sourceId, 'last_commit', headCommit);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -543,6 +543,12 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       detachedWorkingTreeManifest.renamed.length > 0);
 
   if (lastCommit === headCommit && !versionMismatch && !versionNeverSet && !hasDetachedWorkingTreeChanges) {
+    // A successful no-op sync still proves the source is current. Refresh
+    // last_sync_at so doctor's freshness check reflects the maintainer run.
+    await writeSyncAnchor(engine, opts.sourceId, 'last_commit', headCommit);
+    await engine.setConfig('sync.last_run', new Date().toISOString());
+    await writeSyncAnchor(engine, opts.sourceId, 'repo_path', repoPath);
+    await writeChunkerVersion(engine, opts.sourceId, currentVersion);
     return {
       status: 'up_to_date',
       fromCommit: lastCommit,

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -591,6 +591,86 @@ describe('performSync dry-run never writes', () => {
     expect(rows[0]?.last_sync_at).not.toBeNull();
     expect(new Date(rows[0]!.last_sync_at!).getTime()).toBeGreaterThan(Date.now() - 60_000);
   });
+
+  test('source-scoped no-op dry-run stays read-only and leaves stale freshness failing', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const { checkSyncFreshness } = await import('../src/commands/doctor.ts');
+
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config)
+       VALUES ('kayako', 'Kayako', $1, '{}'::jsonb)
+       ON CONFLICT (id) DO UPDATE
+       SET name = EXCLUDED.name,
+           local_path = EXCLUDED.local_path,
+           config = EXCLUDED.config`,
+      [repoPath],
+    );
+
+    const seeded = await performSync(engine, {
+      repoPath,
+      sourceId: 'kayako',
+      noPull: true,
+      noEmbed: true,
+      noExtract: true,
+    });
+    expect(seeded.status).toBe('first_sync');
+
+    const staleSyncAt = new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString();
+    const previousLastRun = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    await engine.executeRaw(
+      `UPDATE sources
+       SET last_sync_at = $1
+       WHERE id = 'kayako'`,
+      [staleSyncAt],
+    );
+    await engine.setConfig('sync.last_run', previousLastRun);
+
+    const before = await engine.executeRaw<{
+      last_commit: string | null;
+      last_sync_at: Date | string | null;
+      local_path: string | null;
+      chunker_version: string | null;
+    }>(
+      `SELECT last_commit, last_sync_at, local_path, chunker_version
+       FROM sources
+       WHERE id = 'kayako'`,
+    );
+    expect(before[0]).toBeDefined();
+    expect(before[0]?.last_sync_at).not.toBeNull();
+
+    const staleBefore = await checkSyncFreshness(engine);
+    expect(staleBefore.status).toBe('fail');
+
+    const preview = await performSync(engine, {
+      repoPath,
+      sourceId: 'kayako',
+      dryRun: true,
+      noPull: true,
+      noEmbed: true,
+      noExtract: true,
+    });
+    expect(preview.status).toBe('dry_run');
+
+    const staleAfter = await checkSyncFreshness(engine);
+    expect(staleAfter.status).toBe('fail');
+
+    const after = await engine.executeRaw<{
+      last_commit: string | null;
+      last_sync_at: Date | string | null;
+      local_path: string | null;
+      chunker_version: string | null;
+    }>(
+      `SELECT last_commit, last_sync_at, local_path, chunker_version
+       FROM sources
+       WHERE id = 'kayako'`,
+    );
+    expect(after[0]).toBeDefined();
+    expect(after[0]?.last_commit).toBe(before[0]?.last_commit);
+    expect(after[0]?.local_path).toBe(before[0]?.local_path);
+    expect(after[0]?.chunker_version).toBe(before[0]?.chunker_version);
+    expect(new Date(after[0]!.last_sync_at!).toISOString()).toBe(new Date(before[0]!.last_sync_at!).toISOString());
+    expect(await engine.getConfig('sync.last_run')).toBe(previousLastRun);
+  });
 });
 
 describe('sync regression — #132 nested transaction deadlock', () => {

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -539,6 +539,58 @@ describe('performSync dry-run never writes', () => {
     expect(page).not.toBeNull();
     expect(page!.title).toBe('Detached NoPull');
   });
+
+  test('source-scoped no-op sync refreshes last_sync_at so doctor stops reporting stale freshness', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const { checkSyncFreshness } = await import('../src/commands/doctor.ts');
+
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config)
+       VALUES ('kayako', 'Kayako', $1, '{}'::jsonb)
+       ON CONFLICT (id) DO UPDATE
+       SET name = EXCLUDED.name,
+           local_path = EXCLUDED.local_path,
+           config = EXCLUDED.config`,
+      [repoPath],
+    );
+
+    const seeded = await performSync(engine, {
+      repoPath,
+      sourceId: 'kayako',
+      noPull: true,
+      noEmbed: true,
+      noExtract: true,
+    });
+    expect(seeded.status).toBe('first_sync');
+
+    await engine.executeRaw(
+      `UPDATE sources
+       SET last_sync_at = $1
+       WHERE id = 'kayako'`,
+      [new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString()],
+    );
+
+    const staleBefore = await checkSyncFreshness(engine);
+    expect(staleBefore.status).toBe('fail');
+
+    const refreshed = await performSync(engine, {
+      repoPath,
+      sourceId: 'kayako',
+      noPull: true,
+      noEmbed: true,
+      noExtract: true,
+    });
+    expect(refreshed.status).toBe('up_to_date');
+
+    const freshnessAfter = await checkSyncFreshness(engine);
+    expect(freshnessAfter.status).toBe('ok');
+
+    const rows = await engine.executeRaw<{ last_sync_at: Date | string | null }>(
+      `SELECT last_sync_at FROM sources WHERE id = 'kayako'`,
+    );
+    expect(rows[0]?.last_sync_at).not.toBeNull();
+    expect(new Date(rows[0]!.last_sync_at!).getTime()).toBeGreaterThan(Date.now() - 60_000);
+  });
 });
 
 describe('sync regression — #132 nested transaction deadlock', () => {


### PR DESCRIPTION
## Problem
Kayako GBrain maintainer refreshes could finish successfully and still leave `doctor` reporting `sync_freshness=fail` for the `kayako` source.

## Root Cause
`checkSyncFreshness()` reads only `sources.last_sync_at`, but `performSyncInner()` returned early with `status: 'up_to_date'` whenever `last_commit === HEAD`. That fast path skipped the metadata updates that happen on other successful sync paths, so a no-op refresh never advanced `last_sync_at`.

## Change Summary
- refresh `last_sync_at`, `sync.last_run`, `repo_path`, and `chunker_version` on the no-op `up_to_date` sync path
- add a regression that forces `last_sync_at` stale, verifies `doctor` fails, runs a no-op source sync, and verifies freshness returns to `ok`

## Verification
- `/paperclip/gbrain/bun/bin/bun test test/sync.test.ts -t "source-scoped no-op sync refreshes last_sync_at so doctor stops reporting stale freshness"`

## Risk
Low. The change only touches the already-successful no-op sync fast path and makes its bookkeeping match the existing successful sync branches.

## Paperclip
- Issue: KAY-790
