### PR TITLE
Prevent MCP facts fallback from tripping extract guard

### DIFF
--- a/src/core/facts/backstop.ts
+++ b/src/core/facts/backstop.ts
@@ -119,6 +119,20 @@ function warnOnce(key: string, msg: string): void {
   // eslint-disable-next-line no-console
   console.warn(msg);
 }
+
+/**
+ * DB-only fallback is a degraded path. For MCP-originated facts, keep it
+ * from recreating the legacy guard shape (`row_num IS NULL AND
+ * entity_slug IS NOT NULL`) by dropping the entity link when the fact could
+ * not be written to a markdown fence. The fact remains queryable by recency
+ * / session / text, but it will not halt the deterministic extract_facts
+ * reconciliation cycle.
+ */
+function legacyDbOnlyEntitySlug(ctx: FactsBackstopCtx, resolvedSlug: string | null): string | null {
+  if (ctx.source === 'mcp:extract_facts' || ctx.source === 'mcp:put_page') return null;
+  return resolvedSlug;
+}
+
 /** Test-only: reset the once-per-process warning memo. */
 export function __resetBackstopWarningsForTests(): void {
   _warnedKeys.clear();
@@ -275,7 +289,12 @@ async function runPipeline(
  *
  * Facts with no resolved entity_slug structurally can't be fenced (no
  * entity page to fence them on), so they take the same legacy DB-only
- * fallback regardless of local_path.
+ * fallback regardless of local_path. Fallback-slugified entity guesses
+ * from MCP surfaces are deliberately treated as unresolved: writing them
+ * as entity-linked DB-only rows recreates the v0.31 guard shape
+ * (row_num NULL + entity_slug NOT NULL) and can halt the extract_facts
+ * cycle. Only exact/fuzzy/prefix-resolved canonical entities are allowed
+ * onto the fence path.
  */
 async function runPipelineWithBody(
   input: { turnText: string; isDreamGenerated: boolean },
@@ -283,7 +302,7 @@ async function runPipelineWithBody(
   abortSignal?: AbortSignal,
 ): Promise<{ inserted: number; duplicate: number; superseded: number; fact_ids: number[] }> {
   const { extractFactsFromTurn } = await import('./extract.ts');
-  const { resolveEntitySlug } = await import('../entities/resolve.ts');
+  const { resolveEntitySlugWithSource } = await import('../entities/resolve.ts');
   const { cosineSimilarity } = await import('./classify.ts');
   const { writeFactsToFence, lookupSourceLocalPath } = await import('./fence-write.ts');
 
@@ -324,8 +343,11 @@ async function runPipelineWithBody(
     // D4: notability filter applied post-extraction, pre-insert.
     if (filter === 'high-only' && f.notability !== 'high') continue;
 
-    const resolvedSlug = f.entity_slug
-      ? await resolveEntitySlug(ctx.engine, ctx.sourceId, f.entity_slug)
+    const resolved = f.entity_slug
+      ? await resolveEntitySlugWithSource(ctx.engine, ctx.sourceId, f.entity_slug)
+      : null;
+    const resolvedSlug = resolved && resolved.source !== 'fallback_slugify'
+      ? resolved.slug
       : null;
 
     // Dedup against DB candidates (correct per Codex Q7: fence rows
@@ -402,7 +424,7 @@ async function runPipelineWithBody(
     const newFact: NewFact = {
       fact: f.fact,
       kind: f.kind,
-      entity_slug: resolvedSlug,
+      entity_slug: legacyDbOnlyEntitySlug(ctx, resolvedSlug),
       visibility,
       notability: f.notability,
       source: f.source,
@@ -459,13 +481,14 @@ async function runPipelineWithBody(
       // v0.34.5: writeFactsToFence refused to spawn a phantom
       // unprefixed entity page (e.g. `jared.md` at brain root).
       // Route these facts to the legacy DB-only path so they
-      // aren't dropped — the slug stays attached but no markdown
-      // file is created.
+      // aren't dropped. MCP-originated facts deliberately lose the
+      // entity link on this degraded path so they cannot recreate the
+      // legacy extract_facts guard shape; non-MCP callers keep the slug.
       for (const { f } of group) {
         const newFact: NewFact = {
           fact: f.fact,
           kind: f.kind,
-          entity_slug: slug,
+          entity_slug: legacyDbOnlyEntitySlug(ctx, slug),
           visibility,
           notability: f.notability,
           source: f.source,

--- a/test/facts-backstop-integration.test.ts
+++ b/test/facts-backstop-integration.test.ts
@@ -19,6 +19,9 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runFactsBackstop, runFactsPipeline } from '../src/core/facts/backstop.ts';
 import {
@@ -109,6 +112,88 @@ describe('runFactsPipeline (extract_facts MCP op path) — response shape stabil
     expect(r.duplicate).toBe(0);
     expect(r.superseded).toBe(0);
     expect(r.fact_ids).toEqual([]);
+  });
+
+  test('fallback-slugified MCP entities do not create guard-triggering DB-only rows', async () => {
+    const brainDir = mkdtempSync(join(tmpdir(), 'gbrain-mcp-facts-'));
+    const sessionId = 'mcp-fallback-guard-' + Math.random().toString(36).slice(2, 8);
+    const prior = await engine.executeRaw<{ local_path: string | null }>(
+      `SELECT local_path FROM sources WHERE id = 'default'`,
+    );
+    try {
+      await engine.executeRaw(`UPDATE sources SET local_path = $1 WHERE id = 'default'`, [brainDir]);
+      chatStub([
+        { fact: 'Synthetic Guard Person prefers blue widgets.', kind: 'preference', notability: 'medium', entity: 'Synthetic Guard Person' },
+      ]);
+
+      const r = await runFactsPipeline('synthetic guard turn', {
+        engine,
+        sourceId: 'default',
+        sessionId,
+        source: 'mcp:extract_facts',
+      });
+
+      expect(r.inserted).toBe(1);
+      expect(existsSync(join(brainDir, 'synthetic-guard-person.md'))).toBe(false);
+
+      const rows = await engine.executeRaw<{ entity_slug: string | null }>(
+        `SELECT entity_slug FROM facts WHERE source_session = $1`,
+        [sessionId],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].entity_slug).toBeNull();
+
+      const guardRows = await engine.executeRaw<{ n: string | number }>(
+        `SELECT COUNT(*) AS n FROM facts WHERE row_num IS NULL AND entity_slug IS NOT NULL`,
+      );
+      expect(Number(guardRows[0]?.n ?? 0)).toBe(0);
+    } finally {
+      await engine.executeRaw(`UPDATE sources SET local_path = $1 WHERE id = 'default'`, [prior[0]?.local_path ?? null]);
+      rmSync(brainDir, { recursive: true, force: true });
+    }
+  });
+
+  test('thin-client MCP fallback drops entity link instead of tripping extract_facts guard', async () => {
+    const sessionId = 'mcp-thin-guard-' + Math.random().toString(36).slice(2, 8);
+    const prior = await engine.executeRaw<{ local_path: string | null }>(
+      `SELECT local_path FROM sources WHERE id = 'default'`,
+    );
+    await engine.putPage('people/thin-client-alice', {
+      title: 'Thin Client Alice',
+      type: 'person',
+      compiled_truth: '# Thin Client Alice\n',
+      frontmatter: {},
+      timeline: '',
+    });
+    try {
+      await engine.executeRaw(`UPDATE sources SET local_path = NULL WHERE id = 'default'`);
+      chatStub([
+        { fact: 'Thin Client Alice prefers async updates.', kind: 'preference', notability: 'medium', entity: 'people/thin-client-alice' },
+      ]);
+
+      const r = await runFactsPipeline('synthetic thin-client turn', {
+        engine,
+        sourceId: 'default',
+        sessionId,
+        source: 'mcp:extract_facts',
+      });
+
+      expect(r.inserted).toBe(1);
+      const rows = await engine.executeRaw<{ entity_slug: string | null; row_num: number | null }>(
+        `SELECT entity_slug, row_num FROM facts WHERE source_session = $1`,
+        [sessionId],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].entity_slug).toBeNull();
+      expect(rows[0].row_num).toBeNull();
+
+      const guardRows = await engine.executeRaw<{ n: string | number }>(
+        `SELECT COUNT(*) AS n FROM facts WHERE row_num IS NULL AND entity_slug IS NOT NULL`,
+      );
+      expect(Number(guardRows[0]?.n ?? 0)).toBe(0);
+    } finally {
+      await engine.executeRaw(`UPDATE sources SET local_path = $1 WHERE id = 'default'`, [prior[0]?.local_path ?? null]);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Prevent MCP-originated DB-only fallback facts from recreating the legacy `row_num IS NULL AND entity_slug IS NOT NULL` guard shape.
- Treat fallback-slugified entity guesses as unresolved so MCP extraction does not create phantom entity pages.
- Add regression coverage for both fallback-slugified MCP entities and thin-client/no-`local_path` MCP fallback.

## Why

When `extract_facts` runs through MCP and the markdown fence path is unavailable or blocked by the stub guard, the fallback direct DB insert could retain `entity_slug` with `row_num = NULL`. Those rows trip the deterministic extract-facts reconciliation guard and can halt future extraction. MCP fallback rows should remain queryable by recency/session/text, but not claim an entity fence row that was never written.

## Verification

- `bun test test/facts-backstop-integration.test.ts test/extract-facts-phase.test.ts test/fence-write.test.ts` — 35 pass
- `bun run typecheck` — pass
