### PR TITLE
v0.42.54.0 fix(cli): supersede active takes (#2078)

### DIFF
--- a/src/commands/takes.ts
+++ b/src/commands/takes.ts
@@ -271,7 +271,7 @@ async function cmdSupersede(engine: BrainEngine, args: string[]): Promise<void> 
     const pageId = await getPageId(engine, slug);
 
     // Read existing row to inherit kind/holder unless overridden
-    const existing = await engine.listTakes({ page_id: pageId, active: false, limit: 500 });
+    const existing = await engine.listTakes({ page_id: pageId, active: true, limit: 500 });
     const target = existing.find(t => t.row_num === rowNum);
     if (!target) {
       console.error(`Row #${rowNum} not found on ${slug}.`);

--- a/test/takes-cli.test.ts
+++ b/test/takes-cli.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import type { BrainEngine, Take, TakeBatchInput, TakesListOpts } from '../src/core/engine.ts';
+import { renderTakesFence } from '../src/core/takes-fence.ts';
+import { runTakes } from '../src/commands/takes.ts';
+
+describe('takes CLI supersede', () => {
+  test('looks up the active target row before superseding', async () => {
+    const slug = 'notes/supersede-cli-example';
+    const pageId = 123;
+    const target: Take = {
+      id: 1,
+      page_id: pageId,
+      page_slug: slug,
+      row_num: 1,
+      claim: 'Original active claim',
+      kind: 'take',
+      holder: 'brain',
+      weight: 0.75,
+      since_date: '2026-01',
+      until_date: null,
+      source: 'example-note',
+      superseded_by: null,
+      active: true,
+      resolved_at: null,
+      resolved_outcome: null,
+      resolved_quality: null,
+      resolved_value: null,
+      resolved_unit: null,
+      resolved_source: null,
+      resolved_by: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    };
+
+    let listOpts: TakesListOpts | undefined;
+    let newRow:
+      | { claim: string; kind: string; holder: string; weight?: number; active?: boolean }
+      | undefined;
+    const engine = {
+      executeRaw: async <T,>() => [{ id: pageId }] as T[],
+      listTakes: async (opts: TakesListOpts) => {
+        listOpts = opts;
+        return [target];
+      },
+      supersedeTake: async (
+        _pageId: number,
+        oldRow: number,
+        row: Omit<TakeBatchInput, 'page_id' | 'row_num' | 'superseded_by'>,
+      ) => {
+        expect(_pageId).toBe(pageId);
+        expect(oldRow).toBe(1);
+        newRow = row;
+        return { oldRow, newRow: 2 };
+      },
+    } as unknown as BrainEngine;
+
+    const dir = mkdtempSync(join(tmpdir(), 'gbrain-takes-cli-'));
+    const path = join(dir, `${slug}.md`);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(
+      path,
+      `# Supersede fixture\n\n${renderTakesFence([{
+        rowNum: 1,
+        claim: target.claim,
+        kind: target.kind,
+        holder: target.holder,
+        weight: target.weight,
+        sinceDate: target.since_date ?? undefined,
+        source: target.source ?? undefined,
+        active: true,
+      }])}\n`,
+      'utf-8',
+    );
+
+    const originalLog = console.log;
+    let updated = '';
+    console.log = () => {};
+    try {
+      await runTakes(engine, [
+        'supersede',
+        slug,
+        '--row',
+        '1',
+        '--claim',
+        'Replacement claim',
+        '--dir',
+        dir,
+      ]);
+      updated = readFileSync(path, 'utf-8');
+    } finally {
+      console.log = originalLog;
+      rmSync(dir, { recursive: true, force: true });
+    }
+
+    expect(listOpts).toMatchObject({ page_id: pageId, active: true, limit: 500 });
+    expect(newRow).toMatchObject({
+      claim: 'Replacement claim',
+      kind: target.kind,
+      holder: target.holder,
+      active: true,
+    });
+    expect(newRow?.weight).toBeCloseTo(0.65);
+
+    expect(updated).toContain('~~Original active claim~~');
+    expect(updated).toContain('Replacement claim');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2078 by making `gbrain takes supersede` load the active target take before inheriting metadata. The previous CLI lookup asked for inactive rows, so the normal active-take supersede path reported `Row #N not found` before reaching the engine.

## Diff

- `src/commands/takes.ts`: changes the supersede preflight lookup from `active: false` to `active: true`.
- `test/takes-cli.test.ts`: adds a focused CLI regression that proves supersede reads the active target row, inherits kind/holder/weight, updates the DB mirror call, and rewrites the markdown fence.

## Test Coverage

- `gbrain-gate.sh <worktree> test/takes-cli.test.ts` - GREEN
  - verify: green except the known macOS-only `check:operations-filter-bypass` false-positive tolerated by the gate
  - unit: `test/takes-cli.test.ts` - 1 pass, 0 fail, 7 assertions
  - e2e: diff selector returned the fail-closed all-E2E set, so the gate skipped unrelated local E2E; CI runs the full E2E suite
