### PR TITLE
feat(put_page): rich-page overwrite guard for agent callers (force=true override)

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -69,6 +69,7 @@ export type ErrorCode =
   | 'rate_limited'      // v0.31: gateway rate-limit upstream
   | 'extraction_failed' // v0.31: facts extractor failed (refusal, parse, abort)
   | 'fact_not_found'    // v0.31: forget_fact / recall on unknown id
+  | 'rich_page_overwrite_blocked' // put_page guard: agent overwrite of a substantial page without force=true
   // eslint-disable-next-line @typescript-eslint/ban-types
   | (string & {});      // OPEN union for forward-compat (eE7 / D13)
 
@@ -607,6 +608,14 @@ const get_page: Operation = {
   cliHints: { name: 'get', positional: ['slug'] },
 };
 
+/**
+ * Threshold (chars of compiled_truth) at/above which a page counts as "rich"
+ * for the put_page overwrite guard. Agent/remote callers are blocked from
+ * overwriting a page with >= this many chars unless they pass force=true.
+ * Exported so the regression test can assert the exact boundary.
+ */
+export const RICH_PAGE_MIN_CHARS = 100;
+
 const put_page: Operation = {
   name: 'put_page',
   description: 'Write/update a page (markdown with frontmatter). Chunks, embeds, reconciles tags, and (when auto_link/auto_timeline are enabled) extracts + reconciles graph links and timeline entries. For large content on Windows (pipe-buffer limit ~45KB) or any file-as-input workflow, use `gbrain capture --file PATH --slug SLUG` — capture reads the file as a Buffer with a binary-NUL guard and adds provenance write-through (v0.39.3.0).',
@@ -622,6 +631,7 @@ const put_page: Operation = {
     source_kind: { type: 'string', required: false, description: 'Ingestion channel taxonomy (capture-cli | put_page | webhook | …). Remote callers: SERVER-STAMPED, client value ignored.' },
     source_uri: { type: 'string', required: false, description: 'Original URI/path/message-id the event carried. Remote callers: SERVER-STAMPED null.' },
     ingested_via: { type: 'string', required: false, description: 'Richer label paired with source_kind. Remote callers: SERVER-STAMPED.' },
+    force: { type: 'boolean', required: false, description: 'Override the rich-page overwrite guard. Agent/remote callers are blocked from overwriting a page that already has substantial content (>= ~100 chars) unless force=true. Trusted local CLI callers are never constrained. Default false.' },
   },
   mutating: true,
   scope: 'write',
@@ -686,6 +696,32 @@ const put_page: Operation = {
         if (!slug.startsWith(prefix) || slug.length === prefix.length) {
           throw new OperationError('permission_denied', `put_page via subagent must write under '${prefix}...'`);
         }
+      }
+    }
+
+    // Rich-page overwrite guard (agent-facing callers only). Runs BEFORE the
+    // dry-run short-circuit so a preview surfaces the same rejection.
+    //
+    // Why: a "helpful upsert" instinct leads agents to overwrite a page that
+    // already holds substantial content with their own "improved" version,
+    // discarding prior work. Prompt-level guidance ("read the page first, don't
+    // overwrite a rich page") does not reliably hold; enforcing at the tool
+    // boundary makes overwrite an explicit, opt-in act (force=true) rather than
+    // an accident. The thrown error names add_timeline_entry / add_link / force
+    // so a blocked agent has a clear path forward.
+    //
+    // FAIL-CLOSED: trusted local CLI callers set ctx.remote === false and are
+    // exempt; anything else (stdio MCP, HTTP MCP, subagent) is treated as
+    // remote (matches the CV6 / v0.26.9 F7b trust posture used elsewhere here).
+    if (ctx.remote !== false && p.force !== true) {
+      const existing = await ctx.engine.getPage(slug, ctx.sourceId ? { sourceId: ctx.sourceId } : undefined);
+      if (existing && existing.compiled_truth && existing.compiled_truth.length >= RICH_PAGE_MIN_CHARS) {
+        throw new OperationError(
+          'rich_page_overwrite_blocked',
+          `Page '${slug}' already has ${existing.compiled_truth.length} chars of content. Overwriting it via put_page would discard that content.`,
+          'Use add_timeline_entry for new dated facts, add_link for new relationships, or pass force=true to deliberately overwrite.',
+          'skills/signal-detector/SKILL.md',
+        );
       }
     }
 

