### PR TITLE
fix(doctor): drop dead llm_fallback_enabled recommendation from conversation_format_coverage

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -4524,8 +4524,7 @@ export async function buildChecks(
             message:
               `${unmatched}/${sample.length} conversation pages (${unmatchedPct.toFixed(1)}%) match NO built-in pattern. ` +
               `Breakdown: ${breakdown}. ` +
-              `Investigate: gbrain conversation-parser scan <slug> | ` +
-              `Enable LLM fallback (opt-in): gbrain config set conversation_parser.llm_fallback_enabled true`,
+              `Investigate: gbrain conversation-parser scan <slug>`,
           });
         } else {
           checks.push({


### PR DESCRIPTION
## Root cause

The `conversation_format_coverage` doctor check recommends `gbrain config set conversation_parser.llm_fallback_enabled true` when many pages match no built-in pattern. But that config key is **dead** — it is never read anywhere — as documented in #1890. The recommendation is a no-op that misleads users into believing an LLM fallback will engage.

## Fix

Remove the dead recommendation from the warning message, keeping the actionable `gbrain conversation-parser scan <slug>` hint.

Refs #1890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)