### PR TITLE
fix(db): validate module singleton before publish — leak + connect/connect + disconnect/connect races (#1720 follow-up)

### DIFF
--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -6,6 +6,18 @@ import { verifySchema } from './schema-verify.ts';
 
 let sql: ReturnType<typeof postgres> | null = null;
 let connectedUrl: string | null = null;
+// #1720: the in-flight create's probe promise. Concurrent connect() callers
+// await THIS — not the not-yet-validated `sql` — so a latecomer never joins a
+// client whose SELECT 1 probe is still pending or about to fail. Null when no
+// create is in flight; resolves once `sql` is published (validated); rejects
+// (with the GBrainError) when the probe fails.
+let connecting: Promise<void> | null = null;
+// #1720: bumped by disconnect() (and by a new connect's teardown) to invalidate
+// an in-flight create. The creator captures this epoch before its probe and, if
+// it changed by the time the probe resolves, aborts WITHOUT publishing `sql` —
+// otherwise a disconnect() that raced the probe (saw `sql` still null, closed
+// nothing) would be silently undone when the probe later publishes a singleton.
+let connectEpoch = 0;
 
 /**
  * Default pool size for Postgres connections. Users on the Supabase transaction
@@ -161,25 +173,40 @@ export function getConnection(): ReturnType<typeof postgres> {
 
 /**
  * Connect the module-level singleton. Returns `true` iff THIS call created the
- * singleton, `false` if it joined an existing one.
+ * singleton, `false` if it joined an existing (or in-flight) one.
  *
- * #1471 ownership: the create-vs-join decision is made HERE, atomically. There
- * is no `await` between the `if (sql)` null-check below and the synchronous
- * `sql = postgres(url, opts)` assignment, so two concurrent module connects
- * cannot both observe `sql === null` and both create. Callers store the return
- * as their ownership token (`PostgresEngine._ownsModuleSingleton`); only the
- * creator may later tear the singleton down. Borrowers (probe engines created
- * while the singleton already exists) get `false` and must NOT disconnect it.
+ * #1471 + #1720 ownership/atomicity: the create-vs-join decision is made HERE,
+ * atomically across THREE states — live (`sql`), in-flight (`connecting`), and
+ * absent. The checks (`if (sql)`, `if (connecting)`) and the synchronous
+ * `connecting = (...)()` assignment run with NO `await` between them, so two
+ * concurrent module connects cannot both become the creator. The singleton
+ * `sql` is published ONLY after its `SELECT 1` probe validates the client, so a
+ * latecomer that arrives mid-probe awaits `connecting` instead of joining an
+ * unvalidated client that may be about to fail (the join-the-dead-client race).
+ * On probe failure every waiter throws and NO caller records ownership; on
+ * success exactly one caller (the creator) gets `true` and waiters get `false`.
+ * Callers store the return as their ownership token
+ * (`PostgresEngine._ownsModuleSingleton`); only the creator may tear it down.
  *
  * Back-compat: callers that ignore the return value are unaffected.
  */
 export async function connect(config: EngineConfig): Promise<boolean> {
+  // Fast path: a validated, live singleton already exists → borrower.
   if (sql) {
     // Warn if a different URL is passed — the old connection is still in use
     if (config.database_url && connectedUrl && config.database_url !== connectedUrl) {
       console.warn('[gbrain] connect() called with a different database_url but a connection already exists. Using existing connection.');
     }
     return false; // joined an existing singleton — caller is a borrower
+  }
+
+  // A create is in flight but not yet probe-validated. Await ITS promise rather
+  // than racing a second create: on success we are a borrower of the now-valid
+  // singleton; on failure the rejection propagates and we throw too. Neither
+  // outcome lets a waiter record ownership of an unvalidated client.
+  if (connecting) {
+    await connecting;
+    return false;
   }
 
   const url = config.database_url;
@@ -191,51 +218,93 @@ export async function connect(config: EngineConfig): Promise<boolean> {
     );
   }
 
-  try {
-    const prepare = resolvePrepare(url);
-    const timeouts = resolveSessionTimeouts();
-    const opts: Record<string, unknown> = {
-      max: resolvePoolSize(),
-      idle_timeout: 20,
-      connect_timeout: 10,
-      types: {
-        // Register pgvector type
-        bigint: postgres.BigInt,
-      },
-      // Silence postgres NOTICE-level messages by default ("relation already
-      // exists, skipping" floods stdout under idempotent CREATE statements
-      // during migrations + initSchema, and breaks stdout-parsing callers like
-      // `gbrain jobs submit --json | ...`). Opt back in with GBRAIN_PG_NOTICES=1.
-      onnotice: process.env.GBRAIN_PG_NOTICES === '1' ? undefined : () => {},
-    };
-    if (Object.keys(timeouts).length > 0) {
-      opts.connection = timeouts;
-    }
-    if (typeof prepare === 'boolean') {
-      opts.prepare = prepare;
-      if (!prepare) {
-        console.warn(
-          '[gbrain] Prepared statements disabled (PgBouncer transaction-mode convention on port 6543). Override with GBRAIN_PREPARE=true if your pooler runs in session mode.',
+  // Become the creator. Publish the in-flight promise SYNCHRONOUSLY (no await
+  // between the checks above and this assignment) so concurrent callers observe
+  // it and await rather than racing a second create.
+  connecting = (async () => {
+    // Capture the epoch BEFORE the probe. A disconnect() (or another teardown)
+    // that races us bumps it; we then refuse to publish a singleton that a
+    // completed disconnect already tore down.
+    const epoch = connectEpoch;
+    let client: ReturnType<typeof postgres> | null = null;
+    try {
+      const prepare = resolvePrepare(url);
+      const timeouts = resolveSessionTimeouts();
+      const opts: Record<string, unknown> = {
+        max: resolvePoolSize(),
+        idle_timeout: 20,
+        connect_timeout: 10,
+        types: {
+          // Register pgvector type
+          bigint: postgres.BigInt,
+        },
+        // Silence postgres NOTICE-level messages by default ("relation already
+        // exists, skipping" floods stdout under idempotent CREATE statements
+        // during migrations + initSchema, and breaks stdout-parsing callers like
+        // `gbrain jobs submit --json | ...`). Opt back in with GBRAIN_PG_NOTICES=1.
+        onnotice: process.env.GBRAIN_PG_NOTICES === '1' ? undefined : () => {},
+      };
+      if (Object.keys(timeouts).length > 0) {
+        opts.connection = timeouts;
+      }
+      if (typeof prepare === 'boolean') {
+        opts.prepare = prepare;
+        if (!prepare) {
+          console.warn(
+            '[gbrain] Prepared statements disabled (PgBouncer transaction-mode convention on port 6543). Override with GBRAIN_PREPARE=true if your pooler runs in session mode.',
+          );
+        }
+      }
+      client = postgres(url, opts);
+
+      // Validate BEFORE publishing as the singleton.
+      await client`SELECT 1`;
+      await setSessionDefaults(client);
+
+      // A disconnect() raced us during the probe — do NOT publish (it would undo
+      // a completed teardown). Fall through to the catch, which ends this client
+      // and rejects so waiters don't join a singleton that was torn down.
+      if (epoch !== connectEpoch) {
+        throw new GBrainError(
+          'Connection aborted',
+          'disconnect() ran while this connect() was still probing',
+          'Retry connect() — the database was torn down mid-connect.',
         );
       }
+
+      // Publish only now — a concurrent caller awaiting `connecting` becomes a
+      // borrower of a client that is proven live.
+      sql = client;
+      connectedUrl = url;
+    } catch (e: unknown) {
+      // #1720: end the half-open client before dropping the reference; a thrown
+      // probe (EMAXCONNSESSION at the session-mode pooler cap, ECONNREFUSED,
+      // etc.) would otherwise orphan a postgres.js client that holds a pooler
+      // client slot. `sql` was never published, so it stays null and a later
+      // connect() can retry; every waiter on `connecting` rethrows this error.
+      sql = null;
+      connectedUrl = null;
+      if (client) {
+        try { await client.end({ timeout: 5 }); } catch { /* best-effort */ }
+      }
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new GBrainError(
+        'Cannot connect to database',
+        msg,
+        'Check your connection URL in ~/.gbrain/config.json',
+      );
     }
-    sql = postgres(url, opts);
+  })();
 
-    // Test connection
-    await sql`SELECT 1`;
-    connectedUrl = url;
-
-    await setSessionDefaults(sql);
-    return true; // we created the singleton — caller is the owner
-  } catch (e: unknown) {
-    sql = null;
-    connectedUrl = null;
-    const msg = e instanceof Error ? e.message : String(e);
-    throw new GBrainError(
-      'Cannot connect to database',
-      msg,
-      'Check your connection URL in ~/.gbrain/config.json',
-    );
+  try {
+    await connecting;
+    return true; // we created + validated the singleton — caller is the owner
+  } finally {
+    // Clear the in-flight marker once settled (success or failure). Waiters hold
+    // their own reference to the promise, so nulling it here does not affect
+    // them; new callers see either the live `sql` (borrow) or a clean slate
+    // (retry).
+    connecting = null;
   }
 }
 
@@ -251,6 +320,11 @@ export async function disconnect(): Promise<void> {
     // instance-pool callers go through here.
     logDbDisconnect('postgres', 'module');
   } catch { /* best-effort; never block disconnect on audit failure */ }
+  // #1720: invalidate any in-flight connect() probe so it refuses to publish a
+  // singleton after this teardown completes (see connectEpoch). Bump BEFORE the
+  // snapshot — it is synchronous, so an in-flight creator that resumes after us
+  // observes the new epoch and aborts.
+  connectEpoch += 1;
   // #1471 (codex #6): snapshot + null the singleton BEFORE awaiting end(), so a
   // concurrent module connect() can't observe a non-null `sql` mid-teardown and
   // join a pool that's already closing. Mirrors the v0.41.8.0 PGLite-disconnect

--- a/test/db-connect-singleton.test.ts
+++ b/test/db-connect-singleton.test.ts
@@ -1,0 +1,128 @@
+/**
+ * #1720 follow-up — db.connect() module-singleton lifecycle.
+ *
+ * Two bugs in the module-singleton create path, both surfaced in adversarial
+ * review of the #1720 autopilot reconnect fix:
+ *
+ *  (A) Leak: `sql = postgres(url, opts)` was assigned before `await sql\`SELECT 1\``,
+ *      and the catch nulled `sql` WITHOUT `await sql.end()` — orphaning a
+ *      postgres.js client that holds a pooler client slot with no reference to
+ *      close it.
+ *  (B) Join-the-dead-client race: because the unvalidated `sql` was published
+ *      before the probe, a concurrent connect() arriving mid-probe saw `sql`
+ *      truthy and returned `false` (borrower) against a client that might be
+ *      about to fail.
+ *
+ * Fix: an in-flight `connecting` promise. The singleton `sql` is published ONLY
+ * after the SELECT 1 probe validates the client; concurrent callers await
+ * `connecting` instead of the unvalidated `sql`. On failure the client is ended
+ * and every waiter throws; on success exactly one caller (creator) gets `true`
+ * and waiters get `false`. (#1471 ownership preserved.)
+ *
+ * Deterministic concurrency: a connect()'s synchronous prefix runs to its first
+ * await before any microtask resolves, so two un-awaited connect() calls reliably
+ * land one as creator and one as waiter. A gated probe lets us resolve/reject the
+ * in-flight SELECT 1 on demand. Repo precedent: mock.module('postgres') (28 files).
+ */
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+
+let clientsCreated = 0;
+let endCalls = 0;
+let gate: { promise: Promise<unknown>; resolve: () => void; reject: (e: unknown) => void };
+
+function freshGate() {
+  let resolve!: () => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<unknown>((res, rej) => {
+    resolve = () => res([{ ok: 1 }]); // SELECT 1 result shape is irrelevant (setSessionDefaults is a no-op)
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeClient() {
+  clientsCreated += 1;
+  // Called as a tagged template (sql`SELECT 1`) → returns the current gate.
+  const client = ((..._a: unknown[]) => gate.promise) as unknown as {
+    (...a: unknown[]): Promise<unknown>;
+    end: (o?: { timeout?: number }) => Promise<void>;
+  };
+  client.end = async () => { endCalls += 1; };
+  return client;
+}
+const factory = ((..._a: unknown[]) => makeClient()) as unknown as { (...a: unknown[]): unknown; BigInt: unknown };
+factory.BigInt = {};
+mock.module('postgres', () => ({ default: factory }));
+
+const db = await import('../src/core/db.ts');
+const CFG = { database_url: 'postgresql://u:p@127.0.0.1:1/db' } as unknown as Parameters<typeof db.connect>[0];
+
+beforeEach(async () => {
+  try { await db.disconnect(); } catch { /* ignore */ }
+  clientsCreated = 0;
+  endCalls = 0;
+  gate = freshGate();
+});
+
+describe('db.connect() singleton lifecycle (#1720 follow-up)', () => {
+  test('(A) a failed probe ends the orphaned client once and leaves the singleton null', async () => {
+    const p = db.connect(CFG);
+    gate.reject(new Error('(EMAXCONNSESSION) max clients reached in session mode'));
+    await expect(p).rejects.toThrow(/Cannot connect to database/);
+    expect(endCalls).toBe(1);                 // half-open client ended, not orphaned
+    expect(() => db.getConnection()).toThrow(); // singleton null
+  });
+
+  test('single successful connect creates the singleton and returns true', async () => {
+    const p = db.connect(CFG);
+    gate.resolve();
+    await expect(p).resolves.toBe(true);
+    expect(clientsCreated).toBe(1);
+    expect(() => db.getConnection()).not.toThrow();
+  });
+
+  test('(B) two concurrent connects, in-flight SUCCESS: one creator (true), one borrower (false), single client', async () => {
+    const p1 = db.connect(CFG);
+    const p2 = db.connect(CFG); // arrives while p1's probe is pending → must await, not race a 2nd create
+    gate.resolve();
+    const results = await Promise.all([p1, p2]);
+    expect(results.filter((r) => r === true).length).toBe(1);
+    expect(results.filter((r) => r === false).length).toBe(1);
+    expect(clientsCreated).toBe(1);                 // NO double-create
+    expect(() => db.getConnection()).not.toThrow();
+  });
+
+  test('(B) two concurrent connects, in-flight FAILURE: both throw, single client created + ended once, singleton null', async () => {
+    const p1 = db.connect(CFG);
+    const p2 = db.connect(CFG);
+    gate.reject(new Error('(EMAXCONNSESSION) max clients reached in session mode'));
+    const settled = await Promise.allSettled([p1, p2]);
+    expect(settled.every((s) => s.status === 'rejected')).toBe(true); // no waiter joins a dead client
+    expect(clientsCreated).toBe(1);                 // no double-create
+    expect(endCalls).toBe(1);                        // the one client ended once
+    expect(() => db.getConnection()).toThrow();      // singleton null
+  });
+
+  test('(C) disconnect() during an in-flight connect() is NOT undone: the probe-completing connect aborts, no singleton published', async () => {
+    const p = db.connect(CFG);        // in-flight; probe pending on the gate, sql still null
+    await db.disconnect();            // races the in-flight connect → bumps epoch, tears nothing down
+    gate.resolve();                   // probe now completes
+    await expect(p).rejects.toThrow(); // creator observes the epoch change → aborts instead of publishing
+    expect(() => db.getConnection()).toThrow(); // disconnect stands — no singleton resurrected
+    expect(endCalls).toBe(1);          // the aborted client was ended (no leak)
+  });
+
+  test('a failed connect leaves a clean slate: a later connect() creates a fresh singleton', async () => {
+    const fail = db.connect(CFG);
+    gate.reject(new Error('boom'));
+    await expect(fail).rejects.toThrow(/Cannot connect/);
+    expect(() => db.getConnection()).toThrow();
+
+    gate = freshGate(); // fresh in-flight probe for the retry
+    const ok = db.connect(CFG);
+    gate.resolve();
+    await expect(ok).resolves.toBe(true);            // `connecting` was cleared → fresh creator
+    expect(clientsCreated).toBe(2);                  // one client per attempt
+    expect(() => db.getConnection()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

`db.connect()` (the module-singleton create path) builds the client, publishes it to the module `sql`, and *then* probes it:

```ts
sql = postgres(url, opts);
await sql`SELECT 1`;   // <- publish happens BEFORE validation
```

Three defects fall out of that ordering — all surfaced in adversarial review of the #1720 autopilot reconnect fix:

1. **Leak.** The catch did `sql = null` **without** `await sql.end()`. A thrown probe (`EMAXCONNSESSION` at the session-mode pooler client cap, `ECONNREFUSED`, …) orphans a postgres.js client that holds a pooler client slot, with no reference left to close it.
2. **Join-the-dead-client race.** Because the unvalidated `sql` was published before the probe, a concurrent `connect()` arriving mid-probe sees `sql` truthy and returns `false` (borrower) against a client that may be about to fail — and records ownership/manager state for an invalid singleton.
3. **Disconnect-vs-in-flight race.** A `disconnect()` racing an in-flight `connect()` sees `sql` still null (probe pending), tears nothing down, and is then silently undone when the probe later publishes the singleton.

## Fix — validate before publish

- **`connecting`** — the in-flight create's probe promise. `connect()` decides atomically across **three** states (live `sql` / in-flight `connecting` / absent): the checks and the synchronous `connecting = (...)()` assignment run with no `await` between them, so two concurrent callers can't both become creator. `sql` is published **only after** the `SELECT 1` probe validates the client; latecomers `await connecting` instead of the unvalidated `sql`. On failure the client is ended and every waiter throws; on success exactly one caller gets `true`, waiters get `false`. (#1471 create-vs-join ownership preserved.)
- **`connectEpoch`** — bumped by `disconnect()` before its snapshot. The creator captures the epoch before its probe and refuses to publish if it changed, ending the client and rejecting — so a completed `disconnect()` can't be resurrected.

## Scope

Module-singleton **create / borrow / failed-probe / disconnect** lifecycle. The separately-tracked `PostgresEngine.reconnect()` module-mode *"wedged-but-non-null pool"* rebuild is **not** addressed here. (The instance-path `connect()` got the analogous end-on-failed-probe cleanup in the sibling PR.)

## Tests

`test/db-connect-singleton.test.ts` — deterministic via a gated mock probe (`mock.module('postgres')`): failed-probe ends the client + nulls the singleton; single success; concurrent success (one creator / one borrower, single client); concurrent failure (both throw, single client, ended once); `disconnect()`-during-in-flight aborts the publish; retry-after-failure creates a fresh singleton. 6 tests green; 54+ db-lock / connection / ownership regression tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)