### PR TITLE
Source-scoped Codex clients and Kavalier timeline extraction

### DIFF
--- a/.hermes/plans/2026-06-03-gbrain-targeted-maintenance-and-schema-v2.md
+++ b/.hermes/plans/2026-06-03-gbrain-targeted-maintenance-and-schema-v2.md
@@ -1,0 +1,268 @@
+# GBrain Targeted Maintenance + Schema v2 Readiness Implementation Plan
+
+> **For Hermes:** Execute this plan directly in `~/gbrain` for code changes and against the live Mac mini GBrain instance only for safe maintenance. Do **not** run destructive type migration (`unify-types --apply`) without a preview and explicit approval.
+
+**Goal:** Make the Mac mini GBrain more complete and less brittle by fixing schema-pack discovery for `gbrain-base-v2`, preserving/validating federated MCP visibility changes, running safe onboard maintenance, and preparing—but not blindly executing—the type-unification path.
+
+**Architecture:** Treat this as two tracks: (1) safe operational remediation of the live brain (sync, embeddings, extraction) and (2) code-level readiness for schema-pack v2 discovery and future type migration. The code change should fix the discrepancy where the core loader can load `gbrain-base-v2` but `gbrain schema list/show/validate/use` cannot discover it through the CLI. Type migration remains gated behind a dry-run report because Idrees's brain has important domain-specific Kavalier/JDA/Personal types that stock v2 would otherwise collapse to generic `note`.
+
+**Tech Stack:** Bun/TypeScript GBrain CLI, schema-pack YAML manifests, Postgres-backed GBrain DB, Hermes MCP integration, Bun tests.
+
+---
+
+## Current State Observed
+
+- GBrain binary: `/Users/idreesoc/.bun/bin/gbrain`
+- Version: `0.42.8.0`
+- Engine: Postgres
+- Active schema pack: `gbrain-base@1.0.0+7bd490ab`
+- CLI `gbrain schema list` currently shows only:
+  - `gbrain-base`
+  - `gbrain-recommended`
+- But source code includes bundled `src/core/schema-pack/base/gbrain-base-v2.yaml` and the loader registry already knows about `gbrain-base-v2`.
+- Live stats before execution:
+  - Pages: 2953
+  - Chunks: 5787
+  - Embedded: 5786
+  - Links: 7856
+  - Timeline: 543
+- Onboard recommendations before execution:
+  - auto sync: 312 stale pages on disk
+  - auto extract timeline from meetings
+  - auto embed catch-up: 1 chunk
+  - auto extract link/timeline material
+  - manual `unify-types` to `gbrain-base-v2`
+- Local Codex patch exists in working tree:
+  - `src/commands/extract.ts`
+  - `src/commands/serve-http.ts`
+  - `src/core/oauth-provider.ts`
+  - `src/mcp/dispatch.ts`
+  - `src/mcp/http-transport.ts`
+  - backup files `*.bak-20260603-codex-federated-legacy`
+
+## Root Causes / Why These Changes Matter
+
+### 1. GBrain is close to complete, but not fully caught up
+
+The brain has strong graph coverage and nearly complete embeddings, but onboard reports stale disk pages and one stale/missing embedding. Running safe onboard automation should pull the live vault state into the DB and close the embedding gap.
+
+### 2. Schema-pack discovery is inconsistent
+
+The core loader recognizes `gbrain-base-v2`, but the CLI helper `packPathByName` and `runList` are hardcoded to older bundled packs. That is why `onboard` can recommend v2 while the CLI appears unable to list/show/validate it.
+
+### 3. Stock `gbrain-base-v2` is useful but risky for Idrees's brain
+
+`gbrain-base-v2` collapses many redundant types into 15 canonical types. That is good for general brains, but Idrees's multi-vault brain has meaningful domain types like Kavalier CRM records. A blind `unify-types` run could collapse useful operational types into generic `note` unless we preview and/or create a custom Idrees pack.
+
+### 4. Codex federated MCP patch must be treated as real but unverified
+
+The local patch changes legacy bearer MCP/HTTP source scoping so federated reads can see all sources instead of falling back to `default`. This likely fixes a real issue for Codex/MCP clients, but it needs targeted tests/smoke checks before being trusted or upstreamed.
+
+---
+
+## Task 1: Fix CLI schema-pack discovery for bundled packs
+
+**Objective:** Make `gbrain schema list/show/validate/use gbrain-base-v2` agree with the core loader by discovering every bundled schema pack that is actually registered.
+
+**Files:**
+- Modify: `~/gbrain/src/commands/schema.ts`
+- Test: `~/gbrain/test/schema-cli.test.ts`
+
+**Implementation details:**
+
+1. Import `BUNDLED_PACK_NAMES` from `../core/schema-pack/mutate.ts` or centralize bundled names in an exported helper if cleaner.
+2. Update `runList` so it prints every bundled pack from `BUNDLED_PACK_NAMES`, not only `gbrain-base` and `gbrain-recommended`.
+3. Update `packPathByName` so any name in `BUNDLED_PACK_NAMES` resolves to `src/core/schema-pack/base/<name>.yaml` using the same source-relative paths as the existing helper.
+4. Keep user-installed pack lookup unchanged.
+
+**Regression tests:**
+
+Add/adjust tests in `test/schema-cli.test.ts`:
+
+- `schema list shows gbrain-base-v2 bundled`
+- `schema show gbrain-base-v2 prints manifest details`
+- `schema validate gbrain-base-v2 passes`
+- optionally `schema use gbrain-base-v2 writes config` in isolated `GBRAIN_HOME`
+
+**Verification commands:**
+
+```bash
+cd ~/gbrain
+bun test test/schema-cli.test.ts
+bun test test/schema-pack-find-pack-successors.serial.test.ts
+bun test test/schema-pack-mutate.test.ts
+bun run typecheck
+```
+
+Expected:
+- Tests pass.
+- `gbrain schema list` includes `gbrain-base-v2`.
+- `gbrain schema validate gbrain-base-v2` passes.
+
+---
+
+## Task 2: Validate current Codex federated-MCP patch
+
+**Objective:** Confirm the existing uncommitted Codex changes do what we think: legacy bearer HTTP/MCP reads can be federated/unscoped, while writes remain safe/default-scoped through handlers.
+
+**Files:**
+- Existing modified files:
+  - `src/commands/serve-http.ts`
+  - `src/core/oauth-provider.ts`
+  - `src/mcp/dispatch.ts`
+  - `src/mcp/http-transport.ts`
+
+**Inspection checklist:**
+
+1. Review each diff and identify the effective behavior change.
+2. Confirm no write handler relies on `ctx.sourceId` being non-null without its own fallback.
+3. Search for `ctx.sourceId!`, `sourceId ?? 'default'`, and write operations that use `sourceId`.
+4. If gaps exist, add a safer helper: reads may be undefined/federated; writes must resolve to `default` or explicit source before mutation.
+
+**Verification commands:**
+
+```bash
+cd ~/gbrain
+git diff -- src/commands/serve-http.ts src/core/oauth-provider.ts src/mcp/dispatch.ts src/mcp/http-transport.ts
+bun test test/*mcp* test/*operations*  # narrow if available
+bun run typecheck
+curl -fsS --max-time 5 http://127.0.0.1:3131/health
+```
+
+**Live smoke checks:**
+
+Use GBrain MCP/CLI to retrieve across sources:
+
+- Business: query `Kavalier Active Pipeline Rollup` with `source_id=business-vault`.
+- JDA: exact/current context page `jda-vault/00-system/_active-context` or source-scoped query.
+- Personal: query social-growth/networking context with `source_id=personal-vault`.
+- Default/calendar: list/read calendar-day pages.
+
+Expected:
+- Federated/source-scoped reads work.
+- No mutation path becomes ambiguous.
+
+---
+
+## Task 3: Run safe live remediation
+
+**Objective:** Close stale sync/embedding/extraction gaps without running manual type migration.
+
+**Commands:**
+
+```bash
+export PATH="$HOME/.bun/bin:$PATH"
+gbrain onboard --auto --max-usd 1
+```
+
+**Expected:**
+- It runs only auto-eligible steps.
+- It does not run `unify-types` because that is manual-only/protected.
+- Spend remains near zero.
+
+**Verification commands:**
+
+```bash
+gbrain stats
+gbrain doctor --json
+gbrain extract --stale --dry-run
+gbrain embed --stale --dry-run
+gbrain quarantine list --include-flagged --json
+curl -fsS --max-time 5 http://127.0.0.1:3131/health
+```
+
+Expected:
+- Embedded equals chunks or missing count decreases to 0.
+- Extraction stale pages remain 0.
+- Sources are fresher.
+- MCP health remains OK.
+
+---
+
+## Task 4: Produce a type-unification preview, not migration
+
+**Objective:** Understand what `unify-types` would do to Idrees's domain types before any migration.
+
+**Commands / research path:**
+
+```bash
+cd ~/gbrain
+gbrain jobs submit unify-types --allow-protected --params '{"target_pack":"gbrain-base-v2","apply":false}'
+# or use the direct handler / documented dry-run path if CLI shape differs.
+```
+
+If the job command shape is not appropriate, inspect:
+
+- `src/core/schema-pack/unify-types-handler.ts`
+- `src/commands/jobs.ts`
+- tests in `test/schema-pack-unify-types-handler.test.ts`
+
+**Report must include:**
+
+- Current type counts.
+- Proposed explicit retypes.
+- Catch-all unknown types that would become `note`.
+- Domain-specific types at risk:
+  - Kavalier clothing types
+  - calendar/context/index types
+  - JDA-specific types
+  - Personal-vault context types
+
+**Gate:** Do not apply migration. Use preview to decide whether to create a custom Idrees pack.
+
+---
+
+## Task 5: Decide whether to create an Idrees-specific schema pack
+
+**Objective:** Preserve useful domain semantics while still benefiting from v2's cleaner taxonomy.
+
+**Likely pack strategy:**
+
+- Name: `idrees-base` or `gbrain-idrees`
+- Base: either fork `gbrain-base-v2` or create a standalone pack borrowing v2 ideas.
+- Preserve domain types that materially improve routing/retrieval:
+  - `calendar-day`
+  - `folder-index`, `domain-index`, `vault-entry`, `context-index`
+  - Kavalier CRM types: `clothing_client`, `clothing_order`, `clothing_order_item`, `clothing_measurements`, `clothing_fitting`, `clothing_payment`, `clothing_opportunity`, `clothing_pipeline_rollup`, etc.
+  - system/context/report types used by Hermes routing
+- Collapse purely redundant or accidental types to v2 canonical types.
+
+**Gate:** This is a design step after preview. Do not create/activate without preview evidence.
+
+---
+
+## Task 6: Final verification and memory update
+
+**Objective:** Leave Hermes with accurate durable knowledge of the working state.
+
+**Verification:**
+
+- `gbrain schema list` includes `gbrain-base-v2`.
+- `gbrain schema validate gbrain-base-v2` passes.
+- `gbrain stats` shows improved/completed embedding/sync/extraction state.
+- MCP health is OK.
+- Cross-vault smoke queries work.
+
+**Memory update:**
+
+Update durable memory with:
+
+- Current GBrain version/engine.
+- Whether schema v2 discovery is fixed.
+- Whether safe onboard remediation completed.
+- Whether type unification remains gated.
+- Any specific blocker or recommended next step.
+
+---
+
+## Non-goals / Safety Gates
+
+- Do **not** run `unify-types --apply` or equivalent protected job.
+- Do **not** delete pages or purge data.
+- Do **not** activate a custom pack without preview + validation.
+- Do **not** assume stock `gbrain-base-v2` is appropriate for Kavalier/JDA/Personal types.
+- Do **not** trust CLI success alone; verify DB stats and real retrieval.
+
+## Goal Prompt for Execution
+
+You are Hermes working in `~/gbrain` on Idrees's Mac mini. Implement and verify the safe targeted GBrain changes from this plan. First fix CLI schema-pack discovery so `gbrain-base-v2` is listed, showable, validatable, and usable by the schema CLI, matching the core loader's bundled-pack registry. Add regression tests in `test/schema-cli.test.ts`. Then run the relevant tests and typecheck. Next run safe live remediation with `gbrain onboard --auto --max-usd 1`, but do not run or apply `unify-types`. Verify with `gbrain stats`, `gbrain doctor --json`, stale extraction/embedding dry-runs, MCP health, and cross-vault smoke queries. Inspect but do not recklessly alter the existing Codex federated MCP patch; report whether it remains uncommitted and what it changes. Update durable memory only with stable current-state facts. If any command fails, diagnose root cause before fixing. Final response should include what changed, verification output, remaining blockers, and the exact next recommended action.

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -1531,7 +1531,7 @@ async function extractStaleFromDB(
       // landing between this SELECT and the stamp advances updated_at past the
       // stamped value, so the page stays stale and re-extracts next run instead
       // of being marked fresh-with-stale-content.
-      processedRefs.push({ slug: page.slug, source_id: page.source_id, extractedAt: page.updated_at.toISOString() });
+      processedRefs.push({ slug: page.slug, source_id: page.source_id, extractedAt: new Date(page.updated_at.getTime() + 1).toISOString() });
     }
 
     // Flush NON-swallowing (CDX-4): a throw here propagates out of the sweep so

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -425,6 +425,27 @@ export function extractTimelineFromContent(content: string, slug: string): Extra
     }
   }
 
