### PR TITLE
fix(autopilot): route DB reconnect through engine.reconnect(); stop crash-loop on pooler drop (#1720)

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -54,7 +54,26 @@ import { inspectLock } from '../core/db-lock.ts';
  */
 export function classifyReconnectError(err: unknown): 'recoverable' | 'unrecoverable' {
   const msg = (err instanceof Error ? err.message : String(err ?? '')).toLowerCase();
-  if (msg.includes('database_url') && (msg.includes('undefined') || msg.includes('missing') || msg.includes('empty') || msg.includes('not set'))) {
+  // #1720: a raw JS runtime TypeError (e.g. "undefined is not an object
+  // (evaluating 'config.database_url')", "x is not a function", "cannot read
+  // properties of undefined") is a PROGRAMMING error in the reconnect path, not
+  // a genuine user misconfiguration. Treat it as recoverable: a transient blip
+  // that tripped a code bug must not crash-loop the daemon forever, and the
+  // AUTOPILOT_MAX_RECONNECT_FAILS cap still bounds retries. This check runs
+  // FIRST because such a message can also contain "database_url".
+  if (
+    msg.includes('is not an object') ||
+    msg.includes('is not a function') ||
+    msg.includes('is not a constructor') ||
+    msg.includes('cannot read prop')
+  ) {
+    return 'recoverable';
+  }
+  // Genuine missing/empty database_url (a real config error surfaced as a
+  // GBrainError from db.ts / postgres-engine.ts) is unrecoverable — it won't
+  // fix itself on retry. "undefined" is deliberately NOT a trigger: its only
+  // producer was the JS TypeError handled above (#1720).
+  if (msg.includes('database_url') && (msg.includes('missing') || msg.includes('empty') || msg.includes('not set'))) {
     return 'unrecoverable';
   }
   if (msg.includes('invalid url') || msg.includes('malformed') || msg.includes('parse url')) {
@@ -72,6 +91,38 @@ export function classifyReconnectError(err: unknown): 'recoverable' | 'unrecover
     return 'unrecoverable';
   }
   return 'recoverable';
+}
+
+/**
+ * Reconnect the engine after a failed DB-health probe, then re-probe to prove
+ * the connection is actually restored before the caller clears its failure
+ * counter. #1720.
+ *
+ * PostgresEngine exposes reconnect() — it reuses its saved config, tears down
+ * and rebuilds the instance pool, and logs pool-recovery audits. The
+ * BrainEngine interface and PGLiteEngine do NOT have reconnect(); for those
+ * there is no in-process reconnect path, so the original probe error is
+ * rethrown into the caller's failure handler.
+ *
+ * This replaces a hand-rolled `disconnect()` + argless `connect()` that crashed
+ * with "undefined is not an object (evaluating 'config.database_url')" —
+ * connect() dereferences its config argument — and whose TypeError was then
+ * misclassified as a fatal config error, crash-looping the daemon.
+ *
+ * reconnect() can silently no-op (a concurrent reconnect already in flight, or
+ * no saved config) and resolve WITHOUT restoring the connection; the trailing
+ * getConfig() probe ensures such a no-op surfaces as a throw so the caller does
+ * not falsely reset its failure counter.
+ */
+export async function reconnectAndProbe(engine: BrainEngine, probeErr: unknown): Promise<void> {
+  const reconnectable = engine as Partial<{ reconnect: (ctx?: { error?: unknown }) => Promise<void> }>;
+  if (typeof reconnectable.reconnect === 'function') {
+    await reconnectable.reconnect({ error: probeErr });
+  } else {
+    throw probeErr;
+  }
+  // Prove health before the caller resets its failure counter.
+  await engine.getConfig('version');
 }
 
 function parseArg(args: string[], flag: string): string | undefined {
@@ -529,8 +580,11 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
       autopilotReconnectFails = 0; // reset on success
     } catch (probeErr) {
       try {
-        await engine.disconnect();
-        await (engine as any).connect?.();
+        // #1720: route through the engine's own reconnect() (reuses saved
+        // config) instead of a hand-rolled disconnect()+argless connect() that
+        // crashed on undefined config and crash-looped the daemon. Re-probes
+        // health internally before we clear the failure counter.
+        await reconnectAndProbe(engine, probeErr);
         autopilotReconnectFails = 0;
       } catch (e) {
         logError('reconnect', e);

--- a/test/autopilot-reconnect-classifier.test.ts
+++ b/test/autopilot-reconnect-classifier.test.ts
@@ -16,9 +16,23 @@ import { describe, test, expect } from 'bun:test';
 import { classifyReconnectError, generateLaunchdPlist } from '../src/commands/autopilot.ts';
 
 describe('classifyReconnectError (#1162)', () => {
-  test('database_url undefined → unrecoverable (the #1162 fingerprint)', () => {
-    const err = new Error('config.database_url undefined');
-    expect(classifyReconnectError(err)).toBe('unrecoverable');
+  // #1720 correction: a raw JS TypeError that merely MENTIONS config.database_url
+  // is a programming error in the reconnect path (an argless connect() that
+  // dereferenced an undefined config), NOT a real missing-config. It must be
+  // RECOVERABLE — classifying it unrecoverable crash-looped the autopilot for
+  // days. Genuine missing-config errors ("database_url is missing"/"is empty",
+  // below) stay unrecoverable because they won't fix themselves on retry.
+  test('JS TypeError mentioning config.database_url → recoverable (#1720 regression)', () => {
+    expect(classifyReconnectError(new Error("undefined is not an object (evaluating 'config.database_url')"))).toBe('recoverable');
+  });
+
+  test('other JS runtime TypeErrors → recoverable (#1720)', () => {
+    expect(classifyReconnectError(new TypeError('engine.connect is not a function'))).toBe('recoverable');
+    expect(classifyReconnectError(new TypeError("Cannot read properties of undefined (reading 'database_url')"))).toBe('recoverable');
+  });
+
+  test('bare "config.database_url undefined" text → recoverable (#1720; not a real config error)', () => {
+    expect(classifyReconnectError(new Error('config.database_url undefined'))).toBe('recoverable');
   });
 
   test('database_url empty → unrecoverable', () => {
@@ -65,7 +79,7 @@ describe('classifyReconnectError (#1162)', () => {
   });
 
   test('case-insensitive match', () => {
-    expect(classifyReconnectError(new Error('DATABASE_URL UNDEFINED'))).toBe('unrecoverable');
+    expect(classifyReconnectError(new Error('DATABASE_URL IS MISSING'))).toBe('unrecoverable');
     expect(classifyReconnectError(new Error('Password Authentication FAILED'))).toBe('unrecoverable');
   });
 });

--- a/test/autopilot-reconnect-helper.test.ts
+++ b/test/autopilot-reconnect-helper.test.ts
@@ -1,0 +1,81 @@
+/**
+ * #1720 — autopilot reconnect helper.
+ *
+ * The daemon crash-looped against the Supabase pooler because its DB-health
+ * catch hand-rolled `await engine.disconnect(); await engine.connect?.();`.
+ * The argless `connect()` dereferenced an undefined config
+ * (`const url = config.database_url`), threw the TypeError
+ * "undefined is not an object (evaluating 'config.database_url')", which the
+ * reconnect classifier then read as a fatal missing-config error → process
+ * exit → launchd respawn → pooler drops again → loop. ~25k CONNECTION_CLOSED
+ * events, brain degraded for days.
+ *
+ * reconnectAndProbe() fixes the root cause:
+ *   - routes through the engine's own reconnect() (PostgresEngine reuses its
+ *     saved config + tears down/rebuilds the instance pool with audit logging),
+ *   - rethrows the original probe error for engines without reconnect()
+ *     (PGLite / inline) instead of crashing on an argless connect(),
+ *   - re-probes health AFTER reconnect so a silent no-op reconnect (e.g. a
+ *     concurrent reconnect already in flight) surfaces as a throw and the
+ *     caller does NOT falsely reset its failure counter.
+ */
+import { describe, test, expect } from 'bun:test';
+import { reconnectAndProbe } from '../src/commands/autopilot.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+function fakeEngine(overrides: Record<string, unknown>): BrainEngine {
+  return {
+    connect: async () => {},
+    disconnect: async () => {},
+    initSchema: async () => {},
+    getConfig: async () => 'ok',
+    ...overrides,
+  } as unknown as BrainEngine;
+}
+
+describe('reconnectAndProbe (#1720)', () => {
+  test('Postgres-style engine: calls reconnect({error}) then re-probes health', async () => {
+    const calls: string[] = [];
+    let reconnectArg: unknown;
+    const engine = fakeEngine({
+      reconnect: async (ctx: unknown) => { calls.push('reconnect'); reconnectArg = ctx; },
+      getConfig: async () => { calls.push('getConfig'); return 'ok'; },
+    });
+    const probeErr = new Error('write CONNECTION_CLOSED');
+    await reconnectAndProbe(engine, probeErr);
+    // reconnect first, THEN a health re-probe to prove the connection is live.
+    expect(calls).toEqual(['reconnect', 'getConfig']);
+    // The probe error is threaded into reconnect() so its audit layer can
+    // classify reap-vs-other.
+    expect(reconnectArg).toEqual({ error: probeErr });
+  });
+
+  test('never calls argless connect() (the #1720 crash path)', async () => {
+    let connectInvoked = false;
+    const engine = fakeEngine({
+      reconnect: async () => {},
+      connect: async () => { connectInvoked = true; },
+    });
+    await reconnectAndProbe(engine, new Error('blip'));
+    expect(connectInvoked).toBe(false);
+  });
+
+  test('engine without reconnect() (PGLite): rethrows the probe error, never argless-connects', async () => {
+    let connectInvoked = false;
+    const engine = fakeEngine({
+      reconnect: undefined,
+      connect: async () => { connectInvoked = true; },
+    });
+    const probeErr = new Error('pglite probe failed');
+    await expect(reconnectAndProbe(engine, probeErr)).rejects.toThrow('pglite probe failed');
+    expect(connectInvoked).toBe(false);
+  });
+
+  test('silent no-op reconnect with DB still dead: re-probe throws so caller will NOT reset its counter', async () => {
+    const engine = fakeEngine({
+      reconnect: async () => { /* no-op: a concurrent reconnect was already in flight */ },
+      getConfig: async () => { throw new Error('write CONNECTION_CLOSED'); },
+    });
+    await expect(reconnectAndProbe(engine, new Error('blip'))).rejects.toThrow('CONNECTION_CLOSED');
+  });
+});


### PR DESCRIPTION
## Problem (#1720)

The autopilot daemon crash-loops against the Supabase pooler. On a DB-health-probe failure, the catch block hand-rolls a reconnect:

```ts
await engine.disconnect();
await (engine as any).connect?.();   // <- called with NO config argument
```

`PostgresEngine.connect(config)` immediately does `const url = config.database_url`, so the argless call throws `undefined is not an object (evaluating 'config.database_url')`. `classifyReconnectError` then matches `database_url` + `undefined` and returns `unrecoverable` → the daemon logs FATAL and exits → launchd `ThrottleInterval` respawns it → the pooler drops the connection again → same crash. Observed: ~25k `CONNECTION_CLOSED` events and a brain degraded for days.

Root cause: `PostgresEngine` already exposes a correct `reconnect()` (reuses its saved config, rebuilds the instance pool, logs pool-recovery audits), but the autopilot catch **predates** it (catch from 2026-04-14; `reconnect()` added later) and never adopted it.

## Fix

- **New `reconnectAndProbe()` helper** routes through `engine.reconnect()` when present (PostgresEngine), and **rethrows the original probe error** for engines without it (the `BrainEngine` interface / `PGLiteEngine`) instead of crashing on an argless `connect()`. It then **re-probes health** (`getConfig`) before the caller clears its failure counter, so a silent no-op reconnect (e.g. a concurrent reconnect already in flight) can't falsely reset it.
- **`classifyReconnectError` hardened**: a raw JS runtime TypeError (`is not an object`, `is not a function`, `is not a constructor`, `cannot read prop`) is now classified **recoverable** — a code bug must not masquerade as fatal misconfiguration and crash-loop the daemon; `AUTOPILOT_MAX_RECONNECT_FAILS` still bounds retries. `undefined` is removed from the unrecoverable `database_url` branch (its only producer was the TypeError above); genuine `missing`/`empty` config stays fatal.

## Tests

- Classifier regression: the real TypeError + variants + bare text → recoverable; genuine missing/empty `database_url` stays unrecoverable.
- New `test/autopilot-reconnect-helper.test.ts`: reconnect→reprobe ordering, the `{ error }` arg passthrough, the never-argless-connect guarantee, the PGLite rethrow path, and the no-op-reconnect → reprobe-throws path.
- Full autopilot suite (107 tests) green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)