### PR TITLE
fix(storage): Supabase signed URLs — prepend /storage/v1

### DIFF
--- a/src/core/storage/supabase.ts
+++ b/src/core/storage/supabase.ts
@@ -195,7 +195,14 @@ export class SupabaseStorage implements StorageBackend {
       throw new Error(`Supabase signed URL failed: ${res.status} ${body}`);
     }
     const result = await res.json() as { signedURL: string };
-    return `${this.projectUrl}${result.signedURL}`;
+    // Supabase returns `signedURL` relative to the Storage API root, e.g.
+    // "/object/sign/<bucket>/<path>?token=...". Prepend projectUrl + "/storage/v1"
+    // (not just projectUrl) or the link 404s. Tolerate an already-absolute URL or a
+    // value that already carries the /storage/v1 prefix.
+    const signed = result.signedURL;
+    if (/^https?:\/\//.test(signed)) return signed;
+    if (signed.startsWith('/storage/v1')) return `${this.projectUrl}${signed}`;
+    return `${this.projectUrl}/storage/v1${signed.startsWith('/') ? '' : '/'}${signed}`;
   }
 
   async getUrl(path: string): Promise<string> {


### PR DESCRIPTION
## Problem

`gbrain files signed-url` (and any `getUrl` on a private Supabase bucket) returns a link that 404s.

`SupabaseStorage.getSignedUrl` builds the URL as `` `${this.projectUrl}${result.signedURL}` ``. But Supabase's sign endpoint returns `signedURL` **relative to the Storage API root** — e.g. `/object/sign/<bucket>/<path>?token=…`. Prepending only `projectUrl` drops the `/storage/v1` segment, so the result is `https://<proj>.supabase.co/object/sign/…` which resolves to 404. (Upload/list/delete are unaffected — they build the full `/storage/v1/object/...` path directly; only `getSignedUrl` used the API's relative return value.)

## Fix

Prepend `` `${this.projectUrl}/storage/v1` ``, tolerating a value that's already absolute or already carries the prefix:

```ts
const signed = result.signedURL;
if (/^https?:\/\//.test(signed)) return signed;
if (signed.startsWith('/storage/v1')) return `${this.projectUrl}${signed}`;
return `${this.projectUrl}/storage/v1${signed.startsWith('/') ? '' : '/'}${signed}`;
```

## Verification

Against a private bucket: before, the generated URL 404'd; manually inserting `/storage/v1` fetched the object (HTTP 200, correct size + content-type). With this fix, `gbrain files signed-url` produces a directly-resolving link. `bun run typecheck` clean; no `SupabaseStorage` test changes needed (the existing suite doesn't exercise `getSignedUrl`'s URL assembly).

Code-only — VERSION/CHANGELOG left to the maintainer's release flow.