### PR TITLE
feat(ai): add OpenCode Zen provider

### DIFF
--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -9,7 +9,7 @@
  * import it from `../../src/cli.ts`.
  *
  * The single ownership site for: (a) folding file-plane API keys
- * (openai/anthropic/zeroentropy) into the gateway env, and (b) threading
+ * (openai/anthropic/opencode/zeroentropy) into the gateway env, and (b) threading
  * local-server `*_BASE_URL` env vars into base_urls. Both matter for the
  * init-time embedding-key probe — without (a) it would false-warn on
  * config.json-keyed users, and without (b) a live probe could hit the wrong
@@ -28,6 +28,7 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   const envFromConfig: Record<string, string> = {};
   if (c.openai_api_key) envFromConfig.OPENAI_API_KEY = c.openai_api_key;
   if (c.anthropic_api_key) envFromConfig.ANTHROPIC_API_KEY = c.anthropic_api_key;
+  if (c.opencode_api_key) envFromConfig.OPENCODE_API_KEY = c.opencode_api_key;
   // v0.37 fix wave (CDX2-5+6): ZE became the default provider in v0.36 but
   // the env-mapping at this seam never picked it up. `gbrain config set
   // zeroentropy_api_key X` wrote DB plane (ignored by gateway). The file-

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -7,6 +7,7 @@
 
 import type { Recipe } from '../types.ts';
 import { openai } from './openai.ts';
+import { opencode } from './opencode.ts';
 import { google } from './google.ts';
 import { anthropic } from './anthropic.ts';
 import { ollama } from './ollama.ts';
