### PR TITLE
feat(ai): support OpenRouter prompt caching

### DIFF
--- a/src/core/ai/capabilities.ts
+++ b/src/core/ai/capabilities.ts
@@ -88,9 +88,13 @@ export function getProviderCapabilities(modelString: string): ProviderCapabiliti
   // boundary; this function returns capabilities for whatever the user asked
   // for, on the assumption it'll be validated elsewhere.
 
+  const supportsPromptCache = chat.supports_prompt_cache;
+
   return {
     supportsToolCalling: chat.supports_tools === true,
-    supportsPromptCaching: chat.supports_prompt_cache === true,
+    supportsPromptCaching: typeof supportsPromptCache === 'function'
+      ? supportsPromptCache(parsed.modelId)
+      : supportsPromptCache === true,
     // No recipe exposes parallel-tools-specifically yet; gate on supports_tools.
     // Subsequent waves can split this into its own recipe field if a provider
     // ever supports tools without parallel dispatch.

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -24,6 +24,10 @@
 import { embed as aiEmbed, embedMany, generateObject, generateText, jsonSchema } from 'ai';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { listRecipes } from './recipes/index.ts';
+import {
+  OPENROUTER_ANTHROPIC_CACHE_SENTINEL,
+  openrouterRequiresExplicitPromptCache,
+} from './recipes/openrouter.ts';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createAnthropic } from '@ai-sdk/anthropic';
@@ -377,7 +381,7 @@ export function applyOpenAICompatConfig(
   cfg: AIGatewayConfig,
 ): { baseURL: string; fetch?: typeof fetch } {
   if (recipe.resolveOpenAICompatConfig) {
-    return recipe.resolveOpenAICompatConfig(cfg.env);
+    return recipe.resolveOpenAICompatConfig(cfg.env, cfg.base_urls?.[recipe.id]);
   }
   const baseURL = cfg.base_urls?.[recipe.id] ?? recipe.base_url_default;
   if (!baseURL) {
@@ -2381,6 +2385,12 @@ export function probeChatModel(modelStr: string): ChatModelProbe {
   return { ok: true };
 }
 
+function chatSupportsPromptCache(recipe: Recipe, modelId: string): boolean {
+  const support = recipe.touchpoints.chat?.supports_prompt_cache;
+  if (typeof support === 'function') return support(modelId);
+  return support === true;
+}
+
 async function resolveChatProvider(modelStr: string): Promise<{ model: any; recipe: Recipe; modelId: string }> {
   const { parsed, recipe } = resolveRecipe(modelStr);
   assertTouchpoint(recipe, 'chat', parsed.modelId, getExtendedModelsForProvider(parsed.providerId));
@@ -2616,7 +2626,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
   const modelStr = modelStrEarly;
   const { model, recipe, modelId } = await resolveChatProvider(modelStr);
 
-  const supportsCache = recipe.touchpoints.chat?.supports_prompt_cache === true;
+  const supportsCache = chatSupportsPromptCache(recipe, modelId);
   const useCache = !!opts.cacheSystem && supportsCache;
 
   // Build messages. Anthropic prompt-cache markers ride on system + last tool
@@ -2636,7 +2646,13 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
   }, {} as Record<string, any>);
 
   const providerOptions: Record<string, any> = {};
-  if (useCache) {
+  if (useCache && recipe.id === 'openrouter' && openrouterRequiresExplicitPromptCache(modelId)) {
+    // OpenRouter's OpenAI-compatible adapter only accepts OpenAI-shaped
+    // providerOptions. Send a private marker through a supported OpenAI field;
+    // the OpenRouter fetch shim converts it to top-level `cache_control` and
+    // strips the marker before the request leaves the process.
+    providerOptions.openai = { promptCacheKey: OPENROUTER_ANTHROPIC_CACHE_SENTINEL };
+  } else if (useCache && recipe.id !== 'openrouter') {
     providerOptions.anthropic = { cacheControl: { type: 'ephemeral' } };
   }
 
@@ -2704,8 +2720,24 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
     const providerMetadata = (result as any).providerMetadata as Record<string, any> | undefined;
     const anthropicCache = providerMetadata?.anthropic ?? {};
 
-    const inTok = Number(usage.inputTokens ?? usage.promptTokens ?? 0);
-    const outTok = Number(usage.outputTokens ?? usage.completionTokens ?? 0);
+    const inputUsage = (usage as any).inputTokens;
+    const outputUsage = (usage as any).outputTokens;
+    const inTok = Number(
+      typeof inputUsage === 'object' && inputUsage !== null
+        ? inputUsage.total
+        : inputUsage ?? (usage as any).promptTokens ?? 0,
+    );
+    const outTok = Number(
+      typeof outputUsage === 'object' && outputUsage !== null
+        ? outputUsage.total
+        : outputUsage ?? (usage as any).completionTokens ?? 0,
+    );
+    const openaiCacheRead = typeof inputUsage === 'object' && inputUsage !== null
+      ? Number(inputUsage.cacheRead ?? 0)
+      : 0;
+    const openaiCacheWrite = typeof inputUsage === 'object' && inputUsage !== null
+      ? Number(inputUsage.cacheWrite ?? 0)
+      : 0;
     _recordBudget(`${recipe.id}:${modelId}`, inTok, outTok);
 
     return {
@@ -2715,8 +2747,8 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
       usage: {
         input_tokens: inTok,
         output_tokens: outTok,
-        cache_read_tokens: Number(anthropicCache.cacheReadInputTokens ?? anthropicCache.cache_read_input_tokens ?? 0),
-        cache_creation_tokens: Number(anthropicCache.cacheCreationInputTokens ?? anthropicCache.cache_creation_input_tokens ?? 0),
+        cache_read_tokens: Number(anthropicCache.cacheReadInputTokens ?? anthropicCache.cache_read_input_tokens ?? openaiCacheRead),
+        cache_creation_tokens: Number(anthropicCache.cacheCreationInputTokens ?? anthropicCache.cache_creation_input_tokens ?? openaiCacheWrite),
       },
       model: `${recipe.id}:${modelId}`,
       providerId: recipe.id,

--- a/src/core/ai/recipes/openrouter.ts
+++ b/src/core/ai/recipes/openrouter.ts
@@ -1,5 +1,59 @@
 import type { Recipe } from '../types.ts';
 
+const OPENROUTER_BASE_URL_DEFAULT = 'https://openrouter.ai/api/v1';
+
+export const OPENROUTER_ANTHROPIC_CACHE_SENTINEL =
+  'gbrain:openrouter:anthropic-cache-control:ephemeral';
+
+export function openrouterSupportsPromptCache(modelId: string): boolean {
+  const normalized = modelId.trim().toLowerCase();
+  // OpenRouter docs: OpenAI prompt caching is automatic for eligible OpenAI
+  // chat models. No request mutation is required; capability detection should
+  // not warn that OpenAI-routed subagent loops are uncached.
+  if (normalized.startsWith('openai/gpt-') || /^openai\/o\d/.test(normalized)) return true;
+
+  // OpenRouter docs: Anthropic Claude routes support prompt caching; Claude
+  // requires cache_control. Keep this family-scoped rather than marking every
+  // Anthropic namespace model as cacheable forever.
+  if (normalized.startsWith('anthropic/claude-')) return true;
+
+  return false;
+}
+
+export function openrouterRequiresExplicitPromptCache(modelId: string): boolean {
+  return modelId.trim().toLowerCase().startsWith('anthropic/claude-');
+}
+
+function rewriteOpenRouterAnthropicCacheControl(body: unknown): unknown {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return body;
+  const record = body as Record<string, unknown>;
+  const model = typeof record.model === 'string' ? record.model : '';
+  if (!openrouterRequiresExplicitPromptCache(model)) return body;
+  if (record.prompt_cache_key !== OPENROUTER_ANTHROPIC_CACHE_SENTINEL) return body;
+
+  const next = { ...record };
+  delete next.prompt_cache_key;
+  next.cache_control = { type: 'ephemeral' };
+  return next;
+}
+
+export const openrouterCompatFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  if (init?.body && typeof init.body === 'string') {
+    try {
+      const parsed = JSON.parse(init.body);
+      const rewritten = rewriteOpenRouterAnthropicCacheControl(parsed);
+      if (rewritten !== parsed) {
+        const headers = new Headers(init.headers ?? {});
+        headers.delete('content-length');
+        init = { ...init, body: JSON.stringify(rewritten), headers };
+      }
+    } catch {
+      // Non-JSON body: let fetch/provider surface the original problem.
+    }
+  }
+  return fetch(input, init);
+}) as unknown as typeof fetch;
+
 /**
  * OpenRouter — single-key fan-out to OpenAI, Anthropic, Google, DeepSeek, and
  * dozens of other providers via a single OpenAI-compatible endpoint at
@@ -42,7 +96,7 @@ export const openrouter: Recipe = {
   name: 'OpenRouter',
   tier: 'openai-compat',
   implementation: 'openai-compatible',
-  base_url_default: 'https://openrouter.ai/api/v1',
+  base_url_default: OPENROUTER_BASE_URL_DEFAULT,
   auth_env: {
     required: ['OPENROUTER_API_KEY'],
     optional: ['OPENROUTER_BASE_URL', 'OPENROUTER_REFERER', 'OPENROUTER_TITLE'],
@@ -59,6 +113,12 @@ export const openrouter: Recipe = {
       'X-OpenRouter-Title': title,
       // Back-compat alias documented as still-supported.
       'X-Title': title,
+    };
+  },
+  resolveOpenAICompatConfig(env, baseURLOverride) {
+    return {
+      baseURL: baseURLOverride ?? env.OPENROUTER_BASE_URL ?? OPENROUTER_BASE_URL_DEFAULT,
+      fetch: openrouterCompatFetch,
     };
   },
   touchpoints: {
@@ -93,7 +153,7 @@ export const openrouter: Recipe = {
       supports_tools: true,
       // Informational only — real gate is isAnthropicProvider() upstream.
       supports_subagent_loop: false,
-      supports_prompt_cache: false,
+      supports_prompt_cache: openrouterSupportsPromptCache,
       // No max_context_tokens: catalog spans 128K to 1M+; a single recipe-wide
       // value is either unsafe for smaller models or wasteful for larger ones.
       // Let upstream errors surface per-model.

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -211,8 +211,13 @@ export interface ChatTouchpoint {
    * Strictly stronger than supports_tools.
    */
   supports_subagent_loop: boolean;
-  /** Anthropic-style ephemeral prompt cache markers honored. */
-  supports_prompt_cache?: boolean;
+  /**
+   * Prompt caching is honored for this chat touchpoint. Static booleans cover
+   * native providers; openai-compatible aggregators may decide per model id
+   * (e.g. OpenRouter caches OpenAI and Anthropic routes but not every routed
+   * model family).
+   */
+  supports_prompt_cache?: boolean | ((modelId: string) => boolean);
   max_context_tokens?: number;
   cost_per_1m_input_usd?: number;
   cost_per_1m_output_usd?: number;
@@ -311,7 +316,7 @@ export interface Recipe {
    * from `AZURE_OPENAI_ENDPOINT` + `AZURE_OPENAI_DEPLOYMENT` and the fetch
    * wrapper splices `api-version` into every request URL.
    */
-  resolveOpenAICompatConfig?(env: Record<string, string | undefined>): {
+  resolveOpenAICompatConfig?(env: Record<string, string | undefined>, baseURLOverride?: string): {
     baseURL: string;
     fetch?: typeof fetch;
   };

--- a/test/ai/capabilities.test.ts
+++ b/test/ai/capabilities.test.ts
@@ -24,6 +24,22 @@ describe('getProviderCapabilities (v0.38 Slice 1 — D6/D7 recipe-driven capabil
     expect(caps.maxContext).toBe(1000000); // Gemini 1.5 Pro
   });
 
+  it('returns capabilities for OpenRouter OpenAI/Anthropic cacheable routes', () => {
+    const openaiCaps = getProviderCapabilities('openrouter:openai/gpt-5.2');
+    expect(openaiCaps.supportsToolCalling).toBe(true);
+    expect(openaiCaps.supportsPromptCaching).toBe(true);
+
+    const anthropicCaps = getProviderCapabilities('openrouter:anthropic/claude-sonnet-4.6');
+    expect(anthropicCaps.supportsToolCalling).toBe(true);
+    expect(anthropicCaps.supportsPromptCaching).toBe(true);
+  });
+
+  it('does not mark every OpenRouter route as cache-capable', () => {
+    const caps = getProviderCapabilities('openrouter:deepseek/deepseek-chat');
+    expect(caps.supportsToolCalling).toBe(true);
+    expect(caps.supportsPromptCaching).toBe(false);
+  });
+
   it('honors Anthropic alias (undated → dated)', () => {
     const caps = getProviderCapabilities('anthropic:claude-haiku-4-5');
     expect(caps.supportsToolCalling).toBe(true);
@@ -52,6 +68,15 @@ describe('classifyCapabilities (D6 — three-tier capability verdict)', () => {
 
   it('returns degraded:no_caching for OpenAI (tools yes, caching no)', () => {
     expect(classifyCapabilities('openai:gpt-5.2')).toBe('degraded:no_caching');
+  });
+
+  it('returns ok for OpenRouter OpenAI/Anthropic cacheable routes', () => {
+    expect(classifyCapabilities('openrouter:openai/gpt-5.2')).toBe('ok');
+    expect(classifyCapabilities('openrouter:anthropic/claude-sonnet-4.6')).toBe('ok');
+  });
+
+  it('keeps non-cacheable OpenRouter routes degraded:no_caching', () => {
+    expect(classifyCapabilities('openrouter:deepseek/deepseek-chat')).toBe('degraded:no_caching');
   });
 
   it('returns degraded:no_caching for Google Gemini', () => {

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -40,11 +40,13 @@ describe('chat touchpoint — recipe registry', () => {
     }
   });
 
-  test('only Anthropic claims supports_prompt_cache=true', () => {
+  test('only Anthropic and model-family-gated OpenRouter claim supports_prompt_cache', () => {
     for (const r of listRecipes()) {
       if (!r.touchpoints.chat) continue;
       if (r.id === 'anthropic') {
         expect(r.touchpoints.chat.supports_prompt_cache).toBe(true);
+      } else if (r.id === 'openrouter') {
+        expect(typeof r.touchpoints.chat.supports_prompt_cache).toBe('function');
       } else {
         expect(r.touchpoints.chat.supports_prompt_cache ?? false).toBe(false);
       }

--- a/test/ai/recipe-openrouter.test.ts
+++ b/test/ai/recipe-openrouter.test.ts
@@ -11,6 +11,12 @@
 
 import { describe, expect, test } from 'bun:test';
 import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+import {
+  OPENROUTER_ANTHROPIC_CACHE_SENTINEL,
+  openrouterCompatFetch,
+  openrouterRequiresExplicitPromptCache,
+  openrouterSupportsPromptCache,
+} from '../../src/core/ai/recipes/openrouter.ts';
 import { defaultResolveAuth } from '../../src/core/ai/gateway.ts';
 import { assertTouchpoint } from '../../src/core/ai/model-resolver.ts';
 import { AIConfigError } from '../../src/core/ai/errors.ts';
@@ -134,5 +140,68 @@ describe('recipe: openrouter', () => {
     expect(r.setup_hint).toContain('OPENROUTER_BASE_URL');
     expect(r.setup_hint).toContain('OPENROUTER_REFERER');
     expect(r.setup_hint).toContain('OPENROUTER_TITLE');
+  });
+
+  test('12. prompt cache capability is selective for OpenRouter model families', () => {
+    expect(openrouterSupportsPromptCache('openai/gpt-5.2')).toBe(true);
+    expect(openrouterSupportsPromptCache('openai/gpt-5.2-chat')).toBe(true);
+    expect(openrouterSupportsPromptCache('openai/o4-mini')).toBe(true);
+    expect(openrouterSupportsPromptCache('openai/text-embedding-3-small')).toBe(false);
+    expect(openrouterSupportsPromptCache('anthropic/claude-sonnet-4.6')).toBe(true);
+    expect(openrouterSupportsPromptCache('anthropic/claude-opus-4.7')).toBe(true);
+    expect(openrouterSupportsPromptCache('deepseek/deepseek-chat')).toBe(false);
+    expect(openrouterSupportsPromptCache('google/gemini-3-flash-preview')).toBe(false);
+  });
+
+  test('13. only Anthropic Claude routes require explicit OpenRouter cache_control', () => {
+    expect(openrouterRequiresExplicitPromptCache('anthropic/claude-sonnet-4.6')).toBe(true);
+    expect(openrouterRequiresExplicitPromptCache('openai/gpt-5.2')).toBe(false);
+    expect(openrouterRequiresExplicitPromptCache('deepseek/deepseek-chat')).toBe(false);
+  });
+
+  test('14. resolveOpenAICompatConfig keeps base URL overrides and installs cache fetch shim', () => {
+    const r = getRecipe('openrouter')!;
+    const compat = r.resolveOpenAICompatConfig!({ OPENROUTER_BASE_URL: 'https://env.example/v1' }, 'https://cfg.example/v1');
+    expect(compat.baseURL).toBe('https://cfg.example/v1');
+    expect(compat.fetch).toBe(openrouterCompatFetch);
+  });
+
+  test('15. fetch shim rewrites Anthropic cache sentinel to top-level cache_control only', async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ input, init });
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+
+    try {
+      await openrouterCompatFetch('https://openrouter.ai/api/v1/chat/completions', {
+        method: 'POST',
+        body: JSON.stringify({
+          model: 'anthropic/claude-sonnet-4.6',
+          prompt_cache_key: OPENROUTER_ANTHROPIC_CACHE_SENTINEL,
+          messages: [{ role: 'user', content: 'hello' }],
+        }),
+      });
+
+      const rewritten = JSON.parse(calls[0].init!.body as string);
+      expect(rewritten.prompt_cache_key).toBeUndefined();
+      expect(rewritten.cache_control).toEqual({ type: 'ephemeral' });
+
+      await openrouterCompatFetch('https://openrouter.ai/api/v1/chat/completions', {
+        method: 'POST',
+        body: JSON.stringify({
+          model: 'openai/gpt-5.2',
+          prompt_cache_key: OPENROUTER_ANTHROPIC_CACHE_SENTINEL,
+          messages: [{ role: 'user', content: 'hello' }],
+        }),
+      });
+
+      const untouched = JSON.parse(calls[1].init!.body as string);
+      expect(untouched.prompt_cache_key).toBe(OPENROUTER_ANTHROPIC_CACHE_SENTINEL);
+      expect(untouched.cache_control).toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/test/db-lock-heartbeat-takeover.test.ts
+++ b/test/db-lock-heartbeat-takeover.test.ts
@@ -21,6 +21,7 @@ import {
   resolveStealGraceSeconds,
   DEFAULT_STEAL_GRACE_SECONDS,
 } from '../src/core/db-lock.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 let engine: PGLiteEngine;
 
@@ -81,22 +82,16 @@ describe('resolveStealGraceSeconds', () => {
     expect(resolveStealGraceSeconds(1)).toBe(60);
   });
 
-  test('env override wins', () => {
-    process.env.GBRAIN_LOCK_STEAL_GRACE_SECONDS = '123';
-    try {
+  test('env override wins', async () => {
+    await withEnv({ GBRAIN_LOCK_STEAL_GRACE_SECONDS: '123' }, async () => {
       expect(resolveStealGraceSeconds(30)).toBe(123);
-    } finally {
-      delete process.env.GBRAIN_LOCK_STEAL_GRACE_SECONDS;
-    }
+    });
   });
 
-  test('bad env override falls back to derived', () => {
-    process.env.GBRAIN_LOCK_STEAL_GRACE_SECONDS = 'nope';
-    try {
+  test('bad env override falls back to derived', async () => {
+    await withEnv({ GBRAIN_LOCK_STEAL_GRACE_SECONDS: 'nope' }, async () => {
       expect(resolveStealGraceSeconds(30)).toBe(600);
-    } finally {
-      delete process.env.GBRAIN_LOCK_STEAL_GRACE_SECONDS;
-    }
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- mark OpenRouter OpenAI chat routes and Anthropic Claude routes as prompt-cache capable on a per-model-family basis
- add an OpenRouter fetch shim that rewrites the OpenAI-compatible adapter's private prompt-cache sentinel into top-level `cache_control` for Anthropic Claude routes only
- preserve OpenAI route behavior as automatic/no-extra-request-mutation and keep non-cacheable OpenRouter families degraded
- surface OpenAI-compatible cached-token usage from AI SDK structured usage when available
- fix an existing test-isolation lint violation in `test/db-lock-heartbeat-takeover.test.ts` by using the repo's `withEnv()` helper

Fixes #1987.

## Why

OpenRouter supports prompt caching for compatible routed providers, but not uniformly across the full catalog:

- OpenAI routes: caching is automatic when the model/provider supports it
- Anthropic Claude routes: OpenRouter requires explicit `cache_control`
- Other routed families should not be blanket-marked cache-capable

This keeps the recipe capability honest while removing the `degraded:no_caching` warning for the OpenRouter model families that do support caching.

## Tests

- `bun test test/ai/recipe-openrouter.test.ts test/ai/capabilities.test.ts`
- `scripts/check-test-isolation.sh`
- `bun test test/db-lock-heartbeat-takeover.test.ts`
- `bun run typecheck`
- `bun run test` exceeded the local 10-minute command timeout while the full sharded suite was still running; no failure from this change was observed before timeout.
