### PR TITLE
fix(readme): correct broken OpenClaw and Hermes project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ GBrain is designed to be installed and operated by an AI agent. The fastest path
 
 If you don't already have an AI agent platform running, start with one of these. Both are designed to read GBrain's install protocol and execute it:
 
-- **[OpenClaw](https://github.com/openclawagents/openclaw)** — deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/alphaclaw) (one click, 8GB+ RAM)
-- **[Hermes](https://github.com/openclawagents/hermes)** — deploy on [Railway](https://github.com/praveen-ks-2001/hermes-agent-template) (one click)
+- **[OpenClaw](https://github.com/openclaw/openclaw)** — deploy [AlphaClaw on Render](https://render.com/deploy?repo=https://github.com/chrysb/alphaclaw) (one click, 8GB+ RAM)
+- **[Hermes](https://github.com/NousResearch/hermes-agent)** — deploy on [Railway](https://github.com/praveen-ks-2001/hermes-agent-template) (one click)
 
 Then paste this into your agent:
 


### PR DESCRIPTION
> **Re-open of #1844.** That PR was closed as "likely solved by other updates," but the broken links are still live on `master` (lines 74–75 of `README.md` today). GitHub wouldn't let me reopen #1844 (the Reopen action fails with a generic validation error even though the branch and diff are intact), so this is a fresh PR rebased on the current `master`.

## What

The **Have your agent install it (recommended)** section of the README links the OpenClaw and Hermes project names to repos under a `openclawagents` org that doesn't exist. Both anchors currently 404:

| Link | Status |
|---|---|
| `[OpenClaw](https://github.com/openclawagents/openclaw)` | ❌ 404 |
| `[Hermes](https://github.com/openclawagents/hermes)` | ❌ 404 |

## Fix

Point each name at its real upstream repo:

- **OpenClaw** → `https://github.com/openclaw/openclaw` — the lobster project itself; the line's own deploy harness (`chrysb/alphaclaw`) is described as *"The ultimate setup harness for OpenClaw,"* confirming OpenClaw is the upstream.
- **Hermes** → `https://github.com/NousResearch/hermes-agent` — Hermes Agent by Nous Research; the Railway template (`praveen-ks-2001/hermes-agent-template`) is a downstream deploy wrapper around it.

This repo's own description — *"Garry's Opinionated OpenClaw/Hermes Agent Brain"* — corroborates the two intended platforms.

The deploy targets (`chrysb/alphaclaw` on Render and the Railway template) already resolve, so they're left unchanged.

Verified at time of this PR: both replacement URLs return `200`, both original URLs return `404`.

> Possibly a separate follow-up: the Hermes line says "deploy on **Railway** (one click)" but the link is a plain GitHub repo rather than a `railway.app/template/...` URL, so it won't actually trigger a one-click Railway deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
