### PR TITLE
fix(subagent): persist + reconcile tool-result turns in the gateway loop

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2958,6 +2958,16 @@ export interface ToolLoopOpts {
   onToolCallComplete?: (gbrainToolUseId: string, output: unknown) => Promise<void>;
   onToolCallFailed?: (gbrainToolUseId: string, error: string) => Promise<void>;
 
+  /**
+   * Persist the synthesized tool-result user turn AFTER every tool in the turn
+   * settles. Without it the assistant tool-call turn is persisted (onAssistantTurn)
+   * but its results are not, so crash-replay rebuilds an unbalanced conversation
+   * (assistant tool-calls with no matching tool-results) and the next chat()
+   * dispatch throws "Tool results are missing". Mirrors the legacy Anthropic
+   * path's user-turn persist in subagent.ts.
+   */
+  onToolResultTurn?: (turnIdx: number, messageIdx: number, blocks: ChatBlock[]) => Promise<void>;
+
   /** Optional per-call heartbeat for observability. */
   onHeartbeat?: (event: string, data: Record<string, unknown>) => void;
 }
@@ -3180,9 +3190,12 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
 
     if (stopReason === 'aborted') break;
 
-    // Feed all tool results back as a single user message.
+    // Feed all tool results back as a single user message. Persist it BEFORE
+    // the next dispatch so crash-replay rebuilds a balanced conversation —
+    // without this, resume sends assistant tool-calls with no matching
+    // tool-results and chat() throws "Tool results are missing".
     const userMessageIdx = messageIdx++;
-    void userMessageIdx;
+    await opts.onToolResultTurn?.(turnIdx, userMessageIdx, toolResultBlocks);
     messages.push({ role: 'user', content: toolResultBlocks });
 
     turnIdx++;

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -806,6 +806,51 @@ async function runSubagentViaGateway(args: GatewayRunArgs): Promise<SubagentResu
     nextMessageIdx = 1;
   }
 
+  // Crash-replay reconciliation. The gateway loop persists the assistant
+  // tool-call turn (onAssistantTurn) before executing tools and persisting the
+  // tool-result turn (onToolResultTurn). A crash in that window leaves the last
+  // persisted message an assistant turn with unanswered tool-calls, so the first
+  // chat() on resume throws "Tool results are missing". Re-synthesize the
+  // tool-result turn from the settled execution rows (keyed by provider id).
+  // Mirrors the legacy Anthropic path's reconciliation.
+  const lastPrior = priorChatMessages[priorChatMessages.length - 1];
+  if (lastPrior && lastPrior.role === 'assistant' && Array.isArray(lastPrior.content)) {
+    const pendingCalls = lastPrior.content.filter(
+      (b): b is Extract<ChatBlock, { type: 'tool-call' }> =>
+        typeof b === 'object' && b !== null && (b as { type?: unknown }).type === 'tool-call',
+    );
+    if (pendingCalls.length > 0) {
+      const settledByProviderId = new Map(
+        (await loadPriorTools(engine, ctx.id)).map(t => [t.tool_use_id, t]),
+      );
+      const reconciled: ChatBlock[] = [];
+      for (const call of pendingCalls) {
+        const outcome = settledByProviderId.get(call.toolCallId);
+        if (outcome?.status === 'complete') {
+          reconciled.push({ type: 'tool-result', toolCallId: call.toolCallId, toolName: call.toolName, output: outcome.output });
+        } else if (outcome?.status === 'failed') {
+          reconciled.push({ type: 'tool-result', toolCallId: call.toolCallId, toolName: call.toolName, output: outcome.error ?? 'tool failed', isError: true });
+        } else {
+          // A tool was still mid-execute (or never persisted) at the crash — we
+          // cannot safely reconstruct its result without risking a re-run of a
+          // non-idempotent tool. Leave it to the loop's own replay short-circuit.
+          reconciled.length = 0;
+          break;
+        }
+      }
+      if (reconciled.length === pendingCalls.length) {
+        await persistMessage(engine, ctx.id, {
+          message_idx: nextMessageIdx,
+          role: 'user',
+          content_blocks: reconciled as unknown as ContentBlock[],
+          tokens_in: null, tokens_out: null, tokens_cache_read: null, tokens_cache_create: null, model: null,
+        });
+        priorChatMessages.push({ role: 'user', content: reconciled });
+        nextMessageIdx++;
+      }
+    }
+  }
+
   // Capability detection drives cache_control injection.
   const verdict = classifyCapabilities(model);
   const cacheSystem = verdict === 'ok' || verdict === 'degraded:no_parallel';
