### PR TITLE
fix(gateway): thread asymmetric input_type to ZeroEntropy via request header — AI-SDK adapter drops providerOptions.openaiCompatible.input_type

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -943,9 +943,11 @@ const voyageCompatFetch = (async (input: RequestInfo | URL, init?: RequestInit) 
  *  - Path: AI SDK adapter calls `${base_url}/embeddings`; ZE wants
  *    `${base_url}/models/embed`. Rewrite the URL path.
  *  - Body: inject `input_type: 'document'` (or `'query'` when threaded via
- *    providerOptions.openaiCompatible.input_type) and `encoding_format:
- *    'float'` (don't trust SDK default; strip any base64 caller injected
- *    to keep the response rewriter simple).
+ *    the `x-gbrain-input-type` request header — NOT providerOptions:
+ *    `openaiCompatible.input_type` is silently dropped by the AI-SDK
+ *    adapter) and `encoding_format: 'float'` (don't trust SDK default;
+ *    strip any base64 caller injected to keep the response rewriter
+ *    simple).
  *  - Response: ZE returns `{results: [{embedding: float[]}], usage:
  *    {total_bytes, total_tokens}}`. AI SDK's openai-compatible Zod schema
  *    expects `{data: [{embedding, index}], usage: {prompt_tokens, ...}}`.
