### PR TITLE
v0.42.54.0 fix(verify): macOS `bun run verify` false-failures (fallback rc + BSD grep)

### DIFF
--- a/scripts/check-operations-filter-bypass.sh
+++ b/scripts/check-operations-filter-bypass.sh
@@ -68,9 +68,11 @@ PATTERN='import[[:space:]]+(\*[[:space:]]+as[[:space:]]+[a-zA-Z_$][a-zA-Z0-9_$]*
 # Collect files that import `operations`. Use a while-loop over grep output
 # instead of `mapfile` to stay compatible with macOS's default bash 3.2.
 FOUND_FILES=""
+# Normalize `//` -> `/`: BSD grep (macOS) emits `src//file.ts` for `grep -r ... src/`, which
+# then fails the exact match against the `src/...` ALLOWED entries below. GNU grep (CI) does not.
 while IFS= read -r f; do
   [ -n "$f" ] && FOUND_FILES="$FOUND_FILES$f"$'\n'
-done < <(grep -rlE --include='*.ts' "$PATTERN" src/ 2>/dev/null | sort -u || true)
+done < <(grep -rlE --include='*.ts' "$PATTERN" src/ 2>/dev/null | sed 's#//*#/#g' | sort -u || true)
 
 FAIL=0
 

--- a/scripts/run-verify-parallel.sh
+++ b/scripts/run-verify-parallel.sh
@@ -125,6 +125,7 @@ for c in "${CHECKS[@]}"; do
   (
     if [ -n "$TIMEOUT_BIN" ]; then
       "$TIMEOUT_BIN" "${TIMEOUT}s" bun run "$c" > "$LOG_FILE" 2>&1
+      rc=$?
     else
       bun run "$c" > "$LOG_FILE" 2>&1 &
       pid=$!
@@ -132,10 +133,10 @@ for c in "${CHECKS[@]}"; do
         sleep 5 && kill -KILL "$pid" 2>/dev/null ) &
       cap_pid=$!
       wait "$pid" 2>/dev/null
+      rc=$?                          # the check's real exit, captured BEFORE the watchdog kill below
       kill "$cap_pid" 2>/dev/null
       wait "$cap_pid" 2>/dev/null
     fi
-    rc=$?
     echo "$rc" > "$EXIT_FILE"
   ) &
   PIDS+=($!)


### PR DESCRIPTION
## What

Two macOS-only bugs make `bun run verify` (the documented pre-push gate) report failures that never happen on Linux CI. On a fresh macOS checkout without GNU coreutils, `bun run verify` currently reports `pass=0 fail=N` even when every check passes — a confusing first run for new Mac contributors. This fixes both so verify is green on macOS, matching CI.

No `VERSION` / `CHANGELOG` bump here — happy to leave versioning to your fix-wave / `/ship`.

## The two bugs

**1. `scripts/run-verify-parallel.sh` — fallback path reports every check as `rc=143`**

macOS ships no `timeout`, and a box without `brew install coreutils` has no `gtimeout`, so `TIMEOUT_BIN` is empty and the script takes the bg-pid + sleep-watchdog fallback. There, the shared `rc=$?` ran *after* `wait "$cap_pid"` — and since the watchdog had just been `kill`ed, `$?` was 143 (SIGTERM) for **every** check, masking each check's real status. Verify then reported `pass=0 fail=N` with all checks at `rc=143`, even when they all passed.

Fix: capture `$?` immediately after `wait "$pid"` (the check process), before killing the watchdog. The `gtimeout`/`timeout` branch already captured the right code.

**2. `scripts/check-operations-filter-bypass.sh` — BSD grep `src//file` breaks the allowlist match**

`grep -rlE ... src/` on BSD grep (the macOS default) emits paths like `src//cli.ts` (doubled slash). The check compares those against the `src/...` entries in `ALLOWED` with an exact `=`, so every allowed importer (`src/cli.ts`, `src/mcp/dispatch.ts`, …) is flagged as a new unlisted importer. GNU grep on CI normalizes the path, so this only bites macOS.

Fix: normalize `//` → `/` on the grep output.

## Verification (macOS, no coreutils)

Forcing the no-`gtimeout` fallback path (the conditions that trigger the bug):

- **Before:** `bun run verify` → `pass=0 fail=30`, every check `rc=143`.
- **After:** `bun run verify` → `[verify-parallel] pass=30 fail=0 | all checks green`, exit 0, zero `rc=143`.

`check-operations-filter-bypass.sh` run directly now exits 0 on BSD grep. The `gtimeout`/`timeout` and GNU-grep paths are untouched, so there is no behavior change on Linux/CI.
