### PR TITLE
fix(markdown): prefer body H1 for missing titles

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -135,7 +135,9 @@ export function parseMarkdown(
   const type = coerceFrontmatterString(frontmatter.type) || (
     opts?.activePack ? inferTypeFromPack(filePath, opts.activePack) : inferType(filePath)
   );
-  const title = coerceFrontmatterString(frontmatter.title).trim() || inferTitle(filePath);
+  const title = coerceFrontmatterString(frontmatter.title).trim()
+    || inferBodyH1(compiled_truth)
+    || inferTitle(filePath);
   const tags = extractTags(frontmatter);
   const slug = coerceFrontmatterString(frontmatter.slug) || inferSlug(filePath);
 
@@ -597,6 +599,11 @@ function inferTypeWithPrefixes(
     }
   }
   return 'concept';
+}
+
+function inferBodyH1(body: string): string {
+  const h1Match = body.match(/^#\s+(.+)$/m);
+  return h1Match?.[1]?.trim() || '';
 }
 
 function inferTitle(filePath?: string): string {

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -88,6 +88,31 @@ Content
     expect(parsed.slug).toBe('concepts/do-things-that-dont-scale');
   });
 
+  test('prefers body H1 over inferred filename when frontmatter title is missing', () => {
+    const md = `---
+type: person
+---
+# Alice Example
+
+Contact notes.
+`;
+    const parsed = parseMarkdown(md, 'contacts/contact-20170928-5-alice-example.md');
+    expect(parsed.title).toBe('Alice Example');
+  });
+
+  test('frontmatter title still wins over body H1', () => {
+    const md = `---
+type: person
+title: A. Example
+---
+# Alice Example
+
+Contact notes.
+`;
+    const parsed = parseMarkdown(md, 'contacts/contact-20170928-5-alice-example.md');
+    expect(parsed.title).toBe('A. Example');
+  });
+
   // v0.20: BrainBench / native inbox-chat-calendar Page types. These 5 directory
   // heuristics exercise PageType 'email | slack | calendar-event | note | meeting'
   // which were added for amara-life-v1 ingest but are useful for any gbrain user


### PR DESCRIPTION
## Summary
- Make `parseMarkdown` use the first body H1 as the title when frontmatter has no usable `title`
- Preserve explicit frontmatter `title` precedence
- Keep filename/path title inference as the final fallback

Fixes #2446

## Verification
- `bun test test/markdown.test.ts`
- `bun run verify`

Note: full `bun run test` was attempted locally but exceeded the tool timeout while still progressing; no test failure was observed.
