### PR TITLE
v0.44.2.0 fix(test): isolate GBRAIN_SOURCE_BOOST in resolveBoostMap unset test

### DIFF
--- a/test/sql-ranking.test.ts
+++ b/test/sql-ranking.test.ts
@@ -209,7 +209,15 @@ describe('parseHardExcludesEnv', () => {
 
 describe('resolveBoostMap', () => {
   test('returns defaults when env is unset', () => {
-    expect(resolveBoostMap(undefined)).toEqual(DEFAULT_SOURCE_BOOSTS);
+    // Isolate from an ambient GBRAIN_SOURCE_BOOST in the dev's shell (#2409):
+    // resolveBoostMap(undefined) falls through to process.env via its default param.
+    const saved = process.env.GBRAIN_SOURCE_BOOST;
+    delete process.env.GBRAIN_SOURCE_BOOST;
+    try {
+      expect(resolveBoostMap(undefined)).toEqual(DEFAULT_SOURCE_BOOSTS);
+    } finally {
+      if (saved !== undefined) process.env.GBRAIN_SOURCE_BOOST = saved;
+    }
   });
 
   test('env override takes precedence over defaults', () => {


### PR DESCRIPTION
## Summary

Test-hygiene fix, **no runtime change**. `test/sql-ranking.test.ts`'s `resolveBoostMap > "returns defaults when env is unset"` failed locally whenever `GBRAIN_SOURCE_BOOST` was exported in the developer's shell.

`resolveBoostMap(envValue = process.env.GBRAIN_SOURCE_BOOST)` reads the env var via its default parameter, so calling `resolveBoostMap(undefined)` falls through to the ambient env. The test asserted the *unset* contract without ensuring the env was actually unset — so it passed on CI (var absent) but failed for any developer with `GBRAIN_SOURCE_BOOST` set.

The test now saves, deletes, and restores `process.env.GBRAIN_SOURCE_BOOST` around the assertion, so it deterministically exercises the unset case in any environment.

## Test plan
- [x] `bun test test/sql-ranking.test.ts` with `GBRAIN_SOURCE_BOOST` exported — 52 pass / 0 fail (was 51 pass / 1 fail)
- [x] `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
