### PR TITLE
fix(content-sanity): null-safe title in assessContentSanity (fixes opts.title.toLowerCase sync crash)

### DIFF
--- a/src/core/content-sanity.ts
+++ b/src/core/content-sanity.ts
@@ -232,8 +232,11 @@ export function assessContentSanity(opts: {
   compiled_truth: string;
   /** Post-parseMarkdown timeline section (empty string if no sentinel). */
   timeline: string;
-  /** Post-parseMarkdown title. Some patterns key on title alone. */
-  title: string;
+  /** Post-parseMarkdown title. Some patterns key on title alone.
+   *  May be undefined/null: pages without a `title:` frontmatter field
+   *  (or git-history commits replayed by `sync` that predate the field)
+   *  yield `parsed.title === undefined`. Coerced defensively below. */
+  title?: string | null;
   /** Effective warn threshold; defaults to DEFAULT_BYTES_WARN. */
   bytes_warn?: number;
   /** Effective block threshold; defaults to DEFAULT_BYTES_BLOCK. */
@@ -259,14 +262,16 @@ export function assessContentSanity(opts: {
   // doesn't repeat the lowercase per literal.
   const bodyHead = body.slice(0, SCAN_HEAD_BYTES);
   const bodyHeadLower = bodyHead.toLowerCase();
-  const titleLower = opts.title.toLowerCase();
+  // Coerce once: opts.title may be undefined/null (see param doc).
+  const title = String(opts.title ?? '');
+  const titleLower = title.toLowerCase();
 
   const junk_pattern_matches: string[] = [];
   for (const p of BUILT_IN_JUNK_PATTERNS) {
     const scope = p.applies_to ?? 'both';
     let matched = false;
     if (scope === 'title' || scope === 'both') {
-      if (p.pattern.test(opts.title)) matched = true;
+      if (p.pattern.test(title)) matched = true;
     }
     if (!matched && (scope === 'body' || scope === 'both')) {
       if (p.pattern.test(bodyHead)) matched = true;


### PR DESCRIPTION
## What

Makes `assessContentSanity()` null-safe on `title`.

`opts.title` is typed `string`, but every caller passes `parsed.title`
(`import-file.ts`, `sources.ts`, `lint.ts`, `doctor.ts`), which is
`undefined` whenever a page has no `title:` frontmatter field. Two paths hit it:

1. Title-less pages (e.g. date/daily notes).
2. `sync` replays git history commit-by-commit — a page with a `title:`
   today did not at older revisions, so `parsed.title` is `undefined` for
   those and the whole sync aborts.

`opts.title.toLowerCase()` (and the title-scope `pattern.test(opts.title)`)
then throw:

```text
opts.title.toLowerCase is not a function. (In 'opts.title.toLowerCase()', 'opts.title.toLowerCase' is undefined)
```

## Fix

Coerce once at the single choke point and make the type honest:

- `title?: string | null` in the opts type
- `const title = String(opts.title ?? '')`, reused for `titleLower` and the title-scope pattern test

## Testing

- `bun test test/content-sanity.test.ts test/content-sanity-literals.test.ts` → 76 pass / 0 fail
- `null` / `undefined` / number / empty / normal string inputs all return a `ContentSanityResult` instead of throwing.

Closes #1658. Confirms and supersedes #1556 (which the original reporter closed as premature pending confirmation against current master — confirmed here on `041d89b` / v0.41.29.0).
