### PR TITLE
fix(remediation): gate sync/extract recs on real extraction lag, not the stale_pages proxy

### DIFF
--- a/src/core/brain-score-recommendations.ts
+++ b/src/core/brain-score-recommendations.ts
@@ -146,6 +146,16 @@ export interface RecommendationContext {
   chatModel?: string;
   /** Whether the chat provider has a usable API key. */
   hasChatApiKey?: boolean;
+  /**
+   * Count of pages needing link/timeline extraction — the SAME staleness the
+   * `gbrain extract --stale` walk and doctor's `links_extraction_lag` check use
+   * (`engine.countStalePagesForExtraction`). Gates the sync→extract pipeline
+   * (sync.repo / extract.all). Replaces the old `health.stale_pages` gate, which
+   * counted "pages whose updated_at predates their newest timeline entry" — a
+   * proxy that broke when the updated_at-on-timeline-insert trigger was dropped
+   * (migration v10) and never reflected real extraction work.
+   */
+  extractionLagPages?: number;
 }
 
 /** Triage result for one check. */
@@ -192,20 +202,28 @@ export function computeRecommendations(
   const source = ctx.sourceId ?? 'default';
 
   // ---------------------------------------------------------------------
-  // sync.repo — fires when sync hasn't run recently OR pages are stale
+  // sync.repo + extract.all — the materialization pipeline, gated on the REAL
+  // extraction lag (pages whose link/timeline edges are stale), NOT on the
+  // legacy `health.stale_pages` proxy. `extractionLagPages` comes from the same
+  // counter the `extract --stale` walk + doctor's `links_extraction_lag` use, so
+  // the recommendation can only fire when running extract will actually reduce
+  // it (and clear the rec). See RecommendationContext.extractionLagPages.
+  // sync.repo is the prerequisite: re-sync so pages are current before extract
+  // materializes their edges.
   // ---------------------------------------------------------------------
-  if (ctx.repoPath && health.stale_pages > 0) {
+  const extractionLag = ctx.extractionLagPages ?? 0;
+  if (ctx.repoPath && extractionLag > 0) {
     const params = { repoPath: ctx.repoPath, sourceId: ctx.sourceId, noEmbed: true };
     out.push({
       id: 'sync.repo',
       job: 'sync',
       params,
       idempotency_key: idemKey(source, 'sync', params),
-      severity: health.stale_pages > 50 ? 'high' : 'medium',
-      est_seconds: Math.min(600, 30 + health.stale_pages * 0.5),
+      severity: extractionLag > 50 ? 'high' : 'medium',
+      est_seconds: Math.min(600, 30 + extractionLag * 0.5),
       est_usd_cost: 0,  // sync is fs+DB only
       depends_on: [],
-      rationale: `${health.stale_pages} stale page${health.stale_pages === 1 ? '' : 's'} on disk`,
+      rationale: `Sync before extracting ${extractionLag} page${extractionLag === 1 ? '' : 's'} with stale link/timeline edges`,
       status: 'remediable',
     });
   }
@@ -237,7 +255,7 @@ export function computeRecommendations(
       est_seconds: Math.min(3600, 5 + health.missing_embeddings * 0.05),
       est_usd_cost,
       // sync should run first so embed sees fresh pages.
-      depends_on: ctx.repoPath && health.stale_pages > 0 ? ['sync.repo'] : [],
+      depends_on: ctx.repoPath && extractionLag > 0 ? ['sync.repo'] : [],
       rationale: `${health.missing_embeddings} chunk${health.missing_embeddings === 1 ? '' : 's'} invisible to vector search`,
       status: 'remediable',
     });
@@ -267,7 +285,7 @@ export function computeRecommendations(
   // Triggered when sync.repo fires (because sync was set to noEmbed:true,
   // and noExtract:true after T5 lands → extract job is the materializer).
   // ---------------------------------------------------------------------
-  if (ctx.repoPath && health.stale_pages > 0) {
+  if (ctx.repoPath && extractionLag > 0) {
     const params = { mode: 'all', dir: ctx.repoPath };
     out.push({
       id: 'extract.all',
@@ -278,7 +296,7 @@ export function computeRecommendations(
       est_seconds: Math.min(600, 30 + health.page_count * 0.01),
       est_usd_cost: 0,
       depends_on: ['sync.repo'],
-      rationale: 'Materialize link + timeline edges from fresh pages',
+      rationale: `Materialize link + timeline edges for ${extractionLag} page${extractionLag === 1 ? '' : 's'} with stale extraction`,
       status: 'remediable',
     });
   }

--- a/src/core/remediation/context.ts
+++ b/src/core/remediation/context.ts
@@ -62,11 +62,22 @@ export async function loadRecommendationContext(
     const fromCfg = cfgField ? (fileCfg as Record<string, unknown> | null)?.[cfgField] : undefined;
     return !!(process.env[envVar] || fromCfg);
   });
+  // Real extraction-lag count — the SAME staleness `gbrain extract --stale`
+  // processes (engine.countStalePagesForExtraction). Drives the sync→extract
+  // recommendation pipeline; replaces the legacy `health.stale_pages` proxy
+  // that no longer reflected real extraction work after the v10 trigger drop.
+  let extractionLagPages = 0;
+  try {
+    extractionLagPages = await engine.countStalePagesForExtraction();
+  } catch {
+    /* counter unavailable (very old brain / mid-migration) — leave at 0 */
+  }
   return {
     repoPath: repoPath ?? undefined,
     embeddingModel,
     embeddingDimensions,
     embeddingProviderConfigured: embeddingConfigured,
     hasChatApiKey: !!(process.env.ANTHROPIC_API_KEY || fileCfg?.anthropic_api_key),
+    extractionLagPages,
   };
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1309,6 +1309,15 @@ export interface BrainStats {
 export interface BrainHealth {
   page_count: number;
   embed_coverage: number;
+  /**
+   * LEGACY proxy: count of pages whose `updated_at` predates their newest
+   * timeline entry. This bumped meaningfully only while a trigger updated
+   * `pages.updated_at` on timeline insert; that trigger was dropped in
+   * migration v10, so the metric no longer reflects real "needs work" state.
+   * NO LONGER gates remediations — the sync→extract pipeline now gates on
+   * `RecommendationContext.extractionLagPages` (the real extraction-lag from
+   * `countStalePagesForExtraction`). Retained for the CLI health line + back-compat.
+   */
   stale_pages: number;
   /**
    * Islanded pages — zero inbound AND zero outbound links. A hub page

--- a/test/brain-score-recommendations.test.ts
+++ b/test/brain-score-recommendations.test.ts
@@ -119,13 +119,12 @@ describe('computeRecommendations', () => {
     expect(recs.find((r) => r.id === 'embed.stale')).toBeUndefined();
   });
 
-  test('stale pages + dead links produce sync + backlinks + extract', () => {
+  test('extraction lag + dead links produce sync + backlinks + extract', () => {
     const health = makeHealth({
-      stale_pages: 25,
       dead_links: 8,
       brain_score: 70,
     });
-    const recs = computeRecommendations(health, { repoPath: '/brain', embeddingProviderConfigured: true });
+    const recs = computeRecommendations(health, { repoPath: '/brain', embeddingProviderConfigured: true, extractionLagPages: 25 });
     const ids = recs.map((r) => r.id);
     expect(ids).toContain('sync.repo');
     expect(ids).toContain('backlinks.fix');
@@ -133,18 +132,17 @@ describe('computeRecommendations', () => {
   });
 
   test('extract.all depends on sync.repo (D14: stable ids)', () => {
-    const health = makeHealth({ stale_pages: 10 });
-    const recs = computeRecommendations(health, { repoPath: '/brain', embeddingProviderConfigured: true });
+    const health = makeHealth();
+    const recs = computeRecommendations(health, { repoPath: '/brain', embeddingProviderConfigured: true, extractionLagPages: 10 });
     const extract = recs.find((r) => r.id === 'extract.all');
     expect(extract?.depends_on).toContain('sync.repo');
   });
 
-  test('embed.stale depends on sync.repo when sync also needed', () => {
+  test('embed.stale depends on sync.repo when extraction also needed', () => {
     const health = makeHealth({
-      stale_pages: 10,
       missing_embeddings: 100,
     });
-    const recs = computeRecommendations(health, { repoPath: '/brain', embeddingProviderConfigured: true });
+    const recs = computeRecommendations(health, { repoPath: '/brain', embeddingProviderConfigured: true, extractionLagPages: 10 });
     const embed = recs.find((r) => r.id === 'embed.stale');
     expect(embed?.depends_on).toContain('sync.repo');
   });
@@ -159,9 +157,9 @@ describe('computeRecommendations', () => {
   test('severity ordering: critical before high before medium', () => {
     const health = makeHealth({
       missing_embeddings: 100,  // critical
-      stale_pages: 80,          // high
     });
-    const recs = computeRecommendations(health, { repoPath: '/brain', embeddingProviderConfigured: true });
+    // extractionLagPages > 50 → sync.repo fires at 'high' severity.
+    const recs = computeRecommendations(health, { repoPath: '/brain', embeddingProviderConfigured: true, extractionLagPages: 80 });
     const critIdx = recs.findIndex((r) => r.severity === 'critical');
     const highIdx = recs.findIndex((r) => r.severity === 'high');
     expect(critIdx).toBeLessThan(highIdx);
@@ -170,11 +168,10 @@ describe('computeRecommendations', () => {
   // D6 #5 — THE critical regression test for the agent contract.
   test('D6 #5: determinism — same input twice produces identical output', () => {
     const health = makeHealth({
-      stale_pages: 10,
       missing_embeddings: 50,
       dead_links: 3,
     });
-    const ctx = { repoPath: '/brain', embeddingProviderConfigured: true, sourceId: 'default' };
+    const ctx = { repoPath: '/brain', embeddingProviderConfigured: true, sourceId: 'default', extractionLagPages: 10 };
     const run1 = computeRecommendations(health, ctx);
     const run2 = computeRecommendations(health, ctx);
     expect(JSON.stringify(run1)).toBe(JSON.stringify(run2));

--- a/test/remediation-context-extraction-lag.test.ts
+++ b/test/remediation-context-extraction-lag.test.ts
@@ -1,0 +1,47 @@
+// test/remediation-context-extraction-lag.test.ts
+//
+// Pins the v-next fix: the sync→extract remediation pipeline gates on REAL
+// extraction lag, not the legacy `health.stale_pages` proxy (which counted
+// "updated_at predates newest timeline entry" — meaningless after the v10
+// trigger drop). loadRecommendationContext now populates `extractionLagPages`
+// from `engine.countStalePagesForExtraction` — the SAME counter the
+// `gbrain extract --stale` walk and doctor's `links_extraction_lag` use — so a
+// recommendation can only fire when running extract will actually reduce it.
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { loadRecommendationContext } from '../src/core/remediation/context.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+describe('loadRecommendationContext — extractionLagPages wiring', () => {
+  it('is 0 on an empty brain (nothing to extract)', async () => {
+    const ctx = await loadRecommendationContext(engine);
+    expect(ctx.extractionLagPages).toBe(0);
+  });
+
+  it('reflects the real extraction-lag count once a page needs extraction', async () => {
+    // A freshly-imported page has links_extracted_at = NULL, which the canonical
+    // countStalePagesForExtraction predicate counts as stale-for-extraction.
+    await engine.putPage('p0', {
+      title: 'p0',
+      type: 'note' as never,
+      compiled_truth: 'body that is long enough to pass any minimum-length guards in the codebase',
+      timeline: '',
+      frontmatter: {},
+      source_path: 'p0.md',
+    });
+    const ctx = await loadRecommendationContext(engine);
+    expect(ctx.extractionLagPages).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Problem

The `sync.repo` and `extract.all` remediations (and `embed.stale`'s sync prerequisite) gate on `health.stale_pages`, defined in both engines as:

```sql
count(*) FROM pages p WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
```

i.e. "pages whose content `updated_at` predates their newest timeline entry." That was a meaningful proxy only while a trigger bumped `pages.updated_at` on every timeline insert — **a trigger dropped in migration v10** (`drop_timeline_search_trigger`). Since then the metric reflects a near-never condition, yet it still fires the two recommendations with the rationale **"N stale pages on disk"** — which is not what it measures and disagrees with both `gbrain sync` (commit-clean) and `doctor`'s `links_extraction_lag`. Operators see sync/extract recs that don't map to real work.

## Fix — gate on the real extraction lag

- `RecommendationContext` gains **`extractionLagPages`**, populated by `loadRecommendationContext` from **`engine.countStalePagesForExtraction`** — the *same* counter the `gbrain extract --stale` walk processes and doctor's `links_extraction_lag` check reports. So the recommendation fires **iff running `extract` will actually reduce it**, and clears once extraction is current. No re-implemented predicate → no drift between the recommender and the job it recommends.
- `sync.repo` / `extract.all` / `embed.stale`'s sync-dependency now gate on `extractionLagPages`; rationale text is honest (`"N page(s) with stale link/timeline edges"`). The sync→extract pipeline shape is unchanged (sync is the prerequisite that brings pages current before extract materializes their edges).
- `health.stale_pages` is **retained** (CLI health line + back-compat — no API/type break) but marked **legacy** in its docstring and **no longer gates any recommendation**.

## Testing

- `test/brain-score-recommendations.test.ts` updated to drive the gate via `ctx.extractionLagPages` (the pure-function pins for `sync.repo`/`extract.all`/`embed.stale` dependencies + severity ordering + determinism).
- `test/remediation-context-extraction-lag.test.ts` (new): PGLite engine test pins that `loadRecommendationContext` reports 0 on an empty brain and >0 once a page needs extraction.
- `bun run typecheck` clean · `bash scripts/run-verify-parallel.sh` 30/30 · recommender + onboard + advisor/features suites green (0 fail).

Companion to #2361 (terminate the `onboard --auto` loop) and #2362 (capability/content gates) — together they make `onboard --auto` recommend only work that can actually clear. Versioning/CHANGELOG left to the maintainer's ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)