### PR TITLE
fix(chunkers/code): don't crash estimateTokens on code containing tiktoken special tokens

### DIFF
--- a/src/core/chunkers/code.ts
+++ b/src/core/chunkers/code.ts
@@ -1158,7 +1158,25 @@ export function estimateTokens(text: string): number {
     tiktokenInitialized = true;
   }
   if (tiktokenEncoder) {
-    return tiktokenEncoder.encode(text).length;
+    try {
+      return tiktokenEncoder.encode(text).length;
+    } catch {
+      // Code legitimately contains tiktoken special-token strings (e.g. CLIP/GPT
+      // tokenizers embed the literal "<|endoftext|>"). The default encode() uses
+      // disallowed_special='all' and THROWS on those, crashing reindex-code on
+      // valid source files. For a token COUNT we don't need special-token
+      // semantics: re-encode treating them as ordinary text (never throws),
+      // heuristic only if even that fails.
+      try {
+        return (
+          tiktokenEncoder as unknown as {
+            encode: (s: string, allowed: string[], disallowed: string[]) => Uint32Array;
+          }
+        ).encode(text, [], []).length;
+      } catch {
+        return Math.max(1, Math.ceil(text.length / 4));
+      }
+    }
   }
   return Math.max(1, Math.ceil(text.length / 4));
 }


### PR DESCRIPTION
## Problem
`reindex-code` / `sync --strategy code` crashes with `The text contains a special token that is not allowed: <|endoftext|>` on otherwise-valid source files. Real code legitimately contains tiktoken special-token strings — e.g. a CLIP or GPT tokenizer implementation embeds the literal `<|endoftext|>`/`<|startoftext|>`. `estimateTokens()` in `src/core/chunkers/code.ts` calls tiktoken's `encode(text)` with the default `disallowed_special='all'`, which throws on those strings, aborting the whole code reindex.

Hit in the wild indexing a repo with an `ios/.../CLIPTokenizer.swift`.

## Fix
A token *counter* should never crash on valid code. Wrap the encode: on throw, re-encode treating special tokens as ordinary text (`encode(text, [], [])`, which never throws); fall back to the length heuristic only if even that fails. Normal text is unchanged (fast path untouched).

## Test
Before: `gbrain reindex-code` exits 1 on a repo containing `<|endoftext|>`. After: completes; all code pages embed; `code-def`/`code-refs` populate.