### PR TITLE
fix(engine): module-singleton ownership guard — stop stray sub-engines nulling the shared pool (#1570)

### DIFF
--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -8,6 +8,15 @@ let sql: ReturnType<typeof postgres> | null = null;
 let connectedUrl: string | null = null;
 
 /**
+ * Whether the process-global connection singleton is currently established.
+ * Used by PostgresEngine to decide module-singleton ownership (#1570): only
+ * the engine that established it may later tear it down.
+ */
+export function isConnected(): boolean {
+  return sql !== null;
+}
+
+/**
  * Default pool size for Postgres connections. Users on the Supabase transaction
  * pooler (port 6543) or any multi-tenant pooler can lower this to avoid
  * MaxClients errors when `gbrain upgrade` spawns subprocesses that each open

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -106,6 +106,17 @@ export class PostgresEngine implements BrainEngine {
   private _connectionStyle: 'instance' | 'module' | null = null;
 
   /**
+   * #1570 root cause: true ONLY for the engine that actually established the
+   * process-global module singleton (db.ts ). A second module-mode engine
+   * that merely shared the existing singleton (e.g. lint's content-sanity probe
+   * in resolveLintContentSanity) must NOT db.disconnect() it on cleanup —
+   * doing so nulls the global out from under the owner mid-cycle and crashes
+   * concurrent phases with "connect() has not been called". Only the owner
+   * tears it down.
+   */
+  private _ownsModuleSingleton = false;
+
+  /**
    * v0.30.1 (Fix 1 + X1 + T5): instance-owned ConnectionManager.
    * - INSTANCE-owned: each PostgresEngine constructs its own.
    * - Worker engines (cycle, sync) inherit via opts.parentConnectionManager.
@@ -177,9 +188,13 @@ export class PostgresEngine implements BrainEngine {
       });
       this.connectionManager.setReadPool(this._sql);
     } else {
-      // Module-level singleton (backward compat for CLI main engine)
+      // Module-level singleton (backward compat for CLI main engine).
+      // Capture whether WE establish it here: only the establishing engine may
+      // tear it down later (see _ownsModuleSingleton + disconnect()).
+      const establishedModuleSingleton = !db.isConnected();
       await db.connect(config);
       this._connectionStyle = 'module';
+      this._ownsModuleSingleton = establishedModuleSingleton;
 
       // v0.30.1: connection-manager wraps the module singleton.
       if (url) {
@@ -220,8 +235,16 @@ export class PostgresEngine implements BrainEngine {
       return;
     }
     if (this._connectionStyle === 'module') {
-      await db.disconnect();
+      // Only the engine that established the process-global singleton may tear
+      // it down. A second module-mode engine that merely shared it (e.g. lint's
+      // content-sanity probe) must leave it intact; otherwise it nulls the
+      // global mid-cycle and crashes concurrent phases with "connect() has not
+      // been called" (#1570 root cause).
+      if (this._ownsModuleSingleton) {
+        await db.disconnect();
+      }
       this._connectionStyle = null;
+      this._ownsModuleSingleton = false;
     }
     // else: nothing to disconnect (already done or never connected)
   }


### PR DESCRIPTION
## Summary

A second `PostgresEngine` connected in **module mode** (no `poolSize`) shares the process-global `db.ts` singleton instead of owning a private pool. Its `disconnect()` unconditionally calls `db.disconnect()`, tearing down the singleton **out from under the engine that established it**. Any concurrent code reading `db.getConnection()` in that window throws `No database connection: connect() has not been called`.

This is the root cause behind #1570 for non-retry-wrapped callers.

## Deterministic repro (dream cycle)

The `lint` phase's `resolveLintContentSanity()` creates a throwaway engine via `engine.connect({})` (module mode) purely to read 4 config keys, then `disconnect()`s it. On a Supabase session pooler (frequent connection blips) this nulls the **main cycle engine's** singleton mid-run, so `sync`/`synthesize` crash with `connect() has not been called` → 0 pages written. Phases wrapped in `withRetry`+`reconnect` (e.g. `extract`) self-heal; un-wrapped phases die.

Captured live with per-instance tracing:
```
connect    id=1 module      # main cycle engine
connect    id=2 module      # lint's resolveLintContentSanity probe
disconnect id=2 module      # -> db.disconnect() nulls the SHARED singleton
... main engine's next getConnection() throws ...
```

v0.41.27's `withRetry` self-heal only covers retry-wrapped paths, so #1570 persisted for everyone else whenever a stray module-mode sub-engine is torn down.

## Fix

Track `_ownsModuleSingleton` — true only for the engine whose `connect()` actually established the singleton (via new `db.isConnected()`) — and gate `db.disconnect()` on it. A *sharing* engine's `disconnect()` now leaves the global intact. Instance pools (`poolSize` set) are unchanged. This also restores `reconnect()`'s own documented "no-ops in module-singleton mode" intent, which never fired because `connect()` always sets `_savedConfig`.

## Test

Ran the full dream cycle repeatedly against a Supabase pooler: **0** `connect() has not been called` errors (previously every run), `sync`/`synthesize` green, 19 synth + 8 pattern pages written. Instance-pool worker paths unaffected.
