### PR TITLE
feat(dream): add --break-lock for gbrain-cycle (closes #1591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to GBrain will be documented in this file.
 
+## [Unreleased]
+
+- **`gbrain dream --break-lock`** (parity with `gbrain sync --break-lock`): safe path / `--max-age <seconds>` (atomic TOCTOU-safe) / `--force-break-lock`. Closes #1591; the cycle lock (held by `gbrain dream` / autopilot) had no CLI escape hatch, so a wedged cycle stranded it indefinitely and `gbrain doctor`'s hint routed operators to `gbrain sync --break-lock` which couldn't actually break it. Same safety semantics as sync: refuses if holder alive (60s liveness grace), refuses cross-host, atomic DELETE keyed on `(id, holder_pid)`.
+
 ## [0.42.42.0] - 2026-06-12
 
 **`gbrain query` no longer pays a flat 10-second exit tax on managed Postgres behind a transaction-mode pooler — and CLI exit codes finally tell the truth on PGLite.** On deployments where the pooler holds sockets open past the bounded pool drain (gbrain#2084, a residual of gbrain#1972), every query printed its results and then sat for 10 seconds until the force-exit banner fired. The cause was two-layered: the hard-deadline timer was armed *before* the operation handler, so a multi-second search on a large brain burned the teardown budget (and any operation slower than 10 seconds was silently killed mid-run with exit 0 and truncated output); and the CLI never exited explicitly on success — it waited for Bun's event loop to drain, which a stuck pooler socket can hold open forever.

--- a/src/commands/dream.ts
+++ b/src/commands/dream.ts
@@ -34,6 +34,11 @@ import { resolveSourceId } from '../core/source-resolver.ts';
 import { fetchSource } from '../core/sources-load.ts';
 import { existsSync } from 'fs';
 import { resolve } from 'node:path';
+import {
+  inspectLock as drInspectLock,
+  deleteLockRow as drDeleteLockRow,
+  deleteLockRowIfStale as drDeleteLockRowIfStale,
+} from '../core/db-lock.ts';
 
 interface DreamArgs {
   json: boolean;
@@ -505,8 +510,132 @@ async function runDrain(
   if (result.remaining === null || result.remaining > 0) process.exit(EXIT_DRAIN_INCOMPLETE);
 }
 
+/**
+ * v0.42.43.0: `gbrain dream --break-lock` parity with sync (closes #1591).
+ * Closes #1591. Cycle lock (held by `gbrain dream`/autopilot) had no CLI
+ * escape hatch; doctor hint routed operators to `gbrain sync --break-lock`
+ * which couldn't actually break it. Same safety semantics as sync:
+ *   - --max-age N: atomic TOCTOU-safe age-gated delete
+ *   - --force-break-lock: skip guards, loud warning
+ *   - safe (no flag): refuse if holder alive on this host
+ *   - cross-host: always refuse (process.kill(pid, 0) invalid across hosts)
+ */
+async function runCycleLockBreak(
+  engine: BrainEngine,
+  lockKey: string,
+  sourceId: string,
+  opts: { force: boolean; json: boolean; maxAgeSeconds?: number },
+): Promise<number> {
+  let snap;
+  try { snap = await drInspectLock(engine, lockKey); }
+  catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (opts.json) console.log(JSON.stringify({ status: 'error', error: msg, lock: lockKey }));
+    else console.error(`Failed to inspect lock ${lockKey}: ${msg}`);
+    return 1;
+  }
+  if (!snap) {
+    if (opts.json) console.log(JSON.stringify({ status: 'absent', lock: lockKey, source_id: sourceId }));
+    else console.log(`Lock ${lockKey} is not held (nothing to break).`);
+    return 0;
+  }
+  const { hostname } = await import('os');
+  const localHost = hostname();
+
+  if (opts.maxAgeSeconds !== undefined && !opts.force) {
+    if (snap.holder_host !== localHost) {
+      if (opts.json) console.log(JSON.stringify({ status: 'refused', reason: 'cross_host', lock: lockKey, source_id: sourceId, snapshot: snap, local_host: localHost }));
+      else { console.error(`Lock ${lockKey} is held on a different host (${snap.holder_host}, this host is ${localHost}).`); console.error('Cross-host --max-age is unsupported. Use --force-break-lock when certain the remote holder is dead.'); }
+      return 1;
+    }
+    const { deleted, lastRefreshedAt } = await drDeleteLockRowIfStale(engine, lockKey, snap.holder_pid, opts.maxAgeSeconds);
+    if (opts.json) {
+      console.log(JSON.stringify({ status: deleted ? 'broken' : 'refused', reason: deleted ? 'max_age_breached' : 'within_max_age', lock: lockKey, source_id: sourceId, snapshot: snap, max_age_seconds: opts.maxAgeSeconds, last_refreshed_at: lastRefreshedAt ? lastRefreshedAt.toISOString() : null }));
+    } else if (deleted) {
+      const ageStr = lastRefreshedAt ? formatAgeHuman(Date.now() - lastRefreshedAt.getTime()) : 'unknown';
+      console.log(`Broke cycle lock ${lockKey} (pid ${snap.holder_pid} on ${snap.holder_host}; last refresh was ${ageStr} ago, > --max-age=${opts.maxAgeSeconds}s).`);
+    } else {
+      if (snap.last_refreshed_at === null) {
+        console.error(`Lock ${lockKey} has NULL last_refreshed_at (pre-v98 brain or migration window).`);
+        console.error('Run `gbrain apply-migrations --yes` to land v98, OR use --force-break-lock if you know the holder is dead.');
+      } else {
+        const ageStr = snap.ms_since_last_refresh != null ? formatAgeHuman(snap.ms_since_last_refresh) : 'unknown';
+        console.error(`Refusing to break lock ${lockKey}: last refresh was ${ageStr} ago, within --max-age=${opts.maxAgeSeconds}s window.`);
+        console.error('The holder is actively refreshing — likely a healthy long-running cycle.');
+      }
+      return 1;
+    }
+    return 0;
+  }
+
+  if (opts.force) {
+    const { deleted } = await drDeleteLockRow(engine, lockKey, snap.holder_pid);
+    if (opts.json) console.log(JSON.stringify({ status: deleted ? 'force_broken' : 'race_already_cleared', lock: lockKey, source_id: sourceId, snapshot: snap }));
+    else if (deleted) { console.log(`Force-broke cycle lock ${lockKey} (was held by pid ${snap.holder_pid} on ${snap.holder_host}, age ${formatAgeHuman(snap.age_ms)}).`); console.log('WARNING: the holder may still be writing. Verify with `gbrain doctor` before re-running.'); }
+    else console.log(`Lock ${lockKey} was already cleared by another process.`);
+    return 0;
+  }
+
+  // safe path: local host, no force, no max-age
+  if (snap.holder_host !== localHost) {
+    if (opts.json) console.log(JSON.stringify({ status: 'refused', reason: 'cross_host', lock: lockKey, source_id: sourceId, snapshot: snap, local_host: localHost }));
+    else { console.error(`Lock ${lockKey} is held on a different host (${snap.holder_host}, this host is ${localHost}).`); console.error('Use --force-break-lock when certain the remote holder is dead.'); }
+    return 1;
+  }
+  if (opts.json) {
+    console.log(JSON.stringify({ status: 'refused', reason: 'active_holder', lock: lockKey, source_id: sourceId, snapshot: snap, local_host: localHost }));
+  } else {
+    console.error(`Lock ${lockKey} is held by pid ${snap.holder_pid} on ${snap.holder_host} (${formatAgeHuman(snap.age_ms)} old, last refresh ${snap.ms_since_last_refresh != null ? formatAgeHuman(snap.ms_since_last_refresh) : 'unknown'} ago).`);
+    console.error('The holder is alive. Use --force-break-lock to clear anyway, or --max-age <seconds> to break only if stale.');
+  }
+  return 1;
+}
+
+function formatAgeHuman(ms: number): string {
+  if (ms < 0) return 'in-the-future';
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m${seconds % 60 ? ` ${seconds % 60}s` : ''}`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h${minutes % 60 ? ` ${minutes % 60}m` : ''}`;
+  const days = Math.floor(hours / 24);
+  return `${days}d${hours % 24 ? ` ${hours % 24}h` : ''}`;
+}
+
 export async function runDream(engine: BrainEngine | null, args: string[]): Promise<CycleReport | void> {
   const opts = parseArgs(args);
+
+  // v0.42.43.0 (PR #2xxx): --break-lock short-circuits BEFORE any cycle work
+  // and BEFORE --help's short-circuit (the break-lock path needs a connected
+  // engine; --help doesn't). Mirrors `gbrain sync --break-lock` for the
+  // gbrain-cycle:* keyspace; Closes #1591.
+  if (
+    args.includes('--break-lock') ||
+    args.includes('--force-break-lock') ||
+    args.includes('--max-age')
+  ) {
+    if (engine === null) {
+      console.error('gbrain dream --break-lock requires a connected brain (no engine available); run `gbrain init` first.');
+      process.exit(1);
+    }
+    const force = args.includes('--force-break-lock');
+    const json = opts.json;
+    const maxAgeIdx = args.indexOf('--max-age');
+    let maxAgeSeconds: number | undefined;
+    if (maxAgeIdx !== -1) {
+      const n = Number(args[maxAgeIdx + 1]);
+      if (!Number.isFinite(n) || n < 0) {
+        console.error('--max-age must be a non-negative number of seconds');
+        process.exit(2);
+      }
+      maxAgeSeconds = n;
+    }
+    const sourceId = opts.source ?? 'default';
+    const lockKey = opts.source ? `gbrain-cycle:${opts.source}` : 'gbrain-cycle';
+    const exitCode = await runCycleLockBreak(engine, lockKey, sourceId, { force, json, maxAgeSeconds });
+    process.exit(exitCode);
+  }
 
   // ─── IRON RULE: --help short-circuits BEFORE any engine-bearing work ─
   // Tests pin this ordering so `gbrain dream --help --source whatever`


### PR DESCRIPTION
## Summary

The cycle lock (held by `gbrain dream` / autopilot) had no CLI escape hatch, so a wedged cycle stranded it indefinitely and `gbrain doctor`'s hint routed operators to `gbrain sync --break-lock` which couldn't actually break it.

This PR adds `gbrain dream --break-lock` with the same safety semantics as the existing `gbrain sync --break-lock`:

- **safe path** (no flag): refuses if holder alive, refuses cross-host (process.kill(pid, 0) is invalid across hosts)
- **`--max-age <seconds>`**: atomic TOCTOU-safe age-gated DELETE keyed on `(id, holder_pid, last_refreshed_at < NOW() - N * INTERVAL)`
- **`--force-break-lock`**: skip guards, atomic DELETE, loud warning that the holder may still be writing
- **`--source <id>`** / **`--json`**: per-source scoping (resolves to `gbrain-cycle:<id>` lock key) and machine-readable output

Doctor at `src/commands/doctor.ts:2417+` already routes cycle locks to `gbrain dream --break-lock` (the if-else chain is in place), so the moment this lands, the existing hint becomes actionable for the first time.

## Test plan

- `gbrain dream --break-lock` (no cycle lock held) → `Lock gbrain-cycle is not held (nothing to break).` exit 0
- `gbrain dream --break-lock` while a healthy cycle holds it → `holder is alive, use --max-age or --force-break-lock` exit 1
- `gbrain dream --break-lock --max-age 60` while a long-dead cycle holds it → `Broke cycle lock gbrain-cycle ...` exit 0
- `gbrain dream --break-lock --force-break-lock` → atomic DELETE, warning emitted
- `gbrain doctor` after merge → `stale_locks` WARN should clear

## Files

- `src/commands/dream.ts`: +129 lines (`runCycleLockBreak` + `formatAgeHuman` + `--break-lock` short-circuit + 3 imports)
- `CHANGELOG.md`: +4 lines ([Unreleased] section)

Closes #1591