### PR TITLE
fix: enable litellm-proxy for chat and embedding, fix user_provided_m…

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -705,19 +705,26 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   }
 
   // Openai-compat recipes with empty models list require a user-provided model.
+  // When user_provided_models is set, only block if the modelId is empty
+  // (user hasn't configured a specific model via e.g. litellm:<model>).
+  // If they have provided one, skip this check — the gateway behind the proxy
+  // validates the model at call time.
   const isUserProvided = (tp as any).user_provided_models === true;
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
     (recipe.id === 'litellm' || isUserProvided)
   ) {
-    return {
-      ok: false,
-      reason: 'user_provided_model_unset',
-      model: modelStr,
-      provider: parsed.providerId,
-      recipeId: recipe.id,
-    };
+    if (!parsed.modelId) {
+      return {
+        ok: false,
+        reason: 'user_provided_model_unset',
+        model: modelStr,
+        provider: parsed.providerId,
+        recipeId: recipe.id,
+      };
+    }
+    // User provided a model — continue to auth-env check below.
   }
 
   const required = recipe.auth_env?.required ?? [];

--- a/src/core/ai/recipes/litellm-proxy.ts
+++ b/src/core/ai/recipes/litellm-proxy.ts
@@ -40,6 +40,30 @@ export const litellmProxy: Recipe = {
       // mismatched-dim responses pre-storage).
       supports_multimodal: true,
     },
+    /**
+     * Chat touchpoint for the LiteLLM proxy. Since the proxy normalizes any
+     * backend to OpenAI-compatible, the same base URL serves both /embeddings
+     * and /chat/completions. Models depend on the proxy's config; declare
+     * empties with user_provided_models so the model allowlist is deferred to
+     * the proxy (the gateway behind the proxy decides what's real).
+     *
+     * Same cost=0 default as other local recipes — when the proxy fronts a
+     * paid provider, set costs via provider per-model config.
+     */
+    chat: {
+      models: [],
+      user_provided_models: true,
+      supports_tools: true,
+      supports_subagent_loop: true,
+      supports_prompt_cache: false,
+      max_context_tokens: 131072,
+      cost_per_1m_input_usd: 0,
+      cost_per_1m_output_usd: 0,
+      price_last_verified: '2026-05-29',
+    },
   },
-  setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL + pass --embedding-model litellm:<model> and --embedding-dimensions <N>.',
+  setup_hint:
+    'Run LiteLLM (https://docs.litellm.ai) in front of any provider; ' +
+    'set LITELLM_BASE_URL + pass --embedding-model litellm:<model> and --embedding-dimensions <N>. ' +
+    'For chat: gbrain config set chat_model litellm:<model>.'
 };

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -381,7 +381,7 @@ function validateDimAgainstTouchpoint(
     };
   }
 
-  if (requestedDims !== undefined && requestedDims !== defaultDims) {
+  if (requestedDims !== undefined && defaultDims > 0 && requestedDims !== defaultDims) {
     // User asked for a non-default dim. Walk the precedence chain.
     const customDimOk = isCustomDimValidForProvider(recipe, modelId, requestedDims, dimsOptions);
     if (!customDimOk.valid) {


### PR DESCRIPTION
Three changes to make litellm work as a general openai-compatible provider:

1. litellm-proxy.ts: add chat touchpoint with user_provided_models
2. gateway.ts diagnoseEmbedding(): only block user_provided_models when parsed.modelId is empty
3. embedding-dim-check.ts: skip custom-dim validation when default_dims=0

These changes were verified with llm endpoint deployed locally.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)