### PR TITLE
fix(sync): prune vendor/, dist/, build/ in walker (matches node_modules)

### DIFF
--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -238,11 +238,26 @@ function matchesAnyGlob(path: string, patterns?: string[]): boolean {
  * `node_modules` lacks a leading dot so the dot-prefix exclusion in
  * isSyncable below doesn't catch it; explicit entry here closes the
  * latent walker bug (#923, #202).
+ *
+ * `vendor`, `dist`, `build` are the same shape one tier up: gitignored
+ * dependency / build-output dirs that exist on disk after `composer
+ * install` / `npm run build` / equivalent. The walker doesn't consult
+ * `.gitignore`, so without these entries a code-strategy sync of a
+ * built PHP/JS repo trips two structural Postgres limits:
+ *   - composer's `autoload_classmap.php` etc. exceed the 1 MiB
+ *     `tsvector` cap → `FILE_TOO_LARGE` rows in `sync_failures`.
+ *   - minified bundles produce >10 900 chunks in a single INSERT,
+ *     blowing the 65 534 bind-param wire-protocol cap → `UNKNOWN`
+ *     rows in `sync_failures` (MAX_PARAMETERS_EXCEEDED).
+ * Empirically hit on PHP+Vue repos at the >2k-page scale.
  */
 const PRUNE_DIR_NAMES = new Set<string>([
   'node_modules',
   '.raw',
   'ops',
+  'vendor',
+  'dist',
+  'build',
 ]);
 
 /**

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -132,6 +132,16 @@ describe('pruneDir', () => {
     expect(pruneDir('ops')).toBe(false);
   });
 
+  test('blocks build-output / vendored-dep dirs (vendor, dist, build)', () => {
+    // Gitignored dirs that exist on disk after `composer install` / `npm
+    // run build`. The walker doesn't read .gitignore, so without these
+    // entries code-strategy sync hits tsvector + bind-param caps on
+    // composer autoload bundles and minified JS chunks.
+    expect(pruneDir('vendor')).toBe(false);
+    expect(pruneDir('dist')).toBe(false);
+    expect(pruneDir('build')).toBe(false);
+  });
+
   test('blocks *.raw sidecar dirs (gbrain convention)', () => {
     expect(pruneDir('.raw')).toBe(false);
     expect(pruneDir('pedro.raw')).toBe(false);


### PR DESCRIPTION
## Symptom

`gbrain doctor` shows growing `sync_failures` on a PHP+Vue repo at the >2k-page scale:

```
64 unacknowledged sync failure(s) [FILE_TOO_LARGE=33, UNKNOWN=31].
  vendor/composer/autoload_static.php
    string is too long for tsvector (1,179,364 bytes, max 1,048,575)
  vendor/composer/autoload_classmap.php
    string is too long for tsvector (1,167,346 bytes, max 1,048,575)
  dist/assets/SomeComponent.vue_vue_type_script_setup_true_lang-XXXX.js
    MAX_PARAMETERS_EXCEEDED: Max number of parameters (65534) exceeded
```

The cited files are gitignored. They exist on disk because the user ran `composer install` / `npm run build` locally. Failures regenerate on every sync, so `gbrain sync --skip-failed` is whack-a-mole rather than a fix.

## Root cause

`src/core/sync.ts`'s `PRUNE_DIR_NAMES` set skips `node_modules`, `.raw`, `ops` at descent time but does not catch `vendor`, `dist`, `build` — gitignored sibling dirs in the same shape. The walker doesn't consult `.gitignore` (would be recursive + hierarchical + negation-aware, non-trivial), so code-strategy sync of a built PHP/JS repo descends into them and trips two structural Postgres limits:

- **tsvector 1 MiB cap.** `vendor/composer/autoload_classmap.php` etc. exceed it → `FILE_TOO_LARGE`.
- **Postgres 65,534 bind-param wire cap.** Minified bundles produce >10,900 chunks in a single INSERT → `UNKNOWN` / `MAX_PARAMETERS_EXCEEDED`.

These are not user-fixable: the files are auto-generated by the toolchain.

## Fix

Add `vendor`, `dist`, `build` to `PRUNE_DIR_NAMES`. Same shape as the existing `node_modules` entry; same rationale (gitignored build artifact / vendored dep). Walker stops descending; failures stop generating.

```diff
 const PRUNE_DIR_NAMES = new Set<string>([
   'node_modules',
   '.raw',
   'ops',
+  'vendor',
+  'dist',
+  'build',
 ]);
```

Doc comment extended to explain the structural Postgres limits + why the walker can't rely on `.gitignore` alone.

## Tests

`test/sync.test.ts` `pruneDir` suite extended with one assertion per added name:

```ts
test('blocks build-output / vendored-dep dirs (vendor, dist, build)', () => {
  expect(pruneDir('vendor')).toBe(false);
  expect(pruneDir('dist')).toBe(false);
  expect(pruneDir('build')).toBe(false);
});
```

All 7 `pruneDir` tests pass. `bun run typecheck` clean.

## Compatibility / blast radius

- **Markdown-strategy syncs** are unaffected — these dirs almost never contain `.md` pages.
- **Code-strategy syncs of PHP/Composer projects with committed `vendor/`** (e.g. some deployment-frozen apps) would lose vendor indexing. Rare in the gbrain target audience (personal/team knowledge brains, not legacy PHP monoliths); easy to opt back in later if needed.
- **Repos that intentionally ship a hand-written `dist/`** (rare; usually `dist/` is auto-generated) lose that too.

If per-repo opinions matter, the natural follow-up is to wire the existing-but-unused `SyncableOptions.exclude?: string[]` field through from per-source `config` JSONB. This PR keeps the baseline simple; that follow-up would layer on top.

## Alternatives considered

1. **Walker reads `.gitignore`** — recursive, hierarchical, negation-aware, perf-sensitive (every descent check would need to walk up the tree). Right answer long-term; non-trivial.
2. **Wire `SyncableOptions.exclude` from per-source config** — type field exists at `src/core/sync.ts:39` but is never populated. Cleaner for per-repo opinions; needs a small CLI surface on `sources add`.

This PR is the minimum-diff fix that matches the existing pruning convention. Either follow-up is compatible.

## Files changed

- `src/core/sync.ts` — 3-line set extension + doc-comment expansion
- `test/sync.test.ts` — 1 new `pruneDir` assertion block (3 cases)

Total: +25 / -0. No public API changes.