### PR TITLE
fix: ground take grading in hybrid evidence

### DIFF
--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -2040,7 +2040,31 @@ export async function runCycle(
           checkAborted(opts.signal);
           progress.start('cycle.grade_takes');
           const { runPhaseGradeTakes } = await import('./cycle/grade-takes.ts');
-          const { result, duration_ms } = await timePhase(() => runPhaseGradeTakes(calibrationCtx, {}) as Promise<PhaseResult>);
+          const configValue = async (key: string): Promise<string | null> => {
+            const value = await engine.getConfig(key);
+            return value === undefined ? null : value;
+          };
+          const configBool = async (key: string, fallback: boolean): Promise<boolean> => {
+            const raw = await configValue(key);
+            if (raw === null) return fallback;
+            const normalized = raw.trim().toLowerCase();
+            if (['true', '1', 'yes', 'on'].includes(normalized)) return true;
+            if (['false', '0', 'no', 'off'].includes(normalized)) return false;
+            return fallback;
+          };
+          const configNumber = async (key: string, fallback: number): Promise<number> => {
+            const raw = await configValue(key);
+            if (raw === null) return fallback;
+            const n = Number(raw);
+            return Number.isFinite(n) ? n : fallback;
+          };
+          const gradeTakesConfig = {
+            autoResolve: await configBool('cycle.grade_takes.auto_resolve.enabled', false),
+            autoResolveThreshold: await configNumber('cycle.grade_takes.auto_resolve.threshold', 0.95),
+            minAgeMonths: await configNumber('cycle.grade_takes.min_age_months', 0),
+            takeLimit: await configNumber('cycle.grade_takes.take_limit', 50),
+          };
+          const { result, duration_ms } = await timePhase(() => runPhaseGradeTakes(calibrationCtx, gradeTakesConfig) as Promise<PhaseResult>);
           result.duration_ms = duration_ms;
           phaseResults.push(result);
           progress.finish();

--- a/src/core/cycle/grade-takes.ts
+++ b/src/core/cycle/grade-takes.ts
@@ -20,15 +20,11 @@
  *   flag because relaxing after data accumulates silently shifts which
  *   historical resolutions count as auto-applied.
  *
- * Evidence retrieval status (v0.36.1.0 ship state):
- *   The default evidence retriever returns an "evidence-retrieval not yet
- *   wired" placeholder. Most verdicts produced by the stub-judge against
- *   the stub-evidence will be 'unresolvable'. Real retrieval (hybrid search
- *   over pages newer than the take's since_date, optionally augmented by a
- *   gateway web-search recipe in v0.37+) lands as a follow-up. The phase
- *   ships now so the wiring is real and the cache table accumulates
- *   verdicts even if early ones are conservative; operators get the
- *   end-to-end loop running ahead of the tuned-prompt arrival.
+ * Evidence retrieval status:
+ *   The default production path uses hybrid search over pages newer than the
+ *   take's since_date. The old placeholder retriever remains exported as a
+ *   test/back-compat seam, but placeholder or uncited evidence is converted
+ *   to an unresolvable cache row before any judge budget is spent.
  *
  * Test seam: opts.judge + opts.evidenceRetriever are injected so the
  * phase runs hermetically in unit tests.
@@ -41,15 +37,17 @@ import { GBrainError } from '../types.ts';
 import type { OperationContext } from '../operations.ts';
 import type { BrainEngine, Take, TakeResolution } from '../engine.ts';
 import type { PhaseStatus, CyclePhase } from '../cycle.ts';
+import type { SearchResult } from '../types.ts';
+import { hybridSearchCached } from '../search/hybrid.ts';
 
 /**
  * Bump when the judge prompt or the JSON output shape changes. Old verdicts
  * stay valid (composite cache key includes prompt_version); new runs re-spend
  * LLM tokens.
  */
-export const GRADE_TAKES_PROMPT_VERSION = 'v0.36.1.0-stub';
+export const GRADE_TAKES_PROMPT_VERSION = 'v0.36.1.1-hybrid-evidence';
 
-export const GRADE_TAKE_PROMPT = `[v0.36.1.0-stub] You are grading a single forecasting take. The author
+export const GRADE_TAKE_PROMPT = `[v0.36.1.1-hybrid-evidence] You are grading a single forecasting take. The author
 made this claim on the given date. Based on the evidence provided, did the
 claim turn out to be:
 - correct        (the world plays out as predicted)
@@ -173,7 +171,7 @@ export function aggregateEnsemble(
 }
 
 /** Evidence retriever signature — injected for tests. */
-export type EvidenceRetrieverFn = (take: Take, scope: ScopedReadOpts) => Promise<string>;
+export type EvidenceRetrieverFn = (take: Take, scope: ScopedReadOpts, engine: BrainEngine) => Promise<string>;
 
 export interface GradeTakesOpts extends BasePhaseOpts {
   /** Minimum age in months before a take is eligible for grading. Default 6. */
@@ -251,6 +249,8 @@ export interface GradeTakesResult {
   ensemble_invoked: number;
   /** E2 ensemble (T5): count of takes where ensemble produced 3/3 unanimous. */
   ensemble_unanimous: number;
+  /** Count of takes skipped before judge because evidence was placeholder or too sparse. */
+  evidence_unavailable: number;
 }
 
 /**
@@ -260,6 +260,55 @@ export interface GradeTakesResult {
  */
 export function evidenceSignature(evidence: string, judgeModelId: string): string {
   return createHash('sha256').update(judgeModelId + '|' + evidence).digest('hex');
+}
+
+const PLACEHOLDER_EVIDENCE_MARKER = '[evidence retrieval not yet wired';
+const UNAVAILABLE_EVIDENCE_MARKER = '[grade evidence unavailable';
+
+export function evidenceIsPlaceholder(evidence: string): boolean {
+  return evidence.includes(PLACEHOLDER_EVIDENCE_MARKER);
+}
+
+export function evidenceHasCitedSnippets(evidence: string): boolean {
+  return /^Source: .+/m.test(evidence) && /^Snippet: .+/m.test(evidence);
+}
+
+function normalizeDateOnly(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const normalized = raw.length === 7 ? `${raw}-15` : raw;
+  const date = new Date(normalized);
+  if (!Number.isFinite(date.getTime())) return null;
+  return date.toISOString().slice(0, 10);
+}
+
+function truncateEvidenceSnippet(text: string, maxChars = 800): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, maxChars - 3)}...`;
+}
+
+export function formatGradeEvidenceFromResults(take: Take, results: SearchResult[]): string {
+  const since = normalizeDateOnly(take.since_date);
+  const usable = results
+    .filter((result) => {
+      const resultDate = normalizeDateOnly(result.effective_date ?? null);
+      if (!resultDate || !result.chunk_text?.trim()) return false;
+      return since ? resultDate > since : true;
+    })
+    .slice(0, 6);
+
+  if (usable.length === 0) {
+    return `${UNAVAILABLE_EVIDENCE_MARKER}: no cited pages newer than take date]`;
+  }
+
+  return usable.map((result, idx) => {
+    const date = normalizeDateOnly(result.effective_date ?? null);
+    return [
+      `Source: ${result.slug}${date ? ` (${date})` : ''}`,
+      `Rank: ${idx + 1}`,
+      `Snippet: ${truncateEvidenceSnippet(result.chunk_text ?? '')}`,
+    ].join('\n');
+  }).join('\n\n');
 }
 
 /**
@@ -302,6 +351,25 @@ Take claim text (the only "evidence" available pre-T-retrieval-impl):
   ${take.claim}
 Made on: ${take.since_date ?? 'unknown'}
 `;
