### PR TITLE
v0.42.52.0 fix(sync): bump last_sync_at heartbeat on 0-changes sync

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1786,6 +1786,18 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       detachedWorkingTreeManifest.renamed.length > 0);
 
   if (lastCommit === headCommit && !versionMismatch && !versionNeverSet && !hasDetachedWorkingTreeChanges) {
+    // v0.42.52.0 (PR #22xx): bump last_sync_at as a heartbeat on every successful
+    // 0-changes sync. D4 invariant ("never advance last_commit on partial") is
+    // preserved: last_sync_at is a monitoring signal (doctor sync_freshness
+    // reads it), separate from the import-converged bookmark. Without this,
+    // a cron-driven `*/15 sync` over a quiet vault leaves last_sync_at pinned
+    // to the last real commit, so doctor falsely flags the source as stale.
+    if (opts.sourceId) {
+      await engine.executeRaw(
+        `UPDATE sources SET last_sync_at = now() WHERE id = $1`,
+        [opts.sourceId],
+      );
+    }
     return {
       status: 'up_to_date',
       fromCommit: lastCommit,

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -911,3 +911,88 @@ describe('#1970: unreachable last_commit bookmark recovery', () => {
     expect(settled.status).toBe('up_to_date');
   });
 });
+
+describe('v0.42.52.0: 0-changes sync bumps last_sync_at heartbeat (D4 invariant preserved)', () => {
+  let engine: PGLiteEngine;
+  const repos: string[] = [];
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+  });
+
+  beforeEach(async () => {
+    await resetPgliteState(engine);
+  });
+
+  afterEach(() => {
+    while (repos.length) {
+      const d = repos.pop();
+      if (d) rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  function personMd(title: string, body: string): string {
+    return ['---', 'type: person', `title: ${title}`, '---', '', body].join('\n');
+  }
+
+  function mkRepo(files: Record<string, string>): string {
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-heartbeat-'));
+    repos.push(dir);
+    execSync('git init', { cwd: dir, stdio: 'pipe' });
+    execSync('git config user.email "test@test.com"', { cwd: dir, stdio: 'pipe' });
+    execSync('git config user.name "Test"', { cwd: dir, stdio: 'pipe' });
+    for (const [rel, content] of Object.entries(files)) {
+      mkdirSync(join(dir, rel, '..'), { recursive: true });
+      writeFileSync(join(dir, rel), content);
+    }
+    execSync('git add -A && git commit -m "initial"', { cwd: dir, stdio: 'pipe' });
+    return dir;
+  }
+
+  const SYNC_OPTS = { noPull: true, noEmbed: true, noExtract: true, sourceId: 'default' } as const;
+
+  async function lastSyncAt(): Promise<string | null> {
+    const rows = await engine.executeRaw<{ last_sync_at: string | null }>(
+      `SELECT last_sync_at FROM sources WHERE id = 'default'`,
+    );
+    return rows[0]?.last_sync_at ?? null;
+  }
+
+  test('consecutive 0-changes syncs advance last_sync_at without advancing last_commit', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+    const repo = mkRepo({
+      'people/alice.md': personMd('Alice', 'Alice is a person.'),
+    });
+
+    const first = await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+    expect(first.status).toBe('first_sync');
+    const afterFirst = await lastSyncAt();
+    expect(afterFirst).not.toBeNull();
+    const firstRows = await engine.executeRaw<{ last_commit: string | null }>(
+      `SELECT last_commit FROM sources WHERE id = 'default'`,
+    );
+    const lastCommit = firstRows[0]?.last_commit;
+    expect(lastCommit).not.toBeNull();
+
+    // Wait 1.1s so the DB clock will tick past `afterFirst`.
+    await new Promise((r) => setTimeout(r, 1100));
+
+    const second = await performSync(engine, { repoPath: repo, ...SYNC_OPTS });
+    expect(second.status).toBe('up_to_date');
+    const afterSecond = await lastSyncAt();
+    expect(afterSecond).not.toBeNull();
+    expect(afterSecond).not.toEqual(afterFirst); // heartbeat bumped
+
+    // D4 invariant: last_commit is unchanged on 0-changes sync.
+    const lastCommitRows = await engine.executeRaw<{ last_commit: string | null }>(
+      `SELECT last_commit FROM sources WHERE id = 'default'`,
+    );
+    expect(lastCommitRows[0]?.last_commit).toEqual(lastCommit);
+  });
+});


