### PR TITLE
fix(dims): handle prefixed model IDs on openai-compatible path

### DIFF
--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -201,9 +201,10 @@ export function dimsProviderOptions(
       // configured for a smaller width (e.g. 1536) hard-fail at first embed.
       // Azure/OpenAI-compat embeddings are symmetric — inputType ignored.
       // v0.36.0.0 (D13): same range validation as native-openai path.
-      if (modelId.startsWith('text-embedding-3')) {
-        if (isOpenAITextEmbedding3Model(modelId) && !isValidOpenAITextEmbedding3Dim(modelId, dims)) {
-          const max = maxOpenAITextEmbedding3Dim(modelId)!;
+      const bareModelId = modelId.includes('/') ? modelId.split('/').pop()! : modelId;
+      if (bareModelId.startsWith('text-embedding-3')) {
+        if (isOpenAITextEmbedding3Model(bareModelId) && !isValidOpenAITextEmbedding3Dim(bareModelId, dims)) {
+          const max = maxOpenAITextEmbedding3Dim(bareModelId)!;
           throw new AIConfigError(
             `OpenAI model "${modelId}" supports embedding_dimensions in 1..${max}, got ${dims}.`,
             `Set \`embedding_dimensions\` to a value between 1 and ${max} ` +

--- a/test/ai/dims-openai.test.ts
+++ b/test/ai/dims-openai.test.ts
@@ -134,3 +134,30 @@ describe('dimsProviderOptions — OpenAI on openai-compatible adapter (Azure cas
     expect(JSON.stringify(opts)).not.toContain('input_type');
   });
 });
+
+describe('dimsProviderOptions — prefixed model IDs (OpenRouter / proxy providers)', () => {
+  test('openai/text-embedding-3-large at 1536d returns dimensions=1536', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'openai/text-embedding-3-large', 1536);
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1536 } });
+  });
+
+  test('openai/text-embedding-3-small at 768d returns dimensions=768', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'openai/text-embedding-3-small', 768);
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 768 } });
+  });
+
+  test('openai/text-embedding-3-large at 5000d throws AIConfigError', () => {
+    expect(() => dimsProviderOptions('openai-compatible', 'openai/text-embedding-3-large', 5000))
+      .toThrow(AIConfigError);
+  });
+
+  test('error message preserves full prefixed model ID for clarity', () => {
+    try {
+      dimsProviderOptions('openai-compatible', 'openai/text-embedding-3-large', 5000);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AIConfigError);
+      expect((err as Error).message).toContain('openai/text-embedding-3-large');
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`dimsProviderOptions()` fails to pass the `dimensions` parameter when the
model ID contains a provider prefix (e.g. `openai/text-embedding-3-large`
via OpenRouter), because the check `modelId.startsWith('text-embedding-3')`
doesn't match the prefixed form.

Without `dimensions`, the upstream provider returns its native dimensionality
(3072 for `-large`) instead of the configured value (e.g. 1536), causing an
immediate "Embedding dim mismatch" error on first embed.

**Repro:**
```ts
dimsProviderOptions('openai-compatible', 'openai/text-embedding-3-large', 1536);
// Returns: undefined (should return { openaiCompatible: { dimensions: 1536 } })
```

The default OpenRouter embedding (`text-embedding-3-small` at 1536d) masked
this because its native size happens to match the default config. The bug
surfaces when using `-large`, or `-small` at a non-1536 dim (512, 768,
1024 — all in the recipe's `dims_options`).

## Fix

Strip the provider prefix (everything before `/`) before the `startsWith`
check. The full prefixed ID is preserved in the error message for clarity.

One-line change in `src/core/ai/dims.ts`, plus 4 test cases in
`test/ai/dims-openai.test.ts` covering the prefixed happy path, Matryoshka
shrink, out-of-range validation, and error message format.

## Test plan

- [x] All 20 tests in `dims-openai.test.ts` pass (16 existing + 4 new)
- [x] No regressions on bare model IDs, DashScope, MiniMax, or ZeroEntropy paths
- [x] Verified end-to-end: `gbrain search` + `gbrain think` work with
      `openrouter:openai/text-embedding-3-large` at 1536d after this fix