### PR TITLE
fix: honor legacy token source grants in OAuth

### DIFF
--- a/src/core/legacy-token-scope.ts
+++ b/src/core/legacy-token-scope.ts
@@ -1,0 +1,22 @@
+/**
+ * Derive a legacy bearer token's source scope from its stored
+ * `access_tokens.permissions.source_id` grant.
+ *
+ * ARRAY = federated read grant, exposed through `allowedSources` with the
+ * first granted source as the scalar write floor. STRING = scalar source.
+ * Missing, empty, or garbage values fail closed to the historical `default`
+ * floor and NEVER widen to all sources.
+ */
+export function parseLegacyTokenScope(rawSource: unknown): { sourceId: string; allowedSources?: string[] } {
+  if (Array.isArray(rawSource)) {
+    const allowedSources = (rawSource as unknown[]).filter(s => typeof s === 'string' && s.length > 0) as string[];
+    if (allowedSources.length > 0) {
+      return { sourceId: allowedSources[0], allowedSources };
+    }
+    return { sourceId: 'default' };
+  }
+  if (typeof rawSource === 'string' && rawSource.length > 0) {
+    return { sourceId: rawSource };
+  }
+  return { sourceId: 'default' };
+}

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -21,10 +21,12 @@ import type {
 } from '@modelcontextprotocol/sdk/shared/auth.js';
 import type { OAuthServerProvider, AuthorizationParams } from '@modelcontextprotocol/sdk/server/auth/provider.js';
 import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
-import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type { AuthInfo as SdkAuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { hashToken, generateToken, isUndefinedColumnError } from './utils.ts';
 import { hasScope, assertAllowedScopes, parseScopeString, InvalidScopeError } from './scope.ts';
+import type { AuthInfo as CoreAuthInfo } from './operations.ts';
+import { parseLegacyTokenScope } from './legacy-token-scope.ts';
 import type { SqlQuery, SqlValue } from './sql-query.ts';
 export type { SqlQuery, SqlValue };
 
@@ -539,7 +541,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
   // Token Verification
   // -------------------------------------------------------------------------
 
-  async verifyAccessToken(token: string): Promise<AuthInfo> {
+  async verifyAccessToken(token: string): Promise<SdkAuthInfo> {
     const tokenHash = hashToken(token);
     const now = Math.floor(Date.now() / 1000);
 
@@ -629,14 +631,29 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
         // operations.ts prefers this array over scalar sourceId when set
         // and non-empty.
         allowedSources,
-      } as AuthInfo;
+      } as CoreAuthInfo as SdkAuthInfo;
     }
 
