### PR TITLE
fix(dream): persist oversize-after-split skip to dream_verdicts (#1879)

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -240,6 +240,13 @@ export interface GBrainConfig {
       verdict_model?: string;
       max_prompt_tokens?: number;
       max_chunks_per_transcript?: number;
+      /**
+       * #1879 — when true (default), the oversize_after_split skip in the
+       * synthesize phase persists to `dream_verdicts` so subsequent runs
+       * short-circuit on the cached verdict instead of re-chunking and
+       * burning per-chunk subagent timeouts every cycle.
+       */
+      persist_oversize_skip?: boolean;
     };
     patterns?: {
       lookback_days?: number;
@@ -623,6 +630,7 @@ export async function loadConfigWithEngine(
   const dbVerdictModel = await dbStr('dream.synthesize.verdict_model');
   const dbMaxPromptTokens = await dbInt('dream.synthesize.max_prompt_tokens');
   const dbMaxChunksPerTranscript = await dbInt('dream.synthesize.max_chunks_per_transcript');
+  const dbPersistOversizeSkip = await dbBool('dream.synthesize.persist_oversize_skip');
   const dbLookbackDays = await dbInt('dream.patterns.lookback_days');
   const dbMinEvidence = await dbInt('dream.patterns.min_evidence');
 
@@ -646,6 +654,9 @@ export async function loadConfigWithEngine(
   }
   if (mergedSynth.max_chunks_per_transcript === undefined && dbMaxChunksPerTranscript !== undefined) {
     mergedSynth.max_chunks_per_transcript = dbMaxChunksPerTranscript;
+  }
+  if (mergedSynth.persist_oversize_skip === undefined && dbPersistOversizeSkip !== undefined) {
+    mergedSynth.persist_oversize_skip = dbPersistOversizeSkip;
   }
   if (mergedPatterns.lookback_days === undefined && dbLookbackDays !== undefined) {
     mergedPatterns.lookback_days = dbLookbackDays;
@@ -751,6 +762,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'dream.synthesize.verdict_model',
   'dream.synthesize.max_prompt_tokens',
   'dream.synthesize.max_chunks_per_transcript',
+  'dream.synthesize.persist_oversize_skip',
   'dream.patterns.lookback_days',
   'dream.patterns.min_evidence',
   // Emotional weight (v0.29)

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -431,19 +431,32 @@ export async function runPhaseSynthesize(
 
       const chunks = splitTranscriptByBudget(t.content, t.contentHash, maxCharsPerChunk);
 
-      // D5 cap hit: log + skip; do NOT write to dream_verdicts. Closes the
-      // poison-pill class — next cycle re-attempts under whatever budget
-      // is then current.
+      // D5 cap hit: log + skip. #1879: under `persistOversizeSkip` (default
+      // true), also write the skip to `dream_verdicts` so subsequent cycles
+      // short-circuit on the cached verdict instead of re-chunking the same
+      // oversize transcript and burning per-chunk subagent timeouts on every
+      // run. The content_hash key means an edited transcript gets a fresh
+      // verdict; operators can opt out with
+      // `dream.synthesize.persist_oversize_skip=false`.
       if (chunks.length > config.maxChunksPerTranscript) {
+        const reason = `oversize_after_split: ${chunks.length}/${config.maxChunksPerTranscript}`;
         process.stderr.write(
           `[dream] transcript ${t.basename} produced ${chunks.length} chunks at ` +
           `${maxCharsPerChunk}-char budget (cap=${config.maxChunksPerTranscript}); skipping. ` +
           `Increase dream.synthesize.max_chunks_per_transcript or use a larger-context model.\n`,
         );
-        skipReports.push({
-          filePath: t.filePath,
-          reason: `oversize_after_split: ${chunks.length}/${config.maxChunksPerTranscript}`,
-        });
+        if (config.persistOversizeSkip) {
+          await engine.putDreamVerdict(t.filePath, t.contentHash, {
+            worth_processing: false,
+            reasons: [reason],
+          });
+          process.stderr.write(
+            `[dream] persisted oversize skip to dream_verdicts (content_hash=${t.contentHash.slice(0, 12)}); ` +
+            `set dream.synthesize.persist_oversize_skip=false to re-evaluate every cycle, or ` +
+            `edit the transcript (changes content_hash) to retry.\n`,
+          );
+        }
+        skipReports.push({ filePath: t.filePath, reason });
         continue;
       }
 
@@ -588,11 +601,27 @@ interface SynthConfig {
   maxPromptTokens: number | null;
   /**
    * D5/D10: Cap on chunks produced from a single transcript. On cap hit, the
-   * transcript is logged + skipped (NOT cached in dream_verdicts — closes the
-   * cache-poisoning class). Operator override:
+   * transcript is logged + skipped. Operator override:
    * `dream.synthesize.max_chunks_per_transcript`.
+   *
+   * #1879 — when the cap fires, also write a `worth_processing: false` row
+   * to `dream_verdicts` under `persistOversizeSkip` (default true) so the
+   * NEXT cycle short-circuits on the cached verdict instead of re-chunking
+   * the same oversize transcript and burning subagent timeouts on every
+   * run. The content_hash key means an edited transcript gets a fresh
+   * verdict. Operators who want the legacy "no cache write" behavior
+   * (re-evaluate every cycle under a possibly-different budget) can set
+   * `dream.synthesize.persist_oversize_skip=false`.
    */
   maxChunksPerTranscript: number;
+  /**
+   * #1879 — when true (default), the oversize_after_split skip persists a
+   * `worth_processing: false` row to `dream_verdicts`. Subsequent runs hit
+   * the verdict cache for the same `(file_path, content_hash)` and skip
+   * before chunking, so a 5MB transcript can't burn cost every night.
+   * Operator override: `dream.synthesize.persist_oversize_skip`.
+   */
+  persistOversizeSkip: boolean;
 }
 
 async function loadSynthConfig(engine: BrainEngine): Promise<SynthConfig> {
@@ -621,6 +650,10 @@ async function loadSynthConfig(engine: BrainEngine): Promise<SynthConfig> {
   const cooldownHoursStr = await engine.getConfig('dream.synthesize.cooldown_hours');
   const maxPromptTokensStr = await engine.getConfig('dream.synthesize.max_prompt_tokens');
   const maxChunksStr = await engine.getConfig('dream.synthesize.max_chunks_per_transcript');
+  // #1879: default true — cost protection wins by default. Explicit
+  // 'false' restores the pre-fix re-evaluate-every-cycle behavior.
+  const persistOversizeSkipStr = await engine.getConfig('dream.synthesize.persist_oversize_skip');
+  const persistOversizeSkip = persistOversizeSkipStr !== 'false';
 
   let excludePatterns: string[] = ['medical', 'therapy'];
   if (excludeStr) {
@@ -658,6 +691,7 @@ async function loadSynthConfig(engine: BrainEngine): Promise<SynthConfig> {
     cooldownHours: cooldownHoursStr ? Math.max(0, parseInt(cooldownHoursStr, 10) || 12) : 12,
     maxPromptTokens,
     maxChunksPerTranscript,
+    persistOversizeSkip,
   };
 }
 

--- a/test/e2e/dream-synthesize-chunking.test.ts
+++ b/test/e2e/dream-synthesize-chunking.test.ts
@@ -114,7 +114,14 @@ function corpusPath(corpusDir: string, basename: string): string {
 }
 
 describe('E2E synthesize chunking — D5 cap hit', () => {
-  test('chunks > max_chunks_per_transcript → skipped with no jobs and no verdict-cache write', async () => {
+  // #1879: under the new default (`dream.synthesize.persist_oversize_skip`
+  // = true), the oversize_after_split skip persists a
+  // `worth_processing: false` row to `dream_verdicts`, so the NEXT cycle
+  // hits the cache and skips before chunking + per-chunk subagent timeouts.
+  // The reporter's repro: a 5MB transcript times out every night, paying
+  // for the ingested input each time, because the same (file_path,
+  // content_hash) was retried unbounded.
+  test('chunks > max_chunks_per_transcript → skipped + skip persisted to dream_verdicts (#1879)', async () => {
     const rig = await setupRig();
     try {
       // Tiny chunk budget (forces N chunks) + tiny cap (forces cap hit).
@@ -131,7 +138,7 @@ describe('E2E synthesize chunking — D5 cap hit', () => {
       const filePath = corpusPath(rig.corpusDir, basename);
       const content = 'fat transcript line\n'.repeat(75_000); // ~1.5M chars
       writeFileSync(filePath, content);
-      await seedVerdict(rig.engine, filePath, content);
+      const contentHash = await seedVerdict(rig.engine, filePath, content);
 
       await withoutAnthropicKey(async () => {
         const result = await runPhaseSynthesize(rig.engine, {
@@ -156,16 +163,131 @@ describe('E2E synthesize chunking — D5 cap hit', () => {
       );
       expect(Number(jobs[0].cnt)).toBe(0);
 
-      // D5: dream_verdicts NOT written for the cap-hit path.
-      // Verify by re-reading the verdict — our seeded row is the ONLY entry.
-      const verdicts = await rig.engine.executeRaw<{ cnt: string | number }>(
-        `SELECT count(*) AS cnt FROM dream_verdicts`,
-      );
-      expect(Number(verdicts[0].cnt)).toBe(1); // only the seed; no cap-hit row added
+      // #1879: the seeded `worth_processing: true` verdict is OVERWRITTEN
+      // by the oversize_after_split persist (same (file_path, content_hash)
+      // key → upsert). The verdict row flips so the next cycle short-
+      // circuits before chunking. Reasons surface the cap-hit so an
+      // operator inspecting the table can see why.
+      const verdict = await rig.engine.getDreamVerdict(filePath, contentHash);
+      expect(verdict).not.toBeNull();
+      expect(verdict!.worth_processing).toBe(false);
+      expect(verdict!.reasons.some(r => /oversize_after_split/.test(r))).toBe(true);
     } finally {
       await rig.cleanup();
     }
   }, 30_000);
+
+  // #1879 escape hatch: operators who prefer the pre-fix "re-evaluate on
+  // every cycle under a possibly-different budget" behavior set the flag
+  // to false. Pin that path so a future change doesn't silently drop it.
+  test('persist_oversize_skip=false: legacy behavior — skip NOT cached so next cycle re-evaluates', async () => {
+    const rig = await setupRig();
+    try {
+      await rig.engine.setConfig('dream.synthesize.enabled', 'true');
+      await rig.engine.setConfig('dream.synthesize.session_corpus_dir', rig.corpusDir);
+      await rig.engine.setConfig('dream.synthesize.max_prompt_tokens', '100000');
+      await rig.engine.setConfig('dream.synthesize.max_chunks_per_transcript', '2');
+      // Opt out: keep the legacy "no cache write" behavior.
+      await rig.engine.setConfig('dream.synthesize.persist_oversize_skip', 'false');
+
+      const basename = '2026-05-08-fat-transcript-optout.txt';
+      const filePath = corpusPath(rig.corpusDir, basename);
+      const content = 'fat transcript line\n'.repeat(75_000);
+      writeFileSync(filePath, content);
+      const contentHash = await seedVerdict(rig.engine, filePath, content);
+
+      await withoutAnthropicKey(async () => {
+        const result = await runPhaseSynthesize(rig.engine, {
+          brainDir: rig.brainDir,
+          dryRun: false,
+        });
+        expect(result.status).toBe('ok');
+        const details = result.details as {
+          skips: Array<{ filePath: string; reason: string }>;
+        };
+        expect(details.skips[0].reason).toMatch(/oversize_after_split/);
+      });
+
+      // Verdict cache untouched — the original `worth_processing: true`
+      // seed survives, so a re-run under a different budget can still
+      // attempt synthesis (the poison-pill protection the original
+      // comment cited).
+      const verdict = await rig.engine.getDreamVerdict(filePath, contentHash);
+      expect(verdict).not.toBeNull();
+      expect(verdict!.worth_processing).toBe(true);
+    } finally {
+      await rig.cleanup();
+    }
+  }, 30_000);
+
+  // #1879 follow-through: after the persist, a SUBSEQUENT cycle short-
+  // circuits at the verdict-cache check (line ~333 in synthesize.ts) —
+  // the transcript is never chunked or dispatched, and zero subagent jobs
+  // get submitted. This is the actual cost-savings path the issue asks
+  // for.
+  test('after persist, the next cycle short-circuits on cached verdict (no chunking, no jobs)', async () => {
+    const rig = await setupRig();
+    try {
+      await rig.engine.setConfig('dream.synthesize.enabled', 'true');
+      await rig.engine.setConfig('dream.synthesize.session_corpus_dir', rig.corpusDir);
+      await rig.engine.setConfig('dream.synthesize.max_prompt_tokens', '100000');
+      await rig.engine.setConfig('dream.synthesize.max_chunks_per_transcript', '2');
+      // persist defaults to true.
+
+      const basename = '2026-05-08-fat-transcript-twice.txt';
+      const filePath = corpusPath(rig.corpusDir, basename);
+      const content = 'fat transcript line\n'.repeat(75_000);
+      writeFileSync(filePath, content);
+      await seedVerdict(rig.engine, filePath, content);
+
+      // First run: persist fires.
+      await withoutAnthropicKey(async () => {
+        await runPhaseSynthesize(rig.engine, { brainDir: rig.brainDir, dryRun: false });
+      });
+
+      // Second run: cooldown is a separate timestamp from the verdict cache.
+      // To force a fresh evaluation cycle, clear the cooldown timestamp the
+      // first run wrote. (`cooldown_hours = 0` is rejected by the config
+      // parser's `|| 12` fallback; clearing the timestamp is the working
+      // bypass.)
+      await rig.engine.executeRaw(
+        `DELETE FROM config WHERE key = 'dream.synthesize.last_completion_ts'`,
+      );
+
+      await withoutAnthropicKey(async () => {
+        const result = await runPhaseSynthesize(rig.engine, {
+          brainDir: rig.brainDir,
+          dryRun: false,
+        });
+        expect(result.status).toBe('ok');
+        // Phase early-returns on `worthProcessing.length === 0` (every
+        // transcript ruled out by cached verdict), so the result.details
+        // shape here is the "all transcripts skipped by significance
+        // filter" branch: { transcripts_discovered, transcripts_processed,
+        // pages_written, verdicts }. No `children_submitted` field — we
+        // never reached the fan-out site.
+        const details = result.details as {
+          transcripts_processed: number;
+          pages_written: number;
+          verdicts?: Array<{ filePath: string; worth: boolean; cached: boolean }>;
+        };
+        expect(details.transcripts_processed).toBe(0);
+        expect(details.pages_written).toBe(0);
+        const cachedNegative = (details.verdicts ?? []).find(v => v.filePath === filePath);
+        expect(cachedNegative).toBeDefined();
+        expect(cachedNegative!.worth).toBe(false);
+        expect(cachedNegative!.cached).toBe(true);
+      });
+
+      // No subagent jobs submitted across both runs.
+      const jobs = await rig.engine.executeRaw<{ cnt: string | number }>(
+        `SELECT count(*) AS cnt FROM minion_jobs WHERE name = 'subagent'`,
+      );
+      expect(Number(jobs[0].cnt)).toBe(0);
+    } finally {
+      await rig.cleanup();
+    }
+  }, 45_000);
 });
 
 describe('E2E synthesize chunking — D8 legacy single-chunk migration', () => {


### PR DESCRIPTION
## Summary

Closes #1879.

The synthesize phase's `chunks > max_chunks_per_transcript` skip (`oversize_after_split`) was logged + tracked in `skipReports`, but deliberately NOT cached in `dream_verdicts`. The original SynthConfig comment cited the *"poison-pill class"*: next cycle should re-attempt under whatever budget is then current.

In practice that means the same oversize transcript gets re-chunked and re-dispatched every cycle. Each per-chunk subagent (Sonnet, 30-min timeout, 30 turns) burns input tokens. **Timed-out children are not recorded in `subagent_messages`**, so the spend doesn't show up in `minion_budget_log` / `budget_ledger` — the recurring cost is invisible in gbrain's own accounting; you only see it on the provider bill. That's the issue's actual complaint.

## Fix

Add `dream.synthesize.persist_oversize_skip` config (default **true**). When the cap fires, also write a `worth_processing: false` row to `dream_verdicts` with reasons `['oversize_after_split: N/cap=M']`. The next cycle's verdict-cache check short-circuits **before** chunking + fan-out: zero subagent jobs submitted, zero recurring cost.

The cache key is `(file_path, content_hash)` — an edited transcript changes the hash and gets re-evaluated naturally. Operators who want the legacy "re-evaluate every cycle under possibly-different budget" behavior can opt out:

```sh
gbrain config set dream.synthesize.persist_oversize_skip false
```

When the persist fires, stderr also prints a one-liner pointing at the opt-out + the content-edit retry path, so the behavior is discoverable.

### Files
- `src/core/cycle/synthesize.ts` — new `SynthConfig.persistOversizeSkip` field, read from config, branched at the skip site. Existing `skipReports` push is unchanged.
- `src/core/config.ts` — TypeScript type field, DB-plane merge, canonical key list.
- `test/e2e/dream-synthesize-chunking.test.ts` — tests updated + extended (see below).

## Test plan

`test/e2e/dream-synthesize-chunking.test.ts` — 3 tests under the existing `D5 cap hit` describe:

- [x] **New default behavior** — `chunks > max_chunks_per_transcript` upserts the verdict row to `worth_processing: false` with reasons including `oversize_after_split`. Updated from the old "no verdict-cache write" assertion.
- [x] **Legacy escape hatch** — with `persist_oversize_skip=false`, the verdict cache is untouched (the seeded `worth_processing: true` row survives the cycle). Pins the opt-out path so future work doesn't silently drop it.
- [x] **Follow-through** — after the persist, the **subsequent** cycle short-circuits at the verdict-cache check: `transcripts_processed: 0`, zero subagent jobs submitted, no fan-out. This is the actual cost-savings path.

```
6 pass / 0 fail in dream-synthesize-chunking.test.ts
94 pass / 0 fail across cycle-synthesize{,-chunker,-slug-collection}, loadConfig-merge, e2e dream-synthesize-chunking
```

- [x] `bun run typecheck` clean

## Non-goals

The issue mentions two related shapes left out of this PR:

1. **Map-reduce / per-chunk merge** for oversized transcripts so large inputs still produce pages. Bigger architectural change — worth its own PR.
2. **`gbrain dream --phase synthesize --input <file> --bypass-verdict-cache`** flag for operators who want to retry a locked-out transcript without editing it or deleting the verdict row. The existing `--input` already bypasses cooldown; a parallel verdict-cache bypass would be the natural follow-up. Also out of scope here.

The fix here stops the cost recurrence; the follow-ups expand what's recoverable. Happy to do either if you'd like.

Diff: 3 files, +185 / -17.