### PR TITLE
fix: accept explicit LiteLLM embedding models

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -704,12 +704,16 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
     };
   }
 
-  // Openai-compat recipes with empty models list require a user-provided model.
+  // OpenAI-compatible recipes with empty model lists require a concrete
+  // provider:model string, but an already-parsed non-empty modelId satisfies
+  // that contract. The old check rejected every litellm/llama-server model,
+  // including valid values like litellm:text-embedding-qwen3-embedding-0.6b.
   const isUserProvided = (tp as any).user_provided_models === true;
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
-    (recipe.id === 'litellm' || isUserProvided)
+    (recipe.id === 'litellm' || isUserProvided) &&
+    !parsed.modelId
   ) {
     return {
       ok: false,

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -449,6 +449,14 @@ function isCustomDimValidForProvider(
     };
   }
 
+  // User-provided OpenAI-compatible recipes (litellm, llama-server) require the
+  // operator to declare the provider's native dimension. Treat that declaration
+  // as schema sizing, not a custom-dimension request; the first embed still
+  // validates the actual returned vector width before storage.
+  if (recipe.touchpoints.embedding?.user_provided_models === true) {
+    return { valid: true, error: '' };
+  }
+
   // Tier 3: provider not known to support custom dims at all.
   return {
     valid: false,

--- a/test/litellm-embedding-config.test.ts
+++ b/test/litellm-embedding-config.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { configureGateway, diagnoseEmbedding, resetGateway } from '../src/core/ai/gateway.ts';
+import { resolveSchemaEmbeddingDim } from '../src/core/embedding-dim-check.ts';
+
+afterEach(() => {
+  resetGateway();
+});
+
+describe('OpenAI-compatible embedding configuration', () => {
+  test('diagnoseEmbedding accepts explicit LiteLLM model ids', () => {
+    configureGateway({
+      embedding_model: 'litellm:text-embedding-qwen3-embedding-0.6b',
+      embedding_dimensions: 1024,
+      env: { LITELLM_API_KEY: 'test-key' },
+      base_urls: { litellm: 'http://127.0.0.1:1234/v1' },
+    });
+
+    expect(diagnoseEmbedding()).toEqual({
+      ok: true,
+      model: 'litellm:text-embedding-qwen3-embedding-0.6b',
+      provider: 'litellm',
+      recipeId: 'litellm',
+    });
+  });
+
+  test('diagnoseEmbedding still rejects provider-only LiteLLM embedding config', () => {
+    configureGateway({
+      embedding_model: 'litellm',
+      embedding_dimensions: 1024,
+      env: { LITELLM_API_KEY: 'test-key' },
+      base_urls: { litellm: 'http://127.0.0.1:1234/v1' },
+    });
+
+    expect(diagnoseEmbedding()).toMatchObject({
+      ok: false,
+      reason: 'unknown_provider',
+      provider: 'unknown',
+    });
+  });
+
+  test('schema dim resolver treats user-provided OpenAI-compatible dims as native schema sizing', () => {
+    expect(resolveSchemaEmbeddingDim({
+      embedding_model: 'litellm:text-embedding-qwen3-embedding-0.6b',
+      embedding_dimensions: 1024,
+    })).toMatchObject({ ok: true, dim: 1024, provider: 'litellm' });
+
+    expect(resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:nomic-embed-text',
+      embedding_dimensions: 768,
+    })).toMatchObject({ ok: true, dim: 768, provider: 'llama-server' });
+  });
+});


### PR DESCRIPTION
## Summary
- Accept explicit model IDs for user-provided OpenAI-compatible embedding recipes like LiteLLM and llama-server
- Treat declared dimensions for those recipes as native schema sizing, not unsupported custom-dimension requests
- Add regression tests for LiteLLM diagnosis and LiteLLM/llama-server schema dimension resolution

## Test Plan
- `bun test test/litellm-embedding-config.test.ts`

## Real behavior proof
Before this patch, a valid config like `embedding_model=litellm:text-embedding-qwen3-embedding-0.6b` could be rejected during embedding diagnosis because the LiteLLM recipe has an empty static model list. During a real local LM Studio/LiteLLM-backed Documents ingest, this blocked a user-provided embedding model even though the provider and concrete model were configured. The new test pins the valid explicit-model path while preserving rejection for provider-only shorthand.
