### PR TITLE
fix(extract): recognize reference wikilinks

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -78,11 +78,11 @@ export type LinkResolutionType = 'qualified' | 'unqualified';
 /**
  * Directory prefix whitelist. These are the top-level slug dirs the extractor
  * recognizes as entity references. Upstream canonical + our extensions:
- *   - Gbrain canonical: people, companies, meetings, concepts, deal, civic, project, source, media, yc, projects
+ *   - Gbrain canonical: people, companies, meetings, concepts, deal, civic, project, source, media, yc, projects, reference
  *   - Our domain extensions: tech, finance, personal, openclaw (domain-organized wikis)
  *   - Our entity prefix: entities (we kept some legacy entities/projects/ pages)
  */
-const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities)';
+const DIR_PATTERN = '(?:people|companies|meetings|concepts|deal|civic|project|projects|source|media|yc|tech|finance|personal|openclaw|entities|reference)';
 
 /**
  * Match `[Name](path)` markdown links pointing to entity directories.

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -140,6 +140,17 @@ describe('extractEntityRefs', () => {
     expect(wikiRefs[0].needsResolution).toBe(true);
   });
 
+  test('recognizes reference-page wikilinks as concrete targets', () => {
+    const refs = extractEntityRefs('See [[reference/mcminnville-market-data]] for source context.');
+    expect(refs.length).toBe(1);
+    expect(refs[0]).toMatchObject({
+      name: 'reference/mcminnville-market-data',
+      slug: 'reference/mcminnville-market-data',
+      dir: 'reference',
+    });
+    expect(refs[0].needsResolution).toBeUndefined();
+  });
+
   test('skips qualified-syntax tokens (those belong to 2a)', () => {
     // [[wiki:topics/ai]] looks like 2a's qualified shape — even though
     // it wouldn't satisfy DIR_PATTERN, 2c must not claim it either


### PR DESCRIPTION
## What does this PR do?

Recognizes `reference/...` pages as concrete markdown/wikilink extraction targets.

The link extractor uses a shared `DIR_PATTERN` whitelist for entity-style links such as `[[people/alice]]`, `[[concepts/foo]]`, and `[[projects/bar]]`. `reference/...` pages are valid durable knowledge pages, but they were missing from that whitelist. As a result, `[[reference/mcminnville-market-data]]` fell through to the generic basename-resolution path and was tagged with `needsResolution: true` instead of being treated as a concrete target slug.

This PR adds `reference` to the recognized directory prefixes and pins the behavior with a focused regression test.

## Related Issue

Refs #2045

I’m using `Refs` rather than `Fixes` because this covers the deterministic extractor-prefix gap for explicit `[[reference/...]]` wikilinks. Maintainers may still want broader graph/orphan validation before closing the full issue.

## Type of Change

- [x] Bug fix
- [x] Tests / regression coverage
- [ ] Documentation update
- [ ] Refactor
- [ ] New feature

## Changes Made

- `src/core/link-extraction.ts`
  - Adds `reference` to the shared `DIR_PATTERN` whitelist used by markdown entity links, unqualified wikilinks, and qualified wikilinks.
- `test/link-extraction.test.ts`
  - Adds regression coverage for `[[reference/mcminnville-market-data]]`.
  - Asserts the ref is emitted as a concrete `reference/...` target and not as a basename-resolution candidate.

## Duplicate Checks

Checked before submission:

- `2045 reference wikilink target`
- `reference wikilink link-extraction`
- `reference type pages wikilinks orphaned`
- `DIR_PATTERN reference`

Result: I found broad related wikilink work in #1188, but did not find an open PR specifically adding `reference` to the concrete `DIR_PATTERN` target path for #2045.

## How to Test

Validated locally:

```bash
git diff --check
bun test test/link-extraction.test.ts
bun run verify
```

Results:

```text
bun test test/link-extraction.test.ts
127 pass
0 fail
325 expect() calls

bun run verify
[verify-parallel] elapsed=17s | pass=30 fail=0 | all checks green
```

## Risk

Low.

This extends an existing prefix whitelist with one page family. Existing recognized prefixes are unchanged, and generic basename-resolution behavior is unchanged for non-whitelisted wikilinks.

Expected behavior change: explicit `reference/...` markdown links and wikilinks can now materialize as concrete graph candidates where they previously fell through to basename resolution.

## Checklist

- [x] Focused, small diff
- [x] Regression test added
- [x] `git diff --check` passed
- [x] Focused unit test passed
- [x] Repository verify gate passed
- [x] Maintainer edits enabled