### PR TITLE
fix(content-sanity): guard against non-string page titles

### DIFF
--- a/src/core/content-sanity.ts
+++ b/src/core/content-sanity.ts
@@ -376,14 +376,20 @@ export function assessContentSanity(opts: {
   // doesn't repeat the lowercase per literal.
   const bodyHead = body.slice(0, SCAN_HEAD_BYTES);
   const bodyHeadLower = bodyHead.toLowerCase();
-  const titleLower = opts.title.toLowerCase();
+  // Defend against non-string titles. YAML coerces an all-digit / leading-"+"
+  // title (e.g. a contact named by a bare phone number, slug "33384818832")
+  // to a number, so `opts.title` can be a number at runtime despite the
+  // declared `string` type. Calling `.toLowerCase()` on it throws and aborts
+  // the entire sync run. Normalize once and reuse.
+  const title = typeof opts.title === 'string' ? opts.title : String(opts.title ?? '');
+  const titleLower = title.toLowerCase();
 
   const junk_pattern_matches: string[] = [];
   for (const p of BUILT_IN_JUNK_PATTERNS) {
     const scope = p.applies_to ?? 'both';
     let matched = false;
     if (scope === 'title' || scope === 'both') {
-      if (p.pattern.test(opts.title)) matched = true;
+      if (p.pattern.test(title)) matched = true;
     }
     if (!matched && (scope === 'body' || scope === 'both')) {
       if (p.pattern.test(bodyHead)) matched = true;

--- a/test/content-sanity.test.ts
+++ b/test/content-sanity.test.ts
@@ -640,3 +640,31 @@ describe('assessContentSanity — confidence split (Q1=A)', () => {
     expect(r.shouldFlag).toBe(false);
   });
 });
+
+// ─── NON-STRING TITLE (regression) ────────────────────────────
+// YAML coerces an all-digit / leading-"+" title (e.g. a contact named by a
+// bare phone number, slug "33384818832") to a number, so `title` can arrive
+// as a number at runtime despite the declared `string` type. The assessor
+// must not call `.toLowerCase()` / `.test()` on a non-string, or the whole
+// sync run aborts with "opts.title.toLowerCase is not a function".
+describe('assessContentSanity — non-string title (regression)', () => {
+  test('numeric title does not crash', () => {
+    expect(() =>
+      assessContentSanity({
+        compiled_truth: 'x',
+        timeline: '',
+        title: 33384818832 as unknown as string,
+      }),
+    ).not.toThrow();
+  });
+
+  test('null / undefined title does not crash', () => {
+    expect(() =>
+      assessContentSanity({
+        compiled_truth: 'x',
+        timeline: '',
+        title: undefined as unknown as string,
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

`assessContentSanity` (`src/core/content-sanity.ts`) is typed to take a string `title`, but at runtime YAML hands it a **number** for numeric-named pages. The clearest trigger: a contact named by a bare phone number, whose page slug is all digits (e.g. `33384818832`). `opts.title.toLowerCase()` then throws:

```
opts.title.toLowerCase is not a function
```

Because the sanity check runs in the import path, that exception aborts the whole `gbrain sync` run, and the offending page never imports — it shows up as a recurring, un-clearable failure in `gbrain doctor` (`--retry-failed` just re-throws).

## Fix

Coerce `title` to a string once at the top of the function and reuse it for both the lowercase scan and the junk-pattern `.test()`:

```ts
const title = typeof opts.title === 'string' ? opts.title : String(opts.title ?? '');
```

One defensive line at the consumer covers every caller (import, lint, doctor, quarantine, sources) without touching the public type.

## Test

Adds a regression block to `test/content-sanity.test.ts` asserting that numeric and null/undefined titles don't throw. `bun test test/content-sanity.test.ts`: 79 pass, 0 fail.

Found on a live brain after upgrading to 0.42.x (the content-quality gate landed in 0.42.8.0).
