### PR TITLE
fix(op-checkpoint): build completed_keys via to_jsonb($3::text[]) — satisfy v119 array CHECK

### DIFF
--- a/src/core/op-checkpoint.ts
+++ b/src/core/op-checkpoint.ts
@@ -179,19 +179,26 @@ export async function recordCompleted(
   // REPLACE semantics (kept deliberately — #1794 V3). Callers like
   // extract-conversation-facts serialize a MUTABLE map through here and rely on
   // stale keys being REMOVED; an append would make them unremovable. The full
-  // set lands in the parent `completed_keys` JSONB column via a single UPSERT —
-  // exactly as before. JSON.stringify into `$3::jsonb` is correct (the text→jsonb
-  // cast yields a proper array; NOT the double-encode trap, which is the template
-  // form). Sync uses `appendCompleted` (below) instead, never this.
+  // set lands in the parent `completed_keys` JSONB column via a single UPSERT.
+  //
+  // Bind the array as a Postgres `text[]` and build the JSONB array in SQL with
+  // `to_jsonb($3::text[])` — the SAME binding APPEND_PATHS_SQL uses. Do NOT
+  // `JSON.stringify(sorted)` into a `$3::jsonb` cast: postgres.js's `.unsafe()`
+  // path (executeRawDirect → runUnsafe) JSON-encodes the string parameter a
+  // SECOND time, so the cast yields a jsonb *scalar string* (`"[...]"`), not an
+  // array. That trips migration v119's `jsonb_typeof(completed_keys) = 'array'`
+  // CHECK and the whole write fails (empirically confirmed; was silently fine
+  // pre-v119 and on PGLite, which hides the double-encode). Sync uses
+  // `appendCompleted` (below) instead, never this.
   const sorted = [...keys].sort();
   return durableWrite(engine, key, 'write', () =>
     engine.executeRawDirect(
       `INSERT INTO op_checkpoints (op, fingerprint, completed_keys, updated_at)
-       VALUES ($1, $2, $3::jsonb, now())
+       VALUES ($1, $2, to_jsonb($3::text[]), now())
        ON CONFLICT (op, fingerprint) DO UPDATE
          SET completed_keys = EXCLUDED.completed_keys,
              updated_at     = now()`,
-      [key.op, key.fingerprint, JSON.stringify(sorted)],
+      [key.op, key.fingerprint, sorted],
     ));
 }
 

