### PR TITLE
Route takes bootstrap through configured models

### DIFF
--- a/src/commands/takes.ts
+++ b/src/commands/takes.ts
@@ -580,7 +580,7 @@ Common flags:
 
 /**
  * v0.41.18.0 (A12, A24, T9) — `gbrain takes extract --from-pages` runs
- * Haiku over concept/atom/lore/briefing/writing/originals pages and
+ * the configured facts extraction model over concept/atom/lore/briefing/writing/originals pages and
  * lifts gradeable claims into the takes fence.
  *
  * Two-gate consent: requires `takes.bootstrap_enabled=true` in config
@@ -616,7 +616,7 @@ async function cmdExtract(engine: BrainEngine, rest: string[]): Promise<void> {
   }
   if (!dryRun && !skipConfirm) {
     process.stderr.write(
-      `[takes extract] sends concept/atom/lore/briefing/writing/originals page content to Haiku.\n` +
+      `[takes extract] sends concept/atom/lore/briefing/writing/originals page content to the configured facts extraction model.\n` +
       `Pass --yes to proceed (or --dry-run to preview).\n`,
     );
     process.exit(1);

--- a/src/core/extract-takes-from-pages.ts
+++ b/src/core/extract-takes-from-pages.ts
@@ -23,6 +23,11 @@ export const ALLOWED_PAGE_TYPES = [
   'concept', 'atom', 'lore', 'briefing', 'writing', 'originals',
 ] as const;
 
+export const DEFAULT_EXCLUDED_SLUG_PATTERNS = [
+  'agent-skillpacks/%',
+  'resolver',
+] as const;
+
 const CLASSIFIER_SYSTEM = `You extract gradeable CLAIMS from longform writing.
 
 Output strict JSON: an array of objects with shape:
@@ -140,10 +145,11 @@ export async function extractTakesFromPages(
       WHERE type IN (${typesList})
         AND deleted_at IS NULL
         AND length(COALESCE(compiled_truth, '')) > 200
+        AND NOT (slug LIKE ANY($${params.length + 1}::text[]))
         ${sourceFilter}
       ORDER BY updated_at DESC
       LIMIT ${maxPages}`,
-    params,
+    [...params, DEFAULT_EXCLUDED_SLUG_PATTERNS],
   );
 
   let pagesScanned = 0;

--- a/src/core/extract-takes-from-pages.ts
+++ b/src/core/extract-takes-from-pages.ts
@@ -16,6 +16,8 @@
 import type { BrainEngine } from './engine.ts';
 import type { TakeBatchInput, TakeKind } from './engine.ts';
 import { chat, isAvailable } from './ai/gateway.ts';
+import { resolveModel } from './model-config.ts';
+import { normalizeModelId } from './model-id.ts';
 
 export const ALLOWED_PAGE_TYPES = [
   'concept', 'atom', 'lore', 'briefing', 'writing', 'originals',
@@ -48,7 +50,7 @@ export interface ExtractTakesFromPagesOpts {
   maxPages?: number;
   /** Owner identifier for the inserted takes. Default 'system'. */
   holder?: string;
-  /** Model override; defaults to facts.extraction_model. */
+  /** Model override; defaults to facts.extraction_model, then utility-tier config. */
   model?: string;
   /** Progress hook called per page. */
   onProgress?: (done: number, total: number, claims: number) => void;
