### PR TITLE
fix(takes): honor facts.extraction_model in takes extract --from-pages

### DIFF
--- a/src/commands/takes.ts
+++ b/src/commands/takes.ts
@@ -616,7 +616,7 @@ async function cmdExtract(engine: BrainEngine, rest: string[]): Promise<void> {
   }
   if (!dryRun && !skipConfirm) {
     process.stderr.write(
-      `[takes extract] sends concept/atom/lore/briefing/writing/originals page content to Haiku.\n` +
+      `[takes extract] sends concept/atom/lore/briefing/writing/originals page content to the configured facts.extraction_model (Haiku if unset).\n` +
       `Pass --yes to proceed (or --dry-run to preview).\n`,
     );
     process.exit(1);

--- a/src/core/extract-takes-from-pages.ts
+++ b/src/core/extract-takes-from-pages.ts
@@ -126,6 +126,15 @@ export async function extractTakesFromPages(
   const dryRun = opts.dryRun ?? false;
   const maxPages = opts.maxPages ?? 50;
   const holder = opts.holder ?? 'system';
+  // Honor facts.extraction_model (the documented default per the `model?`
+  // JSDoc above) instead of a hardcoded Anthropic id, so a brain configured
+  // for OpenAI doesn't silently require an Anthropic key just for takes
+  // bootstrap. The hardcoded Haiku stays only as the last-resort fallback for
+  // brains that never set facts.extraction_model (backward compatibility).
+  const model =
+    opts.model ??
+    (await engine.getConfig('facts.extraction_model')) ??
+    'anthropic:claude-haiku-4-5';
   const sourceFilter = opts.sourceIdFilter ? `AND source_id = $1` : '';
   const params = opts.sourceIdFilter ? [opts.sourceIdFilter] : [];
 
@@ -174,7 +183,7 @@ export async function extractTakesFromPages(
     let response: { text: string };
     try {
       response = await chat({
-        model: opts.model ?? 'anthropic:claude-haiku-4-5',
+        model,
         system: CLASSIFIER_SYSTEM,
         messages: [
           {


### PR DESCRIPTION
Fixes #1857.

## Problem
`gbrain takes extract --from-pages` returns `0 claim(s) from N page(s)` (no error) on an OpenAI-configured brain with no `ANTHROPIC_API_KEY`, even though the chat gateway is healthy and `facts.extraction_model` is `openai:gpt-4.1-mini`.

The per-page classifier hardcoded the model:

```ts
// src/core/extract-takes-from-pages.ts
model: opts.model ?? 'anthropic:claude-haiku-4-5',
```

but the `model?` JSDoc on `ExtractTakesFromPagesOpts` says it "defaults to `facts.extraction_model`", and neither caller sets `opts.model`:
- `src/commands/takes.ts` `cmdExtract` (the CLI handler)
- `src/commands/jobs.ts` (the `extract-takes-from-pages` Minion handler)

So every run used the hardcoded Anthropic id. With no Anthropic key, each per-page `chat()` threw, got swallowed by the per-page `try/catch`, and produced 0 claims. `llm_unavailable` stayed `false` because the gateway-level `isAvailable('chat')` guard passed against the configured OpenAI model — so nothing was printed.

## Fix
Resolve the model from `facts.extraction_model` inside `extractTakesFromPages` (fixes both callers in one place), keeping `anthropic:claude-haiku-4-5` only as the last-resort fallback for brains that never set the config key — backward compatible:

```ts
const model =
  opts.model ??
  (await engine.getConfig('facts.extraction_model')) ??
  'anthropic:claude-haiku-4-5';
```

Also updates the interactive consent prompt in `cmdExtract`, which hardcoded "Haiku" in its text, to name the configured model instead.

## Behavior change
- Brains with `facts.extraction_model` set (most): takes extraction now uses that model, as documented. (Previously: always Anthropic Haiku.)
- Brains that never set `facts.extraction_model` AND have an Anthropic key: unchanged (fallback is still Haiku).
- OpenAI-only brains: now works instead of silently returning 0 claims.

## Verification
On an OpenAI-only brain (`facts.extraction_model = openai:gpt-4.1-mini`, no `ANTHROPIC_API_KEY`):

```
gbrain takes extract --from-pages --source-id default --max-pages 5 --yes
# before: 0 claim(s) from 5 page(s)
# after:  32 claim(s) from 5 page(s)
```
