### PR TITLE
fix(salience): exclude briefings/* from their own Brain Pulse

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -5328,6 +5328,11 @@ export class PGLiteEngine implements BrainEngine {
       params.push(escaped);
       prefixCondition = `AND p.slug LIKE $${params.length} ESCAPE '\\'`;
     }
+    // Exclude briefing pages from their own Brain Pulse — see the matching
+    // block in postgres-engine.ts getRecentSalience() for the rationale.
+    const excludeBriefings = !(slugPrefix && slugPrefix.startsWith('briefings'))
+      ? `AND p.slug NOT LIKE 'briefings/%'`
+      : '';
     params.push(limit);
     const limitParam = `$${params.length}`;
 
@@ -5363,6 +5368,7 @@ export class PGLiteEngine implements BrainEngine {
          LEFT JOIN takes t ON t.page_id = p.id AND t.active = TRUE
         WHERE GREATEST(p.updated_at, COALESCE(p.salience_touched_at, p.updated_at)) >= $1::timestamptz
           ${prefixCondition}
+          ${excludeBriefings}
         GROUP BY p.id
         ORDER BY score DESC
         LIMIT ${limitParam}`,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5485,6 +5485,13 @@ export class PostgresEngine implements BrainEngine {
     const prefixCondition = slugPrefix
       ? sql`AND p.slug LIKE ${slugPrefix.replace(/[\\%_]/g, (c) => '\\' + c) + '%'} ESCAPE '\\'`
       : sql``;
+    // Exclude briefing pages from their own Brain Pulse. The daily briefing
+    // writes to briefings/<date>, gets re-ingested, and would otherwise top
+    // the next salience report as pure self-reference with no real signal.
+    // Suppress unless the caller explicitly asked for the briefings/ prefix.
+    const excludeBriefings = !(slugPrefix && slugPrefix.startsWith('briefings'))
+      ? sql`AND p.slug NOT LIKE 'briefings/%'`
+      : sql``;
     // v0.29.1: third score term via buildRecencyComponentSql. Default
     // 'flat' = v0.29.0 behavior (1 / (1 + days_old)). 'on' opts into the
     // per-prefix decay map (concepts/ evergreen, daily/ aggressive, etc.).
@@ -5518,6 +5525,7 @@ export class PostgresEngine implements BrainEngine {
         LEFT JOIN takes t ON t.page_id = p.id AND t.active = TRUE
        WHERE GREATEST(p.updated_at, COALESCE(p.salience_touched_at, p.updated_at)) >= ${boundaryIso}::timestamptz
          ${prefixCondition}
+         ${excludeBriefings}
        GROUP BY p.id
        ORDER BY score DESC
        LIMIT ${limit}

--- a/test/e2e/salience-pglite.test.ts
+++ b/test/e2e/salience-pglite.test.ts
@@ -112,4 +112,27 @@ describe('v0.29 E2E — getRecentSalience (Garry test)', () => {
     const rows = await engine.getRecentSalience({ days: 7, slugPrefix: 'nope/does-not-exist/' });
     expect(rows).toEqual([]);
   });
+
+  // The daily briefing writes to the vault and re-ingests as
+  // `briefings/<date>`. Without this filter the briefing itself would top
+  // every subsequent Brain Pulse — self-reference with no real signal.
+  describe('briefings excluded from their own Brain Pulse', () => {
+    test('default query hides briefings/* slugs', async () => {
+      await engine.putPage('briefings/2026-05-19', {
+        type: 'note',
+        title: 'Daily Briefing — 2026-05-19',
+        compiled_truth: 'Auto-generated cron briefing.',
+      });
+      const rows = await engine.getRecentSalience({ days: 7, limit: 50 });
+      expect(rows.some(r => r.slug.startsWith('briefings/'))).toBe(false);
+    });
+
+    test('explicit slugPrefix=briefings/ still returns them', async () => {
+      const rows = await engine.getRecentSalience({ days: 7, slugPrefix: 'briefings/' });
+      expect(rows.length).toBeGreaterThan(0);
+      for (const r of rows) {
+        expect(r.slug.startsWith('briefings/')).toBe(true);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The daily briefing writes its output back into the vault, where it re-ingests as `briefings/<date>`. On the next run that freshly-touched page tops `getRecentSalience()` (the Brain Pulse), so the briefing perpetually surfaces **itself** as the most salient recent activity — pure self-reference with no real signal. Over time the Pulse becomes a list of past briefings instead of the underlying knowledge that changed.

## Fix

Exclude `briefings/%` slugs from `getRecentSalience()` in both engines (`PostgresEngine`, `PGLiteEngine`), *unless* the caller explicitly scopes the query to the `briefings/` prefix (in which case they asked for them). The suppression is a single `AND p.slug NOT LIKE 'briefings/%'` clause gated on the requested `slugPrefix`.

## Tests

Adds PGLite E2E coverage in `test/e2e/salience-pglite.test.ts`:
- default query hides `briefings/*` slugs
- explicit `slugPrefix='briefings/'` still returns them

`bun test test/e2e/salience-pglite.test.ts` passes (7 tests).
