### PR TITLE
fix(embed): keep --catch-up running instead of aborting on 32-bit setTimeout overflow

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -73,6 +73,51 @@ export interface EmbedOpts {
   signal?: AbortSignal;
 }
 
+export const MAX_JS_TIMER_DELAY_MS = 2_147_483_647;
+
+export interface AbortTimerHandle {
+  clear(): void;
+}
+
+/**
+ * Schedule an AbortController deadline without ever passing an out-of-range
+ * delay to setTimeout. JS runtimes store timer delays as signed 32-bit
+ * milliseconds; larger values are clamped by Node/Bun and can fire at once.
+ *
+ * @internal exported for targeted regression tests.
+ */
+export function scheduleAbortAfterDelay(controller: AbortController, ms: number): AbortTimerHandle | undefined {
+  if (!Number.isFinite(ms)) return undefined;
+  if (ms <= 0) {
+    controller.abort();
+    return undefined;
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let cancelled = false;
+  const startedAt = Date.now();
+
+  const arm = (remainingMs: number) => {
+    if (cancelled) return;
+    const delayMs = Math.min(MAX_JS_TIMER_DELAY_MS, Math.max(1, remainingMs));
+    timer = setTimeout(() => {
+      if (cancelled) return;
+      const stillRemaining = ms - (Date.now() - startedAt);
+      if (stillRemaining > 0) arm(stillRemaining);
+      else controller.abort();
+    }, delayMs);
+  };
+
+  arm(ms);
+
+  return {
+    clear() {
+      cancelled = true;
+      if (timer !== undefined) clearTimeout(timer);
+    },
+  };
+}
+
 /**
  * Structured result from a library-level embed run.
  *
@@ -630,14 +675,14 @@ async function embedAllStale(
 
   // D3 + D3a + D8: wall-clock budget. 30 min default; env override.
   // v0.41.18.0 (A13): --catch-up removes the wall-clock cap entirely so the
-  // handler runs until countStaleChunks() returns 0. Use Number.MAX_SAFE_INTEGER
-  // (effectively unbounded) instead of the 30-min default. The AbortController
-  // still wraps for SIGINT propagation; just the timer never fires.
+  // handler runs until countStaleChunks() returns 0. Do not emulate "forever"
+  // with a huge setTimeout value: JS timers are 32-bit signed millisecond
+  // delays, so Node/Bun clamp huge values down and abort almost immediately.
   const BUDGET_MS = staleOpts?.catchUp
-    ? Number.MAX_SAFE_INTEGER
+    ? Number.POSITIVE_INFINITY
     : parseInt(process.env.GBRAIN_EMBED_TIME_BUDGET_MS || `${30 * 60 * 1000}`, 10);
   const budgetController = new AbortController();
-  const budgetTimer = setTimeout(() => budgetController.abort(), BUDGET_MS);
+  const budgetTimer = scheduleAbortAfterDelay(budgetController, BUDGET_MS);
   const budgetSignal = budgetController.signal;
   // #1737: the effective signal fires when EITHER the internal wall-clock
   // budget OR the caller's abort (worker timeout / lock loss / SIGTERM) fires.
@@ -772,7 +817,7 @@ async function embedAllStale(
       if (batch.length < PAGE_SIZE) break;
     }
   } finally {
-    clearTimeout(budgetTimer);
+    budgetTimer?.clear();
   }
 
   slog(`Embedded ${result.embedded} chunks across ${totalProcessedPages} pages`);

--- a/test/embed.serial.test.ts
+++ b/test/embed.serial.test.ts
@@ -700,6 +700,67 @@ describe('runEmbed CLI flag wiring (--stale --source)', () => {
 });
 
 describe('embedAllStale wall-clock budget end-to-end (D3 + D3a)', () => {
+  test('timer scheduling chunks large finite budgets instead of overflowing JS timers', async () => {
+    const { MAX_JS_TIMER_DELAY_MS, scheduleAbortAfterDelay } = await import('../src/commands/embed.ts');
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const delays: number[] = [];
+
+    try {
+      (globalThis as any).setTimeout = (_cb: () => void, delay?: number) => {
+        delays.push(Number(delay));
+        return { __fakeTimer: true };
+      };
+      (globalThis as any).clearTimeout = () => {};
+
+      const controller = new AbortController();
+      const handle = scheduleAbortAfterDelay(controller, MAX_JS_TIMER_DELAY_MS + 123_456);
+      handle?.clear();
+
+      expect(delays).toEqual([MAX_JS_TIMER_DELAY_MS]);
+      expect(controller.signal.aborted).toBe(false);
+    } finally {
+      (globalThis as any).setTimeout = originalSetTimeout;
+      (globalThis as any).clearTimeout = originalClearTimeout;
+    }
+  });
+
+  test('--catch-up does not schedule an overflowing budget timer and still embeds stale chunks', async () => {
+    const { MAX_JS_TIMER_DELAY_MS, runEmbedCore } = await import('../src/commands/embed.ts');
+    const originalSetTimeout = globalThis.setTimeout;
+    const seenDelays: number[] = [];
+
+    try {
+      (globalThis as any).setTimeout = ((cb: (...args: any[]) => void, delay?: number, ...args: any[]) => {
+        const numericDelay = Number(delay);
+        seenDelays.push(numericDelay);
+        if (numericDelay > MAX_JS_TIMER_DELAY_MS) {
+          throw new Error(`overflowing timer delay: ${numericDelay}`);
+        }
+        return originalSetTimeout(cb, delay as any, ...args);
+      }) as typeof setTimeout;
+
+      const stale = [
+        { slug: 'catch-up-page', chunk_index: 0, chunk_text: 'x', chunk_source: 'compiled_truth' as const, model: null, token_count: 1, source_id: 'default', page_id: 1 },
+      ];
+      const engine = mockEngine({
+        countStaleChunks: async () => 1,
+        listStaleChunks: async () => stale,
+        getChunks: async () => stale.map(s => ({ chunk_index: s.chunk_index, chunk_text: s.chunk_text, chunk_source: s.chunk_source, embedded_at: null, token_count: 1 })),
+        upsertChunks: async () => {},
+        setPageEmbeddingSignature: async () => {},
+      });
+
+      const result = await runEmbedCore(engine, { stale: true, catchUp: true, batchSize: 64 });
+
+      expect(result.embedded).toBe(1);
+      expect(result.pages_processed).toBe(1);
+      expect(seenDelays.every(d => d <= MAX_JS_TIMER_DELAY_MS)).toBe(true);
+    } finally {
+      (globalThis as any).setTimeout = originalSetTimeout;
+    }
+  });
+
   test('GBRAIN_EMBED_TIME_BUDGET_MS=N cuts the outer loop short on stuck workers', async () => {
     const { runEmbedCore } = await import('../src/commands/embed.ts');
     // Tiny budget: 100ms. Each embed call sleeps 50ms; with budget + multiple


### PR DESCRIPTION
## Problem
`embed --stale --catch-up` aborts after one batch instead of running until the stale backlog is cleared. The unbounded catch-up budget is passed straight to `setTimeout`, which clamps out-of-range (> 2³¹−1 ms) delays and fires the budget `AbortController` immediately. Details in #1946.

## Fix
- Add `scheduleAbortAfterDelay(controller, ms)`: arms the abort deadline and **re-arms within the 32-bit timer cap** so long/unbounded budgets behave correctly (aborts immediately for `ms <= 0`, no-ops for non-finite).
- Use it in `embedAllStale` in place of the single `setTimeout`.
- Regression coverage in `test/embed.serial.test.ts`.

No behavior change for the default bounded (30 min) budget; the fix only affects the unbounded/long-budget path.

Closes #1946