### PR TITLE
fix(facts): harden extraction gating and provider config

### DIFF
--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -21,13 +21,15 @@ import type { AIGatewayConfig } from './types.ts';
 
 export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   // v0.32 (#121 reworked): when ~/.gbrain/config.json declares
-  // openai_api_key / anthropic_api_key, fold them into the gateway env so
-  // recipes that read OPENAI_API_KEY / ANTHROPIC_API_KEY find them. Process
+  // openai_api_key / anthropic_api_key / openrouter_api_key, fold them into
+  // the gateway env so recipes that read OPENAI_API_KEY / ANTHROPIC_API_KEY /
+  // OPENROUTER_API_KEY find them. Process
   // env still wins (it's loaded last) — this is a fallback for daemons /
   // launchd-spawned subprocesses that don't propagate ~/.zshrc-sourced keys.
   const envFromConfig: Record<string, string> = {};
   if (c.openai_api_key) envFromConfig.OPENAI_API_KEY = c.openai_api_key;
   if (c.anthropic_api_key) envFromConfig.ANTHROPIC_API_KEY = c.anthropic_api_key;
+  if (c.openrouter_api_key) envFromConfig.OPENROUTER_API_KEY = c.openrouter_api_key;
   // v0.37 fix wave (CDX2-5+6): ZE became the default provider in v0.36 but
   // the env-mapping at this seam never picked it up. `gbrain config set
   // zeroentropy_api_key X` wrote DB plane (ignored by gateway). The file-

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -601,7 +601,10 @@ export function loadConfig(): GBrainConfig | null {
  * size the schema and must be stable across engine connect.
  */
 export async function loadConfigWithEngine(
-  engine: { getConfig(key: string): Promise<string | null | undefined> },
+  engine: {
+    getConfig(key: string): Promise<string | null | undefined>;
+    listConfigKeys?(prefix?: string): Promise<string[]>;
+  },
   base?: GBrainConfig | null,
 ): Promise<GBrainConfig | null> {
   // Codex /ship finding #3: when there's no file config AND no env DB URL,
@@ -649,11 +652,37 @@ export async function loadConfigWithEngine(
   // first use so a malformed DB row doesn't kill engine connect.
   const dbEmbeddingColumns = await dbStr('embedding_columns');
   const dbSearchEmbeddingColumn = await dbStr('search_embedding_column');
+  const dbProviderBaseUrls: Record<string, string> = {};
+  if (typeof engine.listConfigKeys === 'function') {
+    try {
+      const keys = await engine.listConfigKeys('provider_base_urls.');
+      for (const key of keys) {
+        const provider = key.slice('provider_base_urls.'.length).trim();
+        if (!provider) continue;
+        const value = await dbStr(key);
+        if (value !== undefined && value.trim()) dbProviderBaseUrls[provider] = value.trim();
+      }
+    } catch {
+      // Older/minimal engine shims in tests may not support prefix listing.
+      // Ignore and preserve file/env config behavior.
+    }
+  }
 
   // DB applies only when env did NOT win. Env presence is detected by the
   // sync loadConfig() already setting the field. For each flag, prefer the
   // existing fileConfig value when defined; otherwise fall through to DB.
   const merged: GBrainConfig = { ...fileConfig };
+  if (Object.keys(dbProviderBaseUrls).length > 0) {
+    // Per-provider base URLs are runtime routing knobs and `gbrain config set
+    // provider_base_urls.<id> ...` advertises DB-plane support via
+    // KNOWN_CONFIG_KEY_PREFIXES. Merge them here so the gateway sees the
+    // configured local/private proxy after engine connect. File-plane config
+    // still wins over DB values per the documented precedence.
+    merged.provider_base_urls = {
+      ...dbProviderBaseUrls,
+      ...(merged.provider_base_urls ?? {}),
+    };
+  }
   if (merged.embedding_multimodal === undefined && dbMultimodal !== undefined) {
     merged.embedding_multimodal = dbMultimodal;
   }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -31,6 +31,8 @@ export interface GBrainConfig {
   database_path?: string;
   openai_api_key?: string;
   anthropic_api_key?: string;
+  /** OpenRouter API key. Used by daemon/launchd paths that cannot inherit shell env. */
+  openrouter_api_key?: string;
   /**
    * ZeroEntropy API key. v0.37 fix wave (CDX2-5+6): ZE became the default
    * embedding + reranker provider in v0.36 but lacked a file-plane config
@@ -518,6 +520,7 @@ export function loadConfig(): GBrainConfig | null {
     ...(dbUrl ? { database_path: undefined } : {}),
     ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
     ...(process.env.ANTHROPIC_API_KEY ? { anthropic_api_key: process.env.ANTHROPIC_API_KEY } : {}),
+    ...(process.env.OPENROUTER_API_KEY ? { openrouter_api_key: process.env.OPENROUTER_API_KEY } : {}),
     ...(process.env.ZEROENTROPY_API_KEY ? { zeroentropy_api_key: process.env.ZEROENTROPY_API_KEY } : {}),
     ...(process.env.GBRAIN_EMBEDDING_MODEL ? { embedding_model: process.env.GBRAIN_EMBEDDING_MODEL } : {}),
     ...(process.env.GBRAIN_EMBEDDING_DIMENSIONS ? { embedding_dimensions: parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS, 10) } : {}),
@@ -837,6 +840,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'database_path',
   'openai_api_key',
   'anthropic_api_key',
+  'openrouter_api_key',
   'embedding_model',
   'embedding_dimensions',
   'embedding_disabled',

--- a/src/core/facts/extract.ts
+++ b/src/core/facts/extract.ts
@@ -71,6 +71,76 @@ export const ALL_EXTRACT_KINDS: readonly FactKind[] = [
   'event', 'preference', 'commitment', 'belief', 'fact',
 ] as const;
 
+const ACK_ONLY_RE = /^(ok|okay|yes|no|yep|yeah|nah|thanks|thank you|great|perfect|awesome|lol|haha|cool|sounds good|proceed|do it|go ahead|continue|yess+|wow+|fuck yeah)[.!\s]*$/i;
+const SMOKE_OR_EXACT_REPLY_RE = /\b(smoke test|config smoke|reply exactly|respond exactly|respond with exactly|reply with exactly|exactly:)\b/i;
+const QUESTION_START_RE = /^(what|why|how|when|where|who|which|can|could|should|would|do|does|did|is|are|was|were|will|am)\b/i;
+const TRANSIENT_TASK_RE = /\b(can you|could you|please|help me|open|read|compare|analyze|review|validate|build|create|install|set up|setup|run|test|audit|check|find|search|look|show|tell me|what about|what is|how do|how can|should we|do you|does he|reply|respond|perform a smoke test|report back|push|update the readme)\b/i;
+const DURABLE_SIGNAL_RE = /\b(i prefer|my preference|i like|i don't like|i hate|i love|too long|too much information|short answer|default to|i just want it back to default|tables are not bad|code blocks|telegram formatting|tool calls|verbose|remember|save it as|save this|learn a lesson|update your workflow|upgrade yourself|make sure|always|never|do not|don't|must|we decided|i decided|source of truth|1-3-1|131)\b/i;
+const COMMITMENT_KIND_RE = /\b(make sure|remember|save it as|save this|we decided|i decided|decided|decision|let'?s use|lets use|switch to|default to|use\b[^.]{0,80}\bas default|source of truth|always|never|do not|must|need to|1-3-1|131)\b/i;
+const PREFERENCE_KIND_RE = /\b(i prefer|my preference|i like|i don't like|i hate|i love|i don't want|prefer|preferred|prefers|like|likes|dislike|dislikes|too long|too much information|short answer|tables are not bad|code blocks|telegram formatting|tool calls|verbose|default)\b/i;
+const BELIEF_KIND_RE = /\b(i think|i believe|i'm thinking|i suspect|i agree|this means|that means)\b/i;
+
+function normalizeTurnTextForGuards(turnText: string): string {
+  return turnText
+    .replace(/^\s*\[Brad Mills\]\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Deterministic pre-filter for obvious non-memory turns.
+ *
+ * Runs before the LLM so ordinary task requests and smoke tests cannot be
+ * promoted into durable hot memory. Durable preference/rule markers override
+ * task/question shape; exact-reply probes, pure acknowledgements, Telegram
+ * wrappers, and ordinary questions/tasks skip.
+ */
+export function shouldSkipTurnForFactsExtraction(turnText: string): boolean {
+  const t = normalizeTurnTextForGuards(turnText);
+  if (!t) return true;
+  if (/^\s*\[(Replying to|System note|CONTEXT COMPACTION|IMPORTANT|OUT-OF-BAND)/i.test(t)) return true;
+  if (SMOKE_OR_EXACT_REPLY_RE.test(t)) return true;
+  if (ACK_ONLY_RE.test(t)) return true;
+  if (t.length < 3) return true;
+
+  const hasDurableSignal = DURABLE_SIGNAL_RE.test(t);
+  const isQuestionOrTask = t.includes('?') || QUESTION_START_RE.test(t) || TRANSIENT_TASK_RE.test(t);
+  return isQuestionOrTask && !hasDurableSignal;
+}
+
+/**
+ * Deterministic kind guard for common first-person memory markers.
+ *
+ * The LLM still writes the claim text and handles nuanced extraction. This
+ * guard only normalizes high-signal lexical cases found in real Telegram turns:
+ * rules/decisions as commitments, answer-style/taste feedback as preferences,
+ * explicit hypotheses as beliefs, and typed metric assertions as facts.
+ */
+export function normalizeExtractedFactKind(
+  kind: FactKind,
+  factText: string,
+  turnText: string,
+  hasMetric: boolean,
+): FactKind {
+  if (hasMetric) return 'fact';
+
+  // Prefer fact-text evidence over whole-turn evidence. Multi-claim turns often
+  // contain both a preference and a decision; applying the decision marker to
+  // every extracted fact collapses the split.
+  if (PREFERENCE_KIND_RE.test(factText)) return 'preference';
+  if (COMMITMENT_KIND_RE.test(factText)) return 'commitment';
+  if (BELIEF_KIND_RE.test(factText)) return 'belief';
+
+  const turnHasPreference = PREFERENCE_KIND_RE.test(turnText);
+  const turnHasCommitment = COMMITMENT_KIND_RE.test(turnText);
+  const turnHasBelief = BELIEF_KIND_RE.test(turnText);
+
+  if (turnHasCommitment && !turnHasPreference && !turnHasBelief) return 'commitment';
+  if (turnHasPreference && !turnHasCommitment && !turnHasBelief) return 'preference';
+  if (turnHasBelief && !turnHasCommitment && !turnHasPreference) return 'belief';
+  return kind;
+}
+
 export interface ExtractInput {
   turnText: string;
   /** Opaque session id (MCP _meta.session_id, CLI --session, or null). */
@@ -156,18 +226,22 @@ export async function extractFactsFromTurn(input: ExtractInput): Promise<Extract
   cleaned = cleaned.trim();
   if (!cleaned) return [];
 
-  if (!isAvailable('chat')) {
-    // No chat gateway → no extraction. Caller still inserts facts via direct
-    // `gbrain take add` paths.
-    return [];
-  }
+  if (shouldSkipTurnForFactsExtraction(cleaned)) return [];
 
   const cap = Math.max(1, Math.min(input.maxFactsPerTurn ?? 10, 25));
   const defaultModel = await getFactsExtractionModel(input.engine);
+  const model = input.model ?? defaultModel;
+
+  if (!isAvailable('chat', model)) {
+    // No chat gateway for the effective facts-extraction model → no extraction.
+    // Caller still inserts facts via direct `gbrain take add` paths.
+    return [];
+  }
+
   let result: ChatResult;
   try {
     result = await chat({
-      model: input.model ?? defaultModel,
+      model,
       system: EXTRACTOR_SYSTEM,
       messages: [
         {
@@ -207,7 +281,7 @@ export async function extractFactsFromTurn(input: ExtractInput): Promise<Extract
     for (const p of INJECTION_PATTERNS) factText = factText.replace(p.rx, p.replacement);
     if (factText.length > 500) factText = factText.slice(0, 497) + '...';
 
-    const kind = ALL_EXTRACT_KINDS.includes(candidate.kind as FactKind)
+    const rawKind = ALL_EXTRACT_KINDS.includes(candidate.kind as FactKind)
       ? (candidate.kind as FactKind)
       : 'fact';
     const confidence = clampConfidence(candidate.confidence);
@@ -233,6 +307,7 @@ export async function extractFactsFromTurn(input: ExtractInput): Promise<Extract
     const claimValue  = candidate.value ?? null;
     const claimUnit   = candidate.unit ?? null;
     const claimPeriod = candidate.period ?? null;
+    const kind = normalizeExtractedFactKind(rawKind, factText, cleaned, claimMetric !== null);
 
     facts.push({
       fact: factText,

--- a/test/build-gateway-config-openrouter.test.ts
+++ b/test/build-gateway-config-openrouter.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { buildGatewayConfig } from '../src/core/ai/build-gateway-config.ts';
+import type { GBrainConfig } from '../src/core/config.ts';
+
+describe('buildGatewayConfig openrouter file-plane config', () => {
+  test('maps openrouter_api_key into gateway env and preserves provider base URLs', () => {
+    const cfg: GBrainConfig = {
+      engine: 'pglite',
+      openrouter_api_key: 'unused-local-proxy-key',
+      provider_base_urls: {
+        openrouter: 'http://127.0.0.1:8787/v1',
+      },
+    };
+
+    const gateway = buildGatewayConfig(cfg);
+
+    expect(gateway.env.OPENROUTER_API_KEY).toBe('unused-local-proxy-key');
+    expect(gateway.base_urls?.openrouter).toBe('http://127.0.0.1:8787/v1');
+  });
+});

--- a/test/facts-extract-silent-no-op.test.ts
+++ b/test/facts-extract-silent-no-op.test.ts
@@ -97,6 +97,19 @@ describe('facts extract — silent-no-op regression (v0.31.6 bug class)', () => 
     expect(facts).toEqual([]);
   });
 
+  test('facts model override availability is independent of the global chat model', () => {
+    // A brain can leave the global chat model on Sonnet while routing only
+    // facts extraction through an OpenAI-compatible/private endpoint. The
+    // extractor must probe the effective facts model, not the global chat model.
+    configureGateway({
+      chat_model: 'anthropic:claude-sonnet-4-6',
+      base_urls: { openrouter: 'http://127.0.0.1:8806/v1' },
+      env: { OPENROUTER_API_KEY: 'unused' },
+    });
+    expect(isAvailable('chat')).toBe(false);
+    expect(isAvailable('chat', 'openrouter:private/gemma4-31b')).toBe(true);
+  });
+
   test('extractFactsFromTurn USES the chat transport when available — does NOT silently return []', async () => {
     // The smoking-gun test: when chat IS available, extract MUST actually call
     // the chat transport. If it silently returns [] without calling chat, the

--- a/test/facts-extract-smoke.test.ts
+++ b/test/facts-extract-smoke.test.ts
@@ -21,7 +21,7 @@ import {
   resetGateway,
   type ChatResult,
 } from '../src/core/ai/gateway.ts';
-import { extractFactsFromTurn } from '../src/core/facts/extract.ts';
+import { extractFactsFromTurn, shouldSkipTurnForFactsExtraction, normalizeExtractedFactKind } from '../src/core/facts/extract.ts';
 
 afterEach(() => {
   __setChatTransportForTests(null);
@@ -141,5 +141,49 @@ describe('extractFactsFromTurn — B1 end-to-end smoke', () => {
 
     expect(facts).toHaveLength(3);
     expect(facts.map(f => f.notability)).toEqual(['high', 'medium', 'low']);
+  });
+
+  test('deterministic pre-filter skips transient tasks before calling chat', async () => {
+    let chatCalled = false;
+    __setChatTransportForTests(async (): Promise<ChatResult> => {
+      chatCalled = true;
+      return {
+        text: JSON.stringify({ facts: [{ fact: 'Should not be extracted', kind: 'fact' }] }),
+        blocks: [],
+        stopReason: 'end',
+        usage: { input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_creation_tokens: 0 },
+        model: 'test:stub',
+        providerId: 'test',
+      };
+    });
+
+    expect(shouldSkipTurnForFactsExtraction('Can you look at GitHub and tell me if this is a good skill?')).toBe(true);
+    const facts = await extractFactsFromTurn({
+      turnText: 'Can you look at GitHub and tell me if this is a good skill?',
+      source: 'test:prefilter',
+    });
+
+    expect(facts).toEqual([]);
+    expect(chatCalled).toBe(false);
+  });
+
+  test('deterministic pre-filter keeps durable style feedback and rules', () => {
+    expect(shouldSkipTurnForFactsExtraction('can you summarize all of this high level for me, too long')).toBe(false);
+    expect(shouldSkipTurnForFactsExtraction('make sure all agents use the 1-3-1 rule for asking me questions')).toBe(false);
+    expect(shouldSkipTurnForFactsExtraction('Smoke test. Reply exactly: OK')).toBe(true);
+    expect(shouldSkipTurnForFactsExtraction('yes')).toBe(true);
+  });
+
+  test('kind normalizer pins high-signal preferences, commitments, beliefs, and metrics', () => {
+    expect(normalizeExtractedFactKind('fact', 'Brad likes tables in code blocks', 'tables are not bad. I like tables in code blocks.', false)).toBe('preference');
+    expect(normalizeExtractedFactKind('belief', 'All agents use the 1-3-1 rule', 'make sure all agents use the 1-3-1 rule for asking me questions', false)).toBe('commitment');
+    expect(normalizeExtractedFactKind('fact', 'The software-development folder is redundant', 'Actually I think the software-development folder is redundant', false)).toBe('belief');
+    expect(normalizeExtractedFactKind('event', 'MRR is $50K', 'MRR is $50K', true)).toBe('fact');
+  });
+
+  test('kind normalizer does not smear a decision marker across preference facts in multi-claim turns', () => {
+    const turn = 'I prefer concise fact extraction candidates. I decided to use private Gemma for GBrain fact extraction.';
+    expect(normalizeExtractedFactKind('commitment', 'prefer concise fact extraction candidates', turn, false)).toBe('preference');
+    expect(normalizeExtractedFactKind('fact', 'decided to use private Gemma for GBrain fact extraction', turn, false)).toBe('commitment');
   });
 });

--- a/test/loadConfig-merge.test.ts
+++ b/test/loadConfig-merge.test.ts
@@ -9,12 +9,16 @@ import { loadConfigWithEngine, type GBrainConfig } from '../src/core/config.ts';
 
 interface FakeEngine {
   getConfig(key: string): Promise<string | null | undefined>;
+  listConfigKeys(prefix?: string): Promise<string[]>;
 }
 
 function makeEngine(map: Record<string, string | null | undefined>): FakeEngine {
   return {
     async getConfig(key: string) {
       return map[key];
+    },
+    async listConfigKeys(prefix = '') {
+      return Object.keys(map).filter(k => k.startsWith(prefix));
     },
   };
 }
@@ -45,6 +49,29 @@ describe('loadConfigWithEngine (Phase 4 / F3)', () => {
     const merged = await loadConfigWithEngine(engine, null);
     expect(merged?.search_embedding_column).toBe('embedding_voyage');
     expect(merged?.embedding_columns?.embedding_voyage?.dimensions).toBe(1024);
+  });
+
+  test('DB-plane provider_base_urls.<provider> merge reaches runtime config', async () => {
+    const base: GBrainConfig = { engine: 'pglite' };
+    const engine = makeEngine({
+      'provider_base_urls.openrouter': 'http://127.0.0.1:8806/v1',
+      'provider_base_urls.llama-server': 'http://127.0.0.1:8081/v1',
+    });
+    const merged = await loadConfigWithEngine(engine, base);
+    expect(merged?.provider_base_urls?.openrouter).toBe('http://127.0.0.1:8806/v1');
+    expect(merged?.provider_base_urls?.['llama-server']).toBe('http://127.0.0.1:8081/v1');
+  });
+
+  test('file-plane provider_base_urls win over DB-plane provider overrides', async () => {
+    const base: GBrainConfig = {
+      engine: 'pglite',
+      provider_base_urls: { openrouter: 'http://file-plane/v1' },
+    };
+    const engine = makeEngine({
+      'provider_base_urls.openrouter': 'http://db-plane/v1',
+    });
+    const merged = await loadConfigWithEngine(engine, base);
+    expect(merged?.provider_base_urls?.openrouter).toBe('http://file-plane/v1');
   });
 
   test('DB flag fills in when file/env did not set it', async () => {
@@ -99,6 +126,9 @@ describe('loadConfigWithEngine (Phase 4 / F3)', () => {
     };
     const engine: FakeEngine = {
       async getConfig() {
+        throw new Error('config table missing');
+      },
+      async listConfigKeys() {
         throw new Error('config table missing');
       },
     };
@@ -290,6 +320,9 @@ describe('loadConfigWithEngine (Phase 4 / F3)', () => {
       const base: GBrainConfig = { engine: 'pglite' };
       const engine: FakeEngine = {
         async getConfig() {
+          throw new Error('config table missing');
+        },
+        async listConfigKeys() {
           throw new Error('config table missing');
         },
       };


### PR DESCRIPTION
## Summary

This PR hardens facts extraction around the failure modes discussed in https://github.com/garrytan/gbrain/issues/2221#issuecomment-4719397290.

It adds deterministic guardrails around the existing LLM extractor rather than changing the default model:

- skip obvious transient task/question/ack/exact-reply smoke-test turns before calling chat
- probe chat availability using the effective facts extraction model instead of the global chat model
- normalize high-signal extracted kinds for preferences, commitments, beliefs, and typed metric claims
- avoid smearing a decision marker across unrelated facts in multi-claim turns
- merge DB-plane `provider_base_urls.<provider>` entries into runtime config so configured OpenAI-compatible/private endpoints actually reach the gateway

## Why

The issue thread documents extractor-quality gaps around local/private model usage, transient operational chatter, and provider routing. The narrow bug fixed here is that facts extraction could either call the model on obvious non-memory turns or silently no-op when the configured facts model differed from the global chat model.

## Tests

- `git diff --check`
- `bun test test/facts-extract-smoke.test.ts test/facts-extract-silent-no-op.test.ts test/loadConfig-merge.test.ts`
  - `37 pass / 0 fail / 81 expect() calls`

Also ran `bun run typecheck`; it still fails on existing OpenClaw SDK typing issues unrelated to this patch:

```text
src/core/context-engine.ts(90,44): Property 'buildMemorySystemPromptAddition' does not exist on type 'typeof import(".../openclaw/dist/plugin-sdk/core")'.
test/e2e/openclaw-plugin-load-real.test.ts(281,9): Type 'unknown' is not assignable to type 'ContextEngine | Promise<ContextEngine>'.
```

## Notes

No model defaults are changed by this PR. It only makes extraction safer and makes existing provider/base-url config behave as advertised.
