### PR TITLE
fix(doctor): serialize onboard checks + add timeout to avoid connection-pool deadlock on remote engines

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -7219,7 +7219,30 @@ export async function buildChecks(
     // for embed_staleness, TABLESAMPLE on PG >50K for the coverage pair).
     progress.heartbeat('onboard_checks');
     const { runAllOnboardChecks } = await import('../core/onboard/checks.ts');
-    const onboardResults = await runAllOnboardChecks(engine);
+    // Defensive cap: runAllOnboardChecks talks to the DB and could in principle
+    // stall on a wedged pooled connection. Never let it hang the entire doctor
+    // run — bound it and fall through with a warn if it blows the budget.
+    const ONBOARD_TIMEOUT_MS = 30_000;
+    let onboardResults: { check: Check }[] = [];
+    try {
+      onboardResults = await Promise.race([
+        runAllOnboardChecks(engine),
+        new Promise<never>((_, reject) => {
+          const t = setTimeout(
+            () => reject(new Error(`onboard checks exceeded ${ONBOARD_TIMEOUT_MS}ms (possible connection-pool exhaustion)`)),
+            ONBOARD_TIMEOUT_MS,
+          );
+          // Don't keep the process alive solely for this timer.
+          (t as { unref?: () => void }).unref?.();
+        }),
+      ]);
+    } catch (e) {
+      checks.push({
+        name: 'onboard_checks',
+        status: 'warn',
+        message: `Onboard checks skipped: ${(e as Error).message}`,
+      });
+    }
     for (const r of onboardResults) checks.push(r.check);
   }
 

--- a/src/core/onboard/checks.ts
+++ b/src/core/onboard/checks.ts
@@ -359,16 +359,31 @@ export async function checkTakesCount(
 export async function runAllOnboardChecks(
   engine: BrainEngine,
 ): Promise<OnboardCheckResult[]> {
-  return Promise.all([
-    checkEmbedStaleness(engine),
-    checkEntityLinkCoverage(engine),
-    checkTimelineCoverage(engine),
-    checkTakesCount(engine),
+  // Run SEQUENTIALLY, not via Promise.all. Several of these checks acquire one
+  // (or more, nested) DB connection. On a pooled remote engine (managed
+  // Postgres) with a small pool (e.g. GBRAIN_POOL_SIZE=2, a typical free-tier
+  // pooler size), running them concurrently exhausts the pool and deadlocks
+  // indefinitely — each check holds a connection while waiting for one that
+  // never frees. PGLite has no connection pool, so this was invisible there.
+  // Sequential execution keeps in-flight connections at the per-check level so
+  // onboard checks fit any pool size. Each check already try/catches internally
+  // (safeCount returns 0 on throw), so a single failure can't break the
+  // aggregate, and the whole group is cheap counts (serial cost ~ms).
+  const steps: Array<(e: BrainEngine) => Promise<OnboardCheckResult>> = [
+    checkEmbedStaleness,
+    checkEntityLinkCoverage,
+    checkTimelineCoverage,
+    checkTakesCount,
     // v0.42 type-unification (T13-T15): 3 new checks added to onboard.
-    checkPackUpgradeAvailable(engine),
-    checkTypeProliferation(engine),
-    checkDanglingAliases(engine),
-  ]);
+    checkPackUpgradeAvailable,
+    checkTypeProliferation,
+    checkDanglingAliases,
+  ];
+  const results: OnboardCheckResult[] = [];
+  for (const step of steps) {
+    results.push(await step(engine));
+  }
+  return results;
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Problem
`runAllOnboardChecks` (`src/core/onboard/checks.ts`) runs its 7 DB checks concurrently via `Promise.all`. Each check acquires at least one connection, so on a pooled remote engine (Postgres/Supabase) with a small pool (e.g. `GBRAIN_POOL_SIZE=2`), the concurrent acquisitions exhaust the pool and deadlock — `gbrain doctor` hangs indefinitely (observed >20 min vs ~10s after the fix). It's invisible on PGLite, which has no connection pool.

## Fix
- Run the onboard checks **sequentially** so in-flight connections never exceed the pool size. The checks are cheap serial counts and each already try/catches internally, so this costs ~milliseconds.
- Defensively bound the call from `doctor.ts` with a **30s timeout** that falls through to a `warn` check rather than hanging the whole `doctor` run.

## Repro
1. Point gbrain at a remote Postgres/Supabase brain with a small pool (`GBRAIN_POOL_SIZE=2`).
2. Run `gbrain doctor`. Before: the onboard-checks phase hangs (pool exhausted). After: completes in seconds.

## Notes
Open PR #2007 also touches these same 7 onboard checks (for a different `categorizeCheck` reason) — maintainer may want to land both together.