### PR TITLE
Fix broken AlphaClaw Render deploy links

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ GBrain is designed to be installed and operated by an AI agent. The fastest path
 
 If you don't already have an AI agent platform running, start with one of these. Both are designed to read GBrain's install protocol and execute it:
 
-- **[OpenClaw](https://github.com/openclawagents/openclaw)** — deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/alphaclaw) (one click, 8GB+ RAM)
+- **[OpenClaw](https://github.com/openclawagents/openclaw)** — deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/openclaw-render-template) (one click, 8GB+ RAM)
 - **[Hermes](https://github.com/openclawagents/hermes)** — deploy on [Railway](https://github.com/praveen-ks-2001/hermes-agent-template) (one click)
 
 Then paste this into your agent:

--- a/docs/tutorials/personal-brain.md
+++ b/docs/tutorials/personal-brain.md
@@ -86,12 +86,11 @@ Save this token. You'll need it for the AlphaClaw setup.
 
 AlphaClaw is the setup harness that manages OpenClaw deployment.
 
-1. Go to [alphaclaw.com](https://alphaclaw.com)
+1. [Deploy AlphaClaw to Render](https://render.com/deploy?repo=https://github.com/chrysb/openclaw-render-template) (one click). Set `SETUP_PASSWORD` when prompted.
 2. Enter your **workspace repo** (not the brain repo): `your-org/myagent`
 3. Select "Use existing" if the repo already exists
 4. Enter your GitHub PAT from Step 2
 5. Enter your Telegram bot token from Step 3
-6. Deploy
 
 Render will build a Docker container with the harness. First deploy takes about 5 minutes.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1451,7 +1451,7 @@ GBrain is designed to be installed and operated by an AI agent. The fastest path
 
 If you don't already have an AI agent platform running, start with one of these. Both are designed to read GBrain's install protocol and execute it:
 
-- **[OpenClaw](https://github.com/openclawagents/openclaw)** — deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/alphaclaw) (one click, 8GB+ RAM)
+- **[OpenClaw](https://github.com/openclawagents/openclaw)** — deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/openclaw-render-template) (one click, 8GB+ RAM)
 - **[Hermes](https://github.com/openclawagents/hermes)** — deploy on [Railway](https://github.com/praveen-ks-2001/hermes-agent-template) (one click)
 
 Then paste this into your agent:


### PR DESCRIPTION
## Summary
- Fixes the README "Deploy to Render" link to point at `chrysb/openclaw-render-template` instead of `chrysb/alphaclaw`
- Replaces the bogus `alphaclaw.com` link in the personal-brain tutorial with the correct one-click Render deploy URL
- Regenerates `llms-full.txt` via `bun run build:llms`

## Why — README link
Render's Deploy button requires a `render.yaml` Blueprint Spec in the target repo.
`chrysb/alphaclaw` does not include one, so the current link does not prefill a
service and is not truly one-click.

AlphaClaw's own README uses the dedicated template repo:
https://github.com/chrysb/alphaclaw#deploy-recommended

That template repo includes `render.yaml`:
https://github.com/chrysb/openclaw-render-template/blob/main/render.yaml

## Why — tutorial link
The personal-brain tutorial (Step 4) currently sends users to `alphaclaw.com`.
That domain is unrelated to the AlphaClaw OpenClaw harness — it resolves to a
pet-supply website ("Alpha Claw — Pawsitively the Best for Pets"). There is no
AlphaClaw product hosted there. The correct entry point is the Render one-click
deploy template linked above.

## Test plan
- [ ] Click the updated Render link — Render should show a prefilled AlphaClaw Docker web service
- [ ] Confirm `alphaclaw.com` is no longer linked anywhere in the repo
- [x] `bun run build:llms` produces no diff beyond README change
- [x] `bun test test/build-llms.test.ts` passes (llms drift check)

Made with [Cursor](https://cursor.com)