### PR TITLE
Fix task manager live-context contract

### DIFF
--- a/skills/briefing/SKILL.md
+++ b/skills/briefing/SKILL.md
@@ -65,12 +65,13 @@ Compile a daily briefing from brain context.
 3. **Time-sensitive threads.** Open items from timeline entries:
    - Items with deadlines in the next 48 hours
    - Follow-ups that are overdue
-4. **Recent changes.** Pages updated in the last 24 hours:
+4. **Explicit task list.** If `ops/tasks.md` exists in the workspace, read it directly and include open P0/P1 tasks under ACTION ITEMS. Do not query `ops/tasks` through gbrain; `ops/` is intentionally excluded from sync.
+5. **Recent changes.** Pages updated in the last 24 hours:
    - What changed and why (read timeline entries from gbrain)
-5. **People in play.** List person pages in gbrain sorted by recency:
+6. **People in play.** List person pages in gbrain sorted by recency:
    - Updated in last 7 days
    - Have high activity (many recent timeline entries)
-6. **Stale alerts.** From gbrain health check:
+7. **Stale alerts.** From gbrain health check:
    - Pages flagged as stale that are relevant to today's meetings
 
 ## GBrain-Native Context Loading

--- a/skills/daily-task-manager/SKILL.md
+++ b/skills/daily-task-manager/SKILL.md
@@ -3,7 +3,7 @@ name: daily-task-manager
 version: 1.0.0
 description: |
   Task lifecycle management. Add, complete, defer, remove, and review tasks.
-  Maintains a running task list as a brain page.
+  Maintains a running task list as an ops/tasks.md workspace file.
 triggers:
   - "add task"
   - "complete task"
@@ -12,8 +12,6 @@ triggers:
   - "defer task"
 tools:
   - search
-  - get_page
-  - put_page
   - add_timeline_entry
 mutating: true
 ---
@@ -23,7 +21,8 @@ mutating: true
 ## Contract
 
 This skill guarantees:
-- Tasks stored as a brain page (`ops/tasks.md`) with structured format
+- Tasks stored in the workspace file `ops/tasks.md` with structured format
+- The live-context engine can read P1 tasks from the same file this skill writes
 - Task lifecycle: add → in-progress → complete | defer
 - Priority levels: P0 (urgent), P1 (today), P2 (this week), P3 (backlog)
 - Completed tasks archived with completion date
@@ -31,14 +30,14 @@ This skill guarantees:
 
 ## Phases
 
-1. **Load current tasks.** `gbrain get ops/tasks` — read the task list.
+1. **Load current tasks.** Read the workspace file `ops/tasks.md`. If it does not exist, create it from the Output Format below.
 2. **Execute the requested action:**
    - **Add:** Append task with priority, description, due date. Add timeline entry.
    - **Complete:** Mark as done, move to completed section with date.
    - **Defer:** Move to next day/week with reason.
    - **Remove:** Delete from list (rare, prefer complete or defer).
    - **Review:** Display all active tasks by priority.
-3. **Save.** `gbrain put ops/tasks` — write updated task list.
+3. **Save.** Write the updated task list back to `ops/tasks.md`.
 
 ## Output Format
 
@@ -67,4 +66,4 @@ This skill guarantees:
 - Completing tasks without recording the completion date
 - Deferring tasks without a reason
 - Letting the task list grow unbounded (review weekly)
-- Storing tasks outside the brain (they should be searchable)
+- Writing tasks through `gbrain put ops/tasks`; `ops/` is deliberately excluded from sync, and the live-context engine reads `ops/tasks.md` from disk.

--- a/skills/daily-task-prep/SKILL.md
+++ b/skills/daily-task-prep/SKILL.md
@@ -32,7 +32,7 @@ This skill guarantees:
 
 1. **Load calendar.** Check today's meetings. For each: load attendee brain pages, recent timeline, open threads.
 2. **Check yesterday's threads.** Search brain for yesterday's timeline entries. Flag anything unresolved.
-3. **Review active tasks.** Load `ops/tasks` from brain. Surface P0 and P1 items.
+3. **Review active tasks.** Read `ops/tasks.md` from the workspace file system. Surface P0 and P1 items.
 4. **Compile prep briefing.** Per-meeting context cards + open threads + task priorities.
 
 ## Output Format

