### PR TITLE
[codex] Exclude resolved non-bets from calibration metrics

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4511,6 +4511,8 @@ export class PGLiteEngine implements BrainEngine {
     // (correct|incorrect|partial) — NOT `resolved_quality IS NOT NULL` — so
     // historical comparisons against pre-v74 scorecards stay valid.
     // `unresolvable_count` is a sibling field counting the new 4th state.
+    // The whole aggregate is bets-only; resolved facts/takes/forecasts must
+    // never affect outcome counts, rates, Brier, or calibration.
     const res = await this.db.query(
       `SELECT
          COUNT(*) FILTER (WHERE kind = 'bet')::int                                              AS total_bets,
@@ -4525,7 +4527,7 @@ export class PGLiteEngine implements BrainEngine {
            END
          )::float                                                                               AS brier
        FROM takes
-       WHERE 1=1 ${where}`,
+       WHERE kind = 'bet' ${where}`,
       params,
     );
     const r = res.rows[0] as { total_bets: number; resolved: number; correct: number; incorrect: number; partial: number; unresolvable_count: number; brier: number | null };
@@ -4553,7 +4555,8 @@ export class PGLiteEngine implements BrainEngine {
            weight,
            (resolved_quality = 'correct')::int            AS hit
          FROM takes
-         WHERE resolved_quality IN ('correct','incorrect')
+         WHERE kind = 'bet'
+           AND resolved_quality IN ('correct','incorrect')
            ${where}
        )
        SELECT

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4522,6 +4522,8 @@ export class PostgresEngine implements BrainEngine {
     // (correct|incorrect|partial) — NOT `resolved_quality IS NOT NULL` — so
     // historical comparisons against pre-v74 scorecards stay valid.
     // `unresolvable_count` is a sibling field counting the new 4th state.
+    // The whole aggregate is bets-only; resolved facts/takes/forecasts must
+    // never affect outcome counts, rates, Brier, or calibration.
     const rows = await sql`
       SELECT
         COUNT(*) FILTER (WHERE kind = 'bet')::int                                              AS total_bets,
@@ -4536,7 +4538,7 @@ export class PostgresEngine implements BrainEngine {
           END
         )::float                                                                               AS brier
       FROM takes
-      WHERE 1=1 ${holderClause} ${domainClause} ${sinceClause} ${untilClause} ${allowed}
+      WHERE kind = 'bet' ${holderClause} ${domainClause} ${sinceClause} ${untilClause} ${allowed}
     `;
     const r = rows[0] as { total_bets: number; resolved: number; correct: number; incorrect: number; partial: number; unresolvable_count: number; brier: number | null };
     return finalizeScorecard(r);
@@ -4570,7 +4572,8 @@ export class PostgresEngine implements BrainEngine {
           weight,
           (resolved_quality = 'correct')::int AS hit
         FROM takes
-        WHERE resolved_quality IN ('correct','incorrect')
+        WHERE kind = 'bet'
+          AND resolved_quality IN ('correct','incorrect')
           ${holderClause} ${allowed}
       )
       SELECT

--- a/test/e2e/takes-scorecard-parity.test.ts
+++ b/test/e2e/takes-scorecard-parity.test.ts
@@ -2,8 +2,9 @@
  * v0.30.0 (Slice A1) E2E: scorecard + calibration parity between Postgres
  * and PGLite. Same fixture, same query, same numbers.
  *
- * Seeds 4 binary bets + 1 partial bet into both engines (mirrors the
- * `takes-resolution.test.ts` 4-bet hand-calc reference: Brier=0.205).
+ * Seeds 4 binary bets + 1 partial bet plus resolved non-bet controls into
+ * both engines (mirrors the `takes-resolution.test.ts` 4-bet hand-calc
+ * reference: Brier=0.205).
  * Asserts getScorecard returns byte-identical numeric output and
  * getCalibrationCurve emits the same buckets.
  *
@@ -31,7 +32,8 @@ interface FixtureBet {
   claim: string;
   holder: string;
   weight: number;
-  resolveAs?: 'correct' | 'incorrect' | 'partial';
+  kind?: string;
+  resolveAs?: 'correct' | 'incorrect' | 'partial' | 'unresolvable';
 }
 
 // Same fixture used by takes-resolution.test.ts hand-calc.
@@ -44,6 +46,12 @@ const FIXTURE_BETS: FixtureBet[] = [
   { rowNum: 4, claim: 'b4', holder: 'garry',       weight: 0.4, resolveAs: 'incorrect' },
   { rowNum: 5, claim: 'b5', holder: 'garry',       weight: 0.5, resolveAs: 'partial' },
   { rowNum: 6, claim: 'h1', holder: 'harj-taggar', weight: 0.8, resolveAs: 'correct' },
+  // Resolved non-bets are deliberate contamination controls. None may affect
+  // scorecard totals, outcome counts, rates, Brier, or calibration buckets.
+  { rowNum: 7, claim: 'take-correct', holder: 'garry', weight: 0.1, kind: 'take', resolveAs: 'correct' },
+  { rowNum: 8, claim: 'forecast-incorrect', holder: 'garry', weight: 0.9, kind: 'forecast', resolveAs: 'incorrect' },
+  { rowNum: 9, claim: 'hunch-partial', holder: 'garry', weight: 0.5, kind: 'hunch', resolveAs: 'partial' },
+  { rowNum: 10, claim: 'fact-unresolvable', holder: 'garry', weight: 0.8, kind: 'fact', resolveAs: 'unresolvable' },
 ];
 
 const SCORECARD_PAGE = 'companies/scorecard-parity-fixture';
@@ -59,7 +67,7 @@ async function seedFixture(engine: BrainEngine): Promise<number> {
       page_id: page.id,
       row_num: b.rowNum,
       claim: b.claim,
-      kind: 'bet' as const,
+      kind: b.kind ?? 'bet',
       holder: b.holder,
       weight: b.weight,
     })),
@@ -137,6 +145,8 @@ d('v0.30.0 e2e: scorecard parity (PG vs PGLite)', () => {
     // Also: partial_rate = 1/5 = 0.2 (4 binary + 1 partial = 5 resolved garry rows).
     expect(pgCard.partial_rate).toBeCloseTo(0.2, 6);
     expect(pgliteCard.partial_rate).toBeCloseTo(0.2, 6);
+    expect(pgCard.unresolvable_count).toBe(0);
+    expect(pgliteCard.unresolvable_count).toBe(0);
   });
 
   test('PRIVACY: allow-list ["garry"] gives same totals on both engines AND excludes harj', async () => {

--- a/test/takes-engine.test.ts
+++ b/test/takes-engine.test.ts
@@ -267,6 +267,40 @@ describe('v0.30.0 getScorecard', () => {
     expect(card.brier).toBeCloseTo(0.205, 4);
   });
 
+  test('resolved non-bets contribute zero to every scorecard and calibration field', async () => {
+    const p = await engine.putPage('companies/scorecard-non-bet-controls', {
+      title: 'Scorecard non-bet controls',
+      type: 'company' as const,
+      compiled_truth: '## Takes\n',
+    });
+    await engine.addTakesBatch([
+      { page_id: p.id, row_num: 1, claim: 'scored bet', kind: 'bet', holder: 'garry', weight: 0.8 },
+      { page_id: p.id, row_num: 2, claim: 'resolved forecast', kind: 'forecast', holder: 'garry', weight: 0.1 },
+      { page_id: p.id, row_num: 3, claim: 'resolved take', kind: 'take', holder: 'garry', weight: 0.9 },
+      { page_id: p.id, row_num: 4, claim: 'partial hunch', kind: 'hunch', holder: 'garry', weight: 0.5 },
+      { page_id: p.id, row_num: 5, claim: 'unresolvable fact', kind: 'fact', holder: 'garry', weight: 0.7 },
+    ]);
+    await engine.resolveTake(p.id, 1, { quality: 'correct', resolvedBy: 'garry' });
+    await engine.resolveTake(p.id, 2, { quality: 'correct', resolvedBy: 'garry' });
+    await engine.resolveTake(p.id, 3, { quality: 'incorrect', resolvedBy: 'garry' });
+    await engine.resolveTake(p.id, 4, { quality: 'partial', resolvedBy: 'garry' });
+    await engine.resolveTake(p.id, 5, { quality: 'unresolvable', resolvedBy: 'garry' });
+
+    const opts = { holder: 'garry', domainPrefix: 'companies/scorecard-non-bet-controls' };
+    const card = await engine.getScorecard(opts, undefined);
+    expect(card.total_bets).toBe(1);
+    expect(card.resolved).toBe(1);
+    expect(card.correct).toBe(1);
+    expect(card.incorrect).toBe(0);
+    expect(card.partial).toBe(0);
+    expect(card.unresolvable_count).toBe(0);
+    expect(card.brier).toBeCloseTo(0.04, 6);
+
+    const curve = await engine.getCalibrationCurve({ holder: 'garry' }, undefined);
+    const controlBucket = curve.find(b => b.bucket_lo <= 0.1 && b.bucket_hi > 0.1);
+    expect(controlBucket).toBeUndefined();
+  });
+
   test('PRIVACY: SQL allow-list filter — hidden-holder rows contribute zero', async () => {
     // Add a take from a different holder (e.g., harj). The scorecard with
     // allow-list ['garry'] must NOT count that take in any aggregate.


### PR DESCRIPTION
## What changed

- Scope scorecard aggregates to `kind = 'bet'` in both Postgres and PGLite.
- Apply the same bets-only boundary to calibration-curve buckets.
- Add resolved fact, take, forecast, and hunch controls to the PGLite regression suite and Postgres/PGLite parity fixture.

## Root cause

`total_bets` filtered on `kind = 'bet'`, but the remaining scorecard aggregates and calibration curve selected resolved rows of every kind. Resolved non-bet claims could therefore alter `resolved`, outcome counts, partial/unresolvable rates, Brier score, and calibration buckets.

## Impact

Scorecards and calibration curves now reflect only forward bets, matching their API contract. Existing legitimate bet metrics are unchanged.

## Validation

- `bunx tsc --noEmit --pretty false`
- `bun test test/takes-engine.test.ts test/takes-resolution.test.ts test/take-forecast.test.ts` — 63 passed
- `DATABASE_URL=postgresql://... bun test --timeout 120000 test/e2e/takes-scorecard-parity.test.ts` against an isolated pgvector/Postgres 16 container — 10 passed
- `git diff --check`

The isolated test database was removed after verification.