### PR TITLE
fix(propose_takes): add excludeSlugPrefixes to skip low-signal pages

### DIFF
--- a/src/core/cycle/propose-takes.ts
+++ b/src/core/cycle/propose-takes.ts
@@ -145,6 +145,10 @@ export interface ProposeTakesOpts extends BasePhaseOpts {
   model?: string;
   /** Skip pages that already have a complete takes fence. Default: true. */
   skipPagesWithFence?: boolean;
+  /** Slug prefixes to exclude from proposal scanning (e.g. ["extracts/", "01-raw/"]). 
+   *  Pages whose slug starts with any of these prefixes are skipped before the 
+   *  LLM call, saving tokens on low-signal content. Defaults to ["extracts/"]. */
+  excludeSlugPrefixes?: string[];
 }
 
 export interface ProposeTakesResult {
@@ -307,6 +311,7 @@ class ProposeTakesPhase extends BaseCyclePhase {
     const promptVersion = opts.promptVersion ?? PROPOSE_TAKES_PROMPT_VERSION;
     const pageLimit = opts.pageLimit ?? 100;
     const skipPagesWithFence = opts.skipPagesWithFence ?? false;
+    const excludeSlugPrefixes = opts.excludeSlugPrefixes ?? ['extracts/'];
     const proposalRunId = `propose-${new Date().toISOString().slice(0, 19).replace(/[-:T]/g, '')}-${randomUUID().slice(0, 8)}`;
 
     const result: ProposeTakesResult = {
@@ -333,6 +338,12 @@ class ProposeTakesPhase extends BaseCyclePhase {
     for (const page of pages) {
       result.pages_scanned += 1;
       this.tick(opts);
+
+      // Skip pages whose slug matches any configured exclusion prefix.
+      // Extracts/ pages are extraction receipts (metadata about what was
+      // processed, not original content) — proposing takes against them wastes
+      // LLM tokens without producing useful knowledge. Default: ["extracts/"].
+      if (excludeSlugPrefixes.length > 0 && excludeSlugPrefixes.some(p => page.slug.startsWith(p))) continue;
 
       // Skip pages that have NO prose body (e.g. metadata-only entity stubs).
       const body = page.compiled_truth ?? '';


### PR DESCRIPTION
## Problem

`propose_takes` processes **all** pages returned by `listPages`, including `extracts/` pages that are extraction receipts — metadata records about what was processed during extraction runs, not original user content.

Each `extracts/` page that passes the empty-body and dedup checks triggers a full LLM call (~1500 input + 500 output tokens), wasting budget on pages that will never produce useful takes.

This is an inconsistency with how **search** already handles extract receipts: `DEFAULT_SOURCE_BOOSTS` demotes `extracts/` to 0.3 and they can be hard-excluded via `DEFAULT_HARD_EXCLUDES`. But `propose_takes` has no equivalent filtering — it treats them the same as user-authored pages.

## Why this wastes tokens concretely

A typical brain with regular extraction runs accumulates hundreds of `extracts/` receipt pages. These pages contain structured metadata (source_id, round, run_id, counts) — exactly the kind of low-prose, high-metadata content that produces empty or trivial takes.

With `pageLimit: 100` and `sort: updated_desc`, these frequently-updated receipt pages can crowd out actual user content from the processing window, meaning:
1. LLM tokens spent on receipts → no useful takes returned
2. Real user pages may not get processed within the page limit
3. Budget is consumed without proportional knowledge gain

## Solution

Add `excludeSlugPrefixes` option to `ProposeTakesOpts`:
- Default: `['extracts/']` — consistent with search's demotion of extract receipts
- Configurable — callers can pass additional prefixes or empty array to opt out
- Skips matching pages **before** the LLM call, not after

This mirrors the existing `skipPagesWithFence` pattern: a boolean-style exclusion that's on by default and opt-out if not wanted.

## Impact

- Zero behavioral change for brains with no `extracts/` pages
- For brains with extraction receipts: saves 1 LLM call per receipt page per cycle
- No config file changes required — uses the same opts pattern as `skipPagesWithFence`
- The `pageLimit` budget now goes further since it's not spent on receipts

## Testing

- TypeScript compiles cleanly
- No debug/temporary code
- Backward compatible — default includes the most common low-signal prefix
- Empty array disables filtering for users who want the old behavior