### PR TITLE
feat(autopilot): operator opt-out — exclude a source from the knowledge cycle via config.autopilot_cycle=false

### DIFF
--- a/docs/guides/multi-source-brains.md
+++ b/docs/guides/multi-source-brains.md
@@ -109,6 +109,25 @@ behave exactly as before — every page appears in search.
 
 Flip later with `gbrain sources federate <id>` / `unfederate <id>`.
 
+## Autopilot cycle flag
+
+Every source row also stores `config.autopilot_cycle: boolean` in its JSONB
+config, controlling whether autopilot manages the source.
+
+| Value | Meaning |
+|-------|---------|
+| unset (default) / `true` | Source participates in the autopilot knowledge cycle: per-source sync + extract + full cycle. |
+| `false` | Source is excluded from autopilot — skipped at every per-source dispatch site and by the matching doctor freshness checks. |
+
+The use case is a source kept current by a dedicated external sync pipeline
+(say `my-code-repo`, re-synced by its own CI) rather than autopilot's
+per-source loop. Opting it out stops the two pipelines from racing the same
+source while leaving search, federation, and manual `gbrain sync <id>`
+untouched.
+
+Flip later with `gbrain sources no-cycle <id>` (opt out) / `cycle <id>`
+(re-enable, the default — clears the flag).
+
 ## Commands
 
 Full subcommand reference:
@@ -126,6 +145,8 @@ gbrain sources attach <id>     Write .gbrain-source in CWD (like kubectl context
 gbrain sources detach          Remove .gbrain-source from CWD.
 gbrain sources federate <id>
 gbrain sources unfederate <id>
+gbrain sources no-cycle <id>   Exclude a source from the autopilot knowledge cycle.
+gbrain sources cycle <id>      Re-enable the autopilot cycle (the default).
 ```
 
 ## Citation format for agents

--- a/src/commands/autopilot-fanout.ts
+++ b/src/commands/autopilot-fanout.ts
@@ -33,6 +33,7 @@
 import type { BrainEngine, SourceRow } from '../core/engine.ts';
 import type { MinionQueue } from '../core/minions/queue.ts';
 import { NON_GLOBAL_PHASES, GLOBAL_PHASES, LAST_GLOBAL_AT_KEY } from '../core/cycle.ts';
+import { isAutopilotCycleEnabled } from '../core/sources-load.ts';
 
 const FULL_CYCLE_FLOOR_MIN = 60;
 
@@ -77,6 +78,10 @@ export interface FanoutResult {
   skipped_cap: string[];
   /** Source ids skipped because they're in failure cooldown (#2194 fix #2). */
   skipped_cooldown: string[];
+  /** Source ids skipped because the operator excluded them from the autopilot
+   *  cycle (`config.autopilot_cycle === false`) — e.g. a code source maintained
+   *  by a dedicated external sync pipeline rather than the knowledge cycle. */
+  skipped_cycle_disabled: string[];
   /** True when this tick fell back to the legacy single-job path
    *  (no sources rows / engine empty). */
   legacy_fallback: boolean;
@@ -330,11 +335,17 @@ export function selectSourcesForDispatch(
   floorMin = FULL_CYCLE_FLOOR_MIN,
   recentFailures: Map<string, SourceFailure> = new Map(),
   cooldownOpts: CooldownOpts = { baseMin: FAILURE_COOLDOWN_BASE_MIN, capMin: FAILURE_COOLDOWN_CAP_MIN },
-): { dispatch: SourceRow[]; skippedFresh: SourceRow[]; skippedCap: SourceRow[]; skippedCooldown: SourceRow[] } {
+): { dispatch: SourceRow[]; skippedFresh: SourceRow[]; skippedCap: SourceRow[]; skippedCooldown: SourceRow[]; skippedCycleDisabled: SourceRow[] } {
   const stale: SourceRow[] = [];
   const fresh: SourceRow[] = [];
   const cooldown: SourceRow[] = [];
+  const cycleDisabled: SourceRow[] = [];
   for (const s of sources) {
+    // Operator opt-out: a source with `config.autopilot_cycle === false` is
+    // excluded from the knowledge cycle entirely (it's maintained by a dedicated
+    // external sync pipeline). Checked before freshness so it never dispatches,
+    // regardless of staleness.
+    if (!isAutopilotCycleEnabled(s.config)) { cycleDisabled.push(s); continue; }
     if (!isSourceStale(s, now, floorMin)) { fresh.push(s); continue; }
     // #2194 fix #2: a stale source that recently failed is held in cooldown so
     // it can't re-dispatch every tick (the storm). Success clears it.
@@ -353,7 +364,7 @@ export function selectSourcesForDispatch(
   });
   const dispatch = stale.slice(0, fanoutMax);
   const skippedCap = stale.slice(fanoutMax);
-  return { dispatch, skippedFresh: fresh, skippedCap, skippedCooldown: cooldown };
+  return { dispatch, skippedFresh: fresh, skippedCap, skippedCooldown: cooldown, skippedCycleDisabled: cycleDisabled };
 }
 
 /**
@@ -405,7 +416,7 @@ export async function dispatchPerSource(
     } else {
       log(`[dispatch] job #${job.id} autopilot-cycle (legacy single-source)`);
     }
