### PR TITLE
Make propose_takes resilient to missing Anthropic key

### DIFF
--- a/src/core/cycle/propose-takes.ts
+++ b/src/core/cycle/propose-takes.ts
@@ -40,10 +40,10 @@
 import { randomUUID, createHash } from 'node:crypto';
 import { BaseCyclePhase, type ScopedReadOpts, type BasePhaseOpts } from './base-phase.ts';
 import { chat as gatewayChat } from '../ai/gateway.ts';
+import { hasAnthropicKey } from '../ai/anthropic-key.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { GBrainError } from '../types.ts';
-import type { Page, PageFilters } from '../types.ts';
 import type { OperationContext } from '../operations.ts';
 import type { BrainEngine } from '../engine.ts';
 import type { PhaseStatus, CyclePhase } from '../cycle.ts';
@@ -156,6 +156,12 @@ export interface ProposeTakesResult {
   warnings: string[];
 }
 
+interface ProposeTakesPage {
+  slug: string;
+  source_id: string;
+  compiled_truth: string | null;
+}
+
 /**
  * Compute the content_hash key for the idempotency cache. SHA-256 of the
  * page body suffices — page slug + prompt_version are separate columns in
@@ -208,6 +214,43 @@ export function extractExistingTakesForDedup(pageBody: string): Array<{
     });
   }
   return rows;
+}
+
+function modelNeedsAnthropicKey(model?: string): boolean {
+  if (!model) return true;
+  const normalized = model.toLowerCase();
+  return normalized.startsWith('anthropic:') ||
+    normalized.startsWith('claude') ||
+    normalized === 'sonnet' ||
+    normalized === 'haiku' ||
+    normalized === 'opus';
+}
+
+async function listProposeTakesPages(
+  engine: BrainEngine,
+  scope: ScopedReadOpts,
+  limit: number,
+): Promise<ProposeTakesPage[]> {
+  const where = ['deleted_at IS NULL'];
+  const params: unknown[] = [];
+
+  if (scope.sourceIds && scope.sourceIds.length > 0) {
+    params.push(scope.sourceIds);
+    where.push(`source_id = ANY($${params.length}::text[])`);
+  } else if (scope.sourceId) {
+    params.push(scope.sourceId);
+    where.push(`source_id = $${params.length}`);
+  }
+
+  params.push(limit);
+  return await engine.executeRaw<ProposeTakesPage>(
+    `SELECT slug, source_id, compiled_truth
+     FROM pages
+     WHERE ${where.join(' AND ')}
+     ORDER BY updated_at DESC, id DESC
+     LIMIT $${params.length}`,
+    params,
+  );
 }
 
 /**
@@ -309,6 +352,24 @@ class ProposeTakesPhase extends BaseCyclePhase {
     const skipPagesWithFence = opts.skipPagesWithFence ?? false;
     const proposalRunId = `propose-${new Date().toISOString().slice(0, 19).replace(/[-:T]/g, '')}-${randomUUID().slice(0, 8)}`;
 
+    if (!opts.extractor && modelNeedsAnthropicKey(opts.model) && !hasAnthropicKey()) {
+      return {
+        summary: 'propose_takes skipped: ANTHROPIC_API_KEY is unset',
+        details: {
+          reason: 'no_api_key',
+          pages_scanned: 0,
+          cache_hits: 0,
+          cache_misses: 0,
+          proposals_inserted: 0,
+          budget_exhausted: false,
+          warnings: [],
+          model: opts.model ?? 'claude-sonnet-4-6',
+          prompt_version: promptVersion,
+        },
+        status: 'skipped',
+      };
+    }
+
     const result: ProposeTakesResult = {
       pages_scanned: 0,
       cache_hits: 0,
@@ -318,13 +379,10 @@ class ProposeTakesPhase extends BaseCyclePhase {
       warnings: [],
     };
 
-    // Load pages eligible for proposal. Source-scoped per BaseCyclePhase.
-    const pageFilters: PageFilters = {
-      ...scope,
-      limit: pageLimit,
-      sort: 'updated_desc',
-    };
-    const pages: Page[] = await engine.listPages(pageFilters);
+    // Load only the columns this phase uses. This avoids pulling unrelated
+    // large/toasted page columns into the hot path and makes propose_takes
+    // resilient to corruption in non-essential projections.
+    const pages = await listProposeTakesPages(engine, scope, pageLimit);
 
     if (opts.reporter) {
       opts.reporter.start('propose_takes.pages' as never, pages.length);
@@ -471,4 +529,6 @@ export const __testing = {
   contentHash,
   hasCompleteFence,
   extractExistingTakesForDedup,
+  modelNeedsAnthropicKey,
+  listProposeTakesPages,
 };

--- a/test/propose-takes.test.ts
+++ b/test/propose-takes.test.ts
@@ -15,6 +15,9 @@
  */
 
 import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   runPhaseProposeTakes,
   parseExtractorOutput,
