### PR TITLE
fix(autopilot): export ~/.bun/bin onto PATH in cron wrapper

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -1111,6 +1111,15 @@ function writeWrapperScript(repoPath: string): string {
 # OPENAI/ANTHROPIC keys exported in zshenv reach autopilot.
 [ -f ~/.zshenv ] && source ~/.zshenv 2>/dev/null
 source ~/.zshrc 2>/dev/null || source ~/.bashrc 2>/dev/null || true
+# Belt-and-suspenders PATH fix. ~/.bashrc ships with a non-interactive guard
+# (\`case $- in *i*) ;; *) return;; esac\`) that exits early when launched from
+# cron/systemd/launchd — so its PATH exports never reach this subprocess.
+# Without bun on PATH, the exec'd gbrain (a \`#!/usr/bin/env bun\` script) fails
+# silently with "env: bun: No such file or directory" and leaves a stale
+# lockfile that blocks every subsequent tick. Prepending ~/.bun/bin here
+# keeps the wrapper self-contained regardless of which init file the OS
+# loaded.
+export PATH="$HOME/.bun/bin:$PATH"
 exec '${safeGbrainPath}' autopilot --repo '${safeRepoPath}'
 `;
   writeFileSync(wrapperPath, wrapper, { mode: 0o755 });

--- a/test/autopilot-install.test.ts
+++ b/test/autopilot-install.test.ts
@@ -99,3 +99,29 @@ describe('autopilot wrapper script — env source order (v0.36.1.x #966)', () =>
     expect(src).toMatch(/source\s+~\/\.zshrc/);
   });
 });
+
+// v0.42.x: the wrapper must export PATH with ~/.bun/bin before exec'ing
+// gbrain. The exec'd gbrain has a `#!/usr/bin/env bun` shebang, and the
+// standard Debian ~/.bashrc ships a non-interactive guard
+// (`case $- in *i*) ;; *) return;; esac`) that exits early when cron/launchd/
+// systemd invokes bash non-interactively — so the PATH exports that
+// operators put in ~/.bashrc never reach this subprocess. Without the
+// explicit export the wrapper silently dies with `env: bun: No such file
+// or directory`, leaves a stale lockfile, and blocks every subsequent tick
+// for the 10-min stale-lock window. Regression: see Hermes `cron doctor`
+// reports — this caused a 1-week nightly-cycle outage on at least one
+// operator machine before being diagnosed.
+describe('autopilot wrapper script — bun PATH export (v0.42.x regression)', () => {
+  test('wrapper exports ~/.bun/bin onto PATH before the exec', async () => {
+    const { readFileSync } = await import('fs');
+    const src = readFileSync('src/commands/autopilot.ts', 'utf8');
+    // The export line must appear inside the writeWrapperScript heredoc.
+    expect(src).toMatch(/export\s+PATH="\$HOME\/\.bun\/bin:\$PATH"/);
+    // The export must precede the exec line, otherwise env never sees it.
+    const exportIdx = src.search(/export\s+PATH="\$HOME\/\.bun\/bin/);
+    const execIdx = src.search(/exec\s+'\${safeGbrainPath}'/);
+    expect(exportIdx).toBeGreaterThan(0);
+    expect(execIdx).toBeGreaterThan(0);
+    expect(exportIdx).toBeLessThan(execIdx);
+  });
+});


### PR DESCRIPTION
## What
The wrapper script that `gbrain autopilot --install` writes to `~/.gbrain/autopilot-run.sh` (and runs every 5 min via cron / launchd / systemd) sources `~/.bashrc` to inherit PATH for the exec'd gbrain binary — which has a `#!/usr/bin/env bun` shebang.

The standard Debian/Ubuntu `~/.bashrc` ships a non-interactive guard that `return`s early when bash is launched non-interactively:
```
case $- in
    *i*) ;;
      *) return;;
esac
```

So PATH exports operators add to `~/.bashrc` never reach the wrapper subprocess when it's launched by cron.

## Symptom
The wrapper dies silently with:
```
env: bun: No such file or directory
```
…and leaves a stale lockfile. Every subsequent cron tick hits the lockfile and bails ("Another autopilot instance is running"). The nightly dream cycle hangs waiting on a worker that never comes back, and the wrapper's own 10-min stale-lock window is the only thing that can recover it.

This bit one operator hard: a 1-week nightly-cycle outage with `last_status=error` reported daily by the cron doctor before the root cause was diagnosed. There is no warning at install time, and the failure mode is invisible to anyone whose `~/.bashrc` is the distro default (the default).

## Fix
Prepend `~/.bun/bin` to PATH directly in the wrapper, so it is self-contained regardless of which init file the OS loaded. Same idea as the existing zshenv/zshrc source order — but for the underlying toolchain PATH, not just the API-key exports.

```bash
export PATH="$HOME/.bun/bin:$PATH"
exec '${safeGbrainPath}' autopilot --repo '${safeRepoPath}'
```

Added alongside the existing source order:
- Belt-and-suspenders comment so a future regen of the wrapper doesn't regress it
- Regression test in `test/autopilot-install.test.ts` that asserts the export exists and appears before the `exec`, mirroring the v0.36.1.x #966 test style

## Verified
`bun test test/autopilot-install.test.ts` → 6/6 pass (the 5 existing + 1 new). `bun run typecheck` clean.