### PR TITLE
fix(sync): honor .gitignore in code walk; prune vendor/dist/build

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -11,6 +11,7 @@ import {
   isCodeFilePath,
   isMarkdownFilePath,
   isImageFilePath as isImageFilePathFromSync,
+  pruneDir,
   type SyncStrategy,
 } from '../core/sync.ts';
 import { sortNewestFirst } from '../core/sort-newest-first.ts';
@@ -513,6 +514,51 @@ function isCollectibleForWalker(
 }
 
 /**
+ * Git-aware fast path for `collectSyncableFiles`. Returns the strategy-filtered
+ * list of syncable files when `dir` is inside a git work tree (paths absolute,
+ * sorted), or `null` when `dir` is not a git repo / git is unavailable — in
+ * which case the caller falls back to the recursive FS walk.
+ *
+ * Honors `.gitignore` (the whole point): `git ls-files --cached --others
+ * --exclude-standard` lists tracked + untracked-not-ignored files, so vendored
+ * / build / generated trees never reach the importer. `-z` (NUL-delimited)
+ * survives paths with spaces/newlines. Each path is lstat-checked to preserve
+ * the walker's no-symlink policy and to drop submodule gitlinks (which surface
+ * as a single non-regular entry).
+ */
+function gitListSyncableFiles(
+  dir: string,
+  strategy: SyncStrategy,
+  multimodalOn: boolean,
+): string[] | null {
+  let stdout: string;
+  try {
+    stdout = execFileSync(
+      'git',
+      ['-C', dir, 'ls-files', '--cached', '--others', '--exclude-standard', '-z'],
+      { encoding: 'utf8', maxBuffer: 512 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+  } catch {
+    return null; // not a git work tree, or git not on PATH → FS-walk fallback
+  }
+  const files: string[] = [];
+  for (const rel of stdout.split('\0')) {
+    if (!rel) continue;
+    if (!isCollectibleForWalker(rel, strategy, multimodalOn)) continue;
+    const full = join(dir, rel);
+    let st;
+    try {
+      st = lstatSync(full);
+    } catch {
+      continue; // ls-files raced a deletion, or unreadable
+    }
+    if (st.isSymbolicLink() || !st.isFile()) continue;
+    files.push(full);
+  }
+  return files.sort();
+}
+
+/**
  * v0.31.2 (codex C4 + C5 + C8): unified walker with five hardenings:
  *
  * 1. `lstatSync` + explicit `isSymbolicLink()` skip — never follow symlinks.
@@ -532,6 +578,19 @@ function isCollectibleForWalker(
 export function collectSyncableFiles(dir: string, opts: CollectOpts = {}): string[] {
   const strategy: SyncStrategy = opts.strategy ?? 'markdown';
   const multimodalOn = process.env.GBRAIN_EMBEDDING_MULTIMODAL === 'true';
+
+  // v0.42.x (#1159 --respect-gitignore / #1483 .gbrainignore): when `dir` is a
+  // git work tree, enumerate via `git ls-files` so the walk honors
+  // `.gitignore`. Pre-fix the recursive FS walk below descended into every
+  // git-ignored tree — `vendor/` (PHP Composer), `storage/`, `public/build/`,
+  // etc. — so a Laravel/PHP repo's `--strategy code` sync tried to import ~50k
+  // dependency/build files (and bloated DB + embedding cost on any repo with
+  // vendored data/fixtures). `--cached --others --exclude-standard` = tracked
+  // PLUS untracked-not-ignored, so uncommitted source is still indexed. Non-git
+  // dirs (or git unavailable) fall through to the FS walk below.
+  const gitFiles = gitListSyncableFiles(dir, strategy, multimodalOn);
+  if (gitFiles) return gitFiles;
+
   const maxDepth = resolveMaxWalkDepth();
   const visitedInodes = new Map<string, true>();
   const files: string[] = [];
@@ -548,11 +607,11 @@ export function collectSyncableFiles(dir: string, opts: CollectOpts = {}): strin
       return;
     }
     for (const entry of entries) {
-      // Skip hidden dirs (.git, .claude, .raw, etc.) and `node_modules`/`ops`.
-      // Same set the legacy walkers honored, surfaced once at the top of
-      // every iteration.
-      if (entry.startsWith('.')) continue;
-      if (entry === 'node_modules' || entry === 'ops') continue;
+      // Descent-time prune through the canonical gate (single source of truth
+      // in core/sync.ts) instead of a hand-maintained inline list that drifted
+      // from it. Skips hidden dirs (`.git`, `.raw`, etc.), `node_modules`,
+      // `vendor`, `dist`, `build`, `ops`, and git submodules.
+      if (!pruneDir(entry, d)) continue;
 
       const full = join(d, entry);
       let stat;

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -241,6 +241,14 @@ function matchesAnyGlob(path: string, patterns?: string[]): boolean {
  */
 const PRUNE_DIR_NAMES = new Set<string>([
   'node_modules',
+  // Dependency / build-output trees that are git-ignored on virtually every
+  // repo and never contain hand-authored source worth indexing. `vendor`
+  // (PHP Composer / Go / Ruby bundle), `dist` + `build` (compiled output).
+  // Closes the silent-pollution bug where a Laravel/PHP repo's full code sync
+  // walked ~50k `vendor/` files (#1483 / #1159 / maintainer #1942).
+  'vendor',
+  'dist',
+  'build',
   '.raw',
   'ops',
 ]);


### PR DESCRIPTION
## Problem

`gbrain sync --strategy code` indexes git-ignored trees. On a Laravel/PHP repo this means it descends into `vendor/` (~50k Composer files), `storage/`, and `public/build/`, trying to import **52,164 files** where only ~1,000 are real source. The result: the full sync never finishes (watchdog SIGTERM at ~3%), and whatever it does import floods the index with library internals (`vendor/symfony/...`, `vendor/psy/psysh/...`), so semantic code search returns dependency files instead of project code.

Root cause: `collectSyncableFiles` (the full-sync / dry-run enumerator in `src/commands/import.ts`) reimplemented its own descent skip list inline — `if (entry === 'node_modules' || entry === 'ops') continue;` — bypassing the canonical `pruneDir` gate in `src/core/sync.ts` and ignoring `.gitignore` entirely. The two skip lists drifted, and neither covered `vendor`.

This is the concrete bug behind the open `--respect-gitignore` (#1159) / `.gbrainignore` (#1483) requests and overlaps the maintainer's #1942 vendor/dist/build prune.

## Fix

1. **Git-aware enumeration.** When `dir` is a git work tree, `collectSyncableFiles` now lists files via `git ls-files --cached --others --exclude-standard -z` (tracked + untracked-not-ignored), so the walk honors `.gitignore`. Non-git dirs fall through to the existing recursive FS walk unchanged. EroLab (a Laravel repo): **52,164 → 1,028 files**.
2. **Dedupe the FS fallback to the canonical gate.** The fallback walk now prunes through `pruneDir()` instead of the drifted inline `node_modules || ops` list, so the two can't diverge again.
3. **`PRUNE_DIR_NAMES` gains `vendor`, `dist`, `build`** — dependency/build-output trees that are git-ignored on virtually every repo. This covers the FS-fallback + incremental (`classifySync`) paths.

## Testing

- `git ls-files` path verified end-to-end via `--dry-run` on a real Laravel repo: 52,164 → 1,028.
- Walker regression suites green (90 pass, 0 fail): `test/sync-walker-symlink.test.ts`, `test/brain-writer-walk-prune.test.ts`, `test/sync.test.ts`, `test/sync-walker-submodule.test.ts`.
- `tsc --noEmit` clean.

Symlink policy and submodule-gitlink skipping are preserved (each `ls-files` entry is `lstat`-checked).
