### PR TITLE
fix(facts): end facts:absorb sync abort race + 2 related synthesis-tier fixes

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -2119,14 +2119,28 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     } catch { /* extraction is best-effort */ }
   }
 
-  // v0.31.2: facts extraction now routes through the shared
-  // src/core/facts/backstop.ts helper (PR1 commit 6). Sync uses
-  // queue mode (fire-and-forget) + 'high-only' filter so a 50-page
-  // sync doesn't block on N sequential Sonnet calls. The pre-fix
-  // inline loop is gone — it carried (a) a dead-code type filter
-  // ('conversation'/'transcript'/'therapy'/'call' aren't real
-  // PageTypes), (b) a divergent eligibility shape from put_page,
-  // and (c) raw extract→insert without dedup/supersede.
+  // v0.31.2: facts extraction routes through the shared
+  // src/core/facts/backstop.ts helper (PR1 commit 6) with the 'high-only'
+  // notability filter (HIGH lands now, MEDIUM waits for the dream cycle,
+  // LOW dropped at the LLM layer). The pre-fix inline loop is gone — it
+  // carried (a) a dead-code type filter ('conversation'/'transcript'/
+  // 'therapy'/'call' aren't real PageTypes), (b) a divergent eligibility
+  // shape from put_page, and (c) raw extract→insert without dedup/supersede.
+  //
+  // RC2 fix (facts:absorb abort race): this runs INLINE (await the full
+  // pipeline) rather than fire-and-forget 'queue' mode. Sync was the only
+  // surface enqueuing high-only synthesis fire-and-forget, and on CLI exit
+  // `drainAllBackgroundWorkForCliExit` gives the facts queue only a short
+  // grace before `queue.shutdown()` fires `internalAbort.abort()` — which
+  // cancels the in-flight chat() mid-synthesis and lands a recurring
+  // `pipeline_error: ... The operation was aborted` in the ingest log.
+  // A single-shot synthesis call routinely outlives that grace, so the
+  // race was effectively deterministic for sync. Awaiting here completes
+  // the synthesis WITHIN the sync command (before the exit drain runs), so
+  // it can't be raced by shutdown. Cost: sync now pays synthesis latency
+  // inline, but it's bounded by the existing `pagesAffected.length <= 50`
+  // guard AND the 'high-only' filter (only notable pages reach the LLM).
+  // Per-turn chat keeps fire-and-forget 'queue' mode where latency matters.
   if (!opts.noExtract && pagesAffected.length > 0 && pagesAffected.length <= 50) {
     const { runFactsBackstop } = await import('../core/facts/backstop.ts');
     const factsSourceId = opts.sourceId ?? 'default';
@@ -2152,11 +2166,27 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
             sourceId: factsSourceId,
             sessionId: `sync:${slug}`,
             source: 'sync:import',
-            mode: 'queue',
+            mode: 'inline',
             notabilityFilter: 'high-only',
           },
         );
-      } catch { /* per-page enqueue is best-effort */ }
+      } catch (err) {
+        // Inline mode bubbles pipeline errors to the caller (queue mode
+        // absorb-logs them in its worker). Preserve the D5 failure-visibility
+        // contract by writing the same ingest_log row here so doctor +
+        // dashboard still surface per-source facts failures. Best-effort:
+        // a sync must never fail because a single page's synthesis did.
+        try {
+          const { classifyFactsAbsorbError, writeFactsAbsorbLog } = await import('../core/facts/absorb-log.ts');
+          await writeFactsAbsorbLog(
+            engine,
+            slug,
+            classifyFactsAbsorbError(err),
+            err instanceof Error ? err.message : String(err),
+            factsSourceId,
+          );
+        } catch { /* absorb-logging is itself best-effort */ }
+      }
     }
   }
 

