### PR TITLE
fix: keep maintenance jobs source-local

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import type { CliOptions } from './core/cli-options.ts';
 import { callRemoteTool, RemoteMcpError, unpackToolResult } from './core/mcp-client.ts';
 import { maybePromptForUpgrade } from './core/thin-client-upgrade-prompt.ts';
 import { VERSION } from './version.ts';
+import { getDefaultSourcePath } from './core/source-resolver.ts';
 
 // Build CLI name -> operation lookup
 const cliOps = new Map<string, Operation>();
@@ -1596,10 +1597,10 @@ async function handleCliOnly(command: string, args: string[]) {
             }
           }
         }
-        // sync.repo_path resolution (matches dream phase pattern).
+        // Source-local repo path resolution: explicit --repo, then default source local_path.
         let repoPath: string | undefined;
         try {
-          repoPath = (flags.repo as string) || (await engine.getConfig('sync.repo_path')) || undefined;
+          repoPath = (flags.repo as string) || (await getDefaultSourcePath(engine)) || undefined;
         } catch { /* engine may not be connected for help */ }
         await runNotabilityEval({ cmd: subcmd, flags, engine, repoPath });
         break;

--- a/src/commands/autopilot-fanout.ts
+++ b/src/commands/autopilot-fanout.ts
@@ -15,8 +15,7 @@
  *   - P1-3: PGLite engines default `fanoutMax=1` (PGLite is single-writer;
  *     parallel fan-out would queue uselessly behind the file lock).
  *   - P1-4: enumeration filters `local_path IS NOT NULL` so pure-DB
- *     sources don't get dispatched (handler would fall back to global
- *     sync.repo_path, which is wrong for them).
+ *     sources don't get dispatched without an authoritative filesystem root.
  *   - P1-5: archive recheck happens in the handler (jobs.ts:1146), not
  *     here, so a source archived between fan-out and worker claim still
  *     skips cleanly.
