### PR TITLE
v0.42.54.0 fix(cli): honor search --json output (#2042)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -443,7 +443,7 @@ async function main() {
     // routed path. Date → ISO string; bigint → string (postgres.js shape);
     // Buffer → object. Microsecond-cost; eliminates a whole drift bug class.
     const result = JSON.parse(JSON.stringify(rawResult));
-    const output = formatResult(op.name, result);
+    const output = formatResult(op.name, result, params);
     if (output) process.stdout.write(output);
   } catch (e: unknown) {
     // v0.42.20.0 (codex D4): on error, set exitCode + return so the `finally`
@@ -526,7 +526,7 @@ async function runThinClientRouted(
       signal: sigintController.signal,
     });
     const result = unpackToolResult(raw);
-    const output = formatResult(op.name, result);
+    const output = formatResult(op.name, result, params);
     if (output) process.stdout.write(output);
   } catch (e: unknown) {
     if (e instanceof RemoteMcpError) {
@@ -756,6 +756,10 @@ export function parseOpArgs(op: Operation, args: string[]): Record<string, unkno
       const paramDef = op.params[key];
       if (paramDef?.type === 'boolean') {
         params[key] = true;
+      } else if (key === 'json') {
+        // Generic operation formatter flag. It is intentionally CLI-local:
+        // do not add it to the operation contract exposed over MCP/tools.
+        params[key] = true;
       } else if (i + 1 < args.length) {
         params[key] = args[++i];
         if (paramDef?.type === 'number') params[key] = Number(params[key]);
@@ -817,7 +821,11 @@ async function makeContext(engine: BrainEngine, params: Record<string, unknown>)
 }
 
 // Exported for tests (same import-safety contract as cliAliases/printOpHelp).
-export function formatResult(opName: string, result: unknown): string {
+export function formatResult(
+  opName: string,
+  result: unknown,
+  params: Record<string, unknown> = {},
+): string {
   switch (opName) {
     case 'volunteer_context': {
       const r = result as any;
@@ -856,6 +864,7 @@ export function formatResult(opName: string, result: unknown): string {
     case 'search':
     case 'query': {
       const results = result as any[];
+      if (params.json === true) return JSON.stringify(results, null, 2) + '\n';
       if (results.length === 0) return 'No results.\n';
       // v0.40.4 — --explain switches to per-stage attribution formatter.
       // Reads CliOptions.explain via the module-level singleton.

--- a/test/cli-args.test.ts
+++ b/test/cli-args.test.ts
@@ -20,5 +20,16 @@ describe('parseOpArgs', () => {
       source_id: 'gstack-code-repo-0e4763c9',
     });
   });
-});
 
+  test('--json is a CLI-local formatter flag for shared operations', () => {
+    const params = parseOpArgs(operationsByName.search, [
+      'needle',
+      '--json',
+    ]);
+
+    expect(params).toEqual({
+      query: 'needle',
+      json: true,
+    });
+  });
+});

--- a/test/cli-format-search-json.test.ts
+++ b/test/cli-format-search-json.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { formatResult } from '../src/cli.ts';
+
+describe('formatResult - search/query --json', () => {
+  test('search --json renders the raw result array as parseable JSON', () => {
+    const out = formatResult('search', [
+      {
+        slug: 'docs/example',
+        score: 0.42,
+        chunk_text: 'Example result text',
+      },
+    ], { json: true });
+
+    expect(JSON.parse(out)).toEqual([
+      {
+        slug: 'docs/example',
+        score: 0.42,
+        chunk_text: 'Example result text',
+      },
+    ]);
+  });
+
+  test('query --json keeps empty results machine-readable', () => {
+    const out = formatResult('query', [], { json: true });
+
+    expect(JSON.parse(out)).toEqual([]);
+  });
+});

--- a/test/cli-search-dispatch.test.ts
+++ b/test/cli-search-dispatch.test.ts
@@ -49,6 +49,15 @@ describe('T5 — gbrain search dispatch', () => {
     });
   });
 
+  test('`search "<freetext>" --json` emits a parseable result array', () => {
+    withHome((home) => {
+      const { stdout, stderr, status } = run(['search', 'zzz-no-such-page-xyz', '--json'], home);
+      expect(status).toBe(0);
+      expect(stderr).not.toContain('Unknown subcommand');
+      expect(JSON.parse(stdout)).toEqual([]);
+    });
+  });
+
   test('`search stats --json` routes to the dashboard', () => {
     withHome((home) => {
       const { stdout, status } = run(['search', 'stats', '--json'], home);


### PR DESCRIPTION
## Summary

Fixes #2042 by making the shared `search` / `query` CLI formatter honor the CLI-local `--json` flag. The result payload is now emitted as a parseable JSON array before teardown, so agents consuming piped stdout no longer fall back to human text or an empty-looking result.

## Diff

- `src/cli.ts`: threads parsed CLI params into the shared operation formatter for both local and routed calls, treats `--json` as a CLI-only formatter flag, and renders `search` / `query` results as JSON when requested.
- `test/cli-args.test.ts`: pins `--json` parsing as a formatter flag that does not enter the public operation contract.
- `test/cli-format-search-json.test.ts`: covers non-empty `search --json` and empty `query --json` rendering as machine-readable arrays.
- `test/cli-search-dispatch.test.ts`: adds a real CLI subprocess regression for `gbrain search "<query>" --json` on an empty brain.

## Test Coverage

- `gbrain-gate.sh <worktree> test/cli-args.test.ts test/cli-format-search-json.test.ts test/cli-search-dispatch.test.ts` - GREEN
  - verify: green except the known macOS-only `check:operations-filter-bypass` false-positive tolerated by the gate
  - unit: 8 pass, 0 fail, 15 assertions across the three selected test files
  - e2e: selector returned the fail-closed all-E2E set, so the gate skipped unrelated local E2E; CI runs the full E2E suite
