### PR TITLE
fix(cli): route `gbrain capture` through put_page on thin-client installs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1451,6 +1451,25 @@ async function handleCliOnly(command: string, args: string[]) {
     }
   }
 
+  // `gbrain capture` on thin-client installs bypasses connectEngine entirely —
+  // capture routes through the `put_page` MCP op (runCapture's own thin-client
+  // branch, which passes engine=null). capture is a CLI_ONLY command, so unlike
+  // put / search / whoami it does NOT pass through the shared-op routing seam in
+  // main(); without this bypass it fell through to the unconditional
+  // connectEngine() below and died with "No database URL: database_url is
+  // missing from config" on thin-client configs — while put routed remote fine.
+  // capture is intentionally NOT in THIN_CLIENT_REFUSED_COMMANDS because it CAN
+  // run remotely (the server exposes put_page). Mirrors the `status` /
+  // `eval whoknows` thin-client bypasses above.
+  if (command === 'capture') {
+    const cfgPre = loadConfig();
+    if (isThinClient(cfgPre)) {
+      const { runCapture } = await import('./commands/capture.ts');
+      await runCapture(null, args);
+      return;
+    }
+  }
+
   // v0.37 fix wave (Lane D.4 + CDX2-12): short-circuit `gbrain sync --help`
   // BEFORE the engine bind. runSync has its own --help branch but can't
   // reach it without an engine — which means a user running `--help` from

--- a/test/cli-dispatch-thin-client.test.ts
+++ b/test/cli-dispatch-thin-client.test.ts
@@ -155,6 +155,33 @@ describe('thin-client doctor routes to runRemoteDoctor', () => {
   });
 });
 
+describe('thin-client capture routes remote (does NOT open local engine)', () => {
+  // Regression for the "capture breaks on thin-client" bug. `capture` is a
+  // CLI_ONLY command, so it does NOT pass through the shared-op routing seam
+  // that put / search / whoami use. Before the fix, handleCliOnly had no
+  // thin-client bypass for capture (unlike `status` / `eval whoknows`), so it
+  // fell through to the unconditional `connectEngine()` and died with
+  // "No database URL: database_url is missing from config" — even though
+  // capture has a perfectly good thin-client branch that routes through
+  // callRemoteTool('put_page', ...). put routed remote fine; only capture broke.
+  test('`gbrain capture "..."` routes through put_page, never opens the local engine', async () => {
+    seedThinClientConfig();
+    const r = await run(['capture', 'a thin-client capture thought']);
+    // MUST NOT have tried to open a local Postgres engine. That path throws
+    // the "No database URL" GBrainError from src/core/db.ts — the exact bug.
+    expect(r.stderr).not.toContain('No database URL');
+    expect(r.stderr).not.toContain('database_url is missing');
+    // MUST have routed to the remote MCP instead. brain-host.example is
+    // unreachable in the test env, so capture's thin-client branch surfaces a
+    // remote put_page failure. The "remote put_page failed:" prefix is unique
+    // to capture.ts's thin-client catch block — it can never appear on the
+    // local-engine path — so it is the precise proof that capture routed
+    // through callRemoteTool('put_page', ...) per the README contract.
+    expect(r.stderr).toContain('remote put_page failed');
+    expect(r.exitCode).toBe(1);
+  });
+});
+
 describe('regression — local config still passes through normally', () => {
   test('local PGLite config does NOT trigger thin-client guard for `sync`', async () => {
     // Seed a local PGLite config (no remote_mcp). `gbrain sync` shouldn't


### PR DESCRIPTION
## Summary

On a **thin-client install** (config has `remote_mcp`, no local `database_url`), `gbrain capture "..."` errors out:

```
No database URL: database_url is missing from config.
Fix: Run gbrain init --supabase or gbrain init --url
```

…even though `gbrain put`, `gbrain whoami`, and `gbrain search` all route remote correctly on the **exact same config**. Only `capture` breaks.

This violates the documented contract (README + CHANGELOG):

> thin-client installs route through `callRemoteTool('put_page', ...)`. Same UX both ways.

## Reproduce

```bash
gbrain init --mcp-only \
  --issuer-url <url> --mcp-url <url>/mcp \
  --oauth-client-id <id> --oauth-client-secret <secret>
# creates a config with remote_mcp and NO database_url

gbrain capture "test"
# → No database URL: database_url is missing from config. ...
```

`gbrain put inbox/x` on the same config routes remote correctly (it only fails on *reaching* the server), proving the issue is specific to `capture`.

## Root cause

`capture` is a **`CLI_ONLY`** command, so it is dispatched through `handleCliOnly()` rather than the shared-op routing seam in `main()` that sends non-`localOnly` ops through `runThinClientRouted` on thin-client installs.

`handleCliOnly` already has thin-client bypasses for `status` and `eval whoknows` (both pass `engine=null` and return before connecting) — but **not for `capture`**. So `capture` falls through to the unconditional `connectEngine()`, which throws `No database URL` from `src/core/db.ts` **before** capture's own thin-client branch (`callRemoteTool('put_page', ...)`) can ever run.

`src/commands/capture.ts` was already correct: `runCapture` accepts `engine=null` and guards every local-engine use behind `isThinClient(cfg)` (the source resolver at ~L426, the `put_page`-op fallback at ~L506). The only thing missing was the **dispatch-time bypass** so the local engine is never opened on a thin-client.

`put` / `whoami` / `search` work because they are registered ops (not `CLI_ONLY`) and hit the `main()` routing seam.

## Fix

Add a thin-client bypass for `capture` in `handleCliOnly`, mirroring the existing `status` / `eval whoknows` guards:

```ts
if (command === 'capture') {
  const cfgPre = loadConfig();
  if (isThinClient(cfgPre)) {
    const { runCapture } = await import('./commands/capture.ts');
    await runCapture(null, args);
    return;
  }
}
```

`capture` is intentionally **not** added to `THIN_CLIENT_REFUSED_COMMANDS` because it *can* run remotely (the server exposes `put_page`).

## Test

Adds a regression test to `test/cli-dispatch-thin-client.test.ts` that seeds a thin-client config, spawns `gbrain capture`, and asserts it never emits `No database URL` and instead surfaces the remote `put_page` path. The `"remote put_page failed:"` prefix is unique to capture's thin-client `catch` and cannot appear on the local-engine path, so it is precise proof of remote routing. Watched it fail before the fix (RED) and pass after (GREEN).

## Verification

- `tsc --noEmit` — clean
- `bun run verify` (30 checks) — all green
- `bun test` on `cli-dispatch-thin-client`, `thin-client-routing-audit`, `capture-runcapture`, `commands/capture`, `ingestion/ingest-capture` — **97 pass, 0 fail**

## Notes

- **Local installs are unchanged**: the bypass is gated on `isThinClient(cfg)`, so local-engine capture takes the existing path untouched.
- `src/commands/capture.ts` is unchanged from v0.42.36 through current master, so this bug is present on master too.
