### PR TITLE
fix(pglite): heartbeat file lock without stealing live holders (#2058)

### DIFF
--- a/src/core/pglite-lock.ts
+++ b/src/core/pglite-lock.ts
@@ -14,16 +14,48 @@
  *   try { ... } finally { await releaseLock(lock); }
  */
 
-import { mkdirSync, existsSync, readFileSync, writeFileSync, rmSync, statSync } from 'fs';
+import { randomBytes } from 'crypto';
+import { mkdirSync, existsSync, readFileSync, writeFileSync, rmSync, statSync, renameSync } from 'fs';
+import { hostname } from 'os';
 import { join } from 'path';
 
 const LOCK_DIR_NAME = '.gbrain-lock';
 const LOCK_FILE = 'lock';
 const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes — embed jobs can be long
+const HEARTBEAT_INTERVAL_MS = 60 * 1000;
+const INIT_GRACE_MS = 1000;
+const DEAD_PID_GRACE_MS = 60 * 1000;
+const WAIT_RETRY_MS = 50;
+
+type ProcessState = 'alive' | 'dead' | 'unknown';
+
+interface LockRecord {
+  pid: number;
+  acquired_at: number;
+  command?: string;
+  owner_id?: string;
+  host?: string;
+  last_refreshed_at?: number;
+}
+
+interface AcquireLockOpts {
+  timeoutMs?: number;
+  heartbeatIntervalMs?: number;
+  staleThresholdMs?: number;
+  initGraceMs?: number;
+  deadPidGraceMs?: number;
+  now?: () => number;
+  isProcessAlive?: (pid: number) => ProcessState;
+  host?: string;
+}
 
 export interface LockHandle {
   lockDir: string;
   acquired: boolean;
+  ownerId?: string;
+  pid?: number;
+  host?: string;
+  heartbeat?: ReturnType<typeof setInterval>;
 }
 
 function getLockDir(dataDir: string | undefined): string {
@@ -36,14 +68,128 @@ function getLockDir(dataDir: string | undefined): string {
   return join(dataDir, LOCK_DIR_NAME);
 }
 
-function isProcessAlive(pid: number): boolean {
+function defaultProcessState(pid: number): ProcessState {
   try {
     // Sending signal 0 checks existence without actually sending a signal
     process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
+    return 'alive';
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ESRCH') return 'dead';
+    // EPERM means the process exists but this user cannot signal it.
+    if (code === 'EPERM') return 'alive';
+    return 'unknown';
   }
+}
+
+function ownerId(): string {
+  return `${process.pid}-${randomBytes(8).toString('hex')}`;
+}
+
+function lockPath(lockDir: string): string {
+  return join(lockDir, LOCK_FILE);
+}
+
+function readLockRecord(lockDir: string): LockRecord | null {
+  try {
+    const parsed = JSON.parse(readFileSync(lockPath(lockDir), 'utf-8')) as Partial<LockRecord>;
+    if (
+      typeof parsed.pid === 'number' &&
+      typeof parsed.acquired_at === 'number' &&
+      (parsed.owner_id === undefined || typeof parsed.owner_id === 'string') &&
+      (parsed.host === undefined || typeof parsed.host === 'string') &&
+      (parsed.last_refreshed_at === undefined || typeof parsed.last_refreshed_at === 'number') &&
+      (parsed.command === undefined || typeof parsed.command === 'string')
+    ) {
+      return parsed as LockRecord;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeLockRecordAtomic(lockDir: string, record: LockRecord): void {
+  const tempPath = join(lockDir, `${LOCK_FILE}.${process.pid}.${record.owner_id ?? 'unknown'}.tmp`);
+  writeFileSync(tempPath, JSON.stringify(record), { mode: 0o644 });
+  renameSync(tempPath, lockPath(lockDir));
+}
+
+function sameOwner(record: LockRecord | null, lock: LockHandle): boolean {
+  return !!(
+    record &&
+    lock.ownerId &&
+    record.owner_id === lock.ownerId &&
+    record.pid === lock.pid &&
+    record.host === lock.host
+  );
+}
+
+function lockDirAgeMs(lockDir: string, now: number): number {
+  try {
+    return Math.max(0, now - statSync(lockDir).mtimeMs);
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+function quarantineAndRemoveLockDir(lockDir: string): void {
+  const quarantineDir = `${lockDir}.reap.${process.pid}.${Date.now()}.${randomBytes(4).toString('hex')}`;
+  try {
+    renameSync(lockDir, quarantineDir);
+  } catch {
+    // Missing or raced with another waiter; retry the acquire loop.
+    return;
+  }
+  try {
+    rmSync(quarantineDir, { recursive: true, force: true });
+  } catch {
+    // A quarantine directory is no longer an active lock; best-effort cleanup.
+  }
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function describeHolder(record: LockRecord | null, now: number): string {
+  if (!record) return 'metadata is missing or corrupt';
+  const refreshed = record.last_refreshed_at ?? record.acquired_at;
+  const refreshedAge = Math.max(0, now - refreshed);
+  const parts = [
+    `pid ${record.pid}`,
+    `host ${record.host ?? 'unknown'}`,
+    `held since ${new Date(record.acquired_at).toISOString()}`,
+    `last refreshed ${Math.round(refreshedAge / 1000)}s ago`,
+  ];
+  if (record.command) parts.push(`command: ${record.command}`);
+  return parts.join(', ');
+}
+
+function refreshLock(lock: LockHandle, now: () => number): boolean {
+  if (!lock.lockDir || !lock.acquired) return false;
+  const current = readLockRecord(lock.lockDir);
+  if (!current || !sameOwner(current, lock)) return false;
+  writeLockRecordAtomic(lock.lockDir, {
+    ...current,
+    last_refreshed_at: now(),
+  });
+  return true;
+}
+
+function startHeartbeat(lock: LockHandle, intervalMs: number, now: () => number): ReturnType<typeof setInterval> | undefined {
+  if (!lock.lockDir || !lock.acquired || intervalMs <= 0) return undefined;
+  let timer: ReturnType<typeof setInterval>;
+  timer = setInterval(() => {
+    try {
+      if (!refreshLock(lock, now)) clearInterval(timer);
+    } catch {
+      // The heartbeat is best-effort; the next waiter will fail closed unless
+      // the holder is provably dead.
+    }
+  }, intervalMs);
+  (timer as unknown as { unref?: () => void }).unref?.();
+  return timer;
 }
 
 /**
@@ -51,7 +197,7 @@ function isProcessAlive(pid: number): boolean {
  * Returns { acquired: true } if the lock was obtained, { acquired: false } otherwise.
  * Stale locks (from dead processes) are automatically cleaned up.
  */
-export async function acquireLock(dataDir: string | undefined, opts?: { timeoutMs?: number }): Promise<LockHandle> {
+export async function acquireLock(dataDir: string | undefined, opts: AcquireLockOpts = {}): Promise<LockHandle> {
   const lockDir = getLockDir(dataDir);
 
   // In-memory PGLite — no lock needed (process-scoped, can't be shared)
@@ -63,75 +209,91 @@ export async function acquireLock(dataDir: string | undefined, opts?: { timeoutM
   // can't derive that across helper boundaries.
   mkdirSync(dataDir as string, { recursive: true });
 
-  const timeoutMs = opts?.timeoutMs ?? 30_000; // 30 second default timeout
+  const timeoutMs = opts.timeoutMs ?? 30_000; // 30 second default timeout
+  const heartbeatIntervalMs = opts.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS;
+  const staleThresholdMs = opts.staleThresholdMs ?? STALE_THRESHOLD_MS;
+  const initGraceMs = opts.initGraceMs ?? INIT_GRACE_MS;
+  const deadPidGraceMs = opts.deadPidGraceMs ?? DEAD_PID_GRACE_MS;
+  const now = opts.now ?? Date.now;
+  const host = opts.host ?? hostname();
+  const processState = opts.isProcessAlive ?? defaultProcessState;
   const startTime = Date.now();
+  let lastSeen: LockRecord | null = null;
 
   while (Date.now() - startTime < timeoutMs) {
-    // Check for stale lock first
     if (existsSync(lockDir)) {
-      const lockPath = join(lockDir, LOCK_FILE);
-      try {
-        const lockData = JSON.parse(readFileSync(lockPath, 'utf-8'));
-        const lockPid = lockData.pid as number;
-        const lockTime = lockData.acquired_at as number;
+      const record = readLockRecord(lockDir);
+      lastSeen = record;
+      const currentNow = now();
 
-        // Is the locking process still alive?
-        if (!isProcessAlive(lockPid)) {
-          // Stale lock — clean it up
-          try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition, try again */ }
-        } else if (Date.now() - lockTime > STALE_THRESHOLD_MS) {
-          // Lock held for too long — assume stale (e.g., process hung)
-          // Still alive but probably stuck — force remove
-          try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition */ }
-        } else {
-          // Lock is held by a live process — wait and retry
-          await new Promise(r => setTimeout(r, 1000));
+      if (!record) {
+        if (lockDirAgeMs(lockDir, currentNow) >= initGraceMs) {
+          quarantineAndRemoveLockDir(lockDir);
           continue;
         }
-      } catch {
-        // Corrupt lock file — remove it
-        try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition */ }
+        await wait(Math.min(WAIT_RETRY_MS, Math.max(1, timeoutMs - (Date.now() - startTime))));
+        continue;
       }
+
+      const sameHost = !record.host || record.host === host;
+      const holderState = sameHost ? processState(record.pid) : 'alive';
+      const deadEligible = holderState === 'dead' && currentNow - record.acquired_at >= deadPidGraceMs;
+
+      if (deadEligible) {
+        quarantineAndRemoveLockDir(lockDir);
+        continue;
+      }
+
+      // A stale heartbeat is diagnostic only for PGLite. A live process may
+      // still have the embedded database open even if its JS timer is starved.
+      const lastRefreshedAt = record.last_refreshed_at ?? record.acquired_at;
+      if (currentNow - lastRefreshedAt > staleThresholdMs) lastSeen = record;
+      await wait(Math.min(WAIT_RETRY_MS, Math.max(1, timeoutMs - (Date.now() - startTime))));
+      continue;
     }
 
     // Try to acquire lock (atomic mkdir)
     try {
       mkdirSync(lockDir, { recursive: false });
-      // We got the lock — write our PID
-      const lockPath = join(lockDir, LOCK_FILE);
-      writeFileSync(lockPath, JSON.stringify({
+      const id = ownerId();
+      const acquiredAt = now();
+      const lock: LockHandle = {
+        lockDir,
+        acquired: true,
+        ownerId: id,
         pid: process.pid,
-        acquired_at: Date.now(),
+        host,
+      };
+      writeLockRecordAtomic(lockDir, {
+        pid: process.pid,
+        host,
+        owner_id: id,
+        acquired_at: acquiredAt,
+        last_refreshed_at: acquiredAt,
         command: process.argv.slice(1).join(' '),
-      }), { mode: 0o644 });
+      });
+      lock.heartbeat = startHeartbeat(lock, heartbeatIntervalMs, now);
 
-      return { lockDir, acquired: true };
+      return lock;
     } catch (e: unknown) {
       // mkdir failed — someone else grabbed it between our check and mkdir
       // This is fine, we'll retry
       if (Date.now() - startTime >= timeoutMs) {
-        // Timeout — report which process holds the lock
-        const lockPath = join(lockDir, LOCK_FILE);
-        try {
-          const lockData = JSON.parse(readFileSync(lockPath, 'utf-8'));
-          throw new Error(
-            `GBrain: Timed out waiting for PGLite lock. Process ${lockData.pid} has held it since ${new Date(lockData.acquired_at).toISOString()} (command: ${lockData.command}). ` +
-            `If that process is dead, remove ${lockDir} and try again.`
-          );
-        } catch (readErr) {
-          if (readErr instanceof Error && readErr.message.startsWith('GBrain')) throw readErr;
-          throw new Error(
-            `GBrain: Timed out waiting for PGLite lock. Remove ${lockDir} and try again.`
-          );
-        }
+        throw new Error(
+          `GBrain: Timed out waiting for PGLite lock (${describeHolder(readLockRecord(lockDir) ?? lastSeen, now())}). ` +
+          `If that process is dead, remove ${lockDir} and try again.`
+        );
       }
       // Brief wait before retry
-      await new Promise(r => setTimeout(r, 500));
+      await wait(Math.min(WAIT_RETRY_MS, Math.max(1, timeoutMs - (Date.now() - startTime))));
     }
   }
 
   // Should not reach here, but just in case
-  throw new Error(`GBrain: Timed out waiting for PGLite lock.`);
+  throw new Error(
+    `GBrain: Timed out waiting for PGLite lock (${describeHolder(readLockRecord(lockDir) ?? lastSeen, now())}). ` +
+    `If that process is dead, remove ${lockDir} and try again.`
+  );
 }
 
 /**
@@ -139,10 +301,13 @@ export async function acquireLock(dataDir: string | undefined, opts?: { timeoutM
  */
 export async function releaseLock(lock: LockHandle): Promise<void> {
   if (!lock.lockDir || !lock.acquired) return;
+  if (lock.heartbeat) clearInterval(lock.heartbeat);
 
   try {
-    rmSync(lock.lockDir, { recursive: true, force: true });
+    const current = readLockRecord(lock.lockDir);
+    if (!sameOwner(current, lock)) return;
+    quarantineAndRemoveLockDir(lock.lockDir);
   } catch {
-    // Lock file already removed (e.g., by stale cleanup) — that's fine
+    // Lock file already removed (e.g., by stale cleanup) — that's fine.
   }
 }

--- a/test/pglite-lock.test.ts
+++ b/test/pglite-lock.test.ts
@@ -5,6 +5,32 @@ import { tmpdir } from 'os';
 import { acquireLock, releaseLock, type LockHandle } from '../src/core/pglite-lock';
 
 const TEST_DIR = join(tmpdir(), 'gbrain-lock-test-' + process.pid);
+const LOCK_DIR = '.gbrain-lock';
+const LOCK_FILE = 'lock';
+
+function lockDir(dir = TEST_DIR): string {
+  return join(dir, LOCK_DIR);
+}
+
+function lockPath(dir = TEST_DIR): string {
+  return join(lockDir(dir), LOCK_FILE);
+}
+
+function seedLock(
+  dir: string,
+  data: Record<string, unknown>,
+): void {
+  mkdirSync(lockDir(dir), { recursive: true });
+  writeFileSync(lockPath(dir), JSON.stringify({
+    owner_id: 'seed-owner',
+    pid: process.pid,
+    host: 'test-host',
+    acquired_at: Date.now(),
+    last_refreshed_at: Date.now(),
+    command: 'seeded-test-lock',
+    ...data,
+  }));
+}
 
 describe('pglite-lock', () => {
   beforeEach(() => {
@@ -20,10 +46,10 @@ describe('pglite-lock', () => {
   test('acquires and releases lock', async () => {
     const lock = await acquireLock(TEST_DIR);
     expect(lock.acquired).toBe(true);
-    expect(existsSync(join(TEST_DIR, '.gbrain-lock'))).toBe(true);
+    expect(existsSync(lockDir())).toBe(true);
 
     await releaseLock(lock);
-    expect(existsSync(join(TEST_DIR, '.gbrain-lock'))).toBe(false);
+    expect(existsSync(lockDir())).toBe(false);
   });
 
   test('creates missing data directory before acquiring lock', async () => {
@@ -32,10 +58,10 @@ describe('pglite-lock', () => {
     const lock = await acquireLock(missingDataDir);
     expect(lock.acquired).toBe(true);
     expect(existsSync(missingDataDir)).toBe(true);
-    expect(existsSync(join(missingDataDir, '.gbrain-lock'))).toBe(true);
+    expect(existsSync(lockDir(missingDataDir))).toBe(true);
 
     await releaseLock(lock);
-    expect(existsSync(join(missingDataDir, '.gbrain-lock'))).toBe(false);
+    expect(existsSync(lockDir(missingDataDir))).toBe(false);
   });
 
   test('prevents concurrent lock acquisition', async () => {
@@ -50,17 +76,189 @@ describe('pglite-lock', () => {
 
   test('detects and cleans stale lock from dead process', async () => {
     // Simulate a stale lock from a dead process
-    const lockDir = join(TEST_DIR, '.gbrain-lock');
-    mkdirSync(lockDir);
-    writeFileSync(join(lockDir, 'lock'), JSON.stringify({
+    seedLock(TEST_DIR, {
       pid: 999999999, // Non-existent PID
       acquired_at: Date.now(),
-      command: 'test',
-    }));
+      last_refreshed_at: Date.now(),
+    });
 
     // Should clean up the stale lock and acquire
-    const lock = await acquireLock(TEST_DIR);
+    const lock = await acquireLock(TEST_DIR, {
+      deadPidGraceMs: 0,
+      host: 'test-host',
+      isProcessAlive: () => 'dead',
+    });
     expect(lock.acquired).toBe(true);
+
+    await releaseLock(lock);
+  });
+
+  test('does not steal live lock with old acquire time and fresh heartbeat', async () => {
+    const now = Date.now();
+    seedLock(TEST_DIR, {
+      pid: process.pid,
+      acquired_at: now - 10 * 60_000,
+      last_refreshed_at: now,
+    });
+
+    await expect(acquireLock(TEST_DIR, {
+      timeoutMs: 20,
+      staleThresholdMs: 5 * 60_000,
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+      isProcessAlive: () => 'alive',
+      now: () => now,
+    })).rejects.toThrow(/Timed out/);
+    expect(existsSync(lockDir())).toBe(true);
+    const current = JSON.parse(readFileSync(lockPath(), 'utf-8'));
+    expect(current.owner_id).toBe('seed-owner');
+  });
+
+  test('does not steal live lock with stale heartbeat', async () => {
+    const now = Date.now();
+    seedLock(TEST_DIR, {
+      pid: process.pid,
+      acquired_at: now - 20 * 60_000,
+      last_refreshed_at: now - 10 * 60_000,
+    });
+
+    await expect(acquireLock(TEST_DIR, {
+      timeoutMs: 20,
+      staleThresholdMs: 5 * 60_000,
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+      isProcessAlive: () => 'alive',
+      now: () => now,
+    })).rejects.toThrow(/Timed out/);
+    expect(JSON.parse(readFileSync(lockPath(), 'utf-8')).owner_id).toBe('seed-owner');
+  });
+
+  test('does not force-steal old-format live lock without heartbeat metadata', async () => {
+    const now = Date.now();
+    mkdirSync(lockDir(), { recursive: true });
+    writeFileSync(lockPath(), JSON.stringify({
+      pid: process.pid,
+      acquired_at: now - 10 * 60_000,
+      command: 'legacy-lock',
+    }));
+
+    await expect(acquireLock(TEST_DIR, {
+      timeoutMs: 20,
+      staleThresholdMs: 5 * 60_000,
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+      isProcessAlive: () => 'alive',
+      now: () => now,
+    })).rejects.toThrow(/Timed out/);
+    const current = JSON.parse(readFileSync(lockPath(), 'utf-8'));
+    expect(current.command).toBe('legacy-lock');
+  });
+
+  test('does not clean dead pid inside grace window', async () => {
+    const now = Date.now();
+    seedLock(TEST_DIR, {
+      pid: 999999999,
+      acquired_at: now - 1000,
+      last_refreshed_at: now - 1000,
+    });
+
+    await expect(acquireLock(TEST_DIR, {
+      timeoutMs: 20,
+      deadPidGraceMs: 60_000,
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+      isProcessAlive: () => 'dead',
+      now: () => now,
+    })).rejects.toThrow(/Timed out/);
+    expect(JSON.parse(readFileSync(lockPath(), 'utf-8')).owner_id).toBe('seed-owner');
+  });
+
+  test('treats unknown pid probe result as unsafe to steal', async () => {
+    const now = Date.now();
+    seedLock(TEST_DIR, {
+      pid: 999999999,
+      acquired_at: now - 20 * 60_000,
+      last_refreshed_at: now - 20 * 60_000,
+    });
+
+    await expect(acquireLock(TEST_DIR, {
+      timeoutMs: 20,
+      deadPidGraceMs: 0,
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+      isProcessAlive: () => 'unknown',
+      now: () => now,
+    })).rejects.toThrow(/Timed out/);
+    expect(JSON.parse(readFileSync(lockPath(), 'utf-8')).owner_id).toBe('seed-owner');
+  });
+
+  test('treats EPERM-equivalent pid probe result as alive', async () => {
+    const now = Date.now();
+    seedLock(TEST_DIR, {
+      pid: 999999999,
+      acquired_at: now - 20 * 60_000,
+      last_refreshed_at: now - 20 * 60_000,
+    });
+
+    await expect(acquireLock(TEST_DIR, {
+      timeoutMs: 20,
+      deadPidGraceMs: 0,
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+      isProcessAlive: () => 'alive',
+      now: () => now,
+    })).rejects.toThrow(/Timed out/);
+    expect(JSON.parse(readFileSync(lockPath(), 'utf-8')).owner_id).toBe('seed-owner');
+  });
+
+  test('does not steal cross-host lock', async () => {
+    const now = Date.now();
+    seedLock(TEST_DIR, {
+      pid: 999999999,
+      host: 'other-host',
+      acquired_at: now - 20 * 60_000,
+      last_refreshed_at: now - 20 * 60_000,
+    });
+
+    await expect(acquireLock(TEST_DIR, {
+      timeoutMs: 20,
+      deadPidGraceMs: 0,
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+      isProcessAlive: () => 'dead',
+      now: () => now,
+    })).rejects.toThrow(/Timed out/);
+    expect(JSON.parse(readFileSync(lockPath(), 'utf-8')).host).toBe('other-host');
+  });
+
+  test('does not remove fresh missing metadata during initialization grace', async () => {
+    const now = Date.now();
+    mkdirSync(lockDir(), { recursive: true });
+
+    await expect(acquireLock(TEST_DIR, {
+      timeoutMs: 20,
+      initGraceMs: 60_000,
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+      now: () => now,
+    })).rejects.toThrow(/Timed out/);
+    expect(existsSync(lockDir())).toBe(true);
+  });
+
+  test('recovers old corrupt metadata as orphaned', async () => {
+    const now = Date.now();
+    mkdirSync(lockDir(), { recursive: true });
+    writeFileSync(lockPath(), 'not-json');
+
+    const lock = await acquireLock(TEST_DIR, {
+      timeoutMs: 100,
+      initGraceMs: 0,
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+      now: () => now,
+    });
+    expect(lock.acquired).toBe(true);
+    expect(JSON.parse(readFileSync(lockPath(), 'utf-8')).owner_id).toBeDefined();
 
     await releaseLock(lock);
   });
@@ -75,14 +273,85 @@ describe('pglite-lock', () => {
   });
 
   test('lock file contains PID and command', async () => {
-    const lock = await acquireLock(TEST_DIR);
-    const lockData = JSON.parse(readFileSync(join(TEST_DIR, '.gbrain-lock', 'lock'), 'utf-8'));
+    const lock = await acquireLock(TEST_DIR, {
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+    });
+    const lockData = JSON.parse(readFileSync(lockPath(), 'utf-8'));
 
     expect(lockData.pid).toBe(process.pid);
+    expect(lockData.host).toBe('test-host');
+    expect(lockData.owner_id).toBeDefined();
     expect(lockData.acquired_at).toBeDefined();
+    expect(lockData.last_refreshed_at).toBeDefined();
     expect(lockData.command).toBeDefined();
 
     await releaseLock(lock);
+  });
+
+  test('heartbeat refreshes last_refreshed_at and stops after release', async () => {
+    let now = 1000;
+    const lock = await acquireLock(TEST_DIR, {
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+      now: () => now,
+    });
+    const initial = JSON.parse(readFileSync(lockPath(), 'utf-8'));
+    expect(initial.last_refreshed_at).toBe(1000);
+
+    now = 2000;
+    await new Promise(resolve => setTimeout(resolve, 20));
+    const refreshed = JSON.parse(readFileSync(lockPath(), 'utf-8'));
+    expect(refreshed.last_refreshed_at).toBe(2000);
+
+    await releaseLock(lock);
+    expect(existsSync(lockDir())).toBe(false);
+  });
+
+  test('release does not remove same-pid different-owner lock', async () => {
+    const lock = await acquireLock(TEST_DIR, {
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+    });
+    const replacement = {
+      pid: process.pid,
+      host: 'test-host',
+      owner_id: 'different-owner',
+      acquired_at: Date.now(),
+      last_refreshed_at: Date.now(),
+      command: 'replacement-owner',
+    };
+    writeFileSync(lockPath(), JSON.stringify(replacement));
+
+    await releaseLock(lock);
+    expect(existsSync(lockDir())).toBe(true);
+    expect(JSON.parse(readFileSync(lockPath(), 'utf-8')).owner_id).toBe('different-owner');
+  });
+
+  test('release is a no-op for corrupt, missing-file, and missing-directory locks', async () => {
+    const corruptLock = await acquireLock(TEST_DIR, {
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+    });
+    writeFileSync(lockPath(), 'not-json');
+
+    await releaseLock(corruptLock);
+    expect(existsSync(lockDir())).toBe(true);
+
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    mkdirSync(TEST_DIR, { recursive: true });
+    const missingFileLock = await acquireLock(TEST_DIR, {
+      heartbeatIntervalMs: 5,
+      host: 'test-host',
+    });
+    rmSync(lockPath(), { force: true });
+
+    await releaseLock(missingFileLock);
+    expect(existsSync(lockDir())).toBe(true);
+
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    await releaseLock(missingFileLock);
+    expect(existsSync(lockDir())).toBe(false);
   });
 
   test('releases lock on disconnect even if DB close fails', async () => {
@@ -91,7 +360,7 @@ describe('pglite-lock', () => {
 
     // Simulate DB already closed
     await releaseLock(lock);
-    expect(existsSync(join(TEST_DIR, '.gbrain-lock'))).toBe(false);
+    expect(existsSync(lockDir())).toBe(false);
 
     // Second acquisition should work
     const lock2 = await acquireLock(TEST_DIR);


### PR DESCRIPTION
## What & why

Closes #2058.

The current PGLite lock can remove a lock from a still-live holder once `acquired_at` crosses the stale threshold. That is unsafe for embedded PGLite: a paused or starved process can still hold open database files even if its JS timers are not making progress, so a second process deleting the lock can recreate concurrent access/WAL corruption risk.

Before this PR, a second process could delete a live holder's lock after five minutes. After this PR, stale heartbeat metadata is diagnostic only; the lock is not recovered unless the same-host PID is provably dead and past a short PID-reuse grace window, or the lock directory is an old orphan with missing/corrupt metadata.


## Why this shape

This intentionally does not use a stale heartbeat as a takeover signal. For PGLite, a starved or paused JS process can still hold database files open, so heartbeat age is useful diagnostic data but not proof that it is safe for another process to enter.

The safety choices here are meant to close the race windows around that:

- `owner_id` prevents an old handle from releasing a newer lock created by the same PID.
- `last_refreshed_at` gives waiters better diagnostics without becoming an unsafe steal condition.
- Same-host dead-PID recovery keeps normal crash recovery working, but the short grace window reduces PID-reuse risk.
- Cross-host, `EPERM`, and unknown PID-probe results fail closed because they cannot prove the holder is gone.
- Quarantine rename avoids deleting the active lock directory after reading stale metadata.

## The fix

- Add per-acquisition ownership metadata: `owner_id`, `pid`, `host`, `acquired_at`, `last_refreshed_at`, and `command`.
- Add an owner-checked heartbeat that refreshes `last_refreshed_at` via temp-file write plus atomic rename.
- Fail closed for live PIDs, stale heartbeats, cross-host metadata, `EPERM`, and unknown PID probe results.
- Recover only dead same-host PIDs after a grace window, or old missing/corrupt orphan metadata after initialization grace.
- Replace direct lock-directory deletion during recovery with an atomic quarantine rename followed by best-effort removal.
- Make release owner-checked so a stale handle cannot remove a replacement lock from the same PID.

## Scope decisions

- No release metadata (`VERSION`, `CHANGELOG.md`, `package.json`).
- No public exports, CLI flags, docs, or generated `llms` files.
- No changes to `db-lock.ts` or `pglite-engine.ts`.
- Test seams are internal to `acquireLock` options only.

## Tests

Added deterministic coverage for:

- live PID with old `acquired_at` and fresh `last_refreshed_at` is not stolen
- live PID with stale `last_refreshed_at` is not stolen
- old-format live lock without heartbeat metadata is not force-stolen
- dead same-host PID past grace is cleaned up
- dead same-host PID inside grace is not cleaned up
- unknown and EPERM-equivalent PID probe results are treated as unsafe/alive
- cross-host locks are not auto-stolen
- fresh missing metadata inside initialization grace is not removed
- old corrupt metadata is recovered as orphaned
- acquired locks write `owner_id`, `host`, and `last_refreshed_at`
- heartbeat refreshes `last_refreshed_at` and stops after release
- release removes own lock
- release does not remove same-PID different-owner lock
- release no-ops for corrupt, missing-file, and missing-directory lock state

## Verification

- `bun test test/pglite-lock.test.ts` — 19 pass, 0 fail
- Docker: `docker compose -f docker-compose.ci.yml run --rm --no-deps runner bash -lc 'bun test test/pglite-lock.test.ts'` — 19 pass, 0 fail
- `bun run typecheck` — pass
- `bun run verify` — 30 pass, 0 fail
- `gitleaks detect --source . --redact --no-banner` — no leaks found

I also ran `bun run ci:local -- --no-pull` against both this branch and a clean upstream checkout under local Docker/Colima. Both runs reproduced the same current local-Docker baseline failures, including the same `validateUploadPath` fuzz counterexample (`./../../../tmp`) and shard 3 exit 137, so I did not treat that as branch-specific evidence.
