### PR TITLE
fix(cli): route shared ops to a live local serve daemon instead of dying on the PGLite lock

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,10 @@ import { serializeMarkdown } from './core/markdown.ts';
 import { parseGlobalFlags, setCliOptions, getCliOptions } from './core/cli-options.ts';
 import type { CliOptions } from './core/cli-options.ts';
 import { callRemoteTool, RemoteMcpError, unpackToolResult } from './core/mcp-client.ts';
+import { detectLocalDaemon, probeLocalDaemonHealth, readLocalDaemonToken, callLocalDaemonTool } from './core/local-daemon.ts';
+import type { LocalDaemonInfo } from './core/local-daemon.ts';
+import { extractResultText, isAuthErrorMessage } from './core/connect-probe.ts';
+import { gbrainPath } from './core/config.ts';
 import { maybePromptForUpgrade } from './core/thin-client-upgrade-prompt.ts';
 import { VERSION } from './version.ts';
 
@@ -354,6 +358,21 @@ async function main() {
     return;
   }
 
+  // Local-daemon fallback: on a PGLite install, a live `gbrain serve --http`
+  // (launchd/systemd) holds the single-writer lock — connectEngine() below
+  // could only poll the lock for 30s and die with "Timed out waiting for
+  // PGLite lock". The lock file names the holder and its port; route shared
+  // ops to that daemon over loopback HTTP instead. localOnly ops fall
+  // through: the server hides them, and the existing lock-timeout message
+  // already names the daemon pid to stop.
+  if (!op.localOnly && cfgPre?.engine === 'pglite' && cfgPre.database_path) {
+    const daemon = detectLocalDaemon(cfgPre.database_path);
+    if (daemon && await probeLocalDaemonHealth(daemon.port)) {
+      await runLocalDaemonRouted(op, params, daemon, cliOpts);
+      return;
+    }
+  }
+
   // Local engine path (unchanged behavior for local installs).
   const engine = await connectEngine();
   // #2084: the teardown contract (bounded drain of every background-work sink,
