### PR TITLE
feat(security): '*' wildcard in federated_read for all-sources read scope

### DIFF
--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -135,6 +135,34 @@ queries return rows from any of the listed sources. Omit both flags for the
 v0.33-compatible super-client shape. Pre-v0.34 clients are backfilled to
 `source_id='default'` on `gbrain upgrade`.
 
+**Read-everything with `--federated-read '*'`.** For a read-only client that
+should see *every* source — current and future — pass the `'*'` wildcard
+instead of an explicit list:
+
+```bash
+gbrain auth register-client kb-reader \
+  --grant-types client_credentials \
+  --scopes read \
+  --federated-read '*'
+```
+
+This is the answer to "how do I grant access to sources added later?": an
+explicit source list is **frozen at registration** (there is no command to amend
+it — you'd revoke and re-issue), so a `'*'` grant is the only shape that auto-
+includes repos synced after the client was created. Properties:
+
+- **Read scope only.** `'*'` lives on the read axis; write authority still comes
+  from the scalar `--source` (a `'*'` write source is rejected by the FK), so a
+  wildcard reader can never write across sources.
+- **Deliberate, not a default.** Only an explicit `'*'` widens to all; an
+  empty/garbage grant stays fail-closed to `default` (the v0.42.37 isolation
+  contract is unchanged). Use it when "anyone who can reach this MCP endpoint
+  may read the whole brain" is the intended posture (e.g. a company code KB
+  behind a VPN/internal ALB).
+- **Narrowing still works.** A `'*'` client may pass `source_id: "<one>"` on a
+  call to scope a single query; code-traversal ops (`code_callers` etc.) are
+  single-source and require naming a source explicitly.
+
 Host-repo wrappers can register programmatically:
 
 ```ts

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -405,7 +405,7 @@ export function parseRegisterClientArgs(args: string[]): RegisterClientArgs {
 
 async function registerClient(name: string, args: string[]) {
   if (!name) {
-    console.error('Usage: auth register-client <name> [--grant-types G] [--scopes S] [--source SOURCE] [--federated-read SRC1,SRC2,...] [--redirect-uri URI ...] [--token-endpoint-auth-method client_secret_post|client_secret_basic|none]');
+    console.error('Usage: auth register-client <name> [--grant-types G] [--scopes S] [--source SOURCE] [--federated-read SRC1,SRC2,...|"*"] [--redirect-uri URI ...] [--token-endpoint-auth-method client_secret_post|client_secret_basic|none]');
     process.exit(1);
   }
   let parsed: RegisterClientArgs;
@@ -413,7 +413,7 @@ async function registerClient(name: string, args: string[]) {
     parsed = parseRegisterClientArgs(args);
   } catch (e: any) {
     console.error(`Error: ${e.message}`);
-    console.error('Usage: auth register-client <name> [--grant-types G] [--scopes S] [--source SOURCE] [--federated-read SRC1,SRC2,...] [--redirect-uri URI ...] [--token-endpoint-auth-method client_secret_post|client_secret_basic|none]');
+    console.error('Usage: auth register-client <name> [--grant-types G] [--scopes S] [--source SOURCE] [--federated-read SRC1,SRC2,...|"*"] [--redirect-uri URI ...] [--token-endpoint-auth-method client_secret_post|client_secret_basic|none]');
     process.exit(1);
   }
   const { grantTypes, scopes, sourceId, federatedRead, redirectUris, tokenEndpointAuthMethod } = parsed;
@@ -441,7 +441,10 @@ async function registerClient(name: string, args: string[]) {
         console.log(`  Redirect URIs:       ${redirectUris.join(', ')}`);
       }
       console.log(`  Write source:        ${sourceId}`);
-      console.log(`  Federated reads:     ${effectiveFederated.join(', ')}\n`);
+      const readsLabel = effectiveFederated.includes('*')
+        ? `* (ALL sources, read scope — current and future)`
+        : effectiveFederated.join(', ');
+      console.log(`  Federated reads:     ${readsLabel}\n`);
       if (clientSecret) {
         console.log('Save the client secret — it will not be shown again.');
       } else {

--- a/src/core/legacy-token-scope.ts
+++ b/src/core/legacy-token-scope.ts
@@ -1,17 +1,26 @@
+import { ALL_SOURCES_WILDCARD } from './operations.ts';
+
 /**
  * Derive a legacy bearer token's source scope from its stored
  * `access_tokens.permissions.source_id` grant.
  *
  * ARRAY = federated read grant, exposed through `allowedSources` with the
- * first granted source as the scalar write floor. STRING = scalar source.
- * Missing, empty, or garbage values fail closed to the historical `default`
- * floor and NEVER widen to all sources.
+ * first NON-wildcard source as the scalar write floor. A '*' entry means
+ * "read every source, current and future" — but '*' is a READ grant only
+ * and must never become the scalar write floor, so a wildcard-only array
+ * falls back to 'default'. STRING = scalar source. Missing, empty, or
+ * garbage values fail closed to the historical `default` floor and NEVER
+ * widen to all sources implicitly.
  */
 export function parseLegacyTokenScope(rawSource: unknown): { sourceId: string; allowedSources?: string[] } {
   if (Array.isArray(rawSource)) {
     const allowedSources = (rawSource as unknown[]).filter(s => typeof s === 'string' && s.length > 0) as string[];
     if (allowedSources.length > 0) {
-      return { sourceId: allowedSources[0], allowedSources };
+      // Scalar floor = first NON-wildcard source (the write authority). '*' is a
+      // READ grant only and must never become the scalar write floor, so a
+      // wildcard-only grant falls back to the 'default' floor.
+      const floor = allowedSources.find(s => s !== ALL_SOURCES_WILDCARD) ?? 'default';
+      return { sourceId: floor, allowedSources };
     }
     return { sourceId: 'default' };
   }

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -394,6 +394,18 @@ export interface OperationContext {
 }
 
 /**
+ * A `'*'` entry in a federated_read grant is an explicit, admin-issued
+ * "read every source" wildcard. READ SCOPE ONLY — writes always use the scalar
+ * source floor, never this. It must be set deliberately (e.g.
+ * `gbrain auth register-client --scopes read --federated-read '*'`); an
+ * empty/garbage grant NEVER widens to all (that fail-closed contract is what the
+ * v0.42.37 hardening restored). Solves the static-grant problem: one wildcard
+ * grant covers every source, present AND future, so newly-synced repos are
+ * readable immediately with nothing to re-issue.
+ */
+export const ALL_SOURCES_WILDCARD = '*';
+
+/**
  * v0.34.1 (#861, D9 — P0 leak seal): resolve the source-scope filter for a
  * read-side op handler. Returns an opts fragment ready to spread into the
  * engine call.
@@ -416,6 +428,10 @@ export interface OperationContext {
  */
 export function sourceScopeOpts(ctx: OperationContext): { sourceId?: string; sourceIds?: string[] } {
   const allowed = ctx.auth?.allowedSources;
+  // A deliberate '*' grant spans every source (read scope). Checked BEFORE the
+  // generic array branch so it returns the no-filter shape, not a literal
+  // `source_id = ANY(['*'])` (which would match a nonexistent source named '*').
+  if (allowed && allowed.includes(ALL_SOURCES_WILDCARD)) return {};
   // Treat an empty `allowedSources: []` as "no federated read scope" — the
   // op-handler defers to scalar `ctx.sourceId` below. An attacker-controlled
   // value of `[]` MUST NOT widen scope to "all sources" by being interpreted
@@ -464,8 +480,9 @@ export function linkReadScopeOpts(ctx: OperationContext): { sourceId?: string; s
  *       remote                           → the caller's grant (sourceScopeOpts)
  *   - explicit `source_id`:
  *       remote + federated grant that doesn't include it → permission_denied
+ *       (UNLESS the grant holds the '*' wildcard, which permits any source)
  *       otherwise                                        → `{ sourceId }`
- *   - neither → the caller's grant (sourceScopeOpts).
+ *   - neither → the caller's grant (sourceScopeOpts; '*' grant → spans all).
  *
  * `code_traversal_cache_clear` is intentionally NOT a caller — it is localOnly
  * and carries its own destructive D8 all_sources guard.
@@ -481,7 +498,10 @@ export function resolveRequestedScope(
   }
   if (sourceIdParam !== undefined) {
     const allowed = ctx.auth?.allowedSources;
-    if (ctx.remote !== false && allowed && allowed.length > 0 && !allowed.includes(sourceIdParam)) {
+    // A '*' wildcard grant permits narrowing to ANY single source, so skip the
+    // out-of-grant rejection for it.
+    const wildcard = !!allowed && allowed.includes(ALL_SOURCES_WILDCARD);
+    if (ctx.remote !== false && allowed && allowed.length > 0 && !wildcard && !allowed.includes(sourceIdParam)) {
       throw new OperationError(
         'permission_denied',
         `source '${sourceIdParam}' is outside your granted sources`,

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -28,7 +28,7 @@
 import { createHash } from 'crypto';
 import type { BrainEngine } from '../core/engine.ts';
 import { buildToolDefs } from './tool-defs.ts';
-import { operations } from '../core/operations.ts';
+import { operations, ALL_SOURCES_WILDCARD } from '../core/operations.ts';
 import type { AuthInfo } from '../core/operations.ts';
 import { VERSION } from '../version.ts';
 import { dispatchToolCall } from './dispatch.ts';

--- a/test/get-page-federated-scope.test.ts
+++ b/test/get-page-federated-scope.test.ts
@@ -152,6 +152,14 @@ describe('get_page handler closes the cross-source exact-read leak', () => {
     const page: any = await get_page.handler(ctx, { slug: 'shared/alpha-doc' });
     expect(page.title).toBe('Alpha doc');
   });
+
+  test("remote client with a '*' wildcard grant CAN read any source's slug", async () => {
+    const ctx = ctxOf({ remote: true, auth: { token: 't', clientId: 'c', scopes: [], allowedSources: ['*'] } as any });
+    const beta: any = await get_page.handler(ctx, { slug: 'secret/beta-doc' });
+    expect(beta.title).toBe('Beta secret');
+    const alpha: any = await get_page.handler(ctx, { slug: 'shared/alpha-doc' });
+    expect(alpha.title).toBe('Alpha doc');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/legacy-token-federated-scope.test.ts
+++ b/test/legacy-token-federated-scope.test.ts
@@ -42,4 +42,13 @@ describe('parseLegacyTokenScope', () => {
   test('array with non-string junk is filtered to valid sources', () => {
     expect(parseLegacyTokenScope(['a', 5, '', 'b'])).toEqual({ sourceId: 'a', allowedSources: ['a', 'b'] });
   });
+
+  test("wildcard-only grant ['*'] → '*' read grant, scalar floor falls back to default (never '*')", () => {
+    // '*' is a READ grant; it must NOT become the scalar write floor.
+    expect(parseLegacyTokenScope(['*'])).toEqual({ sourceId: 'default', allowedSources: ['*'] });
+  });
+
+  test("wildcard mixed with a real source ['a','*'] → floor is the real source, grant keeps '*'", () => {
+    expect(parseLegacyTokenScope(['a', '*'])).toEqual({ sourceId: 'a', allowedSources: ['a', '*'] });
+  });
 });

--- a/test/source-scope-resolver.test.ts
+++ b/test/source-scope-resolver.test.ts
@@ -12,6 +12,7 @@ import { describe, test, expect } from 'bun:test';
 import {
   resolveRequestedScope,
   resolveCodeIntelScope,
+  sourceScopeOpts,
   OperationError,
   type OperationContext,
 } from '../src/core/operations.ts';
@@ -96,6 +97,45 @@ describe('resolveRequestedScope — default (no param)', () => {
   });
 });
 
+describe("sourceScopeOpts — '*' wildcard grant", () => {
+  test("a '*' grant spans every source (no filter)", () => {
+    const ctx = ctxOf({ remote: true, sourceId: 'a', auth: { token: 't', clientId: 'c', scopes: [], allowedSources: ['*'] } as any });
+    expect(sourceScopeOpts(ctx)).toEqual({});
+  });
+
+  test("'*' mixed with explicit sources still spans every source", () => {
+    const ctx = ctxOf({ remote: true, auth: { token: 't', clientId: 'c', scopes: [], allowedSources: ['a', '*', 'b'] } as any });
+    expect(sourceScopeOpts(ctx)).toEqual({});
+  });
+
+  test('a non-wildcard array is unchanged (exact federated list)', () => {
+    const ctx = ctxOf({ remote: true, auth: { token: 't', clientId: 'c', scopes: [], allowedSources: ['a', 'b'] } as any });
+    expect(sourceScopeOpts(ctx)).toEqual({ sourceIds: ['a', 'b'] });
+  });
+
+  test('empty grant still fail-closed to the scalar floor (NOT wildcard)', () => {
+    const ctx = ctxOf({ remote: true, sourceId: 'a', auth: { token: 't', clientId: 'c', scopes: [], allowedSources: [] } as any });
+    expect(sourceScopeOpts(ctx)).toEqual({ sourceId: 'a' });
+  });
+});
+
+describe("resolveRequestedScope — '*' wildcard grant", () => {
+  test("remote + '*' grant + __all__ spans the whole brain", () => {
+    const ctx = ctxOf({ remote: true, sourceId: 'a', auth: { token: 't', clientId: 'c', scopes: [], allowedSources: ['*'] } as any });
+    expect(resolveRequestedScope(ctx, '__all__')).toEqual({});
+  });
+
+  test("remote + '*' grant + no param spans the whole brain", () => {
+    const ctx = ctxOf({ remote: true, sourceId: 'a', auth: { token: 't', clientId: 'c', scopes: [], allowedSources: ['*'] } as any });
+    expect(resolveRequestedScope(ctx, undefined)).toEqual({});
+  });
+
+  test("remote + '*' grant can narrow to ANY explicit source (no rejection)", () => {
+    const ctx = ctxOf({ remote: true, auth: { token: 't', clientId: 'c', scopes: [], allowedSources: ['*'] } as any });
+    expect(resolveRequestedScope(ctx, 'anything')).toEqual({ sourceId: 'anything' });
+  });
+});
+
 describe('resolveCodeIntelScope — single-source code traversal', () => {
   test('scalar sourceId → that source, allSources false', () => {
     expect(resolveCodeIntelScope(ctxOf({ remote: true, sourceId: 'a' }), undefined)).toEqual({ allSources: false, sourceId: 'a' });
@@ -118,6 +158,18 @@ describe('resolveCodeIntelScope — single-source code traversal', () => {
 
   test('remote with no source in scope is denied, never widened to all', () => {
     const ctx = ctxOf({ remote: true, sourceId: '' });
+    expect(() => resolveCodeIntelScope(ctx, '__all__')).toThrow(OperationError);
+  });
+
+  test("remote + '*' grant can traverse an explicitly-named source", () => {
+    const ctx = ctxOf({ remote: true, sourceId: '', auth: { token: 't', clientId: 'c', scopes: [], allowedSources: ['*'] } as any });
+    expect(resolveCodeIntelScope(ctx, 'pick-one')).toEqual({ allSources: false, sourceId: 'pick-one' });
+  });
+
+  test("remote + '*' grant WITHOUT an explicit source is denied (traversal is single-source)", () => {
+    // '*' spans reads, but graph traversal needs ONE source — the resolver
+    // yields {} and code-intel must not silently span all for a remote caller.
+    const ctx = ctxOf({ remote: true, sourceId: '', auth: { token: 't', clientId: 'c', scopes: [], allowedSources: ['*'] } as any });
     expect(() => resolveCodeIntelScope(ctx, '__all__')).toThrow(OperationError);
   });
 });


### PR DESCRIPTION
## Problem

Federated read grants — `oauth_clients.federated_read`, or a legacy bearer token's `permissions.source_id` array — are an **exact-match source allow-list that is frozen at client creation**. There is no command to amend a grant after the fact (`auth permissions` only edits `takes_holders`), and `sources add` never touches existing grants. The grant resolves to `source_id = ANY($array)` (`postgres-engine.ts`), pure equality with no prefix/wildcard.

Consequence: in a multi-source brain, **every newly-synced source is invisible to existing read clients** until they are revoked and re-issued with an expanded list. For a brain whose sources grow over time (e.g. a sync job onboarding repos), that's a standing operational tax and a silent-failure trap (new source syncs fine, but reads return empty with no error).

## Fix

A `'*'` entry in a federated_read grant means **"read every source, current and future."** One contained change, routed through the existing single resolver so every read op honors it without per-handler drift:

- **`sourceScopeOpts`** returns the no-filter shape `{}` when the grant holds `'*'` — checked *before* the exact-list branch, so it never degrades to a literal `source_id = ANY(['*'])` (which would match a nonexistent source named `*`).
- **`resolveRequestedScope`** lets a `'*'` client narrow to any explicit `source_id` without the out-of-grant rejection.
- **`parseLegacyTokenScope`** keeps `'*'` out of the scalar **write** floor (falls back to `'default'`).

## Safety

Built to ride *with* the source-isolation contract, not around it:

- **Read scope only.** `'*'` lives on the read axis; write authority is the FK-backed scalar source, which rejects `'*'`. A wildcard reader can never write across sources.
- **Deliberate, never implicit.** Only an explicit `'*'` widens; an empty/garbage grant stays fail-closed to `'default'`. The existing `[]`-must-not-widen guard is untouched.
- **Single chokepoint.** All read ops resolve through `resolveRequestedScope` / `sourceScopeOpts`, so there's no per-handler `__all__` re-inlining (the bug class the existing resolver was built to prevent).

## Usage

```bash
gbrain auth register-client kb-reader \
  --grant-types client_credentials \
  --scopes read \
  --federated-read '*'
```

## Tests

13 new cases across `test/source-scope-resolver.test.ts`, `test/legacy-token-federated-scope.test.ts`, and `test/get-page-federated-scope.test.ts`: wildcard spans all sources; mixed-with-explicit spans all; narrows to any source; read-only write floor; code-traversal stays single-source; **empty/garbage still fail-closed**; non-wildcard arrays unchanged; end-to-end `get_page` reads any source. Verified green alongside the adjacent source-isolation suites (incl. `test/e2e/source-isolation-pglite.test.ts`). `typecheck` and all `bun run verify` checks pass.

Docs: `docs/mcp/DEPLOY.md` documents the flag, the read-only/deliberate/narrowing properties, and the "sources added later" lifecycle gap this closes.

## Notes for the maintainer

No `VERSION` / `package.json` / `CHANGELOG` changes — left to your release/fix-wave process per `docs/RELEASING.md`.