### PR TITLE
fix(resolver): tolerate CRLF line endings in SKILL.md frontmatter parsing

### DIFF
--- a/src/core/check-resolvable.ts
+++ b/src/core/check-resolvable.ts
@@ -219,13 +219,13 @@ export function parseResolverEntries(resolverContent: string): ResolverEntry[] {
 
 /** Simple YAML frontmatter parser — extracts triggers array if present. */
 function extractTriggers(skillContent: string): string[] {
-  const fmMatch = skillContent.match(/^---\n([\s\S]*?)\n---/);
+  const fmMatch = skillContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!fmMatch) return [];
   const fm = fmMatch[1];
-  const triggersMatch = fm.match(/^triggers:\s*\n((?:\s+-\s+.+\n?)*)/m);
+  const triggersMatch = fm.match(/^triggers:\s*\r?\n((?:\s+-\s+.+(?:\r?\n|$))*)/m);
   if (!triggersMatch) return [];
   return triggersMatch[1]
-    .split('\n')
+    .split(/\r?\n/)
     .map(l => l.replace(/^\s+-\s+/, '').replace(/^["']|["']$/g, '').trim())
     .filter(Boolean);
 }

--- a/src/core/skill-frontmatter.ts
+++ b/src/core/skill-frontmatter.ts
@@ -82,7 +82,7 @@ export interface ParsedFrontmatter {
  * `readFileSync(path, 'utf-8')` at the boundary.
  */
 export function parseSkillFrontmatter(content: string): ParsedFrontmatter | null {
-  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!fmMatch) return null;
   const raw = fmMatch[1];
   const out: ParsedFrontmatter = { raw };
@@ -139,11 +139,11 @@ function parseArrayField(raw: string, field: string): string[] | undefined {
       .filter(Boolean);
   }
   // Block form: `field:` + indented `- value` lines on subsequent lines.
-  const blockRe = new RegExp(`^${field}:\\s*\\n((?:[ \\t]+-[ \\t]+[^\\n]+\\n?)+)`, 'm');
+  const blockRe = new RegExp(`^${field}:\\s*\\r?\\n((?:[ \\t]+-[ \\t]+[^\\r\\n]+(?:\\r?\\n|$))+)`, 'm');
   const blockMatch = raw.match(blockRe);
   if (blockMatch) {
     return blockMatch[1]
-      .split('\n')
+      .split(/\r?\n/)
       .map(l => l.replace(/^[ \t]+-[ \t]+/, '').replace(/^["']|["']$/g, '').trim())
       .filter(Boolean);
   }

--- a/test/check-resolvable.test.ts
+++ b/test/check-resolvable.test.ts
@@ -417,3 +417,40 @@ function afterEachCleanup(fn: () => void) {
   afterEach(fn);
 }
 
+
+// ---------------------------------------------------------------------------
+// CRLF tolerance — Windows checkouts (core.autocrlf=true) produce CRLF
+// SKILL.md files; frontmatter + trigger extraction must parse them.
+// ---------------------------------------------------------------------------
+
+describe("CRLF tolerance — checkResolvable", () => {
+  test("CRLF SKILL.md frontmatter still yields reachable skill with triggers", () => {
+    const dir = mkdtempSync(join(tmpdir(), "gbrain-crlf-"));
+    writeFileSync(
+      join(dir, "RESOLVER.md"),
+      `## Test\n| Trigger | Skill |\n|-----|-----|\n| "crlf-skill" | \`skills/crlf-skill/SKILL.md\` |\n`
+    );
+    writeFileSync(
+      join(dir, "manifest.json"),
+      JSON.stringify({ skills: [{ name: "crlf-skill", path: "crlf-skill/SKILL.md" }] }, null, 2)
+    );
+    mkdirSync(join(dir, "crlf-skill"), { recursive: true });
+    const skillMd = [
+      "---",
+      "name: crlf-skill",
+      "description: test",
+      "triggers:",
+      '  - "crlf-skill"',
+      "---",
+      "",
+      "# crlf-skill",
+      "",
+    ].join("\r\n");
+    writeFileSync(join(dir, "crlf-skill", "SKILL.md"), skillMd);
+    const report = checkResolvable(dir);
+    const skillIssues = report.issues.filter(i => i.skill === "crlf-skill");
+    expect(report.summary.unreachable).toBe(0);
+    expect(skillIssues.filter(i => i.type === "mece_gap")).toHaveLength(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/test/skill-brain-first.test.ts
+++ b/test/skill-brain-first.test.ts
@@ -618,3 +618,27 @@ describe('audit-skill-brain-first (snapshot+diff)', () => {
     expect(name).toMatch(/^skill-brain-first-2026-W\d{2}\.jsonl$/);
   });
 });
+
+describe('parseSkillFrontmatter — CRLF tolerance', () => {
+  test('CRLF line endings (Windows checkouts) parse identically to LF', () => {
+    const content = [
+      '---',
+      'name: thing',
+      'mutating: true',
+      'writes_to:',
+      '  - people/',
+      '  - companies/',
+      'triggers:',
+      '  - do the thing',
+      '---',
+      '',
+      '# thing',
+    ].join('\r\n');
+    const fm = parseSkillFrontmatter(content);
+    expect(fm).not.toBeNull();
+    expect(fm!.name).toBe('thing');
+    expect(fm!.mutating).toBe(true);
+    expect(fm!.writes_to).toEqual(['people/', 'companies/']);
+    expect(fm!.triggers).toEqual(['do the thing']);
+  });
+});


### PR DESCRIPTION
## Problem

The frontmatter-fence and trigger-block regexes in `src/core/check-resolvable.ts` (`extractTriggers`) and `src/core/skill-frontmatter.ts` (`parseSkillFrontmatter` / `parseArrayField`) require bare-LF line endings. On Windows checkouts (`core.autocrlf=true` is the default), SKILL.md files and the committed test fixtures carry CRLF in the working tree, so:

- frontmatter silently fails to parse → `triggers:` arrays vanish
- `gbrain check-resolvable` / `gbrain doctor` report bogus `unreachable` + `mece_gap` issues against perfectly valid skill trees (reproduced live: a 52-skill tree that validates clean on LF reports 28 issues when files are CRLF)
- **5 existing tests fail out of the box on Windows** (`analyzeSkillBrainFirst` fixture-corpus tests in `test/skill-brain-first.test.ts`) — CI never sees this because Linux checkouts are LF

## Fix

CRLF-tolerant parsing, no behavior change for LF content:

- fence match `/^---\n…/` → `/^---\r?\n…/`
- trigger/list block matchers allow `\r?\n` at boundaries and exclude `\r` from item captures
- line splits use `/\r?\n/` instead of `'\n'`

One subtlety: `parseArrayField`'s `blockRe` is built via a template literal passed to `new RegExp()`, so the escapes are doubled (`\s`, `\r?\n`) — a single-backslash `\s` in a template literal silently degrades to the letter `s`.

## Tests

Adds CRLF regression tests for both parsers:

- `test/skill-brain-first.test.ts` — `parseSkillFrontmatter` parses a CRLF document identically to LF (name, booleans, block lists, triggers)
- `test/check-resolvable.test.ts` — `checkResolvable` on a fixture whose SKILL.md is CRLF yields 0 unreachable and no `mece_gap`

Verified both directions: with the fix reverted, the new tests fail alongside the 5 pre-existing Windows failures (7 fail / 87 pass); with the fix, the full files pass (94 pass / 0 fail). `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)