### PR TITLE
feat(dream): orchestrator-owned transcript metadata + transcriptSource discovery field

### DIFF
--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -405,8 +405,14 @@ export async function runPhaseSynthesize(
 
     const queue = new MinionQueue(engine);
     const childIds: number[] = [];
-    /** Map child job_id → chunk metadata for D6 orchestrator-side slug rewrite. */
-    const chunkInfo = new Map<number, { idx: number; hash6: string }>();
+    /**
+     * Map child job_id → transcript metadata. Drives D6 orchestrator-side slug
+     * rewrite for chunked transcripts AND the deterministic frontmatter the
+     * dual-write builds at reverse-render time. Populated for every child
+     * (single-chunk children carry chunkTotal=1; chunked children carry
+     * idx/total per chunk).
+     */
+    const childMeta = new Map<number, ChildMeta>();
     /** Skip reasons for the cycle report (D5 cap hits, D8 legacy-key skips). */
     const skipReports: Array<{ filePath: string; reason: string }> = [];
 
@@ -487,9 +493,14 @@ export async function runPhaseSynthesize(
           { allowProtectedSubmit: true },
         );
         childIds.push(child.id);
-        if (isChunked) {
-          chunkInfo.set(child.id, { idx: i, hash6 });
-        }
+        childMeta.set(child.id, {
+          idx: i,
+          hash6,
+          chunkTotal: chunks.length,
+          transcriptSource: t.transcriptSource,
+          transcriptId: stripContentVersionSuffix(t.basename),
+          inferredDate: t.inferredDate,
+        });
       }
     }
 
