### PR TITLE
fix(rerank): classify missing auth before fallback

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1426,6 +1426,24 @@ export async function checkRerankerHealth(engine: BrainEngine): Promise<Check> {
       };
     }
 
+    // Historical #2059 rows were logged as `unknown` before missing reranker
+    // auth was classified at the gateway. Surface repeated unknowns instead of
+    // reporting "ok" while every rerank fails open.
+    const unknownFails = failures.filter((f) => f.reason === 'unknown');
+    if (unknownFails.length >= 3) {
+      const setupHint = unknownFails.some((f) => {
+        const summary = String(f.error_summary ?? '');
+        return summary.includes('ZEROENTROPY_API_KEY') || summary.toLowerCase().includes('api key');
+      })
+        ? ' Fix: verify ZEROENTROPY_API_KEY and run `gbrain models doctor`.'
+        : '';
+      return {
+        name: 'reranker_health',
+        status: 'warn',
+        message: `${unknownFails.length} unknown reranker failure(s) in last 7 days.${setupHint}`,
+      };
+    }
+
     return {
       name: 'reranker_health',
       status: 'ok',

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -3169,7 +3169,15 @@ export async function rerank(input: RerankInput): Promise<RerankResult[]> {
   // whose request/response shape differs from ZE/llama.cpp (e.g. Voyage with
   // `top_k` / `data[]`) needs separate adapter hooks in a follow-up plan.
   const url = `${compat.baseURL.replace(/\/$/, '')}${tp.path ?? '/models/rerank'}`;
-  const auth = applyResolveAuth(recipe, cfg, 'reranker');
+  let auth: { apiKey?: string; headers?: Record<string, string> };
+  try {
+    auth = applyResolveAuth(recipe, cfg, 'reranker');
+  } catch (err) {
+    if (err instanceof AIConfigError) {
+      throw new RerankError(err.message, 'auth');
+    }
+    throw err;
+  }
   // applyResolveAuth returns { apiKey } for Bearer-style auth (SDK's native
   // path) or { headers } for custom-header providers (Azure). v0.37.6.0:
   // recipes can ALSO declare default_headers (attribution etc.) which flow

--- a/test/ai/rerank.test.ts
+++ b/test/ai/rerank.test.ts
@@ -154,6 +154,28 @@ describe('gateway.rerank() — happy path', () => {
 describe('gateway.rerank() — error classification', () => {
   beforeEach(() => configureZE());
 
+  test('missing required reranker API key → RerankError(auth) before HTTP call', async () => {
+    configureGateway({
+      reranker_model: 'zeroentropyai:zerank-2',
+      env: {},
+    });
+    let called = false;
+    __setRerankTransportForTests(async () => {
+      called = true;
+      return mockResp({ results: [{ index: 0, relevance_score: 0.5 }] });
+    });
+
+    try {
+      await rerank({ query: 'q', documents: ['d'] });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(RerankError);
+      expect((err as RerankError).reason).toBe('auth');
+      expect((err as Error).message).toContain('ZEROENTROPY_API_KEY');
+      expect(called).toBe(false);
+    }
+  });
+
   test('401 → auth', async () => {
     __setRerankTransportForTests(async () => new Response('Unauthorized', { status: 401 }));
     try {

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1,4 +1,9 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { withEnv } from './helpers/with-env.ts';
+import { logRerankFailure } from '../src/core/rerank-audit.ts';
 
 describe('doctor command', () => {
   test('doctor module exports runDoctor', async () => {
@@ -42,6 +47,34 @@ describe('doctor command', () => {
     };
     expect(check.issues).toHaveLength(1);
     expect(check.issues![0].action).toContain('trigger');
+  });
+
+  test('reranker_health warns on repeated unknown rerank failures', async () => {
+    const { checkRerankerHealth } = await import('../src/commands/doctor.ts');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gbrain-rerank-doctor-'));
+    try {
+      await withEnv({ GBRAIN_AUDIT_DIR: tmpDir }, async () => {
+        for (let i = 0; i < 3; i++) {
+          logRerankFailure({
+            model: 'zeroentropyai:zerank-2',
+            reason: 'unknown',
+            query_hash: `unknown${i}`,
+            doc_count: 30,
+            error_summary: 'ZeroEntropy reranker requires ZEROENTROPY_API_KEY.',
+          });
+        }
+        const check = await checkRerankerHealth({
+          async getConfig(key: string): Promise<string | null> {
+            return key === 'search.reranker.enabled' ? 'true' : null;
+          },
+        } as any);
+        expect(check.status).toBe('warn');
+        expect(check.message).toContain('unknown');
+        expect(check.message).toContain('ZEROENTROPY_API_KEY');
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   test('runDoctor accepts null engine for filesystem-only mode', async () => {

--- a/test/search/rerank.test.ts
+++ b/test/search/rerank.test.ts
@@ -12,9 +12,14 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { applyReranker, type RerankerOpts } from '../../src/core/search/rerank.ts';
 import { RerankError, type RerankResult } from '../../src/core/ai/gateway.ts';
+import { readRecentRerankFailures } from '../../src/core/rerank-audit.ts';
 import type { SearchResult } from '../../src/core/types.ts';
+import { withEnv } from '../helpers/with-env.ts';
 
 function makeResult(slug: string, score: number, chunk: string): SearchResult {
   return {
@@ -158,6 +163,36 @@ describe('applyReranker — fail-open on every RerankError reason', () => {
     // Must not throw; must return input unchanged.
     const out = await applyReranker('q', results, opts);
     expect(out).toEqual(results);
+  });
+
+  test('missing gateway reranker API key fail-opens and audits auth', async () => {
+    const { configureGateway } = await import('../../src/core/ai/gateway.ts');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gbrain-rerank-search-'));
+    try {
+      await withEnv({ GBRAIN_AUDIT_DIR: tmpDir }, async () => {
+        configureGateway({
+          reranker_model: 'zeroentropyai:zerank-2',
+          env: {},
+        });
+
+        const results = [makeResult('a', 1.0, 'doc a')];
+        const out = await applyReranker('q', results, {
+          enabled: true,
+          topNIn: 1,
+          topNOut: null,
+          model: 'zeroentropyai:zerank-2',
+        });
+
+        expect(out).toEqual(results);
+        const failures = readRecentRerankFailures(1);
+        expect(failures).toHaveLength(1);
+        expect(failures[0]!.reason).toBe('auth');
+        expect(failures[0]!.error_summary).toContain('ZEROENTROPY_API_KEY');
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      configureGateway({ env: { ZEROENTROPY_API_KEY: 'test-key' } });
+    }
   });
 
   test('fail-open on non-RerankError throw too', async () => {


### PR DESCRIPTION
## Summary

Fixes #2059.

This makes missing reranker credentials fail open with the correct `auth` reason instead of being recorded as `unknown` while search silently falls back.

Changes:
- convert reranker `AIConfigError` from missing provider credentials into `RerankError(..., auth)` before any HTTP call
- keep search reranker fail-open behavior, but audit missing `ZEROENTROPY_API_KEY` as `auth`
- make `doctor` warn when recent reranker failures are repeatedly `unknown`, preserving visibility for historical #2059 rows

## Notes on overlap

Checked open PRs for #2059 / reranker auth / `ZEROENTROPY_API_KEY`. Adjacent provider-auth PRs exist, but none cover this ZE reranker failure classification and doctor-health behavior.

## Verification

Ran on Mac mini (`Mac.attlocal.net`, user `maxsmacmini`):

- `bun test test/ai/rerank.test.ts test/search/rerank.test.ts test/doctor.test.ts`
- Result: 121 pass, 0 fail, 292 expect calls

GitHub may report no check suite for this fork draft PR; if so, the focused mini test run above is the current verification evidence.
