### PR TITLE
fix(links): collapse hyphen runs in normalizeBasename

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -27,7 +27,7 @@ import type { PageType } from './types.ts';
  * OR updated_at > links_extracted_at`. It is an ISO-8601 string (NOT a number) —
  * the column is TIMESTAMPTZ and the predicate binds it as `::timestamptz`.
  */
-export const LINK_EXTRACTOR_VERSION_TS = '2026-05-31T00:00:00Z';
+export const LINK_EXTRACTOR_VERSION_TS = '2026-06-10T00:00:00Z';
 
 // ─── Entity references ──────────────────────────────────────────
 
@@ -822,7 +822,17 @@ export interface SlugResolver {
  * final `/`-segment (or the whole slug when it has no `/`).
  */
 export function normalizeBasename(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9\s-]/g, '').trim().replace(/\s+/g, '-');
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    // Collapse runs of whitespace AND hyphens to a single hyphen. Titles that
+    // contain " - " (space-hyphen-space) — e.g. "Idea - X", "Project - Y" —
+    // otherwise produce "idea---x" and fail to match the single-hyphen slug
+    // tail "idea-x" that buildBasenameIndex keys on. The slug generator already
+    // collapses separators; this keeps the lookup side symmetric.
+    .replace(/[\s-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 /** Stable order: shorter slug first (likely closer to brain root), then lexical. */

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -8,6 +8,9 @@ import {
   makeResolver,
   parseTimelineEntries,
   isAutoLinkEnabled,
+  normalizeBasename,
+  buildBasenameIndex,
+  queryBasenameIndex,
   FRONTMATTER_LINK_MAP,
   type SlugResolver,
 } from '../src/core/link-extraction.ts';
@@ -1236,6 +1239,51 @@ describe("v0.18.0 migration v22 — links_resolution_type", () => {
     expect(v22!.sql).toContain("links_resolution_type_check");
     expect(v22!.sql).toContain("qualified");
     expect(v22!.sql).toContain("unqualified");
+  });
+});
+
+describe("normalizeBasename — hyphen-run collapse", () => {
+  test('collapses " - " (space-hyphen-space) to a single hyphen', () => {
+    // Before: "Idea - X" normalized to "idea---x" and missed the slug tail
+    // "idea-x" that buildBasenameIndex keys on.
+    expect(normalizeBasename("Idea - CEO Frustration Intercept")).toBe(
+      "idea-ceo-frustration-intercept",
+    );
+    expect(normalizeBasename("Project - API Marketplace")).toBe(
+      "project-api-marketplace",
+    );
+  });
+
+  test("leaves simple titles single-hyphenated (no regression)", () => {
+    expect(normalizeBasename("Seren Porter")).toBe("seren-porter");
+    expect(normalizeBasename("SourcingGPT")).toBe("sourcinggpt");
+  });
+
+  test("trims stray leading/trailing hyphens", () => {
+    expect(normalizeBasename("- leading")).toBe("leading");
+    expect(normalizeBasename("trailing -")).toBe("trailing");
+  });
+});
+
+describe("queryBasenameIndex — resolves ' - ' titled wikilinks", () => {
+  const idx = buildBasenameIndex([
+    "ideas/idea-ceo-frustration-intercept",
+    "ideas/idea-agentic-communications-fabric",
+    "people/seren-porter",
+  ]);
+
+  test("[[Idea - X]] resolves to its single-hyphen slug", () => {
+    expect(queryBasenameIndex(idx, "Idea - CEO Frustration Intercept")).toEqual([
+      "ideas/idea-ceo-frustration-intercept",
+    ]);
+    expect(queryBasenameIndex(idx, "Idea - Agentic Communications Fabric")).toEqual([
+      "ideas/idea-agentic-communications-fabric",
+    ]);
+  });
+
+  test("simple basenames still resolve, no spurious matches", () => {
+    expect(queryBasenameIndex(idx, "Seren Porter")).toEqual(["people/seren-porter"]);
+    expect(queryBasenameIndex(idx, "Nonexistent Page")).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Bug

Under global-basename resolution, a wikilink whose target title contains `" - "` (space-hyphen-space) never resolves, so the edge is silently dropped. `[[Note - Quarterly Review]]` pointing at the page slugged `notes/note-quarterly-review` produces no link.

## Cause

`normalizeBasename` (src/core/link-extraction.ts) does `.replace(/\s+/g, '-')`, which collapses whitespace runs but not hyphen runs. `" - "` has a literal hyphen between two spaces, so it normalizes to a triple hyphen:

```
"Note - Quarterly Review"            ->  "note---quarterly-review"
slug tail keyed by buildBasenameIndex ->  "note-quarterly-review"
```

They never match. The slug generator already collapses separators, so the lookup side is asymmetric. This hits every page using the common `Type - Name` title convention.

## Fix

Collapse `[\s-]+` to one hyphen and trim stray edge hyphens, matching how slugs are built. Single-space titles are unaffected. Also bumps `LINK_EXTRACTOR_VERSION_TS` per the in-file convention so existing brains re-extract links on update.

## Testing

Added cases to `test/link-extraction.test.ts` for the hyphen-run collapse plus a no-regression check. `bun test test/link-extraction.test.ts` passes, `tsc --noEmit` clean.
