### PR TITLE
fix(schema-pack): enable extract_atoms in gbrain-base-v2

### DIFF
--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -1656,8 +1656,8 @@ export async function runCycle(
     // declaration. When the active pack does NOT declare extract_atoms
     // (e.g. user is on gbrain-base or gbrain-investor), this phase is a
     // no-op with reason='not_in_active_pack'. When the pack does declare
-    // it (gbrain-creator, gbrain-everything), dispatches to the
-    // extract-atoms.ts module (real body in T5; stub for now).
+    // it (gbrain-creator, gbrain-everything, or gbrain-base-v2 after the
+    // #1678 backlog fix), dispatches to the extract-atoms.ts module.
     //
     // borrow_from does NOT borrow phases — each pack declares phase
     // participation explicitly. The packDeclaresPhase helper walks the

--- a/src/core/schema-pack/base/gbrain-base-v2.yaml
+++ b/src/core/schema-pack/base/gbrain-base-v2.yaml
@@ -37,6 +37,16 @@ takes_kinds:
   - bet
   - hunch
 
+# v0.42.x (#1678 structural fix): gbrain-base-v2 is the canonical
+# production taxonomy for brains that already carry atom/source/media
+# primitives. Declaring extract_atoms here lets routine dream/autopilot
+# cycles drain the page backlog instead of requiring an out-of-band drain
+# forever. Keep synthesize_concepts opt-in via creator/everything packs for
+# now: it is a costlier aggregation phase and is not required to prevent the
+# atom-extraction backlog from growing.
+phases:
+  - extract_atoms
+
 migration_from:
   pack: gbrain-base
   version: "1.x"

--- a/test/schema-pack-base-v2-phases.test.ts
+++ b/test/schema-pack-base-v2-phases.test.ts
@@ -1,0 +1,27 @@
+// issue #1678 — gbrain-base-v2 must opt into the atom extraction lifecycle.
+//
+// Regression: after type unification, a brain can run gbrain-base-v2 as the
+// active pack while doctor reports pages eligible for atom extraction. Routine
+// dream/autopilot then skipped the phase because the pack's `phases:` list was
+// empty.
+
+import { describe, expect, test } from 'bun:test';
+import { loadActivePack } from '../src/core/schema-pack/load-active.ts';
+import { _resetPackCacheForTests } from '../src/core/schema-pack/registry.ts';
+
+describe('gbrain-base-v2 phase declarations', () => {
+  test('declares extract_atoms so routine cycles drain atom backlog', async () => {
+    _resetPackCacheForTests();
+    const resolved = await loadActivePack({
+      cfg: null,
+      remote: false,
+      perCall: 'gbrain-base-v2',
+    });
+
+    expect(resolved.manifest.name).toBe('gbrain-base-v2');
+    expect(resolved.manifest.phases ?? []).toContain('extract_atoms');
+    // Keep concept synthesis opt-in through creator/everything until it has
+    // its own backlog doctor signal + cost posture.
+    expect(resolved.manifest.phases ?? []).not.toContain('synthesize_concepts');
+  });
+});


### PR DESCRIPTION
## Summary
- Enable the `extract_atoms` lifecycle phase in `gbrain-base-v2`.
- Add a regression test pinning that `gbrain-base-v2` drains atom backlog during routine cycles.
- Update the cycle comment to include `gbrain-base-v2` in the pack-gated phase list.

## Why
`gbrain-base-v2` is the canonical post-unification pack for brains with atom/source/media primitives. Without an explicit `phases:` declaration, routine dream/autopilot cycles skip `extract_atoms` with `not_in_active_pack`, while doctor can still report eligible pages waiting for atom extraction.

## Test Plan
- `bun test test/schema-pack-base-v2-phases.test.ts test/doctor-extract-atoms-backlog.test.ts test/schema-pack-manifest-v041_2.test.ts`
- `tsc --noEmit`
