### PR TITLE
feat(schema): support source-local schema packs

### DIFF
--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -48,6 +48,7 @@ import {
 import type { SchemaPackManifest, PackPrimitive } from '../core/schema-pack/manifest-v1.ts';
 import { PACK_PRIMITIVES } from '../core/schema-pack/manifest-v1.ts';
 import { gbrainPath, loadConfig, configPath } from '../core/config.ts';
+import { assertValidSourceId } from '../core/source-id.ts';
 
 export async function runSchema(args: string[]): Promise<void> {
   const sub = args[0];
@@ -163,19 +164,52 @@ Resolution chain (7-tier, tier 1 trust-gated):
 `);
 }
 
-async function runActive(_args: string[]): Promise<void> {
+async function runActive(args: string[]): Promise<void> {
+  const flags = parseFlags(args);
+  const source = validateParsedSource(flags);
   const cfg = loadConfig();
-  const resolution = resolveActivePackNameOnly({ cfg, remote: false });
-  const pack = await loadActivePack({ cfg, remote: false });
-  console.log(`Active pack: ${pack.manifest.name} v${pack.manifest.version}`);
-  console.log(`Source: ${resolution.source}`);
-  console.log(`Pack identity: ${pack.identity}`);
-  console.log(`Page types: ${pack.manifest.page_types.length}`);
-  console.log(`Link verbs: ${pack.manifest.link_types.length}`);
-  console.log(`Takes kinds: ${pack.manifest.takes_kinds.join(', ')}`);
-  if (pack.manifest.description) {
-    console.log(`\n${pack.manifest.description}`);
+
+  const emit = async (opts: {
+    dbConfig?: string;
+    perSourceDb?: ReadonlyMap<string, string>;
+  } = {}) => {
+    const resolution = resolveActivePackNameOnly({
+      cfg,
+      remote: false,
+      sourceId: source,
+      perSourceDb: opts.perSourceDb,
+      dbConfig: opts.dbConfig,
+    });
+    const pack = await loadActivePack({
+      cfg,
+      remote: false,
+      sourceId: source,
+      perSourceDb: opts.perSourceDb,
+      dbConfig: opts.dbConfig,
+    });
+    console.log(`Active pack: ${pack.manifest.name} v${pack.manifest.version}`);
+    console.log(`Source: ${resolution.source}`);
+    if (source) console.log(`Source id: ${source}`);
+    console.log(`Pack identity: ${pack.identity}`);
+    console.log(`Page types: ${pack.manifest.page_types.length}`);
+    console.log(`Link verbs: ${pack.manifest.link_types.length}`);
+    console.log(`Takes kinds: ${pack.manifest.takes_kinds.join(', ')}`);
+    if (pack.manifest.description) {
+      console.log(`\n${pack.manifest.description}`);
+    }
+  };
+
+  if (source) {
+    await withConnectedEngine(async (engine) => {
+      const dbConfig = await getConfigTrimmed(engine, 'schema_pack');
+      const perSourceValue = await getConfigTrimmed(engine, `schema_pack.source.${source}`);
+      const perSourceDb = perSourceValue ? new Map([[source, perSourceValue]]) : undefined;
+      await emit({ dbConfig, perSourceDb });
+    });
+    return;
   }
+
+  await emit();
 }
 
 function runList(_args: string[]): void {
@@ -333,10 +367,13 @@ function runValidate(args: string[]): void {
   }
 }
 
-function runUse(args: string[]): void {
-  const packName = args[0];
+function runUse(args: string[]): void | Promise<void> {
+  const flags = parseFlags(args);
+  const source = validateParsedSource(flags);
+  const { positional } = flags;
+  const packName = positional[0];
   if (!packName) {
-    console.error('Usage: gbrain schema use <pack-name>');
+    console.error('Usage: gbrain schema use <pack-name> [--source <id>]');
     process.exit(2);
   }
   const path = packPathByName(packName);
@@ -351,6 +388,15 @@ function runUse(args: string[]): void {
   } catch (e) {
     console.error(`Refusing to activate ${packName}: ${(e as Error).message}`);
     process.exit(1);
+  }
+  if (source) {
+    return withConnectedEngine(async (engine) => {
+      await engine.initSchema();
+      await engine.setConfig(`schema_pack.source.${source}`, packName);
+      console.log(`✓ Active schema pack for source ${source} set to: ${packName}`);
+      console.log(`  Written to DB config key: schema_pack.source.${source}`);
+      console.log(`\nRun \`gbrain schema active --source ${source}\` to verify resolution.`);
+    });
   }
   // Write to file-plane config (~/.gbrain/config.json schema_pack field).
   // Tier 6 in the resolution chain — tiers 1-5 (per-call, env, DB) can
