### PR TITLE
fix(jobs): retry resets started_at + attempts counters

### DIFF
--- a/src/core/minions/queue.ts
+++ b/src/core/minions/queue.ts
@@ -450,12 +450,25 @@ export class MinionQueue {
     });
   }
 
-  /** Re-queue a failed or dead job for retry. */
+  /**
+   * Re-queue a failed or dead job for retry.
+   *
+   * Resets `started_at` and the attempts counters so the user-initiated retry
+   * gets a fresh wall-clock budget and a fresh max_attempts round. Without
+   * resetting `started_at`, the DB-side wall-clock detector
+   * (handleWallClockTimeouts) compares `now() - started_at` against
+   * `timeout_ms * 2` and immediately dead-letters any retry where more time
+   * has elapsed since the original start than the timeout window — which is
+   * always true for a job dead long enough that an operator notices and
+   * retries it. Preserving `stacktrace` retains debug history.
+   */
   async retryJob(id: number): Promise<MinionJob | null> {
     const rows = await this.engine.executeRaw<Record<string, unknown>>(
       `UPDATE minion_jobs SET status = 'waiting', error_text = NULL,
         lock_token = NULL, lock_until = NULL, delay_until = NULL,
-        finished_at = NULL, updated_at = now()
+        finished_at = NULL, started_at = NULL,
+        attempts_made = 0, attempts_started = 0,
+        updated_at = now()
        WHERE id = $1 AND status IN ('failed', 'dead')
        RETURNING *`,
       [id]

--- a/test/minions.test.ts
+++ b/test/minions.test.ts
@@ -640,6 +640,26 @@ describe('MinionQueue: Cancel & Retry', () => {
     expect(retried!.status).toBe('waiting');
     expect(retried!.error_text).toBeNull();
   });
+
+  test('retry resets started_at and attempts counters', async () => {
+    // Regression: pre-fix, retryJob left started_at populated from the
+    // original run. handleWallClockTimeouts then immediately dead-lettered
+    // the retry on the next worker tick because elapsed > timeout_ms * 2.
+    const job = await queue.add('sync', {}, { max_attempts: 1 });
+    await queue.claim('tok1', 30000, 'default', ['sync']);
+    await queue.failJob(job.id, 'tok1', 'error', 'dead');
+
+    const beforeRetry = await queue.getJob(job.id);
+    expect(beforeRetry!.started_at).not.toBeNull();
+    expect(beforeRetry!.attempts_made).toBe(1);
+    expect(beforeRetry!.attempts_started).toBe(1);
+
+    const retried = await queue.retryJob(job.id);
+    expect(retried!.status).toBe('waiting');
+    expect(retried!.started_at).toBeNull();
+    expect(retried!.attempts_made).toBe(0);
+    expect(retried!.attempts_started).toBe(0);
+  });
 });
 
 // --- Pause / Resume (5 tests) ---


### PR DESCRIPTION
## Problem

`gbrain jobs retry <id>` left `started_at` populated from the original run. The DB-side wall-clock detector (`handleWallClockTimeouts`) compares `now() - started_at` against `timeout_ms * 2` and dead-letters any job past that window. For a retry of a *dead* job, the elapsed time since the original start is essentially always `> timeout_ms * 2` — an operator only retries a job after noticing it died, which takes longer than the timeout window itself.

Result: the retry was immediately re-dead-lettered by the next worker tick before any handler ran.

Symptom:
```
gbrain jobs retry 123
# status flips waiting -> dead within ~60s
# error_text = "wall-clock timeout exceeded", attempts_made unchanged
```

## Fix

`retryJob` now resets three fields:

- `started_at = NULL` — the core fix. `claim()` does `started_at = COALESCE(started_at, now())`, so a fresh start is recorded only when the retry is actually claimed.
- `attempts_made = 0` — gives the retry a fresh `max_attempts` round (otherwise a 3/3 dead job dead-letters on the first failure of the retry).
- `attempts_started = 0` — consistency with `attempts_made`.

`stacktrace` is preserved to retain debug history across retries.

This is adjacent to the attempt-counter correctness work in the recent reliability releases (e.g. counting timed-out runs as spent attempts) — it makes operator-initiated retry behave consistently with that model.

## Test

Extends the existing `retry dead job re-queues` test to assert the three resets. Original assertions still pass.