### PR TITLE
fix(import): fall back to body H1 for title when frontmatter lacks title: instead of slug-derived junk (#2446)

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -135,7 +135,16 @@ export function parseMarkdown(
   const type = coerceFrontmatterString(frontmatter.type) || (
     opts?.activePack ? inferTypeFromPack(filePath, opts.activePack) : inferType(filePath)
   );
-  const title = coerceFrontmatterString(frontmatter.title).trim() || inferTitle(filePath);
+  // #2446: title precedence is frontmatter `title:` > the body's first H1 >
+  // the slug/filename-humanized fallback. Slug-based imports (contacts,
+  // calendar) write a correct `# Heading` but no frontmatter title; without
+  // the H1 fallback they get junk titles humanized from the slug
+  // (`Contact 20170928 5 John Defalco`), which also breaks anything keyed on
+  // the title (e.g. the by-mention gazetteer's first-token bucketing).
+  const title =
+    coerceFrontmatterString(frontmatter.title).trim() ||
+    inferTitleFromBody(body) ||
+    inferTitle(filePath);
   const tags = extractTags(frontmatter);
   const slug = coerceFrontmatterString(frontmatter.slug) || inferSlug(filePath);
 
@@ -597,6 +606,31 @@ function inferTypeWithPrefixes(
     }
   }
   return 'concept';
+}
+
+/**
+ * #2446: derive a title from the body's first ATX H1 (`# Heading`).
+ *
+ * Returns the trimmed heading text with the leading `# ` and any decorative
+ * trailing `#` run stripped, or '' if the body has no H1. Only a SINGLE leading
+ * `#` matches — `##`+ (h2 and deeper) are skipped — and lines inside a fenced
+ * code block (```/~~~) are ignored so a `# comment` in a shell snippet can't be
+ * mistaken for the page title.
+ */
+function inferTitleFromBody(body: string): string {
+  let inFence = false;
+  for (const raw of body.split('\n')) {
+    const fence = /^\s*(`{3,}|~{3,})/.exec(raw);
+    if (fence) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    // Exactly one leading `#`, then whitespace, then the heading text.
+    const m = /^#(?!#)\s+(.+?)\s*$/.exec(raw);
+    if (m) return m[1].replace(/\s+#+\s*$/, '').trim();
+  }
+  return '';
 }
 
 function inferTitle(filePath?: string): string {

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -343,3 +343,47 @@ describe('issue #1939 — non-string frontmatter coercion', () => {
     expect(parsed.title).toBe('A Normal Title');
   });
 });
+
+// issue #2446 — when frontmatter has no `title:`, prefer the body's first H1
+// over the slug/filename-humanized fallback. Slug-based imports (contacts,
+// calendar) carry a correct `# Heading` but no frontmatter title; humanizing
+// the slug leaks date/id tokens and loses casing (`Defalco` vs `DeFalco`).
+describe('issue #2446 — body H1 fallback for missing frontmatter title', () => {
+  test('no frontmatter title uses the body H1, not the slug-humanized junk', () => {
+    const md = '---\ntype: person\n---\n\n# John DeFalco\n\nNotes about John.\n';
+    const parsed = parseMarkdown(md, 'people/contact-20170928-5-john-defalco.md');
+    expect(parsed.title).toBe('John DeFalco');
+    // The slug-derived junk title must NOT win.
+    expect(parsed.title).not.toBe('Contact 20170928 5 John Defalco');
+  });
+
+  test('no frontmatter title and no H1 falls back to the inferred slug title', () => {
+    const md = '---\ntype: note\n---\n\njust body prose, no heading\n';
+    const parsed = parseMarkdown(md, 'people/alice-example.md');
+    expect(parsed.title).toBe('Alice Example');
+  });
+
+  test('frontmatter title wins over a body H1 (no regression)', () => {
+    const md = '---\ntitle: Frontmatter Wins\n---\n\n# Body Heading\n\nbody\n';
+    const parsed = parseMarkdown(md, 'people/some-slug.md');
+    expect(parsed.title).toBe('Frontmatter Wins');
+  });
+
+  test('h2 is not treated as the title; first real H1 is used', () => {
+    const md = '---\ntype: note\n---\n\n## Subsection First\n\n# The Real Title\n\nbody\n';
+    const parsed = parseMarkdown(md, 'notes/x.md');
+    expect(parsed.title).toBe('The Real Title');
+  });
+
+  test('a # inside a fenced code block is not mistaken for the title', () => {
+    const md = '---\ntype: note\n---\n\n```sh\n# this is a shell comment, not a heading\n```\n\n# Actual Heading\n';
+    const parsed = parseMarkdown(md, 'notes/x.md');
+    expect(parsed.title).toBe('Actual Heading');
+  });
+
+  test('trailing closing hashes are stripped from the H1', () => {
+    const md = '---\ntype: note\n---\n\n# Closed ATX Heading #\n\nbody\n';
+    const parsed = parseMarkdown(md, 'notes/x.md');
+    expect(parsed.title).toBe('Closed ATX Heading');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2446. When a markdown file's frontmatter has no `title:`, the importer fabricated a title from the slug/filename instead of using the document's own first heading — producing junk titles for any file that relied on its body H1.

## Fix

In `src/core/markdown.ts`, the title now falls back to the body's first H1 before the slug-derived title:

> frontmatter `title:`  →  body H1  →  `inferTitle(filePath)`

A new `inferTitleFromBody()` helper extracts the first ATX H1: it matches only a single leading `#` (skips `##`+ headings), skips lines inside fenced code blocks (so a `# comment` inside a shell fence isn't mistaken for a heading), and strips trailing closing hashes. The page body was already in scope at the title-selection site, so no parsing or signature change was needed. Change is confined to `markdown.ts`.

## Test

6 new cases in `test/markdown.test.ts`: H1 used when frontmatter lacks a title; no-H1 still falls back to the filename (unchanged behavior); frontmatter `title:` still wins over the body H1; plus h2 / code-fence / closing-hash edge cases. Verified to fail on the pre-fix code (slug junk) and pass after.

## Verification

- `bun run typecheck` → clean (`EXIT=0`)
- `bun test test/markdown.test.ts` → all pass

Closes #2446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
