### PR TITLE
docs: route non-project correspondence out of issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,8 @@ about: Something isn't working
 labels: bug
 ---
 
+For non-project correspondence, including legal/IP/attribution or partnership topics, see [SUPPORT.md](https://github.com/garrytan/gbrain/blob/master/SUPPORT.md) instead of opening a public issue.
+
 **What happened?**
 
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Non-project correspondence
+    url: https://github.com/garrytan/gbrain/blob/master/SUPPORT.md
+    about: Legal, IP, attribution, partnership, and other non-project correspondence does not belong in public issues.
+  - name: Security vulnerability
+    url: https://github.com/garrytan/gbrain/security/advisories/new
+    about: Report vulnerabilities privately through GitHub Security Advisories.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,8 @@ about: Suggest an improvement
 labels: enhancement
 ---
 
+For non-project correspondence, including legal/IP/attribution or partnership topics, see [SUPPORT.md](https://github.com/garrytan/gbrain/blob/master/SUPPORT.md) instead of opening a public issue.
+
 **What problem does this solve?**
 
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,39 @@
+# Support
+
+Use GitHub issues for work the project can act on in public:
+
+- reproducible bugs
+- feature requests
+- documentation gaps
+- installation or upgrade problems
+- small, scoped implementation proposals
+
+## Non-project correspondence
+
+Do not open a public issue for legal, IP, attribution, or partnership correspondence.
+Those topics are not actionable as normal project issues, and public issue threads are
+not the right venue for private or legal-sensitive discussion.
+
+If you need to reach the maintainers about one of those topics, use a private channel
+listed by the maintainer or organization outside the issue tracker. Keep the public
+issue tracker focused on reproducible project work.
+
+## Security vulnerabilities
+
+Do not open a public issue for security vulnerabilities. Follow `SECURITY.md` and open
+a private GitHub security advisory instead:
+
+https://github.com/garrytan/gbrain/security/advisories/new
+
+## Questions and setup help
+
+For setup and operation, start with:
+
+- `README.md`
+- `AGENTS.md`
+- `INSTALL_FOR_AGENTS.md`
+- `docs/INSTALL.md`
+
+If those docs are missing something concrete, open a documentation issue and include
+the exact command, output, OS, Bun version, and `gbrain doctor --json` result where
+relevant.

--- a/test/community-support-routing.test.ts
+++ b/test/community-support-routing.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..");
+const read = (path: string) => readFileSync(join(repoRoot, path), "utf8");
+const supportUrl = "https://github.com/garrytan/gbrain/blob/master/SUPPORT.md";
+
+describe("community support routing", () => {
+  test("SUPPORT.md routes non-project correspondence away from public issues", () => {
+    const supportPath = join(repoRoot, "SUPPORT.md");
+    expect(existsSync(supportPath), "SUPPORT.md should exist").toBe(true);
+
+    const support = read("SUPPORT.md").toLowerCase();
+    expect(support).toContain("legal, ip, attribution, or partnership");
+    expect(support).toContain("do not open a public issue");
+    expect(support).toContain("security advisory");
+  });
+
+  test("GitHub issue chooser exposes the non-project correspondence route", () => {
+    const config = read(".github/ISSUE_TEMPLATE/config.yml");
+    expect(config).toContain("blank_issues_enabled: false");
+    expect(config).toContain("Non-project correspondence");
+    expect(config).toContain(supportUrl);
+  });
+
+  test("bug and feature templates tell reporters what belongs in issues", () => {
+    for (const template of [
+      ".github/ISSUE_TEMPLATE/bug_report.md",
+      ".github/ISSUE_TEMPLATE/feature_request.md",
+    ]) {
+      const body = read(template).toLowerCase();
+      expect(body, template).toContain("for non-project correspondence");
+      expect(body, template).toContain(supportUrl.toLowerCase());
+      expect(body, template).toContain("legal/ip/attribution");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Addresses #1627 by routing non-project correspondence out of public GitHub issues instead of treating legal/IP/prior-art claims as normal bug or feature work.

This PR:
- adds `SUPPORT.md` with explicit guidance for actionable issues, non-project correspondence, and security vulnerabilities
- adds GitHub issue chooser contact links for non-project correspondence and private security advisories
- disables blank issues so reporters choose a scoped route
- adds the same routing note to the bug and feature templates
- adds a regression test that pins the routing contract and absolute SUPPORT.md links

## Verification

- `git diff --check origin/master...HEAD` passed
- `bun test test/community-support-routing.test.ts` passed
  - 3 pass, 0 fail, 13 assertions
- `bun run verify` was attempted
  - 29/30 checks passed
  - `check:wasm` exited 137
  - rerunning `bun run check:wasm` alone also exited 137 in this worktree

## Notes

No code/runtime behavior changes. This is intentionally scoped to GitHub community routing so future legal/IP/attribution correspondence does not become public issue-tracker noise.

Addresses #1627
