### PR TITLE
fix(cycle): add autopilot budget seatbelts

### DIFF
--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -331,6 +331,33 @@ export interface PhaseResult {
   error?: PhaseError;
 }
 
+const PAID_CALIBRATION_PHASES = ['propose_takes', 'grade_takes', 'calibration_profile'] as const;
+type PaidCalibrationPhase = typeof PAID_CALIBRATION_PHASES[number];
+
+function isTruthyConfig(raw: string | null | undefined): boolean {
+  if (raw == null) return false;
+  const v = raw.trim().toLowerCase();
+  return !['false', '0', 'no', 'off', ''].includes(v);
+}
+
+async function isPaidCalibrationPhaseEnabled(engine: BrainEngine, phase: PaidCalibrationPhase): Promise<boolean> {
+  const raw = await engine.getConfig(`cycle.${phase}.enabled`).catch(() => null);
+  return isTruthyConfig(raw);
+}
+
+function disabledPaidCalibrationPhaseResult(phase: PaidCalibrationPhase): PhaseResult {
+  return {
+    phase,
+    status: 'skipped',
+    duration_ms: 0,
+    summary: `cycle.${phase}.enabled=false (default OFF)`,
+    details: {
+      reason: 'disabled',
+      enable_hint: `gbrain config set cycle.${phase}.enabled true`,
+    },
+  };
+}
+
 export type CycleStatus = 'ok' | 'clean' | 'partial' | 'skipped' | 'failed';
 
 export interface CycleReport {
@@ -2027,34 +2054,46 @@ export async function runCycle(
 
         if (phases.includes('propose_takes')) {
           checkAborted(opts.signal);
-          progress.start('cycle.propose_takes');
-          const { runPhaseProposeTakes } = await import('./cycle/propose-takes.ts');
-          const { result, duration_ms } = await timePhase(() => runPhaseProposeTakes(calibrationCtx, { repoPath: brainDir ?? undefined }) as Promise<PhaseResult>);
-          result.duration_ms = duration_ms;
-          phaseResults.push(result);
-          progress.finish();
+          if (!(await isPaidCalibrationPhaseEnabled(engine, 'propose_takes'))) {
+            phaseResults.push(disabledPaidCalibrationPhaseResult('propose_takes'));
+          } else {
+            progress.start('cycle.propose_takes');
+            const { runPhaseProposeTakes } = await import('./cycle/propose-takes.ts');
+            const { result, duration_ms } = await timePhase(() => runPhaseProposeTakes(calibrationCtx, { repoPath: brainDir ?? undefined }) as Promise<PhaseResult>);
+            result.duration_ms = duration_ms;
+            phaseResults.push(result);
+            progress.finish();
+          }
           await safeYield(opts.yieldBetweenPhases);
         }
 
         if (phases.includes('grade_takes')) {
           checkAborted(opts.signal);
-          progress.start('cycle.grade_takes');
-          const { runPhaseGradeTakes } = await import('./cycle/grade-takes.ts');
-          const { result, duration_ms } = await timePhase(() => runPhaseGradeTakes(calibrationCtx, {}) as Promise<PhaseResult>);
-          result.duration_ms = duration_ms;
-          phaseResults.push(result);
-          progress.finish();
+          if (!(await isPaidCalibrationPhaseEnabled(engine, 'grade_takes'))) {
+            phaseResults.push(disabledPaidCalibrationPhaseResult('grade_takes'));
+          } else {
+            progress.start('cycle.grade_takes');
+            const { runPhaseGradeTakes } = await import('./cycle/grade-takes.ts');
+            const { result, duration_ms } = await timePhase(() => runPhaseGradeTakes(calibrationCtx, {}) as Promise<PhaseResult>);
+            result.duration_ms = duration_ms;
+            phaseResults.push(result);
+            progress.finish();
+          }
           await safeYield(opts.yieldBetweenPhases);
         }
 
         if (phases.includes('calibration_profile')) {
           checkAborted(opts.signal);
-          progress.start('cycle.calibration_profile');
-          const { runPhaseCalibrationProfile } = await import('./cycle/calibration-profile.ts');
-          const { result, duration_ms } = await timePhase(() => runPhaseCalibrationProfile(calibrationCtx, {}) as Promise<PhaseResult>);
-          result.duration_ms = duration_ms;
-          phaseResults.push(result);
-          progress.finish();
+          if (!(await isPaidCalibrationPhaseEnabled(engine, 'calibration_profile'))) {
+            phaseResults.push(disabledPaidCalibrationPhaseResult('calibration_profile'));
+          } else {
+            progress.start('cycle.calibration_profile');
+            const { runPhaseCalibrationProfile } = await import('./cycle/calibration-profile.ts');
+            const { result, duration_ms } = await timePhase(() => runPhaseCalibrationProfile(calibrationCtx, {}) as Promise<PhaseResult>);
+            result.duration_ms = duration_ms;
+            phaseResults.push(result);
+            progress.finish();
+          }
           await safeYield(opts.yieldBetweenPhases);
         }
       } else {

--- a/src/core/cycle/base-phase.ts
+++ b/src/core/cycle/base-phase.ts
@@ -137,17 +137,38 @@ export abstract class BaseCyclePhase {
 
   /**
    * Resolve the budget cap from config (or default). Override is the explicit
-   * value passed via opts.budgetUsd. Otherwise: config[budgetUsdKey] → default.
+   * value passed via opts.budgetUsd. Otherwise: engine.getConfig(budgetUsdKey)
+   * (DB/config-plane overlay) → ctx.config legacy/file snapshot → default.
    */
-  private resolveBudgetUsd(ctx: OperationContext, opts: BasePhaseOpts): number {
+  private async resolveBudgetUsd(ctx: OperationContext, opts: BasePhaseOpts): Promise<number> {
     if (typeof opts.budgetUsd === 'number') return opts.budgetUsd;
-    const raw = (ctx.config as unknown as Record<string, unknown>)[this.budgetUsdKey];
-    if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) return raw;
-    if (typeof raw === 'string') {
+    const parse = (raw: unknown): number | null => {
+      if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+      if (typeof raw !== 'string') return null;
       const parsed = Number.parseFloat(raw);
-      if (Number.isFinite(parsed) && parsed >= 0) return parsed;
-    }
+      return Number.isFinite(parsed) ? parsed : null;
+    };
+    const dbRaw = ctx.engine.getConfig
+      ? await ctx.engine.getConfig(this.budgetUsdKey).catch(() => null)
+      : null;
+    const dbParsed = parse(dbRaw);
+    if (dbParsed !== null) return dbParsed;
+    const fileRaw = (ctx.config as unknown as Record<string, unknown>)[this.budgetUsdKey];
+    const fileParsed = parse(fileRaw);
+    if (fileParsed !== null) return fileParsed;
     return this.budgetUsdDefault;
+  }
+
+  private async resolveEnabled(ctx: OperationContext): Promise<boolean> {
+    const key = `cycle.${this.name}.enabled`;
+    const raw = ctx.engine.getConfig
+      ? await ctx.engine.getConfig(key).catch(() => null)
+      : null;
+    const v = raw?.trim().toLowerCase();
+    if (v == null || ['false', '0', 'no', 'off', ''].includes(v)) {
+      return false;
+    }
+    return true;
   }
 
   /**
@@ -161,9 +182,25 @@ export abstract class BaseCyclePhase {
     // to thread this would have been the v0.34.1 leak class. Now structural.
     const scope = sourceScopeOpts(ctx);
 
+    if (['propose_takes', 'grade_takes', 'calibration_profile'].includes(this.name)) {
+      const enabled = await this.resolveEnabled(ctx);
+      if (!enabled) {
+        return {
+          phase: this.name,
+          status: 'skipped',
+          duration_ms: Date.now() - t0,
+          summary: `cycle.${this.name}.enabled=false (default OFF)`,
+          details: {
+            reason: 'disabled',
+            enable_hint: `gbrain config set cycle.${this.name}.enabled true`,
+          },
+        };
+      }
+    }
+
     // Budget meter construction. The default path reads config; tests inject.
     if (!opts.meter) {
-      const budgetUsd = this.resolveBudgetUsd(ctx, opts);
+      const budgetUsd = await this.resolveBudgetUsd(ctx, opts);
       this.meter = new BudgetMeter({ budgetUsd, phase: this.name });
     } else {
       this.meter = opts.meter;

--- a/src/core/cycle/budget-meter.ts
+++ b/src/core/cycle/budget-meter.ts
@@ -26,7 +26,7 @@ import { isoWeekFilename, resolveAuditDir } from '../audit-week-file.ts';
 import { estimateMaxCostUsd, ANTHROPIC_PRICING } from '../anthropic-pricing.ts';
 
 export interface BudgetMeterOpts {
-  /** USD cap for the whole cycle. 0 or negative disables the gate. */
+  /** USD cap for the whole cycle. 0 hard-skips; negative is explicit unlimited. */
   budgetUsd: number;
   /** Phase label for telemetry: 'auto_think' | 'drift'. */
   phase: string;
@@ -87,6 +87,27 @@ export class BudgetMeter {
    * Caller is responsible for skipping the actual LLM call when allowed=false.
    */
   check(estimate: SubmitEstimate): BudgetCheckResult {
+    if (this.opts.budgetUsd === 0) {
+      writeLedgerLine(this.auditPath, {
+        schema_version: 1,
+        phase: this.opts.phase,
+        ts: new Date().toISOString(),
+        event: 'submit_denied',
+        model: estimate.modelId,
+        label: estimate.label,
+        estimated_cost_usd: 0,
+        cumulative_cost_usd: this.cumulativeUsd,
+        budget_usd: this.opts.budgetUsd,
+      });
+      return {
+        allowed: false,
+        estimatedCostUsd: 0,
+        cumulativeCostUsd: this.cumulativeUsd,
+        budgetUsd: this.opts.budgetUsd,
+        reason: 'BUDGET_EXHAUSTED: budget cap is $0.00; submit skipped',
+      };
+    }
+
     const cost = estimateMaxCostUsd(estimate.modelId, estimate.estimatedInputTokens, estimate.maxOutputTokens);
 
     // Codex P1 #10: non-Anthropic / unpriced models bypass the gate.
@@ -118,8 +139,8 @@ export class BudgetMeter {
       };
     }
 
-    // Budget disabled (<= 0)
-    if (this.opts.budgetUsd <= 0) {
+    // Explicit unlimited sentinel: negative budget disables the cap.
+    if (this.opts.budgetUsd < 0) {
       this.cumulativeUsd += cost;
       writeLedgerLine(this.auditPath, {
         schema_version: 1,

--- a/src/core/cycle/propose-takes.ts
+++ b/src/core/cycle/propose-takes.ts
@@ -145,6 +145,8 @@ export interface ProposeTakesOpts extends BasePhaseOpts {
   model?: string;
   /** Skip pages that already have a complete takes fence. Default: true. */
   skipPagesWithFence?: boolean;
+  /** Abort after this many consecutive empty/failed extractor results. Default: config or 3. */
+  maxConsecutiveEmptyOrFailed?: number;
 }
 
 export interface ProposeTakesResult {
@@ -153,7 +155,14 @@ export interface ProposeTakesResult {
   cache_misses: number;
   proposals_inserted: number;
   budget_exhausted: boolean;
+  aborted: boolean;
+  abort_reason?: string;
   warnings: string[];
+}
+
+function parsePositiveInt(raw: unknown, fallback: number): number {
+  const n = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
 }
 
 /**
@@ -300,13 +309,18 @@ class ProposeTakesPhase extends BaseCyclePhase {
   protected async process(
     engine: BrainEngine,
     scope: ScopedReadOpts,
-    _ctx: OperationContext,
+    ctx: OperationContext,
     opts: ProposeTakesOpts,
   ): Promise<{ summary: string; details: Record<string, unknown>; status?: PhaseStatus }> {
     const extractor = opts.extractor ?? defaultExtractor;
     const promptVersion = opts.promptVersion ?? PROPOSE_TAKES_PROMPT_VERSION;
     const pageLimit = opts.pageLimit ?? 100;
     const skipPagesWithFence = opts.skipPagesWithFence ?? false;
+    const rawConsecutiveLimit = ctx.engine.getConfig
+      ? await ctx.engine.getConfig('cycle.propose_takes.max_consecutive_empty_or_failed').catch(() => null)
+      : null;
+    const maxConsecutiveEmptyOrFailed = opts.maxConsecutiveEmptyOrFailed
+      ?? parsePositiveInt(rawConsecutiveLimit, 3);
     const proposalRunId = `propose-${new Date().toISOString().slice(0, 19).replace(/[-:T]/g, '')}-${randomUUID().slice(0, 8)}`;
 
     const result: ProposeTakesResult = {
@@ -315,8 +329,10 @@ class ProposeTakesPhase extends BaseCyclePhase {
       cache_misses: 0,
       proposals_inserted: 0,
       budget_exhausted: false,
+      aborted: false,
       warnings: [],
     };
+    let consecutiveEmptyOrFailed = 0;
 
     // Load pages eligible for proposal. Source-scoped per BaseCyclePhase.
     const pageFilters: PageFilters = {
@@ -383,8 +399,31 @@ class ProposeTakesPhase extends BaseCyclePhase {
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         result.warnings.push(`extractor failed on ${page.slug}: ${msg}`);
+        consecutiveEmptyOrFailed += 1;
+        if (consecutiveEmptyOrFailed >= maxConsecutiveEmptyOrFailed) {
+          result.aborted = true;
+          result.abort_reason = `consecutive_empty_or_failed_extractor_results:${consecutiveEmptyOrFailed}`;
+          result.warnings.push(
+            `aborted propose_takes after ${consecutiveEmptyOrFailed} consecutive empty/failed extractor results`,
+          );
+          break;
+        }
         continue;
       }
+
+      if (proposals.length === 0) {
+        consecutiveEmptyOrFailed += 1;
+        if (consecutiveEmptyOrFailed >= maxConsecutiveEmptyOrFailed) {
+          result.aborted = true;
+          result.abort_reason = `consecutive_empty_or_failed_extractor_results:${consecutiveEmptyOrFailed}`;
+          result.warnings.push(
+            `aborted propose_takes after ${consecutiveEmptyOrFailed} consecutive empty/failed extractor results`,
+          );
+          break;
+        }
+        continue;
+      }
+      consecutiveEmptyOrFailed = 0;
 
       // Write proposals to take_proposals. Each row is a separate INSERT
       // because the composite idempotency key is on the per-page tuple — a
@@ -442,13 +481,22 @@ class ProposeTakesPhase extends BaseCyclePhase {
       kind: 'takes.proposed',
       source_id: sourceIdForReceipt,
       round_completed_delta: result.budget_exhausted ? 0 : 1,
-      halt_delta: result.budget_exhausted ? 1 : 0,
+      halt_delta: result.budget_exhausted || result.aborted ? 1 : 0,
     });
 
+    const status: PhaseStatus = result.budget_exhausted || (result.aborted && result.proposals_inserted > 0)
+      ? 'warn'
+      : result.aborted
+        ? 'skipped'
+        : 'ok';
+    const summary = result.aborted
+      ? `propose_takes: aborted after ${result.pages_scanned} pages (${result.abort_reason})`
+      : `propose_takes: scanned ${result.pages_scanned} pages, ${result.cache_hits} cached, ${result.proposals_inserted} new proposals (run ${proposalRunId})`;
+
     return {
-      summary: `propose_takes: scanned ${result.pages_scanned} pages, ${result.cache_hits} cached, ${result.proposals_inserted} new proposals (run ${proposalRunId})`,
-      details: { ...result, proposal_run_id: proposalRunId, prompt_version: promptVersion },
-      status: result.budget_exhausted ? 'warn' : 'ok',
+      summary,
+      details: { ...result, proposal_run_id: proposalRunId, prompt_version: promptVersion, max_consecutive_empty_or_failed: maxConsecutiveEmptyOrFailed },
+      status,
     };
   }
 }

--- a/test/budget-meter.test.ts
+++ b/test/budget-meter.test.ts
@@ -44,10 +44,19 @@ describe('BudgetMeter', () => {
     expect(r2.reason).toContain('BUDGET_EXHAUSTED');
   });
 
-  test('budget=0 disables the gate (cycle runs unbounded)', () => {
+  test('budget=0 hard-skips the submit', () => {
     const meter = new BudgetMeter({ budgetUsd: 0, phase: 'drift', auditPath });
     const r = meter.check({ modelId: 'claude-opus-4-7', estimatedInputTokens: 100_000, maxOutputTokens: 100_000, label: 'huge' });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toContain('$0.00');
+    expect(meter.totalSpent).toBe(0);
+  });
+
+  test('negative budget is the explicit unlimited sentinel', () => {
+    const meter = new BudgetMeter({ budgetUsd: -1, phase: 'drift', auditPath });
+    const r = meter.check({ modelId: 'claude-opus-4-7', estimatedInputTokens: 100_000, maxOutputTokens: 100_000, label: 'huge' });
     expect(r.allowed).toBe(true);
+    expect(meter.totalSpent).toBeGreaterThan(0);
   });
 
   test('non-Anthropic model bypasses gate with warn-once + ledger entry', () => {

--- a/test/calibration-profile.test.ts
+++ b/test/calibration-profile.test.ts
@@ -44,6 +44,9 @@ function buildMockEngine(opts: { scorecard: TakesScorecard }): {
       captured.push({ sql, params: params ?? [] });
       return [];
     },
+    async getConfig(key: string) {
+      return key === 'cycle.calibration_profile.enabled' ? 'true' : null;
+    },
   } as unknown as BrainEngine;
   return { engine, captured };
 }

--- a/test/core/base-phase.test.ts
+++ b/test/core/base-phase.test.ts
@@ -71,16 +71,22 @@ class TestPhase extends BaseCyclePhase {
 
 const captured: CapturedCall[] = [];
 
-function mockEngine(): BrainEngine {
-  return { kind: 'pglite' } as unknown as BrainEngine;
+function mockEngine(config: Record<string, string | null> = {}): BrainEngine {
+  return {
+    kind: 'pglite',
+    async getConfig(key: string) {
+      return config[key] ?? null;
+    },
+  } as unknown as BrainEngine;
 }
 
 function buildCtx(opts: {
   sourceId?: string;
   allowedSources?: string[];
+  config?: Record<string, string | null>;
 } = {}): OperationContext {
   const ctx: OperationContext = {
-    engine: mockEngine(),
+    engine: mockEngine(opts.config),
     config: {} as never,
     logger: { info() {}, warn() {}, error() {} } as never,
     dryRun: false,
@@ -260,6 +266,40 @@ describe('BaseCyclePhase', () => {
       } as unknown as OperationContext;
       const result = await phase.run(ctx);
       expect(result.details.budgetUsd).toBe(7.25);
+    });
+
+    test('prefers engine.getConfig DB-plane value over ctx.config snapshot', async () => {
+      const phase = new TestPhase();
+      phase.onProcess = async () => {
+        const meter = (phase as unknown as { meter?: { check: (e: unknown) => { budgetUsd: number } } }).meter;
+        const check = meter?.check({
+          modelId: 'claude-haiku-4-5',
+          estimatedInputTokens: 1000,
+          maxOutputTokens: 100,
+        });
+        return { summary: 'ok', details: { budgetUsd: check?.budgetUsd } };
+      };
+      const ctx = {
+        ...buildCtx({ sourceId: 'tenant-a', config: { 'cycle.test_phase.budget_usd': '2.5' } }),
+        config: { 'cycle.test_phase.budget_usd': 7.25 },
+      } as unknown as OperationContext;
+      const result = await phase.run(ctx);
+      expect(result.details.budgetUsd).toBe(2.5);
+    });
+
+    test('allows negative DB-plane budget as explicit unlimited sentinel', async () => {
+      const phase = new TestPhase();
+      phase.onProcess = async () => {
+        const meter = (phase as unknown as { meter?: { check: (e: unknown) => { budgetUsd: number } } }).meter;
+        const check = meter?.check({
+          modelId: 'claude-haiku-4-5',
+          estimatedInputTokens: 1000,
+          maxOutputTokens: 100,
+        });
+        return { summary: 'ok', details: { budgetUsd: check?.budgetUsd } };
+      };
+      const result = await phase.run(buildCtx({ sourceId: 'tenant-a', config: { 'cycle.test_phase.budget_usd': '-1' } }));
+      expect(result.details.budgetUsd).toBe(-1);
     });
   });
 });

--- a/test/core/cycle.serial.test.ts
+++ b/test/core/cycle.serial.test.ts
@@ -413,6 +413,47 @@ describe('runCycle — yieldBetweenPhases hook', () => {
   });
 });
 
+describe('runCycle — paid calibration phase enabled gates', () => {
+  async function disablePaidCalibrationPhases() {
+    await sharedEngine.setConfig('cycle.propose_takes.enabled', 'false');
+    await sharedEngine.setConfig('cycle.grade_takes.enabled', 'false');
+    await sharedEngine.setConfig('cycle.calibration_profile.enabled', 'false');
+  }
+
+  beforeEach(async () => {
+    await truncateCycleLocks(sharedEngine);
+    await disablePaidCalibrationPhases();
+  });
+
+  afterEach(async () => {
+    await disablePaidCalibrationPhases();
+  });
+
+  test('propose_takes is skipped by default unless DB config enables it', async () => {
+    const report = await runCycle(sharedEngine, { brainDir: '/tmp/brain', phases: ['propose_takes'] });
+    expect(report.phases).toHaveLength(1);
+    expect(report.phases[0].phase).toBe('propose_takes');
+    expect(report.phases[0].status).toBe('skipped');
+    expect(report.phases[0].details.reason).toBe('disabled');
+
+    await sharedEngine.setConfig('cycle.propose_takes.enabled', 'true');
+    const enabledReport = await runCycle(sharedEngine, { brainDir: '/tmp/brain', phases: ['propose_takes'] });
+    expect(enabledReport.phases[0].phase).toBe('propose_takes');
+    expect(enabledReport.phases[0].details.reason).not.toBe('disabled');
+  });
+
+  test('grade_takes and calibration_profile carry default-off skip receipts', async () => {
+    const report = await runCycle(sharedEngine, {
+      brainDir: '/tmp/brain',
+      phases: ['grade_takes', 'calibration_profile'],
+    });
+    expect(report.phases.map((p: any) => [p.phase, p.status, p.details.reason])).toEqual([
+      ['grade_takes', 'skipped', 'disabled'],
+      ['calibration_profile', 'skipped', 'disabled'],
+    ]);
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────
 // Wave regression guards (#417 + Codex F2)
 // ─────────────────────────────────────────────────────────────────

--- a/test/cycle-pack-gating.test.ts
+++ b/test/cycle-pack-gating.test.ts
@@ -163,7 +163,7 @@ describe('v0.41 T9 R-GATE: pre-existing 17 core phases always run', () => {
   });
 
   test('calibration_profile dispatch does NOT consult packDeclaresPhase', () => {
-    // Pre-existing v0.36.1.0 phase; always-on.
+    // Pre-existing v0.36.1.0 phase; now config-gated default-off, but not pack-gated.
     const cpBlockStart = cycleTsSrc.indexOf("phases.includes('calibration_profile')");
     expect(cpBlockStart).toBeGreaterThan(-1);
     // Window of 1500 chars covers the dispatch.

--- a/test/grade-takes-ensemble.test.ts
+++ b/test/grade-takes-ensemble.test.ts
@@ -59,6 +59,9 @@ function buildMockEngine(opts: { takes: Take[] }): {
     async resolveTake(pageId: number, rowNum: number, resolution: TakeResolution): Promise<void> {
       resolves.push({ pageId, rowNum, resolution });
     },
+    async getConfig(key: string) {
+      return key === 'cycle.grade_takes.enabled' ? 'true' : null;
+    },
   } as unknown as BrainEngine;
   return { engine, captured, resolves };
 }

--- a/test/grade-takes.test.ts
+++ b/test/grade-takes.test.ts
@@ -69,6 +69,9 @@ function buildMockEngine(opts: {
     async resolveTake(pageId: number, rowNum: number, resolution: TakeResolution): Promise<void> {
       resolves.push({ pageId, rowNum, resolution });
     },
+    async getConfig(key: string) {
+      return key === 'cycle.grade_takes.enabled' ? 'true' : null;
+    },
   } as unknown as BrainEngine;
 
   return { engine, captured, resolves };

--- a/test/propose-takes.test.ts
+++ b/test/propose-takes.test.ts
@@ -39,6 +39,7 @@ interface CapturedSql {
 function buildMockEngine(opts: {
   pages: Page[];
   existingProposals?: Set<string>; // composite-key strings already in take_proposals
+  config?: Record<string, string>;
 }): { engine: BrainEngine; captured: CapturedSql[] } {
   const captured: CapturedSql[] = [];
   const existing = opts.existingProposals ?? new Set<string>();
@@ -59,6 +60,9 @@ function buildMockEngine(opts: {
       }
       // INSERT — return nothing
       return [];
+    },
+    async getConfig(key: string) {
+      return opts.config?.[key] ?? (key === 'cycle.propose_takes.enabled' ? 'true' : null);
     },
   } as unknown as BrainEngine;
 
@@ -383,5 +387,57 @@ New prose appended here.`;
     expect(runIdA).toBe(runIdB);
     expect(typeof runIdA).toBe('string');
     expect((runIdA as string).startsWith('propose-')).toBe(true);
+  });
+
+  test('default circuit breaker aborts after 3 consecutive empty extractor results', async () => {
+    const pages = [
+      buildPage({ slug: 'wiki/a', body: 'page a' }),
+      buildPage({ slug: 'wiki/b', body: 'page b' }),
+      buildPage({ slug: 'wiki/c', body: 'page c' }),
+      buildPage({ slug: 'wiki/d', body: 'page d' }),
+    ];
+    const { engine } = buildMockEngine({ pages });
+    let extractorCalls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      extractorCalls++;
+      return [];
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    expect(result.status).toBe('skipped');
+    expect(extractorCalls).toBe(3);
+    const details = result.details as Record<string, unknown>;
+    expect(details.aborted).toBe(true);
+    expect(details.abort_reason).toBe('consecutive_empty_or_failed_extractor_results:3');
+    expect(details.pages_scanned).toBe(3);
+  });
+
+  test('circuit breaker counts failed extractor results and reads DB config override', async () => {
+    const pages = [
+      buildPage({ slug: 'wiki/a', body: 'page a' }),
+      buildPage({ slug: 'wiki/b', body: 'page b' }),
+      buildPage({ slug: 'wiki/c', body: 'page c' }),
+    ];
+    const { engine } = buildMockEngine({
+      pages,
+      config: {
+        'cycle.propose_takes.enabled': 'true',
+        'cycle.propose_takes.max_consecutive_empty_or_failed': '2',
+      },
+    });
+    let extractorCalls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      extractorCalls++;
+      throw new Error('gateway failed');
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    expect(result.status).toBe('skipped');
+    expect(extractorCalls).toBe(2);
+    const details = result.details as Record<string, unknown>;
+    expect(details.max_consecutive_empty_or_failed).toBe(2);
+    expect(details.abort_reason).toBe('consecutive_empty_or_failed_extractor_results:2');
   });
 });


### PR DESCRIPTION
## Summary
- default paid calibration phases off behind DB-backed `cycle.<phase>.enabled` gates
- make cycle phase budgets read DB-overlay config and treat `budget_usd=0` as hard skip, with negative as explicit unlimited
- abort `propose_takes` after consecutive empty/failed extractor results (default 3, DB-configurable)

## Tests
- bun install
- bun run typecheck
- bun test test/budget-meter.test.ts test/core/base-phase.test.ts test/propose-takes.test.ts test/grade-takes.test.ts test/grade-takes-ensemble.test.ts test/calibration-profile.test.ts test/core/cycle.serial.test.ts test/cycle-pack-gating.test.ts

## Notes
- Draft because this intentionally changes default behavior for the paid calibration phases.
