### PR TITLE
fix(skillopt): surface empty rollout failures

### DIFF
--- a/src/commands/skillopt.ts
+++ b/src/commands/skillopt.ts
@@ -311,6 +311,9 @@ export async function runSkillOptCommand(engine: BrainEngine | null, args: strin
       process.stderr.write(`[skillopt] Outcome: ${result.outcome}\n`);
       process.stderr.write(`[skillopt] Best sel-score: ${(result.receipt.best_sel_score ?? 0).toFixed(3)}\n`);
       process.stderr.write(`[skillopt] Final cost: $${(result.receipt.final_cost_usd ?? 0).toFixed(2)}\n`);
+      if ((result.outcome === 'errored' || result.outcome === 'aborted') && result.receipt.error_detail) {
+        process.stderr.write(`[skillopt] Error: ${result.receipt.error_detail}\n`);
+      }
       if (result.mutatedSkillFile) {
         process.stderr.write(`[skillopt] SKILL.md rewritten with ${result.receipt.total_steps ?? 0} optimization steps.\n`);
       } else if (result.proposedPath) {

--- a/src/core/skillopt/audit.ts
+++ b/src/core/skillopt/audit.ts
@@ -33,11 +33,11 @@ export type SkilloptEvent =
       'no_improvement' | 'aborted' | 'errored'; epochs_completed: number;
       total_steps: number; baseline_sel_score?: number; best_sel_score?: number;
       baseline_test_score?: number; test_score?: number; final_cost_usd: number;
-      ts: string }
+      error_detail?: string; ts: string }
   | { kind: 'abort'; run_id: string; skill: string; reason: 'budget_exhausted' |
       'runtime_exhausted' | 'dirty_tree' | 'lock_busy' | 'sentinel_pending' |
-      'bundled_skill_no_flag' | 'd_sel_too_small' | 'sigint'; detail?: string;
-      ts: string };
+      'bundled_skill_no_flag' | 'd_sel_too_small' | 'validation_failed' |
+      'internal_error' | 'sigint'; detail?: string; ts: string };
 
 let _writer: AuditWriter<SkilloptEvent> | null = null;
 

--- a/src/core/skillopt/orchestrator.ts
+++ b/src/core/skillopt/orchestrator.ts
@@ -93,7 +93,7 @@ import { preflight, formatPreflightReport } from './preflight.ts';
 import { isRejected, loadRejectedBuffer, makeRejectedEntry, saveRejectedBuffer } from './rejected-buffer.ts';
 import { runReflect } from './reflect.ts';
 import { acceptCandidate, bestPath, revertAllPending, skillPath } from './version-store.ts';
