### PR TITLE
feat(extract): keep frontmatter links fresh on the incremental cycle

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -536,6 +536,17 @@ export interface ExtractOpts {
    * paths: extractForSlugs, extractLinksFromDir, extractTimelineFromDir.
    */
   signal?: AbortSignal;
+  /**
+   * v0.42 — also extract frontmatter links on the incremental (slugs) path.
+   * `extractForSlugs` extracts BODY links only by default; set this true to also
+   * parse each changed page's frontmatter so `sources:`/`related:` edges stay fresh
+   * when YAML is edited externally and synced in. Applied PER changed page, so the
+   * incremental walk stays bounded (no switch to a full DB scan). Only honored on
+   * the incremental path (`slugs` defined); the full-walk path already covers
+   * frontmatter via its own dispatch. Gated upstream by the config key
+   * `autopilot.incremental_extract_include_frontmatter` (default off).
+   */
+  includeFrontmatter?: boolean;
 }
 
 /**
@@ -574,7 +585,7 @@ export async function runExtractCore(engine: BrainEngine, opts: ExtractOpts): Pr
       // Nothing changed — skip entirely.
       return result;
     }
-    const r = await extractForSlugs(engine, opts.dir, opts.slugs, opts.mode, dryRun, jsonMode, workers, opts.signal);
+    const r = await extractForSlugs(engine, opts.dir, opts.slugs, opts.mode, dryRun, jsonMode, workers, opts.signal, opts.includeFrontmatter);
     result.links_created = r.links_created;
     result.timeline_entries_created = r.timeline_created;
     result.pages_processed = r.pages;
@@ -953,6 +964,11 @@ async function extractForSlugs(
   // shared counter increments atomic.
   workers: number = 1,
   signal?: AbortSignal,
+  // v0.42: when true, also extract frontmatter links per changed page so
+  // externally-edited YAML (`sources:`/`related:`) stays fresh on the cycle.
+  // Default false preserves the body-only incremental behavior. Gated upstream
+  // by `autopilot.incremental_extract_include_frontmatter`.
+  includeFrontmatter: boolean = false,
 ): Promise<{ links_created: number; timeline_created: number; pages: number }> {
   // Build the full slug set for link resolution (fast: just readdir, no file reads)
   const allFiles = walkMarkdownFiles(brainDir);
@@ -1027,7 +1043,7 @@ async function extractForSlugs(
         const content = readFileSync(fullPath, 'utf-8');
 
         if (doLinks) {
-          const links = await extractLinksFromFile(content, relPath, allSlugs, { globalBasename });
+          const links = await extractLinksFromFile(content, relPath, allSlugs, { globalBasename, includeFrontmatter });
           for (const link of links) {
             if (dryRun) {
               if (!jsonMode) console.log(`  ${link.from_slug} → ${link.to_slug} (${link.link_type})`);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -112,6 +112,18 @@ export interface GBrainConfig {
       /** Daily spend cap (USD); bounds drains/day = floor(cap / ~$0.30). Default 2.0. */
       max_usd_per_day?: number;
     };
+    /**
+     * v0.42 — keep frontmatter links fresh on the incremental cycle. The cycle's
+     * extract phase re-extracts only the slugs a sync changed, but `extractForSlugs`
+     * extracts BODY links only — frontmatter (`sources:`/`related:` etc.) link edges
+     * silently drift stale when a page's YAML is edited externally and synced in.
+     * Set true to also extract frontmatter links per changed page each cycle, keeping
+     * externally-edited YAML edges fresh without a full rescan. Default false
+     * (preserves current behavior). Read via the file/env/DB plane in the cycle's
+     * extract dispatch. Disable/enable with
+     * `gbrain config set autopilot.incremental_extract_include_frontmatter <bool>`.
+     */
+    incremental_extract_include_frontmatter?: boolean;
   };
   eval?: {
     /** false disables capture entirely. Defaults to true. */

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -959,6 +959,10 @@ async function runPhaseExtract(
 ): Promise<PhaseResult> {
   try {
     const { runExtractCore } = await import('../commands/extract.ts');
+    const { loadConfig } = await import('./config.ts');
+    // Default off: the incremental cycle extracts body links only unless the
+    // operator opts in to keeping externally-edited frontmatter links fresh too.
+    const includeFrontmatter = loadConfig()?.autopilot?.incremental_extract_include_frontmatter === true;
     // Extract is read-mostly against the filesystem + write to links table.
     // Honor dryRun by skipping with a 'skipped' entry: extract doesn't have
     // a clean dry-run mode today and runCycle should be honest about it.
@@ -978,6 +982,7 @@ async function runPhaseExtract(
       dir: brainDir,
       slugs: changedSlugs,  // undefined = full walk (first run / manual)
       signal,
+      includeFrontmatter,  // honored on the incremental (slugs) path only
     });
     const linksCreated = result?.links_created ?? 0;
     const timelineCreated = result?.timeline_entries_created ?? 0;

--- a/test/extract-incremental.test.ts
+++ b/test/extract-incremental.test.ts
@@ -191,3 +191,38 @@ describe('runExtractCore — incremental cycle path (#417)', () => {
     expect(result.links_created).toBeGreaterThan(0);
   });
 });
