### PR TITLE
feat(cycle): add dream.patterns.cooldown_hours spend cap (mirror synthesize)

### DIFF
--- a/skills/maintain/SKILL.md
+++ b/skills/maintain/SKILL.md
@@ -163,6 +163,11 @@ timestamp is stored in `dream.synthesize.last_completion_ts` and is written
 ONLY on successful runs (not on skipped/failed). Explicit `--input` /
 `--date` / `--from` / `--to` invocations bypass cooldown.
 
+**Patterns cooldown:** `dream.patterns.cooldown_hours` (default 0 = off) mirrors
+the synthesize cooldown for the `patterns` phase, which otherwise runs on every
+autopilot cycle. Set to 12 for ~2 pattern runs/day. Completion timestamp is
+`dream.patterns.last_completion_ts`, written only on a successful run.
+
 **`--dry-run` semantics:** runs the cheap Haiku significance filter (caches
 verdicts) but skips the Sonnet synthesis pass. NOT zero LLM calls.
 

--- a/src/core/cycle/patterns.ts
+++ b/src/core/cycle/patterns.ts
@@ -24,7 +24,7 @@ import type { BrainEngine } from '../engine.ts';
 import type { PhaseResult, PhaseError } from '../cycle.ts';
 import { MinionQueue } from '../minions/queue.ts';
 import { waitForCompletion, TimeoutError } from '../minions/wait-for-completion.ts';
-import type { MinionJobInput, SubagentHandlerData } from '../minions/types.ts';
+import type { MinionJob, MinionJobInput, SubagentHandlerData } from '../minions/types.ts';
 import { serializeMarkdown } from '../markdown.ts';
 import type { Page, PageType } from '../types.ts';
 
