### PR TITLE
fix: allow user-provided embedding dimensions

### DIFF
--- a/docs/integrations/embedding-providers.md
+++ b/docs/integrations/embedding-providers.md
@@ -147,7 +147,7 @@ Recipe ships with `nomic-embed-text` (768d, recommended), `mxbai-embed-large` (1
 
 `llama.cpp`'s `llama-server --embeddings` endpoint. No env required. Optional `LLAMA_SERVER_BASE_URL` (default `http://localhost:8080/v1`) and `LLAMA_SERVER_API_KEY`.
 
-User-driven models: launch llama-server with `--model <gguf-path> --embeddings`, then run `gbrain init --embedding-model llama-server:<your-id> --embedding-dimensions <N>`. The recipe refuses the implicit shorthand `--model llama-server` because there's no canonical first model.
+User-driven models: launch llama-server with `--model <gguf-path> --embeddings`, then run `gbrain init --embedding-model llama-server:<your-id> --embedding-dimensions <N>`. The recipe refuses the implicit shorthand `--model llama-server` because there's no canonical first model. For OpenAI-compatible local services such as BGE/TEI-compatible proxies, set `LLAMA_SERVER_BASE_URL` to the service's `/v1` endpoint and use the model id reported by `/v1/models`; the explicit `--embedding-dimensions` value becomes the schema contract.
 
 ### LiteLLM proxy (universal escape hatch)
 

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -673,6 +673,7 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
+    !parsed.modelId &&
     (recipe.id === 'litellm' || isUserProvided)
   ) {
     return {

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -266,9 +266,11 @@ export interface ResolveSchemaEmbeddingDimOpts {
  *  4. Resolved dim is a positive integer.
  *  5. Resolved dim ≤ PGVECTOR_COLUMN_MAX_DIMS (16000).
  *  6. If user passed `embedding_dimensions`, it either matches
- *     `recipe.touchpoints.embedding.default_dims` OR is in the recipe's
- *     `dims_options` list (Matryoshka providers). Otherwise reject — the
- *     user picked a model that doesn't support custom dims.
+ *     `recipe.touchpoints.embedding.default_dims`, is in the recipe's
+ *     `dims_options` list (Matryoshka providers), or belongs to a
+ *     `user_provided_models` recipe where the explicit dimension is the
+ *     schema contract. Otherwise reject — the user picked a model that
+ *     doesn't support custom dims.
  */
 export function resolveSchemaEmbeddingDim(opts: ResolveSchemaEmbeddingDimOpts): ResolveSchemaDimResult {
   try {
@@ -409,6 +411,14 @@ function isCustomDimValidForProvider(
   requestedDims: number,
   dimsOptions: number[] | undefined,
 ): CustomDimCheck {
+  // Tier 0: bring-your-own-model recipes cannot know dimensions statically.
+  // The user-provided dimension is the schema contract; runtime D12 guards still
+  // reject vectors whose actual length disagrees with this value before storage.
+  const embeddingTouchpoint = recipe.touchpoints.embedding;
+  if (embeddingTouchpoint?.user_provided_models === true) {
+    return { valid: true, error: '' };
+  }
+
   // Tier 1: recipe-declared dims_options.
   if (dimsOptions && dimsOptions.length > 0) {
     if (dimsOptions.includes(requestedDims)) return { valid: true, error: '' };

--- a/test/e2e/init-fresh-pglite.test.ts
+++ b/test/e2e/init-fresh-pglite.test.ts
@@ -294,4 +294,25 @@ describe('v0.37 T12 — happy path with picker-bypassing explicit flag', () => {
     expect(cfg.embedding_model).toBe('voyage:voyage-3-large');
     expect(cfg.embedding_dimensions).toBe(1024);
   }, 120000);
+
+  test('user-provided local embedding model accepts explicit dimensions', async () => {
+    const localHome = makeTempHome();
+    try {
+      const r = await runCli([
+        'init', '--pglite',
+        '--embedding-model', 'llama-server:bge-small-en-v1.5',
+        '--embedding-dimensions', '384',
+      ], {
+        gbrainHome: localHome,
+        env: {},
+      });
+      expect(r.exitCode).toBe(0);
+
+      const cfg = JSON.parse(readFileSync(join(localHome, '.gbrain', 'config.json'), 'utf-8'));
+      expect(cfg.embedding_model).toBe('llama-server:bge-small-en-v1.5');
+      expect(cfg.embedding_dimensions).toBe(384);
+    } finally {
+      rmSync(localHome, { recursive: true, force: true });
+    }
+  }, 120000);
 });

--- a/test/embedding-dim-check.test.ts
+++ b/test/embedding-dim-check.test.ts
@@ -237,6 +237,41 @@ describe('resolveSchemaEmbeddingDim', () => {
     if (got.ok) expect(got.dim).toBe(768);
   });
 
+  test('user-provided local llama-server model accepts explicit schema dimensions', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:bge-small-en-v1.5',
+      embedding_dimensions: 384,
+    });
+    expect(got).toEqual({
+      ok: true,
+      dim: 384,
+      model: 'llama-server:bge-small-en-v1.5',
+      provider: 'llama-server',
+      recipeDefault: 0,
+    });
+  });
+
+  test('user-provided LiteLLM proxy model accepts explicit schema dimensions', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'litellm:any-proxied-embedding-model',
+      embedding_dimensions: 384,
+    });
+    expect(got.ok).toBe(true);
+    if (got.ok) {
+      expect(got.dim).toBe(384);
+      expect(got.provider).toBe('litellm');
+      expect(got.model).toBe('litellm:any-proxied-embedding-model');
+    }
+  });
+
+  test('user-provided models still require a positive explicit dimension', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:bge-small-en-v1.5',
+    });
+    expect(got.ok).toBe(false);
+    if (!got.ok) expect(got.error).toMatch(/positive integer/);
+  });
+
   test('unknown provider rejected with provider list hint', () => {
     const got = resolveSchemaEmbeddingDim({ embedding_model: 'notarealprovider:foo' });
     expect(got.ok).toBe(false);

--- a/test/gateway-embed-model-override.test.ts
+++ b/test/gateway-embed-model-override.test.ts
@@ -16,6 +16,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
   configureGateway,
+  diagnoseEmbedding,
   embedQuery,
   isAvailable,
   resetGateway,
@@ -172,5 +173,37 @@ describe('isAvailable(touchpoint, modelOverride) — D10', () => {
       env: { OPENAI_API_KEY: 'sk-test' },
     });
     expect(isAvailable('embedding', 'totally:unknown')).toBe(false);
+  });
+
+  test('user-provided llama-server embedding model is available when model id is explicit', () => {
+    configureGateway({
+      embedding_model: 'llama-server:bge-small-en-v1.5',
+      embedding_dimensions: 384,
+      env: {},
+    });
+
+    expect(diagnoseEmbedding()).toEqual({
+      ok: true,
+      model: 'llama-server:bge-small-en-v1.5',
+      provider: 'llama-server',
+      recipeId: 'llama-server',
+    });
+    expect(isAvailable('embedding')).toBe(true);
+  });
+
+  test('user-provided LiteLLM embedding model is available when model id is explicit', () => {
+    configureGateway({
+      embedding_model: 'litellm:custom-proxy-model',
+      embedding_dimensions: 384,
+      env: {},
+    });
+
+    expect(diagnoseEmbedding()).toEqual({
+      ok: true,
+      model: 'litellm:custom-proxy-model',
+      provider: 'litellm',
+      recipeId: 'litellm',
+    });
+    expect(isAvailable('embedding')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes local/user-provided embedding backends whose models are not statically enumerable by GBrain recipes.

`llama-server` and `litellm` intentionally declare `models: []` and `user_provided_models: true` because the served embedding model comes from the user's local server/proxy configuration. These recipes already require an explicit `provider:model` and `--embedding-dimensions <N>`, but the current preflight path rejects that explicit dimension as an unsupported "custom dimension" before init/reinit can create the schema.

This PR treats the explicit dimension for `user_provided_models` recipes as the schema contract while preserving the existing positive-integer and pgvector max-dimension guards. Runtime vector-length validation still protects storage if the backend returns vectors with a different length.

It also fixes the embedding gateway availability diagnostic so an explicit user-provided model id like `llama-server:bge-small-en-v1.5` is not reported as `user_provided_model_unset` just because the recipe's static model list is empty.

## Changes

- Allow `resolveSchemaEmbeddingDim()` to accept explicit dimensions for `user_provided_models` recipes.
- Keep missing/invalid dimensions rejected for local/user-provided recipes.
- Make `diagnoseEmbedding()` consider empty-model recipes available when `provider:model` includes an explicit model id.
- Add unit coverage for `llama-server` and `litellm` user-provided model/dimension behavior.
- Add an E2E init regression test for `llama-server:bge-small-en-v1.5 --embedding-dimensions 384`.
- Clarify local `llama-server` docs for OpenAI-compatible local services/proxies.

## Real-world validation

This was found while wiring GBrain to an existing local OpenAI-compatible BGE embedding service. After the local patch, a PGLite brain successfully initialized and embedded 1,327/1,327 chunks using:

```bash
LLAMA_SERVER_BASE_URL=http://127.0.0.1:8090/v1 \
  gbrain reinit-pglite \
  --embedding-model llama-server:bge-small-en-v1.5 \
  --embedding-dimensions 384 \
  --yes
```

## Test plan

- [x] `bun test --timeout 30000 test/embedding-dim-check.test.ts test/gateway-embed-model-override.test.ts`
- [x] `bun test --timeout 30000 test/e2e/init-fresh-pglite.test.ts --test-name-pattern 'user-provided local embedding model accepts explicit dimensions'`
- [x] `NODE_OPTIONS=--max-old-space-size=4096 bun run typecheck`
- [x] Static added-line scan: no secret-looking assignments; no added `eval`/`exec`/shell-exec patterns.
- [x] Independent reviewer pass: no security concerns or logic errors.
