### PR TITLE
fix: allow sync on repos with no commits (Dream Cycle sync phase)

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1665,12 +1665,15 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     }
   }
 
-  // Get current HEAD
+  // Get current HEAD.
+  // When the repo has no commits yet (fresh `git init` before first commit),
+  // performFullSync already handles a blank headCommit by walking the filesystem
+  // directly — no need to throw and block the entire sync phase.
   let headCommit: string;
   try {
     headCommit = git(repoPath, ['rev-parse', 'HEAD']);
   } catch {
-    throw new Error(`No commits in repo ${repoPath}. Make at least one commit before syncing.`);
+    headCommit = '';
   }
 
   // #1970: bookmark reachability. The ONLY thing that should force a full


### PR DESCRIPTION
## Problem

When a gbrain repo was initialized but no commit was ever made
(e.g. after `gbrain init`, before the first `git commit`),
`git rev-parse HEAD` fails. The code throws an error and blocks
the entire Dream Cycle sync phase **every cycle**, indefinitely.

The repo has a `.git` directory (passes the "is it a git repo?"
check) but zero commits (fails the "get HEAD" check). Users who
ran `gbrain init` without manually committing are stuck with
`sync: fail` forever.

## Root Cause

`performFullSync` already handles the zero-commit case -- it walks
the filesystem directly. But the `throw` above prevents the code
from ever reaching it.

## Fix

When `git rev-parse HEAD` fails, set `headCommit` to `""` instead
of throwing. This lets the flow fall through to
`performFullSync(engine, repoPath, headCommit, opts)`, which
imports all syncable files from disk.

**5 lines changed** (including comment):

```diff
-    throw new Error(`No commits in repo ${repoPath}. Make at least one commit before syncing.`);
+    headCommit = '';
```

## Verification

- `!lastCommit` will be true (no prior sync anchor)
  → hits the "First sync" path at ~line 1722 → calls `performFullSync`
- Subsequent syncs with actual commits work normally via the
  incremental diff path
- Tested: `gbrain sync --dry-run` on a repo with zero commits now
  reports files to import instead of throwing

## Test impact

One test comment in `test/e2e/multi-source.test.ts:373` mentions
the old error message as a possible outcome. No assertions are
affected.
