### PR TITLE
fix(config): ignore DATABASE_URL auto-loaded from cwd .env (#427)

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,7 +6,7 @@ import { homedir } from 'os';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-import { saveConfig, loadConfig, loadConfigFileOnly, toEngineConfig, gbrainPath, configPath, isThinClient, type GBrainConfig } from '../core/config.ts';
+import { saveConfig, loadConfig, loadConfigFileOnly, toEngineConfig, gbrainPath, configPath, isThinClient, effectiveEnvDatabaseUrl, type GBrainConfig } from '../core/config.ts';
 import { createEngine } from '../core/engine-factory.ts';
 import { discoverOAuth, mintClientCredentialsToken, smokeTestMcp } from '../core/remote-mcp-probe.ts';
 import { runInitEmbedCheck } from '../core/init-embed-check.ts';
@@ -133,7 +133,11 @@ export async function runInit(args: string[]) {
   if (manualUrl) {
     databaseUrl = manualUrl;
   } else if (isNonInteractive) {
-    const envUrl = process.env.GBRAIN_DATABASE_URL || process.env.DATABASE_URL;
+    // effectiveEnvDatabaseUrl applies the #427 guard: a DATABASE_URL that Bun
+    // auto-loaded from a .env in cwd must not seed a brain config — that is
+    // the "init inside a web-app checkout writes the app's DB into
+    // ~/.gbrain/config.json" failure mode.
+    const envUrl = effectiveEnvDatabaseUrl();
     if (envUrl) {
       databaseUrl = envUrl;
     } else {

--- a/src/commands/migrate-engine.ts
+++ b/src/commands/migrate-engine.ts
@@ -8,7 +8,7 @@
  */
 
 import { createEngine } from '../core/engine-factory.ts';
-import { loadConfig, saveConfig, toEngineConfig, gbrainPath, type GBrainConfig } from '../core/config.ts';
+import { loadConfig, saveConfig, toEngineConfig, gbrainPath, effectiveEnvDatabaseUrl, type GBrainConfig } from '../core/config.ts';
 import type { BrainEngine } from '../core/engine.ts';
 import type { EngineConfig } from '../core/types.ts';
 import { writeFileSync, readFileSync, existsSync, unlinkSync } from 'fs';
@@ -91,7 +91,8 @@ export async function runMigrateEngine(sourceEngine: BrainEngine, args: string[]
   // Build target config
   const targetConfig: EngineConfig = { engine: opts.targetEngine };
   if (opts.targetEngine === 'postgres') {
-    targetConfig.database_url = opts.targetUrl || process.env.GBRAIN_DATABASE_URL || process.env.DATABASE_URL;
+    // #427 guard: don't let a cwd-.env DATABASE_URL become a migration target.
+    targetConfig.database_url = opts.targetUrl || effectiveEnvDatabaseUrl();
     if (!targetConfig.database_url) {
       console.error('Target is Supabase but no connection string provided. Use: --url <connection_string>');
       process.exit(1);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -375,6 +375,96 @@ export function loadConfigFileOnly(): GBrainConfig | null {
   }
 }
 
+/**
+ * #427 guard — DATABASE_URL hijack via Bun's cwd .env auto-load.
+ *
+ * Bun merges `.env` files from the process cwd into process.env before any
+ * user code runs. For a globally-installed tool that is a footgun: running
+ * gbrain inside any checkout whose `.env` defines DATABASE_URL (Next.js,
+ * Hono, Supabase, most web apps) silently retargets the brain at that app's
+ * database. Reads hit the wrong DB; `apply-migrations` can write gbrain's
+ * schema — including its DDL event trigger — into a production app database
+ * (see the v0.42.8 report on #427).
+ *
+ * Bun gives no way to ask which vars came from a .env file (the merge
+ * happens before module load), so we re-parse the .env files Bun auto-loads
+ * from cwd and treat DATABASE_URL as "not operator-provided" when its value
+ * matches one of them. Deliberate overrides still work two ways:
+ *   - GBRAIN_DATABASE_URL: namespaced to this tool, never auto-ignored;
+ *   - exporting DATABASE_URL in the shell: exported vars win over .env in
+ *     Bun, and a deliberate export that happens to EQUAL the cwd .env value
+ *     would have selected the same database anyway — ignoring it changes
+ *     the outcome only by honoring the brain config, which is the safe
+ *     reading of ambiguous intent.
+ *
+ * The file list is a superset of Bun's auto-load set across NODE_ENV values
+ * so the guard doesn't depend on replicating Bun's exact selection logic.
+ */
+const CWD_DOTENV_FILES = ['.env', '.env.local', '.env.development', '.env.production', '.env.test'];
+
+/**
+ * All values assigned to `key` across the .env files in `dir`. Collecting
+ * every assignment (rather than emulating override order) keeps the guard
+ * independent of dotenv precedence rules — a match against ANY assignment
+ * means the value is file-origin. Exported for tests.
+ */
+export function dotenvValuesForKey(key: string, dir: string = process.cwd()): Set<string> {
+  const values = new Set<string>();
+  const assignment = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/;
+  for (const name of CWD_DOTENV_FILES) {
+    let content: string;
+    try {
+      content = readFileSync(join(dir, name), 'utf-8');
+    } catch {
+      continue; // missing/unreadable file — nothing to guard against
+    }
+    for (const rawLine of content.split('\n')) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith('#')) continue;
+      const m = line.match(assignment);
+      if (!m || m[1] !== key) continue;
+      let v = m[2].trim();
+      if ((v.startsWith('"') && v.endsWith('"') && v.length >= 2) ||
+          (v.startsWith("'") && v.endsWith("'") && v.length >= 2)) {
+        v = v.slice(1, -1);
+      } else {
+        const hash = v.indexOf(' #');
+        if (hash !== -1) v = v.slice(0, hash).trim();
+      }
+      if (v) values.add(v);
+    }
+  }
+  return values;
+}
+
+let warnedCwdEnvDbUrlIgnored = false;
+
+/**
+ * The env-provided DB URL gbrain should honor, with the #427 guard applied:
+ * a DATABASE_URL whose value matches an assignment in a cwd .env file is
+ * treated as belonging to the project in cwd, not to gbrain, and ignored
+ * with a one-time stderr notice. GBRAIN_DATABASE_URL is always honored.
+ * `dir` is injectable for tests; callers use the default.
+ */
+export function effectiveEnvDatabaseUrl(dir: string = process.cwd()): string | undefined {
+  if (process.env.GBRAIN_DATABASE_URL) return process.env.GBRAIN_DATABASE_URL;
+  const url = process.env.DATABASE_URL;
+  if (!url) return undefined;
+  if (dotenvValuesForKey('DATABASE_URL', dir).has(url)) {
+    if (!warnedCwdEnvDbUrlIgnored) {
+      warnedCwdEnvDbUrlIgnored = true;
+      console.warn(
+        '[config] Ignoring DATABASE_URL auto-loaded by Bun from a .env file in the current ' +
+        'directory — it belongs to the project here, not to gbrain. Using the engine from ' +
+        '~/.gbrain/config.json instead. To point gbrain at that database deliberately, set ' +
+        'GBRAIN_DATABASE_URL.',
+      );
+    }
+    return undefined;
+  }
+  return url;
+}
+
 export function loadConfig(): GBrainConfig | null {
   let fileConfig: GBrainConfig | null = null;
   try {
@@ -383,8 +473,8 @@ export function loadConfig(): GBrainConfig | null {
     fileConfig = migrateLegacyEmbeddingConfig(parsed) as unknown as GBrainConfig;
   } catch { /* no config file */ }
 
-  // Try env vars
-  const dbUrl = process.env.GBRAIN_DATABASE_URL || process.env.DATABASE_URL;
+  // Try env vars (cwd-.env-origin DATABASE_URL excluded — see #427 guard above)
+  const dbUrl = effectiveEnvDatabaseUrl();
 
   if (!fileConfig && !dbUrl) return null;
 
@@ -916,7 +1006,12 @@ export function gbrainPath(...segments: string[]): string {
  */
 export function getDbUrlSource(): DbUrlSource {
   if (process.env.GBRAIN_DATABASE_URL) return 'env:GBRAIN_DATABASE_URL';
-  if (process.env.DATABASE_URL) return 'env:DATABASE_URL';
+  // Same #427 guard as loadConfig: a DATABASE_URL that Bun auto-loaded from
+  // a cwd .env file is not an operator-provided source. Keeping this in
+  // lockstep with loadConfig matters because doctor uses this to tell the
+  // user where the URL came from — reporting env:DATABASE_URL while
+  // loadConfig ignores it would send them debugging the wrong layer.
+  if (effectiveEnvDatabaseUrl()) return 'env:DATABASE_URL';
   if (!existsSync(configPath())) return null;
   try {
     const raw = readFileSync(configPath(), 'utf-8');

--- a/test/config-env-hijack.test.ts
+++ b/test/config-env-hijack.test.ts
@@ -1,0 +1,144 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, test } from 'bun:test';
+import { dotenvValuesForKey, effectiveEnvDatabaseUrl } from '../src/core/config.ts';
+import { withEnv } from './helpers/with-env.ts';
+
+// #427 — Bun auto-loads `.env` from the process cwd, so running gbrain inside
+// any web-app checkout whose `.env` defines DATABASE_URL silently retargets
+// the brain at that app's database. These tests pin the guard:
+// effectiveEnvDatabaseUrl() must treat a DATABASE_URL whose value matches a
+// cwd .env assignment as file-origin (ignored), while still honoring
+// GBRAIN_DATABASE_URL and genuinely exported DATABASE_URLs.
+//
+// The dir is injected instead of process.chdir'd so these tests stay safe in
+// the parallel shard runner (cwd is process-global, same reason with-env.ts
+// exists for process.env).
+
+function tmpProject(envFiles: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gbrain-env-hijack-'));
+  for (const [name, content] of Object.entries(envFiles)) {
+    writeFileSync(join(dir, name), content);
+  }
+  return dir;
+}
+
+describe('dotenvValuesForKey', () => {
+  test('collects assignments across all auto-loaded .env variants', () => {
+    const dir = tmpProject({
+      '.env': 'DATABASE_URL=postgres://app:pw@prod.example.test:5432/app\n',
+      '.env.local': "DATABASE_URL='postgres://app:pw@local.example.test:5432/app'\n",
+    });
+    try {
+      const values = dotenvValuesForKey('DATABASE_URL', dir);
+      expect(values.has('postgres://app:pw@prod.example.test:5432/app')).toBe(true);
+      expect(values.has('postgres://app:pw@local.example.test:5432/app')).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('handles export prefix, double quotes, comments, and unrelated keys', () => {
+    const dir = tmpProject({
+      '.env': [
+        '# comment line',
+        'export DATABASE_URL="postgres://quoted.example.test/db"',
+        'OTHER_KEY=not-a-db-url',
+        'EMPTY=',
+        '',
+      ].join('\n'),
+    });
+    try {
+      const values = dotenvValuesForKey('DATABASE_URL', dir);
+      expect(values.has('postgres://quoted.example.test/db')).toBe(true);
+      expect(values.size).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('returns empty set when no .env files exist', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-env-hijack-none-'));
+    try {
+      expect(dotenvValuesForKey('DATABASE_URL', dir).size).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('effectiveEnvDatabaseUrl (#427 guard)', () => {
+  const HIJACK_URL = 'postgres://app:pw@victim-prod.example.test:5432/app';
+  const OPERATOR_URL = 'postgres://operator@deliberate.example.test:5432/brain';
+
+  test('ignores DATABASE_URL whose value matches a cwd .env assignment', async () => {
+    const dir = tmpProject({ '.env': `DATABASE_URL=${HIJACK_URL}\n` });
+    try {
+      await withEnv(
+        { GBRAIN_DATABASE_URL: undefined, DATABASE_URL: HIJACK_URL },
+        () => {
+          expect(effectiveEnvDatabaseUrl(dir)).toBeUndefined();
+        },
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('honors an exported DATABASE_URL that differs from the cwd .env', async () => {
+    const dir = tmpProject({ '.env': `DATABASE_URL=${HIJACK_URL}\n` });
+    try {
+      await withEnv(
+        { GBRAIN_DATABASE_URL: undefined, DATABASE_URL: OPERATOR_URL },
+        () => {
+          expect(effectiveEnvDatabaseUrl(dir)).toBe(OPERATOR_URL);
+        },
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('GBRAIN_DATABASE_URL is never ignored, even when it matches the cwd .env', async () => {
+    const dir = tmpProject({ '.env': `GBRAIN_DATABASE_URL=${OPERATOR_URL}\nDATABASE_URL=${HIJACK_URL}\n` });
+    try {
+      await withEnv(
+        { GBRAIN_DATABASE_URL: OPERATOR_URL, DATABASE_URL: HIJACK_URL },
+        () => {
+          expect(effectiveEnvDatabaseUrl(dir)).toBe(OPERATOR_URL);
+        },
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('honors DATABASE_URL when no .env files exist in cwd', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-env-hijack-clean-'));
+    try {
+      await withEnv(
+        { GBRAIN_DATABASE_URL: undefined, DATABASE_URL: OPERATOR_URL },
+        () => {
+          expect(effectiveEnvDatabaseUrl(dir)).toBe(OPERATOR_URL);
+        },
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('returns undefined when neither env var is set', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-env-hijack-unset-'));
+    try {
+      await withEnv(
+        { GBRAIN_DATABASE_URL: undefined, DATABASE_URL: undefined },
+        () => {
+          expect(effectiveEnvDatabaseUrl(dir)).toBeUndefined();
+        },
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #427.

## Problem

Bun merges `.env` files from the process cwd into `process.env` before any user code runs, and `loadConfig()` prefers env `DATABASE_URL` over `~/.gbrain/config.json`. So any gbrain invocation from inside a checkout whose `.env` defines `DATABASE_URL` — Next.js, Hono, Supabase, most web apps — silently retargets the brain at that app's database:

- Reads hit the wrong DB (`relation "pages" does not exist`, misleading "check your config.json" errors — the original #427 report).
- Writes are worse: `gbrain apply-migrations --yes` run from such a directory attempts gbrain's schema DDL against the app's database. One #427 commenter had gbrain's schema **written into their production Supabase**, including the DDL event trigger. I hit the same failure mode against a production Railway Postgres — saved only because that instance lacks the `pgvector` extension.

The operator never opted into any of this: the `.env` belongs to the project in cwd, not to gbrain.

## Fix

Bun gives no way to ask which env vars came from a `.env` file (the merge happens before module load), so `effectiveEnvDatabaseUrl()` re-parses the `.env` files Bun auto-loads from cwd and treats a `DATABASE_URL` whose value matches one of them as file-origin: ignored, with a one-time stderr notice telling the operator what happened and how to override deliberately.

Resulting precedence:

| Source | Honored? |
|---|---|
| `GBRAIN_DATABASE_URL` (any origin) | always — namespaced to gbrain, never auto-ignored |
| `DATABASE_URL` exported in the shell / CI | yes — its value won't match a cwd `.env` assignment (and if it's identical, the same database was meant by the file anyway, so honoring config.json is the safe reading) |
| `DATABASE_URL` auto-loaded by Bun from cwd `.env` | **ignored + warned** |
| `~/.gbrain/config.json` | as before |

Applied at all four read sites so behavior stays consistent: `loadConfig()`, `getDbUrlSource()` (doctor must not report `env:DATABASE_URL` while loadConfig ignores it), `init --non-interactive` (prevents seeding a brain config with the app's DB), and `migrate --to` (prevents the app DB becoming a migration target).

## Why not `--no-env-file` in the shebang?

`#!/usr/bin/env -S bun --no-env-file` fixes this on my machine, but it's wrong as the upstream fix: Windows bin shims never read shebangs (the #427 reporter is on Windows), `env -S` is unavailable on busybox/Alpine, and it would also stop `.env` from supplying other keys (e.g. `OPENAI_API_KEY`) that some workflows rely on — #464 explicitly wants cwd-`.env` auto-loading for autopilot. The in-code guard is cross-platform and narrowly scoped to the one variable that causes cross-database damage.

## Testing

- `test/config-env-hijack.test.ts` — 8 cases pinning the guard: parser (quotes/`export`/comments/multi-file), hijack ignored, differing exported URL honored, `GBRAIN_DATABASE_URL` never ignored, no-`.env` and unset-env passthrough. Uses `withEnv` + injectable dir (no `process.chdir`, parallel-shard safe).
- Existing `config-env`, `loadConfig-merge`, `config` suites: 56 pass, 0 fail. `tsc --noEmit` clean.
- End-to-end: from a repo whose `.env` carries a production `DATABASE_URL`, `bun src/cli.ts doctor --json --fast` now reports `URL present from config-file-path` (previously `env:DATABASE_URL`) and prints the notice once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)