### PR TITLE
release.yml: run verify before bun build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
           bun-version: 1.3.13
       - run: bun install
       - run: bun test
+      - run: bun run verify
       - run: bun build --compile --target=${{ matrix.target }} --outfile bin/${{ matrix.artifact }} src/cli.ts
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:


### PR DESCRIPTION
## Summary

- Add `bun run verify` to the release workflow between `bun test` and the compiled binary build.
- Ensure release-tag builds run the same static verification gate used by PR CI before publishing artifacts.

Fixes #2222

## Testing

- `PATH="/Users/nidheesh/.bun/bin:$PATH" bun run verify` (`pass=30 fail=0`)
