### PR TITLE
fix(import): skip marked.lexer on fence-less pages to avoid bulk-import OOM (#2437)

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -123,7 +123,9 @@ async function extractFencedChunks(
   // accumulated chunk/embedding memory and can OOM the worker, and the
   // try/catch below cannot rescue an OOM (it is process death, not a throw).
   // Skip the lexer entirely when no fence marker (``` or ~~~) is present.
-  if (!/(^|\n)[ \t]{0,3}(```|~~~)/.test(markdown)) return out;
+  // The `\r` in the line-start class mirrors marked's own `\r\n|\r → \n`
+  // normalization, so CR/CRLF-only documents don't lose a real fence.
+  if (!/(^|[\r\n])[ \t]{0,3}(```|~~~)/.test(markdown)) return out;
   let tokens: ReturnType<typeof marked.lexer>;
   try {
     tokens = marked.lexer(markdown);

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -115,6 +115,15 @@ async function extractFencedChunks(
   startChunkIndex: number,
 ): Promise<ChunkInput[]> {
   const out: ChunkInput[] = [];
+  // Fast path: most pages (prose, tables, converted docs) contain no code
+  // fence at all, so there is nothing for this function to extract. marked's
+  // lexer still allocates transient memory proportional to page size on every
+  // call — a ~2MB table-heavy page spikes ~110MB of heap just to produce zero
+  // fenced chunks. During bulk import those per-page spikes stack on top of
+  // accumulated chunk/embedding memory and can OOM the worker, and the
+  // try/catch below cannot rescue an OOM (it is process death, not a throw).
+  // Skip the lexer entirely when no fence marker (``` or ~~~) is present.
+  if (!/(^|\n)[ \t]{0,3}(```|~~~)/.test(markdown)) return out;
   let tokens: ReturnType<typeof marked.lexer>;
   try {
     tokens = marked.lexer(markdown);

--- a/test/fence-extraction.test.ts
+++ b/test/fence-extraction.test.ts
@@ -136,4 +136,32 @@ echo hi
     const fenceChunks = chunks.filter(c => c.chunk_source === 'fenced_code');
     expect(fenceChunks.length).toBe(0);
   });
+
+  // #2437 — extractFencedChunks skips marked.lexer entirely when the body has
+  // no fence marker (the lexer transiently allocates ~60x the page size, which
+  // OOMs the import worker under memory pressure). These two guard that the
+  // fast-path neither breaks tilde fences nor lexes fence-less pages.
+  test('tilde-fenced (~~~) code is still extracted after the no-fence fast-path (#2437)', async () => {
+    const md = 'Docs.\n\n~~~ts\nexport const x = 1;\n~~~\n';
+    await importFromContent(engine, 'guides/fence-tilde', md, { noEmbed: true });
+    const chunks = await engine.getChunks('guides/fence-tilde');
+    const fenceChunks = chunks.filter(c => c.chunk_source === 'fenced_code');
+    expect(fenceChunks.length).toBeGreaterThan(0);
+    expect(fenceChunks[0]!.language).toBe('typescript');
+  });
+
+  test('large fence-less table page imports with zero fenced chunks (no lexer pass) (#2437)', async () => {
+    const cols = 16;
+    const header = '| ' + Array.from({ length: cols }, (_, i) => 'col' + i).join(' | ') + ' |';
+    const sep = '| ' + Array.from({ length: cols }, () => '---').join(' | ') + ' |';
+    const body = Array.from({ length: 2000 }, (_, r) =>
+      '| ' + Array.from({ length: cols }, (_, c) => 'v' + r + '_' + c).join(' | ') + ' |').join('\n');
+    const md = '# Overview\n\n' + header + '\n' + sep + '\n' + body + '\n';
+    // sanity: the page is genuinely fence-less, so the fast-path applies
+    expect(/(^|\n)[ \t]{0,3}(```|~~~)/.test(md)).toBe(false);
+    await importFromContent(engine, 'guides/fence-less-table', md, { noEmbed: true });
+    const chunks = await engine.getChunks('guides/fence-less-table');
+    const fenceChunks = chunks.filter(c => c.chunk_source === 'fenced_code');
+    expect(fenceChunks.length).toBe(0);
+  });
 });

--- a/test/fence-extraction.test.ts
+++ b/test/fence-extraction.test.ts
@@ -150,6 +150,17 @@ echo hi
     expect(fenceChunks[0]!.language).toBe('typescript');
   });
 
