### PR TITLE
fix(postgres-engine): only the singleton owner may disconnect it (#1471)

### DIFF
--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -148,6 +148,16 @@ export async function setSessionDefaults(_sql: ReturnType<typeof postgres>): Pro
   // No-op: timeouts are now applied as startup parameters in resolveSessionTimeouts().
 }
 
+/**
+ * Whether the module-level singleton is currently connected. Lets a
+ * PostgresEngine decide, at connect() time, whether it is creating the
+ * singleton (owner) or borrowing an existing one (borrower) - so only the
+ * owner disconnects it later. See #1471.
+ */
+export function isConnected(): boolean {
+  return sql !== null;
+}
+
 export function getConnection(): ReturnType<typeof postgres> {
   if (!sql) {
     throw new GBrainError(

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -106,6 +106,17 @@ export class PostgresEngine implements BrainEngine {
   private _connectionStyle: 'instance' | 'module' | null = null;
 
   /**
+   * #1471: module-singleton OWNERSHIP. Only the engine whose connect() actually
+   * created the shared db.ts `sql` singleton may disconnect it. A borrower (a
+   * probe engine constructed while the singleton already exists - e.g.
+   * resolveLintContentSanity or doctor) must clear its own marker WITHOUT
+   * calling db.disconnect(), or it nulls the `sql` the owner cycle engine is
+   * still using and every later phase throws "connect() has not been called".
+   * `_connectionStyle` alone can't separate owner from borrower: both are 'module'.
+   */
+  private _ownsModuleSingleton = false;
+
+  /**
    * v0.30.1 (Fix 1 + X1 + T5): instance-owned ConnectionManager.
    * - INSTANCE-owned: each PostgresEngine constructs its own.
    * - Worker engines (cycle, sync) inherit via opts.parentConnectionManager.
@@ -177,9 +188,14 @@ export class PostgresEngine implements BrainEngine {
       });
       this.connectionManager.setReadPool(this._sql);
     } else {
-      // Module-level singleton (backward compat for CLI main engine)
+      // Module-level singleton (backward compat for CLI main engine).
+      // #1471: sample ownership BEFORE delegating to db.connect(). If the
+      // singleton already exists we are a borrower and must never disconnect
+      // it; only the engine that creates it owns its teardown.
+      const ownsSingleton = !db.isConnected();
       await db.connect(config);
       this._connectionStyle = 'module';
+      this._ownsModuleSingleton = ownsSingleton;
 
       // v0.30.1: connection-manager wraps the module singleton.
       if (url) {
@@ -220,7 +236,13 @@ export class PostgresEngine implements BrainEngine {
       return;
     }
     if (this._connectionStyle === 'module') {
-      await db.disconnect();
+      // #1471: only the owner disconnects the shared singleton; a borrower
+      // clears its markers so a probe engine's teardown can't clobber the
+      // owner's live connection.
+      if (this._ownsModuleSingleton) {
+        await db.disconnect();
+        this._ownsModuleSingleton = false;
+      }
       this._connectionStyle = null;
     }
     // else: nothing to disconnect (already done or never connected)

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -191,7 +191,10 @@ export class PostgresEngine implements BrainEngine {
       // Module-level singleton (backward compat for CLI main engine).
       // #1471: sample ownership BEFORE delegating to db.connect(). If the
       // singleton already exists we are a borrower and must never disconnect
-      // it; only the engine that creates it owns its teardown.
+      // it; only the engine that creates it owns its teardown. (Concurrent
+      // module-path connects are not an expected pattern; if two raced and both
+      // sampled isConnected()===false they would both claim ownership - benign,
+      // since db.disconnect() is an idempotent no-op once sql is already null.)
       const ownsSingleton = !db.isConnected();
       await db.connect(config);
       this._connectionStyle = 'module';
@@ -4547,7 +4550,10 @@ export class PostgresEngine implements BrainEngine {
 
   /**
    * Reconnect the engine by tearing down the current pool and creating a fresh one.
-   * No-ops if no saved config (module-singleton mode) or if already reconnecting.
+   * No-ops if the engine was never connected (no saved config) or if a reconnect
+   * is already in progress. Both instance-pool AND module-singleton engines set
+   * _savedConfig on connect(), so both reconnect; #1471's ownership flag is
+   * re-sampled on the connect() leg, so an owner re-acquires and a borrower re-borrows.
    */
   async reconnect(): Promise<void> {
     if (!this._savedConfig || this._reconnecting) return;

--- a/test/postgres-engine-singleton-ownership.test.ts
+++ b/test/postgres-engine-singleton-ownership.test.ts
@@ -1,0 +1,114 @@
+/**
+ * postgres-engine.ts module-singleton ownership guardrails (#1471).
+ *
+ * Root cause: when an engine connects via the module-singleton path (no
+ * poolSize), BOTH the engine that creates the shared db.ts `sql` singleton
+ * (the owner, e.g. the CLI cycle engine) and any engine constructed while
+ * that singleton already exists (a borrower, e.g. the probe engine in
+ * resolveLintContentSanity / doctor) get `_connectionStyle = 'module'`. The
+ * old disconnect() then called `db.disconnect()` for BOTH, so a short-lived
+ * borrower's teardown nulled the shared `sql` the owner was still using -
+ * every later cycle phase then threw "No database connection: connect() has
+ * not been called" and stranded the cycle lock.
+ *
+ * Fix: track ownership. Only the engine whose connect() actually created the
+ * singleton may db.disconnect() it; borrowers clear their own marker without
+ * touching the shared connection.
+ *
+ * Source-level, DB-free guardrails - matching the existing
+ * postgres-engine.test.ts convention (runtime mocking of postgres.js's
+ * tagged-template interface is painful under bun ESM; live behaviour is
+ * exercised by the dream cycle e2e + the manual `gbrain dream --dry-run`
+ * repro recorded on the fix).
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const ENGINE_SRC = readFileSync(
+  join(import.meta.dir, '..', 'src', 'core', 'postgres-engine.ts'),
+  'utf-8',
+);
+const DB_SRC = readFileSync(
+  join(import.meta.dir, '..', 'src', 'core', 'db.ts'),
+  'utf-8',
+);
+
+describe('postgres-engine / module-singleton ownership (#1471)', () => {
+  // Boolean assertions on purpose: matching a regex against the 4500-line
+  // source dumps the whole file into the failure message. `.test()` -> bool
+  // keeps RED output (and CI logs) readable.
+  test('db.ts exposes isConnected() so the engine can detect singleton ownership', () => {
+    const hasIsConnected = /export function isConnected\s*\(\s*\)\s*:\s*boolean/.test(DB_SRC);
+    expect(hasIsConnected).toBe(true);
+  });
+
+  test('PostgresEngine tracks module-singleton ownership with a dedicated flag', () => {
+    expect(ENGINE_SRC.includes('_ownsModuleSingleton')).toBe(true);
+  });
+
+  test('connect() decides ownership from the PRE-EXISTING singleton state, before db.connect()', () => {
+    // stripComments: the explanatory comment mentions "db.connect()", which
+    // would otherwise match before the real call and invert the ordering check.
+    const connect = stripComments(extractMethod(ENGINE_SRC, 'connect'));
+    const ownIdx = connect.search(/db\.isConnected\s*\(/);
+    const connIdx = connect.search(/db\.connect\s*\(/);
+    expect(ownIdx).toBeGreaterThanOrEqual(0);
+    expect(connIdx).toBeGreaterThanOrEqual(0);
+    // Ownership must be sampled BEFORE we (possibly) create the singleton.
+    expect(ownIdx < connIdx).toBe(true);
+    expect(/_ownsModuleSingleton\s*=/.test(connect)).toBe(true);
+  });
+
+  test('disconnect() calls db.disconnect() ONLY when this engine owns the singleton', () => {
+    const disconnect = stripComments(extractMethod(ENGINE_SRC, 'disconnect'));
+    // The shared-singleton teardown must be guarded by the ownership flag - a
+    // borrower clears its marker without nulling the owner's connection.
+    const guarded = /if\s*\(\s*this\._ownsModuleSingleton\s*\)\s*\{[\s\S]*?db\.disconnect\s*\(\s*\)/.test(disconnect);
+    expect(guarded).toBe(true);
+    // And the only db.disconnect() in the method is the guarded one (no
+    // unconditional clobber survives).
+    const calls = [...disconnect.matchAll(/db\.disconnect\s*\(\s*\)/g)];
+    expect(calls.length).toBe(1);
+  });
+});
+
+function stripComments(s: string): string {
+  return s
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|\s)\/\/[^\n]*/g, '$1');
+}
+
+// Brace-match a class method body by name. Mirrors the helper in
+// postgres-engine.test.ts.
+function extractMethod(source: string, name: string): string {
+  const openRe = new RegExp(`^\\s+async\\s+${name}\\s*\\(`, 'm');
+  const match = openRe.exec(source);
+  if (!match) throw new Error(`method ${name} not found in postgres-engine.ts`);
+  // Balance the parameter-list parens first, so a `{` inside a param type
+  // (e.g. connect(config: ... & { poolSize?: number })) isn't mistaken for
+  // the body brace. The body `{` is the first one after the signature's `)`.
+  let i = source.indexOf('(', match.index);
+  let pdepth = 0;
+  for (; i < source.length; i++) {
+    if (source[i] === '(') pdepth++;
+    else if (source[i] === ')') {
+      pdepth--;
+      if (pdepth === 0) { i++; break; }
+    }
+  }
+  i = source.indexOf('{', i);
+  if (i < 0) throw new Error(`no body brace for ${name}`);
+  const start = i;
+  let depth = 0;
+  for (; i < source.length; i++) {
+    const c = source[i];
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces in ${name}`);
+}


### PR DESCRIPTION
## Problem

Fixes #1471 (root cause). Should also resolve the symptom issues that stem from the same module-singleton-null-mid-cycle defect: #1404, #1413, #1491, #1619.

A `PostgresEngine` connecting via the module-singleton path (no `poolSize`) is tagged `_connectionStyle = 'module'` whether it CREATED the shared `db.ts` `sql` singleton (the **owner** - the CLI cycle engine) or merely found it already connected (a **borrower** - the probe engine in `resolveLintContentSanity`, doctor, future probes). The old `disconnect()` called `db.disconnect()` for BOTH, so a short-lived borrower's `finally`-block teardown nulled the singleton the owner cycle engine was still using. Every later phase then threw `No database connection: connect() has not been called`, and `runCycle`'s finally stranded a row in `gbrain_cycle_locks`.

`_connectionStyle` alone can't separate owner from borrower - both are `'module'`. This implements the ownership-flag fix proposed in #1471.

## Fix

- **`db.ts`**: add `isConnected()` so an engine can tell, at `connect()` time, whether the singleton already exists.
- **`postgres-engine.ts`**: add `_ownsModuleSingleton`. `connect()` samples ownership *before* delegating to `db.connect()`; `disconnect()` calls `db.disconnect()` only when this engine owns the singleton. A borrower clears its own marker without touching the shared connection.

Scope:
- Instance-pool engines (`poolSize` set) are unaffected - they never take the module branch.
- `reconnect()` stays correct: an owner's disconnect+reconnect re-acquires ownership (the singleton is null right after its own `db.disconnect()`), and a borrower re-borrows the owner's (possibly refreshed) singleton.

## Tests

- New `test/postgres-engine-singleton-ownership.test.ts`: source-level guardrails (DB-free, matching the existing `postgres-engine.test.ts` convention, since runtime-mocking postgres.js's tagged-template interface is painful under bun ESM). Asserts `db.isConnected()` is sampled before `db.connect()`, and that the only `db.disconnect()` in `disconnect()` is guarded by `_ownsModuleSingleton`.
- `bun run typecheck`: clean.
- Regression (59 tests green): `postgres-engine`, `db-disconnect-audit`, `connection-manager.serial`, `autopilot-reconnect-classifier`, `worker-shutdown-disconnect`.

The live `gbrain dream` cycle is the e2e exercise of this path; the ownership logic above is what keeps the owner's singleton alive across a borrower probe's teardown.
