### PR TITLE
feat(serve-http): honor source + federatedRead in admin register-client

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -28,6 +28,7 @@ import type { OperationContext, AuthInfo } from '../core/operations.ts';
 import { GBrainOAuthProvider, validateTokenEndpointAuthMethod } from '../core/oauth-provider.ts';
 import type { SqlQuery } from '../core/oauth-provider.ts';
 import { hasScope, ALLOWED_SCOPES_LIST, normalizeScopesInput } from '../core/scope.ts';
+import { normalizeSourceInput, normalizeFederatedReadInput } from '../core/source-id.ts';
 import { summarizeMcpParams, dispatchToolCall } from '../mcp/dispatch.ts';
 import { paramDefToSchema } from '../mcp/tool-defs.ts';
 import { getBrainHotMemoryMeta } from '../core/facts/meta-hook.ts';
@@ -1241,7 +1242,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
       //     and other malformed inputs
       // normalizeScopesInput handles all four valid shapes (string, string[],
       // missing, empty) and rejects the rest with a structured 400.
-      const { name, tokenTtl, grantTypes, redirectUris, tokenEndpointAuthMethod } = req.body;
+      const { name, tokenTtl, grantTypes, redirectUris, tokenEndpointAuthMethod, source, federatedRead } = req.body;
       const rawScopes = (req.body as Record<string, unknown>).scopes ?? (req.body as Record<string, unknown>).scope;
       if (!name) { res.status(400).json({ error: 'Name required' }); return; }
       let scopeString: string;
@@ -1273,8 +1274,27 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
         });
         return;
       }
+      // v0.41.x: honor optional `source` (write source_id) and `federatedRead`
+      // (read source set) from the request body, mirroring the CLI's
+      // `--source` / `--federated-read` flags. Omitting both preserves the
+      // historical behavior (source_id='default', federated_read=[source_id]).
+      // Pre-fix this endpoint hardcoded 'default'/undefined, so an admin SPA or
+      // a proxy could never mint a client bound to a non-default brain source
+      // over HTTP — only the CLI could. Validated here for a structured 400.
+      let sourceId: string;
+      let federatedReadIds: string[] | undefined;
+      try {
+        sourceId = normalizeSourceInput(source);
+        federatedReadIds = normalizeFederatedReadInput(federatedRead);
+      } catch (e) {
+        res.status(400).json({
+          error: 'invalid_source',
+          message: e instanceof Error ? e.message : String(e),
+        });
+        return;
+      }
       const result = await oauthProvider.registerClientManual(
-        name, grants, scopeString, uris, 'default', undefined, validatedAuthMethod,
+        name, grants, scopeString, uris, sourceId, federatedReadIds, validatedAuthMethod,
       );
       // Set per-client TTL if specified
       if (tokenTtl && Number(tokenTtl) > 0) {

--- a/src/core/source-id.ts
+++ b/src/core/source-id.ts
@@ -52,3 +52,43 @@ export function assertValidSourceId(s: unknown): asserts s is string {
     );
   }
 }
+
+/**
+ * Normalize the optional `source` field of an `/admin/api/register-client`
+ * request body into a write source_id.
+ *
+ * Mirrors the CLI's `--source` flag. Returns the literal `'default'` when the
+ * field is omitted (`undefined`/`null`) so every caller that doesn't send
+ * `source` keeps landing on source_id='default' (the pre-source HTTP
+ * register-client behavior). A present-but-invalid value throws (via
+ * `assertValidSourceId`) so the route can surface a structured 400 instead of
+ * failing at INSERT time.
+ */
+export function normalizeSourceInput(raw: unknown): string {
+  if (raw === undefined || raw === null) return 'default';
+  assertValidSourceId(raw);
+  return raw;
+}
+
+/**
+ * Normalize the optional `federatedRead` field of an
+ * `/admin/api/register-client` request body into a source_id array, or
+ * `undefined` when omitted.
+ *
+ * Mirrors the CLI's `--federated-read` flag. `undefined`/`null` → `undefined`
+ * so `registerClientManual` applies its own default (`[sourceId]`, a
+ * non-federated client whose read scope equals its write scope). A present
+ * value must be a non-empty array whose every element is a valid source_id;
+ * anything else throws for a structured 400.
+ */
+export function normalizeFederatedReadInput(raw: unknown): string[] | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new Error(
+      `Invalid federatedRead: ${JSON.stringify(raw)}. ` +
+      `Must be a non-empty array of source_ids.`,
+    );
+  }
+  for (const s of raw) assertValidSourceId(s);
+  return raw as string[];
+}

