### PR TITLE
[codex] fix Supabase pgvector doctor checks

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2313,6 +2313,16 @@ export function checkAutopilotLockScope(): Check {
       const raw = readFileSync(legacy, 'utf8').trim();
       if (/^\d+$/.test(raw)) owningPid = raw;
     } catch { /* unreadable → leave 'unknown' */ }
+    if (/^\d+$/.test(owningPid)) {
+      try {
+        process.kill(Number(owningPid), 0);
+        return {
+          name: 'autopilot_lock_scope',
+          status: 'ok',
+          message: `External lock belongs to a running process: ${legacy} (PID ${owningPid})`,
+        };
+      } catch { /* dead or inaccessible → warn below */ }
+    }
     return {
       name: 'autopilot_lock_scope',
       status: 'warn',
@@ -2611,7 +2621,7 @@ async function checkEmbeddingEnvOverride(engine: BrainEngine): Promise<Check> {
   };
 }
 
-async function checkSubagentCapability(engine: BrainEngine): Promise<Check> {
+export async function checkSubagentCapability(engine: BrainEngine): Promise<Check> {
   try {
     const { classifyCapabilities } = await import('../core/ai/capabilities.ts');
     const tierSubagent = await engine.getConfig('models.tier.subagent');
@@ -2661,6 +2671,9 @@ async function checkSubagentCapability(engine: BrainEngine): Promise<Check> {
       const issue = explain(modelsDefault, 'models.default');
       if (issue) return issue;
     }
+    const useGatewayLoopRaw = await engine.getConfig('agent.use_gateway_loop').catch(() => null);
+    const useGatewayLoop =
+      useGatewayLoopRaw === 'true' || useGatewayLoopRaw === '1';
     // v0.37 (T10 / D7) + v0.38 (D7 capability rename): warn when the configured
     // chat_model is non-Anthropic AND ANTHROPIC_API_KEY isn't set. With
     // agent.use_gateway_loop=false (the v0.38 default), subagent jobs still
@@ -2673,7 +2686,7 @@ async function checkSubagentCapability(engine: BrainEngine): Promise<Check> {
       const cfg = loadConfig();
       const chatModel = cfg?.chat_model;
       const { isAnthropicProvider } = await import('../core/model-config.ts');
-      if (chatModel && !isAnthropicProvider(chatModel) && !process.env.ANTHROPIC_API_KEY) {
+      if (chatModel && !isAnthropicProvider(chatModel) && !process.env.ANTHROPIC_API_KEY && !useGatewayLoop) {
         return {
           name: 'subagent_capability',
           status: 'warn',
@@ -2689,7 +2702,9 @@ async function checkSubagentCapability(engine: BrainEngine): Promise<Check> {
     return {
       name: 'subagent_capability',
       status: 'ok',
-      message: tierSubagent
+      message: useGatewayLoop
+        ? `agent.use_gateway_loop=true; subagent jobs route through the configured gateway loop`
+        : tierSubagent
         ? `Subagent tier resolves to "${tierSubagent}" with full tool-loop capability`
         : `Subagent tier resolves to default (claude-sonnet-4-6) — full tool-loop capability`,
     };
@@ -3910,6 +3925,20 @@ export async function computePoolReapHealthCheck(
     };
   }
   return null;
+}
+
+export function parsePgVectorFormattedType(
+  actual: string,
+): { type: 'vector' | 'halfvec'; dimensions: number } | null {
+  // format_type() usually returns `vector(N)` / `halfvec(N)`, but Supabase
+  // installations can expose schema-qualified names such as
+  // `extensions.vector(N)` to restricted app roles.
+  const m = actual.match(/^(?:(?:\w+)\.)?(vector|halfvec)\((\d+)\)$/i);
+  if (!m) return null;
+  return {
+    type: m[1].toLowerCase() as 'vector' | 'halfvec',
+    dimensions: parseInt(m[2], 10),
+  };
 }
 
 export async function buildChecks(
@@ -5402,10 +5431,9 @@ export async function buildChecks(
           issues.push(`${colName}: declared but column does NOT exist in content_chunks`);
           continue;
         }
-        // Expected format: `vector(N)` or `halfvec(N)`.
-        const m = actual.match(/^(vector|halfvec)\((\d+)\)/i);
-        const actualType = m ? m[1].toLowerCase() : actual;
-        const actualDims = m ? parseInt(m[2], 10) : null;
+        const parsed = parsePgVectorFormattedType(actual);
+        const actualType = parsed?.type ?? actual;
+        const actualDims = parsed?.dimensions ?? null;
         if (actualType !== entry.type) {
           issues.push(
             `${colName}: declared type=${entry.type} but actual is ${actual}. ` +

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1875,7 +1875,8 @@ export class PostgresEngine implements BrainEngine {
     // in Voyage multimodal-3 space — no modality filter; the column itself
     // is the discriminator (rows without embedding_multimodal aren't searched).
     const resolvedCol = normalizeEngineColumn(opts?.embeddingColumn);
-    const { col, castSql } = buildVectorCastFragment(resolvedCol);
+    const { col, castSql: rawCastSql } = buildVectorCastFragment(resolvedCol);
+    const castSql = pgvectorCastSql(rawCastSql);
     let modalityFilter: string;
     if (resolvedCol.name === 'embedding_image') {
       modalityFilter = `AND cc.modality = 'image'`;
@@ -2100,9 +2101,9 @@ export class PostgresEngine implements BrainEngine {
         : null;
       const modality = chunk.modality ?? 'text';
 
-      const embeddingPh = embeddingStr ? `$${paramIdx++}::vector` : 'NULL';
+      const embeddingPh = embeddingStr ? `$${paramIdx++}${PG_VECTOR_CAST}` : 'NULL';
       const embeddedAtPh = embeddingStr ? 'now()' : 'NULL';
-      const embeddingImagePh = embeddingImageStr ? `$${paramIdx++}::vector` : 'NULL';
+      const embeddingImagePh = embeddingImageStr ? `$${paramIdx++}${PG_VECTOR_CAST}` : 'NULL';
 
       rows.push(
         `($${paramIdx++}, $${paramIdx++}, $${paramIdx++}, $${paramIdx++}, ` +
@@ -3627,22 +3628,19 @@ export class PostgresEngine implements BrainEngine {
 
   /**
    * v0.41.15.0 (T6, codex #20): per-process cache for the
-   * `facts.embedding` cast suffix. Migration v40 creates the column as
-   * `halfvec(N)` on pgvector >= 0.7 but falls back to `vector(N)` on
-   * older. The pre-v0.41.15 insert path always cast embeddings as
-   * `::vector`, which works via implicit cast on pgvector >= 0.7 but
-   * is honest-only when the column actually IS vector. Probing once
-   * per process + caching the suffix lets the insert match the column
-   * type exactly. Initialized lazily in `insertFacts`.
+   * `facts.embedding` cast suffix. Supabase can install pgvector in the
+   * private `extensions` schema while restricted roles lack schema USAGE, so
+   * current Postgres writes avoid explicit vector type names and let the
+   * target column infer the input type. Initialized lazily in `insertFacts`.
    */
-  private _factsEmbeddingCastSuffix: '::vector' | '::halfvec' | null = null;
+  private _factsEmbeddingCastSuffix: typeof PG_VECTOR_CAST | typeof PG_HALFVEC_CAST | null = null;
 
   /** Test seam: clear the cached cast suffix so tests can re-probe. */
   __resetFactsEmbeddingCastCacheForTest(): void {
     this._factsEmbeddingCastSuffix = null;
   }
 
-  private async resolveFactsEmbeddingCast(): Promise<'::vector' | '::halfvec'> {
+  private async resolveFactsEmbeddingCast(): Promise<typeof PG_VECTOR_CAST | typeof PG_HALFVEC_CAST> {
     if (this._factsEmbeddingCastSuffix !== null) return this._factsEmbeddingCastSuffix;
     const sql = this.sql;
     try {
@@ -3661,19 +3659,17 @@ export class PostgresEngine implements BrainEngine {
       // regex would shadow it. See readFactsEmbeddingDim's identical
       // ordering note.
       if (formatted && /halfvec\(\d+\)/i.test(formatted)) {
-        this._factsEmbeddingCastSuffix = '::halfvec';
+        this._factsEmbeddingCastSuffix = PG_HALFVEC_CAST;
       } else {
-        // Default to '::vector' (the pre-v0.41.15 behavior). On a brain
-        // without the facts.embedding column yet (pre-v40), the cast
-        // suffix is irrelevant — the INSERT would fail elsewhere
-        // anyway. Caching the default still saves the SELECT on
-        // subsequent inserts.
-        this._factsEmbeddingCastSuffix = '::vector';
+        // On a brain without the facts.embedding column yet (pre-v40), the
+        // suffix is irrelevant because the INSERT fails elsewhere anyway.
+        // Caching the default still saves the SELECT on subsequent inserts.
+        this._factsEmbeddingCastSuffix = PG_VECTOR_CAST;
       }
     } catch {
-      // Probe failed — fall back to '::vector' default. Cache so we
-      // don't re-probe on every insert.
-      this._factsEmbeddingCastSuffix = '::vector';
+      // Probe failed. Cache the no-explicit-cast default so we don't re-probe
+      // on every insert.
+      this._factsEmbeddingCastSuffix = PG_VECTOR_CAST;
     }
     return this._factsEmbeddingCastSuffix;
   }
@@ -3685,9 +3681,9 @@ export class PostgresEngine implements BrainEngine {
     if (rows.length === 0) return { inserted: 0, ids: [] };
 
     const sql = this.sql;
-    // v0.41.15.0 (T6, codex #20): resolve the embedding-cast suffix
-    // ONCE per process so the cast matches the actual column type
-    // (halfvec vs vector). The probe is cached after first call.
+    // v0.41.15.0 (T6, codex #20): resolve the embedding-cast suffix ONCE per
+    // process. Current Supabase-safe behavior uses no explicit pgvector type
+    // name; the target column infers the vector input.
     const castSuffix = await this.resolveFactsEmbeddingCast();
     // Single transaction so the v51 partial UNIQUE index can roll back
     // the whole batch on constraint violation. Per-row INSERTs (not
@@ -3870,7 +3866,7 @@ export class PostgresEngine implements BrainEngine {
           AND entity_slug = ${entitySlug}
           AND expired_at IS NULL
           AND embedding IS NOT NULL
-        ORDER BY embedding <=> ${sql.unsafe(`'${lit}'::vector`)}
+        ORDER BY embedding <=> ${sql.unsafe(`'${lit}'${PG_VECTOR_CAST}`)}
         LIMIT ${k}
       `;
       return rows.map(rowToFactPg);
@@ -4296,7 +4292,7 @@ export class PostgresEngine implements BrainEngine {
     const rows = await sql`
       SELECT t.id AS take_id, t.page_id, p.slug AS page_slug, t.row_num,
              t.claim, t.kind, t.holder, t.weight,
-             (1 - (t.embedding <=> ${vec}::vector))::real AS score
+             (1 - (t.embedding <=> ${vec}))::real AS score
       FROM takes t
       JOIN pages p ON p.id = t.page_id
       WHERE t.active
@@ -4305,7 +4301,7 @@ export class PostgresEngine implements BrainEngine {
           ${opts.takesHoldersAllowList ?? null}::text[] IS NULL
           OR t.holder = ANY(${opts.takesHoldersAllowList ?? null}::text[])
         )
-      ORDER BY t.embedding <=> ${vec}::vector
+      ORDER BY t.embedding <=> ${vec}
       LIMIT ${limit}
     `;
     return rows as unknown as TakeHit[];
@@ -5711,6 +5707,18 @@ function rowToFactPg(row: FactRowSqlShape): FactRow {
 function toPgVectorLiteral(v: Float32Array | number[]): string {
   if (v instanceof Float32Array) return '[' + Array.from(v).join(',') + ']';
   return '[' + v.join(',') + ']';
+}
+
+// Supabase often installs pgvector into the private `extensions` schema while
+// restricted app roles lack direct USAGE on that schema. Avoid naming the type
+// in Postgres SQL and let typed columns/operators infer the vector input cast.
+const PG_VECTOR_CAST = '' as const;
+const PG_HALFVEC_CAST = '' as const;
+
+function pgvectorCastSql(castSql: string): string {
+  return castSql
+    .replace(/::halfvec(?:\(\d+\))?/g, PG_HALFVEC_CAST)
+    .replace(/::vector(?:\(\d+\))?/g, PG_VECTOR_CAST);
 }
 
 function pgRowToCodeEdge(row: Record<string, unknown>): import('./types.ts').CodeEdgeResult {

--- a/test/doctor-subagent-capability.test.ts
+++ b/test/doctor-subagent-capability.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { checkSubagentCapability } from '../src/commands/doctor.ts';
+import { withEnv } from './helpers/with-env.ts';
+
+const tmpRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tmpRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('doctor subagent_capability', () => {
+  test('agent.use_gateway_loop=true suppresses non-Anthropic chat_model key warning', async () => {
+    const home = join(tmpdir(), `doctor-subagent-capability-${process.pid}-${Date.now()}`);
+    tmpRoots.push(home);
+    mkdirSync(join(home, '.gbrain'), { recursive: true });
+    writeFileSync(
+      join(home, '.gbrain', 'config.json'),
+      JSON.stringify({ engine: 'pglite', chat_model: 'openai:gpt-5.2' }),
+      'utf8',
+    );
+
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+    try {
+      await engine.setConfig('agent.use_gateway_loop', 'true');
+      await withEnv({
+        GBRAIN_HOME: home,
+        ANTHROPIC_API_KEY: undefined,
+        GBRAIN_CHAT_MODEL: undefined,
+        GBRAIN_DATABASE_URL: undefined,
+        DATABASE_URL: undefined,
+      }, async () => {
+        const check = await checkSubagentCapability(engine);
+        expect(check.status).toBe('ok');
+        expect(check.message).toContain('agent.use_gateway_loop=true');
+      });
+    } finally {
+      await engine.disconnect();
+    }
+  });
+});

--- a/test/doctor-v0_37_7_checks.test.ts
+++ b/test/doctor-v0_37_7_checks.test.ts
@@ -142,4 +142,21 @@ describe('checkAutopilotLockScope (#1226)', () => {
     rmSync(home, { recursive: true, force: true });
     rmSync(gbrainHome, { recursive: true, force: true });
   });
+
+  test('running lock outside GBRAIN_HOME → ok with owner PID', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'doctor-lock-home-'));
+    const gbrainHome = mkdtempSync(join(tmpdir(), 'doctor-lock-gbrain-'));
+    mkdirSync(join(home, '.gbrain'), { recursive: true });
+    writeFileSync(join(home, '.gbrain', 'autopilot.lock'), String(process.pid));
+
+    await withEnv({ HOME: home, GBRAIN_HOME: gbrainHome }, async () => {
+      const r = checkAutopilotLockScope();
+      expect(r.status).toBe('ok');
+      expect(r.message).toMatch(/running process/);
+      expect(r.message).toContain(String(process.pid));
+    });
+
+    rmSync(home, { recursive: true, force: true });
+    rmSync(gbrainHome, { recursive: true, force: true });
+  });
 });

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -54,6 +54,24 @@ describe('doctor command', () => {
     expect(runDoctor.length).toBeLessThanOrEqual(3);
   });
 
+  test('parsePgVectorFormattedType accepts schema-qualified pgvector types', async () => {
+    const { parsePgVectorFormattedType } = await import('../src/commands/doctor.ts');
+
+    expect(parsePgVectorFormattedType('vector(1536)')).toEqual({
+      type: 'vector',
+      dimensions: 1536,
+    });
+    expect(parsePgVectorFormattedType('extensions.vector(1024)')).toEqual({
+      type: 'vector',
+      dimensions: 1024,
+    });
+    expect(parsePgVectorFormattedType('extensions.halfvec(2560)')).toEqual({
+      type: 'halfvec',
+      dimensions: 2560,
+    });
+    expect(parsePgVectorFormattedType('text')).toBeNull();
+  });
+
   // Bug 7 — --fast should differentiate "no config anywhere" from "user
   // chose --fast with GBRAIN_DATABASE_URL / config-file URL present".
   test('getDbUrlSource reflects GBRAIN_DATABASE_URL env var', async () => {

--- a/test/postgres-engine.test.ts
+++ b/test/postgres-engine.test.ts
@@ -92,6 +92,24 @@ describe('postgres-engine / search path timeout isolation', () => {
     expect(keyword).not.toMatch(/SET\s+statement_timeout\s*=\s*['"]?0/);
     expect(vector).not.toMatch(/SET\s+statement_timeout\s*=\s*['"]?0/);
   });
+
+  test('pgvector write/search paths do not name bare vector casts', () => {
+    const upsertChunks = stripComments(extractMethod(SRC, '_upsertChunksOnce'));
+    const insertFact = stripComments(extractMethod(SRC, 'insertFact'));
+    const insertFacts = stripComments(extractMethod(SRC, 'insertFacts'));
+    const findCandidateDuplicates = stripComments(extractMethod(SRC, 'findCandidateDuplicates'));
+    const searchTakesVector = stripComments(extractMethod(SRC, 'searchTakesVector'));
+
+    for (const fn of [
+      upsertChunks,
+      insertFact,
+      insertFacts,
+      findCandidateDuplicates,
+      searchTakesVector,
+    ]) {
+      expect(fn).not.toMatch(/::(?:halfvec|vector)\b/);
+    }
+  });
 });
 
 function stripComments(s: string): string {
@@ -105,7 +123,7 @@ function stripComments(s: string): string {
 // brace. Good enough for the small number of methods in this file.
 function extractMethod(source: string, name: string): string {
   // Find "async <name>(" at method-definition indentation (2 spaces).
-  const openRe = new RegExp(`^\\s+async\\s+${name}\\s*\\(`, 'm');
+  const openRe = new RegExp(`^\\s+(?:private\\s+)?async\\s+${name}\\s*\\(`, 'm');
   const match = openRe.exec(source);
   if (!match) {
     throw new Error(`method ${name} not found in postgres-engine.ts`);


### PR DESCRIPTION
## Summary

- avoid explicit pgvector casts in Supabase Postgres paths where restricted roles cannot use the private extensions schema
- teach doctor to parse schema-qualified pgvector types and respect agent.use_gateway_loop
- treat an external autopilot lock as healthy when its owner PID is still running
- add targeted regression tests for the doctor and Postgres-engine paths

## Validation

- bun test test/doctor-v0_37_7_checks.test.ts test/doctor.test.ts test/doctor-subagent-capability.test.ts test/postgres-engine.test.ts
- bun run typecheck