### PR TITLE
fix(engine): module-singleton shared-ownership — joiner must not tear down shared pool

### DIFF
--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -159,6 +159,17 @@ export function getConnection(): ReturnType<typeof postgres> {
   return sql;
 }
 
+/**
+ * Returns true if the module-level singleton is initialized. Used by
+ * PostgresEngine.connect to detect "I'm joining an already-shared pool"
+ * vs "I'm creating it" — only the creator should be allowed to tear it
+ * down on disconnect, otherwise a temp engine (e.g. lint's content_sanity
+ * config-read engine) silently kills the singleton for the whole cycle.
+ */
+export function isConnected(): boolean {
+  return sql !== null;
+}
+
 export async function connect(config: EngineConfig): Promise<void> {
   if (sql) {
     // Warn if a different URL is passed — the old connection is still in use

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -104,6 +104,22 @@ export class PostgresEngine implements BrainEngine {
    * db.disconnect() and clobber the unrelated module-level connection.
    */
   private _connectionStyle: 'instance' | 'module' | null = null;
+  /**
+   * For module-style connects: did THIS engine instance actually initialize
+   * the singleton, or did it just join an already-live pool? Only the
+   * initializer is allowed to tear the singleton down on disconnect.
+   *
+   * Repro (pre-fix): lint's `resolveLintContentSanity` creates a temp
+   * PostgresEngine to read 4 config keys, calls `engine.connect({})` (no
+   * poolSize → module path). `db.connect()` no-ops because the cycle's
+   * main engine already initialized the singleton. The temp engine sets
+   * `_connectionStyle='module'` regardless. Its `finally { disconnect() }`
+   * then falls through and calls `db.disconnect()` — killing the singleton
+   * mid-cycle. Sync/synthesize/embed phases that run AFTER lint flunk with
+   * "No database connection: connect() has not been called." The bug
+   * surfaces only when the cycle is engine + lint-content-sanity active.
+   */
+  private _ownsModuleSingleton = false;
 
   /**
    * v0.30.1 (Fix 1 + X1 + T5): instance-owned ConnectionManager.
@@ -178,8 +194,14 @@ export class PostgresEngine implements BrainEngine {
       this.connectionManager.setReadPool(this._sql);
     } else {
       // Module-level singleton (backward compat for CLI main engine)
+      const singletonWasLive = db.isConnected();
       await db.connect(config);
       this._connectionStyle = 'module';
+      // Only the initializer owns teardown. Joining an already-live
+      // singleton (e.g. a temp engine reading config keys mid-cycle) must
+      // NOT clobber the shared pool on disconnect. See _ownsModuleSingleton
+      // doc comment for the lint-content-sanity repro.
+      this._ownsModuleSingleton = !singletonWasLive;
 
       // v0.30.1: connection-manager wraps the module singleton.
       if (url) {
@@ -208,8 +230,17 @@ export class PostgresEngine implements BrainEngine {
       return;
     }
     if (this._connectionStyle === 'module') {
-      await db.disconnect();
+      // Only the engine instance that actually initialized the singleton
+      // is allowed to tear it down. A passive sharer (e.g. lint's
+      // resolveLintContentSanity temp engine) silently no-ops here instead
+      // of clobbering the cycle's main engine pool. See _ownsModuleSingleton
+      // doc comment for the repro that caused PRE-FIX sync/synthesize/embed
+      // phases to flunk with "No database connection".
+      if (this._ownsModuleSingleton) {
+        await db.disconnect();
+      }
       this._connectionStyle = null;
+      this._ownsModuleSingleton = false;
     }
     // else: nothing to disconnect (already done or never connected)
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1897,7 +1897,7 @@ export class PostgresEngine implements BrainEngine {
         jitter: BULK_RETRY_OPTS.jitter,
         auditSite,
         signal,
-        onRetry: (attempt, err) => {
+        onRetry: async (attempt, err) => {
           // Compute delay for this attempt for the audit record. withRetry
           // re-computes internally; this mirrors the math so the audit value
           // matches what actually sleeps.
@@ -1906,6 +1906,22 @@ export class PostgresEngine implements BrainEngine {
           auditLogBatchRetry(auditSite, batchSize, attempt, delay, err);
           const msg = err instanceof Error ? err.message : String(err);
           process.stderr.write(`[${auditSite}] connection blip, retrying (attempt ${attempt}/${opts.maxRetries}): ${msg}\n`);
+          // Singleton-null repair: retry-matcher acknowledges
+          // "No database connection" as retryable (PR #1416), but the
+          // historical retry path did not re-establish the pool — all
+          // attempts hit the same null singleton and batches were lost.
+          // withRetry only fires onRetry after isRetryableConnError already
+          // matched, so the err here is always connection-class; mirror the
+          // supervisor pool-restart pattern (minions/supervisor.ts:600).
+          // engine.reconnect() no-ops when _savedConfig is null (module
+          // mode without a saved engine config) so it's safe to call.
+          try {
+            await this.reconnect();
+          } catch (reconnectErr) {
+            process.stderr.write(
+              `[${auditSite}] reconnect failed (will retry against existing pool): ${(reconnectErr as Error).message}\n`,
+            );
+          }
         },
       });
     } catch (err) {

--- a/src/core/retry.ts
+++ b/src/core/retry.ts
@@ -112,8 +112,15 @@ export interface WithRetryOpts {
   signal?: AbortSignal;
   /** Audit-site label for observability. Must be in BATCH_AUDIT_SITES. */
   auditSite?: BatchAuditSite;
-  /** Per-attempt callback fires on each retry (attempt is 1-based). */
-  onRetry?: (attempt: number, err: unknown) => void;
+  /**
+   * Per-attempt callback fires on each retry (attempt is 1-based). May
+   * return a Promise; withRetry awaits it before sleeping + the next
+   * attempt. This lets the callback do pre-retry repair work (e.g.
+   * reconnect a dead pool) atomically with the retry — without await,
+   * an async onRetry is fire-and-forget and the retry races against
+   * unfinished repair, which is the singleton-null repro from PR #1416.
+   */
+  onRetry?: (attempt: number, err: unknown) => void | Promise<void>;
 }
 
 /**
@@ -227,7 +234,9 @@ export async function withRetry<T>(
       if (!isRetryableConnError(err)) throw err;
       lastErr = err;
       if (attempt >= maxRetries) break;
-      opts.onRetry?.(attempt + 1, err);
+      // Awaited so an async onRetry can complete pre-retry repair (e.g.
+      // engine.reconnect()) before the next attempt fires. See WithRetryOpts.
+      await opts.onRetry?.(attempt + 1, err);
       const delay = computeNextDelay(attempt, prevDelay, baseDelay, maxDelay, jitter);
       prevDelay = delay;
       await abortableSleep(delay, signal);

--- a/test/core/retry.test.ts
+++ b/test/core/retry.test.ts
@@ -154,6 +154,69 @@ describe('withRetry primitive — v0.41.2.1 back-compat contract', () => {
     expect((received!.err as Error).message).toBe('Connection terminated unexpectedly');
   });
 
+  test('async onRetry is awaited before the next attempt (PR #1416 follow-up)', async () => {
+    // Without `await opts.onRetry?.(...)` in withRetry, async pre-retry
+    // repair work (e.g. engine.reconnect()) is fire-and-forget and the
+    // next attempt races against unfinished repair. The batchRetry
+    // path relies on this contract to reconnect a null singleton before
+    // the next attempt — see postgres-engine.ts:batchRetry.
+    const events: string[] = [];
+    let calls = 0;
+    await withRetry(
+      async () => {
+        calls++;
+        events.push(`attempt-${calls}-start`);
+        if (calls === 1) throw new Error('No database connection: connect() has not been called');
+        events.push(`attempt-${calls}-ok`);
+        return 'ok';
+      },
+      {
+        delayMs: 0,
+        onRetry: async () => {
+          events.push('onRetry-start');
+          // Force a microtask boundary so a non-awaited onRetry would
+          // resolve AFTER attempt-2-start. With proper await, this
+          // resolves BEFORE attempt-2-start.
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          events.push('onRetry-done');
+        },
+      },
+    );
+    expect(calls).toBe(2);
+    expect(events).toEqual([
+      'attempt-1-start',
+      'onRetry-start',
+      'onRetry-done',
+      'attempt-2-start',
+      'attempt-2-ok',
+    ]);
+  });
+
+  test('async onRetry that throws does not crash withRetry (best-effort repair)', async () => {
+    // engine.reconnect() can itself fail (pool restart still racing the
+    // dead pooler). withRetry should not swallow the original error path:
+    // a throwing onRetry currently propagates, which is the right call —
+    // surfaces the reconnect failure visibly instead of masking it. This
+    // test pins that behavior so a future "swallow onRetry errors" patch
+    // is a deliberate choice rather than an accident.
+    let calls = 0;
+    const promise = withRetry(
+      async () => {
+        calls++;
+        throw new Error('ECONNRESET');
+      },
+      {
+        delayMs: 0,
+        onRetry: async () => {
+          throw new Error('reconnect failed');
+        },
+      },
+    );
+    await expect(promise).rejects.toThrow('reconnect failed');
+    // Only the first attempt ran; onRetry threw before retry could fire.
+    expect(calls).toBe(1);
+  });
+
   test('delayMs default is 500ms when not specified', async () => {
     let calls = 0;
     const start = Date.now();

--- a/test/postgres-engine-module-ownership.test.ts
+++ b/test/postgres-engine-module-ownership.test.ts
@@ -1,0 +1,128 @@
+// Regression for the shared-singleton ownership bug.
+//
+// Pre-fix repro (cycle on direct Postgres):
+//   1. Cycle's main engine connects without poolSize → module path,
+//      initializes the db.ts singleton, _ownsModuleSingleton=true.
+//   2. Lint phase (`resolveLintContentSanity`) creates a temp engine to
+//      read 4 config keys, calls engine.connect({}) → module path again.
+//      db.connect() no-ops (sql is alive). Temp engine sets
+//      _connectionStyle='module' but DID NOT initialize the singleton.
+//   3. Temp engine's `finally { disconnect() }` falls through and calls
+//      db.disconnect() — nulling the singleton for the cycle.
+//   4. Sync/synthesize/embed phases that run AFTER lint flunk with
+//      "No database connection: connect() has not been called."
+//
+// Fix: track `_ownsModuleSingleton` per engine instance; only the
+// initializer is allowed to tear it down. Joiners no-op on disconnect.
+//
+// Hermetic: stubs the postgres driver via mocking `db.ts` exports —
+// no real DB required.
+
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import postgres from 'postgres';
+import { PostgresEngine } from '../src/core/postgres-engine.ts';
+import * as db from '../src/core/db.ts';
+
+describe('PostgresEngine module-singleton ownership (joiner does not tear down shared pool)', () => {
+  let dbConnectCalls = 0;
+  let dbDisconnectCalls = 0;
+  let singletonAlive = false;
+
+  beforeEach(() => {
+    dbConnectCalls = 0;
+    dbDisconnectCalls = 0;
+    singletonAlive = false;
+
+    mock.module('../src/core/db.ts', () => ({
+      ...db,
+      connect: async () => {
+        dbConnectCalls++;
+        singletonAlive = true; // first call wins; subsequent are no-ops
+      },
+      disconnect: async () => {
+        dbDisconnectCalls++;
+        singletonAlive = false;
+      },
+      isConnected: () => singletonAlive,
+      getConnection: () => {
+        if (!singletonAlive) {
+          throw new Error('No database connection: connect() has not been called');
+        }
+        // Real getConnection returns a postgres tag-template; our tests
+        // never call SQL through it, so a stub is sufficient.
+        return (() => { throw new Error('SQL not used in this test'); }) as unknown as ReturnType<typeof postgres>;
+      },
+    }));
+  });
+
+  test('first engine initializes; second engine joins and does NOT disconnect on cleanup', async () => {
+    const config = { database_url: 'postgres://test/test' };
+
+    const primary = new PostgresEngine();
+    await primary.connect(config);
+    expect(dbConnectCalls).toBe(1);
+    expect(singletonAlive).toBe(true);
+
+    // Lint-content-sanity pattern: temp engine joins the shared pool.
+    const joiner = new PostgresEngine();
+    await joiner.connect(config);
+    expect(dbConnectCalls).toBe(2); // call fired but no-op'd
+    expect(singletonAlive).toBe(true); // still alive
+
+    // Temp engine cleans up — must NOT clobber the shared pool.
+    await joiner.disconnect();
+    expect(dbDisconnectCalls).toBe(0); // joiner did not call db.disconnect
+    expect(singletonAlive).toBe(true); // singleton still alive for primary
+
+    // Primary engine owns teardown — disconnect actually fires.
+    await primary.disconnect();
+    expect(dbDisconnectCalls).toBe(1);
+    expect(singletonAlive).toBe(false);
+  });
+
+  test('joiner.disconnect() called BEFORE primary.disconnect() leaves singleton usable', async () => {
+    // This is the exact lint-phase repro: primary runs the cycle, lint
+    // spawns a joiner mid-cycle, lint's finally disconnects joiner,
+    // cycle's NEXT phase still expects the singleton.
+    const config = { database_url: 'postgres://test/test' };
+
+    const primary = new PostgresEngine();
+    await primary.connect(config);
+
+    const joiner = new PostgresEngine();
+    await joiner.connect(config);
+    await joiner.disconnect(); // pre-fix: this nulled the singleton
+
+    // Pre-fix: this throw fired here. Post-fix: singleton is still alive.
+    expect(() => db.isConnected() && true).not.toThrow();
+    expect(singletonAlive).toBe(true);
+  });
+
+  test('joiner.disconnect() is idempotent (second call is a no-op)', async () => {
+    const config = { database_url: 'postgres://test/test' };
+
+    const primary = new PostgresEngine();
+    await primary.connect(config);
+
+    const joiner = new PostgresEngine();
+    await joiner.connect(config);
+    await joiner.disconnect();
+    await joiner.disconnect(); // second call — must not throw, must not clobber
+
+    expect(dbDisconnectCalls).toBe(0);
+    expect(singletonAlive).toBe(true);
+  });
+
+  test('solo engine (no other engines) initializes and tears down correctly', async () => {
+    const config = { database_url: 'postgres://test/test' };
+
+    const solo = new PostgresEngine();
+    await solo.connect(config);
+    expect(dbConnectCalls).toBe(1);
+    expect(singletonAlive).toBe(true);
+
+    await solo.disconnect();
+    expect(dbDisconnectCalls).toBe(1);
+    expect(singletonAlive).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Companion to [#1593](https://github.com/garrytan/gbrain/pull/1593) — that PR repairs the batch-retry path so existing data loss stops. This PR fixes the **root cause**: a temp engine that joins the shared module-level singleton silently kills it for the whole cycle on `disconnect()`.

### Repro (full dream cycle on direct Postgres)

1. Cycle's main engine connects without `poolSize` → module path. `db.ts` singleton initialized; `_connectionStyle='module'`.
2. Lint phase's `resolveLintContentSanity` ([src/commands/lint.ts:298](https://github.com/garrytan/gbrain/blob/master/src/commands/lint.ts)) creates a temp `PostgresEngine` to read 4 config keys, calls `engine.connect({})`.
3. `db.connect()` no-ops because singleton is already alive. Temp engine sets `_connectionStyle='module'` regardless — even though it did nothing.
4. Lint's `try/finally` calls `await engine.disconnect()` on the temp engine. **Pre-fix**: falls through to `db.disconnect()` because `_connectionStyle === 'module'` — and silently nulls the shared singleton for the rest of the cycle.
5. `sync`, `synthesize`, and `embed` phases that run AFTER lint flunk with `"No database connection: connect() has not been called."`

`extract` survives because [#1593](https://github.com/garrytan/gbrain/pull/1593)'s `batchRetry` `onRetry` calls `this.reconnect()` — but the non-batch phases have no such cushion.

### Live evidence

Traced `db.disconnect()` on a v0.41.26.0 install with a temporary stack-trace probe:

```
[DBG] db.disconnect called, sql=alive
Error
    at disconnect (db.ts:228)
    at disconnect (postgres-engine.ts:211)
    at resolveLintContentSanity (lint.ts:319)
    at async runLintCore (lint.ts:395)
    at async runPhaseLint (cycle.ts:676)
    at async runCycle (cycle.ts:1421)
```

The first `db.disconnect()` of the cycle comes from **lint**, not from anything the cycle author would expect.

## Fix

Track per-engine whether THIS instance actually initialized the singleton (`_ownsModuleSingleton`) by snapshotting `db.isConnected()` BEFORE calling `db.connect()`. Only the initializer is allowed to call `db.disconnect()` on cleanup. Joiners no-op — the CLI's main engine retains exclusive teardown rights.

### Two-file change

**`src/core/db.ts`** — export new helper `isConnected()`:

```typescript
export function isConnected(): boolean {
  return sql !== null;
}
```

**`src/core/postgres-engine.ts`** — track ownership in `connect()`, gate teardown in `disconnect()`:

```diff
+ private _ownsModuleSingleton = false;

  async connect(...) {
    ...
    } else {
+     const singletonWasLive = db.isConnected();
      await db.connect(config);
      this._connectionStyle = 'module';
+     this._ownsModuleSingleton = !singletonWasLive;
    }
  }

  async disconnect() {
    ...
    if (this._connectionStyle === 'module') {
+     if (this._ownsModuleSingleton) {
        await db.disconnect();
+     }
      this._connectionStyle = null;
+     this._ownsModuleSingleton = false;
    }
  }
```

## Tests

`test/postgres-engine-module-ownership.test.ts` pins the contract hermetically via `mock.module` on `db.ts`. Four cases:

- first engine initializes; joiner does NOT disconnect on cleanup
- `joiner.disconnect()` BEFORE `primary.disconnect()` leaves singleton alive (the exact lint-phase repro)
- `joiner.disconnect()` is idempotent
- solo engine round-trips correctly

```
$ bun test test/postgres-engine-module-ownership.test.ts
 4 pass, 0 fail, 16 expect() calls

$ bun test test/postgres-engine-module-ownership.test.ts test/engine-factory.test.ts \
          test/connection-resilience.test.ts test/connection-manager.serial.test.ts \
          test/core/retry.test.ts
 99 pass, 0 fail

$ bun run typecheck  # clean
```

## End-to-end verification

Deployed both PRs to the same install + ran `gbrain dream`:

**Before (master + nothing):**
```
✗ sync         sync phase failed
   [InternalError/UNKNOWN] No database connection: connect() has not been called.
✗ synthesize   synthesize phase failed
   [InternalError/SYNTH_PHASE_FAIL] No database connection: connect() has not been called.
✓ extract     285 link(s), 0 timeline entries  ← 13 rows lost in batch
```

**After (PR #1593 + this PR):**
```
✓ sync         +0 added, ~0 modified, -0 deleted
✓ synthesize   73 transcript(s) synthesized in 0.4s     ← drained the backlog
✓ extract      285 link(s), 37 timeline entries         ← full recovery
```

Zero `"No database connection"` in the log. The remaining `✗ embed` is an unrelated `OPENAI_API_KEY` config issue, not the singleton bug.

## Why ship both PRs

[#1593](https://github.com/garrytan/gbrain/pull/1593) and this PR are independently load-bearing:

- This PR alone — `batchRetry`'s pre-existing retry loop has no reconnect, so even though the singleton no longer dies mid-cycle, any **real** (non-leak) connection blip still loses batches. [#1593](https://github.com/garrytan/gbrain/pull/1593) is the defense-in-depth.
- [#1593](https://github.com/garrytan/gbrain/pull/1593) alone — `extract` recovers, but `sync` and `synthesize` keep flunking on every cycle. This PR is the root-cause fix.

Either can land first; merging both gives a fully clean cycle.

## Risk

Minimal — the only behavior change is that **passive sharers** stop tearing down the shared pool. The CLI's main engine, autopilot's long-lived engine, and any first-connecting engine still teardown exactly as before. Second/third-connecting engines (lint's content-sanity, frontmatter audit, any future similar pattern) now correctly no-op on cleanup.