### PR TITLE
fix(cli): BigInt-safe JSON serialization so local-op output normalization doesn't crash (#2450)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -440,9 +440,10 @@ async function main() {
     }
     // ENG-2 (renderer parity by data shape): JSON-round-trip the local-engine
     // path's return value so renderers see the same shape they'd see on the
-    // routed path. Date → ISO string; bigint → string (postgres.js shape);
-    // Buffer → object. Microsecond-cost; eliminates a whole drift bug class.
-    const result = JSON.parse(JSON.stringify(rawResult));
+    // routed path. Date → ISO string; bigint → string (postgres.js shape, via
+    // bigintReplacer — a bare stringify THROWS on bigint, #2450); Buffer →
+    // object. Microsecond-cost; eliminates a whole drift bug class.
+    const result = normalizeLocalResult(rawResult);
     const output = formatResult(op.name, result);
     if (output) process.stdout.write(output);
   } catch (e: unknown) {
@@ -816,6 +817,24 @@ async function makeContext(engine: BrainEngine, params: Record<string, unknown>)
   };
 }
 
+// JSON.stringify replacer that survives a `bigint` anywhere in the tree.
+// Mirrors the postgres.js wire shape (int8 → string), which is exactly what
+// the ENG-2 renderer-parity comment promises: a bare JSON.stringify THROWS on
+// bigint, so the "bigint → string" parity was never actually achieved.
+// Stringify (never Number()) so a BIGSERIAL key past MAX_SAFE_INTEGER keeps
+// full precision and matches the routed-path shape. (#2450)
+export function bigintReplacer(_key: string, value: unknown): unknown {
+  return typeof value === 'bigint' ? value.toString() : value;
+}
+
+// ENG-2 renderer parity: round-trip a local-engine op's return value so
+// renderers see the same shape the routed path produces. Bigint-safe via
+// bigintReplacer. Exported for tests (same import-safety contract as
+// cliAliases/formatResult). (#2450)
+export function normalizeLocalResult(rawResult: unknown): unknown {
+  return JSON.parse(JSON.stringify(rawResult, bigintReplacer));
+}
+
 // Exported for tests (same import-safety contract as cliAliases/printOpHelp).
 export function formatResult(opName: string, result: unknown): string {
   switch (opName) {
@@ -939,7 +958,9 @@ export function formatResult(opName: string, result: unknown): string {
       ).join('\n') + '\n';
     }
     default:
-      return JSON.stringify(result, null, 2) + '\n';
+      // bigintReplacer keeps this fallback renderer crash-proof even if a
+      // future caller hands it a not-yet-normalized result. (#2450)
+      return JSON.stringify(result, bigintReplacer, 2) + '\n';
   }
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -51,6 +51,70 @@ describe('CLI structure', () => {
   });
 });
 