@@ -73,7 +75,7 @@ interface PageRow {
 }
 
 /**
- * Pure helper: parse Haiku JSON output into typed claims. Returns []
+ * Pure helper: parse classifier JSON output into typed claims. Returns []
  * on any parse failure (caller treats as "no claims extracted").
  */
 export function parseClaimsJson(raw: string): Array<{ claim: string; kind: TakeKind; weight: number }> {
@@ -173,8 +175,13 @@ export async function extractTakesFromPages(
 
     let response: { text: string };
     try {
+      const configuredModel = opts.model ?? normalizeModelId(await resolveModel(engine, {
+        configKey: 'facts.extraction_model',
+        tier: 'utility',
+        fallback: 'anthropic:claude-haiku-4-5-20251001',
+      }));
       response = await chat({
-        model: opts.model ?? 'anthropic:claude-haiku-4-5',
+        model: configuredModel,
         system: CLASSIFIER_SYSTEM,
         messages: [
           {

--- a/src/core/model-pricing.ts
+++ b/src/core/model-pricing.ts
@@ -70,6 +70,16 @@ export const CANONICAL_PRICING: Record<string, ModelPricing> = {
   'openai:gpt-5':                         { input:  5.00, output: 20.00 },
   'openai:gpt-5.5':                       { input:  4.00, output: 16.00 },
 
+  // Local ChatGPT/Codex OAuth proxy routed through the OpenRouter-compatible recipe.
+  // These are quota-backed (ChatGPT plan), not metered API-billing models; keep
+  // nominal zero prices so GBrain budget-gated phases do not fail closed on
+  // `no_pricing` while still recording usage audit events.
+  'openrouter:gpt-5.5':                   { input:  0.00, output:  0.00 },
+  'openrouter:gpt-5.4':                   { input:  0.00, output:  0.00 },
+  'openrouter:gpt-5.4-mini':              { input:  0.00, output:  0.00 },
+  'openrouter:gpt-5.3-codex-spark':       { input:  0.00, output:  0.00 },
+  'openrouter:codex-auto-review':         { input:  0.00, output:  0.00 },
+
   // ── Google ─────────────────────────────────────────────────────────────
   'google:gemini-1.5-pro':                { input:  1.25, output:  5.00 },
   // Gemini 2.0 Flash: $0.10 in / $0.40 out (verified 2026-06-03). Reconciled

--- a/test/extract-takes-model-routing.test.ts
+++ b/test/extract-takes-model-routing.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { extractTakesFromPages } from '../src/core/extract-takes-from-pages.ts';
+import {
+  configureGateway,
+  resetGateway,
+  __setChatTransportForTests,
+} from '../src/core/ai/gateway.ts';
+
+describe('extractTakesFromPages model routing', () => {
+  beforeEach(() => {
+    resetGateway();
+    __setChatTransportForTests(null);
+    configureGateway({
+      chat_model: 'openrouter:gpt-5.4',
+      env: { OPENROUTER_API_KEY: 'sk-or-test' },
+    });
+  });
+
+  afterEach(() => {
+    __setChatTransportForTests(null);
+    resetGateway();
+  });
+
+  test('uses facts.extraction_model instead of hardcoded Anthropic Haiku', async () => {
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    try {
+      await engine.initSchema();
+      await engine.setConfig('facts.extraction_model', 'openrouter:gpt-5.4-mini');
+      await engine.db.query(
+        `INSERT INTO pages (source_id, slug, type, title, compiled_truth, frontmatter, content_hash, updated_at)
+         VALUES ('default', 'concepts/model-routing', 'concept', 'Model Routing', $1, '{}'::jsonb, 'hash-model-routing', now())`,
+        ['This page contains a gradeable claim: configured model routing should be honored during takes extraction. '.repeat(6)],
+      );
+
+      const seenModels: string[] = [];
+      __setChatTransportForTests(async (opts) => {
+        seenModels.push(opts.model ?? '<unset>');
+        return {
+          text: JSON.stringify([{ claim: 'Configured model routing is honored during takes extraction', kind: 'fact', weight: 0.9 }]),
+          blocks: [{ type: 'text', text: '[]' }],
+          stopReason: 'end',
+          usage: { input_tokens: 1, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 },
+          model: opts.model ?? 'openrouter:gpt-5.4-mini',
+          providerId: 'openrouter',
+        };
+      });
+
+      const result = await extractTakesFromPages(engine, {
+        bootstrapEnabled: true,
+        dryRun: true,
+        maxPages: 1,
+      });
+
+      expect(result.llm_unavailable).toBe(false);
+      expect(result.pages_scanned).toBe(1);
+      expect(result.claims_extracted).toBe(1);
+      expect(seenModels).toEqual(['openrouter:gpt-5.4-mini']);
+    } finally {
+      await engine.disconnect();
+    }
+  });
+});

--- a/test/extract-takes-model-routing.test.ts
+++ b/test/extract-takes-model-routing.test.ts
@@ -30,13 +30,23 @@ describe('extractTakesFromPages model routing', () => {
       await engine.setConfig('facts.extraction_model', 'openrouter:gpt-5.4-mini');
       await engine.db.query(
         `INSERT INTO pages (source_id, slug, type, title, compiled_truth, frontmatter, content_hash, updated_at)
-         VALUES ('default', 'concepts/model-routing', 'concept', 'Model Routing', $1, '{}'::jsonb, 'hash-model-routing', now())`,
-        ['This page contains a gradeable claim: configured model routing should be honored during takes extraction. '.repeat(6)],
+         VALUES
+           ('default', 'concepts/model-routing', 'concept', 'Model Routing', $1, '{}'::jsonb, 'hash-model-routing', now()),
+           ('default', 'agent-skillpacks/example/skill', 'concept', 'Operational Skill', $2, '{}'::jsonb, 'hash-operational-skill', now() + interval '1 second')`,
+        [
+          'This page contains a gradeable claim: configured model routing should be honored during takes extraction. '.repeat(6),
+          'This operational skillpack page is intentionally newer but should be excluded from takes bootstrapping. '.repeat(6),
+        ],
       );
 
       const seenModels: string[] = [];
+      const seenSlugs: string[] = [];
       __setChatTransportForTests(async (opts) => {
         seenModels.push(opts.model ?? '<unset>');
+        const content = opts.messages[0]?.content;
+        const text = typeof content === 'string' ? content : '';
+        const slugMatch = text.match(/<page slug="([^"]+)"/);
+        if (slugMatch) seenSlugs.push(slugMatch[1]);
         return {
           text: JSON.stringify([{ claim: 'Configured model routing is honored during takes extraction', kind: 'fact', weight: 0.9 }]),
           blocks: [{ type: 'text', text: '[]' }],
@@ -57,6 +67,7 @@ describe('extractTakesFromPages model routing', () => {
       expect(result.pages_scanned).toBe(1);
       expect(result.claims_extracted).toBe(1);
       expect(seenModels).toEqual(['openrouter:gpt-5.4-mini']);
+      expect(seenSlugs).toEqual(['concepts/model-routing']);
     } finally {
       await engine.disconnect();
     }


### PR DESCRIPTION
## Summary
- route takes-from-pages extraction through `facts.extraction_model` / model config instead of hardcoded Anthropic Haiku
- add regression coverage for OpenRouter/Codex-proxy model routing
- exclude operational skillpack/resolver pages from takes bootstrapping so salience focuses on user-facing wiki content
- add local pricing entries for Codex OAuth proxy model IDs

## Tests
- `bun test test/extract-takes-model-routing.test.ts`
- `bun run typecheck`

👾 Generated with [Letta Code](https://letta.com)