### PR TITLE
fix(postgres-engine): tear down half-open client when instance connect() fails (#1720 follow-up)

### DIFF
--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -192,20 +192,43 @@ export class PostgresEngine implements BrainEngine {
       if (typeof prepare === 'boolean') {
         opts.prepare = prepare;
       }
-      this._sql = postgres(url, opts);
-      await this._sql`SELECT 1`;
-      await db.setSessionDefaults(this._sql);
-      this._connectionStyle = 'instance';
+      try {
+        // Mark instance intent BEFORE the awaited probe. reconnect() branches on
+        // `_connectionStyle !== 'instance'`; if the first connect's probe throws
+        // and this were still null, the next reconnect() would silently divert a
+        // poolSize-configured engine into module-singleton recovery (#1720
+        // follow-up, Data R1).
+        this._connectionStyle = 'instance';
+        this._sql = postgres(url, opts);
+        await this._sql`SELECT 1`;
+        await db.setSessionDefaults(this._sql);
 
-      // v0.30.1: instance-owned ConnectionManager wraps the read pool we just
-      // built. Parent inheritance (T5/X1): worker engines pass their parent's
-      // manager so kill-switch state and direct pool are shared.
-      this.connectionManager = new ConnectionManager({
-        url,
-        parent: config.parentConnectionManager,
-        readPoolOwnedExternally: true, // we own _sql; manager just routes
-      });
-      this.connectionManager.setReadPool(this._sql);
+        // v0.30.1: instance-owned ConnectionManager wraps the read pool we just
+        // built. Parent inheritance (T5/X1): worker engines pass their parent's
+        // manager so kill-switch state and direct pool are shared.
+        this.connectionManager = new ConnectionManager({
+          url,
+          parent: config.parentConnectionManager,
+          readPoolOwnedExternally: true, // we own _sql; manager just routes
+        });
+        this.connectionManager.setReadPool(this._sql);
+      } catch (err) {
+        // #1720 follow-up: a failed rebuild (e.g. the SELECT 1 probe throws
+        // EMAXCONNSESSION when the session-mode pooler is at its client cap, or
+        // ECONNREFUSED mid-reconnect) must NOT leave a half-open postgres.js
+        // client retained in _sql — it would hold a pooler client slot until the
+        // next reconnect()'s disconnect(), compounding connection pressure under
+        // a tight cap. Tear down whatever THIS call created, then rethrow.
+        // _connectionStyle / _savedConfig are intentionally left intact so the
+        // next reconnect() still routes through the instance path.
+        try { await this.connectionManager?.disconnect(); } catch { /* best-effort */ }
+        this.connectionManager = null;
+        if (this._sql) {
+          try { await this._sql.end({ timeout: 5 }); } catch { /* best-effort */ }
+          this._sql = null;
+        }
+        throw err;
+      }
     } else {
       // Module-level singleton (backward compat for CLI main engine).
       // #1471: db.connect() returns whether THIS call created the singleton —

--- a/test/postgres-engine-connect-cleanup.test.ts
+++ b/test/postgres-engine-connect-cleanup.test.ts
@@ -1,0 +1,42 @@
+/**
+ * #1720 follow-up — PostgresEngine.connect() must not retain a half-open
+ * postgres.js client when the post-construction probe fails.
+ *
+ * Pre-fix, the instance path (poolSize set) assigned `this._sql = postgres(...)`
+ * and only AFTERWARD awaited `SELECT 1`. A thrown probe (e.g. EMAXCONNSESSION
+ * when the Supabase session-mode pooler is at its client cap, or ECONNREFUSED
+ * mid-rebuild) left `_sql` set as a half-open client that holds a pooler client
+ * slot until the next reconnect()'s disconnect() tears it down. Under a tight
+ * session-mode cap that transient retention compounds connection pressure —
+ * surfaced live alongside the #1720 autopilot crash-loop fix (PR #1935).
+ *
+ * The fix wraps the instance rebuild in try/catch: on failure it ends + nulls
+ * `_sql` (and any partial connectionManager) before rethrowing, so a failed
+ * connect leaves the engine holding ZERO clients. Uses a refused local port —
+ * a real, deterministic failure, no external dependency.
+ */
+import { describe, test, expect } from 'bun:test';
+import { PostgresEngine } from '../src/core/postgres-engine.ts';
+
+describe('PostgresEngine.connect() cleanup on failed probe (#1720 follow-up)', () => {
+  test('instance-path connect() whose probe fails retains no _sql client', async () => {
+    const engine = new PostgresEngine();
+    // postgres() constructs lazily; the SELECT 1 probe then throws ECONNREFUSED
+    // (port 1 is refused immediately), standing in for a failed instance rebuild.
+    await expect(
+      engine.connect({ database_url: 'postgresql://u:p@127.0.0.1:1/db', poolSize: 1 } as unknown as Parameters<PostgresEngine['connect']>[0]),
+    ).rejects.toThrow();
+
+    // The half-open client must be torn down + nulled, not retained until the
+    // next reconnect. This is the load-bearing assertion (pre-fix: _sql is the
+    // retained client object → fails).
+    expect((engine as unknown as { _sql: unknown })._sql).toBeNull();
+    // No dangling partial connection manager either.
+    expect((engine as unknown as { connectionManager: unknown }).connectionManager).toBeNull();
+    // A poolSize-configured engine whose FIRST connect failed must still be
+    // marked 'instance', so the next reconnect() routes through the instance
+    // path (reconnect() branches on `_connectionStyle !== 'instance'`). Leaving
+    // it null would silently divert into module-singleton recovery (Data R1).
+    expect((engine as unknown as { _connectionStyle: unknown })._connectionStyle).toBe('instance');
+  }, 15000);
+});


### PR DESCRIPTION
## Problem

Instance-path `PostgresEngine.connect()` (called with `poolSize`, e.g. `gbrain jobs work` / autopilot worker engines) assigns the client before it probes:

```ts
this._sql = postgres(url, opts);
await this._sql`SELECT 1`;   // <- if this throws, _sql is already set
```

If the probe throws — e.g. `EMAXCONNSESSION` when the Supabase **session-mode pooler is at its client cap**, or `ECONNREFUSED` mid-reconnect — the method propagates the error but leaves `_sql` holding a **half-open postgres.js client**. That client occupies a pooler client slot until the *next* `reconnect()`'s `disconnect()` tears it down. Under a tight session-mode client cap, that transient retention compounds connection pressure.

Surfaced in adversarial review during live verification of the #1720 autopilot crash-loop fix (#1935): the daemon, now staying alive and retrying reconnects (instead of crash-exiting and freeing everything), exercises this path repeatedly during a pooler-saturation window.

## Fix (instance path only)

- Wrap the instance rebuild in `try/catch`. On failure: best-effort `connectionManager?.disconnect()` + null it, then `_sql.end({ timeout: 5 })` + null it, before rethrowing. A failed connect now leaves the engine holding **zero** clients.
- Mark `_connectionStyle = 'instance'` **before** the awaited probe. `reconnect()` branches on `_connectionStyle !== 'instance'`; if a `poolSize`-configured engine's *first* connect failed with the marker still `null`, the next `reconnect()` would silently divert into module-singleton recovery. The `sql` getter's instance self-heal (#1678) already throws a retryable error for instance-style + null `_sql`, so this state is handled.

## Scope / known follow-up

**Instance path only.** The module-singleton path (`db.connect`, `src/core/db.ts:222-231`) has the **same** construct-then-probe shape, with a catch that nulls `sql` *without* `await s.end()`. That is a **separate, named follow-up** — this PR does **not** address it and does **not** claim the module path is safe.

## Tests

`test/postgres-engine-connect-cleanup.test.ts` drives an instance `connect()` to a refused local port; asserts `_sql` and `connectionManager` are null and `_connectionStyle === 'instance'` after the throw (all RED pre-fix). 66 engine/connection/reconnect tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)