### PR TITLE
feat(recipes): add MLX embedding + MLX chat recipes for Apple silicon

### DIFF
--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -49,6 +49,8 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   // on different ports.
   if (process.env.LLAMA_SERVER_RERANKER_BASE_URL) envBaseUrls['llama-server-reranker'] = process.env.LLAMA_SERVER_RERANKER_BASE_URL;
   if (process.env.OLLAMA_BASE_URL) envBaseUrls['ollama'] = process.env.OLLAMA_BASE_URL;
+  if (process.env.MLX_EMBEDDING_BASE_URL) envBaseUrls['mlx-embedding'] = process.env.MLX_EMBEDDING_BASE_URL;
+  if (process.env.MLX_GEMMA4_BASE_URL) envBaseUrls['mlx-gemma4'] = process.env.MLX_GEMMA4_BASE_URL;
   if (process.env.LMSTUDIO_BASE_URL) envBaseUrls['lmstudio'] = process.env.LMSTUDIO_BASE_URL;
   if (process.env.LITELLM_BASE_URL) envBaseUrls['litellm'] = process.env.LITELLM_BASE_URL;
   if (process.env.OPENROUTER_BASE_URL) envBaseUrls['openrouter'] = process.env.OPENROUTER_BASE_URL;

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -9,6 +9,8 @@ import type { Recipe } from '../types.ts';
 import { openai } from './openai.ts';
 import { google } from './google.ts';
 import { anthropic } from './anthropic.ts';
+import { mlxEmbedding } from './mlx-embedding.ts';
+import { mlxGemma4 } from './mlx-gemma4.ts';
 import { ollama } from './ollama.ts';
 import { openrouter } from './openrouter.ts';
 import { voyage } from './voyage.ts';
@@ -28,6 +30,8 @@ const ALL: Recipe[] = [
   openai,
   google,
   anthropic,
+  mlxEmbedding,
+  mlxGemma4,
   ollama,
   openrouter,
   voyage,

--- a/src/core/ai/recipes/mlx-embedding.ts
+++ b/src/core/ai/recipes/mlx-embedding.ts
@@ -1,0 +1,31 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * Local MLX embedding server on Apple Silicon.
+ *
+ * Hunter's preferred local-memory embedding path: the roocode MLX indexer
+ * exposes an OpenAI-compatible /v1/embeddings endpoint backed by
+ * mlx-community/Qwen3-Embedding-8B-4bit-DWQ.
+ */
+export const mlxEmbedding: Recipe = {
+  id: 'mlx-embedding',
+  name: 'MLX Embeddings (local Mac)',
+  tier: 'openai-compat',
+  implementation: 'openai-compatible',
+  base_url_default: 'http://127.0.0.1:8080/v1',
+  auth_env: {
+    required: [],
+    optional: ['MLX_EMBEDDING_BASE_URL', 'MLX_EMBEDDING_API_KEY'],
+    setup_url: 'https://github.com/ml-explore/mlx-examples/tree/main/llms',
+  },
+  touchpoints: {
+    embedding: {
+      models: ['mlx-community/Qwen3-Embedding-8B-4bit-DWQ'],
+      default_dims: 4096,
+      cost_per_1m_tokens_usd: 0,
+      price_last_verified: '2026-06-06',
+      no_batch_cap: true,
+    },
+  },
+  setup_hint: 'Start the local MLX embedding LaunchAgent on 127.0.0.1:8080 with Qwen3-Embedding-8B-4bit-DWQ.',
+};

--- a/src/core/ai/recipes/mlx-gemma4.ts
+++ b/src/core/ai/recipes/mlx-gemma4.ts
@@ -1,0 +1,39 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * Local Gemma 4 MLX chat server on Apple Silicon.
+ *
+ * The server is OpenAI-compatible and intentionally marked tool-unsafe:
+ * GBrain may use it for cheap local query expansion and plain chat, but not
+ * for Minions/subagent loops.
+ */
+export const mlxGemma4: Recipe = {
+  id: 'mlx-gemma4',
+  name: 'Gemma 4 31B MLX (local Mac)',
+  tier: 'openai-compat',
+  implementation: 'openai-compatible',
+  base_url_default: 'http://127.0.0.1:8081/v1',
+  auth_env: {
+    required: [],
+    optional: ['MLX_GEMMA4_BASE_URL', 'MLX_GEMMA4_API_KEY'],
+    setup_url: 'https://github.com/ml-explore/mlx-examples/tree/main/llms/mlx_lm',
+  },
+  touchpoints: {
+    expansion: {
+      models: ['nightmedia/gemma-4-31B-it-mxfp4-mlx'],
+      cost_per_1m_tokens_usd: 0,
+      price_last_verified: '2026-05-22',
+    },
+    chat: {
+      models: ['nightmedia/gemma-4-31B-it-mxfp4-mlx'],
+      supports_tools: false,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      max_context_tokens: 262144,
+      cost_per_1m_input_usd: 0,
+      cost_per_1m_output_usd: 0,
+      price_last_verified: '2026-05-22',
+    },
+  },
+  setup_hint: 'Start mlx_lm.server for Gemma 4 31B MLX on 127.0.0.1:8081.',
+};


### PR DESCRIPTION
Adds first-class recipes for local inference on Apple silicon via `mlx_lm.server` / MLX OpenAI-compatible shims:

- **`mlx-embedding`** — local embedding provider. Running in production with `Qwen3-Embedding-8B-4bit-DWQ` at 4096 dimensions.
- **`mlx-gemma4`** — local chat/expansion provider for MLX-served chat models.

Both follow the existing recipe shape (`base_url_default` + env override), and `buildGatewayConfig` gains `MLX_EMBEDDING_BASE_URL` / `MLX_GEMMA4_BASE_URL` passthrough, mirroring the existing llama-server and Ollama entries.

No behavior change for anyone not setting these env vars.

**Tested:** running since April 2026 on a 24GB M-series Mac mini — embeddings, sync, and autopilot extract cycles against a ~150-page brain. `test/ai/build-gateway-config.test.ts` passes (7/7).
