### PR TITLE
fix(ai): emit dimensions for Qwen3-Embedding on openai-compatible path

### DIFF
--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -220,6 +220,14 @@ export function dimsProviderOptions(
       if (modelId === 'text-embedding-v3' || modelId === 'embedding-3') {
         return { openaiCompatible: { dimensions: dims } };
       }
+      // Qwen3-Embedding family (qwen3-embedding-0.6b/4b/8b) — Matryoshka models
+      // that accept `dimensions` on the OpenAI-compat path. Commonly reached via
+      // a LiteLLM/OpenRouter proxy; without `dimensions` the provider returns its
+      // native width (e.g. 4096 for 8b) and a brain configured for a smaller dim
+      // (1536) hard-fails at first embed. Symmetric retrieval — inputType ignored.
+      if (modelId.includes('qwen3-embedding')) {
+        return { openaiCompatible: { dimensions: dims } };
+      }
       // MiniMax embo-01 takes a `type: 'db' | 'query'` field for asymmetric
       // retrieval. Today still hardcoded to 'db' for back-compat — opting
       // into the new inputType seam is a follow-up (see plan's deferred


### PR DESCRIPTION
## Problem

`dimsProviderOptions` (`src/core/ai/dims.ts`) pins output `dimensions` for the Matryoshka models reachable over the `openai-compatible` adapter — ZeroEntropy `zembed-1`, Voyage, `text-embedding-3*`, DashScope `text-embedding-v3`, Zhipu `embedding-3`. The **Qwen3-Embedding** family (`qwen3-embedding-0.6b/4b/8b`) is also Matryoshka and accepts `dimensions`, but isn't in the list.

So a brain that routes Qwen3-Embedding via a LiteLLM/OpenRouter proxy never gets `dimensions` emitted → the provider returns its **native** width (4096 for the 8b) instead of the configured `embedding_dimensions` → a brain on a 1536-dim schema hard-fails at first embed (dimension mismatch).

## Fix

Add the `qwen3-embedding` family to the same `openai-compatible` passthrough, mirroring the existing DashScope/Zhipu entry (`return { openaiCompatible: { dimensions: dims } }`). 

- No-op for every other model (guarded by the `includes('qwen3-embedding')` check).
- Symmetric retrieval, so `inputType` is ignored — consistent with the DashScope/Zhipu/text-embedding-3 entries right above it.
- Matches the file's existing idiom (one per-model/family check per Matryoshka model on the openai-compat path).

## Notes
- No version/CHANGELOG bump — leaving release mechanics to the maintainer's ship flow.
- Pairs with #2455 (reranker touchpoint) and #2472 (native-anthropic base_urls) as the set of small touchpoints needed to run gbrain fully through a LiteLLM proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)