### PR TITLE
fix(subagent): reliable gateway tool-loop for non-Anthropic providers (persist tool-result messages + JSON-normalize outputs)

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2908,6 +2908,22 @@ export interface ToolLoopOpts {
   ) => Promise<{ gbrainToolUseId: string }>;
   onToolCallComplete?: (gbrainToolUseId: string, output: unknown) => Promise<void>;
   onToolCallFailed?: (gbrainToolUseId: string, error: string) => Promise<void>;
+  /**
+   * Persist the user-role message that carries this turn's tool results back to
+   * the model. Fires once per turn, AFTER every tool execution settles and
+   * BEFORE the results are appended to the in-memory history (write-before-use).
+   *
+   * The legacy Anthropic-direct path always persisted this message; the
+   * gateway path originally dropped it (`void userMessageIdx`), so on
+   * crash-replay `loadPriorMessages` rebuilt a history that ended with an
+   * assistant turn whose tool-calls had NO matching tool-result message. AI SDK
+   * v6 then rejected the prompt — "Tool results are missing for tool calls ..."
+   * (when another assistant turn followed) or "messages do not match the
+   * ModelMessage[] schema" (when it was the last message) — and the job retried
+   * the same broken history until max_attempts. Pinned by
+   * test/e2e/subagent-gateway-resume.test.ts.
+   */
+  onToolResultMessage?: (messageIdx: number, blocks: ChatBlock[]) => Promise<void>;
 
   /** Optional per-call heartbeat for observability. */
   onHeartbeat?: (event: string, data: Record<string, unknown>) => void;
@@ -3131,9 +3147,13 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
 
     if (stopReason === 'aborted') break;
 
-    // Feed all tool results back as a single user message.
+    // Feed all tool results back as a single user message. Persist it BEFORE
+    // appending to the in-memory history (write-before-use) so a crash here
+    // leaves the DB holding a complete, replayable turn: the assistant's
+    // tool-calls AND the matching tool-result message. Dropping this write was
+    // the root cause of the gateway-path resume failures (see onToolResultMessage).
     const userMessageIdx = messageIdx++;
-    void userMessageIdx;
+    await opts.onToolResultMessage?.(userMessageIdx, toolResultBlocks);
     messages.push({ role: 'user', content: toolResultBlocks });
 
     turnIdx++;

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2323,6 +2323,23 @@ export interface ChatToolDef {
   inputSchema: Record<string, unknown>;
 }
 
