### PR TITLE
fix(eval): route LongMemEval models through gateway

### DIFF
--- a/src/commands/eval-longmemeval.ts
+++ b/src/commands/eval-longmemeval.ts
@@ -10,7 +10,7 @@
  */
 
 import { readFileSync, existsSync, openSync, writeSync, closeSync, writeFileSync } from 'fs';
-import Anthropic from '@anthropic-ai/sdk';
+import type Anthropic from '@anthropic-ai/sdk';
 import { withBenchmarkBrain, resetTables } from '../eval/longmemeval/harness.ts';
 import { haystackToPages, type LongMemEvalQuestion } from '../eval/longmemeval/adapter.ts';
 import { renderChatBlock, type ChatSessionForPrompt } from '../eval/longmemeval/sanitize.ts';
@@ -19,6 +19,8 @@ import { hybridSearch } from '../core/search/hybrid.ts';
 import { expandQuery } from '../core/search/expansion.ts';
 import { resolveModel } from '../core/model-config.ts';
 import type { ThinkLLMClient } from '../core/think/index.ts';
+import { chat as gatewayChat, type ChatResult } from '../core/ai/gateway.ts';
+import { normalizeModelId } from '../core/model-id.ts';
 import { createProgress } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
 import type { PGLiteEngine } from '../core/pglite-engine.ts';
@@ -307,6 +309,52 @@ function uniqSessionIds(results: SearchResult[]): string[] {
   return out;
 }
 
