### PR TITLE
fix(schema): bootstrap timeline_entries.event_page_id (v121) forward-reference

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -498,7 +498,11 @@ export class PGLiteEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema='public' AND table_name='pages' AND column_name='embedding_signature') AS pages_embedding_signature_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema='public' AND table_name='pages' AND column_name='links_extracted_at') AS pages_links_extracted_at_exists
+                WHERE table_schema='public' AND table_name='pages' AND column_name='links_extracted_at') AS pages_links_extracted_at_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema='public' AND table_name='timeline_entries') AS timeline_entries_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='timeline_entries' AND column_name='event_page_id') AS timeline_event_page_id_exists
     `);
     const probe = rows[0] as {
       pages_exists: boolean;
@@ -541,6 +545,8 @@ export class PGLiteEngine implements BrainEngine {
       pages_generation_exists: boolean;
       pages_embedding_signature_exists: boolean;
       pages_links_extracted_at_exists: boolean;
+      timeline_entries_exists: boolean;
+      timeline_event_page_id_exists: boolean;
     };
 
     const needsPagesBootstrap = probe.pages_exists && !probe.source_id_exists;
@@ -617,6 +623,14 @@ export class PGLiteEngine implements BrainEngine {
     // it; pre-v112 brains crash without the column, so bootstrap adds it before
     // the CREATE INDEX runs. v112 runs later via runMigrations and is idempotent.
     const needsPagesLinksExtractedAt = probe.pages_exists && !probe.pages_links_extracted_at_exists;
+    // v0.42.x (v121): timeline_entries.event_page_id — the event→timeline
+    // projection pointer. idx_timeline_event_page + idx_timeline_event_dedup in
+    // PGLITE_SCHEMA_SQL reference event_page_id, so a pre-v121 brain
+    // (timeline_entries created before the column existed) crashes on the
+    // CREATE INDEX before v121 can add it. Bootstrap adds the column; the FK +
+    // partial indexes land via the blob (CREATE INDEX IF NOT EXISTS) and v121,
+    // which runs later via runMigrations and is idempotent.
+    const needsTimelineEventPageId = probe.timeline_entries_exists && !probe.timeline_event_page_id_exists;
 
     // Fresh installs (no tables yet) and modern brains both no-op.
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
@@ -628,7 +642,8 @@ export class PGLiteEngine implements BrainEngine {
         && !needsPagesProvenance
         && !needsContextualRetrievalColumns && !needsPagesGeneration
         && !needsPagesEmbeddingSignature
-        && !needsPagesLinksExtractedAt) return;
+        && !needsPagesLinksExtractedAt
+        && !needsTimelineEventPageId) return;
 
     process.stderr.write('  Pre-v0.21 brain detected, applying forward-reference bootstrap\n');
 
@@ -873,6 +888,19 @@ export class PGLiteEngine implements BrainEngine {
       // v112 runs later via runMigrations and is idempotent.
       await this.db.exec(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS links_extracted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsTimelineEventPageId) {
+      // v121 (timeline_entries_event_page_id): the event→timeline projection
+      // pointer. idx_timeline_event_page and idx_timeline_event_dedup in
+      // PGLITE_SCHEMA_SQL reference event_page_id, so a pre-v121 brain
+      // (timeline_entries created before the column existed) crashes on the
+      // CREATE INDEX before v121 can add it. Bootstrap adds only the column;
+      // the guarded FK + partial indexes land via the blob (CREATE INDEX IF NOT
+      // EXISTS) and v121, which runs later via runMigrations and is idempotent.
+      await this.db.exec(`
+        ALTER TABLE timeline_entries ADD COLUMN IF NOT EXISTS event_page_id INTEGER;
       `);
     }
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -381,6 +381,8 @@ export class PostgresEngine implements BrainEngine {
    *     (indexed by `idx_mcp_log_agent_time`) — v0.26.3
    *   - `subagent_messages.provider_id` column (indexed by
    *     `idx_subagent_messages_provider`) — v0.27
+   *   - `timeline_entries.event_page_id` column (indexed by
+   *     `idx_timeline_event_page` and `idx_timeline_event_dedup`) — v0.42.x (v121)
    *
    * Keep this in sync with the PGLite version; covered by
    * `test/schema-bootstrap-coverage.test.ts` (PGLite side) and
@@ -507,7 +509,11 @@ export class PostgresEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'embedding_signature') AS pages_embedding_signature_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'links_extracted_at') AS pages_links_extracted_at_exists
+                WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'links_extracted_at') AS pages_links_extracted_at_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema() AND table_name = 'timeline_entries') AS timeline_entries_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'timeline_entries' AND column_name = 'event_page_id') AS timeline_event_page_id_exists
     `;
     const probe = probeRows[0]!;
 
