### PR TITLE
fix(postgres): don't close a module singleton an engine only joined (deeper #1570 root cause)

### DIFF
--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -159,6 +159,16 @@ export function getConnection(): ReturnType<typeof postgres> {
   return sql;
 }
 
+/**
+ * True when the module-level singleton connection is currently open.
+ * Lets a PostgresEngine that joins an already-open singleton (e.g. a config
+ * probe created inside the dream cycle) know it does NOT own the connection,
+ * so its disconnect() won't end the shared pool out from under the owner.
+ */
+export function isConnected(): boolean {
+  return sql !== null;
+}
+
 export async function connect(config: EngineConfig): Promise<void> {
   if (sql) {
     // Warn if a different URL is passed — the old connection is still in use

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -104,6 +104,16 @@ export class PostgresEngine implements BrainEngine {
    * db.disconnect() and clobber the unrelated module-level connection.
    */
   private _connectionStyle: 'instance' | 'module' | null = null;
+  /**
+   * For module-style engines: whether THIS engine opened the shared db.ts
+   * singleton (true) or merely joined an already-open one (false). Only the
+   * opener may end it on disconnect(). Without this, a transient module-style
+   * engine (e.g. lint's content-sanity config probe at lint.ts:319) created
+   * inside the dream cycle calls db.disconnect() and kills the shared
+   * connection the rest of the cycle depends on — surfacing as
+   * "connect() has not been called" in every later DB phase (extract, etc.).
+   */
+  private _ownsModuleSingleton = false;
 
   /**
    * v0.30.1 (Fix 1 + X1 + T5): instance-owned ConnectionManager.
@@ -177,7 +187,10 @@ export class PostgresEngine implements BrainEngine {
       });
       this.connectionManager.setReadPool(this._sql);
     } else {
-      // Module-level singleton (backward compat for CLI main engine)
+      // Module-level singleton (backward compat for CLI main engine).
+      // Capture ownership BEFORE connect: if the singleton is already open we
+      // are merely joining it and must NOT end it on disconnect().
+      this._ownsModuleSingleton = !db.isConnected();
       await db.connect(config);
       this._connectionStyle = 'module';
 
@@ -220,8 +233,16 @@ export class PostgresEngine implements BrainEngine {
       return;
     }
     if (this._connectionStyle === 'module') {
-      await db.disconnect();
+      // Only the engine that OPENED the shared singleton may end it. A module
+      // engine that joined an already-open singleton (e.g. a config probe
+      // inside the dream cycle) leaves it for its owner to close — this
+      // prevents the cycle-wide connection clobber where lint's content-sanity
+      // probe killed the singleton and every later DB phase failed.
+      if (this._ownsModuleSingleton) {
+        await db.disconnect();
+      }
       this._connectionStyle = null;
+      this._ownsModuleSingleton = false;
     }
     // else: nothing to disconnect (already done or never connected)
   }

--- a/test/e2e/postgres-engine-disconnect-idempotency.test.ts
+++ b/test/e2e/postgres-engine-disconnect-idempotency.test.ts
@@ -84,4 +84,27 @@ describe.skipIf(skip)('PostgresEngine.disconnect idempotency', () => {
     // _connectionStyle was reset to null.
     await expect(engine.disconnect()).resolves.toBeUndefined();
   });
+
+  test('module engine that JOINED an open singleton does NOT clobber it (dream cycle regression)', async () => {
+    // Regression for the gbrain dream Postgres clobber (2026-05-29): lint's
+    // content-sanity config probe (resolveLintContentSanity, lint.ts:319) opened
+    // a module-style engine that JOINED the cycle's already-open singleton, then
+    // disconnect()ed it — ending the SHARED connection so every later DB phase
+    // (extract write, embed, conversation_facts_backfill) threw "connect() has
+    // not been called", the cycle exited 1, and writes were lost.
+    //
+    // The fix: a module engine that joined an already-open singleton does NOT
+    // own it (_ownsModuleSingleton=false via db.isConnected()), so its
+    // disconnect() leaves the connection alive for its opener to close.
+    await db.connect({ database_url: DATABASE_URL! }); // shared singleton (the cycle's main engine)
+    expect(db.isConnected()).toBe(true);
+
+    const joiner = new PostgresEngine();
+    await joiner.connect({ database_url: DATABASE_URL! }); // module-style: joins existing singleton
+    await joiner.disconnect();                            // must NOT end the shared singleton
+
+    expect(db.isConnected()).toBe(true);
+    const rows = await db.getConnection().unsafe('SELECT 1 as ok');
+    expect((rows[0] as unknown as { ok: number }).ok).toBe(1);
+  });
 });


### PR DESCRIPTION
## What

The deeper root cause behind #1570 / #1608. A module-style `PostgresEngine` that **joined** an already-open `db.ts` singleton calls `db.disconnect()` (→ `sql.end()`) on its own `disconnect()`, ending the **shared** connection for the whole process.

#1608 added a `withRetry` self-heal (reconnect between attempts) + a disconnect audit, and its message notes: *"The deeper bug (who's calling disconnect mid-cycle) is left [as follow-up]."* This PR fixes that deeper bug and names the culprit.

## The culprit

`gbrain dream` on Postgres: the **lint** phase's content-sanity probe `resolveLintContentSanity` (`src/commands/lint.ts:315`/`319`) opens a module-style engine to lift `content_sanity` config from the DB, then `disconnect()`s it. That engine merely joined the cycle's already-open singleton (its `db.connect()` was a no-op), so the disconnect ends the shared connection. Every later DB phase (extract write, embed, conversation_facts_backfill) then throws `connect() has not been called` → the cycle exits 1 and silently loses link/timeline writes. `--phase lint` alone "works" because nothing runs after it.

## The fix

Ownership tracking — same pattern as the v0.28.1 jobs-path idempotency fix:
- `db.ts`: new `isConnected()`.
- `postgres-engine.ts`: new `_ownsModuleSingleton`, set to `!db.isConnected()` **before** `db.connect()`. Module-style `disconnect()` only calls `db.disconnect()` when it owns the singleton; a joiner leaves it for its opener to close.

Complements #1608 (prevents the clobber instead of recovering from it).

## Verification

- Full `gbrain dream --source default` exits 0 (was exit 1); extract/embed writes land.
- `test/e2e/postgres-engine-disconnect-idempotency.test.ts`: 3/3 pass incl. a new regression case (`module engine that JOINED an open singleton does NOT clobber it`).
- Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)