### PR TITLE
fix(provider): honor provider_base_urls for native OpenAI and providers test

### DIFF
--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -180,16 +180,29 @@ async function runTest(args: string[]): Promise<void> {
       }
     } catch { /* loadConfig throws when no brain configured — first-time install path; the no-config branch above handles it. */ }
 
+    const cfg = loadConfig();
     if (tpArg === 'embedding') {
-      const dims = recipe?.touchpoints.embedding?.default_dims ?? 1536;
+      const dims =
+        cfg?.embedding_dimensions ??
+        recipe?.touchpoints.embedding?.default_dims ??
+        1536;
       configureGateway({
         embedding_model: modelArg,
         embedding_dimensions: dims,
+        expansion_model: cfg?.expansion_model,
+        chat_model: cfg?.chat_model,
+        chat_fallback_chain: cfg?.chat_fallback_chain,
+        base_urls: cfg?.provider_base_urls,
         env: { ...process.env },
       });
     } else {
       configureGateway({
         chat_model: modelArg,
+        embedding_model: cfg?.embedding_model,
+        embedding_dimensions: cfg?.embedding_dimensions,
+        expansion_model: cfg?.expansion_model,
+        chat_fallback_chain: cfg?.chat_fallback_chain,
+        base_urls: cfg?.provider_base_urls,
         env: { ...process.env },
       });
     }

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -389,6 +389,19 @@ export function applyOpenAICompatConfig(
   return { baseURL };
 }
 
+/** Native OpenAI SDK client; honors `cfg.base_urls.openai` (custom compatible-mode proxy). */
+function createNativeOpenAIClient(cfg: AIGatewayConfig) {
+  const apiKey = cfg.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new AIConfigError(
+      `OpenAI requires OPENAI_API_KEY.`,
+      'Get an API key at https://platform.openai.com/api-keys, then `export OPENAI_API_KEY=...`',
+    );
+  }
+  const baseURL = cfg.base_urls?.openai;
+  return createOpenAI(baseURL ? { apiKey, baseURL } : { apiKey });
+}
+
 /** Configure the gateway. Called by cli.ts#connectEngine. Clears cached models. */
 export function configureGateway(config: AIGatewayConfig): void {
   _config = {
@@ -1200,7 +1213,7 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
         `OpenAI embedding requires OPENAI_API_KEY.`,
         recipe.setup_hint,
       );
-      const client = createOpenAI({ apiKey });
+      const client = createNativeOpenAIClient(cfg);
       // AI SDK v6: use .textEmbeddingModel() for embeddings
       return (client as any).textEmbeddingModel
         ? (client as any).textEmbeddingModel(modelId)
@@ -2123,7 +2136,7 @@ function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayCon
     case 'native-openai': {
       const apiKey = cfg.env.OPENAI_API_KEY;
       if (!apiKey) throw new AIConfigError(`OpenAI expansion requires OPENAI_API_KEY.`, recipe.setup_hint);
-      return createOpenAI({ apiKey }).languageModel(modelId);
+      return createNativeOpenAIClient(cfg).languageModel(modelId);
     }
     case 'native-google': {
       const apiKey = cfg.env.GOOGLE_GENERATIVE_AI_API_KEY;
@@ -2495,7 +2508,7 @@ function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig):
     case 'native-openai': {
       const apiKey = cfg.env.OPENAI_API_KEY;
       if (!apiKey) throw new AIConfigError(`OpenAI chat requires OPENAI_API_KEY.`, recipe.setup_hint);
-      return createOpenAI({ apiKey }).languageModel(modelId);
+      return createNativeOpenAIClient(cfg).languageModel(modelId);
     }
     case 'native-google': {
       const apiKey = cfg.env.GOOGLE_GENERATIVE_AI_API_KEY;


### PR DESCRIPTION
## Summary

- **Native OpenAI gateway path** (`chat`, `expansion`, `embed`) now passes `provider_base_urls.openai` into the AI SDK client, so custom compatible-mode proxies (e.g. third-party OpenAI gateways) work instead of always calling `api.openai.com`.
- **`gbrain providers test --model`** now keeps file-plane `provider_base_urls` and `embedding_dimensions` from `~/.gbrain/config.json` when overriding the model, so isolated probes hit the same endpoint as the configured brain.

## Problem

Users configuring:

```json
"provider_base_urls": { "openai": "https://example.com/v1" },
"chat_model": "openai:gpt-5.4"
```

saw chat/expansion fail with OpenAI official API key errors because `createOpenAI({ apiKey })` ignored the custom base URL. DashScope embedding worked (openai-compatible recipe) but OpenAI chat did not (native-openai recipe).

Separately, `gbrain providers test --model dashscope:...` reconfigured the gateway without `base_urls`, silently falling back to recipe defaults (e.g. dashscope-intl).

## Test plan

- [x] `bun run typecheck`
- [x] `bun test test/providers.test.ts test/ai/build-gateway-config.test.ts`
- [x] Manual: set `provider_base_urls.openai` to a compatible proxy, run `gbrain providers test --touchpoint chat`
- [x] Manual: set custom `provider_base_urls.dashscope`, run `gbrain providers test --model dashscope:text-embedding-v4`


Made with [Cursor](https://cursor.com)