### PR TITLE
fix(cycle): cache empty propose_takes results — stop re-extracting unchanged pages every cycle

### DIFF
--- a/src/core/cycle/propose-takes.ts
+++ b/src/core/cycle/propose-takes.ts
@@ -152,6 +152,9 @@ export interface ProposeTakesResult {
   cache_hits: number;
   cache_misses: number;
   proposals_inserted: number;
+  /** Pages whose extraction returned no proposals, recorded as sentinel cache
+   *  rows so they are not re-extracted until their content changes. */
+  empty_results_cached: number;
   budget_exhausted: boolean;
   warnings: string[];
 }
@@ -314,6 +317,7 @@ class ProposeTakesPhase extends BaseCyclePhase {
       cache_hits: 0,
       cache_misses: 0,
       proposals_inserted: 0,
+      empty_results_cached: 0,
       budget_exhausted: false,
       warnings: [],
     };
@@ -386,6 +390,49 @@ class ProposeTakesPhase extends BaseCyclePhase {
         continue;
       }
 
+      // When the extractor proposes NOTHING, still record the
+      // (source_id, page_slug, content_hash, prompt_version) tuple as a
+      // sentinel row (kind='empty_result', terminal status) so the
+      // idempotency check above treats this page as processed until its
+      // content actually changes.
+      //
+      // Without this, empty-result pages never enter take_proposals, so they
+      // re-qualify as cache misses on every cycle and the phase re-pays the
+      // LLM call for the same unchanged content on every autopilot tick,
+      // forever. On a ~42K-page production brain this produced 57,885
+      // re-extraction calls over 11 days (~95-call batches every ~5 min)
+      // with zero takes to show for it.
+      //
+      // The sentinel is safe: nothing reads take_proposals except this
+      // phase's own idempotency check (and kind='empty_result' is distinct
+      // from every real proposal kind, so any future reader can filter it).
+      if (proposals.length === 0) {
+        await engine.executeRaw(
+          `INSERT INTO take_proposals
+             (source_id, page_slug, content_hash, prompt_version, proposal_run_id,
+              claim_text, kind, holder, weight, domain, dedup_against_fence_rows, model_id, status)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+           ON CONFLICT (source_id, page_slug, content_hash, prompt_version) DO NOTHING`,
+          [
+            sourceId,
+            page.slug,
+            ch,
+            promptVersion,
+            proposalRunId,
+            '', // claim_text — empty marker, not a real proposal
+            'empty_result', // kind — distinct from fact/take/bet/hunch
+            'system', // holder
+            0, // weight
+            null, // domain
+            JSON.stringify(existingTakes),
+            opts.model ?? 'claude-sonnet-4-6',
+            'superseded', // terminal status — never surfaces as pending review
+          ],
+        );
+        result.empty_results_cached += 1;
+        continue;
+      }
+
       // Write proposals to take_proposals. Each row is a separate INSERT
       // because the composite idempotency key is on the per-page tuple — a
       // bulk UPSERT would collapse a same-page-multi-claim run into one row.
@@ -446,7 +493,7 @@ class ProposeTakesPhase extends BaseCyclePhase {
     });
 
     return {
-      summary: `propose_takes: scanned ${result.pages_scanned} pages, ${result.cache_hits} cached, ${result.proposals_inserted} new proposals (run ${proposalRunId})`,
+      summary: `propose_takes: scanned ${result.pages_scanned} pages, ${result.cache_hits} cached, ${result.proposals_inserted} new proposals, ${result.empty_results_cached} empty results cached (run ${proposalRunId})`,
       details: { ...result, proposal_run_id: proposalRunId, prompt_version: promptVersion },
       status: result.budget_exhausted ? 'warn' : 'ok',
     };

--- a/test/propose-takes.test.ts
+++ b/test/propose-takes.test.ts
@@ -287,6 +287,50 @@ describe('runPhaseProposeTakes — phase integration', () => {
     expect(captured.filter(c => c.sql.includes('INSERT INTO take_proposals'))).toHaveLength(0);
   });
 
