### PR TITLE
fix(synthesize): promote subagent timeouts to config keys (#1594)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to GBrain will be documented in this file.
 
+## [0.41.15.0] - 2026-05-28
+
+- `dream.synthesize.subagent_timeout_ms` and
+  `dream.synthesize.subagent_wait_timeout_ms` now control synthesize
+  subagent job and wait timeouts. Defaults remain 30 and 35 minutes.
+
 ## [0.41.14.0] - 2026-05-25
 
 **Your gbrain skills can declare their own routing triggers in their

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -190,6 +190,8 @@ export interface GBrainConfig {
       verdict_model?: string;
       max_prompt_tokens?: number;
       max_chunks_per_transcript?: number;
+      subagent_timeout_ms?: number;
+      subagent_wait_timeout_ms?: number;
     };
     patterns?: {
       lookback_days?: number;
@@ -497,6 +499,12 @@ export async function loadConfigWithEngine(
     const n = parseInt(v, 10);
     return Number.isFinite(n) && n > 0 ? n : undefined;
   }
+  async function dbNum(key: string): Promise<number | undefined> {
+    const v = await dbStr(key);
+    if (v === undefined) return undefined;
+    const n = Number(v);
+    return Number.isNaN(n) ? undefined : n;
+  }
   const dbWarnBytes = await dbInt('content_sanity.bytes_warn');
   const dbBlockBytes = await dbInt('content_sanity.bytes_block');
   const dbJunkEnabled = await dbBool('content_sanity.junk_patterns_enabled');
@@ -530,6 +538,8 @@ export async function loadConfigWithEngine(
   const dbVerdictModel = await dbStr('dream.synthesize.verdict_model');
   const dbMaxPromptTokens = await dbInt('dream.synthesize.max_prompt_tokens');
   const dbMaxChunksPerTranscript = await dbInt('dream.synthesize.max_chunks_per_transcript');
+  const dbSubagentTimeoutMs = await dbNum('dream.synthesize.subagent_timeout_ms');
+  const dbSubagentWaitTimeoutMs = await dbNum('dream.synthesize.subagent_wait_timeout_ms');
   const dbLookbackDays = await dbInt('dream.patterns.lookback_days');
   const dbMinEvidence = await dbInt('dream.patterns.min_evidence');
 
@@ -553,6 +563,12 @@ export async function loadConfigWithEngine(
   }
   if (mergedSynth.max_chunks_per_transcript === undefined && dbMaxChunksPerTranscript !== undefined) {
     mergedSynth.max_chunks_per_transcript = dbMaxChunksPerTranscript;
+  }
+  if (mergedSynth.subagent_timeout_ms === undefined && dbSubagentTimeoutMs !== undefined) {
+    mergedSynth.subagent_timeout_ms = dbSubagentTimeoutMs;
+  }
+  if (mergedSynth.subagent_wait_timeout_ms === undefined && dbSubagentWaitTimeoutMs !== undefined) {
+    mergedSynth.subagent_wait_timeout_ms = dbSubagentWaitTimeoutMs;
   }
   if (mergedPatterns.lookback_days === undefined && dbLookbackDays !== undefined) {
     mergedPatterns.lookback_days = dbLookbackDays;
@@ -658,6 +674,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'dream.synthesize.verdict_model',
   'dream.synthesize.max_prompt_tokens',
   'dream.synthesize.max_chunks_per_transcript',
+  'dream.synthesize.subagent_timeout_ms',
+  'dream.synthesize.subagent_wait_timeout_ms',
   'dream.patterns.lookback_days',
   'dream.patterns.min_evidence',
   // Emotional weight (v0.29)

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -75,6 +75,8 @@ const MIN_PROMPT_TOKENS = 100_000;
 const DEFAULT_MAX_CHUNKS = 24;
 /** Conservative default budget when model is unknown (200K × HEADROOM_RATIO). */
 const UNKNOWN_MODEL_BUDGET_TOKENS = 180_000;
+const DEFAULT_SUBAGENT_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_SUBAGENT_WAIT_TIMEOUT_MS = 35 * 60 * 1000;
 
 /**
  * Compute per-chunk character budget for the resolved model + config override.
@@ -478,7 +480,7 @@ export async function runPhaseSynthesize(
           max_stalled: 3,
           on_child_fail: 'continue',
           idempotency_key,
-          timeout_ms: 30 * 60 * 1000, // 30 min per chunk
+          timeout_ms: config.subagentTimeoutMs,
         };
         const child = await queue.add(
           'subagent',
@@ -499,7 +501,7 @@ export async function runPhaseSynthesize(
     for (const jobId of childIds) {
       try {
         const job = await waitForCompletion(queue, jobId, {
-          timeoutMs: 35 * 60 * 1000,
+          timeoutMs: config.subagentWaitTimeoutMs,
           pollMs: 5 * 1000,
         });
         childOutcomes.push({ jobId, status: job.status });
@@ -593,6 +595,8 @@ interface SynthConfig {
    * `dream.synthesize.max_chunks_per_transcript`.
    */
   maxChunksPerTranscript: number;
+  subagentTimeoutMs: number;
+  subagentWaitTimeoutMs: number;
 }
 
 async function loadSynthConfig(engine: BrainEngine): Promise<SynthConfig> {
@@ -621,6 +625,16 @@ async function loadSynthConfig(engine: BrainEngine): Promise<SynthConfig> {
   const cooldownHoursStr = await engine.getConfig('dream.synthesize.cooldown_hours');
   const maxPromptTokensStr = await engine.getConfig('dream.synthesize.max_prompt_tokens');
   const maxChunksStr = await engine.getConfig('dream.synthesize.max_chunks_per_transcript');
+  const subagentTimeoutMs = await getNumberConfig(
+    engine,
+    'dream.synthesize.subagent_timeout_ms',
+    DEFAULT_SUBAGENT_TIMEOUT_MS,
+  );
+  const subagentWaitTimeoutMs = await getNumberConfig(
+    engine,
+    'dream.synthesize.subagent_wait_timeout_ms',
+    DEFAULT_SUBAGENT_WAIT_TIMEOUT_MS,
+  );
 
   let excludePatterns: string[] = ['medical', 'therapy'];
   if (excludeStr) {
@@ -658,7 +672,20 @@ async function loadSynthConfig(engine: BrainEngine): Promise<SynthConfig> {
     cooldownHours: cooldownHoursStr ? Math.max(0, parseInt(cooldownHoursStr, 10) || 12) : 12,
     maxPromptTokens,
     maxChunksPerTranscript,
+    subagentTimeoutMs,
+    subagentWaitTimeoutMs,
   };
+}
+
+async function getNumberConfig(
+  engine: BrainEngine,
+  key: string,
+  fallback: number,
+): Promise<number> {
+  const raw = await engine.getConfig(key);
+  if (raw === undefined || raw === null) return fallback;
+  const value = Number(raw);
+  return Number.isNaN(value) ? fallback : value;
 }
 
 async function checkCooldown(

--- a/test/config-set.test.ts
+++ b/test/config-set.test.ts
@@ -29,6 +29,11 @@ describe('KNOWN_CONFIG_KEYS', () => {
     expect(KNOWN_CONFIG_KEYS).toContain('models.tier.subagent');
   });
 
+  test('contains the dream synthesize timeout keys (#1594)', () => {
+    expect(KNOWN_CONFIG_KEYS).toContain('dream.synthesize.subagent_timeout_ms');
+    expect(KNOWN_CONFIG_KEYS).toContain('dream.synthesize.subagent_wait_timeout_ms');
+  });
+
   test('no duplicate entries', () => {
     const set = new Set(KNOWN_CONFIG_KEYS);
     expect(set.size).toBe(KNOWN_CONFIG_KEYS.length);

--- a/test/cycle-synthesize-subagent-timeout.test.ts
+++ b/test/cycle-synthesize-subagent-timeout.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { runPhaseSynthesize } from '../src/core/cycle/synthesize.ts';
+
+async function seedWorthProcessingVerdict(
+  engine: PGLiteEngine,
+  filePath: string,
+  content: string,
+): Promise<void> {
+  const contentHash = createHash('sha256').update(content, 'utf8').digest('hex');
+  await engine.putDreamVerdict(filePath, contentHash, {
+    worth_processing: true,
+    reasons: ['seeded for timeout config test'],
+  });
+}
+
+describe('runPhaseSynthesize subagent timeout config', () => {
+  test('dream.synthesize.subagent_timeout_ms flows to submitted subagent job', async () => {
+    const engine = new PGLiteEngine();
+    const brainDir = mkdtempSync(join(tmpdir(), 'gbrain-synth-timeout-brain-'));
+    const corpusDir = mkdtempSync(join(tmpdir(), 'gbrain-synth-timeout-corpus-'));
+
+    try {
+      await engine.connect({ engine: 'pglite' } as never);
+      await engine.initSchema();
+
+      await engine.setConfig('dream.synthesize.enabled', 'true');
+      await engine.setConfig('dream.synthesize.session_corpus_dir', corpusDir);
+      await engine.setConfig('dream.synthesize.subagent_timeout_ms', '600000');
+      await engine.setConfig('dream.synthesize.subagent_wait_timeout_ms', '1');
+
+      const filePath = join(corpusDir, '2026-05-28-dense-transcript.txt');
+      const content = 'dense transcript line\n'.repeat(250);
+      writeFileSync(filePath, content);
+      await seedWorthProcessingVerdict(engine, filePath, content);
+
+      const result = await runPhaseSynthesize(engine, {
+        brainDir,
+        dryRun: false,
+      });
+
+      expect(result.status).toBe('ok');
+
+      const jobs = await engine.executeRaw<{ timeout_ms: string | number | null }>(
+        `SELECT timeout_ms
+           FROM minion_jobs
+          WHERE name = 'subagent'
+          ORDER BY id DESC
+          LIMIT 1`,
+      );
+      expect(jobs).toHaveLength(1);
+      expect(Number(jobs[0].timeout_ms)).toBe(600000);
+    } finally {
+      try { await engine.disconnect(); } catch { /* best-effort */ }
+      rmSync(brainDir, { recursive: true, force: true });
+      rmSync(corpusDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/test/loadConfig-merge.test.ts
+++ b/test/loadConfig-merge.test.ts
@@ -178,7 +178,7 @@ describe('loadConfigWithEngine (Phase 4 / F3)', () => {
   // dream.* — adding env shadows is a separate PR (out of scope for the
   // fix wave). These tests pin that contract.
   describe('dream.* DB-plane merge (v0.41.2.1)', () => {
-    test('DB value fills in for all 5 dream.synthesize.* keys when base unset', async () => {
+    test('DB value fills in for dream.synthesize.* keys when base unset', async () => {
       const base: GBrainConfig = { engine: 'pglite' };
       const engine = makeEngine({
         'dream.synthesize.session_corpus_dir': '/tmp/sessions',
@@ -186,6 +186,8 @@ describe('loadConfigWithEngine (Phase 4 / F3)', () => {
         'dream.synthesize.verdict_model': 'anthropic:claude-haiku-4-5',
         'dream.synthesize.max_prompt_tokens': '180000',
         'dream.synthesize.max_chunks_per_transcript': '32',
+        'dream.synthesize.subagent_timeout_ms': '600000',
+        'dream.synthesize.subagent_wait_timeout_ms': '900000',
       });
       const merged = await loadConfigWithEngine(engine, base);
       expect(merged?.dream?.synthesize?.session_corpus_dir).toBe('/tmp/sessions');
@@ -193,6 +195,8 @@ describe('loadConfigWithEngine (Phase 4 / F3)', () => {
       expect(merged?.dream?.synthesize?.verdict_model).toBe('anthropic:claude-haiku-4-5');
       expect(merged?.dream?.synthesize?.max_prompt_tokens).toBe(180000);
       expect(merged?.dream?.synthesize?.max_chunks_per_transcript).toBe(32);
+      expect(merged?.dream?.synthesize?.subagent_timeout_ms).toBe(600000);
+      expect(merged?.dream?.synthesize?.subagent_wait_timeout_ms).toBe(900000);
     });
 
     test('DB value fills in for both dream.patterns.* keys when base unset', async () => {


### PR DESCRIPTION
Fixes #1594

Promotes two hardcoded subagent timeout literals in `src/core/cycle/synthesize.ts` to config keys (defaults preserve original behavior):

- `dream.synthesize.subagent_timeout_ms` (default 1800000 = 30 min)
- `dream.synthesize.subagent_wait_timeout_ms` (default 2100000 = 35 min)

Registered in config schema + loadConfig merge. Unit test added.

Verification: targeted test ✅, tsc --noEmit ✅, diff --check ✅