### PR TITLE
fix(ai): pass `dimensions` for Google embeddings on openai-compat

### DIFF
--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -220,6 +220,19 @@ export function dimsProviderOptions(
       if (modelId === 'text-embedding-v3' || modelId === 'embedding-3') {
         return { openaiCompatible: { dimensions: dims } };
       }
+      // Google gemini-embedding-2 (and -embedding-001) on openai-compat
+      // proxies (OpenRouter etc.) accept `dimensions` for Matryoshka-style
+      // output truncation. Per Google's docs the supported range is
+      // 128..3072 with recommended values 768 / 1536 / 3072. Without this,
+      // a user who picks e.g. 1536 silently gets back 3072-dim vectors and
+      // the gateway dim-mismatch validator at gateway.ts:1981 hard-fails
+      // on first embed. Symmetric retrieval — inputType ignored.
+      if (
+        modelId.startsWith('google/gemini-embedding') ||
+        modelId === 'text-embedding-004'
+      ) {
+        return { openaiCompatible: { dimensions: dims } };
+      }
       // MiniMax embo-01 takes a `type: 'db' | 'query'` field for asymmetric
       // retrieval. Today still hardcoded to 'db' for back-compat — opting
       // into the new inputType seam is a follow-up (see plan's deferred

--- a/test/ai/dims-google.test.ts
+++ b/test/ai/dims-google.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Google embedding Matryoshka dim plumbing for openai-compat recipes.
+ *
+ * Pins:
+ *  - google/gemini-embedding-2 emits `dimensions: N` on openai-compat
+ *    (matches OpenAI text-3 + DashScope + Zhipu pattern)
+ *  - google/gemini-embedding-001 (legacy name) also handled
+ *  - text-embedding-004 (Google's stable production name) also handled
+ *  - inputType is dropped — Google embeddings are symmetric
+ *  - other Gemini-prefixed models (chat) are NOT matched
+ *
+ * Context: Google's gemini-embedding-2 supports flexible output dims
+ * (128..3072, recommended 768/1536/3072). Without this branch the
+ * gateway sent no `dimensions` field, the API returned 3072, and the
+ * gateway dim-mismatch validator at gateway.ts:1981 hard-failed on
+ * first embed for any brain configured at a non-default dim.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { dimsProviderOptions } from '../../src/core/ai/dims.ts';
+
+describe('Google embeddings — openai-compat Matryoshka', () => {
+  test('google/gemini-embedding-2 emits dimensions=1536', () => {
+    const opts = dimsProviderOptions(
+      'openai-compatible',
+      'google/gemini-embedding-2',
+      1536,
+    );
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1536 } });
+  });
+
+  test('google/gemini-embedding-2 emits dimensions=768 (lower Matryoshka step)', () => {
+    const opts = dimsProviderOptions(
+      'openai-compatible',
+      'google/gemini-embedding-2',
+      768,
+    );
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 768 } });
+  });
+
+  test('google/gemini-embedding-2 emits dimensions=3072 (full-fidelity)', () => {
+    const opts = dimsProviderOptions(
+      'openai-compatible',
+      'google/gemini-embedding-2',
+      3072,
+    );
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 3072 } });
+  });
+
+  test('legacy google/gemini-embedding-001 also covered', () => {
+    const opts = dimsProviderOptions(
+      'openai-compatible',
+      'google/gemini-embedding-001',
+      1536,
+    );
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1536 } });
+  });
+
+  test('text-embedding-004 (stable Google prod name) also covered', () => {
+    const opts = dimsProviderOptions(
+      'openai-compatible',
+      'text-embedding-004',
+      1536,
+    );
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1536 } });
+  });
+
+  test('Google branch ignores inputType (symmetric retrieval)', () => {
+    // Mirrors the CDX2-F6 contract: asymmetric providers (ZE, Voyage) accept
+    // input_type, but Google embeddings are symmetric — must NOT emit the
+    // field or OpenRouter may forward it and cause provider-side rejection.
+    const queryOpts = dimsProviderOptions(
+      'openai-compatible',
+      'google/gemini-embedding-2',
+      1536,
+      'query',
+    );
+    const docOpts = dimsProviderOptions(
+      'openai-compatible',
+      'google/gemini-embedding-2',
+      1536,
+      'document',
+    );
+    expect(queryOpts).toEqual({ openaiCompatible: { dimensions: 1536 } });
+    expect(docOpts).toEqual({ openaiCompatible: { dimensions: 1536 } });
+  });
+
+  test('does NOT match unrelated Google models (e.g. chat gemini-3)', () => {
+    // Gemini chat models live behind the recipe.touchpoints.chat path, not
+    // embedding. If dimsProviderOptions started matching chat model IDs here,
+    // embedMany would send `dimensions` to a chat endpoint and break.
+    const opts = dimsProviderOptions(
+      'openai-compatible',
+      'google/gemini-3-flash-preview',
+      1536,
+    );
+    expect(opts).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds a single new branch in `src/core/ai/dims.ts` (openai-compatible case) so `dimsProviderOptions()` emits `dimensions: N` for Google embedding models on the openai-compat adapter. Mirrors the existing pattern for DashScope `text-embedding-v3`, Zhipu `embedding-3`, and OpenAI `text-embedding-3-*`.

## Why

Google's `gemini-embedding-2` (and legacy `-001` / `text-embedding-004`) supports Matryoshka-style output dim truncation via the `dimensions` request field — range 128..3072, recommended 768 / 1536 / 3072. Without this branch, `dimsProviderOptions()` returned `undefined` for Google models, so the gateway sent no `dimensions` field, the API returned its native 3072, and the dim-mismatch validator at `gateway.ts:1981` hard-failed on first embed for any brain configured at a non-default dim.

Reproducer (pre-fix, with brain at `embedding_dimensions: 1536`):

```bash
gbrain config set embedding_model openrouter:google/gemini-embedding-2
gbrain embed --stale
# → gateway error: vector dim mismatch (expected 1536, got 3072)
```

After this patch, gbrain sends `{"dimensions": 1536}` to the openai-compat `/v1/embeddings` endpoint, OpenRouter forwards to Google, Google returns 1536-dim vectors, gateway validation passes.

## Diff

```diff
+      // Google gemini-embedding-2 (and -embedding-001) on openai-compat
+      // proxies (OpenRouter etc.) accept `dimensions` for Matryoshka-style
+      // output truncation. Per Google's docs the supported range is
+      // 128..3072 with recommended values 768 / 1536 / 3072. ...
+      if (
+        modelId.startsWith('google/gemini-embedding') ||
+        modelId === 'text-embedding-004'
+      ) {
+        return { openaiCompatible: { dimensions: dims } };
+      }
```

Plus a new test file `test/ai/dims-google.test.ts` (7 cases).

## Symmetry note

Google embeddings are symmetric — `input_type` is intentionally NOT emitted (would be rejected provider-side). The test pins this: `inputType='query'` and `inputType='document'` produce identical output blobs.

## Negative pin

The branch uses `startsWith('google/gemini-embedding')` — does NOT match `google/gemini-3-flash-preview` (a chat model). If dimsProviderOptions started matching chat model IDs, `embedMany` would send `dimensions` to a chat endpoint and break. The last test case in `dims-google.test.ts` pins this.

## Verification

- `bun run verify` → **30/30 green**
- 143 targeted tests pass across `dims-openai / dims-zeroentropy / recipe-zhipu / recipe-dashscope / recipe-minimax / recipe-azure-openai / embedQuery / gateway / recipes-existing-regression / asymmetric-encoding-contract / gateway-embed-model-override` (0 regressions)
- 7/7 new tests pass

## Related

- Companion to #2164 (reranker touchpoint — already open) which made the recipe's existing openrouter model ID `google/gemini-embedding-2` actually usable end-to-end.
- Doesn't touch any recipe file — purely a gateway helper change. `dims_options: [512, 768, 1024, 1536]` in the openrouter recipe still gates init (1536 is in-range; users who want 3072 need a separate recipe edit).