+// #2450 — the local-engine output normalizer (cli.ts:445) used a bare
+// JSON.stringify with no replacer. A bigint anywhere in an op's return value
+// (e.g. a BIGSERIAL primary key read back by the Postgres engine) made
+// JSON.stringify THROW "Do not know how to serialize a BigInt", crashing the
+// command before any renderer ran. normalizeLocalResult now stringifies via
+// bigintReplacer (bigint → string, postgres.js wire shape).
+describe('BigInt-safe output normalization (#2450)', () => {
+  test('bare JSON.stringify throws on a bigint (the pre-fix crash)', () => {
+    // Pins the exact failure the fix removes: without a replacer this throws.
+    // (Bun: "JSON.stringify cannot serialize BigInt."; Node: "Do not know how
+    // to serialize a BigInt" — match the shared word either way.)
+    expect(() => JSON.stringify({ id: 9999999999999999999n })).toThrow(
+      /serialize BigInt|serialize a BigInt/i,
+    );
+  });
+
+  test('normalizeLocalResult does NOT throw on a bigint result', async () => {
+    const { normalizeLocalResult } = await import('../src/cli.ts');
+    // BIGSERIAL primary key shape that crashed get_calibration_profile.
+    const rawResult = { id: 42n, holder: 'h', nested: { count: 7n } };
+    expect(() => normalizeLocalResult(rawResult)).not.toThrow();
+  });
+
+  test('normalizeLocalResult serializes bigint → string (postgres.js shape)', async () => {
+    const { normalizeLocalResult } = await import('../src/cli.ts');
+    const out = normalizeLocalResult({
+      id: 42n,
+      nested: { count: 7n },
+      arr: [1n, 2n],
+      str: 'unchanged',
+      num: 3,
+    }) as Record<string, unknown>;
+    expect(out.id).toBe('42');
+    expect((out.nested as Record<string, unknown>).count).toBe('7');
+    expect(out.arr).toEqual(['1', '2']);
+    // Non-bigint values pass through untouched.
+    expect(out.str).toBe('unchanged');
+    expect(out.num).toBe(3);
+  });
+
+  test('bigint past Number.MAX_SAFE_INTEGER keeps full precision as a string', async () => {
+    const { normalizeLocalResult } = await import('../src/cli.ts');
+    // A BIGSERIAL beyond 2^53 would lose precision via Number(); the string
+    // form preserves every digit and matches the routed-path wire shape.
+    const big = 9007199254740993n; // MAX_SAFE_INTEGER + 2
+    const out = normalizeLocalResult({ id: big }) as Record<string, unknown>;
+    expect(out.id).toBe('9007199254740993');
+  });
+
+  test("formatResult's default renderer is bigint-safe", async () => {
+    const { formatResult } = await import('../src/cli.ts');
+    // An op with no custom case falls through to the JSON.stringify default.
+    expect(() => formatResult('__no_such_op__', { id: 5n })).not.toThrow();
+    expect(formatResult('__no_such_op__', { id: 5n })).toContain('"5"');
+  });
+
+  test('cli.ts no longer uses a replacer-less stringify on the normalize path', () => {
+    // Structural guard: the bare `JSON.parse(JSON.stringify(rawResult))` that
+    // threw must be gone, replaced by the bigint-safe normalizeLocalResult.
+    expect(cliSource).toContain('normalizeLocalResult(rawResult)');
+    expect(cliSource).not.toContain('JSON.parse(JSON.stringify(rawResult))');
+  });
+});
+
 describe('CLI version', () => {
   test('VERSION matches package.json', async () => {
     const { VERSION } = await import('../src/version.ts');


### PR DESCRIPTION
## Summary

Fixes #2450. The CLI local-op output normalizer crashed on `BigInt`: `JSON.stringify` throws on a bigint (e.g. a `BIGSERIAL` primary key from the Postgres engine), aborting the command before any renderer ran.

## Root cause

`src/cli.ts` round-trips every local read/write op result through `JSON.parse(JSON.stringify(rawResult))` for normalization, with no replacer. A `BigInt` anywhere in the result makes `JSON.stringify` throw.

## Fix

Add a small local `bigintReplacer` (serializes `BigInt` via `.toString()`) and route the normalization round-trip and the `formatResult` default renderer through it.

`.toString()` (not `Number()`) is deliberate: the normalization path exists to match the renderer output of the routed path, and postgres.js returns `int8` as a **string** on the wire — so `.toString()` preserves that parity and avoids the precision loss `Number()` would introduce past 2^53. (Matches the existing `gateway.ts` convention for serializing bigint.)

**Scope kept tight:** the two sites that share the live crash risk are fixed (the normalization round-trip + `formatResult`'s default case). The `reindex --multimodal --json` site was left alone because its input is typed entirely as `number` (TS guarantees no bigint reaches it), and `gbrain calibration --json` is unreachable per #2035 — the issue itself flags it as later treatment.

## Test

6 new cases in `test/cli.test.ts` covering the normalization path with a `BigInt` (no throw + correct string serialization, including a past-`MAX_SAFE_INTEGER` precision case) plus the `formatResult` default. Verified to throw on the pre-fix code and pass after.

## Verification

- `bun run typecheck` → clean (`EXIT=0`)
- `bun test test/cli.test.ts` → all pass

Closes #2450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
