### PR TITLE
fix(gateway): embed preflight false-fails llama-server/litellm user-provided-model configs

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -709,6 +709,7 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
+    !parsed.modelId &&
     (recipe.id === 'litellm' || isUserProvided)
   ) {
     return {


### PR DESCRIPTION
## Problem

`diagnoseEmbedding()` (the embed preflight added in v0.41.9.0) returns
`user_provided_model_unset` for **any** `llama-server` or `litellm` embedding
config — even when the model is correctly supplied via `embedding_model`.

The branch checks only the recipe's static `models` list (intentionally empty
for user-driven-model recipes like `llama-server`/`litellm`) and never consults
the model the user actually supplied (`parsed.modelId`):

```ts
if (
  Array.isArray(tp.models) &&
  tp.models.length === 0 &&
  (recipe.id === 'litellm' || isUserProvided)
) {
  return { ok: false, reason: 'user_provided_model_unset', ... };
}
```

So a fully valid `embedding_model = llama-server:bge-m3` fails preflight, which
blocks `sync` / `embed` / `import` at entry for every local-embedding
(llama-server) and litellm-proxy user.

## Repro

```ts
configureGateway({ embedding_model: 'llama-server:bge-m3', embedding_dimensions: 1024, env: {}, base_urls: {...} });
diagnoseEmbedding();
// => { ok:false, reason:'user_provided_model_unset', model:'llama-server:bge-m3', ... }
// resolveRecipe('llama-server:bge-m3').parsed => { providerId:'llama-server', modelId:'bge-m3' }  ← model IS supplied
```

## Fix

Add a `!parsed.modelId` guard so the branch only fires when no model was
actually supplied. `parseModelId` already rejects empty/bare ids
(`llama-server:` / `litellm:` → `unknown_provider`) before this point, so the
genuinely-unset case stays covered and this reason becomes a correct no-op
instead of a false positive.

After the fix:
- `llama-server:bge-m3` → `ok:true`
- `litellm:gpt-4o-mini` → `ok:true`
- `litellm:` (empty model) → still rejected (`unknown_provider`, via `parseModelId`)

## Test gap

The `user_provided_model_unset` branch has no coverage in
`test/embed-preflight.test.ts` (which exercises openai / voyage / google /
anthropic / unknown-provider / no-gateway-config). Glad to add a regression
test for the user-provided-model OK path if you'd like it in this PR.