--- a/test/operations-put-page-overwrite-guard.test.ts
+++ b/test/operations-put-page-overwrite-guard.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression guard for the put_page rich-page overwrite guard.
+ *
+ * Contract: agent / remote callers (ctx.remote !== false) cannot overwrite a
+ * page whose existing compiled_truth is >= RICH_PAGE_MIN_CHARS via put_page,
+ * unless they pass force=true. Trusted local CLI callers (ctx.remote === false)
+ * are never constrained and the guard does not even read the existing page.
+ *
+ * The guard runs BEFORE the dry-run short-circuit, so:
+ *   - blocked cases reject regardless of dryRun (a preview surfaces the block),
+ *   - allowed cases fall through to the dry-run early-return, which lets these
+ *     tests stay hermetic (no real importFromContent / engine write needed).
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { operations, RICH_PAGE_MIN_CHARS, type OperationContext } from '../src/core/operations.ts';
+import type { Page } from '../src/core/types.ts';
+
+const STUB_LOGGER = { info: () => {}, warn: () => {}, error: () => {} };
+const STUB_CONFIG = {} as unknown as Parameters<typeof operations[number]['handler']>[0]['config'];
+
+type EngineArg = Parameters<typeof operations[number]['handler']>[0]['engine'];
+
+function findOp(name: string) {
+  const op = operations.find(o => o.name === name);
+  if (!op) throw new Error(`operation ${name} not found`);
+  return op;
+}
+
+// Engine stub whose getPage returns a fixed page (or null). Every OTHER method
+// throws — proving the guard short-circuits before any write and that the
+// allowed paths reach the dry-run early-return, not a real engine write.
+function stubEngineReturning(page: Page | null): EngineArg {
+  return new Proxy({} as never, {
+    get(_t, prop: string) {
+      if (prop === 'getPage') return async () => page;
+      return () => { throw new Error(`engine.${prop} should not have been called — guard/dry-run gate failed`); };
+    },
+  }) as EngineArg;
+}
+
+// Engine stub where EVERY method throws — used for the local-caller case to
+// prove the guard is skipped entirely (getPage is never even called).
+function stubEngineNeverCalled(): EngineArg {
+  return new Proxy({} as never, {
+    get(_t, prop: string) {
+      return () => { throw new Error(`engine.${prop} should not have been called — local caller must bypass the guard`); };
+    },
+  }) as EngineArg;
+}
+
+function makePage(compiledTruthLen: number): Page {
+  // Only compiled_truth is read by the guard; cast past the full Page shape.
+  return { slug: 'people/alice', compiled_truth: 'x'.repeat(compiledTruthLen) } as unknown as Page;
+}
+
+function makeCtx(overrides: Partial<OperationContext> = {}): OperationContext {
+  return {
+    engine: stubEngineReturning(null),
+    config: STUB_CONFIG,
+    logger: STUB_LOGGER,
+    dryRun: true,        // allowed cases short-circuit at the dry-run return
+    remote: true,        // agent / remote caller by default
+    viaSubagent: false,  // not a subagent → skip namespace check, reach the guard
+    ...overrides,
+  } as OperationContext;
+}
+
+const put_page = findOp('put_page');
+const CONTENT = '---\ntitle: x\n---\nnew body';
+
+describe('put_page — rich-page overwrite guard', () => {
+  test('BLOCKS remote overwrite of a page at exactly the threshold (>= is inclusive), no force', async () => {
+    const ctx = makeCtx({ dryRun: false, engine: stubEngineReturning(makePage(RICH_PAGE_MIN_CHARS)) });
+    await expect(put_page.handler(ctx, { slug: 'people/alice', content: CONTENT }))
+      .rejects.toMatchObject({ code: 'rich_page_overwrite_blocked' });
+  });
+
+  test('BLOCKS even on a dry-run preview (guard precedes the dry-run short-circuit)', async () => {
+    const ctx = makeCtx({ dryRun: true, engine: stubEngineReturning(makePage(500)) });
+    await expect(put_page.handler(ctx, { slug: 'people/alice', content: CONTENT }))
+      .rejects.toMatchObject({ code: 'rich_page_overwrite_blocked' });
+  });
+
+  test('ALLOWS when the existing page is thin (< threshold)', async () => {
+    const ctx = makeCtx({ engine: stubEngineReturning(makePage(RICH_PAGE_MIN_CHARS - 1)) });
+    const res = await put_page.handler(ctx, { slug: 'people/alice', content: CONTENT });
+    expect(res).toMatchObject({ dry_run: true, action: 'put_page' });
+  });
+
+  test('ALLOWS when no page exists yet (getPage -> null)', async () => {
+    const ctx = makeCtx({ engine: stubEngineReturning(null) });
+    const res = await put_page.handler(ctx, { slug: 'people/alice', content: CONTENT });
+    expect(res).toMatchObject({ dry_run: true });
+  });
+
+  test('ALLOWS a rich-page overwrite when force=true', async () => {
+    const ctx = makeCtx({ engine: stubEngineReturning(makePage(500)) });
+    const res = await put_page.handler(ctx, { slug: 'people/alice', content: CONTENT, force: true });
+    expect(res).toMatchObject({ dry_run: true });
+  });
+
+  test('ALLOWS trusted local CLI callers (remote=false) and never reads the page', async () => {
+    const ctx = makeCtx({ remote: false, engine: stubEngineNeverCalled() });
+    const res = await put_page.handler(ctx, { slug: 'people/alice', content: CONTENT });
+    expect(res).toMatchObject({ dry_run: true });
+  });
+});