@@ -603,6 +609,19 @@ export class PostgresEngine implements BrainEngine {
     // SCHEMA_SQL replay creates the index. v112 runs later via runMigrations
     // and is idempotent.
     const needsPagesLinksExtractedAt = probe.pages_exists && !probeCr.pages_links_extracted_at_exists;
+    // v0.42.x (v121): timeline_entries.event_page_id — the event→timeline
+    // projection pointer. idx_timeline_event_page + idx_timeline_event_dedup in
+    // SCHEMA_SQL reference event_page_id, so a pre-v121 brain (timeline_entries
+    // created before the column existed) crashes on the blob's CREATE INDEX
+    // before v121 can add it. Bootstrap adds the column; the FK + partial
+    // indexes land via the blob (CREATE INDEX IF NOT EXISTS) and v121, which
+    // runs later via runMigrations and is idempotent.
+    const probeTimeline = probe as {
+      timeline_entries_exists?: boolean;
+      timeline_event_page_id_exists?: boolean;
+    };
+    const needsTimelineEventPageId = probeTimeline.timeline_entries_exists
+      && !probeTimeline.timeline_event_page_id_exists;
 
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
         && !needsPagesDeletedAt && !needsMcpLogBootstrap && !needsSubagentProviderId
@@ -613,7 +632,8 @@ export class PostgresEngine implements BrainEngine {
         && !needsPagesProvenance
         && !needsContextualRetrievalColumns && !needsPagesGeneration
         && !needsPagesEmbeddingSignature
-        && !needsPagesLinksExtractedAt) return;
+        && !needsPagesLinksExtractedAt
+        && !needsTimelineEventPageId) return;
 
     process.stderr.write('  Pre-v0.21 brain detected, applying forward-reference bootstrap\n');
 
@@ -858,6 +878,19 @@ export class PostgresEngine implements BrainEngine {
       // idempotent.
       await conn.unsafe(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS links_extracted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsTimelineEventPageId) {
+      // v121 (timeline_entries_event_page_id): the event→timeline projection
+      // pointer. idx_timeline_event_page and idx_timeline_event_dedup in
+      // SCHEMA_SQL reference event_page_id, so a pre-v121 brain (timeline_entries
+      // created before the column existed) crashes on the blob's CREATE INDEX
+      // before v121 can add it. Bootstrap adds only the column; the guarded FK +
+      // partial indexes land via the blob (CREATE INDEX IF NOT EXISTS) and v121,
+      // which runs later via runMigrations and is idempotent.
+      await conn.unsafe(`
+        ALTER TABLE timeline_entries ADD COLUMN IF NOT EXISTS event_page_id INTEGER;
       `);
     }
   }

