### PR TITLE
fix(embed): only reject as user_provided_model_unset when modelId is truly absent

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -671,7 +671,8 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
-    (recipe.id === 'litellm' || isUserProvided)
+    (recipe.id === 'litellm' || isUserProvided) &&
+    !parsed.modelId
   ) {
     return {
       ok: false,


### PR DESCRIPTION
## Problem

`gbrain init` with a correctly configured embedding model (e.g., `llama-server:text-embedding-qwen3-embedding-0.6b`) fails with `user_provided_model_unset`, even though the user has supplied a valid model string.

## Root Cause

In `diagnoseEmbedding()`, the `user_provided_model_unset` guard only inspects `tp.models` (the touchpoint static model list) but ignores `parsed.modelId` (the user actual model name). `parseModelId()` correctly extracts the modelId, but the guard unconditionally rejects because the touchpoint has an empty static models array.

## Fix

Add `!parsed.modelId` to the condition so it only rejects when the user truly has not supplied a model:

```typescript
if (
    Array.isArray(tp.models) &&
    tp.models.length === 0 &&
    (recipe.id === "litellm" || isUserProvided) &&
    !parsed.modelId  // only reject when modelId is truly absent
)
```

## Testing

- Build passes (1631 modules, zero errors)
- Verified on upgraded v0.42.1.0 fork

Closes #1740