### PR TITLE
Add local Ollama chat routing

### DIFF
--- a/docs/integrations/embedding-providers.md
+++ b/docs/integrations/embedding-providers.md
@@ -40,7 +40,7 @@ The resolved provider + dimensions get persisted to `~/.gbrain/config.json` atom
 | `deepseek` | (no embedding model — chat only) | — | — | — | — |
 | `groq` | (no embedding model — chat only) | — | — | — | — |
 
-**Note on local providers.** Ollama and llama-server have no required API key, so they don't show up in env-detection auto-pick. Pick them explicitly with `--embedding-model ollama:<model>` to avoid silently routing to a daemon that may not be running.
+**Note on local providers.** Ollama and llama-server have no required API key, so they don't show up in env-detection auto-pick. Pick them explicitly with `--embedding-model ollama:<model>` to avoid silently routing to a daemon that may not be running. Ollama can also run local chat/expansion models; set those routes explicitly with `gbrain config set models.chat ollama:<model>` and related per-task model keys.
 
 ## If first import fails
 
@@ -142,6 +142,24 @@ Set `ZHIPUAI_API_KEY`. Models: `embedding-3` (current; Matryoshka 256-2048 dims)
 No env required — Ollama runs unauthenticated locally. Optional `OLLAMA_BASE_URL` (default `http://localhost:11434/v1`) and `OLLAMA_API_KEY` (for auth-enabled deployments).
 
 Recipe ships with `nomic-embed-text` (768d, recommended), `mxbai-embed-large` (1024d), `all-minilm` (384d). `gbrain providers test --model ollama:nomic-embed-text` smoke-tests the local install.
+
+Ollama also exposes an OpenAI-compatible `/v1/chat/completions` endpoint, so gbrain can use local chat models for query expansion, `think`, facts extraction, and dream synthesis. A minimal local setup:
+
+```bash
+ollama pull nomic-embed-text
+ollama pull qwen2.5-coder:14b
+
+gbrain init --pglite --embedding-model ollama:nomic-embed-text --embedding-dimensions 768
+gbrain config set models.chat ollama:qwen2.5-coder:14b
+gbrain config set models.expansion ollama:qwen2.5-coder:14b
+gbrain config set models.think ollama:qwen2.5-coder:14b
+gbrain config set models.dream.synthesize ollama:qwen2.5-coder:14b
+gbrain config set models.dream.synthesize_verdict ollama:qwen2.5-coder:14b
+gbrain config set models.dream.patterns ollama:qwen2.5-coder:14b
+gbrain config set facts.extraction_model ollama:qwen2.5-coder:14b
+```
+
+The recipe marks Ollama chat as **not** tool-capable. That is enough for local reasoning flows, but not for gbrain's subagent/tool loop; keep `models.tier.subagent` on a provider with tool calling when you need that path.
 
 ### llama-server (local, llama.cpp)
 

--- a/src/core/ai/model-resolver.ts
+++ b/src/core/ai/model-resolver.ts
@@ -117,7 +117,7 @@ export function assertTouchpoint(
       `Provider "${recipe.id}" does not support touchpoint "${touchpoint}".`,
       touchpoint === 'embedding' && recipe.id === 'anthropic'
         ? 'Anthropic has no embedding model. Use openai or google for embeddings.'
-        : touchpoint === 'chat' && (recipe.id === 'voyage' || recipe.id === 'ollama')
+        : touchpoint === 'chat' && recipe.id === 'voyage'
           ? `${recipe.name} is configured here only for embeddings. Use openai/anthropic/google/deepseek/groq/together for chat.`
           : undefined,
     );

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -21,6 +21,20 @@ export const ollama: Recipe = {
       // OLLAMA_NUM_PARALLEL config; no static cap to declare. v0.32 (#779).
       no_batch_cap: true,
     },
+    expansion: {
+      models: ['qwen2.5-coder:14b'],
+      cost_per_1m_tokens_usd: 0,
+      price_last_verified: '2026-06-26',
+    },
+    chat: {
+      models: ['qwen2.5-coder:14b'],
+      supports_tools: false,
+      supports_subagent_loop: false,
+      supports_prompt_cache: false,
+      cost_per_1m_input_usd: 0,
+      cost_per_1m_output_usd: 0,
+      price_last_verified: '2026-06-26',
+    },
   },
