### PR TITLE
[codex] Support DashScope text-embedding-v4 config

### DIFF
--- a/docs/integrations/embedding-providers.md
+++ b/docs/integrations/embedding-providers.md
@@ -129,7 +129,22 @@ MiniMax's API takes a `type: 'db' | 'query'` field for asymmetric retrieval. v0.
 
 ### DashScope (Alibaba)
 
-Set `DASHSCOPE_API_KEY`. International endpoint at `dashscope-intl.aliyuncs.com` by default; override `provider_base_urls.dashscope` for the China endpoint. Models: `text-embedding-v3` (current; Matryoshka 64-1024 dims), `text-embedding-v2`.
+Set `DASHSCOPE_API_KEY`. International endpoint at `dashscope-intl.aliyuncs.com` by default; override `provider_base_urls.dashscope` for a China-region Model Studio workspace endpoint, for example `https://<workspace-id>.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`.
+
+Models: `text-embedding-v4` (current; Matryoshka 64-2048 dims), `text-embedding-v3`, `text-embedding-v2`.
+
+For stdio MCP launches that do not inherit shell env vars, store the key in the file-plane config:
+
+```json
+{
+  "embedding_model": "dashscope:text-embedding-v4",
+  "embedding_dimensions": 1024,
+  "provider_base_urls": {
+    "dashscope": "https://<workspace-id>.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+  },
+  "dashscope_api_key": "<key in ~/.gbrain/config.json mode 0600>"
+}
+```
 
 CJK-dominant content tokenizes denser than OpenAI tiktoken; gbrain declares `chars_per_token: 2` so the batch pre-split leaves headroom.
 

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -9,6 +9,8 @@ import { listRecipes, getRecipe } from '../core/ai/recipes/index.ts';
 import { configureGateway, embedOne, isAvailable as gwIsAvailable, chat as gwChat } from '../core/ai/gateway.ts';
 import { probeOllama, probeLMStudio } from '../core/ai/probes.ts';
 import { loadConfig } from '../core/config.ts';
+import type { GBrainConfig } from '../core/config.ts';
+import { buildGatewayConfig } from '../core/ai/build-gateway-config.ts';
 import { AIConfigError, AITransientError } from '../core/ai/errors.ts';
 import type { Recipe } from '../core/ai/types.ts';
 
