### PR TITLE
fix(extract): thread source id through fs-walk path (closes #1503 defect 1)

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -375,6 +375,20 @@ export interface ExtractOpts {
    * own pagination and stay serial in v0.41.15.0.
    */
   workers?: number;
+  /**
+   * Brain source id to stamp on extracted fs-walk rows (#1503 fix).
+   *
+   * The fs-walk extractors build LinkBatchInput / TimelineBatchInput rows
+   * with no source_id, so addLinksBatch / addTimelineEntriesBatch map
+   * missing → literal 'default'. On a brain whose content lives in a
+   * non-'default' source (e.g. 'wiki'), the batch INSERT's
+   * `JOIN pages ON (slug, source_id='default')` drops EVERY row → 0 inserted,
+   * no error (the "created 0 from N pages" silent no-op). Threading the
+   * resolved source id here stamps from/to/origin_source_id so the JOIN
+   * matches. When undefined, rows fall back to 'default' as before (single
+   * 'default'-source brains unaffected).
+   */
+  sourceId?: string;
 }
 
 /**
@@ -413,7 +427,7 @@ export async function runExtractCore(engine: BrainEngine, opts: ExtractOpts): Pr
       // Nothing changed — skip entirely.
       return result;
     }
-    const r = await extractForSlugs(engine, opts.dir, opts.slugs, opts.mode, dryRun, jsonMode, workers);
+    const r = await extractForSlugs(engine, opts.dir, opts.slugs, opts.mode, dryRun, jsonMode, workers, opts.sourceId);
     result.links_created = r.links_created;
     result.timeline_entries_created = r.timeline_created;
     result.pages_processed = r.pages;
@@ -422,12 +436,12 @@ export async function runExtractCore(engine: BrainEngine, opts: ExtractOpts): Pr
 
   // Full walk path: CLI `gbrain extract` or first-run.
   if (opts.mode === 'links' || opts.mode === 'all') {
-    const r = await extractLinksFromDir(engine, opts.dir, dryRun, jsonMode, workers);
+    const r = await extractLinksFromDir(engine, opts.dir, dryRun, jsonMode, workers, opts.sourceId);
     result.links_created = r.created;
     result.pages_processed = r.pages;
   }
   if (opts.mode === 'timeline' || opts.mode === 'all') {
-    const r = await extractTimelineFromDir(engine, opts.dir, dryRun, jsonMode, workers);
+    const r = await extractTimelineFromDir(engine, opts.dir, dryRun, jsonMode, workers, opts.sourceId);
     result.timeline_entries_created = r.created;
     result.pages_processed = Math.max(result.pages_processed, r.pages);
   }
@@ -702,12 +716,22 @@ Status (v0.42):
         }
       }
     } else {
+      // #1503 fix: resolve the brain source id and thread it into the fs-walk
+      // extractors so batch rows carry from/to_source_id. Without this they
+      // default to 'default' and addLinksBatch's JOIN drops every row on a
+      // non-'default' brain → silent "created 0 from N pages". Resolution
+      // honors --source-id, then GBRAIN_SOURCE/.gbrain-source/registered-path/
+      // sole-non-default, mirroring the source-aware inline hooks
+      // (extractLinksForSlugs) that #1204 confirmed correct.
+      const { resolveSourceId } = await import('../core/source-resolver.ts');
+      const resolvedSourceId = await resolveSourceId(engine, sourceIdFilter, brainDir);
       result = await runExtractCore(engine, {
         mode: subcommand as 'links' | 'timeline' | 'all',
         dir: brainDir,
         dryRun,
         jsonMode,
         workers,
+        sourceId: resolvedSourceId,
       });
     }
   } catch (e) {
@@ -745,6 +769,8 @@ async function extractForSlugs(
   // shared flush primitive; JS single-threaded event loop makes the
   // shared counter increments atomic.
   workers: number = 1,
+  // #1503 fix: stamp resolved brain source id on batch rows.
+  sourceId?: string,
 ): Promise<{ links_created: number; timeline_created: number; pages: number }> {
   // Build the full slug set for link resolution (fast: just readdir, no file reads)
   const allFiles = walkMarkdownFiles(brainDir);
@@ -818,7 +844,9 @@ async function extractForSlugs(
               if (!jsonMode) console.log(`  ${link.from_slug} → ${link.to_slug} (${link.link_type})`);
               linksCreated++;
             } else {
-              linkBatch.push(link);
+              linkBatch.push(sourceId
+                ? { ...link, from_source_id: sourceId, to_source_id: sourceId, origin_source_id: sourceId }
+                : link);
               if (linkBatch.length >= BATCH_SIZE) await flushLinks();
             }
           }
@@ -831,7 +859,7 @@ async function extractForSlugs(
               if (!jsonMode) console.log(`  ${entry.slug}: ${entry.date} — ${entry.summary}`);
               timelineCreated++;
             } else {
-              timelineBatch.push({ slug: entry.slug, date: entry.date, source: entry.source, summary: entry.summary, detail: entry.detail });
+              timelineBatch.push({ slug: entry.slug, date: entry.date, source: entry.source, summary: entry.summary, detail: entry.detail, ...(sourceId ? { source_id: sourceId } : {}) });
               if (timelineBatch.length >= BATCH_SIZE) await flushTimeline();
             }
           }
@@ -859,6 +887,9 @@ async function extractLinksFromDir(
   engine: BrainEngine, brainDir: string, dryRun: boolean, jsonMode: boolean,
   // v0.41.15.0 (T7): in-process worker count. Default 1.
   workers: number = 1,
+  // #1503 fix: stamp resolved brain source id on batch rows so the
+  // addLinksBatch JOIN matches non-'default' source pages.
+  sourceId?: string,
 ): Promise<{ created: number; pages: number }> {
   const files = walkMarkdownFiles(brainDir);
   const allSlugs = new Set(files.map(f => pathToSlug(f.relPath)));
@@ -907,7 +938,9 @@ async function extractLinksFromDir(
             if (!jsonMode) console.log(`  ${link.from_slug} → ${link.to_slug} (${link.link_type})`);
             created++;
           } else {
-            batch.push(link);
+            batch.push(sourceId
+              ? { ...link, from_source_id: sourceId, to_source_id: sourceId, origin_source_id: sourceId }
+              : link);
             if (batch.length >= BATCH_SIZE) await flush();
           }
         }
@@ -929,6 +962,9 @@ async function extractTimelineFromDir(
   engine: BrainEngine, brainDir: string, dryRun: boolean, jsonMode: boolean,
   // v0.41.15.0 (T7): in-process worker count. Default 1.
   workers: number = 1,
+  // #1503 fix: stamp resolved brain source id so addTimelineEntriesBatch
+  // matches non-'default' source pages.
+  sourceId?: string,
 ): Promise<{ created: number; pages: number }> {
   const files = walkMarkdownFiles(brainDir);
 
@@ -972,7 +1008,7 @@ async function extractTimelineFromDir(
             if (!jsonMode) console.log(`  ${entry.slug}: ${entry.date} — ${entry.summary}`);
             created++;
           } else {
-            batch.push({ slug: entry.slug, date: entry.date, source: entry.source, summary: entry.summary, detail: entry.detail });
+            batch.push({ slug: entry.slug, date: entry.date, source: entry.source, summary: entry.summary, detail: entry.detail, ...(sourceId ? { source_id: sourceId } : {}) });
             if (batch.length >= BATCH_SIZE) await flush();
           }
         }


### PR DESCRIPTION
Closes #1503 (defect 1).

## Problem

The fs-walk extractors (`extractLinksFromDir` / `extractTimelineFromDir` / `extractForSlugs`) build `LinkBatchInput` / `TimelineBatchInput` rows **without a `source_id`**. `addLinksBatch` / `addTimelineEntriesBatch` then map the missing value to the literal `'default'` and INNER-JOIN `pages ON (slug, source_id='default')`. On a brain whose content lives in a non-`default` source, every row is dropped by the JOIN → **0 inserted, no error** — the silent `Links: created 0 from N pages` no-op.

This is the same root cause as #1204 Bug 1, but reached via the **fs full-walk** path instead of the DB path. #1204 added `--source-id` only to the DB extractors, so even `gbrain extract all --source fs --source-id <id>` still wrote 0 on a federated brain. (This is #1503 **defect 1**; the CLI surface, complementary to the cycle surface described in the issue.)

## Fix

- `ExtractOpts` gains `sourceId?: string`.
- `runExtract`'s fs branch resolves it via the canonical `resolveSourceId` (honors `--source-id`, then `GBRAIN_SOURCE`, `.gbrain-source`, registered `local_path`, sole-non-default) and threads it into `runExtractCore` → the three fs-walk extractors.
- Those stamp `from_source_id`/`to_source_id`/`origin_source_id` on link rows and `source_id` on timeline rows. When unresolved it stays `'default'` (single-`default`-source brains unaffected).
- Mirrors the already-correct inline hooks `extractLinksForSlugs` / `extractTimelineForSlugs` that #1204 confirmed correct.

## Verification

On a `wiki`-source brain (~1900 pages):

```
# before this patch
$ gbrain extract all --source fs --source-id wiki
{ "links_created": 0, "timeline_entries_created": 0, "pages_processed": 1916 }   # dry-run reported 678/117

# after
$ gbrain extract all --source fs --source-id wiki
{ "links_created": 660, "timeline_entries_created": 117, "pages_processed": 1916 }
```

All resulting link rows land under `source_id='wiki'` (verified in Postgres). Extract test suite passes (`extract-source-aware`, `extract-incremental`, `extract-by-mention`, `extract-batch-retry`): 0 fail.

## Out of scope (separate follow-ups)

- #1503 **defect 2** — the cycle's `noExtract: willRunExtractPhase` disables the working source-aware inline path and defers to the (previously broken) full-walk phase. This PR fixes the full-walk path itself; re-enabling/choosing between paths in the cycle is a separate change.
- Basename/case wikilink resolution (#1188) — unrelated resolution gap; this PR only addresses source-id threading on rows that already resolve.
