### PR TITLE
fix(db): refcount module singleton to fix mid-cycle "connect() has not been called" (#1570)

### DIFF
--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -6,6 +6,10 @@ import { verifySchema } from './schema-verify.ts';
 
 let sql: ReturnType<typeof postgres> | null = null;
 let connectedUrl: string | null = null;
+// #1570: the module singleton `sql` is shared by every module-style engine in
+// the process. Refcount its owners so a transient engine's disconnect() can't
+// tear down the connection a long-lived owner (the dream cycle) still needs.
+let sqlRefCount = 0;
 
 /**
  * Default pool size for Postgres connections. Users on the Supabase transaction
@@ -161,6 +165,8 @@ export function getConnection(): ReturnType<typeof postgres> {
 
 export async function connect(config: EngineConfig): Promise<void> {
   if (sql) {
+    // Another owner shares the already-open singleton — count it (#1570).
+    sqlRefCount++;
     // Warn if a different URL is passed — the old connection is still in use
     if (config.database_url && connectedUrl && config.database_url !== connectedUrl) {
       console.warn('[gbrain] connect() called with a different database_url but a connection already exists. Using existing connection.');
@@ -210,11 +216,13 @@ export async function connect(config: EngineConfig): Promise<void> {
     // Test connection
     await sql`SELECT 1`;
     connectedUrl = url;
+    sqlRefCount = 1; // first owner of the freshly-opened singleton (#1570)
 
     await setSessionDefaults(sql);
   } catch (e: unknown) {
     sql = null;
     connectedUrl = null;
+    sqlRefCount = 0;
     const msg = e instanceof Error ? e.message : String(e);
     throw new GBrainError(
       'Cannot connect to database',
@@ -237,9 +245,15 @@ export async function disconnect(): Promise<void> {
     logDbDisconnect('postgres', 'module');
   } catch { /* best-effort; never block disconnect on audit failure */ }
   if (sql) {
-    await sql.end();
-    sql = null;
-    connectedUrl = null;
+    // #1570 fix: only tear down the shared singleton when the LAST owner
+    // releases it, so a transient module-style engine's disconnect() can't
+    // null the connection a long-lived owner (the dream cycle) still uses.
+    sqlRefCount = Math.max(0, sqlRefCount - 1);
+    if (sqlRefCount === 0) {
+      await sql.end();
+      sql = null;
+      connectedUrl = null;
+    }
   }
 }
 

