### PR TITLE
v0.42.53.1 fix(pglite): drain in-flight operations before close (#2348)

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -225,6 +225,7 @@ export class PGLiteEngine implements BrainEngine {
   readonly kind = 'pglite' as const;
   private _db: PGLiteDB | null = null;
   private _lock: LockHandle | null = null;
+  private _inFlight = new Set<Promise<unknown>>();
   // #2034: captured at connect() so reconnect() can restore the same data dir
   // after a drop, matching PostgresEngine's _savedConfig contract.
   private _savedConfig: EngineConfig | null = null;
@@ -271,13 +272,14 @@ export class PGLiteEngine implements BrainEngine {
     // why the CLI's exit paths read gbrain's own verdict
     // (cli-force-exit.ts currentExitCode), never ambient process.exitCode.
     try {
-      this._db = await preservingProcessExitCode(() =>
+      const rawDb = await preservingProcessExitCode(() =>
         PGlite.create({
           dataDir,
           loadDataDir,
           extensions: { vector, pg_trgm },
         }),
       );
+      this._db = this.trackDb(rawDb);
     } catch (err) {
       // v0.13.1: any PGLite.create() failure becomes actionable. v0.41.8.0
       // (#1340): the previous error hint hardcoded the macOS 26.3 link, but
@@ -317,6 +319,7 @@ export class PGLiteEngine implements BrainEngine {
     this._lock = null;
     try {
       if (db) {
+        await this.drainInFlightOperations();
         // Deliberately NOT wrapped in preservingProcessExitCode: close's
         // status write (0) is long-standing baseline behavior that test-runner
         // processes depend on (wrapping it flipped bun test's own exit code —
@@ -329,6 +332,38 @@ export class PGLiteEngine implements BrainEngine {
       if (lock?.acquired) {
         await releaseLock(lock);
       }
+    }
+  }
+
+  private trackInFlight<T>(promise: Promise<T>): Promise<T> {
+    const tracked = promise.finally(() => {
+      this._inFlight.delete(tracked);
+    });
+    this._inFlight.add(tracked);
+    return tracked;
+  }
+
+  private trackDb(db: PGLiteDB): PGLiteDB {
+    return new Proxy(db, {
+      get: (target, prop) => {
+        const value = Reflect.get(target, prop, target);
+        if (typeof value !== 'function') return value;
+        if (prop === 'query' || prop === 'sql' || prop === 'exec' || prop === 'transaction') {
+          return (...args: unknown[]) => {
+            const result = value.apply(target, args);
+            return result && typeof result.then === 'function'
+              ? this.trackInFlight(result)
+              : result;
+          };
+        }
+        return value.bind(target);
+      },
+    }) as PGLiteDB;
+  }
+
+  private async drainInFlightOperations(): Promise<void> {
+    while (this._inFlight.size > 0) {
+      await Promise.allSettled(Array.from(this._inFlight));
     }
   }
 

--- a/test/pglite-engine-disconnect.serial.test.ts
+++ b/test/pglite-engine-disconnect.serial.test.ts
@@ -26,6 +26,16 @@
  *   5. DOUBLE-DISCONNECT THEN CONNECT: after disconnect, a fresh
  *      connect() sees clean state and succeeds.
  *
+ *   6. TRACKED DB PROXY: public PGLite getters still use the native
+ *      PGLite instance as their receiver, so private-field getters like
+ *      `ready` and `closed` keep working after the in-flight wrapper.
+ *
+ *   7. IN-FLIGHT DRAIN: `disconnect()` waits for PGLite query/sql/
+ *      exec/transaction work that is still running underneath an aborted
+ *      caller before invoking `db.close()`. PGLite has no kernel-level
+ *      cancellation; an abort only releases the JS caller, not the WASM
+ *      operation.
+ *
  * Marked .serial because PGLite WASM cold-start dominates wallclock
  * for fresh-engine-per-test cases — running these in the parallel
  * shard pool would starve other PGLite tests of cold-start time.
@@ -39,6 +49,23 @@ import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 
 function newTempDataDir(): string {
   return mkdtempSync(join(tmpdir(), 'gbrain-disconnect-test-'));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+type MutablePgliteDbForDisconnectTest = {
+  query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>;
+  exec: (sql: string) => Promise<unknown[]>;
+  transaction: <T>(fn: (tx: unknown) => Promise<T>) => Promise<T>;
+  close: () => Promise<void>;
+  ready: boolean;
+  closed: boolean;
+};
+
+function internals(engine: PGLiteEngine): { _db: MutablePgliteDbForDisconnectTest | null } {
+  return engine as unknown as { _db: MutablePgliteDbForDisconnectTest | null };
 }
 
 describe('PGLiteEngine.disconnect() — v0.41.8.0 lifecycle invariants', () => {
@@ -214,6 +241,159 @@ describe('PGLiteEngine.disconnect() — v0.41.8.0 lifecycle invariants', () => {
       const result = await engine.executeRaw<{ ok: number }>('SELECT 1 AS ok');
       expect(result[0].ok).toBe(1);
       await engine.disconnect();
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  test('TRACKED DB PROXY: public PGLite getters keep their native receiver', async () => {
+    const dataDir = newTempDataDir();
+    try {
+      const engine = new PGLiteEngine();
+      await engine.connect({ database_path: dataDir });
+      await engine.initSchema();
+
+      const db = engine.db as unknown as { ready: boolean; closed: boolean };
+      expect(() => db.ready).not.toThrow();
+      expect(db.ready).toBe(true);
+      expect(() => db.closed).not.toThrow();
+      expect(db.closed).toBe(false);
+
+      await engine.disconnect();
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  test('IN-FLIGHT DRAIN: disconnect waits for aborted executeRaw query before close', async () => {
+    const dataDir = newTempDataDir();
+    try {
+      const engine = new PGLiteEngine();
+      await engine.connect({ database_path: dataDir });
+      await engine.initSchema();
+
+      const eng = internals(engine);
+
+      let resolveQuery!: () => void;
+      let querySettled = false;
+      let closeCalled = false;
+      let closeSawUnsettledQuery = false;
+      const realClose = eng._db!.close.bind(eng._db!);
+
+      eng._db!.query = async () => {
+        await new Promise<void>((resolve) => {
+          resolveQuery = resolve;
+        });
+        querySettled = true;
+        return { rows: [{ ok: 1 }] };
+      };
+      eng._db!.close = async () => {
+        closeCalled = true;
+        closeSawUnsettledQuery = !querySettled;
+        return realClose();
+      };
+
+      const controller = new AbortController();
+      const raw = engine.executeRaw<{ ok: number }>('SELECT 1 AS ok', [], {
+        signal: controller.signal,
+      });
+      controller.abort();
+      await expect(raw).rejects.toThrow('aborted');
+
+      const disconnecting = engine.disconnect();
+      await sleep(20);
+      expect(closeCalled).toBe(false);
+
+      resolveQuery();
+      await disconnecting;
+      expect(closeCalled).toBe(true);
+      expect(closeSawUnsettledQuery).toBe(false);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  test('IN-FLIGHT DRAIN: disconnect waits for direct exec before close', async () => {
+    const dataDir = newTempDataDir();
+    try {
+      const engine = new PGLiteEngine();
+      await engine.connect({ database_path: dataDir });
+      await engine.initSchema();
+
+      const eng = internals(engine);
+
+      let resolveExec!: () => void;
+      let execSettled = false;
+      let closeCalled = false;
+      let closeSawUnsettledExec = false;
+      const realClose = eng._db!.close.bind(eng._db!);
+
+      eng._db!.exec = async () => {
+        await new Promise<void>((resolve) => {
+          resolveExec = resolve;
+        });
+        execSettled = true;
+        return [];
+      };
+      eng._db!.close = async () => {
+        closeCalled = true;
+        closeSawUnsettledExec = !execSettled;
+        return realClose();
+      };
+
+      const pendingExec = engine.db.exec('SELECT 1');
+      const disconnecting = engine.disconnect();
+      await sleep(20);
+      expect(closeCalled).toBe(false);
+
+      resolveExec();
+      await expect(pendingExec).resolves.toEqual([]);
+      await disconnecting;
+      expect(closeCalled).toBe(true);
+      expect(closeSawUnsettledExec).toBe(false);
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
+  test('IN-FLIGHT DRAIN: disconnect waits for transaction before close', async () => {
+    const dataDir = newTempDataDir();
+    try {
+      const engine = new PGLiteEngine();
+      await engine.connect({ database_path: dataDir });
+      await engine.initSchema();
+
+      const eng = internals(engine);
+
+      let resolveTransaction!: () => void;
+      let transactionSettled = false;
+      let closeCalled = false;
+      let closeSawUnsettledTransaction = false;
+      const realClose = eng._db!.close.bind(eng._db!);
+
+      eng._db!.transaction = async <T>(fn: (tx: unknown) => Promise<T>) => {
+        await new Promise<void>((resolve) => {
+          resolveTransaction = resolve;
+        });
+        transactionSettled = true;
+        return fn({});
+      };
+      eng._db!.close = async () => {
+        closeCalled = true;
+        closeSawUnsettledTransaction = !transactionSettled;
+        return realClose();
+      };
+
+      const pendingTransaction = engine.transaction(async () => 'committed');
+      const disconnecting = engine.disconnect();
+      await sleep(20);
+      expect(closeCalled).toBe(false);
+
+      resolveTransaction();
+      await expect(pendingTransaction).resolves.toBe('committed');
+      await disconnecting;
+      expect(closeCalled).toBe(true);
+      expect(closeSawUnsettledTransaction).toBe(false);
     } finally {
       rmSync(dataDir, { recursive: true, force: true });
     }

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -1313,7 +1313,8 @@ describe('PGLiteEngine: v0.13.1 error-wrap on connect() (#223)', () => {
     // create()).
     // #2084 wrapped the create call in preservingProcessExitCode (Emscripten
     // exitCode containment); the try/catch + error wrap around it is unchanged.
-    expect(src).toContain('this._db = await preservingProcessExitCode(() =>');
+    expect(src).toContain('const rawDb = await preservingProcessExitCode(() =>');
+    expect(src).toContain('this._db = this.trackDb(rawDb);');
     expect(src).toContain('PGlite.create({');
     expect(src).toContain('https://github.com/garrytan/gbrain/issues/223');
     expect(src).toContain('gbrain doctor');


### PR DESCRIPTION
## Summary

Fixes the PGLite teardown race behind #2348: an aborted JS caller can return before the underlying PGLite WASM query actually settles, and `disconnect()` could then close the database handle while that operation was still running.

This keeps the existing PGLite lifecycle model intact: `_db` is still early-nulled, `db.close()` still runs before lock release, and `close()` remains outside `preservingProcessExitCode`.

## What changed

- Wrap the created PGLite handle so public async DB operations (`query`, `sql`, `exec`, `transaction`) are tracked while in flight.
- Drain tracked in-flight operations before calling `db.close()` during `disconnect()`.
- Preserve native PGLite getter receivers when proxying the handle, so getters backed by private fields (`ready`, `closed`) keep working.
- Add disconnect lifecycle regression coverage for:
  - public getter receiver safety on the tracked handle
  - aborted `executeRaw()` query drain before close
  - direct `exec` drain before close
  - transaction drain before close

If the underlying WASM operation never settles, this does not invent a new cancellation primitive; the existing CLI hard-deadline path remains the backstop.

## Verification

- `bun test --timeout 30000 test/pglite-engine-disconnect.serial.test.ts`
- `bun test --timeout 30000 test/pglite-engine.test.ts`
- `bun run typecheck`
- `bun run check:test-isolation`
- `git diff --check`

Fixes #2348
