### PR TITLE
fix(takes): resolve chat model via facts.extraction_model, not hardcoded Haiku (#1857)

### DIFF
--- a/src/core/extract-takes-from-pages.ts
+++ b/src/core/extract-takes-from-pages.ts
@@ -16,6 +16,7 @@
 import type { BrainEngine } from './engine.ts';
 import type { TakeBatchInput, TakeKind } from './engine.ts';
 import { chat, isAvailable } from './ai/gateway.ts';
+import { getFactsExtractionModel } from './facts/extract.ts';
 
 export const ALLOWED_PAGE_TYPES = [
   'concept', 'atom', 'lore', 'briefing', 'writing', 'originals',
@@ -129,6 +130,15 @@ export async function extractTakesFromPages(
   const sourceFilter = opts.sourceIdFilter ? `AND source_id = $1` : '';
   const params = opts.sourceIdFilter ? [opts.sourceIdFilter] : [];
 
+  // #1857: resolve the model once via the canonical facts.extraction_model
+  // chain. Pre-fix this was hardcoded to `anthropic:claude-haiku-4-5`, which
+  // silently returned 0 claims on OpenAI-only brains: per-page chat() would
+  // hit Anthropic with no key and the try/catch below would swallow each
+  // failure. The JSDoc on opts.model said "defaults to facts.extraction_model"
+  // but no caller resolved that — both cmdExtract (commands/takes.ts) and the
+  // Minion handler in commands/jobs.ts leave opts.model unset.
+  const resolvedModel = opts.model ?? await getFactsExtractionModel(engine);
+
   // Fetch eligible pages. Order by updated_at DESC so recently-edited
   // pages get bootstrapped first.
   const typesList = ALLOWED_PAGE_TYPES.map((t) => `'${t}'`).join(', ');
@@ -174,7 +184,7 @@ export async function extractTakesFromPages(
     let response: { text: string };
     try {
       response = await chat({
-        model: opts.model ?? 'anthropic:claude-haiku-4-5',
+        model: resolvedModel,
         system: CLASSIFIER_SYSTEM,
         messages: [
           {

--- a/test/extract-takes-from-pages.test.ts
+++ b/test/extract-takes-from-pages.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression tests for #1857 — `extractTakesFromPages` model resolution.
+ *
+ * Pre-fix the per-page classifier call hardcoded
+ * `model: opts.model ?? 'anthropic:claude-haiku-4-5'` even though the JSDoc
+ * said "defaults to facts.extraction_model". Neither caller (cmdExtract,
+ * the Minion handler) set opts.model, so OpenAI-only brains attempted
+ * Anthropic with no key and the per-page try/catch silently continued —
+ * `takes extract --from-pages` returned `0 claim(s)` with no error.
+ *
+ * These tests pin the model that reaches `chat()` through the canonical
+ * `facts.extraction_model` resolution chain.
+ */
+
+import { describe, expect, test, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import {
+  __setChatTransportForTests,
+  resetGateway,
+  type ChatResult,
+  type ChatOpts,
+} from '../src/core/ai/gateway.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { extractTakesFromPages } from '../src/core/extract-takes-from-pages.ts';
+
+let engine: PGLiteEngine;
+let capturedChatOpts: ChatOpts[] = [];
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+
+  // Chat-transport stub. Captures every call's opts (so tests can assert the
+  // resolved model) and returns an empty claims array so the page loop
+  // completes without inserting takes.
+  __setChatTransportForTests(async (opts: ChatOpts): Promise<ChatResult> => {
+    capturedChatOpts.push(opts);
+    return {
+      text: '[]',
+      blocks: [],
+      stopReason: 'end',
+      usage: {
+        input_tokens: 100,
+        output_tokens: 5,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+      },
+      model: 'stub:stub',
+      providerId: 'stub',
+    };
+  });
+});
+
+afterAll(async () => {
+  __setChatTransportForTests(null);
+  resetGateway();
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  capturedChatOpts = [];
+});
+
+async function seedConceptPage(slug: string): Promise<void> {
+  // Body length must exceed the 200-char floor in extractTakesFromPages's
+  // SQL: `length(COALESCE(compiled_truth, '')) > 200`.
+  const body = 'This is a concept page with enough content to clear the 200-character minimum for the page eligibility filter in extractTakesFromPages so the loop actually attempts a chat call against the configured model. Padding padding padding to be safe.';
+  await engine.putPage(slug, {
+    type: 'concept',
+    title: 'Test Concept',
+    compiled_truth: body,
+  });
+}
+
+describe('#1857 — extractTakesFromPages model resolution', () => {
+  test('uses facts.extraction_model from engine config (OpenAI-only brain case)', async () => {
+    await engine.setConfig('facts.extraction_model', 'openai:gpt-4.1-mini');
+    await seedConceptPage('concepts/cfg-key');
+
+    const result = await extractTakesFromPages(engine, {
+      bootstrapEnabled: true,
+      dryRun: true,
+      maxPages: 5,
+    });
+
+    expect(result.consent_gate_blocked).toBe(false);
+    expect(result.llm_unavailable).toBe(false);
+    expect(result.pages_scanned).toBe(1);
+    expect(capturedChatOpts).toHaveLength(1);
+    expect(capturedChatOpts[0].model).toBe('openai:gpt-4.1-mini');
+  });
+
+  test('falls through to models.default when facts.extraction_model is unset', async () => {
+    await engine.setConfig('models.default', 'openai:gpt-4.1-mini');
+    await seedConceptPage('concepts/default-fallback');
+
+    await extractTakesFromPages(engine, {
+      bootstrapEnabled: true,
+      dryRun: true,
+      maxPages: 5,
+    });
+
+    expect(capturedChatOpts).toHaveLength(1);
+    expect(capturedChatOpts[0].model).toBe('openai:gpt-4.1-mini');
+  });
+
+  test('opts.model still wins over engine config (explicit override path)', async () => {
+    await engine.setConfig('facts.extraction_model', 'openai:gpt-4.1-mini');
+    await seedConceptPage('concepts/explicit-override');
+
+    await extractTakesFromPages(engine, {
+      bootstrapEnabled: true,
+      dryRun: true,
+      maxPages: 5,
+      model: 'anthropic:claude-opus-4-7',
+    });
+
+    expect(capturedChatOpts).toHaveLength(1);
+    expect(capturedChatOpts[0].model).toBe('anthropic:claude-opus-4-7');
+  });
+
+  test('does NOT route to the pre-fix hardcoded Haiku id when no config is set', async () => {
+    // No facts.extraction_model, no models.default. The resolver still falls
+    // through to its Sonnet default — the key regression assertion is that
+    // we never silently land on the old hardcoded `anthropic:claude-haiku-4-5`.
+    await seedConceptPage('concepts/no-config');
+
+    await extractTakesFromPages(engine, {
+      bootstrapEnabled: true,
+      dryRun: true,
+      maxPages: 5,
+    });
+
+    expect(capturedChatOpts).toHaveLength(1);
+    expect(capturedChatOpts[0].model).not.toBe('anthropic:claude-haiku-4-5');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1857.

`extractTakesFromPages`'s per-page `chat()` call hardcoded `opts.model ?? 'anthropic:claude-haiku-4-5'`. The JSDoc on `opts.model` said *"defaults to facts.extraction_model"*, but no caller (`cmdExtract` in `commands/takes.ts`, the `extract-takes-from-pages` Minion handler in `commands/jobs.ts`) set `opts.model`, so every invocation hit the hardcoded Anthropic id regardless of how the brain was configured.

On an OpenAI-only brain without `ANTHROPIC_API_KEY` the failure was silent: the top-level `isAvailable('chat')` gate passed (gateway-configured chat model = OpenAI), but the per-page Anthropic call threw, the surrounding try/catch swallowed it, and the command reported `0 claim(s) from N page(s)` with no error.

## Fix

Resolve the model once via `getFactsExtractionModel(engine)` when `opts.model` is unset — same canonical `resolveModel` chain (`facts.extraction_model` config key → `models.default` → tier `'reasoning'` → env → fallback Sonnet) that `facts/extract.ts` already uses. Callers stay untouched; the fix lives entirely inside the core function so the public contract finally matches its JSDoc.

```ts
const resolvedModel = opts.model ?? await getFactsExtractionModel(engine);
// ...
response = await chat({ model: resolvedModel, ... });
```

## Test plan

New file `test/extract-takes-from-pages.test.ts` pins four points on the resolution chain via the gateway's `__setChatTransportForTests` seam:

- [x] `facts.extraction_model` from engine config (the exact OpenAI-only repro from the issue)
- [x] `models.default` fallthrough when `facts.extraction_model` is unset
- [x] `opts.model` explicit override still wins
- [x] **Regression assertion**: the resolved model is never the pre-fix hardcoded `anthropic:claude-haiku-4-5`

```
4 pass / 0 fail
```

- [x] `bun run typecheck` clean
- [x] Adjacent test files unaffected: `extract-takes.test.ts`, `extract-takes-holder-producer-seam.test.ts`, `extract-conversation-facts.test.ts` — 39/39 pass

## Non-goals

This PR keeps scope tight. Two adjacent latent issues the original report touches on but this PR does NOT change:

- **Silent per-page error swallow** (`try { chat(...) } catch { continue }` at `extract-takes-from-pages.ts:187`). After this fix the OpenAI-only repro stops hitting that path because the model now resolves correctly, but the catch is still there for legitimate rate-limit / content-filter transients. A future PR could surface a single aggregated warning when *every* page fails.
- **Choice of fallback model** (`getFactsExtractionModel` falls back to Sonnet). Higher quality than Haiku but ~3× the cost per page. Worth its own discussion since it's a behavior change for brains that were happy with Haiku's defaults pre-fix; matches the existing JSDoc + `facts.extract.ts` pipeline either way.

Diff: 2 files, +150 / -1. No VERSION / CHANGELOG / package.json changes — per the fix-wave workflow in `docs/RELEASING.md`, those are the wave shipper's concern.