### PR TITLE
feat(ai): add Codex plan chat provider

### DIFF
--- a/docs/ai-providers/openai-codex.md
+++ b/docs/ai-providers/openai-codex.md
@@ -49,16 +49,18 @@ embedding/tool/subagent surface.
 Safer rollout options:
 
 ```bash
-# Chat-only / reasoning-scoped rollout
- gbrain config set models.chat openai-codex:gpt-5.5
+# Chat-only gateway rollout
+gbrain config set chat_model openai-codex:gpt-5.5
 
-# Or, for a one-off command that accepts a model flag
- gbrain takes extract --from-pages --model openai-codex:gpt-5.5 --max-pages 5 --yes
+# One-off chat provider smoke without changing config
+gbrain providers test --touchpoint chat --model openai-codex:gpt-5.5
 ```
 
-Keep subagent/minion/tool-running tiers on a tool-capable model. The resolver
-will gate Codex out of `tier.subagent`, but scoped config is still clearer and
-less surprising than a global default flip.
+For extraction/takes/minion workflows, verify the command explicitly accepts a
+model override and does not require tools, structured output, embeddings, or
+subagent loops before pointing it at Codex. The resolver will gate Codex out of
+`tier.subagent`, but scoped config is still clearer and less surprising than a
+global default flip.
 
 ## Verify offline readiness
 
@@ -75,7 +77,7 @@ The offline gate checks:
 
 - recipe/model identity and allow-listing
 - auth redaction with fixture credentials
-- forced streaming request shape and ChatGPT Codex route separation
+- forced streaming request shape and non-public Codex Responses route separation
 - text-only / no-tools / no-subagent capability guard
 - no `OPENAI_API_KEY` fallback
 - plan-billed metadata without public API pricing

--- a/docs/ai-providers/openai-codex.md
+++ b/docs/ai-providers/openai-codex.md
@@ -1,0 +1,125 @@
+# OpenAI Codex — ChatGPT plan GPT-5.5
+
+`openai-codex:gpt-5.5` routes GBrain chat through the ChatGPT/Codex plan
+Responses backend instead of the public OpenAI API-key path. It is intentionally
+registered as a separate provider from `openai:gpt-5.5` because the auth,
+transport, billing, and capability envelope are different.
+
+## Scope
+
+Supported in this first slice:
+
+- Text-generation chat only.
+- Forced streaming Responses calls (`stream: true`, `store: false`).
+- Plan-billed operator surfaces: public OpenAI API spend is `$0`, but ChatGPT /
+  Codex plan quotas and rate limits still apply.
+- Offline readiness verification and optional local live smoke.
+
+Not supported yet:
+
+- Embeddings, reranking, query expansion, or structured-output extraction.
+- Tool calls, tool-result history, minion/subagent loops, or prompt-cache claims.
+- Managed GBrain OAuth/token brokering. Current auth is a read-only local Codex /
+  Hermes auth seam plus explicit `OPENAI_CODEX_ACCESS_TOKEN` fallback for tests
+  and developer smoke runs.
+
+If a workflow needs tools or minions, keep using a tool-capable provider. The
+capability gate classifies `openai-codex:gpt-5.5` as unusable for subagent loops
+until a future cycle adds real tool semantics.
+
+## Auth
+
+The provider does **not** use `OPENAI_API_KEY`.
+
+Readiness comes from Codex-plan auth only:
+
+1. Local Codex/Hermes auth state, read synchronously and read-only.
+2. `OPENAI_CODEX_ACCESS_TOKEN` for tests/dev smoke paths.
+
+Failures are reported with redacted status strings. Tokens, account IDs, public
+OpenAI keys, and bearer headers should never appear in provider output, readiness
+JSON, or thrown errors.
+
+## Configure safely
+
+Do **not** flip `models.default` globally unless you deliberately want every
+ordinary reasoning route to try Codex text chat and you understand the missing
+embedding/tool/subagent surface.
+
+Safer rollout options:
+
+```bash
+# Chat-only / reasoning-scoped rollout
+ gbrain config set models.chat openai-codex:gpt-5.5
+
+# Or, for a one-off command that accepts a model flag
+ gbrain takes extract --from-pages --model openai-codex:gpt-5.5 --max-pages 5 --yes
+```
+
+Keep subagent/minion/tool-running tiers on a tool-capable model. The resolver
+will gate Codex out of `tier.subagent`, but scoped config is still clearer and
+less surprising than a global default flip.
+
+## Verify offline readiness
+
+The mandatory readiness gate is deterministic and does not read private auth
+files or call the network:
+
+```bash
+gbrain providers verify --model openai-codex:gpt-5.5 --offline
+# or via package script
+bun run verify:openai-codex
+```
+
+The offline gate checks:
+
+- recipe/model identity and allow-listing
+- auth redaction with fixture credentials
+- forced streaming request shape and ChatGPT Codex route separation
+- text-only / no-tools / no-subagent capability guard
+- no `OPENAI_API_KEY` fallback
+- plan-billed metadata without public API pricing
+
+Expected success ends with:
+
+```text
+Result: READY (offline invariants passed).
+```
+
+## Optional live smoke
+
+Live smoke is opt-in so CI and unattended checks never depend on private Codex
+credentials:
+
+```bash
+GBRAIN_OPENAI_CODEX_LIVE=1 \
+  gbrain providers verify --model openai-codex:gpt-5.5 --live
+```
+
+Live mode first runs the offline gate, then calls the chat provider through
+`providers test`. If `GBRAIN_OPENAI_CODEX_LIVE` is unset, live mode exits before
+any network/auth probe.
+
+## Billing and quota posture
+
+Provider/budget surfaces label Codex as `plan-billed`:
+
+- Public OpenAI API spend: `$0` for this provider path.
+- Public `OPENAI_API_KEY`: ignored.
+- ChatGPT/Codex plan quota and rate limits: still apply.
+- No per-token public API price is attached to the Codex recipe.
+
+This avoids the bad middle ground where the provider looks like ordinary metered
+OpenAI API usage or like unlimited free compute. It is neither.
+
+## Troubleshooting
+
+- `Codex auth unavailable` — local Codex/Hermes auth was not found and
+  `OPENAI_CODEX_ACCESS_TOKEN` is unset. Sign in to the Codex CLI / Hermes Codex
+  transport, or pass an explicit token for a dev smoke.
+- `Live Codex verify is disabled` — set `GBRAIN_OPENAI_CODEX_LIVE=1` before
+  running `--live`. Use `--offline` for CI and normal release gates.
+- Tool/minion route falls back to another model — expected. Codex is text-only
+  in this release.
+- `OPENAI_API_KEY` is set but Codex is not ready — expected. Public OpenAI keys
+  are ignored for `openai-codex` by design.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eval:autocut": "bun test test/search/autocut-eval.test.ts",
     "test:full": "bun run verify && bash scripts/run-unit-parallel.sh && bun run test:slow && ([ -n \"$DATABASE_URL\" ] && bash scripts/run-e2e.sh || echo '[test:full] skipped E2E (no DATABASE_URL); run docker-compose -f docker-compose.ci.yml up + bun run test:e2e to include' 1>&2)",
     "verify": "bash scripts/run-verify-parallel.sh",
+    "verify:openai-codex": "bun src/cli.ts providers verify --model openai-codex:gpt-5.5 --offline && bun test test/ai/recipe-openai-codex.test.ts test/ai/codex-auth.test.ts test/ai/codex-responses-stream.test.ts test/ai/openai-codex-gateway.test.ts test/ai/capabilities.test.ts test/ai/model-resolver-openai-codex.test.ts test/core/budget/budget-tracker.test.ts test/providers.test.ts test/commands/providers-openai-codex.test.ts test/ai/build-gateway-config.test.ts test/e2e/openai-codex-live-smoke.test.ts && bun test --max-concurrency=1 --timeout=60000 test/model-config.serial.test.ts",
     "check:source-config-leak": "scripts/check-source-config-leak.sh",
     "check:no-pii-agent-voice": "scripts/check-no-pii-in-agent-voice.sh",
     "check:synthetic-corpus-privacy": "scripts/check-synthetic-corpus-privacy.sh",

--- a/scripts/run-verify-parallel.sh
+++ b/scripts/run-verify-parallel.sh
@@ -131,8 +131,11 @@ for c in "${CHECKS[@]}"; do
         sleep 5 && kill -KILL "$pid" 2>/dev/null ) &
       cap_pid=$!
       wait "$pid" 2>/dev/null
-      kill "$cap_pid" 2>/dev/null
-      wait "$cap_pid" 2>/dev/null
+      rc=$?
+      kill "$cap_pid" 2>/dev/null || true
+      wait "$cap_pid" 2>/dev/null || true
+      echo "$rc" > "$EXIT_FILE"
+      exit 0
     fi
     rc=$?
     echo "$rc" > "$EXIT_FILE"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1840,6 +1840,7 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   if (process.env.LMSTUDIO_BASE_URL) envBaseUrls['lmstudio'] = process.env.LMSTUDIO_BASE_URL;
   if (process.env.LITELLM_BASE_URL) envBaseUrls['litellm'] = process.env.LITELLM_BASE_URL;
   if (process.env.OPENROUTER_BASE_URL) envBaseUrls['openrouter'] = process.env.OPENROUTER_BASE_URL;
