### PR TITLE
feat(facts): date conversation facts at claim time + owner-trusted local fact reads

### DIFF
--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -186,6 +186,19 @@ export interface ConversationSegment {
 }
 
 /**
+ * The `valid_from` to stamp on facts extracted from a segment: the date the
+ * claim was made (the segment's own timestamp), so find_trajectory orders on
+ * "when it happened" rather than "when extracted". Returns `undefined` for an
+ * unparseable date or the 1970 epoch fallback parseConversation emits when a
+ * page carries no date at all — letting insertFacts keep its now() default.
+ */
+export function segmentValidFrom(endIso: string): Date | undefined {
+  const d = new Date(endIso);
+  if (Number.isNaN(d.getTime()) || d.getUTCFullYear() <= 1971) return undefined;
+  return d;
+}
+
+/**
  * Core function opts. Strict — `sourceId` is always required (Eng-v2 A1).
  * Multi-source iteration is the caller's job.
  */
@@ -756,6 +769,10 @@ async function processPage(
     state.result.facts_extracted += extracted.length;
 
     if (!state.dryRun && extracted.length > 0) {
+      // Anchor each fact at WHEN IT WAS SAID — the segment's own date — not the
+      // extraction time (see segmentValidFrom).
+      const segValidFrom = segmentValidFrom(seg.endIso);
+
       // Eng-v2 C1 / E11: page-global row_num. Each fact in this batch gets
       // a unique row_num within (source_id, source_markdown_slug); the
       // accumulator increments across the segment loop.
@@ -765,6 +782,7 @@ async function processPage(
         source_markdown_slug: page.slug,
         source: PER_SEGMENT_SOURCE_PREFIX,
         source_session: sessionId,
+        valid_from: segValidFrom,
         context:
           fact.context ?? `from ${page.slug} segment ${seg.startIso}..${seg.endIso}`,
       }));

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -870,6 +870,10 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'models.chat',
   'models.eval.longmemeval',
   'facts.extraction_model',
