### PR TITLE
feat(files): add delete subcommand for orphan/missing file rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to GBrain will be documented in this file.
 
+## [Unreleased]
+
+- **`gbrain dream --break-lock`** (parity with `gbrain sync --break-lock`): safe path / `--max-age <seconds>` (atomic TOCTOU-safe) / `--force-break-lock`. Closes #1591; the cycle lock (held by `gbrain dream` / autopilot) had no CLI escape hatch, so a wedged cycle stranded it indefinitely and `gbrain doctor`'s hint routed operators to `gbrain sync --break-lock` which couldn't actually break it. Same safety semantics as sync: refuses if holder alive (60s liveness grace), refuses cross-host, atomic DELETE keyed on `(id, holder_pid)`.
+- **`gbrain files delete --id <id> | --path <path>`** (new subcommand): delete orphan/missing file rows from the `files` table. Requires `--yes` to confirm; supports `--json`. Pre-#2xxx the `image_assets` doctor hint pointed at `gbrain sync --skip-failed`, which only acknowledges sync-level failures, not per-file rows; this verb gives operators a per-file cleanup path. The doctor message now lists vanishing file ids and points at this command.
 ## [0.42.42.0] - 2026-06-12
 
 **`gbrain query` no longer pays a flat 10-second exit tax on managed Postgres behind a transaction-mode pooler — and CLI exit codes finally tell the truth on PGLite.** On deployments where the pooler holds sockets open past the bounded pool drain (gbrain#2084, a residual of gbrain#1972), every query printed its results and then sat for 10 seconds until the force-exit banner fired. The cause was two-layered: the hard-deadline timer was armed *before* the operation handler, so a multi-second search on a large brain burned the teardown budget (and any operation slower than 10 seconds was silently killed mid-run with exit 0 and truncated output); and the CLI never exited explicitly on success — it waited for Bun's event loop to drain, which a stuck pooler socket can hold open forever.

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -7019,18 +7019,22 @@ export async function buildChecks(
   if (engine) {
     progress.heartbeat('image_assets');
     try {
-      const rows = await engine.executeRaw<{ storage_path: string }>(
-        `SELECT storage_path FROM files WHERE mime_type LIKE 'image/%' LIMIT 1000`
+      // v0.42.43.0 (PR #2xxx): also project id so the doctor hint can
+      // name a per-row id for `gbrain files delete --id`. Pre-#2xxx the
+      // hint routed operators to `gbrain sync --skip-failed`, which only
+      // acknowledges sync-level failures, not per-file rows.
+      const rows = await engine.executeRaw<{ id: number; storage_path: string }>(
+        `SELECT id, storage_path FROM files WHERE mime_type LIKE 'image/%' LIMIT 1000`
       );
       let vanished = 0;
-      const vanishedPaths: string[] = [];
+      const vanishedRows: Array<{ id: number; storage_path: string }> = [];
       const fs = await import('node:fs');
       for (const r of rows) {
         try {
           fs.statSync(r.storage_path);
         } catch {
           vanished++;
-          if (vanishedPaths.length < 5) vanishedPaths.push(r.storage_path);
+          if (vanishedRows.length < 5) vanishedRows.push({ id: r.id, storage_path: r.storage_path });
         }
       }
       if (rows.length === 0) {
@@ -7041,8 +7045,8 @@ export async function buildChecks(
         checks.push({
           name: 'image_assets',
           status: 'warn',
-          message: `${vanished} of ${rows.length} image(s) missing from disk (e.g. ${vanishedPaths.join(', ')}). ` +
-                   `Fix: restore from git, or \`gbrain sync --skip-failed\` to acknowledge.`,
+          message: `${vanished} of ${rows.length} image(s) missing from disk (e.g. ${vanishedRows.map(r => r.id + ':' + r.storage_path).join(', ')}). ` +
+                   `Fix: restore from git, or \`gbrain files delete --id <id>\` to acknowledge (run \`gbrain files list\` to find ids, or \`gbrain doctor --fix\` for a paste-ready list).`,
         });
       }
     } catch {

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -73,6 +73,9 @@ export async function runFiles(engine: BrainEngine, args: string[]) {
     case 'clean':
       await cleanFiles(args.slice(1));
       break;
+    case 'delete':
+      await deleteFile(engine, args.slice(1));
+      break;
     case 'upload-raw':
       await uploadRaw(engine, args.slice(1));
       break;
@@ -95,6 +98,7 @@ export async function runFiles(engine: BrainEngine, args: string[]) {
       console.error(`  redirect <dir> [--dry-run]  Replace files with .redirect.yaml pointers`);
       console.error(`  restore <dir>             Download from storage, recreate local files`);
       console.error(`  clean <dir> [--yes]       Delete redirect pointers (irreversible)`);
+      console.error(`  delete --id <id>|--path <path> [--yes] [--json]  Delete file row from DB (orphan/missing cleanup)`);
       console.error(`  status                    Show migration status of directories`);
       process.exit(1);
   }
@@ -602,6 +606,75 @@ async function cleanFiles(args: string[]) {
 
   console.log(`Cleaned ${cleaned} redirect breadcrumbs. Cloud storage is now the only source.`);
 }
+/**
+ * v0.42.43.0 (PR #2xxx): delete a file row from the `files` table.
+ * Use case: doctor `image_assets` WARN surfaces vanished images whose
+ * files rows still exist; this verb lets operators clean those up
+ * without going to SQL. The pre-#2xxx fix path (`gbrain sync --skip-failed`)
+ * only acknowledges sync-level failures, not per-file rows.
+ *
+ * Required: --id <id> OR --path <path>
+ * Confirm:  --yes (interactive: prints rows + asks for re-run)
+ * Format:   --json
+ */
+async function deleteFile(engine: BrainEngine, args: string[]) {
+  const confirmed = args.includes('--yes');
+  const json = args.includes('--json');
+  const idIdx = args.indexOf('--id');
+  const pathIdx = args.indexOf('--path');
+  const id = idIdx !== -1 ? Number(args[idIdx + 1]) : null;
+  const storagePath = pathIdx !== -1 ? args[pathIdx + 1] : null;
+
+  if ((id === null || !Number.isFinite(id)) && !storagePath) {
+    console.error('Usage: gbrain files delete --id <id> | --path <path> [--yes] [--json]');
+    console.error('At least one of --id or --path is required.');
+    process.exit(1);
+  }
+
+  type RowShape = { id: number; storage_path: string; original_name: string; page_slug: string | null };
+  let rows: RowShape[];
+  if (id !== null) {
+    rows = await engine.executeRaw<RowShape>(
+      `SELECT id, storage_path, original_name, page_slug FROM files WHERE id = $1`,
+      [id],
+    );
+  } else {
+    rows = await engine.executeRaw<RowShape>(
+      `SELECT id, storage_path, original_name, page_slug FROM files WHERE storage_path = $1 OR original_name = $1`,
+      [storagePath!],
+    );
+  }
+
+  if (rows.length === 0) {
+    if (json) console.log(JSON.stringify({ status: 'not_found', id, storage_path: storagePath }));
+    else console.error(`No file row matches ${id !== null ? `id=${id}` : `path=${storagePath}`}.`);
+    process.exit(1);
+  }
+
+  if (!confirmed) {
+    if (json) {
+      console.log(JSON.stringify({ status: 'confirm_required', rows }));
+    } else {
+      console.error(`About to permanently delete ${rows.length} file row(s):`);
+      for (const r of rows) console.error(`  id=${r.id}  path=${r.storage_path}  page=${r.page_slug ?? '(none)'}`);
+      console.error('Re-run with --yes to confirm.');
+    }
+    process.exit(1);
+  }
+
+  const ids = rows.map(r => r.id);
+  const placeholders = ids.map((_, i) => `$${i + 1}`).join(',');
+  const result = await engine.executeRaw<{ id: number }>(
+    `DELETE FROM files WHERE id IN (${placeholders}) RETURNING id`,
+    ids,
+  );
+  if (json) {
+    console.log(JSON.stringify({ status: 'deleted', count: result.length, ids: result.map(r => r.id) }));
+  } else {
+    console.log(`Deleted ${result.length} file row(s): ${result.map(r => r.id).join(', ')}`);
+  }
+}
+
 
 async function filesStatus(args: string[]) {
   const dir = args[0] || '.';


### PR DESCRIPTION
## Summary

The `image_assets` doctor WARN surfaces vanished images whose files rows still exist. Pre-#2xxx the fix path was `gbrain sync --skip-failed`, which only acknowledges sync-level failures, not per-file rows. This verb gives operators a per-file cleanup path; the doctor message now lists vanishing file ids and points at `gbrain files delete --id <id>`.

## What this PR adds

**`gbrain files delete`** (new subcommand):
- `--id <id>` OR `--path <path>` (required, one of)
- `--yes` to confirm (interactive: prints rows + asks for re-run)
- `--json` for machine-readable output
- Atomic DELETE via parameterized SQL
- Confirms-or-aborts on `not_found` (exit 1)

**Doctor fix**: `image_assets` hint at `src/commands/doctor.ts:6268+` now lists per-row ids and points at `gbrain files delete --id <id>`; the `vanishedPaths` field is now `vanishedRows` (id + storage_path object array).

## Test plan

- `gbrain files delete --id 99999` (no such id) → `No file row matches id=99999.` exit 1
- `gbrain files delete --id 12345` (no --yes) → `About to permanently delete 1 file row(s): id=12345 path=...` + `Re-run with --yes to confirm.` exit 1
- `gbrain files delete --id 12345 --yes` → `Deleted 1 file row(s): 12345` exit 0
- `gbrain files delete --path /missing/path --yes` → same flow
- `gbrain files delete --json` (id present, --yes) → `{"status":"deleted","count":1,"ids":[12345]}` exit 0
- `gbrain doctor` after merge → `image_assets` WARN now mentions per-row ids

## Files

- `src/commands/files.ts`: +73 lines (deleteFile function + case + usage doc)
- `src/commands/doctor.ts`: 16 lines (image_assets SELECT + message update; id now projected)
- `CHANGELOG.md`: +4 lines ([Unreleased] section includes both this PR and the companion `gbrain dream --break-lock` PR #2173 for v0.42.43.0)