### PR TITLE
fix(cli): drain fire-and-forget facts queue (and bound embed fetch) so multi-chunk capture can't pin the PGLite lock

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1747,16 +1747,50 @@ async function handleCliOnly(command: string, args: string[]) {
       }
     }
   } finally {
-    // v0.42.1.0 LOCAL PATCH (see PATCH.md): give the CLI_ONLY dispatch path
-    // the same force-exit-after-main contract the op-dispatch path already has
-    // (cli.ts ~244-256 / 315-316). Without it, a write command like
-    // `gbrain capture` on a MULTI-CHUNK page leaves an async handle open (or
-    // engine.disconnect() itself hangs on PGLite — see the C13 note at ~239),
-    // so the process never exits and pins PGLite's single-writer lock. Every
-    // later gbrain command then dies with "Timed out waiting for PGLite lock"
-    // until the zombie is SIGKILLed. Bound disconnect with an unref'd hard
-    // deadline, then force-exit once it returns. Daemons (serve) are excluded
-    // by shouldForceExitAfterMain(); serve also keeps its no-disconnect rule.
+    // v0.42.1.0 LOCAL PATCH (see PATCH.md item #3): the CLI_ONLY dispatch path
+    // (which owns `gbrain capture`) lacked the op-dispatch finally's
+    // drain-before-disconnect contract (cli.ts ~290-317). That was the TRUE
+    // root cause of the multi-chunk capture hang:
+    //
+    //   `put_page` fires a fire-and-forget facts:absorb job into the bounded
+    //   FactsQueue (operations.ts ~875, mode:'queue') AFTER printing the
+    //   receipt. On a multi-chunk page that in-flight Haiku job is still
+    //   running when this finally tears the engine down. `engine.disconnect()`
+    //   nulls `_db` out from under the job; the job's "PGLite not connected"
+    //   error path re-pumps the queue via queueMicrotask, and that microtask
+    //   storm interleaving with PGLite's WASM message pump spins `db.close()`
+    //   in a 100%-CPU userspace busy-loop that NEVER returns. Because the
+    //   busy-loop pins the JS thread, the unref'd hard-deadline setTimeout
+    //   below can never fire (a same-thread timer needs an event-loop turn the
+    //   busy WASM call never yields — verified: a Worker-thread watchdog can't
+    //   preempt it either). disconnect()'s lock-release in its finally is
+    //   therefore never reached, so the PGLite single-writer lock stays pinned
+    //   and every later gbrain command dies "Timed out waiting for PGLite lock"
+    //   until the zombie is SIGKILLed.
+    //
+    // Fix: DRAIN the fire-and-forget work (facts queue + any pending
+    // last-retrieved writes) BEFORE disconnect, so the job finishes cleanly
+    // against a live engine and `db.close()` returns in ~10ms instead of
+    // busy-looping. This mirrors the op-dispatch finally exactly. The
+    // force-exit hard-deadline below is KEPT as defense-in-depth, but it is no
+    // longer the only thing standing between the user and a wedged brain — and
+    // it can't be (it can't preempt a WASM busy-loop). Daemons (serve) keep
+    // their no-disconnect rule and are excluded from force-exit by
+    // shouldForceExitAfterMain().
+    if (command !== 'serve') {
+      try {
+        const { awaitPendingLastRetrievedWrites } = await import('./core/last-retrieved.ts');
+        await awaitPendingLastRetrievedWrites();
+      } catch { /* best-effort; never block disconnect on drain failure */ }
+      try {
+        // 2s timeout: pages that enqueue no facts pay one ~0ms check; capture/
+        // import that DO enqueue pay up to 2s while the in-flight Haiku job
+        // settles against the still-live engine. drainPending does NOT abort
+        // in-flight work (see facts/queue.ts) so the job completes its write.
+        const { getFactsQueue } = await import('./core/facts/queue.ts');
+        await getFactsQueue().drainPending({ timeout: 2000 });
+      } catch { /* best-effort; never block disconnect on drain failure */ }
+    }
     const forceExit = shouldForceExitAfterMain();
     let hardExitTimer: ReturnType<typeof setTimeout> | undefined;
     if (forceExit) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1747,7 +1747,28 @@ async function handleCliOnly(command: string, args: string[]) {
       }
     }
   } finally {
+    // v0.42.1.0 LOCAL PATCH (see PATCH.md): give the CLI_ONLY dispatch path
+    // the same force-exit-after-main contract the op-dispatch path already has
+    // (cli.ts ~244-256 / 315-316). Without it, a write command like
+    // `gbrain capture` on a MULTI-CHUNK page leaves an async handle open (or
+    // engine.disconnect() itself hangs on PGLite — see the C13 note at ~239),
+    // so the process never exits and pins PGLite's single-writer lock. Every
+    // later gbrain command then dies with "Timed out waiting for PGLite lock"
+    // until the zombie is SIGKILLed. Bound disconnect with an unref'd hard
+    // deadline, then force-exit once it returns. Daemons (serve) are excluded
+    // by shouldForceExitAfterMain(); serve also keeps its no-disconnect rule.
+    const forceExit = shouldForceExitAfterMain();
+    let hardExitTimer: ReturnType<typeof setTimeout> | undefined;
+    if (forceExit) {
+      hardExitTimer = setTimeout(() => {
+        console.warn('[cli] engine.disconnect() did not return within 10000ms — force-exiting');
+        process.exit(0);
+      }, 10_000);
+      hardExitTimer.unref?.();
+    }
     if (command !== 'serve') await engine.disconnect();
+    if (hardExitTimer) clearTimeout(hardExitTimer);
+    if (forceExit) process.exit(0);
   }
 }
 

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -1072,6 +1072,37 @@ async function resolveEmbeddingProvider(modelStr: string): Promise<{ model: any;
   return { model, recipe, modelId: parsed.modelId };
 }
 
