### PR TITLE
feat: add native since-date repair

### DIFF
--- a/src/commands/takes.ts
+++ b/src/commands/takes.ts
@@ -28,6 +28,7 @@ import {
   type ParsedTake,
 } from '../core/takes-fence.ts';
 import { withPageLock } from '../core/page-lock.ts';
+import { repairTakeSinceDates } from '../core/takes-since-date-repair.ts';
 
 // --- Helpers ---
 
@@ -525,6 +526,36 @@ async function cmdCalibration(engine: BrainEngine, args: string[]): Promise<void
   }
 }
 
+async function cmdRepairSinceDate(engine: BrainEngine, args: string[]): Promise<void> {
+  const json = flagPresent(args, '--json');
+  const apply = flagPresent(args, '--apply');
+  const dryRun = flagPresent(args, '--dry-run') || !apply;
+  const yes = flagPresent(args, '--yes');
+  if (apply && dryRun && flagPresent(args, '--dry-run')) {
+    console.error('Error: --apply and --dry-run are mutually exclusive.');
+    process.exit(1);
+  }
+  if (apply && !yes) {
+    console.error('Refusing to mutate takes without --yes. Preview with --dry-run --json first.');
+    process.exit(1);
+  }
+  const rawLimit = flagValue(args, '--limit');
+  const limit = rawLimit === undefined ? undefined : Number(rawLimit);
+  const result = await repairTakeSinceDates(engine, { apply, limit });
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  const mode = result.dry_run ? 'would update' : 'updated';
+  console.log(`${result.dry_run ? '[dry-run] ' : ''}takes since-date repair: ${mode} ${result.dry_run ? result.candidates.length : result.updated} row(s), limit=${result.limit}`);
+  for (const candidate of result.candidates.slice(0, 20)) {
+    console.log(`  ${candidate.page_slug}#${candidate.row_num}: ${candidate.effective_date} (${candidate.effective_date_source}) — ${candidate.claim}`);
+  }
+  if (result.candidates.length > 20) {
+    console.log(`  ... ${result.candidates.length - 20} more candidate(s) omitted`);
+  }
+}
+
 // --- Dispatcher ---
 
 export async function runTakes(engine: BrainEngine, args: string[]): Promise<void> {
@@ -551,6 +582,8 @@ Subcommands:
                                           Aggregate calibration scorecard (v0.30.0)
   takes calibration [<holder>] [--bucket-size 0.1] [--json]
                                           Calibration curve binned by stated weight (v0.30.0)
+  takes repair-since-date [--dry-run] [--apply --yes] [--limit N] [--json]
+                                          Fill missing since_date from real page effective dates
 
 Common flags:
   --dir <path>    Override the brain directory (default: sync.repo_path config)
@@ -570,6 +603,7 @@ Common flags:
     case 'resolve':     return cmdResolve(engine, rest);
     case 'scorecard':   return cmdScorecard(engine, rest);
     case 'calibration': return cmdCalibration(engine, rest);
+    case 'repair-since-date': return cmdRepairSinceDate(engine, rest);
     case 'revisit':     return cmdRevisit(engine, rest);
     case 'extract':     return cmdExtract(engine, rest);
     default:

--- a/src/core/takes-since-date-repair.ts
+++ b/src/core/takes-since-date-repair.ts
@@ -1,0 +1,117 @@
+import type { BrainEngine } from './engine.ts';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 1000;
+
+export interface TakeSinceDateRepairCandidate {
+  take_id: number;
+  page_id: number;
+  page_slug: string;
+  row_num: number;
+  claim: string;
+  kind: string;
+  holder: string;
+  current_since_date: string | null;
+  effective_date: string;
+  effective_date_source: string;
+}
+
+export interface TakeSinceDateRepairResult {
+  dry_run: boolean;
+  limit: number;
+  candidates: TakeSinceDateRepairCandidate[];
+  updated: number;
+}
+
+interface CandidateRow {
+  take_id: number | string;
+  page_id: number | string;
+  page_slug: string;
+  row_num: number | string;
+  claim: string;
+  kind: string;
+  holder: string;
+  current_since_date: string | Date | null;
+  effective_date: string | Date;
+  effective_date_source: string;
+}
+
+export function normalizeTakeSinceDateRepairLimit(raw: number | undefined): number {
+  const limit = raw ?? DEFAULT_LIMIT;
+  if (!Number.isFinite(limit) || limit <= 0) {
+    throw new Error('limit must be a positive number');
+  }
+  return Math.min(Math.floor(limit), MAX_LIMIT);
+}
+
+function dateOnly(value: string | Date): string {
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  return value.slice(0, 10);
+}
+
+function normalizeCandidate(row: CandidateRow): TakeSinceDateRepairCandidate {
+  return {
+    take_id: Number(row.take_id),
+    page_id: Number(row.page_id),
+    page_slug: row.page_slug,
+    row_num: Number(row.row_num),
+    claim: row.claim,
+    kind: row.kind,
+    holder: row.holder,
+    current_since_date: row.current_since_date ? dateOnly(row.current_since_date) : null,
+    effective_date: dateOnly(row.effective_date),
+    effective_date_source: row.effective_date_source,
+  };
+}
+
+export async function repairTakeSinceDates(
+  engine: BrainEngine,
+  opts: { apply?: boolean; limit?: number } = {},
+): Promise<TakeSinceDateRepairResult> {
+  const limit = normalizeTakeSinceDateRepairLimit(opts.limit);
+  const rows = await engine.executeRaw<CandidateRow>(
+    `SELECT t.id AS take_id,
+            t.page_id,
+            p.slug AS page_slug,
+            t.row_num,
+            t.claim,
+            t.kind,
+            t.holder,
+            t.since_date AS current_since_date,
+            p.effective_date,
+            p.effective_date_source
+       FROM takes t
+       JOIN pages p ON p.id = t.page_id
+      WHERE t.active = TRUE
+        AND t.since_date IS NULL
+        AND p.effective_date IS NOT NULL
+        AND p.effective_date_source IS NOT NULL
+        AND p.effective_date_source <> 'fallback'
+      ORDER BY p.effective_date DESC, t.id ASC
+      LIMIT $1`,
+    [limit],
+  );
+  const candidates = rows.map(normalizeCandidate);
+
+  if (!opts.apply || candidates.length === 0) {
+    return { dry_run: !opts.apply, limit, candidates, updated: 0 };
+  }
+
+  let updated = 0;
+  await engine.transaction(async (tx) => {
+    for (const candidate of candidates) {
+      const result = await tx.executeRaw<{ id: number }>(
+        `UPDATE takes
+            SET since_date = $1::text,
+                updated_at = now()
+          WHERE id = $2
+            AND since_date IS NULL
+          RETURNING id`,
+        [candidate.effective_date, candidate.take_id],
+      );
+      updated += result.length;
+    }
+  });
+
+  return { dry_run: false, limit, candidates, updated };
+}

--- a/test/takes-since-date-repair.test.ts
+++ b/test/takes-since-date-repair.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { repairTakeSinceDates } from '../src/core/takes-since-date-repair.ts';
+
+let engine: PGLiteEngine;
+let realPageId: number;
+let fallbackPageId: number;
+let undatedPageId: number;
+
+async function seedPage(slug: string, title: string): Promise<number> {
+  const page = await engine.putPage(slug, {
+    title,
+    type: 'company',
+    compiled_truth: `${title}\n`,
+  });
+  return page.id;
+}
+
+beforeEach(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+
+  realPageId = await seedPage('companies/real-date-example', 'Real Date Example');
+  fallbackPageId = await seedPage('companies/fallback-date-example', 'Fallback Date Example');
+  undatedPageId = await seedPage('companies/undated-example', 'Undated Example');
+
+  await engine.executeRaw(
+    `UPDATE pages SET effective_date = $1::timestamptz, effective_date_source = $2 WHERE id = $3`,
+    ['2025-04-15T00:00:00.000Z', 'date', realPageId],
+  );
+  await engine.executeRaw(
+    `UPDATE pages SET effective_date = $1::timestamptz, effective_date_source = $2 WHERE id = $3`,
+    ['2025-05-20T00:00:00.000Z', 'fallback', fallbackPageId],
+  );
+  await engine.executeRaw(
+    `UPDATE pages SET effective_date = NULL, effective_date_source = NULL WHERE id = $1`,
+    [undatedPageId],
+  );
+
+  await engine.addTakesBatch([
+    { page_id: realPageId, row_num: 1, claim: 'Real dated claim', kind: 'bet', holder: 'garry', weight: 0.6 },
+    { page_id: realPageId, row_num: 2, claim: 'Already dated claim', kind: 'bet', holder: 'garry', weight: 0.7, since_date: '2024-01-01' },
+    { page_id: fallbackPageId, row_num: 1, claim: 'Fallback dated claim', kind: 'bet', holder: 'garry', weight: 0.5 },
+    { page_id: undatedPageId, row_num: 1, claim: 'Undated claim', kind: 'bet', holder: 'garry', weight: 0.5 },
+  ]);
+});
+
+afterEach(async () => {
+  await engine.disconnect();
+});
+
+describe('repairTakeSinceDates', () => {
+  test('dry-run lists only missing since dates backed by real page dates', async () => {
+    const result = await repairTakeSinceDates(engine, { limit: 10 });
+    expect(result.dry_run).toBe(true);
+    expect(result.updated).toBe(0);
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]).toMatchObject({
+      page_slug: 'companies/real-date-example',
+      row_num: 1,
+      effective_date: '2025-04-15',
+      effective_date_source: 'date',
+    });
+
+    const fallbackTakes = await engine.listTakes({ page_id: fallbackPageId });
+    expect(fallbackTakes[0].since_date).toBeNull();
+    const realTakes = await engine.listTakes({ page_id: realPageId, active: true });
+    expect(realTakes.find((take) => take.row_num === 1)?.since_date).toBeNull();
+    expect(realTakes.find((take) => take.row_num === 2)?.since_date).toBe('2024-01-01');
+  });
+
+  test('apply updates capped candidates and remains idempotent', async () => {
+    const first = await repairTakeSinceDates(engine, { apply: true, limit: 1 });
+    expect(first.dry_run).toBe(false);
+    expect(first.candidates).toHaveLength(1);
+    expect(first.updated).toBe(1);
+
+    const realTakes = await engine.listTakes({ page_id: realPageId, active: true });
+    expect(realTakes.find((take) => take.row_num === 1)?.since_date).toBe('2025-04-15');
+    expect(realTakes.find((take) => take.row_num === 2)?.since_date).toBe('2024-01-01');
+
+    const fallbackTakes = await engine.listTakes({ page_id: fallbackPageId });
+    expect(fallbackTakes[0].since_date).toBeNull();
+
+    const second = await repairTakeSinceDates(engine, { apply: true, limit: 10 });
+    expect(second.candidates).toHaveLength(0);
+    expect(second.updated).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds native takes repair-since-date command.
- Repairs missing take since_date from non-fallback page effective_date only, dry-run by default.

## Verification
- bun run typecheck
- bun test test/takes-since-date-repair.test.ts
- git diff --check