### PR TITLE
fix(embed): allow user-provided-model recipes (llama-server, litellm) to pass dim validation and preflight

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -705,11 +705,16 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
   }
 
   // Openai-compat recipes with empty models list require a user-provided model.
+  // Only reject when the user hasn't actually provided a model name — i.e. the
+  // config says `llama-server:` with no model id after the colon. When a model
+  // id IS present (e.g. `llama-server:bge-m3-mlx-fp16`), the user has fulfilled
+  // the requirement and we should let the embed pipeline proceed.
   const isUserProvided = (tp as any).user_provided_models === true;
   if (
     Array.isArray(tp.models) &&
     tp.models.length === 0 &&
-    (recipe.id === 'litellm' || isUserProvided)
+    (recipe.id === 'litellm' || isUserProvided) &&
+    !parsed.modelId
   ) {
     return {
       ok: false,

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -383,8 +383,11 @@ function validateDimAgainstTouchpoint(
     };
   }
 
-  if (requestedDims !== undefined && requestedDims !== defaultDims) {
+  if (requestedDims !== undefined && requestedDims !== defaultDims && defaultDims !== 0) {
     // User asked for a non-default dim. Walk the precedence chain.
+    // Skip validation when defaultDims === 0 (sentinel for user-provided-model
+    // recipes like llama-server/litellm where the user MUST supply dimensions
+    // and any positive integer is valid).
     const customDimOk = isCustomDimValidForProvider(recipe, modelId, requestedDims, dimsOptions);
     if (!customDimOk.valid) {
       return { ok: false, error: customDimOk.error };

--- a/test/embed-preflight.test.ts
+++ b/test/embed-preflight.test.ts
@@ -118,6 +118,27 @@ describe('validateEmbeddingCreds', () => {
       expect(e.diagnosis.reason).toBe('no_gateway_config');
     }
   });
+
+  // user-provided-model recipes (llama-server, litellm) with a model name
+  // configured must pass preflight — no API key required for local providers.
+
+  test('passes for llama-server with model name configured (no API key needed)', () => {
+    configureGateway(baseConfig({
+      embedding_model: 'llama-server:bge-m3-mlx-fp16',
+      embedding_dimensions: 1024,
+      env: {},
+    }));
+    expect(() => validateEmbeddingCreds()).not.toThrow();
+  });
+
+  test('passes for litellm with model name configured (no API key needed)', () => {
+    configureGateway(baseConfig({
+      embedding_model: 'litellm:my-embedding-model',
+      embedding_dimensions: 768,
+      env: {},
+    }));
+    expect(() => validateEmbeddingCreds()).not.toThrow();
+  });
 });
 
 describe('formatEmbeddingCredsError', () => {

--- a/test/embedding-dim-check.test.ts
+++ b/test/embedding-dim-check.test.ts
@@ -310,6 +310,44 @@ describe('resolveSchemaEmbeddingDim', () => {
       expect(got.model).toBe('openai:text-embedding-3-large');
     }
   });
+
+  // user-provided-model recipes (llama-server, litellm) — default_dims is 0
+  // (sentinel for "user must supply dimensions"). Any positive integer must
+  // be accepted because the recipe has no opinion on the model's native size.
+
+  test('llama-server with explicit dims accepted (user-provided model)', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:bge-m3-mlx-fp16',
+      embedding_dimensions: 1024,
+    });
+    expect(got.ok).toBe(true);
+    if (got.ok) {
+      expect(got.dim).toBe(1024);
+      expect(got.model).toBe('llama-server:bge-m3-mlx-fp16');
+      expect(got.provider).toBe('llama-server');
+    }
+  });
+
+  test('litellm with explicit dims accepted (user-provided model)', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'litellm:my-embedding-model',
+      embedding_dimensions: 768,
+    });
+    expect(got.ok).toBe(true);
+    if (got.ok) {
+      expect(got.dim).toBe(768);
+      expect(got.model).toBe('litellm:my-embedding-model');
+      expect(got.provider).toBe('litellm');
+    }
+  });
+
+  test('llama-server without explicit dims rejected (default_dims=0 is not valid)', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'llama-server:some-model',
+    });
+    expect(got.ok).toBe(false);
+    if (!got.ok) expect(got.error).toMatch(/positive integer/);
+  });
 });
 
 describe('resolveSchemaMultimodalDim', () => {


### PR DESCRIPTION
## Summary

Two bugs make local embedding providers (`llama-server`, `litellm`) completely unusable for embeddings:

- **`embedding-dim-check.ts`**: `validateDimAgainstTouchpoint` rejects any `--embedding-dimensions` value for user-provided-model recipes. `defaultDims` is `0` (sentinel for "user must supply"), so any provided value differs from `0` and triggers Matryoshka validation — which fails because `llama-server`/`litellm` aren't in any known provider allow-list. Fix: skip custom-dim validation when `defaultDims === 0`.

- **`gateway.ts`**: `diagnoseEmbedding` blanket-rejects all user-provided-model recipes with `user_provided_model_unset` even when a model name IS configured (e.g. `llama-server:bge-m3-mlx-fp16`). The check only tested `tp.models.length === 0` without verifying `parsed.modelId`. Fix: add `!parsed.modelId` guard.

Together these prevented `gbrain init --embedding-model llama-server:<model> --embedding-dimensions <N>` and `gbrain embed --stale` from succeeding with any local OpenAI-compatible embedding server.

## Test plan

- [x] Added 3 test cases to `test/embedding-dim-check.test.ts` covering llama-server and litellm dim resolution
- [x] Added 2 test cases to `test/embed-preflight.test.ts` covering llama-server and litellm preflight pass
- [x] All 43 tests pass (38 existing + 5 new)
- [ ] Verify `gbrain init --pglite --embedding-model llama-server:<model> --embedding-dimensions 1024` succeeds
- [ ] Verify `gbrain embed --stale` succeeds with a running llama-server endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)