### PR TITLE
fix(minions): route lock claim/renewLock through direct session pool

### DIFF
--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1912,6 +1912,24 @@ export interface BrainEngine {
     opts?: { signal?: AbortSignal },
   ): Promise<T[]>;
 
+  /**
+   * Like `executeRaw`, but routes through the DIRECT (session-mode) pool when
+   * dual-pool is active (Supabase: port 5432), falling back to the read pool
+   * otherwise. Use this for the Minion lock hot-path (`claim`/`renewLock`):
+   * those statements heartbeat a lock over many seconds, and the
+   * transaction-mode pooler (port 6543) recycles connections per-transaction,
+   * which surfaces as `CONNECTION_ENDED` mid-heartbeat → orphaned locks →
+   * silent worker wedge. The direct session pool holds the connection open for
+   * the life of the worker, so heartbeats survive. Single-statement UPDATEs
+   * only — same idempotency contract as `executeRaw`. On PGLite (no pooler)
+   * this is identical to `executeRaw`.
+   */
+  executeRawDirect<T = Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+    opts?: { signal?: AbortSignal },
+  ): Promise<T[]>;
+
   // ============================================================
   // v0.20.0 Cathedral II: code edges (Layer 5 populates, Layer 7 consumes)
   // ============================================================

--- a/src/core/minions/queue.ts
+++ b/src/core/minions/queue.ts
@@ -559,7 +559,10 @@ export class MinionQueue {
   async claim(lockToken: string, lockDurationMs: number, queue: string, registeredNames: string[]): Promise<MinionJob | null> {
     if (registeredNames.length === 0) return null;
 
-    const rows = await this.engine.executeRaw<Record<string, unknown>>(
+    // Direct (session-mode) pool: claim opens the lock that renewLock then
+    // heartbeats. Both must live on a connection the transaction-mode pooler
+    // won't recycle mid-hold, or the lock orphans and the worker wedges.
+    const rows = await this.engine.executeRawDirect<Record<string, unknown>>(
       `UPDATE minion_jobs SET
         status = 'active',
         lock_token = $1,
@@ -1031,7 +1034,10 @@ export class MinionQueue {
 
   /** Renew lock (token-fenced). Returns false if token mismatch (job was reclaimed). */
   async renewLock(id: number, lockToken: string, lockDurationMs: number): Promise<boolean> {
-    const rows = await this.engine.executeRaw<Record<string, unknown>>(
+    // Direct (session-mode) pool — see claim(). The heartbeat that keeps a job
+    // alive for minutes cannot run on the transaction pooler without periodic
+    // CONNECTION_ENDED drops that look like lock-expiry and orphan the job.
+    const rows = await this.engine.executeRawDirect<Record<string, unknown>>(
       `UPDATE minion_jobs SET lock_until = now() + ($1::double precision * interval '1 millisecond'), updated_at = now()
        WHERE id = $2 AND lock_token = $3 AND status = 'active'
        RETURNING id`,

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4753,6 +4753,20 @@ export class PGLiteEngine implements BrainEngine {
     return Promise.race([queryPromise, abortPromise]);
   }
 
+  /**
+   * PGLite is in-process WASM with no connection pooler, so the direct-pool
+   * routing that `executeRawDirect` provides on Postgres is a no-op here:
+   * delegate straight to `executeRaw`. Present so the BrainEngine contract is
+   * satisfied and the Minion lock hot-path works identically on both engines.
+   */
+  async executeRawDirect<T = Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+    opts?: { signal?: AbortSignal },
+  ): Promise<T[]> {
+    return this.executeRaw<T>(sql, params, opts);
+  }
+
   // ============================================================
   // v0.20.0 Cathedral II: code edges (Layer 1 stubs — filled by Layer 5)
   // ============================================================

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4837,6 +4837,48 @@ export class PostgresEngine implements BrainEngine {
     // swap in a fresh pool. See db.ts setSessionDefaults / supervisor.ts.
   }
 
+  /**
+   * Minion lock hot-path variant of executeRaw. Routes to the DIRECT
+   * session-mode pool (port 5432) when dual-pool is active so lock
+   * heartbeats survive the transaction-pooler's per-transaction connection
+   * recycling. See BrainEngine.executeRawDirect for the full rationale.
+   *
+   * When this engine is a transaction-scoped clone (txEngine from
+   * transaction()), `connectionManager` is inherited but `this.sql` is the tx
+   * connection; we intentionally honor the tx connection in that case by
+   * falling through to this.sql, because routing a statement inside an open
+   * transaction onto a different pool would break atomicity. The lock
+   * hot-path (claim/renewLock) does NOT run inside transaction(), so in
+   * practice this always reaches the direct pool there.
+   */
+  async executeRawDirect<T = Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+    opts?: { signal?: AbortSignal },
+  ): Promise<T[]> {
+    // Inside an open transaction, _sql is the reserved tx connection (set via
+    // defineProperty in transaction()); never reroute off it.
+    const inTransaction = this._sql !== null && this.connectionManager?.peekReadPool() !== this._sql;
+    const conn = (!inTransaction && this.connectionManager?.isDualPoolActive())
+      ? await this.connectionManager.ddl()
+      : this.sql;
+    const pending = conn.unsafe(sql, params as Parameters<typeof conn.unsafe>[1]);
+    if (opts?.signal) {
+      if (opts.signal.aborted) {
+        try { (pending as unknown as { cancel?: () => void }).cancel?.(); } catch { /* best-effort */ }
+        throw new DOMException('aborted', 'AbortError');
+      }
+      const onAbort = () => {
+        try { (pending as unknown as { cancel?: () => void }).cancel?.(); } catch { /* best-effort */ }
+      };
+      opts.signal.addEventListener('abort', onAbort, { once: true });
+      return (pending as unknown as Promise<T[]>).finally(() => {
+        opts.signal?.removeEventListener('abort', onAbort);
+      });
+    }
+    return pending as unknown as T[];
+  }
+
   // ============================================================
   // v0.20.0 Cathedral II: code edges (Layer 1 stubs — filled by Layer 5)
   // ============================================================

--- a/test/queue-lock-retry.test.ts
+++ b/test/queue-lock-retry.test.ts
@@ -58,7 +58,11 @@ describe('MinionQueue lock-path recovery (issue #1678)', () => {
       let calls = 0;
       const engine = {
         kind: 'postgres',
-        executeRaw: async () => { calls++; throw connEndedError(); },
+        // claim() routes through executeRawDirect (direct session pool) as of
+        // the lock-hot-path fix; executeRaw is kept as a throwing guard to
+        // prove claim never falls back to it.
+        executeRawDirect: async () => { calls++; throw connEndedError(); },
+        executeRaw: async () => { throw new Error('claim must not use executeRaw'); },
         reconnect: async () => {},
       } as unknown as ConstructorParameters<typeof MinionQueue>[0];
 


### PR DESCRIPTION
## The wedge, root-caused

The Minion lock hot-path — `claim()` and `renewLock()` in `queue.ts` — ran every UPDATE through `engine.executeRaw()`, which is hardcoded to the read pool (`this.sql`). On Supabase that's the **transaction-mode pooler (port 6543)**, which recycles connections per-transaction.

A lock heartbeat is held open for minutes. So the pooler periodically reaps its socket mid-flight → bun's postgres client throws `CONNECTION_ENDED` → the lock looks expired → the worker force-evicts the job → the claim loop wedges (process alive, no errors, claiming nothing). This showed up as repeated silent worker wedges, especially under `enrich` fan-out load.

## The fix was already half-built

gbrain already ships a **dual-pool** design: `ConnectionManager.ddl()/bulk()` route to the direct **session-mode** pool (port 5432, `GBRAIN_DIRECT_DATABASE_URL`), which holds a connection for the worker's lifetime. The lock path just never used it.

Verified empirically: a single connection heartbeating every 2s survived **4/4 beats over 8s on 5432**, vs. `CONNECTION_ENDED` storms on 6543.

## What this PR does

- Adds `BrainEngine.executeRawDirect()` — same contract as `executeRaw`, but routes to the direct pool when dual-pool is active. No-op delegation on PGLite / non-Supabase / kill-switch (`GBRAIN_DISABLE_DIRECT_POOL`).
- Points `claim()` and `renewLock()` at it.
- Single-statement UPDATEs only — same idempotency guarantees, so the **Codex #1 double-claim guard** and the **renewLock no-inline-retry** contract are preserved.
- Transaction-scoped engine clones keep using their tx connection (never reroute a statement off an open transaction — that would break atomicity). The lock hot-path doesn't run inside `transaction()`, so it always reaches the direct pool there.

## Testing

- `test/minions.test.ts` — **169/169 pass** (claim/renewLock via real `PGLiteEngine` delegation path)
- `test/queue-lock-retry.test.ts` — pass; mock updated to `executeRawDirect`, plus a new guard that `claim` never falls back to `executeRaw`
- `tsc --noEmit` — clean
- Guards green: `check-worker-pool-atomicity`, `check-worker-lock-renewal-shape`, `check-no-double-retry`, `check-no-legacy-getconnection`

## Note

No new infra needed — `GBRAIN_DIRECT_DATABASE_URL` is already configured in our env. This just makes the lock path use the pool that was built for exactly this workload.
