### PR TITLE
feat(ai): add reranker touchpoint to LiteLLM proxy recipe

### DIFF
--- a/src/core/ai/recipes/litellm-proxy.ts
+++ b/src/core/ai/recipes/litellm-proxy.ts
@@ -40,6 +40,30 @@ export const litellmProxy: Recipe = {
       // mismatched-dim responses pre-storage).
       supports_multimodal: true,
     },
+    // LiteLLM exposes a rerank endpoint at /v1/rerank that normalizes Cohere /
+    // Voyage / Jina / etc. to the same wire shape gbrain's gateway.rerank()
+    // already speaks (the ZeroEntropy/llama.cpp contract):
+    //   { model, query, documents, top_n } → { results: [{ index, relevance_score }] }
+    // So any rerank model the user registers in their LiteLLM config is reachable
+    // via `gbrain config set search.reranker.model litellm:<model-name>` with no
+    // request/response adapter — same as embeddings ride the proxy today.
+    reranker: {
+      models: [], // user-provided; whatever rerank models the proxy serves
+      // No canonical default — the proxy defines its own model ids. The user
+      // sets search.reranker.model explicitly (mirrors the embedding touchpoint's
+      // user_provided_models contract).
+      default_model: '',
+      // The proxied backend bills (Cohere/Voyage/…); gbrain can't know the rate
+      // from here. Declare 0 so `--max-cost` callers don't hard-fail at the
+      // recipe layer — real cost is tracked by the proxy / upstream provider.
+      cost_per_1m_tokens_usd: 0,
+      price_last_verified: '2026-06-27',
+      max_payload_bytes: 5_000_000,
+      // Leaf path. base_url_default is 'http://localhost:4000' (no /v1 suffix),
+      // so the gateway concatenates to 'http://localhost:4000/v1/rerank' —
+      // LiteLLM's OpenAI-style rerank route.
+      path: '/v1/rerank',
+    },
   },
-  setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL + pass --embedding-model litellm:<model> and --embedding-dimensions <N>.',
+  setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL + pass --embedding-model litellm:<model> and --embedding-dimensions <N>. For rerank: register a rerank model in LiteLLM and set search.reranker.model litellm:<model-name>.',
 };

--- a/test/ai/recipe-litellm-reranker.test.ts
+++ b/test/ai/recipe-litellm-reranker.test.ts
@@ -1,0 +1,39 @@
+/**
+ * litellm-proxy reranker touchpoint smoke.
+ *
+ * Sibling of recipe-llama-server-reranker.test.ts. Pins the reranker touchpoint
+ * added to the LiteLLM proxy recipe so:
+ *  - the touchpoint exists with the `/v1/rerank` leaf path the gateway needs
+ *  - base_url ('http://localhost:4000', no /v1) + path concatenate to a single
+ *    '/v1/rerank' (no doubled prefix)
+ *  - models: [] (user-provided; proxy defines the model ids)
+ *  - cost_per_1m_tokens_usd: 0 so BudgetTracker doesn't hard-fail at the recipe
+ *    layer (the proxied provider bills, not gbrain)
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+
+describe('recipe: litellm reranker touchpoint', () => {
+  test('declares reranker touchpoint with /v1/rerank path', () => {
+    const r = getRecipe('litellm')!;
+    const tp = r.touchpoints.reranker;
+    expect(tp).toBeDefined();
+    expect(tp!.path).toBe('/v1/rerank');
+    expect(tp!.cost_per_1m_tokens_usd).toBe(0);
+    expect(tp!.max_payload_bytes).toBe(5_000_000);
+  });
+
+  test('base_url + path concatenation produces /v1/rerank, NOT /v1/v1/rerank', () => {
+    const r = getRecipe('litellm')!;
+    const combined =
+      r.base_url_default!.replace(/\/$/, '') + (r.touchpoints.reranker!.path ?? '/models/rerank');
+    expect(combined).toBe('http://localhost:4000/v1/rerank');
+    expect(combined).not.toContain('/v1/v1/');
+  });
+
+  test('reranker touchpoint uses empty models[] for user-provided model ids', () => {
+    const r = getRecipe('litellm')!;
+    expect(r.touchpoints.reranker!.models).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Adds a `reranker` touchpoint to the LiteLLM proxy recipe (`src/core/ai/recipes/litellm-proxy.ts`).

## Why

LiteLLM exposes `/v1/rerank`, which normalizes Cohere / Voyage / Jina / etc. to the **same wire shape `gateway.rerank()` already speaks** (the ZeroEntropy / llama.cpp contract):

```
{ model, query, documents, top_n }  →  { results: [{ index, relevance_score }] }
```

So any rerank model a user registers in their LiteLLM config becomes reachable via:

```
gbrain config set search.reranker.model litellm:<model-name>
```

with **no request/response adapter** — the same way embeddings already ride the proxy. Before this, `litellm:` could serve embeddings but not rerank, so users on a LiteLLM-centric stack had to add a separate ZeroEntropy/Voyage credential just for reranking.

## Shape

Mirrors the existing `llama-server-reranker` recipe (the other user-provided/proxy reranker):

- `models: []` — proxy-defined; user sets `search.reranker.model` explicitly.
- `path: '/v1/rerank'` — `base_url_default` is `http://localhost:4000` (no `/v1`), so concatenation yields `http://localhost:4000/v1/rerank` (single prefix, asserted in the test).
- `cost_per_1m_tokens_usd: 0` — the proxied backend bills; gbrain can't know the rate from here, and this keeps `--max-cost` callers from hard-failing at the recipe layer.

## Testing

- New `test/ai/recipe-litellm-reranker.test.ts` (touchpoint present, `/v1/rerank` path, base_url concatenation has no doubled `/v1/v1/`, `models: []`).
- `recipe-llama-server-reranker`, `recipes-existing-regression`, and `rerank` suites pass; `tsc --noEmit` clean.
- Verified end-to-end against a live LiteLLM proxy fronting Cohere `rerank-v4.0-fast`: `{model, query, documents, top_n}` → `{results:[{index, relevance_score}]}`, consumed without modification by `gateway.rerank()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)