### PR TITLE
fix: map openrouter_api_key through buildGatewayConfig into gateway env

### DIFF
--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -9,7 +9,7 @@
  * import it from `../../src/cli.ts`.
  *
  * The single ownership site for: (a) folding file-plane API keys
- * (openai/anthropic/zeroentropy) into the gateway env, and (b) threading
+ * (openai/anthropic/zeroentropy/openrouter) into the gateway env, and (b) threading
  * local-server `*_BASE_URL` env vars into base_urls. Both matter for the
  * init-time embedding-key probe — without (a) it would false-warn on
  * config.json-keyed users, and without (b) a live probe could hit the wrong
@@ -34,6 +34,13 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   // plane field now exists (GBrainConfig type) and gets mapped here, so
   // setting it via `~/.gbrain/config.json` propagates into the gateway.
   if (c.zeroentropy_api_key) envFromConfig.ZEROENTROPY_API_KEY = c.zeroentropy_api_key;
+  // openrouter_api_key: OpenRouter recipe declares OPENROUTER_API_KEY as a
+  // required auth_env var. Without this mapping, users who set the key in
+  // ~/.gbrain/config.json find it silently dropped — the recipe's
+  // defaultResolveAuth reads cfg.env[required[0]] which resolves to undefined,
+  // and the gateway skips the recipe with "missing_env". Process env still
+  // wins via the ...process.env spread below.
+  if (c.openrouter_api_key) envFromConfig.OPENROUTER_API_KEY = c.openrouter_api_key;
 
   // v0.32 codex finding #4+#5 fix: thread local-server _BASE_URL env vars
   // into base_urls so the gateway hits the user's configured port. Without

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -41,6 +41,18 @@ export interface GBrainConfig {
    * merge → buildGatewayConfig env dict → recipe reads ZEROENTROPY_API_KEY.
    */
   zeroentropy_api_key?: string;
+  /**
+   * OpenRouter API key. OpenRouter's recipe reads OPENROUTER_API_KEY from the
+   * gateway env at auth-resolve time. `loadConfig` folds the file-plane value
+   * into the config object via the env overlay, and `buildGatewayConfig` maps
+   * it into the gateway env dict. Without this seam, users who set
+   * openrouter_api_key in ~/.gbrain/config.json (rather than exporting it as a
+   * real OS env var) find it silently dropped — the OpenRouter recipe's
+   * `auth_env.required: ['OPENROUTER_API_KEY']` check never sees the key, and
+   * chat-based operations (takes extract, propose_takes) fail with "chat
+   * gateway unavailable (no API key configured)".
+   */
+  openrouter_api_key?: string;
   /** AI gateway config (v0.14+). v0.36+ default: "zeroentropyai:zembed-1" / 1280 / "anthropic:claude-haiku-4-5-20251001". */
   embedding_model?: string;
   embedding_dimensions?: number;
@@ -526,6 +538,7 @@ export function loadConfig(): GBrainConfig | null {
     ...(process.env.OPENAI_API_KEY ? { openai_api_key: process.env.OPENAI_API_KEY } : {}),
     ...(process.env.ANTHROPIC_API_KEY ? { anthropic_api_key: process.env.ANTHROPIC_API_KEY } : {}),
     ...(process.env.ZEROENTROPY_API_KEY ? { zeroentropy_api_key: process.env.ZEROENTROPY_API_KEY } : {}),
+    ...(process.env.OPENROUTER_API_KEY ? { openrouter_api_key: process.env.OPENROUTER_API_KEY } : {}),
     ...(process.env.GBRAIN_EMBEDDING_MODEL ? { embedding_model: process.env.GBRAIN_EMBEDDING_MODEL } : {}),
     ...(process.env.GBRAIN_EMBEDDING_DIMENSIONS ? { embedding_dimensions: parseInt(process.env.GBRAIN_EMBEDDING_DIMENSIONS, 10) } : {}),
     ...(process.env.GBRAIN_EXPANSION_MODEL ? { expansion_model: process.env.GBRAIN_EXPANSION_MODEL } : {}),
@@ -815,6 +828,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'database_path',
   'openai_api_key',
   'anthropic_api_key',
+  'zeroentropy_api_key',
+  'openrouter_api_key',
   'embedding_model',
   'embedding_dimensions',
   'embedding_disabled',


### PR DESCRIPTION
## Summary

`buildGatewayConfig()` in `src/core/ai/build-gateway-config.ts` maps `openai_api_key`, `anthropic_api_key`, and `zeroentropy_api_key` into the gateway environment dict, but **does not map `openrouter_api_key`**. Users who configure their OpenRouter API key in `~/.gbrain/config.json` (file-plane) find it silently dropped.

## Root Cause

Three missing seams:

1. **`GBrainConfig` interface** (`src/core/config.ts`) — no `openrouter_api_key` field to accept the key from file-plane parse
2. **`loadConfig` env overlay** (`src/core/config.ts`) — no `OPENROUTER_API_KEY` to `openrouter_api_key` merge path
3. **`buildGatewayConfig` mapping** (`src/core/ai/build-gateway-config.ts`) — missing the `c.openrouter_api_key` to `OPENROUTER_API_KEY` line

The OpenRouter recipe declares `auth_env.required: ['OPENROUTER_API_KEY']`. When the gateway's `defaultResolveAuth` reads `cfg.env[required[0]]`, it finds `undefined` even though the key exists in `config.json`. The gateway then reports `missing_env` and skips the OpenRouter recipe entirely.

## Symptoms

| Operation | Outcome |
|-----------|---------|
| `gbrain takes extract --from-pages --yes` | Fails with "chat gateway unavailable (no API key configured)" |
| `gbrain dream` propose_takes phase | Runs but produces 0 proposals via chat gateway |
| Embedding via OpenAI recipe | Works (uses OPENAI_API_KEY, which IS mapped) |
| MCP server sessions | Work (inherits real OS env vars) |

## Workaround

Set `OPENROUTER_API_KEY` as a real OS environment variable (in `~/.bashrc`, `~/.zshrc`, or the process launcher). This bypasses the file-plane gap because `process.env` is spread into the gateway env dict last.

## Fix

PR: https://github.com/psam-717/gbrain/pull/new/fix/openrouter-api-key-gateway

Adds `openrouter_api_key` to all three seams following the same pattern as `zeroentropy_api_key` (v0.37 fix wave).