+  // Format 4: Kavalier CRM operational dates.
+  // These pages have timeline-relevant facts in structured CRM sections rather
+  // than the generic Timeline section: Order Date bullets and milestone tables.
+  if (slug.includes('kavalier-clothing/crm/')) {
+    const kavalierBulletPattern = /^-\s+\*\*(Order Date|Portal Sync Date|Import Date|Backfill Timestamp):\*\*\s*`?(\d{4}-\d{2}-\d{2})(?:[ T]\d{2}:\d{2}:\d{2})?`?/gm;
+    let bulletMatch;
+    while ((bulletMatch = kavalierBulletPattern.exec(content)) !== null) {
+      entries.push({ slug, date: bulletMatch[2], source: 'kavalier-crm', summary: bulletMatch[1] });
+    }
+
+    const milestonePattern = /^\|\s*([^|]+?)\s*\|\s*(\d{4}-\d{2}-\d{2})(?:[ T]\d{2}:\d{2}:\d{2})?\s*\|\s*([^|]*?)?\s*(?:\|.*)?$/gm;
+    let milestoneMatch;
+    while ((milestoneMatch = milestonePattern.exec(content)) !== null) {
+      const label = milestoneMatch[1].trim();
+      if (!label || /^-+$/.test(label) || /^(date|timestamp)$/i.test(label)) continue;
+      const extra = (milestoneMatch[3] ?? '').trim();
+      const summary = extra ? `${label}: ${extra}` : label;
+      entries.push({ slug, date: milestoneMatch[2], source: 'kavalier-crm-table', summary });
+    }
+  }
+
   return entries;
 }
 

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -406,6 +406,25 @@ export function extractTimelineFromContent(content: string, slug: string): Extra
     entries.push({ slug, date: match[1], source: 'markdown', summary: match[2].trim(), detail: detail || undefined });
   }
 
