### PR TITLE
Fix PGLite stale lock recovery for stdio serve

### DIFF
--- a/src/core/pglite-lock.ts
+++ b/src/core/pglite-lock.ts
@@ -14,12 +14,11 @@
  *   try { ... } finally { await releaseLock(lock); }
  */
 
-import { mkdirSync, existsSync, readFileSync, writeFileSync, rmSync, statSync } from 'fs';
+import { mkdirSync, existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 
 const LOCK_DIR_NAME = '.gbrain-lock';
 const LOCK_FILE = 'lock';
-const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes — embed jobs can be long
 
 export interface LockHandle {
   lockDir: string;
@@ -73,16 +72,11 @@ export async function acquireLock(dataDir: string | undefined, opts?: { timeoutM
       try {
         const lockData = JSON.parse(readFileSync(lockPath, 'utf-8'));
         const lockPid = lockData.pid as number;
-        const lockTime = lockData.acquired_at as number;
 
         // Is the locking process still alive?
         if (!isProcessAlive(lockPid)) {
           // Stale lock — clean it up
           try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition, try again */ }
-        } else if (Date.now() - lockTime > STALE_THRESHOLD_MS) {
-          // Lock held for too long — assume stale (e.g., process hung)
-          // Still alive but probably stuck — force remove
-          try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition */ }
         } else {
           // Lock is held by a live process — wait and retry
           await new Promise(r => setTimeout(r, 1000));

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -49,33 +49,6 @@ export async function startMcpServer(engine: BrainEngine) {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-
-  // Exit cleanly when MCP client disconnects (stdin EOF) or on signals.
-  // Without this, orphaned serve processes accumulate and contend for the
-  // PGLite write lock, causing ingest jobs (email-sync) to time out.
-  let shuttingDown = false;
-  const shutdown = (reason: string, code = 0) => {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    process.stderr.write(`[gbrain-serve] shutdown: ${reason}\n`);
-    Promise.resolve(engine.disconnect?.())
-      .catch(() => {})
-      .finally(() => process.exit(code));
-  };
-  // v0.34.1 (#870): when MCP_STDIO=1, the wrapping gateway (OpenClaw's
-  // bundle-mcp layer, others) often pipes the JSON-RPC handshake then
-  // closes its stdin half. Treating that as a permanent disconnect kills
-  // the server before the first tool call arrives. Signal handlers and
-  // transport.onclose still cover the legitimate shutdown paths.
-  if (process.env.MCP_STDIO !== '1') {
-    process.stdin.on('end', () => shutdown('stdin end'));
-    process.stdin.on('close', () => shutdown('stdin close'));
-  }
-  // @ts-ignore — SDK exposes onclose on transport
-  transport.onclose = () => shutdown('transport close');
-  process.on('SIGTERM', () => shutdown('SIGTERM'));
-  process.on('SIGINT', () => shutdown('SIGINT'));
-  process.on('SIGHUP', () => shutdown('SIGHUP'));
 }
 
 // Backward compat: used by `gbrain call` command (trusted local path).

--- a/test/e2e/pglite-cli-exit.serial.test.ts
+++ b/test/e2e/pglite-cli-exit.serial.test.ts
@@ -39,6 +39,7 @@ import {
   rmSync,
   writeFileSync,
   chmodSync,
+  existsSync,
 } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
@@ -275,4 +276,36 @@ describe('v0.41.8.0 — daemon survival (regression guard for narrow force-exit)
     }
     expect(wasAlive).toBe(true);
   }, 15_000);
+});
+
+describe('v0.42.x — stale lock self-heal on next CLI connect', () => {
+  test('gbrain stats reaps a dead-pid stale lock and exits 0', async () => {
+    const lockDir = join(tmpHome, '.gbrain', 'brain.pglite', '.gbrain-lock');
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(
+      join(lockDir, 'lock'),
+      JSON.stringify({
+        pid: 999999999,
+        acquired_at: Date.now() - 60_000,
+        command: 'synthetic-dead-holder',
+      }),
+      'utf-8',
+    );
+
+    const { code, stdout, stderr, durationMs } = await runWithTimeout(
+      ['stats'],
+      15_000,
+    );
+
+    if (code !== 0) {
+      throw new Error(
+        `expected exit 0, got ${code}; duration=${durationMs}ms\n` +
+          `STDOUT:\n${stdout}\nSTDERR:\n${stderr}`,
+      );
+    }
+
+    expect(code).toBe(0);
+    expect(stdout).toContain('Pages:');
+    expect(existsSync(join(lockDir, 'lock'))).toBe(false);
+  }, 30_000);
 });

--- a/test/mcp-stdio-owner-regression.test.ts
+++ b/test/mcp-stdio-owner-regression.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const SERVER_SRC = readFileSync(
+  join(import.meta.dir, '..', 'src', 'mcp', 'server.ts'),
+  'utf-8',
+);
+
+describe('mcp stdio lifecycle owner regression', () => {
+  test('startMcpServer does not install its own stdio or signal shutdown hooks', () => {
+    expect(SERVER_SRC).not.toContain('process.stdin.on(');
+    expect(SERVER_SRC).not.toContain('process.on(\'SIGTERM\'');
+    expect(SERVER_SRC).not.toContain('process.on(\'SIGINT\'');
+    expect(SERVER_SRC).not.toContain('process.on(\'SIGHUP\'');
+    expect(SERVER_SRC).not.toContain('transport.onclose =');
+    expect(SERVER_SRC).not.toContain('engine.disconnect?.()');
+    expect(SERVER_SRC).not.toContain('process.exit(');
+  });
+});

