### PR TITLE
test(import-file): isolate GBRAIN_AUDIT_DIR so oversize fixtures don't pollute the operator's real audit log

### DIFF
--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -29,12 +29,24 @@ function mockEngine(overrides: Partial<Record<string, any>> = {}): BrainEngine {
   return engine;
 }
 
+let priorAuditDir: string | undefined;
+
 beforeAll(() => {
   mkdirSync(TMP, { recursive: true });
+  // Isolate audit writes to the temp dir. The oversized-content fixtures below
+  // (e.g. the 4.9MB `borderline-slug` import) trip the content-sanity
+  // soft_block path, which resolveAuditDir() would otherwise write into the
+  // real ~/.gbrain/audit logs — polluting production audit and surfacing as a
+  // phantom `content_sanity_audit_recent` WARN in `gbrain doctor`.
+  priorAuditDir = process.env.GBRAIN_AUDIT_DIR;
+  process.env.GBRAIN_AUDIT_DIR = join(TMP, 'audit');
+  mkdirSync(process.env.GBRAIN_AUDIT_DIR, { recursive: true });
 });
 
 afterAll(() => {
   rmSync(TMP, { recursive: true, force: true });
+  if (priorAuditDir === undefined) delete process.env.GBRAIN_AUDIT_DIR;
+  else process.env.GBRAIN_AUDIT_DIR = priorAuditDir;
 });
 
 describe('importFile', () => {


### PR DESCRIPTION
## Problem
The "accepts in-memory content just under MAX_FILE_SIZE" test in `test/import-file.test.ts` imports a 4.9MB page that trips the content-sanity oversize soft-block path. `resolveAuditDir()` honors `GBRAIN_AUDIT_DIR` and defaults to `~/.gbrain/audit`, so the test writes that soft_block event into the operator's REAL audit log on every run — a phantom event that surfaces as a recurring `content_sanity_audit_recent` WARN in `gbrain doctor` (related: #1893).

## Fix
Point `GBRAIN_AUDIT_DIR` at the test's temp dir in `beforeAll` and restore the prior value in `afterAll`. Self-contained; no behavior change to the code under test.

## Repro
`bun test test/import-file.test.ts`, then `gbrain doctor` → a `content_sanity` event appears in `~/.gbrain/audit/content-sanity-<week>.jsonl` and feeds the recurring WARN. After the fix, the run writes only to the temp dir.