### PR TITLE
test(conversation-parser): make LLM "no key" tests hermetic

### DIFF
--- a/test/conversation-parser/llm-base.test.ts
+++ b/test/conversation-parser/llm-base.test.ts
@@ -12,6 +12,9 @@
  */
 
 import { describe, expect, test, beforeEach } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { withEnv } from '../helpers/with-env.ts';
 import {
   runLlmCall,
@@ -22,6 +25,14 @@ import {
 } from '../../src/core/conversation-parser/llm-base.ts';
 import { makeChatResult } from './helpers.ts';
 
+// hasAnthropicKey() reads TWO sources: the ANTHROPIC_API_KEY env var AND
+// loadConfig().anthropic_api_key (~/.gbrain/config.json). The "no key" tests
+// must neutralize BOTH or they fail on any machine with a real config key.
+// An empty GBRAIN_HOME makes configPath() resolve to a dir with no config.json
+// → loadConfig() returns null. (#1698 added the config source; this keeps the
+// pre-existing tests hermetic.)
+const EMPTY_CONFIG_HOME = mkdtempSync(join(tmpdir(), 'gbrain-nokey-'));
+
 beforeEach(() => {
   _resetLlmCacheForTests();
 });
@@ -29,7 +40,7 @@ beforeEach(() => {
 describe('probeLlmAvailability', () => {
   test('returns null when ANTHROPIC_API_KEY is unset', async () => {
     await withEnv(
-      { ANTHROPIC_API_KEY: undefined as unknown as string },
+      { ANTHROPIC_API_KEY: undefined as unknown as string, GBRAIN_HOME: EMPTY_CONFIG_HOME },
       async () => {
         expect(probeLlmAvailability('claude-haiku-4-5')).toBeNull();
         expect(probeLlmAvailability('anthropic:claude-haiku-4-5')).toBeNull();
@@ -94,7 +105,7 @@ describe('runLlmCall — happy path', () => {
 describe('runLlmCall — fail-open paths', () => {
   test('provider unavailable returns null without calling transport', async () => {
     await withEnv(
-      { ANTHROPIC_API_KEY: undefined as unknown as string },
+      { ANTHROPIC_API_KEY: undefined as unknown as string, GBRAIN_HOME: EMPTY_CONFIG_HOME },
       async () => {
         let calls = 0;
         const result = await runLlmCall<unknown>({

--- a/test/conversation-parser/llm-fallback.test.ts
+++ b/test/conversation-parser/llm-fallback.test.ts
@@ -12,10 +12,17 @@
  */
 
 import { describe, expect, test, beforeEach } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { withEnv } from '../helpers/with-env.ts';
 import { runLlmFallback } from '../../src/core/conversation-parser/llm-fallback.ts';
 import { _resetLlmCacheForTests } from '../../src/core/conversation-parser/llm-base.ts';
 import { makeChatResult } from './helpers.ts';
+
+// See llm-base.test.ts: neutralize BOTH key sources (env + ~/.gbrain config)
+// for the "no key" test so it's hermetic on machines with a real config key.
+const EMPTY_CONFIG_HOME = mkdtempSync(join(tmpdir(), 'gbrain-nokey-'));
 
 beforeEach(() => {
   _resetLlmCacheForTests();
@@ -71,7 +78,7 @@ describe('runLlmFallback', () => {
 
   test('provider unavailable: returns null without calling transport', async () => {
     await withEnv(
-      { ANTHROPIC_API_KEY: undefined as unknown as string },
+      { ANTHROPIC_API_KEY: undefined as unknown as string, GBRAIN_HOME: EMPTY_CONFIG_HOME },
       async () => {
         let calls = 0;
         const result = await runLlmFallback({


### PR DESCRIPTION
## Root cause

The `probeLlmAvailability` / `runLlmCall` / `runLlmFallback` "no key" tests cleared only `ANTHROPIC_API_KEY`, but `hasAnthropicKey()` also reads `loadConfig().anthropic_api_key` (from `~/.gbrain/config.json`, added in #1698 after these tests were written in v0.41.16.0). On any machine with a real config key (e.g. via `gbrain config set anthropic_api_key`) the probe still saw a key and 3 tests failed.

## Fix

Point `GBRAIN_HOME` at an empty temp dir inside the `withEnv` override so `configPath()` resolves to a dir with no `config.json` → `loadConfig()` returns null → both key sources are clean → probe returns null. Hermetic everywhere now.

## Verification

`conversation-parser` dir: 101 pass / 0 fail (was 98/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)