### PR TITLE
feat: support multi-root MCP skill catalog

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -262,6 +262,16 @@ export interface GBrainConfig {
      * tier so a hosted gbrain never serves its own bundled dev skills).
      */
     skills_dir?: string;
+    /**
+     * Multi-host skill roots for the MCP skill catalog. When present, this
+     * supersedes `skills_dir` and lets one gbrain publish a unified catalog for
+     * several execution hosts without copying their skills into one directory.
+     */
+    skill_roots?: Array<{
+      name: string;
+      dir: string;
+      priority?: number;
+    }>;
   };
 }
 
@@ -697,6 +707,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'mcp.publish_skills',
   'mcp.publish_skills_prompted',
   'mcp.skills_dir',
+  'mcp.skill_roots',
   // Misc
   'artifacts_sync_mode',
   'cross_project_learnings',

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -2001,9 +2001,13 @@ const list_skills: Operation = {
     const sc = await import('./skill-catalog.ts');
     const publish = await sc.readMcpPublishSkills(ctx);
     sc.assertPublishEnabled(ctx, publish);
+    const roots = sc.resolveSkillRoots(await sc.readMcpSkillRoots(ctx));
+    const section = typeof p.section === 'string' ? p.section : undefined;
+    if (roots.length > 0) {
+      return sc.buildSkillCatalogFromRoots(ctx, roots, { section });
+    }
     const override = await sc.readMcpSkillsDir(ctx);
     const { dir, source } = sc.resolveSkillsDir(ctx, override);
-    const section = typeof p.section === 'string' ? p.section : undefined;
     return sc.buildSkillCatalog(ctx, dir, source, { section });
   },
   scope: 'read',
@@ -2024,9 +2028,13 @@ const get_skill: Operation = {
     const sc = await import('./skill-catalog.ts');
     const publish = await sc.readMcpPublishSkills(ctx);
     sc.assertPublishEnabled(ctx, publish);
+    const name = typeof p.name === 'string' ? p.name : '';
+    const roots = sc.resolveSkillRoots(await sc.readMcpSkillRoots(ctx));
+    if (roots.length > 0) {
+      return sc.getSkillDetailFromRoots(ctx, roots, name);
+    }
     const override = await sc.readMcpSkillsDir(ctx);
     const { dir } = sc.resolveSkillsDir(ctx, override);
-    const name = typeof p.name === 'string' ? p.name : '';
     return sc.getSkillDetail(ctx, dir, name);
   },
   scope: 'read',

--- a/src/core/skill-catalog.ts
+++ b/src/core/skill-catalog.ts
@@ -77,12 +77,28 @@ const MAX_SKILL_NAME_LEN = 128;
 /** Where auto-detect found the dir, plus the explicit-config variant. */
 export type ResolvedSkillsDirSource = SkillsDirSource | 'config';
 
