### PR TITLE
feat(ai): declare chat touchpoint for ollama recipe

### DIFF
--- a/src/core/ai/model-resolver.ts
+++ b/src/core/ai/model-resolver.ts
@@ -117,7 +117,7 @@ export function assertTouchpoint(
       `Provider "${recipe.id}" does not support touchpoint "${touchpoint}".`,
       touchpoint === 'embedding' && recipe.id === 'anthropic'
         ? 'Anthropic has no embedding model. Use openai or google for embeddings.'
-        : touchpoint === 'chat' && (recipe.id === 'voyage' || recipe.id === 'ollama')
+        : touchpoint === 'chat' && recipe.id === 'voyage'
           ? `${recipe.name} is configured here only for embeddings. Use openai/anthropic/google/deepseek/groq/together for chat.`
           : undefined,
     );

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -21,6 +21,32 @@ export const ollama: Recipe = {
       // OLLAMA_NUM_PARALLEL config; no static cap to declare. v0.32 (#779).
       no_batch_cap: true,
     },
+    chat: {
+      // Ollama serves whatever model the user has pulled. The openai-compat
+      // tier does NOT enforce this list at runtime — users pass any local
+      // model id (e.g. `ollama:qwen2.5:14b`, `ollama:llama3.1:8b`). The list
+      // below is a curated entry point for the wizard, not an allow-list.
+      // Matches openrouter.ts pattern (catalog spans many models).
+      models: [],
+      // Tool calling is per-model on Ollama. Qwen2.5, Llama 3.1+, Mistral
+      // (recent), and Granite all support /v1 tool calls via Ollama's
+      // OpenAI-compat layer. Conservative true; gateway surfaces upstream
+      // 4xx if the chosen model lacks tool support.
+      supports_tools: true,
+      // Same gate as openrouter: the real subagent-loop gate is
+      // isAnthropicProvider() in src/core/model-config.ts which hard-pins
+      // gbrain's subagent infra to Anthropic-direct (stable tool_use_id
+      // across crashes/replays). Informational only.
+      supports_subagent_loop: false,
+      // Ollama has no Anthropic-style ephemeral prompt cache.
+      supports_prompt_cache: false,
+      // No max_context_tokens: catalog spans 4K (tiny models) to 1M+
+      // (Llama 3.1 / Qwen2.5 long-context variants). Per-model rather than
+      // recipe-wide. Let upstream errors surface per-model.
+      cost_per_1m_input_usd: 0,
+      cost_per_1m_output_usd: 0,
+      price_last_verified: '2026-06-08',
+    },
   },
-  setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` and `ollama serve`.',
+  setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull <model>` and `ollama serve`. For chat: `ollama:qwen2.5:14b` or any pulled model. For embeddings: `ollama:nomic-embed-text` (768d).',
 };

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -51,9 +51,23 @@ describe('chat touchpoint — recipe registry', () => {
     }
   });
 
