### PR TITLE
fix: Bun+Windows write-through EEXIST, non-Anthropic --max-cost pricing, dream-page exclusion in enrich

### DIFF
--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -32,6 +32,7 @@ import { mkdirSync, appendFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { gbrainPath } from '../config.ts';
 import { ANTHROPIC_PRICING, type ModelPricing } from '../anthropic-pricing.ts';
+import { canonicalLookup } from '../model-pricing.ts';
 import { EMBEDDING_PRICING, lookupEmbeddingPrice } from '../embedding-pricing.ts';
 import { splitProviderModelId } from '../model-id.ts';
 import { isoWeekFilename, resolveAuditDir } from '../audit-week-file.ts';
@@ -201,6 +202,12 @@ function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
   if (kind === 'rerank' && providerId && FREE_LOCAL_RERANK_PROVIDERS.has(providerId)) {
     return { input: 0, output: 0 };
   }
+  // Fall back to the full canonical pricing table so non-Anthropic chat
+  // models with a known price (openai:*, google:*, deepseek:*) resolve under
+  // --max-cost instead of TX2 no_pricing hard-failing at $0. ANTHROPIC_PRICING
+  // above is only the bare-keyed Claude view.
+  const canon = canonicalLookup(modelId);
+  if (canon) return canon;
   return null;
 }
 

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -5418,6 +5418,9 @@ export class PGLiteEngine implements BrainEngine {
       );
     }
 
+    // Exclude dream/synthesize-generated pages (parity with postgres-engine).
+    where.push(`(p.frontmatter ->> 'dream_generated') IS DISTINCT FROM 'true'`);
+
     const orderKey = ENRICH_ORDER_SQL[opts.order] ? opts.order : 'inbound-links';
     const orderBy = ENRICH_ORDER_SQL[orderKey];
 

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5560,6 +5560,12 @@ export class PostgresEngine implements BrainEngine {
           )`
       : sql``;
 
+    // Exclude dream/synthesize-generated pages (reflections, originals, cycle
+    // logs carrying frontmatter dream_generated:true). enrich develops ENTITY
+    // stubs; running it on a generated essay/log creates circular self-citation
+    // and drops the H1. IS DISTINCT FROM 'true' keeps NULL/'false' rows.
+    const dreamCondition = sql`AND (p.frontmatter ->> 'dream_generated') IS DISTINCT FROM 'true'`;
+
     // Whitelisted ORDER BY (no injection — enum maps to a literal fragment).
     const orderKey = ENRICH_ORDER_SQL[opts.order] ? opts.order : 'inbound-links';
     const orderBy = sql.unsafe(ENRICH_ORDER_SQL[orderKey]);
@@ -5583,6 +5589,7 @@ export class PostgresEngine implements BrainEngine {
         AND (char_length(p.compiled_truth) + char_length(COALESCE(p.timeline, ''))) < ${threshold}
         ${sourceCondition}
         ${recencyCondition}
+        ${dreamCondition}
       ORDER BY ${orderBy}
       LIMIT ${limit}
     `;

--- a/src/core/write-through.ts
+++ b/src/core/write-through.ts
@@ -123,7 +123,12 @@ export async function writePageThrough(
       frontmatterOverrides: opts.frontmatterOverrides,
     });
 
-    mkdirSync(dirname(filePath), { recursive: true });
+    // On Bun + Windows, mkdirSync(dir, { recursive: true }) can still throw
+    // EEXIST when the directory already exists (POSIX no-ops it). That aborts
+    // the put_page / enrich / capture write-through whenever the prefix dir
+    // already exists, silently leaving the DB and the .md file plane out of sync.
+    const targetDir = dirname(filePath);
+    if (!existsSync(targetDir)) mkdirSync(targetDir, { recursive: true });
 
     // Atomic write: unique temp sibling + rename. Unique name (pid + random)
     // so two concurrent saves to the same target can't clobber each other's


### PR DESCRIPTION
Three small, independent correctness fixes found while running `gbrain enrich` on a Windows + Bun install. Each is its own commit; happy to split into separate PRs if you prefer.

### 1. `write-through`: guard mkdir against EEXIST on Bun + Windows
`writePageThrough` calls `mkdirSync(dirname(filePath), { recursive: true })`. On Bun + Windows this throws `EEXIST` when the directory already exists (Node/POSIX no-op it). Result: every `put_page` / `enrich` / `capture` write-through whose prefix dir (e.g. `entities/`) already existed failed silently, leaving the DB row written but no `.md` file — the DB and file plane drift apart. Guarded with `existsSync` before the recursive mkdir.

### 2. `budget`: resolve non-Anthropic model pricing under `--max-cost`
`BudgetTracker.lookupPricing` only consults `ANTHROPIC_PRICING` (the bare-keyed Claude view). With a finite `--max-cost` and a configured non-Anthropic chat model (e.g. `openai:gpt-5.5`), `reserve()` hits the TX2 `no_pricing` hard-fail at $0 — even though that model's price exists in `CANONICAL_PRICING`. Added a fallback to `canonicalLookup(modelId)` before returning null, so any model with a known canonical price is metered correctly. (The misleading "Re-run with a higher --max-usd" message also stops firing for these models.)

### 3. `enrich`: exclude dream-generated pages from thin candidates
`listEnrichCandidates` picks any thin page of the requested types. With `--types note` (or a broadened `cycle.enrich_thin.types`) it picks up `dream`/synthesize-generated pages (reflections, originals, cycle-summary logs). Enriching those produces circular self-citation and drops the H1. Added `AND (p.frontmatter ->> 'dream_generated') IS DISTINCT FROM 'true'` to both engines (`IS DISTINCT FROM` keeps NULL/`false` rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
