### PR TITLE
fix(import): normalize slug casing at importFromContent entry (mixed-case slugs no longer 404)

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -36,7 +36,7 @@ import {
 } from './embedding-context.ts';
 import { loadSearchModeConfig, resolveSearchMode } from './search/mode.ts';
 import { normalizeAliasList } from './search/alias-normalize.ts';
-import { isUndefinedTableError, warnOncePerProcess } from './utils.ts';
+import { isUndefinedTableError, warnOncePerProcess, validateSlug } from './utils.ts';
 import { computeCorpusGeneration } from './contextual-retrieval-service.ts';
 import { runGuardrails } from './guardrails.ts';
 
@@ -284,6 +284,14 @@ export async function importFromContent(
     remote?: boolean;
   } = {},
 ): Promise<ImportResult> {
+  // Normalize the slug ONCE at the entry point so every downstream tx call
+  // agrees on casing. putPage runs validateSlug (→ lowercase) internally, but
+  // addTag / upsertChunks do NOT — a mixed-case slug therefore wrote the page
+  // under a lowercased key while addTag and the chunk/return paths used the
+  // original casing, producing a spurious "Page not found" that left the row
+  // unreachable. Normalizing here keeps putPage / addTag / upsertChunks / the
+  // returned slug consistent.
+  slug = validateSlug(slug);
   // v0.18.0+ multi-source: when caller is syncing under a non-default source,
   // every per-page tx call must carry `sourceId` so writes target the right
   // (source_id, slug) row. Pre-fix, putPage relied on the schema DEFAULT and

--- a/test/slug-case-regression.test.ts
+++ b/test/slug-case-regression.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression — a mixed-case slug must round-trip through importFromContent.
+ *
+ * Pre-fix bug:
+ *   - putPage runs validateSlug (→ lowercase) internally, but addTag /
+ *     upsertChunks do NOT, and importFromContent passed the caller's original
+ *     (mixed-case) slug straight through to every per-page tx call. A slug like
+ *     `topics/Mixed-CASE` therefore wrote the page row under the lowercased key
+ *     while addTag queried `WHERE slug = 'topics/Mixed-CASE'` — a miss — and
+ *     threw `addTag failed: page "..." not found`, rolling back the whole tx.
+ *     The row became permanently unwritable under that slug.
+ *   - This bit every ingestion source whose IDs carry uppercase (Lark / Feishu
+ *     doc tokens are mixed-case base62, GitHub repo paths, etc.), surfacing as a
+ *     spurious "Page not found" from `gbrain capture` / `put_page`.
+ *
+ * Fix: importFromContent normalizes the slug once at the entry point
+ * (`slug = validateSlug(slug)`), so putPage / addTag / upsertChunks / the
+ * returned slug all agree on casing.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { importFromContent } from '../src/core/import-file.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ type: 'pglite' } as never);
+  await engine.initSchema();
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 60_000);
+
+describe('importFromContent normalizes mixed-case slugs', () => {
+  test('mixed-case slug with tags imports cleanly and is retrievable lowercased', async () => {
+    const slug = 'topics/Mixed-CASE-Slug';
+    const content = [
+      '---',
+      'title: Mixed Case Slug',
+      'type: note',
+      'tags: [regression]',
+      '---',
+      '# Mixed Case Slug',
+      'Body content so the chunk path runs too.',
+    ].join('\n');
+
+    // Pre-fix this rejected with `addTag failed: page "topics/Mixed-CASE-Slug"
+    // not found` and rolled back the import.
+    const res = await importFromContent(engine, slug, content, { noEmbed: true });
+    expect(res.status).not.toBe('error');
+
+    // Stored under the normalized (lowercased) slug and retrievable.
+    const page = await engine.getPage('topics/mixed-case-slug');
+    expect(page).not.toBeNull();
+    expect(page!.slug).toBe('topics/mixed-case-slug');
+
+    // Tag reconciliation (addTag) succeeded — the part that used to throw.
+    const tags = await engine.getTags('topics/mixed-case-slug');
+    expect(tags).toContain('regression');
+  });
+});


### PR DESCRIPTION
## What

`importFromContent` now normalizes the slug once at its entry point (`slug = validateSlug(slug)`), so every per-page tx call agrees on casing.

## Why (root cause)

`putPage` runs `validateSlug` (→ lowercase) internally, but `addTag` and `upsertChunks` do **not** — and `importFromContent` passed the caller's original slug straight through to all of them.

So a **mixed-case slug** wrote the page row under a lowercased key, while `addTag` queried `WHERE slug = '<original-case>'` (a miss) and threw `addTag failed: page "..." not found`, rolling back the whole import. The row then became **permanently unwritable** under that slug.

This bites every ingestion source whose IDs carry uppercase — Lark/Feishu doc tokens (mixed-case base62), GitHub repo paths, etc. — surfacing as a spurious "Page not found" from `gbrain capture` / `put_page`.

## Minimal repro (before this PR)

```
echo body | gbrain capture --stdin --slug Mixed-CASE   # put_page failed: Page not found: Mixed-CASE
echo body | gbrain capture --stdin --slug mixed-case   # works
```

## Fix

One-line normalization at the `importFromContent` entry point — covers `capture` / `put_page` / `sync` (all ingestion flows through here). `putPage`'s internal `validateSlug` stays (idempotent).

## Test

`test/slug-case-regression.test.ts` — imports a mixed-case slug with a tag and asserts it round-trips (retrievable lowercased, tag reconciled). Pre-fix this threw at `addTag`.

## Note

The deeper inconsistency is at the engine layer: `addTag` / `upsertChunks` don't run `validateSlug` while `putPage` does. Normalizing at the `importFromContent` entry fixes all ingestion paths with the smallest diff; glad to also add `validateSlug` to `addTag`/`upsertChunks` in both engines if you'd prefer defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)