### PR TITLE
perf(config): batch + cache engine.getConfig to kill ~85 round-trips per query

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -91,6 +91,25 @@ export function getPostgresSchema(
 export class PostgresEngine implements BrainEngine {
   readonly kind = 'postgres' as const;
   private _sql: ReturnType<typeof postgres> | null = null;
+  /**
+   * perf: process-lifetime config cache. A single search fires ~85
+   * getConfig() reads (loadConfigWithEngine x2 = 30 keys, plus mode/cache/
+   * intent/rerank/graph-signals resolvers). On a remote pooler each read is
+   * a round-trip; serial they dominate query latency (~5s) and can push the
+   * op handler past cli.ts's 10s disconnect force-exit, truncating stdout.
+   * First read batch-loads the whole `config` table into this Map; writes
+   * update it in place. TTL bounds staleness for multi-writer processes.
+   */
+  private _configCache: Map<string, string | null> | null = null;
+  private _configCacheLoadedAt = 0;
+  private get _configCacheTtlMs(): number {
+    const raw = process.env.GBRAIN_CONFIG_CACHE_TTL_MS;
+    if (raw !== undefined) {
+      const n = parseInt(raw, 10);
+      if (Number.isFinite(n) && n >= 0) return n;
+    }
+    return 30_000;
+  }
   /** Saved config for reconnection. */
   private _savedConfig: (EngineConfig & { poolSize?: number; parentConnectionManager?: ConnectionManager }) | null = null;
   /** Whether a reconnect is in progress (prevents concurrent reconnects). */
@@ -4591,9 +4610,27 @@ export class PostgresEngine implements BrainEngine {
 
   // Config
   async getConfig(key: string): Promise<string | null> {
-    const sql = this.sql;
-    const rows = await sql`SELECT value FROM config WHERE key = ${key}`;
-    return rows.length > 0 ? (rows[0].value as string) : null;
+    const ttl = this._configCacheTtlMs;
+    if (ttl === 0) {
+      const sql = this.sql;
+      const rows = await sql`SELECT value FROM config WHERE key = ${key}`;
+      return rows.length > 0 ? (rows[0].value as string) : null;
+    }
+    const fresh =
+      this._configCache !== null &&
+      Date.now() - this._configCacheLoadedAt < ttl;
+    if (!fresh) {
+      const sql = this.sql;
+      const rows = await sql<{ key: string; value: string }[]>`
+        SELECT key, value FROM config
+      `;
+      const map = new Map<string, string | null>();
+      for (const r of rows) map.set(r.key, r.value);
+      this._configCache = map;
+      this._configCacheLoadedAt = Date.now();
+    }
+    // Map.has distinguishes "known-absent" from "not yet loaded".
+    return this._configCache!.has(key) ? this._configCache!.get(key)! : null;
   }
 
   async setConfig(key: string, value: string): Promise<void> {
@@ -4602,11 +4639,15 @@ export class PostgresEngine implements BrainEngine {
       INSERT INTO config (key, value) VALUES (${key}, ${value})
       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
     `;
+    // Write-through so a long-lived process never serves stale config.
+    if (this._configCache !== null) this._configCache.set(key, value);
   }
 
   async unsetConfig(key: string): Promise<number> {
     const sql = this.sql;
     const result = await sql`DELETE FROM config WHERE key = ${key}` as unknown as { count: number };
+    // Write-through: mark known-absent so the cache doesn't serve a stale value.
+    if (this._configCache !== null) this._configCache.set(key, null);
     return result.count ?? 0;
   }
 


### PR DESCRIPTION
Fixes #1693.

## Problem

A single `gbrain query <q>` / `gbrain search <q>` issues **~85 separate `SELECT value FROM config WHERE key = $1` round-trips**. `loadConfigWithEngine` reads 15 keys and is called twice per query; the mode/cache/intent/rerank/graph-signals resolvers each re-read more.

On a local PGLite brain each read is sub-millisecond, so this is invisible. On a **remote Postgres / Supabase pooler** each read is a network round-trip (amplified under transaction-mode `prepare:false`, where every statement re-parses). 85 serial reads = several seconds of pure config latency on every search.

Two user-visible symptoms downstream:

1. **Empty stdout + misleading force-exit.** The CLI's hard-coded 10s disconnect force-exit timer (`cli.ts` `DISCONNECT_HARD_DEADLINE_MS`) is armed *before* the op handler. When the config-read tax pushes the handler past 10s, the unref'd timer fires `process.exit(0)` **mid-handler** → empty stdout + a misleading `engine.disconnect() did not return within 10000ms` line (disconnect was never even reached).
2. **Latency dominated by config, not retrieval.** Measured on a 2486-page brain: `searchVector` 0.75s, `searchKeyword` 0.6s, `embed` 0.31s — but full `hybridSearch` ~7–8s. The delta is config N+1.

## Fix

Add a process-lifetime config cache to `PostgresEngine.getConfig()`:

- First read triggers **one** batch `SELECT key, value FROM config` that populates a `Map`; subsequent `getConfig()` calls are served from memory.
- `setConfig()` / `unsetConfig()` update the Map in place (write-through), so a long-lived process (`serve` / autopilot) never serves stale config.
- A coarse TTL (default 30s, env `GBRAIN_CONFIG_CACHE_TTL_MS`) bounds staleness for multi-writer setups; set `0` to disable caching entirely and restore the original per-key query.

`Map.has` distinguishes "known-absent" (cached null) from "not yet loaded", so a missing key is not re-fetched on every call.

## Result (Supabase session-mode pooler, 2486-page brain)

| Metric | Before | After |
|---|---|---|
| getConfig round-trips / query | ~85 | 1 |
| hybridSearch handler | ~8s | ~3.7s |
| `gbrain query` end-to-end | ~11s | ~5s |

This brings the handler comfortably under the 10s force-exit deadline, removing the empty-stdout failure mode.

## Precedent

`query-cache.ts` already batch-reads config via `WHERE key = ANY($1)`; this PR generalizes that pattern to the hot `getConfig` path.

## Notes

- Behaviour is unchanged with `GBRAIN_CONFIG_CACHE_TTL_MS=0` (falls back to the original single-key query).
- Write-through keeps `serve`/autopilot processes correct without waiting for the TTL.
