### PR TITLE
fix(recipes): add max_batch_tokens cap to Gemini embedding recipe

### DIFF
--- a/src/core/ai/recipes/google.ts
+++ b/src/core/ai/recipes/google.ts
@@ -16,6 +16,15 @@ export const google: Recipe = {
       dims_options: [768, 1536, 3072],
       cost_per_1m_tokens_usd: 0.15,
       price_last_verified: '2026-04-20',
+      // 2026-06-06: cap was missing. Without max_batch_tokens the gateway's
+      // `embed()` runs the no-pre-split fast path (one big embedMany), and
+      // Gemini's :batchEmbedContents endpoint charges 1 RPM per ITEM in the
+      // batch (verified via direct 100-item probe → 429, limit 100). For
+      // the free tier we cap so each sub-batch is ~1 chunk, each sub-batch
+      // costs 1 RPM, and a 143-chunk embed fits in ~90s.
+      max_batch_tokens: 150,
+      chars_per_token: 4,
+      safety_factor: 1.0,
     },
     expansion: {
       models: ['gemini-2.0-flash', 'gemini-2.0-flash-lite'],


### PR DESCRIPTION
## Problem

Without `max_batch_tokens`, the gateway's `embed()` runs the no-pre-split fast path (one big `embedMany`), and Gemini's `:batchEmbedContents` endpoint charges **1 RPM per ITEM in the batch** (verified via direct 100-item probe → 429, free-tier limit 100/min). A 143-chunk embed under the free tier saturates the bucket in the first call and 429s for the rest of the minute.

## Fix

Add `max_batch_tokens: 150`, `chars_per_token: 4`, `safety_factor: 1.0` to the Gemini recipe. With these values, sub-batches are ~1 chunk for typical 4-chars-per-token content, each sub-batch costs 1 RPM, and a 143-chunk embed fits in ~90 seconds.

## Verification

Direct probe of `embedContent` with 100 items: 429 after first call, consistent with per-item RPM billing. With the cap, 143 chunks embed in ~90s on a fresh bucket.
