### PR TITLE
feat(ai/litellm): add chat touchpoint for user_provided_models

### DIFF
--- a/src/core/ai/recipes/litellm-proxy.ts
+++ b/src/core/ai/recipes/litellm-proxy.ts
@@ -40,6 +40,25 @@ export const litellmProxy: Recipe = {
       // mismatched-dim responses pre-storage).
       supports_multimodal: true,
     },
+    // Local fork patch (realpan, 2026-06-09): add chat touchpoint so gbrain can
+    // route think / chat through any LiteLLM-proxied provider. Mirror the
+    // embedding setup:
+    //   - user_provided_models: true (LiteLLM knows its own model catalog)
+    //   - supports_subagent_loop: false (cross-crash replay safety not validated)
+    //   - max_context_tokens: 128000 (reasonable default for proxied chat models)
+    // Models known via LiteLLM include: kimi-coding, minimax-m3,
+    // moonshot-v1-32k, deepseek-chat, etc.
+    chat: {
+      models: [],
+      user_provided_models: true,
+      supports_tools: true,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      max_context_tokens: 128000,
+      cost_per_1m_input_usd: undefined,
+      cost_per_1m_output_usd: undefined,
+      price_last_verified: '2026-06-09',
+    },
   },
   setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL + pass --embedding-model litellm:<model> and --embedding-dimensions <N>.',
 };


### PR DESCRIPTION
# Add chat touchpoint to litellm-proxy recipe

## What

Allow gbrain to use any LiteLLM-proxied chat model for `gbrain think`,
`gbrain search --chat`, and the four model tiers (`utility` / `reasoning` /
`deep` / `subagent`).

Today, `litellm-proxy.ts` only declares an `embedding` touchpoint. When a
user sets `chat_model = litellm:some-model`, `validateModelId()` in
`src/core/ai/gateway.ts` rejects it with:

> Provider "litellm" does not support touchpoint "chat".

This forces users who already run LiteLLM for embeddings to fall back to
Anthropic / DeepSeek for chat, even though the same LiteLLM proxy could
serve both — defeating half the purpose of the proxy.

## Why

The `litellm-proxy.ts` recipe already uses `user_provided_models: true`
for embedding, signalling that the model catalog is owned by the proxy,
not by gbrain. Adding `chat` with the same flag keeps that contract
consistent and unlocks common setups:

- Kimi / Moonshot (especially Kimi Coding Plan, `https://api.kimi.com/coding/v1`,
  which requires `User-Agent: KimiCLI/1.0` + `X-Client-Type: coding-agent`
  headers — easy to wire through LiteLLM `extra_headers`, painful to
  replicate in gbrain's recipe registry)
- MiniMax 海螺AI (when the user already runs a local LiteLLM proxy for
  other providers — no need to special-case MiniMax in `recipes/`)
- Local llama.cpp / vLLM / Ollama endpoints that handle both chat and embed

## Changes

### `src/core/ai/recipes/litellm-proxy.ts`

Add a `chat` touchpoint under the existing `touchpoints: { ... }` object,
mirroring the embedding block's `user_provided_models: true` pattern:

```diff
     supports_multimodal: true,
     },
+    // Allow gbrain to route think / chat / tier-resolver through any
+    // LiteLLM-proxied provider. Mirrors the embedding block:
+    //   - user_provided_models: true (LiteLLM owns the model catalog)
+    //   - supports_subagent_loop: false (cross-crash replay safety not
+    //     validated for proxied providers; flip after a few weeks of
+    //     stable Subagent runs)
+    chat: {
+      models: [],
+      user_provided_models: true,
+      supports_tools: true,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      max_context_tokens: 128000,
+      cost_per_1m_input_usd: undefined,
+      cost_per_1m_output_usd: undefined,
+      price_last_verified: '2026-06-09',
+    },
   },
```

### New: `docs/ai-providers/litellm-chat.md`

Add a setup guide for chat via LiteLLM, complementing the existing
embedding-only `docs/guides/litellm-proxy.md`.

### Updated: `docs/guides/litellm-proxy.md`

Mention chat usage with a `## Use LiteLLM for chat` section.

## Risk

**Low.** The patch only widens what `litellm:<model>` strings resolve to.
It does NOT change the recipe id (`litellm`), does NOT touch the gateway
core (`gateway.ts: instantiateChat` already handles `openai-compatible`
recipes generically), and does NOT modify any default model selection.
Users who currently use `litellm:some-embedding-model` see no change.

The `supports_subagent_loop: false` default is conservative — the
Subagent queue (`src/core/cycle/subagent.ts`) requires stable tool-call
IDs across crashes, and we haven't validated that against arbitrary
LiteLLM-proxied providers. Users who need it can flip the flag in their
local fork or via a config key once we have evidence it's safe.

## Test plan

1. `gbrain providers list | grep litellm` — chat column should now show
   `—` instead of rejecting the model id
2. `gbrain providers test --touchpoint chat --model litellm:<any-name>`
   — should probe and report latency
3. `gbrain config set chat_model litellm:<any-name>` + `gbrain think
   "ping"` — should produce a non-empty answer

## Verified locally

Tested with:
- `litellm:kimi-coding` (Kimi Coding Plan, headers configured in LiteLLM
  `extra_headers`)
- `litellm:minimax-m3` (MiniMax max-token plan)
- `litellm:minimax-m3-fast` (MiniMax M2.7-highspeed)

All three pass `gbrain think "What is 2+2?"` end-to-end through the
LiteLLM proxy on `localhost:4000`.