### PR TITLE
fix(extract): clear stale version watermark

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -475,11 +475,20 @@ export function extractTimelineFromContent(content: string, slug: string): Extra
   // Format 1: Bullet — - **YYYY-MM-DD** | Source — Summary
   const bulletPattern = /^-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*(.+?)\s*[—–-]\s*(.+)$/gm;
   let match;
+  const sourceStyleLines = new Set<string>();
   while ((match = bulletPattern.exec(content)) !== null) {
+    sourceStyleLines.add(match[0]);
     entries.push({ slug, date: match[1], source: match[2].trim(), summary: match[3].trim() });
   }
 
-  // Format 2: Header — ### YYYY-MM-DD — Title
+  // Format 2: Simple bullet — - **YYYY-MM-DD** | Summary or - YYYY-MM-DD: Summary
+  const simpleBulletPattern = /^-\s+(?:\*\*)?(\d{4}-\d{2}-\d{2})(?:\*\*)?\s*(?:\||:|--|---|[—–-])\s*(.+)$/gm;
+  while ((match = simpleBulletPattern.exec(content)) !== null) {
+    if (sourceStyleLines.has(match[0])) continue;
+    entries.push({ slug, date: match[1], source: 'markdown', summary: match[2].trim() });
+  }
+
+  // Format 3: Header — ### YYYY-MM-DD — Title
   const headerPattern = /^###\s+(\d{4}-\d{2}-\d{2})\s*[—–-]\s*(.+)$/gm;
   while ((match = headerPattern.exec(content)) !== null) {
     const afterIdx = match.index + match[0].length;
@@ -1654,16 +1663,21 @@ async function extractStaleFromDB(
         timelineRows.push({ slug: page.slug, date: entry.date, summary: entry.summary, detail: entry.detail || '', source_id: page.source_id });
       }
       // EVERY processed page is stamped (incl. zero-link pages). D4 race fix:
-      // stamp with the row's READ updated_at, NOT now() — a concurrent edit
-      // landing between this SELECT and the stamp advances updated_at past the
-      // stamped value, so the page stays stale and re-extracts next run instead
-      // of being marked fresh-with-stale-content.
+      // stamp with the row's READ updated_at, not now(); if the row predates
+      // the extractor-version watermark, stamp at versionTs so the version arm
+      // clears. A concurrent edit landing after our SELECT still advances
+      // updated_at past this stamp, so the page stays stale instead of being
+      // marked fresh-with-old-content.
       //
       // #1768: stamp the FULL-µs `updated_at_iso` (projected via to_char), NOT
       // `page.updated_at.toISOString()` — the JS Date is ms-truncated, so the
       // µs-precision DB updated_at stayed strictly greater and the page never
       // cleared on Postgres. Stamping the exact value makes them equal.
-      processedRefs.push({ slug: page.slug, source_id: page.source_id, extractedAt: page.updated_at_iso });
+      processedRefs.push({
+        slug: page.slug,
+        source_id: page.source_id,
+        extractedAt: extractionStampForStalePage(page.updated_at_iso, versionTs),
+      });
     }
 
     // Flush NON-swallowing (CDX-4): a throw here propagates out of the sweep so
@@ -1702,6 +1716,15 @@ async function extractStaleFromDB(
     }) + '\n');
   }
   return { linksCreated, timelineCreated, pagesProcessed, staleRemaining };
