### PR TITLE
v0.42.57.0 fix(cycle): stamp path-derived dream sources (#1869)

### DIFF
--- a/src/commands/dream.ts
+++ b/src/commands/dream.ts
@@ -319,9 +319,9 @@ Options:
 
   --source <id>       Scope the cycle to one source so doctor's
                       cycle_freshness check sees a fresh stamp on
-                      completion. Without this, gbrain dream's
-                      timestamp never lands and federated brains
-                      see "stale cycle" forever.
+                      completion. When omitted, gbrain derives the
+                      source from --dir / configured checkout when
+                      it matches sources.local_path.
   --source-id <id>    Alias for --source. Matches the v0.37.7.0+
                       naming used by import/extract/graph-query.
 

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -1481,10 +1481,11 @@ export async function runCycle(
 
       let dbLock: LockHandle | null = null;
       try {
-        // v0.38: per-source lock ID when opts.sourceId is set; legacy
-        // `gbrain-cycle` otherwise (autopilot still passes nothing).
+        // v0.38: per-source lock ID when a source is known; legacy
+        // `gbrain-cycle` otherwise. `cycleSourceId` includes explicit
+        // opts.sourceId and the --dir/local_path-derived source.
         // cycleLockIdFor validates the sourceId via assertValidSourceId.
-        dbLock = await acquireDbCycleLock(engine, opts.sourceId);
+        dbLock = await acquireDbCycleLock(engine, cycleSourceId);
       } catch (e) {
         // Lock acquisition failed catastrophically (e.g., migration missing).
         // Release the PGLite file lock before returning so it doesn't strand
@@ -2312,9 +2313,9 @@ export async function runCycle(
   }
 
   // v0.38 (codex r1 P0-5): persist per-source cycle completion timestamp
-  // when the cycle ran successfully against an explicit source. Read by
+  // when the cycle ran successfully against a known source. Read by
   // autopilot's per-source freshness gate next tick. Skipped when:
-  //   - opts.sourceId is unset (legacy callers — autopilot still here)
+  //   - no source is known (legacy/global callers with no resolvable checkout)
   //   - engine is null (no-DB path)
   //   - status is 'failed' or 'skipped' (don't mark a non-run as fresh)
   //   - dryRun (writes are out of scope)
@@ -2322,7 +2323,7 @@ export async function runCycle(
   // Best-effort: a write failure does NOT change the CycleReport status.
   // The cost of writing the wrong timestamp post-failure is higher than
   // the cost of missing a successful write (next cycle will redo work).
-  if (opts.sourceId && engine && !dryRun && !aborted && (status === 'ok' || status === 'clean' || status === 'partial')) {
+  if (cycleSourceId && engine && !dryRun && !aborted && (status === 'ok' || status === 'clean' || status === 'partial')) {
     try {
       const nowIso = new Date().toISOString();
       // #2194 fix #3 (the cycle split): `last_source_cycle_at` is the NEW gate
@@ -2332,13 +2333,13 @@ export async function runCycle(
       // phases (those gate on autopilot.last_global_at), so writing it on a
       // source-only cycle does not re-introduce the freshness poisoning codex
       // flagged in the rejected skip-based design.
-      await engine.updateSourceConfig(opts.sourceId, {
+      await engine.updateSourceConfig(cycleSourceId, {
         last_source_cycle_at: nowIso,
         last_full_cycle_at: nowIso,
       });
     } catch (e) {
       // Best-effort; cycle already succeeded by the time we get here.
-      console.warn(`[cycle] failed to write last_source_cycle_at for source ${opts.sourceId}: ${e instanceof Error ? e.message : String(e)}`);
+      console.warn(`[cycle] failed to write last_source_cycle_at for source ${cycleSourceId}: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 

--- a/test/cycle-last-full-cycle-at.test.ts
+++ b/test/cycle-last-full-cycle-at.test.ts
@@ -4,7 +4,7 @@
  * was unspecified pre-PR).
  *
  * Conditions for write:
- *   - opts.sourceId is set (legacy callers without sourceId skip the write)
+ *   - opts.sourceId is set OR brainDir resolves to a sources.local_path row
  *   - engine is non-null (no-DB path skips)
  *   - status is 'ok' | 'clean' | 'partial' (failed/skipped don't mark fresh)
  *   - dryRun is false
@@ -48,12 +48,12 @@ beforeEach(async () => {
   gbrainHome = mkdtempSync(join(tmpdir(), 'gbrain-cycle-lfca-home-'));
 });
 
-async function seedSource(id: string): Promise<void> {
+async function seedSource(id: string, localPath = brainDir): Promise<void> {
   await engine.executeRaw(
     `INSERT INTO sources (id, name, local_path, config, archived, created_at)
      VALUES ($1, $2, $3, '{}'::jsonb, false, NOW())
      ON CONFLICT (id) DO UPDATE SET local_path = EXCLUDED.local_path`,
-    [id, id, brainDir],
+    [id, id, localPath],
   );
 }
 
@@ -90,16 +90,28 @@ describe('runCycle last_full_cycle_at exit hook', () => {
     });
   });
 
-  test('legacy caller (no sourceId) does NOT write any source timestamp', async () => {
+  test('caller without sourceId writes timestamp when brainDir resolves to a source', async () => {
     await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
       await seedSource('default-like');
-      // No sourceId passed; should remain untouched.
+      // No sourceId passed; runCycle should derive the source from brainDir.
       await runCycle(engine, {
         brainDir,
         phases: ['lint'],
       });
-      // No per-source write happens; default source's config stays empty.
       const after = await readLastFullCycleAt('default-like');
+      expect(after).not.toBeNull();
+    });
+  });
+
+  test('caller without sourceId and without path-derived source skips the write', async () => {
+    await withEnv({ GBRAIN_HOME: gbrainHome }, async () => {
+      const unrelatedDir = mkdtempSync(join(tmpdir(), 'gbrain-cycle-lfca-other-'));
+      await seedSource('unmatched', unrelatedDir);
+      await runCycle(engine, {
+        brainDir,
+        phases: ['lint'],
+      });
+      const after = await readLastFullCycleAt('unmatched');
       expect(after).toBeNull();
     });
   });

--- a/test/plugin-sdk-compat.d.ts
+++ b/test/plugin-sdk-compat.d.ts
@@ -1,0 +1,3 @@
+declare module '*/plugin-sdk' {
+  export function registerContextEngine(id: string, factory: () => unknown): void;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "*/plugin-sdk": ["test/plugin-sdk-compat.d.ts"]
     }
   },
   "include": ["src", "test"]


### PR DESCRIPTION
## Summary

Fixes #1869 by letting `gbrain dream --dir <path>` reuse the source id already derived from `sources.local_path` when it finishes a successful cycle. Path-scoped dream runs now stamp the same per-source freshness fields as explicit `--source` runs, so doctor no longer keeps reporting a stale cycle for that source.

## Diff

- `src/core/cycle.ts`: uses the resolved `cycleSourceId` for the DB cycle lock and for the best-effort `last_source_cycle_at` / `last_full_cycle_at` update.
- `src/commands/dream.ts`: updates the `--source` help text to describe the new `--dir` / configured-checkout derivation behavior.
- `test/cycle-last-full-cycle-at.test.ts`: covers no-`sourceId` cycle runs that should stamp when `brainDir` matches a source row, plus the still-skipped unmatched-dir case.
- `tsconfig.json` + `test/plugin-sdk-compat.d.ts`: adds a tiny test-only SDK compatibility shim so local typecheck remains deterministic when a host-installed plugin SDK is present.

## Test Coverage

- `gbrain-gate.sh <worktree> test/cycle-last-full-cycle-at.test.ts test/dream-cli-flags.test.ts` - GREEN
  - verify: green except the known macOS-only `check:operations-filter-bypass` false-positive tolerated by the gate
  - unit: 28 pass, 0 fail, 54 assertions across the two selected test files
  - e2e: selector returned the fail-closed all-E2E set, so the gate skipped unrelated local E2E; CI runs the full E2E suite
