### PR TITLE
feat(put_page): env-gated auto_link/auto_timeline opt-in for trusted remote callers

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -779,7 +779,12 @@ const put_page: Operation = {
     const trustedWorkspace = ctx.viaSubagent === true
       && Array.isArray(ctx.allowedSlugPrefixes)
       && ctx.allowedSlugPrefixes.length > 0;
-    if (ctx.remote !== false && !trustedWorkspace) {
+    // JavanC fork: env-gated escape hatch for single-user trusted deployments
+    // (Mac mini canonical host where every MCP caller is an internal agent
+    // gated by bearer token + Cloudflare WAF). Opt-in only; default behavior
+    // preserves upstream's security boundary for untrusted webhook input.
+    const trustedRemote = process.env.GBRAIN_TRUSTED_REMOTE === '1';
+    if (ctx.remote !== false && !trustedWorkspace && !trustedRemote) {
       autoLinks = { skipped: 'remote' };
       autoTimeline = { skipped: 'remote' };
     } else if (result.parsedPage) {


### PR DESCRIPTION
## Background

`put_page` currently skips `auto_link` and `auto_timeline` for remote (MCP) callers:

```ts
// src/core/operations.ts:782
if (ctx.remote !== false && !trustedWorkspace) {
  autoLinks = { skipped: 'remote' };
  autoTimeline = { skipped: 'remote' };
}
```

The security rationale (per the in-code comment): an untrusted page could plant arbitrary outbound links via bare-slug regex matching, and combined with the backlink boost in hybrid search, attacker-placed targets would surface higher. Reasonable default for webhook ingestion or any scenario where the MCP surface is exposed to mixed-trust callers.

## Problem

For single-user deployments where every MCP caller is an internal agent gated by both bearer token auth and a network-level allowlist (e.g. Cloudflare WAF rule that drops any request lacking `Authorization: Bearer gbrain_…`), the default skip becomes pure cost — pages get written via `put_page` but agents must run a separate batch `gbrain extract all` to backfill links, leaving the graph stale between batches.

In our concrete setup (Mac mini canonical host + MacBook MCP client over `https://brain.javan.cc`), the only way for a request to reach `put_page` is via a token we issued ourselves through `gbrain auth create`. The skip is a no-op security boundary in this topology, but the cost (stale link table, missing backlinks, stale `most_connected`) is real.

## Change

Add `GBRAIN_TRUSTED_REMOTE=1` env opt-in:

```ts
const trustedRemote = process.env.GBRAIN_TRUSTED_REMOTE === '1';
if (ctx.remote !== false && !trustedWorkspace && !trustedRemote) {
  autoLinks = { skipped: 'remote' };
  autoTimeline = { skipped: 'remote' };
}
```

- **Default behavior unchanged**: env unset → upstream skip preserved
- **Opt-in only**: operator must explicitly set the env in the server's launchd/systemd EnvironmentVariables
- **Pairs with existing `trustedWorkspace` mechanism**: same idea as the v0.23 dream-cycle bypass, just driven by deployment topology instead of subagent allow-list
- **Composable with `--public-url` + bearer-only access**: operators who terminate at a tunnel/WAF get a clean way to express "this entire MCP surface is trusted"

## Why an env var (rather than a config-table flag)

- The decision is a **deployment-shape** property, not a per-page or per-call setting — should live with the server's launch config, not the brain DB
- Env keeps it out of `gbrain config show` / `gbrain config get`, which is desirable for a security-sensitive override (a future operator should have to consciously add it to the plist, not toggle it through a CLI)
- Mirrors how `--public-url` and similar deployment knobs are already passed

## Tested with

- JavanC fork deployment on Mac mini (gbrain `0.41.29.0`, PGLite engine)
- `serve --http --bind 127.0.0.1 --port 3131 --public-url https://brain.javan.cc` behind cloudflared tunnel + Cloudflare WAF
- Three bearer tokens (one per client machine/agent) issued via `gbrain auth create … --takes-holders world`
- Verification: `put_page` containing `[[concepts/gbrain-multi-host-topology]]` → immediate `get_backlinks` on the target slug shows the new edge without running batch `extract`
- Latency impact: `put_page` round-trip (Cloudflare → tunnel → gbrain) ~970ms median, dominated by ZeroEntropy embedding; auto_link is the deterministic-regex `link-extraction.ts` path noted as `zero LLM`, so the marginal cost vs the skip path is small

## Compat

- No schema change
- No CLI surface change
- No protocol/MCP change (`put_page` still returns the same shape; `auto_links` field just becomes populated instead of `{skipped: 'remote'}` when the env is on)
- Untrusted deployments (webhook ingestion, multi-tenant, public MCP) keep the existing protective default

## Alternatives considered

1. **Per-call flag in the `put_page` op args**: rejected — clients could spoof trust per call, which defeats the purpose
2. **DB-stored "trusted clients" allow-list keyed by token name**: heavier, requires schema; env achieves the same outcome for the single-user case this targets
3. **`gbrain extract` job that accepts `{slug, source_id}`**: complementary, but doesn't help during the window between write and next batch; also blocked on per-page handler refactor in `src/commands/jobs.ts`

Happy to iterate on naming (`GBRAIN_AUTO_LINK_REMOTE` if more descriptive?) or to add a startup log line that notes the override is on when `--http` boots.