### PR TITLE
docs(skills): standardize timeline/back-link format on plain bullet

### DIFF
--- a/skills/_brain-filing-rules.md
+++ b/skills/_brain-filing-rules.md
@@ -66,9 +66,11 @@ Every mention of a person or company with a brain page MUST create a back-link
 FROM that entity's page TO the page mentioning them. This is bidirectional:
 the new page links to the entity, AND the entity's page links back.
 
-Format for back-links (append to Timeline or See Also):
+Format for back-links (append to Timeline or See Also). Plain bullet, em-dash —
+no bold, no `|` pipe — so the timeline extractor (`gbrain extract timeline`) can
+parse it:
 ```
-- **YYYY-MM-DD** | Referenced in [page title](path/to/page.md) -- brief context
+- YYYY-MM-DD — Referenced in [page title](path/to/page.md) — brief context
 ```
 
 An unlinked mention is a broken brain. The graph is the intelligence.

--- a/skills/conventions/quality.md
+++ b/skills/conventions/quality.md
@@ -25,7 +25,7 @@ Every fact written to a brain page must carry an inline `[Source: ...]` citation
 Every mention of a person or company WITH a brain page MUST create a back-link
 FROM that entity's page TO the page mentioning them.
 
-Format: `- **YYYY-MM-DD** | Referenced in [page title](path) -- context`
+Format: `- YYYY-MM-DD — Referenced in [page title](path) — context`
 
 An unlinked mention is a broken brain.
 

--- a/skills/enrich/SKILL.md
+++ b/skills/enrich/SKILL.md
@@ -238,7 +238,10 @@ Active conversations, pending items, things to follow up on.
 
 ## Timeline
 Reverse chronological. Every entry has a date and [Source: ...] citation.
-- **YYYY-MM-DD** | Event description [Source: ...]
+Use this exact plain-bullet shape — `- DATE — text` — no bold, no `|` pipe. This
+is the format the timeline extractor parses (`gbrain extract timeline`); bold or
+pipe variants are silently skipped.
+- YYYY-MM-DD — Event description [Source: ...]
 ```
 
 #### Company page template
@@ -265,7 +268,7 @@ Active items, pending decisions, things to track.
 ---
 
 ## Timeline
-- **YYYY-MM-DD** | Event description [Source: ...]
+- YYYY-MM-DD — Event description [Source: ...]
 ```
 
 ### Step 7: Cross-reference

--- a/skills/idea-ingest/SKILL.md
+++ b/skills/idea-ingest/SKILL.md
@@ -44,7 +44,7 @@ This skill guarantees:
 > **Convention:** See `skills/conventions/quality.md` for Iron Law back-linking.
 
 Every mention of a person or company with a brain page MUST create a back-link.
-Format: `- **YYYY-MM-DD** | Referenced in [page title](path) — brief context`
+Format: `- YYYY-MM-DD — Referenced in [page title](path) — brief context`
 
 ## Phases
 

--- a/skills/maintain/SKILL.md
+++ b/skills/maintain/SKILL.md
@@ -187,7 +187,7 @@ gbrain dream --json                                   # CycleReport JSON
 **Auto-commit deferred to v1.1:** v1 writes files to `brain_dir` but does NOT
 `git add` / `commit` / `push`. Either commit yourself or let `gbrain autopilot`
 handle it.
-Parses `- **YYYY-MM-DD** | Source — Summary` and `### YYYY-MM-DD — Title` formats.
+Parses `- YYYY-MM-DD — Summary` (canonical), legacy `- **YYYY-MM-DD** | Source — Summary`, and `### YYYY-MM-DD — Title` formats.
 Note: extracted entries improve structured queries (`gbrain timeline`), not vector search.
 
 ### Autopilot check
@@ -230,7 +230,7 @@ Check that the back-linking iron law is being followed:
   corresponding back-links FROM those entity pages
 - A mention without a back-link is a broken brain
 - Fix: add the missing back-link to the entity's Timeline or See Also section
-- Format: `- **YYYY-MM-DD** | Referenced in [page title](path) -- brief context`
+- Format: `- YYYY-MM-DD — Referenced in [page title](path) — brief context`
 
 ### Filing rule violations
 Check for common misfiling patterns (see `skills/_brain-filing-rules.md`):
@@ -262,7 +262,7 @@ Populate them periodically or after major imports:
   `advises`, `mentions`, `source`). Idempotent. Use `--source fs --dir <brain>`
   if you have a markdown checkout to walk instead.
 - `gbrain extract timeline --source db` — backfill structured timeline entries.
-  Parses `- **YYYY-MM-DD** | summary` lines from page content. Idempotent (DB
+  Parses `- YYYY-MM-DD — summary` (and legacy `- **YYYY-MM-DD** | summary`) lines from page content. Idempotent (DB
   UNIQUE constraint).
 - `gbrain extract all --source db` — both in one run.
 - `gbrain graph-query <slug> --depth 2` — verify connectivity (use any well-known

--- a/skills/signal-detector/SKILL.md
+++ b/skills/signal-detector/SKILL.md
@@ -49,7 +49,7 @@ This skill guarantees:
 Every time this skill creates or updates a brain page that mentions a person or company:
 1. Check if that person/company has a brain page
 2. If yes → add a back-link FROM their page TO the page you just created/updated
-3. Format: `- **YYYY-MM-DD** | Referenced in [page title](path) — brief context`
+3. Format: `- YYYY-MM-DD — Referenced in [page title](path) — brief context`
 4. An unlinked mention is a broken brain.
 
 ## Phases

--- a/skills/voice-note-ingest/SKILL.md
+++ b/skills/voice-note-ingest/SKILL.md
@@ -140,7 +140,7 @@ analysis is the agent's interpretation; the transcript above is sacred.]
 
 ## Timeline
 
-- **YYYY-MM-DD** | voice note from <channel> — [Brief description]
+- YYYY-MM-DD — voice note from <channel>: [Brief description]
 ```
 
 ## Citation format


### PR DESCRIPTION
## Root cause

The timeline format was specified three different ways across skills (bold+pipe in enrich/filing-rules/signal-detector/idea-ingest/voice-note/maintain, plain bullet in meeting-ingestion) and none consistently matched what the extractor parses. The extractor's structured `source` column (the only thing the bold+pipe variant adds) is written-but-never-read, so bold+pipe buys nothing and just invites drift.

This is the docs companion to the extractor Format-3 fix (#1896): now that `extractTimelineFromContent` parses the plain bullet, every writer-facing spec should point at that one canonical shape.

## Fix

Standardize every writer-facing spec on the canonical plain bullet `- YYYY-MM-DD — text [Source: ...]` (what meeting-ingestion already writes and what the extractor parses). Back-link convention follows suit. `maintain`'s parser-description lines now list plain as canonical with bold+pipe as legacy. Historical migration changelogs left untouched.

## Verification

Cherry-picks cleanly onto current master; pure docs/skill-spec change, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)