### PR TITLE
fix(openclaw): declare gbrain plugin manifest entry

### DIFF
--- a/docs/guides/skillpacks-as-scaffolding.md
+++ b/docs/guides/skillpacks-as-scaffolding.md
@@ -131,7 +131,9 @@ into gbrain so other clients can scaffold it. Default behavior:
   `~/.gbrain/harvest-private-patterns.txt` plus built-in defaults
   (canonical private fork name, common email regex, Slack channel pattern). Any
   match → rollback (delete the harvested files) and exit non-zero.
-- `openclaw.plugin.json` updated with the new slug, sorted.
+- `openclaw.plugin.json` updated with the new slug, sorted. Harvest must preserve
+  the top-level OpenClaw-native plugin fields (`id`, `configSchema`, `contracts`)
+  because OpenClaw validates those before it can install the package.
 - `--no-lint` bypasses the linter (after a manual editorial scrub).
 
 Use the `skillpack-harvest` skill (its companion editorial workflow)

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,4 +1,5 @@
 {
+  "id": "gbrain-context-engine",
   "name": "gbrain",
   "version": "0.32.3.0",
   "description": "Personal knowledge brain with Postgres + pgvector hybrid search",

--- a/skills/skillpack-harvest/SKILL.md
+++ b/skills/skillpack-harvest/SKILL.md
@@ -266,4 +266,5 @@ editorial pass.
   (e.g. `src/commands/<slug>.ts` if the host SKILL.md declares it
   in frontmatter)
 - gbrain's `openclaw.plugin.json` — adds the slug to `skills:`
-  array, sorted alphabetically
+  array, sorted alphabetically, without removing OpenClaw-native plugin fields
+  like `id`, `configSchema`, or `contracts`

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -57,6 +57,8 @@ This mode guarantees:
 - `skills/manifest.json` lists every skill directory
 - `skills/RESOLVER.md` references every skill in the manifest
 - `openclaw.plugin.json` `skills[]` round-trips with both
+- `openclaw.plugin.json` keeps OpenClaw install-required native plugin fields
+  (`id`, object `configSchema`, and `contracts.contextEngines` when applicable)
 - No MECE violations (duplicate triggers across skills)
 
 ### Phases
@@ -72,7 +74,7 @@ This mode guarantees:
 ### Automation
 
 ```bash
-bun test test/skills-conformance.test.ts test/resolver.test.ts
+bun test test/skills-conformance.test.ts test/resolver.test.ts test/openclaw-plugin-manifest.test.ts
 ```
 
 The CI-gated check is the package.json `test` script.

--- a/src/openclaw-context-engine.ts
+++ b/src/openclaw-context-engine.ts
@@ -63,25 +63,26 @@ interface PluginCtx {
   [key: string]: unknown;
 }
 
+export function register(api: PluginApi) {
+  api.registerContextEngine(ENGINE_ID, (ctx: PluginCtx) => {
+    const hostResolver =
+      typeof ctx.resolveEntities === 'function'
+        ? ctx.resolveEntities
+        : typeof ctx.brainQuery === 'function'
+          ? ctx.brainQuery
+          : undefined;
+    return createGBrainContextEngine({
+      workspaceDir: ctx.workspaceDir,
+      resolveEntities: hostResolver,
+    });
+  });
+}
+
 const entry: PluginEntry = {
   id: 'gbrain-context-engine',
   name: 'GBrain Context Engine',
   description: 'Deterministic temporal/spatial context injection on every turn',
-
-  register(api: PluginApi) {
-    api.registerContextEngine(ENGINE_ID, (ctx: PluginCtx) => {
-      const hostResolver =
-        typeof ctx.resolveEntities === 'function'
-          ? ctx.resolveEntities
-          : typeof ctx.brainQuery === 'function'
-            ? ctx.brainQuery
-            : undefined;
-      return createGBrainContextEngine({
-        workspaceDir: ctx.workspaceDir,
-        resolveEntities: hostResolver,
-      });
-    });
-  },
+  register,
 };
 
 export default entry;

--- a/test/openclaw-plugin-manifest.test.ts
+++ b/test/openclaw-plugin-manifest.test.ts
@@ -12,5 +12,6 @@ describe('root OpenClaw plugin manifest', () => {
     expect(manifest.configSchema).toBeDefined();
     expect(typeof manifest.configSchema).toBe('object');
     expect(manifest.contracts?.contextEngines).toContain('gbrain-context');
+    expect(entrySource).toContain('export function register');
   });
 });

--- a/test/openclaw-plugin-manifest.test.ts
+++ b/test/openclaw-plugin-manifest.test.ts
@@ -11,5 +11,6 @@ describe('root OpenClaw plugin manifest', () => {
     expect(manifest.id).toBe(entryId);
     expect(manifest.configSchema).toBeDefined();
     expect(typeof manifest.configSchema).toBe('object');
+    expect(manifest.contracts?.contextEngines).toContain('gbrain-context');
   });
 });

--- a/test/openclaw-plugin-manifest.test.ts
+++ b/test/openclaw-plugin-manifest.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('root OpenClaw plugin manifest', () => {
+  it('declares the id required by OpenClaw plugin installs', () => {
+    const manifest = JSON.parse(readFileSync(join(import.meta.dir, '..', 'openclaw.plugin.json'), 'utf8'));
+    const entrySource = readFileSync(join(import.meta.dir, '..', 'src', 'openclaw-context-engine.ts'), 'utf8');
+    const entryId = entrySource.match(/id:\s*'([^']+)'/)?.[1];
+
+    expect(manifest.id).toBe(entryId);
+    expect(manifest.configSchema).toBeDefined();
+    expect(typeof manifest.configSchema).toBe('object');
+  });
+});


### PR DESCRIPTION
## Summary
- Add the OpenClaw-required top-level `id` to `openclaw.plugin.json` as `gbrain-context-engine`
- Export a direct `register(api)` entrypoint and default plugin object with the same id
- Add a manifest regression test and document that skillpack harvest must preserve OpenClaw-native manifest fields

## Verification
- Checked local OpenClaw clone `/home/filip/c/z_EXT/openclaw`: manifest id/configSchema are required, runtime entry ids must match manifest ids, and direct exported `register` is accepted
- Built this PR entry from commit `5b79167d` with `bun build src/openclaw-context-engine.ts --target=bun --outfile entry.js`
- Reinstalled the built PR artifact into local OpenClaw at `~/.openclaw/local-plugins/gbrain-context-engine`, preserving `~/.openclaw/openclaw.json` byte-for-byte
- Restarted `openclaw-gateway.service`; gateway came back on `127.0.0.1:18789` as OpenClaw `2026.6.10 (aa69b12)`
- `openclaw plugins doctor`: no plugin issues detected
- `openclaw plugins inspect gbrain-context-engine`: `Status: loaded`, source `~/.openclaw/local-plugins/gbrain-context-engine/entry.js`, version `0.42.25.0-pr2551`
- Ran in isolated PR worktree: `bun test test/openclaw-plugin-manifest.test.ts`
- Ran in isolated PR worktree: `bun test test/skills-conformance.test.ts test/resolver.test.ts test/openclaw-plugin-manifest.test.ts`