### PR TITLE
feat: add global JSON output flag (rebased on v0.42.36)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -196,11 +196,15 @@ function maybeEmitUpdateMarker(command: string): void {
 }
 
 async function main() {
-  // Parse global flags (--quiet / --progress-json / --progress-interval)
+  // Parse global flags (--quiet / --json / --progress-json / --progress-interval)
   // BEFORE command dispatch, so `gbrain --progress-json doctor` works.
   // The stripped argv is what the command sees.
+  //
+  // CLI-only commands that own a per-command --json parser are kept in CLI_ONLY
+  // and excluded from the global --json strip — they continue to handle the
+  // flag themselves (e.g. `check-resolvable --json`, `doctor --json`).
   const rawArgs = process.argv.slice(2);
-  const { cliOpts, rest: args } = parseGlobalFlags(rawArgs);
+  const { cliOpts, rest: args } = parseGlobalFlags(rawArgs, { jsonPassThroughCommands: CLI_ONLY });
   setCliOptions(cliOpts);
 
   let command = args[0];
@@ -389,7 +393,12 @@ async function main() {
     // routed path. Date → ISO string; bigint → string (postgres.js shape);
     // Buffer → object. Microsecond-cost; eliminates a whole drift bug class.
     const result = JSON.parse(JSON.stringify(rawResult));
-    const output = formatResult(op.name, result);
+    // v0.42 (PR #507) — global `--json` short-circuits formatResult and emits
+    // the raw result as JSON. Used by agent integrations that need stable
+    // machine-readable output from shared operations.
+    const output = getCliOptions().json
+      ? JSON.stringify(result, null, 2) + '\n'
+      : formatResult(op.name, result);
     if (output) process.stdout.write(output);
   } catch (e: unknown) {
     // v0.42.20.0 (codex D4): on error, set exitCode + return so the `finally`
@@ -479,7 +488,11 @@ async function runThinClientRouted(
       signal: sigintController.signal,
     });
     const result = unpackToolResult(raw);
-    const output = formatResult(op.name, result);
+    // v0.42 (PR #507) — global `--json` short-circuits formatResult on the
+    // routed path too, so behavior matches the local-engine path.
+    const output = getCliOptions().json
+      ? JSON.stringify(result, null, 2) + '\n'
+      : formatResult(op.name, result);
     if (output) process.stdout.write(output);
   } catch (e: unknown) {
     if (e instanceof RemoteMcpError) {
@@ -2104,7 +2117,13 @@ function printHelp() {
   console.log(`gbrain ${VERSION} -- personal knowledge brain
 
 USAGE
-  gbrain <command> [options]
+  gbrain [global-options] <command> [options]
+
+GLOBAL OPTIONS
+  --json                             Emit raw JSON for shared operation commands
+                                       (search, query, get, list, etc.)
+  --quiet                            Suppress non-essential output
+  --progress-json                    Emit progress events as JSON
 
 SETUP
   init [--pglite|--supabase|--url]   Create brain (PGLite default, no server)

--- a/src/core/cli-options.ts
+++ b/src/core/cli-options.ts
@@ -29,6 +29,18 @@ export interface CliOptions {
    * the reranker. Has no effect on other commands.
    */
   explain: boolean;
+  /**
+   * v0.42 (PR #507) — global `--json` flag for shared-operation commands.
+   * When true, cli.ts emits `JSON.stringify(result, null, 2)` for shared
+   * operations like `search` and `query` instead of the human-readable
+   * `formatResult` text.
+   *
+   * CLI-only commands that own their own `--json` parser (e.g.
+   * `check-resolvable`, `doctor`, `dream`, `orphans`) keep the per-command
+   * flag — `parseGlobalFlags` skips `--json` after one of those command
+   * tokens via the `jsonPassThroughCommands` allowlist option.
+   */
+  json: boolean;
 }
 
 export const DEFAULT_CLI_OPTIONS: CliOptions = {
@@ -37,6 +49,7 @@ export const DEFAULT_CLI_OPTIONS: CliOptions = {
   progressInterval: 1000,
   timeoutMs: null,
   explain: false,
+  json: false,
 };
 
 /**
@@ -45,20 +58,40 @@ export const DEFAULT_CLI_OPTIONS: CliOptions = {
  *
  * Recognized:
  *   --quiet
+ *   --json
  *   --progress-json
  *   --progress-interval=<ms>
  *   --progress-interval <ms>   (space-separated form)
  *
  * Unknown flags are passed through unchanged — per-command parsers see them.
  */
-export function parseGlobalFlags(argv: string[]): { cliOpts: CliOptions; rest: string[] } {
+export interface ParseGlobalFlagsOptions {
+  /**
+   * Commands that own their own command-local `--json` parser. When `--json`
+   * appears after one of these command tokens, keep it in `rest` so the command
+   * can preserve its existing CLI contract. `--json` before the command remains
+   * a top-level global flag.
+   */
+  jsonPassThroughCommands?: ReadonlySet<string>;
+}
+
+export function parseGlobalFlags(argv: string[], options: ParseGlobalFlagsOptions = {}): { cliOpts: CliOptions; rest: string[] } {
   const cliOpts: CliOptions = { ...DEFAULT_CLI_OPTIONS };
   const rest: string[] = [];
+  let command: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--quiet') {
       cliOpts.quiet = true;
+      continue;
+    }
+    if (a === '--json') {
+      if (command && options.jsonPassThroughCommands?.has(command)) {
+        rest.push(a);
+      } else {
+        cliOpts.json = true;
+      }
       continue;
     }
     if (a === '--progress-json') {
@@ -74,6 +107,7 @@ export function parseGlobalFlags(argv: string[]): { cliOpts: CliOptions; rest: s
         continue;
       }
       // not a number — let per-command parser handle; pass through
+      if (!command && !a.startsWith('-')) command = a;
       rest.push(a);
       continue;
     }
@@ -114,6 +148,7 @@ export function parseGlobalFlags(argv: string[]): { cliOpts: CliOptions; rest: s
       cliOpts.explain = true;
       continue;
     }
+    if (!command && !a.startsWith('-')) command = a;
     rest.push(a);
   }
 

--- a/test/cli-options.test.ts
+++ b/test/cli-options.test.ts
@@ -58,15 +58,46 @@ describe('parseGlobalFlags', () => {
   });
 
   test('unknown flags pass through unchanged', () => {
-    const r = parseGlobalFlags(['doctor', '--fast', '--json', '--foo=bar']);
-    expect(r.rest).toEqual(['doctor', '--fast', '--json', '--foo=bar']);
+    const r = parseGlobalFlags(['doctor', '--fast', '--foo=bar']);
+    expect(r.rest).toEqual(['doctor', '--fast', '--foo=bar']);
     expect(r.cliOpts).toEqual(DEFAULT_CLI_OPTIONS);
   });
 
   test('all global flags combined', () => {
-    const r = parseGlobalFlags(['--quiet', '--progress-json', '--progress-interval=250', 'sync']);
-    expect(r.cliOpts).toEqual({ quiet: true, progressJson: true, progressInterval: 250, timeoutMs: null, explain: false });
+    const r = parseGlobalFlags(['--quiet', '--json', '--progress-json', '--progress-interval=250', 'sync']);
+    expect(r.cliOpts).toEqual({ quiet: true, json: true, progressJson: true, progressInterval: 250, timeoutMs: null, explain: false });
     expect(r.rest).toEqual(['sync']);
+  });
+
+  // v0.42 (PR #507) — global --json flag
+  test('strips --json before the command and sets json=true', () => {
+    const r = parseGlobalFlags(['--json', 'search', 'ADU permit']);
+    expect(r.cliOpts.json).toBe(true);
+    expect(r.rest).toEqual(['search', 'ADU permit']);
+  });
+
+  test('strips --json after a shared-operation command and sets json=true', () => {
+    const r = parseGlobalFlags(['search', 'ADU permit', '--json']);
+    expect(r.cliOpts.json).toBe(true);
+    expect(r.rest).toEqual(['search', 'ADU permit']);
+  });
+
+  test('keeps command-local --json after an allowlisted CLI-only command', () => {
+    const r = parseGlobalFlags(
+      ['check-resolvable', '--skills-dir', './skills', '--json'],
+      { jsonPassThroughCommands: new Set(['check-resolvable']) },
+    );
+    expect(r.cliOpts.json).toBe(false);
+    expect(r.rest).toEqual(['check-resolvable', '--skills-dir', './skills', '--json']);
+  });
+
+  test('--json before command always becomes global, even with passthrough allowlist', () => {
+    const r = parseGlobalFlags(
+      ['--json', 'doctor', '--fast'],
+      { jsonPassThroughCommands: new Set(['doctor']) },
+    );
+    expect(r.cliOpts.json).toBe(true);
+    expect(r.rest).toEqual(['doctor', '--fast']);
   });
 
   // v0.40.4 — --explain flag
@@ -96,7 +127,7 @@ describe('getCliOptions / setCliOptions singleton', () => {
 
   test('setCliOptions applies + getCliOptions returns a copy', () => {
     _resetCliOptionsForTest();
-    setCliOptions({ quiet: false, progressJson: true, progressInterval: 250, timeoutMs: null, explain: false });
+    setCliOptions({ quiet: false, json: false, progressJson: true, progressInterval: 250, timeoutMs: null, explain: false });
     expect(getCliOptions().progressJson).toBe(true);
     expect(getCliOptions().progressInterval).toBe(250);
   });
@@ -156,12 +187,12 @@ describe('CLI integration: progress streams to the right channel', () => {
 
 describe('cliOptsToProgressOptions', () => {
   test('--quiet → quiet mode', () => {
-    const opts = cliOptsToProgressOptions({ quiet: true, progressJson: false, progressInterval: 1000, timeoutMs: null, explain: false });
+    const opts = cliOptsToProgressOptions({ quiet: true, json: false, progressJson: false, progressInterval: 1000, timeoutMs: null, explain: false });
     expect(opts.mode).toBe('quiet');
   });
 
   test('--progress-json → json mode with interval', () => {
-    const opts = cliOptsToProgressOptions({ quiet: false, progressJson: true, progressInterval: 500, timeoutMs: null, explain: false });
+    const opts = cliOptsToProgressOptions({ quiet: false, json: false, progressJson: true, progressInterval: 500, timeoutMs: null, explain: false });
     expect(opts.mode).toBe('json');
     expect(opts.minIntervalMs).toBe(500);
   });
@@ -173,7 +204,7 @@ describe('cliOptsToProgressOptions', () => {
   });
 
   test('quiet takes priority over progressJson', () => {
-    const opts = cliOptsToProgressOptions({ quiet: true, progressJson: true, progressInterval: 1000, timeoutMs: null, explain: false });
+    const opts = cliOptsToProgressOptions({ quiet: true, json: false, progressJson: true, progressInterval: 1000, timeoutMs: null, explain: false });
     expect(opts.mode).toBe('quiet');
   });
 });


### PR DESCRIPTION
Replaces closed PR #507 — same author, rebased on top of master `959af106` (v0.42.36.0). The original PR can't be reopened because GitHub blocks reopen-after-force-push.

## Summary
- Add a global \`gbrain --json <command>\` flag for shared operation commands (search, query, get, list, etc.). Emits \`JSON.stringify(result, null, 2)\` instead of \`formatResult\` text.
- Preserve existing command-local \`--json\` behavior for CLI-only commands (check-resolvable, doctor, dream, orphans, …) via a new \`jsonPassThroughCommands\` allowlist option on \`parseGlobalFlags\`. cli.ts passes the existing \`CLI_ONLY\` set.
- Document \`--json\` in the top-level help under a new GLOBAL OPTIONS section.

## Why
Agent integrations need stable machine-readable output from shared ops without parsing human-formatted CLI text. Today on master:

\`\`\`
$ gbrain search "x" --json     # silently ignores --json, prints text
$ gbrain --json search "x"     # Unknown command: --json
\`\`\`

Only \`search modes/stats/tune\` honor \`--json\` (per-subcommand parser); the main \`search\`/\`query\` verbs don't have a JSON branch in \`formatResult\`.

## Verified locally on v0.42.36
\`\`\`
$ bun test test/cli-options.test.ts
35 pass, 0 fail (63 expect() calls)

$ bun src/cli.ts --json search "ADU permit" --limit 1
[{ "slug": "...", "score": 0.83, ... }]   ✓ JSON

$ bun src/cli.ts search "ADU permit" --limit 1 --json
[{ "slug": "...", "score": 0.83, ... }]   ✓ JSON

$ bun src/cli.ts search "ADU permit" --limit 1
[0.8303] agents/hermes-family/memory/builtin-memory -- ...   ✓ unchanged
\`\`\`

## Test plan
- \`bun test test/cli-options.test.ts\` — 35 pass
- 4 new tests cover: \`--json\` before command, \`--json\` after command, allowlist passthrough for CLI-only commands, precedence rule (\`--json\` before command always becomes global)
- Existing tests updated for new \`CliOptions.json\` field

## Threading
\`cliOpts.json\` is read at both dispatch sites — local-engine path (cli.ts:393) and remote MCP routed path (cli.ts:486) — so behavior matches across topologies.

Diff: +99/-14 across 3 files.