### PR TITLE
fix(search): keyword search ignores pages.search_vector, exact-title queries return No results

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1535,9 +1535,53 @@ export class PostgresEngine implements BrainEngine {
         ORDER BY score DESC
         LIMIT ${innerLimitParam}
       ),
+      -- PATCH (title-search-fix): page-grain keyword arm. Title tokens live in
+      -- pages.search_vector (title weight A) but were never copied into any
+      -- content_chunks.search_vector, so exact-title queries like
+      -- "agentic AI economy" matched the page vector yet returned zero chunk
+      -- rows -> "No results". This arm unions in pages whose page-level vector
+      -- matches but that have NO matching text chunk (anti-join), so pages that
+      -- already match on body chunks rank EXACTLY as before (zero regression);
+      -- we only ADD pages the chunk-only query would have missed entirely.
+      -- chunk_source is reported as 'compiled_truth' (the snippet's true origin)
+      -- to avoid introducing a new enum value downstream. Symbol/language
+      -- filters are chunk-grain and intentionally omitted here.
+      title_hits AS (
+        SELECT
+          p.slug, p.id as page_id, p.title, p.type, p.source_id,
+          p.effective_date, p.effective_date_source,
+          -1 as chunk_id, 0 as chunk_index,
+          left(coalesce(NULLIF(p.compiled_truth, ''), p.title), 400) as chunk_text,
+          'compiled_truth'::text as chunk_source,
+          ts_rank(p.search_vector, websearch_to_tsquery('english', $1)) * ${sourceFactorCase} AS score
+        FROM pages p
+        JOIN sources s ON s.id = p.source_id
+        WHERE p.search_vector @@ websearch_to_tsquery('english', $1)
+          AND NOT EXISTS (
+            SELECT 1 FROM content_chunks cc2
+            WHERE cc2.page_id = p.id
+              AND cc2.modality = 'text'
+              AND cc2.search_vector @@ websearch_to_tsquery('english', $1)
+          )
+          ${typeClause}
+          ${typesClause}
+          ${excludeSlugsClause}
+          ${afterDateClause}
+          ${beforeDateClause}
+          ${sourceClause}
+          ${hardExcludeClause}
+          ${visibilityClause}
+        ORDER BY score DESC
+        LIMIT ${innerLimitParam}
+      ),
+      combined AS (
+        SELECT * FROM ranked_chunks
+        UNION ALL
+        SELECT * FROM title_hits
+      ),
       best_per_page AS (
         SELECT DISTINCT ON (slug) *
-        FROM ranked_chunks
+        FROM combined
         ORDER BY slug, score DESC
       )
       SELECT slug, page_id, title, type, source_id,


### PR DESCRIPTION
## Problem

`searchKeyword()` ranks only `content_chunks.search_vector` (chunk body text). Page titles are indexed at **weight A** in `pages.search_vector`, but that vector is never queried by the keyword path, and title text is never copied into any chunk at import.

Result: an exact-title query returns nothing from `gbrain search`, while hybrid `gbrain query` ranks the same page highly (it uses embedding similarity, not the keyword index).

Repro (real page in my brain titled around "agentic AI economy"):

```
$ gbrain search "agentic AI economy"
No results.

$ gbrain query "what do we have on the agentic economy?"
[0.91] inbox/2026-05-30-0b5d6ecf
```

The title tokens exist in `pages.search_vector` (weight A) but are unreachable through the keyword path.

## Fix

Add a page-grain `title_hits` CTE to `searchKeyword()` that unions in pages whose `pages.search_vector` matches but that have **no** matching text chunk (`NOT EXISTS` anti-join):

- Pages that already match on a body chunk rank **exactly as before** — zero regression. The arm only *adds* title-only pages the chunk-only query missed entirely.
- Score scales by `ts_rank(pages.search_vector, query) * sourceFactor`, consistent with the chunk arm, so a weak title hit doesn't automatically dominate a strong body hit.
- Snippet reports `chunk_source = 'compiled_truth'` (the snippet's true origin) to avoid introducing a new enum value downstream.
- Synthetic `chunk_id = -1`, `chunk_index = 0` for title-only rows (never collide with real chunk ids).
- Symbol/language filters are chunk-grain and intentionally omitted from this arm.

## Verification

- Failing case now returns the page at rank 1.0 (was `No results`).
- Body-word search unchanged: `gbrain search "agentic"` still ranks via the chunk vector at ~0.38 (proves the title arm is correctly anti-joined and not leaking into pages that already have body hits).
- `bunx tsc --noEmit`: clean.
- `bun test` on the search suites: 49 tests pass (`commands-search.test.ts`, `search-lang-symbol-kind.test.ts`, `utils.test.ts`).
- Independently reproduced and validated by a second agent against the same live DB.

## Notes for reviewers

The anti-join keeps the change narrow and reversible — it touches only the previously-empty result set. Happy to adjust the snippet source label, the `ts_rank` weighting, or fold title tokens into chunk vectors at import instead if you'd prefer that direction.
