### PR TITLE
feat(embed): self-hosted TEI support — Jina recipe, per-text truncation, concurrent dispatch

### DIFF
--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -49,6 +49,7 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   // on different ports.
   if (process.env.LLAMA_SERVER_RERANKER_BASE_URL) envBaseUrls['llama-server-reranker'] = process.env.LLAMA_SERVER_RERANKER_BASE_URL;
   if (process.env.OLLAMA_BASE_URL) envBaseUrls['ollama'] = process.env.OLLAMA_BASE_URL;
+  if (process.env.JINA_BASE_URL) envBaseUrls['jina'] = process.env.JINA_BASE_URL;
   if (process.env.LMSTUDIO_BASE_URL) envBaseUrls['lmstudio'] = process.env.LMSTUDIO_BASE_URL;
   if (process.env.LITELLM_BASE_URL) envBaseUrls['litellm'] = process.env.LITELLM_BASE_URL;
   if (process.env.OPENROUTER_BASE_URL) envBaseUrls['openrouter'] = process.env.OPENROUTER_BASE_URL;
@@ -62,5 +63,6 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
     chat_fallback_chain: c.chat_fallback_chain,
     base_urls: { ...envBaseUrls, ...(c.provider_base_urls ?? {}) }, // config wins over env
     env: { ...envFromConfig, ...process.env }, // process.env wins
