### PR TITLE
fix(ai): litellm proxy unusable for chat — add chat touchpoint + fold proxy api keys

### DIFF
--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -34,6 +34,15 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   // plane field now exists (GBrainConfig type) and gets mapped here, so
   // setting it via `~/.gbrain/config.json` propagates into the gateway.
   if (c.zeroentropy_api_key) envFromConfig.ZEROENTROPY_API_KEY = c.zeroentropy_api_key;
+  // Same fold for the openai-compat proxy recipes (litellm / openrouter /
+  // together): their auth resolves to `${RECIPE_ID}_API_KEY` via applyResolveAuth,
+  // so a `gbrain config set litellm_api_key …` (or a config.json field) must be
+  // mapped into the gateway env or the proxy call goes out unauthenticated and
+  // chat_model=litellm:<m> degrades to "no LLM available". Mirrors the ZE fix.
+  const cAny = c as Record<string, unknown>;
+  if (typeof cAny.litellm_api_key === 'string') envFromConfig.LITELLM_API_KEY = cAny.litellm_api_key;
+  if (typeof cAny.openrouter_api_key === 'string') envFromConfig.OPENROUTER_API_KEY = cAny.openrouter_api_key;
+  if (typeof cAny.together_api_key === 'string') envFromConfig.TOGETHER_API_KEY = cAny.together_api_key;
 
   // v0.32 codex finding #4+#5 fix: thread local-server _BASE_URL env vars
   // into base_urls so the gateway hits the user's configured port. Without

--- a/src/core/ai/recipes/litellm-proxy.ts
+++ b/src/core/ai/recipes/litellm-proxy.ts
@@ -40,6 +40,25 @@ export const litellmProxy: Recipe = {
       // mismatched-dim responses pre-storage).
       supports_multimodal: true,
     },
+    chat: {
+      // LiteLLM's raison d'être is chat: it proxies arbitrary chat backends
+      // (Bedrock, Vertex, Azure, DeepSeek, Qwen, GLM, …) behind one
+      // OpenAI-compatible /chat/completions endpoint. The served model set is
+      // the proxy's own config, so declare empty + user-provided (mirrors the
+      // embedding touchpoint). The openai-compat tier does NOT enforce the list
+      // at runtime — any model id the proxy serves is accepted. Without this
+      // touchpoint, `chat_model` / `models.default = litellm:<model>` silently
+      // degrade to "no LLM available" (validateModelId throws no-chat-touchpoint).
+      models: [],
+      user_provided_models: true,
+      supports_tools: true,
+      // Informational only — the real subagent-loop gate is isAnthropicProvider()
+      // upstream (tool-replay needs Anthropic-style tool_use_ids). litellm can
+      // still drive the gateway loop when agent.use_gateway_loop=true.
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      price_last_verified: '2026-06-07',
+    },
   },
-  setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL + pass --embedding-model litellm:<model> and --embedding-dimensions <N>.',
+  setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL (+ LITELLM_API_KEY if the proxy is authenticated) and use litellm:<model> for --embedding-model, chat_model, or models.default.',
 };


### PR DESCRIPTION
## Problem

The `litellm-proxy` recipe declares only an `embedding` touchpoint — no `chat`.
So any `chat_model` / `models.default = litellm:<model>` fails `validateModelId`
with *"Provider \"litellm\" does not support touchpoint \"chat\""*, and the think
synthesis path then degrades silently to **`(no LLM available — set ANTHROPIC_API_KEY)`**
(misleading: the user configured litellm, not anthropic). This makes LiteLLM —
whose primary purpose is chat — unusable for chat/synthesis/subagent in gbrain.

A second gap: `build-gateway-config.ts` folds `openai_api_key` / `anthropic_api_key` /
`zeroentropy_api_key` from config into the gateway env, but **not** the openai-compat
proxy keys. So `gbrain config set litellm_api_key …` writes the DB plane and never
reaches the proxy call → it goes out unauthenticated. (Same class as the v0.37
ZeroEntropy fold fix.)

## Fix

1. **`recipes/litellm-proxy.ts`** — add a `chat` touchpoint (openai-compatible,
   `user_provided_models: true`, `supports_tools: true`) mirroring the embedding one.
   The proxy serves arbitrary models; the openai-compat tier doesn't enforce the
   list at runtime.
2. **`build-gateway-config.ts`** — fold `litellm_api_key` / `openrouter_api_key` /
   `together_api_key` from config into the gateway env (`LITELLM_API_KEY`, …), the
   same way openai/anthropic/zeroentropy are folded. Their auth resolves to
   `${RECIPE_ID}_API_KEY` via `applyResolveAuth`.

## Verification (against a live authenticated LiteLLM proxy)

- `probeChatModel('litellm:qwen-3.5-plus')` → `{ ok: true }` (was `unknown_model`).
- `gbrain think "…"` synthesizes a real answer through the proxy (was "no LLM available").
- The proxy model returns OpenAI-style `tool_calls`, and with
  `agent.use_gateway_loop=true` a subagent job completes through `gateway.toolLoop()`
  on the litellm model.

No behavior change for users who don't use litellm/openrouter/together.
Happy to add a recipe-shape test pinning the new chat touchpoint if desired.
