### PR TITLE
fix(import): decode UTF-16 text files instead of mangling them into NUL bytes

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -10,6 +10,50 @@ import { findChunkForOffset } from './chunkers/edge-extractor.ts';
 import { extractCodeRefs, imageOfCandidates } from './link-extraction.ts';
 import { embedBatch, embedMultimodal, currentEmbeddingSignature } from './embedding.ts';
 import { slugifyPath, slugifyCodePath, isCodeFilePath } from './sync.ts';
+
+/**
+ * Read a text file as UTF-8, transparently handling other common encodings.
+ *
+ * MetaTrader MQL files (and plenty of Windows-authored notes) ship as UTF-16.
+ * Reading those with `readFileSync(path, 'utf-8')` mis-decodes them into a
+ * string riddled with U+0000, which Postgres then rejects on insert
+ * (`invalid byte sequence for encoding "UTF8": 0x00`), aborting the whole
+ * sync. We detect the encoding by BOM, fall back to a NUL-density heuristic
+ * for BOM-less UTF-16 (MetaTrader's common export shape), and otherwise treat
+ * the bytes as UTF-8 (the overwhelmingly common case — zero behaviour change).
+ */
+export function readTextFileUtf8(filePath: string): string {
+  return decodeTextBuffer(readFileSync(filePath));
+}
+
+export function decodeTextBuffer(buf: Buffer): string {
+  // BOM-driven decoding (authoritative when present).
+  if (buf.length >= 2 && buf[0] === 0xff && buf[1] === 0xfe) return buf.toString('utf16le', 2);
+  if (buf.length >= 2 && buf[0] === 0xfe && buf[1] === 0xff) return decodeUtf16BE(buf.subarray(2));
+  if (buf.length >= 3 && buf[0] === 0xef && buf[1] === 0xbb && buf[2] === 0xbf) return buf.toString('utf8', 3);
+
+  // No BOM: sniff for UTF-16 via NUL density. Valid UTF-8 text never contains
+  // a NUL byte, so any meaningful run of them signals UTF-16. ASCII in UTF-16LE
+  // puts the NUL at odd byte offsets, UTF-16BE at even offsets — that parity
+  // tells us the endianness.
+  const sniff = Math.min(buf.length, 1024);
+  let evenNul = 0;
+  let oddNul = 0;
+  for (let i = 0; i < sniff; i++) {
+    if (buf[i] === 0x00) (i % 2 === 0 ? evenNul++ : oddNul++);
+  }
+  if (evenNul + oddNul >= sniff * 0.1) {
+    return oddNul >= evenNul ? buf.toString('utf16le') : decodeUtf16BE(buf);
+  }
+  return buf.toString('utf8');
+}
+
+function decodeUtf16BE(buf: Buffer): string {
+  const even = buf.length - (buf.length % 2);
+  const swapped = Buffer.from(buf.subarray(0, even));
+  swapped.swap16();
+  return swapped.toString('utf16le');
+}
 import type { ChunkInput, PageInput, PageType } from './types.ts';
 import { computeEffectiveDate } from './effective-date.ts';
 import { MARKDOWN_CHUNKER_VERSION } from './chunkers/recursive.ts';
@@ -931,7 +975,7 @@ export async function importFromFile(
     return { slug: relativePath, status: 'skipped', chunks: 0, error: `File too large (${stat.size} bytes)` };
   }
 