@@ -955,6 +957,17 @@ const voyageCompatFetch = (async (input: RequestInfo | URL, init?: RequestInit) 
  * float[] (not base64), so the Layer 2 cap compares against the JSON
  * payload size of each embedding rather than a base64 string length.
  */
+// Test-only seam for the ZE compat shim's terminal fetch — lets a unit test
+// drive embed()/embedQuery() through the REAL AI-SDK adapter and assert the
+// final wire body (test/ze-input-type-wire.test.ts), which the
+// __setEmbedTransportForTests seam cannot see (it replaces the transport
+// UPSTREAM of the adapter that drops providerOptions). Mirrors the
+// __setChatTransportForTests pattern. Production paths see _zeFetch === null.
+let _zeFetch: typeof fetch | null = null;
+export function __setZeFetchForTests(fn: typeof fetch | null): void {
+  _zeFetch = fn;
+}
+
 const zeroEntropyCompatFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
   // OUTBOUND: normalize URL, rewrite path /embeddings → /models/embed, then
   // rewrite body. fetch accepts RequestInfo (string | Request) | URL; we
@@ -1005,6 +1018,27 @@ const zeroEntropyCompatFetch = (async (input: RequestInfo | URL, init?: RequestI
           parsed.encoding_format = 'float';
           mutated = true;
         }
+        // Asymmetric input_type threading (header → body).
+        // providerOptions.openaiCompatible.input_type never survives the
+        // AI-SDK adapter (unrecognized field; `dimensions` survives because
+        // it's a known param), so EVERY embed — including query-side
+        // embedQuery() — arrived here without input_type and got the
+        // 'document' default below. That silently broke asymmetric
+        // retrieval: the whole vector arm searched with document-typed
+        // query vectors. Fix: embedSubBatch() threads the input type via
+        // the 'x-gbrain-input-type' request header (race-free — travels
+        // with the request); the shim consumes it here and strips it
+        // before sending.
+        const hdrs = new Headers(baseInit.headers ?? {});
+        const threadedInputType = hdrs.get('x-gbrain-input-type');
+        if (threadedInputType === 'query' || threadedInputType === 'document') {
+          if (parsed.input_type !== threadedInputType) {
+            parsed.input_type = threadedInputType;
+            mutated = true;
+          }
+          hdrs.delete('x-gbrain-input-type');
+          baseInit = { ...baseInit, headers: hdrs };
+        }
         // Default input_type when caller didn't thread one (document-side
         // embedding is the correct default for ingest paths).
         if (parsed.input_type === undefined) {
@@ -1022,7 +1056,7 @@ const zeroEntropyCompatFetch = (async (input: RequestInfo | URL, init?: RequestI
     }
   }
 
-  const resp = await fetch(urlString, baseInit);
+  const resp = await (_zeFetch ?? fetch)(urlString, baseInit);
   if (!resp.ok) return resp;
   const ct = resp.headers.get('content-type') ?? '';
   if (!ct.toLowerCase().includes('application/json')) return resp;
@@ -1476,6 +1510,13 @@ async function embedSubBatch(
       model,
       values: texts,
       providerOptions: providerOpts,
+      // Thread the asymmetric input type as a request header —
+      // providerOptions.openaiCompatible.input_type is dropped by the
+      // AI-SDK adapter, which silently made every embed (incl. embedQuery)
+      // document-typed. The ZE compat shim reads + strips this header and
+      // writes input_type into the request body. Wire-level contract:
+      // test/ze-input-type-wire.test.ts.
+      ...(opts?.inputType && { headers: { 'x-gbrain-input-type': opts.inputType } }),
       // v0.42.20.0 — default a per-SUB-BATCH embed timeout (codex #3: bounding
       // once at embed() top would cap a whole multi-batch import; this is the
       // per-SDK-call scope). Composes with a caller signal (Fix 3's 6s query

--- a/test/ze-input-type-wire.test.ts
+++ b/test/ze-input-type-wire.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Wire-level contract for asymmetric input_type threading to ZeroEntropy.
+ *
+ * Why this exists when asymmetric-encoding-contract.test.ts already pins
+ * input_type: that test captures `providerOptions` at the
+ * `__setEmbedTransportForTests` seam — UPSTREAM of the AI-SDK adapter.
+ * The adapter silently drops `providerOptions.openaiCompatible.input_type`
+ * (unrecognized field; `dimensions` survives because it's a known param),
+ * so the providerOptions contract held green while the actual wire body
+ * said `input_type: 'document'` for every request — queries included —
+ * and the entire vector arm did asymmetric retrieval with symmetric
+ * (document-typed) query vectors.
+ *
+ * This test drives embed()/embedQuery() through the REAL adapter and
+ * asserts the body the ZE endpoint receives, via the
+ * `__setZeFetchForTests` terminal-fetch seam. It fails if input_type is
+ * ever again threaded only through providerOptions.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import {
+  configureGateway,
+  resetGateway,
+  embed,
+  embedQuery,
+  __setZeFetchForTests,
+} from '../src/core/ai/gateway.ts';
+
+function configureZE() {
+  configureGateway({
+    embedding_model: 'zeroentropyai:zembed-1',
+    embedding_dimensions: 1280,
+    env: { ZEROENTROPY_API_KEY: 'sk-fake' },
+  });
+}
+
+function fakeZeResponse(count: number, dims: number): Response {
+  // ZE's native response shape — exercises the shim's inbound rewrite
+  // ({results} → {data}, total_tokens → prompt_tokens) on the way back.
+  return new Response(
+    JSON.stringify({
+      results: Array.from({ length: count }, () => ({
+        embedding: Array.from({ length: dims }, () => 0.1),
+      })),
+      usage: { total_bytes: 4, total_tokens: 1 },
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+interface CapturedWire {
+  url: string;
+  body: Record<string, unknown>;
+  headers: Headers;
+}
+
+function captureWire(captured: CapturedWire[]): typeof fetch {
+  return (async (url: RequestInfo | URL, init?: RequestInit) => {
+    captured.push({
+      url: String(url),
+      body: JSON.parse(String(init?.body ?? '{}')),
+      headers: new Headers(init?.headers ?? {}),
+    });
+    return fakeZeResponse(
+      Array.isArray((JSON.parse(String(init?.body ?? '{}')) as { input?: unknown[] }).input)
+        ? ((JSON.parse(String(init?.body ?? '{}')) as { input: unknown[] }).input.length)
+        : 1,
+      1280,
+    );
+  }) as typeof fetch;
+}
+
+afterEach(() => {
+  __setZeFetchForTests(null);
+  resetGateway();
+});
+
+describe('ZE wire body carries asymmetric input_type (adapter drops providerOptions)', () => {
+  test('embedQuery → wire body has input_type=query; threading header stripped', async () => {
+    configureZE();
+    const captured: CapturedWire[] = [];
+    __setZeFetchForTests(captureWire(captured));
+
+    await embedQuery('what does foo bar do?');
+
+    expect(captured.length).toBe(1);
+    expect(captured[0].body.input_type).toBe('query');
+    // The internal threading header must not leak to the provider.
+    expect(captured[0].headers.get('x-gbrain-input-type')).toBeNull();
+    // Sanity: the shim's URL rewrite ran (we're on the real outbound path).
+    expect(captured[0].url).toContain('/models/embed');
+  });
+
+  test('embed (index path) → wire body has input_type=document', async () => {
+    configureZE();
+    const captured: CapturedWire[] = [];
+    __setZeFetchForTests(captureWire(captured));
+
+    await embed(['this is a document being indexed']);
+
+    expect(captured.length).toBe(1);
+    expect(captured[0].body.input_type).toBe('document');
+    expect(captured[0].headers.get('x-gbrain-input-type')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

`embedQuery()` exists and threads `inputType: 'query'` into `providerOptions.openaiCompatible` — but the AI-SDK's openai-compatible adapter **silently drops unrecognized providerOptions fields**. `dimensions` survives (known param); `input_type` doesn't. Every embed request therefore reached the ZeroEntropy compat shim without an `input_type`, and the shim's correct-for-ingest default (`'document'`) applied to **queries too**.

Net effect: the entire vector arm performs asymmetric retrieval with symmetric (document-typed) query vectors. Nothing errors — rankings are just quietly wrong, especially for natural-question phrasings against note-style passages (exactly what asymmetric encoding exists to fix).

## How this was found (evidence chain)

On a real ~2.3k-page / ~9.7k-chunk corpus (zembed-1 @ 1280, Postgres engine):

1. Hybrid search consistently missed targets for natural-question queries that **pure-vector SQL with a properly query-typed vector ranked #1**.
2. A manually **document-typed** query embedding reproduced production's broken rankings **byte-identically** (cosine sims equal to 16 decimal places) — production was provably searching with document-typed query vectors.
3. `gbrain`'s own `embedQuery()` output matched that document-typed vector, not the query-typed one.
4. Post-fix: 8/8 previously-missing natural-question probes rank their target #1 on the same corpus. (An unrelated dims experiment — 1280 vs native 2560 — measured a flat wash, which was the tell: dims should have moved something. The model was never the problem.)

Worth noting: `test/asymmetric-encoding-contract.test.ts` stayed **green** through all of this — it captures `providerOptions` at the `__setEmbedTransportForTests` seam, *upstream* of the adapter that drops the field. The contract it pins is real but doesn't reach the wire.

## Fix

- `embedSubBatch()` threads the input type as an **`x-gbrain-input-type` request header** — headers survive the adapter, travel with the request (race-free), and need no module state.
- `zeroEntropyCompatFetch` consumes + strips the header during its existing body rewrite and writes `input_type` into the request body.
- No API change. The Voyage path is unaffected (it builds its request body directly rather than going through the openai-compatible adapter — `input_type` already reaches the wire there).

## Test

New `test/ze-input-type-wire.test.ts` drives `embed()`/`embedQuery()` through the **real** adapter via a new `__setZeFetchForTests` terminal-fetch seam (mirrors the existing `__set*ForTests` conventions) and asserts the final wire body:

- `embedQuery(...)` → body `input_type: 'query'`, threading header stripped, URL rewrite ran
- `embed([...])` → body `input_type: 'document'`

**Verified to fail without the fix** (the query-side assertion sees `'document'`). `bun run verify`: 30/30 green. Full unit suite: **no new failures vs master** — a set of provider-env-sensitive serial tests (reranker/cross-modal/think-gateway) fails identically on a clean master checkout in my environment (host injects `ANTHROPIC_*` env vars), so I'm expecting CI's clean env to be green.

## Operational note for existing installs

Any cached query-embedding artifacts produced while the bug was live are document-typed — after upgrading, clear the query cache and restart long-running `gbrain serve` processes so they pick up the fixed code.

Possibly related: #1469 reports the hybrid vector path returning identical results regardless of input (ollama). Different symptom — a fixed/ignored query vector vs. a wrong-typed one — so this PR does not claim to fix it, but it's the same subsystem and worth re-testing against this change.
