### PR TITLE
fix: persist gateway tool-result turns

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2813,6 +2813,8 @@ export interface ToolLoopOpts {
   ) => Promise<{ gbrainToolUseId: string }>;
   onToolCallComplete?: (gbrainToolUseId: string, output: unknown) => Promise<void>;
   onToolCallFailed?: (gbrainToolUseId: string, error: string) => Promise<void>;
+  /** Persist the synthesized user turn containing tool-result blocks before the next chat turn. */
+  onToolResults?: (messageIdx: number, blocks: ChatBlock[]) => Promise<void>;
 
   /** Optional per-call heartbeat for observability. */
   onHeartbeat?: (event: string, data: Record<string, unknown>) => void;
@@ -3036,9 +3038,11 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
 
     if (stopReason === 'aborted') break;
 
-    // Feed all tool results back as a single user message.
+    // Feed all tool results back as a single user message. Persist it before the
+    // next chat turn so crash/retry reconstruction preserves the required
+    // assistant tool-call → user tool-result pairing.
     const userMessageIdx = messageIdx++;
-    void userMessageIdx;
+    await opts.onToolResults?.(userMessageIdx, toolResultBlocks);
     messages.push({ role: 'user', content: toolResultBlocks });
 
     turnIdx++;

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -784,6 +784,11 @@ async function runSubagentViaGateway(args: GatewayRunArgs): Promise<SubagentResu
     role: m.role as 'user' | 'assistant',
     content: adaptContentBlocksToChatBlocks(m.content_blocks),
   }));
+  // If a previous worker crashed after settling tool executions but before
+  // persisting the synthesized user tool-result turn, repair the transcript
+  // before the next provider call. Providers like DeepSeek reject assistant
+  // tool-call history without the following tool-result message.
+  await repairDanglingToolResultTurn(engine, ctx.id, priorMessages, priorChatMessages, priorTools);
 
   // Initial seed message if no prior state.
   const initialMessages: ChatMessage[] = priorChatMessages.length === 0
@@ -904,6 +909,18 @@ async function runSubagentViaGateway(args: GatewayRunArgs): Promise<SubagentResu
         [errorMsg, gbrainToolUseId],
       );
     },
+    onToolResults: async (messageIdx, blocks) => {
+      await persistMessage(engine, ctx.id, {
+        message_idx: messageIdx,
+        role: 'user',
+        content_blocks: blocks as unknown as ContentBlock[],
+        tokens_in: null,
+        tokens_out: null,
+        tokens_cache_read: null,
+        tokens_cache_create: null,
+        model: null,
+      });
+    },
     onHeartbeat: heartbeat,
   });
 
