### PR TITLE
fix(embed): label content_chunks.model with the model that produced the vector (#1717)

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -303,6 +303,22 @@ export async function runEmbed(engine: BrainEngine, args: string[]): Promise<Emb
   }
 }
 
+/**
+ * Resolve the embedding model label (`provider:model`) to stamp onto
+ * `content_chunks.model`, so each chunk records the model that actually
+ * produced its vector instead of the gateway default (#1717). Returns
+ * undefined if the gateway is unconfigured; callers then fall back to the
+ * chunk's existing model rather than mislabeling it.
+ */
+async function resolveEmbeddingModelLabel(): Promise<string | undefined> {
+  try {
+    const { getEmbeddingModel } = await import('../core/ai/gateway.ts');
+    return getEmbeddingModel();
+  } catch {
+    return undefined;
+  }
+}
+
 async function embedPage(
   engine: BrainEngine,
   slug: string,
@@ -369,11 +385,16 @@ async function embedPage(
   for (let j = 0; j < toEmbed.length; j++) {
     embeddingMap.set(toEmbed[j].chunk_index, embeddings[j]);
   }
+  // #1717: label each (re)embedded chunk with the model that actually
+  // produced its vector. Preserved chunks (not re-embedded this pass) keep
+  // their existing model so a mixed-model page isn't relabeled wholesale.
+  const embedModelLabel = await resolveEmbeddingModelLabel();
   const updated: ChunkInput[] = chunks.map(c => ({
     chunk_index: c.chunk_index,
     chunk_text: c.chunk_text,
     chunk_source: c.chunk_source,
     embedding: embeddingMap.get(c.chunk_index),
+    model: embeddingMap.has(c.chunk_index) && embedModelLabel ? embedModelLabel : c.model,
     token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
   }));
 
@@ -487,12 +508,16 @@ async function embedAll(
       for (let j = 0; j < toEmbed.length; j++) {
         embeddingMap.set(toEmbed[j].chunk_index, embeddings[j]);
       }
+      // #1717: stamp the resolved embedding model on (re)embedded chunks;
+      // preserve the existing model on chunks left untouched.
+      const embedModelLabel = await resolveEmbeddingModelLabel();
       // Preserve ALL chunks, only update embeddings for stale ones
       const updated: ChunkInput[] = chunks.map(c => ({
         chunk_index: c.chunk_index,
         chunk_text: c.chunk_text,
         chunk_source: c.chunk_source,
         embedding: embeddingMap.get(c.chunk_index) ?? undefined,
+        model: embeddingMap.has(c.chunk_index) && embedModelLabel ? embedModelLabel : c.model,
         token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
       }));
       await engine.upsertChunks(page.slug, updated, pageOpts);
@@ -698,11 +723,15 @@ async function embedAllStale(
           for (let j = 0; j < stale.length; j++) {
             staleIdxToEmbedding.set(stale[j].chunk_index, embeddings[j]);
           }
+          // #1717: label the re-embedded (stale) chunks with the resolved
+          // model; preserve the existing model on the non-stale chunks.
+          const embedModelLabel = await resolveEmbeddingModelLabel();
           const merged: ChunkInput[] = existing.map(c => ({
             chunk_index: c.chunk_index,
             chunk_text: c.chunk_text,
             chunk_source: c.chunk_source,
             embedding: staleIdxToEmbedding.get(c.chunk_index) ?? undefined,
+            model: staleIdxToEmbedding.has(c.chunk_index) && embedModelLabel ? embedModelLabel : c.model,
             token_count: c.token_count || Math.ceil(c.chunk_text.length / 4),
           }));
           await engine.upsertChunks(slug, merged, { sourceId: keySourceId });

--- a/test/embed.serial.test.ts
+++ b/test/embed.serial.test.ts
@@ -759,3 +759,43 @@ describe('embedAllStale --source threading (D7)', () => {
     expect((firstCallOpts as { sourceId?: string }).sourceId).toBe('media-corpus');
   });
 });
+
+// #1717: content_chunks.model must record the model that actually produced
+// each vector, not the gateway default. Kept last in the file so the
+// configureGateway() call here doesn't leak into the other tests' state.
+describe('content_chunks.model labeling (#1717)', () => {
+  test('stamps the resolved embedding model on re-embedded chunks, preserves it on untouched chunks', async () => {
+    const { runEmbedCore } = await import('../src/commands/embed.ts');
+    const { configureGateway } = await import('../src/core/ai/gateway.ts');
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-large',
+      embedding_dimensions: 1536,
+      env: { OPENAI_API_KEY: 'sk-test' },
+    });
+
+    let upserted: any[] | undefined;
+    // Chunk 0 is stale (no embedding) → gets re-embedded this pass.
+    // Chunk 1 is already embedded with a DIFFERENT model → must be preserved,
+    // not relabeled to the current model.
+    const chunks = [
+      { chunk_index: 0, chunk_text: 'a', chunk_source: 'compiled_truth', embedded_at: null, model: 'zeroentropyai:zembed-1', token_count: 1 },
+      { chunk_index: 1, chunk_text: 'b', chunk_source: 'compiled_truth', embedded_at: '2026-01-01', model: 'voyage:voyage-3', token_count: 1 },
+    ];
+    const engine = mockEngine({
+      getPage: async () => ({ slug: 'notes/x', compiled_truth: 'a', timeline: '', source_id: 'default' }),
+      getChunks: async () => chunks,
+      upsertChunks: async (_slug: string, c: any[]) => { upserted = c; },
+      setPageEmbeddingSignature: async () => null,
+    });
+
+    await runEmbedCore(engine, { slugs: ['notes/x'] });
+
+    expect(upserted).toBeDefined();
+    const byIdx = Object.fromEntries(upserted!.map(c => [c.chunk_index, c]));
+    // Re-embedded chunk carries the model that produced its vector (was
+    // mislabeled with DEFAULT_EMBEDDING_MODEL before the fix).
+    expect(byIdx[0].model).toBe('openai:text-embedding-3-large');
+    // Untouched chunk keeps its original model — no wholesale relabel.
+    expect(byIdx[1].model).toBe('voyage:voyage-3');
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #1717.

`gbrain embed --all` / `gbrain embed <slug>` / `gbrain import` built the `ChunkInput[]` for `upsertChunks` **without a `model` field**. `upsertChunks` writes `chunk.model || DEFAULT_EMBEDDING_MODEL`, and its `ON CONFLICT` clause does `model = COALESCE(EXCLUDED.model, content_chunks.model)` where `EXCLUDED.model` is always non-null — so every embedded chunk's `model` column was stamped with the **gateway default** (e.g. `zeroentropyai:zembed-1`) regardless of the model that actually produced the vector.

The vectors themselves are correct (they go through `getEmbeddingModel()`); only the stored `model` label is wrong. This misleads `gbrain doctor`, mixed-model detection, and anyone reading the `model` column to learn which embedding space a chunk lives in (it can read `zeroentropyai:zembed-1` while the vector is actually OpenAI `text-embedding-3-large`).

## Fix

Thread the resolved embedding model (`getEmbeddingModel()` — the same value the batch was embedded with) into the `model` field at all three write sites: `embedPage`, `embedAll` → `embedOnePage`, and `embedAllStale`.

Labeling is **per-chunk**, which the `COALESCE` semantics require for correctness:
- chunks **(re)embedded this pass** → the resolved model;
- chunks **left untouched** (preserved in the same upsert) → keep their existing `model`, so a partially-stale / mixed-model page isn't relabeled wholesale.

Falls back to the chunk's existing model if the gateway is unconfigured (never mislabels).

## Test (`test/embed.serial.test.ts`)

A page with one stale chunk + one already-embedded chunk (with a *different* model):
- the re-embedded chunk is labeled with the configured model (was `DEFAULT_EMBEDDING_MODEL` before the fix);
- the untouched chunk keeps its original model (no wholesale relabel).

```
bun test test/embed.serial.test.ts          # 27 pass / 0 fail
bun test test/embed-stale.serial.test.ts test/operations-embedding-column.test.ts \
         test/embedding-signature-stale.test.ts test/embed-multimodal-batching.test.ts   # 32 pass
bun node_modules/typescript/bin/tsc --noEmit  # 0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)