### PR TITLE
fix: harden doctor, embedding, and source config handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ test/fixtures/pglite-snapshot.version
 
 # Private brain reports — never check these in (per CLAUDE.md privacy rule)
 reports/network-intelligence/
+
+# Auto-managed by gbrain (db_only directories)
+media/x/
+media/articles/
+meetings/transcripts/

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -5161,16 +5161,20 @@ export async function buildChecks(
 
   // 4. pgvector extension
   progress.heartbeat('pgvector');
-  try {
-    const sql = db.getConnection();
-    const ext = await sql`SELECT extname FROM pg_extension WHERE extname = 'vector'`;
-    if (ext.length > 0) {
-      checks.push({ name: 'pgvector', status: 'ok', message: 'Extension installed' });
-    } else {
-      checks.push({ name: 'pgvector', status: 'fail', message: 'Extension not found. Run: CREATE EXTENSION vector;' });
+  if (engine.kind === 'pglite') {
+    checks.push({ name: 'pgvector', status: 'ok', message: 'Skipped (PGLite bundles vector support; extension probe is Postgres-only)' });
+  } else {
+    try {
+      const sql = db.getConnection();
+      const ext = await sql`SELECT extname FROM pg_extension WHERE extname = 'vector'`;
+      if (ext.length > 0) {
+        checks.push({ name: 'pgvector', status: 'ok', message: 'Extension installed' });
+      } else {
+        checks.push({ name: 'pgvector', status: 'fail', message: 'Extension not found. Run: CREATE EXTENSION vector;' });
+      }
+    } catch {
+      checks.push({ name: 'pgvector', status: 'warn', message: 'Could not check pgvector extension' });
     }
-  } catch {
-    checks.push({ name: 'pgvector', status: 'warn', message: 'Could not check pgvector extension' });
   }
 
   // 4b. PgBouncer / prepared-statement compatibility.
@@ -5957,36 +5961,40 @@ export async function buildChecks(
   // surface matches `repair-jsonb` (the previous 4-target scan missed a
   // repair target, per #254/Codex review).
   progress.heartbeat('jsonb_integrity');
-  try {
-    const sql = db.getConnection();
-    const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
-      { table: 'pages',         col: 'frontmatter',    expected: 'object' },
-      { table: 'raw_data',      col: 'data',           expected: 'object' },
-      { table: 'ingest_log',    col: 'pages_updated',  expected: 'array'  },
-      { table: 'files',         col: 'metadata',       expected: 'object' },
-      { table: 'page_versions', col: 'frontmatter',    expected: 'object' },
-    ];
-    let totalBad = 0;
-    const breakdown: string[] = [];
-    for (const { table, col } of targets) {
-      progress.heartbeat(`jsonb_integrity.${table}.${col}`);
-      const rows = await sql.unsafe(
-        `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
-      );
-      const n = Number((rows as any)[0]?.n ?? 0);
-      if (n > 0) { totalBad += n; breakdown.push(`${table}.${col}=${n}`); }
+  if (engine.kind === 'pglite') {
+    checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'Skipped (Postgres JSONB storage regression check is not applicable to PGLite)' });
+  } else {
+    try {
+      const sql = db.getConnection();
+      const targets: Array<{ table: string; col: string; expected: 'object' | 'array' }> = [
+        { table: 'pages',         col: 'frontmatter',    expected: 'object' },
+        { table: 'raw_data',      col: 'data',           expected: 'object' },
+        { table: 'ingest_log',    col: 'pages_updated',  expected: 'array'  },
+        { table: 'files',         col: 'metadata',       expected: 'object' },
+        { table: 'page_versions', col: 'frontmatter',    expected: 'object' },
+      ];
+      let totalBad = 0;
+      const breakdown: string[] = [];
+      for (const { table, col } of targets) {
+        progress.heartbeat(`jsonb_integrity.${table}.${col}`);
+        const rows = await sql.unsafe(
+          `SELECT count(*)::int AS n FROM ${table} WHERE jsonb_typeof(${col}) = 'string'`,
+        );
+        const n = Number((rows as any)[0]?.n ?? 0);
+        if (n > 0) { totalBad += n; breakdown.push(`${table}.${col}=${n}`); }
+      }
+      if (totalBad === 0) {
+        checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'All JSONB columns store objects/arrays' });
+      } else {
+        checks.push({
+          name: 'jsonb_integrity',
+          status: 'warn',
+          message: `${totalBad} row(s) double-encoded (${breakdown.join(', ')}). Fix: gbrain repair-jsonb`,
+        });
+      }
+    } catch {
+      checks.push({ name: 'jsonb_integrity', status: 'warn', message: 'Could not check JSONB integrity' });
     }
-    if (totalBad === 0) {
-      checks.push({ name: 'jsonb_integrity', status: 'ok', message: 'All JSONB columns store objects/arrays' });
-    } else {
-      checks.push({
-        name: 'jsonb_integrity',
-        status: 'warn',
-        message: `${totalBad} row(s) double-encoded (${breakdown.join(', ')}). Fix: gbrain repair-jsonb`,
-      });
-    }
-  } catch {
-    checks.push({ name: 'jsonb_integrity', status: 'warn', message: 'Could not check JSONB integrity' });
   }
 
   // 10b. Takes weight grid integrity (v0.32 — EXP-2).

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3167,6 +3167,15 @@ export async function computeExtractAtomsBacklogCheck(
       };
     }
 
+    const autoDrain = await engine.getConfig('autopilot.auto_drain.enabled').catch(() => null);
+    if (!declared && typeof autoDrain === 'string' && autoDrain.trim().toLowerCase() === 'false') {
+      return {
+        name, status: 'ok',
+        message: `${backlog} page(s) eligible; atom auto-drain disabled by config`,
+        details: { backlog, pack_declares_phase: false, auto_drain_enabled: false, known_approximation: approx },
+      };
+    }
+
     // The incident: pack does NOT run the phase but a real backlog exists →
     // it will grow forever without a signal. WARN with the drain command.
     if (!declared && backlog > 10) {
@@ -5755,7 +5764,7 @@ export async function buildChecks(
   try {
     const health = await engine.getHealth();
     const entityCount = (await engine.executeRaw<{ count: number }>(
-      "SELECT COUNT(*)::int AS count FROM pages WHERE type IN ('entity', 'person', 'company', 'organization')",
+      "SELECT COUNT(*)::int AS count FROM pages WHERE type IN ('entity', 'person', 'company', 'organization') AND deleted_at IS NULL",
     ))[0]?.count ?? 0;
 
     // Compute coverage against eligible entities only — exclude test fixtures
@@ -5810,6 +5819,10 @@ export async function buildChecks(
     // Uses distinct *_score field names (not overloading link_coverage /
     // timeline_coverage, which are entity-scoped).
     if (health.brain_score < 100) {
+      const warnBelowRaw = await engine.getConfig('doctor.brain_score_warn_below').catch(() => null);
+      const warnBelow = warnBelowRaw && Number.isFinite(Number(warnBelowRaw))
+        ? Number(warnBelowRaw)
+        : 70;
       const parts = [
         `embed ${health.embed_coverage_score}/35`,
         `links ${health.link_density_score}/25`,
@@ -5819,7 +5832,7 @@ export async function buildChecks(
       ];
       checks.push({
         name: 'brain_score',
-        status: health.brain_score >= 70 ? 'ok' : 'warn',
+        status: health.brain_score >= warnBelow ? 'ok' : 'warn',
         message: `Brain score ${health.brain_score}/100 (${parts.join(', ')})`,
       });
     } else {

--- a/src/commands/embed.ts
+++ b/src/commands/embed.ts
@@ -514,6 +514,58 @@ export async function runEmbed(engine: BrainEngine, args: string[]): Promise<Emb
   }
 }
 
+const DEFAULT_EMBED_RECHUNK_MAX_CHARS = 1500;
+
+function embedRechunkMaxChars(): number {
+  const raw = process.env.GBRAIN_EMBED_RECHUNK_MAX_CHARS;
+  if (!raw) return DEFAULT_EMBED_RECHUNK_MAX_CHARS;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_EMBED_RECHUNK_MAX_CHARS;
+}
+
+type EmbedCandidateChunk = {
+  chunk_index: number;
+  chunk_text: string;
+  chunk_source: ChunkInput['chunk_source'];
+  embedded_at?: string | Date | null;
+};
+
+function hasOversizedStaleChunk(chunks: EmbedCandidateChunk[]): boolean {
+  const maxChars = embedRechunkMaxChars();
+  return chunks.some(c => !c.embedded_at && c.chunk_text.length > maxChars);
+}
+
+function buildChunkInputsForPage(page: { compiled_truth?: string | null; timeline?: string | null }, maxChars: number): ChunkInput[] {
+  const inputs: ChunkInput[] = [];
+  const compiledTruth = page.compiled_truth ?? '';
+  const timeline = page.timeline ?? '';
+  if (compiledTruth.trim()) {
+    for (const c of chunkText(compiledTruth, { maxChars })) {
+      inputs.push({ chunk_index: inputs.length, chunk_text: c.text, chunk_source: 'compiled_truth' });
+    }
+  }
+  if (timeline.trim()) {
+    for (const c of chunkText(timeline, { maxChars })) {
+      inputs.push({ chunk_index: inputs.length, chunk_text: c.text, chunk_source: 'timeline' });
+    }
+  }
+  return inputs;
+}
+
+async function rechunkPageForEmbedding(
+  engine: BrainEngine,
+  slug: string,
+  sourceId?: string,
+): Promise<Awaited<ReturnType<BrainEngine['getChunks']>> | null> {
+  const opts = sourceId ? { sourceId } : undefined;
+  const page = await engine.getPage(slug, opts);
+  if (!page) return null;
+  const inputs = buildChunkInputsForPage(page, embedRechunkMaxChars());
+  if (inputs.length === 0) return null;
+  await engine.upsertChunks(slug, inputs, opts);
+  return await engine.getChunks(slug, opts);
+}
+
 async function embedPage(
   engine: BrainEngine,
   slug: string,
@@ -534,16 +586,7 @@ async function embedPage(
   let chunks = await engine.getChunks(slug, opts);
   if (chunks.length === 0) {
     const inputs: ChunkInput[] = [];
-    if (page.compiled_truth.trim()) {
-      for (const c of chunkText(page.compiled_truth)) {
-        inputs.push({ chunk_index: inputs.length, chunk_text: c.text, chunk_source: 'compiled_truth' });
-      }
-    }
-    if (page.timeline.trim()) {
-      for (const c of chunkText(page.timeline)) {
-        inputs.push({ chunk_index: inputs.length, chunk_text: c.text, chunk_source: 'timeline' });
-      }
-    }
+    inputs.push(...buildChunkInputsForPage(page, embedRechunkMaxChars()));
 
     if (dryRun) {
       // Count what chunking WOULD produce, without writing.
@@ -556,6 +599,12 @@ async function embedPage(
     if (inputs.length > 0) {
       await engine.upsertChunks(slug, inputs, opts);
       chunks = await engine.getChunks(slug, opts);
+    }
+  }
+  if (!dryRun && hasOversizedStaleChunk(chunks)) {
+    const rechunked = await rechunkPageForEmbedding(engine, slug, sourceId);
+    if (rechunked && rechunked.length > 0) {
+      chunks = rechunked;
     }
   }
 
@@ -1002,15 +1051,24 @@ async function embedAllStale(
 
       async function embedOneKey(key: string) {
         const stale = byKey.get(key)!;
+        let staleForEmbed: EmbedCandidateChunk[] = stale;
         const keySourceId = stale[0]?.source_id ?? 'default';
         const slug = stale[0].slug;
         try {
-          const embeddings = await embedBatchWithBackoff(stale.map(c => c.chunk_text), { abortSignal: effectiveSignal });
+          if (hasOversizedStaleChunk(staleForEmbed)) {
+            const rechunked = await rechunkPageForEmbedding(engine, slug, keySourceId);
+            if (rechunked && rechunked.length > 0) {
+              staleForEmbed = rechunked.filter(c => !c.embedded_at);
+              if (staleForEmbed.length === 0) return;
+            }
+          }
+
+          const embeddings = await embedBatchWithBackoff(staleForEmbed.map(c => c.chunk_text), { abortSignal: effectiveSignal });
           // Re-fetch existing chunks and merge to avoid deleting non-stale chunks.
           const existing = await observed(pacer, () => engine.getChunks(slug, { sourceId: keySourceId }));
           const staleIdxToEmbedding = new Map<number, Float32Array>();
-          for (let j = 0; j < stale.length; j++) {
-            staleIdxToEmbedding.set(stale[j].chunk_index, embeddings[j]);
+          for (let j = 0; j < staleForEmbed.length; j++) {
+            staleIdxToEmbedding.set(staleForEmbed[j].chunk_index, embeddings[j]);
           }
           const merged: ChunkInput[] = existing.map(c => ({
             chunk_index: c.chunk_index,
@@ -1025,12 +1083,12 @@ async function embedAllStale(
           // A partially-stale page keeps preserved chunks of unknown/old
           // provenance, so don't claim it's current. (After invalidate, a
           // signature-drifted page IS fully stale → this stamps it.)
-          if (signature && stale.length === existing.length) {
+          if (signature && staleForEmbed.length === existing.length) {
             await observed(pacer, () =>
               engine.setPageEmbeddingSignature(slug, { sourceId: keySourceId, signature }),
             );
           }
-          result.embedded += stale.length;
+          result.embedded += staleForEmbed.length;
         } catch (e: unknown) {
           // Budget/abort-fired cancellations are expected on the way out; don't
           // spam per-page "Error embedding" lines when we're shutting down.

--- a/src/core/ai/recipes/google.ts
+++ b/src/core/ai/recipes/google.ts
@@ -15,6 +15,12 @@ export const google: Recipe = {
       default_dims: 768,
       dims_options: [768, 1536, 3072],
       cost_per_1m_tokens_usd: 0.15,
+      // gemini-embedding-001 documents a 2,048-token input limit. Keep the
+      // gateway pre-split conservative so dense Markdown/code chunks do not
+      // rely on recursive retry as the first safety net.
+      max_batch_tokens: 2048,
+      chars_per_token: 2,
+      safety_factor: 0.8,
       price_last_verified: '2026-04-20',
     },
     expansion: {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -884,6 +884,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'emotional_weight.user_holder',
   // Cycle phase config
   'cycle.grade_takes.write_gstack_learnings',
+  // Doctor thresholds
+  'doctor.brain_score_warn_below',
   // Content sanity (v0.41)
   'content_sanity.bytes_warn',
   'content_sanity.bytes_block',
@@ -938,6 +940,7 @@ export const KNOWN_CONFIG_KEY_PREFIXES: readonly string[] = [
   'models.',           // models.* (tier, aliases, per-task)
   'dream.',            // dream.synthesize.*, dream.patterns.*
   'cycle.',            // cycle.<phase>.*
+  'doctor.',           // doctor.* operator thresholds
   'embedding_columns.', // per-column overrides
   'provider_base_urls.', // per-provider base URL overrides
   'content_sanity.',    // v0.41 content-sanity tunables

--- a/src/core/doctor-categories.ts
+++ b/src/core/doctor-categories.ts
@@ -67,6 +67,7 @@ export const BRAIN_CHECK_NAMES: ReadonlySet<string> = new Set([
   'cross_modal_modality_backfill',
   'cycle_freshness',
   'effective_date_health',
+  'embed_staleness',
   'embedding_column_registry',
   'embedding_env_override',
   'embedding_provider',
@@ -79,6 +80,7 @@ export const BRAIN_CHECK_NAMES: ReadonlySet<string> = new Set([
   'facts_extraction_health',
   'facts_health',
   'frontmatter_integrity',
+  'entity_link_coverage',
   'grade_confidence_drift',
   'graph_coverage',
   'graph_signals_coverage',
@@ -101,7 +103,9 @@ export const BRAIN_CHECK_NAMES: ReadonlySet<string> = new Set([
   'stub_guard_24h',
   'sync_failures',
   'sync_freshness',
+  'takes_count',
   'takes_weight_grid',
+  'timeline_coverage',
   'unified_multimodal_coverage',
   'voice_gate_health',
 ]);
@@ -166,15 +170,18 @@ export const OPS_CHECK_NAMES: ReadonlySet<string> = new Set([
  */
 export const META_CHECK_NAMES: ReadonlySet<string> = new Set([
   'cycle_phase_scope',
+  'dangling_aliases',
   'eval_capture',
   'minions_migration',
   'multi_source_drift',
+  'pack_upgrade_available',
   'schema_pack_active',
   'schema_pack_consistency',
   'schema_pack_source_drift',
   'schema_version',
   'slug_fallback_audit',
   'timeline_dedup_index',
+  'type_proliferation',
   'upgrade_errors',
 ]);
 

--- a/src/core/onboard/checks.ts
+++ b/src/core/onboard/checks.ts
@@ -337,7 +337,8 @@ export async function checkTakesCount(
         status: 'remediable',
       }));
     } else {
-      message = '0 takes (takes.bootstrap_enabled is false; opt in to enable)';
+      status = 'ok';
+      message = '0 takes (bootstrap disabled by config; opt in with takes.bootstrap_enabled=true)';
     }
   } else {
     message = `${takesCount} takes (calibration usable; >100 ideal)`;

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1295,7 +1295,30 @@ export class PGLiteEngine implements BrainEngine {
     // `JSON.stringify(patch)` as the param; cast to jsonb on the SQL side.
     const result = await this.db.query<{ id: string }>(
       `UPDATE sources
-          SET config = COALESCE(config, '{}'::jsonb) || $1::jsonb
+          SET config =
+            CASE
+              WHEN config IS NULL THEN '{}'::jsonb
+              WHEN jsonb_typeof(config) = 'object' THEN config
+              WHEN jsonb_typeof(config) = 'string'
+                THEN CASE
+                  WHEN (config #>> '{}') IS JSON
+                    THEN COALESCE(NULLIF((config #>> '{}'), '')::jsonb, '{}'::jsonb)
+                  ELSE '{}'::jsonb
+                END
+              WHEN jsonb_typeof(config) = 'array'
+                THEN COALESCE(
+                  (SELECT jsonb_object_agg(kv.key, kv.value)
+                     FROM jsonb_array_elements(config) elem
+                     CROSS JOIN LATERAL jsonb_each(
+                       CASE
+                         WHEN jsonb_typeof(elem) = 'object' THEN elem
+                         ELSE '{}'::jsonb
+                       END
+                     ) kv),
+                  '{}'::jsonb
+                )
+              ELSE '{}'::jsonb
+            END || $1::jsonb
         WHERE id = $2
         RETURNING id`,
       [JSON.stringify(patch), sourceId],

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4677,7 +4677,11 @@ export class PGLiteEngine implements BrainEngine {
     `);
 
     const { rows: types } = await this.db.query(
-      `SELECT type, count(*)::int as count FROM pages GROUP BY type ORDER BY count DESC`
+      `SELECT type, count(*)::int as count
+       FROM pages
+       WHERE deleted_at IS NULL
+       GROUP BY type
+       ORDER BY count DESC`
     );
     const pages_by_type: Record<string, number> = {};
     for (const t of types as { type: string; count: number }[]) {
@@ -4703,27 +4707,39 @@ export class PGLiteEngine implements BrainEngine {
     // dashboard, v0.10.3 metrics give entity-page-level granularity.
     const { rows: [h] } = await this.db.query(`
       WITH entity_pages AS (
-        SELECT id, slug FROM pages WHERE type IN ('person', 'company')
+        SELECT id, slug
+        FROM pages
+        WHERE type IN ('person', 'company')
+          AND deleted_at IS NULL
       )
       SELECT
-        (SELECT count(*) FROM pages) as page_count,
+        (SELECT count(*) FROM pages WHERE deleted_at IS NULL) as page_count,
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NOT NULL)::float /
           GREATEST((SELECT count(*) FROM content_chunks), 1)::float as embed_coverage,
         (SELECT count(*) FROM pages p
          WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
+           AND p.deleted_at IS NULL
         ) as stale_pages,
         -- Bug 11 — orphan = islanded (no inbound AND no outbound).
         -- See BrainHealth.orphan_pages docstring; docs updated to match this.
         (SELECT count(*) FROM pages p
-         WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
+         WHERE p.deleted_at IS NULL
+           AND NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
         ) as orphan_pages,
         (SELECT count(*) FROM links l
-         WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)
+         WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id AND p.deleted_at IS NULL)
         ) as dead_links,
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NULL) as missing_embeddings,
-        (SELECT count(*) FROM links) as link_count,
-        (SELECT count(DISTINCT page_id) FROM timeline_entries) as pages_with_timeline,
+        (SELECT count(*) FROM links l
+         WHERE EXISTS (SELECT 1 FROM pages p WHERE p.id = l.from_page_id AND p.deleted_at IS NULL)
+           AND EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id AND p.deleted_at IS NULL)
+        ) as link_count,
+        (SELECT count(DISTINCT te.page_id)
+         FROM timeline_entries te
+         JOIN pages p ON p.id = te.page_id
+         WHERE p.deleted_at IS NULL
+        ) as pages_with_timeline,
         (SELECT count(*) FROM entity_pages e
          WHERE EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = e.id))::float /
           GREATEST((SELECT count(*) FROM entity_pages), 1)::float as link_coverage,
@@ -4738,6 +4754,7 @@ export class PGLiteEngine implements BrainEngine {
              (SELECT count(*) FROM links l WHERE l.from_page_id = p.id OR l.to_page_id = p.id)::int as link_count
       FROM pages p
       WHERE p.type IN ('person', 'company')
+        AND p.deleted_at IS NULL
       ORDER BY link_count DESC
       LIMIT 5
     `);

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4695,7 +4695,11 @@ export class PostgresEngine implements BrainEngine {
     `;
 
     const types = await sql`
-      SELECT type, count(*)::int as count FROM pages GROUP BY type ORDER BY count DESC
+      SELECT type, count(*)::int as count
+      FROM pages
+      WHERE deleted_at IS NULL
+      GROUP BY type
+      ORDER BY count DESC
     `;
     const pages_by_type: Record<string, number> = {};
     for (const t of types) {
@@ -4723,25 +4727,37 @@ export class PostgresEngine implements BrainEngine {
     // is working as intended, not an orphan.
     const [h] = await sql`
       WITH entity_pages AS (
-        SELECT id, slug FROM pages WHERE type IN ('person', 'company')
+        SELECT id, slug
+        FROM pages
+        WHERE type IN ('person', 'company')
+          AND deleted_at IS NULL
       )
       SELECT
-        (SELECT count(*) FROM pages) as page_count,
+        (SELECT count(*) FROM pages WHERE deleted_at IS NULL) as page_count,
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NOT NULL)::float /
           GREATEST((SELECT count(*) FROM content_chunks), 1)::float as embed_coverage,
         (SELECT count(*) FROM pages p
          WHERE p.updated_at < (SELECT MAX(te.created_at) FROM timeline_entries te WHERE te.page_id = p.id)
+           AND p.deleted_at IS NULL
         ) as stale_pages,
         (SELECT count(*) FROM pages p
-         WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
+         WHERE p.deleted_at IS NULL
+           AND NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
         ) as orphan_pages,
         (SELECT count(*) FROM links l
-         WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)
+         WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id AND p.deleted_at IS NULL)
         ) as dead_links,
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NULL) as missing_embeddings,
-        (SELECT count(*) FROM links) as link_count,
-        (SELECT count(DISTINCT page_id) FROM timeline_entries) as pages_with_timeline,
+        (SELECT count(*) FROM links l
+         WHERE EXISTS (SELECT 1 FROM pages p WHERE p.id = l.from_page_id AND p.deleted_at IS NULL)
+           AND EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id AND p.deleted_at IS NULL)
+        ) as link_count,
+        (SELECT count(DISTINCT te.page_id)
+         FROM timeline_entries te
+         JOIN pages p ON p.id = te.page_id
+         WHERE p.deleted_at IS NULL
+        ) as pages_with_timeline,
         (SELECT count(*) FROM entity_pages e
          WHERE EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = e.id))::float /
           GREATEST((SELECT count(*) FROM entity_pages), 1)::float as link_coverage,
@@ -4755,6 +4771,7 @@ export class PostgresEngine implements BrainEngine {
              (SELECT count(*) FROM links l WHERE l.from_page_id = p.id OR l.to_page_id = p.id)::int as link_count
       FROM pages p
       WHERE p.type IN ('person', 'company')
+        AND p.deleted_at IS NULL
       ORDER BY link_count DESC
       LIMIT 5
     `;

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -1323,8 +1323,13 @@ export class PostgresEngine implements BrainEngine {
              WHEN jsonb_typeof(config) = 'array'
                THEN COALESCE(
                  (SELECT jsonb_object_agg(kv.key, kv.value)
-                    FROM jsonb_array_elements(config) elem,
-                         jsonb_each(elem) kv),
+                    FROM jsonb_array_elements(config) elem
+                    CROSS JOIN LATERAL jsonb_each(
+                      CASE
+                        WHEN jsonb_typeof(elem) = 'object' THEN elem
+                        ELSE '{}'::jsonb
+                      END
+                    ) kv),
                  '{}'::jsonb
                )
              ELSE '{}'::jsonb

--- a/test/ai/adaptive-embed-batch.test.ts
+++ b/test/ai/adaptive-embed-batch.test.ts
@@ -383,7 +383,7 @@ describe('shrink-on-miss adaptive cache', () => {
 describe('startup warning for recipes missing max_batch_tokens', () => {
   beforeEach(() => resetGateway());
 
-  test('configured missing-cap recipe warns once; unrelated recipes stay quiet', () => {
+  test('configureGateway stays quiet when recipes declare caps or explicit no-cap opt-outs', () => {
     const warnings: string[] = [];
     const original = console.warn;
     console.warn = (msg: string) => warnings.push(String(msg));
@@ -400,17 +400,11 @@ describe('startup warning for recipes missing max_batch_tokens', () => {
       console.warn = original;
     }
 
-    // The warning text should match the documented contract.
-    const contractMatch = warnings.filter(w =>
-      w.includes('[ai.gateway]') && w.includes('declares an embedding touchpoint'),
-    );
-    expect(contractMatch.length).toBe(1);
-
-    // Voyage declares max_batch_tokens → suppressed. OpenAI is the
-    // canonical fast-path recipe → also suppressed by id. Both must be
-    // absent from the warnings.
+    // Every current embedding recipe either declares max_batch_tokens, opts
+    // out with no_batch_cap, or is the canonical OpenAI fast path.
+    expect(warnings.find(w => w.includes('declares an embedding touchpoint'))).toBeUndefined();
     expect(warnings.find(w => w.includes('"voyage"'))).toBeUndefined();
     expect(warnings.find(w => w.includes('"openai"'))).toBeUndefined();
-    expect(warnings.find(w => w.includes('"google"'))).toBeDefined();
+    expect(warnings.find(w => w.includes('"google"'))).toBeUndefined();
   });
 });

--- a/test/ai/no-batch-cap-suppression.serial.test.ts
+++ b/test/ai/no-batch-cap-suppression.serial.test.ts
@@ -52,28 +52,15 @@ describe('v0.32 #779: no_batch_cap suppresses the missing-max_batch_tokens warni
     }
   });
 
-  test('configureGateway warns for google only when google embedding is configured', () => {
+  test('configureGateway does not warn for google because it declares a conservative cap', () => {
     warnSpy.mockClear();
     resetGateway();
     configureGateway({ env: {} });
     let messages = warnSpy.mock.calls.map(c => String(c[0] ?? ''));
     expect(
       messages.some(m => m.includes('"google"') && m.includes('without max_batch_tokens')),
-      'google should not warn while OpenAI default is configured',
+      'google declares max_batch_tokens, so startup should stay quiet',
     ).toBe(false);
-
-    warnSpy.mockClear();
-    resetGateway();
-    configureGateway({
-      embedding_model: 'google:gemini-embedding-001',
-      embedding_dimensions: 768,
-      env: { GOOGLE_GENERATIVE_AI_API_KEY: 'fake' },
-    });
-    messages = warnSpy.mock.calls.map(c => String(c[0] ?? ''));
-    expect(
-      messages.some(m => m.includes('"google"') && m.includes('without max_batch_tokens')),
-      'google should warn when configured because it has fixed-cap models',
-    ).toBe(true);
   });
 
   test('every recipe with empty models[] declares user_provided_models OR has openai-fast-path', () => {

--- a/test/config-set.test.ts
+++ b/test/config-set.test.ts
@@ -24,6 +24,10 @@ describe('KNOWN_CONFIG_KEYS', () => {
     expect(KNOWN_CONFIG_KEYS).toContain('search.cache.enabled');
   });
 
+  test('contains doctor operator-threshold keys', () => {
+    expect(KNOWN_CONFIG_KEYS).toContain('doctor.brain_score_warn_below');
+  });
+
   test('contains the models-tier keys (v0.31.12)', () => {
     expect(KNOWN_CONFIG_KEYS).toContain('models.default');
     expect(KNOWN_CONFIG_KEYS).toContain('models.tier.subagent');
@@ -49,6 +53,7 @@ describe('KNOWN_CONFIG_KEY_PREFIXES', () => {
     expect(KNOWN_CONFIG_KEY_PREFIXES).toContain('search.');
     expect(KNOWN_CONFIG_KEY_PREFIXES).toContain('models.');
     expect(KNOWN_CONFIG_KEY_PREFIXES).toContain('dream.');
+    expect(KNOWN_CONFIG_KEY_PREFIXES).toContain('doctor.');
   });
 
   test('prefixes end in `.` (consistent shape)', () => {

--- a/test/doctor-categories.test.ts
+++ b/test/doctor-categories.test.ts
@@ -1,10 +1,10 @@
 /**
  * Drift guard for src/core/doctor-categories.ts.
  *
- * Reads src/commands/doctor.ts source via a literal-string scan, enumerates
- * every `name: '<...>'` Check name, and asserts each appears in exactly ONE
- * category set. The union of the four sets must equal the discovered names
- * exactly — no orphans, no extras.
+ * Reads src/commands/doctor.ts plus the onboard checks doctor imports at
+ * runtime, enumerates every `name: '<...>'` Check name, and asserts each
+ * appears in exactly ONE category set. The union of the four sets must equal
+ * the discovered names exactly — no orphans, no extras.
  *
  * This is the structural failure the v0.41.19.0 plan-eng-review caught:
  * doctor.ts grows new checks regularly; without this guard, the
@@ -25,9 +25,9 @@ import {
 } from '../src/core/doctor-categories.ts';
 
 const DOCTOR_TS_PATH = join(import.meta.dir, '..', 'src', 'commands', 'doctor.ts');
+const ONBOARD_CHECKS_TS_PATH = join(import.meta.dir, '..', 'src', 'core', 'onboard', 'checks.ts');
 
-function enumerateCheckNames(): Set<string> {
-  const source = readFileSync(DOCTOR_TS_PATH, 'utf-8');
+function enumerateCheckNamesInSource(source: string): Set<string> {
   const names = new Set<string>();
   // 1) Inline object-literal form: `{ name: 'foo', ... }`.
   for (const m of source.matchAll(/name:\s*['"]([a-z][a-z0-9_]+)['"]/g)) {
@@ -39,6 +39,16 @@ function enumerateCheckNames(): Set<string> {
   //    name constant.
   for (const m of source.matchAll(/const\s+name\s*=\s*['"]([a-z][a-z0-9_]+)['"]/g)) {
     names.add(m[1]);
+  }
+  return names;
+}
+
+function enumerateCheckNames(): Set<string> {
+  const names = new Set<string>();
+  for (const file of [DOCTOR_TS_PATH, ONBOARD_CHECKS_TS_PATH]) {
+    for (const name of enumerateCheckNamesInSource(readFileSync(file, 'utf-8'))) {
+      names.add(name);
+    }
   }
   return names;
 }

--- a/test/e2e/list-all-sources-postgres.test.ts
+++ b/test/e2e/list-all-sources-postgres.test.ts
@@ -160,4 +160,26 @@ describeIfDB('Postgres parity — updateSourceConfig', () => {
     expect(rows[0]?.typeof).toBe('object');
     expect(rows[0]?.value).toBe('2026-05-22T12:00:00.000Z');
   });
+
+  test('bad array config ignores non-object elements before merge', async () => {
+    await seedSource('epsilon');
+    await engine.executeRaw(
+      `UPDATE sources
+          SET config = '[{"keep":"me"},"bad-shape",["also-bad"]]'::jsonb
+        WHERE id = 'epsilon'`,
+    );
+    await engine.updateSourceConfig('epsilon', {
+      last_source_cycle_at: '2026-06-24T10:40:00.000Z',
+    });
+    const rows = await engine.executeRaw<{ keep: string | null; cycle: string | null; typeof: string }>(
+      `SELECT config->>'keep' AS keep,
+              config->>'last_source_cycle_at' AS cycle,
+              jsonb_typeof(config) AS typeof
+         FROM sources
+        WHERE id = 'epsilon'`,
+    );
+    expect(rows[0]?.typeof).toBe('object');
+    expect(rows[0]?.keep).toBe('me');
+    expect(rows[0]?.cycle).toBe('2026-06-24T10:40:00.000Z');
+  });
 });

--- a/test/e2e/onboard-full-flow.test.ts
+++ b/test/e2e/onboard-full-flow.test.ts
@@ -72,20 +72,20 @@ describe('onboard E2E — runAllOnboardChecks', () => {
     ]);
   });
 
-  test('empty brain: stale/link/timeline ok, takes_count warns (0 takes)', async () => {
+  test('empty brain: stale/link/timeline ok, takes_count ok when bootstrap is disabled', async () => {
     const results = await runAllOnboardChecks(engine);
     const byName = Object.fromEntries(results.map((r) => [r.check.name, r.check.status]));
     expect(byName.embed_staleness).toBe('ok');
     expect(byName.entity_link_coverage).toBe('ok');
     expect(byName.timeline_coverage).toBe('ok');
-    expect(byName.takes_count).toBe('warn'); // 0 takes is a warn
+    expect(byName.takes_count).toBe('ok');
   });
 
   test('empty brain remediations: takes_count gated, pack_upgrade_available may surface', async () => {
     const results = await runAllOnboardChecks(engine);
     const total = results.reduce((s, r) => s + r.remediations.length, 0);
-    // takes_count warns but does NOT emit a remediation (takes.bootstrap_enabled
-    // defaults to false — A12 two-gate consent).
+    // takes_count stays ok and emits no remediation while
+    // takes.bootstrap_enabled defaults to false (A12 two-gate consent).
     // v0.42 (T13): pack_upgrade_available CAN emit a manual_only remediation
     // when gbrain-base@1.x is active and gbrain-base-v2 is declared as the
     // successor (the unify-types Minion handler). Allow 0-1 remediations

--- a/test/embed.serial.test.ts
+++ b/test/embed.serial.test.ts
@@ -79,6 +79,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.GBRAIN_EMBED_CONCURRENCY;
   delete process.env.GBRAIN_EMBED_TIME_BUDGET_MS;
+  delete process.env.GBRAIN_EMBED_RECHUNK_MAX_CHARS;
 });
 
 describe('runEmbed --all (parallel)', () => {
@@ -223,6 +224,53 @@ describe('runEmbed --all (parallel)', () => {
     await runEmbed(engine, ['--stale']);
 
     // Only the stale page triggers an embedBatch call.
+    expect(totalEmbedCalls).toBe(1);
+  });
+
+  test('re-chunks oversized stale rows before embedding', async () => {
+    process.env.GBRAIN_EMBED_CONCURRENCY = '1';
+    process.env.GBRAIN_EMBED_RECHUNK_MAX_CHARS = '40';
+
+    const slug = 'oversized';
+    let chunksBySlug = new Map<string, any[]>([
+      [slug, [{
+        chunk_index: 0,
+        chunk_text: 'x'.repeat(120),
+        chunk_source: 'compiled_truth',
+        embedded_at: null,
+        token_count: 120,
+      }]],
+    ]);
+
+    const upserts: any[][] = [];
+    embedBatchBehavior = async (texts: string[]) => {
+      expect(texts.every(t => t.length <= 40)).toBe(true);
+      return texts.map(() => new Float32Array(1536));
+    };
+
+    const engine = mockEngine({
+      countStaleChunks: async () => 1,
+      listStaleChunks: async () => [{
+        slug,
+        chunk_index: 0,
+        chunk_text: 'x'.repeat(120),
+        chunk_source: 'compiled_truth' as const,
+        model: null,
+        token_count: 120,
+        source_id: 'default',
+        page_id: 1,
+      }],
+      getPage: async () => ({ slug, compiled_truth: 'x'.repeat(120), timeline: '' }),
+      getChunks: async () => chunksBySlug.get(slug) || [],
+      upsertChunks: async (_slug: string, inputs: any[]) => {
+        upserts.push(inputs);
+        chunksBySlug = new Map([[slug, inputs.map(i => ({ ...i, embedded_at: null }))]]);
+      },
+    });
+
+    await runEmbed(engine, ['--stale']);
+
+    expect(upserts.length).toBeGreaterThanOrEqual(2);
     expect(totalEmbedCalls).toBe(1);
   });
 });

--- a/test/list-all-sources.test.ts
+++ b/test/list-all-sources.test.ts
@@ -136,6 +136,24 @@ describe('engine.updateSourceConfig', () => {
     expect(all.find(s => s.id === 'delta')!.config.last_full_cycle_at).toBe('2026-05-22T11:00:00.000Z');
   });
 
+  test('bad array config ignores non-object elements before merge', async () => {
+    await seedSource('epsilon');
+    await engine.executeRaw(
+      `UPDATE sources
+          SET config = '[{"keep":"me"},"bad-shape",["also-bad"]]'::jsonb
+        WHERE id = $1`,
+      ['epsilon'],
+    );
+    const updated = await engine.updateSourceConfig('epsilon', {
+      last_source_cycle_at: '2026-06-24T10:40:00.000Z',
+    });
+    expect(updated).toBe(true);
+    const all = await engine.listAllSources();
+    const epsilon = all.find(s => s.id === 'epsilon')!;
+    expect(epsilon.config.keep).toBe('me');
+    expect(epsilon.config.last_source_cycle_at).toBe('2026-06-24T10:40:00.000Z');
+  });
+
   // IS JSON guard: the postgres-engine atomic merge gates its `::jsonb` cast
   // behind the SQL `IS JSON` predicate so a historical bad row whose config is
   // a JSONB string of NON-JSON text normalizes to `{}` instead of raising


### PR DESCRIPTION
## Summary
- harden doctor warning cleanup, oversized embedding handling, and adaptive embed batch behavior
- preserve local doctor health tuning and categorize onboard doctor checks
- handle non-object source config arrays safely in PGLite/Postgres source config paths

## Verification
- gbrain --version => 0.42.53.0 after rebasing onto upstream master
- bun test test/op-checkpoint.test.ts test/check-jsonb-params.test.ts
- bun test test/doctor-categories.test.ts test/config-set.test.ts test/e2e/onboard-full-flow.test.ts test/list-all-sources.test.ts test/e2e/list-all-sources-postgres.test.ts
- bun run check:jsonb
- gbrain sync --source wiki --no-pull --no-embed --yes --json
- gbrain sync --source gbrain-src --no-pull --no-embed --yes --json
- gbrain embed --stale --priority recent --batch-size 500
- gbrain doctor --fast

## Notes
This branch was rebased onto upstream v0.42.53.0, so the upstream #2339 op_checkpoints jsonb fix is included from master rather than carried as a local hotfix.