### PR TITLE
fix(conversation-parser): add bold-name-no-timestamp builtin (Circleback/Granola/Zoom)

### DIFF
--- a/src/core/conversation-parser/builtins.ts
+++ b/src/core/conversation-parser/builtins.ts
@@ -1,7 +1,7 @@
 /**
  * v0.41.16.0 — Built-in conversation parser pattern registry.
  *
- * Twelve hand-vetted patterns covering the chat-export formats this
+ * Fourteen hand-vetted patterns covering the chat-export formats this
  * codebase is most likely to encounter. Each pattern's regex was
  * derived from a public format reference (source_doc field) so future
  * maintainers can verify against the wild shape.
@@ -50,7 +50,7 @@ export function cleanSpeaker(raw: string, override?: RegExp): string {
   return stripped || raw.trim();
 }
 
-/** The 12 hand-vetted built-in patterns. */
+/** The 14 hand-vetted built-in patterns. */
 export const BUILTIN_PATTERNS: readonly PatternEntry[] = [
   // -------------------------------------------------------------------
   // INLINE-DATE patterns (date in every line; less ambiguous; tried first).
@@ -176,6 +176,61 @@ export const BUILTIN_PATTERNS: readonly PatternEntry[] = [
     ],
     source_doc:
       'OpenClaw meeting-ingestion pipeline reformat of Circleback transcripts (see your OpenClaw skills/meeting-ingestion/SKILL.md)',
+  },
+
+  {
+    // Modern meeting-transcription tools (Circleback, Granola, Zoom)
+    // emit `**Speaker Name:** message text` with NO per-line
+    // timestamp. Every other built-in requires a time anchor, so this
+    // shape scored ~0.002 (one stray line in a long page) and fell
+    // below SCORING_MIN_ACCEPTANCE — parsing to zero messages and
+    // extracting zero conversation-facts. This additive pattern fixes
+    // that: speaker is captured inside the bold markers (`**Name:**`),
+    // there is no time capture, and date_source='frontmatter' with
+    // hour_group undefined routes through parse.ts's no-time branch
+    // (same convention as irc-classic) — every message anchors at
+    // 00:00:00 of the page's frontmatter date. No wall-clock time is
+    // fabricated; intra-day ordering is preserved by line order.
+    //
+    // ORDERING (critical): declared AFTER the timestamped bold
+    // patterns (imessage-slack, telegram-bracket, bold-paren-time) so
+    // it can never shadow them. The scorer tie-breaks on declaration
+    // index, so on a `**Name** (00:00): text` transcript bold-paren-
+    // time scores 1.0 and this pattern scores 0.0 (its regex requires
+    // the colon INSIDE the bold markers — `**Name:**` — which the
+    // paren-time shape `**Name** (time):` never has). On a telegram-
+    // bracket transcript both score 1.0 but telegram-bracket has the
+    // lower index and wins the tie.
+    id: 'bold-name-no-time',
+    origin: 'builtin',
+    // Matches: **Speaker Name:** message text  (colon INSIDE bold).
+    regex: /^\*\*(.+?):\*\*\s*(.*)$/,
+    captures: {
+      speaker_group: 1,
+      text_group: 2,
+    },
+    date_source: 'frontmatter',
+    time_format: '24h',
+    timezone_policy: 'utc_assumed_with_warn',
+    multi_line: false,
+    quick_reject: /^\*\*/,
+    test_positive: [
+      '**Garry Tan:** Okay, start on.',
+      '**Participant 2:** he tried to reset it remotely the other night.',
+      '**Alex Graveley:** That is exactly right.',
+    ],
+    test_negative: [
+      // bold-paren-time shape (colon OUTSIDE bold) MUST fall through:
+      '**Garry** (00:00): text',
+      // imessage-slack shape MUST fall through:
+      '**Alice Example** (2024-03-15 9:00 AM): iMessage shape',
+      // Bold but no colon at all:
+      '**Alice** hello world',
+      // No bold markers:
+      'Garry Tan: plain no bold',
+    ],
+    source_doc:
+      'Circleback / Granola / Zoom meeting-transcript export shape: `**Speaker:** text` with no per-line timestamp',
   },
 
   {

--- a/test/conversation-parser/parse.test.ts
+++ b/test/conversation-parser/parse.test.ts
@@ -235,8 +235,20 @@ describe('parseConversation — disabledBuiltinIds', () => {
       fallbackDate: '2024-03-15',
       disabledBuiltinIds: ['telegram-bracket'],
     });
-    // No other built-in matches this exact shape → no_match.
-    expect(rDisabled.phase).toBe('no_match');
+    // With telegram-bracket disabled, the `**[18:37] 👤 Alice:** hello`
+    // line still has its colon INSIDE the bold markers, so it falls
+    // through to the lower-priority bold-name-no-time pattern (speaker
+    // becomes the whole `[18:37] 👤 Alice` bracket prefix, anchored at
+    // 00:00:00). This proves disable causes fall-through to the next
+    // matching builtin.
+    expect(rDisabled.phase).toBe('regex_match');
+    expect(rDisabled.matched_pattern_id).toBe('bold-name-no-time');
+    // Disabling BOTH bold patterns → genuine no_match.
+    const rBothDisabled = parseConversation(body, {
+      fallbackDate: '2024-03-15',
+      disabledBuiltinIds: ['telegram-bracket', 'bold-name-no-time'],
+    });
+    expect(rBothDisabled.phase).toBe('no_match');
   });
 });
 
