### PR TITLE
fix(sync): op_checkpoints completed_keys double-encode blocks all sync

### DIFF
--- a/src/core/op-checkpoint.ts
+++ b/src/core/op-checkpoint.ts
@@ -179,19 +179,26 @@ export async function recordCompleted(
   // REPLACE semantics (kept deliberately — #1794 V3). Callers like
   // extract-conversation-facts serialize a MUTABLE map through here and rely on
   // stale keys being REMOVED; an append would make them unremovable. The full
-  // set lands in the parent `completed_keys` JSONB column via a single UPSERT —
-  // exactly as before. JSON.stringify into `$3::jsonb` is correct (the text→jsonb
-  // cast yields a proper array; NOT the double-encode trap, which is the template
-  // form). Sync uses `appendCompleted` (below) instead, never this.
+  // set lands in the parent `completed_keys` JSONB column via a single UPSERT.
+  //
+  // #2305: bind the JS string[] as a Postgres text[] and build the jsonb in SQL
+  // via `to_jsonb($3::text[])`. The previous `JSON.stringify(sorted)` + `$3::jsonb`
+  // form is the *parameterized* twin of the `${JSON.stringify(x)}::jsonb`
+  // double-encode trap: postgres.js (`conn.unsafe`, prepare:false) sends the JSON
+  // string as a text param, so `$3::jsonb` parses it into a jsonb STRING scalar
+  // (`"[\"k\"]"`), not an array — which the `op_checkpoints_completed_keys_array`
+  // CHECK then rejects, failing every sync-target checkpoint write. The text[] →
+  // to_jsonb binding is the same one `appendCompleted` already relies on (native
+  // on both Postgres and PGLite). Sync uses `appendCompleted` (below), not this.
   const sorted = [...keys].sort();
   return durableWrite(engine, key, 'write', () =>
     engine.executeRawDirect(
       `INSERT INTO op_checkpoints (op, fingerprint, completed_keys, updated_at)
-       VALUES ($1, $2, $3::jsonb, now())
+       VALUES ($1, $2, to_jsonb($3::text[]), now())
        ON CONFLICT (op, fingerprint) DO UPDATE
          SET completed_keys = EXCLUDED.completed_keys,
              updated_at     = now()`,
-      [key.op, key.fingerprint, JSON.stringify(sorted)],
+      [key.op, key.fingerprint, sorted],
     ));
 }
 

--- a/test/e2e/postgres-jsonb.test.ts
+++ b/test/e2e/postgres-jsonb.test.ts
@@ -26,6 +26,7 @@ import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import {
   hasDatabase, setupDB, teardownDB, getEngine, getConn,
 } from './helpers.ts';
+import { recordCompleted } from '../../src/core/op-checkpoint.ts';
 
 const skip = !hasDatabase();
 const describeE2E = skip ? describe.skip : describe;
@@ -170,5 +171,32 @@ describeE2E('Postgres JSONB round-trip — frontmatter / data / pages_updated / 
     expect(rows.length).toBeGreaterThan(0);
     expect(rows[0].jt).toBe('object');
     expect(rows[0].mood).toBe('happy');
+  });
+
+  test('op_checkpoints.completed_keys — recordCompleted stores array, not string literal', async () => {
+    // Regression for #2305: recordCompleted bound `JSON.stringify(keys)` to a
+    // `$3::jsonb` param via conn.unsafe({prepare:false}), which postgres.js v3
+    // landed as a jsonb STRING scalar ("[\"x\"]") instead of an array. The
+    // op_checkpoints_completed_keys_array CHECK (jsonb_typeof = 'array') then
+    // rejected every sync-target checkpoint write, blocking all sync. PGLite
+    // hid it (different driver path) — so this assertion only bites on Postgres.
+    const engine = getEngine();
+    const conn = getConn();
+
+    await recordCompleted(engine, { op: 'sync-target', fingerprint: 'jsonbtest' }, ['6bf9661b']);
+
+    const rows = await conn.unsafe(`
+      SELECT
+        jsonb_typeof(completed_keys)       AS jt,
+        completed_keys->>0                 AS first,
+        jsonb_array_length(completed_keys) AS len
+      FROM op_checkpoints
+      WHERE op = 'sync-target' AND fingerprint = 'jsonbtest'
+    `);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].jt).toBe('array');
+    expect(rows[0].first).toBe('6bf9661b');
+    expect(rows[0].len).toBe(1);
   });
 });


### PR DESCRIPTION
## Problem

`recordCompleted` (`src/core/op-checkpoint.ts`) blocks **all** `gbrain sync` on Postgres. It binds `JSON.stringify(keys)` to a `$3::jsonb` parameter via `executeRawDirect` → `conn.unsafe(sql, params)` with `{ prepare: false }`. postgres.js v3 sends the JSON string as a text param, so `$3::jsonb` parses it into a jsonb **string scalar** (`"[\"k\"]"`), not an array. The `op_checkpoints_completed_keys_array` CHECK (`jsonb_typeof = 'array'`) then rejects every `sync-target` checkpoint write:

```
[op-checkpoint] write failed (sync-target, <fp>): new row for relation "op_checkpoints"
  violates check constraint "op_checkpoints_completed_keys_array"
[sync] checkpoint target write failed — aborting before import; nothing drained.
Sync PARTIAL: imported 0 of N file(s), reason=checkpoint_unavailable.
```

Result: 0 files imported, `last_commit` never advances; "safe to retry" but every retry hits the same. Fixes #2305.

This is the **parameterized twin** of the `${JSON.stringify(x)}::jsonb` double-encode that `scripts/check-jsonb-pattern.sh` guards against — the grep guard only catches the template form, so this slipped through. The in-code comment even claimed the parameterized form was safe ("NOT the double-encode trap"); it isn't, under `.unsafe()` + `{ prepare: false }`.

Minimal repro:

```js
const sql = postgres(DATABASE_URL, { prepare: false });
await sql.unsafe("select jsonb_typeof($1::jsonb) as t", [JSON.stringify(["x"])]);
// => [{ t: "string" }]   // jsonb STRING scalar, not an array
```

## Fix

Bind the JS `string[]` as a Postgres `text[]` and build the jsonb in SQL via `to_jsonb($3::text[])` — the same native binding `appendCompleted` already relies on (works on both Postgres and PGLite). Drops the `JSON.stringify` + `$3::jsonb`.

## Test

Adds an e2e regression test in `test/e2e/postgres-jsonb.test.ts` asserting `recordCompleted` stores a jsonb **array** (`jsonb_typeof = 'array'`). The bug only manifests on real Postgres (PGLite uses a different driver path and hides it), so the test lives in the Postgres e2e suite.

Verified RED→GREEN against a real Postgres; existing PGLite op-checkpoint unit suite passes (30/0); `tsc --noEmit` clean.


---
**Related contributions** (from the iTradeAIMS fork; reviewed cross-model before opening):
- #2309 — `op_checkpoints` `completed_keys` double-encode sync fix (this PR; fixes #2305)
- #2299 — MQL4/5 + C++ call-graph code intelligence (feature)
