### PR TITLE
feat: add Copilot embedding provider (rebased on v0.42.36)

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -29,6 +29,10 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { z } from 'zod';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { randomUUID } from 'crypto';
 
 import {
   BudgetTracker,
@@ -87,6 +91,101 @@ const AI_MULTIMODAL_TIMEOUT_MS = resolveAiTimeoutMs('GBRAIN_AI_MULTIMODAL_TIMEOU
 function withDefaultTimeout(caller: AbortSignal | undefined, timeoutMs: number): AbortSignal {
   const timeout = AbortSignal.timeout(timeoutMs);
   return caller ? AbortSignal.any([caller, timeout]) : timeout;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub Copilot embeddings (PR #691).
+//
+// GitHub's `/embeddings` endpoint is NOT OpenAI-compatible: request shape is
+// `{ inputs, model }` and response is `{ embeddings: [{ embedding }] }`. The
+// recipe has implementation `'native-copilot'`, which `instantiateEmbedding`
+// turns into a marker object that `embedSubBatch` recognizes and routes
+// through the native fetch helper below — bypassing the Vercel AI SDK.
+// ---------------------------------------------------------------------------
+
+const COPILOT_API_URL = 'https://api.github.com/embeddings';
+const COPILOT_API_VERSION = '2025-05-01';
+const COPILOT_MARKER = Symbol('__gbrainCopilotEmbedding');
+interface CopilotEmbeddingModel { [COPILOT_MARKER]: true; modelId: string; cfg: AIGatewayConfig; }
+function isCopilotModel(model: any): model is CopilotEmbeddingModel {
+  return !!model && typeof model === 'object' && model[COPILOT_MARKER] === true;
+}
+
+function getCopilotToken(env: Record<string, string | undefined>): string {
+  const envToken = env.GBRAIN_COPILOT_TOKEN || env.COPILOT_GITHUB_TOKEN || env.GH_TOKEN || env.GITHUB_TOKEN;
+  if (envToken) return envToken;
+  const configToken = readCopilotCliToken();
+  if (configToken) return configToken;
+  throw new AIConfigError(
+    'Copilot embedding provider requires GBRAIN_COPILOT_TOKEN or a logged-in ~/.copilot/config.json.',
+    'Run GitHub Copilot login or set GBRAIN_COPILOT_TOKEN. Do not paste tokens into chat/logs.',
+  );
+}
+
+function readCopilotCliToken(): string | null {
+  try {
+    const raw = readFileSync(join(homedir(), '.copilot', 'config.json'), 'utf-8');
+    const withoutComments = raw.split('\n').filter(line => !line.trim().startsWith('//')).join('\n');
+    const config = JSON.parse(withoutComments) as {
+      lastLoggedInUser?: { host?: string; login?: string };
+      copilotTokens?: Record<string, string>;
+    };
+    const host = config.lastLoggedInUser?.host;
+    const login = config.lastLoggedInUser?.login;
+    if (host && login) {
+      const preferred = config.copilotTokens?.[`${host}:${login}`];
+      if (preferred) return preferred;
+    }
+    return Object.values(config.copilotTokens || {})[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeVector(vector: Float32Array): Float32Array {
+  let sum = 0;
+  for (let i = 0; i < vector.length; i++) sum += vector[i] * vector[i];
+  const norm = Math.sqrt(sum);
+  if (norm > 0) {
+    for (let i = 0; i < vector.length; i++) vector[i] /= norm;
+  }
+  return vector;
+}
+
+async function embedCopilot(
+  texts: string[],
+  modelId: string,
+  cfg: AIGatewayConfig,
+  opts?: { abortSignal?: AbortSignal },
+): Promise<Float32Array[]> {
+  const token = getCopilotToken(cfg.env);
+  const response = await fetch(cfg.env.GBRAIN_COPILOT_EMBEDDING_URL || COPILOT_API_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'X-GitHub-Api-Version': COPILOT_API_VERSION,
+      'X-GitHub-Request-ID': randomUUID(),
+      'User-Agent': 'gbrain',
+    },
+    body: JSON.stringify({ inputs: texts, model: modelId }),
+    ...(opts?.abortSignal ? { signal: opts.abortSignal } : {}),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new AITransientError(
+      `Copilot embeddings request failed: ${response.status} ${response.statusText}${body ? ` ${body}` : ''}`,
+    );
+  }
+  const payload = await response.json() as { embeddings?: { embedding?: number[] }[] };
+  if (!payload.embeddings || payload.embeddings.length !== texts.length) {
+    throw new AIConfigError(`Copilot embeddings response shape mismatch: expected ${texts.length}, got ${payload.embeddings?.length ?? 0}`);
+  }
+  return payload.embeddings.map(item => {
+    if (!item.embedding) throw new AIConfigError('Copilot embeddings response missing embedding');
+    return normalizeVector(new Float32Array(item.embedding));
+  });
 }
 
 const MAX_CHARS = 8000;
@@ -1221,6 +1320,11 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
       throw new AIConfigError(
         `Anthropic has no embedding model. Use openai or google for embeddings.`,
       );
+    case 'native-copilot':
+      // PR #691: GitHub Copilot embeddings — bypasses Vercel AI SDK because
+      // the request/response shape is { inputs, model } / { embeddings: [{ embedding }] }.
+      // embedSubBatch detects this marker and routes through embedCopilot().
+      return { [COPILOT_MARKER]: true, modelId, cfg } as CopilotEmbeddingModel;
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
       const auth = applyResolveAuth(recipe, cfg, 'embedding');
@@ -1557,6 +1661,24 @@ async function embedSubBatch(
   modelId: string,
   opts?: EmbedOpts,
 ): Promise<Float32Array[]> {
+  // PR #691: Copilot recipe uses native fetch, bypasses Vercel AI SDK.
+  // The marker object set by instantiateEmbedding routes here before _embedTransport.
+  if (isCopilotModel(model)) {
+    try {
+      const embeddings = await embedCopilot(texts, modelId, model.cfg, { abortSignal: opts?.abortSignal });
+      const first = embeddings[0];
+      if (first && first.length !== expectedDims) {
+        throw new AIConfigError(
+          `Embedding dim mismatch: model ${modelId} returned ${first.length} but schema expects ${expectedDims}.`,
+          `Run \`gbrain migrate --embedding-model ${getEmbeddingModel()} --embedding-dimensions ${first.length}\` or change models.`,
+        );
+      }
+      recordSubBatchSuccess(recipe);
+      return embeddings;
+    } catch (err) {
+      throw normalizeAIError(err, `embed(${recipe.id}:${modelId})`);
+    }
+  }
   try {
     const callTransport = () => _embedTransport({
       model,
@@ -2135,6 +2257,9 @@ function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayCon
       if (!apiKey) throw new AIConfigError(`Anthropic expansion requires ANTHROPIC_API_KEY.`, recipe.setup_hint);
       return createAnthropic({ apiKey }).languageModel(modelId);
     }
+    case 'native-copilot':
+      // PR #691: Copilot recipe is embedding-only. Use anthropic/openai/google for expansion.
+      throw new AIConfigError(`Copilot recipe is embedding-only. Use anthropic/openai/google for expansion.`);
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
       const auth = applyResolveAuth(recipe, cfg, 'expansion');
@@ -2507,6 +2632,9 @@ function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig):
       if (!apiKey) throw new AIConfigError(`Anthropic chat requires ANTHROPIC_API_KEY.`, recipe.setup_hint);
       return createAnthropic({ apiKey }).languageModel(modelId);
     }
+    case 'native-copilot':
+      // PR #691: Copilot recipe is embedding-only. Use anthropic/openai/google for chat.
+      throw new AIConfigError(`Copilot recipe is embedding-only. Use anthropic/openai/google for chat.`);
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
       const auth = applyResolveAuth(recipe, cfg, 'chat');

--- a/src/core/ai/recipes/copilot.ts
+++ b/src/core/ai/recipes/copilot.ts
@@ -1,0 +1,40 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * GitHub Copilot / Blackbird embeddings.
+ *
+ * This is not OpenAI-compatible: GitHub's endpoint accepts `{ inputs, model }`
+ * and returns `{ embeddings: [{ embedding }] }`, so gateway.ts handles it as a
+ * dedicated recipe implementation.
+ */
+export const copilot: Recipe = {
+  id: 'copilot',
+  name: 'GitHub Copilot embeddings',
+  tier: 'native',
+  implementation: 'native-copilot',
+  auth_env: {
+    required: [],
+    optional: [
+      'GBRAIN_COPILOT_TOKEN',
+      'COPILOT_GITHUB_TOKEN',
+      'GH_TOKEN',
+      'GITHUB_TOKEN',
+      'GBRAIN_COPILOT_EMBEDDING_URL',
+    ],
+    setup_url: 'https://github.com/features/copilot',
+  },
+  touchpoints: {
+    embedding: {
+      models: ['metis-1024-I16-Binary'],
+      default_dims: 1024,
+      max_batch_tokens: 8192,
+      cost_per_1m_tokens_usd: undefined,
+      price_last_verified: '2026-05-06',
+    },
+  },
+  aliases: {
+    blackbird: 'metis-1024-I16-Binary',
+    metis: 'metis-1024-I16-Binary',
+  },
+  setup_hint: 'Use GitHub Copilot login or set GBRAIN_COPILOT_TOKEN. Configure `GBRAIN_EMBEDDING_MODEL=copilot:metis-1024-I16-Binary` and `GBRAIN_EMBEDDING_DIMENSIONS=1024`.',
+};

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -22,6 +22,7 @@ import { dashscope } from './dashscope.ts';
 import { zhipu } from './zhipu.ts';
 import { azureOpenAI } from './azure-openai.ts';
 import { zeroentropyai } from './zeroentropyai.ts';
+import { copilot } from './copilot.ts';
 import { llamaServerReranker } from './llama-server-reranker.ts';
 
 const ALL: Recipe[] = [
@@ -42,6 +43,7 @@ const ALL: Recipe[] = [
   zhipu,
   azureOpenAI,
   zeroentropyai,
+  copilot,
 ];
 
 /** Map from `provider:id` key to recipe. */

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -22,6 +22,7 @@ export type Implementation =
   | 'native-openai'
   | 'native-google'
   | 'native-anthropic'
+  | 'native-copilot'
   | 'openai-compatible';
 
 export interface EmbeddingTouchpoint {

--- a/test/ai/copilot-provider.test.ts
+++ b/test/ai/copilot-provider.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, expect, mock, test } from 'bun:test';
+import { configureGateway, embedOne, isAvailable, resetGateway } from '../../src/core/ai/gateway.ts';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  resetGateway();
+});
+
+test('copilot recipe is registered for metis embeddings', () => {
+  const recipe = getRecipe('copilot');
+  expect(recipe?.touchpoints.embedding?.models).toContain('metis-1024-I16-Binary');
+  expect(recipe?.touchpoints.embedding?.default_dims).toBe(1024);
+});
+
+test('copilot embedding provider calls GitHub embeddings endpoint without OpenAI-compatible body shape', async () => {
+  const vector = Array.from({ length: 1024 }, (_, i) => i === 0 ? 1 : 0);
+  const fetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+    expect(String(input)).toBe('https://api.github.com/embeddings');
+    expect(init?.method).toBe('POST');
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer test-token');
+    expect(headers['X-GitHub-Api-Version']).toBe('2025-05-01');
+    const body = JSON.parse(String(init?.body));
+    expect(body).toEqual({ inputs: ['gbrain smoke test'], model: 'metis-1024-I16-Binary' });
+    return new Response(JSON.stringify({ embeddings: [{ embedding: vector }] }), { status: 200 });
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  configureGateway({
+    embedding_model: 'copilot:metis-1024-I16-Binary',
+    embedding_dimensions: 1024,
+    env: { GBRAIN_COPILOT_TOKEN: 'test-token' },
+  });
+
+  expect(isAvailable('embedding')).toBe(true);
+  const result = await embedOne('gbrain smoke test');
+  expect(result.length).toBe(1024);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
Replaces closed PR #691 — same author, rebased on top of master \`959af106\` (v0.42.36.0). The original PR can't be reopened because GitHub blocks reopen-after-force-push.

## Summary
Adds native Copilot embedding provider for GitHub Copilot / Blackbird Metis embeddings. Calls GitHub's \`/embeddings\` endpoint directly with the Copilot request/response shape (\`{ inputs, model }\` → \`{ embeddings: [{ embedding }] }\`), bypassing the Vercel AI SDK because the shape is not OpenAI-compatible.

Wires up across all four touchpoints required for \`isAvailable('embedding')\` to return true on v0.42:

1. \`types.ts\` — add \`'native-copilot'\` to the \`Implementation\` union
2. \`recipes/copilot.ts\` — new recipe with \`metis-1024-I16-Binary\` model (1024d), \`max_batch_tokens: 8192\`
3. \`recipes/index.ts\` — register copilot in \`ALL[]\`
4. \`gateway.ts\` — marker-based routing in \`instantiateEmbedding\` + \`embedSubBatch\` short-circuit + clear errors in expansion/chat

## Why
GitHub Copilot's embedding endpoint is the only zero-config embedding option for users who already pay for Copilot — no separate API key, no extra service, just \`~/.copilot/config.json\` which the Copilot CLI maintains. The existing \`litellm-proxy\` recipe is a workaround but requires the user to install LiteLLM, configure it as a Copilot bridge, and run it as a separate process.

## Auth chain
\`GBRAIN_COPILOT_TOKEN\` → \`COPILOT_GITHUB_TOKEN\` → \`GH_TOKEN\` → \`GITHUB_TOKEN\` → \`~/.copilot/config.json\` (Copilot CLI login).

## Architecture

\`\`\`
recipe.implementation = 'native-copilot'
                         │
                         ▼
instantiateEmbedding ──► returns marker { [COPILOT_MARKER]: true, modelId, cfg }
                         │
                         ▼
embedSubBatch ──► isCopilotModel(model) ──► embedCopilot()
                                              │
                                              ▼
                                  fetch(api.github.com/embeddings)
                                  L2 normalize + dim check + abortSignal
\`\`\`

## Verified locally on v0.42.36
\`\`\`
$ bun test test/ai/copilot-provider.test.ts
2 pass, 0 fail

$ bun test test/ai/
317 pass, 0 fail (1070 expect() calls, 31 files, 1.1s)
\`\`\`

Full \`test/ai/\` suite passes — no regressions to existing recipes (anthropic, google, openai, voyage, zeroentropyai, openrouter, litellm-proxy, ollama, …).

## Config
\`\`\`bash
export GBRAIN_EMBEDDING_MODEL=copilot:metis-1024-I16-Binary
export GBRAIN_EMBEDDING_DIMENSIONS=1024
\`\`\`

## What changed during v0.36 → v0.42 forward-port
- \`embedSubBatch\` signature now takes the v0.42 \`EmbedOpts\` (abortSignal, maxRetries) — threaded into \`embedCopilot\` via the existing \`{ abortSignal }\` opts contract
- \`recordSubBatchSuccess(recipe)\` and \`getEmbeddingModel()\` references match v0.42 names
- Recipe declares \`max_batch_tokens: 8192\` (v0.32 D8 batch-budget validation hard-fails recipes without it on first import — the gateway loads the whole recipe table at startup)
- \`User-Agent\` simplified from a hardcoded \`gbrain/0.36.0\` to plain \`gbrain\` (avoids version drift)

Chat / expansion paths throw a clear \`AIConfigError("Copilot recipe is embedding-only.")\`.

Diff: +213/-0 across 5 files.