### PR TITLE
fix(entities): resolver fallback preserves directory prefix instead of collapsing the slash

### DIFF
--- a/src/core/entities/resolve.ts
+++ b/src/core/entities/resolve.ts
@@ -71,8 +71,38 @@ export async function resolveEntitySlug(
     if (expanded) return expanded;
   }
 
-  // 4. Fallback: deterministic slugify.
-  return slugify(trimmed);
+  // 4. Fallback: deterministic slugify, PRESERVING any directory prefix.
+  //    Plain slugify("people/Some Name") → "people-some-name" mangles the
+  //    slash, which (a) can never match the real people/some-name page and
+  //    (b) makes the fence-write stub-guard refuse it as unprefixed → the fact
+  //    silently drops to DB-only instead of being fenced onto a person page.
+  //    Splitting on the first slash keeps "people/Some Name" → a valid,
+  //    fenceable "people/some-name".
+  return slugifyPreservingPrefix(trimmed);
+}
+
+/**
+ * slugify() that preserves a leading directory prefix (`people/`, `companies/`,
+ * `programs/`, ...). The plain slugify collapses every non-alphanumeric run to
+ * a hyphen, so a slug the extractor already prefixed correctly
+ * (`people/some-name`) gets mangled into `people-some-name` — an unprefixed
+ * string the fence-write stub-guard rejects, forcing the fact to the DB-only
+ * path. By splitting on the FIRST slash and slugifying each side independently
+ * we keep the prefix intact:
+ *   "people/Some Name"  → "people/some-name"
+ *   "People/some-name"  → "people/some-name"
+ *   "Some Name"         → "some-name"   (no slash → unchanged behavior)
+ * Used ONLY in the resolver fallback; the exported slugify() keeps its flat
+ * contract for callers that depend on it.
+ */
+export function slugifyPreservingPrefix(raw: string): string {
+  const idx = raw.indexOf('/');
+  if (idx === -1) return slugify(raw);
+  const dir = slugify(raw.slice(0, idx));
+  const rest = slugify(raw.slice(idx + 1));
+  if (!dir) return rest;
+  if (!rest) return dir;
+  return `${dir}/${rest}`;
 }
 
 /**
@@ -139,7 +169,7 @@ export async function resolveEntitySlugWithSource(
     if (expanded) return { slug: expanded, source: 'fuzzy_match' };
   }
 
-  return { slug: slugify(trimmed), source: 'fallback_slugify' };
+  return { slug: slugifyPreservingPrefix(trimmed), source: 'fallback_slugify' };
 }
 
 /**

--- a/test/entity-resolve.test.ts
+++ b/test/entity-resolve.test.ts
@@ -3,6 +3,7 @@ import {
   resolveEntitySlug,
   resolveEntitySlugWithSource,
   slugify,
+  slugifyPreservingPrefix,
   type ResolutionSource,
 } from '../src/core/entities/resolve.ts';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
@@ -167,6 +168,32 @@ describe('slugify', () => {
 
   it('strips accents', () => {
     expect(slugify('José García')).toBe('jose-garcia');
+  });
+});
+
+// The resolver fallback must preserve a directory prefix instead of mangling
+// the slash. Plain slugify('people/Alice Smith') → 'people-alice-smith', which
+// the fence-write stub-guard rejects as unprefixed → the fact silently drops
+// to DB-only. slugifyPreservingPrefix keeps it fenceable.
+describe('slugifyPreservingPrefix', () => {
+  it('preserves a directory prefix and slugifies the tail', () => {
+    expect(slugifyPreservingPrefix('people/Alice Smith')).toBe('people/alice-smith');
+  });
+
+  it('preserves an already-valid prefixed slug unchanged', () => {
+    expect(slugifyPreservingPrefix('people/example-person')).toBe('people/example-person');
+  });
+
+  it('lowercases the directory segment too', () => {
+    expect(slugifyPreservingPrefix('People/Bob Jones')).toBe('people/bob-jones');
+  });
+
+  it('falls back to flat slugify when there is no slash', () => {
+    expect(slugifyPreservingPrefix('Alice Smith')).toBe('alice-smith');
+  });
+
+  it('collapses extra path segments in the tail to hyphens', () => {
+    expect(slugifyPreservingPrefix('companies/Acme Corp/East')).toBe('companies/acme-corp-east');
   });
 });
 


### PR DESCRIPTION
## Problem
The step-4 deterministic-slugify fallback in `resolveEntitySlug` / `resolveEntitySlugWithSource` (`src/core/entities/resolve.ts`) runs plain `slugify()`, which collapses the slash in an already-prefixed reference: `people/Some Name` → `people-some-name`. That mangled, unprefixed slug can never match the real `people/some-name` page (and is rejected by the fence-write stub-guard), so the resolved fact silently drops to DB-only instead of fencing onto the entity page.

## Fix
Add `slugifyPreservingPrefix()` — split on the first slash, slugify each side, rejoin — and use it in the two fallback call sites. The exported flat `slugify()` contract is unchanged; only the prefixed-reference fallback path is affected.

## Repro
1. Brain with a real page `people/some-person.md` and no fuzzy-matching title.
2. `resolveEntitySlug(engine, source_id, "people/Some Person")` (already-prefixed free-form ref that misses exact/fuzzy/expansion).
3. Before: returns `people-some-person` (slash collapsed) → fact drops to DB-only. After: returns `people/some-person` → fences onto the page.

## Tests
Adds `slugifyPreservingPrefix` cases to `test/entity-resolve.test.ts`.