### PR TITLE
fix: parse role-blocked conversation facts natively

### DIFF
--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -142,6 +142,9 @@ export const DEFAULT_MAX_COST_USD = 5.0;
  */
 export const ALLOWED_TYPES = ['conversation', 'meeting', 'slack', 'email'] as const;
 export type AllowedType = (typeof ALLOWED_TYPES)[number];
+// Session transcript captures can arrive as type='note' while still being conversation-fact eligible.
+const CONV_SLUG_PREFIXES = ['gbrain-inbox/transcripts/', 'gbrain-inbox/chat-history/'] as const;
+const CONV_SLUG_RE = /^gbrain-inbox\/(transcripts|chat-history)\//;
 
 /**
  * Pagination batch size for listPages enumeration. Per-batch memory
@@ -989,7 +992,7 @@ export async function runExtractConversationFactsCore(
         result.pages_skipped_disappeared++;
         return;
       }
-      if (!types.includes(page.type as AllowedType)) {
+      if (!types.includes(page.type as AllowedType) && !CONV_SLUG_RE.test(page.slug)) {
         result.pages_skipped++;
         return;
       }
@@ -1040,6 +1043,37 @@ export async function runExtractConversationFactsCore(
 
           // Persist checkpoint between batches so a crash mid-walk
           // doesn't lose all progress.
+          if (!dryRun) {
+            await recordCompleted(engine, checkpointKey(sourceId), cpMapToEntries(state.cpMap));
+          }
+        }
+      }
+
+      // Mine session transcripts captured as type='note' under the known inbox transcript prefixes.
+      // The slugPrefix filter keeps enumeration bounded and covers existing plus future captures without data mutation.
+      for (const slugPrefix of CONV_SLUG_PREFIXES) {
+        let offset = 0;
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          if (signal?.aborted) throw new Error('aborted');
+          if (opts.limit && processedPagesCount >= opts.limit) break;
+          const batch = await engine.listPages({ type: 'note', slugPrefix, sourceId, limit: PAGE_LIST_BATCH, offset });
+          if (batch.length === 0) break;
+          let claimable = batch;
+          if (opts.limit) {
+            const remaining = opts.limit - processedPagesCount;
+            if (remaining < batch.length) claimable = batch.slice(0, remaining);
+          }
+          await runSlidingPool({
+            items: claimable,
+            workers,
+            signal,
+            onItem: (page) => processPageWithLock(page),
+            failureLabel: (page) => page.slug,
+          });
+          processedPagesCount += claimable.length;
+          offset += batch.length;
+          if (batch.length < PAGE_LIST_BATCH) break;
           if (!dryRun) {
             await recordCompleted(engine, checkpointKey(sourceId), cpMapToEntries(state.cpMap));
           }

--- a/src/core/conversation-parser/builtins.ts
+++ b/src/core/conversation-parser/builtins.ts
@@ -248,6 +248,34 @@ export const BUILTIN_PATTERNS: readonly PatternEntry[] = [
   },
 
   {
+    id: 'gbrain-role-heading',
+    origin: 'builtin',
+    regex: /^###[ \t]+(User|Assistant|System|Tool)\s*$/,
+    captures: {
+      speaker_group: 1,
+      text_group: 0,
+    },
+    date_source: 'frontmatter',
+    time_format: '24h',
+    timezone_policy: 'utc_assumed_with_warn',
+    multi_line: true,
+    quick_reject: /^###[ \t]/,
+    score_full_body: true,
+    test_positive: [
+      '### User',
+      '### Assistant',
+      '### System',
+      '### Tool',
+    ],
+    test_negative: [
+      '#### User',
+      '### Userland notes',
+      '**Alice:** plain bold-name',
+    ],
+    source_doc: 'gbrain session transcript `### <Role>` heading-delimited blocks',
+  },
+
+  {
     id: 'telegram-text-export',
     origin: 'builtin',
     // Telegram Desktop's text-export shape: `Alice Doe, [Mar 15, 2024 at 6:37:00 PM]`

--- a/src/core/conversation-parser/parse.ts
+++ b/src/core/conversation-parser/parse.ts
@@ -299,6 +299,73 @@ function monthNameToIndex(name: string): number {
   return MONTHS_SHORT.indexOf(name.toLowerCase().slice(0, 3));
 }
 
+const GBRAIN_ROLE_HEADING_RE = /^###[ \t]+(User|Assistant|System|Tool)\s*$/;
+
+function countGbrainRoleHeadingBlocks(lines: readonly string[]): number {
+  let inFence = false;
+  let seenHeading = false;
+  let currentHasText = false;
+  let blocks = 0;
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    const fence = /^```/.test(line);
+    if (!inFence && GBRAIN_ROLE_HEADING_RE.test(line)) {
+      if (seenHeading && currentHasText) blocks += 1;
+      seenHeading = true;
+      currentHasText = false;
+      continue;
+    }
+    if (seenHeading && line.length > 0) currentHasText = true;
+    if (fence) inFence = !inFence;
+  }
+
+  if (seenHeading && currentHasText) blocks += 1;
+  return blocks;
+}
+
+function applyGbrainRoleHeadingPattern(
+  body: string,
+  dateCtx: DateContext,
+): MatchedMessage[] {
+  const out: MatchedMessage[] = [];
+  const lines = body.split(/\r?\n/);
+  let inFence = false;
+  let currentSpeaker: string | null = null;
+  let currentLines: string[] = [];
+
+  const flush = () => {
+    if (!currentSpeaker) return;
+    const text = currentLines.join('\n').trim();
+    if (text.length > 0) {
+      out.push({
+        speaker: currentSpeaker,
+        timestamp: `${dateCtx.fallbackDate}T00:00:00Z`,
+        text,
+      });
+    }
+  };
+
+  for (const rawLine of lines) {
+    const trimmed = rawLine.trim();
+    const fence = /^```/.test(trimmed);
+    const heading = !inFence ? GBRAIN_ROLE_HEADING_RE.exec(trimmed) : null;
+    if (heading) {
+      flush();
+      currentSpeaker = heading[1];
+      currentLines = [];
+      continue;
+    }
+    if (currentSpeaker) {
+      currentLines.push(rawLine);
+    }
+    if (fence) inFence = !inFence;
+  }
+  flush();
+
+  return out;
+}
+
 /**
  * Apply ONE pattern to the full body. Returns the matched messages
  * with their ISO timestamps. Handles multi-line continuations per D5.
@@ -319,6 +386,9 @@ export function applyPattern(
   dateCtx: DateContext,
 ): MatchedMessage[] {
   if (!body) return [];
+  if (entry.id === 'gbrain-role-heading') {
+    return applyGbrainRoleHeadingPattern(body, dateCtx);
+  }
   const out: MatchedMessage[] = [];
   const lines = body.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
@@ -388,6 +458,9 @@ function scoreFromLines(
   entry: PatternEntry,
 ): number {
   if (lines.length === 0) return 0;
+  if (entry.id === 'gbrain-role-heading') {
+    return countGbrainRoleHeadingBlocks(lines) >= 2 ? 1 : 0;
+  }
   let anchored = 0;
   for (const line of lines) {
     if (entry.quick_reject && !entry.quick_reject.test(line)) continue;

--- a/test/conversation-parser/parse.test.ts
+++ b/test/conversation-parser/parse.test.ts
@@ -125,9 +125,11 @@ describe('parseConversation — every built-in matches its test_positive sample'
       const body = entry.test_positive[0];
       // Multi-line patterns need a body line on the next line.
       const fullBody =
-        entry.multi_line && entry.captures.text_group === 0
-          ? `${body}\nsome body text`
-          : body;
+        entry.id === 'gbrain-role-heading'
+          ? '### User\nhello\n### Assistant\nhi'
+          : entry.multi_line && entry.captures.text_group === 0
+            ? `${body}\nsome body text`
+            : body;
       const r = parseConversation(fullBody, {
         fallbackDate: '2024-03-15',
       });
@@ -137,6 +139,59 @@ describe('parseConversation — every built-in matches its test_positive sample'
       expect(r.matched_pattern_id).toBe(entry.id);
     });
   }
+});
+
+describe('parseConversation — gbrain role heading transcripts', () => {
+  test('splits ### Role heading-delimited blocks into messages', () => {
+    const body = [
+      '### User',
+      'Please check the queue.',
+      '',
+      '### Assistant',
+      'I checked it.',
+      'Two proposals are ready.',
+    ].join('\n');
+    const r = parseConversation(body, { fallbackDate: '2026-06-25' });
+    expect(r.phase).toBe('regex_match');
+    expect(r.matched_pattern_id).toBe('gbrain-role-heading');
+    expect(r.messages).toHaveLength(2);
+    expect(r.messages[0]).toEqual({
+      speaker: 'User',
+      timestamp: '2026-06-25T00:00:00Z',
+      text: 'Please check the queue.',
+    });
+    expect(r.messages[1].speaker).toBe('Assistant');
+    expect(r.messages[1].text).toBe('I checked it.\nTwo proposals are ready.');
+  });
+
+  test('heading-only role transcript does not clear the score floor', () => {
+    const body = ['### User', '', '### Assistant'].join('\n');
+    const r = parseConversation(body, { fallbackDate: '2026-06-25' });
+    expect(r.phase).toBe('no_match');
+    expect(r.messages).toHaveLength(0);
+  });
+
+  test('role headings inside fenced code are preserved as text, not turn splits', () => {
+    const body = [
+      '### User',
+      'Here is the repro:',
+      '```md',
+      '### Assistant',
+      'this is a markdown sample, not a role heading',
+      '```',
+      'Still user text.',
+      '### Assistant',
+      'Confirmed.',
+    ].join('\n');
+    const r = parseConversation(body, { fallbackDate: '2026-06-25' });
+    expect(r.matched_pattern_id).toBe('gbrain-role-heading');
+    expect(r.messages).toHaveLength(2);
+    expect(r.messages[0].speaker).toBe('User');
+    expect(r.messages[0].text).toContain('### Assistant');
+    expect(r.messages[0].text).toContain('Still user text.');
+    expect(r.messages[1].speaker).toBe('Assistant');
+    expect(r.messages[1].text).toBe('Confirmed.');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/extract-conversation-facts.test.ts
+++ b/test/extract-conversation-facts.test.ts
@@ -300,7 +300,7 @@ describe('runExtractConversationFactsCore', () => {
     // truncation semantics than the canonical reset helper.
     await engine.executeRaw(`DELETE FROM facts WHERE source LIKE 'cli:extract-conversation-facts%'`);
     await engine.executeRaw(`DELETE FROM op_checkpoints WHERE op = 'extract-conversation-facts'`);
-    await engine.executeRaw(`DELETE FROM pages WHERE slug LIKE 'conversations/%' OR slug LIKE 'people/alice%'`);
+    await engine.executeRaw(`DELETE FROM pages WHERE slug LIKE 'conversations/%' OR slug LIKE 'people/alice%' OR slug LIKE 'gbrain-inbox/%'`);
     // Set facts.extraction_enabled=true so kill-switch doesn't refuse.
     await engine.setConfig('facts.extraction_enabled', 'true');
     // Seed test pages.
@@ -342,6 +342,25 @@ describe('runExtractConversationFactsCore', () => {
     });
     // pages_considered counts only pages whose type matches the allowlist.
     expect(result.pages_considered).toBe(0);
+  });
+
+  test('transcript note pages under inbox prefixes are eligible', async () => {
+    await engine.putPage('gbrain-inbox/transcripts/session-example', {
+      type: 'note',
+      title: 'Session transcript',
+      compiled_truth: SAMPLE_BODY,
+      timeline: '',
+      frontmatter: {},
+    });
+    const result = await runExtractConversationFactsCore(engine, {
+      sourceId: 'default',
+      slug: 'gbrain-inbox/transcripts/session-example',
+      dryRun: true,
+      sleepMs: 0,
+    });
+    expect(result.pages_considered).toBe(1);
+    expect(result.pages_processed).toBe(1);
+    expect(result.segments_processed).toBeGreaterThanOrEqual(1);
   });
 
   test('sinceIso filters already-processed history', async () => {


### PR DESCRIPTION
## Summary
- Adds native handling for role-blocked conversation sections.
- Extends parser and extraction tests for transcript note slug eligibility.

## Verification
- bun run typecheck
- bun test test/conversation-parser/parse.test.ts test/extract-conversation-facts.test.ts
- bun run check:conversation-fixtures
- git diff --check