### PR TITLE
feat(extract): schema-pack frontmatter_links drive extraction, with D4 fail-empty semantics

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -61,6 +61,9 @@ import { createHash } from 'crypto';
 // shared sliding-pool helper + PGLite-clamp wrapper.
 import { runSlidingPool } from '../core/worker-pool.ts';
 import { parseWorkers, resolveWorkersWithClamp } from '../core/sync-concurrency.ts';
+import { loadActivePack } from '../core/schema-pack/load-active.ts';
+import { loadConfig } from '../core/config.ts';
+import type { SchemaPackManifest } from '../core/schema-pack/manifest-v1.ts';
 
 // Batch size for addLinksBatch / addTimelineEntriesBatch.
 // Postgres bind-parameter limit is 65535. Links use 4 cols/row → 16K hard ceiling;
@@ -77,6 +80,19 @@ const BATCH_SIZE = 100;
 // 25 caps the worst case at ~625MB even if every page is a 25MB transcript.
 // Normal pages are KBs; raise via GBRAIN_EXTRACT_STALE_BATCH for throughput.
 const STALE_BATCH_SIZE = Math.max(1, Number(process.env.GBRAIN_EXTRACT_STALE_BATCH) || 25);
+
+async function loadExtractionSchemaPack(sourceId?: string): Promise<Pick<SchemaPackManifest, 'frontmatter_links'> | undefined> {
+  try {
+    const resolved = await loadActivePack({
+      cfg: loadConfig(),
+      remote: false,
+      sourceId,
+    });
+    return resolved.manifest;
+  } catch {
+    return undefined;
+  }
+}
 // v0.42.7: wall-clock budget for one `extract --stale` invocation (default
 // 30 min). `--catch-up` removes the cap (loops until 0 stale). Mirrors
 // embedAllStale's time-budget shape.
