### PR TITLE
fix: classify enrich-thin blocked states

### DIFF
--- a/src/core/cycle/enrich-thin.ts
+++ b/src/core/cycle/enrich-thin.ts
@@ -69,6 +69,55 @@ interface ResolvedConfig {
   model?: string;
 }
 
+export type EnrichThinResultStatus =
+  | 'completed'
+  | 'disabled'
+  | 'no_chat_gateway'
+  | 'no_sources'
+  | 'no_candidates'
+  | 'insufficient_evidence'
+  | 'zero_budget_cap'
+  | 'budget_blocked'
+  | 'budget_exhausted'
+  | 'walltime_exhausted'
+  | 'partial_errors';
+
+export interface EnrichThinOutcomeInput {
+  sourcesCount: number;
+  candidatesConsidered: number;
+  pagesEnriched: number;
+  pagesSkippedInsufficient: number;
+  anyBudgetFlag: boolean;
+  anyError: boolean;
+  skippedByBrainWideWalltime: number;
+  spentUsd: number;
+  maxCostUsd: number;
+  maxTotalCostUsd: number;
+}
+
+export function classifyEnrichThinOutcome(input: EnrichThinOutcomeInput): {
+  result_status: EnrichThinResultStatus;
+  budget_exhausted: boolean;
+} {
+  if (input.maxCostUsd === 0 || input.maxTotalCostUsd === 0) {
+    return { result_status: 'zero_budget_cap', budget_exhausted: true };
+  }
+  if (input.anyError) return { result_status: 'partial_errors', budget_exhausted: false };
+  if (input.sourcesCount === 0) return { result_status: 'no_sources', budget_exhausted: false };
+  if (input.candidatesConsidered === 0) return { result_status: 'no_candidates', budget_exhausted: false };
+  if (input.anyBudgetFlag && input.spentUsd > 0) {
+    return { result_status: 'budget_exhausted', budget_exhausted: true };
+  }
+  if (input.anyBudgetFlag) return { result_status: 'budget_blocked', budget_exhausted: false };
+  if (input.skippedByBrainWideWalltime > 0) {
+    return { result_status: 'walltime_exhausted', budget_exhausted: false };
+  }
+  if (input.pagesEnriched === 0 && input.pagesSkippedInsufficient > 0) {
+    return { result_status: 'insufficient_evidence', budget_exhausted: false };
+  }
+  return { result_status: 'completed', budget_exhausted: false };
+}
+
 async function loadCfg(engine: BrainEngine): Promise<ResolvedConfig> {
   const get = (k: string) => engine.getConfig(`${CFG_PREFIX}.${k}`);
   const [enabled, maxCost, maxTotalCost, maxTotalWall, maxPages, typesRaw, orderRaw, workersRaw, model] =
@@ -94,6 +143,11 @@ async function loadCfg(engine: BrainEngine): Promise<ResolvedConfig> {
     if (raw == null) return fallback;
     const n = parseFloat(raw);
     return Number.isFinite(n) && n > 0 ? n : fallback;
+  };
+  const parseNonNegativeFloatOrDefault = (raw: string | null, fallback: number): number => {
+    if (raw == null) return fallback;
+    const n = parseFloat(raw);
+    return Number.isFinite(n) && n >= 0 ? n : fallback;
   };
   const parseIntOrDefault = (raw: string | null, fallback: number): number => {
     if (raw == null) return fallback;
@@ -121,8 +175,8 @@ async function loadCfg(engine: BrainEngine): Promise<ResolvedConfig> {
 
   return {
     enabled: enabledFlag,
-    maxCostUsd: parseFloatOrDefault(maxCost, 1.0),
-    maxTotalCostUsd: parseFloatOrDefault(maxTotalCost, 5.0),
+    maxCostUsd: parseNonNegativeFloatOrDefault(maxCost, 1.0),
+    maxTotalCostUsd: parseNonNegativeFloatOrDefault(maxTotalCost, 5.0),
     maxTotalWalltimeMin: parseFloatOrDefault(maxTotalWall, 30),
     maxPagesPerTick: parseIntOrDefault(maxPages, 3),
     types,
@@ -146,12 +200,30 @@ export async function runPhaseEnrichThin(
       summary: 'cycle.enrich_thin.enabled=false (default OFF)',
       details: {
         reason: 'disabled',
+        result_status: 'disabled',
+        budget_exhausted: false,
         enable_hint: 'gbrain config set cycle.enrich_thin.enabled true',
       },
     };
   }
 
   const startedAt = Date.now();
+
+  if (cfg.maxCostUsd === 0 || cfg.maxTotalCostUsd === 0) {
+    return {
+      phase: 'enrich_thin',
+      status: 'skipped',
+      duration_ms: Date.now() - startedAt,
+      summary: 'enrich_thin budget cap is zero; no enrichment attempted',
+      details: {
+        result_status: 'zero_budget_cap',
+        budget_exhausted: true,
+        spent_usd: 0,
+        max_cost_usd: cfg.maxCostUsd,
+        max_total_cost_usd: cfg.maxTotalCostUsd,
+      },
+    };
+  }
 
   // Chat gateway required for synthesis (dry-run skips the LLM but still needs
   // the candidate query; allow dry-run without a gateway).
@@ -161,7 +233,7 @@ export async function runPhaseEnrichThin(
       status: 'skipped',
       duration_ms: Date.now() - startedAt,
       summary: 'no chat gateway configured',
-      details: { reason: 'no_chat_gateway' },
+      details: { reason: 'no_chat_gateway', result_status: 'no_chat_gateway', budget_exhausted: false },
     };
   }
 
@@ -173,7 +245,7 @@ export async function runPhaseEnrichThin(
       status: 'ok',
       duration_ms: Date.now() - startedAt,
       summary: 'no sources to process',
-      details: { sources_count: 0 },
+      details: { sources_count: 0, result_status: 'no_sources', budget_exhausted: false },
     };
   }
 
@@ -231,16 +303,36 @@ export async function runPhaseEnrichThin(
     }
   }
 