+export interface SkillRootConfig {
+  name: string;
+  dir: string;
+  priority?: number;
+}
+
+export interface ResolvedSkillRoot {
+  name: string;
+  dir: string;
+  source: ResolvedSkillsDirSource | 'config_multi';
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 export interface SkillCatalogEntry {
   name: string;
+  /** Original skill name inside its source root. Present for multi-root catalogs. */
+  canonical_name?: string;
+  /** Logical root name from `mcp.skill_roots`. Present for multi-root catalogs. */
+  source_root?: string;
   description: string;
   section: string;
   triggers: string[];
@@ -97,7 +113,9 @@ export interface SkillCatalogEntry {
 
 export interface ListSkillsResult {
   schema_version: 1;
-  skills_dir_source: ResolvedSkillsDirSource;
+  skills_dir_source: ResolvedSkillsDirSource | 'config_multi';
+  /** Logical roots used for a multi-root catalog. Absolute host paths are not exposed. */
+  skill_roots?: Array<{ name: string; source: ResolvedSkillRoot['source'] }>;
   count: number;
   skills: SkillCatalogEntry[];
   instructions: {
@@ -111,6 +129,8 @@ export interface ListSkillsResult {
 export interface GetSkillResult {
   schema_version: 1;
   name: string;
+  canonical_name?: string;
+  source_root?: string;
   /** Allowlisted projection — never the raw frontmatter object. */
   frontmatter: {
     name?: string;
@@ -166,6 +186,96 @@ export async function readMcpSkillsDir(ctx: OperationContext): Promise<string | 
   if (dbVal && dbVal.trim().length > 0) return dbVal;
   const fileVal = ctx.config?.mcp?.skills_dir;
   return fileVal && fileVal.trim().length > 0 ? fileVal : undefined;
+}
+
+function parseSkillRoots(raw: unknown): SkillRootConfig[] | undefined {
+  if (raw == null) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  } catch {
+    throw new OperationError(
+      'invalid_params',
+      'mcp.skill_roots must be valid JSON.',
+      'Use a JSON array like [{"name":"codex","dir":"/path/to/skills"}].',
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new OperationError(
+      'invalid_params',
+      'mcp.skill_roots must be a JSON array.',
+      'Use a JSON array like [{"name":"codex","dir":"/path/to/skills"}].',
+    );
+  }
+  const roots = parsed.map((item, i): SkillRootConfig => {
+    if (typeof item !== 'object' || item === null) {
+      throw new OperationError('invalid_params', `mcp.skill_roots[${i}] must be an object.`);
+    }
+    const name = (item as SkillRootConfig).name;
+    const dir = (item as SkillRootConfig).dir;
+    const priority = (item as SkillRootConfig).priority;
+    if (typeof name !== 'string' || name.trim().length === 0) {
+      throw new OperationError('invalid_params', `mcp.skill_roots[${i}].name must be a non-empty string.`);
+    }
+    if (typeof dir !== 'string' || dir.trim().length === 0) {
+      throw new OperationError('invalid_params', `mcp.skill_roots[${i}].dir must be a non-empty string.`);
+    }
+    if (priority != null && typeof priority !== 'number') {
+      throw new OperationError('invalid_params', `mcp.skill_roots[${i}].priority must be a number.`);
+    }
+    return { name: name.trim(), dir: dir.trim(), priority };
+  });
+  return roots.length > 0 ? roots : undefined;
+}
+
+/**
+ * Read `mcp.skill_roots` from the DB plane, falling back to the file plane.
+ * When present, it supersedes `mcp.skills_dir` so one gbrain can publish a
+ * multi-host catalog without copying skills into a synthetic directory.
+ */
+export async function readMcpSkillRoots(ctx: OperationContext): Promise<SkillRootConfig[] | undefined> {
+  let dbVal: string | null = null;
+  try {
+    dbVal = await ctx.engine.getConfig('mcp.skill_roots');
+  } catch {
+    // ignore — fall through to file plane
+  }
+  if (dbVal && dbVal.trim().length > 0) return parseSkillRoots(dbVal);
+  return parseSkillRoots(ctx.config?.mcp?.skill_roots);
+}
+
+function assertRootNameShape(name: string): void {
+  if (!/^[A-Za-z0-9_.-]+$/.test(name)) {
+    throw new OperationError(
+      'invalid_params',
+      `Invalid skill root name: ${name}`,
+      'Root names may contain letters, digits, underscore, dot, and dash only.',
+    );
+  }
+}
+
+export function resolveSkillRoots(roots: SkillRootConfig[] | undefined): ResolvedSkillRoot[] {
+  if (!roots || roots.length === 0) return [];
+
+  const seen = new Set<string>();
+  return [...roots]
+    .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
+    .map((root): ResolvedSkillRoot => {
+      assertRootNameShape(root.name);
+      if (seen.has(root.name)) {
+        throw new OperationError('invalid_params', `Duplicate skill root name: ${root.name}`);
+      }
+      seen.add(root.name);
+      const dir = resolve(root.dir);
+      if (!existsSync(dir)) {
+        throw new OperationError(
+          'storage_error',
+          `Configured mcp.skill_roots dir does not exist: ${root.dir}`,
+          'Fix it with `gbrain config set mcp.skill_roots ...` or remove the missing root.',
+        );
+      }
+      return { name: root.name, dir, source: 'config_multi' };
+    });
 }
 
 /**
@@ -246,6 +356,63 @@ export function resolveSkillMdPath(skillsDir: string, name: string): string {
     );
   }
   return confineManifestPath(skillsDir, entry);
+}
+
+interface RootSkillMatch {
+  root: ResolvedSkillRoot;
+  canonicalName: string;
+}
+
+function splitRootQualifiedName(name: string): { rootName?: string; skillName: string } {
+  assertSkillNameShape(name);
+  const idx = name.indexOf(':');
+  if (idx < 0) return { skillName: name };
+  const rootName = name.slice(0, idx);
+  const skillName = name.slice(idx + 1);
+  assertRootNameShape(rootName);
+  assertSkillNameShape(skillName);
+  return { rootName, skillName };
+}
+
+function findSkillInRoots(roots: ResolvedSkillRoot[], name: string): RootSkillMatch {
+  const { rootName, skillName } = splitRootQualifiedName(name);
+  if (rootName) {
+    const root = roots.find(r => r.name === rootName);
+    if (!root) {
+      throw new OperationError('page_not_found', `Skill root not found: ${rootName}`);
+    }
+    // Let the single-root resolver enforce manifest/path confinement.
+    resolveSkillMdPath(root.dir, skillName);
+    return { root, canonicalName: skillName };
+  }
+
+  const matches: RootSkillMatch[] = [];
+  for (const root of roots) {
+    try {
+      resolveSkillMdPath(root.dir, skillName);
+      matches.push({ root, canonicalName: skillName });
+    } catch (e) {
+      if (e instanceof OperationError && e.code === 'page_not_found') continue;
+      // A malformed entry should not make name lookup silently succeed elsewhere.
+      throw e;
+    }
+  }
+  if (matches.length === 0) {
+    throw new OperationError(
+      'page_not_found',
+      `Skill not found: ${skillName}`,
+      'Call list_skills to see available skills.',
+    );
+  }
+  if (matches.length > 1) {
+    const names = matches.map(m => `${m.root.name}:${skillName}`).join(', ');
+    throw new OperationError(
+      'invalid_params',
+      `Skill name '${skillName}' exists in multiple roots.`,
+      `Use one of the names returned by list_skills: ${names}`,
+    );
+  }
+  return matches[0];
 }
 
 /**
@@ -465,6 +632,59 @@ export function buildSkillCatalog(
   };
 }
 
+/**
+ * Build a unified catalog across several host skill roots. Duplicate skill
+ * names are published as `root:name`; unique names keep their short form.
+ */
+export function buildSkillCatalogFromRoots(
+  ctx: OperationContext,
+  roots: ResolvedSkillRoot[],
+  opts: { section?: string } = {},
+): ListSkillsResult {
+  const merged: SkillCatalogEntry[] = [];
+  for (const root of roots) {
+    const catalog = buildSkillCatalog(ctx, root.dir, root.source === 'config_multi' ? 'config' : root.source, opts);
+    for (const skill of catalog.skills) {
+      merged.push({
+        ...skill,
+        canonical_name: skill.name,
+        source_root: root.name,
+      });
+    }
+  }
+
+  const counts = new Map<string, number>();
+  for (const skill of merged) {
+    const canonical = skill.canonical_name ?? skill.name;
+    counts.set(canonical, (counts.get(canonical) ?? 0) + 1);
+  }
+
+  const skills = merged.map(skill => {
+    const canonical = skill.canonical_name ?? skill.name;
+    const sourceRoot = skill.source_root;
+    if (sourceRoot && (counts.get(canonical) ?? 0) > 1) {
+      return { ...skill, name: `${sourceRoot}:${canonical}` };
+    }
+    return skill;
+  });
+
+  skills.sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    schema_version: 1,
+    skills_dir_source: 'config_multi',
+    skill_roots: roots.map(r => ({ name: r.name, source: r.source })),
+    count: skills.length,
+    skills,
+    instructions: {
+      summary: SKILL_CATALOG_INSTRUCTIONS.summary,
+      how_to_use: [...SKILL_CATALOG_INSTRUCTIONS.how_to_use],
+      available_brain_tools: availableBrainTools(ctx),
+      fetch_op: 'get_skill',
+    },
+  };
+}
+
 /** Fetch one skill's full instructions (prose only, size-capped, sanitized). */
 export function getSkillDetail(
   ctx: OperationContext,
@@ -513,6 +733,25 @@ export function getSkillDetail(
       available_brain_tools: availableBrainTools(ctx),
       mutating,
     },
+  };
+}
+
+/** Fetch one skill from a multi-root catalog. */
+export function getSkillDetailFromRoots(
+  ctx: OperationContext,
+  roots: ResolvedSkillRoot[],
+  name: string,
+): GetSkillResult {
+  const match = findSkillInRoots(roots, name);
+  const detail = getSkillDetail(ctx, match.root.dir, match.canonicalName);
+  const publishedName = name.includes(':')
+    ? `${match.root.name}:${match.canonicalName}`
+    : detail.name;
+  return {
+    ...detail,
+    name: publishedName,
+    canonical_name: match.canonicalName,
+    source_root: match.root.name,
   };
 }
 

--- a/test/fixtures/skill-catalog/other-skills/brain-ops/SKILL.md
+++ b/test/fixtures/skill-catalog/other-skills/brain-ops/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: brain-ops
+description: Alternate host brain ops.
+triggers:
+  - alternate brain ops
+tools:
+  - search
+writes_pages: false
+mutating: false
+---
+
+# brain-ops
+
+Alternate host body.

--- a/test/fixtures/skill-catalog/other-skills/codex-tool/SKILL.md
+++ b/test/fixtures/skill-catalog/other-skills/codex-tool/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: codex-tool
+description: Codex-only tool fixture.
+triggers:
+  - codex only
+tools:
+  - search
+writes_pages: false
+mutating: false
+---
+
+# codex-tool
+
+Codex-only fixture body.

--- a/test/skill-catalog-transports.test.ts
+++ b/test/skill-catalog-transports.test.ts
@@ -21,6 +21,7 @@ import { dispatchToolCall } from '../src/mcp/dispatch.ts';
 import type { AuthInfo } from '../src/core/operations.ts';
 
 const FIXTURE = join(import.meta.dir, 'fixtures', 'skill-catalog', 'skills');
+const OTHER_FIXTURE = join(import.meta.dir, 'fixtures', 'skill-catalog', 'other-skills');
 
 let engine: PGLiteEngine;
 let home: string;
@@ -106,6 +107,23 @@ describe('list_skills over dispatch', () => {
       expect(r.body.error).toBe('permission_denied');
     });
   });
+
+  test('mcp.skill_roots publishes a unified multi-root catalog', async () => {
+    await withEnv({ GBRAIN_HOME: home }, async () => {
+      await engine.setConfig('mcp.publish_skills', 'true');
+      await engine.setConfig('mcp.skill_roots', JSON.stringify([
+        { name: 'host-a', dir: FIXTURE },
+        { name: 'host-b', dir: OTHER_FIXTURE },
+      ]));
+      const r = await call('list_skills', {}, { remote: true, auth: { token: 't', clientId: 'c', scopes: ['read'] } });
+      expect(r.isError).toBe(false);
+      expect(r.body.skills_dir_source).toBe('config_multi');
+      expect(r.body.skill_roots.map((s: any) => s.name)).toEqual(['host-a', 'host-b']);
+      expect(r.body.skills.map((s: any) => s.name)).toContain('host-a:brain-ops');
+      expect(r.body.skills.map((s: any) => s.name)).toContain('host-b:brain-ops');
+      expect(r.body.skills.map((s: any) => s.name)).toContain('codex-tool');
+    });
+  });
 });
 
 describe('get_skill over dispatch', () => {
@@ -136,6 +154,22 @@ describe('get_skill over dispatch', () => {
       const r = await call('get_skill', { name: 'nope' }, { remote: false });
       expect(r.isError).toBe(true);
       expect(r.body.error).toBe('page_not_found');
+    });
+  });
+
+  test('mcp.skill_roots fetches root-qualified duplicate skills', async () => {
+    await withEnv({ GBRAIN_HOME: home }, async () => {
+      await engine.setConfig('mcp.publish_skills', 'true');
+      await engine.setConfig('mcp.skill_roots', JSON.stringify([
+        { name: 'host-a', dir: FIXTURE },
+        { name: 'host-b', dir: OTHER_FIXTURE },
+      ]));
+      const r = await call('get_skill', { name: 'host-b:brain-ops' }, { remote: true, auth: { token: 't', clientId: 'c', scopes: ['read'] } });
+      expect(r.isError).toBe(false);
+      expect(r.body.name).toBe('host-b:brain-ops');
+      expect(r.body.source_root).toBe('host-b');
+      expect(r.body.canonical_name).toBe('brain-ops');
+      expect(r.body.body).toContain('Alternate host body');
     });
   });
 });