+  test('CR-only (\\r) line endings still extract a fenced chunk (#2437)', async () => {
+    // marked normalizes \r → \n before lexing, so the fast-path's fence probe
+    // must too; otherwise a classic-Mac line-ended page loses its fenced code.
+    const md = 'intro\r```ts\rexport const x = 1;\r```\r';
+    await importFromContent(engine, 'guides/fence-cr', md, { noEmbed: true });
+    const chunks = await engine.getChunks('guides/fence-cr');
+    const fenceChunks = chunks.filter(c => c.chunk_source === 'fenced_code');
+    expect(fenceChunks.length).toBeGreaterThan(0);
+    expect(fenceChunks[0]!.language).toBe('typescript');
+  });
+
   test('large fence-less table page imports with zero fenced chunks (no lexer pass) (#2437)', async () => {
     const cols = 16;
     const header = '| ' + Array.from({ length: cols }, (_, i) => 'col' + i).join(' | ') + ' |';
@@ -158,7 +169,7 @@ echo hi
       '| ' + Array.from({ length: cols }, (_, c) => 'v' + r + '_' + c).join(' | ') + ' |').join('\n');
     const md = '# Overview\n\n' + header + '\n' + sep + '\n' + body + '\n';
     // sanity: the page is genuinely fence-less, so the fast-path applies
-    expect(/(^|\n)[ \t]{0,3}(```|~~~)/.test(md)).toBe(false);
+    expect(/(^|[\r\n])[ \t]{0,3}(```|~~~)/.test(md)).toBe(false);
     await importFromContent(engine, 'guides/fence-less-table', md, { noEmbed: true });
     const chunks = await engine.getChunks('guides/fence-less-table');
     const fenceChunks = chunks.filter(c => c.chunk_source === 'fenced_code');


### PR DESCRIPTION
Fixes #2437.

## What & why

`extractFencedChunks()` in `src/core/import-file.ts` calls `marked.lexer()` on **every** page body to extract fenced code blocks. `marked.lexer` allocates transient memory proportional to page size *even when a page contains no code fence at all*. On large table-/document-heavy pages this transient spike is big enough that, during a bulk `import`/`sync` on an already-loaded brain, it can OOM the worker — and the existing `try/catch` around the lexer cannot rescue an OOM (it is process death, not a throwable error).

On a representative brain **~99% of importable pages contain no code fence**, so the lexer pass is pure wasted work on them, and the largest no-fence pages (converted tables/docs) are exactly the ones with the biggest transient spike.

## The change

A one-line fast-path at the top of `extractFencedChunks()`:

```ts
// no fence marker -> nothing to extract; skip the lexer (and its transient spike)
if (!/(^|\n)[ \t]{0,3}(```|~~~)/.test(markdown)) return out;
```

- Zero correctness cost: a page with no ` ``` ` / `~~~` fence cannot produce a fenced chunk.
- Matches **both** ` ``` ` and `~~~` so tilde-fenced code still extracts (covered by a new test).

## Reproduction

```js
// node --max-old-space-size=80 repro.mjs
import { marked } from 'marked';
const rows = 12000, cols = 16;
const header = '| ' + Array.from({length: cols}, (_, i) => 'col' + i).join(' | ') + ' |';
const sep    = '| ' + Array.from({length: cols}, () => '---').join(' | ') + ' |';
const body   = Array.from({length: rows}, (_, r) =>
  '| ' + Array.from({length: cols}, (_, c) => 'v' + r + '_' + c).join(' | ') + ' |').join('\n');
const md = '# Overview\n\n' + header + '\n' + sep + '\n' + body + '\n';  // NO ``` fence
marked.lexer(md);                                                       // <-- transient spike here
```

| heap cap | before this PR |
|---|---|
| `--max-old-space-size=512` | OK — ~110 MB heap for **3 tokens** (~60x input amplification) |
| `--max-old-space-size=80`  | **FATAL — JS heap out of memory** inside `marked.lexer` |

In a fresh process with ample headroom no single page OOMs; the failure appears once free heap drops below the per-page transient need (worker already holding a large brain's chunk/embedding working set) — which matches the field report (surfaced only when the brain was substantially full, not on a cold import).

## Testing

- `bun test test/fence-extraction.test.ts` → **9 pass** (7 existing + 2 new regression tests)
- `bun run typecheck` → clean
- New tests: (1) tilde-fenced (`~~~`) code still extracts; (2) a large fence-less table page imports with zero fenced chunks.

## Scope / limitation (intentionally honest)

This removes the transient-allocation surface for the common fence-less case (the observed incident). It does **not** make `marked.lexer` safe for pages that *do* contain a fence — a structurally pathological fenced page (e.g. very deeply nested lists) can still OOM. A complete hardening would additionally cap input size / nesting before lexing; happy to follow up with that as a separate PR.

## Notes for maintainers

- No `VERSION` / `CHANGELOG` bump in this PR — left to your release flow so it can pick the version slot without a merge conflict.

