### PR TITLE
fix(embed): only reject user_provided_model_unset when modelId is genuinely absent

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -671,7 +671,8 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
-    (recipe.id === 'litellm' || isUserProvided)
+    (recipe.id === 'litellm' || isUserProvided) &&
+    !parsed.modelId
   ) {
     return {
       ok: false,


### PR DESCRIPTION
### Problem

`diagnoseEmbedding()` unconditionally returns `user_provided_model_unset` for any recipe with `user_provided_models: true` and an empty `models` array (e.g. llama-server). It never checks whether the user has actually supplied a model name via the `embedding_model` config string.

### Root cause

`src/core/ai/gateway.ts` lines 670-682 checks `tp.models.length === 0 && isUserProvided` but never inspects `parsed.modelId`. For `llama-server:text-embedding-qwen3-embedding-0.6b`, `parseModelId()` correctly extracts `modelId = "text-embedding-qwen3-embedding-0.6b"`, but the guard ignores it.

### Fix

Add `!parsed.modelId` to the condition so `user_provided_model_unset` only fires when the model name is genuinely absent.

Fixes #1672