### PR TITLE
fix(extract): wire schema-pack frontmatter_links into link extraction

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -468,7 +468,7 @@ export async function extractPageLinks(
   frontmatter: Record<string, unknown>,
   pageType: PageType,
   resolver: SlugResolver,
-  opts: { globalBasename?: boolean; skipFrontmatter?: boolean } = {},
+  opts: { globalBasename?: boolean; skipFrontmatter?: boolean; packFrontmatterLinks?: ReadonlyArray<{ page_type?: string; fields: readonly string[]; link_type: string }> } = {},
 ): Promise<PageLinksResult> {
   const candidates: LinkCandidate[] = [];
 
@@ -552,7 +552,7 @@ export async function extractPageLinks(
   // path needed `resolveBasenameMatches` on the real resolver.
   let fmUnresolved: UnresolvedFrontmatterRef[] = [];
   if (!opts.skipFrontmatter) {
-    const fm = await extractFrontmatterLinks(slug, pageType, frontmatter, resolver);
+    const fm = await extractFrontmatterLinks(slug, pageType, frontmatter, resolver, opts.packFrontmatterLinks ?? []);
     candidates.push(...fm.candidates);
     fmUnresolved = fm.unresolved;
   }
@@ -1028,11 +1028,30 @@ export async function extractFrontmatterLinks(
   pageType: PageType,
   frontmatter: Record<string, unknown>,
   resolver: SlugResolver,
+  packFrontmatterLinks: ReadonlyArray<{ page_type?: string; fields: readonly string[]; link_type: string }> = [],
 ): Promise<FrontmatterExtractResult> {
   const candidates: LinkCandidate[] = [];
   const unresolved: UnresolvedFrontmatterRef[] = [];
 
-  for (const mapping of FRONTMATTER_LINK_MAP) {
+  // v0.42 pack wiring: merge the active pack's `frontmatter_links` AFTER the
+  // hardcoded FRONTMATTER_LINK_MAP so a forked/active pack can map its own
+  // relationship fields (e.g. `reports_to`) → typed edges. Built-in mappings
+  // win on conflict (back-compat). Pack rules carry no direction/dir-hint, so
+  // direction defaults to 'outgoing' and dirHint to [] — the resolver then
+  // matches by page `title` across all pages, which works for any directory
+  // layout (incl. domain-first OKF bundles), not just people/ + companies/.
+  const packMappings: FrontmatterFieldMapping[] = [];
+  for (const fl of packFrontmatterLinks) {
+    const fields = fl.fields.filter(
+      (f) => !FRONTMATTER_LINK_MAP.some(
+        (m) => (m.pageType ?? undefined) === (fl.page_type ?? undefined) && m.fields.includes(f),
+      ),
+    );
+    if (fields.length === 0) continue;
+    packMappings.push({ fields: [...fields], pageType: fl.page_type, type: fl.link_type, direction: 'outgoing', dirHint: [] });
+  }
+
+  for (const mapping of [...FRONTMATTER_LINK_MAP, ...packMappings]) {
     if (mapping.pageType && mapping.pageType !== pageType) continue;
     for (const field of mapping.fields) {
       const value = frontmatter[field];

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1110,9 +1110,19 @@ async function runAutoLink(
   const resolver = makeResolver(engine, { mode: 'live', sourceId: opts?.sourceId });
   // Issue #972: opt-in bare-wikilink basename resolution. Off by default.
   const globalBasename = await isGlobalBasenameEnabled(engine);
+  // v0.42: thread the active pack's frontmatter_links so pack-declared
+  // relationship fields (e.g. reports_to) become typed edges. File-plane load
+  // is TTL-cached (load-active.ts), so per-put cost is negligible in bulk sync.
+  let packFrontmatterLinks: ReadonlyArray<{ page_type?: string; fields: readonly string[]; link_type: string }> = [];
+  try {
+    const { loadActivePack } = await import('./schema-pack/load-active.ts');
+    const { loadConfig } = await import('./config.ts');
+    const resolvedPack = await loadActivePack({ cfg: loadConfig(), remote: false, sourceId: opts?.sourceId });
+    packFrontmatterLinks = resolvedPack.manifest.frontmatter_links ?? [];
+  } catch { /* pack load failed → hardcoded FRONTMATTER_LINK_MAP only */ }
   const { candidates, unresolved } = await extractPageLinks(
     slug, fullContent, parsed.frontmatter, parsed.type, resolver,
-    { globalBasename },
+    { globalBasename, packFrontmatterLinks },
   );
 
   // Resolve which targets exist (skip refs to non-existent pages to avoid FK

--- a/test/link-extraction-frontmatter-pack.test.ts
+++ b/test/link-extraction-frontmatter-pack.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test';
+import { extractFrontmatterLinks } from '../src/core/link-extraction.ts';
+
+// Resolver shape is taken from the function signature so we don't import the
+// internal type name. Only `.resolve(name, dirHint)` is exercised here.
+type Resolver = Parameters<typeof extractFrontmatterLinks>[3];
+const stubResolver = (map: Record<string, string>): Resolver =>
+  ({ resolve: async (name: string) => map[name] ?? null }) as unknown as Resolver;
+
+describe('extractFrontmatterLinks — pack frontmatter_links wiring (v0.42)', () => {
+  test('pack-declared field produces a typed edge', async () => {
+    const { candidates } = await extractFrontmatterLinks(
+      'people/alice',
+      'person',
+      { reports_to: 'Bob Roberts' },
+      stubResolver({ 'Bob Roberts': 'people/bob-roberts' }),
+      [{ page_type: 'person', fields: ['reports_to'], link_type: 'reports_to' }],
+    );
+    const edge = candidates.find((c) => c.linkType === 'reports_to');
+    expect(edge).toBeDefined();
+    expect(edge!.targetSlug).toBe('people/bob-roberts');
+    expect(edge!.linkSource).toBe('frontmatter');
+  });
+
+  test('built-in FRONTMATTER_LINK_MAP wins on conflict with a pack rule', async () => {
+    const { candidates } = await extractFrontmatterLinks(
+      'people/alice',
+      'person',
+      { company: 'Acme' },
+      stubResolver({ Acme: 'companies/acme' }),
+      // pack tries to remap person.company → related_to; built-in works_at must win
+      [{ page_type: 'person', fields: ['company'], link_type: 'related_to' }],
+    );
+    const edge = candidates.find((c) => c.targetSlug === 'companies/acme');
+    expect(edge).toBeDefined();
+    expect(edge!.linkType).toBe('works_at');
+  });
+
+  test('no pack arg leaves legacy behavior unchanged (unmapped field → no edge)', async () => {
+    const { candidates } = await extractFrontmatterLinks(
+      'people/alice',
+      'person',
+      { reports_to: 'Bob Roberts' },
+      stubResolver({}),
+    );
+    expect(candidates.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

`extractFrontmatterLinks` (`src/core/link-extraction.ts`) only iterates the hardcoded `FRONTMATTER_LINK_MAP`. A forked/active pack's declared `frontmatter_links` are never consulted during extraction — `frontmatterLinkTypeFromPack` exists and is exported but has **no callers in the extraction path** (only `schema_graph` / `schema_lint`). So a pack that declares

```yaml
frontmatter_links:
  - { page_type: person, fields: [reports_to], link_type: reports_to }
```

activates, validates, and lints clean — but produces **0 graph edges**. Same "wiring pending" gap flagged in `extractable.ts` / `expert-types.ts` / `enrichable.ts`.

## Why it matters (OKF, #2193)

A Google **Open Knowledge Format** bundle commonly uses a domain-first layout (e.g. `<area>/entities/<slug>.md`) with relationships expressed in frontmatter (`reports_to:`, etc.). Today such a bundle gets no relationship graph: the body extractor is wikilink-only, and pack `frontmatter_links` are ignored. Wiring `frontmatter_links` lets a pack express its relationship fields and have them become typed edges regardless of directory layout.

## Change

- `extractFrontmatterLinks`: optional `packFrontmatterLinks` param, merged **after** `FRONTMATTER_LINK_MAP` (built-ins win on conflict — back-compat). `dirHint: []` so the resolver matches by page `title` across all pages (works for domain-first / OKF layouts, not just `people/` + `companies/`).
- `operations.ts` `runAutoLink`: thread the active pack's `frontmatter_links` via a TTL-cached file-plane `loadActivePack` (no per-file cost in bulk sync).
- Test: `test/link-extraction-frontmatter-pack.test.ts` — pack edge produced; built-in wins on conflict; legacy no-op without a pack.

## Verified

On a v0.42.51 brain, a `gbrain-base` fork declaring `person.reports_to → reports_to` now produces a `reports_to` edge for person pages that carry that field (confirmed via `gbrain graph-query`). Before this change the same pack produced none.

`bun test test/link-extraction-frontmatter-pack.test.ts` → 3 pass. `bun run verify` → 30/30 green.

## Note

This wires the **frontmatter** half. The **body** half — extracting OKF relative-markdown links `[text](../dir/slug.md)` (the body extractor is wikilink-only today) — is a natural follow-up for full OKF-bundle graph support; happy to send separately.

Refs #2193.
Google OKF: https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing · spec: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
