### PR TITLE
fix(lint): use dedicated pool (poolSize: 2) to avoid consuming module-level singleton

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -312,7 +312,12 @@ async function resolveLintContentSanity(): Promise<LintContentOpts['contentSanit
         database_path: base!.database_path,
       });
       try {
-        await engine.connect({});
+        // poolSize: 2 forces an instance-level pool so engine.disconnect()
+        // does NOT clobber the module-level db singleton that the worker
+        // (or any other caller sharing the process) relies on.
+        // Without this, a lint phase inside an autopilot cycle kills the
+        // worker's shared DB connection and every subsequent phase fails.
+        await engine.connect({ poolSize: 2 });
         const lifted = await loadConfigWithEngine(engine, base);
         cs = lifted?.content_sanity ?? cs;
       } finally {


### PR DESCRIPTION
## Problem

When `gbrain lint` runs inside an autopilot cycle, `resolveLintContentSanity()` connects to the module-level singleton pool via `engine.connect({})`. When `engine.disconnect()` runs in the `finally` block, it tears down the shared pool, breaking subsequent phases that depend on the DB connection.

This is a specific trigger of the broader singleton-disconnect pattern reported in #1729.

## Fix

Use `engine.connect({ poolSize: 2 })` to create an instance-level pool. The `disconnect()` in the `finally` block then safely closes only the instance pool without affecting the module singleton.

```typescript
// Before
await engine.connect({});

// After
await engine.connect({ poolSize: 2 });
```

## Testing

- Build passes (1631 modules, zero errors)
- Verified on upgraded v0.42.1.0 fork

Refs #1729