### PR TITLE
docs(schema): list all 7 bundled read-only packs, not just 2

### DIFF
--- a/skills/conventions/schema-evolution.md
+++ b/skills/conventions/schema-evolution.md
@@ -89,7 +89,7 @@ imports under `meetings/` infer `meeting` type via the pack.
   `expert_routing_without_prefix` lint rule warns about this exact
   shape: an expert-routed type with no prefix never matches a put_page
   inference, so `whoknows` silently never surfaces it.
-- **Don't mutate `gbrain-base` or `gbrain-recommended`.** Fork first.
+- **Don't mutate a bundled pack** (all 7 are read-only: `gbrain-base`, `gbrain-base-v2`, `gbrain-recommended`, `gbrain-creator`, `gbrain-investor`, `gbrain-engineer`, `gbrain-everything`). Fork first.
 
 ## When to remove a type
 

--- a/skills/schema-author/SKILL.md
+++ b/skills/schema-author/SKILL.md
@@ -144,8 +144,9 @@ the signal for which to promote.
 
 ### Phase 4 — Apply (mutate the pack)
 
-If the active pack is bundled (`gbrain-base` or `gbrain-recommended`),
-fork it first:
+If the active pack is bundled (any of the 7 read-only packs: `gbrain-base`,
+`gbrain-base-v2`, `gbrain-recommended`, `gbrain-creator`, `gbrain-investor`,
+`gbrain-engineer`, `gbrain-everything`), fork it first:
 
 ```
 gbrain schema fork gbrain-base mine
@@ -251,7 +252,7 @@ loadActivePack — v0.40.6.0 closed the cross-process invalidation gap).
 
 ## Anti-Patterns
 
-- **Don't mutate `gbrain-base` or `gbrain-recommended`.** Fork first (`gbrain schema fork gbrain-base mine`). These are bundled packs; edits would be lost on upgrade. The mutation primitives refuse with `PACK_READONLY`.
+- **Don't mutate a bundled pack.** All 7 are read-only (`gbrain-base`, `gbrain-base-v2`, `gbrain-recommended`, `gbrain-creator`, `gbrain-investor`, `gbrain-engineer`, `gbrain-everything`). Fork first (`gbrain schema fork gbrain-base mine`). Edits would be lost on upgrade; the mutation primitives refuse with `PACK_READONLY`.
 - **Don't add a type for a directory you imported once for triage.** Pack types are permanent decisions; one-time imports are not. See `skills/conventions/schema-evolution.md` for the <20-pages-don't-pack-codify heuristic.
 - **Don't add `--expert` to a type with no `path_prefixes`.** The `expert_routing_without_prefix` lint warns about this — expert-routed types with no prefix never match a put_page inference, so `whoknows` silently never surfaces them.
 - **Don't promote a `schema suggest` candidate without verifying the prefix matches real content.** Run `lint --with-db` before `add-type` to catch prefix collisions pre-write.


### PR DESCRIPTION
The `schema-evolution` and `schema-author` skill docs only list `gbrain-base` and `gbrain-recommended` as the read-only bundled packs to fork before mutating. gbrain now ships **7** bundled read-only packs, so the "fork first" guidance + matching anti-patterns are stale — an agent reading them could try to mutate one of the other 5 (`gbrain-base-v2`, `gbrain-creator`, `gbrain-investor`, `gbrain-engineer`, `gbrain-everything`) and hit a confusing `PACK_READONLY` refusal the docs never warned about.

Updates both docs to list all 7. Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)