### PR TITLE
feat(code-intel): MQL (MQL4/5) + C++ call-graph code intelligence

### DIFF
--- a/src/core/chunkers/code.ts
+++ b/src/core/chunkers/code.ts
@@ -799,12 +799,17 @@ function mergeSmallSiblings(chunks: CodeChunk[], chunkTarget: number): CodeChunk
     const current = chunks[i]!;
     const currentTokens = estimateTokens(current.text);
     const currentIsScoped = (current.metadata.parentSymbolPath ?? []).length > 0;
-    // If ANY chunk in this file participates in parent-scope emission, the
-    // scope chunks + their siblings all pass through verbatim. A Python
-    // class body's 3 × 10-token methods are each their own chunk on
-    // purpose — merging would erase the (in ClassName) scope header
-    // Layer 6 just added.
-    if (currentTokens >= mergeThreshold || hasScopedChunks || currentIsScoped) {
+    // A named FUNCTION is a call-graph node + a retrieval target, never a
+    // throwaway declaration — so it must survive as its own chunk even when
+    // tiny. MQL indicators are built on small top-level event handlers
+    // (OnInit/OnCalculate/OnChartEvent) that orchestrate everything; merging
+    // them into an anonymous chunk drops their symbol AND every call edge they
+    // own, making the indicator entry layer invisible to the call graph. The
+    // merge's real job is rolling up runs of single-line declarations
+    // (imports/typedefs/consts), not functions.
+    const currentIsNamedFunction =
+      current.metadata.symbolType === 'function' && !!current.metadata.symbolName;
+    if (currentTokens >= mergeThreshold || hasScopedChunks || currentIsScoped || currentIsNamedFunction) {
       merged.push({ ...current, index: merged.length });
       i++;
       continue;
@@ -815,6 +820,11 @@ function mergeSmallSiblings(chunks: CodeChunk[], chunkTarget: number): CodeChunk
     let j = i + 1;
     while (j < chunks.length) {
       const next = chunks[j]!;
+      // Never absorb a named function into a merged group — it's a call-graph
+      // node in its own right. Without this, a preceding tiny declaration
+      // (e.g. a global `CDash g_dashboard;`) starts a group and swallows the
+      // adjacent `OnInit()` handler, erasing its symbol + call edges.
+      if (next.metadata.symbolType === 'function' && !!next.metadata.symbolName) break;
       const nextTokens = estimateTokens(next.text);
       if (groupTokens + nextTokens > chunkTarget) break;
       group.push(next);

--- a/src/core/chunkers/code.ts
+++ b/src/core/chunkers/code.ts
@@ -405,6 +405,9 @@ const NESTED_EMIT_CONFIG: Partial<Record<SupportedCodeLanguage, NestedEmitConfig
   },
   // C++ inline methods live in the class/struct body as function_definition
   // nodes (general-purpose; the MQL tag reuses the same tree-sitter-cpp shape).
+  // Known limitation: a class wrapped in a `namespace` is not yet nested-emitted
+  // (only top-level class/struct bodies are); namespaced C++ methods fall back to
+  // the namespace/bare callee. MQL has no namespaces, so this only narrows C++.
   cpp: {
     parentTypes: new Set(['class_specifier', 'struct_specifier']),
     childTypes: new Set(['function_definition']),

--- a/src/core/chunkers/code.ts
+++ b/src/core/chunkers/code.ts
@@ -125,7 +125,7 @@ async function getParser(): Promise<typeof import('web-tree-sitter')> {
 
 export type SupportedCodeLanguage =
   | 'typescript' | 'tsx' | 'javascript' | 'python' | 'ruby' | 'go'
-  | 'rust' | 'java' | 'c_sharp' | 'cpp' | 'c' | 'php' | 'swift' | 'kotlin'
+  | 'rust' | 'java' | 'c_sharp' | 'cpp' | 'c' | 'mql' | 'php' | 'swift' | 'kotlin'
   | 'scala' | 'lua' | 'elixir' | 'elm' | 'ocaml' | 'dart' | 'zig' | 'solidity'
   | 'bash' | 'css' | 'html' | 'vue' | 'json' | 'yaml' | 'toml' | 'sql';
 
@@ -213,6 +213,10 @@ const LANGUAGE_MANIFEST: Record<SupportedCodeLanguage, LanguageEntry> = {
   c_sharp:    { displayName: 'C#',         embeddedPath: G_CSHARP },
   cpp:        { displayName: 'C++',        embeddedPath: G_CPP },
   c:          { displayName: 'C',          embeddedPath: G_C },
+  // MQL4/MQL5 (MetaQuotes) — a C/C++ subset. Reuse the tree-sitter-cpp grammar
+  // under a distinct tag so filters and qualified-name identity stay separate
+  // from C++.
+  mql:        { displayName: 'MQL',        embeddedPath: G_CPP },
   php:        { displayName: 'PHP',        embeddedPath: G_PHP },
   swift:      { displayName: 'Swift',      embeddedPath: G_SWIFT },
   kotlin:     { displayName: 'Kotlin',     embeddedPath: G_KOTLIN },
@@ -313,6 +317,11 @@ const TOP_LEVEL_TYPES: Partial<Record<SupportedCodeLanguage, Set<string>>> = {
     'function_definition', 'class_specifier', 'struct_specifier',
     'namespace_definition', 'declaration', 'template_declaration',
   ]),
+  // MQL reuses the C++ grammar node shapes.
+  mql: new Set([
+    'function_definition', 'class_specifier', 'struct_specifier',
+    'namespace_definition', 'declaration', 'template_declaration',
+  ]),
   c: new Set(['function_definition', 'struct_specifier', 'declaration', 'preproc_def', 'preproc_include']),
   php: new Set([
     'function_definition', 'class_declaration', 'interface_declaration',
@@ -343,6 +352,9 @@ const BODY_NODE_TYPES = new Set([
   'module_body',
   'body_statement',
   'body',
+  // C/C++/MQL class & struct bodies (tree-sitter-cpp) — descend into them so
+  // nested-emit finds member function_definition nodes.
+  'field_declaration_list',
 ]);
 
 /**
@@ -391,6 +403,16 @@ const NESTED_EMIT_CONFIG: Partial<Record<SupportedCodeLanguage, NestedEmitConfig
     parentTypes: new Set(['class_declaration', 'interface_declaration', 'record_declaration']),
     childTypes: new Set(['method_declaration', 'constructor_declaration']),
   },
+  // C++ inline methods live in the class/struct body as function_definition
+  // nodes (general-purpose; the MQL tag reuses the same tree-sitter-cpp shape).
+  cpp: {
+    parentTypes: new Set(['class_specifier', 'struct_specifier']),
+    childTypes: new Set(['function_definition']),
+  },
+  mql: {
+    parentTypes: new Set(['class_specifier', 'struct_specifier']),
+    childTypes: new Set(['function_definition']),
+  },
 };
 
 let initDone = false;
@@ -433,6 +455,8 @@ export function detectCodeLanguage(filePath: string, content?: string): Supporte
   if (lower.endsWith('.cs')) return 'c_sharp';
   if (lower.endsWith('.cpp') || lower.endsWith('.cc') || lower.endsWith('.cxx') || lower.endsWith('.hpp') || lower.endsWith('.hxx') || lower.endsWith('.hh')) return 'cpp';
   if (lower.endsWith('.c') || lower.endsWith('.h')) return 'c';
+  // MQL4/MQL5 (MetaQuotes): parsed via tree-sitter-cpp under the `mql` tag.
+  if (lower.endsWith('.mq4') || lower.endsWith('.mq5') || lower.endsWith('.mqh')) return 'mql';
   if (lower.endsWith('.php')) return 'php';
   if (lower.endsWith('.swift')) return 'swift';
   if (lower.endsWith('.kt') || lower.endsWith('.kts')) return 'kotlin';
@@ -644,6 +668,19 @@ export async function chunkCodeTextFull(
         ? normalizeSymbolType(typeNode.namedChild(0).type)
         : normalizeSymbolType(typeNode.type);
 
+      // C/C++/MQL out-of-line member definitions (`void CFoo::Bar(){...}`) parse
+      // as top-level function_definitions whose declarator is a
+      // qualified_identifier (scope::name). Scope them to their class so the
+      // def's qualified name matches the inline form (CFoo.Bar) AND the chunk
+      // carries parent-scope metadata (so mergeSmallSiblings won't roll it into
+      // an anonymous merged chunk, which would drop its call edges).
+      let emitName = symbolName;
+      let emitParentPath: string[] = [];
+      if ((language === 'cpp' || language === 'mql') && node.type === 'function_definition') {
+        const ool = extractCppQualifiedDefScope(node);
+        if (ool) { emitName = ool.name; emitParentPath = [ool.scope]; }
+      }
+
       if (nestableNode && symbolName && nestedConfig) {
         const before = chunks.length;
         emitNestedScoped(nestableNode, [], source, filePath, language, nestedConfig, chunks);
@@ -652,11 +689,11 @@ export async function chunkCodeTextFull(
 
       if (estimateTokens(nodeText) <= largeThreshold) {
         chunks.push(buildChunk({
-          body: nodeText, filePath, language, symbolName, symbolType,
+          body: nodeText, filePath, language, symbolName: emitName, symbolType,
           startLine: node.startPosition.row + 1,
           endLine: node.endPosition.row + 1,
           index: chunks.length,
-          parentSymbolPath: [],
+          parentSymbolPath: emitParentPath,
         }));
         continue;
       }
@@ -665,11 +702,11 @@ export async function chunkCodeTextFull(
       const subRanges = splitLargeNode(node, source, chunkTarget);
       if (subRanges.length === 0) {
         chunks.push(buildChunk({
-          body: nodeText, filePath, language, symbolName, symbolType,
+          body: nodeText, filePath, language, symbolName: emitName, symbolType,
           startLine: node.startPosition.row + 1,
           endLine: node.endPosition.row + 1,
           index: chunks.length,
-          parentSymbolPath: [],
+          parentSymbolPath: emitParentPath,
         }));
         continue;
       }
@@ -678,10 +715,10 @@ export async function chunkCodeTextFull(
         const body = source.slice(range.startIndex, range.endIndex).trim();
         if (!body) continue;
         chunks.push(buildChunk({
-          body, filePath, language, symbolName, symbolType,
+          body, filePath, language, symbolName: emitName, symbolType,
           startLine: range.startLine, endLine: range.endLine,
           index: chunks.length,
-          parentSymbolPath: [],
+          parentSymbolPath: emitParentPath,
         }));
       }
     }
@@ -1041,6 +1078,30 @@ function splitLargeNode(node: any, source: string, chunkTarget: number): SplitRa
   return ranges;
 }
 
+/**
+ * C/C++/MQL out-of-line member definition scope. For a `function_definition`
+ * whose declarator chain reaches a `qualified_identifier` (`CFoo::Bar`),
+ * returns `{ scope: 'CFoo', name: 'Bar' }`. Returns null for ordinary
+ * (non-scoped) definitions. Verified against tree-sitter-cpp:
+ * function_definition.declarator → function_declarator.declarator →
+ * qualified_identifier{scope, name}.
+ */
+function extractCppQualifiedDefScope(funcDef: any): { scope: string; name: string } | null {
+  let cur = funcDef.childForFieldName?.('declarator');
+  for (let i = 0; i < 8 && cur; i++) {
+    if (cur.type === 'qualified_identifier') {
+      const scope = cur.childForFieldName('scope')?.text;
+      const name = cur.childForFieldName('name')?.text;
+      if (!scope || !name) return null;
+      const s = sanitize(scope);
+      const n = sanitize(name);
+      return s && n ? { scope: s, name: n } : null;
+    }
+    cur = cur.childForFieldName?.('declarator');
+  }
+  return null;
+}
+
 function extractSymbolName(node: any): string | null {
   // SQL (DerekStride): the chunk node is `statement` wrapping a single inner
   // child whose type is the actual statement kind. Dive in to find the target
@@ -1059,6 +1120,15 @@ function extractSymbolName(node: any): string | null {
   const declaration = node.childForFieldName('declaration');
   if (declaration) {
     const nested = extractSymbolName(declaration);
+    if (nested) return nested;
+  }
+
+  // C / C++ / MQL: the symbol name lives in a `declarator` chain
+  // (function_definition > function_declarator > identifier), not a `name`
+  // field. Recurse through it; the identifier scan below finds the leaf.
+  const declarator = node.childForFieldName('declarator');
+  if (declarator) {
+    const nested = extractSymbolName(declarator);
     if (nested) return nested;
   }
 

--- a/src/core/chunkers/edge-extractor.ts
+++ b/src/core/chunkers/edge-extractor.ts
@@ -351,6 +351,20 @@ function resolveCppReceiverDeclaredType(callNode: any, recvName: string): string
       }
     }
   }
+
+  // 3. File-scope GLOBAL object declaration (`CUnifiedDashboard g_dashboard;` at
+  //    translation-unit top level). MQL indicators wire the entry layer
+  //    (OnInit/OnCalculate/OnChartEvent) to their class internals through these
+  //    global singletons — the dominant indicator→class boundary. Same explicit
+  //    declared-type mechanism as locals/fields; resolved last so an enclosing
+  //    local or member field of the same name shadows it (innermost scope wins).
+  const root = walkToRoot(callNode);
+  for (const child of root?.namedChildren ?? []) {
+    if (child.type === 'declaration') {
+      const t = cppDeclaredClassType(child, recvName);
+      if (t) return t;
+    }
+  }
   return null;
 }
 

--- a/src/core/chunkers/edge-extractor.ts
+++ b/src/core/chunkers/edge-extractor.ts
@@ -34,6 +34,9 @@
  */
 
 import type { SupportedCodeLanguage } from './code.ts';
+// Type-only cycle: qualified-names.ts imports only a TYPE from code.ts, which
+// dynamically imports this module — so this value import has no runtime cycle.
+import { buildQualifiedName } from './qualified-names.ts';
 
 export interface ExtractedEdge {
   /**
@@ -88,6 +91,11 @@ const RECEIVER_RESOLUTION_LANGS: ReadonlySet<SupportedCodeLanguage> = new Set([
   'tsx',
   'javascript',
   'python',
+  // C/C++ (and MQL, which reuses the tree-sitter-cpp shapes) resolve the
+  // IMPLICIT receiver of an intra-class call to the enclosing class. See
+  // resolveCppReceiver.
+  'cpp',
+  'mql',
 ] as const);
 
 /**
@@ -110,6 +118,10 @@ const CALL_CONFIG: Partial<Record<SupportedCodeLanguage, CallConfig>> = {
   go:         { callNodeTypes: new Set(['call_expression']), calleeFieldName: 'function' },
   rust:       { callNodeTypes: new Set(['call_expression', 'method_call_expression']), calleeFieldName: 'function' },
   java:       { callNodeTypes: new Set(['method_invocation']), calleeFieldName: 'name' },
+  // C++ / MQL (tree-sitter-cpp): bare-token call edges (no receiver-type
+  // resolution yet — same baseline as Go/Java).
+  cpp:        { callNodeTypes: new Set(['call_expression']), calleeFieldName: 'function' },
+  mql:        { callNodeTypes: new Set(['call_expression']), calleeFieldName: 'function' },
 };
 
 /**
@@ -168,6 +180,257 @@ function sanitizeIdent(s: string): string | null {
 }
 
 /**
+ * Extract a C/C++/MQL method name from a `function_definition` by walking the
+ * `declarator` chain (function_definition > [ptr/ref_declarator >]
+ * function_declarator > field_identifier/identifier). Mirrors
+ * code.ts:extractSymbolName's declarator handling; kept local to avoid a
+ * runtime import cycle (code.ts dynamically imports this module). Verified
+ * against tree-sitter-cpp: `function_definition.declarator` →
+ * `function_declarator.declarator` → `field_identifier`.
+ */
+function cppMethodName(funcDef: any): string | null {
+  let cur = funcDef;
+  for (let i = 0; i < 8 && cur; i++) {
+    if (cur.type === 'identifier' || cur.type === 'field_identifier') {
+      return sanitizeIdent(cur.text as string);
+    }
+    const d = cur.childForFieldName?.('declarator');
+    if (!d) return null;
+    cur = d;
+  }
+  return null;
+}
+
+/**
+ * Out-of-line member-definition scope. For a top-level `function_definition`
+ * whose declarator chain reaches a `qualified_identifier` (`CFoo::Bar`),
+ * returns `{ scope: 'CFoo', name: 'Bar' }`; null for ordinary definitions.
+ */
+function cppQualifiedDefScope(funcDef: any): { scope: string; name: string } | null {
+  let cur = funcDef.childForFieldName?.('declarator');
+  for (let i = 0; i < 8 && cur; i++) {
+    if (cur.type === 'qualified_identifier') {
+      const scope = cur.childForFieldName('scope')?.text as string | undefined;
+      const name = cur.childForFieldName('name')?.text as string | undefined;
+      if (!scope || !name) return null;
+      const s = sanitizeIdent(scope);
+      const n = sanitizeIdent(name);
+      return s && n ? { scope: s, name: n } : null;
+    }
+    cur = cur.childForFieldName?.('declarator');
+  }
+  return null;
+}
+
+/**
+ * Count the methods named `name` declared by a `class_specifier` /
+ * `struct_specifier` body: inline `function_definition`s AND method prototypes
+ * (`field_declaration` whose declarator is a `function_declarator`). This is
+ * the canonical overload count — out-of-line definitions are implementations of
+ * these declarations, not additional methods, so they are NOT counted here
+ * (counting both would double-count and look like a false overload).
+ */
+function countCppClassBodyMethods(classNode: any, name: string): number {
+  const body = classNode.childForFieldName?.('body');
+  if (!body) return 0;
+  let count = 0;
+  for (const child of body.namedChildren ?? []) {
+    if (child.type === 'function_definition') {
+      if (cppMethodName(child) === name) count++;
+    } else if (child.type === 'field_declaration') {
+      // Only method prototypes (declarator is a function_declarator), not data
+      // members.
+      const d = child.childForFieldName?.('declarator');
+      if (d?.type === 'function_declarator' && cppMethodName(child) === name) count++;
+    }
+  }
+  return count;
+}
+
+/** Walk to the translation_unit root. */
+function walkToRoot(node: any): any {
+  let r = node;
+  while (r.parent) r = r.parent;
+  return r;
+}
+
+/** Find a top-level `class_specifier` / `struct_specifier` named `className`. */
+function findCppClassSpecifier(root: any, className: string): any | null {
+  for (const child of root.namedChildren ?? []) {
+    if (
+      (child.type === 'class_specifier' || child.type === 'struct_specifier') &&
+      (child.childForFieldName('name')?.text as string | undefined) === className
+    ) {
+      return child;
+    }
+  }
+  return null;
+}
+
+/**
+ * Count the methods named `methodName` belonging to class `className` across a
+ * whole translation unit. Prefers the in-file `class_specifier` body (the
+ * canonical declaration site); when the class is declared in another file (the
+ * impl-only `.cpp` shape), falls back to counting out-of-line definitions whose
+ * `qualified_identifier` scope matches.
+ */
+function countCppClassMethodsInFile(root: any, className: string, methodName: string): number {
+  const classNode = findCppClassSpecifier(root, className);
+  if (classNode) return countCppClassBodyMethods(classNode, methodName);
+  let count = 0;
+  for (const child of root.namedChildren ?? []) {
+    if (child.type === 'function_definition') {
+      const ool = cppQualifiedDefScope(child);
+      if (ool && ool.scope === className && ool.name === methodName) count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * If `declNode` (a `field_declaration` or local `declaration`) declares
+ * `recvName` with a USER-CLASS type (`type_identifier`, e.g.
+ * `CWorker m_worker;`), return that type name. Returns null for primitive
+ * types (`int m_count;` → type is `primitive_type`, not a class) or a name
+ * mismatch — so a method call on a primitive never falsely qualifies.
+ */
+function cppDeclaredClassType(declNode: any, recvName: string): string | null {
+  if (cppMethodName(declNode) !== recvName) return null;
+  const typeNode = declNode.childForFieldName?.('type');
+  if (typeNode?.type === 'type_identifier') return sanitizeIdent(typeNode.text as string);
+  return null;
+}
+
+/**
+ * Resolve the declared class type of a call receiver (`m_worker` in
+ * `m_worker.DoWork()`). Checks, in order: a local variable declaration in the
+ * enclosing method body, then a member field of the enclosing class (found via
+ * the inline `class_specifier` or, for an out-of-line method, the class named
+ * by the definition's `qualified_identifier` scope). Returns null when the
+ * receiver isn't a resolvable class-typed field/local — caller stays bare.
+ */
+function resolveCppReceiverDeclaredType(callNode: any, recvName: string): string | null {
+  let node = callNode.parent;
+  let funcBody: any = null;
+  let className: string | null = null;
+  for (let i = 0; i < WALK_DEPTH_CAP && node; i++) {
+    if (!funcBody && node.type === 'function_definition') {
+      funcBody = node.childForFieldName('body');
+      const ool = cppQualifiedDefScope(node);
+      if (ool) className = className ?? ool.scope;
+    }
+    if (node.type === 'class_specifier' || node.type === 'struct_specifier') {
+      className = (node.childForFieldName('name')?.text as string | undefined) ?? className;
+      break;
+    }
+    node = node.parent;
+  }
+
+  // 1. Local variable declaration in the enclosing method body.
+  if (funcBody) {
+    for (const child of funcBody.namedChildren ?? []) {
+      if (child.type === 'declaration') {
+        const t = cppDeclaredClassType(child, recvName);
+        if (t) return t;
+      }
+    }
+  }
+
+  // 2. Member field of the enclosing class.
+  if (className) {
+    const classNode = findCppClassSpecifier(walkToRoot(callNode), className);
+    const body = classNode?.childForFieldName('body');
+    for (const child of body?.namedChildren ?? []) {
+      if (child.type === 'field_declaration') {
+        const t = cppDeclaredClassType(child, recvName);
+        if (t) return t;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * C/C++/MQL receiver resolution. Resolves an IMPLICIT-receiver call — a bare
+ * `m()` (the MQL idiom) or `this->m()` — to its class as `C.m` (dotted, matching
+ * the def's qualified name so getCallersOf/getCalleesOf align). Handles two
+ * enclosing shapes:
+ *   - INLINE: the call sits inside a method defined in the class body → walk up
+ *     to the enclosing `class_specifier`.
+ *   - OUT-OF-LINE: the call sits inside `C::m(){...}` at top level → the class
+ *     is named by the definition's `qualified_identifier` scope.
+ *
+ * The honest precision boundary for implicit-self:
+ *   - exactly 1 declaration of `m` in the class → `C.m`
+ *   - 0 (global/library call like `MathAbs`)     → null → stay bare
+ *   - >1 (overload)                              → null → stay bare (no false edge)
+ *
+ * Explicit member/object receivers (`m_field.m()`, `obj.m()`) resolve to the
+ * RECEIVER's declared class type (`CWorker m_worker;` → `CWorker.m`). The type
+ * is explicit, so the class attribution is certain — no sibling-count needed.
+ * An unresolvable receiver (parameter, unknown, primitive) stays bare.
+ */
+function resolveCppReceiver(
+  callNode: any,
+  callee: any,
+  language: SupportedCodeLanguage,
+  bareCallee: string,
+): string | null {
+  const qualify = (className: string): string =>
+    buildQualifiedName({
+      language,
+      symbolName: bareCallee,
+      symbolType: 'method',
+      parentSymbolPath: [className],
+    })!;
+
+  // A call is one of: bare `m()` (implicit self), `this->m()` (implicit self),
+  // or `recv.m()` / `recv->m()` (explicit receiver → resolve its declared type).
+  let implicitSelf = false;
+  if (callee.type === 'identifier') {
+    implicitSelf = true;
+  } else if (callee.type === 'field_expression') {
+    const arg = callee.childForFieldName('argument');
+    const argText = (arg?.text ?? '') as string;
+    if (argText === 'this' || argText === '(*this)') {
+      implicitSelf = true;
+    } else if (arg?.type === 'identifier') {
+      const recvType = resolveCppReceiverDeclaredType(callNode, argText);
+      return recvType ? qualify(recvType) : null;
+    } else {
+      return null;
+    }
+  } else {
+    return null;
+  }
+  if (!implicitSelf) return null;
+
+  // Walk up looking for the enclosing class (inline) or out-of-line definition.
+  let node = callNode.parent;
+  for (let i = 0; i < WALK_DEPTH_CAP && node; i++) {
+    if (node.type === 'class_specifier' || node.type === 'struct_specifier') {
+      const className = node.childForFieldName('name')?.text as string | undefined;
+      if (!className) return null;
+      return countCppClassBodyMethods(node, bareCallee) === 1 ? qualify(className) : null;
+    }
+    if (node.type === 'function_definition') {
+      // An out-of-line definition (`C::m(){...}`) names its class via the
+      // declarator's qualified_identifier scope. An inline method def has a
+      // plain field_identifier declarator (scope null) → keep walking up to its
+      // enclosing class_specifier.
+      const ool = cppQualifiedDefScope(node);
+      if (ool) {
+        return countCppClassMethodsInFile(walkToRoot(node), ool.scope, bareCallee) === 1
+          ? qualify(ool.scope)
+          : null;
+      }
+    }
+    node = node.parent;
+  }
+  return null;
+}
+
+/**
  * v0.34 W1 — Resolve the receiver type of a member-call expression
  * (`obj.method()`) to a qualified callee name (`Class::method` or
  * `module::method`). Tries the 3 MUST-resolve patterns from the design doc:
@@ -198,6 +461,13 @@ function resolveReceiverType(
   if (!cfg) return null;
   const callee = cfg.calleeFieldName ? callNode.childForFieldName(cfg.calleeFieldName) : null;
   if (!callee) return null;
+
+  // C/C++/MQL parse via tree-sitter-cpp (class_specifier, field_expression,
+  // function_definition) — a different AST shape from the JS/TS/Python member-
+  // expression logic below, so route to the dedicated resolver.
+  if (language === 'cpp' || language === 'mql') {
+    return resolveCppReceiver(callNode, callee, language, bareCallee);
+  }
 
   // Only resolve when the callee is a member/attribute access (obj.method).
   // Bare calls (`f()`) have no receiver to resolve.

--- a/src/core/chunkers/edge-extractor.ts
+++ b/src/core/chunkers/edge-extractor.ts
@@ -293,6 +293,10 @@ function countCppClassMethodsInFile(root: any, className: string, methodName: st
  * `CWorker m_worker;`), return that type name. Returns null for primitive
  * types (`int m_count;` → type is `primitive_type`, not a class) or a name
  * mismatch — so a method call on a primitive never falsely qualifies.
+ *
+ * Known limitation: a REFERENCE-declared receiver (`CWorker& m_worker;`) is not
+ * yet matched here and stays bare (no false edge — just no resolution). MQL has
+ * no reference member fields, so this only narrows the general-purpose C++ reach.
  */
 function cppDeclaredClassType(declNode: any, recvName: string): string | null {
   if (cppMethodName(declNode) !== recvName) return null;

--- a/src/core/code-edge-match.ts
+++ b/src/core/code-edge-match.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared symbol-match SQL for the call-graph edge lookups
+ * (`getCallersOf` / `getCalleesOf`) across BOTH engines.
+ *
+ * The `code_callers` / `code_callees` ops document their `symbol` param as
+ * "bare or qualified name" — both forms must resolve:
+ *
+ *   - QUALIFIED input (`CPipCalculator.CalculatePips`, `Widget::compute`)
+ *     → exact match. Precise: a qualified query never conflates two classes'
+ *       same-named methods, and it stays on the b-tree index (the hot path the
+ *       recursive code walk hammers per BFS node).
+ *   - BARE input (`CalculatePips`) → exact OR last-segment match, so a short
+ *     name still recalls receiver-resolved QUALIFIED edges (e.g. the edge whose
+ *     `to_symbol_qualified` is `CPipCalculator.CalculatePips`). This realizes
+ *     the documented contract and the North Star's 100% recall bar; the
+ *     ambiguity surfaces as multiple distinct qualified callers, not a silent
+ *     zero.
+ *
+ * A bare query pays a sequential scan (the `regexp_replace` defeats the index),
+ * but bare lookups are the inherent fan-out case; qualified lookups — including
+ * every step of the recursive walk, which carries qualified names — keep the
+ * fast exact path.
+ *
+ * Identifiers can't contain `.`/`:`/`#` (`[A-Za-z_][A-Za-z0-9_]*`), so any
+ * input carrying one of those separators IS qualified. The last-segment
+ * extractor `^.*[.:#]` greedily strips through the LAST separator, leaving the
+ * final segment for `.`, `::`, and Ruby's `#` alike.
+ *
+ * `column` is an engine-supplied literal (`to_symbol_qualified` /
+ * `from_symbol_qualified`), never user input — safe to interpolate. The value
+ * stays the bound `$1` parameter in the caller's query.
+ */
+
+/**
+ * POSIX pattern that greedily strips everything through the LAST namespace
+ * separator, leaving the bare final segment. Shared by both engines so the
+ * pglite and postgres last-segment match stay byte-identical (engine parity).
+ */
+export const LAST_SEGMENT_REGEX = '^.*[.:#]';
+
+/** True when `symbol` carries a namespace separator and is therefore qualified. */
+export function isQualifiedSymbol(symbol: string): boolean {
+  return /[.:#]/.test(symbol);
+}
+
+/**
+ * SQL boolean predicate (pglite `$1` style) matching `column` against the bound
+ * `$1` parameter. Qualified inputs match exactly (index-fast, precise); bare
+ * inputs also match on last segment (recall of receiver-resolved qualified
+ * edges). `LAST_SEGMENT_REGEX` has no single-quotes, so inlining it as a SQL
+ * literal here is safe.
+ */
+export function symbolMatchSql(column: string, symbol: string): string {
+  if (isQualifiedSymbol(symbol)) {
+    return `${column} = $1`;
+  }
+  return `(${column} = $1 OR regexp_replace(${column}, '${LAST_SEGMENT_REGEX}', '') = $1)`;
+}

--- a/src/core/code-edge-match.ts
+++ b/src/core/code-edge-match.ts
@@ -1,6 +1,9 @@
 /**
- * Shared symbol-match SQL for the call-graph edge lookups
- * (`getCallersOf` / `getCalleesOf`) across BOTH engines.
+ * Shared symbol-match logic for the call-graph edge lookups
+ * (`getCallersOf` / `getCalleesOf`). pglite uses `symbolMatchSql` directly;
+ * postgres inlines the equivalent SQL from the SAME `LAST_SEGMENT_REGEX` +
+ * `isQualifiedSymbol` guard (behaviorally equivalent across engines, not one
+ * shared call site).
  *
  * The `code_callers` / `code_callees` ops document their `symbol` param as
  * "bare or qualified name" — both forms must resolve:
@@ -33,8 +36,10 @@
 
 /**
  * POSIX pattern that greedily strips everything through the LAST namespace
- * separator, leaving the bare final segment. Shared by both engines so the
- * pglite and postgres last-segment match stay byte-identical (engine parity).
+ * separator, leaving the bare final segment. Imported by BOTH engines (with
+ * `isQualifiedSymbol`) so the last-segment extraction is identical regardless
+ * of engine -- pglite via `symbolMatchSql`, postgres inlined from this same
+ * regex + guard.
  */
 export const LAST_SEGMENT_REGEX = '^.*[.:#]';
 

--- a/src/core/code-intel/recursive-walk.ts
+++ b/src/core/code-intel/recursive-walk.ts
@@ -61,7 +61,11 @@ export type WalkResult =
   | { result: 'ambiguous'; candidates: { symbol_qualified: string; lang?: string; file?: string; lines?: string }[] }
   | { result: 'unsupported_language'; supported: readonly string[] };
 
-const SUPPORTED_LANGS = ['typescript', 'tsx', 'javascript', 'python'] as const;
+// C/C++ and MQL (which reuses the tree-sitter-cpp shapes) carry precise
+// receiver-resolved call edges, so the BFS walk traverses them like any other
+// language. Sink classification is a graceful no-op for them (classifySink
+// returns 'unknown' — MQL-specific sinks are a later enhancement).
+const SUPPORTED_LANGS = ['typescript', 'tsx', 'javascript', 'python', 'cpp', 'mql'] as const;
 
 function clampConfidence(depth: number): number {
   const c = 1.0 / (1 + 0.3 * depth);

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -46,6 +46,7 @@ import { validateSlug, contentHash, rowToPage, rowToStalePage, rowToChunk, rowTo
 import { deriveResolutionTuple, finalizeScorecard } from './takes-resolution.ts';
 import { normalizeWeightForStorage } from './takes-fence.ts';
 import { executeRawJsonb } from './sql-query.ts';
+import { symbolMatchSql } from './code-edge-match.ts';
 import { sanitizeForJsonb, buildLinkRows, buildTimelineRows, buildTakeRows } from './batch-rows.ts';
 import { GBrainError, PAGE_SORT_SQL, ENRICH_ORDER_SQL } from './types.ts';
 import { computeAnomaliesFromBuckets } from './cycle/anomaly.ts';
@@ -5096,16 +5097,19 @@ export class PGLiteEngine implements BrainEngine {
     const sourceClause = opts?.allSources || !opts?.sourceId
       ? ''
       : `AND source_id = '${opts.sourceId.replace(/'/g, "''")}'`;
+    // Bare names recall receiver-resolved qualified edges; qualified names match
+    // exactly (precise + index-fast). See code-edge-match.ts.
+    const matchClause = symbolMatchSql('to_symbol_qualified', qualifiedName);
     const { rows } = await this.db.query(
       `SELECT id, from_chunk_id, to_chunk_id, from_symbol_qualified, to_symbol_qualified,
               edge_type, edge_metadata, source_id, true as resolved
          FROM code_edges_chunk
-         WHERE to_symbol_qualified = $1 ${sourceClause}
+         WHERE ${matchClause} ${sourceClause}
        UNION ALL
        SELECT id, from_chunk_id, NULL as to_chunk_id, from_symbol_qualified, to_symbol_qualified,
               edge_type, edge_metadata, source_id, false as resolved
          FROM code_edges_symbol
-         WHERE to_symbol_qualified = $1 ${sourceClause}
+         WHERE ${matchClause} ${sourceClause}
        LIMIT $2`,
       [qualifiedName, limit],
     );
@@ -5120,16 +5124,19 @@ export class PGLiteEngine implements BrainEngine {
     const sourceClause = opts?.allSources || !opts?.sourceId
       ? ''
       : `AND source_id = '${opts.sourceId.replace(/'/g, "''")}'`;
+    // Bare names recall qualified caller defs; qualified names match exactly
+    // (precise + index-fast). See code-edge-match.ts.
+    const matchClause = symbolMatchSql('from_symbol_qualified', qualifiedName);
     const { rows } = await this.db.query(
       `SELECT id, from_chunk_id, to_chunk_id, from_symbol_qualified, to_symbol_qualified,
               edge_type, edge_metadata, source_id, true as resolved
          FROM code_edges_chunk
-         WHERE from_symbol_qualified = $1 ${sourceClause}
+         WHERE ${matchClause} ${sourceClause}
        UNION ALL
        SELECT id, from_chunk_id, NULL as to_chunk_id, from_symbol_qualified, to_symbol_qualified,
               edge_type, edge_metadata, source_id, false as resolved
          FROM code_edges_symbol
-         WHERE from_symbol_qualified = $1 ${sourceClause}
+         WHERE ${matchClause} ${sourceClause}
        LIMIT $2`,
       [qualifiedName, limit],
     );

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -52,6 +52,7 @@ import type {
   EnrichCandidatesOpts, EnrichCandidate,
 } from './types.ts';
 import { GBrainError, PAGE_SORT_SQL, ENRICH_ORDER_SQL } from './types.ts';
+import { isQualifiedSymbol, LAST_SEGMENT_REGEX } from './code-edge-match.ts';
 import { computeAnomaliesFromBuckets } from './cycle/anomaly.ts';
 import * as db from './db.ts';
 import { ConnectionManager } from './connection-manager.ts';
@@ -5243,17 +5244,22 @@ export class PostgresEngine implements BrainEngine {
     const limit = Math.min(opts?.limit ?? 100, 500);
     const scopedSource: string | null =
       !opts?.allSources && opts?.sourceId ? opts.sourceId : null;
+    // Bare names recall receiver-resolved qualified edges; qualified names match
+    // exactly (precise + index-fast). Mirrors pglite via code-edge-match.ts.
+    const match = isQualifiedSymbol(qualifiedName)
+      ? sql`to_symbol_qualified = ${qualifiedName}`
+      : sql`(to_symbol_qualified = ${qualifiedName} OR regexp_replace(to_symbol_qualified, ${LAST_SEGMENT_REGEX}, '') = ${qualifiedName})`;
     const rows = await sql`
       SELECT id, from_chunk_id, to_chunk_id, from_symbol_qualified, to_symbol_qualified,
              edge_type, edge_metadata, source_id, true as resolved
         FROM code_edges_chunk
-        WHERE to_symbol_qualified = ${qualifiedName}
+        WHERE ${match}
         ${scopedSource ? sql`AND source_id = ${scopedSource}` : sql``}
       UNION ALL
       SELECT id, from_chunk_id, NULL::int as to_chunk_id, from_symbol_qualified, to_symbol_qualified,
              edge_type, edge_metadata, source_id, false as resolved
         FROM code_edges_symbol
-        WHERE to_symbol_qualified = ${qualifiedName}
+        WHERE ${match}
         ${scopedSource ? sql`AND source_id = ${scopedSource}` : sql``}
       LIMIT ${limit}
     `;
@@ -5268,17 +5274,22 @@ export class PostgresEngine implements BrainEngine {
     const limit = Math.min(opts?.limit ?? 100, 500);
     const scopedSource: string | null =
       !opts?.allSources && opts?.sourceId ? opts.sourceId : null;
+    // Bare names recall qualified caller defs; qualified names match exactly
+    // (precise + index-fast). Mirrors pglite via code-edge-match.ts.
+    const match = isQualifiedSymbol(qualifiedName)
+      ? sql`from_symbol_qualified = ${qualifiedName}`
+      : sql`(from_symbol_qualified = ${qualifiedName} OR regexp_replace(from_symbol_qualified, ${LAST_SEGMENT_REGEX}, '') = ${qualifiedName})`;
     const rows = await sql`
       SELECT id, from_chunk_id, to_chunk_id, from_symbol_qualified, to_symbol_qualified,
              edge_type, edge_metadata, source_id, true as resolved
         FROM code_edges_chunk
-        WHERE from_symbol_qualified = ${qualifiedName}
+        WHERE ${match}
         ${scopedSource ? sql`AND source_id = ${scopedSource}` : sql``}
       UNION ALL
       SELECT id, from_chunk_id, NULL::int as to_chunk_id, from_symbol_qualified, to_symbol_qualified,
              edge_type, edge_metadata, source_id, false as resolved
         FROM code_edges_symbol
-        WHERE from_symbol_qualified = ${qualifiedName}
+        WHERE ${match}
         ${scopedSource ? sql`AND source_id = ${scopedSource}` : sql``}
       LIMIT ${limit}
     `;

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -61,6 +61,10 @@ const CODE_EXTENSIONS = new Set<string>([
   '.cs',
   '.cpp', '.cc', '.cxx', '.hpp', '.hxx', '.hh',
   '.c', '.h',
+  // MQL4/MQL5 (MetaTrader). detectCodeLanguage() tags these as 'mql' and they
+  // chunk over the tree-sitter-cpp grammar. Without them here, sync admits no
+  // MetaTrader files and the MQL code-intel feature never sees a single one.
+  '.mq4', '.mq5', '.mqh',
   '.php',
   '.swift',
   '.kt', '.kts',

--- a/test/chunkers/cpp-nested.test.ts
+++ b/test/chunkers/cpp-nested.test.ts
@@ -1,0 +1,44 @@
+/**
+ * C++ nested method emission + declarator-name extraction.
+ *
+ * Pre-existing gap: `cpp` ships in TOP_LEVEL_TYPES (top-level functions/classes
+ * chunk) but was absent from NESTED_EMIT_CONFIG, and extractSymbolName did not
+ * descend the C/C++ `declarator` chain — so C++ class methods were neither
+ * emitted as their own chunks nor named. These are general-purpose chunker
+ * improvements (the MQL layer reuses the same tree-sitter-cpp shapes).
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { chunkCodeText } from '../../src/core/chunkers/code.ts';
+
+const CALCULATOR_CPP = `class Calculator
+{
+public:
+   int Add(int a, int b)
+   {
+      return a + b;
+   }
+
+   int Multiply(int a, int b)
+   {
+      return a * b;
+   }
+};
+`;
+
+describe('C++ — class method definitions', () => {
+  test('emits each class method as its own chunk scoped to the class', async () => {
+    const chunks = await chunkCodeText(CALCULATOR_CPP, 'calc.cpp', { chunkSizeTokens: 50 });
+
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const c of chunks) expect(c.metadata.language).toBe('cpp');
+
+    const add = chunks.find(c => c.metadata.symbolName === 'Add');
+    expect(add).toBeDefined();
+    expect(add!.metadata.parentSymbolPath).toEqual(['Calculator']);
+
+    const mul = chunks.find(c => c.metadata.symbolName === 'Multiply');
+    expect(mul).toBeDefined();
+    expect(mul!.metadata.parentSymbolPath).toEqual(['Calculator']);
+  });
+});

--- a/test/chunkers/cpp-receiver.test.ts
+++ b/test/chunkers/cpp-receiver.test.ts
@@ -1,0 +1,230 @@
+/**
+ * C++ receiver-type resolution at edge-extraction time (cpp-general; the MQL
+ * tag reuses these same tree-sitter-cpp shapes).
+ *
+ * An intra-class call with an IMPLICIT receiver — a bare `Calculate(x)` inside
+ * a method of class C, the C++/MQL idiom — resolves to the enclosing class:
+ * `C.Calculate`. Two classes defining a same-named method therefore key on
+ * DISTINCT qualified callees instead of the conflated bare token.
+ *
+ * The honest precision boundary (exactly-one-sibling rule):
+ *   - exactly 1 inline sibling method named `m` in the class → emit `C.m`
+ *   - 0 siblings (a genuine global/library call like `Helper`) → stay BARE
+ *   - >1 (overload) → stay BARE (no confident false edge)
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { chunkCodeTextFull } from '../../src/core/chunkers/code.ts';
+
+const TWO_CLASSES_HPP = `class CAlpha {
+public:
+  double Calculate(double x) { return Helper(x); }
+  double Run(double x) { return Calculate(x); }
+};
+
+class CBeta {
+public:
+  double Calculate(double x) { return x + 1.0; }
+  double Start(double x) { return Calculate(x); }
+};
+`;
+
+describe('C++ — implicit-this receiver resolution', () => {
+  test('intra-class calls resolve to the enclosing class; globals stay bare', async () => {
+    const { edges } = await chunkCodeTextFull(TWO_CLASSES_HPP, 'src/two.hpp', {
+      chunkSizeTokens: 50,
+    });
+    const callees = edges.filter(e => e.edgeType === 'calls').map(e => e.toSymbol);
+
+    // Sibling calls qualify to their OWN class — no conflation.
+    expect(callees).toContain('CAlpha.Calculate');
+    expect(callees).toContain('CBeta.Calculate');
+
+    // A genuine global/library call has no sibling method → stays bare.
+    expect(callees).toContain('Helper');
+    expect(callees).not.toContain('CAlpha.Helper');
+  });
+
+  test('an overloaded sibling stays bare (no confident false edge)', async () => {
+    const OVERLOADED_HPP = `class CGamma {
+public:
+  double Scale(double x) { return x; }
+  double Scale(double x, double y) { return x + y; }
+  double Run(double x) { return Scale(x); }
+};
+`;
+    const { edges } = await chunkCodeTextFull(OVERLOADED_HPP, 'src/gamma.hpp', {
+      chunkSizeTokens: 50,
+    });
+    const callees = edges.filter(e => e.edgeType === 'calls').map(e => e.toSymbol);
+    // Two methods named Scale → ambiguous → the call stays bare, never a
+    // confident pick of one overload.
+    expect(callees).toContain('Scale');
+    expect(callees).not.toContain('CGamma.Scale');
+  });
+
+  // An OUT-OF-LINE method definition (`void CFoo::Bar(){...}` outside the class
+  // body) has no ENCLOSING class_specifier for the call site to walk up to — the
+  // walk reaches translation_unit. We recover the class from the definition's
+  // `qualified_identifier` scope (`CFoo::Bar` → `CFoo`) and apply the same
+  // exactly-one-declaration rule, so a bare sibling call resolves to `CFoo.Baz`.
+  test('an out-of-line method definition resolves sibling calls to the class', async () => {
+    const OUT_OF_LINE_HPP = `class CFoo {
+public:
+  void Bar();
+  void Baz();
+};
+
+void CFoo::Bar() {
+  Baz();
+}
+
+void CFoo::Baz() {
+}
+`;
+    const { edges } = await chunkCodeTextFull(OUT_OF_LINE_HPP, 'src/foo.hpp', {
+      chunkSizeTokens: 50,
+    });
+    const callees = edges.filter(e => e.edgeType === 'calls').map(e => e.toSymbol);
+    // The class is declared in-file: exactly one declaration of `Baz` (the
+    // prototype) → the out-of-line sibling call qualifies to `CFoo.Baz`.
+    expect(callees).toContain('CFoo.Baz');
+    expect(callees).not.toContain('Baz');
+  });
+
+  test('an overloaded sibling stays bare in an out-of-line definition', async () => {
+    const OUT_OF_LINE_OVERLOAD_HPP = `class CFoo {
+public:
+  void Run();
+  double Scale(double x);
+  double Scale(double x, double y);
+};
+
+void CFoo::Run() {
+  Scale(1.0);
+}
+
+double CFoo::Scale(double x) { return x; }
+double CFoo::Scale(double x, double y) { return x + y; }
+`;
+    const { edges } = await chunkCodeTextFull(OUT_OF_LINE_OVERLOAD_HPP, 'src/foo.hpp', {
+      chunkSizeTokens: 50,
+    });
+    const callees = edges.filter(e => e.edgeType === 'calls').map(e => e.toSymbol);
+    // Two declarations of `Scale` in the class body → ambiguous → stay bare.
+    expect(callees).toContain('Scale');
+    expect(callees).not.toContain('CFoo.Scale');
+  });
+
+  test('a library call in an out-of-line definition stays bare', async () => {
+    const OUT_OF_LINE_LIB_HPP = `class CFoo {
+public:
+  void Tick();
+};
+
+void CFoo::Tick() {
+  TimeCurrent();
+}
+`;
+    const { edges } = await chunkCodeTextFull(OUT_OF_LINE_LIB_HPP, 'src/foo.hpp', {
+      chunkSizeTokens: 50,
+    });
+    const callees = edges.filter(e => e.edgeType === 'calls').map(e => e.toSymbol);
+    // `TimeCurrent` has no declaration in the class → not a sibling → stays bare.
+    expect(callees).toContain('TimeCurrent');
+    expect(callees).not.toContain('CFoo.TimeCurrent');
+  });
+
+  // When the class is declared in ANOTHER file (the .cpp-implements-a-.h shape),
+  // there is no class_specifier in this translation unit. Fall back to counting
+  // out-of-line definitions with the same scope; exactly one → resolve.
+  test('out-of-line defs resolve via scope when the class is declared elsewhere', async () => {
+    const IMPL_ONLY_CPP = `void CExternal::DoWork() {
+  Helper();
+}
+
+void CExternal::Helper() {
+}
+`;
+    const { edges } = await chunkCodeTextFull(IMPL_ONLY_CPP, 'src/external.cpp', {
+      chunkSizeTokens: 50,
+    });
+    const callees = edges.filter(e => e.edgeType === 'calls').map(e => e.toSymbol);
+    // One out-of-line definition of `Helper` with scope `CExternal` → resolve.
+    expect(callees).toContain('CExternal.Helper');
+    expect(callees).not.toContain('Helper');
+  });
+});
+
+describe('C++ — member-field / object receiver resolution', () => {
+  // `m_x.Method()` and `obj.Method()` resolve to the RECEIVER's declared type,
+  // not the enclosing class. The type is explicit (`CWorker m_worker;`), so the
+  // class attribution is certain — no sibling-count guesswork. This is the
+  // dominant call shape in real MQL (member objects + accessor methods).
+  test('a member-field call resolves to the field type, not the enclosing class', async () => {
+    const HPP = `class CHolder {
+private:
+  CWorker m_worker;
+  int     m_count;
+public:
+  void Run() {
+    m_worker.DoWork();
+    m_count = m_count + 1;
+  }
+};
+`;
+    const { edges } = await chunkCodeTextFull(HPP, 'src/holder.hpp', { chunkSizeTokens: 50 });
+    const callees = edges.filter(e => e.edgeType === 'calls').map(e => e.toSymbol);
+    expect(callees).toContain('CWorker.DoWork');
+    // NOT attributed to the enclosing class — it's the field's type.
+    expect(callees).not.toContain('CHolder.DoWork');
+    expect(callees).not.toContain('DoWork');
+  });
+
+  test('a local-object call resolves to the local variable type', async () => {
+    const HPP = `class CHolder {
+public:
+  void Run() {
+    CHelper h;
+    h.Assist();
+  }
+};
+`;
+    const { edges } = await chunkCodeTextFull(HPP, 'src/holder.hpp', { chunkSizeTokens: 50 });
+    const callees = edges.filter(e => e.edgeType === 'calls').map(e => e.toSymbol);
+    expect(callees).toContain('CHelper.Assist');
+    expect(callees).not.toContain('Assist');
+  });
+
+  test('a member call inside an OUT-OF-LINE method resolves via the class fields', async () => {
+    const HPP = `class CHolder {
+private:
+  CWorker m_worker;
+public:
+  void Run();
+};
+
+void CHolder::Run() {
+  m_worker.DoWork();
+}
+`;
+    const { edges } = await chunkCodeTextFull(HPP, 'src/holder.hpp', { chunkSizeTokens: 50 });
+    const callees = edges.filter(e => e.edgeType === 'calls').map(e => e.toSymbol);
+    expect(callees).toContain('CWorker.DoWork');
+  });
+
+  test('a call on an undeclared / unknown receiver stays bare', async () => {
+    const HPP = `class CHolder {
+public:
+  void Run(Something& thing) {
+    thing.Frobnicate();
+  }
+};
+`;
+    const { edges } = await chunkCodeTextFull(HPP, 'src/holder.hpp', { chunkSizeTokens: 50 });
+    const callees = edges.filter(e => e.edgeType === 'calls').map(e => e.toSymbol);
+    // `thing` has no in-scope declaration we can resolve → stay bare.
+    expect(callees).toContain('Frobnicate');
+    expect(callees).not.toContain('CHolder.Frobnicate');
+  });
+});

--- a/test/chunkers/mql.test.ts
+++ b/test/chunkers/mql.test.ts
@@ -1,0 +1,106 @@
+/**
+ * MQL (MetaQuotes MQL4/MQL5) code-intelligence tests.
+ *
+ * MQL is a C/C++ subset; gbrain parses it with the shipped tree-sitter-cpp
+ * grammar under a distinct `mql` language tag (so UX, filters, and qualified
+ * symbol identity are isolated from C++). These fixtures are small,
+ * self-contained MQL classes and are deliberately free of the MQL
+ * `input`/`sinput` keywords, which need a pre-parse shim (later slice).
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { chunkCodeText, chunkCodeTextFull, detectCodeLanguage } from '../../src/core/chunkers/code.ts';
+
+// A representative MQL utility class: inline class methods + an implicit-`this`
+// method call (CalculatePips -> PriceToPips) — the call-graph tracer the edge
+// slice depends on.
+const PIP_CALCULATOR_MQH = `#property strict
+
+class CPipCalculator
+{
+private:
+   double m_pointSize;
+   int    m_digits;
+
+   void CalculatePointSize()
+   {
+      m_digits = (int)MarketInfo(Symbol(), MODE_DIGITS);
+      m_pointSize = (m_digits == 5 || m_digits == 3) ? Point * 10.0 : Point;
+   }
+
+public:
+   CPipCalculator()
+   {
+      CalculatePointSize();
+   }
+
+   double PriceToPips(double priceDifference)
+   {
+      if(m_pointSize == 0) return 0;
+      return MathAbs(priceDifference) / m_pointSize;
+   }
+
+   double CalculatePips(double price1, double price2)
+   {
+      return PriceToPips(price1 - price2);
+   }
+
+   double GetPointSize() const
+   {
+      return m_pointSize;
+   }
+};
+`;
+
+describe('MQL — detectCodeLanguage', () => {
+  test('maps .mq4 / .mq5 / .mqh to the mql language tag', () => {
+    expect(detectCodeLanguage('Indicator.mq4')).toBe('mql');
+    expect(detectCodeLanguage('Expert.mq5')).toBe('mql');
+    expect(detectCodeLanguage('Include/Utils/PipCalculator.mqh')).toBe('mql');
+  });
+
+  test('is case-insensitive for MQL extensions', () => {
+    expect(detectCodeLanguage('FOO.MQH')).toBe('mql');
+  });
+});
+
+describe('MQL — class method definitions', () => {
+  test('emits each class method as its own chunk scoped to the class', async () => {
+    const chunks = await chunkCodeText(
+      PIP_CALCULATOR_MQH,
+      'Include/Utils/PipCalculator.mqh',
+      { chunkSizeTokens: 50 },
+    );
+
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const c of chunks) expect(c.metadata.language).toBe('mql');
+
+    const priceToPips = chunks.find(c => c.metadata.symbolName === 'PriceToPips');
+    expect(priceToPips).toBeDefined();
+    expect(priceToPips!.metadata.parentSymbolPath).toEqual(['CPipCalculator']);
+
+    const calculatePips = chunks.find(c => c.metadata.symbolName === 'CalculatePips');
+    expect(calculatePips).toBeDefined();
+    expect(calculatePips!.metadata.parentSymbolPath).toEqual(['CPipCalculator']);
+  });
+});
+
+describe('MQL — call edges', () => {
+  test('resolves implicit-this calls to the class; globals stay bare', async () => {
+    const { edges } = await chunkCodeTextFull(
+      PIP_CALCULATOR_MQH,
+      'Include/Utils/PipCalculator.mqh',
+      { chunkSizeTokens: 50 },
+    );
+    const callees = edges.filter(e => e.edgeType === 'calls').map(e => e.toSymbol);
+    // CalculatePips() calls PriceToPips(); the constructor calls
+    // CalculatePointSize() — both are sibling methods, so they resolve to the
+    // enclosing class.
+    expect(callees).toContain('CPipCalculator.PriceToPips');
+    expect(callees).toContain('CPipCalculator.CalculatePointSize');
+    // MathAbs / MarketInfo / Symbol are MQL built-ins, not sibling methods —
+    // they stay bare (no false `CPipCalculator.MathAbs` edge).
+    expect(callees).toContain('MathAbs');
+    expect(callees).not.toContain('CPipCalculator.MathAbs');
+  });
+});

--- a/test/code-callers-short-name-recall.test.ts
+++ b/test/code-callers-short-name-recall.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Engine-general: short-name recall against qualified call edges.
+ *
+ * The `code_callers` / `code_callees` ops document their `symbol` param as
+ * "bare or qualified name" — both forms must resolve. Receiver-type resolution
+ * emits QUALIFIED callees (e.g. a `this.compute()` call inside class Widget
+ * emits `Widget::compute`). Without last-segment matching, a bare-name lookup
+ * (`getCallersOf('compute')`) exact-matches nothing and silently returns zero —
+ * breaking the documented contract and the North Star's 100% recall bar.
+ *
+ * This asserts: a qualified edge is reachable by BOTH its bare last segment
+ * (recall) AND its exact qualified name (precision). Uses the existing JS/TS
+ * `this.`-resolution path so it's independent of the cpp/mql slice.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { importCodeFile } from '../src/core/import-file.ts';
+
+const WIDGET_TS = `class Widget {
+  render() {
+    return this.compute();
+  }
+
+  compute() {
+    return 42;
+  }
+}
+`;
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  await importCodeFile(engine, 'src/widget.ts', WIDGET_TS, { noEmbed: true });
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 30_000);
+
+describe('code-callers — short-name recall of qualified edges', () => {
+  test('the this.compute() call resolves to a qualified edge (Widget::compute)', async () => {
+    // Precondition: confirms the W1 receiver resolver actually qualified the
+    // edge, so the recall assertion below is testing the right thing.
+    const callees = await engine.getCalleesOf('Widget.render', { allSources: true });
+    expect(callees.some(c => c.to_symbol_qualified === 'Widget::compute')).toBe(true);
+  });
+
+  test('bare name "compute" recalls the qualified edge', async () => {
+    const callers = await engine.getCallersOf('compute', { allSources: true });
+    expect(callers.some(c => c.from_symbol_qualified.includes('render'))).toBe(true);
+  });
+
+  test('exact qualified name "Widget::compute" still resolves precisely', async () => {
+    const callers = await engine.getCallersOf('Widget::compute', { allSources: true });
+    expect(callers.some(c => c.from_symbol_qualified.includes('render'))).toBe(true);
+  });
+
+  // The last-segment recall only affects edges with a QUALIFIED to_symbol. In
+  // this pipeline that is exclusively receiver-resolved CALL edges: `imports`
+  // edges are qualified but never persist (top-level import statements fall
+  // outside every semantic chunk, so findChunkForOffset drops them), and
+  // `references` edges carry a BARE type name. So the recall widening is inert
+  // for non-call edges — no edge_type scoping needed.
+});

--- a/test/cpp-out-of-line-callers.test.ts
+++ b/test/cpp-out-of-line-callers.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Out-of-line method definition receiver resolution — end-to-end (the gate the
+ * slice actually exists to move: a QUALIFIED `code-callers` query).
+ *
+ * An out-of-line method body — `void CFoo::Bar() { Baz(); }` at translation-unit
+ * top level — has no ENCLOSING class_specifier for the call site to walk up to.
+ * Pre-slice the sibling call `Baz()` keyed on the bare token, so
+ * `getCallersOf('CStats.UpdateCache')` (qualified, exact) missed the edge while
+ * the bare `getCallersOf('UpdateCache')` still recalled it. This slice resolves
+ * the implicit receiver of an out-of-line method to the class named in the
+ * definition's `qualified_identifier` scope, so the edge keys on the fully-
+ * qualified callee and the qualified query lands.
+ *
+ * The honest precision boundary is unchanged from the inline slice:
+ *   - exactly 1 declaration of the callee in the class → resolve `C.callee`
+ *   - an overloaded callee (>1 declaration) → stay bare (no confident false edge)
+ *   - a genuine library/global call (0 declarations) → stay bare
+ *
+ * Fixture mirrors the common out-of-line MQL idiom — prototypes in the class
+ * body, bodies defined out-of-line, `Update()` calling the sibling
+ * `UpdateCache()` and a library `TimeCurrent()`.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { importCodeFile } from '../src/core/import-file.ts';
+
+const OUT_OF_LINE_MQH = `#property strict
+
+class CStats
+{
+private:
+   void     UpdateCache();              // prototype; defined out-of-line below
+   double   Scale(double x);            // overload prototype #1
+   double   Scale(double x, double y);  // overload prototype #2
+public:
+   void     Update();
+   double   Compute(double x);
+};
+
+void CStats::Update()
+{
+   UpdateCache();             // sibling → CStats.UpdateCache (exactly 1 decl)
+   datetime t = TimeCurrent();// library → stays bare
+}
+
+void CStats::UpdateCache()
+{
+}
+
+double CStats::Compute(double x)
+{
+   return Scale(x);           // overloaded sibling → stays bare
+}
+
+double CStats::Scale(double x)
+{
+   return x;
+}
+
+double CStats::Scale(double x, double y)
+{
+   return x + y;
+}
+`;
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  await importCodeFile(
+    engine,
+    'Include/Stats.mqh',
+    OUT_OF_LINE_MQH,
+    { noEmbed: true },
+  );
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 30_000);
+
+describe('out-of-line method receiver resolution — qualified code-callers', () => {
+  test('getCallersOf(CStats.UpdateCache) finds the out-of-line caller', async () => {
+    const callers = await engine.getCallersOf('CStats.UpdateCache', { allSources: true });
+    // The qualified query must land at least one caller (CStats::Update).
+    expect(callers.length).toBeGreaterThan(0);
+    expect(callers.every(c => c.to_symbol_qualified === 'CStats.UpdateCache')).toBe(true);
+  });
+
+  test('bare query "UpdateCache" still recalls the same caller', async () => {
+    const callers = await engine.getCallersOf('UpdateCache', { allSources: true });
+    expect(callers.length).toBeGreaterThan(0);
+  });
+
+  test('an overloaded sibling (Scale) is never falsely qualified', async () => {
+    // >1 declaration → the call stays bare → no edge keys on CStats.Scale.
+    const qualified = await engine.getCallersOf('CStats.Scale', { allSources: true });
+    expect(qualified.length).toBe(0);
+    // The bare token still recalls the call (ambiguity surfaced, not hidden).
+    const bare = await engine.getCallersOf('Scale', { allSources: true });
+    expect(bare.length).toBeGreaterThan(0);
+  });
+
+  test('a library call (TimeCurrent) never qualifies to CStats.TimeCurrent', async () => {
+    const falseQualified = await engine.getCallersOf('CStats.TimeCurrent', { allSources: true });
+    expect(falseQualified.length).toBe(0);
+  });
+});

--- a/test/mql-code-callers.test.ts
+++ b/test/mql-code-callers.test.ts
@@ -1,0 +1,71 @@
+/**
+ * MQL code-intelligence — end-to-end code-callers / code-callees.
+ *
+ * Imports a small MQL class into PGLite and asserts the intra-class call edge
+ * (CalculatePips -> PriceToPips) is queryable via getCallersOf / getCalleesOf.
+ * This is the slice-1 tracer bullet: a call edge usable end-to-end for MQL
+ * through importCodeFile, not just harvested by the chunker.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { importCodeFile } from '../src/core/import-file.ts';
+
+// A representative MQL utility class with inline methods.
+const PIP_CALCULATOR_MQH = `#property strict
+
+class CPipCalculator
+{
+private:
+   double m_pointSize;
+
+public:
+   double PriceToPips(double priceDifference)
+   {
+      if(m_pointSize == 0) return 0;
+      return MathAbs(priceDifference) / m_pointSize;
+   }
+
+   double CalculatePips(double price1, double price2)
+   {
+      return PriceToPips(price1 - price2);
+   }
+};
+`;
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  await importCodeFile(
+    engine,
+    'Include/Utils/PipCalculator.mqh',
+    PIP_CALCULATOR_MQH,
+    { noEmbed: true },
+  );
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 30_000);
+
+describe('MQL — code-callers / code-callees end-to-end', () => {
+  // Receiver-type resolution qualifies the implicit-this call
+  // `PriceToPips(...)` inside CalculatePips to its enclosing class, so the edge
+  // keys on `CPipCalculator.PriceToPips`. A BARE query still recalls it
+  // (getCallersOf/getCalleesOf last-segment match), so short-name lookups keep
+  // working while the qualified form is precise.
+  test('CalculatePips is a caller of PriceToPips (bare query still recalls)', async () => {
+    const callers = await engine.getCallersOf('PriceToPips', { allSources: true });
+    const hit = callers.find(r => r.from_symbol_qualified.includes('CalculatePips'));
+    expect(hit).toBeDefined();
+    expect(hit!.edge_type).toBe('calls');
+  });
+
+  test('PriceToPips is a callee of CalculatePips, keyed on the qualified callee', async () => {
+    const callees = await engine.getCalleesOf('CPipCalculator.CalculatePips', { allSources: true });
+    expect(callees.some(r => r.to_symbol_qualified === 'CPipCalculator.PriceToPips')).toBe(true);
+  });
+});

--- a/test/mql-code-flow.test.ts
+++ b/test/mql-code-flow.test.ts
@@ -1,0 +1,99 @@
+/**
+ * MQL recursive code walk (code_blast / code_flow) end-to-end.
+ *
+ * The receiver-resolution slice made MQL call edges precise and dotted-
+ * qualified. This enables the recursive BFS walk to traverse a real intra-class
+ * call chain. Before this slice the walk's language gate rejected MQL with
+ * `unsupported_language`; now it walks `CChain.Top → CChain.Mid → CChain.Leaf`.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { importCodeFile } from '../src/core/import-file.ts';
+import { runRecursiveWalk } from '../src/core/code-intel/recursive-walk.ts';
+
+// A 3-deep intra-class chain plus a terminal MQL built-in call.
+const CHAIN_MQH = `class CChain
+{
+public:
+   double Leaf(double x)
+   {
+      return MathAbs(x);
+   }
+
+   double Mid(double x)
+   {
+      return Leaf(x);
+   }
+
+   double Top(double x)
+   {
+      return Mid(x);
+   }
+};
+`;
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  await importCodeFile(engine, 'Include/Chain.mqh', CHAIN_MQH, { noEmbed: true });
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 30_000);
+
+describe('MQL — recursive code walk', () => {
+  test('code_flow (callees) walks the resolved intra-class chain', async () => {
+    const r = await runRecursiveWalk(engine, 'CChain.Top', {
+      direction: 'callees',
+      sourceId: 'default',
+      depth: 5,
+    });
+    expect(r.result).toBe('ok');
+    if (r.result === 'ok') {
+      const d1 = r.depth_groups.find(g => g.depth === 1);
+      const d2 = r.depth_groups.find(g => g.depth === 2);
+      expect(d1?.nodes.some(n => n.symbol === 'CChain.Mid')).toBe(true);
+      expect(d2?.nodes.some(n => n.symbol === 'CChain.Leaf')).toBe(true);
+    }
+  });
+
+  test('code_blast (callers) walks back up the chain', async () => {
+    const r = await runRecursiveWalk(engine, 'CChain.Leaf', {
+      direction: 'callers',
+      sourceId: 'default',
+      depth: 5,
+    });
+    expect(r.result).toBe('ok');
+    if (r.result === 'ok') {
+      const d1 = r.depth_groups.find(g => g.depth === 1);
+      expect(d1?.nodes.some(n => n.symbol === 'CChain.Mid')).toBe(true);
+    }
+  });
+
+  // C++ shares the same resolution + edge path as MQL, so the walk is enabled
+  // for it too — assert it isn't gated out.
+  test('cpp is also walkable (shares the receiver-resolution path)', async () => {
+    const CPP = `class CGraph {
+public:
+  int leaf() { return 1; }
+  int top() { return leaf(); }
+};
+`;
+    await importCodeFile(engine, 'src/graph.hpp', CPP, { noEmbed: true });
+    const r = await runRecursiveWalk(engine, 'CGraph.top', {
+      direction: 'callees',
+      sourceId: 'default',
+      depth: 5,
+    });
+    expect(r.result).toBe('ok');
+    if (r.result === 'ok') {
+      const d1 = r.depth_groups.find(g => g.depth === 1);
+      expect(d1?.nodes.some(n => n.symbol === 'CGraph.leaf')).toBe(true);
+    }
+  });
+});

--- a/test/mql-global-receiver-callers.test.ts
+++ b/test/mql-global-receiver-callers.test.ts
@@ -1,0 +1,69 @@
+/**
+ * File-scope GLOBAL object receiver resolution.
+ *
+ * Real MQL indicators wire the entry layer (OnInit/OnCalculate/OnChartEvent) to
+ * their class internals through file-scope global singletons:
+ *
+ *     CUnifiedDashboard g_dashboard;          // file scope
+ *     void OnInit() { g_dashboard.Refresh(); }
+ *
+ * Member-field (`m_x.M()`) and local-object receivers already resolve to the
+ * receiver's declared class type. A GLOBAL object declared at translation-unit
+ * scope is the same mechanism applied to the file-scope symbol table — without
+ * it, the dominant indicator→class boundary stays bare and `code_blast` can't
+ * climb from a class method to the indicator's entry points.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { importCodeFile } from '../src/core/import-file.ts';
+import { runSources } from '../src/commands/sources.ts';
+
+const SRC = 'mql-indicators';
+
+const DASH_MQH = `class CDash
+{
+public:
+   void Refresh(void) { Repaint(); }
+   void Repaint(void) {}
+};
+`;
+
+// The global singleton is declared AND used in the indicator file — the exact
+// shape of the confluence MT5 indicators (CUnifiedDashboard g_dashboard; …).
+const INDICATOR_MQ5 = `#include "Dash.mqh"
+
+CDash g_dashboard;
+
+void OnInit()
+{
+   g_dashboard.Refresh();
+}
+`;
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  await runSources(engine, ['add', SRC, '--no-federated']);
+  await importCodeFile(engine, 'Include/Dash.mqh', DASH_MQH, { noEmbed: true, sourceId: SRC });
+  await importCodeFile(engine, 'Indicators/Probe.mq5', INDICATOR_MQ5, { noEmbed: true, sourceId: SRC });
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 30_000);
+
+describe('MQL — file-scope global object receiver resolution', () => {
+  test('g_dashboard.Refresh() in OnInit keys on the global type (CDash.Refresh)', async () => {
+    const callees = await engine.getCalleesOf('OnInit', { allSources: true });
+    expect(callees.some(c => c.to_symbol_qualified === 'CDash.Refresh')).toBe(true);
+  });
+
+  test('getCallersOf(CDash.Refresh) finds the entry-point caller OnInit', async () => {
+    const callers = await engine.getCallersOf('CDash.Refresh', { allSources: true });
+    expect(callers.some(c => c.from_symbol_qualified.includes('OnInit'))).toBe(true);
+  });
+});

--- a/test/mql-member-field-callers.test.ts
+++ b/test/mql-member-field-callers.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Member-field call resolution — cross-file end-to-end.
+ *
+ * `m_x.Method()` / `obj.Method()` is the DOMINANT call shape in real MQL
+ * (member objects + accessor methods). It resolves to the receiver's declared
+ * class type, so the call graph spans files: a holder calling
+ * `m_worker.DoWork()` keys on `CWorker.DoWork`, and `getCallersOf('CWorker.DoWork')`
+ * finds it even though CWorker is defined in a different include.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { importCodeFile } from '../src/core/import-file.ts';
+import { runSources } from '../src/commands/sources.ts';
+
+// Import under a NON-default source — the multi-source shape of a real brain.
+const SRC = 'mql-indicators';
+
+const WORKER_MQH = `class CWorker
+{
+public:
+   double DoWork(double x)
+   {
+      return x * 2.0;
+   }
+};
+`;
+
+const HOLDER_MQH = `#include "Worker.mqh"
+
+class CHolder
+{
+private:
+   CWorker m_worker;
+public:
+   double Run(double x)
+   {
+      return m_worker.DoWork(x);
+   }
+};
+`;
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  await runSources(engine, ['add', SRC, '--no-federated']);
+  await importCodeFile(engine, 'Include/Worker.mqh', WORKER_MQH, { noEmbed: true, sourceId: SRC });
+  await importCodeFile(engine, 'Include/Holder.mqh', HOLDER_MQH, { noEmbed: true, sourceId: SRC });
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 30_000);
+
+describe('MQL — member-field call resolution (cross-file)', () => {
+  test('the call keys on the field type (CWorker.DoWork), not the holder', async () => {
+    const callees = await engine.getCalleesOf('CHolder.Run', { allSources: true });
+    expect(callees.some(c => c.to_symbol_qualified === 'CWorker.DoWork')).toBe(true);
+    expect(callees.some(c => c.to_symbol_qualified === 'CHolder.DoWork')).toBe(false);
+  });
+
+  test('getCallersOf(CWorker.DoWork) finds the cross-file caller in CHolder', async () => {
+    const callers = await engine.getCallersOf('CWorker.DoWork', { allSources: true });
+    expect(callers.some(c => c.from_symbol_qualified.includes('CHolder'))).toBe(true);
+    expect(callers.every(c => c.to_symbol_qualified === 'CWorker.DoWork')).toBe(true);
+  });
+
+  test('bare query "DoWork" still recalls the edge', async () => {
+    const callers = await engine.getCallersOf('DoWork', { allSources: true });
+    expect(callers.length).toBeGreaterThan(0);
+  });
+
+  // The jewel must reach a REAL brain, which is multi-source: querying SCOPED
+  // (no allSources) is the user-visible path. Edges carry source_id, so the
+  // scoped query lands and stays source-isolated.
+  test('SCOPED (non-default source) caller/callee queries land and stay isolated', async () => {
+    const scoped = await engine.getCallersOf('CWorker.DoWork', { sourceId: SRC });
+    expect(scoped.some(c => c.from_symbol_qualified === 'CHolder.Run')).toBe(true);
+    const callees = await engine.getCalleesOf('CHolder.Run', { sourceId: SRC });
+    expect(callees.some(c => c.to_symbol_qualified === 'CWorker.DoWork')).toBe(true);
+    // A different source scope must NOT see the edge.
+    const other = await engine.getCallersOf('CWorker.DoWork', { sourceId: 'default' });
+    expect(other.length).toBe(0);
+  });
+});

--- a/test/mql-receiver-resolution.test.ts
+++ b/test/mql-receiver-resolution.test.ts
@@ -1,0 +1,105 @@
+/**
+ * MQL receiver-type resolution — precision slice (the "no false edges" gate).
+ *
+ * Two classes each define a same-named method (`Calculate`), each called by a
+ * sibling via the MQL implicit-`this` idiom (bare `Calculate(x)`, no receiver
+ * token). Before receiver-type resolution the call edges keyed on the bare
+ * token `Calculate`, so `code-callers` conflated the two classes. This slice
+ * resolves the implicit receiver to the ENCLOSING class so each edge keys on
+ * the fully-qualified callee (`CAlpha.Calculate` vs `CBeta.Calculate`).
+ *
+ * The honest ceiling we assert here:
+ *   - PRECISION: a qualified query (`CAlpha.Calculate`) returns ONLY that
+ *     class's callers — never the other class's same-named method.
+ *   - RECALL: a bare query (`Calculate`) still returns BOTH callers (the
+ *     ambiguity is surfaced as two distinct qualified callees, not hidden).
+ *   - NO FALSE QUALIFICATION: a genuine library/global call (`MathAbs`) is NOT
+ *     a sibling method, so it stays bare — never `CAlpha.MathAbs`.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { importCodeFile } from '../src/core/import-file.ts';
+
+// Two real-shaped MQL classes with a colliding method name, in the common MQL
+// idiom: inline class methods calling siblings without `this.`.
+const TWO_CLASSES_MQH = `#property strict
+
+class CAlpha
+{
+public:
+   double Calculate(double x)
+   {
+      return MathAbs(x);
+   }
+
+   double Run(double x)
+   {
+      return Calculate(x);
+   }
+};
+
+class CBeta
+{
+public:
+   double Calculate(double x)
+   {
+      return x + 1.0;
+   }
+
+   double Start(double x)
+   {
+      return Calculate(x);
+   }
+};
+`;
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+  await importCodeFile(
+    engine,
+    'Include/TwoClasses.mqh',
+    TWO_CLASSES_MQH,
+    { noEmbed: true },
+  );
+}, 60_000);
+
+afterAll(async () => {
+  if (engine) await engine.disconnect();
+}, 30_000);
+
+describe('MQL receiver-type resolution — no conflation', () => {
+  test('callers of CAlpha.Calculate include CAlpha.Run and EXCLUDE CBeta', async () => {
+    const callers = await engine.getCallersOf('CAlpha.Calculate', { allSources: true });
+    const froms = callers.map(c => c.from_symbol_qualified);
+    expect(froms.some(f => f.includes('Run'))).toBe(true);
+    expect(froms.some(f => f.includes('CBeta'))).toBe(false);
+  });
+
+  test('callers of CBeta.Calculate include CBeta.Start and EXCLUDE CAlpha', async () => {
+    const callers = await engine.getCallersOf('CBeta.Calculate', { allSources: true });
+    const froms = callers.map(c => c.from_symbol_qualified);
+    expect(froms.some(f => f.includes('Start'))).toBe(true);
+    expect(froms.some(f => f.includes('CAlpha'))).toBe(false);
+  });
+
+  test('bare query "Calculate" still recalls BOTH callers (ambiguity surfaced, not hidden)', async () => {
+    const callers = await engine.getCallersOf('Calculate', { allSources: true });
+    const froms = callers.map(c => c.from_symbol_qualified);
+    expect(froms.some(f => f.includes('CAlpha') && f.includes('Run'))).toBe(true);
+    expect(froms.some(f => f.includes('CBeta') && f.includes('Start'))).toBe(true);
+  });
+
+  test('a genuine library call (MathAbs) stays bare — never qualified to CAlpha.MathAbs', async () => {
+    const bare = await engine.getCallersOf('MathAbs', { allSources: true });
+    expect(bare.some(c => c.from_symbol_qualified.includes('CAlpha'))).toBe(true);
+    // The edge target must be the bare token, not a false-qualified sibling.
+    expect(bare.every(c => c.to_symbol_qualified === 'MathAbs')).toBe(true);
+    const falseQualified = await engine.getCalleesOf('CAlpha.Calculate', { allSources: true });
+    expect(falseQualified.some(c => c.to_symbol_qualified === 'CAlpha.MathAbs')).toBe(false);
+  });
+});

--- a/test/sync-classifier-widening.test.ts
+++ b/test/sync-classifier-widening.test.ts
@@ -83,6 +83,25 @@ describe('Layer 2 — isCodeFilePath widening', () => {
     expect(isCodeFilePath('Schema.SQL')).toBe(true); // case-insensitive
   });
 
+  // MQL (MetaTrader MQL4/MQL5) call-graph code-intel wave. The chunker tags
+  // .mq4/.mq5/.mqh as 'mql' over tree-sitter-cpp, but sync only reaches the
+  // chunker for paths isCodeFilePath() admits — so without these extensions
+  // here, `gbrain sync --strategy code` drops every MQL file on the floor and
+  // the code-intel feature never sees a single MetaTrader file. Same bug class
+  // as codex F1 above.
+  test('MQL (MQL4/MQL5) classified as code', () => {
+    expect(isCodeFilePath('Experts/MyEA.mq4')).toBe(true);
+    expect(isCodeFilePath('Experts/MyEA.mq5')).toBe(true);
+    expect(isCodeFilePath('Include/Trade/Trade.mqh')).toBe(true);
+    expect(isCodeFilePath('Button.MQH')).toBe(true); // case-insensitive
+  });
+
+  test('MQL extensions resolve to the mql chunker language', () => {
+    expect(detectCodeLanguage('Experts/MyEA.mq4')).toBe('mql');
+    expect(detectCodeLanguage('Experts/MyEA.mq5')).toBe('mql');
+    expect(detectCodeLanguage('Include/Trade/Trade.mqh')).toBe('mql');
+  });
+
   test('markdown is NOT classified as code', () => {
     expect(isCodeFilePath('docs/README.md')).toBe(false);
     expect(isCodeFilePath('docs/note.mdx')).toBe(false);


### PR DESCRIPTION
## What this delivers

Call-graph **code intelligence for MQL4/MQL5** (MetaTrader) plus the enabling **C++ receiver-type resolution** — `code_callers` / `code_callees` / `code_blast` / `code_flow` over a real MQL corpus. MQL has no dedicated tree-sitter grammar and, as far as we can find, no call-graph tooling anywhere; tagging `.mq4/.mq5/.mqh` as `mql` over the already-shipped tree-sitter-cpp grammar gives gbrain that coverage at zero grammar-maintenance cost.

## Self-contained on fresh checkout

Rebased on current `master` and works **end-to-end**, not just at the unit level:

- `.mq4/.mq5/.mqh` are added to `CODE_EXTENSIONS`, so `gbrain sync --strategy code` actually routes MetaTrader files to the code chunker (guarded by a regression test in `sync-classifier-widening.test.ts`). Without it, sync silently dropped every MQL file.
- Coverage is honest on both ends: **admission** (the classifier test) + **edge extraction** (the `importCodeFile` → `getCallersOf`/`getCalleesOf` tests with committed MQL fixtures, so edge counts are reproducible in CI).

## Receiver-type resolution

Explicit and implicit receivers resolve to the receiver's declared class type, so the graph spans files:

- implicit-self (`m()`, `this->m()`) → enclosing class (exactly-one-declaration rule)
- out-of-line (`C::m(){...}`) → class named by the definition's qualified scope
- member-field / local-object (`m_x.Method()`, `obj.Method()`) → the field/local's declared class type
- **file-scope global objects** (`CDash g_dashboard; … g_dashboard.M()`) → the global's declared class type. Real MQL indicators wire their entry layer (`OnInit`/`OnCalculate`/`OnChartEvent`/`OnTimer`) to class internals through global singletons — this is what connects that boundary to the graph. (`mql-global-receiver-callers.test.ts`)
- **Honest precision boundary:** genuine globals/library calls, overloads, and namespaced/reference-typed receivers stay **bare** — no confident false edges.

## Free-function entry handlers are first-class call-graph nodes

MQL indicators *are* free functions (`OnInit`/`OnCalculate`/…) that orchestrate everything. The small-sibling chunk merge used to roll those tiny top-level functions into an anonymous chunk, dropping their symbol and every call edge — making the whole indicator entry layer invisible. A named function is now never merged (call-graph node, not a throwaway declaration).

**Measured on a real multi-file MQL indicator corpus:** before these two fixes the indicator entry handlers had **0** call edges; after, `OnInit`/`OnCalculate`/`OnChartEvent` resolve their full outgoing call sets and `code_callers` on a dashboard method surfaces `OnInit`/`OnTimer`. All TDD; engine match shares one predicate/regex across PGLite and Postgres (engine parity preserved).

## Encoding note

Real MetaTrader MQL files are frequently **UTF-16**, which the importer rejected outright. That fix is a separate, encoding-general PR (#2393) so it can be reviewed on its own; this PR assumes UTF-8 sources.

## Known limitations (disclosed)

Namespaced classes and reference-typed receivers aren't resolved yet — they stay bare (no false edges). `code_callers`/`code_callees`/`code_def`/`code_refs` are host-CLI ops (no MCP op yet; `code_blast`/`code_flow` do have MCP ops).

*Authored with AI assistance (Claude, plus a cross-model Codex review pass) under the contributor's direction.*
