### PR TITLE
Treat local-path source clone state as not-applicable

### DIFF
--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -127,9 +127,10 @@ export interface SourceStatus {
   last_commit: string | null;
   archived: boolean;
   /**
-   * Discriminated union from validateRepoState. 'not-applicable' if the
-   * source has no local_path (pure DB source). Lets a remote MCP caller
-   * diagnose "is the clone OK?" without SSH access to the brain host.
+   * Discriminated union from validateRepoState for gbrain-managed remote
+   * clones. 'not-applicable' for pure DB and user-supplied local-path sources
+   * (remote_url absent): those paths are not auto-managed clones, so a missing
+   * origin remote must not be reported as a corrupted clone.
    */
   clone_state: RepoState | 'not-applicable';
 }
@@ -728,8 +729,8 @@ export async function getSourceStatus(
 
   const remoteUrl = getRemoteUrl(src.config);
   let cloneState: SourceStatus['clone_state'] = 'not-applicable';
-  if (src.local_path) {
-    cloneState = validateRepoState(src.local_path, remoteUrl ?? undefined);
+  if (src.local_path && remoteUrl) {
+    cloneState = validateRepoState(src.local_path, remoteUrl);
   }
 
   return {

--- a/test/sources-ops.test.ts
+++ b/test/sources-ops.test.ts
@@ -78,6 +78,7 @@ if [ "$has_clone" = "1" ]; then
   exit 0
 fi
 if [ "$has_remote_get_url" = "1" ]; then
+  if [ "$mode" = "remote-get-url-fail" ]; then exit 1; fi
   echo "https://github.com/example/repo"
   exit 0
 fi
@@ -88,7 +89,7 @@ exit 0
   chmodSync(path, 0o755);
 }
 
-function setMode(mode: 'ok' | 'clone-fail'): void {
+function setMode(mode: 'ok' | 'clone-fail' | 'remote-get-url-fail'): void {
   writeFileSync(join(FAKE_GIT_DIR, 'mode'), mode);
 }
 
@@ -447,16 +448,27 @@ describe('getSourceStatus', () => {
     await withEnv2(async () => {
       const userPath = join(GBRAIN_HOME, 'na-fixture');
       mkdirSync(userPath, { recursive: true });
-      // path-only source still gets validateRepoState — but with no expected
-      // URL, it just probes existence + .git. Path exists with no .git → 'no-git'.
-      // To match contract docstring we'd want 'not-applicable' only when
-      // local_path is null. Test the truthful behavior:
+      // Path-only sources are user-supplied working trees, not gbrain-managed
+      // clones. Even if the path has no .git/origin, sources_status should not
+      // call that a clone failure.
       await addSource(engine, { id: 'status-no-url', localPath: userPath });
       const s = await getSourceStatus(engine, 'status-no-url');
-      // local_path set but no .git: returns 'no-git'
-      expect(s.clone_state).toBe('no-git');
+      expect(s.clone_state).toBe('not-applicable');
       expect(s.remote_url).toBeNull();
       rmSync(userPath, { recursive: true, force: true });
+    });
+  });
+
+  test('clone_state still reports "corrupted" for remote-managed clone when origin probe fails', async () => {
+    await withEnv2(async () => {
+      await addSource(engine, {
+        id: 'status-corrupted',
+        remoteUrl: 'https://github.com/example/repo',
+      });
+      setMode('remote-get-url-fail');
+      const s = await getSourceStatus(engine, 'status-corrupted');
+      expect(s.clone_state).toBe('corrupted');
+      expect(s.remote_url).toBe('https://github.com/example/repo');
     });
   });
 


### PR DESCRIPTION
## Summary

Fix `sources_status` clone diagnostics for user-supplied local-path sources.

Sources registered with `--path` have `local_path` but no `remote_url`; they are not gbrain-managed clones. Before this change, `getSourceStatus` still called `validateRepoState(local_path, undefined)`, so a healthy local wiki repo with no `origin` remote could be reported as `clone_state: "corrupted"`. That is misleading for remote MCP callers and can trigger the wrong remediation path.

This changes `getSourceStatus` to run clone validation only for remote-managed sources (`local_path && remote_url`). Pure DB sources and local-path sources now report `clone_state: "not-applicable"`.

## Verification

- `bun test test/sources-ops.test.ts` — 39 pass
- `bun run src/cli.ts call sources_status '{"id":"citadel-portfolio"}'` from Brad's patched local tree returns `clone_state: "not-applicable"` for a real local-path source with `remote_url: null`
- Scripted local verification checked 24 `remote_url: null` sources; all returned `clone_state: "not-applicable"`
- Added regression coverage that remote-managed clone origin-probe failure still reports `clone_state: "corrupted"`

Note: `bun run typecheck` passes in Brad's local carry branch after the patch. On a clean upstream-master worktree, typecheck currently fails in unrelated OpenClaw SDK typings (`src/core/context-engine.ts`, `test/e2e/openclaw-plugin-load-real.test.ts`), so I did not treat that as caused by this two-file change.
