### PR TITLE
fix(frontmatter): derive validate slug from brain root, not absolute path (#565)

### DIFF
--- a/src/commands/frontmatter.ts
+++ b/src/commands/frontmatter.ts
@@ -17,7 +17,7 @@
 
 import { readFileSync, writeFileSync, existsSync, lstatSync, readdirSync } from 'fs';
 import { setCliExitVerdict } from '../core/cli-force-exit.ts';
-import { join, relative, resolve } from 'path';
+import { join, relative, resolve, basename, dirname } from 'path';
 import type { BrainEngine } from '../core/engine.ts';
 import { loadConfig, toEngineConfig } from '../core/config.ts';
 import { createEngine } from '../core/engine-factory.ts';
@@ -154,6 +154,27 @@ interface FileValidation {
   backupPath?: string;
 }
 
+/**
+ * Walk up from `start` (file or dir) to the brain root — the nearest ancestor
+ * containing a `.git` marker — so slug derivation is brain-root-relative,
+ * matching how sync/extract compute slugs. Falls back to the start's own
+ * directory when no marker is found. Fixes #565: for a single-file target,
+ * `relative(resolve(target), file)` was empty (target === file) and fell back
+ * to the ABSOLUTE path, yielding bogus "root/brain/..." slugs and false
+ * SLUG_MISMATCH — which the install-hook pre-commit hook hits on every commit.
+ */
+function findBrainRoot(start: string): string {
+  const startDir = lstatSync(start).isDirectory() ? start : dirname(start);
+  let candidate = startDir;
+  for (let i = 0; i < 40; i++) {
+    if (existsSync(join(candidate, '.git'))) return candidate;
+    const parent = resolve(candidate, '..');
+    if (parent === candidate) break;
+    candidate = parent;
+  }
+  return startDir;
+}
+
 async function runValidate(rest: string[]): Promise<void> {
   const flags: ValidateFlags = { json: false, fix: false, dryRun: false };
   let target: string | null = null;
@@ -176,13 +197,17 @@ async function runValidate(rest: string[]): Promise<void> {
     return;
   }
 
+  const brainRoot = findBrainRoot(resolved);
   const files = collectFiles(resolved);
   const results: FileValidation[] = [];
   const backupRunId = makeFrontmatterBackupRunId();
 
   for (const file of files) {
     const content = readFileSync(file, 'utf8');
-    const expectedSlug = slugifyPath(relative(resolve(target), file) || file);
+    const rel = relative(brainRoot, file);
+    // Files above/outside the brain root fall back to basename rather than
+    // emitting a "../"-prefixed slug for non-brain files.
+    const expectedSlug = slugifyPath(rel && !rel.startsWith('..') ? rel : basename(file));
     const parsed = parseMarkdown(content, file, { validate: true, expectedSlug });
     const errs = parsed.errors ?? [];
     const result: FileValidation = {

--- a/test/frontmatter-validate-slug-565.test.ts
+++ b/test/frontmatter-validate-slug-565.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { spawnSync } from 'child_process';
+
+const fence = '---';
+
+function runValidate(path: string): { stdout: string; code: number } {
+  const r = spawnSync(process.execPath, ['run', 'src/cli.ts', 'frontmatter', 'validate', path], {
+    encoding: 'utf8',
+    cwd: process.cwd(),
+    env: process.env,
+  });
+  return { stdout: r.stdout ?? '', code: r.status ?? -1 };
+}
+
+// Regression for #565. Single-file `frontmatter validate` derived the expected
+// slug from the ABSOLUTE path: `relative(resolve(target), file)` is empty when
+// the target IS the file, so it fell back to `|| file` (the full path),
+// yielding bogus "root/<abs-path>" slugs and a false SLUG_MISMATCH. The hook
+// installed by `frontmatter install-hook` validates staged files one-by-one,
+// so this rejected every commit in a markdown brain. The expected slug must be
+// derived relative to the brain root (nearest `.git`).
+describe('frontmatter validate single-file slug (#565)', () => {
+  let brain: string;
+
+  beforeEach(() => {
+    brain = mkdtempSync(join(tmpdir(), 'fm-565-'));
+    mkdirSync(join(brain, '.git'), { recursive: true }); // brain-root marker
+  });
+
+  afterEach(() => {
+    rmSync(brain, { recursive: true, force: true });
+  });
+
+  test('single file with a correct nested slug validates clean', () => {
+    mkdirSync(join(brain, 'companies'), { recursive: true });
+    const f = join(brain, 'companies', 'readme.md');
+    writeFileSync(f, `${fence}\ntype: company\ntitle: Readme\nslug: companies/readme\n${fence}\n\nbody`);
+    const { stdout, code } = runValidate(f);
+    expect(stdout).not.toContain('SLUG_MISMATCH');
+    expect(code).toBe(0);
+  });
+
+  test('directory validation still derives brain-root-relative slugs', () => {
+    mkdirSync(join(brain, 'people'), { recursive: true });
+    writeFileSync(
+      join(brain, 'people', 'alice.md'),
+      `${fence}\ntype: person\ntitle: Alice\nslug: people/alice\n${fence}\n\nbody`,
+    );
+    const { stdout, code } = runValidate(join(brain, 'people'));
+    expect(stdout).not.toContain('SLUG_MISMATCH');
+    expect(code).toBe(0);
+  });
+
+  test('file with no .git ancestor falls back to basename (no crash, no abs-path slug)', () => {
+    rmSync(join(brain, '.git'), { recursive: true, force: true });
+    const f = join(brain, 'note.md');
+    writeFileSync(f, `${fence}\ntype: note\ntitle: Note\nslug: note\n${fence}\n\nbody`);
+    const { stdout, code } = runValidate(f);
+    expect(stdout).not.toContain('SLUG_MISMATCH');
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

`gbrain frontmatter validate <single-file>` derives the expected slug from the **absolute** filesystem path, producing bogus `root/<abs-path>` slugs and a false `SLUG_MISMATCH`. The pre-commit hook installed by `gbrain frontmatter install-hook` validates staged files one at a time, so this rejects **every commit** in a markdown brain repo (only bypassable with `--no-verify`).

Reopens #565 (closed, but still reproducible on the single-file `validate` path). Present since v0.32.0; reproduced on **v0.42.51**.

## Repro

From a brain root, with a file whose slug is correct:

```
$ gbrain frontmatter validate companies/readme.md
[SLUG_MISMATCH] Frontmatter slug "companies/readme" does not match path-derived slug "root/brain/companies/readme"
```

The file's `slug: companies/readme` is correct; the path-derived slug is the absolute path minus the leading `/`.

## Cause

`src/commands/frontmatter.ts`:

```js
const expectedSlug = slugifyPath(relative(resolve(target), file) || file);
```

`collectFiles` returns `[target]` for a single file, so `file === resolve(target)` → `relative(...)` is `""` → falls back to `|| file` (the absolute path) → `slugifyPath` strips the leading `/` → `root/...`. Validating a subdirectory was also wrong (slugs relative to the subdir, not the brain root).

## Fix

Walk up from the target to the brain root (nearest `.git`) and derive the slug with `relative(brainRoot, file)`, falling back to `basename(file)`. This matches the brain-root resolution `runAudit`/`runGenerate` already use and how sync/extract compute slugs. Files above the brain root fall back to `basename` instead of emitting a `../`-prefixed slug.

(Note: `runAudit`/`runGenerate` have a near-identical walk-up inline — could be unified into the new `findBrainRoot` helper in a follow-up. Kept this PR scoped to the fix.)

## Tests

`test/frontmatter-validate-slug-565.test.ts`: single-file nested slug, directory validation, and the no-`.git` fallback. All 3 pass; the single-file case fails on the default branch without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
