### PR TITLE
fix(agent): consume `agent run` flags that appear after the prompt (#1738)

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -74,8 +74,9 @@ SUBMITTING
     --follow                     Tail status until terminal (default on TTY)
     --detach                     Submit + print job id, exit immediately
 
-  Flags after \`run\` up to the first unrecognized token are parsed; the
-  remainder is the prompt. Use \`--\` to explicitly terminate flag parsing.
+  Flags may appear anywhere after \`run\` (before or after the prompt); the
+  non-flag tokens form the prompt. Use \`--\` to terminate flag parsing so
+  the remainder is treated as literal prompt text.
 
 VIEWING
   gbrain agent logs <job_id>
@@ -107,11 +108,24 @@ function parseRunFlags(args: string[]): { flags: RunFlags; rest: string[] } {
     follow: process.stdout.isTTY === true,
     detach: false,
   };
+  const rest: string[] = [];
   let i = 0;
   while (i < args.length) {
     const a = args[i];
-    if (a === '--') { i++; break; }
-    if (!isKnownFlag(a!)) break;
+    if (a === '--') {
+      // Explicit terminator: everything after `--` is literal prompt text,
+      // even if it looks like a flag.
+      rest.push(...args.slice(i + 1));
+      break;
+    }
+    if (!isKnownFlag(a!)) {
+      // Positional token → part of the prompt. Keep scanning so flags that
+      // appear AFTER the prompt (e.g. `agent run "x" --detach`) are still
+      // consumed instead of leaking into the prompt string (#1738).
+      rest.push(a!);
+      i++;
+      continue;
+    }
     switch (a) {
       case '--subagent-def': flags.subagentDef = args[++i]; i++; break;
       case '--model':        flags.model = args[++i]; i++; break;
@@ -126,7 +140,7 @@ function parseRunFlags(args: string[]): { flags: RunFlags; rest: string[] } {
         throw new Error(`unknown flag: ${a}. Run \`gbrain agent run --help\` for usage.`);
     }
   }
-  return { flags, rest: args.slice(i) };
+  return { flags, rest };
 }
 
 export async function runAgentRun(engine: BrainEngine, args: string[]): Promise<void> {

--- a/test/agent-cli.test.ts
+++ b/test/agent-cli.test.ts
@@ -85,6 +85,35 @@ describe('parseRunFlags', () => {
     const { flags } = agentTesting.parseRunFlags(['--fanout-manifest', '/tmp/m.json']);
     expect(flags.fanoutManifest).toBe('/tmp/m.json');
   });
+
+  // Regression for #1738: flags after the prompt were being swallowed into
+  // the prompt (`agent run "x" --detach` → prompt "x --detach", detach ignored).
+  test('a flag after the prompt is consumed, not leaked into the prompt', () => {
+    const { flags, rest } = agentTesting.parseRunFlags(['test prompt', '--detach']);
+    expect(rest).toEqual(['test prompt']);
+    expect(flags.detach).toBe(true);
+    expect(flags.follow).toBe(false);
+  });
+
+  test('value-flags after the prompt consume their value', () => {
+    const { flags, rest } = agentTesting.parseRunFlags(['do the thing', '--model', 'm', '--max-turns', '5']);
+    expect(rest).toEqual(['do the thing']);
+    expect(flags.model).toBe('m');
+    expect(flags.maxTurns).toBe(5);
+  });
+
+  test('flags on both sides of the prompt are all consumed', () => {
+    const { flags, rest } = agentTesting.parseRunFlags(['--model', 'm', 'summarize', 'this', '--detach']);
+    expect(flags.model).toBe('m');
+    expect(flags.detach).toBe(true);
+    expect(rest).toEqual(['summarize', 'this']);
+  });
+
+  test('`--` after a positional keeps flag-shaped tokens as literal prompt', () => {
+    const { flags, rest } = agentTesting.parseRunFlags(['explain', '--', '--detach', '--model']);
+    expect(flags.detach).toBe(false);
+    expect(rest).toEqual(['explain', '--detach', '--model']);
+  });
 });
 
 describe('parseSince', () => {


### PR DESCRIPTION
## Problem

Fixes #1738.

`gbrain agent run` is documented as the canonical subagent entrypoint, but `parseRunFlags` (`src/commands/agent.ts`) stopped scanning at the first non-flag token and returned `args.slice(i)` as the prompt. Any flag placed **after** the prompt leaked into the prompt string instead of being parsed:

```
$ gbrain agent run "test prompt" --detach
$ gbrain jobs get <id>
  Data: {"prompt":"test prompt --detach"}   # --detach swallowed into the prompt, never applied
```

This silently corrupts the agent's instruction and makes `--detach` / `--follow` behave unreliably depending on argument order.

## Fix

`parseRunFlags` now collects non-flag tokens into the prompt and **keeps scanning**, so known flags are consumed wherever they appear in argv (before, after, or interleaved with the prompt). Behaviour preserved:

- `--` still terminates flag parsing — a prompt that legitimately contains flag-shaped words can be passed literally: `gbrain agent run -- explain the --verbose option`.
- Unknown flags still throw; value-flags still consume their value; prompt token order is preserved.

Help text updated to match the new (and now accurate) contract.

## Tests (`test/agent-cli.test.ts`)

Added to the existing `parseRunFlags` block:
- a flag after the prompt is consumed, not leaked (the issue's exact repro)
- value-flags after the prompt consume their value (`--model m`, `--max-turns 5`)
- flags on both sides of the prompt are all consumed
- `--` after a positional keeps flag-shaped tokens as literal prompt

All 8 pre-existing `parseRunFlags` cases still pass.

```
bun test test/agent-cli.test.ts                # 31 pass / 0 fail
bun test test/agent-runner.test.ts test/submit-agent.test.ts   # green
bun node_modules/typescript/bin/tsc --noEmit   # 0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)