### PR TITLE
fix(recipes): populate llama-server model list + dims_options [test]

### DIFF
--- a/src/core/ai/recipes/llama-server.ts
+++ b/src/core/ai/recipes/llama-server.ts
@@ -29,11 +29,24 @@ export const llamaServer: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: [], // user-driven; whatever model the server was launched with
-      user_provided_models: true,
-      default_dims: 0, // forces explicit --embedding-dimensions
+      // Common embedding model names served by llama-server. Operators
+      // can override the model via env (`GBRAIN_EMBEDDING_MODEL=llama-server:<id>`)
+      // without editing the recipe. Other GGUFs work as long as they
+      // emit a dim in `dims_options` below.
+      models: [
+        'nomic-embed-text-v1.5',
+        'bge-large-en-v1.5',
+        'mxbai-embed-large',
+        'all-MiniLM-L6-v2',
+        'snowflake-arctic-embed',
+        'e5-large-v2',
+      ],
+      default_dims: 768,
+      // llama-server emits whatever dim the model was trained at. nomic-embed
+      // is 768, bge-large and mxbai are 1024, all-MiniLM is 384.
+      dims_options: [384, 768, 1024],
       cost_per_1m_tokens_usd: 0,
-      price_last_verified: '2026-05-10',
+      price_last_verified: '2026-06-06',
       // llama-server's batch capacity is set by `--ctx-size` at launch
       // time; no static cap to declare. v0.32 (#779).
       no_batch_cap: true,


### PR DESCRIPTION
## Problem

The `llama-server` recipe ships with `models: []` and `user_provided_models: true`, which forces the gateway's preflight to return `user_provided_model_unset` and abort `gbrain embed` with a confusing error message even when the user HAS configured `GBRAIN_EMBEDDING_MODEL=llama-server:<id>`.

## Fix

Fill in the model list with common embedding models served by llama-server and add a `dims_options` array so the preflight accepts the natural dims these models emit. Operators can still override per-model via the env var without editing the recipe.

Models added: `nomic-embed-text-v1.5` (768d), `bge-large-en-v1.5` (1024d), `mxbai-embed-large` (1024d), `all-MiniLM-L6-v2` (384d), `snowflake-arctic-embed`, `e5-large-v2`.

## Verification

End-to-end on a Mac mini M1 (16 GB) with brew-installed llama.cpp serving `nomic-embed-text-v1.5` (Q8_0, 768d) on `127.0.0.1:8769`:

- `gbrain import`: 102 markdown files → 173 chunks, 0 errors
- `gbrain embed --stale`: 30/30 pages, 105 chunks, 0 errors
- Warm embed latency: ~36ms

Recommended server flags: `--ctx-size 8192 --batch-size 4096 --ubatch-size 4096 --n-gpu-layers 99`. The OpenAI-compat layer's physical batch size is `n_batch` (NOT `n_ctx`); without `--batch-size 4096` long chunks fail with `500 input (N tokens) is too large to process`.
