### PR TITLE
Fix op checkpoint JSONB array binding

### DIFF
--- a/src/core/op-checkpoint.ts
+++ b/src/core/op-checkpoint.ts
@@ -180,9 +180,12 @@ export async function recordCompleted(
   // extract-conversation-facts serialize a MUTABLE map through here and rely on
   // stale keys being REMOVED; an append would make them unremovable. The full
   // set lands in the parent `completed_keys` JSONB column via a single UPSERT —
-  // exactly as before. JSON.stringify into `$3::jsonb` is correct (the text→jsonb
-  // cast yields a proper array; NOT the double-encode trap, which is the template
-  // form). Sync uses `appendCompleted` (below) instead, never this.
+  // exactly as before. With postgres.js `unsafe`, passing JSON.stringify(sorted)
+  // into a `$3::jsonb` placeholder double-encodes the value as a JSON string
+  // (violating the array CHECK). Passing the JS string[] directly lets postgres.js
+  // bind a real jsonb array on Postgres, while PGLite accepts the same shape.
+  // Sync uses `appendCompleted` (below) for path deltas, but still calls this once
+  // to pin the target commit.
   const sorted = [...keys].sort();
   return durableWrite(engine, key, 'write', () =>
     engine.executeRawDirect(
@@ -191,7 +194,7 @@ export async function recordCompleted(
        ON CONFLICT (op, fingerprint) DO UPDATE
          SET completed_keys = EXCLUDED.completed_keys,
              updated_at     = now()`,
-      [key.op, key.fingerprint, JSON.stringify(sorted)],
+      [key.op, key.fingerprint, sorted],
     ));
 }
 


### PR DESCRIPTION
## Summary

Fixes a live Postgres sync failure where `recordCompleted()` wrote `completed_keys` as a JSON string instead of a JSON array through a `postgres.js` `unsafe` placeholder.

In production this surfaced as:

```text
new row for relation "op_checkpoints" violates check constraint "op_checkpoints_completed_keys_array"
```

The database constraint was correct; the writer was double-encoding the value by passing `JSON.stringify(sorted)` to `$3::jsonb`.

## Change

- Pass the JavaScript `string[]` directly to the `$3::jsonb` placeholder.
- Keep the defensive fallback as an empty JavaScript array.
- This preserves the v119 `completed_keys` array-shape guard and lets postgres.js serialize the JSONB value correctly.

## Validation

```text
bun test test/op-checkpoint*.test.ts
37 pass
0 fail
```

Also validated against the production Artie brain after the same fix:

- `gbrain sync --no-pull --no-embed` completed successfully after previously aborting before import.
- `gbrain embed --stale` restored missing embeddings to 0.
- Retrieval gate remained healthy.