--- a/test/schema-bootstrap-coverage.test.ts
+++ b/test/schema-bootstrap-coverage.test.ts
@@ -168,6 +168,13 @@ const REQUIRED_BOOTSTRAP_COVERAGE: ForwardReference[] = [
   // SCHEMA_SQL replay creates the index. Powers `gbrain extract --stale` + the
   // `links_extraction_lag` doctor check.
   { kind: 'column', table: 'pages', column: 'links_extracted_at' },
+  // v0.42.x (v121) — forward-referenced by `CREATE INDEX idx_timeline_event_page
+  // ON timeline_entries(event_page_id)` and the partial UNIQUE
+  // `idx_timeline_event_dedup ON timeline_entries(event_page_id, date)`.
+  // Pre-v121 brains have timeline_entries without this column; bootstrap adds it
+  // before SCHEMA_SQL replay creates the indexes. Powers the event→timeline
+  // projection (a type:event page projects one dated row keyed to event_page_id).
+  { kind: 'column', table: 'timeline_entries', column: 'event_page_id' },
 ];
 
 test('applyForwardReferenceBootstrap covers every forward reference declared in REQUIRED_BOOTSTRAP_COVERAGE', async () => {
@@ -253,6 +260,14 @@ test('applyForwardReferenceBootstrap covers every forward reference declared in 
       ALTER TABLE pages DROP COLUMN IF EXISTS generation;
       ALTER TABLE pages DROP COLUMN IF EXISTS contextual_retrieval_mode;
       ALTER TABLE pages DROP COLUMN IF EXISTS corpus_generation;
+
+      -- v121 event_page_id strip: drop the indexes + FK first, then the column,
+      -- so the brain looks like it pre-dates the timeline projection pointer and
+      -- applyForwardReferenceBootstrap has to re-add it.
+      DROP INDEX IF EXISTS idx_timeline_event_page;
+      DROP INDEX IF EXISTS idx_timeline_event_dedup;
+      ALTER TABLE timeline_entries DROP CONSTRAINT IF EXISTS timeline_entries_event_page_id_fkey;
+      ALTER TABLE timeline_entries DROP COLUMN IF EXISTS event_page_id;
     `);
 
     // Note: we don't strip sources.archived* here because they're inline in the
@@ -325,6 +340,13 @@ test('after bootstrap, PGLITE_SCHEMA_SQL replays without crashing on missing for
       ALTER TABLE pages DROP COLUMN IF EXISTS import_filename;
       ALTER TABLE pages DROP COLUMN IF EXISTS salience_touched_at;
       ALTER TABLE pages DROP COLUMN IF EXISTS emotional_weight;
+
+      -- v121: strip event_page_id + its indexes/FK so the SCHEMA_SQL replay
+      -- below would crash on idx_timeline_event_page without the bootstrap.
+      DROP INDEX IF EXISTS idx_timeline_event_page;
+      DROP INDEX IF EXISTS idx_timeline_event_dedup;
+      ALTER TABLE timeline_entries DROP CONSTRAINT IF EXISTS timeline_entries_event_page_id_fkey;
+      ALTER TABLE timeline_entries DROP COLUMN IF EXISTS event_page_id;
     `);
 
     // Bootstrap, then schema replay. Either step crashing fails the test.


### PR DESCRIPTION
## Problem

`applyForwardReferenceBootstrap` (both engines) pre-creates columns that the embedded schema blob (`SCHEMA_SQL` / `PGLITE_SCHEMA_SQL`) forward-references but that older brains lack — it covers ~20 such columns. **It's missing the v121 entry.**

`SCHEMA_SQL` has:
```sql
CREATE INDEX IF NOT EXISTS idx_timeline_event_page  ON timeline_entries(event_page_id) WHERE event_page_id IS NOT NULL;
CREATE UNIQUE INDEX IF NOT EXISTS idx_timeline_event_dedup ON timeline_entries(event_page_id, date) WHERE event_page_id IS NOT NULL;
```
but `timeline_entries.event_page_id` is only added by **migration v121** (`timeline_entries_event_page_id`).

On a brain whose `timeline_entries` predates v121, `CREATE TABLE IF NOT EXISTS` is a no-op (the column is never added), so the schema-blob's `CREATE INDEX` throws **`column "event_page_id" does not exist`** during `initSchema()` — *before* `runMigrations()` can apply v121. Result: both `gbrain init --migrate-only` and `gbrain apply-migrations` wedge, the schema version stays behind (e.g. stuck at 120), and every query prints `Schema probe failed: column "event_page_id" does not exist`.

This is the exact wedge class the `schema-bootstrap-coverage` guard was built to prevent (incidents #239/#243/#266/#357/#366/#374/#375/#378/#395/#396). It slipped through because the static A2 check treats a column present in the current `CREATE TABLE` body as covered — which is true for *fresh* installs but not for *upgrade* brains where the `CREATE TABLE IF NOT EXISTS` no-ops — and `event_page_id` was never added to `REQUIRED_BOOTSTRAP_COVERAGE` nor stripped by the runtime tests.

### Observed live
A Postgres brain upgraded across the v121 boundary (image rebuild pulled a newer gbrain). `gbrain query` degraded to keyword-only with the schema-probe warning; `init --migrate-only` and `apply-migrations` both failed identically on `event_page_id`. Manually `ALTER TABLE timeline_entries ADD COLUMN IF NOT EXISTS event_page_id INTEGER` then `init --migrate-only` recovered it (v121+v122 applied cleanly) — i.e. exactly what the missing bootstrap should have done.

## Fix

- **`postgres-engine.ts` + `pglite-engine.ts`**: probe `timeline_entries.event_page_id` and, when the table exists without it, `ALTER TABLE timeline_entries ADD COLUMN IF NOT EXISTS event_page_id INTEGER` before the schema-blob replay. The guarded FK + partial indexes still land via the blob (`CREATE INDEX IF NOT EXISTS`) and the idempotent v121 migration — bootstrap only unblocks the replay, mirroring every other entry (e.g. v112 `links_extracted_at`).
- **`schema-bootstrap-coverage.test.ts`**: add the `REQUIRED_BOOTSTRAP_COVERAGE` entry and strip `event_page_id` + its indexes/FK in both runtime tests so the wedge is reproduced and guarded going forward.

## Verification (local, bun 1.3.10)

- `bun test test/schema-bootstrap-coverage.test.ts` → **9 pass / 0 fail** (migration chain applies v121→v122; bootstrap runs).
- **Negative check** — disabling the new bootstrap block reproduces the failure: the coverage assertion fails **and** `PGLITE_SCHEMA_SQL` replay throws `column "event_page_id" does not exist`. Restoring the block makes it green again. So the test genuinely guards this regression.
- `tsc --noEmit` clean for the edited files.

Additive + idempotent; no-op on fresh installs and on brains already at/after v121.