### PR TITLE
fix(search): normalize `/` in FTS queries so slash-containing terms match

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/paperclip/instances/default/gbrain/code/node_modules

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -59,6 +59,7 @@ import {
   EmbeddingColumnNotRegisteredError,
 } from './search/embedding-column.ts';
 import { hasCJK, escapeLikePattern } from './cjk.ts';
+import { normalizeKeywordQuery } from './search/keyword.ts';
 
 type PGLiteDB = PGlite;
 
@@ -1533,7 +1534,11 @@ export class PGLiteEngine implements BrainEngine {
     }
 
     // v0.20.0 Cathedral II Layer 10 C1/C2: language + symbol-kind filters.
-    const params: unknown[] = [query, innerLimit, limit, offset];
+    // Normalize the FTS query so `/` is split into separate words before
+    // websearch_to_tsquery parses it; Postgres' default parser otherwise
+    // treats `foo/bar` as a single `file`-alias token that never matches
+    // indexed text. See normalizeKeywordQuery in ./search/keyword.ts.
+    const params: unknown[] = [normalizeKeywordQuery(query), innerLimit, limit, offset];
     let extraFilter = '';
     if (opts?.language) {
       params.push(opts.language);
@@ -1770,7 +1775,10 @@ export class PGLiteEngine implements BrainEngine {
       });
     }
 
-    const params: unknown[] = [query, limit, offset];
+    // Same `/` normalization as searchKeyword above — searchKeywordChunks is
+    // the chunk-grain anchor primitive, so a slash in the query would silently
+    // empty the anchor pool too.
+    const params: unknown[] = [normalizeKeywordQuery(query), limit, offset];
     let extraFilter = '';
     if (opts?.language) {
       params.push(opts.language);

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -61,6 +61,7 @@ import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
 import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause, buildRecencyComponentSql, buildBestPerPagePoolCte } from './search/sql-ranking.ts';
 import { DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_DIMENSIONS } from './ai/defaults.ts';
 import { DELETE_BATCH_SIZE } from './engine-constants.ts';
