### PR TITLE
Add autopilot health reporting and sync freshness labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ test/fixtures/pglite-snapshot.version
 
 # Private brain reports — never check these in (per CLAUDE.md privacy rule)
 reports/network-intelligence/
+
+# Auto-managed by gbrain (db_only directories)
+media/x/
+media/articles/
+meetings/transcripts/

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -24,6 +24,17 @@ import type { BrainEngine } from '../core/engine.ts';
 import { loadPreferences } from '../core/preferences.ts';
 import { loadConfig, gbrainPath as gbrainHomePath } from '../core/config.ts';
 import { ChildWorkerSupervisor } from '../core/minions/child-worker-supervisor.ts';
+import {
+  buildAutopilotHealth,
+  detectAutopilotInstallTarget,
+  autopilotEphemeralStartScriptPath as ephemeralStartScriptPath,
+  autopilotPlistPath as plistPath,
+  autopilotSystemdUnitPath as systemdUnitPath,
+  type AutopilotInstallTarget,
+} from '../core/autopilot-health.ts';
+
+export { detectAutopilotInstallTarget as detectInstallTarget };
+export type { AutopilotInstallTarget as InstallTarget };
 
 /**
  * v0.37.7.0 #1162 — classify autopilot reconnect-loop errors.
@@ -721,55 +732,6 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
 
 // --- Install/Uninstall ---
 
-function plistPath(): string {
-  return join(process.env.HOME || '', 'Library', 'LaunchAgents', 'com.gbrain.autopilot.plist');
-}
-
-function systemdUnitPath(): string {
-  return join(process.env.HOME || '', '.config', 'systemd', 'user', 'gbrain-autopilot.service');
-}
-
-function ephemeralStartScriptPath(): string {
-  return join(process.env.HOME || '', '.gbrain', 'start-autopilot.sh');
-}
-
-export type InstallTarget = 'macos' | 'linux-systemd' | 'ephemeral-container' | 'linux-cron';
-
-/**
- * Detect the right supervisor for this host.
- *
- *   - macos   → launchd (always, when platform === 'darwin').
- *   - ephemeral-container → Render / Railway / Fly / Docker. Crontab is
- *                           unreliable here (wiped on deploy); we hand
- *                           the user a start script instead.
- *   - linux-systemd → systemd user scope actually works (is-system-running
- *                     probe succeeds). Codex hardened from the naive
- *                     /run/systemd/system check.
- *   - linux-cron  → fallback.
- */
-export function detectInstallTarget(): InstallTarget {
-  if (process.platform === 'darwin') return 'macos';
-
-  const ephemeral = !!(
-    process.env.RENDER
-    || process.env.RAILWAY_ENVIRONMENT
-    || process.env.FLY_APP_NAME
-    || existsSync('/.dockerenv')
-  );
-  if (ephemeral) return 'ephemeral-container';
-
-  if (existsSync('/run/systemd/system')) {
-    try {
-      execSync('systemctl --user is-system-running', { stdio: 'pipe', timeout: 3000 });
-      return 'linux-systemd';
-    } catch {
-      // user bus not available → fall through to cron.
-    }
-  }
-
-  return 'linux-cron';
-}
-
 function detectOpenClaw(): { detected: boolean; bootstrapCandidates: string[] } {
   const home = process.env.HOME || '';
   const candidates = [
@@ -818,8 +780,8 @@ async function installDaemon(engine: BrainEngine, args: string[]) {
     process.exit(1);
   }
 
-  const forcedTarget = parseArg(args, '--target') as InstallTarget | undefined;
-  const target: InstallTarget = forcedTarget ?? detectInstallTarget();
+  const forcedTarget = parseArg(args, '--target') as AutopilotInstallTarget | undefined;
+  const target: AutopilotInstallTarget = forcedTarget ?? detectAutopilotInstallTarget();
 
   const injectBootstrap = args.includes('--inject-bootstrap');
   const noInject = args.includes('--no-inject');
@@ -1132,29 +1094,30 @@ function uninstallDaemon() {
 }
 
 function showStatus(json: boolean) {
-  const logFile = join(process.env.HOME || '', '.gbrain', 'autopilot.log');
-  let lastLine = '';
-  try {
-    const content = readFileSync(logFile, 'utf-8');
-    const lines = content.trim().split('\n');
-    lastLine = lines[lines.length - 1] || '';
-  } catch { /* no log */ }
-
-  let installed = false;
-  if (process.platform === 'darwin') {
-    installed = existsSync(plistPath());
-  } else {
-    try {
-      const crontab = execSync('crontab -l 2>/dev/null || true', { encoding: 'utf-8' });
-      installed = crontab.includes('gbrain autopilot');
-    } catch { /* no crontab */ }
-  }
+  const health = buildAutopilotHealth();
 
   if (json) {
-    console.log(JSON.stringify({ installed, last_log: lastLine }));
+    console.log(JSON.stringify(health));
   } else {
-    console.log(`Autopilot: ${installed ? 'installed' : 'not installed'}`);
-    if (lastLine) console.log(`Last log: ${lastLine}`);
+    console.log(`Autopilot target: ${health.install_target}`);
+    console.log(`Installed: ${health.installed ? 'yes' : 'no'}`);
+    if (health.artifact_present !== null) {
+      console.log(`Install artifact: ${health.artifact_present ? 'present' : 'missing'}`);
+    }
+    if (health.manager_registered !== null) {
+      console.log(`Manager registered: ${health.manager_registered ? 'yes' : 'no'}`);
+    }
+    if (health.manager_loaded !== null) {
+      console.log(`Manager loaded: ${health.manager_loaded ? 'yes' : 'no'}`);
+    }
+    if (health.running) {
+      console.log(`Runtime: running (PID ${health.pid})`);
+    } else if (health.lockfile_present) {
+      console.log(`Runtime: stale lockfile (PID ${health.pid ?? '?'})`);
+    } else {
+      console.log('Runtime: not running');
+    }
+    if (health.last_log) console.log(`Last log: ${health.last_log}`);
   }
 }
 

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -586,7 +586,7 @@ async function runStatus(engine: BrainEngine, args: string[]): Promise<void> {
   const sources = await loadAllSources(engine, { includeArchived: false });
   if (sources.length === 0) {
     if (json) {
-      console.log(JSON.stringify({ schema_version: 1, sources: [] }, null, 2));
+      console.log(JSON.stringify({ schema_version: 1, freshness_mode: 'live_git', sources: [] }, null, 2));
     } else {
       console.log('No sources registered. Use `gbrain sources add <id> --path <path>` first.');
     }
@@ -597,13 +597,14 @@ async function runStatus(engine: BrainEngine, args: string[]): Promise<void> {
   const metrics = await computeAllSourceMetrics(engine, sources, { probeContent: true });
 
   if (json) {
-    console.log(JSON.stringify({ schema_version: 1, sources: metrics }, null, 2));
+    console.log(JSON.stringify({ schema_version: 1, freshness_mode: 'live_git', sources: metrics }, null, 2));
     return;
   }
 
   // Human-readable table: SOURCE | LAG | EMBED | BACKFILL | FAILS | QUEUE | PAGES | LAST SYNC
   console.log('SOURCES — health');
   console.log('────────────────');
+  console.log('Freshness mode: live_git (host-local HEAD probe)');
   console.log(
     `  ${'SOURCE'.padEnd(20)}  ${'LAG'.padEnd(8)}  ${'EMBED'.padEnd(7)}  ${'BACKFILL'.padEnd(9)}  ${'FAILS'.padEnd(6)}  ${'QUEUE'.padEnd(6)}  ${'PAGES'.padStart(8)}  LAST SYNC`,
   );
@@ -1186,6 +1187,7 @@ Subcommands:
   status [--json]                   v0.40.3.0 — read-only per-source dashboard:
                                     last sync, staleness, page count,
                                     embedding coverage, unacked failures.
+                                    Freshness is live_git on this host.
                                     --json emits {schema_version:1, ...} on
                                     stdout for monitoring pipelines.
   archived [--json]                 List soft-deleted sources and their expiry.

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -36,9 +36,12 @@
  */
 
 import type { BrainEngine } from '../core/engine.ts';
-import { existsSync, readFileSync } from 'node:fs';
-import { gbrainPath, loadConfig, isThinClient } from '../core/config.ts';
+import { loadConfig, isThinClient } from '../core/config.ts';
 import { callRemoteTool, unpackToolResult } from '../core/mcp-client.ts';
+import {
+  buildAutopilotHealth,
+  type AutopilotHealth,
+} from '../core/autopilot-health.ts';
 import {
   buildSyncStatusReport,
   type SyncStatusReport,
@@ -95,12 +98,7 @@ export interface WorkerSummary {
   last_event_ts: string | null;
 }
 
-export interface AutopilotStatus {
-  installed: boolean;
-  lockfile_present: boolean;
-  pid: number | null;
-  running: boolean;
-}
+export type AutopilotStatus = AutopilotHealth;
 
 export interface StatusReport {
   schema_version: typeof SCHEMA_VERSION;
@@ -265,40 +263,6 @@ function buildWorkerSummary(): WorkerSummary {
   return { crashes_24h, clean_exits_24h, by_cause, last_event_ts };
 }
 
-function buildAutopilotStatus(): AutopilotStatus {
-  const lockPath = gbrainPath('autopilot.lock');
-  const lockfile_present = existsSync(lockPath);
-  let pid: number | null = null;
-  let running = false;
-  if (lockfile_present) {
-    try {
-      const raw = readFileSync(lockPath, 'utf-8').trim();
-      const parsed = parseInt(raw, 10);
-      if (Number.isFinite(parsed) && parsed > 0) {
-        pid = parsed;
-        try {
-          // kill -0 probes liveness without sending a real signal. Throws ESRCH
-          // if the PID is gone, EPERM if alive but owned by another user (which
-          // still tells us "something with that PID exists").
-          process.kill(parsed, 0);
-          running = true;
-        } catch (err) {
-          const code = (err as NodeJS.ErrnoException).code;
-          running = code === 'EPERM';
-        }
-      }
-    } catch {
-      /* unreadable lockfile, leave pid=null/running=false */
-    }
-  }
-  return {
-    installed: lockfile_present, // installed-or-running proxy; daemons writing the lock are installed
-    lockfile_present,
-    pid,
-    running,
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Orchestrator
 // ---------------------------------------------------------------------------
@@ -352,7 +316,7 @@ async function buildLocalReport(
     report.queue = await buildQueueCounts(engine);
   }
   if (want('autopilot')) {
-    report.autopilot = buildAutopilotStatus();
+    report.autopilot = buildAutopilotHealth();
   }
   if (warnings.length > 0) report.warnings = warnings;
   return report;
@@ -496,13 +460,23 @@ function renderHuman(report: StatusReport): string {
       lines.push('  local-only — N/A on remote brain');
     } else {
       const a = report.autopilot;
+      const boolOrUnknown = (value: boolean | null) => value === null ? 'n/a' : (value ? 'yes' : 'no');
+      lines.push(
+        `  target=${a.install_target}  installed=${a.installed ? 'yes' : 'no'}  running=${a.running ? 'yes' : 'no'}`,
+      );
+      lines.push(
+        `  artifact=${boolOrUnknown(a.artifact_present)}  registered=${boolOrUnknown(a.manager_registered)}  loaded=${boolOrUnknown(a.manager_loaded)}`,
+      );
       if (a.running) {
         lines.push(`  running (PID ${a.pid})`);
       } else if (a.lockfile_present) {
         lines.push(`  stale lockfile (PID ${a.pid ?? '?'} not alive). Run \`gbrain autopilot --install\` to restart.`);
+      } else if (a.installed && a.manager_loaded === false) {
+        lines.push('  install artifact exists, but the service manager has not loaded autopilot.');
       } else {
         lines.push('  not running. Install with `gbrain autopilot --install`.');
       }
+      if (a.last_log) lines.push(`  last log: ${a.last_log}`);
     }
     lines.push('');
   }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -7,6 +7,7 @@
  *
  * Six sections:
  *   - Sync       — per-source last_sync_at + staleness
+ *                  (`stored_db` / remote-safe; not a live git probe)
  *   - Cycle      — TWO rows: last FULL cycle (autopilot-cycle) +
  *                  last TARGETED run (any autopilot-* job). Reflects
  *                  v0.36.4.0's health-aware autopilot (healthy brains run
@@ -371,6 +372,7 @@ function renderHuman(report: StatusReport): string {
   // Sync
   if (report.sync) {
     lines.push('Sync:');
+    lines.push(`  freshness=${report.sync.freshness_mode} (newest_content_at column; remote-safe)`);
     if (report.sync.sources.length === 0) {
       lines.push('  (no sources registered)');
     } else {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -3047,6 +3047,10 @@ export interface SyncStatusReportSource {
 export interface SyncStatusReport {
   schema_version: 1;
   generated_at: string;
+  /** Freshness signal for staleness_class/staleness_hours in this report.
+   *  `stored_db` means commit-relative lag came from the durable
+   *  `sources.newest_content_at` column, not a live git probe. */
+  freshness_mode: 'stored_db';
   sources: SyncStatusReportSource[];
   unacknowledged_failures: number;
   /** The embedding column counts were computed against. Useful for
@@ -3247,6 +3251,7 @@ export async function buildSyncStatusReport(
   return {
     schema_version: 1,
     generated_at: new Date().toISOString(),
+    freshness_mode: 'stored_db',
     sources: out,
     unacknowledged_failures: unackedCount,
     embedding_column: resolved.name,
@@ -3266,6 +3271,7 @@ export function printSyncStatusReport(
 ): void {
   const write = (line: string) => sink.write(line + '\n');
   write(`\nSync status — generated ${report.generated_at}`);
+  write('Freshness mode: stored_db (newest_content_at column; remote-safe)');
   write(`Embedding column: ${report.embedding_column}\n`);
   if (report.sources.length === 0) {
     write('  (no sources registered)');

--- a/src/core/autopilot-health.ts
+++ b/src/core/autopilot-health.ts
@@ -1,0 +1,208 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+import { gbrainPath } from './config.ts';
+
+export type AutopilotInstallTarget = 'macos' | 'linux-systemd' | 'ephemeral-container' | 'linux-cron';
+
+export interface AutopilotHealth {
+  install_target: AutopilotInstallTarget;
+  installed: boolean;
+  artifact_present: boolean | null;
+  manager_registered: boolean | null;
+  manager_loaded: boolean | null;
+  lockfile_present: boolean;
+  pid: number | null;
+  running: boolean;
+  last_log: string | null;
+}
+
+export interface AutopilotHealthDeps {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  home?: string;
+  gbrainHome?: string;
+  existsSync?: typeof existsSync;
+  readFileSync?: typeof readFileSync;
+  execSync?: typeof execSync;
+  kill?: typeof process.kill;
+}
+
+export function autopilotPlistPath(home = process.env.HOME || ''): string {
+  return join(home, 'Library', 'LaunchAgents', 'com.gbrain.autopilot.plist');
+}
+
+export function autopilotSystemdUnitPath(home = process.env.HOME || ''): string {
+  return join(home, '.config', 'systemd', 'user', 'gbrain-autopilot.service');
+}
+
+export function autopilotEphemeralStartScriptPath(home = process.env.HOME || ''): string {
+  return join(home, '.gbrain', 'start-autopilot.sh');
+}
+
+export function autopilotLogPath(home = process.env.HOME || ''): string {
+  return join(home, '.gbrain', 'autopilot.log');
+}
+
+export function autopilotLockPath(gbrainHome = gbrainPath()): string {
+  return join(gbrainHome, 'autopilot.lock');
+}
+
+export function detectAutopilotInstallTarget(
+  deps: Pick<AutopilotHealthDeps, 'platform' | 'env' | 'existsSync' | 'execSync'> = {},
+): AutopilotInstallTarget {
+  const platform = deps.platform ?? process.platform;
+  const env = deps.env ?? process.env;
+  const hasPath = deps.existsSync ?? existsSync;
+  const run = deps.execSync ?? execSync;
+
+  if (platform === 'darwin') return 'macos';
+
+  const ephemeral = !!(
+    env.RENDER
+    || env.RAILWAY_ENVIRONMENT
+    || env.FLY_APP_NAME
+    || hasPath('/.dockerenv')
+  );
+  if (ephemeral) return 'ephemeral-container';
+
+  if (hasPath('/run/systemd/system')) {
+    try {
+      run('systemctl --user is-system-running', { stdio: 'pipe', timeout: 3000 });
+      return 'linux-systemd';
+    } catch {
+      // fall through to cron
+    }
+  }
+
+  return 'linux-cron';
+}
+
+function readLastLogLine(filePath: string, read: typeof readFileSync): string | null {
+  try {
+    const content = read(filePath, 'utf-8').trim();
+    if (!content) return null;
+    const lines = content.split('\n');
+    return lines[lines.length - 1] || null;
+  } catch {
+    return null;
+  }
+}
+
+function commandSucceeded(
+  run: typeof execSync,
+  command: string,
+  timeout = 3000,
+): boolean {
+  try {
+    run(command, { stdio: 'pipe', timeout });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function commandOutput(
+  run: typeof execSync,
+  command: string,
+  timeout = 3000,
+): string | null {
+  try {
+    const out = run(command, { encoding: 'utf-8', stdio: 'pipe', timeout });
+    return typeof out === 'string' ? out : out.toString('utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function resolvePidState(
+  lockPath: string,
+  hasPath: typeof existsSync,
+  read: typeof readFileSync,
+  kill: typeof process.kill,
+): { lockfile_present: boolean; pid: number | null; running: boolean } {
+  const lockfile_present = hasPath(lockPath);
+  let pid: number | null = null;
+  let running = false;
+
+  if (!lockfile_present) {
+    return { lockfile_present, pid, running };
+  }
+
+  try {
+    const raw = read(lockPath, 'utf-8').trim();
+    const parsed = parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      pid = parsed;
+      try {
+        kill(parsed, 0);
+        running = true;
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        running = code === 'EPERM';
+      }
+    }
+  } catch {
+    // leave pid/running at null/false
+  }
+
+  return { lockfile_present, pid, running };
+}
+
+export function buildAutopilotHealth(deps: AutopilotHealthDeps = {}): AutopilotHealth {
+  const hasPath = deps.existsSync ?? existsSync;
+  const read = deps.readFileSync ?? readFileSync;
+  const run = deps.execSync ?? execSync;
+  const kill = deps.kill ?? process.kill.bind(process);
+  const env = deps.env ?? process.env;
+  const home = deps.home ?? env.HOME ?? process.env.HOME ?? '';
+  const gbrainHome = deps.gbrainHome ?? gbrainPath();
+  const installTarget = detectAutopilotInstallTarget({
+    platform: deps.platform,
+    env,
+    existsSync: hasPath,
+    execSync: run,
+  });
+
+  const last_log = readLastLogLine(autopilotLogPath(home), read);
+  const pidState = resolvePidState(autopilotLockPath(gbrainHome), hasPath, read, kill);
+
+  let artifact_present: boolean | null = null;
+  let manager_registered: boolean | null = null;
+  let manager_loaded: boolean | null = null;
+
+  switch (installTarget) {
+    case 'macos':
+      artifact_present = hasPath(autopilotPlistPath(home));
+      manager_registered = commandSucceeded(run, 'launchctl list com.gbrain.autopilot');
+      manager_loaded = manager_registered;
+      break;
+    case 'linux-systemd':
+      artifact_present = hasPath(autopilotSystemdUnitPath(home));
+      manager_registered = commandSucceeded(run, 'systemctl --user is-enabled gbrain-autopilot.service');
+      manager_loaded = commandSucceeded(run, 'systemctl --user is-active gbrain-autopilot.service');
+      break;
+    case 'ephemeral-container':
+      artifact_present = hasPath(autopilotEphemeralStartScriptPath(home));
+      break;
+    case 'linux-cron': {
+      const crontab = commandOutput(run, 'crontab -l 2>/dev/null || true');
+      manager_registered = Boolean(
+        crontab && (crontab.includes('gbrain autopilot') || crontab.includes('autopilot-run.sh')),
+      );
+      break;
+    }
+  }
+
+  return {
+    install_target: installTarget,
+    installed: artifact_present === true || manager_registered === true,
+    artifact_present,
+    manager_registered,
+    manager_loaded,
+    lockfile_present: pidState.lockfile_present,
+    pid: pidState.pid,
+    running: pidState.running,
+    last_log,
+  };
+}

--- a/src/core/autopilot-health.ts
+++ b/src/core/autopilot-health.ts
@@ -108,8 +108,7 @@ function commandOutput(
   timeout = 3000,
 ): string | null {
   try {
-    const out = run(command, { encoding: 'utf-8', stdio: 'pipe', timeout });
-    return typeof out === 'string' ? out : out.toString('utf-8');
+    return run(command, { encoding: 'utf-8', stdio: 'pipe', timeout });
   } catch {
     return null;
   }

--- a/test/autopilot-health.test.ts
+++ b/test/autopilot-health.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  autopilotLockPath,
+  autopilotLogPath,
+  autopilotPlistPath,
+  autopilotSystemdUnitPath,
+  buildAutopilotHealth,
+} from '../src/core/autopilot-health.ts';
+
+function makeExec(responses: Record<string, string | Error>) {
+  return ((command: string) => {
+    const response = responses[command];
+    if (response instanceof Error) throw response;
+    return response ?? '';
+  }) as typeof import('node:child_process').execSync;
+}
+
+function makeRead(files: Record<string, string>) {
+  return ((filePath: string) => {
+    if (!(filePath in files)) throw new Error(`ENOENT: ${filePath}`);
+    return files[filePath]!;
+  }) as typeof import('node:fs').readFileSync;
+}
+
+function makeExists(existing: string[]) {
+  const set = new Set(existing);
+  return ((filePath: string) => set.has(filePath)) as typeof import('node:fs').existsSync;
+}
+
+describe('buildAutopilotHealth', () => {
+  test('macOS artifact present but launchd not loaded → installed yes, loaded no', () => {
+    const home = '/tmp/home-macos';
+    const gbrainHome = '/tmp/gbrain-macos';
+    const plist = autopilotPlistPath(home);
+    const log = autopilotLogPath(home);
+    const health = buildAutopilotHealth({
+      platform: 'darwin',
+      home,
+      gbrainHome,
+      existsSync: makeExists([plist, log]),
+      readFileSync: makeRead({ [log]: 'first line\nsecond line\n' }),
+      execSync: makeExec({
+        'launchctl list com.gbrain.autopilot': new Error('not loaded'),
+      }),
+      kill: (() => {
+        const err = new Error('missing pid') as NodeJS.ErrnoException;
+        err.code = 'ESRCH';
+        throw err;
+      }) as typeof process.kill,
+    });
+    expect(health.install_target).toBe('macos');
+    expect(health.installed).toBe(true);
+    expect(health.artifact_present).toBe(true);
+    expect(health.manager_registered).toBe(false);
+    expect(health.manager_loaded).toBe(false);
+    expect(health.running).toBe(false);
+    expect(health.last_log).toBe('second line');
+  });
+
+  test('stale lockfile with dead pid surfaces pid but not running', () => {
+    const home = '/tmp/home-lock';
+    const gbrainHome = '/tmp/gbrain-lock';
+    const lock = autopilotLockPath(gbrainHome);
+    const health = buildAutopilotHealth({
+      platform: 'linux',
+      home,
+      gbrainHome,
+      existsSync: makeExists([lock]),
+      readFileSync: makeRead({ [lock]: '4242' }),
+      execSync: makeExec({
+        'crontab -l 2>/dev/null || true': '',
+      }),
+      kill: ((_pid: number, _signal?: number) => {
+        const err = new Error('gone') as NodeJS.ErrnoException;
+        err.code = 'ESRCH';
+        throw err;
+      }) as typeof process.kill,
+    });
+    expect(health.lockfile_present).toBe(true);
+    expect(health.pid).toBe(4242);
+    expect(health.running).toBe(false);
+  });
+
+  test('cron registration with live pid reports installed and running', () => {
+    const home = '/tmp/home-cron';
+    const gbrainHome = '/tmp/gbrain-cron';
+    const lock = autopilotLockPath(gbrainHome);
+    const health = buildAutopilotHealth({
+      platform: 'linux',
+      home,
+      gbrainHome,
+      existsSync: makeExists([lock]),
+      readFileSync: makeRead({ [lock]: '7777' }),
+      execSync: makeExec({
+        'crontab -l 2>/dev/null || true': "*/5 * * * * '/tmp/.gbrain/autopilot-run.sh' >> ~/.gbrain/autopilot.log 2>&1\n",
+      }),
+      kill: (() => {}) as typeof process.kill,
+    });
+    expect(health.install_target).toBe('linux-cron');
+    expect(health.installed).toBe(true);
+    expect(health.artifact_present).toBeNull();
+    expect(health.manager_registered).toBe(true);
+    expect(health.manager_loaded).toBeNull();
+    expect(health.pid).toBe(7777);
+    expect(health.running).toBe(true);
+  });
+
+  test('systemd unit can separate artifact, registration, and active manager state', () => {
+    const home = '/tmp/home-systemd';
+    const gbrainHome = '/tmp/gbrain-systemd';
+    const unit = autopilotSystemdUnitPath(home);
+    const health = buildAutopilotHealth({
+      platform: 'linux',
+      home,
+      gbrainHome,
+      existsSync: makeExists(['/run/systemd/system', unit]),
+      execSync: makeExec({
+        'systemctl --user is-system-running': 'running\n',
+        'systemctl --user is-enabled gbrain-autopilot.service': 'enabled\n',
+        'systemctl --user is-active gbrain-autopilot.service': 'active\n',
+      }),
+    });
+    expect(health.install_target).toBe('linux-systemd');
+    expect(health.installed).toBe(true);
+    expect(health.artifact_present).toBe(true);
+    expect(health.manager_registered).toBe(true);
+    expect(health.manager_loaded).toBe(true);
+    expect(health.running).toBe(false);
+  });
+
+  test('unreadable log and malformed lockfile fail open', () => {
+    const home = '/tmp/home-bad';
+    const gbrainHome = '/tmp/gbrain-bad';
+    const lock = autopilotLockPath(gbrainHome);
+    const health = buildAutopilotHealth({
+      platform: 'linux',
+      home,
+      gbrainHome,
+      existsSync: makeExists([lock]),
+      readFileSync: makeRead({ [lock]: 'not-a-pid' }),
+      execSync: makeExec({
+        'crontab -l 2>/dev/null || true': '',
+      }),
+    });
+    expect(health.lockfile_present).toBe(true);
+    expect(health.pid).toBeNull();
+    expect(health.running).toBe(false);
+    expect(health.last_log).toBeNull();
+  });
+});

--- a/test/autopilot-health.test.ts
+++ b/test/autopilot-health.test.ts
@@ -94,7 +94,7 @@ describe('buildAutopilotHealth', () => {
       execSync: makeExec({
         'crontab -l 2>/dev/null || true': "*/5 * * * * '/tmp/.gbrain/autopilot-run.sh' >> ~/.gbrain/autopilot.log 2>&1\n",
       }),
-      kill: (() => {}) as typeof process.kill,
+      kill: ((_pid: number, _signal?: number | string) => true) as typeof process.kill,
     });
     expect(health.install_target).toBe('linux-cron');
     expect(health.installed).toBe(true);

--- a/test/e2e/status-pglite.test.ts
+++ b/test/e2e/status-pglite.test.ts
@@ -82,6 +82,11 @@ describe('gbrain status E2E (PGLite)', () => {
     expect(parsed).toHaveProperty('workers');
     expect(parsed).toHaveProperty('queue');
     expect(parsed).toHaveProperty('autopilot');
+    expect(parsed.autopilot).toHaveProperty('install_target');
+    expect(parsed.autopilot).toHaveProperty('artifact_present');
+    expect(parsed.autopilot).toHaveProperty('manager_registered');
+    expect(parsed.autopilot).toHaveProperty('manager_loaded');
+    expect(parsed.autopilot).toHaveProperty('last_log');
   });
 
   test('dual cycle rows: last_full + last_targeted surface independently', async () => {

--- a/test/e2e/status-pglite.test.ts
+++ b/test/e2e/status-pglite.test.ts
@@ -77,6 +77,7 @@ describe('gbrain status E2E (PGLite)', () => {
     expect(parsed.schema_version).toBe(1);
     expect(parsed.mode).toBe('local');
     expect(parsed).toHaveProperty('sync');
+    expect(parsed.sync).toHaveProperty('freshness_mode', 'stored_db');
     expect(parsed).toHaveProperty('cycle');
     expect(parsed).toHaveProperty('locks');
     expect(parsed).toHaveProperty('workers');

--- a/test/sources.test.ts
+++ b/test/sources.test.ts
@@ -73,6 +73,20 @@ async function withExitCapture(fn: () => Promise<void>): Promise<number | null> 
   return captured;
 }
 
+async function withConsoleCapture(fn: () => Promise<void>): Promise<string[]> {
+  const origLog = console.log;
+  const lines: string[] = [];
+  console.log = ((...args: unknown[]) => {
+    lines.push(args.map((arg) => String(arg)).join(' '));
+  }) as typeof console.log;
+  try {
+    await fn();
+  } finally {
+    console.log = origLog;
+  }
+  return lines;
+}
+
 describe('sources add', () => {
   test('rejects invalid ids', async () => {
     const { engine } = makeStub();
@@ -171,6 +185,19 @@ describe('sources list', () => {
     await runSources(engine, ['list']);
     const select = calls.find(c => c.sql.includes('ORDER BY (id = \'default\') DESC'));
     expect(select).toBeDefined();
+  });
+});
+
+describe('sources status', () => {
+  test('--json labels freshness mode for the trusted-host live git view', async () => {
+    const { engine } = makeStub();
+    const lines = await withConsoleCapture(() => runSources(engine, ['status', '--json']));
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0] ?? '')).toEqual({
+      schema_version: 1,
+      freshness_mode: 'live_git',
+      sources: [],
+    });
   });
 });
 

--- a/test/sync-all-parallel.test.ts
+++ b/test/sync-all-parallel.test.ts
@@ -182,6 +182,7 @@ describe('buildSyncStatusReport', () => {
     });
 
     const report = await buildSyncStatusReport(engine, sources);
+    expect(report.freshness_mode).toBe('stored_db');
     expect(report.sources).toHaveLength(4);
 
     const byId = new Map(report.sources.map((s) => [s.source_id, s]));
@@ -310,6 +311,7 @@ describe('buildSyncStatusReport', () => {
     expect(report.sources).toEqual([]);
     expect(report.schema_version).toBe(1);
     expect(typeof report.generated_at).toBe('string');
+    expect(report.freshness_mode).toBe('stored_db');
     expect(typeof report.embedding_column).toBe('string');
   });
 
@@ -327,6 +329,7 @@ describe('buildSyncStatusReport', () => {
     // must not change without bumping schema_version.
     expect(report.schema_version).toBe(1);
     expect(typeof report.generated_at).toBe('string');
+    expect(report.freshness_mode).toBe('stored_db');
     expect(Array.isArray(report.sources)).toBe(true);
     expect(typeof report.unacknowledged_failures).toBe('number');
     expect(typeof report.embedding_column).toBe('string');


### PR DESCRIPTION
## Summary
- add a shared autopilot health surface and wire it into operator status reporting
- label sync freshness mode in status and sources operator surfaces
- ignore db-only directories in git to keep autopilot residue out of repo state

## Notes
- this PR was restacked onto `origin/master` from a noisy branch
- it intentionally excludes unrelated `.understand-anything/*` generated files and an older providers-test commit

## Verification
- `bun test test/autopilot-health.test.ts test/e2e/status-pglite.test.ts test/sources.test.ts test/sync-all-parallel.test.ts`