+}
+
+export async function hybridEvidenceRetriever(
+  take: Take,
+  scope: ScopedReadOpts,
+  engine: BrainEngine,
+): Promise<string> {
+  const since = normalizeDateOnly(take.since_date);
+  const results = await hybridSearchCached(engine, take.claim, {
+    limit: 12,
+    tokenBudget: 4_000,
+    useCache: true,
+    expansion: true,
+    detail: 'medium',
+    ...(scope.sourceIds && scope.sourceIds.length > 0 ? { sourceIds: scope.sourceIds } : {}),
+    ...(scope.sourceId ? { sourceId: scope.sourceId } : {}),
+    ...(since ? { since } : {}),
+  });
+  return formatGradeEvidenceFromResults(take, results);
 }
 
 /**
@@ -367,6 +435,35 @@ function verdictToResolution(verdict: JudgeVerdict, resolvedByLabel: string): Ta
   };
 }
 
+async function insertGradeCache(
+  engine: BrainEngine,
+  input: {
+    takeId: number;
+    promptVersion: string;
+    judgeModelId: string;
+    evidenceSignature: string;
+    verdict: JudgeVerdict['verdict'];
+    confidence: number;
+    applied: boolean;
+  },
+): Promise<void> {
+  await engine.executeRaw(
+    `INSERT INTO take_grade_cache
+       (take_id, prompt_version, judge_model_id, evidence_signature, verdict, confidence, applied)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     ON CONFLICT (take_id, prompt_version, judge_model_id, evidence_signature) DO NOTHING`,
+    [
+      input.takeId,
+      input.promptVersion,
+      input.judgeModelId,
+      input.evidenceSignature,
+      input.verdict,
+      input.confidence,
+      input.applied,
+    ],
+  );
+}
+
 class GradeTakesPhase extends BaseCyclePhase {
   readonly name = 'grade_takes' as CyclePhase;
   protected readonly budgetUsdKey = 'cycle.grade_takes.budget_usd';
@@ -388,7 +485,7 @@ class GradeTakesPhase extends BaseCyclePhase {
     opts: GradeTakesOpts,
   ): Promise<{ summary: string; details: Record<string, unknown>; status?: PhaseStatus }> {
     const judge = opts.judge ?? defaultJudge;
-    const evidenceRetriever = opts.evidenceRetriever ?? defaultEvidenceRetriever;
+    const evidenceRetriever = opts.evidenceRetriever ?? hybridEvidenceRetriever;
     const promptVersion = opts.promptVersion ?? GRADE_TAKES_PROMPT_VERSION;
     const minAgeMonths = opts.minAgeMonths ?? 6;
     const takeLimit = opts.takeLimit ?? 50;
@@ -411,6 +508,7 @@ class GradeTakesPhase extends BaseCyclePhase {
       warnings: [],
       ensemble_invoked: 0,
       ensemble_unanimous: 0,
+      evidence_unavailable: 0,
     };
 
     // Load unresolved active takes, oldest-first.
@@ -436,7 +534,7 @@ class GradeTakesPhase extends BaseCyclePhase {
       }
 
       // Retrieve evidence first — the signature depends on it.
-      const evidence = await evidenceRetriever(take, scope);
+      const evidence = await evidenceRetriever(take, scope, engine);
       const sig = evidenceSignature(evidence, judgeModelId);
 
       // Idempotency: skip when (take_id, prompt_version, judge_model_id, evidence_signature) exists.
@@ -448,6 +546,25 @@ class GradeTakesPhase extends BaseCyclePhase {
       );
       if (cached.length > 0) {
         result.cache_hits += 1;
+        continue;
+      }
+
+      if (evidenceIsPlaceholder(evidence) || !evidenceHasCitedSnippets(evidence)) {
+        const reason = evidenceIsPlaceholder(evidence)
+          ? 'placeholder evidence retriever is not allowed to spend judge budget'
+          : 'insufficient cited evidence for judge';
+        result.evidence_unavailable += 1;
+        result.warnings.push(`take ${take.id}: ${reason}; recorded unresolvable without judge call`);
+        await insertGradeCache(engine, {
+          takeId: take.id,
+          promptVersion,
+          judgeModelId,
+          evidenceSignature: sig,
+          verdict: 'unresolvable',
+          confidence: 0,
+          applied: false,
+        });
+        result.verdicts_written += 1;
         continue;
       }
 
@@ -541,13 +658,15 @@ class GradeTakesPhase extends BaseCyclePhase {
 
       // Write the verdict to the cache. Idempotency conflict means another
       // run beat us to it; either way the row exists with consistent state.
-      await engine.executeRaw(
-        `INSERT INTO take_grade_cache
-           (take_id, prompt_version, judge_model_id, evidence_signature, verdict, confidence, applied)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
-         ON CONFLICT (take_id, prompt_version, judge_model_id, evidence_signature) DO NOTHING`,
-        [take.id, promptVersion, recordedJudgeModelId, recordedSig, recordedVerdict.verdict, recordedVerdict.confidence, shouldApply],
-      );
+      await insertGradeCache(engine, {
+        takeId: take.id,
+        promptVersion,
+        judgeModelId: recordedJudgeModelId,
+        evidenceSignature: recordedSig,
+        verdict: recordedVerdict.verdict,
+        confidence: recordedVerdict.confidence,
+        applied: shouldApply,
+      });
       result.verdicts_written += 1;
 
       // Apply to canonical takes if eligible.
@@ -626,4 +745,8 @@ export const __testing = {
   takeIsOldEnough,
   verdictToResolution,
   aggregateEnsemble,
+  evidenceIsPlaceholder,
+  evidenceHasCitedSnippets,
+  formatGradeEvidenceFromResults,
+  hybridEvidenceRetriever,
 };

--- a/test/grade-takes-ensemble.test.ts
+++ b/test/grade-takes-ensemble.test.ts
@@ -101,6 +101,9 @@ function buildCtx(engine: BrainEngine): OperationContext {
   };
 }
 
+const citedEvidence: EvidenceRetrieverFn = async () =>
+  'Source: wiki/outcome-note (2024-01-02)\nRank: 1\nSnippet: Later cited evidence supports grading this take.';
+
 // ─── aggregateEnsemble (pure) ───────────────────────────────────────
 
 describe('aggregateEnsemble', () => {
@@ -186,6 +189,7 @@ describe('runPhaseGradeTakes ensemble — when does the tiebreaker fire?', () =>
     };
     const result = await runPhaseGradeTakes(buildCtx(engine), {
       judge,
+      evidenceRetriever: citedEvidence,
       useEnsemble: false,
       ensembleJudges: [
         { modelId: 'a', fn: ensembleFn },
@@ -208,6 +212,7 @@ describe('runPhaseGradeTakes ensemble — when does the tiebreaker fire?', () =>
     };
     const result = await runPhaseGradeTakes(buildCtx(engine), {
       judge,
+      evidenceRetriever: citedEvidence,
       useEnsemble: true,
       ensembleJudges: [
         { modelId: 'openai:gpt-4o', fn: ensembleFn },
@@ -231,6 +236,7 @@ describe('runPhaseGradeTakes ensemble — when does the tiebreaker fire?', () =>
     };
     await runPhaseGradeTakes(buildCtx(engine), {
       judge,
+      evidenceRetriever: citedEvidence,
       useEnsemble: true,
       ensembleJudges: [{ modelId: 'a', fn: ensembleFn }, { modelId: 'b', fn: ensembleFn }, { modelId: 'c', fn: ensembleFn }],
     });
@@ -248,6 +254,7 @@ describe('runPhaseGradeTakes ensemble — when does the tiebreaker fire?', () =>
     };
     await runPhaseGradeTakes(buildCtx(engine), {
       judge,
+      evidenceRetriever: citedEvidence,
       useEnsemble: true,
       ensembleJudges: [{ modelId: 'a', fn: ensembleFn }, { modelId: 'b', fn: ensembleFn }, { modelId: 'c', fn: ensembleFn }],
     });
@@ -265,6 +272,7 @@ describe('runPhaseGradeTakes ensemble — when does the tiebreaker fire?', () =>
     };
     await runPhaseGradeTakes(buildCtx(engine), {
       judge,
+      evidenceRetriever: citedEvidence,
       useEnsemble: true,
       ensembleJudges: [{ modelId: 'a', fn: ensembleFn }, { modelId: 'b', fn: ensembleFn }, { modelId: 'c', fn: ensembleFn }],
     });
@@ -285,6 +293,7 @@ describe('runPhaseGradeTakes ensemble — auto-apply rules', () => {
 
     await runPhaseGradeTakes(buildCtx(engine), {
       judge,
+      evidenceRetriever: citedEvidence,
       useEnsemble: true,
       ensembleJudges: [
         { modelId: 'openai:gpt-4o', fn: eA },
@@ -312,6 +321,7 @@ describe('runPhaseGradeTakes ensemble — auto-apply rules', () => {
 
     await runPhaseGradeTakes(buildCtx(engine), {
       judge,
+      evidenceRetriever: citedEvidence,
       useEnsemble: true,
       ensembleJudges: [
         { modelId: 'a', fn: eA },
@@ -338,6 +348,7 @@ describe('runPhaseGradeTakes ensemble — auto-apply rules', () => {
 
     await runPhaseGradeTakes(buildCtx(engine), {
       judge,
+      evidenceRetriever: citedEvidence,
       useEnsemble: true,
       ensembleJudges: [
         { modelId: 'a', fn: eA },
@@ -362,6 +373,7 @@ describe('runPhaseGradeTakes ensemble — auto-apply rules', () => {
 
     await runPhaseGradeTakes(buildCtx(engine), {
       judge,
+      evidenceRetriever: citedEvidence,
       useEnsemble: true,
       ensembleJudges: [
         { modelId: 'a', fn: eA },
@@ -381,6 +393,7 @@ describe('runPhaseGradeTakes ensemble — auto-apply rules', () => {
     const judge: JudgeFn = async () => ({ verdict: 'correct', confidence: 0.7, reasoning: 'borderline' });
     await runPhaseGradeTakes(buildCtx(engine), {
       judge,
+      evidenceRetriever: citedEvidence,
       useEnsemble: true,
       ensembleJudges: [],
     });

--- a/test/grade-takes.test.ts
+++ b/test/grade-takes.test.ts
@@ -24,10 +24,13 @@ import {
   parseJudgeOutput,
   evidenceSignature,
   takeIsOldEnough,
+  defaultEvidenceRetriever,
+  formatGradeEvidenceFromResults,
   GRADE_TAKES_PROMPT_VERSION,
   type JudgeFn,
   type EvidenceRetrieverFn,
 } from '../src/core/cycle/grade-takes.ts';
+import type { SearchResult } from '../src/core/types.ts';
 import type { OperationContext } from '../src/core/operations.ts';
 import type { BrainEngine, Take, TakeResolution } from '../src/core/engine.ts';
 
@@ -111,6 +114,9 @@ function buildCtx(engine: BrainEngine): OperationContext {
     sourceId: 'default',
   };
 }
+
+const citedEvidence: EvidenceRetrieverFn = async () =>
+  'Source: wiki/outcome-note (2024-01-02)\nRank: 1\nSnippet: The outcome is now known from a later cited page.';
 
 // ─── parseJudgeOutput ───────────────────────────────────────────────
 
@@ -199,6 +205,43 @@ describe('takeIsOldEnough', () => {
   });
 });
 
+describe('formatGradeEvidenceFromResults', () => {
+  test('keeps cited snippets newer than the take date and drops older hits', () => {
+    const take = buildTake({ id: 1, sinceDate: '2024-01-01' });
+    const evidence = formatGradeEvidenceFromResults(take, [
+      {
+        slug: 'wiki/older',
+        page_id: 10,
+        title: 'Older',
+        type: 'note',
+        chunk_text: 'Older context should not grade the outcome.',
+        chunk_source: 'compiled_truth',
+        chunk_id: 100,
+        chunk_index: 0,
+        effective_date: '2023-12-31',
+        score: 0.9,
+        stale: false,
+      } as SearchResult,
+      {
+        slug: 'wiki/newer',
+        page_id: 11,
+        title: 'Newer',
+        type: 'note',
+        chunk_text: 'Newer cited context can support the verdict.',
+        chunk_source: 'compiled_truth',
+        chunk_id: 101,
+        chunk_index: 0,
+        effective_date: '2024-02-01',
+        score: 0.8,
+        stale: false,
+      } as SearchResult,
+    ]);
+    expect(evidence).toContain('Source: wiki/newer (2024-02-01)');
+    expect(evidence).toContain('Snippet: Newer cited context');
+    expect(evidence).not.toContain('wiki/older');
+  });
+});
+
 // ─── Phase integration ──────────────────────────────────────────────
 
 describe('runPhaseGradeTakes — phase integration', () => {
@@ -206,7 +249,7 @@ describe('runPhaseGradeTakes — phase integration', () => {
     const takes = [buildTake({ id: 1, sinceDate: '2023-01-01' })];
     const { engine, captured, resolves } = buildMockEngine({ takes });
     const judge: JudgeFn = async () => ({ verdict: 'correct', confidence: 0.98, reasoning: 'evidence held' });
-    const evidenceRetriever: EvidenceRetrieverFn = async () => 'mock evidence body';
+    const evidenceRetriever = citedEvidence;
 
     const result = await runPhaseGradeTakes(buildCtx(engine), { judge, evidenceRetriever });
 
@@ -228,7 +271,7 @@ describe('runPhaseGradeTakes — phase integration', () => {
     const takes = [buildTake({ id: 1, sinceDate: '2023-01-01' })];
     const { engine, resolves } = buildMockEngine({ takes });
     const judge: JudgeFn = async () => ({ verdict: 'correct', confidence: 1.0, reasoning: 'certain' });
-    const result = await runPhaseGradeTakes(buildCtx(engine), { judge });
+    const result = await runPhaseGradeTakes(buildCtx(engine), { judge, evidenceRetriever: citedEvidence });
     const details = result.details as Record<string, unknown>;
     expect(details.auto_resolve).toBe(false);
     expect(details.auto_applied).toBe(0);
@@ -241,6 +284,7 @@ describe('runPhaseGradeTakes — phase integration', () => {
     const judge: JudgeFn = async () => ({ verdict: 'incorrect', confidence: 0.96, reasoning: 'contradicted' });
     const result = await runPhaseGradeTakes(buildCtx(engine), {
       judge,
+      evidenceRetriever: citedEvidence,
       autoResolve: true,
       autoResolveThreshold: 0.95,
     });
@@ -257,6 +301,7 @@ describe('runPhaseGradeTakes — phase integration', () => {
     const judge: JudgeFn = async () => ({ verdict: 'correct', confidence: 0.85, reasoning: 'leaning yes' });
     const result = await runPhaseGradeTakes(buildCtx(engine), {
       judge,
+      evidenceRetriever: citedEvidence,
       autoResolve: true,
       autoResolveThreshold: 0.95,
     });
@@ -271,7 +316,12 @@ describe('runPhaseGradeTakes — phase integration', () => {
     const takes = [buildTake({ id: 1, sinceDate: '2023-01-01' })];
     const { engine, resolves } = buildMockEngine({ takes });
     const judge: JudgeFn = async () => ({ verdict: 'unresolvable', confidence: 1.0, reasoning: 'no evidence yet' });
-    await runPhaseGradeTakes(buildCtx(engine), { judge, autoResolve: true, autoResolveThreshold: 0.95 });
+    await runPhaseGradeTakes(buildCtx(engine), {
+      judge,
+      evidenceRetriever: citedEvidence,
+      autoResolve: true,
+      autoResolveThreshold: 0.95,
+    });
     expect(resolves).toHaveLength(0);
   });
 
@@ -320,11 +370,56 @@ describe('runPhaseGradeTakes — phase integration', () => {
       if (calls === 1) throw new Error('judge timeout');
       return { verdict: 'correct', confidence: 0.9, reasoning: 'second succeeded' };
     };
-    const result = await runPhaseGradeTakes(buildCtx(engine), { judge });
+    const result = await runPhaseGradeTakes(buildCtx(engine), { judge, evidenceRetriever: citedEvidence });
     expect(result.status).toBe('ok');
     const details = result.details as Record<string, unknown>;
     expect(details.verdicts_written).toBe(1);
     expect((details.warnings as string[]).length).toBeGreaterThan(0);
     expect((details.warnings as string[])[0]).toContain('judge timeout');
+  });
+
+  test('placeholder evidence records unresolvable before any judge call', async () => {
+    const takes = [buildTake({ id: 1, sinceDate: '2023-01-01' })];
+    const { engine, captured } = buildMockEngine({ takes });
+    let judgeCalls = 0;
+    const judge: JudgeFn = async () => {
+      judgeCalls++;
+      return { verdict: 'correct', confidence: 1, reasoning: 'should not run' };
+    };
+
+    const result = await runPhaseGradeTakes(buildCtx(engine), {
+      judge,
+      evidenceRetriever: defaultEvidenceRetriever,
+    });
+
+    expect(judgeCalls).toBe(0);
+    const details = result.details as Record<string, unknown>;
+    expect(details.evidence_unavailable).toBe(1);
+    expect(details.verdicts_written).toBe(1);
+    const insert = captured.find(c => c.sql.includes('INSERT INTO take_grade_cache'));
+    expect(insert!.params[4]).toBe('unresolvable');
+    expect(insert!.params[5]).toBe(0);
+    expect(insert!.params[6]).toBe(false);
+  });
+
+  test('sparse real retriever output records unresolvable before any judge call', async () => {
+    const takes = [buildTake({ id: 1, sinceDate: '2023-01-01' })];
+    const { engine } = buildMockEngine({ takes });
+    let judgeCalls = 0;
+    const judge: JudgeFn = async () => {
+      judgeCalls++;
+      return { verdict: 'correct', confidence: 1, reasoning: 'should not run' };
+    };
+    const sparseEvidence: EvidenceRetrieverFn = async () => '[grade evidence unavailable: no cited pages newer than take date]';
+
+    const result = await runPhaseGradeTakes(buildCtx(engine), {
+      judge,
+      evidenceRetriever: sparseEvidence,
+    });
+
+    expect(judgeCalls).toBe(0);
+    const details = result.details as Record<string, unknown>;
+    expect(details.evidence_unavailable).toBe(1);
+    expect(details.verdicts_written).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- Grounds take grading with hybrid search evidence instead of placeholder evidence.
- Marks sparse or uncited evidence as unresolvable before paid judge calls.

## Verification
- bun run typecheck
- bun test test/grade-takes.test.ts test/grade-takes-ensemble.test.ts
- git diff --check