### PR TITLE
fix(markdown): case-only SLUG_MISMATCH message names the case diff (#1916)

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -302,9 +302,19 @@ function collectValidationErrors(
   if (ctx.expectedSlug && typeof ctx.parsedFrontmatter.slug === 'string') {
     const declared = ctx.parsedFrontmatter.slug as string;
     if (declared !== ctx.expectedSlug) {
+      // #1916: case-only diff is the common typo (e.g. `slug: projects/README`
+      // against the path-derived `projects/readme`). The two strings look
+      // identical to a quick eye, so the bare "does not match" message left
+      // operators stuck. The path-derived slug is always lowercased by
+      // slugifySegment (sync.ts), so any declared slug that matches under
+      // case-fold but not directly is a casing typo. Name that specifically.
+      const caseOnly = declared.toLowerCase() === ctx.expectedSlug;
+      const message = caseOnly
+        ? `Frontmatter slug "${declared}" differs from path-derived slug "${ctx.expectedSlug}" by case only (gbrain slugs are lowercase). Lowercase the slug field, or remove it to let the path-derived default apply.`
+        : `Frontmatter slug "${declared}" does not match path-derived slug "${ctx.expectedSlug}"`;
       errors.push({
         code: 'SLUG_MISMATCH',
-        message: `Frontmatter slug "${declared}" does not match path-derived slug "${ctx.expectedSlug}"`,
+        message,
       });
     }
   }

--- a/test/markdown-validation.test.ts
+++ b/test/markdown-validation.test.ts
@@ -97,6 +97,37 @@ describe('parseMarkdown validation surface', () => {
       const parsed = parseMarkdown(md, undefined, { validate: true });
       expect(parsed.errors!.map(e => e.code)).not.toContain('SLUG_MISMATCH');
     });
+
+    // #1916: when the only difference is case (the common typo on macOS APFS
+    // where `README.md` files end up with a `slug: projects/README` field but
+    // the path-derived slug is lowercased), the message names the case
+    // mismatch so the operator can act without eyeballing two strings.
+    test('case-only mismatch -> message specifically names case + fix', () => {
+      const md = `${fence}\ntype: doc\ntitle: Readme\nslug: projects/README\n${fence}\n\nbody`;
+      const parsed = parseMarkdown(md, 'projects/README.md', {
+        validate: true,
+        expectedSlug: 'projects/readme',
+      });
+      const e = parsed.errors!.find(err => err.code === 'SLUG_MISMATCH');
+      expect(e).toBeDefined();
+      expect(e!.message).toContain('by case only');
+      expect(e!.message).toContain('gbrain slugs are lowercase');
+      expect(e!.message).toContain('Lowercase the slug field');
+      expect(e!.message).toContain('"projects/README"');
+      expect(e!.message).toContain('"projects/readme"');
+    });
+
+    test('non-case mismatch -> existing message (unchanged)', () => {
+      const md = `${fence}\ntype: concept\ntitle: hi\nslug: wrong-slug\n${fence}\n\nbody`;
+      const parsed = parseMarkdown(md, 'people/jane-doe.md', {
+        validate: true,
+        expectedSlug: 'people/jane-doe',
+      });
+      const e = parsed.errors!.find(err => err.code === 'SLUG_MISMATCH');
+      expect(e).toBeDefined();
+      expect(e!.message).toBe('Frontmatter slug "wrong-slug" does not match path-derived slug "people/jane-doe"');
+      expect(e!.message).not.toContain('by case only');
+    });
   });
 
   describe('NULL_BYTES', () => {


### PR DESCRIPTION
## Summary

Closes #1916.

The bare `SLUG_MISMATCH: Frontmatter slug "projects/README" does not match path-derived slug "projects/readme"` left operators stuck — the two strings look identical to a quick eye, and the error doesn't tell you why. First hit on macOS APFS during a repo cleanup where `README.md` files survived with mixed-case `slug:` fields after default slug normalization lowercased the path-derived side.

## Fix

In `src/core/markdown.ts` (`collectValidationErrors`), detect the case-only subcase (`declared.toLowerCase() === ctx.expectedSlug`) and emit a specific message:

```
Frontmatter slug "projects/README" differs from path-derived slug
"projects/readme" by case only (gbrain slugs are lowercase). Lowercase
the slug field, or remove it to let the path-derived default apply.
```

Any other mismatch falls back to the existing message — no behavior change for non-case diffs.

**Error code stays `SLUG_MISMATCH`** so:
- The lint rule map (`src/commands/lint.ts:45 SLUG_MISMATCH → 'frontmatter-slug-mismatch'`) is unchanged.
- The brain-writer auto-fix path (`src/core/brain-writer.ts:289-304`) that removes mismatched `slug:` fields still triggers on case-only mismatches.
- All existing consumers that test by code (`expect(...).toContain('SLUG_MISMATCH')`) keep working.

This is option (b) from the issue. Option (a) (auto-normalize the declared slug to lowercase) was deliberately not chosen because silently rewriting user input can mask legitimate typos and is harder to reverse than a clearer error.

## Test plan

`test/markdown-validation.test.ts` extends the existing `SLUG_MISMATCH` describe with two new tests:

- [x] **Case-only mismatch** — message contains `"by case only"`, `"gbrain slugs are lowercase"`, `"Lowercase the slug field"`, and both strings verbatim.
- [x] **Non-case mismatch** — message is the existing `... does not match ...` string verbatim and does NOT contain `"by case only"`.

```
27 pass / 0 fail in markdown-validation.test.ts
```

- [x] `bun run typecheck` clean
- [x] Adjacent test files unaffected — `brain-writer.test.ts`, `sync-failures.test.ts`, `import-resume.test.ts`, `markdown-validation.test.ts`: 115/115 pass

Diff: 2 files, +42 / -1.