### PR TITLE
fix(sync): op_checkpoints write a JSONB array, not a string scalar, on Postgres

### DIFF
--- a/src/core/op-checkpoint.ts
+++ b/src/core/op-checkpoint.ts
@@ -180,14 +180,17 @@ export async function recordCompleted(
   // extract-conversation-facts serialize a MUTABLE map through here and rely on
   // stale keys being REMOVED; an append would make them unremovable. The full
   // set lands in the parent `completed_keys` JSONB column via a single UPSERT —
-  // exactly as before. JSON.stringify into `$3::jsonb` is correct (the text→jsonb
-  // cast yields a proper array; NOT the double-encode trap, which is the template
-  // form). Sync uses `appendCompleted` (below) instead, never this.
+  // exactly as before. JSON.stringify the array, then cast `$3::text::jsonb`:
+  // postgres.js (current pin) serializes a bare string param destined for jsonb
+  // AS a jsonb string scalar (double-encode), so `$3::jsonb` yielded
+  // jsonb_typeof='string' and tripped migration v119's array CHECK — hard-failing
+  // every sync-target write. Forcing `::text::jsonb` makes Postgres parse the
+  // JSON text into a real array. Verified: $3::jsonb→'string', $3::text::jsonb→'array'.
   const sorted = [...keys].sort();
   return durableWrite(engine, key, 'write', () =>
     engine.executeRawDirect(
       `INSERT INTO op_checkpoints (op, fingerprint, completed_keys, updated_at)
-       VALUES ($1, $2, $3::jsonb, now())
+       VALUES ($1, $2, $3::text::jsonb, now())
        ON CONFLICT (op, fingerprint) DO UPDATE
          SET completed_keys = EXCLUDED.completed_keys,
              updated_at     = now()`,

--- a/test/e2e/op-checkpoint-jsonb-postgres.test.ts
+++ b/test/e2e/op-checkpoint-jsonb-postgres.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression: op_checkpoints.completed_keys must be a JSONB ARRAY on Postgres.
+ *
+ * recordCompleted() binds `JSON.stringify(sorted)` as a positional parameter to
+ * a `$N::jsonb` cast. On postgres.js (`^3.4.0`) the server describes that
+ * parameter via the cast as json/jsonb, and postgres.js then serializes the
+ * bind value with its JSON serializer (JSON.stringify) — so a pre-stringified
+ * JSON array `["abc"]` is double-encoded into a JSONB STRING scalar
+ * `"[\"abc\"]"`. jsonb_typeof then returns 'string', which violates migration
+ * v119's `CHECK (jsonb_typeof(completed_keys) = 'array')` and hard-fails every
+ * sync-target pin write — the sync aborts with "checkpoint target write failed
+ * (pool unavailable)" and imports 0 files.
+ *
+ * The fix casts `$N::text::jsonb` so the param is sent as text and Postgres
+ * parses the JSON text into a real array. This bug is Postgres-only: PGLite
+ * does not double-encode, so the PGLite coverage in test/op-checkpoint.test.ts
+ * cannot catch it — hence this dedicated e2e file.
+ *
+ * Skipped when DATABASE_URL is unset — mirrors every other test/e2e/ file.
+ * Bring up gbrain-test-pg via the canonical lifecycle described in CLAUDE.md.
+ */
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { setupDB, teardownDB, hasDatabase } from './helpers.ts';
+import type { PostgresEngine } from '../../src/core/postgres-engine.ts';
+import { recordCompleted, loadOpCheckpoint } from '../../src/core/op-checkpoint.ts';
+
+const skip = !hasDatabase();
+const describeIfDB = skip ? describe.skip : describe;
+
+if (skip) {
+  // eslint-disable-next-line no-console
+  console.log('Skipping op-checkpoint-jsonb-postgres E2E (DATABASE_URL not set)');
+}
+
+let engine: PostgresEngine;
+
+beforeAll(async () => {
+  if (skip) return;
+  engine = await setupDB();
+}, 30_000);
+
+afterAll(async () => {
+  if (skip) return;
+  await teardownDB();
+});
+
+beforeEach(async () => {
+  if (skip) return;
+  await engine.executeRaw(`DELETE FROM op_checkpoint_paths`);
+  await engine.executeRaw(`DELETE FROM op_checkpoints`);
+});
+
+describeIfDB('op_checkpoints JSONB array write on Postgres (postgres.js $N::jsonb double-encode)', () => {
+  test('recordCompleted stores completed_keys as a JSONB array, not a string scalar', async () => {
+    // A single commit-sha key — exactly the shape sync.ts persists for the pin
+    // via `recordCompleted(engine, ckpt.target, [pin])`.
+    const key = { op: 'sync-target', fingerprint: 'jsonb-typeof' };
+
+    // With the bug (`$N::jsonb`) this write fails the v119 array CHECK and
+    // durableWrite returns false; with the fix (`$N::text::jsonb`) it lands.
+    const ok = await recordCompleted(engine, key, ['00edc69af71ac1621d28020ee61c84cc82520788']);
+    expect(ok).toBe(true);
+
+    const rows = await engine.executeRaw<{ t: string | null }>(
+      `SELECT jsonb_typeof(completed_keys) AS t
+         FROM op_checkpoints WHERE op = $1 AND fingerprint = $2`,
+      [key.op, key.fingerprint],
+    );
+    // Bare `$N::jsonb` double-encodes to a JSONB string scalar → 'string'.
+    expect(rows[0]?.t).toBe('array');
+  });
+
+  test('recordCompleted satisfies the v119 array CHECK and round-trips through loadOpCheckpoint', async () => {
+    const key = { op: 'sync-target', fingerprint: 'roundtrip' };
+
+    const ok = await recordCompleted(engine, key, ['b', 'a']);
+    expect(ok).toBe(true);
+
+    const loaded = await loadOpCheckpoint(engine, key);
+    expect([...loaded].sort()).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## Problem

Every incremental `gbrain sync` against a **native-Postgres** brain that has real work to import hard-fails:

```
[op-checkpoint] write failed (sync-target, <fp>): new row for relation "op_checkpoints"
  violates check constraint "op_checkpoints_completed_keys_array"
[sync] checkpoint target write failed (pool unavailable) — aborting before import; nothing drained
Sync PARTIAL at <commit>: imported 0 of N file(s), reason=checkpoint_unavailable
```

The `pool unavailable` text is a hardcoded fallback reason in `sync.ts`; the real error is the constraint violation. Sync never advances `last_commit`, so the brain silently stops ingesting new content (no-op syncs and initial full syncs still "succeed", which is why this can hide for a while).

## Root cause

`recordCompleted()` (`src/core/op-checkpoint.ts`) — the sync-target pin write — binds `JSON.stringify(sorted)` as a **positional parameter** to a `$N::jsonb` cast:

```ts
engine.executeRawDirect(
  `INSERT INTO op_checkpoints (op, fingerprint, completed_keys, updated_at)
   VALUES ($1, $2, $3::jsonb, now()) ON CONFLICT ...`,
  [key.op, key.fingerprint, JSON.stringify(sorted)]);  // e.g. '["<commit-sha>"]'
```

`PostgresEngine.executeRawDirect` → `postgres.js` `conn.unsafe(sql, params)`. `.unsafe()` sends inferred type `0` for the JS string, the server then **describes the `$N::jsonb` parameter as json/jsonb via the cast**, and `postgres.js` serializes the bind value with its JSON serializer (`JSON.stringify`). The already-stringified JSON array gets **double-encoded into a JSONB string scalar** (`"[\"<commit-sha>\"]"`), so `jsonb_typeof = 'string'`.

Migration **v119** added `CHECK (jsonb_typeof(completed_keys) = 'array')`, which then rejects the write. (Pre-v119 it silently stored a scalar; v119 turned the latent corruption into a hard sync stop.)

This is **postgres.js library behaviour**, not a connection-config quirk — the pools only configure `bigint` handling / prepare / timeouts, no custom JSON serializer. PGLite does **not** double-encode, so the PGLite path and the PGLite test coverage are unaffected.

Reproduced directly against Postgres:

```
sql.unsafe('SELECT jsonb_typeof($1::jsonb) t',       [JSON.stringify(['x'])]) -> 'string'   ← bug
sql.unsafe('SELECT jsonb_typeof($1::text::jsonb) t', [JSON.stringify(['x'])]) -> 'array'     ← fix
```

## Fix

Cast `$3::text::jsonb` so the parameter is sent as text and Postgres parses the JSON text into a real array. One-token change; `NULL` / `ON CONFLICT ... EXCLUDED` paths are unaffected (`recordCompleted` always passes `JSON.stringify(sorted)` of a string array). This is more conservative than passing the JS array directly — `executeRawJsonb()` already rejects top-level arrays as a cross-driver footgun, and `::text::jsonb` avoids array-binding ambiguity entirely.

The read/append paths are **not** affected: `loadOpCheckpoint()` guards legacy scalar rows before `jsonb_array_elements_text`, and `APPEND_PATHS_SQL` binds paths as `text[]`, not jsonb.

## Test

Adds `test/e2e/op-checkpoint-jsonb-postgres.test.ts` (skipped without `DATABASE_URL`, like every other `test/e2e/` file) asserting `jsonb_typeof(completed_keys) = 'array'` after `recordCompleted()` and a `loadOpCheckpoint` round-trip. Verified against a real Postgres:

- old `$N::jsonb` → **2 fail** (`... violates check constraint "op_checkpoints_completed_keys_array"`)
- new `$N::text::jsonb` → **2 pass**

PGLite-based `test/op-checkpoint.test.ts` cannot cover this (no double-encode on PGLite), hence the dedicated Postgres e2e file.

## Scope note (deliberately focused)

This PR fixes the **checkpoint hard-stop** only. The same positional-`JSON.stringify(...)` + `$N::jsonb` pattern exists at other sites (e.g. `conversation-parser/llm-base.ts`, `commands/agent.ts`, `commands/sources.ts`, `core/sources-ops.ts`, `minions/handlers/subagent.ts`, `search/query-cache.ts`, `code-intel/traversal-cache.ts`). Those don't hard-fail (no array/object CHECK) but can **silently** store JSONB string scalars on Postgres; some readers defensively parse them, which masks rather than fixes. Worth a follow-up — and note `scripts/check-jsonb-pattern.sh` only catches interpolation-style `JSON.stringify(x)::jsonb`, not positional `executeRaw(..., [JSON.stringify(x)])`, so it doesn't flag this class. Left out of this PR to keep the sync fix small and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
