### PR TITLE
fix: bound subagent tool stalls and retry timestamps

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -77,6 +77,9 @@ const AI_CHAT_TIMEOUT_MS = resolveAiTimeoutMs('GBRAIN_AI_CHAT_TIMEOUT_MS', 300_0
 const AI_EMBED_TIMEOUT_MS = resolveAiTimeoutMs('GBRAIN_AI_EMBED_TIMEOUT_MS', 60_000);
 /** multimodal per request. */
 const AI_MULTIMODAL_TIMEOUT_MS = resolveAiTimeoutMs('GBRAIN_AI_MULTIMODAL_TIMEOUT_MS', 60_000);
+/** Per tool execution inside the subagent/gateway tool loop. */
+const AI_TOOL_TIMEOUT_MS = resolveAiTimeoutMs('GBRAIN_SUBAGENT_TOOL_TIMEOUT_MS', 60_000);
+const AI_TOOL_MAX_ATTEMPTS = resolveAiTimeoutMs('GBRAIN_SUBAGENT_TOOL_MAX_ATTEMPTS', 2);
 
 /**
  * Compose a caller signal with a default wall-clock timeout. When the caller
@@ -2927,6 +2930,10 @@ export interface ToolLoopOpts {
   abortSignal?: AbortSignal;
   /** Apply Anthropic cache_control to system + last tool. Silently ignored elsewhere. */
   cacheSystem?: boolean;
+  /** Per-tool wall-clock timeout. Defaults to GBRAIN_SUBAGENT_TOOL_TIMEOUT_MS or 60s. */
+  toolTimeoutMs?: number;
+  /** Max attempts for idempotent transient/timeout tool failures. Defaults to 2. */
+  toolMaxAttempts?: number;
 
   /** Crash-replay state. When set, the loop resumes from the recorded position. */
   replayState?: ToolLoopReplayState;
@@ -2993,6 +3000,8 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
   const maxTurns = opts.maxTurns ?? 20;
   const maxTokens = opts.maxTokens ?? 4096;
   const handlers = opts.toolHandlers;
+  const toolTimeoutMs = opts.toolTimeoutMs ?? AI_TOOL_TIMEOUT_MS;
+  const toolMaxAttempts = Math.max(1, Math.floor(opts.toolMaxAttempts ?? AI_TOOL_MAX_ATTEMPTS));
   const totalUsage: ChatResult['usage'] = {
     input_tokens: 0,
     output_tokens: 0,
@@ -3151,10 +3160,26 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
         );
       }
 
