### PR TITLE
fix: allow gateway loop config flag

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -673,6 +673,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'models.expansion',
   'models.chat',
   'models.eval.longmemeval',
+  // Agent feature flags
+  'agent.use_gateway_loop',
   'facts.extraction_model',
   // Dream cycle config
   'dream.synthesize.session_corpus_dir',

--- a/test/config-set.test.ts
+++ b/test/config-set.test.ts
@@ -29,6 +29,10 @@ describe('KNOWN_CONFIG_KEYS', () => {
     expect(KNOWN_CONFIG_KEYS).toContain('models.tier.subagent');
   });
 
+  test('contains the gateway subagent feature flag recommended by doctor', () => {
+    expect(KNOWN_CONFIG_KEYS).toContain('agent.use_gateway_loop');
+  });
+
   test('no duplicate entries', () => {
     const set = new Set(KNOWN_CONFIG_KEYS);
     expect(set.size).toBe(KNOWN_CONFIG_KEYS.length);
@@ -113,6 +117,10 @@ describe('prefix vs known-key gate logic (mirrored from runConfig)', () => {
 
   test('models.custom.x (under prefix) → "prefix"', () => {
     expect(gate('models.custom.x')).toBe('prefix');
+  });
+
+  test('agent.use_gateway_loop → "known"', () => {
+    expect(gate('agent.use_gateway_loop')).toBe('known');
   });
 
   test('bug-reporter: embedding.provider → "unknown" (no prefix match)', () => {


### PR DESCRIPTION
## Summary
- add `agent.use_gateway_loop` to the known config key registry
- cover the key in the config-set gate regression tests

Closes #1454

## Test plan
- `bun test test/config-set.test.ts`
- `bun run typecheck`
- `scripts/check-test-isolation.sh`
- `git diff --check`