-    // Fallback: legacy access_tokens table (backward compat)
-    const legacyRows = await this.sql`
-      SELECT name FROM access_tokens
-      WHERE token_hash = ${tokenHash} AND revoked_at IS NULL
-    `;
+    // Fallback: legacy access_tokens table (backward compat). Modern legacy
+    // rows may carry permissions.source_id from the pre-OAuth bearer-token
+    // path; OAuth transport must preserve that same source grant instead of
+    // pinning every legacy token to `default`.
+    let legacyRows: Record<string, unknown>[];
+    try {
+      legacyRows = await this.sql`
+        SELECT name, permissions FROM access_tokens
+        WHERE token_hash = ${tokenHash} AND revoked_at IS NULL
+      `;
+    } catch (err) {
+      if (isUndefinedColumnError(err, 'permissions')) {
+        legacyRows = await this.sql`
+          SELECT name FROM access_tokens
+          WHERE token_hash = ${tokenHash} AND revoked_at IS NULL
+        `;
+      } else {
+        throw err;
+      }
+    }
 
     if (legacyRows.length > 0) {
       // Legacy tokens get full admin access (grandfather in).
@@ -646,19 +663,31 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
         UPDATE access_tokens SET last_used_at = now() WHERE token_hash = ${tokenHash}
       `;
       const name = legacyRows[0].name as string;
+      const permissionsRaw = legacyRows[0].permissions;
+      let permissions: unknown = permissionsRaw;
+      if (typeof permissionsRaw === 'string') {
+        try {
+          permissions = JSON.parse(permissionsRaw);
+        } catch {
+          permissions = undefined;
+        }
+      }
+      const sourceGrant = permissions && typeof permissions === 'object'
+        ? (permissions as Record<string, unknown>).source_id
+        : undefined;
+      const { sourceId, allowedSources } = parseLegacyTokenScope(sourceGrant);
       return {
         token,
         clientId: name,
         clientName: name,
         scopes: ['read', 'write', 'admin'],
         expiresAt: Math.floor(Date.now() / 1000) + 365 * 24 * 3600, // Legacy tokens never expire — set 1yr future
-        // v0.34.1 (#861, D13): legacy bearer tokens default to 'default'
-        // source — matches the pre-v0.34 effective behavior where the
-        // serve-http transport fell back to GBRAIN_SOURCE/'default' for
-        // any caller without explicit scope. Operators who want a
-        // narrower scope for legacy tokens migrate to OAuth.
-        sourceId: 'default',
-      } as AuthInfo;
+        // Legacy tokens without an explicit permissions.source_id grant keep
+        // the historical 'default' source floor. Array grants become
+        // allowedSources for federated reads, matching legacy HTTP transport.
+        sourceId,
+        allowedSources,
+      } as CoreAuthInfo as SdkAuthInfo;
     }
 
     throw new InvalidTokenError('Invalid token');

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -34,6 +34,8 @@ import { VERSION } from '../version.ts';
 import { dispatchToolCall } from './dispatch.ts';
 import { buildDefaultLimiters, type RateLimiter } from './rate-limit.ts';
 import { sqlQueryForEngine } from '../core/sql-query.ts';
+import { parseLegacyTokenScope } from '../core/legacy-token-scope.ts';
+export { parseLegacyTokenScope };
 
 const DEFAULT_BODY_CAP = 1024 * 1024; // 1 MiB
 
@@ -84,28 +86,8 @@ interface AuthResult {
   auth?: AuthInfo;
 }
 
-/**
- * #1336: derive a legacy bearer token's source scope from its stored
- * `permissions.source_id`. An ARRAY value is a federated_read grant →
- * `allowedSources` (scoped reads across exactly those sources). A STRING value
- * scopes the scalar floor. Anything else → 'default' (preserves pre-v0.34
- * behavior). NEVER widened to "all": an empty/garbage value keeps the 'default'
- * floor and no federated grant.
- */
-export function parseLegacyTokenScope(rawSource: unknown): { sourceId: string; allowedSources?: string[] } {
-  if (Array.isArray(rawSource)) {
-    const allowedSources = (rawSource as unknown[]).filter(s => typeof s === 'string' && s.length > 0) as string[];
-    if (allowedSources.length > 0) {
-      // Scalar floor: the first granted source (write authority); reads span the array.
-      return { sourceId: allowedSources[0], allowedSources };
-    }
-    return { sourceId: 'default' };
-  }
-  if (typeof rawSource === 'string' && rawSource.length > 0) {
-    return { sourceId: rawSource };
-  }
-  return { sourceId: 'default' };
-}
+/* Legacy token source-scope parsing lives in core/legacy-token-scope.ts and is
+ * re-exported above so the legacy HTTP transport and OAuth provider cannot drift. */
 
 /** Read up to `cap` bytes off req.body. Returns null if cap exceeded. */
 async function readBodyWithCap(req: Request, cap: number): Promise<string | null> {

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -12,6 +12,7 @@ import {
 import { hashToken, generateToken } from '../src/core/utils.ts';
 import { PGLITE_SCHEMA_SQL } from '../src/core/pglite-schema.ts';
 import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import type { AuthInfo as CoreAuthInfo } from '../src/core/operations.ts';
 
 // ---------------------------------------------------------------------------
 // Test setup: in-memory PGLite with OAuth tables
@@ -309,6 +310,33 @@ describe('verifyAccessToken', () => {
     const authInfo = await provider.verifyAccessToken(legacyToken);
     expect(authInfo.clientId).toBe('legacy-agent');
     expect(authInfo.scopes).toEqual(['read', 'write', 'admin']); // grandfathered full access
+  });
+
+  test('legacy access_tokens fallback honors permissions.source_id array grants', async () => {
+    // oauth.test.ts initializes the static PGLite schema blob, not the full
+    // migration stack. Add the v38 permissions column here so the row matches
+    // a modern brain carrying a legacy-token source grant.
+    await sql`
+      ALTER TABLE access_tokens
+        ADD COLUMN IF NOT EXISTS permissions JSONB NOT NULL DEFAULT '{"takes_holders":["world"]}'::jsonb
+    `;
+
+    const legacyToken = generateToken('gbrain_');
+    const hash = hashToken(legacyToken);
+    await sql`
+      INSERT INTO access_tokens (id, name, token_hash, permissions)
+      VALUES (
+        ${crypto.randomUUID()},
+        ${'legacy-federated-agent'},
+        ${hash},
+        ${JSON.stringify({ source_id: ['default', 'src-a', 'src-b'] })}::jsonb
+      )
+    `;
+
+    const authInfo = await provider.verifyAccessToken(legacyToken) as CoreAuthInfo;
+    expect(authInfo.clientId).toBe('legacy-federated-agent');
+    expect(authInfo.sourceId).toBe('default');
+    expect(authInfo.allowedSources).toEqual(['default', 'src-a', 'src-b']);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #2027.

`serve --http` OAuth bearer verification now preserves legacy `access_tokens.permissions.source_id` grants instead of collapsing every legacy fallback token to `sourceId: 'default'`.

Changes:
- Moves legacy token source-scope parsing into `src/core/legacy-token-scope.ts` so the HTTP transport and OAuth provider share one implementation.
- Reads `permissions` in the OAuth provider legacy `access_tokens` fallback, with a schema-backcompat fallback for older tables without that column.
- Returns `allowedSources` for array grants and keeps the historical `default` floor when no valid grant exists.
- Adds an OAuth regression proving array source grants survive `verifyAccessToken()`.

## Verification

Passing:
- `bun test test/oauth.test.ts --test-name-pattern 'legacy access_tokens fallback honors permissions.source_id array grants'`
- `bun test test/legacy-token-federated-scope.test.ts`
- `bun test test/oauth.test.ts`
- `bun test test/legacy-token-federated-scope.test.ts test/oauth.test.ts`
- `bun run typecheck`
- `bun run verify`
- `bun run check:source-id-projection`
- `bun run check:jsonb`
- `git diff --check`
- Independent Hermes subagent diff review: no blocking findings
- Codex exact-PR diff review: clean, no blocking findings
  - Codex also ran `bun test test/oauth.test.ts test/legacy-token-federated-scope.test.ts test/source-scope-resolver.test.ts`: 115 tests, 0 failures
  - Codex also ran `git diff --check origin/master...HEAD`

Could not run locally:
- `bun run ci:local:diff` because Docker is unavailable on this host: `docker: command not found`.

Full unit suite attempt:
- `bun run test` was started and stopped after ~14m37s because it had already surfaced unrelated environment-sensitive failures and continued running.
- Current failures were outside this PR's changed files, including `think-gateway-adapter` with `ANTHROPIC_API_KEY` present, `conversation-parser/llm-fallback`, and `check-resolvable-cli` OpenClaw workspace source detection.

## Notes

Nearby open PR #1648 handles older `GBRAIN_SOURCE` fallback behavior for #1336. This PR is narrower and covers #2027 specifically: stored `permissions.source_id` grants in the OAuth provider legacy-token path.
