### PR TITLE
fix(cli): GBRAIN_EXIT_DRAIN_MS exit-drain knob + arm disconnect watchdog after drain (#2108)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1926,6 +1926,12 @@ async function handleCliOnly(command: string, args: string[]) {
     // #1471: this is also the fall-through OWNER-disconnect — the owner is torn
     // down LAST (after the drain), so module-singleton borrowers never outlive it.
     if (command !== 'serve') {
+      // Drain FIRST, then arm the disconnect watchdog: the timer's contract is
+      // bounding engine.disconnect() (see its message), but armed before the
+      // drain it also killed any drain longer than 10s — which defeats a
+      // GBRAIN_EXIT_DRAIN_MS-extended drain waiting on in-flight facts:absorb
+      // (#2108) and force-exited mid-settle with a misleading warning.
+      await drainAllBackgroundWorkForCliExit();
       const forceExit = shouldForceExitAfterMain();
       let hardExitTimer: ReturnType<typeof setTimeout> | undefined;
       if (forceExit) {
@@ -1935,7 +1941,6 @@ async function handleCliOnly(command: string, args: string[]) {
         }, 10_000);
         hardExitTimer.unref?.();
       }
-      await drainAllBackgroundWorkForCliExit();
       await engine.disconnect();
       if (hardExitTimer) clearTimeout(hardExitTimer);
     }

--- a/src/core/background-work.ts
+++ b/src/core/background-work.ts
@@ -91,7 +91,15 @@ export function __listDrainerNamesForTest(): string[] {
  * the subsequent disconnect.
  */
 export async function drainAllBackgroundWorkForCliExit(opts?: { timeoutMs?: number }): Promise<void> {
-  const timeoutMs = opts?.timeoutMs ?? 2000;
+  // GBRAIN_EXIT_DRAIN_MS — operator escape hatch (#2108): in-flight facts:absorb
+  // LLM round-trips need far more than the 1-2s default to settle on batch
+  // ingest (sync/capture), and the registry's abort() turns "slow" into
+  // "silently lost". drain() returns as soon as work settles, so a large value
+  // costs ~0ms on idle runs. The env wins over call-site values so ONE knob
+  // covers every exit path (op-dispatch passes 1000 explicitly; CLI_ONLY
+  // passes nothing).
+  const envMs = Number(process.env.GBRAIN_EXIT_DRAIN_MS);
+  const timeoutMs = Number.isFinite(envMs) && envMs > 0 ? envMs : (opts?.timeoutMs ?? 2000);
   const ordered = [...drainers.values()].sort(
     (a, b) => a.order - b.order || a.name.localeCompare(b.name),
   );

--- a/test/core/background-work.test.ts
+++ b/test/core/background-work.test.ts
@@ -133,4 +133,51 @@ describe('background-work registry', () => {
     await drainAllBackgroundWorkForCliExit({ timeoutMs: 10 });
     expect(true).toBe(true);
   });
+
+  test('GBRAIN_EXIT_DRAIN_MS env overrides the call-site timeout (#2108)', async () => {
+    const received: number[] = [];
+    const probe: BackgroundWorkDrainer = {
+      name: 'test-env-knob',
+      order: 0,
+      drain: async (timeoutMs) => { received.push(timeoutMs); return { unfinished: 0 }; },
+    };
+    const unreg = __registerDrainerForTest(probe);
+    const prev = process.env.GBRAIN_EXIT_DRAIN_MS;
+    try {
+      process.env.GBRAIN_EXIT_DRAIN_MS = '123456';
+      await drainAllBackgroundWorkForCliExit({ timeoutMs: 50 });
+      expect(received).toContain(123456); // env wins over the explicit call-site value
+    } finally {
+      if (prev === undefined) delete process.env.GBRAIN_EXIT_DRAIN_MS;
+      else process.env.GBRAIN_EXIT_DRAIN_MS = prev;
+      unreg();
+    }
+  });
+
+  test('invalid GBRAIN_EXIT_DRAIN_MS falls back to call-site / default (#2108)', async () => {
+    const received: number[] = [];
+    const probe: BackgroundWorkDrainer = {
+      name: 'test-env-knob-invalid',
+      order: 0,
+      drain: async (timeoutMs) => { received.push(timeoutMs); return { unfinished: 0 }; },
+    };
+    const unreg = __registerDrainerForTest(probe);
+    const prev = process.env.GBRAIN_EXIT_DRAIN_MS;
+    try {
+      for (const bad of ['abc', '0', '-5', '']) {
+        received.length = 0;
+        process.env.GBRAIN_EXIT_DRAIN_MS = bad;
+        await drainAllBackgroundWorkForCliExit({ timeoutMs: 50 });
+        expect(received).toContain(50); // call-site value preserved
+      }
+      received.length = 0;
+      delete process.env.GBRAIN_EXIT_DRAIN_MS;
+      await drainAllBackgroundWorkForCliExit();
+      expect(received).toContain(2000); // documented default when nothing is set
+    } finally {
+      if (prev === undefined) delete process.env.GBRAIN_EXIT_DRAIN_MS;
+      else process.env.GBRAIN_EXIT_DRAIN_MS = prev;
+      unreg();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Closes the silent fact-loss class from #2108 (ask 2): `facts:absorb` fire-and-forget jobs are aborted by the 1-2s exit-drain whenever the in-flight LLM round-trip is slower than the window. Reproduced on the **`gbrain sync` CLI path** as well (not only MCP `put_page`): 17/17 absorbs aborted on a single batch sync, `ingest_log` filling with `gateway_error: [chat(...)] The operation was aborted.`

Two changes, both required:

1. **`src/core/background-work.ts` — `GBRAIN_EXIT_DRAIN_MS` env knob** for the exit-drain timeout. Env wins over call-site values so one knob covers both exit paths (op-dispatch passes `1000` explicitly; the CLI_ONLY teardown passes nothing). `drainPending` settles as soon as in-flight work finishes, so idle runs still exit instantly regardless of the value — the knob only buys patience when there IS work to save.
2. **`src/cli.ts` (CLI_ONLY `finally`) — arm the 10s disconnect watchdog *after* the drain**, not before. Armed early, it force-exits any drain longer than 10s with the misleading `engine.disconnect() did not return within 10000ms` warning — silently defeating any longer drain window (same early-arming class as #2105). Armed after the drain, it bounds only the disconnect, matching its message.

## Validation

- Production Postgres brain, `0.42.40.0`, `facts.extraction_model=anthropic:claude-haiku-4-5`: a 195-file sync (469 chunks) with `GBRAIN_EXIT_DRAIN_MS=600000` completed with **0 aborted absorb rows**, vs **17/17 aborted** immediately before the patch on the same brain.
- Two new unit tests pin the contract: env-wins-over-call-site, and invalid env (`abc`/`0`/`-5`/empty) falls back to call-site/default.
- `tsc --noEmit` clean; drain-related suites (`test/core/background-work.test.ts`, `test/eval-capture-drain.test.ts`, `test/fix-wave-structural.test.ts`, `test/cli-should-force-exit.test.ts`) pass 36/36.

## Notes

- No VERSION/CHANGELOG bump included — left to the maintainer's release wave per the repo's versioning workflow.
- Refs #2108, #2105. Context and field validation also posted at https://github.com/garrytan/gbrain/issues/2108#issuecomment-4689648821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
