### PR TITLE
[codex] fix init schema-pack validation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,9 @@ const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'c
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
 const CLI_ONLY_SELF_HELP = new Set([
+  // `gbrain init --help` has a detailed, state-safe help path in runInit.
+  // Keep it reachable instead of the generic CLI-only one-line stub.
+  'init',
   'upgrade', 'post-upgrade', 'check-update',
   'embed', 'config',
   'skillpack', 'skillpack-check',

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -85,6 +85,8 @@ export async function runInit(args: string[]) {
     return initMigrateOnly({ jsonOutput });
   }
 
+  await validateInitSchemaPack(schemaPack, jsonOutput);
+
   // v0.14: AI provider selection.
   // --embedding-model PROVIDER:MODEL (verbose) or --model PROVIDER (shorthand, picks recipe default)
   const embModelIdx = args.indexOf('--embedding-model');
@@ -160,6 +162,31 @@ interface ResolvedAIOptions {
   chat_model?: string;
   /** v0.37 (D9): user opted into deferred embedding setup. */
   noEmbedding?: boolean;
+}
+
+async function validateInitSchemaPack(schemaPack: string, jsonOutput: boolean): Promise<void> {
+  try {
+    const { loadActivePack } = await import('../core/schema-pack/load-active.ts');
+    await loadActivePack({
+      cfg: null,
+      remote: false,
+      perCall: schemaPack,
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    if (jsonOutput) {
+      console.log(JSON.stringify({
+        status: 'error',
+        reason: 'invalid_schema_pack',
+        schema_pack: schemaPack,
+        message,
+      }));
+    } else {
+      console.error(message);
+      console.error('Run `gbrain schema list` to see available packs, or use `gbrain schema init <name>` to create one.');
+    }
+    process.exit(1);
+  }
 }
 
 /**
@@ -1475,17 +1502,19 @@ OPTIONS
                         Model for query expansion (default: anthropic:claude-haiku)
   --chat-model <PROVIDER:MODEL>
                         Default subagent driver (v0.27+)
+  --schema-pack <NAME>  Initial schema pack for new brains (default: gbrain-base-v2)
 
 EXAMPLES
   gbrain init --pglite                      # Local-only, no API keys
   gbrain init --supabase                    # Interactive Supabase setup
   gbrain init --url postgresql://...        # Use a custom Postgres
-  gbrain init --mcp-only --url https://...  # Thin-client mode
+  gbrain init --mcp-only --issuer-url https://... --mcp-url https://.../mcp
+                                            # Thin-client mode
+  gbrain init --schema-pack gbrain-base     # Use the legacy taxonomy
 
 NOTES
-  - Bare \`gbrain init\` in a directory with 1000+ .md files defaults to Supabase
-    interactive setup. With <1000 files (or with --pglite explicitly), defaults
-    to PGLite at ~/.gbrain/brain.pglite.
+  - Bare \`gbrain init\` in a directory with 1000+ .md files prints a Supabase
+    recommendation, but still defaults to PGLite unless --supabase or --url is passed.
   - Existing config is preserved unless --force is passed.
 `.trim());
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -195,7 +195,10 @@ describe('CLI dispatch integration', () => {
       });
       const stdout = await new Response(proc.stdout).text();
       const exitCode = await proc.exited;
-      expect(stdout).toContain('Usage: gbrain init');
+      expect(stdout).toContain('gbrain init [flags]');
+      expect(stdout).toContain('--schema-pack');
+      expect(stdout).toContain('--mcp-only');
+      expect(stdout).not.toContain('run gbrain --help for the full command list');
       expect(existsSync(join(home, '.gbrain', 'config.json'))).toBe(false);
       expect(exitCode).toBe(0);
     } finally {

--- a/test/e2e/init-fresh-pglite.test.ts
+++ b/test/e2e/init-fresh-pglite.test.ts
@@ -123,6 +123,36 @@ describe('v0.37 T12 — D3 non-TTY no-key fail-loud', () => {
 
 // ============================================================================
 
+describe('init --schema-pack validation', () => {
+  let tmpHome: string;
+
+  beforeAll(() => { tmpHome = makeTempHome(); });
+  afterAll(() => { rmSync(tmpHome, { recursive: true, force: true }); });
+
+  test('unknown schema pack fails before writing config', async () => {
+    const r = await runCli([
+      'init',
+      '--pglite',
+      '--no-embedding',
+      '--schema-pack',
+      'definitely-not-a-pack',
+      '--json',
+    ], {
+      gbrainHome: tmpHome,
+      env: {},
+    });
+
+    expect(r.exitCode).toBe(1);
+    const parsed = JSON.parse(r.stdout.trim().split('\n').pop()!);
+    expect(parsed.reason).toBe('invalid_schema_pack');
+    expect(parsed.schema_pack).toBe('definitely-not-a-pack');
+    expect(parsed.message).toContain('unknown schema pack: definitely-not-a-pack');
+    expect(existsSync(join(tmpHome, '.gbrain', 'config.json'))).toBe(false);
+  }, 60000);
+});
+
+// ============================================================================
+
 describe('v0.37 T12 — D6 regression: bug-reporter no-op keys exit 1 with Levenshtein', () => {
   let tmpHome: string;
 


### PR DESCRIPTION
## What changed

- Route `gbrain init --help` through the init command's detailed help instead of the generic CLI-only stub.
- Validate `--schema-pack` during init before creating the brain or writing config.
- Surface a structured `invalid_schema_pack` JSON error for `--json` callers and add regression coverage.
- Update init help text for `--schema-pack`, `--mcp-only`, and the large-brain Supabase recommendation behavior.

## Why

`gbrain init --schema-pack <typo>` previously exited successfully and persisted a broken `schema_pack`, leaving follow-up schema-pack-aware commands to fail later. Separately, the detailed `init --help` handler existed but was unreachable because CLI dispatch intercepted it with the generic stub.

## Validation

- `bun test test/cli.test.ts --timeout 120000`
- `bun test test/e2e/init-fresh-pglite.test.ts --timeout 240000`
- `bun run typecheck`