--- a/src/core/facts/absorb-log.ts
+++ b/src/core/facts/absorb-log.ts
@@ -141,6 +141,16 @@ export function classifyFactsAbsorbError(err: unknown): FactsAbsorbReason {
   if (name === 'QueueOverflowError' || /queue.*overflow|cap.*hit/i.test(msg)) return 'queue_overflow';
   if (name === 'QueueShutdownError' || /queue.*shutdown|shutting down/i.test(msg)) return 'queue_shutdown';
 
+  // Abort race (RC2): when the facts queue shuts down on CLI exit it fires
+  // `internalAbort.abort()`, which cancels an in-flight chat() mid-synthesis.
+  // The provider surfaces this as an AbortError / "The operation was aborted"
+  // string with none of the queue-shutdown wording above, so it used to fall
+  // through to the catch-all `pipeline_error` — misattributing a benign
+  // shutdown race to a genuine synthesis failure. Bucket it as `queue_shutdown`
+  // (it IS a shutdown-driven cancellation) so doctor + dashboard categorize it
+  // correctly and don't inflate the pipeline-error rate.
+  if (name === 'AbortError' || /operation was aborted|AbortError/i.test(msg)) return 'queue_shutdown';
+
   // Embed-specific: extract.ts catches embedOne errors and stores NULL embedding.
   // If a caller surfaces it explicitly, route to embed_failure.
   if (/embed/i.test(msg) && /(fail|error)/i.test(msg)) return 'embed_failure';

--- a/src/core/model-config.ts
+++ b/src/core/model-config.ts
@@ -8,9 +8,16 @@
  *   2. New-key config (e.g. models.dream.synthesize)
  *   3. Old-key config (deprecated dream.synthesize.model, dream.patterns.model)
  *      — read with stderr deprecation warning, one-per-process
- *   4. Global default (models.default)
- *   5. Env var (process.env[envVar] or GBRAIN_MODEL)
- *   6. Hardcoded fallback (caller-supplied)
+ *   4. Tier override (models.tier.<tier>) — when a `tier` is supplied
+ *   5. Global default (models.default)
+ *   6. Env var (process.env[envVar] or GBRAIN_MODEL)
+ *   7. Tier default (TIER_DEFAULTS[tier]) — when a `tier` is supplied
+ *   8. Hardcoded fallback (caller-supplied)
+ *
+ * The tier override sits ABOVE the global default: a caller that names a
+ * tier AND has `models.tier.<tier>` configured routes to that model even
+ * when a broad `models.default` is also set. (Pre-fix the order was flipped
+ * and `models.default` swallowed every tier override.)
  *
  * Aliases (`opus`, `sonnet`, `haiku`, `gemini`, `gpt`) resolve at the end so any
  * tier can use a short name. Unknown alias passes through unchanged so users can
@@ -35,13 +42,15 @@ export interface ResolveModelOpts {
   /** Env var to consult after global default. Defaults to `GBRAIN_MODEL`. */
   envVar?: string;
   /**
-   * Tier classification (v0.31.12). Looked up after `models.default` and
-   * before the env var. Routing groups: `utility` (haiku-class, classification
-   * + expansion + verdict), `reasoning` (sonnet-class, default chat +
-   * synthesis + fact extraction), `deep` (opus-class, expensive reasoning),
-   * `subagent` (Anthropic-only multi-turn tool loop — never inherits a
-   * non-Anthropic `models.default`; falls back to TIER_DEFAULTS.subagent
-   * with a one-shot stderr warn instead).
+   * Tier classification (v0.31.12). The `models.tier.<tier>` override is
+   * looked up BEFORE `models.default` and the env var, so a tier caller's
+   * configured model wins over the broad default. Routing groups: `utility`
+   * (haiku-class, classification + expansion + verdict), `reasoning`
+   * (sonnet-class, default chat + synthesis + fact extraction), `deep`
+   * (opus-class, expensive reasoning), `subagent` (Anthropic-only multi-turn
+   * tool loop — when it falls through to a non-Anthropic `models.default`,
+   * the capability gate falls back to TIER_DEFAULTS.subagent with a one-shot
+   * stderr warn instead).
    */
   tier?: ModelTier;
   /** Hardcoded last-resort fallback. */
@@ -166,20 +175,27 @@ export async function resolveModel(
       }
     }
 
-    // 4. Global default
-    const def = await engine.getConfig('models.default');
-    if (def && def.trim()) {
-      const resolved = await resolveAlias(engine, def.trim());
-      return enforceSubagentCapable(resolved, opts.tier, 'models.default');
-    }
-
-    // 5. Tier override (v0.31.12)
+    // 4. Tier override (v0.31.12). Checked BEFORE the global default so a
+    //    `tier:'reasoning'` (or any tier) caller with an explicit
+    //    `models.tier.<tier>` config wins over a broad `models.default`.
+    //    Pre-fix this lived below `models.default`, which made a set
+    //    `models.default` swallow every tier override — a tier caller could
+    //    never route to its own configured model. The explicit-configKey
+    //    (steps 2–3) and CLI flag (step 1) still outrank the tier override,
+    //    and the subagent capability gate still runs on the resolved value.
     if (opts.tier) {
       const tierVal = await engine.getConfig(`models.tier.${opts.tier}`);
       if (tierVal && tierVal.trim()) {
         const resolved = await resolveAlias(engine, tierVal.trim());
         return enforceSubagentCapable(resolved, opts.tier, `models.tier.${opts.tier}`);
       }
+    }
+
+    // 5. Global default
+    const def = await engine.getConfig('models.default');
+    if (def && def.trim()) {
+      const resolved = await resolveAlias(engine, def.trim());
+      return enforceSubagentCapable(resolved, opts.tier, 'models.default');
     }
   }
 

