### PR TITLE
feat(recipes): add bge-m3 to ollama embedding recipe + dims_options

### DIFF
--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -13,8 +13,11 @@ export const ollama: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['nomic-embed-text', 'mxbai-embed-large', 'all-minilm'],
+      models: ['nomic-embed-text', 'mxbai-embed-large', 'all-minilm', 'bge-m3'],
       default_dims: 768, // nomic-embed-text native dim
+      // local patch: register bge-m3 (multilingual, strong CN retrieval). dims_options
+      // lets init accept --embedding-dimensions for this provider's non-768 models.
+      dims_options: [384, 768, 1024], // all-minilm=384 · nomic=768 · mxbai-embed-large/bge-m3=1024
       cost_per_1m_tokens_usd: 0,
       price_last_verified: '2026-04-20',
       // Ollama's batch capacity depends on the locally loaded model + the


### PR DESCRIPTION
## What

Extends the Ollama embedding recipe (`src/core/ai/recipes/ollama.ts`):

- Registers **`bge-m3`** as a selectable embedding model (multilingual, strong
  Chinese-language retrieval) alongside the existing `nomic-embed-text`,
  `mxbai-embed-large`, and `all-minilm`.
- Adds a **`dims_options: [384, 768, 1024]`** field on the embedding touchpoint so
  `init` can accept `--embedding-dimensions` for this provider's non-768 models
  (`all-minilm`=384, `nomic-embed-text`=768, `mxbai-embed-large`/`bge-m3`=1024).

## Why

Ollama users running multilingual/Chinese corpora currently have no first-class
local embedding option tuned for CN retrieval; `bge-m3` is a popular, freely
pullable model that fills that gap. Surfacing `dims_options` lets the installer
pick the correct vector dimensionality for whichever local model is selected
instead of assuming the 768-dim default.

## Reviewer notes

- Pure recipe-data change, embedding price stays `$0` (local).
- `dims_options` is a new field on the embedding touchpoint — please confirm it
  matches the `Recipe` type and that `init` reads it for the dimension prompt;
  happy to follow up in this PR if a type/plumbing tweak is wanted.
- Have not run the full `bun run verify` locally yet — flagging for transparency.