### PR TITLE
fix(gateway): reliable tool-loop resume + Date-safe tool output on non-Anthropic providers (#2256 #2273 #2110 #2433)

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2324,6 +2324,18 @@ export interface ChatToolDef {
 }
 
 /**
+ * Round-trip a tool output through JSON so non-JSON values (e.g. a Postgres
+ * `Date` returned by a tool) become AI-SDK v6 `JSONValue`-safe — a `Date`
+ * serializes to its ISO string instead of surviving as a `Date` instance that
+ * the SDK's Zod `JSONValue` validation rejects. This is a serialization fix at
+ * the SDK boundary, NOT a `::jsonb` DB cast. BigInt/circular outputs would throw
+ * in `JSON.stringify`; those are already not LLM-serializable and out of scope.
+ */
+function toJsonSafe(v: unknown): unknown {
+  return JSON.parse(JSON.stringify(v ?? null));
+}
+
+/**
  * Convert gbrain's provider-neutral ChatMessage[] into AI SDK v6 ModelMessage[].
  *
  * The original code passed `opts.messages as any` straight to generateText,
@@ -2354,7 +2366,7 @@ export function toModelMessages(messages: ChatMessage[]): unknown[] {
               ? { type: 'error-text' as const, value: typeof b.output === 'string' ? b.output : JSON.stringify(b.output) }
               : (typeof b.output === 'string'
                 ? { type: 'text' as const, value: b.output }
-                : { type: 'json' as const, value: (b.output ?? null) as never }),
+                : { type: 'json' as const, value: toJsonSafe(b.output) as never }),
           })),
       };
     }
@@ -2891,6 +2903,8 @@ export interface ToolLoopOpts {
    *   2. onToolCallStart   — pending row persisted (D11 step 2)
    *   3. handler.execute   — side effect
    *   4. onToolCallComplete / onToolCallFailed (D11 step 4)
+   *   5. onToolResultMessage — tool-result user message persisted before the
+   *      in-memory push, so a crash mid-loop replays a balanced history.
    */
   onAssistantTurn?: (turnIdx: number, messageIdx: number, blocks: ChatBlock[], usage: ChatResult['usage'], model: string) => Promise<void>;
   /**
@@ -2908,6 +2922,15 @@ export interface ToolLoopOpts {
   ) => Promise<{ gbrainToolUseId: string }>;
   onToolCallComplete?: (gbrainToolUseId: string, output: unknown) => Promise<void>;
   onToolCallFailed?: (gbrainToolUseId: string, error: string) => Promise<void>;
+  /**
+   * Persist the tool-result user message that closes a tool round. Mirrors the
+   * onAssistantTurn ordering: fired (and awaited) BEFORE the in-memory push so a
+   * crash mid-loop resumes with a balanced history (every assistant tool_use turn
+   * is followed by its tool_result turn). Without this, only assistant turns are
+   * persisted and resume rebuilds an unbalanced conversation that the next chat()
+   * rejects ("Tool results are missing").
+   */
+  onToolResultMessage?: (turnIdx: number, messageIdx: number, blocks: ChatBlock[]) => Promise<void>;
 
   /** Optional per-call heartbeat for observability. */
   onHeartbeat?: (event: string, data: Record<string, unknown>) => void;
@@ -3131,9 +3154,12 @@ export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
 
     if (stopReason === 'aborted') break;
 
-    // Feed all tool results back as a single user message.
+    // Feed all tool results back as a single user message. Persist BEFORE the
+    // in-memory push (mirrors onAssistantTurn) so a crash mid-loop resumes with a
+    // balanced history. turnIdx here is still the just-finished assistant turn's
+    // index; message_idx is what governs replay ordering.
     const userMessageIdx = messageIdx++;
-    void userMessageIdx;
+    await opts.onToolResultMessage?.(turnIdx, userMessageIdx, toolResultBlocks);
     messages.push({ role: 'user', content: toolResultBlocks });
 
     turnIdx++;

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -785,6 +785,63 @@ async function runSubagentViaGateway(args: GatewayRunArgs): Promise<SubagentResu
     content: adaptContentBlocksToChatBlocks(m.content_blocks),
   }));
 
