### PR TITLE
fix(code-graph): tag code_edges_symbol rows with source_id on extraction

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -1231,6 +1231,7 @@ export async function importCodeFile(
           from_symbol_qualified: from.symbol_name_qualified,
           to_symbol_qualified: e.toSymbol,
           edge_type: e.edgeType,
+          source_id: sourceId ?? 'default',
         });
       }
 


### PR DESCRIPTION
## Problem

`code_callers` / `code_callees` (and the `resolve_symbol_edges` pass) return `count: 0` / `status: "not_built"` even on brains whose `code_edges_symbol` table is fully populated, while `code_def` / `code_refs` work fine.

## Root cause

`importCodeFile` builds each `CodeEdgeInput` **without** `source_id`, so every extracted call-graph edge is persisted with `source_id = NULL` (`addCodeEdges` maps `e.source_id ?? null`). The reader paths are source-scoped:

- `getCallersOf` / `getCalleesOf` add `AND source_id = <scoped>` → the NULL rows are excluded → `count: 0`.
- `resolveSymbolEdgesIncremental` loads edges with `AND source_id = $2` → 0 rows → it resolves nothing yet still stamps `content_chunks.edges_backfilled_at`, so the chunks are marked done and not retried.

`source_id` is already in scope at the edge-building site (it's used a few lines above in `engine.getChunks(slug, { sourceId })`); it simply wasn't propagated onto the edge input.

`code_def` / `code_refs` are unaffected because they read `content_chunks` brain-wide, without the source filter — which is why the call graph looks "half-broken".

## Fix

Set `source_id: sourceId ?? 'default'` on the `CodeEdgeInput`, mirroring exactly how pages and chunks are persisted everywhere else in the same file (e.g. the `source_id: sourceId ?? 'default'` used around lines 333 and 1070). One line.

## Verify

On a brain with code under a named source: before, `code_callers <symbol>` returns `count: 0` / `not_built`; after a re-`sync` / `reindex-code` with the fix, edges are born tagged and `code_callers` / `code_callees` return `ready` with the correct callers. Verified end-to-end on a small repo (8 edges, all source-tagged) and at scale (~56k edges across 5 sources, 0 NULL).
