### PR TITLE
fix(anomalies): suppress cohorts without enough baseline history

### DIFF
--- a/src/core/cycle/anomaly.ts
+++ b/src/core/cycle/anomaly.ts
@@ -50,29 +50,39 @@ export function meanStddev(samples: number[]): { mean: number; stddev: number } 
  *
  * For each cohort:
  *   1. Compute (mean, stddev) over the baseline daily counts.
- *   2. If stddev > 0:    anomalous when `today.count > mean + sigma*stddev`.
+ *   2. If the cohort has fewer than `minBaselineDays` distinct days with
+ *      activity in the baseline window, **suppress it**. A
+ *      brand-new cohort or one with one day of import noise would otherwise
+ *      produce a 481σ "everything is anomalous" report.
+ *   3. If stddev > 0:    anomalous when `today.count > mean + sigma*stddev`.
  *      sigma_observed   = (today.count - mean) / stddev.
- *   3. If stddev == 0:   small-sample fallback — anomalous when
+ *   4. If stddev == 0:   small-sample fallback — anomalous when
  *      `today.count > mean + 1`. sigma_observed treated as a finite proxy
  *      `today.count - mean` so callers still get a usable sort key.
  *
  * Cohorts with no baseline rows AND no today rows are skipped. Cohorts
- * appearing only in `today` (a brand-new cohort) get a baseline_mean of 0
- * — they're surfaced as anomalies whenever today.count >= 2 (mean+1 fallback).
+ * appearing only in `today` (a brand-new cohort) have 0 active baseline
+ * days and are suppressed whenever `minBaselineDays > 0`.
  *
  * Returns top `limit` rows sorted by `sigma_observed` descending. Each row
  * caps `page_slugs` at 50 entries.
  *
- * @param baseline densified rows over the lookback window, grouped by cohort × day.
- * @param today    rows for the target day, grouped by cohort.
- * @param sigma    threshold multiplier (default 3.0).
- * @param limit    max anomalies to return (default 20).
+ * @param baseline         densified rows over the lookback window, grouped by cohort × day.
+ * @param today            rows for the target day, grouped by cohort.
+ * @param sigma            threshold multiplier (default 3.0).
+ * @param limit            max anomalies to return (default 20).
+ * @param minBaselineDays  minimum distinct active days a cohort needs in the
+ *                         baseline window before it can be flagged. Default 0
+ *                         at this pure-function layer (algorithm-only); the
+ *                         engine layer applies its own default (7) so the
+ *                         briefing/CLI surface gets the suppression.
  */
 export function computeAnomaliesFromBuckets(
   baseline: CohortDayRow[],
   today: CohortTodayRow[],
   sigma: number,
   limit: number = 20,
+  minBaselineDays: number = 0,
 ): AnomalyResult[] {
   // Group baseline samples by (cohort_kind, cohort_value).
   const baselineByCohort = new Map<string, number[]>();
@@ -90,6 +100,13 @@ export function computeAnomaliesFromBuckets(
   for (const t of today) {
     const key = cohortKey(t.cohort_kind, t.cohort_value);
     const samples = baselineByCohort.get(key) ?? [];
+    // Suppress cohorts whose baseline window doesn't have enough
+    // distinct active days. Zero-fill days don't count — we need real history.
+    if (minBaselineDays > 0) {
+      let activeDays = 0;
+      for (const c of samples) if (c > 0) activeDays++;
+      if (activeDays < minBaselineDays) continue;
+    }
     const { mean, stddev } = meanStddev(samples);
 
     let isAnomaly: boolean;

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -3375,12 +3375,17 @@ const find_anomalies: Operation = {
       type: 'number',
       description: 'Sigma threshold. Default 3.0.',
     },
+    min_baseline_days: {
+      type: 'number',
+      description: 'Min distinct active days a cohort needs in the baseline before it can fire. Default 7. Pass 0 to disable.',
+    },
   },
   handler: async (ctx, p) => {
     return ctx.engine.findAnomalies({
       since: typeof p.since === 'string' ? p.since : undefined,
       lookback_days: typeof p.lookback_days === 'number' ? p.lookback_days : undefined,
       sigma: typeof p.sigma === 'number' ? p.sigma : undefined,
+      min_baseline_days: typeof p.min_baseline_days === 'number' ? p.min_baseline_days : undefined,
     });
   },
   cliHints: { name: 'anomalies' },

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -5456,6 +5456,7 @@ export class PGLiteEngine implements BrainEngine {
   async findAnomalies(opts: AnomaliesOpts): Promise<AnomalyResult[]> {
     const sigma = opts.sigma ?? 3.0;
     const lookbackDays = Math.max(1, opts.lookback_days ?? 30);
+    const minBaselineDays = Math.max(0, opts.min_baseline_days ?? 7);
     const sinceIso = (opts.since ?? new Date().toISOString().slice(0, 10));
     const sinceDate = new Date(sinceIso + 'T00:00:00Z');
     const sinceEnd = new Date(sinceDate.getTime() + 86400000);
@@ -5558,7 +5559,7 @@ export class PGLiteEngine implements BrainEngine {
       })),
     ];
 
-    return computeAnomaliesFromBuckets(baseline, today, sigma);
+    return computeAnomaliesFromBuckets(baseline, today, sigma, 20, minBaselineDays);
   }
 }
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5600,6 +5600,7 @@ export class PostgresEngine implements BrainEngine {
     const sql = this.sql;
     const sigma = opts.sigma ?? 3.0;
     const lookbackDays = Math.max(1, opts.lookback_days ?? 30);
+    const minBaselineDays = Math.max(0, opts.min_baseline_days ?? 7);
     // Boundaries: today's window is [since, since+1day); baseline is [since-lookback, since).
     const sinceIso = (opts.since ?? new Date().toISOString().slice(0, 10)); // YYYY-MM-DD
     const sinceDate = new Date(sinceIso + 'T00:00:00Z');
@@ -5710,7 +5711,7 @@ export class PostgresEngine implements BrainEngine {
       })),
     ];
 
