### PR TITLE
fix(git-remote): place --no-recurse-submodules after the git subcommand

### DIFF
--- a/src/core/git-remote.ts
+++ b/src/core/git-remote.ts
@@ -26,12 +26,17 @@ import { isInternalUrl } from './url-safety.ts';
  * - protocol.ext.allow=never: no external helpers (`git-remote-foo`)
  * - --no-recurse-submodules: .gitmodules cannot become a second fetch surface
  */
+// NOTE: only top-level `git -c …` options belong here. Subcommand options like
+// --no-recurse-submodules must be appended AFTER the subcommand (clone/pull),
+// otherwise git rejects them as an unknown top-level option. See SUBMODULE_FLAG.
 export const GIT_SSRF_FLAGS = [
   '-c', 'http.followRedirects=false',
   '-c', 'protocol.file.allow=never',
   '-c', 'protocol.ext.allow=never',
-  '--no-recurse-submodules',
 ] as const;
+
+// Submodule-recursion guard — passed as a subcommand option (after clone/pull).
+export const SUBMODULE_FLAG = '--no-recurse-submodules';
 
 export type RemoteUrlErrorCode =
   | 'invalid_url'
@@ -153,7 +158,7 @@ export function cloneRepo(url: string, destDir: string, opts: CloneOpts = {}): v
     }
   }
 
-  const args: string[] = [...GIT_SSRF_FLAGS, 'clone'];
+  const args: string[] = [...GIT_SSRF_FLAGS, 'clone', SUBMODULE_FLAG];
   if (opts.depth !== 0) {
     args.push(`--depth=${opts.depth ?? 1}`);
   }
@@ -179,7 +184,7 @@ export function cloneRepo(url: string, destDir: string, opts: CloneOpts = {}): v
 
 /** Pull a repo with --ff-only and the same SSRF-defensive flags as cloneRepo. */
 export function pullRepo(repoPath: string, opts: { timeoutMs?: number } = {}): void {
-  const args: string[] = ['-C', repoPath, ...GIT_SSRF_FLAGS, 'pull', '--ff-only'];
+  const args: string[] = ['-C', repoPath, ...GIT_SSRF_FLAGS, 'pull', '--ff-only', SUBMODULE_FLAG];
   try {
     execFileSync('git', args, {
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/test/git-remote.test.ts
+++ b/test/git-remote.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   GIT_SSRF_FLAGS,
+  SUBMODULE_FLAG,
   parseRemoteUrl,
   RemoteUrlError,
   cloneRepo,
@@ -75,19 +76,25 @@ beforeEach(() => {
 const fakePath = (): string => `${FAKE_GIT_DIR}:${process.env.PATH ?? ''}`;
 
 // ---------------------------------------------------------------------------
-// GIT_SSRF_FLAGS — pinned shape (snapshot test). If a future flag is added,
-// update the expected list here AND verify both cloneRepo + pullRepo pick it
-// up via the GIT_SSRF_FLAGS spread (the codex finding that motivated this).
+// GIT_SSRF_FLAGS — pinned shape (snapshot test). These are TOP-LEVEL `git -c …`
+// options ONLY; they are spread BEFORE the git subcommand. Subcommand options
+// like --no-recurse-submodules must NOT live here — git rejects them as an
+// unknown top-level option. Such flags belong in SUBMODULE_FLAG, appended AFTER
+// the clone/pull subcommand (the codex finding that motivated this).
 // ---------------------------------------------------------------------------
 
 describe('GIT_SSRF_FLAGS', () => {
-  test('exact shape — codex SSRF lockdown', () => {
+  test('exact shape — top-level -c flags only', () => {
     expect([...GIT_SSRF_FLAGS]).toEqual([
       '-c', 'http.followRedirects=false',
       '-c', 'protocol.file.allow=never',
       '-c', 'protocol.ext.allow=never',
-      '--no-recurse-submodules',
     ]);
+  });
+
+  test('SUBMODULE_FLAG is a subcommand option, kept out of the top-level flags', () => {
+    expect(SUBMODULE_FLAG).toBe('--no-recurse-submodules');
+    expect([...GIT_SSRF_FLAGS]).not.toContain(SUBMODULE_FLAG);
   });
 });
 
@@ -232,6 +239,9 @@ describe('cloneRepo', () => {
     // Pin the SSRF flags before the 'clone' verb (codex Q2 invariant).
     expect(argv.slice(0, GIT_SSRF_FLAGS.length)).toEqual([...GIT_SSRF_FLAGS]);
     expect(argv).toContain('clone');
+    // --no-recurse-submodules must come AFTER the subcommand, else git rejects
+    // it as an unknown top-level option (the codex finding).
+    expect(argv.indexOf(SUBMODULE_FLAG)).toBeGreaterThan(argv.indexOf('clone'));
     expect(argv).toContain('--depth=1');
     expect(argv).toContain('https://example.com/repo');
     expect(argv[argv.length - 1]).toBe(dest);
@@ -309,6 +319,8 @@ describe('pullRepo', () => {
     expect(argv.slice(2, 2 + GIT_SSRF_FLAGS.length)).toEqual([...GIT_SSRF_FLAGS]);
     expect(argv).toContain('pull');
     expect(argv).toContain('--ff-only');
+    // --no-recurse-submodules must come AFTER the subcommand (the codex finding).
+    expect(argv.indexOf(SUBMODULE_FLAG)).toBeGreaterThan(argv.indexOf('pull'));
     rmSync(repo, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Problem

`GIT_SSRF_FLAGS` includes `--no-recurse-submodules` and is spread **before** the git subcommand in both `cloneRepo` and `pullRepo`:

```
git -C <repo> -c http.followRedirects=false -c protocol.file.allow=never -c protocol.ext.allow=never --no-recurse-submodules pull --ff-only
```

git only accepts `--no-recurse-submodules` as a **subcommand** option (of `clone`/`pull`/`fetch`), not as a top-level `git` option. So the command fails immediately:

```
error: unknown option: `no-recurse-submodules'
```

## Impact

Every `pullRepo`/`cloneRepo` call fails once this flag is reached. On a brain repo with no remote this surfaced as the autopilot daemon's `sync.git_pull` phase failing **on every cycle** (9,000+ consecutive failures in the wild), and `gbrain sync` reporting `sync.git_pull error`. The failure is masked as a generic "git pull failed" so the real cause (bad flag position) isn't obvious.

## Fix

Move `--no-recurse-submodules` out of the top-level `GIT_SSRF_FLAGS` array into a `SUBMODULE_FLAG` constant, appended **after** the subcommand:
- `[...GIT_SSRF_FLAGS, 'clone', SUBMODULE_FLAG]`
- `['-C', repoPath, ...GIT_SSRF_FLAGS, 'pull', '--ff-only', SUBMODULE_FLAG]`

The submodule-fetch hardening is fully preserved — it's the same flag, just in the position git accepts. The `-c …` SSRF flags correctly remain top-level.

## Verification

After the change, `gbrain sync` logs `sync.git_pull done` (previously `sync.git_pull error`), and the autopilot daemon's pull phase no longer errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)