@@ -205,7 +204,7 @@ export async function dispatchPerSource(
       const job = await queue.add(
         'autopilot-cycle',
         {
-          repoPath: opts.repoPath,
+          repoPath: src.local_path,
           source_id: src.id,
           pull: !!remoteUrl,
         },

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -24,6 +24,7 @@ import type { BrainEngine } from '../core/engine.ts';
 import { loadPreferences } from '../core/preferences.ts';
 import { loadConfig, gbrainPath as gbrainHomePath } from '../core/config.ts';
 import { ChildWorkerSupervisor } from '../core/minions/child-worker-supervisor.ts';
+import { getDefaultSourcePath } from '../core/source-resolver.ts';
 
 /**
  * v0.37.7.0 #1162 — classify autopilot reconnect-loop errors.
@@ -143,14 +144,14 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
     return;
   }
 
-  const repoPath = parseArg(args, '--repo') || await engine.getConfig('sync.repo_path');
+  const repoPath = parseArg(args, '--repo') || await getDefaultSourcePath(engine);
   const baseInterval = parseInt(parseArg(args, '--interval') || '300', 10);
   const jsonMode = args.includes('--json');
   const forceInline = args.includes('--inline');
   const noWorker = !shouldSpawnAutopilotWorker(args);
 
   if (!repoPath) {
-    console.error('No repo path. Use --repo or run gbrain sync --repo first.');
+    console.error('No repo path. Use --repo or attach a local_path to the default source with `gbrain sources add/default`.');
     process.exit(1);
   }
 
@@ -808,9 +809,9 @@ exec '${safeGbrainPath}' autopilot --repo '${safeRepoPath}'
 }
 
 async function installDaemon(engine: BrainEngine, args: string[]) {
-  const repoPath = parseArg(args, '--repo') || await engine.getConfig('sync.repo_path');
+  const repoPath = parseArg(args, '--repo') || await getDefaultSourcePath(engine);
   if (!repoPath) {
-    console.error('No repo path. Use --repo or run gbrain sync --repo first.');
+    console.error('No repo path. Use --repo or attach a local_path to the default source with `gbrain sources add/default`.');
     process.exit(1);
   }
 

--- a/src/commands/dream.ts
+++ b/src/commands/dream.ts
@@ -30,7 +30,7 @@ import {
   type CyclePhase,
   type CycleReport,
 } from '../core/cycle.ts';
-import { resolveSourceId } from '../core/source-resolver.ts';
+import { getDefaultSourcePath, getSourceLocalPath, resolveSourceId } from '../core/source-resolver.ts';
 import { fetchSource } from '../core/sources-load.ts';
 import { existsSync } from 'fs';
 import { resolve } from 'node:path';
@@ -198,17 +198,14 @@ function parseArgs(args: string[]): DreamArgs {
 /**
  * Resolve the brain directory without the `findRepoRoot` footgun.
  *
- * Prior dream.ts walked up 10 levels of cwd looking for `.git` and would
- * happily run lint + sync against an unrelated git repo the user happened
- * to be cd'd into. This resolver only trusts two sources:
- *   1. An explicit --dir argument.
- *   2. The `sync.repo_path` config key set by `gbrain init` (engine-backed).
- *
- * If neither is available, we error out instead of guessing.
+ * Trust only explicit --dir or registered source local_path. Legacy
+ * sync.repo_path fallback is contained inside getDefaultSourcePath() for
+ * pre-source default installs; named sources never fall back globally.
  */
 async function resolveBrainDir(
   engine: BrainEngine | null,
   explicit: string | null,
+  sourceId?: string,
 ): Promise<string> {
   if (explicit) {
     if (!existsSync(explicit)) {
@@ -221,14 +218,18 @@ async function resolveBrainDir(
   }
 
   if (engine) {
-    const configured = await engine.getConfig('sync.repo_path');
+    const configured = sourceId
+      ? await getSourceLocalPath(engine, sourceId)
+      : await getDefaultSourcePath(engine);
     if (configured && existsSync(configured)) {
       return resolve(configured);
     }
   }
 
   console.error(
-    'No brain directory found. Pass --dir <path> or configure one via `gbrain init`.',
+    sourceId
+      ? `Source ${sourceId} has no usable local_path. Attach one with \`gbrain sources add ${sourceId} --path <path>\` or pass --dir <path>.`
+      : 'No brain directory found. Pass --dir <path> or configure a default source local_path with `gbrain sources add/default`.',
   );
   process.exit(1);
 }
@@ -420,7 +421,7 @@ export async function runDream(engine: BrainEngine | null, args: string[]): Prom
     }
   }
 
-  const brainDir = await resolveBrainDir(engine, opts.dir);
+  const brainDir = await resolveBrainDir(engine, opts.dir, resolvedSourceId);
   const phases: CyclePhase[] | undefined = opts.phase ? [opts.phase] : undefined;
 
   const report = await runCycle(engine, {

--- a/src/commands/features.ts
+++ b/src/commands/features.ts
@@ -8,6 +8,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import type { BrainEngine } from '../core/engine.ts';
+import { getDefaultSourcePath } from '../core/source-resolver.ts';
 import { VERSION } from '../version.ts';
 
 // --- Types ---
@@ -161,13 +162,13 @@ async function scanFeatures(engine: BrainEngine): Promise<FeatureScanResult> {
 
     // No sync configured
     try {
-      const syncRepo = await engine.getConfig('sync.repo_path');
+      const syncRepo = await getDefaultSourcePath(engine);
       if (!syncRepo) {
         recommendations.push({
           id: 'no-sync', priority: 2,
           title: 'Configure Sync',
-          pitch: `Brain not syncing from git. Changes in your repo don't reach your brain.`,
-          command: 'gbrain sync --repo <path>',
+          pitch: `Default source has no local_path, so repo-backed maintenance cannot run.`,
+          command: 'gbrain sources add default --path <path>',
           auto_fixable: false,
         });
       }

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -446,17 +446,36 @@ export async function runImport(
       const { recordSyncFailures } = await import('../core/sync.ts');
       recordSyncFailures(failures, gitHead);
     }
-    if (failures.length === 0) {
-      await engine.setConfig('sync.last_commit', gitHead);
-    } else {
-      console.error(
-        `\nImport completed with ${failures.length} failure(s). ` +
-        `sync.last_commit NOT advanced — re-run 'gbrain sync' to retry, or ` +
-        `'gbrain sync --skip-failed' to acknowledge and move past them.`,
+    if (sourceId) {
+      if (failures.length === 0) {
+        await engine.executeRaw(
+          `UPDATE sources SET last_commit = $1, last_sync_at = now() WHERE id = $2`,
+          [gitHead, sourceId],
+        );
+      } else {
+        console.error(
+          `\nImport completed with ${failures.length} failure(s). ` +
+          `sources.last_commit NOT advanced for ${sourceId} — re-run 'gbrain sync --source ${sourceId}' to retry, or ` +
+          `'gbrain sync --source ${sourceId} --skip-failed' to acknowledge and move past them.`,
+        );
+      }
+      await engine.executeRaw(
+        `UPDATE sources SET local_path = $1 WHERE id = $2`,
+        [dir, sourceId],
       );
+    } else {
+      if (failures.length === 0) {
+        await engine.setConfig('sync.last_commit', gitHead);
+      } else {
+        console.error(
+          `\nImport completed with ${failures.length} failure(s). ` +
+          `sync.last_commit NOT advanced — re-run 'gbrain sync' to retry, or ` +
+          `'gbrain sync --skip-failed' to acknowledge and move past them.`,
+        );
+      }
+      await engine.setConfig('sync.last_run', new Date().toISOString());
+      await engine.setConfig('sync.repo_path', dir);
     }
-    await engine.setConfig('sync.last_run', new Date().toISOString());
-    await engine.setConfig('sync.repo_path', dir);
   }
 
   return { imported, skipped, errors, chunksCreated, failures };

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -9,6 +9,8 @@ import { MinionWorker } from '../core/minions/worker.ts';
 import type { MinionJob, MinionJobStatus } from '../core/minions/types.ts';
 import { loadConfig, isThinClient } from '../core/config.ts';
 import { callRemoteTool, unpackToolResult } from '../core/mcp-client.ts';
+import { getSourceLocalPath, resolveBrainRepoPath } from '../core/source-resolver.ts';
+import { resolve as resolvePath } from 'path';
 
 function parseFlag(args: string[], flag: string): string | undefined {
   const idx = args.indexOf(flag);
@@ -17,6 +19,50 @@ function parseFlag(args: string[], flag: string): string | undefined {
 
 function hasFlag(args: string[], flag: string): boolean {
   return args.includes(flag);
+}
+
+type JobPathData = Record<string, unknown>;
+
+function jobSourceId(data: JobPathData): string | undefined {
+  if (typeof data.source_id === 'string') return data.source_id;
+  if (typeof data.sourceId === 'string') return data.sourceId;
+  return undefined;
+}
+
+function jobExplicitPath(data: JobPathData): string | undefined {
+  if (typeof data.repoPath === 'string') return data.repoPath;
+  if (typeof data.dir === 'string') return data.dir;
+  return undefined;
+}
+
+export async function resolveJobBrainDir(
+  engine: BrainEngine,
+  data: JobPathData,
+  purpose: string,
+  opts: { requireSourcePathMatch?: boolean } = {},
+): Promise<string> {
+  const explicitPath = jobExplicitPath(data);
+  const sourceId = jobSourceId(data);
+
+  if (explicitPath && sourceId && opts.requireSourcePathMatch) {
+    const sourcePath = await getSourceLocalPath(engine, sourceId);
+    if (!sourcePath) {
+      throw new Error(`${purpose}: source ${sourceId} has no local_path; pass a repoPath only for legacy unscoped jobs or attach the source path first.`);
+    }
+    if (resolvePath(explicitPath) !== resolvePath(sourcePath)) {
+      throw new Error(`${purpose}: repoPath ${explicitPath} does not match source ${sourceId} local_path ${sourcePath}.`);
+    }
+  }
+
+  const resolved = await resolveBrainRepoPath(engine, { explicitPath, sourceId });
+  if (!resolved) {
+    throw new Error(
+      `${purpose}: no brain repo path configured. ` +
+      `Pass job.data.repoPath/job.data.dir, provide source_id/sourceId for a source with local_path, ` +
+      `or configure a default source local_path with \`gbrain sources add/default\`.`,
+    );
+  }
+  return resolved;
 }
 
 /** Parse `--max-waiting N` from CLI args. Returns undefined if absent.
@@ -1291,18 +1337,14 @@ export async function registerBuiltinHandlers(worker: MinionWorker, engine: Brai
     const mode = (typeof job.data.mode === 'string' && ['links', 'timeline', 'all'].includes(job.data.mode))
       ? (job.data.mode as 'links' | 'timeline' | 'all')
       : 'all';
-    const dir = typeof job.data.dir === 'string'
-      ? job.data.dir
-      : (await engine.getConfig('sync.repo_path')) ?? '.';
+    const dir = await resolveJobBrainDir(engine, job.data as JobPathData, 'extract');
     return await runExtractCore(engine, { mode, dir, dryRun: !!job.data.dryRun });
   });
 
   worker.register('backlinks', async (job) => {
     const { runBacklinksCore } = await import('./backlinks.ts');
     const action: 'check' | 'fix' = job.data.action === 'check' ? 'check' : 'fix';
-    const dir = typeof job.data.dir === 'string'
-      ? job.data.dir
-      : (await engine.getConfig('sync.repo_path')) ?? '.';
+    const dir = await resolveJobBrainDir(engine, job.data as JobPathData, 'backlinks');
     return await runBacklinksCore({ action, dir, dryRun: !!job.data.dryRun });
   });
 
@@ -1334,9 +1376,6 @@ export async function registerBuiltinHandlers(worker: MinionWorker, engine: Brai
   // throw on partial: a flaky phase must not block every future cycle.
   worker.register('autopilot-cycle', async (job) => {
     const { runCycle } = await import('../core/cycle.ts');
-    const repoPath = typeof job.data.repoPath === 'string'
-      ? job.data.repoPath
-      : (await engine.getConfig('sync.repo_path')) ?? '.';
 
     // v0.38 (codex r1 P1-2 + P1-5): per-source dispatch threading.
     //   - source_id: when set, runCycle uses the per-source lock ID and
@@ -1395,6 +1434,12 @@ export async function registerBuiltinHandlers(worker: MinionWorker, engine: Brai
 
     // Pull default: legacy `true` for back-compat; explicit boolean wins.
     const pull = typeof job.data.pull === 'boolean' ? job.data.pull : true;
+    const repoPath = await resolveJobBrainDir(
+      engine,
+      job.data as JobPathData,
+      'autopilot-cycle',
+      { requireSourcePathMatch: !!sourceId },
+    );
 
     const report = await runCycle(engine, {
       brainDir: repoPath,
@@ -1525,13 +1570,13 @@ export async function registerBuiltinHandlers(worker: MinionWorker, engine: Brai
   // the single source of truth for phase semantics.
   const makePhaseHandler = (phase: string) => async (job: any) => {
     const { runCycle } = await import('../core/cycle.ts');
-    const repoPath = typeof job.data.repoPath === 'string'
-      ? job.data.repoPath
-      : ((await engine.getConfig('sync.repo_path')) ?? '.');
+    const repoPath = await resolveJobBrainDir(engine, job.data as JobPathData, phase);
+    const sourceId = jobSourceId(job.data as JobPathData);
     const report = await runCycle(engine, {
       brainDir: repoPath,
       phases: [phase as any],
       signal: job.signal,
+      ...(sourceId ? { sourceId } : {}),
     });
     return { phase, status: report.status, report };
   };

--- a/src/commands/notability-eval.ts
+++ b/src/commands/notability-eval.ts
@@ -5,8 +5,8 @@
  *
  *   gbrain notability-eval mine [--target-high N] [--target-medium N]
  *                                [--target-low N] [--out PATH]
- *      Walks meetings/, personal/, daily/ in the brain repo (resolved
- *      via `sync.repo_path` config), splits each markdown body into
+ *      Walks meetings/, personal/, daily/ in the resolved brain repo
+ *      (explicit --repo or default source local_path), splits each markdown body into
  *      paragraphs, cheap-Haiku pre-classifies each candidate paragraph,
  *      stratified-samples to target counts (default 20/20/10), writes
  *      candidates JSONL for hand-confirmation.
@@ -302,7 +302,7 @@ export function writeJsonlCases<T>(path: string, cases: T[]): void {
 }
 
 interface RunNotabilityEvalArgs {
-  /** Repo path to mine from (resolves via sync.repo_path config when undefined). */
+  /** Repo path to mine from (explicit --repo or default source local_path). */
   repoPath?: string;
   /** Subcommand: 'mine' | 'review' | 'help'. */
   cmd: string;
@@ -316,7 +316,7 @@ export async function runNotabilityEval(args: RunNotabilityEvalArgs): Promise<vo
   switch (args.cmd) {
     case 'mine': {
       if (!args.repoPath) {
-        throw new Error('mine requires a repoPath. Set sync.repo_path or pass --repo PATH.');
+        throw new Error('mine requires a repoPath. Attach local_path to the default source or pass --repo PATH.');
       }
       const out = (args.flags.out as string) || defaultMiningOutPath();
       const candidates = await mineNotabilityCandidates(resolve(args.repoPath), {

--- a/src/commands/reindex.ts
+++ b/src/commands/reindex.ts
@@ -39,7 +39,7 @@ interface ReindexOpts {
   dryRun?: boolean;
   /** Emit JSON envelope on stdout. */
   json?: boolean;
-  /** Brain repo path (for reading source files). Falls back to sync.repo_path config or process.cwd(). */
+  /** Brain repo path (for reading source files). Falls back to default source local_path for unscoped runs. */
   repoPath?: string;
   /**
    * Skip the embedding call during re-chunk. New chunks land with NULL

--- a/src/commands/takes.ts
+++ b/src/commands/takes.ts
@@ -28,6 +28,7 @@ import {
   type ParsedTake,
 } from '../core/takes-fence.ts';
 import { withPageLock } from '../core/page-lock.ts';
+import { getDefaultSourcePath } from '../core/source-resolver.ts';
 
 // --- Helpers ---
 
@@ -50,10 +51,10 @@ async function resolveBrainDir(engine: BrainEngine | null, explicitDir: string |
     return explicitDir;
   }
   if (engine) {
-    const configured = await engine.getConfig('sync.repo_path');
+    const configured = await getDefaultSourcePath(engine);
     if (configured && existsSync(configured)) return configured;
   }
-  console.error('No brain directory configured. Pass --dir <path> or run `gbrain init` first.');
+  console.error('No brain directory configured. Pass --dir <path> or configure a default source local_path with `gbrain sources add/default`.');
   process.exit(1);
 }
 
@@ -649,7 +650,7 @@ async function cmdExtract(engine: BrainEngine, rest: string[]): Promise<void> {
  * Inserts a `<!-- gbrain:revisit -->` cursor marker at the bottom of the
  * page body so the editor opens with intent visible.
  */
-async function cmdRevisit(_engine: BrainEngine, rest: string[]): Promise<void> {
+async function cmdRevisit(engine: BrainEngine, rest: string[]): Promise<void> {
   const slug = rest[0];
   if (!slug) {
     process.stderr.write('Usage: gbrain takes revisit <slug>\n');
@@ -657,14 +658,8 @@ async function cmdRevisit(_engine: BrainEngine, rest: string[]): Promise<void> {
   }
   const { existsSync, readFileSync, writeFileSync } = await import('node:fs');
   const { join } = await import('node:path');
-  const { execFileSync, spawnSync } = await import('node:child_process');
-  const { loadConfig } = await import('../core/config.ts');
-  const cfg = loadConfig();
-  const repoPath = (cfg as { sync?: { repo_path?: string } } | null)?.sync?.repo_path;
-  if (!repoPath) {
-    process.stderr.write('No brain repo configured. Run `gbrain config set sync.repo_path /path/to/brain`.\n');
-    process.exit(1);
-  }
+  const { spawnSync } = await import('node:child_process');
+  const repoPath = await resolveBrainDir(engine, null);
   const filePath = join(repoPath, `${slug}.md`);
   if (!existsSync(filePath)) {
     process.stderr.write(`Page not found: ${filePath}\n`);
@@ -683,5 +678,4 @@ async function cmdRevisit(_engine: BrainEngine, rest: string[]): Promise<void> {
   if (result.status !== 0) {
     process.stderr.write(`Editor exited with status ${result.status ?? 'unknown'}\n`);
   }
-  void execFileSync;
 }

--- a/src/core/brain-score-recommendations.ts
+++ b/src/core/brain-score-recommendations.ts
@@ -331,7 +331,7 @@ function classifyOne(check: Check, ctx: RecommendationContext): CheckClassificat
     case 'brain_score':
     case 'sync_freshness':
       if (!ctx.repoPath) {
-        return { check: check.name, status: 'blocked', reason: 'no repo configured (set sync.repo_path)' };
+        return { check: check.name, status: 'blocked', reason: 'no source local_path configured' };
       }
       return { check: check.name, status: 'remediable' };
     case 'missing_embeddings':

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -844,9 +844,8 @@ export interface BrainEngine {
    * `sources-ops.listSources`.
    *
    * Defaults filter out archived sources. When `localPathOnly` is true,
-   * also filters `local_path IS NOT NULL` so the autopilot fan-out doesn't
-   * dispatch jobs for pure-DB sources whose handler would fall back to
-   * the global sync.repo_path (codex r1 P1-4).
+   * also filters `local_path IS NOT NULL` so autopilot fan-out dispatches
+   * only sources with an authoritative filesystem root.
    *
    * `config` is returned as `Record<string, unknown>` — both engines
    * already parse the JSONB at the boundary (Postgres-js returns

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -23,6 +23,7 @@ import { isFactsBackstopEligible } from './facts/eligibility.ts';
 import { stripTakesFence } from './takes-fence.ts';
 import { stripFactsFence } from './facts-fence.ts';
 import { bumpLastRetrievedAt } from './last-retrieved.ts';
+import { fetchSource } from './sources-load.ts';
 import { CJK_SLUG_CHARS } from './cjk.ts';
 import * as db from './db.ts';
 import { VERSION } from '../version.ts';
@@ -187,6 +188,52 @@ export function matchesSlugAllowList(slug: string, prefixes: readonly string[]):
     }
   }
   return false;
+}
+
+type PutPageWriteThroughTarget =
+  | { repoPath: string; layoutSourceId: string }
+  | { skipped: string };
+
+async function resolvePutPageWriteThroughTarget(
+  engine: BrainEngine,
+  sourceId: string,
+): Promise<PutPageWriteThroughTarget> {
+  const source = await fetchSource(engine, sourceId);
+  if (source?.archived === true) return { skipped: 'source_archived' };
+
+  const sourceLocalPath = typeof source?.local_path === 'string'
+    ? source.local_path.trim()
+    : '';
+  if (sourceLocalPath) {
+    // The sources table is authoritative for multi-source brains. A source
+    // local_path is already that source's filesystem root, so write directly
+    // under it. Do not use the global sync.repo_path here: that mutable legacy
+    // config is often set by the latest sync/import and can point at a totally
+    // different source clone.
+    return { repoPath: sourceLocalPath, layoutSourceId: 'default' };
+  }
+
+  if (sourceId !== 'default') {
+    return { skipped: 'source_local_path_missing' };
+  }
+
+  const legacyRepoPath = await engine.getConfig('sync.repo_path');
+  if (!legacyRepoPath) return { skipped: 'no_repo_configured' };
+
+  // Legacy single-default installs predate per-source local_path. Keep this
+  // fallback only for the literal default source; named sources must provide
+  // their own local_path or stay DB-only to avoid cross-source write-through.
+  return { repoPath: legacyRepoPath, layoutSourceId: sourceId };
+}
+
+function isLexicallyInside(root: string, filePath: string): boolean {
+  const rootAbs = resolve(root);
+  const fileAbs = resolve(filePath);
+  const rel = relative(rootAbs, fileAbs);
+  return rel !== ''
+    && !rel.startsWith('..')
+    && !rel.startsWith(`..${sep}`)
+    && resolve(rootAbs, rel) === fileAbs;
 }
 
 /**
@@ -703,10 +750,11 @@ const put_page: Operation = {
     }
 
     // v0.38 put_page write-through (ingestion cathedral):
-    // After importFromContent succeeds, if `sync.repo_path` resolves to a
-    // real directory, persist the markdown file to disk alongside the DB
-    // row. Failures non-fatal — DB write is durable; subsequent sync
-    // reconciles drift.
+    // After importFromContent succeeds, persist the markdown file to the
+    // source-owned filesystem root alongside the DB row. Per-source
+    // `sources.local_path` wins; legacy `sync.repo_path` is only a fallback for
+    // literal default-source installs that predate per-source roots. Failures
+    // are non-fatal — DB write is durable; subsequent sync reconciles drift.
     //
     // Trust gating:
     //   - Subagent sandbox (viaSubagent without allowedSlugPrefixes) → DB-only.
@@ -716,13 +764,13 @@ const put_page: Operation = {
       && !(Array.isArray(ctx.allowedSlugPrefixes) && ctx.allowedSlugPrefixes.length > 0);
     if (!ctx.dryRun && result.status !== 'error' && !isSandboxSubagent) {
       try {
-        const repoPath = await ctx.engine.getConfig('sync.repo_path');
-        if (!repoPath) {
-          writeThrough = { written: false, skipped: 'no_repo_configured' };
-        } else if (!existsSync(repoPath) || !statSync(repoPath).isDirectory()) {
+        const sourceId = ctx.sourceId ?? 'default';
+        const target = await resolvePutPageWriteThroughTarget(ctx.engine, sourceId);
+        if ('skipped' in target) {
+          writeThrough = { written: false, skipped: target.skipped };
+        } else if (!existsSync(target.repoPath) || !statSync(target.repoPath).isDirectory()) {
           writeThrough = { written: false, skipped: 'repo_not_found' };
         } else {
-          const sourceId = ctx.sourceId ?? 'default';
           const writtenPage = await ctx.engine.getPage(result.slug, { sourceId });
           if (writtenPage) {
             const tags = await ctx.engine.getTags(result.slug, { sourceId });
@@ -734,10 +782,14 @@ const put_page: Operation = {
                 source_kind: provenanceVia,
               },
             });
-            const filePath = resolvePageFilePath(repoPath as string, result.slug, sourceId);
-            mkdirSync(dirname(filePath), { recursive: true });
-            writeFileSync(filePath, md, 'utf8');
-            writeThrough = { written: true, path: filePath };
+            const filePath = resolvePageFilePath(target.repoPath, result.slug, target.layoutSourceId);
+            if (!isLexicallyInside(target.repoPath, filePath)) {
+              writeThrough = { written: false, skipped: 'path_escape' };
+            } else {
+              mkdirSync(dirname(filePath), { recursive: true });
+              writeFileSync(filePath, md, 'utf8');
+              writeThrough = { written: true, path: filePath };
+            }
           } else {
             writeThrough = { written: false, skipped: 'page_not_found_after_write' };
           }

--- a/src/core/remediation/context.ts
+++ b/src/core/remediation/context.ts
@@ -8,6 +8,7 @@
 
 import type { BrainEngine } from '../engine.ts';
 import type { RecommendationContext } from '../brain-score-recommendations.ts';
+import { getDefaultSourcePath } from '../source-resolver.ts';
 
 // Re-export so consumers can `import { RecommendationContext } from '../remediation'`
 // — the canonical RecommendationContext type still lives in
@@ -31,7 +32,7 @@ export async function loadRecommendationContext(
   // Also extended the API-key check to recognize the ZE key alongside
   // OpenAI (was OpenAI-only). After Lane C.3, zeroentropy_api_key lives
   // in GBrainConfig + propagates to the gateway env dict.
-  const repoPath = await engine.getConfig('sync.repo_path');
+  const repoPath = await getDefaultSourcePath(engine);
   let embeddingModel: string | undefined;
   let embeddingDimensions: number | undefined;
   try {

--- a/src/core/source-resolver.ts
+++ b/src/core/source-resolver.ts
@@ -239,6 +239,50 @@ export async function getDefaultSourcePath(
   return legacyPath ?? null;
 }
 
+/** Return a registered source's local_path without consulting legacy globals. */
+export async function getSourceLocalPath(
+  engine: BrainEngine,
+  sourceId: string,
+): Promise<string | null> {
+  if (!isValidSourceId(sourceId)) {
+    throw new Error(`Invalid source id "${sourceId}". Must match [a-z0-9-]{1,32}.`);
+  }
+  const rows = await engine.executeRaw<{ local_path: string | null }>(
+    `SELECT local_path FROM sources WHERE id = $1`,
+    [sourceId],
+  );
+  if (rows.length === 0) {
+    throw new Error(
+      `Source "${sourceId}" not found. Available sources: ` +
+      `run \`gbrain sources list\` to see registered sources, ` +
+      `or \`gbrain sources add ${sourceId}\` to create it.`,
+    );
+  }
+  return rows[0]?.local_path ?? null;
+}
+
+/**
+ * Resolve a filesystem brain repo path for command/job surfaces.
+ *
+ * Source-scoped calls intentionally do NOT fall back to global
+ * `sync.repo_path`: a named source with no `local_path` is DB-only or
+ * misconfigured, and using a stale global path would cross source
+ * boundaries. Legacy global fallback remains only in getDefaultSourcePath()
+ * for pre-source single-default installs.
+ */
+export async function resolveBrainRepoPath(
+  engine: BrainEngine,
+  opts: {
+    explicitPath?: string | null;
+    sourceId?: string | null;
+    cwd?: string;
+  } = {},
+): Promise<string | null> {
+  if (opts.explicitPath) return opts.explicitPath;
+  if (opts.sourceId) return await getSourceLocalPath(engine, opts.sourceId);
+  return await getDefaultSourcePath(engine, opts.cwd ?? process.cwd());
+}
+
 /**
  * v0.37.7.0 — tier labels for `resolveSourceWithTier()`. Exported so
  * `gbrain sources current --json` and downstream consumers share a

--- a/test/autopilot-fanout.test.ts
+++ b/test/autopilot-fanout.test.ts
@@ -217,9 +217,17 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
       'autopilot-cycle:alpha:2026-05-22T12:00:00.000Z',
       'autopilot-cycle:beta:2026-05-22T12:00:00.000Z',
     ]);
-    // source_id threaded through job data
+    // source_id and source-local repoPath threaded through job data — never the orchestrator root.
     const sourceIds = added.map(j => (j.data as Record<string, unknown>).source_id).sort();
     expect(sourceIds).toEqual(['alpha', 'beta']);
+    const repoPathsBySource = new Map(
+      added.map(j => [
+        (j.data as Record<string, unknown>).source_id,
+        (j.data as Record<string, unknown>).repoPath,
+      ]),
+    );
+    expect(repoPathsBySource.get('alpha')).toBe('/tmp/alpha');
+    expect(repoPathsBySource.get('beta')).toBe('/tmp/beta');
   });
 
   test('pull: true only when source.config.remote_url is set', async () => {

--- a/test/import-source-id.test.ts
+++ b/test/import-source-id.test.ts
@@ -14,7 +14,8 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { execFileSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
@@ -37,6 +38,9 @@ async function truncatePages(): Promise<void> {
     await (engine as any).db.exec(`DELETE FROM ${t}`);
   }
   await (engine as any).db.exec(`DELETE FROM sources WHERE id <> 'default'`);
+  await engine.unsetConfig?.('sync.repo_path').catch(() => {});
+  await engine.unsetConfig?.('sync.last_commit').catch(() => {});
+  await engine.unsetConfig?.('sync.last_run').catch(() => {});
 }
 
 describe('import --source-id (#1167)', () => {
@@ -78,6 +82,18 @@ describe('import --source-id (#1167)', () => {
     for (const r of rows) {
       expect(r.source_id).toBe('dept-x');
     }
+  });
+
+  test('git-backed import into a registered non-default source does not recreate global sync.repo_path', async () => {
+    execFileSync('git', ['init'], { cwd: scratchDir, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.email', 'gbrain-test@example.invalid'], { cwd: scratchDir });
+    execFileSync('git', ['config', 'user.name', 'GBrain Test'], { cwd: scratchDir });
+    execFileSync('git', ['add', '.'], { cwd: scratchDir });
+    execFileSync('git', ['commit', '-m', 'fixture'], { cwd: scratchDir, stdio: 'ignore' });
+
+    await runImport(engine, [scratchDir, '--source-id', 'dept-x', '--no-embed', '--json']);
+
+    await expect(engine.getConfig('sync.repo_path')).resolves.toBeNull();
   });
 
   test('--source-id value is NOT treated as a positional dir arg', async () => {

--- a/test/ingestion/put-page-write-through.test.ts
+++ b/test/ingestion/put-page-write-through.test.ts
@@ -1,8 +1,8 @@
 /**
  * put_page write-through tests (v0.38).
  *
- * Verifies that put_page writes the markdown file to disk alongside the
- * DB row when sync.repo_path is configured. Trust gating: subagent
+ * Verifies that put_page writes the markdown file to the source-owned
+ * filesystem root alongside the DB row. Legacy sync.repo_path is retained
  * sandbox writes stay DB-only; dry-run stays DB-only; missing-repo
  * stays DB-only.
  */
@@ -49,7 +49,8 @@ beforeEach(async () => {
   tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gbrain-wt-'));
   brainDir = path.join(tmpRoot, 'brain');
   fs.mkdirSync(brainDir, { recursive: true });
-  // Wire sync.repo_path so write-through can find the repo.
+  // Legacy setup: default-source write-through may still fall back here
+  // when sources.local_path is absent.
   await engine.setConfig('sync.repo_path', brainDir);
 });
 
@@ -196,9 +197,57 @@ describe('put_page write-through — config edge cases', () => {
 });
 
 describe('put_page write-through — multi-source filing', () => {
-  test('non-default source lands at brainDir/.sources/<id>/<slug>.md', async () => {
-    // Create a non-default source row first. Schema fields: id (PK),
-    // name (UNIQUE), plus the v0.26.5 archive columns with defaults.
+  test('default source local_path wins over stale global sync.repo_path', async () => {
+    const canonicalDefaultRoot = path.join(tmpRoot, 'canonical-default');
+    const staleCodeRoot = path.join(tmpRoot, 'stale-code-clone');
+    fs.mkdirSync(canonicalDefaultRoot, { recursive: true });
+    fs.mkdirSync(staleCodeRoot, { recursive: true });
+    await engine.executeRaw(
+      "UPDATE sources SET local_path = $1 WHERE id = 'default'",
+      [canonicalDefaultRoot],
+    );
+    await engine.setConfig('sync.repo_path', staleCodeRoot);
+
+    const ctx = makeCtx({ sourceId: 'default', remote: true });
+    const result = (await putPage.handler(ctx, {
+      slug: 'capabilities/source-safe-write',
+      content: '---\ntitle: Source-safe write\n---\n\nbody',
+    })) as { write_through?: { written: boolean; path?: string } };
+
+    const expectedPath = path.join(canonicalDefaultRoot, 'capabilities/source-safe-write.md');
+    const wrongPath = path.join(staleCodeRoot, 'capabilities/source-safe-write.md');
+    expect(result.write_through?.written).toBe(true);
+    expect(result.write_through?.path).toBe(expectedPath);
+    expect(fs.existsSync(expectedPath)).toBe(true);
+    expect(fs.existsSync(wrongPath)).toBe(false);
+  });
+
+  test('non-default source with local_path writes under that source root', async () => {
+    const sourceRoot = path.join(tmpRoot, 'team-x-root');
+    const staleDefaultRoot = path.join(tmpRoot, 'stale-default-root');
+    fs.mkdirSync(sourceRoot, { recursive: true });
+    fs.mkdirSync(staleDefaultRoot, { recursive: true });
+    await engine.executeRaw(
+      "INSERT INTO sources (id, name, local_path) VALUES ('team-x-local', 'team-x-local', $1)",
+      [sourceRoot],
+    );
+    await engine.setConfig('sync.repo_path', staleDefaultRoot);
+
+    const ctx = makeCtx({ sourceId: 'team-x-local' });
+    const result = (await putPage.handler(ctx, {
+      slug: 'shared/page',
+      content: '---\ntitle: X\n---\n\nbody',
+    })) as { write_through?: { written: boolean; path?: string } };
+
+    const expectedPath = path.join(sourceRoot, 'shared/page.md');
+    const wrongPath = path.join(staleDefaultRoot, '.sources/team-x-local/shared/page.md');
+    expect(result.write_through?.written).toBe(true);
+    expect(result.write_through?.path).toBe(expectedPath);
+    expect(fs.existsSync(expectedPath)).toBe(true);
+    expect(fs.existsSync(wrongPath)).toBe(false);
+  });
+
+  test('non-default source without local_path skips write-through instead of borrowing global repo path', async () => {
     await engine.executeRaw(
       "INSERT INTO sources (id, name) VALUES ('team-x', 'team-x')",
     );
@@ -206,10 +255,10 @@ describe('put_page write-through — multi-source filing', () => {
     const result = (await putPage.handler(ctx, {
       slug: 'shared/page',
       content: '---\ntitle: X\n---\n\nbody',
-    })) as { write_through?: { written: boolean; path?: string } };
-    expect(result.write_through?.written).toBe(true);
-    expect(result.write_through?.path).toBe(path.join(brainDir, '.sources/team-x/shared/page.md'));
-    expect(fs.existsSync(result.write_through!.path!)).toBe(true);
+    })) as { write_through?: { written: boolean; skipped?: string; path?: string } };
+    expect(result.write_through?.written).toBe(false);
+    expect(result.write_through?.skipped).toBe('source_local_path_missing');
+    expect(fs.existsSync(path.join(brainDir, '.sources/team-x/shared/page.md'))).toBe(false);
   });
 });
 

--- a/test/jobs-source-path-resolution.test.ts
+++ b/test/jobs-source-path-resolution.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect } from 'bun:test';
+import { resolveJobBrainDir } from '../src/commands/jobs.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+function makeEngine(opts: {
+  defaultPath?: string | null;
+  sourcePaths?: Record<string, string | null>;
+  legacyPath?: string | null;
+} = {}): BrainEngine {
+  const sourcePaths: Record<string, string | null> = { default: opts.defaultPath ?? null, ...(opts.sourcePaths ?? {}) };
+  return {
+    kind: 'pglite',
+    executeRaw: async <T>(sql: string, params?: unknown[]): Promise<T[]> => {
+      if (sql.includes('SELECT id FROM sources WHERE id = $1')) {
+        const id = params?.[0] as string;
+        return (id in sourcePaths ? [{ id } as unknown as T] : []);
+      }
+      if (sql.includes('SELECT local_path FROM sources WHERE id = $1')) {
+        const id = params?.[0] as string;
+        if (id in sourcePaths) return [{ local_path: sourcePaths[id] } as unknown as T];
+        return [];
+      }
+      if (sql.includes('SELECT id, local_path FROM sources')) {
+        return Object.entries(sourcePaths)
+          .filter(([_, local_path]) => local_path !== null)
+          .map(([id, local_path]) => ({ id, local_path }) as unknown as T);
+      }
+      return [];
+    },
+    getConfig: async (key: string) => {
+      if (key === 'sources.default') return 'default';
+      if (key === 'sync.repo_path') return opts.legacyPath ?? null;
+      return null;
+    },
+  } as unknown as BrainEngine;
+}
+
+describe('resolveJobBrainDir', () => {
+  test('explicit repoPath wins when no source coherence check is requested', async () => {
+    const engine = makeEngine({ defaultPath: '/brain/default', sourcePaths: { code: '/brain/code' } });
+    await expect(resolveJobBrainDir(engine, { repoPath: '/explicit', source_id: 'code' }, 'unit-test'))
+      .resolves.toBe('/explicit');
+  });
+
+  test('source_id resolves through the source local_path when repoPath is omitted', async () => {
+    const engine = makeEngine({ defaultPath: '/brain/default', sourcePaths: { code: '/brain/code' }, legacyPath: '/stale/global' });
+    await expect(resolveJobBrainDir(engine, { source_id: 'code' }, 'autopilot-cycle'))
+      .resolves.toBe('/brain/code');
+  });
+
+  test('camelCase sourceId is accepted for sync-style job payloads', async () => {
+    const engine = makeEngine({ defaultPath: '/brain/default', sourcePaths: { work: '/brain/work' } });
+    await expect(resolveJobBrainDir(engine, { sourceId: 'work' }, 'sync'))
+      .resolves.toBe('/brain/work');
+  });
+
+  test('falls back to the default source local_path, not process.cwd(), when no job path/source is provided', async () => {
+    const engine = makeEngine({ defaultPath: '/brain/default', legacyPath: '/stale/global' });
+    await expect(resolveJobBrainDir(engine, {}, 'extract'))
+      .resolves.toBe('/brain/default');
+  });
+
+  test('throws a clear error instead of falling back to cwd when no source path exists', async () => {
+    const engine = makeEngine({ defaultPath: null, legacyPath: null });
+    await expect(resolveJobBrainDir(engine, {}, 'extract'))
+      .rejects.toThrow(/extract: no brain repo path configured/);
+  });
+
+  test('can reject explicit repoPath/source_id mismatches for source-scoped cycle jobs', async () => {
+    const engine = makeEngine({ defaultPath: '/brain/default', sourcePaths: { code: '/brain/code' } });
+    await expect(
+      resolveJobBrainDir(engine, { repoPath: '/wrong/root', source_id: 'code' }, 'autopilot-cycle', { requireSourcePathMatch: true }),
+    ).rejects.toThrow(/repoPath .* does not match source code local_path/);
+  });
+});

--- a/test/source-resolver.test.ts
+++ b/test/source-resolver.test.ts
@@ -14,7 +14,13 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { resolveSourceId, getDefaultSourcePath, __testing } from '../src/core/source-resolver.ts';
+import {
+  resolveSourceId,
+  getDefaultSourcePath,
+  getSourceLocalPath,
+  resolveBrainRepoPath,
+  __testing,
+} from '../src/core/source-resolver.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 
 // ── Stub engine ────────────────────────────────────────────
@@ -268,6 +274,87 @@ describe('getDefaultSourcePath', () => {
     );
     const path = await getDefaultSourcePath(engine, '/custom/path/sub');
     expect(path).toBe('/custom/path');
+  });
+});
+
+// ── source-local path helpers ───────────────────────────────
+
+describe('source-local repo path helpers', () => {
+  function makeSourcePathStub(
+    registeredSources: string[],
+    sourcePaths: Record<string, string | null>,
+    defaultKey: string | null = null,
+    legacyPath: string | null = null,
+  ): BrainEngine {
+    return {
+      kind: 'pglite',
+      executeRaw: async <T>(sql: string, params?: unknown[]): Promise<T[]> => {
+        if (sql.includes('SELECT id FROM sources WHERE id = $1')) {
+          const target = params?.[0];
+          return (registeredSources.includes(target as string)
+            ? [{ id: target } as unknown as T]
+            : []);
+        }
+        if (sql.includes('SELECT local_path FROM sources WHERE id = $1')) {
+          const target = params?.[0] as string;
+          if (target in sourcePaths) return [{ local_path: sourcePaths[target] } as unknown as T];
+          return [];
+        }
+        if (sql.includes('SELECT id, local_path FROM sources')) {
+          return Object.entries(sourcePaths)
+            .filter(([_, p]) => p !== null)
+            .map(([id, local_path]) => ({ id, local_path }) as unknown as T);
+        }
+        return [];
+      },
+      getConfig: async (key: string) => {
+        if (key === 'sources.default') return defaultKey;
+        if (key === 'sync.repo_path') return legacyPath;
+        return null;
+      },
+    } as unknown as BrainEngine;
+  }
+
+  test('getSourceLocalPath returns a named source local_path without touching global sync.repo_path', async () => {
+    const engine = makeSourcePathStub(
+      ['default', 'code'],
+      { default: '/brain/default', code: '/brain/code' },
+      'default',
+      '/stale/global',
+    );
+    await expect(getSourceLocalPath(engine, 'code')).resolves.toBe('/brain/code');
+  });
+
+  test('getSourceLocalPath returns null for a registered source with no local_path', async () => {
+    const engine = makeSourcePathStub(['default', 'dbonly'], { default: '/brain/default', dbonly: null });
+    await expect(getSourceLocalPath(engine, 'dbonly')).resolves.toBeNull();
+  });
+
+  test('getSourceLocalPath throws for missing or malformed source ids', async () => {
+    const engine = makeSourcePathStub(['default'], { default: '/brain/default' });
+    await expect(getSourceLocalPath(engine, 'ghost')).rejects.toThrow(/Source "ghost" not found/);
+    await expect(getSourceLocalPath(engine, 'BAD_ID')).rejects.toThrow(/Invalid source id/);
+  });
+
+  test('resolveBrainRepoPath uses explicit path first, then source local_path, then default source path', async () => {
+    const engine = makeSourcePathStub(
+      ['default', 'code'],
+      { default: '/brain/default', code: '/brain/code' },
+      'default',
+      '/stale/global',
+    );
+
+    await expect(resolveBrainRepoPath(engine, { explicitPath: '/explicit', sourceId: 'code' }))
+      .resolves.toBe('/explicit');
+    await expect(resolveBrainRepoPath(engine, { sourceId: 'code' }))
+      .resolves.toBe('/brain/code');
+    await expect(resolveBrainRepoPath(engine, { cwd: '/nowhere' }))
+      .resolves.toBe('/brain/default');
+  });
+
+  test('resolveBrainRepoPath does not use legacy sync.repo_path for named sources', async () => {
+    const engine = makeSourcePathStub(['default', 'dbonly'], { default: '/brain/default', dbonly: null }, 'default', '/legacy/global');
+    await expect(resolveBrainRepoPath(engine, { sourceId: 'dbonly' })).resolves.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Make source-scoped maintenance/write-through paths resolve from `sources.local_path` instead of borrowing global `sync.repo_path` or falling back to `.`.
- Keep `sync.repo_path` only as a legacy fallback for literal default-source installs.
- Update autopilot fan-out, job handlers, dream/autopilot/takes/notability/features/remediation path resolution, and source-scoped import metadata writes.
- Add regression coverage for source-local job resolution, fan-out repo paths, source-scoped import config behavior, and `put_page` write-through routing.

## Test plan

- `bun install --ignore-scripts`
- `bun run typecheck`
- `bun run verify` — 29/29 checks green
- `bun test test/source-resolver.test.ts test/jobs-source-path-resolution.test.ts test/autopilot-fanout.test.ts test/import-source-id.test.ts test/ingestion/put-page-write-through.test.ts test/import-file.test.ts test/features.test.ts` — 108 pass / 0 fail

## Notes

This was ported onto current `origin/master` in a clean side worktree. The branch intentionally does not enable embeddings, autopilot daemons, recurring jobs, or any live sync loop.