### PR TITLE
fix(links): collapse hyphen runs in normalizeBasename

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -27,7 +27,7 @@ import type { PageType } from './types.ts';
  * OR updated_at > links_extracted_at`. It is an ISO-8601 string (NOT a number) —
  * the column is TIMESTAMPTZ and the predicate binds it as `::timestamptz`.
  */
-export const LINK_EXTRACTOR_VERSION_TS = '2026-05-31T00:00:00Z';
+export const LINK_EXTRACTOR_VERSION_TS = '2026-06-10T00:00:00Z';
 
 // ─── Entity references ──────────────────────────────────────────
 
@@ -822,7 +822,18 @@ export interface SlugResolver {
  * final `/`-segment (or the whole slug when it has no `/`).
  */
 export function normalizeBasename(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9\s-]/g, '').trim().replace(/\s+/g, '-');
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    // Collapse runs of whitespace AND hyphens to a single hyphen. Titles that
+    // contain " - " (space-hyphen-space) — e.g. "Guide - Getting Started" —
+    // otherwise produce "guide---getting-started" and fail to match the
+    // single-hyphen slug tail "guide-getting-started" that buildBasenameIndex
+    // keys on. The slug generator already collapses separators; this keeps the
+    // lookup side symmetric.
+    .replace(/[\s-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 /** Stable order: shorter slug first (likely closer to brain root), then lexical. */

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -8,6 +8,9 @@ import {
   makeResolver,
   parseTimelineEntries,
   isAutoLinkEnabled,
+  normalizeBasename,
+  buildBasenameIndex,
+  queryBasenameIndex,
   FRONTMATTER_LINK_MAP,
   type SlugResolver,
 } from '../src/core/link-extraction.ts';
@@ -1236,6 +1239,53 @@ describe("v0.18.0 migration v22 — links_resolution_type", () => {
     expect(v22!.sql).toContain("links_resolution_type_check");
     expect(v22!.sql).toContain("qualified");
     expect(v22!.sql).toContain("unqualified");
+  });
+});
+
+describe("normalizeBasename — hyphen-run collapse", () => {
+  test('collapses " - " (space-hyphen-space) to a single hyphen', () => {
+    // Before: "Guide - Getting Started" normalized to "guide---getting-started"
+    // and missed the slug tail "guide-getting-started".
+    expect(normalizeBasename("Guide - Getting Started")).toBe(
+      "guide-getting-started",
+    );
+    expect(normalizeBasename("Project - API Gateway")).toBe(
+      "project-api-gateway",
+    );
+  });
+
+  test("leaves simple titles single-hyphenated (no regression)", () => {
+    expect(normalizeBasename("Release Notes")).toBe("release-notes");
+    expect(normalizeBasename("Roadmap")).toBe("roadmap");
+  });
+
+  test("trims stray leading/trailing hyphens", () => {
+    expect(normalizeBasename("- leading")).toBe("leading");
+    expect(normalizeBasename("trailing -")).toBe("trailing");
+  });
+});
+
+describe("queryBasenameIndex — resolves ' - ' titled wikilinks", () => {
+  const idx = buildBasenameIndex([
+    "guides/guide-getting-started",
+    "guides/project-api-gateway",
+    "guides/release-notes",
+  ]);
+
+  test("[[Type - Name]] resolves to its single-hyphen slug", () => {
+    expect(queryBasenameIndex(idx, "Guide - Getting Started")).toEqual([
+      "guides/guide-getting-started",
+    ]);
+    expect(queryBasenameIndex(idx, "Project - API Gateway")).toEqual([
+      "guides/project-api-gateway",
+    ]);
+  });
+
+  test("simple basenames still resolve, no spurious matches", () => {
+    expect(queryBasenameIndex(idx, "Release Notes")).toEqual([
+      "guides/release-notes",
+    ]);
+    expect(queryBasenameIndex(idx, "Nonexistent Page")).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Bug

Under global-basename resolution, a wikilink whose target title contains `" - "` (space-hyphen-space) never resolves, so the edge is silently dropped. `[[Project - API Gateway]]` pointing at the page slugged `guides/project-api-gateway` produces no link.

## Cause

`normalizeBasename` (src/core/link-extraction.ts) does `.replace(/\s+/g, '-')`, which collapses whitespace runs but not hyphen runs. `" - "` has a literal hyphen between two spaces, so it normalizes to a triple hyphen:

```
"Project - API Gateway"               ->  "project---api-gateway"
slug tail keyed by buildBasenameIndex ->  "project-api-gateway"
```

They never match. The slug generator already collapses separators, so the lookup side is asymmetric. This hits every page using the common `Type - Name` title convention.

## Fix

Collapse `[\s-]+` to one hyphen and trim stray edge hyphens, matching how slugs are built. Single-space titles are unaffected. Also bumps `LINK_EXTRACTOR_VERSION_TS` per the in-file convention so existing brains re-extract links on update and pick up the recovered edges.

## Testing

Added cases to `test/link-extraction.test.ts` for the hyphen-run collapse plus a no-regression check.

- `bun test test/link-extraction.test.ts` passes
- `tsc --noEmit` clean

On a ~230-page brain that used the `Type - Name` convention heavily, a full re-extract after the fix recovered ~600 previously-dropped edges and roughly halved the orphan count.

## Aside (not in this PR)

Path-style links with a non-canonical (capitalized) dir prefix, like `[[Some Folder/Some Page]]`, also miss in this resolver because `normalizeBasename` strips the `/` and mashes the segments. The filesystem extract path resolves those via relative-path logic, but the DB/basename resolver does not. Happy to send a follow-up that falls back to the final path segment if that is of interest.
