### PR TITLE
fix(links): exclude soft-deleted endpoints from getLinks/getBacklinks (closes #1702, sibling of #1021)

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -2433,14 +2433,21 @@ export class PGLiteEngine implements BrainEngine {
     // and read-side op handlers that haven't threaded sourceId yet). With
     // opts.sourceId, scope to that source — used by reconcileLinks and any
     // ctx.sourceId-aware read op (D20).
+    //
+    // Soft-delete filter (siblings of #1021/PR #1033): hide rows where either
+    // endpoint page is soft-deleted. Without this, links survive the 72h
+    // recovery window in read-side results even though the endpoint pages are
+    // hidden from get_page / list_pages / search. Hard purge
+    // (purgeDeletedPages) still cascades via FK; this filter only governs the
+    // soft-delete window.
     if (opts?.sourceId) {
       const { rows } = await this.db.query(
         `SELECT f.slug as from_slug, t.slug as to_slug,
                 l.link_type, l.context, l.link_source,
                 o.slug as origin_slug, l.origin_field
          FROM links l
-         JOIN pages f ON f.id = l.from_page_id
-         JOIN pages t ON t.id = l.to_page_id
+         JOIN pages f ON f.id = l.from_page_id AND f.deleted_at IS NULL
+         JOIN pages t ON t.id = l.to_page_id   AND t.deleted_at IS NULL
          LEFT JOIN pages o ON o.id = l.origin_page_id
          WHERE f.slug = $1 AND f.source_id = $2`,
         [slug, opts.sourceId]
@@ -2452,8 +2459,8 @@ export class PGLiteEngine implements BrainEngine {
               l.link_type, l.context, l.link_source,
               o.slug as origin_slug, l.origin_field
        FROM links l
-       JOIN pages f ON f.id = l.from_page_id
-       JOIN pages t ON t.id = l.to_page_id
+       JOIN pages f ON f.id = l.from_page_id AND f.deleted_at IS NULL
+       JOIN pages t ON t.id = l.to_page_id   AND t.deleted_at IS NULL
        LEFT JOIN pages o ON o.id = l.origin_page_id
        WHERE f.slug = $1`,
       [slug]
@@ -2463,14 +2470,15 @@ export class PGLiteEngine implements BrainEngine {
 
   async getBacklinks(slug: string, opts?: { sourceId?: string }): Promise<Link[]> {
     // v0.31.8 (D16): two-branch query. See getLinks() comment.
+    // Soft-delete filter: see getLinks() above.
     if (opts?.sourceId) {
       const { rows } = await this.db.query(
         `SELECT f.slug as from_slug, t.slug as to_slug,
                 l.link_type, l.context, l.link_source,
                 o.slug as origin_slug, l.origin_field
          FROM links l
-         JOIN pages f ON f.id = l.from_page_id
-         JOIN pages t ON t.id = l.to_page_id
+         JOIN pages f ON f.id = l.from_page_id AND f.deleted_at IS NULL
+         JOIN pages t ON t.id = l.to_page_id   AND t.deleted_at IS NULL
          LEFT JOIN pages o ON o.id = l.origin_page_id
          WHERE t.slug = $1 AND t.source_id = $2`,
         [slug, opts.sourceId]
@@ -2482,8 +2490,8 @@ export class PGLiteEngine implements BrainEngine {
               l.link_type, l.context, l.link_source,
               o.slug as origin_slug, l.origin_field
        FROM links l
-       JOIN pages f ON f.id = l.from_page_id
-       JOIN pages t ON t.id = l.to_page_id
+       JOIN pages f ON f.id = l.from_page_id AND f.deleted_at IS NULL
+       JOIN pages t ON t.id = l.to_page_id   AND t.deleted_at IS NULL
        LEFT JOIN pages o ON o.id = l.origin_page_id
        WHERE t.slug = $1`,
       [slug]

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -2479,14 +2479,21 @@ export class PostgresEngine implements BrainEngine {
     // v0.31.8 (D16): two-branch query. Without opts.sourceId, no source filter
     // (preserves pre-v0.31.8 cross-source semantics). With opts.sourceId,
     // scope the from-page lookup. See pglite-engine.ts:getLinks for context.
+    //
+    // Soft-delete filter (siblings of #1021/PR #1033): hide rows where either
+    // endpoint page is soft-deleted. Without this, links survive the 72h
+    // recovery window in read-side results even though the endpoint pages are
+    // hidden from get_page / list_pages / search. Hard purge
+    // (purgeDeletedPages) still cascades via FK; this filter only governs the
+    // soft-delete window.
     if (opts?.sourceId) {
       const rows = await sql`
         SELECT f.slug as from_slug, t.slug as to_slug,
                l.link_type, l.context, l.link_source,
                o.slug as origin_slug, l.origin_field
         FROM links l
-        JOIN pages f ON f.id = l.from_page_id
-        JOIN pages t ON t.id = l.to_page_id
+        JOIN pages f ON f.id = l.from_page_id AND f.deleted_at IS NULL
+        JOIN pages t ON t.id = l.to_page_id   AND t.deleted_at IS NULL
         LEFT JOIN pages o ON o.id = l.origin_page_id
         WHERE f.slug = ${slug} AND f.source_id = ${opts.sourceId}
       `;
@@ -2497,8 +2504,8 @@ export class PostgresEngine implements BrainEngine {
              l.link_type, l.context, l.link_source,
              o.slug as origin_slug, l.origin_field
       FROM links l
-      JOIN pages f ON f.id = l.from_page_id
-      JOIN pages t ON t.id = l.to_page_id
+      JOIN pages f ON f.id = l.from_page_id AND f.deleted_at IS NULL
+      JOIN pages t ON t.id = l.to_page_id   AND t.deleted_at IS NULL
       LEFT JOIN pages o ON o.id = l.origin_page_id
       WHERE f.slug = ${slug}
     `;
@@ -2508,14 +2515,15 @@ export class PostgresEngine implements BrainEngine {
   async getBacklinks(slug: string, opts?: { sourceId?: string }): Promise<Link[]> {
     const sql = this.sql;
     // v0.31.8 (D16): two-branch query, mirrors getLinks above.
+    // Soft-delete filter: see getLinks() above.
     if (opts?.sourceId) {
       const rows = await sql`
         SELECT f.slug as from_slug, t.slug as to_slug,
                l.link_type, l.context, l.link_source,
                o.slug as origin_slug, l.origin_field
         FROM links l
-        JOIN pages f ON f.id = l.from_page_id
-        JOIN pages t ON t.id = l.to_page_id
+        JOIN pages f ON f.id = l.from_page_id AND f.deleted_at IS NULL
+        JOIN pages t ON t.id = l.to_page_id   AND t.deleted_at IS NULL
         LEFT JOIN pages o ON o.id = l.origin_page_id
         WHERE t.slug = ${slug} AND t.source_id = ${opts.sourceId}
       `;
@@ -2526,8 +2534,8 @@ export class PostgresEngine implements BrainEngine {
              l.link_type, l.context, l.link_source,
              o.slug as origin_slug, l.origin_field
       FROM links l
-      JOIN pages f ON f.id = l.from_page_id
-      JOIN pages t ON t.id = l.to_page_id
+      JOIN pages f ON f.id = l.from_page_id AND f.deleted_at IS NULL
+      JOIN pages t ON t.id = l.to_page_id   AND t.deleted_at IS NULL
       LEFT JOIN pages o ON o.id = l.origin_page_id
       WHERE t.slug = ${slug}
     `;

--- a/test/links-soft-deleted.test.ts
+++ b/test/links-soft-deleted.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+
+/**
+ * Regression tests for the soft-delete filter in getLinks / getBacklinks.
+ *
+ * Sibling of #1021 / PR #1033 (which fixed the same class of bug in orphans):
+ * read-side link queries did not honor pages.deleted_at, so during the 72h
+ * soft-delete recovery window a deleted endpoint still surfaced links to/from
+ * that page even though the page itself was hidden from get_page / search.
+ *
+ * Hard purge (purgeDeletedPages) cascades via the FK and is unaffected; these
+ * tests only cover the soft-delete window.
+ */
+describe('links visibility honors soft-delete (engine-injected)', () => {
+  let engine: PGLiteEngine;
+
+  beforeEach(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  }, 60_000);
+
+  afterEach(async () => {
+    if (engine) await engine.disconnect();
+  }, 60_000);
+
+  async function seedPair() {
+    await engine.putPage('people/alice', {
+      type: 'person',
+      title: 'Alice',
+      compiled_truth: 'Alice mentions Bob.',
+      timeline: '',
+    });
+    await engine.putPage('people/bob', {
+      type: 'person',
+      title: 'Bob',
+      compiled_truth: 'Bob.',
+      timeline: '',
+    });
+    await engine.addLink('people/alice', 'people/bob', 'mentioned', 'references', 'markdown');
+  }
+
+  test('getBacklinks hides links from soft-deleted source page', async () => {
+    await seedPair();
+
+    // Sanity: link is visible while both pages are active.
+    const before = await engine.getBacklinks('people/bob');
+    expect(before.map(l => l.from_slug)).toEqual(['people/alice']);
+
+    // Soft-delete the *from* page; its outgoing link should disappear from
+    // bob's backlinks even though the row still exists in the links table
+    // (recovery window contract).
+    await engine.softDeletePage('people/alice');
+    const after = await engine.getBacklinks('people/bob');
+    expect(after).toEqual([]);
+  });
+
+  test('getBacklinks hides links targeting soft-deleted page (defense-in-depth)', async () => {
+    await seedPair();
+
+    // Soft-deleting the *to* page should also remove the row from queries that
+    // pivot on it. This mirrors the get_page contract: a soft-deleted page is
+    // not addressable until restored or 72h passes.
+    await engine.softDeletePage('people/bob');
+    const result = await engine.getBacklinks('people/bob');
+    expect(result).toEqual([]);
+  });
+
+  test('getLinks hides outbound row when target page is soft-deleted', async () => {
+    await seedPair();
+
+    const before = await engine.getLinks('people/alice');
+    expect(before.map(l => l.to_slug)).toEqual(['people/bob']);
+
+    await engine.softDeletePage('people/bob');
+    const after = await engine.getLinks('people/alice');
+    expect(after).toEqual([]);
+  });
+
+  test('getLinks hides outbound row when source page itself is soft-deleted', async () => {
+    await seedPair();
+
+    await engine.softDeletePage('people/alice');
+    const result = await engine.getLinks('people/alice');
+    expect(result).toEqual([]);
+  });
+
+  test('restorePage brings the link row back into view', async () => {
+    await seedPair();
+    await engine.softDeletePage('people/alice');
+    expect(await engine.getBacklinks('people/bob')).toEqual([]);
+
+    const restored = await engine.restorePage('people/alice');
+    expect(restored).toBe(true);
+
+    const after = await engine.getBacklinks('people/bob');
+    expect(after.map(l => l.from_slug)).toEqual(['people/alice']);
+  });
+});


### PR DESCRIPTION
Closes #1702. Sibling of #1021 / PR #1033.

## Problem

`getLinks` and `getBacklinks` JOIN `pages` on the link FKs but do not filter `pages.deleted_at IS NULL`. During the 72h soft-delete recovery window, links to or from a soft-deleted page still appear in the read-side results even though the page itself is hidden from `get_page` / `list_pages` / `search`.

This is the same class of bug PR #1033 fixed for `orphans` and `dead_links`. #1033 didn't touch `getLinks` / `getBacklinks`, so the read-side leak remained.

`delete_page` (MCP op) maps to `softDeletePage`, so any agent that creates and then deletes a page over MCP leaves apparent links behind for 72h, until the autopilot `purgeDeletedPages` hard-deletes the rows and the FK on `links` (`ON DELETE CASCADE`) cleans up. The schema clearly intends links to disappear when their endpoint does — that contract is met on hard delete, not on soft delete.

## Change

Add `AND f.deleted_at IS NULL AND t.deleted_at IS NULL` to the page JOINs in both branches (with and without `opts.sourceId`) of:

- `PGLiteEngine.getLinks`
- `PGLiteEngine.getBacklinks`
- `PostgresEngine.getLinks`
- `PostgresEngine.getBacklinks`

Filtering both endpoints (not just the from-side, which is the visible repro) keeps the read contract symmetric and defends against the case where a target is soft-deleted but a link is queried via the source.

## Why this shape

Followed PR #1033's pattern:
- Same query-level fix (no schema migration, no behavior change for hard delete)
- Same defense-in-depth philosophy (filter both endpoints)
- Same test scaffolding (engine-injected `bun:test`, `softDeletePage` + assertion on the read path)

The graph traversal queries (`traverseGraph`, the recursive `JOIN pages p2 ON p2.id = l.to_page_id` paths) have the same omission, but they are out of scope for this PR to keep the diff reviewable. Happy to fold those into a follow-up.

## Tests

New `test/links-soft-deleted.test.ts` (5 cases):

- getBacklinks hides links from soft-deleted source
- getBacklinks hides links targeting soft-deleted page (defense-in-depth)
- getLinks hides outbound row when target is soft-deleted
- getLinks hides outbound row when source itself is soft-deleted
- `restore_page` brings the row back into view

Existing `test/orphans.test.ts` (57 cases across the related suites) and `test/backlinks.test.ts` continue to pass.

\`\`\`
$ bun test test/links-soft-deleted.test.ts
 5 pass | 0 fail | 9 expect() calls

$ bun test test/orphans.test.ts test/backlinks.test.ts test/reconcile-links.serial.test.ts
 57 pass | 0 fail | 93 expect() calls
\`\`\`

## Compat

- No schema migration
- No public API / op shape change
- Hard delete behavior unchanged (FK cascade still applies)
- `restore_page` semantics preserved (un-hiding a soft-deleted page brings its links back)
- Behavior change is limited to: soft-deleted-but-not-yet-purged endpoints no longer leak into read results

## Discovered while

Building a multi-host gbrain topology and noticing residual backlinks after MCP put_page + delete_page round-trips in a JavanC fork. Wrote up the topology + the bug-class lineage in #1692 (separate JavanC opt-in patch for `GBRAIN_TRUSTED_REMOTE`) before tracking this one down.