### PR TITLE
feat(links): resolve [[wikilink]] frontmatter values via global_basename

### DIFF
--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -552,7 +552,7 @@ export async function extractPageLinks(
   // path needed `resolveBasenameMatches` on the real resolver.
   let fmUnresolved: UnresolvedFrontmatterRef[] = [];
   if (!opts.skipFrontmatter) {
-    const fm = await extractFrontmatterLinks(slug, pageType, frontmatter, resolver);
+    const fm = await extractFrontmatterLinks(slug, pageType, frontmatter, resolver, opts.globalBasename);
     candidates.push(...fm.candidates);
     fmUnresolved = fm.unresolved;
   }
@@ -1023,11 +1023,24 @@ export interface FrontmatterExtractResult {
  * Arrays of objects: uses the `name` or `slug` property (codex tension 6.3).
  * Non-string / non-object entries: silently skipped (log-only).
  */
+/**
+ * Unwrap an Obsidian-style `[[wikilink]]` frontmatter value to its bare link
+ * target: drops the surrounding brackets, any `|alias`, and `#heading` /
+ * `^block` suffixes. Non-bracketed values pass through unchanged. Used to feed
+ * the basename index when global_basename is on (see extractFrontmatterLinks).
+ */
+function unwrapWikilink(value: string): string {
+  const match = /^\s*\[\[(.+?)\]\]\s*$/.exec(value);
+  if (!match) return value;
+  return match[1].split('|')[0].split('#')[0].split('^')[0].trim();
+}
+
 export async function extractFrontmatterLinks(
   slug: string,
   pageType: PageType,
   frontmatter: Record<string, unknown>,
   resolver: SlugResolver,
+  globalBasename = false,
 ): Promise<FrontmatterExtractResult> {
   const candidates: LinkCandidate[] = [];
   const unresolved: UnresolvedFrontmatterRef[] = [];
@@ -1060,7 +1073,23 @@ export async function extractFrontmatterLinks(
         }
         if (!name) continue;   // skip numbers, nulls, malformed objects
 
-        const resolved = await resolver.resolve(name, mapping.dirHint);
+        let resolved = await resolver.resolve(name, mapping.dirHint);
+        if (!resolved && globalBasename && typeof resolver.resolveBasenameMatches === 'function') {
+          // Issue #972 follow-up: extend global_basename resolution to
+          // frontmatter link fields. resolve() can't reach a bare-title
+          // wikilink value (e.g. `sources: "[[2025-12-25_mentor-extraction]]"`)
+          // — it has no '/', so the slug-direct getPage is skipped, and the
+          // field's dirHint may name folders that don't exist in this brain,
+          // so the dir-scoped exact + fuzzy steps miss too. When
+          // link_resolution.global_basename is on, fall back to the SAME
+          // basename index the body bare-wikilink pass uses, after unwrapping
+          // the brackets. Unique-match-only: ambiguous basenames (e.g. archive
+          // duplicates, generic hubs like `_index`) stay unresolved rather than
+          // create a wrong edge.
+          const matches = (await resolver.resolveBasenameMatches(unwrapWikilink(name)))
+            .filter((s) => s !== slug);
+          if (matches.length === 1) resolved = matches[0];
+        }
         if (!resolved) {
           unresolved.push({ field, name });
           continue;

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -270,6 +270,53 @@ describe('extractPageLinks', () => {
     expect(sourceLink!.targetSlug).toBe('meetings/2026-01-15');
   });
 
+  // ─── global_basename for frontmatter link fields (issue #972 follow-up) ───
+
+  test('frontmatter [[wikilink]] resolves via global_basename when resolve() misses', async () => {
+    // `sources: [[2025-12-25_mentor-extraction]]` — bare title, no '/', so the
+    // standard resolver misses; the basename index finds the single match.
+    const resolver: SlugResolver = {
+      resolve: async () => null,
+      resolveBasenameMatches: async (name) =>
+        name === '2025-12-25_mentor-extraction'
+          ? ['trading/raw/2025-12-25_mentor-extraction']
+          : [],
+    };
+    const { candidates } = await extractPageLinks(
+      'trading/wiki/backtesting', 'Body.',
+      { sources: ['[[2025-12-25_mentor-extraction]]'] },
+      'concept', resolver, { globalBasename: true },
+    );
+    // `sources` is direction:'incoming' → edge is resolved → page.
+    const edge = candidates.find(c => c.linkType === 'discussed_in');
+    expect(edge).toBeDefined();
+    expect(edge!.fromSlug).toBe('trading/raw/2025-12-25_mentor-extraction');
+    expect(edge!.targetSlug).toBe('trading/wiki/backtesting');
+  });
+
+  test('frontmatter basename fallback stays unresolved when ambiguous (>1 match)', async () => {
+    const resolver: SlugResolver = {
+      resolve: async () => null,
+      resolveBasenameMatches: async () => ['a/dup', 'b/dup'],
+    };
+    const { candidates, unresolved } = await extractPageLinks(
+      'wiki/x', 'Body.', { sources: ['[[dup]]'] }, 'concept', resolver, { globalBasename: true },
+    );
+    expect(candidates.find(c => c.linkType === 'discussed_in')).toBeUndefined();
+    expect(unresolved.some(u => u.field === 'sources')).toBe(true);
+  });
+
+  test('frontmatter basename fallback is gated OFF when globalBasename is false', async () => {
+    const resolver: SlugResolver = {
+      resolve: async () => null,
+      resolveBasenameMatches: async () => ['raw/note'],
+    };
+    const { candidates } = await extractPageLinks(
+      'wiki/x', 'Body.', { sources: ['[[note]]'] }, 'concept', resolver, // globalBasename omitted = false
+    );
+    expect(candidates.find(c => c.linkType === 'discussed_in')).toBeUndefined();
+  });
+
   test('extracts bare slug references in text', async () => {
     const { candidates } = await extractPageLinks(
       'docs/x', 'See companies/acme for details.', {}, 'concept', nullResolver,


### PR DESCRIPTION
## Problem

Bare-title `[[wikilink]]` values in **frontmatter link fields** never resolve to edges. Example from a PARA/Obsidian vault:

```yaml
sources:
  - "[[2025-12-25_mentor-extraction]]"
```

Walking `SlugResolver.resolve()` for that value:

1. **slug-direct getPage** — skipped: the value has no `/`.
2. **dirHint + slugify exact** — misses: `sources` maps to `dirHint: ['source','media']`, folders that don't exist in this brain (the real page is `…/raw/mentor-transcripts/2025-12-25_mentor-extraction`).
3. **dir-scoped fuzzy** — misses: scoped to the same non-existent dirHints, and the search string still carries the `[[ ]]`.

So it returns `null` and the edge is dropped. The body bare-wikilink path got basename-index resolution in #972 (`resolveBasenameMatches`, gated by `link_resolution.global_basename`), but the **frontmatter path was never wired to it**. On a real vault this silently drops the bulk of `sources:` / `related:` provenance edges (in my brain: ~1,400 `discussed_in` + ~1,600 `related_to` edges were missing).

## Fix

Extend `global_basename` resolution to frontmatter fields:

- `extractFrontmatterLinks` takes a `globalBasename` flag (threaded from `extractPageLinks`, where it's already read from config).
- On a `resolve()` miss, **unwrap** the `[[ ]]` and fall back to `resolver.resolveBasenameMatches` — the same index the body path uses.
- **Unique-match-only**: if the basename maps to >1 page (archive dupes, generic hubs like `_index`), it stays unresolved rather than guess a wrong edge.

Purely additive — frontmatter values that already resolved are unchanged.

## Scope / limitations

- Covers the **db-source extract** and **live `put_page`** paths (both use the real `makeResolver`, which implements `resolveBasenameMatches`).
- The `--source fs` extract uses an inline resolver without a basename index, so it **gracefully no-ops** there via the `typeof resolver.resolveBasenameMatches === 'function'` guard. Wiring an fs-side basename index could be a follow-up.

## Testing

3 new cases in `test/link-extraction.test.ts`:
- resolves a bare-title `[[wikilink]]` frontmatter value via the basename fallback when the flag is on;
- stays unresolved when the basename is ambiguous (>1 match);
- is gated off when `globalBasename` is false.

Full `link-extraction` suite green (130 pass, 0 fail).

Related: follow-up to #972 (global_basename for body wikilinks); complements #1983 (which handles bracket-unwrap + exact slug-path values, but not bare-title basename resolution).
