### PR TITLE
fix(markdown): add case hint for slug mismatches

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -283,9 +283,12 @@ function collectValidationErrors(
   if (ctx.expectedSlug && typeof ctx.parsedFrontmatter.slug === 'string') {
     const declared = ctx.parsedFrontmatter.slug as string;
     if (declared !== ctx.expectedSlug) {
+      const caseHint = declared.toLowerCase() === ctx.expectedSlug
+        ? ` Slugs are case-sensitive; use "${ctx.expectedSlug}" or remove the slug field to use the path-derived value.`
+        : '';
       errors.push({
         code: 'SLUG_MISMATCH',
-        message: `Frontmatter slug "${declared}" does not match path-derived slug "${ctx.expectedSlug}"`,
+        message: `Frontmatter slug "${declared}" does not match path-derived slug "${ctx.expectedSlug}".${caseHint}`,
       });
     }
   }

--- a/test/markdown-validation.test.ts
+++ b/test/markdown-validation.test.ts
@@ -83,6 +83,18 @@ describe('parseMarkdown validation surface', () => {
       expect(parsed.errors!.map(e => e.code)).toContain('SLUG_MISMATCH');
     });
 
+    test('mixed-case slug mismatch includes actionable lowercase hint', () => {
+      const md = `${fence}\ntype: concept\ntitle: hi\nslug: projects/README\n${fence}\n\nbody`;
+      const parsed = parseMarkdown(md, 'projects/README.md', {
+        validate: true,
+        expectedSlug: 'projects/readme',
+      });
+      const error = parsed.errors!.find(e => e.code === 'SLUG_MISMATCH');
+      expect(error).toBeDefined();
+      expect(error!.message).toContain('Slugs are case-sensitive');
+      expect(error!.message).toContain('projects/readme');
+    });
+
     test('matching slug -> no error', () => {
       const md = `${fence}\ntype: concept\ntitle: hi\nslug: people/jane-doe\n${fence}\n\nbody`;
       const parsed = parseMarkdown(md, 'people/jane-doe.md', {


### PR DESCRIPTION
## Summary

- clarify `SLUG_MISMATCH` when the declared frontmatter slug only differs from the path-derived slug by capitalization
- tell the user to use the lowercase path-derived slug or remove `slug:` so the default is used
- add a regression test for `projects/README.md` declaring `slug: projects/README`

Closes #1916.

## Verification

- `bun test test/markdown-validation.test.ts`
- `bun test test/markdown.test.ts test/markdown-validation.test.ts`
