### PR TITLE
fix(gateway): drop non-string text parts in toModelMessages (AI SDK v6 schema reject)

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2360,11 +2360,20 @@ export function toModelMessages(messages: ChatMessage[]): unknown[] {
     }
     return {
       role: m.role,
-      content: blocks.map((b) => {
-        if (b.type === 'text') return { type: 'text' as const, text: b.text };
-        if (b.type === 'tool-call') return { type: 'tool-call' as const, toolCallId: b.toolCallId, toolName: b.toolName, input: b.input };
-        return b;
-      }),
+      content: blocks
+        // Drop text blocks whose `text` is not a string. AI SDK v6 rejects a
+        // text part with undefined/null text ("messages do not match the
+        // ModelMessage[] schema"), failing the whole turn. A reasoning model
+        // (e.g. DeepSeek v4) can emit such a part; the type says `text: string`
+        // but the value arrives from the provider at runtime. Mirrors the
+        // replay path (adaptContentBlocksToChatBlocks), which also drops it —
+        // the reason a job could fail inline yet recover on resume.
+        .filter((b) => b.type !== 'text' || typeof b.text === 'string')
+        .map((b) => {
+          if (b.type === 'text') return { type: 'text' as const, text: b.text };
+          if (b.type === 'tool-call') return { type: 'tool-call' as const, toolCallId: b.toolCallId, toolName: b.toolName, input: b.input };
+          return b;
+        }),
     };
   });
 }

--- a/test/gateway-model-messages.test.ts
+++ b/test/gateway-model-messages.test.ts
@@ -107,6 +107,46 @@ describe('toModelMessages — v6 ModelMessage shape', () => {
     ]);
   });
 
+  // Regression: a reasoning model (e.g. DeepSeek v4) can emit a text part whose
+  // `text` is undefined/null. AI SDK v6 rejects it ("messages do not match the
+  // ModelMessage[] schema"), failing the whole turn. toModelMessages must drop
+  // such parts (mirroring the replay path), so the bug shows up inline but a
+  // resumed run — rebuilt via adaptContentBlocksToChatBlocks — recovers.
+  test('non-string text block is dropped (v6 rejects undefined/null text)', () => {
+    const msgs: ChatMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: undefined as unknown as string },
+          { type: 'tool-call', toolCallId: 'c1', toolName: 'search', input: {} },
+        ],
+      },
+    ];
+    expect(toModelMessages(msgs)).toEqual([
+      { role: 'assistant', content: [{ type: 'tool-call', toolCallId: 'c1', toolName: 'search', input: {} }] },
+    ]);
+  });
+
+  test('valid text alongside a non-string text block is kept; null text dropped', () => {
+    const msgs: ChatMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'real answer' },
+          { type: 'text', text: null as unknown as string },
+        ],
+      },
+    ];
+    expect(toModelMessages(msgs)).toEqual([
+      { role: 'assistant', content: [{ type: 'text', text: 'real answer' }] },
+    ]);
+  });
+
+  test('empty-string text is kept (valid for v6)', () => {
+    const msgs: ChatMessage[] = [{ role: 'assistant', content: [{ type: 'text', text: '' }] }];
+    expect(toModelMessages(msgs)).toEqual([{ role: 'assistant', content: [{ type: 'text', text: '' }] }]);
+  });
+
   test('full multi-turn conversation: user → assistant(tool-call) → tool(result)', () => {
     const msgs: ChatMessage[] = [
       { role: 'user', content: 'find widget' },


### PR DESCRIPTION
A reasoning model (e.g. DeepSeek v4) can return a text content part whose `text` is `undefined`/`null`. The block type is `{type:'text', text:string}`, but the value arrives from the provider at runtime. On the next turn, `toModelMessages` emits it verbatim and AI SDK v6 rejects the request locally with `Invalid prompt: The messages do not match the ModelMessage[] schema` — failing the whole turn. (Confirmed: v6 rejects a text part with `undefined`/`null` text; empty-string text is fine.)

Intermittent, and in the subagent loop it *recovers on resume* because the replay path (`adaptContentBlocksToChatBlocks`) already drops non-string-text parts — so the rebuilt conversation is clean while the in-memory one was not.

**Fix**: `toModelMessages` (the documented `ChatMessage[]` → v6 `ModelMessage[]` converter) drops text parts whose `text` is not a string, mirroring the replay path. Covers every message source (live loop, replay, future). Empty content is valid for v6, so a turn left empty by the drop still passes.

**Tests** pin: non-string text dropped, valid siblings kept, empty-string kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)