### PR TITLE
[codex] Expose query type filters

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1435,6 +1435,12 @@ const query: Operation = {
     image_mime: { type: 'string', description: 'MIME type for the image bytes (auto-derived from path on CLI; required when calling op directly).' },
     limit: { type: 'number', description: 'Max results (default 20)' },
     offset: { type: 'number', description: 'Skip first N results (for pagination)' },
+    types: {
+      type: 'array',
+      description:
+        "Filter to page types, e.g. ['source','conversation'] for evidence-only temporal retrieval. " +
+        "Threads to the existing SearchOpts.types SQL filter.",
+    },
     expand: { type: 'boolean', description: 'Enable multi-query expansion (default: true)' },
     detail: { type: 'string', description: 'Result detail level: low (compiled truth only), medium (default, all with dedup), high (all chunks)' },
     mode: { type: 'string', description: 'Search mode (conservative|balanced|tokenmax). Local callers only; remote uses configured mode.' },
@@ -1536,6 +1542,9 @@ const query: Operation = {
     // hybridSearch path below, so both honor the same grant.
     const sourceIdParam = typeof p.source_id === 'string' ? p.source_id : undefined;
     const querySourceScope = resolveRequestedScope(ctx, sourceIdParam);
+    const typesParam = Array.isArray(p.types)
+      ? (p.types.filter((t): t is PageType => typeof t === 'string' && t.length > 0) as PageType[])
+      : undefined;
 
     // v0.27.1: image-similarity branch. Bypasses hybridSearch (which is
     // text-only); embeds the image via embedMultimodal and runs a direct
@@ -1553,6 +1562,7 @@ const query: Operation = {
         limit: (p.limit as number) || 20,
         offset: (p.offset as number) || 0,
         embeddingColumn: 'embedding_image',
+        types: typesParam,
         ...querySourceScope,
       });
       return results;
@@ -1585,6 +1595,7 @@ const query: Operation = {
       detail,
       language: (p.lang as string) || undefined,
       symbolKind: (p.symbol_kind as string) || undefined,
+      types: typesParam,
       nearSymbol: (p.near_symbol as string) || undefined,
       walkDepth: typeof p.walk_depth === 'number' ? (p.walk_depth as number) : undefined,
       ...querySourceScope,

--- a/test/e2e/source-isolation-pglite.test.ts
+++ b/test/e2e/source-isolation-pglite.test.ts
@@ -264,4 +264,62 @@ describe('v0.34.1 source-isolation regression (#861)', () => {
       expect(r.source_id).toBe('default');
     }
   });
+
+  test('query op exposes and threads multi-type filters for evidence-only retrieval', async () => {
+    const { operations } = await import('../../src/core/operations.ts');
+    const queryOp = operations.find(o => o.name === 'query');
+    expect(queryOp).toBeDefined();
+    expect(queryOp!.params.types?.type).toBe('array');
+
+    await engine.putPage('sources/type-filter-evidence', {
+      type: 'source',
+      title: 'Type Filter Evidence',
+      compiled_truth: 'Receiptgrade temporal substrate needle appears in raw evidence.',
+      timeline: '',
+      frontmatter: {},
+    });
+    await engine.upsertChunks('sources/type-filter-evidence', [{
+      chunk_index: 0,
+      chunk_text: 'Receiptgrade temporal substrate needle appears in raw evidence.',
+      chunk_source: 'compiled_truth',
+      token_count: 8,
+    }]);
+
+    await engine.putPage('companies/type-filter-derived', {
+      type: 'company',
+      title: 'Type Filter Derived',
+      compiled_truth: 'Receiptgrade temporal substrate needle appears in a derived page.',
+      timeline: '',
+      frontmatter: {},
+    });
+    await engine.upsertChunks('companies/type-filter-derived', [{
+      chunk_index: 0,
+      chunk_text: 'Receiptgrade temporal substrate needle appears in a derived page.',
+      chunk_source: 'compiled_truth',
+      token_count: 9,
+    }]);
+
+    const ctx = {
+      engine,
+      config: { engine: 'pglite' as const },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      dryRun: false,
+      remote: true,
+      sourceId: 'default',
+    };
+    const result = await queryOp!.handler(ctx as any, {
+      query: 'Receiptgrade temporal substrate needle',
+      types: ['source', 'conversation'],
+      expand: false,
+      recency: 'off',
+      salience: 'off',
+      limit: 10,
+    });
+    const rows = result as Array<{ slug: string; type: string }>;
+    expect(rows.some(r => r.slug === 'sources/type-filter-evidence')).toBe(true);
+    expect(rows.some(r => r.slug === 'companies/type-filter-derived')).toBe(false);
+    for (const r of rows) {
+      expect(['source', 'conversation']).toContain(r.type);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Exposes the existing `SearchOpts.types` filter on the public `query` operation so MCP/remote callers can request evidence-only or type-scoped retrieval directly.

## Root Cause

The lower search layer already supports page-type filtering, but the public `query` op schema did not accept or thread a `types` parameter. Remote agents therefore had to retrieve all page types and filter client-side, which is both noisier and less reliable for evidence-only temporal retrieval.

## Impact

Callers can now ask for queries such as `types: ["source", "conversation"]` and avoid mixing raw evidence with derived pages when they need source-grounded answers. The same filter is threaded through the text and image/vector query paths.

## Changes

- Add `types` to the public `query` operation params.
- Validate it as a string array and pass it into `hybridSearch` / vector search options.
- Add a PGLite e2e regression proving a source page is returned while a same-keyword derived company page is excluded.

## Validation

- `bun test test/e2e/source-isolation-pglite.test.ts`