-import { runValidationGate } from './validate-gate.ts';
+import { runValidationGate, ValidationGateNoRolloutsError } from './validate-gate.ts';
 import type { SkillOptOpts, EditOp, RunReceipt } from './types.ts';
 
 export interface RunSkillOptResult {
@@ -278,6 +278,7 @@ async function runOptimizationLoop(
   let outcome: 'accepted' | 'no_improvement' | 'aborted' | 'errored' = 'no_improvement';
   let finalText = checkpoint.best_skill_text;
   let totalStepsRun = 0;
+  let runErrorDetail: string | undefined;
 
   try {
     await withBudgetTracker(tracker, async () => {
@@ -472,6 +473,7 @@ async function runOptimizationLoop(
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    runErrorDetail = msg;
     if (msg.includes('BudgetExhausted') || msg.includes('budget_exhausted')) {
       outcome = 'aborted';
       logEvent({
@@ -487,7 +489,7 @@ async function runOptimizationLoop(
         kind: 'abort',
         run_id: runId,
         skill: skillName,
-        reason: 'sigint',
+        reason: err instanceof ValidationGateNoRolloutsError ? 'validation_failed' : 'internal_error',
         detail: msg,
       } as never);
     }
@@ -530,6 +532,7 @@ async function runOptimizationLoop(
     final_cost_usd: tracker.snapshot().cumulativeCostUsd,
     total_steps: totalStepsRun,
     epochs_completed: checkpoint.last_completed_epoch,
+    ...(runErrorDetail ? { error_detail: runErrorDetail } : {}),
   };
 
   logEvent({
@@ -541,6 +544,7 @@ async function runOptimizationLoop(
     total_steps: totalStepsRun,
     best_sel_score: checkpoint.best_sel_score,
     final_cost_usd: tracker.snapshot().cumulativeCostUsd,
+    ...(runErrorDetail ? { error_detail: runErrorDetail } : {}),
   } as never);
 
   // Clean checkpoint on success (resume not needed).

--- a/src/core/skillopt/types.ts
+++ b/src/core/skillopt/types.ts
@@ -201,6 +201,8 @@ export interface RunReceipt {
   final_cost_usd?: number;
   total_steps?: number;
   epochs_completed?: number;
+  /** Present when outcome=errored; intended for CLI/JSON diagnostics. */
+  error_detail?: string;
 }
 
 export interface HistoryRow {

--- a/src/core/skillopt/validate-gate.ts
+++ b/src/core/skillopt/validate-gate.ts
@@ -27,6 +27,27 @@ import type { BenchmarkTask, GateInput, GateResult, ScoredRollout } from './type
 import { VALIDATION_EPSILON, VALIDATION_RUNS_PER_TASK } from './types.ts';
 import type { BrainEngine } from '../engine.ts';
 
+export interface ValidationGateFailure {
+  task_id: string;
+  error: string;
+}
+
+export class ValidationGateNoRolloutsError extends Error {
+  readonly code = 'validation_gate_no_rollouts' as const;
+  readonly failures: ValidationGateFailure[];
+
+  constructor(failures: ValidationGateFailure[]) {
+    const summary = failures
+      .slice(0, 3)
+      .map((f) => `${f.task_id}: ${f.error}`)
+      .join('; ');
+    const more = failures.length > 3 ? `; ... ${failures.length - 3} more` : '';
+    super(`validation gate produced zero scored rollouts; first errors: ${summary}${more}`);
+    this.name = 'ValidationGateNoRollouts';
+    this.failures = failures;
+  }
+}
+
 export interface ValidateGateOpts extends Omit<GateInput, 'selSet'> {
   selSet: BenchmarkTask[];
   engine: BrainEngine;
@@ -103,6 +124,12 @@ export async function runValidationGate(opts: ValidateGateOpts): Promise<GateRes
     return { task_id: opts.selSet[idx]!.task_id, median: 0, runs: [] };
   });
   const scoredRollouts: ScoredRollout[] = settled.flatMap((s) => (s && s.ok) ? s.value.rollouts : []);
+  if (opts.selSet.length > 0 && scoredRollouts.length === 0) {
+    throw new ValidationGateNoRolloutsError(settled.map((s, idx) => ({
+      task_id: opts.selSet[idx]!.task_id,
+      error: (s && !s.ok) ? formatThrown(s.error) : 'no rollout result',
+    })));
+  }
   const selScore = perTaskMedians.length === 0
     ? 0
     : perTaskMedians.reduce((acc, r) => acc + r.median, 0) / perTaskMedians.length;
@@ -128,4 +155,9 @@ export function median(values: readonly number[]): number {
   return sorted.length % 2 === 1
     ? sorted[mid]!
     : (sorted[mid - 1]! + sorted[mid]!) / 2;
+}
+
+function formatThrown(value: unknown): string {
+  if (value instanceof Error) return `${value.name}: ${value.message}`;
+  return String(value);
 }

--- a/test/e2e/skillopt-loop.serial.test.ts
+++ b/test/e2e/skillopt-loop.serial.test.ts
@@ -170,6 +170,8 @@ interface StubOpts {
    * exist in the skill". Override to simulate broken/idiosyncratic agents.
    */
   targetText?: (skillText: string) => string;
+  /** Throw from every target-agent rollout to simulate gateway/toolLoop failure. */
+  targetError?: Error | string;
   /**
    * Optional per-call usage override for the budget-exhaustion test. When
    * set, every chat call reports this usage (driving cumulative cost up
@@ -229,6 +231,9 @@ function installStub(opts: StubOpts): void {
     }
 
     // Target-agent rollout.
+    if (opts.targetError !== undefined) {
+      throw typeof opts.targetError === 'string' ? new Error(opts.targetError) : opts.targetError;
+    }
     const model = chatOpts.model ?? 'anthropic:claude-sonnet-4-6';
     const fn = opts.targetText ?? defaultTargetText;
     return makeChatResult(fn(sys), model, usage);
@@ -406,6 +411,33 @@ describe('skillopt full-loop E2E (happy path + broken cases)', () => {
 
           expect(result.outcome).toBe('no_improvement');
           expect(result.mutatedSkillFile).toBe(false);
+          expect(fs.readFileSync(skillPath(fixture.skillsDir, SKILL), 'utf8'))
+            .toBe(SKILL_PEOPLE_ONLY);
+          expect(loadHistory(fixture.skillsDir, SKILL).filter((r) => r.status === 'committed'))
+            .toHaveLength(0);
+        });
+      } finally {
+        uninstallStub();
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test('broken: all target rollouts fail surfaces errored, not no_improvement', async () => {
+    const fixture = setupFixture(SKILL_PEOPLE_ONLY);
+    try {
+      installStub({
+        targetError: 'gateway loop unavailable',
+      });
+      try {
+        await withEnv({ GBRAIN_AUDIT_DIR: fixture.skillsDir }, async () => {
+          const result = await runOnce(fixture);
+
+          expect(result.outcome).toBe('errored');
+          expect(result.mutatedSkillFile).toBe(false);
+          expect(result.receipt.error_detail).toContain('zero scored rollouts');
+          expect(result.receipt.error_detail).toContain('gateway loop unavailable');
           expect(fs.readFileSync(skillPath(fixture.skillsDir, SKILL), 'utf8'))
             .toBe(SKILL_PEOPLE_ONLY);
           expect(loadHistory(fixture.skillsDir, SKILL).filter((r) => r.status === 'committed'))

--- a/test/skillopt/validate-gate.test.ts
+++ b/test/skillopt/validate-gate.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  runValidationGate,
+  ValidationGateNoRolloutsError,
+} from '../../src/core/skillopt/validate-gate.ts';
+import type { BenchmarkTask, ScoredRollout, Trajectory } from '../../src/core/skillopt/types.ts';
+
+const TASKS: BenchmarkTask[] = [
+  { task_id: 'task-1', task: 'first task', judge: { kind: 'rule', checks: [{ op: 'contains', arg: 'ok' }] } },
+  { task_id: 'task-2', task: 'second task', judge: { kind: 'rule', checks: [{ op: 'contains', arg: 'ok' }] } },
+];
+
+function makeTrajectory(task: BenchmarkTask): Trajectory {
+  return {
+    task_id: task.task_id,
+    task: task.task,
+    final_text: 'ok',
+    tool_calls: [],
+    usage: { input_tokens: 1, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 },
+    turns: 1,
+    stop_reason: 'end',
+    duration_ms: 1,
+  };
+}
+
+describe('runValidationGate rollout failure handling', () => {
+  test('throws a diagnostic error when every rollout fails', async () => {
+    let thrown: unknown;
+    try {
+      await runValidationGate({
+        engine: {} as never,
+        candidateSkillText: 'skill body',
+        selSet: TASKS,
+        bestScore: -1,
+        targetModel: 'test:model',
+        rolloutFn: async () => {
+          throw new Error('gateway not configured');
+        },
+        scoreFn: async () => {
+          throw new Error('score should not run');
+        },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(ValidationGateNoRolloutsError);
+    const err = thrown as ValidationGateNoRolloutsError;
+    expect(err.code).toBe('validation_gate_no_rollouts');
+    expect(err.failures).toHaveLength(2);
+    expect(err.message).toContain('zero scored rollouts');
+    expect(err.message).toContain('task-1');
+    expect(err.message).toContain('gateway not configured');
+  });
+
+  test('keeps pessimistic scoring when only some tasks fail', async () => {
+    const result = await runValidationGate({
+      engine: {} as never,
+      candidateSkillText: 'skill body',
+      selSet: TASKS,
+      bestScore: -1,
+      targetModel: 'test:model',
+      runsPerTask: 1,
+      rolloutFn: async ({ task }) => {
+        if (task.task_id === 'task-2') throw new Error('one bad task');
+        return makeTrajectory(task);
+      },
+      scoreFn: async (trajectory): Promise<ScoredRollout> => ({ trajectory, score: 1 }),
+    });
+
+    expect(result.scoredRollouts).toHaveLength(1);
+    expect(result.perTaskMedians).toEqual([
+      { task_id: 'task-1', median: 1, runs: [1] },
+      { task_id: 'task-2', median: 0, runs: [] },
+    ]);
+    expect(result.selScore).toBe(0.5);
+  });
+});


### PR DESCRIPTION
## Summary
- fail loud when a SkillOpt validation gate produces zero scored rollouts instead of folding every rollout error into score 0
- preserve the original rollout errors in the run receipt, audit log, and CLI output for aborted/errored runs
- add unit and E2E coverage so all-target-rollout failures no longer report as `no_improvement`

## Why
A live `gbrain skillopt` run could return `no_improvement` with `sel_score_runs: []` and `$0.00` spend even though no target rollouts were actually scored. That makes a transport/config/budget failure look like a valid optimization result.

With this change, all-rollout failure surfaces as a diagnostic failure. In the local smoke case, the hidden cause became visible: the default DeepSeek model had no pricing entry under `--max-cost`, so BudgetTracker blocked every rollout.

## Validation
- `bun test test/skillopt/validate-gate.test.ts`
- `bun test test/e2e/skillopt-loop.serial.test.ts`
- `bun test test/skillopt test/e2e/skillopt-loop.serial.test.ts`

## Note
`bun run typecheck` still fails in this checkout on pre-existing missing type/dependency issues for `chokidar`, `fast-check`, and `js-yaml`; those errors are unrelated to this patch.
