### PR TITLE
[codex] Fix stale_pages false positives after timeline extraction

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -786,7 +786,10 @@ async function extractForSlugs(
     const snapshot = timelineBatch.slice();
     timelineBatch.length = 0;
     try {
-      timelineCreated += await engine.addTimelineEntriesBatch(snapshot, { auditSite: 'extract.timeline_inc' });
+      timelineCreated += await engine.addTimelineEntriesBatch(snapshot, {
+        auditSite: 'extract.timeline_inc',
+        createdAtFromPageUpdatedAt: true,
+      });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       if (!jsonMode) console.error(`  timeline batch error (${snapshot.length} rows lost): ${msg}`);
@@ -945,7 +948,10 @@ async function extractTimelineFromDir(
     const snapshot = batch.slice();
     batch.length = 0;
     try {
-      created += await engine.addTimelineEntriesBatch(snapshot, { auditSite: 'extract.timeline_fs' });
+      created += await engine.addTimelineEntriesBatch(snapshot, {
+        auditSite: 'extract.timeline_fs',
+        createdAtFromPageUpdatedAt: true,
+      });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       if (jsonMode) {
@@ -1030,7 +1036,10 @@ export async function extractTimelineForSlugs(
   // v0.18.0+ multi-source: source-qualify so timeline rows don't fan out
   // across every source containing the slug (the addTimelineEntry's
   // INSERT...SELECT-from-pages fan-out was Data R1's HIGH 2).
-  const entryOpts = opts?.sourceId ? { sourceId: opts.sourceId } : undefined;
+  const entryOpts = {
+    ...(opts?.sourceId ? { sourceId: opts.sourceId } : {}),
+    createdAtFromPageUpdatedAt: true,
+  };
   let created = 0;
   for (const slug of slugs) {
     const filePath = join(repoPath, slug + '.md');
@@ -1272,7 +1281,10 @@ async function extractTimelineFromDB(
     const snapshot = batch.slice();
     batch.length = 0;
     try {
-      created += await engine.addTimelineEntriesBatch(snapshot, { auditSite: 'extract.timeline_db' });
+      created += await engine.addTimelineEntriesBatch(snapshot, {
+        auditSite: 'extract.timeline_db',
+        createdAtFromPageUpdatedAt: true,
+      });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       if (jsonMode) {

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -112,11 +112,26 @@ export interface FileSpec {
  *   site.sh` validates every string-literal value at build time.
  * - `signal`: AbortSignal that aborts mid-retry-sleep on SIGTERM/SIGINT.
  *   `MinionWorker.shutdownAbort.signal` is the canonical source.
+ * - `createdAtFromPageUpdatedAt`: timeline batches only. Use when entries are
+ *   deterministic materializations of the owning page content, so health does
+ *   not treat extraction time as newer evidence than the page itself.
  */
 import type { BatchAuditSite } from './retry.ts';
 export interface BatchOpts {
   auditSite?: BatchAuditSite;
   signal?: AbortSignal;
+  createdAtFromPageUpdatedAt?: boolean;
+}
+
+export interface TimelineWriteOpts {
+  skipExistenceCheck?: boolean;
+  sourceId?: string;
+  /**
+   * Use the owning page updated_at as timeline_entries.created_at. Intended
+   * for extraction/autotimeline materialization from the page body itself.
+   * Manual timeline writes should omit this so they remain fresh evidence.
+   */
+  createdAtFromPageUpdatedAt?: boolean;
 }
 
 /** Input row for addLinksBatch. Optional fields default to '' (matches NOT NULL DDL). */
@@ -1214,7 +1229,7 @@ export interface BrainEngine {
   addTimelineEntry(
     slug: string,
     entry: TimelineInput,
-    opts?: { skipExistenceCheck?: boolean; sourceId?: string },
+    opts?: TimelineWriteOpts,
   ): Promise<void>;
   /**
    * Bulk insert timeline entries via a single multi-row INSERT...SELECT FROM (VALUES)

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -810,7 +810,10 @@ const put_page: Operation = {
             // v0.41.18.0: engine self-retries on Supavisor circuit-breaker
             // recovery. auditSite label routes the audit JSONL emission so
             // operators can attribute losses to the agent-write path.
-            const created = await ctx.engine.addTimelineEntriesBatch(batch, { auditSite: 'mcp.put_page.autolink' });
+            const created = await ctx.engine.addTimelineEntriesBatch(batch, {
+              auditSite: 'mcp.put_page.autolink',
+              createdAtFromPageUpdatedAt: true,
+            });
             autoTimeline = { created };
           } else {
             autoTimeline = { created: 0 };

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -6,6 +6,7 @@ import type {
   BrainEngine,
   BatchOpts,
   LinkBatchInput, TimelineBatchInput,
+  TimelineWriteOpts,
   ReservedConnection,
   DreamVerdict, DreamVerdictInput,
   FileSpec, FileRow,
@@ -2881,7 +2882,7 @@ export class PGLiteEngine implements BrainEngine {
   async addTimelineEntry(
     slug: string,
     entry: TimelineInput,
-    opts?: { skipExistenceCheck?: boolean; sourceId?: string },
+    opts?: TimelineWriteOpts,
   ): Promise<void> {
     const sourceId = opts?.sourceId ?? 'default';
     if (!opts?.skipExistenceCheck) {
@@ -2893,9 +2894,21 @@ export class PGLiteEngine implements BrainEngine {
         throw new Error(`addTimelineEntry failed: page "${slug}" (source=${sourceId}) not found`);
       }
     }
-    // ON CONFLICT DO NOTHING via the (page_id, date, summary) unique index.
+    // ON CONFLICT DO NOTHING via the (page_id, date, summary, source) unique index.
     // Source-qualify the page-id lookup so multi-source brains don't fan
     // timeline rows out across every source containing the slug.
+    if (opts?.createdAtFromPageUpdatedAt) {
+      await this.db.query(
+        `INSERT INTO timeline_entries (page_id, date, source, summary, detail, created_at)
+         SELECT id, $2::date, $3, $4, $5, updated_at
+         FROM pages WHERE slug = $1 AND source_id = $6
+         ON CONFLICT (page_id, date, summary, source)
+         DO UPDATE SET created_at = LEAST(timeline_entries.created_at, EXCLUDED.created_at)
+         WHERE timeline_entries.created_at > EXCLUDED.created_at`,
+        [slug, entry.date, entry.source || '', entry.summary, entry.detail || '', sourceId]
+      );
+      return;
+    }
     await this.db.query(
       `INSERT INTO timeline_entries (page_id, date, source, summary, detail)
        SELECT id, $2::date, $3, $4, $5
@@ -2907,10 +2920,15 @@ export class PGLiteEngine implements BrainEngine {
 
   async addTimelineEntriesBatch(entries: TimelineBatchInput[], opts?: BatchOpts): Promise<number> {
     if (entries.length === 0) return 0;
-    return this.batchRetry(opts?.auditSite ?? 'addTimelineEntriesBatch', opts?.signal, () => this._addTimelineEntriesBatchOnce(entries), entries.length);
+    return this.batchRetry(
+      opts?.auditSite ?? 'addTimelineEntriesBatch',
+      opts?.signal,
+      () => this._addTimelineEntriesBatchOnce(entries, opts?.createdAtFromPageUpdatedAt === true),
+      entries.length
+    );
   }
 
-  private async _addTimelineEntriesBatchOnce(entries: TimelineBatchInput[]): Promise<number> {
+  private async _addTimelineEntriesBatchOnce(entries: TimelineBatchInput[], createdAtFromPageUpdatedAt = false): Promise<number> {
     if (entries.length === 0) return 0;
     const slugs = entries.map(e => e.slug);
     const dates = entries.map(e => e.date);
@@ -2918,6 +2936,21 @@ export class PGLiteEngine implements BrainEngine {
     const summaries = entries.map(e => e.summary);
     const details = entries.map(e => e.detail || '');
     const sourceIds = entries.map(e => e.source_id || 'default');
+    if (createdAtFromPageUpdatedAt) {
+      const result = await this.db.query(
+        `INSERT INTO timeline_entries (page_id, date, source, summary, detail, created_at)
+         SELECT p.id, v.date::date, v.source, v.summary, v.detail, p.updated_at
+         FROM unnest($1::text[], $2::text[], $3::text[], $4::text[], $5::text[], $6::text[])
+           AS v(slug, date, source, summary, detail, source_id)
+         JOIN pages p ON p.slug = v.slug AND p.source_id = v.source_id
+         ON CONFLICT (page_id, date, summary, source)
+         DO UPDATE SET created_at = LEAST(timeline_entries.created_at, EXCLUDED.created_at)
+         WHERE timeline_entries.created_at > EXCLUDED.created_at
+         RETURNING 1`,
+        [slugs, dates, sources, summaries, details, sourceIds]
+      );
+      return result.rows.length;
+    }
     const result = await this.db.query(
       `INSERT INTO timeline_entries (page_id, date, source, summary, detail)
        SELECT p.id, v.date::date, v.source, v.summary, v.detail

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -3,6 +3,7 @@ import type {
   BrainEngine,
   BatchOpts,
   LinkBatchInput, TimelineBatchInput,
+  TimelineWriteOpts,
   ReservedConnection,
   DreamVerdict, DreamVerdictInput,
   FileSpec, FileRow,
@@ -2941,7 +2942,7 @@ export class PostgresEngine implements BrainEngine {
   async addTimelineEntry(
     slug: string,
     entry: TimelineInput,
-    opts?: { skipExistenceCheck?: boolean; sourceId?: string },
+    opts?: TimelineWriteOpts,
   ): Promise<void> {
     const sql = this.sql;
     const sourceId = opts?.sourceId ?? 'default';
@@ -2951,11 +2952,22 @@ export class PostgresEngine implements BrainEngine {
         throw new Error(`addTimelineEntry failed: page "${slug}" (source=${sourceId}) not found`);
       }
     }
-    // ON CONFLICT DO NOTHING via the (page_id, date, summary) unique index.
+    // ON CONFLICT DO NOTHING via the (page_id, date, summary, source) unique index.
     // Returning 0 rows means either page missing OR duplicate; skipExistenceCheck
     // makes that ambiguity safe (caller asserts page exists). Source-qualify
     // the page-id lookup so multi-source brains don't fan timeline rows out
     // across every source containing the slug.
+    if (opts?.createdAtFromPageUpdatedAt) {
+      await sql`
+        INSERT INTO timeline_entries (page_id, date, source, summary, detail, created_at)
+        SELECT id, ${entry.date}::date, ${entry.source || ''}, ${entry.summary}, ${entry.detail || ''}, updated_at
+        FROM pages WHERE slug = ${slug} AND source_id = ${sourceId}
+        ON CONFLICT (page_id, date, summary, source)
+        DO UPDATE SET created_at = LEAST(timeline_entries.created_at, EXCLUDED.created_at)
+        WHERE timeline_entries.created_at > EXCLUDED.created_at
+      `;
+      return;
+    }
     await sql`
       INSERT INTO timeline_entries (page_id, date, source, summary, detail)
       SELECT id, ${entry.date}::date, ${entry.source || ''}, ${entry.summary}, ${entry.detail || ''}
@@ -2966,10 +2978,15 @@ export class PostgresEngine implements BrainEngine {
 
   async addTimelineEntriesBatch(entries: TimelineBatchInput[], opts?: BatchOpts): Promise<number> {
     if (entries.length === 0) return 0;
-    return this.batchRetry(opts?.auditSite ?? 'addTimelineEntriesBatch', opts?.signal, () => this._addTimelineEntriesBatchOnce(entries), entries.length);
+    return this.batchRetry(
+      opts?.auditSite ?? 'addTimelineEntriesBatch',
+      opts?.signal,
+      () => this._addTimelineEntriesBatchOnce(entries, opts?.createdAtFromPageUpdatedAt === true),
+      entries.length
+    );
   }
 
-  private async _addTimelineEntriesBatchOnce(entries: TimelineBatchInput[]): Promise<number> {
+  private async _addTimelineEntriesBatchOnce(entries: TimelineBatchInput[], createdAtFromPageUpdatedAt = false): Promise<number> {
     const sql = this.sql;
     const slugs = entries.map(e => e.slug);
     const dates = entries.map(e => e.date);
@@ -2977,6 +2994,20 @@ export class PostgresEngine implements BrainEngine {
     const summaries = entries.map(e => e.summary);
     const details = entries.map(e => e.detail || '');
     const sourceIds = entries.map(e => e.source_id || 'default');
+    if (createdAtFromPageUpdatedAt) {
+      const result = await sql`
+        INSERT INTO timeline_entries (page_id, date, source, summary, detail, created_at)
+        SELECT p.id, v.date::date, v.source, v.summary, v.detail, p.updated_at
+        FROM unnest(${slugs}::text[], ${dates}::text[], ${sources}::text[], ${summaries}::text[], ${details}::text[], ${sourceIds}::text[])
+          AS v(slug, date, source, summary, detail, source_id)
+        JOIN pages p ON p.slug = v.slug AND p.source_id = v.source_id
+        ON CONFLICT (page_id, date, summary, source)
+        DO UPDATE SET created_at = LEAST(timeline_entries.created_at, EXCLUDED.created_at)
+        WHERE timeline_entries.created_at > EXCLUDED.created_at
+        RETURNING 1
+      `;
+      return result.length;
+    }
     const result = await sql`
       INSERT INTO timeline_entries (page_id, date, source, summary, detail)
       SELECT p.id, v.date::date, v.source, v.summary, v.detail

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -1278,6 +1278,74 @@ describe('PGLiteEngine: getHealth graph metrics', () => {
     expect(h.timeline_coverage).toBeCloseTo(1 / 3, 2);
   });
 
+  test('derived timeline batches do not mark their source page stale', async () => {
+    await engine.executeRaw(
+      `UPDATE pages SET updated_at = '2000-01-01T00:00:00Z'::timestamptz
+       WHERE slug = 'people/alice'`,
+    );
+
+    await engine.addTimelineEntriesBatch([
+      { slug: 'people/alice', date: '2026-01-15', summary: 'Joined' },
+    ], { createdAtFromPageUpdatedAt: true });
+
+    const h = await engine.getHealth();
+    expect(h.stale_pages).toBe(0);
+  });
+
+  test('derived single timeline writes do not mark their source page stale', async () => {
+    await engine.executeRaw(
+      `UPDATE pages SET updated_at = '2000-01-01T00:00:00Z'::timestamptz
+       WHERE slug = 'people/alice'`,
+    );
+
+    await engine.addTimelineEntry(
+      'people/alice',
+      { date: '2026-01-15', summary: 'Joined' },
+      { createdAtFromPageUpdatedAt: true },
+    );
+
+    const h = await engine.getHealth();
+    expect(h.stale_pages).toBe(0);
+  });
+
+  test('derived timeline batches repair older now-stamped extracted rows', async () => {
+    await engine.executeRaw(
+      `UPDATE pages SET updated_at = '2000-01-01T00:00:00Z'::timestamptz
+       WHERE slug = 'people/alice'`,
+    );
+
+    await engine.addTimelineEntriesBatch([
+      { slug: 'people/alice', date: '2026-01-15', summary: 'Joined' },
+    ]);
+    expect((await engine.getHealth()).stale_pages).toBe(1);
+
+    await engine.addTimelineEntriesBatch([
+      { slug: 'people/alice', date: '2026-01-15', summary: 'Joined' },
+    ], { createdAtFromPageUpdatedAt: true });
+
+    const rows = await engine.executeRaw<{ c: number }>(
+      `SELECT count(*)::int AS c FROM timeline_entries te
+       JOIN pages p ON p.id = te.page_id
+       WHERE p.slug = 'people/alice'`,
+    );
+    expect(Number(rows[0].c)).toBe(1);
+
+    const h = await engine.getHealth();
+    expect(h.stale_pages).toBe(0);
+  });
+
+  test('manual timeline entries still mark older pages stale', async () => {
+    await engine.executeRaw(
+      `UPDATE pages SET updated_at = '2000-01-01T00:00:00Z'::timestamptz
+       WHERE slug = 'people/alice'`,
+    );
+
+    await engine.addTimelineEntry('people/alice', { date: '2026-01-15', summary: 'Joined' });
+
+    const h = await engine.getHealth();
+    expect(h.stale_pages).toBe(1);
+  });
+
   test('most_connected lists top entities by link count', async () => {
     await engine.addLink('people/alice', 'companies/acme', '', 'works_at');
     await engine.addLink('people/bob', 'companies/acme', '', 'invested_in');


### PR DESCRIPTION
## What changed

This changes timeline extraction/autotimeline writes so timeline rows that are deterministic materializations of a page's own content use that page's `updated_at` as `timeline_entries.created_at`.

Manual timeline writes keep the old behavior: they are stamped with write time and can still make an older page count as stale evidence.

Concretely:
- adds `createdAtFromPageUpdatedAt` to timeline write options
- uses it from `extract timeline/all` and `put_page` autotimeline paths
- mirrors the behavior in PGLite and Postgres engines
- updates conflicting extracted rows by moving `created_at` back to the source page timestamp, so rerunning extract can repair existing now-stamped rows without duplicating timeline entries

## Root cause

`health.stale_pages` intentionally counts pages whose compiled truth is older than newer timeline evidence:

```sql
pages.updated_at < max(timeline_entries.created_at)
```

The false positive is that extraction can create `timeline_entries` from the page body itself, but those rows were stamped with insertion time. That makes the page look stale immediately after a clean sync/extract, even though the timeline row is only a derived index of the page content.

This appears to have become reachable with the v0.10.3 graph layer in `81b3f7a` / #188, which introduced the structured graph/timeline extraction paths and made structured timeline entries graph data. The symptom is already reported in #1230; I did not find an existing PR for this lower-level timestamp fix.

Addresses #1230.

## Validation

- `bun test test/pglite-engine.test.ts` passes: 104 pass
- `bun test test/extract-incremental.test.ts test/extract-source-aware.test.ts` passes: 12 pass
- `bun run typecheck` passes
- `scripts/check-batch-audit-site.sh && scripts/check-no-double-retry.sh` passes

I also ran `bun run ci:local:diff`, but Docker is not running in this local environment, so the selected E2E phase could not start.

I ran the full unit command `bun run test`; all shards and serial tests completed, but the command exited with 2 unrelated local-environment failures in `test/check-resolvable-cli.test.ts` because this machine auto-detects an OpenClaw workspace home root where those tests expect install-path fallback. The failure reproduces when running that test file directly and does not touch the files changed in this PR.
