### PR TITLE
fix(db-lock): bind release to lock acquisition ownership

### DIFF
--- a/src/core/db-lock.ts
+++ b/src/core/db-lock.ts
@@ -80,7 +80,7 @@ export async function tryAcquireDbLock(
     // `gbrain sync --break-lock --max-age <s>` uses last_refreshed_at (not
     // acquired_at) to identify wedged-but-alive holders without stealing
     // healthy long-running holders that are actively refreshing.
-    const rows: Array<{ id: string }> = await sql`
+    const rows: Array<{ id: string; acquired_at: Date | string }> = await sql`
       INSERT INTO gbrain_cycle_locks (id, holder_pid, holder_host, acquired_at, ttl_expires_at, last_refreshed_at)
       VALUES (${lockId}, ${pid}, ${host}, NOW(), NOW() + ${ttl}::interval, NOW())
       ON CONFLICT (id) DO UPDATE
@@ -90,13 +90,14 @@ export async function tryAcquireDbLock(
             ttl_expires_at = NOW() + ${ttl}::interval,
             last_refreshed_at = NOW()
         WHERE gbrain_cycle_locks.ttl_expires_at < NOW()
-      RETURNING id
+      RETURNING id, acquired_at
     `;
     if (rows.length === 0) return null;
+    const acquiredAt = rows[0].acquired_at;
     const deregister = registerCleanup(`db-lock:${lockId}`, async () => {
       await sql`
         DELETE FROM gbrain_cycle_locks
-        WHERE id = ${lockId} AND holder_pid = ${pid}
+        WHERE id = ${lockId} AND holder_pid = ${pid} AND acquired_at = ${acquiredAt}
       `;
     });
     return {
@@ -109,14 +110,14 @@ export async function tryAcquireDbLock(
           UPDATE gbrain_cycle_locks
             SET ttl_expires_at = NOW() + ${ttl}::interval,
                 last_refreshed_at = NOW()
-          WHERE id = ${lockId} AND holder_pid = ${pid}
+          WHERE id = ${lockId} AND holder_pid = ${pid} AND acquired_at = ${acquiredAt}
         `;
       },
       release: async () => {
         deregister();
         await sql`
           DELETE FROM gbrain_cycle_locks
-          WHERE id = ${lockId} AND holder_pid = ${pid}
+          WHERE id = ${lockId} AND holder_pid = ${pid} AND acquired_at = ${acquiredAt}
         `;
       },
     };
@@ -135,14 +136,15 @@ export async function tryAcquireDbLock(
              ttl_expires_at = NOW() + $4::interval,
              last_refreshed_at = NOW()
          WHERE gbrain_cycle_locks.ttl_expires_at < NOW()
-       RETURNING id`,
+       RETURNING id, acquired_at`,
       [lockId, pid, host, ttl],
     );
     if (rows.length === 0) return null;
+    const acquiredAt = (rows[0] as { acquired_at: Date | string }).acquired_at;
     const deregister = registerCleanup(`db-lock:${lockId}`, async () => {
       await db.query(
-        `DELETE FROM gbrain_cycle_locks WHERE id = $1 AND holder_pid = $2`,
-        [lockId, pid],
+        `DELETE FROM gbrain_cycle_locks WHERE id = $1 AND holder_pid = $2 AND acquired_at = $3`,
+        [lockId, pid, acquiredAt],
       );
     });
     return {
@@ -152,15 +154,15 @@ export async function tryAcquireDbLock(
           `UPDATE gbrain_cycle_locks
               SET ttl_expires_at = NOW() + $1::interval,
                   last_refreshed_at = NOW()
-            WHERE id = $2 AND holder_pid = $3`,
-          [ttl, lockId, pid],
+            WHERE id = $2 AND holder_pid = $3 AND acquired_at = $4`,
+          [ttl, lockId, pid, acquiredAt],
         );
       },
       release: async () => {
         deregister();
         await db.query(
-          `DELETE FROM gbrain_cycle_locks WHERE id = $1 AND holder_pid = $2`,
-          [lockId, pid],
+          `DELETE FROM gbrain_cycle_locks WHERE id = $1 AND holder_pid = $2 AND acquired_at = $3`,
+          [lockId, pid, acquiredAt],
         );
       },
     };

--- a/test/db-lock-release-ownership.test.ts
+++ b/test/db-lock-release-ownership.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression: a stale handle from an expired lock must not delete a newer
+ * same-process takeover of the same lock row.
+ *
+ * The old release predicate matched only (id, holder_pid). In a Minion worker
+ * process, multiple jobs can run in the same PID; if an old handle's finally ran
+ * after a same-PID takeover, it could delete the new live lock and leave doctor
+ * seeing inconsistent/stale cycle-lock state. The lock row must be owned by the
+ * specific acquisition, not just by PID.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { tryAcquireDbLock } from '../src/core/db-lock.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+}, 30_000);
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+}, 30_000);
+
+describe('tryAcquireDbLock release ownership', () => {
+  test('old same-pid handle release does not delete newer expired-lock takeover', async () => {
+    const lockId = 'test-lock-release-same-pid-takeover';
+    const first = await tryAcquireDbLock(engine, lockId, 1);
+    expect(first).not.toBeNull();
+
+    // Simulate an expired holder without waiting a minute.
+    await engine.executeRaw(
+      `UPDATE gbrain_cycle_locks
+          SET ttl_expires_at = NOW() - INTERVAL '1 second',
+              last_refreshed_at = NOW() - INTERVAL '1 second'
+        WHERE id = $1`,
+      [lockId],
+    );
+
+    const second = await tryAcquireDbLock(engine, lockId, 1);
+    expect(second).not.toBeNull();
+
+    // The stale first handle has the same process.pid. Its release must not
+    // delete the second handle's newer ownership row.
+    await first!.release();
+
+    const third = await tryAcquireDbLock(engine, lockId, 1);
+    expect(third).toBeNull();
+
+    await second!.release();
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary
- Bind DB lock `refresh()` / `release()` cleanup to the specific acquisition timestamp, not just `(id, holder_pid)`.
- Prevent a stale same-process lock handle from deleting a newer live takeover of the same lock row.
- Add a regression test covering same-PID expired-lock takeover behavior.

## Why
Long-running worker processes can execute multiple jobs under the same PID. If an old handle's `finally` path runs after a same-PID takeover, the previous predicate could delete the newer live lock because it matched only `(id, holder_pid)`. Including `acquired_at` makes the lock handle an ownership token for the specific acquisition.

## Test plan
- `bun install`
- `bun test test/db-lock-release-ownership.test.ts test/db-lock-per-source.test.ts`