+/** JSON.stringify that never throws (bigint / circular → best-effort string). */
+function safeStringify(v: unknown): string {
+  try { return JSON.stringify(v) ?? 'null'; } catch { return String(v); }
+}
+
+/**
+ * Coerce an arbitrary tool-output value into a plain JSON value the AI SDK's
+ * strict JSONValue schema accepts. Round-tripping through JSON converts `Date`
+ * to an ISO string, drops `undefined` object properties, and normalizes nested
+ * structures. Non-serializable inputs (bigint, circular) fall back to a string.
+ * Returns `null` for nullish input so the json part always has a defined value.
+ */
+function toJsonValue(v: unknown): unknown {
+  if (v === null || v === undefined) return null;
+  try { return JSON.parse(JSON.stringify(v)); } catch { return String(v); }
+}
+
 /**
  * Convert gbrain's provider-neutral ChatMessage[] into AI SDK v6 ModelMessage[].
  *
@@ -2351,10 +2368,20 @@ export function toModelMessages(messages: ChatMessage[]): unknown[] {
             toolCallId: b.toolCallId,
             toolName: b.toolName,
             output: b.isError
-              ? { type: 'error-text' as const, value: typeof b.output === 'string' ? b.output : JSON.stringify(b.output) }
+              ? { type: 'error-text' as const, value: typeof b.output === 'string' ? b.output : safeStringify(b.output) }
               : (typeof b.output === 'string'
                 ? { type: 'text' as const, value: b.output }
-                : { type: 'json' as const, value: (b.output ?? null) as never }),
+                // v6 validates the json `value` against a strict JSONValue Zod
+                // schema. gbrain tool outputs routinely carry non-JSON values —
+                // e.g. node-postgres returns `timestamptz` columns as JS `Date`,
+                // so brain_get_page / brain_list_pages rows include Date-typed
+                // updated_at/created_at fields. A raw Date (or undefined/bigint)
+                // makes the whole tool message fail the union ("messages do not
+                // match the ModelMessage[] schema"). Normalize to a plain JSON
+                // value (Date → ISO string, undefined dropped) first. Replay
+                // didn't hit this because the value was already JSON-round-tripped
+                // through the jsonb column.
+                : { type: 'json' as const, value: toJsonValue(b.output) as never }),
           })),
       };
     }

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -777,22 +777,59 @@ async function runSubagentViaGateway(args: GatewayRunArgs): Promise<SubagentResu
     });
   }
 
-  // Convert prior Anthropic-shape messages → ChatMessage with ChatBlock content.
-  // v1 rows store Anthropic content blocks ({type:'tool_use'|'tool_result'|...});
+  // Convert prior Anthropic-shape messages → ChatMessage with ChatBlock content,
+  // healing any tool-result messages that an older (pre-fix) gateway run failed
+  // to persist. v1 rows store Anthropic content blocks ({type:'tool_use'|...});
   // we adapt them to ChatBlock shape (type: 'tool-call' | 'tool-result' | 'text').
-  const priorChatMessages: ChatMessage[] = priorMessages.map(m => ({
-    role: m.role as 'user' | 'assistant',
-    content: adaptContentBlocksToChatBlocks(m.content_blocks),
-  }));
+  //
+  // Self-healing replay: builds tool-execution outputs keyed by message_idx so
+  // an assistant turn whose tool-calls have no following tool-result message
+  // (the gap left by the historical persistence bug) gets its tool-result
+  // message reconstructed from subagent_tool_executions and re-persisted. This
+  // recovers jobs corrupted before the fix AND hardens replay against any
+  // future gap. Inert on fresh runs (priorMessages empty) and on correctly
+  // persisted histories (the tool-result message is already present).
+  const { messages: priorChatMessages, healed: healedToolResultMessages } =
+    rebuildReplayHistory(priorMessages, priorTools);
+
+  // Re-persist any reconstructed tool-result messages so the gap is closed in
+  // the DB (persistMessage uses ON CONFLICT DO NOTHING — idempotent).
+  for (const h of healedToolResultMessages) {
+    await persistMessage(engine, ctx.id, {
+      message_idx: h.messageIdx,
+      role: 'user',
+      content_blocks: h.blocks as unknown as ContentBlock[],
+      tokens_in: null,
+      tokens_out: null,
+      tokens_cache_read: null,
+      tokens_cache_create: null,
+      model: null,
+    });
+  }
+  if (healedToolResultMessages.length > 0) {
+    logSubagentHeartbeat({
+      job_id: ctx.id,
+      event: 'replay_healed_tool_results' as any,
+      count: healedToolResultMessages.length,
+    } as any);
+  }
 
   // Initial seed message if no prior state.
   const initialMessages: ChatMessage[] = priorChatMessages.length === 0
     ? [{ role: 'user', content: data.prompt }]
     : [];
 
-  // Persist seed user message at idx 0 if fresh start.
-  let nextMessageIdx = priorChatMessages.length;
-  if (nextMessageIdx === 0) {
+  // Next message_idx must exceed every persisted/healed idx (NOT the array
+  // length — a still-pending unreconstructable tail could leave a gap, and the
+  // unique (job_id, message_idx) constraint would silently drop a colliding
+  // write under ON CONFLICT DO NOTHING).
+  const maxKnownIdx = Math.max(
+    -1,
+    ...priorMessages.map(m => m.message_idx),
+    ...healedToolResultMessages.map(h => h.messageIdx),
+  );
+  let nextMessageIdx = maxKnownIdx + 1;
+  if (priorChatMessages.length === 0) {
     await persistMessage(engine, ctx.id, {
       message_idx: 0,
       role: 'user',
@@ -904,6 +941,21 @@ async function runSubagentViaGateway(args: GatewayRunArgs): Promise<SubagentResu
         [errorMsg, gbrainToolUseId],
       );
     },
+    onToolResultMessage: async (messageIdx, blocks) => {
+      // Persist the tool-result user message so crash-replay rebuilds a valid
+      // conversation. Symmetric to the legacy Anthropic-direct path; its
+      // absence here was the root cause of the gateway-path resume loop.
+      await persistMessage(engine, ctx.id, {
+        message_idx: messageIdx,
+        role: 'user',
+        content_blocks: blocks as unknown as ContentBlock[],
+        tokens_in: null,
+        tokens_out: null,
+        tokens_cache_read: null,
+        tokens_cache_create: null,
+        model: null,
+      });
+    },
     onHeartbeat: heartbeat,
   });
 
@@ -1014,8 +1066,20 @@ function adaptContentBlocksToChatBlocks(blocks: unknown): ChatBlock[] | string {
   return out;
 }
 
+/** Parse a JSON string, returning the original value if it isn't valid JSON
+ * (a tool may legitimately return a bare string). Used when re-hydrating
+ * tool-execution outputs that the pg driver hands back as JSONB string scalars. */
+function safeJsonParse(s: string): unknown {
+  try { return JSON.parse(s); } catch { return s; }
+}
+
 interface PriorToolV2Row {
   stableKey: string;
+  /** message_idx of the assistant turn that emitted this tool call. */
+  messageIdx: number;
+  /** Provider-supplied tool-call id — matches the assistant block's toolCallId. */
+  providerToolCallId: string;
+  toolName: string;
   status: 'pending' | 'complete' | 'failed';
   output: unknown;
   error: string | null;
@@ -1051,11 +1115,94 @@ async function loadPriorToolsV2(engine: BrainEngine, jobId: number): Promise<Pri
       : `legacy:${jobId}:${r.message_idx}:${r.tool_use_id}:${r.tool_name}`;
     return {
       stableKey,
+      messageIdx: r.message_idx as number,
+      providerToolCallId: r.tool_use_id as string,
+      toolName: r.tool_name as string,
       status: r.status as 'pending' | 'complete' | 'failed',
-      output: r.output,
+      output: typeof r.output === 'string' ? safeJsonParse(r.output) : r.output,
       error: (r.error as string | null) ?? null,
     };
   });
