### PR TITLE
ci(release): run verify before build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
           bun-version: 1.3.13
       - run: bun install
       - run: bun test
+      - run: bun run verify
       - run: bun build --compile --target=${{ matrix.target }} --outfile bin/${{ matrix.artifact }} src/cli.ts
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:


### PR DESCRIPTION
## What does this PR do?

Adds the existing `bun run verify` gate to the release workflow before compiling release binaries.

The release job already installs dependencies and runs `bun test`, but it currently builds publishable binaries without the repository's broader verification gate. Running `verify` here catches typecheck failures, privacy/static guard regressions, admin build drift, resolver issues, and related checks before artifacts are uploaded to a GitHub release.

## Related Issue

Refs #2222

## Type of Change

- [x] CI / release safety

## Changes Made

- `.github/workflows/release.yml`
  - Adds `bun run verify` between `bun test` and the release binary build step.

## Duplicate Checks

Checked immediately before submission:

- `release.yml verify before build`
- `"bun run verify" "release.yml"`
- Issue #2222 state and comments

Result: no exact duplicate PR found; #2222 remains open and directly requests this release workflow change.

## How to Test

Validated locally:

```bash
git diff --check
python3 - <<'PY'
from pathlib import Path
text = Path('.github/workflows/release.yml').read_text()
assert '- run: bun test\n      - run: bun run verify\n      - run: bun build --compile' in text
print('release workflow order check: ok')
PY
bun install --frozen-lockfile
bun run verify
```

Results:

```text
release workflow order check: ok
[verify-parallel] elapsed=17s | pass=30 fail=0 | all checks green
```

Fork CI also passed all reported checks before upstream submission, including `Tier 1 (Mechanical)`, `Tier 2 (LLM Skills)`, `verify`, `gitleaks`, `serial-tests`, and `test (1)` through `test (10)`.

## Risk

Low. This only changes the release CI workflow. It increases release runtime by running the same verification gate already documented for pre-push/CI, and it does not change runtime application code.

## Checklist

- [x] Focused, small diff
- [x] Regression/docs validation added or not applicable
- [x] Duplicate checks completed
- [x] Validation passed
- [x] Maintainer edits enabled
