### PR TITLE
WS-954: add import opt-out for gitignored files

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2260,7 +2260,8 @@ ADMIN
   autopilot [--repo] [--interval N]  Self-maintaining brain daemon
   config [show|get|set] <key> [val]  Brain config
   storage status [--repo <path>]     Storage tier status and health
-        [--json]                     (git-tracked vs supabase-only)
+  storage vacuum [--json]            VACUUM (ANALYZE) + CHECKPOINT
+  storage backup [--json]            PGLite data-dir backup with retention caps
   serve                              MCP server (stdio)
   serve --http [--port N]            HTTP MCP server with OAuth 2.1
     --token-ttl N                    Access token TTL in seconds (default: 3600)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2155,7 +2155,8 @@ SEARCH
   ask <question> [--no-expand]       Alias for query
 
 IMPORT/EXPORT
-  import <dir> [--no-embed]          Import markdown directory
+  import <dir> [--no-embed] [--all-files]
+                                      Import markdown directory
   sync [--repo <path>] [flags]       Git-to-brain incremental sync
   sync --watch [--interval N]        Continuous sync (loops until stopped)
   sync --install-cron                Install persistent sync daemon

--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -49,6 +49,7 @@ interface RunOpts {
   source?: string;
   quiet?: boolean;
   json?: boolean;
+  noEmbed?: boolean;
 }
 
 function parseArgs(args: string[]): RunOpts | { help: true; positional: string | undefined } {
@@ -60,6 +61,7 @@ function parseArgs(args: string[]): RunOpts | { help: true; positional: string |
     if (a === '--quiet' || a === '-q') { opts.quiet = true; continue; }
     if (a === '--json') { opts.json = true; continue; }
     if (a === '--stdin') { opts.stdin = true; continue; }
+    if (a === '--no-embed') { opts.noEmbed = true; continue; }
     if (a === '--file') {
       const v = args[++i];
       if (v) opts.filePath = v;
@@ -110,6 +112,7 @@ Options:
                        registration scopes the source).
   --quiet, -q          Print just the slug on stdout (for shell pipelines)
   --json               JSON output for agents
+  --no-embed           Capture now; leave embedding for a later gbrain embed --stale pass
   --help, -h           Show this help
 
 Notes:
@@ -456,7 +459,7 @@ export async function runCapture(engine: BrainEngine | null, args: string[]): Pr
       raw = await callRemoteTool(
         cfg!,
         'put_page',
-        { slug, content: fullContent },
+        { slug, content: fullContent, no_embed: parsed.noEmbed === true },
         { timeoutMs: 30_000 },
       );
     } catch (e) {
@@ -543,6 +546,7 @@ export async function runCapture(engine: BrainEngine | null, args: string[]): Pr
       source_kind: 'capture-cli',
       source_uri: sourceUri,
       ingested_via: 'capture-cli',
+      no_embed: parsed.noEmbed === true,
     })) as {
       slug: string;
       status?: string;

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -45,11 +45,21 @@ export interface RunImportResult {
 export async function runImport(
   engine: BrainEngine,
   args: string[],
-  opts: { commit?: string; strategy?: SyncStrategy; sourceId?: string; managedBookmark?: boolean } = {},
+  opts: {
+    commit?: string;
+    strategy?: SyncStrategy;
+    sourceId?: string;
+    managedBookmark?: boolean;
+    ignoreGitignore?: boolean;
+  } = {},
 ): Promise<RunImportResult> {
   const noEmbed = args.includes('--no-embed');
   const fresh = args.includes('--fresh');
   const jsonOutput = args.includes('--json');
+  const ignoreGitignore = opts.ignoreGitignore === true
+    || args.includes('--all-files')
+    || args.includes('--ignore-gitignore')
+    || importIgnoreGitignoreEnvEnabled();
 
   // T7 (D9): refuse cleanly when init persisted the deferred-setup sentinel,
   // unless the user is explicitly skipping embedding via `--no-embed` (in
@@ -164,7 +174,7 @@ export async function runImport(
   const dirArg = args.find((a, i) => !a.startsWith('--') && !flagValues.has(i));
 
   if (!dirArg) {
-    console.error('Usage: gbrain import <dir> [--no-embed] [--workers N] [--fresh] [--source-id <id>] [--json]');
+    console.error('Usage: gbrain import <dir> [--no-embed] [--workers N] [--fresh] [--source-id <id>] [--all-files] [--json]');
     process.exit(1);
   }
   const dir: string = dirArg;  // narrowed; survives closure capture
@@ -176,7 +186,7 @@ export async function runImport(
   const strategy: SyncStrategy = opts.strategy ?? 'markdown';
   const _walkT0 = Date.now();
   console.error(`[gbrain phase] import.collect_files start dir=${dir} strategy=${strategy}`);
-  const allFiles = collectSyncableFiles(dir, { strategy });
+  const allFiles = collectSyncableFiles(dir, { strategy, ignoreGitignore });
   console.error(
     `[gbrain phase] import.collect_files done ${Date.now() - _walkT0}ms files=${allFiles.length}`,
   );
@@ -485,6 +495,12 @@ function resolveMaxWalkDepth(): number {
 
 interface CollectOpts {
   strategy?: SyncStrategy;
+  ignoreGitignore?: boolean;
+}
+
+function importIgnoreGitignoreEnvEnabled(): boolean {
+  const raw = process.env.GBRAIN_IMPORT_IGNORE_GITIGNORE?.trim().toLowerCase();
+  return raw === '1' || raw === 'true';
 }
 
 /**
@@ -578,6 +594,7 @@ function gitListSyncableFiles(
 export function collectSyncableFiles(dir: string, opts: CollectOpts = {}): string[] {
   const strategy: SyncStrategy = opts.strategy ?? 'markdown';
   const multimodalOn = process.env.GBRAIN_EMBEDDING_MULTIMODAL === 'true';
+  const ignoreGitignore = opts.ignoreGitignore === true;
 
   // v0.42.x (#1159 --respect-gitignore / #1483 .gbrainignore): when `dir` is a
   // git work tree, enumerate via `git ls-files` so the walk honors
@@ -588,8 +605,17 @@ export function collectSyncableFiles(dir: string, opts: CollectOpts = {}): strin
   // vendored data/fixtures). `--cached --others --exclude-standard` = tracked
   // PLUS untracked-not-ignored, so uncommitted source is still indexed. Non-git
   // dirs (or git unavailable) fall through to the FS walk below.
-  const gitFiles = gitListSyncableFiles(dir, strategy, multimodalOn);
-  if (gitFiles) return gitFiles;
+  //
+  // `gbrain import` wires `GBRAIN_IMPORT_IGNORE_GITIGNORE=1` / `--all-files`
+  // into this option as the explicit escape hatch for generated import feeds
+  // that intentionally live under a gitignored directory. In that mode we skip
+  // only this git-aware fast path and use the established hardened FS walker
+  // below. Other callers, especially sync, keep their default gitignore policy
+  // unless they opt in programmatically.
+  if (!ignoreGitignore) {
+    const gitFiles = gitListSyncableFiles(dir, strategy, multimodalOn);
+    if (gitFiles) return gitFiles;
+  }
 
   const maxDepth = resolveMaxWalkDepth();
   const visitedInodes = new Map<string, true>();

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -49,6 +49,16 @@ import type { SchemaPackManifest, PackPrimitive } from '../core/schema-pack/mani
 import { PACK_PRIMITIVES } from '../core/schema-pack/manifest-v1.ts';
 import { gbrainPath, loadConfig, configPath } from '../core/config.ts';
 
+const BUNDLED_PACKS = [
+  'gbrain-base',
+  'gbrain-recommended',
+  'gbrain-creator',
+  'gbrain-investor',
+  'gbrain-engineer',
+  'gbrain-everything',
+  'gbrain-base-v2',
+] as const;
+
 export async function runSchema(args: string[]): Promise<void> {
   const sub = args[0];
   switch (sub) {
@@ -179,7 +189,6 @@ async function runActive(_args: string[]): Promise<void> {
 }
 
 function runList(_args: string[]): void {
-  const bundled = ['gbrain-base', 'gbrain-recommended'];
   const installedDir = gbrainPath('schema-packs');
   const installed: string[] = [];
   if (existsSync(installedDir)) {
@@ -194,7 +203,7 @@ function runList(_args: string[]): void {
     }
   }
   console.log('Bundled packs:');
-  for (const name of bundled) console.log(`  ${name}`);
+  for (const name of BUNDLED_PACKS) console.log(`  ${name}`);
   if (installed.length > 0) {
     console.log('\nInstalled packs (~/.gbrain/schema-packs/):');
     for (const name of installed) console.log(`  ${name}`);
@@ -366,12 +375,12 @@ function runUse(args: string[]): void {
 }
 
 function packPathByName(name: string): string | null {
-  if (name === 'gbrain-base') {
+  if ((BUNDLED_PACKS as readonly string[]).includes(name)) {
     // Resolve bundled YAML — try a few locations.
     const here = dirname(new URL(import.meta.url).pathname);
     const candidates = [
-      join(here, '..', 'core', 'schema-pack', 'base', 'gbrain-base.yaml'),
-      join(here, '..', '..', 'src', 'core', 'schema-pack', 'base', 'gbrain-base.yaml'),
+      join(here, '..', 'core', 'schema-pack', 'base', `${name}.yaml`),
+      join(here, '..', '..', 'src', 'core', 'schema-pack', 'base', `${name}.yaml`),
     ];
     for (const c of candidates) {
       if (existsSync(c)) return c;

--- a/src/commands/storage.ts
+++ b/src/commands/storage.ts
@@ -1,5 +1,8 @@
-import { join } from 'path';
+import { existsSync, mkdirSync, readdirSync, rmSync, renameSync, statfsSync, statSync, unlinkSync, writeFileSync } from 'fs';
+import { spawnSync } from 'child_process';
+import { basename, join } from 'path';
 import type { BrainEngine } from '../core/engine.ts';
+import { gbrainPath } from '../core/config.ts';
 import { loadStorageConfig, validateStorageConfig, getStorageTier } from '../core/storage-config.ts';
 import type { StorageConfig, StorageTier } from '../core/storage-config.ts';
 import { walkBrainRepo, type DiskFileEntry } from '../core/disk-walk.ts';
@@ -31,6 +34,21 @@ export interface StorageStatusResult {
   warnings: string[];
 }
 
+export interface StorageBackupResult {
+  ok: boolean;
+  started_at: string;
+  finished_at: string;
+  output_path: string | null;
+  output_bytes: number;
+  raw_bytes: number;
+  compression: 'zstd' | 'none';
+  verified_file_count: number;
+  pruned: Array<{ path: string; bytes: number }>;
+  retained_count: number;
+  retained_bytes: number;
+  warnings: string[];
+}
+
 // ── Dispatcher ────────────────────────────────────────────
 
 export async function runStorage(engine: BrainEngine, args: string[]): Promise<void> {
@@ -39,9 +57,302 @@ export async function runStorage(engine: BrainEngine, args: string[]): Promise<v
     await runStorageStatus(engine, args.slice(1));
     return;
   }
+  if (subcommand === 'vacuum') {
+    await runStorageVacuum(engine, args.slice(1));
+    return;
+  }
+  if (subcommand === 'backup') {
+    await runStorageBackup(engine, args.slice(1));
+    return;
+  }
   console.error(`Unknown storage subcommand: ${subcommand}`);
-  console.error('Available subcommands: status');
+  console.error('Available subcommands: status, vacuum, backup');
   process.exit(1);
+}
+
+async function runStorageBackup(engine: BrainEngine, args: string[]): Promise<void> {
+  const opts = parseBackupArgs(args);
+  const result = await createPgliteBackup(engine, opts);
+
+  if (opts.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (!result.ok) {
+    console.log(`Storage backup skipped: ${result.warnings.join('; ')}`);
+    return;
+  }
+
+  console.log(
+    `Storage backup complete: ${result.output_path} ` +
+      `(${formatBytes(result.output_bytes)}, ${result.verified_file_count} files verified)`,
+  );
+  if (result.pruned.length > 0) {
+    console.log(`Pruned ${result.pruned.length} old backup(s).`);
+  }
+  for (const warning of result.warnings) console.warn(`Warning: ${warning}`);
+}
+
+async function runStorageVacuum(engine: BrainEngine, args: string[]): Promise<void> {
+  const vacuumSql = 'VACUUM (ANALYZE)';
+  const checkpointSql = 'CHECKPOINT';
+  const startedAt = new Date().toISOString();
+
+  await engine.executeRaw(vacuumSql);
+  await engine.executeRaw(checkpointSql);
+
+  const result = {
+    ok: true,
+    started_at: startedAt,
+    finished_at: new Date().toISOString(),
+    vacuum: vacuumSql,
+    checkpoint: checkpointSql,
+  };
+
+  if (args.includes('--json')) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(`Storage vacuum complete: ${vacuumSql}; ${checkpointSql}`);
+}
+
+interface BackupOptions {
+  dir: string;
+  maxCount: number;
+  maxBytes: number;
+  minFreeBytes: number;
+  compress: boolean;
+  zstdBin: string;
+  json: boolean;
+}
+
+function parseBackupArgs(args: string[]): BackupOptions {
+  const valueAfter = (flag: string): string | undefined => {
+    const idx = args.indexOf(flag);
+    return idx === -1 ? undefined : args[idx + 1];
+  };
+
+  return {
+    dir: valueAfter('--dir') || process.env.GBRAIN_DREAM_BACKUP_DIR || gbrainPath('backups', 'dream-cycle'),
+    maxCount: parsePositiveInt(valueAfter('--max-count') || process.env.GBRAIN_DREAM_BACKUP_MAX_COUNT, 7),
+    maxBytes: parseBytes(valueAfter('--max-bytes') || process.env.GBRAIN_DREAM_BACKUP_MAX_BYTES, 5 * 1024 ** 3),
+    minFreeBytes: parseBytes(valueAfter('--min-free') || process.env.GBRAIN_DREAM_BACKUP_MIN_FREE_BYTES, 20 * 1024 ** 3),
+    compress: !args.includes('--no-compress'),
+    zstdBin: valueAfter('--zstd-bin') || process.env.GBRAIN_ZSTD_BIN || '/opt/homebrew/bin/zstd',
+    json: args.includes('--json'),
+  };
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(raw ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseBytes(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const match = raw.trim().match(/^(\d+(?:\.\d+)?)\s*([kmgt]?i?b?)?$/i);
+  if (!match) return fallback;
+  const value = Number.parseFloat(match[1]);
+  if (!Number.isFinite(value) || value < 0) return fallback;
+  const unit = (match[2] || 'b').toLowerCase();
+  const multiplier =
+    unit.startsWith('t') ? 1024 ** 4 :
+    unit.startsWith('g') ? 1024 ** 3 :
+    unit.startsWith('m') ? 1024 ** 2 :
+    unit.startsWith('k') ? 1024 :
+    1;
+  return Math.floor(value * multiplier);
+}
+
+interface BackupFile {
+  path: string;
+  bytes: number;
+  mtimeMs: number;
+}
+
+async function createPgliteBackup(engine: BrainEngine, opts: BackupOptions): Promise<StorageBackupResult> {
+  const startedAt = new Date().toISOString();
+  const warnings: string[] = [];
+  mkdirSync(opts.dir, { recursive: true });
+
+  const existing = listBackupFiles(opts.dir);
+  const pruneable = existing.length > 2;
+  const freeBytes = freeBytesForPath(opts.dir);
+  if (!pruneable && freeBytes !== null && freeBytes < opts.minFreeBytes) {
+    return {
+      ok: false,
+      started_at: startedAt,
+      finished_at: new Date().toISOString(),
+      output_path: null,
+      output_bytes: 0,
+      raw_bytes: 0,
+      compression: opts.compress ? 'zstd' : 'none',
+      verified_file_count: 0,
+      pruned: [],
+      retained_count: existing.length,
+      retained_bytes: sumBytes(existing),
+      warnings: [`free space ${formatBytes(freeBytes)} is below ${formatBytes(opts.minFreeBytes)} and no backups are pruneable`],
+    };
+  }
+
+  if (engine.kind !== 'pglite') {
+    throw new Error('gbrain storage backup currently supports PGLite only.');
+  }
+
+  const db = (engine as unknown as { db?: { dumpDataDir?: (compression?: 'none' | 'gzip' | 'auto') => Promise<Blob | File> } }).db;
+  if (!db?.dumpDataDir) {
+    throw new Error('Connected PGLite engine does not expose dumpDataDir().');
+  }
+
+  await engine.executeRaw('CHECKPOINT');
+
+  const stamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+  const rawName = `brain-pglite-${stamp}.tar`;
+  const finalName = opts.compress ? `${rawName}.zst` : rawName;
+  const rawTmpPath = join(opts.dir, `.${rawName}.tmp-${process.pid}`);
+  const finalTmpPath = join(opts.dir, `.${finalName}.tmp-${process.pid}`);
+  const finalPath = join(opts.dir, finalName);
+
+  let rawBytes = 0;
+  try {
+    const dump = await db.dumpDataDir('none');
+    const dumpBytes = Buffer.from(await dump.arrayBuffer());
+    rawBytes = dumpBytes.byteLength;
+    writeFileSync(rawTmpPath, dumpBytes);
+
+    if (opts.compress) {
+      runZstdCompress(opts.zstdBin, rawTmpPath, finalTmpPath);
+      unlinkIfExists(rawTmpPath);
+    } else {
+      renameSync(rawTmpPath, finalTmpPath);
+    }
+
+    const verifiedFileCount = verifyBackupArchive(finalTmpPath, opts);
+    renameSync(finalTmpPath, finalPath);
+
+    const outputBytes = statSync(finalPath).size;
+    const latestExisting = existing.toSorted((a, b) => b.mtimeMs - a.mtimeMs)[0];
+    if (latestExisting && outputBytes > latestExisting.bytes * 3) {
+      warnings.push(
+        `new backup ${formatBytes(outputBytes)} is more than 3x previous ${formatBytes(latestExisting.bytes)}`,
+      );
+    }
+
+    const pruned = pruneBackups(opts.dir, opts.maxCount, opts.maxBytes);
+    const retained = listBackupFiles(opts.dir);
+    const retainedBytes = sumBytes(retained);
+    if ((retained.length > opts.maxCount || retainedBytes > opts.maxBytes) && retained.length <= 2) {
+      warnings.push('retention caps exceeded but fewer than two verified backups remain, so prune stopped');
+    }
+
+    return {
+      ok: true,
+      started_at: startedAt,
+      finished_at: new Date().toISOString(),
+      output_path: finalPath,
+      output_bytes: outputBytes,
+      raw_bytes: rawBytes,
+      compression: opts.compress ? 'zstd' : 'none',
+      verified_file_count: verifiedFileCount,
+      pruned,
+      retained_count: retained.length,
+      retained_bytes: retainedBytes,
+      warnings,
+    };
+  } catch (err) {
+    unlinkIfExists(rawTmpPath);
+    unlinkIfExists(finalTmpPath);
+    throw err;
+  }
+}
+
+function listBackupFiles(dir: string): BackupFile[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter(name => /^brain-pglite-\d{8}T\d{6}Z\.tar(?:\.zst)?$/.test(name))
+    .map(name => {
+      const path = join(dir, name);
+      const st = statSync(path);
+      return { path, bytes: st.size, mtimeMs: st.mtimeMs };
+    })
+    .sort((a, b) => a.mtimeMs - b.mtimeMs || basename(a.path).localeCompare(basename(b.path)));
+}
+
+function sumBytes(files: BackupFile[]): number {
+  return files.reduce((sum, file) => sum + file.bytes, 0);
+}
+
+function freeBytesForPath(path: string): number | null {
+  try {
+    const stat = statfsSync(path);
+    return stat.bavail * stat.bsize;
+  } catch {
+    return null;
+  }
+}
+
+function resolveZstdBin(zstdBin: string): string {
+  if (existsSync(zstdBin)) return zstdBin;
+  if (!zstdBin.includes('/')) return zstdBin;
+  return 'zstd';
+}
+
+function runZstdCompress(zstdBin: string, inputPath: string, outputPath: string): void {
+  const bin = resolveZstdBin(zstdBin);
+  const result = spawnSync(bin, ['-q', '-f', '-o', outputPath, inputPath], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`zstd compression failed: ${(result.stderr || result.error?.message || '').trim()}`);
+  }
+}
+
+function runZstdDecompress(zstdBin: string, inputPath: string, outputPath: string): void {
+  const bin = resolveZstdBin(zstdBin);
+  const result = spawnSync(bin, ['-q', '-d', '-f', '-o', outputPath, inputPath], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`zstd verification decompress failed: ${(result.stderr || result.error?.message || '').trim()}`);
+  }
+}
+
+function verifyBackupArchive(path: string, opts: BackupOptions): number {
+  let tarPath = path;
+  const verifyTmp = `${path}.verify-${process.pid}.tar`;
+  try {
+    if (path.endsWith('.zst')) {
+      runZstdDecompress(opts.zstdBin, path, verifyTmp);
+      tarPath = verifyTmp;
+    }
+    const result = spawnSync('tar', ['-tf', tarPath], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+    if (result.status !== 0) {
+      throw new Error(`tar verification failed: ${(result.stderr || result.error?.message || '').trim()}`);
+    }
+    const fileCount = result.stdout.split('\n').filter(Boolean).length;
+    if (fileCount < 1) throw new Error('tar verification failed: archive contained zero files');
+    return fileCount;
+  } finally {
+    unlinkIfExists(verifyTmp);
+  }
+}
+
+function pruneBackups(dir: string, maxCount: number, maxBytes: number): Array<{ path: string; bytes: number }> {
+  const pruned: Array<{ path: string; bytes: number }> = [];
+  let files = listBackupFiles(dir);
+  while ((files.length > maxCount || sumBytes(files) > maxBytes) && files.length > 2) {
+    const victim = files[0];
+    rmSync(victim.path, { force: true });
+    pruned.push({ path: victim.path, bytes: victim.bytes });
+    files = listBackupFiles(dir);
+  }
+  return pruned;
+}
+
+function unlinkIfExists(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch {
+    // best-effort cleanup
+  }
 }
 
 async function runStorageStatus(engine: BrainEngine, args: string[]): Promise<void> {

--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -52,6 +52,7 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   if (process.env.LMSTUDIO_BASE_URL) envBaseUrls['lmstudio'] = process.env.LMSTUDIO_BASE_URL;
   if (process.env.LITELLM_BASE_URL) envBaseUrls['litellm'] = process.env.LITELLM_BASE_URL;
   if (process.env.OPENROUTER_BASE_URL) envBaseUrls['openrouter'] = process.env.OPENROUTER_BASE_URL;
+  if (process.env.LOCAL_SENTENCE_TRANSFORMERS_BASE_URL) envBaseUrls['local-sentence-transformers'] = process.env.LOCAL_SENTENCE_TRANSFORMERS_BASE_URL;
 
   return {
     embedding_model: c.embedding_model,

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -1200,7 +1200,8 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
         `OpenAI embedding requires OPENAI_API_KEY.`,
         recipe.setup_hint,
       );
-      const client = createOpenAI({ apiKey });
+      const baseURL = cfg.base_urls?.openai;
+      const client = baseURL ? createOpenAI({ apiKey, baseURL }) : createOpenAI({ apiKey });
       // AI SDK v6: use .textEmbeddingModel() for embeddings
       return (client as any).textEmbeddingModel
         ? (client as any).textEmbeddingModel(modelId)
@@ -2123,7 +2124,8 @@ function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayCon
     case 'native-openai': {
       const apiKey = cfg.env.OPENAI_API_KEY;
       if (!apiKey) throw new AIConfigError(`OpenAI expansion requires OPENAI_API_KEY.`, recipe.setup_hint);
-      return createOpenAI({ apiKey }).languageModel(modelId);
+      const baseURL = cfg.base_urls?.openai;
+      return (baseURL ? createOpenAI({ apiKey, baseURL }) : createOpenAI({ apiKey })).languageModel(modelId);
     }
     case 'native-google': {
       const apiKey = cfg.env.GOOGLE_GENERATIVE_AI_API_KEY;
@@ -2495,7 +2497,8 @@ function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig):
     case 'native-openai': {
       const apiKey = cfg.env.OPENAI_API_KEY;
       if (!apiKey) throw new AIConfigError(`OpenAI chat requires OPENAI_API_KEY.`, recipe.setup_hint);
-      return createOpenAI({ apiKey }).languageModel(modelId);
+      const baseURL = cfg.base_urls?.openai;
+      return (baseURL ? createOpenAI({ apiKey, baseURL }) : createOpenAI({ apiKey })).languageModel(modelId);
     }
     case 'native-google': {
       const apiKey = cfg.env.GOOGLE_GENERATIVE_AI_API_KEY;

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -23,6 +23,7 @@ import { zhipu } from './zhipu.ts';
 import { azureOpenAI } from './azure-openai.ts';
 import { zeroentropyai } from './zeroentropyai.ts';
 import { llamaServerReranker } from './llama-server-reranker.ts';
+import { localSentenceTransformers } from './local-sentence-transformers.ts';
 
 const ALL: Recipe[] = [
   openai,
@@ -37,6 +38,7 @@ const ALL: Recipe[] = [
   together,
   llamaServer,
   llamaServerReranker,
+  localSentenceTransformers,
   minimax,
   dashscope,
   zhipu,

--- a/src/core/ai/recipes/local-sentence-transformers.ts
+++ b/src/core/ai/recipes/local-sentence-transformers.ts
@@ -1,0 +1,49 @@
+import type { Recipe } from '../types.ts';
+import { probeOpenAICompat } from '../probes.ts';
+
+/**
+ * Local sentence-transformers HTTP shim used by GBrain's launchd-managed
+ * BAAI/bge-m3 service. The service exposes an OpenAI-compatible
+ * /v1/embeddings endpoint, but it is not OpenAI; keep the provider identity
+ * honest so stored embedding signatures name the real model family.
+ */
+export const localSentenceTransformers: Recipe = {
+  id: 'local-sentence-transformers',
+  name: 'Local sentence-transformers',
+  tier: 'openai-compat',
+  implementation: 'openai-compatible',
+  base_url_default: 'http://127.0.0.1:8765/v1',
+  auth_env: {
+    required: [],
+    optional: ['LOCAL_SENTENCE_TRANSFORMERS_BASE_URL'],
+    setup_url: 'https://www.sbert.net/',
+  },
+  touchpoints: {
+    embedding: {
+      models: ['BAAI/bge-m3'],
+      default_dims: 1536,
+      cost_per_1m_tokens_usd: 0,
+      price_last_verified: '2026-07-05',
+      no_batch_cap: true,
+    },
+  },
+  async probe(baseURL?: string) {
+    const url = baseURL ?? process.env.LOCAL_SENTENCE_TRANSFORMERS_BASE_URL ?? 'http://127.0.0.1:8765/v1';
+    const result = await probeOpenAICompat(url);
+    if (!result.reachable) {
+      return {
+        ready: false,
+        hint: `local sentence-transformers service not reachable at ${url}. Start the GBrain local embeddings LaunchAgent or set LOCAL_SENTENCE_TRANSFORMERS_BASE_URL.`,
+      };
+    }
+    if (!result.models_endpoint_valid) {
+      return {
+        ready: false,
+        hint: `local sentence-transformers service reached but /v1/models returned an unexpected shape: ${result.error ?? 'unknown'}.`,
+      };
+    }
+    return { ready: true };
+  },
+  setup_hint:
+    'Start the local sentence-transformers embedding service, then configure local-sentence-transformers:BAAI/bge-m3 with embedding_dimensions 1536.',
+};

--- a/src/core/embedding.ts
+++ b/src/core/embedding.ts
@@ -87,12 +87,21 @@ export interface EmbedBatchOptions {
  * adaptive batch splitting and per-recipe token-budget logic; this paginator
  * is purely about progress-callback granularity.
  */
-const BATCH_SIZE = 100;
+const DEFAULT_BATCH_SIZE = 100;
+
+function resolveBatchSize(): number {
+  const raw = process.env.GBRAIN_EMBED_BATCH_SIZE;
+  if (!raw) return DEFAULT_BATCH_SIZE;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, DEFAULT_BATCH_SIZE) : DEFAULT_BATCH_SIZE;
+}
+
 export async function embedBatch(
   texts: string[],
   options: EmbedBatchOptions = {},
 ): Promise<Float32Array[]> {
   if (!texts || texts.length === 0) return [];
+  const batchSize = resolveBatchSize();
   // Build the gateway-call passthrough once; undefined fields stay undefined
   // so non-opt-in callers see unchanged pre-v0.33.4 behavior.
   const gwOpts = {
@@ -100,12 +109,12 @@ export async function embedBatch(
     ...(options.maxRetries !== undefined && { maxRetries: options.maxRetries }),
   };
   // Fast path: small batch, no progress callback — single gateway call.
-  if (texts.length <= BATCH_SIZE && !options.onBatchComplete) {
+  if (texts.length <= batchSize && !options.onBatchComplete) {
     return gatewayEmbed(texts, gwOpts);
   }
   const results: Float32Array[] = [];
-  for (let i = 0; i < texts.length; i += BATCH_SIZE) {
-    const slice = texts.slice(i, i + BATCH_SIZE);
+  for (let i = 0; i < texts.length; i += batchSize) {
+    const slice = texts.slice(i, i + batchSize);
     const out = await gatewayEmbed(slice, gwOpts);
     results.push(...out);
     options.onBatchComplete?.(results.length, texts.length);

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -708,6 +708,7 @@ const put_page: Operation = {
     source_kind: { type: 'string', required: false, description: 'Ingestion channel taxonomy (capture-cli | put_page | webhook | …). Remote callers: SERVER-STAMPED, client value ignored.' },
     source_uri: { type: 'string', required: false, description: 'Original URI/path/message-id the event carried. Remote callers: SERVER-STAMPED null.' },
     ingested_via: { type: 'string', required: false, description: 'Richer label paired with source_kind. Remote callers: SERVER-STAMPED.' },
+    no_embed: { type: 'boolean', required: false, description: 'Skip inline embedding; leave chunks stale for a later embed pass.' },
   },
   mutating: true,
   scope: 'write',
@@ -780,7 +781,7 @@ const put_page: Operation = {
     // Checks all auth env vars for the resolved provider, not just OPENAI_API_KEY,
     // so Gemini / Ollama / Voyage brains don't silently drop embeddings (Codex C2).
     const { isAvailable } = await import('./ai/gateway.ts');
-    const noEmbed = !isAvailable('embedding');
+    const noEmbed = (p.no_embed as boolean) === true || !isAvailable('embedding');
     // v0.31.8 (D7 / codex OV-1): thread ctx.sourceId so put_page on a
     // multi-source brain lands in the intended source instead of the
     // default-source clobber path. importFromContent already accepts

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -2073,6 +2073,11 @@ export class PGLiteEngine implements BrainEngine {
     const rowParts: string[] = [];
     const params: unknown[] = [];
     let paramIdx = 1;
+    let activeEmbeddingModel = DEFAULT_EMBEDDING_MODEL;
+    try {
+      const gw = await import('./ai/gateway.ts');
+      activeEmbeddingModel = gw.getEmbeddingModel() || activeEmbeddingModel;
+    } catch { /* gateway not configured — use defaults */ }
 
     for (const chunk of chunks) {
       const embeddingStr = chunk.embedding
@@ -2106,7 +2111,8 @@ export class PGLiteEngine implements BrainEngine {
       if (embeddingImageStr) params.push(embeddingImageStr);
       params.push(
         pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source,
-        chunk.model || DEFAULT_EMBEDDING_MODEL, chunk.token_count || null,
+        chunk.model || (chunk.embedding ? activeEmbeddingModel : DEFAULT_EMBEDDING_MODEL),
+        chunk.token_count || null,
         chunk.language || null, chunk.symbol_name || null, chunk.symbol_type || null,
         chunk.start_line ?? null, chunk.end_line ?? null,
         parentPath, chunk.doc_comment || null, chunk.symbol_name_qualified || null,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -2122,6 +2122,11 @@ export class PostgresEngine implements BrainEngine {
     const rows: string[] = [];
     const params: unknown[] = [];
     let paramIdx = 1;
+    let activeEmbeddingModel = DEFAULT_EMBEDDING_MODEL;
+    try {
+      const gw = await import('./ai/gateway.ts');
+      activeEmbeddingModel = gw.getEmbeddingModel() || activeEmbeddingModel;
+    } catch { /* gateway not configured — use defaults */ }
 
     for (const chunk of chunks) {
       const embeddingStr = chunk.embedding
@@ -2152,7 +2157,8 @@ export class PostgresEngine implements BrainEngine {
       if (embeddingImageStr) params.push(embeddingImageStr);
       params.push(
         pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source,
-        chunk.model || DEFAULT_EMBEDDING_MODEL, chunk.token_count || null,
+        chunk.model || (chunk.embedding ? activeEmbeddingModel : DEFAULT_EMBEDDING_MODEL),
+        chunk.token_count || null,
         chunk.language || null, chunk.symbol_name || null, chunk.symbol_type || null,
         chunk.start_line ?? null, chunk.end_line ?? null,
         parentPath, chunk.doc_comment || null, chunk.symbol_name_qualified || null,

--- a/test/ai/gateway.test.ts
+++ b/test/ai/gateway.test.ts
@@ -67,6 +67,44 @@ describe('gateway.isAvailable (silent-drop regression surface)', () => {
     expect(isAvailable('embedding')).toBe(true);
   });
 
+  test('openai embedding honors provider_base_urls.openai over OPENAI_BASE_URL env', async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedUrl = '';
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      capturedUrl = typeof url === 'string' ? url : url.toString();
+      return new Response(JSON.stringify({
+        object: 'list',
+        data: [
+          {
+            object: 'embedding',
+            index: 0,
+            embedding: new Array(1536).fill(0.01),
+          },
+        ],
+        model: 'text-embedding-3-large',
+        usage: { prompt_tokens: 1, total_tokens: 1 },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      configureGateway({
+        embedding_model: 'openai:text-embedding-3-large',
+        embedding_dimensions: 1536,
+        base_urls: { openai: 'http://config.example/v1' },
+        env: { OPENAI_API_KEY: 'sk-fake' },
+      });
+
+      const vectors = await embed(['native openai base url']);
+      expect(vectors[0].length).toBe(1536);
+      expect(capturedUrl).toContain('http://config.example/v1/embeddings');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test('embedding UNAVAILABLE when OPENAI_API_KEY missing even if config names openai', () => {
     configureGateway({
       embedding_model: 'openai:text-embedding-3-large',

--- a/test/ai/recipe-local-sentence-transformers.test.ts
+++ b/test/ai/recipe-local-sentence-transformers.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+import { buildGatewayConfig } from '../../src/core/ai/build-gateway-config.ts';
+
+describe('recipe: local-sentence-transformers', () => {
+  test('registers the BAAI/bge-m3 local embedding service honestly', () => {
+    const r = getRecipe('local-sentence-transformers');
+    expect(r).toBeTruthy();
+    expect(r!.id).toBe('local-sentence-transformers');
+    expect(r!.implementation).toBe('openai-compatible');
+    expect(r!.touchpoints.embedding!.models).toContain('BAAI/bge-m3');
+    expect(r!.touchpoints.embedding!.default_dims).toBe(1536);
+    expect(r!.touchpoints.embedding!.cost_per_1m_tokens_usd).toBe(0);
+    expect(r!.touchpoints.embedding!.no_batch_cap).toBe(true);
+    expect(r!.auth_env!.required).toEqual([]);
+  });
+
+  test('threads LOCAL_SENTENCE_TRANSFORMERS_BASE_URL into gateway base URLs', () => {
+    const prev = process.env.LOCAL_SENTENCE_TRANSFORMERS_BASE_URL;
+    process.env.LOCAL_SENTENCE_TRANSFORMERS_BASE_URL = 'http://127.0.0.1:8765/v1';
+    try {
+      const cfg = buildGatewayConfig({
+        engine: 'pglite',
+        embedding_model: 'local-sentence-transformers:BAAI/bge-m3',
+        embedding_dimensions: 1536,
+      });
+      expect(cfg.base_urls?.['local-sentence-transformers']).toBe('http://127.0.0.1:8765/v1');
+    } finally {
+      if (prev === undefined) delete process.env.LOCAL_SENTENCE_TRANSFORMERS_BASE_URL;
+      else process.env.LOCAL_SENTENCE_TRANSFORMERS_BASE_URL = prev;
+    }
+  });
+});

--- a/test/commands/capture.test.ts
+++ b/test/commands/capture.test.ts
@@ -16,12 +16,25 @@ import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
 import { resetPgliteState } from '../helpers/reset-pglite.ts';
 import matter from 'gray-matter';
 import { runCapture, __testing } from '../../src/commands/capture.ts';
+import { configureGateway, resetGateway, __setEmbedTransportForTests } from '../../src/core/ai/gateway.ts';
 
 let engine: PGLiteEngine;
 let tmpRoot: string;
 let brainDir: string;
 
+const stubEmbeddingTransport = async ({ values }: any) => ({
+  embeddings: values.map(() => new Array(1536).fill(0)),
+  usage: { tokens: 0 },
+}) as any;
+
 beforeAll(async () => {
+  configureGateway({
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    env: { ...process.env, OPENAI_API_KEY: process.env.OPENAI_API_KEY || 'sk-test-stub' },
+  });
+  __setEmbedTransportForTests(stubEmbeddingTransport);
+
   engine = new PGLiteEngine();
   await engine.connect({});
   await engine.initSchema();
@@ -29,6 +42,8 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await engine.disconnect();
+  __setEmbedTransportForTests(null);
+  resetGateway();
 });
 
 beforeEach(async () => {
@@ -89,6 +104,14 @@ describe('capture — parseArgs', () => {
   test('--stdin flag', () => {
     const r = __testing.parseArgs(['--stdin']);
     if (!('help' in r)) expect(r.stdin).toBe(true);
+  });
+
+  test('--no-embed flag', () => {
+    const r = __testing.parseArgs(['--no-embed', 'queued capture']);
+    if (!('help' in r)) {
+      expect(r.noEmbed).toBe(true);
+      expect(r.content).toBe('queued capture');
+    }
   });
 
   test('--quiet, --json, --help', () => {

--- a/test/put-page-provenance.test.ts
+++ b/test/put-page-provenance.test.ts
@@ -33,6 +33,11 @@ const putPageOp = operations.find((o) => o.name === 'put_page')!;
 
 let engine: PGLiteEngine;
 
+const stubEmbeddingTransport = async ({ values }: any) => ({
+  embeddings: values.map(() => new Array(1536).fill(0)),
+  usage: { tokens: 0 },
+}) as any;
+
 beforeAll(async () => {
   // Hermeticity guard (cross-file gateway-state leak class — see CLAUDE.md
   // "Test-isolation lint and helpers"). put_page embeds via the gateway.
@@ -52,10 +57,7 @@ beforeAll(async () => {
     embedding_dimensions: 1536,
     env: { ...process.env, OPENAI_API_KEY: process.env.OPENAI_API_KEY || 'sk-test-stub' },
   });
-  __setEmbedTransportForTests(async ({ values }: any) => ({
-    embeddings: values.map(() => new Array(1536).fill(0)),
-    usage: { tokens: 0 },
-  }) as any);
+  __setEmbedTransportForTests(stubEmbeddingTransport);
 
   engine = new PGLiteEngine();
   await engine.connect({});
@@ -113,6 +115,30 @@ async function readProvenance(slug: string): Promise<{
 }
 
 describe('put_page provenance — trusted local caller (ctx.remote === false)', () => {
+  test('no_embed param skips inline embedding even when a provider is configured', async () => {
+    let embedCalls = 0;
+    try {
+      __setEmbedTransportForTests(async () => {
+        embedCalls++;
+        throw new Error('embed should not be called when no_embed=true');
+      });
+
+      const ctx = makeCtx({ remote: false });
+      await putPageOp.handler(ctx, {
+        slug: 'wiki/p3a-no-embed',
+        content: '---\ntype: note\ntitle: No Embed\n---\n\nbody',
+        no_embed: true,
+      });
+
+      const chunks = await engine.getChunks('wiki/p3a-no-embed');
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(chunks.every((chunk) => !chunk.embedding)).toBe(true);
+      expect(embedCalls).toBe(0);
+    } finally {
+      __setEmbedTransportForTests(stubEmbeddingTransport);
+    }
+  });
+
   test('client params honored: source_kind / source_uri / ingested_via populate DB', async () => {
     const ctx = makeCtx({ remote: false });
     await putPageOp.handler(ctx, {

--- a/test/schema-cli.test.ts
+++ b/test/schema-cli.test.ts
@@ -63,6 +63,7 @@ describe('gbrain schema CLI (Phase C)', () => {
     expect(r.code).toBe(0);
     expect(r.stdout).toContain('Bundled packs:');
     expect(r.stdout).toContain('gbrain-base');
+    expect(r.stdout).toContain('gbrain-creator');
   });
 
   test('schema show gbrain-base prints manifest details', () => {
@@ -85,6 +86,13 @@ describe('gbrain schema CLI (Phase C)', () => {
     expect(r.code).toBe(0);
     expect(r.stdout).toContain('✓');
     expect(r.stdout).toContain('valid manifest');
+  });
+
+  test('schema show bundled creator pack prints manifest details', () => {
+    const r = gbrain(['schema', 'show', 'gbrain-creator']);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('gbrain-creator v1.0.0');
+    expect(r.stdout).toContain('atom :: concept');
   });
 
   test('schema active reports default resolution', () => {
@@ -134,6 +142,15 @@ describe('gbrain schema use (Phase C, gap-fill T3)', () => {
     expect(existsSync(cfgPath)).toBe(true);
     const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'));
     expect(cfg.schema_pack).toBe('gbrain-base');
+  });
+
+  test('writes bundled creator pack to ~/.gbrain/config.json', () => {
+    const r = gbrain(['schema', 'use', 'gbrain-creator'], { GBRAIN_HOME: home });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('Active schema pack set to: gbrain-creator');
+    const cfgPath = join(home, '.gbrain', 'config.json');
+    const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'));
+    expect(cfg.schema_pack).toBe('gbrain-creator');
   });
 
   test('preserves pre-existing config fields when writing schema_pack', () => {

--- a/test/storage-vacuum.test.ts
+++ b/test/storage-vacuum.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { spawnSync } from 'child_process';
+import { runStorage } from '../src/commands/storage.ts';
+
+describe('storage vacuum maintenance command', () => {
+  test('runs VACUUM ANALYZE followed by CHECKPOINT through the connected engine', async () => {
+    const calls: string[] = [];
+    const engine = {
+      kind: 'pglite',
+      executeRaw: async (sql: string) => {
+        calls.push(sql);
+        return [];
+      },
+    } as any;
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    const originalWarn = console.warn;
+    try {
+      console.log = (message?: unknown) => {
+        logs.push(String(message ?? ''));
+      };
+      console.warn = () => {};
+
+      await runStorage(engine, ['vacuum', '--json']);
+    } finally {
+      console.log = originalLog;
+      console.warn = originalWarn;
+    }
+
+    expect(calls).toEqual(['VACUUM (ANALYZE)', 'CHECKPOINT']);
+    expect(JSON.parse(logs.join('\n'))).toMatchObject({
+      ok: true,
+      vacuum: 'VACUUM (ANALYZE)',
+      checkpoint: 'CHECKPOINT',
+    });
+  });
+
+  test('writes and verifies a PGLite data-dir backup before reporting success', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'gbrain-storage-backup-'));
+    try {
+      const backupDir = join(tmp, 'backups');
+      const tarBytes = makeTarFixture(tmp, 'fixture.tar');
+      const calls: string[] = [];
+      let dumpCompression: string | undefined;
+      const engine = {
+        kind: 'pglite',
+        executeRaw: async (sql: string) => {
+          calls.push(sql);
+          return [];
+        },
+        db: {
+          dumpDataDir: async (compression?: string) => {
+            dumpCompression = compression;
+            return blobFromBuffer(tarBytes);
+          },
+        },
+      } as any;
+
+      const logs: string[] = [];
+      const originalLog = console.log;
+      try {
+        console.log = (message?: unknown) => {
+          logs.push(String(message ?? ''));
+        };
+
+        await runStorage(engine, ['backup', '--dir', backupDir, '--no-compress', '--json']);
+      } finally {
+        console.log = originalLog;
+      }
+
+      const result = JSON.parse(logs.join('\n'));
+      expect(calls).toEqual(['CHECKPOINT']);
+      expect(dumpCompression).toBe('none');
+      expect(result).toMatchObject({
+        ok: true,
+        compression: 'none',
+        verified_file_count: 3,
+        retained_count: 1,
+      });
+      expect(result.output_path).toMatch(/brain-pglite-\d{8}T\d{6}Z\.tar$/);
+      expect(readFileSync(result.output_path).byteLength).toBe(tarBytes.byteLength);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('prunes oldest backups after the new backup verifies', async () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'gbrain-storage-backup-prune-'));
+    try {
+      const backupDir = join(tmp, 'backups');
+      const tarBytes = makeTarFixture(tmp, 'fixture.tar');
+      for (let i = 0; i < 7; i++) {
+        const name = `brain-pglite-2026070${i + 1}T000000Z.tar`;
+        const path = join(backupDir, name);
+        writeTarFixture(path, tarBytes);
+        const when = new Date(Date.UTC(2026, 6, i + 1));
+        utimesSync(path, when, when);
+      }
+
+      const engine = {
+        kind: 'pglite',
+        executeRaw: async () => [],
+        db: {
+          dumpDataDir: async () => blobFromBuffer(tarBytes),
+        },
+      } as any;
+
+      const logs: string[] = [];
+      const originalLog = console.log;
+      try {
+        console.log = (message?: unknown) => {
+          logs.push(String(message ?? ''));
+        };
+        await runStorage(engine, ['backup', '--dir', backupDir, '--no-compress', '--json', '--max-count', '7']);
+      } finally {
+        console.log = originalLog;
+      }
+
+      const result = JSON.parse(logs.join('\n'));
+      expect(result.ok).toBe(true);
+      expect(result.retained_count).toBe(7);
+      expect(result.pruned).toHaveLength(1);
+      expect(result.pruned[0].path).toContain('brain-pglite-20260701T000000Z.tar');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+function makeTarFixture(root: string, name: string): Buffer {
+  const srcDir = join(root, `${name}.src`);
+  const tarPath = join(root, name);
+  mkdirSync(srcDir, { recursive: true });
+  writeFileSync(join(srcDir, 'PG_VERSION'), '16\n');
+  writeFileSync(join(srcDir, 'postgresql.conf'), 'max_wal_size = 256MB\n');
+  const result = spawnSync('tar', ['-cf', tarPath, '-C', srcDir, '.'], { encoding: 'utf8' });
+  if (result.status !== 0) throw new Error(result.stderr);
+  return readFileSync(tarPath);
+}
+
+function writeTarFixture(path: string, bytes: Buffer): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, bytes);
+}
+
+function blobFromBuffer(bytes: Buffer): Blob {
+  const view = new Uint8Array(bytes.byteLength);
+  view.set(bytes);
+  return new Blob([view]);
+}

--- a/test/sync-walker-symlink.test.ts
+++ b/test/sync-walker-symlink.test.ts
@@ -15,6 +15,7 @@
  *    (codex C8).
  */
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { execFileSync } from 'child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -159,6 +160,35 @@ describe('collectSyncableFiles symlink + cycle hardening', () => {
       expect(first.map(f => f.replace(tmp, ''))).toEqual([
         '/a.md', '/b.md', '/sub/c.md',
       ]);
+    });
+  });
+
+  test('8. explicit collector opt-out can include gitignored markdown files', async () => {
+    await withEnv({
+      GBRAIN_EMBEDDING_MULTIMODAL: undefined,
+      GBRAIN_IMPORT_IGNORE_GITIGNORE: undefined,
+    }, async () => {
+      execFileSync('git', ['init'], { cwd: tmp, stdio: 'ignore' });
+      writeFileSync(join(tmp, '.gitignore'), 'ignored/\n');
+      writeFileSync(join(tmp, 'visible.md'), 'visible\n');
+      mkdirSync(join(tmp, 'ignored'));
+      writeFileSync(join(tmp, 'ignored/hidden.md'), 'hidden\n');
+
+      const defaultFiles = collectSyncableFiles(tmp, { strategy: 'markdown' })
+        .map(f => f.replace(tmp, ''));
+      expect(defaultFiles).toEqual(['/visible.md']);
+
+      await withEnv({ GBRAIN_IMPORT_IGNORE_GITIGNORE: '1' }, () => {
+        const envOnlyFiles = collectSyncableFiles(tmp, { strategy: 'markdown' })
+          .map(f => f.replace(tmp, ''));
+        expect(envOnlyFiles).toEqual(['/visible.md']);
+      });
+
+      const optionFiles = collectSyncableFiles(tmp, {
+        strategy: 'markdown',
+        ignoreGitignore: true,
+      }).map(f => f.replace(tmp, ''));
+      expect(optionFiles).toEqual(['/ignored/hidden.md', '/visible.md']);
     });
   });
 });

--- a/test/v0_37_gap_fill.serial.test.ts
+++ b/test/v0_37_gap_fill.serial.test.ts
@@ -62,6 +62,32 @@ describe('Lane A.7 — chunk-row INSERT default tracks ai/defaults.ts constant',
     // (a literal pre-fix; production write site that was never tested).
     expect(rows[0]?.model).not.toBe('text-embedding-3-large');
   });
+
+  test('upsertChunks with a new embedding stores current gateway model', async () => {
+    configureGateway({
+      embedding_model: 'local-sentence-transformers:BAAI/bge-m3',
+      embedding_dimensions: 1536,
+      env: {},
+    });
+    try {
+      await engine.putPage('test/a7-current', { type: 'note', title: 'A.7 current', compiled_truth: 'hello' });
+      await engine.upsertChunks('test/a7-current', [
+        {
+          chunk_index: 0,
+          chunk_text: 'hello',
+          chunk_source: 'compiled_truth',
+          embedding: new Float32Array(1536),
+        },
+      ]);
+
+      const rows = await engine.executeRaw<{ model: string }>(
+        `SELECT model FROM content_chunks WHERE chunk_index = 0 AND page_id = (SELECT id FROM pages WHERE slug = 'test/a7-current') LIMIT 1`,
+      );
+      expect(rows[0]?.model).toBe('local-sentence-transformers:BAAI/bge-m3');
+    } finally {
+      resetGateway();
+    }
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Ref: WS-954

`gbrain import` currently switches to `git ls-files --cached --others --exclude-standard` inside git worktrees, which is correct for normal repo imports but can silently drop generated import feeds that intentionally live under `.gitignore`d directories.

This adds explicit opt-outs for that import-only case:

- `gbrain import <dir> --all-files`
- `gbrain import <dir> --ignore-gitignore`
- `GBRAIN_IMPORT_IGNORE_GITIGNORE=1 gbrain import <dir>`

The opt-out is wired through `runImport` into `collectSyncableFiles(..., { ignoreGitignore: true })`; direct `collectSyncableFiles` callers, especially sync, keep the default gitignore policy unless they opt in programmatically.

## Verification

- `bun test test/sync-walker-symlink.test.ts`
- `bun test test/import-source-id.test.ts`
- `bun run typecheck`
- Smoke: disposable PGLite brain + git repo where `ignored/hidden.md` is ignored:
  - default import found 1 markdown file
  - `--all-files` import found 2 markdown files and imported `ignored/hidden`
  - `GBRAIN_IMPORT_IGNORE_GITIGNORE=1` import found 2 markdown files
