### PR TITLE
feat(auth): federated_write — per-write source authorization (write-side mirror of federated_read)

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -344,6 +344,7 @@ interface RegisterClientArgs {
   scopes: string;
   sourceId: string;
   federatedRead: string[] | undefined;
+  federatedWrite: string[] | undefined;
   redirectUris: string[];
   tokenEndpointAuthMethod: string | undefined;
 }
@@ -354,6 +355,7 @@ export function parseRegisterClientArgs(args: string[]): RegisterClientArgs {
     scopes: 'read',
     sourceId: 'default',
     federatedRead: undefined,
+    federatedWrite: undefined,
     redirectUris: [],
     tokenEndpointAuthMethod: undefined,
   };
@@ -383,6 +385,11 @@ export function parseRegisterClientArgs(args: string[]): RegisterClientArgs {
         out.federatedRead = v.split(',').map(s => s.trim()).filter(Boolean);
         i += 2; break;
       }
+      case '--federated-write': {
+        const v = requireValue();
+        out.federatedWrite = v.split(',').map(s => s.trim()).filter(Boolean);
+        i += 2; break;
+      }
       case '--redirect-uri':
         out.redirectUris.push(requireValue());
         i += 2; break;
@@ -405,7 +412,7 @@ export function parseRegisterClientArgs(args: string[]): RegisterClientArgs {
 
 async function registerClient(name: string, args: string[]) {
   if (!name) {
-    console.error('Usage: auth register-client <name> [--grant-types G] [--scopes S] [--source SOURCE] [--federated-read SRC1,SRC2,...] [--redirect-uri URI ...] [--token-endpoint-auth-method client_secret_post|client_secret_basic|none]');
+    console.error('Usage: auth register-client <name> [--grant-types G] [--scopes S] [--source SOURCE] [--federated-read SRC1,SRC2,...] [--federated-write SRC1,SRC2,...] [--redirect-uri URI ...] [--token-endpoint-auth-method client_secret_post|client_secret_basic|none]');
     process.exit(1);
   }
   let parsed: RegisterClientArgs;
@@ -413,19 +420,23 @@ async function registerClient(name: string, args: string[]) {
     parsed = parseRegisterClientArgs(args);
   } catch (e: any) {
     console.error(`Error: ${e.message}`);
-    console.error('Usage: auth register-client <name> [--grant-types G] [--scopes S] [--source SOURCE] [--federated-read SRC1,SRC2,...] [--redirect-uri URI ...] [--token-endpoint-auth-method client_secret_post|client_secret_basic|none]');
+    console.error('Usage: auth register-client <name> [--grant-types G] [--scopes S] [--source SOURCE] [--federated-read SRC1,SRC2,...] [--federated-write SRC1,SRC2,...] [--redirect-uri URI ...] [--token-endpoint-auth-method client_secret_post|client_secret_basic|none]');
     process.exit(1);
   }
-  const { grantTypes, scopes, sourceId, federatedRead, redirectUris, tokenEndpointAuthMethod } = parsed;
+  const { grantTypes, scopes, sourceId, federatedRead, federatedWrite, redirectUris, tokenEndpointAuthMethod } = parsed;
 
   try {
     await withConfiguredSql(async (sql) => {
       const { GBrainOAuthProvider } = await import('../core/oauth-provider.ts');
       const provider = new GBrainOAuthProvider({ sql });
       const { clientId, clientSecret } = await provider.registerClientManual(
-        name, grantTypes, scopes, redirectUris, sourceId, federatedRead, tokenEndpointAuthMethod,
+        name, grantTypes, scopes, redirectUris, sourceId, federatedRead, tokenEndpointAuthMethod, federatedWrite,
       );
       const effectiveFederated = federatedRead && federatedRead.length > 0 ? federatedRead : [sourceId];
+      // federated_write defaults to '{}' (empty) when omitted: writes are locked
+      // to source_id, the pre-v118 behavior. Only an explicit --federated-write
+      // widens the write scope.
+      const effectiveFederatedWrite = federatedWrite && federatedWrite.length > 0 ? federatedWrite : [];
       const effectiveAuthMethod = tokenEndpointAuthMethod || 'client_secret_post';
       console.log(`OAuth client registered: "${name}"\n`);
       console.log(`  Client ID:           ${clientId}`);
@@ -441,7 +452,8 @@ async function registerClient(name: string, args: string[]) {
         console.log(`  Redirect URIs:       ${redirectUris.join(', ')}`);
       }
       console.log(`  Write source:        ${sourceId}`);
-      console.log(`  Federated reads:     ${effectiveFederated.join(', ')}\n`);
+      console.log(`  Federated reads:     ${effectiveFederated.join(', ')}`);
+      console.log(`  Federated writes:    ${effectiveFederatedWrite.length > 0 ? effectiveFederatedWrite.join(', ') : `<none — writes locked to ${sourceId}>`}\n`);
       if (clientSecret) {
         console.log('Save the client secret — it will not be shown again.');
       } else {

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -5270,6 +5270,42 @@ export const MIGRATIONS: Migration[] = [
         ON context_volunteer_events (source_id, slug);
     `,
   },
+  {
+    version: 118,
+    name: 'oauth_clients_federated_write_column',
+    // federated_write is the WRITE-side mirror of federated_read (#876).
+    // source_id (v60) is the single write-AUTHORITY axis; federated_read (v61)
+    // is the read-SCOPE array. federated_write is the write-SCOPE array: the
+    // set of sources a token may write to. Write ops choose a target source per
+    // call, authorized against `source_id ∪ federated_write` (resolveWriteSource
+    // in operations.ts). A "directorio" curator client can write to
+    // source_id='directorio' while also writing to ['campo', 'lideres'].
+    //
+    // Default '{}' (empty array) — UNLIKE federated_read, there is NO backfill.
+    // Empty means "writes are locked to source_id" (the pre-v118 behavior),
+    // which is exactly the safe default for every existing client. A client only
+    // gains multi-source write by an operator explicitly setting the column
+    // (via `--federated-write` at registration). Keep in sync with
+    // src/schema.sql, src/core/pglite-schema.ts, src/core/schema-embedded.ts.
+    idempotent: true,
+    sql: `
+      ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_write TEXT[] NOT NULL DEFAULT '{}';
+    `,
+  },
+  {
+    version: 119,
+    name: 'oauth_clients_federated_write_gin_index',
+    // GIN index for array-containment lookups, mirroring v65's
+    // idx_oauth_clients_federated_read. Write authorization checks the set in
+    // application code (resolveWriteSource), but the index keeps operator
+    // queries (`WHERE 'campo' = ANY(federated_write)`) and any future
+    // DB-side scoping cheap.
+    idempotent: true,
+    sql: `
+      CREATE INDEX IF NOT EXISTS idx_oauth_clients_federated_write
+        ON oauth_clients USING GIN (federated_write);
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/oauth-provider.ts
+++ b/src/core/oauth-provider.ts
@@ -568,18 +568,27 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     try {
       oauthRows = await this.sql`
         SELECT t.client_id, t.scopes, t.expires_at, t.resource, c.client_name,
-               c.source_id, c.federated_read
+               c.source_id, c.federated_read, c.federated_write
         FROM oauth_tokens t
         LEFT JOIN oauth_clients c ON c.client_id = t.client_id
         WHERE t.token_hash = ${tokenHash} AND t.token_type = 'access'
       `;
     } catch (err) {
       // v0.34.1: pre-v60 brain → source_id column missing. Pre-v61 brain →
-      // federated_read column missing. Both classes degrade to legacy
-      // projection so auth keeps working until the operator runs
-      // apply-migrations. Probe both column names so partial-upgrade brains
-      // (v60 applied but v61 didn't yet) also fall through cleanly.
-      if (isUndefinedColumnError(err, 'source_id') || isUndefinedColumnError(err, 'federated_read')) {
+      // federated_read column missing. Pre-v118 brain → federated_write column
+      // missing. All classes degrade to a narrower projection so auth keeps
+      // working until the operator runs apply-migrations. Probe each column
+      // name so partial-upgrade brains fall through cleanly.
+      if (isUndefinedColumnError(err, 'federated_write')) {
+        // Pre-v118 brain: source_id + federated_read present, no federated_write.
+        oauthRows = await this.sql`
+          SELECT t.client_id, t.scopes, t.expires_at, t.resource, c.client_name,
+                 c.source_id, c.federated_read
+          FROM oauth_tokens t
+          LEFT JOIN oauth_clients c ON c.client_id = t.client_id
+          WHERE t.token_hash = ${tokenHash} AND t.token_type = 'access'
+        `;
+      } else if (isUndefinedColumnError(err, 'source_id') || isUndefinedColumnError(err, 'federated_read')) {
         // Try the v60-only projection first (source_id but no federated_read).
         try {
           oauthRows = await this.sql`
@@ -624,6 +633,15 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
       const allowedSources = Array.isArray(federatedRaw)
         ? (federatedRaw as string[])
         : undefined;
+      // v118: federated_write normalization, same shape as federated_read.
+      // Array (post-v118 brain) → the write-scope set; undefined (pre-v118
+      // projection ran) → column missing on this brain. resolveWriteSource in
+      // operations.ts treats undefined the same as empty: writes stay locked to
+      // sourceId until an operator grants federated_write.
+      const federatedWriteRaw = row.federated_write;
+      const federatedWrite = Array.isArray(federatedWriteRaw)
+        ? (federatedWriteRaw as string[])
+        : undefined;
       return {
         token,
         clientId: row.client_id as string,
@@ -639,6 +657,9 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
         // operations.ts prefers this array over scalar sourceId when set
         // and non-empty.
         allowedSources,
+        // v118: federated write scope. resolveWriteSource in operations.ts
+        // authorizes a per-call write target against sourceId ∪ federatedWrite.
+        federatedWrite,
       } as CoreAuthInfo as SdkAuthInfo;
     }
 
@@ -857,6 +878,7 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     sourceId: string = 'default',
     federatedRead?: string[],
     tokenEndpointAuthMethod?: string,
+    federatedWrite?: string[],
   ): Promise<{ clientId: string; clientSecret?: string }> {
     // v0.28: ALLOWED_SCOPES allowlist. Reject `--scopes "read flying-unicorn"`
     // at registration so meaningless scope strings can't pile up in the DB.
@@ -888,6 +910,32 @@ export class GBrainOAuthProvider implements OAuthServerProvider {
     //   federated_read = [source_id] when omitted (a non-federated client
     //                    has read scope == write scope, the v0.33 default)
     const federated = federatedRead && federatedRead.length > 0 ? federatedRead : [sourceId];
+    // v118: federated_write is the WRITE-side mirror. Default '{}' (empty) when
+    // omitted — writes locked to source_id, the pre-v118 behavior. UNLIKE
+    // federated_read it does NOT default to [sourceId]: resolveWriteSource
+    // already admits ctx.sourceId, so an empty set is the no-op default.
+    const federatedW = federatedWrite && federatedWrite.length > 0 ? federatedWrite : [];
+    try {
+      await this.sql`
+        INSERT INTO oauth_clients (client_id, client_secret_hash, client_name, redirect_uris,
+                                    grant_types, scope, token_endpoint_auth_method,
+                                    client_id_issued_at,
+                                    source_id, federated_read, federated_write)
+        VALUES (${clientId}, ${secretHash}, ${name},
+                ${pgArray(redirectUris)}, ${pgArray(grantTypes)}, ${scopes}, ${authMethod}, ${now},
+                ${sourceId}, ${pgArray(federated)}, ${pgArray(federatedW)})
+      `;
+      return { clientId, clientSecret };
+    } catch (errW) {
+      // Pre-v118 brain: federated_write column missing. Fall back to the
+      // pre-v118 INSERT (source_id + federated_read), which carries its own
+      // cascade for pre-v60/pre-v61 brains. The federated_write grant is
+      // dropped until the operator runs apply-migrations — the client lands
+      // with writes locked to source_id (the safe pre-v118 default).
+      if (!isUndefinedColumnError(errW, 'federated_write')) {
+        throw errW;
+      }
+    }
     try {
       await this.sql`
         INSERT INTO oauth_clients (client_id, client_secret_hash, client_name, redirect_uris,

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -272,6 +272,25 @@ export interface AuthInfo {
    * case (back-compat).
    */
   allowedSources?: string[];
+  /**
+   * v118: array of source ids this OAuth client may WRITE to, beyond its
+   * single write-authority `sourceId`. The WRITE-side mirror of
+   * `allowedSources` (federated_read). Sourced from
+   * `oauth_clients.federated_write`.
+   *
+   * Write ops (`put_page`, `put_raw_data`) accept an optional per-call write
+   * target and authorize it via `resolveWriteSource`: the target must be in
+   * `{sourceId} ∪ federatedWrite` or the call is rejected. A "directorio"
+   * curator client with `sourceId='directorio'` and
+   * `federatedWrite=['campo','lideres']` can write to any of the three
+   * without re-minting tokens.
+   *
+   * Empty array `[]` (or undefined, on a pre-v118 brain) means "writes are
+   * locked to `sourceId`" — the pre-v118 default. Like `allowedSources`, an
+   * empty/attacker-supplied `[]` MUST NOT widen scope; resolveWriteSource only
+   * ever ADDS to the always-allowed `sourceId`.
+   */
+  federatedWrite?: string[];
 }
 
 export interface OperationContext {
@@ -468,6 +487,42 @@ export function resolveRequestedScope(
     return { sourceId: sourceIdParam };
   }
   return sourceScopeOpts(ctx);
+}
+
+/**
+ * v118: resolve the WRITE target source for a mutating op, authorized against
+ * the caller's grant. The write-side mirror of `resolveRequestedScope`.
+ *
+ * FAIL-CLOSED, mirroring the read-side defensive posture (`sourceScopeOpts` /
+ * `resolveRequestedScope`): the always-allowed set is `{ctx.sourceId}` plus
+ * the client's `federatedWrite` grant. A client-supplied `requested` source is
+ * NEVER trusted unchecked — it must be a member of that set or the call is
+ * rejected.
+ *
+ *   - no `requested` (omitted/empty)       → `ctx.sourceId` (UNCHANGED behavior;
+ *                                            pre-v118 clients never sent one)
+ *   - `requested` ∈ {sourceId} ∪ fedWrite  → `requested`
+ *   - `requested` ∉ that set               → throw permission_denied
+ *
+ * An empty / undefined `federatedWrite` collapses the allowed set to just
+ * `ctx.sourceId`, so omitting the grant preserves the single-source write lock.
+ * `ctx.sourceId` is REQUIRED on OperationContext (defaults to 'default'), so
+ * the always-allowed set is never empty.
+ */
+export function resolveWriteSource(ctx: OperationContext, requested?: string): string {
+  if (requested === undefined || requested === '') {
+    return ctx.sourceId;
+  }
+  const federated = ctx.auth?.federatedWrite;
+  const allowed = new Set<string>([ctx.sourceId, ...(federated ?? [])]);
+  if (allowed.has(requested)) {
+    return requested;
+  }
+  throw new OperationError(
+    'permission_denied',
+    `source '${requested}' not in this client's federated_write set`,
+    'Write to your source_id, or ask an operator to add this source to --federated-write.',
+  );
 }
 
 /**
@@ -699,6 +754,12 @@ const put_page: Operation = {
   params: {
     slug: { type: 'string', required: true, description: 'Page slug' },
     content: { type: 'string', required: true, description: 'Full markdown content with YAML frontmatter' },
+    // v118: optional per-call write target (the sala/source to write into).
+    // Authorized against the client's source_id ∪ federated_write set
+    // (resolveWriteSource). Omitted → writes to the client's source_id, the
+    // pre-v118 behavior. A client cannot widen scope by passing an out-of-grant
+    // source — the call is rejected.
+    source: { type: 'string', required: false, description: 'Target source/sala to write into. Must be the client\'s source_id or one of its federated_write sources. Omit to write to the client\'s default source_id.' },
     // v0.39.3.0 provenance write-through (WARN-8 + A1 + CV6). Optional fields
     // for trusted local callers (capture CLI, autopilot, dream cycle). Remote
     // MCP callers (ctx.remote !== false) have their values OVERRIDDEN with
@@ -713,6 +774,14 @@ const put_page: Operation = {
   scope: 'write',
   handler: async (ctx, p) => {
     const slug = p.slug as string;
+
+    // v118: resolve + authorize the write-target source. FAIL-CLOSED: a
+    // client-supplied `source` must be in {ctx.sourceId} ∪ federated_write or
+    // resolveWriteSource throws permission_denied. Runs BEFORE the dry-run
+    // short-circuit so preview calls surface the same rejection (matches the
+    // subagent-namespace check below). Omitted `source` → ctx.sourceId
+    // (unchanged pre-v118 behavior).
+    const writeSourceId = resolveWriteSource(ctx, p.source as string | undefined);
 
     // v0.39.3.0 CV6 trust gate for provenance write-through (WARN-8).
     // Only trusted LOCAL callers (ctx.remote === false — capture CLI,
@@ -775,7 +844,7 @@ const put_page: Operation = {
       }
     }
 
-    if (ctx.dryRun) return { dry_run: true, action: 'put_page', slug: p.slug };
+    if (ctx.dryRun) return { dry_run: true, action: 'put_page', slug: p.slug, source: writeSourceId };
     // Skip embedding when the AI gateway has no embedding provider configured.
     // Checks all auth env vars for the resolved provider, not just OPENAI_API_KEY,
     // so Gemini / Ollama / Voyage brains don't silently drop embeddings (Codex C2).
@@ -797,7 +866,7 @@ const put_page: Operation = {
       const resolved = await loadActivePack({
         cfg: loadConfig(),
         remote: ctx.remote === false ? false : true,
-        sourceId: ctx.sourceId,
+        sourceId: writeSourceId,
       });
       activePack = { page_types: resolved.manifest.page_types };
     } catch {
@@ -810,7 +879,8 @@ const put_page: Operation = {
       // markers (quarantine/content_flag/embed_skip). Fail-closed — anything
       // not strictly local is remote (matches CV6 / v0.26.9 F7b posture).
       remote: ctx.remote !== false,
-      ...(ctx.sourceId ? { sourceId: ctx.sourceId } : {}),
+      // v118: write to the authorized target source (resolveWriteSource).
+      ...(writeSourceId ? { sourceId: writeSourceId } : {}),
       // v0.39.0.0 T1.5: pack-aware type inference (loaded above; legacy
       // inferType behavior when undefined).
       ...(activePack ? { activePack } : {}),
@@ -873,7 +943,8 @@ const put_page: Operation = {
     const isSandboxSubagent = ctx.viaSubagent === true
       && !(Array.isArray(ctx.allowedSlugPrefixes) && ctx.allowedSlugPrefixes.length > 0);
     if (!ctx.dryRun && result.status !== 'error' && !isSandboxSubagent) {
-      const sourceId = ctx.sourceId ?? 'default';
+      // v118: write-through to disk under the authorized write-target source.
+      const sourceId = writeSourceId ?? 'default';
       const provenanceVia = ctx.remote === false ? 'put_page' : 'mcp:put_page';
       // Shared canonical write-through (also used by `gbrain brainstorm/lsd
       // --save`). Renders the file from the saved DB row and writes it
@@ -926,7 +997,7 @@ const put_page: Operation = {
       try {
         const enabled = await isAutoLinkEnabled(ctx.engine);
         if (enabled) {
-          autoLinks = await runAutoLink(ctx.engine, slug, result.parsedPage, ctx.sourceId ? { sourceId: ctx.sourceId } : undefined);
+          autoLinks = await runAutoLink(ctx.engine, slug, result.parsedPage, writeSourceId ? { sourceId: writeSourceId } : undefined);
         }
       } catch (e) {
         autoLinks = { error: e instanceof Error ? e.message : String(e) };
@@ -984,7 +1055,7 @@ const put_page: Operation = {
         },
         {
           engine: ctx.engine,
-          sourceId: ctx.sourceId ?? 'default',
+          sourceId: writeSourceId ?? 'default',
           sessionId: (ctx as { source_session?: string }).source_session ?? null,
           source: 'mcp:put_page',
           mode: 'queue',
@@ -2410,18 +2481,26 @@ const sync_brain: Operation = {
 
 const put_raw_data: Operation = {
   name: 'put_raw_data',
-  description: 'Store raw API response data for a page',
+  description: 'Store raw API response data for a page. `source` is the DATA provenance label (e.g. crustdata); `write_source` (v118) is the brain source/sala to write into, authorized against the client\'s source_id ∪ federated_write set.',
   params: {
     slug: { type: 'string', required: true },
-    source: { type: 'string', required: true, description: 'Data source (e.g., crustdata, happenstance)' },
+    source: { type: 'string', required: true, description: 'Data source label (e.g., crustdata, happenstance). NOT the write-target brain source — see write_source.' },
     data: { type: 'object', required: true, description: 'Raw data object' },
+    // v118: optional per-call write target (the sala/brain source to write
+    // into). Named `write_source` to avoid colliding with `source`, which here
+    // is the data-provenance label. Authorized via resolveWriteSource; omitted
+    // → the client's source_id (pre-v118 behavior).
+    write_source: { type: 'string', required: false, description: 'Target brain source/sala to write into. Must be the client\'s source_id or one of its federated_write sources. Omit to write to the client\'s default source_id.' },
   },
   mutating: true,
   scope: 'write',
   handler: async (ctx, p) => {
-    if (ctx.dryRun) return { dry_run: true, action: 'put_raw_data', slug: p.slug, source: p.source };
-    // v0.31.8 (D7 + D21): thread ctx.sourceId.
-    const sourceOpts = ctx.sourceId ? { sourceId: ctx.sourceId } : {};
+    // v118: resolve + authorize the write-target source FAIL-CLOSED, before the
+    // dry-run short-circuit so preview surfaces the rejection too.
+    const writeSourceId = resolveWriteSource(ctx, p.write_source as string | undefined);
+    if (ctx.dryRun) return { dry_run: true, action: 'put_raw_data', slug: p.slug, source: p.source, write_source: writeSourceId };
+    // v0.31.8 (D7 + D21): thread the authorized write-target source.
+    const sourceOpts = writeSourceId ? { sourceId: writeSourceId } : {};
     await ctx.engine.putRawData(p.slug as string, p.source as string, p.data as object, sourceOpts);
     return { status: 'ok' };
   },

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -785,6 +785,8 @@ export class PGLiteEngine implements BrainEngine {
           DEFAULT 'default' REFERENCES sources(id) ON DELETE SET NULL;
         ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_read TEXT[]
           NOT NULL DEFAULT '{}';
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_write TEXT[]
+          NOT NULL DEFAULT '{}';
       `);
     }
 

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -463,6 +463,8 @@ export class PGLiteEngine implements BrainEngine {
                 WHERE table_schema='public' AND table_name='oauth_clients' AND column_name='source_id') AS oauth_clients_source_id_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema='public' AND table_name='oauth_clients' AND column_name='federated_read') AS oauth_clients_federated_read_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='oauth_clients' AND column_name='federated_write') AS oauth_clients_federated_write_exists,
         EXISTS (SELECT 1 FROM information_schema.tables
                 WHERE table_schema='public' AND table_name='sources') AS sources_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
@@ -521,6 +523,7 @@ export class PGLiteEngine implements BrainEngine {
       oauth_clients_exists: boolean;
       oauth_clients_source_id_exists: boolean;
       oauth_clients_federated_read_exists: boolean;
+      oauth_clients_federated_write_exists: boolean;
       sources_exists: boolean;
       sources_archived_exists: boolean;
       sources_archived_at_exists: boolean;
@@ -568,7 +571,7 @@ export class PGLiteEngine implements BrainEngine {
     // FK to sources(id) + GIN index idx_oauth_clients_federated_read in
     // PGLITE_SCHEMA_SQL crash without them.
     const needsOauthClientsBootstrap = probe.oauth_clients_exists
-      && (!probe.oauth_clients_source_id_exists || !probe.oauth_clients_federated_read_exists);
+      && (!probe.oauth_clients_source_id_exists || !probe.oauth_clients_federated_read_exists || !probe.oauth_clients_federated_write_exists);
     // v0.26.5 (v34): sources.archived + archived_at + archive_expires_at added
     // for soft-delete lifecycle. Not directly referenced by indexes BUT
     // PGLITE_SCHEMA_SQL's `CREATE TABLE IF NOT EXISTS sources` is a no-op on

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -869,6 +869,7 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
   deleted_at              TIMESTAMPTZ,
   source_id               TEXT REFERENCES sources(id) ON DELETE RESTRICT,
   federated_read          TEXT[] NOT NULL DEFAULT '{}',
+  federated_write         TEXT[] NOT NULL DEFAULT '{}',
   -- v0.38 Slice 2 + 3: per-OAuth-client budget cap (v84) + agent binding (v85).
   -- bound_* columns are NULL on legacy clients (no agent scope by default).
   budget_usd_per_day      NUMERIC(10, 2) NULL,
@@ -884,10 +885,16 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
 -- read sources beyond its source_id). Migration v60 adds source_id;
 -- v61-v65 add federated_read + GIN index + flip FK to RESTRICT. Fresh
 -- installs land in the post-migration shape via the inline columns above.
+-- federated_write (v118) is the WRITE-side mirror of federated_read: the set
+-- of sources a token may write to (write ops choose the target per call,
+-- authorized against source_id ∪ federated_write). Empty '{}' = writes locked
+-- to source_id (the pre-v118 default).
 CREATE INDEX IF NOT EXISTS idx_oauth_clients_source_id
   ON oauth_clients(source_id) WHERE source_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_oauth_clients_federated_read
   ON oauth_clients USING GIN (federated_read);
+CREATE INDEX IF NOT EXISTS idx_oauth_clients_federated_write
+  ON oauth_clients USING GIN (federated_write);
 
 CREATE TABLE IF NOT EXISTS oauth_tokens (
   token_hash   TEXT PRIMARY KEY,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -418,6 +418,7 @@ export class PostgresEngine implements BrainEngine {
       oauth_clients_exists: boolean;
       oauth_clients_source_id_exists: boolean;
       oauth_clients_federated_read_exists: boolean;
+      oauth_clients_federated_write_exists: boolean;
       sources_exists: boolean;
       sources_archived_exists: boolean;
       sources_archived_at_exists: boolean;
@@ -472,6 +473,8 @@ export class PostgresEngine implements BrainEngine {
                 WHERE table_schema = current_schema() AND table_name = 'oauth_clients' AND column_name = 'source_id') AS oauth_clients_source_id_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema = current_schema() AND table_name = 'oauth_clients' AND column_name = 'federated_read') AS oauth_clients_federated_read_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'oauth_clients' AND column_name = 'federated_write') AS oauth_clients_federated_write_exists,
         EXISTS (SELECT 1 FROM information_schema.tables
                 WHERE table_schema = current_schema() AND table_name = 'sources') AS sources_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
@@ -541,7 +544,7 @@ export class PostgresEngine implements BrainEngine {
     // FK to sources(id) + GIN index idx_oauth_clients_federated_read in
     // SCHEMA_SQL crash without them.
     const needsOauthClientsBootstrap = probe.oauth_clients_exists
-      && (!probe.oauth_clients_source_id_exists || !probe.oauth_clients_federated_read_exists);
+      && (!probe.oauth_clients_source_id_exists || !probe.oauth_clients_federated_read_exists || !probe.oauth_clients_federated_write_exists);
     // v0.26.5 (v34): sources.archived + archived_at + archive_expires_at added
     // for soft-delete lifecycle. SCHEMA_SQL's `CREATE TABLE IF NOT EXISTS sources`
     // is a no-op on pre-existing sources tables (won't add columns), so the

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -770,6 +770,8 @@ export class PostgresEngine implements BrainEngine {
           DEFAULT 'default' REFERENCES sources(id) ON DELETE SET NULL;
         ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_read TEXT[]
           NOT NULL DEFAULT '{}';
+        ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS federated_write TEXT[]
+          NOT NULL DEFAULT '{}';
       `);
     }
 

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -629,6 +629,7 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
   deleted_at              TIMESTAMPTZ,
   source_id               TEXT REFERENCES sources(id) ON DELETE RESTRICT,
   federated_read          TEXT[] NOT NULL DEFAULT '{}',
+  federated_write         TEXT[] NOT NULL DEFAULT '{}',
   -- v0.38 Slice 2 + 3: per-client daily budget cap (v84) + agent binding (v85).
   budget_usd_per_day      NUMERIC(10, 2) NULL,
   bound_tools             TEXT[] NULL,
@@ -641,10 +642,16 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
 -- v0.34.1 (#861, D13 + #876): source_id is the write-source scope;
 -- federated_read is the read-source array. Migrations v60-v65 land both
 -- columns on upgrade; fresh installs include them inline above.
+-- federated_write (v118) is the WRITE-side mirror of federated_read: the set
+-- of sources a token may write to (write ops choose the target per call,
+-- authorized against source_id ∪ federated_write). Empty '{}' = writes locked
+-- to source_id (the pre-v118 default).
 CREATE INDEX IF NOT EXISTS idx_oauth_clients_source_id
   ON oauth_clients(source_id) WHERE source_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_oauth_clients_federated_read
   ON oauth_clients USING GIN (federated_read);
+CREATE INDEX IF NOT EXISTS idx_oauth_clients_federated_write
+  ON oauth_clients USING GIN (federated_write);
 
 CREATE TABLE IF NOT EXISTS oauth_tokens (
   token_hash   TEXT PRIMARY KEY,

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -625,6 +625,7 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
   deleted_at              TIMESTAMPTZ,
   source_id               TEXT REFERENCES sources(id) ON DELETE RESTRICT,
   federated_read          TEXT[] NOT NULL DEFAULT '{}',
+  federated_write         TEXT[] NOT NULL DEFAULT '{}',
   -- v0.38 Slice 2 + 3: per-client daily budget cap (v84) + agent binding (v85).
   budget_usd_per_day      NUMERIC(10, 2) NULL,
   bound_tools             TEXT[] NULL,
@@ -637,10 +638,16 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
 -- v0.34.1 (#861, D13 + #876): source_id is the write-source scope;
 -- federated_read is the read-source array. Migrations v60-v65 land both
 -- columns on upgrade; fresh installs include them inline above.
+-- federated_write (v118) is the WRITE-side mirror of federated_read: the set
+-- of sources a token may write to (write ops choose the target per call,
+-- authorized against source_id ∪ federated_write). Empty '{}' = writes locked
+-- to source_id (the pre-v118 default).
 CREATE INDEX IF NOT EXISTS idx_oauth_clients_source_id
   ON oauth_clients(source_id) WHERE source_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_oauth_clients_federated_read
   ON oauth_clients USING GIN (federated_read);
+CREATE INDEX IF NOT EXISTS idx_oauth_clients_federated_write
+  ON oauth_clients USING GIN (federated_write);
 
 CREATE TABLE IF NOT EXISTS oauth_tokens (
   token_hash   TEXT PRIMARY KEY,

--- a/test/auth-register-client-args.test.ts
+++ b/test/auth-register-client-args.test.ts
@@ -20,6 +20,7 @@ describe('parseRegisterClientArgs', () => {
     expect(out.scopes).toBe('read');
     expect(out.sourceId).toBe('default');
     expect(out.federatedRead).toBeUndefined();
+    expect(out.federatedWrite).toBeUndefined();
     expect(out.redirectUris).toEqual([]);
     expect(out.tokenEndpointAuthMethod).toBeUndefined();
   });
@@ -42,6 +43,16 @@ describe('parseRegisterClientArgs', () => {
   test('--federated-read comma-separated → array', () => {
     const out = parseRegisterClientArgs(['--federated-read', 'dept-x,wecare,shared']);
     expect(out.federatedRead).toEqual(['dept-x', 'wecare', 'shared']);
+  });
+
+  test('--federated-write comma-separated → array (v118 write-side mirror)', () => {
+    const out = parseRegisterClientArgs(['--federated-write', 'campo,lideres,directorio']);
+    expect(out.federatedWrite).toEqual(['campo', 'lideres', 'directorio']);
+  });
+
+  test('--federated-write omitted → undefined (writes locked to source_id)', () => {
+    const out = parseRegisterClientArgs(['--source', 'directorio']);
+    expect(out.federatedWrite).toBeUndefined();
   });
 
   // T3 REGRESSION: pre-fix indexOf parser only took the first --redirect-uri

--- a/test/put-page-federated-write.test.ts
+++ b/test/put-page-federated-write.test.ts
@@ -1,0 +1,141 @@
+/**
+ * v118 — federated_write: per-call write-target authorization.
+ *
+ * federated_write is the WRITE-side mirror of federated_read (#876): an OAuth
+ * client carries `source_id` (its single write-AUTHORITY) plus an optional
+ * `federated_write` array of additional sources it may write to. Write ops
+ * (put_page, put_raw_data) accept an optional per-call write target, authorized
+ * via `resolveWriteSource` against `{ctx.sourceId} ∪ ctx.auth.federatedWrite`.
+ *
+ * These tests mirror put-page-namespace.test.ts: dry-run with a stub engine so
+ * no DB / network is needed. The dry-run return echoes the resolved `source`,
+ * so we assert the authorized write target directly.
+ *
+ * Coverage:
+ *   (a) no `source`            → resolves to ctx.sourceId (UNCHANGED behavior)
+ *   (b) `source` in the set    → allowed (own source_id OR a federated_write src)
+ *   (c) `source` NOT in the set → rejected with the federated_write auth error
+ *   plus the pure-function contract for resolveWriteSource.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { operations, OperationError, resolveWriteSource } from '../src/core/operations.ts';
+import type { OperationContext, Operation } from '../src/core/operations.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+const put_page = operations.find(o => o.name === 'put_page') as Operation;
+if (!put_page) throw new Error('put_page op missing');
+const put_raw_data = operations.find(o => o.name === 'put_raw_data') as Operation;
+if (!put_raw_data) throw new Error('put_raw_data op missing');
+
+function makeCtx(overrides: Partial<OperationContext> = {}): OperationContext {
+  const engine = {} as BrainEngine; // dry_run short-circuits before touching the engine
+  return {
+    engine,
+    config: { engine: 'postgres' } as any,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    dryRun: true,
+    remote: true,
+    sourceId: 'directorio',
+    ...overrides,
+  };
+}
+
+// A "directorio" curator token: writes to its own source plus campo + lideres.
+function directorioCtx(overrides: Partial<OperationContext> = {}): OperationContext {
+  return makeCtx({
+    sourceId: 'directorio',
+    auth: {
+      token: 'stub',
+      clientId: 'gbrain_cl_director',
+      scopes: ['read', 'write'],
+      sourceId: 'directorio',
+      allowedSources: ['campo', 'lideres', 'directorio'],
+      federatedWrite: ['campo', 'lideres'],
+    },
+    ...overrides,
+  });
+}
+
+describe('v118 resolveWriteSource (pure function)', () => {
+  test('(a) no requested source → ctx.sourceId (unchanged behavior)', () => {
+    expect(resolveWriteSource(directorioCtx(), undefined)).toBe('directorio');
+    expect(resolveWriteSource(directorioCtx(), '')).toBe('directorio');
+  });
+
+  test('(b) requested === ctx.sourceId → allowed (own write authority always admitted)', () => {
+    expect(resolveWriteSource(directorioCtx(), 'directorio')).toBe('directorio');
+  });
+
+  test('(b) requested in federated_write set → allowed', () => {
+    expect(resolveWriteSource(directorioCtx(), 'campo')).toBe('campo');
+    expect(resolveWriteSource(directorioCtx(), 'lideres')).toBe('lideres');
+  });
+
+  test('(c) requested NOT in set → throws permission_denied with the federated_write error', () => {
+    let threw: unknown;
+    try {
+      resolveWriteSource(directorioCtx(), 'finanzas');
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toBeInstanceOf(OperationError);
+    expect((threw as OperationError).code).toBe('permission_denied');
+    expect((threw as OperationError).message).toMatch(/federated_write/);
+    expect((threw as OperationError).message).toMatch(/finanzas/);
+  });
+
+  test('(c) no federatedWrite grant → only ctx.sourceId is admitted; anything else rejected', () => {
+    const ctx = makeCtx({ sourceId: 'campo' }); // no auth.federatedWrite
+    expect(resolveWriteSource(ctx, undefined)).toBe('campo');
+    expect(resolveWriteSource(ctx, 'campo')).toBe('campo');
+    expect(() => resolveWriteSource(ctx, 'directorio')).toThrow(OperationError);
+  });
+
+  test('attacker-supplied empty federatedWrite does NOT widen scope', () => {
+    const ctx = makeCtx({
+      sourceId: 'campo',
+      auth: {
+        token: 'stub', clientId: 'c', scopes: ['write'],
+        sourceId: 'campo', federatedWrite: [],
+      },
+    });
+    expect(() => resolveWriteSource(ctx, 'directorio')).toThrow(/federated_write/);
+  });
+});
+
+describe('v118 put_page honors federated_write', () => {
+  test('(a) no source → writes to ctx.sourceId', async () => {
+    const result = await put_page.handler(directorioCtx(), { slug: 'wiki/x', content: 'stub' });
+    expect(result).toMatchObject({ dry_run: true, action: 'put_page', slug: 'wiki/x', source: 'directorio' });
+  });
+
+  test('(b) source in federated_write set → writes there', async () => {
+    const result = await put_page.handler(directorioCtx(), { slug: 'wiki/x', content: 'stub', source: 'campo' });
+    expect(result).toMatchObject({ dry_run: true, source: 'campo' });
+  });
+
+  test('(c) source not in set → rejected (preview surfaces the rejection)', async () => {
+    const p = put_page.handler(directorioCtx(), { slug: 'wiki/x', content: 'stub', source: 'finanzas' });
+    await expect(p).rejects.toBeInstanceOf(OperationError);
+    await expect(p).rejects.toThrow(/federated_write/);
+  });
+});
+
+describe('v118 put_raw_data honors federated_write (write_source, distinct from data-source `source`)', () => {
+  test('(a) no write_source → writes to ctx.sourceId; data `source` label preserved', async () => {
+    const result = await put_raw_data.handler(directorioCtx(), { slug: 'wiki/x', source: 'crustdata', data: {} });
+    expect(result).toMatchObject({ dry_run: true, action: 'put_raw_data', source: 'crustdata', write_source: 'directorio' });
+  });
+
+  test('(b) write_source in set → writes there', async () => {
+    const result = await put_raw_data.handler(directorioCtx(), { slug: 'wiki/x', source: 'crustdata', data: {}, write_source: 'lideres' });
+    expect(result).toMatchObject({ dry_run: true, write_source: 'lideres' });
+  });
+
+  test('(c) write_source not in set → rejected', async () => {
+    const p = put_raw_data.handler(directorioCtx(), { slug: 'wiki/x', source: 'crustdata', data: {}, write_source: 'finanzas' });
+    await expect(p).rejects.toBeInstanceOf(OperationError);
+    await expect(p).rejects.toThrow(/finanzas/);
+  });
+});

--- a/test/schema-bootstrap-coverage.test.ts
+++ b/test/schema-bootstrap-coverage.test.ts
@@ -121,6 +121,10 @@ const REQUIRED_BOOTSTRAP_COVERAGE: ForwardReference[] = [
   // them before SCHEMA_SQL replay creates the FK + index.
   { kind: 'column', table: 'oauth_clients', column: 'source_id' },
   { kind: 'column', table: 'oauth_clients', column: 'federated_read' },
+  // v118/v119 — forward-referenced by `idx_oauth_clients_federated_write ON
+  // oauth_clients USING GIN (federated_write)`. Pre-v118 brains lack the column;
+  // bootstrap adds it before SCHEMA_SQL replay creates the index.
+  { kind: 'column', table: 'oauth_clients', column: 'federated_write' },
   // v0.26.5 (v34) — promotes archive lifecycle from JSONB config to real
   // columns on sources. CREATE TABLE IF NOT EXISTS is a no-op on existing
   // sources tables, so the visibility filters in search/list_pages that
@@ -238,8 +242,10 @@ test('applyForwardReferenceBootstrap covers every forward reference declared in 
       ALTER TABLE files DROP COLUMN IF EXISTS page_id;
 
       DROP INDEX IF EXISTS idx_oauth_clients_federated_read;
+      DROP INDEX IF EXISTS idx_oauth_clients_federated_write;
       ALTER TABLE oauth_clients DROP COLUMN IF EXISTS source_id;
       ALTER TABLE oauth_clients DROP COLUMN IF EXISTS federated_read;
+      ALTER TABLE oauth_clients DROP COLUMN IF EXISTS federated_write;
 
       -- v0.40.3.0 v90 + v91 column strips so applyForwardReferenceBootstrap
       -- has work to do. Only strip pages columns + the trigger; sources
@@ -828,6 +834,8 @@ test('extractAddedColumnsFromMigrations sanity-checks against known migration co
   // v60+v61 oauth_clients.*
   expect(has('oauth_clients', 'source_id')).toBe(true);
   expect(has('oauth_clients', 'federated_read')).toBe(true);
+  // v118 oauth_clients.federated_write (write-side mirror of federated_read)
+  expect(has('oauth_clients', 'federated_write')).toBe(true);
   // v18 files.*
   expect(has('files', 'source_id')).toBe(true);
   expect(has('files', 'page_id')).toBe(true);


### PR DESCRIPTION
## What
Adds `federated_write TEXT[]` to `oauth_clients`: the set of sources a token may write to, beyond its single `source_id`. Write ops choose a target source per call, authorized against that set — so one token (e.g. a "directorio" curator) can write to campo / lideres / directorio without re-minting tokens.

## Mirror of federated_read
This is the WRITE-side mirror of `federated_read`, implemented at every site federated_read touches:
- column + GIN index in all 3 schema sources (`schema.sql`, `pglite-schema.ts`, `schema-embedded.ts`) + pre-bootstrap on both engines
- idempotent migrations (v118 column, v119 GIN index), no backfill
- `--federated-write SRC1,SRC2,…` CLI flag on `register-client`
- oauth-provider persist + SELECT/normalize, with the same pre-version back-compat fallback shape
- `AuthInfo.federatedWrite` (mirror of `allowedSources`)

## The one non-mirror part: per-write authorization
New `resolveWriteSource(ctx, requested?)` helper, fail-closed like the read-side scope resolution:
- no `requested` → `ctx.sourceId` (UNCHANGED — pre-v118 clients never sent one)
- `requested` ∈ `{sourceId} ∪ federatedWrite` → allowed
- otherwise → `permission_denied` (`source 'X' not in this client's federated_write set`)

Empty/undefined `federated_write` collapses the allowed set to just `source_id`, so omitting the grant exactly preserves the single-source write lock. Server-stamped provenance (`source_kind`/`source_uri`/`ingested_via`) is untouched — the new `source` is a separate, authorized write-target field.

`put_page` gets an optional `source`; `put_raw_data` gets `write_source` (its existing `source` param is the data-provenance label and was left intact).

## Tests
New `test/put-page-federated-write.test.ts` covers: no `source` → `source_id`; `source` in set → allowed; `source` not in set → rejected; attacker-supplied empty `[]` does not widen scope; `put_raw_data` `write_source` vs data-`source` distinction. `tsc --noEmit` clean; existing oauth/source-isolation guard checks pass.

## Compatibility
Default `'{}'` (empty) for every existing client → writes stay locked to `source_id`. No backfill. Pre-v118 brains fall back to the federated_read projection until `apply-migrations` runs.

## Usage
```
gbrain auth register-client director --scopes read,write --source directorio \
  --federated-read campo,lideres,directorio --federated-write campo,lideres,directorio
```
