### PR TITLE
Fix doctor remediation loop and propose_takes spend receipts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'enrich', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'onboard', 'conversation-parser', 'status', 'connect', 'skillopt', 'quarantine', 'self-upgrade', 'advisor', 'watch']);
+const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'enrich', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'budget', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'onboard', 'conversation-parser', 'status', 'connect', 'skillopt', 'quarantine', 'self-upgrade', 'advisor', 'watch']);
 // CLI-only commands whose handlers print their own --help text. These are
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
@@ -55,6 +55,7 @@ const CLI_ONLY_SELF_HELP = new Set([
   'integrations', 'friction',
   'frontmatter', 'check-resolvable',
   'models',
+  'budget',
   'cache',
   'brainstorm', 'lsd',
   // v0.41.20.0 skillopt's detailed HELP constant lives in
@@ -1115,6 +1116,11 @@ async function handleCliOnly(command: string, args: string[]) {
     const { runProviders } = await import('./commands/providers.ts');
     const [sub, ...rest] = args;
     await runProviders(sub, rest);
+    return;
+  }
+  if (command === 'budget') {
+    const { runBudget } = await import('./commands/budget.ts');
+    setCliExitVerdict(await runBudget(args));
     return;
   }
   if (command === 'auth') {
@@ -2271,6 +2277,7 @@ TOOLS
   transcripts recent [--days N]      v0.29: recent raw .txt transcripts (local-only)
   dream [--dry-run] [--json]         Run the overnight maintenance cycle once (cron-friendly).
                                      See also: autopilot --install (continuous daemon).
+  budget reconcile [--days N]        Read back local paid-provider spend ledger
   check-resolvable [--json] [--fix]  Validate skill tree (reachability/MECE/DRY)
   report --type <name> --content ... Save timestamped report to brain/reports/
 

--- a/src/commands/autopilot-fanout.ts
+++ b/src/commands/autopilot-fanout.ts
@@ -77,9 +77,13 @@ export interface FanoutResult {
   skipped_cap: string[];
   /** Source ids skipped because they're in failure cooldown (#2194 fix #2). */
   skipped_cooldown: string[];
+  /** Source ids skipped because a non-terminal autopilot-cycle already exists. */
+  skipped_active: string[];
   /** True when this tick fell back to the legacy single-job path
    *  (no sources rows / engine empty). */
   legacy_fallback: boolean;
+  /** Brain-wide maintenance dispatch result for this tick. */
+  global_maintenance: { dispatched: boolean; reason: 'stale' | 'fresh' | 'deferred'; job_id?: number; parent_job_id?: number };
 }
 
 /**
@@ -103,11 +107,11 @@ export async function resolveFanoutMax(engine: BrainEngine): Promise<number> {
 }
 
 /**
- * Read the worker concurrency the supervisor most recently STARTED with, from
- * its `started` audit event (the lowest-coupling source — no extra lock-row
- * column). Filesystem read; returns null when no supervisor has ever started
- * (or the event lacks concurrency). Filtered by queue so a `shell`-queue
- * supervisor's concurrency doesn't leak into the `default`-queue decision.
+ * Read the worker concurrency the supervisor most recently STARTED with in the
+ * current audit file (the lowest-coupling source — no extra lock-row column).
+ * Filesystem read; returns null when no supervisor has ever started (or the
+ * event lacks concurrency). Filtered by queue so a `shell`-queue supervisor's
+ * concurrency doesn't leak into the `default`-queue decision.
  *
  * ADVISORY use only (doctor warning). Behavior-changing callers (the fanout
  * clamp) must additionally gate on a LIVE supervisor — see
@@ -117,7 +121,7 @@ export async function resolveFanoutMax(engine: BrainEngine): Promise<number> {
 export async function readSupervisorConcurrency(queue = 'default'): Promise<number | null> {
   try {
     const { readSupervisorEvents } = await import('../core/minions/handlers/supervisor-audit.ts');
-    const events = readSupervisorEvents({ sinceMs: 24 * 60 * 60 * 1000 });
+    const events = readSupervisorEvents();
     const started = events
       .filter((e) => e.event === 'started' && (e.queue === undefined || e.queue === queue))
       .pop();
@@ -172,15 +176,17 @@ export function readLastFullCycleAt(src: SourceRow): Date | null {
 
 /**
  * A source needs work when either:
- *   1. It has never had a full cycle complete (`last_full_cycle_at` null), OR
- *   2. The last full cycle is older than the freshness floor.
+ *   1. It has never had a successful source cycle, OR
+ *   2. The last successful source cycle is older than the freshness floor.
  *
  * `last_sync_at` is NOT consulted here — sync is one phase of a cycle, and
  * a brain may have fresh sync but stale extract/embed. The 60-min floor on
- * full-cycle is the canonical freshness signal for autopilot dispatch.
+ * source-cycle success is the canonical freshness signal for autopilot
+ * dispatch; the brain-wide global phases gate separately on
+ * `autopilot.last_global_at`.
  */
 export function isSourceStale(src: SourceRow, now = Date.now(), floorMin = FULL_CYCLE_FLOOR_MIN): boolean {
-  const last = readLastFullCycleAt(src);
+  const last = readLastSuccessAt(src);
   if (last === null) return true;
   const ageMin = (now - last.getTime()) / 60_000;
   return ageMin >= floorMin;
@@ -249,12 +255,14 @@ export async function resolveFailureCooldownOpts(engine: BrainEngine): Promise<C
 }
 
 /**
- * Read recent dead/failed autopilot-cycle jobs grouped by source. Read-at-
- * dispatch (NOT a write hook) because timeouts/RSS-kills/stalls dead-letter via
- * SQL in queue.ts and never run handler code — a write-only cooldown would miss
- * the exact failures that drive the storm. Engine-parity-safe via executeRaw
- * (one query, both engines); cutoff is precomputed in JS to avoid INTERVAL
- * portability concerns. codex #6: rows with a null source_id are excluded.
+ * Read recent dead/failed autopilot-cycle jobs grouped by source. Completed
+ * rows whose structured cycle report says failed/partial count too: handlers
+ * intentionally return those reports instead of throwing, so job status alone
+ * misses the normal phase-failure path. Read-at-dispatch (NOT a write hook)
+ * because timeouts/RSS-kills/stalls dead-letter via SQL in queue.ts and never
+ * run handler code. Engine-parity-safe via executeRaw (one query, both
+ * engines); cutoff is precomputed in JS to avoid INTERVAL portability concerns.
+ * codex #6: rows with a null source_id are excluded.
  */
 export async function readRecentSourceFailures(
   engine: BrainEngine,
@@ -271,7 +279,16 @@ export async function readRecentSourceFailures(
               max(finished_at) AS last_failed_at
          FROM minion_jobs
         WHERE name = 'autopilot-cycle'
-          AND status IN ('dead','failed')
+          AND (
+            status IN ('dead','failed')
+            OR (
+              status = 'completed'
+              AND (
+                result->>'status' IN ('failed','partial')
+                OR result->'report'->>'status' IN ('failed','partial')
+              )
+            )
+          )
           AND data->>'source_id' IS NOT NULL
           AND finished_at IS NOT NULL
           AND finished_at > $1`;
@@ -311,6 +328,27 @@ export async function isSourceInCooldown(engine: BrainEngine, sourceId: string, 
     if (rows[0]) lastSuccessAt = readLastSuccessAt({ config: rows[0].config ?? {} } as SourceRow);
   } catch { /* treat as no success */ }
   return isInFailureCooldown(failure, lastSuccessAt, now, opts);
+}
+
+/**
+ * Read source ids that already have a live per-source autopilot-cycle job. This
+ * prevents capped fanout from re-enqueuing the same oldest sources with a fresh
+ * slot key while the previous batch is still waiting or active.
+ */
+export async function readLiveAutopilotCycleSourceIds(engine: BrainEngine): Promise<Set<string>> {
+  try {
+    const rows = await engine.executeRaw<{ source_id: string | null }>(
+      `SELECT DISTINCT data->>'source_id' AS source_id
+         FROM minion_jobs
+        WHERE name = 'autopilot-cycle'
+          AND status IN ('waiting', 'active', 'delayed', 'waiting-children', 'paused')
+          AND data ? 'source_id'
+          AND data->>'source_id' IS NOT NULL`,
+    );
+    return new Set(rows.map((r) => r.source_id).filter((id): id is string => typeof id === 'string' && id.length > 0));
+  } catch {
+    return new Set();
+  }
 }
 
 /**
@@ -405,7 +443,15 @@ export async function dispatchPerSource(
     } else {
       log(`[dispatch] job #${job.id} autopilot-cycle (legacy single-source)`);
     }
-    return { dispatched: [], skipped_fresh: [], skipped_cap: [], skipped_cooldown: [], legacy_fallback: true };
+    return {
+      dispatched: [],
+      skipped_fresh: [],
+      skipped_cap: [],
+      skipped_cooldown: [],
+      skipped_active: [],
+      legacy_fallback: true,
+      global_maintenance: { dispatched: false, reason: 'deferred' },
+    };
   }
 
   // #2194 fix #2: load recent per-source failures + cooldown knobs so a
@@ -424,8 +470,37 @@ export async function dispatchPerSource(
     cooldownOpts = { baseMin: 0, capMin: FAILURE_COOLDOWN_CAP_MIN };
   }
 
+  const liveCycleSourceIds = await readLiveAutopilotCycleSourceIds(engine);
+  const skippedActive = sources.filter((s) => liveCycleSourceIds.has(s.id));
+  const eligibleSources = liveCycleSourceIds.size > 0
+    ? sources.filter((s) => !liveCycleSourceIds.has(s.id))
+    : sources;
   const { dispatch, skippedFresh, skippedCap, skippedCooldown } =
-    selectSourcesForDispatch(sources, opts.fanoutMax, Date.now(), FULL_CYCLE_FLOOR_MIN, recentFailures, cooldownOpts);
+    selectSourcesForDispatch(eligibleSources, opts.fanoutMax, Date.now(), FULL_CYCLE_FLOOR_MIN, recentFailures, cooldownOpts);
+
+  let globalMaintenance: FanoutResult['global_maintenance'] = { dispatched: false, reason: 'deferred' };
+  let globalParentJobId: number | undefined;
+  if (skippedCap.length === 0 && skippedActive.length === 0) {
+    try {
+      const global = await dispatchGlobalMaintenance(engine, queue, {
+        repoPath: opts.repoPath,
+        slot: opts.slot,
+        timeoutMs: opts.timeoutMs,
+        holdForChildren: dispatch.length > 0,
+        jsonMode: opts.jsonMode,
+        emit,
+        log,
+      });
+      globalMaintenance = global;
+      if (dispatch.length > 0 && global.dispatched && global.parent_job_id) {
+        globalParentJobId = global.parent_job_id;
+      }
+    } catch (e) {
+      if (opts.jsonMode) {
+        emit(JSON.stringify({ event: 'global_maintenance_dispatch_failed', error: e instanceof Error ? e.message : String(e) }));
+      }
+    }
+  }
 
   const dispatched: string[] = [];
   for (const src of dispatch) {
@@ -448,6 +523,7 @@ export async function dispatchPerSource(
           // Per-source idempotency key — two ticks for the same source
           // within the same slot coalesce; different sources never collide.
           idempotency_key: `autopilot-cycle:${src.id}:${opts.slot}`,
+          ...(globalParentJobId ? { parent_job_id: globalParentJobId } : {}),
           max_attempts: 2,
           timeout_ms: opts.timeoutMs,
           // DELIBERATELY no maxWaiting: 1 here. maxWaiting is per
@@ -458,7 +534,15 @@ export async function dispatchPerSource(
           // source per slot, regardless of how many ticks try).
         },
       );
-      dispatched.push(src.id);
+      if (
+        globalParentJobId &&
+        Object.prototype.hasOwnProperty.call(job, 'parent_job_id') &&
+        job.parent_job_id !== globalParentJobId
+      ) {
+        skippedActive.push(src);
+      } else {
+        dispatched.push(src.id);
+      }
       if (opts.jsonMode) {
         emit(JSON.stringify({
           event: 'dispatched',
@@ -487,6 +571,16 @@ export async function dispatchPerSource(
     }
   }
 
+  if (globalParentJobId && dispatched.length === 0) {
+    await engine.executeRaw(
+      `UPDATE minion_jobs
+          SET status = 'waiting', updated_at = now()
+        WHERE id = $1
+          AND status = 'paused'`,
+      [globalParentJobId],
+    );
+  }
+
   if (skippedCap.length > 0 && opts.jsonMode) {
     emit(JSON.stringify({
       event: 'fanout_cap_reached',
@@ -502,12 +596,21 @@ export async function dispatchPerSource(
     }));
   }
 
+  if (skippedActive.length > 0 && opts.jsonMode) {
+    emit(JSON.stringify({
+      event: 'fanout_active_skipped',
+      sources: skippedActive.map(s => s.id),
+    }));
+  }
+
   return {
     dispatched,
     skipped_fresh: skippedFresh.map(s => s.id),
     skipped_cap: skippedCap.map(s => s.id),
     skipped_cooldown: skippedCooldown.map(s => s.id),
+    skipped_active: skippedActive.map(s => s.id),
     legacy_fallback: false,
+    global_maintenance: globalMaintenance,
   };
 }
 
@@ -527,14 +630,25 @@ export function isGlobalMaintenanceStale(lastGlobalAtIso: string | null, now = D
  * window, instead of N per-source cycles each running them concurrently (the
  * RSS blowout). Single-flight is structural: one `idempotency_key` +
  * `maxWaiting:1`, so a slow run never stacks. Gated on `autopilot.last_global_at`
- * (stamped by the handler on success). Postgres-only fan-out concern; on PGLite
- * the file lock already serializes, but the job is still correct there.
+ * (stamped by the handler on success). When per-source jobs are dispatched in
+ * the same tick, they are attached as children so queue-native
+ * waiting-children semantics make this parent claimable only after the source
+ * batch finishes. Postgres-only fan-out concern; on PGLite the file lock
+ * already serializes, but the job is still correct there.
  */
 export async function dispatchGlobalMaintenance(
   engine: BrainEngine,
   queue: MinionQueue,
-  opts: { repoPath: string; slot: string; timeoutMs: number; jsonMode: boolean; emit?: (l: string) => void; log?: (l: string) => void },
-): Promise<{ dispatched: boolean; reason: 'stale' | 'fresh' }> {
+  opts: {
+    repoPath: string;
+    slot: string;
+    timeoutMs: number;
+    holdForChildren?: boolean;
+    jsonMode: boolean;
+    emit?: (l: string) => void;
+    log?: (l: string) => void;
+  },
+): Promise<{ dispatched: boolean; reason: 'stale' | 'fresh'; job_id?: number; parent_job_id?: number }> {
   const emit = opts.emit ?? ((line) => process.stderr.write(line + '\n'));
   const log = opts.log ?? ((line) => console.log(line));
 
@@ -549,6 +663,59 @@ export async function dispatchGlobalMaintenance(
     return { dispatched: false, reason: 'fresh' };
   }
 
+  const liveRows = await engine.executeRaw<{ id: number; status: string }>(
+    `SELECT id, status
+       FROM minion_jobs
+      WHERE name = 'autopilot-global-maintenance'
+        AND queue = 'default'
+        AND status IN ('waiting','active','delayed','waiting-children','paused')
+      ORDER BY created_at ASC, id ASC
+      LIMIT 1`,
+  );
+  if (liveRows.length > 0) {
+    const id = Number(liveRows[0]!.id);
+    if (liveRows[0]!.status === 'paused') {
+      const childRows = await engine.executeRaw<{ count: string }>(
+        `SELECT count(*)::text AS count
+           FROM minion_jobs
+          WHERE parent_job_id = $1
+            AND status NOT IN ('completed','failed','dead','cancelled')`,
+        [id],
+      );
+      const liveChildren = parseInt(childRows[0]?.count ?? '0', 10);
+      if (opts.holdForChildren) {
+        if (liveChildren > 0) {
+          await engine.executeRaw(
+            `UPDATE minion_jobs
+                SET status = 'waiting-children', updated_at = now()
+              WHERE id = $1
+                AND status = 'paused'`,
+            [id],
+          );
+        }
+        if (opts.jsonMode) {
+          emit(JSON.stringify({ event: 'global_maintenance_reusing_held_parent', job_id: id, slot: opts.slot }));
+        } else {
+          log(`[dispatch] autopilot-global-maintenance reusing held parent job #${id}`);
+        }
+        return { dispatched: true, reason: 'stale', job_id: id, parent_job_id: id };
+      }
+      await engine.executeRaw(
+        `UPDATE minion_jobs
+            SET status = $2, updated_at = now()
+          WHERE id = $1
+            AND status = 'paused'`,
+        [id, liveChildren > 0 ? 'waiting-children' : 'waiting'],
+      );
+    }
+    if (opts.jsonMode) {
+      emit(JSON.stringify({ event: 'global_maintenance_already_live', job_id: id, slot: opts.slot }));
+    } else {
+      log(`[dispatch] autopilot-global-maintenance already live as job #${id}`);
+    }
+    return { dispatched: true, reason: 'stale', job_id: id };
+  }
+
   const job = await queue.add(
     'autopilot-global-maintenance',
     { repoPath: opts.repoPath, phases: GLOBAL_PHASES },
@@ -560,12 +727,14 @@ export async function dispatchGlobalMaintenance(
       max_attempts: 2,
       timeout_ms: opts.timeoutMs,
       maxWaiting: 1,
+      hold_until_children: !!opts.holdForChildren,
     },
+    { allowProtectedSubmit: true },
   );
   if (opts.jsonMode) {
     emit(JSON.stringify({ event: 'dispatched', job_id: job.id, mode: 'global_maintenance', slot: opts.slot }));
   } else {
     log(`[dispatch] job #${job.id} autopilot-global-maintenance (brain-wide phases)`);
   }
-  return { dispatched: true, reason: 'stale' };
+  return { dispatched: true, reason: 'stale', job_id: job.id, parent_job_id: job.id };
 }

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -871,7 +871,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
           // codex P1-3). Fresh-install brains with no sources rows fall
           // back to the legacy single autopilot-cycle so existing
           // behavior is preserved.
-          const { dispatchPerSource, dispatchGlobalMaintenance, resolveEffectiveFanoutMax } = await import('./autopilot-fanout.ts');
+          const { dispatchPerSource, resolveEffectiveFanoutMax } = await import('./autopilot-fanout.ts');
           // #2194 fix #1: clamp fan-out to the worker's effective concurrency
           // (reserve ≥1 slot), gated on a LIVE supervisor so a stale audit row
           // can't shrink throughput (codex #9/D5). autopilot-cycle jobs run on
@@ -884,19 +884,16 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
             fanoutMax,
             jsonMode,
           });
-          // #2194 fix #3 / #2227 bug #3: dispatch the single brain-wide
-          // maintenance job (embed/orphans/purge/…) once per window — the per-
-          // source cycles above no longer run global phases, so this is where
-          // the brain-wide work happens (single-flight, no RSS blowout). Only on
-          // the per-source path (legacy single-source still runs everything).
-          if (!result.legacy_fallback) {
-            try {
-              await dispatchGlobalMaintenance(engine, queue, { repoPath, slot, timeoutMs, jsonMode });
-            } catch (e) {
-              if (jsonMode) process.stderr.write(JSON.stringify({ event: 'global_maintenance_dispatch_failed', error: e instanceof Error ? e.message : String(e) }) + '\n');
-            }
-          }
-          if (result.dispatched.length > 0 || result.legacy_fallback) {
+          if (
+            result.legacy_fallback ||
+            (
+              result.skipped_cap.length === 0 &&
+              result.skipped_active.length === 0 &&
+              result.dispatched.length === 0 &&
+              !result.global_maintenance.dispatched &&
+              result.global_maintenance.reason === 'fresh'
+            )
+          ) {
             lastFullCycleAt = Date.now();
           }
           if (jsonMode) {
@@ -906,7 +903,9 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
               skipped_fresh: result.skipped_fresh,
               skipped_cap: result.skipped_cap,
               skipped_cooldown: result.skipped_cooldown,
+              skipped_active: result.skipped_active,
               legacy_fallback: result.legacy_fallback,
+              global_maintenance: result.global_maintenance,
               fanout_max: fanoutMax,
               score,
             }) + '\n');
@@ -914,7 +913,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
             console.log(
               `[dispatch] fanout: ${result.dispatched.length} dispatched, ` +
               `${result.skipped_fresh.length} fresh, ${result.skipped_cap.length} capped, ` +
-              `${result.skipped_cooldown.length} cooldown ` +
+              `${result.skipped_cooldown.length} cooldown, ${result.skipped_active.length} active ` +
               `(score=${score}, max=${fanoutMax})`,
             );
           }

--- a/src/commands/budget.ts
+++ b/src/commands/budget.ts
@@ -1,0 +1,426 @@
+/**
+ * Local budget ledger readback.
+ *
+ * Reads GBrain's budget audit JSONL files and optionally compares them with a
+ * local provider receipt export. No DB, no provider API, no secrets.
+ */
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { mkdirSync } from 'node:fs';
+import { resolveAuditDir } from '../core/audit-week-file.ts';
+
+export type BudgetProviderFilter = 'anthropic' | 'deepseek' | 'all';
+
+export interface BudgetReconcileArgs {
+  days: number;
+  provider: BudgetProviderFilter;
+  json: boolean;
+  externalReceiptsPath: string | null;
+  outPath: string | null;
+  now: Date;
+}
+
+interface SpendRecord {
+  ts: string;
+  model: string | null;
+  provider: string | null;
+  label: string | null;
+  costUsd: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  sourceFile: string;
+}
+
+export interface BudgetSpendSummary {
+  records: number;
+  cost_usd: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  by_model: Array<{ model: string; records: number; cost_usd: number }>;
+  by_label: Array<{ label: string; records: number; cost_usd: number }>;
+}
+
+export interface BudgetReconcileReport {
+  schema_version: 1;
+  window: { since: string; until: string; days: number };
+  provider: BudgetProviderFilter;
+  internal: BudgetSpendSummary & { audit_dir: string; files_read: string[] };
+  external: (BudgetSpendSummary & { path: string }) | null;
+  comparison: {
+    external_provided: boolean;
+    delta_usd: number | null;
+    within_one_cent: boolean | null;
+  };
+}
+
+const HELP = `gbrain budget reconcile - local budget ledger readback
+
+USAGE
+  gbrain budget reconcile [--days N] [--provider anthropic|deepseek|all]
+                           [--external-receipts PATH] [--out PATH] [--json]
+
+WHAT IT DOES
+  Reads ~/.gbrain/audit/budget-*.jsonl (or GBRAIN_AUDIT_DIR) and totals recent
+  paid-provider chat records. With --external-receipts, compares against a local
+  JSON/JSONL provider receipt export. It never calls Anthropic or any provider.
+
+EXAMPLES
+  gbrain budget reconcile --days 7
+  gbrain budget reconcile --days 7 --external-receipts ~/Downloads/anthropic-usage.jsonl
+  gbrain budget reconcile --days 7 --json --out .context/budget-reconcile.json
+`;
+
+export async function runBudget(args: string[]): Promise<number> {
+  const sub = args[0] ?? 'reconcile';
+  if (sub === '--help' || sub === '-h' || sub === 'help') {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (sub !== 'reconcile') {
+    process.stderr.write(`Unknown budget subcommand: ${sub}\n\n${HELP}`);
+    return 2;
+  }
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+
+  let parsed: BudgetReconcileArgs;
+  try {
+    parsed = parseBudgetReconcileArgs(args.slice(1));
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n\n${HELP}`);
+    return 2;
+  }
+
+  const report = buildBudgetReconcileReport(parsed);
+  if (parsed.outPath) {
+    const out = resolve(parsed.outPath);
+    mkdirSync(dirname(out), { recursive: true });
+    writeFileSync(out, JSON.stringify(report, null, 2) + '\n', 'utf-8');
+    if (!parsed.json) process.stdout.write(`Wrote receipt: ${out}\n\n`);
+  }
+  process.stdout.write(parsed.json ? JSON.stringify(report, null, 2) + '\n' : formatBudgetReconcileText(report));
+  return 0;
+}
+
+export function parseBudgetReconcileArgs(args: string[], now = new Date()): BudgetReconcileArgs {
+  let days = 7;
+  let provider: BudgetProviderFilter = 'anthropic';
+  let json = false;
+  let externalReceiptsPath: string | null = null;
+  let outPath: string | null = null;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    switch (a) {
+      case '--days': {
+        const raw = args[++i];
+        if (!raw || !/^\d+$/.test(raw)) throw new Error('--days must be a positive integer');
+        days = Number(raw);
+        if (days <= 0) throw new Error('--days must be a positive integer');
+        break;
+      }
+      case '--provider': {
+        const raw = args[++i];
+        if (raw !== 'anthropic' && raw !== 'deepseek' && raw !== 'all') {
+          throw new Error('--provider must be anthropic, deepseek, or all');
+        }
+        provider = raw;
+        break;
+      }
+      case '--external-receipts':
+      case '--anthropic-receipts': {
+        const raw = args[++i];
+        if (!raw) throw new Error(`${a} requires a path`);
+        externalReceiptsPath = raw;
+        break;
+      }
+      case '--out': {
+        const raw = args[++i];
+        if (!raw) throw new Error('--out requires a path');
+        outPath = raw;
+        break;
+      }
+      case '--json':
+        json = true;
+        break;
+      default:
+        throw new Error(`Unknown budget reconcile flag: ${a}`);
+    }
+  }
+
+  return { days, provider, json, externalReceiptsPath, outPath, now };
+}
+
+export function buildBudgetReconcileReport(args: BudgetReconcileArgs): BudgetReconcileReport {
+  const until = args.now;
+  const since = new Date(until.getTime() - args.days * 24 * 60 * 60 * 1000);
+  const auditDir = resolveAuditDir();
+  const internalRecords = readInternalBudgetRecords(auditDir, since, until, args.provider);
+  const externalRecords = args.externalReceiptsPath
+    ? readExternalReceiptRecords(args.externalReceiptsPath, since, until, args.provider)
+    : null;
+  const internalSummary = summarizeRecords(internalRecords);
+  const externalSummary = externalRecords ? summarizeRecords(externalRecords) : null;
+  const filesRead = Array.from(new Set(internalRecords.map((r) => r.sourceFile))).sort();
+
+  const delta = externalSummary ? internalSummary.cost_usd - externalSummary.cost_usd : null;
+  return {
+    schema_version: 1,
+    window: { since: since.toISOString(), until: until.toISOString(), days: args.days },
+    provider: args.provider,
+    internal: { ...internalSummary, audit_dir: auditDir, files_read: filesRead },
+    external: externalSummary && args.externalReceiptsPath
+      ? { ...externalSummary, path: resolve(args.externalReceiptsPath) }
+      : null,
+    comparison: {
+      external_provided: !!externalSummary,
+      delta_usd: delta,
+      within_one_cent: delta === null ? null : Math.abs(delta) <= 0.01,
+    },
+  };
+}
+
+function readInternalBudgetRecords(
+  auditDir: string,
+  since: Date,
+  until: Date,
+  provider: BudgetProviderFilter,
+): SpendRecord[] {
+  if (!existsSync(auditDir)) return [];
+  const files = readdirSync(auditDir)
+    .filter((name) => name.endsWith('.jsonl') && (name.startsWith('budget-') || name === 'budget.jsonl'))
+    .map((name) => join(auditDir, name));
+  const records: SpendRecord[] = [];
+
+  for (const file of files) {
+    for (const row of readJsonRecords(file)) {
+      if (row.event !== 'record' || row.kind !== 'chat') continue;
+      const ts = timestampInWindow(row.ts, since, until);
+      if (!ts) continue;
+      const model = typeof row.model === 'string' ? row.model : null;
+      const rowProvider = model ? providerForBudgetModel(model) : null;
+      if (!providerMatches(rowProvider, provider, false)) continue;
+      const costUsd = numberFrom(row.actual_cost_usd);
+      if (costUsd === null) continue;
+      records.push({
+        ts,
+        model,
+        provider: rowProvider,
+        label: typeof row.label === 'string' ? row.label : null,
+        costUsd,
+        inputTokens: numberFrom(row.input_tokens) ?? 0,
+        outputTokens: numberFrom(row.output_tokens) ?? 0,
+        cacheReadTokens: numberFrom(row.cache_read_tokens) ?? 0,
+        cacheCreationTokens: numberFrom(row.cache_creation_tokens) ?? 0,
+        sourceFile: file,
+      });
+    }
+  }
+
+  return records;
+}
+
+function readExternalReceiptRecords(
+  path: string,
+  since: Date,
+  until: Date,
+  provider: BudgetProviderFilter,
+): SpendRecord[] {
+  const fullPath = isAbsolute(path) ? path : resolve(path);
+  if (!existsSync(fullPath)) throw new Error(`External receipt file not found: ${fullPath}`);
+  const records: SpendRecord[] = [];
+  for (const row of readJsonRecords(fullPath)) {
+    const ts = timestampInWindow(row.ts ?? row.timestamp ?? row.created_at ?? row.date ?? row.time, since, until);
+    if (!ts) continue;
+    const model = stringFrom(row.model ?? row.model_id ?? row.modelId);
+    const explicitProvider = stringFrom(row.provider ?? row.provider_id ?? row.providerId);
+    const rowProvider = explicitProvider ?? (model ? providerForBudgetModel(model) : null);
+    if (!providerMatches(rowProvider, provider, true)) continue;
+    const costUsd = firstNumber(row.actual_cost_usd, row.cost_usd, row.amount_usd, row.total_usd, row.usd, row.amount);
+    if (costUsd === null) continue;
+    records.push({
+      ts,
+      model,
+      provider: rowProvider,
+      label: stringFrom(row.label ?? row.operation ?? row.event),
+      costUsd,
+      inputTokens: firstNumber(row.input_tokens, row.inputTokens) ?? 0,
+      outputTokens: firstNumber(row.output_tokens, row.outputTokens) ?? 0,
+      cacheReadTokens: firstNumber(row.cache_read_tokens, row.cacheReadTokens, row.cache_read_input_tokens) ?? 0,
+      cacheCreationTokens: firstNumber(row.cache_creation_tokens, row.cacheCreationTokens, row.cache_creation_input_tokens) ?? 0,
+      sourceFile: fullPath,
+    });
+  }
+  return records;
+}
+
+function readJsonRecords(path: string): Array<Record<string, unknown>> {
+  const text = readFileSync(path, 'utf-8').trim();
+  if (!text) return [];
+  if (text.startsWith('[')) {
+    const parsed = JSON.parse(text) as unknown;
+    return Array.isArray(parsed) ? parsed.filter(isObjectRecord) : [];
+  }
+  const rows: Array<Record<string, unknown>> = [];
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (isObjectRecord(parsed)) rows.push(parsed);
+    } catch {
+      // Ignore malformed receipt lines; the readback is best-effort.
+    }
+  }
+  return rows;
+}
+
+function summarizeRecords(records: SpendRecord[]): BudgetSpendSummary {
+  const modelMap = new Map<string, { records: number; cost_usd: number }>();
+  const labelMap = new Map<string, { records: number; cost_usd: number }>();
+  let cost = 0;
+  let input = 0;
+  let output = 0;
+  let cacheRead = 0;
+  let cacheCreate = 0;
+
+  for (const r of records) {
+    cost += r.costUsd;
+    input += r.inputTokens;
+    output += r.outputTokens;
+    cacheRead += r.cacheReadTokens;
+    cacheCreate += r.cacheCreationTokens;
+    bump(modelMap, r.model ?? '(unknown)', r.costUsd);
+    bump(labelMap, r.label ?? '(unlabeled)', r.costUsd);
+  }
+
+  return {
+    records: records.length,
+    cost_usd: roundUsd(cost),
+    input_tokens: input,
+    output_tokens: output,
+    cache_read_tokens: cacheRead,
+    cache_creation_tokens: cacheCreate,
+    by_model: sortedModelBreakdown(modelMap),
+    by_label: sortedLabelBreakdown(labelMap),
+  };
+}
+
+function formatBudgetReconcileText(report: BudgetReconcileReport): string {
+  const lines: string[] = [];
+  lines.push(`Budget readback (${report.window.since.slice(0, 10)} to ${report.window.until.slice(0, 10)} UTC)`);
+  lines.push(`Provider: ${report.provider}`);
+  lines.push(`Internal ledger: ${formatUsd(report.internal.cost_usd)} across ${report.internal.records} chat record(s)`);
+  lines.push(`Audit dir: ${report.internal.audit_dir}`);
+  lines.push(`Audit files: ${report.internal.files_read.length > 0 ? report.internal.files_read.join(', ') : '(none with matching records)'}`);
+  lines.push(`Tokens: input=${report.internal.input_tokens}, output=${report.internal.output_tokens}, cache_read=${report.internal.cache_read_tokens}, cache_create=${report.internal.cache_creation_tokens}`);
+  lines.push('');
+  lines.push('Top internal models:');
+  for (const row of report.internal.by_model.slice(0, 5)) {
+    lines.push(`  ${row.model}: ${formatUsd(row.cost_usd)} (${row.records})`);
+  }
+  if (report.internal.by_model.length === 0) lines.push('  (none)');
+  lines.push('');
+  lines.push('Top internal labels:');
+  for (const row of report.internal.by_label.slice(0, 5)) {
+    lines.push(`  ${row.label}: ${formatUsd(row.cost_usd)} (${row.records})`);
+  }
+  if (report.internal.by_label.length === 0) lines.push('  (none)');
+
+  if (report.external) {
+    lines.push('');
+    lines.push(`External receipts: ${formatUsd(report.external.cost_usd)} across ${report.external.records} record(s)`);
+    lines.push(`External path: ${report.external.path}`);
+    lines.push(`Delta (internal - external): ${formatUsd(report.comparison.delta_usd ?? 0)}`);
+    lines.push(`Within one cent: ${report.comparison.within_one_cent ? 'yes' : 'no'}`);
+  } else {
+    lines.push('');
+    lines.push('External receipts: not provided');
+    lines.push('Compare the internal total above with the Anthropic Console/API export for the same UTC window.');
+  }
+  return lines.join('\n') + '\n';
+}
+
+function providerMatches(rowProvider: string | null, filter: BudgetProviderFilter, allowUnknownExternal: boolean): boolean {
+  if (filter === 'all') return true;
+  if (rowProvider === filter) return true;
+  return allowUnknownExternal && rowProvider === null;
+}
+
+function providerForBudgetModel(model: string): BudgetProviderFilter | null {
+  const normalized = model.toLowerCase();
+  if (normalized.startsWith('anthropic:') || normalized.startsWith('claude-')) return 'anthropic';
+  if (normalized.startsWith('deepseek:') || normalized.startsWith('deepseek-')) return 'deepseek';
+  return null;
+}
+
+function timestampInWindow(value: unknown, since: Date, until: Date): string | null {
+  if (typeof value !== 'string' && typeof value !== 'number') return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  if (d < since || d > until) return null;
+  return d.toISOString();
+}
+
+function firstNumber(...values: unknown[]): number | null {
+  for (const v of values) {
+    const n = numberFrom(v);
+    if (n !== null) return n;
+  }
+  return null;
+}
+
+function numberFrom(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const cleaned = value.trim().replace(/^\$/, '');
+    const n = Number(cleaned);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function stringFrom(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function bump(map: Map<string, { records: number; cost_usd: number }>, key: string, cost: number): void {
+  const prev = map.get(key) ?? { records: 0, cost_usd: 0 };
+  prev.records++;
+  prev.cost_usd += cost;
+  map.set(key, prev);
+}
+
+function sortedModelBreakdown(
+  map: Map<string, { records: number; cost_usd: number }>,
+): Array<{ model: string; records: number; cost_usd: number }> {
+  return Array.from(map.entries())
+    .map(([model, value]) => ({ model, records: value.records, cost_usd: roundUsd(value.cost_usd) }))
+    .sort((a, b) => b.cost_usd - a.cost_usd || a.model.localeCompare(b.model));
+}
+
+function sortedLabelBreakdown(
+  map: Map<string, { records: number; cost_usd: number }>,
+): Array<{ label: string; records: number; cost_usd: number }> {
+  return Array.from(map.entries())
+    .map(([label, value]) => ({ label, records: value.records, cost_usd: roundUsd(value.cost_usd) }))
+    .sort((a, b) => b.cost_usd - a.cost_usd || a.label.localeCompare(b.label));
+}
+
+function roundUsd(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function formatUsd(value: number): string {
+  return `$${value.toFixed(4)}`;
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3786,21 +3786,21 @@ export async function checkCycleFreshness(
       const display = source.name && source.name !== source.id
         ? `'${source.id}' (${source.name})`
         : `'${source.id}'`;
-      const raw = source.config?.last_full_cycle_at;
+      const raw = source.config?.last_source_cycle_at ?? source.config?.last_full_cycle_at;
       if (typeof raw !== 'string') {
-        issues.push(`Source ${display} has never completed a full cycle`);
+        issues.push(`Source ${display} has never completed a source cycle`);
         hasFailures = true;
         continue;
       }
       const last = new Date(raw).getTime();
       if (!Number.isFinite(last)) {
-        issues.push(`Source ${display} has unparseable last_full_cycle_at: ${raw}`);
+        issues.push(`Source ${display} has unparseable cycle timestamp: ${raw}`);
         hasWarnings = true;
         continue;
       }
       const ageMs = now - last;
       if (ageMs < 0) {
-        issues.push(`Source ${display} has future last_full_cycle_at — clock skew`);
+        issues.push(`Source ${display} has future cycle timestamp — clock skew`);
         hasWarnings = true;
         continue;
       }

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1765,9 +1765,10 @@ export async function registerBuiltinHandlers(
       yieldBetweenPhases: async () => { await new Promise<void>((r) => setImmediate(r)); },
     });
 
-    // Stamp last_global_at only on a non-failed run so a failed pass stays stale
-    // and re-dispatches next tick (self-healing retry).
-    if (report.status === 'ok' || report.status === 'clean' || report.status === 'partial') {
+    // Stamp last_global_at only on a fully clean run. `partial` means at least
+    // one global phase failed or warned; keeping it stale lets the next tick
+    // retry instead of marking the whole brain-wide pass fresh.
+    if (report.status === 'ok' || report.status === 'clean') {
       try {
         await engine.setConfig(LAST_GLOBAL_AT_KEY, new Date().toISOString());
       } catch (e) {

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2323,6 +2323,18 @@ export interface ChatToolDef {
   inputSchema: Record<string, unknown>;
 }
 
+function toJsonSafeToolValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'function' || typeof value === 'symbol' || typeof value === 'undefined') return null;
+  if (value === null || typeof value !== 'object') return value;
+  if (seen.has(value)) return '[Circular]';
+  seen.add(value);
+  if (Array.isArray(value)) return value.map((item) => toJsonSafeToolValue(item, seen));
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, nested]) => [key, toJsonSafeToolValue(nested, seen)]),
+  );
+}
+
 /**
  * Convert gbrain's provider-neutral ChatMessage[] into AI SDK v6 ModelMessage[].
  *
@@ -2351,10 +2363,10 @@ export function toModelMessages(messages: ChatMessage[]): unknown[] {
             toolCallId: b.toolCallId,
             toolName: b.toolName,
             output: b.isError
-              ? { type: 'error-text' as const, value: typeof b.output === 'string' ? b.output : JSON.stringify(b.output) }
+              ? { type: 'error-text' as const, value: typeof b.output === 'string' ? b.output : JSON.stringify(toJsonSafeToolValue(b.output)) }
               : (typeof b.output === 'string'
                 ? { type: 'text' as const, value: b.output }
-                : { type: 'json' as const, value: (b.output ?? null) as never }),
+                : { type: 'json' as const, value: toJsonSafeToolValue(b.output ?? null) as never }),
           })),
       };
     }

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2327,6 +2327,7 @@ function toJsonSafeToolValue(value: unknown, seen = new WeakSet<object>()): unkn
   if (typeof value === 'bigint') return value.toString();
   if (typeof value === 'function' || typeof value === 'symbol' || typeof value === 'undefined') return null;
   if (value === null || typeof value !== 'object') return value;
+  if (value instanceof Date) return value.toISOString();
   if (seen.has(value)) return '[Circular]';
   seen.add(value);
   if (Array.isArray(value)) return value.map((item) => toJsonSafeToolValue(item, seen));

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -2325,17 +2325,21 @@ export async function runCycle(
   if (opts.sourceId && engine && !dryRun && !aborted && (status === 'ok' || status === 'clean' || status === 'partial')) {
     try {
       const nowIso = new Date().toISOString();
-      // #2194 fix #3 (the cycle split): `last_source_cycle_at` is the NEW gate
-      // for per-source dispatch (source-scoped phases done). We ALSO keep
-      // `last_full_cycle_at` current so doctor's cycle-freshness check and any
-      // legacy reader stay valid — it's no longer a *gate* for the brain-wide
-      // phases (those gate on autopilot.last_global_at), so writing it on a
-      // source-only cycle does not re-introduce the freshness poisoning codex
-      // flagged in the rejected skip-based design.
-      await engine.updateSourceConfig(opts.sourceId, {
-        last_source_cycle_at: nowIso,
-        last_full_cycle_at: nowIso,
-      });
+      const phaseSet = new Set(phases);
+      const isSplitAutopilotSourceCycle =
+        phases.length === NON_GLOBAL_PHASES.length
+        && NON_GLOBAL_PHASES.every((phase) => phaseSet.has(phase));
+      // #2194 fix #3 (the cycle split): `last_source_cycle_at` is the per-source
+      // gate for source-scoped phases. Only the split autopilot job with exactly
+      // NON_GLOBAL_PHASES skips `last_full_cycle_at`; manual source cycles keep
+      // the legacy freshness contract that doctor/dream callers already read.
+      if (!(isSplitAutopilotSourceCycle && status === 'partial')) {
+        const update: Record<string, string> = { last_source_cycle_at: nowIso };
+        if (!isSplitAutopilotSourceCycle) {
+          update.last_full_cycle_at = nowIso;
+        }
+        await engine.updateSourceConfig(opts.sourceId, update);
+      }
     } catch (e) {
       // Best-effort; cycle already succeeded by the time we get here.
       console.warn(`[cycle] failed to write last_source_cycle_at for source ${opts.sourceId}: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/core/cycle/propose-takes.ts
+++ b/src/core/cycle/propose-takes.ts
@@ -39,7 +39,8 @@
 
 import { randomUUID, createHash } from 'node:crypto';
 import { BaseCyclePhase, type ScopedReadOpts, type BasePhaseOpts } from './base-phase.ts';
-import { chat as gatewayChat } from '../ai/gateway.ts';
+import { chat as gatewayChat, getCurrentBudgetTracker, withBudgetTracker } from '../ai/gateway.ts';
+import { BudgetExhausted, BudgetTracker } from '../budget/budget-tracker.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 import { GBrainError } from '../types.ts';
@@ -54,6 +55,8 @@ import type { PhaseStatus, CyclePhase } from '../cycle.ts';
  * valid as audit history; new runs re-spend LLM tokens on every page.
  */
 export const PROPOSE_TAKES_PROMPT_VERSION = 'v0.36.1.0-tuned-cat15';
+const PROPOSE_TAKES_BUDGET_USD_KEY = 'cycle.propose_takes.budget_usd';
+const PROPOSE_TAKES_BUDGET_USD_DEFAULT = 5.0;
 
 /**
  * Tuned extractor prompt, validated against the hand-labeled synthetic
@@ -285,8 +288,8 @@ export function parseExtractorOutput(raw: string): ProposedTake[] {
  */
 class ProposeTakesPhase extends BaseCyclePhase {
   readonly name = 'propose_takes' as CyclePhase;
-  protected readonly budgetUsdKey = 'cycle.propose_takes.budget_usd';
-  protected readonly budgetUsdDefault = 5.0;
+  protected readonly budgetUsdKey = PROPOSE_TAKES_BUDGET_USD_KEY;
+  protected readonly budgetUsdDefault = PROPOSE_TAKES_BUDGET_USD_DEFAULT;
 
   protected override mapErrorCode(err: unknown): string {
     if (err instanceof GBrainError) return err.problem;
@@ -300,7 +303,7 @@ class ProposeTakesPhase extends BaseCyclePhase {
   protected async process(
     engine: BrainEngine,
     scope: ScopedReadOpts,
-    _ctx: OperationContext,
+    ctx: OperationContext,
     opts: ProposeTakesOpts,
   ): Promise<{ summary: string; details: Record<string, unknown>; status?: PhaseStatus }> {
     const extractor = opts.extractor ?? defaultExtractor;
@@ -308,6 +311,23 @@ class ProposeTakesPhase extends BaseCyclePhase {
     const pageLimit = opts.pageLimit ?? 100;
     const skipPagesWithFence = opts.skipPagesWithFence ?? false;
     const proposalRunId = `propose-${new Date().toISOString().slice(0, 19).replace(/[-:T]/g, '')}-${randomUUID().slice(0, 8)}`;
+    const spendTracker = getCurrentBudgetTracker();
+    const startingCostUsd = spendTracker?.snapshot().cumulativeCostUsd ?? 0;
+    const phaseBudgetUsd = resolvePhaseBudgetUsd(ctx, opts);
+    const scopedSourceId = scope.sourceId ?? (
+      scope.sourceIds?.length === 1 ? scope.sourceIds[0] : undefined
+    );
+
+    if (!scopedSourceId) {
+      return {
+        summary: 'propose_takes skipped: federated source scope needs per-source spend attribution',
+        details: {
+          reason: 'federated_source_scope',
+          source_ids: scope.sourceIds ?? [],
+        },
+        status: 'warn',
+      };
+    }
 
     const result: ProposeTakesResult = {
       pages_scanned: 0,
@@ -381,8 +401,21 @@ class ProposeTakesPhase extends BaseCyclePhase {
           modelHint: opts.model,
         });
       } catch (err) {
+        if (err instanceof BudgetExhausted) {
+          result.budget_exhausted = true;
+          result.warnings.push(
+            `budget exhausted at page ${result.pages_scanned}/${pages.length} (${err.message})`,
+          );
+          break;
+        }
         const msg = err instanceof Error ? err.message : String(err);
         result.warnings.push(`extractor failed on ${page.slug}: ${msg}`);
+        const overage = detectSpendOverage(spendTracker, startingCostUsd, phaseBudgetUsd);
+        if (overage) {
+          result.budget_exhausted = true;
+          result.warnings.push(`budget exhausted after failed page ${result.pages_scanned}/${pages.length} (${overage})`);
+          break;
+        }
         continue;
       }
 
@@ -413,13 +446,29 @@ class ProposeTakesPhase extends BaseCyclePhase {
         );
         result.proposals_inserted += 1;
       }
+      const overage = detectSpendOverage(spendTracker, startingCostUsd, phaseBudgetUsd);
+      if (overage) {
+        result.budget_exhausted = true;
+        result.warnings.push(`budget exhausted after page ${result.pages_scanned}/${pages.length} (${overage})`);
+        break;
+      }
     }
 
     if (opts.reporter) opts.reporter.finish();
 
     // v0.42 Wave B3: receipt + rollup for propose_takes. Source-scoped
     // via the read scope. Receipt only when proposals actually written.
-    const sourceIdForReceipt = scope.sourceId ?? 'default';
+    const sourceIdForReceipt = scopedSourceId;
+    const trackerSnapshot = spendTracker?.snapshot();
+    const finalCostUsd = trackerSnapshot?.cumulativeCostUsd ?? startingCostUsd;
+    const costUsd = Math.max(0, finalCostUsd - startingCostUsd);
+    const finalOverage = detectSpendOverage(spendTracker, startingCostUsd, phaseBudgetUsd);
+    if (finalOverage && !result.budget_exhausted) {
+      result.budget_exhausted = true;
+      result.warnings.push(
+        `budget exhausted after final page (${finalOverage})`,
+      );
+    }
     if (result.proposals_inserted > 0) {
       try {
         await writeReceipt(engine, {
@@ -429,7 +478,8 @@ class ProposeTakesPhase extends BaseCyclePhase {
           round: 'single',
           extracted_at: new Date().toISOString(),
           total_rows: result.proposals_inserted,
-          cost_usd: 0, // tracker isn't exposed at this layer; cost tracked centrally
+          cost_usd: costUsd,
+          ...(opts.model ? { model_id: opts.model } : {}),
           summary:
             `Proposed ${result.proposals_inserted} new takes from ${result.pages_scanned} pages ` +
             `(${result.cache_hits} cached).`,
@@ -441,16 +491,70 @@ class ProposeTakesPhase extends BaseCyclePhase {
     await upsertExtractRollup(engine, {
       kind: 'takes.proposed',
       source_id: sourceIdForReceipt,
+      cost_delta: costUsd,
       round_completed_delta: result.budget_exhausted ? 0 : 1,
       halt_delta: result.budget_exhausted ? 1 : 0,
     });
 
     return {
       summary: `propose_takes: scanned ${result.pages_scanned} pages, ${result.cache_hits} cached, ${result.proposals_inserted} new proposals (run ${proposalRunId})`,
-      details: { ...result, proposal_run_id: proposalRunId, prompt_version: promptVersion },
+      details: { ...result, proposal_run_id: proposalRunId, prompt_version: promptVersion, cost_usd: costUsd },
       status: result.budget_exhausted ? 'warn' : 'ok',
     };
   }
+}
+
+function resolveTrackerBudgetUsd(ctx: OperationContext, opts: ProposeTakesOpts): number | undefined {
+  if (typeof opts.budgetUsd === 'number') {
+    return opts.budgetUsd > 0 ? opts.budgetUsd : undefined;
+  }
+  const raw = (ctx.config as unknown as Record<string, unknown>)[PROPOSE_TAKES_BUDGET_USD_KEY];
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw > 0) {
+    return raw;
+  }
+  if (typeof raw === 'string') {
+    const parsed = Number.parseFloat(raw);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function detectSpendOverage(
+  tracker: BudgetTracker | null,
+  startingCostUsd: number,
+  phaseBudgetUsd: number | undefined,
+): string | null {
+  const snapshot = tracker?.snapshot();
+  if (!snapshot) return null;
+  const phaseCostUsd = Math.max(0, snapshot.cumulativeCostUsd - startingCostUsd);
+  if (phaseBudgetUsd !== undefined && phaseCostUsd > phaseBudgetUsd) {
+    return `phase spend $${phaseCostUsd.toFixed(4)} exceeded cap $${phaseBudgetUsd.toFixed(2)}`;
+  }
+  if (
+    snapshot.maxCostUsd !== undefined &&
+    snapshot.cumulativeCostUsd > snapshot.maxCostUsd &&
+    snapshot.cumulativeCostUsd > startingCostUsd
+  ) {
+    return `cumulative spend $${snapshot.cumulativeCostUsd.toFixed(4)} exceeded tracker cap $${snapshot.maxCostUsd.toFixed(2)}`;
+  }
+  return null;
+}
+
+function resolvePhaseBudgetUsd(ctx: OperationContext, opts: ProposeTakesOpts): number | undefined {
+  if (typeof opts.budgetUsd === 'number') {
+    return opts.budgetUsd > 0 ? opts.budgetUsd : undefined;
+  }
+  const raw = (ctx.config as unknown as Record<string, unknown>)[PROPOSE_TAKES_BUDGET_USD_KEY];
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) {
+    return raw > 0 ? raw : undefined;
+  }
+  if (typeof raw === 'string') {
+    const parsed = Number.parseFloat(raw);
+    return Number.isFinite(parsed) && parsed >= 0
+      ? (parsed > 0 ? parsed : undefined)
+      : PROPOSE_TAKES_BUDGET_USD_DEFAULT;
+  }
+  return PROPOSE_TAKES_BUDGET_USD_DEFAULT;
 }
 
 /**
@@ -461,7 +565,15 @@ export async function runPhaseProposeTakes(
   ctx: OperationContext,
   opts: ProposeTakesOpts = {},
 ) {
-  return new ProposeTakesPhase().run(ctx, opts);
+  const phase = new ProposeTakesPhase();
+  if (getCurrentBudgetTracker()) {
+    return phase.run(ctx, opts);
+  }
+  const tracker = new BudgetTracker({
+    label: 'cycle.propose_takes',
+    maxCostUsd: resolveTrackerBudgetUsd(ctx, opts),
+  });
+  return withBudgetTracker(tracker, () => phase.run(ctx, opts));
 }
 
 /** Test-only access to the class for subclassing in tests. */

--- a/src/core/cycle/propose-takes.ts
+++ b/src/core/cycle/propose-takes.ts
@@ -315,7 +315,9 @@ class ProposeTakesPhase extends BaseCyclePhase {
     const startingCostUsd = spendTracker?.snapshot().cumulativeCostUsd ?? 0;
     const phaseBudgetUsd = resolvePhaseBudgetUsd(ctx, opts);
     const scopedSourceId = scope.sourceId ?? (
-      scope.sourceIds?.length === 1 ? scope.sourceIds[0] : undefined
+      scope.sourceIds?.length === 1
+        ? scope.sourceIds[0]
+        : (scope.sourceIds?.length ? undefined : 'default')
     );
 
     if (!scopedSourceId) {

--- a/src/core/minions/protected-names.ts
+++ b/src/core/minions/protected-names.ts
@@ -63,6 +63,10 @@ export const PROTECTED_JOB_NAMES: ReadonlySet<string> = new Set([
   // auto-drain branch, an explicit `gbrain jobs submit extract-atoms-drain
   // --allow-protected`) can insert it.
   'extract-atoms-drain',
+  // v0.42.x (#2194/#2227) — wrapper for brain-wide global maintenance
+  // phases. It can run cost-bearing/protected cycle phases, so only trusted
+  // local callers such as autopilot may submit it.
+  'autopilot-global-maintenance',
 ]);
 
 /** Check a job name against the protected set. Normalizes whitespace first. */

--- a/src/core/minions/queue.ts
+++ b/src/core/minions/queue.ts
@@ -125,7 +125,7 @@ export class MinionQueue {
     }
     await this.ensureSchema();
 
-    const childStatus: MinionJobStatus = opts?.delay ? 'delayed' : 'waiting';
+    const childStatus: MinionJobStatus = opts?.hold_until_children ? 'paused' : (opts?.delay ? 'delayed' : 'waiting');
     const delayUntil = opts?.delay ? new Date(Date.now() + opts.delay) : null;
     const maxSpawnDepth = opts?.max_spawn_depth ?? this.maxSpawnDepth;
 
@@ -313,7 +313,7 @@ export class MinionQueue {
       if (opts?.parent_job_id) {
         await tx.executeRaw(
           `UPDATE minion_jobs SET status = 'waiting-children', updated_at = now()
-           WHERE id = $1 AND status IN ('waiting','active','delayed')`,
+           WHERE id = $1 AND status IN ('waiting','active','delayed','paused')`,
           [opts.parent_job_id]
         );
       }

--- a/src/core/minions/types.ts
+++ b/src/core/minions/types.ts
@@ -130,6 +130,8 @@ export interface MinionJobInput {
   idempotency_key?: string;
   /** Submission backpressure: cap waiting jobs with this name before inserting a new row. */
   maxWaiting?: number;
+  /** Insert as paused so callers can attach children before the parent is claimable. */
+  hold_until_children?: boolean;
 
   // v12: scheduler polish
   /**

--- a/src/core/remediation/run.ts
+++ b/src/core/remediation/run.ts
@@ -25,6 +25,29 @@ import type {
   StepResult,
 } from './types.ts';
 
+const RUN_SCOPED_IDEMPOTENCY_DELIMITER = ':run:';
+
+async function scopeTerminalRemediationIdempotencyKey(
+  engine: BrainEngine,
+  baseIdempotencyKey: string,
+  doctorRunId: string,
+  runStartedAt: Date,
+): Promise<void> {
+  await engine.executeRaw(
+    `UPDATE minion_jobs
+       SET idempotency_key = idempotency_key || $2 || $3 || ':job:' || id::text
+       WHERE idempotency_key = $1
+         AND status IN ('completed', 'failed', 'dead', 'cancelled')
+         AND created_at < $4`,
+    [
+      baseIdempotencyKey,
+      RUN_SCOPED_IDEMPOTENCY_DELIMITER,
+      doctorRunId,
+      runStartedAt.toISOString(),
+    ],
+  );
+}
+
 /**
  * Submit ordered Remediation jobs sequentially per D3, with D5 cascade
  * on failure and D7 scoped recheck between steps.
@@ -183,6 +206,7 @@ export async function runRemediation(
   const submitted: StepResult[] = [];
   const abortedIds = new Set<string>();
   const doctorRunId = crypto.randomUUID();
+  const runStartedAt = new Date();
 
   const { MinionQueue } = await import('../minions/queue.ts');
   const { waitForCompletion } = await import('../minions/wait-for-completion.ts');
@@ -222,6 +246,7 @@ export async function runRemediation(
   const runLoop = async (): Promise<void> => {
     let stepCount = 0;
     const totalSteps = recs.length;
+    const attemptedIds = new Set<string>(completedFromCheckpoint);
     while (recs.length > 0 && stepCount < maxJobs) {
       const step = recs[0];
       if (!step) break;
@@ -238,6 +263,7 @@ export async function runRemediation(
 
       // D5: if depends_on intersects aborted, skip + cascade
       if (step.depends_on && step.depends_on.some((d: string) => abortedIds.has(d))) {
+        attemptedIds.add(step.id);
         const result: StepResult = { step: stepCount, id: step.id, job_id: null, status: 'skipped_dep_aborted' };
         submitted.push(result);
         abortedIds.add(step.id);
@@ -247,8 +273,15 @@ export async function runRemediation(
       }
 
       hooks.onStepStart?.(stepCount, totalSteps, step);
+      attemptedIds.add(step.id);
       try {
         const isProtected = !!step.protected;
+        await scopeTerminalRemediationIdempotencyKey(
+          engine,
+          step.idempotency_key,
+          doctorRunId,
+          runStartedAt,
+        );
         const job = await queue.add(
           step.job,
           { ...step.params, doctor_run_id: doctorRunId },
@@ -305,7 +338,8 @@ export async function runRemediation(
       // steps with bumped retry suffix (D1).
       if (recs.length === 0 || stepCount >= maxJobs) break;
       const freshHealth = await engine.getHealth();
-      recs = computeRecommendations(freshHealth, ctx).filter((r) => r.status === 'remediable');
+      recs = computeRecommendations(freshHealth, ctx)
+        .filter((r) => r.status === 'remediable' && !attemptedIds.has(r.id));
     }
   };
 

--- a/test/ai/gateway-tools-schema.test.ts
+++ b/test/ai/gateway-tools-schema.test.ts
@@ -75,6 +75,84 @@ describe('gateway tool schema + message shape (real AI SDK v6)', () => {
     ).rejects.toThrow();
   });
 
+  it('REGRESSION: live synth replay with DB BigInt tool output passes ModelMessage schema', async () => {
+    const model = mockModel();
+    const tools = {
+      brain_query: {
+        description: 'query the brain',
+        inputSchema: jsonSchema({ type: 'object', properties: { query: { type: 'string' }, adaptive_return: { type: 'boolean' } } } as any),
+      },
+      brain_get_page: {
+        description: 'get a page',
+        inputSchema: jsonSchema({ type: 'object', properties: { slug: { type: 'string' } } } as any),
+      },
+    };
+    const replayMessages: ChatMessage[] = [
+      { role: 'user', content: [{ type: 'text', text: 'synthesize this transcript' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'I will search first.' },
+          { type: 'tool-call', toolCallId: 'toolu_01Cuq8THTQ8PubikSgFwhw8i', toolName: 'brain_query', input: { query: 'systematic debugging skill SkillOpt Codex', adaptive_return: true } },
+          { type: 'tool-call', toolCallId: 'toolu_01NqeZySmCtpWEmxRVPa1bQu', toolName: 'brain_query', input: { query: 'Sawyer debugging methodology mental models', adaptive_return: true } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'toolu_01Cuq8THTQ8PubikSgFwhw8i',
+            toolName: 'brain_query',
+            output: [{ page_id: 17775n, chunk_id: 183106n, slug: 'wiki/personal/reflections/2026-05-26-codex-systematic-debugging-oauth-session-cookie-secure-580411' }],
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'toolu_01NqeZySmCtpWEmxRVPa1bQu',
+            toolName: 'brain_query',
+            output: [{ page_id: 17760n, chunk_id: 183056n, slug: 'wiki/personal/reflections/2026-05-26-codex-systematic-debugging-cart-discount-rounding-d2aca5' }],
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Now let me search for one more page.' },
+          { type: 'tool-call', toolCallId: 'toolu_01XqcAd7vWeWhU9CHKCTQFH1', toolName: 'brain_query', input: { query: 'SkillOpt path mismatch', adaptive_return: true } },
+          { type: 'tool-call', toolCallId: 'toolu_01JdRsDHvFNCBsTeMqT8UiJ6', toolName: 'brain_get_page', input: { slug: 'wiki/personal/reflections/2026-05-26-codex-systematic-debugging-bigquery-receipt-timestamp-fea68e' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'toolu_01XqcAd7vWeWhU9CHKCTQFH1',
+            toolName: 'brain_query',
+            output: [{ page_id: 17773n, chunk_id: 183098n, slug: 'wiki/originals/ideas/2026-05-26-timeout-as-masking-error-timestamp-semantics-drift-fea68e' }],
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'toolu_01JdRsDHvFNCBsTeMqT8UiJ6',
+            toolName: 'brain_get_page',
+            output: { id: 17773n, slug: 'wiki/personal/reflections/2026-05-26-codex-systematic-debugging-bigquery-receipt-timestamp-fea68e' },
+          },
+        ],
+      },
+    ];
+
+    const result = await generateText({
+      model: model as any,
+      tools: tools as any,
+      messages: toModelMessages(replayMessages) as any,
+    });
+
+    expect(result.text).toBe('ok');
+    const prompt = model.doGenerateCalls[0]!.prompt as any[];
+    expect(prompt.map((m) => m.role)).toEqual(['user', 'assistant', 'tool', 'assistant', 'tool']);
+    expect(prompt.at(-1).content[1].output.value.id).toBe('17773');
+  });
+
   it('REGRESSION: raw tool-result in a role:user message (pre-fix shape) is rejected by v6', async () => {
     const model = mockModel();
     const tools = {

--- a/test/ai/gateway-tools-schema.test.ts
+++ b/test/ai/gateway-tools-schema.test.ts
@@ -135,7 +135,11 @@ describe('gateway tool schema + message shape (real AI SDK v6)', () => {
             type: 'tool-result',
             toolCallId: 'toolu_01JdRsDHvFNCBsTeMqT8UiJ6',
             toolName: 'brain_get_page',
-            output: { id: 17773n, slug: 'wiki/personal/reflections/2026-05-26-codex-systematic-debugging-bigquery-receipt-timestamp-fea68e' },
+            output: {
+              id: 17773n,
+              slug: 'wiki/personal/reflections/2026-05-26-codex-systematic-debugging-bigquery-receipt-timestamp-fea68e',
+              updated_at: new Date('2026-06-21T12:34:56.000Z'),
+            },
           },
         ],
       },
@@ -151,6 +155,7 @@ describe('gateway tool schema + message shape (real AI SDK v6)', () => {
     const prompt = model.doGenerateCalls[0]!.prompt as any[];
     expect(prompt.map((m) => m.role)).toEqual(['user', 'assistant', 'tool', 'assistant', 'tool']);
     expect(prompt.at(-1).content[1].output.value.id).toBe('17773');
+    expect(prompt.at(-1).content[1].output.value.updated_at).toBe('2026-06-21T12:34:56.000Z');
   });
 
   it('REGRESSION: raw tool-result in a role:user message (pre-fix shape) is rejected by v6', async () => {

--- a/test/autopilot-failure-cooldown.test.ts
+++ b/test/autopilot-failure-cooldown.test.ts
@@ -91,27 +91,28 @@ describe('readRecentSourceFailures + isSourceInCooldown (PGLite)', () => {
   afterAll(async () => { await engine.disconnect(); });
   beforeEach(async () => { await resetPgliteState(engine); });
 
-  async function addJob(status: string, sourceId: string | null, finishedMinAgo: number): Promise<void> {
+  async function addJob(status: string, sourceId: string | null, finishedMinAgo: number, result?: Record<string, unknown>): Promise<void> {
     const finished = new Date(Date.now() - finishedMinAgo * 60_000).toISOString();
     const data = sourceId === null ? {} : { source_id: sourceId };
     await engine.executeRaw(
-      `INSERT INTO minion_jobs (name, status, data, finished_at) VALUES ('autopilot-cycle', $1, $2, $3)`,
-      [status, data, finished],
+      `INSERT INTO minion_jobs (name, status, data, finished_at, result) VALUES ('autopilot-cycle', $1, $2, $3, $4)`,
+      [status, data, finished, result ?? null],
     );
   }
 
-  test('groups dead/failed jobs by source with count + max(finished_at)', async () => {
+  test('groups dead/failed jobs and completed failed reports by source', async () => {
     await addJob('dead', 'repo-a', 5);
     await addJob('failed', 'repo-a', 2);
+    await addJob('completed', 'repo-a', 1, { status: 'partial', report: { status: 'partial' } });
     await addJob('dead', 'repo-b', 10);
-    await addJob('completed', 'repo-a', 1); // not counted
+    await addJob('completed', 'repo-b', 1, { status: 'ok', report: { status: 'ok' } }); // not counted
     const map = await readRecentSourceFailures(engine, { sinceMin: 120 });
-    expect(map.get('repo-a')?.count).toBe(2);
+    expect(map.get('repo-a')?.count).toBe(3);
     expect(map.get('repo-b')?.count).toBe(1);
     expect(map.has('repo-a')).toBe(true);
-    // last failed is the most recent of the two (2 min ago).
+    // last failed is the completed partial report (1 min ago).
     const lastA = map.get('repo-a')!.lastFailedAt.getTime();
-    expect(Date.now() - lastA).toBeLessThan(4 * 60_000);
+    expect(Date.now() - lastA).toBeLessThan(3 * 60_000);
   });
 
   test('null source_id rows are excluded (codex #6)', async () => {

--- a/test/autopilot-fanout-clamp.serial.test.ts
+++ b/test/autopilot-fanout-clamp.serial.test.ts
@@ -47,13 +47,13 @@ afterEach(() => {
   try { rmSync(auditDir, { recursive: true, force: true }); } catch { /* noop */ }
 });
 
-function writeStarted(concurrency: number): void {
-  const file = join(auditDir, computeSupervisorAuditFilename());
-  writeFileSync(file, JSON.stringify({
-    event: 'started', ts: new Date().toISOString(), supervisor_pid: 4242,
-    queue: 'default', concurrency,
-  }) + '\n', 'utf8');
-}
+  function writeStarted(concurrency: number, ts = new Date().toISOString()): void {
+    const file = join(auditDir, computeSupervisorAuditFilename());
+    writeFileSync(file, JSON.stringify({
+      event: 'started', ts, supervisor_pid: 4242,
+      queue: 'default', concurrency,
+    }) + '\n', 'utf8');
+  }
 
 describe('resolveEffectiveFanoutMax — clamp gated on live supervisor (#2194/codex #9)', () => {
   test('NO live holder → no clamp (stale audit row cannot shrink throughput)', async () => {
@@ -64,6 +64,18 @@ describe('resolveEffectiveFanoutMax — clamp gated on live supervisor (#2194/co
 
   test('live holder + concurrency 3 → clamp to max(1, 3-1) = 2', async () => {
     writeStarted(3);
+    const holder = await tryAcquireDbLock(engine, supervisorLockId('default'), SUPERVISOR_LOCK_TTL_MIN);
+    expect(holder).not.toBeNull();
+    try {
+      const n = await resolveEffectiveFanoutMax(engine, 'default');
+      expect(n).toBe(2);
+    } finally {
+      await holder!.release();
+    }
+  });
+
+  test('live holder + older started event still clamps after 24h supervisor uptime', async () => {
+    writeStarted(3, new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString());
     const holder = await tryAcquireDbLock(engine, supervisorLockId('default'), SUPERVISOR_LOCK_TTL_MIN);
     expect(holder).not.toBeNull();
     try {

--- a/test/autopilot-fanout-wiring.test.ts
+++ b/test/autopilot-fanout-wiring.test.ts
@@ -48,9 +48,13 @@ describe('autopilot.ts ↔ dispatchPerSource wiring', () => {
     expect(Math.abs(dispatchIdx - fullCycleIdx)).toBeLessThan(3000);
   });
 
-  test('updates lastFullCycleAt on dispatch (so the 60-min floor is honored)', () => {
-    // After the dispatchPerSource call, the lastFullCycleAt module var
-    // must update so the next tick doesn't immediately re-fan-out.
+  test('updates lastFullCycleAt only after a fresh no-op fanout window', () => {
+    // Queued source/global jobs can still fail after dispatch. The daemon's
+    // sleep floor should refresh only after readback proves there is no capped,
+    // active, newly-dispatched, or stale global work left to retry.
+    expect(AUTOPILOT_SRC).toMatch(/result\.skipped_active\.length === 0/);
+    expect(AUTOPILOT_SRC).toMatch(/result\.dispatched\.length === 0/);
+    expect(AUTOPILOT_SRC).toMatch(/result\.global_maintenance\.reason === 'fresh'/);
     expect(AUTOPILOT_SRC).toMatch(/lastFullCycleAt\s*=\s*Date\.now\(\)/);
   });
 

--- a/test/autopilot-fanout.test.ts
+++ b/test/autopilot-fanout.test.ts
@@ -17,7 +17,9 @@ import {
   selectSourcesForDispatch,
   resolveFanoutMax,
   dispatchPerSource,
+  readLiveAutopilotCycleSourceIds,
 } from '../src/commands/autopilot-fanout.ts';
+import { LAST_GLOBAL_AT_KEY } from '../src/core/cycle.ts';
 import type { SourceRow, BrainEngine } from '../src/core/engine.ts';
 
 function src(id: string, last_full_cycle_at?: string | null, extra: Record<string, unknown> = {}): SourceRow {
@@ -58,6 +60,10 @@ describe('isSourceStale', () => {
   test('source cycled 30min ago is fresh', () => {
     const past = new Date(NOW - 30 * 60_000).toISOString();
     expect(isSourceStale(src('a', past), NOW)).toBe(false);
+  });
+  test('source-scoped cycle timestamp is fresh even without legacy full-cycle timestamp', () => {
+    const past = new Date(NOW - 30 * 60_000).toISOString();
+    expect(isSourceStale(src('a', null, { last_source_cycle_at: past }), NOW)).toBe(false);
   });
   test('source cycled exactly at floor (60min) is stale (>=)', () => {
     const past = new Date(NOW - 60 * 60_000).toISOString();
@@ -158,7 +164,7 @@ describe('resolveFanoutMax', () => {
 describe('dispatchPerSource — integration with stubbed engine + queue', () => {
   type AddedJob = { name: string; data: unknown; opts: Record<string, unknown> };
 
-  function makeStubs(sources: SourceRow[], opts?: { listThrows?: boolean }) {
+  function makeStubs(sources: SourceRow[], opts?: { listThrows?: boolean; liveSourceIds?: string[] }) {
     const added: AddedJob[] = [];
     let nextId = 100;
     const engine = {
@@ -166,6 +172,13 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
       listAllSources: async () => {
         if (opts?.listThrows) throw new Error('sources table missing');
         return sources;
+      },
+      getConfig: async (key: string) => key === LAST_GLOBAL_AT_KEY ? new Date().toISOString() : null,
+      executeRaw: async (sql: string) => {
+        if (String(sql).includes(`data->>'source_id'`)) {
+          return (opts?.liveSourceIds ?? []).map((source_id) => ({ source_id }));
+        }
+        return [];
       },
     } as unknown as BrainEngine;
     const queue = {
@@ -243,6 +256,82 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
     expect(added.length).toBe(1);
   });
 
+  test('live source-cycle jobs are skipped before applying fanout cap', async () => {
+    const { engine, queue, added, fanoutOpts } = makeStubs([src('a'), src('b'), src('c')], { liveSourceIds: ['a'] });
+    fanoutOpts.fanoutMax = 1;
+    const result = await dispatchPerSource(engine, queue, fanoutOpts);
+
+    expect(result.dispatched).toEqual(['b']);
+    expect(result.skipped_active).toEqual(['a']);
+    expect(result.skipped_cap).toEqual(['c']);
+    expect(added.length).toBe(1);
+    expect((added[0].data as Record<string, unknown>).source_id).toBe('b');
+  });
+
+  test('live source-cycle jobs defer global maintenance', async () => {
+    const added: AddedJob[] = [];
+    const engine = {
+      kind: 'postgres' as const,
+      listAllSources: async () => [src('a')],
+      getConfig: async () => null,
+      executeRaw: async (sql: string) => {
+        if (String(sql).includes(`data->>'source_id'`)) return [{ source_id: 'a' }];
+        return [];
+      },
+    } as unknown as BrainEngine;
+    const queue = {
+      add: async (name: string, data: unknown, opts: Record<string, unknown>) => {
+        added.push({ name, data, opts });
+        return { id: added.length, parent_job_id: opts.parent_job_id ?? null };
+      },
+    } as unknown as Parameters<typeof dispatchPerSource>[1];
+    const result = await dispatchPerSource(engine, queue, {
+      repoPath: '/tmp',
+      slot: 's',
+      timeoutMs: 1,
+      fanoutMax: 4,
+      jsonMode: true,
+      emit: () => {},
+      log: () => {},
+    });
+
+    expect(result.skipped_active).toEqual(['a']);
+    expect(result.global_maintenance).toEqual({ dispatched: false, reason: 'deferred' });
+    expect(added.length).toBe(0);
+  });
+
+  test('held global parent is released when selected source submits are idempotency hits', async () => {
+    const updates: Array<{ sql: string; params?: unknown[] }> = [];
+    const engine = {
+      kind: 'postgres' as const,
+      listAllSources: async () => [src('a')],
+      getConfig: async () => null,
+      executeRaw: async (sql: string, params?: unknown[]) => {
+        updates.push({ sql: String(sql), params });
+        return [];
+      },
+    } as unknown as BrainEngine;
+    const queue = {
+      add: async (name: string, _data: unknown, opts: Record<string, unknown>) => {
+        if (name === 'autopilot-global-maintenance') return { id: 1, parent_job_id: null };
+        return { id: 99, parent_job_id: null, idempotency_key: opts.idempotency_key };
+      },
+    } as unknown as Parameters<typeof dispatchPerSource>[1];
+    const result = await dispatchPerSource(engine, queue, {
+      repoPath: '/tmp',
+      slot: 's',
+      timeoutMs: 1,
+      fanoutMax: 4,
+      jsonMode: true,
+      emit: () => {},
+      log: () => {},
+    });
+
+    expect(result.dispatched).toEqual([]);
+    expect(result.skipped_active).toEqual(['a']);
+    expect(updates.some((u) => u.sql.includes(`SET status = 'waiting'`) && u.params?.[0] === 1)).toBe(true);
+  });
+
   test('per-submit error does NOT abort the tick', async () => {
     const sources = [src('alpha'), src('boom'), src('charlie')];
     const added: AddedJob[] = [];
@@ -251,6 +340,8 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
     const engine = {
       kind: 'postgres' as const,
       listAllSources: async () => sources,
+      getConfig: async (key: string) => key === LAST_GLOBAL_AT_KEY ? new Date().toISOString() : null,
+      executeRaw: async () => [],
     } as unknown as BrainEngine;
     const queue = {
       add: async (name: string, data: unknown, opts: Record<string, unknown>) => {
@@ -306,5 +397,25 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
     expect(result.dispatched.length).toBe(0);
     expect(result.skipped_fresh.length).toBe(2);
     expect(added.length).toBe(0);
+  });
+});
+
+describe('readLiveAutopilotCycleSourceIds', () => {
+  test('returns non-empty source ids from non-terminal autopilot-cycle jobs', async () => {
+    const engine = {
+      executeRaw: async () => [
+        { source_id: 'alpha' },
+        { source_id: null },
+        { source_id: 'beta' },
+      ],
+    } as unknown as BrainEngine;
+    expect(await readLiveAutopilotCycleSourceIds(engine)).toEqual(new Set(['alpha', 'beta']));
+  });
+
+  test('fails open to an empty set when job readback is unavailable', async () => {
+    const engine = {
+      executeRaw: async () => { throw new Error('old schema'); },
+    } as unknown as BrainEngine;
+    expect(await readLiveAutopilotCycleSourceIds(engine)).toEqual(new Set());
   });
 });

--- a/test/autopilot-global-maintenance.test.ts
+++ b/test/autopilot-global-maintenance.test.ts
@@ -14,6 +14,7 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:tes
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
 import { registerBuiltinHandlers } from '../src/commands/jobs.ts';
+import { MinionQueue } from '../src/core/minions/queue.ts';
 import {
   ALL_PHASES,
   GLOBAL_PHASES,
@@ -26,6 +27,7 @@ import {
   isGlobalMaintenanceStale,
   dispatchPerSource,
 } from '../src/commands/autopilot-fanout.ts';
+import { PROTECTED_JOB_NAMES } from '../src/core/minions/protected-names.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 
 describe('cycle phase partition (#2194 fix #3)', () => {
@@ -62,11 +64,16 @@ describe('isGlobalMaintenanceStale', () => {
 });
 
 describe('dispatchGlobalMaintenance — single-flight gate', () => {
+  test('global maintenance job name is protected from remote submitters', () => {
+    expect(PROTECTED_JOB_NAMES.has('autopilot-global-maintenance')).toBe(true);
+  });
+
   function stubs(lastGlobalAt: string | null) {
     const added: Array<{ name: string; data: any; opts: any }> = [];
     const engine = {
       kind: 'postgres' as const,
       getConfig: async (k: string) => (k === LAST_GLOBAL_AT_KEY ? lastGlobalAt : null),
+      executeRaw: async () => [],
     } as unknown as BrainEngine;
     const queue = {
       add: async (name: string, data: unknown, opts: Record<string, unknown>) => {
@@ -96,7 +103,7 @@ describe('dispatchGlobalMaintenance — single-flight gate', () => {
 });
 
 describe('dispatchPerSource — per-source jobs carry NON_GLOBAL phases (no embed)', () => {
-  test('each per-source job sets phases = NON_GLOBAL_PHASES', async () => {
+  test('stale global maintenance waits as parent of per-source jobs', async () => {
     const sources = [{ id: 'repo-a', name: 'a', config: {} }, { id: 'repo-b', name: 'b', config: {} }];
     const added: any[] = [];
     const engine = {
@@ -106,12 +113,35 @@ describe('dispatchPerSource — per-source jobs carry NON_GLOBAL phases (no embe
       executeRaw: async () => [],
     } as unknown as BrainEngine;
     const queue = { add: async (name: string, data: unknown, opts: unknown) => { added.push({ name, data, opts }); return { id: added.length }; } } as any;
-    await dispatchPerSource(engine, queue, { repoPath: '/tmp', slot: 's', timeoutMs: 1, fanoutMax: 4, jsonMode: true, emit: () => {}, log: () => {} });
-    expect(added.length).toBe(2);
-    for (const j of added) {
+    const result = await dispatchPerSource(engine, queue, { repoPath: '/tmp', slot: 's', timeoutMs: 1, fanoutMax: 4, jsonMode: true, emit: () => {}, log: () => {} });
+    expect(result.global_maintenance.dispatched).toBe(true);
+    expect(added.length).toBe(3);
+    expect(added[0].name).toBe('autopilot-global-maintenance');
+    expect(added[0].opts.delay).toBeUndefined();
+    const sourceJobs = added.filter((j) => j.name === 'autopilot-cycle');
+    expect(sourceJobs.length).toBe(2);
+    for (const j of sourceJobs) {
       expect(j.data.phases).toEqual(NON_GLOBAL_PHASES);
       expect(j.data.phases).not.toContain('embed');
+      expect(j.opts.parent_job_id).toBe(1);
     }
+  });
+
+  test('fanout cap defers global maintenance until all stale sources can run', async () => {
+    const sources = [{ id: 'repo-a', name: 'a', config: {} }, { id: 'repo-b', name: 'b', config: {} }];
+    const added: any[] = [];
+    const engine = {
+      kind: 'postgres' as const,
+      listAllSources: async () => sources,
+      getConfig: async () => null,
+      executeRaw: async () => [],
+    } as unknown as BrainEngine;
+    const queue = { add: async (name: string, data: unknown, opts: unknown) => { added.push({ name, data, opts }); return { id: added.length }; } } as any;
+    const result = await dispatchPerSource(engine, queue, { repoPath: '/tmp', slot: 's', timeoutMs: 1, fanoutMax: 1, jsonMode: true, emit: () => {}, log: () => {} });
+    expect(result.dispatched.length).toBe(1);
+    expect(result.skipped_cap.length).toBe(1);
+    expect(result.global_maintenance).toEqual({ dispatched: false, reason: 'deferred' });
+    expect(added.map((j) => j.name)).toEqual(['autopilot-cycle']);
   });
 });
 
@@ -120,6 +150,127 @@ describe('autopilot-global-maintenance handler stamps last_global_at (PGLite)', 
   beforeAll(async () => { engine = new PGLiteEngine(); await engine.connect({}); await engine.initSchema(); }, 30000);
   afterAll(async () => { await engine.disconnect(); });
   beforeEach(async () => { await resetPgliteState(engine); });
+
+  test('real queue holds global maintenance until its source children finish', async () => {
+    await engine.setConfig('version', '119');
+    await engine.setConfig(LAST_GLOBAL_AT_KEY, 'not-a-date');
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config)
+       VALUES ('repo-a', 'repo-a', '/tmp/repo-a', '{}'::jsonb)`,
+    );
+    const queue = new MinionQueue(engine);
+    const result = await dispatchPerSource(engine, queue, {
+      repoPath: '/tmp',
+      slot: 's',
+      timeoutMs: 1,
+      fanoutMax: 4,
+      jsonMode: true,
+      emit: () => {},
+      log: () => {},
+    });
+    expect(result.global_maintenance.dispatched).toBe(true);
+
+    const rows = await engine.executeRaw<{ name: string; status: string; parent_job_id: number | null }>(
+      `SELECT name, status, parent_job_id FROM minion_jobs ORDER BY id`,
+    );
+    expect(rows).toEqual([
+      { name: 'autopilot-global-maintenance', status: 'waiting-children', parent_job_id: null },
+      { name: 'autopilot-cycle', status: 'waiting', parent_job_id: result.global_maintenance.parent_job_id ?? null },
+    ]);
+  });
+
+  test('dispatch reuses a live global maintenance job instead of queuing a duplicate', async () => {
+    await engine.setConfig('version', '119');
+    await engine.setConfig(LAST_GLOBAL_AT_KEY, 'not-a-date');
+    await engine.executeRaw(
+      `INSERT INTO minion_jobs (name, queue, status, data)
+       VALUES ('autopilot-global-maintenance', 'default', 'active', '{}'::jsonb)`,
+    );
+    const existing = await engine.executeRaw<{ id: number }>(
+      `SELECT id FROM minion_jobs WHERE name = 'autopilot-global-maintenance'`,
+    );
+    const queue = new MinionQueue(engine);
+    const result = await dispatchGlobalMaintenance(engine, queue, {
+      repoPath: '/tmp',
+      slot: 'next-slot',
+      timeoutMs: 1,
+      jsonMode: true,
+      emit: () => {},
+    });
+    const rows = await engine.executeRaw<{ id: number }>(
+      `SELECT id FROM minion_jobs WHERE name = 'autopilot-global-maintenance' ORDER BY id`,
+    );
+    expect(result.dispatched).toBe(true);
+    expect(result.job_id).toBe(existing[0]!.id);
+    expect(result.parent_job_id).toBeUndefined();
+    expect(rows.map((r) => r.id)).toEqual([existing[0]!.id]);
+  });
+
+  test('per-source jobs are not attached to an already-active global maintenance job', async () => {
+    await engine.setConfig('version', '119');
+    await engine.setConfig(LAST_GLOBAL_AT_KEY, 'not-a-date');
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config)
+       VALUES ('repo-a', 'repo-a', '/tmp/repo-a', '{}'::jsonb)`,
+    );
+    await engine.executeRaw(
+      `INSERT INTO minion_jobs (name, queue, status, data)
+       VALUES ('autopilot-global-maintenance', 'default', 'active', '{}'::jsonb)`,
+    );
+
+    const queue = new MinionQueue(engine);
+    const result = await dispatchPerSource(engine, queue, {
+      repoPath: '/tmp',
+      slot: 's',
+      timeoutMs: 1,
+      fanoutMax: 4,
+      jsonMode: true,
+      emit: () => {},
+      log: () => {},
+    });
+    expect(result.global_maintenance.parent_job_id).toBeUndefined();
+
+    const rows = await engine.executeRaw<{ name: string; status: string; parent_job_id: number | null }>(
+      `SELECT name, status, parent_job_id FROM minion_jobs ORDER BY id`,
+    );
+    expect(rows).toEqual([
+      { name: 'autopilot-global-maintenance', status: 'active', parent_job_id: null },
+      { name: 'autopilot-cycle', status: 'waiting', parent_job_id: null },
+    ]);
+  });
+
+  test('orphaned paused global maintenance row is reused as the held parent', async () => {
+    await engine.setConfig('version', '119');
+    await engine.setConfig(LAST_GLOBAL_AT_KEY, 'not-a-date');
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path, config)
+       VALUES ('repo-a', 'repo-a', '/tmp/repo-a', '{}'::jsonb)`,
+    );
+    await engine.executeRaw(
+      `INSERT INTO minion_jobs (name, queue, status, data)
+       VALUES ('autopilot-global-maintenance', 'default', 'paused', '{}'::jsonb)`,
+    );
+
+    const queue = new MinionQueue(engine);
+    const result = await dispatchPerSource(engine, queue, {
+      repoPath: '/tmp',
+      slot: 's',
+      timeoutMs: 1,
+      fanoutMax: 4,
+      jsonMode: true,
+      emit: () => {},
+      log: () => {},
+    });
+
+    expect(result.global_maintenance.parent_job_id).toBe(result.global_maintenance.job_id);
+    const rows = await engine.executeRaw<{ name: string; status: string; parent_job_id: number | null }>(
+      `SELECT name, status, parent_job_id FROM minion_jobs ORDER BY id`,
+    );
+    expect(rows).toEqual([
+      { name: 'autopilot-global-maintenance', status: 'waiting-children', parent_job_id: null },
+      { name: 'autopilot-cycle', status: 'waiting', parent_job_id: result.global_maintenance.job_id ?? null },
+    ]);
+  });
 
   async function captureHandlers() {
     const handlers = new Map<string, (job: any) => Promise<any>>();
@@ -134,13 +285,27 @@ describe('autopilot-global-maintenance handler stamps last_global_at (PGLite)', 
     const handler = handlers.get('autopilot-global-maintenance');
     expect(handler).toBeTruthy();
 
-    const result = await handler!({ data: { phases: ['orphans', 'embed'] }, signal: undefined });
+    const result = await handler!({ data: { phases: ['orphans'] }, signal: undefined });
     // The cycle ran the requested global phases (DB-only on an empty brain).
     expect(result.report.phases.some((p: any) => p.phase === 'orphans')).toBe(true);
-    expect(['ok', 'clean', 'partial']).toContain(result.report.status);
+    expect(['ok', 'clean']).toContain(result.report.status);
     // Freshness stamped so the dispatch gate backs off.
     const stamped = await engine.getConfig(LAST_GLOBAL_AT_KEY);
     expect(stamped).not.toBeNull();
     expect(Number.isFinite(new Date(stamped!).getTime())).toBe(true);
+  });
+
+  test('partial global maintenance does not stamp autopilot.last_global_at', async () => {
+    await engine.unsetConfig(LAST_GLOBAL_AT_KEY);
+    const handlers = await captureHandlers();
+    const handler = handlers.get('autopilot-global-maintenance');
+    expect(handler).toBeTruthy();
+
+    const result = await handler!({
+      data: { repoPath: '/definitely-does-not-exist-for-global-maintenance-test', phases: ['lint'] },
+      signal: { aborted: false },
+    });
+    expect(['partial', 'failed']).toContain(result.report.status);
+    expect(await engine.getConfig(LAST_GLOBAL_AT_KEY)).toBeNull();
   });
 });

--- a/test/budget-reconcile.test.ts
+++ b/test/budget-reconcile.test.ts
@@ -1,0 +1,138 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildBudgetReconcileReport,
+  parseBudgetReconcileArgs,
+  runBudget,
+} from '../src/commands/budget.ts';
+import { withEnv } from './helpers/with-env.ts';
+
+let tmp: string;
+let oldStdoutWrite: typeof process.stdout.write;
+let stdoutCapture: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'gbrain-budget-reconcile-'));
+  stdoutCapture = '';
+  oldStdoutWrite = process.stdout.write.bind(process.stdout);
+  (process.stdout as { write: unknown }).write = (chunk: string | Uint8Array): boolean => {
+    stdoutCapture += typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  };
+});
+
+afterEach(() => {
+  (process.stdout as { write: unknown }).write = oldStdoutWrite;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeJsonl(path: string, rows: Array<Record<string, unknown>>): void {
+  writeFileSync(path, rows.map((row) => JSON.stringify(row)).join('\n') + '\n', 'utf-8');
+}
+
+describe('budget reconcile readback', () => {
+  test('summarizes recent Anthropic budget ledger rows with cache tokens', async () => {
+    writeJsonl(join(tmp, 'budget-2026-W25.jsonl'), [
+      {
+        schema_version: 1,
+        ts: '2026-06-20T12:00:00.000Z',
+        event: 'record',
+        label: 'dream.synthesize',
+        kind: 'chat',
+        model: 'anthropic:claude-sonnet-4-6',
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_tokens: 20,
+        cache_creation_tokens: 10,
+        actual_cost_usd: 0.25,
+      },
+      {
+        schema_version: 1,
+        ts: '2026-06-20T12:05:00.000Z',
+        event: 'record',
+        label: 'deepseek',
+        kind: 'chat',
+        model: 'deepseek:deepseek-v4-pro',
+        actual_cost_usd: 0.99,
+      },
+      {
+        schema_version: 1,
+        ts: '2026-06-20T12:10:00.000Z',
+        event: 'reserve',
+        kind: 'chat',
+        model: 'anthropic:claude-sonnet-4-6',
+        projected_cost_usd: 10,
+      },
+    ]);
+
+    await withEnv({ GBRAIN_AUDIT_DIR: tmp }, async () => {
+      const args = parseBudgetReconcileArgs(['--days', '7'], new Date('2026-06-21T00:00:00.000Z'));
+      const report = buildBudgetReconcileReport(args);
+      expect(report.internal.records).toBe(1);
+      expect(report.internal.cost_usd).toBe(0.25);
+      expect(report.internal.cache_read_tokens).toBe(20);
+      expect(report.internal.cache_creation_tokens).toBe(10);
+      expect(report.internal.by_model[0]).toEqual({
+        model: 'anthropic:claude-sonnet-4-6',
+        records: 1,
+        cost_usd: 0.25,
+      });
+    });
+  });
+
+  test('compares internal ledger to a local external receipt export', async () => {
+    writeJsonl(join(tmp, 'budget-2026-W25.jsonl'), [
+      {
+        ts: '2026-06-20T12:00:00.000Z',
+        event: 'record',
+        kind: 'chat',
+        model: 'claude-haiku-4-5',
+        actual_cost_usd: 0.25,
+      },
+    ]);
+    const external = join(tmp, 'anthropic-export.jsonl');
+    writeJsonl(external, [
+      {
+        timestamp: '2026-06-20T12:01:00.000Z',
+        provider: 'anthropic',
+        model: 'claude-haiku-4-5',
+        cost_usd: 0.245,
+      },
+    ]);
+
+    await withEnv({ GBRAIN_AUDIT_DIR: tmp }, async () => {
+      const args = parseBudgetReconcileArgs(
+        ['--days', '7', '--external-receipts', external],
+        new Date('2026-06-21T00:00:00.000Z'),
+      );
+      const report = buildBudgetReconcileReport(args);
+      expect(report.external?.records).toBe(1);
+      expect(report.comparison.delta_usd).toBeCloseTo(0.005, 8);
+      expect(report.comparison.within_one_cent).toBe(true);
+    });
+  });
+
+  test('runBudget writes an optional JSON receipt path', async () => {
+    writeJsonl(join(tmp, 'budget.jsonl'), [
+      {
+        ts: '2026-06-20T12:00:00.000Z',
+        event: 'record',
+        kind: 'chat',
+        model: 'anthropic:claude-sonnet-4-6',
+        actual_cost_usd: 0.1,
+      },
+    ]);
+    const out = join(tmp, 'receipt.json');
+    await withEnv({ GBRAIN_AUDIT_DIR: tmp }, async () => {
+      const rc = await runBudget(['reconcile', '--days', '30', '--json', '--out', out]);
+      expect(rc).toBe(0);
+      expect(existsSync(out)).toBe(true);
+      const written = JSON.parse(readFileSync(out, 'utf-8'));
+      const printed = JSON.parse(stdoutCapture);
+      expect(written.internal.cost_usd).toBe(0.1);
+      expect(printed.internal.cost_usd).toBe(0.1);
+    });
+  });
+});

--- a/test/cycle-last-full-cycle-at.test.ts
+++ b/test/cycle-last-full-cycle-at.test.ts
@@ -1,7 +1,7 @@
 /**
- * v0.38 — runCycle exit hook writes last_full_cycle_at on per-source
- * cycles. Closes codex round-1 P0-5 (write site for last_full_cycle_at
- * was unspecified pre-PR).
+ * v0.38 — runCycle exit hook writes last_source_cycle_at on per-source
+ * cycles. Per-source split cycles must not stamp last_full_cycle_at because
+ * global maintenance runs separately.
  *
  * Conditions for write:
  *   - opts.sourceId is set (legacy callers without sourceId skip the write)
@@ -15,7 +15,7 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:tes
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
 import { withEnv } from './helpers/with-env.ts';
-import { runCycle } from '../src/core/cycle.ts';
+import { NON_GLOBAL_PHASES, runCycle } from '../src/core/cycle.ts';
 import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -27,7 +27,7 @@ let brainDir: string;
 // GBRAIN_HOME per test, parallel gbrain processes on the same machine
 // (including sibling Conductor worktrees running their own tests)
 // contend for the same lock file — runCycle returns 'skipped' and the
-// last_full_cycle_at exit hook silently no-ops. Each test wraps its
+// last_source_cycle_at exit hook silently no-ops. Each test wraps its
 // body in `withEnv({GBRAIN_HOME: <unique tmp>})` so the file lock path
 // becomes per-test.
 let gbrainHome: string;
@@ -57,6 +57,14 @@ async function seedSource(id: string): Promise<void> {
   );
 }
 
+async function readLastSourceCycleAt(sourceId: string): Promise<string | null> {
+  const sources = await engine.listAllSources();
+  const s = sources.find(x => x.id === sourceId);
+  if (!s) return null;
+  const raw = s.config?.last_source_cycle_at;
+  return typeof raw === 'string' ? raw : null;
+}
+
 async function readLastFullCycleAt(sourceId: string): Promise<string | null> {
   const sources = await engine.listAllSources();
   const s = sources.find(x => x.id === sourceId);
@@ -65,11 +73,11 @@ async function readLastFullCycleAt(sourceId: string): Promise<string | null> {
   return typeof raw === 'string' ? raw : null;
 }
 
-describe('runCycle last_full_cycle_at exit hook', () => {
-  test('per-source cycle with status=ok writes timestamp', async () => {
+describe('runCycle last_source_cycle_at exit hook', () => {
+  test('manual per-source cycle with status=ok writes source and legacy full-cycle timestamps', async () => {
     await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
       await seedSource('alpha');
-      const before = await readLastFullCycleAt('alpha');
+      const before = await readLastSourceCycleAt('alpha');
       expect(before).toBeNull();
 
       // Run a minimal cycle: just lint (filesystem, no DB writes, always returns 'ok')
@@ -82,11 +90,44 @@ describe('runCycle last_full_cycle_at exit hook', () => {
       // lint on an empty dir returns ok+clean+0 fixes
       expect(['ok', 'clean']).toContain(report.status);
 
-      const after = await readLastFullCycleAt('alpha');
+      const after = await readLastSourceCycleAt('alpha');
       expect(after).not.toBeNull();
+      expect(await readLastFullCycleAt('alpha')).not.toBeNull();
       const writtenMs = new Date(after!).getTime();
       expect(writtenMs).toBeGreaterThanOrEqual(t0);
       expect(writtenMs).toBeLessThanOrEqual(Date.now() + 1000);
+    });
+  });
+
+  test('partial split autopilot per-source cycle does not mark source fresh', async () => {
+    await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
+      await seedSource('split-alpha');
+
+      const report = await runCycle(engine, {
+        brainDir,
+        sourceId: 'split-alpha',
+        phases: NON_GLOBAL_PHASES,
+      });
+      expect(report.status).toBe('partial');
+
+      expect(await readLastSourceCycleAt('split-alpha')).toBeNull();
+      expect(await readLastFullCycleAt('split-alpha')).toBeNull();
+    });
+  });
+
+  test('clean split autopilot per-source cycle writes source timestamp without legacy full-cycle stamp', async () => {
+    await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
+      await seedSource('split-clean');
+
+      const report = await runCycle(engine, {
+        brainDir: null,
+        sourceId: 'split-clean',
+        phases: NON_GLOBAL_PHASES,
+      });
+      expect(report.status).toBe('clean');
+
+      expect(await readLastSourceCycleAt('split-clean')).not.toBeNull();
+      expect(await readLastFullCycleAt('split-clean')).toBeNull();
     });
   });
 
@@ -99,7 +140,7 @@ describe('runCycle last_full_cycle_at exit hook', () => {
         phases: ['lint'],
       });
       // No per-source write happens; default source's config stays empty.
-      const after = await readLastFullCycleAt('default-like');
+      const after = await readLastSourceCycleAt('default-like');
       expect(after).toBeNull();
     });
   });
@@ -113,7 +154,7 @@ describe('runCycle last_full_cycle_at exit hook', () => {
         phases: ['lint'],
         dryRun: true,
       });
-      const after = await readLastFullCycleAt('beta');
+      const after = await readLastSourceCycleAt('beta');
       expect(after).toBeNull();
     });
   });
@@ -137,7 +178,7 @@ describe('runCycle last_full_cycle_at exit hook', () => {
       });
       expect(report.status).toBe('skipped');
       expect(report.reason).toBe('cycle_already_running');
-      const after = await readLastFullCycleAt('gamma');
+      const after = await readLastSourceCycleAt('gamma');
       expect(after).toBeNull();
     });
   });
@@ -146,12 +187,12 @@ describe('runCycle last_full_cycle_at exit hook', () => {
     await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
       await seedSource('delta');
       await runCycle(engine, { brainDir, sourceId: 'delta', phases: ['lint'] });
-      const first = await readLastFullCycleAt('delta');
+      const first = await readLastSourceCycleAt('delta');
       expect(first).not.toBeNull();
       // Wait 10ms so the timestamp can advance
       await new Promise(r => setTimeout(r, 10));
       await runCycle(engine, { brainDir, sourceId: 'delta', phases: ['lint'] });
-      const second = await readLastFullCycleAt('delta');
+      const second = await readLastSourceCycleAt('delta');
       expect(second).not.toBeNull();
       expect(new Date(second!).getTime()).toBeGreaterThan(new Date(first!).getTime());
     });

--- a/test/doctor-cycle-freshness.test.ts
+++ b/test/doctor-cycle-freshness.test.ts
@@ -29,9 +29,10 @@ beforeEach(async () => {
 const NOW = Date.parse('2026-05-22T12:00:00.000Z');
 const agoH = (h: number) => new Date(NOW - h * 3600_000).toISOString();
 
-async function seed(id: string, lastFullCycleAt?: string, opts: { local_path?: string | null } = {}): Promise<void> {
-  const config = lastFullCycleAt
-    ? JSON.stringify({ last_full_cycle_at: lastFullCycleAt })
+async function seed(id: string, lastCycleAt?: string, opts: { local_path?: string | null; field?: 'last_full_cycle_at' | 'last_source_cycle_at' } = {}): Promise<void> {
+  const field = opts.field ?? 'last_full_cycle_at';
+  const config = lastCycleAt
+    ? JSON.stringify({ [field]: lastCycleAt })
     : '{}';
   const localPath = opts.local_path === undefined ? `/tmp/${id}` : opts.local_path;
   await engine.executeRaw(
@@ -79,12 +80,19 @@ describe('doctor checkCycleFreshness', () => {
     expect(result.message).toMatch(/gbrain dream --source/);
   });
 
-  test('source with NO last_full_cycle_at (never cycled) returns fail', async () => {
+  test('source with NO cycle timestamp (never cycled) returns fail', async () => {
     await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
     await seed('virgin');
     const result = await checkCycleFreshness(engine, { nowMs: NOW });
     expect(result.status).toBe('fail');
-    expect(result.message).toMatch(/never completed a full cycle/);
+    expect(result.message).toMatch(/never completed a source cycle/);
+  });
+
+  test('source with last_source_cycle_at 2h ago returns ok without legacy full-cycle stamp', async () => {
+    await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
+    await seed('split-fresh', agoH(2), { field: 'last_source_cycle_at' });
+    const result = await checkCycleFreshness(engine, { nowMs: NOW });
+    expect(result.status).toBe('ok');
   });
 
   test('mixed sources: highest severity wins (fail > warn > ok)', async () => {
@@ -102,7 +110,7 @@ describe('doctor checkCycleFreshness', () => {
     await seed('clock-skewed', future);
     const result = await checkCycleFreshness(engine, { nowMs: NOW });
     expect(result.status).toBe('warn');
-    expect(result.message).toMatch(/future last_full_cycle_at/);
+    expect(result.message).toMatch(/future cycle timestamp/);
   });
 
   test('unparseable last_full_cycle_at returns warn', async () => {

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -93,6 +93,30 @@ describe('doctor command', () => {
     expect(source).toContain('gbrain repair-jsonb');
   });
 
+  test('doctor remediate does not re-run an attempted recommendation in the same pass', async () => {
+    const source = await Bun.file(new URL('../src/core/remediation/run.ts', import.meta.url)).text();
+    expect(source).toContain('const attemptedIds = new Set<string>(completedFromCheckpoint);');
+    expect(source).toContain('attemptedIds.add(step.id);');
+    expect(source).toContain("r.status === 'remediable' && !attemptedIds.has(r.id)");
+  });
+
+  test('doctor remediate scopes minion idempotency keys to the current run', async () => {
+    const source = await Bun.file(new URL('../src/core/remediation/run.ts', import.meta.url)).text();
+    expect(source).toContain('RUN_SCOPED_IDEMPOTENCY_DELIMITER');
+    expect(source).toContain("SET idempotency_key = idempotency_key || $2 || $3 || ':job:' || id::text");
+    expect(source).toContain('idempotency_key: step.idempotency_key');
+  });
+
+  test('doctor remediate frees old terminal history without breaking active single-flight', async () => {
+    const source = await Bun.file(new URL('../src/core/remediation/run.ts', import.meta.url)).text();
+    expect(source).toContain('async function scopeTerminalRemediationIdempotencyKey(');
+    expect(source).toContain("status IN ('completed', 'failed', 'dead', 'cancelled')");
+    expect(source).toContain('AND created_at < $4');
+    expect(source).toContain('await scopeTerminalRemediationIdempotencyKey(');
+    expect(source).toContain('const runStartedAt = new Date();');
+    expect(source).toContain('idempotency_key: step.idempotency_key');
+  });
+
   test('jsonb_integrity check covers the four JSONB sites fixed in v0.12.1', async () => {
     const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
     expect(source).toMatch(/table:\s*'pages'.*col:\s*'frontmatter'/);

--- a/test/e2e/autopilot-cooldown-parity.test.ts
+++ b/test/e2e/autopilot-cooldown-parity.test.ts
@@ -18,17 +18,18 @@ import { readRecentSourceFailures } from '../../src/commands/autopilot-fanout.ts
 const SKIP_PG = !hasDatabase();
 
 async function seed(engine: BrainEngine): Promise<void> {
-  const rows: Array<[string, Record<string, unknown>, number]> = [
-    ['dead', { source_id: 'repo-a' }, 5],
-    ['failed', { source_id: 'repo-a' }, 2],
-    ['dead', { source_id: 'repo-b' }, 10],
-    ['completed', { source_id: 'repo-a' }, 1], // excluded (not a failure)
-    ['dead', {}, 3],                            // excluded (null source_id, codex #6)
+  const rows: Array<[string, Record<string, unknown>, number, Record<string, unknown> | null]> = [
+    ['dead', { source_id: 'repo-a' }, 5, null],
+    ['failed', { source_id: 'repo-a' }, 2, null],
+    ['completed', { source_id: 'repo-a' }, 1, { status: 'partial', report: { status: 'partial' } }],
+    ['dead', { source_id: 'repo-b' }, 10, null],
+    ['completed', { source_id: 'repo-b' }, 1, { status: 'ok', report: { status: 'ok' } }], // excluded
+    ['dead', {}, 3, null], // excluded (null source_id, codex #6)
   ];
-  for (const [status, data, minAgo] of rows) {
+  for (const [status, data, minAgo, result] of rows) {
     await engine.executeRaw(
-      `INSERT INTO minion_jobs (name, status, data, finished_at) VALUES ('autopilot-cycle', $1, $2, $3)`,
-      [status, data, new Date(Date.now() - minAgo * 60_000).toISOString()],
+      `INSERT INTO minion_jobs (name, status, data, finished_at, result) VALUES ('autopilot-cycle', $1, $2, $3, $4)`,
+      [status, data, new Date(Date.now() - minAgo * 60_000).toISOString(), result],
     );
   }
 }
@@ -46,7 +47,7 @@ describe('failure-cooldown query — PGLite', () => {
 
   test('groups failures by source, excludes completed + null-source', async () => {
     const map = await readRecentSourceFailures(engine, { sinceMin: 120 });
-    expect(summarize(map)).toEqual({ 'repo-a': 2, 'repo-b': 1 });
+    expect(summarize(map)).toEqual({ 'repo-a': 3, 'repo-b': 1 });
   });
 });
 
@@ -57,6 +58,6 @@ describe('failure-cooldown query — PGLite', () => {
 
   test('Postgres returns the SAME groupings as PGLite', async () => {
     const map = await readRecentSourceFailures(engine, { sinceMin: 120 });
-    expect(summarize(map)).toEqual({ 'repo-a': 2, 'repo-b': 1 });
+    expect(summarize(map)).toEqual({ 'repo-a': 3, 'repo-b': 1 });
   });
 });

--- a/test/propose-takes.test.ts
+++ b/test/propose-takes.test.ts
@@ -23,8 +23,9 @@ import {
   extractExistingTakesForDedup,
   PROPOSE_TAKES_PROMPT_VERSION,
   type ProposeTakesExtractor,
-  type ProposedTake,
 } from '../src/core/cycle/propose-takes.ts';
+import { getCurrentBudgetTracker, withBudgetTracker } from '../src/core/ai/gateway.ts';
+import { BudgetExhausted, BudgetTracker } from '../src/core/budget/budget-tracker.ts';
 import type { OperationContext } from '../src/core/operations.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 import type { Page } from '../src/core/types.ts';
@@ -36,11 +37,18 @@ interface CapturedSql {
   params: unknown[];
 }
 
+interface CapturedPutPage {
+  slug: string;
+  page: Record<string, unknown>;
+  opts?: { sourceId?: string };
+}
+
 function buildMockEngine(opts: {
   pages: Page[];
   existingProposals?: Set<string>; // composite-key strings already in take_proposals
-}): { engine: BrainEngine; captured: CapturedSql[] } {
+}): { engine: BrainEngine; captured: CapturedSql[]; putPages: CapturedPutPage[] } {
   const captured: CapturedSql[] = [];
+  const putPages: CapturedPutPage[] = [];
   const existing = opts.existingProposals ?? new Set<string>();
 
   const engine = {
@@ -60,9 +68,24 @@ function buildMockEngine(opts: {
       // INSERT — return nothing
       return [];
     },
+    async putPage(slug: string, page: Record<string, unknown>, putOpts?: { sourceId?: string }) {
+      putPages.push({ slug, page, opts: putOpts });
+      return {
+        id: putPages.length,
+        slug,
+        type: page.type ?? 'extract_receipt',
+        title: page.title ?? slug,
+        compiled_truth: page.compiled_truth ?? '',
+        timeline: '',
+        frontmatter: page.frontmatter ?? {},
+        source_id: putOpts?.sourceId ?? 'default',
+        created_at: new Date(),
+        updated_at: new Date(),
+      } as Page;
+    },
   } as unknown as BrainEngine;
 
-  return { engine, captured };
+  return { engine, captured, putPages };
 }
 
 function buildPage(opts: { slug: string; body: string; sourceId?: string }): Page {
@@ -383,5 +406,258 @@ New prose appended here.`;
     expect(runIdA).toBe(runIdB);
     expect(typeof runIdA).toBe('string');
     expect((runIdA as string).startsWith('propose-')).toBe(true);
+  });
+
+  test('receipt and rollup record active BudgetTracker spend', async () => {
+    const pages = [buildPage({ slug: 'wiki/costed', body: 'This market will expand faster than consensus expects.' })];
+    const { engine, captured, putPages } = buildMockEngine({ pages });
+    const extractor: ProposeTakesExtractor = async () => {
+      const tracker = getCurrentBudgetTracker();
+      expect(tracker).not.toBeNull();
+      tracker!.record({
+        modelId: 'anthropic:claude-sonnet-4-6',
+        inputTokens: 1_000,
+        outputTokens: 500,
+        label: 'gateway.chat',
+      });
+      return [
+        {
+          claim_text: 'The market will expand faster than consensus expects',
+          kind: 'take',
+          holder: 'brain',
+          weight: 0.6,
+        },
+      ];
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), {
+      extractor,
+      model: 'anthropic:claude-sonnet-4-6',
+    });
+
+    const costUsd = (result.details as Record<string, unknown>).cost_usd as number;
+    expect(costUsd).toBeGreaterThan(0);
+    expect(putPages).toHaveLength(1);
+    expect((putPages[0]!.page.frontmatter as Record<string, unknown>).cost_usd).toBe(costUsd);
+    expect(putPages[0]!.page.compiled_truth as string).toContain('Cost: $');
+
+    const rollup = captured.find(c => c.sql.includes('INSERT INTO extract_rollup_7d'));
+    expect(rollup).toBeDefined();
+    expect(rollup!.params[3]).toBe(costUsd);
+  });
+
+  test('receipt omits model_id when the model came from gateway configuration', async () => {
+    const pages = [buildPage({ slug: 'wiki/no-explicit-model', body: 'Configured model is not known to the receipt layer.' })];
+    const { engine, putPages } = buildMockEngine({ pages });
+    const extractor: ProposeTakesExtractor = async () => [
+      { claim_text: 'Configured model is not known to the receipt layer', kind: 'take', holder: 'brain', weight: 0.5 },
+    ];
+
+    await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    expect((putPages[0]!.page.frontmatter as Record<string, unknown>).model_id).toBeUndefined();
+  });
+
+  test('receipt cost is the phase delta when an outer BudgetTracker already has spend', async () => {
+    const pages = [buildPage({ slug: 'wiki/outer-tracker', body: 'One more prediction worth proposing.' })];
+    const { engine, putPages } = buildMockEngine({ pages });
+    const outerTracker = new BudgetTracker({ label: 'outer-test', maxCostUsd: 1 });
+    outerTracker.record({
+      modelId: 'anthropic:claude-sonnet-4-6',
+      inputTokens: 10_000,
+      outputTokens: 1_000,
+      label: 'prior.phase',
+    });
+    const priorCost = outerTracker.snapshot().cumulativeCostUsd;
+    const extractor: ProposeTakesExtractor = async () => {
+      getCurrentBudgetTracker()!.record({
+        modelId: 'anthropic:claude-sonnet-4-6',
+        inputTokens: 1_000,
+        outputTokens: 500,
+        label: 'gateway.chat',
+      });
+      return [{ claim_text: 'One more prediction will matter', kind: 'take', holder: 'brain', weight: 0.55 }];
+    };
+
+    const result = await withBudgetTracker(outerTracker, () =>
+      runPhaseProposeTakes(buildCtx(engine), { extractor, model: 'anthropic:claude-sonnet-4-6' }),
+    );
+
+    const costUsd = (result.details as Record<string, unknown>).cost_usd as number;
+    expect(costUsd).toBeGreaterThan(0);
+    expect(outerTracker.snapshot().cumulativeCostUsd).toBeGreaterThan(priorCost + costUsd - 0.0000001);
+    expect(costUsd).toBeLessThan(priorCost);
+    expect((putPages[0]!.page.frontmatter as Record<string, unknown>).cost_usd).toBe(costUsd);
+  });
+
+  test('BudgetExhausted from the gateway tracker stops the phase as warn', async () => {
+    const pages = [
+      buildPage({ slug: 'wiki/a', body: 'page a' }),
+      buildPage({ slug: 'wiki/b', body: 'page b' }),
+    ];
+    const { engine } = buildMockEngine({ pages });
+    let calls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      calls++;
+      throw new BudgetExhausted('cycle.propose_takes: cap reached', {
+        reason: 'cost',
+        spent: 0.01,
+        cap: 0.01,
+        modelId: 'anthropic:claude-sonnet-4-6',
+      });
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+    const details = result.details as Record<string, unknown>;
+    expect(result.status).toBe('warn');
+    expect(details.budget_exhausted).toBe(true);
+    expect((details.warnings as string[])[0]).toContain('budget exhausted');
+    expect(calls).toBe(1);
+  });
+
+  test('default wrapper does not hard-fail unpriced chat models without an explicit cap', async () => {
+    const pages = [buildPage({ slug: 'wiki/unpriced', body: 'Unpriced local model should still propose.' })];
+    const { engine } = buildMockEngine({ pages });
+    const extractor: ProposeTakesExtractor = async () => {
+      getCurrentBudgetTracker()!.reserve({
+        modelId: 'local-chat:unpriced-test-model',
+        estimatedInputTokens: 100,
+        maxOutputTokens: 50,
+        kind: 'chat',
+        label: 'gateway.chat',
+      });
+      return [{ claim_text: 'Unpriced local model should still propose', kind: 'take', holder: 'brain', weight: 0.5 }];
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), {
+      extractor,
+      model: 'local-chat:unpriced-test-model',
+    });
+    const details = result.details as Record<string, unknown>;
+    expect(result.status).toBe('ok');
+    expect(details.budget_exhausted).toBe(false);
+    expect(details.proposals_inserted).toBe(1);
+  });
+
+  test('final-call BudgetTracker overage marks the phase halted', async () => {
+    const pages = [buildPage({ slug: 'wiki/final-overage', body: 'Final call can exceed cap after usage records.' })];
+    const { engine, captured } = buildMockEngine({ pages });
+    const tracker = new BudgetTracker({ label: 'outer-tight', maxCostUsd: 0.000001 });
+    const extractor: ProposeTakesExtractor = async () => {
+      try {
+        getCurrentBudgetTracker()!.record({
+          modelId: 'anthropic:claude-sonnet-4-6',
+          inputTokens: 1_000,
+          outputTokens: 500,
+          label: 'gateway.chat',
+        });
+      } catch (err) {
+        expect(err).toBeInstanceOf(BudgetExhausted);
+      }
+      return [{ claim_text: 'Final call can exceed cap', kind: 'take', holder: 'brain', weight: 0.6 }];
+    };
+
+    const result = await withBudgetTracker(tracker, () =>
+      runPhaseProposeTakes(buildCtx(engine), { extractor, model: 'anthropic:claude-sonnet-4-6' }),
+    );
+    const details = result.details as Record<string, unknown>;
+    expect(result.status).toBe('warn');
+    expect(details.budget_exhausted).toBe(true);
+    expect((details.warnings as string[]).at(-1)).toContain('budget exhausted');
+    const rollup = captured.find(c => c.sql.includes('INSERT INTO extract_rollup_7d'));
+    expect(rollup!.params[4]).toBe(1); // halt_delta
+    expect(rollup!.params[7]).toBe(0); // round_completed_delta
+  });
+
+  test('default phase cap still halts final actual spend overage', async () => {
+    const pages = [
+      buildPage({ slug: 'wiki/default-cap-overage', body: 'A very expensive final call should halt.' }),
+      buildPage({ slug: 'wiki/should-not-run', body: 'This page should not be submitted after the overage.' }),
+    ];
+    const { engine, captured } = buildMockEngine({ pages });
+    let calls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      calls++;
+      getCurrentBudgetTracker()!.record({
+        modelId: 'anthropic:claude-sonnet-4-6',
+        inputTokens: 2_000_000,
+        outputTokens: 0,
+        label: 'gateway.chat',
+      });
+      return [{ claim_text: 'A very expensive final call should halt', kind: 'take', holder: 'brain', weight: 0.6 }];
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), {
+      extractor,
+      model: 'anthropic:claude-sonnet-4-6',
+    });
+    const details = result.details as Record<string, unknown>;
+    expect(result.status).toBe('warn');
+    expect(details.budget_exhausted).toBe(true);
+    expect((details.cost_usd as number)).toBeGreaterThan(5);
+    expect(calls).toBe(1);
+    const rollup = captured.find(c => c.sql.includes('INSERT INTO extract_rollup_7d'));
+    expect(rollup!.params[4]).toBe(1);
+    expect(rollup!.params[7]).toBe(0);
+  });
+
+  test('failed extractor calls check actual spend before continuing', async () => {
+    const pages = [
+      buildPage({ slug: 'wiki/failed-expensive', body: 'The failed call is expensive.' }),
+      buildPage({ slug: 'wiki/should-not-run-after-failure-overage', body: 'This should not run.' }),
+    ];
+    const { engine, captured } = buildMockEngine({ pages });
+    let calls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      calls++;
+      getCurrentBudgetTracker()!.record({
+        modelId: 'anthropic:claude-sonnet-4-6',
+        inputTokens: 2_000_000,
+        outputTokens: 0,
+        label: 'gateway.chat.failed',
+      });
+      throw new Error('provider returned malformed JSON after usage');
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), {
+      extractor,
+      model: 'anthropic:claude-sonnet-4-6',
+    });
+    const details = result.details as Record<string, unknown>;
+    expect(result.status).toBe('warn');
+    expect(details.budget_exhausted).toBe(true);
+    expect(calls).toBe(1);
+    expect(details.proposals_inserted).toBe(0);
+    const rollup = captured.find(c => c.sql.includes('INSERT INTO extract_rollup_7d'));
+    expect(rollup!.params[4]).toBe(1);
+    expect(rollup!.params[7]).toBe(0);
+  });
+
+  test('multi-source federated scope skips instead of writing default-source spend', async () => {
+    const { engine, captured, putPages } = buildMockEngine({
+      pages: [buildPage({ slug: 'wiki/a', body: 'federated page', sourceId: 'source-a' })],
+    });
+    const ctx = {
+      ...buildCtx(engine),
+      sourceId: undefined,
+      auth: {
+        token: 'test',
+        clientId: 'client',
+        scopes: ['read'],
+        allowedSources: ['source-a', 'source-b'],
+      },
+    } as OperationContext;
+    let extractorCalls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      extractorCalls++;
+      return [{ claim_text: 'x', kind: 'take', holder: 'brain', weight: 0.5 }];
+    };
+
+    const result = await runPhaseProposeTakes(ctx, { extractor });
+    expect(result.status).toBe('warn');
+    expect((result.details as Record<string, unknown>).reason).toBe('federated_source_scope');
+    expect(extractorCalls).toBe(0);
+    expect(putPages).toHaveLength(0);
+    expect(captured.find(c => c.sql.includes('INSERT INTO extract_rollup_7d'))).toBeUndefined();
   });
 });

--- a/test/propose-takes.test.ts
+++ b/test/propose-takes.test.ts
@@ -646,7 +646,7 @@ New prose appended here.`;
         scopes: ['read'],
         allowedSources: ['source-a', 'source-b'],
       },
-    } as OperationContext;
+    } as unknown as OperationContext;
     let extractorCalls = 0;
     const extractor: ProposeTakesExtractor = async () => {
       extractorCalls++;

--- a/test/propose-takes.test.ts
+++ b/test/propose-takes.test.ts
@@ -660,4 +660,22 @@ New prose appended here.`;
     expect(putPages).toHaveLength(0);
     expect(captured.find(c => c.sql.includes('INSERT INTO extract_rollup_7d'))).toBeUndefined();
   });
+
+  test('unscoped local scope defaults receipts to default source', async () => {
+    const { engine, putPages } = buildMockEngine({
+      pages: [buildPage({ slug: 'wiki/unscoped-default', body: 'Unscoped local cycle should still propose.' })],
+    });
+    const ctx = {
+      ...buildCtx(engine),
+      sourceId: undefined,
+    } as unknown as OperationContext;
+    const extractor: ProposeTakesExtractor = async () => [
+      { claim_text: 'Unscoped local cycle should still propose', kind: 'take', holder: 'brain', weight: 0.5 },
+    ];
+
+    const result = await runPhaseProposeTakes(ctx, { extractor });
+    expect(result.status).toBe('ok');
+    expect(putPages).toHaveLength(1);
+    expect(putPages[0]!.opts?.sourceId).toBe('default');
+  });
 });


### PR DESCRIPTION
## Summary
- stop doctor remediation from repeating the same recommendation in one pass
- record real propose_takes spend in extract receipts and rollups from the active BudgetTracker
- add `gbrain budget reconcile` for local Anthropic/provider spend readback against the internal budget ledger before capped synthesis runs
- make autopilot dispatch per-source work before global maintenance, hold global maintenance behind source children, and reuse live/paused global jobs instead of duplicating them
- keep source-cycle freshness distinct from full-cycle freshness, avoid marking partial split source cycles fresh, and include failed/partial completed source reports in cooldown detection
- skip sources that already have live source-cycle jobs before applying the fanout cap, defer global maintenance while source work is still active, and only refresh the daemon sleep floor after a fresh no-op readback
- protect the global-maintenance job name from remote submitters and harden AI SDK tool-result JSON coercion for Date/BigInt values

## Verification
- `bun test test/budget-reconcile.test.ts test/ai/gateway-tools-schema.test.ts test/propose-takes.test.ts`
- `bun run typecheck`
- `bun src/cli.ts budget reconcile --days 7 --json --out /tmp/gbrain-budget-reconcile-pr2344-sync.json`
  - readback: provider `anthropic`, 2730 records, `$221.808218`, source file `/Users/sawbeck/.gbrain/audit/budget-2026-W25.jsonl`
- `bun test test/autopilot-global-maintenance.test.ts test/autopilot-fanout.test.ts test/autopilot-failure-cooldown.test.ts test/e2e/autopilot-cooldown-parity.test.ts test/cycle-last-full-cycle-at.test.ts test/doctor-cycle-freshness.test.ts test/dream.test.ts test/minions.test.ts test/trust-boundary-contract.test.ts test/budget-reconcile.test.ts test/ai/gateway-tools-schema.test.ts test/propose-takes.test.ts && bun run typecheck`
  - 323 pass, 3 skip, 0 fail
- `bun test test/autopilot-fanout-clamp.serial.test.ts test/autopilot-global-maintenance.test.ts test/autopilot-fanout.test.ts test/autopilot-failure-cooldown.test.ts test/e2e/autopilot-cooldown-parity.test.ts test/cycle-last-full-cycle-at.test.ts test/doctor-cycle-freshness.test.ts test/minions.test.ts test/trust-boundary-contract.test.ts test/budget-reconcile.test.ts test/ai/gateway-tools-schema.test.ts test/propose-takes.test.ts && bun run typecheck`
  - 304 pass, 3 skip, 0 fail
- `bun test test/autopilot-fanout-wiring.test.ts test/autopilot-fanout.test.ts test/autopilot-global-maintenance.test.ts test/autopilot-failure-cooldown.test.ts test/e2e/autopilot-cooldown-parity.test.ts test/cycle-last-full-cycle-at.test.ts test/doctor-cycle-freshness.test.ts test/minions.test.ts test/trust-boundary-contract.test.ts && bun run typecheck`
  - 266 pass, 3 skip, 0 fail
- `bun run verify`
  - 30/30 checks passed
- `autoreview --mode branch --base upstream/master --engine codex --model gpt-5.5 --thinking high`
  - clean: no accepted/actionable findings; overall patch is correct

## Local CI note
- `bun run ci:local:diff` passed host gitleaks/no-leak checks but the Docker runner is blocked on this Mac bind-mounted worktree by Bun `--compile` failing to rename its temp artifact from `/run/host_virtiofs/...`; the same `scripts/check-wasm-embedded.sh` guard passes on the host and in `bun run verify`.
