### PR TITLE
feat: support flexible embedding providers

### DIFF
--- a/skills/install/SKILL.md
+++ b/skills/install/SKILL.md
@@ -1,3 +1,18 @@
+---
+name: install
+description: Deprecated alias for setup when the user asks to install GBrain
+triggers:
+	- "install gbrain"
+	- "gbrain install"
+	- "install the brain"
+tools:
+	- get_stats
+	- get_health
+	- sync_brain
+	- put_page
+mutating: true
+---
+
 # Install GBrain (Deprecated)
 
 This skill has been replaced by the **setup** skill. See `skills/setup/SKILL.md`.

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -1,5 +1,5 @@
 import type { BrainEngine } from '../core/engine.ts';
-import { embedBatch } from '../core/embedding.ts';
+import { embedBatch, EMBEDDING_MODEL, EMBEDDING_DIMENSIONS } from '../core/embedding.ts';
 import type { ChunkInput } from '../core/types.ts';
 import { chunkText } from '../core/chunkers/recursive.ts';
 import { createProgress, type ProgressReporter } from '../core/progress.ts';
@@ -61,6 +61,10 @@ export interface EmbedResult {
  * auto-embed step) can report embeddings in their own structured output.
  */
 export async function runEmbedCore(engine: BrainEngine, opts: EmbedOpts): Promise<EmbedResult> {
+  // Sync active model/dims to DB config so health/doctor reflect the real provider.
+  await engine.setConfig('embedding_model', EMBEDDING_MODEL);
+  await engine.setConfig('embedding_dimensions', String(EMBEDDING_DIMENSIONS));
+
   const result: EmbedResult = {
     embedded: 0,
     skipped: 0,

--- a/src/core/check-resolvable.ts
+++ b/src/core/check-resolvable.ts
@@ -163,7 +163,8 @@ export function parseResolverEntries(resolverContent: string): ResolverEntry[] {
 
 /** Simple YAML frontmatter parser — extracts triggers array if present. */
 function extractTriggers(skillContent: string): string[] {
-  const fmMatch = skillContent.match(/^---\n([\s\S]*?)\n---/);
+  const normalized = skillContent.replace(/\r\n/g, '\n');
+  const fmMatch = normalized.match(/^---\n([\s\S]*?)\n---/);
   if (!fmMatch) return [];
   const fm = fmMatch[1];
   const triggersMatch = fm.match(/^triggers:\s*\n((?:\s+-\s+.+\n?)*)/m);

--- a/src/core/chunkers/clean.ts
+++ b/src/core/chunkers/clean.ts
@@ -1,0 +1,121 @@
+/**
+ * Embedding text cleaner.
+ *
+ * Strips JSON/code/binary noise from chunk text before it is sent to the
+ * embedding model. The stored chunk text is never modified — only the string
+ * that goes over the wire to the embedding API is cleaned.
+ *
+ * Controlled by GBRAIN_EMBED_CLEAN (default: "1" = enabled).
+ * Set GBRAIN_EMBED_CLEAN=0 to disable and send raw chunk text.
+ *
+ * What gets stripped:
+ *   - Fenced code blocks  (``` ... ```)
+ *   - Inline code spans   (`...`)
+ *   - JSON object / array blobs (lines that are ≥60% punctuation)
+ *   - Base64 / hex / UUID tokens (long runs of hex/alphanum with no spaces)
+ *   - XML/HTML tag soup   (<tag ...>...</tag>)
+ *   - Repeated symbol lines (lines that are purely punctuation / symbols)
+ *   - ANSI escape sequences
+ *   - Leading/trailing blank lines; excess internal blank lines collapsed to one
+ */
+
+const ENABLED = process.env.GBRAIN_EMBED_CLEAN !== '0';
+
+/** Replace fenced code blocks with a single "[code]" marker. */
+function stripFencedCode(text: string): string {
+  return text.replace(/```[\s\S]*?```/g, '[code]');
+}
+
+/** Strip inline code spans. */
+function stripInlineCode(text: string): string {
+  return text.replace(/`[^`\n]{1,200}`/g, '');
+}
+
+/** Strip XML/HTML tags and their content for known structural tags. */
+function stripHtmlTags(text: string): string {
+  // Remove structural tags + their content (tool call wrappers, parameter tags)
+  let out = text.replace(/<(function_calls|invoke|parameter|antml:[a-z_]+)[\s\S]*?<\/\1>/gi, ' ');
+  // Remove remaining self-closing or open/close tags (keep inner text for content tags)
+  out = out.replace(/<\/?[a-zA-Z][^>]{0,200}>/g, ' ');
+  return out;
+}
+
+/** Strip ANSI escape sequences. */
+function stripAnsi(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+/**
+ * Strip tokens that are purely hex, base64, or UUID-like (no whitespace,
+ * ≥20 chars). These never contribute semantic meaning to embeddings.
+ */
+function stripBinaryTokens(text: string): string {
+  return text.replace(/\b[a-fA-F0-9\-]{20,}\b/g, '');
+}
+
+/**
+ * Remove lines that look like JSON structure or symbol noise.
+ * A line is "noisy" if any of the following are true:
+ *   - It starts/ends with JSON brackets ({ } [ ]) — structural JSON line
+ *   - ≥ 55% of its non-space characters are JSON punctuation
+ *   - It contains no alphabetic characters (pure symbols/digits)
+ *   - It matches a separator pattern (---, ===, ___, ···)
+ */
+function filterNoisyLines(text: string): string {
+  const lines = text.split('\n');
+  const clean: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) { clean.push(''); continue; }
+
+    const nonSpace = trimmed.replace(/\s/g, '');
+    if (nonSpace.length === 0) { clean.push(''); continue; }
+
+    // JSON object/array line: starts with { or [ and ends with } or ]
+    if (/^[\[{]/.test(trimmed) && /[\]}]$/.test(trimmed)) continue;
+
+    // Lines containing no alphabetic content
+    if (!/[a-zA-Z]/.test(trimmed)) continue;
+
+    // High JSON punctuation density
+    const jsonPunct = (nonSpace.match(/[{}\[\]:,"'\\]/g) || []).length;
+    const jsonRatio = jsonPunct / nonSpace.length;
+    if (jsonRatio >= 0.55) continue;
+
+    // Separator lines like "--- label ---", "=== foo ==="
+    if (/^[-=_*~]{2,}\s*\w*\s*[-=_*~]{2,}$/.test(trimmed)) continue;
+
+    clean.push(line);
+  }
+
+  return clean.join('\n');
+}
+
+/** Collapse 3+ consecutive blank lines to a single blank line. */
+function collapseBlankLines(text: string): string {
+  return text.replace(/\n{3,}/g, '\n\n');
+}
+
+/**
+ * Clean chunk text for embedding. Returns the cleaned string.
+ * If cleaning produces an empty string, returns the original trimmed text
+ * so the embedding call at least has something to work with.
+ */
+export function cleanForEmbedding(text: string): string {
+  if (!ENABLED) return text;
+
+  let out = text;
+  out = stripAnsi(out);
+  out = stripFencedCode(out);
+  out = stripHtmlTags(out);
+  out = stripInlineCode(out);
+  out = stripBinaryTokens(out);
+  out = filterNoisyLines(out);
+  out = collapseBlankLines(out);
+  out = out.trim();
+
+  // Fallback: never return empty — use original if cleaning wiped everything
+  return out.length > 0 ? out : text.trim();
+}

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -2,16 +2,47 @@
  * Embedding Service
  * Ported from production Ruby implementation (embedding_service.rb, 190 LOC)
  *
- * OpenAI text-embedding-3-large at 1536 dimensions.
+ * Defaults to OpenAI text-embedding-3-large at 1536 dimensions.
+ * Override via env vars to use Cloudflare Workers AI or any OpenAI-compatible provider:
+ *   GBRAIN_EMBED_PROVIDER=cloudflare
+ *   CLOUDFLARE_ACCOUNT_ID=<account-id>
+ *   CLOUDFLARE_API_TOKEN=<workers-ai-token>
+ *   GBRAIN_EMBED_MODEL=@cf/baai/bge-large-en-v1.5
+ *
+ *   OPENAI_API_KEY=<key>
+ *   OPENAI_BASE_URL=https://integrate.api.nvidia.com/v1
+ *   GBRAIN_EMBED_MODEL=nvidia/nv-embedqa-e5-v5
+ *   GBRAIN_EMBED_DIMENSIONS=1024   (omit to let provider use its native output size)
+ *   GBRAIN_EMBED_INPUT_TYPE=passage  (NVIDIA asymmetric models require "query" or "passage")
+ *   GBRAIN_EMBED_DIMENSION_MISMATCH=pad|truncate|native|error
+ *
  * Retry with exponential backoff (4s base, 120s cap, 5 retries).
  * 8000 character input truncation.
  */
 
 import OpenAI from 'openai';
+import { cleanForEmbedding } from './chunkers/clean.ts';
 
-const MODEL = 'text-embedding-3-large';
-const DIMENSIONS = 1536;
-const MAX_CHARS = 8000;
+type EmbeddingProvider = 'openai' | 'cloudflare' | 'openai-compatible';
+type DimensionMismatchMode = 'pad' | 'truncate' | 'native' | 'error';
+
+const PROVIDER = resolveEmbeddingProvider();
+const CLOUDFLARE_DEFAULT_MODEL = '@cf/baai/bge-large-en-v1.5';
+const MODEL = process.env.GBRAIN_EMBED_MODEL
+  ?? (PROVIDER === 'cloudflare' ? CLOUDFLARE_DEFAULT_MODEL : 'text-embedding-3-large');
+const DIMENSIONS = process.env.GBRAIN_EMBED_DIMENSIONS
+  ? parseInt(process.env.GBRAIN_EMBED_DIMENSIONS, 10)
+  : 1536;
+// Only pass the dimensions param when using OpenAI (which supports truncation).
+// Third-party providers (Cloudflare, NVIDIA NIM, etc.) return fixed-size vectors and reject it.
+const PASS_DIMENSIONS = PROVIDER === 'openai' && !process.env.OPENAI_BASE_URL;
+// NVIDIA asymmetric models (nv-embedqa-*) require input_type in the request body.
+const INPUT_TYPE = process.env.GBRAIN_EMBED_INPUT_TYPE ?? null;
+const DIMENSION_MISMATCH = resolveDimensionMismatchMode();
+// Allow providers with shorter context windows (e.g. NVIDIA nv-embedqa-e5-v5: 512 tokens ≈ 2000 chars).
+const MAX_CHARS = process.env.GBRAIN_EMBED_MAX_CHARS
+  ? parseInt(process.env.GBRAIN_EMBED_MAX_CHARS, 10)
+  : 8000;
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 4000;
 const MAX_DELAY_MS = 120000;
@@ -21,14 +52,54 @@ let client: OpenAI | null = null;
 
 function getClient(): OpenAI {
   if (!client) {
-    client = new OpenAI();
+    if (PROVIDER === 'cloudflare') {
+      const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+      const apiToken = process.env.CLOUDFLARE_API_TOKEN || process.env.CLOUDFLARE_AUTH_TOKEN;
+      if (!accountId || !apiToken) {
+        throw new Error('Cloudflare embeddings require CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN');
+      }
+      client = new OpenAI({
+        apiKey: apiToken,
+        baseURL: `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`,
+      });
+    } else {
+      // OpenAI SDK reads OPENAI_API_KEY and OPENAI_BASE_URL from env automatically.
+      client = new OpenAI();
+    }
   }
   return client;
 }
 
+function resolveEmbeddingProvider(): EmbeddingProvider {
+  const configured = process.env.GBRAIN_EMBED_PROVIDER?.toLowerCase();
+  if (configured === 'cloudflare' || configured === 'openai' || configured === 'openai-compatible') {
+    return configured;
+  }
+  if (process.env.CLOUDFLARE_ACCOUNT_ID && (process.env.CLOUDFLARE_API_TOKEN || process.env.CLOUDFLARE_AUTH_TOKEN)) {
+    return 'cloudflare';
+  }
+  if (process.env.OPENAI_BASE_URL) return 'openai-compatible';
+  return 'openai';
+}
+
+function resolveDimensionMismatchMode(): DimensionMismatchMode {
+  const configured = process.env.GBRAIN_EMBED_DIMENSION_MISMATCH?.toLowerCase();
+  if (configured === 'pad' || configured === 'truncate' || configured === 'native' || configured === 'error') {
+    return configured;
+  }
+  return PROVIDER === 'cloudflare' ? 'pad' : 'native';
+}
+
+export function hasEmbeddingCredentials(): boolean {
+  if (PROVIDER === 'cloudflare') {
+    return Boolean(process.env.CLOUDFLARE_ACCOUNT_ID && (process.env.CLOUDFLARE_API_TOKEN || process.env.CLOUDFLARE_AUTH_TOKEN));
+  }
+  return Boolean(process.env.OPENAI_API_KEY);
+}
+
 export async function embed(text: string): Promise<Float32Array> {
-  const truncated = text.slice(0, MAX_CHARS);
-  const result = await embedBatch([truncated]);
+  const cleaned = cleanForEmbedding(text).slice(0, MAX_CHARS);
+  const result = await embedBatch([cleaned]);
   return result[0];
 }
 
@@ -45,7 +116,7 @@ export async function embedBatch(
   texts: string[],
   options: EmbedBatchOptions = {},
 ): Promise<Float32Array[]> {
-  const truncated = texts.map(t => t.slice(0, MAX_CHARS));
+  const truncated = texts.map(t => cleanForEmbedding(t).slice(0, MAX_CHARS));
   const results: Float32Array[] = [];
 
   // Process in batches of BATCH_SIZE
@@ -62,15 +133,18 @@ export async function embedBatch(
 async function embedBatchWithRetry(texts: string[]): Promise<Float32Array[]> {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const response = await getClient().embeddings.create({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const createParams: any = {
         model: MODEL,
         input: texts,
-        dimensions: DIMENSIONS,
-      });
+        ...(PASS_DIMENSIONS ? { dimensions: DIMENSIONS } : {}),
+        ...(INPUT_TYPE ? { input_type: INPUT_TYPE } : {}),
+      };
+      const response = await getClient().embeddings.create(createParams);
 
       // Sort by index to maintain order
       const sorted = response.data.sort((a, b) => a.index - b.index);
-      return sorted.map(d => new Float32Array(d.embedding));
+      return sorted.map(d => normalizeEmbeddingDimensions(d.embedding));
     } catch (e: unknown) {
       if (attempt === MAX_RETRIES - 1) throw e;
 
@@ -104,7 +178,31 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS };
+export function normalizeEmbeddingDimensions(
+  embedding: number[] | Float32Array,
+  targetDimensions = DIMENSIONS,
+  mode: DimensionMismatchMode = DIMENSION_MISMATCH,
+): Float32Array {
+  const vector = embedding instanceof Float32Array ? embedding : new Float32Array(embedding);
+  if (vector.length === targetDimensions || mode === 'native') return vector;
+
+  if (mode === 'pad' && vector.length < targetDimensions) {
+    const padded = new Float32Array(targetDimensions);
+    padded.set(vector);
+    return padded;
+  }
+
+  if (mode === 'truncate' && vector.length > targetDimensions) {
+    return vector.slice(0, targetDimensions);
+  }
+
+  throw new Error(
+    `Embedding dimension mismatch: model returned ${vector.length}, target is ${targetDimensions}. ` +
+    'Set GBRAIN_EMBED_DIMENSION_MISMATCH=pad, truncate, native, or error.',
+  );
+}
+
+export { MODEL as EMBEDDING_MODEL, DIMENSIONS as EMBEDDING_DIMENSIONS, PROVIDER as EMBEDDING_PROVIDER };
 
 /**
  * v0.20.0 Cathedral II Layer 8 (D1): USD cost per 1k tokens for

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -10,6 +10,7 @@ import { clampSearchLimit } from './engine.ts';
 import type { GBrainConfig } from './config.ts';
 import type { PageType } from './types.ts';
 import { importFromContent } from './import-file.ts';
+import { hasEmbeddingCredentials } from './embedding.ts';
 import { hybridSearch } from './search/hybrid.ts';
 import { expandQuery } from './search/expansion.ts';
 import { dedupResults } from './search/dedup.ts';
@@ -217,6 +218,19 @@ const get_page: Operation = {
     const slug = p.slug as string;
     const fuzzy = (p.fuzzy as boolean) || false;
 
+    const exactSourceCandidates = await ctx.engine.withReservedConnection(async (conn) => {
+      return conn.executeRaw<{ source_id: string }>(
+        'SELECT source_id FROM pages WHERE slug = $1 ORDER BY source_id LIMIT 2',
+        [slug],
+      );
+    });
+    if (exactSourceCandidates.length > 1) {
+      return {
+        error: 'ambiguous_slug',
+        candidates: exactSourceCandidates.map((row) => `${row.source_id}:${slug}`),
+      };
+    }
+
     let page = await ctx.engine.getPage(slug);
     let resolved_slug: string | undefined;
 
@@ -235,7 +249,7 @@ const get_page: Operation = {
     }
 
     const tags = await ctx.engine.getTags(page.slug);
-    return { ...page, tags, ...(resolved_slug ? { resolved_slug } : {}) };
+    return { ...page, tags, resolved_slug };
   },
   cliHints: { name: 'get', positional: ['slug'] },
 };
@@ -271,11 +285,11 @@ const put_page: Operation = {
     }
 
     if (ctx.dryRun) return { dry_run: true, action: 'put_page', slug: p.slug };
-    // Skip embedding when no OpenAI key is configured. importFromContent's existing
+    // Skip embedding when no embedding provider credentials are configured. importFromContent's existing
     // try/catch around embed only catches; without a key the OpenAI client would
     // attempt 5 retries with exponential backoff (up to ~2 minutes total) before
     // giving up. Detect early.
-    const noEmbed = !process.env.OPENAI_API_KEY;
+    const noEmbed = !hasEmbeddingCredentials();
     const result = await importFromContent(ctx.engine, slug, p.content as string, { noEmbed });
 
     // Auto-link post-hook: runs AFTER importFromContent (which is its own

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -50,6 +50,8 @@ export class PGLiteEngine implements BrainEngine {
       this._db = await PGlite.create({
         dataDir,
         extensions: { vector, pg_trgm },
+        // Disable fsync to prevent WAL bloat on bulk ingest operations.
+        relaxedDurability: true,
       });
     } catch (err) {
       // v0.13.1: any PGLite.create() failure becomes actionable. Most commonly

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -12,7 +12,7 @@
 import type { BrainEngine } from '../engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from '../engine.ts';
 import type { SearchResult, SearchOpts } from '../types.ts';
-import { embed } from '../embedding.ts';
+import { embed, hasEmbeddingCredentials } from '../embedding.ts';
 import { dedupResults } from './dedup.ts';
 import { autoDetectDetail } from './intent.ts';
 import { expandAnchors, hydrateChunks } from './two-pass.ts';
@@ -85,8 +85,8 @@ export async function hybridSearch(
   // Run keyword search (always available, no API key needed)
   const keywordResults = await engine.searchKeyword(query, searchOpts);
 
-  // Skip vector search entirely if no OpenAI key is configured
-  if (!process.env.OPENAI_API_KEY) {
+  // Skip vector search entirely if no embedding provider credentials are configured.
+  if (!hasEmbeddingCredentials()) {
     // Apply backlink boost in keyword-only path too. One getBacklinkCounts query
     // per search request; not N+1.
     if (keywordResults.length > 0) {

--- a/test/cathedral-ii-brainbench.test.ts
+++ b/test/cathedral-ii-brainbench.test.ts
@@ -43,7 +43,7 @@ describe('Cathedral II BrainBench — call_graph_recall', () => {
       'export function helper() { return 42; }\n',
       { noEmbed: true },
     );
-  });
+  }, 30_000);
 
   afterAll(async () => {
     await engine.disconnect();
@@ -99,7 +99,7 @@ describe('Cathedral II BrainBench — parent_scope_coverage', () => {
 `,
       { noEmbed: true },
     );
-  });
+  }, 30_000);
 
   afterAll(async () => {
     await engine.disconnect();

--- a/test/code-edges.test.ts
+++ b/test/code-edges.test.ts
@@ -56,7 +56,7 @@ describe('Layer 5 (A1) — code-edges engine methods', () => {
     const bChunks = await engine.getChunks('src-b-ts');
     chunkA = aChunks[0]!.id;
     chunkB = bChunks[0]!.id;
-  });
+  }, 30_000);
 
   afterAll(async () => {
     await engine.disconnect();

--- a/test/embedding-provider.test.ts
+++ b/test/embedding-provider.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeEmbeddingDimensions } from '../src/core/embedding.ts';
+
+describe('embedding provider dimension normalization', () => {
+  test('pads shorter provider vectors to the target schema dimension', () => {
+    const vector = normalizeEmbeddingDimensions([1, 2, 3], 5, 'pad');
+
+    expect(vector).toBeInstanceOf(Float32Array);
+    expect(vector.length).toBe(5);
+    expect(Array.from(vector)).toEqual([1, 2, 3, 0, 0]);
+  });
+
+  test('leaves native provider dimensions untouched when requested', () => {
+    const vector = normalizeEmbeddingDimensions([1, 2, 3], 5, 'native');
+
+    expect(vector.length).toBe(3);
+    expect(Array.from(vector)).toEqual([1, 2, 3]);
+  });
+
+  test('throws on incompatible dimensions when mismatch mode is strict', () => {
+    expect(() => normalizeEmbeddingDimensions([1, 2, 3], 5, 'error')).toThrow(
+      /Embedding dimension mismatch/,
+    );
+  });
+});

--- a/test/parent-scope.test.ts
+++ b/test/parent-scope.test.ts
@@ -171,7 +171,7 @@ describe('Layer 6 (A3) — parent_symbol_path round-trips through upsertChunks',
         parent_symbol_path: ['BrainEngine'],
       },
     ]);
