### PR TITLE
feat(auth): enforce bound_slug_prefixes on the READ side — per-prefix…

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -344,6 +344,7 @@ interface RegisterClientArgs {
   scopes: string;
   sourceId: string;
   federatedRead: string[] | undefined;
+  boundSlugPrefixes: string[] | undefined;
   redirectUris: string[];
   tokenEndpointAuthMethod: string | undefined;
 }
@@ -354,6 +355,7 @@ export function parseRegisterClientArgs(args: string[]): RegisterClientArgs {
     scopes: 'read',
     sourceId: 'default',
     federatedRead: undefined,
+    boundSlugPrefixes: undefined,
     redirectUris: [],
     tokenEndpointAuthMethod: undefined,
   };
@@ -383,6 +385,14 @@ export function parseRegisterClientArgs(args: string[]): RegisterClientArgs {
         out.federatedRead = v.split(',').map(s => s.trim()).filter(Boolean);
         i += 2; break;
       }
+      case '--bound-slug-prefixes': {
+        // Read+write slug-prefix binding. Glob semantics of
+        // matchesSlugAllowList: `clients/*` = all descendants of clients/,
+        // a bare entry = exactly that slug. Omit for an unrestricted client.
+        const v = requireValue();
+        out.boundSlugPrefixes = v.split(',').map(s => s.trim()).filter(Boolean);
+        i += 2; break;
+      }
       case '--redirect-uri':
         out.redirectUris.push(requireValue());
         i += 2; break;
