### PR TITLE
fix(engine): batch upsertChunks INSERT under the int16 Bind param ceiling

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1983,6 +1983,36 @@ export class PGLiteEngine implements BrainEngine {
     // (1024-dim Voyage). Text/code chunks pass embedding=Float32Array +
     // embedding_image=null. Default modality='text' when omitted.
     const cols = '(page_id, chunk_index, chunk_text, chunk_source, embedding, model, token_count, embedded_at, language, symbol_name, symbol_type, start_line, end_line, parent_symbol_path, doc_comment, symbol_name_qualified, modality, embedding_image)';
+
+    // Batch the multi-row INSERT to stay under the Bind parameter ceiling. The
+    // PGLite engine binds params through a SIGNED int16, so a single INSERT
+    // silently no-ops (0 rows, NO error thrown) above 32767 params; the
+    // generated __generated__/graphql.ts chunked past that and pinned
+    // sync.last_commit. Both engines share this conservative budget. (Fix 6)
+    const MAX_BIND_PARAMS = 30000;
+    let batch: ChunkInput[] = [];
+    let batchParams = 0;
+    for (const chunk of chunks) {
+      // Base row = 15 params + 1 per present embedding (text / image vector).
+      const rowParamCount =
+        15 + (chunk.embedding ? 1 : 0) + (chunk.embedding_image ? 1 : 0);
+      if (batch.length > 0 && batchParams + rowParamCount > MAX_BIND_PARAMS) {
+        await this._insertChunkBatch(cols, pageId, batch);
+        batch = [];
+        batchParams = 0;
+      }
+      batch.push(chunk);
+      batchParams += rowParamCount;
+    }
+    if (batch.length > 0) await this._insertChunkBatch(cols, pageId, batch);
+  }
+
+  /**
+   * Build and run one multi-row INSERT ... ON CONFLICT for a param-budgeted
+   * slice of chunks (Fix 6). Keeps each statement under the signed-int16 Bind
+   * parameter ceiling.
+   */
+  private async _insertChunkBatch(cols: string, pageId: number, chunks: ChunkInput[]): Promise<void> {
     const rowParts: string[] = [];
     const params: unknown[] = [];
     let paramIdx = 1;

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -2008,6 +2008,37 @@ export class PostgresEngine implements BrainEngine {
     // v0.27.1 (Phase 8): added `modality` + `embedding_image` to the column
     // list. Image chunks pass embedding=null + embedding_image=Float32Array.
     const cols = '(page_id, chunk_index, chunk_text, chunk_source, embedding, model, token_count, embedded_at, language, symbol_name, symbol_type, start_line, end_line, parent_symbol_path, doc_comment, symbol_name_qualified, modality, embedding_image)';
+
+    // Batch the multi-row INSERT to stay under the Bind parameter ceiling. The
+    // PGLite engine binds params through a SIGNED int16, so a single INSERT
+    // silently no-ops (0 rows, NO error thrown) above 32767 params; the
+    // generated __generated__/graphql.ts chunked past that and pinned
+    // sync.last_commit. Both engines share this conservative budget. (Fix 6)
+    const MAX_BIND_PARAMS = 30000;
+    let batch: ChunkInput[] = [];
+    let batchParams = 0;
+    for (const chunk of chunks) {
+      // Base row = 15 params + 1 per present embedding (text / image vector).
+      const rowParamCount =
+        15 + (chunk.embedding ? 1 : 0) + (chunk.embedding_image ? 1 : 0);
+      if (batch.length > 0 && batchParams + rowParamCount > MAX_BIND_PARAMS) {
+        await this._insertChunkBatch(cols, pageId, batch);
+        batch = [];
+        batchParams = 0;
+      }
+      batch.push(chunk);
+      batchParams += rowParamCount;
+    }
+    if (batch.length > 0) await this._insertChunkBatch(cols, pageId, batch);
+  }
+
+  /**
+   * Build and run one multi-row INSERT ... ON CONFLICT for a param-budgeted
+   * slice of chunks (Fix 6). Keeps each statement under the signed-int16 Bind
+   * parameter ceiling.
+   */
+  private async _insertChunkBatch(cols: string, pageId: number, chunks: ChunkInput[]): Promise<void> {
+    const sql = this.sql;
     const rows: string[] = [];
     const params: unknown[] = [];
     let paramIdx = 1;

--- a/test/e2e/upsertchunks-bind-ceiling-postgres.test.ts
+++ b/test/e2e/upsertchunks-bind-ceiling-postgres.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Postgres upsertChunks param-ceiling regression (E2E)
+ *
+ * postgres.js rejects any query with more than 65534 bound parameters, so a
+ * single unbounded multi-row INSERT throws once a page chunks past ~4369 rows
+ * (~15 params/row). upsertChunks must split the INSERT into batches. This is
+ * the Postgres-engine analogue of the PGLite signed-int16 regression in
+ * test/pglite-engine.test.ts (PGLite fails silently at 32767; postgres.js
+ * fails loudly at 65534 — both are fixed by the same batching).
+ *
+ * Gated by DATABASE_URL — skips gracefully when no real Postgres is available.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import type { ChunkInput, PageInput } from "../../src/core/types.ts";
+import { hasDatabase, setupDB, teardownDB, getEngine } from "./helpers.ts";
+
+const describeDB = hasDatabase() ? describe : describe.skip;
+
+describeDB(
+  "Postgres: upsertChunks past the postgres.js Bind param limit",
+  () => {
+    beforeAll(setupDB);
+    afterAll(teardownDB);
+
+    test("stores every chunk when params exceed the postgres.js max", async () => {
+      const engine = getEngine();
+      const page: PageInput = {
+        type: "concept",
+        title: "Many Chunks",
+        compiled_truth: "page with many chunks",
+      };
+      await engine.putPage("test/many-chunks-pg", page);
+
+      // ~15 params/row; 5000 rows => ~75000 params, past postgres.js's 65534 cap.
+      const COUNT = 5000;
+      const many: ChunkInput[] = Array.from({ length: COUNT }, (_, i) => ({
+        chunk_index: i,
+        chunk_text: `Chunk number ${i}`,
+        chunk_source: "compiled_truth",
+      }));
+      await engine.upsertChunks("test/many-chunks-pg", many);
+
+      const chunks = await engine.getChunks("test/many-chunks-pg");
+      expect(chunks.length).toBe(COUNT);
+      // Content stays intact and contiguous across batch boundaries.
+      expect(chunks[0].chunk_text).toBe("Chunk number 0");
+      expect(chunks[3000].chunk_text).toBe("Chunk number 3000");
+      expect(chunks[COUNT - 1].chunk_text).toBe(`Chunk number ${COUNT - 1}`);
+    });
+  },
+);

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -407,6 +407,28 @@ describe('PGLiteEngine: Chunks', () => {
     expect(chunks.length).toBe(1);
     expect(chunks[0].embedding).not.toBeNull();
   });
+
+  test('upsertChunks stores every row past the int16 Bind param ceiling', async () => {
+    // Regression: PGLite binds a statement's params through a SIGNED int16,
+    // so a single multi-row INSERT silently inserts 0 rows (NO error thrown)
+    // once it exceeds 32767 bound params. At ~15 params/row that ceiling is
+    // ~2184 text chunks, so upsertChunks must split the INSERT into batches.
+    // 2500 chunks => ~37500 params, which forces more than one batch.
+    await engine.putPage('test/many-chunks', testPage);
+    const COUNT = 2500;
+    const many: ChunkInput[] = Array.from({ length: COUNT }, (_, i) => ({
+      chunk_index: i,
+      chunk_text: `Chunk number ${i}`,
+      chunk_source: 'compiled_truth',
+    }));
+    await engine.upsertChunks('test/many-chunks', many);
+    const chunks = await engine.getChunks('test/many-chunks');
+    expect(chunks.length).toBe(COUNT);
+    // Content stays intact and contiguous across the batch boundary.
+    expect(chunks[0].chunk_text).toBe('Chunk number 0');
+    expect(chunks[2000].chunk_text).toBe('Chunk number 2000');
+    expect(chunks[COUNT - 1].chunk_text).toBe(`Chunk number ${COUNT - 1}`);
+  });
 });
 
 // ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`upsertChunks` can **silently lose every chunk of a page** with no error thrown.