@@ -22,6 +25,7 @@ import {
   hasCompleteFence,
   extractExistingTakesForDedup,
   PROPOSE_TAKES_PROMPT_VERSION,
+  __testing,
   type ProposeTakesExtractor,
   type ProposedTake,
 } from '../src/core/cycle/propose-takes.ts';
@@ -45,11 +49,18 @@ function buildMockEngine(opts: {
 
   const engine = {
     kind: 'pglite',
-    async listPages() {
+    async listPages(): Promise<Page[]> {
       return opts.pages;
     },
     async executeRaw<T>(sql: string, params?: unknown[]): Promise<T[]> {
       captured.push({ sql, params: params ?? [] });
+      if (sql.includes('SELECT slug, source_id, compiled_truth')) {
+        return opts.pages.map((p) => ({
+          slug: p.slug,
+          source_id: p.source_id,
+          compiled_truth: p.compiled_truth,
+        })) as T[];
+      }
       // SELECT idempotency check
       if (sql.includes('SELECT id FROM take_proposals')) {
         const [sourceId, slug, ch, pv] = params ?? [];
@@ -243,6 +254,39 @@ describe('extractExistingTakesForDedup', () => {
 // ─── Phase integration ──────────────────────────────────────────────
 
 describe('runPhaseProposeTakes — phase integration', () => {
+  test('default extractor skips cleanly when Anthropic is not configured', async () => {
+    const oldHome = process.env.GBRAIN_HOME;
+    const oldKey = process.env.ANTHROPIC_API_KEY;
+    const tempHome = mkdtempSync(join(tmpdir(), 'gbrain-propose-no-key-'));
+    process.env.GBRAIN_HOME = tempHome;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      const { engine, captured } = buildMockEngine({
+        pages: [buildPage({ slug: 'wiki/a', body: 'claim-ish prose' })],
+      });
+      const result = await runPhaseProposeTakes(buildCtx(engine));
+
+      expect(result.status).toBe('skipped');
+      expect(result.summary).toContain('ANTHROPIC_API_KEY is unset');
+      expect((result.details as Record<string, unknown>).reason).toBe('no_api_key');
+      expect(captured).toHaveLength(0);
+    } finally {
+      if (oldHome === undefined) delete process.env.GBRAIN_HOME;
+      else process.env.GBRAIN_HOME = oldHome;
+      if (oldKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = oldKey;
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test('modelNeedsAnthropicKey preserves explicit non-Anthropic model overrides', () => {
+    expect(__testing.modelNeedsAnthropicKey()).toBe(true);
+    expect(__testing.modelNeedsAnthropicKey('claude-sonnet-4-6')).toBe(true);
+    expect(__testing.modelNeedsAnthropicKey('anthropic:claude-sonnet-4-6')).toBe(true);
+    expect(__testing.modelNeedsAnthropicKey('sonnet')).toBe(true);
+    expect(__testing.modelNeedsAnthropicKey('openai:gpt-5.2')).toBe(false);
+  });
+
   test('happy path: scans pages, extracts proposals, writes via INSERT', async () => {
     const pages = [buildPage({ slug: 'wiki/concepts/network-effects', body: 'Marketplaces with cold-start liquidity always win.' })];
     const { engine, captured } = buildMockEngine({ pages });
@@ -383,5 +427,17 @@ New prose appended here.`;
     expect(runIdA).toBe(runIdB);
     expect(typeof runIdA).toBe('string');
     expect((runIdA as string).startsWith('propose-')).toBe(true);
+  });
+
+  test('loads proposal candidates with a narrow page projection', async () => {
+    const pages = [buildPage({ slug: 'wiki/narrow', body: 'A narrow projection avoids unrelated page columns.' })];
+    const { engine, captured } = buildMockEngine({ pages });
+    const extractor: ProposeTakesExtractor = async () => [];
+    await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    const pageSelect = captured.find(c => c.sql.includes('FROM pages'));
+    expect(pageSelect?.sql).toContain('SELECT slug, source_id, compiled_truth');
+    expect(pageSelect?.sql).not.toContain('SELECT p.*');
+    expect(pageSelect?.sql).not.toContain('search_vector');
   });
 });


### PR DESCRIPTION
## Summary

This makes the `propose_takes` dream phase fail softer in two operationally common cases:

- If the phase would use its default Anthropic/Claude extractor and no Anthropic key is configured, it now returns `status: "skipped"` with `reason: "no_api_key"` before reading pages or calling the gateway.
- The phase now loads proposal candidates through a narrow page projection (`slug`, `source_id`, `compiled_truth`) instead of `listPages()` / `SELECT p.*`.

## Why

A local PGLite brain with corruption in an unrelated toasted `pages` column caused `gbrain dream --phase propose_takes` to crash before the phase could do useful work. Separately, when no Anthropic key is configured, the phase currently emits one extractor warning per page. Other dream phases already cheap-skip when Anthropic is unavailable; this gives `propose_takes` the same operator-friendly behavior.

The narrow projection does not fix corrupted storage, but it reduces the blast radius: `propose_takes` only needs slug/source/body, so it should not pull unrelated page columns into the hot path.

## Tests

- `bun test test/propose-takes.test.ts`
- `bun run typecheck`
