### PR TITLE
fix: ignore clone health for path-only sources

### DIFF
--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -656,8 +656,8 @@ export async function getSourceStatus(
 
   const remoteUrl = getRemoteUrl(src.config);
   let cloneState: SourceStatus['clone_state'] = 'not-applicable';
-  if (src.local_path) {
-    cloneState = validateRepoState(src.local_path, remoteUrl ?? undefined);
+  if (src.local_path && remoteUrl) {
+    cloneState = validateRepoState(src.local_path, remoteUrl);
   }
 
   return {

--- a/test/sources-ops.test.ts
+++ b/test/sources-ops.test.ts
@@ -443,14 +443,9 @@ describe('getSourceStatus', () => {
     await withEnv2(async () => {
       const userPath = join(GBRAIN_HOME, 'na-fixture');
       mkdirSync(userPath, { recursive: true });
-      // path-only source still gets validateRepoState — but with no expected
-      // URL, it just probes existence + .git. Path exists with no .git → 'no-git'.
-      // To match contract docstring we'd want 'not-applicable' only when
-      // local_path is null. Test the truthful behavior:
       await addSource(engine, { id: 'status-no-url', localPath: userPath });
       const s = await getSourceStatus(engine, 'status-no-url');
-      // local_path set but no .git: returns 'no-git'
-      expect(s.clone_state).toBe('no-git');
+      expect(s.clone_state).toBe('not-applicable');
       expect(s.remote_url).toBeNull();
       rmSync(userPath, { recursive: true, force: true });
     });


### PR DESCRIPTION
## Summary
- Treat path-only local sources without `remote_url` as `clone_state: not-applicable`
- Preserve clone health validation for remote-managed sources with `remote_url`
- Update `sources-ops` regression coverage for the path-only contract

## Verification
- Static scan on scoped diff: clean
- Independent reviewer verdict: passed, no security concerns or logic errors
- `bun test test/sources-ops.test.ts --timeout 30000` → 24 pass / 0 fail

## Context
This addresses the default local GBrain source being reported as `clone_state: corrupted` even though it is a path-only source rather than a managed clone.