### PR TITLE
fix(sync): bind op_checkpoints.completed_keys as text[] to avoid jsonb double-encode on native Postgres

### DIFF
--- a/src/core/op-checkpoint.ts
+++ b/src/core/op-checkpoint.ts
@@ -180,18 +180,22 @@ export async function recordCompleted(
   // extract-conversation-facts serialize a MUTABLE map through here and rely on
   // stale keys being REMOVED; an append would make them unremovable. The full
   // set lands in the parent `completed_keys` JSONB column via a single UPSERT —
-  // exactly as before. JSON.stringify into `$3::jsonb` is correct (the text→jsonb
-  // cast yields a proper array; NOT the double-encode trap, which is the template
-  // form). Sync uses `appendCompleted` (below) instead, never this.
+  // exactly as before. completed_keys is built with `to_jsonb($3::text[])`: the
+  // keys bind as a Postgres text[] and to_jsonb yields a real jsonb ARRAY. The
+  // older `$3::jsonb` form with JSON.stringify(keys) double-encodes on the native
+  // postgres.js direct pool — the JS string gets JSON-serialized AGAIN, landing a
+  // jsonb *string* that fails CHECK (jsonb_typeof = 'array') and aborts every
+  // incremental sync as PARTIAL (PGLite tolerated it; native Postgres does not).
+  // Sync uses `appendCompleted` (below) instead, never this.
   const sorted = [...keys].sort();
   return durableWrite(engine, key, 'write', () =>
     engine.executeRawDirect(
       `INSERT INTO op_checkpoints (op, fingerprint, completed_keys, updated_at)
-       VALUES ($1, $2, $3::jsonb, now())
+       VALUES ($1, $2, to_jsonb($3::text[]), now())
        ON CONFLICT (op, fingerprint) DO UPDATE
          SET completed_keys = EXCLUDED.completed_keys,
              updated_at     = now()`,
-      [key.op, key.fingerprint, JSON.stringify(sorted)],
+      [key.op, key.fingerprint, sorted],
     ));
 }
 


### PR DESCRIPTION
Fixes #2332.

`recordCompleted()` bound `completed_keys` as `JSON.stringify(sorted)` → `$3::jsonb`. On the native postgres.js direct pool this double-encodes the JS string into a jsonb *string*, violating `CHECK (jsonb_typeof = 'array')`, so the checkpoint INSERT fails and every incremental sync aborts PARTIAL (`checkpoint_unavailable`) without advancing `last_commit`. PGLite tolerated the old form; native Postgres does not.

This aligns `recordCompleted` with the already-proven `text[]` binding used by `APPEND_PATHS_SQL`: bind the keys as a Postgres `text[]` and build the jsonb with `to_jsonb()`.

### Verification

- **Driver probe** (postgres.js 3.4.9): old form → `jsonb_typeof = 'string'`; new form → `'array'`.
  ```
  current  typeof=string   "[\"x\",\"y\"]"
  fixed    typeof=array     ["x", "y"]
  ```
- **End-to-end** on native Postgres 17: a previously-failing incremental `gbrain sync` now advances `last_commit`; `op_checkpoints` holds valid array rows and clears on clean exit.

### Optional follow-ups (separate, not in this PR)

- One-time data repair for any rows already stuck as a non-array scalar.
- Have `gbrain sync` exit non-zero (or a distinct code) on `checkpoint_unavailable` so cron/CI wrappers don't read a partial as success.
