### PR TITLE
feat(ai/recipes/litellm): declare chat + expansion touchpoints (#2207)

### DIFF
--- a/src/core/ai/recipes/litellm-proxy.ts
+++ b/src/core/ai/recipes/litellm-proxy.ts
@@ -40,6 +40,21 @@ export const litellmProxy: Recipe = {
       // mismatched-dim responses pre-storage).
       supports_multimodal: true,
     },
+    expansion: {
+      models: [],
+      cost_per_1m_tokens_usd: undefined,
+      price_last_verified: '2026-06-14',
+    },
+    chat: {
+      models: [],
+      supports_tools: true,
+      supports_subagent_loop: true,
+      supports_prompt_cache: false,
+      max_context_tokens: 200_000,
+      cost_per_1m_input_usd: undefined,
+      cost_per_1m_output_usd: undefined,
+      price_last_verified: '2026-06-14',
+    },
   },
   setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL + pass --embedding-model litellm:<model> and --embedding-dimensions <N>.',
 };


### PR DESCRIPTION
Closes #2207.

## Summary

**The bug.** The litellm recipe shipped only an `embedding` touchpoint. `getProviderCapabilities()` in `src/core/ai/capabilities.ts:74-104` throws when `recipe.touchpoints.chat` is missing; `classifyCapabilities()` catches and returns `'unknown'`; `enforceSubagentCapable()` in `src/core/model-config.ts:231-281` treats `'unknown'` as fail-closed and replaces the user's choice with `TIER_DEFAULTS.subagent` (`anthropic:claude-sonnet-4-6`). On a brain that routes paid traffic through a LiteLLM-shaped proxy and has no `ANTHROPIC_API_KEY` in env, every subagent loop dispatch then throws `AIConfigError: Anthropic ... requires ANTHROPIC_API_KEY`. The stderr warn says "unrecognized provider", but the recipe IS registered: the gate is gating on missing touchpoint, not on missing recipe.

**The fix.** Declare `chat` and `expansion` touchpoints on `src/core/ai/recipes/litellm-proxy.ts`, mirroring the openai recipe's shape:

- `models: []` (litellm proxies arbitrary backends; `assertTouchpoint` already skips allowlist checks for `tier: 'openai-compat'`).
- `supports_tools: true`, `supports_subagent_loop: true`.
- `supports_prompt_cache: false` (OpenAI-compat backends don't honor Anthropic-style `cache_control`; the loop emits a one-time `degraded:no_caching` warn).
- `max_context_tokens: 200_000` (conservative GPT-5-family default).
- costs `undefined` (varies by proxied provider).

After the patch, `classifyCapabilities('litellm:gpt-5.4', recipe)` returns `degraded:no_caching` (chat-capable, no Anthropic-style prompt cache). `enforceSubagentCapable` no longer steals the model choice; the loop runs against whatever the proxy is configured to back.

**Open design questions (deliberately deferred to review):** see #2207 for three items the maintainer may want to fold in or split off: `ChatTouchpoint.user_provided_models?: true` as the explicit signal vs. relying on `tier === 'openai-compat'`; `max_context_tokens` (200K vs `undefined` so per-deployment reality wins); same patch for `llama-server` (embedding-only today) plus a reconsider of ollama's `supports_subagent_loop: false` for tool-capable local models. Happy to revise the patch in any of those directions.

**Adjacent observation (drop-in, not bundled):** the warn message at `src/core/model-config.ts:258` reads "unrecognized provider" even when the recipe IS registered; the underlying signal is `classifyCapabilities` returning `'unknown'` because the chat touchpoint is missing. A clearer message would be `provider does not declare a chat touchpoint`. Out of scope for this PR; happy to file as a follow-up.

## Tests

- `bun test test/ai/recipes-existing-regression.test.ts test/ai/gateway.test.ts test/ai/capabilities.test.ts test/ai/recipe-llama-server.test.ts test/ai/no-batch-cap-suppression.serial.test.ts test/openai-compat-multimodal.test.ts test/model-config.serial.test.ts`: 107/107 pass. The IRON RULE regression test in `recipes-existing-regression.test.ts` already iterates all openai-compatible recipes' `chat` touchpoint through `applyResolveAuth`; the litellm recipe is now exercised on the chat path.
- Functional probe (capability path): `classifyCapabilities('litellm:gpt-5.4', recipe)` returns `degraded:no_caching` post-patch; before the patch it returned `'unknown'` (same shape as the embedding-only `ollama` recipe still does today).
- `bun test test/ai/`: 346/346 pass across 32 files.
- `bun run typecheck` clean. `bun run verify` clean (30 parallel checks).
