### PR TITLE
fix(eval-longmemeval): route answer-gen + extractor through the gateway (supersedes #1401)

### DIFF
--- a/src/commands/eval-longmemeval.ts
+++ b/src/commands/eval-longmemeval.ts
@@ -10,7 +10,6 @@
  */
 
 import { readFileSync, existsSync, openSync, writeSync, closeSync, writeFileSync } from 'fs';
-import Anthropic from '@anthropic-ai/sdk';
 import { withBenchmarkBrain, resetTables } from '../eval/longmemeval/harness.ts';
 import { haystackToPages, type LongMemEvalQuestion } from '../eval/longmemeval/adapter.ts';
 import { renderChatBlock, type ChatSessionForPrompt } from '../eval/longmemeval/sanitize.ts';
@@ -18,7 +17,7 @@ import { importFromContent } from '../core/import-file.ts';
 import { hybridSearch } from '../core/search/hybrid.ts';
 import { expandQuery } from '../core/search/expansion.ts';
 import { resolveModel } from '../core/model-config.ts';
-import type { ThinkLLMClient } from '../core/think/index.ts';
+import { __thinkAdapter, type ThinkLLMClient } from '../core/think/index.ts';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
 import type { PGLiteEngine } from '../core/pglite-engine.ts';
@@ -468,17 +467,39 @@ export async function runEvalLongMemEval(args: string[], runOpts: RunOpts = {}):
     fallback: 'sonnet',
   });
 
-  // Wrap Anthropic SDK so its `.messages.create` shape matches ThinkLLMClient.
-  // Same pattern as src/core/think/index.ts:247-249.
-  const realClient = new Anthropic();
-  const client: ThinkLLMClient = runOpts.client ?? {
-    create: (params, callOpts) => realClient.messages.create(params, callOpts),
-  };
-  // v0.40.2.0 — separate extractor client (defaults to same SDK).
-  const extractorClient: ThinkLLMClient = runOpts.extractorClient ?? {
-    create: (params, callOpts) => realClient.messages.create(params, callOpts),
-  };
-  const trajectoryEnabled = !opts.noTrajectory;
+  // Route LLM calls through the gateway (gbrain's canonical chat seam) instead
+  // of constructing `new Anthropic()` directly. The gateway normalizes the
+  // model id — a bare `claude-sonnet-4-6` AND a provider-prefixed
+  // `anthropic:claude-sonnet-4-6` both resolve — and owns auth, which fixes the
+  // 404 the raw Anthropic SDK threw when `resolveModel` returned a prefixed id.
+  // Mirrors the v0.35.5.0 `think` refactor (tryBuildGatewayClient). Tests inject
+  // via runOpts.client, short-circuiting the gateway path entirely.
+  //
+  // `--retrieval-only` never calls the answer-gen client (see the hypothesis
+  // ternary in runOneQuestion), so skip construction entirely in that mode — it
+  // must run with NO key / NO client (the keyless CI e2e relies on this, and the
+  // old `new Anthropic()` was likewise constructed-but-never-called there).
+  // Otherwise build the gateway client and fail fast if no chat model exists.
+  let client: ThinkLLMClient;
+  if (opts.retrievalOnly) {
+    client = runOpts.client ?? {
+      create: async () => {
+        throw new Error('[longmemeval] answer-gen client invoked in --retrieval-only mode (unreachable)');
+      },
+    };
+  } else {
+    const built = runOpts.client ?? (await __thinkAdapter.tryBuildGatewayClient(model));
+    if (!built) {
+      process.stderr.write(
+        `[longmemeval] no chat model available for "${model}" — configure an API key for its ` +
+        `provider (e.g. ANTHROPIC_API_KEY, or \`gbrain config set anthropic_api_key <key>\`) then retry.\n`,
+      );
+      process.exit(1);
+    }
+    client = built;
+  }
+
+  let trajectoryEnabled = !opts.noTrajectory;
   const extractorModel = trajectoryEnabled
     ? await resolveModel(null, {
         cliFlag: runOpts.extractorModel,
@@ -486,6 +507,20 @@ export async function runEvalLongMemEval(args: string[], runOpts: RunOpts = {}):
         fallback: 'haiku',
       })
     : '';