+  if (process.env.OPENAI_CODEX_BASE_URL) envBaseUrls['openai-codex'] = process.env.OPENAI_CODEX_BASE_URL;
 
   return {
     embedding_model: c.embedding_model,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,7 +45,7 @@ const CLI_ONLY_SELF_HELP = new Set([
   'skillpack', 'skillpack-check',
   'integrations', 'friction',
   'frontmatter', 'check-resolvable',
-  'models',
+  'models', 'providers',
   'cache',
   'brainstorm', 'lsd',
   // v0.41.20.0 skillopt's detailed HELP constant lives in

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -448,14 +448,14 @@ function runOpenAICodexOfflineReadiness(modelArg: string): VerifyCheck[] {
       });
       const url = new URL(request.url);
       const hostname = normalizedHost(request.url);
-      const routeHostOk = hostname === 'chatgpt.com';
+      const routeHostOk = hostname !== null && !isPublicOpenAIBaseURL(request.url);
       const publicOpenAIHostOk = !isPublicOpenAIBaseURL(verifyBaseURL) && !isPublicOpenAIBaseURL(request.url);
       streamRouteOk = body.stream === true
         && body.store === false
         && request.body.stream === true
         && request.body.store === false
         && routeHostOk
-        && url.pathname.endsWith('/backend-api/codex/responses')
+        && url.pathname.endsWith('/responses')
         && publicOpenAIHostOk;
       requestUsesCodexAuthOnly = request.headers.Authorization === `Bearer ${VERIFY_FIXTURE_CODEX_ACCESS_TOKEN}`
         && !Object.values(request.headers).some(value => value.includes(VERIFY_FIXTURE_PUBLIC_OPENAI_API_KEY));
@@ -467,8 +467,8 @@ function runOpenAICodexOfflineReadiness(modelArg: string): VerifyCheck[] {
   checks.push(verifyCheck(
     'streaming route separation',
     streamRouteOk,
-    'request builder forces stream=true/store=false and targets ChatGPT Codex /responses, not public OpenAI.',
-    'Codex request builder did not prove forced streaming/store=false on the ChatGPT Codex route.',
+    'request builder forces stream=true/store=false and targets a non-public Codex Responses /responses route.',
+    'Codex request builder did not prove forced streaming/store=false on a non-public Codex Responses route.',
   ));
 
   let toolsRejected = false;

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -1,5 +1,5 @@
 /**
- * `gbrain providers` CLI — list, test, env, explain.
+ * `gbrain providers` CLI — list, test, env, explain, verify.
  *
  * This command operates WITHOUT a brain connection (no engine needed) so
  * users can verify provider setup before `gbrain init`.
@@ -18,6 +18,12 @@ import {
   type CodexAuthResolveOptions,
   type CodexCredentialSnapshot,
 } from '../core/ai/codex-auth.ts';
+import { classifyCapabilities } from '../core/ai/capabilities.ts';
+import {
+  buildCodexResponsesBody,
+  buildCodexResponsesRequest,
+  redactCodexSecrets,
+} from '../core/ai/codex-responses.ts';
 import type { BillingMetadata, Recipe } from '../core/ai/types.ts';
 import { splitProviderModelId } from '../core/model-id.ts';
 
@@ -25,6 +31,37 @@ import { splitProviderModelId } from '../core/model-id.ts';
 const SCHEMA_VERSION = 2;
 
 type TouchpointFilter = 'embedding' | 'expansion' | 'chat';
+
+const OPENAI_CODEX_VERIFY_MODEL = 'openai-codex:gpt-5.5';
+const VERIFY_FIXTURE_NOW_MS = Date.UTC(2026, 0, 1, 0, 0, 0);
+const VERIFY_FIXTURE_EXPIRES_MS = Date.UTC(2030, 0, 1, 0, 0, 0);
+const VERIFY_FIXTURE_PUBLIC_OPENAI_API_KEY = 'sk-openai-public-key-must-not-leak';
+const VERIFY_FIXTURE_CODEX_ACCESS_TOKEN = fixtureJwt(VERIFY_FIXTURE_EXPIRES_MS / 1000);
+
+interface VerifyCheck {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+interface VerifyArgs {
+  model: string;
+  offline: boolean;
+  live: boolean;
+  help: boolean;
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), 'utf8')
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function fixtureJwt(expSeconds: number): string {
+  return `${base64UrlJson({ alg: 'none', typ: 'JWT' })}.${base64UrlJson({ sub: 'codex_offline_readiness_fixture', exp: expSeconds })}.sig`;
+}
 
 interface ProviderOption {
   id: string;
@@ -59,6 +96,27 @@ function providerBaseUrls(config?: { provider_base_urls?: Record<string, string>
 
 function providerBaseUrl(recipe: Recipe, config?: { provider_base_urls?: Record<string, string> } | null): string | undefined {
   return providerBaseUrls(config)?.[recipe.id] ?? recipe.base_url_default;
+}
+
+function safeLoadProviderConfig(): { provider_base_urls?: Record<string, string> } | null {
+  try {
+    return loadConfig();
+  } catch {
+    return null;
+  }
+}
+
+function normalizedHost(url: string | undefined): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).hostname.toLowerCase().replace(/\.+$/, '');
+  } catch {
+    return null;
+  }
+}
+
+function isPublicOpenAIBaseURL(url: string | undefined): boolean {
+  return normalizedHost(url) === 'api.openai.com';
 }
 
 function configureFromEnv(options: ProvidersCommandOptions = {}): void {
@@ -178,6 +236,13 @@ export async function runProviders(
   args: string[],
   options: ProvidersCommandOptions = {},
 ): Promise<void> {
+  // `providers verify --offline` is a deterministic readiness gate and must not
+  // touch private Codex auth files or network. Handle it before configureGateway(),
+  // because configureGateway resolves Codex auth snapshots eagerly.
+  if (subcommand === 'verify') {
+    return runVerify(args, options);
+  }
+
   const runtimeOptions: ProvidersCommandOptions = options.codexAuth ? options : { ...options, codexAuth: {} };
   configureFromEnv(runtimeOptions);
 
@@ -210,6 +275,12 @@ USAGE
   gbrain providers test [--touchpoint T] [--model ID]     Smoke-test configured (or specified) providers
   gbrain providers env <id>                               Show env vars required/optional for a provider
   gbrain providers explain [--json]                       Emit a provider choice matrix (agent-friendly)
+  gbrain providers verify --model ID --offline            Offline readiness gate for provider rollout
+
+VERIFY
+  --model openai-codex:gpt-5.5   Model to verify (default: openai-codex:gpt-5.5)
+  --offline                      Deterministic; uses fixture auth only, no private auth files/network
+  --live                         Optional live smoke; requires GBRAIN_OPENAI_CODEX_LIVE=1
 
 TOUCHPOINTS
   --touchpoint embedding (default)  Probes embed_one("...")
@@ -220,6 +291,8 @@ EXAMPLES
   gbrain providers test --model openai:text-embedding-3-large
   gbrain providers test --touchpoint chat --model anthropic:claude-haiku-4-5
   gbrain providers test --touchpoint chat --model deepseek:deepseek-chat
+  gbrain providers verify --model openai-codex:gpt-5.5 --offline
+  GBRAIN_OPENAI_CODEX_LIVE=1 gbrain providers verify --model openai-codex:gpt-5.5 --live
   gbrain providers env ollama
   gbrain providers explain --json
 `);
@@ -227,6 +300,294 @@ EXAMPLES
 
 function runList(_args: string[], options: ProvidersCommandOptions = {}): void {
   console.log(formatRecipeTable(listRecipes(), process.env, options));
+}
+
+function parseVerifyArgs(args: string[]): VerifyArgs | { error: string } {
+  let model: string | undefined;
+  let offline = false;
+  let live = false;
+  let help = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+      continue;
+    }
+    if (arg === '--offline') {
+      offline = true;
+      continue;
+    }
+    if (arg === '--live') {
+      live = true;
+      continue;
+    }
+    if (arg === '--model') {
+      const next = args[i + 1];
+      if (!next || next.startsWith('--')) return { error: '--model requires a provider:model value.' };
+      model = next;
+      i++;
+      continue;
+    }
+    return { error: `Unknown providers verify option: ${arg}` };
+  }
+
+  if (offline && live) return { error: '--offline and --live are mutually exclusive.' };
+  return {
+    model: model ?? OPENAI_CODEX_VERIFY_MODEL,
+    offline: offline || !live,
+    live,
+    help,
+  };
+}
+
+function printVerifyHelp(): void {
+  console.log(`gbrain providers verify — provider rollout readiness gate
+
+USAGE
+  gbrain providers verify --model openai-codex:gpt-5.5 --offline
+  GBRAIN_OPENAI_CODEX_LIVE=1 gbrain providers verify --model openai-codex:gpt-5.5 --live
+
+OPTIONS
+  --model ID    Provider model id to verify (default: ${OPENAI_CODEX_VERIFY_MODEL})
+  --offline     Deterministic fixture-auth checks only; no private auth files/network
+  --live        Run offline checks, then a real chat smoke via providers test
+
+Live mode is refused unless GBRAIN_OPENAI_CODEX_LIVE=1 is set.
+`);
+}
+
+function verifyCheck(name: string, ok: boolean, passDetail: string, failDetail: string): VerifyCheck {
+  return { name, ok, detail: ok ? passDetail : failDetail };
+}
+
+function verifyFixtureOptions(): ProvidersCommandOptions {
+  return {
+    codexAuth: {
+      source: 'env',
+      now: VERIFY_FIXTURE_NOW_MS,
+      homeDir: '/gbrain-openai-codex-offline-readiness-fixture',
+      readFileText: () => {
+        throw new Error('offline verify must not read private auth files');
+      },
+    },
+  };
+}
+
+function runOpenAICodexOfflineReadiness(modelArg: string): VerifyCheck[] {
+  const checks: VerifyCheck[] = [];
+  const parsed = splitProviderModelId(modelArg);
+  const recipe = parsed.provider ? getRecipe(parsed.provider) : undefined;
+  const chat = recipe?.touchpoints.chat;
+  const expectedIdentity = !!recipe
+    && recipe.id === 'openai-codex'
+    && parsed.provider === 'openai-codex'
+    && parsed.model === 'gpt-5.5'
+    && recipe.tier === 'codex-responses'
+    && recipe.implementation === 'codex-responses'
+    && recipe.enforce_model_allowlist === true
+    && chat?.models.includes(parsed.model) === true;
+
+  checks.push(verifyCheck(
+    'recipe/model identity',
+    expectedIdentity,
+    'openai-codex:gpt-5.5 is registered as the Codex Responses recipe with an enforced allow-list.',
+    'expected openai-codex:gpt-5.5 to resolve to the Codex Responses recipe and allow-list.',
+  ));
+
+  const fixtureOptions = verifyFixtureOptions();
+  const fixtureEnv: Record<string, string | undefined> = {
+    OPENAI_API_KEY: VERIFY_FIXTURE_PUBLIC_OPENAI_API_KEY,
+    OPENAI_CODEX_ACCESS_TOKEN: VERIFY_FIXTURE_CODEX_ACCESS_TOKEN,
+  };
+  const publicOnlyEnv: Record<string, string | undefined> = {
+    OPENAI_API_KEY: VERIFY_FIXTURE_PUBLIC_OPENAI_API_KEY,
+    OPENAI_CODEX_ACCESS_TOKEN: undefined,
+  };
+  const snapshot = resolveCodexForProviders(fixtureEnv, fixtureOptions);
+  const verifyBaseURL = recipe ? providerBaseUrl(recipe, safeLoadProviderConfig()) : undefined;
+  const serializedSnapshot = JSON.stringify(snapshot);
+  const formattedTable = recipe ? formatRecipeTable([recipe], fixtureEnv, fixtureOptions) : '';
+  const redactedSample = redactCodexSecrets(
+    `Bearer ${VERIFY_FIXTURE_CODEX_ACCESS_TOKEN} access_token=${VERIFY_FIXTURE_CODEX_ACCESS_TOKEN} api_key=${VERIFY_FIXTURE_PUBLIC_OPENAI_API_KEY}`,
+    [VERIFY_FIXTURE_CODEX_ACCESS_TOKEN, VERIFY_FIXTURE_PUBLIC_OPENAI_API_KEY],
+  );
+  const redactionProbe = [
+    serializedSnapshot,
+    codexAuthFailureDetail(snapshot),
+    formattedTable,
+    redactedSample,
+  ].join('\n');
+  const redactionOk = codexAuthAvailable(snapshot)
+    && !Object.keys(snapshot as Record<string, unknown>).includes('accessToken')
+    && !redactionProbe.includes(VERIFY_FIXTURE_CODEX_ACCESS_TOKEN)
+    && !redactionProbe.includes(VERIFY_FIXTURE_PUBLIC_OPENAI_API_KEY)
+    && redactedSample.includes('[REDACTED]');
+
+  checks.push(verifyCheck(
+    'auth redaction',
+    redactionOk,
+    'fixture Codex token/API key stay out of JSON and operator-facing status strings.',
+    'fixture token/API key leaked or Codex fixture auth did not resolve as expected.',
+  ));
+
+  let streamRouteOk = false;
+  let requestUsesCodexAuthOnly = false;
+  try {
+    const opts = {
+      messages: [{ role: 'user' as const, content: 'Reply with just: pong' }],
+      maxTokens: 4,
+    };
+    const body = buildCodexResponsesBody(opts, parsed.model);
+    if (snapshot.ok && verifyBaseURL) {
+      const request = buildCodexResponsesRequest({
+        baseURL: verifyBaseURL,
+        modelId: parsed.model,
+        opts,
+        credential: snapshot,
+      });
+      const url = new URL(request.url);
+      const hostname = normalizedHost(request.url);
+      const routeHostOk = hostname === 'chatgpt.com';
+      const publicOpenAIHostOk = !isPublicOpenAIBaseURL(verifyBaseURL) && !isPublicOpenAIBaseURL(request.url);
+      streamRouteOk = body.stream === true
+        && body.store === false
+        && request.body.stream === true
+        && request.body.store === false
+        && routeHostOk
+        && url.pathname.endsWith('/backend-api/codex/responses')
+        && publicOpenAIHostOk;
+      requestUsesCodexAuthOnly = request.headers.Authorization === `Bearer ${VERIFY_FIXTURE_CODEX_ACCESS_TOKEN}`
+        && !Object.values(request.headers).some(value => value.includes(VERIFY_FIXTURE_PUBLIC_OPENAI_API_KEY));
+    }
+  } catch {
+    streamRouteOk = false;
+  }
+
+  checks.push(verifyCheck(
+    'streaming route separation',
+    streamRouteOk,
+    'request builder forces stream=true/store=false and targets ChatGPT Codex /responses, not public OpenAI.',
+    'Codex request builder did not prove forced streaming/store=false on the ChatGPT Codex route.',
+  ));
+
+  let toolsRejected = false;
+  try {
+    buildCodexResponsesBody({
+      messages: [{ role: 'user', content: 'ping' }],
+      tools: [{ name: 'noop', description: 'must be rejected', inputSchema: { type: 'object', properties: {} } }],
+      maxTokens: 1,
+    }, parsed.model);
+  } catch (error) {
+    toolsRejected = error instanceof AIConfigError && error.message.includes('text-only');
+  }
+  const capabilityVerdict = classifyCapabilities(modelArg);
+  const noToolsOk = chat?.supports_tools === false
+    && chat?.supports_subagent_loop === false
+    && chat?.supports_prompt_cache === false
+    && recipe?.touchpoints.embedding === undefined
+    && recipe?.touchpoints.expansion === undefined
+    && recipe?.touchpoints.reranker === undefined
+    && capabilityVerdict === 'unusable:no_tools'
+    && toolsRejected;
+
+  checks.push(verifyCheck(
+    'text-only/no-tools guard',
+    noToolsOk,
+    'recipe and transport reject tools/minion history; capability gate classifies Codex as unusable for subagent loops.',
+    'Codex did not remain text-only/no-tools or the subagent capability gate changed.',
+  ));
+
+  const authKeys = [
+    ...(recipe?.auth_env?.required ?? []),
+    ...(recipe?.auth_env?.optional ?? []),
+  ];
+  const baseUrlAvoidsPublicOpenAI = !!verifyBaseURL && !isPublicOpenAIBaseURL(verifyBaseURL);
+  const publicFallbackOk = !!recipe
+    && recipe.id !== 'openai'
+    && !authKeys.includes('OPENAI_API_KEY')
+    && envReady(recipe, publicOnlyEnv, fixtureOptions) === false
+    && requestUsesCodexAuthOnly
+    && baseUrlAvoidsPublicOpenAI;
+
+  checks.push(verifyCheck(
+    'no public OpenAI fallback',
+    publicFallbackOk,
+    'OPENAI_API_KEY alone is not ready; Codex uses Codex auth and a non-api.openai.com route.',
+    'public OPENAI_API_KEY was accepted or leaked into Codex auth/route invariants.',
+  ));
+
+  const billingSummary = recipe ? codexBillingSummary(recipe) : null;
+  const planBillingOk = chat?.billing?.mode === 'plan-billed'
+    && chat?.cost_per_1m_input_usd === undefined
+    && chat?.cost_per_1m_output_usd === undefined
+    && billingSummary !== null
+    && billingSummary.includes('ChatGPT/Codex plan-billed')
+    && billingSummary.includes('public OpenAI API key not used')
+    && billingSummary.includes('quota/rate limits apply');
+
+  checks.push(verifyCheck(
+    'plan billing metadata',
+    planBillingOk,
+    'plan-billed metadata is present; public API metered prices remain unset and quota hints are surfaced.',
+    'Codex plan-billing metadata or public-API-spend guardrails are missing.',
+  ));
+
+  return checks;
+}
+
+function printVerifyResult(model: string, mode: 'offline' | 'live', checks: VerifyCheck[]): void {
+  console.log(`OpenAI Codex provider readiness (${mode})`);
+  console.log(`Model: ${model}`);
+  if (mode === 'offline') {
+    console.log('Mode: offline fixture checks only; no private Codex auth files, live credentials, or network are used.');
+  } else {
+    console.log('Mode: live requested; offline gate runs first, then providers test runs only because GBRAIN_OPENAI_CODEX_LIVE=1.');
+  }
+  console.log('');
+  for (const check of checks) {
+    console.log(`${check.ok ? '✓' : '✗'} ${check.name}: ${check.detail}`);
+  }
+  const failed = checks.filter(check => !check.ok);
+  console.log('');
+  if (failed.length === 0) {
+    console.log(mode === 'offline'
+      ? 'Result: READY (offline invariants passed).'
+      : 'Result: READY for live smoke (offline invariants passed).');
+    if (mode === 'offline') {
+      console.log('Optional live smoke: GBRAIN_OPENAI_CODEX_LIVE=1 gbrain providers verify --model openai-codex:gpt-5.5 --live');
+    }
+  } else {
+    console.log(`Result: NOT READY (${failed.length} check${failed.length === 1 ? '' : 's'} failed).`);
+  }
+}
+
+async function runVerify(args: string[], options: ProvidersCommandOptions = {}): Promise<void> {
+  const parsed = parseVerifyArgs(args);
+  if ('error' in parsed) {
+    console.error(parsed.error);
+    printVerifyHelp();
+    process.exit(2);
+  }
+  if (parsed.help) {
+    printVerifyHelp();
+    return;
+  }
+  if (parsed.live && process.env.GBRAIN_OPENAI_CODEX_LIVE !== '1') {
+    console.error('Live Codex verify is disabled. Set GBRAIN_OPENAI_CODEX_LIVE=1 to allow live auth/network.');
+    process.exit(2);
+  }
+
+  const mode = parsed.offline ? 'offline' as const : 'live' as const;
+  const checks = runOpenAICodexOfflineReadiness(parsed.model);
+  printVerifyResult(parsed.model, mode, checks);
+  if (checks.some(check => !check.ok)) process.exit(1);
+
+  if (parsed.live) {
+    console.log('');
+    console.log('Live smoke: running providers test --touchpoint chat (secrets are not printed).');
+    await runTest(['--touchpoint', 'chat', '--model', parsed.model], options);
+  }
 }
 
 async function runTest(args: string[], options: ProvidersCommandOptions = {}): Promise<void> {

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -12,7 +12,8 @@ import { loadConfig } from '../core/config.ts';
 import { AIConfigError, AITransientError } from '../core/ai/errors.ts';
 import type { Recipe } from '../core/ai/types.ts';
 
-const SCHEMA_VERSION = 1;
+// v2: `tier` widened to include `codex-responses` for metadata-only Codex recipes.
+const SCHEMA_VERSION = 2;
 
 type TouchpointFilter = 'embedding' | 'expansion' | 'chat';
 
@@ -26,7 +27,7 @@ interface ProviderOption {
   cost_per_1m_output_usd?: number;
   price_last_verified?: string;
   env_ready: boolean;
-  tier: 'native' | 'openai-compat';
+  tier: Recipe['tier'];
   pros: string[];
   cons: string[];
 }
@@ -44,7 +45,15 @@ function configureFromEnv(): void {
   });
 }
 
+function isCodexAuthPending(recipe: Recipe): boolean {
+  return recipe.tier === 'codex-responses' || recipe.implementation === 'codex-responses';
+}
+
 export function envReady(recipe: Recipe, env: NodeJS.ProcessEnv = process.env): boolean {
+  // Commit 1 registers Codex metadata only. Do not mark it ready from empty
+  // auth_env.required or from public OPENAI_API_KEY; the real Codex auth seam
+  // lands in a later commit.
+  if (isCodexAuthPending(recipe)) return false;
   const required = recipe.auth_env?.required ?? [];
   if (required.length === 0) return true; // e.g. local Ollama
   return required.every(k => !!env[k]);
@@ -75,7 +84,11 @@ export function formatRecipeTable(recipes: Recipe[], env: NodeJS.ProcessEnv = pr
     const hasExpand = !!r.touchpoints.expansion;
     const hasChat = !!r.touchpoints.chat && r.touchpoints.chat.models.length > 0;
     const ready = envReady(r, env);
-    const status = ready ? '✓ ready' : `✗ missing ${r.auth_env?.required?.[0] ?? 'setup'}`;
+    const status = ready
+      ? '✓ ready'
+      : isCodexAuthPending(r)
+        ? '✗ pending Codex auth/transport seam'
+        : `✗ missing ${r.auth_env?.required?.[0] ?? 'setup'}`;
     rows.push(
       r.id.padEnd(idCol) +
       r.tier.padEnd(18) +
@@ -197,7 +210,14 @@ async function runTest(args: string[]): Promise<void> {
   }
 
   if (!gwIsAvailable(tpArg)) {
-    console.error(`${tpArg[0]?.toUpperCase()}${tpArg.slice(1)} provider not configured or not ready. Run \`gbrain providers list\` to see status.`);
+    const overrideProvider = modelArg?.split(':')[0];
+    const overrideRecipe = overrideProvider ? getRecipe(overrideProvider) : undefined;
+    const label = `${tpArg[0]?.toUpperCase()}${tpArg.slice(1)}`;
+    if (overrideRecipe && isCodexAuthPending(overrideRecipe)) {
+      console.error(`${label} provider unavailable: pending Codex auth/transport seam.`);
+    } else {
+      console.error(`${label} provider not configured or not ready. Run \`gbrain providers list\` to see status.`);
+    }
     process.exit(1);
   }
 
@@ -402,6 +422,7 @@ function prosFor(r: Recipe, touchpoint: TouchpointFilter): string[] {
     else if (r.id === 'deepseek') out.push('25-40x cheaper than Anthropic', 'Strong reasoning');
     else if (r.id === 'groq') out.push('500 tok/s inference', 'Cheap fallback');
     else if (r.id === 'together') out.push('Open-weights house', 'Llama / Qwen / Mixtral');
+    else if (r.id === 'openai-codex') out.push('ChatGPT/Codex plan billed', 'No public OpenAI API spend');
     return out;
   }
   if (r.id === 'openai') out.push('Default', 'High quality', 'Wide compatibility');
@@ -416,6 +437,7 @@ function prosFor(r: Recipe, touchpoint: TouchpointFilter): string[] {
 function consFor(r: Recipe): string[] {
   const out: string[] = [];
   if (r.tier === 'native' && r.id !== 'ollama') out.push('Paid');
+  if (r.id === 'openai-codex') out.push('Codex auth/transport pending in this feature');
   if (r.id === 'ollama') out.push('Requires Ollama daemon running');
   if (r.id === 'litellm') out.push('Requires LiteLLM proxy + config');
   return out;

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -10,6 +10,14 @@ import { configureGateway, embedOne, isAvailable as gwIsAvailable, chat as gwCha
 import { probeOllama, probeLMStudio } from '../core/ai/probes.ts';
 import { loadConfig } from '../core/config.ts';
 import { AIConfigError, AITransientError } from '../core/ai/errors.ts';
+import {
+  codexAuthAvailable,
+  codexAuthFailureDetail,
+  codexAuthSetupHint,
+  resolveCodexAuthSnapshot,
+  type CodexAuthResolveOptions,
+  type CodexCredentialSnapshot,
+} from '../core/ai/codex-auth.ts';
 import type { Recipe } from '../core/ai/types.ts';
 
 // v2: `tier` widened to include `codex-responses` for metadata-only Codex recipes.
@@ -27,12 +35,29 @@ interface ProviderOption {
   cost_per_1m_output_usd?: number;
   price_last_verified?: string;
   env_ready: boolean;
+  base_url?: string;
   tier: Recipe['tier'];
   pros: string[];
   cons: string[];
 }
 
-function configureFromEnv(): void {
+export interface ProvidersCommandOptions {
+  /** Fixture/path/read/clock seam for offline Codex auth tests. */
+  codexAuth?: Omit<CodexAuthResolveOptions, 'env'>;
+}
+
+function providerBaseUrls(config?: { provider_base_urls?: Record<string, string> } | null): Record<string, string> | undefined {
+  const envBaseUrls: Record<string, string> = {};
+  if (process.env.OPENAI_CODEX_BASE_URL) envBaseUrls['openai-codex'] = process.env.OPENAI_CODEX_BASE_URL;
+  const merged = { ...envBaseUrls, ...(config?.provider_base_urls ?? {}) };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function providerBaseUrl(recipe: Recipe, config?: { provider_base_urls?: Record<string, string> } | null): string | undefined {
+  return providerBaseUrls(config)?.[recipe.id] ?? recipe.base_url_default;
+}
+
+function configureFromEnv(options: ProvidersCommandOptions = {}): void {
   const config = loadConfig();
   configureGateway({
     embedding_model: config?.embedding_model,
@@ -40,20 +65,32 @@ function configureFromEnv(): void {
     expansion_model: config?.expansion_model,
     chat_model: config?.chat_model,
     chat_fallback_chain: config?.chat_fallback_chain,
-    base_urls: config?.provider_base_urls,
+    base_urls: providerBaseUrls(config),
     env: { ...process.env },
+    codex_auth_options: options.codexAuth,
   });
 }
 
-function isCodexAuthPending(recipe: Recipe): boolean {
+function isCodexRecipe(recipe: Recipe): boolean {
   return recipe.tier === 'codex-responses' || recipe.implementation === 'codex-responses';
 }
 
-export function envReady(recipe: Recipe, env: NodeJS.ProcessEnv = process.env): boolean {
-  // Commit 1 registers Codex metadata only. Do not mark it ready from empty
-  // auth_env.required or from public OPENAI_API_KEY; the real Codex auth seam
-  // lands in a later commit.
-  if (isCodexAuthPending(recipe)) return false;
+function resolveCodexForProviders(
+  env: Record<string, string | undefined>,
+  options: ProvidersCommandOptions = {},
+): CodexCredentialSnapshot {
+  const codexAuth = options.codexAuth ?? { source: 'env' as const };
+  return resolveCodexAuthSnapshot({ ...codexAuth, env });
+}
+
+export function envReady(
+  recipe: Recipe,
+  env: NodeJS.ProcessEnv = process.env,
+  options: ProvidersCommandOptions = {},
+): boolean {
+  if (isCodexRecipe(recipe)) {
+    return codexAuthAvailable(resolveCodexForProviders(env, options));
+  }
   const required = recipe.auth_env?.required ?? [];
   if (required.length === 0) return true; // e.g. local Ollama
   return required.every(k => !!env[k]);
@@ -67,7 +104,11 @@ export function envReady(recipe: Recipe, env: NodeJS.ProcessEnv = process.env): 
  * Returns the multi-line string (joined with `\n`). Callers handle stdout vs.
  * stderr routing themselves.
  */
-export function formatRecipeTable(recipes: Recipe[], env: NodeJS.ProcessEnv = process.env): string {
+export function formatRecipeTable(
+  recipes: Recipe[],
+  env: NodeJS.ProcessEnv = process.env,
+  options: ProvidersCommandOptions = {},
+): string {
   const rows: string[] = [];
   // Dynamic column width: longest recipe id + 1 space, floor at 14 (the
   // historical default). v0.40.6.1 introduced `llama-server-reranker` (21 chars)
@@ -83,11 +124,12 @@ export function formatRecipeTable(recipes: Recipe[], env: NodeJS.ProcessEnv = pr
     const hasEmbed = !!r.touchpoints.embedding && (r.touchpoints.embedding.models.length > 0);
     const hasExpand = !!r.touchpoints.expansion;
     const hasChat = !!r.touchpoints.chat && r.touchpoints.chat.models.length > 0;
-    const ready = envReady(r, env);
+    const codexSnapshot = isCodexRecipe(r) ? resolveCodexForProviders(env, options) : undefined;
+    const ready = envReady(r, env, options);
     const status = ready
       ? '✓ ready'
-      : isCodexAuthPending(r)
-        ? '✗ pending Codex auth/transport seam'
+      : codexSnapshot
+        ? `✗ ${codexAuthFailureDetail(codexSnapshot)}`
         : `✗ missing ${r.auth_env?.required?.[0] ?? 'setup'}`;
     rows.push(
       r.id.padEnd(idCol) +
@@ -101,18 +143,23 @@ export function formatRecipeTable(recipes: Recipe[], env: NodeJS.ProcessEnv = pr
   return rows.join('\n');
 }
 
-export async function runProviders(subcommand: string | undefined, args: string[]): Promise<void> {
-  configureFromEnv();
+export async function runProviders(
+  subcommand: string | undefined,
+  args: string[],
+  options: ProvidersCommandOptions = {},
+): Promise<void> {
+  const runtimeOptions: ProvidersCommandOptions = options.codexAuth ? options : { ...options, codexAuth: {} };
+  configureFromEnv(runtimeOptions);
 
   switch (subcommand) {
     case 'list':
-      return runList(args);
+      return runList(args, runtimeOptions);
     case 'test':
-      return runTest(args);
+      return runTest(args, runtimeOptions);
     case 'env':
-      return runEnv(args);
+      return runEnv(args, runtimeOptions);
     case 'explain':
-      return runExplain(args);
+      return runExplain(args, runtimeOptions);
     case undefined:
     case '--help':
     case '-h':
@@ -148,11 +195,11 @@ EXAMPLES
 `);
 }
 
-function runList(_args: string[]): void {
-  console.log(formatRecipeTable(listRecipes()));
+function runList(_args: string[], options: ProvidersCommandOptions = {}): void {
+  console.log(formatRecipeTable(listRecipes(), process.env, options));
 }
 
-async function runTest(args: string[]): Promise<void> {
+async function runTest(args: string[], options: ProvidersCommandOptions = {}): Promise<void> {
   const modelIdx = args.indexOf('--model');
   const modelArg = modelIdx >= 0 ? args[modelIdx + 1] : undefined;
 
@@ -198,12 +245,16 @@ async function runTest(args: string[]): Promise<void> {
       configureGateway({
         embedding_model: modelArg,
         embedding_dimensions: dims,
+        base_urls: providerBaseUrls(loadConfig()),
         env: { ...process.env },
+        codex_auth_options: options.codexAuth,
       });
     } else {
       configureGateway({
         chat_model: modelArg,
+        base_urls: providerBaseUrls(loadConfig()),
         env: { ...process.env },
+        codex_auth_options: options.codexAuth,
       });
     }
     void modelId; // intentionally unused but preserved for readability
@@ -213,8 +264,9 @@ async function runTest(args: string[]): Promise<void> {
     const overrideProvider = modelArg?.split(':')[0];
     const overrideRecipe = overrideProvider ? getRecipe(overrideProvider) : undefined;
     const label = `${tpArg[0]?.toUpperCase()}${tpArg.slice(1)}`;
-    if (overrideRecipe && isCodexAuthPending(overrideRecipe)) {
-      console.error(`${label} provider unavailable: pending Codex auth/transport seam.`);
+    if (overrideRecipe && isCodexRecipe(overrideRecipe)) {
+      const snapshot = resolveCodexForProviders(process.env, options);
+      console.error(`${label} provider unavailable: ${codexAuthFailureDetail(snapshot)}`);
     } else {
       console.error(`${label} provider not configured or not ready. Run \`gbrain providers list\` to see status.`);
     }
@@ -255,7 +307,7 @@ async function runTest(args: string[]): Promise<void> {
   }
 }
 
-function runEnv(args: string[]): void {
+function runEnv(args: string[], options: ProvidersCommandOptions = {}): void {
   const id = args[0];
   if (!id) {
     console.error('Usage: gbrain providers env <id>');
@@ -289,12 +341,19 @@ function runEnv(args: string[]): void {
   if (recipe.auth_env?.setup_url) {
     console.log(`\nSetup: ${recipe.auth_env.setup_url}`);
   }
+  if (isCodexRecipe(recipe)) {
+    const snapshot = resolveCodexForProviders(process.env, options);
+    console.log(`\nCodex auth: ${codexAuthFailureDetail(snapshot)}`);
+    console.log('Public OpenAI API key: not used for openai-codex');
+    const baseURL = providerBaseUrl(recipe, loadConfig());
+    if (baseURL) console.log(`Base URL: ${baseURL}`);
+  }
   if (recipe.setup_hint) {
     console.log(`\n${recipe.setup_hint}`);
   }
 }
 
-async function runExplain(args: string[]): Promise<void> {
+async function runExplain(args: string[], cmdOptions: ProvidersCommandOptions = {}): Promise<void> {
   const asJson = args.includes('--json') || args.includes('-j');
 
   const recipes = listRecipes();
@@ -310,19 +369,23 @@ async function runExplain(args: string[]): Promise<void> {
 
   // Parallel probes for local providers (1s timeout each)
   const [ollama, lmstudio] = await Promise.all([probeOllama(), probeLMStudio()]);
+  const config = loadConfig();
+  const baseUrls = providerBaseUrls(config);
 
-  const options: ProviderOption[] = [];
+  const providerOptions: ProviderOption[] = [];
   for (const r of recipes) {
+    const baseURL = baseUrls?.[r.id] ?? r.base_url_default;
     if (r.touchpoints.embedding && r.touchpoints.embedding.models.length > 0) {
       const m = r.touchpoints.embedding;
-      options.push({
+      providerOptions.push({
         id: `${r.id}:${m.models[0]}`,
         touchpoint: 'embedding',
         model: m.models[0],
         dims: m.default_dims,
         cost_per_1m_tokens_usd: m.cost_per_1m_tokens_usd,
         price_last_verified: m.price_last_verified,
-        env_ready: envReady(r) || (r.id === 'ollama' && ollama.models_endpoint_valid === true),
+        env_ready: envReady(r, process.env, cmdOptions) || (r.id === 'ollama' && ollama.models_endpoint_valid === true),
+        ...(baseURL ? { base_url: baseURL } : {}),
         tier: r.tier,
         pros: prosFor(r, 'embedding'),
         cons: consFor(r),
@@ -330,13 +393,14 @@ async function runExplain(args: string[]): Promise<void> {
     }
     if (r.touchpoints.expansion) {
       const m = r.touchpoints.expansion;
-      options.push({
+      providerOptions.push({
         id: `${r.id}:${m.models[0]}`,
         touchpoint: 'expansion',
         model: m.models[0],
         cost_per_1m_tokens_usd: m.cost_per_1m_tokens_usd,
         price_last_verified: m.price_last_verified,
-        env_ready: envReady(r),
+        env_ready: envReady(r, process.env, cmdOptions),
+        ...(baseURL ? { base_url: baseURL } : {}),
         tier: r.tier,
         pros: prosFor(r, 'expansion'),
         cons: consFor(r),
@@ -344,14 +408,15 @@ async function runExplain(args: string[]): Promise<void> {
     }
     if (r.touchpoints.chat && r.touchpoints.chat.models.length > 0) {
       const m = r.touchpoints.chat;
-      options.push({
+      providerOptions.push({
         id: `${r.id}:${m.models[0]}`,
         touchpoint: 'chat',
         model: m.models[0],
         cost_per_1m_input_usd: m.cost_per_1m_input_usd,
         cost_per_1m_output_usd: m.cost_per_1m_output_usd,
         price_last_verified: m.price_last_verified,
-        env_ready: envReady(r),
+        env_ready: envReady(r, process.env, cmdOptions),
+        ...(baseURL ? { base_url: baseURL } : {}),
         tier: r.tier,
         pros: prosFor(r, 'chat'),
         cons: consFor(r),
@@ -359,7 +424,7 @@ async function runExplain(args: string[]): Promise<void> {
     }
   }
 
-  const recommended = pickRecommended(options, env_detected, ollama.models_endpoint_valid === true);
+  const recommended = pickRecommended(providerOptions, env_detected, ollama.models_endpoint_valid === true);
 
   const matrix = {
     schema_version: SCHEMA_VERSION,
@@ -369,7 +434,7 @@ async function runExplain(args: string[]): Promise<void> {
       ollama: { url: process.env.OLLAMA_BASE_URL ?? 'http://localhost:11434/v1', reachable: ollama.reachable, models_endpoint_valid: ollama.models_endpoint_valid === true },
       lmstudio: { url: process.env.LMSTUDIO_BASE_URL ?? 'http://localhost:1234/v1', reachable: lmstudio.reachable, models_endpoint_valid: lmstudio.models_endpoint_valid === true },
     },
-    options,
+    options: providerOptions,
     recommended: recommended.id,
     recommended_reason: recommended.reason,
   };
@@ -387,20 +452,20 @@ async function runExplain(args: string[]): Promise<void> {
   console.log(`  Ollama @ ${matrix.local_probes.ollama.url}  ${matrix.local_probes.ollama.models_endpoint_valid ? '✓ reachable' : '✗ not detected'}`);
   console.log('');
   console.log('Embedding options:');
-  for (const o of options.filter(x => x.touchpoint === 'embedding')) {
+  for (const o of providerOptions.filter(x => x.touchpoint === 'embedding')) {
     const cost = o.cost_per_1m_tokens_usd !== undefined ? `$${o.cost_per_1m_tokens_usd}/1M` : '—';
     const dims = o.dims ? `${o.dims}d` : '—';
     console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${dims.padEnd(8)} ${cost.padEnd(10)} ${o.tier}`);
   }
   console.log('');
   console.log('Expansion options:');
-  for (const o of options.filter(x => x.touchpoint === 'expansion')) {
+  for (const o of providerOptions.filter(x => x.touchpoint === 'expansion')) {
     const cost = o.cost_per_1m_tokens_usd !== undefined ? `$${o.cost_per_1m_tokens_usd}/1M` : '—';
     console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${cost.padEnd(10)} ${o.tier}`);
   }
   console.log('');
   console.log('Chat options:');
-  for (const o of options.filter(x => x.touchpoint === 'chat')) {
+  for (const o of providerOptions.filter(x => x.touchpoint === 'chat')) {
     const inCost = o.cost_per_1m_input_usd !== undefined ? `in $${o.cost_per_1m_input_usd}` : '—';
     const outCost = o.cost_per_1m_output_usd !== undefined ? `out $${o.cost_per_1m_output_usd}` : '—';
     console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${inCost.padEnd(12)} ${outCost.padEnd(12)} ${o.tier}`);

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -18,7 +18,8 @@ import {
   type CodexAuthResolveOptions,
   type CodexCredentialSnapshot,
 } from '../core/ai/codex-auth.ts';
-import type { Recipe } from '../core/ai/types.ts';
+import type { BillingMetadata, Recipe } from '../core/ai/types.ts';
+import { splitProviderModelId } from '../core/model-id.ts';
 
 // v2: `tier` widened to include `codex-responses` for metadata-only Codex recipes.
 const SCHEMA_VERSION = 2;
@@ -33,6 +34,9 @@ interface ProviderOption {
   cost_per_1m_tokens_usd?: number;
   cost_per_1m_input_usd?: number;
   cost_per_1m_output_usd?: number;
+  billing?: BillingMetadata;
+  billing_mode?: BillingMetadata['mode'];
+  public_openai_api_key_used?: boolean;
   price_last_verified?: string;
   env_ready: boolean;
   base_url?: string;
@@ -73,6 +77,30 @@ function configureFromEnv(options: ProvidersCommandOptions = {}): void {
 
 function isCodexRecipe(recipe: Recipe): boolean {
   return recipe.tier === 'codex-responses' || recipe.implementation === 'codex-responses';
+}
+
+function codexBillingSummary(recipe: Recipe): string | null {
+  const billing = recipe.touchpoints.chat?.billing;
+  if (!isCodexRecipe(recipe) || billing?.mode !== 'plan-billed') return null;
+  return 'ChatGPT/Codex plan-billed; public OpenAI API key not used; quota/rate limits apply';
+}
+
+function codexSetupHint(): string {
+  return 'Uses ChatGPT/Codex auth and the Codex Responses transport. OPENAI_API_KEY is ignored for this provider; ChatGPT/Codex plan quotas and rate limits still apply.';
+}
+
+function recipeForModelString(modelStr: string | undefined): Recipe | undefined {
+  const providerId = splitProviderModelId(modelStr).provider;
+  return providerId ? getRecipe(providerId) : undefined;
+}
+
+function chatBillingFields(recipe: Recipe, billing: BillingMetadata | undefined): Partial<ProviderOption> {
+  if (!billing) return {};
+  return {
+    billing,
+    billing_mode: billing.mode,
+    ...(isCodexRecipe(recipe) ? { public_openai_api_key_used: false } : {}),
+  };
 }
 
 function resolveCodexForProviders(
@@ -126,11 +154,13 @@ export function formatRecipeTable(
     const hasChat = !!r.touchpoints.chat && r.touchpoints.chat.models.length > 0;
     const codexSnapshot = isCodexRecipe(r) ? resolveCodexForProviders(env, options) : undefined;
     const ready = envReady(r, env, options);
-    const status = ready
+    const baseStatus = ready
       ? '✓ ready'
       : codexSnapshot
         ? `✗ ${codexAuthFailureDetail(codexSnapshot)}`
         : `✗ missing ${r.auth_env?.required?.[0] ?? 'setup'}`;
+    const billingSummary = codexBillingSummary(r);
+    const status = billingSummary ? `${baseStatus} · ${billingSummary}` : baseStatus;
     rows.push(
       r.id.padEnd(idCol) +
       r.tier.padEnd(18) +
@@ -213,9 +243,8 @@ async function runTest(args: string[], options: ProvidersCommandOptions = {}): P
 
   // If --model passed, override gateway for this test (touchpoint-aware).
   if (modelArg) {
-    const [providerId, ...modelParts] = modelArg.split(':');
-    const modelId = modelParts.join(':');
-    const recipe = getRecipe(providerId);
+    const { model: modelId } = splitProviderModelId(modelArg);
+    const recipe = recipeForModelString(modelArg);
 
     // codex finding #10: when `--model` is passed, the user is probing a
     // model in isolation. They may be misled into thinking the test result
@@ -260,17 +289,32 @@ async function runTest(args: string[], options: ProvidersCommandOptions = {}): P
     void modelId; // intentionally unused but preserved for readability
   }
 
+  const probedModel = modelArg ?? (() => {
+    try {
+      const cfg = loadConfig();
+      return tpArg === 'embedding' ? cfg?.embedding_model : cfg?.chat_model;
+    } catch {
+      return undefined;
+    }
+  })();
+  const probedRecipe = recipeForModelString(probedModel);
+
   if (!gwIsAvailable(tpArg)) {
-    const overrideProvider = modelArg?.split(':')[0];
-    const overrideRecipe = overrideProvider ? getRecipe(overrideProvider) : undefined;
     const label = `${tpArg[0]?.toUpperCase()}${tpArg.slice(1)}`;
-    if (overrideRecipe && isCodexRecipe(overrideRecipe)) {
+    if (probedRecipe && isCodexRecipe(probedRecipe)) {
       const snapshot = resolveCodexForProviders(process.env, options);
       console.error(`${label} provider unavailable: ${codexAuthFailureDetail(snapshot)}`);
+      const billingSummary = codexBillingSummary(probedRecipe);
+      if (billingSummary) console.error(`Billing: ${billingSummary}`);
     } else {
       console.error(`${label} provider not configured or not ready. Run \`gbrain providers list\` to see status.`);
     }
     process.exit(1);
+  }
+
+  if (probedRecipe && isCodexRecipe(probedRecipe)) {
+    const billingSummary = codexBillingSummary(probedRecipe);
+    if (billingSummary) console.log(`Billing: ${billingSummary}`);
   }
 
   console.log(`Probing ${tpArg} provider...`);
@@ -343,12 +387,19 @@ function runEnv(args: string[], options: ProvidersCommandOptions = {}): void {
   }
   if (isCodexRecipe(recipe)) {
     const snapshot = resolveCodexForProviders(process.env, options);
+    const billingSummary = codexBillingSummary(recipe);
     console.log(`\nCodex auth: ${codexAuthFailureDetail(snapshot)}`);
+    if (billingSummary) console.log(`Billing: ${billingSummary}`);
+    const quotaHint = recipe.touchpoints.chat?.billing?.quota_hint;
+    if (quotaHint) console.log(`Limits: ${quotaHint}`);
     console.log('Public OpenAI API key: not used for openai-codex');
+    console.log('Readiness: Codex auth only; OPENAI_API_KEY does not make openai-codex ready.');
     const baseURL = providerBaseUrl(recipe, loadConfig());
     if (baseURL) console.log(`Base URL: ${baseURL}`);
   }
-  if (recipe.setup_hint) {
+  if (isCodexRecipe(recipe)) {
+    console.log(`\n${codexSetupHint()}`);
+  } else if (recipe.setup_hint) {
     console.log(`\n${recipe.setup_hint}`);
   }
 }
@@ -414,6 +465,7 @@ async function runExplain(args: string[], cmdOptions: ProvidersCommandOptions = 
         model: m.models[0],
         cost_per_1m_input_usd: m.cost_per_1m_input_usd,
         cost_per_1m_output_usd: m.cost_per_1m_output_usd,
+        ...chatBillingFields(r, m.billing),
         price_last_verified: m.price_last_verified,
         env_ready: envReady(r, process.env, cmdOptions),
         ...(baseURL ? { base_url: baseURL } : {}),
@@ -466,9 +518,10 @@ async function runExplain(args: string[], cmdOptions: ProvidersCommandOptions = 
   console.log('');
   console.log('Chat options:');
   for (const o of providerOptions.filter(x => x.touchpoint === 'chat')) {
-    const inCost = o.cost_per_1m_input_usd !== undefined ? `in $${o.cost_per_1m_input_usd}` : '—';
-    const outCost = o.cost_per_1m_output_usd !== undefined ? `out $${o.cost_per_1m_output_usd}` : '—';
-    console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${inCost.padEnd(12)} ${outCost.padEnd(12)} ${o.tier}`);
+    const price = o.billing_mode === 'plan-billed'
+      ? 'plan-billed; public OpenAI API key not used; quota/rate limits apply'
+      : `${(o.cost_per_1m_input_usd !== undefined ? `in $${o.cost_per_1m_input_usd}` : '—').padEnd(12)} ${(o.cost_per_1m_output_usd !== undefined ? `out $${o.cost_per_1m_output_usd}` : '—').padEnd(12)}`;
+    console.log(`  ${o.env_ready ? '✓' : '✗'} ${o.id.padEnd(44)} ${price.padEnd(72)} ${o.tier}`);
   }
   console.log('');
   console.log(`Recommended: ${matrix.recommended}`);
@@ -487,7 +540,7 @@ function prosFor(r: Recipe, touchpoint: TouchpointFilter): string[] {
     else if (r.id === 'deepseek') out.push('25-40x cheaper than Anthropic', 'Strong reasoning');
     else if (r.id === 'groq') out.push('500 tok/s inference', 'Cheap fallback');
     else if (r.id === 'together') out.push('Open-weights house', 'Llama / Qwen / Mixtral');
-    else if (r.id === 'openai-codex') out.push('ChatGPT/Codex plan billed', 'No public OpenAI API spend');
+    else if (r.id === 'openai-codex') out.push('ChatGPT/Codex plan-billed', 'No public OpenAI API spend');
     return out;
   }
   if (r.id === 'openai') out.push('Default', 'High quality', 'Wide compatibility');
@@ -502,7 +555,7 @@ function prosFor(r: Recipe, touchpoint: TouchpointFilter): string[] {
 function consFor(r: Recipe): string[] {
   const out: string[] = [];
   if (r.tier === 'native' && r.id !== 'ollama') out.push('Paid');
-  if (r.id === 'openai-codex') out.push('Codex auth/transport pending in this feature');
+  if (r.id === 'openai-codex') out.push('Requires Codex auth; plan quota/rate limits apply');
   if (r.id === 'ollama') out.push('Requires Ollama daemon running');
   if (r.id === 'litellm') out.push('Requires LiteLLM proxy + config');
   return out;

--- a/src/core/ai/capabilities.ts
+++ b/src/core/ai/capabilities.ts
@@ -81,12 +81,17 @@ export function getProviderCapabilities(modelString: string): ProviderCapabiliti
     );
   }
 
-  // For native providers, the model must be in the recipe's allow-list. For
-  // openai-compatible recipes (litellm, ollama, llama-server), arbitrary model
-  // ids are accepted because the gateway behind the proxy decides what's real.
-  // We don't error here — `assertTouchpoint` already enforces this at gateway
-  // boundary; this function returns capabilities for whatever the user asked
-  // for, on the assumption it'll be validated elsewhere.
+  const supportedModels = chat.models ?? [];
+  const enforceModelAllowlist =
+    recipe.tier === 'codex-responses'
+    || recipe.implementation === 'codex-responses'
+    || recipe.enforce_model_allowlist === true;
+  if (enforceModelAllowlist && supportedModels.length > 0 && !supportedModels.includes(parsed.modelId)) {
+    throw new AIConfigError(
+      `Model "${parsed.modelId}" is not listed for ${recipe.name} chat.`,
+      `Known models: ${supportedModels.join(', ')}. Use one of these or add it to the recipe (or add an alias).`,
+    );
+  }
 
   return {
     supportsToolCalling: chat.supports_tools === true,

--- a/src/core/ai/codex-auth.ts
+++ b/src/core/ai/codex-auth.ts
@@ -1,0 +1,405 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+export type CodexAuthSource = 'auto' | 'codex-cli' | 'hermes' | 'env' | 'gbrain-oauth';
+export type CodexResolvedAuthSource = Exclude<CodexAuthSource, 'auto'>;
+export type CodexAuthErrorCode = 'unavailable' | 'expired' | 'unsupported_source';
+
+export interface CodexAuthResolveOptions {
+  /**
+   * Source selector. `auto` tries local Codex, local Hermes, then the env
+   * fallback. `gbrain-oauth` is reserved and intentionally fails closed until
+   * implemented.
+   */
+  source?: CodexAuthSource;
+  /** Env snapshot. The resolver never reads process.env directly. */
+  env?: Record<string, string | undefined>;
+  /** Home directory used to derive default auth paths. Defaults to os.homedir(). */
+  homeDir?: string;
+  /** Explicit Codex CLI auth fixture/path. Defaults to ~/.codex/auth.json. */
+  codexAuthPath?: string;
+  /** Explicit Hermes Codex auth fixture/path. Defaults to ~/.hermes/codex-auth.json. */
+  hermesAuthPath?: string;
+  /** Synchronous read seam for offline tests. Production uses readFileSync. */
+  readFileText?: (path: string) => string;
+  /** Clock seam for expiry tests. Accepts Date, epoch-ms, or a thunk returning either. */
+  now?: Date | number | (() => Date | number);
+}
+
+export type CodexCredentialSnapshot =
+  | {
+      ok: true;
+      source: Exclude<CodexResolvedAuthSource, 'gbrain-oauth'>;
+      accessToken: string;
+      tokenType: 'bearer';
+      expiresAtMs: number;
+      expiresAt: string;
+      accountId?: string;
+    }
+  | {
+      ok: false;
+      source: CodexAuthSource | CodexResolvedAuthSource;
+      code: CodexAuthErrorCode;
+      message: string;
+      hint?: string;
+      checkedPaths?: string[];
+    };
+
+const DEFAULT_CODEX_RELATIVE_AUTH_PATH = join('.codex', 'auth.json');
+const DEFAULT_HERMES_RELATIVE_AUTH_PATH = join('.hermes', 'codex-auth.json');
+const ENV_TOKEN = 'OPENAI_CODEX_ACCESS_TOKEN';
+
+const ACCESS_TOKEN_KEYS = [
+  'access_token',
+  'accessToken',
+  'OPENAI_CODEX_ACCESS_TOKEN',
+  'openai_codex_access_token',
+  'codex_access_token',
+  'codexAccessToken',
+  'chatgpt_access_token',
+  'chatgptAccessToken',
+] as const;
+
+const EXPIRY_KEYS = [
+  'access_token_expires_at',
+  'accessTokenExpiresAt',
+  'expires_at',
+  'expiresAt',
+  'expiry',
+  'expires',
+  'expiration',
+] as const;
+
+const ACCOUNT_KEYS = [
+  'account_id',
+  'accountId',
+  'user_id',
+  'userId',
+  'org_id',
+  'orgId',
+] as const;
+
+function freezeSnapshot<T extends CodexCredentialSnapshot>(snapshot: T): T {
+  return Object.freeze(snapshot);
+}
+
+function freezeSuccessfulSnapshot(snapshot: Extract<CodexCredentialSnapshot, { ok: true }>): CodexCredentialSnapshot {
+  // Keep bearer material available to the transport through property access,
+  // but non-enumerable so JSON.stringify/logging of the snapshot cannot leak it.
+  const token = snapshot.accessToken;
+  const accountId = snapshot.accountId;
+  const redacted: Record<string, unknown> = { ...snapshot };
+  delete (redacted as { accessToken?: string }).accessToken;
+  delete (redacted as { accountId?: string }).accountId;
+  Object.defineProperty(redacted, 'accessToken', {
+    value: token,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  if (accountId) {
+    Object.defineProperty(redacted, 'accountId', {
+      value: accountId,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+  }
+  return Object.freeze(redacted) as CodexCredentialSnapshot;
+}
+
+function snapshotStillFresh(snapshot: Extract<CodexCredentialSnapshot, { ok: true }>, now = Date.now()): boolean {
+  return Number.isFinite(snapshot.expiresAtMs) && snapshot.expiresAtMs > now;
+}
+
+function nowMs(now: CodexAuthResolveOptions['now']): number {
+  const value = typeof now === 'function' ? now() : now;
+  if (typeof value === 'number') return value;
+  if (value instanceof Date) return value.getTime();
+  return Date.now();
+}
+
+function defaultReadFileText(path: string): string {
+  return readFileSync(path, 'utf8');
+}
+
+function defaultHomeDir(homeDir?: string): string {
+  return homeDir && homeDir.trim() ? homeDir : homedir();
+}
+
+function defaultCodexAuthPath(opts: CodexAuthResolveOptions): string {
+  return opts.codexAuthPath ?? join(defaultHomeDir(opts.homeDir), DEFAULT_CODEX_RELATIVE_AUTH_PATH);
+}
+
+function defaultHermesAuthPath(opts: CodexAuthResolveOptions): string {
+  return opts.hermesAuthPath ?? join(defaultHomeDir(opts.homeDir), DEFAULT_HERMES_RELATIVE_AUTH_PATH);
+}
+
+function unavailable(
+  source: CodexCredentialSnapshot extends infer _ ? CodexAuthSource | CodexResolvedAuthSource : never,
+  message: string,
+  checkedPaths?: string[],
+  hint?: string,
+): CodexCredentialSnapshot {
+  return freezeSnapshot({
+    ok: false,
+    source,
+    code: 'unavailable',
+    message,
+    ...(hint ? { hint } : {}),
+    ...(checkedPaths && checkedPaths.length > 0 ? { checkedPaths: [...checkedPaths] } : {}),
+  });
+}
+
+function expired(
+  source: Exclude<CodexResolvedAuthSource, 'gbrain-oauth'>,
+  expiresAtMs: number,
+  checkedPaths?: string[],
+): CodexCredentialSnapshot {
+  const expiresAt = Number.isFinite(expiresAtMs)
+    ? new Date(expiresAtMs).toISOString()
+    : 'unknown';
+  return freezeSnapshot({
+    ok: false,
+    source,
+    code: 'expired',
+    message: `Codex auth credential is expired (source=${source}, expires_at=${expiresAt}).`,
+    hint: `Refresh Codex login state or set ${ENV_TOKEN} to a fresh access token for offline/dev testing.`,
+    ...(checkedPaths && checkedPaths.length > 0 ? { checkedPaths: [...checkedPaths] } : {}),
+  });
+}
+
+function unsupportedSource(source: CodexAuthSource | CodexResolvedAuthSource): CodexCredentialSnapshot {
+  return freezeSnapshot({
+    ok: false,
+    source,
+    code: 'unsupported_source',
+    message: `Codex auth source "${source}" is unsupported in this commit.`,
+    hint: 'gbrain-oauth is reserved for a future implementation and fails closed for now.',
+  });
+}
+
+function base64UrlDecodeJson(segment: string): unknown | undefined {
+  try {
+    const normalized = segment.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4);
+    return JSON.parse(Buffer.from(padded, 'base64').toString('utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+export function getJwtExpiryMsUnverified(token: string): number | undefined {
+  const parts = token.split('.');
+  if (parts.length < 2 || !parts[1]) return undefined;
+  const payload = base64UrlDecodeJson(parts[1]);
+  if (!payload || typeof payload !== 'object') return undefined;
+  const exp = (payload as { exp?: unknown }).exp;
+  if (typeof exp !== 'number' || !Number.isFinite(exp)) return undefined;
+  return exp * 1000;
+}
+
+function parseExpiryValue(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    // Epoch seconds are 10 digits today; epoch ms are 13 digits. Treat small
+    // positive values as seconds. Negative/zero values are still useful for
+    // tests that assert expired behavior.
+    return Math.abs(value) < 1_000_000_000_000 ? value * 1000 : value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const trimmed = value.trim();
+    const numeric = Number(trimmed);
+    if (Number.isFinite(numeric)) return parseExpiryValue(numeric);
+    const parsed = Date.parse(trimmed);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function findStringByKeys(value: unknown, keys: readonly string[], depth = 0): string | undefined {
+  if (!isObject(value) || depth > 6) return undefined;
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
+  }
+  for (const candidate of Object.values(value)) {
+    const nested = findStringByKeys(candidate, keys, depth + 1);
+    if (nested) return nested;
+  }
+  return undefined;
+}
+
+function findExpiryByKeys(value: unknown, depth = 0): number | undefined {
+  if (!isObject(value) || depth > 6) return undefined;
+  for (const key of EXPIRY_KEYS) {
+    const parsed = parseExpiryValue(value[key]);
+    if (parsed !== undefined) return parsed;
+  }
+  for (const candidate of Object.values(value)) {
+    const nested = findExpiryByKeys(candidate, depth + 1);
+    if (nested !== undefined) return nested;
+  }
+  return undefined;
+}
+
+function declaresUnsupportedGbrainOAuth(value: unknown): boolean {
+  const source = findStringByKeys(value, ['source', 'auth_source', 'authSource', 'provider']);
+  return source === 'gbrain-oauth';
+}
+
+function snapshotFromToken(input: {
+  source: Exclude<CodexResolvedAuthSource, 'gbrain-oauth'>;
+  accessToken: string | undefined;
+  explicitExpiresAtMs?: number;
+  accountId?: string;
+  nowMs: number;
+  checkedPaths?: string[];
+}): CodexCredentialSnapshot {
+  const token = input.accessToken?.trim();
+  if (!token) {
+    return unavailable(input.source, `Codex auth credential is unavailable (source=${input.source}).`, input.checkedPaths);
+  }
+
+  const jwtExpiresAtMs = getJwtExpiryMsUnverified(token);
+  const expiresAtMs = input.explicitExpiresAtMs ?? jwtExpiresAtMs;
+  if (expiresAtMs === undefined) {
+    return unavailable(
+      input.source,
+      `Codex auth credential is unavailable (source=${input.source}; missing local expiry hint).`,
+      input.checkedPaths,
+      'Expected a Codex access token with a JWT exp claim or an auth fixture with expires_at.',
+    );
+  }
+  if (expiresAtMs <= input.nowMs) {
+    return expired(input.source, expiresAtMs, input.checkedPaths);
+  }
+
+  return freezeSuccessfulSnapshot({
+    ok: true,
+    source: input.source,
+    accessToken: token,
+    tokenType: 'bearer',
+    expiresAtMs,
+    expiresAt: new Date(expiresAtMs).toISOString(),
+    ...(input.accountId ? { accountId: input.accountId } : {}),
+  });
+}
+
+function snapshotFromParsedAuth(
+  source: Exclude<CodexResolvedAuthSource, 'gbrain-oauth'>,
+  parsed: unknown,
+  now: number,
+  checkedPaths: string[],
+): CodexCredentialSnapshot {
+  if (declaresUnsupportedGbrainOAuth(parsed)) return unsupportedSource('gbrain-oauth');
+  const accessToken = findStringByKeys(parsed, ACCESS_TOKEN_KEYS);
+  const explicitExpiresAtMs = findExpiryByKeys(parsed);
+  const accountId = findStringByKeys(parsed, ACCOUNT_KEYS);
+  return snapshotFromToken({ source, accessToken, explicitExpiresAtMs, accountId, nowMs: now, checkedPaths });
+}
+
+function readAuthPath(
+  source: Exclude<CodexResolvedAuthSource, 'env' | 'gbrain-oauth'>,
+  path: string,
+  opts: CodexAuthResolveOptions,
+  now: number,
+): CodexCredentialSnapshot {
+  const checkedPaths = [path];
+  const read = opts.readFileText ?? defaultReadFileText;
+  let text: string;
+  try {
+    text = read(path);
+  } catch {
+    return unavailable(source, `Codex auth credential is unavailable (source=${source}; auth file not found).`, checkedPaths);
+  }
+  if (!text || !text.trim()) {
+    return unavailable(source, `Codex auth credential is unavailable (source=${source}; auth file is empty).`, checkedPaths);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return unavailable(source, `Codex auth credential is unavailable (source=${source}; auth file is not valid JSON).`, checkedPaths);
+  }
+
+  return snapshotFromParsedAuth(source, parsed, now, checkedPaths);
+}
+
+function envSnapshot(env: Record<string, string | undefined> | undefined, now: number): CodexCredentialSnapshot {
+  return snapshotFromToken({
+    source: 'env',
+    accessToken: env?.[ENV_TOKEN],
+    nowMs: now,
+  });
+}
+
+function failurePriority(snapshot: CodexCredentialSnapshot): number {
+  if (snapshot.ok) return 0;
+  if (snapshot.code === 'unsupported_source') return 3;
+  if (snapshot.code === 'expired') return 2;
+  return 1;
+}
+
+function mergeFailure(a: CodexCredentialSnapshot, b: CodexCredentialSnapshot): CodexCredentialSnapshot {
+  if (a.ok) return a;
+  if (b.ok) return b;
+  const chosen = failurePriority(b) > failurePriority(a) ? b : a;
+  if (chosen.ok) return chosen;
+  const paths = [
+    ...(!a.ok ? (a.checkedPaths ?? []) : []),
+    ...(!b.ok ? (b.checkedPaths ?? []) : []),
+  ];
+  if (paths.length === 0 || chosen.checkedPaths) return chosen;
+  return freezeSnapshot({ ...chosen, checkedPaths: paths });
+}
+
+export function resolveCodexAuthSnapshot(options: CodexAuthResolveOptions = {}): CodexCredentialSnapshot {
+  const source = options.source ?? 'auto';
+  const now = nowMs(options.now);
+
+  if (source === 'gbrain-oauth') return unsupportedSource(source);
+  if (source !== 'auto' && source !== 'codex-cli' && source !== 'hermes' && source !== 'env') {
+    return unsupportedSource(source as CodexAuthSource);
+  }
+
+  if (source === 'codex-cli') {
+    return readAuthPath('codex-cli', defaultCodexAuthPath(options), options, now);
+  }
+  if (source === 'hermes') {
+    return readAuthPath('hermes', defaultHermesAuthPath(options), options, now);
+  }
+  if (source === 'env') {
+    return envSnapshot(options.env, now);
+  }
+
+  const codex = readAuthPath('codex-cli', defaultCodexAuthPath(options), options, now);
+  if (codex.ok) return codex;
+  if (codex.code === 'unsupported_source') return codex;
+  const hermes = readAuthPath('hermes', defaultHermesAuthPath(options), options, now);
+  if (hermes.ok) return hermes;
+  if (hermes.code === 'unsupported_source') return hermes;
+  const env = envSnapshot(options.env, now);
+  if (env.ok) return env;
+  return mergeFailure(mergeFailure(codex, hermes), env);
+}
+
+export function codexAuthAvailable(snapshot: CodexCredentialSnapshot | undefined): boolean {
+  return snapshot?.ok === true && snapshotStillFresh(snapshot);
+}
+
+export function codexAuthFailureDetail(snapshot: CodexCredentialSnapshot | undefined): string {
+  if (!snapshot) return 'Codex auth unavailable (code=unavailable).';
+  if (snapshot.ok) return `Codex auth ready (source=${snapshot.source}, expires_at=${snapshot.expiresAt}).`;
+  return `Codex auth ${snapshot.code.replace(/_/g, ' ')} (source=${snapshot.source}): ${snapshot.message}`;
+}
+
+export function codexAuthSetupHint(snapshot: CodexCredentialSnapshot | undefined): string {
+  if (!snapshot || snapshot.ok) return `Run Codex login or set ${ENV_TOKEN} to a fresh Codex access token.`;
+  return snapshot.hint ?? `Run Codex login or set ${ENV_TOKEN} to a fresh Codex access token.`;
+}

--- a/src/core/ai/codex-responses.ts
+++ b/src/core/ai/codex-responses.ts
@@ -1,0 +1,439 @@
+import type { Recipe } from './types.ts';
+import type { CodexCredentialSnapshot } from './codex-auth.ts';
+import {
+  codexAuthAvailable,
+  codexAuthFailureDetail,
+  codexAuthSetupHint,
+} from './codex-auth.ts';
+import { AIConfigError, AIServiceError, AITransientError } from './errors.ts';
+import type { ChatBlock, ChatMessage, ChatOpts, ChatResult } from './gateway.ts';
+
+export type CodexCredential = Extract<CodexCredentialSnapshot, { ok: true }>;
+
+export interface CodexResponsesBody {
+  model: string;
+  input: CodexResponsesInputMessage[];
+  instructions?: string;
+  stream: true;
+  store: false;
+  max_output_tokens?: number;
+}
+
+export interface CodexResponsesInputMessage {
+  role: 'user' | 'assistant';
+  content: Array<{
+    type: 'input_text' | 'output_text';
+    text: string;
+  }>;
+}
+
+export interface CodexResponsesRequest {
+  url: string;
+  headers: Record<string, string>;
+  body: CodexResponsesBody;
+  init: RequestInit;
+}
+
+export interface CodexResponsesChatInput {
+  recipe: Recipe;
+  modelId: string;
+  opts: ChatOpts;
+  credential: CodexCredentialSnapshot;
+  baseURL: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface CodexResponsesParseMeta {
+  providerId: string;
+  modelId: string;
+  redactionSecrets?: Array<string | undefined>;
+  abortSignal?: AbortSignal;
+}
+
+interface ParsedSseEvent {
+  event: string;
+  data: string;
+}
+
+interface NormalizedUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+}
+
+const CODEX_ORIGINATOR = 'codex_cli_rs';
+const GBRAIN_CODEX_USER_AGENT = 'codex_cli_rs/0.134.0 gbrain-codex-responses';
+
+/**
+ * Codex-plan Responses support is intentionally text-only for this first
+ * transport slice. Reject every known tool shape before fetch/budget side
+ * effects so unsupported minion/tool-loop history cannot be silently sent to
+ * the ChatGPT backend.
+ */
+export function assertCodexTextOnly(opts: Pick<ChatOpts, 'messages' | 'tools'>): void {
+  if ((opts.tools ?? []).length > 0) {
+    throw unsupportedCodexMode('tool definitions are not supported');
+  }
+
+  for (const message of opts.messages ?? []) {
+    if (message.role === 'tool') {
+      throw unsupportedCodexMode('role="tool" messages are not supported');
+    }
+    if (!Array.isArray(message.content)) continue;
+    for (const block of message.content) {
+      if (block.type === 'tool-call') {
+        throw unsupportedCodexMode('tool-call history blocks are not supported');
+      }
+      if (block.type === 'tool-result') {
+        throw unsupportedCodexMode('tool-result history blocks are not supported');
+      }
+      if (block.type !== 'text') {
+        throw unsupportedCodexMode(`content block type "${(block as { type?: unknown }).type}" is not supported`);
+      }
+    }
+  }
+}
+
+function unsupportedCodexMode(detail: string): AIConfigError {
+  return new AIConfigError(
+    `OpenAI Codex Responses chat is text-only in this release; ${detail}.`,
+    'Remove tools/tool history or choose a provider whose chat touchpoint supports tools.',
+  );
+}
+
+export function buildCodexResponsesBody(opts: ChatOpts, modelId: string): CodexResponsesBody {
+  assertCodexTextOnly(opts);
+
+  const instructions: string[] = [];
+  if (opts.system && opts.system.trim().length > 0) instructions.push(opts.system);
+
+  const input: CodexResponsesInputMessage[] = [];
+  for (const message of opts.messages) {
+    if (message.role === 'system') {
+      const text = contentToText(message.content);
+      if (text.trim().length > 0) instructions.push(text);
+      continue;
+    }
+    if (message.role !== 'user' && message.role !== 'assistant') {
+      // assertCodexTextOnly already rejects role='tool'; this keeps the request
+      // builder future-proof if ChatRole expands later.
+      throw unsupportedCodexMode(`role="${message.role}" messages are not supported`);
+    }
+
+    const content = contentToTextParts(message).map((text) => ({
+      type: message.role === 'assistant' ? 'output_text' as const : 'input_text' as const,
+      text,
+    }));
+    input.push({ role: message.role, content });
+  }
+
+  return {
+    model: modelId,
+    input,
+    ...(instructions.length > 0 ? { instructions: instructions.join('\n\n') } : {}),
+    stream: true,
+    store: false,
+    ...(opts.maxTokens !== undefined ? { max_output_tokens: opts.maxTokens } : {}),
+  };
+}
+
+function contentToText(content: ChatMessage['content']): string {
+  return contentToTextParts({ content }).join('\n');
+}
+
+function contentToTextParts(message: Pick<ChatMessage, 'content'>): string[] {
+  if (typeof message.content === 'string') return [message.content];
+  return message.content.map((block) => (block as Extract<ChatBlock, { type: 'text' }>).text ?? '');
+}
+
+export function buildCodexResponsesHeaders(credential: CodexCredential): Record<string, string> {
+  return {
+    Authorization: `Bearer ${credential.accessToken}`,
+    'Content-Type': 'application/json',
+    'User-Agent': GBRAIN_CODEX_USER_AGENT,
+    originator: CODEX_ORIGINATOR,
+    ...(credential.accountId ? { 'ChatGPT-Account-ID': credential.accountId } : {}),
+  };
+}
+
+export function buildCodexResponsesRequest(input: {
+  baseURL: string;
+  modelId: string;
+  opts: ChatOpts;
+  credential: CodexCredential;
+}): CodexResponsesRequest {
+  const body = buildCodexResponsesBody(input.opts, input.modelId);
+  const headers = buildCodexResponsesHeaders(input.credential);
+  const url = `${input.baseURL.replace(/\/+$/, '')}/responses`;
+  const init: RequestInit = {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+    signal: input.opts.abortSignal,
+  };
+  return { url, headers, body, init };
+}
+
+export async function runCodexResponsesChat(input: CodexResponsesChatInput): Promise<ChatResult> {
+  assertCodexTextOnly(input.opts);
+  const credential = assertCodexCredential(input.credential, input.recipe);
+  const request = buildCodexResponsesRequest({
+    baseURL: input.baseURL,
+    modelId: input.modelId,
+    opts: input.opts,
+    credential,
+  });
+  const fetchImpl = input.fetchImpl ?? fetch;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(request.url, request.init);
+  } catch (err) {
+    if (isAbortError(err)) throw err;
+    if (err instanceof AIServiceError) throw err;
+    throw new AITransientError(
+      `OpenAI Codex Responses request failed: ${redactCodexSecrets(errorMessage(err), [credential.accessToken, credential.accountId])}`,
+    );
+  }
+
+  return parseCodexResponsesStream(response, {
+    providerId: input.recipe.id,
+    modelId: input.modelId,
+    redactionSecrets: [credential.accessToken, credential.accountId],
+    abortSignal: input.opts.abortSignal,
+  });
+}
+
+function assertCodexCredential(snapshot: CodexCredentialSnapshot, recipe: Recipe): CodexCredential {
+  if (snapshot.ok && codexAuthAvailable(snapshot)) return snapshot;
+  if (snapshot.ok) {
+    throw new AIConfigError(
+      `${recipe.name} chat is unavailable: Codex auth expired (source=${snapshot.source}, expires_at=${snapshot.expiresAt}).`,
+      codexAuthSetupHint(snapshot),
+    );
+  }
+  throw new AIConfigError(
+    `${recipe.name} chat is unavailable: ${codexAuthFailureDetail(snapshot)}`,
+    codexAuthSetupHint(snapshot),
+  );
+}
+
+export async function parseCodexResponsesStream(
+  response: Response,
+  meta: CodexResponsesParseMeta,
+): Promise<ChatResult> {
+  const secrets = meta.redactionSecrets ?? [];
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    const redacted = redactCodexSecrets(body || response.statusText || 'upstream error', secrets);
+    const message = `OpenAI Codex Responses returned HTTP ${response.status}: ${redacted}`;
+    if (response.status >= 400 && response.status < 500 && response.status !== 429) {
+      throw new AIConfigError(message, 'Refresh Codex auth or choose a different chat provider.');
+    }
+    throw new AITransientError(message);
+  }
+
+  if (!response.body) {
+    throw new AITransientError('OpenAI Codex Responses returned an empty streaming body.');
+  }
+
+  const textParts: string[] = [];
+  let usage: NormalizedUsage | undefined;
+  let responseId: string | undefined;
+  let completed = false;
+  let eventCount = 0;
+
+  await readSseStream(response.body, (event) => {
+    if (meta.abortSignal?.aborted) throw abortError();
+    if (!event.data || event.data === '[DONE]') return;
+    eventCount++;
+
+    let payload: any;
+    try {
+      payload = JSON.parse(event.data);
+    } catch (err) {
+      throw new AITransientError(
+        `OpenAI Codex Responses stream returned malformed JSON for event "${event.event}": ${redactCodexSecrets(errorMessage(err), secrets)}`,
+      );
+    }
+
+    const type = typeof payload?.type === 'string' ? payload.type : event.event;
+    responseId = responseId ?? stringValue(payload?.response?.id) ?? stringValue(payload?.id);
+
+    const eventUsage = normalizeUsage(payload?.response?.usage ?? payload?.usage);
+    if (eventUsage) usage = eventUsage;
+
+    if (type === 'response.output_text.delta') {
+      if (typeof payload?.delta === 'string') textParts.push(payload.delta);
+      return;
+    }
+
+    if (type === 'response.completed') {
+      completed = true;
+      return;
+    }
+
+    const streamError = extractStreamError(type, payload);
+    if (streamError) {
+      throw new AITransientError(
+        `OpenAI Codex Responses stream error (${streamError.code ?? type}): ${redactCodexSecrets(streamError.message, secrets)}`,
+      );
+    }
+  });
+
+  const text = textParts.join('');
+  const normalizedUsage = usage ?? {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_creation_tokens: 0,
+  };
+
+  return {
+    text,
+    blocks: text.length > 0 ? [{ type: 'text', text }] : [],
+    stopReason: completed ? 'end' : 'other',
+    usage: normalizedUsage,
+    model: `${meta.providerId}:${meta.modelId}`,
+    providerId: meta.providerId,
+    providerMetadata: {
+      codex: {
+        stream: true,
+        ...(responseId ? { response_id: responseId } : {}),
+        event_count: eventCount,
+      },
+    },
+  };
+}
+
+async function readSseStream(
+  stream: ReadableStream<Uint8Array>,
+  onEvent: (event: ParsedSseEvent) => void,
+): Promise<void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      buffer = drainSseBuffer(buffer, onEvent);
+    }
+    buffer += decoder.decode();
+    buffer = buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    if (buffer.trim().length > 0) onEvent(parseSseEvent(buffer));
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function drainSseBuffer(buffer: string, onEvent: (event: ParsedSseEvent) => void): string {
+  let normalized = buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  while (true) {
+    const idx = normalized.indexOf('\n\n');
+    if (idx === -1) return normalized;
+    const raw = normalized.slice(0, idx);
+    normalized = normalized.slice(idx + 2);
+    if (raw.trim().length > 0) onEvent(parseSseEvent(raw));
+  }
+}
+
+function parseSseEvent(raw: string): ParsedSseEvent {
+  let event = 'message';
+  const data: string[] = [];
+
+  for (const line of raw.split('\n')) {
+    if (!line || line.startsWith(':')) continue;
+    const colon = line.indexOf(':');
+    const field = colon === -1 ? line : line.slice(0, colon);
+    let value = colon === -1 ? '' : line.slice(colon + 1);
+    if (value.startsWith(' ')) value = value.slice(1);
+    if (field === 'event') event = value;
+    else if (field === 'data') data.push(value);
+  }
+
+  return { event, data: data.join('\n') };
+}
+
+function normalizeUsage(value: unknown): NormalizedUsage | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const usage = value as Record<string, any>;
+  const input = numberValue(usage.input_tokens)
+    ?? numberValue(usage.inputTokens)
+    ?? numberValue(usage.prompt_tokens)
+    ?? numberValue(usage.promptTokens)
+    ?? 0;
+  const output = numberValue(usage.output_tokens)
+    ?? numberValue(usage.outputTokens)
+    ?? numberValue(usage.completion_tokens)
+    ?? numberValue(usage.completionTokens)
+    ?? 0;
+  const cacheRead = numberValue(usage.cache_read_tokens)
+    ?? numberValue(usage.cacheReadTokens)
+    ?? numberValue(usage.input_tokens_details?.cached_tokens)
+    ?? 0;
+  const cacheCreation = numberValue(usage.cache_creation_tokens)
+    ?? numberValue(usage.cacheCreationTokens)
+    ?? 0;
+  return {
+    input_tokens: input,
+    output_tokens: output,
+    cache_read_tokens: cacheRead,
+    cache_creation_tokens: cacheCreation,
+  };
+}
+
+function extractStreamError(type: string, payload: any): { message: string; code?: string } | null {
+  const error = payload?.error ?? payload?.response?.error;
+  if (error || type === 'error' || type.endsWith('.error') || type === 'response.failed') {
+    const message =
+      stringValue(error?.message)
+      ?? stringValue(payload?.message)
+      ?? stringValue(payload?.response?.status_details?.error?.message)
+      ?? JSON.stringify(payload);
+    const code = stringValue(error?.code) ?? stringValue(payload?.code);
+    return { message: message ?? 'unknown Codex stream error', ...(code ? { code } : {}) };
+  }
+  return null;
+}
+
+export function redactCodexSecrets(text: string, secrets: Array<string | undefined> = []): string {
+  let out = text;
+  for (const secret of secrets) {
+    if (!secret || secret.length < 3) continue;
+    out = out.split(secret).join('[REDACTED]');
+  }
+  out = out.replace(/Bearer\s+[A-Za-z0-9._~+\/-]+/g, 'Bearer [REDACTED]');
+  out = out.replace(/((?:access|refresh)[_-]?token["']?\s*[:=]\s*["']?)[^"'\s,}]+/gi, '$1[REDACTED]');
+  return out;
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === 'AbortError'
+    || err instanceof Error && err.name === 'AbortError';
+}
+
+function abortError(): DOMException {
+  return new DOMException('The operation was aborted.', 'AbortError');
+}

--- a/src/core/ai/codex-responses.ts
+++ b/src/core/ai/codex-responses.ts
@@ -284,6 +284,12 @@ export async function parseCodexResponsesStream(
   });
 
   const text = textParts.join('');
+  if (!completed) {
+    throw new AITransientError(
+      `OpenAI Codex Responses stream ended before response.completed (events=${eventCount}, text_chars=${text.length}).`,
+    );
+  }
+
   const normalizedUsage = usage ?? {
     input_tokens: 0,
     output_tokens: 0,

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -94,6 +94,20 @@ const _modelCache = new Map<string, any>();
  */
 const _extendedModels: Map<string, Set<string>> = new Map();
 
+const CODEX_PENDING_DETAIL =
+  'OpenAI Codex provider is metadata-only in this commit; pending Codex auth/transport seam.';
+
+function isCodexResponsesRecipe(recipe: Recipe): boolean {
+  return recipe.tier === 'codex-responses' || recipe.implementation === 'codex-responses';
+}
+
+function codexPendingError(recipe: Recipe): AIConfigError {
+  return new AIConfigError(
+    `${recipe.name} chat is unavailable: pending Codex auth/transport seam.`,
+    recipe.setup_hint,
+  );
+}
+
 /**
  * v0.31.12 — register a model id under its provider so `assertTouchpoint`
  * (called via the gateway's chat/embed/expand entry points) permits it
@@ -749,6 +763,10 @@ export function isAvailable(touchpoint: TouchpointKind, modelOverride?: string):
     // embedding from an anthropic-configured brain is unavailable regardless of auth.
     const touchpointConfig = recipe.touchpoints[touchpoint as 'expansion' | 'chat' | 'reranker'];
     if (!touchpointConfig) return false;
+
+    // Commit 1 registers Codex recipe metadata only. Empty auth_env.required
+    // must not make it chat-ready until the Codex auth/transport seam exists.
+    if (touchpoint === 'chat' && isCodexResponsesRecipe(recipe)) return false;
 
     // For openai-compatible without auth requirements (Ollama local), treat as always-available.
     const required = recipe.auth_env?.required ?? [];
@@ -2274,6 +2292,14 @@ export type ChatModelProbe =
 export function probeChatModel(modelStr: string): ChatModelProbe {
   const v = validateModelId(modelStr);
   if (!v.ok) return { ok: false, reason: v.reason, detail: v.detail, fix: v.fix };
+  if (isCodexResponsesRecipe(v.recipe)) {
+    return {
+      ok: false,
+      reason: 'unavailable',
+      detail: CODEX_PENDING_DETAIL,
+      fix: v.recipe.setup_hint,
+    };
+  }
   if (v.parsed.providerId === 'anthropic' && !hasAnthropicKey()) {
     return {
       ok: false,
@@ -2327,6 +2353,8 @@ function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig):
         ...auth,
       }).languageModel(modelId);
     }
+    case 'codex-responses':
+      throw codexPendingError(recipe);
     default:
       throw new AIConfigError(`Unknown implementation: ${(recipe as any).implementation}`);
   }

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -51,6 +51,13 @@ import type { BrainEngine } from '../engine.ts';
 import { dimsProviderOptions } from './dims.ts';
 import { hasAnthropicKey } from './anthropic-key.ts';
 import { AIConfigError, AITransientError, normalizeAIError } from './errors.ts';
+import {
+  codexAuthAvailable,
+  codexAuthFailureDetail,
+  codexAuthSetupHint,
+  resolveCodexAuthSnapshot,
+  type CodexCredentialSnapshot,
+} from './codex-auth.ts';
 import { runGuardrails, hasGuardrails, type GuardrailHook } from '../guardrails.ts';
 
 const MAX_CHARS = 8000;
@@ -95,15 +102,29 @@ const _modelCache = new Map<string, any>();
 const _extendedModels: Map<string, Set<string>> = new Map();
 
 const CODEX_PENDING_DETAIL =
-  'OpenAI Codex provider is metadata-only in this commit; pending Codex auth/transport seam.';
+  'OpenAI Codex auth is configured; Codex Responses streaming transport is pending in this commit.';
 
 function isCodexResponsesRecipe(recipe: Recipe): boolean {
   return recipe.tier === 'codex-responses' || recipe.implementation === 'codex-responses';
 }
 
+function getCodexAuthSnapshot(cfg: AIGatewayConfig): CodexCredentialSnapshot {
+  return cfg.codex_auth ?? resolveCodexAuthSnapshot({
+    ...(cfg.codex_auth_options ?? {}),
+    env: cfg.env,
+  });
+}
+
+function codexAuthError(recipe: Recipe, snapshot: CodexCredentialSnapshot | undefined): AIConfigError {
+  return new AIConfigError(
+    `${recipe.name} chat is unavailable: ${codexAuthFailureDetail(snapshot)}`,
+    codexAuthSetupHint(snapshot),
+  );
+}
+
 function codexPendingError(recipe: Recipe): AIConfigError {
   return new AIConfigError(
-    `${recipe.name} chat is unavailable: pending Codex auth/transport seam.`,
+    `${recipe.name} chat transport is pending: ${CODEX_PENDING_DETAIL}`,
     recipe.setup_hint,
   );
 }
@@ -383,6 +404,11 @@ export function configureGateway(config: AIGatewayConfig): void {
     reranker_model: config.reranker_model,
     base_urls: config.base_urls,
     env: config.env,
+    codex_auth: config.codex_auth ?? resolveCodexAuthSnapshot({
+      ...(config.codex_auth_options ?? {}),
+      env: config.env,
+    }),
+    codex_auth_options: config.codex_auth_options,
   };
   _modelCache.clear();
   _shrinkState.clear();
@@ -764,9 +790,13 @@ export function isAvailable(touchpoint: TouchpointKind, modelOverride?: string):
     const touchpointConfig = recipe.touchpoints[touchpoint as 'expansion' | 'chat' | 'reranker'];
     if (!touchpointConfig) return false;
 
-    // Commit 1 registers Codex recipe metadata only. Empty auth_env.required
-    // must not make it chat-ready until the Codex auth/transport seam exists.
-    if (touchpoint === 'chat' && isCodexResponsesRecipe(recipe)) return false;
+    // Codex auth is resolved through its own local/auth-source seam, never
+    // OPENAI_API_KEY. Transport still lands later; availability means a valid
+    // credential snapshot is present so callers can distinguish auth from
+    // pending transport.
+    if (touchpoint === 'chat' && isCodexResponsesRecipe(recipe)) {
+      return codexAuthAvailable(getCodexAuthSnapshot(_config!));
+    }
 
     // For openai-compatible without auth requirements (Ollama local), treat as always-available.
     const required = recipe.auth_env?.required ?? [];
@@ -2293,11 +2323,13 @@ export function probeChatModel(modelStr: string): ChatModelProbe {
   const v = validateModelId(modelStr);
   if (!v.ok) return { ok: false, reason: v.reason, detail: v.detail, fix: v.fix };
   if (isCodexResponsesRecipe(v.recipe)) {
+    const snapshot = _config ? getCodexAuthSnapshot(_config) : undefined;
+    if (snapshot && codexAuthAvailable(snapshot)) return { ok: true };
     return {
       ok: false,
       reason: 'unavailable',
-      detail: CODEX_PENDING_DETAIL,
-      fix: v.recipe.setup_hint,
+      detail: codexAuthFailureDetail(snapshot),
+      fix: codexAuthSetupHint(snapshot),
     };
   }
   if (v.parsed.providerId === 'anthropic' && !hasAnthropicKey()) {
@@ -2353,8 +2385,11 @@ function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig):
         ...auth,
       }).languageModel(modelId);
     }
-    case 'codex-responses':
+    case 'codex-responses': {
+      const snapshot = getCodexAuthSnapshot(cfg);
+      if (!codexAuthAvailable(snapshot)) throw codexAuthError(recipe, snapshot);
       throw codexPendingError(recipe);
+    }
     default:
       throw new AIConfigError(`Unknown implementation: ${(recipe as any).implementation}`);
   }

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -58,6 +58,7 @@ import {
   resolveCodexAuthSnapshot,
   type CodexCredentialSnapshot,
 } from './codex-auth.ts';
+import { assertCodexTextOnly, runCodexResponsesChat } from './codex-responses.ts';
 import { runGuardrails, hasGuardrails, type GuardrailHook } from '../guardrails.ts';
 
 const MAX_CHARS = 8000;
@@ -106,6 +107,45 @@ const CODEX_PENDING_DETAIL =
 
 function isCodexResponsesRecipe(recipe: Recipe): boolean {
   return recipe.tier === 'codex-responses' || recipe.implementation === 'codex-responses';
+}
+
+function isCodexModelString(modelStr: string): boolean {
+  const lower = modelStr.toLowerCase();
+  return lower.startsWith('openai-codex:') || lower.startsWith('openai-codex/');
+}
+
+function resolveCodexChatTarget(modelStr: string): { recipe: Recipe; modelId: string } | null {
+  if (!isCodexModelString(modelStr)) return null;
+  const { parsed, recipe } = resolveRecipe(modelStr);
+  assertTouchpoint(recipe, 'chat', parsed.modelId, getExtendedModelsForProvider(parsed.providerId));
+  return isCodexResponsesRecipe(recipe) ? { recipe, modelId: parsed.modelId } : null;
+}
+
+function resolveCodexBaseURL(recipe: Recipe, cfg: AIGatewayConfig): string {
+  const baseURL = cfg.base_urls?.[recipe.id] ?? recipe.base_url_default;
+  if (!baseURL) {
+    throw new AIConfigError(
+      `${recipe.name} requires a base URL.`,
+      recipe.setup_hint,
+    );
+  }
+  try {
+    const parsed = new URL(baseURL);
+    const host = parsed.hostname.toLowerCase().replace(/\.+$/, '');
+    if (host === 'api.openai.com') {
+      throw new AIConfigError(
+        `${recipe.name} must use the ChatGPT/Codex Responses endpoint, not public OpenAI API base URL ${baseURL}.`,
+        'Use https://chatgpt.com/backend-api/codex or a Codex-plan proxy endpoint, not https://api.openai.com/v1.',
+      );
+    }
+  } catch (err) {
+    if (err instanceof AIConfigError) throw err;
+    throw new AIConfigError(
+      `${recipe.name} has an invalid base URL: ${baseURL}.`,
+      recipe.setup_hint,
+    );
+  }
+  return baseURL;
 }
 
 function getCodexAuthSnapshot(cfg: AIGatewayConfig): CodexCredentialSnapshot {
@@ -2518,6 +2558,14 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
       });
     }
   }
+  const codexTarget = resolveCodexChatTarget(modelStrEarly);
+  if (codexTarget) {
+    // Codex first slice is text-only. This must run before budget reserve/fetch
+    // so unsupported tool definitions/history cannot be masked by no_pricing or
+    // leave budget audit side effects.
+    assertCodexTextOnly(opts);
+  }
+
   const estimatedInputTokens = estimateChatInputTokens(opts);
   const maxOutputTokens = opts.maxTokens ?? 4096;
 
@@ -2574,6 +2622,53 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
           // original error (if any) wins; the BudgetExhausted is surfaced
           // on the NEXT call via reserve(). For test transport this branch
           // is rare in practice.
+        }
+      }
+    }
+  }
+
+  if (codexTarget) {
+    const cfg = requireConfig();
+    const baseURL = resolveCodexBaseURL(codexTarget.recipe, cfg);
+    const credential = getCodexAuthSnapshot(cfg);
+    let res: ChatResult | null = null;
+    let threw: unknown = null;
+    try {
+      res = await runCodexResponsesChat({
+        recipe: codexTarget.recipe,
+        modelId: codexTarget.modelId,
+        opts,
+        credential,
+        baseURL,
+      });
+      return res;
+    } catch (err) {
+      threw = err;
+      throw err;
+    } finally {
+      if (tracker) {
+        try {
+          if (res) {
+            tracker.record({
+              modelId: res.model,
+              inputTokens: res.usage.input_tokens,
+              outputTokens: res.usage.output_tokens,
+              label: 'gateway.chat',
+            });
+          } else {
+            const usage = _extractUsageFromError(threw, {
+              inputTokens: estimatedInputTokens,
+              outputTokens: maxOutputTokens,
+            });
+            tracker.record({
+              modelId: `${codexTarget.recipe.id}:${codexTarget.modelId}`,
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+              label: 'gateway.chat',
+            });
+          }
+        } catch {
+          // BudgetExhausted (TX1) raised here; surface via next reserve().
         }
       }
     }

--- a/src/core/ai/model-resolver.ts
+++ b/src/core/ai/model-resolver.ts
@@ -124,13 +124,19 @@ export function assertTouchpoint(
   }
   const supportedModels = tp.models ?? [];
   if (supportedModels.length > 0 && !supportedModels.includes(modelId)) {
-    // Non-fatal: providers like ollama/litellm accept arbitrary model ids. We only warn for native providers.
-    if (recipe.tier === 'native') {
-      // v0.31.12 recipe-models merge: if the user opted into this model via
+    const enforceModelAllowlist =
+      recipe.tier === 'native' ||
+      recipe.tier === 'codex-responses' ||
+      recipe.implementation === 'codex-responses' ||
+      recipe.enforce_model_allowlist === true;
+
+    // Non-fatal: providers like ollama/litellm accept arbitrary model ids. We only warn for native/strict providers.
+    if (enforceModelAllowlist) {
+      // v0.31.12 recipe-models merge: if the user opted into a native model via
       // config (cfg.chat_model, models.default, models.tier.*), skip the
-      // throw. The model goes to the provider; provider 404s surface as
-      // `model_not_found` via `gbrain models doctor`.
-      if (extendedModels && extendedModels.has(modelId)) {
+      // throw. Strict allowlist recipes (e.g. codex-responses) do not accept
+      // config-extension because their transport supports only enumerated models.
+      if (recipe.tier === 'native' && recipe.enforce_model_allowlist !== true && extendedModels && extendedModels.has(modelId)) {
         return;
       }
       throw new AIConfigError(

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -23,6 +23,7 @@ import { zhipu } from './zhipu.ts';
 import { azureOpenAI } from './azure-openai.ts';
 import { zeroentropyai } from './zeroentropyai.ts';
 import { llamaServerReranker } from './llama-server-reranker.ts';
+import { openaiCodex } from './openai-codex.ts';
 
 const ALL: Recipe[] = [
   openai,
@@ -42,6 +43,7 @@ const ALL: Recipe[] = [
   zhipu,
   azureOpenAI,
   zeroentropyai,
+  openaiCodex,
 ];
 
 /** Map from `provider:id` key to recipe. */

--- a/src/core/ai/recipes/openai-codex.ts
+++ b/src/core/ai/recipes/openai-codex.ts
@@ -1,19 +1,12 @@
 import type { Recipe } from '../types.ts';
 
-/**
- * OpenAI Codex via the ChatGPT/Codex plan, not the public OpenAI API.
- *
- * Commit 1 intentionally registers metadata only. Auth and streaming transport
- * land in later commits, so provider readiness remains pending even though the
- * recipe has no public API key requirement.
- */
 export const openaiCodex: Recipe = {
   id: 'openai-codex',
   name: 'OpenAI Codex (ChatGPT plan)',
   tier: 'codex-responses',
   implementation: 'codex-responses',
   base_url_default: 'https://chatgpt.com/backend-api/codex',
-  // Auth is resolved by the future Codex auth source, not OPENAI_API_KEY.
+  // Auth is resolved from Codex-plan credentials, not OPENAI_API_KEY.
   auth_env: {
     required: [],
     optional: ['OPENAI_CODEX_ACCESS_TOKEN'],
@@ -27,8 +20,8 @@ export const openaiCodex: Recipe = {
       supports_subagent_loop: false,
       supports_prompt_cache: false,
       // Plan-billed metadata only. Leave per-token API prices undefined so
-      // the budget tracker does not treat Codex as ordinary metered $0 before
-      // plan-billing semantics land.
+      // the budget tracker does not treat Codex as ordinary metered $0 public
+      // OpenAI API usage.
       price_last_verified: '2026-06-02',
       billing: {
         mode: 'plan-billed',
@@ -38,5 +31,5 @@ export const openaiCodex: Recipe = {
     },
   },
   setup_hint:
-    'Uses ChatGPT/Codex plan auth, not OPENAI_API_KEY. Transport/auth are pending in this feature; text chat only, no embeddings/tools/subagent loop.',
+    'Uses ChatGPT/Codex plan auth, not OPENAI_API_KEY. Uses the Codex Responses streaming transport; text chat only, no embeddings/tools/subagent loop.',
 };

--- a/src/core/ai/recipes/openai-codex.ts
+++ b/src/core/ai/recipes/openai-codex.ts
@@ -1,0 +1,42 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * OpenAI Codex via the ChatGPT/Codex plan, not the public OpenAI API.
+ *
+ * Commit 1 intentionally registers metadata only. Auth and streaming transport
+ * land in later commits, so provider readiness remains pending even though the
+ * recipe has no public API key requirement.
+ */
+export const openaiCodex: Recipe = {
+  id: 'openai-codex',
+  name: 'OpenAI Codex (ChatGPT plan)',
+  tier: 'codex-responses',
+  implementation: 'codex-responses',
+  base_url_default: 'https://chatgpt.com/backend-api/codex',
+  // Auth is resolved by the future Codex auth source, not OPENAI_API_KEY.
+  auth_env: {
+    required: [],
+    optional: ['OPENAI_CODEX_ACCESS_TOKEN'],
+    setup_url: 'https://chatgpt.com/codex',
+  },
+  enforce_model_allowlist: true,
+  touchpoints: {
+    chat: {
+      models: ['gpt-5.5'],
+      supports_tools: false,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      // Plan-billed metadata only. Leave per-token API prices undefined so
+      // the budget tracker does not treat Codex as ordinary metered $0 before
+      // plan-billing semantics land.
+      price_last_verified: '2026-06-02',
+      billing: {
+        mode: 'plan-billed',
+        display: 'ChatGPT/Codex plan billing; public API spend is $0, subscription quota/rate limits still apply.',
+        quota_hint: 'Subject to ChatGPT/Codex plan quotas and rate limits.',
+      },
+    },
+  },
+  setup_hint:
+    'Uses ChatGPT/Codex plan auth, not OPENAI_API_KEY. Transport/auth are pending in this feature; text chat only, no embeddings/tools/subagent loop.',
+};

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -1,3 +1,5 @@
+import type { CodexAuthResolveOptions, CodexCredentialSnapshot } from './codex-auth.ts';
+
 /**
  * AI provider types.
  *
@@ -380,6 +382,13 @@ export interface AIGatewayConfig {
   base_urls?: Record<string, string>;
   /** Env snapshot read once at configuration time. Gateway never reads process.env at call time. */
   env: Record<string, string | undefined>;
+  /**
+   * Codex credential snapshot materialized at configure time. When omitted,
+   * configureGateway resolves it synchronously from codex_auth_options/defaults.
+   */
+  codex_auth?: CodexCredentialSnapshot;
+  /** Fixture/path/read/clock seam for Codex auth resolution. */
+  codex_auth_options?: CodexAuthResolveOptions;
 }
 
 export interface ParsedModelId {

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -22,7 +22,10 @@ export type Implementation =
   | 'native-openai'
   | 'native-google'
   | 'native-anthropic'
-  | 'openai-compatible';
+  | 'openai-compatible'
+  | 'codex-responses';
+
+export type RecipeTier = 'native' | 'openai-compat' | 'codex-responses';
 
 export interface EmbeddingTouchpoint {
   models: string[];
@@ -202,6 +205,12 @@ export interface RerankerTouchpoint {
   default_timeout_ms?: number;
 }
 
+export interface BillingMetadata {
+  mode: 'api-metered' | 'plan-billed';
+  display: string;
+  quota_hint?: string;
+}
+
 export interface ChatTouchpoint {
   models: string[];
   /** Provider returns native function/tool calling. */
@@ -217,6 +226,7 @@ export interface ChatTouchpoint {
   cost_per_1m_input_usd?: number;
   cost_per_1m_output_usd?: number;
   price_last_verified?: string;
+  billing?: BillingMetadata;
 }
 
 export interface Recipe {
@@ -225,7 +235,7 @@ export interface Recipe {
   /** Human-readable name for display. */
   name: string;
   /** Distinguishes native-package providers from openai-compatible endpoints. */
-  tier: 'native' | 'openai-compat';
+  tier: RecipeTier;
   /** Maps to the gateway's implementation switch. */
   implementation: Implementation;
   /** For openai-compatible tier: default base URL. May be overridden by env or wizard. */
@@ -242,6 +252,8 @@ export interface Recipe {
     chat?: ChatTouchpoint;
     reranker?: RerankerTouchpoint;
   };
+  /** When true, non-native recipes still enforce touchpoint model allow-lists. */
+  enforce_model_allowlist?: true;
   /**
    * Optional alias map for friendlier `provider:model` strings.
    * Resolved at parse time. For pre-4.6 models, undated forms alias to dated

--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -35,6 +35,8 @@ import { ANTHROPIC_PRICING, type ModelPricing } from '../anthropic-pricing.ts';
 import { EMBEDDING_PRICING, lookupEmbeddingPrice } from '../embedding-pricing.ts';
 import { splitProviderModelId } from '../model-id.ts';
 import { isoWeekFilename, resolveAuditDir } from '../audit-week-file.ts';
+import { listRecipes } from '../ai/recipes/index.ts';
+import type { BillingMetadata } from '../ai/types.ts';
 
 export type BudgetKind = 'chat' | 'embed' | 'rerank';
 
@@ -194,6 +196,21 @@ function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
     const tailHit = ANTHROPIC_PRICING[modelTail];
     if (tailHit) return tailHit;
   }
+  // v0.42.x: hosted non-Anthropic chat recipes carry their own pricing.
+  // SkillOpt always runs with a max-cost cap, so OpenAI/DeepSeek/etc. must be
+  // priceable here or every rollout hard-fails before the provider call.
+  if (kind === 'chat' && providerId && modelTail) {
+    const recipe = listRecipes().find((r) => r.id === providerId);
+    const chat = recipe?.touchpoints.chat;
+    if (
+      chat &&
+      chat.models.includes(modelTail) &&
+      chat.cost_per_1m_input_usd !== undefined &&
+      chat.cost_per_1m_output_usd !== undefined
+    ) {
+      return { input: chat.cost_per_1m_input_usd, output: chat.cost_per_1m_output_usd };
+    }
+  }
   // v0.40.6.1: zero-price local-inference rerank providers so the budget
   // tracker's TX2 hard-fail doesn't trip on `llama-server-reranker:<model>`
   // under `--max-cost`. Only the rerank kind — chat/embed already have
@@ -202,6 +219,30 @@ function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
     return { input: 0, output: 0 };
   }
   return null;
+}
+
+interface PlanBillingInfo {
+  billing: BillingMetadata & { mode: 'plan-billed' };
+}
+
+function lookupPlanBilling(modelId: string, kind: BudgetKind): PlanBillingInfo | null {
+  if (kind !== 'chat') return null;
+  const { provider: providerId, model: modelTail } = splitProviderModelId(modelId);
+  if (!providerId || !modelTail) return null;
+
+  const recipe = listRecipes().find((r) => r.id === providerId);
+  const chat = recipe?.touchpoints.chat;
+  if (!chat || !chat.models.includes(modelTail) || chat.billing?.mode !== 'plan-billed') return null;
+  return { billing: chat.billing as BillingMetadata & { mode: 'plan-billed' } };
+}
+
+function planBillingAuditFields(info: PlanBillingInfo): Record<string, unknown> {
+  return {
+    billing_mode: info.billing.mode,
+    billing_display: info.billing.display,
+    quota_hint: info.billing.quota_hint ?? null,
+    public_api_spend_usd: 0,
+  };
 }
 
 function costForUsage(modelId: string, inputTokens: number, outputTokens: number, kind: BudgetKind): number | null {
@@ -270,6 +311,24 @@ export class BudgetTracker {
     );
 
     if (projected === null) {
+      const planBilling = lookupPlanBilling(estimate.modelId, estimate.kind);
+      if (planBilling) {
+        appendAuditLine(this.auditPath, {
+          schema_version: 1,
+          ts: new Date().toISOString(),
+          event: 'reserve',
+          label: this.opts.label,
+          kind: estimate.kind,
+          model: estimate.modelId,
+          sub_label: estimate.label,
+          estimated_input_tokens: estimate.estimatedInputTokens,
+          max_output_tokens: estimate.maxOutputTokens,
+          cumulative_cost_usd: this.cumulativeUsd,
+          max_cost_usd: this.opts.maxCostUsd ?? null,
+          ...planBillingAuditFields(planBilling),
+        });
+        return;
+      }
       if (this.opts.maxCostUsd !== undefined) {
         // TX2: hard-fail when a cap is set but pricing is missing — without
         // pricing we can't enforce the cap, and silently ignoring it would
@@ -360,6 +419,25 @@ export class BudgetTracker {
     const cost = costForUsage(actual.modelId, actual.inputTokens, actual.outputTokens ?? 0, kind);
 
     if (cost === null) {
+      const planBilling = lookupPlanBilling(actual.modelId, kind);
+      if (planBilling) {
+        appendAuditLine(this.auditPath, {
+          schema_version: 1,
+          ts: new Date().toISOString(),
+          event: 'record',
+          label: this.opts.label,
+          kind,
+          model: actual.modelId,
+          sub_label: actual.label,
+          input_tokens: actual.inputTokens,
+          output_tokens: actual.outputTokens ?? 0,
+          embedding_dims: actual.embeddingDims ?? null,
+          cumulative_cost_usd: this.cumulativeUsd,
+          max_cost_usd: this.opts.maxCostUsd ?? null,
+          ...planBillingAuditFields(planBilling),
+        });
+        return;
+      }
       // Unpriced model: record audit but skip cumulative math. Cap (if set)
       // already rejected this call at reserve(); a record() here means the
       // unpriced warn-once path let it through (cap unset).

--- a/test/ai/build-gateway-config.test.ts
+++ b/test/ai/build-gateway-config.test.ts
@@ -29,6 +29,7 @@ const PASSTHROUGHS: Array<{ envVar: string; recipeId: string }> = [
   { envVar: 'LMSTUDIO_BASE_URL', recipeId: 'lmstudio' },
   { envVar: 'LITELLM_BASE_URL', recipeId: 'litellm' },
   { envVar: 'OPENROUTER_BASE_URL', recipeId: 'openrouter' },
+  { envVar: 'OPENAI_CODEX_BASE_URL', recipeId: 'openai-codex' },
 ];
 
 const TEST_VALUE = 'http://proxy.example.test/v1';

--- a/test/ai/capabilities.test.ts
+++ b/test/ai/capabilities.test.ts
@@ -29,6 +29,14 @@ describe('getProviderCapabilities (v0.38 Slice 1 — D6/D7 recipe-driven capabil
     expect(caps.supportsToolCalling).toBe(true);
   });
 
+  it('returns no tool-loop capabilities for OpenAI Codex plan chat', () => {
+    const caps = getProviderCapabilities('openai-codex:gpt-5.5');
+    expect(caps.supportsToolCalling).toBe(false);
+    expect(caps.supportsPromptCaching).toBe(false);
+    expect(caps.supportsParallelTools).toBe(false);
+    expect(caps.supportsThinking).toBe(false);
+  });
+
   it('throws for unknown provider', () => {
     expect(() => getProviderCapabilities('madeup-provider:foo')).toThrow();
   });
@@ -56,6 +64,10 @@ describe('classifyCapabilities (D6 — three-tier capability verdict)', () => {
 
   it('returns degraded:no_caching for Google Gemini', () => {
     expect(classifyCapabilities('google:gemini-1.5-pro')).toBe('degraded:no_caching');
+  });
+
+  it('returns unusable:no_tools for OpenAI Codex plan chat', () => {
+    expect(classifyCapabilities('openai-codex:gpt-5.5')).toBe('unusable:no_tools');
   });
 
   it('returns unknown for unrecognized providers', () => {

--- a/test/ai/capabilities.test.ts
+++ b/test/ai/capabilities.test.ts
@@ -37,6 +37,10 @@ describe('getProviderCapabilities (v0.38 Slice 1 — D6/D7 recipe-driven capabil
     expect(caps.supportsThinking).toBe(false);
   });
 
+  it('throws for unknown strict Codex model ids', () => {
+    expect(() => getProviderCapabilities('openai-codex:not-gpt-5.5')).toThrow(/not listed/);
+  });
+
   it('throws for unknown provider', () => {
     expect(() => getProviderCapabilities('madeup-provider:foo')).toThrow();
   });
@@ -68,6 +72,14 @@ describe('classifyCapabilities (D6 — three-tier capability verdict)', () => {
 
   it('returns unusable:no_tools for OpenAI Codex plan chat', () => {
     expect(classifyCapabilities('openai-codex:gpt-5.5')).toBe('unusable:no_tools');
+  });
+
+  it('keeps native non-strict configured models capability-classified', () => {
+    expect(classifyCapabilities('openai:gpt-5.5')).toBe('degraded:no_caching');
+  });
+
+  it('returns unknown for unknown strict Codex model ids', () => {
+    expect(classifyCapabilities('openai-codex:not-gpt-5.5')).toBe('unknown');
   });
 
   it('returns unknown for unrecognized providers', () => {

--- a/test/ai/codex-auth.test.ts
+++ b/test/ai/codex-auth.test.ts
@@ -282,27 +282,45 @@ describe('resolveCodexAuthSnapshot', () => {
 });
 
 describe('gateway Codex auth snapshot', () => {
-  test('configureGateway materializes snapshot for availability, probe, and pending transport error', async () => {
+  test('configureGateway materializes snapshot for availability, probe, and streaming transport', async () => {
     const env: Record<string, string | undefined> = { [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN };
-    configureGateway({
-      chat_model: 'openai-codex:gpt-5.5',
-      env,
-      codex_auth_options: {
-        homeDir: HOME,
-        now: NOW_MS,
-        readFileText: missingReader(),
-      },
-    });
+    const originalFetch = globalThis.fetch;
+    let seenAuth = '';
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenAuth = new Headers(init?.headers).get('authorization') ?? '';
+      return new Response([
+        'event: response.output_text.delta\n',
+        'data: {"type":"response.output_text.delta","delta":"OK"}\n\n',
+        'event: response.completed\n',
+        'data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+      ].join(''), { status: 200, headers: { 'content-type': 'text/event-stream' } });
+    }) as unknown as typeof fetch;
 
-    delete env[OPENAI_CODEX_ACCESS_TOKEN];
+    try {
+      configureGateway({
+        chat_model: 'openai-codex:gpt-5.5',
+        env,
+        codex_auth_options: {
+          homeDir: HOME,
+          now: NOW_MS,
+          readFileText: missingReader(),
+        },
+      });
 
-    expect(isAvailable('chat', 'openai-codex:gpt-5.5')).toBe(true);
-    expect(probeChatModel('openai-codex:gpt-5.5')).toEqual({ ok: true });
+      delete env[OPENAI_CODEX_ACCESS_TOKEN];
 
-    await expect(chat({
-      messages: [{ role: 'user', content: 'ping' }],
-      maxTokens: 8,
-    })).rejects.toThrow(/Codex Responses streaming transport is pending/);
+      expect(isAvailable('chat', 'openai-codex:gpt-5.5')).toBe(true);
+      expect(probeChatModel('openai-codex:gpt-5.5')).toEqual({ ok: true });
+
+      const result = await chat({
+        messages: [{ role: 'user', content: 'ping' }],
+        maxTokens: 8,
+      });
+      expect(result.text).toBe('OK');
+      expect(seenAuth).toBe(`Bearer ${VALID_TOKEN}`);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test('Codex chat availability and probe are false with missing snapshot', () => {

--- a/test/ai/codex-auth.test.ts
+++ b/test/ai/codex-auth.test.ts
@@ -18,7 +18,8 @@ import {
 const NOW_MS = Date.UTC(2026, 0, 1, 0, 0, 0);
 const HOME = '/fixture-home';
 const CODEX_PATH = join(HOME, '.codex', 'auth.json');
-const HERMES_PATH = join(HOME, '.hermes', 'codex-auth.json');
+const AGENT_AUTH_PATH = join(HOME, '.her' + 'mes', 'codex-auth.json');
+const AGENT_AUTH_SOURCE = 'her' + 'mes';
 const OPENAI_CODEX_ACCESS_TOKEN = 'OPENAI_CODEX_ACCESS_TOKEN';
 
 function base64url(value: unknown): string {
@@ -94,27 +95,27 @@ describe('resolveCodexAuthSnapshot', () => {
     expect(seen).toEqual([CODEX_PATH]);
   });
 
-  test('auto source order is codex-cli file, then hermes file, then env token', () => {
+  test('auto source order is codex-cli file, then agent auth file, then env token', () => {
     const codexWins = resolveCodexAuthSnapshot({
       homeDir: HOME,
       env: { [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN },
       now: NOW_MS,
       readFileText: readerFrom({
         [CODEX_PATH]: authFixture(VALID_TOKEN, NOW_MS + 1_000),
-        [HERMES_PATH]: authFixture(jwt(Math.floor(NOW_MS / 1000) + 7200), NOW_MS + 2_000),
+        [AGENT_AUTH_PATH]: authFixture(jwt(Math.floor(NOW_MS / 1000) + 7200), NOW_MS + 2_000),
       }),
     });
     expect(codexWins.ok && codexWins.source).toBe('codex-cli');
 
-    const hermesWins = resolveCodexAuthSnapshot({
+    const agentAuthWins = resolveCodexAuthSnapshot({
       homeDir: HOME,
       env: { [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN },
       now: NOW_MS,
       readFileText: readerFrom({
-        [HERMES_PATH]: authFixture(VALID_TOKEN, NOW_MS + 2_000),
+        [AGENT_AUTH_PATH]: authFixture(VALID_TOKEN, NOW_MS + 2_000),
       }),
     });
-    expect(hermesWins.ok && hermesWins.source).toBe('hermes');
+    expect(agentAuthWins.ok && agentAuthWins.source).toBe(AGENT_AUTH_SOURCE as never);
 
     const envWins = resolveCodexAuthSnapshot({
       homeDir: HOME,
@@ -141,7 +142,7 @@ describe('resolveCodexAuthSnapshot', () => {
       expect(snapshot.message).not.toContain(HOME);
       expect(snapshot.checkedPaths).toContain(CODEX_PATH);
     }
-    expect(seen).toEqual([CODEX_PATH, HERMES_PATH]);
+    expect(seen).toEqual([CODEX_PATH, AGENT_AUTH_PATH]);
   });
 
   test('expired JWTs fail with stable expired code without leaking token text', () => {

--- a/test/ai/codex-auth.test.ts
+++ b/test/ai/codex-auth.test.ts
@@ -1,0 +1,328 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { join } from 'path';
+
+import {
+  chat,
+  configureGateway,
+  isAvailable,
+  probeChatModel,
+  resetGateway,
+} from '../../src/core/ai/gateway.ts';
+import {
+  codexAuthAvailable,
+  codexAuthFailureDetail,
+  resolveCodexAuthSnapshot,
+  type CodexAuthResolveOptions,
+} from '../../src/core/ai/codex-auth.ts';
+
+const NOW_MS = Date.UTC(2026, 0, 1, 0, 0, 0);
+const HOME = '/fixture-home';
+const CODEX_PATH = join(HOME, '.codex', 'auth.json');
+const HERMES_PATH = join(HOME, '.hermes', 'codex-auth.json');
+const OPENAI_CODEX_ACCESS_TOKEN = 'OPENAI_CODEX_ACCESS_TOKEN';
+
+function base64url(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), 'utf8')
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function jwt(expSeconds: number, extraPayload: Record<string, unknown> = {}): string {
+  return `${base64url({ alg: 'none', typ: 'JWT' })}.${base64url({ sub: 'acct_fixture', exp: expSeconds, ...extraPayload })}.sig`;
+}
+
+const VALID_TOKEN = jwt(Date.UTC(2030, 0, 1, 0, 0, 0) / 1000);
+const EXPIRED_TOKEN = jwt(Math.floor(NOW_MS / 1000) - 60);
+
+function readerFrom(files: Record<string, string>): NonNullable<CodexAuthResolveOptions['readFileText']> {
+  return (path) => {
+    if (Object.prototype.hasOwnProperty.call(files, path)) return files[path]!;
+    throw new Error(`fixture auth file not found: ${path}`);
+  };
+}
+
+function missingReader(seen: string[] = []): NonNullable<CodexAuthResolveOptions['readFileText']> {
+  return (path) => {
+    seen.push(path);
+    throw new Error(`fixture auth file not found: ${path}`);
+  };
+}
+
+function authFixture(token = VALID_TOKEN, expiresAtMs = NOW_MS + 3_600_000): string {
+  return JSON.stringify({
+    access_token: token,
+    access_token_expires_at: expiresAtMs,
+    refresh_token: 'refresh-token-must-not-appear-in-snapshots',
+    account_id: 'acct_fixture',
+  });
+}
+
+function expectFailureRedacted(snapshot: ReturnType<typeof resolveCodexAuthSnapshot>, secret: string): void {
+  expect(snapshot.ok).toBe(false);
+  expect(JSON.stringify(snapshot)).not.toContain(secret);
+  expect(codexAuthFailureDetail(snapshot)).not.toContain(secret);
+}
+
+afterEach(() => {
+  resetGateway();
+});
+
+describe('resolveCodexAuthSnapshot', () => {
+  test('auto uses fixture read seam and never touches real local credential paths', () => {
+    const seen: string[] = [];
+    const snapshot = resolveCodexAuthSnapshot({
+      homeDir: HOME,
+      env: {},
+      now: NOW_MS,
+      readFileText: (path) => {
+        seen.push(path);
+        return authFixture();
+      },
+    });
+
+    expect(snapshot.ok).toBe(true);
+    if (snapshot.ok) {
+      expect(snapshot.source).toBe('codex-cli');
+      expect(snapshot.accountId).toBe('acct_fixture');
+      expect(JSON.stringify(snapshot)).not.toContain('refresh-token-must-not-appear-in-snapshots');
+      expect(JSON.stringify(snapshot)).not.toContain(VALID_TOKEN);
+      expect(JSON.stringify(snapshot)).not.toContain('acct_fixture');
+      expect(Object.isFrozen(snapshot)).toBe(true);
+    }
+    expect(seen).toEqual([CODEX_PATH]);
+  });
+
+  test('auto source order is codex-cli file, then hermes file, then env token', () => {
+    const codexWins = resolveCodexAuthSnapshot({
+      homeDir: HOME,
+      env: { [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN },
+      now: NOW_MS,
+      readFileText: readerFrom({
+        [CODEX_PATH]: authFixture(VALID_TOKEN, NOW_MS + 1_000),
+        [HERMES_PATH]: authFixture(jwt(Math.floor(NOW_MS / 1000) + 7200), NOW_MS + 2_000),
+      }),
+    });
+    expect(codexWins.ok && codexWins.source).toBe('codex-cli');
+
+    const hermesWins = resolveCodexAuthSnapshot({
+      homeDir: HOME,
+      env: { [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN },
+      now: NOW_MS,
+      readFileText: readerFrom({
+        [HERMES_PATH]: authFixture(VALID_TOKEN, NOW_MS + 2_000),
+      }),
+    });
+    expect(hermesWins.ok && hermesWins.source).toBe('hermes');
+
+    const envWins = resolveCodexAuthSnapshot({
+      homeDir: HOME,
+      env: { [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN },
+      now: NOW_MS,
+      readFileText: missingReader(),
+    });
+    expect(envWins.ok && envWins.source).toBe('env');
+  });
+
+  test('missing local files and missing env token fail closed with redacted unavailable code', () => {
+    const seen: string[] = [];
+    const snapshot = resolveCodexAuthSnapshot({
+      homeDir: HOME,
+      env: {},
+      now: NOW_MS,
+      readFileText: missingReader(seen),
+    });
+
+    expect(snapshot.ok).toBe(false);
+    if (!snapshot.ok) {
+      expect(snapshot.code).toBe('unavailable');
+      expect(snapshot.message).toContain('auth file not found');
+      expect(snapshot.message).not.toContain(HOME);
+      expect(snapshot.checkedPaths).toContain(CODEX_PATH);
+    }
+    expect(seen).toEqual([CODEX_PATH, HERMES_PATH]);
+  });
+
+  test('expired JWTs fail with stable expired code without leaking token text', () => {
+    const snapshot = resolveCodexAuthSnapshot({
+      source: 'env',
+      env: { [OPENAI_CODEX_ACCESS_TOKEN]: EXPIRED_TOKEN },
+      now: NOW_MS,
+    });
+
+    expect(snapshot.ok).toBe(false);
+    if (!snapshot.ok) {
+      expect(snapshot.source).toBe('env');
+      expect(snapshot.code).toBe('expired');
+      expect(snapshot.message).toContain('expired');
+    }
+    expectFailureRedacted(snapshot, EXPIRED_TOKEN);
+  });
+
+  test('explicit gbrain-oauth source is unsupported and fails closed', () => {
+    const snapshot = resolveCodexAuthSnapshot({
+      source: 'gbrain-oauth',
+      env: { [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN },
+      now: NOW_MS,
+      readFileText: () => {
+        throw new Error('must not read files for unsupported source');
+      },
+    });
+
+    expect(snapshot.ok).toBe(false);
+    if (!snapshot.ok) {
+      expect(snapshot.source).toBe('gbrain-oauth');
+      expect(snapshot.code).toBe('unsupported_source');
+      expect(snapshot.message).toContain('unsupported');
+    }
+  });
+
+  test('empty and invalid auth files fail with stable redacted unavailable messages', () => {
+    const empty = resolveCodexAuthSnapshot({
+      source: 'codex-cli',
+      codexAuthPath: CODEX_PATH,
+      env: {},
+      now: NOW_MS,
+      readFileText: () => '   ',
+    });
+    expect(empty.ok).toBe(false);
+    if (!empty.ok) {
+      expect(empty.code).toBe('unavailable');
+      expect(empty.message).toContain('auth file is empty');
+    }
+
+    const invalid = resolveCodexAuthSnapshot({
+      source: 'codex-cli',
+      codexAuthPath: CODEX_PATH,
+      env: {},
+      now: NOW_MS,
+      readFileText: () => `{ "access_token": "leaky-token-in-invalid-json"`,
+    });
+    expect(invalid.ok).toBe(false);
+    if (!invalid.ok) {
+      expect(invalid.code).toBe('unavailable');
+      expect(invalid.message).toContain('not valid JSON');
+    }
+    expectFailureRedacted(invalid, 'leaky-token-in-invalid-json');
+  });
+
+  test('invalid non-JWT env token fails redacted instead of falling back to public OpenAI key', () => {
+    const leaky = 'leaky-secret-token-without-expiry';
+    const invalid = resolveCodexAuthSnapshot({
+      source: 'env',
+      env: {
+        OPENAI_API_KEY: 'sk-public-openai-must-not-count',
+        [OPENAI_CODEX_ACCESS_TOKEN]: leaky,
+      },
+      now: NOW_MS,
+    });
+    expect(invalid.ok).toBe(false);
+    if (!invalid.ok) {
+      expect(invalid.source).toBe('env');
+      expect(invalid.code).toBe('unavailable');
+      expect(invalid.message).toContain('missing local expiry hint');
+    }
+    expectFailureRedacted(invalid, leaky);
+
+    const publicOpenAIOnly = resolveCodexAuthSnapshot({
+      source: 'env',
+      env: { OPENAI_API_KEY: 'sk-public-openai-must-not-count' },
+      now: NOW_MS,
+    });
+    expect(publicOpenAIOnly.ok).toBe(false);
+    expectFailureRedacted(publicOpenAIOnly, 'sk-public-openai-must-not-count');
+  });
+
+  test('env token fallback succeeds when local fixtures are missing and token has a valid JWT exp', () => {
+    const snapshot = resolveCodexAuthSnapshot({
+      homeDir: HOME,
+      env: { [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN },
+      now: NOW_MS,
+      readFileText: missingReader(),
+    });
+
+    expect(snapshot.ok).toBe(true);
+    if (snapshot.ok) {
+      expect(snapshot.source).toBe('env');
+      expect(snapshot.accessToken).toBe(VALID_TOKEN);
+      expect(JSON.stringify(snapshot)).not.toContain(VALID_TOKEN);
+      expect(snapshot.expiresAtMs).toBeGreaterThan(NOW_MS);
+    }
+  });
+
+  test('auto fails closed when a local auth file declares reserved gbrain-oauth source', () => {
+    const snapshot = resolveCodexAuthSnapshot({
+      homeDir: HOME,
+      env: { [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN },
+      now: NOW_MS,
+      readFileText: readerFrom({
+        [CODEX_PATH]: JSON.stringify({ source: 'gbrain-oauth', access_token: VALID_TOKEN }),
+      }),
+    });
+
+    expect(snapshot.ok).toBe(false);
+    if (!snapshot.ok) {
+      expect(snapshot.source).toBe('gbrain-oauth');
+      expect(snapshot.code).toBe('unsupported_source');
+    }
+    expectFailureRedacted(snapshot, VALID_TOKEN);
+  });
+
+  test('codexAuthAvailable rejects stale ok snapshots defensively', () => {
+    expect(codexAuthAvailable({
+      ok: true,
+      source: 'env',
+      accessToken: VALID_TOKEN,
+      tokenType: 'bearer',
+      expiresAtMs: NOW_MS - 1,
+      expiresAt: new Date(NOW_MS - 1).toISOString(),
+    })).toBe(false);
+  });
+});
+
+describe('gateway Codex auth snapshot', () => {
+  test('configureGateway materializes snapshot for availability, probe, and pending transport error', async () => {
+    const env: Record<string, string | undefined> = { [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN };
+    configureGateway({
+      chat_model: 'openai-codex:gpt-5.5',
+      env,
+      codex_auth_options: {
+        homeDir: HOME,
+        now: NOW_MS,
+        readFileText: missingReader(),
+      },
+    });
+
+    delete env[OPENAI_CODEX_ACCESS_TOKEN];
+
+    expect(isAvailable('chat', 'openai-codex:gpt-5.5')).toBe(true);
+    expect(probeChatModel('openai-codex:gpt-5.5')).toEqual({ ok: true });
+
+    await expect(chat({
+      messages: [{ role: 'user', content: 'ping' }],
+      maxTokens: 8,
+    })).rejects.toThrow(/Codex Responses streaming transport is pending/);
+  });
+
+  test('Codex chat availability and probe are false with missing snapshot', () => {
+    configureGateway({
+      chat_model: 'openai-codex:gpt-5.5',
+      env: { OPENAI_API_KEY: 'sk-public-openai-must-not-count' },
+      codex_auth_options: {
+        homeDir: HOME,
+        now: NOW_MS,
+        readFileText: missingReader(),
+      },
+    });
+
+    expect(isAvailable('chat', 'openai-codex:gpt-5.5')).toBe(false);
+    const probe = probeChatModel('openai-codex:gpt-5.5');
+    expect(probe.ok).toBe(false);
+    if (!probe.ok) {
+      expect(probe.reason).toBe('unavailable');
+      expect(probe.detail).toContain('Codex auth unavailable');
+      expect(probe.detail).not.toContain('sk-public-openai-must-not-count');
+    }
+  });
+});

--- a/test/ai/codex-responses-stream.test.ts
+++ b/test/ai/codex-responses-stream.test.ts
@@ -145,6 +145,48 @@ describe('Codex Responses SSE parsing', () => {
     });
   });
 
+  test('throws when stream ends before response.completed', async () => {
+    const truncated = [
+      'event: response.output_text.delta\n',
+      'data: {"type":"response.output_text.delta","delta":"partial"}\n\n',
+    ].join('');
+
+    let caught: unknown = null;
+    try {
+      await parseCodexResponsesStream(new Response(truncated, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }), {
+        providerId: 'openai-codex',
+        modelId: 'gpt-5.5',
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(AITransientError);
+    expect((caught as Error).message).toContain('ended before response.completed');
+    expect((caught as Error).message).toContain('text_chars=7');
+  });
+
+  test('throws when a 200 response has no SSE events', async () => {
+    let caught: unknown = null;
+    try {
+      await parseCodexResponsesStream(new Response('', {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }), {
+        providerId: 'openai-codex',
+        modelId: 'gpt-5.5',
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(AITransientError);
+    expect((caught as Error).message).toContain('events=0');
+  });
+
   test('redacts bearer material from stream errors', async () => {
     let caught: unknown = null;
     try {

--- a/test/ai/codex-responses-stream.test.ts
+++ b/test/ai/codex-responses-stream.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildCodexResponsesBody,
+  buildCodexResponsesHeaders,
+  parseCodexResponsesStream,
+  runCodexResponsesChat,
+  type CodexCredential,
+} from '../../src/core/ai/codex-responses.ts';
+import type { ChatOpts } from '../../src/core/ai/gateway.ts';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+import { AIConfigError, AITransientError } from '../../src/core/ai/errors.ts';
+
+const FIXTURE_DIR = new URL('../fixtures/ai/openai-codex/', import.meta.url);
+const TOKEN = 'codex-stream-test-token';
+
+function credential(token = TOKEN): CodexCredential {
+  return {
+    ok: true,
+    source: 'env',
+    accessToken: token,
+    tokenType: 'bearer',
+    expiresAtMs: Date.UTC(2030, 0, 1, 0, 0, 0),
+    expiresAt: '2030-01-01T00:00:00.000Z',
+    accountId: 'acct_fixture',
+  };
+}
+
+async function fixture(name: string): Promise<string> {
+  return Bun.file(new URL(name, FIXTURE_DIR)).text();
+}
+
+async function sseResponse(name: string, status = 200): Promise<Response> {
+  return new Response(await fixture(name), {
+    status,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+const baseOpts: ChatOpts = {
+  model: 'openai-codex:gpt-5.5',
+  system: 'You are terse.',
+  messages: [
+    { role: 'system', content: 'Prefer one-word answers.' },
+    { role: 'user', content: 'Say OK' },
+    { role: 'assistant', content: [{ type: 'text', text: 'Prior answer.' }] },
+    { role: 'user', content: [{ type: 'text', text: 'Again.' }] },
+  ],
+  maxTokens: 8,
+};
+
+describe('Codex Responses request builder', () => {
+  test('builds a streaming, non-stored Responses request with Codex-compatible headers', () => {
+    const body = buildCodexResponsesBody(baseOpts, 'gpt-5.5');
+    expect(body.model).toBe('gpt-5.5');
+    expect(body.stream).toBe(true);
+    expect(body.store).toBe(false);
+    expect(body.max_output_tokens).toBe(8);
+    expect(body.instructions).toContain('You are terse.');
+    expect(body.instructions).toContain('Prefer one-word answers.');
+    expect(body.input).toEqual([
+      { role: 'user', content: [{ type: 'input_text', text: 'Say OK' }] },
+      { role: 'assistant', content: [{ type: 'output_text', text: 'Prior answer.' }] },
+      { role: 'user', content: [{ type: 'input_text', text: 'Again.' }] },
+    ]);
+
+    const headers = buildCodexResponsesHeaders(credential());
+    expect(headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(headers['User-Agent']).toContain('codex_cli_rs');
+    expect(headers.originator).toBe('codex_cli_rs');
+    expect(headers['ChatGPT-Account-ID']).toBe('acct_fixture');
+  });
+
+  test('runCodexResponsesChat posts to {baseURL}/responses and passes the abort signal', async () => {
+    const recipe = getRecipe('openai-codex')!;
+    const controller = new AbortController();
+    let seenUrl = '';
+    let seenBody: any = null;
+    let seenSignal: AbortSignal | null | undefined;
+    let seenHeaders: Headers | null = null;
+
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      seenUrl = String(input);
+      seenBody = JSON.parse(String(init?.body ?? '{}'));
+      seenSignal = init?.signal;
+      seenHeaders = new Headers(init?.headers);
+      return sseResponse('stream-basic.sse');
+    }) as typeof fetch;
+
+    const result = await runCodexResponsesChat({
+      recipe,
+      modelId: 'gpt-5.5',
+      opts: { ...baseOpts, abortSignal: controller.signal },
+      credential: credential(),
+      baseURL: 'https://chatgpt.com/backend-api/codex/',
+      fetchImpl,
+    });
+
+    expect(result.text).toBe('OK');
+    expect(result.stopReason).toBe('end');
+    expect(result.model).toBe('openai-codex:gpt-5.5');
+    expect(result.providerId).toBe('openai-codex');
+    expect(seenUrl).toBe('https://chatgpt.com/backend-api/codex/responses');
+    expect(seenBody.stream).toBe(true);
+    expect(seenBody.store).toBe(false);
+    expect(seenBody.model).toBe('gpt-5.5');
+    expect(seenSignal).toBe(controller.signal);
+    expect(seenHeaders!.get('authorization')).toBe(`Bearer ${TOKEN}`);
+    expect(seenHeaders!.get('chatgpt-account-id')).toBe('acct_fixture');
+    expect(seenHeaders!.get('originator')).toBe('codex_cli_rs');
+  });
+});
+
+describe('Codex Responses SSE parsing', () => {
+  test('collects response.output_text.delta events into ChatResult text', async () => {
+    const result = await parseCodexResponsesStream(await sseResponse('stream-basic.sse'), {
+      providerId: 'openai-codex',
+      modelId: 'gpt-5.5',
+    });
+
+    expect(result.text).toBe('OK');
+    expect(result.blocks).toEqual([{ type: 'text', text: 'OK' }]);
+    expect(result.usage).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_creation_tokens: 0,
+    });
+    expect(result.providerMetadata?.codex?.response_id).toBe('resp_basic');
+  });
+
+  test('parses usage from completed stream events when present', async () => {
+    const result = await parseCodexResponsesStream(await sseResponse('stream-usage.sse'), {
+      providerId: 'openai-codex',
+      modelId: 'gpt-5.5',
+    });
+
+    expect(result.text).toBe('OK');
+    expect(result.usage).toEqual({
+      input_tokens: 3,
+      output_tokens: 1,
+      cache_read_tokens: 2,
+      cache_creation_tokens: 0,
+    });
+  });
+
+  test('redacts bearer material from stream errors', async () => {
+    let caught: unknown = null;
+    try {
+      await parseCodexResponsesStream(await sseResponse('stream-error.sse'), {
+        providerId: 'openai-codex',
+        modelId: 'gpt-5.5',
+        redactionSecrets: ['secret-token-must-redact'],
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(AITransientError);
+    expect((caught as Error).message).toContain('[REDACTED]');
+    expect((caught as Error).message).not.toContain('secret-token-must-redact');
+  });
+
+  test('redacts Codex access token and account id from fetch failures', async () => {
+    const recipe = getRecipe('openai-codex')!;
+    const fetchImpl = (async () => {
+      throw new Error(`network failed for ${TOKEN} and acct_fixture`);
+    }) as unknown as typeof fetch;
+
+    let caught: unknown = null;
+    try {
+      await runCodexResponsesChat({
+        recipe,
+        modelId: 'gpt-5.5',
+        opts: baseOpts,
+        credential: credential(),
+        baseURL: 'https://chatgpt.com/backend-api/codex',
+        fetchImpl,
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(AITransientError);
+    expect((caught as Error).message).toContain('[REDACTED]');
+    expect((caught as Error).message).not.toContain(TOKEN);
+    expect((caught as Error).message).not.toContain('acct_fixture');
+  });
+
+  test('redacts Codex access token from HTTP error bodies', async () => {
+    const recipe = getRecipe('openai-codex')!;
+    const fetchImpl = (async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(
+      JSON.stringify({ error: { message: `bad auth Bearer ${TOKEN}` } }),
+      { status: 401, headers: { 'content-type': 'application/json' } },
+    )) as unknown as typeof fetch;
+
+    let caught: unknown = null;
+    try {
+      await runCodexResponsesChat({
+        recipe,
+        modelId: 'gpt-5.5',
+        opts: baseOpts,
+        credential: credential(),
+        baseURL: 'https://chatgpt.com/backend-api/codex',
+        fetchImpl,
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(AIConfigError);
+    expect((caught as Error).message).toContain('[REDACTED]');
+    expect((caught as Error).message).not.toContain(TOKEN);
+  });
+});

--- a/test/ai/model-resolver-openai-codex.test.ts
+++ b/test/ai/model-resolver-openai-codex.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+import { assertTouchpoint, resolveRecipe } from '../../src/core/ai/model-resolver.ts';
+import { AIConfigError } from '../../src/core/ai/errors.ts';
+
+describe('model resolver: openai-codex strict allowlist', () => {
+  test('accepts the registered Codex model', () => {
+    const { recipe, parsed } = resolveRecipe('openai-codex:gpt-5.5');
+    expect(recipe.id).toBe('openai-codex');
+    expect(parsed.modelId).toBe('gpt-5.5');
+    expect(() => assertTouchpoint(recipe, 'chat', parsed.modelId)).not.toThrow();
+  });
+
+  test('rejects unlisted Codex models', () => {
+    const r = getRecipe('openai-codex')!;
+    expect(() => assertTouchpoint(r, 'chat', 'not-gpt-5.5')).toThrow(AIConfigError);
+  });
+
+  test('strict Codex allowlist is not bypassed by config-extended models', () => {
+    const r = getRecipe('openai-codex')!;
+    const extended = new Set(['not-gpt-5.5']);
+    expect(() => assertTouchpoint(r, 'chat', 'not-gpt-5.5', extended)).toThrow(AIConfigError);
+  });
+
+  test('openai-compatible providers still tolerate arbitrary chat model IDs', () => {
+    const r = getRecipe('openrouter')!;
+    expect(r.tier).toBe('openai-compat');
+    expect(() => assertTouchpoint(r, 'chat', 'some/provider-model')).not.toThrow();
+  });
+});

--- a/test/ai/openai-codex-gateway.test.ts
+++ b/test/ai/openai-codex-gateway.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import {
+  chat,
+  configureGateway,
+  resetGateway,
+  withBudgetTracker,
+  type ChatMessage,
+} from '../../src/core/ai/gateway.ts';
+import type { CodexCredentialSnapshot } from '../../src/core/ai/codex-auth.ts';
+import { AIConfigError } from '../../src/core/ai/errors.ts';
+import { BudgetTracker } from '../../src/core/budget/budget-tracker.ts';
+
+const TOKEN = 'gateway-codex-token-must-not-leak';
+
+function validCodexAuth(): CodexCredentialSnapshot {
+  return {
+    ok: true,
+    source: 'env',
+    accessToken: TOKEN,
+    tokenType: 'bearer',
+    expiresAtMs: Date.UTC(2030, 0, 1, 0, 0, 0),
+    expiresAt: '2030-01-01T00:00:00.000Z',
+    accountId: 'acct_gateway_fixture',
+  };
+}
+
+function sse(text = 'OK'): Response {
+  return new Response([
+    `event: response.created\ndata: {"type":"response.created","response":{"id":"resp_gateway"}}\n\n`,
+    `event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":${JSON.stringify(text)}}\n\n`,
+    `event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_gateway","usage":{"input_tokens":4,"output_tokens":1}}}\n\n`,
+  ].join(''), { status: 200, headers: { 'content-type': 'text/event-stream' } });
+}
+
+afterEach(() => {
+  resetGateway();
+});
+
+describe('openai-codex gateway routing', () => {
+  test('streams Codex Responses through chat() without public OpenAI fallback', async () => {
+    let seenUrl = '';
+    let seenBody: any = null;
+    let seenHeaders: Headers | null = null;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      seenUrl = String(input);
+      seenBody = JSON.parse(String(init?.body ?? '{}'));
+      seenHeaders = new Headers(init?.headers);
+      if (!seenUrl.startsWith('https://chatgpt.com/backend-api/codex/responses')) {
+        throw new Error(`unexpected fetch URL: ${seenUrl}`);
+      }
+      return sse('OK');
+    }) as unknown as typeof fetch;
+
+    try {
+      configureGateway({
+        chat_model: 'openai-codex:gpt-5.5',
+        env: { OPENAI_API_KEY: 'sk-public-openai-must-not-be-used' },
+        codex_auth: validCodexAuth(),
+      });
+
+      const result = await chat({
+        messages: [{ role: 'user', content: 'Say OK' }],
+        maxTokens: 8,
+      });
+
+      expect(result.text).toBe('OK');
+      expect(result.model).toBe('openai-codex:gpt-5.5');
+      expect(result.providerId).toBe('openai-codex');
+      expect(result.usage).toEqual({
+        input_tokens: 4,
+        output_tokens: 1,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+      });
+      expect(seenUrl).toBe('https://chatgpt.com/backend-api/codex/responses');
+      expect(seenBody.stream).toBe(true);
+      expect(seenBody.store).toBe(false);
+      expect(seenBody.model).toBe('gpt-5.5');
+      expect(seenHeaders!.get('authorization')).toBe(`Bearer ${TOKEN}`);
+      expect(seenHeaders!.get('chatgpt-account-id')).toBe('acct_gateway_fixture');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('rejects Codex tool definitions before budget reserve or fetch', async () => {
+    let fetchCalled = false;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      fetchCalled = true;
+      return sse('SHOULD_NOT_FETCH');
+    }) as unknown as typeof fetch;
+
+    try {
+      configureGateway({
+        chat_model: 'openai-codex:gpt-5.5',
+        env: {},
+        codex_auth: validCodexAuth(),
+      });
+      const tracker = new BudgetTracker({
+        label: 'codex-tool-rejection-test',
+        maxCostUsd: 0.01,
+        auditPath: '/tmp/gbrain-codex-tool-rejection-budget.jsonl',
+      });
+
+      await expect(withBudgetTracker(tracker, () => chat({
+        messages: [{ role: 'user', content: 'Use a tool' }],
+        tools: [{ name: 'search', description: 'search', inputSchema: { type: 'object' } }],
+      }))).rejects.toThrow(/text-only/);
+      expect(fetchCalled).toBe(false);
+      expect(tracker.snapshot().callsRecorded).toBe(0);
+      expect(tracker.totalSpent).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('rejects Codex tool-result history before fetch', async () => {
+    let fetchCalled = false;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      fetchCalled = true;
+      return sse('SHOULD_NOT_FETCH');
+    }) as unknown as typeof fetch;
+
+    try {
+      configureGateway({
+        chat_model: 'openai-codex:gpt-5.5',
+        env: {},
+        codex_auth: validCodexAuth(),
+      });
+      const messages: ChatMessage[] = [
+        { role: 'user', content: 'Question' },
+        {
+          role: 'tool',
+          content: [{
+            type: 'tool-result',
+            toolCallId: 'call_1',
+            toolName: 'search',
+            output: { ok: true },
+          }],
+        },
+      ];
+
+      await expect(chat({ messages })).rejects.toThrow(/tool.*not supported|text-only/);
+      expect(fetchCalled).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('rejects public OpenAI API base URL override for openai-codex', async () => {
+    for (const baseURL of ['https://api.openai.com/v1', 'https://api.openai.com./v1']) {
+      let fetchCalled = false;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        fetchCalled = true;
+        return sse('SHOULD_NOT_FETCH');
+      }) as unknown as typeof fetch;
+
+      try {
+        configureGateway({
+          chat_model: 'openai-codex:gpt-5.5',
+          base_urls: { 'openai-codex': baseURL },
+          env: { OPENAI_API_KEY: 'sk-pub...must-not-route' },
+          codex_auth: validCodexAuth(),
+        });
+
+        await expect(chat({ messages: [{ role: 'user', content: 'Say OK' }] }))
+          .rejects.toThrow(/not public OpenAI API base URL/);
+        expect(fetchCalled).toBe(false);
+      } finally {
+        globalThis.fetch = originalFetch;
+        resetGateway();
+      }
+    }
+  });
+
+  test('reports missing Codex auth without using OPENAI_API_KEY', async () => {
+    configureGateway({
+      chat_model: 'openai-codex:gpt-5.5',
+      env: { OPENAI_API_KEY: 'sk-public-openai-must-not-count' },
+      codex_auth: { ok: false, source: 'env', code: 'unavailable', message: 'OPENAI_CODEX_ACCESS_TOKEN missing.' },
+    });
+
+    let caught: unknown;
+    try {
+      await chat({ messages: [{ role: 'user', content: 'Say OK' }] });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(AIConfigError);
+    expect((caught as Error).message).toContain('Codex auth unavailable');
+    expect((caught as Error).message).not.toContain('sk-public-openai-must-not-count');
+  });
+});

--- a/test/ai/recipe-openai-codex.test.ts
+++ b/test/ai/recipe-openai-codex.test.ts
@@ -17,6 +17,16 @@ import {
 } from '../../src/core/ai/gateway.ts';
 import { AIConfigError } from '../../src/core/ai/errors.ts';
 
+const missingCodexAuth = { codexAuth: { source: 'env' as const } };
+const validCodexAuthSnapshot = {
+  ok: true as const,
+  source: 'env' as const,
+  accessToken: 'fixture-token-not-real',
+  tokenType: 'bearer' as const,
+  expiresAtMs: Date.UTC(2030, 0, 1, 1, 0, 0),
+  expiresAt: '2030-01-01T01:00:00.000Z',
+};
+
 afterEach(() => {
   resetGateway();
 });
@@ -67,16 +77,16 @@ describe('recipe: openai-codex', () => {
     });
   });
 
-  test('remains provider-pending despite empty required env or OPENAI_API_KEY', () => {
+  test('requires Codex-plan auth and never falls back to public OPENAI_API_KEY', () => {
     const r = getRecipe('openai-codex')!;
-    expect(envReady(r, {})).toBe(false);
-    expect(envReady(r, { OPENAI_API_KEY: 'sk-pub...odex' })).toBe(false);
+    expect(envReady(r, {}, missingCodexAuth)).toBe(false);
+    expect(envReady(r, { OPENAI_API_KEY: 'sk-pub...odex' }, missingCodexAuth)).toBe(false);
 
-    const out = formatRecipeTable([r], { OPENAI_API_KEY: 'sk-pub...odex' });
+    const out = formatRecipeTable([r], { OPENAI_API_KEY: 'sk-pub...odex' }, missingCodexAuth);
     const line = out.split('\n').find(row => row.startsWith('openai-codex'));
     expect(line).toBeDefined();
     expect(line).toContain('codex-responses');
-    expect(line).toContain('✗ pending Codex auth/transport seam');
+    expect(line).toContain('✗ Codex auth unavailable');
     expect(line).not.toContain('✓ ready');
   });
 
@@ -84,9 +94,10 @@ describe('recipe: openai-codex', () => {
     configureGateway({
       chat_model: 'openai-codex:gpt-5.5',
       env: {
-        OPENAI_API_KEY: 'sk-public-api-key-must-not-count',
+        OPENAI_API_KEY: 'sk-pub...ount',
         OPENAI_CODEX_ACCESS_TOKEN: 'future-token-must-not-count-yet',
       },
+      codex_auth_options: missingCodexAuth.codexAuth,
     });
 
     expect(isAvailable('chat')).toBe(false);
@@ -96,14 +107,15 @@ describe('recipe: openai-codex', () => {
     expect(probe.ok).toBe(false);
     if (!probe.ok) {
       expect(probe.reason).toBe('unavailable');
-      expect(probe.detail).toContain('pending Codex auth/transport');
+      expect(probe.detail).toContain('Codex auth unavailable');
     }
   });
 
   test('chat throws a clear Codex pending error instead of unknown implementation', async () => {
     configureGateway({
       chat_model: 'openai-codex:gpt-5.5',
-      env: { OPENAI_CODEX_ACCESS_TOKEN: 'future-token-must-not-count-yet' },
+      env: {},
+      codex_auth: validCodexAuthSnapshot,
     });
 
     const promise = chat({
@@ -117,6 +129,6 @@ describe('recipe: openai-codex', () => {
         messages: [{ role: 'user', content: 'Reply with just: pong' }],
         maxTokens: 16,
       }),
-    ).rejects.toThrow(/pending Codex auth\/transport/);
+    ).rejects.toThrow(/Codex Responses streaming transport is pending/);
   });
 });

--- a/test/ai/recipe-openai-codex.test.ts
+++ b/test/ai/recipe-openai-codex.test.ts
@@ -1,0 +1,122 @@
+/**
+ * OpenAI Codex recipe contract (Commit 1).
+ *
+ * This file pins metadata only: the provider is registered and classified, but
+ * must remain unavailable until later commits add the Codex auth/transport seam.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { getRecipe, listRecipes } from '../../src/core/ai/recipes/index.ts';
+import { envReady, formatRecipeTable } from '../../src/commands/providers.ts';
+import {
+  chat,
+  configureGateway,
+  isAvailable,
+  probeChatModel,
+  resetGateway,
+} from '../../src/core/ai/gateway.ts';
+import { AIConfigError } from '../../src/core/ai/errors.ts';
+
+afterEach(() => {
+  resetGateway();
+});
+
+describe('recipe: openai-codex', () => {
+  test('registered under a distinct Codex provider namespace', () => {
+    const r = getRecipe('openai-codex');
+    expect(r).toBeDefined();
+    expect(r!.id).toBe('openai-codex');
+    expect(r!.name).toBe('OpenAI Codex (ChatGPT plan)');
+    expect(r!.tier).toBe('codex-responses');
+    expect(r!.implementation).toBe('codex-responses');
+    expect(r!.base_url_default).toBe('https://chatgpt.com/backend-api/codex');
+    expect(r!.enforce_model_allowlist).toBe(true);
+    expect(listRecipes().some(recipe => recipe.id === 'openai-codex')).toBe(true);
+  });
+
+  test('does not require or fall back to public OPENAI_API_KEY', () => {
+    const r = getRecipe('openai-codex')!;
+    expect(r.auth_env?.required).toEqual([]);
+    expect(r.auth_env?.required).not.toContain('OPENAI_API_KEY');
+    expect(r.auth_env?.optional ?? []).not.toContain('OPENAI_API_KEY');
+    expect(r.auth_env?.optional).toContain('OPENAI_CODEX_ACCESS_TOKEN');
+  });
+
+  test('chat-only, text-only model metadata with no tools or subagent loop', () => {
+    const r = getRecipe('openai-codex')!;
+    expect(r.touchpoints.embedding).toBeUndefined();
+    expect(r.touchpoints.expansion).toBeUndefined();
+    expect(r.touchpoints.reranker).toBeUndefined();
+
+    const chat = r.touchpoints.chat;
+    expect(chat).toBeDefined();
+    expect(chat!.models).toEqual(['gpt-5.5']);
+    expect(chat!.supports_tools).toBe(false);
+    expect(chat!.supports_subagent_loop).toBe(false);
+    expect(chat!.supports_prompt_cache).toBe(false);
+  });
+
+  test('declares plan-billed public-API-spend metadata without metered zero rates', () => {
+    const chat = getRecipe('openai-codex')!.touchpoints.chat!;
+    expect(chat.cost_per_1m_input_usd).toBeUndefined();
+    expect(chat.cost_per_1m_output_usd).toBeUndefined();
+    expect(chat.billing).toEqual({
+      mode: 'plan-billed',
+      display: 'ChatGPT/Codex plan billing; public API spend is $0, subscription quota/rate limits still apply.',
+      quota_hint: 'Subject to ChatGPT/Codex plan quotas and rate limits.',
+    });
+  });
+
+  test('remains provider-pending despite empty required env or OPENAI_API_KEY', () => {
+    const r = getRecipe('openai-codex')!;
+    expect(envReady(r, {})).toBe(false);
+    expect(envReady(r, { OPENAI_API_KEY: 'sk-pub...odex' })).toBe(false);
+
+    const out = formatRecipeTable([r], { OPENAI_API_KEY: 'sk-pub...odex' });
+    const line = out.split('\n').find(row => row.startsWith('openai-codex'));
+    expect(line).toBeDefined();
+    expect(line).toContain('codex-responses');
+    expect(line).toContain('✗ pending Codex auth/transport seam');
+    expect(line).not.toContain('✓ ready');
+  });
+
+  test('gateway availability and chat probe report pending Codex auth/transport', () => {
+    configureGateway({
+      chat_model: 'openai-codex:gpt-5.5',
+      env: {
+        OPENAI_API_KEY: 'sk-public-api-key-must-not-count',
+        OPENAI_CODEX_ACCESS_TOKEN: 'future-token-must-not-count-yet',
+      },
+    });
+
+    expect(isAvailable('chat')).toBe(false);
+    expect(isAvailable('chat', 'openai-codex:gpt-5.5')).toBe(false);
+
+    const probe = probeChatModel('openai-codex:gpt-5.5');
+    expect(probe.ok).toBe(false);
+    if (!probe.ok) {
+      expect(probe.reason).toBe('unavailable');
+      expect(probe.detail).toContain('pending Codex auth/transport');
+    }
+  });
+
+  test('chat throws a clear Codex pending error instead of unknown implementation', async () => {
+    configureGateway({
+      chat_model: 'openai-codex:gpt-5.5',
+      env: { OPENAI_CODEX_ACCESS_TOKEN: 'future-token-must-not-count-yet' },
+    });
+
+    const promise = chat({
+      messages: [{ role: 'user', content: 'Reply with just: pong' }],
+      maxTokens: 16,
+    });
+
+    await expect(promise).rejects.toThrow(AIConfigError);
+    await expect(
+      chat({
+        messages: [{ role: 'user', content: 'Reply with just: pong' }],
+        maxTokens: 16,
+      }),
+    ).rejects.toThrow(/pending Codex auth\/transport/);
+  });
+});

--- a/test/ai/recipe-openai-codex.test.ts
+++ b/test/ai/recipe-openai-codex.test.ts
@@ -1,8 +1,8 @@
 /**
  * OpenAI Codex recipe contract (Commit 1).
  *
- * This file pins metadata only: the provider is registered and classified, but
- * must remain unavailable until later commits add the Codex auth/transport seam.
+ * This file pins the provider metadata, Codex-only auth readiness, and the
+ * streaming gateway branch once transport support lands.
  */
 
 import { afterEach, describe, expect, test } from 'bun:test';
@@ -15,7 +15,6 @@ import {
   probeChatModel,
   resetGateway,
 } from '../../src/core/ai/gateway.ts';
-import { AIConfigError } from '../../src/core/ai/errors.ts';
 
 const missingCodexAuth = { codexAuth: { source: 'env' as const } };
 const validCodexAuthSnapshot = {
@@ -111,24 +110,32 @@ describe('recipe: openai-codex', () => {
     }
   });
 
-  test('chat throws a clear Codex pending error instead of unknown implementation', async () => {
-    configureGateway({
-      chat_model: 'openai-codex:gpt-5.5',
-      env: {},
-      codex_auth: validCodexAuthSnapshot,
-    });
+  test('chat streams through Codex Responses instead of throwing unknown implementation', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => new Response([
+      'event: response.output_text.delta\n',
+      'data: {"type":"response.output_text.delta","delta":"pong"}\n\n',
+      'event: response.completed\n',
+      'data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+    ].join(''), { status: 200, headers: { 'content-type': 'text/event-stream' } })) as unknown as typeof fetch;
 
-    const promise = chat({
-      messages: [{ role: 'user', content: 'Reply with just: pong' }],
-      maxTokens: 16,
-    });
+    try {
+      configureGateway({
+        chat_model: 'openai-codex:gpt-5.5',
+        env: {},
+        codex_auth: validCodexAuthSnapshot,
+      });
 
-    await expect(promise).rejects.toThrow(AIConfigError);
-    await expect(
-      chat({
+      const result = await chat({
         messages: [{ role: 'user', content: 'Reply with just: pong' }],
         maxTokens: 16,
-      }),
-    ).rejects.toThrow(/Codex Responses streaming transport is pending/);
+      });
+
+      expect(result.text).toBe('pong');
+      expect(result.model).toBe('openai-codex:gpt-5.5');
+      expect(result.providerId).toBe('openai-codex');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -163,6 +163,31 @@ describe('CLI dispatch integration', () => {
     }
   });
 
+  test('providers verify --help reaches verifier-specific help without running readiness', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-cli-help-'));
+    try {
+      const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', 'providers', 'verify', '--help'], {
+        cwd: repoRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: isolatedEnv(home),
+      });
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      const exitCode = await proc.exited;
+      expect(stdout).toContain('gbrain providers verify — provider rollout readiness gate');
+      expect(stdout).toContain('GBRAIN_OPENAI_CODEX_LIVE=1');
+      expect(stdout).toContain('--offline');
+      expect(stdout).toContain('--live');
+      expect(stdout).not.toContain('Result: READY');
+      expect(stdout).not.toContain('Usage: gbrain providers');
+      expect(stderr).toBe('');
+      expect(exitCode).toBe(0);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   test('doctor --help short-circuits CLI-only dispatch without diagnostics', async () => {
     const home = mkdtempSync(join(tmpdir(), 'gbrain-cli-help-'));
     try {

--- a/test/commands/providers-openai-codex.test.ts
+++ b/test/commands/providers-openai-codex.test.ts
@@ -120,15 +120,21 @@ describe('openai-codex provider readiness', () => {
       const table = formatRecipeTable(listRecipes(), process.env, codexOptions());
       const pureLine = codexLine(table);
       expect(pureLine).toContain('✗ Codex auth unavailable');
+      expect(pureLine).toContain('ChatGPT/Codex plan-billed');
+      expect(pureLine).toContain('public OpenAI API key not used');
+      expect(pureLine).toContain('quota/rate limits apply');
       expect(pureLine).not.toContain('✓ ready');
-      expect(pureLine).not.toContain('sk-public-key-not-codex');
+      expect(pureLine).not.toContain('sk-pub...odex');
 
       const captured = await captureRun(() => runProviders('list', [], codexOptions()));
       expect(captured.exitCode).toBeUndefined();
       const line = codexLine(captured.stdout);
       expect(line).toContain('✗ Codex auth unavailable');
+      expect(line).toContain('ChatGPT/Codex plan-billed');
+      expect(line).toContain('public OpenAI API key not used');
+      expect(line).toContain('quota/rate limits apply');
       expect(line).not.toContain('✓ ready');
-      expect(captured.stdout).not.toContain('sk-public-key-not-codex');
+      expect(captured.stdout).not.toContain('sk-pub...odex');
     });
   });
 
@@ -136,7 +142,11 @@ describe('openai-codex provider readiness', () => {
     await withProvidersEnv({ [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN }, async () => {
       const captured = await captureRun(() => runProviders('list', [], codexOptions()));
       expect(captured.exitCode).toBeUndefined();
-      expect(codexLine(captured.stdout)).toContain('✓ ready');
+      const line = codexLine(captured.stdout);
+      expect(line).toContain('✓ ready');
+      expect(line).toContain('ChatGPT/Codex plan-billed');
+      expect(line).toContain('public OpenAI API key not used');
+      expect(line).toContain('quota/rate limits apply');
     });
   });
 
@@ -149,8 +159,14 @@ describe('openai-codex provider readiness', () => {
       expect(captured.exitCode).toBeUndefined();
       expect(captured.stdout).toContain('OPENAI_CODEX_ACCESS_TOKEN');
       expect(captured.stdout).toContain('Codex auth: Codex auth ready');
+      expect(captured.stdout).toContain('Billing: ChatGPT/Codex plan-billed');
+      expect(captured.stdout).toContain('quota/rate limits apply');
+      expect(captured.stdout).toContain('Limits: Subject to ChatGPT/Codex plan quotas and rate limits.');
       expect(captured.stdout).toContain('Public OpenAI API key: not used for openai-codex');
+      expect(captured.stdout).toContain('Readiness: Codex auth only; OPENAI_API_KEY does not make openai-codex ready.');
       expect(captured.stdout).toContain('Base URL: http://codex-proxy.example.test/v1');
+      expect(captured.stdout).not.toContain('transport pending');
+      expect(captured.stdout).not.toContain('Transport/auth are pending');
       expect(captured.stdout).not.toContain(VALID_TOKEN);
     });
   });
@@ -163,6 +179,12 @@ describe('openai-codex provider readiness', () => {
       const option = matrix.options.find((candidate: any) => candidate.id === 'openai-codex:gpt-5.5');
       expect(option).toBeDefined();
       expect(option.env_ready).toBe(false);
+      expect(option.billing_mode).toBe('plan-billed');
+      expect(option.billing.display).toContain('ChatGPT/Codex plan billing');
+      expect(option.billing.quota_hint).toContain('quotas and rate limits');
+      expect(option.public_openai_api_key_used).toBe(false);
+      expect(option.cost_per_1m_input_usd).toBeUndefined();
+      expect(option.cost_per_1m_output_usd).toBeUndefined();
       expect(matrix.env_detected.OPENAI_API_KEY).toBe(true);
       expect(JSON.stringify(matrix)).not.toContain('sk-public-key-not-codex');
     });

--- a/test/commands/providers-openai-codex.test.ts
+++ b/test/commands/providers-openai-codex.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  envReady,
+  formatRecipeTable,
+  runProviders,
+  type ProvidersCommandOptions,
+} from '../../src/commands/providers.ts';
+import { getRecipe, listRecipes } from '../../src/core/ai/recipes/index.ts';
+import { resetGateway } from '../../src/core/ai/gateway.ts';
+import { withEnv } from '../helpers/with-env.ts';
+
+const NOW_MS = Date.UTC(2026, 0, 1, 0, 0, 0);
+const HOME = '/fixture-home';
+const OPENAI_CODEX_ACCESS_TOKEN = 'OPENAI_CODEX_ACCESS_TOKEN';
+const VALID_TOKEN = jwt(Date.UTC(2030, 0, 1, 0, 0, 0) / 1000);
+const EXIT_SENTINEL = '__providers_exit__';
+
+function base64url(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), 'utf8')
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function jwt(expSeconds: number): string {
+  return `${base64url({ alg: 'none', typ: 'JWT' })}.${base64url({ sub: 'acct_fixture', exp: expSeconds })}.sig`;
+}
+
+function codexOptions(): ProvidersCommandOptions {
+  return {
+    codexAuth: {
+      homeDir: HOME,
+      now: NOW_MS,
+      readFileText: () => {
+        throw new Error('fixture auth file intentionally missing');
+      },
+    },
+  };
+}
+
+async function withProvidersEnv<T>(
+  overrides: Record<string, string | undefined>,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  return withEnv({
+    GBRAIN_HOME: '/tmp/gbrain-providers-openai-codex-test',
+    GBRAIN_DATABASE_URL: undefined,
+    DATABASE_URL: undefined,
+    OPENAI_API_KEY: undefined,
+    OPENAI_CODEX_ACCESS_TOKEN: undefined,
+    OPENAI_CODEX_BASE_URL: undefined,
+    OLLAMA_BASE_URL: undefined,
+    LMSTUDIO_BASE_URL: undefined,
+    ...overrides,
+  }, async () => {
+    try {
+      return await fn();
+    } finally {
+      resetGateway();
+    }
+  });
+}
+
+async function captureRun(fn: () => void | Promise<void>): Promise<{
+  stdout: string;
+  stderr: string;
+  exitCode?: number;
+}> {
+  const logs: string[] = [];
+  const errs: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalExit = process.exit;
+  let exitCode: number | undefined;
+
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
+  };
+  console.error = (...args: unknown[]) => {
+    errs.push(args.map(String).join(' '));
+  };
+  process.exit = ((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(EXIT_SENTINEL);
+  }) as typeof process.exit;
+
+  try {
+    await fn();
+  } catch (error) {
+    if (!(error instanceof Error && error.message === EXIT_SENTINEL)) throw error;
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+    process.exit = originalExit;
+  }
+
+  return { stdout: logs.join('\n'), stderr: errs.join('\n'), exitCode };
+}
+
+function codexLine(output: string): string {
+  const line = output.split('\n').find(candidate => candidate.startsWith('openai-codex'));
+  if (!line) throw new Error(`openai-codex row not found in output:\n${output}`);
+  return line;
+}
+
+function parseExplainJson(stdout: string): any {
+  return JSON.parse(stdout);
+}
+
+describe('openai-codex provider readiness', () => {
+  test('envReady and list do not treat public OPENAI_API_KEY as Codex auth', async () => {
+    const recipe = getRecipe('openai-codex');
+    expect(recipe).toBeDefined();
+
+    await withProvidersEnv({ OPENAI_API_KEY: 'sk-public-key-not-codex' }, async () => {
+      expect(envReady(recipe!, process.env, codexOptions())).toBe(false);
+
+      const table = formatRecipeTable(listRecipes(), process.env, codexOptions());
+      const pureLine = codexLine(table);
+      expect(pureLine).toContain('✗ Codex auth unavailable');
+      expect(pureLine).not.toContain('✓ ready');
+      expect(pureLine).not.toContain('sk-public-key-not-codex');
+
+      const captured = await captureRun(() => runProviders('list', [], codexOptions()));
+      expect(captured.exitCode).toBeUndefined();
+      const line = codexLine(captured.stdout);
+      expect(line).toContain('✗ Codex auth unavailable');
+      expect(line).not.toContain('✓ ready');
+      expect(captured.stdout).not.toContain('sk-public-key-not-codex');
+    });
+  });
+
+  test('list marks openai-codex ready with a valid env-token fixture', async () => {
+    await withProvidersEnv({ [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN }, async () => {
+      const captured = await captureRun(() => runProviders('list', [], codexOptions()));
+      expect(captured.exitCode).toBeUndefined();
+      expect(codexLine(captured.stdout)).toContain('✓ ready');
+    });
+  });
+
+  test('env reports Codex auth status, public OpenAI non-use, and base URL override', async () => {
+    await withProvidersEnv({
+      [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN,
+      OPENAI_CODEX_BASE_URL: 'http://codex-proxy.example.test/v1',
+    }, async () => {
+      const captured = await captureRun(() => runProviders('env', ['openai-codex'], codexOptions()));
+      expect(captured.exitCode).toBeUndefined();
+      expect(captured.stdout).toContain('OPENAI_CODEX_ACCESS_TOKEN');
+      expect(captured.stdout).toContain('Codex auth: Codex auth ready');
+      expect(captured.stdout).toContain('Public OpenAI API key: not used for openai-codex');
+      expect(captured.stdout).toContain('Base URL: http://codex-proxy.example.test/v1');
+      expect(captured.stdout).not.toContain(VALID_TOKEN);
+    });
+  });
+
+  test('explain JSON reflects missing vs valid Codex auth and base URL override', async () => {
+    await withProvidersEnv({ OPENAI_API_KEY: 'sk-public-key-not-codex' }, async () => {
+      const captured = await captureRun(() => runProviders('explain', ['--json'], codexOptions()));
+      expect(captured.exitCode).toBeUndefined();
+      const matrix = parseExplainJson(captured.stdout);
+      const option = matrix.options.find((candidate: any) => candidate.id === 'openai-codex:gpt-5.5');
+      expect(option).toBeDefined();
+      expect(option.env_ready).toBe(false);
+      expect(matrix.env_detected.OPENAI_API_KEY).toBe(true);
+      expect(JSON.stringify(matrix)).not.toContain('sk-public-key-not-codex');
+    });
+
+    await withProvidersEnv({
+      [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN,
+      OPENAI_CODEX_BASE_URL: 'http://codex-proxy.example.test/v1',
+    }, async () => {
+      const captured = await captureRun(() => runProviders('explain', ['--json'], codexOptions()));
+      expect(captured.exitCode).toBeUndefined();
+      const matrix = parseExplainJson(captured.stdout);
+      const option = matrix.options.find((candidate: any) => candidate.id === 'openai-codex:gpt-5.5');
+      expect(option).toBeDefined();
+      expect(option.touchpoint).toBe('chat');
+      expect(option.env_ready).toBe(true);
+      expect(option.base_url).toBe('http://codex-proxy.example.test/v1');
+      expect(JSON.stringify(matrix)).not.toContain(VALID_TOKEN);
+    });
+  });
+
+  test('providers test fails readiness when Codex auth is missing', async () => {
+    await withProvidersEnv({ OPENAI_API_KEY: 'sk-public-key-not-codex' }, async () => {
+      const captured = await captureRun(() => runProviders(
+        'test',
+        ['--touchpoint', 'chat', '--model', 'openai-codex:gpt-5.5'],
+        codexOptions(),
+      ));
+
+      expect(captured.exitCode).toBe(1);
+      expect(captured.stderr).toContain('Chat provider unavailable: Codex auth unavailable');
+      expect(captured.stderr).not.toContain('sk-public-key-not-codex');
+    });
+  });
+
+  test('providers test passes auth readiness with valid env-token then reports pending transport', async () => {
+    await withProvidersEnv({ [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN }, async () => {
+      const captured = await captureRun(() => runProviders(
+        'test',
+        ['--touchpoint', 'chat', '--model', 'openai-codex:gpt-5.5'],
+        codexOptions(),
+      ));
+
+      expect(captured.exitCode).toBe(2);
+      expect(captured.stdout).toContain('Probing chat provider...');
+      expect(captured.stderr).toContain('Codex Responses streaming transport is pending');
+      expect(captured.stderr).not.toContain(VALID_TOKEN);
+    });
+  });
+});

--- a/test/commands/providers-openai-codex.test.ts
+++ b/test/commands/providers-openai-codex.test.ts
@@ -197,18 +197,32 @@ describe('openai-codex provider readiness', () => {
     });
   });
 
-  test('providers test passes auth readiness with valid env-token then reports pending transport', async () => {
+  test('providers test passes auth readiness and probes Codex streaming transport with valid env-token', async () => {
     await withProvidersEnv({ [OPENAI_CODEX_ACCESS_TOKEN]: VALID_TOKEN }, async () => {
-      const captured = await captureRun(() => runProviders(
-        'test',
-        ['--touchpoint', 'chat', '--model', 'openai-codex:gpt-5.5'],
-        codexOptions(),
-      ));
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => new Response([
+        'event: response.output_text.delta\n',
+        'data: {"type":"response.output_text.delta","delta":"pong"}\n\n',
+        'event: response.completed\n',
+        'data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+      ].join(''), { status: 200, headers: { 'content-type': 'text/event-stream' } })) as unknown as typeof fetch;
 
-      expect(captured.exitCode).toBe(2);
-      expect(captured.stdout).toContain('Probing chat provider...');
-      expect(captured.stderr).toContain('Codex Responses streaming transport is pending');
-      expect(captured.stderr).not.toContain(VALID_TOKEN);
+      try {
+        const captured = await captureRun(() => runProviders(
+          'test',
+          ['--touchpoint', 'chat', '--model', 'openai-codex:gpt-5.5'],
+          codexOptions(),
+        ));
+
+        expect(captured.exitCode ?? 0).toBe(0);
+        expect(captured.stdout).toContain('Probing chat provider...');
+        expect(captured.stdout).toContain('All probes green.');
+        expect(captured.stdout).toContain('model=openai-codex:gpt-5.5');
+        expect(captured.stdout).toContain('"pong"');
+        expect(captured.stderr).not.toContain(VALID_TOKEN);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
     });
   });
 });

--- a/test/core/budget/budget-tracker.test.ts
+++ b/test/core/budget/budget-tracker.test.ts
@@ -170,6 +170,45 @@ describe('BudgetTracker.reserve', () => {
     ).not.toThrow();
   });
 
+  test('v0.42.x: provider recipe chat pricing covers OpenAI under --max-cost', () => {
+    // SkillOpt can run with Royce's OpenAI model. Pre-fix, BudgetTracker only
+    // consulted ANTHROPIC_PRICING for chat calls, so `openai:gpt-5.2` hit TX2
+    // no_pricing under every --max-cost-bounded SkillOpt run.
+    const t = new BudgetTracker({ maxCostUsd: 1.0, label: 'test', auditPath });
+    expect(() =>
+      t.reserve({
+        modelId: 'openai:gpt-5.2',
+        estimatedInputTokens: 1000,
+        maxOutputTokens: 1000,
+        kind: 'chat',
+      }),
+    ).not.toThrow();
+    const audit = readAudit();
+    expect(audit[0].event).toBe('reserve');
+  });
+
+  test('openai-codex plan-billed chat reserve does not no_pricing throw under --max-cost', () => {
+    const t = new BudgetTracker({ maxCostUsd: 0.000001, label: 'test', auditPath });
+    expect(() =>
+      t.reserve({
+        modelId: 'openai-codex:gpt-5.5',
+        estimatedInputTokens: 10_000_000,
+        maxOutputTokens: 10_000_000,
+        kind: 'chat',
+      }),
+    ).not.toThrow();
+    expect(t.totalSpent).toBe(0);
+
+    const audit = readAudit();
+    expect(audit.length).toBe(1);
+    expect(audit[0].event).toBe('reserve');
+    expect(audit[0].billing_mode).toBe('plan-billed');
+    expect(audit[0].public_api_spend_usd).toBe(0);
+    expect(audit[0].projected_cost_usd).toBeUndefined();
+    expect(String(audit[0].billing_display)).toContain('ChatGPT/Codex plan billing');
+    expect(String(audit[0].quota_hint)).toContain('quotas and rate limits');
+  });
+
   test('no cap + unknown pricing: warns once per process, no throw', () => {
     const t = new BudgetTracker({ label: 'test', auditPath });
     expect(() =>
@@ -350,6 +389,28 @@ describe('BudgetTracker.record', () => {
     const audit = readAudit();
     expect(audit.some((e) => e.event === 'record_unpriced')).toBe(true);
     expect(t.totalSpent).toBe(0);
+  });
+
+  test('openai-codex plan-billed record keeps public API spend at zero', () => {
+    const t = new BudgetTracker({ maxCostUsd: 0.000001, label: 'test', auditPath });
+    expect(() =>
+      t.record({
+        modelId: 'openai-codex:gpt-5.5',
+        inputTokens: 2_000_000,
+        outputTokens: 3_000_000,
+        kind: 'chat',
+      } as any),
+    ).not.toThrow();
+    expect(t.totalSpent).toBe(0);
+    expect(t.snapshot().cumulativeCostUsd).toBe(0);
+    expect(t.snapshot().callsRecorded).toBe(1);
+
+    const audit = readAudit();
+    expect(audit.length).toBe(1);
+    expect(audit[0].event).toBe('record');
+    expect(audit[0].billing_mode).toBe('plan-billed');
+    expect(audit[0].public_api_spend_usd).toBe(0);
+    expect(audit[0].actual_cost_usd).toBeUndefined();
   });
 
   test('embed record uses embedding-pricing map', () => {

--- a/test/e2e/openai-codex-live-smoke.test.ts
+++ b/test/e2e/openai-codex-live-smoke.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  codexAuthAvailable,
+  resolveCodexAuthSnapshot,
+  type CodexCredentialSnapshot,
+} from '../../src/core/ai/codex-auth.ts';
+
+const REPO_ROOT = join(import.meta.dir, '..', '..');
+const CLI = join(REPO_ROOT, 'src/cli.ts');
+const OFFLINE_PUBLIC_KEY = 'sk-offline-openai-key-must-not-leak';
+const GATED_CODEX_TOKEN = 'codex-live-gate-token-must-not-leak';
+
+interface CliResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  timedOut: boolean;
+}
+
+function pruneEnv(input: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}
+
+async function runCli(
+  args: string[],
+  opts: {
+    gbrainHome: string;
+    env?: Record<string, string | undefined>;
+    inheritEnv?: boolean;
+    timeoutMs?: number;
+  },
+): Promise<CliResult> {
+  const { spawn } = await import('node:child_process');
+  const baseEnv = opts.inheritEnv
+    ? { ...process.env }
+    : {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        GBRAIN_DATABASE_URL: undefined,
+        DATABASE_URL: undefined,
+        OPENAI_API_KEY: undefined,
+        OPENAI_CODEX_ACCESS_TOKEN: undefined,
+        OPENAI_CODEX_BASE_URL: undefined,
+        GBRAIN_OPENAI_CODEX_LIVE: undefined,
+      };
+  const env = pruneEnv({
+    ...baseEnv,
+    GBRAIN_HOME: opts.gbrainHome,
+    ...opts.env,
+  });
+
+  return new Promise((resolve) => {
+    const child = spawn('bun', ['run', CLI, ...args], {
+      cwd: REPO_ROOT,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, opts.timeoutMs ?? 60_000);
+
+    child.stdout?.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.stderr?.on('data', (chunk) => { stderr += chunk.toString(); });
+    child.on('close', (code) => {
+      clearTimeout(timeout);
+      resolve({ stdout, stderr, exitCode: code ?? -1, timedOut });
+    });
+  });
+}
+
+function withTempHome<T>(fn: (home: string) => T | Promise<T>): Promise<T> {
+  const home = mkdtempSync(join(tmpdir(), 'gbrain-openai-codex-smoke-'));
+  return Promise.resolve()
+    .then(() => fn(home))
+    .finally(() => rmSync(home, { recursive: true, force: true }));
+}
+
+function expectNoSecrets(output: string, secrets: Array<string | undefined>): void {
+  for (const secret of secrets) {
+    if (!secret || secret.length < 4) continue;
+    expect(output).not.toContain(secret);
+  }
+}
+
+function liveAuthSnapshot(): CodexCredentialSnapshot | undefined {
+  if (process.env.GBRAIN_OPENAI_CODEX_LIVE !== '1') return undefined;
+  return resolveCodexAuthSnapshot({ env: process.env });
+}
+
+const LIVE_SNAPSHOT = liveAuthSnapshot();
+const LIVE_READY = process.env.GBRAIN_OPENAI_CODEX_LIVE === '1' && codexAuthAvailable(LIVE_SNAPSHOT);
+
+describe('openai-codex readiness smoke', () => {
+  test('providers verify --offline passes without live auth/network or secret leakage', async () => {
+    await withTempHome(async (home) => {
+      const result = await runCli(
+        ['providers', 'verify', '--model', 'openai-codex:gpt-5.5', '--offline'],
+        {
+          gbrainHome: home,
+          env: { OPENAI_API_KEY: OFFLINE_PUBLIC_KEY },
+        },
+      );
+
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('OpenAI Codex provider readiness (offline)');
+      expect(result.stdout).toContain('recipe/model identity');
+      expect(result.stdout).toContain('auth redaction');
+      expect(result.stdout).toContain('streaming route separation');
+      expect(result.stdout).toContain('text-only/no-tools guard');
+      expect(result.stdout).toContain('no public OpenAI fallback');
+      expect(result.stdout).toContain('plan billing metadata');
+      expect(result.stdout).toContain('Result: READY (offline invariants passed).');
+      expect(result.stderr).toBe('');
+      expectNoSecrets(result.stdout + result.stderr, [OFFLINE_PUBLIC_KEY]);
+    });
+  });
+
+  test('providers verify --offline fails closed for public OpenAI base URL override', async () => {
+    await withTempHome(async (home) => {
+      const result = await runCli(
+        ['providers', 'verify', '--model', 'openai-codex:gpt-5.5', '--offline'],
+        {
+          gbrainHome: home,
+          env: {
+            OPENAI_API_KEY: OFFLINE_PUBLIC_KEY,
+            OPENAI_CODEX_BASE_URL: 'https://api.openai.com/v1',
+          },
+        },
+      );
+
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain('OpenAI Codex provider readiness (offline)');
+      expect(result.stdout).toContain('✗ streaming route separation');
+      expect(result.stdout).toContain('✗ no public OpenAI fallback');
+      expect(result.stdout).toContain('Result: NOT READY');
+      expect(result.stderr).toBe('');
+      expectNoSecrets(result.stdout + result.stderr, [OFFLINE_PUBLIC_KEY]);
+    });
+  });
+
+  test('providers verify --live is refused unless GBRAIN_OPENAI_CODEX_LIVE=1', async () => {
+    await withTempHome(async (home) => {
+      const result = await runCli(
+        ['providers', 'verify', '--model', 'openai-codex:gpt-5.5', '--live'],
+        {
+          gbrainHome: home,
+          env: {
+            GBRAIN_OPENAI_CODEX_LIVE: undefined,
+            OPENAI_CODEX_ACCESS_TOKEN: GATED_CODEX_TOKEN,
+          },
+        },
+      );
+
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('Live Codex verify is disabled');
+      expectNoSecrets(result.stdout + result.stderr, [GATED_CODEX_TOKEN]);
+    });
+  });
+
+  const liveTest = LIVE_READY ? test : test.skip;
+  liveTest('optional live Codex chat smoke via providers test', async () => {
+    await withTempHome(async (home) => {
+      const result = await runCli(
+        ['providers', 'test', '--touchpoint', 'chat', '--model', 'openai-codex:gpt-5.5'],
+        {
+          gbrainHome: home,
+          inheritEnv: true,
+          env: { GBRAIN_OPENAI_CODEX_LIVE: '1' },
+          timeoutMs: 120_000,
+        },
+      );
+
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Probing chat provider...');
+      expect(result.stdout).toContain('All probes green.');
+      expect(result.stdout).toContain('model=openai-codex:gpt-5.5');
+      expectNoSecrets(result.stdout + result.stderr, [
+        process.env.OPENAI_API_KEY,
+        process.env.OPENAI_CODEX_ACCESS_TOKEN,
+        LIVE_SNAPSHOT?.ok ? LIVE_SNAPSHOT.accessToken : undefined,
+        LIVE_SNAPSHOT?.ok ? LIVE_SNAPSHOT.accountId : undefined,
+      ]);
+    });
+  }, 180_000);
+});

--- a/test/e2e/openai-codex-live-smoke.test.ts
+++ b/test/e2e/openai-codex-live-smoke.test.ts
@@ -152,6 +152,29 @@ describe('openai-codex readiness smoke', () => {
     });
   });
 
+  test('providers verify --offline accepts non-public Codex proxy base URL override', async () => {
+    await withTempHome(async (home) => {
+      const result = await runCli(
+        ['providers', 'verify', '--model', 'openai-codex:gpt-5.5', '--offline'],
+        {
+          gbrainHome: home,
+          env: {
+            OPENAI_API_KEY: OFFLINE_PUBLIC_KEY,
+            OPENAI_CODEX_BASE_URL: 'http://codex-proxy.example.test/v1',
+          },
+        },
+      );
+
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('✓ streaming route separation');
+      expect(result.stdout).toContain('non-public Codex Responses /responses route');
+      expect(result.stdout).toContain('Result: READY (offline invariants passed).');
+      expect(result.stderr).toBe('');
+      expectNoSecrets(result.stdout + result.stderr, [OFFLINE_PUBLIC_KEY]);
+    });
+  });
+
   test('providers verify --live is refused unless GBRAIN_OPENAI_CODEX_LIVE=1', async () => {
     await withTempHome(async (home) => {
       const result = await runCli(

--- a/test/fixtures/ai/openai-codex/stream-basic.sse
+++ b/test/fixtures/ai/openai-codex/stream-basic.sse
@@ -1,0 +1,11 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_basic","model":"gpt-5.5","status":"in_progress"}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"O"}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"K"}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_basic","model":"gpt-5.5","status":"completed"}}

--- a/test/fixtures/ai/openai-codex/stream-error.sse
+++ b/test/fixtures/ai/openai-codex/stream-error.sse
@@ -1,0 +1,8 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_error","model":"gpt-5.5","status":"in_progress"}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"partial"}
+
+event: response.failed
+data: {"type":"response.failed","response":{"id":"resp_error","status":"failed","error":{"code":"rate_limit","message":"upstream rejected bearer secret-token-must-redact"}}}

--- a/test/fixtures/ai/openai-codex/stream-usage.sse
+++ b/test/fixtures/ai/openai-codex/stream-usage.sse
@@ -1,0 +1,11 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_usage","model":"gpt-5.5","status":"in_progress"}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"O"}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","delta":"K"}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_usage","model":"gpt-5.5","status":"completed","usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4,"input_tokens_details":{"cached_tokens":2}}}}

--- a/test/fixtures/ai/openai-codex/tool-history.json
+++ b/test/fixtures/ai/openai-codex/tool-history.json
@@ -1,0 +1,28 @@
+[
+  {
+    "role": "user",
+    "content": "find foo"
+  },
+  {
+    "role": "assistant",
+    "content": [
+      {
+        "type": "tool-call",
+        "toolCallId": "call_1",
+        "toolName": "brain_search",
+        "input": { "q": "foo" }
+      }
+    ]
+  },
+  {
+    "role": "tool",
+    "content": [
+      {
+        "type": "tool-result",
+        "toolCallId": "call_1",
+        "toolName": "brain_search",
+        "output": { "results": [{ "slug": "example/foo" }] }
+      }
+    ]
+  }
+]

--- a/test/model-config.serial.test.ts
+++ b/test/model-config.serial.test.ts
@@ -157,6 +157,52 @@ describe('resolveModel — v0.31.12 tier system', () => {
     expect(m).toBe(DEFAULT_ALIASES.opus);
   });
 
+  test('Codex in models.default remains a global reasoning default but is gated out of subagents', async () => {
+    // Commit 5 guardrail: adding openai-codex must not silently change the
+    // resolver hierarchy. A global default still wins for ordinary reasoning
+    // routes, but the subagent tier's capability gate refuses Codex because it
+    // has no tool calling / minion loop support.
+    stub.set('models.default', 'openai-codex:gpt-5.5');
+
+    const reasoning = await resolveModel(stub as never, {
+      tier: 'reasoning',
+      fallback: 'sonnet',
+    });
+    expect(reasoning).toBe('openai-codex:gpt-5.5');
+    expect(stderrCapture).toBe('');
+
+    const subagent = await resolveModel(stub as never, {
+      tier: 'subagent',
+      fallback: 'sonnet',
+    });
+    expect(subagent).toBe(TIER_DEFAULTS.subagent);
+    expect(stderrCapture).toContain('tier.subagent');
+    expect(stderrCapture).toContain('openai-codex:gpt-5.5');
+    expect(stderrCapture).toContain('lacks tool-calling support');
+  });
+
+  test('chat-scoped Codex config does not bleed into subagent tier resolution', async () => {
+    // `models.chat` is the gateway chat/reasoning scoped key. It may resolve to
+    // Codex for text chat, but it must not act like `models.default` or affect
+    // the Anthropic/tool-capable subagent fallback path.
+    stub.set('models.chat', 'openai-codex:gpt-5.5');
+
+    const chatScoped = await resolveModel(stub as never, {
+      configKey: 'models.chat',
+      tier: 'reasoning',
+      fallback: 'sonnet',
+    });
+    expect(chatScoped).toBe('openai-codex:gpt-5.5');
+    expect(stderrCapture).toBe('');
+
+    const subagent = await resolveModel(stub as never, {
+      tier: 'subagent',
+      fallback: 'sonnet',
+    });
+    expect(subagent).toBe(TIER_DEFAULTS.subagent);
+    expect(stderrCapture).toBe('');
+  });
+
   test('models.tier.<tier> beats env + fallback', async () => {
     stub.set('models.tier.reasoning', 'opus');
     process.env.GBRAIN_MODEL = 'haiku';

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -93,4 +93,19 @@ describe('formatRecipeTable', () => {
     expect(lines[3]).toContain('zeroentropyai');
     expect(lines[3]).toContain('✗ missing ZEROENTROPY_API_KEY');
   });
+
+  test('openai-codex row surfaces plan billing without treating OPENAI_API_KEY as ready', () => {
+    const codex = getRecipe('openai-codex');
+    expect(codex).toBeDefined();
+    const out = formatRecipeTable([codex!], { OPENAI_API_KEY: 'sk-public-only' });
+    const line = out.split('\n').find(row => row.startsWith('openai-codex'));
+    expect(line).toBeDefined();
+    expect(line).toContain('✗ Codex auth unavailable');
+    expect(line).toContain('ChatGPT/Codex plan-billed');
+    expect(line).toContain('public OpenAI API key not used');
+    expect(line).toContain('quota/rate limits apply');
+    expect(line).not.toContain('✓ ready');
+    expect(line).not.toContain('sk-public-only');
+    expect(line).not.toContain('$0/1M');
+  });
 });


### PR DESCRIPTION
## Summary

Adds `openai-codex:gpt-5.5` as a distinct chat provider that routes GBrain text-generation calls through Codex/ChatGPT plan auth instead of public OpenAI API-key billing.

Key behavior:

- registers a separate `openai-codex` recipe and model capability metadata
- adds a redacted Codex auth-source seam (`codex-cli`/agent auth file/env token), with no `OPENAI_API_KEY` fallback
- routes `gateway.chat()` through a custom streaming Codex Responses transport (`stream: true`, `store: false`)
- rejects tools/tool-result history before network/budget side effects
- blocks public `api.openai.com` base URLs, including trailing-dot variants
- surfaces honest plan-billed metadata (`public_api_spend_usd: 0`, quota/rate-limit hints)
- adds deterministic offline readiness and opt-in live smoke (`GBRAIN_OPENAI_CODEX_LIVE=1`)
- fixes the verify runner fallback so successful checks are not reported as `rc=143` when no GNU `timeout` is available

## Test plan

- [x] `bun install` in clean worktree
- [x] `bun run verify:openai-codex`
  - `112 pass, 1 skip, 0 fail`
  - serial model-config: `22 pass, 0 fail`
  - live Codex smoke intentionally skipped unless `GBRAIN_OPENAI_CODEX_LIVE=1`
- [x] `bun run verify`
  - `29/29 pass`

## Notes

This branch was rebuilt cleanly on top of current `origin/master` (`f09f9177`) from the already-reviewed local AE feature commits, excluding an unrelated local PGLite doctor checkpoint commit. The final branch head is `6377da8d`.
