### PR TITLE
Add stale take embedding writer

### DIFF
--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -128,6 +128,12 @@ export interface EmbedResult {
   total_chunks: number;
   /** Number of pages processed (whether or not they had stale chunks). */
   pages_processed: number;
+  /** Takes newly embedded in this run (separate from chunk count). */
+  embedded_takes?: number;
+  /** Takes that would be embedded in dry-run mode. */
+  would_embed_takes?: number;
+  /** Total stale takes considered by the stale-takes lane. */
+  total_takes?: number;
   /** True if this run was a dry-run. */
   dryRun: boolean;
   /**
@@ -644,7 +650,11 @@ async function embedAll(
     // D7: thread sourceId so `gbrain embed --stale --source X` actually scopes.
     // v0.41.18.0 (A13): thread batchSize/priority/catchUp into the stale path.
     // #1737: thread the external abort signal so the cycle embed phase bails.
-    return await embedAllStale(engine, sourceId, dryRun, result, onProgress, staleOpts, signature, signal);
+    await embedAllStale(engine, sourceId, dryRun, result, onProgress, staleOpts, signature, signal);
+    if (!isAborted(signal)) {
+      await embedAllStaleTakes(engine, sourceId, dryRun, result, staleOpts, signal);
+    }
+    return;
   }
 
   // --all path: pacer (no-op when off). E-1: lower the worker count to the
@@ -1095,6 +1105,93 @@ async function embedAllStale(
     if (remaining > 0) {
       serr(`\n  [embed] catch-up finished but ${remaining} chunk(s) remain stale after ${embedFailures} embed failure(s). These are not embeddable as-is; re-running won't clear them until the underlying error is resolved.`);
     }
+  }
+}
+
+async function embedAllStaleTakes(
+  engine: BrainEngine,
+  sourceId: string | undefined,
+  dryRun: boolean,
+  result: EmbedResult,
+  staleOpts?: {
+    batchSize?: number;
+    pacer?: DbPacer;
+    paceMaxConcurrency?: number;
+  },
+  signal?: AbortSignal,
+) {
+  const sourceOpt = sourceId ? { sourceId } : undefined;
+  const staleCount = await engine.countStaleTakes(sourceOpt);
+  result.total_takes = (result.total_takes ?? 0) + staleCount;
+
+  if (staleCount === 0) {
+    if (dryRun) slog('[dry-run] Would embed 0 takes (0 stale found)');
+    else slog('Embedded 0 takes (0 stale found)');
+    return;
+  }
+
+  if (dryRun) {
+    result.would_embed_takes = (result.would_embed_takes ?? 0) + staleCount;
+    slog(`[dry-run] Would embed ${staleCount} stale takes`);
+    return;
+  }
+
+  const PAGE_SIZE = staleOpts?.batchSize ?? 2000;
+  const BASE_CONCURRENCY = parseInt(process.env.GBRAIN_EMBED_CONCURRENCY || '20', 10);
+  const CONCURRENCY = staleOpts?.paceMaxConcurrency
+    ? Math.min(BASE_CONCURRENCY, staleOpts.paceMaxConcurrency)
+    : BASE_CONCURRENCY;
+  const pacer = staleOpts?.pacer ?? createNoopPacer();
+  let afterTakeId = 0;
+  let embedded = 0;
+  let failures = 0;
+
+  while (!isAborted(signal)) {
+    const batch = await observed(pacer, () =>
+      engine.listStaleTakes({
+        batchSize: PAGE_SIZE,
+        afterTakeId,
+        ...(sourceId && { sourceId }),
+      }),
+    );
+    if (batch.length === 0) break;
+    afterTakeId = batch[batch.length - 1].take_id;
+
+    let embeddings: Float32Array[];
+    try {
+      embeddings = await embedBatchWithBackoff(batch.map(t => t.claim), { abortSignal: signal });
+    } catch (e: unknown) {
+      if (isAborted(signal)) break;
+      failures += batch.length;
+      serr(`\n  Error embedding take batch after id ${afterTakeId}: ${e instanceof Error ? e.message : e}`);
+      if (batch.length < PAGE_SIZE) break;
+      continue;
+    }
+    const tasks = batch.map((row, i) => ({ row, embedding: embeddings[i] }));
+    await runSlidingPool({
+      items: tasks,
+      workers: CONCURRENCY,
+      signal,
+      onItem: async ({ row, embedding }) => {
+        try {
+          const updated = await observed(pacer, () => engine.setTakeEmbedding(row.take_id, embedding));
+          if (updated) embedded++;
+        } catch (e: unknown) {
+          if (isAborted(signal)) return;
+          failures++;
+          serr(`\n  Error embedding take ${row.page_slug}#${row.row_num}: ${e instanceof Error ? e.message : e}`);
+        }
+      },
+      failureLabel: ({ row }) => `${row.page_slug}#${row.row_num}`,
+    });
+
+    if (batch.length < PAGE_SIZE) break;
+  }
+
+  result.embedded_takes = (result.embedded_takes ?? 0) + embedded;
+  slog(`Embedded ${embedded} takes`);
+  if (failures > 0) {
+    serr(`\n  [embed] ${failures} take embedding update(s) failed; re-run picks them up via embedding IS NULL.`);
   }
 }
 

--- a/src/core/cycle/phases/consolidate.ts
+++ b/src/core/cycle/phases/consolidate.ts
@@ -26,6 +26,7 @@ import type { BrainEngine, FactRow } from '../../engine.ts';
 import type { PhaseResult } from '../../cycle.ts';
 import { cosineSimilarity } from '../../facts/classify.ts';
 import { isAborted } from '../../abort-check.ts';
+import { slugify } from '../../entities/resolve.ts';
 
 export interface ConsolidatePhaseOpts {
   dryRun?: boolean;
@@ -58,6 +59,7 @@ export async function runPhaseConsolidate(
   let takesWritten = 0;
   let bucketsProcessed = 0;
   let bucketsSkipped = 0;
+  let bucketsMissingPage = 0;
 
   // Pull every (source_id, entity_slug) bucket of unconsolidated facts.
   // Uses the partial idx_facts_unconsolidated index.
@@ -122,13 +124,16 @@ export async function runPhaseConsolidate(
     bucketsProcessed += 1;
     const clusters = clusterFacts(unconsolidated, threshold);
 
-    // Resolve entity_slug → page_id. If page missing in this source, skip.
-    const pageRows = await engine.executeRaw<{ id: number }>(
-      `SELECT id FROM pages WHERE source_id = $1 AND slug = $2 AND deleted_at IS NULL LIMIT 1`,
-      [b.source_id, b.entity_slug],
-    );
-    if (pageRows.length === 0) continue;
-    const pageId = pageRows[0].id;
+    // Resolve entity_slug → page_id. Extractors can leave display-name-shaped
+    // values ("Alice Example") in older facts, so accept exact slug first and
+    // then entity-page title / slugified forms. If no entity page exists in
+    // this source, skip; consolidate never auto-creates pages.
+    const page = await resolveEntityPageForConsolidate(engine, b.source_id, b.entity_slug);
+    if (!page) {
+      bucketsMissingPage += 1;
+      continue;
+    }
+    const pageId = page.id;
 
     // Existing row_num max for this page → start appending after it.
     const rowMaxRows = await engine.executeRaw<{ max: number }>(
@@ -264,8 +269,92 @@ export async function runPhaseConsolidate(
       takes_written: takesWritten,
       buckets_processed: bucketsProcessed,
       buckets_skipped: bucketsSkipped,
+      buckets_missing_page: bucketsMissingPage,
     },
   };
+}
+
+const CONSOLIDATE_ENTITY_TYPES = ['person', 'company', 'concept', 'organization'] as const;
+
+async function resolveEntityPageForConsolidate(
+  engine: BrainEngine,
+  sourceId: string,
+  entitySlugOrName: string,
+): Promise<{ id: number; slug: string } | null> {
+  const raw = entitySlugOrName.trim();
+  if (!raw) return null;
+  const token = slugify(raw);
+  const candidates = Array.from(new Set([
+    raw,
+    token,
+    `people/${token}`,
+    `companies/${token}`,
+    `concepts/${token}`,
+    `wiki/people/${token}`,
+    `wiki/companies/${token}`,
+    `wiki/concepts/${token}`,
+    `wiki/organizations/${token}`,
+  ].filter(Boolean)));
+
+  const direct = await engine.executeRaw<{ id: number; slug: string }>(
+    `SELECT id, slug
+       FROM pages
+      WHERE source_id = $1
+        AND deleted_at IS NULL
+        AND slug = ANY($2::text[])
+      ORDER BY CASE WHEN slug = $3 THEN 0 ELSE 1 END, slug ASC
+      LIMIT 1`,
+    [sourceId, candidates, raw],
+  );
+  if (direct.length > 0) return direct[0];
+
+  const byTitle = await engine.executeRaw<{ id: number; slug: string }>(
+    `SELECT id, slug
+       FROM pages
+      WHERE source_id = $1
+        AND deleted_at IS NULL
+        AND type = ANY($3::text[])
+        AND lower(title) = lower($2)
+      ORDER BY slug ASC
+      LIMIT 1`,
+    [sourceId, raw, [...CONSOLIDATE_ENTITY_TYPES]],
+  );
+  if (byTitle.length > 0) return byTitle[0];
+
+  const suffixes = [`%/${token}`];
+  const bySuffix = await engine.executeRaw<{ id: number; slug: string }>(
+    `SELECT id, slug
+       FROM pages
+      WHERE source_id = $1
+        AND deleted_at IS NULL
+        AND type = ANY($3::text[])
+        AND slug LIKE ANY($2::text[])
+      ORDER BY slug ASC
+      LIMIT 1`,
+    [sourceId, suffixes, [...CONSOLIDATE_ENTITY_TYPES]],
+  );
+  if (bySuffix.length > 0) return bySuffix[0];
+
+  try {
+    const fuzzy = await engine.executeRaw<{ id: number; slug: string; score: number }>(
+      `SELECT id, slug,
+              GREATEST(similarity(lower(title), lower($2)), similarity(slug, $4)) AS score
+         FROM pages
+        WHERE source_id = $1
+          AND deleted_at IS NULL
+          AND type = ANY($3::text[])
+          AND (lower(title) % lower($2) OR slug ILIKE '%' || $4 || '%')
+        ORDER BY score DESC, slug ASC
+        LIMIT 1`,
+      [sourceId, raw, [...CONSOLIDATE_ENTITY_TYPES], token],
+    );
+    if (fuzzy.length > 0 && fuzzy[0].score >= 0.55) return fuzzy[0];
+  } catch {
+    // pg_trgm may be unavailable on some PGLite/Postgres builds; exact paths above
+    // are sufficient for deterministic operation.
+  }
+
+  return null;
 }
 
 /**

--- a/src/core/cycle/phases/consolidate.ts
+++ b/src/core/cycle/phases/consolidate.ts
@@ -44,6 +44,8 @@ export interface ConsolidatePhaseOpts {
   minFactsPerBucket?: number;
   /** Minimum age (ms) of the OLDEST fact in a bucket before consolidation. Default 24h. */
   minOldestAgeMs?: number;
+  /** Minimum fuzzy entity-page resolution score. Default 0.55; DB config can override. */
+  fuzzyResolveMinScore?: number;
 }
 
 export async function runPhaseConsolidate(
@@ -54,12 +56,26 @@ export async function runPhaseConsolidate(
   const threshold = opts.clusterThreshold ?? 0.85;
   const minPerBucket = opts.minFactsPerBucket ?? 3;
   const minOldestAgeMs = opts.minOldestAgeMs ?? 24 * 60 * 60 * 1000;
+  const fuzzyResolveMinScore = opts.fuzzyResolveMinScore
+    ?? await readConfigNumber(engine, 'cycle.consolidate.fuzzy_resolve_min_score', 0.55);
 
   let factsConsolidated = 0;
   let takesWritten = 0;
   let bucketsProcessed = 0;
   let bucketsSkipped = 0;
   let bucketsMissingPage = 0;
+  const resolvedBy = {
+    exact: 0,
+    title: 0,
+    suffix: 0,
+    fuzzy: 0,
+  };
+  const fuzzyResolutionSamples: Array<{
+    source_id: string;
+    entity_slug: string;
+    page_slug: string;
+    score: number;
+  }> = [];
 
   // Pull every (source_id, entity_slug) bucket of unconsolidated facts.
   // Uses the partial idx_facts_unconsolidated index.
@@ -128,10 +144,30 @@ export async function runPhaseConsolidate(
     // values ("Alice Example") in older facts, so accept exact slug first and
     // then entity-page title / slugified forms. If no entity page exists in
     // this source, skip; consolidate never auto-creates pages.
-    const page = await resolveEntityPageForConsolidate(engine, b.source_id, b.entity_slug);
+    const page = await resolveEntityPageForConsolidate(
+      engine,
+      b.source_id,
+      b.entity_slug,
+      fuzzyResolveMinScore,
+    );
     if (!page) {
       bucketsMissingPage += 1;
       continue;
+    }
+    resolvedBy[page.method] += 1;
+    if (page.method === 'fuzzy') {
+      const score = page.score ?? 0;
+      if (fuzzyResolutionSamples.length < 25) {
+        fuzzyResolutionSamples.push({
+          source_id: b.source_id,
+          entity_slug: b.entity_slug,
+          page_slug: page.slug,
+          score,
+        });
+      }
+      process.stderr.write(
+        `[consolidate] fuzzy_entity_resolution source=${b.source_id} entity_slug=${JSON.stringify(b.entity_slug)} page_slug=${JSON.stringify(page.slug)} score=${score.toFixed(3)} threshold=${fuzzyResolveMinScore}\n`,
+      );
     }
     const pageId = page.id;
 
@@ -261,8 +297,8 @@ export async function runPhaseConsolidate(
     status: factsConsolidated > 0 ? 'ok' : 'ok',
     duration_ms: 0,
     summary: dryRun
-      ? `(dry-run) would promote ${factsConsolidated} facts into ${takesWritten} takes across ${bucketsProcessed} buckets`
-      : `promoted ${factsConsolidated} facts into ${takesWritten} takes across ${bucketsProcessed} buckets`,
+      ? `(dry-run) would promote ${factsConsolidated} facts into ${takesWritten} takes across ${bucketsProcessed} buckets; resolved: ${resolvedBy.exact} exact / ${resolvedBy.title} title / ${resolvedBy.suffix} suffix / ${resolvedBy.fuzzy} fuzzy`
+      : `promoted ${factsConsolidated} facts into ${takesWritten} takes across ${bucketsProcessed} buckets; resolved: ${resolvedBy.exact} exact / ${resolvedBy.title} title / ${resolvedBy.suffix} suffix / ${resolvedBy.fuzzy} fuzzy`,
     details: {
       dryRun,
       facts_consolidated: factsConsolidated,
@@ -270,17 +306,28 @@ export async function runPhaseConsolidate(
       buckets_processed: bucketsProcessed,
       buckets_skipped: bucketsSkipped,
       buckets_missing_page: bucketsMissingPage,
+      resolved_by: resolvedBy,
+      fuzzy_resolve_min_score: fuzzyResolveMinScore,
+      fuzzy_resolution_samples: fuzzyResolutionSamples,
     },
   };
 }
 
 const CONSOLIDATE_ENTITY_TYPES = ['person', 'company', 'concept', 'organization'] as const;
+type ConsolidateEntityResolutionMethod = 'exact' | 'title' | 'suffix' | 'fuzzy';
+type ConsolidateEntityResolution = {
+  id: number;
+  slug: string;
+  method: ConsolidateEntityResolutionMethod;
+  score?: number;
+};
 
 async function resolveEntityPageForConsolidate(
   engine: BrainEngine,
   sourceId: string,
   entitySlugOrName: string,
-): Promise<{ id: number; slug: string } | null> {
+  fuzzyMinScore: number,
+): Promise<ConsolidateEntityResolution | null> {
   const raw = entitySlugOrName.trim();
   if (!raw) return null;
   const token = slugify(raw);
@@ -306,7 +353,7 @@ async function resolveEntityPageForConsolidate(
       LIMIT 1`,
     [sourceId, candidates, raw],
   );
-  if (direct.length > 0) return direct[0];
+  if (direct.length > 0) return { id: direct[0].id, slug: direct[0].slug, method: 'exact' };
 
   const byTitle = await engine.executeRaw<{ id: number; slug: string }>(
     `SELECT id, slug
@@ -319,7 +366,7 @@ async function resolveEntityPageForConsolidate(
       LIMIT 1`,
     [sourceId, raw, [...CONSOLIDATE_ENTITY_TYPES]],
   );
-  if (byTitle.length > 0) return byTitle[0];
+  if (byTitle.length > 0) return { id: byTitle[0].id, slug: byTitle[0].slug, method: 'title' };
 
   const suffixes = [`%/${token}`];
   const bySuffix = await engine.executeRaw<{ id: number; slug: string }>(
@@ -333,7 +380,7 @@ async function resolveEntityPageForConsolidate(
       LIMIT 1`,
     [sourceId, suffixes, [...CONSOLIDATE_ENTITY_TYPES]],
   );
-  if (bySuffix.length > 0) return bySuffix[0];
+  if (bySuffix.length > 0) return { id: bySuffix[0].id, slug: bySuffix[0].slug, method: 'suffix' };
 
   try {
     const fuzzy = await engine.executeRaw<{ id: number; slug: string; score: number }>(
@@ -348,13 +395,30 @@ async function resolveEntityPageForConsolidate(
         LIMIT 1`,
       [sourceId, raw, [...CONSOLIDATE_ENTITY_TYPES], token],
     );
-    if (fuzzy.length > 0 && fuzzy[0].score >= 0.55) return fuzzy[0];
+    if (fuzzy.length > 0 && fuzzy[0].score >= fuzzyMinScore) {
+      return { id: fuzzy[0].id, slug: fuzzy[0].slug, method: 'fuzzy', score: fuzzy[0].score };
+    }
   } catch {
     // pg_trgm may be unavailable on some PGLite/Postgres builds; exact paths above
     // are sufficient for deterministic operation.
   }
 
   return null;
+}
+
+async function readConfigNumber(
+  engine: BrainEngine,
+  key: string,
+  fallback: number,
+): Promise<number> {
+  try {
+    const raw = await engine.getConfig(key);
+    if (raw == null || raw.trim() === '') return fallback;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
 }
 
 /**

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -322,9 +322,16 @@ export interface TakeHit {
 /** v0.28 stale-takes row (mirrors StaleChunkRow shape). Embedding column intentionally omitted. */
 export interface StaleTakeRow {
   take_id: number;
+  source_id: string;
   page_slug: string;
   row_num: number;
   claim: string;
+}
+
+export interface StaleTakesOpts {
+  sourceId?: string;
+  batchSize?: number;
+  afterTakeId?: number;
 }
 
 /** Resolution metadata for resolveTake. */
@@ -1449,10 +1456,13 @@ export interface BrainEngine {
   getTakeEmbeddings(ids: number[]): Promise<Map<number, Float32Array>>;
 
   /** Pre-flight count for `gbrain embed --stale`. WHERE active AND embedding IS NULL. */
-  countStaleTakes(): Promise<number>;
+  countStaleTakes(opts?: { sourceId?: string }): Promise<number>;
 
   /** List stale takes (no embedding column in payload — same pattern as listStaleChunks). */
-  listStaleTakes(): Promise<StaleTakeRow[]>;
+  listStaleTakes(opts?: StaleTakesOpts): Promise<StaleTakeRow[]>;
+
+  /** Write one take embedding produced from the take's bare claim text. */
+  setTakeEmbedding(takeId: number, embedding: Float32Array): Promise<boolean>;
 
   /**
    * Update a take's mutable fields. May NOT change claim/kind/holder per the

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -9,7 +9,7 @@ import type {
   ReservedConnection,
   DreamVerdict, DreamVerdictInput,
   FileSpec, FileRow,
-  TakeBatchInput, Take, TakesListOpts, TakeHit, StaleTakeRow,
+  TakeBatchInput, Take, TakesListOpts, TakeHit, StaleTakeRow, StaleTakesOpts,
   TakeResolution, SynthesisEvidenceInput,
   TakesScorecard, TakesScorecardOpts, CalibrationBucket, CalibrationCurveOpts,
   FactRow, FactKind, FactVisibility, FactInsertStatus,
@@ -4360,21 +4360,47 @@ export class PGLiteEngine implements BrainEngine {
     return out;
   }
 
-  async countStaleTakes(): Promise<number> {
+  async setTakeEmbedding(takeId: number, embedding: Float32Array): Promise<boolean> {
+    const embedStr = toPgVectorLiteral(embedding);
+    const result = await this.db.query(
+      `UPDATE takes SET
+         embedding = $2::vector,
+         embedded_at = now(),
+         updated_at = now()
+       WHERE id = $1
+       RETURNING 1`,
+      [takeId, embedStr],
+    );
+    return result.rows.length > 0;
+  }
+
+  async countStaleTakes(opts: { sourceId?: string } = {}): Promise<number> {
     const { rows } = await this.db.query(
-      `SELECT count(*)::int AS count FROM takes WHERE active AND embedding IS NULL`
+      `SELECT count(*)::int AS count
+       FROM takes t
+       JOIN pages p ON p.id = t.page_id
+       WHERE t.active
+         AND t.embedding IS NULL
+         AND ($1::text IS NULL OR p.source_id = $1)`,
+      [opts.sourceId ?? null],
     );
     return Number((rows[0] as { count?: number } | undefined)?.count ?? 0);
   }
 
-  async listStaleTakes(): Promise<StaleTakeRow[]> {
+  async listStaleTakes(opts: StaleTakesOpts = {}): Promise<StaleTakeRow[]> {
+    const limit = Math.max(1, Math.min(10_000, opts.batchSize ?? 2000));
+    const afterTakeId = opts.afterTakeId ?? 0;
     const { rows } = await this.db.query(
-      `SELECT t.id AS take_id, p.slug AS page_slug, t.row_num, t.claim
+      `SELECT t.id AS take_id, p.source_id, p.slug AS page_slug, t.row_num, t.claim
        FROM takes t
        JOIN pages p ON p.id = t.page_id
-       WHERE t.active AND t.embedding IS NULL
+       WHERE t.active
+         AND t.embedding IS NULL
+         AND t.id > $1
+         AND ($2::text IS NULL OR p.source_id = $2)
        ORDER BY t.id
-       LIMIT 100000`
+       LIMIT $3`,
+      [afterTakeId, opts.sourceId ?? null, limit],
     );
     return rows as unknown as StaleTakeRow[];
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -6,7 +6,7 @@ import type {
   ReservedConnection,
   DreamVerdict, DreamVerdictInput,
   FileSpec, FileRow,
-  TakeBatchInput, Take, TakesListOpts, TakeHit, StaleTakeRow,
+  TakeBatchInput, Take, TakesListOpts, TakeHit, StaleTakeRow, StaleTakesOpts,
   TakeResolution, SynthesisEvidenceInput,
   TakesScorecard, TakesScorecardOpts, CalibrationBucket, CalibrationCurveOpts,
   FactRow, FactKind, FactVisibility, FactInsertStatus,
@@ -3693,6 +3693,7 @@ export class PostgresEngine implements BrainEngine {
    * type exactly. Initialized lazily in `insertFacts`.
    */
   private _factsEmbeddingCastSuffix: '::vector' | '::halfvec' | null = null;
+  private _takesEmbeddingCastSuffix: '::vector' | '::halfvec' | null = null;
 
   /** Test seam: clear the cached cast suffix so tests can re-probe. */
   __resetFactsEmbeddingCastCacheForTest(): void {
@@ -3733,6 +3734,30 @@ export class PostgresEngine implements BrainEngine {
       this._factsEmbeddingCastSuffix = '::vector';
     }
     return this._factsEmbeddingCastSuffix;
+  }
+
+  private async resolveTakesEmbeddingCast(): Promise<'::vector' | '::halfvec'> {
+    if (this._takesEmbeddingCastSuffix !== null) return this._takesEmbeddingCastSuffix;
+    const sql = this.sql;
+    try {
+      const rows = await sql<Array<{ formatted: string | null }>>`
+        SELECT format_type(a.atttypid, a.atttypmod) AS formatted
+          FROM pg_attribute a
+          JOIN pg_class c ON c.oid = a.attrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public'
+           AND c.relname = 'takes'
+           AND a.attname = 'embedding'
+           AND NOT a.attisdropped
+      `;
+      const formatted = rows?.[0]?.formatted ?? null;
+      this._takesEmbeddingCastSuffix = formatted && /halfvec\(\d+\)/i.test(formatted)
+        ? '::halfvec'
+        : '::vector';
+    } catch {
+      this._takesEmbeddingCastSuffix = '::vector';
+    }
+    return this._takesEmbeddingCastSuffix;
   }
 
   async insertFacts(
@@ -4400,23 +4425,48 @@ export class PostgresEngine implements BrainEngine {
     return out;
   }
 
-  async countStaleTakes(): Promise<number> {
+  async setTakeEmbedding(takeId: number, embedding: Float32Array): Promise<boolean> {
+    const sql = this.sql;
+    const embedLit = toPgVectorLiteral(embedding);
+    const castSuffix = await this.resolveTakesEmbeddingCast();
+    const result = await sql`
+      UPDATE takes SET
+        embedding = ${sql.unsafe(`'${embedLit}'${castSuffix}`)},
+        embedded_at = now(),
+        updated_at = now()
+      WHERE id = ${takeId}
+      RETURNING 1
+    `;
+    return result.length > 0;
+  }
+
+  async countStaleTakes(opts: { sourceId?: string } = {}): Promise<number> {
     const sql = this.sql;
     const [row] = await sql`
-      SELECT count(*)::int AS count FROM takes WHERE active AND embedding IS NULL
+      SELECT count(*)::int AS count
+      FROM takes t
+      JOIN pages p ON p.id = t.page_id
+      WHERE t.active
+        AND t.embedding IS NULL
+        AND (${opts.sourceId ?? null}::text IS NULL OR p.source_id = ${opts.sourceId ?? null})
     `;
     return Number((row as { count?: number } | undefined)?.count ?? 0);
   }
 
-  async listStaleTakes(): Promise<StaleTakeRow[]> {
+  async listStaleTakes(opts: StaleTakesOpts = {}): Promise<StaleTakeRow[]> {
     const sql = this.sql;
+    const limit = Math.max(1, Math.min(10_000, opts.batchSize ?? 2000));
+    const afterTakeId = opts.afterTakeId ?? 0;
     const rows = await sql`
-      SELECT t.id AS take_id, p.slug AS page_slug, t.row_num, t.claim
+      SELECT t.id AS take_id, p.source_id, p.slug AS page_slug, t.row_num, t.claim
       FROM takes t
       JOIN pages p ON p.id = t.page_id
-      WHERE t.active AND t.embedding IS NULL
+      WHERE t.active
+        AND t.embedding IS NULL
+        AND t.id > ${afterTakeId}
+        AND (${opts.sourceId ?? null}::text IS NULL OR p.source_id = ${opts.sourceId ?? null})
       ORDER BY t.id
-      LIMIT 100000
+      LIMIT ${limit}
     `;
     return rows as unknown as StaleTakeRow[];
   }

--- a/test/cycle-consolidate.test.ts
+++ b/test/cycle-consolidate.test.ts
@@ -152,6 +152,27 @@ describe('runPhaseConsolidate', () => {
     }
   });
 
+  test('display-name entity_slug resolves to an existing entity page', async () => {
+    const pageId = await engine.putPage('wiki/people/brad-mills', {
+      title: 'Brad Mills',
+      type: 'person' as const,
+      compiled_truth: '# Brad Mills\n',
+    });
+    for (let i = 0; i < 3; i++) {
+      await engine.executeRaw(
+        `INSERT INTO facts (source_id, entity_slug, fact, kind, source, valid_from, confidence, embedding, embedded_at)
+         VALUES ('default', 'Brad Mills', $1, 'fact', 'test', $2::timestamptz, 0.9, $3::vector, $2::timestamptz)`,
+        [`brad display-name fact ${i}`, oldDate(), unitVec()],
+      );
+    }
+
+    const r = await runPhaseConsolidate(engine, {});
+    expect(r.details.facts_consolidated).toBe(3);
+    expect(r.details.takes_written).toBe(1);
+    const takes = await engine.executeRaw<{ page_id: number }>(`SELECT page_id FROM takes`);
+    expect(takes[0]?.page_id).toBe(pageId.id);
+  });
+
   test('skips bucket when no matching page exists in source', async () => {
     // Don't seed a page — entity_slug 'no-page' won't resolve.
     for (let i = 0; i < 4; i++) {

--- a/test/cycle-consolidate.test.ts
+++ b/test/cycle-consolidate.test.ts
@@ -169,8 +169,65 @@ describe('runPhaseConsolidate', () => {
     const r = await runPhaseConsolidate(engine, {});
     expect(r.details.facts_consolidated).toBe(3);
     expect(r.details.takes_written).toBe(1);
+    expect((r.details.resolved_by as Record<string, number>).exact).toBeGreaterThanOrEqual(1);
     const takes = await engine.executeRaw<{ page_id: number }>(`SELECT page_id FROM takes`);
     expect(takes[0]?.page_id).toBe(pageId.id);
+  });
+
+  test('fuzzy entity resolution is audited and counted in the phase result', async () => {
+    const pageId = await engine.putPage('wiki/companies/beyond-the-checkout', {
+      title: 'Beyond the Checkout',
+      type: 'company' as const,
+      compiled_truth: '# Beyond the Checkout\n',
+    });
+    for (let i = 0; i < 3; i++) {
+      await engine.executeRaw(
+        `INSERT INTO facts (source_id, entity_slug, fact, kind, source, valid_from, confidence, embedding, embedded_at)
+         VALUES ('default', 'Beyond Checkout', $1, 'fact', 'test', $2::timestamptz, 0.9, $3::vector, $2::timestamptz)`,
+        [`beyond checkout fuzzy fact ${i}`, oldDate(), unitVec()],
+      );
+    }
+
+    const r = await runPhaseConsolidate(engine, {});
+    expect(r.details.facts_consolidated).toBe(3);
+    expect(r.details.takes_written).toBe(1);
+    expect(r.summary).toContain('fuzzy');
+    expect((r.details.resolved_by as Record<string, number>).fuzzy).toBeGreaterThanOrEqual(1);
+    const samples = r.details.fuzzy_resolution_samples as Array<{ entity_slug: string; page_slug: string; score: number }>;
+    expect(samples.length).toBeGreaterThanOrEqual(1);
+    expect(samples[0].entity_slug).toBe('Beyond Checkout');
+    expect(samples[0].page_slug).toBe('wiki/companies/beyond-the-checkout');
+    expect(samples[0].score).toBeGreaterThanOrEqual(0.55);
+
+    const takes = await engine.executeRaw<{ page_id: number }>(`SELECT page_id FROM takes`);
+    expect(takes[0]?.page_id).toBe(pageId.id);
+  });
+
+  test('cycle.consolidate.fuzzy_resolve_min_score can disable loose fuzzy matches', async () => {
+    await engine.setConfig('cycle.consolidate.fuzzy_resolve_min_score', '0.99');
+    try {
+      await engine.putPage('wiki/companies/beyond-the-checkout', {
+        title: 'Beyond the Checkout',
+        type: 'company' as const,
+        compiled_truth: '# Beyond the Checkout\n',
+      });
+      for (let i = 0; i < 3; i++) {
+        await engine.executeRaw(
+          `INSERT INTO facts (source_id, entity_slug, fact, kind, source, valid_from, confidence, embedding, embedded_at)
+           VALUES ('default', 'Beyond Checkout', $1, 'fact', 'test', $2::timestamptz, 0.9, $3::vector, $2::timestamptz)`,
+          [`beyond checkout gated fact ${i}`, oldDate(), unitVec()],
+        );
+      }
+
+      const r = await runPhaseConsolidate(engine, {});
+      expect(r.details.facts_consolidated).toBe(0);
+      expect(r.details.takes_written).toBe(0);
+      expect(r.details.fuzzy_resolve_min_score).toBe(0.99);
+      expect((r.details.resolved_by as Record<string, number>).fuzzy).toBe(0);
+      expect(r.details.buckets_missing_page).toBeGreaterThanOrEqual(1);
+    } finally {
+      await engine.unsetConfig('cycle.consolidate.fuzzy_resolve_min_score');
+    }
   });
 
   test('skips bucket when no matching page exists in source', async () => {

--- a/test/e2e/takes-postgres.test.ts
+++ b/test/e2e/takes-postgres.test.ts
@@ -154,6 +154,30 @@ d('v0.28 takes engine — Postgres', () => {
     const stale = await engine.listStaleTakes();
     expect(stale.length).toBe(count);
     expect(stale[0]).toHaveProperty('take_id');
+    expect(stale[0]).toHaveProperty('source_id');
+
+    const defaultCount = await engine.countStaleTakes({ sourceId: 'default' });
+    expect(defaultCount).toBe(count);
+    const missingSource = await engine.listStaleTakes({ sourceId: 'missing-source' });
+    expect(missingSource).toHaveLength(0);
+  });
+
+  test('setTakeEmbedding clears one stale take on real Postgres', async () => {
+    const engine = getEngine();
+    const before = await engine.countStaleTakes();
+    const [row] = await engine.listStaleTakes({ batchSize: 1 });
+    expect(row).toBeTruthy();
+
+    const embedding = new Float32Array(1536);
+    embedding[0] = 1;
+    embedding[1] = 0.5;
+    const updated = await engine.setTakeEmbedding(row.take_id, embedding);
+    expect(updated).toBe(true);
+
+    const after = await engine.countStaleTakes();
+    expect(after).toBe(before - 1);
+    const embeddings = await engine.getTakeEmbeddings([row.take_id]);
+    expect(embeddings.get(row.take_id)?.[0]).toBe(1);
   });
 });
 

--- a/test/embed.serial.test.ts
+++ b/test/embed.serial.test.ts
@@ -56,6 +56,9 @@ function mockEngine(overrides: Partial<Record<string, any>> = {}): BrainEngine {
   const track = (method: string) => (...args: any[]) => {
     calls.push({ method, args });
     if (overrides[method]) return overrides[method](...args);
+    if (method === 'countStaleTakes') return Promise.resolve(0);
+    if (method === 'listStaleTakes') return Promise.resolve([]);
+    if (method === 'setTakeEmbedding') return Promise.resolve(true);
     return Promise.resolve(null);
   };
   const engine = new Proxy({} as any, {
@@ -224,6 +227,27 @@ describe('runEmbed --all (parallel)', () => {
 
     // Only the stale page triggers an embedBatch call.
     expect(totalEmbedCalls).toBe(1);
+  });
+
+  test('wires stale takes through the same --stale embedding pass', async () => {
+    const staleTakes = [
+      { take_id: 101, source_id: 'default', page_slug: 'people/alice-example', row_num: 1, claim: 'Alice is technical' },
+      { take_id: 102, source_id: 'default', page_slug: 'companies/acme-example', row_num: 1, claim: 'Acme is growing' },
+    ];
+    const updated: number[] = [];
+    const engine = mockEngine({
+      countStaleChunks: async () => 0,
+      countStaleTakes: async () => staleTakes.length,
+      listStaleTakes: async ({ afterTakeId }: { afterTakeId?: number }) =>
+        afterTakeId && afterTakeId >= 102 ? [] : staleTakes,
+      setTakeEmbedding: async (id: number) => { updated.push(id); return true; },
+    });
+
+    const result = await runEmbedCore(engine, { stale: true });
+
+    expect(totalEmbedCalls).toBe(1);
+    expect(updated.sort()).toEqual([101, 102]);
+    expect(result.embedded_takes).toBe(2);
   });
 });
 

--- a/test/takes-engine.test.ts
+++ b/test/takes-engine.test.ts
@@ -373,6 +373,24 @@ describe('countStaleTakes + listStaleTakes', () => {
     const stale = await engine.listStaleTakes();
     expect(stale.length).toBe(count);
     expect(stale[0]).toHaveProperty('take_id');
+    expect(stale[0]).toHaveProperty('source_id');
     expect(stale[0]).toHaveProperty('claim');
+  });
+
+  test('setTakeEmbedding clears one stale take and makes it retrievable', async () => {
+    const before = await engine.countStaleTakes();
+    const [row] = await engine.listStaleTakes({ batchSize: 1 });
+    expect(row).toBeTruthy();
+
+    const embedding = new Float32Array(1536);
+    embedding[0] = 1;
+    embedding[1] = 0.5;
+    const updated = await engine.setTakeEmbedding(row.take_id, embedding);
+    expect(updated).toBe(true);
+
+    const after = await engine.countStaleTakes();
+    expect(after).toBe(before - 1);
+    const embeddings = await engine.getTakeEmbeddings([row.take_id]);
+    expect(embeddings.get(row.take_id)?.[0]).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- wires `gbrain embed --stale` to also scan active takes with `embedding IS NULL`
- implements `countStaleTakes`, `listStaleTakes({ sourceId, batchSize, afterTakeId })`, and `setTakeEmbedding` for both PGLite and Postgres
- writes take embeddings from the bare `claim`, stamps `embedded_at`, supports vector/halfvec Postgres columns, and keeps stale take work source-scoped
- loosens consolidate page resolution for older display-name-shaped `facts.entity_slug` values (exact slug first, then entity title / slugified paths) so eligible facts can actually promote to an entity page

## Why

The facts→takes consolidate lane can promote facts into `takes`, but new take rows were not picked up by `gbrain embed --stale`: the stale-take engine methods were effectively dead stubs and there was no `UPDATE takes SET embedding = ...` path. A consolidate run could therefore create invisible/retrieval-dead takes until someone manually re-embedded them out of band.

## Verification

- `bun test test/takes-engine.test.ts test/embed.serial.test.ts test/cycle-consolidate.test.ts` — pass (62/62)
- `bun test test/e2e/takes-postgres.test.ts` — pass/skip without `DATABASE_URL` (23 skipped)
- `scripts/check-jsonb-pattern.sh && scripts/check-test-isolation.sh && scripts/check-privacy.sh && scripts/check-test-real-names.sh` — pass
- `bun run build` — pass

Local note: `bun run verify` currently fails in this checkout on an unrelated OpenClaw SDK type mismatch (`buildMemorySystemPromptAddition` missing from `/Users/senemaro/node_modules/openclaw/dist/plugin-sdk/core`), not in the changed takes/consolidate code.
