### PR TITLE
fix(extract): recognize plain-bullet interaction logs and date-only session headers in timeline extraction

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -469,6 +469,39 @@ export async function extractLinksFromFile(
 
 // --- Timeline extraction ---
 
+/**
+ * Normalize a vault date token to a real ISO `YYYY-MM-DD` for the
+ * `timeline_entries.date` SQL DATE column.
+ *   - `YYYY-MM-DD`           -> as-is (validated)
+ *   - `YYYY-MM` (month-only) -> `YYYY-MM-01`
+ * Range tokens (`A to B`) are split by the caller, which passes the start.
+ * Returns null for anything that isn't a real calendar date.
+ */
+function normalizeTimelineDate(raw: string): string | null {
+  const t = raw.trim();
+  let iso: string;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(t)) iso = t;
+  else if (/^\d{4}-\d{2}$/.test(t)) iso = `${t}-01`;
+  else return null;
+  const [y, mo, d] = iso.split('-').map(Number);
+  if (mo < 1 || mo > 12 || d < 1 || d > 31) return null;
+  const dt = new Date(Date.UTC(y, mo - 1, d));
+  if (dt.getUTCFullYear() !== y || dt.getUTCMonth() !== mo - 1 || dt.getUTCDate() !== d) return null;
+  return iso;
+}
+
+/**
+ * Split an optional trailing evidence link off an interaction-log summary.
+ * Vault bullets often end with ` — [slack](url)`; only strip when the trailing
+ * token is a lone markdown link so prose that merely ends with a dash clause is
+ * left intact.
+ */
+function splitTrailingSource(text: string): { summary: string; source: string } {
+  const m = text.match(/^(.*\S)\s+[—–]\s+(\[[^\]]+\]\([^)]+\))\s*$/);
+  if (m) return { summary: m[1].trim(), source: m[2].trim() };
+  return { summary: text.trim(), source: 'interaction-log' };
+}
+
 /** Extract timeline entries from markdown content */
 export function extractTimelineFromContent(content: string, slug: string): ExtractedTimelineEntry[] {
   const entries: ExtractedTimelineEntry[] = [];
@@ -492,6 +525,45 @@ export function extractTimelineFromContent(content: string, slug: string): Extra
     );
     const detail = content.slice(afterIdx, endIdx).trim();
     entries.push({ slug, date: match[1], source: 'markdown', summary: match[2].trim(), detail: detail || undefined });
