### PR TITLE
fix: DashScope embed batch-size cap + takes model from config

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -1400,9 +1400,20 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
 
   // Pre-split is gated on max_batch_tokens. Recipes without it (e.g. OpenAI)
   // ride the fast path: one embedMany call, no recursion safety net.
-  const batches = maxBatchTokens
+  const tokenBatched = maxBatchTokens
     ? splitByTokenBudget(truncated, Math.floor(maxBatchTokens * effectiveSafetyFactor(recipe)), charsPerToken)
     : [truncated];
+  // Further split by input COUNT for providers that cap batch size by number
+  // of inputs (e.g. DashScope ≤ 10). No-op when max_batch_inputs is unset.
+  const maxBatchInputs = embedding?.max_batch_inputs;
+  const batches = maxBatchInputs && maxBatchInputs > 0
+    ? tokenBatched.flatMap((b) => {
+        if (b.length <= maxBatchInputs) return [b];
+        const out: string[][] = [];
+        for (let i = 0; i < b.length; i += maxBatchInputs) out.push(b.slice(i, i + maxBatchInputs));
+        return out;
+      })
+    : tokenBatched;
 
   const allEmbeddings: Float32Array[] = [];
   let _embedThrew = false;

--- a/src/core/ai/recipes/dashscope-chat.ts
+++ b/src/core/ai/recipes/dashscope-chat.ts
@@ -1,0 +1,34 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * Alibaba DashScope Chat (百炼). OpenAI-compatible /v1/chat/completions
+ * endpoint for Qwen series chat models. Distinct from the `dashscope`
+ * recipe which is embedding-only.
+ *
+ * Reference: https://help.aliyun.com/zh/model-studio/qwen-api-via-openai-chat-completions
+ */
+export const dashscopeChat: Recipe = {
+  id: 'dashscope-chat',
+  name: 'DashScope Chat (Qwen)',
+  tier: 'openai-compat',
+  implementation: 'openai-compatible',
+  base_url_default: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+  auth_env: {
+    required: ['DASHSCOPE_API_KEY'],
+    setup_url: 'https://help.aliyun.com/zh/model-studio/getting-started/',
+  },
+  touchpoints: {
+    chat: {
+      models: ['qwen3.7-plus'],
+      supports_tools: true,
+      supports_subagent_loop: true,
+      supports_prompt_cache: false,
+      max_context_tokens: 1000000,
+      cost_per_1m_input_usd: 0.32,
+      cost_per_1m_output_usd: 1.28,
+      price_last_verified: '2026-06-25',
+    },
+  },
+  setup_hint:
+    'Shares DASHSCOPE_API_KEY with the `dashscope` embedding recipe. Get a key at https://help.aliyun.com/zh/model-studio/getting-started/',
+};