--- a/test/register-client-source-normalize.test.ts
+++ b/test/register-client-source-normalize.test.ts
@@ -1,0 +1,82 @@
+/**
+ * normalizeSourceInput / normalizeFederatedReadInput contract.
+ *
+ * The `/admin/api/register-client` HTTP endpoint historically hardcoded
+ * source_id='default' (and federated_read=[source_id]) — only the CLI
+ * (`--source` / `--federated-read`) could bind a client to a non-default
+ * brain source. These two normalizers let the HTTP endpoint accept the same
+ * inputs from the request body while preserving the historical default when
+ * the fields are omitted.
+ *
+ * Hermetic — pure-function unit tests, no engine, no HTTP.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { normalizeSourceInput, normalizeFederatedReadInput } from '../src/core/source-id.ts';
+
+describe('normalizeSourceInput', () => {
+  test('undefined → "default" (backward compat)', () => {
+    expect(normalizeSourceInput(undefined)).toBe('default');
+  });
+
+  test('null → "default" (backward compat)', () => {
+    expect(normalizeSourceInput(null)).toBe('default');
+  });
+
+  test('valid source_id passes through', () => {
+    expect(normalizeSourceInput('mind-agent-brain')).toBe('mind-agent-brain');
+  });
+
+  test('single-char source_id is valid', () => {
+    expect(normalizeSourceInput('a')).toBe('a');
+  });
+
+  test('invalid source_id (underscore) throws', () => {
+    expect(() => normalizeSourceInput('mind_agent_brain')).toThrow(/Invalid source_id/);
+  });
+
+  test('invalid source_id (uppercase) throws', () => {
+    expect(() => normalizeSourceInput('Mind')).toThrow(/Invalid source_id/);
+  });
+
+  test('invalid source_id (edge hyphen) throws', () => {
+    expect(() => normalizeSourceInput('-mind')).toThrow(/Invalid source_id/);
+  });
+
+  test('non-string (number) throws', () => {
+    expect(() => normalizeSourceInput(42)).toThrow(/Invalid source_id/);
+  });
+});
+
+describe('normalizeFederatedReadInput', () => {
+  test('undefined → undefined (let registerClientManual default to [sourceId])', () => {
+    expect(normalizeFederatedReadInput(undefined)).toBeUndefined();
+  });
+
+  test('null → undefined', () => {
+    expect(normalizeFederatedReadInput(null)).toBeUndefined();
+  });
+
+  test('valid single-element array passes through', () => {
+    expect(normalizeFederatedReadInput(['mind-agent-brain'])).toEqual(['mind-agent-brain']);
+  });
+
+  test('valid multi-element array passes through (read across both sources)', () => {
+    expect(normalizeFederatedReadInput(['default', 'mind-agent-brain'])).toEqual([
+      'default',
+      'mind-agent-brain',
+    ]);
+  });
+
+  test('empty array throws (ambiguous — omit the field instead)', () => {
+    expect(() => normalizeFederatedReadInput([])).toThrow(/Invalid federatedRead/);
+  });
+
+  test('non-array (string) throws', () => {
+    expect(() => normalizeFederatedReadInput('default')).toThrow(/Invalid federatedRead/);
+  });
+
+  test('array with an invalid source_id element throws', () => {
+    expect(() => normalizeFederatedReadInput(['default', 'bad_id'])).toThrow(/Invalid source_id/);
+  });
+});


### PR DESCRIPTION
## Problem

`POST /admin/api/register-client` hardcodes `source_id='default'` and `federated_read=undefined`:

```ts
const result = await oauthProvider.registerClientManual(
  name, grants, scopeString, uris, 'default', undefined, validatedAuthMethod,
);
```

So a client minted **over HTTP** — by the admin SPA, or by a proxy that provisions per-user OAuth clients programmatically — can never be bound to a non-`default` brain source. Only the CLI (`gbrain auth register-client --source <id> --federated-read <a,b>`) can, because it calls `registerClientManual` with the real `sourceId` / `federatedRead` args.

Concretely: a downstream MCP→MCP proxy that mints a `client_credentials` client per user via this endpoint gets a client pinned to `source_id='default'`, so every read resolves to the `default` source regardless of which brain source actually holds the corpus. There is no HTTP path to fix it after the fact (only `update-client-ttl` / `revoke-client` exist).

## Change

Thread the already-supported `sourceId` / `federatedRead` parameters of `registerClientManual` through from the request body:

- `source` (string) → write `source_id`
- `federatedRead` (string[]) → read source set

Mirrors the CLI's `--source` / `--federated-read` flags.

**Backward-compatible:** omitting `source` keeps `source_id='default'`; omitting `federatedRead` keeps `federated_read=[source_id]` (the existing non-federated default). Both fields are validated against the canonical `source_id` regex (`src/core/source-id.ts`) and surface a structured `400 invalid_source` on bad input — no more 500-at-INSERT for a malformed id.

Validation lives in two small pure helpers (`normalizeSourceInput`, `normalizeFederatedReadInput`) next to the canonical `source_id` validators, following the `normalizeScopesInput` precedent.

## Tests

New hermetic unit test `test/register-client-source-normalize.test.ts` (15 cases): omitted→`'default'`, valid/invalid source ids, federated array shapes, empty-array and bad-element rejection.

```
bun test test/register-client-source-normalize.test.ts   # 15 pass
bun test test/source-id.test.ts                          # 19 pass (no regression)
bun test test/scope-normalize.test.ts                    # 28 pass (adjacent endpoint logic)
bun build src/cli.ts                                     # builds clean
```

(Full e2e in `test/e2e/serve-http-oauth.test.ts` needs a `DATABASE_URL`; not run locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)