### PR TITLE
fix(ai/gateway): wrap tool inputSchema with ai SDK's jsonSchema() helper

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -21,7 +21,7 @@
  *     rotation (via configureGateway()) invalidates stale entries.
  */
 
-import { embed as aiEmbed, embedMany, generateObject, generateText } from 'ai';
+import { embed as aiEmbed, embedMany, generateObject, generateText, jsonSchema } from 'ai';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { listRecipes } from './recipes/index.ts';
 import { createOpenAI } from '@ai-sdk/openai';
@@ -2457,7 +2457,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
   const tools = (opts.tools ?? []).reduce((acc, t) => {
     acc[t.name] = {
       description: t.description,
-      inputSchema: { jsonSchema: t.inputSchema } as any,
+      inputSchema: jsonSchema(t.inputSchema as any),
     };
     return acc;
   }, {} as Record<string, any>);


### PR DESCRIPTION
## Symptom

A subagent fan-out we run on top of `gbrain` (one parent → 38 children, each calling `chat()` with tools defined) died — all 38 children — with the same runtime error before a single LLM call could fire:

```
[chat(anthropic:claude-haiku-4-5-20251001)] schema is not a function. (In 'schema()', 'schema' is an instance of Object)
```

## Root cause

`src/core/ai/gateway.ts` builds the `tools` map for the Vercel AI SDK like this:

```ts
const tools = (opts.tools ?? []).reduce((acc, t) => {
  acc[t.name] = {
    description: t.description,
    inputSchema: { jsonSchema: t.inputSchema } as any,
  };
  return acc;
}, {} as Record<string, any>);
```

The bare `{ jsonSchema: t.inputSchema } as any` is then handed to AI SDK v6's `asSchema()` in `@ai-sdk/provider-utils/dist/index.mjs` (~line 2126). `asSchema()` branches on what kind of input it received:

- a real `Schema` (has `[schemaSymbol]` + `validate`)
- a `ZodSchema`
- a `StandardSchema` (`~standard`)
- a `LazySchema` (function)

A plain `{ jsonSchema: ... }` object matches none of these branches, so the SDK falls through to invoking the input as a function: `schema()` → `schema is not a function` because `schema` is an `Object` literal.

## Fix

`ai` already exports the `jsonSchema()` helper (re-exported from `@ai-sdk/provider-utils`) precisely for this case — it wraps a JSON Schema 7 object in a proper `Schema<T>` with `[schemaSymbol]` and a no-op `validate`. Two-line change:

```diff
- import { embed as aiEmbed, embedMany, generateObject, generateText } from 'ai';
+ import { embed as aiEmbed, embedMany, generateObject, generateText, jsonSchema } from 'ai';
...
- inputSchema: { jsonSchema: t.inputSchema } as any,
+ inputSchema: jsonSchema(t.inputSchema as any),
```

## Verification

- `bun build --compile --outfile bin/gbrain src/cli.ts` — clean.
- Hot-restarted `gbrain autopilot` against the patched source.
- Retried one of the dead subagent children (job `13028`, model `anthropic:claude-haiku-4-5-20251001`, tools enabled) — the SDK now accepts the tool schema and the LLM call fires.

## Impact

Any caller of `chat()` that passes `opts.tools` will hit this. Hot path for tool-using minions / subagent fan-outs.

## Scope

One file, two lines. No new dependencies — `jsonSchema` is already exported from the `ai` package this repo pins (`^6.0.168`).