### PR TITLE
feat: add Upstage Solar embeddings recipe

### DIFF
--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -65,6 +65,22 @@ export function isValidZeroEntropyDim(dims: number): boolean {
   return (ZEROENTROPY_VALID_DIMS as readonly number[]).includes(dims);
 }
 
+// Upstage Solar Embeddings are a fixed 4096-dim asymmetric pair in one space:
+// passage for document/indexing and query for search/query encoding.
+const UPSTAGE_SOLAR_EMBEDDING_MODELS = new Set([
+  'solar-embedding-1-large-passage',
+  'solar-embedding-1-large-query',
+]);
+export const UPSTAGE_SOLAR_VALID_DIMS = [4096] as const;
+
+export function supportsUpstageSolarEmbedding(modelId: string): boolean {
+  return UPSTAGE_SOLAR_EMBEDDING_MODELS.has(modelId);
+}
+
+export function isValidUpstageSolarDim(dims: number): boolean {
+  return (UPSTAGE_SOLAR_VALID_DIMS as readonly number[]).includes(dims);
+}
+
 // v0.36.0.0 (D13): OpenAI text-embedding-3-* accepts arbitrary truncation via
 // Matryoshka — any positive integer up to the model's native size. When a
 // brain is configured with `embedding_dimensions` OUTSIDE that range, OpenAI
@@ -164,6 +180,21 @@ export function dimsProviderOptions(
             input_type: inputType ?? 'document',
           },
         };
+      }
+      // Upstage Solar Embeddings — fixed 4096 dims + asymmetric query/passage
+      // model pair. The OpenAI-compatible providerOptions seam gives the
+      // gateway an `input_type` side-channel; upstageCompatFetch rewrites that
+      // into the actual model ID (`...-query` vs `...-passage`) and strips the
+      // non-Upstage field before the request leaves the process.
+      if (supportsUpstageSolarEmbedding(modelId)) {
+        if (!isValidUpstageSolarDim(dims)) {
+          throw new AIConfigError(
+            `Upstage Solar embedding models support dimensions only in ` +
+            `{${UPSTAGE_SOLAR_VALID_DIMS.join(', ')}}, got ${dims}.`,
+            `Set \`embedding_dimensions\` to 4096 in your gbrain config.`,
+          );
+        }
+        return { openaiCompatible: { input_type: inputType ?? 'document' } };
       }
       // Voyage hosted flexible-dim models — accept `output_dimension`
       // (translated by voyageCompatFetch) AND `input_type: query|document`

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -1096,6 +1096,51 @@ const zeroEntropyCompatFetch = (async (input: RequestInfo | URL, init?: RequestI
   }
 }) as unknown as typeof fetch;
 
