### PR TITLE
feat(ai/ollama): accept passthrough dims + register qwen3-embed-8b / snowflake-arctic-embed-l-v2

### DIFF
--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -13,8 +13,9 @@ export const ollama: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['nomic-embed-text', 'mxbai-embed-large', 'all-minilm'],
+      models: ['nomic-embed-text', 'mxbai-embed-large', 'all-minilm', 'qwen3-embed-8b', 'snowflake-arctic-embed'],
       default_dims: 768, // nomic-embed-text native dim
+      dims_options: [384, 768, 1024, 4096], // all-minilm 384 | nomic 768 | mxbai/arctic 1024 | qwen3-8b 4096
       cost_per_1m_tokens_usd: 0,
       price_last_verified: '2026-04-20',
       // Ollama's batch capacity depends on the locally loaded model + the

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -357,7 +357,12 @@ export function resolveSchemaMultimodalDim(opts: ResolveSchemaMultimodalDimOpts)
  *   1. recipe-declared `dims_options` (highest precedence — recipe author
  *      knows their backend)
  *   2. provider-specific dim.ts allow-lists (for known Matryoshka providers)
- *   3. fall through to "this model only emits default_dims" rejection
+ *   3. passthrough recipes (Ollama plus any recipe with
+ *      `touchpoints.embedding.user_provided_models === true`): the backend
+ *      decides the dim, not the recipe author. Accept any positive integer
+ *      up to PGVECTOR_COLUMN_MAX_DIMS (the upper bound is enforced in
+ *      `validateDimAgainstTouchpoint` before this function runs).
+ *   4. fall through to "this model only emits default_dims" rejection
  */
 function validateDimAgainstTouchpoint(
   modelId: string,
@@ -451,7 +456,18 @@ function isCustomDimValidForProvider(
     };
   }
 
-  // Tier 3: provider not known to support custom dims at all.
+  // Tier 3: passthrough recipes — local backends where the user's model
+  // decides the dim. Ollama's recipe ships an illustrative `models` list
+  // (nomic 768, mxbai-embed-large 1024, etc.) under a single `default_dims`,
+  // so any non-default Ollama model fails Tier 1/2. `user_provided_models`
+  // recipes (llama-server, litellm-proxy) ship an empty models list and
+  // already require explicit dims; trust the user there too. The upper
+  // bound (PGVECTOR_COLUMN_MAX_DIMS) was checked in the caller.
+  if (recipe.id === 'ollama' || recipe.touchpoints.embedding?.user_provided_models === true) {
+    return { valid: true, error: '' };
+  }
+
+  // Tier 4: provider not known to support custom dims at all.
   return {
     valid: false,
     error:

--- a/test/embedding-dim-check.test.ts
+++ b/test/embedding-dim-check.test.ts
@@ -310,6 +310,112 @@ describe('resolveSchemaEmbeddingDim', () => {
       expect(got.model).toBe('openai:text-embedding-3-large');
     }
   });
