### PR TITLE
fix(skill-catalog): fold block-scalar descriptions instead of leaking `|`/`>` (#1711)

### DIFF
--- a/src/core/skill-catalog.ts
+++ b/src/core/skill-catalog.ts
@@ -326,11 +326,36 @@ function availableBrainTools(ctx: OperationContext): string[] {
 // Frontmatter projection + description
 // ---------------------------------------------------------------------------
 
-/** Parse a single-line `description:` from raw frontmatter (best-effort). */
+/**
+ * Parse the `description:` field from raw frontmatter (best-effort). Handles
+ * both inline (`description: text`) and YAML block scalars (`description: |`
+ * or `description: >`, including chomping/indent indicators like `|-`, `>2`),
+ * folding block content into a single line. Returns undefined when there's no
+ * usable value so the caller falls back to the body's first prose line — a bare
+ * block indicator must NOT leak through as the literal `|`/`>`.
+ */
 function parseDescriptionField(raw: string): string | undefined {
-  const m = raw.match(/^description:\s*["']?(.+?)["']?\s*$/m);
-  if (!m) return undefined;
-  const v = m[1].trim();
+  const lines = raw.split('\n');
+  const idx = lines.findIndex(l => /^description:/.test(l));
+  if (idx === -1) return undefined;
+
+  const after = lines[idx].replace(/^description:[ \t]*/, '');
+  // Block scalar: `|` or `>`, optional chomping (+/-) and/or indent digit,
+  // optional trailing comment. Fold the following indented lines into one line.
+  if (/^[|>][+-]?\d*[ \t]*(#.*)?$/.test(after.trim())) {
+    const folded: string[] = [];
+    for (let i = idx + 1; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.trim() === '') { folded.push(''); continue; }
+      if (/^[ \t]/.test(line)) { folded.push(line.trim()); continue; }
+      break; // dedent to column 0 → next top-level key ends the block
+    }
+    const v = folded.join(' ').replace(/\s+/g, ' ').trim();
+    return v.length > 0 ? v : undefined;
+  }
+
+  // Inline value (strip a matching pair / stray surrounding quote).
+  const v = after.trim().replace(/^["']|["']$/g, '').trim();
   return v.length > 0 ? v : undefined;
 }
 

--- a/test/skill-catalog.test.ts
+++ b/test/skill-catalog.test.ts
@@ -142,6 +142,26 @@ describe('oneLineDescription', () => {
   test('empty when nothing usable', () => {
     expect(oneLineDescription('', '# only a heading')).toBe('');
   });
+  test('folds a literal block-scalar (|) description into one line', () => {
+    const raw = 'name: browse\ndescription: |\n  Fast headless browser for QA.\n  Navigate any URL.\nallowed-tools:\n  - Bash';
+    expect(oneLineDescription(raw, '# h\nbody')).toBe(
+      'Fast headless browser for QA. Navigate any URL.',
+    );
+  });
+  test('folds a folded block-scalar (>) description', () => {
+    expect(oneLineDescription('description: >\n  one two\n  three', 'body')).toBe(
+      'one two three',
+    );
+  });
+  test('handles block-scalar chomping indicators (|-)', () => {
+    expect(oneLineDescription('description: |-\n  trimmed text', 'body')).toBe('trimmed text');
+  });
+  test('never leaks a bare block indicator; empty block falls back to body', () => {
+    // regression: `description: |` with no content used to surface as "|"
+    expect(oneLineDescription('description: |\nname: x', '# H\nReal body line.')).toBe(
+      'Real body line.',
+    );
+  });
 });
 
 describe('crossReferenceTools', () => {


### PR DESCRIPTION
## Summary

Fixes #1711 — `list_skills` / `get_skill` returned the literal YAML block-scalar indicator (`|` or `>`) as a skill's description for any `SKILL.md` authored with `description: |` (or `>`).

## Root cause

`src/core/skill-catalog.ts` → `parseDescriptionField`:

```js
const m = raw.match(/^description:\s*["']?(.+?)["']?\s*$/m);
...
return v.length > 0 ? v : undefined;   // returns "|" for `description: |`
```

The single-line regex captured the block indicator `|` (length 1 > 0), so `oneLineDescription`'s `?? firstProseLine(body)` fallback never fired.

## Fix

`parseDescriptionField` now detects a block-scalar header (`|`/`>` with optional chomping `+`/`-` and indent digit, optional trailing comment), folds the following indented lines into a single line, and returns `undefined` for an empty block so the body fallback still works. Inline (and quoted) descriptions are unchanged.

## Tests

Added 4 cases to the existing `oneLineDescription` suite in `test/skill-catalog.test.ts`:
- folds a literal block scalar (`|`)
- folds a folded block scalar (`>`)
- handles chomping indicators (`|-`)
- never leaks a bare indicator; empty block falls back to body (regression)

```
bun test test/skill-catalog.test.ts   → 19 pass / 0 fail
bun run verify                         → 29 checks, all green
```

Scope: catalog-display only; no data path or `get_skill` body change.