--- a/test/pglite-engine-disconnect.serial.test.ts
+++ b/test/pglite-engine-disconnect.serial.test.ts
@@ -103,7 +103,7 @@ describe('PGLiteEngine.disconnect() — v0.41.8.0 lifecycle invariants', () => {
     } finally {
       rmSync(dataDir, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('SNAPSHOT + EARLY-NULL: _db is nulled before await close', async () => {
     const dataDir = newTempDataDir();
@@ -131,7 +131,7 @@ describe('PGLiteEngine.disconnect() — v0.41.8.0 lifecycle invariants', () => {
     } finally {
       rmSync(dataDir, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('LOCK LEAK GUARD: if db.close() throws, lock still releases', async () => {
     const dataDir = newTempDataDir();
@@ -169,7 +169,7 @@ describe('PGLiteEngine.disconnect() — v0.41.8.0 lifecycle invariants', () => {
     } finally {
       rmSync(dataDir, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('IDEMPOTENCY: double disconnect is a clean no-op on the second call', async () => {
     const dataDir = newTempDataDir();
@@ -197,7 +197,7 @@ describe('PGLiteEngine.disconnect() — v0.41.8.0 lifecycle invariants', () => {
     } finally {
       rmSync(dataDir, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   test('RECONNECT after disconnect sees clean state', async () => {
     const dataDir = newTempDataDir();
@@ -217,5 +217,5 @@ describe('PGLiteEngine.disconnect() — v0.41.8.0 lifecycle invariants', () => {
     } finally {
       rmSync(dataDir, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 });

--- a/test/pglite-lock.test.ts
+++ b/test/pglite-lock.test.ts
@@ -65,6 +65,30 @@ describe('pglite-lock', () => {
     await releaseLock(lock);
   });
 
+  test('does not reap a live process lock even if timeout expires', async () => {
+    const lockDir = join(TEST_DIR, '.gbrain-lock');
+    mkdirSync(lockDir);
+    writeFileSync(join(lockDir, 'lock'), JSON.stringify({
+      pid: process.pid,
+      acquired_at: Date.now() - 10 * 60 * 1000,
+      command: 'live-holder',
+    }));
+
+    await expect(acquireLock(TEST_DIR, { timeoutMs: 1000 })).rejects.toThrow(/Timed out/);
+    expect(existsSync(join(lockDir, 'lock'))).toBe(true);
+  });
+
+  test('cleans a corrupt lock file and acquires the lock', async () => {
+    const lockDir = join(TEST_DIR, '.gbrain-lock');
+    mkdirSync(lockDir);
+    writeFileSync(join(lockDir, 'lock'), '{not-json');
+
+    const lock = await acquireLock(TEST_DIR);
+    expect(lock.acquired).toBe(true);
+
+    await releaseLock(lock);
+  });
+
   test('skips lock for in-memory (undefined dataDir)', async () => {
     const lock = await acquireLock(undefined);
     expect(lock.acquired).toBe(true);


### PR DESCRIPTION
## Summary
- stop `startMcpServer()` from owning stdio/signal shutdown so `runServe()` is the single lifecycle owner
- preserve dead-PID/corrupt-lock reclaim while refusing to reap live PGLite holders
- add regression coverage for stale-lock self-heal, single-owner stdio lifecycle, and slower serial disconnect tests

## Root cause
`gbrain serve` already installs stdio/signal/parent-watchdog shutdown in `runServe()`, but `startMcpServer()` also installed its own stdin, transport, and signal shutdown hooks. That created a double-owner cleanup path around `engine.disconnect()` / `process.exit()`. In parallel, `pglite-lock.ts` still contained the older "reap long-held live lock" behavior, which is unsafe for embedded Postgres and not needed once dead-PID stale locks are reclaimed reliably on the next connect.

## Fix
- remove the duplicate stdio/signal shutdown hooks from `src/mcp/server.ts`
- keep stale-lock recovery in `acquireLock()` limited to dead PIDs and corrupt lockfiles
- add a serial CLI regression that seeds a dead-PID stale lock and proves `gbrain stats` reaps it and exits 0
- add a lightweight regression test that prevents future reintroduction of a second stdio lifecycle owner
- extend PGLite lock coverage and raise timeouts on the heavy disconnect serial tests so the intended invariants stay green under cold migration startup

## Validation
- `bun test test/pglite-lock.test.ts`
- `bun test test/mcp-stdio-owner-regression.test.ts`
- `bun test test/serve-stdio-lifecycle.test.ts`
- `bun test test/pglite-engine-disconnect.serial.test.ts`
- `bun test test/e2e/pglite-cli-exit.serial.test.ts`
