### PR TITLE
fix: preserve cycle engine during lint phase

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -26,6 +26,7 @@ import {
 } from '../core/content-sanity.ts';
 import { loadOperatorLiterals } from '../core/content-sanity-literals.ts';
 import { loadConfig, loadConfigWithEngine, gbrainPath } from '../core/config.ts';
+import type { BrainEngine } from '../core/engine.ts';
 
 export interface LintIssue {
   file: string;
@@ -295,32 +296,46 @@ export function fixContent(content: string): string {
  * Also loads the operator literals file (`~/.gbrain/junk-substrings.txt`)
  * once per lint invocation so multi-file lint runs amortize the read.
  */
-async function resolveLintContentSanity(): Promise<LintContentOpts['contentSanity']> {
+async function resolveLintContentSanity(engine?: BrainEngine | null): Promise<LintContentOpts['contentSanity']> {
   const base = loadConfig();
   let cs = base?.content_sanity;
 
-  // DB-plane lift: only attempt when the file/env config suggests an
-  // engine is configured. Avoids spinning up a fresh PGLite just to
-  // read 4 config keys in a CI lint run that has no brain at all.
-  const hasEngineConfig = !!(base?.database_url || base?.database_path);
-  if (hasEngineConfig) {
+  // DB-plane lift: prefer a caller-owned engine when one already exists
+  // (e.g. `dream full` / cycle). That avoids opening and disconnecting a
+  // temporary module-singleton Postgres engine inside lint while later phases
+  // still expect the cycle-owned engine to remain connected.
+  if (engine) {
     try {
-      const { createEngine } = await import('../core/engine-factory.ts');
-      const engine = await createEngine({
-        engine: base!.engine,
-        database_url: base!.database_url,
-        database_path: base!.database_path,
-      });
-      try {
-        await engine.connect({});
-        const lifted = await loadConfigWithEngine(engine, base);
-        cs = lifted?.content_sanity ?? cs;
-      } finally {
-        await engine.disconnect().catch(() => { /* best-effort cleanup */ });
-      }
+      const lifted = await loadConfigWithEngine(engine, base);
+      cs = lifted?.content_sanity ?? cs;
     } catch {
       // Engine unreachable or failed mid-probe — fall through to
       // file/env values. Lint should never block on engine state.
+    }
+  } else {
+    // DB-plane lift: only attempt when the file/env config suggests an
+    // engine is configured. Avoids spinning up a fresh PGLite just to
+    // read 4 config keys in a CI lint run that has no brain at all.
+    const hasEngineConfig = !!(base?.database_url || base?.database_path);
+    if (hasEngineConfig) {
+      try {
+        const { createEngine } = await import('../core/engine-factory.ts');
+        const temporaryEngine = await createEngine({
+          engine: base!.engine,
+          database_url: base!.database_url,
+          database_path: base!.database_path,
+        });
+        try {
+          await temporaryEngine.connect({});
+          const lifted = await loadConfigWithEngine(temporaryEngine, base);
+          cs = lifted?.content_sanity ?? cs;
+        } finally {
+          await temporaryEngine.disconnect().catch(() => { /* best-effort cleanup */ });
+        }
+      } catch {
+        // Engine unreachable or failed mid-probe — fall through to
+        // file/env values. Lint should never block on engine state.
+      }
     }
   }
 
@@ -361,6 +376,10 @@ export interface LintOpts {
    *  `runLintCore` resolves via the file/env/DB chain. Tests inject
    *  this directly to bypass the FS + engine layers. */
   contentSanity?: LintContentOpts['contentSanity'];
+  /** v0.41.40: caller-owned engine. When a cycle already has an engine,
+   *  pass it through so content-sanity DB config is read without opening
+   *  and later disconnecting a temporary module-singleton Postgres engine. */
+  engine?: BrainEngine | null;
 }
 
 export interface LintResult {
@@ -392,7 +411,7 @@ export async function runLintCore(opts: LintOpts): Promise<LintResult> {
   // Resolve content-sanity config once for this lint run (D1: lift DB
   // config when reachable). Caller can pre-pass via opts.contentSanity
   // (tests, Minion handler) to bypass the engine probe entirely.
-  const contentSanity = opts.contentSanity ?? await resolveLintContentSanity();
+  const contentSanity = opts.contentSanity ?? await resolveLintContentSanity(opts.engine);
   const lintOpts: LintContentOpts = { contentSanity };
 
   let totalIssues = 0;

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -700,10 +700,10 @@ function checkAborted(signal?: AbortSignal): void {
 // keyword is the minimal seam that lets behavioral tests drive the
 // wrapper's result-mapping (counter → status enum + summary) without
 // going through runCycle's full setup cost.
-export async function runPhaseLint(brainDir: string, dryRun: boolean): Promise<PhaseResult> {
+export async function runPhaseLint(brainDir: string, dryRun: boolean, engine?: BrainEngine | null): Promise<PhaseResult> {
   try {
     const { runLintCore } = await import('../commands/lint.ts');
-    const result = await runLintCore({ target: brainDir, fix: true, dryRun });
+    const result = await runLintCore({ target: brainDir, fix: true, dryRun, engine });
     const issues = result.total_issues ?? 0;
     const fixed = result.total_fixed ?? 0;
     const remaining = Math.max(0, issues - fixed);
@@ -1481,7 +1481,7 @@ export async function runCycle(
         phaseResults.push(skipNoBrainDir('lint'));
       } else {
         progress.start('cycle.lint');
-        const { result, duration_ms } = await timePhase(() => runPhaseLint(brainDir, dryRun));
+        const { result, duration_ms } = await timePhase(() => runPhaseLint(brainDir, dryRun, engine));
         result.duration_ms = duration_ms;
         phaseResults.push(result);
         progress.finish();

--- a/test/core/cycle.serial.test.ts
+++ b/test/core/cycle.serial.test.ts
@@ -15,7 +15,7 @@ import { existsSync, unlinkSync } from 'fs';
 // ─── Mocks ──────────────────────────────────────────────────────────
 // Track what each phase was called with so tests can assert.
 
-let lintCalls: Array<{ target: string; fix: boolean; dryRun: boolean | undefined }> = [];
+let lintCalls: Array<{ target: string; fix: boolean; dryRun: boolean | undefined; engine: unknown }> = [];
 let backlinksCalls: Array<{ action: string; dir: string; dryRun: boolean | undefined }> = [];
 let syncCalls: Array<{ dryRun: boolean | undefined; noPull: boolean | undefined; noExtract: boolean | undefined; sourceId: string | undefined }> = [];
 let extractCalls: Array<{ mode: string; dir: string; slugs: string[] | undefined }> = [];
@@ -25,7 +25,7 @@ let orphansCalls: number = 0;
 // Mock lint
 mock.module('../../src/commands/lint.ts', () => ({
   runLintCore: async (opts: any) => {
-    lintCalls.push({ target: opts.target, fix: opts.fix, dryRun: opts.dryRun });
+    lintCalls.push({ target: opts.target, fix: opts.fix, dryRun: opts.dryRun, engine: opts.engine });
     return { total_issues: 2, total_fixed: opts.dryRun ? 0 : 2, pages_scanned: 5 };
   },
 }));
@@ -208,6 +208,12 @@ describe('runCycle — phase selection', () => {
     expect(lintCalls.length).toBe(1);
     expect(backlinksCalls.length).toBe(0);
     expect(syncCalls.length).toBe(0);
+  });
+
+  test('cycle-owned engine is threaded into lint during full cycles', async () => {
+    await runCycle(sharedEngine, { brainDir: '/tmp/brain', phases: ['lint', 'sync'] });
+
+    expect(lintCalls.at(-1)?.engine).toBe(sharedEngine);
   });
 
   test('--phase orphans only runs orphans', async () => {


### PR DESCRIPTION
## Summary
- Thread the cycle-owned BrainEngine into the lint phase.
- Reuse caller-owned engine when resolving content-sanity config.
- Avoid creating and disconnecting a temporary engine during full dream/cycle lint.

## Test Plan
- bun test test/core/cycle.serial.test.ts --test-name-pattern 'cycle-owned engine is threaded into lint during full cycles'
- bun test test/core/cycle.serial.test.ts
- bun test test/lint.test.ts test/lint-content-sanity.test.ts test/post-write-lint.test.ts
- bun run verify
