### PR TITLE
fix(retry): reconnect on null instance pool in non-batch config reads (#1593 follow-up)

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -2037,6 +2037,47 @@ export class PostgresEngine implements BrainEngine {
     }
   }
 
+  /**
+   * Single-statement sibling of {@link batchRetry} for NON-batch reads/writes
+   * that touch `this.sql` directly (the config accessors, per-phase reads).
+   *
+   * Why a separate helper rather than reusing `batchRetry`:
+   * - `batchRetry` emits batch-retry audit JSONL sized by `batchSize` and is
+   *   typed to `BatchAuditSite`. A config read is not a sized batch — routing
+   *   it through `batchRetry` would inflate the `batch_retry_health` doctor
+   *   metric and demand a bogus enum member. This path keeps the SAME retry +
+   *   reconnect posture but emits no batch audit.
+   *
+   * Why it is needed at all (PR #1593 follow-up / #1570):
+   *   The `sql` getter throws a RETRYABLE "No database connection" by design
+   *   when an instance pool was torn down mid-cycle (issue #1678), precisely so
+   *   a `withRetry`+`reconnect` caller rebuilds the pool and self-heals. The
+   *   batch path already had that wrapper; non-batch reads did not — so the
+   *   first hard DB call after a mid-cycle disconnect (e.g. `loadCfg`'s
+   *   `getConfig`) threw unhandled and crashed the worker into a respawn loop.
+   *   This closes that gap.
+   *
+   * `fn` MUST re-read `this.sql` on each invocation — `reconnect()` rebuilds
+   * the pool between attempts, so callers pass a thunk, never a captured `sql`
+   * handle. Safe for the config writes too: `withRetry` only retries on
+   * `isRetryableConnError` (a connection-class failure where the statement
+   * never committed), and both writes are idempotent (upsert / delete) so even
+   * a lost-ack replay converges.
+   */
+  private async connRetry<T>(fn: () => Promise<T>): Promise<T> {
+    const opts = this.getBulkRetryOpts();
+    return withRetry(fn, {
+      maxRetries: opts.maxRetries,
+      delayMs: opts.delayMs,
+      delayMaxMs: opts.delayMaxMs,
+      jitter: BULK_RETRY_OPTS.jitter,
+      // Same reconnect posture as batchRetry: rebuild a dead instance pool
+      // before the next attempt. Race-safe via the engine's `_reconnecting`
+      // guard; fail-loud — a reconnect throw propagates as the real cause.
+      reconnect: (ctx) => this.reconnect(ctx),
+    });
+  }
+
   // Chunks
   async upsertChunks(slug: string, chunks: ChunkInput[], opts?: { sourceId?: string } & BatchOpts): Promise<void> {
     return this.batchRetry(opts?.auditSite ?? 'upsertChunks', opts?.signal, () => this._upsertChunksOnce(slug, chunks, opts), chunks.length);
@@ -4748,34 +4789,46 @@ export class PostgresEngine implements BrainEngine {
 
   // Config
   async getConfig(key: string): Promise<string | null> {
-    const sql = this.sql;
-    const rows = await sql`SELECT value FROM config WHERE key = ${key}`;
-    return rows.length > 0 ? (rows[0].value as string) : null;
+    // connRetry: a mid-cycle instance-pool teardown makes `this.sql` throw a
+    // retryable "No database connection"; reconnect + retry instead of crashing
+    // the worker (PR #1593 follow-up).
+    return this.connRetry(async () => {
+      const sql = this.sql;
+      const rows = await sql`SELECT value FROM config WHERE key = ${key}`;
+      return rows.length > 0 ? (rows[0].value as string) : null;
+    });
   }
 
   async setConfig(key: string, value: string): Promise<void> {
-    const sql = this.sql;
-    await sql`
-      INSERT INTO config (key, value) VALUES (${key}, ${value})
-      ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
-    `;
+    return this.connRetry(async () => {
+      const sql = this.sql;
+      await sql`
+        INSERT INTO config (key, value) VALUES (${key}, ${value})
+        ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+      `;
+    });
   }
 
   async unsetConfig(key: string): Promise<number> {
-    const sql = this.sql;
-    const result = await sql`DELETE FROM config WHERE key = ${key}` as unknown as { count: number };
-    return result.count ?? 0;
+    return this.connRetry(async () => {
+      const sql = this.sql;
+      const result = await sql`DELETE FROM config WHERE key = ${key}` as unknown as { count: number };
+      return result.count ?? 0;
+    });
   }
 
   async listConfigKeys(prefix: string): Promise<string[]> {
-    const sql = this.sql;
-    // LIKE-escape literal % and _ so a config key with those chars resolves correctly.
+    // LIKE-escape literal % and _ so a config key with those chars resolves
+    // correctly. Pure string work — keep it outside the retried thunk.
     const escaped = prefix.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
     const pattern = `${escaped}%`;
-    const rows = await sql<{ key: string }[]>`
-      SELECT key FROM config WHERE key LIKE ${pattern} ESCAPE '\\' ORDER BY key
-    `;
-    return rows.map(r => r.key);
+    return this.connRetry(async () => {
+      const sql = this.sql;
+      const rows = await sql<{ key: string }[]>`
+        SELECT key FROM config WHERE key LIKE ${pattern} ESCAPE '\\' ORDER BY key
+      `;
+      return rows.map(r => r.key);
+    });
   }
 
   // Migration support

--- a/test/postgres-engine-config-reconnect.test.ts
+++ b/test/postgres-engine-config-reconnect.test.ts
@@ -1,0 +1,83 @@
+/**
+ * PR #1593 follow-up — non-batch config reads must self-heal the same way the
+ * batch path does.
+ *
+ * `getConfig` (and the sibling config accessors) touch `this.sql` directly.
+ * When an instance pool is torn down mid-cycle the getter throws a RETRYABLE
+ * "No database connection" (issue #1678) by design, so a withRetry+reconnect
+ * caller can rebuild the pool and recover. Pre-fix these accessors had NO such
+ * wrapper, so the first hard DB call after a mid-cycle disconnect (loadCfg's
+ * `getConfig`) threw unhandled and crashed the worker into a respawn loop
+ * (the autopilot crash @rayers reported on #1593). This pins that the config
+ * accessors now reconnect + retry, and that non-retryable errors are NOT
+ * masked by a reconnect.
+ *
+ * Pure: pokes private fields and stubs `reconnect` to simulate the pool
+ * rebuild; no real DB.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { PostgresEngine } from '../src/core/postgres-engine.ts';
+
+// A tagged-template-callable fake `sql` that resolves to the given rows.
+function fakeSql(rows: unknown[]) {
+  return (..._args: unknown[]) => Promise.resolve(rows);
+}
+
+// Near-instant retry delays so the inter-attempt sleep does not slow the test.
+// Shape matches `typeof BULK_RETRY_OPTS` (the getBulkRetryOpts cache type).
+const FAST_RETRY = { maxRetries: 3, delayMs: 1, delayMaxMs: 1, jitter: 'none' as const };
+
+describe('PostgresEngine non-batch config reads self-heal (PR #1593 follow-up)', () => {
+  it('getConfig reconnects + retries a null instance pool, then returns the value', async () => {
+    const e = new PostgresEngine();
+    (e as unknown as { _connectionStyle: string })._connectionStyle = 'instance';
+    (e as unknown as { _sql: unknown })._sql = null; // instance pool torn down → getter throws retryable
+    (e as unknown as { _bulkRetryOptsCache: unknown })._bulkRetryOptsCache = FAST_RETRY;
+
+    let reconnectCalls = 0;
+    (e as unknown as { reconnect: () => Promise<void> }).reconnect = async () => {
+      reconnectCalls++;
+      // Simulate reconnect installing a live pool — the next attempt sees it.
+      (e as unknown as { _sql: unknown })._sql = fakeSql([{ value: 'live-value' }]);
+    };
+
+    const got = await e.getConfig('some.key');
+    expect(got).toBe('live-value');
+    expect(reconnectCalls).toBe(1); // exactly one reconnect closed the gap
+  });
+
+  it('getConfig surfaces a non-retryable error without reconnecting (no masking)', async () => {
+    const e = new PostgresEngine();
+    (e as unknown as { _connectionStyle: string })._connectionStyle = 'instance';
+    (e as unknown as { _bulkRetryOptsCache: unknown })._bulkRetryOptsCache = FAST_RETRY;
+    // A live pool whose query throws a NON-retryable (non-connection) error.
+    (e as unknown as { _sql: unknown })._sql = () =>
+      Promise.reject(new Error('syntax error at or near "SLECT"'));
+
+    let reconnectCalls = 0;
+    (e as unknown as { reconnect: () => Promise<void> }).reconnect = async () => {
+      reconnectCalls++;
+    };
+
+    await expect(e.getConfig('k')).rejects.toThrow('syntax error');
+    expect(reconnectCalls).toBe(0); // non-retryable → no reconnect, error not masked
+  });
+
+  it('listConfigKeys reconnects + retries a null instance pool, then returns keys', async () => {
+    const e = new PostgresEngine();
+    (e as unknown as { _connectionStyle: string })._connectionStyle = 'instance';
+    (e as unknown as { _sql: unknown })._sql = null;
+    (e as unknown as { _bulkRetryOptsCache: unknown })._bulkRetryOptsCache = FAST_RETRY;
+
+    let reconnectCalls = 0;
+    (e as unknown as { reconnect: () => Promise<void> }).reconnect = async () => {
+      reconnectCalls++;
+      (e as unknown as { _sql: unknown })._sql = fakeSql([{ key: 'a.one' }, { key: 'a.two' }]);
+    };
+
+    const keys = await e.listConfigKeys('a.');
+    expect(keys).toEqual(['a.one', 'a.two']);
+    expect(reconnectCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

#1593 wired `reconnect()` into the **batch** retry path so a null instance pool rebuilds itself mid-cycle. The **non-batch** path was explicitly left as follow-up in that PR's Scope section, and @rayers confirmed it in production (#1593 (comment) https://github.com/garrytan/gbrain/pull/1593#issuecomment-4598669084): on a long-running `gbrain autopilot` daemon, late-cycle phases throw `No database connection`, `executeJob` crashes unhandled, the worker exits code 1 and respawns every ~5 min.

The first hard DB call after a mid-cycle instance-pool teardown is `loadCfg`'s `engine.getConfig()` (x7). That accessor, like its siblings, touches `this.sql` directly with no retry wrapper.

## Root cause

The `sql` getter already throws a **retryable** `No database connection` when an instance pool went null (issue #1678, `postgres-engine.ts:136`), by design, precisely so a `withRetry`+`reconnect` caller rebuilds the pool and recovers. The batch path (`batchRetry`) has that wrapper. The config accessors (`getConfig`, `setConfig`, `unsetConfig`, `listConfigKeys`) do not, so the retryable throw propagates unhandled and kills the worker.

## Fix

Add `connRetry`, a single-statement sibling of `batchRetry`: same `reconnect: (ctx) => this.reconnect(ctx)` posture and `BULK_RETRY_OPTS` timing, but no batch-retry audit (these are not sized batches, so they must not inflate the `batch_retry_health` doctor metric). Route the four config accessors through it. Each retried thunk re-reads `this.sql`, so a reconnect between attempts is picked up.

All four are single-statement and idempotent (reads; upsert; delete), so retry-on-connection-error is safe. `withRetry` only retries on `isRetryableConnError`, so non-connection errors (syntax, constraint) still throw immediately and are not masked.

## Tests

`test/postgres-engine-config-reconnect.test.ts` (pure, no DB; pokes private fields + stubs `reconnect`):

- `getConfig` reconnects + retries a null instance pool, then returns the value (exactly one reconnect).
- `getConfig` surfaces a non-retryable error without reconnecting (no masking).
- `listConfigKeys` reconnects + retries a null instance pool, then returns keys.

```
$ bun test test/postgres-engine-config-reconnect.test.ts
 3 pass, 0 fail

$ bun test test/postgres-engine-getter-selfheal.test.ts test/config.test.ts test/config-set.test.ts test/config-unset.test.ts test/core/retry.test.ts test/connection-resilience.test.ts
 115 pass, 0 fail

$ bun run typecheck   # tsc --noEmit, clean
```

## Scope and relationship to other PRs

- Builds on #1593 (batch-path reconnect, now reflected on master) and is the non-batch half that PR called out as follow-up.
- Orthogonal to the instance-pool `reconnect()` hardening @rayers proposed on #1593 (build-then-swap): that makes `reconnect()` itself crash-safe, this makes the non-batch callers invoke reconnect at all. Both are needed and compose cleanly.
- Orthogonal to #1754 (module-singleton refcount, `db.ts`).
- Intentionally narrow: the config accessor family only. The same `connRetry` helper extends to other non-batch reads as obvious follow-ups.