### PR TITLE
dream: support Codex OAuth synthesize on PGLite

### DIFF
--- a/src/core/ai/codex-oauth.ts
+++ b/src/core/ai/codex-oauth.ts
@@ -1,0 +1,376 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+
+import { AIConfigError, AITransientError } from './errors.ts';
+
+const DEFAULT_CODEX_BASE_URL = 'https://chatgpt.com/backend-api/codex';
+const CODEX_OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+const CODEX_OAUTH_TOKEN_URL = 'https://auth.openai.com/oauth/token';
+const CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120;
+
+type Env = Record<string, string | undefined>;
+
+type AuthStore = Record<string, any>;
+
+interface TokenSet {
+  access_token: string;
+  refresh_token?: string;
+  [key: string]: unknown;
+}
+
+interface TokenSource {
+  kind: 'provider' | 'pool' | 'codex-cli';
+  tokens: TokenSet;
+  storePath?: string;
+  poolIndex?: number;
+}
+
+export function resolveCodexBaseURL(env: Env): string {
+  return (env.HERMES_CODEX_BASE_URL ?? '').trim().replace(/\/$/, '') || DEFAULT_CODEX_BASE_URL;
+}
+
+function hermesAuthPath(env: Env): string {
+  const home = (env.HERMES_HOME ?? '').trim() || join(homedir(), '.hermes');
+  return join(home, 'auth.json');
+}
+
+function codexCliAuthPath(env: Env): string {
+  const home = (env.CODEX_HOME ?? '').trim() || join(homedir(), '.codex');
+  return join(home, 'auth.json');
+}
+
+function readJsonFile(path: string): AuthStore | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as AuthStore;
+  } catch {
+    return null;
+  }
+}
+
+function writeJsonFileAtomic(path: string, payload: AuthStore): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, `${JSON.stringify(payload, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  renameSync(tmp, path);
+}
+
+function asTokenSet(value: unknown): TokenSet | null {
+  if (!value || typeof value !== 'object') return null;
+  const obj = value as Record<string, unknown>;
+  const access = typeof obj.access_token === 'string' ? obj.access_token.trim() : '';
+  if (!access) return null;
+  const refresh = typeof obj.refresh_token === 'string' ? obj.refresh_token.trim() : '';
+  return refresh ? { ...obj, access_token: access, refresh_token: refresh } as TokenSet : { ...obj, access_token: access } as TokenSet;
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+  try {
+    const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+    return JSON.parse(Buffer.from(padded, 'base64').toString('utf8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function accessTokenIsExpiring(token: string, skewSeconds = CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS): boolean {
+  const payload = decodeJwtPayload(token);
+  const exp = payload?.exp;
+  if (typeof exp !== 'number') return false;
+  return exp <= Math.floor(Date.now() / 1000) + Math.max(0, skewSeconds);
+}
+
+function loadCodexTokens(env: Env): TokenSource | null {
+  const storePath = hermesAuthPath(env);
+  const store = readJsonFile(storePath);
+  if (store) {
+    const providerTokens = asTokenSet(store.providers?.['openai-codex']?.tokens);
+    if (providerTokens) return { kind: 'provider', tokens: providerTokens, storePath };
+
+    const pool = store.credential_pool?.['openai-codex'];
+    if (Array.isArray(pool)) {
+      for (let i = 0; i < pool.length; i++) {
+        const entry = pool[i];
+        if (!entry || typeof entry !== 'object') continue;
+        const resetAt = (entry as Record<string, unknown>).last_error_reset_at;
+        if (typeof resetAt === 'number' && resetAt > Date.now() / 1000) continue;
+        const tokens = asTokenSet(entry);
+        if (tokens) return { kind: 'pool', tokens, storePath, poolIndex: i };
+      }
+    }
+  }
+
+  const cliTokens = asTokenSet(readJsonFile(codexCliAuthPath(env))?.tokens);
+  if (cliTokens) return { kind: 'codex-cli', tokens: cliTokens };
+  return null;
+}
+
+function persistRefreshedTokens(env: Env, source: TokenSource, refreshed: TokenSet): void {
+  const storePath = source.storePath ?? hermesAuthPath(env);
+  const store = readJsonFile(storePath) ?? {};
+  store.providers = store.providers && typeof store.providers === 'object' ? store.providers : {};
+  store.providers['openai-codex'] = store.providers['openai-codex'] && typeof store.providers['openai-codex'] === 'object'
+    ? store.providers['openai-codex']
+    : {};
+
+  if (source.kind === 'provider' || source.kind === 'codex-cli') {
+    store.providers['openai-codex'].tokens = refreshed;
+    store.providers['openai-codex'].last_refresh = new Date().toISOString();
+    store.providers['openai-codex'].auth_mode = 'chatgpt';
+  }
+
+  if (source.kind === 'pool' && typeof source.poolIndex === 'number') {
+    store.credential_pool = store.credential_pool && typeof store.credential_pool === 'object' ? store.credential_pool : {};
+    const pool = Array.isArray(store.credential_pool['openai-codex']) ? store.credential_pool['openai-codex'] : [];
+    const entry = pool[source.poolIndex] && typeof pool[source.poolIndex] === 'object' ? pool[source.poolIndex] : {};
+    pool[source.poolIndex] = {
+      ...entry,
+      access_token: refreshed.access_token,
+      refresh_token: refreshed.refresh_token ?? entry.refresh_token,
+      last_refresh: new Date().toISOString(),
+      last_status: null,
+      last_status_at: null,
+      last_error_code: null,
+      last_error_reason: null,
+      last_error_message: null,
+      last_error_reset_at: null,
+    };
+    store.credential_pool['openai-codex'] = pool;
+  }
+
+  writeJsonFileAtomic(storePath, store);
+}
+
+async function refreshCodexTokens(tokens: TokenSet, timeoutMs: number): Promise<TokenSet> {
+  const refresh = typeof tokens.refresh_token === 'string' ? tokens.refresh_token.trim() : '';
+  if (!refresh) {
+    throw new AIConfigError(
+      'OpenAI Codex OAuth token is expired and no refresh_token is available.',
+      'Run `codex` once in a terminal, then run `hermes auth` or `hermes model` to refresh OpenAI Codex OAuth.',
+    );
+  }
+
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refresh,
+    client_id: CODEX_OAUTH_CLIENT_ID,
+  });
+  const response = await fetch(CODEX_OAUTH_TOKEN_URL, {
+    method: 'POST',
+    headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  if (response.status === 429) {
+    throw new AITransientError('OpenAI Codex OAuth token refresh is rate-limited (429); credentials may still be valid.');
+  }
+  if (!response.ok) {
+    let detail = '';
+    try {
+      const payload = await response.json() as Record<string, any>;
+      const err = payload.error;
+      detail = typeof err === 'string'
+        ? err
+        : typeof err?.message === 'string'
+          ? err.message
+          : typeof payload.error_description === 'string'
+            ? payload.error_description
+            : '';
+    } catch {
+      // Keep generic message.
+    }
+    throw new AIConfigError(
+      `OpenAI Codex OAuth token refresh failed with HTTP ${response.status}${detail ? `: ${detail}` : ''}.`,
+      'Run `codex` once in a terminal, then run `hermes auth` or `hermes model` to refresh OpenAI Codex OAuth.',
+    );
+  }
+
+  const payload = await response.json() as Record<string, unknown>;
+  const access = typeof payload.access_token === 'string' ? payload.access_token.trim() : '';
+  if (!access) {
+    throw new AIConfigError('OpenAI Codex OAuth refresh response did not include access_token.');
+  }
+  const nextRefresh = typeof payload.refresh_token === 'string' && payload.refresh_token.trim()
+    ? payload.refresh_token.trim()
+    : refresh;
+  return { ...tokens, access_token: access, refresh_token: nextRefresh };
+}
+
+export async function resolveCodexOAuthAccessToken(env: Env): Promise<string> {
+  const source = loadCodexTokens(env);
+  if (!source) {
+    throw new AIConfigError(
+      'No OpenAI Codex OAuth credentials found in Hermes or Codex CLI auth stores.',
+      'Run `codex` once in a terminal, then run `hermes auth` or `hermes model` to authenticate OpenAI Codex.',
+    );
+  }
+
+  let tokens = source.tokens;
+  if (accessTokenIsExpiring(tokens.access_token)) {
+    const timeoutRaw = Number(env.HERMES_CODEX_REFRESH_TIMEOUT_SECONDS ?? '20');
+    const timeoutMs = Math.max(5_000, Number.isFinite(timeoutRaw) ? timeoutRaw * 1000 : 20_000);
+    tokens = await refreshCodexTokens(tokens, timeoutMs);
+    try {
+      persistRefreshedTokens(env, source, tokens);
+    } catch (err) {
+      throw new AIConfigError(
+        `OpenAI Codex OAuth token refreshed but could not be persisted: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return tokens.access_token;
+}
+
+function cloneHeaders(headers: Headers): Headers {
+  const out = new Headers(headers);
+  out.delete('content-length');
+  out.set('content-type', 'application/json');
+  out.set('accept', 'text/event-stream');
+  return out;
+}
+
+function parseCodexSse(text: string): Record<string, unknown> {
+  let completed: Record<string, any> | null = null;
+  const outputByIndex = new Map<number, unknown>();
+  let lastError: Record<string, unknown> | null = null;
+
+  for (const frame of text.split(/\r?\n\r?\n/)) {
+    if (!frame.trim()) continue;
+    let event = '';
+    const dataLines: string[] = [];
+    for (const line of frame.split(/\r?\n/)) {
+      if (line.startsWith('event:')) event = line.slice('event:'.length).trim();
+      if (line.startsWith('data:')) dataLines.push(line.slice('data:'.length).trimStart());
+    }
+    if (dataLines.length === 0) continue;
+    const raw = dataLines.join('\n');
+    if (raw === '[DONE]') continue;
+    let payload: Record<string, any>;
+    try {
+      payload = JSON.parse(raw) as Record<string, any>;
+    } catch {
+      continue;
+    }
+    if (event === 'response.output_item.done' && payload.item) {
+      const idx = typeof payload.output_index === 'number' ? payload.output_index : outputByIndex.size;
+      outputByIndex.set(idx, payload.item);
+    } else if ((event === 'response.completed' || event === 'response.incomplete') && payload.response) {
+      completed = payload.response as Record<string, any>;
+    } else if (event === 'error' || payload.type === 'error') {
+      lastError = payload;
+    }
+  }
+
+  if (!completed) {
+    throw new AITransientError(`OpenAI Codex stream ended without response.completed${lastError ? `: ${JSON.stringify(lastError)}` : ''}`);
+  }
+
+  const output = [...outputByIndex.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, item]) => item);
+  if ((!Array.isArray(completed.output) || completed.output.length === 0) && output.length > 0) {
+    completed.output = output;
+  }
+  return completed;
+}
+
+function responseHeaders(upstream: Response): Headers {
+  const headers = new Headers();
+  headers.set('content-type', 'application/json');
+  const requestId = upstream.headers.get('x-request-id') ?? upstream.headers.get('openai-request-id');
+  if (requestId) headers.set('x-request-id', requestId);
+  return headers;
+}
+
+function contentToText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((part) => {
+      if (!part || typeof part !== 'object') return '';
+      const obj = part as Record<string, unknown>;
+      if (typeof obj.text === 'string') return obj.text;
+      if (typeof obj.content === 'string') return obj.content;
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+function hoistDeveloperInstructions(body: Record<string, unknown>): void {
+  if (typeof body.instructions === 'string' && body.instructions.trim()) return;
+  const input = body.input;
+  if (!Array.isArray(input)) return;
+  const instructionParts: string[] = [];
+  const kept: unknown[] = [];
+  for (const item of input) {
+    if (!item || typeof item !== 'object') {
+      kept.push(item);
+      continue;
+    }
+    const obj = item as Record<string, unknown>;
+    const role = typeof obj.role === 'string' ? obj.role : '';
+    if (role === 'developer' || role === 'system') {
+      const text = contentToText(obj.content).trim();
+      if (text) instructionParts.push(text);
+      continue;
+    }
+    kept.push(item);
+  }
+  if (instructionParts.length > 0) {
+    body.instructions = instructionParts.join('\n\n');
+    body.input = kept;
+  }
+}
+
+export function createCodexResponsesFetch(env: Env): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const original = input instanceof Request ? input : new Request(input, init);
+    const url = new URL(original.url);
+    if (!url.pathname.endsWith('/responses')) {
+      const passthroughHeaders = new Headers(original.headers);
+      passthroughHeaders.set('Authorization', `Bearer ${await resolveCodexOAuthAccessToken(env)}`);
+      return fetch(original, { headers: passthroughHeaders, signal: init?.signal ?? original.signal });
+    }
+
+    const token = await resolveCodexOAuthAccessToken(env);
+    const headers = cloneHeaders(original.headers);
+    headers.set('Authorization', `Bearer ${token}`);
+
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(await original.text()) as Record<string, unknown>;
+    } catch (err) {
+      throw new AIConfigError(`OpenAI Codex request body was not JSON: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    body.stream = true;
+    body.store = false;
+    hoistDeveloperInstructions(body);
+    // ChatGPT's Codex backend currently rejects this otherwise-standard Responses field.
+    delete body.max_output_tokens;
+
+    const upstream = await fetch(url, {
+      method: original.method || 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: init?.signal ?? original.signal,
+    });
+
+    if (!upstream.ok) return upstream;
+
+    const streamed = await upstream.text();
+    const completed = parseCodexSse(streamed);
+    return new Response(JSON.stringify(completed), {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: responseHeaders(upstream),
+    });
+  }) as typeof fetch;
+}

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2491,6 +2491,15 @@ async function resolveChatProvider(modelStr: string): Promise<{ model: any; reci
 }
 
 function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig): any {
+  if (recipe.id === 'openai-codex') {
+    const compat = applyOpenAICompatConfig(recipe, cfg);
+    return createOpenAI({
+      apiKey: 'codex-oauth',
+      baseURL: compat.baseURL,
+      ...(compat.fetch ? { fetch: compat.fetch } : {}),
+    }).responses(modelId);
+  }
+
   switch (recipe.implementation) {
     case 'native-openai': {
       const apiKey = cfg.env.OPENAI_API_KEY;
@@ -2731,6 +2740,16 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
   }, {} as Record<string, any>);
 
   const providerOptions: Record<string, any> = {};
+  if (recipe.id === 'openai-codex') {
+    // The OpenAI Responses API defaults to stored/stateful response items.
+    // GBrain's toolLoop is deliberately stateless and re-sends the full
+    // assistant tool-call + tool-result history every turn. Keeping Responses
+    // storage on can make the provider expect out-of-band tool outputs for a
+    // prior stored response and reject the next turn with "Tool results are
+    // missing...". Codex OAuth runs through Responses, so pin it to stateless
+    // calls while preserving normal OpenAI/Anthropic behavior.
+    providerOptions.openai = { store: false };
+  }
   if (useCache) {
     providerOptions.anthropic = { cacheControl: { type: 'ephemeral' } };
   }

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -7,6 +7,7 @@
 
 import type { Recipe } from '../types.ts';
 import { openai } from './openai.ts';
+import { openaiCodex } from './openai-codex.ts';
 import { google } from './google.ts';
 import { anthropic } from './anthropic.ts';
 import { ollama } from './ollama.ts';
@@ -26,6 +27,7 @@ import { llamaServerReranker } from './llama-server-reranker.ts';
 
 const ALL: Recipe[] = [
   openai,
+  openaiCodex,
   google,
   anthropic,
   ollama,

--- a/src/core/ai/recipes/openai-codex.ts
+++ b/src/core/ai/recipes/openai-codex.ts
@@ -1,0 +1,41 @@
+import type { Recipe } from '../types.ts';
+import { resolveCodexBaseURL, createCodexResponsesFetch } from '../codex-oauth.ts';
+
+export const openaiCodex: Recipe = {
+  id: 'openai-codex',
+  name: 'OpenAI Codex OAuth',
+  tier: 'native',
+  // `gateway.ts` special-cases this recipe to use createOpenAI().responses(...)
+  // with a Codex OAuth fetch wrapper. Keeping the implementation on
+  // native-openai lets the rest of the recipe registry stay provider-neutral.
+  implementation: 'native-openai',
+  auth_env: {
+    required: [],
+    optional: ['HERMES_HOME', 'CODEX_HOME', 'HERMES_CODEX_BASE_URL', 'HERMES_CODEX_REFRESH_TIMEOUT_SECONDS'],
+    setup_url: 'https://hermes-agent.nousresearch.com/docs/integrations/providers',
+  },
+  touchpoints: {
+    chat: {
+      models: ['gpt-5.5', 'gpt-5.4'],
+      supports_tools: true,
+      supports_subagent_loop: true,
+      supports_prompt_cache: false,
+      max_context_tokens: 200000,
+      price_last_verified: '2026-06-15',
+    },
+    expansion: {
+      models: ['gpt-5.5', 'gpt-5.4'],
+      price_last_verified: '2026-06-15',
+    },
+  },
+  aliases: {
+    'gpt-5.5-codex': 'gpt-5.5',
+  },
+  setup_hint: 'Authenticate Codex OAuth with Hermes (`hermes auth` / `hermes model`) or the Codex CLI (`codex`). GBrain reads ~/.hermes/auth.json and falls back to ~/.codex/auth.json.',
+  resolveOpenAICompatConfig(env) {
+    return {
+      baseURL: resolveCodexBaseURL(env),
+      fetch: createCodexResponsesFetch(env),
+    };
+  },
+};

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -404,6 +404,9 @@ export async function runPhaseSynthesize(
     }
 
     const queue = new MinionQueue(engine);
+    const childQueueName = engine.kind === 'pglite'
+      ? `dream-inline-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      : 'default';
     const childIds: number[] = [];
     /** Map child job_id → chunk metadata for D6 orchestrator-side slug rewrite. */
     const chunkInfo = new Map<number, { idx: number; hash6: string }>();
@@ -479,6 +482,7 @@ export async function runPhaseSynthesize(
           on_child_fail: 'continue',
           idempotency_key,
           timeout_ms: 30 * 60 * 1000, // 30 min per chunk
+          ...(childQueueName !== 'default' ? { queue: childQueueName } : {}),
         };
         const child = await queue.add(
           'subagent',
@@ -491,6 +495,15 @@ export async function runPhaseSynthesize(
           chunkInfo.set(child.id, { idx: i, hash6 });
         }
       }
+    }
+
+    // PGLite cannot be drained by a separate `gbrain jobs work` process: the
+    // file-backed engine is exclusive-lock single-process. For CLI/cron dream
+    // runs, spin a tiny in-process worker scoped to the private queue above so
+    // synthesize's subagent jobs actually execute instead of sitting in
+    // `waiting` until waitForCompletion times out.
+    if (engine.kind === 'pglite' && childIds.length > 0) {
+      await runPgliteSubagentsInline(engine, childIds, childQueueName);
     }
 
     // Wait for every child to reach a terminal state. Tick yieldDuringPhase
@@ -532,10 +545,12 @@ export async function runPhaseSynthesize(
     // engine.putPage so no allow-list path needed).
     const summaryDate = opts.date ?? today();
     const summarySlug = `dream-cycle-summaries/${summaryDate}`;
-    // Back-compat: writeSummaryPage takes string[] for display; map refs back to slugs.
+    // Keep report slugs as DB identity, but render source-aware disk/link slugs
+    // in the human summary so Obsidian links resolve to the files we actually write.
     const writtenSlugs = writtenRefs.map(r => r.slug);
+    const summarySlugs = writtenRefs.map(r => resolveDreamReverseWriteSlug(opts.brainDir, r.slug, r.source_id));
     if (SUMMARY_SLUG_RE.test(summarySlug)) {
-      await writeSummaryPage(engine, opts.brainDir, summarySlug, summaryDate, writtenSlugs, childOutcomes);
+      await writeSummaryPage(engine, opts.brainDir, summarySlug, summaryDate, summarySlugs, childOutcomes);
     }
 
     // Write completion timestamp ON SUCCESS only.
@@ -565,6 +580,40 @@ export async function runPhaseSynthesize(
   } catch (e) {
     return failed(makeError('InternalError', 'SYNTH_PHASE_FAIL',
       e instanceof Error ? (e.message || 'synthesize phase threw') : String(e)));
+  }
+}
+
+async function runPgliteSubagentsInline(
+  engine: BrainEngine,
+  childIds: number[],
+  queueName: string,
+): Promise<void> {
+  const { MinionWorker } = await import('../minions/worker.ts');
+  const { makeSubagentHandler } = await import('../minions/handlers/subagent.ts');
+
+  const queue = new MinionQueue(engine);
+  const worker = new MinionWorker(engine, {
+    queue: queueName,
+    concurrency: 1,
+    pollInterval: 100,
+    healthCheckInterval: 0,
+  });
+  worker.register('subagent', makeSubagentHandler({ engine }));
+
+  const workerDone = worker.start();
+  try {
+    await Promise.race([
+      Promise.all(childIds.map((jobId) => waitForCompletion(queue, jobId, {
+        timeoutMs: 35 * 60 * 1000,
+        pollMs: 250,
+      }))),
+      workerDone.then(() => {
+        throw new Error('PGLite inline subagent worker stopped before synthesize children completed');
+      }),
+    ]);
+  } finally {
+    worker.stop();
+    await workerDone.catch(() => {});
   }
 }
 
@@ -1070,6 +1119,56 @@ async function hasLegacySingleChunkCompletion(
 
 // ── Reverse-write DB rows → markdown files ───────────────────────────
 
+/**
+ * Resolve the slug used for reverse-written markdown inside `brainDir`.
+ *
+ * Dream subagents historically wrote virtual slugs prefixed with the repo
+ * source id (for example `wiki/personal/reflections/...`). In a source-aware
+ * checkout with `.gbrain-source = wiki`, `brainDir` is already the wiki root,
+ * so writing that slug literally creates `wiki/wiki/...`. Strip only this
+ * explicit active-source prefix for default-source dream rows; all other paths
+ * retain the old behavior.
+ */
+export function resolveDreamReverseWriteSlug(
+  brainDir: string,
+  slug: string,
+  sourceId: string,
+): string {
+  if (sourceId !== 'default') return slug;
+  const activeSourceId = readDotfileSourceId(brainDir);
+  if (!activeSourceId) return slug;
+  const prefix = `${activeSourceId}/`;
+  return slug.startsWith(prefix) ? slug.slice(prefix.length) : slug;
+}
+
+export function resolveDreamReverseWriteFilePath(
+  brainDir: string,
+  slug: string,
+  sourceId: string,
+): string {
+  // v0.32.8 F6: non-default sources land at brainDir/.sources/<id>/<slug>.md
+  // so same-slug-different-source pages don't collide. Default-source pages
+  // stay at brainDir/<slug>.md, except source-aware checkouts strip a matching
+  // virtual source prefix to avoid brainDir/<source>/<source>/... nesting.
+  if (sourceId !== 'default') {
+    return join(brainDir, '.sources', sourceId, `${slug}.md`);
+  }
+  return join(brainDir, `${resolveDreamReverseWriteSlug(brainDir, slug, sourceId)}.md`);
+}
+
+function readDotfileSourceId(brainDir: string): string | null {
+  const sourcePath = join(brainDir, '.gbrain-source');
+  if (!existsSync(sourcePath)) return null;
+  try {
+    const sourceId = readFileSync(sourcePath, 'utf8').trim();
+    if (!sourceId) return null;
+    validateSourceId(sourceId);
+    return sourceId;
+  } catch {
+    return null;
+  }
+}
+
 async function reverseWriteRefs(
   engine: BrainEngine,
   brainDir: string,
@@ -1084,12 +1183,7 @@ async function reverseWriteRefs(
     const tags = await engine.getTags(slug, { sourceId: source_id });
     try {
       const md = renderPageToMarkdown(page, tags);
-      // v0.32.8 F6: non-default sources land at brainDir/.sources/<id>/<slug>.md
-      // so same-slug-different-source pages don't collide. Default-source
-      // pages stay at brainDir/<slug>.md so single-source brains see no change.
-      const filePath = source_id === 'default'
-        ? join(brainDir, `${slug}.md`)
-        : join(brainDir, '.sources', source_id, `${slug}.md`);
+      const filePath = resolveDreamReverseWriteFilePath(brainDir, slug, source_id);
       mkdirSync(dirname(filePath), { recursive: true });
       writeFileSync(filePath, md, 'utf8');
       count++;

--- a/test/core/ai/codex-oauth.test.ts
+++ b/test/core/ai/codex-oauth.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { createCodexResponsesFetch } from '../../../src/core/ai/codex-oauth.ts';
+
+function jwtWithExp(exp: number): string {
+  const enc = (obj: unknown) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${enc({ alg: 'none' })}.${enc({ exp })}.sig`;
+}
+
+describe('openai-codex OAuth fetch wrapper', () => {
+  test('streams Codex responses, hoists instructions, and returns SDK-parseable JSON', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-codex-oauth-'));
+    try {
+      mkdirSync(join(dir), { recursive: true });
+      writeFileSync(join(dir, 'auth.json'), JSON.stringify({
+        credential_pool: {
+          'openai-codex': [{
+            source: 'manual:device_code',
+            access_token: jwtWithExp(Math.floor(Date.now() / 1000) + 3600),
+            refresh_token: 'refresh-token',
+          }],
+        },
+      }));
+
+      const priorFetch = globalThis.fetch;
+      let captured: any = null;
+      let authHeader = '';
+      globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        authHeader = headers.get('authorization') ?? '';
+        captured = JSON.parse(String(init?.body));
+        const sse = [
+          'event: response.output_item.done',
+          'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"msg_1","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"OK","annotations":[],"logprobs":[]}]}}',
+          '',
+          'event: response.completed',
+          'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":0,"status":"completed","model":"gpt-5.5","output":[],"usage":{"input_tokens":1,"output_tokens":1}}}',
+          '',
+        ].join('\n');
+        return new Response(sse, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+      }) as typeof fetch;
+
+      try {
+        const wrapped = createCodexResponsesFetch({ HERMES_HOME: dir });
+        const response = await wrapped('https://chatgpt.com/backend-api/codex/responses', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            model: 'gpt-5.5',
+            input: [
+              { role: 'developer', content: 'Reply exactly OK.' },
+              { role: 'user', content: [{ type: 'input_text', text: 'Say OK' }] },
+            ],
+            max_output_tokens: 10,
+          }),
+        });
+        const json = await response.json() as Record<string, any>;
+
+        const body = captured as Record<string, any>;
+        expect(authHeader.startsWith('Bearer ')).toBe(true);
+        expect(body.stream).toBe(true);
+        expect(body.store).toBe(false);
+        expect(body.instructions).toBe('Reply exactly OK.');
+        expect(body).not.toHaveProperty('max_output_tokens');
+        expect((body.input as unknown[])).toHaveLength(1);
+        expect(json.output?.[0]?.content?.[0]?.text).toBe('OK');
+      } finally {
+        globalThis.fetch = priorFetch;
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/cycle-synthesize-chunker.test.ts
+++ b/test/cycle-synthesize-chunker.test.ts
@@ -17,7 +17,15 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { splitTranscriptByBudget, rewriteChunkedSlug } from '../src/core/cycle/synthesize.ts';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  splitTranscriptByBudget,
+  rewriteChunkedSlug,
+  resolveDreamReverseWriteFilePath,
+  resolveDreamReverseWriteSlug,
+} from '../src/core/cycle/synthesize.ts';
 
 describe('splitTranscriptByBudget — single chunk path', () => {
   test('returns single-element array when content <= maxChars', () => {
@@ -172,6 +180,45 @@ describe('rewriteChunkedSlug — D6 zero-Sonnet-trust slug rewrite', () => {
 
   test('empty slug passes through', () => {
     expect(rewriteChunkedSlug('', 'abc123', 0)).toBe('');
+  });
+});
+
+describe('resolveDreamReverseWriteFilePath — source-aware wiki checkout guard', () => {
+  function withTempBrainDir(fn: (dir: string) => void): void {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-dream-reverse-'));
+    try {
+      fn(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test('strips active source prefix for default-source dream rows', () => {
+    withTempBrainDir((dir) => {
+      writeFileSync(join(dir, '.gbrain-source'), 'wiki\n', 'utf8');
+      expect(resolveDreamReverseWriteSlug(dir, 'wiki/personal/reflections/foo', 'default'))
+        .toBe('personal/reflections/foo');
+      expect(resolveDreamReverseWriteFilePath(dir, 'wiki/personal/reflections/foo', 'default'))
+        .toBe(join(dir, 'personal/reflections/foo.md'));
+    });
+  });
+
+  test('leaves default-source slugs unchanged without a matching source prefix', () => {
+    withTempBrainDir((dir) => {
+      writeFileSync(join(dir, '.gbrain-source'), 'wiki\n', 'utf8');
+      expect(resolveDreamReverseWriteSlug(dir, 'personal/reflections/foo', 'default'))
+        .toBe('personal/reflections/foo');
+      expect(resolveDreamReverseWriteFilePath(dir, 'personal/reflections/foo', 'default'))
+        .toBe(join(dir, 'personal/reflections/foo.md'));
+    });
+  });
+
+  test('preserves non-default source isolation under .sources', () => {
+    withTempBrainDir((dir) => {
+      writeFileSync(join(dir, '.gbrain-source'), 'wiki\n', 'utf8');
+      expect(resolveDreamReverseWriteFilePath(dir, 'wiki/personal/reflections/foo', 'team'))
+        .toBe(join(dir, '.sources/team/wiki/personal/reflections/foo.md'));
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- add `openai-codex` as a chat recipe backed by local Codex OAuth credentials
- run PGLite dream synthesize subagent jobs through a scoped inline worker instead of waiting for an external worker that cannot open the same PGLite file
- force Codex Responses chat calls into stateless `store:false` mode so GBrain's manual tool loop can round-trip tool results
- prevent dream reverse-writes from creating nested `wiki/wiki/...` paths when `.gbrain-source` already names the active source

## Why

This fixes the local failure mode where `gbrain dream --phase synthesize` could judge transcripts successfully but never drain subagent jobs on PGLite, and then, once drained, reverse-write dream pages under a nested `wiki/` directory for source-aware wiki repos.

Related issue: #2213

## Verification

```bash
bun test test/gateway-model-messages.test.ts test/cycle-synthesize-chunker.test.ts test/core/ai/codex-oauth.test.ts
bun run typecheck
```

Also smoke-tested locally with a controlled non-dry synthesize run using `openai-codex:gpt-5.5`; it completed one subagent and reverse-wrote two pages to `originals/...` and `personal/...`, not nested `wiki/...`.
