### PR TITLE
fix(sync): skip Python venv/ in the code walker

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -548,7 +548,10 @@ export function collectSyncableFiles(dir: string, opts: CollectOpts = {}): strin
       // Same set the legacy walkers honored, surfaced once at the top of
       // every iteration.
       if (entry.startsWith('.')) continue;
-      if (entry === 'node_modules' || entry === 'ops') continue;
+      // `venv` is the Python equivalent of `node_modules`: a vendored
+      // dependency tree (often thousands of files) that floods the slug
+      // namespace and triggers ON CONFLICT collisions on first full sync.
+      if (entry === 'node_modules' || entry === 'ops' || entry === 'venv') continue;
 
       const full = join(d, entry);
       let stat;

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -241,6 +241,11 @@ function matchesAnyGlob(path: string, patterns?: string[]): boolean {
  */
 const PRUNE_DIR_NAMES = new Set<string>([
   'node_modules',
+  // Python venv: vendored dependency tree, the `node_modules` analogue.
+  // Like `node_modules` it lacks a leading dot so isSyncable's dot-prefix
+  // exclusion misses it; explicit entry keeps incremental sync consistent
+  // with the first-sync walker in commands/import.ts.
+  'venv',
   '.raw',
   'ops',
 ]);


### PR DESCRIPTION
## Problem

Running `gbrain sync --strategy code` against a Python repo crashes on the
first full sync. The first-sync walker `collectSyncableFiles`
(`src/commands/import.ts`) skips `node_modules` but **not** Python `venv/`,
so it descends into the virtualenv and tries to index thousands of vendored
files. The resulting slug collisions blow up `putPage`'s
`INSERT ... ON CONFLICT ... RETURNING` (PGLite returns no row), surfacing as:

```
undefined is not an object (evaluating 'row.deleted_at')
```

On a real-world repo this was **1418 of 1467 "files" failing**, with the
1418 coming almost entirely from `venv/` (3258 files on disk). Excluding
`venv/` drops the walk to the 16 real tracked files and sync completes
cleanly (0 errors).

## Fix

Add `venv` alongside `node_modules` in both walk paths:

- `src/commands/import.ts` — the inline skip in the first-sync `collectSyncableFiles` walker.
- `src/core/sync.ts` — `PRUNE_DIR_NAMES`, so the incremental walker stays consistent.

`venv` is the Python equivalent of `node_modules`: a vendored dependency
tree that should never be indexed. (`.venv` is already covered by the
existing leading-dot exclusion; this closes the dotless `venv` gap.)

## Test

Existing walker/syncable suites pass unchanged:

```
bun test test/disk-walk.test.ts test/import-file.test.ts \
  test/brain-writer-walk-prune.test.ts test/check-resolvable-cli.test.ts
# 115 pass, 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)