--- a/test/facts-absorb-log.test.ts
+++ b/test/facts-absorb-log.test.ts
@@ -59,6 +59,25 @@ describe('classifyFactsAbsorbError — reason routing', () => {
     expect(classifyFactsAbsorbError(new Error('queue is shutting down'))).toBe('queue_shutdown');
   });
 
+  test('abort race (RC2) → queue_shutdown, not pipeline_error', () => {
+    // The facts queue's shutdown() fires internalAbort.abort() on CLI exit,
+    // cancelling an in-flight chat() mid-synthesis. Providers surface this as
+    // an AbortError / "The operation was aborted" with none of the
+    // queue-shutdown wording, so it used to fall through to pipeline_error.
+    // It's a shutdown-driven cancellation → categorize it as queue_shutdown.
+    const aborted = new Error('The operation was aborted');
+    expect(classifyFactsAbsorbError(aborted)).toBe('queue_shutdown');
+    const named = new Error('aborted');
+    named.name = 'AbortError';
+    expect(classifyFactsAbsorbError(named)).toBe('queue_shutdown');
+    // The live-log shape that motivated the fix.
+    expect(
+      classifyFactsAbsorbError(
+        new Error('[chat(openrouter:deepseek/deepseek-v4-flash)] The operation was aborted'),
+      ),
+    ).toBe('queue_shutdown');
+  });
+
   test('embed-specific failure → embed_failure', () => {
     expect(classifyFactsAbsorbError(new Error('embedOne failed: dim mismatch'))).toBe('embed_failure');
   });

