### PR TITLE
fix(sync,sources,autopilot,jobs): repo paths absolute at ingress; refuse stored relative anchors

### DIFF
--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -38,6 +38,24 @@ import { logSelfUpgrade } from '../core/audit/self-upgrade-audit.ts';
 import { detectInstallMethod } from './upgrade.ts';
 import { evaluateQuietHours } from '../core/minions/quiet-hours.ts';
 import { inspectLock } from '../core/db-lock.ts';
+import { resolveRepoArg, requireAbsoluteStoredPath } from '../core/repo-path.ts';
+
+/**
+ * Shared --repo resolution for the run loop and --install. A typed --repo is
+ * resolved against cwd at ingress; a config-sourced value must already be
+ * absolute (repo-path.ts invariant) — --install bakes it verbatim into the
+ * wrapper script, so a relative value here would freeze the cwd bug into
+ * launchd/cron.
+ */
+async function resolveAutopilotRepoPath(
+  engine: BrainEngine,
+  args: string[],
+): Promise<string | null> {
+  const arg = parseArg(args, '--repo');
+  if (arg) return resolveRepoArg(arg);
+  const stored = await engine.getConfig('sync.repo_path');
+  return stored ? requireAbsoluteStoredPath(stored, 'config sync.repo_path') : null;
+}
 
 /**
  * v0.37.7.0 #1162 — classify autopilot reconnect-loop errors.
@@ -331,7 +349,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
     return;
   }
 
-  const repoPath = parseArg(args, '--repo') || await engine.getConfig('sync.repo_path');
+  const repoPath = await resolveAutopilotRepoPath(engine, args);
   const baseInterval = parseInt(parseArg(args, '--interval') || '300', 10);
   const jsonMode = args.includes('--json');
   const forceInline = args.includes('--inline');
@@ -1142,7 +1160,7 @@ exec '${safeGbrainPath}' autopilot --repo '${safeRepoPath}'
 }
 
 async function installDaemon(engine: BrainEngine, args: string[]) {
-  const repoPath = parseArg(args, '--repo') || await engine.getConfig('sync.repo_path');
+  const repoPath = await resolveAutopilotRepoPath(engine, args);
   if (!repoPath) {
     console.error('No repo path. Use --repo or run gbrain sync --repo first.');
     process.exit(1);

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,6 +1,7 @@
 import { readdirSync, lstatSync, existsSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { join, relative } from 'path';
+import { resolveRepoArg } from '../core/repo-path.ts';
 import { cpus, totalmem } from 'os';
 import type { BrainEngine } from '../core/engine.ts';
 import { importFile, importImageFile, isImageFilePath } from '../core/import-file.ts';
@@ -461,7 +462,10 @@ export async function runImport(
       );
     }
     await engine.setConfig('sync.last_run', new Date().toISOString());
-    await engine.setConfig('sync.repo_path', dir);
+    // repo-path.ts invariant: never persist a relative repo path. This write
+    // is how `gbrain import .` used to seed the anchor that a later bare
+    // `gbrain sync` from the wrong cwd resolved into a foreign tree.
+    await engine.setConfig('sync.repo_path', resolveRepoArg(dir));
   }
 
   return { imported, skipped, errors, chunksCreated, failures };

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -10,6 +10,7 @@ import { WORKER_EXIT_RSS_WATCHDOG } from '../core/minions/worker-exit-codes.ts';
 import type { MinionJob, MinionJobStatus } from '../core/minions/types.ts';
 import type { PaceKeyOverrides } from '../core/pace-mode.ts';
 import { loadConfig, isThinClient } from '../core/config.ts';
+import { requireAbsoluteStoredPath } from '../core/repo-path.ts';
 import { callRemoteTool, unpackToolResult } from '../core/mcp-client.ts';
 import { parseNiceValue, applyNiceness, getEffectiveNiceness, formatNice } from '../core/minions/niceness.ts';
 
@@ -1322,7 +1323,12 @@ export async function registerBuiltinHandlers(
   const quiet = opts?.quiet === true;
   worker.register('sync', async (job) => {
     const { performSync } = await import('./sync.ts');
-    const repoPath = typeof job.data.repoPath === 'string' ? job.data.repoPath : undefined;
+    // repo-path.ts invariant: job payloads are storage — a relative repoPath
+    // enqueued by an older binary would otherwise resolve against the WORKER
+    // daemon's cwd. Fail the job loudly instead.
+    const repoPath = typeof job.data.repoPath === 'string'
+      ? requireAbsoluteStoredPath(job.data.repoPath, 'job.data.repoPath')
+      : undefined;
     const noPull = !!job.data.noPull;
     // noEmbed defaults to true (embed is a separate job — submit `embed --stale`
     // after sync, OR run via the autopilot cycle which has its own embed phase).

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, statSync } from 'fs';
 import { execFileSync } from 'child_process';
-import { join, relative } from 'path';
+import { join, relative, isAbsolute } from 'path';
+import { resolveRepoArg, requireAbsoluteStoredPath } from '../core/repo-path.ts';
 import type { BrainEngine } from '../core/engine.ts';
 import { DELETE_BATCH_SIZE } from '../core/engine-constants.ts';
 import { importFile } from '../core/import-file.ts';
@@ -969,6 +970,10 @@ async function writeSyncAnchor(
   // the legacy 2-column write; `null` clears the column (git unavailable).
   newestContentEpochMs?: number | null,
 ): Promise<void> {
+  // repo-path.ts invariant: storage never holds a relative repo path. All
+  // current callers pass the already-resolved phase value; this keeps the
+  // guarantee local for future call sites.
+  if (which === 'repo_path') value = resolveRepoArg(value);
   if (sourceId) {
     const col = which === 'repo_path' ? 'local_path' : 'last_commit';
     // last_sync_at bookmarked on every last_commit advance.
@@ -1468,8 +1473,21 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // report names WHICH phase spun. Doesn't fix #1342 but converts
   // "hung with no output" into actionable diagnostic data.
   serr(`[gbrain phase] sync.resolve_repo`);
-  // Resolve repo path
-  const repoPath = opts.repoPath || await readSyncAnchor(engine, opts.sourceId, 'repo_path');
+  // Resolve repo path. A caller-supplied path is resolved against cwd (it is
+  // this invocation's intent); a STORED anchor must already be absolute —
+  // resolving a relative anchor against whatever cwd this process happens to
+  // have is the wrong-tree footgun (see core/repo-path.ts).
+  const cliRepoPath = opts.repoPath ? resolveRepoArg(opts.repoPath) : null;
+  const storedRepoPath = cliRepoPath
+    ? null
+    : await readSyncAnchor(engine, opts.sourceId, 'repo_path');
+  if (storedRepoPath) {
+    requireAbsoluteStoredPath(
+      storedRepoPath,
+      opts.sourceId ? `sources.local_path for "${opts.sourceId}"` : 'config sync.repo_path',
+    );
+  }
+  const repoPath = cliRepoPath ?? storedRepoPath;
   if (!repoPath) {
     const hint = opts.sourceId
       ? `Source "${opts.sourceId}" has no local_path. Run: gbrain sources add ${opts.sourceId} --path <path>`
@@ -3348,7 +3366,11 @@ See also:
     return;
   }
 
-  const repoPath = args.find((a, i) => args[i - 1] === '--repo') || undefined;
+  const repoArgRaw = args.find((a, i) => args[i - 1] === '--repo');
+  // Resolve at ingress (repo-path.ts invariant): the cwd at the moment the
+  // user typed --repo is intent; everything downstream (anchors, wrapper
+  // scripts) must only ever see the absolute form.
+  const repoPath = repoArgRaw ? resolveRepoArg(repoArgRaw) : undefined;
   const watch = args.includes('--watch');
   const intervalStr = args.find((a, i) => args[i - 1] === '--interval');
   const interval = intervalStr ? parseInt(intervalStr, 10) : 60;
@@ -3578,11 +3600,30 @@ See also:
     // own "do work?" gate (sync.ts:1057+1075) + doctor's sync_freshness.
     // Both columns predate v0.41 (writeSyncAnchor / writeChunkerVersion); no
     // schema migration needed.
-    const sources = await engine.executeRaw<{ id: string; name: string; local_path: string | null; config: Record<string, unknown>; last_commit: string | null; chunker_version: string | null }>(
+    const allSources = await engine.executeRaw<{ id: string; name: string; local_path: string | null; config: Record<string, unknown>; last_commit: string | null; chunker_version: string | null }>(
       `SELECT id, name, local_path, config, last_commit, chunker_version FROM sources WHERE local_path IS NOT NULL`,
     );
-    if (!sources || sources.length === 0) {
+    if (!allSources || allSources.length === 0) {
       console.log('No sources with local_path configured. Use `gbrain sources add <id> --path <path>` first.');
+      return;
+    }
+
+    // repo-path.ts invariant: a legacy relative local_path must reach neither
+    // the cost estimator nor the fan-out — runOne passes local_path as
+    // opts.repoPath, which performSync treats as caller intent and would
+    // resolve against THIS process's cwd (the wrong-tree footgun). Migration
+    // 120 clears such rows; this guard covers a brain that hasn't migrated
+    // yet. Exclude loudly, keep the remaining sources best-effort.
+    const sources = allSources.filter((s) => {
+      if (!s.local_path || isAbsolute(s.local_path)) return true;
+      console.error(
+        `[${s.id}] skipped: sources.local_path "${s.local_path}" is relative. ` +
+        `Fix once: gbrain sync --source ${s.id} --repo <absolute-path>`,
+      );
+      return false;
+    });
+    if (sources.length === 0) {
+      console.error('All sources were skipped (relative local_path). Nothing to sync.');
       return;
     }
 
@@ -4146,7 +4187,9 @@ export async function syncOneSource(
   const cfg = (src.config || {}) as { strategy?: 'markdown' | 'code' | 'auto' };
   const log = `\n--- Syncing source: ${src.name} ---\n`;
   const repoOpts: SyncOpts = {
-    repoPath: src.local_path!,
+    // src is a db row: a stored local_path is refused when relative rather
+    // than forwarded as caller intent (repo-path.ts invariant).
+    repoPath: requireAbsoluteStoredPath(src.local_path!, `sources.local_path for "${src.id}"`),
     dryRun: shared.dryRun,
     full: shared.full,
     noPull: shared.noPull,

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -5367,6 +5367,41 @@ export const MIGRATIONS: Migration[] = [
       END $$;
     `,
   },
+  {
+    version: 120,
+    name: 'repo_path_anchors_absolute_only',
+    // v0.42.x — repo-path invariant (core/repo-path.ts): storage never holds
+    // a relative repo path. Writers now normalize at ingress (sync --repo,
+    // import, sources add, autopilot); this migration clears LEGACY relative
+    // anchors so the dozen-plus readers (sync --all fan-out, jobs, cycle,
+    // remediation, takes, …) can never resolve one against their own cwd —
+    // the wrong-tree footgun that made a bare `gbrain sync` from a foreign
+    // directory import that tree and reconcile the real brain away.
+    //
+    // NULL/DELETE, not fix-up: the cwd that seeded a relative anchor is
+    // unknowable after the fact, so any rewrite would be a guess. A cleared
+    // anchor lands every consumer in its existing, explicit "no repo path —
+    // use --repo / sources add --path" error, and the next successful
+    // `gbrain sync --repo <abs>` re-seeds it normalized.
+    //
+    // Absolute means POSIX ('/…') or Windows drive/UNC ('C:\…', '\\host\…');
+    // everything else is a cwd-dependent trap.
+    idempotent: true,
+    sql: `
+      DELETE FROM config
+       WHERE key = 'sync.repo_path'
+         AND value NOT LIKE '/%'
+         AND value !~ '^[A-Za-z]:[/\\\\]'
+         AND value NOT LIKE '\\\\\\\\%';
+
+      UPDATE sources
+         SET local_path = NULL
+       WHERE local_path IS NOT NULL
+         AND local_path NOT LIKE '/%'
+         AND local_path !~ '^[A-Za-z]:[/\\\\]'
+         AND local_path NOT LIKE '\\\\\\\\%';
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/repo-path.ts
+++ b/src/core/repo-path.ts
@@ -1,0 +1,41 @@
+/**
+ * Repo-path hygiene (incident 2026-07-02).
+ *
+ * Invariant: a repo path is resolved to an absolute path exactly once, at
+ * arg ingress; storage (config `sync.repo_path`, `sources.local_path`,
+ * generated daemon wrapper scripts) never holds a relative path; a relative
+ * value read back from storage is a hard error, never silently resolved
+ * against cwd.
+ *
+ * Why: `sync.repo_path` persisted as "." made a later bare `gbrain sync`
+ * from an unrelated project directory import THAT tree as the brain source
+ * and reconcile every real brain page as "source file removed" — dropping
+ * the links/timeline graph rows. Files survive in git; db-only rows don't.
+ */
+import { isAbsolute, resolve } from 'path';
+
+/**
+ * Resolve a user-typed --repo/--path argument against cwd at parse time.
+ * Typing a relative path interactively stays legal — the shell's cwd is the
+ * user's stated intent at that moment. What must never happen is persisting
+ * the relative form.
+ */
+export function resolveRepoArg(p: string): string {
+  return resolve(p);
+}
+
+/**
+ * Guard for repo paths read back from storage. Refuses to resolve a relative
+ * value against the current cwd — that is exactly the wrong-tree footgun:
+ * whichever directory the next bare invocation happens to run from becomes
+ * the sync source.
+ */
+export function requireAbsoluteStoredPath(value: string, storageDesc: string): string {
+  if (isAbsolute(value)) return value;
+  throw new Error(
+    `${storageDesc} holds a relative path "${value}". Refusing to resolve it against ` +
+    `the current directory — a bare invocation from the wrong cwd would sync the wrong ` +
+    `tree. Fix it once with an absolute path: gbrain sync --repo <absolute-path> ` +
+    `(or: gbrain config set sync.repo_path <absolute-path>).`,
+  );
+}

