### PR TITLE
fix: improve runtime compatibility for schema-v2 and subagents

### DIFF
--- a/skills/schema-unify/SKILL.md
+++ b/skills/schema-unify/SKILL.md
@@ -7,7 +7,7 @@ tools:
   - gbrain onboard --check --explain
   - gbrain onboard --check --json
   - gbrain jobs submit unify-types
-  - gbrain jobs follow
+  - gbrain jobs get
   - gbrain schema active
   - gbrain schema use
   - gbrain schema stats
@@ -93,11 +93,13 @@ gbrain jobs submit unify-types \
   --params '{"target_pack":"gbrain-base-v2"}'
 ```
 
-Watch progress per phase:
+Inspect progress/result per phase:
 
 ```bash
-gbrain jobs follow <job_id>
+gbrain jobs get <job_id>
 ```
+
+Note: older skill notes referenced `gbrain jobs follow`, but this build exposes job inspection through `gbrain jobs get <job_id>`.
 
 On a 186K-page brain expect ~10 minutes. The handler runs:
 1. Preflight (validate target pack has `mapping_rules:`)
@@ -241,7 +243,7 @@ Final celebration summary to stderr:
 ═══════════════════════════════════════════════════════════
 ```
 
-JSON output (`gbrain jobs follow <id> --json`) returns the structured `UnifyTypesResult` shape with `per_phase`, `pack_identity_after`, `active_pack_flipped`.
+Job inspection (`gbrain jobs get <id>`) surfaces the structured `UnifyTypesResult` shape with `per_phase`, `pack_identity_after`, `active_pack_flipped` when the handler records it in the result payload.
 
 ## Reference
 