### PR DESCRIPTION
## What

Adds a tool-boundary guard to `put_page`: remote/agent callers can't overwrite a page whose existing `compiled_truth` is substantial (>= 100 chars) unless they pass `force: true`. Trusted local CLI callers (`ctx.remote === false`) are unaffected and the guard does not even read the existing page for them.

## Why

Agents follow a "helpful upsert" instinct: they read a page, decide they can improve it, and call `put_page` with a rewritten version, silently discarding the prior content. Prompt-level guidance ("read the page first; don't overwrite a rich page") does not reliably hold across models. Enforcing at the tool boundary turns an accidental clobber into an explicit, opt-in act.

The thrown error (`rich_page_overwrite_blocked`) names the alternatives so a blocked agent has a clear path forward:

> Use add_timeline_entry for new dated facts, add_link for new relationships, or pass force=true to deliberately overwrite.

## Details

- New `force` boolean param on `put_page` — propagates to the MCP tool schema automatically via the contract-first op definitions.
- New `ErrorCode` member `rich_page_overwrite_blocked`.
- New exported `RICH_PAGE_MIN_CHARS = 100` threshold.
- Guard runs **before** the dry-run short-circuit, so a dry-run preview surfaces the same block (matches the existing subagent-namespace check precedent).
- **Fail-closed:** anything not strictly `ctx.remote === false` is treated as remote (matches the CV6 / v0.26.9 F7b trust posture already used in this handler for provenance stamping).
- Multi-source aware: reads the existing page with `ctx.sourceId`.

## Tests

- New hermetic regression suite `test/operations-put-page-overwrite-guard.test.ts` (6 cases): blocks at the threshold boundary, blocks on dry-run preview, allows thin pages, allows when no page exists, allows with `force=true`, and allows local callers without even reading the page.
- `bun run typecheck` clean.
- parity / mcp-tool-defs / public-exports / operations-* suites green (157 tests).

## Notes

- VERSION / CHANGELOG intentionally left untouched for the maintainer's release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
