### PR TITLE
v0.42.42.0 fix(config): render nested config values as JSON in `config show`

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -35,6 +35,16 @@ export function redactConfigValue(key: string, value: string): string {
   return value;
 }
 
+// Render a single config value for `gbrain config show`. Strings route
+// through redactConfigValue (secrets masked); nested objects/arrays are
+// JSON-stringified so the display loop's template literal doesn't coerce
+// them to "[object Object]" (e.g. the mcp/self_upgrade/search blocks).
+export function formatConfigValue(key: string, value: unknown): string {
+  if (typeof value === 'string') return redactConfigValue(key, value);
+  if (value !== null && typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
 export async function runConfig(engine: BrainEngine, args: string[]) {
   const action = args[0];
 
@@ -46,8 +56,7 @@ export async function runConfig(engine: BrainEngine, args: string[]) {
     }
     console.log('GBrain config:');
     for (const [k, v] of Object.entries(config)) {
-      const display = typeof v === 'string' ? redactConfigValue(k, v) : v;
-      console.log(`  ${k}: ${display}`);
+      console.log(`  ${k}: ${formatConfigValue(k, v)}`);
     }
     return;
   }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 import { readFileSync } from 'fs';
-import { isSensitiveConfigKey, redactConfigValue } from '../src/commands/config.ts';
+import { isSensitiveConfigKey, redactConfigValue, formatConfigValue } from '../src/commands/config.ts';
 
 // redactUrl is not exported, so we test it by reading the source and
 // reimplementing the regex to verify the pattern, then test via CLI
@@ -251,5 +251,33 @@ describe('loadConfig — GBRAIN_MAX_MARKUP_RATIO env (v0.42 #1699)', () => {
     await withHomeAndEnv({ GBRAIN_MAX_MARKUP_RATIO: '1.5' }, (cfg) => {
       expect((cfg as { content_sanity?: { max_markup_ratio?: number } }).content_sanity?.max_markup_ratio).toBeUndefined();
     });
+  });
+});
+
+describe('formatConfigValue', () => {
+  test('JSON-stringifies nested objects instead of rendering [object Object]', () => {
+    expect(formatConfigValue('mcp', { publish_skills: true })).toBe('{"publish_skills":true}');
+    expect(formatConfigValue('search', { mode: 'balanced' })).toBe('{"mode":"balanced"}');
+  });
+
+  test('JSON-stringifies arrays', () => {
+    expect(formatConfigValue('sources', ['a', 'b'])).toBe('["a","b"]');
+  });
+
+  test('no config value renders as "[object Object]"', () => {
+    for (const v of [{ mode: 'notify', mode_prompted: true }, { publish_skills: true }, ['x']]) {
+      expect(formatConfigValue('k', v)).not.toContain('[object Object]');
+    }
+  });
+
+  test('redacts sensitive string values', () => {
+    expect(formatConfigValue('zeroentropy_api_key', 'ze_secret123')).toBe('***');
+    expect(formatConfigValue('database_url', 'postgresql://user:pw@host:5432/db'))
+      .toBe('postgresql://user:***@host:5432/db');
+  });
+
+  test('passes through plain string + primitive values', () => {
+    expect(formatConfigValue('engine', 'postgres')).toBe('postgres');
+    expect(formatConfigValue('embedding_disabled', false)).toBe('false');
   });
 });


### PR DESCRIPTION
## Problem

`gbrain config show` renders nested config values as `[object Object]`:

```
GBrain config:
  engine: postgres
  schema_pack: gbrain-base-v2
  mcp: [object Object]
  self_upgrade: [object Object]
  search: [object Object]
  database_url: postgresql://...:***@...
```

The show loop interpolated each value straight into a template literal:

```ts
const display = typeof v === 'string' ? redactConfigValue(k, v) : v;
console.log(`  ${k}: ${display}`);
```

When `v` is a non-string (`mcp`, `self_upgrade`, `search`), template-literal
coercion calls `.toString()` → `[object Object]`, hiding the actual config.

## Fix

Extract a `formatConfigValue(key, value)` helper (single source of truth,
matching the existing `redactConfigValue` pattern in this file):

- **strings** → `redactConfigValue` (secrets still masked)
- **objects/arrays** → `JSON.stringify`
- **primitives** → `String(value)`

After:

```
  mcp: {"publish_skills":true}
  self_upgrade: {"mode":"notify","mode_prompted":true}
  search: {"mode":"balanced"}
```

## Tests

Adds a `formatConfigValue` describe block to `test/config.test.ts`:
- nested objects/arrays JSON-stringify (no `[object Object]`)
- secret string values stay redacted (`api_key` → `***`, db password masked)
- plain strings + primitives pass through

`bun test test/config.test.ts` → 27 pass / 0 fail. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)