+}
+
+/**
+ * Rebuild the gateway replay history from persisted messages, healing any
+ * tool-result message a pre-fix gateway run failed to persist.
+ *
+ * The historical bug: the gateway tool-loop persisted assistant turns and
+ * per-tool execution rows but never persisted the user-role message carrying
+ * the tool results. On resume, the rebuilt conversation ended with an
+ * assistant turn whose tool-calls had no matching tool-result message, which
+ * AI SDK v6 rejects ("Tool results are missing for tool calls ..." /
+ * "messages do not match the ModelMessage[] schema"). The job then looped on
+ * the same broken history until max_attempts.
+ *
+ * For every assistant turn that emitted tool-calls and is NOT already followed
+ * by a tool-result message, we synthesize that message from the (settled)
+ * subagent_tool_executions rows at the same message_idx, matching each
+ * assistant tool-call by provider toolCallId. The synthesized message is
+ * inserted at `assistantIdx + 1` — exactly where the forward path
+ * (onToolResultMessage) writes it — and returned in `healed` so the caller can
+ * close the gap in the DB.
+ *
+ * Conservative on ambiguity: if any tool-call's execution is still `pending` or
+ * has no row, that turn is left un-healed (no fabricated result for work that
+ * may not have run). Such a tail reproduces the original failure rather than
+ * inventing data — no regression versus pre-fix behavior.
+ */
+function rebuildReplayHistory(
+  priorMessages: PersistedMessage[],
+  priorTools: PriorToolV2Row[],
+): { messages: ChatMessage[]; healed: Array<{ messageIdx: number; blocks: ChatBlock[] }> } {
+  const execsByMsgIdx = new Map<number, PriorToolV2Row[]>();
+  for (const t of priorTools) {
+    const arr = execsByMsgIdx.get(t.messageIdx);
+    if (arr) arr.push(t); else execsByMsgIdx.set(t.messageIdx, [t]);
+  }
+
+  const messages: ChatMessage[] = [];
+  const healed: Array<{ messageIdx: number; blocks: ChatBlock[] }> = [];
+
+  for (let i = 0; i < priorMessages.length; i++) {
+    const m = priorMessages[i];
+    const content = adaptContentBlocksToChatBlocks(m.content_blocks);
+    messages.push({ role: m.role, content });
+
+    if (m.role !== 'assistant' || !Array.isArray(content)) continue;
+    const toolCalls = content.filter(
+      (b): b is Extract<ChatBlock, { type: 'tool-call' }> => b.type === 'tool-call',
+    );
+    if (toolCalls.length === 0) continue;
+
+    // Already answered? (correctly persisted history — the common post-fix case)
+    const next = priorMessages[i + 1];
+    const nextContent = next ? adaptContentBlocksToChatBlocks(next.content_blocks) : null;
+    const alreadyAnswered = next?.role === 'user' && Array.isArray(nextContent)
+      && nextContent.some(b => b.type === 'tool-result');
+    if (alreadyAnswered) continue;
+
+    // Reconstruct from settled executions, matched by provider toolCallId.
+    const byProviderId = new Map(
+      (execsByMsgIdx.get(m.message_idx) ?? []).map(e => [e.providerToolCallId, e]),
+    );
+    const blocks: ChatBlock[] = [];
+    let reconstructable = true;
+    for (const tc of toolCalls) {
+      const exec = byProviderId.get(tc.toolCallId);
+      if (!exec || exec.status === 'pending') { reconstructable = false; break; }
+      blocks.push(
+        exec.status === 'failed'
+          ? { type: 'tool-result', toolCallId: tc.toolCallId, toolName: tc.toolName, output: exec.error ?? 'tool failed', isError: true }
+          : { type: 'tool-result', toolCallId: tc.toolCallId, toolName: tc.toolName, output: exec.output ?? null },
+      );
+    }
+    if (!reconstructable) continue;
+
+    messages.push({ role: 'user', content: blocks });
+    healed.push({ messageIdx: m.message_idx + 1, blocks });
+  }
+
+  return { messages, healed };
 }
 
 // ── Internal: persistence ───────────────────────────────────

