### PR TITLE
fix(subagent): re-pair tool-results on gateway-loop replay (AI_MissingToolResultsError)

### DIFF
--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -777,21 +777,25 @@ async function runSubagentViaGateway(args: GatewayRunArgs): Promise<SubagentResu
     });
   }
 
-  // Convert prior Anthropic-shape messages → ChatMessage with ChatBlock content.
-  // v1 rows store Anthropic content blocks ({type:'tool_use'|'tool_result'|...});
-  // we adapt them to ChatBlock shape (type: 'tool-call' | 'tool-result' | 'text').
-  const priorChatMessages: ChatMessage[] = priorMessages.map(m => ({
-    role: m.role as 'user' | 'assistant',
-    content: adaptContentBlocksToChatBlocks(m.content_blocks),
-  }));
+  // Reconstruct the conversation, re-inserting the tool-result messages that the
+  // gateway loop persists out-of-band (in subagent_tool_executions, NOT as
+  // subagent_messages rows). A naive 1:1 map yields assistant tool-call turns with
+  // no following tool-result message; on replay the loop seeds `messages` from
+  // these (see replayState.priorMessages below) and the next generateText() throws
+  // AI SDK v6 AI_MissingToolResultsError. See reconstructReplayMessages.
+  const priorToolExecs = await loadPriorTools(engine, ctx.id);
+  const priorChatMessages: ChatMessage[] = reconstructReplayMessages(priorMessages, priorToolExecs);
 
   // Initial seed message if no prior state.
-  const initialMessages: ChatMessage[] = priorChatMessages.length === 0
+  const initialMessages: ChatMessage[] = priorMessages.length === 0
     ? [{ role: 'user', content: data.prompt }]
     : [];
 
