### PR TITLE
fix(embed): only reject as user_provided_model_unset when modelId is absent

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -709,7 +709,8 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
-    (recipe.id === 'litellm' || isUserProvided)
+    (recipe.id === 'litellm' || isUserProvided) &&
+    !parsed.modelId
   ) {
     return {
       ok: false,


### PR DESCRIPTION
Closes #2204

## Summary

Fixes `diagnoseEmbedding()` returning `user_provided_model_unset` when a valid modelId has been parsed from the config string. This makes custom embedding providers (LM Studio, llama-server, Ollama, vLLM) functional when configured through `user_provided_models`.

## Change

In `src/core/ai/gateway.ts`, adds `!parsed.modelId` to the preflight rejection condition so that a successfully parsed model name is not falsely rejected.

## Root Cause

The guard checked `models.length === 0 && isUserProvided` without checking whether `parsed.modelId` was populated. A valid config string like `llama-server:text-embedding-qwen3-0.6b` correctly parses a modelId, but the guard ignored it and rejected anyway.

## Testing

- Auto-merge was clean against v0.42.44.0 (no conflicts)
- Diff: +1 line, -1 line in a single condition
- Covers both `litellm` and generic `user_provided_models` paths

cc: @justemu