### PR TITLE
fix(cycle): guard extract against empty-queue zero-walk + log symbol-resolve progress

### DIFF
--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -950,11 +950,55 @@ async function runPhaseSync(
   }
 }
 
+/**
+ * Decide the effective slug set for the cycle's extract phase.
+ *
+ * Extract runs in two modes:
+ *  - `changedSlugs === undefined` → full walk (first run / manual).
+ *  - `changedSlugs` defined → incremental: extract only those slugs.
+ *
+ * An *empty defined* array (`[]`) is the degenerate incremental case: sync ran
+ * but reported zero changed pages, so extract walks nothing. On a steady-state
+ * brain whose link graph is already built that is the correct, fast outcome.
+ *
+ * But if an out-of-band process drains git→DB before the cycle's own sync runs,
+ * sync sees HEAD == HEAD and returns `[]` even though links were never
+ * extracted — the incremental path then walks zero slugs and link coverage
+ * stays at zero indefinitely after a brain rebuild. Guard against that: when
+ * handed an empty defined queue, fall back to a full walk if the source has
+ * pages but no links originate from it. Brains that already have links keep the
+ * fast empty-incremental path (no extra work for the common case).
+ */
+export async function resolveExtractSlugs(
+  engine: BrainEngine,
+  changedSlugs: string[] | undefined,
+  sourceId: string | undefined,
+): Promise<string[] | undefined> {
+  if (!changedSlugs || changedSlugs.length !== 0 || !sourceId) return changedSlugs;
+  const pageRow = await engine.executeRaw<{ n: string }>(
+    `SELECT COUNT(*) AS n FROM pages WHERE source_id = $1 AND deleted_at IS NULL`,
+    [sourceId],
+  );
+  const linkRow = await engine.executeRaw<{ n: string }>(
+    `SELECT COUNT(*) AS n FROM links l
+       JOIN pages p ON p.id = l.from_page_id
+      WHERE p.source_id = $1`,
+    [sourceId],
+  );
+  const pageCount = parseInt(pageRow[0]?.n ?? '0', 10);
+  const linkCount = parseInt(linkRow[0]?.n ?? '0', 10);
+  // Pages exist but the link graph is empty → a prior sync drained the change
+  // queue without extract ever running. Force a full walk to rebuild links.
+  if (pageCount > 0 && linkCount === 0) return undefined;
+  return changedSlugs;
+}
+
 async function runPhaseExtract(
   engine: BrainEngine,
   brainDir: string,
   dryRun: boolean,
   changedSlugs?: string[],
+  sourceId?: string,
   signal?: AbortSignal,
 ): Promise<PhaseResult> {
   try {
@@ -971,29 +1015,32 @@ async function runPhaseExtract(
         details: { dryRun: true, reason: 'no_dry_run_support' },
       };
     }
+    // Guard against an empty incremental queue silently skipping a needed
+    // full walk when the link graph is empty (see resolveExtractSlugs).
+    const effectiveSlugs = await resolveExtractSlugs(engine, changedSlugs, sourceId);
     // Incremental path: if sync told us which slugs changed, only extract those.
     // On a 54K-page brain this turns a 10-minute full walk into a sub-second pass.
     const result = await runExtractCore(engine, {
       mode: 'all',
       dir: brainDir,
-      slugs: changedSlugs,  // undefined = full walk (first run / manual)
+      slugs: effectiveSlugs,  // undefined = full walk (first run / manual)
       signal,
     });
     const linksCreated = result?.links_created ?? 0;
     const timelineCreated = result?.timeline_entries_created ?? 0;
-    const incremental = changedSlugs !== undefined;
+    const incremental = effectiveSlugs !== undefined;
     return {
       phase: 'extract',
       status: 'ok',
       duration_ms: 0,
       summary: incremental
-        ? `${linksCreated} link(s), ${timelineCreated} timeline entries (incremental: ${changedSlugs.length} slugs)`
+        ? `${linksCreated} link(s), ${timelineCreated} timeline entries (incremental: ${effectiveSlugs.length} slugs)`
         : `${linksCreated} link(s), ${timelineCreated} timeline entries`,
       details: {
         linksCreated, timelineCreated,
         pages_processed: result?.pages_processed ?? 0,
         incremental,
-        ...(incremental ? { slugs_targeted: changedSlugs.length } : {}),
+        ...(incremental ? { slugs_targeted: effectiveSlugs.length } : {}),
       },
     };
   } catch (e) {
@@ -1134,8 +1181,27 @@ async function runPhaseResolveSymbolEdges(
     let totalResolved = 0;
     let totalAmbiguous = 0;
     let totalUnmatched = 0;
+    // Per-batch progress logging so a slow or wedged resolve_symbol_edges phase
+    // leaves a visible last-walked chunk count in the log instead of going dark
+    // for the whole phase. resolveSymbolEdgesIncremental walks chunks in
+    // batches and invokes onProgress after each batch commit.
+    const phaseStart = Date.now();
+    let lastProgressAt = Date.now();
     for (const s of sources) {
-      const stats = await resolveSymbolEdgesIncremental(engine, { sourceId: s.id });
+      const stats = await resolveSymbolEdgesIncremental(engine, {
+        sourceId: s.id,
+        onProgress: (ps) => {
+          const now = Date.now();
+          const batchMs = now - lastProgressAt;
+          lastProgressAt = now;
+          const elapsedS = ((now - phaseStart) / 1000).toFixed(1);
+          console.error(
+            `[resolve_symbol_edges] source=${s.id} chunks_walked=${ps.chunks_walked} batches=${ps.batches}` +
+            ` edges_examined=${ps.edges_examined} resolved=${ps.edges_resolved}` +
+            ` batch_ms=${batchMs} elapsed_s=${elapsedS}`,
+          );
+        },
+      });
       totalChunks += stats.chunks_walked;
       totalResolved += stats.edges_resolved;
       totalAmbiguous += stats.edges_ambiguous;
@@ -1706,7 +1772,10 @@ export async function runCycle(
         // If sync didn't run (phases exclude it) or failed, syncPagesAffected
         // is undefined → extract falls back to full walk (safe default).
         progress.start('cycle.extract');
-        const { result, duration_ms } = await timePhase(() => runPhaseExtract(engine, brainDir, dryRun, syncPagesAffected, opts.signal));
+        // Pass the resolved cycleSourceId so runPhaseExtract's empty-queue
+        // guard (resolveExtractSlugs) can count this source's pages/links and
+        // fall back to a full walk when the link graph is empty.
+        const { result, duration_ms } = await timePhase(() => runPhaseExtract(engine, brainDir, dryRun, syncPagesAffected, cycleSourceId, opts.signal));
         result.duration_ms = duration_ms;
         phaseResults.push(result);
         progress.finish();

--- a/test/cycle-extract-zero-walk-guard.test.ts
+++ b/test/cycle-extract-zero-walk-guard.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression guard for the dream/autopilot extract phase: an empty *defined*
+ * incremental queue (`changedSlugs: []`) must NOT silently skip a full walk
+ * when the source has pages but an empty link graph.
+ *
+ * Scenario: an out-of-band process drains git→DB before the cycle's own sync
+ * runs. Sync then sees HEAD == HEAD and returns `pagesAffected: []`. Treating
+ * that as "incremental queue of length 0" walks zero slugs even though links
+ * were never extracted — link coverage stays at zero indefinitely after a
+ * brain rebuild. resolveExtractSlugs() converts that degenerate `[]` to
+ * `undefined` (full walk) when pages exist but no links originate from the
+ * source, while preserving the fast empty-incremental path on brains that
+ * already have links.
+ *
+ * Uses PGLite/in-memory — no DB connection required.
+ */
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { resolveExtractSlugs } from '../src/core/cycle.ts';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+const SRC = 'default';
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({ engine: 'pglite' });
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+async function seedPage(slug: string, body: string): Promise<void> {
+  const [type, name] = slug.split('/');
+  await engine.putPage(slug, {
+    type: type as 'person' | 'company',
+    title: name,
+    compiled_truth: body,
+    timeline: '',
+    frontmatter: {},
+    content_hash: 'h',
+  });
+}
+
+describe('resolveExtractSlugs — empty-queue zero-walk guard', () => {
+  test('undefined queue is passed through unchanged (full walk)', async () => {
+    await seedPage('people/alice-example', '# alice');
+    expect(await resolveExtractSlugs(engine as unknown as BrainEngine, undefined, SRC)).toBeUndefined();
+  });
+
+  test('non-empty incremental queue is passed through unchanged', async () => {
+    await seedPage('people/alice-example', '# alice');
+    const slugs = ['people/alice-example'];
+    expect(await resolveExtractSlugs(engine as unknown as BrainEngine, slugs, SRC)).toEqual(slugs);
+  });
+
+  test('empty queue with pages but NO links → falls back to full walk (undefined)', async () => {
+    await seedPage('people/alice-example', '# alice');
+    await seedPage('people/bob-example', '# bob');
+    // No links inserted → empty link graph.
+    expect(await resolveExtractSlugs(engine as unknown as BrainEngine, [], SRC)).toBeUndefined();
+  });
+
+  test('empty queue with NO pages stays empty (nothing to rebuild)', async () => {
+    expect(await resolveExtractSlugs(engine as unknown as BrainEngine, [], SRC)).toEqual([]);
+  });
+
+  test('empty queue keeps fast empty-incremental path once links exist', async () => {
+    await seedPage('people/alice-example', '# alice\n\n[bob](people/bob-example)');
+    await seedPage('people/bob-example', '# bob');
+    await engine.addLinksBatch([
+      { from_slug: 'people/alice-example', to_slug: 'people/bob-example' },
+    ]);
+    expect(await resolveExtractSlugs(engine as unknown as BrainEngine, [], SRC)).toEqual([]);
+  });
+
+  test('empty queue without a sourceId is left untouched (cannot count)', async () => {
+    await seedPage('people/alice-example', '# alice');
+    expect(await resolveExtractSlugs(engine as unknown as BrainEngine, [], undefined)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Two independent robustness fixes to the dream / autopilot cycle, both isolated to `src/core/cycle.ts`:

### 1. Guard the extract phase against an empty-queue zero-walk

The extract phase treats a defined `changedSlugs` array as *incremental* — extract only those slugs. An **empty defined** array (`[]`) means sync reported zero changed pages. On a steady-state brain whose link graph is already built, walking nothing is the correct, fast outcome.

But when an out-of-band process drains git → DB **before** the cycle's own sync runs, sync sees `HEAD == HEAD` and returns `pagesAffected: []` even though links were never extracted. The incremental path then walks zero slugs, and **link coverage stays at zero indefinitely** after a brain rebuild. The same drained-queue path also nerfs downstream phases that key off the change set.

`resolveExtractSlugs()` (new, exported for testing) converts that degenerate `[]` to `undefined` (full walk) **only when** the source has pages but no links originate from it. Brains that already have links keep the fast empty-incremental path, so the common case pays nothing extra. The source id is threaded from the `cycleSourceId` already computed at cycle entry.

### 2. Per-batch progress logging in `resolve_symbol_edges`

`resolveSymbolEdgesIncremental` already exposes an `onProgress` callback, but the cycle phase ignored it — so a slow or wedged phase went dark for its whole duration with no way to tell how far it got. This wires `onProgress` to emit `chunks_walked` / `batches` / `edges_examined` / `resolved` plus per-batch and elapsed timing, leaving a visible last-walked checkpoint in the log.

## Why

Both are real production failure modes: (1) a brain that silently never rebuilds its link graph, and (2) an opaque multi-minute/hour phase with no observability when it stalls.

## Tests

- New `test/cycle-extract-zero-walk-guard.test.ts` (PGLite, in-memory) covers `resolveExtractSlugs`: `undefined` pass-through, non-empty pass-through, empty-with-pages-no-links → full walk, empty-no-pages stays empty, empty-once-links-exist keeps the fast path, and empty-without-sourceId untouched.
- Existing `test/extract-incremental.test.ts` (8 cases) still green.
- The logging change is observability-only (no behavior change).
