### PR TITLE
fix: allow user-provided llama-server embedding model

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -709,7 +709,8 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
-    (recipe.id === 'litellm' || isUserProvided)
+    (recipe.id === 'litellm' || isUserProvided) &&
+    !parsed.modelId
   ) {
     return {
       ok: false,

--- a/test/embed-preflight.test.ts
+++ b/test/embed-preflight.test.ts
@@ -6,7 +6,7 @@
  * process.env.
  */
 import { describe, test, expect, beforeEach, afterAll } from 'bun:test';
-import { configureGateway, resetGateway } from '../src/core/ai/gateway.ts';
+import { configureGateway, diagnoseEmbedding, resetGateway } from '../src/core/ai/gateway.ts';
 import {
   validateEmbeddingCreds,
   formatEmbeddingCredsError,
@@ -106,6 +106,22 @@ describe('validateEmbeddingCreds', () => {
     if (!e.diagnosis.ok) {
       expect(e.diagnosis.reason).toBe('unknown_provider');
     }
+  });
+
+  test('passes for llama-server when the configured model string includes a user model id', () => {
+    configureGateway(baseConfig({
+      embedding_model: 'llama-server:text-embedding-qwen3-embedding-0.6b',
+      embedding_dimensions: 1024,
+      env: {},
+    }));
+
+    expect(diagnoseEmbedding()).toEqual({
+      ok: true,
+      model: 'llama-server:text-embedding-qwen3-embedding-0.6b',
+      provider: 'llama-server',
+      recipeId: 'llama-server',
+    });
+    expect(() => validateEmbeddingCreds()).not.toThrow();
   });
 
   test('throws no_gateway_config when gateway was not configured', () => {


### PR DESCRIPTION
## Summary
- fix embedding preflight for user-provided llama-server embedding model ids
- add regression coverage for `llama-server:text-embedding-qwen3-embedding-0.6b`

Fixes #1740

## Verification
- `bun test test/embed-preflight.test.ts --test-name-pattern 'passes for llama-server'` ✅
- `bun test test/embed-preflight.test.ts` ✅
- `bun run typecheck` ✅
- `bun run verify` ⚠️ 29/30 passed locally; `check:wasm` failed in this worktree with `bun build --compile` killed/exit 137 after the machine reported the Data volume at 100% capacity. Focused tests and typecheck pass.
