### PR TITLE
Suppress NER onboarding when active pack cannot infer NER links

### DIFF
--- a/src/core/onboard/checks.ts
+++ b/src/core/onboard/checks.ts
@@ -18,6 +18,7 @@
 import type { BrainEngine } from '../engine.ts';
 import type { RemediationStep } from '../remediation-step.ts';
 import { makeRemediationStep } from '../remediation-step.ts';
+import { loadConfig } from '../config.ts';
 
 /** Shared shape returned by all four checks. */
 export interface OnboardCheckResult {
@@ -42,6 +43,23 @@ async function safeCount(engine: BrainEngine, sql: string, params: unknown[] = [
     return Number.isFinite(n) ? n : 0;
   } catch {
     return 0;
+  }
+}
+
+async function activePackSupportsNerInference(engine: BrainEngine): Promise<boolean> {
+  try {
+    const { loadActivePack } = await import('../schema-pack/load-active.ts');
+    let dbConfig: string | undefined;
+    try {
+      dbConfig = (await engine.getConfig('schema_pack')) ?? undefined;
+    } catch { /* engine.config may not exist on very old brains */ }
+    const active = await loadActivePack({ cfg: loadConfig(), remote: false, dbConfig })
+      .catch(() => null);
+    return active?.manifest.link_types.some(
+      (lt) => lt.inference && typeof lt.inference === 'object' && typeof lt.inference.regex === 'string',
+    ) ?? false;
+  } catch {
+    return false;
   }
 }
 
@@ -162,6 +180,9 @@ export async function checkEntityLinkCoverage(
   const remediations: RemediationStep[] = [];
   let status: 'ok' | 'warn' | 'fail' = 'ok';
   let message: string;
+  const nerInferenceAvailable = coverage < 0.7
+    ? await activePackSupportsNerInference(engine)
+    : false;
 
   // v0.41.18.0: warn-only, never fail. Empty entity link coverage is "needs
   // work" not "broken" — doctor's exit code should not flip from a fresh
@@ -172,30 +193,38 @@ export async function checkEntityLinkCoverage(
     message = `Coverage ${pct}% ± ${ciPct}%${sampleNote}`;
   } else if (coverage >= 0.4) {
     status = 'warn';
-    message = `Coverage ${pct}% ± ${ciPct}% (target 70%)${sampleNote}`;
-    remediations.push(makeRemediationStep({
-      id: 'onboard.extract_ner_links',
-      job: 'extract-ner',
-      params: {},
-      severity: 'medium',
-      est_seconds: 300,
-      est_usd_cost: 0,
-      rationale: `Entity link coverage at ${pct}%; NER extraction lifts typed-link density`,
-      status: 'remediable',
-    }));
+    message = nerInferenceAvailable
+      ? `Coverage ${pct}% ± ${ciPct}% (target 70%)${sampleNote}`
+      : `Coverage ${pct}% ± ${ciPct}% (target 70%; active pack has no NER regex rules)${sampleNote}`;
+    if (nerInferenceAvailable) {
+      remediations.push(makeRemediationStep({
+        id: 'onboard.extract_ner_links',
+        job: 'extract-ner',
+        params: {},
+        severity: 'medium',
+        est_seconds: 300,
+        est_usd_cost: 0,
+        rationale: `Entity link coverage at ${pct}%; NER extraction lifts typed-link density`,
+        status: 'remediable',
+      }));
+    }
   } else {
     status = 'warn';
-    message = `Coverage ${pct}% ± ${ciPct}% (target 70%)${sampleNote}`;
-    remediations.push(makeRemediationStep({
-      id: 'onboard.extract_ner_links',
-      job: 'extract-ner',
-      params: {},
-      severity: 'high',
-      est_seconds: 600,
-      est_usd_cost: 0,
-      rationale: `Entity link coverage at ${pct}%; NER extraction lifts typed-link density`,
-      status: 'remediable',
-    }));
+    message = nerInferenceAvailable
+      ? `Coverage ${pct}% ± ${ciPct}% (target 70%)${sampleNote}`
+      : `Coverage ${pct}% ± ${ciPct}% (target 70%; active pack has no NER regex rules)${sampleNote}`;
+    if (nerInferenceAvailable) {
+      remediations.push(makeRemediationStep({
+        id: 'onboard.extract_ner_links',
+        job: 'extract-ner',
+        params: {},
+        severity: 'high',
+        est_seconds: 600,
+        est_usd_cost: 0,
+        rationale: `Entity link coverage at ${pct}%; NER extraction lifts typed-link density`,
+        status: 'remediable',
+      }));
+    }
   }
   return {
     check: { name: 'entity_link_coverage', status, message },

--- a/test/onboard-entity-link-coverage.test.ts
+++ b/test/onboard-entity-link-coverage.test.ts
@@ -1,0 +1,60 @@
+// Entity-link onboarding should only recommend extract-ner when the active
+// schema pack can actually infer NER links.
+
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { checkEntityLinkCoverage } from '../src/core/onboard/checks.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { _resetPackCacheForTests } from '../src/core/schema-pack/registry.ts';
+
+let engine: PGLiteEngine;
+
+beforeEach(async () => {
+  if (!engine) {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  }
+  await resetPgliteState(engine);
+  _resetPackCacheForTests();
+});
+
+afterAll(async () => {
+  await engine?.disconnect();
+});
+
+async function seedUnlinkedEntities() {
+  for (const slug of ['people/alice', 'people/bob', 'companies/acme']) {
+    await engine.putPage(slug, {
+      title: slug,
+      type: slug.startsWith('companies/') ? 'company' as never : 'person' as never,
+      compiled_truth: 'Entity page with no inbound links yet.',
+      timeline: '',
+      frontmatter: {},
+      source_path: `${slug}.md`,
+    });
+  }
+}
+
+describe('checkEntityLinkCoverage', () => {
+  test('recommends extract-ner when the active pack has NER regex rules', async () => {
+    await engine.setConfig('schema_pack', 'gbrain-base');
+    await seedUnlinkedEntities();
+
+    const result = await checkEntityLinkCoverage(engine);
+
+    expect(result.check.status).toBe('warn');
+    expect(result.remediations.map((r) => r.job)).toContain('extract-ner');
+  });
+
+  test('does not recommend extract-ner when the active pack has no NER regex rules', async () => {
+    await engine.setConfig('schema_pack', 'gbrain-base-v2');
+    await seedUnlinkedEntities();
+
+    const result = await checkEntityLinkCoverage(engine);
+
+    expect(result.check.status).toBe('warn');
+    expect(result.check.message).toContain('active pack has no NER regex rules');
+    expect(result.remediations.map((r) => r.job)).not.toContain('extract-ner');
+  });
+});


### PR DESCRIPTION
## Summary
- Gate the `onboard.extract_ner_links` remediation on the active schema pack actually declaring at least one `link_types[].inference.regex` rule.
- Keep `entity_link_coverage` as a warning when graph coverage is low, but avoid submitting a no-op `extract-ner` job under packs that cannot infer NER links.
- Add focused PGLite coverage for both sides of the contract: `gbrain-base` still recommends NER, while `gbrain-base-v2` does not.

## Why
`extract-ner` only does useful work when the active schema pack has regex-backed inference rules. The bundled `gbrain-base` pack has those rules for verbs like `founded`, `invested_in`, and `works_at`; `gbrain-base-v2` currently declares link verbs/inverses but does not declare `inference.regex` metadata.

Without this guard, `gbrain onboard --check` recommends `extract-ner` solely because entity-link coverage is low, even when the active pack gives the NER extractor no regex rules to run. On a `gbrain-base-v2` brain this produces a misleading remediation: the CLI NER path cleanly no-ops with 0 pages / 0 links, while onboard still suggests it as an auto-remediation.

This PR makes the recommendation capability-aware. It does not try to reintroduce broad regex inference into `gbrain-base-v2`; that is a separate schema-design decision.

## Tests
- `bun test test/onboard-entity-link-coverage.test.ts`
- `bun test test/e2e/onboard-full-flow.test.ts`
- `bun run typecheck`