### PR DESCRIPTION
## Summary

`gbrain sync` over a quiet vault (no new commits since the last sync) successfully runs, but `sources.last_sync_at` is **not** written. This makes `gbrain doctor sync_freshness` (warn 24h / fail 72h) flag the source as stale for as long as the vault is quiet — even though the sync IS working.

The D4 invariant ("never advance `last_commit` on partial import", documented in `sync.ts:2673-2680`) is preserved. `last_sync_at` is a separate monitoring signal (read by `doctor` only), distinct from the import-converged bookmark.

## Reproduction (5 lines, no gbrain install required)

```bash
# 1. Setup a fresh obsidian source + commit a single .md file
# 2. gbrain sync --source obsidian   # first_sync, last_sync_at = NOW
# 3. (do nothing) gbrain sync --source obsidian   # up_to_date
# 4. SELECT last_sync_at FROM sources WHERE id = 'obsidian';
# 5. Observed: still pinned to step 2.  Expected: bumped to step 3.
```

Verified live on Bruce's brain (commit `9bf96db8` = `v0.42.51.0`, 2026-06-21 17:09 CST):
- `last_sync_at` stuck at `2026-06-20 07:14:28 UTC` for 25.7h
- `gbrain doctor` → `[WARN] sync_freshness: ... 25h ago`
- `gbrain sync --repo` runs every 15 min via WSL crontab (`*/15 * * * *`), reports "Already up to date", but never writes `last_sync_at`

## Fix

`src/commands/sync.ts` line ~1786 (the `up_to_date` early-return path):

```typescript
// Before:
if (lastCommit === headCommit && !versionMismatch && !versionNeverSet && !hasDetachedWorkingTreeChanges) {
  return { status: 'up_to_date', ... };  // no DB write
}

// After:
if (lastCommit === headCommit && !versionMismatch && !versionNeverSet && !hasDetachedWorkingTreeChanges) {
  // v0.42.52.0: bump last_sync_at as a heartbeat on every successful 0-changes sync.
  // D4 invariant preserved: only last_sync_at is touched, not last_commit.
  if (opts.sourceId) {
    await engine.executeRaw(
      `UPDATE sources SET last_sync_at = now() WHERE id = $1`,
      [opts.sourceId],
    );
  }
  return { status: 'up_to_date', ... };
}
```

Diff: 2 files, +97/-0 lines (additive only).

## Test

`test/sync.test.ts` adds 1 describe block with 1 test:
- Sets up a PGLite engine + a quiet vault
- Runs `performSync` twice with 1.1s gap
- Asserts `status: 'first_sync'` then `status: 'up_to_date'`
- Asserts `last_sync_at` advanced between runs
- Asserts `last_commit` did **not** change (D4 invariant preserved)

Pattern matches the existing #1970 test scaffold (`PGLiteEngine + resetPgliteState + mkRepo`).

## Verification (local)

```
$ bun test test/sync.test.ts -t 'v0.42.52.0'
(pass) v0.42.52.0: 0-changes sync bumps last_sync_at heartbeat (D4 invariant preserved)
 1 pass / 0 fail / 7 expect() calls

$ bun test test/sync.test.ts
 67 pass / 0 fail / 188 expect() calls
```

No regression on existing tests (#1970: 7 pass, all sync tests: 67 pass).

## Workaround (already deployed)

Until this PR merges, Bruce runs this in production:

```cron
# WSL crontab
17 * * * * /usr/bin/docker exec gbrain-pg psql -U gbrain -d gbrain -c \
  "UPDATE sources SET last_sync_at = NOW() WHERE local_path IS NOT NULL AND last_sync_at < NOW() - INTERVAL '6 hours';" \
  >> /home/lost9999/.gbrain/run/sync-heartbeat.log 2>&1
```

## Related context

- v0.42.51.0 (#2255) added the "in-progress sync via live lock" signal to `sync_freshness`. **This PR complements that**: a sync that's running reports ok via the lock; a sync that ran but did nothing also reports ok via the heartbeat.
- v0.42.36.0 (#1794) introduced the D4 invariant. The intent (no partial advance) is preserved.

## Checklist

- [x] Reproduction documented
- [x] Fix is minimal (12 lines in sync.ts, additive)
- [x] D4 invariant explicitly preserved in test
- [x] No regression on existing tests (67 pass)
- [x] Workaround documented
- [x] Follows upstream commit message convention
