### PR TITLE
fix(sync): pin write double-encodes jsonb scalar — every sync aborts at checkpoint

### DIFF
--- a/src/core/op-checkpoint.ts
+++ b/src/core/op-checkpoint.ts
@@ -187,7 +187,7 @@ export async function recordCompleted(
   return durableWrite(engine, key, 'write', () =>
     engine.executeRawDirect(
       `INSERT INTO op_checkpoints (op, fingerprint, completed_keys, updated_at)
-       VALUES ($1, $2, $3::jsonb, now())
+       VALUES ($1, $2, $3::text::jsonb, now())
        ON CONFLICT (op, fingerprint) DO UPDATE
          SET completed_keys = EXCLUDED.completed_keys,
              updated_at     = now()`,


### PR DESCRIPTION
## Problem

Multi-source brains stop syncing entirely after a recent change to the durable checkpoint path. Every `gbrain sync` aborts at the very first checkpoint write with:

```
[op-checkpoint] write failed (sync-target, <fp>): new row for relation "op_checkpoints" violates check constraint "op_checkpoints_completed_keys_array"
[sync] checkpoint target write failed (pool unavailable) — aborting before import; nothing drained, next run retries.
Sync PARTIAL at <commit>: imported 0 of N file(s), reason=checkpoint_unavailable.
```

The `(pool unavailable)` text is a **misleading wrapper** — the pool is healthy. The real error is SQLSTATE `23514` (CHECK violation) on the `completed_keys` column.

## Root cause

`recordCompleted()` in `src/core/op-checkpoint.ts` persists the sync-target pin as:

```ts
`INSERT INTO op_checkpoints (op, fingerprint, completed_keys, updated_at)
 VALUES ($1, $2, $3::jsonb, now()) ...`,
[key.op, key.fingerprint, JSON.stringify(sorted)]
```

Under `postgres.js` `.unsafe(sql, params)`, binding a JS **string** to a `$3::jsonb` param double-encodes it: the text->jsonb cast wraps the already-JSON string into a jsonb **scalar string** rather than parsing it into a jsonb array. That fails the table CHECK:

```sql
CONSTRAINT op_checkpoints_completed_keys_array CHECK (jsonb_typeof(completed_keys) = 'array')
```

`sync.ts` persists the pin via `recordCompleted(ckpt.target, [pin])` *before* the first path flush (by design, so a crash resumes to the pinned target). Because that write throws on the first attempt, **no source can ever anchor a sync** — `appendCompleted` (the `text[]` path-flush) is never reached. The constraint that was added to protect the load is now rejecting every legitimate write.

## Fix

Cast the param through `text` first so it binds as text and the `text->jsonb` cast parses it into a real array:

```ts
VALUES ($1, $2, $3::text::jsonb, now())
```

Verified bindings (live, against Supabase Postgres via postgres.js `.unsafe`):

| binding | `jsonb_typeof(completed_keys)` |
|---|---|
| `$3::jsonb` + `JSON.stringify([...])` | ❌ throws 23514 (scalar) |
| `$3::text::jsonb` + `JSON.stringify([...])` | ✅ `array` |
| `$3` + `sql.json([...])` | ✅ `array` |
| `to_jsonb($3::text[])` + `[...]` | ✅ `array` |

`appendCompleted`'s `unnest($3::text[])` path was already correct and is unaffected; only the single-shot pin write in `recordCompleted` needed the cast.

## Verification

Reproduced and fixed on a 5-source brain that had been stuck **84h** (GBrain Doctor 0/100, all sources `severely stale`). After the one-line change, the smallest source synced on the first attempt:

```
Synced 2018def9..642558cf:
  +19 added, ~0 modified, -0 deleted
  42 chunks created, 19 pages embedded
```

Scope: one-line, lowest-risk cast on the pin-write statement. No schema change, no behavior change beyond letting the write land.
