### PR TITLE
v0.42.27.0 fix(autopilot): harden runaway safeguards (#1678)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ export/
 # .context/test-shards/. Workspace-local by design — never committed.
 .context/
 
+# Local autoreview hook reports are generated during agent commits/reviews.
+.autoreview-reports/
+
 # Tier 3 PGLite snapshot fixture (built on demand by build:pglite-snapshot)
 test/fixtures/pglite-snapshot.tar
 test/fixtures/pglite-snapshot.version

--- a/src/commands/autopilot-fanout.ts
+++ b/src/commands/autopilot-fanout.ts
@@ -56,6 +56,7 @@ export interface FanoutResult {
   dispatched: string[];
   /** Source ids skipped because their last_full_cycle_at is still fresh. */
   skipped_fresh: string[];
+  skipped_pending: string[];
   /** Source ids beyond the fanoutMax cap (will retry next tick). */
   skipped_cap: string[];
   /** True when this tick fell back to the legacy single-job path
@@ -144,6 +145,45 @@ export function selectSourcesForDispatch(
   return { dispatch, skippedFresh: fresh, skippedCap };
 }
 
+export interface PendingAutopilotCycles {
+  global: boolean;
+  sourceIds: Set<string>;
+}
+
+export async function listPendingAutopilotCycles(engine: BrainEngine): Promise<PendingAutopilotCycles> {
+  try {
+    const rows = await engine.executeRaw<{ source_id: string | null }>(
+      `SELECT data->>'source_id' AS source_id
+         FROM minion_jobs
+        WHERE name = 'autopilot-cycle'
+          AND queue = 'default'
+          AND status NOT IN ('completed', 'failed', 'dead', 'cancelled')
+        GROUP BY data->>'source_id'`,
+    );
+    const sourceIds = new Set<string>();
+    let global = false;
+    for (const row of rows) {
+      if (typeof row.source_id === 'string' && row.source_id.length > 0) {
+        sourceIds.add(row.source_id);
+      } else if (row.source_id === null) {
+        global = true;
+      }
+    }
+    return { global, sourceIds };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    if (/\bminion_jobs\b/i.test(message) && /(does not exist|no such table|undefined_table)/i.test(message)) {
+      return { global: false, sourceIds: new Set() };
+    }
+    throw e;
+  }
+}
+
+export async function hasPendingSourceCycle(engine: BrainEngine, sourceId: string): Promise<boolean> {
+  const pending = await listPendingAutopilotCycles(engine);
+  return pending.global || pending.sourceIds.has(sourceId);
+}
+
 /**
  * Per-tick autopilot fan-out. Replaces the v0.36+ single autopilot-cycle
  * dispatch when `shouldFullCycle` is true.
@@ -183,6 +223,7 @@ export async function dispatchPerSource(
       {
         queue: 'default',
         idempotency_key: `autopilot-cycle:${opts.slot}`,
+        liveSingletonKey: 'autopilot-cycle:global',
         max_attempts: 2,
         timeout_ms: opts.timeoutMs,
         maxWaiting: 1,
@@ -193,14 +234,34 @@ export async function dispatchPerSource(
     } else {
       log(`[dispatch] job #${job.id} autopilot-cycle (legacy single-source)`);
     }
-    return { dispatched: [], skipped_fresh: [], skipped_cap: [], legacy_fallback: true };
+    return { dispatched: [], skipped_fresh: [], skipped_pending: [], skipped_cap: [], legacy_fallback: true };
   }
 
-  const { dispatch, skippedFresh, skippedCap } = selectSourcesForDispatch(sources, opts.fanoutMax);
+  const { dispatch, skippedFresh } = selectSourcesForDispatch(sources, Number.MAX_SAFE_INTEGER);
+  const pendingCycles = await listPendingAutopilotCycles(engine);
 
   const dispatched: string[] = [];
+  const skippedPending: string[] = [];
+  const skippedCap: typeof dispatch = [];
   for (const src of dispatch) {
     try {
+      if (pendingCycles.global || pendingCycles.sourceIds.has(src.id)) {
+        skippedPending.push(src.id);
+        if (opts.jsonMode) {
+          emit(JSON.stringify({
+            event: 'fanout_source_pending',
+            source_id: src.id,
+            reason: 'live_autopilot_cycle',
+          }));
+        } else {
+          log(`[dispatch] skip source=${src.id}: prior autopilot-cycle still live`);
+        }
+        continue;
+      }
+      if (dispatched.length >= opts.fanoutMax) {
+        skippedCap.push(src);
+        continue;
+      }
       const remoteUrl = typeof src.config?.remote_url === 'string' ? src.config.remote_url : null;
       const job = await queue.add(
         'autopilot-cycle',
@@ -214,6 +275,7 @@ export async function dispatchPerSource(
           // Per-source idempotency key — two ticks for the same source
           // within the same slot coalesce; different sources never collide.
           idempotency_key: `autopilot-cycle:${src.id}:${opts.slot}`,
+          liveSingletonKey: `autopilot-cycle:${src.id}`,
           max_attempts: 2,
           timeout_ms: opts.timeoutMs,
           // DELIBERATELY no maxWaiting: 1 here. maxWaiting is per
@@ -264,6 +326,7 @@ export async function dispatchPerSource(
   return {
     dispatched,
     skipped_fresh: skippedFresh.map(s => s.id),
+    skipped_pending: skippedPending,
     skipped_cap: skippedCap.map(s => s.id),
     legacy_fallback: false,
   };

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -17,7 +17,7 @@
  *   gbrain autopilot --status [--json]
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, utimesSync, unlinkSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync, utimesSync, unlinkSync, statSync, renameSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
 import type { BrainEngine } from '../core/engine.ts';
@@ -37,6 +37,62 @@ import { logSelfUpgrade } from '../core/audit/self-upgrade-audit.ts';
 import { detectInstallMethod } from './upgrade.ts';
 import { evaluateQuietHours } from '../core/minions/quiet-hours.ts';
 import { inspectLock } from '../core/db-lock.ts';
+
+const AUTOPILOT_LOCK_STALE_MINUTES = 10;
+
+export type AutopilotLockDecisionReason = 'fresh_live' | 'fresh_invalid' | 'invalid_pid' | 'pid_dead' | 'stale_age';
+
+export interface AutopilotLockAcquireResult {
+  acquired: boolean;
+  reason: AutopilotLockDecisionReason | null;
+  pid: number | null;
+}
+
+export function parseAutopilotLockPid(raw: string): number | null {
+  const value = raw.trim();
+  if (!/^\d+$/.test(value)) return null;
+  const pid = Number.parseInt(value, 10);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null;
+}
+
+export function isAutopilotLockPidLive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    const code = e && typeof e === 'object' && 'code' in e ? String((e as { code?: unknown }).code) : '';
+    return code === 'EPERM';
+  }
+}
+
+export function shouldTakeOverAutopilotLock(
+  raw: string,
+  mtimeMs: number,
+  nowMs = Date.now(),
+  isPidLive = isAutopilotLockPidLive,
+): { takeOver: boolean; reason: AutopilotLockDecisionReason; pid: number | null } {
+  const ageMinutes = (nowMs - mtimeMs) / 60000;
+  const pid = parseAutopilotLockPid(raw);
+  if (pid === null) {
+    return ageMinutes >= AUTOPILOT_LOCK_STALE_MINUTES
+      ? { takeOver: true, reason: 'invalid_pid', pid }
+      : { takeOver: false, reason: 'fresh_invalid', pid };
+  }
+  const pidLive = isPidLive(pid);
+  if (pidLive && ageMinutes < AUTOPILOT_LOCK_STALE_MINUTES) {
+    return { takeOver: false, reason: 'fresh_live', pid };
+  }
+  if (ageMinutes >= AUTOPILOT_LOCK_STALE_MINUTES) return { takeOver: true, reason: 'stale_age', pid };
+  return { takeOver: true, reason: 'pid_dead', pid };
+}
+
+function fileErrorCode(e: unknown): string {
+  return e && typeof e === 'object' && 'code' in e ? String((e as { code?: unknown }).code) : '';
+}
+
+function isMissingFileError(e: unknown): boolean {
+  return fileErrorCode(e) === 'ENOENT';
+}
 
 /**
  * v0.37.7.0 #1162 — classify autopilot reconnect-loop errors.
@@ -89,6 +145,116 @@ function logError(phase: string, e: unknown) {
     mkdirSync(logDir, { recursive: true });
     appendFileSync(join(logDir, 'autopilot.log'), line + '\n');
   } catch { /* best-effort */ }
+}
+
+export function refreshAutopilotLockIfOwned(lockPath: string, pid = process.pid): boolean {
+  try {
+    if (parseAutopilotLockPid(readFileSync(lockPath, 'utf8')) !== pid) return false;
+    utimesSync(lockPath, new Date(), new Date());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function removeAutopilotLockIfOwned(lockPath: string, pid = process.pid) {
+  try {
+    if (parseAutopilotLockPid(readFileSync(lockPath, 'utf8')) === pid) {
+      unlinkSync(lockPath);
+    }
+  } catch {}
+}
+
+function readExistingAutopilotLock(lockPath: string): { raw: string; mtimeMs: number } | null {
+  try {
+    const stat = statSync(lockPath);
+    try {
+      return { raw: readFileSync(lockPath, 'utf8'), mtimeMs: stat.mtimeMs };
+    } catch (e) {
+      if (!isMissingFileError(e)) throw e;
+      return null;
+    }
+  } catch (e) {
+    if (!isMissingFileError(e)) throw e;
+    return null;
+  }
+}
+
+function tryAcquireTakeoverLock(
+  takeoverPath: string,
+  pid: number,
+  nowMs: number,
+  isPidLive: (pid: number) => boolean,
+): boolean {
+  try {
+    writeFileSync(takeoverPath, String(pid), { flag: 'wx' });
+    return true;
+  } catch (e) {
+    if (fileErrorCode(e) !== 'EEXIST') throw e;
+  }
+
+  const existing = readExistingAutopilotLock(takeoverPath);
+  if (!existing) return tryAcquireTakeoverLock(takeoverPath, pid, nowMs, isPidLive);
+  const decision = shouldTakeOverAutopilotLock(existing.raw, existing.mtimeMs, nowMs, isPidLive);
+  if (!decision.takeOver) return false;
+  try { unlinkSync(takeoverPath); } catch (e) {
+    if (!isMissingFileError(e)) throw e;
+  }
+  try {
+    writeFileSync(takeoverPath, String(pid), { flag: 'wx' });
+    return true;
+  } catch (e) {
+    if (fileErrorCode(e) === 'EEXIST') return false;
+    throw e;
+  }
+}
+
+export function acquireAutopilotLock(
+  lockPath: string,
+  homePath = gbrainHomePath(),
+  pid = process.pid,
+  nowMs = Date.now(),
+  isPidLive = isAutopilotLockPidLive,
+  attempts = 0,
+): AutopilotLockAcquireResult {
+  mkdirSync(homePath, { recursive: true });
+  const existing = readExistingAutopilotLock(lockPath);
+
+  if (existing) {
+    const decision = shouldTakeOverAutopilotLock(existing.raw, existing.mtimeMs, nowMs, isPidLive);
+    if (!decision.takeOver) {
+      return { acquired: false, reason: decision.reason, pid: decision.pid };
+    }
+    const takeoverPath = `${lockPath}.takeover`;
+    if (!tryAcquireTakeoverLock(takeoverPath, pid, nowMs, isPidLive)) {
+      return { acquired: false, reason: decision.reason, pid: decision.pid };
+    }
+    try {
+      const current = readExistingAutopilotLock(lockPath);
+      if (current) {
+        const currentDecision = shouldTakeOverAutopilotLock(current.raw, current.mtimeMs, nowMs, isPidLive);
+        if (!currentDecision.takeOver) {
+          return { acquired: false, reason: currentDecision.reason, pid: currentDecision.pid };
+        }
+      }
+      const nextLockPath = `${lockPath}.${pid}.tmp`;
+      writeFileSync(nextLockPath, String(pid));
+      renameSync(nextLockPath, lockPath);
+      return { acquired: true, reason: decision.reason, pid: decision.pid };
+    } finally {
+      removeAutopilotLockIfOwned(takeoverPath, pid);
+    }
+  }
+
+  try {
+    writeFileSync(lockPath, String(pid), { flag: 'wx' });
+    return { acquired: true, reason: null, pid: null };
+  } catch (e) {
+    if (fileErrorCode(e) === 'EEXIST' && attempts < 1) {
+      return acquireAutopilotLock(lockPath, homePath, pid, nowMs, isPidLive, attempts + 1);
+    }
+    throw e;
+  }
 }
 
 /**
@@ -349,18 +515,18 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
   // forever.
   const lockPath = gbrainHomePath('autopilot.lock');
   try {
-    mkdirSync(gbrainHomePath(), { recursive: true });
-    if (existsSync(lockPath)) {
-      const stat = require('fs').statSync(lockPath);
-      const ageMinutes = (Date.now() - stat.mtimeMs) / 60000;
-      if (ageMinutes < 10) {
-        console.error('Another autopilot instance is running (lock file is fresh). Exiting.');
-        process.exit(0);
-      }
-      console.log('Stale lock file found (>10 min). Taking over.');
+    const lock = acquireAutopilotLock(lockPath);
+    if (!lock.acquired) {
+      console.error('Another autopilot instance is running (lock file is fresh). Exiting.');
+      process.exit(0);
     }
-    writeFileSync(lockPath, String(process.pid));
-  } catch { /* best-effort */ }
+    if (lock.reason) {
+      console.log(`Stale lock file found (${lock.reason}). Taking over.`);
+    }
+  } catch (e) {
+    console.error(`[autopilot] FATAL: failed to acquire lock: ${e instanceof Error ? e.message : String(e)}`);
+    process.exit(1);
+  }
 
   console.log(`Autopilot starting. Repo: ${repoPath}, interval: ${baseInterval}s`);
 