--- a/test/db-singleton-refcount.test.ts
+++ b/test/db-singleton-refcount.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+
+/**
+ * #1570 regression: the db.ts module singleton (`sql`) is shared by every
+ * module-style engine in the process. Before the refcount, a transient
+ * engine's disconnect() called `sql.end()` + nulled the singleton while a
+ * long-lived owner (the `gbrain dream` cycle engine) was still using it,
+ * causing sync/synthesize to throw "connect() has not been called" mid-cycle.
+ *
+ * The fix refcounts owners: connect() increments, disconnect() decrements,
+ * and the pool is only torn down when the LAST owner releases it.
+ *
+ * We mock `postgres` so connect()/disconnect() run without a live database —
+ * matching connection-resilience.test.ts's "extract the behavior, unit-test
+ * it" posture.
+ */
+
+let endCalls = 0;
+function makeFakeSql() {
+  // Tagged-template-callable client: db.connect() does `await sql`SELECT 1``.
+  const fn: any = (..._args: unknown[]) => Promise.resolve([{ ok: 1 }]);
+  fn.end = async () => { endCalls++; };
+  return fn;
+}
+
+mock.module('postgres', () => {
+  const factory: any = (_url: string, _opts: unknown) => makeFakeSql();
+  factory.BigInt = class {}; // db.ts references postgres.BigInt in the type map
+  return { default: factory };
+});
+
+const CFG = { database_url: 'postgres://test/refcount' } as any;
+
+describe('db.ts module singleton refcount (#1570)', () => {
+  let db: typeof import('../src/core/db.ts');
+
+  beforeEach(async () => {
+    endCalls = 0;
+    db = await import('../src/core/db.ts');
+    // Drain any owners left over from a prior test so each case starts clean.
+    for (let i = 0; i < 16; i++) {
+      try { await db.disconnect(); } catch { /* already torn down */ }
+    }
+    endCalls = 0;
+  });
+
+  it('keeps the singleton alive until the LAST owner disconnects', async () => {
+    await db.connect(CFG);            // fresh owner → refcount 1
+    await db.connect(CFG);            // shared owner → refcount 2
+    expect(() => db.getConnection()).not.toThrow();
+
+    await db.disconnect();            // a transient owner releases → refcount 1
+    expect(() => db.getConnection()).not.toThrow(); // STILL alive — the #1570 fix
+    expect(endCalls).toBe(0);         // pool not torn down while an owner remains
+
+    await db.disconnect();            // last owner releases → refcount 0
+    expect(endCalls).toBe(1);         // now the pool is ended exactly once
+    expect(() => db.getConnection()).toThrow(/connect\(\) has not been called/);
+  });
+
+  it('a single connect/disconnect pair tears down exactly once', async () => {
+    await db.connect(CFG);
+    expect(() => db.getConnection()).not.toThrow();
+    await db.disconnect();
+    expect(endCalls).toBe(1);
+    expect(() => db.getConnection()).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the `#1570` "singleton-null" class: during `gbrain dream` the `sync` and `synthesize` phases throw **`No database connection: connect() has not been called`** mid-cycle, even though the engine connected successfully at startup. Root cause is a shared-ownership bug on the `db.ts` module singleton; fix is to **reference-count its owners**.

This is the production caller the v0.41.25 disconnect instrumentation (`src/core/audit/db-disconnect-audit.ts`, *"only this audit tells us WHO is actually calling disconnect mid-process"*) was added to find.

## Reproduction

`gbrain dream` against a **PgBouncer-pooled Postgres** (Supabase-style transaction pooler). The cycle completes "partial":

```
✗ sync        sync phase failed
    [InternalError/UNKNOWN] No database connection: connect() has not been called.
✗ synthesize  synthesize phase failed
    [InternalError/SYNTH_PHASE_FAIL] No database connection: connect() has not been called.
✓ extract     ... (only survives because the batch-retry layer reconnects mid-phase)
```

## Root cause (traced with live stacks)

The module-level `sql` singleton in `src/core/db.ts` is shared by **every module-style engine in the process**. `gbrain dream` connects more than one engine (the main cycle engine plus a transient probe/migration engine). When the **transient** engine calls `disconnect()`, `PostgresEngine.disconnect()` (module style) calls `db.disconnect()`, which runs `sql.end()` and **nulls the shared singleton** — while the long-lived cycle engine is still using it.

Instrumented `db.disconnect()` with a stack — the offending call fires **before `cycle.sync`**:

```
Error: db.disconnect
    at disconnect (src/core/db.ts)            // sql.end() + sql = null
    at disconnect (src/core/postgres-engine.ts)  // PostgresEngine.disconnect, module style
    at processTicksAndRejections (native)
```

…and then every singleton consumer in `sync`/`synthesize` throws:

```
at getConnection (src/core/db.ts)
at executeRaw (src/core/postgres-engine.ts)
at resolveSourceForDir (src/core/cycle.ts)     // sync phase
at runPhaseSync (src/core/cycle.ts)
```
```
at getConnection (src/core/db.ts)
at getConfig (src/core/postgres-engine.ts)
at loadSynthConfig (src/core/cycle/synthesize.ts)   // synthesize phase
```

`extract` only survives because the v0.41.25 batch-retry layer detects the dead connection and reconnects mid-phase (the "~150 lost rows" symptom). `sync`/`synthesize` have no such retry and hard-fail.

## Fix

Reference-count the module singleton in `src/core/db.ts`:

- `connect()` increments the count (and sets it to `1` on a fresh open; resets to `0` on connect failure).
- `disconnect()` decrements, and only runs `sql.end()` + nulls the singleton when the **last** owner releases it.

A transient engine's `disconnect()` now decrements without tearing down the connection the cycle engine still depends on. ~17 lines, no behavior change for the single-owner path.

## Verification

After the fix, the same `gbrain dream` run:

```
✓ sync        +1377 added, ~86 modified, -0 deleted
- synthesize  dream.synthesize.session_corpus_dir is unset   (skipped on config, no longer a crash)
✓ extract / extract_facts / recompute_emotional_weight / embed
"connect() has not been called" errors: 0
```

## Tests

- New `test/db-singleton-refcount.test.ts` (mocks `postgres`, no live DB): asserts `connect → connect → disconnect` keeps the pool alive, and the final `disconnect` tears it down exactly once.
- Existing `connection-resilience` + `connection-manager` suites: **51 pass, 0 fail** (no regression).

## Notes

- The v0.41.25 batch-retry reconnect (symptom mitigation) remains valuable for genuine connection drops; this patches the actual ownership boundary so the disconnect doesn't happen in the first place.
- An alternative would be to give transient/probe engines `poolSize` (instance mode) so they never touch the singleton, but refcounting is the smaller, more general fix and keeps the module-singleton contract intact for all existing callers.
