### PR TITLE
fix(orphans): exclude generated corpus roots

### DIFF
--- a/src/commands/orphans.ts
+++ b/src/commands/orphans.ts
@@ -53,7 +53,15 @@ const DENY_PREFIXES = [
 ];
 
 /** First slug segments where no inbound links is expected */
-const FIRST_SEGMENT_EXCLUSIONS = new Set(['scratch', 'thoughts', 'catalog', 'entities']);
+const FIRST_SEGMENT_EXCLUSIONS = new Set([
+  'scratch',
+  'thoughts',
+  'catalog',
+  'entities',
+  'raw',
+  'atoms',
+  'skills',
+]);
 
 // --- Filter logic ---
 

--- a/test/orphans-pure-fn.test.ts
+++ b/test/orphans-pure-fn.test.ts
@@ -169,6 +169,7 @@ describe('shouldExclude — orphan filter regression (preserve curation)', () =>
 
   test('raw segment is excluded', () => {
     expect(shouldExclude('media/x/raw/post')).toBe(true);
+    expect(shouldExclude('raw/chats/claude-code/session')).toBe(true);
   });
 
   test('deny-prefixes are excluded', () => {
@@ -183,6 +184,8 @@ describe('shouldExclude — orphan filter regression (preserve curation)', () =>
     expect(shouldExclude('thoughts/today')).toBe(true);
     expect(shouldExclude('catalog/movies')).toBe(true);
     expect(shouldExclude('entities/anonymous')).toBe(true);
+    expect(shouldExclude('atoms/fact-123')).toBe(true);
+    expect(shouldExclude('skills/gbrain-operations')).toBe(true);
   });
 
   test('regular slugs are NOT excluded', () => {


### PR DESCRIPTION
## Summary
- Treat top-level `raw/`, `atoms/`, and `skills/` slugs as non-linkable roots for orphan reporting.
- Preserve the existing nested `/raw/` exclusion while covering top-level raw source trees.
- Add regression coverage for top-level raw, generated atom pages, and imported skill corpus pages.

## Why
`gbrain orphans` already excludes generated/pseudo locations where inbound links are not expected, including nested `/raw/` segments. In live multi-source brains, raw transcripts, generated atom pages, and imported skill corpus pages commonly live at top-level roots (`raw/`, `atoms/`, `skills/`). Counting those pages as linkable can dominate the orphan ratio and obscure actual curated wiki graph health.

## Verification
- `bun test test/orphans-pure-fn.test.ts`
- `bun run typecheck`
- `~/.agents/skills/autoreview/scripts/autoreview --mode auto`
