### PR TITLE
fix(dream): drop ANTHROPIC_API_KEY gate from patterns phase

### DIFF
--- a/src/core/cycle/patterns.ts
+++ b/src/core/cycle/patterns.ts
@@ -63,11 +63,12 @@ export async function runPhasePatterns(
       });
     }
 
-    // Submit one subagent for pattern detection.
-    if (!process.env.ANTHROPIC_API_KEY) {
-      return skipped('no_api_key', 'ANTHROPIC_API_KEY unset; pattern detection skipped');
-    }
-
+    // Submit one subagent for pattern detection. The subagent dispatches via
+    // the gateway model-tier resolver, so a hardcoded ANTHROPIC_API_KEY gate
+    // here misclassifies non-Anthropic stacks (litellm/codex-proxy) as
+    // "no upstream" even though synthesize routes through the same gateway
+    // happily. Synthesize already dropped its cheap-skip gate (see
+    // makeJudgeClient docstring); patterns now matches.
     const allowedSlugPrefixes = await loadAllowedSlugPrefixes();
     if (allowedSlugPrefixes.length === 0) {
       return failed(makeError('InternalError', 'NO_ALLOWLIST',


### PR DESCRIPTION

Closes #2278, #2782

## Summary

**The bug.** `gbrain dream --phase patterns` returns `{ status: 'skipped', reason: 'no_api_key' }` on any non-Anthropic stack (litellm-proxy, codex-proxy, ollama, openrouter, any openai-compat deployment) regardless of how `models.dream.patterns` resolves. The phase never reaches its subagent submission below, which would have routed through the gateway and dispatched correctly.

**The fix.** Drop the `if (!process.env.ANTHROPIC_API_KEY)` short-circuit in `src/core/cycle/patterns.ts`. The subagent submission below already uses the same gateway model-tier resolver that synthesize uses; when the gateway is misconfigured, dispatch surfaces a clear `AIConfigError` per-call rather than a misclassified `skipped: no_api_key` verdict.

## Diagnosis

- `src/core/cycle/patterns.ts:67-69` (pre-patch) short-circuits when `ANTHROPIC_API_KEY` is unset:

  ```ts   if (!process.env.ANTHROPIC_API_KEY) {     return skipped('no_api_key', 'ANTHROPIC_API_KEY unset; pattern detection skipped');   }   ```

- The submission immediately below the gate calls `submitSubagent(...)`, which routes through `gateway.toolLoop()` via the recipe registered for whichever model the resolver selected. That path already supports every non-Anthropic recipe (litellm, ollama, openrouter, openai, claude-cli, …).
- The sibling synthesize phase removed its equivalent gate (see the `makeJudgeClient` docstring at `src/core/cycle/synthesize.ts:804`, which "preserves the legacy 'no ANTHROPIC_API_KEY' cheap-skip semantics" while delegating real auth probing to the gateway recipe's `auth_env.required` machinery).

The patterns phase carries the same pattern in its body but never had the gate updated when the rest of the cycle moved to gateway-routed dispatch.

## Reproduction

1. Fresh brain with no `ANTHROPIC_API_KEY` in env, paid traffic routed through any non-Anthropic recipe.
2. `gbrain config set models.dream.patterns litellm:gpt-5.4` (or any non-`anthropic:*` model).
3. `gbrain dream --phase patterns --json`.
4. Expected: subagent dispatches and returns pattern detections.
5. Actual (pre-patch): `{ status: 'skipped', reason: 'no_api_key' }`.

## Tests

- Manual verification on a brain with `models.dream.patterns = litellm:gpt-5.4` and no `ANTHROPIC_API_KEY` in env: pre-patch returned the `skipped` verdict; post-patch dispatched through the litellm route and returned pattern detections.
- No new unit test added; the change deletes a literal env-var check and the existing patterns-phase tests cover the dispatch path. Happy to add a regression test that asserts the phase reaches the gateway when `ANTHROPIC_API_KEY` is unset if the maintainer prefers.

## Adjacent observation (follow-up, not in this PR)

Other phases / commands may carry similar stale `ANTHROPIC_API_KEY` checks that pre-date the gateway-routed dispatch. Worth a `rg -n 'ANTHROPIC_API_KEY' src/core/cycle src/commands` sweep to catch siblings. The synthesize phase is already clean; patterns is the one this PR fixes. Anything else found would be a separate small PR per site.