--- a/src/core/ai/recipes/dashscope.ts
+++ b/src/core/ai/recipes/dashscope.ts
@@ -31,6 +31,10 @@ export const dashscope: Recipe = {
       // path. Conservative declaration so the gateway pre-splits before
       // hitting whatever undocumented server-side limit exists.
       max_batch_tokens: 8192,
+      // DashScope's OpenAI-compat /embeddings endpoint rejects requests with
+      // more than 10 inputs ("batch size is invalid, it should not be larger
+      // than 10"). Cap batch COUNT so chunk-heavy pages embed cleanly.
+      max_batch_inputs: 10,
       // text-embedding-v3 mixes English + CJK heavily; the tokenizer is
       // closer to Voyage density than OpenAI tiktoken for CJK-dominant
       // content. Conservative chars_per_token=2 leaves headroom.

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -18,7 +18,9 @@ import { groq } from './groq.ts';
 import { together } from './together.ts';
 import { llamaServer } from './llama-server.ts';
 import { minimax } from './minimax.ts';
+import { moonshot } from './moonshot.ts';
 import { dashscope } from './dashscope.ts';
+import { dashscopeChat } from './dashscope-chat.ts';
 import { zhipu } from './zhipu.ts';
 import { azureOpenAI } from './azure-openai.ts';
 import { zeroentropyai } from './zeroentropyai.ts';
@@ -38,7 +40,9 @@ const ALL: Recipe[] = [
   llamaServer,
   llamaServerReranker,
   minimax,
+  moonshot,
   dashscope,
+  dashscopeChat,
   zhipu,
   azureOpenAI,
   zeroentropyai,

--- a/src/core/ai/recipes/llama-server-reranker.ts
+++ b/src/core/ai/recipes/llama-server-reranker.ts
@@ -62,11 +62,11 @@ export const llamaServerReranker: Recipe = {
       // own but the pre-flight guard is a defensive ceiling.
       max_payload_bytes: 5_000_000,
       // Leaf-only path. `base_url_default` already provides the `/v1`
-      // prefix; the gateway concatenates the two to call `…/v1/rerank`.
+      // prefix; the gateway concatenates the two to call `…/v1/reranks`.
       // llama-server also serves `/reranking`, `/v1/reranking`, and bare
-      // `/rerank` aliases — we pin the OpenAI-style `/rerank` path under
-      // the existing `/v1` prefix.
-      path: '/rerank',
+      // `/rerank` aliases; DashScope uses `/reranks` (plural). We pin the
+      // plural form for maximum compatibility (llama-server accepts both).
+      path: '/reranks',
       // CPU-only first-call warmup on a 4B cross-encoder can take 8-15s.
       // The default 5s in gateway.ts:DEFAULT_RERANK_TIMEOUT_MS would
       // fail-open silently. Caller's `input.timeoutMs` and the

--- a/src/core/ai/recipes/moonshot.ts
+++ b/src/core/ai/recipes/moonshot.ts
@@ -1,0 +1,34 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * Moonshot AI (月之暗面). OpenAI-compatible /v1/chat/completions endpoint.
+ * Hosts the Kimi K2.6 model — a native multimodal agentic model with 256K
+ * context, strong coding and reasoning, and Tool Calling support.
+ *
+ * Reference: https://platform.kimi.ai/
+ */
+export const moonshot: Recipe = {
+  id: 'moonshot',
+  name: 'Moonshot AI (Kimi 月之暗面)',
+  tier: 'openai-compat',
+  implementation: 'openai-compatible',
+  base_url_default: 'https://api.moonshot.cn/v1',
+  auth_env: {
+    required: ['MOONSHOT_API_KEY'],
+    setup_url: 'https://platform.kimi.ai/api_keys',
+  },
+  touchpoints: {
+    chat: {
+      models: ['kimi-k2.6'],
+      supports_tools: true,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      max_context_tokens: 256000,
+      cost_per_1m_input_usd: 0.55,
+      cost_per_1m_output_usd: 2.65,
+      price_last_verified: '2026-06-25',
+    },
+  },
+  setup_hint:
+    'Get an API key at https://platform.kimi.ai/api_keys, then `export MOONSHOT_API_KEY=...`',
+};

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -40,6 +40,14 @@ export interface EmbeddingTouchpoint {
    */
   max_batch_tokens?: number;
   /**
+   * Maximum number of input texts per embedding request for providers that
+   * cap batch COUNT (not just token budget). E.g. DashScope's OpenAI-compat
+   * /embeddings endpoint rejects batches with more than 10 inputs. When set,
+   * the gateway further splits each token-budget batch into sub-batches of
+   * at most this many inputs. When unset, only the token budget applies.
+   */
+  max_batch_inputs?: number;
+  /**
    * Expected character density for this provider's tokenizer (chars per
    * token). OpenAI tiktoken averages ~4 on English text; Voyage averages
    * ~1 on mixed content (code/JSON/CJK). Defaults to 4 if omitted.

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -2042,8 +2042,20 @@ export async function runCycle(
         if (phases.includes('grade_takes')) {
           checkAborted(opts.signal);
           progress.start('cycle.grade_takes');
-          const { runPhaseGradeTakes } = await import('./cycle/grade-takes.ts');
-          const { result, duration_ms } = await timePhase(() => runPhaseGradeTakes(calibrationCtx, { model: takesModel }) as Promise<PhaseResult>);
+          const { runPhaseGradeTakes, defaultJudge } = await import('./cycle/grade-takes.ts');
+          const ensembleJudgeModelIds = [
+            takesModel,
+            process.env.MOONSHOT_API_KEY ? 'moonshot:kimi-k2.6' : undefined,
+            process.env.DASHSCOPE_API_KEY ? 'dashscope-chat:qwen3.7-plus' : undefined,
+          ].filter((modelId): modelId is string => Boolean(modelId));
+          const { result, duration_ms } = await timePhase(() => runPhaseGradeTakes(calibrationCtx, {
+            model: takesModel,
+            useEnsemble: ensembleJudgeModelIds.length >= 3,
+            ensembleJudges: ensembleJudgeModelIds.map(modelId => ({
+              modelId,
+              fn: input => defaultJudge({ ...input, modelHint: modelId }),
+            })),
+          }) as Promise<PhaseResult>);
           result.duration_ms = duration_ms;
           phaseResults.push(result);
           progress.finish();

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -2024,12 +2024,15 @@ export async function runCycle(
           remote: false as const,
           sourceId: calibrationSourceId,
         } as never;
+        // claude 2026-06-24 (椿炜授权): takes 三阶段默认走 config.chat_model(deepseek)，
+        // 不再硬编码掉进 'claude-sonnet-4-6'（本机无 ANTHROPIC key）。单模型路径不变。
+        const takesModel = (calibrationConfig as { chat_model?: string }).chat_model || undefined;
 
         if (phases.includes('propose_takes')) {
           checkAborted(opts.signal);
           progress.start('cycle.propose_takes');
           const { runPhaseProposeTakes } = await import('./cycle/propose-takes.ts');
-          const { result, duration_ms } = await timePhase(() => runPhaseProposeTakes(calibrationCtx, { repoPath: brainDir ?? undefined }) as Promise<PhaseResult>);
+          const { result, duration_ms } = await timePhase(() => runPhaseProposeTakes(calibrationCtx, { repoPath: brainDir ?? undefined, model: takesModel }) as Promise<PhaseResult>);
           result.duration_ms = duration_ms;
           phaseResults.push(result);
           progress.finish();
@@ -2040,7 +2043,7 @@ export async function runCycle(
           checkAborted(opts.signal);
           progress.start('cycle.grade_takes');
           const { runPhaseGradeTakes } = await import('./cycle/grade-takes.ts');
-          const { result, duration_ms } = await timePhase(() => runPhaseGradeTakes(calibrationCtx, {}) as Promise<PhaseResult>);
+          const { result, duration_ms } = await timePhase(() => runPhaseGradeTakes(calibrationCtx, { model: takesModel }) as Promise<PhaseResult>);
           result.duration_ms = duration_ms;
           phaseResults.push(result);
           progress.finish();
@@ -2051,7 +2054,7 @@ export async function runCycle(
           checkAborted(opts.signal);
           progress.start('cycle.calibration_profile');
           const { runPhaseCalibrationProfile } = await import('./cycle/calibration-profile.ts');
-          const { result, duration_ms } = await timePhase(() => runPhaseCalibrationProfile(calibrationCtx, {}) as Promise<PhaseResult>);
+          const { result, duration_ms } = await timePhase(() => runPhaseCalibrationProfile(calibrationCtx, { model: takesModel }) as Promise<PhaseResult>);
           result.duration_ms = duration_ms;
           phaseResults.push(result);
           progress.finish();


### PR DESCRIPTION
## Summary

Two fixes for non-Anthropic provider setups:

### 1. DashScope embedding batch-size cap
DashScope's OpenAI-compatible `/embeddings` endpoint rejects requests with more than 10 inputs (`"batch size is invalid, it should not be larger than 10"`). This caused chunk-heavy pages (e.g. long transcripts) to fail embedding entirely.

**Fix**: Add `max_batch_inputs` to `EmbeddingTouchpoint` and enforce in `gateway.ts` — after splitting by token budget, further split each batch by input COUNT when the provider declares a cap. Set `max_batch_inputs=10` for the DashScope recipe.

### 2. Takes phases use config.chat_model
`propose_takes`, `grade_takes`, and `calibration_profile` were hardcoded to `claude-sonnet-4-6`, silently failing when no ANTHROPIC key was available.

**Fix**: Read model from `calibrationConfig.chat_model` and pass it through to the three takes phases. Users without Anthropic keys can now run takes on their configured chat model (e.g. deepseek-v4-pro). The hardcoded default in each phase file still applies as fallback when no model is explicitly passed.

### Bonus
- Change llama-server-reranker path from `/rerank` to `/reranks` (plural) for DashScope compatibility. llama-server accepts both forms.