### PR TITLE
fix(ai): honor user-provided embedding model ids

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -709,7 +709,8 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
-    (recipe.id === 'litellm' || isUserProvided)
+    (recipe.id === 'litellm' || isUserProvided) &&
+    !parsed.modelId
   ) {
     return {
       ok: false,

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -8,6 +8,7 @@ import {
   getEmbeddingDimensions,
   getExpansionModel,
   VoyageResponseTooLargeError,
+  diagnoseEmbedding,
 } from '../../src/core/ai/gateway.ts';
 
 // v0.39.x ship-wave fix: gateway module is process-scoped. Without an
@@ -90,6 +91,21 @@ describe('gateway.isAvailable (silent-drop regression surface)', () => {
       embedding_model: 'ollama:nomic-embed-text',
       embedding_dimensions: 768,
       env: {},
+    });
+    expect(isAvailable('embedding')).toBe(true);
+  });
+
+  test('embedding AVAILABLE for user-provided llama-server model from config string', () => {
+    configureGateway({
+      embedding_model: 'llama-server:text-embedding-qwen3-embedding-0.6b',
+      embedding_dimensions: 1024,
+      env: {},
+    });
+    expect(diagnoseEmbedding()).toEqual({
+      ok: true,
+      model: 'llama-server:text-embedding-qwen3-embedding-0.6b',
+      provider: 'llama-server',
+      recipeId: 'llama-server',
     });
     expect(isAvailable('embedding')).toBe(true);
   });


### PR DESCRIPTION
## Summary
- allow `diagnoseEmbedding()` to accept user-provided embedding model ids parsed from the `provider:model` config string
- keep the existing `user_provided_model_unset` diagnostic for empty-model recipes only when no model id was provided
- add a regression test for a `llama-server:<model>` embedding config

## Test Plan
- `npm exec --yes bun@1.3.13 -- test test/ai/gateway.test.ts`
- `npm exec --yes bun@1.3.13 -- run typecheck`

Fixes #2204.
Related to #2295.