@@ -33,15 +35,7 @@ interface ProviderOption {
 
 function configureFromEnv(): void {
   const config = loadConfig();
-  configureGateway({
-    embedding_model: config?.embedding_model,
-    embedding_dimensions: config?.embedding_dimensions,
-    expansion_model: config?.expansion_model,
-    chat_model: config?.chat_model,
-    chat_fallback_chain: config?.chat_fallback_chain,
-    base_urls: config?.provider_base_urls,
-    env: { ...process.env },
-  });
+  configureGateway(buildGatewayConfig(config ?? ({} as GBrainConfig)));
 }
 
 export function envReady(recipe: Recipe, env: NodeJS.ProcessEnv = process.env): boolean {

--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -28,6 +28,7 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   const envFromConfig: Record<string, string> = {};
   if (c.openai_api_key) envFromConfig.OPENAI_API_KEY = c.openai_api_key;
   if (c.anthropic_api_key) envFromConfig.ANTHROPIC_API_KEY = c.anthropic_api_key;
+  if (c.dashscope_api_key) envFromConfig.DASHSCOPE_API_KEY = c.dashscope_api_key;
   // v0.37 fix wave (CDX2-5+6): ZE became the default provider in v0.36 but
   // the env-mapping at this seam never picked it up. `gbrain config set
   // zeroentropy_api_key X` wrote DB plane (ignored by gateway). The file-

--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -212,12 +212,12 @@ export function dimsProviderOptions(
         }
         return { openaiCompatible: { dimensions: dims } };
       }
-      // DashScope text-embedding-v3 (Matryoshka 64-1024) and Zhipu
-      // embedding-3 (Matryoshka 256-2048) both accept `dimensions` on the
-      // OpenAI-compat path. Without this, user-selected non-default dims are
-      // silently ignored and the provider returns its default size.
+      // DashScope text-embedding-v3/v4 and Zhipu embedding-3 accept
+      // `dimensions` on the OpenAI-compat path. Without this, user-selected
+      // non-default dims are silently ignored and the provider returns its
+      // default size.
       // Symmetric retrieval — inputType ignored.
-      if (modelId === 'text-embedding-v3' || modelId === 'embedding-3') {
+      if (modelId === 'text-embedding-v3' || modelId === 'text-embedding-v4' || modelId === 'embedding-3') {
         return { openaiCompatible: { dimensions: dims } };
       }
       // MiniMax embo-01 takes a `type: 'db' | 'query'` field for asymmetric

--- a/src/core/ai/recipes/dashscope.ts
+++ b/src/core/ai/recipes/dashscope.ts
@@ -2,8 +2,8 @@ import type { Recipe } from '../types.ts';
 
 /**
  * Alibaba DashScope (灵积). OpenAI-compatible /embeddings endpoint at
- * dashscope-intl.aliyuncs.com. Hosts text-embedding-v2 (older) and
- * text-embedding-v3 (current; Matryoshka-aware up to 1024 dims).
+ * dashscope-intl.aliyuncs.com. Hosts text-embedding-v2 (older),
+ * text-embedding-v3, and text-embedding-v4 (Qwen3-Embedding series).
  *
  * Reference: https://help.aliyun.com/zh/model-studio/getting-started/
  *
@@ -24,9 +24,9 @@ export const dashscope: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['text-embedding-v3', 'text-embedding-v2'],
+      models: ['text-embedding-v4', 'text-embedding-v3', 'text-embedding-v2'],
       default_dims: 1024,
-      dims_options: [64, 128, 256, 512, 768, 1024],
+      dims_options: [64, 128, 256, 512, 768, 1024, 1536, 2048],
       // Alibaba doesn't publish a hard batch-token cap for the OpenAI-compat
       // path. Conservative declaration so the gateway pre-splits before
       // hitting whatever undocumented server-side limit exists.

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -31,6 +31,7 @@ export interface GBrainConfig {
   database_path?: string;
   openai_api_key?: string;
   anthropic_api_key?: string;
+  dashscope_api_key?: string;
   /**
    * ZeroEntropy API key. v0.37 fix wave (CDX2-5+6): ZE became the default
    * embedding + reranker provider in v0.36 but lacked a file-plane config
@@ -815,6 +816,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'database_path',
   'openai_api_key',
   'anthropic_api_key',
+  'dashscope_api_key',
   'embedding_model',
   'embedding_dimensions',
   'embedding_disabled',

--- a/test/ai/build-gateway-config.test.ts
+++ b/test/ai/build-gateway-config.test.ts
@@ -84,4 +84,22 @@ describe('buildGatewayConfig env-baseURL passthrough', () => {
       },
     );
   });
+
+  test('file-plane dashscope_api_key flows through to gateway env', async () => {
+    await withEnv({ DASHSCOPE_API_KEY: undefined }, async () => {
+      const cfg = buildGatewayConfig({
+        dashscope_api_key: 'sk-dashscope-file-plane',
+      } as unknown as GBrainConfig);
+      expect(cfg.env?.DASHSCOPE_API_KEY).toBe('sk-dashscope-file-plane');
+    });
+  });
+
+  test('process env still wins over file-plane dashscope_api_key', async () => {
+    await withEnv({ DASHSCOPE_API_KEY: 'sk-dashscope-env' }, async () => {
+      const cfg = buildGatewayConfig({
+        dashscope_api_key: 'sk-dashscope-file-plane',
+      } as unknown as GBrainConfig);
+      expect(cfg.env?.DASHSCOPE_API_KEY).toBe('sk-dashscope-env');
+    });
+  });
 });

--- a/test/ai/recipe-dashscope.test.ts
+++ b/test/ai/recipe-dashscope.test.ts
@@ -20,16 +20,17 @@ describe('recipe: dashscope', () => {
     expect(r!.auth_env?.required).toEqual(['DASHSCOPE_API_KEY']);
   });
 
-  test('embedding touchpoint declares text-embedding-v3 first + 1024 dims', () => {
+  test('embedding touchpoint declares text-embedding-v4 first + 1024 dims', () => {
     const r = getRecipe('dashscope')!;
     expect(r.touchpoints.embedding).toBeDefined();
-    expect(r.touchpoints.embedding!.models[0]).toBe('text-embedding-v3');
+    expect(r.touchpoints.embedding!.models[0]).toBe('text-embedding-v4');
+    expect(r.touchpoints.embedding!.models).toContain('text-embedding-v3');
     expect(r.touchpoints.embedding!.models).toContain('text-embedding-v2');
     expect(r.touchpoints.embedding!.default_dims).toBe(1024);
-    expect(r.touchpoints.embedding!.dims_options).toEqual([64, 128, 256, 512, 768, 1024]);
-    // Matryoshka: every dims option ≤ 2000 (HNSW-compatible).
+    expect(r.touchpoints.embedding!.dims_options).toEqual([64, 128, 256, 512, 768, 1024, 1536, 2048]);
+    // 2048 works but is above pgvector's HNSW cap, so exact scan fallback is expected.
     for (const d of r.touchpoints.embedding!.dims_options ?? []) {
-      expect(d).toBeLessThanOrEqual(2000);
+      expect(d).toBeLessThanOrEqual(2048);
     }
   });
 
@@ -55,8 +56,8 @@ describe('recipe: dashscope', () => {
     expect(r.touchpoints.embedding!.chars_per_token).toBeGreaterThan(0);
   });
 
-  test('dimsProviderOptions threads dimensions for text-embedding-v3 (Matryoshka)', async () => {
-    // Codex finding #1: DashScope text-embedding-v3 is Matryoshka 64-1024.
+  test('dimsProviderOptions threads dimensions for text-embedding-v3/v4 (Matryoshka)', async () => {
+    // Codex finding #1: DashScope text-embedding-v3/v4 are Matryoshka.
     // Without `dimensions` on the wire, user-selected non-default dims are
     // silently ignored and the provider returns its default size.
     const { dimsProviderOptions } = await import('../../src/core/ai/dims.ts');
@@ -64,6 +65,10 @@ describe('recipe: dashscope', () => {
       .toEqual({ openaiCompatible: { dimensions: 512 } });
     expect(dimsProviderOptions('openai-compatible', 'text-embedding-v3', 1024))
       .toEqual({ openaiCompatible: { dimensions: 1024 } });
+    expect(dimsProviderOptions('openai-compatible', 'text-embedding-v4', 1024))
+      .toEqual({ openaiCompatible: { dimensions: 1024 } });
+    expect(dimsProviderOptions('openai-compatible', 'text-embedding-v4', 2048))
+      .toEqual({ openaiCompatible: { dimensions: 2048 } });
     // text-embedding-v2 is fixed-dim; no passthrough.
     expect(dimsProviderOptions('openai-compatible', 'text-embedding-v2', 1024))
       .toBeUndefined();

--- a/test/config-set.test.ts
+++ b/test/config-set.test.ts
@@ -15,6 +15,7 @@ describe('KNOWN_CONFIG_KEYS', () => {
     expect(KNOWN_CONFIG_KEYS).toContain('embedding_model');
     expect(KNOWN_CONFIG_KEYS).toContain('embedding_dimensions');
     expect(KNOWN_CONFIG_KEYS).toContain('embedding_disabled');  // v0.37 D9
+    expect(KNOWN_CONFIG_KEYS).toContain('dashscope_api_key');
     expect(KNOWN_CONFIG_KEYS).toContain('expansion_model');
     expect(KNOWN_CONFIG_KEYS).toContain('chat_model');
   });

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -5,10 +5,19 @@
  * gateway / loadConfig; E2E exercises those.
  */
 
-import { describe, test, expect } from 'bun:test';
-import { formatRecipeTable, envReady } from '../src/commands/providers.ts';
+import { afterEach, describe, test, expect } from 'bun:test';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { formatRecipeTable, envReady, runProviders } from '../src/commands/providers.ts';
 import { listRecipes, getRecipe } from '../src/core/ai/recipes/index.ts';
+import { resetGateway, __setEmbedTransportForTests } from '../src/core/ai/gateway.ts';
 import type { Recipe } from '../src/core/ai/types.ts';
+import { emptyHome, withEnv } from './helpers/with-env.ts';
+
+afterEach(() => {
+  __setEmbedTransportForTests(null);
+  resetGateway();
+});
 
 describe('envReady', () => {
   test('true when all required env vars set', () => {
@@ -92,5 +101,38 @@ describe('formatRecipeTable', () => {
     expect(lines[2]).toContain('✓ ready');
     expect(lines[3]).toContain('zeroentropyai');
     expect(lines[3]).toContain('✗ missing ZEROENTROPY_API_KEY');
+  });
+});
+
+describe('providers test command', () => {
+  test('uses file-plane DashScope key and provider_base_urls from buildGatewayConfig', async () => {
+    const home = emptyHome();
+    const configDir = join(home, '.gbrain');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), JSON.stringify({
+      embedding_model: 'dashscope:text-embedding-v4',
+      embedding_dimensions: 1024,
+      dashscope_api_key: 'sk-dashscope-file-plane',
+      provider_base_urls: {
+        dashscope: 'https://workspace.example.test/compatible-mode/v1',
+      },
+    }));
+
+    const calls: Array<{ modelId: string; providerOptions: any }> = [];
+    __setEmbedTransportForTests(async ({ model, values, providerOptions }: any) => {
+      calls.push({ modelId: model?.modelId ?? '<unknown>', providerOptions });
+      return {
+        embeddings: values.map(() => new Array(1024).fill(0)),
+        usage: { tokens: 0 },
+      } as any;
+    });
+
+    await withEnv({ GBRAIN_HOME: home, DASHSCOPE_API_KEY: undefined }, async () => {
+      await runProviders('test', ['--json']);
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].modelId).toBe('text-embedding-v4');
+    expect(calls[0].providerOptions?.openaiCompatible?.dimensions).toBe(1024);
   });
 });


### PR DESCRIPTION
## Summary

Adds first-class DashScope `text-embedding-v4` support and makes DashScope config work for stdio MCP launches.

Changes:
- add `text-embedding-v4` to the DashScope recipe
- allow DashScope dimensions up to `2048`
- pass `dimensions` for DashScope v4 on the OpenAI-compatible embedding path
- add file-plane `dashscope_api_key` support
- make `gbrain providers test` use the shared gateway config builder
- document China-region Model Studio workspace base URLs

## Why

China-region Alibaba Model Studio workspaces use a workspace-specific OpenAI-compatible base URL, for example:

```text
https://<workspace-id>.cn-beijing.maas.aliyuncs.com/compatible-mode/v1
```

`text-embedding-v4` works against that endpoint. Before this patch, a local setup needed manual edits because:

- the DashScope recipe only listed v2/v3
- v4 dimensions were not passed through
- `providers test` could disagree with `put`, `search`, and `serve`
- `gbrain serve` launched by Claude Code MCP could not see DashScope credentials unless the host process exported `DASHSCOPE_API_KEY`

## Validation

```bash
bun test test/ai/recipe-dashscope.test.ts test/ai/build-gateway-config.test.ts test/providers.test.ts test/config-set.test.ts
bun run typecheck
```

Also manually verified with a private DashScope workspace, without committing the workspace id or key:

```bash
gbrain providers test --json
echo "DashScope v4 smoke test" | gbrain put setup-gbrain-filekey-smoke-test
gbrain search "DashScope v4 smoke test"
```

## Related

Fixes #2447.
