### PR TITLE
[codex] Fix search date filters to use event dates

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1548,7 +1548,7 @@ export class PGLiteEngine implements BrainEngine {
     // got reimported). Same param shape as Postgres engine.
     if (opts?.afterDate) {
       params.push(opts.afterDate);
-      extraFilter += ` AND COALESCE(p.effective_date, p.updated_at, p.created_at) > $${params.length}::timestamptz`;
+      extraFilter += ` AND COALESCE(p.effective_date, p.updated_at, p.created_at) >= $${params.length}::timestamptz`;
     }
     if (opts?.beforeDate) {
       params.push(opts.beforeDate);
@@ -1651,7 +1651,7 @@ export class PGLiteEngine implements BrainEngine {
     }
     if (opts?.afterDate) {
       params.push(opts.afterDate);
-      extraFilter += ` AND COALESCE(p.effective_date, p.updated_at, p.created_at) > $${params.length}::timestamptz`;
+      extraFilter += ` AND COALESCE(p.effective_date, p.updated_at, p.created_at) >= $${params.length}::timestamptz`;
     }
     if (opts?.beforeDate) {
       params.push(opts.beforeDate);
@@ -1777,7 +1777,7 @@ export class PGLiteEngine implements BrainEngine {
     // v0.29.1 since/until parity (codex pass-1 #10).
     if (opts?.afterDate) {
       params.push(opts.afterDate);
-      extraFilter += ` AND COALESCE(p.effective_date, p.updated_at, p.created_at) > $${params.length}::timestamptz`;
+      extraFilter += ` AND COALESCE(p.effective_date, p.updated_at, p.created_at) >= $${params.length}::timestamptz`;
     }
     if (opts?.beforeDate) {
       params.push(opts.beforeDate);
@@ -1868,7 +1868,7 @@ export class PGLiteEngine implements BrainEngine {
     // pages — preserves pagination contract.
     if (opts?.afterDate) {
       params.push(opts.afterDate);
-      extraFilter += ` AND COALESCE(p.effective_date, p.updated_at, p.created_at) > $${params.length}::timestamptz`;
+      extraFilter += ` AND COALESCE(p.effective_date, p.updated_at, p.created_at) >= $${params.length}::timestamptz`;
     }
     if (opts?.beforeDate) {
       params.push(opts.beforeDate);

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1592,16 +1592,17 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
-    // v0.27.0: date filtering support
+    // v0.29.1 — since/until date filter. Keep parity with PGLite:
+    // callers expect event-time filtering via effective_date, not refresh time.
     let afterDateClause = '';
     if (opts?.afterDate) {
       params.push(opts.afterDate);
-      afterDateClause = `AND COALESCE(p.updated_at, p.created_at) > $${params.length}::timestamptz`;
+      afterDateClause = `AND COALESCE(p.effective_date, p.updated_at, p.created_at) >= $${params.length}::timestamptz`;
     }
     let beforeDateClause = '';
     if (opts?.beforeDate) {
       params.push(opts.beforeDate);
-      beforeDateClause = `AND COALESCE(p.updated_at, p.created_at) < $${params.length}::timestamptz`;
+      beforeDateClause = `AND COALESCE(p.effective_date, p.updated_at, p.created_at) < $${params.length}::timestamptz`;
     }
     // v0.34.1 (#861 — P0 leak seal): source-isolation filter. When the
     // caller's auth scope is set, narrow the inner CTE candidate set so
@@ -1741,16 +1742,17 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
-    // v0.27.0: date filtering support
+    // v0.29.1 — since/until date filter. Keep parity with PGLite:
+    // callers expect event-time filtering via effective_date, not refresh time.
     let afterDateClause = '';
     if (opts?.afterDate) {
       params.push(opts.afterDate);
-      afterDateClause = `AND COALESCE(p.updated_at, p.created_at) > $${params.length}::timestamptz`;
+      afterDateClause = `AND COALESCE(p.effective_date, p.updated_at, p.created_at) >= $${params.length}::timestamptz`;
     }
     let beforeDateClause = '';
     if (opts?.beforeDate) {
       params.push(opts.beforeDate);
-      beforeDateClause = `AND COALESCE(p.updated_at, p.created_at) < $${params.length}::timestamptz`;
+      beforeDateClause = `AND COALESCE(p.effective_date, p.updated_at, p.created_at) < $${params.length}::timestamptz`;
     }
     // v0.34.1 (#861 — P0 leak seal): source-isolation. Anchor primitive
     // for two-pass retrieval, so cross-source anchors would let the walk
@@ -1863,16 +1865,17 @@ export class PostgresEngine implements BrainEngine {
       params.push(symbolKind);
       symbolKindClause = `AND cc.symbol_type = $${params.length}`;
     }
-    // v0.27.0: date filtering support
+    // v0.29.1 — since/until date filter. Keep parity with PGLite:
+    // callers expect event-time filtering via effective_date, not refresh time.
     let afterDateClause = '';
     if (opts?.afterDate) {
       params.push(opts.afterDate);
-      afterDateClause = `AND COALESCE(p.updated_at, p.created_at) > $${params.length}::timestamptz`;
+      afterDateClause = `AND COALESCE(p.effective_date, p.updated_at, p.created_at) >= $${params.length}::timestamptz`;
     }
     let beforeDateClause = '';
     if (opts?.beforeDate) {
       params.push(opts.beforeDate);
-      beforeDateClause = `AND COALESCE(p.updated_at, p.created_at) < $${params.length}::timestamptz`;
+      beforeDateClause = `AND COALESCE(p.effective_date, p.updated_at, p.created_at) < $${params.length}::timestamptz`;
     }
     // v0.34.1 (#861, F2 — P0 leak seal): source-isolation in the INNER CTE
     // specifically. Pushing the filter inside narrows the HNSW candidate set

--- a/src/core/search/hybrid.ts
+++ b/src/core/search/hybrid.ts
@@ -48,6 +48,15 @@ export const RRF_K = 60;
 const COMPILED_TRUTH_BOOST = 2.0;
 const pendingCacheWrites = new Set<Promise<unknown>>();
 
+function normalizeUntilExclusive(until: string | undefined): string | undefined {
+  if (!until) return undefined;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(until)) return until;
+  const d = new Date(`${until}T00:00:00.000Z`);
+  if (Number.isNaN(d.getTime())) return until;
+  d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString();
+}
+
 /**
  * v0.42 (issue #1699) agent-warning channel. Stamps `SearchResult.content_flag`
  * for any result whose page carries a `frontmatter.content_flag` marker (fuzzy
@@ -849,6 +858,11 @@ export async function hybridSearch(
   // Auto-detect detail level from query intent when caller doesn't specify
   const detail = opts?.detail ?? autoDetectDetail(query);
   const detailResolved: 'low' | 'medium' | 'high' | null = detail ?? null;
+  const sinceBound = opts?.since ?? opts?.afterDate;
+  const untilBound = opts?.until !== undefined
+    ? normalizeUntilExclusive(opts.until)
+    : opts?.beforeDate;
+
   const searchOpts: SearchOpts = {
     limit: innerLimit,
     detail,
@@ -863,8 +877,8 @@ export async function hybridSearch(
     // v0.29.1: since/until take precedence over deprecated afterDate/beforeDate.
     // The engine still consumes the legacy field names; this aliasing keeps
     // PR #618 callers compiling while the new names are the public surface.
-    afterDate: opts?.since ?? opts?.afterDate,
-    beforeDate: opts?.until ?? opts?.beforeDate,
+    afterDate: sinceBound,
+    beforeDate: untilBound,
     // v0.34.1 (#861, D9 — P0 leak seal): thread source-scoping through so the
     // inner engine.searchKeyword / engine.searchVector calls apply the
     // WHERE source_id filter at SQL level. Pre-fix, this explicit pick

--- a/test/chunk-grain-fts.test.ts
+++ b/test/chunk-grain-fts.test.ts
@@ -84,6 +84,31 @@ describe('Cathedral II Layer 3 — searchKeyword external contract', () => {
     await engine.upsertChunks('guides/unrelated', [
       { chunk_index: 0, chunk_text: 'Ship to production on a Tuesday, never a Friday.', chunk_source: 'compiled_truth' },
     ]);
+    // Regression: date filters must use effective_date, not updated_at. Both
+    // pages are inserted during the test run, so updated_at is "now"; only the
+    // event-dated page belongs in a since=2026-05-20 result set.
+    await engine.putPage('guides/refactor-old-event', {
+      type: 'guide',
+      title: 'Old event refactor',
+      compiled_truth: 'placeholder',
+      timeline: '',
+      effective_date: new Date('2026-04-01T00:00:00.000Z'),
+      effective_date_source: 'date',
+    });
+    await engine.upsertChunks('guides/refactor-old-event', [
+      { chunk_index: 0, chunk_text: 'Refactor old event should not pass a May since filter.', chunk_source: 'compiled_truth' },
+    ]);
+    await engine.putPage('guides/refactor-boundary-event', {
+      type: 'guide',
+      title: 'Boundary event refactor',
+      compiled_truth: 'placeholder',
+      timeline: '',
+      effective_date: new Date('2026-05-20T00:00:00.000Z'),
+      effective_date_source: 'date',
+    });
+    await engine.upsertChunks('guides/refactor-boundary-event', [
+      { chunk_index: 0, chunk_text: 'Refactor boundary event should pass an inclusive May since filter.', chunk_source: 'compiled_truth' },
+    ]);
   });
 
   afterAll(async () => {
@@ -117,6 +142,16 @@ describe('Cathedral II Layer 3 — searchKeyword external contract', () => {
   test('non-matching query returns empty', async () => {
     const results = await engine.searchKeyword('zzzzznomatch');
     expect(results).toEqual([]);
+  });
+
+  test('date filters use effective_date, not updated_at', async () => {
+    const results = await engine.searchKeyword('refactor', {
+      afterDate: '2026-05-20',
+      limit: 20,
+    });
+    const slugs = results.map(r => r.slug);
+    expect(slugs).toContain('guides/refactor-boundary-event');
+    expect(slugs).not.toContain('guides/refactor-old-event');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes temporal search filtering so `since` / `until` operate on page event time first, using `effective_date` before falling back to `updated_at` / `created_at`. It also makes the lower bound inclusive and normalizes plain `YYYY-MM-DD` `until` values to the next day for the existing exclusive upper-bound comparison.

## Root Cause

The Postgres search paths were filtering dates against `COALESCE(p.updated_at, p.created_at)`, so recently reimported or refreshed pages could appear in a recent-event query even when their actual `effective_date` was old. PGLite already used `effective_date`, but its lower bound was exclusive.

## Impact

Temporal queries such as "what happened since May 20" can otherwise include old pages that were merely touched recently, or miss events that fall exactly on the lower-bound date.

## Changes

- Use `COALESCE(p.effective_date, p.updated_at, p.created_at)` in Postgres search date filters.
- Make lower bounds inclusive in Postgres and PGLite.
- Normalize plain-date `until` values to the next-day timestamp before passing them to the exclusive upper-bound engine filter.
- Add a regression that inserts an old event refreshed during the test and verifies it is excluded by a May `afterDate`, while the boundary date is included.

## Validation

- `bun test test/chunk-grain-fts.test.ts`