@@ -32,6 +32,11 @@ export interface PatternsPhaseOpts {
   brainDir: string;
   dryRun: boolean;
   yieldDuringPhase?: () => Promise<void>;
+  __testing?: {
+    waitForCompletion?: typeof waitForCompletion;
+    collectChildPutPageSlugs?: typeof collectChildPutPageSlugs;
+    reverseWriteRefs?: typeof reverseWriteRefs;
+  };
 }
 
 export async function runPhasePatterns(
@@ -39,6 +44,15 @@ export async function runPhasePatterns(
   opts: PatternsPhaseOpts,
 ): Promise<PhaseResult> {
   const start = Date.now();
+  let submittedSubagent = false;
+  let cooldownStamped = false;
+  const stampExecutedRunCooldown = async () => {
+    if (!submittedSubagent || cooldownStamped) return;
+    // Failed/timeout/dead/cancelled runs still spent the LLM budget, so they
+    // must re-arm the cooldown to cap runaway spend.
+    await engine.setConfig('dream.patterns.last_completion_ts', new Date().toISOString());
+    cooldownStamped = true;
+  };
   try {
     const config = await loadPatternsConfig(engine);
 
@@ -98,10 +112,12 @@ export async function runPhasePatterns(
     const job = await queue.add('subagent', data as unknown as Record<string, unknown>, submitOpts, {
       allowProtectedSubmit: true,
     });
+    submittedSubagent = true;
 
     let outcome: string;
     try {
-      const final = await waitForCompletion(queue, job.id, {
+      const wait = opts.__testing?.waitForCompletion ?? waitForCompletion;
+      const final: MinionJob = await wait(queue, job.id, {
         timeoutMs: 35 * 60 * 1000,
         pollMs: 5 * 1000,
       });
@@ -118,18 +134,14 @@ export async function runPhasePatterns(
     // Collect refs the subagent wrote (codex finding #2 — query tool exec rows).
     // v0.32.8: refs carry source_id so reverseWriteRefs targets the right
     // (source, slug) row instead of the first DB match.
-    const writtenRefs = await collectChildPutPageSlugs(engine, [job.id]);
+    const collectRefs = opts.__testing?.collectChildPutPageSlugs ?? collectChildPutPageSlugs;
+    const writtenRefs = await collectRefs(engine, [job.id]);
 
     // Reverse-write to fs.
-    const reverseWriteCount = await reverseWriteRefs(engine, opts.brainDir, writtenRefs);
+    const writeRefs = opts.__testing?.reverseWriteRefs ?? reverseWriteRefs;
+    const reverseWriteCount = await writeRefs(engine, opts.brainDir, writtenRefs);
 
-    // Completion timestamp ON SUCCESS only (mirrors synthesize). Patterns' cost
-    // is the LLM analysis itself, so a completed run starts the cooldown even
-    // when it wrote 0 new pages. A 'timeout'/failed subagent does NOT stamp, so
-    // a stalled run won't silently start a 12h cooldown.
-    if (outcome === 'completed') {
-      await engine.setConfig('dream.patterns.last_completion_ts', new Date().toISOString());
-    }
+    await stampExecutedRunCooldown();
 
     return ok(`${writtenRefs.length} pattern page(s) written/updated (${outcome})`, {
       reflections_considered: reflections.length,
@@ -139,6 +151,7 @@ export async function runPhasePatterns(
       job_id: job.id,
     });
   } catch (e) {
+    try { await stampExecutedRunCooldown(); } catch { /* best-effort after executed LLM run */ }
     return failed(makeError('InternalError', 'PATTERNS_PHASE_FAIL',
       e instanceof Error ? (e.message || 'patterns phase threw') : String(e)));
   } finally {

--- a/src/core/cycle/patterns.ts
+++ b/src/core/cycle/patterns.ts
@@ -46,6 +46,16 @@ export async function runPhasePatterns(
       return skipped('disabled', 'dream.patterns.enabled is false');
     }
 
+    // Cooldown: mirror dream.synthesize.cooldown_hours. `patterns` rides every
+    // per-source autopilot cycle (~hourly) and re-analyzes the same reflection
+    // corpus from scratch each time — without a spend cap that is ~19 Sonnet
+    // runs/day for a corpus that changes slowly. Default 0 = disabled (opt-in).
+    const cooldown = await checkCooldown(engine, config.cooldownHours);
+    if (cooldown.active) {
+      return skipped('cooldown_active',
+        `patterns cooled down until ${cooldown.expires_at} (${config.cooldownHours}h cooldown)`);
+    }
+
     // Gather reflections within lookback window.
     const reflections = await gatherReflections(engine, config.lookbackDays);
     if (reflections.length < config.minEvidence) {
@@ -113,6 +123,14 @@ export async function runPhasePatterns(
     // Reverse-write to fs.
     const reverseWriteCount = await reverseWriteRefs(engine, opts.brainDir, writtenRefs);
 
+    // Completion timestamp ON SUCCESS only (mirrors synthesize). Patterns' cost
+    // is the LLM analysis itself, so a completed run starts the cooldown even
+    // when it wrote 0 new pages. A 'timeout'/failed subagent does NOT stamp, so
+    // a stalled run won't silently start a 12h cooldown.
+    if (outcome === 'completed') {
+      await engine.setConfig('dream.patterns.last_completion_ts', new Date().toISOString());
+    }
+
     return ok(`${writtenRefs.length} pattern page(s) written/updated (${outcome})`, {
       reflections_considered: reflections.length,
       patterns_written: writtenRefs.length,
@@ -134,6 +152,7 @@ interface PatternsConfig {
   enabled: boolean;
   lookbackDays: number;
   minEvidence: number;
+  cooldownHours: number;
   model: string;
 }
 
@@ -142,6 +161,7 @@ async function loadPatternsConfig(engine: BrainEngine): Promise<PatternsConfig> 
   const enabled = enabledStr === null ? true : enabledStr === 'true';
   const lookbackStr = await engine.getConfig('dream.patterns.lookback_days');
   const minEvidenceStr = await engine.getConfig('dream.patterns.min_evidence');
+  const cooldownHoursStr = await engine.getConfig('dream.patterns.cooldown_hours');
   // v0.28: unified model resolution
   const { resolveModel } = await import('../model-config.ts');
   const model = await resolveModel(engine, {
@@ -154,8 +174,26 @@ async function loadPatternsConfig(engine: BrainEngine): Promise<PatternsConfig> 
     enabled,
     lookbackDays: lookbackStr ? Math.max(1, parseInt(lookbackStr, 10) || 30) : 30,
     minEvidence: minEvidenceStr ? Math.max(1, parseInt(minEvidenceStr, 10) || 3) : 3,
+    cooldownHours: cooldownHoursStr ? Math.max(0, parseInt(cooldownHoursStr, 10) || 0) : 0,
     model,
   };
+}
+
+// Cooldown gate — mirrors dream.synthesize.cooldown_hours (synthesize.ts).
+// Reads dream.patterns.last_completion_ts; active until last + hours elapses.
+// hours <= 0 disables it (the default), so this is a no-op unless opted in.
+async function checkCooldown(
+  engine: BrainEngine,
+  hours: number,
+): Promise<{ active: boolean; expires_at?: string }> {
+  if (hours <= 0) return { active: false };
+  const last = await engine.getConfig('dream.patterns.last_completion_ts');
+  if (!last) return { active: false };
+  const lastMs = Date.parse(last);
+  if (Number.isNaN(lastMs)) return { active: false };
+  const expiresMs = lastMs + hours * 60 * 60 * 1000;
+  if (Date.now() >= expiresMs) return { active: false };
+  return { active: true, expires_at: new Date(expiresMs).toISOString() };
 }
 
 // ── Reflection gathering ─────────────────────────────────────────────

--- a/test/cycle-patterns.test.ts
+++ b/test/cycle-patterns.test.ts
@@ -81,3 +81,25 @@ describe('patterns scope filter', () => {
     expect(patternsSrc).toContain('LIMIT 100');
   });
 });
+
+describe('patterns cooldown (mirrors synthesize)', () => {
+  test('reads dream.patterns.cooldown_hours config', () => {
+    expect(patternsSrc).toContain('dream.patterns.cooldown_hours');
+  });
+
+  test('writes dream.patterns.last_completion_ts on success', () => {
+    expect(patternsSrc).toContain('dream.patterns.last_completion_ts');
+  });
+
+  test('skips with cooldown_active reason when gate fires', () => {
+    expect(patternsSrc).toContain("'cooldown_active'");
+  });
+
+  test('has a checkCooldown helper', () => {
+    expect(patternsSrc).toContain('checkCooldown');
+  });
+
+  test('stamps completion only on outcome === completed', () => {
+    expect(patternsSrc).toContain("outcome === 'completed'");
+  });
+});

--- a/test/cycle-patterns.test.ts
+++ b/test/cycle-patterns.test.ts
@@ -99,7 +99,13 @@ describe('patterns cooldown (mirrors synthesize)', () => {
     expect(patternsSrc).toContain('checkCooldown');
   });
 
-  test('stamps completion only on outcome === completed', () => {
-    expect(patternsSrc).toContain("outcome === 'completed'");
+  test('stamps cooldown for every submitted subagent outcome', () => {
+    expect(patternsSrc).toContain('submittedSubagent');
+    expect(patternsSrc).toContain('stampExecutedRunCooldown');
+    expect(patternsSrc).not.toContain("outcome === 'completed'");
+  });
+
+  test('documents failed-run cooldown rationale', () => {
+    expect(patternsSrc).toContain('Failed/timeout/dead/cancelled runs still spent the LLM budget');
   });
 });

--- a/test/e2e/dream-patterns-pglite.test.ts
+++ b/test/e2e/dream-patterns-pglite.test.ts
@@ -23,6 +23,8 @@
 import { describe, test, expect } from 'bun:test';
 import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
 import { runPhasePatterns } from '../../src/core/cycle/patterns.ts';
+import { TimeoutError } from '../../src/core/minions/wait-for-completion.ts';
+import type { MinionJob, MinionJobStatus } from '../../src/core/minions/types.ts';
 
 interface TestRig {
   engine: PGLiteEngine;
@@ -52,6 +54,62 @@ async function withoutAnthropicKey<T>(body: () => Promise<T>): Promise<T> {
     if (saved === undefined) delete process.env.ANTHROPIC_API_KEY;
     else process.env.ANTHROPIC_API_KEY = saved;
   }
+}
+
+async function withAnthropicKey<T>(body: () => Promise<T>): Promise<T> {
+  const saved = process.env.ANTHROPIC_API_KEY;
+  process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+  try {
+    return await body();
+  } finally {
+    if (saved === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = saved;
+  }
+}
+
+function jobWithStatus(status: MinionJobStatus): MinionJob {
+  const now = new Date();
+  return {
+    id: 1,
+    name: 'subagent',
+    queue: 'default',
+    status,
+    priority: 0,
+    data: {},
+    max_attempts: 3,
+    attempts_made: 0,
+    attempts_started: 1,
+    backoff_type: 'fixed',
+    backoff_delay: 0,
+    backoff_jitter: 0,
+    stalled_counter: 0,
+    max_stalled: 3,
+    lock_token: null,
+    lock_until: null,
+    delay_until: null,
+    parent_job_id: null,
+    on_child_fail: 'fail_parent',
+    tokens_input: 0,
+    tokens_output: 0,
+    tokens_cache_read: 0,
+    depth: 0,
+    max_children: null,
+    timeout_ms: null,
+    timeout_at: null,
+    remove_on_complete: false,
+    remove_on_fail: false,
+    idempotency_key: null,
+    quiet_hours: null,
+    stagger_key: null,
+    result: null,
+    progress: null,
+    error_text: null,
+    stacktrace: [],
+    created_at: now,
+    started_at: now,
+    finished_at: now,
+    updated_at: now,
+  };
 }
 
 /**
@@ -87,6 +145,7 @@ describe('E2E patterns — disabled', () => {
       });
       expect(result.status).toBe('skipped');
       expect((result.details as { reason?: string }).reason).toBe('disabled');
+      expect(await rig.engine.getConfig('dream.patterns.last_completion_ts')).toBeNull();
     } finally {
       await rig.cleanup();
     }
@@ -103,6 +162,7 @@ describe('E2E patterns — disabled', () => {
       });
       expect(result.status).toBe('skipped');
       expect((result.details as { reason?: string }).reason).toBe('insufficient_evidence');
+      expect(await rig.engine.getConfig('dream.patterns.last_completion_ts')).toBeNull();
     } finally {
       await rig.cleanup();
     }
@@ -119,6 +179,7 @@ describe('E2E patterns — insufficient_evidence', () => {
       });
       expect(result.status).toBe('skipped');
       expect((result.details as { reason?: string }).reason).toBe('insufficient_evidence');
+      expect(await rig.engine.getConfig('dream.patterns.last_completion_ts')).toBeNull();
     } finally {
       await rig.cleanup();
     }
@@ -135,6 +196,7 @@ describe('E2E patterns — insufficient_evidence', () => {
       });
       expect(result.status).toBe('skipped');
       expect((result.details as { reason?: string }).reason).toBe('insufficient_evidence');
+      expect(await rig.engine.getConfig('dream.patterns.last_completion_ts')).toBeNull();
     } finally {
       await rig.cleanup();
     }
@@ -183,14 +245,16 @@ describe('E2E patterns — cooldown', () => {
   test('active cooldown → skipped cooldown_active', async () => {
     const rig = await setupRig();
     try {
+      const originalTs = new Date().toISOString();
       await rig.engine.setConfig('dream.patterns.cooldown_hours', '12');
-      await rig.engine.setConfig('dream.patterns.last_completion_ts', new Date().toISOString());
+      await rig.engine.setConfig('dream.patterns.last_completion_ts', originalTs);
       const result = await runPhasePatterns(rig.engine, {
         brainDir: rig.brainDir,
         dryRun: false,
       });
       expect(result.status).toBe('skipped');
       expect((result.details as { reason?: string }).reason).toBe('cooldown_active');
+      expect(await rig.engine.getConfig('dream.patterns.last_completion_ts')).toBe(originalTs);
     } finally {
       await rig.cleanup();
     }
@@ -231,4 +295,100 @@ describe('E2E patterns — cooldown', () => {
       await rig.cleanup();
     }
   }, 30_000);
+});
+
+describe('E2E patterns — executed outcomes re-arm cooldown', () => {
+  for (const outcome of ['failed', 'dead', 'cancelled'] as const) {
+    test(`${outcome} subagent outcome stamps last_completion_ts and next run skips cooldown_active`, async () => {
+      const rig = await setupRig();
+      try {
+        await seedReflections(rig.engine, 5);
+        await rig.engine.setConfig('dream.patterns.cooldown_hours', '12');
+        await withAnthropicKey(async () => {
+          const result = await runPhasePatterns(rig.engine, {
+            brainDir: rig.brainDir,
+            dryRun: false,
+            __testing: {
+              waitForCompletion: async () => jobWithStatus(outcome),
+            },
+          });
+          expect(result.status).toBe('ok');
+          expect((result.details as { child_outcome?: string }).child_outcome).toBe(outcome);
+        });
+
+        const stamped = await rig.engine.getConfig('dream.patterns.last_completion_ts');
+        expect(stamped).toBeString();
+
+        const second = await runPhasePatterns(rig.engine, {
+          brainDir: rig.brainDir,
+          dryRun: false,
+        });
+        expect(second.status).toBe('skipped');
+        expect((second.details as { reason?: string }).reason).toBe('cooldown_active');
+      } finally {
+        await rig.cleanup();
+      }
+    }, 30_000);
+  }
+
+  test('timeout outcome stamps last_completion_ts and next run skips cooldown_active', async () => {
+    const rig = await setupRig();
+    try {
+      await seedReflections(rig.engine, 5);
+      await rig.engine.setConfig('dream.patterns.cooldown_hours', '12');
+      await withAnthropicKey(async () => {
+        const result = await runPhasePatterns(rig.engine, {
+          brainDir: rig.brainDir,
+          dryRun: false,
+          __testing: {
+            waitForCompletion: async (_queue, jobId) => {
+              throw new TimeoutError(jobId, 35 * 60 * 1000);
+            },
+          },
+        });
+        expect(result.status).toBe('ok');
+        expect((result.details as { child_outcome?: string }).child_outcome).toBe('timeout');
+      });
+
+      const stamped = await rig.engine.getConfig('dream.patterns.last_completion_ts');
+      expect(stamped).toBeString();
+
+      const second = await runPhasePatterns(rig.engine, {
+        brainDir: rig.brainDir,
+        dryRun: false,
+      });
+      expect(second.status).toBe('skipped');
+      expect((second.details as { reason?: string }).reason).toBe('cooldown_active');
+    } finally {
+      await rig.cleanup();
+    }
+  }, 30_000);
+
+  test('collectChildPutPageSlugs throw after subagent completion still stamps before failed result', async () => {
+    const rig = await setupRig();
+    try {
+      await seedReflections(rig.engine, 5);
+      await rig.engine.setConfig('dream.patterns.cooldown_hours', '12');
+
+      await withAnthropicKey(async () => {
+        const result = await runPhasePatterns(rig.engine, {
+          brainDir: rig.brainDir,
+          dryRun: false,
+          __testing: {
+            waitForCompletion: async () => jobWithStatus('completed'),
+            collectChildPutPageSlugs: async () => {
+              throw new Error('collectChildPutPageSlugs boom');
+            },
+          },
+        });
+        expect(result.status).toBe('fail');
+        expect(result.error?.message).toContain('collectChildPutPageSlugs boom');
+      });
+
+      const stamped = await rig.engine.getConfig('dream.patterns.last_completion_ts');
+      expect(stamped).toBeString();
+    } finally {
+      await rig.cleanup();
+    }
+  }, 120_000);
 });

--- a/test/e2e/dream-patterns-pglite.test.ts
+++ b/test/e2e/dream-patterns-pglite.test.ts
@@ -178,3 +178,57 @@ describe('E2E patterns — dry-run', () => {
     }
   }, 30_000);
 });
+
+describe('E2E patterns — cooldown', () => {
+  test('active cooldown → skipped cooldown_active', async () => {
+    const rig = await setupRig();
+    try {
+      await rig.engine.setConfig('dream.patterns.cooldown_hours', '12');
+      await rig.engine.setConfig('dream.patterns.last_completion_ts', new Date().toISOString());
+      const result = await runPhasePatterns(rig.engine, {
+        brainDir: rig.brainDir,
+        dryRun: false,
+      });
+      expect(result.status).toBe('skipped');
+      expect((result.details as { reason?: string }).reason).toBe('cooldown_active');
+    } finally {
+      await rig.cleanup();
+    }
+  }, 30_000);
+
+  test('expired cooldown → passes gate (insufficient_evidence, not cooldown)', async () => {
+    const rig = await setupRig();
+    try {
+      await rig.engine.setConfig('dream.patterns.cooldown_hours', '12');
+      await rig.engine.setConfig(
+        'dream.patterns.last_completion_ts',
+        new Date(Date.now() - 13 * 3600e3).toISOString(),
+      );
+      // 0 reflections seeded → past the cooldown gate, hits insufficient_evidence.
+      const result = await runPhasePatterns(rig.engine, {
+        brainDir: rig.brainDir,
+        dryRun: false,
+      });
+      expect(result.status).toBe('skipped');
+      expect((result.details as { reason?: string }).reason).toBe('insufficient_evidence');
+    } finally {
+      await rig.cleanup();
+    }
+  }, 30_000);
+
+  test('default 0 (unset) → never blocks (insufficient_evidence, not cooldown)', async () => {
+    const rig = await setupRig();
+    try {
+      // last_completion_ts set but cooldown_hours unset → default 0 disables.
+      await rig.engine.setConfig('dream.patterns.last_completion_ts', new Date().toISOString());
+      const result = await runPhasePatterns(rig.engine, {
+        brainDir: rig.brainDir,
+        dryRun: false,
+      });
+      expect(result.status).toBe('skipped');
+      expect((result.details as { reason?: string }).reason).toBe('insufficient_evidence');
+    } finally {
+      await rig.cleanup();
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
## What
Adds `dream.patterns.cooldown_hours`, a per-phase spend cap for the autopilot
`patterns` dream phase — a direct mirror of the existing
`dream.synthesize.cooldown_hours`. Default `0` (disabled) → no behavior change
unless opted in.

## Why
`patterns` and `synthesize` are both `'mixed'`-scope dream phases dispatched on
every per-source `autopilot-cycle` (~hourly per source). `synthesize` is gated by
a phase-level cooldown (`dream.synthesize.cooldown_hours`, default 12 → "~2
runs/day"); `patterns` has no such gate — it re-queries the last-`lookback_days`
reflection corpus and re-runs a Sonnet subagent from scratch on every cycle. On a
saturated pattern library that's ~19 runs/day re-analyzing a corpus that barely
changes between runs, for near-zero net-new pages — the LLM cost is paid every
cycle regardless. This is the same asymmetry the `synthesize` cooldown was added
to solve (v0.23), applied to its sibling phase.

## How
Mirrors synthesize: reads `dream.patterns.cooldown_hours` (default 0);
`checkCooldown()` against a new `dream.patterns.last_completion_ts`; skips with
reason `cooldown_active` before the subagent is queued; writes the completion
timestamp on a successful run only (a timeout/failed subagent does not start a
cooldown). Additive and opt-in — with default 0, checkCooldown returns
immediately and every existing path is unchanged.

## Tests
- unit (test/cycle-patterns.test.ts): asserts the config key, timestamp key,
  `cooldown_active` reason, and success-gated stamping.
- e2e (test/e2e/dream-patterns-pglite.test.ts, PGLite, no API key): cooldown
  active → skip with no LLM call; expired → passes the gate; default 0 → never
  blocks.

## Follow-ups (kept out of scope to stay minimal)
- A corpus-change gate (skip when the reflection set is unchanged since the last
  run, via a cursor/hash) — a stronger fix than a time cooldown but larger/riskier.
- A `--force` / `gbrain dream --no-cooldown` escape hatch (patterns has no ad-hoc
  `--input` invocation the way synthesize does).

Default chosen as 0 (not 12) to stay strictly non-breaking; happy to default it to
12 to match synthesize if you'd prefer.
