### PR TITLE
Fix takes search and think vector recall

### DIFF
--- a/src/commands/think.ts
+++ b/src/commands/think.ts
@@ -9,6 +9,7 @@ import type { BrainEngine } from '../core/engine.ts';
 import { runThink, persistSynthesis } from '../core/think/index.ts';
 import { loadConfig, isThinClient } from '../core/config.ts';
 import { callRemoteTool, unpackToolResult } from '../core/mcp-client.ts';
+import { embedQuery } from '../core/ai/gateway.ts';
 
 function flagValue(args: string[], name: string): string | undefined {
   const i = args.indexOf(name);
@@ -118,6 +119,10 @@ prints what would have been the input (exit 0).
         // think when no profile exists, with NO_CALIBRATION_PROFILE warning.
         withCalibration,
         ...(calibrationHolder ? { calibrationHolder } : {}),
+        // Local CLI should exercise the takes vector-recall lane when the
+        // configured embedding provider is available; runThink catches and
+        // surfaces QUESTION_EMBED_FAILED if the provider is unavailable.
+        embedQuestion: embedQuery,
         // Local CLI: no MCP allow-list filter — operator owns the brain.
       });
 

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1815,6 +1815,7 @@ const think: Operation = {
     // and get default scope + remote=false from runThink's CLI path.
     const scope = sourceScopeOpts(ctx);
     const { runThink, persistSynthesis } = await import('./think/index.ts');
+    const { embedQuery } = await import('./ai/gateway.ts');
     const result = await runThink(ctx.engine, {
       question: String(p.question),
       anchor: p.anchor ? String(p.anchor) : undefined,
@@ -1830,6 +1831,10 @@ const think: Operation = {
       since: p.since ? String(p.since) : undefined,
       until: p.until ? String(p.until) : undefined,
       takesHoldersAllowList: ctx.takesHoldersAllowList,
+      // MCP callers should get parity with local CLI for the takes vector-
+      // recall lane. runThink degrades to keyword-only with a warning if the
+      // embedding provider is unavailable.
+      embedQuestion: embedQuery,
       ...(scope.sourceId !== undefined ? { sourceId: scope.sourceId } : {}),
       ...(scope.sourceIds !== undefined ? { allowedSources: scope.sourceIds } : {}),
       remote: ctx.remote === true,

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4302,20 +4302,48 @@ export class PGLiteEngine implements BrainEngine {
     opts: { limit?: number; takesHoldersAllowList?: string[] } = {},
   ): Promise<TakeHit[]> {
     const limit = clampSearchLimit(opts.limit, 30, 100);
+    const anyTermQuery = query.trim().split(/\s+/).filter(Boolean).join(' OR ') || query;
     const { rows } = await this.db.query(
-      `SELECT t.id AS take_id, t.page_id, p.slug AS page_slug, t.row_num,
+      `WITH q AS (
+         SELECT
+           websearch_to_tsquery('english', $1) AS q_all,
+           websearch_to_tsquery('english', $4) AS q_any
+       )
+       SELECT t.id AS take_id, t.page_id, p.slug AS page_slug, t.row_num,
               t.claim, t.kind, t.holder, t.weight,
-              similarity(t.claim, $1)::real AS score
+              GREATEST(
+                similarity(t.claim, $1),
+                ts_rank_cd(to_tsvector('english', t.claim), q.q_all),
+                ts_rank_cd(to_tsvector('english', t.claim), q.q_any)
+              )::real AS score
        FROM takes t
        JOIN pages p ON p.id = t.page_id
+       CROSS JOIN q
        WHERE t.active
-         AND t.claim % $1
+         AND (
+           t.claim % $1
+           OR to_tsvector('english', t.claim) @@ q.q_all
+           OR to_tsvector('english', t.claim) @@ q.q_any
+         )
          AND ($2::text[] IS NULL OR t.holder = ANY($2::text[]))
-       ORDER BY score DESC, t.weight DESC
+       ORDER BY
+         CASE WHEN to_tsvector('english', t.claim) @@ q.q_all THEN 1 ELSE 0 END DESC,
+         score DESC,
+         t.weight DESC
        LIMIT $3`,
-      [query, opts.takesHoldersAllowList ?? null, limit]
+      [query, opts.takesHoldersAllowList ?? null, limit, anyTermQuery]
     );
-    return rows as unknown as TakeHit[];
+    return (rows as unknown as Array<Record<string, unknown>>).map((r) => ({
+      take_id: Number(r.take_id),
+      page_id: Number(r.page_id),
+      page_slug: String(r.page_slug),
+      row_num: Number(r.row_num),
+      claim: String(r.claim),
+      kind: r.kind as TakeHit['kind'],
+      holder: String(r.holder),
+      weight: Number(r.weight),
+      score: Number(r.score),
+    }));
   }
 
   async searchTakesVector(
@@ -4337,7 +4365,17 @@ export class PGLiteEngine implements BrainEngine {
        LIMIT $3`,
       [vec, opts.takesHoldersAllowList ?? null, limit]
     );
-    return rows as unknown as TakeHit[];
+    return (rows as unknown as Array<Record<string, unknown>>).map((r) => ({
+      take_id: Number(r.take_id),
+      page_id: Number(r.page_id),
+      page_slug: String(r.page_slug),
+      row_num: Number(r.row_num),
+      claim: String(r.claim),
+      kind: r.kind as TakeHit['kind'],
+      holder: String(r.holder),
+      weight: Number(r.weight),
+      score: Number(r.score),
+    }));
   }
 
   async getTakeEmbeddings(ids: number[]): Promise<Map<number, Float32Array>> {

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4343,22 +4343,50 @@ export class PostgresEngine implements BrainEngine {
   async searchTakes(query: string, opts: SearchOpts & { takesHoldersAllowList?: string[] } = {}): Promise<TakeHit[]> {
     const sql = this.sql;
     const limit = clampSearchLimit(opts.limit, 30, 100);
+    const anyTermQuery = query.trim().split(/\s+/).filter(Boolean).join(' OR ') || query;
     const rows = await sql`
+      WITH q AS (
+        SELECT
+          websearch_to_tsquery('english', ${query}) AS q_all,
+          websearch_to_tsquery('english', ${anyTermQuery}) AS q_any
+      )
       SELECT t.id AS take_id, t.page_id, p.slug AS page_slug, t.row_num,
              t.claim, t.kind, t.holder, t.weight,
-             similarity(t.claim, ${query})::real AS score
+             GREATEST(
+               similarity(t.claim, ${query}),
+               ts_rank_cd(to_tsvector('english', t.claim), q.q_all),
+               ts_rank_cd(to_tsvector('english', t.claim), q.q_any)
+             )::real AS score
       FROM takes t
       JOIN pages p ON p.id = t.page_id
+      CROSS JOIN q
       WHERE t.active
-        AND t.claim % ${query}
+        AND (
+          t.claim % ${query}
+          OR to_tsvector('english', t.claim) @@ q.q_all
+          OR to_tsvector('english', t.claim) @@ q.q_any
+        )
         AND (
           ${opts.takesHoldersAllowList ?? null}::text[] IS NULL
           OR t.holder = ANY(${opts.takesHoldersAllowList ?? null}::text[])
         )
-      ORDER BY score DESC, t.weight DESC
+      ORDER BY
+        CASE WHEN to_tsvector('english', t.claim) @@ q.q_all THEN 1 ELSE 0 END DESC,
+        score DESC,
+        t.weight DESC
       LIMIT ${limit}
     `;
-    return rows as unknown as TakeHit[];
+    return (rows as unknown as Array<Record<string, unknown>>).map((r) => ({
+      take_id: Number(r.take_id),
+      page_id: Number(r.page_id),
+      page_slug: String(r.page_slug),
+      row_num: Number(r.row_num),
+      claim: String(r.claim),
+      kind: r.kind as TakeHit['kind'],
+      holder: String(r.holder),
+      weight: Number(r.weight),
+      score: Number(r.score),
+    }));
   }
 
   async searchTakesVector(
@@ -4383,7 +4411,17 @@ export class PostgresEngine implements BrainEngine {
       ORDER BY t.embedding <=> ${vec}::vector
       LIMIT ${limit}
     `;
-    return rows as unknown as TakeHit[];
+    return (rows as unknown as Array<Record<string, unknown>>).map((r) => ({
+      take_id: Number(r.take_id),
+      page_id: Number(r.page_id),
+      page_slug: String(r.page_slug),
+      row_num: Number(r.row_num),
+      claim: String(r.claim),
+      kind: r.kind as TakeHit['kind'],
+      holder: String(r.holder),
+      weight: Number(r.weight),
+      score: Number(r.score),
+    }));
   }
 
   async getTakeEmbeddings(ids: number[]): Promise<Map<number, Float32Array>> {

--- a/test/e2e/takes-postgres.test.ts
+++ b/test/e2e/takes-postgres.test.ts
@@ -87,6 +87,12 @@ d('v0.28 takes engine — Postgres', () => {
     expect(hits.length).toBeGreaterThan(0);
     expect(hits[0].claim.toLowerCase()).toContain('technical');
 
+    const singleTermHits = await engine.searchTakes('technical');
+    expect(singleTermHits.some(h => h.claim.toLowerCase().includes('technical'))).toBe(true);
+
+    const questionHits = await engine.searchTakes('who is a technical founder?');
+    expect(questionHits.some(h => h.claim.toLowerCase().includes('technical'))).toBe(true);
+
     const worldHits = await engine.searchTakes('founder', { takesHoldersAllowList: ['world'] });
     expect(worldHits.every(h => h.holder === 'world')).toBe(true);
   });

--- a/test/takes-engine.test.ts
+++ b/test/takes-engine.test.ts
@@ -96,6 +96,14 @@ describe('searchTakes', () => {
     expect(hits.some(h => h.claim.toLowerCase().includes('technical'))).toBe(true);
   });
 
+  test('keyword search falls back to full-text for short terms and natural-language questions', async () => {
+    const singleTermHits = await engine.searchTakes('technical');
+    expect(singleTermHits.some(h => h.claim.toLowerCase().includes('technical'))).toBe(true);
+
+    const questionHits = await engine.searchTakes('who is a technical founder?');
+    expect(questionHits.some(h => h.claim.toLowerCase().includes('technical'))).toBe(true);
+  });
+
   test('searchTakes honors takesHoldersAllowList', async () => {
     const worldHits = await engine.searchTakes('founder', { takesHoldersAllowList: ['world'] });
     expect(worldHits.every(h => h.holder === 'world')).toBe(true);


### PR DESCRIPTION
## Summary

Fixes two take-retrieval gaps found while testing the rebuilt takes layer:

- `takes_search` could miss short terms and natural-language questions because it relied too narrowly on trigram similarity.
- `think` gathered keyword takes but skipped vector take recall because the local CLI and MCP operation paths did not pass an `embedQuestion` function into `runThink()`.

## Changes

- Adds full-text `websearch_to_tsquery` recall alongside pg_trgm for Postgres takes search.
- Adds all-term / any-term lexical fallbacks for natural-language questions.
- Preserves per-token holder allow-list filtering.
- Normalizes Postgres take IDs and scores into JSON-safe numbers.
- Wires `embedQuery` into both local `gbrain think` and MCP/operation `think`, while preserving graceful degradation if question embedding fails.
- Adds regression coverage for the lexical recall path.

## Verification

- `bun install --frozen-lockfile`
- `bun test test/takes-engine.test.ts test/think-pipeline.serial.test.ts test/takes-mcp-allowlist.serial.test.ts`
  - 68 pass / 0 fail

Local live smoke tests on the original checkout after the same fixes:

- `gbrain call takes_search '{"query":"Zeus","limit":3}'` returned Zeus Wallet takes.
- `gbrain call takes_search '{"query":"what does Brad believe about Bitcoin custody?","limit":3}'` returned takes.
- `gbrain think 'what does Brad believe about Bitcoin custody?' --json` reported `takesFromKeyword: 30` and `takesFromVector: 30`.
- `gbrain call think '{"question":"what does Brad believe about Bitcoin custody?","rounds":1}'` reported `takesFromKeyword: 30` and `takesFromVector: 30`.
