### PR TITLE
Strengthen think citation coverage diagnostics

### DIFF
--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -147,6 +147,12 @@ export interface ThinkResult {
     takesFromKeyword: number;
     takesFromVector: number;
     graphHits: number;
+    /** Page slugs in the same rank order used to render <pages>. */
+    pageSlugsByRank: string[];
+    /** Unique page slugs present in resolved structured or fallback citations. */
+    citedPageSlugs: string[];
+    /** False when a synthesis ran but the rank-1 page is absent from resolved citations. */
+    topPageCited: boolean;
   };
 }
 
@@ -271,6 +277,7 @@ export async function runThink(
     questionEmbedding,
     takesHoldersAllowList: opts.takesHoldersAllowList,
   });
+  const pageSlugsByRank = gather.pages.map(p => p.slug);
 
   // Render evidence blocks for the prompt
   const pagesBlock = renderPagesBlock(gather.pages);
@@ -458,6 +465,9 @@ export async function runThink(
           takesFromKeyword: gather.diagnostics.takesFromKeyword,
           takesFromVector: gather.diagnostics.takesFromVector,
           graphHits: gather.diagnostics.graphHits,
+          pageSlugsByRank,
+          citedPageSlugs: [],
+          topPageCited: false,
         },
       };
     }
@@ -489,6 +499,18 @@ export async function runThink(
   if (resolved.warnings.length > 0) {
     for (const w of resolved.warnings) warnings.push(w);
   }
+  const citedPageSlugSet = new Set(
+    resolved.citations
+      .map(c => c.page_slug)
+      .filter(slug => typeof slug === 'string' && slug.length > 0)
+      .map(slug => slug.toLowerCase()),
+  );
+  const citedPageSlugs = [...citedPageSlugSet].sort();
+  const topPageSlug = pageSlugsByRank[0] ?? null;
+  const topPageCited = topPageSlug === null || citedPageSlugSet.has(topPageSlug.toLowerCase());
+  if (synthesisOk && response.answer.trim().length > 0 && topPageSlug !== null && !topPageCited) {
+    warnings.push(`TOP_PAGE_NOT_CITED: ${topPageSlug}`);
+  }
 
   // Round-loop scaffolding (rounds > 1 currently re-runs without gap-driven retrieval).
   // The loop is in place so the v0.29 gap-fill heuristic doesn't change the call site.
@@ -516,6 +538,9 @@ export async function runThink(
       takesFromKeyword: gather.diagnostics.takesFromKeyword,
       takesFromVector: gather.diagnostics.takesFromVector,
       graphHits: gather.diagnostics.graphHits,
+      pageSlugsByRank,
+      citedPageSlugs,
+      topPageCited,
     },
   };
 }

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -181,6 +181,66 @@ function tryParseJSON(text: string): unknown {
   }
 }
 
