### PR TITLE
fix(embed): don't arm wall-clock timer in --catch-up (#1946)

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -629,15 +629,19 @@ async function embedAllStale(
   const CONCURRENCY = parseInt(process.env.GBRAIN_EMBED_CONCURRENCY || '20', 10);
 
   // D3 + D3a + D8: wall-clock budget. 30 min default; env override.
-  // v0.41.18.0 (A13): --catch-up removes the wall-clock cap entirely so the
-  // handler runs until countStaleChunks() returns 0. Use Number.MAX_SAFE_INTEGER
-  // (effectively unbounded) instead of the 30-min default. The AbortController
-  // still wraps for SIGINT propagation; just the timer never fires.
+  // #1946: --catch-up removes the wall-clock cap entirely. Earlier versions
+  // used `setTimeout(…, Number.MAX_SAFE_INTEGER)`, but JS timer delays are
+  // clamped to a signed-32-bit ms range (~24.8 days); an out-of-range delay
+  // fires on the next tick and aborts the run after the first batch. Skip
+  // arming the timer in catch-up mode instead. The AbortController stays
+  // around so `budgetSignal.aborted` keeps its semantics (never true here).
   const BUDGET_MS = staleOpts?.catchUp
-    ? Number.MAX_SAFE_INTEGER
+    ? null
     : parseInt(process.env.GBRAIN_EMBED_TIME_BUDGET_MS || `${30 * 60 * 1000}`, 10);
   const budgetController = new AbortController();
-  const budgetTimer = setTimeout(() => budgetController.abort(), BUDGET_MS);
+  const budgetTimer = BUDGET_MS == null
+    ? null
+    : setTimeout(() => budgetController.abort(), BUDGET_MS);
   const budgetSignal = budgetController.signal;
   // #1737: the effective signal fires when EITHER the internal wall-clock
   // budget OR the caller's abort (worker timeout / lock loss / SIGTERM) fires.
@@ -772,7 +776,7 @@ async function embedAllStale(
       if (batch.length < PAGE_SIZE) break;
     }
   } finally {
-    clearTimeout(budgetTimer);
+    if (budgetTimer) clearTimeout(budgetTimer);
   }
 
   slog(`Embedded ${result.embedded} chunks across ${totalProcessedPages} pages`);

--- a/test/embed.serial.test.ts
+++ b/test/embed.serial.test.ts
@@ -755,6 +755,53 @@ describe('embedAllStale wall-clock budget end-to-end (D3 + D3a)', () => {
     // workers to drain (1 worker × 80ms latency). Generous upper bound: 1500ms.
     expect(elapsed).toBeLessThan(1500);
   });
+
+  // #1946: pre-fix, --catch-up set BUDGET_MS to Number.MAX_SAFE_INTEGER, which
+  // overflows setTimeout's signed-32-bit ms cap and fires on the next tick —
+  // the loop aborted after the first batch. Regression: with catchUp, the
+  // run must process every batch through to countStaleChunks==0.
+  test('--catch-up does NOT abort after the first batch (32-bit setTimeout overflow)', async () => {
+    const { runEmbedCore } = await import('../src/commands/embed.ts');
+    process.env.GBRAIN_EMBED_CONCURRENCY = '1';
+
+    // 5 rows across 5 separate listStaleChunks calls (PAGE_SIZE=1 so each
+    // batch is one row and the outer loop ticks 5 times).
+    const allRows = Array.from({ length: 5 }, (_, i) => ({
+      slug: `c-${i}`,
+      chunk_index: 0,
+      chunk_text: `t${i}`,
+      chunk_source: 'compiled_truth' as const,
+      model: null,
+      token_count: 1,
+      source_id: 'default',
+      page_id: i + 1,
+    }));
+
+    const engine = mockEngine({
+      countStaleChunks: async () => allRows.length,
+      listStaleChunks: async (opts: { afterPageId?: number } = {}) => {
+        const startIdx = (opts.afterPageId ?? 0);
+        const idx = allRows.findIndex(r => r.page_id > startIdx);
+        if (idx === -1) return [];
+        return [allRows[idx]];
+      },
+      getChunks: async () => [],
+      upsertChunks: async () => {},
+    });
+
+    // Mild per-call latency so a falsely-armed sub-tick timer would cut us
+    // off long before the loop finishes.
+    embedBatchBehavior = async (texts) => {
+      await new Promise(r => setTimeout(r, 20));
+      return texts.map(() => new Float32Array(1536));
+    };
+
+    const result = await runEmbedCore(engine, { stale: true, catchUp: true, batchSize: 1 });
+
+    // Every page should be processed — no premature abort.
+    expect(result.pages_processed).toBe(5);
+    expect(result.embedded).toBe(5);
+  });
 });
 
 describe('embedAllStale --source threading (D7)', () => {


### PR DESCRIPTION
## Summary

Closes #1946.

`embedAllStale` armed the budget timer with `setTimeout(..., Number.MAX_SAFE_INTEGER)` when `--catch-up` was set. JS timer delays are clamped to a signed 32-bit ms range (~24.8 days); any out-of-range delay fires on the next tick. So the `AbortController` aborted after the first batch, and large stale backlogs silently never caught up across runs.

## Fix

Skip arming the timer entirely in catch-up mode:

```ts
const BUDGET_MS = staleOpts?.catchUp
  ? null
  : parseInt(process.env.GBRAIN_EMBED_TIME_BUDGET_MS || `${30 * 60 * 1000}`, 10);
const budgetController = new AbortController();
const budgetTimer = BUDGET_MS == null
  ? null
  : setTimeout(() => budgetController.abort(), BUDGET_MS);
```

The `AbortController` is still constructed and still composed via `anySignal(budgetSignal, externalSignal)`, so SIGINT / worker-timeout / lock-loss propagation is unchanged — only the internal wall-clock timer is absent. `budgetSignal.aborted` stays `false` throughout catch-up, so the existing budget-exceeded log branch is unreachable in that mode (correct: catch-up has no budget to exceed).

Alternative shapes considered:
- **Clamp to `2**31 - 1` (~24.8 days)** — works in practice but isn't semantically "until `countStaleChunks()` returns 0", and a backlog that legitimately exceeds 24 days would re-introduce the silent abort.
- **Re-arm pattern** — adds complexity for no behavior gain over "just don't arm it."

## Test plan

- [x] `bun test test/embed.serial.test.ts` — 29/29 pass, including the existing `GBRAIN_EMBED_TIME_BUDGET_MS=N` budget test (unchanged behavior on the non-catch-up path)
- [x] New regression test: `--catch-up does NOT abort after the first batch (32-bit setTimeout overflow)` — asserts all 5 batches process through to completion under catch-up
- [x] `bun run typecheck` clean

Diff: 2 files, +58 / -7. `src/commands/embed.ts` + `test/embed.serial.test.ts` only. No VERSION / CHANGELOG / package.json changes — per the fix-wave workflow in `docs/RELEASING.md`, those are the wave shipper's concern.