### PR TITLE
fix(pglite): fail closed on stale live lock heartbeat (#2058)

### DIFF
--- a/src/core/pglite-lock.ts
+++ b/src/core/pglite-lock.ts
@@ -24,17 +24,16 @@ const LOCK_FILE = 'lock';
 // LIVE holder (embed jobs run for many minutes) is never mistaken for stale.
 const HEARTBEAT_INTERVAL_MS = 30_000;
 
-// #2058: a holder whose heartbeat refreshed within this window is ALIVE and is
-// NEVER stolen, regardless of how old the lock is. Only a holder that STOPPED
-// refreshing past this grace (hung, crashed without cleanup, or a PID since
-// reused by an unrelated process) is reaped. Pairing heartbeat-age with PID
-// liveness is what defeats both the WAL-corruption bug (stealing a live
-// writer) AND the PID-reuse false-positive (a recycled PID reading as "alive").
-// Env-overridable as an incident escape hatch, matching the sync-lock knobs.
+// #2058: a holder whose heartbeat refreshed within this window is clearly ALIVE
+// and working. A stale heartbeat is diagnostic only: a live/starved process can
+// still hold PGLite files open, so it is unsafe to steal from a PID that still
+// exists or cannot be probed conclusively.
 function stealGraceMs(): number {
   const env = parseInt(process.env.GBRAIN_PGLITE_LOCK_STEAL_GRACE_SECONDS ?? '', 10);
   return Number.isFinite(env) && env > 0 ? env * 1000 : 10 * 60 * 1000; // default 600s
 }
+
+type ProcessLiveness = 'alive' | 'dead' | 'unknown';
 
 export interface LockHandle {
   lockDir: string;
@@ -47,11 +46,11 @@ export interface LockHandle {
   heartbeat?: ReturnType<typeof setInterval>;
   lockPath?: string;
   /**
-   * #2058 (codex): our ownership token (`<pid>:<acquired_at>`). If we stall
-   * past the steal grace, another process can reap + re-acquire. When we
-   * resume, the heartbeat and release MUST verify the on-disk lock is STILL
-   * ours before touching it — otherwise a resumed stale holder would refresh
-   * or delete the NEW owner's live lock, re-opening the concurrent-writer hole.
+   * #2058 (codex): our ownership token (`<pid>:<acquired_at>`). If we exit and
+   * another process reaps + re-acquires, the heartbeat and release MUST verify
+   * the on-disk lock is STILL ours before touching it — otherwise a resumed
+   * stale holder would refresh or delete the NEW owner's live lock, re-opening
+   * the concurrent-writer hole.
    */
   ownerToken?: string;
 }
@@ -97,13 +96,16 @@ function getLockDir(dataDir: string | undefined): string {
   return join(dataDir, LOCK_DIR_NAME);
 }
 
-function isProcessAlive(pid: number): boolean {
+function isProcessAlive(pid: number): ProcessLiveness {
   try {
     // Sending signal 0 checks existence without actually sending a signal
     process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
+    return 'alive';
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ESRCH') return 'dead';
+    if (code === 'EPERM') return 'alive';
+    return 'unknown';
   }
 }
 
@@ -112,7 +114,10 @@ function isProcessAlive(pid: number): boolean {
  * Returns { acquired: true } if the lock was obtained, { acquired: false } otherwise.
  * Stale locks (from dead processes) are automatically cleaned up.
  */
-export async function acquireLock(dataDir: string | undefined, opts?: { timeoutMs?: number }): Promise<LockHandle> {
+export async function acquireLock(dataDir: string | undefined, opts?: {
+  timeoutMs?: number;
+  isProcessAlive?: (pid: number) => ProcessLiveness;
+}): Promise<LockHandle> {
   const lockDir = getLockDir(dataDir);
 
   // In-memory PGLite — no lock needed (process-scoped, can't be shared)
@@ -125,6 +130,7 @@ export async function acquireLock(dataDir: string | undefined, opts?: { timeoutM
   mkdirSync(dataDir as string, { recursive: true });
 
   const timeoutMs = opts?.timeoutMs ?? 30_000; // 30 second default timeout
+  const probeProcess = opts?.isProcessAlive ?? isProcessAlive;
   const startTime = Date.now();
 
   while (Date.now() - startTime < timeoutMs) {
@@ -136,21 +142,21 @@ export async function acquireLock(dataDir: string | undefined, opts?: { timeoutM
         const lockPid = lockData.pid as number;
         const lockTime = lockData.acquired_at as number;
 
-        // #2058: classify by PID liveness AND heartbeat freshness. A holder
-        // that is alive AND refreshed its heartbeat within the steal grace is
-        // genuinely working (e.g. a multi-minute embed) and is NEVER reaped —
-        // force-removing it here is what corrupted the single-writer WAL.
-        const alive = isProcessAlive(lockPid);
+        // #2058: classify by PID liveness AND heartbeat freshness. A stale
+        // heartbeat on a live PID is NOT proof the embedded DB is closed: the
+        // JS timer can be paused/starved while PGLite still holds WAL files.
+        const holderState = probeProcess(lockPid);
         const lastRefresh = (lockData.refreshed_at as number | undefined) ?? lockTime;
         const sinceRefresh = Date.now() - lastRefresh;
-        if (!alive) {
+        if (holderState === 'dead') {
           // Holder process is gone — reap.
           try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition, try again */ }
         } else if (sinceRefresh > stealGraceMs()) {
-          // PID is alive but the heartbeat stopped past the grace window:
-          // either the holder hung, or this PID was reused by an unrelated
-          // process (the real holder died and stopped refreshing). Reap.
-          try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition */ }
+          // PID is alive or unprobeable but the heartbeat stopped past the
+          // grace window. Fail closed: wait and eventually surface the holder
+          // diagnostic instead of stealing a possibly-live PGLite process.
+          await new Promise(r => setTimeout(r, 1000));
+          continue;
         } else {
           // Live holder refreshing within grace — wait and retry.
           await new Promise(r => setTimeout(r, 1000));

--- a/test/pglite-lock.test.ts
+++ b/test/pglite-lock.test.ts
@@ -133,25 +133,35 @@ describe('pglite-lock #2058 heartbeat + steal-grace', () => {
     expect(existsSync(join(TEST_DIR, '.gbrain-lock'))).toBe(true);
   });
 
-  test('a LIVE PID whose heartbeat went stale past the grace window IS reaped', async () => {
-    // PID is alive (our own) but hasn't refreshed in 20min (> 600s grace):
-    // hung holder, or a reused PID whose real holder is gone. Reap + acquire.
+  test('[REGRESSION] a LIVE PID whose heartbeat went stale past the grace window is NOT stolen', async () => {
+    // PID is alive (our own) but hasn't refreshed in 20min (> 600s grace).
+    // A starved JS heartbeat does not prove PGLite has closed its files, so the
+    // waiter must fail closed instead of force-removing the lock.
     writeHolder({ pid: process.pid, acquiredAgoMs: 25 * 60_000, refreshedAgoMs: 20 * 60_000 });
 
-    const lock = await acquireLock(TEST_DIR, { timeoutMs: 2000 });
-    expect(lock.acquired).toBe(true);
-    await releaseLock(lock);
+    await expect(acquireLock(TEST_DIR, { timeoutMs: 1200 })).rejects.toThrow(/Timed out/);
+    expect(existsSync(join(TEST_DIR, '.gbrain-lock'))).toBe(true);
   });
 
-  test('GBRAIN_PGLITE_LOCK_STEAL_GRACE_SECONDS tunes the grace window', async () => {
+  test('GBRAIN_PGLITE_LOCK_STEAL_GRACE_SECONDS does not make live stale-heartbeat holders stealable', async () => {
     // withEnv keeps the process-global mutation isolated across shard files.
     await withEnv({ GBRAIN_PGLITE_LOCK_STEAL_GRACE_SECONDS: '5' }, async () => {
-      // Refreshed 30s ago — fresh under the 600s default, STALE under 5s.
+      // Refreshed 30s ago: stale under this 5s diagnostic threshold, but still
+      // unsafe to steal because the owning PID is live.
       writeHolder({ pid: process.pid, acquiredAgoMs: 60_000, refreshedAgoMs: 30_000 });
-      const lock = await acquireLock(TEST_DIR, { timeoutMs: 2000 });
-      expect(lock.acquired).toBe(true);
-      await releaseLock(lock);
+      await expect(acquireLock(TEST_DIR, { timeoutMs: 1200 })).rejects.toThrow(/Timed out/);
+      expect(existsSync(join(TEST_DIR, '.gbrain-lock'))).toBe(true);
     });
+  });
+
+  test('an unknown PID probe result is unsafe to steal', async () => {
+    writeHolder({ pid: 999999999, acquiredAgoMs: 25 * 60_000, refreshedAgoMs: 20 * 60_000 });
+
+    await expect(acquireLock(TEST_DIR, {
+      timeoutMs: 1200,
+      isProcessAlive: () => 'unknown',
+    })).rejects.toThrow(/Timed out/);
+    expect(existsSync(join(TEST_DIR, '.gbrain-lock'))).toBe(true);
   });
 
   test('[REGRESSION] releaseLock does NOT remove a lock that was stolen + re-acquired by another process', async () => {


### PR DESCRIPTION
Closes #2058

## Summary

`v0.42.41.0` fixed the original age-only PGLite lock steal by adding a heartbeat and ownership token. One unsafe edge remains: a same-host process whose JS heartbeat is stale can still have the `.gbrain-lock` directory force-removed while its PID is alive.

For embedded PGLite, a stale JS timer is not proof the WASM Postgres process has closed its files. A paused/starved holder can still have the data directory open, so stealing from a live PID can recreate the single-writer/WAL corruption class this lock exists to prevent.

## The fix

This keeps the current heartbeat and owner-token design, but changes stale-heartbeat handling to fail closed:

- PID probe now returns `alive | dead | unknown` instead of collapsing all `process.kill(pid, 0)` errors to dead.
- `ESRCH` is the only automatic dead-process reclaim path.
- `EPERM`, unknown probe errors, and live PIDs are treated as unsafe to steal.
- A stale heartbeat on a live/unprobeable PID now waits and eventually times out with the existing holder diagnostic instead of deleting the lock.
- Dead PID cleanup and owner-checked heartbeat/release behavior remain intact.

## Scope decisions

- Only touches `src/core/pglite-lock.ts` and `test/pglite-lock.test.ts`.
- No release files, no CHANGELOG, no docs/llms churn, no CLI surface.
- No replacement of the merged `#2058` implementation. This is a narrow follow-up on top of it.
- No new public command or config. `GBRAIN_PGLITE_LOCK_STEAL_GRACE_SECONDS` remains a stale-heartbeat diagnostic threshold, but no longer authorizes stealing from a live PID.

## Test Coverage

`test/pglite-lock.test.ts` now pins the remaining unsafe case:

- live PID + fresh heartbeat is not stolen
- live PID + stale heartbeat is not stolen
- lowering `GBRAIN_PGLITE_LOCK_STEAL_GRACE_SECONDS` does not make a live stale-heartbeat holder stealable
- unknown PID probe result is not stolen
- dead PID is still cleaned up by the existing stale-dead-process test
- owner-checked release still does not remove a replacement owner lock

## Verification Results

Targeted and type checks:

```bash
bun test test/pglite-lock.test.ts
# 13 pass / 0 fail

bun run typecheck
# tsc --noEmit
```

`bun run verify` caveat: in this Codex shell, the parent verify wrapper is SIGTERM'd at ~30s, which marks every parallel child as `143` even though no individual check failed. To avoid reporting a false failure as a repo failure, I ran every check listed by `scripts/run-verify-parallel.sh --dry-list` in smaller batches. All 30 constituent checks passed, including privacy, JSONB, source-id projection, test-isolation, WASM, admin build, resolver, doc-history, worker-lock-renewal-shape, and typecheck.

## Test plan

- [x] `bun test test/pglite-lock.test.ts`
- [x] `bun run typecheck`
- [x] All 30 `bun run verify` constituent checks, run in batches because the wrapper is killed by this shell at ~30s