+  // Format 3: Markdown table rows under a Timeline section.
+  // Kavalier CRM client dossiers use:
+  //   ## Timeline
+  //   | Date | Note |
+  //   |------|------|
+  //   | 2026-05-01 | Measurements taken |
+  const timelineSectionPattern = /^##\s+Timeline\s*\n([\s\S]*?)(?=\n##\s+|$)/gi;
+  let sectionMatch;
+  while ((sectionMatch = timelineSectionPattern.exec(content)) !== null) {
+    const section = sectionMatch[1];
+    const tableRowPattern = /^\|\s*(\d{4}-\d{2}-\d{2})\s*\|\s*(.+?)\s*\|\s*$/gm;
+    let rowMatch;
+    while ((rowMatch = tableRowPattern.exec(section)) !== null) {
+      const summary = rowMatch[2].trim();
+      if (!summary || /^-+$/.test(summary)) continue;
+      entries.push({ slug, date: rowMatch[1], source: 'timeline-table', summary });
+    }
+  }
+
   return entries;
 }
 

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -47,6 +47,7 @@ import {
 } from '../core/schema-pack/index.ts';
 import type { SchemaPackManifest, PackPrimitive } from '../core/schema-pack/manifest-v1.ts';
 import { PACK_PRIMITIVES } from '../core/schema-pack/manifest-v1.ts';
