### PR TITLE
fix(doctor): avoid misleading PGLite and gateway-loop warnings

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2672,8 +2672,18 @@ async function checkSubagentCapability(engine: BrainEngine): Promise<Check> {
       const { loadConfig } = await import('../core/config.ts');
       const cfg = loadConfig();
       const chatModel = cfg?.chat_model;
+      const useGatewayLoopRaw = await engine.getConfig('agent.use_gateway_loop').catch(() => null);
+      const useGatewayLoop = useGatewayLoopRaw === 'true' || useGatewayLoopRaw === '1';
       const { isAnthropicProvider } = await import('../core/model-config.ts');
       if (chatModel && !isAnthropicProvider(chatModel) && !process.env.ANTHROPIC_API_KEY) {
+        if (useGatewayLoop) {
+          return {
+            name: 'subagent_capability',
+            status: 'ok',
+            message:
+              `chat_model is "${chatModel}" (non-Anthropic), but agent.use_gateway_loop=true routes subagent loops through the configured gateway path.`,
+          };
+        }
         return {
           name: 'subagent_capability',
           status: 'warn',
@@ -2684,7 +2694,7 @@ async function checkSubagentCapability(engine: BrainEngine): Promise<Check> {
             `Either set ANTHROPIC_API_KEY or enable: \`gbrain config set agent.use_gateway_loop true\`.`,
         };
       }
-    } catch { /* loadConfig may throw; fall through */ }
+    } catch { /* loadConfig / config-table reads may throw; fall through */ }
 
     return {
       name: 'subagent_capability',
@@ -4918,16 +4928,24 @@ export async function buildChecks(
 
   // 4. pgvector extension
   progress.heartbeat('pgvector');
-  try {
-    const sql = db.getConnection();
-    const ext = await sql`SELECT extname FROM pg_extension WHERE extname = 'vector'`;
-    if (ext.length > 0) {
-      checks.push({ name: 'pgvector', status: 'ok', message: 'Extension installed' });
-    } else {
-      checks.push({ name: 'pgvector', status: 'fail', message: 'Extension not found. Run: CREATE EXTENSION vector;' });
+  if (engine.kind === 'pglite') {
+    checks.push({
+      name: 'pgvector',
+      status: 'ok',
+      message: 'Skipped (PGLite — pgvector is bundled in the WASM engine)',
+    });
+  } else {
+    try {
+      const sql = db.getConnection();
+      const ext = await sql`SELECT extname FROM pg_extension WHERE extname = 'vector'`;
+      if (ext.length > 0) {
+        checks.push({ name: 'pgvector', status: 'ok', message: 'Extension installed' });
+      } else {
+        checks.push({ name: 'pgvector', status: 'fail', message: 'Extension not found. Run: CREATE EXTENSION vector;' });
+      }
+    } catch {
+      checks.push({ name: 'pgvector', status: 'warn', message: 'Could not check pgvector extension' });
     }
-  } catch {
-    checks.push({ name: 'pgvector', status: 'warn', message: 'Could not check pgvector extension' });
   }
 
   // 4b. PgBouncer / prepared-statement compatibility.
@@ -5687,36 +5705,44 @@ export async function buildChecks(
   // surface matches `repair-jsonb` (the previous 4-target scan missed a
   // repair target, per #254/Codex review).
   progress.heartbeat('jsonb_integrity');
-  try {
-    const sql = db.getConnection();
-    const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
-      { table: 'pages',         col: 'frontmatter',    expected: 'object' },
-      { table: 'raw_data',      col: 'data',           expected: 'object' },
-      { table: 'ingest_log',    col: 'pages_updated',  expected: 'array'  },
-      { table: 'files',         col: 'metadata',       expected: 'object' },
-      { table: 'page_versions', col: 'frontmatter',    expected: 'object' },
-    ];
-    let totalBad = 0;
-    const breakdown: string[] = [];
-    for (const { table, col } of targets) {
-      progress.heartbeat(`jsonb_integrity.${table}.${col}`);
-      const rows = await sql.unsafe(
-        `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
-      );
-      const n = Number((rows as any)[0]?.n ?? 0);
-      if (n > 0) { totalBad += n; breakdown.push(`${table}.${col}=${n}`); }
+  if (engine.kind === 'pglite') {
+    checks.push({
+      name: 'jsonb_integrity',
+      status: 'ok',
+      message: 'Skipped (PGLite — JSONB double-encode bug is Postgres-only; repair-jsonb is a no-op)',
+    });
+  } else {
+    try {
+      const sql = db.getConnection();
+      const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
+        { table: 'pages',         col: 'frontmatter',    expected: 'object' },
+        { table: 'raw_data',      col: 'data',           expected: 'object' },
+        { table: 'ingest_log',    col: 'pages_updated',  expected: 'array'  },
+        { table: 'files',         col: 'metadata',       expected: 'object' },
+        { table: 'page_versions', col: 'frontmatter',    expected: 'object' },
+      ];
+      let totalBad = 0;
+      const breakdown: string[] = [];
+      for (const { table, col } of targets) {
+        progress.heartbeat(`jsonb_integrity.${table}.${col}`);
+        const rows = await sql.unsafe(
+          `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
+        );
+        const n = Number((rows as any)[0]?.n ?? 0);
+        if (n > 0) { totalBad += n; breakdown.push(`${table}.${col}=${n}`); }
+      }
+      if (totalBad === 0) {
+        checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'All JSONB columns store objects/arrays' });
+      } else {
+        checks.push({
+          name: 'jsonb_integrity',
+          status: 'warn',
+          message: `${totalBad} row(s) double-encoded (${breakdown.join(', ')}). Fix: gbrain repair-jsonb`,
+        });
+      }
+    } catch {
+      checks.push({ name: 'jsonb_integrity', status: 'warn', message: 'Could not check JSONB integrity' });
     }
-    if (totalBad === 0) {
-      checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'All JSONB columns store objects/arrays' });
-    } else {
-      checks.push({
-        name: 'jsonb_integrity',
-        status: 'warn',
-        message: `${totalBad} row(s) double-encoded (${breakdown.join(', ')}). Fix: gbrain repair-jsonb`,
-      });
-    }
-  } catch {
-    checks.push({ name: 'jsonb_integrity', status: 'warn', message: 'Could not check JSONB integrity' });
   }
 
   // 10b. Takes weight grid integrity (v0.32 — EXP-2).

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -75,6 +75,14 @@ export interface GBrainConfig {
    */
   storage?: unknown;
   /**
+   * v0.38+ subagent execution knobs. `agent.use_gateway_loop` lets non-Anthropic
+   * chat models drive protected subagent jobs through the configured gateway
+   * path instead of requiring ANTHROPIC_API_KEY.
+   */
+  agent?: {
+    use_gateway_loop?: boolean;
+  };
+  /**
    * v0.25.0 — session capture settings. Read via file-plane `loadConfig()`
    * at process boot (NOT `gbrain config set` which writes the DB plane —
    * those are different stores). Edit `~/.gbrain/config.json` directly.
@@ -697,6 +705,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'chat_fallback_chain',
   'provider_base_urls',
   'storage',
+  'agent',
+  'agent.use_gateway_loop',
   'eval',
   'eval.capture',
   'eval.scrub_pii',

--- a/test/doctor-pglite-and-gateway-loop.test.ts
+++ b/test/doctor-pglite-and-gateway-loop.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression coverage for misleading doctor warnings on PGLite brains and
+ * gateway-loop subagent configuration.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { buildChecks } from '../src/commands/doctor.ts';
+
+const OLD_ENV = { ...process.env };
+let home: string;
+let engine: PGLiteEngine;
+
+async function setupEngine(extraConfig: Record<string, unknown> = {}) {
+  home = mkdtempSync(join(tmpdir(), 'gbrain-doctor-regression-'));
+  process.env = { ...OLD_ENV };
+  delete process.env.ANTHROPIC_API_KEY;
+  process.env.GBRAIN_HOME = home;
+  process.env.GBRAIN_CHAT_MODEL = 'openai:gpt-5.2';
+  mkdirSync(join(home, '.gbrain'), { recursive: true });
+  writeFileSync(
+    join(home, '.gbrain', 'config.json'),
+    JSON.stringify({
+      engine: 'pglite',
+      database_path: join(home, '.gbrain', 'brain.pglite'),
+      chat_model: 'openai:gpt-5.2',
+      ...extraConfig,
+    }, null, 2) + '\n',
+  );
+  engine = new PGLiteEngine();
+  await engine.connect({ database_url: '' });
+  await engine.initSchema();
+}
+
+async function teardownEngine() {
+  try { await engine?.disconnect(); } catch {}
+  process.env = { ...OLD_ENV };
+  if (home) rmSync(home, { recursive: true, force: true });
+}
+
+async function checkMap() {
+  const checks = await buildChecks(engine, ['--json', '--scope=brain']);
+  return new Map(checks.map((c) => [c.name, c]));
+}
+
+describe('doctor PGLite and gateway-loop warnings', () => {
+  beforeEach(async () => {
+    await setupEngine();
+  });
+
+  afterEach(async () => {
+    await teardownEngine();
+  });
+
+  test('PGLite reports pgvector and jsonb integrity as ok/not-applicable, not warnings', async () => {
+    const checks = await checkMap();
+    expect(checks.get('pgvector')?.status).toBe('ok');
+    expect(checks.get('pgvector')?.message).toContain('PGLite');
+    expect(checks.get('jsonb_integrity')?.status).toBe('ok');
+    expect(checks.get('jsonb_integrity')?.message).toContain('PGLite');
+  });
+
+  test('agent.use_gateway_loop=true suppresses non-Anthropic missing-Anthropic-key warning', async () => {
+    await engine.setConfig('agent.use_gateway_loop', 'true');
+    const checks = await checkMap();
+    const check = checks.get('subagent_capability');
+    expect(check?.status).toBe('ok');
+    expect(check?.message).toContain('agent.use_gateway_loop=true');
+    expect(check?.message).not.toContain('ANTHROPIC_API_KEY is not set');
+  });
+});


### PR DESCRIPTION
## Summary
- Treat pgvector and JSONB integrity checks as OK/not-applicable on PGLite instead of warning on Postgres-only probes.
- Honor agent.use_gateway_loop=true in subagent capability doctor checks before warning about missing ANTHROPIC_API_KEY for non-Anthropic chat models.
- Add agent.use_gateway_loop to known config keys.
- Add regression coverage for PGLite doctor checks and gateway-loop subagent configuration.

## Test Plan
- bun test test/doctor-pglite-and-gateway-loop.test.ts
- bun test test/doctor-subagent-health.test.ts test/doctor.test.ts
- bun run typecheck

## Local verification
- Andrew's local PGLite brain now reports pgvector/jsonb_integrity/subagent_capability as OK in doctor output; remaining warning is only takes_count.