-  const totals = { enriched: 0, skipped_insufficient: 0, sources_processed: 0 };
+  const totals = { enriched: 0, skipped_insufficient: 0, sources_processed: 0, candidates_considered: 0 };
   for (const r of Object.values(perSourceResults)) {
     if (!r.error) totals.sources_processed++;
+    totals.candidates_considered = (totals.candidates_considered ?? 0) + r.candidates_considered;
     totals.enriched += r.pages_enriched;
     totals.skipped_insufficient += r.pages_skipped_insufficient;
   }
 
   const anyError = Object.values(perSourceResults).some((r) => r.error);
-  const status = anyError ? 'warn' : 'ok';
-  const summary = `${totals.enriched} page(s) enriched across ${totals.sources_processed}/${sources.length} sources, ~$${totalSpent.toFixed(4)} spent`;
+  const anyBudgetFlag = Object.values(perSourceResults).some((r) => r.budget_exhausted === true);
+  const outcome = classifyEnrichThinOutcome({
+    sourcesCount: sources.length,
+    candidatesConsidered: totals.candidates_considered ?? 0,
+    pagesEnriched: totals.enriched,
+    pagesSkippedInsufficient: totals.skipped_insufficient,
+    anyBudgetFlag,
+    anyError,
+    skippedByBrainWideWalltime,
+    spentUsd: totalSpent,
+    maxCostUsd: cfg.maxCostUsd,
+    maxTotalCostUsd: cfg.maxTotalCostUsd,
+  });
+  const status =
+    outcome.result_status === 'partial_errors' ||
+    outcome.result_status === 'budget_blocked' ||
+    outcome.result_status === 'budget_exhausted' ||
+    outcome.result_status === 'walltime_exhausted'
+      ? 'warn'
+      : 'ok';
+  const summary = `${totals.enriched} page(s) enriched across ${totals.sources_processed}/${sources.length} sources, ~$${totalSpent.toFixed(4)} spent (${outcome.result_status})`;
 
   return {
     phase: 'enrich_thin',
@@ -250,6 +342,9 @@ export async function runPhaseEnrichThin(
     details: {
       sources_count: sources.length,
       sources_processed: totals.sources_processed,
+      result_status: outcome.result_status,
+      budget_exhausted: outcome.budget_exhausted,
+      candidates_considered: totals.candidates_considered ?? 0,
       pages_enriched: totals.enriched,
       pages_skipped_insufficient: totals.skipped_insufficient,
       spent_usd: totalSpent,

--- a/test/enrich-cycle-phase.test.ts
+++ b/test/enrich-cycle-phase.test.ts
@@ -8,7 +8,7 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
-import { runPhaseEnrichThin } from '../src/core/cycle/enrich-thin.ts';
+import { classifyEnrichThinOutcome, runPhaseEnrichThin } from '../src/core/cycle/enrich-thin.ts';
 
 let engine: PGLiteEngine;
 
@@ -53,6 +53,8 @@ describe('runPhaseEnrichThin', () => {
     const perSource = r.details.per_source as Record<string, { pages_enriched: number; candidates_considered: number }>;
     expect(perSource['default'].pages_enriched).toBe(0);
     expect(perSource['default'].candidates_considered).toBe(0);
+    expect(r.details.result_status).toBe('no_candidates');
+    expect(r.details.budget_exhausted).toBe(false);
   });
 
   test('enabled + dry-run respects max_pages_per_tick cap', async () => {
@@ -96,5 +98,43 @@ describe('runPhaseEnrichThin', () => {
     expect(r.status).toBe('ok');
     expect(r.details.max_cost_usd).toBe(0.5);
     expect(r.details.max_total_cost_usd).toBe(5.0); // brain-wide default unchanged
+  });
+
+  test('zero budget cap is the only zero-spend budget_exhausted path', async () => {
+    await engine.setConfig('cycle.enrich_thin.enabled', 'true');
+    await engine.setConfig('cycle.enrich_thin.max_total_cost_usd', '0');
+    const r = await runPhaseEnrichThin(engine, { dryRun: true });
+    expect(r.status).toBe('skipped');
+    expect(r.details.result_status).toBe('zero_budget_cap');
+    expect(r.details.budget_exhausted).toBe(true);
+    expect(r.details.spent_usd).toBe(0);
+  });
+
+  test('outcome classifier separates blocked budget from real exhaustion', () => {
+    expect(classifyEnrichThinOutcome({
+      sourcesCount: 1,
+      candidatesConsidered: 2,
+      pagesEnriched: 0,
+      pagesSkippedInsufficient: 0,
+      anyBudgetFlag: true,
+      anyError: false,
+      skippedByBrainWideWalltime: 0,
+      spentUsd: 0,
+      maxCostUsd: 0.01,
+      maxTotalCostUsd: 1,
+    })).toEqual({ result_status: 'budget_blocked', budget_exhausted: false });
+
+    expect(classifyEnrichThinOutcome({
+      sourcesCount: 1,
+      candidatesConsidered: 2,
+      pagesEnriched: 1,
+      pagesSkippedInsufficient: 0,
+      anyBudgetFlag: true,
+      anyError: false,
+      skippedByBrainWideWalltime: 0,
+      spentUsd: 0.02,
+      maxCostUsd: 0.01,
+      maxTotalCostUsd: 1,
+    })).toEqual({ result_status: 'budget_exhausted', budget_exhausted: true });
   });
 });


### PR DESCRIPTION
## Summary
- Adds explicit enrich-thin result status classification.
- Distinguishes disabled, no sources, no candidates, evidence gaps, zero cap, blocked budget, and true exhaustion.

## Verification
- bun run typecheck
- bun test test/enrich-cycle-phase.test.ts test/e2e/dream-cycle-phase-order-pglite.test.ts
- git diff --check