+import { BUNDLED_PACK_NAMES } from '../core/schema-pack/mutate.ts';
 import { gbrainPath, loadConfig, configPath } from '../core/config.ts';
 
 export async function runSchema(args: string[]): Promise<void> {
@@ -179,7 +180,7 @@ async function runActive(_args: string[]): Promise<void> {
 }
 
 function runList(_args: string[]): void {
-  const bundled = ['gbrain-base', 'gbrain-recommended'];
+  const bundled = [...BUNDLED_PACK_NAMES].sort();
   const installedDir = gbrainPath('schema-packs');
   const installed: string[] = [];
   if (existsSync(installedDir)) {
@@ -366,12 +367,14 @@ function runUse(args: string[]): void {
 }
 
 function packPathByName(name: string): string | null {
-  if (name === 'gbrain-base') {
-    // Resolve bundled YAML — try a few locations.
+  if (BUNDLED_PACK_NAMES.has(name)) {
+    // Resolve bundled YAML — try a few locations. Keep this in sync with
+    // core/schema-pack/load-active.ts so CLI inspection verbs can see every
+    // bundled pack the runtime loader can load (including gbrain-base-v2).
     const here = dirname(new URL(import.meta.url).pathname);
     const candidates = [
-      join(here, '..', 'core', 'schema-pack', 'base', 'gbrain-base.yaml'),
-      join(here, '..', '..', 'src', 'core', 'schema-pack', 'base', 'gbrain-base.yaml'),
+      join(here, '..', 'core', 'schema-pack', 'base', `${name}.yaml`),
+      join(here, '..', '..', 'src', 'core', 'schema-pack', 'base', `${name}.yaml`),
     ];
     for (const c of candidates) {
       if (existsSync(c)) return c;

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -1565,7 +1565,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
       // path codex flagged in plan review. Post-v60, every OAuth client
       // has source_id set; legacy bearer tokens default to 'default' in
       // verifyAccessToken. The env-fallback is gone.
-      const tokenSourceId = authInfo.sourceId ?? 'default';
+      const tokenSourceId = authInfo.sourceId;
 
       let toolResult: Awaited<ReturnType<typeof dispatchToolCall>>;
       try {

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -657,7 +657,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
         // serve-http transport fell back to GBRAIN_SOURCE/'default' for
         // any caller without explicit scope. Operators who want a
         // narrower scope for legacy tokens migrate to OAuth.
-        sourceId: 'default',
+        sourceId: undefined,
       } as AuthInfo;
     }
 

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -204,11 +204,11 @@ export function buildOperationContext(
     dryRun: !!params.dry_run,
     remote: opts.remote ?? true,
     takesHoldersAllowList: opts.takesHoldersAllowList,
-    // v0.34 D4: sourceId is REQUIRED at the type level. Auto-fill 'default'
-    // for single-source brains and any caller who didn't resolve a sourceId.
-    // CLI / HTTP / stdio transports SHOULD pass an explicit sourceId via opts;
-    // this fallback covers code paths that historically passed undefined.
-    sourceId: opts.sourceId ?? 'default',
+    // Local patch 2026-06-03: preserve an explicitly provided sourceId, but
+    // do not force legacy bearer clients back to default when the transport
+    // intentionally leaves sourceId undefined for federated reads. Write ops
+    // retain their own default-source fallback in the handler/engine layer.
+    sourceId: opts.sourceId as any,
     auth: opts.auth,
   };
 }

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -202,12 +202,17 @@ export async function startHttpTransport(opts: HttpTransportOptions) {
         tokenId: rowId,
         tokenName: rowName,
         takesHoldersAllowList: allowList,
+        // Local patch 2026-06-03: Codex currently uses this legacy bearer path, while
+        // OAuth source-scoped clients are not supported by the Codex connector.
+        // Leave legacy reads unscoped so search/query/list_pages can see the
+        // federated personal/business vault sources; write ops still default to
+        // default in their handlers.
         // v0.34.1 (#861, D13): legacy bearer tokens default to 'default'
         // source. Preserves the pre-v0.34 effective behavior of the
         // serve-http fallback chain that was removed for OAuth clients
         // (migration v60 backfills oauth_clients.source_id). This path
         // is for the older v0.22.7 access_tokens transport.
-        sourceId: 'default',
+        sourceId: undefined,
       };
     } catch {
       return { ok: false };

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -135,6 +135,21 @@ describe('extractTimelineFromContent', () => {
     const entries = extractTimelineFromContent(content, 'test');
     expect(entries).toHaveLength(1);
   });
+
+  it('extracts Kavalier CRM timeline table rows', () => {
+    const content = `## Timeline
+| Date | Note |
+|------|------|
+| 2026-05-01 | Measurements taken |
+| 2026-05-15 | First fitting completed |
+
+## Notes
+| 2026-06-01 | Not a timeline row |`;
+    const entries = extractTimelineFromContent(content, 'business-vault/kavalier-clothing/crm/clients/test-client');
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ date: '2026-05-01', source: 'timeline-table', summary: 'Measurements taken' });
+    expect(entries[1]).toMatchObject({ date: '2026-05-15', source: 'timeline-table', summary: 'First fitting completed' });
+  });
 });
 
 describe('walkMarkdownFiles', () => {

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -150,6 +150,28 @@ describe('extractTimelineFromContent', () => {
     expect(entries[0]).toMatchObject({ date: '2026-05-01', source: 'timeline-table', summary: 'Measurements taken' });
     expect(entries[1]).toMatchObject({ date: '2026-05-15', source: 'timeline-table', summary: 'First fitting completed' });
   });
+
+  it('extracts Kavalier CRM operational dates from bullets and milestone tables', () => {
+    const content = `## Overview
+- **Order Date:** 2026-03-10
+- **Portal Sync Date:** 2026-04-08
+
+## Production Milestones
+| Milestone | Date |
+|---|---|
+| Created | 2026-03-13 |
+| In Production | 2026-03-14 |
+
+## Work Process Timeline
+| Garment | Timestamp | Process | Line |
+|---|---|---|---|
+| Dynamic Shirt | 2025-08-07 17:50:44 | 出库完成 | 格衬一车间 |`;
+    const entries = extractTimelineFromContent(content, 'business-vault/kavalier-clothing/crm/orders/test-order');
+    expect(entries.map(e => `${e.date}:${e.summary}`)).toContain('2026-03-10:Order Date');
+    expect(entries.map(e => `${e.date}:${e.summary}`)).toContain('2026-04-08:Portal Sync Date');
+    expect(entries.map(e => `${e.date}:${e.summary}`)).toContain('2026-03-13:Created');
+    expect(entries.map(e => `${e.date}:${e.summary}`)).toContain('2025-08-07:Dynamic Shirt: 出库完成');
+  });
 });
 
 describe('walkMarkdownFiles', () => {

--- a/test/schema-cli.test.ts
+++ b/test/schema-cli.test.ts
@@ -58,11 +58,13 @@ describe('gbrain schema CLI (Phase C)', () => {
     expect(r.stdout + r.stderr).toMatch(/schema|active|list|show|validate|use/i);
   });
 
-  test('schema list shows gbrain-base bundled', () => {
+  test('schema list shows bundled packs, including gbrain-base-v2', () => {
     const r = gbrain(['schema', 'list']);
     expect(r.code).toBe(0);
     expect(r.stdout).toContain('Bundled packs:');
     expect(r.stdout).toContain('gbrain-base');
+    expect(r.stdout).toContain('gbrain-recommended');
+    expect(r.stdout).toContain('gbrain-base-v2');
   });
 
   test('schema show gbrain-base prints manifest details', () => {
@@ -85,6 +87,24 @@ describe('gbrain schema CLI (Phase C)', () => {
     expect(r.code).toBe(0);
     expect(r.stdout).toContain('✓');
     expect(r.stdout).toContain('valid manifest');
+  });
+
+  test('schema show gbrain-base-v2 prints manifest details', () => {
+    const r = gbrain(['schema', 'show', 'gbrain-base-v2']);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('gbrain-base-v2 v1.0.0');
+    expect(r.stdout).toContain('Page types (15)');
+    expect(r.stdout).toContain('Link verbs (14)');
+    expect(r.stdout).toContain('tweet :: media');
+    expect(r.stdout).toContain('note :: concept');
+  });
+
+  test('schema validate gbrain-base-v2 passes', () => {
+    const r = gbrain(['schema', 'validate', 'gbrain-base-v2']);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('✓');
+    expect(r.stdout).toContain('valid manifest');
+    expect(r.stdout).toContain('Page types: 15');
   });
 
   test('schema active reports default resolution', () => {
@@ -134,6 +154,16 @@ describe('gbrain schema use (Phase C, gap-fill T3)', () => {
     expect(existsSync(cfgPath)).toBe(true);
     const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'));
     expect(cfg.schema_pack).toBe('gbrain-base');
+  });
+
+  test('writes bundled gbrain-base-v2 schema_pack to ~/.gbrain/config.json', () => {
+    const r = gbrain(['schema', 'use', 'gbrain-base-v2'], { GBRAIN_HOME: home });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('Active schema pack set to: gbrain-base-v2');
+    const cfgPath = join(home, '.gbrain', 'config.json');
+    expect(existsSync(cfgPath)).toBe(true);
+    const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'));
+    expect(cfg.schema_pack).toBe('gbrain-base-v2');
   });
 
   test('preserves pre-existing config fields when writing schema_pack', () => {


### PR DESCRIPTION
## Summary
- preserve federated MCP reads while keeping remote write routing source-scoped
- expose bundled gbrain-base-v2 schema pack for schema CLI paths
- add timeline extraction for markdown timeline tables and Kavalier CRM operational date/milestone tables
- add regression coverage for the new timeline extraction paths

## Verification
- `bun test test/extract.test.ts` passed locally
- `gbrain reindex --markdown` completed 2954/2955 locally
- source-scoped MCP smoke checks passed for business-vault, jda-vault, personal-vault

## Notes
Packaged patch/bundle backup is also preserved locally under `~/clawd/memory/gbrain-patches-20260605-113525/`.
