### PR TITLE
fix(files): handle bigint size_bytes in list output

### DIFF
--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -16,7 +16,7 @@ interface FileRecord {
   filename: string;
   storage_path: string;
   mime_type: string | null;
-  size_bytes: number;
+  size_bytes: number | bigint | string | null;
   content_hash: string;
   metadata: Record<string, unknown>;
   created_at: string;
@@ -40,6 +40,12 @@ function getMimeType(filePath: string): string | null {
 function fileHash(filePath: string): string {
   const content = readFileSync(filePath);
   return createHash('sha256').update(content).digest('hex');
+}
+
+export function formatFileSizeKb(rawSizeBytes: number | bigint | string | null): string {
+  if (rawSizeBytes == null) return '?';
+  const sizeBytes = Number(rawSizeBytes);
+  return Number.isFinite(sizeBytes) ? `${Math.round(sizeBytes / 1024)}KB` : '?';
 }
 
 export async function runFiles(engine: BrainEngine, args: string[]) {
@@ -116,8 +122,7 @@ async function listFiles(engine: BrainEngine, slug?: string) {
 
   console.log(`${rows.length} file(s):`);
   for (const row of rows) {
-    const sizeBytes = row.size_bytes as number | null;
-    const size = sizeBytes ? `${Math.round(sizeBytes / 1024)}KB` : '?';
+    const size = formatFileSizeKb(row.size_bytes as FileRecord['size_bytes']);
     console.log(`  ${row.page_slug || '(unlinked)'} / ${row.filename}  [${size}, ${row.mime_type || '?'}]`);
   }
 }

--- a/test/files-command.test.ts
+++ b/test/files-command.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test';
+import { formatFileSizeKb } from '../src/commands/files.ts';
+
+describe('formatFileSizeKb', () => {
+  test('formats numeric file sizes', () => {
+    expect(formatFileSizeKb(35 * 1024)).toBe('35KB');
+    expect(formatFileSizeKb(512)).toBe('1KB');
+    expect(formatFileSizeKb(0)).toBe('0KB');
+  });
+
+  test('formats bigint file sizes returned by Postgres', () => {
+    expect(formatFileSizeKb(35n * 1024n)).toBe('35KB');
+  });
+
+  test('formats string file sizes from drivers that stringify bigint values', () => {
+    expect(formatFileSizeKb('35840')).toBe('35KB');
+  });
+
+  test('prints unknown for missing or invalid sizes', () => {
+    expect(formatFileSizeKb(null)).toBe('?');
+    expect(formatFileSizeKb('not-a-number')).toBe('?');
+  });
+});


### PR DESCRIPTION
## Summary

- normalize `files.size_bytes` before formatting `gbrain files list` output
- handle Postgres `bigint` values without mixing BigInt and number arithmetic
- add focused coverage for number, bigint, string, null, invalid, and zero sizes

Fixes #2527.

## Verification

```bash
bun test test/files-command.test.ts
bun run typecheck
```
