### PR TITLE
perf(ai): opt high-volume cycle/extraction LLM calls into Anthropic prompt caching

### DIFF
--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -426,6 +426,10 @@ export async function runPhaseExtractAtoms(
     try {
       const result = await chat({
         system: EXTRACT_PROMPT,
+        // EXTRACT_PROMPT is a constant — identical across every call in a
+        // cycle — so let Anthropic prompt-cache it (cache reads bill at 10%
+        // of base input price; ignored by providers without cache support).
+        cacheSystem: true,
         messages: [
           {
             role: 'user',

--- a/src/core/cycle/synthesize-concepts.ts
+++ b/src/core/cycle/synthesize-concepts.ts
@@ -179,6 +179,10 @@ export async function runPhaseSynthesizeConcepts(
         try {
           const result = await chat({
             system: SYNTH_PROMPT,
+            // SYNTH_PROMPT is a constant — identical across every call in a
+            // cycle — so let Anthropic prompt-cache it (ignored by providers
+            // without cache support).
+            cacheSystem: true,
             messages: [
               {
                 role: 'user',

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -778,6 +778,10 @@ export function makeJudgeClient(verdictModel: string): JudgeClient | null {
       const result: ChatResult = await gatewayChat({
         model: modelStr,
         system,
+        // The synthesize system prompt is identical across the turns of one
+        // transcript's tool loop — let Anthropic prompt-cache it (ignored by
+        // providers without cache support).
+        cacheSystem: true,
         messages,
         maxTokens: params.max_tokens,
       });

--- a/src/core/facts/extract.ts
+++ b/src/core/facts/extract.ts
@@ -167,6 +167,11 @@ export async function extractFactsFromTurn(input: ExtractInput): Promise<Extract
     result = await chat({
       model: input.model ?? defaultModel,
       system: EXTRACTOR_SYSTEM,
+      // EXTRACTOR_SYSTEM is a constant — identical across every fact-extraction
+      // call — so let Anthropic prompt-cache it. On bulk paths (conversation-facts
+      // backfills, dream-cycle extract_facts) the repeated system prompt is a
+      // meaningful share of input cost. Ignored by providers without cache support.
+      cacheSystem: true,
       messages: [
         {
           role: 'user',


### PR DESCRIPTION
## Summary

gbrain's gateway fully supports Anthropic prompt caching (`ChatOpts.cacheSystem` + `supports_prompt_cache: true` in the Anthropic recipe + `providerOptions.anthropic.cacheControl` wiring) — **but almost no internal call site opts in**, so the mechanism never fires for the highest-volume LLM paths.

Production measurement (Anthropic Console token export, May 2026, gbrain-dedicated API key): **only 4.9% of input tokens went through the prompt cache** — 9.17M tokens billed at the full no-cache rate. The biggest single day billed 4.12M input tokens with zero cache activity. Cache reads bill at 10% of base input price, so for repeated-context workloads this gap multiplies real spend several-fold.

## The fix

Add `cacheSystem: true` to the four cycle/extraction call sites that already pass a **constant** `system` prompt — pure one-line opt-ins to existing, already-shipped gateway machinery:

| Call site | System prompt | Why it benefits |
|---|---|---|
| `src/core/facts/extract.ts` (extractFactsFromTurn) | `EXTRACTOR_SYSTEM` constant | Every fact-extraction call sends the same system prompt; bulk paths (conversation-facts backfills, dream-cycle extract_facts) make hundreds-to-thousands of calls per run |
| `src/core/cycle/extract-atoms.ts` | `EXTRACT_PROMPT` constant | Per-item extraction in a loop, identical system every call |
| `src/core/cycle/synthesize-concepts.ts` | `SYNTH_PROMPT` constant | Per-concept-group synthesis in a loop |
| `src/core/cycle/synthesize.ts` (gateway adapter) | per-transcript system | Identical across the turns of one transcript's tool loop |

No behavior change for non-Anthropic providers: the gateway's `supports_prompt_cache` gate makes `cacheSystem` a no-op for recipes that don't declare cache support.

## Deliberately NOT in this PR

`propose-takes.ts`, `grade-takes.ts`, and `calibration-profile.ts` build their entire prompt into the **user message** (no `system` param), so they can't benefit from `cacheSystem` without restructuring their prompts into a stable system part + variable user part. Since those prompts are tuned (measured F1 scores, `PROPOSE_TAKES_PROMPT_VERSION` cache keys), restructuring them deserves its own PR with a prompt-version bump and re-validation — flagged as a follow-up rather than bundled here.

## Tests

Existing tests for the touched files pass unchanged (the injected-extractor / transport-seam test patterns don't assert on the exact ChatOpts shape). `bun run verify` green.

## Evidence / context

Companion to #1760 (propose_takes re-grind). Both came out of a spend audit on a ~42K-page production brain where the May 2026 Anthropic bill was dominated by uncached, repeated dream-cycle calls. Happy to share the (content-free) token-usage aggregates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
