### PR TITLE
fix(mcp): whoami over stdio returns local identity instead of unknown_transport

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -1601,6 +1601,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
       try {
         toolResult = await dispatchToolCall(engine, name, params as Record<string, unknown> | undefined, {
           remote: true,
+          transport: 'http',
           takesHoldersAllowList: tokenAllowList,
           sourceId: tokenSourceId,
           metaHook: getBrainHotMemoryMeta,

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -300,6 +300,19 @@ export interface OperationContext {
    */
   remote: boolean;
   /**
+   * Which MCP transport delivered this call, when it came over MCP.
+   * `'stdio'` is the local pipe (`gbrain serve`) — remote/untrusted by the
+   * trust boundary, but auth-less BY DESIGN (no per-token auth on a local
+   * pipe; see src/mcp/server.ts). `'http'` is the OAuth/bearer HTTP transport,
+   * which threads `auth`. Unset for the trusted local CLI path.
+   *
+   * whoami uses this to distinguish "stdio pipe, legitimately auth-less"
+   * (report transport: 'local') from "HTTP transport that dropped auth"
+   * (a real bug → fail-closed unknown_transport). Do NOT use this to grant
+   * trust — `remote` remains the trust discriminator.
+   */
+  transport?: 'stdio' | 'http';
+  /**
    * Subagent runtime context (v0.16+). Set by the subagent tool dispatcher when
    * dispatching an op as a tool call from an LLM loop. Used to enforce per-op
    * agent policy (e.g. put_page namespace rule).
@@ -3650,6 +3663,15 @@ const whoami: Operation = {
     // of `ctx.remote === false`. Empty scopes array forces clients to
     // special-case `transport: 'local'` explicitly.
     if (ctx.remote === false) {
+      return { transport: 'local', scopes: [] };
+    }
+    // The stdio MCP pipe (`gbrain serve`) is remote/untrusted by the trust
+    // boundary but carries no per-token auth by design (local pipe — see
+    // src/mcp/server.ts). That is NOT the "transport dropped auth" bug; it is
+    // the expected shape for stdio. Report it as a local, unprivileged
+    // identity (empty scopes grant nothing — no trust escalation). Only an
+    // auth-less HTTP transport is a genuine bug, so it stays fail-closed.
+    if (ctx.transport === 'stdio') {
       return { transport: 'local', scopes: [] };
     }
     if (!ctx.auth) {

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -30,6 +30,13 @@ export interface ToolResult {
 export interface DispatchOpts {
   /** Defaults to true (remote/untrusted). Local CLI callers (`gbrain call`) pass false. */
   remote?: boolean;
+  /**
+   * Which MCP transport delivered this call. `'stdio'` set by the stdio
+   * server (local pipe, no per-token auth), `'http'` by the HTTP transport.
+   * Threaded into OperationContext.transport so whoami can distinguish a
+   * legitimately auth-less stdio pipe from an HTTP transport that dropped auth.
+   */
+  transport?: 'stdio' | 'http';
   /** Override the default stderr logger (e.g. CLI uses console.* directly). */
   logger?: OperationContext['logger'];
   /**
@@ -210,6 +217,7 @@ export function buildOperationContext(
     // this fallback covers code paths that historically passed undefined.
     sourceId: opts.sourceId ?? 'default',
     auth: opts.auth,
+    transport: opts.transport,
   };
 }
 

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -381,6 +381,7 @@ export async function startHttpTransport(opts: HttpTransportOptions) {
         // path defaults to 'default' per AuthResult.sourceId above.
         const result = await dispatchToolCall(engine, toolName, args, {
           remote: true,
+          transport: 'http',
           takesHoldersAllowList: auth.takesHoldersAllowList,
           sourceId: auth.sourceId,
           // #1336: thread the token's federated_read grant so read ops scope

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -42,6 +42,10 @@ export async function startMcpServer(engine: BrainEngine) {
     // `gbrain call <op>` (sets remote=false in src/cli.ts).
     return dispatchToolCall(engine, name, params, {
       remote: true,
+      // Identify the stdio local pipe so whoami reports a local (unprivileged)
+      // identity instead of fail-closing on the by-design absence of per-token
+      // auth. Does NOT loosen trust — remote stays true.
+      transport: 'stdio',
       takesHoldersAllowList: ['world'],
       // v0.31: source defaults to 'default' for stdio (no per-token scope).
       // Operators who want a different source on stdio MCP should set

--- a/test/whoami.test.ts
+++ b/test/whoami.test.ts
@@ -94,12 +94,59 @@ describe('whoami op contract', () => {
     expect(result.expires_at).toBeNull();
   });
 
+  // stdio MCP pipe (`gbrain serve`): remote/untrusted by the trust boundary
+  // but auth-less BY DESIGN (a local pipe has no per-token auth). This is NOT
+  // the "transport dropped auth" bug below — it is the expected shape for
+  // stdio, so whoami reports a local, unprivileged identity instead of
+  // throwing. Regression guard for the long-standing unknown_transport thrown
+  // on every stdio whoami call.
+  test('stdio transport returns local identity with empty scopes (no auth by design)', async () => {
+    const result = (await whoami.handler(
+      ctxWith({ remote: true, transport: 'stdio', auth: undefined }),
+      {},
+    )) as any;
+    expect(result.transport).toBe('local');
+    expect(result.scopes).toEqual([]);
+  });
+
+  test('stdio transport grants nothing even if a stale auth blob leaked through', async () => {
+    // Empty scopes regardless of auth: the stdio pipe must never surface
+    // privileges. remote stays true, so all untrusted-caller protections hold.
+    const result = (await whoami.handler(
+      ctxWith({
+        remote: true,
+        transport: 'stdio',
+        auth: {
+          token: 'x',
+          clientId: 'gbrain_cl_123',
+          scopes: ['admin'],
+          expiresAt: 999999,
+        } as AuthInfo,
+      }),
+      {},
+    )) as any;
+    expect(result.transport).toBe('local');
+    expect(result.scopes).toEqual([]);
+  });
+
   // Q3: ambiguous transport — fail-closed. The footgun this guards against
   // is a future transport that lands without threading auth, where a buggy
   // caller might trust whoami's output to gate sensitive ops.
   test('unknown_transport throws when remote=true AND auth is missing', async () => {
     try {
       await whoami.handler(ctxWith({ remote: true, auth: undefined }), {});
+      throw new Error('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(OperationError);
+      expect((e as OperationError).message).toMatch(/unknown_transport|did not thread/);
+    }
+  });
+
+  test('unknown_transport still throws for an auth-less HTTP transport (fail-closed preserved)', async () => {
+    // The stdio relaxation must NOT extend to HTTP: an HTTP transport that
+    // drops auth is a genuine bug and stays fail-closed.
+    try {
+      await whoami.handler(ctxWith({ remote: true, transport: 'http', auth: undefined }), {});
       throw new Error('expected throw');
     } catch (e) {
       expect(e).toBeInstanceOf(OperationError);


### PR DESCRIPTION
# PR title

fix(mcp): whoami over stdio returns local identity instead of unknown_transport

> Note: this repo's convention prefixes PR titles with the next version
> (`vX.Y.Z.W ...`). I left that off because an external branch can't know the
> next `/ship` version. Add it when you bump, e.g.
> `v0.42.53.0 fix(mcp): whoami over stdio ...`.

# PR body

## Problem

Calling `whoami` over the **stdio MCP transport** (`gbrain serve`, the
Claude Desktop / Claude Code default) always throws:

```
unknown_transport: whoami called over a remote transport that did not thread
ctx.auth. This is a transport bug — every remote call site must populate
ctx.auth or set ctx.remote === false.
```

The stdio pipe is `remote: true` (untrusted, per the trust boundary) but
carries **no per-token auth by design** — a local pipe has no OAuth/bearer
token (see the comment at `src/mcp/server.ts`). `whoami` required `ctx.auth`
for any `remote !== false` call, so it could never succeed over stdio. The
contract had no way for stdio to satisfy it: it can't set `remote: false`
(that would loosen trust) and it has no auth to thread.

## Fix

Thread an explicit `transport: 'stdio' | 'http'` signal from the MCP dispatch
sites into `OperationContext`. `whoami` now returns a local, unprivileged
identity for the stdio pipe:

```json
{ "transport": "local", "scopes": [] }
```

Why this is safe:

- **No trust change.** `ctx.remote` stays `true` for stdio — every
  untrusted-caller protection (`file_upload` confinement, the `takes`
  holder allow-list `['world']`, source isolation) is unchanged.
- **No privilege.** `scopes: []` grants nothing; consumers that gate on
  scopes get zero.
- **HTTP stays fail-closed.** The `unknown_transport` throw is preserved for
  an auth-less **HTTP** transport, which is a genuine bug — the relaxation is
  scoped to the stdio pipe only.
- Anyone who can talk to the stdio pipe already has local execution as the
  user (they spawned the process), so reporting "local" reveals/grants
  nothing new.

## Changes

| File | Change |
|---|---|
| `src/core/operations.ts` | add `OperationContext.transport`; `whoami` stdio branch returns local identity |
| `src/mcp/dispatch.ts` | `DispatchOpts.transport` + thread onto context in `buildOperationContext` |
| `src/mcp/server.ts` | stdio server tags `transport: 'stdio'` (remote stays true) |
| `src/mcp/http-transport.ts`, `src/commands/serve-http.ts` | tag `transport: 'http'` for consistency |
| `test/whoami.test.ts` | stdio returns local + grants nothing; HTTP without auth still fail-closed |

## Tests

- `bun test test/whoami.test.ts` → 12 pass / 0 fail (9 existing + 3 new).
- `bun run typecheck` → clean.

No `VERSION` / `CHANGELOG` bump — left to your `/ship` flow to avoid conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
