### PR TITLE
fix(durability): set rebase.autoStash during harden so pull --rebase tolerates uncommitted write-throughs

### DIFF
--- a/src/core/brain-repo-durability.ts
+++ b/src/core/brain-repo-durability.ts
@@ -6,6 +6,8 @@
  * sessions edit a stale tree. The moment gbrain is given a PAT + a GitHub URL
  * for a brain repo, `hardenBrainRepo` makes durability work, idempotently:
  *
+ *   0. set `rebase.autoStash` so `git pull --rebase` tolerates uncommitted
+ *      write-throughs (otherwise the first unstaged page wedges every commit-push)
  *   1. pull current state (divergence-safe rebase; skip-on-dirty)
  *   2. repo-scoped credential wiring (reuse an existing helper if present)
  *   3. LOCAL untracked post-commit hook (best-effort background auto-push)
@@ -609,6 +611,17 @@ export async function hardenBrainRepo(opts: HardenOpts): Promise<DurabilityRepor
   const log = (l: string) => opts.logger?.(redact(l));
 
   if (!isGitRepo(repoPath)) throw new Error(`not a git repo: ${repoPath}`);
+
+  // Make `git pull --rebase` tolerate uncommitted write-throughs. `gbrain capture`
+  // writes the DB row + clone .md but does NOT commit (the writer is meant to run
+  // scripts/brain-commit-push.sh). Concurrent captures and the autopilot/dream-cycle
+  // passes therefore leave uncommitted tracked pages in the working tree. The committed
+  // helper (and the durability rules) start with `git pull --rebase`, which HARD-FAILS
+  // on any unstaged tracked change ("cannot pull with rebase: You have unstaged
+  // changes") — so the first stuck file wedges every subsequent commit-push and pages
+  // stop reaching the remote. `rebase.autoStash` makes that pull stash→rebase→reapply
+  // instead of failing. Idempotent; repo-scoped (local config only).
+  if (!dryRun) { try { gitConfigSet(repoPath, 'rebase.autoStash', 'true'); } catch { /* non-fatal */ } }
 
   const branch = opts.branch || detectDefaultBranch(repoPath);
   const steps: DurabilityStep[] = [];


### PR DESCRIPTION
## Problem

`gbrain capture` / `put_page` writes the DB row **and** the clone `.md`, but does **not** commit — durability is the writer's job via `scripts/brain-commit-push.sh`. In practice, concurrent captures and gbrain's own autopilot/dream-cycle passes leave **uncommitted tracked pages** in the brain clone's working tree.

The committed helper (`brain-commit-push.sh`) and the durability rules both start with `git pull --rebase`, which **hard-fails on any unstaged tracked change**:

```
error: cannot pull with rebase: You have unstaged changes.
error: please commit or stash them.
```

Once one uncommitted page is present, that first `git pull --rebase` fails, so **every subsequent commit-push wedges** — including fully-compliant collectors that *do* call the helper. Pages then stop reaching GitHub entirely.

I hit this live on a headless OpenClaw brain: **29 pages (including a real meeting transcript) were stuck in the DB + clone but never pushed for ~3h**, until a manual `git pull --rebase` + push cleared the backlog. It recurs whenever an uncommitted write-through accumulates.

## Fix

Set `rebase.autoStash` (repo-scoped, idempotent) during `hardenBrainRepo`, before the pull step — so the harden's own pull, the committed helper's pull, and the agent durability rules' `git pull --rebase` all **stash → rebase → reapply** instead of failing on a dirty tree.

- One statement, reuses the existing `gitConfigSet` helper.
- Repo-scoped local config; honors `dryRun`; non-fatal.
- Idempotent — re-running harden is a no-op on the config.

Verified RED→GREEN on the same git: with an uncommitted file, `git pull --rebase` errors as above; after `git config rebase.autoStash true`, the same pull succeeds.

I could not run the full gbrain test suite from my environment, so this is offered honest-blocked on CI/tests — happy to adjust placement (e.g. promote it to a reported harden `StepName`) if you'd prefer it surfaced as its own step.