+function textFromContent(content: Anthropic.MessageParam['content']): string {
+  if (typeof content === 'string') return content;
+  return content.map(block => ('text' in block ? block.text : '')).join('');
+}
+
+function systemToText(system: Anthropic.MessageCreateParamsNonStreaming['system']): string | undefined {
+  if (typeof system === 'string') return system;
+  if (Array.isArray(system)) return system.map(block => ('text' in block ? block.text : '')).join('');
+  return undefined;
+}
+
+function chatResultToAnthropicMessage(result: ChatResult, model: string): Anthropic.Message {
+  return {
+    id: 'gbrain-gateway-longmemeval',
+    type: 'message',
+    role: 'assistant',
+    model,
+    content: [{ type: 'text', text: result.text }],
+    stop_reason: result.stopReason === 'length' ? 'max_tokens' : result.stopReason === 'tool_calls' ? 'tool_use' : 'end_turn',
+    usage: {
+      input_tokens: result.usage.input_tokens,
+      output_tokens: result.usage.output_tokens,
+    },
+  } as unknown as Anthropic.Message;
+}
+
+function makeGatewayClient(resolvedModel: string): ThinkLLMClient {
+  const model = normalizeModelId(resolvedModel);
+  return {
+    create: async (params, callOpts): Promise<Anthropic.Message> => {
+      const messages = params.messages.map(m => ({
+        role: m.role,
+        content: textFromContent(m.content),
+      }));
+      const result = await gatewayChat({
+        model,
+        system: systemToText(params.system),
+        messages,
+        maxTokens: params.max_tokens,
+        abortSignal: callOpts?.signal,
+      });
+      return chatResultToAnthropicMessage(result, model);
+    },
+  };
+}
+
 async function generateAnswer(
   client: ThinkLLMClient,
   question: string,
@@ -364,12 +412,13 @@ async function generateAnswer(
 }
 
 export interface RunOpts {
-  /** Inject an Anthropic client for tests; defaults to a fresh SDK client. */
+  /** Inject an LLM client for tests; defaults to the provider-neutral AI gateway. */
   client?: ThinkLLMClient;
   /**
-   * v0.40.2.0 — separate stub for the Haiku claim extractor. Tests can
+   * v0.40.2.0 — separate stub for the claim extractor. Tests can
    * isolate "extractor stubbed, answer-gen real" from "extractor real,
-   * answer-gen stubbed". Defaults to the same SDK client when omitted.
+   * answer-gen stubbed". Defaults to the gateway-routed extractor model
+   * when trajectory extraction is enabled.
    */
   extractorClient?: ThinkLLMClient;
   /**
@@ -468,16 +517,6 @@ export async function runEvalLongMemEval(args: string[], runOpts: RunOpts = {}):
     fallback: 'sonnet',
   });
 
-  // Wrap Anthropic SDK so its `.messages.create` shape matches ThinkLLMClient.
-  // Same pattern as src/core/think/index.ts:247-249.
-  const realClient = new Anthropic();
-  const client: ThinkLLMClient = runOpts.client ?? {
-    create: (params, callOpts) => realClient.messages.create(params, callOpts),
-  };
-  // v0.40.2.0 — separate extractor client (defaults to same SDK).
-  const extractorClient: ThinkLLMClient = runOpts.extractorClient ?? {
-    create: (params, callOpts) => realClient.messages.create(params, callOpts),
-  };
   const trajectoryEnabled = !opts.noTrajectory;
   const extractorModel = trajectoryEnabled
     ? await resolveModel(null, {
@@ -486,6 +525,15 @@ export async function runEvalLongMemEval(args: string[], runOpts: RunOpts = {}):
         fallback: 'haiku',
       })
     : '';
+
+  // Default answer generation and extractor calls must route through the
+  // provider-neutral gateway. resolveModel() returns provider-prefixed ids like
+  // `anthropic:claude-sonnet-4-6`; handing those directly to Anthropic's raw SDK
+  // 404s out of the box. The gateway normalizes before native SDK dispatch.
+  const client: ThinkLLMClient = runOpts.client ?? makeGatewayClient(model);
+  const extractorClient: ThinkLLMClient = runOpts.extractorClient ?? (
+    trajectoryEnabled ? makeGatewayClient(extractorModel) : client
+  );
 
   process.stderr.write(`[longmemeval] estimated 20-60 minutes for ${questions.length} questions; use --limit N for shorter runs\n`);
   process.stderr.write(`[longmemeval] connecting in-memory brain...\n`);
@@ -508,6 +556,7 @@ export async function runEvalLongMemEval(args: string[], runOpts: RunOpts = {}):
   }
   let runStart = Date.now();
   let errorCount = 0;
+  let extractorErrorCount = 0;
 
   // v0.41.10 engine-sharing seam: when a caller-owned engine is provided
   // (tests using beforeAll/afterAll to amortize PGLite cold-create across
@@ -526,11 +575,12 @@ export async function runEvalLongMemEval(args: string[], runOpts: RunOpts = {}):
     for (const q of questions) {
       const qStart = Date.now();
       try {
-        await runOneQuestion(engine, q, opts, model, client, emitter, recallByType, {
+        const questionStats = await runOneQuestion(engine, q, opts, model, client, emitter, recallByType, {
           trajectoryEnabled,
           extractorClient,
           extractorModel,
         });
+        extractorErrorCount += questionStats.extractorErrors;
         progress.tick(1, q.question_id);
       } catch (err: any) {
         errorCount++;
@@ -585,6 +635,9 @@ export async function runEvalLongMemEval(args: string[], runOpts: RunOpts = {}):
     const total = cache.hits + cache.misses;
     const pct = total === 0 ? 0 : (cache.hits / total) * 100;
     process.stderr.write(`[longmemeval] extractor.cache_hits: ${cache.hits} / ${total} sessions (${pct.toFixed(1)}%, cached_bodies=${cache.size})\n`);
+    if (extractorErrorCount > 0) {
+      process.stderr.write(`[longmemeval] extractor.errors: ${extractorErrorCount} session(s) failed; trajectory recall may degrade\n`);
+    }
     process.stderr.write(`[longmemeval] methodology_note: ${TRAJECTORY_METHODOLOGY_NOTE}\n`);
   }
 
@@ -625,8 +678,9 @@ async function runOneQuestion(
   emitter: JsonlEmitter,
   recallByType: Record<string, { hit: number; total: number }>,
   traj: TrajectoryRunOpts,
-): Promise<void> {
+): Promise<{ extractorErrors: number }> {
   await resetTables(engine);
+  let extractorErrors = 0;
   const adapterPages = haystackToPages(q);
   // Track date per slug so generateAnswer can pass it through structural framing.
   const dates = q.haystack_dates ?? [];
@@ -645,7 +699,7 @@ async function runOneQuestion(
     // summary level. Each call is fail-open; one bad session never
     // kills the per-question loop.
     if (traj.trajectoryEnabled) {
-      await extractAndInsertClaims({
+      const extractResult = await extractAndInsertClaims({
         engine,
         client: traj.extractorClient,
         model: traj.extractorModel,
@@ -655,6 +709,7 @@ async function runOneQuestion(
         sourceId: 'default',
         aliasMap,
       });
+      if (extractResult.error) extractorErrors++;
     }
   }
 
@@ -767,6 +822,7 @@ async function runOneQuestion(
       methodology_note: TRAJECTORY_METHODOLOGY_NOTE,
     } : {}),
   });
+  return { extractorErrors };
 }
 
 /**

--- a/src/eval/longmemeval/extract.ts
+++ b/src/eval/longmemeval/extract.ts
@@ -44,11 +44,12 @@ import type { BrainEngine, NewFact } from '../../core/engine.ts';
  * fallback chain here:
  *   1. Strip markdown fences if present, then JSON.parse.
  *   2. Find the first `[...]` substring and JSON.parse that.
- * Throws when neither path produces a valid array — caller treats
- * throw as "fail open, 0 facts for this session."
+ * Returns null when neither path produces a valid array — caller treats
+ * null as "fail open, 0 facts for this session" while surfacing the
+ * extractor failure in benchmark telemetry.
  */
-function parseExtractedJsonArray(raw: string): unknown[] {
-  if (typeof raw !== 'string' || !raw.trim()) return [];
+function parseExtractedJsonArray(raw: string): unknown[] | null {
+  if (typeof raw !== 'string' || !raw.trim()) return null;
   // Strip ```json ... ``` fences if present.
   const fenceMatch = raw.match(/```(?:json)?\s*\n?([\s\S]*?)```/i);
   const cleaned = (fenceMatch ? fenceMatch[1] : raw).trim();
@@ -69,7 +70,7 @@ function parseExtractedJsonArray(raw: string): unknown[] {
       // fall through
     }
   }
-  return [];
+  return null;
 }
 
 /** v0.40.2.0 wire shape for the extractor's per-session Haiku output. */
@@ -265,9 +266,10 @@ async function callExtractor(
   }
   const block = response.content.find(b => b.type === 'text');
   const text = block && 'text' in block ? block.text : '';
-  if (!text) return [];
+  if (!text) return null;
 
   const parsed = parseExtractedJsonArray(text);
+  if (parsed === null) return null;
   if (parsed.length === 0) return [];
   const claims: ExtractedClaim[] = [];
   for (const item of parsed) {
@@ -293,6 +295,8 @@ export interface ExtractResult {
   parsed: number;
   /** Whether this session's claims came from cache (hit) or LLM (miss). */
   cacheHit: boolean;
+  /** Non-empty when the extractor failed before producing a parseable response. */
+  error?: string;
 }
 
 export async function extractAndInsertClaims(opts: {
@@ -322,7 +326,11 @@ export async function extractAndInsertClaims(opts: {
     }
   }
 
-  if (!claims || claims.length === 0) {
+  if (!claims) {
+    return { inserted: 0, parsed: 0, cacheHit, error: 'extractor_failed' };
+  }
+
+  if (claims.length === 0) {
     return { inserted: 0, parsed: 0, cacheHit };
   }
 

--- a/test/eval-longmemeval-e2e.slow.test.ts
+++ b/test/eval-longmemeval-e2e.slow.test.ts
@@ -17,7 +17,7 @@
  * Stub MessagesClient lives in test/helpers/longmemeval-stub.ts.
  */
 
-import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
 import { mkdtempSync, readFileSync, existsSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -26,6 +26,7 @@ import type { LongMemEvalQuestion } from '../src/eval/longmemeval/adapter.ts';
 import { createBenchmarkBrain } from '../src/eval/longmemeval/harness.ts';
 import type { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { makeStubClient } from './helpers/longmemeval-stub.ts';
+import { __setChatTransportForTests, resetGateway, type ChatResult } from '../src/core/ai/gateway.ts';
 
 const FIXTURE_PATH = join(import.meta.dir, 'fixtures', 'longmemeval-mini.jsonl');
 
@@ -42,11 +43,62 @@ afterAll(async () => {
   if (sharedEngine) await sharedEngine.disconnect();
 });
 
+afterEach(() => {
+  __setChatTransportForTests(null);
+  resetGateway();
+});
+
+function gatewayResult(text: string, model: string): ChatResult {
+  return {
+    text,
+    blocks: [{ type: 'text', text }],
+    stopReason: 'end',
+    usage: {
+      input_tokens: 1,
+      output_tokens: 1,
+      cache_read_tokens: 0,
+      cache_creation_tokens: 0,
+    },
+    model,
+    providerId: model.split(':')[0] ?? 'anthropic',
+  };
+}
+
 // ---------------------------------------------------------------------------
 // 8. end-to-end with stubbed LLM
 // ---------------------------------------------------------------------------
 
 describe('runEvalLongMemEval: end-to-end with stubbed LLM', () => {
+  test('default answer-gen + extractor route provider-prefixed models through gateway', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'lme-gateway-'));
+    const outPath = join(tmp, 'hypothesis.jsonl');
+    const seenModels: string[] = [];
+    try {
+      __setChatTransportForTests(async (opts) => {
+        const model = opts.model ?? '';
+        seenModels.push(model);
+        if (opts.system?.includes('You extract typed claims')) {
+          return gatewayResult('[]', model);
+        }
+        return gatewayResult('gateway-answer', model);
+      });
+
+      await runEvalLongMemEval(
+        [FIXTURE_PATH, '--keyword-only', '--limit', '1', '--output', outPath, '--top-k', '3', '--model', 'sonnet'],
+        { engine: sharedEngine },
+      );
+
+      expect(seenModels).toContain('anthropic:claude-sonnet-4-6');
+      expect(seenModels).toContain('anthropic:claude-haiku-4-5-20251001');
+      const rows = readFileSync(outPath, 'utf8').split('\n').filter(Boolean).map(l => JSON.parse(l));
+      expect(rows.length).toBe(1);
+      expect(rows[0].hypothesis).toContain('gateway-answer');
+      expect(rows[0].error).toBeUndefined();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  }, 60_000);
+
   test('5-question fixture produces 5 valid JSONL lines via --output', async () => {
     const tmp = mkdtempSync(join(tmpdir(), 'lme-test-'));
     const outPath = join(tmp, 'hypothesis.jsonl');

--- a/test/longmemeval-extract.test.ts
+++ b/test/longmemeval-extract.test.ts
@@ -265,7 +265,7 @@ describe('extractAndInsertClaims — content-hash cache', () => {
 });
 
 describe('extractAndInsertClaims — fail-open paths', () => {
-  test('malformed JSON output → 0 inserted, no throw', async () => {
+  test('malformed JSON output → 0 inserted, no throw, reports extractor error', async () => {
     const aliasMap = makeAliasMap();
     const client: ThinkLLMClient = {
       create: async () => ({
@@ -280,9 +280,10 @@ describe('extractAndInsertClaims — fail-open paths', () => {
       sessionBody: 'body', sourceId: 'default', aliasMap,
     });
     expect(result.inserted).toBe(0);
+    expect(result.error).toBe('extractor_failed');
   });
 
-  test('Haiku call throws → 0 inserted, no throw', async () => {
+  test('Haiku call throws → 0 inserted, no throw, reports extractor error', async () => {
     const aliasMap = makeAliasMap();
     const client: ThinkLLMClient = {
       create: async () => { throw new Error('synthetic API failure'); },
@@ -292,6 +293,7 @@ describe('extractAndInsertClaims — fail-open paths', () => {
       sessionBody: 'body', sourceId: 'default', aliasMap,
     });
     expect(result.inserted).toBe(0);
+    expect(result.error).toBe('extractor_failed');
   });
 
   test('empty array output → 0 inserted, no throw', async () => {


### PR DESCRIPTION
## Summary

Fixes #2099.

`gbrain eval longmemeval` resolved default model aliases to provider-prefixed IDs like `anthropic:claude-sonnet-4-6`, then passed those IDs directly into the raw Anthropic SDK. That 404s out of the box because the native SDK expects a bare Anthropic model name.

This PR routes LongMemEval answer generation and trajectory extraction through the provider-neutral AI gateway instead, matching the rest of the provider-routed chat stack. It also makes extractor failures visible in benchmark telemetry instead of silently degrading trajectory recall.

## What changed

- Replace LongMemEval's default raw `new Anthropic()` clients with a small gateway-backed `ThinkLLMClient` adapter.
- Preserve existing test injection seams for answer-gen and extractor clients.
- Convert gateway responses back into the Anthropic-shaped message object expected by existing LongMemEval helper code.
- Report `extractor.errors` in the LongMemEval summary when extractor calls fail or return unparseable output.
- Keep valid empty extractor arrays as non-errors.

## Verification

- `bun test test/longmemeval-extract.test.ts --timeout 60000` PASS, 19 tests
- `bun test test/eval-longmemeval-e2e.slow.test.ts --timeout 90000` PASS, 12 tests
- `bunx tsc --noEmit --pretty false` PASS
- `bun run check:gateway-routed` PASS
- `bun run build` PASS
- `bun run verify` PASS, 30 checks
- `git diff --check` PASS

## Autoreview

- Initial Hermes reviewer pass found one blocker: malformed extractor output still looked like a valid empty result.
- Fixed by returning `extractor_failed` for unparseable/no-text extractor output while leaving valid `[]` as non-error.
- Fresh reviewer pass after the fix: CLEAN, no blocking findings.

## Notes

A rerun of `bun run build` initially hit local disk ENOSPC while copying the Bun executable. I removed generated/cache artifacts under `/tmp`, reran the build, and it passed. No source files were removed.
