### PR TITLE
Tune cycle freshness for nightly source dreams

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3742,6 +3742,105 @@ export async function checkPoolBudget(_engine: BrainEngine): Promise<Check> {
   }
 }
 
+type CycleFreshnessSourceScope = {
+  allowlist?: Set<string>;
+  ignorelist: Set<string>;
+  invalid: string[];
+  configured: boolean;
+};
+
+const CYCLE_FRESHNESS_SOURCE_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+type DoctorSourceRow = Awaited<ReturnType<BrainEngine['listAllSources']>>[number];
+
+function parseCycleFreshnessSourceList(raw: string | null | undefined, label: string): {
+  ids: string[];
+  invalid: string[];
+} | null {
+  if (raw === null || raw === undefined || raw.trim() === '') return null;
+  const parts = raw.split(',').map((s) => s.trim()).filter(Boolean);
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  const invalid: string[] = [];
+  for (const part of parts) {
+    if (!CYCLE_FRESHNESS_SOURCE_ID_RE.test(part)) {
+      invalid.push(`${label} contains invalid source id "${part}"`);
+      continue;
+    }
+    if (!seen.has(part)) {
+      seen.add(part);
+      ids.push(part);
+    }
+  }
+  return { ids, invalid };
+}
+
+async function getCycleFreshnessConfig(engine: BrainEngine, key: string): Promise<string | null> {
+  try {
+    return await engine.getConfig(key);
+  } catch {
+    return null;
+  }
+}
+
+async function resolveCycleFreshnessSourceScope(
+  engine: BrainEngine,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<CycleFreshnessSourceScope> {
+  const dbAllowlist = await getCycleFreshnessConfig(engine, 'doctor.cycle_freshness.source_allowlist');
+  const dbIgnorelist = await getCycleFreshnessConfig(engine, 'doctor.cycle_freshness.source_ignorelist');
+  const allowRaw =
+    (env.GBRAIN_CYCLE_FRESHNESS_SOURCE_ALLOWLIST?.trim() ? env.GBRAIN_CYCLE_FRESHNESS_SOURCE_ALLOWLIST : undefined) ??
+    (env.DREAM_SOURCE_ALLOWLIST?.trim() ? env.DREAM_SOURCE_ALLOWLIST : undefined) ??
+    dbAllowlist;
+  const ignoreRaw =
+    (env.GBRAIN_CYCLE_FRESHNESS_SOURCE_IGNORELIST?.trim() ? env.GBRAIN_CYCLE_FRESHNESS_SOURCE_IGNORELIST : undefined) ??
+    dbIgnorelist;
+
+  const parsedAllow = parseCycleFreshnessSourceList(allowRaw, 'source allowlist');
+  const parsedIgnore = parseCycleFreshnessSourceList(ignoreRaw, 'source ignorelist');
+  return {
+    allowlist: parsedAllow ? new Set(parsedAllow.ids) : undefined,
+    ignorelist: new Set(parsedIgnore?.ids ?? []),
+    invalid: [...(parsedAllow?.invalid ?? []), ...(parsedIgnore?.invalid ?? [])],
+    configured: !!parsedAllow || !!parsedIgnore,
+  };
+}
+
+function applyCycleFreshnessSourceScope(
+  sources: DoctorSourceRow[],
+  scope: CycleFreshnessSourceScope,
+): DoctorSourceRow[] {
+  return sources.filter((source) => {
+    if (scope.allowlist && !scope.allowlist.has(source.id)) return false;
+    if (scope.ignorelist.has(source.id)) return false;
+    return true;
+  });
+}
+
+function cycleFreshnessScopeDetails(
+  sources: DoctorSourceRow[],
+  scopedSources: DoctorSourceRow[],
+  scope: CycleFreshnessSourceScope,
+): Record<string, unknown> | undefined {
+  if (!scope.configured) return undefined;
+  return {
+    checked_source_count: scopedSources.length,
+    skipped_source_count: sources.length - scopedSources.length,
+    source_allowlist: scope.allowlist ? Array.from(scope.allowlist).sort() : undefined,
+    source_ignorelist: Array.from(scope.ignorelist).sort(),
+  };
+}
+
+function cycleFreshnessScopeSuffix(
+  sources: DoctorSourceRow[],
+  scopedSources: DoctorSourceRow[],
+  scope: CycleFreshnessSourceScope,
+): string {
+  if (!scope.configured) return '';
+  return ` (${scopedSources.length}/${sources.length} source(s) checked by cycle_freshness source scope)`;
+}
+
 /**
  * v0.38 — per-source `last_full_cycle_at` freshness check.
  *
@@ -3754,13 +3853,16 @@ export async function checkPoolBudget(_engine: BrainEngine): Promise<Check> {
  *
  * Default thresholds: warn at 6h, fail at 24h. Tighter than sync_freshness
  * because full-cycle staleness compounds (sync stale → extract stale →
- * embed stale → search stale). Env overrides:
+ * embed stale → search stale). Env/config overrides:
  *   - GBRAIN_CYCLE_FRESHNESS_WARN_HOURS (default 6)
  *   - GBRAIN_CYCLE_FRESHNESS_FAIL_HOURS (default 24)
+ *   - GBRAIN_CYCLE_FRESHNESS_SOURCE_ALLOWLIST / DREAM_SOURCE_ALLOWLIST
+ *   - GBRAIN_CYCLE_FRESHNESS_SOURCE_IGNORELIST
+ *   - DB config: doctor.cycle_freshness.source_allowlist / source_ignorelist
  */
 export async function checkCycleFreshness(
   engine: BrainEngine,
-  opts?: { nowMs?: number },
+  opts?: { nowMs?: number; env?: NodeJS.ProcessEnv },
 ): Promise<Check> {
   try {
     const sources = await engine.listAllSources({ localPathOnly: true });
@@ -3769,6 +3871,27 @@ export async function checkCycleFreshness(
         name: 'cycle_freshness',
         status: 'ok',
         message: 'No federated sources to cycle',
+      };
+    }
+
+    const scope = await resolveCycleFreshnessSourceScope(engine, opts?.env);
+    if (scope.invalid.length > 0) {
+      return {
+        name: 'cycle_freshness',
+        status: 'warn',
+        message: `Invalid cycle_freshness source scope: ${scope.invalid.join('; ')}`,
+        details: cycleFreshnessScopeDetails(sources, sources, scope),
+      };
+    }
+    const scopedSources = applyCycleFreshnessSourceScope(sources, scope);
+    const details = cycleFreshnessScopeDetails(sources, scopedSources, scope);
+    const scopeSuffix = cycleFreshnessScopeSuffix(sources, scopedSources, scope);
+    if (scopedSources.length === 0) {
+      return {
+        name: 'cycle_freshness',
+        status: 'ok',
+        message: `No federated sources to cycle after cycle_freshness source scope${scopeSuffix}`,
+        details,
       };
     }
 
@@ -3782,7 +3905,7 @@ export async function checkCycleFreshness(
     let hasWarnings = false;
     let hasFailures = false;
 
-    for (const source of sources) {
+    for (const source of scopedSources) {
       const display = source.name && source.name !== source.id
         ? `'${source.id}' (${source.name})`
         : `'${source.id}'`;
@@ -3818,20 +3941,23 @@ export async function checkCycleFreshness(
       return {
         name: 'cycle_freshness',
         status: 'fail',
-        message: `${issues.join('; ')}. Run \`gbrain dream --source <id>\` for each stale source, or start \`gbrain autopilot\`.`,
+        message: `${issues.join('; ')}. Run \`gbrain dream --source <id>\` for each stale source, or start \`gbrain autopilot\`${scopeSuffix}.`,
+        details,
       };
     }
     if (hasWarnings) {
       return {
         name: 'cycle_freshness',
         status: 'warn',
-        message: `${issues.join('; ')}.`,
+        message: `${issues.join('; ')}${scopeSuffix}.`,
+        details,
       };
     }
     return {
       name: 'cycle_freshness',
       status: 'ok',
-      message: `All ${sources.length} federated source(s) cycled recently`,
+      message: `All ${scopedSources.length} federated source(s) cycled recently${scopeSuffix}`,
+      details,
     };
   } catch (e) {
     return {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3783,6 +3783,34 @@ async function getCycleFreshnessConfig(engine: BrainEngine, key: string): Promis
   }
 }
 
+function parseCycleFreshnessHours(raw: string | null | undefined, label: string, fallback: number): number | null {
+  if (raw === null || raw === undefined || raw.trim() === '') return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    if (!_envNumberWarned.has(label)) {
+      _envNumberWarned.add(label);
+      console.warn(`[gbrain doctor] Ignoring invalid ${label}=${raw}; using default ${fallback}h.`);
+    }
+    return fallback;
+  }
+  return n;
+}
+
+async function resolveCycleFreshnessHours(
+  engine: BrainEngine,
+  env: NodeJS.ProcessEnv | undefined,
+  envKey: string,
+  dbKey: string,
+  fallback: number,
+): Promise<number> {
+  const scopedEnv = env ?? process.env;
+  const envHours = parseCycleFreshnessHours(scopedEnv[envKey], envKey, fallback);
+  if (envHours !== null) return envHours;
+  const dbHours = parseCycleFreshnessHours(await getCycleFreshnessConfig(engine, dbKey), dbKey, fallback);
+  if (dbHours !== null) return dbHours;
+  return fallback;
+}
+
 async function resolveCycleFreshnessSourceScope(
   engine: BrainEngine,
   env: NodeJS.ProcessEnv = process.env,
@@ -3858,6 +3886,7 @@ function cycleFreshnessScopeSuffix(
  *   - GBRAIN_CYCLE_FRESHNESS_FAIL_HOURS (default 24)
  *   - GBRAIN_CYCLE_FRESHNESS_SOURCE_ALLOWLIST / DREAM_SOURCE_ALLOWLIST
  *   - GBRAIN_CYCLE_FRESHNESS_SOURCE_IGNORELIST
+ *   - DB config: doctor.cycle_freshness.warn_hours / fail_hours
  *   - DB config: doctor.cycle_freshness.source_allowlist / source_ignorelist
  */
 export async function checkCycleFreshness(
@@ -3895,8 +3924,20 @@ export async function checkCycleFreshness(
       };
     }
 
-    const warnHours = _resolveSyncFreshnessHours('GBRAIN_CYCLE_FRESHNESS_WARN_HOURS', 6);
-    const failHours = _resolveSyncFreshnessHours('GBRAIN_CYCLE_FRESHNESS_FAIL_HOURS', 24);
+    const warnHours = await resolveCycleFreshnessHours(
+      engine,
+      opts?.env,
+      'GBRAIN_CYCLE_FRESHNESS_WARN_HOURS',
+      'doctor.cycle_freshness.warn_hours',
+      6,
+    );
+    const failHours = await resolveCycleFreshnessHours(
+      engine,
+      opts?.env,
+      'GBRAIN_CYCLE_FRESHNESS_FAIL_HOURS',
+      'doctor.cycle_freshness.fail_hours',
+      24,
+    );
     const warnMs = warnHours * 60 * 60 * 1000;
     const failMs = failHours * 60 * 60 * 1000;
     const now = opts?.nowMs ?? Date.now();

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -882,8 +882,10 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   // Emotional weight (v0.29)
   'emotional_weight.high_tags',
   'emotional_weight.user_holder',
-  // Cycle phase config
+  // Cycle phase/config health
   'cycle.grade_takes.write_gstack_learnings',
+  'doctor.cycle_freshness.source_allowlist',
+  'doctor.cycle_freshness.source_ignorelist',
   // Content sanity (v0.41)
   'content_sanity.bytes_warn',
   'content_sanity.bytes_block',

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -884,6 +884,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'emotional_weight.user_holder',
   // Cycle phase/config health
   'cycle.grade_takes.write_gstack_learnings',
+  'doctor.cycle_freshness.warn_hours',
+  'doctor.cycle_freshness.fail_hours',
   'doctor.cycle_freshness.source_allowlist',
   'doctor.cycle_freshness.source_ignorelist',
   // Content sanity (v0.41)

--- a/test/config-set.test.ts
+++ b/test/config-set.test.ts
@@ -38,6 +38,12 @@ describe('KNOWN_CONFIG_KEYS', () => {
     expect(KNOWN_CONFIG_KEYS).toContain('embed.backfill_max_usd');
   });
 
+  test('contains cycle_freshness cadence keys (nightly dashboard tuning)', () => {
+    expect(KNOWN_CONFIG_KEYS).toContain('doctor.cycle_freshness.warn_hours');
+    expect(KNOWN_CONFIG_KEYS).toContain('doctor.cycle_freshness.fail_hours');
+    expect(KNOWN_CONFIG_KEYS).toContain('doctor.cycle_freshness.source_allowlist');
+  });
+
   test('no duplicate entries', () => {
     const set = new Set(KNOWN_CONFIG_KEYS);
     expect(set.size).toBe(KNOWN_CONFIG_KEYS.length);

--- a/test/doctor-cycle-freshness.test.ts
+++ b/test/doctor-cycle-freshness.test.ts
@@ -121,4 +121,69 @@ describe('doctor checkCycleFreshness', () => {
     expect(result.status).toBe('ok');
     expect(result.message).toMatch(/No federated sources/);
   });
+
+  test('DB source allowlist limits cycle freshness to intentionally dreamed operating sources', async () => {
+    await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
+    await seed('citadel-ops', agoH(1));
+    await seed('reference-brain', undefined);
+    await engine.setConfig('doctor.cycle_freshness.source_allowlist', 'citadel-ops');
+
+    const result = await checkCycleFreshness(engine, { nowMs: NOW, env: {} as NodeJS.ProcessEnv });
+
+    expect(result.status).toBe('ok');
+    expect(result.message).toMatch(/1\/2 source\(s\) checked/);
+    expect(result.details).toMatchObject({
+      checked_source_count: 1,
+      skipped_source_count: 1,
+      source_allowlist: ['citadel-ops'],
+    });
+  });
+
+  test('DREAM_SOURCE_ALLOWLIST is honored as doctor cycle_freshness allowlist fallback', async () => {
+    await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
+    await seed('citadel-portfolio', agoH(1));
+    await seed('martell-brain', undefined);
+
+    const result = await checkCycleFreshness(engine, {
+      nowMs: NOW,
+      env: { DREAM_SOURCE_ALLOWLIST: 'citadel-portfolio' } as NodeJS.ProcessEnv,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.details).toMatchObject({
+      checked_source_count: 1,
+      skipped_source_count: 1,
+      source_allowlist: ['citadel-portfolio'],
+    });
+  });
+
+  test('source ignorelist can suppress intentionally excluded stale sources', async () => {
+    await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
+    await seed('fresh-operating', agoH(1));
+    await seed('excluded-reference', undefined);
+    await engine.setConfig('doctor.cycle_freshness.source_ignorelist', 'excluded-reference');
+
+    const result = await checkCycleFreshness(engine, { nowMs: NOW, env: {} as NodeJS.ProcessEnv });
+
+    expect(result.status).toBe('ok');
+    expect(result.details).toMatchObject({
+      checked_source_count: 1,
+      skipped_source_count: 1,
+      source_ignorelist: ['excluded-reference'],
+    });
+  });
+
+  test('invalid cycle freshness source scope returns warn instead of silently hiding sources', async () => {
+    await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
+    await seed('fresh', agoH(1));
+
+    const result = await checkCycleFreshness(engine, {
+      nowMs: NOW,
+      env: { GBRAIN_CYCLE_FRESHNESS_SOURCE_ALLOWLIST: 'fresh,bad/source' } as NodeJS.ProcessEnv,
+    });
+
+    expect(result.status).toBe('warn');
+    expect(result.message).toMatch(/Invalid cycle_freshness source scope/);
+    expect(result.message).toMatch(/bad\/source/);
+  });
 });

--- a/test/doctor-cycle-freshness.test.ts
+++ b/test/doctor-cycle-freshness.test.ts
@@ -79,6 +79,38 @@ describe('doctor checkCycleFreshness', () => {
     expect(result.message).toMatch(/gbrain dream --source/);
   });
 
+  test('DB-configured cycle freshness thresholds support nightly cadence with grace', async () => {
+    await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
+    await seed('nightly-fresh', agoH(29));
+    await seed('missed-one-night', agoH(36));
+    await engine.setConfig('doctor.cycle_freshness.warn_hours', '30');
+    await engine.setConfig('doctor.cycle_freshness.fail_hours', '48');
+
+    const result = await checkCycleFreshness(engine, { nowMs: NOW, env: {} as NodeJS.ProcessEnv });
+
+    expect(result.status).toBe('warn');
+    expect(result.message).toMatch(/missed-one-night/);
+    expect(result.message).not.toMatch(/nightly-fresh/);
+  });
+
+  test('cycle freshness env thresholds override DB-configured thresholds', async () => {
+    await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
+    await seed('env-overrides-db', agoH(36));
+    await engine.setConfig('doctor.cycle_freshness.warn_hours', '30');
+    await engine.setConfig('doctor.cycle_freshness.fail_hours', '48');
+
+    const result = await checkCycleFreshness(engine, {
+      nowMs: NOW,
+      env: {
+        GBRAIN_CYCLE_FRESHNESS_WARN_HOURS: '6',
+        GBRAIN_CYCLE_FRESHNESS_FAIL_HOURS: '24',
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(result.status).toBe('fail');
+    expect(result.message).toMatch(/env-overrides-db/);
+  });
+
   test('source with NO last_full_cycle_at (never cycled) returns fail', async () => {
     await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
     await seed('virgin');


### PR DESCRIPTION
## Summary

This PR makes `doctor.cycle_freshness` match an intentionally once-nightly dream cadence:

- scopes the check to operating sources via `doctor.cycle_freshness.source_allowlist` / `source_ignorelist`, with `DREAM_SOURCE_ALLOWLIST` as a runtime fallback
- adds DB-configured threshold keys: `doctor.cycle_freshness.warn_hours` and `doctor.cycle_freshness.fail_hours`
- keeps env vars as the highest-precedence override for emergency/operator use
- registers the new keys so `gbrain config set ...` works without `--force`

## Why

A once-nightly dream cron cannot stay green under the old 6h warn / 24h fail defaults, even when it is healthy. Operators can now set daily-with-grace thresholds once in DB config, e.g. warn at 30h and fail at 48h, and have both interactive and HTTP/remote doctor use the same cadence.

## Verification

- `bun test test/doctor-cycle-freshness.test.ts test/config-set.test.ts`
- `bun run typecheck`
