### PR TITLE
feat: emit import heartbeat progress

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -41,6 +41,56 @@ export interface RunImportResult {
   failures: Array<{ path: string; error: string }>;
 }
 
+export interface ImportHeartbeatState {
+  processed: number;
+  total: number;
+  imported: number;
+  skipped: number;
+  errors: number;
+  chunksCreated: number;
+  activeWorkers: number;
+  lastSuccessPath: string | null;
+  slowFiles: Array<{ path: string; elapsedMs: number }>;
+  elapsedMs: number;
+}
+
+export function formatImportHeartbeat(state: ImportHeartbeatState): string {
+  const pct = state.total > 0 ? Math.floor((state.processed / state.total) * 100) : 100;
+  const elapsedS = Math.max(0, Math.round(state.elapsedMs / 1000));
+  const rate = state.elapsedMs > 0 ? state.processed / (state.elapsedMs / 1000) : 0;
+  const remaining = Math.max(0, state.total - state.processed);
+  const etaS = rate > 0 ? Math.round(remaining / rate) : null;
+  const parts = [
+    `[gbrain heartbeat] import.files ${state.processed}/${state.total} (${pct}%)`,
+    `imported=${state.imported}`,
+    `skipped=${state.skipped}`,
+    `errors=${state.errors}`,
+    `chunks=${state.chunksCreated}`,
+    `active=${state.activeWorkers}`,
+    `elapsed=${elapsedS}s`,
+  ];
+  if (etaS !== null) parts.push(`eta=${etaS}s`);
+  if (state.lastSuccessPath) parts.push(`last_success=${state.lastSuccessPath}`);
+  if (state.slowFiles.length > 0) {
+    const slow = state.slowFiles
+      .slice(0, 3)
+      .map(f => `${f.path}:${Math.round(f.elapsedMs / 1000)}s`)
+      .join(',');
+    parts.push(`slow=${slow}`);
+  }
+  return parts.join(' ');
+}
+
+function resolveImportHeartbeatMs(): number {
+  const raw = process.env.GBRAIN_IMPORT_HEARTBEAT_MS;
+  if (raw === '0' || raw === 'false') return 0;
+  if (raw) {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return 30_000;
+}
+
 export async function runImport(
   engine: BrainEngine,
   args: string[],
@@ -215,7 +265,31 @@ export async function runImport(
   const importedSlugs: string[] = [];
   const errorCounts: Record<string, number> = {};
   const failures: Array<{ path: string; error: string }> = []; // Bug 9
+  let lastSuccessPath: string | null = null;
+  const activeFiles = new Map<string, number>();
   const startTime = Date.now();
+  const heartbeatMs = resolveImportHeartbeatMs();
+  const heartbeat = heartbeatMs > 0
+    ? setInterval(() => {
+      const now = Date.now();
+      console.error(formatImportHeartbeat({
+        processed,
+        total: files.length,
+        imported,
+        skipped,
+        errors,
+        chunksCreated,
+        activeWorkers: activeFiles.size,
+        lastSuccessPath,
+        slowFiles: Array.from(activeFiles.entries())
+          .map(([path, startedAt]) => ({ path, elapsedMs: now - startedAt }))
+          .filter(f => f.elapsedMs >= 5000)
+          .sort((a, b) => b.elapsedMs - a.elapsedMs),
+        elapsedMs: now - startTime,
+      }));
+    }, heartbeatMs)
+    : null;
+  if (heartbeat?.unref) heartbeat.unref();
 
   // Progress on stderr so stdout stays clean for the final summary / --json payload.
   const progress = createProgress(cliOptsToProgressOptions(getCliOptions()));
@@ -227,6 +301,7 @@ export async function runImport(
 
   async function processFile(eng: BrainEngine, filePath: string) {
     const relativePath = relative(dir, filePath);
+    activeFiles.set(relativePath, Date.now());
     // v0.31.2 (D5): per-file slow-path log. Fires only when a single
     // file takes >5s. The user's hang surfaces as one file taking
     // forever — without this, the agent can't see which file.
@@ -247,6 +322,7 @@ export async function runImport(
         imported++;
         chunksCreated += result.chunks;
         importedSlugs.push(result.slug);
+        lastSuccessPath = relativePath;
         // v0.33.2: path-based checkpoint — record only on success.
         completed.add(relativePath);
       } else {
@@ -275,6 +351,7 @@ export async function runImport(
       failures.push({ path: relativePath, error: msg });
     }
     processed++;
+    activeFiles.delete(relativePath);
     tickProgress();
     // Save checkpoint every 100 SUCCESSFUL adds (not every 100 processed).
     // Failed files never enter `completed`, so a flaky file can't push the
@@ -353,6 +430,7 @@ export async function runImport(
     }
   }
 
+  if (heartbeat) clearInterval(heartbeat);
   progress.finish();
 
   // Error summary

--- a/test/import-heartbeat.test.ts
+++ b/test/import-heartbeat.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+
+import { formatImportHeartbeat } from '../src/commands/import.ts';
+
+describe('import heartbeat formatting', () => {
+  test('renders progress, rate-derived eta, last success, and slow active files', () => {
+    const line = formatImportHeartbeat({
+      processed: 25,
+      total: 100,
+      imported: 20,
+      skipped: 4,
+      errors: 1,
+      chunksCreated: 87,
+      activeWorkers: 2,
+      lastSuccessPath: 'docs/last.md',
+      slowFiles: [
+        { path: 'docs/slow-a.md', elapsedMs: 12_400 },
+        { path: 'docs/slow-b.md', elapsedMs: 7_100 },
+      ],
+      elapsedMs: 10_000,
+    });
+
+    expect(line).toContain('[gbrain heartbeat] import.files 25/100 (25%)');
+    expect(line).toContain('imported=20');
+    expect(line).toContain('skipped=4');
+    expect(line).toContain('errors=1');
+    expect(line).toContain('chunks=87');
+    expect(line).toContain('active=2');
+    expect(line).toContain('elapsed=10s');
+    expect(line).toContain('eta=30s');
+    expect(line).toContain('last_success=docs/last.md');
+    expect(line).toContain('slow=docs/slow-a.md:12s,docs/slow-b.md:7s');
+  });
+});


### PR DESCRIPTION
## Summary
- Emit a periodic stderr heartbeat during long-running imports
- Report processed/total, imported/skipped/errors, chunks, active worker count, elapsed time, ETA, last successful file, and slow active files
- Add a unit test for the heartbeat formatter

## Test Plan
- `bun test test/import-heartbeat.test.ts`

## Real behavior proof
During a 30k-file Documents import backed by a LAN OpenAI-compatible embedding server, normal progress output stopped updating for hours while the parent process still appeared alive. This heartbeat gives operators enough state to tell slow embeddings from a stuck import without polluting stdout or JSON output.
