### PR TITLE
fix(init): point soul-audit hint at the conversational skill, not a nonexistent CLI verb

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1455,7 +1455,7 @@ export function reportModStatus(): void {
     console.log('  cd ~/.claude/skills/gstack && ./setup');
   }
   console.log('Resolver: skills/RESOLVER.md');
-  console.log('Soul audit: run `gbrain soul-audit` to customize agent identity');
+  console.log('Soul audit: ask your agent to "run a soul audit" to customize its identity (see skills/soul-audit)');
   // Retrieval Reflex (#1981): the deterministic pointer layer is ON by default
   // (no action needed). The policy skill is installed into the HOST repo on
   // request — we PRINT the command rather than silently mutating the host repo.


### PR DESCRIPTION
## Problem
`gbrain init` ends by printing:

> Soul audit: run `gbrain soul-audit` to customize agent identity

But `soul-audit` is not a CLI command — it's a conversational agent skill (`skills/soul-audit/SKILL.md`, invoked by natural language like "run a soul audit"). Running `gbrain soul-audit` falls through the dispatcher to `Unknown command: soul-audit` and exits 1, so the closing line of the very first command a new user runs points them at a dead end. Fixes #2102.

## Fix
Reword the single hint line to point at the conversational skill instead of the nonexistent verb — issue #2102's preferred Option 1 (reword, do not add a CLI command). One-line, string-only change in `src/commands/init.ts`; no command/dispatch changes.

---
*Co-developed with my AI coding agent; verified that the soul-audit surface is a conversational skill, not a CLI verb.*