### PR TITLE
fix(gbrain): avoid harden hook push race

### DIFF
--- a/src/core/brain-repo-durability.ts
+++ b/src/core/brain-repo-durability.ts
@@ -678,7 +678,7 @@ function commitScaffolding(repoPath: string, branch: string, redact: (s: string)
       stdio: ['ignore', 'pipe', 'ignore'], timeout: 10_000, env: { ...process.env, ...GIT_ENV },
     }).toString().trim();
     if (!staged) return { status: 'ok', detail: 'scaffolding already committed' };
-    execFileSync('git', ['-C', repoPath, 'commit', '-m', 'chore(gbrain): install brain durability scaffolding'], {
+    execFileSync('git', ['-C', repoPath, 'commit', '--no-verify', '-m', 'chore(gbrain): install brain durability scaffolding'], {
       stdio: 'ignore', timeout: 30_000, env: { ...process.env, ...GIT_ENV },
     });
     execFileSync('git', ['-C', repoPath, ...['-c', 'http.followRedirects=false'], 'push', 'origin', `HEAD:${branch}`], {


### PR DESCRIPTION
## Summary
- make hardenBrainRepo's internal scaffolding commit use --no-verify
- avoids the freshly installed post-commit hook racing harden's explicit synchronous push

## Verification
- bun test test/brain-durability-hook.serial.test.ts (5 consecutive runs)
- bun run verify (31 checks green)

CI monitor source: Test run 28610422792 failed in serial-tests on test/brain-durability-hook.serial.test.ts with git index.lock during note.md add.