### PR TITLE
fix(ai): honor base_urls override for native-anthropic chat/expansion

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2133,7 +2133,11 @@ function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayCon
     case 'native-anthropic': {
       const apiKey = cfg.env.ANTHROPIC_API_KEY;
       if (!apiKey) throw new AIConfigError(`Anthropic expansion requires ANTHROPIC_API_KEY.`, recipe.setup_hint);
-      return createAnthropic({ apiKey }).languageModel(modelId);
+      // Honor an explicit base_urls override (parity with the openai-compatible
+      // branch) so the Anthropic client can target an Anthropic-compatible proxy
+      // instead of api.anthropic.com. No override → default endpoint, unchanged.
+      const baseURL = cfg.base_urls?.[recipe.id];
+      return createAnthropic({ apiKey, ...(baseURL ? { baseURL } : {}) }).languageModel(modelId);
     }
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
@@ -2505,7 +2509,11 @@ function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig):
     case 'native-anthropic': {
       const apiKey = cfg.env.ANTHROPIC_API_KEY;
       if (!apiKey) throw new AIConfigError(`Anthropic chat requires ANTHROPIC_API_KEY.`, recipe.setup_hint);
-      return createAnthropic({ apiKey }).languageModel(modelId);
+      // Honor an explicit base_urls override (parity with the openai-compatible
+      // branch) so the Anthropic client can target an Anthropic-compatible proxy
+      // instead of api.anthropic.com. No override → default endpoint, unchanged.
+      const baseURL = cfg.base_urls?.[recipe.id];
+      return createAnthropic({ apiKey, ...(baseURL ? { baseURL } : {}) }).languageModel(modelId);
     }
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).


### PR DESCRIPTION
## Problem

The `native-anthropic` branches in `instantiateChat` and `instantiateExpansion` (`src/core/ai/gateway.ts`) construct the Anthropic client with `createAnthropic({ apiKey })`, **ignoring `cfg.base_urls`**.

This is inconsistent with the rest of the gateway:
- The `openai-compatible` branches resolve `cfg.base_urls?.[recipe.id] ?? recipe.base_url_default`.
- The expansion/chat **cache keys** (lines ~2112 and ~2484) already fold `cfg.base_urls?.[recipe.id]` into the key.

So a `base_urls` override for an Anthropic recipe is threaded through config *and* the cache key, but then **dropped at client construction** — `provider_base_urls.anthropic` has no effect and chat/expansion always hit `api.anthropic.com`.

## Fix

Honor `cfg.base_urls?.[recipe.id]` in both `native-anthropic` branches, mirroring the `openai-compatible` convention. When no override is present, behavior is unchanged (default Anthropic endpoint).

This lets the Anthropic client target an Anthropic-compatible proxy (e.g. a LiteLLM `/v1/messages` endpoint serving an Anthropic-format model) for `think`/synthesis and chat, which are pinned to the Anthropic provider.

## Notes
- No version/CHANGELOG bump — leaving the release mechanics to the maintainer's ship flow.
- Minimal, additive, and a no-op when `base_urls` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)