+import { normalizeKeywordQuery } from './search/keyword.ts';
 
 function escapeSqlStringLiteral(value: string): string {
   return value.replace(/'/g, "''");
@@ -1564,7 +1565,11 @@ export class PostgresEngine implements BrainEngine {
     const hardExcludePrefixes = resolveHardExcludes(opts?.exclude_slug_prefixes, opts?.include_slug_prefixes);
     const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes);
 
-    const params: unknown[] = [query];
+    // Normalize the FTS query so `/` is split into separate words before
+    // websearch_to_tsquery parses it; otherwise Postgres' default parser
+    // treats `foo/bar` as a single `file`-alias token and the query returns
+    // zero hits. See normalizeKeywordQuery in ./search/keyword.ts.
+    const params: unknown[] = [normalizeKeywordQuery(query)];
     let typeClause = '';
     if (type) {
       params.push(type);
@@ -1713,7 +1718,11 @@ export class PostgresEngine implements BrainEngine {
     const hardExcludePrefixes = resolveHardExcludes(opts?.exclude_slug_prefixes, opts?.include_slug_prefixes);
     const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes);
 
-    const params: unknown[] = [query];
+    // Normalize the FTS query so `/` is split into separate words before
+    // websearch_to_tsquery parses it; otherwise Postgres' default parser
+    // treats `foo/bar` as a single `file`-alias token and the query returns
+    // zero hits. See normalizeKeywordQuery in ./search/keyword.ts.
+    const params: unknown[] = [normalizeKeywordQuery(query)];
     let typeClause = '';
     if (type) {
       params.push(type);

--- a/src/core/search/keyword.ts
+++ b/src/core/search/keyword.ts
@@ -1,6 +1,22 @@
 import type { BrainEngine } from '../engine.ts';
 import type { SearchResult, SearchOpts } from '../types.ts';
 
+// Postgres' default text-search parser classifies `foo/bar` as a single
+// `file`-alias token. Under the english config that alias maps to the
+// `simple` dictionary, so `websearch_to_tsquery('english', 'foo/bar')`
+// produces the single lexeme `'foo/bar'`. That lexeme never matches indexed
+// chunk text whose `to_tsvector('english', …)` split on the slash, so any
+// query containing `/` silently returns zero hits — e.g. pasting a meeting
+// title like `Author1/Author2 - Topic`. Replacing `/` with whitespace breaks
+// the file-alias token into ordinary `asciiword`s, which then stem and match
+// through the english dictionary the same way the manually-despaced query
+// does. Quoted phrases (`"foo/bar"`) still become phrase queries
+// (`foo <-> bar`), which is at least as permissive as the no-hits baseline.
+// The semantic / vector path is unaffected.
+export function normalizeKeywordQuery(query: string): string {
+  return query.replace(/\//g, ' ').replace(/\s+/g, ' ').trim();
+}
+
 export async function keywordSearch(
   engine: BrainEngine,
   query: string,

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -216,6 +216,27 @@ describe('PGLiteEngine: Search', () => {
     expect(results.length).toBe(0);
   });
 
+  // Regression: queries containing `/` used to silently return zero hits.
+  // Postgres' default text-search parser classifies `foo/bar` as a `file`-
+  // alias token mapped to the `simple` dictionary, so it becomes a single
+  // un-stemmed lexeme `'foo/bar'` that almost never matches indexed text.
+  // searchKeyword now normalizes `/` to whitespace before websearch_to_tsquery
+  // parses, so the FTS path matches the same content the user would find by
+  // manually dropping the slash.
+  test('searchKeyword: query with `/` matches content with the same words', async () => {
+    // Both lexemes co-occur in the `companies/novamind` chunk
+    // ('NovaMind builds AI agents for enterprise'). Pre-fix this returned 0
+    // because `NovaMind/AI` was parsed as a single file-alias token.
+    const singleSlash = await engine.searchKeyword('NovaMind/AI');
+    expect(singleSlash.length).toBeGreaterThan(0);
+    expect(singleSlash[0].slug).toBe('companies/novamind');
+
+    // Slash in the middle of a multi-word query — same fix path.
+    const midSlash = await engine.searchKeyword('AI NovaMind/agents');
+    expect(midSlash.length).toBeGreaterThan(0);
+    expect(midSlash[0].slug).toBe('companies/novamind');
+  });
+
   test('tsvector trigger populates search_vector on insert', async () => {
     // Verify the PL/pgSQL trigger fires and content_chunks.search_vector is
     // populated from chunk_text. v0.20.0 Cathedral II Layer 3 moved FTS from


### PR DESCRIPTION
## Problem

Keyword search silently returns **zero hits** for any query containing a `/`.

Postgres' default text-search parser classifies `foo/bar` as a single `file`-alias token. Under the `english` config that alias maps to the `simple` dictionary, so `websearch_to_tsquery('english', 'foo/bar')` produces the single un-stemmed lexeme `'foo/bar'`, which never matches indexed chunk text whose `to_tsvector('english', …)` split on the slash. Pasting a meeting/title fragment like `Author1/Author2 - Topic` hits this every time, while the same query with the slash removed matches fine.

Reproduce:
```sql
SELECT to_tsvector('english','NovaMind builds AI agents') @@ websearch_to_tsquery('english','NovaMind/AI');  -- f
SELECT to_tsvector('english','NovaMind builds AI agents') @@ websearch_to_tsquery('english','NovaMind AI');   -- t
```

## Fix

Add `normalizeKeywordQuery()` in `src/core/search/keyword.ts` (replace `/` with whitespace, collapse runs) and route the FTS-bound query params through it in both engines before `websearch_to_tsquery`:
- `PostgresEngine.searchKeyword` / `searchKeywordChunks`
- `PGLiteEngine.searchKeyword` / `searchKeywordChunks`

The slash-split tokens then stem and match through the english dictionary exactly as the manually-despaced query does. The semantic / vector path is untouched; quoted phrases (`"foo/bar"`) still degrade to phrase queries (`foo <-> bar`), which is at least as permissive as the current no-hits baseline.

## Tests

Adds a PGLite regression test (`test/pglite-engine.test.ts`) covering a leading `NovaMind/AI` query and a mid-query `AI NovaMind/agents` query; both now return the matching page where they previously returned nothing. Full `bun test test/pglite-engine.test.ts` passes (101 tests).