-    return computeAnomaliesFromBuckets(baseline, today, sigma);
+    return computeAnomaliesFromBuckets(baseline, today, sigma, 20, minBaselineDays);
   }
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -514,6 +514,12 @@ export interface AnomaliesOpts {
   lookback_days?: number;
   /** Sigma threshold. Default 3.0. */
   sigma?: number;
+  /**
+   * Minimum distinct active days a cohort needs in the baseline window before
+   * it can be flagged. Default 7 (prevents Day-1-of-import "every
+   * cohort is anomalous at 481σ" noise). Pass 0 to disable.
+   */
+  min_baseline_days?: number;
 }
 
 export interface AnomalyResult {

--- a/test/anomalies.test.ts
+++ b/test/anomalies.test.ts
@@ -80,13 +80,14 @@ describe('computeAnomaliesFromBuckets', () => {
     expect(computeAnomaliesFromBuckets(baseline, today, 3.0)).toEqual([]);
   });
 
-  test('brand-new cohort (no baseline) requires count >= 2', () => {
+  test('brand-new cohort (no baseline) requires count >= 2 when guard disabled', () => {
     // No baseline rows for "newtag"; today.count=2 → mean=0, stddev=0, threshold=mean+1=1, 2>1 ✓
+    // Pass minBaselineDays=0 to exercise the legacy small-sample fallback.
     const today: CohortTodayRow[] = [
       { cohort_kind: 'tag', cohort_value: 'newtag', count: 2, page_slugs: ['a','b'] },
       { cohort_kind: 'tag', cohort_value: 'singleton', count: 1, page_slugs: ['x'] },
     ];
-    const r = computeAnomaliesFromBuckets([], today, 3.0);
+    const r = computeAnomaliesFromBuckets([], today, 3.0, 20, 0);
     expect(r.length).toBe(1);
     expect(r[0].cohort_value).toBe('newtag');
   });
@@ -140,5 +141,93 @@ describe('computeAnomaliesFromBuckets', () => {
     const tagEntry = r.find(x => x.cohort_kind === 'tag');
     expect(tagEntry).toBeDefined();
     expect(tagEntry!.baseline_mean).toBe(0);
+  });
+});
+
+describe('min_baseline_days guard', () => {
+  function densify(values: number[], cohort_value: string, kind: 'tag' | 'type' = 'tag'): CohortDayRow[] {
+    return values.map((count, i) => ({
+      cohort_kind: kind,
+      cohort_value,
+      day: `2026-04-${String(i + 1).padStart(2, '0')}`,
+      count,
+    }));
+  }
+
+  test('cohort with no baseline rows is suppressed under default-7 guard', () => {
+    // Day-1-of-import noise: brand-new cohort, 0 active baseline days.
+    const today: CohortTodayRow[] = [
+      { cohort_kind: 'tag', cohort_value: 'fresh-import', count: 7, page_slugs: ['a','b','c','d','e','f','g'] },
+    ];
+    const r = computeAnomaliesFromBuckets([], today, 3.0, 20, 7);
+    expect(r).toEqual([]);
+  });
+
+  test('cohort with < N active baseline days is suppressed', () => {
+    // 30-day baseline window but only 3 days have any activity → not enough history.
+    const baseline: CohortDayRow[] = densify(
+      [1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+      'sparse'
+    );
+    const today: CohortTodayRow[] = [
+      { cohort_kind: 'tag', cohort_value: 'sparse', count: 7, page_slugs: ['p1','p2','p3','p4','p5','p6','p7'] },
+    ];
+    expect(computeAnomaliesFromBuckets(baseline, today, 3.0, 20, 7)).toEqual([]);
+  });
+
+  test('cohort with >= N active baseline days still fires', () => {
+    // 7 distinct active days out of 30 → threshold met, real anomaly fires.
+    const baseline: CohortDayRow[] = densify(
+      [1,0,1,0,1,0,1,0,1,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+      'borderline'
+    );
+    const today: CohortTodayRow[] = [
+      { cohort_kind: 'tag', cohort_value: 'borderline', count: 15, page_slugs: Array.from({length:15}, (_,i)=>`p${i}`) },
+    ];
+    const r = computeAnomaliesFromBuckets(baseline, today, 3.0, 20, 7);
+    expect(r.length).toBe(1);
+    expect(r[0].cohort_value).toBe('borderline');
+  });
+
+  test('only zero-filled baseline days do not count as active history', () => {
+    // 30 days of pure zero-fill (cohort_keys CTE in the engine includes this
+    // cohort because it appeared in the window, but every day was empty).
+    // Without the guard this would be a brand-new-cohort small-sample anomaly;
+    // with the guard it's suppressed.
+    const baseline: CohortDayRow[] = densify(
+      Array.from({length: 30}, () => 0),
+      'zeros-only'
+    );
+    const today: CohortTodayRow[] = [
+      { cohort_kind: 'tag', cohort_value: 'zeros-only', count: 5, page_slugs: ['a','b','c','d','e'] },
+    ];
+    expect(computeAnomaliesFromBuckets(baseline, today, 3.0, 20, 7)).toEqual([]);
+    // Same input with guard disabled: small-sample fallback fires.
+    expect(computeAnomaliesFromBuckets(baseline, today, 3.0, 20, 0).length).toBe(1);
+  });
+
+  test('passing min_baseline_days=0 disables the guard (legacy behavior)', () => {
+    const today: CohortTodayRow[] = [
+      { cohort_kind: 'tag', cohort_value: 'fresh-import', count: 7, page_slugs: ['a','b','c','d','e','f','g'] },
+    ];
+    const r = computeAnomaliesFromBuckets([], today, 3.0, 20, 0);
+    expect(r.length).toBe(1);
+    expect(r[0].cohort_value).toBe('fresh-import');
+  });
+
+  test('guard works mixed: dense cohort fires, sparse cohort suppressed', () => {
+    const baseline: CohortDayRow[] = [
+      // 10 active days, count=2 each → solid baseline
+      ...densify([2,2,2,2,2,2,2,2,2,2], 'dense'),
+      // 1 active day → not enough history
+      ...densify([3,0,0,0,0,0,0,0,0,0], 'sparse'),
+    ];
+    const today: CohortTodayRow[] = [
+      { cohort_kind: 'tag', cohort_value: 'dense', count: 8, page_slugs: ['a','b','c','d','e','f','g','h'] },
+      { cohort_kind: 'tag', cohort_value: 'sparse', count: 8, page_slugs: ['x'] },
+    ];
+    const r = computeAnomaliesFromBuckets(baseline, today, 3.0, 20, 7);
+    expect(r.length).toBe(1);
+    expect(r[0].cohort_value).toBe('dense');
   });
 });

--- a/test/e2e/anomalies-pglite.test.ts
+++ b/test/e2e/anomalies-pglite.test.ts
@@ -31,6 +31,15 @@ beforeAll(async () => {
     });
     await engine.addTag(slug, 'wedding');
   }
+  // Pin the wedding pages to noon UTC of TODAY. putPage stamps updated_at via
+  // the DB clock (server-local), while the anomaly window is derived from
+  // `new Date().toISOString()` (UTC); near a UTC midnight boundary those two
+  // dates disagree and the "today" window misses the pages. Anchor explicitly
+  // so the fixture is deterministic regardless of the runner's timezone.
+  await engine.executeRaw(
+    `UPDATE pages SET updated_at = '${TODAY}T12:00:00Z'::timestamptz
+      WHERE slug LIKE 'personal/wedding/%'`
+  );
 
   // 100 background pages, tagged with rotating "steady" tags, backdated.
   const RANDOM_TAGS = ['hardware', 'product', 'meeting'];
@@ -43,11 +52,12 @@ beforeAll(async () => {
     });
     await engine.addTag(slug, RANDOM_TAGS[i % RANDOM_TAGS.length]);
   }
-  // Spread the random pages randomly across the last 30 days
-  // (excluding today, so the wedding cohort is the only "today" spike).
+  // Spread the random pages randomly across the last 30 days relative to the
+  // same UTC TODAY the anomaly window uses (excluding today, so the wedding
+  // cohort is the only "today" spike).
   await engine.executeRaw(
     `UPDATE pages
-        SET updated_at = now() - interval '1 day' - (random() * interval '29 days')
+        SET updated_at = '${TODAY}T12:00:00Z'::timestamptz - interval '1 day' - (random() * interval '29 days')
       WHERE slug LIKE 'notes/random-%'`
   );
 });