@@ -903,6 +948,22 @@ async function runSubagentViaGateway(args: GatewayRunArgs): Promise<SubagentResu
          WHERE gbrain_tool_use_id::text = $2`,
         [errorMsg, gbrainToolUseId],
       );
+    },
+    onToolResultTurn: async (_turnIdx, messageIdx, blocks) => {
+      // Persist the tool-result user turn so crash-replay reconstructs a
+      // balanced conversation. The gateway loop persists assistant turns via
+      // onAssistantTurn; without this symmetric write the tool-result turns
+      // were dropped and resume failed with "Tool results are missing".
+      await persistMessage(engine, ctx.id, {
+        message_idx: messageIdx,
+        role: 'user',
+        content_blocks: blocks as unknown as ContentBlock[],
+        tokens_in: null,
+        tokens_out: null,
+        tokens_cache_read: null,
+        tokens_cache_create: null,
+        model: null,
+      });
     },
     onHeartbeat: heartbeat,
   });

--- a/test/e2e/subagent-gateway-toolresult-replay.test.ts
+++ b/test/e2e/subagent-gateway-toolresult-replay.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Regression: the gateway-native subagent loop must persist the tool-result
+ * user turn and reconcile it on crash-replay, so a resumed conversation is
+ * structurally balanced (every assistant tool-call is answered by a matching
+ * tool-result before the next dispatch).
+ *
+ * The bug: `gateway.toolLoop` pushed the tool-result user turn to the in-memory
+ * array but never persisted it (no `onToolResultTurn` callback), and the
+ * gateway path had no replay reconciliation. After any interruption between the
+ * assistant-turn persist and turn completion, replay rebuilt
+ * `[user, assistant(tool-calls)]` with no tool-results, and the next real
+ * `chat()` threw "Tool results are missing for tool calls ...". It poisoned
+ * every retry → dead job. It only hit the non-Anthropic stack (the legacy
+ * Anthropic path already persisted + reconciled tool-result turns).
+ *
+ * Why the existing crash-replay test missed it: that suite stubs the chat
+ * transport, so the real AI SDK validator never runs and an unbalanced messages
+ * array is never rejected. This test captures what the loop hands to `chat()`
+ * on resume and asserts it is balanced — the property the validator enforces in
+ * production.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
+import { resetPgliteState } from '../helpers/reset-pglite.ts';
+import { makeSubagentHandler } from '../../src/core/minions/handlers/subagent.ts';
+import type { MinionJobContext, ToolDef, ToolCtx } from '../../src/core/minions/types.ts';
+import {
+  __setChatTransportForTests,
+  configureGateway,
+  resetGateway,
+  type ChatBlock,
+  type ChatMessage,
+  type ChatResult,
+} from '../../src/core/ai/gateway.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+  resetGateway();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+  await engine.setConfig('version', '85');
+  await engine.setConfig('agent.use_gateway_loop', 'true');
+  configureGateway({
+    chat_model: 'anthropic:claude-sonnet-4-6',
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    expansion_model: 'anthropic:claude-haiku-4-5',
+    env: {
+      ANTHROPIC_API_KEY: 'stub',
+      OPENAI_API_KEY: 'stub',
+      DEEPSEEK_API_KEY: 'stub',
+      GROQ_API_KEY: 'stub',
+      TOGETHER_API_KEY: 'stub',
+    },
+  });
+});
+
+afterEach(() => {
+  __setChatTransportForTests(null);
+});
+
+function makeStubTools(executions: Array<{ name: string; input: unknown }>): ToolDef[] {
+  return [{
+    name: 'search',
+    description: 'stub search',
+    input_schema: { type: 'object' },
+    idempotent: true,
+    async execute(input: unknown, _ctx: ToolCtx) {
+      executions.push({ name: 'search', input });
+      return { results: [{ slug: 'wiki/foo' }] };
+    },
+  }];
+}
+
+function buildHandler(toolRegistry: ToolDef[]) {
+  return makeSubagentHandler({
+    engine,
+    config: {} as any,
+    toolRegistry,
+    makeAnthropic: () => ({ messages: { create: async () => { throw new Error('legacy path should not be invoked'); } } }) as any,
+  });
+}
+
+function makeCtx(jobId: number, prompt: string, modelId: string): MinionJobContext {
+  return {
+    id: jobId,
+    name: 'subagent',
+    data: { prompt, model: modelId },
+    attempts_made: 1,
+    signal: new AbortController().signal,
+    shutdownSignal: new AbortController().signal,
+    updateProgress: async () => {},
+    updateTokens: async () => {},
+    log: async () => {},
+    isActive: async () => true,
+    readInbox: async () => [],
+  } as MinionJobContext;
+}
+
+/**
+ * Seed the exact poisoned shape this bug produced: the assistant tool-call turn
+ * persisted (idx 1) and the tool execution marked complete, but NO tool-result
+ * user turn at idx 2 (the gateway path never wrote it).
+ */
+async function seedToolResultGapState(prompt: string, providerToolCallId: string, model: string) {
+  const jobRows = await engine.executeRaw<{ id: number }>(
+    `INSERT INTO minion_jobs (name, status, data, queue, priority, created_at)
+     VALUES ('subagent', 'active', $1::jsonb, 'default', 0, now()) RETURNING id`,
+    [JSON.stringify({ prompt })],
+  );
+  const jobId = jobRows[0].id;
+  await engine.executeRaw(
+    `INSERT INTO subagent_messages (job_id, message_idx, role, content_blocks, model)
+     VALUES ($1, 0, 'user', $2::jsonb, NULL),
+            ($1, 1, 'assistant', $3::jsonb, $4)`,
+    [
+      jobId,
+      JSON.stringify([{ type: 'text', text: prompt }]),
+      JSON.stringify([{ type: 'tool-call', toolCallId: providerToolCallId, toolName: 'search', input: { q: 'foo' } }]),
+      model,
+    ],
+  );
+  await engine.executeRaw(
+    `INSERT INTO subagent_tool_executions
+       (job_id, message_idx, tool_use_id, tool_name, input, status, schema_version, ordinal, gbrain_tool_use_id, output)
+     VALUES ($1, 1, $2, 'search', '{}'::jsonb, 'complete', 2, 0, '01987654-3210-7000-8000-aaaaaaaaaaaa'::uuid, $3::jsonb)`,
+    [jobId, providerToolCallId, JSON.stringify({ results: ['prior'] })],
+  );
+  return jobId;
+}
+
+/**
+ * The fix lives in the provider-agnostic gateway loop, so it must hold for every
+ * non-Anthropic provider that routes through it. Parametrize the crash-replay
+ * property across the recognized tool-capable non-Anthropic recipes rather than
+ * a single provider, so a regression on any one surfaces here.
+ */
+const NON_ANTHROPIC_PROVIDERS: ReadonlyArray<{ model: string; providerId: string }> = [
+  { model: 'openai:gpt-4o-mini', providerId: 'openai' },
+  { model: 'deepseek:deepseek-chat', providerId: 'deepseek' },
+  { model: 'groq:llama-3.3-70b-versatile', providerId: 'groq' },
+  { model: 'together:meta-llama/Llama-3.3-70B-Instruct-Turbo', providerId: 'together' },
+];
+
+describe('gateway subagent loop — tool-result turn persistence + replay reconciliation', () => {
+  for (const provider of NON_ANTHROPIC_PROVIDERS) {
+    it(`resume hands chat() a BALANCED conversation on ${provider.providerId} (every assistant tool-call answered)`, async () => {
+      const providerToolCallId = 'call_8Alll6DvrBKPDeD1hGofWJSD';
+      const seenMessages: ChatMessage[][] = [];
+      __setChatTransportForTests(async (opts): Promise<ChatResult> => {
+        seenMessages.push(opts.messages as ChatMessage[]);
+        return {
+          text: 'final answer after replay',
+          blocks: [{ type: 'text', text: 'final answer after replay' }] as ChatBlock[],
+          stopReason: 'end',
+          usage: { input_tokens: 20, output_tokens: 6, cache_read_tokens: 0, cache_creation_tokens: 0 },
+          model: provider.model,
+          providerId: provider.providerId,
+        };
+      });
+
+      const executions: Array<{ name: string; input: unknown }> = [];
+      const handler = buildHandler(makeStubTools(executions));
+      const jobId = await seedToolResultGapState('surface patterns', providerToolCallId, provider.model);
+
+      const result = await handler(makeCtx(jobId, 'surface patterns', provider.model));
+
+      // The prior complete tool is NOT re-executed.
+      expect(executions.length).toBe(0);
+      expect(result.result).toBe('final answer after replay');
+
+      // The conversation handed to chat() on resume must be balanced: the
+      // assistant tool-call turn is followed by a user turn carrying a
+      // tool-result for the same id. Pre-fix, the resume dispatch ended with the
+      // unanswered assistant tool-call and the real validator would have thrown.
+      const firstDispatch = seenMessages[0];
+      const asstIdx = firstDispatch.findIndex(
+        m => m.role === 'assistant' && Array.isArray(m.content) && m.content.some(b => (b as ChatBlock).type === 'tool-call'),
+      );
+      expect(asstIdx).toBeGreaterThanOrEqual(0);
+      const answered = new Set<string>();
+      for (const m of firstDispatch.slice(asstIdx + 1)) {
+        if (Array.isArray(m.content)) {
+          for (const b of m.content) {
+            if ((b as ChatBlock).type === 'tool-result') answered.add((b as Extract<ChatBlock, { type: 'tool-result' }>).toolCallId);
+          }
+        }
+      }
+      expect(answered.has(providerToolCallId)).toBe(true);
+    });
+  }
+
+  it('persists the reconciled tool-result user turn to subagent_messages (state is balanced on disk)', async () => {
+    const providerToolCallId = 'call_uLo1qezAkyyFv8EwNL6ekaP8';
+    const provider = NON_ANTHROPIC_PROVIDERS[0];
+    __setChatTransportForTests(async (): Promise<ChatResult> => ({
+      text: 'done',
+      blocks: [{ type: 'text', text: 'done' }] as ChatBlock[],
+      stopReason: 'end',
+      usage: { input_tokens: 10, output_tokens: 2, cache_read_tokens: 0, cache_creation_tokens: 0 },
+      model: provider.model,
+      providerId: provider.providerId,
+    }));
+
+    const handler = buildHandler(makeStubTools([]));
+    const jobId = await seedToolResultGapState('surface patterns', providerToolCallId, provider.model);
+    await handler(makeCtx(jobId, 'surface patterns', provider.model));
+
+    const rows = await engine.executeRaw<{ message_idx: number; role: string; content_blocks: unknown }>(
+      `SELECT message_idx, role, content_blocks FROM subagent_messages WHERE job_id = $1 ORDER BY message_idx`,
+      [jobId],
+    );
+    // Find a user turn carrying a tool-result for the crashed call id.
+    const hasReconciledTurn = rows.some(r => {
+      if (r.role !== 'user') return false;
+      const blocks = typeof r.content_blocks === 'string' ? JSON.parse(r.content_blocks) : r.content_blocks;
+      return Array.isArray(blocks) && blocks.some((b: any) => b?.type === 'tool-result' && b?.toolCallId === providerToolCallId);
+    });
+    expect(hasReconciledTurn).toBe(true);
+  });
+});


### PR DESCRIPTION

Closes #2273

## Summary

**The bug.** Subagent jobs that take the gateway-loop path (`agent.use_gateway_loop = true`, used by every non-Anthropic recipe) die deterministically after any mid-conversation interruption with `[chat(litellm:gpt-X.Y)] Tool results are missing for tool calls call_<id>, ...`. The failure scaled with parallel-tool-call count, which read as a provider-bridge bug but was not. The error came from the next `chat()` dispatch operating on a stale in-memory message array, not from the wire response of the prior call.

**The fix.** `gateway.toolLoop` gains an `onToolResultTurn` callback fired when the tool-result user turn is built. `runSubagentViaGateway` wires the callback to persist the turn before the next dispatch AND reconciles on replay: when prior messages end with unanswered tool-calls, it re-synthesizes the tool-result turn from the settled `subagent_tool_executions` rows. Bails if any tool is still unsettled, so a non-idempotent tool is never re-run.

This mirrors the legacy Anthropic-direct path's existing reconciliation behavior; the gateway path was the only dispatch shape that lacked it.

## Diagnosis

- `gateway.toolLoop` (pre-patch) built the tool-result user turn in memory after the tool executions settled, then discarded the index. `runSubagentViaGateway` had no persistence hook, so the turn never reached `subagent_messages`.
- On any interruption (worker recycle, rate-lease renewal, RSS watchdog, abort, clean shutdown), replay rebuilt the conversation from `subagent_messages` without the tool-result row. The shape was unbalanced: assistant `tool_call` turns with no matching `tool` user turns.
- The next `chat()` dispatch hit the provider's validator with the unbalanced shape; provider returned the "Tool results are missing for tool calls ..." error; worker treated as hard failure, retried the same unbalanced shape, dead-lettered the job.
- The legacy Anthropic-direct path in `src/core/minions/handlers/subagent.ts` already persists the user-turn reconciliation; the gateway path was simply never extended.

## Reproduction

1. Brain configured for any non-Anthropic chat provider (litellm-proxy, ollama, openrouter, openai, deepseek, groq). Set `agent.use_gateway_loop = true`.
2. Submit a subagent job whose dispatch fires parallel tool calls (`gbrain dream --phase patterns` is the deterministic local trigger).
3. Interrupt mid-conversation: `kill -TERM` the worker, or let the RSS watchdog recycle the process.
4. The worker re-claims the job and replays. Replay rebuilds the conversation from persisted rows.
5. Next `chat()` throws `Tool results are missing for tool calls call_<id>, ...`. Job dead-letters.

Observed on gbrain 0.42.43.0 through 0.42.51.0.

## Tests

- New `test/e2e/subagent-gateway-toolresult-replay.test.ts`: captures the real transport input shape and asserts the resumed conversation is balanced, parametrized across the recognized tool-capable non-Anthropic providers (openai, deepseek, groq, together) so the provider-agnostic property is proven per provider, not assumed. Fails on master without the patch; passes with it. ~5s runtime.
- Verified end-to-end on a production-shaped brain routing through an OpenAI-compatible proxy. Pre-patch: every interruption dead-lettered the active jobs; post-patch: every interruption resumed cleanly across worker recycles, RSS-watchdog kills, and clean restarts.
- `bun run typecheck` clean. `bun run verify` green.

## Adjacent observation (not in this PR)

`agent.use_gateway_loop` is missing from `KNOWN_CONFIG_KEYS` (operators have to discover the `--force` escape hatch from the error message). And with the gateway path's recipe coverage now broad (every non-Anthropic provider plus Anthropic itself via `native-anthropic`), the default could flip from `false` to `true`. Both worth follow-up discussion; not in scope here.

