### PR TITLE
fix(doctor): resolve Windows storage paths under WSL

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -41,6 +41,7 @@ import { lagFromContentMs } from '../core/source-health.ts';
 import { CHUNKER_VERSION } from '../core/chunkers/code.ts';
 import { LINK_EXTRACTOR_VERSION_TS } from '../core/link-extraction.ts';
 import { isUndefinedColumnError } from '../core/utils.ts';
+import { resolveExistingStoragePath } from '../core/path-resolve.ts';
 // issue #1777: hidden_by_search_policy — count chunked pages withheld from
 // default search by the hard-exclude prefix policy. Reuses the canonical
 // exclude resolver + LIKE escaper + visibility clause so the doctor count can't
@@ -6740,11 +6741,8 @@ export async function buildChecks(
       );
       let vanished = 0;
       const vanishedPaths: string[] = [];
-      const fs = await import('node:fs');
       for (const r of rows) {
-        try {
-          fs.statSync(r.storage_path);
-        } catch {
+        if (resolveExistingStoragePath(r.storage_path) === null) {
           vanished++;
           if (vanishedPaths.length < 5) vanishedPaths.push(r.storage_path);
         }

--- a/src/core/path-resolve.ts
+++ b/src/core/path-resolve.ts
@@ -1,0 +1,41 @@
+import { existsSync } from 'node:fs';
+
+/**
+ * Return candidate filesystem paths for a persisted storage path.
+ *
+ * A brain may index paths from a Windows host, for example
+ * `D:/vault/image.jpg`, while doctor later runs inside WSL. In that runtime
+ * Node cannot stat the literal drive path, but the same file is available via
+ * `/mnt/d/...`. Keep the database value unchanged and resolve only when doing
+ * filesystem health checks.
+ */
+export function storagePathCandidates(storagePath: string, platform = process.platform): string[] {
+  const candidates = [storagePath];
+  const slash = String.fromCharCode(92);
+  const drive = storagePath.charAt(0).toLowerCase();
+  const hasWindowsDrive =
+    storagePath.length > 2 &&
+    storagePath.charAt(1) === ':' &&
+    drive >= 'a' &&
+    drive <= 'z';
+
+  if (hasWindowsDrive && platform !== 'win32') {
+    let rest = storagePath.slice(2);
+    while (rest.startsWith('/') || rest.startsWith(slash)) rest = rest.slice(1);
+    rest = rest.split(slash).join('/');
+    candidates.push(`/mnt/${drive}/${rest}`);
+  }
+
+  return Array.from(new Set(candidates));
+}
+
+export function resolveExistingStoragePath(storagePath: string): string | null {
+  for (const candidate of storagePathCandidates(storagePath)) {
+    try {
+      if (existsSync(candidate)) return candidate;
+    } catch {
+      // Continue to the next platform-specific candidate.
+    }
+  }
+  return null;
+}

--- a/test/path-resolve.test.ts
+++ b/test/path-resolve.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { storagePathCandidates } from '../src/core/path-resolve.ts';
+
+describe('storagePathCandidates', () => {
+  test('adds WSL mount candidate for Windows drive paths on non-Windows platforms', () => {
+    expect(storagePathCandidates('D:/vault/image.jpg', 'linux')).toEqual([
+      'D:/vault/image.jpg',
+      '/mnt/d/vault/image.jpg',
+    ]);
+    expect(storagePathCandidates('D:\\vault\\nested image.jpg', 'linux')).toEqual([
+      'D:\\vault\\nested image.jpg',
+      '/mnt/d/vault/nested image.jpg',
+    ]);
+  });
+
+  test('does not add WSL candidates on Windows', () => {
+    expect(storagePathCandidates('D:/vault/image.jpg', 'win32')).toEqual(['D:/vault/image.jpg']);
+  });
+
+  test('leaves native paths unchanged', () => {
+    expect(storagePathCandidates('/mnt/d/vault/image.jpg', 'linux')).toEqual(['/mnt/d/vault/image.jpg']);
+    expect(storagePathCandidates('relative/image.jpg', 'linux')).toEqual(['relative/image.jpg']);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a small storage-path resolver for persisted Windows drive paths when doctor runs on non-Windows hosts such as WSL.
- Use that resolver in the `image_assets` doctor check instead of directly statting the persisted path.
- Add candidate-generation unit coverage for Windows drive paths, Windows runtime behavior, and native paths.

## Why
A brain can index images from a Windows host as paths like `D:/vault/image.jpg`. When `gbrain doctor` later runs under WSL, Node cannot stat that literal path even though the file exists at `/mnt/d/vault/image.jpg`. The previous `image_assets` check therefore reported all indexed images as missing and suggested `gbrain sync --skip-failed`, even though no asset was actually missing.

## Validation
- Local function smoke check:
  - `storagePathCandidates("D:/vault/image.jpg", "linux")` -> `["D:/vault/image.jpg", "/mnt/d/vault/image.jpg"]`
- Local live doctor against a WSL/Windows vault:
  - `image_assets`: `ok`, `248 image(s) all present on disk`
- `git diff --check` passed.

Note: this local WSL machine has a Bun 1.3.14 runner crash unrelated to this patch (`panic(main thread): Segmentation fault at address 0x0`) when invoking `bun test`; the included test is pure and should run under CI.
