### PR TITLE
fix(schema): list all bundled packs

### DIFF
--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -41,6 +41,7 @@ import {
   setExpertRoutingOnType,
   setExtractableOnType,
   UnknownPackError,
+  BUNDLED_PACK_NAMES,
   updateTypeOnPack,
   __setPackLocatorForTests,
   _resetPackLocatorForTests,
@@ -179,7 +180,7 @@ async function runActive(_args: string[]): Promise<void> {
 }
 
 function runList(_args: string[]): void {
-  const bundled = ['gbrain-base', 'gbrain-recommended'];
+  const bundled = Array.from(BUNDLED_PACK_NAMES);
   const installedDir = gbrainPath('schema-packs');
   const installed: string[] = [];
   if (existsSync(installedDir)) {
@@ -366,12 +367,12 @@ function runUse(args: string[]): void {
 }
 
 function packPathByName(name: string): string | null {
-  if (name === 'gbrain-base') {
+  if (BUNDLED_PACK_NAMES.has(name)) {
     // Resolve bundled YAML — try a few locations.
     const here = dirname(new URL(import.meta.url).pathname);
     const candidates = [
-      join(here, '..', 'core', 'schema-pack', 'base', 'gbrain-base.yaml'),
-      join(here, '..', '..', 'src', 'core', 'schema-pack', 'base', 'gbrain-base.yaml'),
+      join(here, '..', 'core', 'schema-pack', 'base', `${name}.yaml`),
+      join(here, '..', '..', 'src', 'core', 'schema-pack', 'base', `${name}.yaml`),
     ];
     for (const c of candidates) {
       if (existsSync(c)) return c;

--- a/src/core/schema-pack/mutate.ts
+++ b/src/core/schema-pack/mutate.ts
@@ -93,7 +93,15 @@ export class SchemaPackMutationError extends Error {
   }
 }
 
-export const BUNDLED_PACK_NAMES = new Set(['gbrain-base', 'gbrain-recommended', 'gbrain-base-v2']);
+export const BUNDLED_PACK_NAMES = new Set([
+  'gbrain-base',
+  'gbrain-recommended',
+  'gbrain-creator',
+  'gbrain-investor',
+  'gbrain-engineer',
+  'gbrain-everything',
+  'gbrain-base-v2',
+]);
 
 export interface MutateResult {
   /** Pack name that was mutated. */

--- a/test/schema-cli.test.ts
+++ b/test/schema-cli.test.ts
@@ -58,11 +58,13 @@ describe('gbrain schema CLI (Phase C)', () => {
     expect(r.stdout + r.stderr).toMatch(/schema|active|list|show|validate|use/i);
   });
 
-  test('schema list shows gbrain-base bundled', () => {
+  test('schema list shows all bundled packs', () => {
     const r = gbrain(['schema', 'list']);
     expect(r.code).toBe(0);
     expect(r.stdout).toContain('Bundled packs:');
     expect(r.stdout).toContain('gbrain-base');
+    expect(r.stdout).toContain('gbrain-recommended');
+    expect(r.stdout).toContain('gbrain-base-v2');
   });
 
   test('schema show gbrain-base prints manifest details', () => {
@@ -78,6 +80,15 @@ describe('gbrain schema CLI (Phase C)', () => {
     expect(r.stdout).toContain('Takes kinds: fact, take, bet, hunch');
     expect(r.stdout).toContain('person :: entity');
     expect(r.stdout).toContain('company :: entity');
+  });
+
+  test('schema show gbrain-base-v2 prints bundled successor manifest', () => {
+    const r = gbrain(['schema', 'show', 'gbrain-base-v2']);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('gbrain-base-v2 v1.0.0');
+    expect(r.stdout).toContain('Page types (15)');
+    expect(r.stdout).toContain('person :: entity');
+    expect(r.stdout).toContain('note :: concept');
   });
 
   test('schema validate gbrain-base passes', () => {

--- a/test/schema-pack-mutate.test.ts
+++ b/test/schema-pack-mutate.test.ts
@@ -101,9 +101,13 @@ describe('locateMutablePackFile — bundled guard', () => {
   it('BUNDLED_PACK_NAMES export contains all bundled packs', () => {
     expect(BUNDLED_PACK_NAMES.has('gbrain-base')).toBe(true);
     expect(BUNDLED_PACK_NAMES.has('gbrain-recommended')).toBe(true);
+    expect(BUNDLED_PACK_NAMES.has('gbrain-creator')).toBe(true);
+    expect(BUNDLED_PACK_NAMES.has('gbrain-investor')).toBe(true);
+    expect(BUNDLED_PACK_NAMES.has('gbrain-engineer')).toBe(true);
+    expect(BUNDLED_PACK_NAMES.has('gbrain-everything')).toBe(true);
     // v0.42 (T22): gbrain-base-v2 joins the bundled set.
     expect(BUNDLED_PACK_NAMES.has('gbrain-base-v2')).toBe(true);
-    expect(BUNDLED_PACK_NAMES.size).toBe(3);
+    expect(BUNDLED_PACK_NAMES.size).toBe(7);
   });
 
   it('rejects gbrain-base-v2 with PACK_READONLY (bundled guard)', () => {


### PR DESCRIPTION
## Summary
- make the schema CLI use the shared bundled-pack registry instead of a stale hardcoded two-pack list
- allow bundled packs such as gbrain-base-v2 and the lens packs to appear in schema list/show/use
- extend schema CLI and mutation tests for the bundled successor pack

## Root Cause
The repo already shipped gbrain-base-v2 and the loader/mutation surfaces knew about it, but src/commands/schema.ts kept its own stale bundled-pack list/path resolver. This made official docs/onboard recommendations point to a pack that schema show/use reported as unknown.

## Validation
- bun test test/schema-cli.test.ts
- bun test test/schema-pack-mutate.test.ts
- bun test test/schema-pack-find-pack-successors.serial.test.ts test/onboard-pack-upgrade-checks.test.ts
- bun run typecheck
- live CLI smoke: gbrain schema list, gbrain schema show gbrain-base-v2, isolated GBRAIN_HOME gbrain schema use gbrain-base-v2