### PR TITLE
feat(embedding): add max_batch_items to cap batch by item count

### DIFF
--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -61,6 +61,7 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
     chat_model: c.chat_model,
     chat_fallback_chain: c.chat_fallback_chain,
     base_urls: { ...envBaseUrls, ...(c.provider_base_urls ?? {}) }, // config wins over env
+    provider_batch_items: c.provider_batch_items,
     env: { ...envFromConfig, ...process.env }, // process.env wins
   };
 }

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -1396,12 +1396,13 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
 
   const embedding = recipe.touchpoints?.embedding;
   const maxBatchTokens = embedding?.max_batch_tokens;
+  const maxBatchItems = cfg.provider_batch_items?.[recipe.id] ?? embedding?.max_batch_items;
   const charsPerToken = embedding?.chars_per_token ?? DEFAULT_CHARS_PER_TOKEN;
 
   // Pre-split is gated on max_batch_tokens. Recipes without it (e.g. OpenAI)
   // ride the fast path: one embedMany call, no recursion safety net.
   const batches = maxBatchTokens
-    ? splitByTokenBudget(truncated, Math.floor(maxBatchTokens * effectiveSafetyFactor(recipe)), charsPerToken)
+    ? splitByTokenBudget(truncated, Math.floor(maxBatchTokens * effectiveSafetyFactor(recipe)), maxBatchItems, charsPerToken)
     : [truncated];
 
   const allEmbeddings: Float32Array[] = [];
@@ -1457,6 +1458,7 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
 export function splitByTokenBudget(
   texts: string[],
   budgetTokens: number,
+  maxBatchItems?: number,
   charsPerToken: number = DEFAULT_CHARS_PER_TOKEN,
 ): string[][] {
   const ratio = charsPerToken > 0 ? charsPerToken : DEFAULT_CHARS_PER_TOKEN;
@@ -1466,7 +1468,9 @@ export function splitByTokenBudget(
 
   for (const text of texts) {
     const estTokens = Math.ceil(text.length / ratio);
-    if (current.length > 0 && currentTokens + estTokens > budgetTokens) {
+    // Cap by whichever limit is hit first: token budget or item count
+    const itemLimitHit = maxBatchItems !== undefined && current.length >= maxBatchItems;
+    if (current.length > 0 && (currentTokens + estTokens > budgetTokens || itemLimitHit)) {
       batches.push(current);
       current = [];
       currentTokens = 0;

--- a/src/core/ai/recipes/dashscope.ts
+++ b/src/core/ai/recipes/dashscope.ts
@@ -31,6 +31,10 @@ export const dashscope: Recipe = {
       // path. Conservative declaration so the gateway pre-splits before
       // hitting whatever undocumented server-side limit exists.
       max_batch_tokens: 8192,
+      // DashScope limits each API call to 10 input items.
+      // Without this cap, gbrain's token-based batching can pack
+      // 20+ small chunks into one request → HTTP 400.
+      max_batch_items: 10,
       // text-embedding-v3 mixes English + CJK heavily; the tokenizer is
       // closer to Voyage density than OpenAI tiktoken for CJK-dominant
       // content. Conservative chars_per_token=2 leaves headroom.

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -31,6 +31,13 @@ export interface EmbeddingTouchpoint {
   cost_per_1m_tokens_usd?: number;
   price_last_verified?: string; // ISO date
   /**
+   * Maximum items (input array length) per batch for this provider's
+   * embedding endpoint. When set alongside max_batch_tokens, batches are
+   * capped by whichever limit is hit first. DashScope text-embedding-v3/v4
+   * require max_batch_items: 10.
+   */
+  max_batch_items?: number;
+  /**
    * Maximum tokens per batch for this provider's embedding endpoint.
    * When set, the gateway pre-splits batches at
    * `max_batch_tokens × safety_factor / chars_per_token` characters and
@@ -366,6 +373,12 @@ export interface AIGatewayConfig {
   chat_fallback_chain?: string[];
   /** Optional per-provider base URL override (openai-compatible variants). */
   base_urls?: Record<string, string>;
+  /**
+   * Optional per-provider max batch items override. When set, overrides
+   * the recipe's max_batch_items. Format: { providerId: number }.
+   * Useful for providers like DashScope that limit API batch size to 10.
+   */
+  provider_batch_items?: Record<string, number>;
   /** Env snapshot read once at configuration time. Gateway never reads process.env at call time. */
   env: Record<string, string | undefined>;
 }


### PR DESCRIPTION
DashScope text-embedding-v3/v4 limit each API call to 10 input items, but gbrain's token-based batching can pack 20+ small chunks into one request, causing HTTP 400.

Changes:
- Add max_batch_items to EmbeddingTouchpoint in types.ts
- Add provider_batch_items to AIGatewayConfig for runtime override
- Update build-gateway-config.ts to pass through provider_batch_items
- Update splitByTokenBudget to accept maxBatchItems; cap by tokens or items, whichever is hit first
- Set max_batch_items: 10 in DashScope recipe