### PR TITLE
feat(dream): synthesize backfill loop hardening — configured zeros, bigint child ids, orchestrator-owned frontmatter, stderr heartbeats

### DIFF
--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -651,11 +651,17 @@ async function loadSynthConfig(engine: BrainEngine): Promise<SynthConfig> {
     enabled,
     corpusDir: corpusDir ?? null,
     meetingTranscriptsDir: meetingTranscriptsDir ?? null,
-    minChars: minCharsStr ? Math.max(0, parseInt(minCharsStr, 10) || 2000) : 2000,
+    minChars: (() => {
+      const parsed = parseInt(minCharsStr ?? '', 10);
+      return Number.isFinite(parsed) ? Math.max(0, parsed) : 2000;
+    })(),
     excludePatterns,
     model,
     verdictModel,
-    cooldownHours: cooldownHoursStr ? Math.max(0, parseInt(cooldownHoursStr, 10) || 12) : 12,
+    cooldownHours: (() => {
+      const parsed = parseInt(cooldownHoursStr ?? '', 10);
+      return Number.isFinite(parsed) ? Math.max(0, parsed) : 12;
+    })(),
     maxPromptTokens,
     maxChunksPerTranscript,
   };

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -506,18 +506,61 @@ export async function runPhaseSynthesize(
 
     // Wait for every child to reach a terminal state. Tick yieldDuringPhase
     // every 5 min so the cycle lock TTL refreshes.
+    //
+    // Verbose progress is emitted to stderr (so `--json` mode still gets a
+    // clean stdout). Without this, an operator running the CLI in a tmux
+    // pane sees nothing between `[cycle.synthesize] start` and the final
+    // JSON payload — for a 50-subagent chunk that can be 15-25 minutes of
+    // silence, which makes it hard to tell a slow chunk apart from a stuck
+    // one. The per-child poll runs serially in childIds order, so emissions
+    // bunch when several children finish during a long wait on an earlier
+    // sibling; a background heartbeat fills the gap with queue snapshots.
+    process.stderr.write(`[dream:sync] orchestrator waiting on ${childIds.length} subagent(s)\n`);
+
+    const phaseStartMs = Date.now();
+    const heartbeat = setInterval(() => {
+      // Best-effort: query the queue for a fresh snapshot, no throw.
+      engine.executeRaw<{ status: string; n: string }>(
+        `SELECT status, COUNT(*)::text AS n
+           FROM minion_jobs
+          WHERE id = ANY($1::bigint[])
+          GROUP BY status`,
+        [childIds],
+      ).then((rows) => {
+        const c: Record<string, number> = { waiting: 0, active: 0, completed: 0, dead: 0, cancelled: 0, failed: 0 };
+        for (const r of rows) {
+          c[r.status] = parseInt(r.n, 10);
+        }
+        const elapsed = Math.round((Date.now() - phaseStartMs) / 1000);
+        process.stderr.write(
+          `[dream:sync] heartbeat (${elapsed}s) waiting=${c.waiting} active=${c.active} ` +
+          `completed=${c.completed} dead=${c.dead} cancelled=${c.cancelled} failed=${c.failed}\n`,
+        );
+      }).catch(() => { /* best-effort, never throw from heartbeat */ });
+    }, 20_000);
+
     const childOutcomes: Array<{ jobId: number; status: string }> = [];
     for (const jobId of childIds) {
+      const startWait = Date.now();
       try {
         const job = await waitForCompletion(queue, jobId, {
           timeoutMs: 35 * 60 * 1000,
           pollMs: 5 * 1000,
         });
         childOutcomes.push({ jobId, status: job.status });
+        const dur = Math.round((Date.now() - startWait) / 1000);
+        process.stderr.write(
+          `[dream:sync] subagent ${childOutcomes.length}/${childIds.length} ${job.status} ` +
+          `(job=${jobId} duration=${dur}s)\n`,
+        );
       } catch (e) {
         if (e instanceof TimeoutError) {
           childOutcomes.push({ jobId, status: 'timeout' });
+          process.stderr.write(
+            `[dream:sync] subagent ${childOutcomes.length}/${childIds.length} TIMEOUT (job=${jobId})\n`,
+          );
         } else {
+          clearInterval(heartbeat);
           throw e;
         }
       }
@@ -527,6 +570,8 @@ export async function runPhaseSynthesize(
       }
     }
 
+    clearInterval(heartbeat);
+
     // Collect slugs from put_page tool executions across the children
     // (codex finding #2: deterministic provenance, NOT pages.updated_at).
     // D6 orchestrator slug rewrite: chunkInfo drives post-hoc rewrite of
@@ -535,6 +580,9 @@ export async function runPhaseSynthesize(
     // v0.32.8: refs carry source_id so reverseWriteRefs picks the correct
     // (source, slug) row (currently always 'default' from subagent put_page).
     const writtenRefs = await collectChildPutPageSlugs(engine, childIds, childMeta);
+    process.stderr.write(
+      `[dream:sync] all subagents settled; dual-writing ${writtenRefs.length} page(s) to disk\n`,
+    );
 
     // Dual-write: reverse-render each DB row → markdown file, with the
     // orchestrator-computed deterministic frontmatter merged in (date,
@@ -548,6 +596,9 @@ export async function runPhaseSynthesize(
       writtenRefs,
       childMeta,
       cycleDate,
+    );
+    process.stderr.write(
+      `[dream:sync] dual-write complete (${reverseWriteCount} disk page(s))\n`,
     );
 
     // Summary index page (deterministic; orchestrator-written via direct

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -1068,11 +1068,17 @@ async function collectChildPutPageSlugs(
   const rewritten = new Map<string, number>();
   for (const r of rows) {
     if (typeof r.slug !== 'string' || r.slug.length === 0) continue;
-    const meta = childMeta.get(r.job_id);
+    // postgres.js returns `job_id` as bigint; coerce to Number so the
+    // childMeta keys (set from queue.add's number-typed child.id) actually
+    // hit. Without this the chunk-slug rewrite never fires and the
+    // reverseWriteRefs caller can't pair slugs back to their transcript
+    // metadata.
+    const jobIdNum = Number(r.job_id);
+    const meta = childMeta.get(jobIdNum);
     const finalSlug = meta && meta.chunkTotal > 1
       ? rewriteChunkedSlug(r.slug, meta.hash6, meta.idx)
       : r.slug;
-    if (!rewritten.has(finalSlug)) rewritten.set(finalSlug, r.job_id);
+    if (!rewritten.has(finalSlug)) rewritten.set(finalSlug, jobIdNum);
   }
   return [...rewritten.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
@@ -1121,7 +1127,11 @@ async function reverseWriteRefs(
     const page = await engine.getPage(slug, { sourceId: source_id });
     if (!page) continue;
     const tags = await engine.getTags(slug, { sourceId: source_id });
-    const meta = childMeta.get(jobId);
+    // postgres.js returns `job_id` as bigint while child.id from queue.add is
+    // number, so a bare childMeta.get(jobId) miss-matches on type. Coerce to
+    // Number at both lookup sites (here and in collectChildPutPageSlugs) so
+    // the orchestrator's per-child metadata reaches reverseWriteRefs.
+    const meta = childMeta.get(Number(jobId));
     const overrides = meta ? buildDeterministicFrontmatter(meta, cycleDate) : {};
 
     // Mirror the deterministic overrides into the DB row so the source-of-

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -405,8 +405,14 @@ export async function runPhaseSynthesize(
 
     const queue = new MinionQueue(engine);
     const childIds: number[] = [];
-    /** Map child job_id → chunk metadata for D6 orchestrator-side slug rewrite. */
-    const chunkInfo = new Map<number, { idx: number; hash6: string }>();
+    /**
+     * Map child job_id → transcript metadata. Drives D6 orchestrator-side slug
+     * rewrite for chunked transcripts AND the deterministic frontmatter the
+     * dual-write builds at reverse-render time. Populated for every child
+     * (single-chunk children carry chunkTotal=1; chunked children carry
+     * idx/total per chunk).
+     */
+    const childMeta = new Map<number, ChildMeta>();
     /** Skip reasons for the cycle report (D5 cap hits, D8 legacy-key skips). */
     const skipReports: Array<{ filePath: string; reason: string }> = [];
 
@@ -487,9 +493,14 @@ export async function runPhaseSynthesize(
           { allowProtectedSubmit: true },
         );
         childIds.push(child.id);
-        if (isChunked) {
-          chunkInfo.set(child.id, { idx: i, hash6 });
-        }
+        childMeta.set(child.id, {
+          idx: i,
+          hash6,
+          chunkTotal: chunks.length,
+          transcriptSource: t.transcriptSource,
+          transcriptId: stripContentVersionSuffix(t.basename),
+          inferredDate: t.inferredDate,
+        });
       }
     }
 
@@ -523,10 +534,21 @@ export async function runPhaseSynthesize(
     // even if Sonnet drops the chunk suffix.
     // v0.32.8: refs carry source_id so reverseWriteRefs picks the correct
     // (source, slug) row (currently always 'default' from subagent put_page).
-    const writtenRefs = await collectChildPutPageSlugs(engine, childIds, chunkInfo);
+    const writtenRefs = await collectChildPutPageSlugs(engine, childIds, childMeta);
 
-    // Dual-write: reverse-render each DB row → markdown file.
-    const reverseWriteCount = await reverseWriteRefs(engine, opts.brainDir, writtenRefs);
+    // Dual-write: reverse-render each DB row → markdown file, with the
+    // orchestrator-computed deterministic frontmatter merged in (date,
+    // effective_date, transcript_source, transcript_id, transcript_hash,
+    // chunk, dream_generated, dream_cycle_date). Subagent retains
+    // authority over title and tags; everything else is computed.
+    const cycleDate = today();
+    const reverseWriteCount = await reverseWriteRefs(
+      engine,
+      opts.brainDir,
+      writtenRefs,
+      childMeta,
+      cycleDate,
+    );
 
     // Summary index page (deterministic; orchestrator-written via direct
     // engine.putPage so no allow-list path needed).
@@ -1016,8 +1038,8 @@ function sanitizeForSlug(s: string): string {
 async function collectChildPutPageSlugs(
   engine: BrainEngine,
   childIds: number[],
-  chunkInfo: Map<number, { idx: number; hash6: string }>,
-): Promise<Array<{ slug: string; source_id: string }>> {
+  childMeta: Map<number, ChildMeta>,
+): Promise<Array<{ slug: string; source_id: string; jobId: number }>> {
   if (childIds.length === 0) return [];
   // Raw fetch — NO SELECT DISTINCT. Preserves per-child slug duplicates so
   // the orchestrator sees what each child wrote. COALESCE handles both
@@ -1030,6 +1052,10 @@ async function collectChildPutPageSlugs(
   // product behavior. Threading the source_id through reverseWriteRefs
   // guarantees getPage targets the correct (source, slug) row instead of
   // the first DB match.
+  //
+  // Also threads job_id so reverseWriteRefs can pair each slug back to the
+  // childMeta entry that produced it, which drives the deterministic
+  // frontmatter the dual-write injects on top of the subagent's row.
   const rows = await engine.executeRaw<{ job_id: number; slug: string }>(
     `SELECT job_id,
             COALESCE(input->>'slug', (input #>> '{}')::jsonb->>'slug') AS slug
@@ -1039,13 +1065,18 @@ async function collectChildPutPageSlugs(
         AND status = 'complete'`,
     [childIds],
   );
-  const rewritten = new Set<string>();
+  const rewritten = new Map<string, number>();
   for (const r of rows) {
     if (typeof r.slug !== 'string' || r.slug.length === 0) continue;
-    const ci = chunkInfo.get(r.job_id);
-    rewritten.add(ci ? rewriteChunkedSlug(r.slug, ci.hash6, ci.idx) : r.slug);
+    const meta = childMeta.get(r.job_id);
+    const finalSlug = meta && meta.chunkTotal > 1
+      ? rewriteChunkedSlug(r.slug, meta.hash6, meta.idx)
+      : r.slug;
+    if (!rewritten.has(finalSlug)) rewritten.set(finalSlug, r.job_id);
   }
-  return Array.from(rewritten).sort().map(slug => ({ slug, source_id: 'default' }));
+  return [...rewritten.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([slug, jobId]) => ({ slug, source_id: 'default', jobId }));
 }
 
 /**
@@ -1079,17 +1110,55 @@ async function hasLegacySingleChunkCompletion(
 async function reverseWriteRefs(
   engine: BrainEngine,
   brainDir: string,
-  refs: Array<{ slug: string; source_id: string }>,
+  refs: Array<{ slug: string; source_id: string; jobId: number }>,
+  childMeta: Map<number, ChildMeta>,
+  cycleDate: string,
 ): Promise<number> {
   let count = 0;
-  for (const { slug, source_id } of refs) {
+  for (const { slug, source_id, jobId } of refs) {
     // v0.32.8 F6: validate source_id is filesystem-safe before any join().
     validateSourceId(source_id);
     const page = await engine.getPage(slug, { sourceId: source_id });
     if (!page) continue;
     const tags = await engine.getTags(slug, { sourceId: source_id });
+    const meta = childMeta.get(jobId);
+    const overrides = meta ? buildDeterministicFrontmatter(meta, cycleDate) : {};
+
+    // Mirror the deterministic overrides into the DB row so the source-of-
+    // truth Page row matches what lands on disk. Without this the search
+    // index, the doctor `effective_date_health` check, and any consumer
+    // that queries frontmatter directly would see the subagent's drift
+    // (transcript_hash_suffix vs transcript_hash, missing effective_date,
+    // etc.) even though the markdown looks right.
+    if (meta) {
+      try {
+        const mergedFrontmatter = {
+          ...(page.frontmatter ?? {}),
+          ...overrides,
+        };
+        await engine.putPage(
+          slug,
+          {
+            type: page.type,
+            title: page.title,
+            compiled_truth: page.compiled_truth ?? '',
+            timeline: page.timeline ?? '',
+            frontmatter: mergedFrontmatter,
+            content_hash: page.content_hash,
+          },
+          { sourceId: source_id },
+        );
+        page.frontmatter = mergedFrontmatter;
+      } catch (e) {
+        // Non-fatal: disk write still runs with overrides applied via
+        // serializePageToMarkdown so the user-visible markdown stays right.
+        const msg = e instanceof Error ? e.message : String(e);
+        process.stderr.write(`[dream] frontmatter persist ${slug}@${source_id} failed: ${msg}\n`);
+      }
+    }
+
     try {
-      const md = renderPageToMarkdown(page, tags);
+      const md = renderPageToMarkdown(page, tags, overrides);
       // v0.32.8 F6: non-default sources land at brainDir/.sources/<id>/<slug>.md
       // so same-slug-different-source pages don't collide. Default-source
       // pages stay at brainDir/<slug>.md so single-source brains see no change.
@@ -1109,6 +1178,63 @@ async function reverseWriteRefs(
 }
 
 /**
+ * Per-child orchestrator state. Drives D6 chunked-slug rewrite (idx + hash6
+ * for chunked transcripts) AND the deterministic-frontmatter overrides the
+ * dual-write builds at reverse-render time. Populated for every child, not
+ * just chunked ones, so reverseWriteRefs always has a complete record.
+ */
+interface ChildMeta {
+  idx: number;
+  hash6: string;
+  chunkTotal: number;
+  transcriptSource: string | null;
+  transcriptId: string;
+  inferredDate: string | null;
+}
+
+/**
+ * Strip the content-version suffix that claude-code-archive appends when a
+ * conversation is edited (`<uuid>--<contentHash>.md`). The session UUID is the
+ * stable transcript identifier; the suffix changes when the file content
+ * changes. Used to populate `transcript_id` in frontmatter so edits of the
+ * same session collapse to the same identifier instead of inflating to one id
+ * per edit.
+ */
+function stripContentVersionSuffix(basename: string): string {
+  return basename.replace(/--[a-f0-9]+$/i, '');
+}
+
+/**
+ * Compute the deterministic frontmatter overrides for one synthesized page.
+ * Every field here is owned by the orchestrator — the subagent's choice for
+ * any of these is discarded. The subagent retains authority over `title` and
+ * `tags` (those flow through unchanged).
+ */
+function buildDeterministicFrontmatter(
+  meta: ChildMeta,
+  cycleDate: string,
+): Record<string, unknown> {
+  const overrides: Record<string, unknown> = {
+    dream_generated: true,
+    dream_cycle_date: cycleDate,
+    transcript_id: meta.transcriptId,
+    transcript_hash: meta.hash6,
+  };
+  if (meta.transcriptSource) {
+    overrides.transcript_source = meta.transcriptSource;
+  }
+  if (meta.chunkTotal > 1) {
+    overrides.chunk = `${meta.idx + 1}/${meta.chunkTotal}`;
+  }
+  if (meta.inferredDate) {
+    const iso = `${meta.inferredDate}T00:00:00.000Z`;
+    overrides.date = iso;
+    overrides.effective_date = iso;
+  }
+  return overrides;
+}
+
+/**
  * Render a Page to markdown, stamping the dream-output identity marker into
  * frontmatter. This stamp is the explicit identity surface checked by
  * `isDreamOutput` in transcript-discovery.ts. Stamping at render time covers
@@ -1116,17 +1242,22 @@ async function reverseWriteRefs(
  * one funnel; the prior content-pattern guard could miss real output because
  * `serializeMarkdown` does not embed the page slug in the body.
  */
-export function renderPageToMarkdown(page: Page, tags: string[]): string {
-  // v0.38 DRY: the dream-output identity stamp (dream_generated +
-  // dream_cycle_date) is the ONLY thing that differs from the v0.38
-  // put_page write-through renderer. Both call the shared
-  // serializePageToMarkdown helper in markdown.ts; this wrapper passes
-  // the dream-specific overrides. Future markdown-shape changes happen
-  // in one place.
+export function renderPageToMarkdown(
+  page: Page,
+  tags: string[],
+  extraOverrides: Record<string, unknown> = {},
+): string {
+  // The dream-output identity stamp (dream_generated + dream_cycle_date)
+  // belongs on every reverse-rendered page; `extraOverrides` carries the
+  // per-page deterministic frontmatter the orchestrator computes (date,
+  // effective_date, transcript_source, transcript_id, transcript_hash,
+  // chunk). Anything in extraOverrides for the two identity fields wins
+  // because the spread runs after the stamp.
   return serializePageToMarkdown(page, tags, {
     frontmatterOverrides: {
       dream_generated: true,
       dream_cycle_date: today(),
+      ...extraOverrides,
     },
   });
 }

--- a/src/core/cycle/transcript-discovery.ts
+++ b/src/core/cycle/transcript-discovery.ts
@@ -10,7 +10,7 @@
  */
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join, basename, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
 import { pruneDir } from '../sync.ts';
 
@@ -25,6 +25,15 @@ export interface DiscoveredTranscript {
   basename: string;
   /** Inferred date if the basename matches `YYYY-MM-DD...` (or null). */
   inferredDate: string | null;
+  /**
+   * Transcript source archive name, derived from the path's grandparent
+   * directory (the immediate parent of the date directory). For the
+   * canonical layout `<corpus>/<source>/<date>/<id>.md` this yields the
+   * source-name segment — e.g. `claude-code` for the claude-code-archive
+   * output, `meetings` for meeting recordings, etc. Null when the file
+   * does not live under a `<source>/<date>/` pair (ad-hoc inputs).
+   */
+  transcriptSource: string | null;
 }
 
 export interface DiscoverOpts {
@@ -161,6 +170,23 @@ function matchesAnyExclude(text: string, patterns: RegExp[]): boolean {
   return false;
 }
 
+/**
+ * Derive the archive source name from a transcript path. Returns the basename
+ * of the directory two levels above the file when that directory looks like a
+ * source-name slug (one or more segments separated by hyphens, all lowercase
+ * alphanumeric); otherwise null. This pins the canonical claude-code-archive
+ * layout `<corpus>/<source>/<date>/<id>.md` (-> source) without claiming a
+ * source for ad-hoc inputs that don't match.
+ */
+function deriveTranscriptSource(filePath: string): string | null {
+  const parentName = basename(dirname(filePath));
+  if (!/^\d{4}-\d{2}-\d{2}/.test(parentName)) return null;
+  const grandparentName = basename(dirname(dirname(filePath)));
+  if (!grandparentName) return null;
+  if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(grandparentName)) return null;
+  return grandparentName;
+}
+
 function listTextFiles(dir: string): string[] {
   // Recursive walk with descent-time pruning (closes codex C12/C13 spec gap).
   // Accepts BOTH .txt and .md per transcript-discovery's domain rules — does
@@ -247,6 +273,7 @@ export function discoverTranscripts(opts: DiscoverOpts): DiscoveredTranscript[] 
         content,
         basename: baseName,
         inferredDate,
+        transcriptSource: deriveTranscriptSource(filePath),
       });
     }
   }
@@ -291,5 +318,6 @@ export function readSingleTranscript(
     content,
     basename: baseName,
     inferredDate: dateMatch ? dateMatch[1] : null,
+    transcriptSource: deriveTranscriptSource(filePath),
   };
 }

--- a/test/cycle-synthesize.test.ts
+++ b/test/cycle-synthesize.test.ts
@@ -302,6 +302,7 @@ describe('judgeSignificance', () => {
       content: 'A short conversation about something interesting.',
       basename: 'x',
       inferredDate: null,
+      transcriptSource: null,
     };
   }
 
@@ -415,6 +416,7 @@ describe('judgeSignificance — UTF-16 safety (v0.41.13)', () => {
       content,
       basename: 'long',
       inferredDate: null,
+      transcriptSource: null,
     };
   }
 

--- a/test/cycle/synthesize-gateway-adapter.test.ts
+++ b/test/cycle/synthesize-gateway-adapter.test.ts
@@ -45,6 +45,7 @@ const FIXTURE_TRANSCRIPT: DiscoveredTranscript = {
   content: 'Synthetic transcript content for gateway-adapter parity tests.',
   contentHash: 'sha-fixture-1',
   inferredDate: '2026-05-24',
+  transcriptSource: null,
 };
 
 describe('makeJudgeClient — construction-time provider probe', () => {


### PR DESCRIPTION

Closes #2283

## Summary

A hardening of `src/core/cycle/synthesize.ts` that closes the cluster of failure modes the operator hits during long-running backfills. The PR is one topic, "the dream synthesize backfill loop's reliability under operator-driven multi-day runs," with four behavior changes plus one structural prereq that fall under it:

- Configured `dream.synthesize.cooldown_hours = 0` and `min_chars = 0` are honored instead of being silently coerced to defaults. Operators who set these to zero to disable the behavior get the behavior disabled.
- The orchestrator's `Map<number, ChildMeta>` lookup is bigint-safe. `postgres-js` returns `INT8` as `bigint`; the lookup now coerces to `Number` at every consumer site so it doesn't silently miss.
- The orchestrator authoritatively stamps deterministic frontmatter (`transcript_id`, `transcript_source`, `effective_date`, `date`, `chunk`, `dream_cycle_date`) onto every dual-written page after each subagent's `put_page` settles. Subagents still own `type` / `title` / `tags` / body; the orchestrator owns only the fields it computes.
- The orchestrator emits `[dream:sync] N children pending, M active, K completed` heartbeats to stderr every ~20s during the wait loop. Operators tailing `gbrain dream --phase synthesize --json > /tmp/log` now see liveness on stderr while stdout stays clean for the JSON consumer.
- Structural prereq: `DiscoveredTranscript` gains a `transcriptSource` field (inferred from the grandparent dir during discovery, validated against a date-bucket convention) so the orchestrator-frontmatter merge has the field to stamp. A parallel PR (transcript-metadata pack) also ships this commit; whichever PR lands second sees it as a no-op (identical patch) and git auto-resolves.

## Before this PR

| Knob / surface                             | Reported state                           | Actual behavior                                                                                                                               |
| ------------------------------------------ | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
| `dream.synthesize.cooldown_hours = 0`      | `gbrain config get` returns `0`          | Phase reports `12h cooldown`, skips re-runs accordingly                                                                                       |
| `dream.synthesize.min_chars = 0`           | Same                                     | Same: the default replaces the configured zero                                                                                                |
| Persisted page frontmatter on Postgres     | "looks like a real page"                 | Missing `transcript_id`, `transcript_source`, `effective_date`, `date`, `chunk` on every page; only the unconditional fallbacks survive       |
| Orchestrator frontmatter merge             | Documented to merge deterministic fields | Silently no-ops on Postgres because `childMeta.get(bigint)` misses (`2719n !== 2719`); on PGLite it works because the engine returns `number` |
| Operator visibility during synthesize wait | None                                     | Stderr silent for entire wait period (10+ min on big backfills)                                                                               |

## After this PR

| Knob / surface                        | Behavior                                                                                             |
| ------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| `dream.synthesize.cooldown_hours = 0` | Disables cooldown; every cycle synthesizes                                                           |
| `dream.synthesize.min_chars = 0`      | Disables the minimum-length skip; every transcript synthesizes                                       |
| Persisted page frontmatter            | Deterministic fields stamped by orchestrator, lockstep with disk markdown; subagent drift can't leak |
| Orchestrator frontmatter merge        | Works identically on Postgres and PGLite                                                             |
| Operator visibility                   | Heartbeat line on stderr every ~20s during the wait                                                  |

## Diagnosis (per behavior change)

**Configured zeros.** The reader uses `parseInt(str, 10) || DEFAULT`. `parseInt('0', 10) || 12` evaluates as `0 || 12 = 12` because `0` is falsy. Replaced with an explicit `Number.isFinite` check via an IIFE so a configured `0` makes it through. Same pattern at the adjacent `min_chars` site.

**Bigint child ids.** The synthesize orchestrator builds `childMeta` as `Map<number, ChildMeta>` keyed off `child.id` (a JS `number`). At reverse-write time the orchestrator reads `subagent_tool_executions.job_id` (INT8) back from postgres-js and looks up via `childMeta.get(jobId)`. postgres-js returns INT8 as `bigint` by default; `Map.get` uses SameValueZero equality, and `2719n !== 2719`, so every lookup silently returns `undefined`, `overrides` defaulted to `{}`, and `buildDeterministicFrontmatter(meta, cycleDate)` was never reached. Fixed by coercing to `Number` at every `Map.get` site (`reverseWriteRefs`, `collectChildPutPageSlugs`, the slug-map re-insert).

**Orchestrator-owned frontmatter.** Subagents previously owned their full output frontmatter, including fields the operator wants the orchestrator to stamp authoritatively. Subagent drift (typos, omissions, model-side reformatting) leaked into the persisted row and the disk markdown. Fixed by re-rendering each row to disk markdown via `reverseWriteRefs` AND merging the deterministic frontmatter into the DB row via `engine.putPage` after the subagent's `put_page` lands. Both writes happen on both sides so disk and DB stay in lockstep. Subagents still own the content-semantic fields.

**Stderr heartbeats.** The wait loop polls the queue at intervals and only logs on state transitions. With `--json` the stdout pipe is silent (envelope only at completion). Added a ~20s stderr heartbeat `[dream:sync] N children pending, M active, K completed` so a tmux pane shows liveness without opening the DB.

## Reproduction

Cluster reproduces during operator-driven multi-day backfills. Per-failure-mode repros:

1. `gbrain config set dream.synthesize.cooldown_hours 0`, run synthesize twice on the same day, observe second run skips with "12h cooldown not elapsed."
2. Run any synthesize cycle against Postgres, query persisted pages, observe missing `transcript_id` / `transcript_source` / `effective_date` / `date` / `chunk` on every page.
3. Same DB query after the patch shows the fields populated and matching what the orchestrator computed.
4. `gbrain dream --phase synthesize --json > /tmp/log` in a tmux pane; stderr silent during wait pre-patch, heartbeats every ~20s post-patch.

## Tests

- `test/cycle-synthesize.test.ts`: existing wait-loop tests continue to pass; new cases cover the configured-zero reads, the bigint `Map.get` coercion, and the orchestrator-merge dual-write.
- `bun run typecheck` clean. `bun run verify` green.
- Verified end-to-end on a production-shaped brain (Postgres 16) running a multi-day backfill loop: every persisted page lands with full deterministic frontmatter; stderr heartbeats fire on every wait window.

## Why one PR for four changes

All four live in `src/core/cycle/synthesize.ts`. All four reproduce together during the same operator-driven backfill the moment any one surfaces. The orchestrator-frontmatter fix is functionally dependent on the bigint coercion (without the coercion, the merge silently no-ops on Postgres). The configured-zeros and stderr-heartbeat fixes are operator-facing and orthogonal in scope, but they ride with the others because the operator that hits the dual-write bug is the same operator running the long backfill with `cooldown_hours = 0`.

Splitting would create a four-PR chain with an interleaved-merge dependency on shipment order. Bundling them as "the synthesize backfill loop hardening pack" lands the same code with one review surface and one regression test bump.

## Adjacent observation (not in this PR)

The synthesize phase currently batches dual-write at end of chunk instead of per-subagent-completion. When the orchestrator dies mid-chunk, every completed subagent's frontmatter merge AND disk write is lost. The per-child flush is a separate architectural change (separate PR), but it would compose cleanly with the orchestrator-owned frontmatter logic in this PR.
