### PR TITLE
fix(migrations): avoid concurrent index drop inside DO blocks

### DIFF
--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -505,7 +505,7 @@ export const MIGRATIONS: Migration[] = [
                JOIN pg_class c ON c.oid = i.indexrelid
                WHERE c.relname = 'idx_pages_updated_at_desc' AND NOT i.indisvalid
              ) THEN
-               EXECUTE 'DROP INDEX CONCURRENTLY IF EXISTS idx_pages_updated_at_desc';
+               EXECUTE 'DROP INDEX IF EXISTS idx_pages_updated_at_desc';
              END IF;
            END $$;`
         );
@@ -1622,7 +1622,7 @@ export const MIGRATIONS: Migration[] = [
               JOIN pg_class c ON c.oid = i.indexrelid
               WHERE c.relname = 'pages_deleted_at_purge_idx' AND NOT i.indisvalid
             ) THEN
-              EXECUTE 'DROP INDEX CONCURRENTLY IF EXISTS pages_deleted_at_purge_idx';
+              EXECUTE 'DROP INDEX IF EXISTS pages_deleted_at_purge_idx';
             END IF;
           END $$;
         `);
@@ -1970,7 +1970,7 @@ export const MIGRATIONS: Migration[] = [
               JOIN pg_class c ON c.oid = i.indexrelid
               WHERE c.relname = 'pages_coalesce_date_idx' AND NOT i.indisvalid
             ) THEN
-              EXECUTE 'DROP INDEX CONCURRENTLY IF EXISTS pages_coalesce_date_idx';
+              EXECUTE 'DROP INDEX IF EXISTS pages_coalesce_date_idx';
             END IF;
           END $$;
         `);
@@ -3271,7 +3271,7 @@ export const MIGRATIONS: Migration[] = [
                JOIN pg_class c ON c.oid = i.indexrelid
                WHERE c.relname = 'idx_chunks_embedding_null' AND NOT i.indisvalid
              ) THEN
-               EXECUTE 'DROP INDEX CONCURRENTLY IF EXISTS idx_chunks_embedding_null';
+               EXECUTE 'DROP INDEX IF EXISTS idx_chunks_embedding_null';
              END IF;
            END $$;`
         );
@@ -3543,7 +3543,7 @@ export const MIGRATIONS: Migration[] = [
                JOIN pg_class c ON c.oid = i.indexrelid
                WHERE c.relname = 'takes_resolved_at_idx' AND NOT i.indisvalid
              ) THEN
-               EXECUTE 'DROP INDEX CONCURRENTLY IF EXISTS takes_resolved_at_idx';
+               EXECUTE 'DROP INDEX IF EXISTS takes_resolved_at_idx';
              END IF;
            END $$;`
         );
@@ -4216,7 +4216,7 @@ export const MIGRATIONS: Migration[] = [
                JOIN pg_class c ON c.oid = i.indexrelid
                WHERE c.relname = 'pages_generation_idx' AND NOT i.indisvalid
              ) THEN
-               EXECUTE 'DROP INDEX CONCURRENTLY IF EXISTS pages_generation_idx';
+               EXECUTE 'DROP INDEX IF EXISTS pages_generation_idx';
              END IF;
            END $$;`
         );
@@ -4481,7 +4481,7 @@ export const MIGRATIONS: Migration[] = [
                JOIN pg_class c ON c.oid = i.indexrelid
                WHERE c.relname = 'idx_facts_extract_conversation_session' AND NOT i.indisvalid
              ) THEN
-               EXECUTE 'DROP INDEX CONCURRENTLY IF EXISTS idx_facts_extract_conversation_session';
+               EXECUTE 'DROP INDEX IF EXISTS idx_facts_extract_conversation_session';
              END IF;
            END $$;`
         );
@@ -4534,7 +4534,7 @@ export const MIGRATIONS: Migration[] = [
                JOIN pg_class c ON c.oid = i.indexrelid
                WHERE c.relname = 'pages_dedup_idx' AND NOT i.indisvalid
              ) THEN
-               EXECUTE 'DROP INDEX CONCURRENTLY IF EXISTS pages_dedup_idx';
+               EXECUTE 'DROP INDEX IF EXISTS pages_dedup_idx';
              END IF;
            END $$;`
         );
@@ -4713,7 +4713,7 @@ export const MIGRATIONS: Migration[] = [
                JOIN pg_class c ON c.oid = i.indexrelid
                WHERE c.relname = 'content_chunks_stale_idx' AND NOT i.indisvalid
              ) THEN