+  // Resume rebalance (#2256). A worker killed mid-tool-round leaves the trailing
+  // assistant tool_use turn persisted (onAssistantTurn fires BEFORE dispatch) but
+  // its tool-result wrapper unwritten — the outputs live only in
+  // subagent_tool_executions. The gateway loop calls chat() first thing on resume,
+  // so a non-Anthropic provider rejects the dangling tool_use ("Tool results are
+  // missing" / ModelMessage schema). Synthesize the tool-result user turn from the
+  // SETTLED executions so the rebuilt history is balanced and durable. Reading
+  // output/error directly is v1- and v2-safe — it never keys by gbrain_tool_use_id,
+  // so the legacy/D5 path can't be mis-reconciled the way an onToolCallStart-based
+  // re-dispatch would (v1 rows have ordinal=NULL and would miss the conflict key,
+  // re-executing a completed tool). A tool still 'pending' (crashed mid-execute) or
+  // with no exec row can't be reconstructed without risking a non-idempotent re-run
+  // or fabricating a result, so surface it as unrecoverable instead.
+  const lastPrior = priorMessages[priorMessages.length - 1];
+  const lastChat = priorChatMessages[priorChatMessages.length - 1];
+  const trailingToolCalls = lastPrior?.role === 'assistant' && lastChat && Array.isArray(lastChat.content)
+    ? lastChat.content.filter((b): b is Extract<ChatBlock, { type: 'tool-call' }> => b.type === 'tool-call')
+    : [];
+  if (trailingToolCalls.length > 0) {
+    const execRows = await engine.executeRaw<{
+      tool_use_id: string; ordinal: number | null; status: string; output: unknown; error: string | null;
+    }>(
+      `SELECT tool_use_id, ordinal, status, output, error
+         FROM subagent_tool_executions
+        WHERE job_id = $1 AND message_idx = $2`,
+      [ctx.id, lastPrior.message_idx],
+    );
+    const execByToolUseId = new Map(execRows.map(r => [String(r.tool_use_id), r]));
+    const resultBlocks: ChatBlock[] = trailingToolCalls.map((call, idx) => {
+      const exec = execByToolUseId.get(call.toolCallId) ?? execRows.find(r => Number(r.ordinal) === idx);
+      if (exec?.status === 'complete') {
+        return { type: 'tool-result', toolCallId: call.toolCallId, toolName: call.toolName, output: exec.output ?? null };
+      }
+      if (exec?.status === 'failed') {
+        return { type: 'tool-result', toolCallId: call.toolCallId, toolName: call.toolName, output: exec.error ?? 'tool failed', isError: true };
+      }
+      // 'pending' (crashed mid-execute) or no row at all — not safely reconcilable.
+      const label = toolHandlers.get(call.toolName)?.idempotent === true ? 'tool' : 'non-idempotent tool';
+      throw new Error(
+        `${label} "${call.toolName}" pending on resume (job_id=${ctx.id}, message_idx=${lastPrior.message_idx}) `
+        + `— cannot safely reconcile the crashed tool round`,
+      );
+    });
+    const resultIdx = priorChatMessages.length; // contiguous slot after the trailing assistant turn
+    await persistMessage(engine, ctx.id, {
+      message_idx: resultIdx,
+      role: 'user',
+      content_blocks: resultBlocks as unknown as ContentBlock[],
+      tokens_in: null,
+      tokens_out: null,
+      tokens_cache_read: null,
+      tokens_cache_create: null,
+      model: null,
+    });
+    priorChatMessages.push({ role: 'user', content: resultBlocks });
+  }
+
   // Initial seed message if no prior state.
   const initialMessages: ChatMessage[] = priorChatMessages.length === 0
     ? [{ role: 'user', content: data.prompt }]
@@ -863,6 +920,22 @@ async function runSubagentViaGateway(args: GatewayRunArgs): Promise<SubagentResu
         cache_read: usage.cache_read_tokens,
       });
       heartbeat('llm_call_completed', { turn_idx: turnIdx, tokens: usage });
