### PR TITLE
fix(postgres-engine): build-then-swap reconnect() so a failed rebuild can't brick the engine

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4860,20 +4860,42 @@ export class PostgresEngine implements BrainEngine {
       logPoolRecovery(isReap ? 'reap_detected' : 'reconnect_other', ctx?.error);
     } catch { /* audit is best-effort */ }
 
+    // Instance pool: BUILD-THEN-SWAP. Snapshot the live pool, build a fresh one,
+    // and only tear the old one down once the new one is proven live. The naive
+    // disconnect()-then-connect() ordering nulls `_sql` BEFORE the rebuild, so a
+    // connect() failure during a transient blip leaves `_sql === null` for the
+    // rest of the process. A dead `_sql` falls through to the module-singleton
+    // accessor — which the autopilot process never connected — so every
+    // subsequent non-retry-wrapped call (getConfig, per-phase reads) throws
+    // "No database connection: connect() has not been called" and crashes the
+    // worker into a respawn loop (#1593 root-cause). Holding the old pool until
+    // the new one validates keeps the engine usable; postgres.js pools self-heal
+    // on the next query once Postgres is back, and batchRetry's backoff retries.
+    const oldSql = this._sql;
+    const oldManager = this.connectionManager;
     try {
-      // Instance pool: tear down old pool (best-effort — it may already be dead).
-      try { await this.disconnect(); } catch { /* swallow */ }
+      this._sql = null; // force connect() to build a fresh pool, not reuse
+      // connect() validates the new pool via `SELECT 1` before returning.
       await this.connect(this._savedConfig);
+      // New pool is live — discard the old one best-effort.
+      if (oldSql) { try { await oldSql.end({ timeout: 5 }); } catch { /* swallow */ } }
       try {
         const { logPoolRecovery } = await import('./audit/pool-recovery-audit.ts');
         logPoolRecovery('reconnect_succeeded');
       } catch { /* best-effort */ }
     } catch (err) {
+      // Rebuild failed: tear down the half-built pool (if any) and restore the
+      // prior live pool + manager so the engine stays usable.
+      if (this._sql && this._sql !== oldSql) {
+        try { await this._sql.end({ timeout: 5 }); } catch { /* swallow */ }
+      }
+      this._sql = oldSql;
+      this.connectionManager = oldManager;
       try {
         const { logPoolRecovery } = await import('./audit/pool-recovery-audit.ts');
         logPoolRecovery('reconnect_failed', err);
       } catch { /* best-effort */ }
-      throw err;
+      throw err; // let batchRetry's backoff handle the retry
     } finally {
       this._reconnecting = false;
     }

--- a/test/connection-resilience.test.ts
+++ b/test/connection-resilience.test.ts
@@ -311,7 +311,13 @@ describe('Eng-review D3 — executeRaw has no per-call retry wrapper', () => {
     // can classify the triggering error for the pool-recovery audit. Match the
     // prefix so both `reconnect()` and `reconnect(ctx?)` satisfy the contract.
     expect(src).toContain('async reconnect(');
-    expect(src).toContain('await this.disconnect()');
+    // #1593 build-then-swap: reconnect() no longer disconnect()-then-connect()s
+    // on the instance-pool path (that nulled _sql, so a connect() failure during
+    // a transient blip left the engine permanently dead → worker respawn loop).
+    // It now snapshots the live pool, builds a fresh one, and ends the OLD pool
+    // only once the new one validates — restoring it on failure. Assert the
+    // old-pool teardown, which is the recovery contract this test guards.
+    expect(src).toContain('await oldSql.end(');
   });
 
   it('Supervisor still has the 3-strikes-then-reconnect path', () => {


### PR DESCRIPTION
## Context

Follow-up to #1593 (closed). That PR wired `reconnect` into `batchRetry`'s `onRetry` — which has since landed on master independently. As @jalagrange and I confirmed there, the wiring is necessary but **not sufficient**: the `reconnect()` it calls can itself brick the engine. Juan split the remaining work into two layers and left this one (the `reconnect()` crash-safety) to me; the non-batch-call-sites layer is his #1891.

## Problem

`PostgresEngine.reconnect()` on the instance-pool path does `disconnect()` (which nulls `_sql`) **before** attempting `connect()`:

```js
try { await this.disconnect(); } catch {}   // _sql = null HERE
await this.connect(this._savedConfig);        // if THIS throws, _sql stays null forever
```

So when a transient blip fires the retry→reconnect path and Postgres is unreachable for those few seconds, `connect()` throws and `_sql` is left null permanently. Every subsequent call uses the accessor `this._sql || db.getConnection()`; with `_sql` null it falls through to the module singleton, which a long-running instance-pool process (e.g. the autopilot worker) never connected → throw. Non-bulk methods (`getConfig`, per-phase reads) have no retry wrapper, so the first one after the failed reconnect throws unhandled and crashes the worker, which respawns and repeats every ~5 min.

Observed in production on a long-running `gbrain autopilot` daemon (direct local Postgres): worker runs a cycle's early phases fine, late phases throw `No database connection: connect() has not been called`, `executeJob` crashes unhandled, exit code 1, respawn loop.

## Fix — build-then-swap

Snapshot the live pool, build a fresh one, and only tear the old one down once the new one is **proven live** (`connect()` validates via `SELECT 1` before returning). If the rebuild fails, restore the old pool so the engine stays usable — postgres.js pools self-heal on the next query once Postgres is back, and `batchRetry`'s backoff retries. Keeps the existing reap-detection + pool-recovery audit logging untouched; only the teardown ordering changes.

## Test

`test/connection-resilience.test.ts` (25 pass) + `test/core/retry-reconnect.test.ts` (5 pass), typecheck clean. The recovery-contract guard is updated to assert the build-then-swap old-pool teardown rather than the removed `disconnect()` call.

Complementary to #1891 (non-batch call-site retry wrapper) and orthogonal to the module-singleton ownership work — this is the instance-pool layer.
