### PR TITLE
fix(capture): make fallback title truncation explicit

### DIFF
--- a/skills/capture/SKILL.md
+++ b/skills/capture/SKILL.md
@@ -62,7 +62,7 @@ gbrain capture "..." --json           # structured output for agents
 - **Slug:** `inbox/YYYY-MM-DD-<hash8>` (stable for same content; the daemon's 24h dedup catches re-captures).
 - **Type:** `note` (override with `--type idea` etc.).
 - **Frontmatter stamps:** `captured_via: capture-cli`, `captured_at: <ISO>`.
-- **Title:** first non-empty line of the body, capped at 80 chars.
+- **Title:** first non-empty line of the body, with overlong fallback titles capped at 80 chars using explicit ellipsis.
 
 ## Output Format
 

--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -211,15 +211,91 @@ export function maybeRewriteSourceFkError(err: unknown, sourceId: string | undef
 }
 
 /**
- * Derive a title from the first non-empty, non-`---` line of the body,
- * stripping leading markdown heading marks, capped at 80 chars.
+ * Derive a readable title from the first non-empty, non-`---` line of the body,
+ * stripping leading markdown heading marks. Preserve the existing first-line
+ * semantics, but make overlong fallback truncation explicit and Unicode-safe.
  * Falls back to 'Capture' when no usable line exists.
  */
+const MAX_DERIVED_TITLE_CHARS = 80;
+
+function isWhitespaceChar(ch: string): boolean {
+  return /\s/u.test(ch);
+}
+
+function isSkippableTitleLine(line: string): boolean {
+  let start = 0;
+  while (start < line.length && isWhitespaceChar(line[start] ?? '')) start += 1;
+  if (start >= line.length) return true;
+  if (line[start] !== '-') return false;
+
+  let end = line.length;
+  while (end > start && isWhitespaceChar(line[end - 1] ?? '')) end -= 1;
+  return end - start === 3 && line.slice(start, end) === '---';
+}
+
+function firstUsableTitleLine(rawBody: string): string {
+  let start = 0;
+  while (start <= rawBody.length) {
+    const newline = rawBody.indexOf('\n', start);
+    const end = newline === -1 ? rawBody.length : newline;
+    const lineEnd = end > start && rawBody[end - 1] === '\r' ? end - 1 : end;
+    const line = rawBody.slice(start, lineEnd);
+    if (!isSkippableTitleLine(line)) return line;
+    if (newline === -1) return '';
+    start = newline + 1;
+  }
+  return '';
+}
+
+function normalizeTitlePrefix(text: string, maxLength: number): { value: string; hasMore: boolean } {
+  const chars: string[] = [];
+  let count = 0;
+  let sawContent = false;
+  let pendingSpace = false;
+
+  for (const ch of text) {
+    if (isWhitespaceChar(ch)) {
+      if (sawContent) pendingSpace = true;
+      continue;
+    }
+
+    if (pendingSpace) {
+      if (count >= maxLength) return { value: chars.join('').trimEnd(), hasMore: true };
+      chars.push(' ');
+      count += 1;
+      pendingSpace = false;
+    }
+
+    sawContent = true;
+    if (count >= maxLength) return { value: chars.join('').trimEnd(), hasMore: true };
+    chars.push(ch);
+    count += 1;
+  }
+
+  return { value: chars.join('').trimEnd(), hasMore: false };
+}
+
+function trimAtWordBoundary(text: string, maxLength: number): string {
+  const normalized = normalizeTitlePrefix(text, maxLength);
+  if (!normalized.hasMore) return normalized.value;
+
+  const suffix = '…';
+  const limit = Math.max(1, maxLength - suffix.length);
+  let cut = normalizeTitlePrefix(text, limit).value.trimEnd();
+  const boundary = Math.max(cut.lastIndexOf(' '), cut.lastIndexOf('-'), cut.lastIndexOf('/'));
+  const minBoundary = Math.max(16, Math.floor(limit * 0.25));
+  if (boundary >= minBoundary) {
+    cut = cut.slice(0, boundary).replace(/[\s\-/]+$/g, '');
+  } else {
+    cut = cut.replace(/[\s\-/]+$/g, '');
+  }
+  return `${cut || normalizeTitlePrefix(text, limit).value.trim()}${suffix}`;
+}
+
 function deriveTitle(rawBody: string): string {
-  const firstLine = rawBody
-    .split('\n')
-    .find((l) => l.trim().length > 0 && l.trim() !== '---') ?? '';
-  return firstLine.replace(/^#+\s*/, '').slice(0, 80) || 'Capture';
+  const firstLine = firstUsableTitleLine(rawBody);
+  const withoutHeading = firstLine.replace(/^#+\s*/, '');
+  return trimAtWordBoundary(withoutHeading, MAX_DERIVED_TITLE_CHARS) || 'Capture';
 }
 
 /**

--- a/test/capture-build-content.test.ts
+++ b/test/capture-build-content.test.ts
@@ -190,9 +190,36 @@ describe('deriveTitle (no-frontmatter path)', () => {
     expect(deriveTitle('### Triple hash\nrest')).toBe('Triple hash');
   });
 
-  test('caps at 80 chars', () => {
-    const long = 'a'.repeat(120);
-    expect(deriveTitle(long)).toBe('a'.repeat(80));
+  test('caps at 80 chars with explicit ellipsis', () => {
+    const long = 'a'.repeat(300);
+    expect(deriveTitle(long).length).toBe(80);
+    expect(deriveTitle(long)).toBe('a'.repeat(79) + '…');
+  });
+
+  test('preserves dotted first-line text instead of guessing sentence boundaries', () => {
+    expect(deriveTitle('2026. Forecast continues with a full explanatory sentence.')).toBe('2026. Forecast continues with a full explanatory sentence.');
+    expect(deriveTitle('1. Ordered item continues with enough context.')).toBe('1. Ordered item continues with enough context.');
+    expect(deriveTitle('Jan. 5 update needs follow-up. This is still the first line.')).toBe('Jan. 5 update needs follow-up. This is still the first line.');
+    expect(deriveTitle('GBrain vs. OpenClaw notes')).toBe('GBrain vs. OpenClaw notes');
+    expect(deriveTitle('# U.S. Market Map')).toBe('U.S. Market Map');
+  });
+
+  test('does not split astral Unicode while truncating fallback titles', () => {
+    const shortEmojiSentence = `${'😀'.repeat(40)}.`;
+    expect(deriveTitle(shortEmojiSentence)).toBe(shortEmojiSentence);
+
+    const title = deriveTitle('😀'.repeat(300));
+    expect(title).toEndWith('…');
+    expect(Array.from(title).length).toBe(80);
+    expect([...title].some((ch) => ch.length === 1 && /[\uD800-\uDFFF]/.test(ch))).toBe(false);
+  });
+
+  test('does not collapse long URL titles to the scheme separator', () => {
+    const url = `https://example.com?${'a'.repeat(300)}`;
+    const title = deriveTitle(url);
+    expect(title).toStartWith('https://example.com?');
+    expect(title).toEndWith('…');
+    expect(title.length).toBeLessThanOrEqual(80);
   });
 
   test('falls back to Capture for empty input', () => {

--- a/test/commands/capture.test.ts
+++ b/test/commands/capture.test.ts
@@ -136,11 +136,26 @@ describe('capture — buildContent', () => {
     expect(parsed.data.title).toBe('Real first line');
   });
 
-  test('caps title at 80 chars', () => {
-    const longLine = 'x'.repeat(200);
+  test('preserves first line under the 80-char cap', () => {
+    const line = 'Verify live state before trusting memory or assumptions.';
+    const result = __testing.buildContent(line, {});
+    const parsed = matter(result);
+    expect(parsed.data.title).toBe(line);
+  });
+
+  test('preserves abbreviation and numeric text without guessing sentence boundaries', () => {
+    const line = 'Jan. 5 update: GBrain vs. OpenClaw notes for the U.S. market';
+    const result = __testing.buildContent(line, {});
+    const parsed = matter(result);
+    expect(parsed.data.title).toBe(line);
+  });
+
+  test('makes fallback title truncation explicit for overlong single-token lines', () => {
+    const longLine = 'x'.repeat(300);
     const result = __testing.buildContent(longLine, {});
     const parsed = matter(result);
     expect(typeof parsed.data.title).toBe('string');
+    expect((parsed.data.title as string).endsWith('…')).toBe(true);
     expect((parsed.data.title as string).length).toBeLessThanOrEqual(80);
   });
 


### PR DESCRIPTION
## Summary

`gbrain capture` already derives fallback titles from the first non-empty body line and caps them at 80 characters. This keeps that existing cap, but makes truncation safer and visible.

Changes:

- replace silent `.slice(0, 80)` truncation with an explicit ellipsis when fallback titles are overlong
- keep the existing first-line title semantics and 80-character cap
- truncate with bounded codepoint-aware iteration so astral Unicode is not split
- avoid materializing an entire overlong first line just to derive the capped title
- preserve useful URL prefixes instead of collapsing long URLs at separators
- update capture skill docs and regression coverage

## Testing

- `env -u GBRAIN_HOME HOME="$(mktemp -d)" bun test test/capture-build-content.test.ts test/commands/capture.test.ts`
  - 45 pass, 0 fail
- `bun run typecheck`
- `bun run verify`
  - 30 checks green
- `git diff --check`

Also manually checked derived-title behavior for long single-token text, long URLs, astral Unicode, separator-only first lines, and dotted title text.
