### PR TITLE
chore(skills): remove deprecated install/ skill directory

### DIFF
--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -1,9 +1,0 @@
-# Install GBrain (Deprecated)
-
-This skill has been replaced by the **setup** skill. See `skills/setup/SKILL.md`.
-
-The setup skill provides:
-- Auto-provision Supabase via CLI (< 2 min TTHW)
-- Manual fallback with non-interactive init
-- AGENTS.md auto-injection (upgrade-safe)
-- First import and health verification


### PR DESCRIPTION
## What

Removes the deprecated `skills/install/` directory.

## Why

`skills/install/SKILL.md` is only a deprecation note pointing users at the `setup` skill. It has no frontmatter, is not listed in `manifest.json`, and is already skipped by `loadSkillTriggerIndex`. This matches the open item in `TODOS.md`:

> **remove the deprecated `install/` skill directory entirely.** It has no SKILL.md (just a deprecation note pointing at setup/) and is correctly skipped by `loadSkillTriggerIndex`. Removing the directory cleans up the bundled skill tree.

## Safety / no functional change

- `getSkillDirs()` in `test/skills-conformance.test.ts` reads `skills/` dynamically and already filters out `install`; after this removal that `name !== "install"` filter is a harmless no-op (left in place to keep the diff minimal — happy to drop it too if you prefer).
- `skill-trigger-index.test.ts` builds its own temporary `install` fixtures, so it is unaffected.
- Not referenced by `manifest.json` or `RESOLVER.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)