+  // Separate extractor client for trajectory routing, also gateway-routed.
+  // A null client (no key / unknown provider for the extractor model) disables
+  // trajectory for this run rather than failing the whole eval — trajectory is
+  // an optional enrichment, not core to the benchmark.
+  let extractorClient: ThinkLLMClient | null = null;
+  if (trajectoryEnabled) {
+    extractorClient = runOpts.extractorClient ?? (await __thinkAdapter.tryBuildGatewayClient(extractorModel));
+    if (!extractorClient) {
+      process.stderr.write(
+        `[longmemeval] extractor model "${extractorModel}" unavailable — disabling trajectory routing for this run.\n`,
+      );
+      trajectoryEnabled = false;
+    }
+  }
 
   process.stderr.write(`[longmemeval] estimated 20-60 minutes for ${questions.length} questions; use --limit N for shorter runs\n`);
   process.stderr.write(`[longmemeval] connecting in-memory brain...\n`);
@@ -612,7 +647,9 @@ export async function runEvalLongMemEval(args: string[], runOpts: RunOpts = {}):
 
 interface TrajectoryRunOpts {
   trajectoryEnabled: boolean;
-  extractorClient: ThinkLLMClient;
+  // null when the extractor model's provider is unavailable; trajectoryEnabled
+  // is forced false in that case, so the extractor path below is never reached.
+  extractorClient: ThinkLLMClient | null;
   extractorModel: string;
 }
 
