### PR TITLE
feat(gateway): Amazon Bedrock provider — embedding, reranker, chat

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "gbrain",
       "dependencies": {
+        "@ai-sdk/amazon-bedrock": "^4.0.112",
         "@ai-sdk/anthropic": "^3.0.71",
         "@ai-sdk/google": "^3.0.64",
         "@ai-sdk/openai": "^3.0.53",
@@ -51,6 +52,8 @@
     "@electric-sql/pglite",
   ],
   "packages": {
+    "@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@4.0.112", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.81", "@ai-sdk/openai": "3.0.67", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@smithy/eventstream-codec": "^4.0.1", "@smithy/util-utf8": "^4.0.0", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-PsSh7a6qW+3kQXPs1kD4wDwuZby0t1PIaB6j/1aMKmPFJ5LxcIcULLMF/bjITLt5o/8lc0t6TXIwG0zlhH7uZw=="],
+
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.74", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Xew9rfz9WWhDSyF8rNhjT/XWOWelNfJrMlmG0Ahw210hStisRpQZ1s+7VeI9JTJOZ5y5tXqBi5kfPwYnCfyRTA=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.109", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-r6dOqThjODp1vOhGRJg2OCmyB/ZOQtGx1esZ2SDvwDX5XoX8dBqYaYjLg8MPXTzMGJSgOkJyCxWgUcZtAl16pw=="],
@@ -63,7 +66,7 @@
 
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.30.1", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-nuKvp7wOIz6BFei8WrTdhmSsx5mwnArYyJgh4+vYu3V4J0Ltb8Xm3odPm51n1aSI0XxNCrDl7O88cxCtUdAkaw=="],
 