-  // Persist seed user message at idx 0 if fresh start.
-  let nextMessageIdx = priorChatMessages.length;
+  // Persist seed user message at idx 0 if fresh start. Use the persisted-message
+  // count (priorMessages), NOT priorChatMessages.length — the latter now also
+  // counts the re-inserted tool-result messages, which are not their own
+  // subagent_messages rows, so the loop's messageIdx counter would otherwise skip.
+  let nextMessageIdx = priorMessages.length;
   if (nextMessageIdx === 0) {
     await persistMessage(engine, ctx.id, {
       message_idx: 0,
@@ -840,7 +844,7 @@ async function runSubagentViaGateway(args: GatewayRunArgs): Promise<SubagentResu
     replayState: {
       priorMessages: priorChatMessages,
       priorTools: priorToolsByStableKey,
-      nextTurnIdx: priorChatMessages.filter(m => m.role === 'assistant').length,
+      nextTurnIdx: priorMessages.filter(m => m.role === 'assistant').length,
       nextMessageIdx,
     },
     onAssistantTurn: async (turnIdx, messageIdx, blocks, usage, modelStr) => {
@@ -966,6 +970,73 @@ export function stripProviderPrefix(modelString: string): string {
  * Symmetric in the other direction is handled by persisting ChatBlock[] as-is
  * (the JSONB column accepts both shapes; v2 writes carry the new vocabulary).
  */
+/**
+ * Reconstruct the gateway-loop conversation for a subagent replay, re-pairing each
+ * prior assistant tool-call turn with the tool-results it produced.
+ *
+ * The gateway tool-loop persists tool executions to `subagent_tool_executions`
+ * rather than as `subagent_messages` rows, so mapping prior messages 1:1 yields
+ * assistant tool-call turns with no following tool-result message. On replay the
+ * loop seeds its `messages` array from this reconstruction; the next
+ * `generateText()` then throws AI SDK v6's `AI_MissingToolResultsError`
+ * ("Tool results are missing for tool calls …") — every assistant tool-call must
+ * be answered by a tool-result. Provider-neutral, but only reachable on the
+ * non-Anthropic gateway path (`agent.use_gateway_loop`), where the assistant
+ * commonly emits PARALLEL tool calls (a single crashed turn then drops several
+ * tool-results at once). The pre-existing crash-replay e2e stubs the chat
+ * transport, so it never drove `generateText` and never caught this.
+ *
+ * For each prior assistant turn with tool-calls, append one tool-result message
+ * (role `'user'`; `toModelMessages` promotes an all-tool-result message to role
+ * `'tool'`) pairing every call with its persisted outcome, keyed by
+ * `(message_idx, provider tool_use_id)`. A call with no completed execution
+ * (crash before the result was persisted) gets a synthesized error result so the
+ * turn still validates and the model can recover on the next turn.
+ *
+ * Pure (no I/O) so it is unit-testable without a database; the caller loads
+ * `priorMessages` + `priorToolExecs` and threads them in.
+ */
+export function reconstructReplayMessages(
+  priorMessages: Pick<PersistedMessage, 'message_idx' | 'role' | 'content_blocks'>[],
+  priorToolExecs: Pick<PersistedToolExec, 'message_idx' | 'tool_use_id' | 'tool_name' | 'status' | 'output' | 'error'>[],
+): ChatMessage[] {
+  const execByKey = new Map<string, { status: 'pending' | 'complete' | 'failed'; output: unknown; error: string | null }>();
+  for (const e of priorToolExecs) {
+    execByKey.set(`${e.message_idx}:${e.tool_use_id}`, { status: e.status, output: e.output, error: e.error });
+  }
+  const messages: ChatMessage[] = [];
+  for (const m of priorMessages) {
+    const content = adaptContentBlocksToChatBlocks(m.content_blocks);
+    messages.push({ role: m.role, content });
+    if (m.role !== 'assistant' || !Array.isArray(content)) continue;
+    const calls = content.filter(
+      (b): b is Extract<ChatBlock, { type: 'tool-call' }> => b.type === 'tool-call',
+    );
+    if (calls.length === 0) continue;
+    const results: ChatBlock[] = calls.map(c => {
+      const ex = execByKey.get(`${m.message_idx}:${c.toolCallId}`);
+      if (ex && ex.status !== 'pending') {
+        return {
+          type: 'tool-result',
+          toolCallId: c.toolCallId,
+          toolName: c.toolName,
+          output: ex.status === 'failed' ? (ex.error ?? 'tool failed') : ex.output,
+          isError: ex.status === 'failed',
+        };
+      }
+      return {
+        type: 'tool-result',
+        toolCallId: c.toolCallId,
+        toolName: c.toolName,
+        output: 'tool result unavailable on replay',
+        isError: true,
+      };
+    });
+    messages.push({ role: 'user', content: results });
+  }
+  return messages;
+}
+
 function adaptContentBlocksToChatBlocks(blocks: unknown): ChatBlock[] | string {
   if (typeof blocks === 'string') return blocks;
   if (!Array.isArray(blocks)) return [];

--- a/test/subagent-replay-toolresult-repair.test.ts
+++ b/test/subagent-replay-toolresult-repair.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'bun:test';
+import { generateText } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+import { reconstructReplayMessages } from '../src/core/minions/handlers/subagent.ts';
+import { toModelMessages, type ChatMessage } from '../src/core/ai/gateway.ts';
+
+// Regression guard for the gateway-loop subagent replay dropping tool-results.
+//
+// The gateway tool-loop persists tool executions to `subagent_tool_executions`,
+// NOT as `subagent_messages` rows. Reconstructing the conversation on replay with
+// a naive 1:1 map therefore yields assistant tool-call turns with no following
+// tool-result message. On replay the loop seeds `messages` from the
+// reconstruction and the next `generateText()` throws AI SDK v6's
+// `AI_MissingToolResultsError` — fatal for any provider routed through the
+// gateway loop that emits PARALLEL tool calls (a single crashed turn drops
+// several tool-results at once).
+//
+// The pre-existing crash-replay e2e (test/e2e/subagent-crash-replay-multi-
+// provider.test.ts) stubs the chat transport, so it short-circuits BEFORE
+// generateText and never exercised the ModelMessage conversion — which is why
+// this slipped through. The last test below drives the REAL AI SDK v6
+// generateText (no network) so the failure point is actually validated.
+
+// Anthropic/v2 content-block shapes as persisted in subagent_messages.content_blocks.
+function assistantTurn(calls: { id: string; name: string; input: unknown }[]) {
+  return calls.map((c) => ({ type: 'tool-call', toolCallId: c.id, toolName: c.name, input: c.input }));
+}
+
+const TWO_PARALLEL_CALLS = [
+  { message_idx: 0, role: 'user' as const, content_blocks: [{ type: 'text', text: 'do the thing' }] },
+  {
+    message_idx: 1,
+    role: 'assistant' as const,
+    content_blocks: assistantTurn([
+      { id: 'call_a', name: 'search', input: { q: 'x' } },
+      { id: 'call_b', name: 'fetch', input: { u: 'y' } },
+    ]),
+  },
+];
+
+const TWO_COMPLETE_EXECS = [
+  { message_idx: 1, tool_use_id: 'call_a', tool_name: 'search', status: 'complete' as const, output: { hits: 3 }, error: null },
+  { message_idx: 1, tool_use_id: 'call_b', tool_name: 'fetch', status: 'complete' as const, output: { body: 'ok' }, error: null },
+];
+
+function mockModel(): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doGenerate: async () => ({
+      content: [{ type: 'text', text: 'ok' }],
+      finishReason: 'stop',
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      warnings: [],
+    }),
+  } as any);
+}
+
+describe('reconstructReplayMessages (gateway-loop subagent replay)', () => {
+  it('re-pairs every parallel tool-call with its persisted tool-result', () => {
+    const out = reconstructReplayMessages(TWO_PARALLEL_CALLS as any, TWO_COMPLETE_EXECS as any);
+
+    // [user, assistant(2 tool-calls), user(2 tool-results)]
+    expect(out).toHaveLength(3);
+    expect(out[1].role).toBe('assistant');
+    expect(out[2].role).toBe('user');
+
+    const results = out[2].content as Array<{ type: string; toolCallId: string; output: unknown; isError?: boolean }>;
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.type === 'tool-result')).toBe(true);
+    expect(results.map((r) => r.toolCallId).sort()).toEqual(['call_a', 'call_b']);
+    const byId = Object.fromEntries(results.map((r) => [r.toolCallId, r]));
+    expect(byId['call_a'].output).toEqual({ hits: 3 });
+    expect(byId['call_a'].isError).toBe(false);
+    expect(byId['call_b'].output).toEqual({ body: 'ok' });
+  });
+
+  it('does not append a tool-result message for non-tool assistant turns', () => {
+    const textOnly = [
+      { message_idx: 0, role: 'user' as const, content_blocks: [{ type: 'text', text: 'hi' }] },
+      { message_idx: 1, role: 'assistant' as const, content_blocks: [{ type: 'text', text: 'hello' }] },
+    ];
+    const out = reconstructReplayMessages(textOnly as any, []);
+    expect(out).toHaveLength(2);
+    expect(out.every((m) => m.role !== 'user' || Array.isArray(m.content))).toBe(true);
+  });
+
+  it('synthesizes error results for failed / missing executions so the turn still validates', () => {
+    const execs = [
+      { message_idx: 1, tool_use_id: 'call_a', tool_name: 'search', status: 'failed' as const, output: null, error: 'boom' },
+      // call_b has NO persisted execution (crash before result was written)
+    ];
+    const out = reconstructReplayMessages(TWO_PARALLEL_CALLS as any, execs as any);
+    const results = out[2].content as Array<{ toolCallId: string; output: unknown; isError?: boolean }>;
+    const byId = Object.fromEntries(results.map((r) => [r.toolCallId, r]));
+    expect(byId['call_a'].isError).toBe(true);
+    expect(byId['call_a'].output).toBe('boom');
+    expect(byId['call_b'].isError).toBe(true);
+    expect(byId['call_b'].output).toBe('tool result unavailable on replay');
+  });
+
+  it('the reconstructed history passes real AI SDK v6 generateText; the naive 1:1 map throws', async () => {
+    const model = mockModel();
+
+    // WITH the fix: re-paired history converts + validates against v6.
+    const repaired = reconstructReplayMessages(TWO_PARALLEL_CALLS as any, TWO_COMPLETE_EXECS as any);
+    const ok = await generateText({ model: model as any, messages: toModelMessages(repaired) as any });
+    expect(ok.text).toBe('ok');
+
+    // WITHOUT the fix: naive 1:1 map leaves the assistant's parallel tool-calls
+    // unanswered → AI SDK v6 rejects (AI_MissingToolResultsError).
+    const naive: ChatMessage[] = TWO_PARALLEL_CALLS.map((m) => ({
+      role: m.role,
+      content: m.content_blocks as any,
+    }));
+    await expect(
+      generateText({ model: mockModel() as any, messages: toModelMessages(naive) as any }),
+    ).rejects.toThrow(/tool result/i);
+  });
+});


### PR DESCRIPTION
## Problem

Every subagent routed through the gateway tool-loop (`agent.use_gateway_loop`, i.e. any non-Anthropic provider) that emits **parallel tool calls** permanently fails on retry with:

```
[chat(<provider>)] Tool results are missing for tool calls call_…, call_…, call_…
```

i.e. AI SDK v6's `AI_MissingToolResultsError`. In production on GLM (`glm-coding`) this killed cron/agent jobs the day after the gateway loop took over — company-pulse and every `dream`-synthesize subagent that fanned out parallel tool calls died, and the retries compounded the failure.

## Root cause

The gateway loop persists tool executions to `subagent_tool_executions`, **not** as `subagent_messages` rows. On replay, `runSubagentViaGateway` rebuilt the prior conversation with a naive 1:1 map:

```ts
const priorChatMessages = priorMessages.map(m => ({ role: m.role, content: adaptContentBlocksToChatBlocks(m.content_blocks) }));
```

That yields assistant tool-call turns with **no following tool-result message**. The loop seeds `messages` from `replayState.priorMessages`, so the next `generateText()` sees unanswered tool-calls and v6 rejects the prompt. A single crashed turn with N parallel calls drops all N tool-results at once.

## Fix

- Extract a pure, unit-testable `reconstructReplayMessages(priorMessages, priorToolExecs)` that re-inserts a tool-result message after each prior assistant tool-call turn, pairing every call with its persisted outcome (keyed by `message_idx` + provider `tool_use_id`). A call with no completed execution (crash before the result was persisted) gets a synthesized error result so the turn still validates and the model recovers next turn.
- Derive `nextMessageIdx`, `nextTurnIdx`, and the `initialMessages` seed-condition from the **persisted-message count** (`priorMessages`), not `priorChatMessages.length` — the latter now also counts the re-inserted tool-result messages (which are not their own `subagent_messages` rows), so the loop's `messageIdx` counter would otherwise skip.

Provider-neutral; only reachable on the gateway path.

## Why the existing tests didn't catch it

`test/e2e/subagent-crash-replay-multi-provider.test.ts` stubs the chat transport (`__setChatTransportForTests`), so it short-circuits **before** `generateText` runs and never exercised the ModelMessage conversion — the same blind spot called out in `test/ai/gateway-tools-schema.test.ts`.

## Testing

New `test/subagent-replay-toolresult-repair.test.ts` (4 tests, no network):
- re-pairs every parallel tool-call with its persisted tool-result;
- no spurious tool-result message for non-tool turns;
- synthesizes error results for failed / missing executions;
- **drives the real AI SDK v6 `generateText`** (via `MockLanguageModelV3`) and asserts the re-paired history validates while the naive 1:1 map throws.

Regression: `subagent-crash-replay-multi-provider` (13), `gateway-tools-schema` (3), `gateway-tool-loop` (7) all still pass.

> Context: this is the upstream reconciliation of a long-running local fork patch (the `f9c22f7` "C-3" the fork notes said should land upstream alongside #1708/#868).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
