### PR TITLE
fix: scope exact get_page to federated sources

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -517,25 +517,17 @@ const get_page: Operation = {
     const slug = p.slug as string;
     const fuzzy = (p.fuzzy as boolean) || false;
     const includeDeleted = (p.include_deleted as boolean) === true;
-    // v0.31.8 (D20): thread ctx.sourceId through read-side ops. Only pass
-    // sourceId when it's set on ctx — when unset (local CLI default chain
-    // resolves to no source), the engine two-branch query falls through to
-    // the cross-source view, preserving pre-v0.31.8 behavior. MCP callers
-    // (stdio + HTTP) populate ctx.sourceId via the transport layer.
-    const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
-    // v0.41.13 #1436: fuzzy resolveSlugs ALSO needs source scope — pre-fix
-    // it was unscoped, so a remote `get_page` with `fuzzy: true` could
-    // return candidates from sources outside ctx.auth.allowedSources /
-    // ctx.sourceId. sourceScopeOpts(ctx) is the canonical precedence
-    // ladder (federated array > scalar > nothing) shared with every other
-    // read-side handler.
-    const fuzzyScope = sourceScopeOpts(ctx);
+    // v0.42.x Plan 3: exact reads must honor the same source-scope ladder as
+    // fuzzy resolution. Federated OAuth clients carry auth.allowedSources,
+    // which sourceScopeOpts converts to sourceIds; array scope wins over the
+    // scalar ctx.sourceId.
+    const sourceOpts = sourceScopeOpts(ctx);
 
     let page = await ctx.engine.getPage(slug, { includeDeleted, ...sourceOpts });
     let resolved_slug: string | undefined;
 
     if (!page && fuzzy) {
-      const candidates = await ctx.engine.resolveSlugs(slug, fuzzyScope);
+      const candidates = await ctx.engine.resolveSlugs(slug, sourceOpts);
       if (candidates.length === 1) {
         page = await ctx.engine.getPage(candidates[0], { includeDeleted, ...sourceOpts });
         resolved_slug = candidates[0];
@@ -555,7 +547,7 @@ const get_page: Operation = {
     // inside bumpLastRetrievedAt (D2).
     bumpLastRetrievedAt(ctx.engine, [page.id]);
 
-    const tags = await ctx.engine.getTags(page.slug, sourceOpts);
+    const tags = await ctx.engine.getTags(page.slug, { sourceId: page.source_id });
     // Privacy boundary for the per-token allow-list (v0.28.6 for takes,
     // v0.32.2 for facts).
     //

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -808,13 +808,17 @@ export class PGLiteEngine implements BrainEngine {
   }
 
   // Pages CRUD
-  async getPage(slug: string, opts?: { sourceId?: string; includeDeleted?: boolean }): Promise<Page | null> {
+  async getPage(slug: string, opts?: { sourceId?: string; sourceIds?: string[]; includeDeleted?: boolean }): Promise<Page | null> {
     // v0.26.5: hide soft-deleted by default; opt-in via opts.includeDeleted.
     const includeDeleted = opts?.includeDeleted === true;
     const sourceId = opts?.sourceId;
+    const sourceIds = opts?.sourceIds;
     const where: string[] = ['slug = $1'];
     const params: unknown[] = [slug];
-    if (sourceId) {
+    if (sourceIds && sourceIds.length > 0) {
+      params.push(sourceIds);
+      where.push(`source_id = ANY($${params.length}::text[])`);
+    } else if (sourceId) {
       params.push(sourceId);
       where.push(`source_id = $${params.length}`);
     }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -831,13 +831,18 @@ export class PostgresEngine implements BrainEngine {
   }
 
   // Pages CRUD
-  async getPage(slug: string, opts?: { sourceId?: string; includeDeleted?: boolean }): Promise<Page | null> {
+  async getPage(slug: string, opts?: { sourceId?: string; sourceIds?: string[]; includeDeleted?: boolean }): Promise<Page | null> {
     const sql = this.sql;
     const includeDeleted = opts?.includeDeleted === true;
     const sourceId = opts?.sourceId;
+    const sourceIds = opts?.sourceIds;
     // v0.26.5: default hides soft-deleted rows. Compose with optional sourceId
     // filter via fragment chaining (postgres.js supports sql`` composition).
-    const sourceCondition = sourceId ? sql`AND source_id = ${sourceId}` : sql``;
+    const sourceCondition = sourceIds && sourceIds.length > 0
+      ? sql`AND source_id = ANY(${sourceIds}::text[])`
+      : sourceId
+        ? sql`AND source_id = ${sourceId}`
+        : sql``;
     const deletedCondition = includeDeleted ? sql`` : sql`AND deleted_at IS NULL`;
     const rows = await sql`
       SELECT id, source_id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at, deleted_at,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -330,6 +330,8 @@ export interface PageFilters {
 export interface GetPageOpts {
   /** Filter to a specific source. When omitted, getPage returns the first slug match across sources (pre-existing semantics). */
   sourceId?: string;
+  /** Filter to any of these sources. When present/non-empty, this wins over sourceId for federated reads. */
+  sourceIds?: string[];
   /** Include soft-deleted pages. Default false. See PageFilters.includeDeleted. */
   includeDeleted?: boolean;
 }

--- a/test/operations-fuzzy-source-scope.test.ts
+++ b/test/operations-fuzzy-source-scope.test.ts
@@ -24,6 +24,7 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { operations, type OperationContext } from '../src/core/operations.ts';
 
 let engine: PGLiteEngine;
 
@@ -59,6 +60,13 @@ beforeEach(async () => {
     compiled_truth: 'Beta-source Alice page.',
     frontmatter: { type: 'person' },
   }, { sourceId: 'beta' });
+
+  await engine.putPage('people/beta-only', {
+    type: 'person',
+    title: 'Beta Only',
+    compiled_truth: 'Only visible through beta source scope.',
+    frontmatter: { type: 'person' },
+  }, { sourceId: 'beta' });
 });
 
 describe('#1436 — resolveSlugs honors source scope', () => {
@@ -77,6 +85,31 @@ describe('#1436 — resolveSlugs honors source scope', () => {
 
     const alphaOnly = await engine.resolveSlugs('people/alice', { sourceIds: ['alpha'] });
     expect(alphaOnly).toEqual(['people/alice']);
+  });
+
+  test('exact get_page honors AuthInfo.allowedSources over scalar ctx.sourceId', async () => {
+    const getPage = operations.find(o => o.name === 'get_page');
+    if (!getPage) throw new Error('get_page operation missing');
+    const ctx = {
+      engine,
+      config: { engine: 'pglite' },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      dryRun: false,
+      remote: true,
+      sourceId: 'alpha',
+      auth: {
+        token: 'test-token',
+        clientId: 'test-client',
+        scopes: ['read'],
+        sourceId: 'alpha',
+        allowedSources: ['alpha', 'beta'],
+      },
+    } as unknown as OperationContext;
+
+    const page = await getPage.handler(ctx, { slug: 'people/beta-only' }) as { title: string; source_id: string };
+
+    expect(page.title).toBe('Beta Only');
+    expect(page.source_id).toBe('beta');
   });
 
   test('unscoped call (no opts) preserves pre-fix back-compat for internal callers', async () => {


### PR DESCRIPTION
## Summary

Fixes exact `get_page` reads so they honor OAuth federated read scope (`auth.allowedSources`) instead of only the scalar `ctx.sourceId`.

## Problem

Federated OAuth clients can read broader source sets through list/search paths, but exact `get_page` was still scoped only by `ctx.sourceId`. A client with `source=shared` and `federated_read=shared,internal` could not exact-read an internal page by id, even though broader read surfaces honored the federated scope.

## Changes

- Thread `sourceScopeOpts(ctx)` into exact `get_page`.
- Add `sourceIds` support to PGLite/Postgres `getPage`.
- Preserve back-compat for unscoped internal callers.
- Load tags from the concrete returned page's `source_id`.
- Add regression coverage for exact `get_page` honoring `AuthInfo.allowedSources` over scalar `ctx.sourceId`.

## Verification

- `bun test test/operations-fuzzy-source-scope.test.ts` — 7 passed
- `bun test test/e2e/source-isolation-pglite.test.ts` — 14 passed
- `bun run typecheck` — passed
