### PR TITLE
fix(doctor): two false-positive/timeout fixes — drift walk skips node_modules; bare-tweet skips inline-code + cited lines

### DIFF
--- a/src/commands/integrity.ts
+++ b/src/commands/integrity.ts
@@ -98,8 +98,17 @@ export function findBareTweetHits(compiledTruth: string, slug: string): BareTwee
     }
     // If the line already contains a tweet URL, it's cited — skip
     if (URL_NEARBY_RE.test(line)) continue;
+    // If the line carries an explicit source citation (e.g.
+    // "[Source: X, @handle, 2026-05-28]"), it's already attributed — skip.
+    // Catches instructional/example lines in recipe docs that demonstrate
+    // the CORRECT citation format. (v0.42.x)
+    if (/\[\s*source:/i.test(line)) continue;
+    // Strip inline-code spans (`...`) before matching: phrases shown as
+    // inline-code templates in docs are examples, not bare claims. The
+    // fenced-code skip above only covers ``` blocks, not inline backticks.
+    const lineForMatch = line.replace(/`[^`]*`/g, '');
     for (const re of BARE_TWEET_PHRASES) {
-      const m = line.match(re);
+      const m = lineForMatch.match(re);
       if (m) {
         hits.push({ slug, line: i + 1, rawLine: line.trim(), phrase: m[0] });
         break; // one finding per line is enough

--- a/src/core/multi-source-drift.ts
+++ b/src/core/multi-source-drift.ts
@@ -87,6 +87,11 @@ function walkMarkdownAndMdxFiles(
     for (const entry of entries) {
       if (truncated) return;
       if (entry.startsWith('.')) continue;
+      // Skip heavy non-content dirs so the walk doesn't exhaust the time
+      // budget on dependency/build trees (node_modules can be 50k+ files
+      // with zero .md). These are never gbrain page sources.
+      if (entry === 'node_modules' || entry === 'dist' || entry === 'build' ||
+          entry === '.next' || entry === 'vendor' || entry === 'target') continue;
       const full = join(d, entry);
       let isDir = false;
       try {
@@ -95,6 +100,9 @@ function walkMarkdownAndMdxFiles(
         continue;
       }
       if (isDir) {
+        // Time check on directory descent too, so a deep dependency-free
+        // tree still respects the deadline even before any .md is found.
+        if (Date.now() >= deadlineMs) { truncated = true; return; }
         walk(full);
         continue;
       }


### PR DESCRIPTION
Two small, independent accuracy fixes to doctor checks. Grouped because both are 'the check fires wrongly / never completes on real repos.'

## 1. multi_source_drift — skip node_modules/dist/build in the FS walk
`walkMarkdownAndMdxFiles` recursed into **every** directory, including `node_modules` (50k+ files in RN/Astro repos). The time-budget check only fired on `.md` pushes, so the walk spent its whole deadline traversing dependency trees with zero `.md` and returned `truncated=true` — meaning `multi_source_drift` reported *'walk hit limit/timeout'* and **never actually checked for drift** on any real project.

Fix: skip `node_modules`/`dist`/`build`/`.next`/`vendor`/`target` (never page sources) + add a deadline check on directory descent. The check now completes and detects real cross-source drift. (8 lines.)

## 2. integrity bare-tweet — exempt inline-code spans + explicitly-cited lines
`findBareTweetHits` skipped fenced code blocks but **not inline-code spans**, so a recipe/doc line showing the *correct* citation format inline — e.g. `\`Tweeted about {topic} [Source: X, @handle, date]\`` — was false-flagged as a bare tweet.

Fix: strip inline-code spans before matching, and exempt lines carrying an explicit `[Source: ...]` citation. (10 lines.)

Both verified on a live multi-source brain (drift check now completes + reports cleanly; bare-tweet false-positives on a Twitter-ingestion recipe doc cleared).