### PR TITLE
fix(recipes): per-model embedding dims — unblocks ollama mxbai/all-minilm/bge-m3

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,6 +10,7 @@ import { saveConfig, loadConfig, loadConfigFileOnly, toEngineConfig, gbrainPath,
 import { createEngine } from '../core/engine-factory.ts';
 import { discoverOAuth, mintClientCredentialsToken, smokeTestMcp } from '../core/remote-mcp-probe.ts';
 import { runInitEmbedCheck } from '../core/init-embed-check.ts';
+import { defaultDimsForModel } from '../core/ai/dims.ts';
 
 export async function runInit(args: string[]) {
   // Help guard: cli.ts only routes --help to printOpHelp() for shared-op
@@ -246,7 +247,7 @@ async function resolveAIOptions(opts: ResolveAIOptionsArgs): Promise<ResolvedAIO
       process.exit(1);
     }
     out.embedding_model = `${shorthand}:${firstModel}`;
-    out.embedding_dimensions = recipe.touchpoints.embedding!.default_dims;
+    out.embedding_dimensions = defaultDimsForModel(recipe.touchpoints.embedding!, firstModel);
   }
 
   if (dimsArg !== null && !Number.isNaN(dimsArg) && dimsArg > 0) {
@@ -271,7 +272,8 @@ async function resolveAIOptions(opts: ResolveAIOptionsArgs): Promise<ResolvedAIO
       process.exit(1);
     }
     if (recipe?.touchpoints.embedding?.default_dims) {
-      out.embedding_dimensions = recipe.touchpoints.embedding.default_dims;
+      const modelId = out.embedding_model.split(':').slice(1).join(':');
+      out.embedding_dimensions = defaultDimsForModel(recipe.touchpoints.embedding, modelId);
     }
   }
 