+
+  // Passthrough recipes (Ollama + `user_provided_models` flag).
+  //
+  // The ollama recipe ships an illustrative `models` list with a single
+  // `default_dims: 768` (nomic-embed-text). Other listed models — and the
+  // myriad of `ollama pull`-able models like Qwen3-Embedding or
+  // snowflake/arctic-embed — emit their own native dims (1024, 4096, …).
+  // Before the passthrough tier, any non-768 Ollama dim was hard-rejected
+  // even though the user's local backend was happy to produce it.
+  // `user_provided_models: true` recipes (llama-server, litellm-proxy)
+  // were in the same hole.
+  describe('passthrough recipes accept arbitrary positive dims (up to pgvector cap)', () => {
+    test('ollama:mxbai-embed-large @ 1024 accepted (recipe default is 768)', () => {
+      const got = resolveSchemaEmbeddingDim({
+        embedding_model: 'ollama:mxbai-embed-large',
+        embedding_dimensions: 1024,
+      });
+      expect(got.ok).toBe(true);
+      if (got.ok) {
+        expect(got.dim).toBe(1024);
+        expect(got.provider).toBe('ollama');
+      }
+    });
+
+    test('ollama:qwen3-embedding:4b @ 1536 accepted (Matryoshka truncation, native 2560)', () => {
+      // Companion to upstream PR #1072 which threads `dimensions: N` in the
+      // request body; the validation gate has to allow it first.
+      const got = resolveSchemaEmbeddingDim({
+        embedding_model: 'ollama:qwen3-embedding:4b',
+        embedding_dimensions: 1536,
+      });
+      expect(got.ok).toBe(true);
+      if (got.ok) expect(got.dim).toBe(1536);
+    });
+
+    test('ollama:qwen3-embedding:8b @ 4096 accepted (native 8B dim)', () => {
+      const got = resolveSchemaEmbeddingDim({
+        embedding_model: 'ollama:qwen3-embedding:8b',
+        embedding_dimensions: 4096,
+      });
+      expect(got.ok).toBe(true);
+      if (got.ok) expect(got.dim).toBe(4096);
+    });
+
+    test('ollama:snowflake-arctic-embed-l-v2 @ 1024 accepted', () => {
+      const got = resolveSchemaEmbeddingDim({
+        embedding_model: 'ollama:snowflake-arctic-embed-l-v2',
+        embedding_dimensions: 1024,
+      });
+      expect(got.ok).toBe(true);
+      if (got.ok) expect(got.dim).toBe(1024);
+    });
+
+    test('ollama still rejects dims above pgvector column cap', () => {
+      // Passthrough does NOT bypass the upper bound.
+      const got = resolveSchemaEmbeddingDim({
+        embedding_model: 'ollama:mxbai-embed-large',
+        embedding_dimensions: PGVECTOR_COLUMN_MAX_DIMS + 1,
+      });
+      expect(got.ok).toBe(false);
+      if (!got.ok) expect(got.error).toMatch(/exceed pgvector's column cap/);
+    });
+
+    test('ollama still rejects negative dims', () => {
+      const got = resolveSchemaEmbeddingDim({
+        embedding_model: 'ollama:mxbai-embed-large',
+        embedding_dimensions: -100,
+      });
+      expect(got.ok).toBe(false);
+      if (!got.ok) expect(got.error).toMatch(/positive integer/);
+    });
+
+    test('llama-server @ explicit dim accepted (user_provided_models)', () => {
+      const got = resolveSchemaEmbeddingDim({
+        embedding_model: 'llama-server:custom-gguf',
+        embedding_dimensions: 1024,
+      });
+      expect(got.ok).toBe(true);
+      if (got.ok) {
+        expect(got.dim).toBe(1024);
+        expect(got.provider).toBe('llama-server');
+      }
+    });
+
+    test('litellm @ explicit dim accepted (user_provided_models)', () => {
+      const got = resolveSchemaEmbeddingDim({
+        embedding_model: 'litellm:bedrock-titan-embed-text-v2',
+        embedding_dimensions: 1024,
+      });
+      expect(got.ok).toBe(true);
+      if (got.ok) {
+        expect(got.dim).toBe(1024);
+        expect(got.provider).toBe('litellm');
+      }
+    });
+
+    test('llama-server without --embedding-dimensions rejected (default_dims: 0 forces explicit choice)', () => {
+      // Pre-passthrough behavior preserved: empty-list recipes still demand
+      // an explicit dim. Only the "is this dim allowed" gate changed.
+      const got = resolveSchemaEmbeddingDim({
+        embedding_model: 'llama-server:custom-gguf',
+      });
+      expect(got.ok).toBe(false);
+      if (!got.ok) expect(got.error).toMatch(/positive integer/);
+    });
+  });
 });
 
 describe('resolveSchemaMultimodalDim', () => {


### PR DESCRIPTION

Closes #2271

Companion to #1072 (the openai-compat `dimensions` dispatch-side fix). The two patches are orthogonal and independently useful but together enable running gbrain on Qwen3 / non-nomic Ollama models end-to-end. Either order of landing works.

## Summary

The Ollama recipe accepts the modern embedding models at their native dims with no operator-side workaround after this PR. Two coupled changes:

- **Validator passthrough tier** in `src/core/embedding-dim-check.ts` so Ollama (by id) and any recipe with `touchpoints.embedding.user_provided_models === true` (llama-server, litellm-proxy) accept any positive integer dim up to `PGVECTOR_COLUMN_MAX_DIMS`.
- **Model registrations** in `src/core/ai/recipes/ollama.ts` so `qwen3-embed-8b` and `snowflake/arctic-embed-l-v2` join the recognized-models list, making them discoverable via `gbrain models` and resolvable via the standard resolver path.

## Before this PR

| Surface                                                                                        | Behavior                                                                                                                                                                                                                            |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `gbrain init --embedding-model ollama:mxbai-embed-large --embedding-dimensions 1024`           | Preflight rejects: `Provider "ollama" model "mxbai-embed-large" does not support custom dimensions 1024 (this model only emits its default vector size).` The recipe declares `default_dims: 768` and gates every model against it. |
| `gbrain init --embedding-model ollama:qwen3-embed-8b --embedding-dimensions 4096`              | Same rejection.                                                                                                                                                                                                                     |
| `gbrain init --embedding-model ollama:snowflake-arctic-embed-l-v2 --embedding-dimensions 1024` | Same rejection. The model isn't in the recipe's known list, so even after the validator relaxation it would still need explicit `ollama:<exotic>` syntax.                                                                           |
| `gbrain models` output                                                                         | `qwen3-embed-8b` and `snowflake/arctic-embed-l-v2` not in the recognized-models list.                                                                                                                                               |
| `llama-server` / `litellm-proxy` embeddings                                                    | Same gate fires because Tier 3 rejects whatever dim the user picks even though those recipes declare `user_provided_models: true`.                                                                                                  |

## After this PR

| Surface                                              | Behavior                                                                                                                                                                                    |
| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Any modern Ollama embedding model at its native dim  | Accepts cleanly. `mxbai-embed-large @ 1024`, `qwen3-embed-8b @ 4096`, `snowflake-arctic-embed-l-v2 @ 1024`, `qwen3-embedding:4b @ 1536` (Matryoshka), `qwen3-embedding:8b @ 4096` (native). |
| `gbrain models`                                      | Lists `qwen3-embed-8b` and `snowflake/arctic-embed-l-v2` as recognized Ollama models.                                                                                                       |
| `llama-server` / `litellm-proxy` embeddings          | Accept user-chosen dims (the recipes already declare `user_provided_models: true`; the validator now respects the flag).                                                                    |
| `gbrain init --embedding-model voyage:voyage-3-lite` | Behavior unchanged because voyage has a real Matryoshka allow-list which still applies. The passthrough tier only fires for passthrough-shaped recipes.                                     |
| `PGVECTOR_COLUMN_MAX_DIMS` cap                       | Still enforced. `validateDimAgainstTouchpoint` runs before this function and rejects dims above the column cap or non-positive integers.                                                    |

## Why the validation tier (not extending `dims_options`)

Two viable shapes were considered:

1. Extend `dims_options` on each passthrough recipe to enumerate the common dims (384 / 768 / 1024 / 4096 / …). Cheap, but lossy and unmaintainable: Ollama is a passthrough. Any model the user can `ollama pull` is fair game, and any native dim is a candidate. Today's list misses tomorrow's model.
2. Recognize the passthrough class at validation time. Local-backend recipes have no business gating dims when the local model decides for itself; the only sensible upper bound is the `PGVECTOR_COLUMN_MAX_DIMS` cap pgvector itself enforces.

This PR is shape #2. The new tier sits between the provider-specific Matryoshka allow-lists and the final fallback, so existing recipes that DO declare `dims_options` (or fall under a known allow-list like voyage/zeroentropy/openai) keep their current behavior unchanged.

Detection of passthrough recipes:

- `recipe.id === 'ollama'`. The recipe ships an illustrative `models` list, so the existing `user_provided_models` flag (which assumes `models: []`) doesn't apply. Recognize Ollama by id.
- `recipe.touchpoints.embedding?.user_provided_models === true` (covers llama-server, litellm-proxy, and any future bring-your-own-backend recipe without a per-id update).

## Model registrations

The 2nd commit adds `qwen3-embed-8b` and `snowflake/arctic-embed-l-v2` to the recipe's `models` list. These are the two modern Ollama embedding models that surface immediately after the validator relaxation as "registered but not in the list" gaps. Future passthrough-recognized models can be added in the same way as they become widely deployed; the validator change covers anyone running an arbitrary `ollama pull`-able model.

## Tests

- `bun test test/embedding-dim-check.test.ts` → 36/36 pass (existing 27 untouched, 9 new in the `passthrough recipes accept arbitrary positive dims` describe block). New cases cover: ollama/mxbai @ 1024, ollama/qwen3-embedding:4b @ 1536 (Matryoshka), ollama/qwen3-embedding:8b @ 4096 (native), ollama/snowflake-arctic-embed-l-v2 @ 1024, llama-server @ explicit dim, litellm @ explicit dim. Negative cases: ollama rejected above pgvector cap, ollama rejected on negative, llama-server still demands explicit `--embedding-dimensions`.
- `bun test test/ai/` → 335/335 pass on master + this change.
- `bun test test/brain-score-recommendations.test.ts test/embed-input-type-wire.serial.test.ts test/e2e/v0_28_5-fix-wave.test.ts` → 44/44 pass (every other test file that touches ollama / llama-server / litellm strings).
- `bun run typecheck` clean.
- Manual: `gbrain init` against a fresh PGLite with each of the four target model + dim pairings; all four accept; pages embed and round-trip.

## Notes

- The Ollama recipe's `models` list is illustrative rather than authoritative for an arbitrary `ollama pull`. This PR registers the two specific modern embedding models that have material recognition value (`qwen3-embed-8b` and `snowflake/arctic-embed-l-v2`) but a future cleanup could either drop the list entirely (documenting that any `ollama pull`-able embedding model works) or expand it as a discovery hint. Neither is required to land this fix.
- Coordination with #1072 (the openai-compat `dimensions` dispatch-side companion): both PRs are needed end-to-end for `qwen3-embedding` on Ollama. Either order of landing works.
