### PR TITLE
feat(facts): support configurable organic entity namespaces

### DIFF
--- a/src/core/facts/fence-write.ts
+++ b/src/core/facts/fence-write.ts
@@ -37,6 +37,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, appendF
 import { join, dirname } from 'node:path';
 
 import type { BrainEngine, NewFact, FactVisibility } from '../engine.ts';
+import type { PageType } from '../types.ts';
 import { withPageLock } from '../page-lock.ts';
 import { gbrainPath } from '../config.ts';
 import { upsertFactRow, parseFactsFence } from '../facts-fence.ts';
@@ -115,23 +116,31 @@ function recordWriteFailure(slug: string, sourceId: string, warnings: string[], 
 /**
  * Stub-create body for a new entity page. Minimum frontmatter so the
  * page validates as gbrain-canonical markdown and survives an
- * `importFromFile` round-trip. Type inferred from slug prefix
- * (e.g. `people/alice` → 'person'); unknown prefixes fall back to
- * 'concept' which is the most permissive PageType.
+ * `importFromFile` round-trip. Type inferred from an explicit slug-prefix
+ * map. Unsupported prefixes are rejected instead of silently becoming
+ * generic concepts; that keeps extract_facts from creating durable-looking
+ * slop pages under arbitrary directories.
  */
+const STUB_PAGE_TYPES: Record<string, PageType> = {
+  people: 'person',
+  companies: 'company',
+  deals: 'deal',
+  topics: 'concept',
+  projects: 'project',
+  services: 'project',
+};
+
 function stubEntityPage(slug: string): string {
   const prefix = slug.split('/')[0];
-  const type =
-    prefix === 'people'    ? 'person' :
-    prefix === 'companies' ? 'company' :
-    prefix === 'deals'     ? 'deal' :
-    prefix === 'topics'    ? 'concept' :
-    /* fallback */           'concept';
+  const type = STUB_PAGE_TYPES[prefix];
+  if (!type) {
+    throw new Error(`Refusing to stub-create unsupported fact target prefix: ${prefix}`);
+  }
   const tail = slug.split('/').slice(1).join('/');
   const title = tail
     .replace(/[-_/]+/g, ' ')
     .replace(/\b\w/g, c => c.toUpperCase()) || slug;
-  return `---\ntype: ${type}\ntitle: ${title}\nslug: ${slug}\n---\n\n# ${title}\n`;
+  return `---\ntype: ${type}\ntitle: ${title}\nslug: ${slug}\ngraph_role: stub\ngenerated_by: gbrain.extract_facts\n---\n\n# ${title}\n`;
 }
 
 /**

--- a/src/core/facts/fence-write.ts
+++ b/src/core/facts/fence-write.ts
@@ -116,12 +116,18 @@ function recordWriteFailure(slug: string, sourceId: string, warnings: string[], 
 /**
  * Stub-create body for a new entity page. Minimum frontmatter so the
  * page validates as gbrain-canonical markdown and survives an
- * `importFromFile` round-trip. Type inferred from an explicit slug-prefix
- * map. Unsupported prefixes are rejected instead of silently becoming
- * generic concepts; that keeps extract_facts from creating durable-looking
- * slop pages under arbitrary directories.
+ * `importFromFile` round-trip. Core entity prefixes get specific page
+ * types, and common organic-knowledge namespaces are enabled by default.
+ * Operators can extend the namespace taxonomy without code changes via
+ * config key `facts.entity_namespaces`, e.g.
+ * `{ "restaurants": "concept", "events": { "type": "event" } }`.
+ *
+ * The separate unprefixed/unknown-prefix guard below is the anti-slop
+ * boundary: configured `restaurants/comal-next-door` is intentional,
+ * while bare `jared` or unknown `widgets/foo` still cannot spawn a
+ * phantom page.
  */
-const STUB_PAGE_TYPES: Record<string, PageType> = {
+const CORE_STUB_PAGE_TYPES: Record<string, PageType> = {
   people: 'person',
   companies: 'company',
   deals: 'deal',
@@ -130,12 +136,47 @@ const STUB_PAGE_TYPES: Record<string, PageType> = {
   services: 'project',
 };
 
-function stubEntityPage(slug: string): string {
-  const prefix = slug.split('/')[0];
-  const type = STUB_PAGE_TYPES[prefix];
-  if (!type) {
-    throw new Error(`Refusing to stub-create unsupported fact target prefix: ${prefix}`);
+const DEFAULT_ENTITY_NAMESPACE_TYPES: Record<string, PageType> = {
+  restaurants: 'concept',
+  appliances: 'concept',
+  venues: 'concept',
+  products: 'concept',
+  events: 'event',
+  ideas: 'concept',
+  neighborhoods: 'concept',
+  trips: 'concept',
+};
+
+function parseEntityNamespaceConfig(raw: string | null): Record<string, PageType> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const out: Record<string, PageType> = {};
+    for (const [prefix, value] of Object.entries(parsed)) {
+      if (!/^[a-z0-9][a-z0-9-]*$/.test(prefix)) continue;
+      const type = typeof value === 'string'
+        ? value
+        : value && typeof value === 'object' && !Array.isArray(value) && typeof (value as { type?: unknown }).type === 'string'
+          ? (value as { type: string }).type
+          : null;
+      if (!type || !/^[a-z][a-z0-9_-]*$/.test(type)) continue;
+      out[prefix] = type;
+    }
+    return out;
+  } catch {
+    return {};
   }
+}
+
+async function loadStubPageTypes(engine: BrainEngine): Promise<Record<string, PageType>> {
+  const configured = parseEntityNamespaceConfig(await engine.getConfig('facts.entity_namespaces'));
+  return { ...CORE_STUB_PAGE_TYPES, ...DEFAULT_ENTITY_NAMESPACE_TYPES, ...configured };
+}
+
+function stubEntityPage(slug: string, stubPageTypes: Record<string, PageType>): string {
+  const prefix = slug.split('/')[0];
+  const type = stubPageTypes[prefix] ?? 'concept';
   const tail = slug.split('/').slice(1).join('/');
   const title = tail
     .replace(/[-_/]+/g, ' ')
@@ -177,6 +218,7 @@ export async function writeFactsToFence(
 
   const filePath = join(target.localPath, `${target.slug}.md`);
   const tmpPath = `${filePath}.tmp`;
+  const stubPageTypes = await loadStubPageTypes(engine);
 
   return withPageLock(
     target.slug,
@@ -203,7 +245,7 @@ export async function writeFactsToFence(
         // in resolveEntitySlug is sufficient and this guard can be removed.
         // The audit log under `~/.gbrain/audit/stub-guard-YYYY-Www.jsonl`
         // is the operator visibility surface for that retirement decision.
-        if (!target.slug.includes('/')) {
+        if (!target.slug.includes('/') || !(target.slug.split('/')[0] in stubPageTypes)) {
           logStubGuardEvent({
             slug: target.slug,
             source_id: target.sourceId,
@@ -211,13 +253,13 @@ export async function writeFactsToFence(
           });
           // eslint-disable-next-line no-console
           console.warn(
-            `[facts] refusing to stub-create unprefixed entity page slug=${target.slug} — routing to legacy DB-only path. Provide a directory prefix (people/, companies/, etc.) to opt into fence writes.`,
+            `[facts] refusing to stub-create unconfigured entity page slug=${target.slug} — routing to legacy DB-only path. Provide a configured namespace prefix (facts.entity_namespaces) to opt into fence writes.`,
           );
           return { inserted: 0, ids: [], stubGuardBlocked: true };
         }
         // Stub-create the parent directory if it doesn't exist.
         mkdirSync(dirname(filePath), { recursive: true });
-        body = stubEntityPage(target.slug);
+        body = stubEntityPage(target.slug, stubPageTypes);
       }
 
       // 2. Upsert each fact onto the fence in input order. row_num

--- a/test/fence-write.test.ts
+++ b/test/fence-write.test.ts
@@ -46,6 +46,7 @@ beforeEach(async () => {
     `UPDATE sources SET local_path = $1 WHERE id = 'default'`,
     [brainDir],
   );
+  await engine.unsetConfig('facts.entity_namespaces');
 });
 
 const baseInput = (overrides: Partial<FenceInputFact> = {}): FenceInputFact => ({
@@ -179,6 +180,60 @@ describe('writeFactsToFence — happy path', () => {
     expect(existsSync(join(brainDir, 'companies/acme.md'))).toBe(true);
     const companyBody = readFileSync(join(brainDir, 'companies/acme.md'), 'utf-8');
     expect(companyBody).toContain('type: company');
+
+    const restaurantResult = await writeFactsToFence(
+      engine,
+      { sourceId: 'default', localPath: brainDir, slug: 'restaurants/comal-next-door' },
+      [baseInput({ fact: 'Comal Next Door is a restaurant Shan mentions in Oakland.' })],
+    );
+    expect(restaurantResult.inserted).toBe(1);
+    const restaurantBody = readFileSync(join(brainDir, 'restaurants/comal-next-door.md'), 'utf-8');
+    expect(restaurantBody).toContain('type: concept');
+    expect(restaurantBody).toContain('slug: restaurants/comal-next-door');
+    expect(restaurantBody).toContain('Comal Next Door is a restaurant Shan mentions in Oakland.');
+
+    const organicPrefixResult = await writeFactsToFence(
+      engine,
+      { sourceId: 'default', localPath: brainDir, slug: 'appliances/cuisinart-air-fryer' },
+      [baseInput({ fact: 'Shan has a Cuisinart air fryer with no preheat option.' })],
+    );
+    expect(organicPrefixResult.inserted).toBe(1);
+    const applianceBody = readFileSync(join(brainDir, 'appliances/cuisinart-air-fryer.md'), 'utf-8');
+    expect(applianceBody).toContain('type: concept');
+    expect(applianceBody).toContain('slug: appliances/cuisinart-air-fryer');
+    expect(applianceBody).toContain('Shan has a Cuisinart air fryer with no preheat option.');
+
+    const unknownPrefixResult = await writeFactsToFence(
+      engine,
+      { sourceId: 'default', localPath: brainDir, slug: 'widgets/ambiguous-thing' },
+      [baseInput({ fact: 'Ambiguous thing should not silently create a new namespace.' })],
+    );
+    expect(unknownPrefixResult.inserted).toBe(0);
+    expect(unknownPrefixResult.stubGuardBlocked).toBe(true);
+    expect(existsSync(join(brainDir, 'widgets/ambiguous-thing.md'))).toBe(false);
+
+    await engine.setConfig('facts.entity_namespaces', JSON.stringify({
+      'social-contexts': 'concept',
+      gatherings: { type: 'event' },
+    }));
+    const configuredNamespaceResult = await writeFactsToFence(
+      engine,
+      { sourceId: 'default', localPath: brainDir, slug: 'social-contexts/yc-dinner' },
+      [baseInput({ fact: 'YC dinner context is a social memory namespace.' })],
+    );
+    expect(configuredNamespaceResult.inserted).toBe(1);
+    const configuredBody = readFileSync(join(brainDir, 'social-contexts/yc-dinner.md'), 'utf-8');
+    expect(configuredBody).toContain('type: concept');
+    expect(configuredBody).toContain('slug: social-contexts/yc-dinner');
+
+    const configuredEventResult = await writeFactsToFence(
+      engine,
+      { sourceId: 'default', localPath: brainDir, slug: 'gatherings/parul-birthday-dinner' },
+      [baseInput({ fact: 'Parul birthday dinner is an event memory namespace.' })],
+    );
+    expect(configuredEventResult.inserted).toBe(1);
+    const configuredEventBody = readFileSync(join(brainDir, 'gatherings/parul-birthday-dinner.md'), 'utf-8');
+    expect(configuredEventBody).toContain('type: event');
 
     const projectResult = await writeFactsToFence(
       engine,

--- a/test/fence-write.test.ts
+++ b/test/fence-write.test.ts
@@ -80,6 +80,8 @@ describe('writeFactsToFence — happy path', () => {
     const body = readFileSync(filePath, 'utf-8');
     expect(body).toContain('type: person');
     expect(body).toContain('slug: people/alice');
+    expect(body).toContain('graph_role: stub');
+    expect(body).toContain('generated_by: gbrain.extract_facts');
     expect(body).toContain('## Facts');
     expect(body).toContain('Founded Acme in 2017');
 
@@ -166,7 +168,7 @@ describe('writeFactsToFence — happy path', () => {
     expect(rows.rows[2]).toMatchObject({ row_num: 3, fact: 'Third' });
   });
 
-  test('stub-creates nested directories (companies/x → mkdir companies)', async () => {
+  test('stub-creates nested directories with exact prefix types', async () => {
     const result = await writeFactsToFence(
       engine,
       { sourceId: 'default', localPath: brainDir, slug: 'companies/acme' },
@@ -175,8 +177,18 @@ describe('writeFactsToFence — happy path', () => {
 
     expect(result.inserted).toBe(1);
     expect(existsSync(join(brainDir, 'companies/acme.md'))).toBe(true);
-    const body = readFileSync(join(brainDir, 'companies/acme.md'), 'utf-8');
-    expect(body).toContain('type: company');  // type inferred from slug prefix
+    const companyBody = readFileSync(join(brainDir, 'companies/acme.md'), 'utf-8');
+    expect(companyBody).toContain('type: company');
+
+    const projectResult = await writeFactsToFence(
+      engine,
+      { sourceId: 'default', localPath: brainDir, slug: 'projects/marketbot' },
+      [baseInput({ fact: 'MarketBot exists' })],
+    );
+    expect(projectResult.inserted).toBe(1);
+    const projectBody = readFileSync(join(brainDir, 'projects/marketbot.md'), 'utf-8');
+    expect(projectBody).toContain('type: project');
+    expect(projectBody).toContain('graph_role: stub');
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds typed frontmatter when facts stub-create new entity pages so generated markdown survives import round-trips.
- Replaces hardcoded organic entity prefix handling with a configurable `facts.entity_namespaces` registry.
- Keeps anti-slop protection for bare slugs and unconfigured prefixes while allowing everyday namespaces like restaurants, venues, ideas, neighborhoods, appliances, and social contexts.

## Test plan
- `bun test test/fence-write.test.ts`
- `bun run build`

## Notes
This is intentionally generic: it avoids needing code changes for every new organic knowledge namespace while still blocking accidental root-page or unknown-prefix slop from extraction/STT mistakes.
