### PR TITLE
fix(doctor): clear atom backlog and orphan false positives

### DIFF
--- a/src/commands/dream.ts
+++ b/src/commands/dream.ts
@@ -460,8 +460,9 @@ async function runDrain(
   // Dry-run: preview the backlog without holding the lock or extracting.
   if (opts.dryRun) {
     const remaining = await countExtractAtomsBacklog(engine, extractionSourceId);
+    const stopped = remaining === 0 ? 'drained' : 'window';
     if (opts.json) {
-      console.log(JSON.stringify({ phase: 'extract_atoms', status: 'ok', dry_run: true, extracted: 0, skipped: 0, remaining, batches: 0, stopped: 'window' }, null, 2));
+      console.log(JSON.stringify({ phase: 'extract_atoms', status: 'ok', dry_run: true, extracted: 0, skipped: 0, remaining, batches: 0, stopped }, null, 2));
     } else {
       console.log(`[drain] dry-run: ${remaining ?? '?'} page(s) eligible for atom extraction (no work done)`);
     }

--- a/src/commands/orphans.ts
+++ b/src/commands/orphans.ts
@@ -24,6 +24,15 @@ export interface OrphanPage {
   domain: string;
 }
 
+export interface OrphanCandidatePage {
+  slug: string;
+  title: string;
+  domain: string | null;
+  source_id?: string;
+  type?: string | null;
+  frontmatter?: Record<string, unknown> | null;
+}
+
 export interface OrphanResult {
   orphans: OrphanPage[];
   total_orphans: number;
@@ -85,6 +94,31 @@ export function shouldExclude(slug: string): boolean {
   return false;
 }
 
+export function isGeneratedAtomPage(page: {
+  type?: string | null;
+  frontmatter?: Record<string, unknown> | null;
+}): boolean {
+  if (page.type !== 'atom') return false;
+  const fm = page.frontmatter;
+  if (!fm || typeof fm !== 'object') return false;
+
+  const hasSourceHash =
+    typeof fm.source_hash === 'string' && fm.source_hash.trim().length > 0;
+  const hasExtractionOrigin =
+    (typeof fm.source_slug === 'string' && fm.source_slug.trim().length > 0) ||
+    (typeof fm.source_path === 'string' && fm.source_path.trim().length > 0) ||
+    (typeof fm.extracted_by === 'string' && fm.extracted_by.trim().length > 0);
+  return hasSourceHash && hasExtractionOrigin;
+}
+
+export function shouldExcludePage(page: {
+  slug: string;
+  type?: string | null;
+  frontmatter?: Record<string, unknown> | null;
+}): boolean {
+  return shouldExclude(page.slug) || isGeneratedAtomPage(page);
+}
+
 /**
  * Derive domain from frontmatter or first slug segment.
  */
@@ -107,7 +141,7 @@ export function deriveDomain(frontmatterDomain: string | null | undefined, slug:
  */
 export async function queryOrphanPages(
   engine: BrainEngine,
-): Promise<{ slug: string; title: string; domain: string | null }[]> {
+): Promise<OrphanCandidatePage[]> {
   return engine.findOrphanPages();
 }
 
@@ -145,7 +179,7 @@ export async function findOrphans(
   const progress = createProgress(cliOptsToProgressOptions(getCliOptions()));
   progress.start('orphans.scan');
   const stopHb = startHeartbeat(progress, 'scanning pages for missing inbound links…');
-  let allOrphans: { slug: string; title: string; domain: string | null }[];
+  let allOrphans: OrphanCandidatePage[];
   let total: number;
   let excludedAll: number;
   try {
@@ -169,14 +203,18 @@ export async function findOrphans(
       liveParams.push(sourceId);
       scopeClause = ` AND source_id = $${liveParams.length}`;
     }
-    const liveRows = await engine.executeRaw<{ slug: string }>(
-      `SELECT slug FROM pages WHERE deleted_at IS NULL${scopeClause}`,
+    const liveRows = await engine.executeRaw<{
+      slug: string;
+      type: string | null;
+      frontmatter: Record<string, unknown> | null;
+    }>(
+      `SELECT slug, type, frontmatter FROM pages WHERE deleted_at IS NULL${scopeClause}`,
       liveParams,
     );
     total = liveRows.length;
     excludedAll = includePseudo
       ? 0
-      : liveRows.reduce((n, r) => n + (shouldExclude(r.slug) ? 1 : 0), 0);
+      : liveRows.reduce((n, r) => n + (shouldExcludePage(r) ? 1 : 0), 0);
   } finally {
     stopHb();
     progress.finish();
@@ -184,7 +222,7 @@ export async function findOrphans(
 
   const filtered = includePseudo
     ? allOrphans
-    : allOrphans.filter(row => !shouldExclude(row.slug));
+    : allOrphans.filter(row => !shouldExcludePage(row));
 
   const orphans: OrphanPage[] = filtered.map(row => ({
     slug: row.slug,

--- a/src/core/connection-manager.ts
+++ b/src/core/connection-manager.ts
@@ -168,6 +168,24 @@ export function deriveDirectUrl(url: string): string | null {
 }
 
 /**
+ * Resolve the direct-pool URL from explicit/env override + primary URL.
+ *
+ * A direct override that still points at a Supabase pooler is unsafe: the
+ * manager would believe DDL/bulk work is on a long-timeout direct connection
+ * while still routing through Supavisor. Treat that as misconfiguration and
+ * derive the real direct host from the primary/override pooler shape instead.
+ */
+export function resolveDirectUrl(primaryUrl: string, override?: string | null): string | null {
+  const candidate = override ?? deriveDirectUrl(primaryUrl);
+  if (!candidate) return null;
+  if (!isSupabasePoolerUrl(candidate)) return candidate;
+
+  const derived = deriveDirectUrl(primaryUrl) ?? deriveDirectUrl(candidate);
+  if (!derived || isSupabasePoolerUrl(derived)) return null;
+  return derived;
+}
+
+/**
  * Read kill-switch state from env. Subordinate to parent manager's state
  * when present (A2 inheritance).
  */
@@ -215,7 +233,7 @@ export class ConnectionManager {
       this._isSupabase = isSupabasePoolerUrl(opts.url);
       // Direct URL: explicit override > env > derive > null
       const envOverride = process.env.GBRAIN_DIRECT_DATABASE_URL;
-      this._directUrl = opts.directUrl ?? envOverride ?? deriveDirectUrl(opts.url);
+      this._directUrl = resolveDirectUrl(opts.url, opts.directUrl ?? envOverride);
     }
   }
 

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -70,6 +70,8 @@ const EXTRACTABLE_PAGE_TYPES = [
 ] as const;
 const PAGE_DISCOVERY_BUDGET = 50;
 const MIN_PAGE_CHARS_FOR_EXTRACTION = 500;
+const RAW_SOURCE_HOLDER_EXCLUSION_SQL =
+  `AND NOT (p.type = 'source' AND COALESCE(p.frontmatter ? 'raw', false))`;
 
 export interface ExtractAtomsOpts {
   brainDir?: string;
@@ -162,6 +164,9 @@ interface DiscoveredPage {
  *      participate in the NOT EXISTS check anyway.
  *   #4 dream_generated exclusion — prevents the phase from chewing
  *      its own output (e.g. dream-generated originals).
+ *   #5 raw source-holder exclusion — source pages that only point at a raw
+ *      import payload are not extractable prose; counting them creates a
+ *      permanent backlog/no_progress loop.
  */
 export async function discoverExtractablePages(
   engine: BrainEngine,
@@ -180,6 +185,7 @@ export async function discoverExtractablePages(
       AND p.content_hash IS NOT NULL
       AND COALESCE(p.frontmatter->>'imported_from',   '') <> 'markdown-greenfield'
       AND COALESCE(p.frontmatter->>'dream_generated', '') <> 'true'
+      ${RAW_SOURCE_HOLDER_EXCLUSION_SQL}
       AND length(COALESCE(p.compiled_truth, '')) >= $3
       ${hasFilter ? "AND p.slug = ANY($5::text[])" : ''}
       AND NOT EXISTS (
@@ -252,6 +258,7 @@ export async function countExtractAtomsBacklog(
            AND p.content_hash IS NOT NULL
            AND COALESCE(p.frontmatter->>'imported_from',   '') <> 'markdown-greenfield'
            AND COALESCE(p.frontmatter->>'dream_generated', '') <> 'true'
+           ${RAW_SOURCE_HOLDER_EXCLUSION_SQL}
            AND length(COALESCE(p.compiled_truth, '')) >= $3
            AND NOT EXISTS (
              SELECT 1 FROM pages atom
@@ -265,6 +272,7 @@ export async function countExtractAtomsBacklog(
            AND p.content_hash IS NOT NULL
            AND COALESCE(p.frontmatter->>'imported_from',   '') <> 'markdown-greenfield'
            AND COALESCE(p.frontmatter->>'dream_generated', '') <> 'true'
+           ${RAW_SOURCE_HOLDER_EXCLUSION_SQL}
            AND length(COALESCE(p.compiled_truth, '')) >= $2
            AND NOT EXISTS (
              SELECT 1 FROM pages atom

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -1329,7 +1329,14 @@ export interface BrainEngine {
   findOrphanPages(opts?: {
     sourceId?: string;
     sourceIds?: string[];
-  }): Promise<Array<{ slug: string; title: string; domain: string | null }>>;
+  }): Promise<Array<{
+    slug: string;
+    title: string;
+    domain: string | null;
+    source_id: string;
+    type: string | null;
+    frontmatter: Record<string, unknown> | null;
+  }>>;
 
   // Tags
   /**

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -3194,7 +3194,14 @@ export class PGLiteEngine implements BrainEngine {
   async findOrphanPages(opts?: {
     sourceId?: string;
     sourceIds?: string[];
-  }): Promise<Array<{ slug: string; title: string; domain: string | null }>> {
+  }): Promise<Array<{
+    slug: string;
+    title: string;
+    domain: string | null;
+    source_id: string;
+    type: string | null;
+    frontmatter: Record<string, unknown> | null;
+  }>> {
     // Soft-delete filter on BOTH sides:
     //   - candidate: p.deleted_at IS NULL — soft-deleted pages aren't orphan candidates
     //   - link source: src.deleted_at IS NULL — links FROM soft-deleted pages don't count as inbound
@@ -3219,7 +3226,10 @@ export class PGLiteEngine implements BrainEngine {
       `SELECT
          p.slug,
          COALESCE(p.title, p.slug) AS title,
-         p.frontmatter->>'domain' AS domain
+         p.frontmatter->>'domain' AS domain,
+         p.source_id,
+         p.type,
+         p.frontmatter
        FROM pages p
        WHERE p.deleted_at IS NULL
          ${sourceFilter}
@@ -3233,7 +3243,14 @@ export class PGLiteEngine implements BrainEngine {
        ORDER BY p.slug`,
       params
     );
-    return rows as Array<{ slug: string; title: string; domain: string | null }>;
+    return rows as Array<{
+      slug: string;
+      title: string;
+      domain: string | null;
+      source_id: string;
+      type: string | null;
+      frontmatter: Record<string, unknown> | null;
+    }>;
   }
 
   // Tags

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -3273,7 +3273,14 @@ export class PostgresEngine implements BrainEngine {
   async findOrphanPages(opts?: {
     sourceId?: string;
     sourceIds?: string[];
-  }): Promise<Array<{ slug: string; title: string; domain: string | null }>> {
+  }): Promise<Array<{
+    slug: string;
+    title: string;
+    domain: string | null;
+    source_id: string;
+    type: string | null;
+    frontmatter: Record<string, unknown> | null;
+  }>> {
     const sql = this.sql;
     // Soft-delete filter on BOTH sides:
     //   - candidate: p.deleted_at IS NULL — soft-deleted pages aren't orphan candidates
@@ -3296,7 +3303,10 @@ export class PostgresEngine implements BrainEngine {
       SELECT
         p.slug,
         COALESCE(p.title, p.slug) AS title,
-        p.frontmatter->>'domain' AS domain
+        p.frontmatter->>'domain' AS domain,
+        p.source_id,
+        p.type,
+        p.frontmatter
       FROM pages p
       WHERE p.deleted_at IS NULL
         ${sourceFilter}
@@ -3309,7 +3319,14 @@ export class PostgresEngine implements BrainEngine {
         )
       ORDER BY p.slug
     `;
-    return rows as unknown as Array<{ slug: string; title: string; domain: string | null }>;
+    return rows as unknown as Array<{
+      slug: string;
+      title: string;
+      domain: string | null;
+      source_id: string;
+      type: string | null;
+      frontmatter: Record<string, unknown> | null;
+    }>;
   }
 
   // Tags

--- a/test/connection-manager.serial.test.ts
+++ b/test/connection-manager.serial.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
 import {
   isSupabasePoolerUrl,
   deriveDirectUrl,
+  resolveDirectUrl,
   readKillSwitchEnv,
   resolveDirectPoolSize,
   ConnectionManager,
@@ -78,6 +79,26 @@ describe('deriveDirectUrl', () => {
   });
 });
 
+describe('resolveDirectUrl', () => {
+  test('derives a real direct host when override is still a Supabase pooler', () => {
+    const direct = resolveDirectUrl(
+      'postgresql://postgres.abcxyz:p@aws-0-us-west-2.pooler.supabase.com:6543/postgres',
+      'postgresql://postgres.abcxyz:p@aws-0-us-west-2.pooler.supabase.com:5432/postgres',
+    );
+
+    expect(direct).toBe('postgresql://postgres:p@db.abcxyz.supabase.co:5432/postgres');
+    expect(direct).not.toContain('pooler.supabase.com');
+  });
+
+  test('keeps a non-pooler direct override', () => {
+    const direct = resolveDirectUrl(
+      'postgresql://postgres.abc:p@aws.pooler.supabase.com:6543/db',
+      'postgresql://u:p@custom-direct.example.com:5432/db',
+    );
+    expect(direct).toBe('postgresql://u:p@custom-direct.example.com:5432/db');
+  });
+});
+
 describe('readKillSwitchEnv', () => {
   let original: string | undefined;
   beforeEach(() => { original = process.env.GBRAIN_DISABLE_DIRECT_POOL; });
@@ -145,13 +166,18 @@ describe('resolveDirectPoolSize', () => {
 
 describe('ConnectionManager — describeMode + dual-pool routing', () => {
   let originalKillSwitch: string | undefined;
+  let originalDirectUrl: string | undefined;
   beforeEach(() => {
     originalKillSwitch = process.env.GBRAIN_DISABLE_DIRECT_POOL;
+    originalDirectUrl = process.env.GBRAIN_DIRECT_DATABASE_URL;
     delete process.env.GBRAIN_DISABLE_DIRECT_POOL;
+    delete process.env.GBRAIN_DIRECT_DATABASE_URL;
   });
   afterEach(() => {
     if (originalKillSwitch === undefined) delete process.env.GBRAIN_DISABLE_DIRECT_POOL;
     else process.env.GBRAIN_DISABLE_DIRECT_POOL = originalKillSwitch;
+    if (originalDirectUrl === undefined) delete process.env.GBRAIN_DIRECT_DATABASE_URL;
+    else process.env.GBRAIN_DIRECT_DATABASE_URL = originalDirectUrl;
   });
 
   test('non-Supabase URL → single mode', () => {
@@ -188,6 +214,25 @@ describe('ConnectionManager — describeMode + dual-pool routing', () => {
       directUrl: 'postgresql://u:p@custom-direct.example.com:5432/db',
     });
     expect(cm.resolveDirectUrl()).toContain('custom-direct.example.com');
+  });
+
+  test('explicit pooler directUrl override is normalized to direct host', () => {
+    const cm = new ConnectionManager({
+      url: 'postgresql://postgres.abc:p@aws.pooler.supabase.com:6543/db',
+      directUrl: 'postgresql://postgres.abc:p@aws.pooler.supabase.com:5432/db',
+    });
+    expect(cm.resolveDirectUrl()).toContain('db.abc.supabase.co:5432');
+    expect(cm.resolveDirectUrl()).not.toContain('pooler.supabase.com');
+  });
+
+  test('env pooler directUrl override is normalized to direct host', () => {
+    process.env.GBRAIN_DIRECT_DATABASE_URL =
+      'postgresql://postgres.abc:p@aws.pooler.supabase.com:5432/db';
+    const cm = new ConnectionManager({
+      url: 'postgresql://postgres.abc:p@aws.pooler.supabase.com:6543/db',
+    });
+    expect(cm.resolveDirectUrl()).toContain('db.abc.supabase.co:5432');
+    expect(cm.resolveDirectUrl()).not.toContain('pooler.supabase.com');
   });
 
   test('host string contains creds neither in describeMode nor resolveDirectUrl logging', () => {

--- a/test/doctor-extract-atoms-backlog.test.ts
+++ b/test/doctor-extract-atoms-backlog.test.ts
@@ -76,6 +76,16 @@ describe('countExtractAtomsBacklog (issue #1678)', () => {
     });
     expect(await countExtractAtomsBacklog(engine)).toBe(0);
   });
+
+  it('ignores raw source-holder pages', async () => {
+    await engine.putPage('wiki/raw-email-source', {
+      type: 'source',
+      title: 'Raw email source',
+      compiled_truth: BODY,
+      frontmatter: { raw: 'raw/email/example.md' },
+    });
+    expect(await countExtractAtomsBacklog(engine)).toBe(0);
+  });
 });
 
 describe('computeExtractAtomsBacklogCheck (issue #1678)', () => {

--- a/test/doctor-orphan-ratio.test.ts
+++ b/test/doctor-orphan-ratio.test.ts
@@ -127,6 +127,44 @@ describe('runDoctor — orphan_ratio check (local surface, D5)', () => {
     expect(check!.message).toMatch(/orphan ratio/i);
   });
 
+  test('generated atom leaves do not inflate orphan_ratio', async () => {
+    for (let i = 0; i < 100; i++) {
+      await engine.putPage(`companies/linked-${i}`, {
+        type: 'company', title: `Linked ${i}`, compiled_truth: 'b', timeline: '', frontmatter: {},
+      });
+    }
+    await engine.putPage('writing/index', {
+      type: 'note', title: 'Index', compiled_truth: 'index', timeline: '', frontmatter: {},
+    });
+    const links = [];
+    for (let i = 0; i < 100; i++) {
+      links.push({
+        from_slug: 'writing/index',
+        to_slug: `companies/linked-${i}`,
+        link_type: 'mentions', link_source: 'markdown', context: '',
+      });
+    }
+    await engine.addLinksBatch(links);
+    for (let i = 0; i < 200; i++) {
+      await engine.putPage(`atoms/2026-06-14/generated-${i}`, {
+        type: 'atom',
+        title: `Generated ${i}`,
+        compiled_truth: 'generated atom body',
+        timeline: '',
+        frontmatter: {
+          source_hash: `hash-${i}`,
+          source_slug: 'meeting/source',
+          extracted_by: 'extract_atoms',
+        },
+      });
+    }
+
+    const report = await runDoctorJson();
+    const check = findCheck(report, 'orphan_ratio');
+    expect(check!.status).toBe('ok');
+    expect(check!.message).toContain('(1/101 linkable pages)');
+  });
+
   test('high orphan ratio (>0.5, <=0.8) → warn with fix-hint', async () => {
     for (let i = 0; i < 100; i++) {
       await engine.putPage(`companies/co-${i}`, {

--- a/test/extract-atoms-page-discovery.test.ts
+++ b/test/extract-atoms-page-discovery.test.ts
@@ -174,6 +174,18 @@ describe('v0.41.2.1: discoverExtractablePages SQL contract', () => {
     expect(discovered.map((d) => d.slug)).toEqual(['original/normal']);
   });
 
+  test('raw source-holder pages are excluded', async () => {
+    await seedPage({ slug: 'source/normal', type: 'source' });
+    await seedPage({
+      slug: 'wiki/raw-email-source',
+      type: 'source',
+      frontmatter: { raw: 'raw/email/example.md' },
+    });
+
+    const discovered = await discoverExtractablePages(engine, 'default');
+    expect(discovered.map((d) => d.slug)).toEqual(['source/normal']);
+  });
+
   test('pages with NULL content_hash excluded (D9 #3 — no .slice crash)', async () => {
     await seedPage({ slug: 'meeting/with-hash', type: 'meeting' });
     await seedPage({ slug: 'meeting/no-hash', type: 'meeting', content_hash: null });

--- a/test/orphans.test.ts
+++ b/test/orphans.test.ts
@@ -1,6 +1,8 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import {
   shouldExclude,
+  shouldExcludePage,
+  isGeneratedAtomPage,
   deriveDomain,
   formatOrphansText,
   findOrphans,
@@ -95,6 +97,34 @@ describe('shouldExclude', () => {
   test('does NOT exclude a page ending with log-like text that is not /log', () => {
     expect(shouldExclude('devlog')).toBe(false);
     expect(shouldExclude('changelog')).toBe(false);
+  });
+});
+
+describe('generated atom orphan exclusion', () => {
+  test('excludes generated atom leaves by default', () => {
+    const page = {
+      slug: 'atoms/2026-06-14/example',
+      type: 'atom',
+      frontmatter: {
+        source_hash: 'abc123abc123abc1',
+        source_slug: 'meeting/source',
+        extracted_by: 'extract_atoms',
+      },
+    };
+
+    expect(isGeneratedAtomPage(page)).toBe(true);
+    expect(shouldExcludePage(page)).toBe(true);
+  });
+
+  test('does not exclude user-authored atom pages without extraction metadata', () => {
+    const page = {
+      slug: 'atoms/manual/example',
+      type: 'atom',
+      frontmatter: {},
+    };
+
+    expect(isGeneratedAtomPage(page)).toBe(false);
+    expect(shouldExcludePage(page)).toBe(false);
   });
 });
 
@@ -268,6 +298,30 @@ describe('findOrphans (engine-injected)', () => {
 
     const slugs = result.orphans.map(o => o.slug).sort();
     expect(slugs).toContain('_atlas');
+  });
+
+  test('generated atom leaves are excluded by default but included with includePseudo', async () => {
+    await engine.putPage('atoms/2026-06-14/extracted', {
+      type: 'atom',
+      title: 'Extracted atom',
+      compiled_truth: 'generated atom body',
+      timeline: '',
+      frontmatter: {
+        source_hash: 'abc123abc123abc1',
+        source_slug: 'meeting/source',
+        extracted_by: 'extract_atoms',
+      },
+    });
+
+    const defaultResult = await findOrphans(engine);
+    expect(defaultResult.orphans.map(o => o.slug)).not.toContain('atoms/2026-06-14/extracted');
+    expect(defaultResult.total_pages).toBe(1);
+    expect(defaultResult.total_linkable).toBe(0);
+    expect(defaultResult.excluded).toBe(1);
+
+    const includePseudo = await findOrphans(engine, { includePseudo: true });
+    expect(includePseudo.orphans.map(o => o.slug)).toContain('atoms/2026-06-14/extracted');
+    expect(includePseudo.total_linkable).toBe(1);
   });
 
   test('queryOrphanPages delegates to the passed engine (no global db)', async () => {


### PR DESCRIPTION
## Summary
- Exclude raw source-holder pages from extract_atoms discovery/backlog so they do not create permanent no-progress doctor blockers.
- Exclude generated atom leaves from orphan reporting by default while preserving user-authored atom pages.
- Normalize Supabase pooler direct-URL overrides to a real direct host before enabling split-pool routing.
- Report extract_atoms drain dry-run as stopped=drained when remaining is zero.

## Verification
- PASS: bun test test/connection-manager.serial.test.ts test/extract-atoms-page-discovery.test.ts test/doctor-extract-atoms-backlog.test.ts test/orphans.test.ts test/doctor-orphan-ratio.test.ts test/extract-atoms-drain.test.ts
- PASS: bun run typecheck
- PASS: bun run verify
- PASS locally before PR prep: gbrain doctor --json exits 0; extract_atoms dry-run remaining=0; queue_health/wedged_queue OK; GStack search smoke returns hits.

## Full test caveat
- Attempted full bun run test locally before opening this PR. It failed in unrelated broader suites/local environment areas, including config/skillpack/init tests, missing ip-address under @modelcontextprotocol/sdk for admin server smoke, and hybrid/reranker/search integration tests. The changed surfaces are covered by the targeted passing suites above.

## Operational note
- A local launchd wrapper change was kept out of this PR: /Users/bpalisoc/.gbrain/autopilot-run.sh exports GBRAIN_DISABLE_DIRECT_POOL=1 for this machine's supervisor runtime.