-               EXECUTE 'DROP INDEX CONCURRENTLY IF EXISTS content_chunks_stale_idx';
+               EXECUTE 'DROP INDEX IF EXISTS content_chunks_stale_idx';
              END IF;
            END $$;`
         );
@@ -4758,7 +4758,7 @@ export const MIGRATIONS: Migration[] = [
                JOIN pg_class c ON c.oid = i.indexrelid
                WHERE c.relname = 'pages_atom_source_hash_idx' AND NOT i.indisvalid
              ) THEN
-               EXECUTE 'DROP INDEX CONCURRENTLY IF EXISTS pages_atom_source_hash_idx';
+               EXECUTE 'DROP INDEX IF EXISTS pages_atom_source_hash_idx';
              END IF;
            END $$;`
         );

--- a/test/migrate.test.ts
+++ b/test/migrate.test.ts
@@ -624,7 +624,7 @@ describe('migrate v14 — pages_updated_at_index (handler-based, engine-aware)',
     expect(v14!.sql).toBe('');
   });
 
-  test('v14 handler source contains CONCURRENTLY + invalid-index cleanup for Postgres branch', async () => {
+  test('v14 handler source contains concurrent create + transaction-safe invalid-index cleanup for Postgres branch', async () => {
     const { readFileSync } = await import('fs');
     const src = readFileSync('src/core/migrate.ts', 'utf-8');
     const v14Start = src.indexOf("name: 'pages_updated_at_index'");
@@ -632,13 +632,13 @@ describe('migrate v14 — pages_updated_at_index (handler-based, engine-aware)',
     const v14Block = src.slice(v14Start, v14Start + 3000);
     expect(v14Block).toContain('pg_index');
     expect(v14Block).toContain('indisvalid');
-    expect(v14Block).toContain('DROP INDEX CONCURRENTLY IF EXISTS idx_pages_updated_at_desc');
+    expect(v14Block).toContain('DROP INDEX IF EXISTS idx_pages_updated_at_desc');
     expect(v14Block).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pages_updated_at_desc');
     // Order within the handler body: DROP IF EXISTS must precede CREATE IF NOT EXISTS,
     // so a failed prior CONCURRENTLY build is cleaned before re-create. Anchor on the
     // explicit "IF EXISTS" / "IF NOT EXISTS" phrases so the header doc-comment
     // (which mentions both unqualified) doesn't fool the ordering assertion.
-    const dropIdx = v14Block.indexOf('DROP INDEX CONCURRENTLY IF EXISTS');
+    const dropIdx = v14Block.indexOf('DROP INDEX IF EXISTS');
     const createIdx = v14Block.indexOf('CREATE INDEX CONCURRENTLY IF NOT EXISTS');
     expect(dropIdx).toBeLessThan(createIdx);
     expect(v14Block).toContain('engine.kind');
@@ -736,7 +736,7 @@ describe('migrate v66 — embed_stale_partial_index (D6)', () => {
     expect(v66!.sql).toBe('');
   });
 
-  test('v66 handler source: CONCURRENTLY + invalid-index cleanup on Postgres branch', async () => {
+  test('v66 handler source: concurrent create + transaction-safe invalid-index cleanup on Postgres branch', async () => {
     const { readFileSync } = await import('fs');
     const src = readFileSync('src/core/migrate.ts', 'utf-8');
     const v66Start = src.indexOf("name: 'embed_stale_partial_index'");
@@ -744,14 +744,14 @@ describe('migrate v66 — embed_stale_partial_index (D6)', () => {
     const v66Block = src.slice(v66Start, v66Start + 3000);
     expect(v66Block).toContain('pg_index');
     expect(v66Block).toContain('indisvalid');
-    expect(v66Block).toContain('DROP INDEX CONCURRENTLY IF EXISTS idx_chunks_embedding_null');
+    expect(v66Block).toContain('DROP INDEX IF EXISTS idx_chunks_embedding_null');
     expect(v66Block).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chunks_embedding_null');
     // Partial index predicate must match the production query in
     // postgres-engine.ts / pglite-engine.ts: `WHERE embedding IS NULL`.
     expect(v66Block).toContain('WHERE embedding IS NULL');
     // DROP IF EXISTS must precede CREATE IF NOT EXISTS so a failed prior
     // CONCURRENTLY build is cleaned before re-create.
-    const dropIdx = v66Block.indexOf('DROP INDEX CONCURRENTLY IF EXISTS');
+    const dropIdx = v66Block.indexOf('DROP INDEX IF EXISTS');
     const createIdx = v66Block.indexOf('CREATE INDEX CONCURRENTLY IF NOT EXISTS');
     expect(dropIdx).toBeLessThan(createIdx);
     // Branches on engine.kind (handler-pattern from v14).


### PR DESCRIPTION
## Summary
- use plain `DROP INDEX IF EXISTS` for invalid concurrent-index cleanup inside migration DO blocks
- keep `CREATE INDEX CONCURRENTLY` for Postgres index creation outside a transaction
- update migration structural tests to assert transaction-safe cleanup

## Test plan
- `bun test test/migrate.test.ts test/migrate-retry.test.ts test/migrations-registry.test.ts`