@@ -450,6 +616,17 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
     console.log('[autopilot] --no-worker set: dispatch loop only (worker managed externally)');
   }
 
+  const lockHeartbeat = setInterval(() => { refreshAutopilotLockIfOwned(lockPath); }, 60_000);
+
+  const drainChildSupervisor = async () => {
+    if (!childSupervisor) return;
+    childSupervisor.killChild('SIGTERM');
+    await childSupervisor.awaitChildExit(35_000);
+    if (childSupervisor.childAlive) {
+      childSupervisor.killChild('SIGKILL');
+    }
+  };
+
   // Async shutdown with 35s drain window for the worker child. The worker
   // has its own SIGTERM handler (minions/worker.ts:79-85) that drains
   // in-flight jobs for up to 30s before exit. We give it 35s here to
@@ -461,14 +638,9 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
     if (stopping) return;
     stopping = true;
     console.log(`Autopilot stopping (${sig}).`);
-    if (childSupervisor) {
-      childSupervisor.killChild('SIGTERM');
-      await childSupervisor.awaitChildExit(35_000);
-      if (childSupervisor.childAlive) {
-        childSupervisor.killChild('SIGKILL');
-      }
-    }
-    try { unlinkSync(lockPath); } catch { /* already gone */ }
+    clearInterval(lockHeartbeat);
+    await drainChildSupervisor();
+    removeAutopilotLockIfOwned(lockPath);
     process.exit(0);
   };
   process.on('SIGTERM', () => { void shutdown('SIGTERM'); });
