### PR TITLE
fix(cycle): stamp last_full_cycle_at for the source resolved from brainDir

### DIFF
--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -2190,24 +2190,30 @@ export async function runCycle(
   const status = deriveStatus(phaseResults, totals);
 
   // v0.38 (codex r1 P0-5): persist per-source cycle completion timestamp
-  // when the cycle ran successfully against an explicit source. Read by
-  // autopilot's per-source freshness gate next tick. Skipped when:
-  //   - opts.sourceId is unset (legacy callers — autopilot still here)
-  //   - engine is null (no-DB path)
+  // when the cycle ran successfully against a resolvable source. Read by
+  // autopilot's per-source freshness gate next tick.
+  //
+  // Uses `cycleSourceId` (opts.sourceId ?? the source resolved from brainDir),
+  // the SAME id the cycle locked + scoped its phases to — NOT raw opts.sourceId.
+  // The autopilot's inline cycle sets brainDir but passes no explicit sourceId,
+  // so keying the stamp off opts.sourceId alone never advanced last_full_cycle_at
+  // and `gbrain doctor` reported cycle_freshness stale even while the autopilot
+  // cycled every interval. Skipped when:
+  //   - no source resolves (engine null, or no checkout AND no opts.sourceId)
   //   - status is 'failed' or 'skipped' (don't mark a non-run as fresh)
   //   - dryRun (writes are out of scope)
   //
   // Best-effort: a write failure does NOT change the CycleReport status.
   // The cost of writing the wrong timestamp post-failure is higher than
   // the cost of missing a successful write (next cycle will redo work).
-  if (opts.sourceId && engine && !dryRun && (status === 'ok' || status === 'clean' || status === 'partial')) {
+  if (cycleSourceId && engine && !dryRun && (status === 'ok' || status === 'clean' || status === 'partial')) {
     try {
-      await engine.updateSourceConfig(opts.sourceId, {
+      await engine.updateSourceConfig(cycleSourceId, {
         last_full_cycle_at: new Date().toISOString(),
       });
     } catch (e) {
       // Best-effort; cycle already succeeded by the time we get here.
-      console.warn(`[cycle] failed to write last_full_cycle_at for source ${opts.sourceId}: ${e instanceof Error ? e.message : String(e)}`);
+      console.warn(`[cycle] failed to write last_full_cycle_at for source ${cycleSourceId}: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 

--- a/test/cycle-last-full-cycle-at.test.ts
+++ b/test/cycle-last-full-cycle-at.test.ts
@@ -3,8 +3,10 @@
  * cycles. Closes codex round-1 P0-5 (write site for last_full_cycle_at
  * was unspecified pre-PR).
  *
- * Conditions for write:
- *   - opts.sourceId is set (legacy callers without sourceId skip the write)
+ * Conditions for write (keyed off `cycleSourceId` = opts.sourceId ?? the
+ * source resolved from brainDir, so the autopilot's inline cycle — brainDir
+ * set, no explicit sourceId — also advances the timestamp):
+ *   - a source resolves (explicit sourceId, or brainDir matches a source)
  *   - engine is non-null (no-DB path skips)
  *   - status is 'ok' | 'clean' | 'partial' (failed/skipped don't mark fresh)
  *   - dryRun is false
@@ -90,17 +92,45 @@ describe('runCycle last_full_cycle_at exit hook', () => {
     });
   });
 
-  test('legacy caller (no sourceId) does NOT write any source timestamp', async () => {
+  test('no explicit sourceId but brainDir resolves a source → writes the resolved source timestamp', async () => {
     await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
-      await seedSource('default-like');
-      // No sourceId passed; should remain untouched.
+      // The autopilot's inline cycle sets brainDir but passes no sourceId.
+      // runCycle resolves the source from brainDir (local_path match) into
+      // cycleSourceId and stamps last_full_cycle_at for it — otherwise
+      // cycle_freshness reports the brain stale even while the autopilot
+      // cycles every interval.
+      await seedSource('resolved-from-dir'); // local_path = brainDir
+      expect(await readLastFullCycleAt('resolved-from-dir')).toBeNull();
+
+      const t0 = Date.now();
+      const report = await runCycle(engine, {
+        brainDir,
+        phases: ['lint'],
+      });
+      expect(['ok', 'clean']).toContain(report.status);
+
+      const after = await readLastFullCycleAt('resolved-from-dir');
+      expect(after).not.toBeNull();
+      expect(new Date(after!).getTime()).toBeGreaterThanOrEqual(t0);
+    });
+  });
+
+  test('no sourceId and brainDir matches no source → does not write', async () => {
+    await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
+      // A source exists but its local_path does NOT match brainDir, so
+      // resolveSourceForDir returns undefined, cycleSourceId is undefined,
+      // and no per-source timestamp is written.
+      await engine.executeRaw(
+        `INSERT INTO sources (id, name, local_path, config, archived, created_at)
+         VALUES ('unmatched', 'unmatched', '/no/such/repo', '{}'::jsonb, false, NOW())
+         ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path`,
+        [],
+      );
       await runCycle(engine, {
         brainDir,
         phases: ['lint'],
       });
-      // No per-source write happens; default source's config stays empty.
-      const after = await readLastFullCycleAt('default-like');
-      expect(after).toBeNull();
+      expect(await readLastFullCycleAt('unmatched')).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Problem
`gbrain doctor`'s `cycle_freshness` goes stale on autopilot-maintained brains even though the autopilot cycles every interval. `runCycle` only stamps `last_full_cycle_at` when an explicit `opts.sourceId` is passed, but the autopilot's inline cycle sets `brainDir` and no `sourceId`. Details in #1992.

## Fix
`runCycle` already resolves `cycleSourceId = opts.sourceId ?? resolveSourceForDir(engine, brainDir)` and uses it for the cycle lock + phase scoping. This keys the `last_full_cycle_at` stamp off that same id instead of raw `opts.sourceId`:
- autopilot inline cycle (brainDir set, no sourceId) → resolves + stamps the source ✓
- `dream --source X` (explicit sourceId) → unchanged ✓
- no checkout + no sourceId → `cycleSourceId` undefined → no stamp (unchanged) ✓

No change to cycle scope — `cycleSourceId` is the same id the cycle already locked + scoped its phases to.

## Tests
`test/cycle-last-full-cycle-at.test.ts`: the prior "legacy caller (no sourceId) does NOT write" case encoded the bug (it seeded a source at `brainDir`). It now asserts the resolved-from-`brainDir` source IS stamped, plus a new case that a `brainDir` matching no source still does not write.

Closes #1992