### PR TITLE
fix: use jsonSchema() wrapper and parameters key for AI SDK tool definitions

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -21,7 +21,7 @@
  *     rotation (via configureGateway()) invalidates stale entries.
  */
 
-import { embed as aiEmbed, embedMany, generateObject, generateText } from 'ai';
+import { embed as aiEmbed, embedMany, generateObject, generateText, jsonSchema } from 'ai';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { listRecipes } from './recipes/index.ts';
 import { createOpenAI } from '@ai-sdk/openai';
@@ -2457,7 +2457,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
   const tools = (opts.tools ?? []).reduce((acc, t) => {
     acc[t.name] = {
       description: t.description,
-      inputSchema: { jsonSchema: t.inputSchema } as any,
+      parameters: jsonSchema(t.inputSchema),
     };
     return acc;
   }, {} as Record<string, any>);


### PR DESCRIPTION
## Problem

When `agent.use_gateway_loop=true` is enabled for non-Anthropic providers, subagent tool loops fail with `schema is not a function`.

## Root Cause

`gateway.chat()` passes tool definitions to `generateText()` using `inputSchema: { jsonSchema: t.inputSchema }`. The Vercel AI SDK expects the `parameters` key with `jsonSchema()`-wrapped values. The `inputSchema` key is silently ignored for openai-compatible providers.

## Fix

- Import `jsonSchema` from the `ai` package
- Replace `inputSchema: { jsonSchema: t.inputSchema }` with `parameters: jsonSchema(t.inputSchema)`

## Testing

- Build passes (1631 modules, zero errors)
- Verified on upgraded v0.42.1.0 fork

Closes #1739