@@ -310,6 +313,8 @@
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
@@ -581,6 +586,20 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
+    "@ai-sdk/amazon-bedrock/@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.81", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA=="],
+
+    "@ai-sdk/amazon-bedrock/@ai-sdk/openai": ["@ai-sdk/openai@3.0.67", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oAiGC9eWG7IgtdsdS74bOCnAAHarAfTJhWN9x5INwnWPekL802AvF+0I5DvLzIF1MIRmNw4N8mPSL/GUVbX9Mw=="],
+
+    "@ai-sdk/anthropic/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+
+    "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+
+    "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+
+    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+
     "@anthropic-ai/sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
@@ -594,6 +613,8 @@
     "@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
     "@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
 
     "eventsource/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 

--- a/docs/ai-providers/bedrock.md
+++ b/docs/ai-providers/bedrock.md
@@ -1,0 +1,73 @@
+# Amazon Bedrock
+
+Use Bedrock when you want AWS-managed auth and model access.
+
+## Requirements
+
+- `AWS_REGION`
+- Bedrock model access enabled in that region
+- IAM permission for `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream`
+
+## Auth
+
+### Explicit keys
+
+```bash
+export AWS_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=AKIA...
+export AWS_SECRET_ACCESS_KEY=***
+export AWS_SESSION_TOKEN=***   # optional
+```
+
+### IAM role
+
+Set `AWS_REGION` and let the SDK resolve credentials from the environment or instance role.
+
+## Supported models
+
+### Embeddings
+
+- `amazon.titan-embed-text-v2:0` — 256/512/1024/1536 dims
+- `amazon.titan-embed-text-v1` — 1536 dims
+- `cohere.embed-english-v3`
+- `cohere.embed-multilingual-v3`
+
+### Rerank
+
+- `amazon.rerank-v1:0`
+- `cohere.rerank-v3-5:0`
+
+### Chat
+
+- `anthropic.claude-sonnet-4-5-20251101-v1:0`
+- `anthropic.claude-sonnet-4-6-20260101-v1:0`
+- `anthropic.claude-haiku-4-5-20251001-v1:0`
+- `us.anthropic.claude-sonnet-4-5-20251101-v1:0`
+- `us.anthropic.claude-sonnet-4-6-20260101-v1:0`
+- `us.anthropic.claude-haiku-4-5-20251001-v1:0`
+- `amazon.nova-pro-v1:0`
+- `amazon.nova-lite-v1:0`
+- `amazon.nova-micro-v1:0`
+
+## Example
+
+```bash
+gbrain config set embedding_model bedrock:amazon.titan-embed-text-v2:0
+gbrain config set reranker_model bedrock:amazon.rerank-v1:0
+gbrain config set expansion_model bedrock:anthropic.claude-sonnet-4-6-20260101-v1:0
+```
+
+## Subagents
+
+`supports_subagent_loop` stays `false` for now. If you want Bedrock-backed tool loops, enable:
+
+```bash
+gbrain config set agent.use_gateway_loop true
+```
+
+## Troubleshooting
+
+- `AccessDeniedException` → enable the model in the Bedrock console and check IAM.
+- `UnrecognizedClientException` / `InvalidSignatureException` → bad or expired AWS credentials.
+- `ValidationException: model not found` → wrong model ID or region.
+- Endpoint resolution errors → choose a Bedrock-supported `AWS_REGION`.

--- a/docs/integrations/embedding-providers.md
+++ b/docs/integrations/embedding-providers.md
@@ -32,6 +32,7 @@ The resolved provider + dimensions get persisted to `~/.gbrain/config.json` atom
 | `minimax` | `MINIMAX_API_KEY` | 1536 | 0.07 | no | no |
 | `dashscope` | `DASHSCOPE_API_KEY` | 1024 | varies | no | no |
 | `zhipu` | `ZHIPUAI_API_KEY` | 1024 | varies | no | no |
+| `bedrock` | `AWS_REGION` (+ optional key vars or IAM role) | 1536 | 0.02 | no | no |
 | `ollama` | (none — runs locally) | 768 | 0 | yes | no |
 | `llama-server` | (none — runs locally) | user-set | 0 | yes | no |
 | `litellm` | `LITELLM_API_KEY` (optional) | user-set | varies | yes (proxy) | no |

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     ]
   },
   "dependencies": {
+    "@ai-sdk/amazon-bedrock": "^4.0.112",
     "@ai-sdk/anthropic": "^3.0.71",
     "@ai-sdk/google": "^3.0.64",
     "@ai-sdk/openai": "^3.0.53",

--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -34,6 +34,11 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   // plane field now exists (GBrainConfig type) and gets mapped here, so
   // setting it via `~/.gbrain/config.json` propagates into the gateway.
   if (c.zeroentropy_api_key) envFromConfig.ZEROENTROPY_API_KEY = c.zeroentropy_api_key;
+  // Bedrock: region + optional explicit credentials (IAM role fallback when keys absent).
+  if (c.aws_region) envFromConfig.AWS_REGION = c.aws_region;
+  if (c.aws_access_key_id) envFromConfig.AWS_ACCESS_KEY_ID = c.aws_access_key_id;
+  if (c.aws_secret_access_key) envFromConfig.AWS_SECRET_ACCESS_KEY = c.aws_secret_access_key;
+  if (c.aws_session_token) envFromConfig.AWS_SESSION_TOKEN = c.aws_session_token;
 
   // v0.32 codex finding #4+#5 fix: thread local-server _BASE_URL env vars
   // into base_urls so the gateway hits the user's configured port. Without

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -27,6 +27,7 @@ import { listRecipes } from './recipes/index.ts';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { z } from 'zod';
 
@@ -387,6 +388,18 @@ export function applyOpenAICompatConfig(
     );
   }
   return { baseURL };
+}
+
+/** Build a Bedrock client config from gateway env. */
+function buildBedrockClientConfig(cfg: AIGatewayConfig): { region: string; accessKeyId?: string; secretAccessKey?: string; sessionToken?: string } {
+  const region = cfg.env.AWS_REGION ?? '';
+  if (!cfg.env.AWS_ACCESS_KEY_ID) return { region };
+  return {
+    region,
+    accessKeyId: cfg.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: cfg.env.AWS_SECRET_ACCESS_KEY ?? '',
+    ...(cfg.env.AWS_SESSION_TOKEN ? { sessionToken: cfg.env.AWS_SESSION_TOKEN } : {}),
+  };
 }
 
 /** Configure the gateway. Called by cli.ts#connectEngine. Clears cached models. */
