### PR TITLE
fix(sync): crash-safe renames loop — record per-file failures instead of throwing

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -2306,11 +2306,24 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       } catch {
         // Slug doesn't exist or collision, treat as add
       }
-      // Reimport at new path (picks up content changes)
+      // Reimport at new path (picks up content changes). Wrapped to match the
+      // deletes/adds loops: a malformed renamed file is recorded to failedFiles
+      // and skipped, NOT thrown uncaught. importFile still throws on content
+      // sanity-block, duplicate-slug, and missing-link endpoints; an uncaught
+      // throw here crashes the whole sync mid-run and freezes the checkpoint,
+      // defeating --skip-failed. A `skipped` result carrying an error is also
+      // captured so the failure is recorded rather than silently dropped.
       const filePath = join(repoPath, to);
       if (existsSync(filePath)) {
-        const result = await importFile(engine, filePath, to, { noEmbed, sourceId: opts.sourceId, activePack: syncActivePack });
-        if (result.status === 'imported') chunksCreated += result.chunks;
+        try {
+          const result = await importFile(engine, filePath, to, { noEmbed, sourceId: opts.sourceId, activePack: syncActivePack });
+          if (result.status === 'imported') chunksCreated += result.chunks;
+          else if (result.status === 'skipped' && (result as { error?: string }).error) {
+            failedFiles.push({ path: to, error: String((result as { error?: string }).error) });
+          }
+        } catch (e: unknown) {
+          failedFiles.push({ path: to, error: e instanceof Error ? e.message : String(e) });
+        }
       }
       pagesAffected.push(newSlug);
       await markCompleted(to);


### PR DESCRIPTION
## What

The renames loop in `performSyncInner` reimports each renamed file via `importFile()` with **no `try/catch`** — unlike the deletes loop and the adds/mods loop, which both record per-file failures to `failedFiles`. This wraps the renames reimport to match those loops.

## Why

`importFile()` returns a status, but it still **throws** on several paths — content sanity-block (`ContentSanityBlockError`), duplicate-slug, and missing-link endpoints. In the renames loop an uncaught throw propagates all the way out and **crashes the entire sync mid-run**, freezing the checkpoint and defeating `--skip-failed`. A `skipped`-with-error result was also silently dropped (never recorded to `failedFiles`).

I hit this in the wild on a tree-wide rename — a `shared/ → system/` vault reorg of ~10,857 renames. One malformed-YAML renamed file threw and killed incremental sync at rename ~4,900/10,857, with `--skip-failed` set. The deletes/adds loops would have recorded-and-skipped it; the renames loop crashed.

(Note: the related `maxBuffer` ENOBUFS fix in `git()` and the `failedFiles` hoist are already on `master` — this PR is only the remaining renames-loop gap.)

## Change

Wrap the renames `importFile()` call in `try/catch`, pushing both the thrown error and the `skipped`-with-error case to `failedFiles` — identical to the existing deletes/adds pattern. `sync.ts` only, +16/-3, no behavior change on the happy path.