--- a/src/core/context-engine.ts
+++ b/src/core/context-engine.ts
@@ -453,7 +453,13 @@ function resolveActivity(
  * every `assemble()` call. 1 MB is generous for a human-edited task list. */
 const MAX_TASKS_MD_BYTES = 1_000_000;
 
-/** Extract open tasks from ops/tasks.md "## Today" section. */
+/** Extract open tasks from ops/tasks.md Today section.
+ *
+ * The daily-task-manager skill documents priority headings such as
+ * `## P1 — Today`, while older fixtures used a bare `## Today` heading.
+ * Accept both so the live-context reader matches the documented writer
+ * contract instead of silently surfacing no tasks.
+ */
 function resolveTodayTasks(workspaceDir: string): string[] {
   try {
     const path = join(workspaceDir, 'ops', 'tasks.md');
@@ -461,15 +467,17 @@ function resolveTodayTasks(workspaceDir: string): string[] {
     // statSync throws if the file doesn't exist; that lands in the outer catch.
     if (statSync(path).size > MAX_TASKS_MD_BYTES) return [];
     const raw = readFileSync(path, 'utf8');
-    const todayMatch = raw.match(/## Today[\s\S]*?(?=\n## |$)/);
+    const todayMatch = raw.match(/^##\s+(?:P\d\s+[—-]\s+)?Today\b[\s\S]*?(?=\n##\s+|(?![\s\S]))/m);
     if (!todayMatch) return [];
 
     const lines = todayMatch[0].split('\n');
     const open: string[] = [];
     for (const line of lines) {
-      // Match unchecked task lines: - [ ] **task name** ...
-      const m = line.match(/^\s*-\s*\[ \]\s*\*\*(.+?)\*\*/);
-      if (m) open.push(sanitizeForPrompt(m[1].trim()));
+      // Match unchecked task lines from both formats:
+      // - [ ] **task name** — metadata
+      // - [ ] task name
+      const m = line.match(/^\s*-\s*\[ \]\s*(?:\*\*(.+?)\*\*|(.+?))\s*$/);
+      if (m) open.push(sanitizeForPrompt((m[1] ?? m[2]).trim()));
     }
     return open.slice(0, 5); // cap at 5 to keep prompt lean
   } catch {

--- a/test/context-engine.test.ts
+++ b/test/context-engine.test.ts
@@ -322,6 +322,26 @@ describe('gbrain-context engine', () => {
     expect(result.systemPromptAddition).not.toContain('Something later');
   });
 
+  it('injects documented P1 Today tasks from ops/tasks.md', async () => {
+    tmpDir = makeWorkspace({
+      heartbeat: { garryAwake: true },
+      tasks: `# Tasks\n\n## P0 — Urgent\n- [ ] **Escalate outage**\n\n## P1 — Today\n- [ ] Call Alice about launch plan\n- [ ] **Review Bob contract**\n- [x] Completed item\n\n## P2 — This Week\n- [ ] Should not surface`,
+    });
+    const engine = createGBrainContextEngine({ workspaceDir: tmpDir });
+
+    const result = await engine.assemble({
+      sessionId: 'test-session',
+      messages: [],
+    });
+
+    expect(result.systemPromptAddition).toContain('Open tasks');
+    expect(result.systemPromptAddition).toContain('Call Alice about launch plan');
+    expect(result.systemPromptAddition).toContain('Review Bob contract');
+    expect(result.systemPromptAddition).not.toContain('Escalate outage');
+    expect(result.systemPromptAddition).not.toContain('Completed item');
+    expect(result.systemPromptAddition).not.toContain('Should not surface');
+  });
+
   it('no activity section when calendar is empty and no tasks', async () => {
     tmpDir = makeWorkspace({
       heartbeat: { garryAwake: true },


### PR DESCRIPTION
## Summary

Fixes the task-list live-context contract described in #2186.

Changes:
- Teach `resolveTodayTasks()` to read the documented `## P1 — Today` section as well as the older `## Today` fixture shape.
- Accept both documented plain task lines (`- [ ] task`) and legacy bold task lines (`- [ ] **task**`).
- Update task-related skill docs so daily-task-manager, daily-task-prep, and briefing all use the same disk-backed `ops/tasks.md` contract instead of `gbrain get/put ops/tasks`.
- Add a regression test for the documented P1 Today format.

## Test

- `git diff --check`
- `npm exec --yes bun -- test test/context-engine.test.ts`
