### PR TITLE
fix(ai): serialize Date in tool-result json output so Postgres timestamps don't crash multi-tool loops (#2433)

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2354,7 +2354,7 @@ export function toModelMessages(messages: ChatMessage[]): unknown[] {
               ? { type: 'error-text' as const, value: typeof b.output === 'string' ? b.output : JSON.stringify(b.output) }
               : (typeof b.output === 'string'
                 ? { type: 'text' as const, value: b.output }
-                : { type: 'json' as const, value: (b.output ?? null) as never }),
+                : { type: 'json' as const, value: JSON.parse(JSON.stringify(b.output ?? null)) as never }),
           })),
       };
     }

--- a/test/gateway-model-messages.test.ts
+++ b/test/gateway-model-messages.test.ts
@@ -60,6 +60,35 @@ describe('toModelMessages — v6 ModelMessage shape', () => {
     ]);
   });
 
+  test('Date in tool-result json output serializes to ISO string (Postgres timestamps, #2433)', () => {
+    const msgs: ChatMessage[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'c1',
+            toolName: 'brain_list_pages',
+            output: { rows: [{ updated_at: new Date('2026-06-26T06:56:59.000Z') }] },
+          },
+        ],
+      },
+    ];
+    expect(toModelMessages(msgs)).toEqual([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'c1',
+            toolName: 'brain_list_pages',
+            output: { type: 'json', value: { rows: [{ updated_at: '2026-06-26T06:56:59.000Z' }] } },
+          },
+        ],
+      },
+    ]);
+  });
+
   test('string tool-result output becomes {type:text,value}', () => {
     const msgs: ChatMessage[] = [
       {


### PR DESCRIPTION
## Summary

Fixes #2433. Any multi-tool rollout or subagent loop that called a brain tool returning Postgres timestamp columns (e.g. `brain_list_pages`, `brain_query`) crashed AI SDK v6 validation with `AI_InvalidPromptError: The messages do not match the ModelMessage[] schema`.

## Root cause

`node-postgres` deserializes timestamp columns into JS `Date` instances. `toModelMessages()` (`src/core/ai/gateway.ts`) emitted the tool result in its `json` branch as `{ type: 'json', value: b.output }`, passing those `Date`s through raw. AI SDK v6's `jsonValueSchema` accepts only `null | string | number | boolean | record | array` — not `Date` — so the entire message tree was rejected.

## Fix

JSON-roundtrip the value in the `json` branch so `Date`s (including nested ones) serialize to ISO strings the validator accepts:

```ts
value: JSON.parse(JSON.stringify(b.output ?? null)) as never
```

Scope kept tight: the `error-text` branch already stringifies and is untouched; no `BigInt` handling added (that's a separate concern, #2450).

## Test

`test/gateway-model-messages.test.ts` gains a case feeding a tool-result whose `output` nests a `Date`, asserting it serializes to the ISO string. Confirmed it **fails on the pre-fix code** (receives a raw `Date`) and **passes after**. The issue author independently verified the fix on a real workload (subagent rollout success 1/5 → 5/5).

## Verification

- `bun run typecheck` → clean (`EXIT=0`)
- `bun test test/gateway-model-messages.test.ts` → all pass

Closes #2433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