@@ -436,7 +438,7 @@ async function resolveEmbeddingByEnv(out: ResolvedAIOptions, nonInteractive: boo
         await import('../core/ai/defaults.ts');
       const dims = fullModel === DEFAULT_EMBEDDING_MODEL
         ? DEFAULT_EMBEDDING_DIMENSIONS
-        : tp.default_dims;
+        : defaultDimsForModel(tp, model);
       out.embedding_model = fullModel;
       out.embedding_dimensions = dims;
       console.error(

--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -9,8 +9,21 @@
  * providerOptions shape to produce vector(N)".
  */
 
-import type { Implementation } from './types.ts';
+import type { EmbeddingTouchpoint, Implementation } from './types.ts';
 import { AIConfigError } from './errors.ts';
+
+/**
+ * Resolve the native dim a specific model emits. Fixed-size providers
+ * (Ollama) host models with different native widths but a recipe declares
+ * only one `default_dims`; `model_dims` overrides it per model id. Unlisted
+ * models keep `default_dims` — the pre-`model_dims` behavior.
+ */
+export function defaultDimsForModel(
+  tp: Pick<EmbeddingTouchpoint, 'default_dims' | 'model_dims'>,
+  modelId: string,
+): number {
+  return tp.model_dims?.[modelId] ?? tp.default_dims;
+}
 
 // Voyage hosted models that accept `output_dimension` (values:
 // 256 / 512 / 1024 / 2048). Per Voyage's API parameter docs as of 2026-05.

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -48,7 +48,7 @@ import type {
 import { resolveRecipe, assertTouchpoint, parseModelId } from './model-resolver.ts';
 import { resolveModel, TIER_DEFAULTS } from '../model-config.ts';
 import type { BrainEngine } from '../engine.ts';
-import { dimsProviderOptions } from './dims.ts';
+import { dimsProviderOptions, defaultDimsForModel } from './dims.ts';
 import { hasAnthropicKey } from './anthropic-key.ts';
 import { AIConfigError, AITransientError, normalizeAIError } from './errors.ts';
 import { runGuardrails, hasGuardrails, type GuardrailHook } from '../guardrails.ts';
@@ -1881,7 +1881,9 @@ async function embedMultimodalOpenAICompat(
   // we skip the dim check rather than fabricate an expected value — the
   // engine's vector(N) column will reject mismatched rows at INSERT time
   // with a clearer error than anything we could throw here.
-  const recipeDims = recipe.touchpoints.embedding?.default_dims ?? 0;
+  const recipeDims = recipe.touchpoints.embedding
+    ? defaultDimsForModel(recipe.touchpoints.embedding, modelId)
+    : 0;
   const expectedDims = recipeDims > 0
     ? recipeDims
     : (cfg.embedding_dimensions ?? 0);

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -13,8 +13,19 @@ export const ollama: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['nomic-embed-text', 'mxbai-embed-large', 'all-minilm'],
+      models: ['nomic-embed-text', 'mxbai-embed-large', 'all-minilm', 'bge-m3'],
       default_dims: 768, // nomic-embed-text native dim
+      // Ollama models are fixed-dim but not all 768: without this map,
+      // `--embedding-model ollama:mxbai-embed-large` (or bge-m3) either
+      // provisions a wrong-width vector(768) column or hard-fails the
+      // init-time dim validation (catch-22: 1024 rejected as "custom",
+      // omitting the flag rejected as "required").
+      model_dims: {
+        'nomic-embed-text': 768,
+        'mxbai-embed-large': 1024,
+        'all-minilm': 384,
+        'bge-m3': 1024,
+      },
       cost_per_1m_tokens_usd: 0,
       price_last_verified: '2026-04-20',
       // Ollama's batch capacity depends on the locally loaded model + the

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -27,6 +27,15 @@ export type Implementation =
 export interface EmbeddingTouchpoint {
   models: string[];
   default_dims: number;
+  /**
+   * Per-model native dims for providers whose listed models emit different
+   * fixed widths (Ollama: nomic-embed-text 768, mxbai-embed-large 1024,
+   * all-minilm 384, bge-m3 1024). Overrides `default_dims` for the listed
+   * model ids; unlisted models fall back to `default_dims`. Resolve via
+   * `defaultDimsForModel()` in dims.ts — never read `default_dims` directly
+   * when a model id is in scope.
+   */
+  model_dims?: Record<string, number>;
   dims_options?: number[]; // for Matryoshka-aware providers
   cost_per_1m_tokens_usd?: number;
   price_last_verified?: string; // ISO date

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -29,6 +29,7 @@ import {
   isOpenAITextEmbedding3Model,
   isValidOpenAITextEmbedding3Dim,
   maxOpenAITextEmbedding3Dim,
+  defaultDimsForModel,
 } from './ai/dims.ts';
 
 /**
@@ -284,7 +285,7 @@ export function resolveSchemaEmbeddingDim(opts: ResolveSchemaEmbeddingDimOpts): 
           `Pick a recipe with an embedding touchpoint (gbrain providers list).`,
       };
     }
-    return validateDimAgainstTouchpoint(parsed.modelId, recipe, tp.default_dims, tp.dims_options, opts.embedding_dimensions);
+    return validateDimAgainstTouchpoint(parsed.modelId, recipe, defaultDimsForModel(tp, parsed.modelId), tp.dims_options, opts.embedding_dimensions);
   } catch (err) {
     return { ok: false, error: err instanceof AIConfigError ? err.message : String(err) };
   }
@@ -335,7 +336,7 @@ export function resolveSchemaMultimodalDim(opts: ResolveSchemaMultimodalDimOpts)
           `Pick a multimodal-capable model from this provider.`,
       };
     }
-    return validateDimAgainstTouchpoint(parsed.modelId, recipe, tp.default_dims, tp.dims_options, opts.embedding_multimodal_dimensions);
+    return validateDimAgainstTouchpoint(parsed.modelId, recipe, defaultDimsForModel(tp, parsed.modelId), tp.dims_options, opts.embedding_multimodal_dimensions);
   } catch (err) {
     return { ok: false, error: err instanceof AIConfigError ? err.message : String(err) };
   }

--- a/test/embedding-dim-check.test.ts
+++ b/test/embedding-dim-check.test.ts
@@ -257,6 +257,43 @@ describe('resolveSchemaEmbeddingDim', () => {
     if (got.ok) expect(got.dim).toBe(768);
   });
 
+  test('Ollama bge-m3 explicit 1024 accepted (model_dims override)', () => {
+    const got = resolveSchemaEmbeddingDim({
+      embedding_model: 'ollama:bge-m3',
+      embedding_dimensions: 1024,
+    });
+    expect(got.ok).toBe(true);
+    if (got.ok) {
+      expect(got.dim).toBe(1024);
+      expect(got.recipeDefault).toBe(1024);
+    }
+  });
+
+  test('Ollama bge-m3 without explicit dims resolves to its native 1024', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:bge-m3' });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(1024);
+  });
+
+  test('Ollama mxbai-embed-large resolves per-model 1024, not recipe default 768', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:mxbai-embed-large' });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(1024);
+  });
+
+  test('Ollama model absent from model_dims keeps default 768 and still rejects custom dims', () => {
+    const fallback = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:some-future-model' });
+    expect(fallback.ok).toBe(true);
+    if (fallback.ok) expect(fallback.dim).toBe(768);
+
+    const custom = resolveSchemaEmbeddingDim({
+      embedding_model: 'ollama:some-future-model',
+      embedding_dimensions: 999,
+    });
+    expect(custom.ok).toBe(false);
+    if (!custom.ok) expect(custom.error).toMatch(/does not support custom dimensions/);
+  });
+
   test('unknown provider rejected with provider list hint', () => {
     const got = resolveSchemaEmbeddingDim({ embedding_model: 'notarealprovider:foo' });
     expect(got.ok).toBe(false);


### PR DESCRIPTION
## Problem

The Ollama recipe declares a single `default_dims: 768` (nomic-embed-text's native width), but two of its three listed models emit different fixed sizes — `mxbai-embed-large` (1024) and `all-minilm` (384) — and the popular `bge-m3` (1024) isn't listed at all.

Configuring any non-768 ollama model hits a catch-22:

```
$ gbrain reinit-pglite --yes --embedding-model ollama:bge-m3 --embedding-dimensions 1024
Refusing to init: Provider "ollama" model "bge-m3" does not support custom dimensions 1024
(this model only emits its default vector size). Either drop --embedding-dimensions or pick a Matryoshka-aware model.

$ gbrain reinit-pglite --yes --embedding-model ollama:bge-m3
--embedding-dimensions <N> is required.
```

Both directions are rejected, so these models are unusable. Additionally, the first-model auto-pick paths in `init.ts` read `tp.default_dims` directly and could provision a wrong-width `vector(768)` column for a 1024-dim model.

## Fix

- `EmbeddingTouchpoint.model_dims?: Record<string, number>` — optional per-model native dims
- `defaultDimsForModel(tp, modelId)` helper in `dims.ts`; wired through `resolveSchemaEmbeddingDim`, `resolveSchemaMultimodalDim`, the gateway's multimodal dim check, and the three `init.ts` dim-derivation paths
- Ollama recipe maps its models' true native dims and adds `bge-m3`

Models absent from the map fall back to `default_dims`, so recipes without `model_dims` behave exactly as before.

## Testing

- 4 new cases in `test/embedding-dim-check.test.ts` (explicit 1024 accepted; omitted flag resolves native 1024; mxbai resolves per-model 1024; unlisted model keeps 768 + still rejects custom dims)
- `bun test test/embedding-dim-check.test.ts` → 31 pass / 0 fail; `test/ai/gateway.test.ts` → 36 pass; `tsc --noEmit` clean
- Verified live: `gbrain init --pglite --embedding-model ollama:bge-m3 --embedding-dimensions 1024` now provisions a 1024-dim brain, imported 147 pages, hybrid search working

🤖 Generated with [Claude Code](https://claude.com/claude-code)