--- a/test/skill-catalog.test.ts
+++ b/test/skill-catalog.test.ts
@@ -3,13 +3,16 @@ import { join } from 'path';
 import type { OperationContext } from '../src/core/operations.ts';
 import {
   buildSkillCatalog,
+  buildSkillCatalogFromRoots,
   getSkillDetail,
+  getSkillDetailFromRoots,
   crossReferenceTools,
   oneLineDescription,
   resolveSkillMdPath,
 } from '../src/core/skill-catalog.ts';
 
 const FIXTURE = join(import.meta.dir, 'fixtures', 'skill-catalog', 'skills');
+const OTHER_FIXTURE = join(import.meta.dir, 'fixtures', 'skill-catalog', 'other-skills');
 
 /** Minimal ctx stub — the pure catalog functions only read remote/auth. */
 function ctx(remote: boolean, scopes?: string[]): OperationContext {
@@ -105,6 +108,36 @@ describe('buildSkillCatalog', () => {
   });
 });
 
+describe('buildSkillCatalogFromRoots', () => {
+  const roots = [
+    { name: 'host-a', dir: FIXTURE, source: 'config_multi' as const },
+    { name: 'host-b', dir: OTHER_FIXTURE, source: 'config_multi' as const },
+  ];
+
+  test('merges roots and namespaces duplicates only', () => {
+    const res = buildSkillCatalogFromRoots(ctx(true, ['read']), roots);
+    const names = res.skills.map(s => s.name).sort();
+    expect(res.skills_dir_source).toBe('config_multi');
+    expect(res.skill_roots?.map(r => r.name)).toEqual(['host-a', 'host-b']);
+    expect(names).toContain('host-a:brain-ops');
+    expect(names).toContain('host-b:brain-ops');
+    expect(names).toContain('codex-tool');
+    expect(names).toContain('query-helper');
+
+    const codexTool = res.skills.find(s => s.name === 'codex-tool')!;
+    expect(codexTool.source_root).toBe('host-b');
+    expect(codexTool.canonical_name).toBe('codex-tool');
+  });
+
+  test('section filter applies across every root', () => {
+    const all = buildSkillCatalogFromRoots(ctx(true, ['read']), roots);
+    const section = all.skills.find(s => s.name === 'codex-tool')!.section;
+    const filtered = buildSkillCatalogFromRoots(ctx(true, ['read']), roots, { section });
+    expect(filtered.skills.length).toBeGreaterThan(0);
+    expect(filtered.skills.every(s => s.section === section)).toBe(true);
+  });
+});
+
 describe('getSkillDetail', () => {
   test('returns prose body + allowlisted frontmatter (drops writes_to/sources)', () => {
     const res = getSkillDetail(ctx(true, ['read']), FIXTURE, 'brain-ops');
@@ -129,6 +162,33 @@ describe('getSkillDetail', () => {
     expect(res.unavailable_tools.sort()).toEqual(['put_page', 'web_search']);
     expect(res.client_guidance.mutating).toBe(true);
     expect(res.client_guidance.protocol.length).toBeGreaterThan(0);
+  });
+});
+
+describe('getSkillDetailFromRoots', () => {
+  const roots = [
+    { name: 'host-a', dir: FIXTURE, source: 'config_multi' as const },
+    { name: 'host-b', dir: OTHER_FIXTURE, source: 'config_multi' as const },
+  ];
+
+  test('fetches a unique skill by short name', () => {
+    const res = getSkillDetailFromRoots(ctx(true, ['read']), roots, 'codex-tool');
+    expect(res.name).toBe('codex-tool');
+    expect(res.canonical_name).toBe('codex-tool');
+    expect(res.source_root).toBe('host-b');
+    expect(res.body).toContain('Codex-only fixture body');
+  });
+
+  test('fetches a duplicate skill by root-qualified name', () => {
+    const res = getSkillDetailFromRoots(ctx(true, ['read']), roots, 'host-b:brain-ops');
+    expect(res.name).toBe('host-b:brain-ops');
+    expect(res.canonical_name).toBe('brain-ops');
+    expect(res.source_root).toBe('host-b');
+    expect(res.body).toContain('Alternate host body');
+  });
+
+  test('rejects an ambiguous unqualified duplicate', () => {
+    expect(() => getSkillDetailFromRoots(ctx(true, ['read']), roots, 'brain-ops')).toThrow(/multiple roots/);
   });
 });
 


### PR DESCRIPTION
## Summary

This adds optional multi-root support for the MCP skill catalog via `mcp.skill_roots`. It lets one gbrain MCP server publish skills from multiple host directories without copying skill files into one shared directory.

The existing single-root `mcp.skills_dir` behavior is unchanged. When `mcp.skill_roots` is configured, the catalog merges all configured roots and only namespaces duplicate skill names as `root:name`; unique skills keep their short names. `get_skill` supports both unique short names and root-qualified duplicate names.

## Why

Some users run gbrain alongside multiple agent hosts, each with its own skill directory. Copying skills between hosts creates drift and makes upgrades harder. A multi-root catalog lets gbrain act as the central MCP skill publisher while preserving each host's source-of-truth skill files.

## Changes

- Add `mcp.skill_roots` config support.
- Add multi-root catalog and detail helpers.
- Route MCP `list_skills` / `get_skill` through multi-root mode when configured.
- Preserve existing `mcp.skills_dir` behavior when no roots are configured.
- Add tests for merged catalogs, duplicate namespacing, root-qualified fetches, and transport dispatch.

## Validation

- `bun test test/skill-catalog.test.ts test/skill-catalog-security.test.ts test/skill-catalog-transports.test.ts`