@@ -507,7 +679,11 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
 
     // Refresh the lock mtime so another cron-fired autopilot doesn't
     // declare the instance stale after 10 minutes (Codex C).
-    try { utimesSync(lockPath, new Date(), new Date()); } catch { /* best-effort */ }
+    if (!refreshAutopilotLockIfOwned(lockPath)) {
+      console.error('[autopilot] Lost autopilot lock ownership. Stopping.');
+      stopping = true;
+      break;
+    }
 
     // DB health check (reconnect if needed).
     //
@@ -882,6 +1058,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
               event: 'fanout_summary',
               dispatched: result.dispatched,
               skipped_fresh: result.skipped_fresh,
+              skipped_pending: result.skipped_pending,
               skipped_cap: result.skipped_cap,
               legacy_fallback: result.legacy_fallback,
               fanout_max: fanoutMax,
@@ -890,7 +1067,8 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
           } else if (!result.legacy_fallback) {
             console.log(
               `[dispatch] fanout: ${result.dispatched.length} dispatched, ` +
-              `${result.skipped_fresh.length} fresh, ${result.skipped_cap.length} capped ` +
+              `${result.skipped_fresh.length} fresh, ${result.skipped_pending.length} pending, ` +
+              `${result.skipped_cap.length} capped ` +
               `(score=${score}, max=${fanoutMax})`,
             );
           }
