### PR TITLE
fix(think): stop printing the Gaps section twice in CLI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to GBrain will be documented in this file.
 
+## [UNRELEASED] - fix(think): duplicate "Gaps" section in CLI output
+
+`knowledgebase think` printed the **Gaps** section twice: once from the model's answer body (the synthesis prompt instructs the model to include an Answer/Conflicts/Gaps structure) and again from the CLI rendering the structured `gaps[]` array as a second `## Gaps` block. The renderer now suppresses the structured block when the answer body already contains a Gaps heading (`shouldRenderGapsBlock`, unit-tested). The structured block still renders when the model omits a Gaps section from the body, so no gap data is lost.
+
 ## [0.41.29.0] - 2026-05-29
 
 **Your meeting transcripts that look like `**Garry Tan:** ...` now actually

--- a/src/commands/think.ts
+++ b/src/commands/think.ts
@@ -16,6 +16,19 @@ function flagValue(args: string[], name: string): string | undefined {
   return args[i + 1];
 }
 
+/**
+ * The synthesis prompt instructs the model to include a "Gaps" section in the
+ * answer body. The CLI also has a structured `gaps[]` array it can render as a
+ * `## Gaps` block. Rendering both prints Gaps twice, so only emit the
+ * structured block when there are gaps AND the answer body does not already
+ * contain a Gaps heading. Exported for unit testing.
+ */
+export function shouldRenderGapsBlock(answer: string, gaps: string[]): boolean {
+  if (gaps.length === 0) return false;
+  const answerHasGaps = /^#{1,6}\s*Gaps\b/im.test(answer);
+  return !answerHasGaps;
+}
+
 function flagPresent(args: string[], name: string): boolean {
   return args.includes(name);
 }
@@ -133,7 +146,7 @@ the gather phase still runs and prints what would have been the input.
   console.log(`# ${question}\n`);
   console.log(result.answer);
   console.log('');
-  if (result.gaps.length > 0) {
+  if (shouldRenderGapsBlock(result.answer, result.gaps)) {
     console.log('## Gaps');
     for (const g of result.gaps) console.log(`- ${g}`);
     console.log('');

--- a/test/think-render-gaps.test.ts
+++ b/test/think-render-gaps.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression test for `shouldRenderGapsBlock` in `src/commands/think.ts`.
+ *
+ * The synthesis prompt instructs the model to include a "Gaps" section inside
+ * the answer body. The CLI also renders a structured `## Gaps` block from the
+ * `gaps[]` array. Rendering both prints "Gaps" twice. This pins the de-dup
+ * rule: the structured block is suppressed when the answer body already
+ * contains a Gaps heading.
+ *
+ * Hermetic, no DB, no API keys.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { shouldRenderGapsBlock } from '../src/commands/think.ts';
+
+describe('shouldRenderGapsBlock — duplicate Gaps suppression', () => {
+  test('suppresses structured block when answer body already has a Gaps heading', () => {
+    const answer = '## Answer\n\nSome text.\n\n## Gaps\n\n- missing X\n';
+    expect(shouldRenderGapsBlock(answer, ['missing X'])).toBe(false);
+  });
+
+  test('renders structured block when answer body has no Gaps heading', () => {
+    const answer = '## Answer\n\nSome text with no gaps section.';
+    expect(shouldRenderGapsBlock(answer, ['missing X'])).toBe(true);
+  });
+
+  test('never renders when there are no gaps', () => {
+    expect(shouldRenderGapsBlock('## Answer\n\nText.', [])).toBe(false);
+    expect(shouldRenderGapsBlock('## Answer\n\n## Gaps\n- x', [])).toBe(false);
+  });
+
+  test('matches Gaps heading at any markdown level and case-insensitively', () => {
+    expect(shouldRenderGapsBlock('# Gaps\n- x', ['x'])).toBe(false);
+    expect(shouldRenderGapsBlock('### gaps\n- x', ['x'])).toBe(false);
+    expect(shouldRenderGapsBlock('###### GAPS\n- x', ['x'])).toBe(false);
+  });
+
+  test('does not match the word "gaps" in prose (heading-anchored only)', () => {
+    const answer = '## Answer\n\nThere are some gaps in the data, but no section.';
+    expect(shouldRenderGapsBlock(answer, ['missing X'])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`gbrain think` prints the **Gaps** section twice in human-readable output:

1. The synthesis prompt instructs the model to include a `Gaps` section in the answer body (`src/core/think/prompt.ts` — "Sections: Answer, Conflicts, Gaps").
2. The CLI renderer (`src/commands/think.ts`) *also* prints a `## Gaps` block from the structured `gaps[]` array.

So the rendered output shows `## Gaps` once from the model's body and again from the renderer. Affects every model (provider-agnostic) and every `think` invocation that produces gaps.

## Fix

Extract a pure, exported `shouldRenderGapsBlock(answer, gaps)` helper that returns `true` only when there are gaps **and** the answer body does not already contain a Gaps heading. The renderer calls it instead of the bare `gaps.length > 0` check.

No gap data is lost: when the model omits a Gaps section from the body, the structured block still renders.

## Test evidence

- New hermetic test `test/think-render-gaps.test.ts` (5 cases, no DB / no API keys): suppresses on body-has-Gaps, renders on body-no-Gaps, never renders on empty gaps, matches Gaps heading at any markdown level + case-insensitively, and does **not** match the word "gaps" in prose (heading-anchored).
- `bun test test/think-render-gaps.test.ts`: 5 pass / 0 fail.
- `tsc --noEmit`: clean.

## Before / after

```
# before — Gaps printed twice
## Gaps
- ...        (from model answer body)
...
## Gaps
- ...        (from structured renderer)

# after — Gaps printed once
## Gaps
- ...
```

## Notes

- Pre-existing bug, unrelated to any other in-flight PR.
- VERSION not bumped — left for the maintainer's release flow; CHANGELOG entry is under `[UNRELEASED]`.
