### PR TITLE
fix(autopilot): stamp federated freshness cycles

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -351,13 +351,28 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
   try {
     mkdirSync(gbrainHomePath(), { recursive: true });
     if (existsSync(lockPath)) {
-      const stat = require('fs').statSync(lockPath);
+      const fs = require('fs');
+      const stat = fs.statSync(lockPath);
       const ageMinutes = (Date.now() - stat.mtimeMs) / 60000;
-      if (ageMinutes < 10) {
+      const lockPidRaw = fs.readFileSync(lockPath, 'utf8').trim();
+      const lockPid = Number(lockPidRaw);
+      const lockPidAlive = Number.isInteger(lockPid) && lockPid > 0 && (() => {
+        try {
+          process.kill(lockPid, 0);
+          return true;
+        } catch {
+          return false;
+        }
+      })();
+      if (ageMinutes < 10 && lockPidAlive) {
         console.error('Another autopilot instance is running (lock file is fresh). Exiting.');
         process.exit(0);
       }
-      console.log('Stale lock file found (>10 min). Taking over.');
+      if (ageMinutes < 10 && !lockPidAlive) {
+        console.log(`Fresh autopilot lock belongs to dead pid ${lockPidRaw || '<empty>'}. Taking over.`);
+      } else {
+        console.log('Stale lock file found (>10 min). Taking over.');
+      }
     }
     writeFileSync(lockPath, String(process.pid));
   } catch { /* best-effort */ }
@@ -634,51 +649,40 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
         const slot = new Date(slotMs).toISOString();
         const timeoutMs = Math.max(baseInterval * 2 * 1000, 300_000);
 
-        // ── v0.40 D17: per-source freshness check ────────────────────
-        // Runs first; independent of score gate. Submits a 'sync' job per
-        // source whose last_sync_at is older than the interval. The sync
-        // handler (T6/T7) auto-enqueues embed-backfill on completion if
-        // pages changed.
+        // ── v0.40 D17 / v0.42.25 hotfix: per-source full-cycle freshness ──
+        // Runs first; independent of score gate. This MUST dispatch the same
+        // per-source autopilot-cycle primitive doctor checks via
+        // sources.config.last_full_cycle_at. A sync-only job updates
+        // last_sync_at but never stamps last_full_cycle_at, so doctor keeps
+        // failing cycle_freshness forever while autopilot proudly logs work.
+        // Also do not use maxWaiting here: it coalesces by (name, queue), not
+        // by source. dispatchPerSource owns the source-aware idempotency keys.
+        let sourceFreshnessCycleDispatched = false;
         try {
           const { isFederatedV2Enabled } = await import('../core/feature-flags.ts');
           if (await isFederatedV2Enabled(engine)) {
-            const { loadAllSources } = await import('../core/sources-load.ts');
-            const sources = await loadAllSources(engine);
-            const intervalMs = baseInterval * 1000;
-            const now = Date.now();
-            for (const src of sources) {
-              if (!src.local_path) continue;
-              const lastSyncMs = src.last_sync_at ? new Date(src.last_sync_at).getTime() : 0;
-              const ageMs = now - lastSyncMs;
-              if (ageMs < intervalMs) continue; // fresh enough
-              try {
-                const job = await queue.add(
-                  'sync',
-                  {
-                    sourceId: src.id,
-                    repoPath: src.local_path,
-                    auto_embed_backfill: true,
-                    embed_reason: 'autopilot_freshness',
-                  },
-                  {
-                    queue: 'default',
-                    idempotency_key: `autopilot-sync:${src.id}:${slot}`,
-                    max_attempts: 2,
-                    timeout_ms: timeoutMs,
-                    maxWaiting: 1,
-                  },
-                );
-                if (jsonMode) {
-                  process.stderr.write(JSON.stringify({
-                    event: 'dispatched', job_id: job.id, mode: 'freshness',
-                    source_id: src.id, age_ms: ageMs,
-                  }) + '\n');
-                } else {
-                  console.log(`[dispatch] job #${job.id} sync (freshness: ${src.id}; age=${Math.floor(ageMs / 60000)}min)`);
-                }
-              } catch (e) {
-                logError('dispatch.freshness', e);
-              }
+            const { dispatchPerSource, resolveFanoutMax } = await import('./autopilot-fanout.ts');
+            const fanoutMax = await resolveFanoutMax(engine);
+            const result = await dispatchPerSource(engine, queue, {
+              repoPath,
+              slot,
+              timeoutMs,
+              fanoutMax,
+              jsonMode,
+            });
+            sourceFreshnessCycleDispatched = result.dispatched.length > 0 || result.legacy_fallback;
+            if (sourceFreshnessCycleDispatched) {
+              lastFullCycleAt = Date.now();
+            }
+            if (jsonMode) {
+              process.stderr.write(JSON.stringify({
+                event: 'freshness_cycle_summary',
+                dispatched: result.dispatched,
+                skipped_fresh: result.skipped_fresh,
+                skipped_cap: result.skipped_cap,
+                legacy_fallback: result.legacy_fallback,
+                fanout_max: fanoutMax,
+              }) + '\n');
             }
           }
         } catch (e) {
@@ -852,7 +856,11 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
 
         const shouldSleep = score >= 95 && plan.length === 0 && minutesSinceLastFull < FULL_CYCLE_FLOOR_MIN;
 
-        if (shouldSleep) {
+        if (sourceFreshnessCycleDispatched) {
+          if (jsonMode) {
+            process.stderr.write(JSON.stringify({ event: 'skip_targeted_after_freshness_cycle', score, plan_size: plan.length }) + '\n');
+          }
+        } else if (shouldSleep) {
           if (jsonMode) {
             process.stderr.write(JSON.stringify({ event: 'skip_healthy', score, plan_size: 0 }) + '\n');
           }

--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -186,6 +186,45 @@ export async function runExtractFacts(
     slugs = Array.from(slugSet);
   }
 
+  // ── Fast-path: no fence facts to reconcile ─────────────────────
+  // Full-walk autopilot cycles can cover thousands of pages. When the source
+  // has no existing fence-derived facts AND no page currently contains a
+  // Facts fence, the per-page delete/reinsert loop below degenerates into
+  // thousands of no-op DELETE round-trips. On remote Postgres/Supabase that can
+  // hold a minion job for minutes despite doing no useful work. Skip safely:
+  // there are no rows to delete and no fences to insert.
+  if (opts.slugs === undefined && phantomResult.touched_canonicals.length === 0) {
+    try {
+      const [counts] = await engine.executeRaw<{
+        existing_fence_facts: number | string;
+        pages_with_facts_fence: number | string;
+      }>(
+        `SELECT
+           (SELECT COUNT(*) FROM facts
+             WHERE source_id = $1
+               AND source_markdown_slug IS NOT NULL
+               AND row_num IS NOT NULL) AS existing_fence_facts,
+           (SELECT COUNT(*) FROM pages
+             WHERE source_id = $1
+               AND compiled_truth LIKE '%## Facts%') AS pages_with_facts_fence`,
+        [sourceId],
+      );
+      const existingFenceFacts = Number(counts?.existing_fence_facts ?? 0);
+      const pagesWithFactsFence = Number(counts?.pages_with_facts_fence ?? 0);
+      if (existingFenceFacts === 0 && pagesWithFactsFence === 0) {
+        result.pagesScanned = slugs.length;
+        return result;
+      }
+    } catch (err) {
+      // Fall back to the conservative per-page loop if the optimization probe
+      // fails. extract_facts should remain correct even when this fast-path is
+      // unavailable on older schemas/backends.
+      result.warnings.push(
+        `extract_facts fast-path probe failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
   // ── Reconcile each page ───────────────────────────────────────
   for (const slug of slugs) {
     result.pagesScanned += 1;

--- a/test/autopilot-fanout-wiring.test.ts
+++ b/test/autopilot-fanout-wiring.test.ts
@@ -36,19 +36,38 @@ describe('autopilot.ts ↔ dispatchPerSource wiring', () => {
     // dispatchPerSource must appear in the same hot path as the
     // pre-fix `queue.add('autopilot-cycle', ...)` did — i.e. when
     // shouldFullCycle is true, not in the targeted-plan path.
-    const dispatchIdx = AUTOPILOT_SRC.indexOf('dispatchPerSource(engine, queue');
-    expect(dispatchIdx).toBeGreaterThan(-1);
-    // Verify shouldFullCycle is structurally near the call (within
-    // ~3000 chars of source, roughly the same if/else branch)
     const fullCycleIdx = AUTOPILOT_SRC.indexOf('shouldFullCycle');
     expect(fullCycleIdx).toBeGreaterThan(-1);
-    expect(Math.abs(dispatchIdx - fullCycleIdx)).toBeLessThan(3000);
+    const dispatchIdx = AUTOPILOT_SRC.indexOf('dispatchPerSource(engine, queue', fullCycleIdx);
+    expect(dispatchIdx).toBeGreaterThan(fullCycleIdx);
+    // Verify shouldFullCycle is structurally near the call (within
+    // ~3000 chars of source, roughly the same if/else branch)
+    expect(dispatchIdx - fullCycleIdx).toBeLessThan(3000);
   });
 
   test('updates lastFullCycleAt on dispatch (so the 60-min floor is honored)', () => {
     // After the dispatchPerSource call, the lastFullCycleAt module var
     // must update so the next tick doesn't immediately re-fan-out.
     expect(AUTOPILOT_SRC).toMatch(/lastFullCycleAt\s*=\s*Date\.now\(\)/);
+  });
+
+
+  test('freshness gate dispatches per-source cycles, not sync-only jobs', () => {
+    const freshnessIdx = AUTOPILOT_SRC.indexOf('per-source full-cycle freshness');
+    expect(freshnessIdx).toBeGreaterThan(-1);
+    const autoDrainIdx = AUTOPILOT_SRC.indexOf('#1685 GAP D', freshnessIdx);
+    expect(autoDrainIdx).toBeGreaterThan(freshnessIdx);
+    const freshnessBlock = AUTOPILOT_SRC.slice(freshnessIdx, autoDrainIdx);
+
+    expect(freshnessBlock).toContain('dispatchPerSource(engine, queue');
+    expect(freshnessBlock).not.toContain("queue.add(\n                  'sync'");
+    expect(freshnessBlock).not.toContain('autopilot-sync:${src.id}:${slot}');
+    expect(freshnessBlock).not.toMatch(/maxWaiting\s*:/);
+  });
+
+  test('skips targeted remediation after freshness cycle dispatch', () => {
+    expect(AUTOPILOT_SRC).toContain('sourceFreshnessCycleDispatched');
+    expect(AUTOPILOT_SRC).toContain('skip_targeted_after_freshness_cycle');
   });
 
   test('does NOT regress to the single-job dispatch on the full-cycle path', () => {

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -175,6 +175,28 @@ describe('runExtractFacts — happy path', () => {
     expect(r.pagesScanned).toBe(2);
     expect(r.factsInserted).toBe(2);
   });
+
+  test('full walk fast-path skips no-op per-page deletes when no fence facts exist', async () => {
+    await putPage('people/no-facts-1', '# One\n\nNo facts fence.\n');
+    await putPage('people/no-facts-2', '# Two\n\nStill no facts fence.\n');
+
+    const originalDeleteFactsForPage = engine.deleteFactsForPage.bind(engine);
+    let deleteCalls = 0;
+    engine.deleteFactsForPage = async (...args: Parameters<typeof engine.deleteFactsForPage>) => {
+      deleteCalls += 1;
+      return originalDeleteFactsForPage(...args);
+    };
+    try {
+      const r = await runExtractFacts(engine); // no slugs filter = full walk
+      expect(r.pagesScanned).toBe(2);
+      expect(r.pagesWithFacts).toBe(0);
+      expect(r.factsInserted).toBe(0);
+      expect(r.factsDeleted).toBe(0);
+      expect(deleteCalls).toBe(0);
+    } finally {
+      engine.deleteFactsForPage = originalDeleteFactsForPage;
+    }
+  });
 });
 
 describe('runExtractFacts — empty-fence guard (Codex R2-#7)', () => {


### PR DESCRIPTION
## Summary

- Dispatch federated freshness work as per-source `autopilot-cycle` jobs instead of sync-only jobs, so `sources.config.last_full_cycle_at` is stamped and `doctor` cycle freshness reflects real full-cycle state.
- Avoid duplicate targeted remediation after freshness-cycle fanout dispatch.
- Treat fresh autopilot lock files as active only when their recorded PID is still alive, so dead fresh locks do not block restart.
- Add an `extract_facts` full-walk fast-path for sources with no fence facts and no pages containing a Facts fence, avoiding thousands of no-op per-page DELETE round trips on remote Postgres/Supabase.

## Why

A live federated setup had autopilot running but `gbrain doctor` still failed `cycle_freshness`: the freshness gate submitted `sync` jobs, which update `last_sync_at` but never update `last_full_cycle_at`. The same incident exposed stale fresh lock files after restarts, and very slow no-op full-walk `extract_facts` scans over thousands of pages with an empty facts table.

## Tests

```sh
timeout 180 bun test \
  test/extract-facts-phase.test.ts \
  test/autopilot-fanout-wiring.test.ts \
  test/autopilot-fanout.test.ts \
  test/cycle-last-full-cycle-at.test.ts
```

Result: 54 pass, 0 fail.

## Live verification

On the affected runtime after applying the hotfix:

- `catalyst-os` and `catalyst-repo` both stamped fresh `last_full_cycle_at`.
- `gbrain --progress-json doctor --json` reports `cycle_freshness` as `ok`.
- Remaining doctor warning is unrelated: `takes_count` because takes bootstrap is disabled.
