### PR TITLE
feat(cycle): make consolidate gates config-tunable

### DIFF
--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -1987,10 +1987,32 @@ export async function runCycle(
       } else {
         progress.start('cycle.consolidate');
         const { runPhaseConsolidate } = await import('./cycle/phases/consolidate.ts');
+        // Consolidate gates are config-tunable (DB plane). Unset keys keep the
+        // built-in defaults (0.85 cluster / 3 facts / 24h age), so behavior is
+        // unchanged unless an operator opts in. Federated multi-source brains
+        // (entity pages in one source, facts in others) or short-lived source
+        // corpora often need a lower cluster threshold and/or age gate than the
+        // single-personal-brain defaults assume.
+        const consolidateNum = async (key: string): Promise<number | undefined> => {
+          try {
+            const raw = await engine.getConfig(key);
+            if (raw === null || raw === undefined) return undefined;
+            const n = Number(raw);
+            return Number.isFinite(n) ? n : undefined;
+          } catch {
+            return undefined;
+          }
+        };
+        const clusterThreshold = await consolidateNum('consolidate.cluster_threshold');
+        const minFactsPerBucket = await consolidateNum('consolidate.min_facts_per_bucket');
+        const minOldestAgeHours = await consolidateNum('consolidate.min_oldest_age_hours');
         const { result, duration_ms } = await timePhase(() => runPhaseConsolidate(engine, {
           dryRun,
           yieldDuringPhase: opts.yieldDuringPhase,
           signal: opts.signal,
+          ...(clusterThreshold !== undefined ? { clusterThreshold } : {}),
+          ...(minFactsPerBucket !== undefined ? { minFactsPerBucket } : {}),
+          ...(minOldestAgeHours !== undefined ? { minOldestAgeMs: minOldestAgeHours * 3_600_000 } : {}),
         }));
         result.duration_ms = duration_ms;
         phaseResults.push(result);


### PR DESCRIPTION
## What

Make the dream `consolidate` phase's promotion gates configurable via three optional DB-plane config keys, read in the `cycle.ts` dispatch and passed to `runPhaseConsolidate` (which already accepts the opts):

| key | default (unchanged) |
|---|---|
| `consolidate.cluster_threshold` | `0.85` |
| `consolidate.min_facts_per_bucket` | `3` |
| `consolidate.min_oldest_age_hours` | `24` |

Unset keys keep the built-in defaults, so behavior is **unchanged unless an operator opts in**. Uses the same `engine.getConfig()` + numeric-fallback pattern as the sync cost-gate.

## Why

The gates are currently hard-coded in `consolidate.ts`. The defaults are tuned for a single personal brain where facts and their entity pages live in one source. Two real deployments can't promote facts → takes with those defaults:

- **Federated / multi-source company brains** — entity pages in a `graph` source, facts in `meetings`/`ops`/`conversations`. Facts about the same entity are diverse (span many docs), so the 0.85 cluster threshold rarely forms a ≥2 cluster and almost nothing consolidates. Lowering to ~0.6 promotes sane takes; there's no supported way to set it short of a fork or an out-of-band script calling `runPhaseConsolidate` directly.
- **Historical / bulk-imported corpora** — a one-time backfill of already-old content wants the 24h "settle" gate relaxed.

This lets operators tune those cases without forking the engine.

## Testing

- `engine.getConfig` returns `string | null`; helper coerces to a finite number or `undefined` (falls back to the phase default). Invalid/missing values are safe no-ops.
- No behavior change when the keys are unset (the common case) — the spread only adds an opt when a valid value is configured.

I left `VERSION` / `CHANGELOG.md` untouched for your release flow — happy to add a changelog entry in your preferred format if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