+function thinkMessageToResponse(result: Anthropic.Message): {
+  response: ThinkResponse;
+  synthesisOk: boolean;
+  warnings: string[];
+} {
+  const warnings: string[] = [];
+  const block = result.content.find(b => b.type === 'text');
+  const text = block && 'text' in block ? block.text : '';
+  const parsed = tryParseJSON(text);
+  if (!parsed || typeof parsed !== 'object') {
+    warnings.push('LLM_OUTPUT_NOT_JSON');
+    return {
+      response: { answer: text, citations: [], gaps: [] },
+      synthesisOk: false,
+      warnings,
+    };
+  }
+  const r = parsed as Partial<ThinkResponse>;
+  return {
+    response: {
+      answer: typeof r.answer === 'string' ? r.answer : '',
+      citations: Array.isArray(r.citations) ? (r.citations as ThinkResponse['citations']) : [],
+      gaps: Array.isArray(r.gaps) ? (r.gaps as string[]).filter(g => typeof g === 'string') : [],
+    },
+    synthesisOk: true,
+    warnings,
+  };
+}
+
+function summarizeCitationCoverage(citations: ParsedCitation[], pageSlugsByRank: string[]): {
+  citedPageSlugs: string[];
+  topPageSlug: string | null;
+  topPageCited: boolean;
+} {
+  const citedPageSlugSet = new Set(
+    citations
+      .map(c => c.page_slug)
+      .filter(slug => typeof slug === 'string' && slug.length > 0)
+      .map(slug => slug.toLowerCase()),
+  );
+  const citedPageSlugs = [...citedPageSlugSet].sort();
+  const topPageSlug = pageSlugsByRank[0] ?? null;
+  const topPageCited = topPageSlug === null || citedPageSlugSet.has(topPageSlug.toLowerCase());
+  return { citedPageSlugs, topPageSlug, topPageCited };
+}
+
+function buildTopPageCitationRepairMessage(topPageSlug: string, response: ThinkResponse): string {
+  return [
+    'The previous JSON response did not cite the top-ranked retrieval page.',
+    `Top-ranked page slug: ${topPageSlug}`,
+    'Revise the same answer as a single valid JSON object matching the original schema.',
+    `If the top-ranked page is relevant, cite [${topPageSlug}] inline and include it in the citations array with row_num null.`,
+    'If the top-ranked page is not relevant, keep the answer but add a gaps item explaining why it is insufficient or irrelevant.',
+    'Do not fabricate facts, slugs, or row numbers. Do not add prose outside JSON.',
+    '',
+    'Previous JSON response:',
+    JSON.stringify(response),
+  ].join('\n');
+}
+
 /**
  * Persist citations into synthesis_evidence. Resolves slugs to page_ids
  * via the engine. Pages that don't exist in the brain are skipped + warn'd.
@@ -429,6 +489,7 @@ export async function runThink(
   // return ANDs it with a non-empty-answer check (catches valid-but-empty JSON).
   let synthesisOk = true;
   let response: ThinkResponse;
+  let repairClient: ThinkLLMClient | null = null;
   if (opts.stubResponse) {
     response = opts.stubResponse;
   } else {
@@ -471,45 +532,68 @@ export async function runThink(
         },
       };
     }
+    repairClient = client;
     const result = await client.create({
       model: modelUsed,
       max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
       system: systemPrompt,
       messages: [{ role: 'user', content: userMessage }],
     });
-    const block = result.content.find(b => b.type === 'text');
-    const text = block && 'text' in block ? block.text : '';
-    const parsed = tryParseJSON(text);
-    if (!parsed || typeof parsed !== 'object') {
-      warnings.push('LLM_OUTPUT_NOT_JSON');
-      synthesisOk = false;  // #1698: malformed output (and the non-JSON graceful sentinel)
-      response = { answer: text, citations: [], gaps: [] };
-    } else {
-      const r = parsed as Partial<ThinkResponse>;
-      response = {
-        answer: typeof r.answer === 'string' ? r.answer : '',
-        citations: Array.isArray(r.citations) ? (r.citations as ThinkResponse['citations']) : [],
-        gaps: Array.isArray(r.gaps) ? (r.gaps as string[]).filter(g => typeof g === 'string') : [],
-      };
-    }
+    const parsed = thinkMessageToResponse(result);
+    for (const w of parsed.warnings) warnings.push(w);
+    synthesisOk = parsed.synthesisOk;
+    response = parsed.response;
   }
 
   // Resolve citations: prefer structured, fall back to inline-marker regex scan.
-  const resolved = resolveCitations(response.citations, response.answer);
+  let resolved = resolveCitations(response.citations, response.answer);
+  let citationCoverage = summarizeCitationCoverage(resolved.citations, pageSlugsByRank);
+  if (
+    repairClient
+    && synthesisOk
+    && response.answer.trim().length > 0
+    && citationCoverage.topPageSlug !== null
+    && !citationCoverage.topPageCited
+  ) {
+    const topPageSlug = citationCoverage.topPageSlug;
+    warnings.push(`TOP_PAGE_CITATION_REPAIR_ATTEMPTED: ${topPageSlug}`);
+    const repairResult = await repairClient.create({
+      model: modelUsed,
+      max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+      system: systemPrompt,
+      messages: [
+        { role: 'user', content: userMessage },
+        { role: 'assistant', content: JSON.stringify(response) },
+        { role: 'user', content: buildTopPageCitationRepairMessage(topPageSlug, response) },
+      ],
+    });
+    const repairParsed = thinkMessageToResponse(repairResult);
+    if (repairParsed.synthesisOk && repairParsed.response.answer.trim().length > 0) {
+      const repairResolved = resolveCitations(repairParsed.response.citations, repairParsed.response.answer);
+      const repairCoverage = summarizeCitationCoverage(repairResolved.citations, pageSlugsByRank);
+      if (repairCoverage.topPageCited) {
+        warnings.push(`TOP_PAGE_CITATION_REPAIR_APPLIED: ${topPageSlug}`);
+        for (const w of repairParsed.warnings) warnings.push(`TOP_PAGE_CITATION_REPAIR_${w}`);
+        response = repairParsed.response;
+        resolved = repairResolved;
+        citationCoverage = repairCoverage;
+      } else {
+        warnings.push(`TOP_PAGE_CITATION_REPAIR_FAILED: ${topPageSlug}`);
+      }
+    } else {
+      warnings.push(`TOP_PAGE_CITATION_REPAIR_INVALID: ${topPageSlug}`);
+    }
+  }
   if (resolved.warnings.length > 0) {
     for (const w of resolved.warnings) warnings.push(w);
   }
-  const citedPageSlugSet = new Set(
-    resolved.citations
-      .map(c => c.page_slug)
-      .filter(slug => typeof slug === 'string' && slug.length > 0)
-      .map(slug => slug.toLowerCase()),
-  );
-  const citedPageSlugs = [...citedPageSlugSet].sort();
-  const topPageSlug = pageSlugsByRank[0] ?? null;
-  const topPageCited = topPageSlug === null || citedPageSlugSet.has(topPageSlug.toLowerCase());
-  if (synthesisOk && response.answer.trim().length > 0 && topPageSlug !== null && !topPageCited) {
-    warnings.push(`TOP_PAGE_NOT_CITED: ${topPageSlug}`);
+  if (
+    synthesisOk
+    && response.answer.trim().length > 0
+    && citationCoverage.topPageSlug !== null
+    && !citationCoverage.topPageCited
+  ) {
+    warnings.push(`TOP_PAGE_NOT_CITED: ${citationCoverage.topPageSlug}`);
   }
 
   // Round-loop scaffolding (rounds > 1 currently re-runs without gap-driven retrieval).
@@ -539,8 +623,8 @@ export async function runThink(
       takesFromVector: gather.diagnostics.takesFromVector,
       graphHits: gather.diagnostics.graphHits,
       pageSlugsByRank,
-      citedPageSlugs,
-      topPageCited,
+      citedPageSlugs: citationCoverage.citedPageSlugs,
+      topPageCited: citationCoverage.topPageCited,
     },
   };
 }

--- a/src/core/think/prompt.ts
+++ b/src/core/think/prompt.ts
@@ -48,6 +48,10 @@ export const THINK_SYSTEM_PROMPT_BASE = `You are gbrain's synthesis engine. You 
 Hard rules:
 - Cite EVERY substantive claim. Use [slug#row] for take citations and [slug] for page citations.
   Inline the citation immediately after the claim it supports. Never fabricate slugs/rows.
+- Treat the first <page> in <pages> as the top-ranked retrieval result. If that page contains
+  evidence relevant to the question, cite it in the answer body and include it in the structured
+  citations array. If you do not use it, add a gaps item explaining why the top-ranked page was
+  insufficient or irrelevant.
 - If a take has weight < 0.5 or kind=hunch, mark it explicitly: "garry has a hunch (w=0.4) that..."
   rather than asserting it as established. Confidence is part of the data.
 - If two takes contradict (different holders, opposite claims), surface BOTH in a "Conflicts"

--- a/test/think-pipeline.serial.test.ts
+++ b/test/think-pipeline.serial.test.ts
@@ -18,6 +18,9 @@ beforeAll(async () => {
     title: 'Alice', type: 'person', compiled_truth: 'Alice founded Acme.',
   });
   alicePageId = alice.id;
+  await engine.upsertChunks('people/alice-example', [
+    { chunk_index: 0, chunk_text: 'Alice founded Acme and is a strong technical founder.', chunk_source: 'compiled_truth' },
+  ]);
   await engine.addTakesBatch([
     { page_id: alicePageId, row_num: 1, claim: 'CEO of Acme', kind: 'fact', holder: 'world', weight: 1.0 },
     { page_id: alicePageId, row_num: 2, claim: 'Strong technical founder', kind: 'take', holder: 'garry', weight: 0.85 },
@@ -177,6 +180,53 @@ describe('runThink (with stub client)', () => {
     expect(result.gaps).toEqual(['no info on funding history']);
     expect(result.takesGathered).toBeGreaterThan(0);
     expect(result.warnings).not.toContain('LLM_OUTPUT_NOT_JSON');
+  });
+
+  test('repairs once when synthesis omits the top-ranked page citation', async () => {
+    let calls = 0;
+    let repairPrompt = '';
+    const stubClient: ThinkLLMClient = {
+      create: async (params) => {
+        calls += 1;
+        if (calls === 2) {
+          const last = params.messages.at(-1);
+          repairPrompt = typeof last?.content === 'string' ? last.content : '';
+        }
+        return {
+          id: `msg_repair_${calls}`,
+          type: 'message',
+          role: 'assistant',
+          model: 'stub',
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 10, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, server_tool_use: null, service_tier: null },
+          content: [{
+            type: 'text',
+            text: JSON.stringify(calls === 1 ? {
+              answer: 'Alice founded Acme.',
+              citations: [],
+              gaps: [],
+            } : {
+              answer: 'Alice founded Acme [people/alice-example].',
+              citations: [{ page_slug: 'people/alice-example', row_num: null, citation_index: 1 }],
+              gaps: [],
+            }),
+          }],
+        };
+      },
+    };
+
+    const result = await runThink(engine, {
+      question: 'Alice founded Acme',
+      client: stubClient,
+    });
+
+    expect(calls).toBe(2);
+    expect(repairPrompt).toContain('top-ranked retrieval page');
+    expect(result.diagnostics.topPageCited).toBe(true);
+    expect(result.diagnostics.citedPageSlugs).toContain('people/alice-example');
+    expect(result.warnings).toContain('TOP_PAGE_CITATION_REPAIR_APPLIED: people/alice-example');
+    expect(result.warnings).not.toContain('TOP_PAGE_NOT_CITED: people/alice-example');
   });
 
   test('handles malformed LLM output gracefully (regex citation fallback)', async () => {


### PR DESCRIPTION
## Summary

- add a top-ranked page citation contract to `gbrain think`
- expose page citation coverage diagnostics (`pageSlugsByRank`, `citedPageSlugs`, `topPageCited`)
- add a bounded native repair retry when a non-empty synthesis omits the rank-1 page citation
- cover the repair path with a regression test

## Why

`think` can retrieve the right page as rank 1, pass it into the prompt, and still return structured citations that omit that page. The previous behavior made it hard for callers and evals to distinguish retrieval failure from final citation selection failure.

This keeps the fix inside the native `think` owner rather than requiring downstream wrappers to patch citations.

## Verification

- `bun run typecheck`
- `bun test test/think-pipeline.serial.test.ts test/think-gateway-adapter.test.ts test/think-with-calibration.test.ts test/system-prompt.test.ts`
- local patched live probe against a public fixture set: 4/4 passed