@@ -1139,6 +1152,14 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
       throw new AIConfigError(
         `Anthropic has no embedding model. Use openai or google for embeddings.`,
       );
+    case 'native-bedrock': {
+      if (!cfg.env.AWS_REGION) throw new AIConfigError(
+        'Bedrock embedding requires AWS_REGION.',
+        recipe.setup_hint,
+      );
+      const bedrockClient = createAmazonBedrock(buildBedrockClientConfig(cfg));
+      return bedrockClient.textEmbeddingModel(modelId);
+    }
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
       const auth = applyResolveAuth(recipe, cfg, 'embedding');
@@ -2040,6 +2061,11 @@ function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayCon
       if (!apiKey) throw new AIConfigError(`Anthropic expansion requires ANTHROPIC_API_KEY.`, recipe.setup_hint);
       return createAnthropic({ apiKey }).languageModel(modelId);
     }
+    case 'native-bedrock': {
+      if (!cfg.env.AWS_REGION) throw new AIConfigError('Bedrock expansion requires AWS_REGION.', recipe.setup_hint);
+      const bedrockClient = createAmazonBedrock(buildBedrockClientConfig(cfg));
+      return bedrockClient(modelId);
+    }
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
       const auth = applyResolveAuth(recipe, cfg, 'expansion');
@@ -2411,6 +2437,11 @@ function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig):
       const apiKey = cfg.env.ANTHROPIC_API_KEY;
       if (!apiKey) throw new AIConfigError(`Anthropic chat requires ANTHROPIC_API_KEY.`, recipe.setup_hint);
       return createAnthropic({ apiKey }).languageModel(modelId);
+    }
+    case 'native-bedrock': {
+      if (!cfg.env.AWS_REGION) throw new AIConfigError('Bedrock chat requires AWS_REGION.', recipe.setup_hint);
+      const bedrockClient = createAmazonBedrock(buildBedrockClientConfig(cfg));
+      return bedrockClient(modelId);
     }
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
@@ -3229,6 +3260,30 @@ export async function rerank(input: RerankInput): Promise<RerankResult[]> {
       // BudgetExhausted (TX1) suppressed; surfaces on next reserve().
     }
   };
