### PR TITLE
fix(op-checkpoint): bind completed_keys as array, not JSON string (postgres.js jsonb double-encode)

### DIFF
--- a/src/core/op-checkpoint.ts
+++ b/src/core/op-checkpoint.ts
@@ -179,10 +179,15 @@ export async function recordCompleted(
   // REPLACE semantics (kept deliberately — #1794 V3). Callers like
   // extract-conversation-facts serialize a MUTABLE map through here and rely on
   // stale keys being REMOVED; an append would make them unremovable. The full
-  // set lands in the parent `completed_keys` JSONB column via a single UPSERT —
-  // exactly as before. JSON.stringify into `$3::jsonb` is correct (the text→jsonb
-  // cast yields a proper array; NOT the double-encode trap, which is the template
-  // form). Sync uses `appendCompleted` (below) instead, never this.
+  // set lands in the parent `completed_keys` JSONB column via a single UPSERT.
+  //
+  // Bind the RAW `string[]`, NOT `JSON.stringify(sorted)`. postgres.js (1.3.x)
+  // pre-encodes a JS string bound to a `$3::jsonb` param as JSON, so the server
+  // stores a jsonb SCALAR STRING ("[\"x\"]") — jsonb_typeof = 'string', which
+  // violates the `op_checkpoints_completed_keys_array` CHECK and aborts every
+  // sync/embed/extract pin write. Passing the array lets postgres.js cast it to a
+  // proper jsonb array (jsonb_typeof = 'array'). Sync uses `appendCompleted`
+  // (below) instead, never this.
   const sorted = [...keys].sort();
   return durableWrite(engine, key, 'write', () =>
     engine.executeRawDirect(
@@ -191,7 +196,7 @@ export async function recordCompleted(
        ON CONFLICT (op, fingerprint) DO UPDATE
          SET completed_keys = EXCLUDED.completed_keys,
              updated_at     = now()`,
-      [key.op, key.fingerprint, JSON.stringify(sorted)],
+      [key.op, key.fingerprint, sorted],
     ));
 }
 

--- a/test/e2e/postgres-jsonb.test.ts
+++ b/test/e2e/postgres-jsonb.test.ts
@@ -26,6 +26,7 @@ import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import {
   hasDatabase, setupDB, teardownDB, getEngine, getConn,
 } from './helpers.ts';
+import { recordCompleted, loadOpCheckpoint } from '../../src/core/op-checkpoint.ts';
 
 const skip = !hasDatabase();
 const describeE2E = skip ? describe.skip : describe;
@@ -170,5 +171,43 @@ describeE2E('Postgres JSONB round-trip — frontmatter / data / pages_updated / 
     expect(rows.length).toBeGreaterThan(0);
     expect(rows[0].jt).toBe('object');
     expect(rows[0].mood).toBe('happy');
+  });
+
+  test('op_checkpoints.completed_keys — recordCompleted stores an array, not a string literal', async () => {
+    // Same double-encode trap as the frontmatter bug, in a different write
+    // site: recordCompleted binds the completed-keys set to a `$3::jsonb`
+    // param. Passing JSON.stringify(set) makes postgres.js pre-encode the
+    // string, so the server stored a jsonb SCALAR STRING ("[\"k\"]") —
+    // jsonb_typeof = 'string'. Migration v119's CHECK
+    // (op_checkpoints_completed_keys_array) then REJECTS the write, so the
+    // first checkpoint of every resumable sync / embed / extract pin aborted.
+    // PGLite never double-encoded, so the unit suite passed straight through.
+    // Binding the raw string[] makes postgres.js cast it to a real jsonb array.
+    const engine = getEngine();
+    const conn = getConn();
+    const key = { op: 'embed', fingerprint: 'jsonb-roundtrip' };
+
+    await conn.unsafe(`DELETE FROM op_checkpoints WHERE op = $1 AND fingerprint = $2`, [key.op, key.fingerprint]);
+
+    // Old code: this write violates the array CHECK → durableWrite returns false.
+    const ok = await recordCompleted(engine, key, ['chunk-2', 'chunk-1']);
+    expect(ok).toBe(true);
+
+    const rows = await conn.unsafe(`
+      SELECT
+        jsonb_typeof(completed_keys)       AS jt,
+        completed_keys->>0                 AS first,
+        jsonb_array_length(completed_keys) AS len
+      FROM op_checkpoints
+      WHERE op = 'embed' AND fingerprint = 'jsonb-roundtrip'
+    `);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].jt).toBe('array');
+    expect(rows[0].len).toBe(2);
+    expect(rows[0].first).toBe('chunk-1'); // recordCompleted sorts before write
+
+    // And the values survive the read path.
+    expect((await loadOpCheckpoint(engine, key)).sort()).toEqual(['chunk-1', 'chunk-2']);
   });
 });


### PR DESCRIPTION
## Symptom

On a Postgres-backed brain, the **first** checkpoint write of every resumable `sync` aborts (and the `embed` / `extract` pin writes too):

```
[op-checkpoint] write failed (...): new row for relation "op_checkpoints"
violates check constraint "op_checkpoints_completed_keys_array"
[sync] checkpoint target write failed (pool unavailable) — aborting before import
Sync PARTIAL ...: imported 0 of N file(s), reason=checkpoint_unavailable.
```

This wedges sync entirely — a backlog silently accumulates because no batch ever commits its checkpoint.

## Root cause

`recordCompleted` in `src/core/op-checkpoint.ts` binds `JSON.stringify(sorted)` into a `$3::jsonb` param:

```ts
[key.op, key.fingerprint, JSON.stringify(sorted)]
```

postgres.js (v3) **pre-encodes** a JS string bound to a `jsonb` param, so the server stores a jsonb **scalar string** (`"[\"x\"]"`) rather than an array → `jsonb_typeof = 'string'`. Migration v119's `op_checkpoints_completed_keys_array` CHECK then rejects the write.

PGLite never double-encodes (different driver path), which is exactly why the unit suite passed straight through and this only bites real Postgres. This is the same class as the v0.12.0 frontmatter double-encode that the rest of `postgres-engine.ts` already avoids via `sql.json()`.

`appendCompleted` is unaffected — it binds `$3::text[]`, not jsonb.

## Fix

Bind the raw `string[]`; postgres.js casts it to a proper jsonb array:

```ts
[key.op, key.fingerprint, sorted]
```

A/B repro against postgres.js v3 + real Postgres (`op_checkpoints` empty):

```js
import postgres from 'postgres';
const sql = postgres('postgresql://.../gbrain');
// today  -> jsonb_typeof = 'string'  (CHECK violation on insert)
await sql.unsafe(`SELECT jsonb_typeof($1::jsonb) t`, [JSON.stringify(['x'])]);
// fix    -> jsonb_typeof = 'array'   (correct)
await sql.unsafe(`SELECT jsonb_typeof($1::jsonb) t`, [['x']]);
```

## Tests

- Adds an e2e regression to `test/e2e/postgres-jsonb.test.ts` that round-trips `recordCompleted` through real Postgres and asserts `jsonb_typeof(completed_keys) = 'array'`. On the old binding it fails with the exact CHECK-violation signature above; with the fix it passes.
- Verified locally:
  - `bun test test/op-checkpoint.test.ts` → 30/30 pass (PGLite, fix doesn't regress).
  - `bun test test/e2e/postgres-jsonb.test.ts` against pgvector pg16 → 6/6 pass with the fix; the new test **fails** when the buggy `JSON.stringify(sorted)` is restored.
  - `tsc --noEmit` clean; `scripts/check-jsonb-pattern.sh` passes.

Affected version: 0.42.52.0 (`src/core/op-checkpoint.ts`, the #1794 resumable-sync checkpoint path).

Made with [Cursor](https://cursor.com)