### PR TITLE
fix(doctor): reuse liveSyncStatus for sync liveness

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -3486,17 +3486,8 @@ export async function checkSyncFreshness(
     let liveSyncSnap: (sourceId: string) => Promise<{ holder_pid: number; holder_host: string } | null> =
       async () => null;
     try {
-      const { inspectLock, syncLockId } = await import('../core/db-lock.ts');
-      liveSyncSnap = async (sourceId: string) => {
-        try {
-          const snap = await inspectLock(engine, syncLockId(sourceId));
-          return snap && !snap.ttl_expired
-            ? { holder_pid: snap.holder_pid, holder_host: snap.holder_host }
-            : null;
-        } catch {
-          return null;
-        }
-      };
+      const { liveSyncStatus } = await import('../core/db-lock.ts');
+      liveSyncSnap = (sourceId: string) => liveSyncStatus(engine, sourceId);
     } catch {
       /* db-lock unavailable — skip in-progress detection, staleness stands. */
     }

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -31,17 +31,6 @@ describe('doctor command', () => {
     expect(src).toContain('gbrain frontmatter validate');
   });
 
-  test('checkSyncFreshness uses shared liveSyncStatus for live-lock liveness', async () => {
-    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
-    const block = source.slice(
-      source.indexOf('const inProgress: string[] = []'),
-      source.indexOf('for (const source of sources)'),
-    );
-    expect(block).toContain('liveSyncStatus');
-    expect(block).not.toContain('inspectLock');
-    expect(block).not.toContain('syncLockId');
-  });
-
   test('Check interface supports issues array', async () => {
     // `Check` is a TypeScript interface — type-only, no runtime value.
     // Importing it for type assertion is enough to validate the shape.

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -31,6 +31,17 @@ describe('doctor command', () => {
     expect(src).toContain('gbrain frontmatter validate');
   });
 
+  test('checkSyncFreshness uses shared liveSyncStatus for live-lock liveness', async () => {
+    const source = await Bun.file(new URL('../src/commands/doctor.ts', import.meta.url)).text();
+    const block = source.slice(
+      source.indexOf('const inProgress: string[] = []'),
+      source.indexOf('for (const source of sources)'),
+    );
+    expect(block).toContain('liveSyncStatus');
+    expect(block).not.toContain('inspectLock');
+    expect(block).not.toContain('syncLockId');
+  });
+
   test('Check interface supports issues array', async () => {
     // `Check` is a TypeScript interface — type-only, no runtime value.
     // Importing it for type assertion is enough to validate the shape.


### PR DESCRIPTION
## Summary

- route doctor sync-liveness detection through the shared `liveSyncStatus()` helper
- remove the duplicated `inspectLock(syncLockId(...))` logic from `checkSyncFreshness`
- add a regression guard so the doctor path keeps using the shared helper

## Verification

- `bun test test/db-lock-inspect.test.ts test/doctor.test.ts`: 98 pass, 0 fail
- `bun test test/doctor.test.ts`: 84 pass, 0 fail
- `git diff --check`
