### PR TITLE
fix(embeddings): local Ollama/llama-server models can't init at non-768 native dim

### DIFF
--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -384,10 +384,16 @@ function validateDimAgainstTouchpoint(
   }
 
   if (requestedDims !== undefined && requestedDims !== defaultDims) {
-    // User asked for a non-default dim. Walk the precedence chain.
-    const customDimOk = isCustomDimValidForProvider(recipe, modelId, requestedDims, dimsOptions);
-    if (!customDimOk.valid) {
-      return { ok: false, error: customDimOk.error };
+    // FORK PATCH (creaminds): local Ollama/llama-server models emit a fixed native
+    // dim that may differ from the recipe's single default_dims (bge-m3=1024 vs nomic=768).
+    // The upstream ollama recipe declares one default_dims (768) for all three models,
+    // so mxbai/bge-m3 are listed but un-initialisable. Trust the user-supplied native
+    // dim for local providers; keep the guard for cloud providers.
+    if (recipe.id !== 'ollama' && recipe.id !== 'llama-server') {
+      const customDimOk = isCustomDimValidForProvider(recipe, modelId, requestedDims, dimsOptions);
+      if (!customDimOk.valid) {
+        return { ok: false, error: customDimOk.error };
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

The `ollama` embedding recipe declares a single `default_dims: 768` for three models with **different** native dimensions:

```ts
// src/core/ai/recipes/ollama.ts
embedding: {
  models: ['nomic-embed-text', 'mxbai-embed-large', 'all-minilm'],
  default_dims: 768,   // nomic=768, but mxbai-embed-large=1024, all-minilm=384
}
```

As a result `mxbai-embed-large` and `all-minilm` are **listed but cannot be initialised**:

- `gbrain init --pglite --embedding-model ollama:mxbai-embed-large` (no `--embedding-dimensions`) builds a `vector(768)` schema, then the first embed fails: `Embedding dim mismatch: model mxbai-embed-large returned 1024 but schema expects 768`.
- Adding `--embedding-dimensions 1024` is rejected by the guard: `Provider "ollama" model "mxbai-embed-large" does not support custom dimensions 1024 (this model only emits its default vector size)` — because `ollama` isn't in the Matryoshka allow-list in `embedding-dim-check.ts`.
- `reinit-pglite` *requires* `--embedding-dimensions`, which `init` then refuses — a catch-22.

So any local Ollama/llama-server model whose native dim ≠ 768 is unusable. This also blocks multilingual models like **`bge-m3` (1024d)**, which matter a lot for non-English corpora.

## Fix

In `validateDimAgainstTouchpoint`, skip the custom-dim rejection for **local** providers (`ollama`, `llama-server`), trusting the user-supplied native dim. Cloud providers keep the Matryoshka guard unchanged.

```
gbrain init --pglite --embedding-model ollama:bge-m3 --embedding-dimensions 1024   # now works
```

## Notes

- Minimal, local-only change; cloud behaviour is untouched.
- An alternative (arguably cleaner) fix would be per-model `default_dims`/`dims_options` in the ollama recipe (e.g. `mxbai-embed-large→1024`, `all-minilm→384`). Happy to switch to that approach if preferred.
