### PR TITLE
fix(markdown): treat `#` lines inside closed frontmatter as YAML comments, not headings

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -213,39 +213,39 @@ function collectValidationErrors(
     return;
   }
 
-  // 3. MISSING_CLOSE — find the next `---` after the opener. If a markdown
-  //    heading appears before it, that's a strong signal the closing
-  //    delimiter is missing (the heading was meant to be in the body).
+  // 3. MISSING_CLOSE — find the next `---` after the opener.
   let closeLine = -1;
-  let headingBeforeClose = -1;
   for (let i = firstNonEmpty + 1; i < lines.length; i++) {
-    const t = lines[i].trim();
-    if (t === '---') {
+    if (lines[i].trim() === '---') {
       closeLine = i;
       break;
     }
-    if (/^#{1,6}\s/.test(t) && headingBeforeClose === -1) {
-      headingBeforeClose = i;
-    }
   }
   if (closeLine === -1) {
+    // No closing fence found. Surface the first heading-shaped line as a
+    // hint for where the parser thinks the frontmatter went off the rails —
+    // only useful when the close is genuinely missing, since YAML allows
+    // `#` comment lines inside a closed fence (see comment below).
+    let headingHint = -1;
+    for (let i = firstNonEmpty + 1; i < lines.length; i++) {
+      if (/^#{1,6}\s/.test(lines[i].trim())) {
+        headingHint = i;
+        break;
+      }
+    }
     errors.push({
       code: 'MISSING_CLOSE',
       message:
-        headingBeforeClose >= 0
-          ? `No closing --- before heading at line ${headingBeforeClose + 1}`
+        headingHint >= 0
+          ? `No closing --- before heading at line ${headingHint + 1}`
           : 'No closing --- delimiter found',
-      line: headingBeforeClose >= 0 ? headingBeforeClose + 1 : firstNonEmpty + 1,
+      line: headingHint >= 0 ? headingHint + 1 : firstNonEmpty + 1,
     });
     return;
   }
-  if (headingBeforeClose >= 0 && headingBeforeClose < closeLine) {
-    errors.push({
-      code: 'MISSING_CLOSE',
-      message: `Heading at line ${headingBeforeClose + 1} found inside frontmatter zone (closing --- comes after)`,
-      line: headingBeforeClose + 1,
-    });
-  }
+  // Closing fence found. Content between opening and closing is YAML, which
+  // permits `#` comment lines anywhere — those are not markdown headings
+  // and must not raise MISSING_CLOSE.
 
   // 4. EMPTY_FRONTMATTER — open and close present but nothing meaningful between.
   const fmBody = lines.slice(firstNonEmpty + 1, closeLine).join('\n').trim();

--- a/test/markdown-validation.test.ts
+++ b/test/markdown-validation.test.ts
@@ -50,6 +50,38 @@ describe('parseMarkdown validation surface', () => {
       const e = parsed.errors!.find(e => e.code === 'MISSING_CLOSE');
       expect(e).toBeDefined();
     });
+
+    test('YAML # comment at top of closed frontmatter does NOT trigger MISSING_CLOSE', () => {
+      // Real-world repro: research-note templates often lead with `#` comment
+      // lines as YAML comments inside the fence. The parser previously read
+      // these as markdown H1s and false-positived MISSING_CLOSE even when the
+      // closing `---` was present.
+      const md = `${fence}
+# Research Template
+# This file serves as a template for all research findings
+
+research_id: "R19"
+title: "iOS App Clip security limitations"
+${fence}
+
+body`;
+      const parsed = parseMarkdown(md, undefined, { validate: true });
+      expect(parsed.errors!.map(e => e.code)).not.toContain('MISSING_CLOSE');
+    });
+
+    test('YAML # comments interleaved with keys do NOT trigger MISSING_CLOSE', () => {
+      const md = `${fence}
+type: concept
+# section: identifiers
+research_id: "R19"
+# section: routing
+slug: research/r19
+${fence}
+
+body`;
+      const parsed = parseMarkdown(md, undefined, { validate: true });
+      expect(parsed.errors!.map(e => e.code)).not.toContain('MISSING_CLOSE');
+    });
   });
 
   describe('YAML_PARSE', () => {


### PR DESCRIPTION

Closes #2152

## Summary

**The bug.** `parseMarkdown` walked the lines after the opening `---` and recorded the first `^#{1,6}\s`-shaped line as
`headingBeforeClose`. When the closing `---` was later found, the scanner still flagged the recorded line as
`MISSING_CLOSE` with `Heading at line N found inside frontmatter zone (closing --- comes after)`. But `#` lines inside a
closed YAML fence are comments by spec, not markdown headings. Templates that lead their frontmatter with annotation
comments (e.g. `# Research Template` above the keys) tripped the false positive on every parse.

**The fix.** Only walk for the closing `---`. When it is found, content between the fences is YAML; `#` lines are
comments, not headings. When the close is genuinely missing, surface the first heading-shaped line as the
where-it-went-off-the-rails hint (this branch was already correct and preserved verbatim).

**Precedent.** v0.37.5.0 (#1229) `fix(markdown): YAML-aware NESTED_QUOTES validator (stops flagging valid YAML)` is the
twin pattern: same parser, same "stop the false positive without weakening the genuine-error path."

## Tests

- `bun test test/markdown-validation.test.ts` → 27 pass / 0 fail (25 prior + 2 new regression tests covering YAML `#`
  comments at the top of a closed frontmatter and `#` comments interleaved with keys). 33 expect() calls.
- `bun test test/markdown.test.ts test/lint-frontmatter.test.ts test/doctor-frontmatter-partial.test.ts
  test/frontmatter-cli.test.ts` → 68 pass / 0 fail across the four adjacent test files. 146 expect() calls.
- `bun run verify` → 30/30 checks green in 10s, exit 0.
- `bun run typecheck` → exit 0, no diagnostics.