PGLite binds a statement's parameters through a **signed int16**, so a single multi-row `INSERT` silently inserts **0 rows** once it exceeds **32767** bound params. Verified empirically against the real `PGLiteEngine` (in-memory):

| bound params | rows actually stored |
| ------------ | -------------------- |
| 32760        | all                  |
| 32775        | **0 (no error)**     |

`upsertChunks` built one unbounded multi-row `INSERT` at ~15 params/row, so any page that chunks past **~2184 rows** silently dropped **all** of its chunks. Large generated files hit this in normal indexing, and at higher counts it escalated to the server-side `bind message has N parameter formats but 0 parameters` error, which aborts the surrounding transaction and (in a sync loop) pins the git anchor so every run re-imports from scratch.

## Fix

Split the multi-row `INSERT` into `<=30000`-param batches (comfortable margin under 32767) by extracting the per-row build + `INSERT ... ON CONFLICT` into a new `_insertChunkBatch` helper. Applied to **both** `pglite-engine.ts` and `postgres-engine.ts` for parity (postgres.js rejects loudly at 65534 rather than silently truncating, but shares the same conservative budget).

The orphan-prune `DELETE` and the empty-chunks early `return` stay in `_upsertChunksOnce`, so they still run **exactly once** per call -- only the `INSERT` is batched.

## Test

Adds a regression test that upserts **2500 text chunks** (~37500 params, forcing more than one batch) and asserts all are stored with contiguous content across the batch boundary.

- **Fails** on the pre-fix engine (stores 0 rows).
- **Passes** after the fix.

## Verification

- `npx tsc --noEmit` -> 0 errors.
- New regression test passes; verified it fails when the engine fix is reverted but the test is kept.
- The 4 pre-existing `pglite-engine.test.ts` failures (search_vector trigger / stats) are present on `master` before this change and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
