### PR TITLE
feat: add import planning summary

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,6 +1,6 @@
 import { readdirSync, lstatSync, existsSync } from 'fs';
 import { execFileSync } from 'child_process';
-import { join, relative } from 'path';
+import { join, relative, extname } from 'path';
 import { cpus, totalmem } from 'os';
 import type { BrainEngine } from '../core/engine.ts';
 import { importFile, importImageFile, isImageFilePath } from '../core/import-file.ts';
@@ -41,6 +41,53 @@ export interface RunImportResult {
   failures: Array<{ path: string; error: string }>;
 }
 
+export interface ImportPlanSummary {
+  status: 'import_plan';
+  dir: string;
+  strategy: SyncStrategy;
+  total_files: number;
+  total_bytes: number;
+  by_extension: Array<{ extension: string; files: number; bytes: number }>;
+  workers: number;
+  source_id: string;
+  embedding: 'enabled' | 'disabled';
+}
+
+export function summarizeImportPlan(opts: {
+  dir: string;
+  strategy: SyncStrategy;
+  files: string[];
+  workers: number;
+  sourceId?: string;
+  noEmbed: boolean;
+}): ImportPlanSummary {
+  const byExt = new Map<string, { files: number; bytes: number }>();
+  let totalBytes = 0;
+  for (const file of opts.files) {
+    let size = 0;
+    try { size = lstatSync(file).size; } catch { size = 0; }
+    totalBytes += size;
+    const extension = extname(file).toLowerCase() || '[noext]';
+    const row = byExt.get(extension) ?? { files: 0, bytes: 0 };
+    row.files += 1;
+    row.bytes += size;
+    byExt.set(extension, row);
+  }
+  return {
+    status: 'import_plan',
+    dir: opts.dir,
+    strategy: opts.strategy,
+    total_files: opts.files.length,
+    total_bytes: totalBytes,
+    by_extension: Array.from(byExt.entries())
+      .map(([extension, row]) => ({ extension, ...row }))
+      .sort((a, b) => b.bytes - a.bytes || b.files - a.files || a.extension.localeCompare(b.extension)),
+    workers: opts.workers,
+    source_id: opts.sourceId ?? 'default',
+    embedding: opts.noEmbed ? 'disabled' : 'enabled',
+  };
+}
+
 export async function runImport(
   engine: BrainEngine,
   args: string[],
@@ -49,12 +96,11 @@ export async function runImport(
   const noEmbed = args.includes('--no-embed');
   const fresh = args.includes('--fresh');
   const jsonOutput = args.includes('--json');
+  const planOnly = args.includes('--plan') || args.includes('--dry-run');
 
-  // T7 (D9): refuse cleanly when init persisted the deferred-setup sentinel,
-  // unless the user is explicitly skipping embedding via `--no-embed` (in
-  // which case the chunks land without vectors and the user can backfill
-  // later with `gbrain embed --stale` after configuring a provider).
-  if (!noEmbed) {
+  // Planning is intentionally credentials-free: operators use it before spending
+  // embedding calls or wiring API keys to see what a large tree would import.
+  if (!noEmbed && !planOnly) {
     const { assertEmbeddingEnabled } = await import('../core/embedding-dim-check.ts');
     const { loadConfig } = await import('../core/config.ts');
     try {
@@ -163,7 +209,7 @@ export async function runImport(
   const dirArg = args.find((a, i) => !a.startsWith('--') && !flagValues.has(i));
 
   if (!dirArg) {
-    console.error('Usage: gbrain import <dir> [--no-embed] [--workers N] [--fresh] [--source-id <id>] [--json]');
+    console.error('Usage: gbrain import <dir> [--no-embed] [--workers N] [--fresh] [--source-id <id>] [--json] [--plan|--dry-run]');
     process.exit(1);
   }
   const dir: string = dirArg;  // narrowed; survives closure capture
@@ -181,7 +227,11 @@ export async function runImport(
   );
   const fileTypeLabel = strategy === 'code' ? 'code'
     : strategy === 'auto' ? 'syncable' : 'markdown';
-  console.log(`Found ${allFiles.length} ${fileTypeLabel} files`);
+  if (jsonOutput) {
+    console.error(`Found ${allFiles.length} ${fileTypeLabel} files`);
+  } else {
+    console.log(`Found ${allFiles.length} ${fileTypeLabel} files`);
+  }
 
   // Sort newest-first so date-prefixed brain paths get embedded before older ones.
   // See src/core/sort-newest-first.ts for the policy.
@@ -196,7 +246,9 @@ export async function runImport(
     const cp = loadCheckpoint(checkpointPath, dir);
     if (cp) {
       for (const p of cp.completedPaths) completed.add(p);
-      console.log(`Resuming from checkpoint: skipping ${completed.size} already-processed files`);
+      const resumeMsg = `Resuming from checkpoint: skipping ${completed.size} already-processed files`;
+      if (jsonOutput) console.error(resumeMsg);
+      else console.log(resumeMsg);
     }
   }
   const files = resumeFilter(allFiles, dir, completed);
@@ -204,7 +256,36 @@ export async function runImport(
   // Determine actual worker count
   const actualWorkers = workerCount > 1 ? workerCount : 1;
   if (actualWorkers > 1) {
-    console.log(`Using ${actualWorkers} parallel workers`);
+    const workersMsg = `Using ${actualWorkers} parallel workers`;
+    if (jsonOutput) console.error(workersMsg);
+    else console.log(workersMsg);
+  }
+
+  if (planOnly) {
+    const plan = summarizeImportPlan({
+      dir,
+      strategy,
+      files: allFiles,
+      workers: actualWorkers,
+      sourceId,
+      noEmbed,
+    });
+    if (jsonOutput) {
+      console.log(JSON.stringify(plan));
+    } else {
+      console.log('\nImport plan:');
+      console.log(`  source: ${plan.source_id}`);
+      console.log(`  strategy: ${plan.strategy}`);
+      console.log(`  embedding: ${plan.embedding}`);
+      console.log(`  workers: ${plan.workers}`);
+      console.log(`  files: ${plan.total_files}`);
+      console.log(`  bytes: ${plan.total_bytes}`);
+      console.log('  top extensions:');
+      for (const row of plan.by_extension.slice(0, 10)) {
+        console.log(`    ${row.extension}: ${row.files} files, ${row.bytes} bytes`);
+      }
+    }
+    return { imported: 0, skipped: 0, errors: 0, chunksCreated: 0, failures: [] };
   }
 
   let imported = 0;

--- a/test/import-plan.test.ts
+++ b/test/import-plan.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { summarizeImportPlan } from '../src/commands/import.ts';
+
+let tmp: string | null = null;
+
+afterEach(() => {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+  tmp = null;
+});
+
+describe('import plan summary', () => {
+  test('summarizes importable files by extension without embedding', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'gbrain-import-plan-'));
+    const md = join(tmp, 'a.md');
+    const txt = join(tmp, 'b.txt');
+    const txt2 = join(tmp, 'c.txt');
+    writeFileSync(md, 'hello');
+    writeFileSync(txt, 'world!');
+    writeFileSync(txt2, 'again');
+
+    const plan = summarizeImportPlan({
+      dir: tmp,
+      strategy: 'markdown',
+      files: [md, txt, txt2],
+      workers: 2,
+      sourceId: 'documents',
+      noEmbed: true,
+    });
+
+    expect(plan).toMatchObject({
+      status: 'import_plan',
+      dir: tmp,
+      strategy: 'markdown',
+      total_files: 3,
+      total_bytes: 16,
+      workers: 2,
+      source_id: 'documents',
+      embedding: 'disabled',
+    });
+    expect(plan.by_extension).toEqual([
+      { extension: '.txt', files: 2, bytes: 11 },
+      { extension: '.md', files: 1, bytes: 5 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `gbrain import --plan` / `--dry-run` to summarize a corpus before importing
- Report source, strategy, embedding mode, worker count, total files/bytes, and top extensions
- Keep JSON-mode progress chatter on stderr so the plan payload stays machine-readable
- Add a unit test for the planning summary

## Test Plan
- `bun test test/import-plan.test.ts`

## Real behavior proof
For a large Documents ingest, I had to write an external staging/planning script just to know what would be imported before spending embedding calls. This PR adds the core planning summary directly to import so operators can inspect large trees first.
