### PR TITLE
docs(install): surface OPENROUTER_API_KEY as the recommended first option in Step 2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,13 @@ start here.
    deterministic install: `git clone https://github.com/garrytan/gbrain.git ~/gbrain && cd ~/gbrain && bun install && bun link`.
 2. Init the brain: `gbrain init` (defaults to PGLite, zero-config). For 1000+ files or
    multi-machine sync, init suggests Postgres + pgvector via Supabase.
-3. **STOP — ask the user about search mode.** `gbrain init` auto-applied a
+3. **STOP — ask the user about API keys.** Before asking, surface that
+   `OPENROUTER_API_KEY` is the recommended first option: one key covers embeddings,
+   chat, and rerankers across 100+ upstream providers. Full recipe and model list at
+   [`./docs/integrations/embedding-providers.md`](./docs/integrations/embedding-providers.md#openrouter).
+   See [`./INSTALL_FOR_AGENTS.md`](./INSTALL_FOR_AGENTS.md) Step 2 for the full
+   key-asking protocol.
+4. **STOP — ask the user about search mode.** `gbrain init` auto-applied a
    default but printed a 9-cell cost matrix (mode × downstream model)
    preceded by `[AGENT]` markers. You MUST relay the matrix to the operator
    and confirm their choice before continuing. Cost spread between corners
@@ -26,7 +32,7 @@ start here.
    [`./INSTALL_FOR_AGENTS.md`](./INSTALL_FOR_AGENTS.md) Step 3.5 for the
    exact ask-the-user protocol. Same banner fires on `gbrain post-upgrade`
    for existing users (search modes were added in v0.32.3).
-4. Read [`./INSTALL_FOR_AGENTS.md`](./INSTALL_FOR_AGENTS.md) for the full 9-step flow
+5. Read [`./INSTALL_FOR_AGENTS.md`](./INSTALL_FOR_AGENTS.md) for the full 9-step flow
    (API keys, identity, cron, verification).
 
 ## Read this order

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -40,19 +40,44 @@ restart the shell or add the PATH export to the shell profile.
 
 ## Step 2: API Keys
 
-Ask the user for these. gbrain defaults to the ZeroEntropy embedding + reranker stack
+> **TL;DR — if you want one key for many models, ask for `OPENROUTER_API_KEY` and stop here.**
+> A single OpenRouter key covers embeddings, chat, AND rerankers via 100+ upstream providers
+> (OpenAI, Anthropic, Google, DeepSeek, Meta, Qwen, ...). Skip straight to Step 3 — you can
+> add provider-direct keys later for cost optimization. See
+> [`docs/integrations/embedding-providers.md` › OpenRouter](./docs/integrations/embedding-providers.md#openrouter)
+> for the full recipe, model list, and per-provider pricing.
+
+Otherwise, ask the user for the keys below. gbrain defaults to the ZeroEntropy embedding + reranker stack
 (as of v0.36.2.0); OpenAI/Voyage are still supported as fallbacks via `gbrain config
 set embedding_model <provider:model>`.
 
 ```bash
-export ZEROENTROPY_API_KEY=ze-...     # default embedding + reranker (v0.36.2.0+)
-export OPENAI_API_KEY=sk-...          # fallback for vector search; also used for chat models
-export ANTHROPIC_API_KEY=sk-ant-...   # optional, improves search quality via query expansion
+export OPENROUTER_API_KEY=sk-or-v1-...   # one key for many models — recommended for new installs
+# OR pick a provider-direct stack (cheaper, but 3 separate vendors and bills):
+export ZEROENTROPY_API_KEY=ze-...        # default embedding + reranker (v0.36.2.0+)
+export OPENAI_API_KEY=sk-...             # fallback for vector search; also used for chat models
+export ANTHROPIC_API_KEY=sk-ant-...      # optional, improves search quality via query expansion
 ```
+
+**If the user provides `OPENROUTER_API_KEY`** (and no other keys), default the install to:
+- `embedding_model = openrouter:openai/text-embedding-3-small` (1536d, $0.02/1M)
+- `chat_model` stays unset (uses the gbrain default — usually Anthropic-direct for subagent
+  loops, since OpenRouter-routed Anthropic is rejected at submit time per the OpenRouter recipe)
+- For non-subagent chat, set `chat_model = openrouter:anthropic/claude-haiku-4.5` or
+  `openrouter:google/gemini-3-flash-preview` per user preference.
+
+**If the user provides a provider-direct stack**, follow the original defaults.
 
 Save to shell profile or `.env`. Keys are picked up by `gbrain config set` automatically
 or can be stored in `~/.gbrain/config.json` (file plane). Without any embedding provider,
 keyword search still works. Without Anthropic, search works but skips query expansion.
+
+**Optional attribution env** (OpenRouter only — set so the OR leaderboard credits the
+operator's deployment, not gbrain):
+```bash
+export OPENROUTER_REFERER=https://your-domain   # default https://gbrain.ai
+export OPENROUTER_TITLE=your-deployment-name    # default gbrain
+```
 
 ## Step 3: Create the Brain
 


### PR DESCRIPTION
## What

The install doc currently leads with three provider-direct keys (ZeroEntropy, OpenAI, Anthropic) without mentioning that gbrain has full OpenRouter support already documented in `docs/integrations/embedding-providers.md`.

For new users who don't have a strong preference, a single `OPENROUTER_API_KEY` covers embeddings, chat, and rerankers across 100+ upstream providers with one bill and one payment endpoint. That's a meaningfully better first-install experience than handing the user a 3-key shopping list.

## Why I hit this

Installing gbrain for an agent stack that already had a few LLM endpoints configured. The setup assumed I'd want to add a separate API key for each provider family. I would have preferred one OpenRouter key for everything. The recipe was already there — just not surfaced at the install-front-door.

## Changes

**`INSTALL_FOR_AGENTS.md` Step 2:**
- Add a TL;DR callout putting `OPENROUTER_API_KEY` first
- Add config defaults for the OR-only case (`embedding_model = openrouter:openai/text-embedding-3-small`, `chat_model` left at gbrain default for subagent compatibility)
- Add the `OPENROUTER_REFERER` / `OPENROUTER_TITLE` attribution env vars so forks/operators get credited on OR's leaderboard
- Keep the existing provider-direct options as a fallback path

**`AGENTS.md` install step 3:**
- Insert a STOP-and-ask-for-API-keys step before the existing STOP-and-ask-for-search-mode step, linking to the OpenRouter recipe

## Notes

The full provider matrix, model list, subagent caveat, and pricing stay where they are in `docs/integrations/embedding-providers.md`. This PR just makes sure new agents don't miss the option at install time.

Happy to revise phrasing, restructure as a separate `Step 1.5: pick your LLM gateway`, or split the AGENTS.md change into a separate PR if maintainers prefer. Just let me know.
