### PR TITLE
fix(sync): coerce YAML-auto-parsed frontmatter scalars to string

### DIFF
--- a/src/core/content-sanity.ts
+++ b/src/core/content-sanity.ts
@@ -376,14 +376,22 @@ export function assessContentSanity(opts: {
   // doesn't repeat the lowercase per literal.
   const bodyHead = body.slice(0, SCAN_HEAD_BYTES);
   const bodyHeadLower = bodyHead.toLowerCase();
-  const titleLower = opts.title.toLowerCase();
+  // Defense-in-depth coercion. parseMarkdown now normalizes frontmatter
+  // titles via coerceFrontmatterString (e.g. YAML auto-parses unquoted
+  // `title: 2026-06-03` to a Date), but assessContentSanity is also called
+  // directly from MCP put_page, lint, sources audit, doctor, and quarantine
+  // — any of which could be handed a non-string title from a caller that
+  // hasn't gone through parseMarkdown. Skipping a journal entry because a
+  // .toLowerCase() crashed is a worse failure than a one-line String() guard.
+  const titleStr = typeof opts.title === 'string' ? opts.title : String(opts.title ?? '');
+  const titleLower = titleStr.toLowerCase();
 
   const junk_pattern_matches: string[] = [];
   for (const p of BUILT_IN_JUNK_PATTERNS) {
     const scope = p.applies_to ?? 'both';
     let matched = false;
     if (scope === 'title' || scope === 'both') {
-      if (p.pattern.test(opts.title)) matched = true;
+      if (p.pattern.test(titleStr)) matched = true;
     }
     if (!matched && (scope === 'body' || scope === 'both')) {
       if (p.pattern.test(bodyHead)) matched = true;

--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -105,12 +105,12 @@ export function parseMarkdown(
 
   const { compiled_truth, timeline } = splitBody(body);
 
-  const type = (frontmatter.type as string) || (
+  const type = coerceFrontmatterString(frontmatter.type) || (
     opts?.activePack ? inferTypeFromPack(filePath, opts.activePack) : inferType(filePath)
   );
-  const title = (frontmatter.title as string) || inferTitle(filePath);
+  const title = coerceFrontmatterString(frontmatter.title) || inferTitle(filePath);
   const tags = extractTags(frontmatter);
-  const slug = (frontmatter.slug as string) || inferSlug(filePath);
+  const slug = coerceFrontmatterString(frontmatter.slug) || inferSlug(filePath);
 
   const cleanFrontmatter = { ...frontmatter };
   delete cleanFrontmatter.type;
@@ -564,6 +564,47 @@ function inferTitle(filePath?: string): string {
   const parts = filePath.split('/');
   const filename = parts[parts.length - 1]?.replace(/\.md$/i, '') || 'Untitled';
   return filename.replace(/[-_]/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+/**
+ * Coerce a frontmatter scalar (title / slug / type) into a string.
+ *
+ * Why this exists: js-yaml (via gray-matter) auto-parses unquoted scalars by
+ * YAML 1.1 tag-resolution rules. `title: 2026-06-03` therefore parses to a
+ * `Date` object, not a string — and downstream code (`assessContentSanity`,
+ * embedding-context `sanitizeTitle`, slug derivation) calls `.toLowerCase()`
+ * / `.replace()` / `.trim()` on it and throws `opts.title.toLowerCase is not
+ * a function`. Same hazard for numeric scalars (`title: 2026`), booleans
+ * (`title: yes` → true), nulls (`title: ~`), and timestamps.
+ *
+ * The old code used `(frontmatter.title as string) || ...` which was a
+ * compile-time-only cast — a runtime lie. This helper does the real coercion:
+ *
+ *  - string                  → trimmed string (passthrough)
+ *  - Date                    → ISO `YYYY-MM-DD` (matches the user's literal
+ *                              intent: they wrote a date-shaped title)
+ *  - number / boolean        → `String(...)`
+ *  - null / undefined / ''   → '' (caller's `||` fallback then takes over)
+ *  - object / array          → '' (fall through to inferTitle — pathological
+ *                              shapes like `title: [a, b]` shouldn't masquerade
+ *                              as a real title)
+ *
+ * This is the root-cause fix for the sync skip-class that quietly drops
+ * Obsidian journal entries with unquoted ISO-date titles.
+ */
+function coerceFrontmatterString(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (value instanceof Date) {
+    // YAML-spec Dates are always UTC-anchored when no offset is given, so
+    // toISOString() preserves the user's literal day-of-year.
+    return value.toISOString().slice(0, 10);
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  // null, undefined, object, array → empty string. Caller's `||` falls
+  // through to the inference function (inferTitle/inferSlug/inferType).
+  return '';
 }
 
 function inferSlug(filePath?: string): string {

--- a/test/content-sanity.test.ts
+++ b/test/content-sanity.test.ts
@@ -640,3 +640,45 @@ describe('assessContentSanity — confidence split (Q1=A)', () => {
     expect(r.shouldFlag).toBe(false);
   });
 });
+
+// ─── NON-STRING TITLE COERCION ────────────────────────────────
+//
+// Regression: a caller may hand us a non-string title (e.g. a YAML
+// auto-parsed Date from gray-matter, or `undefined` from a malformed
+// frontmatter). The pre-fix code called `opts.title.toLowerCase()` directly
+// and threw "opts.title.toLowerCase is not a function", which silently
+// skipped every Obsidian journal page with an unquoted ISO-date title during
+// `gbrain sync`. parseMarkdown coerces at parse time; assessContentSanity
+// coerces defensively here as a second wall (it has callers besides
+// import-file).
+
+describe('assessContentSanity — non-string title coercion (defense-in-depth)', () => {
+  test('Date title (YAML-auto-parsed unquoted ISO date) does not crash', () => {
+    const dateTitle = new Date('2026-06-03T00:00:00.000Z') as unknown as string;
+    const r = assessContentSanity({
+      compiled_truth: 'A journal entry from June 3.',
+      timeline: '',
+      title: dateTitle,
+    });
+    expect(r.shouldQuarantine).toBe(false);
+    expect(r.shouldFlag).toBe(false);
+  });
+
+  test('undefined title does not crash', () => {
+    const r = assessContentSanity({
+      compiled_truth: 'body',
+      timeline: '',
+      title: undefined as unknown as string,
+    });
+    expect(r.shouldQuarantine).toBe(false);
+  });
+
+  test('numeric title does not crash', () => {
+    const r = assessContentSanity({
+      compiled_truth: 'body',
+      timeline: '',
+      title: 2026 as unknown as string,
+    });
+    expect(r.shouldQuarantine).toBe(false);
+  });
+});

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -107,6 +107,108 @@ Content
     const parsed = parseMarkdown(md, path);
     expect(parsed.type).toBe(expectedType);
   });
+
+  // Regression: YAML auto-parses unquoted scalars by type tag. An unquoted
+  // ISO-date title (`title: 2026-06-03`) used to surface as a `Date` object,
+  // which crashed every downstream `.toLowerCase()` / `.replace()` /
+  // `.trim()` call (assessContentSanity, sanitizeTitle, slug derivation) with
+  // "opts.title.toLowerCase is not a function" — silently skipping every
+  // Obsidian daily-journal entry during `gbrain sync`. parseMarkdown now
+  // coerces non-string scalars at parse time so the ParsedMarkdown contract
+  // (title: string) is actually honored at runtime.
+  describe('frontmatter scalar coercion (YAML auto-typing)', () => {
+    test('unquoted ISO-date title parses to YYYY-MM-DD string, not a Date', () => {
+      const md = `---
+title: 2026-06-03
+type: journal
+---
+Today's entry.
+`;
+      const parsed = parseMarkdown(md, 'journal/2026-06-03.md');
+      expect(typeof parsed.title).toBe('string');
+      expect(parsed.title).toBe('2026-06-03');
+      // The whole reason this regression exists: downstream calls .toLowerCase()
+      // on the title. If we ever regress, this line throws.
+      expect(parsed.title.toLowerCase()).toBe('2026-06-03');
+    });
+
+    test('unquoted full timestamp title parses to YYYY-MM-DD string', () => {
+      const md = `---
+title: 2026-06-03T10:30:00Z
+type: journal
+---
+Body
+`;
+      const parsed = parseMarkdown(md, 'journal/entry.md');
+      expect(typeof parsed.title).toBe('string');
+      expect(parsed.title).toBe('2026-06-03');
+    });
+
+    test('quoted ISO-date title stays a string (no regression)', () => {
+      const md = `---
+title: "2026-06-03"
+type: journal
+---
+Body
+`;
+      const parsed = parseMarkdown(md, 'journal/2026-06-03.md');
+      expect(parsed.title).toBe('2026-06-03');
+    });
+
+    test('numeric title (e.g. year) coerces to string', () => {
+      const md = `---
+title: 2026
+type: note
+---
+Body
+`;
+      const parsed = parseMarkdown(md);
+      expect(typeof parsed.title).toBe('string');
+      expect(parsed.title).toBe('2026');
+    });
+
+    test('explicit boolean title (`title: true`) coerces to string', () => {
+      // YAML 1.2 only treats `true`/`false` as booleans (js-yaml default;
+      // unlike YAML 1.1's `yes`/`no`/`on`/`off`). Coercing to "true" is
+      // better than crashing — the user wrote a literal scalar and gets a
+      // literal scalar back as a string.
+      const md = `---
+title: true
+type: note
+---
+Body
+`;
+      const parsed = parseMarkdown(md);
+      expect(typeof parsed.title).toBe('string');
+      expect(parsed.title).toBe('true');
+    });
+
+    test('null title (`title: ~`) falls back to inferred title', () => {
+      const md = `---
+title: ~
+type: note
+---
+Body
+`;
+      const parsed = parseMarkdown(md, 'notes/standup-2026-06-03.md');
+      expect(typeof parsed.title).toBe('string');
+      // Falls through `|| inferTitle(filePath)` once coercion returns ''.
+      expect(parsed.title).toBe('Standup 2026 06 03');
+    });
+
+    test('unquoted ISO-date slug coerces (same hazard as title)', () => {
+      const md = `---
+title: Daily Journal
+slug: 2026-06-03
+type: journal
+---
+Body
+`;
+      const parsed = parseMarkdown(md, 'journal/2026-06-03.md');
+      expect(typeof parsed.slug).toBe('string');
+      expect(parsed.slug).toBe('2026-06-03');
+    });
+  });
 });
 
 describe('splitBody', () => {


### PR DESCRIPTION
## Summary

YAML auto-resolves unquoted scalars by tag — `title: 2026-06-03` therefore parses to a JavaScript `Date` object (not a string), `title: 2026` to a number, `title: true` to a boolean. `parseMarkdown` returned the raw value behind an `as string` cast that was a compile-time-only lie. Every consumer that called `.toLowerCase()` / `.replace()` / `.trim()` on `parsed.title` (`assessContentSanity`, `sanitizeTitle`, slug derivation, the intent-weights ranker) crashed with:

```
opts.title.toLowerCase is not a function
```

For `gbrain sync --source <obsidian-vault>`, the symptom was silent: each file with an unquoted ISO-date title (every daily-journal entry) was caught by `--skip-failed` and dropped. ~28 journal entries vanished from a single overnight sync run before the pattern was identified. The contained reproduction:

```yaml
---
title: 2026-06-03
type: journal
---
```

…crashes `assessContentSanity` at the line `opts.title.toLowerCase()`.

## Fix

- `parseMarkdown` now coerces `frontmatter.title` / `.slug` / `.type` via a shared `coerceFrontmatterString` helper so the `ParsedMarkdown.title: string` contract is honored at runtime:
  - `string` → trimmed string (passthrough)
  - `Date` → ISO `YYYY-MM-DD` (matches user's literal intent)
  - `number` / `boolean` → `String(...)`
  - `null` / `undefined` / `''` → `''` (caller's `||` fallback then fires)
  - `object` / `array` → `''` (falls through to `inferTitle` / `inferSlug` / `inferType`)
- `assessContentSanity` adds a defense-in-depth coercion at the title callsite. It has direct callers (MCP `put_page`, `lint`, `doctor`, `sources audit`, `quarantine`) that don't all flow through `parseMarkdown`, and the cost of a one-line `String(...)` guard is zero compared to a silent page-skip.

## Test plan

- [x] `test/markdown.test.ts` — new `frontmatter scalar coercion (YAML auto-typing)` describe block covers: unquoted ISO date, full timestamp, quoted ISO date (no-regression), numeric title, boolean title, null title (falls back to inference), unquoted ISO-date slug.
- [x] `test/content-sanity.test.ts` — new `non-string title coercion (defense-in-depth)` block exercises Date, `undefined`, and numeric titles handed directly to `assessContentSanity`.
- [x] 231/231 tests pass across the affected surfaces (`markdown`, `markdown-validation`, `markdown-serializer`, `content-sanity`, `content-sanity-literals`, `import-file-content-sanity`, `lint-content-sanity`, `ingestion/markdown-greenfield`).
- [x] `bunx tsc --noEmit` clean.
- [x] `bun run verify` — 29/30 checks pass. The one failure (`check:resolver`) is pre-existing on master and unrelated (orphan-trigger entries in a local skills dir).
- [x] Manual reproduction: minimal date-titled fixture crashed `assessContentSanity` before the fix; same fixture parses cleanly to `title: "2026-06-03"` (typeof string) after.

## Out of scope (filed if it survives investigation)

Mike's overnight sync also surfaced a trailing `The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined` error during sync finalization that leaves `sources.last_sync_at` un-advanced. No stack trace was captured in the original run; needs a reproduction before a targeted fix. Investigation narrowed it to the post-import phase (`extract` / `facts` / `embed`) but a real reproduction is required to land a clean fix.

Co-Authored-By: Michael Adair <michaeladair44@gmail.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)