### PR TITLE
fix: extend statement_timeout for initSchema DDL on large brains

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -76,7 +76,24 @@ export class PostgresEngine implements BrainEngine {
     // on DDL statements (DROP TRIGGER + CREATE TRIGGER acquire AccessExclusiveLock)
     await conn`SELECT pg_advisory_lock(42)`;
     try {
-      await conn.unsafe(SCHEMA_SQL);
+      // SCHEMA_SQL includes index builds (e.g. the HNSW idx_chunks_embedding)
+      // that can exceed Supabase's ~2 min server statement_timeout on a large
+      // brain, aborting the whole batch with SQLSTATE 57014. Run the schema on a
+      // reserved backend with an extended session-scoped timeout — the same
+      // primitive and rationale as runMigrationSQL's transaction:false path
+      // (a plain SET on the pool would leak the GUC onto other connections).
+      // A bigger maintenance_work_mem keeps index builds off the slow on-disk
+      // path. Both SETs are best-effort: managed Postgres may restrict them, in
+      // which case the DDL runs with server defaults.
+      await this.withReservedConnection(async (rconn) => {
+        try {
+          await rconn.executeRaw("SET statement_timeout = '600000'");
+          await rconn.executeRaw("SET maintenance_work_mem = '256MB'");
+        } catch {
+          // Non-fatal: fall through and run with server defaults.
+        }
+        await rconn.executeRaw(SCHEMA_SQL);
+      });
 
       // Run any pending migrations automatically
       const { applied } = await runMigrations(this);


### PR DESCRIPTION
## Problem

`PostgresEngine.initSchema()` runs `SCHEMA_SQL` on a pooled connection with **no `statement_timeout` override**. The schema batch includes index builds — notably the HNSW `idx_chunks_embedding` on `content_chunks` — that can run longer than Supabase's ~2 min server-enforced `statement_timeout` once a brain grows. When that happens the whole batch aborts with `SQLSTATE 57014` (`canceling statement due to statement timeout`), and since the batch is a single implicit transaction, nothing in it commits.

This wedges `gbrain init --migrate-only`, which is exactly what the v0.11.0 migration's Phase A shells out to (`execSync('gbrain init --migrate-only', { timeout: 60_000 })`). The Node-side 60s wrapper masks it as a `spawnSync ETIMEDOUT`; running the command directly surfaces the real server-side cancellation at ~2 min.

`runMigrationSQL` already solves this for its `transaction:false` path using the reserved-connection primitive from #356 — `initSchema` was the remaining gap that doesn't get that treatment.

## Fix

Run `SCHEMA_SQL` inside `withReservedConnection`, setting a session-scoped `statement_timeout = '600000'` and a larger `maintenance_work_mem = '256MB'` on that dedicated backend before the DDL (a larger `maintenance_work_mem` keeps index builds off the slow on-disk path). This mirrors `runMigrationSQL`'s established pattern and rationale: a plain `SET` on the pool would leak the GUC onto other connections, so it goes on a reserved backend instead.

Both `SET`s are best-effort (wrapped in try/catch): if a managed Postgres restricts them, the DDL falls through and runs with server defaults — same behavior as `runMigrationSQL`.

## Notes

- No change to the tagged-template `sql\`...\`` form, so the `test/postgres-engine.test.ts` bare-`SET statement_timeout` source guardrail stays satisfied (uses `executeRaw` on a reserved connection, the approved #356 pattern).
- Reproduced on a ~10k-chunk Supabase brain where the v0.11.0→0.18.1 chain was wedged at Phase A; with this change the schema applies cleanly and the full chain completes.

## Testing

- `bun test` — full unit suite green (2086 pass; the 18 fail / 3 errors are all `test/e2e/*` skipping because `DATABASE_URL` isn't set locally).
- `test/postgres-engine.test.ts` — 6/6 pass (guardrail intact).
- E2E migration path (`migrate-chain`, `migration-flow`) not run locally (no test DB); CI exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)