+}
+
+export function extractionStampForStalePage(readUpdatedAtIso: string, versionTs: string): string {
+  const readMs = Date.parse(readUpdatedAtIso);
+  const versionMs = Date.parse(versionTs);
+  if (Number.isFinite(readMs) && Number.isFinite(versionMs) && versionMs > readMs) {
+    return versionTs;
+  }
+  return readUpdatedAtIso;
 }
 
 /**

--- a/src/core/doctor-categories.ts
+++ b/src/core/doctor-categories.ts
@@ -67,11 +67,13 @@ export const BRAIN_CHECK_NAMES: ReadonlySet<string> = new Set([
   'cross_modal_modality_backfill',
   'cycle_freshness',
   'effective_date_health',
+  'embed_staleness',
   'embedding_column_registry',
   'embedding_env_override',
   'embedding_provider',
   'embedding_width_consistency',
   'embeddings',
+  'entity_link_coverage',
   'eval_drift',
   'extract_atoms_backlog',
   'extract_health',
@@ -101,7 +103,9 @@ export const BRAIN_CHECK_NAMES: ReadonlySet<string> = new Set([
   'stub_guard_24h',
   'sync_failures',
   'sync_freshness',
+  'takes_count',
   'takes_weight_grid',
+  'timeline_coverage',
   'unified_multimodal_coverage',
   'voice_gate_health',
 ]);
@@ -165,14 +169,17 @@ export const OPS_CHECK_NAMES: ReadonlySet<string> = new Set([
  */
 export const META_CHECK_NAMES: ReadonlySet<string> = new Set([
   'cycle_phase_scope',
+  'dangling_aliases',
   'eval_capture',
   'minions_migration',
   'multi_source_drift',
+  'pack_upgrade_available',
   'schema_pack_active',
   'schema_pack_consistency',
   'schema_pack_source_drift',
   'schema_version',
   'slug_fallback_audit',
+  'type_proliferation',
   'upgrade_errors',
 ]);
 

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -28,7 +28,7 @@ import { ensureWellFormed } from './text-safe.ts';
  * OR updated_at > links_extracted_at`. It is an ISO-8601 string (NOT a number) —
  * the column is TIMESTAMPTZ and the predicate binds it as `::timestamptz`.
  */
-export const LINK_EXTRACTOR_VERSION_TS = '2026-05-31T00:00:00Z';
+export const LINK_EXTRACTOR_VERSION_TS = '2026-06-11T00:00:00Z';
 
 // ─── Entity references ──────────────────────────────────────────
 
@@ -1100,9 +1100,9 @@ export interface TimelineCandidate {
   detail: string;
 }
 
-// Match: `- **YYYY-MM-DD** | summary` or `- **YYYY-MM-DD** -- summary`
-// or `- **YYYY-MM-DD** - summary` or just `**YYYY-MM-DD** | summary`.
-const TIMELINE_LINE_RE = /^\s*-?\s*\*\*(\d{4}-\d{2}-\d{2})\*\*\s*[|\-–—]+\s*(.+?)\s*$/;
+// Match canonical `- **YYYY-MM-DD** | summary` and the repo-template legacy
+// form `- YYYY-MM-DD: summary`.
+const TIMELINE_LINE_RE = /^\s*-?\s*(?:\*\*)?(\d{4}-\d{2}-\d{2})(?:\*\*)?\s*(?:\||:|--|---|[–—-])\s*(.+?)\s*$/;
 
 /**
  * Parse timeline entries from content. Looks at:

--- a/test/doctor-categories.test.ts
+++ b/test/doctor-categories.test.ts
@@ -1,7 +1,7 @@
 /**
  * Drift guard for src/core/doctor-categories.ts.
  *
- * Reads src/commands/doctor.ts source via a literal-string scan, enumerates
+ * Reads doctor-surface source files via a literal-string scan, enumerates
  * every `name: '<...>'` Check name, and asserts each appears in exactly ONE
  * category set. The union of the four sets must equal the discovered names
  * exactly — no orphans, no extras.
@@ -25,9 +25,9 @@ import {
 } from '../src/core/doctor-categories.ts';
 
 const DOCTOR_TS_PATH = join(import.meta.dir, '..', 'src', 'commands', 'doctor.ts');
+const ONBOARD_CHECKS_TS_PATH = join(import.meta.dir, '..', 'src', 'core', 'onboard', 'checks.ts');
 
-function enumerateCheckNames(): Set<string> {
-  const source = readFileSync(DOCTOR_TS_PATH, 'utf-8');
+function enumerateCheckNamesFromSource(source: string): Set<string> {
   const names = new Set<string>();
   // 1) Inline object-literal form: `{ name: 'foo', ... }`.
   for (const m of source.matchAll(/name:\s*['"]([a-z][a-z0-9_]+)['"]/g)) {
@@ -43,8 +43,18 @@ function enumerateCheckNames(): Set<string> {
   return names;
 }
 
+function enumerateCheckNames(): Set<string> {
+  const names = new Set<string>();
+  for (const path of [DOCTOR_TS_PATH, ONBOARD_CHECKS_TS_PATH]) {
+    for (const name of enumerateCheckNamesFromSource(readFileSync(path, 'utf-8'))) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
 describe('doctor-categories drift guard', () => {
-  test('every check name in doctor.ts source belongs to exactly one category set', () => {
+  test('every doctor-surface check name belongs to exactly one category set', () => {
     const discovered = enumerateCheckNames();
     const allCategorized = new Set<string>([
       ...BRAIN_CHECK_NAMES,
@@ -59,7 +69,7 @@ describe('doctor-categories drift guard', () => {
     }
     if (missing.length > 0) {
       throw new Error(
-        `These check names appear in doctor.ts but are not categorized in ` +
+        `These check names appear in doctor-surface code but are not categorized in ` +
           `src/core/doctor-categories.ts: ${missing.sort().join(', ')}. ` +
           `Add each to BRAIN/SKILL/OPS/META_CHECK_NAMES.`,
       );
@@ -106,7 +116,7 @@ describe('doctor-categories drift guard', () => {
     // refactors require more headroom.
     if (stale.length > 2) {
       throw new Error(
-        `These categorized names no longer appear in doctor.ts: ${stale.sort().join(', ')}. ` +
+        `These categorized names no longer appear in doctor-surface code: ${stale.sort().join(', ')}. ` +
           `Remove them from src/core/doctor-categories.ts.`,
       );
     }
@@ -121,6 +131,9 @@ describe('categorizeCheck', () => {
   test('returns the right category for a known brain name', () => {
     expect(categorizeCheck('embedding_provider')).toBe('brain');
     expect(categorizeCheck('graph_coverage')).toBe('brain');
+    expect(categorizeCheck('entity_link_coverage')).toBe('brain');
+    expect(categorizeCheck('timeline_coverage')).toBe('brain');
+    expect(categorizeCheck('takes_count')).toBe('brain');
     expect(categorizeCheck('sync_freshness')).toBe('brain');
   });
 
@@ -137,6 +150,9 @@ describe('categorizeCheck', () => {
 
   test('returns the right category for a known meta name', () => {
     expect(categorizeCheck('schema_version')).toBe('meta');
+    expect(categorizeCheck('pack_upgrade_available')).toBe('meta');
+    expect(categorizeCheck('type_proliferation')).toBe('meta');
+    expect(categorizeCheck('dangling_aliases')).toBe('meta');
     expect(categorizeCheck('upgrade_errors')).toBe('meta');
   });
 

--- a/test/extract-incremental.test.ts
+++ b/test/extract-incremental.test.ts
@@ -120,6 +120,21 @@ describe('runExtractCore — incremental cycle path (#417)', () => {
     expect(result.timeline_entries_created).toBe(0);
   });
 
+  test('5b. mode: timeline extracts repo-template date-colon bullets', async () => {
+    const body = '# alice\n\n## Timeline\n- 2026-01-01: started [Source: test]';
+    await seedPage('people/alice-example', body);
+    const result = await runExtractCore(engine as unknown as BrainEngine, {
+      mode: 'timeline',
+      dir: tempDir,
+      slugs: ['people/alice-example'],
+    });
+
+    expect(result.timeline_entries_created).toBe(1);
+    const timeline = await engine.getTimeline('people/alice-example');
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0].summary).toBe('started [Source: test]');
+  });
+
   test('6. dryRun: true does not invoke addLinksBatch / addTimelineEntriesBatch', async () => {
     await seedPage('people/alice-example', '# alice\n\n[bob](people/bob-example)');
     await seedPage('people/bob-example', '# bob');

--- a/test/extract-stale.test.ts
+++ b/test/extract-stale.test.ts
@@ -135,6 +135,19 @@ describe('gbrain extract --stale', () => {
     expect(stamp1).not.toBeNull();
   });
 
+  test('historical pages older than extractor version clear after --stale', async () => {
+    await engine.putPage('people/alice', personPage('Alice'));
+    await engine.executeRaw(`UPDATE pages SET updated_at = '2026-01-01T00:00:00Z' WHERE slug = 'people/alice'`);
+    expect(await engine.countStalePagesForExtraction({ versionTs: LINK_EXTRACTOR_VERSION_TS })).toBe(1);
+
+    await runExtract(engine, ['--stale']);
+
+    expect(await engine.countStalePagesForExtraction({ versionTs: LINK_EXTRACTOR_VERSION_TS })).toBe(0);
+    const stamp = await stampOf('people/alice');
+    expect(stamp).not.toBeNull();
+    expect(Date.parse(stamp!)).toBeGreaterThanOrEqual(Date.parse(LINK_EXTRACTOR_VERSION_TS));
+  });
+
   test('--dry-run reports count and writes nothing', async () => {
     await engine.putPage('people/alice', personPage('Alice'));
     await engine.putPage('companies/acme', companyPage('Acme', '[Alice](people/alice) joined [Acme](companies/acme).'));

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -685,14 +685,21 @@ describe('parseTimelineEntries', () => {
     expect(entries.length).toBe(1);
   });
 
+  test('parses repo-template legacy format: - YYYY-MM-DD: summary', () => {
+    const entries = parseTimelineEntries('- 2026-05-31: Event. [Source: Discord]');
+    expect(entries.length).toBe(1);
+    expect(entries[0]).toEqual({ date: '2026-05-31', summary: 'Event. [Source: Discord]', detail: '' });
+  });
+
   test('parses multiple entries', () => {
     const content = `## Timeline
 - **2026-01-15** | First event
+- 2026-02-20: Second event
 - **2026-02-20** | Second event
 - **2026-03-10** | Third event`;
     const entries = parseTimelineEntries(content);
-    expect(entries.length).toBe(3);
-    expect(entries.map(e => e.date)).toEqual(['2026-01-15', '2026-02-20', '2026-03-10']);
+    expect(entries.length).toBe(4);
+    expect(entries.map(e => e.date)).toEqual(['2026-01-15', '2026-02-20', '2026-02-20', '2026-03-10']);
   });
 
   test('skips invalid dates (2026-13-45)', () => {
@@ -1264,4 +1271,3 @@ describe("v0.18.0 migration v22 — links_resolution_type", () => {
     expect(v22!.sql).toContain("unqualified");
   });
 });
-


### PR DESCRIPTION
## Summary
- stamp historical stale pages at the extractor-version watermark so the version arm clears without hiding concurrent edits
- parse legacy repo-template timeline bullets like - YYYY-MM-DD: summary
- include onboard/doctor health checks in category drift coverage

## Tests
- bun test test/doctor-categories.test.ts test/extract-incremental.test.ts test/extract-stale.test.ts test/link-extraction.test.ts: 160 pass, 0 fail