### PR TITLE
fix: make cycle/brainstorm model assignment configurable via config

### DIFF
--- a/src/commands/brainstorm.ts
+++ b/src/commands/brainstorm.ts
@@ -273,7 +273,7 @@ async function runBrainstormCli(
       maxCostUsd: parsed.maxCost,
       maxFarSet: parsed.maxFarSet,
       strictBudget: parsed.strictBudget,
-      judgeModel: parsed.judgeModel,
+      judgeModel: parsed.judgeModel || (config as any)?.models?.brainstorm?.judge || undefined,
       maxIdeasPerJudgeCall: parsed.maxIdeasPerJudgeCall,
       resumeRunId: parsed.resume,
       forceResume: parsed.forceResume,

--- a/src/core/brainstorm/orchestrator.ts
+++ b/src/core/brainstorm/orchestrator.ts
@@ -499,7 +499,7 @@ const DEFAULT_PARALLELISM = 4;
  */
 export async function runBrainstorm(
   engine: BrainEngine,
-  config: { embedding_model?: string; emotional_weight?: { user_holder?: string } },
+  config: { embedding_model?: string; chat_model?: string; emotional_weight?: { user_holder?: string } },
   opts: BrainstormOptions
 ): Promise<BrainstormResult> {
   // v0.39.3.0 (Phase 5, CV11+T4): outer try/catch around the orchestrator
@@ -521,7 +521,7 @@ export async function runBrainstorm(
 
 async function runBrainstormImpl(
   engine: BrainEngine,
-  config: { embedding_model?: string; emotional_weight?: { user_holder?: string } },
+  config: { embedding_model?: string; chat_model?: string; emotional_weight?: { user_holder?: string } },
   opts: BrainstormOptions,
 ): Promise<BrainstormResult> {
   // v0.39.0.0 T10: install a gateway-layer BudgetTracker scope around the
@@ -541,7 +541,7 @@ async function runBrainstormImpl(
 
 async function _runBrainstormInner(
   engine: BrainEngine,
-  config: { embedding_model?: string; emotional_weight?: { user_holder?: string } },
+  config: { embedding_model?: string; chat_model?: string; emotional_weight?: { user_holder?: string } },
   opts: BrainstormOptions,
 ): Promise<BrainstormResult> {
   const profile = opts.profile ?? BRAINSTORM_PROFILE;
@@ -550,7 +550,7 @@ async function _runBrainstormInner(
   const embedFn = opts.embedQueryFn ?? embedQuery;
 
   // ---- Phase 0: cost preview + TTY grace ----
-  const modelStr = opts.modelOverride ?? 'anthropic:claude-sonnet-4-6';
+  const modelStr = opts.modelOverride ?? config.chat_model ?? 'anthropic:claude-sonnet-4-6';
   const { aborted, estimate } = await previewCostAndWait({
     profile,
     model: modelStr,

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -1902,6 +1902,8 @@ export async function runCycle(
       if (engine) {
         const cfgMod = await import('./config.ts');
         const calibrationConfig = cfgMod.loadConfig() ?? ({} as ReturnType<typeof cfgMod.loadConfig> & object);
+        const calibrationExpansionModel = (calibrationConfig as any)?.expansion_model ?? undefined;
+        const calibrationJudgeModel = (calibrationConfig as any)?.models?.brainstorm?.judge ?? calibrationExpansionModel;
         const calibrationSourceId = cycleSourceId;
         const calibrationCtx = {
           engine,
@@ -1916,7 +1918,7 @@ export async function runCycle(
           checkAborted(opts.signal);
           progress.start('cycle.propose_takes');
           const { runPhaseProposeTakes } = await import('./cycle/propose-takes.ts');
-          const { result, duration_ms } = await timePhase(() => runPhaseProposeTakes(calibrationCtx, { repoPath: brainDir ?? undefined }) as Promise<PhaseResult>);
+          const { result, duration_ms } = await timePhase(() => runPhaseProposeTakes(calibrationCtx, { repoPath: brainDir ?? undefined, model: calibrationExpansionModel }) as Promise<PhaseResult>);
           result.duration_ms = duration_ms;
           phaseResults.push(result);
           progress.finish();
@@ -1927,7 +1929,7 @@ export async function runCycle(
           checkAborted(opts.signal);
           progress.start('cycle.grade_takes');
           const { runPhaseGradeTakes } = await import('./cycle/grade-takes.ts');
-          const { result, duration_ms } = await timePhase(() => runPhaseGradeTakes(calibrationCtx, {}) as Promise<PhaseResult>);
+          const { result, duration_ms } = await timePhase(() => runPhaseGradeTakes(calibrationCtx, { model: calibrationJudgeModel }) as Promise<PhaseResult>);
           result.duration_ms = duration_ms;
           phaseResults.push(result);
           progress.finish();
@@ -1938,7 +1940,7 @@ export async function runCycle(
           checkAborted(opts.signal);
           progress.start('cycle.calibration_profile');
           const { runPhaseCalibrationProfile } = await import('./cycle/calibration-profile.ts');
-          const { result, duration_ms } = await timePhase(() => runPhaseCalibrationProfile(calibrationCtx, {}) as Promise<PhaseResult>);
+          const { result, duration_ms } = await timePhase(() => runPhaseCalibrationProfile(calibrationCtx, { model: calibrationExpansionModel }) as Promise<PhaseResult>);
           result.duration_ms = duration_ms;
           phaseResults.push(result);
           progress.finish();

--- a/src/core/cycle/calibration-profile.ts
+++ b/src/core/cycle/calibration-profile.ts
@@ -228,7 +228,7 @@ class CalibrationProfilePhase extends BaseCyclePhase {
   ): Promise<{ summary: string; details: Record<string, unknown>; status?: PhaseStatus }> {
     const holder = opts.holder ?? 'garry';
     const promptVersion = opts.promptVersion ?? CALIBRATION_PROFILE_PROMPT_VERSION;
-    const modelId = opts.model ?? 'claude-sonnet-4-6';
+    const modelId = opts.model ?? 'claude-sonnet-4-6'; // resolved from config via cycle.ts
     const gradeCompletion = opts.gradeCompletion ?? 1.0;
     const patternsGenerator = opts.patternsGenerator ?? defaultPatternsGenerator;
     const biasTagsGenerator = opts.biasTagsGenerator ?? defaultBiasTagsGenerator;

--- a/src/core/cycle/grade-takes.ts
+++ b/src/core/cycle/grade-takes.ts
@@ -395,7 +395,7 @@ class GradeTakesPhase extends BaseCyclePhase {
     const autoResolve = opts.autoResolve ?? false; // D17 default OFF
     const autoResolveThreshold = opts.autoResolveThreshold ?? 0.95; // D12 conservative
     const resolvedByLabel = opts.resolvedByLabel ?? 'gbrain:grade_takes';
-    const judgeModelId = opts.model ?? 'claude-sonnet-4-6';
+    const judgeModelId = opts.model ?? opts.judgeModel ?? 'claude-sonnet-4-6';
 
     const useEnsemble = opts.useEnsemble ?? false;
     const ensembleThreshold = opts.ensembleThreshold ?? 0.85;

--- a/src/core/cycle/propose-takes.ts
+++ b/src/core/cycle/propose-takes.ts
@@ -359,7 +359,7 @@ class ProposeTakesPhase extends BaseCyclePhase {
 
       // Budget pre-check before the LLM call. Estimate: ~1500 input tokens + 500 output.
       const budget = this.checkBudget({
-        modelId: opts.model ?? 'claude-sonnet-4-6',
+        modelId: opts.model ?? 'claude-sonnet-4-6', // resolved from config via cycle.ts
         estimatedInputTokens: 1500,
         maxOutputTokens: 500,
       });
@@ -408,7 +408,7 @@ class ProposeTakesPhase extends BaseCyclePhase {
             p.weight,
             p.domain ?? null,
             JSON.stringify(existingTakes),
-            opts.model ?? 'claude-sonnet-4-6',
+            opts.model ?? 'claude-sonnet-4-6', // resolved from config via cycle.ts
           ],
         );
         result.proposals_inserted += 1;


### PR DESCRIPTION
## Problem

`gbrain brainstorm` and `gbrain lsd` are hardcoded to `anthropic:claude-sonnet-4-6` as the default model, making them unrunnable without `ANTHROPIC_API_KEY` even when a user has a valid `chat_model` or `expansion_model` configured in their gbrain config.

This is the core issue reported in #1307 and the main blocker for #1779.

## Solution

Make all hardcoded model defaults read from config first, falling back to the existing Anthropic default only when nothing is configured:

- **brainstorm/orchestrator**: `opts.modelOverride ?? config.chat_model ?? 'anthropic:claude-sonnet-4-6'` — uses configured chat model for cross-generation
- **brainstorm CLI**: `parsed.judgeModel || config.models?.brainstorm?.judge || undefined` — reads judge model from config
- **cycle.ts**: extracts `expansion_model` and `models.brainstorm.judge` from config and passes them to `propose_takes`, `grade_takes`, and `calibration_profile` sub-phases
- **grade-takes**: `opts.model ?? opts.judgeModel ?? 'claude-sonnet-4-6'`
- **calibration-profile**: model resolved from `opts.model` (passed by cycle.ts from config)
- **propose-takes**: model resolved from `opts.model` (passed by cycle.ts from config)

No hardcoded model names changed to different hardcoded names — the resolution now flows through config.

## Config keys users can set

```json
{
  "chat_model": "ollama:llama3.3",
  "expansion_model": "ollama:deepseek-r1",
  "models": {
    "brainstorm": {
      "judge": "ollama:qwen3"
    }
  }
}
```

## Testing

- TypeScript compiles cleanly
- Backward compatible — when no config is set, behavior is identical to current code (falls back to Anthropic defaults)
- No debug/temporary code included

Fixes #1307
Related to #1779