### PR TITLE
feat(cycle): accept UUID source ids at the cycle lock via a slug-legal derived token

### DIFF
--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -508,6 +508,14 @@ export interface LockHandle {
 }
 
 /**
+ * Canonical (lowercase) RFC 4122 UUID. A 36-char UUID breaks the 32-char
+ * slug rule at the lock id, but hyphen-stripped it is slug-legal by
+ * construction (32 lowercase hex chars, alnum edges). Uppercase or
+ * otherwise non-canonical UUIDs deliberately stay invalid.
+ */
+const UUID_SOURCE_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
  * Compute the cycle lock ID for a given source.
  *
  * - `undefined` returns the legacy `'gbrain-cycle'` ID, preserving
@@ -520,11 +528,22 @@ export interface LockHandle {
  * - Valid IDs return `'gbrain-cycle:<source_id>'` so per-source cycles
  *   acquire distinct rows in `gbrain_cycle_locks` and don't serialize
  *   through one global lock.
+ * - A canonical (lowercase) RFC 4122 UUID — the common tenant-key shape
+ *   when gbrain is embedded as a library — derives a slug-legal lock token
+ *   by stripping hyphens: exactly 32 lowercase hex chars, stable, and still
+ *   recognizable next to the raw id in logs. The raw sourceId stays the
+ *   data key everywhere else; only the lock id (and, on PGLite, the lock
+ *   file path component) uses the derived token.
  *
- * @throws if `sourceId` is provided but invalid per `source-id.ts`.
+ * @throws if `sourceId` is provided but is neither a valid slug per
+ *   `source-id.ts` nor a canonical UUID (codex r2 P1-B defense-in-depth
+ *   unchanged for every other shape).
  */
 export function cycleLockIdFor(sourceId?: string): string {
   if (sourceId === undefined) return LEGACY_CYCLE_LOCK_ID;
+  if (UUID_SOURCE_ID_RE.test(sourceId)) {
+    return `${LEGACY_CYCLE_LOCK_ID}:${sourceId.replaceAll('-', '')}`;
+  }
   assertValidSourceId(sourceId);
   return `${LEGACY_CYCLE_LOCK_ID}:${sourceId}`;
 }

--- a/test/cycle-lock-per-source.test.ts
+++ b/test/cycle-lock-per-source.test.ts
@@ -44,6 +44,29 @@ describe('cycleLockIdFor', () => {
     expect(cycleLockIdFor()).not.toBe(cycleLockIdFor('legacy'));
   });
 
+  describe('UUID source ids (embedder tenant keys)', () => {
+    test('canonical UUID derives a slug-legal lock token by stripping hyphens', () => {
+      // A multi-tenant embedder's sourceId is a user UUID: 36 chars breaks
+      // the slug rule at the lock, so every such cycle died at acquisition.
+      // Hyphen-stripped it is exactly 32 lowercase hex chars — slug-legal.
+      expect(cycleLockIdFor('550e8400-e29b-41d4-a716-446655440000')).toBe(
+        'gbrain-cycle:550e8400e29b41d4a716446655440000',
+      );
+    });
+
+    test('distinct UUIDs produce distinct lock ids, none colliding with legacy', () => {
+      const a = cycleLockIdFor('550e8400-e29b-41d4-a716-446655440000');
+      const b = cycleLockIdFor('123e4567-e89b-42d3-a456-426614174000');
+      expect(a).not.toBe(b);
+      expect(a).not.toBe('gbrain-cycle');
+      expect(b).not.toBe('gbrain-cycle');
+    });
+
+    test('non-canonical (uppercase) UUIDs still throw', () => {
+      expect(() => cycleLockIdFor('550E8400-E29B-41D4-A716-446655440000')).toThrow();
+    });
+  });
+
   describe('internal validation (codex r2 P1-B)', () => {
     test('throws on path-traversal shapes', () => {
       expect(() => cycleLockIdFor('../etc')).toThrow();


### PR DESCRIPTION
### Problem

`cycleLockIdFor` validates sourceId as a 1-32 lowercase slug. When gbrain is
embedded as a library in a multi-tenant service, sourceId is a tenant key: an
RFC 4122 UUID, 36 characters. Every per-source nightly cycle died at lock
acquisition (status='failed', reason='lock_acquisition_error') before its
first phase ran. Nobody dreamed that night.

### Change

A canonical lowercase UUID stripped of hyphens is exactly 32 lowercase hex
chars: slug-legal by construction, stable, and still recognizable next to the
raw id in logs. `cycleLockIdFor` derives the LOCK id that way; the raw
sourceId stays the data key everywhere else.

Deliberately narrow: every other non-slug shape still throws. The codex r2
P1-B defense-in-depth block (path traversal, whitespace, underscores,
uppercase, length, empty) is untouched and green; uppercase UUIDs also still
throw (canonical lowercase only).

### Tests

New describe block in `test/cycle-lock-per-source.test.ts`: derivation,
distinctness, non-canonical rejection. 44/44 green across the three files that
exercise cycleLockIdFor; verify 31/31; typecheck clean.

### Context

This is the patch we carry in production at Memini (a multi-tenant consumer
app built on gbrain). Full field notes coming as a write-up.