@@ -644,7 +681,7 @@ async function runOneQuestion(
     // preprocessing — methodology disclosed at the envelope + stderr
     // summary level. Each call is fail-open; one bad session never
     // kills the per-question loop.
-    if (traj.trajectoryEnabled) {
+    if (traj.trajectoryEnabled && traj.extractorClient) {
       await extractAndInsertClaims({
         engine,
         client: traj.extractorClient,

--- a/test/longmemeval-gateway-routing.test.ts
+++ b/test/longmemeval-gateway-routing.test.ts
@@ -1,0 +1,206 @@
+/**
+ * longmemeval answer-gen routes through gateway.chat() (not `new Anthropic()`).
+ *
+ * Proves the fix for the provider-prefix 404 class: `resolveModel` returns a
+ * provider-prefixed id (`anthropic:claude-sonnet-4-6` from the `sonnet`
+ * fallback). The old code passed that raw to `new Anthropic().messages.create`,
+ * which 404s because the Anthropic SDK only accepts a bare model id. Routing
+ * through the gateway (via the exported `tryBuildGatewayClient` adapter, the
+ * same seam `think` uses) accepts the prefixed id and dispatches it correctly.
+ *
+ * Hermetic: PGLite in-memory + a stubbed gateway chat transport (no real API
+ * call). Critically, NO client is injected via runOpts, so the
+ * `tryBuildGatewayClient` path actually runs — the existing
+ * `longmemeval-trajectory-routing` tests inject `runOpts.client` and therefore
+ * never exercise this path. `--keyword-only` skips embeddings; `--no-trajectory`
+ * isolates the single answer-gen call.
+ *
+ * Mirrors test/longmemeval-trajectory-routing.test.ts (harness setup) +
+ * test/think-gateway-adapter.test.ts (transport stub).
+ */
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { writeFileSync, mkdtempSync, rmSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { runEvalLongMemEval } from '../src/commands/eval-longmemeval.ts';
+import { __setChatTransportForTests, resetGateway, type ChatResult } from '../src/core/ai/gateway.ts';
+import { withEnv } from './helpers/with-env.ts';
+import type { LongMemEvalQuestion } from '../src/eval/longmemeval/adapter.ts';
+
+let tmpDir: string;
+let datasetPath: string;
+let outputPath: string;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'lme-gateway-'));
+  datasetPath = join(tmpDir, 'dataset.jsonl');
+  outputPath = join(tmpDir, 'output.jsonl');
+
+  const questions: LongMemEvalQuestion[] = [
+    {
+      question_id: 'q1',
+      question_type: 'single-session-user',
+      question: 'What coffee did I mention?',
+      answer: 'placeholder',
+      haystack_sessions: [
+        { session_id: 'sess-1', turns: [
+          { role: 'user', content: 'I had a Blue Bottle coffee this morning' },
+        ]},
+      ],
+      answer_session_ids: ['sess-1'],
+      haystack_dates: ['2026-01-15'],
+    },
+  ];
+  writeFileSync(datasetPath, questions.map(q => JSON.stringify(q)).join('\n'));
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  __setChatTransportForTests(null);
+  resetGateway();
+});
+
+function readOutput(): Array<Record<string, unknown>> {
+  const raw = readFileSync(outputPath, 'utf-8').trim();
+  return raw.split('\n').map(line => JSON.parse(line));
+}
+
+describe('runEvalLongMemEval — answer-gen routes through the gateway', () => {
+  test('a provider-prefixed model id reaches gateway.chat (the case new Anthropic() 404s on)', async () => {
+    await withEnv({ ANTHROPIC_API_KEY: 'sk-test-fake' }, async () => {
+      let receivedModel = '';
+      let calls = 0;
+      __setChatTransportForTests(async (opts): Promise<ChatResult> => {
+        receivedModel = opts.model ?? '';
+        calls++;
+        return {
+          text: 'Blue Bottle',
+          blocks: [],
+          stopReason: 'end',
+          usage: { input_tokens: 10, output_tokens: 5, cache_read_tokens: 0, cache_creation_tokens: 0 },
+          model: opts.model ?? 'unknown',
+          providerId: 'anthropic',
+        };
+      });
+
+      // No --model → resolveModel falls back to `sonnet` →
+      // `anthropic:claude-sonnet-4-6`. No injected client → tryBuildGatewayClient
+      // builds the gateway-routed client. The dummy ANTHROPIC_API_KEY satisfies
+      // tryBuildGatewayClient's key probe.
+      await runEvalLongMemEval(
+        [datasetPath, '--keyword-only', '--no-trajectory', '--output', outputPath],
+        {},
+      );
+
+      // The answer-gen call dispatched through the gateway...
+      expect(calls).toBeGreaterThan(0);
+      // ...carrying the PROVIDER-PREFIXED id. Under the old `new Anthropic()`
+      // path this exact string 404'd; the gateway accepts and routes it.
+      expect(receivedModel).toBe('anthropic:claude-sonnet-4-6');
+
+      // And the run completed end-to-end, emitting a per-question row.
+      const out = readOutput();
+      expect(out.length).toBe(1);
+    });
+  });
+
+  test('an already-bare model id (--model claude-sonnet-4-6) also routes cleanly', async () => {
+    await withEnv({ ANTHROPIC_API_KEY: 'sk-test-fake' }, async () => {
+      let receivedModel = '';
+      __setChatTransportForTests(async (opts): Promise<ChatResult> => {
+        receivedModel = opts.model ?? '';
+        return {
+          text: 'Blue Bottle',
+          blocks: [],
+          stopReason: 'end',
+          usage: { input_tokens: 10, output_tokens: 5, cache_read_tokens: 0, cache_creation_tokens: 0 },
+          model: opts.model ?? 'unknown',
+          providerId: 'anthropic',
+        };
+      });
+
+      await runEvalLongMemEval(
+        [datasetPath, '--keyword-only', '--no-trajectory', '--model', 'claude-sonnet-4-6', '--output', outputPath],
+        {},
+      );
+
+      // tryBuildGatewayClient normalizes a bare id by adding the anthropic:
+      // prefix, so the gateway sees the canonical provider:model form either way.
+      expect(receivedModel).toBe('anthropic:claude-sonnet-4-6');
+      expect(readOutput().length).toBe(1);
+    });
+  });
+});
+
+describe('runEvalLongMemEval — trajectory ON (the nightly-probe production path)', () => {
+  test('extractor AND answer-gen both route through the gateway, and the answer round-trips', async () => {
+    await withEnv({ ANTHROPIC_API_KEY: 'sk-test-fake' }, async () => {
+      let extractorModelSeen = '';
+      let answerModelSeen = '';
+      const ANSWER_TEXT = 'Blue Bottle (gateway round-trip)';
+      // One global transport for BOTH call sites; branch on the model. The
+      // extractor resolves to the utility tier (haiku); the answer-gen to the
+      // sonnet fallback. No clients injected → both go through
+      // tryBuildGatewayClient, which is the production default since the nightly
+      // probe runs WITHOUT --no-trajectory.
+      __setChatTransportForTests(async (opts): Promise<ChatResult> => {
+        const model = opts.model ?? '';
+        const base = {
+          blocks: [] as [],
+          stopReason: 'end' as const,
+          usage: { input_tokens: 1, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 },
+          model,
+          providerId: 'anthropic',
+        };
+        if (model.includes('haiku')) {
+          extractorModelSeen = model;
+          return { ...base, text: JSON.stringify([]) }; // extractor: empty claims array (valid JSON)
+        }
+        answerModelSeen = model;
+        return { ...base, text: ANSWER_TEXT };
+      });
+
+      await runEvalLongMemEval(
+        [datasetPath, '--keyword-only', '--output', outputPath],
+        {},
+      );
+
+      // Extractor (utility tier → haiku) reached the gateway with a PREFIXED id.
+      expect(extractorModelSeen).toContain('haiku');
+      expect(extractorModelSeen.startsWith('anthropic:')).toBe(true);
+      // Answer-gen (sonnet fallback) reached the gateway with the prefixed id.
+      expect(answerModelSeen).toBe('anthropic:claude-sonnet-4-6');
+      // The stubbed answer round-tripped through chatResultToMessage into the
+      // output `hypothesis` field — proves the single-text-block adapter shape
+      // is consumed correctly by generateAnswer (not just "didn't crash").
+      const out = readOutput();
+      expect(out.length).toBe(1);
+      expect(out[0].hypothesis).toContain(ANSWER_TEXT);
+    });
+  });
+});
+
+describe('runEvalLongMemEval — --retrieval-only needs no chat client', () => {
+  test('runs with no client and no key (must NOT build/require the gateway client)', async () => {
+    await withEnv({ ANTHROPIC_API_KEY: undefined }, async () => {
+      // Regression guard: --retrieval-only never calls the answer-gen client.
+      // The gateway refactor must skip building it in this mode rather than
+      // process.exit(1) when no key is configured — otherwise the keyless CI
+      // e2e (test/eval-longmemeval-e2e.slow.test.ts) dies. No transport stub,
+      // no injected client, no key on purpose: if process.exit fired, this test
+      // process would be killed before the assertions run.
+      await runEvalLongMemEval(
+        [datasetPath, '--keyword-only', '--retrieval-only', '--no-trajectory', '--output', outputPath],
+        {},
+      );
+      const out = readOutput();
+      expect(out.length).toBe(1);
+      // hypothesis is the retrieved-sessions text block, not an LLM answer.
+      expect(typeof out[0].hypothesis).toBe('string');
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`gbrain eval longmemeval` constructed `new Anthropic()` and passed
`resolveModel()`'s output straight to `.messages.create({ model })`.
`resolveModel` returns a **provider-prefixed** id (e.g.
`anthropic:claude-sonnet-4-6` from the `sonnet` fallback / `DEFAULT_ALIASES`).
The Anthropic SDK only accepts a bare model id, so it 404s on the prefixed
form — every question fails unless a bare id is forced via `--model`. The
trajectory extractor (`tier: 'utility'` → `anthropic:claude-haiku-4-5-...`)
hits the same wall.

`stripProviderPrefix` exists upstream for the subagent path (`subagent.ts`)
but was never applied at these SDK-direct call sites.

## Fix

Route both the answer-gen and the trajectory extractor through the **gateway**
(`tryBuildGatewayClient`, the adapter `think` has used since v0.35.5.0) instead
of constructing `new Anthropic()` directly. The gateway:

- normalizes the model id — a bare `claude-sonnet-4-6` **and** a prefixed
  `anthropic:claude-sonnet-4-6` both resolve;
- owns auth + provider routing.

So the 404 class is fixed at the root for every provider, not stripped at one
call site.

Behavioral details:
- **Answer-gen**: hard-fails with a clear, actionable stderr message when no
  chat model is available (was an opaque per-question SDK throw).
- **Extractor**: a null gateway client (no key / unknown provider for the
  extractor model) disables trajectory routing for the run rather than failing
  the whole eval — trajectory is optional enrichment.
- Tests still inject via `runOpts.client` / `runOpts.extractorClient`,
  short-circuiting the gateway path.

## Why this supersedes #1401

#1401 applied `stripProviderPrefix` at the longmemeval call sites — a narrow
workaround. This routes through the canonical gateway seam instead, which is how
every other LLM call site in gbrain already works (chat, expansion, synthesize,
think). It fixes the root cause and aligns longmemeval with the rest of the
codebase. Recommend closing #1401 in favor of this.

## Testing

- `test/longmemeval-gateway-routing.test.ts` (new, 3 cases) exercises the
  **default** (non-injected) path with a stubbed gateway transport:
  - answer-gen sends the prefixed `anthropic:claude-sonnet-4-6` through
    `gateway.chat` (the exact id the SDK 404'd on);
  - a bare `--model claude-sonnet-4-6` normalizes to the same prefixed form;
  - **trajectory ON** (the default the nightly probe runs): extractor sends a
    prefixed `anthropic:claude-haiku-4-5-...` AND answer-gen sends prefixed
    sonnet, and the stubbed answer round-trips into the output `hypothesis`.
- Existing `longmemeval-*` tests pass unchanged (the `runOpts.client` injection
  short-circuit is intact).
- `tsc --noEmit` clean.
- **Verified end-to-end**: a live `gbrain eval longmemeval --limit 1` with NO
  `--model` (resolves to the prefixed `anthropic:claude-sonnet-4-6` — the exact
  id the old `new Anthropic()` path 404'd on) completed with `0 errors` and
  returned a valid answer against the real Anthropic API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
