### PR TITLE
feat(oauth): opt-in Google Workspace login gate for the browser authorization_code flow

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2236,6 +2236,11 @@ ADMIN
     --token-ttl N                    Access token TTL in seconds (default: 3600)
     --enable-dcr                     Enable Dynamic Client Registration
     --public-url URL                 Public issuer URL (required behind proxy/tunnel)
+    --oauth-login-hd DOMAIN          Require Google sign-in on this hosted domain
+                                     before /authorize issues a code (opt-in gate)
+    --oauth-google-client-id ID      Google OAuth client id   (required with --oauth-login-hd)
+    --oauth-google-client-secret S   Google OAuth client secret (required with --oauth-login-hd)
+    --oauth-session-secret SECRET    HMAC key for login session+state cookies (required with --oauth-login-hd)
   connect <mcp-url> --token <t>      Wire Claude Code to a remote gbrain (bearer token)
         [--install] [--json]         Print the paste-ready command, or --install to run it
   call <tool> '<json>'               Raw tool invocation

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -27,6 +27,29 @@ import { operations, OperationError } from '../core/operations.ts';
 import type { OperationContext, AuthInfo } from '../core/operations.ts';
 import { GBrainOAuthProvider, validateTokenEndpointAuthMethod } from '../core/oauth-provider.ts';
 import type { SqlQuery } from '../core/oauth-provider.ts';
+import {
+  resolveGoogleLoginConfig,
+  buildGoogleAuthUrl,
+  signState,
+  verifyState,
+  signSession,
+  verifySession,
+  signPkce,
+  verifyPkce,
+  generateCodeVerifier,
+  codeChallengeS256,
+  generateNonce,
+  safeReturnUrl,
+  exchangeGoogleCode,
+  verifyGoogleIdToken,
+  GoogleJwksCache,
+  LOGIN_SESSION_COOKIE,
+  LOGIN_PKCE_COOKIE,
+  SESSION_TTL_SECONDS,
+  STATE_TTL_SECONDS,
+} from '../core/oauth-google-login.ts';
+import type { GoogleLoginConfig } from '../core/oauth-google-login.ts';
+import { randomUUID } from 'crypto';
 import { hasScope, ALLOWED_SCOPES_LIST, normalizeScopesInput } from '../core/scope.ts';
 import { summarizeMcpParams, dispatchToolCall } from '../mcp/dispatch.ts';
 import { paramDefToSchema } from '../mcp/tool-defs.ts';
