### PR TITLE
fix(op-checkpoint): write completed_keys as a jsonb array, not a double-encoded scalar (#2328)

### DIFF
--- a/src/core/op-checkpoint.ts
+++ b/src/core/op-checkpoint.ts
@@ -179,19 +179,25 @@ export async function recordCompleted(
   // REPLACE semantics (kept deliberately — #1794 V3). Callers like
   // extract-conversation-facts serialize a MUTABLE map through here and rely on
   // stale keys being REMOVED; an append would make them unremovable. The full
-  // set lands in the parent `completed_keys` JSONB column via a single UPSERT —
-  // exactly as before. JSON.stringify into `$3::jsonb` is correct (the text→jsonb
-  // cast yields a proper array; NOT the double-encode trap, which is the template
-  // form). Sync uses `appendCompleted` (below) instead, never this.
+  // set lands in the parent `completed_keys` JSONB column via a single UPSERT.
+  //
+  // #2328: `JSON.stringify(sorted)` bound to a `$3::jsonb` PARAM is the
+  // double-encode trap (postgres.js stringifies the string again → a jsonb
+  // SCALAR), which the v119 `completed_keys` array CHECK rejects on every write
+  // ("violates op_checkpoints_completed_keys_array"). It silently slipped the
+  // `check-jsonb-pattern` guard because that only matches the `${...}::jsonb`
+  // TEMPLATE form, not a positional param. Fix: pass the JS array as a native
+  // `text[]` param (the same shape `appendCompleted` relies on) and lift it to a
+  // jsonb array with `to_jsonb`. No JSON.stringify, no double-encode.
   const sorted = [...keys].sort();
   return durableWrite(engine, key, 'write', () =>
     engine.executeRawDirect(
       `INSERT INTO op_checkpoints (op, fingerprint, completed_keys, updated_at)
-       VALUES ($1, $2, $3::jsonb, now())
+       VALUES ($1, $2, to_jsonb($3::text[]), now())
        ON CONFLICT (op, fingerprint) DO UPDATE
          SET completed_keys = EXCLUDED.completed_keys,
              updated_at     = now()`,
-      [key.op, key.fingerprint, JSON.stringify(sorted)],
+      [key.op, key.fingerprint, sorted],
     ));
 }
 

--- a/test/op-checkpoint.test.ts
+++ b/test/op-checkpoint.test.ts
@@ -106,6 +106,20 @@ describe('loadOpCheckpoint / recordCompleted / clearOpCheckpoint', () => {
     expect(result.sort()).toEqual(['chunk-1', 'chunk-2', 'chunk-3']);
   });
 
+  test('#2328: completed_keys is stored as a jsonb ARRAY, not a scalar', async () => {
+    // The v119 CHECK requires jsonb_typeof = 'array'. recordCompleted must NOT
+    // double-encode (JSON.stringify into a ::jsonb param) or postgres.js writes a
+    // jsonb string scalar that fails the CHECK on every write. PGLite doesn't
+    // reproduce the double-encode, but this still pins the array shape.
+    const key = { op: 'embed', fingerprint: 'arr00001' };
+    await recordCompleted(engine, key, ['k-2', 'k-1']);
+    const rows = await engine.executeRaw<{ t: string }>(
+      `SELECT jsonb_typeof(completed_keys) AS t FROM op_checkpoints WHERE op = $1 AND fingerprint = $2`,
+      [key.op, key.fingerprint],
+    );
+    expect(rows[0]?.t).toBe('array');
+  });
+
   test('write overwrites prior state', async () => {
     const key = { op: 'embed', fingerprint: 'abc12345' };
     await recordCompleted(engine, key, ['chunk-1']);


### PR DESCRIPTION
## What

`recordCompleted` bound `JSON.stringify(sorted)` to a `$3::jsonb` param - the double-encode trap. postgres.js stringifies the string again, producing a jsonb **scalar** that the v119 `completed_keys` array CHECK rejects (`violates op_checkpoints_completed_keys_array`) on **every** write. It slipped the `check-jsonb-pattern` guard because that only matches the `${...}::jsonb` template form, not a positional param.

Impact: every `extract-conversation-facts` and `extract links --by-mention` run logged the failure and lost its resume checkpoint, so re-runs reprocessed already-completed work.

## How

Pass the JS array as a native `text[]` param and lift it to jsonb with `to_jsonb($3::text[])` - the same shape `appendCompleted` already relies on. No `JSON.stringify`, no double-encode.

## Verified

Against live Postgres: the write succeeds, `completed_keys` is `jsonb_typeof` **array**, and the key set round-trips. PGLite never reproduced the double-encode (it hid the bug), so the existing PGLite round-trip tests stayed green; added a `jsonb_typeof='array'` assertion to pin the shape. typecheck clean; verify 30/30.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)