+/**
+ * Wall-clock ceiling for a single embedding HTTP request. Plain `fetch`
+ * (Bun/Node) has NO default request timeout, so a stalled provider socket
+ * makes the `await` never settle. The AI SDK's `maxRetries` only fires on a
+ * SETTLED error response — a half-open socket never settles, so it can't help.
+ * For an `openai-compatible` provider (ZeroEntropy, Voyage, generic) we own
+ * the `fetch`, so we attach a timeout here. Without it, an intermittently
+ * stalled embed request hangs `gbrain capture`/import indefinitely INSIDE
+ * `embedBatch` — long before the `finally`/disconnect runs — and on PGLite
+ * pins the single-writer lock until an external SIGKILL (garrytan/gbrain#1762).
+ * 60s is generous vs. observed 2–7s latencies while still bounding lock-hold.
+ */
+const EMBED_FETCH_TIMEOUT_MS = 60_000;
+
+/**
+ * Wrap a fetch implementation so every embedding request carries a wall-clock
+ * timeout. Composes with (never clobbers) any caller/SDK-supplied AbortSignal
+ * — e.g. the `abortSignal` threaded from a wall-clock budget — so the request
+ * is cancelled by whichever fires first.
+ */
+function withEmbedFetchTimeout(inner?: typeof fetch): typeof fetch {
+  const base = inner ?? fetch;
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const timeout = AbortSignal.timeout(EMBED_FETCH_TIMEOUT_MS);
+    const signal = init?.signal
+      ? AbortSignal.any([init.signal, timeout])
+      : timeout;
+    return base(input, { ...(init ?? {}), signal });
+  }) as unknown as typeof fetch;
+}
+
 function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
   switch (recipe.implementation) {
     case 'native-openai': {
@@ -1113,17 +1144,20 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
       // ZeroEntropy needs zeroEntropyCompatFetch (URL path + body input_type
       // + response shape rewrite + OOM caps). Same per-recipe-id branch
       // pattern as voyage so adding a third compat shim is one more case.
-      const fetchWrapper =
+      const innerFetch =
         compat.fetch ??
         (recipe.id === 'voyage'
           ? voyageCompatFetch
           : recipe.id === 'zeroentropyai'
           ? zeroEntropyCompatFetch
           : undefined);
+      // Always wrap so the embed request can never hang forever, regardless of
+      // recipe (a missing per-request timeout was the root cause of #1762).
+      const fetchWrapper = withEmbedFetchTimeout(innerFetch);
       const client = createOpenAICompatible({
         name: recipe.id,
         baseURL: compat.baseURL,
-        ...(fetchWrapper ? { fetch: fetchWrapper } : {}),
+        fetch: fetchWrapper,
         ...auth,
       });
       return client.textEmbeddingModel(modelId);


### PR DESCRIPTION
Closes #1762.

> **Update (2026-06-02):** the original root-cause analysis in this PR and in #1762 was **disproven** by deeper instrumentation. The real cause is a fire-and-forget facts-queue job, not a missing teardown contract / leaked embedder socket. Full corrected analysis below; the force-exit patch is retained only as defense-in-depth.

### Problem
`gbrain capture` (and other `CLI_ONLY` write commands) on a **multi-chunk page** writes the page, embeds the chunks, prints the receipt — then **never exits**. The process keeps PGLite's single-writer lock held, so every later `gbrain` command fails `Timed out waiting for PGLite lock` until it is `SIGKILL`ed. Single-chunk pages exit cleanly. Content + embeddings land before the hang, so it is purely a teardown problem.

### Root cause (corrected)
`put_page` fires a **fire-and-forget `facts:absorb` Haiku job** into the bounded `FactsQueue` (`mode:'queue'`) *after* printing the receipt. On a multi-chunk page that job is still in flight when `handleCliOnly`'s `finally` tears the engine down. Unlike the op-dispatch `finally`, `handleCliOnly` did **not drain that queue** before `engine.disconnect()`.

`disconnect()` nulls `_db` out from under the in-flight job. The job's "PGLite not connected" error path re-pumps the queue via `queueMicrotask`, and that microtask storm interleaving with PGLite's WASM message pump spins `db.close()` into a **100%-CPU userspace busy-loop that never returns** (in isolation `db.close()` returns in ~9ms — confirmed via `/proc/<pid>/stat` CPU sampling).

Because the busy-loop pins the single JS thread, the unref'd 10s force-exit `setTimeout` from the earlier patch **can never fire** (a same-thread timer needs an event-loop turn the busy WASM call never yields; a worker-thread watchdog can't preempt it either). So `disconnect()`'s lock-release in its own `finally` is never reached, and the PGLite single-writer lock stays pinned indefinitely.

This is why the force-exit-after-main approach (the prior commit) could not fix it — it treats the symptom (process won't exit) but the thread is wedged before any exit path can run.

> Note: this corrects the earlier claim that "per-chunk Haiku synopsis is not the cause." A Haiku job **is** the trigger — but it is the `facts:absorb` queue job, not the per-chunk synopsis path.

### Fix
1. In `handleCliOnly`'s `finally`, **drain the fire-and-forget work before disconnect** — `awaitPendingLastRetrievedWrites()` + `getFactsQueue().drainPending({ timeout: 2000 })` — mirroring the op-dispatch `finally`. The Haiku job then settles against a still-live engine and `db.close()` returns in ~10ms instead of busy-looping.
2. The force-exit hard-deadline from the prior commit is **kept as defense-in-depth** (it just can't be the only safeguard).
3. **`gateway.ts` `withEmbedFetchTimeout`** — fixes a separate latent hang: a stalled `openai-compatible` embed socket inside the inline `embedBatch` `await` hangs capture *during* work (before disconnect), also pinning the lock. The Vercel AI SDK `maxRetries` only fires on a *settled* error, so a half-open socket is unbounded without a per-request timeout. Adds a 60s `AbortSignal.timeout`, composed via `AbortSignal.any` so it never clobbers a caller-supplied signal.

`src/cli.ts` + `src/core/ai/gateway.ts` only.

### Testing
Reproduced the hang on a multi-chunk meeting-page capture (`tokenmax`): pre-fix it hangs every run (SIGKILLed at timeout, lock pinned). Post-fix: **5/5 clean** — exit 0, ~3s, no zombie process, PGLite lock immediately free (`gbrain get`/`doctor` run right after with no timeout). Root cause was localized with `MARK` probes (since removed) + `/proc` CPU sampling.

### Impact
Hits anyone whose config produces multi-chunk pages (e.g. `tokenmax`) ingesting larger pages via `capture`/`import` — one hung ingest bricks all subsequent `gbrain` commands until manually killed.