-    return { dispatched: [], skipped_fresh: [], skipped_cap: [], skipped_cooldown: [], legacy_fallback: true };
+    return { dispatched: [], skipped_fresh: [], skipped_cap: [], skipped_cooldown: [], skipped_cycle_disabled: [], legacy_fallback: true };
   }
 
   // #2194 fix #2: load recent per-source failures + cooldown knobs so a
@@ -424,7 +435,7 @@ export async function dispatchPerSource(
     cooldownOpts = { baseMin: 0, capMin: FAILURE_COOLDOWN_CAP_MIN };
   }
 
-  const { dispatch, skippedFresh, skippedCap, skippedCooldown } =
+  const { dispatch, skippedFresh, skippedCap, skippedCooldown, skippedCycleDisabled } =
     selectSourcesForDispatch(sources, opts.fanoutMax, Date.now(), FULL_CYCLE_FLOOR_MIN, recentFailures, cooldownOpts);
 
   const dispatched: string[] = [];
@@ -502,11 +513,19 @@ export async function dispatchPerSource(
     }));
   }
 
+  if (skippedCycleDisabled.length > 0 && opts.jsonMode) {
+    emit(JSON.stringify({
+      event: 'fanout_cycle_disabled_skipped',
+      sources: skippedCycleDisabled.map(s => s.id),
+    }));
+  }
+
   return {
     dispatched,
     skipped_fresh: skippedFresh.map(s => s.id),
     skipped_cap: skippedCap.map(s => s.id),
     skipped_cooldown: skippedCooldown.map(s => s.id),
+    skipped_cycle_disabled: skippedCycleDisabled.map(s => s.id),
     legacy_fallback: false,
   };
 }

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -648,12 +648,16 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
         try {
           const { isFederatedV2Enabled } = await import('../core/feature-flags.ts');
           if (await isFederatedV2Enabled(engine)) {
-            const { loadAllSources } = await import('../core/sources-load.ts');
+            const { loadAllSources, isAutopilotCycleEnabled } = await import('../core/sources-load.ts');
             const sources = await loadAllSources(engine);
             const intervalMs = baseInterval * 1000;
             const now = Date.now();
             for (const src of sources) {
               if (!src.local_path) continue;
+              // Operator opt-out: sources excluded from the autopilot cycle
+              // (`config.autopilot_cycle === false`) are synced by a dedicated
+              // external pipeline, not by autopilot freshness.
+              if (!isAutopilotCycleEnabled(src.config)) continue;
               const lastSyncMs = src.last_sync_at ? new Date(src.last_sync_at).getTime() : 0;
               const ageMs = now - lastSyncMs;
               if (ageMs < intervalMs) continue; // fresh enough
@@ -740,12 +744,15 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
                 }
 
                 if (submittedToday < maxJobsToday) {
-                  const { loadAllSources } = await import('../core/sources-load.ts');
+                  const { loadAllSources, isAutopilotCycleEnabled } = await import('../core/sources-load.ts');
                   const { countExtractAtomsBacklog } = await import('../core/cycle/extract-atoms.ts');
                   const sources = await loadAllSources(engine);
                   for (const src of sources) {
                     if (submittedToday >= maxJobsToday) break; // brain-wide daily cap (fairness)
                     if (!src.local_path) continue;
+                    // Operator opt-out: sources excluded from the autopilot cycle
+                    // (`config.autopilot_cycle === false`) don't get per-source atom drains.
+                    if (!isAutopilotCycleEnabled(src.config)) continue;
                     const backlog = await countExtractAtomsBacklog(engine, src.id);
                     if (backlog === null || backlog <= threshold) continue;
                     // Time-sloted key (CODEX #2): a static key would block the
@@ -906,6 +913,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
               skipped_fresh: result.skipped_fresh,
               skipped_cap: result.skipped_cap,
               skipped_cooldown: result.skipped_cooldown,
+              skipped_cycle_disabled: result.skipped_cycle_disabled,
               legacy_fallback: result.legacy_fallback,
               fanout_max: fanoutMax,
               score,
@@ -914,7 +922,8 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
             console.log(
               `[dispatch] fanout: ${result.dispatched.length} dispatched, ` +
               `${result.skipped_fresh.length} fresh, ${result.skipped_cap.length} capped, ` +
-              `${result.skipped_cooldown.length} cooldown ` +
+              `${result.skipped_cooldown.length} cooldown, ` +
+              `${result.skipped_cycle_disabled.length} cycle-disabled ` +
               `(score=${score}, max=${fanoutMax})`,
             );
           }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2255,9 +2255,15 @@ export async function checkSourceRoutingHealth(engine: BrainEngine): Promise<Che
  */
 export async function checkFederationHealth(engine: BrainEngine): Promise<Check> {
   try {
-    const { loadAllSources } = await import('../core/sources-load.ts');
+    const { loadAllSources, isAutopilotCycleEnabled } = await import('../core/sources-load.ts');
     const { computeAllSourceMetrics } = await import('../core/source-health.ts');
-    const sources = await loadAllSources(engine, { includeArchived: false });
+    // Operator opt-out: drop sources with config.autopilot_cycle === false from
+    // the per-source health evaluation (same spirit as excluding archived). An
+    // excluded source's sync lag / embed coverage stop advancing once autopilot
+    // stops cycling it, so it must not FAIL/warn here or emit a "run gbrain sync"
+    // remediation it can't act on.
+    const sources = (await loadAllSources(engine, { includeArchived: false }))
+      .filter((s) => isAutopilotCycleEnabled(s.config));
     if (sources.length <= 1) {
       return {
         name: 'federation_health',
@@ -3373,6 +3379,7 @@ export async function checkSyncFreshness(
   opts?: { nowMs?: number; localOnly?: boolean },
 ): Promise<Check> {
   try {
+    const { isAutopilotCycleEnabled } = await import('../core/sources-load.ts');
     // v0.41.27.0: SELECT widens to carry last_commit + chunker_version so
     // the git short-circuit gate (below) can compare against what
     // `gbrain sync`'s up-to-date predicate at sync.ts:1057+1075 checks.
@@ -3386,13 +3393,23 @@ export async function checkSyncFreshness(
       last_commit: string | null;
       chunker_version: string | null;
       newest_content_at: Date | null;
+      config: Record<string, unknown> | string | null;
     }>(
       // v0.41.32.0: newest_content_at feeds the REMOTE (non-localOnly) lag so
       // doctorReportRemote never shells out to git on a DB-supplied local_path.
-      `SELECT id, name, local_path, last_sync_at, last_commit, chunker_version, newest_content_at FROM sources WHERE local_path IS NOT NULL`,
+      // `config` carries the operator autopilot_cycle opt-out (read below).
+      `SELECT id, name, local_path, last_sync_at, last_commit, chunker_version, newest_content_at, config FROM sources WHERE local_path IS NOT NULL`,
     );
 
-    if (sources.length === 0) {
+    // Operator opt-out: a source with config.autopilot_cycle === false has its
+    // last_sync_at frozen by design (autopilot stops syncing it). Drop it from
+    // the per-source staleness evaluation entirely — like the archived filter —
+    // so it can't FAIL sync_freshness or emit a "run gbrain sync" remediation.
+    // Dropping it up front also keeps the 3-bucket count invariant
+    // (unchanged + synced_recently + stale === sources.length) intact.
+    const cycledSources = sources.filter((s) => isAutopilotCycleEnabled(s.config));
+
+    if (cycledSources.length === 0) {
       return {
         name: 'sync_freshness',
         status: 'ok',
@@ -3474,7 +3491,7 @@ export async function checkSyncFreshness(
       /* db-lock unavailable — skip in-progress detection, staleness stands. */
     }
 
-    for (const source of sources) {
+    for (const source of cycledSources) {
       // Embed source.id in user-visible messages so `gbrain sync --source <id>`
       // matches what the user copy-pastes. Show display name in parens when set.
       const display = source.name && source.name !== source.id
@@ -3598,11 +3615,11 @@ export async function checkSyncFreshness(
     // v0.41.27.0: D2 ok-message reshape. Three branches surface what the
     // git short-circuit actually did so operators understand "unchanged
     // since last sync" vs "synced recently".
-    if (unchanged_count === sources.length) {
+    if (unchanged_count === cycledSources.length) {
       return {
         name: 'sync_freshness',
         status: 'ok',
-        message: `All ${sources.length} federated source(s) up to date (no new commits since last sync)${inProgressNote}`,
+        message: `All ${cycledSources.length} federated source(s) up to date (no new commits since last sync)${inProgressNote}`,
         details,
       };
     }
@@ -3610,14 +3627,14 @@ export async function checkSyncFreshness(
       return {
         name: 'sync_freshness',
         status: 'ok',
-        message: `${sources.length} federated source(s): ${synced_recently_count} synced recently, ${unchanged_count} unchanged since last sync${inProgressNote}`,
+        message: `${cycledSources.length} federated source(s): ${synced_recently_count} synced recently, ${unchanged_count} unchanged since last sync${inProgressNote}`,
         details,
       };
     }
     return {
       name: 'sync_freshness',
       status: 'ok',
-      message: `All ${sources.length} federated source(s) synced recently${inProgressNote}`,
+      message: `All ${cycledSources.length} federated source(s) synced recently${inProgressNote}`,
       details,
     };
   } catch (e) {
@@ -3763,6 +3780,7 @@ export async function checkCycleFreshness(
   opts?: { nowMs?: number },
 ): Promise<Check> {
   try {
+    const { isAutopilotCycleEnabled } = await import('../core/sources-load.ts');
     const sources = await engine.listAllSources({ localPathOnly: true });
     if (sources.length === 0) {
       return {
@@ -3786,6 +3804,14 @@ export async function checkCycleFreshness(
       const display = source.name && source.name !== source.id
         ? `'${source.id}' (${source.name})`
         : `'${source.id}'`;
+      // Operator opt-out: a source with config.autopilot_cycle === false is
+      // excluded from the autopilot knowledge cycle, so its last_full_cycle_at
+      // intentionally stops advancing. Skip it from the staleness evaluation
+      // (like the archived short-circuit) so it can't FAIL the check or emit a
+      // misleading "run gbrain dream" remediation.
+      if (!isAutopilotCycleEnabled(source.config)) {
+        continue;
+      }
       const raw = source.config?.last_full_cycle_at;
       if (typeof raw !== 'string') {
         issues.push(`Source ${display} has never completed a full cycle`);

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -16,6 +16,8 @@
  *   gbrain sources detach        — remove .gbrain-source from CWD
  *   gbrain sources federate <id>   — sources.config.federated = true
  *   gbrain sources unfederate <id> — sources.config.federated = false
+ *   gbrain sources no-cycle <id>   — sources.config.autopilot_cycle = false
+ *   gbrain sources cycle <id>      — removes sources.config.autopilot_cycle (re-enables)
  *
  * NOT in scope for Step 6 (deferred per plan):
  *   - import-from-github (needs SSRF + clone integration)
@@ -729,6 +731,34 @@ async function runFederate(engine: BrainEngine, args: string[], value: boolean):
   }
 }
 
+// ── Subcommand: cycle / no-cycle (autopilot cycle opt-out) ──
+
+async function runAutopilotCycle(engine: BrainEngine, args: string[], value: boolean): Promise<void> {
+  const id = args[0];
+  if (!id) {
+    console.error(`Usage: gbrain sources ${value ? 'cycle' : 'no-cycle'} <id>`);
+    process.exit(2);
+  }
+  const src = await fetchSource(engine, id);
+  if (!src) {
+    console.error(`Source "${id}" not found.`);
+    process.exit(4);
+  }
+  const config = parseConfig(src.config);
+  if (value) {
+    // Re-enable = back to the default (unset). Remove the key rather than
+    // writing `true` so the persisted config matches a never-opted-out source.
+    delete config.autopilot_cycle;
+  } else {
+    config.autopilot_cycle = false;
+  }
+  await engine.executeRaw(
+    `UPDATE sources SET config = $1::jsonb WHERE id = $2`,
+    [JSON.stringify(config), id],
+  );
+  console.log(`Source "${id}" now ${value ? 'participates in the autopilot knowledge cycle (per-source sync + extract + full cycle)' : 'is excluded from the autopilot knowledge cycle (maintain it via its own external sync pipeline)'}.`);
+}
+
 // ── v0.40 sources status (D12) ──────────────────────────────
 async function runStatus(engine: BrainEngine, args: string[]): Promise<void> {
   const json = args.includes('--json');
@@ -1317,6 +1347,8 @@ export async function runSources(engine: BrainEngine, args: string[]): Promise<v
     case 'detach':     runDetach(); return;
     case 'federate':   return runFederate(engine, rest, true);
     case 'unfederate': return runFederate(engine, rest, false);
+    case 'cycle':      return runAutopilotCycle(engine, rest, true);
+    case 'no-cycle':   return runAutopilotCycle(engine, rest, false);
     case 'archive':    return runArchive(engine, rest);
     case 'restore':    return runRestore(engine, rest);
     case 'purge':      return runPurge(engine, rest);
@@ -1384,6 +1416,11 @@ Subcommands:
                                     targeting the brain you think you are.
   federate <id>                     Make source appear in cross-source default search.
   unfederate <id>                   Isolate source from default search.
+  no-cycle <id>                     Exclude source from the autopilot knowledge
+                                    cycle (per-source sync + extract + full
+                                    cycle). For a source kept current by its own
+                                    external sync pipeline.
+  cycle <id>                        Re-enable the autopilot cycle (the default).
   set-cr-mode <id> <none|title|per_chunk_synopsis>
                                     Per-source contextual retrieval mode
                                     override (v0.40.3.0). Pass "unset" or

--- a/src/core/sources-load.ts
+++ b/src/core/sources-load.ts
@@ -61,6 +61,21 @@ export function isSourceFederated(config: unknown): boolean {
 }
 
 /**
+ * Whether a source participates in the autopilot knowledge cycle.
+ *
+ * Operators can opt a source OUT by setting `config.autopilot_cycle = false`
+ * (e.g. a code repository kept current by a dedicated external sync pipeline
+ * rather than autopilot's per-source sync + extract + full cycle). Excluded
+ * sources are skipped at every per-source dispatch site (fan-out cycle,
+ * freshness-sync, atom auto-drain) and by doctor's per-source cycle/sync
+ * freshness checks. Enabled-by-default: only the literal boolean `false`
+ * opts out, so missing/true/null all keep cycling.
+ */
+export function isAutopilotCycleEnabled(config: unknown): boolean {
+  return parseSourceConfig(config).autopilot_cycle !== false;
+}
+
+/**
  * Enumerate every source. Order: 'default' first, then alphabetical by id.
  *
  * Caller filters in-process when the predicate is cheap (federatedOnly,

--- a/test/autopilot-fanout.test.ts
+++ b/test/autopilot-fanout.test.ts
@@ -128,6 +128,23 @@ describe('selectSourcesForDispatch', () => {
     expect(result.skippedFresh).toEqual([]);
     expect(result.skippedCap).toEqual([]);
   });
+
+  test('config.autopilot_cycle === false excludes a source even when stale', () => {
+    // `disabled` is never-cycled (maximally stale) but opted out of the cycle.
+    const disabled = src('disabled', null, { autopilot_cycle: false });
+    const result = selectSourcesForDispatch([disabled, src('a'), fresh('b', 5)], 10, NOW);
+    expect(result.dispatch.map(s => s.id)).toEqual(['a']);
+    expect(result.skippedCycleDisabled.map(s => s.id)).toEqual(['disabled']);
+    expect(result.skippedFresh.map(s => s.id)).toEqual(['b']);
+  });
+
+  test('config.autopilot_cycle !== false (true / unset) still participates', () => {
+    const enabled = src('enabled', null, { autopilot_cycle: true });
+    const unset = src('unset'); // no autopilot_cycle key
+    const result = selectSourcesForDispatch([enabled, unset], 10, NOW);
+    expect(result.dispatch.map(s => s.id).sort()).toEqual(['enabled', 'unset']);
+    expect(result.skippedCycleDisabled).toEqual([]);
+  });
 });
 
 describe('resolveFanoutMax', () => {

--- a/test/doctor-cycle-freshness.test.ts
+++ b/test/doctor-cycle-freshness.test.ts
@@ -29,10 +29,15 @@ beforeEach(async () => {
 const NOW = Date.parse('2026-05-22T12:00:00.000Z');
 const agoH = (h: number) => new Date(NOW - h * 3600_000).toISOString();
 
-async function seed(id: string, lastFullCycleAt?: string, opts: { local_path?: string | null } = {}): Promise<void> {
-  const config = lastFullCycleAt
-    ? JSON.stringify({ last_full_cycle_at: lastFullCycleAt })
-    : '{}';
+async function seed(
+  id: string,
+  lastFullCycleAt?: string,
+  opts: { local_path?: string | null; autopilotCycle?: boolean } = {},
+): Promise<void> {
+  const configObj: Record<string, unknown> = {};
+  if (lastFullCycleAt) configObj.last_full_cycle_at = lastFullCycleAt;
+  if (opts.autopilotCycle !== undefined) configObj.autopilot_cycle = opts.autopilotCycle;
+  const config = JSON.stringify(configObj);
   const localPath = opts.local_path === undefined ? `/tmp/${id}` : opts.local_path;
   await engine.executeRaw(
     `INSERT INTO sources (id, name, local_path, config, archived, created_at)
@@ -111,6 +116,28 @@ describe('doctor checkCycleFreshness', () => {
     const result = await checkCycleFreshness(engine, { nowMs: NOW });
     expect(result.status).toBe('warn');
     expect(result.message).toMatch(/unparseable/);
+  });
+
+  test('cycle-excluded source (config.autopilot_cycle === false) does NOT fail', async () => {
+    await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
+    // Stale by every threshold (72h > 24h fail) AND never updated since the
+    // operator opted it out — would normally FAIL + emit a "gbrain dream"
+    // remediation. The opt-out must suppress both.
+    await seed('opted-out', agoH(72), { autopilotCycle: false });
+    const result = await checkCycleFreshness(engine, { nowMs: NOW });
+    expect(result.status).toBe('ok');
+    expect(result.message).not.toMatch(/gbrain dream --source/);
+    expect(result.message).not.toMatch(/opted-out/);
+  });
+
+  test('cycle-excluded source does not mask a real fail from an included source', async () => {
+    await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
+    await seed('opted-out', agoH(72), { autopilotCycle: false }); // excluded → ignored
+    await seed('stale', agoH(72));                                 // included → fail
+    const result = await checkCycleFreshness(engine, { nowMs: NOW });
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/stale/);
+    expect(result.message).not.toMatch(/opted-out/);
   });
 
   test('local_path NULL sources are filtered (codex P1-4 parity)', async () => {


### PR DESCRIPTION
## What

Adds a per-source operator opt-out from the autopilot knowledge cycle. A source whose config sets `autopilot_cycle: false` is excluded from autopilot's per-source work, so a repository kept current by a **dedicated external sync pipeline** is never re-dispatched by autopilot — regardless of staleness.

## Why

When a source repo is maintained by its own out-of-band sync (e.g. a nightly `gbrain sync --strategy code` job), autopilot's per-source cycle becomes a second writer: it re-imports with the default `markdown` strategy and runs per-source extract / atom-drain on it. That fights the dedicated pipeline over the `last_commit` bookmark and pulls unwanted content into the brain. There was no first-class way to say "this source is managed elsewhere — leave it out of the cycle."

## What it does

Enabled-by-default; only the literal boolean `false` opts out, so existing sources are unaffected. Gated behind a shared `isAutopilotCycleEnabled()` helper (mirrors `isSourceFederated`) at all three per-source dispatch points:

- fan-out source selection (`selectSourcesForDispatch`) — surfaced as a new `skipped_cycle_disabled` bucket in the fan-out result + `--json` telemetry
- the freshness-sync loop
- the per-source atom auto-drain loop

It also teaches the three `gbrain doctor` per-source freshness checks (`cycle_freshness`, `sync_freshness`, `federation_health`) to skip excluded sources — otherwise an opt-out source would stand-FAIL forever (its `last_full_cycle_at` stops advancing), depress `brain_score` (which feeds back into autopilot's own `shouldFullCycle` gate), and emit misleading "run gbrain dream/sync" remediation.

Operator surface: `gbrain sources cycle|no-cycle <id>` (symmetric with `federate`/`unfederate`), plus a note in `docs/guides/multi-source-brains.md`.

## Tests

- `test/autopilot-fanout.test.ts`: `autopilot_cycle: false` excludes even a maximally-stale source; `true`/unset still participates.
- `test/doctor-cycle-freshness.test.ts`: an excluded stale source returns `ok` (no FAIL, not named, no remediation) and doesn't mask a real FAIL from an included source.
- `bun run typecheck` clean; fan-out + doctor suites green; `scripts/check-jsonb-pattern.sh` passes.

## Notes

- No `VERSION` / `package.json` / `CHANGELOG` bump — left for the maintainer fix-wave per `docs/RELEASING.md`.
- Possible follow-up: the brain-wide global maintenance phases (embed / orphans / symbol-edges) intentionally still cover an excluded source's already-imported content — the opt-out is about the per-source *refresh* cycle, not excising existing content from search / hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