@@ -299,6 +322,18 @@ interface ServeHttpOptions {
    * tracking the regenerated value through other means.
    */
   suppressBootstrapToken?: boolean;
+  /**
+   * OPT-IN Google-Workspace login gate. The gate is OFF unless
+   * `oauthLoginHd` is set. When set, the browser `authorization_code` flow at
+   * /authorize requires a Google sign-in on the allowed hosted domain before a
+   * code is issued; the remaining three options are then REQUIRED (startup
+   * fails fast otherwise). All four undefined → behavior is byte-for-byte
+   * unchanged. See src/core/oauth-google-login.ts.
+   */
+  oauthLoginHd?: string;
+  oauthGoogleClientId?: string;
+  oauthGoogleClientSecret?: string;
+  oauthSessionSecret?: string;
 }
 
 /**
@@ -407,6 +442,27 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   const bind = options.bind ?? '127.0.0.1';
   const config = loadConfig() || { engine: 'pglite' as const };
 
+  // OPT-IN Google login gate. resolveGoogleLoginConfig returns undefined when
+  // --oauth-login-hd is unset (gate OFF → unchanged behavior); it THROWS when
+  // --oauth-login-hd is set but a required google credential / session secret
+  // is missing, so we surface that as a fail-fast startup error rather than
+  // half-enabling the gate. The throw propagates to the CLI's serve handler.
+  let googleLogin: GoogleLoginConfig | undefined;
+  try {
+    googleLogin = resolveGoogleLoginConfig({
+      oauthLoginHd: options.oauthLoginHd,
+      oauthGoogleClientId: options.oauthGoogleClientId,
+      oauthGoogleClientSecret: options.oauthGoogleClientSecret,
+      oauthSessionSecret: options.oauthSessionSecret,
+    });
+  } catch (e) {
+    console.error(`[serve-http] ${e instanceof Error ? e.message : e}`);
+    process.exit(1);
+  }
+  // Lazy JWKS cache for id_token verification — only instantiated when the
+  // gate is on, so the default path adds zero objects.
+  const jwksCache = googleLogin ? new GoogleJwksCache() : undefined;
+
   if (logFullParams) {
     console.error(
       '[serve-http] WARNING: --log-full-params writes raw request payloads to mcp_request_log + SSE feed. Disable for shared dashboards or production.',
@@ -449,6 +505,13 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
     sql,
     tokenTtl,
     dcrDisabled: !enableDcr,
+    // CRITICAL-1: when the Google login gate is on, harden EVERY DCR
+    // `/register` to public + authorization_code/refresh_token + `read` so a
+    // self-registered client cannot mint a confidential `client_credentials`
+    // admin token that skips `/authorize` (→ the gate). See
+    // GBrainClientsStore.registerClient. Machine clients minted by the operator
+    // via `registerClientManual` are unaffected.
+    loginGateEnabled: googleLogin !== undefined,
   });
 
   // Sweep expired tokens on startup (non-blocking)
@@ -695,6 +758,201 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   // SDK's mcpAuthRouter reads provider.clientsStore once and only wires up
   // /register when the store exposes registerClient — so passing dcrDisabled
   // to the constructor is sufficient. No monkey-patching here.
+
+  // ---------------------------------------------------------------------------
+  // OPT-IN Google-Workspace login gate (src/core/oauth-google-login.ts)
+  // ---------------------------------------------------------------------------
+  // When `googleLogin` is set, the browser `authorization_code` flow at
+  // /authorize must carry a valid login-session cookie. If it doesn't, the gate
+  // captures the original /authorize URL in a signed, expiring state value and
+  // 302-redirects to /login/google. Google signs the user in (constrained to
+  // the allowed hosted domain), redirects back to /login/google/callback, which
+  // verifies the id_token, sets the login-session cookie, and bounces back to
+  // the original /authorize URL — which now passes the gate.
+  //
+  // ALL of this is inert when the gate is off: the middleware below short-
+  // circuits to next() and the two /login/google routes are never reached
+  // (they 404 unless the gate is on). client_credentials never hits /authorize,
+  // so machine-to-machine tokens are entirely unaffected. The public base URL
+  // is derived from issuerUrl (the same source the server uses for the OAuth
+  // issuer / --public-url) — not hardcoded.
+  if (googleLogin) {
+    const cfg = googleLogin;
+    const publicBaseUrl = issuerUrl.origin;
+    const googleRedirectUri = `${publicBaseUrl}/login/google/callback`;
+
+    // Session cookie shares the secure/SameSite posture of the admin cookie,
+    // EXCEPT SameSite=Lax is REQUIRED (not Strict): the cookie must be sent on
+    // the top-level redirect back to /authorize from /login/google/callback. A
+    // Strict cookie would be withheld on that cross-site navigation and the
+    // gate would loop. Path=/ so it's sent to /authorize and the callback.
+    const loginCookieOpts = (req: Request) => ({
+      httpOnly: true as const,
+      sameSite: 'lax' as const,
+      secure: req.secure || issuerUrl.protocol === 'https:',
+      maxAge: SESSION_TTL_SECONDS * 1000,
+      path: '/',
+    });
+
+    // PKCE/nonce cookie posture (MEDIUM-1 + MEDIUM-2): HttpOnly + Secure +
+    // SameSite=Lax (must survive the top-level redirect from Google back to the
+    // callback) + Path scoped to the callback so it's only sent where it's read.
+    // Short maxAge = STATE_TTL_SECONDS — the login round-trip is interactive.
+    const pkceCookieOpts = (req: Request) => ({
+      httpOnly: true as const,
+      sameSite: 'lax' as const,
+      secure: req.secure || issuerUrl.protocol === 'https:',
+      maxAge: STATE_TTL_SECONDS * 1000,
+      path: '/login/google/callback',
+    });
+
+    // Start a Google login: mint a fresh PKCE verifier + nonce, set the signed,
+    // browser-bound PKCE cookie, and redirect to Google's auth endpoint with the
+    // signed state (return_url carrier), the S256 code_challenge, and the nonce.
+    // Binding the verifier+nonce to this browser closes the replayable-state /
+    // session-fixation gap and adds PKCE + OIDC nonce to the gbrain↔Google leg.
+    function startGoogleLogin(req: Request, res: Response, returnUrl: string) {
+      const now = Math.floor(Date.now() / 1000);
+      const verifier = generateCodeVerifier();
+      const nonce = generateNonce();
+      const state = signState(
+        { return_url: returnUrl, nonce: randomUUID(), exp: now + STATE_TTL_SECONDS },
+        cfg.sessionSecret,
+      );
+      const pkce = signPkce({ verifier, nonce, exp: now + STATE_TTL_SECONDS }, cfg.sessionSecret);
+      res.cookie(LOGIN_PKCE_COOKIE, pkce, pkceCookieOpts(req));
+      res.redirect(buildGoogleAuthUrl({
+        clientId: cfg.clientId,
+        redirectUri: googleRedirectUri,
+        hd: cfg.hd,
+        state,
+        codeChallenge: codeChallengeS256(verifier),
+        nonce,
+      }));
+    }
+
+    // Gate middleware — register BEFORE mcpAuthRouter so it runs ahead of the
+    // SDK's /authorize handler. Only gates /authorize; every other route
+    // (including /token, /register, /mcp) is untouched.
+    app.use('/authorize', (req: Request, res: Response, next: NextFunction) => {
+      const cookie = (req.cookies as Record<string, string> | undefined)?.[LOGIN_SESSION_COOKIE];
+      const session = verifySession(cookie, cfg.sessionSecret);
+      if (session) return next();
+
+      // No valid session — start the Google login. Capture the full original
+      // /authorize URL (path + query) so we can return to it afterward.
+      startGoogleLogin(req, res, req.originalUrl);
+    });
+
+    // GET /login/google — explicit entry point (also reachable directly). Mints
+    // a fresh state with no return_url constraint beyond /authorize and
+    // redirects to Google. Used when an operator hits the login URL directly;
+    // the gate path above normally redirects straight to Google itself.
+    app.get('/login/google', (req: Request, res: Response) => {
+      const rawReturn = typeof req.query.return_url === 'string' ? req.query.return_url : '/authorize';
+      const returnUrl = safeReturnUrl(rawReturn, publicBaseUrl) ? rawReturn : '/authorize';
+      startGoogleLogin(req, res, returnUrl);
+    });
+
+    // GET /login/google/callback — Google redirects here with code + state.
+    app.get('/login/google/callback', async (req: Request, res: Response) => {
+      // Clear the browser-bound PKCE cookie regardless of outcome — it is
+      // single-use. Same path/flags as when it was set so the clear actually
+      // matches the cookie.
+      const clearPkceCookie = () =>
+        res.clearCookie(LOGIN_PKCE_COOKIE, {
+          httpOnly: true,
+          sameSite: 'lax',
+          secure: req.secure || issuerUrl.protocol === 'https:',
+          path: '/login/google/callback',
+        });
+      try {
+        const state = verifyState(
+          typeof req.query.state === 'string' ? req.query.state : undefined,
+          cfg.sessionSecret,
+        );
+        if (!state) {
+          clearPkceCookie();
+          res.status(400).json({ error: 'invalid_state', error_description: 'state missing, tampered, or expired' });
+          return;
+        }
+        // Browser binding (MEDIUM-1): the PKCE/nonce cookie must be present and
+        // valid. Its absence means this callback was not initiated by this
+        // browser's /authorize redirect (replay / session-fixation attempt) —
+        // reject cleanly.
+        const pkceCookie = (req.cookies as Record<string, string> | undefined)?.[LOGIN_PKCE_COOKIE];
+        const pkce = verifyPkce(pkceCookie, cfg.sessionSecret);
+        if (!pkce) {
+          clearPkceCookie();
+          res.status(400).json({ error: 'invalid_request', error_description: 'login session cookie missing or invalid' });
+          return;
+        }
+        const code = typeof req.query.code === 'string' ? req.query.code : undefined;
+        if (!code) {
+          clearPkceCookie();
+          res.status(400).json({ error: 'invalid_request', error_description: 'code required' });
+          return;
+        }
+
+        // Exchange the code for tokens at Google (passing the PKCE verifier),
+        // then verify the id_token against Google's JWKS (RS256) and assert
+        // iss/aud/exp/hd/email_verified AND that its nonce matches the cookie.
+        const tokenRes = await exchangeGoogleCode({
+          code,
+          clientId: cfg.clientId,
+          clientSecret: cfg.clientSecret,
+          redirectUri: googleRedirectUri,
+          codeVerifier: pkce.verifier,
+        });
+        if (!tokenRes.id_token) {
+          clearPkceCookie();
+          res.status(400).json({ error: 'invalid_grant', error_description: 'Google returned no id_token' });
+          return;
+        }
+        // Pull the JWKS (cached by kid) for the token's signing key.
+        const kid = (() => {
+          try {
+            const h = JSON.parse(Buffer.from(tokenRes.id_token!.split('.')[0].replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'));
+            return typeof h.kid === 'string' ? h.kid : undefined;
+          } catch { return undefined; }
+        })();
+        const jwks = await jwksCache!.getForKid(kid);
+        const claims = verifyGoogleIdToken(tokenRes.id_token, jwks, {
+          clientId: cfg.clientId,
+          hd: cfg.hd,
+          nonce: pkce.nonce,
+        });
+
+        // Success — clear the single-use PKCE cookie, set the signed login-
+        // session cookie, and bounce back to the validated /authorize URL. The
+        // open-redirect guard rejects anything not same-origin + /authorize.
+        const dest = safeReturnUrl(state.return_url, publicBaseUrl);
+        if (!dest) {
+          clearPkceCookie();
+          res.status(400).json({ error: 'invalid_return_url', error_description: 'return_url failed the same-origin /authorize guard' });
+          return;
+        }
+        clearPkceCookie();
+        const session = signSession(
+          { email: claims.email, exp: Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS },
+          cfg.sessionSecret,
+        );
+        res.cookie(LOGIN_SESSION_COOKIE, session, loginCookieOpts(req));
+        res.redirect(dest);
+      } catch (e) {
+        // LOW-1: log the detailed error server-side (exchangeGoogleCode's
+        // IdTokenError embeds Google's response body) but return a generic
+        // description to the anonymous caller — don't echo Google's body.
+        clearPkceCookie();
+        console.error(`[serve-http] Google login callback failed: ${e instanceof Error ? e.message : e}`);
+        res.status(401).json({ error: 'login_denied', error_description: 'Google sign-in failed' });
+      }
+    });
+
+    console.error(
+      `[serve-http] Google login gate ENABLED — /authorize requires sign-in on hosted domain "${cfg.hd}".`,
+    );
+  }
 
   const authRouter = mcpAuthRouter(authRouterOptions);
 
@@ -1404,7 +1662,14 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
     res.status(405).json({ jsonrpc: '2.0', error: { code: -32000, message: 'Method not allowed' }, id: null });
   });
 
-  app.post('/mcp', requireBearerAuth({ verifier: oauthProvider }), async (req: Request, res: Response) => {
+  // resourceMetadataUrl adds `resource_metadata="..."` to the 401
+  // WWW-Authenticate: Bearer header (RFC 9728 / MCP protected-resource spec)
+  // without disturbing the existing `error="invalid_token"` content. The SDK's
+  // mcpAuthRouter already serves the document at this path (resourceServerUrl
+  // defaults to the issuer). Derived from issuerUrl, not hardcoded.
+  const resourceMetadataUrl = `${issuerUrl.origin}/.well-known/oauth-protected-resource`;
+
+  app.post('/mcp', requireBearerAuth({ verifier: oauthProvider, resourceMetadataUrl }), async (req: Request, res: Response) => {
     const startTime = Date.now();
     const authInfo = (req as any).auth as AuthInfo;
 
@@ -1747,7 +2012,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   app.post(
     '/ingest',
     ingestRateLimiter,
-    requireBearerAuth({ verifier: oauthProvider, requiredScopes: ['write'] }),
+    requireBearerAuth({ verifier: oauthProvider, requiredScopes: ['write'], resourceMetadataUrl }),
     express.raw({ type: '*/*', limit: ingestMaxBytes }),
     async (req: Request, res: Response) => {
       const startTime = Date.now();
@@ -2104,6 +2369,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
 ║  Issuer:    ${issuerUrl.origin.padEnd(40)}║
 ║  Clients:   ${String((clientCount[0] as any).count).padEnd(40)}║
 ║  DCR:       ${(enableDcr ? 'enabled' : 'disabled').padEnd(40)}║
+║  LoginGate: ${(googleLogin ? `google:${googleLogin.hd}` : 'off').padEnd(40)}║
 ║  Skills:    ${skillStatus.bannerValue.padEnd(40)}║
 ║  Token TTL: ${(tokenTtl + 's').padEnd(40)}║
 ╠══════════════════════════════════════════════════════╣

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -15,7 +15,7 @@ import type { Request, Response, NextFunction } from 'express';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
-import { randomBytes, createHash } from 'crypto';
+import { randomBytes, createHash, randomUUID } from 'crypto';
 import { safeHexEqual } from '../core/timing-safe.ts';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -49,7 +49,6 @@ import {
   STATE_TTL_SECONDS,
 } from '../core/oauth-google-login.ts';
 import type { GoogleLoginConfig } from '../core/oauth-google-login.ts';
-import { randomUUID } from 'crypto';
 import { hasScope, ALLOWED_SCOPES_LIST, normalizeScopesInput } from '../core/scope.ts';
 import { summarizeMcpParams, dispatchToolCall } from '../mcp/dispatch.ts';
 import { paramDefToSchema } from '../mcp/tool-defs.ts';

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -113,8 +113,27 @@ export async function runServe(
     // restart.
     const suppressBootstrapToken = args.includes('--suppress-bootstrap-token');
 
+    // OPT-IN Google-Workspace login gate (off unless --oauth-login-hd / env is set).
+    // When enabled, the browser `authorization_code` flow at /authorize first
+    // requires a Google sign-in on the allowed hosted domain before gbrain's
+    // OAuth provider issues a code. Plumbed through the same arg-index pattern
+    // as the flags above; resolved + validated (fail-fast) in serve-http.ts.
+    // Each flag falls back to an env var so secrets can be supplied out-of-band
+    // (e.g. Cloud Run --set-secrets) instead of appearing in argv / process list.
+    const flagOrEnv = (flag: string, env: string): string | undefined => {
+      const idx = args.indexOf(flag);
+      return idx >= 0 ? args[idx + 1] : process.env[env];
+    };
+    const oauthLoginHd = flagOrEnv('--oauth-login-hd', 'GBRAIN_OAUTH_LOGIN_HD');
+    const oauthGoogleClientId = flagOrEnv('--oauth-google-client-id', 'GBRAIN_OAUTH_GOOGLE_CLIENT_ID');
+    const oauthGoogleClientSecret = flagOrEnv('--oauth-google-client-secret', 'GBRAIN_OAUTH_GOOGLE_CLIENT_SECRET');
+    const oauthSessionSecret = flagOrEnv('--oauth-session-secret', 'GBRAIN_OAUTH_SESSION_SECRET');
+
     const { runServeHttp } = await import('./serve-http.ts');
-    await runServeHttp(engine, { port, tokenTtl, enableDcr, publicUrl, logFullParams, bind, suppressBootstrapToken });
+    await runServeHttp(engine, {
+      port, tokenTtl, enableDcr, publicUrl, logFullParams, bind, suppressBootstrapToken,
+      oauthLoginHd, oauthGoogleClientId, oauthGoogleClientSecret, oauthSessionSecret,
+    });
     return;
   }
 

--- a/src/core/oauth-google-login.ts
+++ b/src/core/oauth-google-login.ts
@@ -1,0 +1,653 @@
+/**
+ * Google-Workspace login gate for the browser OAuth `authorization_code` flow.
+ *
+ * OPT-IN. Everything here is dormant unless `serve --http` is started with
+ * `--oauth-login-hd <domain>`. When the gate is enabled, a remote MCP client
+ * (Claude Code) doing the browser `/authorize` flow must first sign in with a
+ * Google account on the allowed hosted domain (`hd`) before gbrain's OAuth
+ * provider issues an authorization code. This makes Dynamic Client
+ * Registration safe to enable: today `/authorize` issues a code to anyone.
+ *
+ * This module is dependency-light and fully unit-testable. It holds only pure
+ * functions plus a small JWKS cache; no Express, no DB, no process state. The
+ * wiring (routes, cookies, redirects) lives in `src/commands/serve-http.ts`.
+ *
+ * JWT/JWKS: gbrain has no `jose` dependency (checked package.json), so RS256
+ * verification is implemented with Node's built-in `crypto`. We verify the
+ * Google-minted `id_token` against Google's published JWKS rather than trusting
+ * the token endpoint response blindly.
+ *
+ * Google OIDC endpoints (constants, not config — they are stable and public):
+ *   - authorization:  https://accounts.google.com/o/oauth2/v2/auth
+ *   - token:          https://oauth2.googleapis.com/token
+ *   - JWKS:           https://www.googleapis.com/oauth2/v3/certs
+ */
+
+import {
+  createHash,
+  createHmac,
+  createPublicKey,
+  createVerify,
+  randomBytes,
+  timingSafeEqual,
+} from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+export const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+export const GOOGLE_CERTS_URL = 'https://www.googleapis.com/oauth2/v3/certs';
+
+/**
+ * Accepted `iss` claim values for a Google-minted id_token. Google emits one
+ * of these two forms; both are valid per the OIDC discovery document.
+ */
+export const GOOGLE_ISSUERS = new Set<string>([
+  'accounts.google.com',
+  'https://accounts.google.com',
+]);
+
+/** Default login-session cookie name. Mirrors the `gbrain_admin` cookie style. */
+export const LOGIN_SESSION_COOKIE = 'gbrain_login';
+
+/**
+ * Short-lived cookie that carries the PKCE `code_verifier` + OIDC `nonce` for
+ * the gbrain↔Google round-trip, bound to THIS browser. Scoped to the callback
+ * path and signed with the session secret. Cleared after the callback runs.
+ */
+export const LOGIN_PKCE_COOKIE = 'gbrain_login_pkce';
+
+/** Clock-skew leeway (seconds) applied to `exp` checks on state + id_token. */
+export const CLOCK_SKEW_SECONDS = 60;
+
+/** Login-session TTL (seconds). ~12h, per spec. */
+export const SESSION_TTL_SECONDS = 12 * 60 * 60;
+
+/** Signed-state TTL (seconds). Short — the login round-trip is interactive. */
+export const STATE_TTL_SECONDS = 10 * 60;
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolved Google login-gate configuration. Constructed once at startup by
+ * `resolveGoogleLoginConfig` from the CLI flags. When the gate is disabled the
+ * whole object is `undefined` and the middleware is a pass-through.
+ */
+export interface GoogleLoginConfig {
+  /** Allowed Google hosted domain (the `hd` claim), e.g. `raavasolutions.com`. */
+  hd: string;
+  /** Google OAuth client id (web application credentials). */
+  clientId: string;
+  /** Google OAuth client secret. */
+  clientSecret: string;
+  /** HMAC key used to sign both the login-session cookie and the state value. */
+  sessionSecret: string;
+}
+
+export interface GoogleLoginFlags {
+  oauthLoginHd?: string;
+  oauthGoogleClientId?: string;
+  oauthGoogleClientSecret?: string;
+  oauthSessionSecret?: string;
+}
+
+/**
+ * Fail-fast resolver. Returns `undefined` when `--oauth-login-hd` is unset
+ * (gate OFF — byte-for-byte unchanged behavior). When `--oauth-login-hd` IS
+ * set, the google client id/secret and session secret are all REQUIRED;
+ * throwing here makes the server refuse to start with a clear error rather
+ * than half-enabling the gate.
+ */
+export function resolveGoogleLoginConfig(flags: GoogleLoginFlags): GoogleLoginConfig | undefined {
+  const hd = flags.oauthLoginHd?.trim();
+  if (!hd) return undefined;
+
+  const missing: string[] = [];
+  const clientId = flags.oauthGoogleClientId?.trim();
+  const clientSecret = flags.oauthGoogleClientSecret?.trim();
+  const sessionSecret = flags.oauthSessionSecret?.trim();
+  if (!clientId) missing.push('--oauth-google-client-id');
+  if (!clientSecret) missing.push('--oauth-google-client-secret');
+  if (!sessionSecret) missing.push('--oauth-session-secret');
+
+  if (missing.length > 0) {
+    throw new Error(
+      `--oauth-login-hd is set (Google login gate enabled) but ${missing.join(', ')} ` +
+        `${missing.length === 1 ? 'is' : 'are'} missing. ` +
+        'All of --oauth-google-client-id, --oauth-google-client-secret, and ' +
+        '--oauth-session-secret are required when the gate is on.',
+    );
+  }
+
+  return { hd, clientId: clientId!, clientSecret: clientSecret!, sessionSecret: sessionSecret! };
+}
+
+// ---------------------------------------------------------------------------
+// base64url helpers (no external dep)
+// ---------------------------------------------------------------------------
+
+export function base64urlEncode(input: Buffer | string): string {
+  const buf = typeof input === 'string' ? Buffer.from(input, 'utf8') : input;
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function base64urlDecode(input: string): Buffer {
+  const pad = input.length % 4 === 0 ? '' : '='.repeat(4 - (input.length % 4));
+  return Buffer.from(input.replace(/-/g, '+').replace(/_/g, '/') + pad, 'base64');
+}
+
+/**
+ * Constant-time string compare for HMAC signatures. Length mismatch returns
+ * false without throwing (callers route to a clean rejection).
+ */
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+function hmac(secret: string, data: string): string {
+  return base64urlEncode(createHmac('sha256', secret).update(data).digest());
+}
+
+// ---------------------------------------------------------------------------
+// PKCE (RFC 7636) — binds the gbrain↔Google leg to one browser
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a high-entropy PKCE `code_verifier` (RFC 7636 §4.1). 32 random
+ * bytes → 43-char base64url string, well within the 43–128 char range the RFC
+ * mandates. Pure aside from the CSPRNG.
+ */
+export function generateCodeVerifier(): string {
+  return base64urlEncode(randomBytes(32));
+}
+
+/**
+ * Derive the S256 `code_challenge` from a `code_verifier` (RFC 7636 §4.2):
+ * `base64url(SHA256(ASCII(verifier)))`. Pure.
+ */
+export function codeChallengeS256(verifier: string): string {
+  return base64urlEncode(createHash('sha256').update(verifier).digest());
+}
+
+/**
+ * Generate a random OIDC `nonce` to bind the id_token to this login attempt
+ * (replay defense). 16 random bytes → base64url. Pure aside from the CSPRNG.
+ */
+export function generateNonce(): string {
+  return base64urlEncode(randomBytes(16));
+}
+
+// ---------------------------------------------------------------------------
+// Signed state (CSRF + return-url carrier for the Google round-trip)
+// ---------------------------------------------------------------------------
+
+export interface StatePayload {
+  /** The original `/authorize` URL (path + query) to redirect back to. */
+  return_url: string;
+  /** Random nonce; binds this state value to one login attempt. */
+  nonce: string;
+  /** Expiry, Unix epoch seconds. */
+  exp: number;
+}
+
+/**
+ * Sign a state payload as `<base64url(json)>.<hmac>`. The HMAC covers the
+ * encoded payload so any tamper (return_url, nonce, exp) invalidates it.
+ */
+export function signState(payload: StatePayload, secret: string): string {
+  const body = base64urlEncode(JSON.stringify(payload));
+  return `${body}.${hmac(secret, body)}`;
+}
+
+/**
+ * Verify + decode a signed state value. Returns the payload on success, or
+ * `null` on any failure: malformed, bad signature, or expired. Pure — caller
+ * supplies `now` for deterministic tests (defaults to wall clock).
+ */
+export function verifyState(
+  value: string | undefined,
+  secret: string,
+  now: number = Math.floor(Date.now() / 1000),
+): StatePayload | null {
+  if (!value) return null;
+  const dot = value.lastIndexOf('.');
+  if (dot <= 0) return null;
+  const body = value.slice(0, dot);
+  const sig = value.slice(dot + 1);
+  if (!safeEqual(sig, hmac(secret, body))) return null;
+  let payload: StatePayload;
+  try {
+    payload = JSON.parse(base64urlDecode(body).toString('utf8')) as StatePayload;
+  } catch {
+    return null;
+  }
+  if (
+    typeof payload !== 'object' ||
+    payload === null ||
+    typeof payload.return_url !== 'string' ||
+    typeof payload.nonce !== 'string' ||
+    typeof payload.exp !== 'number'
+  ) {
+    return null;
+  }
+  if (payload.exp + CLOCK_SKEW_SECONDS < now) return null;
+  return payload;
+}
+
+// ---------------------------------------------------------------------------
+// Signed session cookie ({email, exp})
+// ---------------------------------------------------------------------------
+
+export interface SessionPayload {
+  email: string;
+  /** Expiry, Unix epoch seconds. */
+  exp: number;
+}
+
+export function signSession(payload: SessionPayload, secret: string): string {
+  const body = base64urlEncode(JSON.stringify(payload));
+  return `${body}.${hmac(secret, body)}`;
+}
+
+/**
+ * Verify + decode a session cookie. Returns the payload on success, `null` on
+ * malformed / bad-signature / expired. No clock-skew leeway on the session
+ * (it is our own cookie; a 12h TTL has ample margin).
+ */
+export function verifySession(
+  value: string | undefined,
+  secret: string,
+  now: number = Math.floor(Date.now() / 1000),
+): SessionPayload | null {
+  if (!value) return null;
+  const dot = value.lastIndexOf('.');
+  if (dot <= 0) return null;
+  const body = value.slice(0, dot);
+  const sig = value.slice(dot + 1);
+  if (!safeEqual(sig, hmac(secret, body))) return null;
+  let payload: SessionPayload;
+  try {
+    payload = JSON.parse(base64urlDecode(body).toString('utf8')) as SessionPayload;
+  } catch {
+    return null;
+  }
+  if (
+    typeof payload !== 'object' ||
+    payload === null ||
+    typeof payload.email !== 'string' ||
+    typeof payload.exp !== 'number'
+  ) {
+    return null;
+  }
+  if (payload.exp < now) return null;
+  return payload;
+}
+
+// ---------------------------------------------------------------------------
+// Signed PKCE/nonce cookie ({verifier, nonce, exp}) — browser binding
+// ---------------------------------------------------------------------------
+
+export interface PkcePayload {
+  /** PKCE code_verifier sent to Google's token endpoint on the callback. */
+  verifier: string;
+  /** OIDC nonce; must equal the id_token's `nonce` claim on the callback. */
+  nonce: string;
+  /** Expiry, Unix epoch seconds. */
+  exp: number;
+}
+
+/**
+ * Sign a PKCE/nonce payload as `<base64url(json)>.<hmac>`, identical in shape to
+ * the state + session carriers. The cookie holding this is HttpOnly + Secure +
+ * SameSite=Lax + path-scoped to the callback, so a valid value is bound to the
+ * browser that started the login.
+ */
+export function signPkce(payload: PkcePayload, secret: string): string {
+  const body = base64urlEncode(JSON.stringify(payload));
+  return `${body}.${hmac(secret, body)}`;
+}
+
+/**
+ * Verify + decode the PKCE/nonce cookie. Returns the payload on success, `null`
+ * on malformed / bad-signature / expired (with CLOCK_SKEW_SECONDS leeway, like
+ * the state carrier). Pure — caller supplies `now` for deterministic tests.
+ */
+export function verifyPkce(
+  value: string | undefined,
+  secret: string,
+  now: number = Math.floor(Date.now() / 1000),
+): PkcePayload | null {
+  if (!value) return null;
+  const dot = value.lastIndexOf('.');
+  if (dot <= 0) return null;
+  const body = value.slice(0, dot);
+  const sig = value.slice(dot + 1);
+  if (!safeEqual(sig, hmac(secret, body))) return null;
+  let payload: PkcePayload;
+  try {
+    payload = JSON.parse(base64urlDecode(body).toString('utf8')) as PkcePayload;
+  } catch {
+    return null;
+  }
+  if (
+    typeof payload !== 'object' ||
+    payload === null ||
+    typeof payload.verifier !== 'string' ||
+    typeof payload.nonce !== 'string' ||
+    typeof payload.exp !== 'number'
+  ) {
+    return null;
+  }
+  if (payload.exp + CLOCK_SKEW_SECONDS < now) return null;
+  return payload;
+}
+
+// ---------------------------------------------------------------------------
+// Open-redirect guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Only allow a `return_url` that is same-origin as `publicBaseUrl` AND whose
+ * path is prefixed `/authorize`. Returns the safe absolute URL string on
+ * success, or `null` on rejection (off-origin, wrong path, unparseable).
+ *
+ * This is the open-redirect guard required by the spec: a signed state value
+ * could in principle be replayed, but the destination is still constrained to
+ * this server's `/authorize` so it can never bounce a browser to an attacker
+ * origin.
+ */
+export function safeReturnUrl(returnUrl: string, publicBaseUrl: string): string | null {
+  let base: URL;
+  let target: URL;
+  try {
+    base = new URL(publicBaseUrl);
+    // Resolve against base so a path-only return_url ("/authorize?...") is
+    // accepted and an absolute off-origin URL is caught by the origin check.
+    target = new URL(returnUrl, base);
+  } catch {
+    return null;
+  }
+  if (target.origin !== base.origin) return null;
+  if (target.pathname !== '/authorize' && !target.pathname.startsWith('/authorize/')) {
+    return null;
+  }
+  return target.toString();
+}
+
+// ---------------------------------------------------------------------------
+// Build Google auth URL
+// ---------------------------------------------------------------------------
+
+export interface BuildAuthUrlArgs {
+  clientId: string;
+  redirectUri: string;
+  hd: string;
+  state: string;
+  /** PKCE S256 challenge (base64url(SHA256(verifier))). */
+  codeChallenge: string;
+  /** OIDC nonce; echoed back in the id_token's `nonce` claim. */
+  nonce: string;
+}
+
+/**
+ * Build the Google authorization-endpoint URL. Fixed params per spec:
+ * `response_type=code`, `scope=openid email`, `access_type=online`,
+ * `prompt=select_account`. `hd` constrains the account picker to the allowed
+ * hosted domain (defense-in-depth; the id_token `hd` claim is still verified
+ * server-side — `hd` here is a hint, the claim check is the boundary).
+ *
+ * Carries PKCE (`code_challenge` + `code_challenge_method=S256`) and the OIDC
+ * `nonce` so the gbrain↔Google leg is bound to one browser: the matching
+ * `code_verifier` + `nonce` live in a signed, browser-scoped cookie and are
+ * checked on the callback.
+ */
+export function buildGoogleAuthUrl(args: BuildAuthUrlArgs): string {
+  const u = new URL(GOOGLE_AUTH_URL);
+  u.searchParams.set('client_id', args.clientId);
+  u.searchParams.set('redirect_uri', args.redirectUri);
+  u.searchParams.set('response_type', 'code');
+  u.searchParams.set('scope', 'openid email');
+  u.searchParams.set('hd', args.hd);
+  u.searchParams.set('access_type', 'online');
+  u.searchParams.set('prompt', 'select_account');
+  u.searchParams.set('state', args.state);
+  u.searchParams.set('code_challenge', args.codeChallenge);
+  u.searchParams.set('code_challenge_method', 'S256');
+  u.searchParams.set('nonce', args.nonce);
+  return u.toString();
+}
+
+// ---------------------------------------------------------------------------
+// JWKS (RS256 id_token verification, no jose dependency)
+// ---------------------------------------------------------------------------
+
+/** A single RSA JWK from Google's certs endpoint. */
+export interface GoogleJwk {
+  kid: string;
+  kty: string;
+  n: string;
+  e: string;
+  alg?: string;
+  use?: string;
+}
+
+export interface GoogleJwks {
+  keys: GoogleJwk[];
+}
+
+/**
+ * Convert an RSA JWK ({n, e}) into a Node `KeyObject` for signature
+ * verification. Uses the JWK import path built into Node's crypto — no PEM
+ * hand-assembly, no external dep.
+ */
+function jwkToKeyObject(jwk: GoogleJwk) {
+  return createPublicKey({
+    key: { kty: 'RSA', n: jwk.n, e: jwk.e },
+    format: 'jwk',
+  });
+}
+
+/**
+ * Decoded JWT shape returned by `verifyGoogleIdToken`. Only the claims we
+ * assert on are typed; Google includes more.
+ */
+export interface IdTokenClaims {
+  iss: string;
+  aud: string;
+  sub: string;
+  email: string;
+  email_verified?: boolean;
+  hd?: string;
+  nonce?: string;
+  exp: number;
+  iat?: number;
+  [k: string]: unknown;
+}
+
+export class IdTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'IdTokenError';
+  }
+}
+
+/**
+ * Verify a Google id_token (RS256 JWT) against a JWKS and assert all claims
+ * required by the gate. PURE given a JWKS — no network — so it is fully
+ * unit-testable with a locally-generated RSA keypair + stub JWKS.
+ *
+ * Checks, in order:
+ *   1. header alg === RS256 and a matching `kid` exists in the JWKS
+ *   2. RS256 signature verifies against that key
+ *   3. iss ∈ GOOGLE_ISSUERS
+ *   4. aud === expectedClientId
+ *   5. exp > now (with CLOCK_SKEW_SECONDS leeway)
+ *   6. hd === expectedHd
+ *   7. email_verified === true
+ *   8. nonce === expectedNonce (only when `opts.nonce` is supplied) — binds the
+ *      token to the login attempt that minted the matching browser cookie.
+ *      Constant-time compared so a mismatch leaks no timing signal.
+ *
+ * Throws `IdTokenError` with a specific message on the first failed check;
+ * returns the decoded claims on success.
+ */
+export function verifyGoogleIdToken(
+  idToken: string,
+  jwks: GoogleJwks,
+  opts: { clientId: string; hd: string; nonce?: string; now?: number },
+): IdTokenClaims {
+  const now = opts.now ?? Math.floor(Date.now() / 1000);
+  const parts = idToken.split('.');
+  if (parts.length !== 3) throw new IdTokenError('id_token is not a well-formed JWT');
+  const [headerB64, payloadB64, sigB64] = parts;
+
+  let header: { alg?: string; kid?: string };
+  let claims: IdTokenClaims;
+  try {
+    header = JSON.parse(base64urlDecode(headerB64).toString('utf8'));
+  } catch {
+    throw new IdTokenError('id_token header is not valid JSON');
+  }
+  try {
+    claims = JSON.parse(base64urlDecode(payloadB64).toString('utf8')) as IdTokenClaims;
+  } catch {
+    throw new IdTokenError('id_token payload is not valid JSON');
+  }
+
+  if (header.alg !== 'RS256') {
+    throw new IdTokenError(`unexpected id_token alg ${JSON.stringify(header.alg)}; expected RS256`);
+  }
+  const jwk = jwks.keys.find(k => k.kid === header.kid && k.kty === 'RSA');
+  if (!jwk) throw new IdTokenError(`no matching JWKS key for kid ${JSON.stringify(header.kid)}`);
+
+  // RS256 signature verification over `header.payload`.
+  const verifier = createVerify('RSA-SHA256');
+  verifier.update(`${headerB64}.${payloadB64}`);
+  verifier.end();
+  const ok = verifier.verify(jwkToKeyObject(jwk), base64urlDecode(sigB64));
+  if (!ok) throw new IdTokenError('id_token signature verification failed');
+
+  if (!GOOGLE_ISSUERS.has(claims.iss)) {
+    throw new IdTokenError(`unexpected id_token iss ${JSON.stringify(claims.iss)}`);
+  }
+  if (claims.aud !== opts.clientId) {
+    throw new IdTokenError('id_token aud does not match the configured client_id');
+  }
+  if (typeof claims.exp !== 'number' || claims.exp + CLOCK_SKEW_SECONDS < now) {
+    throw new IdTokenError('id_token is expired');
+  }
+  if (claims.hd !== opts.hd) {
+    throw new IdTokenError(
+      `id_token hd ${JSON.stringify(claims.hd)} is not the allowed hosted domain`,
+    );
+  }
+  if (claims.email_verified !== true) {
+    throw new IdTokenError('id_token email is not verified');
+  }
+  // Nonce binding: only enforced when the caller supplies an expected nonce
+  // (the gate always does; the pure unit tests can omit it). `safeEqual`
+  // returns false on a length mismatch or a missing claim, so a token without
+  // a `nonce` claim is rejected when one is expected.
+  if (opts.nonce !== undefined) {
+    if (typeof claims.nonce !== 'string' || !safeEqual(claims.nonce, opts.nonce)) {
+      throw new IdTokenError('id_token nonce does not match the login attempt');
+    }
+  }
+  return claims;
+}
+
+// ---------------------------------------------------------------------------
+// JWKS cache (by kid) — runtime network fetch, not unit-tested
+// ---------------------------------------------------------------------------
+
+/**
+ * Small process-lifetime JWKS cache. Google rotates signing keys; we cache the
+ * full keyset and re-fetch when the requested `kid` is absent (key rotation)
+ * or the soft TTL has elapsed. `fetchImpl` is injectable for tests.
+ */
+export class GoogleJwksCache {
+  private cached: GoogleJwks | null = null;
+  private fetchedAt = 0;
+  private readonly ttlMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: { ttlMs?: number; fetchImpl?: typeof fetch } = {}) {
+    this.ttlMs = opts.ttlMs ?? 60 * 60 * 1000; // 1h soft TTL
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  /**
+   * Return a JWKS that contains `kid`. Serves from cache when fresh and the
+   * kid is present; otherwise re-fetches Google's certs endpoint once.
+   */
+  async getForKid(kid: string | undefined): Promise<GoogleJwks> {
+    const fresh = this.cached && Date.now() - this.fetchedAt < this.ttlMs;
+    const hasKid = !!this.cached && (!kid || this.cached.keys.some(k => k.kid === kid));
+    if (fresh && hasKid) return this.cached!;
+    return this.refresh();
+  }
+
+  private async refresh(): Promise<GoogleJwks> {
+    const res = await this.fetchImpl(GOOGLE_CERTS_URL);
+    if (!res.ok) throw new IdTokenError(`JWKS fetch failed: ${res.status}`);
+    const json = (await res.json()) as GoogleJwks;
+    if (!json || !Array.isArray(json.keys)) throw new IdTokenError('JWKS response malformed');
+    this.cached = json;
+    this.fetchedAt = Date.now();
+    return json;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Token exchange (runtime network call, not unit-tested)
+// ---------------------------------------------------------------------------
+
+export interface GoogleTokenResponse {
+  id_token?: string;
+  access_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  scope?: string;
+}
+
+/**
+ * Exchange a Google authorization `code` for tokens at the Google token
+ * endpoint. POSTs the form per OAuth 2.0. `fetchImpl` is injectable for tests.
+ */
+export async function exchangeGoogleCode(
+  args: {
+    code: string;
+    clientId: string;
+    clientSecret: string;
+    redirectUri: string;
+    /** PKCE code_verifier matching the code_challenge sent at /authorize. */
+    codeVerifier?: string;
+  },
+  fetchImpl: typeof fetch = fetch,
+): Promise<GoogleTokenResponse> {
+  const body = new URLSearchParams({
+    code: args.code,
+    client_id: args.clientId,
+    client_secret: args.clientSecret,
+    redirect_uri: args.redirectUri,
+    grant_type: 'authorization_code',
+  });
+  if (args.codeVerifier !== undefined) body.set('code_verifier', args.codeVerifier);
+  const res = await fetchImpl(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new IdTokenError(`Google token exchange failed: ${res.status} ${text.slice(0, 200)}`);
+  }
+  return (await res.json()) as GoogleTokenResponse;
+}

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -181,14 +181,41 @@ interface GBrainOAuthProviderOptions {
    * before mcpAuthRouter ran).
    */
   dcrDisabled?: boolean;
+  /**
+   * True when the resolved Google login gate config exists (serve-http resolves
+   * it from `--oauth-login-hd`). When set, `GBrainClientsStore.registerClient`
+   * (the DCR `/register` path) hardens EVERY self-registration to public
+   * (`token_endpoint_auth_method='none'`), strips `client_credentials` from
+   * `grant_types`, and clamps scope to `read` — forcing every self-registered
+   * client through `/authorize` (→ the Google gate) and capping it at read.
+   * Without this an anonymous caller could `POST /register` a confidential
+   * `client_credentials` client and mint an admin token via `POST /token`,
+   * never hitting `/authorize` and bypassing the gate. The operator path
+   * (`registerClientManual`) is NEVER affected. When the gate is OFF, DCR
+   * behavior is unchanged (backward compatible).
+   */
+  loginGateEnabled?: boolean;
 }
 
 // ---------------------------------------------------------------------------
 // Clients Store
 // ---------------------------------------------------------------------------
 
+/**
+ * Grants a self-registered (DCR) client may hold when the Google login gate is
+ * on. `client_credentials` is deliberately excluded — it is the grant that
+ * skips `/authorize` (and therefore the gate). A self-registered client may
+ * only obtain tokens through the browser `authorization_code` flow (+ refresh).
+ */
+const GATE_HARDENED_GRANT_TYPES = ['authorization_code', 'refresh_token'] as const;
+
 class GBrainClientsStore implements OAuthRegisteredClientsStore {
-  constructor(private sql: SqlQuery) {}
+  /**
+   * @param loginGateEnabled when true, harden every DCR `/register` (this
+   *   class's `registerClient`) to public + authorization_code/refresh_token +
+   *   `read`. See `GBrainOAuthProviderOptions.loginGateEnabled`.
+   */
+  constructor(private sql: SqlQuery, private loginGateEnabled = false) {}
 
   async getClient(clientId: string): Promise<OAuthClientInformationFull | undefined> {
     const rows = await this.sql`
@@ -239,7 +266,43 @@ class GBrainClientsStore implements OAuthRegisteredClientsStore {
     // `--enable-dcr` is not the looser entry point. CLI and admin paths gate
     // through the same `validateTokenEndpointAuthMethod` helper — all three
     // registration entry points share one allow-list.
-    const authMethod = validateTokenEndpointAuthMethod(client.token_endpoint_auth_method);
+    const requestedAuthMethod = validateTokenEndpointAuthMethod(client.token_endpoint_auth_method);
+
+    // Login-gate hardening (CRITICAL-1): when the Google login gate is on, EVERY
+    // self-registered client MUST be forced through `/authorize` (→ the gate)
+    // and capped at `read`. Without this, an anonymous caller could
+    // `POST /register` a CONFIDENTIAL `client_credentials` client and mint an
+    // admin token via `POST /token` — never hitting `/authorize`, bypassing the
+    // gate entirely. So we:
+    //   - force token_endpoint_auth_method='none' (public, PKCE-only) — do NOT
+    //     honor a requested confidential method;
+    //   - strip `client_credentials` from grant_types so the only grants are
+    //     authorization_code + refresh_token (the browser flow);
+    //   - clamp scope to `read`.
+    // The operator path (registerClientManual) is a SEPARATE method and is
+    // never affected. When the gate is OFF, behavior is unchanged.
+    const authMethod = this.loginGateEnabled ? 'none' : requestedAuthMethod;
+
+    const requestedGrants = client.grant_types || ['client_credentials'];
+    const grantTypes = this.loginGateEnabled
+      ? (() => {
+          const filtered = requestedGrants.filter(g => g !== 'client_credentials');
+          return filtered.length > 0 ? filtered : [...GATE_HARDENED_GRANT_TYPES];
+        })()
+      : requestedGrants;
+
+    // DCR scope clamp: a self-registered PUBLIC client (PKCE-only,
+    // token_endpoint_auth_method='none') is the surface a browser/agent
+    // registers without operator review — it must NEVER be able to grant
+    // itself `write` or `admin`. Clamp its registered scope to `read` only.
+    // Confidential DCR clients (those that present a secret) are unaffected
+    // *when the gate is OFF*; with the gate ON every registration is forced
+    // public above, so this clamp fires for all of them. Admin-minted clients
+    // go through registerClientManual, not this path, so they keep their full
+    // requested scope. The clamp happens before the INSERT and the response
+    // below echoes the clamped value, so the stored row and the DCR reply agree.
+    const requestedScope = client.scope;
+    const effectiveScope = authMethod === 'none' ? 'read' : requestedScope;
 
     const clientId = generateToken('gbrain_cl_');
     // v0.34.1 (#909): RFC 7591 §2 — clients that authenticate at the token
@@ -271,8 +334,8 @@ class GBrainClientsStore implements OAuthRegisteredClientsStore {
                                     client_id_issued_at, source_id, federated_read)
         VALUES (${clientId}, ${secretHash}, ${client.client_name || 'unnamed'},
                 ${pgArray((client.redirect_uris || []).map(String))},
-                ${pgArray(client.grant_types || ['client_credentials'])},
-                ${client.scope || ''}, ${authMethod},
+                ${pgArray(grantTypes)},
+                ${effectiveScope || ''}, ${authMethod},
                 ${now}, ${'default'}, ${pgArray(['default'])})
       `;
     } catch (err) {
@@ -284,8 +347,8 @@ class GBrainClientsStore implements OAuthRegisteredClientsStore {
                                         client_id_issued_at, source_id)
             VALUES (${clientId}, ${secretHash}, ${client.client_name || 'unnamed'},
                     ${pgArray((client.redirect_uris || []).map(String))},
-                    ${pgArray(client.grant_types || ['client_credentials'])},
-                    ${client.scope || ''}, ${authMethod},
+                    ${pgArray(grantTypes)},
+                    ${effectiveScope || ''}, ${authMethod},
                     ${now}, ${'default'})
           `;
         } catch (err2) {
@@ -296,8 +359,8 @@ class GBrainClientsStore implements OAuthRegisteredClientsStore {
                                           client_id_issued_at)
               VALUES (${clientId}, ${secretHash}, ${client.client_name || 'unnamed'},
                       ${pgArray((client.redirect_uris || []).map(String))},
-                      ${pgArray(client.grant_types || ['client_credentials'])},
-                      ${client.scope || ''}, ${authMethod},
+                      ${pgArray(grantTypes)},
+                      ${effectiveScope || ''}, ${authMethod},
                       ${now})
             `;
           } else {
@@ -311,8 +374,8 @@ class GBrainClientsStore implements OAuthRegisteredClientsStore {
                                       client_id_issued_at)
           VALUES (${clientId}, ${secretHash}, ${client.client_name || 'unnamed'},
                   ${pgArray((client.redirect_uris || []).map(String))},
-                  ${pgArray(client.grant_types || ['client_credentials'])},
-                  ${client.scope || ''}, ${authMethod},
+                  ${pgArray(grantTypes)},
+                  ${effectiveScope || ''}, ${authMethod},
                   ${now})
         `;
       } else {
@@ -327,6 +390,15 @@ class GBrainClientsStore implements OAuthRegisteredClientsStore {
     // exactly once — same shape as before.
     const response: OAuthClientInformationFull = {
       ...client,
+      // Echo the clamped scope so the DCR reply matches the stored row. A
+      // public client that requested `read write` is told it has `read`.
+      scope: effectiveScope,
+      // Echo the hardened grant_types + auth method so the DCR reply matches
+      // the stored row. With the login gate on, a client that requested
+      // `client_secret_post` + `client_credentials` is told it is public
+      // (`none`) with `['authorization_code','refresh_token']`.
+      grant_types: grantTypes,
+      token_endpoint_auth_method: authMethod,
       client_id: clientId,
       client_id_issued_at: now,
     };
@@ -348,7 +420,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
 
   constructor(options: GBrainOAuthProviderOptions) {
     this.sql = options.sql;
-    this._clientsStore = new GBrainClientsStore(this.sql);
+    this._clientsStore = new GBrainClientsStore(this.sql, options.loginGateEnabled === true);
     this.dcrDisabled = options.dcrDisabled === true;
     this.tokenTtl = options.tokenTtl || 3600;
     this.refreshTtl = options.refreshTtl || 30 * 24 * 3600;

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -268,12 +268,15 @@ class GBrainClientsStore implements OAuthRegisteredClientsStore {
     // registration entry points share one allow-list.
     const requestedAuthMethod = validateTokenEndpointAuthMethod(client.token_endpoint_auth_method);
 
-    // Login-gate hardening (CRITICAL-1): when the Google login gate is on, EVERY
-    // self-registered client MUST be forced through `/authorize` (→ the gate)
-    // and capped at `read`. Without this, an anonymous caller could
+    // Login-gate hardening (CRITICAL-1): when the Google login gate is on, every
+    // client self-registered FROM NOW ON is forced through `/authorize` (→ the
+    // gate) and capped at `read`. Without this, an anonymous caller could
     // `POST /register` a CONFIDENTIAL `client_credentials` client and mint an
     // admin token via `POST /token` — never hitting `/authorize`, bypassing the
-    // gate entirely. So we:
+    // gate entirely. (Note: this is registration-time hardening, not retroactive —
+    // any confidential client_credentials client registered while the gate was
+    // OFF keeps working at /token. Enable the gate from the start, or revoke
+    // pre-existing DCR clients when turning it on.) So we:
     //   - force token_endpoint_auth_method='none' (public, PKCE-only) — do NOT
     //     honor a requested confidential method;
     //   - strip `client_credentials` from grant_types so the only grants are
@@ -291,18 +294,16 @@ class GBrainClientsStore implements OAuthRegisteredClientsStore {
         })()
       : requestedGrants;
 
-    // DCR scope clamp: a self-registered PUBLIC client (PKCE-only,
-    // token_endpoint_auth_method='none') is the surface a browser/agent
-    // registers without operator review — it must NEVER be able to grant
-    // itself `write` or `admin`. Clamp its registered scope to `read` only.
-    // Confidential DCR clients (those that present a secret) are unaffected
-    // *when the gate is OFF*; with the gate ON every registration is forced
-    // public above, so this clamp fires for all of them. Admin-minted clients
-    // go through registerClientManual, not this path, so they keep their full
-    // requested scope. The clamp happens before the INSERT and the response
-    // below echoes the clamped value, so the stored row and the DCR reply agree.
-    const requestedScope = client.scope;
-    const effectiveScope = authMethod === 'none' ? 'read' : requestedScope;
+    // DCR scope clamp: when the gate is ON, every registration is forced public
+    // above and must be capped at `read` — a self-registered browser/agent client
+    // must NEVER grant itself `write`/`admin`. When the gate is OFF we leave the
+    // requested scope untouched so behavior is byte-for-byte unchanged from
+    // upstream (the gate-OFF DCR path is not ours to alter in this feature).
+    // Admin-minted clients go through registerClientManual, not this path, so
+    // they keep their full requested scope. The clamp happens before the INSERT
+    // and the response below echoes the clamped value, so the stored row and the
+    // DCR reply agree.
+    const effectiveScope = this.loginGateEnabled ? 'read' : client.scope;
 
     const clientId = generateToken('gbrain_cl_');
     // v0.34.1 (#909): RFC 7591 §2 — clients that authenticate at the token

--- a/test/oauth-dcr-scope-clamp.test.ts
+++ b/test/oauth-dcr-scope-clamp.test.ts
@@ -1,0 +1,210 @@
+/**
+ * DCR scope-clamp security test (src/core/oauth-provider.ts registerClient).
+ *
+ * A self-registered PUBLIC client (token_endpoint_auth_method='none', PKCE-only
+ * — the surface a browser/agent registers without operator review) must NEVER
+ * be able to grant itself `write` or `admin`. registerClient clamps its scope
+ * to `read`. Confidential DCR clients keep their requested scope, and admin-
+ * minted clients (registerClientManual) are unaffected.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGlite } from '@electric-sql/pglite';
+import { vector } from '@electric-sql/pglite/vector';
+import { pg_trgm } from '@electric-sql/pglite/contrib/pg_trgm';
+import { GBrainOAuthProvider } from '../src/core/oauth-provider.ts';
+import { PGLITE_SCHEMA_SQL } from '../src/core/pglite-schema.ts';
+
+let db: PGlite;
+let sql: (strings: TemplateStringsArray, ...values: unknown[]) => Promise<any>;
+let provider: GBrainOAuthProvider;
+// Second provider with the Google login gate ENABLED — exercises the
+// CRITICAL-1 DCR hardening path. Shares the same DB.
+let gatedProvider: GBrainOAuthProvider;
+
+beforeAll(async () => {
+  db = new PGlite({ extensions: { vector, pg_trgm } });
+  await db.exec(PGLITE_SCHEMA_SQL);
+  sql = async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const query = strings.reduce((acc, str, i) => acc + str + (i < values.length ? `$${i + 1}` : ''), '');
+    const result = await db.query(query, values as any[]);
+    return result.rows;
+  };
+  provider = new GBrainOAuthProvider({ sql, tokenTtl: 60, refreshTtl: 300 });
+  gatedProvider = new GBrainOAuthProvider({ sql, tokenTtl: 60, refreshTtl: 300, loginGateEnabled: true });
+}, 30_000);
+
+afterAll(async () => {
+  if (db) await db.close();
+}, 15_000);
+
+async function storedScope(clientId: string): Promise<string> {
+  const rows = await sql`SELECT scope FROM oauth_clients WHERE client_id = ${clientId}`;
+  return rows[0].scope as string;
+}
+
+async function storedRow(
+  clientId: string,
+): Promise<{ scope: string; grant_types: string[]; token_endpoint_auth_method: string; client_secret_hash: string | null }> {
+  const rows = await sql`
+    SELECT scope, grant_types, token_endpoint_auth_method, client_secret_hash
+    FROM oauth_clients WHERE client_id = ${clientId}
+  `;
+  return rows[0];
+}
+
+describe('DCR scope clamp (registerClient)', () => {
+  test('public client (none) requesting "read write admin" is clamped to "read"', async () => {
+    const reg = await provider.clientsStore.registerClient!({
+      client_name: 'browser-dcr',
+      redirect_uris: ['https://app.example.com/callback'],
+      grant_types: ['authorization_code'],
+      scope: 'read write admin',
+      token_endpoint_auth_method: 'none',
+    } as any);
+    expect(reg.scope).toBe('read');
+    expect(await storedScope(reg.client_id)).toBe('read');
+    // Public client: no secret issued.
+    expect(reg.client_secret).toBeUndefined();
+  });
+
+  test('public client (none) requesting "write" is clamped to "read"', async () => {
+    const reg = await provider.clientsStore.registerClient!({
+      client_name: 'browser-dcr-2',
+      redirect_uris: ['https://app.example.com/cb'],
+      grant_types: ['authorization_code'],
+      scope: 'write',
+      token_endpoint_auth_method: 'none',
+    } as any);
+    expect(reg.scope).toBe('read');
+    expect(await storedScope(reg.client_id)).toBe('read');
+  });
+
+  test('confidential DCR client keeps its requested scope (not clamped)', async () => {
+    const reg = await provider.clientsStore.registerClient!({
+      client_name: 'confidential-dcr',
+      redirect_uris: ['https://app.example.com/cb'],
+      grant_types: ['authorization_code'],
+      scope: 'read write',
+      token_endpoint_auth_method: 'client_secret_post',
+    } as any);
+    expect(reg.scope).toBe('read write');
+    expect(await storedScope(reg.client_id)).toBe('read write');
+    // Confidential client: secret issued.
+    expect(typeof reg.client_secret).toBe('string');
+  });
+
+  test('admin-minted client (registerClientManual) is unaffected by the clamp', async () => {
+    const { clientId } = await provider.registerClientManual(
+      'admin-minted',
+      ['authorization_code'],
+      'read write',
+      ['https://app.example.com/cb'],
+      'default',
+      undefined,
+      'none', // even a public admin-minted client keeps its scope
+    );
+    expect(await storedScope(clientId)).toBe('read write');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CRITICAL-1: with the Google login gate ENABLED, the DCR /register path
+// (registerClient) hardens EVERY self-registration — confidential or public —
+// to public (none) + ['authorization_code','refresh_token'] + read. This
+// forces every self-registered client through /authorize (→ the gate) and
+// caps it at read, closing the confidential-client client_credentials bypass.
+// ---------------------------------------------------------------------------
+
+describe('DCR login-gate hardening (registerClient, gate ENABLED)', () => {
+  test('confidential client_credentials admin registration is forced public + authz_code/refresh + read', async () => {
+    const reg = await gatedProvider.clientsStore.registerClient!({
+      client_name: 'attacker-confidential',
+      redirect_uris: ['https://app.example.com/cb'],
+      grant_types: ['client_credentials'],
+      scope: 'admin',
+      token_endpoint_auth_method: 'client_secret_post',
+    } as any);
+
+    // Echoed DCR response is hardened.
+    expect(reg.token_endpoint_auth_method).toBe('none');
+    expect(reg.scope).toBe('read');
+    expect(reg.grant_types).toEqual(['authorization_code', 'refresh_token']);
+    // Public client → no secret minted (the client_credentials path is dead).
+    expect(reg.client_secret).toBeUndefined();
+
+    // Stored row agrees with the echoed response.
+    const row = await storedRow(reg.client_id);
+    expect(row.token_endpoint_auth_method).toBe('none');
+    expect(row.scope).toBe('read');
+    expect(row.grant_types).toEqual(['authorization_code', 'refresh_token']);
+    expect(row.client_secret_hash).toBeNull();
+  });
+
+  test('mixed grant_types: client_credentials stripped, authorization_code retained', async () => {
+    const reg = await gatedProvider.clientsStore.registerClient!({
+      client_name: 'attacker-mixed',
+      redirect_uris: ['https://app.example.com/cb'],
+      grant_types: ['authorization_code', 'client_credentials'],
+      scope: 'write',
+      token_endpoint_auth_method: 'client_secret_post',
+    } as any);
+    expect(reg.grant_types).toEqual(['authorization_code']);
+    expect(reg.token_endpoint_auth_method).toBe('none');
+    expect(reg.scope).toBe('read');
+    expect((await storedRow(reg.client_id)).grant_types).toEqual(['authorization_code']);
+  });
+
+  test('public PKCE client is also clamped to read (unchanged outcome, gate-on path)', async () => {
+    const reg = await gatedProvider.clientsStore.registerClient!({
+      client_name: 'public-gated',
+      redirect_uris: ['https://app.example.com/cb'],
+      grant_types: ['authorization_code', 'refresh_token'],
+      scope: 'read write admin',
+      token_endpoint_auth_method: 'none',
+    } as any);
+    expect(reg.token_endpoint_auth_method).toBe('none');
+    expect(reg.scope).toBe('read');
+    expect(reg.grant_types).toEqual(['authorization_code', 'refresh_token']);
+  });
+
+  test('gate DISABLED leaves confidential client_credentials DCR behavior unchanged', async () => {
+    // Same registration as the first gated test but via the ungated provider.
+    const reg = await provider.clientsStore.registerClient!({
+      client_name: 'confidential-ungated',
+      redirect_uris: ['https://app.example.com/cb'],
+      grant_types: ['client_credentials'],
+      scope: 'read write',
+      token_endpoint_auth_method: 'client_secret_post',
+    } as any);
+    // Confidential, secret issued, grants + scope preserved (prior behavior).
+    expect(reg.token_endpoint_auth_method).toBe('client_secret_post');
+    expect(reg.scope).toBe('read write');
+    expect(reg.grant_types).toEqual(['client_credentials']);
+    expect(typeof reg.client_secret).toBe('string');
+    const row = await storedRow(reg.client_id);
+    expect(row.token_endpoint_auth_method).toBe('client_secret_post');
+    expect(row.grant_types).toEqual(['client_credentials']);
+    expect(row.client_secret_hash).not.toBeNull();
+  });
+
+  test('operator path (registerClientManual) is unaffected even when gate is enabled', async () => {
+    // registerClientManual on the GATED provider must still honor a
+    // confidential client_credentials admin minting (the operator/admin path).
+    const { clientId, clientSecret } = await gatedProvider.registerClientManual(
+      'operator-machine',
+      ['client_credentials'],
+      'admin',
+      [],
+      'default',
+      undefined,
+      'client_secret_post',
+    );
+    const row = await storedRow(clientId);
+    expect(row.token_endpoint_auth_method).toBe('client_secret_post');
+    expect(row.scope).toBe('admin');
+    expect(row.grant_types).toEqual(['client_credentials']);
+    expect(row.client_secret_hash).not.toBeNull();
+    expect(typeof clientSecret).toBe('string');
+  });
+});

--- a/test/oauth-dcr-scope-clamp.test.ts
+++ b/test/oauth-dcr-scope-clamp.test.ts
@@ -1,11 +1,11 @@
 /**
  * DCR scope-clamp security test (src/core/oauth-provider.ts registerClient).
  *
- * A self-registered PUBLIC client (token_endpoint_auth_method='none', PKCE-only
- * — the surface a browser/agent registers without operator review) must NEVER
- * be able to grant itself `write` or `admin`. registerClient clamps its scope
- * to `read`. Confidential DCR clients keep their requested scope, and admin-
- * minted clients (registerClientManual) are unaffected.
+ * With the login gate ON, registerClient hardens EVERY self-registration to
+ * public (none) + authorization_code/refresh_token + `read`, forcing it through
+ * /authorize (→ the gate) and capping it at read. With the gate OFF, behavior is
+ * byte-for-byte unchanged from upstream (no clamp). Admin-minted clients
+ * (registerClientManual) are never affected, gate on or off.
  */
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
@@ -54,7 +54,10 @@ async function storedRow(
 }
 
 describe('DCR scope clamp (registerClient)', () => {
-  test('public client (none) requesting "read write admin" is clamped to "read"', async () => {
+  // Backward-compat invariant: with the login gate OFF, registerClient must
+  // behave byte-for-byte like upstream — no scope clamp. The read clamp is a
+  // gate-ON hardening only (see the gate-ENABLED block below).
+  test('gate OFF: public client (none) requesting "read write admin" keeps its scope (unchanged upstream behavior)', async () => {
     const reg = await provider.clientsStore.registerClient!({
       client_name: 'browser-dcr',
       redirect_uris: ['https://app.example.com/callback'],
@@ -62,13 +65,13 @@ describe('DCR scope clamp (registerClient)', () => {
       scope: 'read write admin',
       token_endpoint_auth_method: 'none',
     } as any);
-    expect(reg.scope).toBe('read');
-    expect(await storedScope(reg.client_id)).toBe('read');
+    expect(reg.scope).toBe('read write admin');
+    expect(await storedScope(reg.client_id)).toBe('read write admin');
     // Public client: no secret issued.
     expect(reg.client_secret).toBeUndefined();
   });
 
-  test('public client (none) requesting "write" is clamped to "read"', async () => {
+  test('gate OFF: public client (none) requesting "write" keeps "write"', async () => {
     const reg = await provider.clientsStore.registerClient!({
       client_name: 'browser-dcr-2',
       redirect_uris: ['https://app.example.com/cb'],
@@ -76,8 +79,8 @@ describe('DCR scope clamp (registerClient)', () => {
       scope: 'write',
       token_endpoint_auth_method: 'none',
     } as any);
-    expect(reg.scope).toBe('read');
-    expect(await storedScope(reg.client_id)).toBe('read');
+    expect(reg.scope).toBe('write');
+    expect(await storedScope(reg.client_id)).toBe('write');
   });
 
   test('confidential DCR client keeps its requested scope (not clamped)', async () => {

--- a/test/oauth-google-login.test.ts
+++ b/test/oauth-google-login.test.ts
@@ -353,9 +353,19 @@ describe('verifyGoogleIdToken', () => {
     expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(/not verified/);
   });
 
-  test('rejects an unexpected alg (none / HS256)', () => {
+  test('rejects alg=none', () => {
     const token = mintIdToken({}, { alg: 'none' });
     expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(/alg/);
+  });
+
+  test('rejects alg=HS256 (RS/HS confusion) before any signature work', () => {
+    const token = mintIdToken({}, { alg: 'HS256' });
+    expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(/alg/);
+  });
+
+  test('rejects email_verified absent (undefined), not only false', () => {
+    const token = mintIdToken({ email_verified: undefined });
+    expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(/not verified/);
   });
 
   test('rejects when no JWKS key matches the kid', () => {

--- a/test/oauth-google-login.test.ts
+++ b/test/oauth-google-login.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Unit tests for the OPT-IN Google-Workspace login gate
+ * (src/core/oauth-google-login.ts).
+ *
+ * Pure-function coverage: state sign/verify (tamper + expiry rejected),
+ * session sign/verify, id_token verification (reject wrong aud / wrong iss /
+ * expired / wrong hd / email_verified=false / bad signature) using a locally
+ * generated RSA keypair to mint test id_tokens and a stub JWKS, build-auth-url
+ * shape, the open-redirect guard, and the fail-fast config resolver.
+ *
+ * No network, no DB, no Express — every function under test is pure given its
+ * inputs (id_token verification takes the JWKS as an argument).
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { generateKeyPairSync, createSign, createHash, randomUUID } from 'node:crypto';
+import {
+  resolveGoogleLoginConfig,
+  base64urlEncode,
+  base64urlDecode,
+  signState,
+  verifyState,
+  signSession,
+  verifySession,
+  signPkce,
+  verifyPkce,
+  generateCodeVerifier,
+  codeChallengeS256,
+  generateNonce,
+  safeReturnUrl,
+  buildGoogleAuthUrl,
+  verifyGoogleIdToken,
+  IdTokenError,
+  GOOGLE_AUTH_URL,
+  type GoogleJwks,
+  type IdTokenClaims,
+} from '../src/core/oauth-google-login.ts';
+
+const SECRET = 'test-session-secret-which-is-long-enough';
+const NOW = 1_900_000_000; // fixed reference time for deterministic exp checks
+
+// ---------------------------------------------------------------------------
+// resolveGoogleLoginConfig (fail-fast)
+// ---------------------------------------------------------------------------
+
+describe('resolveGoogleLoginConfig', () => {
+  test('returns undefined (gate OFF) when --oauth-login-hd is unset', () => {
+    expect(resolveGoogleLoginConfig({})).toBeUndefined();
+    expect(resolveGoogleLoginConfig({ oauthLoginHd: '   ' })).toBeUndefined();
+  });
+
+  test('throws naming each missing required flag when hd is set', () => {
+    expect(() => resolveGoogleLoginConfig({ oauthLoginHd: 'example.com' })).toThrow(
+      /--oauth-google-client-id/,
+    );
+    try {
+      resolveGoogleLoginConfig({ oauthLoginHd: 'example.com', oauthGoogleClientId: 'id' });
+      throw new Error('should have thrown');
+    } catch (e) {
+      const msg = (e as Error).message;
+      // The "... are missing" clause names exactly the two unsupplied flags.
+      const missingClause = msg.split(' are missing')[0];
+      expect(missingClause).toContain('--oauth-google-client-secret');
+      expect(missingClause).toContain('--oauth-session-secret');
+      expect(missingClause).not.toContain('--oauth-google-client-id');
+    }
+  });
+
+  test('resolves a full config when all flags present', () => {
+    const cfg = resolveGoogleLoginConfig({
+      oauthLoginHd: 'example.com',
+      oauthGoogleClientId: 'cid',
+      oauthGoogleClientSecret: 'csecret',
+      oauthSessionSecret: 'ssecret',
+    });
+    expect(cfg).toEqual({
+      hd: 'example.com',
+      clientId: 'cid',
+      clientSecret: 'csecret',
+      sessionSecret: 'ssecret',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signState / verifyState
+// ---------------------------------------------------------------------------
+
+describe('signState / verifyState', () => {
+  const payload = { return_url: '/authorize?x=1', nonce: randomUUID(), exp: NOW + 600 };
+
+  test('round-trips a valid state', () => {
+    const value = signState(payload, SECRET);
+    expect(verifyState(value, SECRET, NOW)).toEqual(payload);
+  });
+
+  test('rejects a tampered body', () => {
+    const value = signState(payload, SECRET);
+    const [body, sig] = value.split('.');
+    const tampered =
+      base64urlEncode(JSON.stringify({ ...payload, return_url: 'https://evil.example/authorize' })) +
+      '.' +
+      sig;
+    expect(verifyState(tampered, SECRET, NOW)).toBeNull();
+    void body;
+  });
+
+  test('rejects a wrong signature / wrong secret', () => {
+    const value = signState(payload, SECRET);
+    expect(verifyState(value, 'different-secret', NOW)).toBeNull();
+  });
+
+  test('rejects an expired state (beyond clock skew)', () => {
+    const expired = { ...payload, exp: NOW - 600 };
+    const value = signState(expired, SECRET);
+    expect(verifyState(value, SECRET, NOW)).toBeNull();
+  });
+
+  test('rejects malformed input', () => {
+    expect(verifyState(undefined, SECRET, NOW)).toBeNull();
+    expect(verifyState('', SECRET, NOW)).toBeNull();
+    expect(verifyState('no-dot', SECRET, NOW)).toBeNull();
+    expect(verifyState('.onlysig', SECRET, NOW)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signSession / verifySession
+// ---------------------------------------------------------------------------
+
+describe('signSession / verifySession', () => {
+  const payload = { email: 'alice@example.com', exp: NOW + 3600 };
+
+  test('round-trips a valid session', () => {
+    const value = signSession(payload, SECRET);
+    expect(verifySession(value, SECRET, NOW)).toEqual(payload);
+  });
+
+  test('rejects tamper, wrong secret, and expiry', () => {
+    const value = signSession(payload, SECRET);
+    const [, sig] = value.split('.');
+    const tampered = base64urlEncode(JSON.stringify({ email: 'evil@elsewhere.com', exp: payload.exp })) + '.' + sig;
+    expect(verifySession(tampered, SECRET, NOW)).toBeNull();
+    expect(verifySession(value, 'nope', NOW)).toBeNull();
+    expect(verifySession(signSession({ email: 'a@b.c', exp: NOW - 1 }, SECRET), SECRET, NOW)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// safeReturnUrl (open-redirect guard)
+// ---------------------------------------------------------------------------
+
+describe('safeReturnUrl', () => {
+  const base = 'https://brain.example.com';
+
+  test('accepts same-origin /authorize path (relative)', () => {
+    expect(safeReturnUrl('/authorize?response_type=code', base)).toBe(
+      'https://brain.example.com/authorize?response_type=code',
+    );
+  });
+
+  test('accepts same-origin /authorize path (absolute)', () => {
+    expect(safeReturnUrl('https://brain.example.com/authorize?a=1', base)).toBe(
+      'https://brain.example.com/authorize?a=1',
+    );
+  });
+
+  test('rejects off-origin redirect', () => {
+    expect(safeReturnUrl('https://evil.example.com/authorize', base)).toBeNull();
+    expect(safeReturnUrl('//evil.example.com/authorize', base)).toBeNull();
+  });
+
+  test('rejects non-/authorize paths', () => {
+    expect(safeReturnUrl('/admin', base)).toBeNull();
+    expect(safeReturnUrl('/authorized-evil', base)).toBeNull();
+    expect(safeReturnUrl('https://brain.example.com/mcp', base)).toBeNull();
+  });
+
+  test('rejects unparseable input', () => {
+    expect(safeReturnUrl('http://[bad', base)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildGoogleAuthUrl
+// ---------------------------------------------------------------------------
+
+describe('buildGoogleAuthUrl', () => {
+  test('builds the Google auth URL with the required params (incl. PKCE + nonce)', () => {
+    const url = new URL(
+      buildGoogleAuthUrl({
+        clientId: 'cid',
+        redirectUri: 'https://brain.example.com/login/google/callback',
+        hd: 'example.com',
+        state: 'STATEVALUE',
+        codeChallenge: 'CHALLENGE',
+        nonce: 'NONCEVALUE',
+      }),
+    );
+    expect(`${url.origin}${url.pathname}`).toBe(GOOGLE_AUTH_URL);
+    expect(url.searchParams.get('client_id')).toBe('cid');
+    expect(url.searchParams.get('redirect_uri')).toBe('https://brain.example.com/login/google/callback');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('scope')).toBe('openid email');
+    expect(url.searchParams.get('hd')).toBe('example.com');
+    expect(url.searchParams.get('access_type')).toBe('online');
+    expect(url.searchParams.get('prompt')).toBe('select_account');
+    expect(url.searchParams.get('state')).toBe('STATEVALUE');
+    expect(url.searchParams.get('code_challenge')).toBe('CHALLENGE');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('nonce')).toBe('NONCEVALUE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PKCE helpers + signed PKCE/nonce cookie
+// ---------------------------------------------------------------------------
+
+describe('PKCE helpers', () => {
+  test('generateCodeVerifier produces a 43+ char base64url string', () => {
+    const v = generateCodeVerifier();
+    expect(v.length).toBeGreaterThanOrEqual(43);
+    expect(/^[A-Za-z0-9_-]+$/.test(v)).toBe(true);
+  });
+
+  test('codeChallengeS256 is base64url(SHA256(verifier)) and deterministic', () => {
+    const v = generateCodeVerifier();
+    const c1 = codeChallengeS256(v);
+    const c2 = codeChallengeS256(v);
+    expect(c1).toBe(c2);
+    expect(/^[A-Za-z0-9_-]+$/.test(c1)).toBe(true);
+    // Different verifiers → different challenges.
+    expect(codeChallengeS256(generateCodeVerifier())).not.toBe(c1);
+  });
+
+  test('generateNonce is non-empty base64url', () => {
+    const n = generateNonce();
+    expect(n.length).toBeGreaterThan(0);
+    expect(/^[A-Za-z0-9_-]+$/.test(n)).toBe(true);
+  });
+});
+
+describe('signPkce / verifyPkce', () => {
+  const payload = { verifier: generateCodeVerifier(), nonce: generateNonce(), exp: NOW + 600 };
+
+  test('round-trips a valid PKCE/nonce cookie', () => {
+    const value = signPkce(payload, SECRET);
+    expect(verifyPkce(value, SECRET, NOW)).toEqual(payload);
+  });
+
+  test('rejects tamper, wrong secret, and expiry', () => {
+    const value = signPkce(payload, SECRET);
+    const [, sig] = value.split('.');
+    const tampered = base64urlEncode(JSON.stringify({ ...payload, verifier: 'attacker' })) + '.' + sig;
+    expect(verifyPkce(tampered, SECRET, NOW)).toBeNull();
+    expect(verifyPkce(value, 'nope', NOW)).toBeNull();
+    expect(verifyPkce(signPkce({ ...payload, exp: NOW - 600 }, SECRET), SECRET, NOW)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyGoogleIdToken — locally-minted RSA keypair + stub JWKS
+// ---------------------------------------------------------------------------
+
+const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const KID = 'test-kid-1';
+
+function stubJwks(): GoogleJwks {
+  const jwk = publicKey.export({ format: 'jwk' }) as { n: string; e: string };
+  return { keys: [{ kid: KID, kty: 'RSA', n: jwk.n, e: jwk.e, alg: 'RS256', use: 'sig' }] };
+}
+
+function mintIdToken(
+  claims: Partial<IdTokenClaims>,
+  opts: { kid?: string; alg?: string; signWith?: 'good' | 'bad' } = {},
+): string {
+  const header = { alg: opts.alg ?? 'RS256', kid: opts.kid ?? KID, typ: 'JWT' };
+  const body: IdTokenClaims = {
+    iss: 'https://accounts.google.com',
+    aud: 'cid',
+    sub: '12345',
+    email: 'alice@example.com',
+    email_verified: true,
+    hd: 'example.com',
+    exp: NOW + 600,
+    iat: NOW,
+    ...claims,
+  };
+  const headerB64 = base64urlEncode(JSON.stringify(header));
+  const payloadB64 = base64urlEncode(JSON.stringify(body));
+  const signingInput = `${headerB64}.${payloadB64}`;
+
+  let signer = createSign('RSA-SHA256');
+  signer.update(signingInput);
+  signer.end();
+  // A bad signature: sign with a DIFFERENT freshly-generated key.
+  const keyToUse =
+    opts.signWith === 'bad'
+      ? generateKeyPairSync('rsa', { modulusLength: 2048 }).privateKey
+      : privateKey;
+  const sig = base64urlEncode(signer.sign(keyToUse));
+  return `${signingInput}.${sig}`;
+}
+
+const VERIFY_OPTS = { clientId: 'cid', hd: 'example.com', now: NOW };
+
+describe('verifyGoogleIdToken', () => {
+  test('accepts a fully-valid id_token', () => {
+    const token = mintIdToken({});
+    const claims = verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS);
+    expect(claims.email).toBe('alice@example.com');
+    expect(claims.hd).toBe('example.com');
+  });
+
+  test('accepts the bare-domain iss form', () => {
+    const token = mintIdToken({ iss: 'accounts.google.com' });
+    expect(verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS).email).toBe('alice@example.com');
+  });
+
+  test('rejects a bad signature (signed with a different key)', () => {
+    const token = mintIdToken({}, { signWith: 'bad' });
+    expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(IdTokenError);
+    expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(/signature/);
+  });
+
+  test('rejects wrong aud', () => {
+    const token = mintIdToken({ aud: 'someone-else' });
+    expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(/aud/);
+  });
+
+  test('rejects wrong iss', () => {
+    const token = mintIdToken({ iss: 'https://evil.example.com' });
+    expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(/iss/);
+  });
+
+  test('rejects an expired token', () => {
+    const token = mintIdToken({ exp: NOW - 600 });
+    expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(/expired/);
+  });
+
+  test('rejects wrong hosted domain', () => {
+    const token = mintIdToken({ hd: 'other-company.com' });
+    expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(/hosted domain/);
+  });
+
+  test('rejects a missing hd claim', () => {
+    const token = mintIdToken({ hd: undefined });
+    expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(/hosted domain/);
+  });
+
+  test('rejects email_verified=false', () => {
+    const token = mintIdToken({ email_verified: false });
+    expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(/not verified/);
+  });
+
+  test('rejects an unexpected alg (none / HS256)', () => {
+    const token = mintIdToken({}, { alg: 'none' });
+    expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(/alg/);
+  });
+
+  test('rejects when no JWKS key matches the kid', () => {
+    const token = mintIdToken({}, { kid: 'unknown-kid' });
+    expect(() => verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS)).toThrow(/JWKS key/);
+  });
+
+  test('rejects a non-JWT shaped token', () => {
+    expect(() => verifyGoogleIdToken('not.a', stubJwks(), VERIFY_OPTS)).toThrow(/well-formed/);
+  });
+
+  // Nonce binding (MEDIUM-2). When an expected nonce is supplied, the id_token's
+  // nonce claim must match it constant-time; a mismatch or a missing claim is
+  // rejected. When no nonce is expected (pure-function callers), it's skipped.
+  test('accepts a matching nonce when one is expected', () => {
+    const token = mintIdToken({ nonce: 'expected-nonce' });
+    const claims = verifyGoogleIdToken(token, stubJwks(), { ...VERIFY_OPTS, nonce: 'expected-nonce' });
+    expect(claims.email).toBe('alice@example.com');
+  });
+
+  test('rejects a mismatched nonce', () => {
+    const token = mintIdToken({ nonce: 'attacker-nonce' });
+    expect(() => verifyGoogleIdToken(token, stubJwks(), { ...VERIFY_OPTS, nonce: 'expected-nonce' })).toThrow(/nonce/);
+  });
+
+  test('rejects a missing nonce claim when one is expected', () => {
+    const token = mintIdToken({ nonce: undefined });
+    expect(() => verifyGoogleIdToken(token, stubJwks(), { ...VERIFY_OPTS, nonce: 'expected-nonce' })).toThrow(/nonce/);
+  });
+
+  test('skips the nonce check when no expected nonce is supplied', () => {
+    const token = mintIdToken({ nonce: 'whatever' });
+    expect(verifyGoogleIdToken(token, stubJwks(), VERIFY_OPTS).email).toBe('alice@example.com');
+  });
+});

--- a/test/oauth-login-gate-middleware.test.ts
+++ b/test/oauth-login-gate-middleware.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Integration-style test of the OPT-IN Google login-gate middleware shape
+ * (the /authorize gate wired in src/commands/serve-http.ts).
+ *
+ * Spins up a minimal Express app that mounts the SAME gate middleware logic the
+ * server uses — verifySession on the login cookie, otherwise sign a state +
+ * 302 to the Google auth URL — and exercises the three required cases over real
+ * HTTP with `fetch` (redirect:'manual'):
+ *
+ *   1. gate DISABLED            → request passes through (200)
+ *   2. gate ENABLED, no cookie  → 302 to /login/google flow (accounts.google.com)
+ *   3. gate ENABLED, valid cookie → passes through (200)
+ *
+ * The full OAuth provider + DB are intentionally out of scope here; the gate's
+ * decision (next vs redirect) is the unit under test and is pure cookie/state
+ * logic from oauth-google-login.ts.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import express from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import cookieParser from 'cookie-parser';
+import type { Server } from 'node:http';
+import {
+  signSession,
+  signPkce,
+  buildGoogleAuthUrl,
+  signState,
+  verifySession,
+  generateCodeVerifier,
+  codeChallengeS256,
+  generateNonce,
+  LOGIN_SESSION_COOKIE,
+  LOGIN_PKCE_COOKIE,
+  SESSION_TTL_SECONDS,
+  STATE_TTL_SECONDS,
+  GOOGLE_AUTH_URL,
+} from '../src/core/oauth-google-login.ts';
+import { randomUUID } from 'node:crypto';
+
+const SECRET = 'integration-session-secret-long-enough';
+const HD = 'example.com';
+const CLIENT_ID = 'cid';
+
+/** Build a tiny app whose /authorize is gated exactly like serve-http.ts. */
+function buildApp(opts: { gateEnabled: boolean; publicBaseUrl: string }) {
+  const app = express();
+  app.use(cookieParser());
+
+  if (opts.gateEnabled) {
+    app.use('/authorize', (req: Request, res: Response, next: NextFunction) => {
+      const cookie = (req.cookies as Record<string, string> | undefined)?.[LOGIN_SESSION_COOKIE];
+      const session = verifySession(cookie, SECRET);
+      if (session) return next();
+      const now = Math.floor(Date.now() / 1000);
+      const verifier = generateCodeVerifier();
+      const nonce = generateNonce();
+      const state = signState(
+        { return_url: req.originalUrl, nonce: randomUUID(), exp: now + STATE_TTL_SECONDS },
+        SECRET,
+      );
+      const pkce = signPkce({ verifier, nonce, exp: now + STATE_TTL_SECONDS }, SECRET);
+      res.cookie(LOGIN_PKCE_COOKIE, pkce, {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/login/google/callback',
+        maxAge: STATE_TTL_SECONDS * 1000,
+      });
+      res.redirect(
+        buildGoogleAuthUrl({
+          clientId: CLIENT_ID,
+          redirectUri: `${opts.publicBaseUrl}/login/google/callback`,
+          hd: HD,
+          state,
+          codeChallenge: codeChallengeS256(verifier),
+          nonce,
+        }),
+      );
+    });
+  }
+
+  // Stand-in for the SDK's /authorize handler: if control reaches here, the
+  // gate passed (or was disabled).
+  app.get('/authorize', (_req: Request, res: Response) => {
+    res.status(200).json({ reached: 'authorize' });
+  });
+
+  return app;
+}
+
+function listen(app: express.Express): Promise<{ url: string; server: Server }> {
+  return new Promise((resolve) => {
+    const server = app.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve({ url: `http://127.0.0.1:${port}`, server });
+    });
+  });
+}
+
+let disabledSrv: { url: string; server: Server };
+let enabledSrv: { url: string; server: Server };
+
+beforeAll(async () => {
+  disabledSrv = await listen(buildApp({ gateEnabled: false, publicBaseUrl: 'http://127.0.0.1' }));
+  enabledSrv = await listen(buildApp({ gateEnabled: true, publicBaseUrl: enabledBaseUrlPlaceholder() }));
+});
+
+// The publicBaseUrl in the redirect_uri doesn't affect the gate decision, so a
+// placeholder is fine; the redirect target's host is accounts.google.com.
+function enabledBaseUrlPlaceholder() {
+  return 'http://127.0.0.1';
+}
+
+afterAll(() => {
+  disabledSrv?.server.close();
+  enabledSrv?.server.close();
+});
+
+describe('login-gate middleware', () => {
+  test('gate DISABLED → /authorize passes through (200)', async () => {
+    const r = await fetch(`${disabledSrv.url}/authorize?response_type=code`, { redirect: 'manual' });
+    expect(r.status).toBe(200);
+    expect(await r.json()).toEqual({ reached: 'authorize' });
+  });
+
+  test('gate ENABLED + no cookie → 302 to Google auth URL', async () => {
+    const r = await fetch(`${enabledSrv.url}/authorize?response_type=code&client_id=x`, {
+      redirect: 'manual',
+    });
+    expect(r.status).toBe(302);
+    const loc = r.headers.get('location') ?? '';
+    expect(loc.startsWith(GOOGLE_AUTH_URL)).toBe(true);
+    const u = new URL(loc);
+    expect(u.searchParams.get('hd')).toBe(HD);
+    expect(u.searchParams.get('client_id')).toBe(CLIENT_ID);
+    expect(u.searchParams.get('response_type')).toBe('code');
+    // state must be present and signed (has the body.sig shape)
+    expect((u.searchParams.get('state') ?? '').includes('.')).toBe(true);
+    // PKCE + nonce on the Google leg (MEDIUM-1 + MEDIUM-2).
+    expect(u.searchParams.get('code_challenge_method')).toBe('S256');
+    expect((u.searchParams.get('code_challenge') ?? '').length).toBeGreaterThan(0);
+    expect((u.searchParams.get('nonce') ?? '').length).toBeGreaterThan(0);
+    // The browser-bound PKCE cookie is set on the redirect, scoped to the
+    // callback path and HttpOnly.
+    const setCookie = r.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain(`${LOGIN_PKCE_COOKIE}=`);
+    expect(setCookie.toLowerCase()).toContain('httponly');
+    expect(setCookie).toContain('Path=/login/google/callback');
+  });
+
+  test('gate ENABLED + valid login cookie → passes through (200)', async () => {
+    const session = signSession(
+      { email: 'alice@example.com', exp: Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS },
+      SECRET,
+    );
+    const r = await fetch(`${enabledSrv.url}/authorize?response_type=code`, {
+      redirect: 'manual',
+      headers: { cookie: `${LOGIN_SESSION_COOKIE}=${session}` },
+    });
+    expect(r.status).toBe(200);
+    expect(await r.json()).toEqual({ reached: 'authorize' });
+  });
+
+  test('gate ENABLED + tampered cookie → still redirects (302)', async () => {
+    const r = await fetch(`${enabledSrv.url}/authorize`, {
+      redirect: 'manual',
+      headers: { cookie: `${LOGIN_SESSION_COOKIE}=garbage.value` },
+    });
+    expect(r.status).toBe(302);
+    expect((r.headers.get('location') ?? '').startsWith(GOOGLE_AUTH_URL)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds an **opt-in** Google-Workspace login gate to the HTTP server's OAuth `authorization_code` flow. When enabled, a browser-driven MCP client (Claude Code, Cursor, etc.) doing the remote-MCP OAuth dance must sign in with a Google account on an allowed hosted domain (`hd`) **before** `/authorize` issues an authorization code.

## Why

Today `oauth-provider.ts authorize()` issues a code to any caller, and `/register` (DCR) is unauthenticated. So turning on `--enable-dcr` for a publicly-reachable deployment means anyone can self-register and read the brain. This gate makes DCR safe to enable for a team deployment: only signed-in users on your Workspace domain can complete the flow.

## Backward compatibility

100% opt-in. Dormant unless `--oauth-login-hd <domain>` is set (each flag also reads a `GBRAIN_OAUTH_*` env var so secrets can be supplied out-of-band, e.g. via a secret manager rather than argv). With it unset, behavior is byte-for-byte unchanged — verified against the existing oauth test suites.

## How

New `src/core/oauth-google-login.ts` (dependency-light — no `jose`; RS256 verified with `node:crypto` against Google's JWKS):
- `GET /login/google` + `GET /login/google/callback`; gate middleware on `/authorize` registered before `mcpAuthRouter`.
- `id_token` verification: RS256 signature via JWKS, plus `iss`/`aud`/`exp` (with skew)/`hd`/`email_verified` assertions. The id_token from Google's `/token` is verified, not trusted.
- **PKCE (S256) + OIDC `nonce`** on the server↔Google leg, bound to the browser via a signed `HttpOnly; Secure; SameSite=Lax` cookie (closes state-replay / login-CSRF / session-fixation).
- Signed, expiring `state` as the return-url carrier with an **open-redirect guard** (same-origin + `/authorize`-prefixed).
- Session cookie `{email, exp}`, HMAC-signed, constant-time compare.

**DCR hardening (only when the gate is enabled):** every self-registered `/register` client is forced to public (`token_endpoint_auth_method=none`) + `authorization_code`/`refresh_token` + `read` scope, stripping `client_credentials` so a self-registered client cannot mint a privileged token via `/token` and bypass `/authorize`. The operator path (`registerClientManual`) is untouched, so admin-minted machine clients keep full grants/scope.

Also adds `resource_metadata` to the `/mcp` 401 `WWW-Authenticate` (RFC 9728 discovery hint).

## Tests

New unit + integration tests (all green; full suite shows only pre-existing env-gated failures): id_token verification (wrong aud/iss/expired/wrong hd/`email_verified`=false/bad sig/bad alg/unknown kid/nonce mismatch), state/session/PKCE sign+verify with tamper+expiry, open-redirect guard, gate middleware (off→passthrough, on+no-cookie→redirect, on+valid→passthrough), and the DCR clamp including the confidential-`client_credentials`-admin bypass case.

## Config

```
serve --http --oauth-login-hd your-workspace.com \
  --oauth-google-client-id <id> \
  --oauth-google-client-secret <secret> \
  --oauth-session-secret <random> \
  --enable-dcr
```

Happy to adjust naming/version/CHANGELOG to match your release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)