### PR TITLE
fix: route Windows PGLite init diagnostics

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -170,9 +170,8 @@ export function classifyPgliteInitError(
 ): PgliteInitFailure {
   if (/\$\$bunfs|ENOENT[\s\S]*pglite\.data/i.test(message)) return 'bunfs';
   if (platform === 'win32') {
-    const hasShellEvidence = /NativeCommandError|FullyQualifiedErrorId\s*:\s*NativeCommandError|At line:\d+ char:\d+|CategoryInfo\s*:|PowerShell/i.test(message);
     const hasWindowsApostrophePath = /[A-Z]:\\[^\n\r]*'[^\n\r]*/i.test(message);
-    if (hasShellEvidence || hasWindowsApostrophePath) return 'windows-path-shell';
+    if (hasWindowsApostrophePath) return 'windows-path-shell';
     if (/abort.*runtime|wasm.*runtime|Aborted\(\)|Cannot find module ['"]?@electric-sql\/pglite/i.test(message)) {
       return 'windows-pglite-unknown';
     }

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -170,8 +170,9 @@ export function classifyPgliteInitError(
 ): PgliteInitFailure {
   if (/\$\$bunfs|ENOENT[\s\S]*pglite\.data/i.test(message)) return 'bunfs';
   if (platform === 'win32') {
+    const hasShellEvidence = /NativeCommandError|FullyQualifiedErrorId\s*:\s*NativeCommandError|At line:\d+ char:\d+|CategoryInfo\s*:|PowerShell/i.test(message);
     const hasWindowsApostrophePath = /[A-Z]:\\[^\n\r]*'[^\n\r]*/i.test(message);
-    if (hasWindowsApostrophePath) return 'windows-path-shell';
+    if (hasShellEvidence && hasWindowsApostrophePath) return 'windows-path-shell';
     if (/abort.*runtime|wasm.*runtime|Aborted\(\)|Cannot find module ['"]?@electric-sql\/pglite/i.test(message)) {
       return 'windows-pglite-unknown';
     }

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -146,6 +146,14 @@ export function computeSnapshotSchemaHash(
  * `macos-26-3` — the pre-existing #223 hint signature (early macOS
  *   26.3 builds shipped a broken WASM runtime).
  *
+ * `windows-path-shell` — issue #2008 shape: PowerShell / NativeCommandError
+ *   wrapped around PGLite-looking red herrings when a Windows profile or
+ *   install path contains shell-special characters such as apostrophes.
+ *
+ * `windows-pglite-unknown` — Windows PGLite/WASM failures without shell/path
+ *   evidence. Still avoids the macOS #223 fallback, but does not prescribe
+ *   the #2008 path workaround.
+ *
  * `unknown` — falls through to a generic hint that still names the
  *   doctor command and the most-common-cause link.
  *
@@ -154,10 +162,21 @@ export function computeSnapshotSchemaHash(
  * errors). Match the literal `$$bunfs` marker OR ENOENT+pglite.data
  * co-occurrence.
  */
-export type PgliteInitFailure = 'bunfs' | 'macos-26-3' | 'unknown';
+export type PgliteInitFailure = 'bunfs' | 'macos-26-3' | 'windows-path-shell' | 'windows-pglite-unknown' | 'unknown';
 
-export function classifyPgliteInitError(message: string): PgliteInitFailure {
+export function classifyPgliteInitError(
+  message: string,
+  platform: NodeJS.Platform = process.platform,
+): PgliteInitFailure {
   if (/\$\$bunfs|ENOENT[\s\S]*pglite\.data/i.test(message)) return 'bunfs';
+  if (platform === 'win32') {
+    const hasShellEvidence = /NativeCommandError|FullyQualifiedErrorId\s*:\s*NativeCommandError|At line:\d+ char:\d+|CategoryInfo\s*:|PowerShell/i.test(message);
+    const hasWindowsApostrophePath = /[A-Z]:\\[^\n\r]*'[^\n\r]*/i.test(message);
+    if (hasShellEvidence || hasWindowsApostrophePath) return 'windows-path-shell';
+    if (/wasm.*runtime|Aborted\(\)|Cannot find module ['"]?@electric-sql\/pglite/i.test(message)) {
+      return 'windows-pglite-unknown';
+    }
+  }
   if (/abort.*runtime|macos.*26\.3|wasm.*runtime/i.test(message)) {
     return 'macos-26-3';
   }
@@ -183,6 +202,24 @@ export function buildPgliteInitErrorMessage(
       hint =
         '  This is most commonly the macOS 26.3 WASM bug:\n' +
         '  https://github.com/garrytan/gbrain/issues/223';
+      break;
+    case 'windows-path-shell':
+      hint =
+        '  This looks like a Windows shell/path quoting failure before PGLite starts.\n' +
+        '  If your Windows username or install path contains an apostrophe or\n' +
+        '  another shell-special character, PowerShell can corrupt the migration\n' +
+        '  command and surface NativeCommandError, missing-module, or WASM errors\n' +
+        '  as red herrings. Move the install/brain to a quote-safe path such as\n' +
+        '  C:\\gbrain, then rerun `gbrain apply-migrations --yes`.\n' +
+        '  See https://github.com/garrytan/gbrain/issues/2008';
+      break;
+    case 'windows-pglite-unknown':
+      hint =
+        '  This is a Windows PGLite/WASM initialization failure, but it does not\n' +
+        '  include the PowerShell / NativeCommandError path-corruption signature\n' +
+        '  from issue #2008. Run `gbrain doctor`, then rerun\n' +
+        '  `gbrain apply-migrations --yes --non-interactive` from a fresh shell.\n' +
+        '  If it repeats, paste the full original error into a new issue.';
       break;
     case 'unknown':
     default:

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -173,7 +173,7 @@ export function classifyPgliteInitError(
     const hasShellEvidence = /NativeCommandError|FullyQualifiedErrorId\s*:\s*NativeCommandError|At line:\d+ char:\d+|CategoryInfo\s*:|PowerShell/i.test(message);
     const hasWindowsApostrophePath = /[A-Z]:\\[^\n\r]*'[^\n\r]*/i.test(message);
     if (hasShellEvidence || hasWindowsApostrophePath) return 'windows-path-shell';
-    if (/wasm.*runtime|Aborted\(\)|Cannot find module ['"]?@electric-sql\/pglite/i.test(message)) {
+    if (/abort.*runtime|wasm.*runtime|Aborted\(\)|Cannot find module ['"]?@electric-sql\/pglite/i.test(message)) {
       return 'windows-pglite-unknown';
     }
   }

--- a/test/pglite-init-classifier.test.ts
+++ b/test/pglite-init-classifier.test.ts
@@ -71,6 +71,11 @@ Original error: Aborted(). Build with -sASSERTIONS for more info.`;
     expect(classifyPgliteInitError(msg, 'win32')).toBe('windows-pglite-unknown');
   });
 
+  test('windows apostrophe path without shell wrapper stays generic', () => {
+    const msg = `PGLite failed to initialize its WASM runtime at C:\\Users\\quote-test'\\.gbrain. Original error: Aborted().`;
+    expect(classifyPgliteInitError(msg, 'win32')).toBe('windows-pglite-unknown');
+  });
+
   test('unknown verdict for generic / unrecognized errors', () => {
     const msg = 'TypeError: cannot read property of undefined at PGlite.create';
     expect(classifyPgliteInitError(msg)).toBe('unknown');

--- a/test/pglite-init-classifier.test.ts
+++ b/test/pglite-init-classifier.test.ts
@@ -53,6 +53,11 @@ Original error: Aborted(). Build with -sASSERTIONS for more info.`;
     expect(classifyPgliteInitError(msg, 'win32')).toBe('windows-pglite-unknown');
   });
 
+  test('windows abort/runtime wording never falls through to the macOS verdict', () => {
+    const msg = 'PGLite failed: abort while starting runtime';
+    expect(classifyPgliteInitError(msg, 'win32')).toBe('windows-pglite-unknown');
+  });
+
   test('unknown verdict for generic / unrecognized errors', () => {
     const msg = 'TypeError: cannot read property of undefined at PGlite.create';
     expect(classifyPgliteInitError(msg)).toBe('unknown');

--- a/test/pglite-init-classifier.test.ts
+++ b/test/pglite-init-classifier.test.ts
@@ -35,6 +35,24 @@ describe('classifyPgliteInitError', () => {
     expect(classifyPgliteInitError(msg)).toBe('macos-26-3');
   });
 
+  test('windows path/shell verdict for #2008 NativeCommandError + WASM red herring', () => {
+    const msg = `bun :
+At line:1 char:31
++ ... C:\\Users\\quote-test'\\.gbrain"; bun run src/cli.ts apply-migrations --yes
++                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (:String) [], RemoteException
+    + FullyQualifiedErrorId : NativeCommandError
+
+Phase A (schema) failed: PGLite failed to initialize its WASM runtime.
+Original error: Aborted(). Build with -sASSERTIONS for more info.`;
+    expect(classifyPgliteInitError(msg, 'win32')).toBe('windows-path-shell');
+  });
+
+  test('windows generic WASM failure does not get the apostrophe/path verdict', () => {
+    const msg = 'PGLite failed to initialize its WASM runtime. Original error: Aborted().';
+    expect(classifyPgliteInitError(msg, 'win32')).toBe('windows-pglite-unknown');
+  });
+
   test('unknown verdict for generic / unrecognized errors', () => {
     const msg = 'TypeError: cannot read property of undefined at PGlite.create';
     expect(classifyPgliteInitError(msg)).toBe('unknown');
@@ -80,8 +98,33 @@ describe('buildPgliteInitErrorMessage — hint routing', () => {
     expect(msg).toContain(original);
   });
 
+  test('windows path/shell verdict names #2008 and does not blame macOS', () => {
+    const msg = buildPgliteInitErrorMessage(
+      'windows-path-shell',
+      'NativeCommandError followed by Aborted() from PGLite',
+    );
+    expect(msg).toContain('Windows');
+    expect(msg).toContain('apostrophe');
+    expect(msg).toContain('issues/2008');
+    expect(msg).not.toContain('macOS 26.3');
+    expect(msg).not.toContain('issues/223');
+  });
+
+  test('windows generic verdict avoids macOS and avoids apostrophe-specific advice', () => {
+    const msg = buildPgliteInitErrorMessage(
+      'windows-pglite-unknown',
+      'PGLite failed to initialize its WASM runtime. Original error: Aborted().',
+    );
+    expect(msg).toContain('Windows');
+    expect(msg).toContain('gbrain doctor');
+    expect(msg).not.toContain('macOS 26.3');
+    expect(msg).not.toContain('issues/223');
+    expect(msg).not.toContain('apostrophe');
+    expect(msg).not.toContain('C:\\gbrain');
+  });
+
   test('all verdicts produce the canonical header line', () => {
-    for (const v of ['bunfs', 'macos-26-3', 'unknown'] as const) {
+    for (const v of ['bunfs', 'macos-26-3', 'windows-path-shell', 'windows-pglite-unknown', 'unknown'] as const) {
       const msg = buildPgliteInitErrorMessage(v, original);
       expect(msg.startsWith('PGLite failed to initialize its WASM runtime.')).toBe(true);
     }

--- a/test/pglite-init-classifier.test.ts
+++ b/test/pglite-init-classifier.test.ts
@@ -58,6 +58,19 @@ Original error: Aborted(). Build with -sASSERTIONS for more info.`;
     expect(classifyPgliteInitError(msg, 'win32')).toBe('windows-pglite-unknown');
   });
 
+  test('windows PowerShell wrapper without apostrophe path stays generic', () => {
+    const msg = `bun :
+At line:1 char:31
++ ... C:\\Users\\quote-safe\\.gbrain"; bun run src/cli.ts apply-migrations --yes
++                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (:String) [], RemoteException
+    + FullyQualifiedErrorId : NativeCommandError
+
+Phase A (schema) failed: PGLite failed to initialize its WASM runtime.
+Original error: Aborted(). Build with -sASSERTIONS for more info.`;
+    expect(classifyPgliteInitError(msg, 'win32')).toBe('windows-pglite-unknown');
+  });
+
   test('unknown verdict for generic / unrecognized errors', () => {
     const msg = 'TypeError: cannot read property of undefined at PGlite.create';
     expect(classifyPgliteInitError(msg)).toBe('unknown');


### PR DESCRIPTION
## Summary
- add Windows-aware PGLite init-error verdicts so Windows failures no longer fall through to the macOS 26.3 / #223 hint
- route the #2008 PowerShell / NativeCommandError + apostrophe-path shape to a Windows path-quoting message that names #2008
- keep generic Windows WASM / `Aborted()` / missing-module failures on a Windows-generic path instead of prescribing the apostrophe workaround

Closes #2008.

## Scope note
PR #1554 already covers the package.json postinstall shell shim. This PR intentionally avoids that surface and fixes the remaining diagnostic-routing failure so Windows users do not get pointed at the wrong macOS issue.

## Verification
- RED: `bun test test/pglite-init-classifier.test.ts` initially failed because the #2008 fixture routed to `macos-26-3`
- GREEN: `bun test test/pglite-init-classifier.test.ts test/fix-wave-structural.test.ts`
- `bun run typecheck`
- `bun run build`
- Autoreview: Codex found an overbroad Windows `Aborted()` classifier and a privacy issue in the fixture; both were fixed. Final Codex review found no blockers.
