### PR TITLE
fix(pglite): populate chunk FTS vectors on upsert

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1952,6 +1952,22 @@ export class PGLiteEngine implements BrainEngine {
          embedding_image = COALESCE(EXCLUDED.embedding_image, content_chunks.embedding_image)`,
       params
     );
+
+    // Defense in depth for PGLite fresh installs whose chunk FTS trigger is
+    // absent or wedged: keyword search reads content_chunks.search_vector, so
+    // the write path must leave newly upserted chunks searchable even when the
+    // schema trigger fails to do it for us. This mirrors migration v28's
+    // backfill expression and is idempotent with the normal trigger path.
+    await this.db.query(
+      `UPDATE content_chunks
+          SET search_vector =
+            setweight(to_tsvector('english', COALESCE(doc_comment, '')), 'A') ||
+            setweight(to_tsvector('english', COALESCE(symbol_name_qualified, '')), 'A') ||
+            setweight(to_tsvector('english', COALESCE(chunk_text, '')), 'B')
+        WHERE page_id = $1
+          AND chunk_index = ANY($2::int[])`,
+      [pageId, newIndices],
+    );
   }
 
   async getChunks(slug: string, opts?: { sourceId?: string }): Promise<Chunk[]> {

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -210,6 +210,40 @@ describe('PGLiteEngine: Search', () => {
     expect(results.length).toBeGreaterThan(0);
   });
 
+  test('upsertChunks remains keyword-searchable when the chunk FTS trigger is missing', async () => {
+    // Fresh Agent Box PGLite installs can end up with pages/chunks present but
+    // empty keyword results when the trigger that normally computes
+    // content_chunks.search_vector is absent. upsertChunks is the write path
+    // behind put_page/import, so it must populate the vector directly as a
+    // safety net instead of relying exclusively on schema-trigger state.
+    await truncateAll();
+    await (engine as any).db.exec('DROP TRIGGER IF EXISTS chunk_search_vector_trigger ON content_chunks');
+    await engine.putPage('concepts/mcp-eval-sentinel', {
+      type: 'note',
+      title: 'MCP eval sentinel',
+      compiled_truth: 'MCP eval sentinel Carlos uniqueprobe after fresh Agent Box setup.',
+    });
+    await engine.upsertChunks('concepts/mcp-eval-sentinel', [
+      {
+        chunk_index: 0,
+        chunk_text: 'MCP eval sentinel Carlos uniqueprobe after fresh Agent Box setup.',
+        chunk_source: 'compiled_truth',
+      },
+    ]);
+
+    const { rows } = await (engine as any).db.query(
+      `SELECT cc.search_vector::text AS search_vector
+         FROM content_chunks cc
+         JOIN pages p ON p.id = cc.page_id
+        WHERE p.slug = $1`,
+      ['concepts/mcp-eval-sentinel'],
+    );
+    expect(String(rows[0]?.search_vector ?? '')).toContain('uniqueprob');
+
+    const results = await engine.searchKeyword('uniqueprobe', { limit: 5 });
+    expect(results.map(r => r.slug)).toContain('concepts/mcp-eval-sentinel');
+  });
+
   test('searchVector returns empty when no embeddings', async () => {
     const fakeEmbedding = new Float32Array(1536);
     const results = await engine.searchVector(fakeEmbedding);


### PR DESCRIPTION
## Summary
- populate PGLite content_chunks.search_vector directly after upsertChunks
- add regression that drops the chunk FTS trigger and verifies fresh chunks still search

## Tests
- bun test test/pglite-engine.test.ts --timeout 20000 -t "upsertChunks remains keyword-searchable"
- bun test test/pglite-engine.test.ts --timeout 30000