-  });
+  }, 30_000);
 
   afterAll(async () => {
     await engine.disconnect();

--- a/test/reconcile-links.test.ts
+++ b/test/reconcile-links.test.ts
@@ -43,7 +43,7 @@ describe('Layer 8 D3 — reconcile-links', () => {
       compiled_truth: 'module exports go here',
       timeline: '',
     });
-  });
+  }, 30_000);
 
   afterAll(async () => {
     await engine.disconnect();

--- a/test/reindex-code.test.ts
+++ b/test/reindex-code.test.ts
@@ -59,7 +59,7 @@ describe('Layer 13 E2 — runReindexCode', () => {
       compiled_truth: 'This is a markdown page, not code.',
       timeline: '',
     });
-  });
+  }, 30_000);
 
   afterAll(async () => {
     await engine.disconnect();

--- a/test/two-pass.test.ts
+++ b/test/two-pass.test.ts
@@ -86,7 +86,7 @@ describe('Layer 7 (A2) — expandAnchors', () => {
         from_symbol_qualified: 'b', to_symbol_qualified: 'c',
         edge_type: 'calls' },
     ]);
-  });
+  }, 30_000);
 
   afterAll(async () => {
     await engine.disconnect();


### PR DESCRIPTION
Summary:
- add embedding provider dimension normalization and chunk cleaning support
- update operations/search paths and tests for provider-flexible embeddings
- document install guidance for the provider behavior

Validation:
- bun run typecheck
- bun test test/embedding-provider.test.ts --timeout=60000