### PR TITLE
fix(whoami): return a defined identity for stdio MCP instead of throwing unknown_transport

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -1535,6 +1535,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
       try {
         toolResult = await dispatchToolCall(engine, name, params as Record<string, unknown> | undefined, {
           remote: true,
+          transport: 'http',
           takesHoldersAllowList: tokenAllowList,
           sourceId: tokenSourceId,
           metaHook: getBrainHotMemoryMeta,

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -296,6 +296,21 @@ export interface OperationContext {
    */
   remote: boolean;
   /**
+   * Which MCP transport carried this call. Set explicitly by the two
+   * remote/untrusted MCP transports — `'stdio'` by the local stdio server
+   * (src/mcp/server.ts), `'http'` by the HTTP MCP transports. Left undefined
+   * for the local CLI path (`gbrain call`, remote=false), which has no MCP
+   * transport.
+   *
+   * This is a transport-IDENTITY discriminator only — it is NOT a trust
+   * signal and never widens access. `remote` remains the sole authority
+   * gate; stdio MCP is still `remote: true` and sees only `visibility='world'`.
+   * The single consumer today is `whoami`, which needs to tell stdio (a
+   * known, auth-less local pipe) apart from an HTTP call that lost its
+   * `ctx.auth` (a genuine threading bug worth throwing on).
+   */
+  transport?: 'stdio' | 'http';
+  /**
    * Subagent runtime context (v0.16+). Set by the subagent tool dispatcher when
    * dispatching an op as a tool call from an LLM loop. Used to enforce per-op
    * agent policy (e.g. put_page namespace rule).
@@ -3104,12 +3119,13 @@ const get_recent_transcripts: Operation = {
 const whoami: Operation = {
   name: 'whoami',
   description:
-    'Introspect the calling identity. Returns one of three transport shapes: ' +
+    'Introspect the calling identity. Returns one of four transport shapes: ' +
     '{transport: "oauth", client_id, client_name, scopes, expires_at}, ' +
-    '{transport: "legacy", token_name, scopes, expires_at: null}, or ' +
-    '{transport: "local", scopes: []}. Throws unknown_transport when the ' +
-    'context is ambiguous (remote=true without auth) — fail-closed posture ' +
-    'mirroring the v0.26.9 trust-boundary contract.',
+    '{transport: "legacy", token_name, scopes, expires_at: null}, ' +
+    '{transport: "stdio", scopes: []} (local auth-less MCP pipe), or ' +
+    '{transport: "local", scopes: []} (trusted CLI). Throws unknown_transport ' +
+    'when the context is ambiguous (remote HTTP without auth) — fail-closed ' +
+    'posture mirroring the v0.26.9 trust-boundary contract.',
   params: {},
   scope: 'read',
   handler: async (ctx) => {
@@ -3121,12 +3137,22 @@ const whoami: Operation = {
     if (ctx.remote === false) {
       return { transport: 'local', scopes: [] };
     }
+    // stdio MCP is a known, auth-less local pipe. It is deliberately kept
+    // `remote: true` (so it sees only visibility='world' and never the
+    // private fence — see the `remote` trust-boundary contract above), so it
+    // can't return the full-trust `local` shape. Give it its own honest
+    // shape with EMPTY scopes: no fabricated authority, but a defined answer
+    // instead of throwing. The throw below stays reserved for an HTTP call
+    // that lost its ctx.auth — a real threading bug, not a normal transport.
+    if (ctx.transport === 'stdio') {
+      return { transport: 'stdio', scopes: [] };
+    }
     if (!ctx.auth) {
       throw new OperationError(
         'unknown_transport',
         'whoami called over a remote transport that did not thread ctx.auth. ' +
-          'This is a transport bug — every remote call site must populate ctx.auth ' +
-          'or set ctx.remote === false.',
+          'This is a transport bug — every remote call site must populate ctx.auth, ' +
+          'set ctx.transport === "stdio" (local pipe), or set ctx.remote === false.',
       );
     }
     // OAuth tokens have client_id starting with 'gbrain_cl_'; legacy

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -70,6 +70,14 @@ export interface DispatchOpts {
    * was replaced by dispatchToolCall.
    */
   auth?: AuthInfo;
+  /**
+   * Which MCP transport is dispatching. `'stdio'` from src/mcp/server.ts,
+   * `'http'` from the HTTP MCP transports. Threaded into OperationContext so
+   * `whoami` can return a defined `transport: 'stdio'` shape for the auth-less
+   * local pipe instead of throwing unknown_transport. NOT a trust signal —
+   * `remote` remains the access gate. Local CLI dispatch leaves it unset.
+   */
+  transport?: 'stdio' | 'http';
 }
 
 /**
@@ -210,6 +218,7 @@ export function buildOperationContext(
     // this fallback covers code paths that historically passed undefined.
     sourceId: opts.sourceId ?? 'default',
     auth: opts.auth,
+    transport: opts.transport,
   };
 }
 

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -360,6 +360,7 @@ export async function startHttpTransport(opts: HttpTransportOptions) {
         // path defaults to 'default' per AuthResult.sourceId above.
         const result = await dispatchToolCall(engine, toolName, args, {
           remote: true,
+          transport: 'http',
           takesHoldersAllowList: auth.takesHoldersAllowList,
           sourceId: auth.sourceId,
         });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -35,6 +35,10 @@ export async function startMcpServer(engine: BrainEngine) {
     // `gbrain call <op>` (sets remote=false in src/cli.ts).
     return dispatchToolCall(engine, name, params, {
       remote: true,
+      // Identify the transport (not a trust signal — `remote` stays true) so
+      // whoami can return a defined `transport: 'stdio'` shape for this
+      // auth-less local pipe instead of throwing unknown_transport.
+      transport: 'stdio',
       takesHoldersAllowList: ['world'],
       // v0.31: source defaults to 'default' for stdio (no per-token scope).
       // Operators who want a different source on stdio MCP should set

--- a/test/e2e/whoami-stdio-mcp.test.ts
+++ b/test/e2e/whoami-stdio-mcp.test.ts
@@ -1,0 +1,114 @@
+/**
+ * E2E — `whoami` over the REAL stdio MCP transport.
+ *
+ * Codifies the manual probe from the fix/whoami-stdio-transport work
+ * (garrytan/gbrain#1625). It spins up `gbrain serve` as an actual subprocess,
+ * drives it through the MCP SDK client over stdio (initialize handshake +
+ * tools/call), and asserts `whoami` returns the `{transport:'stdio', scopes:[]}`
+ * shape — NOT the `unknown_transport` throw the bug produced.
+ *
+ * This is the process/transport-level belt-and-suspenders that the unit tests
+ * (test/whoami.test.ts) and dispatcher tests can't give: it proves
+ * src/mcp/server.ts actually threads `transport: 'stdio'` end to end, through
+ * the real MCP SDK and a separate OS process.
+ *
+ * Hermetic: fresh PGLite brain in a temp GBRAIN_HOME, no DATABASE_URL, no API
+ * keys. Delegates to `bun run src/cli.ts` because bun --compile can't bundle
+ * PGLite assets (same constraint as pglite-cli-exit.serial.test.ts).
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+const REPO_ROOT = resolve(import.meta.dir, '..', '..');
+const CLI = join(REPO_ROOT, 'src', 'cli.ts');
+const BUN = process.execPath; // the bun running this test — no PATH dependency
+
+let tmpHome: string;
+let repoSourceDir: string;
+let runEnv: NodeJS.ProcessEnv;
+
+beforeAll(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'gbrain-whoami-stdio-'));
+  repoSourceDir = mkdtempSync(join(tmpdir(), 'gbrain-whoami-stdio-src-'));
+
+  // Minimal git repo so `init --repo` has a HEAD to anchor against. whoami
+  // needs no pages, so we skip `sync`.
+  writeFileSync(join(repoSourceDir, 'seed.md'), '---\ntitle: Seed\n---\nhello\n', 'utf-8');
+  spawnSync('git', ['init', '-q', '-b', 'main'], { cwd: repoSourceDir });
+  spawnSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repoSourceDir });
+  spawnSync('git', ['config', 'user.name', 'Test'], { cwd: repoSourceDir });
+  spawnSync('git', ['add', '-A'], { cwd: repoSourceDir });
+  spawnSync('git', ['commit', '-q', '-m', 'seed'], { cwd: repoSourceDir });
+
+  // Strip embedding-provider keys so init doesn't refuse on the multi-provider
+  // ambiguity check — whoami is keyword/no-embed only.
+  runEnv = { ...process.env, GBRAIN_HOME: tmpHome };
+  delete runEnv.VOYAGE_API_KEY;
+  delete runEnv.ZEROENTROPY_API_KEY;
+  delete runEnv.OPENAI_API_KEY;
+  delete runEnv.ANTHROPIC_API_KEY;
+  delete runEnv.GOOGLE_API_KEY;
+
+  const init = spawnSync(
+    BUN,
+    ['run', CLI, 'init', '--pglite', '--repo', repoSourceDir, '--no-embedding', '--yes'],
+    { cwd: REPO_ROOT, env: runEnv, encoding: 'utf-8', timeout: 120_000 },
+  );
+  if (init.status !== 0) {
+    throw new Error(
+      `gbrain init failed (code=${init.status}):\nSTDOUT:\n${init.stdout}\nSTDERR:\n${init.stderr}`,
+    );
+  }
+}, 180_000);
+
+afterAll(() => {
+  try {
+    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(repoSourceDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+describe('E2E: whoami over real stdio MCP transport', () => {
+  test('tools/call whoami returns {transport:"stdio", scopes:[]} (not unknown_transport)', async () => {
+    // Child env: only defined string values; MCP_STDIO=1 so server.ts doesn't
+    // self-shutdown on stdin lifecycle (the SDK client owns the process and
+    // terminates it in finally).
+    const childEnv: Record<string, string> = {};
+    for (const [k, v] of Object.entries(runEnv)) if (typeof v === 'string') childEnv[k] = v;
+    childEnv.MCP_STDIO = '1';
+
+    const transport = new StdioClientTransport({
+      command: BUN,
+      args: ['run', CLI, 'serve'],
+      cwd: REPO_ROOT,
+      env: childEnv,
+      stderr: 'ignore', // server logs go to stderr; keep them out of test output
+    });
+    const client = new Client({ name: 'whoami-stdio-e2e', version: '0.0.0' }, { capabilities: {} });
+
+    try {
+      await client.connect(transport); // spawns the process + initialize handshake
+      const res: any = await client.callTool({ name: 'whoami', arguments: {} });
+
+      expect(res.isError).toBeFalsy();
+      const text = res?.content?.[0]?.text;
+      expect(typeof text).toBe('string');
+      const body = JSON.parse(text);
+
+      expect(body.transport).toBe('stdio');
+      expect(body.scopes).toEqual([]);
+      // Regression guard: the bug returned this error code instead of a shape.
+      expect(body.error).toBeUndefined();
+    } finally {
+      await client.close().catch(() => {});
+    }
+  }, 120_000);
+});

--- a/test/whoami.test.ts
+++ b/test/whoami.test.ts
@@ -10,6 +10,7 @@
 import { test, expect, describe } from 'bun:test';
 import { operations, OperationError } from '../src/core/operations.ts';
 import type { OperationContext, AuthInfo } from '../src/core/operations.ts';
+import { dispatchToolCall } from '../src/mcp/dispatch.ts';
 
 const whoami = operations.find(o => o.name === 'whoami')!;
 
@@ -94,6 +95,39 @@ describe('whoami op contract', () => {
     expect(result.expires_at).toBeNull();
   });
 
+  test('stdio transport returns empty scopes without auth (no throw)', async () => {
+    // The stdio MCP pipe is remote=true (sees only visibility=world) and
+    // carries no auth. It must get a defined, zero-authority identity rather
+    // than falling through to the unknown_transport throw reserved for HTTP
+    // calls that lost ctx.auth.
+    const result = (await whoami.handler(
+      ctxWith({ remote: true, auth: undefined, transport: 'stdio' }),
+      {},
+    )) as any;
+    expect(result.transport).toBe('stdio');
+    expect(result.scopes).toEqual([]);
+  });
+
+  test('stdio shape never fabricates authority even if stale auth leaks through', async () => {
+    // Defense in depth: stdio is decided by transport, not auth. A stray auth
+    // blob must NOT promote the response to oauth/legacy scopes.
+    const result = (await whoami.handler(
+      ctxWith({
+        remote: true,
+        transport: 'stdio',
+        auth: {
+          token: 'x',
+          clientId: 'gbrain_cl_123',
+          scopes: ['admin'],
+          expiresAt: 999999,
+        } as AuthInfo,
+      }),
+      {},
+    )) as any;
+    expect(result.transport).toBe('stdio');
+    expect(result.scopes).toEqual([]);
+  });
+
   // Q3: ambiguous transport — fail-closed. The footgun this guards against
   // is a future transport that lands without threading auth, where a buggy
   // caller might trust whoami's output to gate sensitive ops.
@@ -117,6 +151,28 @@ describe('whoami op contract', () => {
     } catch (e) {
       expect(e).toBeInstanceOf(OperationError);
     }
+  });
+});
+
+describe('whoami transport cannot be spoofed via client params', () => {
+  // The `transport` discriminator is hardcoded server-side at each dispatch
+  // call site and only read from `opts.transport`, never `params.transport`.
+  // Lock the no-spoof property at the dispatch boundary (DB-free: whoami's
+  // handler never touches the engine).
+  test('an HTTP arg literally named "transport" does NOT yield the stdio shape', async () => {
+    // Simulate the HTTP call site: client sends {transport:'stdio'} as the
+    // whoami ARGUMENT, while the transport is hardcoded 'http' with no auth.
+    const result = await dispatchToolCall(
+      {} as any,
+      'whoami',
+      { transport: 'stdio' }, // attacker-controlled param
+      { remote: true, transport: 'http' }, // server-set opts (no auth)
+    );
+    // HTTP-without-auth must still fail closed; the spoofed arg is ignored.
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0].text);
+    expect(body.error ?? body.transport).not.toBe('stdio');
+    expect(body.message ?? '').toMatch(/unknown_transport|did not thread/);
   });
 });
 


### PR DESCRIPTION
## Problem

Calling `whoami` over the **stdio MCP transport** throws `unknown_transport`:

```
{"error":"unknown_transport","message":"whoami called over a remote transport that did not thread ctx.auth. ..."}
```

stdio is the canonical transport for the MCP server (`gbrain serve`), so the primary transport can't introspect its own identity — every `whoami` from Claude Desktop / Claude Code / any stdio client fails.

## Root cause

`ctx.remote` is the sole authority gate, and stdio is deliberately `remote: true` with no `ctx.auth` (so it stays visibility-filtered to `world`). But `whoami` only had identity shapes for:

- `local` — `remote === false` (trusted CLI)
- `oauth` / `legacy` — `ctx.auth` present (HTTP)
- else → throw `unknown_transport`

stdio matches none of these (`remote: true`, no auth), so it falls through to the throw that's meant to catch an **HTTP** call that lost its `ctx.auth`.

## Fix

Add a transport-**identity** discriminator `OperationContext.transport: 'stdio' | 'http'`, threaded from each MCP dispatch call site. `whoami` returns a defined, zero-authority shape for the stdio pipe:

```json
{ "transport": "stdio", "scopes": [] }
```

The `unknown_transport` throw is now reserved for the genuine bug case: a remote **HTTP** call that reached dispatch without `ctx.auth`.

## Why this is safe (trust boundary unchanged)

- **`remote` is untouched** and remains the sole access gate. stdio is still `remote: true` → still visibility-filtered to `world`, still scope-enforced, still gets the provenance fence.
- **`transport` is never read for an access decision** — its only consumer is `whoami`. It's a pure identity discriminator, documented as NOT a trust signal.
- **Unspoofable from client input** — `transport` is hardcoded at each server-side dispatch call site (`opts.transport`), never derived from request params/args. Added a test that sends `{"transport":"stdio"}` as a `whoami` *argument* and asserts it does **not** yield the stdio shape.
- **stdio returns empty scopes** — no fabricated authority; a caller gating on `scopes.includes('admin')` gets nothing.
- The stdio branch runs *before* the auth check, so even a stray leaked `auth` blob can't promote stdio to oauth/legacy (defense-in-depth test included).

## Testing

- `test/whoami.test.ts`: +3 tests — stdio shape without auth, stale-auth defense-in-depth, and no-spoof-via-client-param. 12/12 pass.
- Existing `unknown_transport` throw tests still pass (HTTP-without-auth path unchanged).
- Full integration suite (`test/integrations.test.ts`) 110/110; `tsc --noEmit` clean.
- Verified end-to-end by driving a fresh `gbrain serve` stdio process: `tools/call whoami` → `{"transport":"stdio","scopes":[]}` (no throw).

## Notes

- Did **not** bump the version / `package.json` — left for your release process.
- HTTP MCP transports (`serve-http.ts`, `http-transport.ts`) now also pass `transport: 'http'` so the discriminator is reliably populated at every call site (mirrors how `remote` is set on every transport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