@@ -475,6 +487,86 @@ describe('bold-paren-time pattern (Circleback meeting transcripts)', () => {
     expect(r.phase).toBe('regex_match');
     expect(r.matched_pattern_id).toBe('bold-paren-time');
     expect(r.messages).toHaveLength(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bold-name-no-time pattern (Circleback / Granola / Zoom transcripts with NO
+// per-line timestamp — `**Speaker:** text`). Additive pattern; ordered AFTER
+// the timestamped bold patterns so it can never shadow bold-paren-time.
+// ---------------------------------------------------------------------------
+
+describe('bold-name-no-time pattern (Circleback/Granola/Zoom, no timestamp)', () => {
+  test('parses **Speaker:** text transcript with frontmatter date anchor', () => {
+    const body = [
+      '**Garry Tan:** Okay, start on. And then weirdly like zoom doesn\u2019t...',
+      '**Participant 2:** he tried to reset it remotely the other night. Let me ask him.',
+      '**Garry Tan:** I mean it\u2019s really just like we need to get zoom to fix this.',
+      '**Participant 2:** Okay, let me.',
+    ].join('\n');
+    const r = parseConversation(body, { fallbackDate: '2026-05-28' });
+    expect(r.phase).toBe('regex_match');
+    expect(r.matched_pattern_id).toBe('bold-name-no-time');
+    expect(r.messages).toHaveLength(4);
+    expect(r.messages[0]).toEqual({
+      speaker: 'Garry Tan',
+      timestamp: '2026-05-28T00:00:00Z',
+      text: 'Okay, start on. And then weirdly like zoom doesn\u2019t...',
+    });
+    expect(r.messages[1].speaker).toBe('Participant 2');
+    expect(r.messages[1].text).toBe(
+      'he tried to reset it remotely the other night. Let me ask him.',
+    );
+    expect(r.messages[3]).toEqual({
+      speaker: 'Participant 2',
+      timestamp: '2026-05-28T00:00:00Z',
+      text: 'Okay, let me.',
+    });
+    // No-time pattern anchors at 00:00:00 of the frontmatter date
+    // (same convention as irc-classic). No wall-clock time fabricated.
+  });
+
+  test('scores above the 0.05 acceptance floor on a pure bold-name transcript', () => {
+    const body = [
+      '**Garry Tan:** line one',
+      '**Participant 2:** line two',
+      '**Garry Tan:** line three',
+    ].join('\n');
+    const r = parseConversation(body);
+    expect(r.phase).toBe('regex_match');
+    expect(r.matched_pattern_id).toBe('bold-name-no-time');
+    expect(r.messages).toHaveLength(3);
+    // No fallbackDate → epoch default, still anchors at 00:00:00.
+    expect(r.messages[0].timestamp).toBe('1970-01-01T00:00:00Z');
+  });
+
+  // REGRESSION: the new pattern must NOT shadow bold-paren-time. A
+  // `**Garry** (00:00): text` line has its colon OUTSIDE the bold
+  // markers, so it must still parse via bold-paren-time, not the new
+  // bold-name-no-time pattern.
+  test('REGRESSION: **Speaker** (HH:MM): text still matches bold-paren-time', () => {
+    const body = [
+      '**Garry Tan** (00:00): Hey, can you hear me?',
+      '**Participant 2** (02:22): Yeah, just joined.',
+    ].join('\n');
+    const r = parseConversation(body, { fallbackDate: '2026-03-19' });
+    expect(r.phase).toBe('regex_match');
+    expect(r.matched_pattern_id).toBe('bold-paren-time');
+    expect(r.matched_pattern_id).not.toBe('bold-name-no-time');
+    expect(r.messages).toHaveLength(2);
+    expect(r.messages[0].timestamp).toBe('2026-03-19T00:00:00Z');
+  });
+
+  // REGRESSION: a pure telegram-bracket transcript also has the colon
+  // inside the bold markers, but telegram-bracket is declared earlier
+  // and wins the score tie — bold-name-no-time must not steal it.
+  test('REGRESSION: telegram-bracket transcript still matches telegram-bracket', () => {
+    const body = [
+      '**[18:37] \u{1f464} Alice:** one',
+      '**[18:38] \u{1f464} Bob:** two',
+    ].join('\n');
+    const r = parseConversation(body, { fallbackDate: '2024-03-15' });
+    expect(r.matched_pattern_id).toBe('telegram-bracket');
   });
 });
 


### PR DESCRIPTION
## Problem

gbrain's conversation parser ships 13 builtin patterns in `src/core/conversation-parser/builtins.ts` — **every one requires a per-line timestamp** (an inline date or a time anchor like `(HH:MM)` / `[HH:MM]`).

Modern meeting-transcription tools — **Circleback, Granola, Zoom** — emit transcripts as `**Speaker Name:** message text` with **no per-line timestamp**:

```
**Garry Tan:** Okay, start on. And then weirdly like zoom doesn't...
**Participant 2:** he tried to reset it remotely the other night. Let me ask him.
**Garry Tan:** I mean it's really just like we need to get zoom to fix this.
**Participant 2:** Okay, let me.
```

With no time anchor, this shape matches no builtin. A single accidental anchor on a long page scores ~`0.002`, well below the `SCORING_MIN_ACCEPTANCE` gate of `0.05` in `parse.ts`, so the page parses to **0 messages** and extracts **zero conversation-facts**.

### Real-world impact

In a production brain, the coverage scan reported `conversation_format_coverage: 100% _no_match` — **104/104 conversation pages** plus **3,423 eligible pages** matched no builtin pattern and silently yielded nothing.

## The fix

New **additive** builtin `bold-name-no-time`:

- regex `/^\*\*(.+?):\*\*\s*(.*)$/` — captures the speaker **inside** the bold markers (`**Name:**`), message text in group 2.
- No time capture. `date_source: 'frontmatter'` with `hour_group` undefined routes through `parse.ts`'s existing no-time branch (the same convention as `irc-classic`), anchoring every message at `00:00:00` of the page's frontmatter date. **No wall-clock time is fabricated**; intra-day ordering is preserved by line order.
- Declared **after** the timestamped bold patterns (`imessage-slack`, `telegram-bracket`, `bold-paren-time`) so it can never shadow them. The scorer tie-breaks on declaration index, and the regex requires the colon **inside** the bold markers, so the `**Name** (time):` paren-time shape (colon outside) still matches `bold-paren-time`, not this pattern.

No existing pattern is modified.

## Tests

Added a dedicated `bold-name-no-time` test block in `test/conversation-parser/parse.test.ts`:
- parses the real 4-line `**Speaker:** text` sample → 4 messages with correct speaker/text, anchored at `00:00:00` of the frontmatter date;
- scores above the `0.05` acceptance floor on a pure bold-name transcript (epoch-default date when none supplied);
- **regression**: `**Garry** (HH:MM): text` still matches `bold-paren-time` (not the new pattern);
- **regression**: a pure `telegram-bracket` transcript still matches `telegram-bracket` (wins the score tie via lower declaration index).

Updated the existing `disabledBuiltinIds` test: disabling `telegram-bracket` now correctly falls through to `bold-name-no-time` (the bracket line's colon is inside the bold markers); disabling both yields the genuine `no_match`.

Full suite result:

```
bun test test/conversation-parser/ test/conversation-parser-cli.test.ts test/extract-conversation-facts.test.ts
131 pass / 134
```

The 3 failures are **pre-existing on master** and env-driven (`probeLlmAvailability returns null when ANTHROPIC_API_KEY is unset` and two sibling "provider unavailable" fail-open tests) — they fail identically on clean `master` in this sandbox because an `ANTHROPIC_API_KEY` is present in the environment. They are unrelated to this change. `eval-conversation-parser-cli` and `extract-conversation-facts-workers` are fully green (32/32). All 14 builtins (13 existing + new) pass their module-load `validatePatternEntry` checks and their `test_positive` parse loop.

---

### Separately noticed (not in this PR)

`doctor --source <id>` does **not** scope the `orphan_ratio` check. In `src/commands/doctor.ts` (~line 4559), `getOrphansData(engine, { includePseudo: false })` takes no source filter, so `--source default` still reports a brain-wide orphan ratio across all federated sources. Suggested follow-up: thread `sourceId` into `getOrphansData`. (Note only — intentionally not fixed here.)