--- a/test/e2e/op-checkpoint-postgres.test.ts
+++ b/test/e2e/op-checkpoint-postgres.test.ts
@@ -1,0 +1,91 @@
+/**
+ * E2E (real Postgres) — recordCompleted writes a JSONB *array*, not a scalar.
+ *
+ * Skipped gracefully when DATABASE_URL is unset. Catches a class of bug PGLite
+ * cannot: postgres.js's `.unsafe(sql, params)` path (executeRawDirect →
+ * runUnsafe) JSON-encodes a string parameter a SECOND time. So the pre-fix
+ * `recordCompleted` — `JSON.stringify(sorted)` bound to a `$3::jsonb` cast —
+ * produced a jsonb *scalar string* (`"[...]"`, jsonb_typeof = 'string'), which
+ * trips migration v119's `op_checkpoints_completed_keys_array` CHECK
+ * (`jsonb_typeof(completed_keys) = 'array'`) and fails the whole write. The fix
+ * binds the array as `text[]` and builds the array in SQL via
+ * `to_jsonb($3::text[])` (the same binding APPEND_PATHS_SQL uses).
+ *
+ * PGLite does not double-encode, so the PGLite unit suite (test/op-checkpoint.test.ts)
+ * passes on BOTH the broken and fixed code — this real-Postgres test is the only
+ * layer that regression-guards the binding.
+ *
+ * Scoped to a reserved `__test_ckpt_pg__` op so it never touches real checkpoint
+ * rows; beforeAll/afterAll delete only that op.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PostgresEngine } from '../../src/core/postgres-engine.ts';
+import { recordCompleted, loadOpCheckpoint, clearOpCheckpoint } from '../../src/core/op-checkpoint.ts';
+
+const dbUrl = process.env.DATABASE_URL;
+if (!dbUrl) {
+  describe.skip('postgres E2E — op-checkpoint recordCompleted (skipped: DATABASE_URL unset)', () => {
+    test('skipped', () => { expect(true).toBe(true); });
+  });
+} else {
+  let engine: PostgresEngine;
+  const OP = '__test_ckpt_pg__';
+
+  const wipe = () => engine.executeRaw(`DELETE FROM op_checkpoints WHERE op = $1`, [OP]);
+
+  beforeAll(async () => {
+    engine = new PostgresEngine();
+    await engine.connect({ database_url: dbUrl } as never);
+    await engine.initSchema(); // applies migration v119 (the array CHECK)
+    await wipe();
+  });
+
+  afterAll(async () => {
+    await wipe();
+    await engine.disconnect();
+  });
+
+  test('recordCompleted persists a JSONB array (survives the v119 array CHECK)', async () => {
+    const key = { op: OP, fingerprint: 'arr00001' };
+    const keys = ['chunk-2', 'chunk-1', 'chunk-3'];
+
+    const ok = await recordCompleted(engine, key, keys);
+    // Pre-fix: the double-encoded scalar string trips the CHECK; durableWrite
+    // swallows the error and returns false. Post-fix: true.
+    expect(ok).toBe(true);
+
+    const rows = await engine.executeRaw<{ typ: string }>(
+      `SELECT jsonb_typeof(completed_keys) AS typ FROM op_checkpoints
+        WHERE op = $1 AND fingerprint = $2`,
+      [key.op, key.fingerprint],
+    );
+    expect(rows[0]?.typ).toBe('array');
+
+    // Round-trips through the loader (sorted set).
+    const loaded = await loadOpCheckpoint(engine, key);
+    expect([...loaded].sort()).toEqual(['chunk-1', 'chunk-2', 'chunk-3']);
+
+    await clearOpCheckpoint(engine, key);
+  });
+
+  test('recordCompleted REPLACE semantics keep the column an array', async () => {
+    const key = { op: OP, fingerprint: 'arr00002' };
+
+    expect(await recordCompleted(engine, key, ['a', 'b'])).toBe(true);
+    // REPLACE (not append): a smaller set must overwrite, still a valid array.
+    expect(await recordCompleted(engine, key, ['a'])).toBe(true);
+
+    const rows = await engine.executeRaw<{ typ: string }>(
+      `SELECT jsonb_typeof(completed_keys) AS typ FROM op_checkpoints
+        WHERE op = $1 AND fingerprint = $2`,
+      [key.op, key.fingerprint],
+    );
+    expect(rows[0]?.typ).toBe('array');
+
+    const loaded = await loadOpCheckpoint(engine, key);
+    expect([...loaded].sort()).toEqual(['a']);
+
+    await clearOpCheckpoint(engine, key);
+  });
+}


### PR DESCRIPTION
## Problem

`recordCompleted()` in `src/core/op-checkpoint.ts` bound `JSON.stringify(sorted)` to a `$3::jsonb` cast. On the direct session pool, `executeRawDirect → runUnsafe → postgres.js conn.unsafe(sql, params)` JSON-encodes the string parameter a **second** time, so the cast yields a jsonb **scalar string** (`"[...]"`, `jsonb_typeof = 'string'`) instead of an array.

Migration **v119** (`op_checkpoints_completed_keys_array_check`) added `CHECK (jsonb_typeof(completed_keys) = 'array')`. So after v119, every `recordCompleted` write of a non-empty array fails the constraint:

```
[op-checkpoint] write failed (sync-target, …): new row for relation "op_checkpoints"
  violates check constraint "op_checkpoints_completed_keys_array"
[sync] checkpoint target write failed (pool unavailable) — aborting before import; banked 0 file(s)
```

This breaks **`gbrain sync`'s pin write** (the `sync-target` checkpoint at `src/commands/sync.ts:1956`) — large syncs abort before importing and bank 0 files every run — and every other `recordCompleted` caller (embed/extract checkpoints). The `"pool unavailable"` wording is misleading; the underlying error is the CHECK violation, not pool exhaustion.

The existing in-code comment claiming the `JSON.stringify`-into-`$3::jsonb` form was correct ("NOT the double-encode trap") was wrong for the `.unsafe()` path.

## Fix

Bind the array as a Postgres `text[]` and build the JSONB array in SQL with `to_jsonb($3::text[])` — the **same binding `APPEND_PATHS_SQL` already uses** in this file, and the pattern `CLAUDE.md` mandates ("JSONB: never `JSON.stringify` into a `::jsonb` cast"). One line of SQL + pass the array directly instead of pre-stringifying.

## Why the unit suite didn't catch it

PGLite does **not** double-encode, so `test/op-checkpoint.test.ts` passes on both the broken and fixed code — an engine-parity gap. This PR adds `test/e2e/op-checkpoint-postgres.test.ts` (skips when `DATABASE_URL` is unset; runs in the Postgres CI matrix) asserting `recordCompleted` persists `jsonb_typeof = 'array'` and round-trips through the loader, including the REPLACE-semantics path. It's scoped to a reserved `__test_ckpt_pg__` op and self-cleans.

## Verification

- Empirically reproduced against a real Postgres brain: the old `JSON.stringify`→`$3::jsonb` form is **REJECTED** by the v119 CHECK; the new `to_jsonb($3::text[])` form stores a proper `array`. After the fix, live `op_checkpoints` rows land as arrays and `gbrain sync` resumes banking paths.
- `bun run typecheck` clean.
- `test/op-checkpoint.test.ts` (PGLite): 30 tests pass.
- The new e2e test passes the skip path locally (no `DATABASE_URL`); it could not be exercised against Postgres on my machine because the shared session pooler was saturated by a concurrent backfill, but its assertions mirror the reproduced behavior and the established `*-postgres.test.ts` pattern.

## Note for maintainer

I don't own the release queue, so I did **not** bump `VERSION`/`package.json` or add a `CHANGELOG` header — please assign the version and prefix the PR title per the version-first convention on merge.
