### PR TITLE
fix(jobs): backlinks worker defaults to check, not fix

### DIFF
--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1538,7 +1538,13 @@ export async function registerBuiltinHandlers(
 
   worker.register('backlinks', async (job) => {
     const { runBacklinksCore } = await import('./backlinks.ts');
-    const action: 'check' | 'fix' = job.data.action === 'check' ? 'check' : 'fix';
+    // Default to 'check', not 'fix': backlinks jobs submitted with an empty
+    // payload (e.g. the sync→embed→backlinks chains enqueued after ingestion)
+    // must never rewrite tracked brain pages with generated "Referenced in"
+    // timeline bullets. Mirrors the documented intent in src/core/cycle.ts
+    // (runPhaseBacklinks). The filesystem fixer stays available explicitly
+    // via '{"action":"fix"}' or `gbrain check-backlinks fix`.
+    const action: 'check' | 'fix' = job.data.action === 'fix' ? 'fix' : 'check';
     const dir = typeof job.data.dir === 'string'
       ? job.data.dir
       : (await engine.getConfig('sync.repo_path')) ?? '.';

--- a/test/backlinks-job-default.test.ts
+++ b/test/backlinks-job-default.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Structural regression for the backlinks Minion handler default.
+ *
+ * Backlinks jobs submitted with an EMPTY payload (the sync→embed→backlinks
+ * chains enqueued after every ingestion) must run as 'check', never 'fix'.
+ * The pre-fix handler inverted the default (`=== 'check' ? 'check' : 'fix'`),
+ * so every routine post-ingestion job rewrote tracked brain pages with
+ * generated "Referenced in" timeline bullets — contradicting the documented
+ * intent in src/core/cycle.ts (runPhaseBacklinks): "Maintenance cycles must
+ * not rewrite tracked brain pages with generated 'Referenced in' timeline
+ * bullets."
+ *
+ * Source-grep is the right tool here (see fix-wave-structural.test.ts): the
+ * handler dynamically imports runBacklinksCore and walks a real repo dir, so
+ * a behavioral test would require heavy mocking that hides the regression
+ * behind a test seam. The rule is "this specific default must stay 'check'".
+ */
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+
+describe('backlinks Minion handler — empty payload defaults to check, not fix', () => {
+  const src = readFileSync('src/commands/jobs.ts', 'utf8');
+
+  // Isolate the backlinks register block so assertions can't accidentally
+  // match another handler's action parsing.
+  const blockMatch = src.match(
+    /worker\.register\('backlinks',[\s\S]*?runBacklinksCore\(\{[\s\S]*?\}\);/
+  );
+
+  test('the backlinks handler block exists', () => {
+    expect(blockMatch).not.toBeNull();
+  });
+
+  test("default action is 'check' (explicit opt-in required for 'fix')", () => {
+    const block = blockMatch![0];
+    expect(block).toMatch(
+      /job\.data\.action\s*===\s*'fix'\s*\?\s*'fix'\s*:\s*'check'/
+    );
+  });
+
+  test('the inverted (fix-by-default) shape stays absent', () => {
+    const block = blockMatch![0];
+    expect(block).not.toMatch(
+      /job\.data\.action\s*===\s*'check'\s*\?\s*'check'\s*:\s*'fix'/
+    );
+  });
+});


### PR DESCRIPTION
## What

  Backlinks Minion jobs submitted with an **empty payload** — the
  sync→embed→backlinks chains enqueued after every ingestion — default to
  `action='fix'` and rewrite tracked brain pages with generated
  "Referenced in" timeline bullets on every routine run. On our production
  brain this silently polluted 129 vault files in a single day before we
  traced it back to the handler.

  ## Why this is a bug, not a behavior choice

  `src/core/cycle.ts` (runPhaseBacklinks) documents the exact opposite
  intent:

  > Maintenance cycles must not rewrite tracked brain pages with generated
  > "Referenced in" timeline bullets. [...] the legacy filesystem fixer
  > remains available explicitly via `gbrain check-backlinks fix`.

  The jobs-worker handler simply inverts that default
  (`=== 'check' ? 'check' : 'fix'`), so any caller that doesn't know to

  ## Fix

  One line: default to `'check'`; `'fix'` requires explicit opt-in via
  `'{"action":"fix"}'` (the submit shape already documented in the jobs
  help text) or `gbrain check-backlinks fix`. Both explicit paths are
  unchanged.

  ## Tests

  Adds `test/backlinks-job-default.test.ts`, a structural regression
  pinning the default (fix-wave-structural.test.ts precedent): the handler
  dynamically imports `runBacklinksCore` and walks a real repo dir, so a
  behavioral test would need mocking that hides the regression behind a
  test seam. `bun test test/backlinks-job-default.test.ts
  test/handlers.test.ts` → 11 pass / 0 fail; `bun run typecheck` clean.

  Verified in production: post-fix, an empty-payload backlinks job on a
  ~1200-page brain returns `{"action":"check","fixed":0,"gaps_found":3243,
  "pages_affected":130}` — 130 pages it would previously have rewritten.