### PR TITLE
feat(zhipu): add chat/expansion support + fix expand() for openai-compat providers

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2019,21 +2019,40 @@ export async function expand(query: string): Promise<string[]> {
   if (!query || !query.trim()) return [query];
   if (!isAvailable('expansion')) return [query];
 
+  const expansionPrompt = [
+    'Rewrite the search query below into 3-4 different, related queries that would help find relevant documents.',
+    'Return ONLY a JSON object with a "queries" array. Do NOT include the original query in the result.',
+    'Each rewrite should emphasize different aspects, synonyms, or framings.',
+    '',
+    `Query: ${query}`,
+  ].join('\n');
+
   try {
     const { model, recipe, modelId } = await resolveExpansionProvider(getExpansionModel());
-    const result = await generateObject({
-      model,
-      schema: ExpansionSchema,
-      prompt: [
-        'Rewrite the search query below into 3-4 different, related queries that would help find relevant documents.',
-        'Return ONLY the JSON object. Do NOT include the original query in the result.',
-        'Each rewrite should emphasize different aspects, synonyms, or framings.',
-        '',
-        `Query: ${query}`,
-      ].join('\n'),
-    });
 
-    const expansions = result.object?.queries ?? [];
+    let expansions: string[] = [];
+
+    // Providers that don't support structured outputs (e.g. zhipu/GLM via
+    // openai-compatible) fail silently with generateObject. Fall back to
+    // generateText + manual JSON parse for openai-compat recipes.
+    if (recipe.implementation === 'openai-compatible') {
+      const textResult = await generateText({ model, prompt: expansionPrompt });
+      const raw = textResult.text.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+      try {
+        const parsed = JSON.parse(raw);
+        expansions = Array.isArray(parsed.queries) ? parsed.queries.filter((q: any) => typeof q === 'string') : [];
+      } catch {
+        // JSON parse failed — treat as no expansion
+      }
+    } else {
+      const result = await generateObject({
+        model,
+        schema: ExpansionSchema,
+        prompt: expansionPrompt,
+      });
+      expansions = result.object?.queries ?? [];
+    }
+
     // Deduplicate + include the original query
     const seen = new Set<string>();
     const all = [query, ...expansions].filter(q => {

--- a/src/core/ai/recipes/zhipu.ts
+++ b/src/core/ai/recipes/zhipu.ts
@@ -34,7 +34,22 @@ export const zhipu: Recipe = {
       max_batch_tokens: 8192,
       chars_per_token: 2,
     },
+    expansion: {
+      models: ['glm-4.7', 'glm-4.7-flash'],
+      cost_per_1m_tokens_usd: 0.15,
+      price_last_verified: '2026-05-29',
+    },
+    chat: {
+      models: ['glm-4.7', 'glm-4.7-flash', 'glm-5.1', 'glm-5-turbo'],
+      supports_tools: true,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      max_context_tokens: 200000,
+      cost_per_1m_input_usd: 0.5,
+      cost_per_1m_output_usd: 2.0,
+      price_last_verified: '2026-05-29',
+    },
   },
   setup_hint:
-    'Get an API key at https://open.bigmodel.cn/, then `export ZHIPUAI_API_KEY=...`',
+    'Get an API key at https://open.bigmodel.cn/ or https://z.ai/, then `export ZHIPUAI_API_KEY=...`',
 };


### PR DESCRIPTION
## Summary

- **Add chat + expansion touchpoints to the Zhipu recipe** — the recipe only declared embedding touchpoints, so `isAvailable('chat')` and `isAvailable('expansion')` returned false even with `ZHIPUAI_API_KEY` set. Adds GLM-4.7, GLM-4.7-flash, GLM-5.1, GLM-5-turbo as chat/expansion models.

- **Fix silent expansion failure for all openai-compatible providers** — `generateObject()` uses `response_format: json_schema` which most openai-compatible endpoints don't support. The call fails silently and `expand()` returns only the original query. For openai-compat recipes, fall back to `generateText()` + manual JSON parse. Native providers (Anthropic, OpenAI, Google) keep the existing `generateObject()` path unchanged.

This affects every openai-compatible provider with expansion enabled: Zhipu/GLM, DeepSeek, Groq, Together, Ollama, and any future recipe using the `openai-compatible` implementation.

## Test plan

- [x] Confirmed `gbrain providers list` shows zhipu with EMBED/EXPAND/CHAT all `yes` + `ready`
- [x] Confirmed `expand()` returns 3-4 expanded queries via GLM-4.7 through Z.ai endpoint
- [x] Confirmed `isAvailable('expansion')` and `isAvailable('chat')` return true with `ZHIPUAI_API_KEY` set
- [x] Confirmed native providers (Anthropic/OpenAI) still use the `generateObject()` path (no behavioral change)
- [ ] Verify other openai-compat providers (DeepSeek, Groq) also benefit from the generateText fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)