@@ -26,6 +27,7 @@ import { llamaServerReranker } from './llama-server-reranker.ts';
 
 const ALL: Recipe[] = [
   openai,
+  opencode,
   google,
   anthropic,
   ollama,

--- a/src/core/ai/recipes/opencode.ts
+++ b/src/core/ai/recipes/opencode.ts
@@ -1,0 +1,50 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * OpenCode Zen exposes curated coding models behind OpenAI-compatible chat
+ * completions for non-OpenAI/non-Anthropic models.
+ *
+ * The provider id is intentionally `opencode` so config reflects the account
+ * and billing surface: one OpenCode Zen key can route DeepSeek, MiniMax, GLM,
+ * Kimi, and other Zen-hosted models.
+ */
+export const opencode: Recipe = {
+  id: 'opencode',
+  name: 'OpenCode Zen',
+  tier: 'openai-compat',
+  implementation: 'openai-compatible',
+  base_url_default: 'https://opencode.ai/zen/v1',
+  auth_env: {
+    required: ['OPENCODE_API_KEY'],
+    setup_url: 'https://opencode.ai/auth',
+  },
+  touchpoints: {
+    chat: {
+      models: [
+        'deepseek-v4-pro',
+        'deepseek-v4-flash',
+        'minimax-m3',
+        'minimax-m2.7',
+        'minimax-m2.5',
+        'glm-5.2',
+        'glm-5.1',
+        'glm-5',
+        'kimi-k2.7-code',
+        'kimi-k2.6',
+        'kimi-k2.5',
+        'grok-build-0.1',
+        'big-pickle',
+        'mimo-v2.5-free',
+        'north-mini-code-free',
+        'nemotron-3-ultra-free',
+        'deepseek-v4-flash-free',
+      ],
+      supports_tools: true,
+      supports_subagent_loop: true,
+      supports_prompt_cache: false,
+      max_context_tokens: 128000,
+      price_last_verified: '2026-07-03',
+    },
+  },
+  setup_hint: 'Create an OpenCode Zen API key at https://opencode.ai/auth, then `export OPENCODE_API_KEY=...` and use `opencode:<model-id>`.',
+};

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -31,6 +31,8 @@ export interface GBrainConfig {
   database_path?: string;
   openai_api_key?: string;
   anthropic_api_key?: string;
+  /** OpenCode Zen API key for opencode:<model> chat routing. */
+  opencode_api_key?: string;
   /**
    * ZeroEntropy API key. v0.37 fix wave (CDX2-5+6): ZE became the default
    * embedding + reranker provider in v0.36 but lacked a file-plane config

--- a/test/ai/build-gateway-config.test.ts
+++ b/test/ai/build-gateway-config.test.ts
@@ -84,4 +84,13 @@ describe('buildGatewayConfig env-baseURL passthrough', () => {
       },
     );
   });
+
+  test('opencode_api_key maps to OPENCODE_API_KEY for OpenCode Zen', async () => {
+    await withEnv({ OPENCODE_API_KEY: undefined }, async () => {
+      const cfg = buildGatewayConfig({
+        opencode_api_key: 'sk-opencode-test',
+      } as unknown as GBrainConfig);
+      expect(cfg.env.OPENCODE_API_KEY).toBe('sk-opencode-test');
+    });
+  });
 });

--- a/test/ai/gateway-chat.test.ts
+++ b/test/ai/gateway-chat.test.ts
@@ -29,8 +29,8 @@ import { AIConfigError } from '../../src/core/ai/errors.ts';
 import { listRecipes, getRecipe } from '../../src/core/ai/recipes/index.ts';
 
 describe('chat touchpoint — recipe registry', () => {
-  test('all six chat-capable providers ship a chat touchpoint with supports_subagent_loop', () => {
-    const expected = ['anthropic', 'openai', 'google', 'deepseek', 'groq', 'together'];
+  test('all chat-capable providers ship a chat touchpoint with supports_subagent_loop', () => {
+    const expected = ['anthropic', 'openai', 'opencode', 'google', 'deepseek', 'groq', 'together'];
     for (const id of expected) {
       const r = getRecipe(id);
       expect(r, `recipe missing: ${id}`).toBeDefined();
@@ -57,6 +57,7 @@ describe('chat touchpoint — recipe registry', () => {
   });
 
   test('openai-compat chat recipes have base_url_default', () => {
+    expect(getRecipe('opencode')!.base_url_default).toBe('https://opencode.ai/zen/v1');
     expect(getRecipe('deepseek')!.base_url_default).toBe('https://api.deepseek.com/v1');
     expect(getRecipe('groq')!.base_url_default).toBe('https://api.groq.com/openai/v1');
     expect(getRecipe('together')!.base_url_default).toBe('https://api.together.xyz/v1');
@@ -103,6 +104,7 @@ describe('chat touchpoint — model resolver + aliases (Codex F-OV-5)', () => {
   test('assertTouchpoint accepts chat for chat-capable native + openai-compat providers', () => {
     expect(() => assertTouchpoint(getRecipe('anthropic')!, 'chat', 'claude-opus-4-7')).not.toThrow();
     expect(() => assertTouchpoint(getRecipe('openai')!, 'chat', 'gpt-5.2')).not.toThrow();
+    expect(() => assertTouchpoint(getRecipe('opencode')!, 'chat', 'deepseek-v4-flash')).not.toThrow();
     expect(() => assertTouchpoint(getRecipe('google')!, 'chat', 'gemini-2.0-flash')).not.toThrow();
     expect(() => assertTouchpoint(getRecipe('deepseek')!, 'chat', 'deepseek-chat')).not.toThrow();
   });

--- a/test/ai/recipes-existing-regression.test.ts
+++ b/test/ai/recipes-existing-regression.test.ts
@@ -39,6 +39,7 @@ describe('IRON RULE: existing 9 recipes survive the v0.32 resolveAuth refactor',
       'litellm',
       'ollama',
       'openai',
+      'opencode',
       'together',
       'voyage',
     ]) {
@@ -335,4 +336,3 @@ describe('default_headers / resolveDefaultHeaders contract (v0.37.2.0)', () => {
     expect(e.headers).toEqual({ 'X-Static': 'static-val' });
   });
 });
-


### PR DESCRIPTION
## Summary
- Adds a first-class `opencode` OpenAI-compatible provider recipe for OpenCode Zen.
- Maps `opencode_api_key` to `OPENCODE_API_KEY` in gateway config.
- Extends provider registry and regression coverage so `opencode:<model>` works for chat/subagent-capable models.

## Verification
- `bun test test/ai/gateway-chat.test.ts test/ai/recipes-existing-regression.test.ts test/ai/build-gateway-config.test.ts test/model-config.serial.test.ts`
- Live probe against OpenCode Zen: `bun src/cli.ts providers test --touchpoint chat --model opencode:deepseek-v4-flash`