@@ -412,23 +458,31 @@ import {
 
 interface ParsedFlags {
   json: boolean;
+  sourceSpecified: boolean;
   source: string | undefined;
   positional: string[];
 }
 
 function parseFlags(args: string[]): ParsedFlags {
   let json = false;
+  let sourceSpecified = false;
   let source: string | undefined;
   const positional: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === '--json') { json = true; continue; }
-    if (a === '--source' || a === '--source-id') { source = args[++i]; continue; }
-    if (a.startsWith('--source=')) { source = a.slice('--source='.length); continue; }
-    if (a.startsWith('--source-id=')) { source = a.slice('--source-id='.length); continue; }
+    if (a === '--source' || a === '--source-id') { sourceSpecified = true; source = args[++i]; continue; }
+    if (a.startsWith('--source=')) { sourceSpecified = true; source = a.slice('--source='.length); continue; }
+    if (a.startsWith('--source-id=')) { sourceSpecified = true; source = a.slice('--source-id='.length); continue; }
     positional.push(a);
   }
-  return { json, source, positional };
+  return { json, sourceSpecified, source, positional };
+}
+
+function validateParsedSource(flags: Pick<ParsedFlags, 'sourceSpecified' | 'source'>): string | undefined {
+  if (!flags.sourceSpecified) return undefined;
+  assertValidSourceId(flags.source);
+  return flags.source;
 }
 
 async function withConnectedEngine<T>(fn: (engine: import('../core/engine.ts').BrainEngine) => Promise<T>): Promise<T> {
@@ -442,6 +496,7 @@ async function withConnectedEngine<T>(fn: (engine: import('../core/engine.ts').B
   const connectConfig: import('../core/types.ts').EngineConfig = {
     engine: engineKind,
     database_url: (cfg as { database_url?: string }).database_url,
+    database_path: (cfg as { database_path?: string }).database_path,
   };
   const engine = await createEngine(connectConfig);
   await engine.connect(connectConfig);
@@ -452,10 +507,24 @@ async function withConnectedEngine<T>(fn: (engine: import('../core/engine.ts').B
   }
 }
 
+async function getConfigTrimmed(
+  engine: import('../core/engine.ts').BrainEngine,
+  key: string,
+): Promise<string | undefined> {
+  try {
+    const value = await engine.getConfig(key);
+    return value?.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 // ------------- T2: schema detect ----------------------------------
 
 async function runDetectCmd(args: string[]): Promise<void> {
-  const { json, source } = parseFlags(args);
+  const flags = parseFlags(args);
+  const { json } = flags;
+  const source = validateParsedSource(flags);
   const result = await withConnectedEngine((engine) => runDetect(engine, { sourceId: source }));
   if (json) {
     console.log(JSON.stringify({ schema_version: 1, ...result }, null, 2));
@@ -478,7 +547,9 @@ async function runDetectCmd(args: string[]): Promise<void> {
 // ------------- T3: schema suggest ---------------------------------
 
 async function runSuggestCmd(args: string[]): Promise<void> {
-  const { json, source } = parseFlags(args);
+  const flags = parseFlags(args);
+  const { json } = flags;
+  const source = validateParsedSource(flags);
   const result = await withConnectedEngine((engine) => runSuggest(engine, { sourceId: source }));
   if (json) {
     console.log(JSON.stringify({ schema_version: 1, ...result }, null, 2));
@@ -498,7 +569,9 @@ async function runSuggestCmd(args: string[]): Promise<void> {
 // ------------- T4: schema review-candidates -----------------------
 
 async function runReviewCandidatesCmd(args: string[]): Promise<void> {
-  const { json, source, positional } = parseFlags(args);
+  const flags = parseFlags(args);
+  const { json, positional } = flags;
+  const source = validateParsedSource(flags);
   const applyIdx = positional.indexOf('--apply');
   const applySlug = applyIdx >= 0 ? positional[applyIdx + 1] : undefined;
   const result = await withConnectedEngine((engine) =>
@@ -775,7 +848,9 @@ async function runExplainCmd(args: string[]): Promise<void> {
 }
 
 async function runReviewOrphansCmd(args: string[]): Promise<void> {
-  const { json, source } = parseFlags(args);
+  const flags = parseFlags(args);
+  const { json } = flags;
+  const source = validateParsedSource(flags);
   const result = await withConnectedEngine((engine) =>
     runReviewOrphans(engine, { sourceId: source }),
   );
@@ -933,7 +1008,9 @@ function handleMutationError(err: unknown): never {
 }
 
 async function runStatsCmd(args: string[]): Promise<void> {
-  const { json, source } = parseFlags(args);
+  const flags = parseFlags(args);
+  const { json } = flags;
+  const source = validateParsedSource(flags);
   await withConnectedEngine(async (engine) => {
     const ctx = { engine, config: {}, logger: console, dryRun: false, remote: false, sourceId: source } as never;
     const result = await runStatsCore(ctx, source ? { sourceId: source } : {});
@@ -968,7 +1045,9 @@ async function runStatsCmd(args: string[]): Promise<void> {
 
 async function runSyncCmd(args: string[]): Promise<void> {
   const apply = args.includes('--apply');
-  const { json, source } = parseFlags(args);
+  const flags = parseFlags(args);
+  const { json } = flags;
+  const source = validateParsedSource(flags);
   await withConnectedEngine(async (engine) => {
     const ctx = { engine, config: {}, logger: console, dryRun: false, remote: false, sourceId: source } as never;
     const result = await runSyncCore(ctx, {

--- a/src/core/schema-pack/best-effort.ts
+++ b/src/core/schema-pack/best-effort.ts
@@ -48,12 +48,39 @@ export async function loadActivePackBestEffort(
   ctx: OperationContext,
 ): Promise<ResolvedPack | null> {
   try {
+    const dbConfig = await getDbConfigBestEffort(ctx, 'schema_pack');
+    const perSourceDb = await getPerSourcePackConfigBestEffort(ctx, ctx.sourceId);
     return await loadActivePack({
       cfg: loadConfig(),
       remote: ctx.remote ?? true,
       sourceId: ctx.sourceId,
+      perSourceDb,
+      dbConfig,
     });
   } catch {
     return null;
+  }
+}
+
+async function getDbConfigBestEffort(ctx: OperationContext, key: string): Promise<string | undefined> {
+  try {
+    const value = await ctx.engine.getConfig(key);
+    return value?.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function getPerSourcePackConfigBestEffort(
+  ctx: OperationContext,
+  sourceId: string | undefined,
+): Promise<ReadonlyMap<string, string> | undefined> {
+  if (!sourceId) return undefined;
+  try {
+    const value = await ctx.engine.getConfig(`schema_pack.source.${sourceId}`);
+    const pack = value?.trim();
+    return pack ? new Map([[sourceId, pack]]) : undefined;
+  } catch {
+    return undefined;
   }
 }

--- a/test/schema-cli-contract.test.ts
+++ b/test/schema-cli-contract.test.ts
@@ -54,6 +54,7 @@ describe('v0.39 T6 — schema CLI contract', () => {
     expect(SCHEMA_TS).toContain('function parseFlags(args: string[]): ParsedFlags');
     expect(SCHEMA_TS).toContain('interface ParsedFlags');
     expect(SCHEMA_TS).toContain('json: boolean');
+    expect(SCHEMA_TS).toContain('sourceSpecified: boolean');
     expect(SCHEMA_TS).toContain('source: string | undefined');
     expect(SCHEMA_TS).toContain('positional: string[]');
   });

--- a/test/schema-cli.test.ts
+++ b/test/schema-cli.test.ts
@@ -160,6 +160,54 @@ describe('gbrain schema use (Phase C, gap-fill T3)', () => {
     expect(cfg.schema_pack).toBe('gbrain-base');
   });
 
+  test('schema use --source writes per-source DB config and schema active --source resolves it', () => {
+    const init = gbrain(['init', '--pglite', '--no-embedding', '--yes'], { GBRAIN_HOME: home });
+    expect(init.code).toBe(0);
+    const packDir = join(home, '.gbrain', 'schema-packs', 'feeds-pack');
+    mkdirSync(packDir, { recursive: true });
+    writeFileSync(join(packDir, 'pack.yaml'), `api_version: gbrain-schema-pack-v1\nname: feeds-pack\nversion: 1.0.0\ndescription: feeds test pack\ngbrain_min_version: 0.38.0\nextends: null\nborrow_from: []\npage_types:\n  - name: tweet\n    primitive: media\n    path_prefixes:\n      - tweets/\n    aliases: []\n    extractable: true\n    expert_routing: false\nlink_types: []\nfrontmatter_links: []\ntakes_kinds:\n  - fact\n  - take\n  - bet\n  - hunch\nenrichable_types: []\nfiling_rules: []\n`, 'utf-8');
+
+    const use = gbrain(['schema', 'use', 'feeds-pack', '--source', 'feeds'], { GBRAIN_HOME: home });
+    expect(use.code).toBe(0);
+    expect(use.stdout).toContain('Active schema pack for source feeds set to: feeds-pack');
+
+    const active = gbrain(['schema', 'active', '--source', 'feeds'], { GBRAIN_HOME: home });
+    expect(active.code).toBe(0);
+    expect(active.stdout).toContain('Active pack: feeds-pack v1.0.0');
+    expect(active.stdout).toContain('Source: per-source-db');
+    expect(active.stdout).toContain('Source id: feeds');
+  });
+
+  test('schema use rejects missing or empty --source without changing global config', () => {
+    for (const sourceFlag of [['--source'], ['--source=']]) {
+      const testHome = mkdtempSync(join(tmpdir(), 'gbrain-schema-use-missing-source-'));
+      try {
+        const r = gbrain(['schema', 'use', 'gbrain-base', ...sourceFlag], { GBRAIN_HOME: testHome });
+        expect(r.code).toBe(1);
+        expect(r.stderr).toContain('Invalid source_id');
+        expect(existsSync(join(testHome, '.gbrain', 'config.json'))).toBe(false);
+      } finally {
+        rmSync(testHome, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test('source-aware schema verbs reject missing or empty explicit --source', () => {
+    for (const command of [
+      ['schema', 'active', '--source='],
+      ['schema', 'stats', '--source='],
+      ['schema', 'sync', '--apply', '--source='],
+      ['schema', 'detect', '--source='],
+      ['schema', 'suggest', '--source='],
+      ['schema', 'review-candidates', '--source='],
+      ['schema', 'review-orphans', '--source'],
+    ]) {
+      const r = gbrain(command, { GBRAIN_HOME: home });
+      expect(r.code).toBe(1);
+      expect(r.stderr).toContain('Invalid source_id');
+    }
+  });
+
   test('unknown pack rejected with exit 1 + paste-ready hint', () => {
     const r = gbrain(['schema', 'use', 'no-such-pack-xyz'], { GBRAIN_HOME: home });
     expect(r.code).toBe(1);

--- a/test/schema-pack-stats.test.ts
+++ b/test/schema-pack-stats.test.ts
@@ -131,6 +131,30 @@ describe('runStatsCore — single source', () => {
       expect(result.per_source[0]!.source_id).toBe('src-a');
     });
   });
+
+  it('uses the per-source schema_pack.source.<id> override for source-scoped pack stats', async () => {
+    await withEnv({ GBRAIN_HOME: tmpDir, GBRAIN_SCHEMA_PACK: undefined }, async () => {
+      seedTinyPack('global-pack', [{ name: 'person', prefix: 'people/' }]);
+      const feedsDir = join(tmpDir, 'feeds-pack');
+      mkdirSync(feedsDir, { recursive: true });
+      const feedsPackPath = join(feedsDir, 'pack.yaml');
+      writeFileSync(feedsPackPath, `api_version: gbrain-schema-pack-v1\nname: feeds-pack\nversion: 1.0.0\ndescription: ""\ngbrain_min_version: 0.38.0\nextends: null\nborrow_from: []\npage_types:\n  - name: tweet\n    primitive: media\n    path_prefixes:\n      - tweets/\n    aliases: []\n    extractable: true\n    expert_routing: false\nlink_types: []\nfrontmatter_links: []\ntakes_kinds:\n  - fact\n  - take\n  - bet\n  - hunch\nenrichable_types: []\nfiling_rules: []\n`, 'utf-8');
+      __setPackLocatorForTests((name) => {
+        if (name === 'global-pack') return join(tmpDir, 'global-pack', 'pack.yaml');
+        if (name === 'feeds-pack') return feedsPackPath;
+        return null;
+      });
+      await engine.setConfig('schema_pack', 'global-pack');
+      await engine.setConfig('schema_pack.source.feeds', 'feeds-pack');
+      await seedPage('tweets/a', { type: 'tweet', sourceId: 'feeds', sourcePath: 'tweets/a.md' });
+      await seedPage('people/alice', { type: 'person', sourceId: 'kermit', sourcePath: 'people/alice.md' });
+
+      const result = await runStatsCore({ ...ctxOf(), sourceId: 'feeds' } as never, { sourceId: 'feeds' });
+
+      expect(result.pack_identity).toStartWith('feeds-pack@1.0.0+');
+      expect(result.dead_prefixes).toEqual([]);
+    });
+  });
 });
 
 describe('runStatsCore — federated', () => {


### PR DESCRIPTION
## Summary
- add DB-backed per-source schema pack activation via `gbrain schema use <pack> --source <id>`
- make `schema active --source <id>` and source-scoped stats resolve `schema_pack.source.<id>`
- preserve PGLite `database_path` in schema CLI DB connections
- reject missing/empty explicit `--source` on source-aware schema verbs to avoid unscoped/global fallthrough, including write-side `schema sync --apply`

## Test Plan
- `bun test test/schema-pack-sync.test.ts test/schema-pack-stats.test.ts test/schema-pack-load-active.serial.test.ts test/schema-cli.test.ts test/schema-cli-contract.test.ts`
- `bun run typecheck`
- `pytest -q tests/gbrain_routing` for the Kermit-private policy harness (not part of this PR)

## Notes
- This adds product-level support for connector/source-local schema ownership, so raw evidence sources can own types/prefixes without keeping every connector route in the global pack.
- Live Kermit schema-pack mutation should wait until the running/global `gbrain` binary includes this change and `gbrain schema active --source <source>` is verified against the live brain.