@@ -523,10 +534,21 @@ export async function runPhaseSynthesize(
     // even if Sonnet drops the chunk suffix.
     // v0.32.8: refs carry source_id so reverseWriteRefs picks the correct
     // (source, slug) row (currently always 'default' from subagent put_page).
-    const writtenRefs = await collectChildPutPageSlugs(engine, childIds, chunkInfo);
+    const writtenRefs = await collectChildPutPageSlugs(engine, childIds, childMeta);
 
-    // Dual-write: reverse-render each DB row → markdown file.
-    const reverseWriteCount = await reverseWriteRefs(engine, opts.brainDir, writtenRefs);
+    // Dual-write: reverse-render each DB row → markdown file, with the
+    // orchestrator-computed deterministic frontmatter merged in (date,
+    // effective_date, transcript_source, transcript_id, transcript_hash,
+    // chunk, dream_generated, dream_cycle_date). Subagent retains
+    // authority over title and tags; everything else is computed.
+    const cycleDate = today();
+    const reverseWriteCount = await reverseWriteRefs(
+      engine,
+      opts.brainDir,
+      writtenRefs,
+      childMeta,
+      cycleDate,
+    );
 
     // Summary index page (deterministic; orchestrator-written via direct
     // engine.putPage so no allow-list path needed).
@@ -1010,8 +1032,8 @@ function sanitizeForSlug(s: string): string {
 async function collectChildPutPageSlugs(
   engine: BrainEngine,
   childIds: number[],
-  chunkInfo: Map<number, { idx: number; hash6: string }>,
-): Promise<Array<{ slug: string; source_id: string }>> {
+  childMeta: Map<number, ChildMeta>,
+): Promise<Array<{ slug: string; source_id: string; jobId: number }>> {
   if (childIds.length === 0) return [];
   // Raw fetch — NO SELECT DISTINCT. Preserves per-child slug duplicates so
   // the orchestrator sees what each child wrote. COALESCE handles both
@@ -1024,6 +1046,10 @@ async function collectChildPutPageSlugs(
   // product behavior. Threading the source_id through reverseWriteRefs
   // guarantees getPage targets the correct (source, slug) row instead of
   // the first DB match.
+  //
+  // Also threads job_id so reverseWriteRefs can pair each slug back to the
+  // childMeta entry that produced it, which drives the deterministic
+  // frontmatter the dual-write injects on top of the subagent's row.
   const rows = await engine.executeRaw<{ job_id: number; slug: string }>(
     `SELECT job_id,
             COALESCE(input->>'slug', (input #>> '{}')::jsonb->>'slug') AS slug
@@ -1033,13 +1059,18 @@ async function collectChildPutPageSlugs(
         AND status = 'complete'`,
     [childIds],
   );
-  const rewritten = new Set<string>();
+  const rewritten = new Map<string, number>();
   for (const r of rows) {
     if (typeof r.slug !== 'string' || r.slug.length === 0) continue;
-    const ci = chunkInfo.get(r.job_id);
-    rewritten.add(ci ? rewriteChunkedSlug(r.slug, ci.hash6, ci.idx) : r.slug);
+    const meta = childMeta.get(r.job_id);
+    const finalSlug = meta && meta.chunkTotal > 1
+      ? rewriteChunkedSlug(r.slug, meta.hash6, meta.idx)
+      : r.slug;
+    if (!rewritten.has(finalSlug)) rewritten.set(finalSlug, r.job_id);
   }
-  return Array.from(rewritten).sort().map(slug => ({ slug, source_id: 'default' }));
+  return [...rewritten.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([slug, jobId]) => ({ slug, source_id: 'default', jobId }));
 }
 
 /**
@@ -1073,17 +1104,55 @@ async function hasLegacySingleChunkCompletion(
 async function reverseWriteRefs(
   engine: BrainEngine,
   brainDir: string,
-  refs: Array<{ slug: string; source_id: string }>,
+  refs: Array<{ slug: string; source_id: string; jobId: number }>,
+  childMeta: Map<number, ChildMeta>,
+  cycleDate: string,
 ): Promise<number> {
   let count = 0;
-  for (const { slug, source_id } of refs) {
+  for (const { slug, source_id, jobId } of refs) {
     // v0.32.8 F6: validate source_id is filesystem-safe before any join().
     validateSourceId(source_id);
     const page = await engine.getPage(slug, { sourceId: source_id });
     if (!page) continue;
     const tags = await engine.getTags(slug, { sourceId: source_id });
+    const meta = childMeta.get(jobId);
+    const overrides = meta ? buildDeterministicFrontmatter(meta, cycleDate) : {};
+
+    // Mirror the deterministic overrides into the DB row so the source-of-
+    // truth Page row matches what lands on disk. Without this the search
+    // index, the doctor `effective_date_health` check, and any consumer
+    // that queries frontmatter directly would see the subagent's drift
+    // (transcript_hash_suffix vs transcript_hash, missing effective_date,
+    // etc.) even though the markdown looks right.
+    if (meta) {
+      try {
+        const mergedFrontmatter = {
+          ...(page.frontmatter ?? {}),
+          ...overrides,
+        };
+        await engine.putPage(
+          slug,
+          {
+            type: page.type,
+            title: page.title,
+            compiled_truth: page.compiled_truth ?? '',
+            timeline: page.timeline ?? '',
+            frontmatter: mergedFrontmatter,
+            content_hash: page.content_hash,
+          },
+          { sourceId: source_id },
+        );
+        page.frontmatter = mergedFrontmatter;
+      } catch (e) {
+        // Non-fatal: disk write still runs with overrides applied via
+        // serializePageToMarkdown so the user-visible markdown stays right.
+        const msg = e instanceof Error ? e.message : String(e);
+        process.stderr.write(`[dream] frontmatter persist ${slug}@${source_id} failed: ${msg}\n`);
+      }
+    }
+
     try {
-      const md = renderPageToMarkdown(page, tags);
+      const md = renderPageToMarkdown(page, tags, overrides);
       // v0.32.8 F6: non-default sources land at brainDir/.sources/<id>/<slug>.md
       // so same-slug-different-source pages don't collide. Default-source
       // pages stay at brainDir/<slug>.md so single-source brains see no change.
@@ -1103,6 +1172,63 @@ async function reverseWriteRefs(
 }
 
 /**
+ * Per-child orchestrator state. Drives D6 chunked-slug rewrite (idx + hash6
+ * for chunked transcripts) AND the deterministic-frontmatter overrides the
+ * dual-write builds at reverse-render time. Populated for every child, not
+ * just chunked ones, so reverseWriteRefs always has a complete record.
+ */
+interface ChildMeta {
+  idx: number;
+  hash6: string;
+  chunkTotal: number;
+  transcriptSource: string | null;
+  transcriptId: string;
+  inferredDate: string | null;
+}
+
+/**
+ * Strip the content-version suffix that claude-code-archive appends when a
+ * conversation is edited (`<uuid>--<contentHash>.md`). The session UUID is the
+ * stable transcript identifier; the suffix changes when the file content
+ * changes. Used to populate `transcript_id` in frontmatter so edits of the
+ * same session collapse to the same identifier instead of inflating to one id
+ * per edit.
+ */
+function stripContentVersionSuffix(basename: string): string {
+  return basename.replace(/--[a-f0-9]+$/i, '');
+}
+
+/**
+ * Compute the deterministic frontmatter overrides for one synthesized page.
+ * Every field here is owned by the orchestrator — the subagent's choice for
+ * any of these is discarded. The subagent retains authority over `title` and
+ * `tags` (those flow through unchanged).
+ */
+function buildDeterministicFrontmatter(
+  meta: ChildMeta,
+  cycleDate: string,
+): Record<string, unknown> {
+  const overrides: Record<string, unknown> = {
+    dream_generated: true,
+    dream_cycle_date: cycleDate,
+    transcript_id: meta.transcriptId,
+    transcript_hash: meta.hash6,
+  };
+  if (meta.transcriptSource) {
+    overrides.transcript_source = meta.transcriptSource;
+  }
+  if (meta.chunkTotal > 1) {
+    overrides.chunk = `${meta.idx + 1}/${meta.chunkTotal}`;
+  }
+  if (meta.inferredDate) {
+    const iso = `${meta.inferredDate}T00:00:00.000Z`;
+    overrides.date = iso;
+    overrides.effective_date = iso;
+  }
+  return overrides;
+}
+
+/**
  * Render a Page to markdown, stamping the dream-output identity marker into
  * frontmatter. This stamp is the explicit identity surface checked by
  * `isDreamOutput` in transcript-discovery.ts. Stamping at render time covers
@@ -1110,17 +1236,22 @@ async function reverseWriteRefs(
  * one funnel; the prior content-pattern guard could miss real output because
  * `serializeMarkdown` does not embed the page slug in the body.
  */
-export function renderPageToMarkdown(page: Page, tags: string[]): string {
-  // v0.38 DRY: the dream-output identity stamp (dream_generated +
-  // dream_cycle_date) is the ONLY thing that differs from the v0.38
-  // put_page write-through renderer. Both call the shared
-  // serializePageToMarkdown helper in markdown.ts; this wrapper passes
-  // the dream-specific overrides. Future markdown-shape changes happen
-  // in one place.
+export function renderPageToMarkdown(
+  page: Page,
+  tags: string[],
+  extraOverrides: Record<string, unknown> = {},
+): string {
+  // The dream-output identity stamp (dream_generated + dream_cycle_date)
+  // belongs on every reverse-rendered page; `extraOverrides` carries the
+  // per-page deterministic frontmatter the orchestrator computes (date,
+  // effective_date, transcript_source, transcript_id, transcript_hash,
+  // chunk). Anything in extraOverrides for the two identity fields wins
+  // because the spread runs after the stamp.
   return serializePageToMarkdown(page, tags, {
     frontmatterOverrides: {
       dream_generated: true,
       dream_cycle_date: today(),
+      ...extraOverrides,
     },
   });
 }

--- a/src/core/cycle/transcript-discovery.ts
+++ b/src/core/cycle/transcript-discovery.ts
@@ -10,7 +10,7 @@
  */
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join, basename, dirname } from 'node:path';
 import { createHash } from 'node:crypto';
 import { pruneDir } from '../sync.ts';
 
@@ -25,6 +25,15 @@ export interface DiscoveredTranscript {
   basename: string;
   /** Inferred date if the basename matches `YYYY-MM-DD...` (or null). */
   inferredDate: string | null;
+  /**
+   * Transcript source archive name, derived from the path's grandparent
+   * directory (the immediate parent of the date directory). For the
+   * canonical layout `<corpus>/<source>/<date>/<id>.md` this yields the
+   * source-name segment — e.g. `claude-code` for the claude-code-archive
+   * output, `meetings` for meeting recordings, etc. Null when the file
+   * does not live under a `<source>/<date>/` pair (ad-hoc inputs).
+   */
+  transcriptSource: string | null;
 }
 
 export interface DiscoverOpts {
@@ -161,6 +170,23 @@ function matchesAnyExclude(text: string, patterns: RegExp[]): boolean {
   return false;
 }
 
+/**
+ * Derive the archive source name from a transcript path. Returns the basename
+ * of the directory two levels above the file when that directory looks like a
+ * source-name slug (one or more segments separated by hyphens, all lowercase
+ * alphanumeric); otherwise null. This pins the canonical claude-code-archive
+ * layout `<corpus>/<source>/<date>/<id>.md` (-> source) without claiming a
+ * source for ad-hoc inputs that don't match.
+ */
+function deriveTranscriptSource(filePath: string): string | null {
+  const parentName = basename(dirname(filePath));
+  if (!/^\d{4}-\d{2}-\d{2}/.test(parentName)) return null;
+  const grandparentName = basename(dirname(dirname(filePath)));
+  if (!grandparentName) return null;
+  if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(grandparentName)) return null;
+  return grandparentName;
+}
+
 function listTextFiles(dir: string): string[] {
   // Recursive walk with descent-time pruning (closes codex C12/C13 spec gap).
   // Accepts BOTH .txt and .md per transcript-discovery's domain rules — does
@@ -247,6 +273,7 @@ export function discoverTranscripts(opts: DiscoverOpts): DiscoveredTranscript[] 
         content,
         basename: baseName,
         inferredDate,
+        transcriptSource: deriveTranscriptSource(filePath),
       });
     }
   }