+  }
+
+  // Format 3: Plain interaction-log bullet (date + colon, no bold) —
+  //   - YYYY-MM-DD: Summary [— [src](url)]
+  //   - YYYY-MM-DD to YYYY-MM-DD: Summary   (range -> start date)
+  //   - YYYY-MM: Summary                    (month-only -> YYYY-MM-01)
+  // Distinct from Format 1: no **bold** date, colon separator (not a pipe).
+  // Matches the common people-page `## Interaction Log` bullet convention.
+  const interactionPattern = /^[ \t]*-\s+(\d{4}-\d{2}(?:-\d{2})?)(?:\s+to\s+\d{4}-\d{2}(?:-\d{2})?)?\s*:\s*(.+)$/gm;
+  while ((match = interactionPattern.exec(content)) !== null) {
+    const date = normalizeTimelineDate(match[1]);
+    if (!date) continue;
+    const { summary, source } = splitTrailingSource(match[2]);
+    if (summary.length === 0) continue;
+    entries.push({ slug, date, source, summary });
+  }
+
+  // Format 4: Date-only / range session-log header —
+  //   ### YYYY-MM-DD                 (prose body below, no ` — title`)
+  //   ### YYYY-MM-DD to YYYY-MM-DD
+  // Mutually exclusive with Format 2, which requires a trailing ` — title`.
+  // Matches the common `## Session Log` H3-per-day convention; the first
+  // non-empty body line becomes the summary, the rest the detail.
+  const sessionHeaderPattern = /^###\s+(\d{4}-\d{2}-\d{2})(?:\s+to\s+(\d{4}-\d{2}-\d{2}))?[ \t]*$/gm;
+  while ((match = sessionHeaderPattern.exec(content)) !== null) {
+    const date = normalizeTimelineDate(match[1]);
+    if (!date) continue;
+    const afterIdx = match.index + match[0].length;
+    const nextHeader = content.indexOf('\n### ', afterIdx);
+    const nextSection = content.indexOf('\n## ', afterIdx);
+    const endIdx = Math.min(
+      nextHeader >= 0 ? nextHeader : content.length,
+      nextSection >= 0 ? nextSection : content.length,
+    );
+    const detail = content.slice(afterIdx, endIdx).trim();
+    if (detail.length === 0) continue;
+    const firstLine = detail.split('\n').map(s => s.trim()).find(s => s.length > 0) ?? '';
+    const summary = firstLine.length > 200 ? `${firstLine.slice(0, 197)}…` : firstLine;
+    entries.push({ slug, date, source: 'session-log', summary: summary || date, detail });
   }
 
   return entries;

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -1104,10 +1104,58 @@ export interface TimelineCandidate {
 // or `- **YYYY-MM-DD** - summary` or just `**YYYY-MM-DD** | summary`.
 const TIMELINE_LINE_RE = /^\s*-?\s*\*\*(\d{4}-\d{2}-\d{2})\*\*\s*[|\-–—]+\s*(.+?)\s*$/;
 
+// Plain interaction-log bullet (date + colon, no bold) —
+//   `- YYYY-MM-DD: summary`, optional ` to YYYY-MM-DD` range, or `YYYY-MM` month.
+const TIMELINE_BULLET_DATE_RE = /^\s*-\s+(\d{4}-\d{2}(?:-\d{2})?)(?:\s+to\s+\d{4}-\d{2}(?:-\d{2})?)?\s*:\s*(.+?)\s*$/;
+
+// Date-only session-log header: `### YYYY-MM-DD` (date-only or range), with
+// prose below acting as the entry body.
+const TIMELINE_H3_DATE_RE = /^\s*###\s+(\d{4}-\d{2}-\d{2})(?:\s+to\s+\d{4}-\d{2}-\d{2})?\s*$/;
+
+/**
+ * Normalize a vault date token to ISO `YYYY-MM-DD`. Accepts month-only
+ * `YYYY-MM` (-> `-01`); returns null for non-calendar dates.
+ */
+function normalizeVaultDate(raw: string): string | null {
+  const t = raw.trim();
+  if (isValidDate(t)) return t;
+  if (/^\d{4}-\d{2}$/.test(t)) {
+    const iso = `${t}-01`;
+    return isValidDate(iso) ? iso : null;
+  }
+  return null;
+}
+
+/**
+ * Identify a timeline "head" line and return its date + inline summary.
+ * Recognizes the bold format plus the plain-bullet interaction-log format and
+ * the date-only session-log H3 header. Header heads carry an empty summary
+ * (filled from the prose body by the caller). Returns null for non-head lines.
+ */
+function matchTimelineHead(line: string): { date: string; summary: string } | null {
+  let m = TIMELINE_LINE_RE.exec(line);
+  if (m && isValidDate(m[1]) && m[2].trim().length > 0) {
+    return { date: m[1], summary: m[2].trim() };
+  }
+  m = TIMELINE_BULLET_DATE_RE.exec(line);
+  if (m) {
+    const date = normalizeVaultDate(m[1]);
+    if (date && m[2].trim().length > 0) return { date, summary: m[2].trim() };
+  }
+  m = TIMELINE_H3_DATE_RE.exec(line);
+  if (m) {
+    const date = normalizeVaultDate(m[1]);
+    if (date) return { date, summary: '' };
+  }
+  return null;
+}
+
 /**
  * Parse timeline entries from content. Looks at:
  *   - The full content (most pages have a top-level "## Timeline" heading).
  *   - Free-form `- **DATE** | text` lines anywhere.
+ *   - Plain interaction-log bullets `- DATE: text` (people-page convention).
+ *   - Date-only session-log headers `### DATE` with prose below.
  *
  * Skips dates that don't represent valid calendar dates (e.g. 2026-13-45).
  * Multi-line entries: a date line followed by indented or blank-then-text
@@ -1119,24 +1167,20 @@ export function parseTimelineEntries(content: string): TimelineCandidate[] {
 
   let i = 0;
   while (i < lines.length) {
-    const m = TIMELINE_LINE_RE.exec(lines[i]);
-    if (!m) {
+    const head = matchTimelineHead(lines[i]);
+    if (!head) {
       i++;
       continue;
     }
-    const date = m[1];
-    const summary = m[2].trim();
-    if (!isValidDate(date) || summary.length === 0) {
-      i++;
-      continue;
-    }
+    const date = head.date;
+    let summary = head.summary;
 
     // Collect optional detail lines (indented, until next date or heading).
     const detailLines: string[] = [];
     let j = i + 1;
     while (j < lines.length) {
       const next = lines[j];
-      if (TIMELINE_LINE_RE.test(next)) break;
+      if (matchTimelineHead(next)) break;
       if (/^#{1,6}\s/.test(next)) break;
       if (next.trim().length === 0 && detailLines.length === 0) {
         // skip leading blank line; if we hit a blank after detail content
@@ -1153,7 +1197,17 @@ export function parseTimelineEntries(content: string): TimelineCandidate[] {
       }
       break;
     }
-    result.push({ date, summary, detail: detailLines.join(' ').trim() });
+    const detail = detailLines.join(' ').trim();
+    // Date-only session-log headers carry their summary in the prose body.
+    if (summary.length === 0) {
+      const firstLine = detailLines.find(s => s.length > 0) ?? '';
+      if (firstLine.length === 0) {
+        i = j;
+        continue;
+      }
+      summary = firstLine.length > 200 ? `${firstLine.slice(0, 197)}…` : firstLine;
+    }
+    result.push({ date, summary, detail });
     i = j;
   }
   return result;

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -135,6 +135,51 @@ describe('extractTimelineFromContent', () => {
     const entries = extractTimelineFromContent(content, 'test');
     expect(entries).toHaveLength(1);
   });
+
+  it('extracts plain interaction-log bullets (- DATE: summary)', () => {
+    const content = `## Interaction Log\n\n- 2026-05-05: Synced on the telemetry roadmap`;
+    const entries = extractTimelineFromContent(content, 'people/test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date).toBe('2026-05-05');
+    expect(entries[0].summary).toBe('Synced on the telemetry roadmap');
+  });
+
+  it('splits a trailing markdown link off the interaction-log summary', () => {
+    const content = `- 2026-05-05: Reviewed the PR together — [slack](https://example.com/p123)`;
+    const entries = extractTimelineFromContent(content, 'people/test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].summary).toBe('Reviewed the PR together');
+    expect(entries[0].source).toBe('[slack](https://example.com/p123)');
+  });
+
+  it('normalizes a date range to its start date', () => {
+    const content = `- 2025-10-15 to 2025-10-18: Built the hackathon poster`;
+    const entries = extractTimelineFromContent(content, 'people/test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date).toBe('2025-10-15');
+  });
+
+  it('normalizes a month-only date to the first of the month', () => {
+    const content = `- 2026-01: Joined the telemetry onboarding path`;
+    const entries = extractTimelineFromContent(content, 'people/test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date).toBe('2026-01-01');
+  });
+
+  it('extracts date-only session-log headers (### DATE with prose below)', () => {
+    const content = `## Session Log\n\n### 2026-04-08\nConnected Snowflake. Still blocked on prod access.`;
+    const entries = extractTimelineFromContent(content, 'work/test');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].date).toBe('2026-04-08');
+    expect(entries[0].summary).toBe('Connected Snowflake. Still blocked on prod access.');
+  });
+
+  it('does not double-count a titled header as a date-only header', () => {
+    const content = `### 2025-03-28 — Round Closed\n\nAll docs signed.`;
+    const entries = extractTimelineFromContent(content, 'deals/seed');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].summary).toBe('Round Closed');
+  });
 });
 
 describe('walkMarkdownFiles', () => {

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -720,6 +720,46 @@ More prose here.
     const entries = parseTimelineEntries(content);
     expect(entries.length).toBe(2);
   });
+
+  test('parses plain interaction-log bullets: - YYYY-MM-DD: summary', () => {
+    const entries = parseTimelineEntries('- 2026-05-05: Synced on the telemetry roadmap');
+    expect(entries.length).toBe(1);
+    expect(entries[0]).toEqual({ date: '2026-05-05', summary: 'Synced on the telemetry roadmap', detail: '' });
+  });
+
+  test('normalizes a date range bullet to its start date', () => {
+    const entries = parseTimelineEntries('- 2025-10-15 to 2025-10-18: Built the poster');
+    expect(entries.length).toBe(1);
+    expect(entries[0].date).toBe('2025-10-15');
+  });
+
+  test('normalizes a month-only bullet to the first of the month', () => {
+    const entries = parseTimelineEntries('- 2026-01: Joined the onboarding path');
+    expect(entries.length).toBe(1);
+    expect(entries[0].date).toBe('2026-01-01');
+  });
+
+  test('parses date-only session-log headers with prose body', () => {
+    const content = `## Session Log
+
+### 2026-04-08
+Connected Snowflake. Still blocked on prod access.
+
+### 2026-05-05
+Snowflake prod access granted.`;
+    const entries = parseTimelineEntries(content);
+    expect(entries.length).toBe(2);
+    expect(entries[0]).toEqual({
+      date: '2026-04-08',
+      summary: 'Connected Snowflake. Still blocked on prod access.',
+      detail: 'Connected Snowflake. Still blocked on prod access.',
+    });
+    expect(entries[1].date).toBe('2026-05-05');
+  });
+
+  test('skips invalid plain-bullet dates', () => {
+    expect(parseTimelineEntries('- 2026-13-45: Bad date')).toEqual([]);
+  });
 });
 
 // ─── isAutoLinkEnabled ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

The two timeline parsers — `extractTimelineFromContent` (fs walk, `src/commands/extract.ts`) and `parseTimelineEntries` (DB / `put_page` auto-timeline, `src/core/link-extraction.ts`) — only recognized two shapes:

- bold-pipe bullets: `- **YYYY-MM-DD** | Source — Summary`
- titled headers: `### YYYY-MM-DD — Title`

Brains that keep people interaction logs as plain `- YYYY-MM-DD: summary` bullets and session logs as date-only `### YYYY-MM-DD` headers (entry body in the prose below) extracted **zero** timeline entries. The `timeline_entries` graph stayed empty and `gbrain doctor` reported timeline coverage near 0% despite rich, well-dated content on every entity page.

This PR teaches **both** parsers two additional formats, kept in lockstep so the fs and DB paths agree:

- **Format 3 — plain interaction-log bullet** `- YYYY-MM-DD: summary`
  - splits a trailing markdown-link source off the summary (`… — [slack](url)`)
  - date ranges `A to B` → start date
  - month-only `YYYY-MM` → `YYYY-MM-01`
- **Format 4 — date-only / range session-log header** `### YYYY-MM-DD` (and `### A to B`)
  - first non-empty prose line becomes the summary, the block becomes the detail
  - mutually exclusive with the existing titled-header format (no double counting)

All dates are normalized and calendar-validated before insertion, so the `timeline_entries.date` SQL DATE column never sees a range or partial token.

### Impact (real vault, ~410 pages, 83 person pages)

| Metric | Before | After |
| --- | --- | --- |
| `timeline_entries` | 4 | 772 |
| entity timeline coverage (`doctor`) | 1% | 88% |
| `brain_score` timeline component | 0/15 | 5/15 |

No vault-format changes were required — the parsers now meet the content where it is.

## Test plan

- [x] `bun test test/extract.test.ts test/link-extraction.test.ts` → 159 pass / 0 fail (includes new cases for interaction bullets, trailing-source split, date ranges, month-only dates, date-only session headers, titled-header non-regression, and invalid-date rejection)
- [x] `bun run typecheck` → 0 errors
- [x] Verified existing Format 1 / Format 2 behavior is unchanged

Made with [Cursor](https://cursor.com)