### PR TITLE
fix: make dream extract_facts idempotent so fence rows don't duplicate each cycle

### DIFF
--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -11,15 +11,16 @@
  *   1. Reads the markdown body (DB-side fetch via engine.getPage).
  *   2. Parses the `## Facts` fence with parseFactsFence.
  *   3. Maps ParsedFact → FenceExtractedFact via extractFactsFromFenceText.
- *   4. Wipes the page's DB index via deleteFactsForPage.
- *   5. Re-inserts via engine.insertFacts batch.
+ *   4. De-dupes rows by canonical (claim, source) content key.
+ *   5. Reconciles the page-scoped DB index: no-op when already in sync,
+ *      insert only missing keys when possible, or wipe/reinsert when stale
+ *      DB rows need cleanup.
  *
- * After the phase, the DB index for every affected page byte-matches
- * the fence (modulo embeddings + runtime-derived fields). Pages with
- * no fence go through delete-then-empty-insert — DB rows for that
- * page coordinate are wiped; legacy NULL-source_markdown_slug rows
- * survive because deleteFactsForPage targets source_markdown_slug =
- * slug only.
+ * After the phase, the DB index for every affected page matches the
+ * fence's canonical (claim, source) row set (modulo embeddings +
+ * runtime-derived fields). Pages with no fence wipe DB rows for that
+ * page coordinate only; legacy NULL-source_markdown_slug rows survive
+ * because deleteFactsForPage targets source_markdown_slug = slug only.
  *
  * Empty-fence guard (Codex R2-#7): the phase refuses to do its
  * destructive reconciliation pass when legacy rows (row_num IS NULL,
@@ -35,13 +36,23 @@ import type { BrainEngine } from '../engine.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { parseFactsFence } from '../facts-fence.ts';
-import { extractFactsFromFenceText } from '../facts/extract-from-fence.ts';
+import {
+  extractFactsFromFenceText,
+  FENCE_SOURCE_DEFAULT,
+  type FenceExtractedFact,
+} from '../facts/extract-from-fence.ts';
 import {
   runPhantomRedirectPass,
   emptyPhantomPassResult,
   type PhantomPassResult,
 } from './phantom-redirect.ts';
 import { embed, isAvailable } from '../ai/gateway.ts';
+
+interface ExistingPageFact {
+  fact: string;
+  source: string | null;
+  row_num: number | string | null;
+}
 
 export interface ExtractFactsOpts {
   /** Subset of slugs to reconcile. undefined = walk every page in the brain. */
@@ -76,6 +87,37 @@ export interface ExtractFactsResult {
   phantomsSkippedDrift: number;
   phantomsLockBusy: boolean;
   phantomsMorePending: boolean;
+}
+
+function factContentKey(fact: string, source: string | null | undefined): string {
+  return `${fact}\u0000${source ?? FENCE_SOURCE_DEFAULT}`;
+}
+
+function dedupeFactsByContentKey(facts: FenceExtractedFact[]): FenceExtractedFact[] {
+  const seen = new Set<string>();
+  const deduped: FenceExtractedFact[] = [];
+  for (const fact of facts) {
+    const key = factContentKey(fact.fact, fact.source);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(fact);
+  }
+  return deduped;
+}
+
+async function listExistingFactsForPage(
+  engine: BrainEngine,
+  slug: string,
+  sourceId: string,
+): Promise<ExistingPageFact[]> {
+  return engine.executeRaw<ExistingPageFact>(
+    `SELECT fact, source, row_num
+       FROM facts
+      WHERE source_id = $1
+        AND source_markdown_slug = $2
+      ORDER BY row_num ASC, id ASC`,
+    [sourceId, slug],
+  );
 }
 
 /**
@@ -207,23 +249,55 @@ export async function runExtractFacts(
 
     if (parsed.facts.length > 0) result.pagesWithFacts += 1;
 
-    if (opts.dryRun) continue;
-
-    // Wipe-and-reinsert per page. The deleteFactsForPage call targets
-    // source_markdown_slug = slug only, so NULL-source_markdown_slug
-    // legacy rows survive (the partial-UNIQUE-index keyspace).
-    const deleted = await engine.deleteFactsForPage(slug, sourceId);
-    result.factsDeleted += deleted.deleted;
-
-    if (parsed.facts.length === 0) continue;
-
     // v0.35.4 (D-ENG-1) — thread page.effective_date as the fallback
     // valid_from. Without this, fence rows without explicit `validFrom:`
     // land with `valid_from = now()` (import timestamp) and every
     // trajectory query against the page returns import dates instead of
     // claim dates.
     const pageEffectiveDate = page.effective_date ? new Date(page.effective_date) : null;
-    const extracted = extractFactsFromFenceText(parsed.facts, slug, sourceId, { pageEffectiveDate });
+    const extracted = dedupeFactsByContentKey(
+      extractFactsFromFenceText(parsed.facts, slug, sourceId, { pageEffectiveDate }),
+    );
+
+    if (opts.dryRun) continue;
+
+    const existing = await listExistingFactsForPage(engine, slug, sourceId);
+    const existingKeys = new Set(existing.map(f => factContentKey(f.fact, f.source)));
+    const desiredByKey = new Map(extracted.map(f => [factContentKey(f.fact, f.source), f]));
+
+    if (extracted.length === 0) {
+      if (existing.length > 0) {
+        const deleted = await engine.deleteFactsForPage(slug, sourceId);
+        result.factsDeleted += deleted.deleted;
+      }
+      continue;
+    }
+
+    const hasStaleExisting = existing.some(f => !desiredByKey.has(factContentKey(f.fact, f.source)));
+    const hasDuplicateExisting = existing.length !== existingKeys.size;
+    const hasRowNumDrift = existing.some(f => {
+      const desired = desiredByKey.get(factContentKey(f.fact, f.source));
+      return desired !== undefined && Number(f.row_num) !== desired.row_num;
+    });
+
+    if (
+      existing.length === extracted.length &&
+      !hasStaleExisting &&
+      !hasDuplicateExisting &&
+      !hasRowNumDrift
+    ) {
+      continue;
+    }
+
+    let toInsert = extracted.filter(f => !existingKeys.has(factContentKey(f.fact, f.source)));
+    if (hasStaleExisting || hasDuplicateExisting || hasRowNumDrift) {
+      // Fall back to the legacy page-level reconcile when old DB rows must
+      // be removed. The deleteFactsForPage call targets source_markdown_slug
+      // = slug only, so NULL-source_markdown_slug legacy rows survive.
+      const deleted = await engine.deleteFactsForPage(slug, sourceId);
+      result.factsDeleted += deleted.deleted;
+      toInsert = extracted;
+    }
 
     // v0.35.4 (D-CDX-3) — batch-embed before insert. Without this,
     // cycle-inserted facts land with `embedding = NULL`, which breaks
@@ -232,15 +306,15 @@ export async function runExtractFacts(
     // unavailable (no API key configured), facts still insert with
     // NULL embeddings — drift_score gracefully returns null and
     // clustering falls back to recency.
-    if (isAvailable('embedding') && extracted.length > 0) {
+    if (isAvailable('embedding') && toInsert.length > 0) {
       try {
-        const texts = extracted.map(e => e.fact);
+        const texts = toInsert.map(e => e.fact);
         const embeddings = await embed(texts);
         // Defensive: embed should return one vector per input; if the
         // gateway returns a partial array (provider partial-batch retry
         // returning fewer than requested), only fill what we have.
-        for (let i = 0; i < extracted.length && i < embeddings.length; i++) {
-          extracted[i].embedding = embeddings[i];
+        for (let i = 0; i < toInsert.length && i < embeddings.length; i++) {
+          toInsert[i].embedding = embeddings[i];
         }
       } catch (err) {
         // Embedding failure is non-fatal — facts still get inserted, just
@@ -251,7 +325,9 @@ export async function runExtractFacts(
       }
     }
 
-    const inserted = await engine.insertFacts(extracted, { source_id: sourceId }); // gbrain-allow-direct-insert: extract_facts cycle phase reconciles fence → DB
+    if (toInsert.length === 0) continue;
+
+    const inserted = await engine.insertFacts(toInsert, { source_id: sourceId }); // gbrain-allow-direct-insert: extract_facts cycle phase reconciles fence → DB
     result.factsInserted += inserted.inserted;
   }
 

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -12,6 +12,7 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runExtractFacts } from '../src/core/cycle/extract-facts.ts';
+import { parseFactsFence } from '../src/core/facts-fence.ts';
 
 let engine: PGLiteEngine;
 
@@ -99,9 +100,85 @@ describe('runExtractFacts — happy path', () => {
     );
 
     expect(r2.guardTriggered).toBe(false);
+    expect(r2.factsInserted).toBe(0);
+    expect(r2.factsDeleted).toBe(0);
     expect(after2.rows.map((r: { fact: string }) => r.fact))
       .toEqual(after1.rows.map((r: { fact: string }) => r.fact));
     expect(after2.rows).toHaveLength(2);
+  });
+
+  test('dedupes duplicate fence rows by claim and source without rewriting the fence', async () => {
+    const body = FACT_FENCE(
+      `| 1 | A | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |
+| 2 | A | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    );
+    await putPage('people/alice', body);
+
+    const r1 = await runExtractFacts(engine, { slugs: ['people/alice'] });
+    const r2 = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r1.factsInserted).toBe(1);
+    expect(r2.factsInserted).toBe(0);
+    expect(r2.factsDeleted).toBe(0);
+
+    // The cycle dedups the derived DB index; it does not destructively
+    // rewrite user-authored markdown fence rows.
+    const page = await engine.getPage('people/alice', { sourceId: 'default' });
+    expect(parseFactsFence(page?.compiled_truth ?? '').facts).toHaveLength(2);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact, source FROM facts WHERE source_markdown_slug = 'people/alice'`,
+    );
+    expect(rows.rows).toHaveLength(1);
+    expect(rows.rows[0]).toMatchObject({ fact: 'A', source: 's' });
+  });
+
+  test('same claim with a different source is not treated as duplicate', async () => {
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | Same claim | fact | 1.0 | world | medium | 2026-01-01 |  | source-a |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | Same claim | fact | 1.0 | world | medium | 2026-01-01 |  | source-a |  |
+| 2 | Same claim | fact | 1.0 | world | medium | 2026-01-01 |  | source-b |  |`,
+    ));
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    expect(r.factsInserted).toBe(1);
+    expect(r.factsDeleted).toBe(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact, source FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,
+    );
+    expect(rows.rows).toEqual([
+      expect.objectContaining({ fact: 'Same claim', source: 'source-a' }),
+      expect.objectContaining({ fact: 'Same claim', source: 'source-b' }),
+    ]);
+  });
+
+  test('new fact added to the fence is inserted once without re-appending existing facts', async () => {
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | Existing | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | Existing | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |
+| 2 | New | fact | 1.0 | world | medium | 2026-01-01 |  | s |  |`,
+    ));
+
+    const r = await runExtractFacts(engine, { slugs: ['people/alice'] });
+    expect(r.factsInserted).toBe(1);
+    expect(r.factsDeleted).toBe(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY row_num`,
+    );
+    expect(rows.rows.map((row: { fact: string }) => row.fact)).toEqual(['Existing', 'New']);
   });
 
   test('removed-from-fence row is deleted from DB (wipe-and-reinsert pattern)', async () => {


### PR DESCRIPTION
## Summary

Re-running a `gbrain dream` cycle on unchanged content no longer accumulates duplicate facts. The `extract_facts` phase in `src/core/cycle/extract-facts.ts` now de-duplicates extracted facts against existing fence rows by the canonical `(claim, source)` content key before appending or calling `engine.insertFacts(...)`, so a no-change cycle is a no-op.

## Why this matters

Issue #1781 reported that on a Postgres-engine brain the `extract_facts` phase was non-idempotent: each cycle re-inserted the same facts and re-appended byte-identical `## Facts` fence rows, growing roughly linearly with the run count (the reporter saw total=4360 / distinct=929 / dupes=3431, with one entity page carrying ~85 identical fenced rows of the same claim). `gbrain sync` alone did not duplicate, and `consolidate` did not recover the duplicates. The row-level dedup key `(claim, source)` used by `upsertFactRow` was not applied on the `extract_facts` write path; `dedupeFactsByContentKey` and `factContentKey` in `extract-facts.ts` now apply it, and the existing empty-fence guard and legacy NULL-source pre-check are preserved.

## Testing

Covered by the new cases in `test/extract-facts-phase.test.ts`: extracting twice on an unchanged page inserts 0 the second time, same-claim-different-source is not treated as a duplicate, a legitimately new fact is inserted exactly once, and the empty-fence / legacy-row guards still short-circuit. Full suite runs in CI.

Fixes #1781
