### PR TITLE
fix(gateway): avoid Response.clone() in ZeroEntropy/Voyage embed shims (bun <1.1.27 truncation)

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -815,7 +815,7 @@ const voyageCompatFetch = (async (input: RequestInfo | URL, init?: RequestInit) 
   if (!ct.toLowerCase().includes('application/json')) return resp;
 
   // v0.31.8 (D2 + D10): Layer 1 — Content-Length pre-check BEFORE the
-  // body is parsed. The pre-fix code did `await resp.clone().json()`
+  // body is parsed. The pre-fix code did `await resp.json()`
   // first, which fully parses arbitrary-size JSON into JS heap before
   // any size check could fire. A compromised/malicious Voyage endpoint
   // could OOM the worker on a single response. The 256 MB cap is sized
@@ -843,7 +843,7 @@ const voyageCompatFetch = (async (input: RequestInfo | URL, init?: RequestInit) 
   //   - `embedding` is a base64 string (SDK schema expects `number[]`)
   //   - `usage` lacks `prompt_tokens` (SDK schema requires it when usage present)
   try {
-    const json: any = await resp.clone().json();
+    const json: any = await resp.json();
     if (!json || typeof json !== 'object') return resp;
     let modified = false;
     if (Array.isArray(json.data)) {
@@ -883,7 +883,7 @@ const voyageCompatFetch = (async (input: RequestInfo | URL, init?: RequestInit) 
     return new Response(JSON.stringify(json), {
       status: resp.status,
       statusText: resp.statusText,
-      headers: resp.headers,
+      headers: (() => { const _h = new Headers(resp.headers); _h.delete("content-length"); _h.delete("content-encoding"); _h.delete("transfer-encoding"); return _h; })(),
     });
   } catch (err) {
     // OOM-cap throws MUST propagate. The catch is here for "Voyage returned
@@ -1008,7 +1008,7 @@ const zeroEntropyCompatFetch = (async (input: RequestInfo | URL, init?: RequestI
   // prompt_tokens when `usage` is present — same divergence Voyage hit at
   // gateway.ts:655).
   try {
-    const json: any = await resp.clone().json();
+    const json: any = await resp.json();
     if (!json || typeof json !== 'object') return resp;
     let modified = false;
     if (Array.isArray(json.results) && !Array.isArray(json.data)) {
@@ -1047,7 +1047,7 @@ const zeroEntropyCompatFetch = (async (input: RequestInfo | URL, init?: RequestI
     return new Response(JSON.stringify(json), {
       status: resp.status,
       statusText: resp.statusText,
-      headers: resp.headers,
+      headers: (() => { const _h = new Headers(resp.headers); _h.delete("content-length"); _h.delete("content-encoding"); _h.delete("transfer-encoding"); return _h; })(),
     });
   } catch (err) {
     // OOM-cap throws MUST propagate. Voyage's pattern: instanceof check on


### PR DESCRIPTION
Fixes #1610.

## Problem
`gbrain embed` fails with `[embed(zeroentropyai:zembed-1)] Invalid JSON response` for any page that produces **2 or more chunks**; single-chunk pages succeed. Same failure mode for the Voyage compat path. The ZeroEntropy API itself is fine — a direct `fetch` of the exact multi-input request returns HTTP 200 valid JSON (~124 KB for 5 chunks).

## Root cause
On **bun < 1.1.27**, `Response.clone()` truncates large in-progress streaming bodies (oven-sh/bun#6348, oven-sh/bun#4765; fixed in bun v1.1.27). Both `zeroEntropyCompatFetch` and `voyageCompatFetch` read the upstream response via `await resp.clone().json()`, so for responses with ≥2 embeddings the clone is truncated → `JSON.parse` throws `Unexpected end of JSON input` → the shim's `catch` silently `return resp` → the AI SDK reports `Invalid JSON response`. Single-result responses (~25 KB) stay under the truncation threshold, which is why it looks intermittent / size-dependent.

Confirmed by logging the shim's catch:
```
[ZEDBG] catch: Unexpected end of JSON input | name: SyntaxError
```

## Fix
Read the body directly (`await resp.json()`) instead of cloning, in both compat shims (3 call sites). Also drop the now-stale `content-length` / `content-encoding` / `transfer-encoding` headers when returning the rewritten body, since its length differs from the original.

Minimal, surgical change (verified: after this, all previously-failing multi-chunk pages embed successfully and a full brain reaches 100% coverage).

## Note
This change leaves the existing `if (!modified) return resp;` / `catch { return resp; }` fallback paths as-is. For ZeroEntropy/Voyage these are unreachable (a `results[]` array is always present, and `JSON.parse` no longer fails once the body isn't truncated), so they don't return a consumed body in practice. If you'd prefer fully-defensive fallbacks, I'm happy to read the body once into a local and reuse it across all return paths — just say the word.

## Test environment
gbrain 0.41.27.0 (also repros on 0.41.26.x), bun 1.0.36, macOS (Apple M1 / arm64). The bug is architecture-independent.
