### PR TITLE
feat(embed): add transient embedding fallback chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to GBrain will be documented in this file.
 
+## [0.42.45.0] - 2026-06-16
+
+### Added
+- **Embedding fallback chain.** `embedding_fallback_chain` / `GBRAIN_EMBEDDING_FALLBACK_CHAIN` lets `embed()` try configured secondary embedding models on transient provider failures without masking config errors. Explicit per-call embedding-model overrides remain exact and do not use the global chain.
+- **Qwen3-Embedding via Ollama.** The Ollama recipe now lists Qwen3-Embedding models and threads flexible `dimensions` through the OpenAI-compatible path so a local fallback can match the active vector column width.
+
+### To take advantage of v0.42.45.0
+Set `GBRAIN_EMBEDDING_FALLBACK_CHAIN` to a comma-separated list such as `ollama:qwen3-embedding:4b`, ensure the fallback provider returns the same dimensions as the active column, then restart long-running gbrain daemons. See `skills/migrations/v0.42.45.0.md` for the operator runbook.
+
 ## [0.42.44.0] - 2026-06-13
 
 ### Fixed

--- a/skills/migrations/v0.42.45.0.md
+++ b/skills/migrations/v0.42.45.0.md
@@ -1,0 +1,48 @@
+# v0.42.45.0 migration — embedding fallback chain
+
+The v0.42.45.0 upgrade adds an optional transient-failure fallback chain for text embeddings.
+
+## What changed
+
+- New config/env field: `embedding_fallback_chain` / `GBRAIN_EMBEDDING_FALLBACK_CHAIN`.
+- `embed()` now tries the primary `embedding_model` first, then each fallback entry in order, **only** when the failure is an `AITransientError` (timeouts, 5xx/network, exhausted provider retries).
+- `AIConfigError` still fails fast. Bad API keys, model typos, unsupported dimensions, and dim mismatches are not masked by a fallback provider.
+- Explicit per-call `embed(..., { embeddingModel, dimensions })` calls do **not** use the global fallback chain. These calls are used by dynamic embedding columns and must remain exact.
+- Ollama's recipe now lists Qwen3-Embedding models and exposes flexible dimensions so local Qwen fallbacks can return the same width as the active vector column.
+
+## Operator setup: OpenAI primary + local Qwen fallback
+
+Use file/env configuration for schema-sizing embedding fields. Do not rely on DB-plane `gbrain config set embedding_model` for the primary model.
+
+```bash
+# primary stays wherever your file/env config already sets it, for example:
+export GBRAIN_EMBEDDING_MODEL=openai:text-embedding-3-large
+export GBRAIN_EMBEDDING_DIMENSIONS=1536
+
+# fallback chain is comma-separated provider:model entries:
+export GBRAIN_EMBEDDING_FALLBACK_CHAIN=ollama:qwen3-embedding:4b
+
+# WSL → Windows Ollama example:
+export OLLAMA_BASE_URL=http://172.19.16.1:11434/v1
+```
+
+For systemd-managed daemons, put non-secret values like `OLLAMA_BASE_URL` and `GBRAIN_EMBEDDING_FALLBACK_CHAIN` in a user-service drop-in, and keep API keys in the environment file.
+
+## Verification
+
+```bash
+gbrain doctor
+bun test test/ai/embedding-fallback.test.ts test/ai/gateway.test.ts test/ai/build-gateway-config.test.ts test/config-env.test.ts
+```
+
+Expected behavior:
+
+- The active embedding provider reports the configured primary model and DB-aligned dimensions.
+- Fallback providers are only consulted after transient failures.
+- Qwen3-Embedding via Ollama receives the configured `dimensions` parameter instead of returning its native width.
+
+## Caveats
+
+- All models in the chain must produce vectors compatible with the active column dimensions.
+- Fallback does not re-embed existing content and does not bridge between vector spaces.
+- Local fallback availability still depends on the local server being reachable from the gbrain process.

