### PR TITLE
fix(facts): cycle reconcile preserves cli-sourced facts (#1928)

### DIFF
--- a/src/core/cycle/extract-facts.ts
+++ b/src/core/cycle/extract-facts.ts
@@ -19,7 +19,12 @@
  * no fence go through delete-then-empty-insert — DB rows for that
  * page coordinate are wiped; legacy NULL-source_markdown_slug rows
  * survive because deleteFactsForPage targets source_markdown_slug =
- * slug only.
+ * slug only. #1928 — CLI-deposited rows (`source LIKE 'cli:%'`) also
+ * survive: `gbrain extract-conversation-facts` writes to transcript
+ * pages that carry no `## Facts` fence by design, so the wipe at the
+ * fence-reconcile coordinate must skip rows it doesn't own. The
+ * exclusion is passed at the call site via deleteFactsForPage's
+ * `excludeSourcePrefixes` option.
  *
  * Empty-fence guard (Codex R2-#7): the phase refuses to do its
  * destructive reconciliation pass when legacy rows (row_num IS NULL,
@@ -212,7 +217,14 @@ export async function runExtractFacts(
     // Wipe-and-reinsert per page. The deleteFactsForPage call targets
     // source_markdown_slug = slug only, so NULL-source_markdown_slug
     // legacy rows survive (the partial-UNIQUE-index keyspace).
-    const deleted = await engine.deleteFactsForPage(slug, sourceId);
+    // #1928: also exclude `cli:%`-sourced rows so out-of-band CLI deposits
+    // (e.g. `cli:extract-conversation-facts`, which write to conversation
+    // pages that carry no `## Facts` fence by design) survive the reconcile.
+    // Without this, a full-walk reconcile (which the cycle falls back to
+    // when sync fails — see cycle.ts) wipes every conversation-fact row.
+    const deleted = await engine.deleteFactsForPage(slug, sourceId, {
+      excludeSourcePrefixes: ['cli:'],
+    });
     result.factsDeleted += deleted.deleted;
 
     if (parsed.facts.length === 0) continue;

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1653,8 +1653,18 @@ export interface BrainEngine {
    * structural guarantee that legacy rows live in a different keyspace
    * until the v0_32_2 migration backfills them. Cycle-phase callers in
    * commit 7 add the empty-fence-guard as a belt-and-suspenders check.
+   *
+   * #1928 — `opts.excludeSourcePrefixes` skips rows whose `source` matches
+   * any of the given LIKE prefixes (each prefix is matched as `prefix%`).
+   * The cycle's `extract_facts` phase passes `['cli:']` so CLI-deposited
+   * rows (e.g. `cli:extract-conversation-facts`, which write to pages
+   * that have no `## Facts` fence by design) survive the fence reconcile.
    */
-  deleteFactsForPage(slug: string, source_id: string): Promise<{ deleted: number }>;
+  deleteFactsForPage(
+    slug: string,
+    source_id: string,
+    opts?: { excludeSourcePrefixes?: string[] },
+  ): Promise<{ deleted: number }>;
 
   /**
    * Mark a fact expired. Never DELETE. Returns true iff a row was updated.

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -3506,10 +3506,26 @@ export class PGLiteEngine implements BrainEngine {
     return { inserted: ids.length, ids };
   }
 
-  async deleteFactsForPage(slug: string, source_id: string): Promise<{ deleted: number }> {
+  async deleteFactsForPage(
+    slug: string,
+    source_id: string,
+    opts?: { excludeSourcePrefixes?: string[] },
+  ): Promise<{ deleted: number }> {
+    const prefixes = opts?.excludeSourcePrefixes ?? [];
+    if (prefixes.length === 0) {
+      const result = await this.db.query(
+        `DELETE FROM facts WHERE source_id = $1 AND source_markdown_slug = $2`,
+        [source_id, slug],
+      );
+      return { deleted: result.affectedRows ?? 0 };
+    }
+    // #1928: each prefix becomes 'prefix%' for LIKE.
+    const patterns = prefixes.map(p => p + '%');
     const result = await this.db.query(
-      `DELETE FROM facts WHERE source_id = $1 AND source_markdown_slug = $2`,
-      [source_id, slug],
+      `DELETE FROM facts
+         WHERE source_id = $1 AND source_markdown_slug = $2
+           AND NOT (source LIKE ANY($3::text[]))`,
+      [source_id, slug, patterns],
     );
     return { deleted: result.affectedRows ?? 0 };
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -3650,10 +3650,26 @@ export class PostgresEngine implements BrainEngine {
     return { inserted: ids.length, ids };
   }
 
-  async deleteFactsForPage(slug: string, source_id: string): Promise<{ deleted: number }> {
+  async deleteFactsForPage(
+    slug: string,
+    source_id: string,
+    opts?: { excludeSourcePrefixes?: string[] },
+  ): Promise<{ deleted: number }> {
     const sql = this.sql;
+    const prefixes = opts?.excludeSourcePrefixes ?? [];
+    if (prefixes.length === 0) {
+      const result = await sql`
+        DELETE FROM facts WHERE source_id = ${source_id} AND source_markdown_slug = ${slug}
+      `;
+      return { deleted: result.count ?? 0 };
+    }
+    // #1928: each prefix becomes 'prefix%' for LIKE.
+    const patterns = prefixes.map(p => p + '%');
     const result = await sql`
-      DELETE FROM facts WHERE source_id = ${source_id} AND source_markdown_slug = ${slug}
+      DELETE FROM facts
+      WHERE source_id = ${source_id}
+        AND source_markdown_slug = ${slug}
+        AND NOT (source LIKE ANY(${patterns}::text[]))
     `;
     return { deleted: result.count ?? 0 };
   }

--- a/test/extract-facts-phase.test.ts
+++ b/test/extract-facts-phase.test.ts
@@ -319,3 +319,152 @@ describe('runExtractFacts — empty-slugs guard (v0.36.x #1096 regression)', () 
     expect(r.pagesScanned).toBe(1);
   });
 });
+
+// #1928 — The cycle's wipe-and-reinsert is keyed on
+// (source_id, source_markdown_slug). CLI deposits (e.g. conversation-facts)
+// land on that exact coordinate but live OUTSIDE the fence — the
+// reconcile shouldn't touch them. Pre-fix: every cycle run that reached
+// a conversation page deleted every cli-sourced fact on it; combined
+// with the "failed-sync ⇒ full-walk fallback" in cycle.ts, one cycle
+// could wipe an entire conversation-facts backfill.
+describe('runExtractFacts — #1928 CLI-deposited facts survive the wipe', () => {
+  // CLI deposits stamp page-global row_num values; we use a high seed
+  // value so the fence reconcile (which numbers from 1) doesn't collide
+  // with the cli row on the partial-UNIQUE index over
+  // (source_id, source_markdown_slug, row_num).
+  let cliRowSeq = 100;
+  async function seedCliFact(slug: string, fact: string, sourceTag = 'cli:extract-conversation-facts'): Promise<void> {
+    const rowNum = cliRowSeq++;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
+                          valid_from, source, confidence, row_num, source_markdown_slug)
+       VALUES ('default', $1, $2, 'event', 'private', 'medium',
+               now(), $3, 1.0, $4, $1)`,
+      [slug, fact, sourceTag, rowNum],
+    );
+  }
+
+  test('CLI-sourced fact on a fenceless page survives the per-page reconcile', async () => {
+    // Conversation pages carry no `## Facts` fence by design.
+    await putPage('conversations/imessage/alice', '# iMessage: Alice\n\nplain transcript body, no fence here.\n');
+    await seedCliFact('conversations/imessage/alice', 'Alice started at Acme on 2024-03-16');
+
+    const r = await runExtractFacts(engine, { slugs: ['conversations/imessage/alice'] });
+
+    // Phase parses the page (no fence → 0 facts in fence, 0 inserted).
+    expect(r.pagesScanned).toBe(1);
+    expect(r.pagesWithFacts).toBe(0);
+    expect(r.factsInserted).toBe(0);
+    // And the cli row was NOT counted as deleted (the exclusion held).
+    expect(r.factsDeleted).toBe(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact, source FROM facts WHERE source_markdown_slug = 'conversations/imessage/alice'`,
+    );
+    expect(rows.rows).toHaveLength(1);
+    expect(rows.rows[0].fact).toBe('Alice started at Acme on 2024-03-16');
+    expect(rows.rows[0].source).toBe('cli:extract-conversation-facts');
+  });
+
+  test('full-walk fallback (no slugs) does not wipe CLI deposits across all pages', async () => {
+    // The "amplifier" scenario from the issue: cycle.ts falls back to a
+    // full-brain walk when sync fails; pre-fix every conversation page in
+    // the brain got its cli rows wiped in one shot.
+    await putPage('conversations/imessage/alice', '# iMessage: Alice\n\ntranscript a.\n');
+    await putPage('conversations/imessage/bob', '# iMessage: Bob\n\ntranscript b.\n');
+    await putPage('conversations/imessage/carol', '# iMessage: Carol\n\ntranscript c.\n');
+    await seedCliFact('conversations/imessage/alice', 'A1');
+    await seedCliFact('conversations/imessage/bob', 'B1');
+    await seedCliFact('conversations/imessage/carol', 'C1');
+
+    const r = await runExtractFacts(engine);  // full walk
+
+    expect(r.pagesScanned).toBeGreaterThanOrEqual(3);
+    expect(r.factsInserted).toBe(0);
+    expect(r.factsDeleted).toBe(0);  // not a single cli row deleted
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact FROM facts WHERE source LIKE 'cli:%' ORDER BY fact`,
+    );
+    expect(rows.rows.map((r: { fact: string }) => r.fact)).toEqual(['A1', 'B1', 'C1']);
+  });
+
+  test('non-cli rows on the same page coordinate ARE still wiped (reconcile semantics preserved)', async () => {
+    // A page that DOES have a fence — its fence-derived rows (source = 'sync:import' etc.)
+    // should still get the wipe-and-reinsert treatment. The cli exclusion is narrow.
+    await putPage('people/alice', FACT_FENCE(
+      `| 1 | New fence fact | fact | 1.0 | world | medium | 2026-01-01 |  | sync:import |  |`,
+    ));
+    // Seed a pre-existing fence-row (mimics what a previous reconcile left).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
+                          valid_from, source, confidence, row_num, source_markdown_slug)
+       VALUES ('default', 'people/alice', 'stale fence fact', 'fact', 'world', 'medium',
+               now(), 'sync:import', 1.0, 99, 'people/alice')`,
+    );
+    // And seed a cli row on the same coordinate.
+    await seedCliFact('people/alice', 'cli fact that must survive');
+
+    await runExtractFacts(engine, { slugs: ['people/alice'] });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows = await (engine as any).db.query(
+      `SELECT fact, source FROM facts WHERE source_markdown_slug = 'people/alice' ORDER BY fact`,
+    );
+    const facts = rows.rows.map((r: { fact: string; source: string }) => ({ fact: r.fact, source: r.source }));
+    // Stale fence row gone, new fence row in, cli row survives.
+    expect(facts).toEqual([
+      { fact: 'New fence fact', source: 'sync:import' },
+      { fact: 'cli fact that must survive', source: 'cli:extract-conversation-facts' },
+    ]);
+  });
+
+  test('engine.deleteFactsForPage honors excludeSourcePrefixes directly (engine-level pin)', async () => {
+    await seedCliFact('engine-pin/page', 'cli row', 'cli:extract-conversation-facts');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
+                          valid_from, source, confidence, row_num, source_markdown_slug)
+       VALUES ('default', 'engine-pin/page', 'fence row', 'fact', 'world', 'medium',
+               now(), 'sync:import', 1.0, 1, 'engine-pin/page')`,
+    );
+
+    const result = await engine.deleteFactsForPage('engine-pin/page', 'default', {
+      excludeSourcePrefixes: ['cli:'],
+    });
+    // 1 deleted: the sync:import fence row.
+    // 1 survives: the cli row.
+    expect(result.deleted).toBe(1);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const survivors = await (engine as any).db.query(
+      `SELECT fact, source FROM facts WHERE source_markdown_slug = 'engine-pin/page'`,
+    );
+    expect(survivors.rows).toHaveLength(1);
+    expect(survivors.rows[0].fact).toBe('cli row');
+  });
+
+  test('engine.deleteFactsForPage with no excludeSourcePrefixes deletes every page-coord row (back-compat)', async () => {
+    await seedCliFact('compat/page', 'cli row');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (engine as any).db.query(
+      `INSERT INTO facts (source_id, entity_slug, fact, kind, visibility, notability,
+                          valid_from, source, confidence, row_num, source_markdown_slug)
+       VALUES ('default', 'compat/page', 'fence row', 'fact', 'world', 'medium',
+               now(), 'sync:import', 1.0, 1, 'compat/page')`,
+    );
+
+    const result = await engine.deleteFactsForPage('compat/page', 'default');
+    expect(result.deleted).toBe(2);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const survivors = await (engine as any).db.query(
+      `SELECT COUNT(*) AS n FROM facts WHERE source_markdown_slug = 'compat/page'`,
+    );
+    expect(Number(survivors.rows[0].n)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1928. **Data-loss class bug** per the issue (one cycle wiped 1829 conversation-facts rows in the reporter's brain).

The `extract_facts` cycle phase wiped every fact row on each reconciled page's `(source_id, source_markdown_slug)` coordinate. CLI deposits — notably `gbrain extract-conversation-facts`, which writes rows with `source LIKE 'cli:extract-conversation-facts%'` against transcript pages that carry **no `## Facts` fence by design** — live on that exact coordinate. So a reconcile for a transcript page was: delete every fact, reinsert nothing.

Combined with the failed-sync ⇒ full-walk fallback in `cycle.ts` (`syncPagesAffected = undefined` → walk every page), one autopilot cycle could wipe an entire conversation-facts backfill while reporting `status: 'ok'` and `0 fact(s) reconciled across N page(s)`.

## Fix

Add an optional `excludeSourcePrefixes` option to `deleteFactsForPage`. The cycle phase passes `['cli:']` so CLI-deposited rows survive the wipe.

### Files

- `src/core/engine.ts` — interface: optional `opts?: { excludeSourcePrefixes?: string[] }` on `deleteFactsForPage`. JSDoc updated.
- `src/core/postgres-engine.ts` + `src/core/pglite-engine.ts` — engine parity. Both implementations short-circuit to the existing single-statement DELETE when no prefixes are passed (back-compat) and add `AND NOT (source LIKE ANY($N::text[]))` when prefixes are present.
- `src/core/cycle/extract-facts.ts` — call site passes `excludeSourcePrefixes: ['cli:']`. File header updated to document the exclusion.

The reporter's suggested-fix paragraph from the issue mentions running this exact call-site guard locally and confirming fence reconciliation still byte-matches.

## Non-goals (issue's "secondary hardening" — not in this PR)

The issue suggests two additional hardenings worth considering separately:

1. **Destructive phase shouldn't inherit the "failed-sync ⇒ full-walk" fallback.** That's a `cycle.ts` change at a different layer and worth its own PR — the fix here makes the data loss impossible regardless of whether the fallback runs, so it's strictly additive.
2. **`factsDeleted >> factsInserted` should `warn` status.** Useful canary, but signal-only — also strictly additive on top of this fix.

Kept the scope tight to the data-loss fix; happy to follow up on either if you'd like.

## Test plan

`test/extract-facts-phase.test.ts` gains a new `#1928 CLI-deposited facts survive the wipe` describe with five tests:

- [x] CLI-sourced fact on a fenceless page survives slug-scoped reconcile (`factsDeleted: 0`)
- [x] Full-walk fallback (no `slugs` filter) does NOT wipe CLI deposits brain-wide (the "amplifier" scenario from the issue)
- [x] Non-cli rows on the same `(source_id, source_markdown_slug)` coordinate ARE still wiped (reconcile semantics preserved for `sync:import` / `mcp:put_page` fence rows)
- [x] Engine-level pin: `deleteFactsForPage` honors the option directly (1 deleted, 1 cli row survives)
- [x] Back-compat: no opts deletes every coordinate row (pre-#1928 behavior unchanged)

Result:

```
18 pass / 0 fail in extract-facts-phase.test.ts
96 pass / 0 fail across extract-facts-phase, insert-facts-batch, phantom-redirect, extract-conversation-facts
```

- [x] `bun run typecheck` clean

Diff: 5 files, +211 / -8.