-  setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` and `ollama serve`.',
+  setup_hint: 'Install Ollama from https://ollama.ai, then `ollama pull nomic-embed-text` for embeddings and `ollama pull qwen2.5-coder:14b` for local chat. Start it with `ollama serve`.',
 };

--- a/test/ai/capabilities.test.ts
+++ b/test/ai/capabilities.test.ts
@@ -24,6 +24,13 @@ describe('getProviderCapabilities (v0.38 Slice 1 — D6/D7 recipe-driven capabil
     expect(caps.maxContext).toBe(1000000); // Gemini 1.5 Pro
   });
 
+  it('returns local chat capabilities for Ollama without tool-loop support', () => {
+    const caps = getProviderCapabilities('ollama:qwen2.5-coder:14b');
+    expect(caps.supportsToolCalling).toBe(false);
+    expect(caps.supportsPromptCaching).toBe(false);
+    expect(caps.supportsParallelTools).toBe(false);
+  });
+
   it('honors Anthropic alias (undated → dated)', () => {
     const caps = getProviderCapabilities('anthropic:claude-haiku-4-5');
     expect(caps.supportsToolCalling).toBe(true);
@@ -56,6 +63,10 @@ describe('classifyCapabilities (D6 — three-tier capability verdict)', () => {
 
   it('returns degraded:no_caching for Google Gemini', () => {
     expect(classifyCapabilities('google:gemini-1.5-pro')).toBe('degraded:no_caching');
+  });
+
+  it('returns unusable:no_tools for Ollama subagent loops', () => {
+    expect(classifyCapabilities('ollama:qwen2.5-coder:14b')).toBe('unusable:no_tools');
   });
 
   it('returns unknown for unrecognized providers', () => {

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -29,7 +29,7 @@ import { AIConfigError } from '../../src/core/ai/errors.ts';
 import { listRecipes, getRecipe } from '../../src/core/ai/recipes/index.ts';
 
 describe('chat touchpoint — recipe registry', () => {
-  test('all six chat-capable providers ship a chat touchpoint with supports_subagent_loop', () => {
+  test('all hosted tool-loop providers ship a chat touchpoint with supports_subagent_loop', () => {
     const expected = ['anthropic', 'openai', 'google', 'deepseek', 'groq', 'together'];
     for (const id of expected) {
       const r = getRecipe(id);
@@ -51,12 +51,21 @@ describe('chat touchpoint — recipe registry', () => {
     }
   });
 
-  test('embedding-only providers (voyage, ollama) do NOT declare chat', () => {
+  test('Voyage remains embedding-only', () => {
     expect(getRecipe('voyage')!.touchpoints.chat).toBeUndefined();
-    expect(getRecipe('ollama')!.touchpoints.chat).toBeUndefined();
+  });
+
+  test('Ollama declares local chat without subagent tool-loop support', () => {
+    const chat = getRecipe('ollama')!.touchpoints.chat;
+    expect(chat).toBeDefined();
+    expect(chat!.models).toContain('qwen2.5-coder:14b');
+    expect(chat!.supports_tools).toBe(false);
+    expect(chat!.supports_subagent_loop).toBe(false);
+    expect(chat!.supports_prompt_cache).toBe(false);
   });
 
   test('openai-compat chat recipes have base_url_default', () => {
+    expect(getRecipe('ollama')!.base_url_default).toBe('http://localhost:11434/v1');
     expect(getRecipe('deepseek')!.base_url_default).toBe('https://api.deepseek.com/v1');
     expect(getRecipe('groq')!.base_url_default).toBe('https://api.groq.com/openai/v1');
     expect(getRecipe('together')!.base_url_default).toBe('https://api.together.xyz/v1');
@@ -105,12 +114,11 @@ describe('chat touchpoint — model resolver + aliases (Codex F-OV-5)', () => {
     expect(() => assertTouchpoint(getRecipe('openai')!, 'chat', 'gpt-5.2')).not.toThrow();
     expect(() => assertTouchpoint(getRecipe('google')!, 'chat', 'gemini-2.0-flash')).not.toThrow();
     expect(() => assertTouchpoint(getRecipe('deepseek')!, 'chat', 'deepseek-chat')).not.toThrow();
+    expect(() => assertTouchpoint(getRecipe('ollama')!, 'chat', 'qwen2.5-coder:14b')).not.toThrow();
   });
 
   test('assertTouchpoint rejects chat on embedding-only providers with a fix hint', () => {
     expect(() => assertTouchpoint(getRecipe('voyage')!, 'chat', 'voyage-3'))
-      .toThrow(AIConfigError);
-    expect(() => assertTouchpoint(getRecipe('ollama')!, 'chat', 'nomic-embed-text'))
       .toThrow(AIConfigError);
   });
 
@@ -127,6 +135,7 @@ describe('chat touchpoint — model resolver + aliases (Codex F-OV-5)', () => {
   test('assertTouchpoint accepts arbitrary model on openai-compat tier', () => {
     // openai-compat lets users pass models not declared in the recipe (provider may host more)
     expect(() => assertTouchpoint(getRecipe('groq')!, 'chat', 'some-future-model')).not.toThrow();
+    expect(() => assertTouchpoint(getRecipe('ollama')!, 'chat', 'locally-installed-model')).not.toThrow();
   });
 });
 

--- a/test/ai/recipe-ollama.test.ts
+++ b/test/ai/recipe-ollama.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Ollama recipe smoke.
+ *
+ * Pins the local-first contract:
+ *   - no hosted credentials are required
+ *   - embeddings use the local /v1 embeddings endpoint
+ *   - chat + expansion can use Ollama's OpenAI-compatible /v1/chat/completions
+ *   - chat is intentionally not marked as subagent/tool-loop capable
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+import { defaultResolveAuth } from '../../src/core/ai/gateway.ts';
+import { assertTouchpoint } from '../../src/core/ai/model-resolver.ts';
+
+describe('recipe: ollama', () => {
+  test('registered with local OpenAI-compatible shape', () => {
+    const r = getRecipe('ollama');
+    expect(r).toBeDefined();
+    expect(r!.id).toBe('ollama');
+    expect(r!.tier).toBe('openai-compat');
+    expect(r!.implementation).toBe('openai-compatible');
+    expect(r!.base_url_default).toBe('http://localhost:11434/v1');
+    expect(r!.auth_env?.required ?? []).toEqual([]);
+    expect(r!.auth_env?.optional ?? []).toContain('OLLAMA_BASE_URL');
+    expect(r!.auth_env?.optional ?? []).toContain('OLLAMA_API_KEY');
+  });
+
+  test('declares local embedding, expansion, and chat touchpoints', () => {
+    const r = getRecipe('ollama')!;
+
+    expect(r.touchpoints.embedding).toBeDefined();
+    expect(r.touchpoints.embedding!.models).toContain('nomic-embed-text');
+    expect(r.touchpoints.embedding!.default_dims).toBe(768);
+    expect(r.touchpoints.embedding!.cost_per_1m_tokens_usd).toBe(0);
+
+    expect(r.touchpoints.expansion).toBeDefined();
+    expect(r.touchpoints.expansion!.models).toContain('qwen2.5-coder:14b');
+    expect(r.touchpoints.expansion!.cost_per_1m_tokens_usd).toBe(0);
+
+    expect(r.touchpoints.chat).toBeDefined();
+    expect(r.touchpoints.chat!.models).toContain('qwen2.5-coder:14b');
+    expect(r.touchpoints.chat!.supports_tools).toBe(false);
+    expect(r.touchpoints.chat!.supports_subagent_loop).toBe(false);
+    expect(r.touchpoints.chat!.supports_prompt_cache).toBe(false);
+    expect(r.touchpoints.chat!.cost_per_1m_input_usd).toBe(0);
+    expect(r.touchpoints.chat!.cost_per_1m_output_usd).toBe(0);
+  });
+
+  test('model resolver accepts local chat and expansion models', () => {
+    const r = getRecipe('ollama')!;
+
+    expect(() => assertTouchpoint(r, 'chat', 'qwen2.5-coder:14b')).not.toThrow();
+    expect(() => assertTouchpoint(r, 'expansion', 'qwen2.5-coder:14b')).not.toThrow();
+    expect(() => assertTouchpoint(r, 'chat', 'locally-installed-model')).not.toThrow();
+  });
+
+  test('default auth: no env -> "Bearer unauthenticated"', () => {
+    const r = getRecipe('ollama')!;
+    const auth = defaultResolveAuth(r, {}, 'chat');
+    expect(auth.headerName).toBe('Authorization');
+    expect(auth.token).toBe('Bearer unauthenticated');
+  });
+
+  test('default auth: OLLAMA_API_KEY set -> "Bearer <key>"', () => {
+    const r = getRecipe('ollama')!;
+    const auth = defaultResolveAuth(r, { OLLAMA_API_KEY: 'sk-ollama-fake' }, 'chat');
+    expect(auth.headerName).toBe('Authorization');
+    expect(auth.token).toBe('Bearer sk-ollama-fake');
+  });
+});


### PR DESCRIPTION
## Problem

GBrain already has a local-first story for embeddings through Ollama, but higher-level reasoning paths still effectively require a hosted chat provider. That means users who choose Ollama for privacy, cost control, or offline/local development can embed and search locally, but cannot use the same local stack for query expansion, `think`, facts extraction, or dream synthesis.

Ollama exposes an OpenAI-compatible `/v1/chat/completions` API, so gbrain can route those reasoning calls locally without adding a new transport.

## Summary

- add Ollama expansion and chat touchpoints using the local OpenAI-compatible API
- mark Ollama chat as non-tool/non-subagent-loop capable while allowing local reasoning flows
- document local Ollama setup for embeddings, chat, dream, think, and facts extraction
- add recipe, gateway, and capability regression coverage

## Notes

This does not make Ollama a subagent/tool-loop provider. The recipe explicitly marks tool calling, prompt caching, and subagent-loop support as unsupported. Users who need gbrain's subagent/tool loop should still route that tier to a tool-capable provider.

## Testing

- `bun test test/ai/recipe-ollama.test.ts test/ai/gateway-chat.test.ts test/ai/capabilities.test.ts`
- `bun test test/ai/recipes-existing-regression.test.ts test/providers.test.ts test/init-env-detection.test.ts`
- `bun run typecheck`
- `bun src/cli.ts providers list`
