### PR TITLE
docs(proposals): visual-doc-retrieval — spec, plan, tasks, research

### DIFF
--- a/docs/proposals/visual-doc-retrieval/plan.md
+++ b/docs/proposals/visual-doc-retrieval/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: Faithful Retrieval over Visually-Rich Documents
+
+**Branch**: `feat/visual-doc-retrieval` · **Spec**: `./spec.md` · **Status**: Draft
+
+## Summary
+
+Add a gbrain ingestion + retrieval path for visually-rich PDFs (tables, figures, charts) that preserves visual/tabular content plain-text extraction destroys. Documents are segmented into **semantic units** (table, figure+caption, section) by an LLM-vision layout detector, each unit is **multimodally embedded** (image), retrieval is sharpened by a **cross-encoder rerank**, and answers are produced by a **vision read** of the retrieved unit with provenance. Rationale and measured tradeoffs: `/workspaces/random/gbrain-testing/COMPARISON.md` (§5–§7).
+
+## Technical Context
+
+**Language/Version**: TypeScript on Bun (gbrain's runtime).
+
+**Primary Dependencies**: gbrain AI gateway (`src/core/ai/`); Voyage `voyage-multimodal-3.5` (unit embedding) + `rerank-2.5` (precision); Anthropic Claude vision (layout detection + answer read) via the gateway; `pdftoppm`/poppler (PDF→image render). All model access routes through the gateway — no direct provider SDK calls at call sites.
+
+**Storage**: PGLite + pgvector (default) / Postgres + pgvector (scale) — existing gbrain engines; new tables for units + provenance, in lockstep across both engines.
+
+**Testing**: `bun test`; engine-parity test for any new SQL; unit tests for layout post-processing (deterministic part) with the stochastic vision call stubbed.
+
+**Target Platform**: gbrain CLI + MCP server (stdio/HTTP) on Linux/macOS.
+
+**Project Type**: Library/CLI feature inside the gbrain monorepo (contract-first operation + minion handler + AI recipe).
+
+**Performance Goals**: ingest a 20-page PDF within the configured cost budget; query p50 dominated by rerank+vision-read (~seconds), recall stage sub-second.
+
+**Constraints**: per-unit embedding ≤ Voyage 32K-token cap (no silent truncation, FR-004); reproducibility within a pinned model version (FR-013); cost budget enforced + reported (FR-015, SC-007).
+
+**Scale/Scope**: personal-to-moderate (≤ low-thousands of docs) for v1.
+
+## Constitution Check
+
+*GATE: gbrain's invariants are its constitution (`CLAUDE.md` → Cross-cutting invariants). This feature must satisfy:*
+
+- **Contract-first** — new capabilities are `Operation`s in `src/core/operations.ts` (CLI + MCP generated); each carries `scope` + optional `localOnly`. ✅ planned.
+- **Trust fail-closed** — ingestion/answer ops that spawn vision/model work assert `ctx.remote === false` where they must; reads honor `sourceScopeOpts(ctx)`. ✅ planned.
+- **Engine parity** — new unit/provenance tables land in BOTH `pglite-engine.ts` and `postgres-engine.ts`, pinned by `test/e2e/engine-parity.test.ts`; DDL in the `MIGRATIONS` array in `src/core/migrate.ts`. ✅ planned.
+- **JSONB** — region/bbox metadata passed as raw objects to `executeRaw`/`executeRawJsonb`, never `JSON.stringify` into a `::jsonb` cast. ✅ planned.
+- **Config planes** — model/budget/driver settings read from file plane (`~/.gbrain/config.json`) or env, never `gbrain config set` (DB plane). ✅ planned.
+- **Bulk progress to stderr** — ingestion streams progress via `src/core/progress.ts` (stdout stays clean for `--json`). ✅ planned.
+- **AI gateway is the single seam** — all model calls (embed/rerank/vision) go through `src/core/ai/gateway.ts` recipes; layout-detection + vision-read added as gateway-routed calls, not ad-hoc SDK usage. ⚠️ *gateway today returns AI-SDK `LanguageModelV2`; the vision-read + layout calls fit the existing native-anthropic chat path; the multimodal-embed fits the existing `voyage` recipe's multimodal path (`supports_multimodal`).* No new dispatch type required.
+
+*No constitution violations anticipated → Complexity Tracking empty.*
+
+## Project Structure
+
+### Documentation (this feature)
+```
+docs/proposals/visual-doc-retrieval/
+├── spec.md      # WHAT/WHY (done)
+├── plan.md      # this file — HOW
+├── tasks.md     # sliced, dependency-ordered tasks
+└── research.md  # Phase 0 — points at gbrain-testing/COMPARISON.md (the experiments)
+```
+
+### Source code (gbrain repo)
+```
+src/core/ai/recipes/          # reuse voyage (multimodal path) + anthropic (vision) recipes
+src/core/ingestion/
+  └── visual/                 # NEW: render, detect_layout, semantic-unit crop, provenance
+src/core/ai/layout/           # NEW: detect_layout (LLM-vision, strict-schema JSON, cached)
+src/core/operations.ts        # NEW ops: ingest_visual_doc, (answer path reuses query/think)
+src/core/minions/handlers/    # NEW: visual-ingest minion (long-running, queued)
+src/core/migrate.ts           # NEW migration: units + provenance columns/tables (both engines)
+test/                         # parity test + layout post-process unit tests (vision stubbed)
+```
+
+## Phase 0 — Research (DONE)
+
+The hard questions are already answered empirically in `gbrain-testing/COMPARISON.md`:
+- Text extraction garbles dense tables; vision reads them faithfully (§1–§4, the `55.266.1` vs `55.2/66.1` result).
+- Multimodal embedding retrieves page images from text queries (§5); cross-modal similarity runs below text→text (calibration caveat).
+- Granularity ladder: whole-doc (truncates+dilutes) ≪ per-page < per-half < **semantic unit** (§5b–§5d).
+- Rerank lifts the true unit and sharpens scores; chunk+transcribe+rerank is crispest (§5e–§5f).
+- Cost: embed/rerank ≈ free at this scale; vision-LLM tokens are the only real cost — decide ingest-time vs query-time (§6).
+- Determinism/layout risk concentrate in the vision/layout steps → cache outputs, pin versions, layout-aware chunking (§7).
+
+**Open research item**: `detect_layout` box precision (pure LLM-vision vs hybrid with a deterministic detector) — see `detect-layout-plan.md` work; v1 ships pure LLM-vision with normalized bboxes + padding, hybrid deferred.
+
+## Phase 1 — Design (contracts & data model)
+
+**Data model (entities → tables, both engines):**
+- `documents` (reuse existing pages/source where possible) — id, source, page_count, content_hash.
+- `units` — id, document_id, type (table/figure/text/...), page(s), bbox (jsonb, normalized), reading_order, provenance, confidence, embedding (vector, multimodal column), source_image_ref.
+- Provenance recorded on every unit (FR-009).
+
+**Contracts:**
+- `detect_layout(page_image) -> regions[]` — LLM-vision, strict JSON schema, normalized bboxes, cached by page content-hash (FR-002, FR-011; determinism §7).
+- `ingest_visual_doc` operation — `scope: admin`, queued to a minion; render → detect_layout → crop units → multimodal-embed → persist + provenance; idempotent by content hash (FR-001/003/004/008/012); progress→stderr.
+- Retrieval reuses `query`/`search` over the multimodal column; **rerank** stage added on the candidate units (FR-005/007).
+- Answer path reuses `think`/vision-read over the retrieved unit, returning provenance and an explicit "not found" when recall is empty (FR-008/014).
+
+## Phase 2 — Tasks
+
+See `tasks.md` (sliced by user story P1→P4, dependency-ordered, parity- and budget-aware).
+
+## Complexity Tracking
+
+*Empty — no constitution violations to justify. The one risk (LLM-vision bbox precision) is contained: normalized bboxes + crop padding + geometric fallback (FR-011), with a hybrid detector deferred to a follow-up if precision is insufficient.*

--- a/docs/proposals/visual-doc-retrieval/research.md
+++ b/docs/proposals/visual-doc-retrieval/research.md
@@ -1,0 +1,29 @@
+# Research (Phase 0): extraction, embedding, chunking, rerank tradeoffs
+
+Decisions below are backed by a hands-on benchmark on the RAG paper (arXiv:2005.11401). Self-contained summary; the raw runs/artifacts live in a companion scratch dir (`gbrain-testing/COMPARISON.md`, not part of this repo).
+
+## Decision: read tables with vision, not text extraction
+- Text extractors (firecrawl/pdftotext) and a flat AI extract **garble dense tables** — a `55.2/66.1` cell flattened to `55.266.1`; the alphaXiv "report" mode paraphrases (no raw table).
+- **Claude vision-PDF transcribed the same table faithfully** (`55.2/66.1`, split columns recovered).
+- → Visual/tabular fidelity requires a **vision** step; plain text extraction is insufficient (SC-001).
+
+## Decision: embed semantic **units**, not pages or whole docs
+- Granularity ladder (multimodal embedding, one model): whole-doc **0.223** (truncated + diluted) ≪ per-page **0.486** < per-half **0.549** < **semantic unit** (clean per-table separation).
+- Whole-doc-as-one-vector hit the **32K-token per-input cap** → ~32% of pages (incl. the last) silently dropped → motivates FR-004 (no silent truncation) and SC-003.
+- Finer chunks fixed **mis-localization** (per-page returned the wrong page; the table crop won) → FR-002, FR-005.
+
+## Decision: multimodal embedding for recall, rerank for precision
+- `voyage-multimodal-3.5` retrieves the correct page **image** from a **text** query (clean diagonal) — no extraction needed. Architecture: one shared transformer over image patch-tokens + text tokens (not image→text).
+- **Cross-modal similarity runs below text→text** → calibration caveat: keep corpus modality-consistent and/or rerank (§7).
+- `rerank-2.5` (cross-encoder, text-only) lifts the true unit and sharpens scores; **chunk→vision-transcribe→rerank** gave the crispest separation (q_QA +0.234, q_gen +0.377). Rerank operates on a **text representation** of candidate units.
+
+## Decision: ingest-time vs query-time vision (cost)
+- Embedding + reranking are **≈ free at personal scale** (Voyage free tier ≈ thousands of docs). The only cost with no free tier is **vision/LLM tokens** (measured ~$0.012/page vision).
+- → v1 default: **lazy** — multimodal-embed everything (cheap), vision-read only the retrieved hit (~1¢/query). Front-load vision only for heavily re-queried corpora (FR-015, SC-007).
+
+## Decision: contain non-determinism + layout risk
+- The stochastic/fragile steps are layout detection + vision; everything else (render, embed, exact search, rerank) is deterministic within a pinned model version.
+- → **Cache** layout + transcription artifacts (content-hash), **pin** model versions, **layout-aware** chunking with bbox provenance, **geometric fallback** on detection failure (FR-011, FR-013).
+
+## Open item
+- `detect_layout` bbox precision: v1 = pure LLM-vision (normalized bboxes + padding); a hybrid with a deterministic table/figure detector is deferred (T025) if precision proves insufficient.

--- a/docs/proposals/visual-doc-retrieval/spec.md
+++ b/docs/proposals/visual-doc-retrieval/spec.md
@@ -1,0 +1,140 @@
+# Feature Specification: Faithful Retrieval over Visually-Rich Documents
+
+**Feature Branch**: `001-visual-doc-retrieval`
+
+**Created**: 2026-06-19
+
+**Status**: Draft
+
+**Input**: User description: "Implement the pipeline for ingesting visually-rich documents (PDFs with tables, figures, charts) into a searchable knowledge base, so queries retrieve the correct content and answers stay faithful to the source — including the visual/tabular content that plain text extraction loses."
+
+<!-- This spec is WHAT/WHY only. Implementation choices (multimodal embedding, vision transcription, layout detection, reranking, specific providers) are deliberately deferred to plan.md — see Assumptions. -->
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Ingest a document without losing its tables and figures (Priority: P1)
+
+A user adds a PDF that carries meaning in its layout — tables of numbers, charts, figures — to the knowledge base, and that visual content survives ingestion intact (not flattened to garbled or missing text).
+
+**Why this priority**: This is the system's entire reason to exist. Plain text extraction silently corrupts dense tables and drops figures; if ingestion isn't faithful, nothing downstream can be. A working version of just this story already delivers value: a trustworthy store of visual documents.
+
+**Independent Test**: Ingest a PDF containing a dense numeric table; confirm the table's values are present and uncorrupted when the unit is retrieved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PDF with a numeric table whose cells include sub-columns, **When** it is ingested and the table is later retrieved, **Then** the cell values are intact (sub-columns preserved, not merged into a single garbled number).
+2. **Given** a PDF page containing a figure or chart, **When** it is ingested, **Then** the figure's content is retained and retrievable (not silently dropped).
+3. **Given** a multi-page PDF, **When** it is ingested, **Then** every page's content is represented — none lost to length limits.
+
+---
+
+### User Story 2 - Retrieve the correct unit for a query (Priority: P2)
+
+A user asks a question, and the system returns the specific document region that answers it — distinguishing the right table/section from sibling regions and from unrelated pages.
+
+**Why this priority**: Faithful storage is worthless if retrieval surfaces the wrong region. Precision (right unit, not just right document) is what makes the store usable.
+
+**Independent Test**: Index a document with two tables on one page; issue two targeted queries; each returns its own table as the top result.
+
+**Acceptance Scenarios**:
+
+1. **Given** a document with multiple sibling tables, **When** a user queries content specific to one of them, **Then** that table is the top-ranked result, clearly separated from the others.
+2. **Given** a long document, **When** a user queries content located on a late page, **Then** that content is retrieved at parity with early-page content.
+3. **Given** a query whose words differ from the source wording (paraphrase/synonyms), **When** retrieval runs, **Then** the semantically matching unit is still returned.
+
+---
+
+### User Story 3 - Get a faithful, sourced answer (Priority: P3)
+
+A user asks for a specific fact (e.g., a value from a table); the system returns an answer that matches the source exactly and cites where it came from.
+
+**Why this priority**: The end deliverable. It depends on P1 (faithful content) and P2 (right unit), so it ranks below them, but it's what the user ultimately consumes.
+
+**Independent Test**: Ask a question whose answer is a specific table value; verify the returned value equals the source and the answer cites the page/region.
+
+**Acceptance Scenarios**:
+
+1. **Given** a retrieved unit, **When** the user asks for a specific value in it, **Then** the answer equals the source value and includes provenance (document, page, region).
+2. **Given** a question with no supporting content in the corpus, **When** the user asks it, **Then** the system reports "no relevant content found" rather than fabricating an answer.
+
+---
+
+### User Story 4 - Reproducible, cost-bounded ingestion (Priority: P3)
+
+An operator re-ingests documents and runs queries with predictable, bounded cost and no duplication or silent drift.
+
+**Why this priority**: Operability. Not user-facing value per se, but required for trust at scale and for repeatable results.
+
+**Independent Test**: Ingest the same unchanged document twice; confirm no duplicate units; confirm reported cost is within the configured budget.
+
+**Acceptance Scenarios**:
+
+1. **Given** an unchanged document, **When** it is ingested a second time, **Then** no duplicate units are created.
+2. **Given** a configured per-document/per-query budget, **When** ingestion or a query runs, **Then** cost stays within budget and the actual cost is reported.
+
+---
+
+### Edge Cases
+
+- **Scanned / image-only PDF** (no machine-readable text layer) — must still be ingested and made retrievable.
+- **Table or figure spanning a page break** — must be reassembled into one unit, not split into two useless halves.
+- **Multi-column layout / non-linear reading order** — units and reading order must be correct, not column-fused.
+- **A single region larger than the processing size limit** — must be handled (sub-split or flagged), never silently truncated.
+- **Corrupt, encrypted, or password-protected PDF** — must fail explicitly with a clear error, not partially ingest.
+- **Layout segmentation low-confidence or failed** — must fall back to a safe chunking strategy and flag the document, never hard-fail.
+- **Query about absent content** — must return "not found," not a confident hallucination.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST ingest documents whose meaning lives in visual layout (tables, figures, charts) and preserve that content for retrieval.
+- **FR-002**: System MUST segment each document into **semantically coherent units** (a table, a figure with its caption, a section) rather than fixed-size or arbitrary geometric splits.
+- **FR-003**: System MUST preserve dense tabular/numeric content without value corruption (no merged or garbled cells).
+- **FR-004**: System MUST NOT silently drop or truncate any portion of a document during ingestion; unprocessable content MUST be flagged, not dropped.
+- **FR-005**: System MUST retrieve the correct semantic unit for a query, distinguishing it from sibling units within the same document.
+- **FR-006**: System MUST allow querying the full extent of a document regardless of its length (no late-content loss).
+- **FR-007**: System MUST support queries that are semantic (paraphrase/synonym), not only literal keyword matches.
+- **FR-008**: System MUST return answers that faithfully match the source content and include provenance (document, page, region).
+- **FR-009**: System MUST record the source location (page + region) for every retrievable unit.
+- **FR-010**: System MUST ingest documents lacking a machine-readable text layer (scanned / image-only).
+- **FR-011**: System MUST degrade gracefully when automated layout segmentation is low-confidence or fails — fall back to a safe chunking strategy and flag the document; never hard-fail ingestion.
+- **FR-012**: Ingestion MUST be idempotent — re-ingesting unchanged content MUST NOT create duplicate units.
+- **FR-013**: System MUST keep retrieval results reproducible for a fixed configuration. [NEEDS CLARIFICATION: tolerance/behavior when an underlying model version changes — re-index automatically, warn, or pin?]
+- **FR-014**: System MUST distinguish "no relevant content found" from a confident answer (no fabrication when the corpus lacks the information).
+- **FR-015**: System SHOULD allow an operator to bound per-document and per-query cost and MUST report actual cost incurred.
+- **FR-016**: Reassembly MUST stitch a unit that spans a page boundary (e.g., a continued table) into a single retrievable unit.
+
+### Key Entities *(include if feature involves data)*
+
+- **Document**: a source file. Attributes: id, source/URI, page count, content hash (for idempotency), ingestion status.
+- **Semantic Unit (Chunk)**: a coherent region of a document. Attributes: type (table/figure/chart/text/caption/section), page(s), bounding region, reading order, provenance, confidence, link to its embedding.
+- **Embedding**: the searchable representation of a unit (modality-aware: visual or textual).
+- **Query**: a user information need (text, possibly multimodal).
+- **Retrieval Result**: a ranked set of units with relevance scores and provenance.
+- **Answer**: a response grounded in retrieved unit(s), with citations to the source region(s).
+
+## Success Criteria *(mandatory)*
+
+<!-- Targets grounded in the empirical study in /workspaces/random/gbrain-testing/COMPARISON.md -->
+
+### Measurable Outcomes
+
+- **SC-001**: On a benchmark of dense tables, retrieved/read table values contain **zero cell-merge/garble errors** (baseline failure observed: a "55.2/66.1" cell flattened to "55.266.1"; target: 0 such errors).
+- **SC-002**: For documents with multiple sibling tables, a targeted query returns the **correct unit as the #1 result in ≥95%** of cases.
+- **SC-003**: **100% of a document's content is retrievable** — late-page content (e.g., a final-page table) retrieves at parity with early-page content (baseline failure: whole-document single-vector silently dropped ~32% of pages including the last; target: no loss).
+- **SC-004**: **≥99% of answered queries include correct provenance** (document, page, region) that a reviewer can verify against the source.
+- **SC-005**: Re-ingesting an unchanged document creates **0 duplicate units**.
+- **SC-006**: For queries with no supporting content, the system returns an explicit "not found" in **≥95%** of such cases (no fabricated answer).
+- **SC-007**: Per-document ingestion cost and per-query cost stay **within the configured budget**, and actual cost is reported for every run.
+- **SC-008**: A query phrased with no lexical overlap with the source still retrieves the correct unit (semantic match), measured as **≥90% recall@3** on a paraphrase benchmark.
+
+## Assumptions
+
+- Target "users" are developers (or an automated agent) building a searchable knowledge base over their own document corpus; this is infrastructure, not an end-user app.
+- Documents in scope for v1 are **PDFs** (papers, reports, slides, scanned docs). [NEEDS CLARIFICATION: which non-PDF formats, if any, are in scope — DOCX/XLSX/HTML?]
+- Scale for v1 is **personal-to-moderate** (≤ low-thousands of documents); large-scale sharding/multi-tenant is out of scope. [NEEDS CLARIFICATION: target corpus size]
+- A vector/semantic store and a vision-capable model are available; **specific providers and architecture (embedding model, vision model, reranker, layout detector) are HOW and are deferred to `plan.md`.**
+- Network access to hosted models is assumed; fully-offline operation is out of scope for v1. [NEEDS CLARIFICATION: is on-prem/offline a requirement?]
+- The system may reuse an existing knowledge-store/persistence layer rather than introducing a new one. [NEEDS CLARIFICATION: reuse the existing brain store, or stand up a dedicated one?]
+- "Faithful" is judged against the source PDF as ground truth; human-reviewable provenance is the verification mechanism.

--- a/docs/proposals/visual-doc-retrieval/tasks.md
+++ b/docs/proposals/visual-doc-retrieval/tasks.md
@@ -1,0 +1,63 @@
+# Tasks: Faithful Retrieval over Visually-Rich Documents
+
+**Spec**: `./spec.md` · **Plan**: `./plan.md`
+
+Format: `[ID] [P?] [Story] Description` — **[P]** = parallelizable (different files, no dep). Each User Story phase is an independently shippable PR.
+
+## Phase 1: Setup (shared)
+
+- [ ] T001 Add proposal docs (spec/plan/tasks/research) under `docs/proposals/visual-doc-retrieval/` — **this PR**.
+- [ ] T002 [P] Confirm `pdftoppm`/poppler availability + render helper (`src/core/ingestion/visual/render.ts`): page→PNG at a pinned DPI; deterministic.
+- [ ] T003 [P] Add file-plane config keys (read-only at call sites): `visual.embedding_model` (`voyage:voyage-multimodal-3.5`), `visual.layout_model`, `visual.budget_*`. No `gbrain config set` (DB plane).
+
+## Phase 2: Foundational (blocking prerequisites)
+
+- [ ] T004 Migration in `src/core/migrate.ts` `MIGRATIONS`: `units` table + provenance columns + multimodal embedding column — DDL for **both** engines (`pglite-engine.ts` + `postgres-engine.ts`).
+- [ ] T005 Extend `test/e2e/engine-parity.test.ts` to cover the new SQL shape (parity gate).
+- [ ] T006 [P] Wire the `voyage` recipe's **multimodal path** (`supports_multimodal`) for unit embedding through the gateway; confirm `embedMultimodal` route (no new dispatch type).
+- [ ] T007 [P] Add gateway-routed **vision call** helper (native-anthropic chat path) for layout detection + answer read.
+- [ ] T008 Progress wiring via `src/core/progress.ts` for the ingest path (stderr; `--json` clean).
+
+## Phase 3: User Story 1 — Faithful ingest, no lost tables/figures (P1) 🎯 MVP
+
+- [ ] T009 [US1] `detect_layout(page_image)` in `src/core/ai/layout/` — LLM-vision, **strict JSON schema**, normalized bboxes, caption-binding + column-aware reading order; cached by page content-hash.
+- [ ] T010 [P] [US1] Layout post-process (deterministic): validate/clamp bboxes, drop header/footer, pad crops, cross-page table stitch (FR-016), low-confidence → geometric fallback (FR-011).
+- [ ] T011 [P] [US1] Unit cropper `src/core/ingestion/visual/crop.ts`: denormalize bbox×dims → semantic-unit image + provenance.
+- [ ] T012 [US1] `ingest_visual_doc` Operation in `operations.ts` (`scope:'admin'`, queued); idempotent by content hash (no duplicate units, FR-012); never truncate, flag unprocessable (FR-004).
+- [ ] T013 [US1] Visual-ingest minion handler in `src/core/minions/handlers/`: render → detect_layout → crop → multimodal-embed → persist + provenance.
+- [ ] T014 [P] [US1] Unit tests: layout post-process + cropper (vision call **stubbed** — keep deterministic part covered).
+- [ ] T015 [US1] Validate against the RAG paper p6: auto-detected table crops reproduce the manual §5d separation (the go/no-go gate from `detect-layout-plan.md`).
+
+**Checkpoint**: a visually-rich PDF ingests; its tables/figures persist as retrievable units with provenance. (SC-001, SC-003, SC-005.)
+
+## Phase 4: User Story 2 — Retrieve the correct unit (P2)
+
+- [ ] T016 [US2] Extend `query`/`search` to rank over the multimodal unit column; return units with provenance.
+- [ ] T017 [US2] Add **rerank-2.5** stage on candidate units (text rep of the unit), gateway-routed; cross-modal-gap mitigation (§5/§7).
+- [ ] T018 [P] [US2] Retrieval eval harness: sibling-table separation (SC-002) + late-content parity (SC-003) + paraphrase recall@3 (SC-008), using `gbrain-testing/` corpus.
+
+**Checkpoint**: targeted queries return the correct unit #1, late content retrievable, paraphrase queries work.
+
+## Phase 5: User Story 3 — Faithful, sourced answer (P3)
+
+- [ ] T019 [US3] Answer path: vision-read the top retrieved unit (gateway), return value + provenance (page/region) (FR-008, SC-004).
+- [ ] T020 [US3] "Not found" guard: empty/low-confidence recall → explicit no-answer, no fabrication (FR-014, SC-006).
+
+**Checkpoint**: a value question returns the source-exact value with a citation.
+
+## Phase 6: User Story 4 — Reproducible, cost-bounded ops (P3)
+
+- [ ] T021 [US4] Cache layout + vision-transcription artifacts (content-hash) → freeze the stochastic steps (§7 determinism).
+- [ ] T022 [US4] Budget enforcement + cost reporting per ingest/query (FR-015, SC-007); pin model versions, store model id with the index (FR-013).
+
+## Phase 7: Polish
+
+- [ ] T023 [P] `gbrain doctor` check: visual pipeline config + model reachability.
+- [ ] T024 [P] Docs: usage + the ingest-time-vs-query-time cost decision (from §6).
+- [ ] T025 Decide hybrid `detect_layout` (deterministic detector for tight boxes) if LLM bbox precision proves insufficient (deferred from Phase 0).
+
+## Dependencies & PR slicing
+- Phase 1–2 → **PR 2** (foundation: render, config, migration+parity, gateway wiring).
+- Phase 3 (US1) → **PR 3** (MVP: faithful ingest). Independently shippable.
+- Phase 4 (US2) → **PR 4**; Phase 5 (US3) → **PR 5**; Phase 6 (US4) → **PR 6**; Phase 7 → **PR 7**.
+- **This PR (PR 1)** = the proposal docs (spec/plan/tasks/research) only — design review before code.


### PR DESCRIPTION
Spec-driven proposal for a visually-rich PDF ingestion + retrieval pipeline: faithful tables/figures via vision, semantic-unit chunking, multimodal embedding, cross-encoder rerank, sourced answers. WHAT/WHY in spec.md; HOW (gateway recipes, ops, minion, engine-parity migration) in plan.md; sliced tasks in tasks.md; empirical rationale in research.md.