+  // Owner opt-in: let the local stdio MCP pipe read this owner's private facts
+  // (find_trajectory / recall). Default off; HTTP transport ignores it. See
+  // src/core/facts/reader-trust.ts.
+  'facts.trust_local_reads',
   // Dream cycle config
   'dream.synthesize.session_corpus_dir',
   'dream.synthesize.meeting_transcripts_dir',

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -578,6 +578,8 @@ export interface TrajectoryOpts {
   sourceIds?: string[];
   /** When true, filters to visibility='world' only. Set by MCP layer from ctx.remote. */
   remote?: boolean;
+  /** Owner opt-in: read private facts despite `remote`. See facts/reader-trust.ts. */
+  trustedFactReads?: boolean;
   /** Metric filter. When set, only facts with this canonical metric label participate. */
   metric?: string;
   /**

--- a/src/core/facts/meta-hook.ts
+++ b/src/core/facts/meta-hook.ts
@@ -17,6 +17,7 @@
 import type { OperationContext } from './../operations.ts';
 import type { FactRow } from './../engine.ts';
 import { effectiveConfidence } from './decay.ts';
+import { readableFactVisibilities } from './reader-trust.ts';
 
 const DEFAULT_TTL_MS = 30_000;
 const DEFAULT_TOP_K = 10;
@@ -61,9 +62,9 @@ export async function getBrainHotMemoryMeta(
     return cached.payload;
   }
 
-  // Build a fresh payload. Visibility tier: remote → world-only;
-  // local → all rows.
-  const visibility = ctx.remote === false ? undefined : ['world'] as ('world' | 'private')[];
+  // Build a fresh payload. Visibility tier: untrusted remote → world-only;
+  // trusted local + owner-trusted reads → all rows.
+  const visibility = readableFactVisibilities(ctx);
 
   let rows: FactRow[] = [];
   if (sessionId) {

--- a/src/core/facts/reader-trust.ts
+++ b/src/core/facts/reader-trust.ts
@@ -1,0 +1,40 @@
+/**
+ * Fact-read visibility trust.
+ *
+ * Fact rows are tagged `private` | `world`. Remote/untrusted callers
+ * (`remote === true`) see only `world` rows — the posture that keeps a
+ * published or HTTP-served brain from leaking private claims to strangers.
+ *
+ * But the stdio MCP server is an unauthenticated LOCAL pipe: on a single-owner
+ * machine the caller IS the owner, yet it still defaults `remote: true` for
+ * safety, so the owner's own agent is denied the owner's own private facts
+ * (e.g. `find_trajectory` returns empty over MCP even though the facts exist).
+ *
+ * `trustedFactReads` is a narrow, READ-ONLY trust elevation, deliberately
+ * DECOUPLED from `remote` so every other remote protection — file_upload
+ * confinement, source isolation, fence stripping, takes-holder scoping — stays
+ * fully in force. The stdio MCP server sets it ONLY when the brain owner opts
+ * in via the `facts.trust_local_reads` config (default off). The HTTP/published
+ * transport never sets it, so a served brain stays world-only regardless.
+ */
+export interface FactReaderTrust {
+  /** Mirrors OperationContext.remote. Anything not strictly `true` is local/trusted. */
+  remote?: boolean;
+  /** Owner opt-in: this remote caller may read private facts. */
+  trustedFactReads?: boolean;
+}
+
+/** True when the reader is restricted to `visibility = 'world'` rows. */
+export function factsWorldOnly(t: FactReaderTrust): boolean {
+  return t.remote === true && t.trustedFactReads !== true;
+}
+
+/**
+ * Visibility filter for list-style fact reads: `['world']` when the reader is
+ * world-only, `undefined` (no filter — all rows) when it is trusted.
+ */
+export function readableFactVisibilities(
+  t: FactReaderTrust,
+): ('private' | 'world')[] | undefined {
+  return factsWorldOnly(t) ? ['world'] : undefined;
+}

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -18,6 +18,7 @@ import { captureEvalCandidate, isEvalCaptureEnabled, isEvalScrubEnabled } from '
 import type { HybridSearchMeta } from './types.ts';
 import { extractPageLinks, isAutoLinkEnabled, isAutoTimelineEnabled, isGlobalBasenameEnabled, parseTimelineEntries, makeResolver, type UnresolvedFrontmatterRef } from './link-extraction.ts';
 import { isFactsBackstopEligible } from './facts/eligibility.ts';
+import { readableFactVisibilities } from './facts/reader-trust.ts';
 import { stripTakesFence } from './takes-fence.ts';
 import { stripFactsFence } from './facts-fence.ts';
 import { getContentFlag } from './quarantine.ts';
@@ -299,6 +300,15 @@ export interface OperationContext {
    * remote/untrusted (defense in depth in case the type is bypassed via cast).
    */
   remote: boolean;
+  /**
+   * Owner opt-in (`facts.trust_local_reads`): allow this remote caller to read
+   * `private` facts. A NARROW, read-only trust elevation decoupled from
+   * `remote` — every other remote protection (file confinement, source
+   * isolation, fence stripping, takes scoping) stays in force. Set ONLY by the
+   * stdio MCP server when the config is on; the HTTP transport never sets it.
+   * Consulted via `src/core/facts/reader-trust.ts`.
+   */
+  trustedFactReads?: boolean;
   /**
    * Subagent runtime context (v0.16+). Set by the subagent tool dispatcher when
    * dispatching an op as a tool call from an LLM loop. Used to enforce per-op
@@ -3554,6 +3564,7 @@ const find_trajectory: Operation = {
       entitySlug: p.entity_slug,
       ...scope,
       remote: ctx.remote === true,
+      trustedFactReads: ctx.trustedFactReads === true,
       metric,
       kind,
       since,
@@ -3914,13 +3925,9 @@ const recall: Operation = {
     const includeExpired = p.include_expired === true;
     const grep = typeof p.grep === 'string' ? p.grep.toLowerCase() : null;
 
-    // Visibility filter: remote callers see world-only unless their token
-    // grants elevated visibility (future-proofing; v0.31 ships world-only
-    // for remote, all for local CLI).
-    const visibility =
-      ctx.remote === false
-        ? undefined
-        : ['world'] as ('private' | 'world')[];
+    // Visibility filter: world-only for untrusted remote callers; all rows for
+    // trusted local CLI and owner-trusted reads (facts.trust_local_reads).
+    const visibility = readableFactVisibilities(ctx);
 
     let rows: Awaited<ReturnType<typeof ctx.engine.listFactsByEntity>> = [];
 

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -18,6 +18,7 @@ import type {
 } from './engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
 import { withRetry, BULK_RETRY_OPTS, resolveBulkRetryOpts, computeNextDelay, type BatchAuditSite } from './retry.ts';
+import { factsWorldOnly } from './facts/reader-trust.ts';
 import { logBatchRetry as auditLogBatchRetry, logBatchExhausted as auditLogBatchExhausted } from './audit/batch-retry-audit.ts';
 import { runMigrations } from './migrate.ts';
 import { PGLITE_SCHEMA_SQL, getPGLiteSchema } from './pglite-schema.ts';
@@ -3853,7 +3854,7 @@ export class PGLiteEngine implements BrainEngine {
     const useArray = Array.isArray(opts.sourceIds) && opts.sourceIds.length > 0;
     const sourceIds = useArray ? opts.sourceIds! : null;
     const sourceId = opts.sourceId ?? 'default';
-    const remoteFilter = opts.remote === true;
+    const remoteFilter = factsWorldOnly(opts);
 
     // Build SQL dynamically. PGLite uses $N positional params; we
     // assemble the WHERE clauses + params array in tandem to keep them

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -14,6 +14,7 @@ import type {
   SourceRow,
 } from './engine.ts';
 import { withRetry, BULK_RETRY_OPTS, resolveBulkRetryOpts, computeNextDelay, type BatchAuditSite } from './retry.ts';
+import { factsWorldOnly } from './facts/reader-trust.ts';
 import { logBatchRetry as auditLogBatchRetry, logBatchExhausted as auditLogBatchExhausted } from './audit/batch-retry-audit.ts';
 import type {
   DomainBankSampleOpts, CorpusSampleOpts, DomainBankRow,
@@ -3976,7 +3977,7 @@ export class PostgresEngine implements BrainEngine {
     const useArray = Array.isArray(opts.sourceIds) && opts.sourceIds.length > 0;
     const sourceIds = useArray ? opts.sourceIds! : null;
     const sourceId = opts.sourceId ?? 'default';
-    const remoteFilter = opts.remote === true;
+    const remoteFilter = factsWorldOnly(opts);
 
     // Source-scope predicate: array path (federated) wins over scalar.
     // Engine.ts contract: returns chronological points; regressions +

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -30,6 +30,13 @@ export interface ToolResult {
 export interface DispatchOpts {
   /** Defaults to true (remote/untrusted). Local CLI callers (`gbrain call`) pass false. */
   remote?: boolean;
+  /**
+   * Owner opt-in (`facts.trust_local_reads`): let this remote caller read
+   * `private` facts. Set ONLY by the stdio MCP server; the HTTP transport
+   * leaves it unset so a served brain stays world-only. See
+   * `src/core/facts/reader-trust.ts`.
+   */
+  trustedFactReads?: boolean;
   /** Override the default stderr logger (e.g. CLI uses console.* directly). */
   logger?: OperationContext['logger'];
   /**
@@ -203,6 +210,7 @@ export function buildOperationContext(
     logger: opts.logger || stderrLogger,
     dryRun: !!params.dry_run,
     remote: opts.remote ?? true,
+    trustedFactReads: opts.trustedFactReads === true,
     takesHoldersAllowList: opts.takesHoldersAllowList,
     // v0.34 D4: sourceId is REQUIRED at the type level. Auto-fill 'default'
     // for single-source brains and any caller who didn't resolve a sourceId.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -35,6 +35,16 @@ export async function startMcpServer(engine: BrainEngine) {
   // shape and cast through `any` (the SDK accepts it via the ServerResult union).
   server.setRequestHandler(CallToolRequestSchema, async (request: any): Promise<any> => {
     const { name, arguments: params } = request.params;
+    // Owner opt-in: the stdio pipe is local + unauthenticated, so on a
+    // single-owner machine its caller is the owner. When facts.trust_local_reads
+    // is on, let fact reads (find_trajectory / recall) see this owner's own
+    // private facts. Narrow + read-only — every other remote protection stays
+    // on (remote stays true). HTTP transport never sets this. Best-effort: a
+    // config read blip falls back to the safe world-only default.
+    let trustedFactReads = false;
+    try {
+      trustedFactReads = (await engine.getConfig('facts.trust_local_reads')) === 'true';
+    } catch { /* keep world-only default */ }
     // v0.28: stdio MCP has no per-token auth (local pipe). Default the
     // takes-holder allow-list to ['world'] so agent-facing callers don't
     // see private hunches via takes_list / takes_search / query. Operators
@@ -42,6 +52,7 @@ export async function startMcpServer(engine: BrainEngine) {
     // `gbrain call <op>` (sets remote=false in src/cli.ts).
     return dispatchToolCall(engine, name, params, {
       remote: true,
+      trustedFactReads,
       takesHoldersAllowList: ['world'],
       // v0.31: source defaults to 'default' for stdio (no per-token scope).
       // Operators who want a different source on stdio MCP should set

--- a/test/engine-find-trajectory.test.ts
+++ b/test/engine-find-trajectory.test.ts
@@ -153,6 +153,22 @@ describe('findTrajectory — visibility filter (D-CDX-1 / R6)', () => {
     const all = await engine.findTrajectory({ entitySlug: 'traj-vis-default' });
     expect(all.length).toBe(2);
   });
+
+  test('remote=true + trustedFactReads bypasses world-only (owner-trusted reads)', async () => {
+    await insertTyped({ entity_slug: 'traj-vis-trusted', metric: 'mrr', value: 50000, visibility: 'private', valid_from: new Date('2026-01-15') });
+    await insertTyped({ entity_slug: 'traj-vis-trusted', metric: 'mrr', value: 99999, visibility: 'world',   valid_from: new Date('2026-04-12') });
+
+    // Untrusted remote: world only.
+    const untrusted = await engine.findTrajectory({ entitySlug: 'traj-vis-trusted', remote: true });
+    expect(untrusted.length).toBe(1);
+    expect(untrusted[0].value).toBe(99999);
+
+    // Owner-trusted remote: sees the private point too. remote stays true — only
+    // fact-read visibility is elevated.
+    const trusted = await engine.findTrajectory({ entitySlug: 'traj-vis-trusted', remote: true, trustedFactReads: true });
+    expect(trusted.length).toBe(2);
+    expect(trusted.map(p => p.value).sort((a, b) => (a! - b!))).toEqual([50000, 99999]);
+  });
 });
 
 describe('findTrajectory — metric + since + until filters', () => {

--- a/test/extract-conversation-facts.test.ts
+++ b/test/extract-conversation-facts.test.ts
@@ -33,7 +33,29 @@ import {
   MAX_PAGE_BODY_BYTES,
   TERMINAL_AUDIT_SOURCE,
   PER_SEGMENT_SOURCE_PREFIX,
+  segmentValidFrom,
 } from '../src/commands/extract-conversation-facts.ts';
+
+// ---------------------------------------------------------------------------
+// segmentValidFrom — fact dating (claim date, not extraction date).
+// ---------------------------------------------------------------------------
+
+describe('segmentValidFrom', () => {
+  test('returns the segment date for a real timestamp', () => {
+    const d = segmentValidFrom('2026-06-15T11:18:00Z');
+    expect(d).toBeInstanceOf(Date);
+    expect(d!.toISOString().slice(0, 10)).toBe('2026-06-15');
+  });
+
+  test('returns undefined for the 1970 epoch fallback (no page date)', () => {
+    expect(segmentValidFrom('1970-01-01T00:00:00Z')).toBeUndefined();
+  });
+
+  test('returns undefined for an unparseable date', () => {
+    expect(segmentValidFrom('not-a-date')).toBeUndefined();
+    expect(segmentValidFrom('')).toBeUndefined();
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Fixture helpers.

--- a/test/facts-reader-trust.test.ts
+++ b/test/facts-reader-trust.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  factsWorldOnly,
+  readableFactVisibilities,
+} from '../src/core/facts/reader-trust.ts';
+
+describe('factsWorldOnly', () => {
+  test('trusted local callers see all (remote unset or false)', () => {
+    expect(factsWorldOnly({})).toBe(false);
+    expect(factsWorldOnly({ remote: false })).toBe(false);
+    expect(factsWorldOnly({ remote: false, trustedFactReads: false })).toBe(false);
+  });
+
+  test('untrusted remote callers are world-only', () => {
+    expect(factsWorldOnly({ remote: true })).toBe(true);
+    expect(factsWorldOnly({ remote: true, trustedFactReads: false })).toBe(true);
+  });
+
+  test('owner-trusted remote reads bypass the world-only filter', () => {
+    expect(factsWorldOnly({ remote: true, trustedFactReads: true })).toBe(false);
+  });
+
+  test('trustedFactReads only matters when remote (no effect locally)', () => {
+    expect(factsWorldOnly({ remote: false, trustedFactReads: true })).toBe(false);
+  });
+});
+
+describe('readableFactVisibilities', () => {
+  test("world-only readers get the ['world'] filter", () => {
+    expect(readableFactVisibilities({ remote: true })).toEqual(['world']);
+  });
+
+  test('trusted readers get undefined (no filter — all rows)', () => {
+    expect(readableFactVisibilities({ remote: false })).toBeUndefined();
+    expect(readableFactVisibilities({})).toBeUndefined();
+    expect(readableFactVisibilities({ remote: true, trustedFactReads: true })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Two fixes that make `find_trajectory` (and fact recall) actually usable for a
single-owner brain whose facts come from conversation extraction.

### 1. Date facts at claim time, not extraction time

`extract-conversation-facts` built fact rows without a `valid_from`, so
`insertFacts` stamped `now()`. `find_trajectory` orders entirely by `valid_from`,
so every entity's timeline collapsed onto the day it was extracted instead of
when the claim was actually made. Each segment already carries its own
timestamps; we now stamp each fact with the segment date (`segmentValidFrom`),
guarding the `1970` epoch fallback that `parseConversation` emits when a page
has no date at all (then `valid_from` stays unset and `insertFacts` keeps its
`now()` default).

### 2. Owner-trusted local fact reads

Fact rows are `private` | `world`. Remote callers are filtered to `world` only —
correct for a published or HTTP-served brain. But the stdio MCP server is an
unauthenticated **local pipe**: on a single-owner machine its caller is the
owner, yet it still defaults `remote: true`, so the owner's own agent gets an
empty `find_trajectory` over MCP even though the facts exist.

This adds `trustedFactReads` — a narrow, **read-only** trust elevation
decoupled from `remote`, so every other remote protection (file confinement,
source isolation, fence stripping, takes-holder scoping) stays fully in force.
The stdio server sets it only when the owner opts in via
`facts.trust_local_reads` (default off); the HTTP transport never sets it, so a
served brain stays `world`-only regardless.

## How

- `src/core/facts/reader-trust.ts` (new): `factsWorldOnly(ctx)` /
  `readableFactVisibilities(ctx)` — the single decision point for fact-read
  visibility. `world`-only iff `remote === true && !trustedFactReads`.
- All four fact-read visibility sites now route through it: `findTrajectory`
  (both engines, kept in lockstep), the recall meta-hook, and the
  `listFactsByEntity` op path. No more open-coded `remote === false ? … : …`.
- `OperationContext.trustedFactReads` + `TrajectoryOpts.trustedFactReads`;
  `find_trajectory` op threads `ctx.trustedFactReads` to the engine.
- `dispatch.ts` carries the flag; the **stdio** server reads
  `facts.trust_local_reads` (best-effort; a config blip falls back to the safe
  world-only default) and sets it. HTTP dispatch leaves it unset.
- `facts.trust_local_reads` registered as a config key (default off).
- `segmentValidFrom` extracted as a pure, exported helper and used in the
  extraction row build.

## Result

On a ~13.7K-page comms brain with ~58 private conversation facts:
- `find_trajectory(<entity>)` over a trusted reader returns the populated points
  list; an untrusted reader still gets `0`; local CLI unchanged. (Verified
  end-to-end against the live engine in all three modes.)
- Newly extracted facts carry the conversation date as `valid_from` instead of
  the extraction date.

## Tests

- `facts-reader-trust`: full truth table for both helpers.
- `engine-find-trajectory`: new case — `remote=true + trustedFactReads` returns
  private points while plain `remote=true` stays world-only.
- `extract-conversation-facts`: `segmentValidFrom` (real date / epoch fallback /
  unparseable).
- `bun run typecheck` clean; `bun run verify` 30/30; touched suites green.

Depends on #2357 (the Slack block-format parser) for facts to flow on a
collector-native brain.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
