### PR TITLE
fix(ner): mask existing links before mention scan to stop spurious edges

### DIFF
--- a/src/core/by-mention.ts
+++ b/src/core/by-mention.ts
@@ -27,7 +27,7 @@
  */
 
 import type { BrainEngine } from './engine.ts';
-import { stripCodeBlocks } from './link-extraction.ts';
+import { stripCodeBlocks, stripWikilinks } from './link-extraction.ts';
 
 /** D2: hardcoded entity types for v1. Pack-aware extension is TODO-1. */
 export const LINKABLE_ENTITY_TYPES = ['person', 'company', 'organization', 'entity'] as const;
@@ -222,9 +222,11 @@ export async function buildGazetteer(
  *  - First-mention-only cap: dedup by `entry.slug` (one link per
  *    target page regardless of how many body mentions there are).
  *
- * Code-block stripping via `stripCodeBlocks` (preserves offsets, so the
- * returned mention offsets index into the ORIGINAL text not the stripped
- * text — useful for downstream debugging tools).
+ * Code-block stripping via `stripCodeBlocks` and existing-link masking via
+ * `stripWikilinks` (both preserve offsets, so the returned mention offsets
+ * index into the ORIGINAL text not the stripped text — useful for downstream
+ * debugging tools). Masking existing `[[...]]` / `[text](slug)` links is what
+ * prevents already-linked words from minting a second spurious NER edge.
  */
 export function findMentionedEntities(
   text: string,
@@ -232,7 +234,13 @@ export function findMentionedEntities(
   opts: FindMentionsOpts,
 ): Mention[] {
   if (!text || gazetteer.size === 0) return [];
-  const stripped = stripCodeBlocks(text);
+  // Mask code blocks AND existing links before tokenizing: a word that is
+  // already inside a `[[...]]` wikilink or a `[text](slug)` markdown link is
+  // already a link target and must NOT mint a second, spurious NER edge.
+  // Both strippers are offset-preserving (equal-length whitespace), so mention
+  // offsets still index into the ORIGINAL text. Order is irrelevant since each
+  // only blanks spans the other would already pass through.
+  const stripped = stripWikilinks(stripCodeBlocks(text));
   const tokens = tokenizeForScan(stripped);
   if (tokens.length === 0) return [];
 

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -142,6 +142,67 @@ export function stripCodeBlocks(content: string): string {
 }
 
 /**
+ * Mask already-linked spans from markdown, replacing them with whitespace of
+ * equivalent length (offset-preserving, same contract as stripCodeBlocks).
+ *
+ * Masks two forms so a downstream tokenizer never sees text that is ALREADY a
+ * link target:
+ *  - Wikilinks `[[...]]` (any inner content, including `|display` and bare
+ *    `[[term]]`). Nesting-safe: consumes up to the first `]]` it finds, so a
+ *    correctly-formed link is fully masked; this is deliberately broad (no
+ *    DIR_PATTERN whitelist) because the goal is "don't re-scan linked text",
+ *    not "parse a valid link".
+ *  - Markdown inline links `[text](target)` — the whole span is masked so the
+ *    visible `text` isn't tokenized into a spurious mention.
+ *
+ * Why this exists (v0.42.0.x): findMentionedEntities tokenizes body text to
+ * mint typed NER edges. Without masking, a word sitting INSIDE an existing
+ * link (e.g. the "Session" in `[[fleet/x|Session Recap]]`, or `principles`
+ * in `[[first-principles-thinking]]`) matches the gazetteer and creates a
+ * second, spurious edge from already-linked text. Masking existing links
+ * before the scan removes that false-positive class entirely.
+ */
+export function stripWikilinks(content: string): string {
+  let out = '';
+  let i = 0;
+  while (i < content.length) {
+    // Wikilink: [[ ... ]] — mask through the first closing ]].
+    if (content.startsWith('[[', i)) {
+      const end = content.indexOf(']]', i + 2);
+      if (end === -1) { out += ' '.repeat(content.length - i); break; }
+      out += ' '.repeat(end + 2 - i);
+      i = end + 2;
+      continue;
+    }
+    // Markdown inline link: [text](target) — mask the whole span. Only treat
+    // it as a link when a `](` follows the opening `[` before the matching
+    // `]`, and the `(...)` closes on the same line. Otherwise emit the `[`
+    // verbatim (it's prose, not a link).
+    if (content[i] === '[') {
+      const closeBracket = content.indexOf(']', i + 1);
+      if (
+        closeBracket !== -1 &&
+        content[closeBracket + 1] === '(' &&
+        !content.slice(i + 1, closeBracket).includes('\n')
+      ) {
+        const closeParen = content.indexOf(')', closeBracket + 2);
+        if (closeParen !== -1 && !content.slice(closeBracket + 2, closeParen).includes('\n')) {
+          out += ' '.repeat(closeParen + 1 - i);
+          i = closeParen + 1;
+          continue;
+        }
+      }
+      out += content[i];
+      i++;
+      continue;
+    }
+    out += content[i];
+    i++;
+  }
+  return out;
+}
+
+/**
  * A code-reference found in markdown prose. Created by extractCodeRefs and
  * consumed by importFromFile's tail to build doc↔impl edges (v0.19.0 E1).
  */

--- a/test/by-mention.test.ts
+++ b/test/by-mention.test.ts
@@ -159,6 +159,53 @@ describe('findMentionedEntities — pure cases', () => {
     expect(mentions).toHaveLength(0);
   });
 
+  test('6b. wikilink masking — bare [[Acme]] does NOT mint a mention', () => {
+    const g = gazetteerFromEntries([
+      { slug: 'companies/acme', source_id: 'default', title: 'Acme' },
+    ]);
+    const mentions = findMentionedEntities('We invested in [[Acme]] last year.', g, {
+      fromSlug: 'writing/post-1', fromSourceId: 'default',
+    });
+    expect(mentions).toHaveLength(0);
+  });
+
+  test('6c. wikilink masking — word inside [[slug|Display]] display text is not re-scanned', () => {
+    const g = gazetteerFromEntries([
+      { slug: 'companies/acme', source_id: 'default', title: 'Acme' },
+    ]);
+    // "Acme" lives only inside the display text of an existing link.
+    const mentions = findMentionedEntities('See [[companies/acme|Acme Corp update]].', g, {
+      fromSlug: 'writing/post-1', fromSourceId: 'default',
+    });
+    expect(mentions).toHaveLength(0);
+  });
+
+  test('6d. markdown-link masking — word inside [text](slug) is not re-scanned', () => {
+    const g = gazetteerFromEntries([
+      { slug: 'companies/acme', source_id: 'default', title: 'Acme' },
+    ]);
+    const mentions = findMentionedEntities('Read the [Acme report](companies/acme).', g, {
+      fromSlug: 'writing/post-1', fromSourceId: 'default',
+    });
+    expect(mentions).toHaveLength(0);
+  });
+
+  test('6e. masking is span-local — an UNLINKED mention on the same line still matches', () => {
+    const g = gazetteerFromEntries([
+      { slug: 'companies/acme', source_id: 'default', title: 'Acme' },
+    ]);
+    // First "Acme" is inside a link (masked); the second, bare "Acme" must match.
+    const body = 'Both [[companies/acme|Acme]] and Acme grew.';
+    const mentions = findMentionedEntities(body, g, {
+      fromSlug: 'writing/post-1', fromSourceId: 'default',
+    });
+    expect(mentions).toHaveLength(1);
+    expect(mentions[0]!.slug).toBe('companies/acme');
+    // Offset must point at the BARE occurrence (un-stripped original text).
+    expect(body.slice(mentions[0]!.offset, mentions[0]!.offset + 4)).toBe('Acme');
+    expect(mentions[0]!.offset).toBe(body.lastIndexOf('Acme'));
+  });
+
   test('10. first-mention-only cap — 5 body mentions of same entity → 1 link', () => {
     const g = gazetteerFromEntries([
       { slug: 'companies/acme', source_id: 'default', title: 'Acme' },


### PR DESCRIPTION
## Problem

The by-mention NER scan re-scanned text that already contained explicit `[[wikilinks]]`, producing spurious duplicate/competing edges for names that were already linked.

## Fix

Mask already-linked spans before the mention scan so an explicit link isn't double-counted as a bare mention. Adds the masking pass in `link-extraction.ts` + wires it into `by-mention.ts`.

## Verification

48 tests pass (`test/by-mention.test.ts` + related), 0 fail — including coverage for the masking behavior.

Small, self-contained (3 files, +121/-5).