### PR TITLE
docs(ai/recipes/litellm): document /v1 suffix in setup_hint (#2209)

### DIFF
--- a/src/core/ai/recipes/litellm-proxy.ts
+++ b/src/core/ai/recipes/litellm-proxy.ts
@@ -41,5 +41,9 @@ export const litellmProxy: Recipe = {
       supports_multimodal: true,
     },
   },
-  setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL + pass --embedding-model litellm:<model> and --embedding-dimensions <N>.',
+  setup_hint:
+    'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL + pass --embedding-model litellm:<model> and --embedding-dimensions <N>. ' +
+    'Path convention: vanilla LiteLLM serves /chat/completions at the host root (LITELLM_BASE_URL=http://host:port). ' +
+    'OpenAI-shaped proxies (codex-proxy, some Azure-OpenAI mirrors, third-party translators) serve /v1/chat/completions and require the /v1 suffix (LITELLM_BASE_URL=http://host:port/v1). ' +
+    'If chat dispatch returns 401 Unauthorized but `curl $LITELLM_BASE_URL/models` returns 200 with a valid bearer, the /v1 suffix is the missing piece.',
 };


### PR DESCRIPTION
Closes #2209.

## Summary

**The bug.** The litellm `setup_hint` says "set LITELLM_BASE_URL" with no guidance on the path prefix. Vanilla LiteLLM serves `/chat/completions` at the host root, so `LITELLM_BASE_URL=http://host:port` works. OpenAI-shaped proxies (codex-proxy, some Azure-OpenAI mirrors, third-party translators) serve only `/v1/chat/completions` and reject the bare path with 401 Unauthorized. The AI SDK surfaces the 401 as `AIConfigError: Unauthorized — Check your API key`, so the diagnostic dead-ends on the bearer rather than the URL shape. `curl $LITELLM_BASE_URL/models` returns 200 with the same bearer, which makes the 401 doubly misleading.

**The fix.** Append three sentences to `src/core/ai/recipes/litellm-proxy.ts`'s `setup_hint`: the vanilla form (root), the OpenAI-shaped form (`/v1` suffix), and the cross-check (`curl $LITELLM_BASE_URL/models` returns 200 with the bearer → `/v1` is the missing piece). One-paragraph string concatenation matches the existing setup_hint shape; `llama-server-reranker.ts` is the precedent.

**Adjacent surface (worth filing as a follow-up, not bundled here):** `gbrain models doctor` could probe `${LITELLM_BASE_URL}/chat/completions` and `${LITELLM_BASE_URL}/v1/chat/completions` with the configured bearer and surface the path-shape mismatch explicitly. Out of scope for this doc-only PR.

## Tests

- No behavior change; the only edit is the `setup_hint` string. Recipe-level tests (`test/ai/recipes-existing-regression.test.ts`, `test/ai/gateway.test.ts`): 53/53 pass.
- `bun run typecheck` clean. `bun run verify` clean (30 parallel checks).