@@ -57,8 +67,16 @@ afterAll(async () => {
 });
 
 describe('v0.29 E2E — findAnomalies (Garry test)', () => {
-  test('wedding-tag cohort fires as anomaly with sigma > 3 vs zero baseline', async () => {
-    const rows = await engine.findAnomalies({ since: TODAY, lookback_days: 30, sigma: 3.0 });
+  test('wedding-tag cohort fires as anomaly when guard is disabled', async () => {
+    // The wedding fixture is exactly the Day-1-of-import shape this guard suppresses
+    // by default: 0 active baseline days for the wedding tag. To prove the
+    // legacy detector behavior still works, pass min_baseline_days: 0.
+    const rows = await engine.findAnomalies({
+      since: TODAY,
+      lookback_days: 30,
+      sigma: 3.0,
+      min_baseline_days: 0,
+    });
     const wedding = rows.find(r => r.cohort_kind === 'tag' && r.cohort_value === 'wedding');
     expect(wedding).toBeDefined();
     expect(wedding!.count).toBe(7);
@@ -67,8 +85,12 @@ describe('v0.29 E2E — findAnomalies (Garry test)', () => {
     expect(wedding!.sigma_observed).toBeGreaterThan(3);
   });
 
-  test('returned page_slugs sample contains wedding pages', async () => {
-    const rows = await engine.findAnomalies({ since: TODAY, lookback_days: 30 });
+  test('returned page_slugs sample contains wedding pages (guard disabled)', async () => {
+    const rows = await engine.findAnomalies({
+      since: TODAY,
+      lookback_days: 30,
+      min_baseline_days: 0,
+    });
     const wedding = rows.find(r => r.cohort_kind === 'tag' && r.cohort_value === 'wedding');
     expect(wedding!.page_slugs.length).toBe(7);
     expect(wedding!.page_slugs.every(s => s.startsWith('personal/wedding/'))).toBe(true);
@@ -85,9 +107,9 @@ describe('v0.29 E2E — findAnomalies (Garry test)', () => {
     expect(rows).toEqual([]);
   });
 
-  test('high sigma threshold suppresses borderline cohorts', async () => {
-    const lowRows = await engine.findAnomalies({ since: TODAY, lookback_days: 30, sigma: 0.5 });
-    const highRows = await engine.findAnomalies({ since: TODAY, lookback_days: 30, sigma: 100 });
+  test('high sigma threshold suppresses borderline cohorts (guard disabled)', async () => {
+    const lowRows = await engine.findAnomalies({ since: TODAY, lookback_days: 30, sigma: 0.5, min_baseline_days: 0 });
+    const highRows = await engine.findAnomalies({ since: TODAY, lookback_days: 30, sigma: 100, min_baseline_days: 0 });
     // sigma=100 should suppress every cohort (would need a literally
     // impossible spike to fire). The wedding cohort fires at sigma 3 so
     // there's enough headroom for sigma=0.5 ⊇ sigma=100.
@@ -101,5 +123,26 @@ describe('v0.29 E2E — findAnomalies (Garry test)', () => {
       // not sigma * stddev. Confirm the sigma_observed is finite (no NaN).
       expect(Number.isFinite(weddingHigh.sigma_observed)).toBe(true);
     }
+  });
+});
+
+describe('Day-1-of-import anomaly suppression (E2E)', () => {
+  test('default min_baseline_days=7 suppresses the wedding cohort', async () => {
+    // Same fixture as the Garry test, but with the default guard active.
+    // The wedding tag has 0 active baseline days (all touches are today), so
+    // it must be suppressed — otherwise we'd report 481σ Day-1 noise.
+    const rows = await engine.findAnomalies({ since: TODAY, lookback_days: 30, sigma: 3.0 });
+    const wedding = rows.find(r => r.cohort_kind === 'tag' && r.cohort_value === 'wedding');
+    expect(wedding).toBeUndefined();
+  });
+
+  test('no cohort with enough baseline → empty array', async () => {
+    // The random pages were spread across 30 days but are not touched today.
+    // Combined with the wedding-tag suppression, the Day-1 result is [].
+    const rows = await engine.findAnomalies({ since: TODAY, lookback_days: 30 });
+    // All returned rows must have at least 7 distinct active days of baseline.
+    // (No way to introspect the baseline from the result, but the wedding/
+    // background fixture intentionally has none — so [] is the contract.)
+    expect(rows).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

`computeAnomaliesFromBuckets` flags a cohort whenever today's count clears the small-sample fallback (`count > mean + 1`). On a fresh import — or any cohort whose first real activity is *today* — the baseline window is all zero-fill, so **every brand-new cohort fires at once** and the Brain Pulse / `anomalies` report reads "everything is anomalous at 481σ." That Day-1 noise buries the genuine spikes the feature exists to surface.

## Fix

Add a `min_baseline_days` guard: a cohort must have at least that many *distinct active* baseline days (zero-fill days don't count) before it can be flagged.

- `computeAnomaliesFromBuckets(...)` gains a trailing `minBaselineDays = 0` param — **no behavior change** for direct callers.
- `PostgresEngine.findAnomalies` / `PGLiteEngine.findAnomalies` default the operation to **7**.
- The `find_anomalies` operation exposes `min_baseline_days` so callers can tune it or disable the guard (`0`).

## Tests

- `test/anomalies.test.ts` — unit coverage: suppress below threshold, fire at/above it, zero-fill days don't count toward active days, disabled at `0`.
- `test/e2e/anomalies-pglite.test.ts` — default `7` suppresses the Day-1 wedding cohort; `min_baseline_days: 0` reproduces the legacy firing behavior.

While updating the E2E fixture I also made its timestamps deterministic: it previously stamped pages via the server-local DB clock (`now()`) but derived the anomaly window from `new Date().toISOString()` (UTC), so the suite flaked whenever a run straddled a UTC midnight boundary. Pages are now anchored to the same UTC day the window uses.

`bun test test/anomalies.test.ts test/e2e/anomalies-pglite.test.ts` → 25 passing.