+
+describe('runExtractCore — incremental frontmatter gate (includeFrontmatter)', () => {
+  // alice has a `source:` frontmatter edge but NO body links. The incremental
+  // path extracts body links only by default, so the frontmatter edge is the
+  // sole signal that distinguishes the gate off vs on.
+  const aliceFm = '---\nsource: companies/acme-example\n---\n# alice';
+
+  test('9. default (flag omitted) does NOT extract frontmatter links on the incremental path', async () => {
+    await seedPage('companies/acme-example', '# acme');
+    await seedPage('people/alice-example', aliceFm);
+    const result = await runExtractCore(engine as unknown as BrainEngine, {
+      mode: 'all',
+      dir: tempDir,
+      slugs: ['people/alice-example'],
+    });
+    // alice's only potential edge is her frontmatter `source:`; with the gate off
+    // it must not be extracted (preserves the body-only incremental behavior).
+    expect(result.pages_processed).toBe(1);
+    expect(result.links_created).toBe(0);
+  });
+
+  test('10. includeFrontmatter: true extracts the frontmatter link on the incremental path', async () => {
+    await seedPage('companies/acme-example', '# acme');
+    await seedPage('people/alice-example', aliceFm);
+    const result = await runExtractCore(engine as unknown as BrainEngine, {
+      mode: 'all',
+      dir: tempDir,
+      slugs: ['people/alice-example'],
+      includeFrontmatter: true,
+    });
+    // Same page, gate on → the `source:` frontmatter edge is now extracted.
+    expect(result.pages_processed).toBe(1);
+    expect(result.links_created).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Problem

The autopilot/dream **cycle's extract phase** re-extracts only the slugs a sync changed (`extractForSlugs`), but it extracts **body links only**. A page's frontmatter link fields (`sources:` / `related:` etc.) are never re-extracted on the incremental path. So when frontmatter is edited externally (e.g. in Obsidian) and synced in, those edges silently **drift stale** relative to body edges.

Only two paths refresh frontmatter edges today: a `put_page` write, or a manual `gbrain extract links --include-frontmatter`. Plain `sync` + the cycle do not — so in a vault where frontmatter `sources:`/`related:` is curated heavily, the drift is continuous and operator-visible.

## Root cause

`extractLinksFromFile` already accepts and applies `{ includeFrontmatter }` per file. The incremental path just never threads the flag:

```ts
// extractForSlugs → src/commands/extract.ts
const links = await extractLinksFromFile(content, relPath, allSlugs, { globalBasename });
//                                                                     ^ includeFrontmatter dropped
```

`runExtractCore`'s `opts.slugs !== undefined` branch routes to `extractForSlugs` and never reaches the full-walk path, so the cycle never gets frontmatter extraction.

## Fix

Thread an `includeFrontmatter` flag from the cycle's extract dispatch through `ExtractOpts → extractForSlugs → extractLinksFromFile`. Because it's applied **per changed page inside the already-bounded slug set**, extraction stays incremental — no switch to a full DB scan. Cost = one extra frontmatter parse per *changed* page per cycle.

Gated behind a config key, **default off** so existing brains see zero behavior change on upgrade:

```
gbrain config set autopilot.incremental_extract_include_frontmatter true
```

## Relation to #2406

#2406 makes the *put_page* / *manual extract* paths resolve bracketed frontmatter values via `global_basename`. This PR closes the complementary gap on the *cycle/sync* path so externally-edited frontmatter stays fresh without a manual sweep. Edges land as `link_source='frontmatter'` (or `'frontmatter-basename'` once #2406's basename resolution is enabled). Together they make frontmatter edges first-class on every write path.

## Tests

Two regression cases added to `test/extract-incremental.test.ts` (PGLite, no DB connection):
- gate **off** → a frontmatter-only page yields `0 links` on the incremental path (body-only behavior preserved)
- `includeFrontmatter: true` → the `source:` frontmatter edge is extracted

`bun run verify` + the extract/link/cycle test surface pass locally.

## Note on the threading

`extractForSlugs` takes positional params; I added `includeFrontmatter` as a trailing optional (default `false`) to keep the change minimal and back-compat. Happy to refactor it to an opts object if you'd prefer that shape.