-      // Step 3: execute (side effect).
+      // Step 3: execute (side effect). Bound every call: DB/pooler/client
+      // hangs must settle as failed tool results instead of squatting a worker
+      // slot until the whole job timeout expires. Only idempotent tools retry.
       opts.onHeartbeat?.('tool_called', { turn_idx: turnIdx, tool_name: call.toolName });
       try {
-        const output = await handler.execute(call.input, opts.abortSignal ?? new AbortController().signal);
+        const output = await executeToolWithTimeoutAndRetry({
+          toolName: call.toolName,
+          input: call.input,
+          baseSignal: opts.abortSignal,
+          timeoutMs: toolTimeoutMs,
+          maxAttempts: toolMaxAttempts,
+          idempotent: handler.idempotent === true,
+          execute: signal => handler.execute(call.input, signal),
+          onRetry: (attempt, error) => opts.onHeartbeat?.('tool_retry', {
+            turn_idx: turnIdx,
+            tool_name: call.toolName,
+            attempt,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        });
         // Step 4: settle complete.
         await opts.onToolCallComplete?.(gbrainToolUseId, output);
         toolResultBlocks.push({
@@ -3193,6 +3218,94 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
   }
 
   return { finalText, totalTurns: turnIdx, totalUsage, stopReason, messages };
+}
+
+export class ToolCallTimeoutError extends Error {
+  constructor(public toolName: string, public timeoutMs: number) {
+    super(`tool "${toolName}" timed out after ${timeoutMs}ms`);
+    this.name = 'ToolCallTimeoutError';
+  }
+}
+
+interface ExecuteToolWithTimeoutAndRetryOpts {
+  toolName: string;
+  input: unknown;
+  baseSignal?: AbortSignal;
+  timeoutMs: number;
+  maxAttempts: number;
+  idempotent: boolean;
+  execute: (signal: AbortSignal) => Promise<unknown>;
+  onRetry?: (attempt: number, error: unknown) => void;
+}
+
+export async function executeToolWithTimeoutAndRetry(
+  opts: ExecuteToolWithTimeoutAndRetryOpts,
+): Promise<unknown> {
+  let attempt = 0;
+  let lastErr: unknown;
+  const maxAttempts = opts.idempotent ? Math.max(1, opts.maxAttempts) : 1;
+  while (attempt < maxAttempts) {
+    attempt += 1;
+    try {
+      return await executeSingleToolAttempt(opts);
+    } catch (err) {
+      lastErr = err;
+      if (opts.baseSignal?.aborted) throw err;
+      if (attempt >= maxAttempts || !isRetryableToolError(err)) throw err;
+      opts.onRetry?.(attempt + 1, err);
+      await sleep(Math.min(1000 * attempt, 3000), opts.baseSignal);
+    }
+  }
+  throw lastErr;
+}
+
+async function executeSingleToolAttempt(opts: ExecuteToolWithTimeoutAndRetryOpts): Promise<unknown> {
+  const timeoutController = new AbortController();
+  const timer = setTimeout(() => {
+    timeoutController.abort(new ToolCallTimeoutError(opts.toolName, opts.timeoutMs));
+  }, opts.timeoutMs);
+  const signal = opts.baseSignal
+    ? AbortSignal.any([opts.baseSignal, timeoutController.signal])
+    : timeoutController.signal;
+
+  let abortListener: (() => void) | undefined;
+  const abortPromise = new Promise<never>((_, reject) => {
+    abortListener = () => {
+      const reason = signal.reason;
+      reject(reason instanceof Error ? reason : new Error('tool call aborted'));
+    };
+    if (signal.aborted) abortListener();
+    else signal.addEventListener('abort', abortListener, { once: true });
+  });
+
+  const workPromise = Promise.resolve().then(() => opts.execute(signal));
+  workPromise.catch(() => { /* Promise.race may have timed out first; avoid unhandled rejection. */ });
+  try {
+    return await Promise.race([workPromise, abortPromise]);
+  } finally {
+    clearTimeout(timer);
+    if (abortListener) signal.removeEventListener('abort', abortListener);
+  }
+}
+
+function isRetryableToolError(err: unknown): boolean {
+  if (err instanceof ToolCallTimeoutError) return true;
+  const name = err && typeof err === 'object' ? String((err as { name?: unknown }).name ?? '') : '';
+  const message = err instanceof Error ? err.message : String(err);
+  if (name === 'TimeoutError') return true;
+  return /CONNECT_TIMEOUT|connect timeout|Cannot connect|ECONNRESET|ECONNREFUSED|ETIMEDOUT|connection terminated|server closed the connection|pooler/i.test(message);
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(signal.reason ?? new Error('aborted'));
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error('aborted'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 // ---- Reranker (v0.35.0.0+) ----

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -49,7 +49,7 @@ import {
 } from './subagent-audit.ts';
 import { resolveModel, isAnthropicProvider, TIER_DEFAULTS } from '../../model-config.ts';
 import { buildSystemPrompt, DEFAULT_SUBAGENT_SYSTEM } from '../system-prompt.ts';
-import { toolLoop as gatewayToolLoop } from '../../ai/gateway.ts';
+import { executeToolWithTimeoutAndRetry, toolLoop as gatewayToolLoop } from '../../ai/gateway.ts';
 import type { ChatToolDef, ChatMessage, ChatBlock, ChatResult, ToolHandler } from '../../ai/gateway.ts';
 import { classifyCapabilities } from '../../ai/capabilities.ts';
 import { randomUUIDv7 } from 'bun';
@@ -390,8 +390,23 @@ export function makeSubagentHandler(deps: SubagentDeps) {
           }
           await persistToolExecPending(engine, ctx.id, last.message_idx, use.id, use.name, use.input);
           try {
-            const output = await toolDef.execute(use.input, {
-              engine, jobId: ctx.id, remote: true, signal: ctx.signal,
+            const output = await executeToolWithTimeoutAndRetry({
+              toolName: use.name,
+              input: use.input,
+              baseSignal: mergeSignals(ctx.signal, ctx.shutdownSignal),
+              timeoutMs: subagentToolTimeoutMs(),
+              maxAttempts: subagentToolMaxAttempts(),
+              idempotent: toolDef.idempotent === true,
+              execute: signal => toolDef.execute(use.input, {
+                engine, jobId: ctx.id, remote: true, signal,
+              }),
+              onRetry: (attempt, error) => logSubagentHeartbeat({
+                job_id: ctx.id,
+                event: 'tool_retry' as any,
+                tool_name: use.name,
+                attempt,
+                error: error instanceof Error ? error.message : String(error),
+              } as any),
             });
             await persistToolExecComplete(engine, ctx.id, use.id, output);
             synthesizedResults.push({
@@ -645,11 +660,27 @@ export function makeSubagentHandler(deps: SubagentDeps) {
 
         const toolStart = Date.now();
         try {
-          const output = await toolDef.execute(use.input, {
-            engine,
-            jobId: ctx.id,
-            remote: true,
-            signal: ctx.signal,
+          const output = await executeToolWithTimeoutAndRetry({
+            toolName,
+            input: use.input,
+            baseSignal: mergeSignals(ctx.signal, ctx.shutdownSignal),
+            timeoutMs: subagentToolTimeoutMs(),
+            maxAttempts: subagentToolMaxAttempts(),
+            idempotent: toolDef.idempotent === true,
+            execute: signal => toolDef.execute(use.input, {
+              engine,
+              jobId: ctx.id,
+              remote: true,
+              signal,
+            }),
+            onRetry: (attempt, error) => logSubagentHeartbeat({
+              job_id: ctx.id,
+              event: 'tool_retry' as any,
+              turn_idx: turnIdx,
+              tool_name: toolName,
+              attempt,
+              error: error instanceof Error ? error.message : String(error),
+            } as any),
           });
           await persistToolExecComplete(engine, ctx.id, use.id, output);
           logSubagentHeartbeat({
@@ -904,6 +935,8 @@ async function runSubagentViaGateway(args: GatewayRunArgs): Promise<SubagentResu
         [errorMsg, gbrainToolUseId],
       );
     },
+    toolTimeoutMs: subagentToolTimeoutMs(),
+    toolMaxAttempts: subagentToolMaxAttempts(),
     onHeartbeat: heartbeat,
   });
 
@@ -1180,6 +1213,18 @@ async function persistToolExecFailed(
 }
 
 // ── Internal: helpers ───────────────────────────────────────
+
+function subagentToolTimeoutMs(): number {
+  const raw = process.env.GBRAIN_SUBAGENT_TOOL_TIMEOUT_MS;
+  const n = raw === undefined ? 60_000 : Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : 60_000;
+}
+
+function subagentToolMaxAttempts(): number {
+  const raw = process.env.GBRAIN_SUBAGENT_TOOL_MAX_ATTEMPTS;
+  const n = raw === undefined ? 2 : Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.max(1, Math.floor(n)) : 2;
+}
 
 function asStringIfNotObject(value: unknown): string {
   if (typeof value === 'string') return value;

--- a/src/core/minions/queue.ts
+++ b/src/core/minions/queue.ts
@@ -471,11 +471,19 @@ export class MinionQueue {
     });
   }
 
-  /** Re-queue a failed or dead job for retry. */
+  /**
+   * Re-queue a failed or dead job for retry.
+   *
+   * Reset started_at/timeout_at as well as terminal/lock fields. Wall-clock
+   * timeout recovery keys off started_at (not attempts), so leaving the old
+   * value in place makes manually retried timeout casualties insta-die on the
+   * next claim before the handler gets a real fresh run.
+   */
   async retryJob(id: number): Promise<MinionJob | null> {
     const rows = await this.engine.executeRaw<Record<string, unknown>>(
       `UPDATE minion_jobs SET status = 'waiting', error_text = NULL,
         lock_token = NULL, lock_until = NULL, delay_until = NULL,
+        started_at = NULL, timeout_at = NULL,
         finished_at = NULL, updated_at = now()
        WHERE id = $1 AND status IN ('failed', 'dead')
        RETURNING *`,

--- a/test/minions.test.ts
+++ b/test/minions.test.ts
@@ -735,6 +735,34 @@ describe('MinionQueue: Cancel & Retry', () => {
     expect(retried!.status).toBe('waiting');
     expect(retried!.error_text).toBeNull();
   });
+
+  test('retry resets stale runtime timestamps so wall-clock timeout casualties get a fresh claim window', async () => {
+    const job = await queue.add('sync', { prompt: 'x' }, { timeout_ms: 1000 });
+    await queue.claim('tok1', 30000, 'default', ['sync']);
+    await engine.executeRaw(
+      `UPDATE minion_jobs
+       SET started_at = now() - interval '10 minutes',
+           timeout_at = now() - interval '9 minutes',
+           status = 'dead',
+           error_text = 'wall-clock timeout exceeded',
+           finished_at = now()
+       WHERE id = $1`,
+      [job.id],
+    );
+
+    const retried = await queue.retryJob(job.id);
+    expect(retried!.status).toBe('waiting');
+    expect(retried!.started_at).toBeNull();
+    expect(retried!.timeout_at).toBeNull();
+
+    const claimed = await queue.claim('tok2', 30000, 'default', ['sync']);
+    expect(claimed!.id).toBe(job.id);
+    expect(claimed!.started_at).not.toBeNull();
+    expect(claimed!.timeout_at).not.toBeNull();
+
+    const dead = await queue.handleWallClockTimeouts(30000);
+    expect(dead.map(j => j.id)).not.toContain(job.id);
+  });
 });
 
 // --- Pause / Resume (5 tests) ---

--- a/test/subagent-tool-timeout.test.ts
+++ b/test/subagent-tool-timeout.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  __setChatTransportForTests,
+  executeToolWithTimeoutAndRetry,
+  toolLoop,
+  type ChatResult,
+} from '../src/core/ai/gateway.ts';
+
+afterEach(() => {
+  __setChatTransportForTests(null);
+});
+
+const usage = {
+  input_tokens: 1,
+  output_tokens: 1,
+  cache_read_tokens: 0,
+  cache_creation_tokens: 0,
+};
+
+describe('subagent tool execution timeout/retry', () => {
+  test('executeToolWithTimeoutAndRetry bounds a hung tool even if it ignores the abort signal', async () => {
+    const started = Date.now();
+    await expect(executeToolWithTimeoutAndRetry({
+      toolName: 'brain_search',
+      input: { query: 'wedged pooler' },
+      timeoutMs: 20,
+      maxAttempts: 1,
+      idempotent: true,
+      execute: async () => new Promise(() => {}),
+    })).rejects.toThrow('tool "brain_search" timed out after 20ms');
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  test('idempotent transient tool failures retry and feed the successful result back into the loop', async () => {
+    let chatCalls = 0;
+    __setChatTransportForTests(async (): Promise<ChatResult> => {
+      chatCalls += 1;
+      if (chatCalls === 1) {
+        return {
+          text: '',
+          blocks: [{ type: 'tool-call', toolCallId: 'call-1', toolName: 'brain_search', input: { query: 'supabase' } }],
+          stopReason: 'tool_calls',
+          usage,
+          model: 'test:model',
+          providerId: 'test',
+        };
+      }
+      return {
+        text: 'done',
+        blocks: [{ type: 'text', text: 'done' }],
+        stopReason: 'end',
+        usage,
+        model: 'test:model',
+        providerId: 'test',
+      };
+    });
+
+    let attempts = 0;
+    const retries: number[] = [];
+    const result = await toolLoop({
+      model: 'test:model',
+      initialMessages: [{ role: 'user', content: 'search' }],
+      tools: [{ name: 'brain_search', description: 'Search', inputSchema: { type: 'object' } }],
+      toolHandlers: new Map([['brain_search', {
+        idempotent: true,
+        async execute() {
+          attempts += 1;
+          if (attempts === 1) throw new Error('Cannot connect to database: CONNECT_TIMEOUT');
+          return { ok: true };
+        },
+      }]]),
+      toolTimeoutMs: 1000,
+      toolMaxAttempts: 2,
+      onHeartbeat(event, data) {
+        if (event === 'tool_retry') retries.push(data.attempt as number);
+      },
+    });
+
+    expect(result.stopReason).toBe('end');
+    expect(result.finalText).toBe('done');
+    expect(attempts).toBe(2);
+    expect(retries).toEqual([2]);
+    expect(chatCalls).toBe(2);
+  });
+
+  test('non-idempotent transient tool failures do not retry', async () => {
+    let attempts = 0;
+    await expect(executeToolWithTimeoutAndRetry({
+      toolName: 'write_side_effect',
+      input: {},
+      timeoutMs: 1000,
+      maxAttempts: 3,
+      idempotent: false,
+      execute: async () => {
+        attempts += 1;
+        throw new Error('Cannot connect to database: CONNECT_TIMEOUT');
+      },
+    })).rejects.toThrow('Cannot connect');
+    expect(attempts).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- bound subagent tool calls with a per-tool timeout and one retry through the AI gateway
- make the subagent handler pass retry/timeout policy into tool execution
- reset `started_at`/`timeout_at` when stalled jobs are retried so resurrected jobs get a fresh lease

## Tests
- `bun install --ignore-scripts`
- `bun test test/subagent-tool-timeout.test.ts test/minions.test.ts --max-concurrency=2`
- `bun run typecheck`