-  test('embedding-only providers (voyage, ollama) do NOT declare chat', () => {
+  test('embedding-only providers (voyage) do NOT declare chat', () => {
+    // Voyage remains embedding-only. Ollama declared chat in v0.42.37
+    // (covers local Qwen/Llama/Mistral via openai-compat tier).
     expect(getRecipe('voyage')!.touchpoints.chat).toBeUndefined();
-    expect(getRecipe('ollama')!.touchpoints.chat).toBeUndefined();
+  });
+
+  test('ollama declares chat with user-driven model list (openai-compat)', () => {
+    const chat = getRecipe('ollama')!.touchpoints.chat;
+    expect(chat).toBeDefined();
+    // Empty curated list — openai-compat tier accepts arbitrary model ids
+    // at runtime (whatever the user has pulled locally).
+    expect(chat!.models).toEqual([]);
+    expect(chat!.supports_tools).toBe(true);
+    expect(chat!.supports_subagent_loop).toBe(false);
+    expect(chat!.supports_prompt_cache).toBe(false);
+    expect(chat!.cost_per_1m_input_usd).toBe(0);
+    expect(chat!.cost_per_1m_output_usd).toBe(0);
   });
 
   test('openai-compat chat recipes have base_url_default', () => {
@@ -110,8 +124,13 @@ describe('chat touchpoint — model resolver + aliases (Codex F-OV-5)', () => {
   test('assertTouchpoint rejects chat on embedding-only providers with a fix hint', () => {
     expect(() => assertTouchpoint(getRecipe('voyage')!, 'chat', 'voyage-3'))
       .toThrow(AIConfigError);
-    expect(() => assertTouchpoint(getRecipe('ollama')!, 'chat', 'nomic-embed-text'))
-      .toThrow(AIConfigError);
+  });
+
+  test('assertTouchpoint accepts chat for ollama with arbitrary model id', () => {
+    // openai-compat tier — Ollama serves whatever model the user pulled.
+    // Recipe declares models:[] so the resolver does not enforce a list.
+    expect(() => assertTouchpoint(getRecipe('ollama')!, 'chat', 'qwen2.5:14b')).not.toThrow();
+    expect(() => assertTouchpoint(getRecipe('ollama')!, 'chat', 'llama3.1:8b')).not.toThrow();
   });
 
   test('assertTouchpoint rejects unknown native model with the model list in the fix hint', () => {


### PR DESCRIPTION
## Summary

The `ollama` recipe in `src/core/ai/recipes/ollama.ts` only declares an `embedding` touchpoint, even though Ollama serves any pulled model via OpenAI-compatible `/v1/chat/completions`. As a result, routing `tier.utility` (or any chat tier) at `ollama:<model>` throws:

```
AIConfigError: Provider "ollama" does not offer a chat touchpoint.
```

…despite `capabilities.ts:80`'s own error hint already listing `ollama` in the known chat-providers list.

This PR closes that gap so users with a local Ollama-served model (Qwen2.5, Llama 3.1, Mistral, etc.) can route gbrain's utility/subagent tier to local inference and eliminate Anthropic spend on Haiku-class background work (expansion, dream verdict, contradictions judge).

## Changes

- **`src/core/ai/recipes/ollama.ts`** — add `chat` touchpoint with:
  - `models: []` — user-driven (openai-compat tier does not enforce list at runtime; matches `openrouter.ts` and `litellm-proxy.ts` pattern)
  - `supports_tools: true` — Qwen2.5, Llama 3.1+, Mistral, Granite all support `/v1` tool calls via Ollama's OpenAI-compat layer
  - `supports_subagent_loop: false` — real gate is `isAnthropicProvider()` upstream; informational only (same as openrouter)
  - `supports_prompt_cache: false`
  - `cost_per_1m_input_usd: 0`, `cost_per_1m_output_usd: 0`
- **`src/core/ai/model-resolver.ts`** — drop `ollama` from the embedding-only fix-hint branch (voyage stays — it really is embedding-only)
- **`test/ai/gateway-chat.test.ts`** — replace the negative-assertion test ("ollama does NOT declare chat") with positive assertions that ollama declares chat with the expected user-driven shape, and that `assertTouchpoint` accepts arbitrary local model ids (`qwen2.5:14b`, `llama3.1:8b`)

## Tested

Locally against Qwen2.5-14B on RTX 4080 SUPER:

```bash
gbrain config set models.tier.utility ollama:qwen2.5:14b
```

Routing dashboard correctly cascades `models.expansion`, `models.dream.synthesize_verdict`, and `models.eval.contradictions_judge` to local Ollama.

```bash
bun test test/providers.test.ts \
         test/ai/recipes-existing-regression.test.ts \
         test/ai/gateway-chat.test.ts \
         test/ai/build-gateway-config.test.ts
# 58 pass / 0 fail.
```

## Test plan

- [x] All targeted unit tests pass (58/58)
- [x] `gbrain config set models.tier.utility ollama:qwen2.5:14b` succeeds (was previously rejected at config-write or first-call time)
- [x] `gbrain models` shows utility tier + cascaded per-task overrides pointing at `ollama:qwen2.5:14b`
- [x] Direct smoke test of Ollama `/v1/chat/completions` returns valid OpenAI-format response

🤖 Generated with [Claude Code](https://claude.com/claude-code)