@@ -376,7 +392,7 @@ function parseFrontmatterFromContent(content: string, relPath: string): Record<s
  */
 export async function extractLinksFromFile(
   content: string, relPath: string, allSlugs: Set<string>,
-  opts?: { includeFrontmatter?: boolean; globalBasename?: boolean },
+  opts?: { includeFrontmatter?: boolean; globalBasename?: boolean; schemaPack?: Pick<SchemaPackManifest, 'frontmatter_links'> },
 ): Promise<ExtractedLink[]> {
   const links: ExtractedLink[] = [];
   const slug = pathToSlug(relPath);
@@ -451,7 +467,7 @@ export async function extractLinksFromFile(
       : topDir === 'meetings' ? 'meeting'
       : 'concept';
     const fm = parseFrontmatterFromContent(content, relPath);
-    const fmLinks = await extractFrontmatterLinks(slug, pageType as never, fm, fsResolver);
+    const fmLinks = await extractFrontmatterLinks(slug, pageType as never, fm, fsResolver, { schemaPack: opts?.schemaPack });
     for (const c of fmLinks.candidates) {
       links.push({
         from_slug: c.fromSlug ?? slug,
@@ -948,6 +964,7 @@ async function extractForSlugs(
 
   // Issue #972: read the basename flag once per extract run.
   const globalBasename = await isGlobalBasenameEnabled(engine);
+  const schemaPack = doLinks ? await loadExtractionSchemaPack() : undefined;
 
   const linkBatch: LinkBatchInput[] = [];
   const timelineBatch: TimelineBatchInput[] = [];
@@ -1001,7 +1018,7 @@ async function extractForSlugs(
         const content = readFileSync(fullPath, 'utf-8');
 
         if (doLinks) {
-          const links = await extractLinksFromFile(content, relPath, allSlugs, { globalBasename });
+          const links = await extractLinksFromFile(content, relPath, allSlugs, { globalBasename, schemaPack });
           for (const link of links) {
             if (dryRun) {
               if (!jsonMode) console.log(`  ${link.from_slug} → ${link.to_slug} (${link.link_type})`);
@@ -1056,6 +1073,7 @@ async function extractLinksFromDir(
   // re-query the DB. globalBasename = true emits one edge per basename
   // match for bare wikilinks like `[[struktura]]`.
   const globalBasename = await isGlobalBasenameEnabled(engine);
+  const schemaPack = await loadExtractionSchemaPack();
 
   // Progress stream on stderr (separate from the action-events --json writes
   // to stdout, which tests grep for). Rate-gated; respects global --quiet /
@@ -1092,7 +1110,7 @@ async function extractLinksFromDir(
     onItem: async (file) => {
       try {
         const content = readFileSync(file.path, 'utf-8');
-        const links = await extractLinksFromFile(content, file.relPath, allSlugs, { globalBasename });
+        const links = await extractLinksFromFile(content, file.relPath, allSlugs, { globalBasename, schemaPack });
         for (const link of links) {
           if (dryRunSeen) {
             const key = `${link.from_slug}::${link.to_slug}::${link.link_type}`;
@@ -1203,13 +1221,14 @@ export async function extractLinksForSlugs(
     : undefined;
   // Issue #972: same flag as the standalone extract path.
   const globalBasename = await isGlobalBasenameEnabled(engine);
+  const schemaPack = await loadExtractionSchemaPack(opts?.sourceId);
   let created = 0;
   for (const slug of slugs) {
     const filePath = join(repoPath, slug + '.md');
     if (!existsSync(filePath)) continue;
     try {
       const content = readFileSync(filePath, 'utf-8');
-      for (const link of await extractLinksFromFile(content, slug + '.md', allSlugs, { globalBasename })) {
+      for (const link of await extractLinksFromFile(content, slug + '.md', allSlugs, { globalBasename, schemaPack })) {
         try { await engine.addLink(link.from_slug, link.to_slug, link.context, link.link_type, link.link_source, undefined, undefined, linkOpts); created++; } catch { /* skip */ } // gbrain-allow-direct-insert: gbrain extract single-row fallback when batch path declines a row
       }
     } catch { /* skip */ }
@@ -1279,6 +1298,7 @@ async function extractLinksFromDB(
   // Issue #972: opt-in global-basename wikilink resolution. Read once
   // per extract run; threaded into each extractPageLinks call.
   const globalBasename = await isGlobalBasenameEnabled(engine);
+  const schemaPack = await loadExtractionSchemaPack(sourceIdFilter);
   // v0.32.8: listAllPageRefs enumerates (slug, source_id) so we can thread
   // sourceId to getPage AND build a cross-source resolution map for link
   // disambiguation. Pre-fix used getAllSlugs() which collapsed
@@ -1359,7 +1379,7 @@ async function extractLinksFromDB(
     // basename lookup; off by default for back-compat.
     const extracted = await extractPageLinks(
       slug, fullContent, page.frontmatter, page.type, resolver,
-      { skipFrontmatter: !includeFrontmatter, globalBasename },
+      { skipFrontmatter: !includeFrontmatter, globalBasename, schemaPack },
     );
     unresolved.push(...extracted.unresolved);
 
@@ -1585,6 +1605,7 @@ async function extractStaleFromDB(
   const resolver = makeResolver(engine, { mode: 'batch' });
   const nullResolver = { resolve: async () => null as string | null };
   const activeResolver = includeFrontmatter ? resolver : nullResolver;
+  const schemaPack = includeFrontmatter ? await loadExtractionSchemaPack(sourceIdFilter) : undefined;
   const allRefs = await engine.listAllPageRefs();
   const allSlugs = new Set<string>();
   const slugToSources = new Map<string, string[]>();
@@ -1617,6 +1638,7 @@ async function extractStaleFromDB(
       const fullContent = page.compiled_truth + '\n' + page.timeline;
       const extracted = await extractPageLinks(
         page.slug, fullContent, page.frontmatter, page.type, activeResolver,
+        { skipFrontmatter: !includeFrontmatter, schemaPack },
       );
       for (const c of extracted.candidates) {
         const r = resolveCandidateSources(c, page.slug, page.source_id, allSlugs, slugToSources);

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -61,8 +61,8 @@ import { createHash } from 'crypto';
 // shared sliding-pool helper + PGLite-clamp wrapper.
 import { runSlidingPool } from '../core/worker-pool.ts';
 import { parseWorkers, resolveWorkersWithClamp } from '../core/sync-concurrency.ts';
-import { loadActivePack } from '../core/schema-pack/load-active.ts';
-import { loadConfig } from '../core/config.ts';
+import { loadActivePackBestEffortWithResolution } from '../core/schema-pack/best-effort.ts';
+import type { OperationContext } from '../core/operations.ts';
 import type { SchemaPackManifest } from '../core/schema-pack/manifest-v1.ts';
 
 // Batch size for addLinksBatch / addTimelineEntriesBatch.
@@ -81,17 +81,35 @@ const BATCH_SIZE = 100;
 // Normal pages are KBs; raise via GBRAIN_EXTRACT_STALE_BATCH for throughput.
 const STALE_BATCH_SIZE = Math.max(1, Number(process.env.GBRAIN_EXTRACT_STALE_BATCH) || 25);
 
-async function loadExtractionSchemaPack(sourceId?: string): Promise<Pick<SchemaPackManifest, 'frontmatter_links'> | undefined> {
-  try {
-    const resolved = await loadActivePack({
-      cfg: loadConfig(),
-      remote: false,
-      sourceId,
-    });
-    return resolved.manifest;
-  } catch {
-    return undefined;
+interface ExtractionSchemaPackState {
+  schemaPack?: Pick<SchemaPackManifest, 'frontmatter_links'>;
+  skipFrontmatter: boolean;
+}
+
+async function loadExtractionSchemaPack(sourceId?: string): Promise<ExtractionSchemaPackState> {
+  const ctx = {
+    engine: undefined as never,
+    config: {} as never,
+    logger: { info: () => {}, warn: () => {}, error: () => {} } as never,
+    dryRun: false,
+    remote: false,
+    ...(sourceId ? { sourceId } : {}),
+  } as OperationContext;
+  const result = await loadActivePackBestEffortWithResolution(ctx);
+  if (!result.pack) {
+    if (result.configured) {
+      console.error(
+        `[schema] active schema_pack \`${result.resolution.pack_name}\` (${result.resolution.source}) failed to load; ` +
+        'skipping frontmatter link extraction for this run to avoid legacy-verb edges.',
+      );
+      return { skipFrontmatter: true };
+    }
+    return { skipFrontmatter: false };
   }
+  if (!result.configured || result.pack.manifest.frontmatter_links.length === 0) {
+    return { skipFrontmatter: false };
+  }
+  return { schemaPack: result.pack.manifest, skipFrontmatter: false };
 }
 // v0.42.7: wall-clock budget for one `extract --stale` invocation (default
 // 30 min). `--catch-up` removes the cap (loops until 0 stale). Mirrors
@@ -964,7 +982,7 @@ async function extractForSlugs(
 
   // Issue #972: read the basename flag once per extract run.
   const globalBasename = await isGlobalBasenameEnabled(engine);
-  const schemaPack = doLinks ? await loadExtractionSchemaPack() : undefined;
+  const schemaPackState = doLinks ? await loadExtractionSchemaPack() : undefined;
 
   const linkBatch: LinkBatchInput[] = [];
   const timelineBatch: TimelineBatchInput[] = [];
@@ -1018,7 +1036,7 @@ async function extractForSlugs(
         const content = readFileSync(fullPath, 'utf-8');
 
         if (doLinks) {
-          const links = await extractLinksFromFile(content, relPath, allSlugs, { globalBasename, schemaPack });
+          const links = await extractLinksFromFile(content, relPath, allSlugs, { globalBasename, schemaPack: schemaPackState?.schemaPack });
           for (const link of links) {
             if (dryRun) {
               if (!jsonMode) console.log(`  ${link.from_slug} → ${link.to_slug} (${link.link_type})`);
@@ -1073,7 +1091,7 @@ async function extractLinksFromDir(
   // re-query the DB. globalBasename = true emits one edge per basename
   // match for bare wikilinks like `[[struktura]]`.
   const globalBasename = await isGlobalBasenameEnabled(engine);
-  const schemaPack = await loadExtractionSchemaPack();
+  const schemaPackState = await loadExtractionSchemaPack();
 
   // Progress stream on stderr (separate from the action-events --json writes
   // to stdout, which tests grep for). Rate-gated; respects global --quiet /
@@ -1110,7 +1128,7 @@ async function extractLinksFromDir(
     onItem: async (file) => {
       try {
         const content = readFileSync(file.path, 'utf-8');
-        const links = await extractLinksFromFile(content, file.relPath, allSlugs, { globalBasename, schemaPack });
+        const links = await extractLinksFromFile(content, file.relPath, allSlugs, { globalBasename, schemaPack: schemaPackState.schemaPack });
         for (const link of links) {
           if (dryRunSeen) {
             const key = `${link.from_slug}::${link.to_slug}::${link.link_type}`;
@@ -1221,14 +1239,14 @@ export async function extractLinksForSlugs(
     : undefined;
   // Issue #972: same flag as the standalone extract path.
   const globalBasename = await isGlobalBasenameEnabled(engine);
-  const schemaPack = await loadExtractionSchemaPack(opts?.sourceId);
+  const schemaPackState = await loadExtractionSchemaPack(opts?.sourceId);
   let created = 0;
   for (const slug of slugs) {
     const filePath = join(repoPath, slug + '.md');
     if (!existsSync(filePath)) continue;
     try {
       const content = readFileSync(filePath, 'utf-8');
-      for (const link of await extractLinksFromFile(content, slug + '.md', allSlugs, { globalBasename, schemaPack })) {
+      for (const link of await extractLinksFromFile(content, slug + '.md', allSlugs, { globalBasename, schemaPack: schemaPackState.schemaPack })) {
         try { await engine.addLink(link.from_slug, link.to_slug, link.context, link.link_type, link.link_source, undefined, undefined, linkOpts); created++; } catch { /* skip */ } // gbrain-allow-direct-insert: gbrain extract single-row fallback when batch path declines a row
       }
     } catch { /* skip */ }
@@ -1298,7 +1316,7 @@ async function extractLinksFromDB(
   // Issue #972: opt-in global-basename wikilink resolution. Read once
   // per extract run; threaded into each extractPageLinks call.
   const globalBasename = await isGlobalBasenameEnabled(engine);
-  const schemaPack = await loadExtractionSchemaPack(sourceIdFilter);
+  const schemaPackState = await loadExtractionSchemaPack(sourceIdFilter);
   // v0.32.8: listAllPageRefs enumerates (slug, source_id) so we can thread
   // sourceId to getPage AND build a cross-source resolution map for link
   // disambiguation. Pre-fix used getAllSlugs() which collapsed
@@ -1379,7 +1397,7 @@ async function extractLinksFromDB(
     // basename lookup; off by default for back-compat.
     const extracted = await extractPageLinks(
       slug, fullContent, page.frontmatter, page.type, resolver,
-      { skipFrontmatter: !includeFrontmatter, globalBasename, schemaPack },
+      { skipFrontmatter: !includeFrontmatter || schemaPackState.skipFrontmatter, globalBasename, schemaPack: schemaPackState.schemaPack },
     );
     unresolved.push(...extracted.unresolved);
 
@@ -1605,7 +1623,7 @@ async function extractStaleFromDB(
   const resolver = makeResolver(engine, { mode: 'batch' });
   const nullResolver = { resolve: async () => null as string | null };
   const activeResolver = includeFrontmatter ? resolver : nullResolver;
-  const schemaPack = includeFrontmatter ? await loadExtractionSchemaPack(sourceIdFilter) : undefined;
+  const schemaPackState = includeFrontmatter ? await loadExtractionSchemaPack(sourceIdFilter) : undefined;
   const allRefs = await engine.listAllPageRefs();
   const allSlugs = new Set<string>();
   const slugToSources = new Map<string, string[]>();
@@ -1638,7 +1656,7 @@ async function extractStaleFromDB(
       const fullContent = page.compiled_truth + '\n' + page.timeline;
       const extracted = await extractPageLinks(
         page.slug, fullContent, page.frontmatter, page.type, activeResolver,
-        { skipFrontmatter: !includeFrontmatter, schemaPack },
+        { skipFrontmatter: !includeFrontmatter || schemaPackState?.skipFrontmatter, schemaPack: schemaPackState?.schemaPack },
       );
       for (const c of extracted.candidates) {
         const r = resolveCandidateSources(c, page.slug, page.source_id, allSlugs, slugToSources);

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -48,6 +48,7 @@ import {
 import type { SchemaPackManifest, PackPrimitive } from '../core/schema-pack/manifest-v1.ts';
 import { PACK_PRIMITIVES } from '../core/schema-pack/manifest-v1.ts';
 import { gbrainPath, loadConfig, configPath } from '../core/config.ts';
+import { BUNDLED_PACK_NAMES as BUNDLED_PACK_NAME_LIST } from '../core/schema-pack/bundled.ts';
 
 export async function runSchema(args: string[]): Promise<void> {
   const sub = args[0];
@@ -179,7 +180,7 @@ async function runActive(_args: string[]): Promise<void> {
 }
 
 function runList(_args: string[]): void {
-  const bundled = ['gbrain-base', 'gbrain-recommended'];
+  const bundled = [...BUNDLED_PACK_NAME_LIST];
   const installedDir = gbrainPath('schema-packs');
   const installed: string[] = [];
   if (existsSync(installedDir)) {
@@ -366,12 +367,13 @@ function runUse(args: string[]): void {
 }
 
 function packPathByName(name: string): string | null {
-  if (name === 'gbrain-base') {
-    // Resolve bundled YAML — try a few locations.
+  if ((BUNDLED_PACK_NAME_LIST as readonly string[]).includes(name)) {
+    // Resolve bundled YAML — try a few locations so source, built, and
+    // worktree executions all inspect the same native pack surface.
     const here = dirname(new URL(import.meta.url).pathname);
     const candidates = [
-      join(here, '..', 'core', 'schema-pack', 'base', 'gbrain-base.yaml'),
-      join(here, '..', '..', 'src', 'core', 'schema-pack', 'base', 'gbrain-base.yaml'),
+      join(here, '..', 'core', 'schema-pack', 'base', `${name}.yaml`),
+      join(here, '..', '..', 'src', 'core', 'schema-pack', 'base', `${name}.yaml`),
     ];
     for (const c of candidates) {
       if (existsSync(c)) return c;

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -13,6 +13,8 @@
 
 import type { BrainEngine } from './engine.ts';
 import type { PageType } from './types.ts';
+import type { SchemaPackManifest } from './schema-pack/manifest-v1.ts';
+import { frontmatterLinkTypeFromPack } from './schema-pack/link-inference.ts';
 
 /**
  * v0.42.7 — link-extraction version stamp. Bump this ISO timestamp whenever the
@@ -27,7 +29,7 @@ import type { PageType } from './types.ts';
  * OR updated_at > links_extracted_at`. It is an ISO-8601 string (NOT a number) —
  * the column is TIMESTAMPTZ and the predicate binds it as `::timestamptz`.
  */
-export const LINK_EXTRACTOR_VERSION_TS = '2026-05-31T00:00:00Z';
+export const LINK_EXTRACTOR_VERSION_TS = '2026-06-10T00:00:00Z';
 
 // ─── Entity references ──────────────────────────────────────────
 
@@ -467,7 +469,7 @@ export async function extractPageLinks(
   frontmatter: Record<string, unknown>,
   pageType: PageType,
   resolver: SlugResolver,
-  opts: { globalBasename?: boolean; skipFrontmatter?: boolean } = {},
+  opts: { globalBasename?: boolean; skipFrontmatter?: boolean; schemaPack?: Pick<SchemaPackManifest, 'frontmatter_links'> } = {},
 ): Promise<PageLinksResult> {
   const candidates: LinkCandidate[] = [];
 
@@ -551,7 +553,7 @@ export async function extractPageLinks(
   // path needed `resolveBasenameMatches` on the real resolver.
   let fmUnresolved: UnresolvedFrontmatterRef[] = [];
   if (!opts.skipFrontmatter) {
-    const fm = await extractFrontmatterLinks(slug, pageType, frontmatter, resolver);
+    const fm = await extractFrontmatterLinks(slug, pageType, frontmatter, resolver, { schemaPack: opts.schemaPack });
     candidates.push(...fm.candidates);
     fmUnresolved = fm.unresolved;
   }
@@ -1004,6 +1006,50 @@ export interface FrontmatterExtractResult {
   unresolved: UnresolvedFrontmatterRef[];
 }
 
+export interface FrontmatterExtractOptions {
+  /**
+   * Optional active schema pack. When supplied, frontmatter_links rules
+   * override the legacy hardcoded verb for matching fields. Legacy direction
+   * and dirHint are preserved where a legacy mapping exists; pack-only fields
+   * default to outgoing slug-shaped links.
+   */
+  schemaPack?: Pick<SchemaPackManifest, 'frontmatter_links'>;
+}
+
+function frontmatterMappingsForPage(
+  pageType: string,
+  schemaPack?: Pick<SchemaPackManifest, 'frontmatter_links'>,
+): FrontmatterFieldMapping[] {
+  if (!schemaPack || schemaPack.frontmatter_links.length === 0) return FRONTMATTER_LINK_MAP;
+
+  const mappings: FrontmatterFieldMapping[] = [];
+  const seen = new Set<string>();
+
+  for (const mapping of FRONTMATTER_LINK_MAP) {
+    if (mapping.pageType && mapping.pageType !== pageType) continue;
+    for (const field of mapping.fields) {
+      const packType = frontmatterLinkTypeFromPack(schemaPack, pageType, field);
+      mappings.push({ ...mapping, fields: [field], type: packType ?? mapping.type });
+      seen.add(field);
+    }
+  }
+
+  for (const rule of schemaPack.frontmatter_links) {
+    if (rule.page_type !== pageType) continue;
+    const fields = rule.fields.filter(field => !seen.has(field));
+    if (fields.length === 0) continue;
+    mappings.push({
+      fields,
+      pageType,
+      type: rule.link_type,
+      direction: 'outgoing',
+      dirHint: '',
+    });
+  }
+
+  return mappings;
+}
+
 /**
  * Extract typed graph edges from YAML frontmatter. Async because the
  * resolver may need to query the DB for fuzzy matches.
@@ -1017,11 +1063,12 @@ export async function extractFrontmatterLinks(
   pageType: PageType,
   frontmatter: Record<string, unknown>,
   resolver: SlugResolver,
+  opts: FrontmatterExtractOptions = {},
 ): Promise<FrontmatterExtractResult> {
   const candidates: LinkCandidate[] = [];
   const unresolved: UnresolvedFrontmatterRef[] = [];
 
-  for (const mapping of FRONTMATTER_LINK_MAP) {
+  for (const mapping of frontmatterMappingsForPage(pageType, opts.schemaPack)) {
     if (mapping.pageType && mapping.pageType !== pageType) continue;
     for (const field of mapping.fields) {
       const value = frontmatter[field];

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -4274,7 +4274,8 @@ const list_schema_packs: Operation = {
     const { existsSync, readdirSync } = await import('node:fs');
     const { join } = await import('node:path');
     const { gbrainPath } = await import('./config.ts');
-    const bundled = ['gbrain-base', 'gbrain-recommended'];
+    const { BUNDLED_PACK_NAMES } = await import('./schema-pack/bundled.ts');
+    const bundled = [...BUNDLED_PACK_NAMES];
     const installedDir = gbrainPath('schema-packs');
     const installed: string[] = [];
     if (existsSync(installedDir)) {

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -8,6 +8,7 @@ import { resolve, relative, sep } from 'path';
 import type { BrainEngine } from './engine.ts';
 import { clampSearchLimit } from './engine.ts';
 import type { GBrainConfig } from './config.ts';
+import type { SchemaPackManifest } from './schema-pack/manifest-v1.ts';
 import type { PageType } from './types.ts';
 import { importFromContent } from './import-file.ts';
 import { writePageThrough } from './write-through.ts';
@@ -17,6 +18,7 @@ import { dedupResults } from './search/dedup.ts';
 import { captureEvalCandidate, isEvalCaptureEnabled, isEvalScrubEnabled } from './eval-capture.ts';
 import type { HybridSearchMeta } from './types.ts';
 import { extractPageLinks, isAutoLinkEnabled, isAutoTimelineEnabled, isGlobalBasenameEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef } from './link-extraction.ts';
+import { loadActivePackBestEffort } from './schema-pack/best-effort.ts';
 import { isFactsBackstopEligible } from './facts/eligibility.ts';
 import { stripTakesFence } from './takes-fence.ts';
 import { stripFactsFence } from './facts-fence.ts';
@@ -926,7 +928,10 @@ const put_page: Operation = {
       try {
         const enabled = await isAutoLinkEnabled(ctx.engine);
         if (enabled) {
-          autoLinks = await runAutoLink(ctx.engine, slug, result.parsedPage, ctx.sourceId ? { sourceId: ctx.sourceId } : undefined);
+          autoLinks = await runAutoLink(ctx.engine, slug, result.parsedPage, {
+            ...(ctx.sourceId ? { sourceId: ctx.sourceId } : {}),
+            schemaPack: (await loadActivePackBestEffort(ctx))?.manifest,
+          });
         }
       } catch (e) {
         autoLinks = { error: e instanceof Error ? e.message : String(e) };
@@ -1059,7 +1064,7 @@ async function runAutoLink(
   engine: BrainEngine,
   slug: string,
   parsed: { type: PageType; compiled_truth: string; timeline: string; frontmatter: Record<string, unknown> },
-  opts?: { sourceId?: string },
+  opts?: { sourceId?: string; schemaPack?: Pick<SchemaPackManifest, 'frontmatter_links'> },
 ): Promise<{ created: number; removed: number; errors: number; unresolved: UnresolvedFrontmatterRef[] }> {
   const fullContent = parsed.compiled_truth + '\n' + parsed.timeline;
   // v0.31.8 (codex OV-2): thread sourceId through every read + write inside
@@ -1084,7 +1089,7 @@ async function runAutoLink(
   const globalBasename = await isGlobalBasenameEnabled(engine);
   const { candidates, unresolved } = await extractPageLinks(
     slug, fullContent, parsed.frontmatter, parsed.type, resolver,
-    { globalBasename },
+    { globalBasename, schemaPack: opts?.schemaPack },
   );
 
   // Resolve which targets exist (skip refs to non-existent pages to avoid FK

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -18,7 +18,7 @@ import { dedupResults } from './search/dedup.ts';
 import { captureEvalCandidate, isEvalCaptureEnabled, isEvalScrubEnabled } from './eval-capture.ts';
 import type { HybridSearchMeta } from './types.ts';
 import { extractPageLinks, isAutoLinkEnabled, isAutoTimelineEnabled, isGlobalBasenameEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef } from './link-extraction.ts';
-import { loadActivePackBestEffort } from './schema-pack/best-effort.ts';
+import { loadActivePackBestEffortWithResolution } from './schema-pack/best-effort.ts';
 import { isFactsBackstopEligible } from './facts/eligibility.ts';
 import { stripTakesFence } from './takes-fence.ts';
 import { stripFactsFence } from './facts-fence.ts';
@@ -928,9 +928,20 @@ const put_page: Operation = {
       try {
         const enabled = await isAutoLinkEnabled(ctx.engine);
         if (enabled) {
+          const packState = await loadActivePackBestEffortWithResolution(ctx);
+          if (!packState.pack && packState.configured) {
+            console.error(
+              `[schema] active schema_pack \`${packState.resolution.pack_name}\` (${packState.resolution.source}) failed to load; ` +
+              'skipping frontmatter link extraction for this put_page auto-link run to avoid legacy-verb edges.',
+            );
+          }
+          const schemaPack = packState.configured && packState.pack?.manifest.frontmatter_links.length
+            ? packState.pack.manifest
+            : undefined;
           autoLinks = await runAutoLink(ctx.engine, slug, result.parsedPage, {
             ...(ctx.sourceId ? { sourceId: ctx.sourceId } : {}),
-            schemaPack: (await loadActivePackBestEffort(ctx))?.manifest,
+            schemaPack,
+            skipFrontmatter: !packState.pack && packState.configured,
           });
         }
       } catch (e) {
@@ -1064,7 +1075,7 @@ async function runAutoLink(
   engine: BrainEngine,
   slug: string,
   parsed: { type: PageType; compiled_truth: string; timeline: string; frontmatter: Record<string, unknown> },
-  opts?: { sourceId?: string; schemaPack?: Pick<SchemaPackManifest, 'frontmatter_links'> },
+  opts?: { sourceId?: string; schemaPack?: Pick<SchemaPackManifest, 'frontmatter_links'>; skipFrontmatter?: boolean },
 ): Promise<{ created: number; removed: number; errors: number; unresolved: UnresolvedFrontmatterRef[] }> {
   const fullContent = parsed.compiled_truth + '\n' + parsed.timeline;
   // v0.31.8 (codex OV-2): thread sourceId through every read + write inside
@@ -1089,7 +1100,7 @@ async function runAutoLink(
   const globalBasename = await isGlobalBasenameEnabled(engine);
   const { candidates, unresolved } = await extractPageLinks(
     slug, fullContent, parsed.frontmatter, parsed.type, resolver,
-    { globalBasename, schemaPack: opts?.schemaPack },
+    { globalBasename, skipFrontmatter: opts?.skipFrontmatter, schemaPack: opts?.schemaPack },
   );
 
   // Resolve which targets exist (skip refs to non-existent pages to avoid FK

--- a/src/core/schema-pack/best-effort.ts
+++ b/src/core/schema-pack/best-effort.ts
@@ -24,8 +24,8 @@
 
 import { loadConfig } from '../config.ts';
 import type { OperationContext } from '../operations.ts';
-import { loadActivePack } from './load-active.ts';
-import type { ResolvedPack } from './registry.ts';
+import { loadActivePack, resolveActivePackNameOnly } from './load-active.ts';
+import type { ResolvedPack, ResolutionResult } from './registry.ts';
 
 /**
  * Best-effort loader for the active schema pack. Returns null on any
@@ -44,16 +44,43 @@ import type { ResolvedPack } from './registry.ts';
  *     : [];  // EMPTY filter, NOT hardcoded defaults
  *   const results = await search(query, { types });
  */
+function activePackInput(ctx: OperationContext) {
+  return {
+    cfg: loadConfig(),
+    remote: ctx.remote ?? true,
+    sourceId: ctx.sourceId,
+  };
+}
+
 export async function loadActivePackBestEffort(
   ctx: OperationContext,
 ): Promise<ResolvedPack | null> {
   try {
-    return await loadActivePack({
-      cfg: loadConfig(),
-      remote: ctx.remote ?? true,
-      sourceId: ctx.sourceId,
-    });
+    return await loadActivePack(activePackInput(ctx));
   } catch {
     return null;
   }
+}
+
+export interface ActivePackBestEffortResult {
+  pack: ResolvedPack | null;
+  resolution: ResolutionResult;
+  configured: boolean;
+}
+
+/**
+ * Best-effort active pack load plus resolution provenance. Consumers that
+ * need to preserve legacy fallback only for an unconfigured default pack can
+ * distinguish `configured=false` from a configured pack that failed to load.
+ *
+ * Still NEVER throws and NEVER logs; call sites choose how loud their
+ * fail-empty surface should be.
+ */
+export async function loadActivePackBestEffortWithResolution(
+  ctx: OperationContext,
+): Promise<ActivePackBestEffortResult> {
+  const input = activePackInput(ctx);
+  const resolution = resolveActivePackNameOnly(input);
+  const pack = await loadActivePackBestEffort(ctx);
+  return { pack, resolution, configured: resolution.source !== 'default' };
 }

--- a/src/core/schema-pack/bundled.ts
+++ b/src/core/schema-pack/bundled.ts
@@ -1,0 +1,20 @@
+// Bundled schema-pack registry.
+//
+// Keep all bundled pack consumers on this one list so CLI/MCP inspection,
+// active-pack loading, mutation guards, and upgrade discovery cannot drift.
+
+export const BUNDLED_PACK_NAMES = [
+  'gbrain-base',
+  'gbrain-recommended',
+  'gbrain-creator',
+  'gbrain-investor',
+  'gbrain-engineer',
+  'gbrain-everything',
+  'gbrain-base-v2',
+] as const;
+
+export type BundledPackName = typeof BUNDLED_PACK_NAMES[number];
+
+export function isBundledPackName(name: string): name is BundledPackName {
+  return (BUNDLED_PACK_NAMES as readonly string[]).includes(name);
+}

--- a/src/core/schema-pack/load-active.ts
+++ b/src/core/schema-pack/load-active.ts
@@ -37,6 +37,7 @@ import {
   type ResolutionInput,
   type ResolutionResult,
 } from './registry.ts';
+import { BUNDLED_PACK_NAMES } from './bundled.ts';
 
 /**
  * Inputs the caller (operations.ts handler / engine query path) provides.
@@ -92,28 +93,7 @@ export function _resetPackLocatorForTests(): void {
  * throwing UnknownPackError with a paste-ready install hint.
  */
 function defaultPackLocator(name: string): string | null {
-  // v0.39 T8 — bundled packs registry. gbrain-base + gbrain-recommended
-  // ship in src/core/schema-pack/base/. Add a new entry here to bundle
-  // additional canonical packs.
-  //
-  // v0.41 T4 — lens packs join the bundle: creator (atoms + concepts +
-  // extract_atoms/synthesize_concepts phases), investor (theses + bet
-  // resolution + 3 calibration domains), engineer (gstack-learnings bridge
-  // + 3 calibration domains), everything (meta-pack stacking all three
-  // via extends + borrow_from). Each ships as a real YAML at base/<name>.yaml.
-  const BUNDLED: ReadonlyArray<string> = [
-    'gbrain-base',
-    'gbrain-recommended',
-    'gbrain-creator',
-    'gbrain-investor',
-    'gbrain-engineer',
-    'gbrain-everything',
-    // v0.42 type-unification: 15-type canonical successor to gbrain-base.
-    // Ships as install default (Lane E T17) + via gbrain onboard pack
-    // upgrade flow (the unify-types Minion handler).
-    'gbrain-base-v2',
-  ];
-  if (BUNDLED.includes(name)) {
+  if ((BUNDLED_PACK_NAMES as readonly string[]).includes(name)) {
     // Resolve bundled YAML relative to this source file. Works in both
     // direct-bun execution and bun --compile binaries.
     const here = dirname(fileURLToPath(import.meta.url));

--- a/src/core/schema-pack/loader.ts
+++ b/src/core/schema-pack/loader.ts
@@ -159,6 +159,28 @@ export function parseYamlMini(content: string): unknown {
     return parseMapping(baseIndent);
   }
 
+  function parseBlockScalar(parentIndent: number, folded: boolean): string {
+    const contentIndent = parentIndent + 2;
+    const out: string[] = [];
+    while (i < lines.length) {
+      const raw = lines[i];
+      if (isBlank(raw)) {
+        out.push('');
+        i++;
+        continue;
+      }
+      const indent = indentOf(raw);
+      if (indent <= parentIndent) break;
+      const withoutComment = stripComment(raw);
+      out.push(withoutComment.slice(Math.min(contentIndent, indent)));
+      i++;
+    }
+    if (folded) {
+      return out.join(' ').replace(/\s+$/u, '');
+    }
+    return out.join('\n').replace(/\n+$/u, '');
+  }
+
   function parseSequence(baseIndent: number): unknown[] {
     const result: unknown[] = [];
     while (i < lines.length) {
@@ -227,6 +249,10 @@ export function parseYamlMini(content: string): unknown {
           i++;
           if (rest2 === '') {
             map[key2] = parseBlock(nextIndent + 2);
+          } else if (rest2 === '|' || rest2 === '|-' || rest2 === '|+') {
+            map[key2] = parseBlockScalar(nextIndent, false);
+          } else if (rest2 === '>' || rest2 === '>-' || rest2 === '>+') {
+            map[key2] = parseBlockScalar(nextIndent, true);
           } else {
             map[key2] = parseScalar(rest2);
           }
@@ -257,6 +283,10 @@ export function parseYamlMini(content: string): unknown {
       i++;
       if (rest === '') {
         result[key] = parseBlock(indent + 2);
+      } else if (rest === '|' || rest === '|-' || rest === '|+') {
+        result[key] = parseBlockScalar(indent, false);
+      } else if (rest === '>' || rest === '>-' || rest === '>+') {
+        result[key] = parseBlockScalar(indent, true);
       } else {
         result[key] = parseScalar(rest);
       }

--- a/src/core/schema-pack/mutate.ts
+++ b/src/core/schema-pack/mutate.ts
@@ -65,6 +65,7 @@ import { invalidateQueryCache } from './query-cache-invalidator.ts';
 import { logMutationFailure, logMutationSuccess, type MutationActor, type MutationOp } from './mutate-audit.ts';
 import { runFilePlaneLintRules } from './lint-rules.ts';
 import { withPackLock, type PackLockOpts } from './pack-lock.ts';
+import { BUNDLED_PACK_NAMES as BUNDLED_PACK_NAME_LIST } from './bundled.ts';
 import type { BrainEngine } from '../engine.ts';
 
 export type PackFileFormat = 'json' | 'yaml';
@@ -93,7 +94,7 @@ export class SchemaPackMutationError extends Error {
   }
 }
 
-export const BUNDLED_PACK_NAMES = new Set(['gbrain-base', 'gbrain-recommended', 'gbrain-base-v2']);
+export const BUNDLED_PACK_NAMES = new Set<string>(BUNDLED_PACK_NAME_LIST);
 
 export interface MutateResult {
   /** Pack name that was mutated. */

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -12,6 +12,7 @@ import {
   type SlugResolver,
 } from '../src/core/link-extraction.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
+import { parseSchemaPackManifest } from '../src/core/schema-pack/index.ts';
 
 // v0.27.1 cherry-3: image-to-page path-proximity heuristic.
 describe('imageOfCandidates', () => {
@@ -242,6 +243,58 @@ describe('extractPageLinks', () => {
     const sourceLink = candidates.find(c => c.linkType === 'source');
     expect(sourceLink).toBeDefined();
     expect(sourceLink!.targetSlug).toBe('meetings/2026-01-15');
+  });
+
+  test('pack frontmatter_links can override a legacy field verb while preserving resolution', async () => {
+    const pack = parseSchemaPackManifest({
+      api_version: 'gbrain-schema-pack-v1',
+      name: 'jarvis-test',
+      version: '0.1.0',
+      extends: null,
+      page_types: [],
+      link_types: [{ name: 'sourced_from' }],
+      frontmatter_links: [
+        { page_type: 'person', fields: ['source'], link_type: 'sourced_from' },
+      ],
+    });
+    const { candidates } = await extractPageLinks(
+      'people/alice', 'Some content.', { source: 'meetings/2026-01-15' }, 'person', allowAllResolver,
+      { schemaPack: pack },
+    );
+    const sourceLink = candidates.find(c => c.targetSlug === 'meetings/2026-01-15');
+    expect(sourceLink).toBeDefined();
+    expect(sourceLink!.linkType).toBe('sourced_from');
+    expect(sourceLink!.fromSlug).toBe('people/alice');
+  });
+
+  test('pack-only frontmatter_links emit outgoing edges for custom fields', async () => {
+    const pack = parseSchemaPackManifest({
+      api_version: 'gbrain-schema-pack-v1',
+      name: 'jarvis-test',
+      version: '0.1.0',
+      extends: null,
+      page_types: [],
+      link_types: [{ name: 'about' }],
+      frontmatter_links: [
+        { page_type: 'note', fields: ['primary_entity'], link_type: 'about' },
+      ],
+    });
+    const { candidates } = await extractFrontmatterLinks(
+      'notes/alice-brief',
+      'note' as never,
+      { primary_entity: 'people/alice' },
+      allowAllResolver,
+      { schemaPack: pack },
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      fromSlug: 'notes/alice-brief',
+      targetSlug: 'people/alice',
+      linkType: 'about',
+      linkSource: 'frontmatter',
+      originSlug: 'notes/alice-brief',
+      originField: 'primary_entity',
+    });
   });
 
   test('extracts bare slug references in text', async () => {

--- a/test/operations-schema-pack.test.ts
+++ b/test/operations-schema-pack.test.ts
@@ -149,6 +149,9 @@ describe('list_schema_packs', () => {
       seedPack('mine');
       const result = await operationsByName.list_schema_packs!.handler(ctxOf(), {}) as { bundled: string[]; installed: string[] };
       expect(result.bundled).toContain('gbrain-base');
+      expect(result.bundled).toContain('gbrain-recommended');
+      expect(result.bundled).toContain('gbrain-base-v2');
+      expect(result.bundled).toContain('gbrain-investor');
       expect(result.installed).toContain('mine');
     });
   });

--- a/test/schema-cli.test.ts
+++ b/test/schema-cli.test.ts
@@ -58,11 +58,14 @@ describe('gbrain schema CLI (Phase C)', () => {
     expect(r.stdout + r.stderr).toMatch(/schema|active|list|show|validate|use/i);
   });
 
-  test('schema list shows gbrain-base bundled', () => {
+  test('schema list shows all bundled packs', () => {
     const r = gbrain(['schema', 'list']);
     expect(r.code).toBe(0);
     expect(r.stdout).toContain('Bundled packs:');
     expect(r.stdout).toContain('gbrain-base');
+    expect(r.stdout).toContain('gbrain-recommended');
+    expect(r.stdout).toContain('gbrain-base-v2');
+    expect(r.stdout).toContain('gbrain-investor');
   });
 
   test('schema show gbrain-base prints manifest details', () => {
@@ -85,6 +88,40 @@ describe('gbrain schema CLI (Phase C)', () => {
     expect(r.code).toBe(0);
     expect(r.stdout).toContain('✓');
     expect(r.stdout).toContain('valid manifest');
+  });
+
+  test('schema show/validate exposes bundled gbrain-recommended', () => {
+    const show = gbrain(['schema', 'show', 'gbrain-recommended']);
+    expect(show.code).toBe(0);
+    expect(show.stdout).toContain('gbrain-recommended v1.0.0');
+    expect(show.stdout).toContain('Page types (');
+    expect(show.stdout).toContain('meeting :: temporal');
+
+    const validate = gbrain(['schema', 'validate', 'gbrain-recommended']);
+    expect(validate.code).toBe(0);
+    expect(validate.stdout).toContain('valid manifest');
+  });
+
+  test('schema show exposes bundled gbrain-base-v2 successor pack', () => {
+    const r = gbrain(['schema', 'show', 'gbrain-base-v2']);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('gbrain-base-v2 v1.0.0');
+    expect(r.stdout).toContain('Page types (15)');
+    expect(r.stdout).toContain('Link verbs (14)');
+  });
+
+  test('schema active loads configured gbrain-recommended with real types', () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-schema-active-recommended-'));
+    try {
+      mkdirSync(join(home, '.gbrain'), { recursive: true });
+      writeFileSync(join(home, '.gbrain', 'config.json'), JSON.stringify({ schema_pack: 'gbrain-recommended' }), 'utf-8');
+      const r = gbrain(['schema', 'active'], { GBRAIN_HOME: home });
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain('Active pack: gbrain-recommended');
+      expect(r.stdout).not.toContain('Page types: 0');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   test('schema active reports default resolution', () => {

--- a/test/schema-pack-best-effort.test.ts
+++ b/test/schema-pack-best-effort.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { loadActivePackBestEffort } from '../src/core/schema-pack/best-effort.ts';
+import { loadActivePackBestEffort, loadActivePackBestEffortWithResolution } from '../src/core/schema-pack/best-effort.ts';
 import {
   __setPackLocatorForTests,
   _resetPackLocatorForTests,
@@ -78,6 +78,25 @@ describe('loadActivePackBestEffort', () => {
     await withEnv({ GBRAIN_HOME: tmpDir }, async () => {
       // resolves, doesn't throw.
       await expect(loadActivePackBestEffort(fakeCtx())).resolves.toBeNull();
+    });
+  });
+
+  it('reports unconfigured default separately from configured pack load failure', async () => {
+    await withEnv({ GBRAIN_HOME: tmpDir, GBRAIN_SCHEMA_PACK: undefined }, async () => {
+      const result = await loadActivePackBestEffortWithResolution(fakeCtx());
+      expect(result.configured).toBe(false);
+      expect(result.resolution.source).toBe('default');
+      expect(result.pack?.manifest.name).toBe('gbrain-base');
+    });
+  });
+
+  it('reports configured=true when a configured pack fails to load', async () => {
+    __setPackLocatorForTests(() => null);
+    await withEnv({ GBRAIN_HOME: tmpDir, GBRAIN_SCHEMA_PACK: 'never-installed' }, async () => {
+      const result = await loadActivePackBestEffortWithResolution(fakeCtx());
+      expect(result.configured).toBe(true);
+      expect(result.resolution).toMatchObject({ pack_name: 'never-installed', source: 'env' });
+      expect(result.pack).toBeNull();
     });
   });
 });

--- a/test/schema-pack-loader.test.ts
+++ b/test/schema-pack-loader.test.ts
@@ -345,6 +345,25 @@ describe('YAML mini-parser', () => {
     expect(result.types[1].weight).toBe(2);
   });
 
+  test('parses block scalar without swallowing following keys', () => {
+    const yaml = `name: blocky
+description: |
+  First line.
+  Second line.
+page_types:
+  - name: meeting
+    primitive: temporal
+    path_prefixes:
+      - meetings/
+    aliases: []
+    extractable: true
+    expert_routing: false`;
+    const result = parseYamlMini(yaml) as { description: string; page_types: Array<Record<string, unknown>> };
+    expect(result.description).toBe('First line.\nSecond line.');
+    expect(result.page_types).toHaveLength(1);
+    expect(result.page_types[0].name).toBe('meeting');
+  });
+
   test('strips comments', () => {
     const result = parseYamlMini('# top comment\nname: value # inline comment') as Record<string, unknown>;
     expect(result.name).toBe('value');
@@ -373,6 +392,27 @@ extends: null`;
     });
     const pack = loadPackFromString(json, 'fixture.json');
     expect(pack.name).toBe('json-pack');
+  });
+
+  test('loads block-scalar pack descriptions without losing page types', () => {
+    const pack = loadPackFromString(`api_version: gbrain-schema-pack-v1
+name: recommended-fixture
+version: 1.0.0
+extends: gbrain-base
+description: |
+  Operational starter pack.
+page_types:
+  - name: meeting
+    primitive: temporal
+    path_prefixes:
+      - meetings/
+    aliases: []
+    extractable: true
+    expert_routing: false
+link_types: []`, 'fixture.yaml');
+    expect(pack.name).toBe('recommended-fixture');
+    expect(pack.extends).toBe('gbrain-base');
+    expect(pack.page_types.map((t) => t.name)).toContain('meeting');
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixes D4 fail-empty semantics for pack-fed frontmatter link extraction.
- Uses the shared `loadActivePackBestEffort` path from `extract.ts` instead of an open-coded loader.
- Preserves legacy `FRONTMATTER_LINK_MAP` fallback only when no schema pack is configured or the configured/active pack declares zero `frontmatter_links`.
- Skips frontmatter link extraction, with a loud stderr warning, when a configured schema pack fails to load so extraction never silently emits legacy-verb edges against packed-out user intent.

## Why this matches Garry's migration pattern

This completes the follow-through described in `TODOS.md`:

- `T1.5 follow-through` says runtime call sites should consume pack-aware type/filter helpers through the shared best-effort loader rather than retaining hardcoded defaults.
- `TODO-1 (P2)` repeats the same migration shape for the later `--by-mention` gazetteer: use `loadActivePackBestEffort(ctx)` first, then fall back only for unconfigured/back-compat cases.

The important contract is D4: pack load failure is not a signal to resurrect hardcoded legacy behavior. It is a fail-empty condition for that pack-fed extraction surface.

## Notes

The existing `extractStaleFromDB` `skipFrontmatter` threading is intentionally retained. It keeps stale extraction's frontmatter pass behind the same explicit `includeFrontmatter` gate while still allowing body/wikilink extraction to proceed.

## Verification

- `bun test test/link-extraction.test.ts`
- `bun test test/schema-pack-best-effort.test.ts`
- `bun test test/schema-pack-load-active.serial.test.ts`
- `bun test test/put-page-provenance.test.ts`
- `bun run typecheck`

> Stacked on #2029 (`fix(schema): make bundled pack inspection truthful`) — the first commit here is that PR; review the second commit (`fix(extract): ...`) plus the base wiring commit for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
