### PR TITLE
fix(ai): allow current Gemini models

### DIFF
--- a/src/core/ai/recipes/google.ts
+++ b/src/core/ai/recipes/google.ts
@@ -11,7 +11,7 @@ export const google: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['gemini-embedding-001'],
+      models: ['gemini-embedding-001', 'gemini-embedding-2', 'gemini-embedding-2-preview'],
       default_dims: 768,
       dims_options: [768, 1536, 3072],
       cost_per_1m_tokens_usd: 0.15,
@@ -23,7 +23,14 @@ export const google: Recipe = {
       price_last_verified: '2026-04-20',
     },
     chat: {
-      models: ['gemini-2.0-flash-exp', 'gemini-2.0-flash', 'gemini-1.5-pro'],
+      models: [
+        'gemini-2.5-flash',
+        'gemini-2.5-pro',
+        'gemini-2.0-flash-001',
+        'gemini-2.0-flash',
+        'gemini-2.0-flash-lite',
+        'gemini-1.5-pro',
+      ],
       supports_tools: true,
       supports_subagent_loop: true,
       supports_prompt_cache: false,

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -104,6 +104,7 @@ describe('chat touchpoint — model resolver + aliases (Codex F-OV-5)', () => {
     expect(() => assertTouchpoint(getRecipe('anthropic')!, 'chat', 'claude-opus-4-7')).not.toThrow();
     expect(() => assertTouchpoint(getRecipe('openai')!, 'chat', 'gpt-5.2')).not.toThrow();
     expect(() => assertTouchpoint(getRecipe('google')!, 'chat', 'gemini-2.0-flash')).not.toThrow();
+    expect(() => assertTouchpoint(getRecipe('google')!, 'chat', 'gemini-2.5-flash')).not.toThrow();
     expect(() => assertTouchpoint(getRecipe('deepseek')!, 'chat', 'deepseek-chat')).not.toThrow();
   });
 


### PR DESCRIPTION
## Summary
- add current Gemini 2.5 chat models to the Google recipe allowlist
- add current Gemini embedding model aliases
- guard gemini-2.5-flash chat resolution in gateway tests

## Verification
- bun test test/ai/gateway-chat.test.ts test/think-gateway-adapter.test.ts
- git diff --check