### PR TITLE
fix: merge parent page_types through schema-pack extends/borrow_from chain

### DIFF
--- a/src/core/schema-pack/registry.ts
+++ b/src/core/schema-pack/registry.ts
@@ -52,7 +52,7 @@
 //     inside the registry.
 
 import { statSync } from 'node:fs';
-import type { SchemaPackManifest } from './manifest-v1.ts';
+import type { PackPageType, SchemaPackManifest } from './manifest-v1.ts';
 import { computeManifestSha8, packIdentity } from './manifest-v1.ts';
 import { computeAliasClosureHash, buildAliasGraph, type AliasGraph } from './closure.ts';
 
@@ -177,6 +177,47 @@ function snapshotMatches(files: ReadonlyArray<{ path: string; mtimeMs: number }>
   return true;
 }
 
+function mergePageTypesInto(byName: Map<string, PackPageType>, pageTypes: ReadonlyArray<PackPageType>): void {
+  for (const pageType of pageTypes) byName.set(pageType.name, pageType);
+}
+
+async function borrowedPageTypes(
+  manifest: SchemaPackManifest,
+  loadByName: (name: string) => Promise<SchemaPackManifest>,
+  opts: {
+    onDepthWarn?: (depth: number, chain: string[]) => void;
+    loadByPath?: (name: string) => string | null;
+  },
+): Promise<PackPageType[]> {
+  const out: PackPageType[] = [];
+  for (const entry of manifest.borrow_from ?? []) {
+    const borrowedManifest = await loadByName(entry.pack);
+    const resolvedBorrowed = await resolvePack(borrowedManifest, loadByName, opts);
+    const typeFilter = entry.types ? new Set(entry.types) : null;
+    for (const pageType of resolvedBorrowed.manifest.page_types) {
+      if (typeFilter && !typeFilter.has(pageType.name)) continue;
+      out.push(pageType);
+    }
+  }
+  return out;
+}
+
+async function mergeResolvedPageTypes(
+  manifestsLeafToRoot: ReadonlyArray<SchemaPackManifest>,
+  loadByName: (name: string) => Promise<SchemaPackManifest>,
+  opts: {
+    onDepthWarn?: (depth: number, chain: string[]) => void;
+    loadByPath?: (name: string) => string | null;
+  },
+): Promise<PackPageType[]> {
+  const byName = new Map<string, PackPageType>();
+  for (const layer of [...manifestsLeafToRoot].reverse()) {
+    mergePageTypesInto(byName, await borrowedPageTypes(layer, loadByName, opts));
+    mergePageTypesInto(byName, layer.page_types);
+  }
+  return [...byName.values()];
+}
+
 /**
  * Walk the reverse extends-graph: every cached entry whose `chain`
  * contains `name`. The set is unbounded in principle but bounded in
@@ -258,6 +299,7 @@ export async function resolvePack(
   // cache snapshot (codex C6 — child cache entry must remember every
   // parent so invalidatePackCache(parentName) can cascade).
   const chain: string[] = [manifest.name];
+  const manifests: SchemaPackManifest[] = [manifest];
   let cursor: SchemaPackManifest | null = manifest;
   while (cursor?.extends) {
     const parentName = cursor.extends;
@@ -272,15 +314,18 @@ export async function resolvePack(
       opts.onDepthWarn?.(chain.length, chain);
     }
     cursor = await loadByName(parentName);
+    manifests.push(cursor);
   }
 
-  // For v0.38 skeleton: closure is computed on the manifest itself.
-  // Full extends-merging (child-wins) is the v0.41+ T20 follow-up.
-  const alias_graph = buildAliasGraph(manifest);
-  const alias_closure_hash = await computeAliasClosureHash(manifest);
+  const resolvedManifest: SchemaPackManifest = {
+    ...manifest,
+    page_types: await mergeResolvedPageTypes(manifests, loadByName, opts),
+  };
+  const alias_graph = buildAliasGraph(resolvedManifest);
+  const alias_closure_hash = await computeAliasClosureHash(resolvedManifest);
 
   const resolved: ResolvedPack = {
-    manifest,
+    manifest: resolvedManifest,
     identity: id,
     manifest_sha8: sha8,
     alias_closure_hash,

--- a/test/schema-pack-registry.test.ts
+++ b/test/schema-pack-registry.test.ts
@@ -18,7 +18,29 @@ import {
 import type { SchemaPackManifest } from '../src/core/schema-pack/manifest-v1.ts';
 import { SCHEMA_PACK_API_VERSION } from '../src/core/schema-pack/manifest-v1.ts';
 
-function makeManifest(name: string, extendsName: string | null = null): SchemaPackManifest {
+function makePageType(
+  name: string,
+  opts: Partial<SchemaPackManifest['page_types'][number]> = {},
+): SchemaPackManifest['page_types'][number] {
+  return {
+    name,
+    primitive: 'concept',
+    path_prefixes: [`${name}/`],
+    aliases: [],
+    extractable: false,
+    expert_routing: false,
+    ...opts,
+  };
+}
+
+function makeManifest(
+  name: string,
+  extendsName: string | null = null,
+  opts: {
+    borrowFrom?: SchemaPackManifest['borrow_from'];
+    pageTypes?: SchemaPackManifest['page_types'];
+  } = {},
+): SchemaPackManifest {
   return {
     api_version: SCHEMA_PACK_API_VERSION,
     name,
@@ -26,8 +48,8 @@ function makeManifest(name: string, extendsName: string | null = null): SchemaPa
     description: '',
     gbrain_min_version: '0.38.0',
     extends: extendsName,
-    borrow_from: [],
-    page_types: [],
+    borrow_from: opts.borrowFrom ?? [],
+    page_types: opts.pageTypes ?? [],
     link_types: [],
     frontmatter_links: [],
     takes_kinds: ['fact', 'take', 'bet', 'hunch'],
@@ -76,6 +98,158 @@ describe('resolvePack — happy path', () => {
     const ra = await resolvePack(a, noop);
     const rb = await resolvePack(b, noop);
     expect(ra.identity).not.toBe(rb.identity);
+  });
+});
+
+describe('resolvePack — page type inheritance', () => {
+  test('gbrain-investor shape inherits gbrain-base page types plus its own additions', async () => {
+    const baseTypeNames = [
+      'writing',
+      'analysis',
+      'guide',
+      'hardware',
+      'architecture',
+      'concept',
+      'person',
+      'company',
+      'deal',
+      'yc',
+      'civic',
+      'project',
+      'source',
+      'media',
+      'email',
+      'slack',
+      'calendar-event',
+      'note',
+      'meeting',
+      'conversation',
+      'atom',
+      'code',
+      'image',
+      'synthesis',
+      'extract_receipt',
+    ];
+    expect(baseTypeNames).toHaveLength(25);
+
+    const base = makeManifest('gbrain-base', null, {
+      pageTypes: baseTypeNames.map((name) => makePageType(name)),
+    });
+    const investor = makeManifest('gbrain-investor', 'gbrain-base', {
+      pageTypes: [
+        makePageType('thesis'),
+        makePageType('bet_resolution_log'),
+      ],
+    });
+
+    const resolved = await resolvePack(investor, chainLoader({ 'gbrain-base': base }));
+    const names = resolved.manifest.page_types.map((pt) => pt.name);
+    expect(names).toHaveLength(27);
+    expect(names).toContain('person');
+    expect(names).toContain('thesis');
+    expect(names).toContain('bet_resolution_log');
+  });
+
+  test('child page type overrides parent type with the same name', async () => {
+    const parent = makeManifest('parent', null, {
+      pageTypes: [
+        makePageType('person', {
+          primitive: 'entity',
+          path_prefixes: ['people/'],
+          expert_routing: true,
+        }),
+        makePageType('company', { primitive: 'entity' }),
+      ],
+    });
+    const child = makeManifest('child', 'parent', {
+      pageTypes: [
+        makePageType('person', {
+          primitive: 'concept',
+          path_prefixes: ['humans/'],
+          expert_routing: false,
+        }),
+      ],
+    });
+
+    const resolved = await resolvePack(child, chainLoader({ parent }));
+    const people = resolved.manifest.page_types.filter((pt) => pt.name === 'person');
+    expect(people).toHaveLength(1);
+    expect(people[0].path_prefixes).toEqual(['humans/']);
+    expect(people[0].primitive).toBe('concept');
+    expect(people[0].expert_routing).toBe(false);
+    expect(resolved.manifest.page_types.map((pt) => pt.name)).toContain('company');
+  });
+
+  test('multi-level extends chain merges each level once and selected borrow_from types', async () => {
+    const base = makeManifest('gbrain-base', null, {
+      pageTypes: [
+        makePageType('person', { primitive: 'entity' }),
+        makePageType('company', { primitive: 'entity' }),
+        makePageType('deal', { primitive: 'temporal' }),
+        makePageType('atom', { primitive: 'annotation', path_prefixes: ['base-atoms/'] }),
+      ],
+    });
+    const investor = makeManifest('gbrain-investor', 'gbrain-base', {
+      pageTypes: [
+        makePageType('thesis'),
+        makePageType('bet_resolution_log', { primitive: 'temporal' }),
+      ],
+    });
+    const creator = makeManifest('gbrain-creator', 'gbrain-base', {
+      pageTypes: [
+        makePageType('atom', { primitive: 'concept', path_prefixes: ['creator-atoms/'] }),
+      ],
+    });
+    const engineer = makeManifest('gbrain-engineer', 'gbrain-base', {
+      pageTypes: [
+        makePageType('learning', { primitive: 'annotation' }),
+      ],
+    });
+    const everything = makeManifest('gbrain-everything', 'gbrain-investor', {
+      borrowFrom: [
+        { pack: 'gbrain-creator', types: ['atom'] },
+        { pack: 'gbrain-engineer', types: ['learning'] },
+      ],
+    });
+
+    const resolved = await resolvePack(
+      everything,
+      chainLoader({
+        'gbrain-base': base,
+        'gbrain-investor': investor,
+        'gbrain-creator': creator,
+        'gbrain-engineer': engineer,
+      }),
+    );
+
+    const names = resolved.manifest.page_types.map((pt) => pt.name);
+    expect(names).toHaveLength(7);
+    expect(new Set(names).size).toBe(7);
+    expect(names).toEqual(expect.arrayContaining([
+      'person',
+      'company',
+      'deal',
+      'thesis',
+      'bet_resolution_log',
+      'atom',
+      'learning',
+    ]));
+    const atom = resolved.manifest.page_types.find((pt) => pt.name === 'atom');
+    expect(atom?.path_prefixes).toEqual(['creator-atoms/']);
+  });
+
+  test('extends:null packs resolve to exactly their inline page types', async () => {
+    const base = makeManifest('gbrain-base', null, {
+      pageTypes: [
+        makePageType('person'),
+        makePageType('company'),
+      ],
+    });
+
+    const resolved = await resolvePack(base, async () => {
+      throw new Error('loader should not be called');
+    });
+    expect(resolved.manifest.page_types).toEqual(base.page_types);
   });
 });
 


### PR DESCRIPTION
## Summary
Activating an `extends`-based schema pack now inherits the parent chain's page types instead of dropping them. `resolvePack` in `src/core/schema-pack/registry.ts` merges `page_types` across the resolved extends chain (and `borrow_from` entries), so `gbrain-investor` resolves to 27 types (the 25 from `gbrain-base` plus its 2 own) rather than 2.

## Why this matters
Issue #1749 reports that every `extends`-based pack (`gbrain-investor`, `gbrain-recommended`, `gbrain-everything`) strips the taxonomy to its own declared types because `resolvePack` walked the extends chain only for the depth cap and cache snapshot, then built the resolved pack from its own `page_types`. `gbrain-recommended` and `gbrain-everything` collapsed to 0 types and `gbrain schema explain person` returned "not in active pack".

## Testing
- `test/schema-pack-registry.test.ts` asserts `gbrain-investor` resolves to 27 types and that a child redefining a parent type name (`person`) overrides rather than duplicates.
- A multi-level chain (`everything` -> `investor` -> `base`) merges each level once and respects the depth cap; `extends: null` packs still resolve to exactly their inline types.

Fixes #1749