@@ -578,6 +597,74 @@ async function runThinClientRouted(
     // exit 1 — but this should never happen post-CDX-4.
     console.error(e instanceof Error ? e.message : String(e));
     process.off('SIGINT', onSigint);
+    process.exit(1);
+  } finally {
+    process.off('SIGINT', onSigint);
+  }
+}
+
+/**
+ * Local-daemon fallback dispatcher — the loopback sibling of
+ * runThinClientRouted. Called from main() when a live `gbrain serve --http`
+ * holds the PGLite lock (see src/core/local-daemon.ts for detection).
+ * Timeout policy matches the thin client (ENG-4): --timeout=Ns wins;
+ * otherwise 180s for `think`, 30s for everything else. Results render
+ * through the SAME unpackToolResult + formatResult pair as both other
+ * paths — renderer parity by data shape.
+ */
+async function runLocalDaemonRouted(
+  op: Operation,
+  params: Record<string, unknown>,
+  daemon: LocalDaemonInfo,
+  cliOpts: CliOptions,
+): Promise<void> {
+  const defaultTimeoutMs = op.name === 'think' ? 180_000 : 30_000;
+  const timeoutMs = cliOpts.timeoutMs ?? defaultTimeoutMs;
+
+  const token = readLocalDaemonToken();
+  if (!token) {
+    console.error(`gbrain serve (pid ${daemon.pid}) holds the PGLite lock; routing this command through it needs a bearer token.`);
+    console.error(`Set GBRAIN_REMOTE_TOKEN or write one to ${gbrainPath('agents.token')} (mint on this host: gbrain auth create cli).`);
+    console.error('Or stop the daemon and re-run.');
+    process.exit(1);
+  }
+
+  const sigintController = new AbortController();
+  const onSigint = () => sigintController.abort(new Error('SIGINT'));
+  process.on('SIGINT', onSigint);
+
+  // Observability sibling of the thin-client banner, same suppression rules
+  // (--quiet, non-TTY, GBRAIN_NO_BANNER=1). No identity fetch — same host,
+  // same version, zero extra round-trips.
+  if (!bannerSuppressed(cliOpts)) {
+    process.stderr.write(`[local-daemon → 127.0.0.1:${daemon.port} · pid ${daemon.pid}]\n`);
+  }
+
+  try {
+    const raw = await callLocalDaemonTool(daemon.port, token, op.name, params, {
+      timeoutMs,
+      signal: sigintController.signal,
+    });
+    if (raw.isError) {
+      const msg = extractResultText(raw.content) || 'unknown tool error';
+      if (isAuthErrorMessage(msg)) {
+        console.error(`Local daemon rejected the bearer token (GBRAIN_REMOTE_TOKEN / ${gbrainPath('agents.token')}).`);
+        console.error('Re-mint on this host: gbrain auth create cli');
+      } else {
+        console.error(msg);
+      }
+      process.exit(1);
+    }
+    const result = unpackToolResult(raw);
+    const output = formatResult(op.name, result);
+    if (output) process.stdout.write(output);
+  } catch (e: unknown) {
+    if (sigintController.signal.aborted) {
+      process.off('SIGINT', onSigint);
+      process.exit(130);
+    }
+    console.error(`Local daemon call failed: ${e instanceof Error ? e.message : String(e)}`);
+    console.error(`The daemon (pid ${daemon.pid}) holds the PGLite lock, so the local engine path would only time out. Stop the daemon or retry.`);
     process.exit(1);
   } finally {
     process.off('SIGINT', onSigint);

--- a/src/core/local-daemon.ts
+++ b/src/core/local-daemon.ts
@@ -1,0 +1,162 @@
+/**
+ * Local-daemon CLI fallback — route shared ops to a live local
+ * `gbrain serve --http` instead of dying on the PGLite lock.
+ *
+ * PGLite is single-connection: while a serve daemon (launchd/systemd) holds
+ * `<dataDir>/.gbrain-lock`, `connectEngine()` on a local install can only
+ * poll the lock for 30s and throw "Timed out waiting for PGLite lock" —
+ * even though the daemon is serving the SAME brain over loopback HTTP the
+ * whole time. The lock file already records everything needed to route
+ * around the collision: the holder's pid and argv (including `--port N`).
+ * Detection is pure file reads + a loopback /health probe; no engine
+ * connect, no OAuth discovery.
+ *
+ * Auth: `serve --http` guards /mcp with requireBearerAuth, so the CLI needs
+ * a raw bearer token. Resolution: `GBRAIN_REMOTE_TOKEN` env var (same var
+ * `gbrain connect` reads), then `<gbrain home>/agents.token` — the 0600
+ * file host bootstrap scripts drop next to config.json when installing
+ * agent MCP configs. `callRemoteTool` is OAuth-only (see connect-probe.ts),
+ * so the tool call here reuses that probe's raw-bearer StreamableHTTP
+ * pattern, including the Promise.race timeout guard: the AbortSignal alone
+ * does not cover client.connect()'s initialize handshake.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { gbrainPath } from './config.ts';
+
+export interface LocalDaemonInfo {
+  pid: number;
+  port: number;
+}
+
+export interface DetectDeps {
+  isProcessAlive: (pid: number) => boolean;
+  readFile: (path: string) => string;
+}
+
+const DEFAULT_DETECT_DEPS: DetectDeps = {
+  isProcessAlive: (pid) => {
+    try {
+      process.kill(pid, 0); // signal 0 = existence check
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  readFile: (p) => readFileSync(p, 'utf-8'),
+};
+
+/**
+ * Parse a lock-file `command` string (argv.slice(1).join(' ') — see
+ * pglite-lock.ts) into the HTTP port of a `serve --http` holder.
+ * Returns null for any other holder (stdio serve, embed, import, ...):
+ * those have no HTTP surface to route to.
+ */
+export function parseServeHttpPort(command: unknown): number | null {
+  if (typeof command !== 'string') return null;
+  const tokens = command.split(/\s+/);
+  if (!tokens.includes('serve') || !tokens.includes('--http')) return null;
+  const portIdx = tokens.indexOf('--port');
+  if (portIdx === -1) return 3131; // runServe default (serve.ts)
+  const port = parseInt(tokens[portIdx + 1] ?? '', 10);
+  return Number.isFinite(port) && port > 0 && port < 65536 ? port : null;
+}
+
+/**
+ * Read `<dataDir>/.gbrain-lock/lock` and return the live `serve --http`
+ * holder, or null when there is no daemon to route to (no lock, corrupt
+ * lock, dead holder, or a non-HTTP holder). Null means: proceed to the
+ * normal local-engine path.
+ */
+export function detectLocalDaemon(
+  dataDir: string | undefined,
+  deps: DetectDeps = DEFAULT_DETECT_DEPS,
+): LocalDaemonInfo | null {
+  if (!dataDir) return null; // in-memory — no lock, no daemon
+  try {
+    const raw = JSON.parse(deps.readFile(join(dataDir, '.gbrain-lock', 'lock')));
+    const pid = raw.pid;
+    if (typeof pid !== 'number' || !deps.isProcessAlive(pid)) return null;
+    const port = parseServeHttpPort(raw.command);
+    if (port === null) return null;
+    return { pid, port };
+  } catch {
+    return null;
+  }
+}
+
+/** True iff GET /health on loopback answers 200 {status:"ok"} in time. */
+export async function probeLocalDaemonHealth(port: number, timeoutMs = 1500): Promise<boolean> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return false;
+    const body = (await res.json().catch(() => null)) as { status?: string } | null;
+    return body?.status === 'ok';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Bearer token for the loopback /mcp call. `GBRAIN_REMOTE_TOKEN` wins;
+ * falls back to `<gbrain home>/agents.token`. Null when neither is set —
+ * the caller renders the actionable error (the doomed 30s lock wait is
+ * never worth falling through to).
+ */
+export function readLocalDaemonToken(env: NodeJS.ProcessEnv = process.env): string | null {
+  const fromEnv = env.GBRAIN_REMOTE_TOKEN?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    return readFileSync(gbrainPath('agents.token'), 'utf-8').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One raw-bearer MCP tool call against the local daemon. Timeout is a real
+ * Promise.race (connect-probe.ts pattern): a daemon that accepts the socket
+ * then stalls mid-handshake must not hang the CLI. `signal` is the CLI's
+ * SIGINT controller; aborting it cancels the in-flight HTTP.
+ */
+export async function callLocalDaemonTool(
+  port: number,
+  token: string,
+  name: string,
+  args: Record<string, unknown>,
+  opts: { timeoutMs: number; signal?: AbortSignal },
+): Promise<{ isError?: boolean; content?: unknown }> {
+  const doCall = async () => {
+    const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), {
+      requestInit: {
+        headers: { Authorization: `Bearer ${token}` },
+        ...(opts.signal ? { signal: opts.signal } : {}),
+      },
+    });
+    const client = new Client({ name: 'gbrain-cli-local', version: '1' }, { capabilities: {} });
+    try {
+      await client.connect(transport);
+      const res = await client.callTool({ name, arguments: args });
+      return res as { isError?: boolean; content?: unknown };
+    } finally {
+      try { await client.close(); } catch { /* best-effort */ }
+    }
+  };
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutGuard = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`local daemon call timed out after ${opts.timeoutMs}ms`)),
+      opts.timeoutMs,
+    );
+  });
+  try {
+    return await Promise.race([doCall(), timeoutGuard]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/test/local-daemon.test.ts
+++ b/test/local-daemon.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Local-daemon CLI fallback — detection + token-resolution contract.
+ *
+ * Pins the pure seams of src/core/local-daemon.ts so the cli.ts routing
+ * guard can't silently regress: which lock holders count as a routable
+ * daemon (live `serve --http` only), how the port is parsed out of the
+ * lock file's argv string, and the bearer-token precedence
+ * (GBRAIN_REMOTE_TOKEN env > <gbrain home>/agents.token file).
+ * The HTTP surfaces (health probe, raw-bearer tool call) follow the
+ * connect-probe.ts pattern and are exercised by the live-daemon e2e path.
+ */
+
+import { describe, test, expect, afterEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  parseServeHttpPort,
+  detectLocalDaemon,
+  readLocalDaemonToken,
+} from '../src/core/local-daemon.ts';
+
+describe('parseServeHttpPort', () => {
+  test('serve --http --port N → N', () => {
+    expect(parseServeHttpPort('/Users/x/gbrain/src/cli.ts serve --http --port 3131')).toBe(3131);
+  });
+
+  test('serve --http without --port → default 3131', () => {
+    expect(parseServeHttpPort('/Users/x/gbrain/src/cli.ts serve --http')).toBe(3131);
+  });
+
+  test('stdio serve (no --http) → null: nothing to route to', () => {
+    expect(parseServeHttpPort('/Users/x/gbrain/src/cli.ts serve')).toBeNull();
+  });
+
+  test('non-serve holders (embed, import) → null', () => {
+    expect(parseServeHttpPort('/Users/x/gbrain/src/cli.ts embed')).toBeNull();
+    expect(parseServeHttpPort('/Users/x/gbrain/src/cli.ts import ~/notes')).toBeNull();
+  });
+
+  test('garbage port values → null', () => {
+    expect(parseServeHttpPort('cli.ts serve --http --port nope')).toBeNull();
+    expect(parseServeHttpPort('cli.ts serve --http --port 0')).toBeNull();
+    expect(parseServeHttpPort('cli.ts serve --http --port 99999')).toBeNull();
+  });
+
+  test('non-string command (corrupt lock) → null', () => {
+    expect(parseServeHttpPort(undefined)).toBeNull();
+    expect(parseServeHttpPort(42)).toBeNull();
+  });
+});
+
+describe('detectLocalDaemon', () => {
+  const lockJson = (over: Record<string, unknown> = {}) =>
+    JSON.stringify({
+      pid: 4242,
+      acquired_at: 1,
+      refreshed_at: 2,
+      command: 'cli.ts serve --http --port 3131',
+      ...over,
+    });
+
+  test('live serve --http holder → pid + port', () => {
+    expect(
+      detectLocalDaemon('/data', { isProcessAlive: () => true, readFile: () => lockJson() }),
+    ).toEqual({ pid: 4242, port: 3131 });
+  });
+
+  test('dead holder → null (acquireLock will reap it)', () => {
+    expect(
+      detectLocalDaemon('/data', { isProcessAlive: () => false, readFile: () => lockJson() }),
+    ).toBeNull();
+  });
+
+  test('live non-HTTP holder (embed) → null', () => {
+    expect(
+      detectLocalDaemon('/data', {
+        isProcessAlive: () => true,
+        readFile: () => lockJson({ command: 'cli.ts embed' }),
+      }),
+    ).toBeNull();
+  });
+
+  test('missing lock file → null', () => {
+    expect(
+      detectLocalDaemon('/data', {
+        isProcessAlive: () => true,
+        readFile: () => { throw new Error('ENOENT'); },
+      }),
+    ).toBeNull();
+  });
+
+  test('corrupt lock JSON → null', () => {
+    expect(
+      detectLocalDaemon('/data', { isProcessAlive: () => true, readFile: () => '{nope' }),
+    ).toBeNull();
+  });
+
+  test('in-memory (no dataDir) → null', () => {
+    expect(
+      detectLocalDaemon(undefined, { isProcessAlive: () => true, readFile: () => lockJson() }),
+    ).toBeNull();
+  });
+});
+
+describe('readLocalDaemonToken', () => {
+  const savedHome = process.env.GBRAIN_HOME;
+  let tmp: string | null = null;
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.GBRAIN_HOME;
+    else process.env.GBRAIN_HOME = savedHome;
+    if (tmp) { rmSync(tmp, { recursive: true, force: true }); tmp = null; }
+  });
+
+  const makeHome = (tokenFile?: string): void => {
+    tmp = mkdtempSync(join(tmpdir(), 'gbrain-local-daemon-'));
+    mkdirSync(join(tmp, '.gbrain'), { recursive: true });
+    if (tokenFile !== undefined) {
+      writeFileSync(join(tmp, '.gbrain', 'agents.token'), tokenFile, { mode: 0o600 });
+    }
+    process.env.GBRAIN_HOME = tmp;
+  };
+
+  test('GBRAIN_REMOTE_TOKEN env wins over the file', () => {
+    makeHome('gbrain_filetoken');
+    expect(readLocalDaemonToken({ GBRAIN_REMOTE_TOKEN: ' gbrain_envtoken ' } as NodeJS.ProcessEnv))
+      .toBe('gbrain_envtoken');
+  });
+
+  test('falls back to agents.token (trimmed)', () => {
+    makeHome('gbrain_filetoken\n');
+    expect(readLocalDaemonToken({} as NodeJS.ProcessEnv)).toBe('gbrain_filetoken');
+  });
+
+  test('empty file → null', () => {
+    makeHome('\n');
+    expect(readLocalDaemonToken({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  test('no env, no file → null', () => {
+    makeHome(undefined);
+    expect(readLocalDaemonToken({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

On a local PGLite install with `gbrain serve --http` running as a daemon (launchd/systemd), every shared CLI op (`search`, `query`, ...) goes `connectEngine()` → `acquireLock()` and times out after 30s with **"GBrain: Timed out waiting for PGLite lock"** — while the daemon is serving the same brain over loopback HTTP the whole time. MCP clients work; the CLI is dead on the host.

## Fix

New `src/core/local-daemon.ts` + a routing seam in `cli.ts` right before the local-engine connect:

- **Detection** reads the existing lock file (`<dataDir>/.gbrain-lock/lock`): live pid + `serve --http` argv + `--port N` (default 3131). Dead/corrupt/non-HTTP holders fall through to the unchanged local path.
- **Health** is confirmed with a loopback `GET /health` (1.5s cap) before routing.
- **Auth** is a raw bearer token — `GBRAIN_REMOTE_TOKEN` env, else `<gbrain home>/agents.token` — using the raw-bearer StreamableHTTP pattern from `connect-probe.ts` (`callRemoteTool` is OAuth-only). No token → immediate actionable error instead of the doomed 30s lock wait.
- **Rendering** goes through the same `unpackToolResult` + `formatResult` pair as the thin-client path — renderer parity by data shape. Timeout policy matches ENG-4 (180s `think`, 30s otherwise, `--timeout` wins). SIGINT aborts in-flight HTTP with exit 130.
- `localOnly` ops fall through unchanged: the server hides them, and the existing lock-timeout message already names the daemon pid to stop.

## Testing

- `test/local-daemon.test.ts` — 16 tests pinning holder classification (dead pid, stdio serve, embed, corrupt lock → all null), port parsing, and token precedence.
- `tsc --noEmit` clean; `cli-args` / `connect` / `thin-client-routing-audit` suites pass (139 tests).
- Live: with a launchd daemon holding the lock, `gbrain search` / `gbrain query` return results in ~1s (previously 30s timeout), TTY banner `[local-daemon → 127.0.0.1:3131 · pid N]` shows the route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)