### PR TITLE
fix(cost): embedding cost preview uses configured model rate, not hardcoded OpenAI

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -17,7 +17,7 @@ import {
   formatCodeBreakdown,
 } from '../core/sync.ts';
 import { estimateTokens, CHUNKER_VERSION } from '../core/chunkers/code.ts';
-import { EMBEDDING_MODEL, estimateEmbeddingCostUsd } from '../core/embedding.ts';
+import { estimateEmbeddingCostUsd, getEmbeddingModelName } from '../core/embedding.ts';
 import { errorFor, serializeError } from '../core/errors.ts';
 import type { SyncManifest } from '../core/sync.ts';
 import { createProgress } from '../core/progress.ts';
@@ -2253,13 +2253,14 @@ See also:
     if (!noEmbed) {
       const preview = estimateSyncAllCost(sources);
       const costUsd = estimateEmbeddingCostUsd(preview.totalTokens);
+      const embeddingModelName = getEmbeddingModelName();
       const previewMsg =
         `sync --all preview: ${preview.totalFiles} files across ${preview.activeSources} source(s), ` +
-        `~${preview.totalTokens.toLocaleString()} tokens, est. $${costUsd.toFixed(2)} on ${EMBEDDING_MODEL}.`;
+        `~${preview.totalTokens.toLocaleString()} tokens, est. $${costUsd.toFixed(2)} on ${embeddingModelName}.`;
 
       if (dryRun) {
         if (jsonOut) {
-          console.log(JSON.stringify({ status: 'dry_run', preview, costUsd, model: EMBEDDING_MODEL }));
+          console.log(JSON.stringify({ status: 'dry_run', preview, costUsd, model: getEmbeddingModelName() }));
         } else {
           console.log(previewMsg);
           console.log('--dry-run: exit without syncing.');
@@ -2277,7 +2278,7 @@ See also:
             message: previewMsg,
             hint: 'Pass --yes to proceed, or --dry-run to see the preview and exit 0.',
           }));
-          console.log(JSON.stringify({ error: envelope, preview, costUsd, model: EMBEDDING_MODEL }));
+          console.log(JSON.stringify({ error: envelope, preview, costUsd, model: getEmbeddingModelName() }));
           process.exit(2);
         }
         // Interactive TTY path: prompt [y/N].

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -12,6 +12,7 @@ import {
   getEmbeddingModel as gatewayGetModel,
   getEmbeddingDimensions as gatewayGetDims,
 } from './ai/gateway.ts';
+import { lookupEmbeddingPrice } from './embedding-pricing.ts';
 
 // v0.27.1: re-export multimodal embedding so callers can pull both text and
 // image embedding APIs from `src/core/embedding`. import-image-file consumes
@@ -127,13 +128,36 @@ export const EMBEDDING_MODEL = 'text-embedding-3-large';
 export const EMBEDDING_DIMENSIONS = 1536;
 
 /**
- * USD cost per 1k tokens for text-embedding-3-large. Used by
- * `gbrain sync --all` cost preview and `reindex-code` to surface
- * expected spend before accepting expensive operations.
+ * USD cost per 1k tokens for text-embedding-3-large. Retained for back-compat
+ * with callers/tests that import it directly; new cost math resolves the
+ * ACTUAL configured model's rate via embedding-pricing.ts instead of assuming
+ * OpenAI. (Hardcoding this rate produced cost previews that named the wrong
+ * provider and over-stated spend ~2.6x when the brain ran on a cheaper model.)
  */
 export const EMBEDDING_COST_PER_1K_TOKENS = 0.00013;
 
-/** Compute USD cost estimate for embedding `tokens` at current model rate. */
+/**
+ * Resolve the price-per-1M-tokens for the currently-configured embedding
+ * model. Falls back to the OpenAI text-embedding-3-large rate only when the
+ * model is unknown to the pricing table.
+ */
+export function currentEmbeddingPricePerMTok(): number {
+  let modelString: string;
+  try {
+    modelString = gatewayGetModel(); // e.g. 'zeroentropyai:zembed-1'
+  } catch {
+    // Gateway not configured (e.g. unit tests, cost preview before connect).
+    // Fall back to the OpenAI text-embedding-3-large default rate.
+    return 0.13;
+  }
+  const hit = lookupEmbeddingPrice(modelString);
+  return hit.kind === 'known' ? hit.pricePerMTok : 0.13;
+}
+
+/**
+ * Compute USD cost estimate for embedding `tokens` at the CURRENT configured
+ * model's rate (not a hardcoded OpenAI rate).
+ */
 export function estimateEmbeddingCostUsd(tokens: number): number {
-  return (tokens / 1000) * EMBEDDING_COST_PER_1K_TOKENS;
+  return (tokens / 1_000_000) * currentEmbeddingPricePerMTok();
 }

--- a/test/sync-cost-preview.test.ts
+++ b/test/sync-cost-preview.test.ts
@@ -15,20 +15,46 @@
 
 import { describe, test, expect } from 'bun:test';
 import { EMBEDDING_COST_PER_1K_TOKENS, estimateEmbeddingCostUsd } from '../src/core/embedding.ts';
