### PR TITLE
fix(op-checkpoint): write completed_keys as a jsonb array, not a double-encoded string param

### DIFF
--- a/src/core/op-checkpoint.ts
+++ b/src/core/op-checkpoint.ts
@@ -187,11 +187,11 @@ export async function recordCompleted(
   return durableWrite(engine, key, 'write', () =>
     engine.executeRawDirect(
       `INSERT INTO op_checkpoints (op, fingerprint, completed_keys, updated_at)
-       VALUES ($1, $2, $3::jsonb, now())
+       VALUES ($1, $2, to_jsonb($3::text[]), now())
        ON CONFLICT (op, fingerprint) DO UPDATE
          SET completed_keys = EXCLUDED.completed_keys,
              updated_at     = now()`,
-      [key.op, key.fingerprint, JSON.stringify(sorted)],
+      [key.op, key.fingerprint, sorted],
     ));
 }
 


### PR DESCRIPTION
## Summary

`recordCompleted` (the shared op-checkpoint writer in `src/core/op-checkpoint.ts`) persists `completed_keys` by passing `JSON.stringify(keys)` into a `$3::jsonb` parameter. Under `postgres.js` (`conn.unsafe(sql, params)`) that string parameter is double-encoded into a JSONB **scalar string** (e.g. `"[\"abc\"]"`) instead of a JSONB **array**.

Before v0.42.51 this was a silent corruption — `loadOpCheckpoint` already tolerates a non-array parent row (it filters on `jsonb_typeof(completed_keys) = 'array'` and skips scalars). v0.42.51's migration 119 added `CHECK (jsonb_typeof(completed_keys) = 'array')`, which turns the bad write into a hard failure:

```
[op-checkpoint] write failed (sync-target, …): new row for relation "op_checkpoints" violates check constraint "op_checkpoints_completed_keys_array"
[sync] checkpoint target write failed (pool unavailable) — aborting before import; nothing drained
Sync PARTIAL: imported 0 of N file(s), reason=checkpoint_unavailable
```

So on a Postgres-backed brain, `gbrain sync` (and `extract-by-mention`, which also routes through `recordCompleted`) aborts before importing a single file. The parent rows that *do* satisfy the new constraint are the ones written by `APPEND_PATHS_SQL`, which uses a `'[]'::jsonb` **literal** (not a bound param) and therefore dodges the double-encode.

## Reproduce

On a Postgres-backed brain (≥ v0.42.51, migration 119 applied) with any pending changes:

```
gbrain sync --source <any> --no-pull
# → Sync PARTIAL: imported 0 of N file(s), reason=checkpoint_unavailable
```

psql confirms the two shapes against the v119 constraint:

```sql
-- array literal: satisfies the CHECK
INSERT … completed_keys = '["x"]'::jsonb;            -- OK
-- double-encoded scalar (what the bound string param produces): rejected
INSERT … completed_keys = to_jsonb('["x"]'::text);   -- violates the CHECK
```

## Fix

Pass the JS `string[]` as a native `text[]` parameter and build the JSONB with `to_jsonb($3::text[])` — the same shape `APPEND_PATHS_SQL` already relies on for the child paths. This guarantees `jsonb_typeof = 'array'` regardless of how the driver encodes string params.

```diff
-       VALUES ($1, $2, $3::jsonb, now())
+       VALUES ($1, $2, to_jsonb($3::text[]), now())
…
-      [key.op, key.fingerprint, JSON.stringify(sorted)],
+      [key.op, key.fingerprint, sorted],
```

## Tests

`bun test test/op-checkpoint.test.ts` → 30/30 pass (including the v119 CHECK / defensive-loader cases). Verified end-to-end on three Postgres-backed brains: `gbrain sync` now drains pending files instead of aborting with `checkpoint_unavailable`.