@@ -405,7 +415,7 @@ export function parseRegisterClientArgs(args: string[]): RegisterClientArgs {
 
 async function registerClient(name: string, args: string[]) {
   if (!name) {
-    console.error('Usage: auth register-client <name> [--grant-types G] [--scopes S] [--source SOURCE] [--federated-read SRC1,SRC2,...] [--redirect-uri URI ...] [--token-endpoint-auth-method client_secret_post|client_secret_basic|none]');
+    console.error('Usage: auth register-client <name> [--grant-types G] [--scopes S] [--source SOURCE] [--federated-read SRC1,SRC2,...] [--bound-slug-prefixes P1,P2,...] [--redirect-uri URI ...] [--token-endpoint-auth-method client_secret_post|client_secret_basic|none]');
     process.exit(1);
   }
   let parsed: RegisterClientArgs;
@@ -413,17 +423,17 @@ async function registerClient(name: string, args: string[]) {
     parsed = parseRegisterClientArgs(args);
   } catch (e: any) {
     console.error(`Error: ${e.message}`);
-    console.error('Usage: auth register-client <name> [--grant-types G] [--scopes S] [--source SOURCE] [--federated-read SRC1,SRC2,...] [--redirect-uri URI ...] [--token-endpoint-auth-method client_secret_post|client_secret_basic|none]');
+    console.error('Usage: auth register-client <name> [--grant-types G] [--scopes S] [--source SOURCE] [--federated-read SRC1,SRC2,...] [--bound-slug-prefixes P1,P2,...] [--redirect-uri URI ...] [--token-endpoint-auth-method client_secret_post|client_secret_basic|none]');
     process.exit(1);
   }
-  const { grantTypes, scopes, sourceId, federatedRead, redirectUris, tokenEndpointAuthMethod } = parsed;
+  const { grantTypes, scopes, sourceId, federatedRead, boundSlugPrefixes, redirectUris, tokenEndpointAuthMethod } = parsed;
 
   try {
     await withConfiguredSql(async (sql) => {
       const { GBrainOAuthProvider } = await import('../core/oauth-provider.ts');
       const provider = new GBrainOAuthProvider({ sql });
       const { clientId, clientSecret } = await provider.registerClientManual(
-        name, grantTypes, scopes, redirectUris, sourceId, federatedRead, tokenEndpointAuthMethod,
+        name, grantTypes, scopes, redirectUris, sourceId, federatedRead, tokenEndpointAuthMethod, boundSlugPrefixes,
       );
       const effectiveFederated = federatedRead && federatedRead.length > 0 ? federatedRead : [sourceId];
       const effectiveAuthMethod = tokenEndpointAuthMethod || 'client_secret_post';
@@ -441,7 +451,8 @@ async function registerClient(name: string, args: string[]) {
         console.log(`  Redirect URIs:       ${redirectUris.join(', ')}`);
       }
       console.log(`  Write source:        ${sourceId}`);
-      console.log(`  Federated reads:     ${effectiveFederated.join(', ')}\n`);
+      console.log(`  Federated reads:     ${effectiveFederated.join(', ')}`);
+      console.log(`  Slug binding:        ${boundSlugPrefixes && boundSlugPrefixes.length > 0 ? boundSlugPrefixes.join(', ') : '<unrestricted>'}\n`);
       if (clientSecret) {
         console.log('Save the client secret — it will not be shown again.');
       } else {
@@ -524,6 +535,7 @@ Usage:
      --scopes "<read write admin>"                         (default: read)
      --source <id>                                         (default: default)
      --federated-read <id1,id2,...>                        (default: [source])
+     --bound-slug-prefixes <clients/*,people/*,...>        (default: unrestricted — confines READ + subagent-write to matching slugs)
      --redirect-uri <https://...>                          (v0.41.3+; repeatable; required for authorization_code)
      --token-endpoint-auth-method <method>                 (v0.41.3+; client_secret_post | client_secret_basic | none;
                                                             'none' = public PKCE-only client, no secret minted)

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -554,24 +554,46 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     // error here — caught at the boundary via isUndefinedColumnError so
     // unmigrated brains degrade to "no source scope" rather than refusing
     // every token verification.
-    let oauthRows: Record<string, unknown>[];
+    let oauthRows: Record<string, unknown>[] | undefined;
     try {
       oauthRows = await this.sql`
         SELECT t.client_id, t.scopes, t.expires_at, t.resource, c.client_name,
-               c.source_id, c.federated_read
+               c.source_id, c.federated_read, c.bound_slug_prefixes
         FROM oauth_tokens t
         LEFT JOIN oauth_clients c ON c.client_id = t.client_id
         WHERE t.token_hash = ${tokenHash} AND t.token_type = 'access'
       `;
     } catch (err) {
       // v0.34.1: pre-v60 brain → source_id column missing. Pre-v61 brain →
-      // federated_read column missing. Both classes degrade to legacy
-      // projection so auth keeps working until the operator runs
-      // apply-migrations. Probe both column names so partial-upgrade brains
-      // (v60 applied but v61 didn't yet) also fall through cleanly.
-      if (isUndefinedColumnError(err, 'source_id') || isUndefinedColumnError(err, 'federated_read')) {
+      // federated_read column missing. Pre-v85 brain → bound_slug_prefixes
+      // column missing. All classes degrade to legacy projection so auth
+      // keeps working until the operator runs apply-migrations. Probe the
+      // column names so partial-upgrade brains (v60 applied but v61 didn't
+      // yet) also fall through cleanly.
+      if (
+        isUndefinedColumnError(err, 'source_id') ||
+        isUndefinedColumnError(err, 'federated_read') ||
+        isUndefinedColumnError(err, 'bound_slug_prefixes')
+      ) {
+        // v61..v84 brain: federated_read exists but bound_slug_prefixes
+        // doesn't yet. Retry WITHOUT the binding column so federated read
+        // scope is preserved on partially-upgraded brains.
+        if (isUndefinedColumnError(err, 'bound_slug_prefixes')) {
+          try {
+            oauthRows = await this.sql`
+              SELECT t.client_id, t.scopes, t.expires_at, t.resource, c.client_name,
+                     c.source_id, c.federated_read
+              FROM oauth_tokens t
+              LEFT JOIN oauth_clients c ON c.client_id = t.client_id
+              WHERE t.token_hash = ${tokenHash} AND t.token_type = 'access'
+            `;
+          } catch {
+            // Older columns missing too — fall through to the chain below.
+            oauthRows = undefined;
+          }
+        }
         // Try the v60-only projection first (source_id but no federated_read).
-        try {
+        if (!oauthRows) try {
           oauthRows = await this.sql`
             SELECT t.client_id, t.scopes, t.expires_at, t.resource, c.client_name, c.source_id
             FROM oauth_tokens t
@@ -596,7 +618,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
       }
     }
 
-    if (oauthRows.length > 0) {
+    if (oauthRows && oauthRows.length > 0) {
       const row = oauthRows[0];
       // NULL expires_at is treated as expired (fail-closed). Schema permits NULL,
       // and the SDK's bearerAuth requires `typeof expiresAt === 'number'` — we
@@ -614,6 +636,14 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
       const allowedSources = Array.isArray(federatedRaw)
         ? (federatedRaw as string[])
         : undefined;
+      // Read-side slug binding (migration v85 column). NULL/undefined =
+      // unrestricted (back-compat: every pre-binding client keeps full
+      // visibility). An array — INCLUDING an empty one — is the binding,
+      // enforced fail-closed by slugScopeOpts in operations.ts.
+      const boundRaw = row.bound_slug_prefixes;
+      const boundSlugPrefixes = Array.isArray(boundRaw)
+        ? (boundRaw as string[])
+        : undefined;
       return {
         token,
         clientId: row.client_id as string,
@@ -629,6 +659,10 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
         // operations.ts prefers this array over scalar sourceId when set
         // and non-empty.
         allowedSources,
+        // Slug-prefix read binding from oauth_clients.bound_slug_prefixes.
+        // slugScopeOpts in operations.ts confines every read-side op to
+        // matching slugs when this is set.
+        boundSlugPrefixes,
       } as AuthInfo;
     }
 
@@ -820,6 +854,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     sourceId: string = 'default',
     federatedRead?: string[],
     tokenEndpointAuthMethod?: string,
+    boundSlugPrefixes?: string[],
   ): Promise<{ clientId: string; clientSecret?: string }> {
     // v0.28: ALLOWED_SCOPES allowlist. Reject `--scopes "read flying-unicorn"`
     // at registration so meaningless scope strings can't pile up in the DB.
@@ -851,20 +886,41 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     //   federated_read = [source_id] when omitted (a non-federated client
     //                    has read scope == write scope, the v0.33 default)
     const federated = federatedRead && federatedRead.length > 0 ? federatedRead : [sourceId];
+    // Read-side slug binding (migration v85 column). NULL = unrestricted —
+    // a client registered without --bound-slug-prefixes keeps full read
+    // visibility (back-compat). A non-empty list confines every read op.
+    const boundPrefixes = boundSlugPrefixes && boundSlugPrefixes.length > 0 ? boundSlugPrefixes : null;
     try {
       await this.sql`
         INSERT INTO oauth_clients (client_id, client_secret_hash, client_name, redirect_uris,
                                     grant_types, scope, token_endpoint_auth_method,
                                     client_id_issued_at,
-                                    source_id, federated_read)
+                                    source_id, federated_read, bound_slug_prefixes)
         VALUES (${clientId}, ${secretHash}, ${name},
                 ${pgArray(redirectUris)}, ${pgArray(grantTypes)}, ${scopes}, ${authMethod}, ${now},
-                ${sourceId}, ${pgArray(federated)})
+                ${sourceId}, ${pgArray(federated)}, ${boundPrefixes ? pgArray(boundPrefixes) : null})
       `;
     } catch (err) {
-      // Pre-v60 / pre-v61 brain: column missing. Fall back through both
-      // projections so registration still works until apply-migrations.
-      if (isUndefinedColumnError(err, 'federated_read')) {
+      // Pre-v60 / pre-v61 / pre-v85 brain: column missing. Fall back through
+      // the projections so registration still works until apply-migrations.
+      if (isUndefinedColumnError(err, 'bound_slug_prefixes')) {
+        if (boundPrefixes) {
+          // Refuse to silently mint an UNBOUND client when the operator
+          // explicitly asked for a binding the schema can't store yet.
+          throw new Error(
+            'bound_slug_prefixes requires schema migration v85 — run `gbrain apply-migrations --yes` first.',
+          );
+        }
+        await this.sql`
+          INSERT INTO oauth_clients (client_id, client_secret_hash, client_name, redirect_uris,
+                                      grant_types, scope, token_endpoint_auth_method,
+                                      client_id_issued_at,
+                                      source_id, federated_read)
+          VALUES (${clientId}, ${secretHash}, ${name},
+                  ${pgArray(redirectUris)}, ${pgArray(grantTypes)}, ${scopes}, ${authMethod}, ${now},
+                  ${sourceId}, ${pgArray(federated)})
+        `;
+      } else if (isUndefinedColumnError(err, 'federated_read')) {
         // v60-only brain: source_id but no federated_read.
         try {
           await this.sql`

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -272,6 +272,25 @@ export interface AuthInfo {
    * case (back-compat).
    */
   allowedSources?: string[];
+  /**
+   * Slug-prefix read binding. Sourced from `oauth_clients.bound_slug_prefixes`
+   * (migration v85 — the agent-binding column). When set and non-empty, every
+   * read-side operation confines its results to slugs matching the list
+   * (same glob semantics as `matchesSlugAllowList`: `clients/*` matches all
+   * descendants of `clients/`, a bare entry matches exactly one slug).
+   *
+   * `undefined` (column NULL, legacy bearer token, or pre-v85 brain) means
+   * "unrestricted" — back-compat with every existing deployment. An empty
+   * array `[]` means "bound to nothing" and is enforced fail-closed (the
+   * client sees no pages): an attacker-controlled `[]` MUST NOT widen scope
+   * by being read as "no filter" — mirror of the `allowedSources` rule in
+   * `sourceScopeOpts`.
+   *
+   * Completes the binding feature read-side: `bound_slug_prefixes` already
+   * bounds what a client may delegate to subagents write-side (submit_agent).
+   * One column, one concept — the slug-prefix authority of the client.
+   */
+  boundSlugPrefixes?: string[];
 }
 
 export interface OperationContext {
@@ -426,6 +445,61 @@ export function sourceScopeOpts(ctx: OperationContext): { sourceId?: string; sou
 }
 
 /**
+ * Read-side slug-prefix binding for the calling OAuth client — the slug-axis
+ * sibling of `sourceScopeOpts`. Returns the client's `bound_slug_prefixes`
+ * (glob semantics of `matchesSlugAllowList`) or `null` when the caller is
+ * unrestricted (local CLI, legacy token, or a client row with NULL binding).
+ *
+ * IMPORTANT: an empty array is returned AS-IS (not collapsed to null) —
+ * "bound to nothing" is fail-closed and must stay distinct from "unbound".
+ *
+ * Every read-side handler routes its results through this helper (SQL-side
+ * via SearchOpts/PageFilters threading where the engine supports it,
+ * post-filter via `filterRowsBySlugBinding` / `assertSlugReadable` where it
+ * doesn't) — drift between sites is a cross-prefix data leak, same bug class
+ * as a missed `sourceScopeOpts` thread.
+ */
+export function slugScopeOpts(ctx: OperationContext): string[] | null {
+  const bound = ctx.auth?.boundSlugPrefixes;
+  if (bound === undefined) return null;
+  return bound;
+}
+
+/**
+ * Throw-on-violation guard for single-slug read ops (get_page, get_chunks,
+ * get_backlinks target, ...). Deliberately throws `not_found` — NOT
+ * `permission_denied` — so an out-of-binding probe cannot be used as an
+ * existence oracle: the response is indistinguishable from a slug that
+ * doesn't exist.
+ */
+export function assertSlugReadable(ctx: OperationContext, slug: string): void {
+  const bound = slugScopeOpts(ctx);
+  if (bound === null) return;
+  if (!matchesSlugAllowList(slug, bound)) {
+    throw new OperationError('page_not_found', `Page not found: ${slug}`, 'Check the slug.');
+  }
+}
+
+/**
+ * Post-filter for list-shaped read results (backlinks, timeline, graph nodes,
+ * resolve_slugs candidates, facts). Rows whose slug falls outside the
+ * caller's binding are silently dropped — the caller sees the brain as if
+ * out-of-binding pages did not exist.
+ */
+export function filterRowsBySlugBinding<T>(
+  ctx: OperationContext,
+  rows: T[],
+  slugOf: (row: T) => string | null | undefined,
+): T[] {
+  const bound = slugScopeOpts(ctx);
+  if (bound === null) return rows;
+  return rows.filter(r => {
+    const slug = slugOf(r);
+    return typeof slug === 'string' && matchesSlugAllowList(slug, bound);
+  });
+}
+
+/**
  * T4/D5 — resolve a per-call search-mode override. Honored ONLY for trusted/
  * local callers (ctx.remote === false) so a remote OAuth client can't escalate
  * to the costly tokenmax bundle. Local + unknown mode → loud reject; remote +
@@ -518,6 +592,9 @@ const get_page: Operation = {
     const slug = p.slug as string;
     const fuzzy = (p.fuzzy as boolean) || false;
     const includeDeleted = (p.include_deleted as boolean) === true;
+    // OAuth slug-prefix read binding: an out-of-binding slug is
+    // indistinguishable from a missing page (no existence oracle).
+    assertSlugReadable(ctx, slug);
     // v0.31.8 (D20): thread ctx.sourceId through read-side ops. Only pass
     // sourceId when it's set on ctx — when unset (local CLI default chain
     // resolves to no source), the engine two-branch query falls through to
@@ -536,7 +613,13 @@ const get_page: Operation = {
     let resolved_slug: string | undefined;
 
     if (!page && fuzzy) {
-      const candidates = await ctx.engine.resolveSlugs(slug, fuzzyScope);
+      // Slug binding applies to fuzzy candidates too — an out-of-binding
+      // candidate must neither be returned nor counted toward ambiguity.
+      const candidates = filterRowsBySlugBinding(
+        ctx,
+        await ctx.engine.resolveSlugs(slug, fuzzyScope),
+        c => c,
+      );
       if (candidates.length === 1) {
         page = await ctx.engine.getPage(candidates[0], { includeDeleted, ...sourceOpts });
         resolved_slug = candidates[0];
@@ -1250,6 +1333,9 @@ const list_pages: Operation = {
     // were ignored at this op handler and the engine returned every source's
     // pages indiscriminately.
     const scope = sourceScopeOpts(ctx);
+    // OAuth slug-prefix read binding — engine-level SQL filter, same trust
+    // posture as the source scope above.
+    const bound = slugScopeOpts(ctx);
     const pages = await ctx.engine.listPages({
       type: p.type as any,
       tag: p.tag as string,
@@ -1258,6 +1344,7 @@ const list_pages: Operation = {
       updated_after: typeof p.updated_after === 'string' ? p.updated_after : undefined,
       sort,
       ...scope,
+      ...(bound !== null ? { restrictSlugPrefixes: bound } : {}),
     });
     return pages.map(pg => ({
       slug: pg.slug,
@@ -1299,8 +1386,13 @@ const search: Operation = {
     // provider). Defaults to cheap-hybrid (D4/D15).
     const keywordOnly = (await ctx.engine.getConfig('search.mcp_keyword_only')) === 'true';
 
+    // OAuth slug-prefix read binding — threaded as a SearchOpts trust filter
+    // so the SQL layer confines every search path (keyword, vector, chunks).
+    const boundPrefixes = slugScopeOpts(ctx);
+    const restrict = boundPrefixes !== null ? { restrict_slug_prefixes: boundPrefixes } : {};
+
     if (keywordOnly) {
-      const raw = await ctx.engine.searchKeyword(queryText, { limit, offset, ...scope });
+      const raw = await ctx.engine.searchKeyword(queryText, { limit, offset, ...scope, ...restrict });
       const results = dedupResults(raw);
       stampEvidenceSafe(results);
       // #1699: the keyword-only opt-out must STILL surface the content_flag
@@ -1320,6 +1412,7 @@ const search: Operation = {
       offset,
       expansion: false,
       ...scope,
+      ...restrict,
       ...(perCallMode ? { mode: perCallMode } : {}),
       onMeta: (m) => { capturedMeta = m; },
     });
@@ -1446,6 +1539,12 @@ const query: Operation = {
           ? {}
           : { sourceId: sourceIdParam }
         : sourceScopeOpts(ctx);
+    // OAuth slug-prefix read binding. Deliberately NO per-call opt-out
+    // (unlike source_id='__all__' above, which is a routing convenience):
+    // the binding is a trust boundary, threaded unconditionally into every
+    // retrieval branch of this op.
+    const queryBound = slugScopeOpts(ctx);
+    const queryRestrict = queryBound !== null ? { restrict_slug_prefixes: queryBound } : {};
 
     // v0.27.1: image-similarity branch. Bypasses hybridSearch (which is
     // text-only); embeds the image via embedMultimodal and runs a direct
@@ -1464,6 +1563,7 @@ const query: Operation = {
         offset: (p.offset as number) || 0,
         embeddingColumn: 'embedding_image',
         ...querySourceScope,
+        ...queryRestrict,
       });
       return results;
     }
@@ -1498,6 +1598,7 @@ const query: Operation = {
       nearSymbol: (p.near_symbol as string) || undefined,
       walkDepth: typeof p.walk_depth === 'number' ? (p.walk_depth as number) : undefined,
       ...querySourceScope,
+      ...queryRestrict,
       // v0.29.1 — agent-explicit recency + salience. Omitted = heuristic defaults.
       salience: p.salience as 'off' | 'on' | 'strong' | undefined,
       recency: p.recency as 'off' | 'on' | 'strong' | undefined,
@@ -1578,7 +1679,7 @@ const takes_list: Operation = {
     offset: { type: 'number', description: 'Skip first N rows' },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.listTakes({
+    return filterRowsBySlugBinding(ctx, await ctx.engine.listTakes({
       page_slug: p.page_slug as string | undefined,
       holder: p.holder as string | undefined,
       kind: p.kind as never,
@@ -1590,7 +1691,7 @@ const takes_list: Operation = {
       // Per-token allow-list — server-side filter for MCP-bound calls.
       // Local CLI callers leave takesHoldersAllowList unset and see all holders.
       takesHoldersAllowList: ctx.takesHoldersAllowList,
-    });
+    }), t => t.page_slug);
   },
   cliHints: { name: 'takes-list' },
 };
@@ -1604,10 +1705,10 @@ const takes_search: Operation = {
     limit: { type: 'number', description: 'Max results (default 30, cap 100)' },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.searchTakes(p.query as string, {
+    return filterRowsBySlugBinding(ctx, await ctx.engine.searchTakes(p.query as string, {
       limit: p.limit as number | undefined,
       takesHoldersAllowList: ctx.takesHoldersAllowList,
-    });
+    }), t => t.page_slug);
   },
   cliHints: { name: 'takes-search', positional: ['query'] },
 };
@@ -1712,6 +1813,11 @@ const think: Operation = {
       takesHoldersAllowList: ctx.takesHoldersAllowList,
       ...(scope.sourceId !== undefined ? { sourceId: scope.sourceId } : {}),
       ...(scope.sourceIds !== undefined ? { allowedSources: scope.sourceIds } : {}),
+      // OAuth slug-prefix read binding — confines think's internal gather.
+      ...((): { boundSlugPrefixes?: string[] } => {
+        const b = slugScopeOpts(ctx);
+        return b !== null ? { boundSlugPrefixes: b } : {};
+      })(),
       remote: ctx.remote === true,
     });
 
@@ -1783,6 +1889,7 @@ const get_tags: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
+    assertSlugReadable(ctx, p.slug as string);
     // v0.31.8 (D20): thread ctx.sourceId for read-side ops on multi-source brains.
     const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
     return ctx.engine.getTags(p.slug as string, sourceOpts);
@@ -1850,10 +1957,17 @@ const get_links: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
+    assertSlugReadable(ctx, p.slug as string);
     // v0.31.8 (D16): thread ctx.sourceId. When unset, engine falls through
     // to cross-source view (back-compat).
     const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
-    return ctx.engine.getLinks(p.slug as string, sourceOpts);
+    // Out-of-binding link TARGETS are dropped: an edge into a hidden
+    // prefix must not reveal that the target exists.
+    return filterRowsBySlugBinding(
+      ctx,
+      await ctx.engine.getLinks(p.slug as string, sourceOpts),
+      l => l.to_slug,
+    );
   },
   scope: 'read',
 };
@@ -1865,8 +1979,15 @@ const get_backlinks: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
+    assertSlugReadable(ctx, p.slug as string);
     const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
-    return ctx.engine.getBacklinks(p.slug as string, sourceOpts);
+    // Out-of-binding link SOURCES are dropped: a backlink from a hidden
+    // prefix must not reveal the referrer's existence or its context line.
+    return filterRowsBySlugBinding(
+      ctx,
+      await ctx.engine.getBacklinks(p.slug as string, sourceOpts),
+      l => l.from_slug,
+    );
   },
   scope: 'read',
   cliHints: { name: 'backlinks', positional: ['slug'] },
@@ -1905,12 +2026,27 @@ const traverse_graph: Operation = {
     // traverseGraph / traversePaths happily followed edges into pages from
     // foreign sources, leaking topology + page metadata via the graph op.
     const scope = sourceScopeOpts(ctx);
+    // OAuth slug-prefix read binding: the walk root must be readable, and
+    // out-of-binding nodes/edges are dropped from the result. Edges of a
+    // VISIBLE node that point into a hidden prefix are also pruned so the
+    // node list can't leak hidden topology.
+    assertSlugReadable(ctx, slug);
+    const bound = slugScopeOpts(ctx);
     // Backward compat: when neither link_type nor direction is provided, return
     // the legacy GraphNode[] shape. Once either is set, switch to GraphPath[].
     if (linkType === undefined && direction === undefined) {
-      return ctx.engine.traverseGraph(slug, depth, scope);
+      const nodes = await ctx.engine.traverseGraph(slug, depth, scope);
+      if (bound === null) return nodes;
+      return filterRowsBySlugBinding(ctx, nodes, n => n.slug).map(n => ({
+        ...n,
+        links: n.links.filter(l => matchesSlugAllowList(l.to_slug, bound)),
+      }));
     }
-    return ctx.engine.traversePaths(slug, { depth, linkType, direction, ...scope });
+    const paths = await ctx.engine.traversePaths(slug, { depth, linkType, direction, ...scope });
+    if (bound === null) return paths;
+    return paths.filter(
+      e => matchesSlugAllowList(e.from_slug, bound) && matchesSlugAllowList(e.to_slug, bound),
+    );
   },
   scope: 'read',
   cliHints: { name: 'graph', positional: ['slug'] },
@@ -1968,6 +2104,7 @@ const get_timeline: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
+    assertSlugReadable(ctx, p.slug as string);
     // v0.31.8 (D20): thread ctx.sourceId.
     const sourceId = ctx.sourceId;
     return ctx.engine.getTimeline(p.slug as string, sourceId ? { sourceId } : undefined);
@@ -2204,6 +2341,7 @@ const get_versions: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
+    assertSlugReadable(ctx, p.slug as string);
     // v0.31.8 (D20): thread ctx.sourceId.
     const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
     const versions = await ctx.engine.getVersions(p.slug as string, sourceOpts);
@@ -2297,6 +2435,7 @@ const get_raw_data: Operation = {
     source: { type: 'string', description: 'Filter by source' },
   },
   handler: async (ctx, p) => {
+    assertSlugReadable(ctx, p.slug as string);
     // v0.31.8 (D20 + D21): thread ctx.sourceId.
     const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
     return ctx.engine.getRawData(p.slug as string, p.source as string | undefined, sourceOpts);
@@ -2313,7 +2452,13 @@ const resolve_slugs: Operation = {
     partial: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.resolveSlugs(p.partial as string);
+    // OAuth slug-prefix read binding: out-of-binding candidates are dropped
+    // so fuzzy resolution can't be used to enumerate hidden prefixes.
+    return filterRowsBySlugBinding(
+      ctx,
+      await ctx.engine.resolveSlugs(p.partial as string),
+      c => c,
+    );
   },
   scope: 'read',
 };
@@ -2325,6 +2470,7 @@ const get_chunks: Operation = {
     slug: { type: 'string', required: true },
   },
   handler: async (ctx, p) => {
+    assertSlugReadable(ctx, p.slug as string);
     // v0.31.8 (D20): thread ctx.sourceId.
     const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
     return ctx.engine.getChunks(p.slug as string, sourceOpts);
@@ -2364,7 +2510,15 @@ const get_ingest_log: Operation = {
     limit: { type: 'number', description: 'Max entries (default 20)' },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.getIngestLog({ limit: clampSearchLimit(p.limit as number | undefined, 20, 50) });
+    const entries = await ctx.engine.getIngestLog({ limit: clampSearchLimit(p.limit as number | undefined, 20, 50) });
+    // OAuth slug-prefix read binding: prune out-of-binding slugs from each
+    // entry's pages_updated list.
+    const boundIngest = slugScopeOpts(ctx);
+    if (boundIngest === null) return entries;
+    return entries.map(e => ({
+      ...e,
+      pages_updated: e.pages_updated.filter(sl => matchesSlugAllowList(sl, boundIngest)),
+    }));
   },
   scope: 'read',
 };
@@ -2933,10 +3087,15 @@ const find_orphans: Operation = {
     // source-bound OAuth client's scope — a read leak in the v0.34.1
     // source-isolation class. Local CLI callers route through `gbrain
     // orphans --source` instead (ctx.remote === false → empty scope here).
-    return findOrphans(ctx.engine, {
+    const result = await findOrphans(ctx.engine, {
       includePseudo: (p.include_pseudo as boolean) || false,
       ...sourceScopeOpts(ctx),
     });
+    // OAuth slug-prefix read binding: drop out-of-binding orphan rows.
+    // Aggregate counts are left as-is (brain-shape metadata, not content).
+    const boundOrphans = slugScopeOpts(ctx);
+    if (boundOrphans === null) return result;
+    return { ...result, orphans: result.orphans.filter(o => matchesSlugAllowList(o.slug, boundOrphans)) };
   },
   cliHints: { name: 'orphans', hidden: true },
 };
@@ -2997,12 +3156,17 @@ const get_recent_salience: Operation = {
   },
   handler: async (ctx, p) => {
     const recencyBias = p.recency_bias === 'on' ? 'on' : 'flat';
-    return ctx.engine.getRecentSalience({
-      days: typeof p.days === 'number' ? p.days : undefined,
-      limit: typeof p.limit === 'number' ? p.limit : undefined,
-      slugPrefix: typeof p.slugPrefix === 'string' ? p.slugPrefix : undefined,
-      recency_bias: recencyBias,
-    });
+    // OAuth slug-prefix read binding: post-filter (salience rows are slug-keyed).
+    return filterRowsBySlugBinding(
+      ctx,
+      await ctx.engine.getRecentSalience({
+        days: typeof p.days === 'number' ? p.days : undefined,
+        limit: typeof p.limit === 'number' ? p.limit : undefined,
+        slugPrefix: typeof p.slugPrefix === 'string' ? p.slugPrefix : undefined,
+        recency_bias: recencyBias,
+      }),
+      r => r.slug,
+    );
   },
   cliHints: { name: 'salience' },
 };
@@ -3026,11 +3190,19 @@ const find_anomalies: Operation = {
     },
   },
   handler: async (ctx, p) => {
-    return ctx.engine.findAnomalies({
+    const anomalies = await ctx.engine.findAnomalies({
       since: typeof p.since === 'string' ? p.since : undefined,
       lookback_days: typeof p.lookback_days === 'number' ? p.lookback_days : undefined,
       sigma: typeof p.sigma === 'number' ? p.sigma : undefined,
     });
+    // OAuth slug-prefix read binding: prune out-of-binding slugs from each
+    // cohort's example list (cohort-level counts stay — shape metadata).
+    const boundAnoms = slugScopeOpts(ctx);
+    if (boundAnoms === null) return anomalies;
+    return anomalies.map(a => ({
+      ...a,
+      page_slugs: a.page_slugs.filter(sl => matchesSlugAllowList(sl, boundAnoms)),
+    }));
   },
   cliHints: { name: 'anomalies' },
 };
@@ -3071,13 +3243,20 @@ const find_experts: Operation = {
     const { loadActivePackBestEffort, expertTypesFromPack } = await import('./schema-pack/index.ts');
     const pack = await loadActivePackBestEffort(ctx);
     const types = pack ? expertTypesFromPack(pack.manifest) : [];
-    return findExperts(ctx.engine, {
-      topic,
-      limit: typeof p.limit === 'number' ? p.limit : undefined,
-      explain: p.explain === true,
-      types: types as never,
-      ...sourceScopeOpts(ctx),
-    });
+    // OAuth slug-prefix read binding: post-filter (findExperts → hybridSearch
+    // internally; the binding also rides SearchOpts there, this is the
+    // belt-and-suspenders at the op boundary).
+    return filterRowsBySlugBinding(
+      ctx,
+      await findExperts(ctx.engine, {
+        topic,
+        limit: typeof p.limit === 'number' ? p.limit : undefined,
+        explain: p.explain === true,
+        types: types as never,
+        ...sourceScopeOpts(ctx),
+      }),
+      r => r.slug,
+    );
   },
   cliHints: { name: 'whoknows', positional: ['topic'] },
 };
@@ -3139,10 +3318,19 @@ const find_contradictions: Operation = {
       }
       return true;
     });
+    // OAuth slug-prefix read binding: a finding is visible only when BOTH
+    // sides are within the binding (one hidden side would leak its content
+    // via the contradiction excerpt).
+    const boundContra = slugScopeOpts(ctx);
+    const visible = boundContra === null
+      ? filtered
+      : filtered.filter(f =>
+          matchesSlugAllowList(f.a.slug, boundContra) && matchesSlugAllowList(f.b.slug, boundContra),
+        );
     return {
       run_id: latest.run_id,
       ran_at: latest.ran_at,
-      contradictions: filtered.slice(0, limit),
+      contradictions: visible.slice(0, limit),
       total_in_run: findings.length,
     };
   },
@@ -3188,6 +3376,8 @@ const find_trajectory: Operation = {
     if (typeof p.entity_slug !== 'string' || !p.entity_slug.trim()) {
       throw new Error('find_trajectory requires entity_slug (string)');
     }
+    // OAuth slug-prefix read binding: trajectory rows are keyed by entity.
+    assertSlugReadable(ctx, p.entity_slug);
     const metric = typeof p.metric === 'string' ? p.metric : undefined;
     const kind = (p.kind === 'metric' || p.kind === 'event' || p.kind === 'all')
       ? (p.kind as 'metric' | 'event' | 'all')
@@ -3609,6 +3799,11 @@ const recall: Operation = {
     }
 
     if (grep) rows = rows.filter(r => r.fact.toLowerCase().includes(grep));
+
+    // OAuth slug-prefix read binding: facts about out-of-binding entities are
+    // dropped (entity_slug NULL rows too — fail-closed for bound callers,
+    // since their provenance can't be verified against the binding).
+    rows = filterRowsBySlugBinding(ctx, rows, r => r.entity_slug);
 
     // v0.32: optional pending-consolidation count piggy-backed on the recall
     // response. Single round trip on thin-client; omitted when not requested

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -48,7 +48,7 @@ import { normalizeWeightForStorage } from './takes-fence.ts';
 import { GBrainError, PAGE_SORT_SQL, ENRICH_ORDER_SQL } from './types.ts';
 import { computeAnomaliesFromBuckets } from './cycle/anomaly.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
-import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause, buildRecencyComponentSql, buildBestPerPagePoolCte } from './search/sql-ranking.ts';
+import { buildSourceFactorCase, buildHardExcludeClause, buildSlugAllowClause, buildVisibilityClause, buildRecencyComponentSql, buildBestPerPagePoolCte } from './search/sql-ranking.ts';
 import {
   normalizeEngineColumn,
   buildVectorCastFragment,
@@ -1134,6 +1134,12 @@ export class PGLiteEngine implements BrainEngine {
     if (filters?.includeDeleted !== true) {
       where.push('p.deleted_at IS NULL');
     }
+    // OAuth slug-prefix read binding (trust filter, see PageFilters docs).
+    // Same builder as the search paths; strip the leading `AND ` to fit the
+    // where-array composition style.
+    if (filters?.restrictSlugPrefixes) {
+      where.push(buildSlugAllowClause('p.slug', filters.restrictSlugPrefixes).replace(/^AND /, ''));
+    }
 
     const whereSql = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
     params.push(limit, offset);
@@ -1442,7 +1448,11 @@ export class PGLiteEngine implements BrainEngine {
     const boostMap = resolveBoostMap();
     const sourceFactorCase = buildSourceFactorCase('p.slug', boostMap, opts?.detail);
     const hardExcludePrefixes = resolveHardExcludes(opts?.exclude_slug_prefixes, opts?.include_slug_prefixes);
-    const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes);
+    // OAuth slug-prefix read binding (trust filter) folds into the same
+    // interpolation site as the hard-exclude policy filter — every query
+    // shape that honors hard-excludes honors the binding by construction.
+    const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes) +
+      (opts?.restrict_slug_prefixes ? ` ${buildSlugAllowClause('p.slug', opts.restrict_slug_prefixes)}` : '');
 
     // v0.26.5: visibility filter (soft-deleted + archived-source).
     const visibilityClause = buildVisibilityClause('p', 's');
@@ -1683,7 +1693,11 @@ export class PGLiteEngine implements BrainEngine {
     const boostMap = resolveBoostMap();
     const sourceFactorCase = buildSourceFactorCase('p.slug', boostMap, opts?.detail);
     const hardExcludePrefixes = resolveHardExcludes(opts?.exclude_slug_prefixes, opts?.include_slug_prefixes);
-    const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes);
+    // OAuth slug-prefix read binding (trust filter) folds into the same
+    // interpolation site as the hard-exclude policy filter — every query
+    // shape that honors hard-excludes honors the binding by construction.
+    const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes) +
+      (opts?.restrict_slug_prefixes ? ` ${buildSlugAllowClause('p.slug', opts.restrict_slug_prefixes)}` : '');
     const visibilityClause = buildVisibilityClause('p', 's');
 
     // v0.32.7: CJK branch (same as searchKeyword but without page-dedup).
@@ -1776,7 +1790,11 @@ export class PGLiteEngine implements BrainEngine {
     // `slug` resolves cleanly (T1 per-page pool restructure).
     const sourceFactorCaseOnSlug = buildSourceFactorCase('slug', boostMap, opts?.detail);
     const hardExcludePrefixes = resolveHardExcludes(opts?.exclude_slug_prefixes, opts?.include_slug_prefixes);
-    const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes);
+    // OAuth slug-prefix read binding (trust filter) folds into the same
+    // interpolation site as the hard-exclude policy filter — every query
+    // shape that honors hard-excludes honors the binding by construction.
+    const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes) +
+      (opts?.restrict_slug_prefixes ? ` ${buildSlugAllowClause('p.slug', opts.restrict_slug_prefixes)}` : '');
     const innerLimit = offset + Math.max(limit * 5, 100);
 
     const params: unknown[] = [vecStr, innerLimit, limit, offset];

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -56,7 +56,7 @@ import { ConnectionManager } from './connection-manager.ts';
 import { logConnectionEvent } from './connection-audit.ts';
 import { validateSlug, contentHash, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, parseEmbedding, tryParseEmbedding, takeRowToTake, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
-import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause, buildRecencyComponentSql, buildBestPerPagePoolCte } from './search/sql-ranking.ts';
+import { buildSourceFactorCase, buildHardExcludeClause, buildSlugAllowClause, buildVisibilityClause, buildRecencyComponentSql, buildBestPerPagePoolCte } from './search/sql-ranking.ts';
 import { DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_DIMENSIONS } from './ai/defaults.ts';
 import { DELETE_BATCH_SIZE } from './engine-constants.ts';
 
@@ -1195,6 +1195,12 @@ export class PostgresEngine implements BrainEngine {
     const deletedCondition = filters?.includeDeleted === true
       ? sql``
       : sql`AND p.deleted_at IS NULL`;
+    // OAuth slug-prefix read binding (trust filter, see PageFilters docs).
+    // buildSlugAllowClause emits a fully-escaped literal fragment (same
+    // builder as the search paths) — spliced via sql.unsafe like orderBy.
+    const restrictCondition = filters?.restrictSlugPrefixes
+      ? sql.unsafe(buildSlugAllowClause('p.slug', filters.restrictSlugPrefixes))
+      : sql``;
 
     // v0.29: ORDER BY threading via PAGE_SORT_SQL whitelist (no SQL injection).
     // postgres.js sql.unsafe lets us splice the literal fragment safely.
@@ -1204,7 +1210,7 @@ export class PostgresEngine implements BrainEngine {
     const rows = await sql`
       SELECT p.* FROM pages p
       ${tagJoin}
-      WHERE 1=1 ${typeCondition} ${tagCondition} ${updatedCondition} ${slugCondition} ${sourceCondition} ${deletedCondition}
+      WHERE 1=1 ${typeCondition} ${tagCondition} ${updatedCondition} ${slugCondition} ${sourceCondition} ${deletedCondition} ${restrictCondition}
       ORDER BY ${orderBy} LIMIT ${limit} OFFSET ${offset}
     `;
 
@@ -1515,7 +1521,11 @@ export class PostgresEngine implements BrainEngine {
     const boostMap = resolveBoostMap();
     const sourceFactorCase = buildSourceFactorCase('p.slug', boostMap, opts?.detail);
     const hardExcludePrefixes = resolveHardExcludes(opts?.exclude_slug_prefixes, opts?.include_slug_prefixes);
-    const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes);
+    // OAuth slug-prefix read binding (trust filter) folds into the same
+    // interpolation site as the hard-exclude policy filter — every query
+    // shape that honors hard-excludes honors the binding by construction.
+    const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes) +
+      (opts?.restrict_slug_prefixes ? ` ${buildSlugAllowClause('p.slug', opts.restrict_slug_prefixes)}` : '');
 
     const params: unknown[] = [query];
     let typeClause = '';
@@ -1664,7 +1674,11 @@ export class PostgresEngine implements BrainEngine {
     const boostMap = resolveBoostMap();
     const sourceFactorCase = buildSourceFactorCase('p.slug', boostMap, opts?.detail);
     const hardExcludePrefixes = resolveHardExcludes(opts?.exclude_slug_prefixes, opts?.include_slug_prefixes);
-    const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes);
+    // OAuth slug-prefix read binding (trust filter) folds into the same
+    // interpolation site as the hard-exclude policy filter — every query
+    // shape that honors hard-excludes honors the binding by construction.
+    const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes) +
+      (opts?.restrict_slug_prefixes ? ` ${buildSlugAllowClause('p.slug', opts.restrict_slug_prefixes)}` : '');
 
     const params: unknown[] = [query];
     let typeClause = '';
@@ -1785,7 +1799,11 @@ export class PostgresEngine implements BrainEngine {
     const boostMap = resolveBoostMap();
     const sourceFactorCaseOnSlug = buildSourceFactorCase('slug', boostMap, opts?.detail);
     const hardExcludePrefixes = resolveHardExcludes(opts?.exclude_slug_prefixes, opts?.include_slug_prefixes);
-    const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes);
+    // OAuth slug-prefix read binding (trust filter) folds into the same
+    // interpolation site as the hard-exclude policy filter — every query
+    // shape that honors hard-excludes honors the binding by construction.
+    const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes) +
+      (opts?.restrict_slug_prefixes ? ` ${buildSlugAllowClause('p.slug', opts.restrict_slug_prefixes)}` : '');
     const innerLimit = offset + Math.max(limit * 5, 100);
 
     const params: unknown[] = [vecStr];

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -866,6 +866,10 @@ export async function hybridSearch(
     // ordering means we can't lazy-spread the full opts).
     sourceId: opts?.sourceId,
     sourceIds: opts?.sourceIds,
+    // OAuth slug-prefix read binding (trust filter) — same MUST-add rule as
+    // the source-scoping fields above: dropping it here would silently
+    // un-confine every bound client on the hybrid hot path.
+    restrict_slug_prefixes: opts?.restrict_slug_prefixes,
     // v0.36 (D11): pass the pre-validated descriptor into the engine so
     // it never has to read config. Engines normalize string-or-descriptor
     // via normalizeEngineColumn; the descriptor path is the strict one.
@@ -1563,7 +1567,12 @@ export async function hybridSearchCached(
     (opts?.walkDepth ?? 0) > 0 ||
     Boolean(opts?.nearSymbol) ||
     isNonDefaultColumn ||
-    adaptiveReturnOn;
+    adaptiveReturnOn ||
+    // OAuth slug-prefix read binding: a restricted result set must never be
+    // served to (or written for) a caller with a different binding — the
+    // cache key doesn't carry the binding, so restricted calls bypass the
+    // cache entirely (same posture as adaptiveReturn above).
+    Boolean(opts?.restrict_slug_prefixes);
 
   let cacheStatus: 'hit' | 'miss' | 'disabled' = skipCache ? 'disabled' : 'miss';
   let cacheSimilarity: number | undefined;

--- a/src/core/search/sql-ranking.ts
+++ b/src/core/search/sql-ranking.ts
@@ -111,6 +111,38 @@ export function buildHardExcludeClause(slugColumn: string, prefixes: string[]): 
 }
 
 /**
+ * Build a POSITIVE slug allow-clause for OAuth slug-prefix read binding —
+ * the inverse of `buildHardExcludeClause`. A row survives only when its slug
+ * matches at least one entry of the caller's `bound_slug_prefixes`.
+ *
+ * Glob semantics mirror `matchesSlugAllowList` in operations.ts (the
+ * write-side enforcement): `clients/*` admits every descendant of `clients/`
+ * (but not the bare slug `clients` itself); a bare entry admits exactly that
+ * slug. The two sites MUST stay in lockstep — SQL-side filtering (search,
+ * list_pages) and TS-side post-filtering (backlinks, graph nodes) implement
+ * the same binding.
+ *
+ * Returns `'AND FALSE'` for an EMPTY list: an explicit empty binding means
+ * "bound to nothing" and must stay fail-closed (cf. AuthInfo.boundSlugPrefixes).
+ * Callers that mean "unrestricted" must not call this at all (binding null).
+ *
+ * @param slugColumn — qualified column reference (engine-supplied, trusted)
+ * @param prefixes   — the caller's bound_slug_prefixes (client-supplied; escaped)
+ * @returns raw SQL fragment (no leading space) — always non-empty
+ */
+export function buildSlugAllowClause(slugColumn: string, prefixes: string[]): string {
+  const terms = prefixes
+    .filter(p => p.length > 0)
+    .map(p =>
+      p.endsWith('/*')
+        ? `${slugColumn} LIKE ${buildLikePrefixLiteral(p.slice(0, -1))}`
+        : `${slugColumn} = '${escapeSqlLiteral(p)}'`,
+    );
+  if (!terms.length) return 'AND FALSE';
+  return `AND (${terms.join(' OR ')})`;
+}
+
+/**
  * v0.26.5 — Build the soft-delete + archived-source visibility filter.
  *
  * Two filters in one fragment:

--- a/src/core/think/gather.ts
+++ b/src/core/think/gather.ts
@@ -19,6 +19,7 @@ import type { BrainEngine, TakeHit, Take } from '../engine.ts';
 import { hybridSearch } from '../search/hybrid.ts';
 import type { SearchResult } from '../types.ts';
 import { sanitizeQueryForPrompt } from '../search/expansion.ts';
+import { matchesSlugAllowList } from '../operations.ts';
 
 export interface ThinkGatherOpts {
   question: string;
@@ -34,6 +35,15 @@ export interface ThinkGatherOpts {
   questionEmbedding?: Float32Array;
   /** When set, MCP-bound calls forward this allow-list to takes_search. Local CLI leaves unset. */
   takesHoldersAllowList?: string[];
+  /**
+   * OAuth slug-prefix read binding (oauth_clients.bound_slug_prefixes),
+   * threaded from the think op handler. Confines every gather stream:
+   * hybrid pages (SQL-side via SearchOpts), takes (post-filter on
+   * page_slug), and graph walk (post-filter on slugs). Without this thread
+   * a bound client could exfiltrate hidden-prefix content through think's
+   * synthesized answer.
+   */
+  restrictSlugPrefixes?: string[];
 }
 
 export interface ThinkGatherResult {
@@ -110,6 +120,9 @@ export async function runGather(
   const pagesPromise = hybridSearch(engine, opts.question, {
     limit: gatherLimit,
     expansion: false,  // think provides its own anchor + graph context; no need for re-expansion
+    ...(opts.restrictSlugPrefixes !== undefined
+      ? { restrict_slug_prefixes: opts.restrictSlugPrefixes }
+      : {}),
   }).catch((e) => {
     process.stderr.write(`[think.gather] hybrid stream failed: ${(e as Error).message}\n`);
     return [] as SearchResult[];
@@ -152,9 +165,18 @@ export async function runGather(
         })
     : Promise.resolve([] as string[]);
 
-  const [pages, takesKw, takesVec, graphSlugs] = await Promise.all([
+  let [pages, takesKw, takesVec, graphSlugs] = await Promise.all([
     pagesPromise, takesKwPromise, takesVecPromise, graphPromise,
   ]);
+
+  // OAuth slug-prefix read binding — post-filter the streams that don't go
+  // through SearchOpts (takes + graph). Same matcher as the op layer.
+  const bound = opts.restrictSlugPrefixes;
+  if (bound !== undefined) {
+    takesKw = takesKw.filter(t => matchesSlugAllowList(t.page_slug, bound));
+    takesVec = takesVec.filter(t => matchesSlugAllowList(t.page_slug, bound));
+    graphSlugs = graphSlugs.filter(sl => matchesSlugAllowList(sl, bound));
+  }
 
   // Fuse takes streams (keyword + vector). Key by (page_slug, row_num).
   const fusedTakes = fuseRanked(

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -106,6 +106,13 @@ export interface RunThinkOpts {
    */
   allowedSources?: string[];
   /**
+   * OAuth slug-prefix read binding — projection of
+   * `OperationContext.auth.boundSlugPrefixes` via `slugScopeOpts(ctx)`.
+   * Confines every gather stream (pages, takes, graph) so a bound client
+   * can't exfiltrate hidden-prefix content through the synthesized answer.
+   */
+  boundSlugPrefixes?: string[];
+  /**
    * v0.40.2.0 — scalar projection of `OperationContext.remote`. When
    * true, trajectory queries apply `visibility='world'` filter (mirrors
    * the recall posture for untrusted callers). CLI defaults to false.
@@ -270,6 +277,7 @@ export async function runThink(
     anchor: opts.anchor,
     questionEmbedding,
     takesHoldersAllowList: opts.takesHoldersAllowList,
+    restrictSlugPrefixes: opts.boundSlugPrefixes,
   });
 
   // Render evidence blocks for the prompt

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -296,6 +296,14 @@ export interface PageFilters {
    */
   slugPrefix?: string;
   /**
+   * OAuth slug-prefix read binding — same TRUST semantics as
+   * `SearchOpts.restrict_slug_prefixes` (glob list from
+   * oauth_clients.bound_slug_prefixes, threaded by the op layer via
+   * `slugScopeOpts(ctx)`). Applied on top of `slugPrefix` (a caller-side
+   * scoping convenience), never instead of it. Empty array = no rows.
+   */
+  restrictSlugPrefixes?: string[];
+  /**
    * v0.26.5: include soft-deleted pages (rows with `deleted_at IS NOT NULL`).
    * Default false: hides soft-deleted pages from `list_pages` so agents see the
    * same set search returns. Set true to enumerate the recoverable set during
@@ -904,6 +912,17 @@ export interface SearchOpts {
    * though they're hard-excluded by default.
    */
   include_slug_prefixes?: string[];
+  /**
+   * OAuth slug-prefix read binding (oauth_clients.bound_slug_prefixes).
+   * When set, results are POSITIVELY confined to slugs matching the list —
+   * glob semantics of `matchesSlugAllowList` (`clients/*` = descendants,
+   * bare entry = exact slug). Unlike include/exclude above (ranking-policy
+   * knobs), this is a TRUST filter threaded by the op layer from
+   * `slugScopeOpts(ctx)`; engines apply it via `buildSlugAllowClause` in
+   * every search path. Empty array = fail-closed (no rows). Undefined =
+   * unrestricted.
+   */
+  restrict_slug_prefixes?: string[];
   detail?: 'low' | 'medium' | 'high';
   /**
    * v0.20.0 Cathedral II: filter by content_chunks.language (e.g., 'typescript',

--- a/test/e2e/slug-isolation-pglite.test.ts
+++ b/test/e2e/slug-isolation-pglite.test.ts
@@ -1,0 +1,264 @@
+/**
+ * OAuth slug-prefix read binding (oauth_clients.bound_slug_prefixes) —
+ * read-side isolation regression suite.
+ *
+ * A client bound to e.g. ['clients/*', 'people/*'] must never see content
+ * outside those prefixes through ANY read surface: engine search paths
+ * (SQL-side via SearchOpts.restrict_slug_prefixes), listPages
+ * (PageFilters.restrictSlugPrefixes), and the op-handler layer
+ * (slugScopeOpts / assertSlugReadable / filterRowsBySlugBinding).
+ *
+ * Modeled on test/e2e/source-isolation-pglite.test.ts (the source-axis
+ * sibling). Same two-layer coverage: engine layer + op-handler layer with
+ * a simulated AuthInfo carrying boundSlugPrefixes.
+ *
+ * Binding semantics under test (see AuthInfo.boundSlugPrefixes):
+ *  - undefined (no binding)  → unrestricted (back-compat)
+ *  - non-empty list          → confined; glob semantics of matchesSlugAllowList
+ *  - empty array []          → fail-closed: sees NOTHING
+ */
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+import { resetPgliteState } from '../helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+/** Op-handler ctx with an optional slug binding on AuthInfo. */
+function mkCtx(boundSlugPrefixes?: string[]) {
+  return {
+    engine,
+    config: { engine: 'pglite' as const },
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    dryRun: false,
+    remote: true,
+    ...(boundSlugPrefixes !== undefined
+      ? {
+          auth: {
+            token: 'test',
+            clientId: 'test-bound-client',
+            scopes: ['read'],
+            boundSlugPrefixes,
+          },
+        }
+      : {}),
+  };
+}
+
+async function seedPage(slug: string, title: string, text: string) {
+  await engine.putPage(slug, {
+    type: 'note',
+    title,
+    compiled_truth: text,
+    timeline: '',
+    frontmatter: {},
+  }, { sourceId: 'default' });
+  await engine.upsertChunks(slug, [{
+    chunk_index: 0,
+    chunk_text: text,
+    chunk_source: 'compiled_truth',
+    token_count: Math.ceil(text.length / 4),
+  }], { sourceId: 'default' });
+}
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  // One page per prefix family. All share the marker keyword so a search
+  // that ignores the binding would return all of them.
+  await seedPage('clients/acme-example', 'Acme (client)', 'Acme client notes. Zebra-marker keyword here.');
+  await seedPage('clients/acme-example/meetings/2026-06-01', 'Acme meeting', 'Acme meeting notes. Zebra-marker keyword here.');
+  await seedPage('people/alice-example', 'Alice', 'Alice profile. Zebra-marker keyword here.');
+  await seedPage('partenaires/fund-a', 'Fund A (partner)', 'Partner fund notes. Zebra-marker keyword here. SECRET-PARTNER-TERMS.');
+  // Cross-prefix edges for the backlink / link / graph leak tests.
+  await engine.addLink('clients/acme-example', 'partenaires/fund-a', 'acme works with fund-a', 'mentions');
+  await engine.addLink('partenaires/fund-a', 'clients/acme-example', 'fund-a invested in acme', 'mentions');
+  await engine.addLink('clients/acme-example', 'people/alice-example', 'alice is the acme contact', 'mentions');
+});
+
+// ---------------------------------------------------------------------------
+// Engine layer
+// ---------------------------------------------------------------------------
+
+describe('engine layer — SearchOpts.restrict_slug_prefixes', () => {
+  test('searchKeyword confined to clients/*', async () => {
+    const rows = await engine.searchKeyword('Zebra-marker', {
+      restrict_slug_prefixes: ['clients/*'],
+    });
+    expect(rows.length).toBeGreaterThan(0);
+    for (const r of rows) {
+      expect(r.slug.startsWith('clients/')).toBe(true);
+    }
+  });
+
+  test('searchKeyword unrestricted sees every prefix (back-compat)', async () => {
+    const rows = await engine.searchKeyword('Zebra-marker', {});
+    const slugs = new Set(rows.map(r => r.slug));
+    expect(slugs.has('partenaires/fund-a')).toBe(true);
+    expect(slugs.has('people/alice-example')).toBe(true);
+  });
+
+  test('searchKeyword with EMPTY binding returns nothing (fail-closed)', async () => {
+    const rows = await engine.searchKeyword('Zebra-marker', {
+      restrict_slug_prefixes: [],
+    });
+    expect(rows.length).toBe(0);
+  });
+
+  test('bare entry matches exactly one slug, not descendants', async () => {
+    const rows = await engine.searchKeyword('Zebra-marker', {
+      restrict_slug_prefixes: ['clients/acme-example'],
+    });
+    const slugs = new Set(rows.map(r => r.slug));
+    expect(slugs.has('clients/acme-example')).toBe(true);
+    expect(slugs.has('clients/acme-example/meetings/2026-06-01')).toBe(false);
+  });
+
+  test('searchKeywordChunks honors the binding', async () => {
+    const rows = await engine.searchKeywordChunks('SECRET-PARTNER-TERMS', {
+      restrict_slug_prefixes: ['clients/*', 'people/*'],
+    });
+    expect(rows.length).toBe(0);
+  });
+
+  test('listPages with restrictSlugPrefixes confined', async () => {
+    const pages = await engine.listPages({ restrictSlugPrefixes: ['people/*'] });
+    expect(pages.length).toBe(1);
+    expect(pages[0].slug).toBe('people/alice-example');
+  });
+
+  test('listPages with empty binding returns nothing', async () => {
+    const pages = await engine.listPages({ restrictSlugPrefixes: [] });
+    expect(pages.length).toBe(0);
+  });
+
+  test('LIKE metacharacters in a prefix are escaped, not wildcards', async () => {
+    // 'clients_' would match 'clientsx' if `_` reached LIKE unescaped.
+    await seedPage('clientsx/sneaky', 'Sneaky', 'Zebra-marker keyword here.');
+    const rows = await engine.searchKeyword('Zebra-marker', {
+      restrict_slug_prefixes: ['clients_/*'],
+    });
+    expect(rows.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Op-handler layer
+// ---------------------------------------------------------------------------
+
+describe('op layer — bound client is confined on every read surface', () => {
+  async function op(name: string) {
+    const { operations } = await import('../../src/core/operations.ts');
+    const found = operations.find(o => o.name === name);
+    expect(found).toBeDefined();
+    return found!;
+  }
+
+  test('search op: bound to clients/* sees only clients rows', async () => {
+    const searchOp = await op('search');
+    const rows = (await searchOp.handler(
+      mkCtx(['clients/*']) as any,
+      { query: 'Zebra-marker' },
+    )) as Array<{ slug: string }>;
+    expect(rows.length).toBeGreaterThan(0);
+    for (const r of rows) expect(r.slug.startsWith('clients/')).toBe(true);
+  });
+
+  test('search op: unbound client still sees everything (back-compat)', async () => {
+    const searchOp = await op('search');
+    const rows = (await searchOp.handler(
+      mkCtx() as any,
+      { query: 'Zebra-marker' },
+    )) as Array<{ slug: string }>;
+    const slugs = new Set(rows.map(r => r.slug));
+    expect(slugs.has('partenaires/fund-a')).toBe(true);
+  });
+
+  test('get_page: out-of-binding slug is page_not_found (no existence oracle)', async () => {
+    const getPage = await op('get_page');
+    await expect(
+      getPage.handler(mkCtx(['clients/*']) as any, { slug: 'partenaires/fund-a' }),
+    ).rejects.toThrow(/Page not found/);
+  });
+
+  test('get_page: in-binding slug resolves normally', async () => {
+    const getPage = await op('get_page');
+    const page = (await getPage.handler(
+      mkCtx(['clients/*']) as any,
+      { slug: 'clients/acme-example' },
+    )) as { slug: string };
+    expect(page.slug).toBe('clients/acme-example');
+  });
+
+  test('list_pages: bound client enumerates only its prefixes', async () => {
+    const listPages = await op('list_pages');
+    const rows = (await listPages.handler(
+      mkCtx(['clients/*', 'people/*']) as any,
+      {},
+    )) as Array<{ slug: string }>;
+    expect(rows.length).toBeGreaterThan(0);
+    for (const r of rows) {
+      expect(r.slug.startsWith('clients/') || r.slug.startsWith('people/')).toBe(true);
+    }
+  });
+
+  test('resolve_slugs: hidden prefixes are not enumerable', async () => {
+    const resolveSlugs = await op('resolve_slugs');
+    const rows = (await resolveSlugs.handler(
+      mkCtx(['clients/*']) as any,
+      { partial: 'fund' },
+    )) as string[];
+    expect(rows.length).toBe(0);
+  });
+
+  test('get_links: edge into a hidden prefix is dropped', async () => {
+    const getLinks = await op('get_links');
+    const rows = (await getLinks.handler(
+      mkCtx(['clients/*', 'people/*']) as any,
+      { slug: 'clients/acme-example' },
+    )) as Array<{ to_slug: string }>;
+    const targets = rows.map(l => l.to_slug);
+    expect(targets).toContain('people/alice-example');
+    expect(targets).not.toContain('partenaires/fund-a');
+  });
+
+  test('get_backlinks: referrer in a hidden prefix is dropped', async () => {
+    const getBacklinks = await op('get_backlinks');
+    const rows = (await getBacklinks.handler(
+      mkCtx(['clients/*']) as any,
+      { slug: 'clients/acme-example' },
+    )) as Array<{ from_slug: string }>;
+    expect(rows.map(l => l.from_slug)).not.toContain('partenaires/fund-a');
+  });
+
+  test('traverse_graph: hidden nodes pruned, visible nodes keep only visible edges', async () => {
+    const traverse = await op('traverse_graph');
+    const nodes = (await traverse.handler(
+      mkCtx(['clients/*', 'people/*']) as any,
+      { slug: 'clients/acme-example', depth: 2 },
+    )) as Array<{ slug: string; links: { to_slug: string }[] }>;
+    for (const n of nodes) {
+      expect(n.slug.startsWith('partenaires/')).toBe(false);
+      for (const l of n.links) {
+        expect(l.to_slug.startsWith('partenaires/')).toBe(false);
+      }
+    }
+  });
+
+  test('empty binding [] is fail-closed at the op layer too', async () => {
+    const searchOp = await op('search');
+    const rows = (await searchOp.handler(
+      mkCtx([]) as any,
+      { query: 'Zebra-marker' },
+    )) as Array<{ slug: string }>;
+    expect(rows.length).toBe(0);
+  });
+});

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -209,6 +209,28 @@ describe('verifyAccessToken', () => {
     expect(authInfo.token).toBe(tokens.access_token);
   });
 
+  test('bound_slug_prefixes projects onto AuthInfo.boundSlugPrefixes', async () => {
+    // Read-side slug binding: registered binding must ride the token so
+    // slugScopeOpts(ctx) can confine every read op.
+    const { clientId, clientSecret } = await provider.registerClientManual(
+      'bound-agent', ['client_credentials'], 'read', [], 'default', undefined, undefined,
+      ['clients/*', 'people/*'],
+    );
+    const tokens = await provider.exchangeClientCredentials(clientId, clientSecret!, 'read');
+    const authInfo = await provider.verifyAccessToken(tokens.access_token);
+    expect((authInfo as { boundSlugPrefixes?: string[] }).boundSlugPrefixes)
+      .toEqual(['clients/*', 'people/*']);
+  });
+
+  test('unbound client has NO boundSlugPrefixes on AuthInfo (unrestricted)', async () => {
+    const { clientId, clientSecret } = await provider.registerClientManual(
+      'unbound-agent', ['client_credentials'], 'read',
+    );
+    const tokens = await provider.exchangeClientCredentials(clientId, clientSecret!, 'read');
+    const authInfo = await provider.verifyAccessToken(tokens.access_token);
+    expect((authInfo as { boundSlugPrefixes?: string[] }).boundSlugPrefixes).toBeUndefined();
+  });
+
   test('expired token is rejected', async () => {
     // Insert a token that's already expired
     const expiredToken = generateToken('gbrain_at_');


### PR DESCRIPTION
## TL;DR

  `oauth_clients.bound_slug_prefixes` (migration v85, agent-binding wave) already
  bounds what a client may delegate to subagents on the WRITE side
  (`submit_agent`). This PR completes the binding on the READ side: a client
  bound to e.g. `['clients/*', 'people/*']` is now confined to matching slugs
  across every read surface. One column, one concept — the slug-prefix authority
  of the OAuth client.

  > Design-first PR: we built this because we needed it in production (one
  > company brain, per-teammate tokens), and we tried to follow the house
  > patterns closely (`sourceScopeOpts` ladder, fail-closed trust, engine
  > parity, no-oracle errors). If you'd rather fold per-prefix read ACL into
  > the mounts/brains access-policy story or a different shape, happy to
  > rework — flagging the need + a working implementation either way.

  ## Use case

  One brain, one vault, several team members with different access levels.
  Splitting the vault into sources breaks every `[[wikilink]]` (slugs lose
  their prefix); per-prefix token binding keeps the vault intact:

  ```bash
  gbrain auth register-client teammate-agent \
    --scopes read \
    --bound-slug-prefixes "clients/*,people/*,tools/*"

  The teammate's agent (a downstream OpenClaw, Claude Code over MCP, …) can
  search, read, and traverse clients/** and people/**, and never sees —
  or learns the existence of — anything under other prefixes.

  Semantics

  - Glob semantics are exactly matchesSlugAllowList (the existing
  write-side matcher): clients/* = all descendants (not the bare slug
  clients), a bare entry = exactly that slug. SQL side and TS side share
  the same contract, pinned by tests.
  - bound_slug_prefixes = NULL (every existing client) → unrestricted.
  Zero behavior change for current deployments; no migration needed (v85
  column already exists).
  - [] (explicit empty) → fail-closed, sees nothing — mirror of the
  allowedSources empty-array rule in sourceScopeOpts.
  - Out-of-binding single-slug reads throw page_not_found with the standard
  message — no existence oracle: indistinguishable from a missing page.
  - No per-call opt-out (deliberately unlike source_id='__all__'): the
  binding is a trust boundary, not a routing convenience.

  What's in the diff (by area)

  Auth plumbing
  - AuthInfo.boundSlugPrefixes projected by verifyAccessToken from
  oauth_clients.bound_slug_prefixes. Fallback chain extended so
  v61..v84 brains (federated_read present, binding column absent) retain
  their federated scope instead of degrading to the v60 projection.
  - registerClientManual + CLI gbrain auth register-client --bound-slug-prefixes p1,p2. On a
  pre-v85 schema it refuses loudly
  rather than silently minting an unbound client.

  Op layer (src/core/operations.ts) — slug-axis siblings of sourceScopeOpts
  - slugScopeOpts(ctx) — the canonical accessor (null = unrestricted).
  - assertSlugReadable(ctx, slug) — throws page_not_found (no oracle).
  - filterRowsBySlugBinding(ctx, rows, slugOf) — post-filter for
  list-shaped results.
  - Wired into: get_page (incl. fuzzy candidates), search, query (text
    - image branches), list_pages, get_tags, get_links,
  get_backlinks, traverse_graph (nodes pruned AND visible nodes' edges
  into hidden prefixes pruned), get_timeline, get_versions,
  get_raw_data, resolve_slugs, get_chunks, get_ingest_log,
  recall (entity_slug; NULL-entity rows dropped fail-closed for bound
  callers), takes_list, takes_search, find_experts, find_orphans,
  get_recent_salience, find_anomalies, find_trajectory,
  find_contradictions (both sides must be visible), think (gather
  streams: pages SQL-side, takes + graph post-filtered).

  SQL layer
  - SearchOpts.restrict_slug_prefixes (trust filter, distinct from the
  include/exclude ranking-policy knobs) + buildSlugAllowClause in
  sql-ranking.ts (positive inverse of buildHardExcludeClause,
  LIKE-escaped). Folded into the same interpolation site as the
  hard-exclude clause in searchKeyword / searchVector /
  searchKeywordChunks, both engines — every query shape that honors
  hard-excludes honors the binding by construction.
  - PageFilters.restrictSlugPrefixes on listPages, both engines.
  - hybrid.ts: the field is added to the explicit searchOpts pick (per
  the MUST-add comment for source-scoping fields), and restricted calls
  bypass query_cache entirely (binding is not in the cache key —
  same posture as adaptiveReturn; folding it into knobsHash is the
  natural follow-up if you'd rather cache).

  Tests

  - New test/e2e/slug-isolation-pglite.test.ts (18 cases), modeled on
  source-isolation-pglite.test.ts: engine layer + op layer, confinement
  on every surface, bare-vs-glob semantics, empty-binding fail-closed,
  LIKE-metachar escaping (a _ in a prefix can't act as a wildcard),
  link/backlink/graph leak guards, no-existence-oracle, unbound
  back-compat.
  - 2 new AuthInfo projection cases in test/oauth.test.ts.
  - bun run typecheck clean; oauth (93), source-isolation,
  sql-ranking, search, search-exclude, operations-trust-boundary
  suites green (251 cases).
  - Validated end-to-end on a production brain (~1.7K pages): bound
  client_credentials token → /token → /mcp — broad + targeted
  searches, direct get_page on hidden slugs, list_pages,
  resolve_slugs: zero leaks; legacy/unbound tokens unaffected.

  Known v1 limitation (documented in code)

  traverse_graph drops hidden nodes and prunes visible nodes' edges into
  hidden prefixes, but a multi-hop walk THROUGH a hidden node can still
  surface a visible far node — i.e. the existence of some path, never
  content. Stopping traversal at the binding frontier would be the stricter
  alternative; we kept v1 simple and called it out.

  Compatibility

  - No schema migration (v85 column reused).
  - No behavior change for any existing client (NULL binding = unrestricted).
  - New SearchOpts/PageFilters fields are optional and ignored when unset.