### PR TITLE
fix(doctor): treat disabled retrieval reflex as intentional

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -4069,8 +4069,8 @@ export function buildRetrievalReflexCheck(skillsDir: string | null): Check {
     if (!enabled) {
       return {
         name,
-        status: 'warn',
-        message: 'retrieval reflex disabled (config/env) — entity pointer layer off',
+        status: 'ok',
+        message: 'retrieval reflex intentionally disabled (config/env) — entity pointer layer off',
         details: { enabled: false, engine: engineKind, policy_skill_installed: skillInstalled },
       };
     }

--- a/test/doctor-retrieval-reflex.test.ts
+++ b/test/doctor-retrieval-reflex.test.ts
@@ -9,12 +9,12 @@ import { buildRetrievalReflexCheck } from '../src/commands/doctor.ts';
 import { withEnv } from './helpers/with-env.ts';
 
 describe('buildRetrievalReflexCheck', () => {
-  test('disabled via env → warn, names the right check', async () => {
+  test('disabled via env → ok intentional-off, names the right check', async () => {
     await withEnv({ GBRAIN_RETRIEVAL_REFLEX: 'false' }, async () => {
       const c = buildRetrievalReflexCheck(null);
       expect(c.name).toBe('retrieval_reflex_health');
-      expect(c.status).toBe('warn');
-      expect(c.message).toContain('disabled');
+      expect(c.status).toBe('ok');
+      expect(c.message).toContain('intentionally disabled');
       expect((c.details as any)?.enabled).toBe(false);
     });
   });


### PR DESCRIPTION
## Summary

Treat `retrieval_reflex_health` as OK when Retrieval Reflex is explicitly disabled via config/env.

If the operator has deliberately turned the entity-pointer layer off, doctor should not report a warning/degradation. The check should still surface the state clearly in the message/details, but the health result should distinguish intentional-off from broken/missing runtime plumbing.

This matters for PGLite operators who must temporarily disable Reflex IPC because durable `gbrain serve` currently monopolizes the embedded DB and makes normal CLI commands time out (tracked separately in #2458).

## Tests

- `bun test test/doctor-retrieval-reflex.test.ts`
- `bun run typecheck`
