### PR TITLE
feat: support auto import workers

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -148,10 +148,11 @@ export async function runImport(
   // v0.22.13 (PR #490 Q2): shared parseWorkers helper rejects bad input
   // (--workers 0, -3, "foo") with a loud error instead of silently falling
   // through to 1. Mirrors sync.ts's flag handling.
-  const { parseWorkers } = await import('../core/sync-concurrency.ts');
-  let workerCount: number;
+  const { parseWorkers, autoConcurrency } = await import('../core/sync-concurrency.ts');
+  let workerCount: number | undefined;
+  const workersAuto = workersArg === 'auto';
   try {
-    workerCount = parseWorkers(workersArg ?? undefined) ?? 1;
+    workerCount = workersAuto ? undefined : parseWorkers(workersArg ?? undefined);
   } catch (e) {
     console.error(e instanceof Error ? e.message : String(e));
     process.exit(1);
@@ -201,8 +202,9 @@ export async function runImport(
   }
   const files = resumeFilter(allFiles, dir, completed);
 
-  // Determine actual worker count
-  const actualWorkers = workerCount > 1 ? workerCount : 1;
+  // Determine actual worker count. Default stays serial for backwards compatibility;
+  // `--workers auto` opts into the shared sync/import concurrency policy.
+  const actualWorkers = workersAuto ? autoConcurrency(engine, files.length, undefined) : (workerCount ?? 1);
   if (actualWorkers > 1) {
     console.log(`Using ${actualWorkers} parallel workers`);
   }

--- a/test/import-workers-auto.test.ts
+++ b/test/import-workers-auto.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC = readFileSync(join(import.meta.dir, '../src/commands/import.ts'), 'utf-8');
+
+describe('import --workers auto wiring', () => {
+  test('accepts --workers auto and routes through shared autoConcurrency policy', () => {
+    expect(SRC).toContain("workersArg === 'auto'");
+    expect(SRC).toContain('autoConcurrency(engine, files.length, undefined)');
+    expect(SRC).toContain('workerCount ?? 1');
+  });
+});


### PR DESCRIPTION
## Summary
- Allow `gbrain import --workers auto` to opt into the shared auto-concurrency policy
- Keep the default import path serial for compatibility
- Add a regression test that pins the CLI wiring to `autoConcurrency`

## Test Plan
- `bun test test/import-workers-auto.test.ts`

## Real behavior proof
For a large Documents import, I had to manually choose worker counts. Sync already has a shared auto-concurrency policy, but import could only accept explicit integers. This makes the operator path less footgunny without changing default serial behavior.
