### PR TITLE
schema-pack: declare extract_atoms + synthesize_concepts phases on gbrain-base-v2

### DIFF
--- a/src/core/schema-pack/base/gbrain-base-v2.yaml
+++ b/src/core/schema-pack/base/gbrain-base-v2.yaml
@@ -31,6 +31,17 @@ description: 14-type DRY/MECE canonical taxonomy + `note` catch-all (15 total). 
 gbrain_min_version: 0.42.0
 extends: null
 borrow_from: []
+
+# Cycle phases. base-v2 declares the `atom` and `concept` page types (see
+# page_types below) but, without declaring the phases that produce them, those
+# types stay empty on a base-v2 brain — extract_atoms/synthesize_concepts are
+# gated on the active pack's `phases:` list. Declaring them here makes the
+# canonical taxonomy self-consistent: the types it ships are actually populated.
+# (`phases:` is additive — the ~17 core phases always run regardless.)
+phases:
+  - extract_atoms
+  - synthesize_concepts
+
 takes_kinds:
   - fact
   - take


### PR DESCRIPTION
## Problem

`gbrain-base-v2` declares the `atom` and `concept` page types, but its `phases:` list is empty. Since `extract_atoms` / `synthesize_concepts` are gated on the **active pack's** `phases:`, a base-v2 brain never populates those two types — the taxonomy ships the types but nothing produces them.

The only bundled packs that declare these phases (`gbrain-creator` / `gbrain-everything`) `extend: gbrain-base` (v1), so adopting them means leaving the v2 canonical taxonomy and re-typing the corpus.

## Change

Declare the two phases on `gbrain-base-v2` itself (one additive block). `phases:` is additive — the core phases always run — so this only turns on atom extraction + concept synthesis for base-v2 brains, making the canonical taxonomy self-consistent (the types it ships get populated).

## Verified

On a live base-v2 brain (≈200 pages), `extract_atoms` produced real atoms from the corpus and `synthesize_concepts` ran clean (promotes concepts as atoms accrue across topics/months). I did not run the repo's full test suite locally.

## Open question for you

A user pack that merely `extends: gbrain-base-v2` does **not** inherit v2's types — the extends type-merge appears to skip a standalone bundled parent (base-v2 has `extends: null`). So a thin opt-in `extends`-pack isn't currently a clean alternative, which is why this declares the phases on base-v2 directly.

If you'd rather keep phases **off** base-v2 by default (e.g. to avoid the per-cycle LLM cost for users who only want the taxonomy), I'm happy to instead ship a separate opt-in `gbrain-base-v2-creator` pack + register it — just let me know your preference.

---
_Drafted with Claude Code; verified against a real base-v2 brain._