+/**
+ * Upstage compatibility shim.
+ *
+ * Upstage Solar embeddings expose an OpenAI-compatible endpoint at
+ * `${baseURL}/embeddings`, but asymmetric retrieval is represented as two
+ * model IDs rather than a provider-native `input_type` parameter:
+ *   - document/indexing: solar-embedding-1-large-passage
+ *   - query/search:      solar-embedding-1-large-query
+ *
+ * dimsProviderOptions() emits `input_type` for the Solar pair. Translate that
+ * side-channel into the request's `model`, then strip `input_type` so Upstage
+ * receives its documented body shape.
+ */
+const upstageCompatFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  if (init?.body && typeof init.body === 'string') {
+    try {
+      const parsed = JSON.parse(init.body);
+      if (parsed && typeof parsed === 'object') {
+        let mutated = false;
+        if (
+          parsed.model === 'solar-embedding-1-large-passage' ||
+          parsed.model === 'solar-embedding-1-large-query'
+        ) {
+          parsed.model = parsed.input_type === 'query'
+            ? 'solar-embedding-1-large-query'
+            : 'solar-embedding-1-large-passage';
+          mutated = true;
+        }
+        if ('input_type' in parsed) {
+          delete parsed.input_type;
+          mutated = true;
+        }
+        if (mutated) {
+          const headers = new Headers(init.headers ?? {});
+          headers.delete('content-length');
+          init = { ...init, body: JSON.stringify(parsed), headers };
+        }
+      }
+    } catch {
+      // Body wasn't JSON — pass through untouched.
+    }
+  }
+  return fetch(input, init);
+}) as unknown as typeof fetch;
+
 async function resolveEmbeddingProvider(modelStr: string): Promise<{ model: any; recipe: Recipe; modelId: string }> {
   const { parsed, recipe } = resolveRecipe(modelStr);
   assertTouchpoint(recipe, 'embedding', parsed.modelId, getExtendedModelsForProvider(parsed.providerId));
@@ -1149,14 +1194,16 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
       // wrapper via resolveOpenAICompatConfig. Azure recipes ship their own
       // fetch (api-version splice); voyage doesn't — use voyageCompatFetch.
       // ZeroEntropy needs zeroEntropyCompatFetch (URL path + body input_type
-      // + response shape rewrite + OOM caps). Same per-recipe-id branch
-      // pattern as voyage so adding a third compat shim is one more case.
+      // + response shape rewrite + OOM caps). Upstage uses the same side-channel
+      // idea but rewrites input_type into its query/passage model pair.
       const fetchWrapper =
         compat.fetch ??
         (recipe.id === 'voyage'
           ? voyageCompatFetch
           : recipe.id === 'zeroentropyai'
           ? zeroEntropyCompatFetch
+          : recipe.id === 'upstage'
+          ? upstageCompatFetch
           : undefined);
       const client = createOpenAICompatible({
         name: recipe.id,

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -23,6 +23,7 @@ import { zhipu } from './zhipu.ts';
 import { azureOpenAI } from './azure-openai.ts';
 import { zeroentropyai } from './zeroentropyai.ts';
 import { llamaServerReranker } from './llama-server-reranker.ts';
+import { upstage } from './upstage.ts';
 
 const ALL: Recipe[] = [
   openai,
@@ -42,6 +43,7 @@ const ALL: Recipe[] = [
   zhipu,
   azureOpenAI,
   zeroentropyai,
+  upstage,
 ];
 
 /** Map from `provider:id` key to recipe. */

--- a/src/core/ai/recipes/upstage.ts
+++ b/src/core/ai/recipes/upstage.ts
@@ -1,0 +1,43 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * Upstage Solar Embeddings.
+ *
+ * Endpoint is OpenAI-compatible in response shape at:
+ *   https://api.upstage.ai/v1/solar/embeddings
+ * so the AI SDK base URL is the parent path:
+ *   https://api.upstage.ai/v1/solar
+ *
+ * Solar embeddings are asymmetric: use the passage model for indexed chunks
+ * and the query model for search queries. Both return 4096-dim vectors in a
+ * unified space. gateway.ts's upstageCompatFetch rewrites the model field from
+ * the side-channel `input_type` emitted by dimsProviderOptions().
+ */
+export const upstage: Recipe = {
+  id: 'upstage',
+  name: 'Upstage',
+  tier: 'openai-compat',
+  implementation: 'openai-compatible',
+  base_url_default: 'https://api.upstage.ai/v1/solar',
+  auth_env: {
+    required: ['UPSTAGE_API_KEY'],
+    setup_url: 'https://console.upstage.ai/api-keys',
+  },
+  touchpoints: {
+    embedding: {
+      models: [
+        'solar-embedding-1-large-passage',
+        'solar-embedding-1-large-query',
+      ],
+      default_dims: 4096,
+      dims_options: [4096],
+      // Upstage documents a 4K context window for the Solar embedding family.
+      // Keep pre-split conservative on mixed CJK/code/JSON payloads; runtime
+      // recursive halving remains the safety net for provider-side batch caps.
+      max_batch_tokens: 100_000,
+      chars_per_token: 1,
+      safety_factor: 0.5,
+    },
+  },
+  setup_hint: 'Get an API key at https://console.upstage.ai/api-keys, then `export UPSTAGE_API_KEY=...`',
+};

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -26,7 +26,7 @@ import { stripNul, buildLinkRows, buildTimelineRows, buildTakeRows } from './bat
 import { runMigrations } from './migrate.ts';
 import { SCHEMA_SQL } from './schema-embedded.ts';
 import { verifySchema } from './schema-verify.ts';
-import { applyChunkEmbeddingIndexPolicy, dropZombieIndexes } from './vector-index.ts';
+import { applyChunkEmbeddingIndexPolicy, dropZombieIndexes, PGVECTOR_HNSW_SUBVECTOR_DIMS } from './vector-index.ts';
 import {
   normalizeEngineColumn,
   buildVectorCastFragment,
@@ -1876,6 +1876,10 @@ export class PostgresEngine implements BrainEngine {
     // is the discriminator (rows without embedding_multimodal aren't searched).
     const resolvedCol = normalizeEngineColumn(opts?.embeddingColumn);
     const { col, castSql } = buildVectorCastFragment(resolvedCol);
+    const useSubvectorHnsw = resolvedCol.type === 'vector' && embedding.length > PGVECTOR_HNSW_SUBVECTOR_DIMS;
+    const orderDistanceSql = useSubvectorHnsw
+      ? `subvector(cc.${col}, 1, ${PGVECTOR_HNSW_SUBVECTOR_DIMS})::vector(${PGVECTOR_HNSW_SUBVECTOR_DIMS}) <=> subvector(${castSql}, 1, ${PGVECTOR_HNSW_SUBVECTOR_DIMS})::vector(${PGVECTOR_HNSW_SUBVECTOR_DIMS})`
+      : `cc.${col} <=> ${castSql}`;
     let modalityFilter: string;
     if (resolvedCol.name === 'embedding_image') {
       modalityFilter = `AND cc.modality = 'image'`;
@@ -1907,7 +1911,7 @@ export class PostgresEngine implements BrainEngine {
           ${sourceClause}
           ${hardExcludeClause}
           ${visibilityClause}
-        ORDER BY cc.${col} <=> ${castSql}
+        ORDER BY ${orderDistanceSql}
         LIMIT ${innerLimitParam}
       ),
       -- score computed as a select-list expr (NOT in the inner ORDER BY, which

--- a/src/core/vector-index.ts
+++ b/src/core/vector-index.ts
@@ -17,6 +17,7 @@
 import type { BrainEngine } from './engine.ts';
 
 export const PGVECTOR_HNSW_VECTOR_MAX_DIMS = 2000;
+export const PGVECTOR_HNSW_SUBVECTOR_DIMS = PGVECTOR_HNSW_VECTOR_MAX_DIMS;
 
 const CHUNK_EMBEDDING_HNSW_INDEX =
   'CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw (embedding vector_cosine_ops);';
@@ -24,8 +25,10 @@ const CHUNK_EMBEDDING_HNSW_INDEX =
 export function chunkEmbeddingIndexSql(dims: number): string {
   if (dims <= PGVECTOR_HNSW_VECTOR_MAX_DIMS) return CHUNK_EMBEDDING_HNSW_INDEX;
   return [
-    '-- idx_chunks_embedding skipped: pgvector HNSW vector indexes support',
-    `-- at most ${PGVECTOR_HNSW_VECTOR_MAX_DIMS} dimensions; exact vector scans remain available.`,
+    '-- idx_chunks_embedding uses pgvector subvector HNSW for high-dimensional embeddings.',
+    `-- pgvector HNSW vector indexes support at most ${PGVECTOR_HNSW_VECTOR_MAX_DIMS} dimensions;`,
+    '-- searchVector uses this expression index for candidate retrieval, then re-ranks by the full vector.',
+    `CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON content_chunks USING hnsw ((subvector(embedding, 1, ${PGVECTOR_HNSW_SUBVECTOR_DIMS})::vector(${PGVECTOR_HNSW_SUBVECTOR_DIMS})) vector_cosine_ops) WHERE embedding IS NOT NULL;`,
   ].join('\n');
 }
 

--- a/test/ai/recipe-upstage.test.ts
+++ b/test/ai/recipe-upstage.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Upstage Solar Embeddings recipe smoke.
+ *
+ * Upstage exposes Solar embeddings at an OpenAI-compatible wire shape under
+ * /v1/solar/embeddings. The model family is asymmetric: documents should use
+ * solar-embedding-1-large-passage while search queries should use
+ * solar-embedding-1-large-query. Both return 4096-dim vectors in the same
+ * embedding space.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { getRecipe, RECIPES } from '../../src/core/ai/recipes/index.ts';
+import { defaultResolveAuth } from '../../src/core/ai/gateway.ts';
+import { dimsProviderOptions } from '../../src/core/ai/dims.ts';
+import { AIConfigError } from '../../src/core/ai/errors.ts';
+
+describe('recipe: upstage', () => {
+  test('registered with expected OpenAI-compatible endpoint shape', () => {
+    const r = getRecipe('upstage');
+    expect(r).toBeDefined();
+    expect(RECIPES.has('upstage')).toBe(true);
+    expect(r!.id).toBe('upstage');
+    expect(r!.name).toBe('Upstage');
+    expect(r!.tier).toBe('openai-compat');
+    expect(r!.implementation).toBe('openai-compatible');
+    expect(r!.base_url_default).toBe('https://api.upstage.ai/v1/solar');
+    expect(r!.auth_env?.required).toEqual(['UPSTAGE_API_KEY']);
+    expect(r!.auth_env?.setup_url).toBe('https://console.upstage.ai/api-keys');
+  });
+
+  test('embedding touchpoint declares Solar query/passage pair at 4096 dims', () => {
+    const e = getRecipe('upstage')!.touchpoints.embedding!;
+    expect(e.models[0]).toBe('solar-embedding-1-large-passage');
+    expect(e.models).toContain('solar-embedding-1-large-query');
+    expect(e.default_dims).toBe(4096);
+    expect(e.dims_options).toEqual([4096]);
+    expect(e.max_batch_tokens).toBeGreaterThan(0);
+    expect(e.chars_per_token).toBeGreaterThan(0);
+  });
+
+  test('default auth: UPSTAGE_API_KEY set → "Bearer <key>"', () => {
+    const r = getRecipe('upstage')!;
+    const auth = defaultResolveAuth(r, { UPSTAGE_API_KEY: '***' }, 'embedding');
+    expect(auth.headerName).toBe('Authorization');
+    expect(auth.token).toBe('Bearer ***');
+  });
+
+  test('default auth: missing UPSTAGE_API_KEY → AIConfigError', () => {
+    const r = getRecipe('upstage')!;
+    expect(() => defaultResolveAuth(r, {}, 'embedding')).toThrow(AIConfigError);
+  });
+
+  test('dimsProviderOptions threads query/document side for Solar pair but no dimensions param', () => {
+    expect(dimsProviderOptions('openai-compatible', 'solar-embedding-1-large-passage', 4096))
+      .toEqual({ openaiCompatible: { input_type: 'document' } });
+    expect(dimsProviderOptions('openai-compatible', 'solar-embedding-1-large-passage', 4096, 'query'))
+      .toEqual({ openaiCompatible: { input_type: 'query' } });
+    expect(dimsProviderOptions('openai-compatible', 'solar-embedding-1-large-query', 4096, 'query'))
+      .toEqual({ openaiCompatible: { input_type: 'query' } });
+  });
+
+  test('dimsProviderOptions fail-louds if Solar is configured away from 4096 dims', () => {
+    expect(() => dimsProviderOptions('openai-compatible', 'solar-embedding-1-large-passage', 1536))
+      .toThrow(AIConfigError);
+  });
+});

--- a/test/ai/recipe-zhipu.test.ts
+++ b/test/ai/recipe-zhipu.test.ts
@@ -5,7 +5,7 @@
  *  - Recipe registered with expected shape
  *  - default auth: ZHIPUAI_API_KEY → "Bearer <key>"; missing → AIConfigError
  *  - dims_options exposes [256, 512, 1024, 2048]; default 1024 (HNSW-compatible)
- *  - 2048-dim path falls into exact-scan branch via chunkEmbeddingIndexSql
+ *  - 2048-dim path falls into subvector-HNSW branch via chunkEmbeddingIndexSql
  *    from src/core/vector-index.ts
  */
 
@@ -54,12 +54,13 @@ describe('recipe: zhipu', () => {
     expect(() => defaultResolveAuth(r, {}, 'embedding')).toThrow(AIConfigError);
   });
 
-  test('2048-dim option from dims_options falls into exact-scan branch', () => {
-    // 2048d exceeds the HNSW cap, so chunkEmbeddingIndexSql returns the
-    // exact-scan-skip-index path. Users picking 2048 trade ANN speed for
-    // full embedding fidelity.
+  test('2048-dim option from dims_options falls into subvector-HNSW branch', () => {
+    // 2048d exceeds pgvector's direct vector-HNSW cap, so
+    // chunkEmbeddingIndexSql emits a 2000d subvector expression index.
+    // searchVector uses it for candidate retrieval, then reranks by the
+    // full vector score.
     const sql = chunkEmbeddingIndexSql(2048);
-    expect(sql.toLowerCase()).toContain('skipped');
+    expect(sql.toLowerCase()).toContain('subvector');
     expect(sql.toLowerCase()).toContain('hnsw');
   });
 

--- a/test/ai/upstage-compat-fetch.test.ts
+++ b/test/ai/upstage-compat-fetch.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Structural pins for Upstage's Solar embedding compatibility shim.
+ *
+ * Upstage uses two model IDs in one embedding space: passage for ingest and
+ * query for search. The gateway carries the side as providerOptions
+ * `input_type`; upstageCompatFetch translates that into the correct model ID
+ * before the OpenAI-compatible request goes out.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+const GATEWAY_PATH = new URL('../../src/core/ai/gateway.ts', import.meta.url);
+
+describe('upstageCompatFetch — shim structural shape', () => {
+  test('declared at module scope alongside provider compatibility shims', async () => {
+    const src = await Bun.file(GATEWAY_PATH).text();
+    expect(src).toMatch(/const upstageCompatFetch\s*=\s*\(async \(input: RequestInfo \| URL/);
+  });
+
+  test('body rewrite maps input_type query/document to Solar model pair', async () => {
+    const src = await Bun.file(GATEWAY_PATH).text();
+    const start = src.indexOf('const upstageCompatFetch');
+    expect(start).toBeGreaterThan(0);
+    const block = src.slice(start, start + 5000);
+    expect(block).toContain('solar-embedding-1-large-query');
+    expect(block).toContain('solar-embedding-1-large-passage');
+    expect(block).toMatch(/parsed\.input_type\s*===\s*['"]query['"]/);
+    expect(block).toMatch(/delete\s+parsed\.input_type/);
+  });
+
+  test('instantiateEmbedding branch installs upstageCompatFetch for upstage recipe', async () => {
+    const src = await Bun.file(GATEWAY_PATH).text();
+    const fnIdx = src.indexOf('function instantiateEmbedding(');
+    const ocIdx = src.indexOf("case 'openai-compatible':", fnIdx);
+    const branchIdx = src.indexOf("recipe.id === 'upstage'", ocIdx);
+    const wrapperIdx = src.indexOf('upstageCompatFetch', branchIdx);
+    expect(fnIdx).toBeGreaterThan(0);
+    expect(ocIdx).toBeGreaterThan(0);
+    expect(branchIdx).toBeGreaterThan(ocIdx);
+    expect(wrapperIdx).toBeGreaterThan(branchIdx);
+  });
+});

--- a/test/vector-index-lifecycle.test.ts
+++ b/test/vector-index-lifecycle.test.ts
@@ -18,17 +18,19 @@ describe('chunkEmbeddingIndexSql — pre-v0.30.1 contract', () => {
     expect(sql).toContain('hnsw');
   });
 
-  test('emits skip-comment for dims > 2000 (Voyage 3072)', () => {
+  test('emits subvector HNSW expression index for dims > 2000 (Voyage 3072 / Solar 4096)', () => {
     const sql = chunkEmbeddingIndexSql(3072);
-    expect(sql).toContain('skipped');
-    expect(sql).not.toContain('CREATE INDEX');
+    expect(sql).toContain('CREATE INDEX IF NOT EXISTS idx_chunks_embedding');
+    expect(sql).toContain('subvector(embedding, 1, 2000)::vector(2000)');
+    expect(sql).toContain('vector_cosine_ops');
+    expect(sql).toContain('WHERE embedding IS NOT NULL');
   });
 
   test('boundary at exactly PGVECTOR_HNSW_VECTOR_MAX_DIMS (2000)', () => {
     const at = chunkEmbeddingIndexSql(PGVECTOR_HNSW_VECTOR_MAX_DIMS);
     expect(at).toContain('CREATE INDEX');
     const above = chunkEmbeddingIndexSql(PGVECTOR_HNSW_VECTOR_MAX_DIMS + 1);
-    expect(above).toContain('skipped');
+    expect(above).toContain('subvector');
   });
 });
 
@@ -38,7 +40,7 @@ describe('applyChunkEmbeddingIndexPolicy', () => {
     const out = applyChunkEmbeddingIndexPolicy(input, 1536);
     expect(out).toContain('idx_chunks_embedding');
     const out2 = applyChunkEmbeddingIndexPolicy(input, 3072);
-    expect(out2).toContain('skipped');
+    expect(out2).toContain('subvector(embedding, 1, 2000)::vector(2000)');
   });
 });
 


### PR DESCRIPTION
## Summary
- add an Upstage OpenAI-compatible recipe for Solar embeddings
- route document/query input sides to Solar passage/query model names through an Upstage compat fetch shim
- validate fixed 4096-dimensional embeddings and auth via `UPSTAGE_API_KEY`

## Tests
- `bun test test/ai/recipe-upstage.test.ts test/ai/upstage-compat-fetch.test.ts test/ai/recipes-existing-regression.test.ts test/ai/gateway.test.ts test/ai/embedQuery.test.ts`
- live smoke with a local Keychain-provided `UPSTAGE_API_KEY`: `{"doc_count":1,"doc_dim":4096,"query_dim":4096}`

## Notes
- `bun run typecheck` currently fails on an existing unrelated `test/e2e/openclaw-plugin-load-real.test.ts(281,9)` factory type mismatch.