+    embed_http_concurrency: c.embed?.http_concurrency,
   };
 }

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -78,6 +78,44 @@ const AI_EMBED_TIMEOUT_MS = resolveAiTimeoutMs('GBRAIN_AI_EMBED_TIMEOUT_MS', 60_
 /** multimodal per request. */
 const AI_MULTIMODAL_TIMEOUT_MS = resolveAiTimeoutMs('GBRAIN_AI_MULTIMODAL_TIMEOUT_MS', 60_000);
 
+// ---------------------------------------------------------------------------
+// Embed sub-batch concurrency.
+//
+// _embedHttpConcurrency limits concurrent sub-batch HTTP calls within any
+// multi-batch embed() call (i.e. when a recipe declares max_batch_tokens and
+// the input splits into >1 sub-batch). Single-batch calls skip the semaphore
+// entirely (fast path). Set via brain config embed.http_concurrency (normal
+// path) or GBRAIN_EMBED_HTTP_CONCURRENCY env var (incident-time override;
+// env wins). Default 1 preserves the prior sequential behaviour.
+// ---------------------------------------------------------------------------
+function resolveIntEnv(envVar: string): number | undefined {
+  const raw = process.env[envVar];
+  if (raw === undefined || raw === '') return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : undefined;
+}
+
+let _embedHttpConcurrency = 1;
+
+// Process-global FIFO semaphore bounding concurrent embed sub-batch HTTP
+// calls at `_embedHttpConcurrency`. acquire() takes a slot or queues;
+// release() hands the slot directly to the next waiter (count unchanged)
+// or frees it. Fair FIFO; no busy-wait.
+let _embedInFlight = 0;
+const _embedSlotWaiters: Array<() => void> = [];
+async function acquireEmbedSlot(): Promise<void> {
+  if (_embedInFlight < _embedHttpConcurrency) {
+    _embedInFlight++;
+    return;
+  }
+  await new Promise<void>((resolve) => _embedSlotWaiters.push(resolve));
+}
+function releaseEmbedSlot(): void {
+  const next = _embedSlotWaiters.shift();
+  if (next) next();
+  else _embedInFlight = Math.max(0, _embedInFlight - 1);
+}
+
 /**
  * Compose a caller signal with a default wall-clock timeout. When the caller
  * supplies its own (Fix 3's 6s query deadline, the facts queue's shutdown abort,
@@ -422,6 +460,11 @@ export function configureGateway(config: AIGatewayConfig): void {
     if (m) registerExtendedModel(m);
   }
   warnRecipesMissingBatchTokens();
+  // env var wins (incident-time override); config key is normal path; default 1.
+  _embedHttpConcurrency =
+    resolveIntEnv('GBRAIN_EMBED_HTTP_CONCURRENCY') ??
+    config.embed_http_concurrency ??
+    1;
 }
 
 /**
@@ -549,6 +592,10 @@ export function resetGateway(): void {
   _chatTransport = null;
   _warnedRecipes.clear();
   _extendedModels.clear();
+  // Reset semaphore state so tests don't leak concurrent-slot accounting.
+  _embedHttpConcurrency = 1;
+  _embedInFlight = 0;
+  _embedSlotWaiters.length = 0;
 }
 
 /**
@@ -563,6 +610,17 @@ export function resetGateway(): void {
 export function __setEmbedTransportForTests(fn: EmbedManyFn | null): void {
   _embedTransport = fn ?? embedMany;
   _embedTransportInstalled = fn !== null;
+}
+
+/**
+ * Test-only seam for embed concurrency. Pass a number to set the limit;
+ * pass null to restore the default (1). Resets semaphore state.
+ * @internal
+ */
+export function __setEmbedConcurrencyForTests(n: number | null): void {
+  _embedHttpConcurrency = n ?? 1;
+  _embedInFlight = 0;
+  _embedSlotWaiters.length = 0;
 }
 
 /**
@@ -1364,13 +1422,22 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
   const resolveTarget = opts?.embeddingModel ?? getEmbeddingModel();
   const tracker = __budgetStore.getStore() ?? null;
   const { model, recipe, modelId } = await resolveEmbeddingProvider(resolveTarget);
-  const truncated = texts.map(t => (t ?? '').slice(0, MAX_CHARS));
+  // When the recipe declares a token budget, cap each text to fit within it.
+  // Without this, a single chunk exceeding max_batch_tokens lands in a
+  // sub-batch of 1 and still hangs the provider — splitting cannot help at
+  // the individual-text level. Fires for any recipe with max_batch_tokens.
+  const embedding = recipe.touchpoints?.embedding;
+  const recipeBatchTokens = embedding?.max_batch_tokens;
+  const charsPerToken = embedding?.chars_per_token ?? DEFAULT_CHARS_PER_TOKEN;
+  const perTextMaxChars = recipeBatchTokens !== undefined
+    ? Math.min(MAX_CHARS, Math.floor(recipeBatchTokens * effectiveSafetyFactor(recipe) * charsPerToken))
+    : MAX_CHARS;
+  const truncated = texts.map(t => (t ?? '').slice(0, perTextMaxChars));
 
   // Reserve up front for the worst-case batch token count. Embeddings have
   // no output rate, so maxOutputTokens=0. record() at the end uses the
   // actual total reported by the SDK across all sub-batches.
   if (tracker) {
-    const charsPerToken = recipe.touchpoints?.embedding?.chars_per_token ?? DEFAULT_CHARS_PER_TOKEN;
     const totalChars = truncated.reduce((s, t) => s + t.length, 0);
     const estimatedInputTokens = Math.ceil(totalChars / Math.max(charsPerToken, 1));
     tracker.reserve({
@@ -1394,24 +1461,33 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
   );
   const expected = effectiveDims;
 
-  const embedding = recipe.touchpoints?.embedding;
-  const maxBatchTokens = embedding?.max_batch_tokens;
-  const charsPerToken = embedding?.chars_per_token ?? DEFAULT_CHARS_PER_TOKEN;
-
-  // Pre-split is gated on max_batch_tokens. Recipes without it (e.g. OpenAI)
-  // ride the fast path: one embedMany call, no recursion safety net.
-  const batches = maxBatchTokens
-    ? splitByTokenBudget(truncated, Math.floor(maxBatchTokens * effectiveSafetyFactor(recipe)), charsPerToken)
+  // Pre-split is gated on the recipe token budget. Recipes without it (e.g.
+  // OpenAI) ride the fast path: one embedMany call, no recursion safety net.
+  const batches = recipeBatchTokens
+    ? splitByTokenBudget(truncated, Math.floor(recipeBatchTokens * effectiveSafetyFactor(recipe)), charsPerToken)
     : [truncated];
 
-  const allEmbeddings: Float32Array[] = [];
+  const subResults: Float32Array[][] = new Array(batches.length);
   let _embedThrew = false;
   try {
-    for (const batch of batches) {
-      const result = await embedSubBatch(batch, model, providerOpts, expected, recipe, modelId, opts);
-      allEmbeddings.push(...result);
+    if (batches.length === 1) {
+      // Fast path: single batch — no concurrency overhead needed.
+      subResults[0] = await embedSubBatch(batches[0]!, model, providerOpts, expected, recipe, modelId, opts);
+    } else {
+      // Concurrent sub-batch dispatch. Preserves output order via indexed
+      // Promise.all while saturating multiple replicas of a self-hosted
+      // embedder. The semaphore caps in-flight HTTP calls (embed.http_concurrency)
+      // so a multi-batch page never swamps the server.
+      await Promise.all(batches.map(async (batch, i) => {
+        await acquireEmbedSlot();
+        try {
+          subResults[i] = await embedSubBatch(batch, model, providerOpts, expected, recipe, modelId, opts);
+        } finally {
+          releaseEmbedSlot();
+        }
+      }));
     }
-    return allEmbeddings;
+    return subResults.flat();
   } catch (err) {
     _embedThrew = true;
     throw err;
@@ -1422,7 +1498,6 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
       // chars-per-token. On failure, A3 amended says charge the pessimistic
       // estimate too — embed has no output side, so the input estimate IS
       // the worst case.
-      const charsPerToken = recipe.touchpoints?.embedding?.chars_per_token ?? DEFAULT_CHARS_PER_TOKEN;
       const totalChars = truncated.reduce((s, t) => s + t.length, 0);
       const inputTokens = Math.ceil(totalChars / Math.max(charsPerToken, 1));
       try {

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -23,6 +23,7 @@ import { zhipu } from './zhipu.ts';
 import { azureOpenAI } from './azure-openai.ts';
 import { zeroentropyai } from './zeroentropyai.ts';
 import { llamaServerReranker } from './llama-server-reranker.ts';
+import { jina } from './jina.ts';
 
 const ALL: Recipe[] = [
   openai,
@@ -42,6 +43,7 @@ const ALL: Recipe[] = [
   zhipu,
   azureOpenAI,
   zeroentropyai,
+  jina,
 ];
 
 /** Map from `provider:id` key to recipe. */

--- a/src/core/ai/recipes/jina.ts
+++ b/src/core/ai/recipes/jina.ts
@@ -1,0 +1,46 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * Jina Embeddings via a self-hosted text-embeddings-inference (TEI) server.
+ *
+ * TEI with jina-v2-base-code ONNX enforces a 2048-token per-request limit.
+ * Code tokenizes at ~1 char/token; safety_factor=0.5 gives a 1024-char
+ * per-text budget — well under the hard limit even with tokenizer variance.
+ *
+ * The model list below covers the most common Jina v2/v3 models. Because TEI
+ * serves whatever model you launched it with, user_provided_models is set so
+ * the gateway accepts any `jina:<id>` the user supplies.
+ */
+export const jina: Recipe = {
+  id: 'jina',
+  name: 'Jina Embeddings (self-hosted TEI)',
+  tier: 'openai-compat',
+  implementation: 'openai-compatible',
+  base_url_default: 'http://localhost:8080/v1',
+  auth_env: {
+    required: [],
+    optional: ['JINA_BASE_URL', 'JINA_API_KEY'],
+    setup_url: 'https://github.com/huggingface/text-embeddings-inference',
+  },
+  touchpoints: {
+    embedding: {
+      models: [
+        'jina-embeddings-v2-base-code',
+        'jina-embeddings-v2-base-en',
+        'jina-embeddings-v2-small-en',
+        'jina-embeddings-v3',
+      ],
+      user_provided_models: true,
+      // v2 models output 768 dims. jina-embeddings-v3 outputs 1024 dims —
+      // pass --embedding-dimensions 1024 explicitly when using v3.
+      default_dims: 768,
+      cost_per_1m_tokens_usd: 0,
+      price_last_verified: '2026-06-17',
+      max_batch_tokens: 2048,
+      chars_per_token: 1,
+      safety_factor: 0.5,
+    },
+  },
+  setup_hint:
+    'Run text-embeddings-inference with a Jina model. Set JINA_BASE_URL to the server URL.',
+};

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -368,6 +368,12 @@ export interface AIGatewayConfig {
   base_urls?: Record<string, string>;
   /** Env snapshot read once at configuration time. Gateway never reads process.env at call time. */
   env: Record<string, string | undefined>;
+  /**
+   * Max concurrent embed sub-batch HTTP calls. Sourced from brain config
+   * `embed.http_concurrency` (via buildGatewayConfig); `GBRAIN_EMBED_HTTP_CONCURRENCY`
+   * env var overrides at configureGateway time. Default 1 (sequential).
+   */
+  embed_http_concurrency?: number;
 }
 
 export interface ParsedModelId {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -342,6 +342,16 @@ export interface GBrainConfig {
      */
     skills_dir?: string;
   };
+
+  /**
+   * Embed pipeline tunables. DB-plane keys (e.g. `embed.http_concurrency`)
+   * are merged here by `loadConfigWithEngine()`. File-plane config and
+   * env vars don't have an `embed` section; only the DB plane does.
+   */
+  embed?: {
+    /** Max concurrent embed sub-batch HTTP calls. Default 1 (sequential). */
+    http_concurrency?: number;
+  };
 }
 
 /**
@@ -790,6 +800,13 @@ export async function loadConfigWithEngine(
     merged.dream = mergedDream;
   }
 
+  // embed.* DB-plane merge. Currently only http_concurrency; extend here as
+  // more embed tunables graduate from env-only to config-key.
+  const dbEmbedHttpConcurrency = await dbInt('embed.http_concurrency');
+  if (dbEmbedHttpConcurrency !== undefined) {
+    merged.embed = { ...(merged.embed ?? {}), http_concurrency: merged.embed?.http_concurrency ?? dbEmbedHttpConcurrency };
+  }
+
   return merged;
 }
 
@@ -923,6 +940,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'spend.posture',
   'sync.cost_gate_min_usd',
   'sync.federated_v2',
+  'embed.http_concurrency',
   'embed.backfill_cooldown_min',
   'embed.backfill_max_usd_per_source_24h',
   'embed.backfill_max_usd',

--- a/test/ai/adaptive-embed-batch.test.ts
+++ b/test/ai/adaptive-embed-batch.test.ts
@@ -37,6 +37,7 @@ import {
   isTokenLimitError,
   __setEmbedTransportForTests,
   __getShrinkStateForTests,
+  __setEmbedConcurrencyForTests,
 } from '../../src/core/ai/gateway.ts';
 import { AIConfigError, AITransientError } from '../../src/core/ai/errors.ts';
 
@@ -81,6 +82,14 @@ function configureGoogle(): void {
     embedding_model: 'google:gemini-embedding-001',
     embedding_dimensions: 768,
     env: { GOOGLE_GENERATIVE_AI_API_KEY: 'fake' },
+  });
+}
+
+function configureJina(): void {
+  configureGateway({
+    embedding_model: 'jina:jina-embeddings-v2-base-code',
+    embedding_dimensions: 768,
+    env: {},
   });
 }
 
@@ -412,5 +421,198 @@ describe('startup warning for recipes missing max_batch_tokens', () => {
     expect(warnings.find(w => w.includes('"voyage"'))).toBeUndefined();
     expect(warnings.find(w => w.includes('"openai"'))).toBeUndefined();
     expect(warnings.find(w => w.includes('"google"'))).toBeDefined();
+  });
+});
+
+// --------- 8. Jina / self-hosted TEI: recipe-driven token budget + concurrent dispatch ---------
+//
+// These tests cover the two production issues solved by the Jina recipe:
+//
+//   A. max_batch_tokens=2048 in the Jina recipe triggers pre-splitting so
+//      pages with many chunks are never sent as one over-budget request.
+//
+//   B. embed.http_concurrency (set via __setEmbedConcurrencyForTests in tests)
+//      fans out sub-batches concurrently, saturating multiple TEI replicas.
+//      Output order is preserved via indexed Promise.all.
+
+describe('Jina recipe: recipe-driven pre-splitting', () => {
+  beforeEach(() => resetGateway());
+  afterEach(() => __setEmbedTransportForTests(null));
+
+  test('texts exceeding per-batch budget are split into multiple sub-batches', async () => {
+    // Jina: max_batch_tokens=2048, chars_per_token=1, safety_factor=0.5
+    // → batch budget = floor(2048 * 0.5) = 1024 chars
+    // 4 texts of 700 chars each: 700 < 1024 so one fits, 700+700=1400 > 1024
+    // → each goes into its own batch.
+    configureJina();
+
+    const stub = mock(async ({ values }: { values: string[] }) =>
+      ({ embeddings: values.map(() => new Array(768).fill(0.1)) })
+    );
+    __setEmbedTransportForTests(stub as any);
+
+    const texts = Array.from({ length: 4 }, () => 'x'.repeat(700));
+    const result = await embed(texts);
+
+    expect(result).toHaveLength(4);
+    // 4 texts × 700 chars, budget 1024 → 4 sub-batches of 1.
+    expect(stub).toHaveBeenCalledTimes(4);
+  });
+
+  test('texts fitting within budget are batched together', async () => {
+    // 4 texts of 200 chars each: 200+200=400, 400+200=600, 600+200=800 < 1024
+    // → all 4 fit in one batch.
+    configureJina();
+
+    const stub = mock(async ({ values }: { values: string[] }) =>
+      ({ embeddings: values.map(() => new Array(768).fill(0.1)) })
+    );
+    __setEmbedTransportForTests(stub as any);
+
+    const texts = Array.from({ length: 4 }, () => 'x'.repeat(200));
+    const result = await embed(texts);
+
+    expect(result).toHaveLength(4);
+    expect(stub).toHaveBeenCalledTimes(1);
+  });
+
+  test('output order preserved across sub-batches', async () => {
+    // 3 texts of 700 chars → 3 sub-batches. Each call's index encodes in
+    // slot[0] so we can verify the final concat is in input order.
+    configureJina();
+
+    let callIdx = 0;
+    const stub = mock(async ({ values }: { values: string[] }) => {
+      const idx = callIdx++;
+      return { embeddings: values.map(() => Array.from({ length: 768 }, (_, j) => j === 0 ? idx : 0)) };
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    const texts = ['a'.repeat(700), 'b'.repeat(700), 'c'.repeat(700)];
+    const result = await embed(texts);
+
+    expect(result).toHaveLength(3);
+    expect(result.map(v => v[0])).toEqual([0, 1, 2]);
+  });
+});
+
+describe('Jina recipe: concurrent sub-batch dispatch', () => {
+  beforeEach(() => resetGateway());
+  afterEach(() => {
+    __setEmbedTransportForTests(null);
+    __setEmbedConcurrencyForTests(null);
+  });
+
+  test('semaphore limits concurrent in-flight calls to the configured limit', async () => {
+    configureJina();
+    // 5 sub-batches but max 2 concurrent.
+    __setEmbedConcurrencyForTests(2);
+
+    let concurrent = 0;
+    let maxSeen = 0;
+    const stub = mock(async ({ values }: { values: string[] }) => {
+      concurrent++;
+      maxSeen = Math.max(maxSeen, concurrent);
+      await new Promise(r => setTimeout(r, 0));
+      concurrent--;
+      return { embeddings: values.map(() => new Array(768).fill(0.1)) };
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    // 5 texts of 700 chars → 5 sub-batches of 1.
+    const texts = Array.from({ length: 5 }, () => 'x'.repeat(700));
+    await embed(texts);
+
+    expect(maxSeen).toBeLessThanOrEqual(2);
+    expect(stub).toHaveBeenCalledTimes(5);
+  });
+
+  test('concurrency=1 (default) executes sub-batches sequentially', async () => {
+    configureJina();
+    __setEmbedConcurrencyForTests(1);
+
+    const callOrder: number[] = [];
+    const stub = mock(async ({ values }: { values: string[] }) => {
+      callOrder.push(callOrder.length);
+      await new Promise(r => setTimeout(r, 0));
+      return { embeddings: values.map(() => new Array(768).fill(0.1)) };
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    // 3 sub-batches of 1 text each.
+    const texts = Array.from({ length: 3 }, () => 'x'.repeat(700));
+    const result = await embed(texts);
+
+    expect(stub).toHaveBeenCalledTimes(3);
+    expect(result).toHaveLength(3);
+    expect(callOrder).toEqual([0, 1, 2]);
+  });
+});
+
+// --------- 9. Per-text truncation from recipe token budget ---------
+//
+// When a recipe declares max_batch_tokens, embed() must cap each individual
+// text to (max_batch_tokens × safety_factor × chars_per_token) chars before
+// splitting. Without this, a single oversized chunk lands in a sub-batch of 1
+// and still hangs the provider — splitByTokenBudget operates at batch level,
+// not within a text. This fires for ANY recipe with max_batch_tokens, not
+// just Jina.
+
+describe('per-text truncation from recipe token budget', () => {
+  beforeEach(() => resetGateway());
+  afterEach(() => __setEmbedTransportForTests(null));
+
+  test('Jina recipe: texts longer than per-text budget are truncated before splitting', async () => {
+    // Jina: max_batch_tokens=2048, chars_per_token=1, safety_factor=0.5
+    // → perTextMaxChars = min(8000, floor(2048 * 0.5 * 1)) = 1024
+    configureGateway({
+      embedding_model: 'jina:jina-embeddings-v2-base-code',
+      embedding_dimensions: 768,
+      env: {},
+    });
+
+    const received: string[][] = [];
+    const stub = mock(async ({ values }: { values: string[] }) => {
+      received.push([...values]);
+      return { embeddings: values.map(() => new Array(768).fill(0.1)) };
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    // 3 texts of 2000 chars each — all exceed the 1024-char per-text budget.
+    const texts = ['a'.repeat(2000), 'b'.repeat(2000), 'c'.repeat(2000)];
+    const result = await embed(texts);
+
+    expect(result).toHaveLength(3);
+    // Every text sent to the provider must be ≤ 1024 chars.
+    const allTexts = received.flat();
+    expect(allTexts).toHaveLength(3);
+    for (const t of allTexts) {
+      expect(t.length).toBeLessThanOrEqual(1024);
+    }
+  });
+
+  test('recipe with no max_batch_tokens: texts are not truncated below MAX_CHARS', async () => {
+    // OpenAI has no max_batch_tokens — fast path, no per-text budget cap.
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-large',
+      embedding_dimensions: 1536,
+      env: { OPENAI_API_KEY: 'sk-fake' },
+    });
+
+    const received: string[][] = [];
+    const stub = mock(async ({ values }: { values: string[] }) => {
+      received.push([...values]);
+      return { embeddings: values.map(() => new Array(1536).fill(0.1)) };
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    // 3 texts of 2000 chars — under MAX_CHARS=8000, so no truncation.
+    const texts = ['a'.repeat(2000), 'b'.repeat(2000), 'c'.repeat(2000)];
+    await embed(texts);
+
+    const allTexts = received.flat();
+    for (const t of allTexts) {
+      expect(t.length).toBe(2000); // untouched
+    }
   });
 });


### PR DESCRIPTION
## Problem

Pointing gbrain's embedding pipeline at a self-hosted [text-embeddings-inference](https://github.com/huggingface/text-embeddings-inference) (TEI) server surfaces three gaps. TEI enforces a fixed per-request token budget and is typically run as N replicas behind a load balancer:

1. **No recipe for it.** The `openai-compatible` recipes that *could* point at TEI (ollama, llama-server) declare `no_batch_cap`, so the token-split path never engages — a page's chunks are sent as one over-budget request and the server hangs until the client timeout fires.
2. **Per-text truncation is too coarse.** `embed()` caps each text to a flat `MAX_CHARS` (8000) before `splitByTokenBudget()`. A single chunk larger than the recipe's per-request budget lands in a sub-batch of 1 and *still* exceeds the limit — splitting can't help at the individual-text level. **This affects any recipe with `max_batch_tokens` (Voyage, ZeroEntropy), not just self-hosted TEI.**
3. **Sequential dispatch wastes replicas.** Multi-batch `embed()` calls dispatch sub-batches strictly one-at-a-time, so a single replica works while the rest sit idle.

## Fix

### 1. Jina Embeddings recipe (`src/core/ai/recipes/jina.ts`)

A new `openai-compatible` recipe for self-hosted TEI, declaring `max_batch_tokens: 2048`, `chars_per_token: 1`, `safety_factor: 0.5` (sized for `jina-v2-base-code` ONNX). `user_provided_models` lets the gateway accept any `jina:<id>` the server was launched with. `JINA_BASE_URL` threads into the gateway `base_urls`, mirroring `OLLAMA_BASE_URL` / `LLAMA_SERVER_BASE_URL`.

### 2. Per-text truncation from the recipe token budget (`gateway.ts`)

When a recipe declares `max_batch_tokens`, each text is now capped to `min(MAX_CHARS, floor(max_batch_tokens × safety_factor × chars_per_token))` chars before splitting — the same formula the pre-split budget already uses, extended one level down to the individual text. This is a **latent correctness fix** that benefits Voyage/ZeroEntropy too: an oversized single chunk previously hung the provider regardless of recipe.

### 3. Concurrent sub-batch dispatch via `embed.http_concurrency`

Sub-batches now dispatch through `Promise.all` bounded by a process-global FIFO semaphore; **output order is preserved** via indexed slots. The limit comes from the `embed.http_concurrency` brain-config key (**default 1 = prior sequential behaviour**, so no change on upgrade), overridable at incident time by `GBRAIN_EMBED_HTTP_CONCURRENCY`. Single-batch calls skip the semaphore (fast path).

Measured against a self-hosted TEI deployment (6 replicas, `jina-v2-base-code`): a ~37k-chunk corpus embedded in ~20 min at `http_concurrency=48` vs ~10h sequentially, with all replicas saturated instead of one.

## Safety

- **Default behaviour is unchanged.** `embed.http_concurrency` defaults to 1 (sequential); the per-text cap only tightens for recipes that already declare `max_batch_tokens`; OpenAI's fast path (no budget) is untouched.
- **Output order preserved** under concurrent dispatch (indexed `Promise.all`, verified by test).
- **No new env-var surface beyond one documented override.** Concurrency is a config key first; `GBRAIN_EMBED_HTTP_CONCURRENCY` is an incident-time escape hatch.

## Tests

32 cases in `test/ai/adaptive-embed-batch.test.ts`:
- Recipe-driven pre-splitting (split when over budget, batch together when under, order preservation)
- Per-text truncation (Jina recipe truncates to budget; fast-path recipes pass texts through untouched)
- Concurrent dispatch (semaphore bounds in-flight calls; `concurrency=1` stays sequential)

`bun run typecheck` clean.