### PR TITLE
fix(db-lock): self-heal cycle-lock refresh on pooler-reaped CONNECTION_ENDED

### DIFF
--- a/src/core/db-lock.ts
+++ b/src/core/db-lock.ts
@@ -23,6 +23,21 @@
  */
 import { hostname } from 'os';
 import type { BrainEngine } from './engine.ts';
+import { withRetry } from './retry.ts';
+
+/**
+ * Resolve a best-effort reconnect callback for `withRetry`. `reconnect()`
+ * is a PostgresEngine-private method (not on the BrainEngine interface), so
+ * we duck-type it. Returns undefined for engines (PGLite) that don't expose
+ * it — withRetry then simply retries against the existing pool, which is the
+ * correct behavior for an in-process engine that can't lose a socket.
+ */
+function resolveReconnect(engine: BrainEngine): (() => Promise<void>) | undefined {
+  const maybe = engine as unknown as { reconnect?: () => Promise<void> };
+  return typeof maybe.reconnect === 'function'
+    ? () => maybe.reconnect!()
+    : undefined;
+}
 
 export interface DbLockHandle {
   id: string;
@@ -105,12 +120,35 @@ export async function tryAcquireDbLock(
         // v0.41.13.0: bump BOTH ttl_expires_at AND last_refreshed_at.
         // Without last_refreshed_at, --max-age would steal healthy locks
         // whose acquired_at is old but whose holder is alive and refreshing.
-        await sql`
-          UPDATE gbrain_cycle_locks
-            SET ttl_expires_at = NOW() + ${ttl}::interval,
-                last_refreshed_at = NOW()
-          WHERE id = ${lockId} AND holder_pid = ${pid}
-        `;
+        //
+        // The refresh tick fires every (TTL/6) ms (~5 min for the default
+        // 30-min cycle lock), but the read pool's `idle_timeout` is 20s, so
+        // the connection is ALWAYS reaped between ticks. Against a
+        // transaction-mode pooler (PgBouncer/Supavisor :6543) the reconnect
+        // can lose the race and postgres.js raises `write CONNECTION_ENDED`.
+        // An unhandled throw here trips withRefreshingLock's catch, sets
+        // healthOk=false, and makes the worker voluntarily release + exit —
+        // the observed every-~5-min "crash" loop. Wrap in withRetry so a
+        // reaped socket self-heals (rebuild the pool, retry) instead of
+        // killing the holder. Matches the engine-level batchRetry idiom
+        // (#1570) and the CONNECTION_ENDED matcher addition in this change.
+        await withRetry(
+          async () => {
+            await sql`
+              UPDATE gbrain_cycle_locks
+                SET ttl_expires_at = NOW() + ${ttl}::interval,
+                    last_refreshed_at = NOW()
+              WHERE id = ${lockId} AND holder_pid = ${pid}
+            `;
+          },
+          {
+            maxRetries: 3,
+            delayMs: 500,
+            delayMaxMs: 4000,
+            jitter: 'decorrelated',
+            reconnect: resolveReconnect(engine),
+          },
+        );
       },
       release: async () => {
         deregister();
@@ -592,7 +630,16 @@ async function engineSelectOne(engine: BrainEngine): Promise<void> {
   };
   if (engine.kind === 'postgres' && maybePG.sql) {
     const sql = maybePG.sql as any;
-    await sql`SELECT 1`;
+    // The heartbeat shares the read pool with refresh(), whose connection
+    // the transaction-mode pooler reaps between the ~5-min ticks. A reaped
+    // socket surfaces as `write CONNECTION_ENDED` — a FALSE wedge signal
+    // (the backend is healthy; only the idle connection died). Retrying
+    // once self-heals it so the heartbeat only fails on a genuinely
+    // unreachable Postgres, not on routine pooler idle-reaping.
+    await withRetry(
+      async () => { await sql`SELECT 1`; },
+      { maxRetries: 2, delayMs: 300, delayMaxMs: 2000, reconnect: resolveReconnect(engine) },
+    );
     return;
   }
   if (engine.kind === 'pglite' && maybePGLite.db) {

--- a/src/core/retry-matcher.ts
+++ b/src/core/retry-matcher.ts
@@ -25,6 +25,15 @@ const CONN_PATTERNS = [
   // postgres.js's auto-recovery between queries). Matches the literal
   // message shape from PR #1416's reported batch-loss incident.
   /No database connection/i,
+  // postgres.js raises this when it tries to write to a socket the
+  // transaction-mode pooler (PgBouncer/Supavisor, port 6543) already
+  // reaped between statements. The error carries code 'CONNECTION_ENDED'
+  // and a message like "write CONNECTION_ENDED <host>:<port>". This is
+  // the ROOT transient drop on long-lived heartbeats (cycle-lock refresh)
+  // that idle out the connection between ticks; without it the matcher
+  // only caught the downstream "No database connection" after the pool
+  // was already nulled, so the first (recoverable) error escaped retry.
+  /CONNECTION_ENDED/i,
 ];
 
 interface PgError {
@@ -93,6 +102,10 @@ export function isRetryableConnError(err: unknown): boolean {
   //   08001 sqlclient_unable_to_establish_sqlconnection
   //   08004 sqlserver_rejected_establishment_of_sqlconnection
   if (code && /^08/.test(code)) return true;
+  // postgres.js's own transient socket-reaped code (transaction-mode pooler
+  // closed the connection between statements). Not a standard SQLSTATE, so
+  // matched explicitly here in addition to the message pattern below.
+  if (code === 'CONNECTION_ENDED') return true;
   // v0.41.2.1: typed-shape match for gbrain's own GBrainError
   // (problem === 'No database connection'). Avoids brittle string match
   // when the error wrapper is gbrain-internal.

--- a/test/retry-matcher.test.ts
+++ b/test/retry-matcher.test.ts
@@ -58,6 +58,21 @@ describe('isRetryableConnError', () => {
     expect(isRetryableConnError(new Error('ECONNRESET'))).toBe(true);
   });
 
+  test('matches postgres.js CONNECTION_ENDED code (pooler-reaped socket)', () => {
+    // postgres.js raises this when writing to a connection the
+    // transaction-mode pooler already closed between statements — the
+    // root transient drop on long-lived cycle-lock refresh heartbeats.
+    expect(
+      isRetryableConnError(pgError('CONNECTION_ENDED', 'write CONNECTION_ENDED host:6543'))
+    ).toBe(true);
+  });
+
+  test('matches CONNECTION_ENDED via message when code is absent', () => {
+    expect(
+      isRetryableConnError(new Error('write CONNECTION_ENDED aws-1-us-east-1.pooler.supabase.com:6543'))
+    ).toBe(true);
+  });
+
   test('matches database-starting-up', () => {
     expect(
       isRetryableConnError(new Error('the database system is starting up'))


### PR DESCRIPTION
## Problem

A production worker logged **400+ "crashes" / 24h** — one every ~5 minutes — all with the same chain:

```
[cycle.lint] done
Promotion error: No database connection: connect() has not been called.
Job NNNN (autopilot-cycle) released after infrastructure abort (lock-renewal-failed); stall detector will requeue (no attempt burned)
write CONNECTION_ENDED aws-1-...pooler.supabase.com:6543
worker_exited code=1 ... likely_cause=runtime_error
```

These aren't data-losing (jobs requeue, no attempt burned — `withRefreshingLock`'s designed safety release) but they are noisy and throughput-killing: the worker restarts every cycle and the autopilot queue backs up.

## Root cause

`withRefreshingLock`'s refresh tick fires every `(TTL/6)` ms — **~5 min** for the default 30-min cycle lock. But the read pool's `idle_timeout` is **20s** (`connection-manager.ts`), so the connection is *always* reaped between ticks. Against a transaction-mode pooler (PgBouncer / Supavisor :6543) the reconnect races and postgres.js raises **`write CONNECTION_ENDED`**.

That throw escapes both `engineSelectOne` (the SELECT-1 heartbeat) and `handle.refresh()`, trips `withRefreshingLock`'s catch, sets `healthOk=false`, and the worker voluntarily releases + exits code 1.

The existing retry matcher (`retry-matcher.ts`) caught the **downstream** `No database connection` GBrainError — but only *after* the pool was already nulled. The **root** `CONNECTION_ENDED` had no matching pattern, so the first (recoverable) error escaped retry entirely.

## Fix (two minimal, idiomatic changes)

1. **`retry-matcher.ts`** — add `CONNECTION_ENDED` (postgres.js error *code* + message pattern). Benefits every `withRetry` call site, not just locks.

2. **`db-lock.ts`** — wrap `refresh()` and the SELECT-1 heartbeat in `withRetry` with a duck-typed `reconnect()` callback (PostgresEngine-private; `undefined` for PGLite, which can't lose a socket). A reaped connection self-heals (rebuild pool, retry) instead of killing the lock holder. Mirrors the engine-level `batchRetry` idiom from #1570.

## Tests

- `+2` CONNECTION_ENDED cases in `retry-matcher.test.ts` (code form + message form).
- `tsc --noEmit` clean.
- `retry-matcher` (17 pass) + `db-lock-refresh` + `worker-lock-renewal` + `worker-lock-renewal-shape` suites green.

## Notes / alternatives considered

- **Bumping `idle_timeout`**: rejected — fights the pooler's own reaping and just moves the race.
- **Pinning refresh to `withReservedConnection`** (the `db-lock.ts:552` "Lane B follow-up" TODO): heavier surface; `withRetry`+reconnect achieves the same self-heal with far less risk and reuses the existing primitive. The reserved-connection pin is still a reasonable future hardening.