### PR TITLE
fix(config): generic DATABASE_URL silently overrides a configured brain

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -383,8 +383,13 @@ export function loadConfig(): GBrainConfig | null {
     fileConfig = migrateLegacyEmbeddingConfig(parsed) as unknown as GBrainConfig;
   } catch { /* no config file */ }
 
-  // Try env vars
-  const dbUrl = process.env.GBRAIN_DATABASE_URL || process.env.DATABASE_URL;
+  // Try env vars. GBRAIN_DATABASE_URL is the intentional gbrain-specific operator
+  // override and always wins. The generic DATABASE_URL is only a LAST-RESORT
+  // fallback — it must not override a brain already configured in config.json, or
+  // a co-located app's DATABASE_URL in the same environment silently repoints
+  // gbrain at the wrong database. (PGLite brains have no config database_url, so a
+  // bare DATABASE_URL still upgrades them to Postgres — the operator escape hatch.)
+  const dbUrl = process.env.GBRAIN_DATABASE_URL || fileConfig?.database_url || process.env.DATABASE_URL;
 
   if (!fileConfig && !dbUrl) return null;
 


### PR DESCRIPTION
## Problem
`loadConfig()` resolves the database URL as:
```ts
const dbUrl = process.env.GBRAIN_DATABASE_URL || process.env.DATABASE_URL;
```
and that value then **overrides `config.json`** in the merge below it.

The generic `DATABASE_URL` is an extremely common env var — many apps/frameworks set it. If gbrain runs in an environment where another project's `DATABASE_URL` is present (a co-located app, a sourced `.env`, a dev shell), gbrain **silently connects to that other database instead of the brain configured in `config.json`** — no error, just wrong data (e.g. `gbrain stats` showing 0 pages, or worse, auto-running migrations against an unrelated database on connect).

We hit this in a real fleet: a machine whose `config.json` correctly pointed at the shared brain still resolved to a different Supabase project because a `DATABASE_URL` for a separate app was in the environment.

## Fix
Make precedence: **`GBRAIN_DATABASE_URL` > `config.json` `database_url` > generic `DATABASE_URL`.**
```ts
const dbUrl = process.env.GBRAIN_DATABASE_URL || fileConfig?.database_url || process.env.DATABASE_URL;
```
- `GBRAIN_DATABASE_URL` stays the intentional, gbrain-specific operator override (unchanged).
- A configured brain (`config.json.database_url`) is no longer hijacked by a co-located `DATABASE_URL`.
- PGLite brains have no `config.json.database_url`, so a bare `DATABASE_URL` still upgrades them to Postgres — the existing operator escape hatch (and the engine-inference comment) is preserved.

One-line change in `src/core/config.ts`. Happy to add a `test/config.test.ts` case asserting config.json wins over a stray `DATABASE_URL`.