--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -358,7 +358,10 @@ export async function addSource(
   // sync resolve it against whatever cwd the process happens to have.
   let finalPath = opts.localPath ? resolvePath(opts.localPath) : null;
   if (parsedUrl) {
-    finalPath = opts.cloneDir ?? defaultCloneDir(opts.id);
+    // --clone-dir is user input like --path: resolve at ingress so the clone
+    // lands (and is stored) absolute. defaultCloneDir is $GBRAIN_HOME-based,
+    // already absolute.
+    finalPath = opts.cloneDir ? resolvePath(opts.cloneDir) : defaultCloneDir(opts.id);
   }
   if (finalPath) {
     const others = await engine.executeRaw<{ id: string; local_path: string }>(

--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -352,8 +352,11 @@ export async function addSource(
     }
   }
 
-  // Overlap check for any local path (existing behavior).
-  let finalPath = opts.localPath ?? null;
+  // Overlap check for any local path (existing behavior). Resolve to absolute
+  // first (repo-path.ts invariant): a relative local_path both defeats the
+  // string-prefix overlap check below and, once stored, makes every later
+  // sync resolve it against whatever cwd the process happens to have.
+  let finalPath = opts.localPath ? resolvePath(opts.localPath) : null;
   if (parsedUrl) {
     finalPath = opts.cloneDir ?? defaultCloneDir(opts.id);
   }

--- a/test/repo-path.test.ts
+++ b/test/repo-path.test.ts
@@ -1,0 +1,168 @@
+/**
+ * repo-path invariant (src/core/repo-path.ts): repo paths are resolved to
+ * absolute at arg ingress; a relative path read back from storage is a hard
+ * error, never silently resolved against cwd.
+ *
+ * Regression shape (incident 2026-07-02): `sync.repo_path` stored as "."
+ * made a bare `gbrain sync` from an unrelated project directory import that
+ * tree as the brain source and reconcile every real brain page as removed.
+ * The performSync tests below seed exactly that state and assert the sync
+ * refuses at the resolve_repo phase instead of importing the foreign cwd.
+ */
+
+import { test, expect, describe, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { resolve, isAbsolute } from 'path';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+import { resolveRepoArg, requireAbsoluteStoredPath } from '../src/core/repo-path.ts';
+import { addSource } from '../src/core/sources-ops.ts';
+import { performSync } from '../src/commands/sync.ts';
+import { runMigrations } from '../src/core/migrate.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+});
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('resolveRepoArg', () => {
+  test('resolves a relative arg against cwd', () => {
+    expect(resolveRepoArg('foo/bar')).toBe(resolve(process.cwd(), 'foo/bar'));
+  });
+
+  test('resolves "." to cwd itself', () => {
+    expect(resolveRepoArg('.')).toBe(process.cwd());
+  });
+
+  test('keeps an absolute arg unchanged', () => {
+    const abs = resolve('/tmp', 'gbrain-repo-path-abs');
+    expect(resolveRepoArg(abs)).toBe(abs);
+  });
+});
+
+describe('requireAbsoluteStoredPath', () => {
+  test('passes an absolute path through unchanged', () => {
+    const abs = resolve('/tmp', 'gbrain-repo-path-abs');
+    expect(requireAbsoluteStoredPath(abs, 'config sync.repo_path')).toBe(abs);
+  });
+
+  test('throws on "." naming the storage location', () => {
+    expect(() => requireAbsoluteStoredPath('.', 'config sync.repo_path'))
+      .toThrow(/config sync\.repo_path holds a relative path "\."/);
+  });
+
+  test('throws on a bare relative path with remediation in the message', () => {
+    expect(() => requireAbsoluteStoredPath('brain', 'sources.local_path for "default"'))
+      .toThrow(/gbrain sync --repo <absolute-path>/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addSource — storage never holds a relative local_path
+// ---------------------------------------------------------------------------
+
+describe('addSource local_path normalization', () => {
+  test('a relative --path is stored absolute (resolved against cwd)', async () => {
+    const row = await addSource(engine, {
+      id: 'rel-path',
+      localPath: 'some/relative/dir',
+      federated: null,
+    });
+    expect(row.local_path).toBe(resolve(process.cwd(), 'some/relative/dir'));
+    expect(isAbsolute(row.local_path!)).toBe(true);
+  });
+
+  test('an absolute --path is stored unchanged', async () => {
+    const abs = resolve('/tmp', 'gbrain-repo-path-source');
+    const row = await addSource(engine, {
+      id: 'abs-path',
+      localPath: abs,
+      federated: null,
+    });
+    expect(row.local_path).toBe(abs);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// performSync — resolve_repo refuses stored relative anchors
+// ---------------------------------------------------------------------------
+
+describe('performSync stored-anchor guard', () => {
+  test('bare sync with sync.repo_path="." throws instead of using cwd', async () => {
+    await engine.setConfig('sync.repo_path', '.');
+    await expect(performSync(engine, { skipLock: true }))
+      .rejects.toThrow(/config sync\.repo_path holds a relative path "\."/);
+  });
+
+  test('per-source sync with a legacy relative local_path names the source', async () => {
+    // Raw INSERT bypasses addSource on purpose: simulates a legacy row
+    // persisted before normalization existed.
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path) VALUES ('legacy', 'legacy', '.')`,
+    );
+    await expect(performSync(engine, { skipLock: true, sourceId: 'legacy' }))
+      .rejects.toThrow(/sources\.local_path for "legacy" holds a relative path/);
+  });
+
+  test('a caller-supplied relative repoPath is resolved, not refused', async () => {
+    // The cwd IS this invocation's intent for explicit args; expect sync to
+    // proceed past resolve_repo and fail later on the non-repo directory,
+    // NOT with the stored-anchor refusal.
+    await expect(performSync(engine, { skipLock: true, repoPath: 'no/such/dir', noPull: true }))
+      .rejects.not.toThrow(/holds a relative path/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Migration 120 — legacy relative anchors are cleared, absolute ones survive
+// ---------------------------------------------------------------------------
+
+describe('migration 120 — repo_path_anchors_absolute_only', () => {
+  test('clears relative anchors, keeps POSIX and Windows absolute ones', async () => {
+    // Seed directly (bypassing the now-normalizing writers) to simulate rows
+    // persisted by a pre-invariant binary.
+    await engine.setConfig('sync.repo_path', '.');
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path) VALUES
+         ('legacy-rel', 'legacy-rel', 'brain'),
+         ('ok-posix',   'ok-posix',   '/abs/brain'),
+         ('ok-win',     'ok-win',     'C:\\brain'),
+         ('ok-unc',     'ok-unc',     '\\\\host\\share')`,
+    );
+
+    // Rewind to just before 120 so runMigrations replays only this migration.
+    await engine.setConfig('version', '119');
+    await runMigrations(engine);
+
+    expect(await engine.getConfig('sync.repo_path')).toBeFalsy();
+    const rows = await engine.executeRaw<{ id: string; local_path: string | null }>(
+      `SELECT id, local_path FROM sources ORDER BY id`,
+    );
+    const byId = Object.fromEntries(rows.map((r) => [r.id, r.local_path]));
+    expect(byId['legacy-rel']).toBeNull();
+    expect(byId['ok-posix']).toBe('/abs/brain');
+    expect(byId['ok-win']).toBe('C:\\brain');
+    expect(byId['ok-unc']).toBe('\\\\host\\share');
+  });
+
+  test('keeps an absolute config anchor', async () => {
+    await engine.setConfig('sync.repo_path', '/abs/brain');
+    await engine.setConfig('version', '119');
+    await runMigrations(engine);
+    expect(await engine.getConfig('sync.repo_path')).toBe('/abs/brain');
+  });
+});

--- a/test/sources-resync-recovery.test.ts
+++ b/test/sources-resync-recovery.test.ts
@@ -10,7 +10,7 @@
 
 import { test, expect, describe, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { mkdirSync, writeFileSync, rmSync, chmodSync, existsSync } from 'fs';
-import { join } from 'path';
+import { join, relative, resolve, isAbsolute } from 'path';
 import { tmpdir } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { addSource, recloneIfMissing } from '../src/core/sources-ops.ts';
@@ -282,6 +282,30 @@ describe('performSync re-clone branch (driven by sync.ts:320 logic)', () => {
       );
       expect(existsSync(userTree)).toBe(true);
       expect(existsSync(sentinel)).toBe(true);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// repo-path.ts invariant: a relative --clone-dir must be stored absolute
+// ---------------------------------------------------------------------------
+
+describe('addSource --clone-dir normalization', () => {
+  test('a relative --clone-dir is resolved against cwd before clone + insert', async () => {
+    await withEnv({ GBRAIN_HOME, PATH: fakePath() }, async () => {
+      // Express a sandboxed tmp target RELATIVE to the test cwd so the
+      // resolved clone still lands inside FAKE_GIT_DIR, never the repo tree.
+      const absTarget = join(FAKE_GIT_DIR, 'clone-rel-target');
+      const relTarget = relative(process.cwd(), absTarget);
+      expect(isAbsolute(relTarget)).toBe(false);
+
+      const row = await addSource(engine, {
+        id: 'clone-rel',
+        remoteUrl: 'https://github.com/example/repo',
+        cloneDir: relTarget,
+      });
+      expect(row.local_path).toBe(resolve(absTarget));
+      expect(isAbsolute(row.local_path!)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Problem

Repo paths are persisted verbatim at four ingress points and re-resolved against cwd at read time. Once a relative value (typically `.`) lands in storage, every later bare invocation resolves it against whatever directory the process happens to run from.

Real incident (2026-07-02): `sync.repo_path` held `.` (seeded by `gbrain import .`). A bare `gbrain sync` from an unrelated project directory imported that tree (140 md files) as the brain source and reconciled 2,496 real brain pages as "source file removed", dropping their links/timeline graph rows. Files survived in git; db-only rows didn't.

Ingress points that persisted raw input:

- `import.ts` — `setConfig('sync.repo_path', dir)` with the raw CLI arg (the original seeder).
- `sync.ts` — `--repo` parsed raw; `writeSyncAnchor` stores whatever string flows in; the resolve phase uses a stored anchor relative to cwd.
- `autopilot.ts` — `--repo`/config used raw; `--install` bakes the raw string into the generated wrapper script (`exec gbrain autopilot --repo '.'`), freezing the bug into launchd/cron.
- `sources-ops.ts` — `addSource` stores `--path` verbatim; a relative path also defeats the string-prefix overlap check.

## Fix

Invariant (new `src/core/repo-path.ts`): **a repo path is resolved to an absolute path exactly once, at arg ingress; storage never holds a relative path; a relative value read back from storage is a hard error, never silently resolved against cwd.**

- `resolveRepoArg(p)` — resolve user-typed `--repo`/`--path` against cwd at parse time (typing a relative path interactively stays legal; persisting it doesn't).
- `requireAbsoluteStoredPath(value, storageDesc)` — throw with remediation (`gbrain sync --repo <abs>` / `gbrain config set sync.repo_path <abs>`) when a stored anchor is relative. Protects installs that already carry legacy `.` rows.

Wired at: sync CLI parse + `performSyncInner` resolve phase (single choke point — covers bare sync, `--source`, `--all`, cycle.ts, jobs.ts, MCP op) + `writeSyncAnchor`; autopilot run + `--install` (shared `resolveAutopilotRepoPath`); `addSource`; `import.ts` anchor write.

## Stored legacy rows (second review round)

A resolve-phase guard alone is bypassable: `sync --all`, the jobs `sync` handler, and a dozen-plus `getConfig('sync.repo_path')` readers fetch the stored path themselves and pass it as `opts.repoPath` (= caller intent, resolved not refused). Layered fix instead of per-site patches:

- **Migration 120 `repo_path_anchors_absolute_only`** — clears legacy relative anchors (config DELETE, `sources.local_path` → NULL; POSIX + Windows drive/UNC count as absolute). Every consumer falls into its existing explicit "no repo path — use --repo / sources add --path" error; the next `gbrain sync --repo <abs>` re-seeds normalized.
- **`sync --all`** — sources with a relative `local_path` are excluded loudly before the cost estimator and fan-out (pre-migration window).
- **jobs `sync` handler** — `job.data.repoPath` is persisted payload; a relative value fails the job with remediation instead of resolving against the worker daemon's cwd.

## Clone dir (third review round)

A third round caught `sources add --url --clone-dir <relative>`: the URL branch overwrote the normalized path with raw `opts.cloneDir`. Now resolved like `--path` (`defaultCloneDir` is `$GBRAIN_HOME`-based, already absolute).

## Tests

`test/repo-path.test.ts` (13 tests, PGLite harness) + 1 in `test/sources-resync-recovery.test.ts`:

- helper behavior (resolve against cwd, absolute passthrough, refusal message names the storage key + remediation),
- `addSource` stores absolute for relative `--path`,
- regression shape: seeded `sync.repo_path='.'` → bare `performSync` throws at `resolve_repo`; seeded legacy relative `sources.local_path` → per-source sync throws naming the source; caller-supplied relative `repoPath` still resolves (not refused),
- migration 120: relative anchors cleared; POSIX / `C:\` / UNC absolutes survive,
- relative `--clone-dir` through the real (fake-git) clone flow stores an absolute row.

`bun run typecheck` clean; full unit suite: 9419 pass, 7 pre-existing environment-dependent failures reproduced identically on a clean master checkout (live `~/.gbrain` state, `OPENAI_API_KEY` present, global `tag.gpgsign=true` breaking lightweight-tag fixtures) — none related to this diff.

Deployed on the incident machine: migration applied cleanly, and re-seeding the incident state (`sources.local_path = '.'`) now refuses at `sync.resolve_repo` with the remediation message instead of importing the foreign cwd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeWThyfkWsf2tHTD2NzJD8
