### PR TITLE
fix(sync): write checkpoint keys as jsonb arrays

### DIFF
--- a/src/core/op-checkpoint.ts
+++ b/src/core/op-checkpoint.ts
@@ -179,19 +179,24 @@ export async function recordCompleted(
   // REPLACE semantics (kept deliberately — #1794 V3). Callers like
   // extract-conversation-facts serialize a MUTABLE map through here and rely on
   // stale keys being REMOVED; an append would make them unremovable. The full
-  // set lands in the parent `completed_keys` JSONB column via a single UPSERT —
-  // exactly as before. JSON.stringify into `$3::jsonb` is correct (the text→jsonb
-  // cast yields a proper array; NOT the double-encode trap, which is the template
-  // form). Sync uses `appendCompleted` (below) instead, never this.
+  // set lands in the parent `completed_keys` JSONB column via a single UPSERT.
+  //
+  // IMPORTANT (v0.42.52 sync-target bug): pass the set as a native text[] and
+  // convert server-side with to_jsonb($3::text[]). Passing JSON.stringify(sorted)
+  // to `$3::jsonb` works on PGLite but postgres.js sends it as a JSON *string*
+  // scalar on Postgres, which violates v119's
+  // op_checkpoints_completed_keys_array CHECK and aborts sync-target pinning.
+  // Sync path deltas use `appendCompleted` (below); this remains the replace
+  // writer for sync-target and non-sync consumers.
   const sorted = [...keys].sort();
   return durableWrite(engine, key, 'write', () =>
     engine.executeRawDirect(
       `INSERT INTO op_checkpoints (op, fingerprint, completed_keys, updated_at)
-       VALUES ($1, $2, $3::jsonb, now())
+       VALUES ($1, $2, to_jsonb($3::text[]), now())
        ON CONFLICT (op, fingerprint) DO UPDATE
          SET completed_keys = EXCLUDED.completed_keys,
              updated_at     = now()`,
-      [key.op, key.fingerprint, JSON.stringify(sorted)],
+      [key.op, key.fingerprint, sorted],
     ));
 }
 

--- a/test/op-checkpoint.test.ts
+++ b/test/op-checkpoint.test.ts
@@ -106,6 +106,27 @@ describe('loadOpCheckpoint / recordCompleted / clearOpCheckpoint', () => {
     expect(result.sort()).toEqual(['chunk-1', 'chunk-2', 'chunk-3']);
   });
 
+  test('recordCompleted passes a native text[] param, not a JSON string scalar', async () => {
+    let seenSql = '';
+    let seenParams: unknown[] | undefined;
+    const fakeEngine = {
+      executeRawDirect: async (sql: string, params?: unknown[]) => {
+        seenSql = sql;
+        seenParams = params;
+        return [];
+      },
+    };
+
+    const ok = await recordCompleted(fakeEngine as any, { op: 'sync-target', fingerprint: 'fp-param' }, ['b', 'a']);
+
+    expect(ok).toBe(true);
+    expect(seenSql).toContain('to_jsonb($3::text[])');
+    expect(seenParams?.[0]).toBe('sync-target');
+    expect(seenParams?.[1]).toBe('fp-param');
+    expect(seenParams?.[2]).toEqual(['a', 'b']);
+    expect(typeof seenParams?.[2]).not.toBe('string');
+  });
+
   test('write overwrites prior state', async () => {
     const key = { op: 'embed', fingerprint: 'abc12345' };
     await recordCompleted(engine, key, ['chunk-1']);


### PR DESCRIPTION
## Summary

Fixes a Postgres-specific checkpoint writer bug where `recordCompleted()` could write `completed_keys` as a JSON string scalar instead of a JSONB array.

With schema v119's `op_checkpoints_completed_keys_array` CHECK, this aborts `sync-target` checkpoint writes and prevents `gbrain sync` from advancing `last_commit` even after the import work has already succeeded.

The fix passes the sorted keys as a native `text[]` parameter and converts server-side with `to_jsonb($3::text[])`.

## Why

`JSON.stringify(sorted)` bound to `$3::jsonb` passes on PGLite but can be encoded by `postgres.js` as a JSON string scalar on live Postgres. The existing PGLite round-trip tests therefore did not catch the live driver behavior.

## Tests

- `bun test test/op-checkpoint.test.ts`
- `bun run typecheck`
- `bun test test/sync-resumable-import.serial.test.ts`

Local live verification also confirmed a real `gbrain-op-sa sync --repo ~/brain` advanced the source bookmark without the `op_checkpoints_completed_keys_array` error.