+  test('empty extraction result writes a sentinel cache row (re-grind fix)', async () => {
+    const pages = [buildPage({ slug: 'wiki/concepts/quiet-page', body: 'Prose that yields no takes.' })];
+    const { engine, captured } = buildMockEngine({ pages });
+    const extractor: ProposeTakesExtractor = async () => []; // extractor finds nothing
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    expect(result.status).toBe('ok');
+    const details = result.details as Record<string, unknown>;
+    expect(details.proposals_inserted).toBe(0);
+    expect(details.empty_results_cached).toBe(1);
+
+    // Exactly one sentinel row INSERT, marked so it can never be confused
+    // with a real proposal.
+    const inserts = captured.filter(c => c.sql.includes('INSERT INTO take_proposals'));
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]!.params[5]).toBe(''); // claim_text — empty marker
+    expect(inserts[0]!.params[6]).toBe('empty_result'); // kind
+    expect(inserts[0]!.params[12]).toBe('superseded'); // status — terminal
+  });
+
+  test('second run after an empty result is a cache hit (no repeat LLM call)', async () => {
+    const body = 'Prose that yields no takes.';
+    const ch = contentHash(body);
+    const pages = [buildPage({ slug: 'wiki/concepts/quiet-page', body })];
+    // Simulate the sentinel row written by a prior run: it occupies the same
+    // composite idempotency key a real proposal would.
+    const existing = new Set([`default|wiki/concepts/quiet-page|${ch}|${PROPOSE_TAKES_PROMPT_VERSION}`]);
+    const { engine, captured } = buildMockEngine({ pages, existingProposals: existing });
+    let extractorCalls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      extractorCalls++;
+      return [];
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    expect(extractorCalls).toBe(0); // the LLM is never called again
+    const details = result.details as Record<string, unknown>;
+    expect(details.cache_hits).toBe(1);
+    expect(details.empty_results_cached).toBe(0);
+    expect(captured.filter(c => c.sql.includes('INSERT INTO take_proposals'))).toHaveLength(0);
+  });
+
   test('passes existing fence rows to extractor as dedup context (F2 fix)', async () => {
     const body = `# Page
 


### PR DESCRIPTION
## Summary

The dream-cycle `propose_takes` phase re-extracts the **same unchanged pages on every autopilot tick**, because pages whose extraction returns no proposals never enter the idempotency cache.

`runPhase()` walks the top-100 most-recently-updated pages, checks `take_proposals` for `(source_id, page_slug, content_hash, prompt_version)`, and calls the LLM on cache misses. But the INSERT only happens inside `for (const p of proposals)` — **when `proposals` is `[]`, no row is written**, so the same page is a cache miss again on the next cycle, ~5 minutes later, forever.

Observed on a ~42K-page production brain (Supabase, autopilot every ~5 min): **57,885 propose_takes call submissions over 11 days** — near-identical batches of ~95 calls in 92% of cycles, constant volume regardless of new content — with **zero takes produced** (`gbrain takes list` empty). Ledger evidence (daily call counts from `~/.gbrain/audit/dream-budget-*.jsonl`) available on request; it contains no page content.

The per-cycle `$5` budget cap never fires on this pattern: each cycle self-limits at ~$1.14 (batch size × per-call estimate), so the damage accrues across 25-219 cycles/day rather than within one cycle.

## The fix

When the extractor returns an empty array, insert one **sentinel row** under the same composite idempotency key:

- `kind = 'empty_result'` — distinct from every real proposal kind (`fact`/`take`/`bet`/`hunch`), so it can never be confused with a real proposal and any future reader can filter it
- `claim_text = ''`, `weight = 0`, `holder = 'system'`
- `status = 'superseded'` — terminal, so it never surfaces as pending review

The page is then skipped by the existing idempotency check until its `content_hash` actually changes. Safe by construction: the only reader of `take_proposals` in the codebase is this phase's own idempotency check.

Also adds an `empty_results_cached` counter to `ProposeTakesResult` and the phase summary line, so operators can see the cache working.

## Tests

Two new cases in `test/propose-takes.test.ts` (existing mock-engine conventions):

1. **empty extraction result writes a sentinel cache row** — asserts exactly one INSERT with `kind='empty_result'`, `claim_text=''`, `status='superseded'`, and `empty_results_cached=1`
2. **second run after an empty result is a cache hit** — asserts the extractor (LLM) is never called again and no further INSERTs happen

All 27 tests in the file pass; `bun run verify` green (29/29 checks).

## Notes

- No schema changes — the sentinel uses existing columns and the existing unique index.
- Existing rows and real proposals are unaffected; `ON CONFLICT DO NOTHING` preserves race safety.
- A natural follow-up (not in this PR): gate proposal on `content_hash` change rather than `updated_at` recency, and/or a daily (not per-cycle) dream-cycle budget cap, since per-cycle caps structurally cannot catch per-tick grinders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
