### PR TITLE
feat: add Ollama Qwen3 embedding dimensions

### DIFF
--- a/src/commands/init-provider-picker.ts
+++ b/src/commands/init-provider-picker.ts
@@ -21,6 +21,7 @@
  */
 
 import { listRecipes } from '../core/ai/recipes/index.ts';
+import { embeddingDefaultDimsForModel } from '../core/ai/model-resolver.ts';
 import { envReady, formatRecipeTable } from './providers.ts';
 import { readLineSafe } from './init.ts';
 import type { Recipe } from '../core/ai/types.ts';
@@ -123,8 +124,8 @@ export async function pickProvider(opts: PickProviderOpts): Promise<PickedProvid
   const lines = ready.map((r, i) => {
     const tp = r.touchpoints[opts.touchpoint];
     let label = `  ${i + 1}) ${r.id}`;
-    if (opts.touchpoint === 'embedding' && tp && 'default_dims' in tp) {
-      label += `  (${tp.default_dims}d)`;
+    if (opts.touchpoint === 'embedding' && tp && 'default_dims' in tp && 'models' in tp && Array.isArray(tp.models) && tp.models.length > 0) {
+      label += `  (${embeddingDefaultDimsForModel(r, tp.models[0])}d)`;
     }
     if (tp && 'models' in tp && Array.isArray(tp.models) && tp.models.length > 0) {
       label += `  ${tp.models[0]}`;
@@ -169,7 +170,7 @@ export async function pickProvider(opts: PickProviderOpts): Promise<PickedProvid
 
   const dim =
     opts.touchpoint === 'embedding' && 'default_dims' in tp
-      ? (tp as { default_dims: number }).default_dims
+      ? embeddingDefaultDimsForModel(picked, modelId)
       : 0;
 
   return {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -241,8 +241,9 @@ async function resolveAIOptions(opts: ResolveAIOptionsArgs): Promise<ResolvedAIO
       console.error(`Provider ${shorthand} has no embedding models listed. Use --embedding-model provider:model.`);
       process.exit(1);
     }
+    const { embeddingDefaultDimsForModel } = await import('../core/ai/model-resolver.ts');
     out.embedding_model = `${shorthand}:${firstModel}`;
-    out.embedding_dimensions = recipe.touchpoints.embedding!.default_dims;
+    out.embedding_dimensions = embeddingDefaultDimsForModel(recipe, firstModel);
   }
 
   if (dimsArg !== null && !Number.isNaN(dimsArg) && dimsArg > 0) {
@@ -267,7 +268,9 @@ async function resolveAIOptions(opts: ResolveAIOptionsArgs): Promise<ResolvedAIO
       process.exit(1);
     }
     if (recipe?.touchpoints.embedding?.default_dims) {
-      out.embedding_dimensions = recipe.touchpoints.embedding.default_dims;
+      const { parseModelId, embeddingDefaultDimsForModel } = await import('../core/ai/model-resolver.ts');
+      const parsed = parseModelId(out.embedding_model);
+      out.embedding_dimensions = embeddingDefaultDimsForModel(recipe, parsed.modelId);
     }
   }
 
@@ -430,9 +433,10 @@ async function resolveEmbeddingByEnv(out: ResolvedAIOptions, nonInteractive: boo
       // legacy OpenAI 1536), not the recipe's 2560.
       const { DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_DIMENSIONS } =
         await import('../core/ai/defaults.ts');
+      const { embeddingDefaultDimsForModel } = await import('../core/ai/model-resolver.ts');
       const dims = fullModel === DEFAULT_EMBEDDING_MODEL
         ? DEFAULT_EMBEDDING_DIMENSIONS
-        : tp.default_dims;
+        : embeddingDefaultDimsForModel(r, model);
       out.embedding_model = fullModel;
       out.embedding_dimensions = dims;
       console.error(

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -6,6 +6,7 @@
  */
 
 import { listRecipes, getRecipe } from '../core/ai/recipes/index.ts';
+import { parseModelId, embeddingDefaultDimsForModel } from '../core/ai/model-resolver.ts';
 import { configureGateway, embedOne, isAvailable as gwIsAvailable, chat as gwChat } from '../core/ai/gateway.ts';
 import { probeOllama, probeLMStudio } from '../core/ai/probes.ts';
 import { loadConfig } from '../core/config.ts';
@@ -181,7 +182,7 @@ async function runTest(args: string[]): Promise<void> {
     } catch { /* loadConfig throws when no brain configured — first-time install path; the no-config branch above handles it. */ }
 
     if (tpArg === 'embedding') {
-      const dims = recipe?.touchpoints.embedding?.default_dims ?? 1536;
+      const dims = recipe ? embeddingDefaultDimsForModel(recipe, parseModelId(modelArg).modelId) : 1536;
       configureGateway({
         embedding_model: modelArg,
         embedding_dimensions: dims,
@@ -299,7 +300,7 @@ async function runExplain(args: string[]): Promise<void> {
         id: `${r.id}:${m.models[0]}`,
         touchpoint: 'embedding',
         model: m.models[0],
-        dims: m.default_dims,
+        dims: embeddingDefaultDimsForModel(r, m.models[0]),
         cost_per_1m_tokens_usd: m.cost_per_1m_tokens_usd,
         price_last_verified: m.price_last_verified,
         env_ready: envReady(r) || (r.id === 'ollama' && ollama.models_endpoint_valid === true),

--- a/src/core/ai/model-resolver.ts
+++ b/src/core/ai/model-resolver.ts
@@ -141,6 +141,20 @@ export function assertTouchpoint(
   }
 }
 
+/**
+ * Return the native embedding width for a concrete model in a recipe.
+ *
+ * Most providers expose one fixed width per embedding recipe, so default_dims is
+ * enough. Local/model-hosting recipes such as Ollama can list multiple fixed
+ * width models under the same provider; model_dims lets those models size the
+ * schema correctly without forcing users to pass --embedding-dimensions.
+ */
+export function embeddingDefaultDimsForModel(recipe: Recipe, modelId: string): number {
+  const tp = recipe.touchpoints.embedding;
+  if (!tp) return 0;
+  return tp.model_dims?.[modelId] ?? tp.default_dims;
+}
+
 export function knownProviderIds(): string[] {
   return [...RECIPES.keys()];
 }

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -13,14 +13,22 @@ export const ollama: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['nomic-embed-text', 'mxbai-embed-large', 'all-minilm'],
+      models: ['nomic-embed-text', 'qwen3-embedding:0.6b', 'qwen3-embedding', 'mxbai-embed-large', 'bge-m3', 'all-minilm'],
       default_dims: 768, // nomic-embed-text native dim
+      model_dims: {
+        'nomic-embed-text': 768,
+        'qwen3-embedding:0.6b': 1024,
+        'qwen3-embedding': 4096,
+        'mxbai-embed-large': 1024,
+        'bge-m3': 1024,
+        'all-minilm': 384,
+      },
       cost_per_1m_tokens_usd: 0,
-      price_last_verified: '2026-04-20',
+      price_last_verified: '2026-06-06',
       // Ollama's batch capacity depends on the locally loaded model + the
       // OLLAMA_NUM_PARALLEL config; no static cap to declare. v0.32 (#779).
       no_batch_cap: true,
     },
   },
-  setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` and `ollama serve`.',
+  setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` (or `ollama pull qwen3-embedding:0.6b`) and `ollama serve`.',
 };

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -27,6 +27,12 @@ export type Implementation =
 export interface EmbeddingTouchpoint {
   models: string[];
   default_dims: number;
+  /**
+   * Optional per-model native dimensions for providers that expose multiple
+   * fixed-width embedding models under one recipe (for example Ollama local
+   * models). When omitted, consumers fall back to default_dims.
+   */
+  model_dims?: Record<string, number>;
   dims_options?: number[]; // for Matryoshka-aware providers
   cost_per_1m_tokens_usd?: number;
   price_last_verified?: string; // ISO date

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -16,7 +16,7 @@
 import type { BrainEngine } from './engine.ts';
 import { PGVECTOR_HNSW_VECTOR_MAX_DIMS } from './vector-index.ts';
 import { gbrainPath } from './config.ts';
-import { resolveRecipe } from './ai/model-resolver.ts';
+import { resolveRecipe, embeddingDefaultDimsForModel } from './ai/model-resolver.ts';
 import type { Recipe } from './ai/types.ts';
 import { AIConfigError } from './ai/errors.ts';
 import {
@@ -265,8 +265,9 @@ export interface ResolveSchemaEmbeddingDimOpts {
  *  3. Recipe declares an `embedding` touchpoint.
  *  4. Resolved dim is a positive integer.
  *  5. Resolved dim ≤ PGVECTOR_COLUMN_MAX_DIMS (16000).
- *  6. If user passed `embedding_dimensions`, it either matches
- *     `recipe.touchpoints.embedding.default_dims` OR is in the recipe's
+ *  6. If user passed `embedding_dimensions`, it either matches the model's
+ *     native default (`model_dims[model]` when declared, otherwise
+ *     `recipe.touchpoints.embedding.default_dims`) OR is in the recipe's
  *     `dims_options` list (Matryoshka providers). Otherwise reject — the
  *     user picked a model that doesn't support custom dims.
  */
@@ -282,7 +283,8 @@ export function resolveSchemaEmbeddingDim(opts: ResolveSchemaEmbeddingDimOpts): 
           `Pick a recipe with an embedding touchpoint (gbrain providers list).`,
       };
     }
-    return validateDimAgainstTouchpoint(parsed.modelId, recipe, tp.default_dims, tp.dims_options, opts.embedding_dimensions);
+    const defaultDims = embeddingDefaultDimsForModel(recipe, parsed.modelId);
+    return validateDimAgainstTouchpoint(parsed.modelId, recipe, defaultDims, tp.dims_options, opts.embedding_dimensions);
   } catch (err) {
     return { ok: false, error: err instanceof AIConfigError ? err.message : String(err) };
   }

--- a/test/embedding-dim-check.test.ts
+++ b/test/embedding-dim-check.test.ts
@@ -237,6 +237,43 @@ describe('resolveSchemaEmbeddingDim', () => {
     if (got.ok) expect(got.dim).toBe(768);
   });
 
+  test('Ollama qwen3-embedding:0.6b resolves to its per-model 1024d default', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:qwen3-embedding:0.6b' });
+    expect(got).toEqual({
+      ok: true,
+      dim: 1024,
+      model: 'ollama:qwen3-embedding:0.6b',
+      provider: 'ollama',
+      recipeDefault: 1024,
+    });
+  });
+
+  test('Ollama qwen3-embedding resolves to its per-model 4096d default', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:qwen3-embedding' });
+    expect(got).toEqual({
+      ok: true,
+      dim: 4096,
+      model: 'ollama:qwen3-embedding',
+      provider: 'ollama',
+      recipeDefault: 4096,
+    });
+  });
+
+  test('Ollama all-minilm resolves to its per-model 384d default', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:all-minilm' });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(384);
+  });
+
+  test('Ollama qwen3-embedding rejects non-native explicit dimensions', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'ollama:qwen3-embedding:0.6b',
+      embedding_dimensions: 768,
+    });
+    expect(got.ok).toBe(false);
+    if (!got.ok) expect(got.error).toMatch(/does not support custom dimensions 768/);
+  });
+
   test('unknown provider rejected with provider list hint', () => {
     const got = resolveSchemaEmbeddingDim({ embedding_model: 'notarealprovider:foo' });
     expect(got.ok).toBe(false);


### PR DESCRIPTION
## Summary
- add per-model Ollama embedding dimension metadata, including Qwen3 embedding defaults
- route provider/init dimension resolution through provider recipes instead of assuming one Ollama dimension
- add regression coverage for Qwen3, all-minilm, invalid explicit Ollama dimensions, and related schema dimension resolution paths

## Test Plan
- `bun test test/embedding-dim-check.test.ts`