### PR TITLE
feat(sync): GBRAIN_NO_PRUNE_DIRS — un-prune a content dir (e.g. an ops/ KB)

### DIFF
--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -261,14 +261,35 @@ const PRUNE_DIR_NAMES = new Set<string>([
  * existing callers stay back-compat; new callers (sync walker, extract
  * walker) thread it through.
  */
+/**
+ * Names to NOT prune even though they're in PRUNE_DIR_NAMES (or match the
+ * `.raw` sidecar rule) — an escape hatch for brains that legitimately use one
+ * of these names as a content directory (e.g. an `ops/` knowledge base instead
+ * of throwaway operational files). Set `GBRAIN_NO_PRUNE_DIRS` to a comma-
+ * separated list (e.g. `ops`). Empty/unset = default pruning. Dot-prefixed dirs
+ * and git submodules are ALWAYS pruned regardless (genuine non-content).
+ */
+export function parseNoPruneDirs(raw: string | undefined = process.env.GBRAIN_NO_PRUNE_DIRS): Set<string> {
+  if (!raw) return new Set<string>();
+  const out = new Set<string>();
+  for (const part of raw.split(',')) {
+    const t = part.trim();
+    if (t) out.add(t);
+  }
+  return out;
+}
+
 export function pruneDir(name: string, parentDir?: string): boolean {
   if (!name) return true;
   if (name.startsWith('.')) return false;
-  if (PRUNE_DIR_NAMES.has(name)) return false;
+  // GBRAIN_NO_PRUNE_DIRS un-prunes named dirs so a brain can use e.g. `ops/`
+  // as a real content tree. Dot-dirs + submodules stay pruned regardless.
+  const noPrune = parseNoPruneDirs();
+  if (PRUNE_DIR_NAMES.has(name) && !noPrune.has(name)) return false;
   // `.raw` is the literal directory name; `*.raw` is the gbrain sidecar
   // convention (e.g. `people/pedro.raw/` holds raw source for pedro.md).
   // Both forms should be skipped at descent time.
-  if (name.endsWith('.raw')) return false;
+  if (name.endsWith('.raw') && !noPrune.has(name)) return false;
   // Submodule detection: a git submodule directory contains `.git` as
   // a FILE (a "gitfile" pointing into the parent's .git/modules/...),
   // not a directory. Best-effort: if we can't stat (e.g. cross-platform

--- a/test/sync-no-prune-dirs.test.ts
+++ b/test/sync-no-prune-dirs.test.ts
@@ -1,0 +1,33 @@
+/**
+ * GBRAIN_NO_PRUNE_DIRS — escape hatch to un-prune a content dir (e.g. `ops/`)
+ * that's otherwise in PRUNE_DIR_NAMES. Dot-dirs + submodules stay pruned.
+ */
+import { test, expect, afterEach } from 'bun:test';
+import { pruneDir, parseNoPruneDirs } from '../src/core/sync.ts';
+
+afterEach(() => { delete process.env.GBRAIN_NO_PRUNE_DIRS; });
+
+test('parseNoPruneDirs: trims, drops empties/dupes, empty when unset', () => {
+  expect([...parseNoPruneDirs('ops')]).toEqual(['ops']);
+  expect([...parseNoPruneDirs(' ops , foo ,, ')].sort()).toEqual(['foo', 'ops']);
+  expect([...parseNoPruneDirs('ops,ops')]).toEqual(['ops']);
+  expect([...parseNoPruneDirs(undefined)]).toEqual([]);
+  expect([...parseNoPruneDirs('')]).toEqual([]);
+});
+
+test('default: ops/node_modules/.raw pruned, normal dirs kept', () => {
+  delete process.env.GBRAIN_NO_PRUNE_DIRS;
+  expect(pruneDir('ops')).toBe(false);
+  expect(pruneDir('node_modules')).toBe(false);
+  expect(pruneDir('foo.raw')).toBe(false);
+  expect(pruneDir('people')).toBe(true);
+  expect(pruneDir('operations')).toBe(true);
+});
+
+test('GBRAIN_NO_PRUNE_DIRS=ops un-prunes ops, leaves the rest pruned', () => {
+  process.env.GBRAIN_NO_PRUNE_DIRS = 'ops';
+  expect(pruneDir('ops')).toBe(true);          // now synced
+  expect(pruneDir('node_modules')).toBe(false); // still pruned
+  expect(pruneDir('.git')).toBe(false);         // dot-dirs ALWAYS pruned
+  expect(pruneDir('.obsidian')).toBe(false);
+});


### PR DESCRIPTION
## What

Adds `GBRAIN_NO_PRUNE_DIRS` (comma-separated env var) that removes directory names from `PRUNE_DIR_NAMES` at walk time, so a brain can sync a tree whose top-level name happens to collide with a pruned name.

## Why

`PRUNE_DIR_NAMES = {node_modules, .raw, ops}` is hardcoded. `ops` in particular is a *semantic* prune ("operations, not knowledge") — great for repos that use `ops/` for throwaway operational files. But some brains use `ops/` as a genuine **knowledge base** (e.g. `ops/_kb/{compliance,finance,partners,...}`). For them, the entire tree is silently invisible to search with no opt-out — a single hardcoded name decides it.

This gives an escape hatch without changing any default: set `GBRAIN_NO_PRUNE_DIRS=ops` and that tree syncs.

## Behavior

- Comma-separated; trims whitespace, drops empties/dupes.
- Only un-prunes names in `PRUNE_DIR_NAMES` (and the `*.raw` suffix rule).
- **Dot-prefixed dirs (`.git`, `.obsidian`, …) and git submodules stay pruned regardless** — those are never content.
- Unset/empty = exactly today's behavior. Purely additive, no default change.
- Routes through `pruneDir`, so every walker (sync, extract, transcript-discovery) honors it consistently.

## Example

```bash
GBRAIN_NO_PRUNE_DIRS=ops gbrain sync --all
```

## Tests

`test/sync-no-prune-dirs.test.ts` — parser contract + prune/un-prune matrix (ops un-pruned, node_modules still pruned, dot-dirs always pruned). `bun run typecheck` clean.

## Context

Env-var form mirrors the existing `GBRAIN_SOURCE`/`GBRAIN_SOURCES` convention. Happy to reshape as a `sync.*` config key instead if you'd prefer config-driven over env.