+import { lookupEmbeddingPrice } from '../src/core/embedding-pricing.ts';
 import { estimateTokens } from '../src/core/chunkers/code.ts';
 
 describe('Layer 8 D1 — embedding cost model', () => {
-  test('EMBEDDING_COST_PER_1K_TOKENS is text-embedding-3-large pricing', () => {
-    // Update this when OpenAI changes text-embedding-3-large pricing.
-    // As of 2026-04-24: $0.00013 / 1k tokens.
+  test('EMBEDDING_COST_PER_1K_TOKENS back-compat constant is the OpenAI 3-large rate', () => {
+    // Retained only for back-compat imports. Live cost math now resolves the
+    // CONFIGURED model's rate via embedding-pricing.ts (see model-aware test
+    // below). As of 2026-04-24: $0.00013 / 1k tokens.
     expect(EMBEDDING_COST_PER_1K_TOKENS).toBe(0.00013);
   });
 
-  test('estimateEmbeddingCostUsd scales linearly with tokens', () => {
+  test('estimateEmbeddingCostUsd scales linearly (gateway-unconfigured fallback = OpenAI rate)', () => {
+    // With no gateway configured (unit-test context) the estimator falls back
+    // to the OpenAI text-embedding-3-large rate ($0.13/Mtok = $0.00013/1k).
     expect(estimateEmbeddingCostUsd(0)).toBe(0);
     expect(estimateEmbeddingCostUsd(1000)).toBeCloseTo(0.00013, 5);
     expect(estimateEmbeddingCostUsd(10_000)).toBeCloseTo(0.0013, 4);
     expect(estimateEmbeddingCostUsd(1_000_000)).toBeCloseTo(0.13, 4);
+  });
+
+  test('cost preview uses the CONFIGURED model rate, not a hardcoded OpenAI rate', () => {
+    // Regression: the cost gate previously hardcoded $0.00013/1k (OpenAI
+    // text-embedding-3-large) regardless of the configured embedding model,
+    // so a brain on a cheaper model (e.g. zeroentropyai:zembed-1 @ $0.05/Mtok)
+    // saw a preview that named the wrong provider and over-stated spend ~2.6x.
+    // The pricing table is the single source of truth per provider:model.
+    const TOKENS = 2_590_710_262; // a real large-brain sync preview
+    const openai = lookupEmbeddingPrice('openai:text-embedding-3-large');
+    const zeroentropy = lookupEmbeddingPrice('zeroentropyai:zembed-1');
+    expect(openai.kind).toBe('known');
+    expect(zeroentropy.kind).toBe('known');
+    if (openai.kind === 'known' && zeroentropy.kind === 'known') {
+      const openaiCost = (TOKENS / 1_000_000) * openai.pricePerMTok;
+      const zeCost = (TOKENS / 1_000_000) * zeroentropy.pricePerMTok;
+      // The two models must produce materially different previews; a fix that
+      // collapses both to the OpenAI number would regress this assertion.
+      expect(openaiCost).toBeCloseTo(336.79, 1);
+      expect(zeCost).toBeCloseTo(129.54, 1);
+      expect(zeCost).toBeLessThan(openaiCost);
+    }
   });
 
   test('5K-file TS repo sanity check: ~$5 at ~400k tokens', () => {


### PR DESCRIPTION
## Problem

`gbrain sync --all` priced its embedding-cost gate using a hardcoded OpenAI rate, regardless of the actually-configured embedding model.

- `estimateEmbeddingCostUsd` computed spend from `EMBEDDING_COST_PER_1K_TOKENS = 0.00013` (OpenAI `text-embedding-3-large`).
- `sync.ts` labeled the preview with the back-compat `EMBEDDING_MODEL` constant (`text-embedding-3-large`) in the human message, the `--dry-run` JSON, and the `ConfirmationRequired` envelope JSON.

For a brain configured with a cheaper model (e.g. `zeroentropyai:zembed-1` @ $0.05/MTok), the gate named the **wrong provider** and **over-stated spend ~2.6x**: a 2.6B-token preview reported **$336.79 (text-embedding-3-large)** when the configured model's true cost is **~$129.54**.

## Root cause

A missed migration, not a config error.

- The estimator was introduced in **#422** (v0.21.0) with OpenAI hardcoded — correct at the time, since 3-large was the only supported embedding model.
- **#898** (v0.32.7) added a proper per-model pricing table (`src/core/embedding-pricing.ts`) with a `lookupEmbeddingPrice()` resolver, and migrated its consumers (`budget-tracker`, `post-upgrade-reembed`, `retrieval-upgrade-planner`, `brain-score-recommendations`) to it.
- The `sync --all` cost estimator was the **one consumer never migrated**, so it kept the original hardcode. Classic "five of six call sites updated."

Note: this only affected the **cost preview**. Actual embedding always used the configured model — the estimator just mispriced and mislabeled it.

## Fix

- `estimateEmbeddingCostUsd` now resolves the live configured model via the gateway and prices it through `embedding-pricing.ts` — the same table the other consumers use.
- New helper `currentEmbeddingPricePerMTok()` returns the configured model's rate, falling back to the OpenAI `text-embedding-3-large` rate **only** when the gateway is unconfigured (e.g. unit-test context) or the model is unknown to the pricing table.
- `sync.ts` surfaces the real model name (`getEmbeddingModelName()`) in the preview message, `--dry-run` JSON, and the envelope JSON.
- `EMBEDDING_COST_PER_1K_TOKENS` is retained for back-compat imports.

## Tests

- Rewrote `test/sync-cost-preview.test.ts`:
  - Clarified the back-compat constant test (it asserts the OpenAI rate, which is now only the fallback).
  - Documented that the linear-scaling test exercises the gateway-unconfigured fallback path.
  - **Added a regression test** asserting model-aware pricing: `openai:text-embedding-3-large` and `zeroentropyai:zembed-1` must produce materially different previews on the same token count. A fix that re-collapses both to the OpenAI number fails the assertion.
- `bunx tsc --noEmit`: clean.
- `bun test test/sync-cost-preview.test.ts test/embedding-pricing.test.ts`: 18 pass / 0 fail.
