### PR TITLE
fix(skillopt): support AI SDK v6 tool loops

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -21,7 +21,7 @@
  *     rotation (via configureGateway()) invalidates stale entries.
  */
 
-import { embed as aiEmbed, embedMany, generateObject, generateText } from 'ai';
+import { embed as aiEmbed, embedMany, generateObject, generateText, jsonSchema } from 'ai';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { listRecipes } from './recipes/index.ts';
 import { createOpenAI } from '@ai-sdk/openai';
@@ -2457,7 +2457,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
   const tools = (opts.tools ?? []).reduce((acc, t) => {
     acc[t.name] = {
       description: t.description,
-      inputSchema: { jsonSchema: t.inputSchema } as any,
+      inputSchema: jsonSchema(t.inputSchema as any) as any,
     };
     return acc;
   }, {} as Record<string, any>);
@@ -2654,6 +2654,14 @@ export interface ToolLoopResult {
   messages: ChatMessage[];
 }
 
+function toolResultJson(output: unknown): { type: 'json'; value: unknown } {
+  return { type: 'json', value: output };
+}
+
+function toolResultError(message: string): { type: 'error-text'; value: string } {
+  return { type: 'error-text', value: message };
+}
+
 /**
  * Provider-agnostic tool-calling loop. Wraps `gateway.chat()` with:
  *   - assistant→tool-dispatch→tool-result cycle
@@ -2769,7 +2777,7 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
           type: 'tool-result',
           toolCallId: call.toolCallId,
           toolName: call.toolName,
-          output: `tool "${call.toolName}" is not in the registry for this subagent`,
+          output: toolResultError(`tool "${call.toolName}" is not in the registry for this subagent`),
           isError: true,
         });
         opts.onHeartbeat?.('tool_failed', { turn_idx: turnIdx, tool_name: call.toolName, error: 'not_registered' });
@@ -2808,7 +2816,7 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
           type: 'tool-result',
           toolCallId: call.toolCallId,
           toolName: call.toolName,
-          output: prior.output,
+          output: toolResultJson(prior.output),
         });
         opts.onHeartbeat?.('tool_replay_complete', { turn_idx: turnIdx, tool_name: call.toolName });
         continue;
@@ -2818,7 +2826,7 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
           type: 'tool-result',
           toolCallId: call.toolCallId,
           toolName: call.toolName,
-          output: prior.error ?? 'tool failed',
+          output: toolResultError(prior.error ?? 'tool failed'),
           isError: true,
         });
         opts.onHeartbeat?.('tool_replay_failed', { turn_idx: turnIdx, tool_name: call.toolName });
@@ -2842,7 +2850,7 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
           type: 'tool-result',
           toolCallId: call.toolCallId,
           toolName: call.toolName,
-          output,
+          output: toolResultJson(output),
         });
         opts.onHeartbeat?.('tool_result', { turn_idx: turnIdx, tool_name: call.toolName });
       } catch (err) {
@@ -2852,7 +2860,7 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
           type: 'tool-result',
           toolCallId: call.toolCallId,
           toolName: call.toolName,
-          output: errMsg,
+          output: toolResultError(errMsg),
           isError: true,
         });
         opts.onHeartbeat?.('tool_failed', { turn_idx: turnIdx, tool_name: call.toolName, error: errMsg });
@@ -2861,10 +2869,10 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
 
     if (stopReason === 'aborted') break;
 
-    // Feed all tool results back as a single user message.
-    const userMessageIdx = messageIdx++;
-    void userMessageIdx;
-    messages.push({ role: 'user', content: toolResultBlocks });
+    // Feed all tool results back as a single tool message.
+    const toolMessageIdx = messageIdx++;
+    void toolMessageIdx;
+    messages.push({ role: 'tool', content: toolResultBlocks });
 
     turnIdx++;
   }

--- a/src/core/skillopt/orchestrator.ts
+++ b/src/core/skillopt/orchestrator.ts
@@ -79,10 +79,11 @@
 
 import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { BudgetTracker } from '../budget/budget-tracker.ts';
 import { withBudgetTracker } from '../ai/gateway.ts';
 import { errorFor } from '../errors.ts';
-import { applyEditBatch, getWorkingTreeStatusForFile } from './apply-edits.ts';
+import { applyEditBatch, getWorkingTreeStatusForFile, atomicWrite } from './apply-edits.ts';
 import { logEvent, sha8 } from './audit.ts';
 import { loadBenchmark, splitBench, parseSplit } from './benchmark.ts';
 import { getBundledSkillContext, shouldMutateSkillFile } from './bundled-skill-gate.ts';
@@ -504,6 +505,8 @@ async function runOptimizationLoop(
     // Note: acceptCandidate is gated by mutateDecision.mutate above, so best.md
     // isn't written in --no-mutate mode. Write it explicitly here.
     // (Simplified for v1 — a follow-up routes the proposed-only path cleanly.)
+    fs.mkdirSync(path.dirname(proposedPath), { recursive: true });
+    atomicWrite(proposedPath, finalText);
   } else if (mutateDecision.mutate) {
     mutatedSkillFile = finalOutcome === 'accepted';
   }

--- a/src/core/skillopt/rollout.ts
+++ b/src/core/skillopt/rollout.ts
@@ -18,8 +18,9 @@
 
 import { chat as gatewayChat, toolLoop, type ChatMessage, type ChatToolDef, type ToolHandler } from '../ai/gateway.ts';
 import { BRAIN_TOOL_ALLOWLIST } from '../minions/tools/brain-allowlist.ts';
-import { operations, type OperationContext } from '../operations.ts';
+import { operations, type OperationContext, type ParamDef } from '../operations.ts';
 import { loadConfig } from '../config.ts';
+import { paramDefToSchema } from '../../mcp/tool-defs.ts';
 import type { BrainEngine } from '../engine.ts';
 import type { BenchmarkTask, Trajectory } from './types.ts';
 
@@ -207,11 +208,11 @@ function stripBrainPrefix(toolName: string): string {
   return toolName.startsWith('brain_') ? toolName.slice('brain_'.length) : toolName;
 }
 
-function paramsToSchema(params: Record<string, { type: string; description?: string; required?: boolean }>): Record<string, unknown> {
+function paramsToSchema(params: Record<string, ParamDef>): Record<string, unknown> {
   return {
     type: 'object' as const,
     properties: Object.fromEntries(
-      Object.entries(params).map(([k, v]) => [k, { type: v.type, description: v.description }]),
+      Object.entries(params).map(([k, v]) => [k, paramDefToSchema(v)]),
     ),
     required: Object.entries(params).filter(([, v]) => v.required).map(([k]) => k),
   };

--- a/test/ai/gateway-tool-loop.test.ts
+++ b/test/ai/gateway-tool-loop.test.ts
@@ -5,6 +5,7 @@ import {
   configureGateway,
   resetGateway,
   type ChatBlock,
+  type ChatMessage,
   type ToolHandler,
 } from '../../src/core/ai/gateway.ts';
 
@@ -92,6 +93,53 @@ describe('gateway.toolLoop (v0.38 D11 — provider-agnostic loop control)', () =
     expect(result.finalText).toBe('final answer');
     expect(result.totalUsage.input_tokens).toBe(25); // 10 + 15
     expect(result.totalUsage.output_tokens).toBe(9); // 4 + 5
+  });
+
+  it('feeds tool results back as AI SDK v6 tool-role output blocks', async () => {
+    const observedMessages: ChatMessage[][] = [];
+    let turn = 0;
+    __setChatTransportForTests(async (opts) => {
+      observedMessages.push(opts.messages.map((m) => ({ ...m })));
+      turn++;
+      if (turn === 1) {
+        return {
+          text: '',
+          blocks: [
+            { type: 'tool-call', toolCallId: 'tc-json', toolName: 'search', input: { q: 'foo' } },
+          ] as ChatBlock[],
+          stopReason: 'tool_calls',
+          usage: { input_tokens: 10, output_tokens: 4, cache_read_tokens: 0, cache_creation_tokens: 0 },
+          model: 'anthropic:claude-sonnet-4-6',
+          providerId: 'anthropic',
+        };
+      }
+      return {
+        text: 'done',
+        blocks: [{ type: 'text', text: 'done' }] as ChatBlock[],
+        stopReason: 'end',
+        usage: { input_tokens: 5, output_tokens: 2, cache_read_tokens: 0, cache_creation_tokens: 0 },
+        model: 'anthropic:claude-sonnet-4-6',
+        providerId: 'anthropic',
+      };
+    });
+
+    await toolLoop({
+      initialMessages: [{ role: 'user', content: 'find foo' }],
+      tools: [{ name: 'search', description: 'search the brain', inputSchema: { type: 'object' } }],
+      toolHandlers: new Map([['search', { idempotent: true, async execute() { return { ok: true }; } }]]),
+    });
+
+    const secondTurnMessages = observedMessages[1]!;
+    const toolMessage = secondTurnMessages.at(-1)!;
+    expect(toolMessage.role).toBe('tool');
+    expect(Array.isArray(toolMessage.content)).toBe(true);
+    const [toolResult] = toolMessage.content as ChatBlock[];
+    expect(toolResult).toMatchObject({
+      type: 'tool-result',
+      toolCallId: 'tc-json',
+      toolName: 'search',
+      output: { type: 'json', value: { ok: true } },
+    });
   });
 
   it('captures persistence callbacks in order: assistant → tool start → tool complete', async () => {

--- a/test/skillopt/rollout-schema.test.ts
+++ b/test/skillopt/rollout-schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { runRollout } from '../../src/core/skillopt/rollout.ts';
+import type { ChatToolDef, ToolLoopOpts, ToolLoopResult } from '../../src/core/ai/gateway.ts';
+
+describe('skillopt rollout tool schemas', () => {
+  test('preserves ParamDef enum/default/items metadata from brain operations', async () => {
+    let capturedTools: ChatToolDef[] = [];
+
+    await runRollout({
+      engine: {} as never,
+      skillText: 'Answer the task using read-only brain tools when useful.',
+      task: { task_id: 'schema-capture', task: 'noop', judge: { kind: 'rule', checks: [] } },
+      targetModel: 'anthropic:claude-sonnet-4-6',
+      toolLoopFn: async (opts: ToolLoopOpts): Promise<ToolLoopResult> => {
+        capturedTools = opts.tools;
+        return {
+          finalText: 'done',
+          totalTurns: 0,
+          totalUsage: { input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_creation_tokens: 0 },
+          stopReason: 'end',
+          messages: [{ role: 'assistant', content: [{ type: 'text', text: 'done' }] }],
+        };
+      },
+    });
+
+    const listPages = capturedTools.find((tool) => tool.name === 'brain_list_pages');
+    expect(listPages).toBeDefined();
+    const listPagesProps = listPages!.inputSchema.properties as Record<string, any>;
+    expect(listPagesProps.sort.enum).toContain('updated_desc');
+
+    const traverseGraph = capturedTools.find((tool) => tool.name === 'brain_traverse_graph');
+    expect(traverseGraph).toBeDefined();
+    const traverseProps = traverseGraph!.inputSchema.properties as Record<string, any>;
+    expect(traverseProps.direction.enum).toEqual(['in', 'out', 'both']);
+  });
+});


### PR DESCRIPTION
## Summary

- Wrap raw JSON schemas with AI SDK v6 `jsonSchema()` when building gateway tools.
- Feed tool results back as `role: 'tool'` messages with v6-compatible `{ type: 'json' | 'error-text', value }` outputs.
- Reuse the central `paramDefToSchema()` mapper for SkillOpt rollout tools so enum/default/items metadata survives.
- Persist the accepted proposal artifact in `--no-mutate` SkillOpt runs by writing `skillopt/best.md` atomically.

## Why

While testing `gbrain skillopt` with an OpenAI-compatible chat provider, tool calls failed with schema/tool-result shape errors under AI SDK v6. After the gateway fixes, chat, forced toolLoop, and one SkillOpt rollout all complete successfully.

## Test Plan

- `bun --check src/core/ai/gateway.ts src/core/skillopt/rollout.ts src/core/skillopt/orchestrator.ts test/ai/gateway-tool-loop.test.ts test/skillopt/rollout-schema.test.ts`
- `bun test test/ai/gateway-tool-loop.test.ts test/skillopt/rollout-schema.test.ts`
- `bun run typecheck`

Local note: full `bun run verify` is not reliable in my Windows/MSYS checkout because many package scripts invoke bare `scripts/*.sh` paths that Bun for Windows cannot dispatch directly; the focused checks and typecheck above are green.