--- a/src/commands/eval-cross-modal.ts
+++ b/src/commands/eval-cross-modal.ts
@@ -271,6 +271,7 @@ function configureGatewayForCli(): boolean {
     configureGateway({
       embedding_model: undefined,
       embedding_dimensions: undefined,
+      embedding_fallback_chain: undefined,
       expansion_model: undefined,
       chat_model: undefined,
       chat_fallback_chain: undefined,
@@ -282,6 +283,7 @@ function configureGatewayForCli(): boolean {
   configureGateway({
     embedding_model: config.embedding_model,
     embedding_dimensions: config.embedding_dimensions,
+    embedding_fallback_chain: config.embedding_fallback_chain,
     expansion_model: config.expansion_model,
     chat_model: config.chat_model,
     chat_fallback_chain: config.chat_fallback_chain,

--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -57,6 +57,7 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
     embedding_model: c.embedding_model,
     embedding_dimensions: c.embedding_dimensions,
     embedding_multimodal_model: c.embedding_multimodal_model,
+    embedding_fallback_chain: c.embedding_fallback_chain,
     expansion_model: c.expansion_model,
     chat_model: c.chat_model,
     chat_fallback_chain: c.chat_fallback_chain,

--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -212,12 +212,17 @@ export function dimsProviderOptions(
         }
         return { openaiCompatible: { dimensions: dims } };
       }
-      // DashScope text-embedding-v3 (Matryoshka 64-1024) and Zhipu
-      // embedding-3 (Matryoshka 256-2048) both accept `dimensions` on the
+      // DashScope text-embedding-v3 (Matryoshka 64-1024), Zhipu
+      // embedding-3 (Matryoshka 256-2048), and Ollama-hosted Qwen3-Embedding
+      // (Matryoshka/user-defined 32-4096) accept `dimensions` on the
       // OpenAI-compat path. Without this, user-selected non-default dims are
       // silently ignored and the provider returns its default size.
       // Symmetric retrieval — inputType ignored.
-      if (modelId === 'text-embedding-v3' || modelId === 'embedding-3') {
+      if (
+        modelId === 'text-embedding-v3' ||
+        modelId === 'embedding-3' ||
+        modelId.startsWith('qwen3-embedding')
+      ) {
         return { openaiCompatible: { dimensions: dims } };
       }
       // MiniMax embo-01 takes a `type: 'db' | 'query'` field for asymmetric

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -395,6 +395,7 @@ export function configureGateway(config: AIGatewayConfig): void {
     embedding_model: config.embedding_model ?? DEFAULT_EMBEDDING_MODEL,
     embedding_dimensions: config.embedding_dimensions ?? DEFAULT_EMBEDDING_DIMENSIONS,
     embedding_multimodal_model: config.embedding_multimodal_model,
+    embedding_fallback_chain: config.embedding_fallback_chain,
     expansion_model: config.expansion_model ?? DEFAULT_EXPANSION_MODEL,
     chat_model: config.chat_model ?? DEFAULT_CHAT_MODEL,
     chat_fallback_chain: config.chat_fallback_chain,
@@ -414,6 +415,7 @@ export function configureGateway(config: AIGatewayConfig): void {
   for (const m of [
     _config.embedding_model,
     _config.embedding_multimodal_model,
+    ...(_config.embedding_fallback_chain ?? []),
     _config.expansion_model,
     _config.chat_model,
     _config.reranker_model,
@@ -473,6 +475,7 @@ export async function reconfigureGatewayWithEngine(engine: BrainEngine): Promise
   for (const m of [
     _config.embedding_model,
     _config.embedding_multimodal_model,
+    ...(_config.embedding_fallback_chain ?? []),
     _config.expansion_model,
     _config.chat_model,
     _config.reranker_model,
@@ -621,6 +624,20 @@ export function getChatModel(): string {
 
 export function getChatFallbackChain(): string[] {
   return requireConfig().chat_fallback_chain ?? [];
+}
+
+/**
+ * Get the configured embedding fallback chain. Returns [] when unset.
+ *
+ * Each entry is a "provider:modelId" string. On `AITransientError` from
+ * the primary `embedding_model`, `embed()` tries each entry in order before
+ * propagating the last error.
+ *
+ * Schema caveat: all entries must produce the same `embedding_dimensions`
+ * as the primary (the gateway does not cross-decode between sizes).
+ */
+export function getEmbeddingFallbackChain(): string[] {
+  return requireConfig().embedding_fallback_chain ?? [];
 }
 
 /**
@@ -1357,14 +1374,43 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
   if (!texts || texts.length === 0) return [];
 
   const cfg = requireConfig();
-  // v0.36 (D10): caller may override the model. Used by the dynamic-embedding-
-  // column path so hybridSearch can embed via the column's provider, not the
-  // global default. resolveEmbeddingProvider validates the override at the
-  // recipe layer — bad model strings throw AIConfigError with a clear hint.
-  const resolveTarget = opts?.embeddingModel ?? getEmbeddingModel();
-  const tracker = __budgetStore.getStore() ?? null;
-  const { model, recipe, modelId } = await resolveEmbeddingProvider(resolveTarget);
+  const primary = opts?.embeddingModel ?? getEmbeddingModel();
+  // v0.42 port: explicit per-call embeddingModel overrides are used by
+  // dynamic embedding columns and must remain exact. Do not apply the global
+  // fallback chain to those calls; a fallback vector for the wrong column is
+  // worse than a loud failure.
+  const chain = opts?.embeddingModel
+    ? [primary]
+    : [primary, ...getEmbeddingFallbackChain()].filter((m, i, arr) => !!m && arr.indexOf(m) === i);
   const truncated = texts.map(t => (t ?? '').slice(0, MAX_CHARS));
+
+  let lastTransient: AITransientError | null = null;
+  for (let i = 0; i < chain.length; i++) {
+    const modelStr = chain[i]!;
+    const isLast = i === chain.length - 1;
+    try {
+      return await embedWithModel(truncated, modelStr, cfg, opts);
+    } catch (err) {
+      if (err instanceof AITransientError && !isLast) {
+        lastTransient = err;
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  if (lastTransient) throw lastTransient;
+  throw new AIConfigError('No embedding model configured.');
+}
+
+async function embedWithModel(
+  truncated: string[],
+  modelStr: string,
+  cfg: AIGatewayConfig,
+  opts?: EmbedOpts,
+): Promise<Float32Array[]> {
+  const tracker = __budgetStore.getStore() ?? null;
+  const { model, recipe, modelId } = await resolveEmbeddingProvider(modelStr);
 
   // Reserve up front for the worst-case batch token count. Embeddings have
   // no output rate, so maxOutputTokens=0. record() at the end uses the
@@ -1381,10 +1427,10 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
       label: 'gateway.embed',
     });
   }
+
   // Dim override (D10) — when caller passes `dimensions`, use it. Otherwise
   // fall back to the global cfg default. dimsProviderOptions throws a
-  // clear AIConfigError when a Voyage flexible-dim model gets an
-  // unsupported value (the existing v0.33.1.1 fail-loud path).
+  // clear AIConfigError when a flexible-dim model gets an unsupported value.
   const effectiveDims = opts?.dimensions ?? cfg.embedding_dimensions ?? DEFAULT_EMBEDDING_DIMENSIONS;
   const providerOpts = dimsProviderOptions(
     recipe.implementation,
@@ -1399,7 +1445,8 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
   const charsPerToken = embedding?.chars_per_token ?? DEFAULT_CHARS_PER_TOKEN;
 
   // Pre-split is gated on max_batch_tokens. Recipes without it (e.g. OpenAI)
-  // ride the fast path: one embedMany call, no recursion safety net.
+  // ride the fast path: one embedMany call, no recursion safety net. Each
+  // fallback link uses its own recipe policy and shrink state.
   const batches = maxBatchTokens
     ? splitByTokenBudget(truncated, Math.floor(maxBatchTokens * effectiveSafetyFactor(recipe)), charsPerToken)
     : [truncated];
@@ -1422,9 +1469,9 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
       // chars-per-token. On failure, A3 amended says charge the pessimistic
       // estimate too — embed has no output side, so the input estimate IS
       // the worst case.
-      const charsPerToken = recipe.touchpoints?.embedding?.chars_per_token ?? DEFAULT_CHARS_PER_TOKEN;
+      const recordCharsPerToken = recipe.touchpoints?.embedding?.chars_per_token ?? DEFAULT_CHARS_PER_TOKEN;
       const totalChars = truncated.reduce((s, t) => s + t.length, 0);
-      const inputTokens = Math.ceil(totalChars / Math.max(charsPerToken, 1));
+      const inputTokens = Math.ceil(totalChars / Math.max(recordCharsPerToken, 1));
       try {
         tracker.record({
           modelId: `${recipe.id}:${modelId}`,

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -13,10 +13,11 @@ export const ollama: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['nomic-embed-text', 'mxbai-embed-large', 'all-minilm'],
-      default_dims: 768, // nomic-embed-text native dim
+      models: ['qwen3-embedding:4b', 'qwen3-embedding', 'qwen3-embedding:0.6b', 'qwen3-embedding:8b', 'nomic-embed-text', 'mxbai-embed-large', 'all-minilm'],
+      default_dims: 1536, // Qwen3-Embedding supports user-defined 32-4096 dims; keep existing OpenAI-sized brains compatible.
+      dims_options: [768, 1024, 1536, 2048, 2560, 4096],
       cost_per_1m_tokens_usd: 0,
-      price_last_verified: '2026-04-20',
+      price_last_verified: '2026-06-15',
       // Ollama's batch capacity depends on the locally loaded model + the
       // OLLAMA_NUM_PARALLEL config; no static cap to declare. v0.32 (#779).
       no_batch_cap: true,

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -347,6 +347,12 @@ export interface AIGatewayConfig {
    * Allows brains using OpenAI for text to use Voyage for image embeddings.
    */
   embedding_multimodal_model?: string;
+  /**
+   * Optional transient-failure fallback chain for `embed()`.
+   * Each entry is a "provider:modelId" string. See
+   * `GBrainConfig.embedding_fallback_chain` for semantics.
+   */
+  embedding_fallback_chain?: string[];
   /** Current expansion model as "provider:modelId". */
   expansion_model?: string;
   /** Default chat model for `gateway.chat()` callers (subagent default). */

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -45,6 +45,16 @@ export interface GBrainConfig {
   embedding_model?: string;
   embedding_dimensions?: number;
   /**
+   * Optional transient-failure fallback chain for `embed()`.
+   * Each entry is a "provider:modelId" string. On `AITransientError` from
+   * the primary embedding model, the gateway tries each entry in order
+   * before giving up.
+   *
+   * Schema caveat: all entries must produce the same `embedding_dimensions`
+   * as the primary (the gateway does not cross-decode between sizes).
+   */
+  embedding_fallback_chain?: string[];
+  /**
    * v0.37 (D9): user opted into deferred-setup mode at init time via
    * `gbrain init --no-embedding`. When true, embed callsites and `gbrain
    * import` refuse with a `gbrain config set embedding_model <id>` hint
@@ -521,6 +531,9 @@ export function loadConfig(): GBrainConfig | null {
     ...(process.env.ZEROENTROPY_API_KEY ? { zeroentropy_api_key: process.env.ZEROENTROPY_API_KEY } : {}),
     ...(process.env.GBRAIN_EMBEDDING_MODEL ? { embedding_model: process.env.GBRAIN_EMBEDDING_MODEL } : {}),
     ...(process.env.GBRAIN_EMBEDDING_DIMENSIONS ? { embedding_dimensions: parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS, 10) } : {}),
+    ...(process.env.GBRAIN_EMBEDDING_FALLBACK_CHAIN
+      ? { embedding_fallback_chain: process.env.GBRAIN_EMBEDDING_FALLBACK_CHAIN.split(',').map(s => s.trim()).filter(Boolean) }
+      : {}),
     ...(process.env.GBRAIN_EXPANSION_MODEL ? { expansion_model: process.env.GBRAIN_EXPANSION_MODEL } : {}),
     ...(process.env.GBRAIN_CHAT_MODEL ? { chat_model: process.env.GBRAIN_CHAT_MODEL } : {}),
     ...(process.env.GBRAIN_CHAT_FALLBACK_CHAIN

--- a/test/ai/build-gateway-config.test.ts
+++ b/test/ai/build-gateway-config.test.ts
@@ -84,4 +84,13 @@ describe('buildGatewayConfig env-baseURL passthrough', () => {
       },
     );
   });
+
+  test('threads embedding_fallback_chain into AIGatewayConfig', async () => {
+    await withEnv(envFor(null), async () => {
+      const cfg = buildGatewayConfig({
+        embedding_fallback_chain: ['ollama:qwen3-embedding:4b'],
+      } as unknown as GBrainConfig);
+      expect(cfg.embedding_fallback_chain).toEqual(['ollama:qwen3-embedding:4b']);
+    });
+  });
 });

--- a/test/ai/embedding-fallback.test.ts
+++ b/test/ai/embedding-fallback.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  __setEmbedTransportForTests,
+  configureGateway,
+  embed,
+  getEmbeddingFallbackChain,
+  resetGateway,
+} from '../../src/core/ai/gateway.ts';
+import { AIConfigError, AITransientError } from '../../src/core/ai/errors.ts';
+
+function fakeEmbeddings(values: string[], dims = 1536): { embeddings: number[][] } {
+  return {
+    embeddings: values.map(() => Array.from({ length: dims }, () => 0.1)),
+  };
+}
+
+function configureWithFallback(fallback = ['ollama:qwen3-embedding:4b']): void {
+  configureGateway({
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    embedding_fallback_chain: fallback,
+    env: { OPENAI_API_KEY: 'sk-fake' },
+    base_urls: { ollama: 'http://127.0.0.1:11434/v1' },
+  });
+}
+
+describe('embedding fallback chain', () => {
+  beforeEach(() => resetGateway());
+  afterEach(() => __setEmbedTransportForTests(null));
+
+  test('getEmbeddingFallbackChain returns [] when unset', () => {
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-large',
+      embedding_dimensions: 1536,
+      env: { OPENAI_API_KEY: 'sk-fake' },
+    });
+
+    expect(getEmbeddingFallbackChain()).toEqual([]);
+  });
+
+  test('getEmbeddingFallbackChain returns configured chain', () => {
+    configureWithFallback(['ollama:qwen3-embedding:4b', 'voyage:voyage-3-large']);
+
+    expect(getEmbeddingFallbackChain()).toEqual([
+      'ollama:qwen3-embedding:4b',
+      'voyage:voyage-3-large',
+    ]);
+  });
+
+  test('transient primary failure falls through to fallback', async () => {
+    configureWithFallback();
+    const stub = mock(async ({ values }: { values: string[] }) => {
+      if (stub.mock.calls.length === 1) {
+        throw new Error('temporary upstream outage');
+      }
+      return fakeEmbeddings(values);
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    const vectors = await embed(['fallback probe']);
+
+    expect(vectors).toHaveLength(1);
+    expect(vectors[0]).toHaveLength(1536);
+    expect(stub.mock.calls.length).toBe(2);
+  });
+
+  test('all transient chain links throw the last transient error', async () => {
+    configureWithFallback();
+    const stub = mock(async () => {
+      throw new Error(`temporary outage ${stub.mock.calls.length}`);
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    await expect(embed(['fallback probe'])).rejects.toBeInstanceOf(AITransientError);
+    expect(stub.mock.calls.length).toBe(2);
+  });
+
+  test('AIConfigError fails fast and does not consult fallback', async () => {
+    configureWithFallback();
+    const stub = mock(async () => {
+      throw new AIConfigError('bad model id', 'fix the model');
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    await expect(embed(['fallback probe'])).rejects.toBeInstanceOf(AIConfigError);
+    expect(stub.mock.calls.length).toBe(1);
+  });
+
+  test('explicit embeddingModel override does not use global fallback chain', async () => {
+    configureWithFallback();
+    const stub = mock(async () => {
+      throw new Error('primary override outage');
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    await expect(embed(['column probe'], {
+      embeddingModel: 'openai:text-embedding-3-large',
+      dimensions: 1536,
+    })).rejects.toBeInstanceOf(AITransientError);
+    expect(stub.mock.calls.length).toBe(1);
+  });
+
+  test('primary listed in fallback chain is de-duped', async () => {
+    configureWithFallback([
+      'openai:text-embedding-3-large',
+      'ollama:qwen3-embedding:4b',
+    ]);
+    const stub = mock(async ({ values }: { values: string[] }) => {
+      if (stub.mock.calls.length === 1) {
+        throw new Error('temporary upstream outage');
+      }
+      return fakeEmbeddings(values);
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    const vectors = await embed(['dedupe probe']);
+
+    expect(vectors).toHaveLength(1);
+    expect(stub.mock.calls.length).toBe(2);
+  });
+});

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -173,6 +173,11 @@ describe('dims.dimsProviderOptions', () => {
     expect(opts).toBeUndefined();
   });
 
+  test('Qwen3 Ollama openai-compatible returns dimensions param', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'qwen3-embedding:4b', 1536);
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1536 } });
+  });
+
   test('Voyage flexible-dim models return dimensions for the SDK shim', () => {
     const opts = dimsProviderOptions('openai-compatible', 'voyage-3-large', 1024);
     expect(opts).toEqual({ openaiCompatible: { dimensions: 1024 } });

--- a/test/config-env.test.ts
+++ b/test/config-env.test.ts
@@ -128,4 +128,27 @@ describe('loadConfig env database URL precedence', () => {
       rmSync(home, { recursive: true, force: true });
     }
   });
+
+  test('GBRAIN_EMBEDDING_FALLBACK_CHAIN parses comma-separated model ids', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-config-env-'));
+    try {
+      await withEnv(
+        {
+          GBRAIN_HOME: home,
+          GBRAIN_DATABASE_URL: undefined,
+          DATABASE_URL: 'postgres://only:***@gbrain.test:5432/db',
+          GBRAIN_EMBEDDING_FALLBACK_CHAIN: ' ollama:qwen3-embedding:4b, voyage:voyage-3-large ',
+        },
+        () => {
+          const cfg = loadConfig();
+          expect(cfg?.embedding_fallback_chain).toEqual([
+            'ollama:qwen3-embedding:4b',
+            'voyage:voyage-3-large',
+          ]);
+        },
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
Adds embedding_fallback_chain / GBRAIN_EMBEDDING_FALLBACK_CHAIN on current master, preserves explicit per-call embeddingModel overrides, and ports Qwen3-Embedding Ollama dimensions support.

Tests: bun test test/ai/ test/config-env.test.ts; bun run build; bun run check:no-double-retry.