### PR TITLE
feat: write import manifest records

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,6 +1,6 @@
-import { readdirSync, lstatSync, existsSync } from 'fs';
+import { readdirSync, lstatSync, existsSync, appendFileSync, mkdirSync } from 'fs';
 import { execFileSync } from 'child_process';
-import { join, relative } from 'path';
+import { join, relative, dirname } from 'path';
 import { cpus, totalmem } from 'os';
 import type { BrainEngine } from '../core/engine.ts';
 import { importFile, importImageFile, isImageFilePath } from '../core/import-file.ts';
@@ -39,6 +39,22 @@ export interface RunImportResult {
   errors: number;
   chunksCreated: number;
   failures: Array<{ path: string; error: string }>;
+}
+
+export interface ImportManifestRecord {
+  path: string;
+  source_id: string;
+  status: 'imported' | 'skipped' | 'error';
+  slug?: string;
+  chunks?: number;
+  error?: string;
+  duration_ms: number;
+}
+
+export function appendImportManifestRecord(path: string, record: ImportManifestRecord): void {
+  const dir = dirname(path);
+  if (dir && dir !== '.') mkdirSync(dir, { recursive: true });
+  appendFileSync(path, JSON.stringify(record) + '\n', 'utf-8');
 }
 
 export async function runImport(
@@ -145,6 +161,8 @@ export async function runImport(
   }
   const workersIdx = args.indexOf('--workers');
   const workersArg = workersIdx !== -1 ? args[workersIdx + 1] : null;
+  const manifestIdx = args.indexOf('--manifest');
+  const manifestPath = manifestIdx !== -1 ? args[manifestIdx + 1] : null;
   // v0.22.13 (PR #490 Q2): shared parseWorkers helper rejects bad input
   // (--workers 0, -3, "foo") with a loud error instead of silently falling
   // through to 1. Mirrors sync.ts's flag handling.
@@ -160,13 +178,18 @@ export async function runImport(
   const flagValues = new Set<number>();
   if (workersIdx !== -1) flagValues.add(workersIdx + 1);
   if (sourceIdIdx !== -1) flagValues.add(sourceIdIdx + 1);
+  if (manifestIdx !== -1) flagValues.add(manifestIdx + 1);
   const dirArg = args.find((a, i) => !a.startsWith('--') && !flagValues.has(i));
 
   if (!dirArg) {
-    console.error('Usage: gbrain import <dir> [--no-embed] [--workers N] [--fresh] [--source-id <id>] [--json]');
+    console.error('Usage: gbrain import <dir> [--no-embed] [--workers N] [--fresh] [--source-id <id>] [--manifest path.jsonl] [--json]');
     process.exit(1);
   }
   const dir: string = dirArg;  // narrowed; survives closure capture
+  if (manifestIdx !== -1 && !manifestPath) {
+    console.error('--manifest requires a path');
+    process.exit(1);
+  }
 
   // v0.31.2: collect under the right strategy. Pre-fix this called
   // collectMarkdownFiles unconditionally — code-strategy first sync
@@ -247,10 +270,31 @@ export async function runImport(
         imported++;
         chunksCreated += result.chunks;
         importedSlugs.push(result.slug);
+        if (manifestPath) {
+          appendImportManifestRecord(manifestPath, {
+            path: relativePath,
+            source_id: sourceId ?? 'default',
+            status: 'imported',
+            slug: result.slug,
+            chunks: result.chunks,
+            duration_ms: _fileMs,
+          });
+        }
         // v0.33.2: path-based checkpoint — record only on success.
         completed.add(relativePath);
       } else {
         skipped++;
+        if (manifestPath) {
+          appendImportManifestRecord(manifestPath, {
+            path: relativePath,
+            source_id: sourceId ?? 'default',
+            status: 'skipped',
+            slug: result.slug,
+            chunks: result.chunks,
+            error: result.error,
+            duration_ms: _fileMs,
+          });
+        }
         if (result.error && result.error !== 'unchanged') {
           console.error(`  Skipped ${relativePath}: ${result.error}`);
           // Bug 9 — non-"unchanged" skips carry a real error reason.
@@ -273,6 +317,15 @@ export async function runImport(
       errors++;
       skipped++;
       failures.push({ path: relativePath, error: msg });
+      if (manifestPath) {
+        appendImportManifestRecord(manifestPath, {
+          path: relativePath,
+          source_id: sourceId ?? 'default',
+          status: 'error',
+          error: msg,
+          duration_ms: Date.now() - _fileT0,
+        });
+      }
     }
     processed++;
     tickProgress();

--- a/test/import-manifest.test.ts
+++ b/test/import-manifest.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { appendImportManifestRecord } from '../src/commands/import.ts';
+
+let tmp: string | null = null;
+
+afterEach(() => {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+  tmp = null;
+});
+
+describe('import manifest records', () => {
+  test('appends jsonl records and creates parent directories', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'gbrain-import-manifest-'));
+    const manifest = join(tmp, 'logs', 'manifest.jsonl');
+
+    appendImportManifestRecord(manifest, {
+      path: 'docs/a.md',
+      source_id: 'documents',
+      status: 'imported',
+      slug: 'docs/a',
+      chunks: 3,
+      duration_ms: 42,
+    });
+    appendImportManifestRecord(manifest, {
+      path: 'docs/b.md',
+      source_id: 'documents',
+      status: 'skipped',
+      error: 'unchanged',
+      duration_ms: 7,
+    });
+
+    expect(existsSync(manifest)).toBe(true);
+    const rows = readFileSync(manifest, 'utf-8').trim().split('\n').map(line => JSON.parse(line));
+    expect(rows).toEqual([
+      {
+        path: 'docs/a.md',
+        source_id: 'documents',
+        status: 'imported',
+        slug: 'docs/a',
+        chunks: 3,
+        duration_ms: 42,
+      },
+      {
+        path: 'docs/b.md',
+        source_id: 'documents',
+        status: 'skipped',
+        error: 'unchanged',
+        duration_ms: 7,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `gbrain import --manifest path.jsonl` for append-only per-file import audit records
- Record imported/skipped/error status, source id, slug, chunks, errors, and duration
- Add a unit test for JSONL manifest appends and parent directory creation

## Test Plan
- `bun test test/import-manifest.test.ts`

## Real behavior proof
During a large Documents import, the only durable failure trail was stderr plus an external script. A JSONL manifest gives operators a machine-readable record of what imported, skipped, or failed so large imports can be resumed and audited without scraping terminal output.
