### PR TITLE
fix(onboard): stop dropping onboard-check remediations on the --apply --auto path

### DIFF
--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -125,12 +125,16 @@ export async function runOnboard(engine: BrainEngine, args: string[]): Promise<v
 
   // --auto path: runs through the T2 library orchestrator. Hooks emit CLI
   // progress to stderr; the final result lands as JSON on stdout (or human
-  // summary).
+  // summary). extraRemediations (gathered above from runAllOnboardChecks)
+  // gets threaded into the runner so the auto-eligible onboard-check
+  // remediations (extract-ner, extract-timeline-from-meetings, etc.) reach
+  // the planner — the same wiring the --check path uses on line ~109.
   const result = await runRemediation(
     engine,
     {
       targetScore,
       maxUsd,
+      extraRemediations,
       // --auto --yes opts into the prompt_required tier too; library
       // doesn't distinguish auto_apply vs prompt_required, it just runs
       // every remediation in the plan. The plan-building side (T12 render)

--- a/src/core/remediation/run.ts
+++ b/src/core/remediation/run.ts
@@ -66,9 +66,10 @@ export async function runRemediation(
   } = await import('../remediation-checkpoint.ts');
 
   const ctx = await loadRecommendationContext(engine);
+  const extraRemediations = opts.extraRemediations ?? [];
 
   // Pre-flight ceiling check via the shared plan computation.
-  const initialPlan = await computeRemediationPlan(engine, { targetScore });
+  const initialPlan = await computeRemediationPlan(engine, { targetScore, extraRemediations });
   if (initialPlan.target_unreachable) {
     hooks.onTargetUnreachable?.(targetScore, initialPlan.max_reachable_score);
     return {
@@ -87,7 +88,7 @@ export async function runRemediation(
   }
 
   const initialHealth = await engine.getHealth();
-  let recs: RemediationStep[] = computeRecommendations(initialHealth, ctx)
+  let recs: RemediationStep[] = computeRecommendations(initialHealth, ctx, extraRemediations)
     .filter((r) => r.status === 'remediable');
   if (recs.length === 0) {
     hooks.onNothingToDo?.(initialHealth.brain_score, targetScore);

--- a/src/core/remediation/types.ts
+++ b/src/core/remediation/types.ts
@@ -63,6 +63,16 @@ export interface RemediationOpts {
   resumePlanHash?: string;
   /** Whether to attempt resume at all (default false). */
   resume?: boolean;
+  /**
+   * Caller-supplied RemediationStep entries threaded into the planner.
+   * Mirrors RemediationPlanOptions.extraRemediations so onboard's --apply
+   * --auto path can forward the same onboard-check remediations its --check
+   * path already passes through computeRemediationPlan. Without this field
+   * the runner saw only generic brain_score remediations (sync, embed,
+   * etc.) and reported "Nothing to do" whenever the only applicable work
+   * was an extra (e.g. extract-ner, extract-timeline-from-meetings).
+   */
+  extraRemediations?: RemediationStep[];
 }
 
 /**


### PR DESCRIPTION
Closes #2160

## Summary

**The bug.** `gbrain onboard --apply --auto --max-usd N --target-score N` returned `Brain at score X/100, target Y/100. Nothing to do.` even when `gbrain onboard --check --explain` listed several auto-eligible recommendations. The check path correctly threaded onboard-check remediations into the planner; the apply path never received them.

**The fix.** Add `extraRemediations` to `RemediationOpts`, read it in `runRemediation`, thread it into both `computeRemediationPlan` and `computeRecommendations`, and pass the already-gathered array from `commands/onboard.ts:129` (the `--apply --auto` branch) the same way `commands/onboard.ts:109` (the `--check` branch) already does.

## Diagnosis

- `commands/onboard.ts:105-106` gathers `extraRemediations` via `runAllOnboardChecks(engine).flatMap(r => r.remediations)`.
- `commands/onboard.ts:109` (the `--check` branch) correctly passes `{ targetScore, extraRemediations }` to `computeRemediationPlan`.
- `commands/onboard.ts:129` (the `--apply --auto` branch) called `runRemediation(engine, { targetScore, maxUsd }, hooks)` with no `extraRemediations` field.
- Downstream, `core/remediation/run.ts:71` built the pre-flight plan via `computeRemediationPlan(engine, { targetScore })` with no extras, and `core/remediation/run.ts:90` called `computeRecommendations(initialHealth, ctx)` with the default empty `extraRemediations = []`. Only generic brain_score remediations (sync, embed, etc.) reached the runner. For a brain that's clean on those (0 stale pages, 0 missing embeddings), `recs.length === 0` and the runner fires `onNothingToDo`.

## Reproduction

1. Fresh brain at brain_score < target_score, with `entity_link_coverage` and `timeline_coverage` showing remediable auto-eligibles in `gbrain onboard --check --explain`.
2. `gbrain onboard --apply --auto --max-usd 5 --target-score 70`.
3. Expected: jobs queued for the auto-eligibles. Actual: `Brain at score X/100, target Y/100. Nothing to do.`

Observed on gbrain 0.42.42.0.

## Tests

Verified end-to-end against a live brain at brain_score 45/100 with target 70:

- Pre-patch: `onboard --apply --auto --max-usd 5 --target-score 70` returned "Nothing to do" instantly.
- Post-patch: same invocation submitted `extract-timeline-from-meetings` as `minion_jobs.id=1, status=waiting`, a worker (started via `gbrain jobs work`) claimed and completed it, brain_score advanced.

A regression test would feed `runRemediation` an extra step that the brain_score generator never emits (e.g., `extract-ner`) and assert it appears in `result.submitted`. Happy to add one in this PR if useful; the three-file shape currently mirrors the existing `--check` path verbatim so the contract change is minimal.

## Adjacent observation (follow-up, not in this PR)

`onboard --apply --auto` has an undocumented prereq: a worker (`gbrain jobs work` or `gbrain autopilot`) must be running to claim queued jobs. With this patch landed, the apply path correctly queues jobs; with no worker `attempts_started` stays 0 and onboard times out at 540s (`error: timeout after 540007ms waiting for job 1`). The failure mode reads as a broken handler. A heartbeat check on `minion_jobs` (no `attempts_started` across all rows within K seconds) emitting a one-line hint, or a docs touch in `gbrain onboard --help`, would close the gap. Happy to file a follow-up if useful.