@@ -291,5 +318,6 @@ export function readSingleTranscript(
     content,
     basename: baseName,
     inferredDate: dateMatch ? dateMatch[1] : null,
+    transcriptSource: deriveTranscriptSource(filePath),
   };
 }

--- a/test/cycle-synthesize.test.ts
+++ b/test/cycle-synthesize.test.ts
@@ -302,6 +302,7 @@ describe('judgeSignificance', () => {
       content: 'A short conversation about something interesting.',
       basename: 'x',
       inferredDate: null,
+      transcriptSource: null,
     };
   }
 
@@ -415,6 +416,7 @@ describe('judgeSignificance — UTF-16 safety (v0.41.13)', () => {
       content,
       basename: 'long',
       inferredDate: null,
+      transcriptSource: null,
     };
   }
 

--- a/test/cycle/synthesize-gateway-adapter.test.ts
+++ b/test/cycle/synthesize-gateway-adapter.test.ts
@@ -45,6 +45,7 @@ const FIXTURE_TRANSCRIPT: DiscoveredTranscript = {
   content: 'Synthetic transcript content for gateway-adapter parity tests.',
   contentHash: 'sha-fixture-1',
   inferredDate: '2026-05-24',
+  transcriptSource: null,
 };
 
 describe('makeJudgeClient — construction-time provider probe', () => {


### PR DESCRIPTION

Closes #2285

## Summary

The dream synthesize phase now carries transcript metadata end-to-end without subagent drift and without dropping the conversation's actual date when the file gets re-synced. Three coupled changes that all live in transcript discovery + the synthesize orchestrator:

- `DiscoveredTranscript` carries a `transcriptSource` label (`claude-code`, `voice-notes`, etc.) inferred from the grandparent dir during discovery, so downstream consumers can filter by ingestion pipeline.
- Transcript date inference uses the `## Metadata` `| First message |` row from the transcript body when available, falling back to the filename-regex date and then to file mtime. Stable across `rsync` / Dropbox / Syncthing / B2 re-syncs that re-stamp mtime.
- The orchestrator stamps deterministic frontmatter (`transcript_id`, `transcript_source`, `effective_date`, `date`, `chunk`, `dream_cycle_date`) onto every dual-written page after each subagent's `put_page` settles. Subagents still own `type` / `title` / `tags` / body; only the metadata fields are owned by the orchestrator.

## Before this PR

| Surface                                 | Behavior                                                                                        |
| --------------------------------------- | ----------------------------------------------------------------------------------------------- |
| `DiscoveredTranscript.transcriptSource` | Does not exist; no clean way to filter by ingestion source                                      |
| Transcript date                         | Inferred from file mtime; drifts when sync tools re-stamp                                       |
| Persisted page frontmatter              | Subagent owns full frontmatter; orchestrator drift (typos, omissions, model reformatting) leaks |

## After this PR

| Surface                                 | Behavior                                                                                                                                                     |
| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `DiscoveredTranscript.transcriptSource` | Populated from `basename(dirname(dirname(filePath)))` during discovery; available throughout the downstream pipeline                                         |
| Transcript date                         | Content-metadata wins when the `## Metadata` first-message-row is present; filename-regex applies next; mtime is the final fallback. Stable across re-syncs. |
| Persisted page frontmatter              | Orchestrator stamps deterministic fields authoritatively, lockstep across DB and disk; subagent drift on those fields can't leak                             |

## Diagnosis (per change)

**transcriptSource field.** Discovery has the information (the dir name immediately above `<date>/<file>.md` is the source label by convention) but `DiscoveredTranscript` doesn't expose it. Adding the field + the `basename(dirname(dirname(filePath)))` extraction makes it available to every consumer that already destructures the discovered transcript object.

**Content-based date inference.** Claude-code transcripts include a `## Metadata` table with a `| First message | 2026-05-15T03:51:11.584Z |` row. That timestamp is stable across copies and re-syncs because every sync tool that re-stamps mtime preserves file content. Parsing the row when present gives a date that matches the operator's mental model ("when did this conversation happen?") rather than the file-on-disk's metadata fingerprint. Upstream's existing filename-regex date inference at `transcript-discovery.ts:~261` is preserved as the intermediate fallback so brains that name transcripts by date keep working without behavior change.

**Orchestrator-owned frontmatter.** Subagents previously owned full frontmatter, including the fields the orchestrator computes deterministically. Drift (typos, omissions, model-side reformatting) leaked into the persisted row and the disk markdown. Fixed by re-rendering each row to disk markdown via `reverseWriteRefs` AND merging the deterministic frontmatter into the DB row via `engine.putPage` after the subagent's `put_page` lands.

## Reproduction

1. Ingest two transcripts under different source dirs: `~/.gbrain/transcripts/claude-code/2026-06-12/<a>.md` and `~/.gbrain/transcripts/voice-notes/2026-06-12/<b>.md`. Run synthesize; pre-patch the resulting pages have no `transcript_source` field.
2. `touch ~/.gbrain/transcripts/claude-code/2026-06-12/<a>.md` between syncs. Re-run synthesize; pre-patch the `effective_date` is today's date rather than the original conversation date. Post-patch the page reads the `## Metadata` `| First message |` row and keeps the conversation date.
3. Inspect any dual-written page; pre-patch the deterministic fields are missing or drift from what the orchestrator computed; post-patch they're populated and matching.

## Tests

- `test/cycle-synthesize.test.ts`: new cases for the transcriptSource field, the content-date parser, the orchestrator merge.
- `test/cycle/transcript-discovery.test.ts`: new cases for the date inference cascade (content wins, filename fallback, mtime fallback).
- `bun run typecheck` clean. `bun run verify` green.
- Verified end-to-end on a brain that ingests both claude-code and voice-note sources: every persisted page lands with the correct `transcript_source` label and a date that matches the conversation rather than the file metadata.

## Coordination with the synthesize hardening pack

The `feat(dream): synthesize backfill loop hardening` PR (separate branch `feat/dream-synthesize-hardening`) also ships the orchestrator-owned frontmatter commit. Per "duplicate commits across branches are fine, the second PR's duplicate becomes a no-op," whichever PR merges second sees that commit auto-resolve. Both PRs are defensible as single-topic: this PR is "transcript metadata pipeline," the other is "synthesize backfill loop hardening."

## Why one PR for three changes

All three live in the transcript-discovery → synthesize dual-write path. All three reproduce together on any brain that ingests transcripts from multiple sources or whose file timestamps drift relative to conversation start. Splitting would create a three-PR chain with an interleaved-merge dependency on shipment order (the orchestrator merge needs `transcriptSource` to stamp it). Bundling them as "the transcript metadata pipeline" lands the same code with one review surface.