+    },
+    onToolResultMessage: async (_turnIdx, messageIdx, blocks) => {
+      // Persist the tool-result user turn so resume rebuilds a balanced history.
+      // Same v2 content_blocks contract as onAssistantTurn; tokens/model are
+      // null (no LLM call produced this turn). persistMessage binds via
+      // $N::text::jsonb (JSON.stringify also ISO-izes any Date in tool output).
+      await persistMessage(engine, ctx.id, {
+        message_idx: messageIdx,
+        role: 'user',
+        content_blocks: blocks as unknown as ContentBlock[],
+        tokens_in: null,
+        tokens_out: null,
+        tokens_cache_read: null,
+        tokens_cache_create: null,
+        model: null,
+      });
     },
     onToolCallStart: async (turnIdx, messageIdx, ordinal, toolName, input, providerToolCallId) => {
       // CRITICAL — read back the canonical gbrain_tool_use_id from RETURNING,

--- a/test/ai/gateway-tool-loop.test.ts
+++ b/test/ai/gateway-tool-loop.test.ts
@@ -253,6 +253,89 @@ describe('gateway.toolLoop (v0.38 D11 — provider-agnostic loop control)', () =
     expect(result.totalTurns).toBeGreaterThanOrEqual(3);
   });
 
+  it('persists the tool-result user turn so resume rebuilds a balanced history (#2256)', async () => {
+    // Two tool rounds, then a final text turn — models a non-Anthropic provider.
+    let turn = 0;
+    __setChatTransportForTests(async () => {
+      turn++;
+      if (turn <= 2) {
+        return {
+          text: '',
+          blocks: [
+            { type: 'tool-call', toolCallId: `tc${turn}`, toolName: 'search', input: { n: turn } },
+          ] as ChatBlock[],
+          stopReason: 'tool_calls',
+          usage: { input_tokens: 2, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 },
+          model: 'deepseek:deepseek-chat',
+          providerId: 'deepseek',
+        };
+      }
+      return {
+        text: 'done',
+        blocks: [{ type: 'text', text: 'done' }] as ChatBlock[],
+        stopReason: 'end',
+        usage: { input_tokens: 2, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 },
+        model: 'deepseek:deepseek-chat',
+        providerId: 'deepseek',
+      };
+    });
+
+    // Record exactly what the subagent handler persists to subagent_messages.
+    const persisted: Array<{ idx: number; role: 'assistant' | 'user'; blocks: ChatBlock[] }> = [];
+    let toolResultCalls = 0;
+
+    await toolLoop({
+      initialMessages: [{ role: 'user', content: 'find things' }],
+      tools: [{ name: 'search', description: 's', inputSchema: { type: 'object' } }],
+      toolHandlers: new Map([['search', {
+        idempotent: true,
+        async execute(input) { return { hit: (input as { n: number }).n }; },
+      }]]),
+      onAssistantTurn: async (_turnIdx, messageIdx, blocks) => {
+        persisted.push({ idx: messageIdx, role: 'assistant', blocks });
+      },
+      onToolResultMessage: async (_turnIdx, messageIdx, blocks) => {
+        toolResultCalls++;
+        persisted.push({ idx: messageIdx, role: 'user', blocks });
+      },
+      onToolCallStart: async (turnIdx, _msgIdx, ordinal) => ({ gbrainToolUseId: `gb-${turnIdx}-${ordinal}` }),
+    });
+
+    // Fires once per tool round (two rounds here) — never silently dropped.
+    expect(toolResultCalls).toBe(2);
+
+    // message_idx is contiguous and interleaved: assistant, user, assistant, user, assistant.
+    persisted.sort((a, b) => a.idx - b.idx);
+    expect(persisted.map((m) => m.idx)).toEqual([0, 1, 2, 3, 4]);
+    expect(persisted.map((m) => m.role)).toEqual(['assistant', 'user', 'assistant', 'user', 'assistant']);
+
+    // Rebuild the conversation exactly as loadPriorMessages would (ordered by
+    // message_idx, all roles) and assert it is BALANCED: every assistant turn
+    // carrying tool-call blocks is immediately followed by a turn carrying the
+    // matching tool-result blocks. This is the property the next chat() requires;
+    // before this fix only assistant turns were persisted, so resume rebuilt an
+    // unbalanced history that the provider rejected ("Tool results are missing").
+    const priorMessages = persisted.map((m) => ({ role: m.role, content: m.blocks }));
+    for (let i = 0; i < priorMessages.length; i++) {
+      const content = priorMessages[i].content;
+      const toolCalls = content.filter(
+        (b): b is Extract<ChatBlock, { type: 'tool-call' }> => b.type === 'tool-call',
+      );
+      if (priorMessages[i].role === 'assistant' && toolCalls.length > 0) {
+        const next = priorMessages[i + 1];
+        expect(next).toBeDefined();
+        const resultIds = new Set(
+          next!.content
+            .filter((b): b is Extract<ChatBlock, { type: 'tool-result' }> => b.type === 'tool-result')
+            .map((b) => b.toolCallId),
+        );
+        for (const call of toolCalls) {
+          expect(resultIds.has(call.toolCallId)).toBe(true);
+        }
+      }
+    }
+  });
+
   it('returns refusal reason without dispatching tools when stopReason=refusal', async () => {
     __setChatTransportForTests(async () => ({
       text: 'I cannot help with that',

--- a/test/e2e/subagent-crash-replay-multi-provider.test.ts
+++ b/test/e2e/subagent-crash-replay-multi-provider.test.ts
@@ -42,9 +42,36 @@ import {
   __setChatTransportForTests,
   configureGateway,
   resetGateway,
+  toModelMessages,
   type ChatBlock,
+  type ChatMessage,
   type ChatResult,
 } from '../../src/core/ai/gateway.ts';
+
+/**
+ * Assert a conversation is BALANCED: every assistant turn that carries tool-call
+ * blocks is immediately followed by a turn carrying the matching tool-result
+ * blocks. This is the property a real provider enforces and that assistant-only
+ * persistence violated on a mid-execution-crash resume.
+ */
+function assertBalanced(messages: ChatMessage[]): void {
+  for (let i = 0; i < messages.length; i++) {
+    const content = messages[i].content;
+    if (messages[i].role !== 'assistant' || !Array.isArray(content)) continue;
+    const toolCalls = content.filter((b): b is Extract<ChatBlock, { type: 'tool-call' }> => b.type === 'tool-call');
+    if (toolCalls.length === 0) continue;
+    const next = messages[i + 1];
+    expect(next).toBeDefined();
+    const resultIds = new Set(
+      (Array.isArray(next!.content) ? next!.content : [])
+        .filter((b): b is Extract<ChatBlock, { type: 'tool-result' }> => b.type === 'tool-result')
+        .map(b => b.toolCallId),
+    );
+    for (const call of toolCalls) {
+      expect(resultIds.has(call.toolCallId)).toBe(true);
+    }
+  }
+}
 
 let engine: PGLiteEngine;
 
@@ -507,6 +534,91 @@ describe('SIGKILL crash-replay reconciliation across provider matrix (v0.38 LOAD
         [jobId],
       );
       expect(Number(toolRows[0].n)).toBe(1);
+    });
+  });
+
+  describe('resume rebalance — mid-execution crash yields a balanced history (#2256)', () => {
+    it('synthesizes the missing tool-result turn so the resume chat() history is balanced', async () => {
+      const { jobId } = await seedCrashedState('find foo', 'v2');
+
+      // Capture the message history handed to chat() on the FIRST (resume) call.
+      // Unlike the reconciliation tests above (which stub chat() and ignore its
+      // input), this asserts that history is BALANCED — the exact property a real
+      // provider enforces and that the old assistant-only persistence violated.
+      let firstCall: ChatMessage[] | null = null;
+      __setChatTransportForTests(async (opts) => {
+        if (!firstCall) firstCall = opts.messages;
+        return PROVIDER_MATRIX[0].finalResponse;
+      });
+
+      const executions: Array<{ name: string; input: unknown }> = [];
+      const handler = buildHandler(makeStubTools(executions));
+      const ctx = await makeCrashedCtx(jobId, 'find foo', 'anthropic:claude-sonnet-4-6');
+      const result = await handler(ctx);
+
+      // Prior complete tool is reconstructed from the DB, never re-executed.
+      expect(executions.length).toBe(0);
+
+      // The resume history is balanced: the crashed assistant tool_use turn is
+      // now followed by its synthesized tool-result turn. Without the fix it
+      // ended on the dangling tool_use and a real provider would reject it.
+      expect(firstCall).not.toBeNull();
+      assertBalanced(firstCall!);
+      // The v6 ModelMessage projection succeeds (no dangling tool_use).
+      expect(() => toModelMessages(firstCall!)).not.toThrow();
+      // The synthesized tool-result carries the prior completed output.
+      const toolMsg = (firstCall as unknown as ChatMessage[])[2];
+      expect(toolMsg.role).toBe('user');
+      expect((toolMsg.content as ChatBlock[])[0]).toMatchObject({
+        type: 'tool-result',
+        toolCallId: 'provider-tc-v2-crashed',
+      });
+
+      // Persisted durably so a SECOND crash also resumes balanced.
+      const rows = await engine.executeRaw<{ message_idx: number; role: string }>(
+        `SELECT message_idx, role FROM subagent_messages WHERE job_id = $1 ORDER BY message_idx`,
+        [jobId],
+      );
+      expect(rows.map(r => r.role)).toEqual(['user', 'assistant', 'user', 'assistant']);
+      expect(result.result).toBe(PROVIDER_MATRIX[0].finalResponse.text);
+      expect(result.stop_reason).toBe('end_turn');
+    });
+
+    it('surfaces a still-pending non-idempotent tool on the trailing turn as unrecoverable', async () => {
+      // Trailing ASSISTANT tool_use turn whose tool is still 'pending' (worker
+      // killed mid-execute, before the result was written). It cannot be
+      // reconstructed without risking a double side-effect, so rebalance refuses.
+      const jobRows = await engine.executeRaw<{ id: number }>(
+        `INSERT INTO minion_jobs (name, status, data, queue, priority, created_at)
+         VALUES ('subagent', 'active', '{}'::jsonb, 'default', 0, now())
+         RETURNING id`,
+      );
+      const jobId = jobRows[0].id;
+      await engine.executeRaw(
+        `INSERT INTO subagent_messages (job_id, message_idx, role, content_blocks, model)
+         VALUES ($1, 0, 'user', '[{"type":"text","text":"do it"}]'::jsonb, NULL),
+                ($1, 1, 'assistant', $2::jsonb, 'anthropic:claude-sonnet-4-6')`,
+        [jobId, JSON.stringify([{ type: 'tool-call', toolCallId: 'tc-mid', toolName: 'put_page', input: { slug: 'foo' } }])],
+      );
+      await engine.executeRaw(
+        `INSERT INTO subagent_tool_executions
+           (job_id, message_idx, tool_use_id, tool_name, input, status, schema_version, ordinal, gbrain_tool_use_id)
+         VALUES ($1, 1, 'tc-mid', 'put_page', '{}'::jsonb, 'pending', 2, 0, '01987654-3210-7000-8000-dddddddddddd'::uuid)`,
+        [jobId],
+      );
+
+      __setChatTransportForTests(async () => PROVIDER_MATRIX[0].finalResponse);
+      const tools: ToolDef[] = [{
+        name: 'put_page',
+        description: 'non-idempotent stub',
+        input_schema: { type: 'object' },
+        idempotent: false,
+        async execute() { throw new Error('should not be called'); },
+      }];
+      const handler = buildHandler(tools);
+      const ctx = await makeCrashedCtx(jobId, 'do it', 'anthropic:claude-sonnet-4-6');
+
+      await expect(handler(ctx)).rejects.toThrow(/non-idempotent tool "put_page" pending on resume/i);
     });
   });
 });

