### PR TITLE
fix: wikilink slug case-normalization (silently dropped edges) + autopilot reconnect recovery

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -529,8 +529,8 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
       autopilotReconnectFails = 0; // reset on success
     } catch (probeErr) {
       try {
-        await engine.disconnect();
-        await (engine as any).connect?.();
+        // Reuse saved config; connect() with no args crashed on config.poolSize.
+        await (engine as any).reconnect?.();
         autopilotReconnectFails = 0;
       } catch (e) {
         logError('reconnect', e);

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -82,7 +82,7 @@ export type LinkResolutionType = 'qualified' | 'unqualified';
  *   - Our domain extensions: tech, finance, personal, openclaw (domain-organized wikis)
  *   - Our entity prefix: entities (we kept some legacy entities/projects/ pages)
  */
-const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities)';
+const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|deals|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities|analysis|medical|writing|group-chats|tools|vendors|books)';
 
 /**
  * Match `[Name](path)` markdown links pointing to entity directories.
@@ -311,8 +311,11 @@ export function extractEntityRefs(content: string): EntityRef[] {
   while ((match = mdPattern.exec(stripped)) !== null) {
     const name = match[1];
     const fullPath = match[2];
-    const slug = fullPath;
-    const dir = fullPath.split('/')[0];
+    // Canonical slugs are lowercase; normalize so `analysis/THE-PORTRAIT`
+    // resolves to the real page `analysis/the-portrait` (the addLinksBatch
+    // JOIN on pages is case-sensitive — a mismatch silently drops the edge).
+    const slug = fullPath.toLowerCase();
+    const dir = slug.split('/')[0];
     refs.push({ name, slug, dir });
     markdownRanges.push([match.index, match.index + match[0].length]);
   }
@@ -329,6 +332,7 @@ export function extractEntityRefs(content: string): EntityRef[] {
     if (slug.includes('://')) continue;
     if (slug.endsWith('.md')) slug = slug.slice(0, -3);
     const displayName = (match[3] || slug).trim();
+    slug = slug.toLowerCase();
     const dir = slug.split('/')[0];
     refs.push({ name: displayName, slug, dir, sourceId });
     qualifiedRanges.push([match.index, match.index + match[0].length]);
@@ -345,6 +349,7 @@ export function extractEntityRefs(content: string): EntityRef[] {
     if (slug.includes('://')) continue;
     if (slug.endsWith('.md')) slug = slug.slice(0, -3);
     const displayName = (match[2] || slug).trim();
+    slug = slug.toLowerCase();
     const dir = slug.split('/')[0];
     refs.push({ name: displayName, slug, dir });
     unqualifiedRanges.push([match.index, match.index + match[0].length]);


### PR DESCRIPTION
Two small but high-impact bug fixes, both found and verified against a live ~1,900-page Postgres brain.

## 1. `link-extraction`: wikilink/markdown slug targets aren't case-normalized

`addLinksBatch` inserts edges with `INSERT ... SELECT FROM unnest(...) JOIN pages ON p.slug = target`. That JOIN is case-sensitive, so any link whose target isn't already lowercased silently produces **no row** — the edge is dropped and the target page looks orphaned.

In practice this hits every index/hub link written in mixed case, e.g. `[[people/INDEX]]` → target `people/INDEX` → no match for the real page `people/index` → edge dropped. `dead_links` stays 0 (nothing is stored), so the failure is invisible; the page just shows up as an orphan.

**Fix:** lowercase the slug (not the display name) in all three `extractEntityRefs` passes (markdown link, qualified wikilink, unqualified wikilink). Canonical slugs are already lowercase (the resolver regex enforces it), so this is safe.

Also extends `DIR_PATTERN` with additional knowledge-base directories that were silently un-extractable (`deals` — note the existing entry was singular `deal` only — plus `analysis`, `medical`, `writing`, `group-chats`, `tools`, `vendors`, `books`). Longer term `DIR_PATTERN` would be better as configurable rather than hardcoded; this is the immediate fix.

**Verified in production:** after deploying, pages with inbound links appeared in directories that previously had zero (`deals/` 42, `medical/` 28, `group-chats/` 123, `analysis/` 11, `books/` 11), with no change to the already-working `people/`/`companies/`.

## 2. `autopilot`: reconnect path calls `connect()` with no arguments

In the cycle DB-health check, on a dropped connection the recovery path calls `await (engine as any).connect?.()` with **no config**, so `PostgresEngine.connect(config)` immediately evaluates `config.poolSize` on `undefined` and throws `undefined is not an object (evaluating 'config.poolSize')`. The daemon can never recover from a dropped connection and trips the consecutive-failure cap. (The `#1162` error-classification wraps this call but doesn't fix the root cause.)

**Fix:** call `engine.reconnect()`, which already exists and tears down the dead pool + re-dials using the config saved at startup.

Observed in production as the daemon going dead for ~2 weeks after a connection blip; after the fix it survives drops and resumes cycling.

---

Happy to add unit tests for the slug case-normalization (the `extractEntityRefs` lowercasing is straightforward to cover) and split into two PRs if preferred.
