### PR TITLE
Diagnose & recover unclean PGLite data dirs (refs #223)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1217,6 +1217,16 @@ async function handleCliOnly(command: string, args: string[]) {
     return;
   }
   if (command === 'doctor') {
+    if (args.includes('--rebuild-pglite')) {
+      const cfgForRebuild = loadConfig();
+      if (isThinClient(cfgForRebuild)) {
+        refuseThinClient('doctor --rebuild-pglite', cfgForRebuild!.remote_mcp!.mcp_url);
+      }
+      const { runDoctorRebuildPglite } = await import('./commands/doctor.ts');
+      await runDoctorRebuildPglite(args);
+      return;
+    }
+
     // Multi-topology v1: thin-client doctor. When `~/.gbrain/config.json`
     // has remote_mcp set, every DB-bound check is irrelevant. Route to the
     // outbound-HTTP probe set in `src/core/doctor-remote.ts` and return
@@ -2183,6 +2193,7 @@ SETUP
   upgrade                            Self-update
   check-update [--json]              Check for new versions
   doctor [--json] [--fast]            Health check (resolver, skills, pgvector, RLS, embeddings)
+  doctor --rebuild-pglite [--yes]     Move aside a broken PGLite data dir and re-init
   integrations [subcommand]          Manage integration recipes (senses + reflexes)
 
 PAGES

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -7232,6 +7232,99 @@ export async function runDoctor(
   setCliExitVerdict(hasFail ? 1 : 0);
 }
 
+export async function runDoctorRebuildPglite(args: string[]): Promise<void> {
+  const jsonOutput = args.includes('--json');
+  const yes = args.includes('--yes') || args.includes('-y');
+  const noSync = args.includes('--no-sync');
+  const cfg = loadConfig();
+
+  if (cfg?.engine !== 'pglite') {
+    const message = `gbrain doctor --rebuild-pglite is for local PGLite brains only (current engine: ${cfg?.engine || 'none'}).`;
+    if (jsonOutput) console.log(JSON.stringify({ status: 'error', reason: 'not_pglite', message }));
+    else console.error(message);
+    process.exit(1);
+  }
+
+  const dbPath = cfg.database_path || gbrainPath('brain.pglite');
+  if (!existsSync(dbPath)) {
+    const message = `No PGLite brain found at ${dbPath}. Run \`gbrain init --pglite\` to create one.`;
+    if (jsonOutput) console.log(JSON.stringify({ status: 'error', reason: 'no_brain', message }));
+    else console.error(message);
+    process.exit(1);
+  }
+
+  const ts = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+  const backupPath = `${dbPath}.broken-${ts}`;
+  if (existsSync(backupPath)) {
+    const message = `Backup destination already exists at ${backupPath}.`;
+    if (jsonOutput) console.log(JSON.stringify({ status: 'error', reason: 'backup_exists', message }));
+    else console.error(message);
+    process.exit(1);
+  }
+
+  if (!yes) {
+    if (!process.stdin.isTTY) {
+      const message = 'Non-TTY environment requires --yes to rebuild PGLite.';
+      if (jsonOutput) console.log(JSON.stringify({ status: 'error', reason: 'no_tty_no_yes', message }));
+      else console.error(message);
+      process.exit(1);
+    }
+    process.stdout.write(`Move ${dbPath} aside and create a fresh PGLite brain? (y/N): `);
+    const stdin = process.stdin as unknown as {
+      setEncoding?: (encoding: string) => void;
+      on?: (event: 'data', cb: (chunk: string) => void) => void;
+      off?: (event: 'data', cb: (chunk: string) => void) => void;
+    };
+    stdin.setEncoding?.('utf8');
+    const confirmed = await new Promise<boolean>((resolve) => {
+      const onData = (chunk: string) => {
+        stdin.off?.('data', onData);
+        const answer = chunk.trim().toLowerCase();
+        resolve(answer === 'y' || answer === 'yes');
+      };
+      stdin.on?.('data', onData);
+    });
+    if (!confirmed) {
+      if (jsonOutput) console.log(JSON.stringify({ status: 'aborted', reason: 'user_declined' }));
+      else console.log('Aborted. Brain untouched.');
+      process.exit(0);
+    }
+  }
+
+  const { preservePgliteDirAndReinit, buildPgliteReinitArgsFromConfig } =
+    await import('./reinit-pglite.ts');
+  try {
+    const result = await preservePgliteDirAndReinit({
+      dbPath,
+      backupPath,
+      initArgs: buildPgliteReinitArgsFromConfig(cfg, dbPath, { jsonOutput }),
+      jsonOutput,
+      syncAfter: !noSync,
+    });
+    if (jsonOutput) {
+      console.log(JSON.stringify({
+        status: 'success',
+        brain_path: result.brainPath,
+        backup_path: result.backupPath,
+        synced: result.synced,
+      }));
+    } else {
+      console.log('');
+      console.log('PGLite rebuild complete.');
+      console.log(`  Fresh brain: ${result.brainPath}`);
+      console.log(`  Preserved old data dir: ${result.backupPath}`);
+      if (!result.synced) {
+        console.log('  Sync skipped or did not complete. Run `gbrain sync` to repopulate from sources.');
+      }
+    }
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    if (jsonOutput) console.log(JSON.stringify({ status: 'error', reason: 'rebuild_failed', message }));
+    else console.error(message);
+    process.exit(1);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/src/commands/reinit-pglite.ts
+++ b/src/commands/reinit-pglite.ts
@@ -19,8 +19,9 @@
  */
 
 import { existsSync, renameSync, statSync } from 'fs';
-import { dirname } from 'path';
-import { loadConfig, loadConfigFileOnly, gbrainPath } from '../core/config.ts';
+import { join } from 'path';
+import { loadConfig, loadConfigFileOnly, gbrainPath, isThinClient, type GBrainConfig } from '../core/config.ts';
+import { acquireLock, acquireMaintenanceLock, releaseLock, type LockHandle } from '../core/pglite-lock.ts';
 
 interface ReinitOpts {
   embeddingModel: string;
@@ -31,6 +32,20 @@ interface ReinitOpts {
   noSync: boolean;
 }
 
+export interface PreservePgliteDirAndReinitOpts {
+  dbPath: string;
+  backupPath: string;
+  initArgs: string[];
+  jsonOutput: boolean;
+  syncAfter: boolean;
+}
+
+export interface PreservePgliteDirAndReinitResult {
+  brainPath: string;
+  backupPath: string;
+  synced: boolean;
+}
+
 export async function runReinitPglite(args: string[]): Promise<void> {
   const opts = parseArgs(args);
 
@@ -38,6 +53,13 @@ export async function runReinitPglite(args: string[]): Promise<void> {
   // works there and migrating data is non-destructive — wipe-and-reinit
   // on Postgres would drop the entire brain.
   const cfg = loadConfig();
+  if (isThinClient(cfg)) {
+    fail(
+      opts.jsonOutput,
+      'thin_client',
+      `gbrain reinit-pglite requires a local PGLite brain. This install is a thin client of ${cfg!.remote_mcp!.mcp_url}. Run it on the remote host.`,
+    );
+  }
   if (cfg?.engine !== 'pglite') {
     fail(
       opts.jsonOutput,
@@ -120,18 +142,6 @@ export async function runReinitPglite(args: string[]): Promise<void> {
   const existingFile = loadConfigFileOnly();
   void existingFile; // referenced for the comment above; init.ts handles the merge
 
-  try {
-    renameSync(dbPath, bakPath);
-  } catch (e: unknown) {
-    fail(
-      opts.jsonOutput,
-      'backup_failed',
-      `Failed to back up brain to ${bakPath}: ${e instanceof Error ? e.message : String(e)}`,
-    );
-  }
-
-  if (!opts.jsonOutput) console.log(`Backed up brain to ${bakPath}`);
-
   // Step 2: re-init with the new model/dimensions. Delegate to runInit
   // so we go through the full Lane B precedence chain + dim-mismatch
   // detector + saveConfig merge.
@@ -145,54 +155,135 @@ export async function runReinitPglite(args: string[]): Promise<void> {
   }
   if (opts.jsonOutput) initArgs.push('--json');
 
-  const { runInit } = await import('./init.ts');
-  await runInit(initArgs);
-
-  // Step 3: re-sync (unless --no-sync). Best-effort because the user
-  // already has a working brain; sync failure shouldn't roll back.
-  if (!opts.noSync) {
-    if (!opts.jsonOutput) console.log('');
-    if (!opts.jsonOutput) console.log('Re-syncing brain repo...');
-    try {
-      // Need an engine handle to call runSync. Open one against the
-      // freshly-init'd brain.
-      const { createEngine } = await import('../core/engine-factory.ts');
-      const newCfg = loadConfig();
-      if (!newCfg) {
-        if (!opts.jsonOutput) console.error('Warning: no config after reinit; skipping sync. Run `gbrain sync` manually.');
-        return;
-      }
-      const engine = await createEngine({ engine: 'pglite' });
-      await engine.connect({ database_path: newCfg.database_path || dbPath, engine: 'pglite' });
-      try {
-        const { runSync } = await import('./sync.ts');
-        await runSync(engine, []);
-      } finally {
-        try { await engine.disconnect(); } catch { /* best-effort */ }
-      }
-    } catch (e: unknown) {
-      if (!opts.jsonOutput) {
-        console.error('');
-        console.error(`Warning: sync after reinit failed (${e instanceof Error ? e.message : String(e)}).`);
-        console.error('The brain is initialized but empty. Run \`gbrain sync\` to populate it.');
-      }
-    }
+  let result: PreservePgliteDirAndReinitResult;
+  try {
+    result = await preservePgliteDirAndReinit({
+      dbPath,
+      backupPath: bakPath,
+      initArgs,
+      jsonOutput: opts.jsonOutput,
+      syncAfter: !opts.noSync,
+    });
+  } catch (e: unknown) {
+    fail(
+      opts.jsonOutput,
+      'reinit_failed',
+      e instanceof Error ? e.message : String(e),
+    );
   }
+  if (!opts.jsonOutput) console.log(`Backed up brain to ${result.backupPath}`);
 
   if (opts.jsonOutput) {
     console.log(JSON.stringify({
       status: 'success',
-      brain_path: dbPath,
-      backup_path: bakPath,
+      brain_path: result.brainPath,
+      backup_path: result.backupPath,
       embedding_model: opts.embeddingModel,
       embedding_dimensions: opts.embeddingDimensions,
-      synced: !opts.noSync,
+      synced: result.synced,
     }));
   } else {
     console.log('');
     console.log('Reinit complete. To roll back:');
     console.log(`  mv ${bakPath} ${dbPath}`);
   }
+}
+
+export async function preservePgliteDirAndReinit(
+  opts: PreservePgliteDirAndReinitOpts,
+): Promise<PreservePgliteDirAndReinitResult> {
+  let maintenanceLock: LockHandle | null = null;
+  let dataLock: LockHandle | null = null;
+  try {
+    maintenanceLock = await acquireMaintenanceLock(opts.dbPath);
+    dataLock = await acquireLock(opts.dbPath);
+
+    try {
+      renameSync(opts.dbPath, opts.backupPath);
+      if (dataLock.lockDir) {
+        dataLock.lockDir = join(opts.backupPath, '.gbrain-lock');
+        dataLock.lockPath = join(dataLock.lockDir, 'lock');
+      }
+    } catch (e: unknown) {
+      throw new Error(`Failed to back up brain to ${opts.backupPath}: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      if (dataLock?.acquired) {
+        try { await releaseLock(dataLock); } catch { /* best-effort cleanup */ }
+        dataLock = null;
+      }
+    }
+
+    const { runInit } = await import('./init.ts');
+    await withOptionalStdoutSilence(opts.jsonOutput, () => runInit(opts.initArgs));
+
+    let synced = false;
+    if (opts.syncAfter) {
+      if (!opts.jsonOutput) console.log('');
+      if (!opts.jsonOutput) console.log('Re-syncing brain repo...');
+      try {
+        const { createEngine } = await import('../core/engine-factory.ts');
+        const newCfg = loadConfig();
+        if (!newCfg) {
+          if (!opts.jsonOutput) console.error('Warning: no config after reinit; skipping sync. Run `gbrain sync` manually.');
+          return { brainPath: opts.dbPath, backupPath: opts.backupPath, synced: false };
+        }
+        const engine = await createEngine({ engine: 'pglite' });
+        await engine.connect({ database_path: newCfg.database_path || opts.dbPath, engine: 'pglite' });
+        try {
+          const { runSync } = await import('./sync.ts');
+          await withOptionalStdoutSilence(opts.jsonOutput, () => runSync(engine, []));
+          synced = true;
+        } finally {
+          try { await engine.disconnect(); } catch { /* best-effort */ }
+        }
+      } catch (e: unknown) {
+        if (!opts.jsonOutput) {
+          console.error('');
+          console.error(`Warning: sync after reinit failed (${e instanceof Error ? e.message : String(e)}).`);
+          console.error('The brain is initialized but empty. Run `gbrain sync` to populate it.');
+        }
+      }
+    }
+
+    return { brainPath: opts.dbPath, backupPath: opts.backupPath, synced };
+  } finally {
+    if (dataLock?.acquired) {
+      try { await releaseLock(dataLock); } catch { /* best-effort cleanup */ }
+    }
+    if (maintenanceLock?.acquired) {
+      try { await releaseLock(maintenanceLock); } catch { /* best-effort cleanup */ }
+    }
+  }
+}
+
+async function withOptionalStdoutSilence<T>(
+  silence: boolean,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!silence) return fn();
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    return await fn();
+  } finally {
+    console.log = originalLog;
+  }
+}
+
+export function buildPgliteReinitArgsFromConfig(
+  cfg: GBrainConfig,
+  dbPath: string,
+  opts?: { jsonOutput?: boolean },
+): string[] {
+  const initArgs = ['--pglite', '--path', dbPath];
+  if (cfg.embedding_model) {
+    initArgs.push('--embedding-model', cfg.embedding_model);
+  }
+  if (cfg.embedding_dimensions) {
+    initArgs.push('--embedding-dimensions', String(cfg.embedding_dimensions));
+  }
+  if (opts?.jsonOutput) initArgs.push('--json');
+  return initArgs;
 }
 
 function parseArgs(args: string[]): ReinitOpts {

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -146,6 +146,11 @@ export function computeSnapshotSchemaHash(
  * `macos-26-3` — the pre-existing #223 hint signature (early macOS
  *   26.3 builds shipped a broken WASM runtime).
  *
+ * `pglite-data-dir-recovery-candidate` — persistent dataDir existed
+ *   before PGlite.create() and looked like a PGLite/Postgres data
+ *   directory. This is only a recovery/rebuild hint, not a corruption
+ *   diagnosis.
+ *
  * `unknown` — falls through to a generic hint that still names the
  *   doctor command and the most-common-cause link.
  *
@@ -154,14 +159,95 @@ export function computeSnapshotSchemaHash(
  * errors). Match the literal `$$bunfs` marker OR ENOENT+pglite.data
  * co-occurrence.
  */
-export type PgliteInitFailure = 'bunfs' | 'macos-26-3' | 'unknown';
+export type PgliteInitFailure =
+  | 'bunfs'
+  | 'macos-26-3'
+  | 'pglite-data-dir-recovery-candidate'
+  | 'unknown';
 
-export function classifyPgliteInitError(message: string): PgliteInitFailure {
+export type PgliteDataDirPreflightSnapshot = {
+  persistent: boolean;
+  exists: boolean;
+  isDirectory?: boolean;
+  entries?: string[];
+  hasPgVersion?: boolean;
+  hasBaseDir?: boolean;
+  hasGlobalDir?: boolean;
+  hasPgWalDir?: boolean;
+  readError?: string;
+};
+
+export function isPgliteDataDirRecoveryCandidate(
+  snapshot?: PgliteDataDirPreflightSnapshot,
+): boolean {
+  if (!snapshot?.persistent || !snapshot.exists || snapshot.isDirectory === false) return false;
+  if (snapshot.hasPgVersion) return true;
+  if (snapshot.hasBaseDir && snapshot.hasGlobalDir) return true;
+
+  const entries = new Set((snapshot.entries ?? []).map((entry) => entry.toLowerCase()));
+  return entries.has('pg_version') || (entries.has('base') && entries.has('global'));
+}
+
+export function classifyPgliteInitError(
+  message: string,
+  dataDirPreflight?: PgliteDataDirPreflightSnapshot,
+): PgliteInitFailure {
   if (/\$\$bunfs|ENOENT[\s\S]*pglite\.data/i.test(message)) return 'bunfs';
   if (/abort.*runtime|macos.*26\.3|wasm.*runtime/i.test(message)) {
     return 'macos-26-3';
   }
+  if (isPgliteDataDirRecoveryCandidate(dataDirPreflight)) {
+    return 'pglite-data-dir-recovery-candidate';
+  }
   return 'unknown';
+}
+
+function snapshotPgliteDataDirBeforeCreate(
+  dataDir: string | undefined,
+): PgliteDataDirPreflightSnapshot | undefined {
+  if (!dataDir) return undefined;
+  try {
+    // Lazy require keeps this file testable in non-Node-compatible bundles.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('node:fs') as typeof import('node:fs');
+    if (!fs.existsSync(dataDir)) {
+      return { persistent: true, exists: false };
+    }
+
+    const stat = fs.statSync(dataDir);
+    if (!stat.isDirectory()) {
+      return { persistent: true, exists: true, isDirectory: false };
+    }
+
+    const entries = fs.readdirSync(dataDir);
+    const isChildDir = (name: string): boolean => {
+      try {
+        return fs.statSync(`${dataDir}/${name}`).isDirectory();
+      } catch {
+        return false;
+      }
+    };
+    const hasPgVersion = entries.includes('PG_VERSION');
+    const hasBaseDir = entries.includes('base') && isChildDir('base');
+    const hasGlobalDir = entries.includes('global') && isChildDir('global');
+    const hasPgWalDir = entries.includes('pg_wal') && isChildDir('pg_wal');
+    return {
+      persistent: true,
+      exists: true,
+      isDirectory: true,
+      entries,
+      hasPgVersion,
+      hasBaseDir,
+      hasGlobalDir,
+      hasPgWalDir,
+    };
+  } catch (err) {
+    return {
+      persistent: true,
+      exists: true,
+      readError: err instanceof Error ? err.message : String(err),
+    };
+  }
 }
 
 export function buildPgliteInitErrorMessage(
@@ -183,6 +269,11 @@ export function buildPgliteInitErrorMessage(
       hint =
         '  This is most commonly the macOS 26.3 WASM bug:\n' +
         '  https://github.com/garrytan/gbrain/issues/223';
+      break;
+    case 'pglite-data-dir-recovery-candidate':
+      hint =
+        '  The existing PGLite data directory may need recovery/rebuild.\n' +
+        '  Fix: run `gbrain doctor --rebuild-pglite` and retry.';
       break;
     case 'unknown':
     default:
@@ -270,6 +361,7 @@ export class PGLiteEngine implements BrainEngine {
     // a snapshot/restore around these awaits does NOT contain them. That is
     // why the CLI's exit paths read gbrain's own verdict
     // (cli-force-exit.ts currentExitCode), never ambient process.exitCode.
+    const dataDirPreflight = snapshotPgliteDataDirBeforeCreate(dataDir);
     try {
       this._db = await preservingProcessExitCode(() =>
         PGlite.create({
@@ -286,7 +378,9 @@ export class PGLiteEngine implements BrainEngine {
       // pglite.data WASM payload). Route the hint by failure shape so
       // users get the right next step.
       const original = err instanceof Error ? err.message : String(err);
-      const verdict = classifyPgliteInitError(original);
+      const verdict = dataDirPreflight
+        ? classifyPgliteInitError(original, dataDirPreflight)
+        : classifyPgliteInitError(original);
       const wrapped = new Error(buildPgliteInitErrorMessage(verdict, original));
       // Release the lock so a fresh process can try again; leaking the lock
       // here turns a recoverable init error into a stuck-brain state.

--- a/src/core/pglite-lock.ts
+++ b/src/core/pglite-lock.ts
@@ -18,6 +18,7 @@ import { mkdirSync, existsSync, readFileSync, writeFileSync, rmSync, statSync } 
 import { join } from 'path';
 
 const LOCK_DIR_NAME = '.gbrain-lock';
+const MAINTENANCE_LOCK_SUFFIX = '.maintenance-lock';
 const LOCK_FILE = 'lock';
 
 // #2058: refresh the lock's `refreshed_at` while held so a long-running but
@@ -97,6 +98,11 @@ function getLockDir(dataDir: string | undefined): string {
   return join(dataDir, LOCK_DIR_NAME);
 }
 
+function getMaintenanceLockDir(dataDir: string | undefined): string {
+  if (!dataDir) return '';
+  return `${dataDir}${MAINTENANCE_LOCK_SUFFIX}`;
+}
+
 function isProcessAlive(pid: number): boolean {
   try {
     // Sending signal 0 checks existence without actually sending a signal
@@ -128,6 +134,30 @@ export async function acquireLock(dataDir: string | undefined, opts?: { timeoutM
   const startTime = Date.now();
 
   while (Date.now() - startTime < timeoutMs) {
+    const maintenanceLockDir = getMaintenanceLockDir(dataDir);
+    if (maintenanceLockDir && existsSync(maintenanceLockDir)) {
+      const lockPath = join(maintenanceLockDir, LOCK_FILE);
+      try {
+        const lockData = JSON.parse(readFileSync(lockPath, 'utf-8'));
+        const lockPid = lockData.pid as number;
+        const lockTime = lockData.acquired_at as number;
+        const alive = isProcessAlive(lockPid);
+        const lastRefresh = (lockData.refreshed_at as number | undefined) ?? lockTime;
+        const sinceRefresh = Date.now() - lastRefresh;
+        if (lockPid === process.pid) {
+          // Rebuild/reinit owns the maintenance lock and may open the freshly
+          // initialized data dir while other processes are held off.
+        } else if (!alive || sinceRefresh > stealGraceMs()) {
+          try { rmSync(maintenanceLockDir, { recursive: true, force: true }); } catch { /* race condition */ }
+        } else {
+          await new Promise(r => setTimeout(r, 1000));
+          continue;
+        }
+      } catch {
+        try { rmSync(maintenanceLockDir, { recursive: true, force: true }); } catch { /* race condition */ }
+      }
+    }
+
     // Check for stale lock first
     if (existsSync(lockDir)) {
       const lockPath = join(lockDir, LOCK_FILE);
@@ -204,6 +234,67 @@ export async function acquireLock(dataDir: string | undefined, opts?: { timeoutM
 
   // Should not reach here, but just in case
   throw new Error(`GBrain: Timed out waiting for PGLite lock.`);
+}
+
+/**
+ * Acquire a sibling maintenance lock for data-dir replacement operations.
+ *
+ * The normal PGLite lock intentionally lives inside the data directory. During
+ * rebuild/reinit we rename that directory, so the in-dir lock moves with it.
+ * This sibling lock stays at the stable target path and tells new openers to
+ * wait until the replacement data dir has been initialized.
+ */
+export async function acquireMaintenanceLock(
+  dataDir: string | undefined,
+  opts?: { timeoutMs?: number },
+): Promise<LockHandle> {
+  const lockDir = getMaintenanceLockDir(dataDir);
+  if (!lockDir) return { lockDir: '', acquired: true };
+  const timeoutMs = opts?.timeoutMs ?? 30_000;
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    if (existsSync(lockDir)) {
+      const lockPath = join(lockDir, LOCK_FILE);
+      try {
+        const lockData = JSON.parse(readFileSync(lockPath, 'utf-8'));
+        const lockPid = lockData.pid as number;
+        const lockTime = lockData.acquired_at as number;
+        const alive = isProcessAlive(lockPid);
+        const lastRefresh = (lockData.refreshed_at as number | undefined) ?? lockTime;
+        const sinceRefresh = Date.now() - lastRefresh;
+        if (!alive || sinceRefresh > stealGraceMs()) {
+          try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition */ }
+        } else {
+          await new Promise(r => setTimeout(r, 1000));
+          continue;
+        }
+      } catch {
+        try { rmSync(lockDir, { recursive: true, force: true }); } catch { /* race condition */ }
+      }
+    }
+
+    try {
+      mkdirSync(lockDir, { recursive: false });
+      const lockPath = join(lockDir, LOCK_FILE);
+      const now = Date.now();
+      writeFileSync(lockPath, JSON.stringify({
+        pid: process.pid,
+        acquired_at: now,
+        refreshed_at: now,
+        command: process.argv.slice(1).join(' '),
+      }), { mode: 0o644 });
+      const ownerToken = tokenOf({ pid: process.pid, acquired_at: now });
+      return { lockDir, acquired: true, lockPath, ownerToken, heartbeat: startHeartbeat(lockPath, ownerToken) };
+    } catch {
+      if (Date.now() - startTime >= timeoutMs) {
+        throw new Error(`GBrain: Timed out waiting for PGLite maintenance lock. Remove ${lockDir} and try again.`);
+      }
+      await new Promise(r => setTimeout(r, 500));
+    }
+  }
+
+  throw new Error(`GBrain: Timed out waiting for PGLite maintenance lock.`);
 }
 
 /**

--- a/test/doctor-rebuild-pglite.serial.test.ts
+++ b/test/doctor-rebuild-pglite.serial.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const REPO = new URL('..', import.meta.url).pathname.replace(/\/$/, '');
+const SKIP = process.env.GBRAIN_SKIP_SUBPROCESS_TESTS === '1';
+
+async function runCli(
+  args: string[],
+  env: Record<string, string>,
+  timeoutMs: number,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(['bun', 'run', `${REPO}/src/cli.ts`, ...args], {
+    cwd: REPO,
+    env: { ...process.env, ...env, GBRAIN_PGLITE_SNAPSHOT: '' },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const killer = setTimeout(() => {
+    try { proc.kill('SIGKILL'); } catch { /* already dead */ }
+  }, timeoutMs);
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { exitCode, stdout, stderr };
+  } finally {
+    clearTimeout(killer);
+  }
+}
+
+describe('gbrain doctor --rebuild-pglite', () => {
+  test.skipIf(SKIP)('runs before normal doctor DB connect and emits one JSON envelope', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-doctor-rebuild-'));
+    try {
+      const dotgbrain = join(home, '.gbrain');
+      const dbPath = join(dotgbrain, 'brain.pglite');
+      mkdirSync(dotgbrain, { recursive: true });
+      writeFileSync(join(dotgbrain, 'config.json'), JSON.stringify({
+        engine: 'pglite',
+        database_path: dbPath,
+        embedding_dimensions: 1536,
+      }) + '\n');
+
+      const env = {
+        HOME: home,
+        GBRAIN_HOME: home,
+      };
+
+      const init = await runCli(['init', '--migrate-only'], env, 90_000);
+      if (init.exitCode !== 0) {
+        console.error('--- init stdout ---\n' + init.stdout);
+        console.error('--- init stderr ---\n' + init.stderr);
+      }
+      expect(init.exitCode).toBe(0);
+
+      const rebuild = await runCli(
+        ['doctor', '--rebuild-pglite', '--yes', '--no-sync', '--json'],
+        env,
+        120_000,
+      );
+      if (rebuild.exitCode !== 0) {
+        console.error('--- rebuild stdout ---\n' + rebuild.stdout);
+        console.error('--- rebuild stderr ---\n' + rebuild.stderr);
+      }
+      expect(rebuild.exitCode).toBe(0);
+
+      const parsed = JSON.parse(rebuild.stdout) as {
+        status: string;
+        brain_path: string;
+        backup_path: string;
+        synced: boolean;
+      };
+      expect(parsed.status).toBe('success');
+      expect(parsed.brain_path).toBe(dbPath);
+      expect(parsed.backup_path).toContain(`${dbPath}.broken-`);
+      expect(parsed.synced).toBe(false);
+    } finally {
+      try { rmSync(home, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  }, 300_000);
+});

--- a/test/pglite-init-classifier.test.ts
+++ b/test/pglite-init-classifier.test.ts
@@ -17,6 +17,8 @@ import { describe, test, expect } from 'bun:test';
 import {
   classifyPgliteInitError,
   buildPgliteInitErrorMessage,
+  isPgliteDataDirRecoveryCandidate,
+  type PgliteDataDirPreflightSnapshot,
 } from '../src/core/pglite-engine.ts';
 
 describe('classifyPgliteInitError', () => {
@@ -51,6 +53,71 @@ describe('classifyPgliteInitError', () => {
   test('case-insensitive matching on bunfs marker', () => {
     expect(classifyPgliteInitError('SYSCALL ENOENT on /$$BUNFS/root')).toBe('bunfs');
   });
+
+  test('persistent existing PGLite-shaped data dir can be a recovery candidate', () => {
+    const snapshot: PgliteDataDirPreflightSnapshot = {
+      persistent: true,
+      exists: true,
+      isDirectory: true,
+      entries: ['PG_VERSION', 'base', 'global', 'pg_wal'],
+      hasPgVersion: true,
+      hasBaseDir: true,
+      hasGlobalDir: true,
+      hasPgWalDir: true,
+    };
+    expect(classifyPgliteInitError('Aborted(native code)', snapshot)).toBe(
+      'pglite-data-dir-recovery-candidate',
+    );
+  });
+
+  test('data-dir recovery candidate does not apply to in-memory or fresh missing dataDir', () => {
+    expect(classifyPgliteInitError('Aborted(native code)', {
+      persistent: false,
+      exists: false,
+    })).toBe('unknown');
+    expect(classifyPgliteInitError('Aborted(native code)', {
+      persistent: true,
+      exists: false,
+    })).toBe('unknown');
+  });
+
+  test('known bunfs and macOS signatures keep precedence over data-dir snapshot', () => {
+    const snapshot: PgliteDataDirPreflightSnapshot = {
+      persistent: true,
+      exists: true,
+      isDirectory: true,
+      hasPgVersion: true,
+    };
+    expect(classifyPgliteInitError('ENOENT: cannot open pglite.data', snapshot)).toBe(
+      'bunfs',
+    );
+    expect(classifyPgliteInitError(
+      'abort() called from wasm runtime on macOS 26.3 build',
+      snapshot,
+    )).toBe(
+      'macos-26-3',
+    );
+  });
+});
+
+describe('isPgliteDataDirRecoveryCandidate', () => {
+  test('accepts fabricated Postgres-shaped snapshot entries', () => {
+    expect(isPgliteDataDirRecoveryCandidate({
+      persistent: true,
+      exists: true,
+      isDirectory: true,
+      entries: ['base', 'global'],
+    })).toBe(true);
+  });
+
+  test('rejects generic non-empty persistent directories', () => {
+    expect(isPgliteDataDirRecoveryCandidate({
+      persistent: true,
+      exists: true,
+      isDirectory: true,
+      entries: ['README.md', 'tmp'],
+    })).toBe(false);
+  });
 });
 
 describe('buildPgliteInitErrorMessage — hint routing', () => {
@@ -81,10 +148,24 @@ describe('buildPgliteInitErrorMessage — hint routing', () => {
   });
 
   test('all verdicts produce the canonical header line', () => {
-    for (const v of ['bunfs', 'macos-26-3', 'unknown'] as const) {
+    const verdicts = [
+      'bunfs',
+      'macos-26-3',
+      'pglite-data-dir-recovery-candidate',
+      'unknown',
+    ] as const;
+    for (const v of verdicts) {
       const msg = buildPgliteInitErrorMessage(v, original);
       expect(msg.startsWith('PGLite failed to initialize its WASM runtime.')).toBe(true);
     }
+  });
+
+  test('data-dir recovery candidate surfaces rebuild hint and avoids corruption wording', () => {
+    const msg = buildPgliteInitErrorMessage('pglite-data-dir-recovery-candidate', original);
+    expect(msg).toContain('existing PGLite data directory may need recovery/rebuild');
+    expect(msg).toContain('gbrain doctor --rebuild-pglite');
+    expect(msg).not.toMatch(/wal-corruption|WAL corruption/i);
+    expect(msg).toContain(original);
   });
 });
 

--- a/test/pglite-lock.test.ts
+++ b/test/pglite-lock.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { acquireLock, releaseLock, type LockHandle } from '../src/core/pglite-lock';
+import { acquireLock, acquireMaintenanceLock, releaseLock, type LockHandle } from '../src/core/pglite-lock';
 import { withEnv } from './helpers/with-env.ts';
 
 const TEST_DIR = join(tmpdir(), 'gbrain-lock-test-' + process.pid);
@@ -84,6 +84,20 @@ describe('pglite-lock', () => {
     expect(lockData.command).toBeDefined();
 
     await releaseLock(lock);
+  });
+
+  test('maintenance lock lets its owner initialize while blocking stale rename races', async () => {
+    const maintenance = await acquireMaintenanceLock(TEST_DIR);
+    expect(maintenance.acquired).toBe(true);
+    expect(existsSync(`${TEST_DIR}.maintenance-lock`)).toBe(true);
+
+    const lock = await acquireLock(TEST_DIR);
+    expect(lock.acquired).toBe(true);
+    expect(existsSync(join(TEST_DIR, '.gbrain-lock'))).toBe(true);
+
+    await releaseLock(lock);
+    await releaseLock(maintenance);
+    expect(existsSync(`${TEST_DIR}.maintenance-lock`)).toBe(false);
   });
 
   test('releases lock on disconnect even if DB close fails', async () => {

--- a/test/v0_37_gap_fill.serial.test.ts
+++ b/test/v0_37_gap_fill.serial.test.ts
@@ -417,6 +417,26 @@ describe('reinit-pglite — backup + reinit', () => {
     expect(exits).toContain(1);
   });
 
+  test('builds init args from existing PGLite config for rebuild callers', async () => {
+    const { buildPgliteReinitArgsFromConfig } = await import('../src/commands/reinit-pglite.ts');
+    const dbPath = join(tmpHome, '.gbrain', 'brain.pglite');
+    expect(buildPgliteReinitArgsFromConfig({
+      engine: 'pglite',
+      database_path: dbPath,
+      embedding_model: 'zeroentropyai:zembed-1',
+      embedding_dimensions: 1280,
+    }, dbPath, { jsonOutput: true })).toEqual([
+      '--pglite',
+      '--path',
+      dbPath,
+      '--embedding-model',
+      'zeroentropyai:zembed-1',
+      '--embedding-dimensions',
+      '1280',
+      '--json',
+    ]);
+  });
+
   test('refuses when missing required --embedding-model / --embedding-dimensions', async () => {
     const { runReinitPglite } = await import('../src/commands/reinit-pglite.ts');
     const origExit = process.exit;


### PR DESCRIPTION
## Summary

Addresses recurring `Aborted()` crashes from PGLite (#223) that are usually unclean shutdowns / WAL recovery candidates rather than the originally-suspected macOS 26.3 WASM bug (per WilliamCourterWelch's diagnosis in the thread).

Two commits, complementary:

- **e2fc66c5** — adds a conservative `pglite-data-dir-recovery-candidate` verdict in `src/core/pglite-engine.ts`. Takes a preflight filesystem snapshot before `PGlite.create()` so post-failure classification doesn't conflate startup residue with pre-existing crash residue. Wrapped error now pastes the recovery command.
- **4861e00d** — adds opt-in `gbrain doctor --rebuild-pglite`, routed in `src/cli.ts` **before** the normal doctor engine connect (mirrors `reinit-pglite`). Extracts a lock-safe preserve/reinit helper that both commands share. Adds a sibling maintenance lock to prevent rename/reinit races. Refuses on thin-client config. Real subprocess smoke test for the rebuild JSON behavior.

Per the maintainer's request in the issue thread for a `gbrain doctor --rebuild-on-pglite-wasm-abort` recovery path and clearer error wrap in `pglite-engine.ts connect()`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `git diff --check` — clean
- [x] `bun test test/pglite-init-classifier.test.ts test/pglite-lock.test.ts test/doctor-rebuild-pglite.serial.test.ts` — green
- [x] `bun test test/v0_37_gap_fill.serial.test.ts test/fix-wave-structural.test.ts` — green (broader smoke, no regressions)
- [x] Manual repro: hit `Aborted()` on a corrupted data dir → wrapped error now names the rebuild command → `gbrain doctor --rebuild-pglite --yes` recovers via put+search round-trip

## Design notes

- Verdict deliberately named "recovery-candidate" + uses "may be" wording rather than overclaiming WAL corruption — `postmaster.pid` alone, or non-empty `pg_wal/`, are not reliable corruption signals.
- Rebuild is opt-in only; no prompts from engine code (would hang `gbrain serve` + other noninteractive callers).
- Lock released **before** the data-dir rename so the in-dir `.gbrain-lock` doesn't get carried into the `.broken-<ts>` backup as a stale lock.
- Consistent with upstream electric-sql/pglite#994 declining automatic library-level repair — recovery is an explicit user-driven tool here.
