### PR TITLE
fix(budget): let deliberately-unpriced providers (openrouter:*) run under --max-cost

### DIFF
--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -156,6 +156,21 @@ const FREE_LOCAL_EMBED_PROVIDERS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Provider id prefixes that are deliberately absent from the native pricing
+ * tables because the provider meters billing itself at its own rates —
+ * OpenRouter today (its markup != native pricing, so a table entry would
+ * lie). Unlike the FREE_LOCAL_* sets these are NOT free, so they never
+ * price at $0. Instead, a `--max-cost` reserve() falls through to the
+ * existing warn-once path: the cap cannot meter what the tables cannot
+ * price, and a TX2 hard-fail makes `--max-cost` unusable for every
+ * OpenRouter-routed command. Matched against the provider half of the
+ * `provider:model` / `provider/model` string.
+ */
+const CAP_EXEMPT_UNPRICED_PROVIDERS: ReadonlySet<string> = new Set([
+  'openrouter',
+]);
+
+/**
  * Look up `modelId` in the chat or embedding pricing maps. Returns a
  * per-1M-token price tuple, or null when unknown.
  *
@@ -254,7 +269,9 @@ export class BudgetTracker {
    * BEFORE any provider call when:
    *   - cumulative + projected > maxCostUsd (reason: 'cost')
    *   - wall-clock > maxRuntimeMs (reason: 'runtime')
-   *   - maxCostUsd set AND pricing missing (reason: 'no_pricing') -- TX2
+   *   - maxCostUsd set AND pricing missing (reason: 'no_pricing') -- TX2,
+   *     unless the provider is deliberately unpriced
+   *     (CAP_EXEMPT_UNPRICED_PROVIDERS) — those fall to the warn-once path.
    *
    * When maxCostUsd is unset, missing pricing warns-once but does not throw
    * (legacy behavior preserved for non-priced providers).
@@ -270,10 +287,13 @@ export class BudgetTracker {
     );
 
     if (projected === null) {
-      if (this.opts.maxCostUsd !== undefined) {
+      const { provider: unpricedProvider } = splitProviderModelId(estimate.modelId);
+      const capExemptUnpriced = !!unpricedProvider && CAP_EXEMPT_UNPRICED_PROVIDERS.has(unpricedProvider);
+      if (this.opts.maxCostUsd !== undefined && !capExemptUnpriced) {
         // TX2: hard-fail when a cap is set but pricing is missing — without
         // pricing we can't enforce the cap, and silently ignoring it would
-        // void the contract.
+        // void the contract. Deliberately-unpriced providers
+        // (CAP_EXEMPT_UNPRICED_PROVIDERS) fall through to warn-once instead.
         const msg = `${this.opts.label}: no pricing entry for model "${estimate.modelId}" (kind=${estimate.kind}). ` +
           `Add it to src/core/${estimate.kind === 'embed' ? 'embedding-pricing.ts' : 'anthropic-pricing.ts'} or drop --max-cost.`;
         this.fireExhausted();

--- a/test/core/budget/budget-tracker.test.ts
+++ b/test/core/budget/budget-tracker.test.ts
@@ -138,6 +138,43 @@ describe('BudgetTracker.reserve', () => {
     expect((caught as Error).message).toMatch(/anthropic-pricing\.ts/);
   });
 
+  test('cap-exempt unpriced provider (openrouter:*) under --max-cost falls to warn-once, no throw', () => {
+    // OpenRouter ids are deliberately unpriced in the native tables (the
+    // provider bills at its own marked-up rates, so a table entry would lie).
+    // Pre-fix, ANY --max-cost run routed through OpenRouter TX2 hard-failed
+    // before its first LLM call. The cap stays a hard ceiling for priced
+    // models; deliberately-unpriced providers degrade to warn-once.
+    const t = new BudgetTracker({ maxCostUsd: 5.0, label: 'test', auditPath });
+    expect(() =>
+      t.reserve({
+        modelId: 'openrouter:deepseek/deepseek-chat',
+        estimatedInputTokens: 100,
+        maxOutputTokens: 100,
+        kind: 'chat',
+      }),
+    ).not.toThrow();
+    expect(stderrCapture).toMatch(/BUDGET_TRACKER_NO_PRICING/);
+    const audit = readAudit();
+    expect(audit[0].event).toBe('reserve_unpriced');
+  });
+
+  test('non-exempt unknown provider under --max-cost still TX2 hard-fails (regression guard)', () => {
+    const t = new BudgetTracker({ maxCostUsd: 5.0, label: 'test', auditPath });
+    let caught: unknown = null;
+    try {
+      t.reserve({
+        modelId: 'mystery:campfire-72b',
+        estimatedInputTokens: 100,
+        maxOutputTokens: 100,
+        kind: 'chat',
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(BudgetExhausted);
+    expect((caught as BudgetExhausted).reason).toBe('no_pricing');
+  });
+
   test('v0.41.20.0: slash-prefix anthropic/claude-* under --max-cost does NOT no_pricing throw (THE FIX)', () => {
     // Pre-v0.41.20.0: lookupPricing only split modelId on ':'. CLI users
     // running `gbrain brainstorm --judge-model anthropic/claude-sonnet-4-6


### PR DESCRIPTION
### Problem

TX2 hard-fails `reserve()` when a cost cap is set and the model is absent from
the native pricing tables. OpenRouter ids are deliberately unpriced there (the
provider bills at its own marked-up rates, so a table entry would lie), which
makes every `--max-cost` run routed through OpenRouter fail before its first
LLM call.

### Change

`CAP_EXEMPT_UNPRICED_PROVIDERS`: a sibling of the FREE_LOCAL_* sets, but NOT
zero-priced, because these are paid providers the tables cannot honestly
meter. Ids whose provider half is in the set fall through to the existing
warn-once path instead of the TX2 throw. Every other unknown model still
hard-fails.

### Tests

Two new cases in `test/core/budget/budget-tracker.test.ts`: openrouter:* under
--max-cost reserves via the warn-once path and writes a reserve_unpriced audit
row; an unknown non-exempt provider still throws no_pricing (regression
guard). 28/28 green; verify 31/31; typecheck clean.

### Context

Hit in production at Memini, where chat/embed traffic is OpenRouter-routed and
every capped brainstorm died at TX2. Carried as a vendored patch since 0.42.40.