### PR TITLE
fix: 5 Ollama compatibility fixes for local-first usage

### DIFF
--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -21,6 +21,20 @@ export const ollama: Recipe = {
       // OLLAMA_NUM_PARALLEL config; no static cap to declare. v0.32 (#779).
       no_batch_cap: true,
     },
+    chat: {
+      models: ['llama3.3', 'qwen3', 'deepseek-r1'],
+      supports_tools: true,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      cost_per_1m_input_usd: 0,
+      cost_per_1m_output_usd: 0,
+      price_last_verified: '2026-06-02',
+    },
+    expansion: {
+      models: ['llama3.3', 'qwen3', 'deepseek-r1'],
+      cost_per_1m_tokens_usd: 0,
+      price_last_verified: '2026-06-02',
+    },
   },
   setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` and `ollama serve`.',
 };

--- a/src/core/brainstorm/judges.ts
+++ b/src/core/brainstorm/judges.ts
@@ -361,6 +361,11 @@ function isAxisScoreInRange(n: unknown): n is number {
 function validateIdeaShape(raw: unknown): { id: string; scores: JudgeAxisScores; note: string } | null {
   if (typeof raw !== 'object' || raw === null) return null;
   const r = raw as Record<string, unknown>;
+  // Some models (e.g. Kimi K2) return numeric ids instead of string ids like "Idea 01".
+  // Coerce to string for compatibility.
+  if (typeof r.id === 'number') {
+    r.id = 'Idea ' + String(r.id).padStart(2, '0');
+  }
   if (typeof r.id !== 'string') return null;
   const note = typeof r.note === 'string' ? r.note : '';
   const s = r.scores;

--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -156,6 +156,20 @@ const FREE_LOCAL_EMBED_PROVIDERS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Provider id prefixes whose chat models run on local inference (electricity,
+ * not API tokens) and so price at $0. Without this, a `--max-cost`-bounded
+ * brainstorm/lsd configured for a local chat provider TX2 hard-fails because
+ * lookupPricing has no entry for them. Matched against the provider half
+ * of the `provider:model` string.
+ *
+ * Sibling to FREE_LOCAL_EMBED_PROVIDERS and FREE_LOCAL_RERANK_PROVIDERS.
+ */
+const FREE_LOCAL_CHAT_PROVIDERS: ReadonlySet<string> = new Set([
+  'ollama',
+  'llama-server',
+]);
+
+/**
  * Look up `modelId` in the chat or embedding pricing maps. Returns a
  * per-1M-token price tuple, or null when unknown.
  *
@@ -199,6 +213,9 @@ function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
   // under `--max-cost`. Only the rerank kind — chat/embed already have
   // their own provider-specific pricing surfaces.
   if (kind === 'rerank' && providerId && FREE_LOCAL_RERANK_PROVIDERS.has(providerId)) {
+    return { input: 0, output: 0 };
+  }
+  if (kind === 'chat' && providerId && FREE_LOCAL_CHAT_PROVIDERS.has(providerId)) {
     return { input: 0, output: 0 };
   }
   return null;

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -26,7 +26,7 @@ import { resolveCitations, type ParsedCitation } from './cite-render.ts';
 import { resolveModel } from '../model-config.ts';
 import { chat as gatewayChat, probeChatModel, type ChatResult } from '../ai/gateway.ts';
 import { AIConfigError } from '../ai/errors.ts';
-import { normalizeModelId } from '../model-id.ts';
+import { normalizeModelId, splitProviderModelId } from '../model-id.ts';
 import { hasAnthropicKey } from '../ai/anthropic-key.ts';
 
 /** Anthropic Messages client interface — same shape used by subagent.ts so test stubs can be shared. */
@@ -439,7 +439,9 @@ export async function runThink(
     // Closes #952 (think over MCP returns "no LLM available").
     const client = opts.client ?? await tryBuildGatewayClient(modelUsed, { explicitModel: opts.modelExplicit });
     if (!client) {
-      warnings.push('NO_ANTHROPIC_API_KEY');
+      // Warnings about API keys are now handled per-provider in gateway
+      const providerId = splitProviderModelId(modelUsed).provider;
+      if (providerId === 'anthropic') warnings.push('NO_ANTHROPIC_API_KEY');
       // Degrade gracefully: return the gather without synthesis. Better than throwing.
       return {
         question: opts.question,
@@ -748,7 +750,7 @@ function buildGracefulMessage(modelStr: string): {
     type: 'message',
     role: 'assistant',
     model: modelStr,
-    content: [{ type: 'text', text: '(no LLM available — set anthropic_api_key via gbrain config or ANTHROPIC_API_KEY env)' }],
+    content: [{ type: 'text', text: '(no LLM available — set chat_model, expansion_model, or anthropic_api_key via gbrain config)' }],
     usage: { input_tokens: 0, output_tokens: 0 },
     stop_reason: 'end_turn',
   };


### PR DESCRIPTION
## Problem

Several features break when using Ollama or other local inference providers instead of Anthropic:

1. **`--max-cost` hard-fails for brainstorm/lsd**: `lookupPricing` returns `null` for local chat providers (Ollama, llama-server), causing budget-gated operations to fail even though the user explicitly configured a free local provider.

2. **Numeric idea IDs crash brainstorm judges**: Some models (e.g. Kimi K2 via Ollama) return numeric `id` fields in idea JSON instead of the expected string format like `"Idea 01"`, causing validation to silently reject all ideas.

3. **False `NO_ANTHROPIC_API_KEY` warning**: The warning fires even when the user has Ollama or OpenRouter configured — it's only relevant for the Anthropic provider.

4. **Unhelpful "no LLM available" message**: The error message only mentions `anthropic_api_key`, not the other config options (`chat_model`, `expansion_model`) that are the correct way to configure non-Anthropic providers.

5. **Ollama recipe missing chat/expansion touchpoints**: The Ollama recipe only defines embedding touchpoints. Without chat and expansion, the recipe system cannot route reasoning calls to Ollama, and `supports_tools` is not declared.

## Solution

1. Add `FREE_LOCAL_CHAT_PROVIDERS` set (parallel to existing `FREE_LOCAL_EMBED_PROVIDERS`) — returns zero pricing for local chat providers, fixing `--max-cost` budget checks.

2. Coerce numeric `id` to string format (`5` → `"Idea 05"`) in `validateIdeaShape` before the string type check.

3. Scope `NO_ANTHROPIC_API_KEY` warning to only fire when `providerId === 'anthropic'`.

4. Update "no LLM available" message to mention `chat_model`, `expansion_model`, or `anthropic_api_key`.

5. Add `chat` and `expansion` touchpoints to the Ollama recipe with generic models (`llama3.3`, `qwen3`, `deepseek-r1`), `supports_tools: true`, and zero cost.

## Testing

- TypeScript compiles cleanly (`tsc --noEmit` passes)
- No debug/temporary code included
- Backward compatible — all changes are additive; existing defaults unchanged

## Related Issues

Related to #1307 (hardcoded Anthropic model in brainstorm)
Related to #1779 (configurable reasoning/expansion LLM via recipes)