### PR TITLE
feat(stdio-mcp): GBRAIN_SOURCES env var for multi-source federated reads

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,6 +8,31 @@ import { buildToolDefs } from './tool-defs.ts';
 import { dispatchToolCall, validateParams, buildOperationContext } from './dispatch.ts';
 import { getBrainHotMemoryMeta } from '../core/facts/meta-hook.ts';
 
+/**
+ * v0.36.0.1: Parse `GBRAIN_SOURCES` (plural, comma-separated) into a normalized
+ * array of source ids for stdio MCP federated reads. Returns `undefined` when
+ * the env var is unset OR resolves to an empty list (so callers fall back to
+ * the scalar `GBRAIN_SOURCE` path).
+ *
+ * Exported for unit testing — the parsing rules (trim, drop empties, drop
+ * dupes) are the same regression-class as the federated_read array
+ * normalization. Drift here would silently re-introduce the docc-source-id
+ * bug class on stdio MCP.
+ */
+export function parseStdioAllowedSources(raw: string | undefined): string[] | undefined {
+  if (!raw) return undefined;
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const part of raw.split(',')) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
 export async function startMcpServer(engine: BrainEngine) {
   const server = new Server(
     { name: 'gbrain', version: VERSION },
@@ -33,13 +58,35 @@ export async function startMcpServer(engine: BrainEngine) {
     // see private hunches via takes_list / takes_search / query. Operators
     // who want stdio to see everything should call ops directly via
     // `gbrain call <op>` (sets remote=false in src/cli.ts).
+    // v0.36.0.1: federated reads for stdio MCP. HTTP MCP sources allowedSources
+    // from oauth_clients.federated_read at token-verification time; stdio MCP
+    // has no per-token auth and pre-fix could only scope to one source via
+    // GBRAIN_SOURCE. Now GBRAIN_SOURCES (plural, comma-separated) populates
+    // a synthetic AuthInfo.allowedSources so the same federated-read pattern
+    // works on stdio. Example: `env GBRAIN_SOURCES=default,docc,popify`.
+    // GBRAIN_SOURCE (singular) remains the scalar write-scope fallback for
+    // single-source setups. Parsing rules pinned in parseStdioAllowedSources().
+    const allowedSources = parseStdioAllowedSources(process.env.GBRAIN_SOURCES);
+    const stdioAuth = allowedSources && allowedSources.length > 0
+      ? {
+          token: 'stdio',
+          clientId: 'stdio',
+          scopes: ['read', 'write'],
+          sourceId: process.env.GBRAIN_SOURCE || allowedSources[0],
+          allowedSources,
+        }
+      : undefined;
+
     return dispatchToolCall(engine, name, params, {
       remote: true,
       takesHoldersAllowList: ['world'],
       // v0.31: source defaults to 'default' for stdio (no per-token scope).
       // Operators who want a different source on stdio MCP should set
       // GBRAIN_SOURCE in the env or use --source via `gbrain call`.
-      sourceId: process.env.GBRAIN_SOURCE || 'default',
+      // v0.36.0.1: GBRAIN_SOURCES (plural) wins for federated reads via
+      // synthetic AuthInfo above; GBRAIN_SOURCE is the scalar fallback.
+      sourceId: process.env.GBRAIN_SOURCE || allowedSources?.[0] || 'default',
+      auth: stdioAuth,
       // v0.31 (eD3): _meta.brain_hot_memory injection so Claude Desktop /
       // Code see the brain's relevant hot memory automatically alongside
       // every tool-call response. Best-effort; absorbs errors.

--- a/test/stdio-mcp-allowed-sources.test.ts
+++ b/test/stdio-mcp-allowed-sources.test.ts
@@ -1,0 +1,88 @@
+/**
+ * v0.36.0.1 — `GBRAIN_SOURCES` env-var parser for stdio MCP federated reads.
+ *
+ * HTTP MCP sources `allowedSources` from `oauth_clients.federated_read` at
+ * token-verification time. Stdio MCP has no per-token auth and historically
+ * could only scope to ONE source via `GBRAIN_SOURCE`. Now `GBRAIN_SOURCES`
+ * (plural, comma-separated) populates a synthetic `AuthInfo.allowedSources`
+ * so the same federated-read pattern works on stdio.
+ *
+ * These tests pin the parsing rules (trim, drop empties, drop dupes, empty
+ * input → undefined). Drift here silently re-introduces the docc-bug class
+ * where MCP clients couldn't see federated sources.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { parseStdioAllowedSources } from '../src/mcp/server.ts';
+
+describe('parseStdioAllowedSources', () => {
+  test('undefined env → undefined (preserve scalar fallback path)', () => {
+    expect(parseStdioAllowedSources(undefined)).toBeUndefined();
+  });
+
+  test('empty string → undefined (no synthetic auth, no widening)', () => {
+    expect(parseStdioAllowedSources('')).toBeUndefined();
+  });
+
+  test('whitespace-only → undefined', () => {
+    expect(parseStdioAllowedSources('   ')).toBeUndefined();
+    expect(parseStdioAllowedSources(',,,')).toBeUndefined();
+    expect(parseStdioAllowedSources(' , , ')).toBeUndefined();
+  });
+
+  test('single source returns single-element array', () => {
+    expect(parseStdioAllowedSources('docc')).toEqual(['docc']);
+  });
+
+  test('comma-separated list parses cleanly', () => {
+    expect(parseStdioAllowedSources('default,docc,popify')).toEqual([
+      'default',
+      'docc',
+      'popify',
+    ]);
+  });
+
+  test('trims whitespace around each entry (typical shell quoting)', () => {
+    expect(parseStdioAllowedSources('default, docc, popify')).toEqual([
+      'default',
+      'docc',
+      'popify',
+    ]);
+    expect(parseStdioAllowedSources(' default , docc , popify ')).toEqual([
+      'default',
+      'docc',
+      'popify',
+    ]);
+  });
+
+  test('drops empty entries from leading/trailing/double commas', () => {
+    expect(parseStdioAllowedSources(',default,,docc,')).toEqual(['default', 'docc']);
+  });
+
+  test('drops duplicates, preserves first-seen order', () => {
+    expect(parseStdioAllowedSources('default,docc,default,popify,docc')).toEqual([
+      'default',
+      'docc',
+      'popify',
+    ]);
+  });
+
+  test('order is preserved (regression guard: do NOT sort)', () => {
+    // The first element doubles as the scalar `sourceId` fallback in
+    // server.ts (write authority for single-source setups). Sorting would
+    // silently change which source receives writes when GBRAIN_SOURCE
+    // (singular) is unset.
+    expect(parseStdioAllowedSources('popify,docc,autotrader')).toEqual([
+      'popify',
+      'docc',
+      'autotrader',
+    ]);
+  });
+
+  test('non-canonical source ids pass through unchanged (validation lives elsewhere)', () => {
+    // The parser does NOT validate source ids against the sources table.
+    // That's the engine's job at query time — and an unknown source id
+    // simply matches zero rows, which is fail-safe (no widening).
+    expect(parseStdioAllowedSources('nonexistent-source')).toEqual(['nonexistent-source']);
+  });
+});


### PR DESCRIPTION
## What

Adds `GBRAIN_SOURCES` (plural, comma-separated) env var for stdio MCP, so callers on a multi-source brain can read across every listed source.

## Why

Stdio MCP (the `gbrain serve` transport Claude Desktop / Code / Cursor speak) can only scope to ONE source via `GBRAIN_SOURCE` (singular). On a multi-source brain, every read scopes to `default` and pages in other sources come back `page_not_found` / empty. The HTTP transport already solves this — it populates `auth.allowedSources` from `oauth_clients.federated_read` and routes reads through `sourceScopeOpts(ctx)`. Stdio had no equivalent.

This bridges that gap: `GBRAIN_SOURCES` populates a synthetic `AuthInfo.allowedSources` for stdio callers, so the **existing** `sourceScopeOpts(ctx)` federated-read path (the same one HTTP uses) works on stdio too. No new scoping logic — it reuses what's already there.

## Behavior

- `GBRAIN_SOURCE` (singular) unchanged — scalar write-scope fallback for single-source setups.
- When both set, `GBRAIN_SOURCES` wins for reads; its first entry is the write-scope fallback when `GBRAIN_SOURCE` is unset.
- Parser trims whitespace, drops dupes, preserves first-seen order, treats empty input as "no federated scope" (falls through to scalar).
- Purely additive — brains that don't set `GBRAIN_SOURCES` behave exactly as before.

## Example

\`\`\`json
"gbrain": {
  "command": "gbrain",
  "args": ["serve"],
  "env": { "GBRAIN_SOURCES": "default,docc,popify,personal-brain" }
}
\`\`\`

## Tests

`test/stdio-mcp-allowed-sources.test.ts` — 10 cases pinning the parser contract (trim / dedupe / order / empty → scalar fallback). `bun run typecheck` clean.

## Context

Maintained as a fork-local patch (donogeme/gbrain) since v0.41.26; upstreaming so multi-source stdio users don't need a fork. Versioning/CHANGELOG left to maintainer discretion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)