### PR TITLE
fix(embeddings): stop rejecting user-provided (litellm/llama-server) models with custom dims

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -705,19 +705,27 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   }
 
   // Openai-compat recipes with empty models list require a user-provided model.
+  // configureGateway() registers the configured model into the extended-models
+  // set (the same set the real embed/chat call paths consult via
+  // getExtendedModelsForProvider); honor it here so a configured user-provided
+  // model (e.g. litellm:embed) passes the preflight instead of false-failing as
+  // "unset".
   const isUserProvided = (tp as any).user_provided_models === true;
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
     (recipe.id === 'litellm' || isUserProvided)
   ) {
-    return {
-      ok: false,
-      reason: 'user_provided_model_unset',
-      model: modelStr,
-      provider: parsed.providerId,
-      recipeId: recipe.id,
-    };
+    const extended = getExtendedModelsForProvider(parsed.providerId);
+    if (!extended || !extended.has(parsed.modelId)) {
+      return {
+        ok: false,
+        reason: 'user_provided_model_unset',
+        model: modelStr,
+        provider: parsed.providerId,
+        recipeId: recipe.id,
+      };
+    }
   }
 
   const required = recipe.auth_env?.required ?? [];

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -449,6 +449,16 @@ function isCustomDimValidForProvider(
     };
   }
 
+  // Tier 2.5: user-provided-model recipes (litellm, llama-server) ship an
+  // empty `models` list — the operator supplies the model AND its output
+  // dimension, so gbrain has no fixed dim list to validate against. Trust the
+  // user-declared dims (already bounded to 1..PGVECTOR_COLUMN_MAX_DIMS by the
+  // caller). Without this, a valid `litellm:embed` with `--embedding-dimensions
+  // 2560` is wrongly rejected by the Tier 3 catch-all below.
+  if (recipe.touchpoints.embedding?.user_provided_models === true) {
+    return { valid: true, error: '' };
+  }
+
   // Tier 3: provider not known to support custom dims at all.
   return {
     valid: false,


### PR DESCRIPTION
## Problem

A configured user-provided embedding model with a custom dimension — e.g. `litellm:embed` at 2560 dims via a LiteLLM proxy — is wrongly rejected in **two** independent places, which makes a LiteLLM-fronted (or llama-server) embedding setup unusable for both `gbrain init` and `import`/`embed`. Both rejections are false negatives: the model is configured, the endpoint works, and the *actual* embed call path accepts it — only the validation/preflight layers refuse.

User-provided-model recipes (`litellm`, `llama-server`) intentionally ship an empty `models: []` list with `user_provided_models: true`: the operator supplies both the model name and its output dimension, because gbrain can't know what a proxy serves.

## Defect 1 — init dim validation rejects the custom dim

`src/core/embedding-dim-check.ts` › `isCustomDimValidForProvider()`

The custom-dimension validator walks: Tier 1 (recipe `dims_options`) → Tier 2 (provider-specific Matryoshka allow-lists: voyage / zeroentropy / openai) → Tier 3 catch-all that **rejects everything else**. User-provided recipes match none of the first two tiers, so any `--embedding-dimensions N` falls through to Tier 3 and is rejected with *"this model only emits its default vector size."* But these recipes have no fixed dim list to validate against — the user legitimately declares the dim.

**Fix:** add a tier *before* the Tier-3 catch-all that trusts the user-declared dims for `user_provided_models` recipes. It's already bounded to `1..PGVECTOR_COLUMN_MAX_DIMS` by the caller (`validateDimAgainstTouchpoint`), and only reached when `requestedDims !== defaultDims`. Fixed-dimension providers still hit their own tiers first and are unaffected.

## Defect 2 — embed credential preflight false-fails a *configured* model

`src/core/ai/gateway.ts` › `diagnoseEmbedding()`

The preflight returns `user_provided_model_unset` whenever a user-provided recipe's **static** `tp.models` array is empty — without consulting the per-gateway `_extendedModels` registry that `configureGateway()` populates with the configured model, and that the **real call paths already consult** via `getExtendedModelsForProvider()`:

- `resolveEmbeddingProvider()` — in `gateway.ts` (as of HEAD `80581445`, line 1109)
- `resolveChatProvider()` — (as of HEAD `80581445`, lines 2351, 2394)
- `resolveExpansionProvider()` — (as of HEAD `80581445`, line 2022)

(Line numbers will drift on `master`; the function names are the stable reference.)

So a correctly configured `litellm:embed` passes the actual embed call but is blocked at the preflight (`import`/`embed`/`sync` refuse with "set one: gbrain config set embedding_model litellm:<model>").

**Fix:** consult `getExtendedModelsForProvider(parsed.providerId)` in the same branch; only return `user_provided_model_unset` when the configured model is **not** registered. A genuine misconfiguration (no model registered) still fails the preflight — this narrows a false positive without introducing a false negative.

## Scope / safety

- Both changes are additive and gated; **no behavior change for any other provider**. Voyage/ZeroEntropy/OpenAI/fixed-dim recipes hit the exact same tiers as before, and the gateway branch is already gated to `tp.models.length === 0 && (litellm || user_provided)`.
- All existing failure paths are preserved (empty/invalid dim, unknown provider, no touchpoint, missing auth env, genuinely-unset user model).

## Verification

- Ran `bun run typecheck` (the repo's typecheck script, which runs `tsc --noEmit`): clean — exit code 0, no errors.
- Found and fixed against a real self-hosted deployment: a single-tenant Postgres + pgvector brain embedding via a LiteLLM proxy at `litellm:embed`, 2560 dims. Before this change, `gbrain init` refuses the dimension (Defect 1) and `gbrain import`'s embed preflight false-fails despite the model being configured and the endpoint reachable (Defect 2); after it, init builds the `vector(2560)` schema and import embeds normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
