### PR TITLE
fix(cli): route thin-client CLI-only commands before DB connect

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -892,6 +892,11 @@ function formatResult(opName: string, result: unknown): string {
 const THIN_CLIENT_REFUSED_COMMANDS = new Set([
   'sync', 'embed', 'extract', 'extract-conversation-facts', 'enrich', 'migrate', 'apply-migrations',
   'repair-jsonb', 'orphans', 'integrity', 'serve',
+  // Thin clients have no local engine. Refuse DB-bound CLI-only commands
+  // here unless they have an explicit pre-engine remote branch below.
+  'import', 'export', 'call', 'features', 'autopilot', 'graph-query', 'agent',
+  'book-mirror', 'reindex', 'reindex-code', 'reindex-frontmatter', 'salience',
+  'anomalies', 'edges-backfill', 'quarantine', 'repos',
   // v0.31.1 (CDX-2 op coverage matrix): more local-only commands
   'dream', 'transcripts', 'storage',
   // v0.31.1 CDX-2 audit: takes/sources have multiple subcommands; some
@@ -935,6 +940,22 @@ const THIN_CLIENT_REFUSE_HINTS: Record<string, string> = {
   orphans: "orphans needs the host's brain. Run on the host or use the `find_orphans` MCP tool from your agent.",
   transcripts: 'transcripts is server-private (raw chat exports stay on the host). Read transcripts on the host machine.',
   storage: 'storage operates on the local repo on disk. Run on the host.',
+  import: 'import reads local files and writes the host brain. Run on the host, or use `gbrain capture` for a single note.',
+  export: 'export reads the host brain and writes local files. Run on the host.',
+  call: '`call` is a trusted local operation escape hatch. Use the corresponding MCP tool from your agent instead.',
+  features: 'features scans the host brain and proposes host-side fixes. Use `gbrain remote doctor` for thin-client health, or run `gbrain features` on the host.',
+  autopilot: 'autopilot runs host maintenance. Use `gbrain remote ping` to queue a host cycle.',
+  'graph-query': 'graph-query requires direct local DB access. Run on the host, or use `search` / `query` through the thin client.',
+  agent: 'agent commands run host-side agent/minion workflows. Run on the host.',
+  'book-mirror': 'book-mirror reads and writes host-side storage. Run on the host.',
+  reindex: 'reindex mutates host indexes. Run on the host.',
+  'reindex-code': 'reindex-code mutates host code indexes. Run on the host.',
+  'reindex-frontmatter': 'reindex-frontmatter mutates host indexes. Run on the host.',
+  salience: 'salience computes host-side scores. Run on the host.',
+  anomalies: 'anomalies scans host-side state. Run on the host.',
+  'edges-backfill': 'edges-backfill mutates host graph edges. Run on the host.',
+  quarantine: 'quarantine mutates page flags in the host brain. Run on the host or use an admin MCP tool if one exists.',
+  repos: 'repos inspects host-side repository metadata. Run on the host.',
   takes: 'takes mutate subcommands edit local .md files; routing the read subcommands lands in v0.31.x. For now: use `takes_list` and `takes_search` MCP tools from your agent, or run on the host.',
   sources: 'sources commands manage local DB + config rows. Per-subcommand thin-client routing lands in v0.31.x. For now: use `sources_list` / `sources_status` MCP tools, or run on the host.',
   // v0.32 audit additions
@@ -1384,6 +1405,53 @@ async function handleCliOnly(command: string, args: string[]) {
     const { runCapture } = await import('./commands/capture.ts');
     await runCapture(null, args);
     return;
+  }
+  if (command === 'capture') {
+    const cfgPre = loadConfig();
+    if (cfgPre && isThinClient(cfgPre)) {
+      const { runCapture } = await import('./commands/capture.ts');
+      await runCapture(null, args);
+      return;
+    }
+  }
+
+  // Thin-client route/refusal branches for CLI-only commands with handlers
+  // that already know how to call the remote MCP. Keep them before the
+  // generic connectEngine() path so they don't fall into the "No database URL"
+  // trap on installs that intentionally have no local DB.
+  if (command === 'jobs') {
+    const cfgPre = loadConfig();
+    if (cfgPre && isThinClient(cfgPre)) {
+      const sub = args[0];
+      if (!sub || sub === '--help' || sub === '-h' || sub === 'list' || sub === 'get') {
+        const { runJobs } = await import('./commands/jobs.ts');
+        await runJobs(null as never, args);
+        return;
+      }
+      refuseThinClient('jobs', cfgPre.remote_mcp!.mcp_url);
+    }
+  }
+  if (command === 'recall' || command === 'forget') {
+    const cfgPre = loadConfig();
+    if (cfgPre && isThinClient(cfgPre)) {
+      const { runRecall, runForget } = await import('./commands/recall.ts');
+      if (command === 'recall') await runRecall(null as never, args);
+      else await runForget(null as never, args);
+      return;
+    }
+  }
+  if (command === 'config') {
+    const cfgPre = loadConfig();
+    if (cfgPre && isThinClient(cfgPre)) {
+      if (args[0] === 'show') {
+        const { runConfig } = await import('./commands/config.ts');
+        await runConfig(null as never, args);
+        return;
+      }
+      console.error(`\`gbrain config ${args[0] ?? ''}\` requires the host DB/config plane.`);
+      console.error(`(thin-client of ${cfgPre.remote_mcp!.mcp_url})`);
+      process.exit(1);
+    }
   }
 
   // v0.41.39 (#1700): same pattern for `enrich --help`. enrich is in

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -131,6 +131,24 @@ function formatJobDetail(job: MinionJob): string {
   return lines.join('\n');
 }
 
+function coerceRemoteJobDates(job: MinionJob): MinionJob {
+  const dateKeys = [
+    'lock_until', 'delay_until', 'timeout_at',
+    'created_at', 'started_at', 'finished_at', 'updated_at',
+  ] as const;
+  const out = { ...(job as unknown as Record<string, unknown>) };
+  for (const key of dateKeys) {
+    const value = out[key];
+    if (typeof value === 'string' && value.length > 0) out[key] = new Date(value);
+    else if (value == null) out[key] = null;
+  }
+  return out as unknown as MinionJob;
+}
+
+function coerceRemoteJobsDates(jobs: MinionJob[]): MinionJob[] {
+  return jobs.map(coerceRemoteJobDates);
+}
+
 export async function runJobs(engine: BrainEngine, args: string[]): Promise<void> {
   const sub = args[0];
 
@@ -436,7 +454,7 @@ HANDLER TYPES (built in)
         const raw = await callRemoteTool(cfg!, 'list_jobs', {
           status, queue: queueName, limit,
         }, { timeoutMs: 30_000 });
-        jobs = unpackToolResult<MinionJob[]>(raw);
+        jobs = coerceRemoteJobsDates(unpackToolResult<MinionJob[]>(raw));
       } else {
         try { await queue.ensureSchema(); }
         catch (e) { console.error(e instanceof Error ? e.message : String(e)); process.exit(1); }
@@ -465,7 +483,8 @@ HANDLER TYPES (built in)
       if (isThinClient(cfg)) {
         try {
           const raw = await callRemoteTool(cfg!, 'get_job', { id }, { timeoutMs: 30_000 });
-          job = unpackToolResult<MinionJob | null>(raw);
+          const unpacked = unpackToolResult<MinionJob | null>(raw);
+          job = unpacked ? coerceRemoteJobDates(unpacked) : null;
         } catch (e) {
           // The remote op throws `invalid_params` on not-found; surface as
           // the same "Job not found" exit-1 the local path produces.

--- a/test/thin-client-routing-audit.test.ts
+++ b/test/thin-client-routing-audit.test.ts
@@ -38,6 +38,14 @@ const V032_REFUSE_ADDITIONS = [
   'code-def', 'code-refs', 'code-callers', 'code-callees',
 ];
 
+// 2026-06-09 follow-up audit: these CLI-only commands previously fell past
+// the thin-client guard and tried to open the absent local DB.
+const DB_BOUND_CLI_ONLY_REFUSALS = [
+  'import', 'export', 'call', 'features', 'autopilot', 'graph-query', 'agent',
+  'book-mirror', 'reindex', 'reindex-code', 'reindex-frontmatter', 'salience',
+  'anomalies', 'edges-backfill', 'quarantine', 'repos',
+];
+
 describe('thin-client routing audit — v0.32 REFUSE additions stay in the table', () => {
   test('THIN_CLIENT_REFUSED_COMMANDS set declaration is intact', () => {
     expect(CLI_SOURCE).toContain('const THIN_CLIENT_REFUSED_COMMANDS = new Set([');
@@ -62,6 +70,24 @@ describe('thin-client routing audit — v0.32 REFUSE additions stay in the table
       const hintsBlock = CLI_SOURCE.slice(hintsStart, hintsEnd);
       // Hint keys with embedded dashes are quoted (`'code-def':`); others
       // can be bare (`pages:`). Accept either shape.
+      const bareKey = new RegExp(`\\b${command.replace(/-/g, '\\-')}\\s*:`);
+      const quotedKey = new RegExp(`['"]${command.replace(/-/g, '\\-')}['"]\\s*:`);
+      expect(bareKey.test(hintsBlock) || quotedKey.test(hintsBlock)).toBe(true);
+    });
+  }
+
+  for (const command of DB_BOUND_CLI_ONLY_REFUSALS) {
+    test(`'${command}' is refused instead of opening a thin-client local DB`, () => {
+      const setStart = CLI_SOURCE.indexOf('const THIN_CLIENT_REFUSED_COMMANDS = new Set([');
+      const setEnd = CLI_SOURCE.indexOf(']);', setStart);
+      const setBlock = CLI_SOURCE.slice(setStart, setEnd);
+      expect(setBlock).toContain(`'${command}'`);
+
+      const hintsStart = CLI_SOURCE.indexOf(
+        'const THIN_CLIENT_REFUSE_HINTS: Record<string, string> = {',
+      );
+      const hintsEnd = CLI_SOURCE.indexOf('};', hintsStart);
+      const hintsBlock = CLI_SOURCE.slice(hintsStart, hintsEnd);
       const bareKey = new RegExp(`\\b${command.replace(/-/g, '\\-')}\\s*:`);
       const quotedKey = new RegExp(`['"]${command.replace(/-/g, '\\-')}['"]\\s*:`);
       expect(bareKey.test(hintsBlock) || quotedKey.test(hintsBlock)).toBe(true);
@@ -125,5 +151,15 @@ describe('thin-client routing audit — v0.32 ROUTE additions wire callRemoteToo
     expect(src).toContain(`from '../core/mcp-client.ts'`);
     expect(src).toContain(`callRemoteTool(cfg!, 'list_jobs'`);
     expect(src).toContain(`callRemoteTool(cfg!, 'get_job'`);
+  });
+
+  test('src/commands/jobs.ts: remote jobs are date-coerced before rendering', () => {
+    const src = readFileSync(
+      join(import.meta.dir, '..', 'src', 'commands', 'jobs.ts'),
+      'utf8',
+    );
+    expect(src).toContain('coerceRemoteJobDates');
+    expect(src).toContain('created_at');
+    expect(src).toContain('new Date(value)');
   });
 });


### PR DESCRIPTION
Fixes thin-client CLI-only commands that were falling through to local connectEngine() and reporting missing database_url even though thin-client installs intentionally have no local DB.

Changes:
- route capture, jobs list/get, recall/forget, and config show before engine connect when remote_mcp is configured
- cleanly refuse DB-bound host-only CLI commands on thin clients with actionable hints
- coerce remote job timestamp strings back to Date before rendering
- extend thin-client routing audit coverage for the newly refused commands and remote job date coercion

Verification:
- bun run typecheck
- bun test test/thin-client-routing-audit.test.ts test/cli-dispatch-thin-client.test.ts test/capture-runcapture.test.ts
- live thin-client smoke: capture, jobs list, recall --today, config show, features refusal