--- a/src/core/extract-timeline-from-meetings.ts
+++ b/src/core/extract-timeline-from-meetings.ts
@@ -63,7 +63,12 @@ export async function extractTimelineFromMeetings(
     `SELECT slug, source_id, title, effective_date, updated_at,
             compiled_truth, COALESCE(timeline, '') AS timeline
        FROM pages
-      WHERE type = 'meeting'
+      WHERE (
+              type = 'meeting'
+              OR slug LIKE 'meetings/%'
+              OR frontmatter->>'legacy_type' = 'meeting'
+              OR frontmatter->'tags' ? 'meeting'
+            )
         AND deleted_at IS NULL
         ${sourceFilter}
       ORDER BY effective_date DESC NULLS LAST, slug`,
@@ -85,7 +90,12 @@ export async function extractTimelineFromMeetings(
        JOIN pages pf ON pf.id = l.from_page_id
        JOIN pages pt ON pt.id = l.to_page_id
       WHERE l.link_type = 'attended'
-        AND pf.type = 'meeting'
+        AND (
+              pf.type = 'meeting'
+              OR pf.slug LIKE 'meetings/%'
+              OR pf.frontmatter->>'legacy_type' = 'meeting'
+              OR pf.frontmatter->'tags' ? 'meeting'
+            )
         AND pf.deleted_at IS NULL
         AND pt.deleted_at IS NULL`,
   );

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -106,12 +106,12 @@ export interface SubagentDeps {
   /** Anthropic client. Defaults to the SDK-constructed client. */
   client?: MessagesClient;
   /**
-   * Anthropic SDK constructor. Defaults to `() => new Anthropic()`.
+   * Anthropic SDK constructor. Defaults to `(apiKey) => new Anthropic({ apiKey })`.
    * Overridable in tests so the factory default-client branch is
    * exercisable without an ANTHROPIC_API_KEY or a real API call.
    * When `deps.client` is provided, this is unused.
    */
-  makeAnthropic?: () => Anthropic;
+  makeAnthropic?: (apiKey?: string) => Anthropic;
   /** Config (MCP, brain, etc.). Defaults to loadConfig(). */
   config?: GBrainConfig;
   /** Rate-lease key. Defaults to `anthropic:messages`. */
@@ -165,8 +165,8 @@ export function makeSubagentHandler(deps: SubagentDeps) {
   // lives at sdk.messages.create. Assigning sdk.messages directly gets the
   // right object; JS method-call semantics preserve `this` at the call
   // site (subagent.ts invokes client.create(...) with client === sdk.messages).
-  const makeAnthropic = deps.makeAnthropic ?? (() => new Anthropic());
-  const client: MessagesClient = deps.client ?? makeAnthropic().messages;
+  const makeAnthropic = deps.makeAnthropic ?? ((apiKey?: string) => new Anthropic(apiKey ? { apiKey } : undefined));
+  let client: MessagesClient | null = deps.client ?? null;
   const config = deps.config ?? loadConfig() ?? ({ engine: 'postgres' } as GBrainConfig);
   const rateLeaseKey = deps.rateLeaseKey ?? DEFAULT_RATE_KEY;
   const maxConcurrent = deps.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
@@ -279,6 +279,17 @@ export function makeSubagentHandler(deps: SubagentDeps) {
         maxTurns,
       });
     }
+
+    // ── Legacy Anthropic client ──────────────────────────────
+    // Cron/LaunchAgent workers often run without shell env, while `gbrain config set
+    // anthropic_api_key ...` stores the key in the brain config table. Construct the
+    // SDK client lazily after the engine is available so DB/file config can satisfy
+    // Anthropic auth instead of relying solely on process.env.
+    if (!client) {
+      const apiKey = await resolveAnthropicApiKey(engine, config);
+      client = makeAnthropic(apiKey || undefined).messages;
+    }
+    const messagesClient = client;
 
     // ── Load prior state (replay) ───────────────────────────
     const priorMessages = await loadPriorMessages(engine, ctx.id);
@@ -503,7 +514,7 @@ export function makeSubagentHandler(deps: SubagentDeps) {
         };
 
         const combinedSignal = mergeSignals(ctx.signal, ctx.shutdownSignal);
-        assistantMsg = await client.create(params, { signal: combinedSignal });
+        assistantMsg = await messagesClient.create(params, { signal: combinedSignal });
       } catch (err) {
         // Release lease eagerly on error so we don't starve capacity.
         await releaseLease(engine, lease.leaseId!).catch(() => {});
@@ -937,6 +948,23 @@ async function runSubagentViaGateway(args: GatewayRunArgs): Promise<SubagentResu
 function recipeIdFromModel(modelString: string): string {
   const idx = modelString.indexOf(':');
   return idx > 0 ? modelString.slice(0, idx) : 'anthropic';
+}
+
+export async function resolveAnthropicApiKey(engine: BrainEngine, config?: GBrainConfig): Promise<string | undefined> {
+  const envKey = process.env.ANTHROPIC_API_KEY?.trim();
+  if (envKey) return envKey;
+
+  try {
+    const dbKey = await engine.getConfig('anthropic_api_key');
+    if (typeof dbKey === 'string' && dbKey.trim()) return dbKey.trim();
+  } catch {
+    // Fall through to file config. Some tests and degraded runtime paths have
+    // an engine that cannot read config yet.
+  }
+
+  const fileKey = (config as GBrainConfig & { anthropic_api_key?: unknown } | undefined)?.anthropic_api_key;
+  if (typeof fileKey === 'string' && fileKey.trim()) return fileKey.trim();
+  return undefined;
 }
 
 /**

--- a/test/subagent-handler.test.ts
+++ b/test/subagent-handler.test.ts
@@ -18,6 +18,7 @@ import { MinionQueue } from '../src/core/minions/queue.ts';
 import {
   makeSubagentHandler,
   RateLeaseUnavailableError,
+  resolveAnthropicApiKey,
   stripProviderPrefix,
   type MessagesClient,
 } from '../src/core/minions/handlers/subagent.ts';
@@ -582,7 +583,7 @@ describe('makeSubagentHandler default client construction', () => {
     } as unknown as Anthropic;
 
     // Crucial: do NOT pass `client`. Only `makeAnthropic`. This forces the
-    // factory to hit the default-client branch (`deps.client ?? makeAnthropic().messages`).
+    // factory to hit the default-client branch (`makeAnthropic(apiKey).messages`).
     const handler = makeSubagentHandler({
       engine,
       makeAnthropic: () => fakeSdk,
@@ -594,5 +595,57 @@ describe('makeSubagentHandler default client construction', () => {
     expect(calls.length).toBe(1);
     expect(result.stop_reason).toBe('end_turn');
     expect(result.result).toBe('ok');
+  });
+
+  test('default Anthropic client uses DB config key when process env is absent', async () => {
+    const original = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    await engine.setConfig('anthropic_api_key', 'sk-ant-db-test');
+    try {
+      expect(await resolveAnthropicApiKey(engine, {} as any)).toBe('sk-ant-db-test');
+
+      const calls: Anthropic.MessageCreateParamsNonStreaming[] = [];
+      let seenApiKey: string | undefined;
+      const fakeSdk = {
+        messages: {
+          async create(params: Anthropic.MessageCreateParamsNonStreaming): Promise<Anthropic.Message> {
+            calls.push(params);
+            return {
+              id: 'msg_db_key',
+              type: 'message',
+              role: 'assistant',
+              model: params.model,
+              stop_reason: 'end_turn',
+              stop_sequence: null,
+              content: [{ type: 'text', text: 'db key ok' }],
+              usage: {
+                input_tokens: 1,
+                output_tokens: 1,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+              },
+            } as unknown as Anthropic.Message;
+          },
+        },
+      } as unknown as Anthropic;
+
+      const handler = makeSubagentHandler({
+        engine,
+        makeAnthropic: (apiKey?: string) => {
+          seenApiKey = apiKey;
+          return fakeSdk;
+        },
+        toolRegistry: [],
+      });
+      const ctx = await makeCtx({ prompt: 'hello from cron-like env' });
+      const result = await handler(ctx);
+
+      expect(seenApiKey).toBe('sk-ant-db-test');
+      expect(calls.length).toBe(1);
+      expect(result.result).toBe('db key ok');
+    } finally {
+      await engine.setConfig('anthropic_api_key', '');
+      if (original) process.env.ANTHROPIC_API_KEY = original;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Recognise schema-v2 meeting pages during timeline extraction, including `meetings/` slugs, `legacy_type: meeting`, and `meeting` tags.
- Resolve subagent Anthropic credentials from GBrain config when `ANTHROPIC_API_KEY` is absent from the process environment, which helps non-interactive runtimes such as cron/LaunchAgent jobs.
- Replace stale `gbrain jobs follow` guidance in the schema-unify skill with the supported `gbrain jobs get` command.

## Test Plan
- `bun test test/subagent-handler.test.ts`
- `bun run typecheck`
- `scripts/check-privacy.sh`
- `scripts/check-test-real-names.sh`
- `scripts/check-no-pii-in-agent-voice.sh`
- `git diff --check`