+  // Bedrock reranking uses the AI SDK path instead of the raw HTTP transport below.
+  if (recipe.implementation === 'native-bedrock') {
+    try {
+      if (!cfg.env.AWS_REGION) throw new RerankError('Bedrock rerank requires AWS_REGION.', 'unknown');
+      const bedrockClient = createAmazonBedrock(buildBedrockClientConfig(cfg));
+      const rerankModel = (bedrockClient as any).reranking(parsed.modelId);
+      const result = await rerankModel.doRerank({
+        query: input.query,
+        documents: input.documents,
+        topN: input.topN,
+        abortSignal: ctrl.signal,
+      });
+      clearTimeout(t);
+      _rerankRecord();
+      return result.rerankings.map((r: any) => ({ index: r.index, relevanceScore: r.relevanceScore }));
+    } catch (err) {
+      clearTimeout(t);
+      _rerankRecord();
+      if (err instanceof RerankError) throw err;
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new RerankError(`rerank (bedrock): ${msg}`, 'network');
+    }
+  }
+
   try {
     const transport: RerankTransport = _rerankTransport ?? ((u, init) => fetch(u, init));
     const resp = await transport(url, {

--- a/src/core/ai/recipes/bedrock.ts
+++ b/src/core/ai/recipes/bedrock.ts
@@ -1,0 +1,63 @@
+import type { Recipe } from '../types.ts';
+
+/** Amazon Bedrock recipe. Requires AWS_REGION and Bedrock model access. */
+export const bedrock: Recipe = {
+  id: 'bedrock',
+  name: 'Amazon Bedrock',
+  tier: 'native',
+  implementation: 'native-bedrock',
+  auth_env: {
+    required: ['AWS_REGION'],
+    optional: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN'],
+    setup_url: 'https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started.html',
+  },
+  touchpoints: {
+    embedding: {
+      models: [
+        'amazon.titan-embed-text-v2:0',   // 1536d, Matryoshka (256/512/1024/1536)
+        'amazon.titan-embed-text-v1',      // 1536d fixed
+        'cohere.embed-english-v3',         // 1024d
+        'cohere.embed-multilingual-v3',    // 1024d, 100+ languages
+      ],
+      default_dims: 1536,
+      dims_options: [256, 512, 1024, 1536],
+      cost_per_1m_tokens_usd: 0.02,
+      price_last_verified: '2026-06-03',
+      max_batch_tokens: 8_000,
+      chars_per_token: 4,
+      safety_factor: 0.8,
+    },
+    reranker: {
+      models: [
+        'amazon.rerank-v1:0',
+        'cohere.rerank-v3-5:0',
+      ],
+      default_model: 'amazon.rerank-v1:0',
+      cost_per_1m_tokens_usd: 0.0,
+      price_last_verified: '2026-06-03',
+      max_payload_bytes: 5_000_000,
+    },
+    chat: {
+      models: [
+        'anthropic.claude-sonnet-4-5-20251101-v1:0',
+        'anthropic.claude-sonnet-4-6-20260101-v1:0',
+        'anthropic.claude-haiku-4-5-20251001-v1:0',
+        'us.anthropic.claude-sonnet-4-5-20251101-v1:0',
+        'us.anthropic.claude-sonnet-4-6-20260101-v1:0',
+        'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+        'amazon.nova-pro-v1:0',
+        'amazon.nova-lite-v1:0',
+        'amazon.nova-micro-v1:0',
+      ],
+      supports_tools: true,
+      supports_subagent_loop: false,
+    },
+  },
+  setup_hint: [
+    'Set AWS_REGION to your Bedrock-enabled region (e.g. us-east-1).',
+    'Auth via keys: AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY.',
+    'Auth via IAM role: no env keys needed when running on EC2/ECS/Lambda.',
+    'Enable model access in the AWS Bedrock console before first use.',
+    'For subagent loops: gbrain config set agent.use_gateway_loop true',
+  ].join(' '),
+};

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -21,6 +21,7 @@ import { minimax } from './minimax.ts';
 import { dashscope } from './dashscope.ts';
 import { zhipu } from './zhipu.ts';
 import { azureOpenAI } from './azure-openai.ts';
+import { bedrock } from './bedrock.ts';
 import { zeroentropyai } from './zeroentropyai.ts';
 import { llamaServerReranker } from './llama-server-reranker.ts';
 
@@ -41,6 +42,7 @@ const ALL: Recipe[] = [
   dashscope,
   zhipu,
   azureOpenAI,
+  bedrock,
   zeroentropyai,
 ];
 

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -22,6 +22,7 @@ export type Implementation =
   | 'native-openai'
   | 'native-google'
   | 'native-anthropic'
+  | 'native-bedrock'
   | 'openai-compatible';
 
 export interface EmbeddingTouchpoint {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -41,6 +41,11 @@ export interface GBrainConfig {
    * merge → buildGatewayConfig env dict → recipe reads ZEROENTROPY_API_KEY.
    */
   zeroentropy_api_key?: string;
+  /** Amazon Bedrock — region is always required; key vars optional (IAM role fallback). */
+  aws_region?: string;
+  aws_access_key_id?: string;
+  aws_secret_access_key?: string;
+  aws_session_token?: string;
   /** AI gateway config (v0.14+). v0.36+ default: "zeroentropyai:zembed-1" / 1280 / "anthropic:claude-haiku-4-5-20251001". */
   embedding_model?: string;
   embedding_dimensions?: number;
@@ -407,6 +412,10 @@ export function loadConfig(): GBrainConfig | null {
     ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
     ...(process.env.ANTHROPIC_API_KEY ? { anthropic_api_key: process.env.ANTHROPIC_API_KEY } : {}),
     ...(process.env.ZEROENTROPY_API_KEY ? { zeroentropy_api_key: process.env.ZEROENTROPY_API_KEY } : {}),
+    ...(process.env.AWS_REGION ? { aws_region: process.env.AWS_REGION } : {}),
+    ...(process.env.AWS_ACCESS_KEY_ID ? { aws_access_key_id: process.env.AWS_ACCESS_KEY_ID } : {}),
+    ...(process.env.AWS_SECRET_ACCESS_KEY ? { aws_secret_access_key: process.env.AWS_SECRET_ACCESS_KEY } : {}),
+    ...(process.env.AWS_SESSION_TOKEN ? { aws_session_token: process.env.AWS_SESSION_TOKEN } : {}),
     ...(process.env.GBRAIN_EMBEDDING_MODEL ? { embedding_model: process.env.GBRAIN_EMBEDDING_MODEL } : {}),
     ...(process.env.GBRAIN_EMBEDDING_DIMENSIONS ? { embedding_dimensions: parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS, 10) } : {}),
     ...(process.env.GBRAIN_EXPANSION_MODEL ? { expansion_model: process.env.GBRAIN_EXPANSION_MODEL } : {}),

--- a/test/ai/gateway-bedrock.test.ts
+++ b/test/ai/gateway-bedrock.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
+import {
+  configureGateway,
+  resetGateway,
+  isAvailable,
+  embed,
+} from '../../src/core/ai/gateway.ts';
+import { buildGatewayConfig } from '../../src/core/ai/build-gateway-config.ts';
+import { parseModelId, resolveRecipe } from '../../src/core/ai/model-resolver.ts';
+import { AIConfigError } from '../../src/core/ai/errors.ts';
+import { listRecipes } from '../../src/core/ai/recipes/index.ts';
+
+afterAll(() => resetGateway());
+
+describe('bedrock recipe registration', () => {
+  test('bedrock recipe is registered with correct id and implementation', () => {
+    const recipes = listRecipes();
+    const bedrock = recipes.find(r => r.id === 'bedrock');
+    expect(bedrock).toBeDefined();
+    expect(bedrock!.implementation).toBe('native-bedrock');
+    expect(bedrock!.tier).toBe('native');
+  });
+
+  test('bedrock recipe declares embedding touchpoint', () => {
+    const recipes = listRecipes();
+    const bedrock = recipes.find(r => r.id === 'bedrock')!;
+    expect(bedrock.touchpoints.embedding).toBeDefined();
+    expect(bedrock.touchpoints.embedding!.models).toContain('amazon.titan-embed-text-v2:0');
+    expect(bedrock.touchpoints.embedding!.default_dims).toBe(1536);
+  });
+
+  test('bedrock recipe declares reranker touchpoint', () => {
+    const recipes = listRecipes();
+    const bedrock = recipes.find(r => r.id === 'bedrock')!;
+    expect(bedrock.touchpoints.reranker).toBeDefined();
+    expect(bedrock.touchpoints.reranker!.models).toContain('amazon.rerank-v1:0');
+    expect(bedrock.touchpoints.reranker!.models).toContain('cohere.rerank-v3-5:0');
+    expect(bedrock.touchpoints.reranker!.default_model).toBe('amazon.rerank-v1:0');
+  });
+
+  test('bedrock recipe declares chat touchpoint', () => {
+    const recipes = listRecipes();
+    const bedrock = recipes.find(r => r.id === 'bedrock')!;
+    expect(bedrock.touchpoints.chat).toBeDefined();
+    expect(bedrock.touchpoints.chat!.supports_tools).toBe(true);
+    expect(bedrock.touchpoints.chat!.supports_subagent_loop).toBe(false);
+    expect(bedrock.touchpoints.chat!.models).toContain('anthropic.claude-sonnet-4-6-20260101-v1:0');
+    expect(bedrock.touchpoints.chat!.models).toContain('amazon.nova-pro-v1:0');
+  });
+
+  test('bedrock recipe requires AWS_REGION', () => {
+    const recipes = listRecipes();
+    const bedrock = recipes.find(r => r.id === 'bedrock')!;
+    expect(bedrock.auth_env).toBeDefined();
+    expect(bedrock.auth_env!.required).toContain('AWS_REGION');
+  });
+
+  test('bedrock recipe has optional key vars', () => {
+    const recipes = listRecipes();
+    const bedrock = recipes.find(r => r.id === 'bedrock')!;
+    expect(bedrock.auth_env).toBeDefined();
+    expect(bedrock.auth_env!.optional).toContain('AWS_ACCESS_KEY_ID');
+    expect(bedrock.auth_env!.optional).toContain('AWS_SECRET_ACCESS_KEY');
+    expect(bedrock.auth_env!.optional).toContain('AWS_SESSION_TOKEN');
+  });
+});
+
+describe('bedrock model resolution', () => {
+  test('parseModelId resolves bedrock prefix', () => {
+    const parsed = parseModelId('bedrock:amazon.titan-embed-text-v2:0');
+    expect(parsed.providerId).toBe('bedrock');
+    expect(parsed.modelId).toBe('amazon.titan-embed-text-v2:0');
+  });
+
+  test('resolveRecipe finds bedrock recipe', () => {
+    const { recipe, parsed } = resolveRecipe('bedrock:amazon.titan-embed-text-v2:0');
+    expect(recipe.id).toBe('bedrock');
+    expect(parsed.modelId).toBe('amazon.titan-embed-text-v2:0');
+  });
+});
+
+describe('bedrock gateway availability', () => {
+  beforeEach(() => resetGateway());
+
+  test('embedding AVAILABLE when AWS_REGION is set', () => {
+    configureGateway({
+      embedding_model: 'bedrock:amazon.titan-embed-text-v2:0',
+      embedding_dimensions: 1536,
+      env: { AWS_REGION: 'us-east-1' },
+    });
+    expect(isAvailable('embedding')).toBe(true);
+  });
+
+  test('embedding UNAVAILABLE when AWS_REGION is missing', () => {
+    configureGateway({
+      embedding_model: 'bedrock:amazon.titan-embed-text-v2:0',
+      embedding_dimensions: 1536,
+      env: {},
+    });
+    expect(isAvailable('embedding')).toBe(false);
+  });
+});
+
+describe('bedrock instantiateEmbedding errors', () => {
+  beforeEach(() => resetGateway());
+
+  test('embed throws AIConfigError when AWS_REGION is missing', async () => {
+    configureGateway({
+      embedding_model: 'bedrock:amazon.titan-embed-text-v2:0',
+      embedding_dimensions: 1536,
+      env: {},
+    });
+    try {
+      await embed(['test']);
+      expect(true).toBe(false); // should not reach
+    } catch (err) {
+      expect(err).toBeInstanceOf(AIConfigError);
+      expect((err as AIConfigError).message).toContain('AWS_REGION');
+    }
+  });
+});
+
+describe('bedrock config env flow', () => {
+  test('buildGatewayConfig maps aws_region from GBrainConfig to env.AWS_REGION', () => {
+    // Temporarily clear process.env AWS vars so config-file values win the merge.
+    const saved = {
+      AWS_REGION: process.env.AWS_REGION,
+      AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
+      AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+      AWS_SESSION_TOKEN: process.env.AWS_SESSION_TOKEN,
+    };
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.AWS_SESSION_TOKEN;
+    try {
+      const gw = buildGatewayConfig({
+        engine: 'pglite',
+        aws_region: 'us-west-2',
+        aws_access_key_id: 'AKIATEST123',
+        aws_secret_access_key: 'secret123',
+        aws_session_token: 'token456',
+      });
+      expect(gw.env.AWS_REGION).toBe('us-west-2');
+      expect(gw.env.AWS_ACCESS_KEY_ID).toBe('AKIATEST123');
+      expect(gw.env.AWS_SECRET_ACCESS_KEY).toBe('secret123');
+      expect(gw.env.AWS_SESSION_TOKEN).toBe('token456');
+    } finally {
+      // Restore
+      for (const [k, v] of Object.entries(saved)) {
+        if (v !== undefined) process.env[k] = v;
+        else delete process.env[k];
+      }
+    }
+  });
+
+  test('process.env.AWS_REGION flows through buildGatewayConfig', () => {
+    // process.env is spread into the gateway env dict — process.env wins over config file
+    const prev = process.env.AWS_REGION;
+    try {
+      process.env.AWS_REGION = 'eu-west-1';
+      const gw = buildGatewayConfig({ engine: 'pglite' });
+      expect(gw.env.AWS_REGION).toBe('eu-west-1');
+    } finally {
+      if (prev !== undefined) process.env.AWS_REGION = prev;
+      else delete process.env.AWS_REGION;
+    }
+  });
+
+  test('bedrock isAvailable returns true when config has aws_region', () => {
+    resetGateway();
+    const gw = buildGatewayConfig({
+      engine: 'pglite',
+      embedding_model: 'bedrock:amazon.titan-embed-text-v2:0',
+      embedding_dimensions: 1536,
+      aws_region: 'us-east-1',
+    });
+    configureGateway(gw);
+    expect(isAvailable('embedding')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds `bedrock` as a native provider, filling the only major enterprise
hosting gap in the recipe registry. AWS shops running on Bedrock can now
use gbrain without a LiteLLM proxy or a second API key vendor.

## Provider surface

**Embedding** — Titan Embed Text v2 (1536d, Matryoshka 256/512/1024/1536),
Titan v1, Cohere Embed English v3, Cohere Embed Multilingual v3.

**Reranker** — `amazon.rerank-v1:0` and `cohere.rerank-v3-5:0`. Uses
`@ai-sdk/amazon-bedrock`'s `RerankingModelV4.doRerank()` instead of the
ZeroEntropy/llama.cpp wire shape — Bedrock's rerank API is structurally
different (queries array, not a flat documents list), so the native path
branches early in `rerank()` before the raw HTTP fetch.

**Chat** — Claude on Bedrock (cross-region inference prefixes included),
Nova Pro/Lite/Micro.

## Auth

AWS_REGION is required. Key-based auth (ACCESS_KEY_ID + SECRET +
optional SESSION_TOKEN) and IAM instance profile/role are both supported.
The pattern matches how the rest of the stack handles optional key env vars
— no keys present means the SDK falls back to the credential provider chain.

## Implementation notes

- `native-bedrock` added to the `Implementation` union in `types.ts`.
  Three switch sites in `gateway.ts` get the new case (instantiateEmbedding,
  instantiateExpansion, instantiateChat). Credential resolution extracted into
  `buildBedrockClientConfig(cfg)` to avoid repeating the optional-key spread
  across all four call sites (the fourth being the rerank branch).
- `@ai-sdk/amazon-bedrock` is a static import, same as the existing
  native-openai / native-google providers.
- `supports_subagent_loop: false`. The gateway-native tool loop
  (`agent.use_gateway_loop = true`) already supports any recipe with
  `supports_tools: true`, so Bedrock Claude works for subagents today with
  that flag. The flag is false by default because crash-replay `tool_call_id`
  stability across the Bedrock converse API hasn't been verified the way
  native-anthropic has.

## Not in this PR

- No Titan Rerank — not available on Bedrock as of this writing.
- No multimodal embedding — Titan v2 is text-only.
- Subagent crash-replay verification for `supports_subagent_loop: true` — follow-up.

## Verification

```
bun run typecheck
bun test test/ai/gateway-bedrock.test.ts   # 11 pass
bun test test/ai/gateway.test.ts           # 36 pass, no regressions
bash scripts/check-gateway-routed-no-direct-anthropic.sh
bash scripts/check-privacy.sh
bash scripts/check-key-files-current-state.sh
npx fallow audit --changed-since master    # new clone groups: 0
```
