### PR TITLE
docs: add retrieval routing hints to search/query help text

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,17 @@ for (const op of operations) {
 // CLI-only commands that bypass the operation layer
 const CLI_ONLY = new Set(['init', 'upgrade', 'check-update', 'import', 'export', 'files', 'embed', 'serve', 'call', 'config', 'doctor']);
 
+const RETRIEVAL_ROUTING_HINTS: Record<string, string[]> = {
+  search: [
+    'Use for exact known tokens, structured fields, and historical exact-match lookups.',
+    'For concept, synonym, landscape, all matching/every matching/anything matching, or recall-completeness questions, use gbrain query.',
+  ],
+  query: [
+    'Use for concept, synonym, landscape, all matching/every matching/anything matching, and recall-completeness questions.',
+    'Use gbrain search for exact known tokens, structured fields, or historical exact-match lookups.',
+  ],
+};
+
 async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
@@ -305,6 +316,14 @@ function printOpHelp(op: Operation) {
   const name = op.cliHints?.name || op.name;
   console.log(`Usage: gbrain ${name} ${positional} [options]\n`);
   console.log(op.description + '\n');
+  const routingHints = RETRIEVAL_ROUTING_HINTS[name];
+  if (routingHints) {
+    console.log('When to use which:');
+    for (const hint of routingHints) {
+      console.log(`  ${hint}`);
+    }
+    console.log('');
+  }
   const entries = Object.entries(op.params);
   if (entries.length > 0) {
     console.log('Options:');
@@ -340,8 +359,9 @@ PAGES
   list [--type T] [--tag T] [-n N]   List pages
 
 SEARCH
-  search <query>                     Keyword search (tsvector)
-  query <question> [--no-expand]     Hybrid search (RRF + expansion)
+  search <query>                     Keyword search (tsvector): exact known token, structured field, historical exact-match
+  query <question> [--no-expand]     Hybrid search (RRF + expansion): concept, synonym, landscape, recall-completeness
+                                     When to use which: start with query for all matching/every matching/anything matching questions.
 
 IMPORT/EXPORT
   import <dir> [--no-embed]          Import markdown directory

--- a/test/cli-help-discoverability.test.ts
+++ b/test/cli-help-discoverability.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from 'bun:test';
+
+const cwd = new URL('..', import.meta.url).pathname;
+
+async function runCli(args: string[]) {
+  const proc = Bun.spawn(['bun', 'run', 'src/cli.ts', ...args], {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+describe('CLI help discoverability', () => {
+  test('global help routes exact lookup to search and recall questions to query', async () => {
+    const { stdout, exitCode } = await runCli(['--help']);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('search <query>');
+    expect(stdout).toContain('Keyword search (tsvector)');
+    expect(stdout).toContain('exact known token');
+    expect(stdout).toContain('structured field');
+    expect(stdout).toContain('historical exact-match');
+    expect(stdout).toContain('query <question> [--no-expand]');
+    expect(stdout).toContain('Hybrid search (RRF + expansion)');
+    expect(stdout).toContain('concept');
+    expect(stdout).toContain('synonym');
+    expect(stdout).toContain('landscape');
+    expect(stdout).toContain('recall-completeness');
+    expect(stdout).toContain('When to use which: start with query for all matching');
+  });
+
+  test('search help includes routing note and existing usage/options', async () => {
+    const { stdout, stderr, exitCode } = await runCli(['search', '--help']);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe('');
+    expect(stdout).toContain('Usage: gbrain search');
+    expect(stdout).toContain('Keyword search using full-text search');
+    expect(stdout).toContain('When to use which:');
+    expect(stdout).toContain('exact known tokens');
+    expect(stdout).toContain('structured fields');
+    expect(stdout).toContain('historical exact-match lookups');
+    expect(stdout).toContain('use gbrain query');
+    expect(stdout).toContain('concept');
+    expect(stdout).toContain('landscape');
+    expect(stdout).toContain('all matching');
+    expect(stdout).toContain('recall-completeness');
+    expect(stdout).toContain('Options:');
+    expect(stdout).toContain('<query>');
+    expect(stdout).toContain('--limit');
+  });
+
+  test('query help names the recommended fuzzy recall cases', async () => {
+    const { stdout, stderr, exitCode } = await runCli(['query', '--help']);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe('');
+    expect(stdout).toContain('Usage: gbrain query');
+    expect(stdout).toContain('Hybrid search with vector + keyword + multi-query expansion');
+    expect(stdout).toContain('concept');
+    expect(stdout).toContain('synonym');
+    expect(stdout).toContain('landscape');
+    expect(stdout).toContain('all matching');
+    expect(stdout).toContain('recall-completeness');
+    expect(stdout).toContain('Use gbrain search for exact known tokens');
+  });
+
+  test('unknown subcommand still returns a non-empty help pointer', async () => {
+    const { stderr, exitCode } = await runCli(['notacommand']);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('Unknown command: notacommand');
+    expect(stderr).toContain('Run gbrain --help for available commands.');
+  });
+});


### PR DESCRIPTION
## Summary
Adds retrieval routing hints to the `search` and `query` command help text so users pick the right tool: `search` for exact known tokens and structured-field lookups, `query` for concept, synonym, landscape, and recall-completeness questions. Each command's help now cross-references the other.

Adds a help-discoverability test asserting both hints render.

Fixes #2416