--- a/test/e2e/subagent-gateway-resume.test.ts
+++ b/test/e2e/subagent-gateway-resume.test.ts
@@ -1,0 +1,231 @@
+/**
+ * E2E regression: gateway-path subagent loop persists tool-result messages and
+ * heals pre-fix histories on resume.
+ *
+ * Root cause this guards (gotcha #16): the gateway tool-loop persisted assistant
+ * turns and per-tool execution rows but NEVER persisted the user-role message
+ * carrying the tool results. On any resume (worker restart / re-claim) the
+ * rebuilt conversation ended with an assistant turn whose tool-calls had no
+ * matching tool-result message — AI SDK v6 then rejects the prompt with
+ * "Tool results are missing for tool calls ..." (or "messages do not match the
+ * ModelMessage[] schema" when it was the last message) and the job loops to
+ * max_attempts. The legacy Anthropic-direct path always persisted this message;
+ * the gateway path dropped it (`void userMessageIdx`).
+ *
+ * Two guarantees:
+ *   1. Forward fix — a multi-turn tool flow persists contiguous message_idx
+ *      (0,1,2,3,...) with the tool-result user message at every even index.
+ *   2. Self-healing replay — a job corrupted by the OLD behavior (assistant
+ *      tool-call turn with NO following tool-result message) resumes cleanly:
+ *      the missing message is reconstructed from subagent_tool_executions, the
+ *      tool is NOT re-executed, and the job completes.
+ *
+ * Hermetic: PGLite in-memory engine, gateway transport stubbed.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+import { resetPgliteState } from '../helpers/reset-pglite.ts';
+import { makeSubagentHandler } from '../../src/core/minions/handlers/subagent.ts';
+import type { MinionJobContext, ToolDef, ToolCtx } from '../../src/core/minions/types.ts';
+import {
+  __setChatTransportForTests,
+  configureGateway,
+  resetGateway,
+  type ChatBlock,
+  type ChatResult,
+} from '../../src/core/ai/gateway.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  await engine.setConfig('version', '85');
+  await engine.setConfig('agent.use_gateway_loop', 'true');
+  configureGateway({
+    chat_model: 'anthropic:claude-sonnet-4-6',
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    expansion_model: 'anthropic:claude-haiku-4-5',
+    env: { ANTHROPIC_API_KEY: 'stub', OPENAI_API_KEY: 'stub' },
+  });
+});
+
+function clearGateway(): void {
+  __setChatTransportForTests(null);
+  resetGateway();
+}
+
+async function makeFakeJob(prompt: string, model: string): Promise<{ jobId: number; ctx: MinionJobContext; executions: Array<{ name: string }> }> {
+  const rows = await engine.executeRaw<{ id: number }>(
+    `INSERT INTO minion_jobs (name, status, data, queue, priority, created_at)
+     VALUES ('subagent', 'active', $1::jsonb, 'default', 0, now())
+     RETURNING id`,
+    [JSON.stringify({ prompt, model })],
+  );
+  const jobId = rows[0].id;
+  const executions: Array<{ name: string }> = [];
+  const ctx: MinionJobContext = {
+    id: jobId,
+    name: 'subagent',
+    data: { prompt, model },
+    attempts_made: 0,
+    signal: new AbortController().signal,
+    shutdownSignal: new AbortController().signal,
+    updateProgress: async () => {},
+    updateTokens: async () => {},
+    log: async () => {},
+    isActive: async () => true,
+    readInbox: async () => [],
+  };
+  return { jobId, ctx, executions };
+}
+
+function searchTool(executions: Array<{ name: string }>): ToolDef[] {
+  return [{
+    name: 'search',
+    description: 'stub search',
+    input_schema: { type: 'object' },
+    idempotent: true,
+    async execute(_input: unknown, _ctx: ToolCtx) {
+      executions.push({ name: 'search' });
+      return { results: [{ slug: 'wiki/foo' }] };
+    },
+  }];
+}
+
+function buildHandler(toolRegistry: ToolDef[]) {
+  return makeSubagentHandler({
+    engine,
+    config: {} as any,
+    toolRegistry,
+    makeAnthropic: () => ({ messages: { create: async () => { throw new Error('legacy path should not be invoked'); } } }) as any,
+  });
+}
+
+describe('gateway subagent resume (gotcha #16 — tool-result message persistence)', () => {
+  afterAll(() => clearGateway());
+
+  it('forward fix: a 2-turn tool flow persists the tool-result user message (no message_idx gap)', async () => {
+    let turn = 0;
+    __setChatTransportForTests(async () => {
+      turn++;
+      if (turn === 1) {
+        return {
+          text: '',
+          blocks: [{ type: 'tool-call', toolCallId: 'tc-1', toolName: 'search', input: { q: 'acme' } }] as ChatBlock[],
+          stopReason: 'tool_calls',
+          usage: { input_tokens: 10, output_tokens: 5, cache_read_tokens: 0, cache_creation_tokens: 0 },
+          model: 'anthropic:claude-sonnet-4-6',
+          providerId: 'anthropic',
+        } satisfies ChatResult;
+      }
+      return {
+        text: 'done',
+        blocks: [{ type: 'text', text: 'done' }] as ChatBlock[],
+        stopReason: 'end',
+        usage: { input_tokens: 8, output_tokens: 2, cache_read_tokens: 0, cache_creation_tokens: 0 },
+        model: 'anthropic:claude-sonnet-4-6',
+        providerId: 'anthropic',
+      } satisfies ChatResult;
+    });
+
+    const executions: Array<{ name: string }> = [];
+    const handler = buildHandler(searchTool(executions));
+    const { jobId, ctx } = await makeFakeJob('find acme', 'anthropic:claude-sonnet-4-6');
+    const result = await handler(ctx);
+
+    expect(result.result).toBe('done');
+
+    const msgs = await engine.executeRaw<Record<string, unknown>>(
+      `SELECT message_idx, role FROM subagent_messages WHERE job_id = $1 ORDER BY message_idx`,
+      [jobId],
+    );
+    // Contiguous: user(0) → assistant w/ tool-call(1) → user w/ tool-result(2) → assistant(3).
+    expect(msgs.map(m => [m.message_idx, m.role])).toEqual([
+      [0, 'user'], [1, 'assistant'], [2, 'user'], [3, 'assistant'],
+    ]);
+
+    // The idx-2 user message must actually carry the tool-result block.
+    const idx2 = await engine.executeRaw<{ content_blocks: unknown }>(
+      `SELECT content_blocks FROM subagent_messages WHERE job_id = $1 AND message_idx = 2`,
+      [jobId],
+    );
+    const blocks = typeof idx2[0].content_blocks === 'string'
+      ? JSON.parse(idx2[0].content_blocks as string)
+      : idx2[0].content_blocks;
+    expect(Array.isArray(blocks)).toBe(true);
+    expect((blocks as any[])[0].type).toBe('tool-result');
+    expect((blocks as any[])[0].toolCallId).toBe('tc-1');
+  });
+
+  it('self-healing resume: a pre-fix corrupted job (missing tool-result message) completes without re-executing the tool', async () => {
+    const { jobId, ctx } = await makeFakeJob('find acme', 'anthropic:claude-sonnet-4-6');
+
+    // Seed a job in the BROKEN pre-fix shape: user(0), assistant-with-tool-call(1),
+    // a completed tool execution at idx 1 — but NO tool-result user message at idx 2.
+    await engine.executeRaw(
+      `INSERT INTO subagent_messages (job_id, message_idx, role, content_blocks) VALUES
+         ($1, 0, 'user', $2::jsonb),
+         ($1, 1, 'assistant', $3::jsonb)`,
+      [
+        jobId,
+        JSON.stringify([{ type: 'text', text: 'find acme' }]),
+        JSON.stringify([
+          { type: 'text', text: 'let me search' },
+          { type: 'tool-call', toolCallId: 'tc-1', toolName: 'search', input: { q: 'acme' } },
+        ]),
+      ],
+    );
+    await engine.executeRaw(
+      `INSERT INTO subagent_tool_executions
+         (job_id, message_idx, tool_use_id, tool_name, input, status, output, schema_version, ordinal, gbrain_tool_use_id, provider_id)
+       VALUES ($1, 1, 'tc-1', 'search', $2::jsonb, 'complete', $3::jsonb, 2, 0, gen_random_uuid(), 'anthropic')`,
+      [jobId, JSON.stringify({ q: 'acme' }), JSON.stringify({ results: [{ slug: 'wiki/foo' }] })],
+    );
+
+    // On resume the loop's FIRST chat() must receive a valid history (the healed
+    // tool-result message), so it returns the final answer.
+    __setChatTransportForTests(async () => ({
+      text: 'recovered and done',
+      blocks: [{ type: 'text', text: 'recovered and done' }] as ChatBlock[],
+      stopReason: 'end',
+      usage: { input_tokens: 9, output_tokens: 3, cache_read_tokens: 0, cache_creation_tokens: 0 },
+      model: 'anthropic:claude-sonnet-4-6',
+      providerId: 'anthropic',
+    } satisfies ChatResult));
+
+    const executions: Array<{ name: string }> = [];
+    const handler = buildHandler(searchTool(executions));
+    ctx.attempts_made = 1; // a resume
+
+    const result = await handler(ctx);
+
+    // Completed (not stuck looping on "Tool results are missing").
+    expect(result.result).toBe('recovered and done');
+    expect(result.stop_reason).toBe('end_turn');
+    // The tool's persisted output was reused — NOT re-executed.
+    expect(executions.length).toBe(0);
+
+    // The gap was healed in the DB: idx 2 is now a tool-result user message.
+    const msgs = await engine.executeRaw<Record<string, unknown>>(
+      `SELECT message_idx, role FROM subagent_messages WHERE job_id = $1 ORDER BY message_idx`,
+      [jobId],
+    );
+    const idx2 = msgs.find(m => m.message_idx === 2);
+    expect(idx2).toBeDefined();
+    expect(idx2!.role).toBe('user');
+    // And the resumed assistant turn was appended after the healed message.
+    expect(msgs.some(m => m.message_idx === 3 && m.role === 'assistant')).toBe(true);
+  });
+});

--- a/test/gateway-model-messages.test.ts
+++ b/test/gateway-model-messages.test.ts
@@ -120,4 +120,58 @@ describe('toModelMessages — v6 ModelMessage shape', () => {
     expect((out[2] as any).role).toBe('tool');
     expect((out[2] as any).content[0].output).toEqual({ type: 'json', value: { hits: 0 } });
   });
+
+  // Regression: gbrain tool outputs carry non-JSON values that AI SDK v6's
+  // strict JSONValue schema rejects. node-postgres returns `timestamptz`
+  // columns as JS Date, so brain_get_page / brain_list_pages rows include
+  // Date-typed updated_at/created_at. A raw Date made the whole tool message
+  // fail the ModelMessage union ("messages do not match the ModelMessage[]
+  // schema") on every live multi-turn run. Replay didn't hit it because the
+  // value had already been JSON-round-tripped through the jsonb column.
+  test('Date in tool-result output is normalized to an ISO string (v6 JSONValue)', () => {
+    const when = new Date('2026-06-04T12:34:56.000Z');
+    const msgs: ChatMessage[] = [
+      {
+        role: 'user',
+        content: [{ type: 'tool-result', toolCallId: 'c1', toolName: 'brain_list_pages', output: { rows: [{ slug: 'a', updated_at: when }] } }],
+      },
+    ];
+    const out = toModelMessages(msgs);
+    expect((out[0] as any).content[0].output).toEqual({
+      type: 'json',
+      value: { rows: [{ slug: 'a', updated_at: '2026-06-04T12:34:56.000Z' }] },
+    });
+  });
+
+  test('undefined fields in tool-result output are dropped (valid JSONValue)', () => {
+    const msgs: ChatMessage[] = [
+      {
+        role: 'user',
+        content: [{ type: 'tool-result', toolCallId: 'c1', toolName: 'x', output: { a: 1, b: undefined } }],
+      },
+    ];
+    expect((toModelMessages(msgs)[0] as any).content[0].output).toEqual({ type: 'json', value: { a: 1 } });
+  });
+
+  test('a Date-bearing tool output is ACCEPTED by AI SDK generateText validation (no ModelMessage rejection)', async () => {
+    const { generateText } = await import('ai');
+    const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible');
+    const msgs: ChatMessage[] = [
+      { role: 'user', content: 'list pages' },
+      { role: 'assistant', content: [{ type: 'tool-call', toolCallId: 'c1', toolName: 'brain_list_pages', input: {} }] },
+      { role: 'user', content: [{ type: 'tool-result', toolCallId: 'c1', toolName: 'brain_list_pages', output: { rows: [{ slug: 'a', updated_at: new Date('2026-06-04T00:00:00Z') }] } }] },
+    ];
+    // Dead URL + no retries: prompt validation runs BEFORE the network call, so
+    // a schema rejection would throw synchronously. Assert the error (if any) is
+    // a connection error, NOT a ModelMessage schema rejection.
+    const provider = createOpenAICompatible({ name: 'dead', baseURL: 'http://127.0.0.1:1/v1' });
+    let msg = '';
+    try {
+      await generateText({ model: provider('m'), messages: toModelMessages(msgs) as any, maxOutputTokens: 8, maxRetries: 0 });
+    } catch (e: any) {
+      msg = String(e?.message ?? e);
+    }
+    expect(msg).not.toContain('ModelMessage');
+    expect(msg).not.toContain('Invalid prompt');
+  });
 });


### PR DESCRIPTION
Fixes #2256.

The gateway-native subagent loop (`agent.use_gateway_loop=true`, mandatory for non-Anthropic providers) couldn't reliably complete a multi-turn tool conversation. Two independent bugs combined to make subagent jobs loop on retries forever. Both surface as AI SDK v6 errors: `Invalid prompt: The messages do not match the ModelMessage[] schema` and `Tool results are missing for tool calls <ids>`. The Anthropic-direct path is unaffected.

## Commit 1 — persist tool-result messages; self-heal on resume

`toolLoop()` fed each turn's tool results back as a `role:'user'` message but never persisted it (`void userMessageIdx`), and `runSubagentViaGateway` discarded `ToolLoopResult.messages`. So `subagent_messages` had gaps at every even `message_idx`. On any resume, `loadPriorMessages` rebuilt a history of adjacent assistant turns with dangling tool-calls, which AI SDK v6 rejects — before the `replayState.priorTools` reconciler (which only runs inside tool-dispatch, after `chat()`) ever gets a chance. The job then looped to `max_attempts`. The legacy Anthropic-direct path always persisted this message.

- `toolLoop`: new `onToolResultMessage` callback, fired before the in-memory push (write-before-use).
- `runSubagentViaGateway`: wires it to persist the tool-result message; and `rebuildReplayHistory()` self-heals already-corrupted jobs by reconstructing each missing tool-result message from settled `subagent_tool_executions` rows (matched by provider `toolCallId`) and re-persisting it. Conservative: a still-pending/absent exec leaves the turn un-healed rather than fabricating data. `nextMessageIdx` now derives from `max(known idx)+1` so a healed gap can't collide under the unique `(job_id, message_idx)` constraint.

## Commit 2 — JSON-normalize tool-result outputs

AI SDK v6 validates each tool-result `json` output against a strict `JSONValue` schema. node-postgres returns `timestamptz` as JS `Date`, so `brain_get_page`/`brain_list_pages` rows carry Date-typed `updated_at`/`created_at`; a raw `Date` (also `undefined`/`bigint`) fails the `ModelMessage` union the turn after such a tool runs. Replay masked it (the jsonb round-trip had already stringified the Date).

- `toModelMessages`: normalize the `json` value via `toJsonValue()` (JSON round-trip: `Date`→ISO, `undefined` dropped, non-serializable→string), plus a non-throwing `safeStringify()` for the error-text branch. Persisted blocks are unaffected (write path already JSON-stringifies, so stored and sent forms now agree).

## Tests
- `test/e2e/subagent-gateway-resume.test.ts` — forward persistence (contiguous `message_idx`, no gaps) + self-healing resume from a pre-fix corrupted job without re-executing the tool.
- `test/gateway-model-messages.test.ts` — `Date`→ISO normalization, `undefined` drop, and a real `generateText` validation accepting a Date-bearing tool output (no `ModelMessage` rejection).
- Existing `subagent-gateway-path` and cross-provider `subagent-crash-replay-multi-provider` suites stay green (33 pass on this branch).

## Validation
Deployed against a live `llama-server:qwen36b` dream backlog where 23/23 multi-turn jobs were stuck looping. After the fix, jobs that previously failed every retry run the full multi-turn synthesis to completion with contiguous `message_idx` (verified one job: 16 messages, idx 0–15, real synthesis output; the rest drained the same way). The only non-completions were pre-existing `wall-clock timeout` deaths on the heaviest transcripts that had already exhausted most of their retry budget on the old bug — not a regression.
