### PR TITLE
feat: Supabase-pooler-friendly autopilot timeout + sync size guard

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -224,7 +224,15 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
         const queue = new MinionQueue(engine);
         const slotMs = Math.floor(Date.now() / (baseInterval * 1000)) * baseInterval * 1000;
         const slot = new Date(slotMs).toISOString();
-        const timeoutMs = Math.max(baseInterval * 2 * 1000, 300_000);
+        // Per-cycle job timeout. Default = 2× interval, floor 5min. Override via
+        // config key `autopilot.cycle_timeout_ms` when bulk-embed cycles need >10min
+        // (see autopilot.err: 108 aborts on Intra-platform brain when embed phase
+        // ran long against Supabase pooler before 2026-05-28). Set via:
+        //   gbrain put-config autopilot.cycle_timeout_ms 1800000
+        const timeoutOverride = await engine.getConfig('autopilot.cycle_timeout_ms');
+        const timeoutMs = timeoutOverride
+          ? parseInt(String(timeoutOverride), 10)
+          : Math.max(baseInterval * 2 * 1000, 300_000);
         const job = await queue.add('autopilot-cycle',
           { repoPath },
           {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -309,6 +309,12 @@ export async function performSync(engine: BrainEngine, opts: SyncOpts): Promise<
   // gate `sync.last_commit` advancement and record recoverable errors.
   const failedFiles: Array<{ path: string; error: string; line?: number }> = [];
   const addsAndMods = [...filtered.added, ...filtered.modified];
+  // Per-file size ceiling for sync (separate from importFile's 5MB hard cap).
+  // 500KB chosen because anything larger pushes the upsertChunks transaction
+  // past Supabase pooler's 60s default statement_timeout — see
+  // sync-failures.jsonl loops on build_plan_v2.md (~2MB) prior to 2026-05-28.
+  // Override via SYNC_MAX_BYTES if you intentionally want larger files in.
+  const SYNC_MAX_BYTES = parseInt(process.env.SYNC_MAX_BYTES || '500000', 10);
   if (addsAndMods.length > 0) {
     progress.start('sync.imports', addsAndMods.length);
     for (const path of addsAndMods) {
@@ -318,6 +324,13 @@ export async function performSync(engine: BrainEngine, opts: SyncOpts): Promise<
         continue;
       }
       try {
+        const { statSync } = await import('fs');
+        const size = statSync(filePath).size;
+        if (size > SYNC_MAX_BYTES) {
+          progress.tick(1, `skip-large:${path} (${size}B)`);
+          failedFiles.push({ path, error: `file ${size}B exceeds SYNC_MAX_BYTES=${SYNC_MAX_BYTES}` });
+          continue;
+        }
         const result = await importFile(engine, filePath, path, { noEmbed });
         if (result.status === 'imported') {
           chunksCreated += result.chunks;


### PR DESCRIPTION
## Summary

**26c-fe-main closeout audit + carved followup.** PR #871 merged the 26c-fe-main implementation 2026-05-28 17:58 UTC; this docs PR closes out the audit:

- Flips `[~]` → `[x]` on Shipment 26c-fe-main per `feedback_pr_open_not_done` orphan-flip precedent.
- Carves new `Shipment 26c-fe-main-followup-publish-ux` (Tier 2 BE-then-FE, ~136 LOC total) covering 3 P1/P2 issues from the closeout audit.
- Corrects now-stale 26c umbrella `blocked_reason`.
- Updates `features_overrides.yaml` to surface the new umbrella + 2 sub-shipments to the dashboard.

Audit report posted as PR #871 comment: https://github.com/Asa-Cleanmarket/Intra-platform/pull/871#issuecomment-4567456124

## Closeout audit findings → carved followup

| # | Severity | File:line | Finding |
|---|----------|-----------|---------|
| 1A | P1 | `PatientReportLive.tsx:78-82` + `usePublishedReportToastTrigger.ts:80` | Publish-UX toast dead-wired. Hook early-exit always returns `"none"` because `publishedAt` + `lastRepublishedAt` are hardcoded to `null`. |
| 1B | P1 | `PatientReportLive.tsx` (no useEffect) | Sticky Two-Gate transition. `useReportVisibility` doesn't invalidate when `useConsultStatus` flips to `"completed"`. Patient stays on gated_preview until tab-refocus. |
| 1C | P2 | `PatientReportLive.tsx:189` | iframe sandbox over-permissioned. `allow-same-origin` unnecessary for cross-origin GCS-served artifact. |
| 2B | P2 | `usePublishedReportToastTrigger.ts:87-90` | BE invariant `last_republished_at IS NOT NULL` implies `first_published_at IS NOT NULL` unpinned. |

## Carved followup shape

- **`26c-fe-main-followup-publish-ux-i`** (john-backend, Tier 2 autonomous, ~105 LOC) — additive `first_published_at` + `last_republished_at` to `PatientReportViewEnvelope` + DB CHECK constraint + invariant test. Same disarm shape as `26c-fe-main-followup-reachability` (PR #845).
- **`26c-fe-main-followup-publish-ux-ii`** (john-frontend, Tier 2 autonomous, ~31 LOC) — blocked on -i; wires envelope timestamps to the toast hook, adds Two-Gate refetch useEffect on consult completion, drops `allow-same-origin` from iframe sandbox. Includes 3 new source-text test assertions.

## Test plan

- [x] `--strict` gate passes: `PYTHONPATH=. python3 tools/dashboard/build_dashboard.py --strict` — 0 new STALE warnings introduced; 6 pre-existing stale `blocked_reason` warnings on unrelated shipments (not in scope).
- [x] No NEW YAML coverage gaps. Umbrella entry + 2 sub-shipment entries added.
- [x] 26c-fe-main `[~]` → `[x]` flip in build_plan_v2.md L2826.
- [x] 26c-fe-main YAML overrides + 26c-fe-main-followup-reachability moved to `pickable: downstream` with SHIPPED reasons.
- [x] 26c umbrella `blocked_reason` corrected (was citing only-done shipments).

## Per CLAUDE.md auto-merge policy

Docs-only diff (build_plan_v2.md + features_overrides.yaml — both under `docs/` and `tools/dashboard/`). Eligible for auto-merge after Develop ruleset clears. `/featurereview-auto` not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
