### PR TITLE
sources: gate recloneIfMissing against paths outside the managed clone root

### DIFF
--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -38,7 +38,7 @@
 
 import { existsSync, mkdirSync, renameSync, rmSync, lstatSync } from 'fs';
 import { realpathSync } from 'fs';
-import { join, dirname, resolve as resolvePath } from 'path';
+import { join, dirname, relative, sep, isAbsolute, resolve as resolvePath } from 'path';
 import { randomBytes } from 'crypto';
 import type { BrainEngine } from './engine.ts';
 import {
@@ -66,6 +66,7 @@ export type SourceOpErrorCode =
   | 'not_found'
   | 'protected_id'
   | 'clone_dir_outside_gbrain'
+  | 'unsafe_reclone_path'
   | 'symlink_escape';
 
 export class SourceOpError extends Error {
@@ -251,6 +252,64 @@ export function isPathContained(child: string, parent: string): boolean {
   // Append a separator to parent so /foo doesn't match /foobar.
   const parentWithSep = resolvedParent.endsWith('/') ? resolvedParent : resolvedParent + '/';
   return resolvedChild === resolvedParent || resolvedChild.startsWith(parentWithSep);
+}
+
+function isResolvedPathWithin(
+  childAbs: string,
+  parentAbs: string,
+  allowEqual = true,
+): boolean {
+  const rel = relative(parentAbs, childAbs);
+  if (rel === '') return allowEqual;
+  return (
+    rel !== '..' &&
+    !rel.startsWith(`..${sep}`) &&
+    !isAbsolute(rel) &&
+    resolvePath(parentAbs, rel) === childAbs
+  );
+}
+
+function pathExistsByLstat(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasRawParentSegment(path: string): boolean {
+  return path.split(sep).some((segment) => segment === '..');
+}
+
+function isManagedRecloneTarget(localPath: string, cloneRoot: string): boolean {
+  if (hasRawParentSegment(localPath)) return false;
+
+  const rootAbs = resolvePath(cloneRoot);
+  const targetAbs = resolvePath(localPath);
+  if (!isResolvedPathWithin(targetAbs, rootAbs, false)) return false;
+
+  let rootReal: string;
+  try {
+    rootReal = realpathSync(rootAbs);
+  } catch {
+    return false;
+  }
+
+  let ancestor = targetAbs;
+  while (!pathExistsByLstat(ancestor)) {
+    const parent = dirname(ancestor);
+    if (parent === ancestor) return false;
+    ancestor = parent;
+  }
+
+  let ancestorReal: string;
+  try {
+    ancestorReal = realpathSync(ancestor);
+  } catch {
+    return false;
+  }
+  return isResolvedPathWithin(ancestorReal, rootReal);
 }
 
 // ── addSource ───────────────────────────────────────────────────────────────
@@ -697,6 +756,17 @@ export async function recloneIfMissing(
 
   const state = validateRepoState(src.local_path, remoteUrl);
   if (state === 'healthy') return false;
+
+  const cloneRoot = gbrainPath('clones');
+  mkdirSync(cloneRoot, { recursive: true });
+  if (!isManagedRecloneTarget(src.local_path, cloneRoot)) {
+    throw new SourceOpError(
+      'unsafe_reclone_path',
+      `Refusing to re-clone source "${id}" into ${resolvePath(src.local_path)}: ` +
+        `path is outside the gbrain-managed clone root ${resolvePath(cloneRoot)}. ` +
+        `Repoint or re-add the source instead.`,
+    );
+  }
 
   // Re-clone via temp + rename, mirroring addSource's atomicity contract.
   const tempDir = makeTempCloneDir(id);

--- a/test/sources-ops.test.ts
+++ b/test/sources-ops.test.ts
@@ -13,7 +13,7 @@ import {
   chmodSync,
   existsSync,
 } from 'fs';
-import { join } from 'path';
+import { join, relative, sep } from 'path';
 import { tmpdir } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import {
@@ -504,6 +504,104 @@ describe('recloneIfMissing — T4 restore + autopurge recovery', () => {
       await addSource(engine, { id: 't4-no-url', localPath: '/tmp/anywhere' });
       const recloned = await recloneIfMissing(engine, 't4-no-url');
       expect(recloned).toBe(false);
+    });
+  });
+
+  test('refuses to re-clone into non-managed local_path and preserves contents', async () => {
+    await withEnv2(async () => {
+      const userPath = join(GBRAIN_HOME, 'user-working-tree');
+      mkdirSync(userPath, { recursive: true });
+      writeFileSync(join(userPath, 'sentinel'), 'do-not-touch');
+      await engine.executeRaw(
+        `INSERT INTO sources (id, name, local_path, config) VALUES ('t4-unsafe-path', 'x', $1, $2::jsonb)`,
+        [userPath, JSON.stringify({ remote_url: 'https://github.com/example/repo' })],
+      );
+
+      try {
+        await recloneIfMissing(engine, 't4-unsafe-path');
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(SourceOpError);
+        expect((e as SourceOpError).code).toBe('unsafe_reclone_path');
+      }
+      expect(existsSync(join(userPath, 'sentinel'))).toBe(true);
+    });
+  });
+
+  test('normalizes relative and trailing-slash unsafe paths before rejecting', async () => {
+    await withEnv2(async () => {
+      const userPath = join(GBRAIN_HOME, 'relative-working-tree');
+      mkdirSync(userPath, { recursive: true });
+      writeFileSync(join(userPath, 'sentinel'), 'do-not-touch');
+      const relativePath = `${relative(process.cwd(), userPath)}/`;
+      await engine.executeRaw(
+        `INSERT INTO sources (id, name, local_path, config) VALUES ('t4-relative-unsafe', 'x', $1, $2::jsonb)`,
+        [relativePath, JSON.stringify({ remote_url: 'https://github.com/example/repo' })],
+      );
+
+      try {
+        await recloneIfMissing(engine, 't4-relative-unsafe');
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(SourceOpError);
+        expect((e as SourceOpError).code).toBe('unsafe_reclone_path');
+      }
+      expect(existsSync(join(userPath, 'sentinel'))).toBe(true);
+    });
+  });
+
+  test('refuses clone-root symlink parents that resolve outside managed storage', async () => {
+    await withEnv2(async () => {
+      const target = join(GBRAIN_HOME, 'symlink-target');
+      mkdirSync(target, { recursive: true });
+      writeFileSync(join(target, 'sentinel'), 'do-not-touch');
+      mkdirSync(CLONE_ROOT, { recursive: true });
+      const linkParent = join(CLONE_ROOT, 'linked-parent');
+      symlinkSync(target, linkParent);
+      const masqueradingPath = join(linkParent, 'child-clone');
+      await engine.executeRaw(
+        `INSERT INTO sources (id, name, local_path, config) VALUES ('t4-symlink-unsafe', 'x', $1, $2::jsonb)`,
+        [masqueradingPath, JSON.stringify({ remote_url: 'https://github.com/example/repo' })],
+      );
+
+      try {
+        await recloneIfMissing(engine, 't4-symlink-unsafe');
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(SourceOpError);
+        expect((e as SourceOpError).code).toBe('unsafe_reclone_path');
+      }
+      expect(existsSync(join(target, 'sentinel'))).toBe(true);
+      expect(existsSync(masqueradingPath)).toBe(false);
+      rmSync(linkParent, { force: true });
+    });
+  });
+
+  test("refuses raw '..' through clone-root symlink parents and preserves outside victim", async () => {
+    await withEnv2(async () => {
+      const target = join(GBRAIN_HOME, 'dotdot-target');
+      const victim = join(GBRAIN_HOME, 'dotdot-victim');
+      mkdirSync(target, { recursive: true });
+      mkdirSync(victim, { recursive: true });
+      writeFileSync(join(victim, 'sentinel'), 'do-not-touch');
+      mkdirSync(CLONE_ROOT, { recursive: true });
+      const linkParent = join(CLONE_ROOT, 'dotdot-link');
+      symlinkSync(target, linkParent);
+      const masqueradingPath = `${linkParent}${sep}..${sep}dotdot-victim`;
+      await engine.executeRaw(
+        `INSERT INTO sources (id, name, local_path, config) VALUES ('t4-symlink-dotdot', 'x', $1, $2::jsonb)`,
+        [masqueradingPath, JSON.stringify({ remote_url: 'https://github.com/example/repo' })],
+      );
+
+      try {
+        await recloneIfMissing(engine, 't4-symlink-dotdot');
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(SourceOpError);
+        expect((e as SourceOpError).code).toBe('unsafe_reclone_path');
+      }
+      expect(existsSync(join(victim, 'sentinel'))).toBe(true);
+      rmSync(linkParent, { force: true });
     });
   });
 });


### PR DESCRIPTION
## Summary

`recloneIfMissing` recovers a degraded source by re-cloning via a destructive temp + rename over `src.local_path`, but it never verified that `local_path` is actually gbrain-managed storage. A source that was re-added or repointed at a user-managed directory could therefore have that directory wiped during recovery.

This gates the destructive reclone behind `isManagedRecloneTarget()`:

- Rejects any raw `..` path segment first, so a symlinked segment followed by `..` cannot make the OS-resolved `rm`/`rename` target diverge from the lexically-checked path.
- Requires the resolved path to be strictly contained in the gbrain clone root.
- Is symlink-aware: it `realpath`s the nearest existing ancestor and confirms it resolves within the realpathed clone root, so a symlinked parent pointing outside managed storage is rejected.

When the target is not managed it throws `unsafe_reclone_path` instead of deleting anything, and tells the user to repoint or re-add the source.

## Testing

- `bun test test/sources-ops.test.ts` -> 28 pass, covering: non-managed path, relative/trailing-slash normalization, symlink parent escape, and raw `..` traversal. Each asserts the outside victim file survives.
- `bun run verify` -> 29/29.

Closes #1526