### PR TITLE
[codex] test supervisor degraded retry recovery

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -180,12 +180,15 @@ Deferred from the v0.42.41.0 fix wave (eng-reviewed as separate scope, not hotfi
 See plan + GSTACK REVIEW REPORT at
 `~/.claude/plans/system-instruction-you-are-working-zany-thacker.md`.
 
-- [ ] **P1 — supervisor: retry-with-backoff instead of hard stop on transient DB outages (#1994).**
+- [x] **P1 — supervisor: retry-with-backoff instead of hard stop on transient DB outages (#1994).**
   `max_crashes_exceeded` gives up permanently; a transient pooler blip that trips the
   counter wedges the supervisor until manual restart. **Why:** the #2034 reconnect fix
   makes the engine recover, but the supervisor still hard-stops. **Where:**
   `src/core/minions/supervisor.ts` crash-count loop — add exponential backoff with a
-  much higher (or no) permanent-give-up threshold for recoverable errors.
+  much higher (or no) permanent-give-up threshold for recoverable errors. **Completed:**
+  `ChildWorkerSupervisor` now treats `maxCrashes` as a soft degraded-retry budget,
+  emits `crash_budget_degraded`, and only permanently stops at the hard ceiling
+  (`GBRAIN_SUPERVISOR_HARD_STOP_CRASHES`, `0` = retry forever).
 - [ ] **P2 — PGLite `reindex-frontmatter` / backfill statement_timeout boost (#1963).**
   Community RCA: `SET LOCAL statement_timeout` is gated on `engine.kind === 'postgres'`,
   so PGLite inherits the 30s session default and trips on non-trivial batches; the CLI

--- a/test/child-worker-supervisor.test.ts
+++ b/test/child-worker-supervisor.test.ts
@@ -535,6 +535,54 @@ esac
         h.cleanup();
       }
     });
+
+    it('a stable respawn after a transient outage clears degraded mode before the hard ceiling', async () => {
+      const h = makeHarness(
+        'degraded-recovers',
+        `
+# First four runs model a transient DB outage that crosses the soft budget.
+# The fifth run exits non-zero after a stable interval; crashCount should reset
+# to 1 instead of marching toward the hard ceiling.
+exit 1
+`,
+      );
+      try {
+        const SIX_MIN = 6 * 60_000;
+        const timestamps = [
+          0, 1_000,              // crashCount 1
+          1_000, 2_000,          // crashCount 2
+          2_000, 3_000,          // crashCount 3: degraded warn
+          3_000, 4_000,          // crashCount 4: retry continues
+          4_000, 4_000 + SIX_MIN, // stable run resets crashCount to 1
+        ];
+        let idx = 0;
+        const fakeNow = () => timestamps[idx++] ?? timestamps[timestamps.length - 1];
+
+        const { events, maxCrashesFired } = await runUntilTerminal(h, {
+          maxCrashes: 3,
+          hardStopMaxCrashes: 6,
+          _backoffFloorMs: 1,
+          _now: fakeNow,
+          stopAfterEvents: 15,
+        });
+
+        expect(maxCrashesFired).toBeNull();
+        const exits = events.filter(
+          (e): e is Extract<ChildSupervisorEvent, { kind: 'worker_exited' }> =>
+            e.kind === 'worker_exited',
+        );
+        expect(exits.map((e) => e.crashCount)).toEqual([1, 2, 3, 4, 1]);
+
+        const degraded = events.filter(
+          (e): e is Extract<ChildSupervisorEvent, { kind: 'health_warn' }> =>
+            e.kind === 'health_warn' && e.reason === 'crash_budget_degraded',
+        );
+        expect(degraded.length).toBe(1);
+        expect(degraded[0]).toMatchObject({ count: 3, max: 3 });
+      } finally {
+        h.cleanup();
+      }
+    });
   });
 
   describe('issue #1801 — restartCurrentChild + killChild liveness fix', () => {


### PR DESCRIPTION
## Summary
- add a regression test for supervisor degraded retry recovery after transient crash bursts
- mark the stale #1994 TODO complete with the current soft-budget/hard-ceiling behavior

## Verification
- `bun test test/child-worker-supervisor.test.ts` (15 pass, 0 fail)
- `bun test test/supervisor.test.ts` (20 pass, 0 fail)
- `bun run verify` (30 checks green)

## Notes
- Direct push to `garrytan/gbrain` failed with 403 for the authenticated account, so this PR is opened from fork `frankr/gbrain-1`.
