### PR TITLE
test(ai): pin gateway tool schema conversion

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2532,6 +2532,22 @@ async function classifyGatewayGuardrail(input: {
   }
 }
 
+export function toAISDKTools(tools: ChatToolDef[] | undefined): Record<string, any> | undefined {
+  if (!tools || tools.length === 0) return undefined;
+  return tools.reduce((acc, t) => {
+    acc[t.name] = {
+      description: t.description,
+      // AI SDK v6 requires a Schema (carrying the schema symbol), not a plain
+      // `{jsonSchema}` object — the bare object makes asSchema() treat it as a
+      // thunk and call schema(), throwing "schema is not a function". Wrap the
+      // raw JSON Schema with the SDK's jsonSchema() helper so tool calls work
+      // through the real toolLoop (skillopt rollouts + subagent jobs).
+      inputSchema: jsonSchema(t.inputSchema as any),
+    };
+    return acc;
+  }, {} as Record<string, any>);
+}
+
 export async function chat(opts: ChatOpts): Promise<ChatResult> {
   const tracker = __budgetStore.getStore() ?? null;
   const modelStrEarly = opts.model ?? getChatModel();
@@ -2619,21 +2635,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
   const supportsCache = recipe.touchpoints.chat?.supports_prompt_cache === true;
   const useCache = !!opts.cacheSystem && supportsCache;
 
-  // Build messages. Anthropic prompt-cache markers ride on system + last tool
-  // via providerOptions; the AI SDK accepts the system as a string for
-  // generateText, so cache markers go through providerOptions.anthropic.
-  const tools = (opts.tools ?? []).reduce((acc, t) => {
-    acc[t.name] = {
-      description: t.description,
-      // AI SDK v6 requires a Schema (carrying the schema symbol), not a plain
-      // `{jsonSchema}` object — the bare object makes asSchema() treat it as a
-      // thunk and call schema(), throwing "schema is not a function". Wrap the
-      // raw JSON Schema with the SDK's jsonSchema() helper so tool calls work
-      // through the real toolLoop (skillopt rollouts + subagent jobs).
-      inputSchema: jsonSchema(t.inputSchema as any),
-    };
-    return acc;
-  }, {} as Record<string, any>);
+  const tools = toAISDKTools(opts.tools);
 
   const providerOptions: Record<string, any> = {};
   if (useCache) {

--- a/test/ai/gateway-tools-schema.test.ts
+++ b/test/ai/gateway-tools-schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { generateText, jsonSchema } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
-import { toModelMessages, type ChatMessage } from '../../src/core/ai/gateway.ts';
+import { toAISDKTools, toModelMessages, type ChatMessage } from '../../src/core/ai/gateway.ts';
 
 // v0.42 AI SDK v6 fix — the regression guard that the original bug evaded.
 // Every gateway/toolLoop test stubs the chat transport, which short-circuits
@@ -36,13 +36,13 @@ const internalMessages: ChatMessage[] = [
 describe('gateway tool schema + message shape (real AI SDK v6)', () => {
   it('jsonSchema()-wrapped tools + adapted messages pass generateText without throwing', async () => {
     const model = mockModel();
-    // Built exactly as gateway.chat() builds it (the primary fix).
-    const tools = {
-      search: {
+    const tools = toAISDKTools([
+      {
+        name: 'search',
         description: 'search the brain',
-        inputSchema: jsonSchema({ type: 'object', properties: { q: { type: 'string' } } } as any),
+        inputSchema: { type: 'object', properties: { q: { type: 'string' } } },
       },
-    };
+    ]);
 
     const result = await generateText({
       model: model as any,


### PR DESCRIPTION
## Summary
- Extract gateway tool conversion into `toAISDKTools()` so `chat()` and tests exercise the same schema builder
- Keep AI SDK v6 tool schemas wrapped with `jsonSchema()` instead of the legacy bare `{ jsonSchema }` object that triggers `schema is not a function`
- Strengthen the real `generateText()` regression test for the gateway tool loop path

Closes #1487

## Test Plan
- `bun test test/ai/gateway-tools-schema.test.ts`
- `bun test test/ai/gateway-tools-schema.test.ts test/ai/gateway-chat.test.ts test/ai/gateway-tool-loop.test.ts`
- `bun run verify`