@@ -1023,6 +1201,9 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
     // Wait for next cycle
     await new Promise(r => setTimeout(r, interval * 1000));
   }
+  clearInterval(lockHeartbeat);
+  await drainChildSupervisor();
+  removeAutopilotLockIfOwned(lockPath);
 }
 
 // --- Install/Uninstall ---

--- a/src/core/minions/queue.ts
+++ b/src/core/minions/queue.ts
@@ -127,6 +127,10 @@ export class MinionQueue {
     const childStatus: MinionJobStatus = opts?.delay ? 'delayed' : 'waiting';
     const delayUntil = opts?.delay ? new Date(Date.now() + opts.delay) : null;
     const maxSpawnDepth = opts?.max_spawn_depth ?? this.maxSpawnDepth;
+    const liveSingletonKey = opts?.liveSingletonKey ?? null;
+    const jobData = liveSingletonKey
+      ? { ...((data ?? {}) as Record<string, unknown>), _live_singleton_key: liveSingletonKey }
+      : (data ?? {});
 
     return this.engine.transaction(async (tx) => {
       // 1. Idempotency fast path — if a row already exists for this key, return it
@@ -196,6 +200,25 @@ export class MinionQueue {
             return coalesced;
           }
         }
+      }
+
+      if (liveSingletonKey) {
+        const singletonQueue = opts?.queue ?? 'default';
+        await tx.executeRaw(
+          `SELECT pg_advisory_xact_lock(hashtext('minion_livesingleton:' || $1))`,
+          [liveSingletonKey]
+        );
+        const existingLive = await tx.executeRaw<Record<string, unknown>>(
+          `SELECT * FROM minion_jobs
+           WHERE name = $1
+             AND queue = $2
+             AND status NOT IN ('completed', 'failed', 'dead', 'cancelled')
+             AND data->>'_live_singleton_key' = $3
+           ORDER BY created_at DESC, id DESC
+           LIMIT 1`,
+          [jobName, singletonQueue, liveSingletonKey]
+        );
+        if (existingLive.length > 0) return rowToMinionJob(existingLive[0]);
       }
 
       // 2. Parent lock + depth/cap validation
@@ -268,7 +291,7 @@ export class MinionQueue {
         opts?.queue ?? 'default',
         childStatus,
         opts?.priority ?? 0,
-        data ?? {},
+        jobData,
         opts?.max_attempts ?? 3,
         opts?.backoff_type ?? 'exponential',
         opts?.backoff_delay ?? 1000,

--- a/src/core/minions/types.ts
+++ b/src/core/minions/types.ts
@@ -130,6 +130,7 @@ export interface MinionJobInput {
   idempotency_key?: string;
   /** Submission backpressure: cap waiting jobs with this name before inserting a new row. */
   maxWaiting?: number;
+  liveSingletonKey?: string;
 
   // v12: scheduler polish
   /**

--- a/test/autopilot-fanout.test.ts
+++ b/test/autopilot-fanout.test.ts
@@ -17,6 +17,8 @@ import {
   selectSourcesForDispatch,
   resolveFanoutMax,
   dispatchPerSource,
+  hasPendingSourceCycle,
+  listPendingAutopilotCycles,
 } from '../src/commands/autopilot-fanout.ts';
 import type { SourceRow, BrainEngine } from '../src/core/engine.ts';
 
@@ -167,6 +169,7 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
         if (opts?.listThrows) throw new Error('sources table missing');
         return sources;
       },
+      executeRaw: async () => [],
     } as unknown as BrainEngine;
     const queue = {
       add: async (name: string, data: unknown, addOpts: Record<string, unknown>) => {
@@ -196,6 +199,7 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
     expect(added[0].name).toBe('autopilot-cycle');
     expect((added[0].data as Record<string, unknown>).source_id).toBeUndefined();
     expect(added[0].opts.idempotency_key).toBe('autopilot-cycle:2026-05-22T12:00:00.000Z');
+    expect(added[0].opts.liveSingletonKey).toBe('autopilot-cycle:global');
   });
 
   test('listAllSources throwing also falls back to legacy', async () => {
@@ -217,9 +221,142 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
       'autopilot-cycle:alpha:2026-05-22T12:00:00.000Z',
       'autopilot-cycle:beta:2026-05-22T12:00:00.000Z',
     ]);
+    const singletonKeys = added.map(j => j.opts.liveSingletonKey as string).sort();
+    expect(singletonKeys).toEqual([
+      'autopilot-cycle:alpha',
+      'autopilot-cycle:beta',
+    ]);
     // source_id threaded through job data
     const sourceIds = added.map(j => (j.data as Record<string, unknown>).source_id).sort();
     expect(sourceIds).toEqual(['alpha', 'beta']);
+  });
+
+  test('per-source fan-out skips a source that already has a live cycle', async () => {
+    const added: AddedJob[] = [];
+    const events: string[] = [];
+    let pendingQueries = 0;
+    const engine = {
+      kind: 'postgres' as const,
+      listAllSources: async () => [src('alpha'), src('beta')],
+      executeRaw: async () => {
+        pendingQueries += 1;
+        return [{ source_id: 'alpha' }];
+      },
+    } as unknown as BrainEngine;
+    const queue = {
+      add: async (name: string, data: unknown, opts: Record<string, unknown>) => {
+        added.push({ name, data, opts });
+        return { id: 100 + added.length };
+      },
+    } as unknown as Parameters<typeof dispatchPerSource>[1];
+
+    const result = await dispatchPerSource(engine, queue, {
+      repoPath: '/tmp/brain',
+      slot: '2026-05-22T12:00:00.000Z',
+      timeoutMs: 600_000,
+      fanoutMax: 4,
+      jsonMode: true,
+      emit: (line) => events.push(line),
+      log: () => {},
+    });
+
+    expect(result.dispatched).toEqual(['beta']);
+    expect(result.skipped_pending).toEqual(['alpha']);
+    expect(pendingQueries).toBe(1);
+    expect(added.length).toBe(1);
+    expect((added[0].data as Record<string, unknown>).source_id).toBe('beta');
+    expect(events.some(e => e.includes('fanout_source_pending') && e.includes('alpha'))).toBe(true);
+  });
+
+  test('pending sources do not consume fanout slots for other stale sources', async () => {
+    const added: AddedJob[] = [];
+    const engine = {
+      kind: 'postgres' as const,
+      listAllSources: async () => [src('alpha'), src('beta'), src('gamma')],
+      executeRaw: async () => [{ source_id: 'alpha' }],
+    } as unknown as BrainEngine;
+    const queue = {
+      add: async (name: string, data: unknown, opts: Record<string, unknown>) => {
+        added.push({ name, data, opts });
+        return { id: 100 + added.length };
+      },
+    } as unknown as Parameters<typeof dispatchPerSource>[1];
+
+    const result = await dispatchPerSource(engine, queue, {
+      repoPath: '/tmp/brain',
+      slot: '2026-05-22T12:00:00.000Z',
+      timeoutMs: 600_000,
+      fanoutMax: 1,
+      jsonMode: true,
+      emit: () => {},
+      log: () => {},
+    });
+
+    expect(result.dispatched).toEqual(['beta']);
+    expect(result.skipped_pending).toEqual(['alpha']);
+    expect(result.skipped_cap).toEqual(['gamma']);
+    expect((added[0].data as Record<string, unknown>).source_id).toBe('beta');
+  });
+
+  test('pending check does not block first-run brains before jobs schema exists', async () => {
+    const engine = {
+      executeRaw: async () => {
+        throw new Error('relation "minion_jobs" does not exist');
+      },
+    } as unknown as BrainEngine;
+
+    expect(await hasPendingSourceCycle(engine, 'alpha')).toBe(false);
+    const pending = await listPendingAutopilotCycles(engine);
+    expect(pending.global).toBe(false);
+    expect(pending.sourceIds.size).toBe(0);
+  });
+
+  test('pending check treats legacy source-less cycles as global blockers', async () => {
+    let query = '';
+    const engine = {
+      executeRaw: async (sql: string) => {
+        query = sql;
+        return [{ source_id: null }];
+      },
+    } as unknown as BrainEngine;
+
+    expect(await hasPendingSourceCycle(engine, 'alpha')).toBe(true);
+    expect(query).toContain("data->>'source_id'");
+  });
+
+  test('legacy source-less pending cycles are checked once per tick', async () => {
+    const added: AddedJob[] = [];
+    let pendingQueries = 0;
+    const engine = {
+      kind: 'postgres' as const,
+      listAllSources: async () => [src('alpha'), src('beta'), src('gamma')],
+      executeRaw: async () => {
+        pendingQueries += 1;
+        return [{ source_id: null }];
+      },
+    } as unknown as BrainEngine;
+    const queue = {
+      add: async (name: string, data: unknown, opts: Record<string, unknown>) => {
+        added.push({ name, data, opts });
+        return { id: 100 + added.length };
+      },
+    } as unknown as Parameters<typeof dispatchPerSource>[1];
+
+    const result = await dispatchPerSource(engine, queue, {
+      repoPath: '/tmp/brain',
+      slot: '2026-05-22T12:00:00.000Z',
+      timeoutMs: 600_000,
+      fanoutMax: 2,
+      jsonMode: true,
+      emit: () => {},
+      log: () => {},
+    });
+
+    expect(result.dispatched).toEqual([]);
+    expect(result.skipped_pending).toEqual(['alpha', 'beta', 'gamma']);
+    expect(result.skipped_cap).toEqual([]);
+    expect(added).toEqual([]);
+    expect(pendingQueries).toBe(1);
   });
 
   test('pull: true only when source.config.remote_url is set', async () => {
@@ -251,6 +388,7 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
     const engine = {
       kind: 'postgres' as const,
       listAllSources: async () => sources,
+      executeRaw: async () => [],
     } as unknown as BrainEngine;
     const queue = {
       add: async (name: string, data: unknown, opts: Record<string, unknown>) => {
@@ -294,6 +432,7 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
     await dispatchPerSource(engine, queue, fanoutOpts);
     for (const job of added) {
       expect(job.opts.maxWaiting).toBeUndefined();
+      expect(String(job.opts.liveSingletonKey)).toStartWith('autopilot-cycle:');
     }
   });
 

--- a/test/autopilot-lock-path.test.ts
+++ b/test/autopilot-lock-path.test.ts
@@ -15,10 +15,11 @@
 
 import { describe, test, expect } from 'bun:test';
 import { withEnv } from './helpers/with-env.ts';
-import { mkdtempSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { gbrainPath } from '../src/core/config.ts';
+import { acquireAutopilotLock, parseAutopilotLockPid, refreshAutopilotLockIfOwned, removeAutopilotLockIfOwned, shouldTakeOverAutopilotLock } from '../src/commands/autopilot.ts';
 
 describe('autopilot lock path scoped to GBRAIN_HOME (#1226)', () => {
   test('one GBRAIN_HOME produces one canonical lock path', async () => {
@@ -63,5 +64,116 @@ describe('autopilot lock path scoped to GBRAIN_HOME (#1226)', () => {
       expect(lockPath.endsWith('autopilot.lock')).toBe(true);
       expect(lockPath.length).toBeGreaterThan('autopilot.lock'.length);
     });
+  });
+
+  test('lock takeover allows fresh files when the recorded PID is gone', () => {
+    const now = Date.parse('2026-06-06T12:00:00.000Z');
+    const decision = shouldTakeOverAutopilotLock('99999', now - 60_000, now, () => false);
+    expect(decision).toEqual({ takeOver: true, reason: 'pid_dead', pid: 99999 });
+  });
+
+  test('lock takeover refuses fresh files when the recorded PID is live', () => {
+    const now = Date.parse('2026-06-06T12:00:00.000Z');
+    const decision = shouldTakeOverAutopilotLock('12345', now - 60_000, now, () => true);
+    expect(decision).toEqual({ takeOver: false, reason: 'fresh_live', pid: 12345 });
+  });
+
+  test('lock takeover allows invalid or old lock files', () => {
+    const now = Date.parse('2026-06-06T12:00:00.000Z');
+    expect(parseAutopilotLockPid('not-a-pid')).toBeNull();
+    expect(shouldTakeOverAutopilotLock('not-a-pid', now - 11 * 60_000, now, () => true).reason).toBe('invalid_pid');
+    expect(shouldTakeOverAutopilotLock('12345', now - 11 * 60_000, now, () => false).reason).toBe('stale_age');
+  });
+
+  test('lock takeover refuses fresh invalid lock files', () => {
+    const now = Date.parse('2026-06-06T12:00:00.000Z');
+    const decision = shouldTakeOverAutopilotLock('', now - 60_000, now, () => false);
+    expect(decision).toEqual({ takeOver: false, reason: 'fresh_invalid', pid: null });
+    expect(parseAutopilotLockPid('123abc')).toBeNull();
+    expect(parseAutopilotLockPid('123 junk')).toBeNull();
+    expect(shouldTakeOverAutopilotLock('123abc', now - 60_000, now, () => false).reason).toBe('fresh_invalid');
+    expect(shouldTakeOverAutopilotLock('123 junk', now - 11 * 60_000, now, () => true).reason).toBe('invalid_pid');
+  });
+
+  test('lock takeover allows old lock files even when the recorded PID is still live', () => {
+    const now = Date.parse('2026-06-06T12:00:00.000Z');
+    const decision = shouldTakeOverAutopilotLock('12345', now - 11 * 60_000, now, () => true);
+    expect(decision).toEqual({ takeOver: true, reason: 'stale_age', pid: 12345 });
+  });
+
+  test('lock cleanup only removes the file still owned by the current PID', () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-autopilot-cleanup-'));
+    const lockPath = join(home, 'autopilot.lock');
+    writeFileSync(lockPath, '22222');
+
+    removeAutopilotLockIfOwned(lockPath, 11111);
+    expect(existsSync(lockPath)).toBe(true);
+
+    removeAutopilotLockIfOwned(lockPath, 22222);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  test('lock refresh only touches the file still owned by the current PID', () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-autopilot-refresh-'));
+    const lockPath = join(home, 'autopilot.lock');
+    writeFileSync(lockPath, '22222');
+
+    expect(refreshAutopilotLockIfOwned(lockPath, 11111)).toBe(false);
+    expect(readFileSync(lockPath, 'utf8')).toBe('22222');
+    expect(refreshAutopilotLockIfOwned(lockPath, 22222)).toBe(true);
+  });
+
+  test('lock acquisition creates a missing lock and refuses a fresh live owner', () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-autopilot-acquire-'));
+    const lockPath = join(home, 'autopilot.lock');
+
+    expect(acquireAutopilotLock(lockPath, home, 11111)).toEqual({ acquired: true, reason: null, pid: null });
+    expect(readFileSync(lockPath, 'utf8')).toBe('11111');
+
+    const blocked = acquireAutopilotLock(lockPath, home, 22222, Date.now(), () => true);
+    expect(blocked).toEqual({ acquired: false, reason: 'fresh_live', pid: 11111 });
+    expect(readFileSync(lockPath, 'utf8')).toBe('11111');
+  });
+
+  test('lock acquisition replaces stale owned locks with the new PID', () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-autopilot-stale-acquire-'));
+    const lockPath = join(home, 'autopilot.lock');
+    const now = Date.parse('2026-06-06T12:00:00.000Z');
+    writeFileSync(lockPath, '11111');
+    utimesSync(lockPath, (now - 11 * 60_000) / 1000, (now - 11 * 60_000) / 1000);
+
+    const result = acquireAutopilotLock(lockPath, home, 22222, now, () => false);
+    expect(result).toEqual({ acquired: true, reason: 'stale_age', pid: 11111 });
+    expect(readFileSync(lockPath, 'utf8')).toBe('22222');
+  });
+
+  test('lock acquisition refuses stale takeover when another contender holds the takeover lock', () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-autopilot-takeover-held-'));
+    const lockPath = join(home, 'autopilot.lock');
+    const now = Date.parse('2026-06-06T12:00:00.000Z');
+    writeFileSync(lockPath, '11111');
+    writeFileSync(`${lockPath}.takeover`, '33333');
+    utimesSync(lockPath, (now - 11 * 60_000) / 1000, (now - 11 * 60_000) / 1000);
+
+    const result = acquireAutopilotLock(lockPath, home, 22222, now, () => true);
+    expect(result).toEqual({ acquired: false, reason: 'stale_age', pid: 11111 });
+    expect(readFileSync(lockPath, 'utf8')).toBe('11111');
+  });
+
+  test('lock acquisition recovers an old takeover lock', () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-autopilot-old-takeover-'));
+    const lockPath = join(home, 'autopilot.lock');
+    const takeoverPath = `${lockPath}.takeover`;
+    const now = Date.parse('2026-06-06T12:00:00.000Z');
+    writeFileSync(lockPath, '11111');
+    writeFileSync(takeoverPath, '33333');
+    const old = (now - 11 * 60_000) / 1000;
+    utimesSync(lockPath, old, old);
+    utimesSync(takeoverPath, old, old);
+
+    const result = acquireAutopilotLock(lockPath, home, 22222, now, () => false);
+    expect(result).toEqual({ acquired: true, reason: 'stale_age', pid: 11111 });
+    expect(readFileSync(lockPath, 'utf8')).toBe('22222');
+    expect(existsSync(takeoverPath)).toBe(false);
   });
 });

--- a/test/e2e/autopilot-fanout-postgres.test.ts
+++ b/test/e2e/autopilot-fanout-postgres.test.ts
@@ -103,7 +103,7 @@ describeIfDB('autopilot fan-out — Postgres E2E', () => {
     expect(sources).toEqual(['alpha', 'beta', 'gamma']);
   });
 
-  test('re-dispatch within same slot dedupes via idempotency key', async () => {
+  test('re-dispatch within same slot skips pending source', async () => {
     await seedSource('alpha');
     await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
     const queue = new MinionQueue(engine);
@@ -120,8 +120,8 @@ describeIfDB('autopilot fan-out — Postgres E2E', () => {
     const r1 = await dispatchPerSource(engine, queue, opts);
     const r2 = await dispatchPerSource(engine, queue, opts);
     expect(r1.dispatched).toEqual(['alpha']);
-    expect(r2.dispatched).toEqual(['alpha']);
-    // Only ONE row in minion_jobs (idempotency-key coalesce)
+    expect(r2.dispatched).toEqual([]);
+    expect(r2.skipped_pending).toEqual(['alpha']);
     const jobs = await engine.executeRaw<{ id: number }>(
       `SELECT id FROM minion_jobs WHERE name = 'autopilot-cycle'`,
     );

--- a/test/minions-lease-full-retry.test.ts
+++ b/test/minions-lease-full-retry.test.ts
@@ -56,6 +56,23 @@ async function claimJobReal(name: string): Promise<{ id: number; lockToken: stri
 }
 
 describe('queue.releaseLeaseFullJob (Bug 2 load-bearing)', () => {
+  test('liveSingletonKey returns an existing live job and allows a new terminal successor', async () => {
+    const first = await queue.add('test-singleton', { seq: 1 }, { liveSingletonKey: 'cycle:alpha' });
+    const second = await queue.add('test-singleton', { seq: 2 }, { liveSingletonKey: 'cycle:alpha' });
+    expect(second.id).toBe(first.id);
+
+    const live = await queue.getJob(first.id);
+    expect((live!.data as Record<string, unknown>).seq).toBe(1);
+    expect((live!.data as Record<string, unknown>)._live_singleton_key).toBe('cycle:alpha');
+
+    await engine.executeRaw(
+      `UPDATE minion_jobs SET status = 'completed', finished_at = now() WHERE id = $1`,
+      [first.id],
+    );
+    const third = await queue.add('test-singleton', { seq: 3 }, { liveSingletonKey: 'cycle:alpha' });
+    expect(third.id).not.toBe(first.id);
+  });
+
   test('flips status to delayed without incrementing attempts_made', async () => {
     await queue.add('test-flip', {});
     const { id, lockToken } = await claimJobReal('test-flip');


### PR DESCRIPTION
## Summary

Hardens GBrain autopilot against the incident class from #1678: duplicate cycles, stale/fresh lock confusion, and unbounded fan-out requeue pressure that can turn into CPU and memory runaway.

This keeps GBrain's useful background work alive. The fix deduplicates and bounds work per source instead of disabling autopilot, workers, or memory compounding.

Refs #1678
Related #1849

## Changes made

- Add per-source pending-cycle detection before autopilot fan-out dispatches new `autopilot-cycle` jobs.
- Add queue-level `liveSingletonKey` support so live nonterminal jobs are coalesced even when the hourly idempotency key changes.
- Make `autopilot.lock` PID-aware and fail closed:
  - fresh live owner blocks startup;
  - fresh invalid lock blocks startup instead of truncating unknown state;
  - stale locks can be recovered under a takeover lock;
  - cleanup and heartbeat only mutate the lock if the current process still owns it.
- Preserve fan-out throughput by ensuring already-pending sources do not consume fanout slots for other stale sources.
- Add regression tests for fan-out pending guards, source-less legacy blockers, lock takeover behavior, and queue singleton behavior.
- Ignore `.autoreview-reports/` generated by the local review hook.

## Tests/checks run

- `git diff --check origin/master...HEAD` - passed
- `bun run typecheck` - passed (`tsc --noEmit`)
- `bun test test/autopilot-fanout.test.ts test/autopilot-lock-path.test.ts test/autopilot-supervisor-wiring.test.ts test/minions-lease-full-retry.test.ts` - passed (`61 pass`, `0 fail`, `170 expect() calls`)
- `bun test test/e2e/autopilot-fanout-postgres.test.ts` - skipped locally (`0 pass`, `6 skip`, no `DATABASE_URL`)
- Autoreview final pass: clean, no accepted/actionable findings (`overall: patch is correct (0.82)`)
- Quality gate final focused pass: passed. Full omission/adversarial reports were retained separately; those phases produced false positives around existing secret-warning text and diff counters, so the final gate used the non-noisy test/review path after manual triage.

## Risks or unfinished items

- Postgres E2E still needs a real `DATABASE_URL` run in CI or a trusted local database to verify the SQL path end-to-end.
- This PR addresses the autopilot/job coalescing and lock-safety incident path. It does not fully resolve broader launchd/browser/computer-use policy questions from the local incident report.
- Because #1678 is broader than this patch, this PR references it instead of auto-closing it.
