### PR TITLE
fix(doctor): reduce stale supervisor crash noise

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3376,7 +3376,13 @@ export async function buildChecks(
     // shape is the right contract.
     const summary = summarizeCrashes(events);
     const crashes24h = summary.total;
-    const causeStr = `runtime=${summary.by_cause.runtime_error} oom=${summary.by_cause.oom_or_external_kill} unknown=${summary.by_cause.unknown} legacy=${summary.by_cause.legacy}`;
+    const lastStartMs = lastStart ? Date.parse(lastStart) : NaN;
+    const postStartEvents = Number.isFinite(lastStartMs)
+      ? events.filter(e => Date.parse(e.ts) >= lastStartMs)
+      : events;
+    const postStartSummary = summarizeCrashes(postStartEvents);
+    const postStartCrashes = postStartSummary.total;
+    const postStartCauseStr = `runtime=${postStartSummary.by_cause.runtime_error} oom=${postStartSummary.by_cause.oom_or_external_kill} unknown=${postStartSummary.by_cause.unknown} legacy=${postStartSummary.by_cause.legacy}`;
     const maxCrashesEvent = events.filter(e => e.event === 'max_crashes_exceeded').pop() ?? null;
 
     // Only surface a Check if the supervisor was ever observed (stops the
@@ -3394,20 +3400,21 @@ export async function buildChecks(
           status: 'warn',
           message: `Supervisor not running (last_start=${lastStart ?? 'unknown'}). Restart with: gbrain jobs supervisor start --detach`,
         });
-      } else if (crashes24h >= 1) {
-        // Threshold dropped from `>3` (pre-fix, inflated by clean exits being
-        // miscounted) to `>=1` (any real crash is signal). Per-cause breakdown
-        // gives operators triage context without grep'ing the JSONL.
+      } else if (postStartCrashes >= 1) {
+        // A crash after the current supervisor start is actionable. Older
+        // crashes in the rolling 24h audit are historical signal only: if the
+        // supervisor is currently running and has not crashed since this start,
+        // report OK and let the rolling counter age out.
         checks.push({
           name: 'supervisor',
           status: 'warn',
-          message: `Worker crashed ${crashes24h}x in last 24h (${causeStr}). Check ~/.gbrain/audit/supervisor-*.jsonl for context.`,
+          message: `Worker crashed ${postStartCrashes}x since current start (${postStartCauseStr}; rolling_24h=${crashes24h}). Check ~/.gbrain/audit/supervisor-*.jsonl for context.`,
         });
       } else {
         checks.push({
           name: 'supervisor',
           status: 'ok',
-          message: `running=true pid=${supervisorPid} last_start=${lastStart ?? 'unknown'} crashes_24h=${crashes24h} clean_exits_24h=${summary.clean_exits}`,
+          message: `running=true pid=${supervisorPid} last_start=${lastStart ?? 'unknown'} crashes_since_start=${postStartCrashes} crashes_24h=${crashes24h} clean_exits_24h=${summary.clean_exits}`,
         });
       }
     }

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -975,14 +975,17 @@ describe('supervisor crash classifier wiring (v0.35.x)', () => {
     );
   });
 
-  test('doctor.ts warn threshold dropped from >3 to >=1', async () => {
+  test('doctor.ts warns on crashes since current supervisor start, not stale rolling crashes', async () => {
     const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
-    // The pre-fix `crashes24h > 3` threshold made sense only because the
-    // counter was over-counting clean exits. Under accurate counts, any real
-    // crash is signal — threshold lands at `>=1`.
-    expect(source).toMatch(/crashes24h\s*>=\s*1/);
-    // The old `> 3` predicate must not survive on the supervisor check.
+    // The supervisor check should warn for an actionable crash after the
+    // current supervisor start. Historical rolling-24h crashes are context
+    // only when the current process has stayed healthy.
+    expect(source).toMatch(/postStartCrashes\s*>=\s*1/);
+    expect(source).toContain('crashes_since_start=');
+    expect(source).toContain('rolling_24h=');
+    // The old stale-noise predicates must not survive on the supervisor check.
     expect(source).not.toMatch(/crashes24h\s*>\s*3/);
+    expect(source).not.toMatch(/crashes24h\s*>=\s*1/);
   });
 
   test('doctor.ts ok + warn messages include per-cause breakdown and clean_exits_24h', async () => {


### PR DESCRIPTION
## Summary
- Treat supervisor crashes before the current process start as historical context instead of actionable warnings.
- Preserve the rolling 24h crash count in doctor output, but warn only when crashes happened since the current supervisor start.
- Updates regression coverage for the new post-start crash semantics.

## Test plan
- `bun test test/doctor.test.ts`
- `bun run build`
