### PR TITLE
Fix native local embedding setup blockers

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -704,12 +704,19 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
     };
   }
 
-  // Openai-compat recipes with empty models list require a user-provided model.
+  // OpenAI-compatible recipes with an empty static model list are valid when
+  // the caller supplied a concrete provider:model id. Pre-fix, llama-server
+  // declared `user_provided_models: true` and a configured model such as
+  // `llama-server:bge-small-en-v1.5-q4_k_m` was still rejected here, making
+  // the local embedding recipe impossible to use outside tests. Keep the
+  // diagnostic for malformed/bare provider ids; parseModelId above guarantees
+  // `parsed.modelId` is non-empty for real provider:model strings.
   const isUserProvided = (tp as any).user_provided_models === true;
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
-    (recipe.id === 'litellm' || isUserProvided)
+    (recipe.id === 'litellm' || isUserProvided) &&
+    !parsed.modelId
   ) {
     return {
       ok: false,

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -36,7 +36,7 @@ import {
 } from './embedding-context.ts';
 import { loadSearchModeConfig, resolveSearchMode } from './search/mode.ts';
 import { normalizeAliasList } from './search/alias-normalize.ts';
-import { isUndefinedTableError, warnOncePerProcess } from './utils.ts';
+import { isUndefinedTableError, validateSlug, warnOncePerProcess } from './utils.ts';
 import { computeCorpusGeneration } from './contextual-retrieval-service.ts';
 import { runGuardrails } from './guardrails.ts';
 
@@ -284,6 +284,14 @@ export async function importFromContent(
     remote?: boolean;
   } = {},
 ): Promise<ImportResult> {
+  // Canonicalize once at the import boundary. PostgresEngine.putPage also
+  // validates/canonicalizes slugs before INSERT; without this, explicit
+  // mixed-case slugs are inserted lowercased but chunked under the original
+  // slug, causing `Page not found` in upsertChunks. Default capture slugs are
+  // already lowercase, which is why the bug only hit explicit slugs like
+  // timestamped `...T...Z` canaries.
+  slug = validateSlug(slug);
+
   // v0.18.0+ multi-source: when caller is syncing under a non-default source,
   // every per-page tx call must carry `sourceId` so writes target the right
   // (source_id, slug) row. Pre-fix, putPage relied on the schema DEFAULT and

--- a/test/gateway-embed-model-override.test.ts
+++ b/test/gateway-embed-model-override.test.ts
@@ -173,4 +173,20 @@ describe('isAvailable(touchpoint, modelOverride) — D10', () => {
     });
     expect(isAvailable('embedding', 'totally:unknown')).toBe(false);
   });
+
+  test('llama-server accepts explicit user-provided local embedding model ids', () => {
+    // llama-server intentionally ships with an empty static model list: the
+    // served id is whatever the operator launched with --model_alias. The
+    // configured provider:model string is therefore the model allowlist. Pre-fix,
+    // diagnoseEmbedding rejected every llama-server embedding model because the
+    // recipe had user_provided_models=true and models=[] even when the model id
+    // was explicit.
+    configureGateway({
+      embedding_model: 'llama-server:bge-small-en-v1.5-q4_k_m',
+      embedding_dimensions: 384,
+      env: {},
+      base_urls: { 'llama-server': 'http://127.0.0.1:18080/v1' },
+    });
+    expect(isAvailable('embedding')).toBe(true);
+  });
 });

--- a/test/import-content-slug-canonicalization.test.ts
+++ b/test/import-content-slug-canonicalization.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { importFromContent } from '../src/core/import-file.ts';
+
+describe('importFromContent slug canonicalization', () => {
+  let engine: PGLiteEngine;
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({});
+    await engine.initSchema();
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+  }, 30_000);
+
+  test('explicit mixed-case slug is canonicalized before chunk upsert', async () => {
+    const mixed = 'inbox/Explicit-Fix-20260629T003419Z';
+    const canonical = 'inbox/explicit-fix-20260629t003419z';
+    const md = `# Explicit slug proof\n\nThis page proves mixed-case explicit slugs chunk under the canonical slug.`;
+
+    const result = await importFromContent(engine, mixed, md, { noEmbed: true });
+
+    expect(result.slug).toBe(canonical);
+    expect(result.status).toBe('imported');
+
+    const page = await engine.getPage(canonical);
+    expect(page?.slug).toBe(canonical);
+
+    const chunks = await engine.getChunks(canonical);
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks[0]!.chunk_text).toContain('mixed-case explicit slugs');
+  });
+});


### PR DESCRIPTION
## Summary

- canonicalize explicit import slugs before chunk upsert so mixed-case CLI slugs don't create page/chunk casing mismatches
- allow llama-server embedding recipes with explicit user-provided model ids (for local GGUF embedding servers)
- add regression coverage for both paths

## Why

Local embedding providers should work through normal source/config/install paths, not runtime patches. A SPAS rehearsal exposed two setup blockers:

1. `importFromContent()` passed a mixed-case explicit slug through chunking after `putPage()` canonicalized the page row.
2. `diagnoseEmbedding()` rejected `llama-server:<model-id>` even when the model id was explicit, because the recipe declares `models: []` with `user_provided_models: true`.

## Tests

- `bun test test/gateway-embed-model-override.test.ts test/embed-input-type-wire.serial.test.ts`
- `bun test test/import-content-slug-canonicalization.test.ts --timeout 30000`
- `bun run verify`
