### PR TITLE
fix(think): surface page-vs-page conflicts on takes-empty brains; make retrieval breadth env-configurable

### DIFF
--- a/src/core/think/gather.ts
+++ b/src/core/think/gather.ts
@@ -24,7 +24,8 @@ export interface ThinkGatherOpts {
   question: string;
   /** Anchor entity slug. When set, the graph stream activates. */
   anchor?: string;
-  /** Soft cap on total results across all streams. Default 40. */
+  /** Soft cap on total results across all streams. Default 40, overridable via
+   *  GBRAIN_THINK_GATHER_LIMIT (widen for conflict/variant recall, e.g. drift probes). */
   gatherLimit?: number;
   /** Soft cap on take results. Default 30. */
   takesLimit?: number;
@@ -54,6 +55,17 @@ export interface ThinkGatherResult {
 }
 
 const RRF_K = 60;
+
+/**
+ * Read a positive-integer tuning knob from the environment, falling back to the
+ * upstream default. Lets retrieval breadth be tuned per-install (e.g. a brain
+ * with many near-duplicate sources that needs wider conflict/variant recall)
+ * without changing default behavior. Matches gbrain's GBRAIN_* env-knob pattern.
+ */
+function envInt(name: string, fallback: number): number {
+  const n = parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
 
 /** Reciprocal-rank fusion: 1/(k+rank). Stable, parameter-light, matches search/hybrid.ts k. */
 function rrfScore(rank: number): number {
@@ -98,7 +110,7 @@ export async function runGather(
   engine: BrainEngine,
   opts: ThinkGatherOpts,
 ): Promise<ThinkGatherResult> {
-  const gatherLimit = opts.gatherLimit ?? 40;
+  const gatherLimit = opts.gatherLimit ?? envInt('GBRAIN_THINK_GATHER_LIMIT', 40);
   const takesLimit = opts.takesLimit ?? 30;
   const graphDepth = opts.graphDepth ?? 2;
 
@@ -181,7 +193,7 @@ export async function runGather(
  * Pages are rendered as `<page slug="..." score="...">excerpt</page>`;
  * takes are rendered via the renderTakesBlock helper from sanitize.ts.
  */
-export function renderPagesBlock(pages: SearchResult[], excerptLen = 600): string {
+export function renderPagesBlock(pages: SearchResult[], excerptLen = envInt('GBRAIN_THINK_EXCERPT_LEN', 600)): string {
   return pages.map((p, idx) => {
     const slug = String((p as unknown as { slug?: string }).slug ?? '');
     const excerpt = String(

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -150,7 +150,13 @@ export interface ThinkResult {
   };
 }
 
-const DEFAULT_MAX_OUTPUT_TOKENS = 4000;
+// Default 4000; override via GBRAIN_THINK_MAX_OUTPUT_TOKENS. Conflict-dense
+// syntheses (e.g. drift probes over a brain with many divergent sources) can
+// truncate mid-JSON at 4000 — raise the cap per-install rather than hardcode it.
+const DEFAULT_MAX_OUTPUT_TOKENS = (() => {
+  const n = parseInt(process.env.GBRAIN_THINK_MAX_OUTPUT_TOKENS ?? '', 10);
+  return Number.isFinite(n) && n > 0 ? n : 4000;
+})();
 
 function inferIntent(question: string, anchor?: string): string {
   if (anchor) return 'entity';

--- a/src/core/think/prompt.ts
+++ b/src/core/think/prompt.ts
@@ -50,8 +50,23 @@ Hard rules:
   Inline the citation immediately after the claim it supports. Never fabricate slugs/rows.
 - If a take has weight < 0.5 or kind=hunch, mark it explicitly: "garry has a hunch (w=0.4) that..."
   rather than asserting it as established. Confidence is part of the data.
-- If two takes contradict (different holders, opposite claims), surface BOTH in a "Conflicts"
-  section. Never silently pick one.
+- CONFLICTS: If two or more SOURCES (pages and/or takes) give conflicting or divergent values
+  for the SAME fact — a number stated against a different base, a stale value, a contradictory
+  commitment, or different holders making opposite claims — surface ALL of them in a "Conflicts"
+  section. Never silently pick one, and NEVER reconcile a lower figure as a "discount" or
+  "variant" unless a source EXPLICITLY states that relationship. In the Conflicts section emit
+  ONE bullet per conflict, each STARTING with a severity tag in square brackets:
+  [HIGH] = money/pricing/contract/identity/legal/client-facing commitment; [MEDIUM] = timeline/
+  scope/operational; [LOW] = wording/cosmetic. Follow the tag with the fact and each conflicting
+  value with its [slug]. Example:
+  "- [HIGH] Phase 1 price: $2,000 [finance/velox_revenue_tracker] vs 1k AUD / 50% off [cold_outreach/warm_dm_scripts]"
+  The Conflicts section is ONLY for genuine disagreements. Do NOT emit a bullet to report that
+  sources AGREE, that a value is "consistent across sources", or that "no contradiction was found"
+  — if a fact is consistent, omit it entirely. An explicitly-stated discount off a stated base is
+  NOT a conflict. If there are zero genuine conflicts, omit the Conflicts section.
+- VARIANTS: When a fact legitimately has conditional or variant values (e.g. standard vs warm-lead
+  vs mentor pricing; per-segment terms; per-phase prices), ENUMERATE every variant with its
+  condition and [slug]. Do not collapse to a single "standard" value or drop the variants.
 - If you cannot answer because the brain doesn't contain the relevant data, say so in the
   "Gaps" section. List the specific missing pieces. Do not make up answers.
 - Never instruct the user (no "you should" / "I recommend X"). The brain reports; the user decides.


### PR DESCRIPTION
## Problem

`gbrain think`'s synthesis prompt only instructs the model to surface conflicts **between takes** ("If two takes contradict … surface BOTH"). On a brain whose knowledge lives in **pages** — takes table empty, the common personal-vault case — contradictory facts across pages (e.g. a price stated as `$2,000` in one doc and `$1,000` in another) are silently reconciled into a single answer instead of flagged. The conflict-detection feature is effectively dead when `takes = 0`.

## Changes (two commits)

**1. `fix(think)` — surface page-vs-page conflicts.** Broaden the Conflicts rule in `prompt.ts` to cover **pages and/or takes**: surface every fact where sources give divergent values, never reconcile a lower figure as a "discount" unless a source states it, enumerate conditional/variant values, suppress "sources agree" non-bullets, and tag each conflict `[HIGH]/[MEDIUM]/[LOW]` so the section is machine-parseable. No new behavior at default settings except that genuine page-vs-page conflicts now appear in the Conflicts section instead of being silently resolved.

**2. `feat(think)` — env-configurable retrieval breadth.** Retrieval breadth becomes tunable per-install via env vars, matching the existing `GBRAIN_*` knob convention (`GBRAIN_SYNC_*`, `GBRAIN_PACE_*`). **Defaults unchanged:**

| Env var | Default | Effect |
|---|---|---|
| `GBRAIN_THINK_GATHER_LIMIT` | 40 | pages gathered for synthesis |
| `GBRAIN_THINK_EXCERPT_LEN` | 600 | per-page excerpt chars (a too-narrow excerpt hides facts deep in a long page) |
| `GBRAIN_THINK_MAX_OUTPUT_TOKENS` | 4000 | synthesis output cap (conflict-dense answers truncate mid-JSON at 4000) |

## Why it matters

A drift/contradiction probe over a pages-only brain returned *zero* conflicts before this change despite real contradictions (stale prices, duplicated-then-diverged commitments); after it, the same probe surfaces them with severity. The env knobs let an install widen recall for that use case without forking.

## Notes for the maintainer

- I implemented the knobs as **env vars** to match the existing `GBRAIN_*` convention; happy to wire them as DB-plane `think.*` config keys instead if you'd prefer.
- Commits are split fix/feat so the bug fix can be cherry-picked independently of the knobs.
- Conventional-commit titles, no VERSION bump — left for your `/ship` flow.
- Verified by running `gbrain think` against a populated PGLite brain (compiles + runs; conflicts now surface and the Conflicts section is correctly omitted when there are none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
