### PR TITLE
fix(retry): reconnect engine pool in batchRetry onRetry — singleton-null repair

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1897,7 +1897,7 @@ export class PostgresEngine implements BrainEngine {
         jitter: BULK_RETRY_OPTS.jitter,
         auditSite,
         signal,
-        onRetry: (attempt, err) => {
+        onRetry: async (attempt, err) => {
           // Compute delay for this attempt for the audit record. withRetry
           // re-computes internally; this mirrors the math so the audit value
           // matches what actually sleeps.
@@ -1906,6 +1906,22 @@ export class PostgresEngine implements BrainEngine {
           auditLogBatchRetry(auditSite, batchSize, attempt, delay, err);
           const msg = err instanceof Error ? err.message : String(err);
           process.stderr.write(`[${auditSite}] connection blip, retrying (attempt ${attempt}/${opts.maxRetries}): ${msg}\n`);
+          // Singleton-null repair: retry-matcher acknowledges
+          // "No database connection" as retryable (PR #1416), but the
+          // historical retry path did not re-establish the pool — all
+          // attempts hit the same null singleton and batches were lost.
+          // withRetry only fires onRetry after isRetryableConnError already
+          // matched, so the err here is always connection-class; mirror the
+          // supervisor pool-restart pattern (minions/supervisor.ts:600).
+          // engine.reconnect() no-ops when _savedConfig is null (module
+          // mode without a saved engine config) so it's safe to call.
+          try {
+            await this.reconnect();
+          } catch (reconnectErr) {
+            process.stderr.write(
+              `[${auditSite}] reconnect failed (will retry against existing pool): ${(reconnectErr as Error).message}\n`,
+            );
+          }
         },
       });
     } catch (err) {

--- a/src/core/retry.ts
+++ b/src/core/retry.ts
@@ -112,8 +112,15 @@ export interface WithRetryOpts {
   signal?: AbortSignal;
   /** Audit-site label for observability. Must be in BATCH_AUDIT_SITES. */
   auditSite?: BatchAuditSite;
-  /** Per-attempt callback fires on each retry (attempt is 1-based). */
-  onRetry?: (attempt: number, err: unknown) => void;
+  /**
+   * Per-attempt callback fires on each retry (attempt is 1-based). May
+   * return a Promise; withRetry awaits it before sleeping + the next
+   * attempt. This lets the callback do pre-retry repair work (e.g.
+   * reconnect a dead pool) atomically with the retry — without await,
+   * an async onRetry is fire-and-forget and the retry races against
+   * unfinished repair, which is the singleton-null repro from PR #1416.
+   */
+  onRetry?: (attempt: number, err: unknown) => void | Promise<void>;
 }
 
 /**
@@ -227,7 +234,9 @@ export async function withRetry<T>(
       if (!isRetryableConnError(err)) throw err;
       lastErr = err;
       if (attempt >= maxRetries) break;
-      opts.onRetry?.(attempt + 1, err);
+      // Awaited so an async onRetry can complete pre-retry repair (e.g.
+      // engine.reconnect()) before the next attempt fires. See WithRetryOpts.
+      await opts.onRetry?.(attempt + 1, err);
       const delay = computeNextDelay(attempt, prevDelay, baseDelay, maxDelay, jitter);
       prevDelay = delay;
       await abortableSleep(delay, signal);

--- a/test/core/retry.test.ts
+++ b/test/core/retry.test.ts
@@ -154,6 +154,69 @@ describe('withRetry primitive — v0.41.2.1 back-compat contract', () => {
     expect((received!.err as Error).message).toBe('Connection terminated unexpectedly');
   });
 
+  test('async onRetry is awaited before the next attempt (PR #1416 follow-up)', async () => {
+    // Without `await opts.onRetry?.(...)` in withRetry, async pre-retry
+    // repair work (e.g. engine.reconnect()) is fire-and-forget and the
+    // next attempt races against unfinished repair. The batchRetry
+    // path relies on this contract to reconnect a null singleton before
+    // the next attempt — see postgres-engine.ts:batchRetry.
+    const events: string[] = [];
+    let calls = 0;
+    await withRetry(
+      async () => {
+        calls++;
+        events.push(`attempt-${calls}-start`);
+        if (calls === 1) throw new Error('No database connection: connect() has not been called');
+        events.push(`attempt-${calls}-ok`);
+        return 'ok';
+      },
+      {
+        delayMs: 0,
+        onRetry: async () => {
+          events.push('onRetry-start');
+          // Force a microtask boundary so a non-awaited onRetry would
+          // resolve AFTER attempt-2-start. With proper await, this
+          // resolves BEFORE attempt-2-start.
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          events.push('onRetry-done');
+        },
+      },
+    );
+    expect(calls).toBe(2);
+    expect(events).toEqual([
+      'attempt-1-start',
+      'onRetry-start',
+      'onRetry-done',
+      'attempt-2-start',
+      'attempt-2-ok',
+    ]);
+  });
+
+  test('async onRetry that throws does not crash withRetry (best-effort repair)', async () => {
+    // engine.reconnect() can itself fail (pool restart still racing the
+    // dead pooler). withRetry should not swallow the original error path:
+    // a throwing onRetry currently propagates, which is the right call —
+    // surfaces the reconnect failure visibly instead of masking it. This
+    // test pins that behavior so a future "swallow onRetry errors" patch
+    // is a deliberate choice rather than an accident.
+    let calls = 0;
+    const promise = withRetry(
+      async () => {
+        calls++;
+        throw new Error('ECONNRESET');
+      },
+      {
+        delayMs: 0,
+        onRetry: async () => {
+          throw new Error('reconnect failed');
+        },
+      },
+    );
+    await expect(promise).rejects.toThrow('reconnect failed');
+    // Only the first attempt ran; onRetry threw before retry could fire.
+    expect(calls).toBe(1);
+  });
+
   test('delayMs default is 500ms when not specified', async () => {
     let calls = 0;
     const start = Date.now();


### PR DESCRIPTION
## Problem

[#1416](https://github.com/garrytan/gbrain/pull/1416) added `"No database connection"` to `retry-matcher.ts`'s retryable patterns, but the retry path never re-establishes the connection pool. When `engine.disconnect()` runs mid-cycle (for example between dream phases, or via `connection-manager` lifecycle), the module-level singleton in `db.ts` goes null; the in-flight batch flunks with `"No database connection: connect() has not been called."`, `withRetry` faithfully fires 3/3 retries against the same null singleton, and the batch is **silently lost**.

### Live repro

`gbrain dream` on v0.41.26.0 against direct Postgres (not Supavisor):

```
[extract.timeline_fs] 706/706 (100%)
[extract.timeline_fs] connection blip, retrying (attempt 1/3): No database connection: connect() has not been called. Fix: Run gbrain init --supabase or gbrain init --url <connection_string>
[extract.timeline_fs] connection blip, retrying (attempt 2/3): No database connection: connect() has not been called. Fix: Run gbrain init --supabase or gbrain init --url <connection_string>
[extract.timeline_fs] connection blip, retrying (attempt 3/3): No database connection: connect() has not been called. Fix: Run gbrain init --supabase or gbrain init --url <connection_string>
  batch error (13 timeline rows lost): No database connection: connect() has not been called.
[extract.timeline_fs] 706/706 (100%) done
Timeline: created 0 entries from 706 pages
```

Downstream doctor symptoms:

```
[FAIL] batch_retry_health: 192 exhausted batch retries in last 24h
       (worst: extract.links_fs = 174). Sustained circuit-breaker incident.
[FAIL] cycle_freshness: Source 'default' has never completed a full cycle.
```

The `cycle_freshness` FAIL is a downstream effect: a later phase (`conversation_facts_backfill`) hits the dead singleton via `engine.getConfig()` and aborts the cycle.

### Root cause

Three load-bearing facts confirmed in source:

- `retry-matcher.ts:23-27` matches `/No database connection/i` and adds the typed `problem === 'No database connection'` branch — explicitly cited as the [#1416](https://github.com/garrytan/gbrain/pull/1416) follow-up.
- `postgres-engine.ts:batchRetry` `onRetry` only logs + audits — no reconnect path.
- `postgres-engine.ts:reconnect()` already exists and is exactly what's needed; it's invoked from `minions/supervisor.ts:600` but not from the retry path. `_savedConfig` is preserved at `postgres-engine.ts:95` for this purpose.
- Bonus: `retry.ts:withRetry` calls `opts.onRetry?.(...)` **without `await`**, so an async repair callback would race the next attempt regardless.

## Fix

Two-file change. ~92 lines including tests.

### `src/core/retry.ts`

Widen `WithRetryOpts.onRetry` to allow `Promise<void>` and `await` the call in `withRetry`. The old fire-and-forget call meant async pre-retry repair work (e.g. `engine.reconnect()`) could not run atomically with the retry. Sync callers are unaffected — `await undefined` resolves immediately.

### `src/core/postgres-engine.ts`

In `batchRetry`'s `onRetry`, call `this.reconnect()` before the next attempt sleeps. Mirrors the supervisor pool-restart pattern. `engine.reconnect()` no-ops when `_savedConfig` is null (module-singleton mode without a saved engine config), so the call is defensively safe. `withRetry` only invokes `onRetry` after `isRetryableConnError` matches, so every `onRetry` call is for a connection-class error where reconnect is the right repair.

```diff
   onRetry: async (attempt, err) => {
     // ... existing audit + log ...
+    try {
+      await this.reconnect();
+    } catch (reconnectErr) {
+      process.stderr.write(
+        `[${auditSite}] reconnect failed (will retry against existing pool): ${(reconnectErr as Error).message}\n`,
+      );
+    }
   },
```

## Tests

In `test/core/retry.test.ts`:

- **`async onRetry is awaited before the next attempt`** — pins the contract `batchRetry` now depends on. Asserts event ordering across an async `onRetry` with a microtask boundary; without the `await` patch the assertion would break.
- **`async onRetry that throws does not crash withRetry`** — pins the best-effort repair contract: a throwing reconnect surfaces visibly rather than being swallowed.

```
$ bun test test/core/retry.test.ts
 39 pass, 0 fail, 194 expect() calls

$ bun test test/core/retry.test.ts test/core/retry-stress.slow.test.ts test/retry-matcher.test.ts test/connection-resilience.test.ts test/doctor-batch-retry.test.ts
 94 pass, 0 fail

$ bun run typecheck
$ tsc --noEmit   # clean
```

Full `bun test` run also clean against this branch (the two `pglite-engine.test.ts > Stats & Health` failures repro on `origin/master` without these changes — pre-existing, unrelated).

## Scope of this PR

Intentionally narrow — only the batch path. The non-batch path (`conversation_facts_backfill`'s direct `engine.getConfig()` call) has the same root cause but a different fix shape (likely `engine.ensureConnected()` at phase start, or wrapping `getConfig` itself in withRetry). Happy to follow up in a second PR if this direction is approved.

## Risk

- `await opts.onRetry?.(...)` adds at most one event-loop tick per retry. No throughput impact on the common case.
- `this.reconnect()` is already exercised in production by the supervisor path. Calling it on every connection-class retry adds pool churn on a real connection blip but eliminates the pathological case of N retries against a dead pool. Net win.
- `reconnect()` is `_reconnecting`-guarded so concurrent retries collapse into a single re-init.

## Why not just block the `disconnect()` call?

Considered. `engine.disconnect()` mid-cycle is intentional in some lifecycle paths (Astra autopilot between phases, test teardown reuse, etc.) and the existing `_connectionStyle === 'module'` guard already prevents accidental clobbering between engines. Removing legitimate disconnects to paper over the retry-path gap moves the bug, doesn't fix it. The retry path is the right place to be resilient — that's what `retry-matcher`'s `"No database connection"` entry already implies the design intends.