@@ -1016,9 +1033,79 @@ function adaptContentBlocksToChatBlocks(blocks: unknown): ChatBlock[] | string {
 
 interface PriorToolV2Row {
   stableKey: string;
+  messageIdx: number;
+  providerToolUseId: string;
+  toolName: string;
+  ordinal: number | null;
   status: 'pending' | 'complete' | 'failed';
   output: unknown;
   error: string | null;
+}
+
+async function repairDanglingToolResultTurn(
+  engine: BrainEngine,
+  jobId: number,
+  priorMessages: PersistedMessage[],
+  priorChatMessages: ChatMessage[],
+  priorTools: PriorToolV2Row[],
+): Promise<void> {
+  const lastPersisted = priorMessages.at(-1);
+  const lastChat = priorChatMessages.at(-1);
+  if (!lastPersisted || lastPersisted.role !== 'assistant' || !lastChat || lastChat.role !== 'assistant') return;
+  if (!Array.isArray(lastChat.content)) return;
+
+  const toolCalls = lastChat.content.filter(
+    (b): b is { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown } =>
+      b.type === 'tool-call',
+  );
+  if (toolCalls.length === 0) return;
+
+  const toolResultBlocks: ChatBlock[] = [];
+  for (let callIdx = 0; callIdx < toolCalls.length; callIdx++) {
+    const call = toolCalls[callIdx];
+    const priorTool = priorTools.find((tool) => (
+      tool.messageIdx === lastPersisted.message_idx
+      && (
+        (tool.ordinal !== null && tool.ordinal === callIdx)
+        || (tool.providerToolUseId === call.toolCallId && tool.toolName === call.toolName)
+      )
+    ));
+    if (!priorTool || priorTool.status === 'pending') {
+      throw new Error(
+        `cannot repair replay transcript: missing settled result for tool "${call.toolName}" at message_idx=${lastPersisted.message_idx} ordinal=${callIdx}`,
+      );
+    }
+    toolResultBlocks.push({
+      type: 'tool-result',
+      toolCallId: call.toolCallId,
+      toolName: call.toolName,
+      output: priorTool.status === 'failed' ? (priorTool.error ?? 'tool failed') : priorTool.output,
+      ...(priorTool.status === 'failed' ? { isError: true } : {}),
+    });
+  }
+
+  const nextMessageIdx = Math.max(...priorMessages.map((m) => m.message_idx)) + 1;
+  await persistMessage(engine, jobId, {
+    message_idx: nextMessageIdx,
+    role: 'user',
+    content_blocks: toolResultBlocks as unknown as ContentBlock[],
+    tokens_in: null,
+    tokens_out: null,
+    tokens_cache_read: null,
+    tokens_cache_create: null,
+    model: null,
+  });
+  priorMessages.push({
+    message_idx: nextMessageIdx,
+    role: 'user',
+    content_blocks: toolResultBlocks as unknown as ContentBlock[],
+    tokens_in: null,
+    tokens_out: null,
+    tokens_cache_read: null,
+    tokens_cache_create: null,
+    model: null,
+  });
+  priorChatMessages.push({ role: 'user', content: toolResultBlocks });
 }
 
 /**
@@ -1051,6 +1138,10 @@ async function loadPriorToolsV2(engine: BrainEngine, jobId: number): Promise<Pri
       : `legacy:${jobId}:${r.message_idx}:${r.tool_use_id}:${r.tool_name}`;
     return {
       stableKey,
+      messageIdx: r.message_idx as number,
+      providerToolUseId: r.tool_use_id as string,
+      toolName: r.tool_name as string,
+      ordinal: (r.ordinal as number | null) ?? null,
       status: r.status as 'pending' | 'complete' | 'failed',
       output: r.output,
       error: (r.error as string | null) ?? null,

--- a/test/ai/gateway-tool-loop.test.ts
+++ b/test/ai/gateway-tool-loop.test.ts
@@ -94,9 +94,9 @@ describe('gateway.toolLoop (v0.38 D11 — provider-agnostic loop control)', () =
     expect(result.totalUsage.output_tokens).toBe(9); // 4 + 5
   });
 
-  it('captures persistence callbacks in order: assistant → tool start → tool complete', async () => {
+  it('captures persistence callbacks in order: assistant → tool start → tool complete → tool results', async () => {
     let turn = 0;
-    __setChatTransportForTests(async () => {
+    __setChatTransportForTests(async (opts) => {
       turn++;
       if (turn === 1) {
         return {
@@ -110,6 +110,10 @@ describe('gateway.toolLoop (v0.38 D11 — provider-agnostic loop control)', () =
           providerId: 'anthropic',
         };
       }
+      expect(opts.messages.at(-1)).toEqual({
+        role: 'user',
+        content: [{ type: 'tool-result', toolCallId: 'tc1', toolName: 'echo', output: { msg: 'hi' } }],
+      });
       return {
         text: 'done',
         blocks: [{ type: 'text', text: 'done' }] as ChatBlock[],
@@ -139,15 +143,20 @@ describe('gateway.toolLoop (v0.38 D11 — provider-agnostic loop control)', () =
       onToolCallComplete: async (gbrainToolUseId, _output) => {
         events.push(`onToolCallComplete(${gbrainToolUseId})`);
       },
+      onToolResults: async (messageIdx, blocks) => {
+        events.push(`onToolResults(${messageIdx}, ${JSON.stringify(blocks)})`);
+      },
     });
 
     // Write-ordering invariant: assistant persisted BEFORE pending tool row;
-    // pending row persisted BEFORE execute; execute BEFORE complete.
+    // pending row persisted BEFORE execute; execute BEFORE complete; the
+    // synthesized user tool-result turn is persisted BEFORE the next chat call.
     expect(events[0]).toBe('onAssistantTurn(0)');
     expect(events[1]).toMatch(/onToolCallStart\(turn=0, ordinal=0, name=echo/);
     expect(events[2]).toMatch(/execute/);
     expect(events[3]).toMatch(/onToolCallComplete\(gb-0-0\)/);
-    expect(events[4]).toBe('onAssistantTurn(1)'); // final assistant turn
+    expect(events[4]).toMatch(/onToolResults\(1,/);
+    expect(events[5]).toBe('onAssistantTurn(1)'); // final assistant turn
   });
 
   it('replay short-circuits a complete prior tool execution', async () => {

--- a/test/e2e/subagent-crash-replay-multi-provider.test.ts
+++ b/test/e2e/subagent-crash-replay-multi-provider.test.ts
@@ -296,8 +296,14 @@ describe('SIGKILL crash-replay reconciliation across provider matrix (v0.38 LOAD
       // Stub the SECOND turn — replay should NOT call gateway.chat() for
       // turn 1 (the tool dispatch already happened pre-crash). It should
       // immediately re-feed the tool_result and ask the LLM for the final
-      // text answer.
-      __setChatTransportForTests(async () => provider.finalResponse);
+      // text answer. The stub validates the repaired provider-facing history.
+      __setChatTransportForTests(async (opts) => {
+        const last = opts.messages.at(-1);
+        expect(last?.role).toBe('user');
+        expect(JSON.stringify(last?.content)).toContain('tool-result');
+        expect(JSON.stringify(last?.content)).toContain('provider-tc-v2-crashed');
+        return provider.finalResponse;
+      });
 
       const executions: Array<{ name: string; input: unknown }> = [];
       const tools = makeStubTools(executions);

--- a/test/e2e/subagent-gateway-path.test.ts
+++ b/test/e2e/subagent-gateway-path.test.ts
@@ -253,6 +253,25 @@ describe('runSubagentViaGateway (v0.38 Slice 1 — full handler path through gat
     expect(String(toolRows[0].gbrain_tool_use_id)).toMatch(/^[0-9a-f-]{36}$/); // UUID v7
     expect(toolRows[0].tool_use_id).toBe('provider-tc-1'); // provider id preserved
 
+    // Verify synthesized tool-result turn is persisted between the assistant
+    // tool-call turn and the final assistant turn. This is the #1886 invariant:
+    // replay must not reconstruct an assistant tool call with no following result.
+    const messages = await engine.executeRaw<Record<string, unknown>>(
+      `SELECT message_idx, role, content_blocks
+         FROM subagent_messages
+        WHERE job_id = $1
+        ORDER BY message_idx`,
+      [jobId],
+    );
+    expect(messages.map((m) => [m.message_idx, m.role])).toEqual([
+      [0, 'user'],
+      [1, 'assistant'],
+      [2, 'user'],
+      [3, 'assistant'],
+    ]);
+    expect(JSON.stringify(messages[2].content_blocks)).toContain('tool-result');
+    expect(JSON.stringify(messages[2].content_blocks)).toContain('provider-tc-1');
+
     // Token accumulation across both turns.
     expect(result.tokens.in).toBe(45); // 20 + 25
     expect(result.tokens.out).toBe(12); // 8 + 4


### PR DESCRIPTION
## Summary

Fixes #1886.

This closes the gateway subagent crash/replay gap that can produce provider histories with an assistant tool-call message but no following user tool-result message. DeepSeek and other AI SDK-backed providers reject that shape with `Tool result is missing for tool call`.

Changes:
- persist synthesized `role: user` tool-result turns from `gateway.toolLoop()` before the next provider call
- wire the subagent gateway handler to write those tool-result turns into `subagent_messages`
- repair replay transcripts that already crashed after a tool execution settled but before the tool-result user turn was persisted
- pin the failure with provider-matrix replay coverage, including DeepSeek

## Notes on overlap

This is narrower than the adjacent replay-repair work in #1934 / #2062. It fixes the normal forward-write path and the specific settled-tool/missing-user-result replay state for #1886. It does not try to replace broader dangling replay reconstruction work.

## Verification

- `bun test test/e2e/subagent-crash-replay-multi-provider.test.ts --test-name-pattern 'v2 shape'`
  - confirmed RED before replay repair: provider-facing history ended in `assistant`
  - confirmed GREEN after repair across Anthropic, OpenAI, Google, OpenRouter, DeepSeek
- `bun test test/ai/gateway-tool-loop.test.ts test/e2e/subagent-gateway-path.test.ts test/e2e/subagent-crash-replay-multi-provider.test.ts`
  - 27 pass, 0 fail
- `bun run verify`
  - 30 checks green
- Codex blocking review on final diff
  - `CLEAN`
