### PR TITLE
fix(budget): price non-Anthropic chat models via the canonical table

### DIFF
--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -32,6 +32,7 @@ import { mkdirSync, appendFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { gbrainPath } from '../config.ts';
 import { ANTHROPIC_PRICING, type ModelPricing } from '../anthropic-pricing.ts';
+import { canonicalLookup } from '../model-pricing.ts';
 import { EMBEDDING_PRICING, lookupEmbeddingPrice } from '../embedding-pricing.ts';
 import { splitProviderModelId } from '../model-id.ts';
 import { isoWeekFilename, resolveAuditDir } from '../audit-week-file.ts';
@@ -194,6 +195,14 @@ function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
     const tailHit = ANTHROPIC_PRICING[modelTail];
     if (tailHit) return tailHit;
   }
+  // Non-Anthropic chat models (openai:, openrouter:, google:, etc.) live in
+  // the canonical pricing table, not the Anthropic-only ANTHROPIC_PRICING
+  // view. Without this fall-through, every non-Anthropic chat model returns
+  // null -> under the always-present default cost cap, reserve() throws
+  // BudgetExhausted (no_pricing) BEFORE the provider call, silently zeroing
+  // extraction for those providers.
+  const canonical = canonicalLookup(modelId);
+  if (canonical) return canonical;
   // v0.40.6.1: zero-price local-inference rerank providers so the budget
   // tracker's TX2 hard-fail doesn't trip on `llama-server-reranker:<model>`
   // under `--max-cost`. Only the rerank kind — chat/embed already have

--- a/src/core/model-pricing.ts
+++ b/src/core/model-pricing.ts
@@ -70,6 +70,12 @@ export const CANONICAL_PRICING: Record<string, ModelPricing> = {
   'openai:gpt-5':                         { input:  5.00, output: 20.00 },
   'openai:gpt-5.5':                       { input:  4.00, output: 16.00 },
 
+  // -- OpenRouter (subscription/proxy endpoints -- $0 per-token; without an
+  //    entry the budget gate hard-fails on missing pricing under the default
+  //    cap) ----------------------------------------------------------------
+  'openrouter:gpt-5.5':                   { input:  0.00, output:  0.00 },
+  'openrouter:gpt-5.4-mini':              { input:  0.00, output:  0.00 },
+
   // ── Google ─────────────────────────────────────────────────────────────
   'google:gemini-1.5-pro':                { input:  1.25, output:  5.00 },
   // Gemini 2.0 Flash: $0.10 in / $0.40 out (verified 2026-06-03). Reconciled


### PR DESCRIPTION
## Problem

`lookupChatPrice` in `budget-tracker.ts` only consults `ANTHROPIC_PRICING`. Any non-Anthropic chat model (`openai:gpt-5.5`, `openrouter:*`, `google:*`) resolves to null pricing, and because a default cost cap is always present, `reserve()` throws `BudgetExhausted (no_pricing)` **before the provider call**. Facts extraction silently produces nothing for those providers — no error surfaces to the operator.

Hit this in production running gbrain extraction through a subscription proxy (OpenAI-compatible endpoint) — extraction was silently dead until we traced it to the budget gate.

## Fix

- `lookupChatPrice` falls through to the existing exported `canonicalLookup` from `model-pricing.ts` after the Anthropic views miss.
- Add $0 canonical entries for subscription-proxy OpenRouter endpoints (`openrouter:gpt-5.5`, `openrouter:gpt-5.4-mini`) so the TX2 hard-fail doesn't trip on per-token-free routes.

Running patched in production since 2026-06-11 (two daemons, extraction + dream drills green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)