--- a/test/model-config.serial.test.ts
+++ b/test/model-config.serial.test.ts
@@ -147,9 +147,25 @@ describe('resolveModel — 6-tier precedence', () => {
 });
 
 describe('resolveModel — v0.31.12 tier system', () => {
-  test('models.default beats tier override', async () => {
+  test('tier override beats models.default', async () => {
+    // Fix (model precedence): a tier caller's explicit `models.tier.<tier>`
+    // config wins over a broad `models.default`. Pre-fix the order was
+    // flipped — `models.default` was checked first and swallowed every tier
+    // override, so a `tier:'reasoning'` caller could never route to its own
+    // configured model when a default was set.
     stub.set('models.default', 'opus');
     stub.set('models.tier.reasoning', 'haiku');
+    const m = await resolveModel(stub as never, {
+      tier: 'reasoning',
+      fallback: 'sonnet',
+    });
+    expect(m).toBe(DEFAULT_ALIASES.haiku);
+  });
+
+  test('models.default still applies when no matching tier override', async () => {
+    // The tier override only wins when `models.tier.<tier>` is actually set.
+    // With no tier config, resolution falls through to `models.default`.
+    stub.set('models.default', 'opus');
     const m = await resolveModel(stub as never, {
       tier: 'reasoning',
       fallback: 'sonnet',


### PR DESCRIPTION
## Summary

Three related fixes to the `facts:absorb` synthesis tier, the largest of which (RC2) ends a shutdown-time abort race that makes `gbrain sync`'s high-only fact synthesis fail almost every time.

> **Draft / review requested.** The abort race depends on the autopilot/CLI-exit timing and is hard to exercise deterministically in a unit test, so this is opened as a draft. Unit/typecheck results are below; I'm asking a maintainer to confirm the design choice (inline-await vs. raising the drain grace) and to validate against a live sync cycle. Happy to adjust.

## Bug 1 (RC2) — `facts:absorb` abort race during sync

**Diagnosis.** `sync.ts` enqueues the high-only fact absorb fire-and-forget (`mode:'queue'`, `notabilityFilter:'high-only'`). On CLI exit, `drainAllBackgroundWorkForCliExit` (`src/core/background-work.ts`) gives the facts queue only ~1–2s (the two call sites in `src/cli.ts` pass `timeoutMs: 1000` and the default `2000`), then calls the registered `abort()` → `FactsQueue.shutdown()` (`src/core/facts/queue.ts`), which sets `shuttingDown=true` and fires `this.internalAbort.abort()`. That signal is threaded into the in-flight `chat()` call, cancelling synthesis mid-flight. A single-shot synthesis call routinely takes longer than the grace, so for sync the race is effectively deterministic.

**Evidence (live brain, v0.42.26.0).** `gbrain doctor` → `facts_extraction_health`:

```
[OK] facts_extraction_health: Facts:absorb activity in last 24h (under threshold 10): default: 4 pipeline_error.
```

The underlying ingest_log rows are the recurring shape:

```
pipeline_error: [chat(openrouter:deepseek/deepseek-v4-flash)] The operation was aborted
```

**Fix (chosen: inline-await, the minimal localized change).** Switch the sync high-only absorb from `mode:'queue'` to `mode:'inline'` so the synthesis completes *within* the sync command, before the CLI-exit drain ever runs — it can no longer be raced by `shutdown()`. Sync now pays synthesis latency inline, but that is bounded by the two guards already on this block: `pagesAffected.length <= 50` and the `high-only` notability filter (only notable pages reach the LLM). Per-turn chat keeps fire-and-forget `queue` mode where latency matters.

I preferred this over raising the facts-queue drain grace to ~30s because (a) it removes the race entirely on the affected path rather than widening a timing window that can still lose under a slow provider, (b) it's localized to the one surface that was enqueuing synthesis fire-and-forget, and (c) raising the grace would make *every* CLI command that enqueues facts (capture, import, sync) hang up to ~30s on exit. Open to the grace approach instead if maintainers prefer to keep sync's facts path non-blocking — happy to switch.

Inline mode bubbles pipeline errors to the caller (queue mode absorb-logs them in its worker), so the catch block now writes the same `ingest_log` row via `classifyFactsAbsorbError` + `writeFactsAbsorbLog`, preserving the D5 failure-visibility contract for doctor + dashboard. Best-effort — a sync never fails because one page's synthesis did.

## Bug 2 — `resolveModel` tier override precedence

`resolveModel` (`src/core/model-config.ts`) checked `models.default` *before* the tier override, so a `tier:'reasoning'` (or any tier) caller could never override a set `models.default` — the broad default swallowed every tier-specific config. Reordered so `models.tier.<tier>` is consulted before `models.default`. The CLI flag and explicit configKey / deprecated key still outrank the tier override, and the subagent capability gate (`enforceSubagentCapable`) still runs on each resolved value — including the `models.default` fallthrough — so subagent routing is unchanged. Doc comments + the tier-system test updated to the corrected precedence.

## Bug 3 — abort errors misclassified as `pipeline_error`

`classifyFactsAbsorbError` (`src/core/facts/absorb-log.ts`) bucketed AbortError / "operation was aborted" as the catch-all `pipeline_error`, conflating a benign shutdown race with a genuine synthesis failure (and inflating the pipeline-error rate doctor reads). Added a branch mapping `/operation was aborted|AbortError/i` (and the `AbortError` name) to the existing `queue_shutdown` reason — it *is* a shutdown-driven cancellation, and reusing the existing reason avoids a new reason code / doctor threshold.

Note: with Bug 1 fixed, the sync path should stop producing these aborted errors entirely; Bug 3 still correctly classifies any abort race that surfaces from other paths or timing.

## Files changed

| File | Change |
|---|---|
| `src/commands/sync.ts` | high-only sync absorb `mode:'queue'` → `mode:'inline'`; catch block writes absorb-log row to preserve failure visibility |
| `src/core/model-config.ts` | reorder `resolveModel` so tier override beats `models.default`; doc comments |
| `src/core/facts/absorb-log.ts` | `classifyFactsAbsorbError`: map abort errors → `queue_shutdown` |
| `test/model-config.serial.test.ts` | flip "models.default beats tier override" → "tier override beats models.default"; add no-tier-config fallthrough test |
| `test/facts-absorb-log.test.ts` | add abort-race classification test using the live-log error shape |

## What was tested locally

- `bun run typecheck` (tsc --noEmit) — **clean**.
- `bun test` on the affected suites — **all pass**:
  - `test/model-config.serial.test.ts` — 21 pass
  - `test/facts-absorb-log.test.ts` — 17 pass
  - `test/facts-queue.test.ts` + `test/facts-queue-drain-pending.test.ts` — 13 pass
  - `test/core/background-work.test.ts` — 6 pass
  - `test/facts-backstop*.test.ts` (3 files) — 24 pass
  - `test/sync.test.ts` + `test/sync-inline-extract-stamps.serial.test.ts` — 61 pass

## What was NOT tested locally

- **The RC2 race itself end-to-end.** It depends on the autopilot/CLI-exit drain timing and isn't deterministically reproducible in a unit test. The fix is reasoned from the code path + the live ingest-log evidence above; I have not observed a post-fix sync cycle confirming the `aborted` rows stop. Maintainer validation against a live sync is requested.
- No e2e suite run (no `DATABASE_URL` in this environment).
- One pre-existing repo lint failure (`check:trailing-newline` on `test/fixtures/e5-lease-cap-ab/2026-05-24-baseline-dry-run.json`) is unrelated to this PR and untouched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
