### PR TITLE
fix: harden gbrain config home resolution

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { installSignalHandlers as installCleanupSignalHandlers } from './core/pr
 installCleanupSignalHandlers();
 
 import { readFileSync } from 'fs';
-import { loadConfig, loadConfigWithEngine, toEngineConfig, isThinClient } from './core/config.ts';
+import { loadConfig, loadConfigWithEngine, toEngineConfig, isThinClient, noBrainConfiguredMessage } from './core/config.ts';
 import type { GBrainConfig } from './core/config.ts';
 import type { AIGatewayConfig } from './core/ai/types.ts';
 import type { BrainEngine } from './core/engine.ts';
@@ -1856,7 +1856,7 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
 async function connectEngine(opts?: { probeOnly?: boolean }): Promise<BrainEngine> {
   const config = loadConfig();
   if (!config) {
-    console.error('No brain configured. Run: gbrain init');
+    console.error(noBrainConfiguredMessage());
     process.exit(1);
   }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, mkdirSync, chmodSync, existsSync } from 'fs';
-import { isAbsolute, join } from 'path';
+import { dirname, isAbsolute, join, parse } from 'path';
 import { homedir } from 'os';
 import type { EngineConfig, EmbeddingColumnConfig } from './types.ts';
 
@@ -831,8 +831,10 @@ export function toEngineConfig(config: GBrainConfig): EngineConfig {
 
 export function configDir(): string {
   // Allow override for tests, Docker, and multi-tenant deployments.
-  // GBRAIN_HOME is a parent dir; we always append '.gbrain' ourselves so
-  // setting GBRAIN_HOME=/tmp/x yields configDir() === '/tmp/x/.gbrain'.
+  // GBRAIN_HOME is usually a parent dir; append '.gbrain' so setting
+  // GBRAIN_HOME=/tmp/x yields configDir() === '/tmp/x/.gbrain'. If the
+  // override itself is already named '.gbrain', accept it as the config dir so
+  // common wrapper/env mistakes do not strand an otherwise valid brain.
   // Validates the override: must be absolute, no '..' segments.
   const override = process.env.GBRAIN_HOME;
   if (override && override.trim()) {
@@ -843,13 +845,65 @@ export function configDir(): string {
     if (trimmed.split(/[\\/]/).includes('..')) {
       throw new Error(`GBRAIN_HOME must not contain '..' segments; got: ${trimmed}`);
     }
-    return join(trimmed, '.gbrain');
+    const normalized = stripTrailingPathSeparators(trimmed);
+    if (normalized.split(/[\\/]/).at(-1) === '.gbrain') return normalized;
+    return join(normalized, '.gbrain');
   }
-  return join(homedir(), '.gbrain');
+  const home = homedir();
+  const hermesOperatorHome = hermesProfileOperatorHome(home);
+  if (hermesOperatorHome) {
+    const profileConfigPath = join(home, '.gbrain', 'config.json');
+    const operatorConfigDir = join(hermesOperatorHome, '.gbrain');
+    if (!existsSync(profileConfigPath) && existsSync(join(operatorConfigDir, 'config.json'))) {
+      return operatorConfigDir;
+    }
+  }
+  return join(home, '.gbrain');
 }
 
 export function configPath(): string {
   return join(configDir(), 'config.json');
+}
+
+export function noBrainConfiguredMessage(): string {
+  const lines = [
+    `No brain configured. Expected config: ${configPath()}`,
+    'Run: gbrain init',
+  ];
+  const hint = noBrainConfiguredHint();
+  if (hint) lines.push(`Hint: ${hint}`);
+  return lines.join('\n');
+}
+
+function noBrainConfiguredHint(): string {
+  const override = process.env.GBRAIN_HOME?.trim();
+  if (override) {
+    const normalized = stripTrailingPathSeparators(override);
+    if (normalized.split(/[\\/]/).at(-1) === '.gbrain') {
+      const parent = dirname(normalized);
+      return `GBRAIN_HOME points directly at a .gbrain directory; this is accepted. The parent-directory form is GBRAIN_HOME=${parent}.`;
+    }
+    return 'GBRAIN_HOME is treated as a parent directory; GBrain appends .gbrain/config.json under it unless the override itself is named .gbrain.';
+  }
+
+  const home = process.env.HOME?.trim() || homedir();
+  const operatorHome = hermesProfileOperatorHome(home);
+  if (operatorHome) {
+    return `Hermes profile HOME detected; set HOME=${operatorHome} or GBRAIN_HOME=${operatorHome}. GBRAIN_HOME=${join(operatorHome, '.gbrain')} is also accepted, but the parent-directory form is preferred.`;
+  }
+
+  return 'Set HOME to the operator home, or set GBRAIN_HOME to the parent directory that contains .gbrain or to the .gbrain directory itself.';
+}
+
+function hermesProfileOperatorHome(home: string): string | null {
+  return home.match(/^(.*)[\\/]\.hermes[\\/]profiles[\\/][^\\/]+[\\/]home$/)?.[1] ?? null;
+}
+
+function stripTrailingPathSeparators(pathValue: string): string {
+  const root = parse(pathValue).root;
+  const stripped = pathValue.replace(/[\\/]+$/, '');
+  if (root && stripped.length < root.length) return root;
+  return stripped || pathValue;
 }
 
 /**

--- a/test/no-brain-config-diagnostic.test.ts
+++ b/test/no-brain-config-diagnostic.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from 'bun:test';
+import { execFileSync } from 'child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { configDir, configPath, noBrainConfiguredMessage } from '../src/core/config.ts';
+import { withEnv } from './helpers/with-env.ts';
+
+const CLI = join(__dirname, '..', 'src', 'cli.ts');
+
+function envFor(envOverrides: Record<string, string | undefined>): Record<string, string> {
+  const env = { ...process.env, ...envOverrides } as Record<string, string | undefined>;
+  delete env.DATABASE_URL;
+  delete env.GBRAIN_DATABASE_URL;
+  return env as Record<string, string>;
+}
+
+function runCliWithEnv(envOverrides: Record<string, string | undefined>): { exitCode: number; stderr: string } {
+  try {
+    execFileSync('bun', ['run', CLI, 'stats'], {
+      env: envFor(envOverrides),
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { exitCode: 0, stderr: '' };
+  } catch (err: any) {
+    return {
+      exitCode: err.status ?? 1,
+      stderr: err.stderr?.toString?.() ?? '',
+    };
+  }
+}
+
+function readConfigPathsWithEnv(envOverrides: Record<string, string | undefined>): { dir: string; path: string } {
+  const stdout = execFileSync('bun', ['-e', `
+    import { configDir, configPath } from './src/core/config.ts';
+    console.log(JSON.stringify({ dir: configDir(), path: configPath() }));
+  `], {
+    cwd: join(__dirname, '..'),
+    env: envFor(envOverrides),
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return JSON.parse(stdout);
+}
+
+describe('no brain configured diagnostic', () => {
+  test('prints resolved config path and Hermes profile HOME hint', async () => {
+    const result = runCliWithEnv({
+      HOME: '/home/operator/.hermes/profiles/ops-watch/home',
+      GBRAIN_HOME: undefined,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('No brain configured.');
+    expect(result.stderr).toContain('Expected config: /home/operator/.hermes/profiles/ops-watch/home/.gbrain/config.json');
+    expect(result.stderr).toContain('HOME=/home/operator');
+    expect(result.stderr).toContain('GBRAIN_HOME=/home/operator');
+    expect(result.stderr).toContain('GBRAIN_HOME=/home/operator/.gbrain is also accepted');
+    expect(result.stderr).toContain('Run: gbrain init');
+  });
+
+  test('accepts GBRAIN_HOME pointing directly at a .gbrain directory', async () => {
+    await withEnv({
+      HOME: '/home/operator',
+      GBRAIN_HOME: '/home/operator/.gbrain',
+      DATABASE_URL: undefined,
+      GBRAIN_DATABASE_URL: undefined,
+    }, async () => {
+      const msg = noBrainConfiguredMessage();
+
+      expect(configPath()).toBe('/home/operator/.gbrain/config.json');
+      expect(msg).toContain('Expected config: /home/operator/.gbrain/config.json');
+      expect(msg).toContain('GBRAIN_HOME points directly at a .gbrain directory; this is accepted.');
+      expect(msg).toContain('GBRAIN_HOME=/home/operator');
+    });
+  });
+
+  test('default no-config hint does not reject direct .gbrain overrides', async () => {
+    await withEnv({
+      GBRAIN_HOME: undefined,
+      DATABASE_URL: undefined,
+      GBRAIN_DATABASE_URL: undefined,
+    }, async () => {
+      const msg = noBrainConfiguredMessage();
+      expect(msg).toContain('or to the .gbrain directory itself');
+      expect(msg).not.toContain('not the .gbrain directory itself');
+    });
+  });
+
+  test('keeps absolute root absolute when normalizing trailing separators', async () => {
+    await withEnv({
+      HOME: '/home/operator',
+      GBRAIN_HOME: '/',
+      DATABASE_URL: undefined,
+      GBRAIN_DATABASE_URL: undefined,
+    }, async () => {
+      expect(configDir()).toBe('/.gbrain');
+      expect(configPath()).toBe('/.gbrain/config.json');
+    });
+  });
+
+  test('normalizes trailing separators without double-appending .gbrain', async () => {
+    await withEnv({
+      HOME: '/home/operator',
+      GBRAIN_HOME: '/home/operator/.gbrain///',
+      DATABASE_URL: undefined,
+      GBRAIN_DATABASE_URL: undefined,
+    }, async () => {
+      expect(configDir()).toBe('/home/operator/.gbrain');
+      expect(configPath()).toBe('/home/operator/.gbrain/config.json');
+    });
+  });
+
+  test('falls back from Hermes profile HOME to operator .gbrain when present', async () => {
+    const operatorHome = join(tmpdir(), `gbrain-hermes-home-${process.pid}-${Date.now()}`);
+    const profileHome = join(operatorHome, '.hermes', 'profiles', 'ops-watch', 'home');
+    try {
+      mkdirSync(join(operatorHome, '.gbrain'), { recursive: true });
+      mkdirSync(profileHome, { recursive: true });
+      writeFileSync(join(operatorHome, '.gbrain', 'config.json'), JSON.stringify({ engine: 'pglite', database_path: '/tmp/brain.pglite' }));
+
+      const paths = readConfigPathsWithEnv({
+        HOME: profileHome,
+        GBRAIN_HOME: undefined,
+        DATABASE_URL: undefined,
+        GBRAIN_DATABASE_URL: undefined,
+      });
+      expect(paths.dir).toBe(join(operatorHome, '.gbrain'));
+      expect(paths.path).toBe(join(operatorHome, '.gbrain', 'config.json'));
+    } finally {
+      rmSync(operatorHome, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Accept `GBRAIN_HOME` pointing directly at a `.gbrain` directory as well as the existing parent-directory form.
- Let Hermes profile `HOME=.../.hermes/profiles/<profile>/home` fall back to the operator `.gbrain` config when the profile has no local config and the operator config exists.
- Expand the no-config diagnostic so operators see the resolved config path and non-contradictory recovery hints.
- Add regression coverage for direct `.gbrain`, profile-HOME fallback, root/trailing separator normalization, and diagnostic wording.

## Test plan
- `bun test test/no-brain-config-diagnostic.test.ts test/config-env.test.ts test/cli.test.ts test/gbrain-home-isolation.test.ts` → 36 pass / 0 fail
- `bun run typecheck` → pass
- `git diff --check -- src/core/config.ts src/cli.ts test/no-brain-config-diagnostic.test.ts` → pass
- Read-only Codex review → APPROVE
- Live smoke from focused branch:
  - `HOME=/home/aleks/.hermes/profiles/ops-watch/home`, `GBRAIN_HOME` unset: `gbrain stats` succeeded
  - `GBRAIN_HOME=/home/aleks/.gbrain`: `gbrain stats` succeeded
  - profile-HOME `gbrain put tmp/profile-home-pr-put-works --content ...` succeeded; temp page was soft-deleted

## Notes
- This PR is a focused slice from a dirty local tree. It excludes unrelated local doctor changes.
- Running the live smoke against the newer branch applied the pending local schema migration 112 → 113 before stats completed.
