### PR TITLE
fix(recipes/x-to-brain): use /users/by/username for app-only bearer health check

### DIFF
--- a/recipes/x-to-brain.md
+++ b/recipes/x-to-brain.md
@@ -11,7 +11,7 @@ secrets:
     where: https://developer.x.com/en/portal/dashboard — create a project + app, copy the Bearer Token from "Keys and tokens"
 health_checks:
   - type: http
-    url: "https://api.x.com/2/users/me"
+    url: "https://api.x.com/2/users/by/username/$X_HANDLE"
     auth: bearer
     auth_token: "$X_BEARER_TOKEN"
     label: "X API"


### PR DESCRIPTION
## Problem

The `x-to-brain` recipe's health check probes `https://api.x.com/2/users/me`, which requires **user-context OAuth**. Under an app-only bearer token (what the rest of the recipe uses), `/users/me` returns 401 — so the health check fails on every probe even when the token is valid.

## Fix

Switch the probe to `https://api.x.com/2/users/by/username/$X_HANDLE`, which works under app-only bearer and matches how the rest of the recipe authenticates.

Requires the operator to set `$X_HANDLE` alongside `$X_BEARER_TOKEN`.