### PR TITLE
fix(postgres): persist checkpoint completed_keys as jsonb array

### DIFF
--- a/src/core/op-checkpoint.ts
+++ b/src/core/op-checkpoint.ts
@@ -180,25 +180,20 @@ export async function recordCompleted(
   // extract-conversation-facts serialize a MUTABLE map through here and rely on
   // stale keys being REMOVED; an append would make them unremovable. The full
   // set lands in the parent `completed_keys` JSONB column via a single UPSERT.
-  // #2339: bind through `$3::text::jsonb`, NOT `$3::jsonb`. Under postgres.js
-  // `.unsafe(sql, params)` (executeRawDirect's path) a JS string bound to a
-  // `$N::jsonb` param double-encodes — the text→jsonb cast wraps the already-JSON
-  // string into a jsonb *string scalar*, which fails the v119
-  // `op_checkpoints_completed_keys_array CHECK (jsonb_typeof = 'array')` and aborts
-  // every sync on real Postgres (PGLite parses it silently, which hid the bug).
-  // Casting through `text` first binds it as a plain text param so the text→jsonb
-  // cast parses it into a genuine jsonb array. This is the positional-param form of
-  // the CLAUDE.md double-encode trap (the grep guard only caught the template form).
-  // Sync uses `appendCompleted` (below, `unnest($3::text[])`) instead, never this.
+  // `completed_keys` must remain a JSONB array: native Postgres/postgres.js
+  // unsafe/direct binding can turn a JSON-stringified array plus `$3::jsonb`
+  // into a JSONB string. Binding the sorted JS string[] as text[] and converting
+  // server-side with to_jsonb() preserves the array shape while keeping
+  // replace/upsert semantics and deterministic ordering unchanged.
   const sorted = [...keys].sort();
   return durableWrite(engine, key, 'write', () =>
     engine.executeRawDirect(
       `INSERT INTO op_checkpoints (op, fingerprint, completed_keys, updated_at)
-       VALUES ($1, $2, $3::text::jsonb, now())
+       VALUES ($1, $2, to_jsonb($3::text[]), now())
        ON CONFLICT (op, fingerprint) DO UPDATE
          SET completed_keys = EXCLUDED.completed_keys,
              updated_at     = now()`,
-      [key.op, key.fingerprint, JSON.stringify(sorted)],
+      [key.op, key.fingerprint, sorted],
     ));
 }
 

--- a/test/op-checkpoint.test.ts
+++ b/test/op-checkpoint.test.ts
@@ -106,6 +106,34 @@ describe('loadOpCheckpoint / recordCompleted / clearOpCheckpoint', () => {
     expect(result.sort()).toEqual(['chunk-1', 'chunk-2', 'chunk-3']);
   });
 
+  test('recordCompleted stores completed_keys as a sorted JSONB array', async () => {
+    const key = { op: 'embed', fingerprint: 'fp-array-shape' };
+    await recordCompleted(engine, key, ['b', 'a']);
+
+    const rows = await engine.executeRaw<{ typ: string; raw: string }>(
+      `SELECT jsonb_typeof(completed_keys) AS typ, completed_keys::text AS raw
+       FROM op_checkpoints WHERE op = $1 AND fingerprint = $2`,
+      [key.op, key.fingerprint],
+    );
+
+    expect(rows[0].typ).toBe('array');
+    expect(JSON.parse(rows[0].raw)).toEqual(['a', 'b']);
+  });
+
+  test('recordCompleted keeps empty completed_keys as a JSONB array', async () => {
+    const key = { op: 'embed', fingerprint: 'fp-empty-array-shape' };
+    await recordCompleted(engine, key, []);
+
+    const rows = await engine.executeRaw<{ typ: string; raw: string }>(
+      `SELECT jsonb_typeof(completed_keys) AS typ, completed_keys::text AS raw
+       FROM op_checkpoints WHERE op = $1 AND fingerprint = $2`,
+      [key.op, key.fingerprint],
+    );
+
+    expect(rows[0].typ).toBe('array');
+    expect(JSON.parse(rows[0].raw)).toEqual([]);
+  });
+
   test('write overwrites prior state', async () => {
     const key = { op: 'embed', fingerprint: 'abc12345' };
     await recordCompleted(engine, key, ['chunk-1']);
@@ -202,9 +230,9 @@ describe('appendCompleted (delta) + union read', () => {
   test('recordCompleted still REPLACES (sync appendCompleted does not)', async () => {
     // Guards V3: recordCompleted must remove stale keys, not append them.
     const key = { op: 'embed', fingerprint: 'fp-replace' };
-    await recordCompleted(engine, key, ['x', 'y']);
-    await recordCompleted(engine, key, ['x']);
-    expect((await loadOpCheckpoint(engine, key)).sort()).toEqual(['x']);
+    await recordCompleted(engine, key, ['b', 'a']);
+    await recordCompleted(engine, key, ['c']);
+    expect(await loadOpCheckpoint(engine, key)).toEqual(['c']);
   });
 
   test('purge of a stale parent cascades to its child rows', async () => {
@@ -316,6 +344,26 @@ describe('BUG 3: completed_keys array-shape guard (v119 CHECK + defensive loader
         `ALTER TABLE op_checkpoints ADD CONSTRAINT ${CONSTRAINT} CHECK (jsonb_typeof(completed_keys) = 'array')`,
       );
     }
+  });
+});
+
+describe('recordCompleted SQL parameter shape', () => {
+  test('binds sorted string[] and converts with to_jsonb($3::text[])', async () => {
+    const calls: Array<{ sql: string; params?: unknown[] }> = [];
+    const fakeEngine = {
+      async executeRawDirect(sql: string, params?: unknown[]) {
+        calls.push({ sql, params });
+        return [];
+      },
+    };
+
+    const ok = await recordCompleted(fakeEngine as any, { op: 'embed', fingerprint: 'fp-param-shape' }, ['b', 'a']);
+
+    expect(ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sql).toContain('to_jsonb($3::text[])');
+    expect(calls[0].sql).not.toContain('$3::jsonb');
+    expect(calls[0].params).toEqual(['embed', 'fp-param-shape', ['a', 'b']]);
   });
 });
 


### PR DESCRIPTION
Summary:
- Fixes native Postgres checkpoint writes in `recordCompleted()`.
- Binds checkpoint keys as `text[]` and converts server-side with `to_jsonb($3::text[])`.
- Avoids JSON-stringified arrays being persisted as JSONB strings through the postgres.js unsafe/direct path.

Problem:
- `completed_keys` has a CHECK requiring JSONB array shape.
- Passing `JSON.stringify(sorted)` into `$3::jsonb` can produce a JSONB string on native Postgres driver binding paths.
- This causes checkpoint writes to fail and sync operations to become partial with `checkpoint_unavailable`.

Fix:
- Replace `$3::jsonb` + `JSON.stringify(sorted)` with `to_jsonb($3::text[])` + sorted string array.
- Keeps deterministic sorting and replace/upsert semantics.

Tests:
- `bun test test/op-checkpoint.test.ts`
- `bun run typecheck`
- `bun run check:jsonb`
- Native Postgres integration coverage was not available in the existing targeted test suite; this adds parameter-shape coverage and JSONB array-shape assertions without private environment details.

Security:
- No credentials, local paths, or environment values included.

Related:
- None.
