### PR TITLE
feat: attach concepts to extracted atoms

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,7 @@ for (const op of operations) {
 }
 
 // CLI-only commands that bypass the operation layer
-const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'enrich', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'onboard', 'conversation-parser', 'status', 'connect', 'skillopt', 'quarantine', 'self-upgrade', 'advisor', 'watch']);
+const CLI_ONLY = new Set(['init', 'reinit-pglite', 'upgrade', 'post-upgrade', 'check-update', 'integrations', 'publish', 'check-backlinks', 'lint', 'report', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor', 'migrate', 'eval', 'sync', 'extract', 'extract-conversation-facts', 'enrich', 'features', 'autopilot', 'graph-query', 'jobs', 'agent', 'apply-migrations', 'skillpack-check', 'skillpack', 'resolvers', 'integrity', 'repair-jsonb', 'orphans', 'sources', 'mounts', 'dream', 'check-resolvable', 'routing-eval', 'skillify', 'smoke-test', 'providers', 'storage', 'repos', 'code-def', 'code-refs', 'reindex', 'reindex-code', 'reindex-frontmatter', 'code-callers', 'code-callees', 'frontmatter', 'auth', 'friction', 'claw-test', 'book-mirror', 'takes', 'atoms', 'think', 'salience', 'anomalies', 'transcripts', 'models', 'remote', 'recall', 'forget', 'edges-backfill', 'cache', 'ze-switch', 'founder', 'brainstorm', 'lsd', 'schema', 'capture', 'onboard', 'conversation-parser', 'status', 'connect', 'skillopt', 'quarantine', 'self-upgrade', 'advisor', 'watch']);
 // CLI-only commands whose handlers print their own --help text. These are
 // excluded from the generic short-circuit so detailed per-command and
 // per-subcommand usage stays reachable.
@@ -91,6 +91,8 @@ const CLI_ONLY_SELF_HELP = new Set([
   // v0.41.39 (#1700) — enrich ships its own detailed HELP (ordering, budget
   // best-effort caveat, provenance, --reenrich-after). Route around the stub.
   'enrich',
+  // Atom maintenance has subcommands and explicit mutation gates.
+  'atoms',
   // `gbrain connect --help` prints its own usage (flags + examples) from
   // runConnect; route around the generic one-line short-circuit.
   'connect',
@@ -956,7 +958,7 @@ export function formatResult(opName: string, result: unknown): string {
  * `runRemoteDoctor` for thin-client installs.
  */
 const THIN_CLIENT_REFUSED_COMMANDS = new Set([
-  'sync', 'embed', 'extract', 'extract-conversation-facts', 'enrich', 'migrate', 'apply-migrations',
+  'sync', 'embed', 'extract', 'extract-conversation-facts', 'enrich', 'atoms', 'migrate', 'apply-migrations',
   'repair-jsonb', 'orphans', 'integrity', 'serve',
   // v0.43 (#2095): watch streams against a LOCAL engine; thin clients get
   // the volunteer_context MCP op instead.
@@ -995,6 +997,7 @@ const THIN_CLIENT_REFUSE_HINTS: Record<string, string> = {
   extract: 'extract runs on the host. Use `gbrain remote ping` to trigger a cycle including extract.',
   'extract-conversation-facts': 'extract-conversation-facts runs on the host (requires local engine + chat gateway). Run on the host machine.',
   enrich: 'enrich runs on the host (requires local engine + chat gateway for grounded synthesis). Run on the host machine.',
+  atoms: 'atoms maintenance reads and mutates the host brain. Run on the host machine.',
   migrate: "migrate runs on the host's local engine. Run on the host machine.",
   'apply-migrations': 'schema migrations run on the host. SSH and run there.',
   'repair-jsonb': 'repair-jsonb operates on the local DB only.',
@@ -1858,6 +1861,11 @@ async function handleCliOnly(command: string, args: string[]) {
       case 'takes': {
         const { runTakes } = await import('./commands/takes.ts');
         await runTakes(engine, args);
+        break;
+      }
+      case 'atoms': {
+        const { runAtoms } = await import('./commands/atoms.ts');
+        await runAtoms(engine, args);
         break;
       }
       case 'onboard': {

--- a/src/commands/atoms.ts
+++ b/src/commands/atoms.ts
@@ -1,0 +1,259 @@
+/**
+ * gbrain atoms - atom maintenance commands.
+ *
+ * The first subcommand is a deterministic, no-spend concept-label backfill for
+ * atom pages created before extract_atoms started writing frontmatter.concepts.
+ * It uses only existing signals and never invents labels with an LLM.
+ */
+
+import type { BrainEngine } from '../core/engine.ts';
+import { normalizeAtomConceptLabels } from '../core/cycle/extract-atoms.ts';
+
+interface AtomConceptRow {
+  id: number;
+  slug: string;
+  source_id: string;
+  frontmatter: unknown;
+  compiled_truth: string | null;
+}
+
+export interface BackfillAtomConceptsOpts {
+  apply?: boolean;
+  yes?: boolean;
+  limit?: number;
+  sourceId?: string;
+}
+
+export interface AtomConceptCandidate {
+  id: number;
+  slug: string;
+  source_id: string;
+  concepts: string[];
+}
+
+export interface BackfillAtomConceptsResult {
+  dry_run: boolean;
+  limit: number;
+  source_id?: string;
+  examined: number;
+  candidates: AtomConceptCandidate[];
+  updated: number;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 500;
+
+function printHelp(): void {
+  console.log(`gbrain atoms - atom maintenance.
+
+Usage:
+  gbrain atoms backfill-concepts [--dry-run] [--apply --yes] [--limit N] [--source-id ID] [--json]
+
+Subcommands:
+  backfill-concepts   Populate frontmatter.concepts on old atom pages from
+                      existing deterministic signals only: concept_refs,
+                      concept/concept_slug fields, tags/topics/keywords, and
+                      [[concepts/...]] links in the atom body.
+
+Safety:
+  Defaults to --dry-run. Mutations require both --apply and --yes.
+  --limit caps the selected atom rows per run (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).
+`);
+}
+
+function flagValue(args: string[], name: string): string | undefined {
+  const i = args.indexOf(name);
+  return i >= 0 && i + 1 < args.length ? args[i + 1] : undefined;
+}
+
+function parseLimit(raw: string | undefined): number {
+  if (!raw) return DEFAULT_LIMIT;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
+  return Math.min(n, MAX_LIMIT);
+}
+
+function asRecord(raw: unknown): Record<string, unknown> {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) return raw as Record<string, unknown>;
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function collectValues(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.flatMap(collectValues);
+  if (typeof raw === 'string') return [raw];
+  return [];
+}
+
+function candidateToLabel(raw: string): string | null {
+  let value = raw.trim();
+  if (!value) return null;
+  if (value.startsWith('#')) value = value.slice(1);
+  const aliasIndex = value.indexOf('|');
+  if (aliasIndex >= 0) value = value.slice(0, aliasIndex);
+  value = value.replace(/^wiki:/, '');
+  if (value.startsWith('concepts/')) {
+    value = value.split('/').filter(Boolean).pop() ?? value;
+  }
+  const normalized = normalizeAtomConceptLabels([value])[0];
+  return normalized ?? null;
+}
+
+function extractConceptLinks(body: string | null): string[] {
+  if (!body) return [];
+  const out: string[] = [];
+  const re = /\[\[\s*(?:wiki:)?concepts\/([^\]|#]+)(?:#[^\]|]+)?(?:\|[^\]]*)?\s*\]\]/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(body)) !== null) {
+    out.push(match[1]);
+  }
+  return out;
+}
+
+export function deriveAtomConceptLabels(frontmatter: unknown, body: string | null): string[] {
+  const fm = asRecord(frontmatter);
+  const rawValues = [
+    ...collectValues(fm.concept_refs),
+    ...collectValues(fm.concept_ref),
+    ...collectValues(fm.concepts_legacy),
+    ...collectValues(fm.concept_slugs),
+    ...collectValues(fm.concept_slug),
+    ...collectValues(fm.concepts_old),
+    ...collectValues(fm.concept),
+    ...collectValues(fm.tags),
+    ...collectValues(fm.topics),
+    ...collectValues(fm.keywords),
+    ...extractConceptLinks(body),
+  ];
+
+  const labels: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of rawValues) {
+    const label = candidateToLabel(raw);
+    if (!label || seen.has(label)) continue;
+    seen.add(label);
+    labels.push(label);
+    if (labels.length >= 5) break;
+  }
+  return labels;
+}
+
+async function loadCandidateRows(
+  engine: BrainEngine,
+  opts: { limit: number; sourceId?: string },
+): Promise<AtomConceptRow[]> {
+  const params: unknown[] = [];
+  let sourceFilter = '';
+  if (opts.sourceId) {
+    params.push(opts.sourceId);
+    sourceFilter = `AND source_id = $${params.length}`;
+  }
+  params.push(opts.limit);
+  const limitParam = `$${params.length}`;
+
+  return engine.executeRaw<AtomConceptRow>(
+    `SELECT id, slug, source_id, frontmatter, compiled_truth
+       FROM pages
+      WHERE type = 'atom'
+        AND deleted_at IS NULL
+        ${sourceFilter}
+        AND NOT COALESCE((
+          jsonb_typeof(frontmatter->'concepts') = 'array'
+          AND jsonb_array_length(frontmatter->'concepts') > 0
+        ), false)
+      ORDER BY id
+      LIMIT ${limitParam}`,
+    params,
+  );
+}
+
+export async function backfillAtomConcepts(
+  engine: BrainEngine,
+  opts: BackfillAtomConceptsOpts = {},
+): Promise<BackfillAtomConceptsResult> {
+  const limit = Math.min(opts.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+  const dryRun = opts.apply !== true;
+  if (!dryRun && opts.yes !== true) {
+    throw new Error('Refusing to mutate atom concepts without --yes. Preview with --dry-run --json first.');
+  }
+
+  const rows = await loadCandidateRows(engine, { limit, sourceId: opts.sourceId });
+  const candidates: AtomConceptCandidate[] = [];
+  for (const row of rows) {
+    const concepts = deriveAtomConceptLabels(row.frontmatter, row.compiled_truth);
+    if (concepts.length === 0) continue;
+    candidates.push({ id: row.id, slug: row.slug, source_id: row.source_id, concepts });
+  }
+
+  let updated = 0;
+  if (!dryRun) {
+    for (const candidate of candidates) {
+      await engine.executeRaw(
+        `UPDATE pages
+            SET frontmatter = COALESCE(frontmatter, '{}'::jsonb) || $2::text::jsonb
+          WHERE id = $1`,
+        [candidate.id, JSON.stringify({ concepts: candidate.concepts })],
+      );
+      updated++;
+    }
+  }
+
+  return {
+    dry_run: dryRun,
+    limit,
+    ...(opts.sourceId && { source_id: opts.sourceId }),
+    examined: rows.length,
+    candidates,
+    updated,
+  };
+}
+
+function parseBackfillConceptsArgs(args: string[]): BackfillAtomConceptsOpts & { json?: boolean } {
+  const apply = args.includes('--apply');
+  return {
+    apply,
+    yes: args.includes('--yes'),
+    limit: parseLimit(flagValue(args, '--limit')),
+    sourceId: flagValue(args, '--source-id'),
+    json: args.includes('--json'),
+  };
+}
+
+export async function runAtoms(engine: BrainEngine, args: string[]): Promise<void> {
+  const sub = args[0];
+  if (!sub || args.includes('--help') || args.includes('-h')) {
+    printHelp();
+    return;
+  }
+
+  if (sub !== 'backfill-concepts') {
+    console.error(`Unknown atoms subcommand: ${sub}`);
+    printHelp();
+    process.exit(2);
+  }
+
+  const opts = parseBackfillConceptsArgs(args.slice(1));
+  const result = await backfillAtomConcepts(engine, opts);
+  if (opts.json) {
+    console.log(JSON.stringify({ status: 'ok', ...result }, null, 2));
+    return;
+  }
+
+  const prefix = result.dry_run ? '[dry-run] ' : '';
+  console.log(`${prefix}atom concept backfill: ${result.candidates.length} candidate(s), ${result.updated} updated, examined=${result.examined}, limit=${result.limit}`);
+  for (const candidate of result.candidates.slice(0, 10)) {
+    console.log(`  ${candidate.slug}: ${candidate.concepts.join(', ')}`);
+  }
+  if (result.candidates.length > 10) {
+    console.log(`  ... ${result.candidates.length - 10} more`);
+  }
+}

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -116,6 +116,7 @@ interface ExtractedAtom {
   title: string;
   atom_type: typeof ATOM_TYPES[number];
   body: string;
+  concepts?: string[];
   source_quote?: string;
   lesson?: string;
   virality_score?: number;
@@ -132,11 +133,14 @@ quote, or short essay angle. Each atom must:
 
 Output a JSON array of atoms (1-3 per transcript, never more than 3).
 Each atom: {title (≤80 chars), atom_type, body (2-4 sentences),
+concepts (0-5 reusable kebab-case labels, max 32 chars each),
 source_quote (verbatim ≤200 chars), lesson (one sentence), virality_score
 (0-100), emotional_register (one of: shocking, inspiring, funny, sobering,
 practical, controversial)}.
 
 atom_type MUST be one of: ${ATOM_TYPES.join(', ')}.
+concepts MUST be reusable short labels like "ai-agents" or "founder-psychology",
+not sentence-length tags.
 
 Output ONLY the JSON array, no prose.`;
 
@@ -522,6 +526,7 @@ export async function runPhaseExtractAtoms(
             item.kind === 'transcript'
               ? { source_path: item.filePath }
               : { source_slug: item.slug };
+          const concepts = normalizeAtomConceptLabels(atom.concepts);
           // v0.41.2.1 D9 #1 — thread sourceId through every putPage so
           // atoms land in the source we discovered them from. Pre-fix
           // the third arg was missing and atoms always wrote to 'default'.
@@ -534,6 +539,7 @@ export async function runPhaseExtractAtoms(
               frontmatter: {
                 type: 'atom',
                 atom_type: atom.atom_type,
+                ...(concepts.length > 0 && { concepts }),
                 ...originFrontmatter,
                 source_hash: item.contentHash.slice(0, 16),
                 ...(atom.source_quote && { source_quote: atom.source_quote }),
@@ -672,6 +678,7 @@ export function parseAtomsResponse(raw: string): ExtractedAtom[] {
       title,
       atom_type: atomType as typeof ATOM_TYPES[number],
       body,
+      concepts: normalizeAtomConceptLabels(obj.concepts),
       source_quote: typeof obj.source_quote === 'string' ? obj.source_quote.slice(0, 500) : undefined,
       lesson: typeof obj.lesson === 'string' ? obj.lesson : undefined,
       virality_score:
@@ -685,6 +692,27 @@ export function parseAtomsResponse(raw: string): ExtractedAtom[] {
     });
   }
   return atoms;
+}
+
+export function normalizeAtomConceptLabels(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of raw) {
+    if (typeof value !== 'string') continue;
+    const normalized = value
+      .trim()
+      .toLowerCase()
+      .replace(/[\s_]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    if (normalized.length === 0 || normalized.length > 32) continue;
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(normalized)) continue;
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    out.push(normalized);
+    if (out.length >= 5) break;
+  }
+  return out;
 }
 
 function todayDate(): string {

--- a/src/core/schema-pack/base/gbrain-base-v2.yaml
+++ b/src/core/schema-pack/base/gbrain-base-v2.yaml
@@ -31,6 +31,9 @@ description: 14-type DRY/MECE canonical taxonomy + `note` catch-all (15 total). 
 gbrain_min_version: 0.42.0
 extends: null
 borrow_from: []
+phases:
+  - extract_atoms
+  - synthesize_concepts
 takes_kinds:
   - fact
   - take

--- a/test/atoms-backfill-concepts.test.ts
+++ b/test/atoms-backfill-concepts.test.ts
@@ -1,0 +1,98 @@
+import { beforeAll, afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import {
+  backfillAtomConcepts,
+  deriveAtomConceptLabels,
+} from '../src/commands/atoms.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+async function seedAtom(slug: string, frontmatter: Record<string, unknown>, body = 'body') {
+  await engine.putPage(slug, {
+    title: slug,
+    type: 'atom' as never,
+    compiled_truth: body,
+    timeline: '',
+    frontmatter: { type: 'atom', ...frontmatter },
+  });
+}
+
+describe('deriveAtomConceptLabels', () => {
+  test('derives capped normalized labels from legacy frontmatter and concept links', () => {
+    const labels = deriveAtomConceptLabels(
+      {
+        concept_refs: ['concepts/AI Agents', 'Founder_Psychology'],
+        tags: ['#Hardware', 'AI Agents'],
+        topics: ['too long '.repeat(10)],
+      },
+      'Mentions [[concepts/Enterprise Sales|enterprise]] and [[wiki:concepts/Physical Proof]].',
+    );
+    expect(labels).toEqual([
+      'ai-agents',
+      'founder-psychology',
+      'hardware',
+      'enterprise-sales',
+      'physical-proof',
+    ]);
+  });
+});
+
+describe('backfillAtomConcepts', () => {
+  test('dry-run reports deterministic candidates without mutating pages', async () => {
+    await seedAtom(
+      'atoms/old',
+      { concept_refs: ['concepts/AI Agents'] },
+      'See [[concepts/Founder Psychology]].',
+    );
+
+    const result = await backfillAtomConcepts(engine, { limit: 10 });
+    expect(result.dry_run).toBe(true);
+    expect(result.updated).toBe(0);
+    expect(result.candidates).toEqual([
+      expect.objectContaining({
+        slug: 'atoms/old',
+        concepts: ['ai-agents', 'founder-psychology'],
+      }),
+    ]);
+
+    const rows = await engine.executeRaw<{ frontmatter: { concepts?: string[] } }>(
+      `SELECT frontmatter FROM pages WHERE slug = 'atoms/old'`,
+    );
+    expect(rows[0].frontmatter.concepts).toBeUndefined();
+  });
+
+  test('apply requires explicit yes and updates only capped candidates', async () => {
+    await seedAtom('atoms/a', { tags: ['AI Agents'] });
+    await seedAtom('atoms/b', { tags: ['Founder Psychology'] });
+    await seedAtom('atoms/has-concepts', { concepts: ['already-set'], tags: ['Ignored'] });
+
+    await expect(backfillAtomConcepts(engine, { apply: true, limit: 1 })).rejects.toThrow(/without --yes/);
+
+    const result = await backfillAtomConcepts(engine, { apply: true, yes: true, limit: 1 });
+    expect(result.updated).toBe(1);
+    expect(result.candidates.length).toBe(1);
+
+    const rows = await engine.executeRaw<{ slug: string; frontmatter: { concepts?: string[] } }>(
+      `SELECT slug, frontmatter FROM pages WHERE type = 'atom' ORDER BY slug`,
+    );
+    const bySlug = new Map(rows.map((row) => [row.slug, row.frontmatter.concepts]));
+    expect(bySlug.get('atoms/a')).toEqual(['ai-agents']);
+    expect(bySlug.get('atoms/b')).toBeUndefined();
+    expect(bySlug.get('atoms/has-concepts')).toEqual(['already-set']);
+  });
+});

--- a/test/cycle/extract-atoms-synthesize-concepts.test.ts
+++ b/test/cycle/extract-atoms-synthesize-concepts.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
-import { runPhaseExtractAtoms, parseAtomsResponse } from '../../src/core/cycle/extract-atoms.ts';
+import { runPhaseExtractAtoms, parseAtomsResponse, normalizeAtomConceptLabels } from '../../src/core/cycle/extract-atoms.ts';
 import { runPhaseSynthesizeConcepts } from '../../src/core/cycle/synthesize-concepts.ts';
 import { resetPgliteState } from '../helpers/reset-pglite.ts';
 import type { ChatResult, ChatOpts } from '../../src/core/ai/gateway.ts';
@@ -96,10 +96,36 @@ describe('v0.41 T5: parseAtomsResponse', () => {
     }
   });
 
+  test('normalizes concept labels with cap, length, and dedupe rules', () => {
+    const labels = normalizeAtomConceptLabels([
+      'AI Agents',
+      'ai-agents',
+      'Founder_Psychology',
+      'bad/slash',
+      'this-label-is-far-too-long-to-keep',
+      'Hardware',
+      'Design Tools',
+      'Open Source',
+      'Extra Label',
+    ]);
+    expect(labels).toEqual([
+      'ai-agents',
+      'founder-psychology',
+      'hardware',
+      'design-tools',
+      'open-source',
+    ]);
+  });
+
   test('clamps virality_score to [0, 100]', () => {
     expect(parseAtomsResponse(`[{"title":"a","atom_type":"insight","body":"b","virality_score":150}]`)[0].virality_score).toBeUndefined();
     expect(parseAtomsResponse(`[{"title":"a","atom_type":"insight","body":"b","virality_score":-5}]`)[0].virality_score).toBeUndefined();
     expect(parseAtomsResponse(`[{"title":"a","atom_type":"insight","body":"b","virality_score":75}]`)[0].virality_score).toBe(75);
+  });
+
+  test('parses normalized concept labels from atom JSON', () => {
+    const raw = `[{"title":"a","atom_type":"insight","body":"b","concepts":["AI Agents","Founder_Psychology"]}]`;
+    expect(parseAtomsResponse(raw)[0].concepts).toEqual(['ai-agents', 'founder-psychology']);
   });
 });
 
@@ -115,7 +141,7 @@ describe('v0.41 T5: runPhaseExtractAtoms via stubbed chat', () => {
 
   test('extracts atoms from transcript via stub chat', async () => {
     const chat = stubChat(`[
-      {"title":"Renders vs physical proof","atom_type":"insight","body":"Enterprise buyers want tangible prototypes."},
+      {"title":"Renders vs physical proof","atom_type":"insight","body":"Enterprise buyers want tangible prototypes.","concepts":["Enterprise Sales","Physical Proof"]},
       {"title":"Founder lesson","atom_type":"anecdote","body":"Story about a founder."}
     ]`);
     const result = await runPhaseExtractAtoms(engine, {
@@ -128,10 +154,11 @@ describe('v0.41 T5: runPhaseExtractAtoms via stubbed chat', () => {
     expect(result.details?.transcripts_processed).toBe(1);
 
     // Verify pages were written
-    const rows = await engine.executeRaw<{ slug: string; type: string }>(
-      `SELECT slug, type FROM pages WHERE type = 'atom'`,
+    const rows = await engine.executeRaw<{ slug: string; type: string; frontmatter: { concepts?: string[] } }>(
+      `SELECT slug, type, frontmatter FROM pages WHERE type = 'atom' ORDER BY slug`,
     );
     expect(rows.length).toBe(2);
+    expect(rows.some((row) => row.frontmatter.concepts?.includes('enterprise-sales'))).toBe(true);
   });
 
   test('dry-run counts but does NOT write', async () => {


### PR DESCRIPTION
## Summary
- Adds synthesize_concepts to the base schema phase list.
- Normalizes and writes concept labels produced during atom extraction.

## Verification
- bun run typecheck
- bun test test/cycle/extract-atoms-synthesize-concepts.test.ts test/schema-pack-manifest-v041_2.test.ts test/cycle-pack-gating.test.ts
- git diff --check