### PR TITLE
fix(postgres): coerce timeline batch dates to text before unnest cast

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -2934,7 +2934,11 @@ export class PostgresEngine implements BrainEngine {
   private async _addTimelineEntriesBatchOnce(entries: TimelineBatchInput[]): Promise<number> {
     const sql = this.sql;
     const slugs = entries.map(e => e.slug);
-    const dates = entries.map(e => e.date);
+    // Coerce Date/timestamptz values to 'YYYY-MM-DD' strings so postgres.js binds
+    // the array as text[] (not timestamptz[]); otherwise unnest(...::text[]) throws
+    // 42846 "cannot cast type timestamp with time zone to text[]" and the whole
+    // batch fails silently. effective_date arrives as a JS Date on the PG engine.
+    const dates = entries.map(e => typeof e.date === 'string' ? e.date : new Date(e.date as unknown as string).toISOString().slice(0, 10));
     const sources = entries.map(e => e.source || '');
     const summaries = entries.map(e => e.summary);
     const details = entries.map(e => e.detail || '');


### PR DESCRIPTION
## Problem

`gbrain extract --from-meetings` silently writes **0 timeline entries** on the Postgres engine, even with hundreds of meetings and entity pages. `gbrain doctor` shows timeline coverage stuck at 0% with no error reported.

## Root cause

`PostgresEngine._addTimelineEntriesBatchOnce` builds the date array and binds it into an `unnest(...::text[])`:

```ts
const dates = entries.map(e => e.date);
// ...
unnest(${slugs}::text[], ${dates}::text[], ...)
```

On the Postgres engine, `effective_date` (the source of these dates in `extract-timeline-from-meetings.ts`) comes back as a **JS `Date`**. `postgres.js` then infers the array parameter as `timestamptz[]`, and the `::text[]` cast throws:

```
PostgresError: cannot cast type timestamp with time zone to text[]  (SQLSTATE 42846)
```

The whole batch fails. Because `extractTimelineFromMeetings`'s `flush()` swallows the batch error in a bare `catch {}`, the CLI cheerfully reports `timeline_entries_created: 0` and exits 0. Nothing surfaces.

This only bites the Postgres/Supabase engine (PGLite returns date strings, so the array binds as `text[]` and the cast is a no-op).

## Fix

Coerce non-string date values to `'YYYY-MM-DD'` before binding, so the array binds as `text[]`. String callers are unaffected, and the SQL already does `v.date::date`.

## Verification

On a Supabase brain with 307 meetings and 316 entity pages:

- **Before:** `timeline_entries_created: 0`, `timeline_entries` table empty, doctor timeline coverage 0%.
- **After:** `timeline_entries_created: 2561` across 260 entity pages; re-run is idempotent (0 new); doctor timeline coverage populated.

A 1-row batch and synthetic 50/200-row batches with **string** dates always succeeded — the only differing variable was the date *type* (Date vs string), which this patch normalizes.

## Suggested follow-up (not in this PR)

The bare `catch {}` in `extractTimelineFromMeetings`'s `flush()` masked this for a long time. Consider logging the swallowed batch error (or surfacing a non-fatal warning) so future write failures aren't invisible.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>