-  let content = readFileSync(filePath, 'utf-8');
+  let content = readTextFileUtf8(filePath);
 
   // Route code files through the code import path
   if (isCodeFilePath(relativePath)) {

--- a/test/import-utf16.test.ts
+++ b/test/import-utf16.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Text-import encoding: MetaTrader MQL files (and many Windows-authored
+ * notes) ship as UTF-16, not UTF-8. importFile() read every file with
+ * readFileSync(path, 'utf-8'), which mis-decodes UTF-16 into a string full
+ * of U+0000 — and Postgres then rejects the insert with
+ * `invalid byte sequence for encoding "UTF8": 0x00`, so the whole sync
+ * aborts. readTextFileUtf8() detects the encoding (BOM-aware, plus a
+ * no-BOM UTF-16 heuristic) and returns clean UTF-8 text.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { readTextFileUtf8 } from '../src/core/import-file.ts';
+
+const SOURCE = '//+---+\nvoid OnTick(void)\n  {\n   double p = Bid;\n  }\n';
+const NUL = String.fromCharCode(0);
+let dir: string | null = null;
+
+function tmp(name: string, bytes: Buffer): string {
+  dir = mkdtempSync(join(tmpdir(), 'gb-utf16-'));
+  const p = join(dir, name);
+  writeFileSync(p, bytes);
+  return p;
+}
+
+afterEach(() => {
+  if (dir) { rmSync(dir, { recursive: true, force: true }); dir = null; }
+});
+
+describe('readTextFileUtf8 — encoding-aware text import', () => {
+  test('UTF-16LE with BOM decodes to clean UTF-8', () => {
+    const buf = Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(SOURCE, 'utf16le')]);
+    const out = readTextFileUtf8(tmp('ea.mq5', buf));
+    expect(out).toBe(SOURCE);
+    expect(out).not.toContain(NUL);
+  });
+
+  test('UTF-16BE with BOM decodes to clean UTF-8', () => {
+    const le = Buffer.from(SOURCE, 'utf16le');
+    const be = Buffer.from(le); be.swap16();
+    const buf = Buffer.concat([Buffer.from([0xfe, 0xff]), be]);
+    const out = readTextFileUtf8(tmp('ea.mqh', buf));
+    expect(out).toBe(SOURCE);
+    expect(out).not.toContain(NUL);
+  });
+
+  test('UTF-16LE WITHOUT BOM (MetaTrader export shape) decodes via heuristic', () => {
+    const buf = Buffer.from(SOURCE, 'utf16le');
+    const out = readTextFileUtf8(tmp('ea.mq4', buf));
+    expect(out).toBe(SOURCE);
+    expect(out).not.toContain(NUL);
+  });
+
+  test('plain UTF-8 is returned unchanged', () => {
+    const buf = Buffer.from(SOURCE, 'utf8');
+    expect(readTextFileUtf8(tmp('ea.ts', buf))).toBe(SOURCE);
+  });
+
+  test('UTF-8 with BOM has the BOM stripped', () => {
+    const buf = Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(SOURCE, 'utf8')]);
+    const out = readTextFileUtf8(tmp('note.md', buf));
+    expect(out).toBe(SOURCE);
+    expect(out.charCodeAt(0)).not.toBe(0xfeff);
+  });
+});


### PR DESCRIPTION
## Problem

`importFile()` read every file with `readFileSync(path, 'utf-8')`. UTF-16 sources — the norm for MetaTrader MQL files and common for Windows-authored notes — decode under UTF-8 into strings riddled with `U+0000`. Postgres then rejects the insert with `invalid byte sequence for encoding "UTF8": 0x00`, which aborts the **entire** sync (every file in the batch fails the checkpoint, `last_commit` never advances).

This is encoding-general, not language-specific — any UTF-16 markdown or code file hits it.

## Fix

Add `readTextFileUtf8()` / `decodeTextBuffer()` and route the single import read boundary through it:

- **BOM-driven** decoding when a BOM is present (UTF-16 LE/BE, UTF-8 BOM stripped).
- **No-BOM UTF-16 heuristic**: valid UTF-8 text never contains a `NUL` byte, so a meaningful run of them signals UTF-16; byte-parity of the NULs picks the endianness. This covers MetaTrader's common BOM-less export shape.
- **Plain UTF-8 is returned unchanged** — zero behaviour change for the overwhelmingly common case.

## Tests

- `test/import-utf16.test.ts` — UTF-16 LE/BE with BOM, BOM-less UTF-16 LE, plain UTF-8, and UTF-8-with-BOM, all asserting clean UTF-8 out with no residual `NUL`.
- Verified end-to-end through the real `sync --strategy code` → DB path: a UTF-16 file that previously failed with the `0x00` error now imports cleanly.

Complements the MQL code-intelligence work (#2299): MetaTrader's MQL files are predominantly UTF-16, so this is what lets a real MQL corpus ingest at all.

*Authored with AI assistance (Claude) under the contributor's direction.*
