### PR TITLE
fix(importer): coerce non-string frontmatter title before toLowerCase (#1939)

### DIFF
--- a/src/core/content-sanity.ts
+++ b/src/core/content-sanity.ts
@@ -376,7 +376,13 @@ export function assessContentSanity(opts: {
   // doesn't repeat the lowercase per literal.
   const bodyHead = body.slice(0, SCAN_HEAD_BYTES);
   const bodyHeadLower = bodyHead.toLowerCase();
-  const titleLower = opts.title.toLowerCase();
+  // Defensive: `opts.title` is typed `string`, but the importer feeds the raw
+  // YAML-parsed frontmatter value. `title: 404` parses as a number and
+  // `title: 2024-06-01` as a Date, so a bare `.toLowerCase()` throws
+  // ("opts.title.toLowerCase is not a function") and the importer skips the
+  // page. A thrown importer error wedges the source bookmark (#1939), forcing a
+  // full re-walk that never converges (#1794). Coerce to string first.
+  const titleLower = String(opts.title ?? '').toLowerCase();
 
   const junk_pattern_matches: string[] = [];
   for (const p of BUILT_IN_JUNK_PATTERNS) {

--- a/test/content-sanity.test.ts
+++ b/test/content-sanity.test.ts
@@ -640,3 +640,34 @@ describe('assessContentSanity — confidence split (Q1=A)', () => {
     expect(r.shouldFlag).toBe(false);
   });
 });
+
+// ─── REGRESSION: non-string title (#1939) ─────────────────────
+// The importer feeds the raw YAML-parsed frontmatter value. `title: 404`
+// parses as a number and `title: 2024-06-01` as a Date, so a bare
+// `opts.title.toLowerCase()` threw and skipped the page — wedging the source
+// bookmark (#1939) and forcing a never-converging full re-walk (#1794).
+describe('assessContentSanity — non-string title coercion (#1939)', () => {
+  test('numeric title does not throw', () => {
+    expect(() =>
+      // @ts-expect-error — simulate importer passing a YAML number
+      assessContentSanity({ compiled_truth: 'hello world', timeline: '', title: 404 }),
+    ).not.toThrow();
+  });
+
+  test('Date title does not throw', () => {
+    expect(() =>
+      // @ts-expect-error — simulate importer passing a YAML Date
+      assessContentSanity({ compiled_truth: 'hello world', timeline: '', title: new Date('2024-06-01') }),
+    ).not.toThrow();
+  });
+
+  test('null/undefined title does not throw', () => {
+    expect(() =>
+      // @ts-expect-error — simulate missing title
+      assessContentSanity({ compiled_truth: 'hello world', timeline: '', title: null }),
+    ).not.toThrow();
+    expect(() =>
+      assessContentSanity({ compiled_truth: 'hello world', timeline: '', title: undefined as unknown as string }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1939 (and the convergence half of #1794): the gbrain importer crashes on any page whose frontmatter `title` parses as a non-string, silently skipping the page and **wedging the source sync bookmark** — which forces a full re-walk of the whole repo that never converges, so new commits stop being indexed.

## Root cause

`assessContentSanity` (src/core/content-sanity.ts:379) is typed `title: string`, but the importer hands it the raw YAML-parsed frontmatter value:

```yaml
title: 404          # -> number
title: 2024-06-01   # -> Date
```

`opts.title.toLowerCase()` then throws `opts.title.toLowerCase is not a function`, the importer skips the file, and per the #1939 mechanism a thrown importer error leaves the `default` source bookmark stuck.

## Live evidence (garrytan/brain)

- `default` source bookmark stuck at **2026-06-04** for 3+ days while commits kept landing.
- A 2.5h sync sat at **9% (18.5K/204K files)** re-walking from scratch, never converging (#1794), burning ~27% CPU continuously.
- **21 real poison files** on the brain (titles like `404`, `40`, `222`, `529`, numeric apple-notes). Drain log: `opts.title.toLowerCase is not a function ... (suppressing further ...)`.
- Data-side already fixed on our brain by quoting those 21 titles; this PR is the durable code fix so it can't recur from a single bad title.

## Fix

```ts
const titleLower = String(opts.title ?? '').toLowerCase();
```

One line, defensive at the use site. Added 3 regression tests (numeric / Date / null titles no longer throw). Full suite: **80 pass / 0 fail**.

## Note on #1794

This removes the *trigger* (a single poison file should not wedge the bookmark), but the underlying "full sync never checkpoints, killed = lose all progress" invariant in #1794 is still worth a separate fix (intermediate `last_commit` checkpointing). This PR makes the common case stop firing.
