### PR TITLE
fix(reindex): drain skipped metafile pages

### DIFF
--- a/src/commands/reindex.ts
+++ b/src/commands/reindex.ts
@@ -27,6 +27,7 @@ import { importFromContent, importFromFile } from '../core/import-file.ts';
 import { serializeMarkdown } from '../core/markdown.ts';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
+import { unsyncableReason } from '../core/sync.ts';
 import { existsSync } from 'fs';
 import { resolve } from 'path';
 // v0.41.15.0 (T10, D9): per-batch parallel workers.
@@ -86,6 +87,12 @@ function parseArgs(args: string[]): ReindexOpts {
     }
   }
   return out;
+}
+
+function isSkippedMarkdownMetafile(sourcePath: string | null): boolean {
+  if (!sourcePath) return false;
+  const normalized = sourcePath.replace(/\\/g, '/').replace(/^\.\/+/, '');
+  return unsyncableReason(normalized, { strategy: 'markdown' }) === 'metafile';
 }
 
 /**
@@ -208,6 +215,12 @@ export async function runReindex(engine: BrainEngine, args: string[]): Promise<R
       onItem: async (row) => {
         reporter.tick();
         try {
+          if (isSkippedMarkdownMetafile(row.source_path)) {
+            await engine.softDeletePage(row.slug, { sourceId: row.source_id });
+            skipped++;
+            return;
+          }
+
           if (row.source_path && repoPath) {
             const absPath = resolve(repoPath, row.source_path);
             if (existsSync(absPath)) {
@@ -270,7 +283,7 @@ export async function runReindex(engine: BrainEngine, args: string[]): Promise<R
       chunker_version: MARKDOWN_CHUNKER_VERSION,
     }) + '\n');
   } else {
-    process.stderr.write(`[reindex] Done. reindexed=${reindexed} failed=${failed} pending=${Math.max(0, pending - reindexed - failed)}\n`);
+    process.stderr.write(`[reindex] Done. reindexed=${reindexed} skipped=${skipped} failed=${failed} pending=${Math.max(0, pending - reindexed - skipped - failed)}\n`);
   }
 
   return result;

--- a/test/reindex.test.ts
+++ b/test/reindex.test.ts
@@ -68,6 +68,26 @@ describe('gbrain reindex --markdown (v0.32.7)', () => {
     expect(rows.every(r => Number(r.chunker_version) === MARKDOWN_CHUNKER_VERSION)).toBe(true);
   });
 
+  test('soft-deletes stale sync metafile rows during markdown sweep', async () => {
+    await seedLegacyPage('legacy-readme', 'legacy README body', 'docs/README.md');
+
+    const result = await runReindex(engine, ['--markdown', '--no-embed']);
+    expect(result.pending).toBe(1);
+    expect(result.reindexed).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.failed).toBe(0);
+
+    const rows = await engine.executeRaw<{ deleted_at: string | null; chunker_version: number }>(
+      `SELECT deleted_at, chunker_version FROM pages WHERE slug = 'legacy-readme'`,
+    );
+    expect(rows[0].deleted_at).not.toBeNull();
+    expect(Number(rows[0].chunker_version)).toBe(1);
+
+    const second = await runReindex(engine, ['--markdown', '--no-embed']);
+    expect(second.pending).toBe(0);
+    expect(second.reindexed).toBe(0);
+  });
+
   test('idempotent: re-run on a fully-updated brain reports nothing to do', async () => {
     await seedLegacyPage('note-e', 'body e');
     // First pass with --no-embed bumps chunker_version but does NOT stamp


### PR DESCRIPTION
## Summary
- Soft-delete pending markdown reindex rows whose `source_path` is a canonical sync metafile.
- Reuse the existing sync classifier so reindex matches the README/index/log/schema skip policy.
- Add a PGLite regression covering the phantom README drain.

Closes #1902

## Verification
- `npx --yes bun@latest test test/reindex.test.ts`
- `npx --yes bun@latest test test/sync-isSyncable-shape.test.ts test/reindex.test.ts`
- `npx --yes bun@latest run typecheck`
- `git diff --check`