--- a/test/gateway-model-messages.test.ts
+++ b/test/gateway-model-messages.test.ts
@@ -107,6 +107,37 @@ describe('toModelMessages — v6 ModelMessage shape', () => {
     ]);
   });
 
+  test('Date in tool-result output is JSON-safe — no Date instance survives (#2273)', () => {
+    // A tool returning a Postgres row leaks a JS Date in its output. AI SDK v6's
+    // Zod JSONValue validation rejects a raw Date instance, so the json arm must
+    // round-trip it to an ISO string before handing it to the SDK.
+    const ts = new Date('2026-04-03T12:34:56.000Z');
+    const msgs: ChatMessage[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'tool-result', toolCallId: 'c1', toolName: 'get_row', output: { created_at: ts, nested: { updated_at: ts } } },
+        ],
+      },
+    ];
+    const value = (toModelMessages(msgs)[0] as any).content[0].output.value;
+    expect((toModelMessages(msgs)[0] as any).content[0].output.type).toBe('json');
+    expect(value.created_at).toBe('2026-04-03T12:34:56.000Z');
+    expect(value.nested.updated_at).toBe('2026-04-03T12:34:56.000Z');
+    expect(value.created_at instanceof Date).toBe(false);
+    expect(value).toEqual(JSON.parse(JSON.stringify({ created_at: ts, nested: { updated_at: ts } })));
+  });
+
+  test('a bare Date tool-result output serializes to its ISO string', () => {
+    const ts = new Date('2026-01-15T00:00:00.000Z');
+    const msgs: ChatMessage[] = [
+      { role: 'user', content: [{ type: 'tool-result', toolCallId: 'c1', toolName: 't', output: ts }] },
+    ];
+    expect(toModelMessages(msgs)).toEqual([
+      { role: 'tool', content: [{ type: 'tool-result', toolCallId: 'c1', toolName: 't', output: { type: 'json', value: '2026-01-15T00:00:00.000Z' } }] },
+    ]);
+  });
+
   test('full multi-turn conversation: user → assistant(tool-call) → tool(result)', () => {
     const msgs: ChatMessage[] = [
       { role: 'user', content: 'find widget' },


### PR DESCRIPTION
## Why

On non-Anthropic providers (Gemini / DeepSeek / openai-compat) the agentic subagent loop (`agent.use_gateway_loop=true`) is unusable across multi-turn tool conversations: after a crash+resume it rebuilds an unbalanced history ("Tool results are missing" / "messages do not match the ModelMessage[] schema"), and any tool whose output contains a Postgres `Date` crashes the loop. These are the core reasons non-Anthropic agent loops don't work today.

## Root causes & fixes

**A — tool-result turn never persisted.** `toolLoop` built the tool-result user message but did `void userMessageIdx` — pushing it in-memory only. Only assistant turns were persisted, so resume rebuilt assistant `tool_use` blocks with no following `tool_result` turn → unbalanced → next `chat()` rejects.
→ Added `onToolResultMessage` to `ToolLoopOpts`, awaited **before** the in-memory push (mirroring `onAssistantTurn`'s persist-before-proceed ordering), and wired it in `runSubagentViaGateway` to persist the `role:'user'` tool-result turn to `subagent_messages`.

**B — mid-execution crash leaves a dangling tool_use.** A worker killed mid-tool-round persists the assistant `tool_use` turn (it fires before dispatch) but not the tool-result wrapper — the outputs live only in `subagent_tool_executions`. The existing crash-replay tests **stub `chat()`** and so never validated that the rebuilt history is balanced; against a real provider it still rejected the dangling `tool_use`.
→ On resume, synthesize the tool-result user turn from the **settled** executions so the rebuilt history is balanced before the first `chat()`. Done **subagent-side** (reads `output`/`error` directly) so it is **v1- and v2-safe**: a loop-side re-dispatch would mis-key v1 legacy rows (`ordinal=NULL` misses the `ON CONFLICT` key) and re-execute a completed tool. A still-`pending` tool (crashed mid-`execute`) is surfaced as unrecoverable rather than re-run or fabricated.

**C — `Date` in tool output.** `toModelMessages` emitted a tool output object straight into a `{ type:'json', value }` AI-SDK part; a `Date` survived as a `Date` instance and failed AI-SDK v6 `JSONValue` validation.
→ Round-trip the `json` arm through `toJsonSafe` (`Date` → ISO string). Serialization fix at the SDK boundary — **not** a `::jsonb` DB cast.

## Tests

The transport-stubbed suite missed all three bugs, so the new tests are written to actually catch them (each was confirmed to fail without its fix):

- `test/ai/gateway-tool-loop.test.ts` — multi-turn run asserting `onToolResultMessage` fires once per tool round with contiguous interleaved `message_idx`, then rebuilds the conversation and asserts it is **balanced** (every assistant tool-call turn is followed by its matching tool-result turn).
- `test/e2e/subagent-crash-replay-multi-provider.test.ts` — captures the **actual messages** handed to `chat()` on resume and asserts they're balanced (`toModelMessages` projects cleanly, no dangling `tool_use`), the synthesized turn is persisted durably, and a still-pending non-idempotent trailing tool surfaces as unrecoverable.
- `test/gateway-model-messages.test.ts` — a `Date` (and nested `{ts: Date}`) tool output yields a JSON-safe value (no `Date` instance survives; ISO string present).

## Scope

No schema change — reuses `subagent_messages` + `persistMessage` (binds via `$N::text::jsonb`, CLAUDE.md-compliant). Engine parity unaffected. No version/CHANGELOG bump (left to the maintainer's release wave).

## Verification

- `bun run typecheck` — clean
- subagent-direct tests (7 files incl. crash-replay e2e): 89 pass / 0 fail
- gateway-direct tests (4 files): 43 pass / 0 fail
- negative check: both new e2e tests fail with the fix disabled (genuine guards)
- guards pass: `check:jsonb`, `check:gateway-routed`, `check:test-names`, `check:privacy`, `check:test-isolation`, `check:proposal-pii`

Fixes #2256, #2273, #2110, #2433. Refs #2115, #2202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
