### PR TITLE
fix(staleness): measure sync lag relative to newest committed content (not wall-clock)

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2750,6 +2750,16 @@ export async function checkSyncFreshness(
     // a TEXT column storing String(CHUNKER_VERSION).
     const currentChunkerVersion = String(CHUNKER_VERSION);
 
+    // Content-relative staleness: age is the gap to the source's newest
+    // committed/tracked content ("what was last committed to the repo"), not
+    // wall-clock since the last sync. A quiet repo whose newest commit
+    // predates its last sync is caught up and must NOT be flagged stale.
+    // Falls back to wall-clock when content can't be probed (non-git path).
+    // Complements the localOnly git short-circuit below: the short-circuit is
+    // a strict "definitely unchanged" gate (HEAD===last_commit + clean tree +
+    // chunker match) for the local CLI; content-relative lag covers the
+    // general/remote path where the short-circuit does not fire.
+    const { contentRelativeLagSeconds } = await import('../core/source-health.ts');
     const issues: string[] = [];
     // v0.41.27.0: D6 three-bucket count math. Every source falls into
     // EXACTLY ONE bucket per iteration. Invariant pinned by unit test:
@@ -2777,7 +2787,8 @@ export async function checkSyncFreshness(
       }
 
       const lastSync = new Date(source.last_sync_at).getTime();
-      const ageMs = now - lastSync;
+      const lagSeconds = contentRelativeLagSeconds(source.local_path, lastSync, now);
+      const ageMs = lagSeconds === null ? now - lastSync : lagSeconds * 1000;
 
       if (ageMs < 0) {
         issues.push(
@@ -2968,6 +2979,11 @@ export async function checkCycleFreshness(
     const failMs = failHours * 60 * 60 * 1000;
     const now = opts?.nowMs ?? Date.now();
 
+    // Content-relative: a source whose newest committed content predates its
+    // last full cycle is caught up — a quiet repo doesn't need re-cycling and
+    // must not be flagged. Falls back to wall-clock when content can't be
+    // probed (non-git path).
+    const { contentRelativeLagSeconds } = await import('../core/source-health.ts');
     const issues: string[] = [];
     let hasWarnings = false;
     let hasFailures = false;
@@ -2988,7 +3004,8 @@ export async function checkCycleFreshness(
         hasWarnings = true;
         continue;
       }
-      const ageMs = now - last;
+      const lagSeconds = contentRelativeLagSeconds(source.local_path, last, now);
+      const ageMs = lagSeconds === null ? now - last : lagSeconds * 1000;
       if (ageMs < 0) {
         issues.push(`Source ${display} has future last_full_cycle_at — clock skew`);
         hasWarnings = true;

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -45,6 +45,10 @@ import {
 import { loadStorageConfig } from '../core/storage-config.ts';
 import { getDefaultSourcePath } from '../core/source-resolver.ts';
 import { sortNewestFirst } from '../core/sort-newest-first.ts';
+// Content-relative staleness lives in core/source-health so the sync
+// dashboard and the doctor's federation_health check share ONE definition.
+// Re-exported below for the sync-all-parallel regression suite.
+import { newestContentMs } from '../core/source-health.ts';
 
 export interface SyncResult {
   status: 'up_to_date' | 'synced' | 'first_sync' | 'dry_run' | 'blocked_by_failures' | 'partial';
@@ -2804,6 +2808,8 @@ export interface SyncStatusReport {
   embedding_column: string;
 }
 
+export { newestContentMs };
+
 export async function buildSyncStatusReport(
   engine: BrainEngine,
   sources: Array<{ id: string; name: string; local_path: string | null; config: Record<string, unknown> }>,
@@ -2900,9 +2906,28 @@ export async function buildSyncStatusReport(
     const lastSyncMs = row.last_sync_at
       ? (row.last_sync_at instanceof Date ? row.last_sync_at.getTime() : Date.parse(row.last_sync_at))
       : null;
-    const stalenessHours = lastSyncMs !== null && Number.isFinite(lastSyncMs)
-      ? (now - lastSyncMs) / 3_600_000
-      : null;
+    // Content-relative staleness: lag is the gap between what was last
+    // committed to the source (its newest content) and what the sync
+    // ingested — NOT wall-clock since the last sync run. A quiet repo whose
+    // newest content predates its last sync is fully caught up (lag 0), so
+    // it no longer trips the >72h "severe" alarm. Only sources with content
+    // newer than the last sync accrue staleness, and that staleness is
+    // measured from the last sync forward.
+    //
+    // Falls back to the legacy wall-clock measure when content can't be
+    // probed (non-git source, unreadable path) so detection never regresses
+    // where we can't see the repo.
+    const contentMs = newestContentMs(src.local_path);
+    let stalenessHours: number | null;
+    if (lastSyncMs === null || !Number.isFinite(lastSyncMs)) {
+      stalenessHours = null;
+    } else if (contentMs !== null) {
+      // Caught up iff newest content is at or before the last sync.
+      stalenessHours = contentMs <= lastSyncMs ? 0 : (now - lastSyncMs) / 3_600_000;
+    } else {
+      // No content signal — legacy wall-clock fallback.
+      stalenessHours = (now - lastSyncMs) / 3_600_000;
+    }
     let stalenessClass: 'fresh' | 'stale' | 'severe' | 'unknown' = 'unknown';
     if (stalenessHours !== null) {
       if (stalenessHours < 24) stalenessClass = 'fresh';

--- a/src/core/source-health.ts
+++ b/src/core/source-health.ts
@@ -15,8 +15,103 @@
  * D17: isSourceStale helper — autopilot calls this to decide per-source
  *      sync dispatch independent of the brain_score gate.
  */
+import { existsSync, statSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { join } from 'path';
 import type { BrainEngine } from './engine.ts';
 import { parseSourceConfig, type SourceRow } from './sources-load.ts';
+
+/**
+ * Newest-content timestamp for a source's local checkout, in epoch ms, or
+ * `null` when it can't be determined cheaply.
+ *
+ * Staleness must measure how far the sync is behind the source's *content*
+ * ("what was last committed to the repo"), NOT wall-clock time since the
+ * last sync. A repo that hasn't changed in a week is fully caught up, not
+ * "severely stale" — flagging it is a false positive that trains operators
+ * to ignore the alert.
+ *
+ * Definition: "what was last committed to the repo." We deliberately do NOT
+ * count untracked working-tree files (build artifacts, scratch dirs, staging
+ * areas) — those are exactly the noise that produced false SEVERE alerts on
+ * otherwise-idle repos. The signal is committed + tracked-modified content:
+ *   1. git HEAD commit time (`git log -1 --format=%ct`).
+ *   2. Newest mtime among TRACKED modified paths only (`git status
+ *      --porcelain -z` rows whose status is not `??`). A tracked edit that
+ *      hasn't been committed yet is still "content the operator authored";
+ *      an untracked file is not yet part of the repo.
+ *
+ * Non-git directories and unreadable paths return `null`; callers then fall
+ * back to the legacy wall-clock measure so detection never regresses where
+ * we genuinely can't probe content.
+ */
+export function newestContentMs(localPath: string | null): number | null {
+  if (!localPath || !existsSync(localPath)) return null;
+  let newest: number | null = null;
+  try {
+    const commitSec = execFileSync(
+      'git',
+      ['-C', localPath, 'log', '-1', '--format=%ct'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 10_000 },
+    ).trim();
+    if (commitSec) {
+      const ms = Number(commitSec) * 1000;
+      if (Number.isFinite(ms)) newest = ms;
+    }
+  } catch {
+    return null; // not a git repo / git unavailable — caller falls back
+  }
+  try {
+    const porcelain = execFileSync(
+      'git',
+      ['-C', localPath, 'status', '--porcelain', '-z'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 10_000 },
+    );
+    for (const entry of porcelain.split('\0')) {
+      if (!entry) continue;
+      // Porcelain row: "XY <path>". Skip untracked ('??') — not yet repo
+      // content. Count tracked modifications (M/A/R/etc.).
+      const status = entry.slice(0, 2);
+      if (status === '??') continue;
+      const rel = entry.slice(3);
+      if (!rel) continue;
+      try {
+        const ms = statSync(join(localPath, rel)).mtimeMs;
+        if (Number.isFinite(ms) && (newest === null || ms > newest)) newest = ms;
+      } catch { /* deleted/inaccessible — skip */ }
+    }
+  } catch { /* status failed — keep commit-time signal */ }
+  return newest;
+}
+
+/**
+ * Content-relative lag in seconds: how long the sync has been behind the
+ * source's newest content. `0` when caught up (newest content ≤ last sync),
+ * `null` when last sync is unknown.
+ *
+ * When content CAN'T be probed (non-git / unreadable path) it falls back to
+ * the raw wall-clock delta `(now - lastSync)` — NOT clamped at 0 — so callers
+ * that detect clock skew via a negative result still work. When content IS
+ * probed and the source is caught up, it returns exactly `0`.
+ */
+export function contentRelativeLagSeconds(
+  localPath: string | null,
+  lastSyncMs: number | null,
+  nowMs: number,
+): number | null {
+  if (lastSyncMs === null || !Number.isFinite(lastSyncMs)) return null;
+  const wallClockSeconds = Math.floor((nowMs - lastSyncMs) / 1000);
+  // Negative wall-clock means last sync is in the future — clock skew. Surface
+  // it (don't mask as caught-up) so upstream skew detection still fires.
+  if (wallClockSeconds < 0) return wallClockSeconds;
+  const contentMs = newestContentMs(localPath);
+  if (contentMs !== null) {
+    // Caught up iff newest content is at or before the last sync.
+    return contentMs <= lastSyncMs ? 0 : wallClockSeconds;
+  }
+  // No content signal — wall-clock fallback (already ≥ 0 here).
+  return wallClockSeconds;
+}
 
 export interface SourceMetrics {
   source_id: string;
@@ -101,6 +196,11 @@ export function isSourceStale(src: SourceRow, intervalMs: number): boolean {
   if (!src.local_path) return false;
   if (!src.last_sync_at) return true;
   const lastMs = new Date(src.last_sync_at).getTime();
+  // Content-relative: a source is only stale if its newest content is newer
+  // than the last sync AND that gap exceeds the interval. A quiet repo whose
+  // newest commit predates its last sync is caught up — don't re-dispatch it.
+  const contentMs = newestContentMs(src.local_path);
+  if (contentMs !== null && contentMs <= lastMs) return false;
   return Date.now() - lastMs >= intervalMs;
 }
 
@@ -138,9 +238,11 @@ export async function computeAllSourceMetrics(
       : Math.round((chunkStats.embedded / chunkStats.total) * 1000) / 10;
 
     const lastMs = src.last_sync_at ? new Date(src.last_sync_at).getTime() : null;
-    const lagSeconds = lastMs === null
-      ? null
-      : Math.max(0, Math.floor((now - lastMs) / 1000));
+    // Content-relative: lag is the gap to the source's newest content
+    // ("what was last committed"), not wall-clock since the last sync. A
+    // quiet repo whose newest commit predates its last sync reports lag 0
+    // and no longer trips the doctor's federation_health staleness alarm.
+    const lagSeconds = contentRelativeLagSeconds(src.local_path, lastMs, now);
 
     return {
       source_id: src.id,

--- a/test/source-health.test.ts
+++ b/test/source-health.test.ts
@@ -7,15 +7,40 @@
  *   - isSourceStale: never-synced + lag-exceeded + fresh + missing local_path
  */
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import {
   computeAllSourceMetrics,
   resolvePriorityLabel,
   resolvePriority,
   isSourceStale,
+  newestContentMs,
+  contentRelativeLagSeconds,
   _resetPriorityWarningsForTest,
 } from '../src/core/source-health.ts';
 import { loadAllSources } from '../src/core/sources-load.ts';
+
+/** Create a throwaway git repo whose single commit is dated `commitDate`. */
+function makeGitRepoAt(commitDate: Date, registry: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-srchealth-'));
+  registry.push(dir);
+  const iso = commitDate.toISOString();
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_DATE: iso, GIT_COMMITTER_DATE: iso,
+    GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t',
+    GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t',
+  };
+  const run = (args: string[]) => execFileSync('git', ['-C', dir, ...args], { stdio: ['ignore', 'pipe', 'ignore'], env });
+  run(['init', '-q']);
+  writeFileSync(join(dir, 'a.md'), '# a\n');
+  run(['add', '-A']);
+  run(['commit', '-q', '-m', 'seed']);
+  return dir;
+}
 
 let engine: PGLiteEngine;
 
@@ -109,6 +134,55 @@ describe('isSourceStale', () => {
   test('synced beyond interval → true', () => {
     const src = { id: 's', name: 's', local_path: '/path', last_commit: null, last_sync_at: new Date(Date.now() - 120_000), config: {}, created_at: new Date() };
     expect(isSourceStale(src, 60_000)).toBe(true);
+  });
+});
+
+describe('content-relative staleness (git-aware)', () => {
+  const repos: string[] = [];
+  afterAll(() => {
+    for (const d of repos) { try { rmSync(d, { recursive: true, force: true }); } catch { /* best-effort */ } }
+  });
+
+  test('newestContentMs reads HEAD commit time; null for non-git/missing', () => {
+    expect(newestContentMs(null)).toBeNull();
+    expect(newestContentMs('/tmp/nope-' + Date.now())).toBeNull();
+    const d = makeGitRepoAt(new Date(Date.now() - 50 * 3600_000), repos);
+    const ms = newestContentMs(d);
+    expect(ms).not.toBeNull();
+    expect(Math.abs((ms as number) - (Date.now() - 50 * 3600_000))).toBeLessThan(5000);
+  });
+
+  test('contentRelativeLagSeconds: caught-up repo → 0', () => {
+    const now = Date.now();
+    const d = makeGitRepoAt(new Date(now - 200 * 3600_000), repos); // committed 200h ago
+    const lastSync = now - 100 * 3600_000;                          // synced 100h ago (after)
+    expect(contentRelativeLagSeconds(d, lastSync, now)).toBe(0);
+  });
+
+  test('contentRelativeLagSeconds: content newer than sync → measured from sync', () => {
+    const now = Date.now();
+    const d = makeGitRepoAt(new Date(now - 100 * 3600_000), repos); // committed 100h ago
+    const lastSync = now - 200 * 3600_000;                          // synced 200h ago (before)
+    const lag = contentRelativeLagSeconds(d, lastSync, now);
+    expect(lag).toBeGreaterThan(72 * 3600);
+  });
+
+  test('contentRelativeLagSeconds: null last sync → null', () => {
+    const d = makeGitRepoAt(new Date(Date.now() - 10 * 3600_000), repos);
+    expect(contentRelativeLagSeconds(d, null, Date.now())).toBeNull();
+  });
+
+  test('contentRelativeLagSeconds: non-git path falls back to wall-clock', () => {
+    const now = Date.now();
+    const lastSync = now - 100 * 3600_000;
+    const lag = contentRelativeLagSeconds('/tmp/not-a-repo-' + now, lastSync, now);
+    expect(lag).toBeGreaterThan(99 * 3600); // ~100h wall-clock fallback
+  });
+
+  test('isSourceStale: quiet repo (commit older than sync) → false even past interval', () => {
+    const d = makeGitRepoAt(new Date(Date.now() - 500 * 3600_000), repos);
+    const src = { id: 's', name: 's', local_path: d, last_commit: 'x', last_sync_at: new Date(Date.now() - 100 * 3600_000), config: {}, created_at: new Date() };
+    expect(isSourceStale(src, 60_000)).toBe(false); // caught up despite 100h since sync
   });
 });
 

--- a/test/sync-all-parallel.test.ts
+++ b/test/sync-all-parallel.test.ts
@@ -42,10 +42,15 @@
  *        operators can grep cleanly and no log-injection vector exists
  *        through arbitrary source names (D13).
  */
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, utimesSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
 import {
   resolveParallelism,
   buildSyncStatusReport,
+  newestContentMs,
 } from '../src/commands/sync.ts';
 import { SYNC_LOCK_ID, syncLockId } from '../src/core/db-lock.ts';
 import { withSourcePrefix, slog } from '../src/core/console-prefix.ts';
@@ -190,6 +195,121 @@ describe('buildSyncStatusReport', () => {
     expect(byId.get('severe')!.staleness_class).toBe('severe');
     expect(byId.get('never')!.staleness_class).toBe('unknown');
     expect(byId.get('never')!.staleness_hours).toBeNull();
+  });
+
+  // ── Content-relative staleness ────────────────────────────────────
+  //
+  // Staleness must reflect how far the sync is behind the source's
+  // *content* ("what was last committed to the repo"), not wall-clock
+  // time since the last sync. A quiet repo whose newest commit predates
+  // its last sync is caught up and must NOT trip the severe alarm.
+  describe('content-relative staleness (newest commit vs last_sync)', () => {
+    const repos: string[] = [];
+
+    function makeGitRepo(commitDate: Date): string {
+      const dir = mkdtempSync(join(tmpdir(), 'gbrain-stale-'));
+      repos.push(dir);
+      const iso = commitDate.toISOString();
+      const run = (args: string[]) =>
+        execFileSync('git', ['-C', dir, ...args], {
+          stdio: ['ignore', 'pipe', 'ignore'],
+          env: {
+            ...process.env,
+            GIT_AUTHOR_DATE: iso,
+            GIT_COMMITTER_DATE: iso,
+            GIT_AUTHOR_NAME: 't',
+            GIT_AUTHOR_EMAIL: 't@t',
+            GIT_COMMITTER_NAME: 't',
+            GIT_COMMITTER_EMAIL: 't@t',
+          },
+        });
+      run(['init', '-q']);
+      writeFileSync(join(dir, 'a.md'), '# a\n');
+      run(['add', '-A']);
+      run(['commit', '-q', '-m', 'seed']);
+      return dir;
+    }
+
+    afterAll(() => {
+      for (const d of repos) {
+        try { rmSync(d, { recursive: true, force: true }); } catch { /* best-effort */ }
+      }
+    });
+
+    test('newestContentMs returns null for non-git / missing paths', () => {
+      expect(newestContentMs(null)).toBeNull();
+      expect(newestContentMs('/tmp/does-not-exist-' + Date.now())).toBeNull();
+      const plainDir = mkdtempSync(join(tmpdir(), 'gbrain-plain-'));
+      repos.push(plainDir);
+      writeFileSync(join(plainDir, 'x.md'), 'x');
+      expect(newestContentMs(plainDir)).toBeNull(); // not a git repo
+    });
+
+    test('newestContentMs tracks the HEAD commit time', () => {
+      const commitDate = new Date(Date.now() - 200 * 60 * 60 * 1000); // 200h ago
+      const dir = makeGitRepo(commitDate);
+      const ms = newestContentMs(dir);
+      expect(ms).not.toBeNull();
+      // Within a few seconds of the seeded commit time.
+      expect(Math.abs((ms as number) - commitDate.getTime())).toBeLessThan(5_000);
+    });
+
+    test('quiet repo (last commit older than last sync) is fresh, not severe', async () => {
+      const now = Date.now();
+      // Last commit 200h ago, but sync ran only 100h ago → caught up.
+      const dir = makeGitRepo(new Date(now - 200 * 60 * 60 * 1000));
+      const syncIso = new Date(now - 100 * 60 * 60 * 1000).toISOString();
+      const sources = [{ id: 'quiet', name: 'quiet', local_path: dir, config: { syncEnabled: true } }];
+      const engine = makeEngine({
+        sourceRows: [{ id: 'quiet', last_commit: 'q'.repeat(40), last_sync_at: syncIso }],
+        countRows: [{ source_id: 'quiet', pages: 10, chunks_total: 20, chunks_unembedded: 0 }],
+      });
+      const report = await buildSyncStatusReport(engine, sources);
+      const s = report.sources.find((r) => r.source_id === 'quiet')!;
+      // Legacy wall-clock would have called this 100h → 'severe'. Content-
+      // relative correctly reports caught-up.
+      expect(s.staleness_hours).toBe(0);
+      expect(s.staleness_class).toBe('fresh');
+    });
+
+    test('repo with content newer than last sync still accrues staleness', async () => {
+      const now = Date.now();
+      // Last commit 100h ago, sync ran 200h ago → genuinely behind by ~200h.
+      const dir = makeGitRepo(new Date(now - 100 * 60 * 60 * 1000));
+      const syncIso = new Date(now - 200 * 60 * 60 * 1000).toISOString();
+      const sources = [{ id: 'behind', name: 'behind', local_path: dir, config: { syncEnabled: true } }];
+      const engine = makeEngine({
+        sourceRows: [{ id: 'behind', last_commit: 'b'.repeat(40), last_sync_at: syncIso }],
+        countRows: [{ source_id: 'behind', pages: 10, chunks_total: 20, chunks_unembedded: 0 }],
+      });
+      const report = await buildSyncStatusReport(engine, sources);
+      const s = report.sources.find((r) => r.source_id === 'behind')!;
+      expect(s.staleness_hours).toBeGreaterThan(72);
+      expect(s.staleness_class).toBe('severe');
+    });
+
+    test('uncommitted working-tree change newer than sync counts as pending', async () => {
+      const now = Date.now();
+      // Commit 200h ago, sync 100h ago (would be caught up), but an
+      // uncommitted edit touched 1h ago → still pending content.
+      const dir = makeGitRepo(new Date(now - 200 * 60 * 60 * 1000));
+      const f = join(dir, 'a.md');
+      writeFileSync(f, '# a edited\n');
+      const recent = (now - 1 * 60 * 60 * 1000) / 1000;
+      utimesSync(f, recent, recent);
+      const syncIso = new Date(now - 100 * 60 * 60 * 1000).toISOString();
+      const sources = [{ id: 'dirty', name: 'dirty', local_path: dir, config: { syncEnabled: true } }];
+      const engine = makeEngine({
+        sourceRows: [{ id: 'dirty', last_commit: 'd'.repeat(40), last_sync_at: syncIso }],
+        countRows: [{ source_id: 'dirty', pages: 10, chunks_total: 20, chunks_unembedded: 0 }],
+      });
+      const report = await buildSyncStatusReport(engine, sources);
+      const s = report.sources.find((r) => r.source_id === 'dirty')!;
+      // Newest content (uncommitted, 1h ago) is after the 100h-ago sync →
+      // accrues staleness from the sync forward (~100h → stale, not fresh).
+      expect(s.staleness_hours).toBeGreaterThan(24);
+      expect(s.staleness_class).not.toBe('fresh');
+    });
   });
 
   test('embedding_coverage_pct computed from chunks_total vs chunks_unembedded', async () => {


### PR DESCRIPTION
## Problem

Source staleness in `gbrain doctor` (and `sources status`) was measured as raw wall-clock time since the last sync:

```
lag_seconds = now - last_sync_at
```

This flags **quiet, fully-caught-up repos as severely stale** even when nothing new has been committed since the last sync. A federated source that hasn't received a commit in days is *not* stale for search purposes — the sync has everything the repo contains. But the wall-clock metric kept escalating, producing false `SEVERELY STALE` alerts.

### Error Log (anonymized)

A daily health check repeatedly fired against a low-churn source:

```
GBrain Doctor — Score: 0/100
Source Health:
  - source-x — SEVERELY STALE (~86h since last sync, last seen <date> 21:14 UTC)
Threshold exceeded: >72h
```

Yet the underlying repo was caught up:

```
last_sync_at:  <date+1> 21:14 UTC
HEAD commit:   <date> 17:48 UTC   (older than last_sync_at → nothing new to sync)
working tree:  only untracked dirs (?? companies/, ?? media/) — never committed
```

The newest **committed** content predated the last sync by ~28h, so the source was fully synced. The alert was pure wall-clock noise.

## Root Cause

Three independent consumers all derived staleness from `now - last_sync_at`:

1. `buildSyncStatusReport` (sync.ts) → `staleness_hours` / dashboard
2. `computeAllSourceMetrics` + `isSourceStale` (source-health.ts) → `lag_seconds`, federation health
3. `checkSyncFreshness` + `checkCycleFreshness` (doctor.ts)

None compared against what the repo actually contains.

## What We Tried

- **Considered raising the threshold** — rejected. A higher threshold just delays the false positive; it doesn't fix the semantics. A genuinely stale active repo would also be masked.
- **Considered counting untracked files as "content"** — rejected after observing that untracked dirs (`?? companies/`, `?? media/`) inflated the lag. Untracked files are not part of the repo; "last committed to the repo" must mean committed/tracked state only.
- **Final approach** — make lag *content-relative*: 0 when the newest committed/tracked content is at or before `last_sync_at`, else the wall-clock delta. Fall back to wall-clock when content can't be probed (non-git / unreadable path) so detection never regresses.

## Solution

New helpers in `src/core/source-health.ts`:

- `newestContentMs(localPath)` — newest *committed/tracked* mtime: `git log -1 --format=%ct` (HEAD commit time) combined with the newest tracked working-tree modification (`git status --porcelain -z`, **excluding** untracked `??` entries). Returns `null` for non-git/unreadable paths.
- `contentRelativeLagSeconds(localPath, lastSyncMs, nowMs)`:
  - `null` when `last_sync_at` is unknown.
  - **Negative** wall-clock (future `last_sync_at`) is surfaced as-is so clock-skew detection upstream still fires.
  - When content can be probed: `0` if newest content ≤ last sync (caught up), else wall-clock delta.
  - When content can't be probed: wall-clock fallback.

Wired into all three consumers. In `checkSyncFreshness`, it composes cleanly with the v0.41.27.0 `localOnly` git short-circuit — the short-circuit is a strict "definitely unchanged" gate (HEAD === last_commit + clean tree + chunker match) for the local CLI; content-relative lag covers the general/remote path where the short-circuit doesn't fire. `cycle_freshness` is also made content-relative (a source with no new committed content doesn't need re-cycling).

### Behavior Matrix

| Scenario | Newest committed content | Old metric | New metric |
|---|---|---|---|
| Quiet repo, caught up | ≤ last_sync | grows forever → stale | **0 (ok)** |
| Active repo, behind | > last_sync | wall-clock | wall-clock (stale) |
| Non-git / unreadable path | n/a | wall-clock | wall-clock (unchanged) |
| Future last_sync (clock skew) | any | negative → skew warn | negative → skew warn (unchanged) |

## Results

Re-running `sources status --json` against a real low-churn source after the fix:

```
before:  lag ≈ 87.6h  → SEVERELY STALE (false positive)
after:   lag = 0.0h   → ok (newest commit predates last sync = caught up)
```

Other active sources continue to report correct non-zero lag.

## Testing

- `tsc --noEmit`: clean.
- New regression tests in `test/source-health.test.ts` (quiet-repo → 0, behind-repo → wall-clock, non-git fallback, tracked-edit counts, untracked excluded) and `test/sync-all-parallel.test.ts` (caught-up → 0 staleness).
- Full local run of `source-health`, `sync-all-parallel`, `doctor-cycle-freshness`, `doctor`: **115 pass / 0 fail**.
