### PR TITLE
fix(search): port the CJK keyword fallback to the Postgres engine (PGLite parity)

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1676,8 +1676,8 @@ export class PGLiteEngine implements BrainEngine {
    *     chunk_text are compared as-stored).
    *   - Empty-query guard returns no results without binding SQL.
    *
-   * Postgres engine is intentionally untouched (multi-tenant deployments
-   * can install pgroonga / zhparser when needed; out of scope here).
+   * Ported to postgres-engine.ts `_searchKeywordCJK` (Postgres parity) so
+   * both engines share the same CJK fallback semantics.
    */
   private async _searchKeywordCJK(
     query: string,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -63,6 +63,7 @@ import { ConnectionManager } from './connection-manager.ts';
 import { logConnectionEvent } from './connection-audit.ts';
 import { validateSlug, contentHash, rowToPage, rowToStalePage, rowToChunk, rowToSearchResult, parseEmbedding, tryParseEmbedding, takeRowToTake, takeHitRowToHit, isUndefinedTableError, warnOncePerProcess } from './utils.ts';
 import { resolveBoostMap, resolveHardExcludes } from './search/source-boost.ts';
+import { hasCJK, escapeLikePattern } from './cjk.ts';
 import { buildSourceFactorCase, buildHardExcludeClause, buildVisibilityClause, buildRecencyComponentSql, buildBestPerPagePoolCte } from './search/sql-ranking.ts';
 import { DEFAULT_EMBEDDING_MODEL, DEFAULT_EMBEDDING_DIMENSIONS } from './ai/defaults.ts';
 import { DELETE_BATCH_SIZE } from './engine-constants.ts';
@@ -1690,6 +1691,30 @@ export class PostgresEngine implements BrainEngine {
     const hardExcludePrefixes = resolveHardExcludes(opts?.exclude_slug_prefixes, opts?.include_slug_prefixes);
     const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes);
 
+    // v0.26.5: visibility filter hides soft-deleted pages and pages from
+    // archived sources. Joined `sources s` lets the predicate compile to a
+    // column lookup. NOT bypassed by detail=high — soft-delete is a contract,
+    // not a temporal preference. (Hoisted above the CJK branch so the
+    // fallback can reuse it, mirroring the PGLite hoist.)
+    const visibilityClause = buildVisibilityClause('p', 's');
+
+    // v0.32.7 CJK branch (Postgres parity): `websearch_to_tsquery('english')`
+    // can't tokenize CJK — a Chinese/Japanese/Korean query compiles to an
+    // empty tsquery and the FTS path silently returns nothing. Switch to
+    // ILIKE on chunk_text with occurrence-count ranking as the ts_rank
+    // substitute when the query contains CJK characters, mirroring the
+    // PGLite engine's `_searchKeywordCJK`. ASCII path stays exactly the
+    // same below.
+    if (hasCJK(query)) {
+      return this._searchKeywordCJK(query, {
+        limit, offset, innerLimit, sourceFactorCase,
+        hardExcludeClause, visibilityClause,
+        detailFilter: detailLow ? `AND cc.chunk_source = 'compiled_truth'` : '',
+        opts,
+        dedup: true,
+      });
+    }
+
     const params: unknown[] = [query];
     let typeClause = '';
     if (type) {
@@ -1752,11 +1777,8 @@ export class PostgresEngine implements BrainEngine {
     params.push(offset);
     const offsetParam = `$${params.length}`;
 
-    // v0.26.5: visibility filter hides soft-deleted pages and pages from
-    // archived sources. Joined `sources s` lets the predicate compile to a
-    // column lookup. NOT bypassed by detail=high — soft-delete is a contract,
-    // not a temporal preference.
-    const visibilityClause = buildVisibilityClause('p', 's');
+    // visibilityClause already declared above (v0.32.7 parity: hoisted so
+    // the CJK branch can reuse it).
     // FTS config name (e.g. 'english', 'pt_br'). Validated by getFtsLanguage()
     // — safe to interpolate into raw SQL.
     const ftsLang = getFtsLanguage();
@@ -1815,6 +1837,207 @@ export class PostgresEngine implements BrainEngine {
   }
 
   /**
+   * v0.32.7 CJK keyword fallback (Postgres parity port of the PGLite
+   * engine's `_searchKeywordCJK`). `websearch_to_tsquery('english')` can't
+   * tokenize CJK so the FTS path returns empty for Chinese / Japanese /
+   * Korean queries. This routes to an ILIKE substring scan with
+   * occurrence-count ranking as a ts_rank substitute.
+   *
+   * Same discipline as the PGLite implementation (codex outside-voice C8):
+   *   - Two distinct parameter bindings: $1 qLike (LIKE-escaped, for ILIKE)
+   *     and $2 qRaw (un-escaped, for ranking arithmetic via
+   *     position/replace). Escaped chars cannot be reused as ranking
+   *     substrings.
+   *   - Explicit `ESCAPE '\'` on the ILIKE clause.
+   *   - Symmetric: no asymmetric whitespace strip (caller's query and
+   *     chunk_text are compared as-stored).
+   *   - Empty-query guard returns no results without binding SQL.
+   *
+   * Adapted to this engine's conventions rather than copied verbatim:
+   * postgres.js `sql.begin()` + `SET LOCAL statement_timeout` (pool-safe,
+   * R6-F006), filter params first with limit/offset appended last,
+   * `false AS stale`, and this engine's full filter set (type / types /
+   * exclude_slugs / language / symbolKind / afterDate / beforeDate /
+   * source scope — the superset the ASCII FTS paths support here).
+   */
+  private async _searchKeywordCJK(
+    query: string,
+    ctx: {
+      limit: number;
+      offset: number;
+      innerLimit: number;
+      sourceFactorCase: string;
+      hardExcludeClause: string;
+      visibilityClause: string;
+      detailFilter: string;
+      opts: SearchOpts | undefined;
+      dedup: boolean;
+    },
+  ): Promise<SearchResult[]> {
+    const { limit, offset, innerLimit, sourceFactorCase, hardExcludeClause, visibilityClause, detailFilter, opts, dedup } = ctx;
+    const qRaw = query;
+    if (qRaw.length === 0) return [];
+    const qLike = escapeLikePattern(qRaw);
+
+    // $1 = qLike (escaped for ILIKE)
+    // $2 = qRaw  (raw for position()/replace() ranking arithmetic)
+    // Filter params next; inner-limit/limit/offset appended last (this
+    // engine's named-param convention).
+    const params: unknown[] = [qLike, qRaw];
+    let typeClause = '';
+    if (opts?.type) {
+      params.push(opts.type);
+      typeClause = `AND p.type = $${params.length}`;
+    }
+    // v0.33: multi-type filter for whoknows. AND-applied alongside the
+    // single-value `type` filter (callers can use either or both).
+    let typesClause = '';
+    if (opts?.types && opts.types.length > 0) {
+      params.push(opts.types);
+      typesClause = `AND p.type = ANY($${params.length}::text[])`;
+    }
+    let excludeSlugsClause = '';
+    if (opts?.exclude_slugs?.length) {
+      params.push(opts.exclude_slugs);
+      excludeSlugsClause = `AND p.slug != ALL($${params.length}::text[])`;
+    }
+    let languageClause = '';
+    if (opts?.language) {
+      params.push(opts.language);
+      languageClause = `AND cc.language = $${params.length}`;
+    }
+    let symbolKindClause = '';
+    if (opts?.symbolKind) {
+      params.push(opts.symbolKind);
+      symbolKindClause = `AND cc.symbol_type = $${params.length}`;
+    }
+    // v0.27.0: date filtering support
+    let afterDateClause = '';
+    if (opts?.afterDate) {
+      params.push(opts.afterDate);
+      afterDateClause = `AND COALESCE(p.updated_at, p.created_at) > $${params.length}::timestamptz`;
+    }
+    let beforeDateClause = '';
+    if (opts?.beforeDate) {
+      params.push(opts.beforeDate);
+      beforeDateClause = `AND COALESCE(p.updated_at, p.created_at) < $${params.length}::timestamptz`;
+    }
+    // v0.34.1 (#861 — P0 leak seal): source-isolation on the CJK fallback
+    // path too. Array form wins over scalar.
+    let sourceClause = '';
+    if (opts?.sourceIds && opts.sourceIds.length > 0) {
+      params.push(opts.sourceIds);
+      sourceClause = `AND p.source_id = ANY($${params.length}::text[])`;
+    } else if (opts?.sourceId) {
+      params.push(opts.sourceId);
+      sourceClause = `AND p.source_id = $${params.length}`;
+    }
+
+    // Occurrence-count ranking: count occurrences of $qRaw in chunk_text via
+    // (length(chunk) - length(replace(chunk, q, ''))) / length(q). Acts as
+    // a ts_rank substitute. position()-tiebreaker so earlier-in-chunk hits
+    // outrank later ones at the same occurrence count. Same expression as
+    // the PGLite implementation.
+    const scoreExpr = `
+      ((LENGTH(cc.chunk_text) - LENGTH(REPLACE(cc.chunk_text, $2, ''))) / NULLIF(LENGTH($2), 0)::real
+        + 1.0 / NULLIF(POSITION($2 IN cc.chunk_text), 0)::real)
+      * ${sourceFactorCase}
+    `;
+
+    let rawQuery: string;
+    if (dedup) {
+      params.push(innerLimit);
+      const innerLimitParam = `$${params.length}`;
+      params.push(limit);
+      const limitParam = `$${params.length}`;
+      params.push(offset);
+      const offsetParam = `$${params.length}`;
+      rawQuery = `
+        WITH ranked_chunks AS (
+          SELECT
+            p.slug, p.id as page_id, p.title, p.type, p.source_id,
+            p.effective_date, p.effective_date_source,
+            cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+            ${scoreExpr} AS score
+          FROM content_chunks cc
+          JOIN pages p ON p.id = cc.page_id
+          JOIN sources s ON s.id = p.source_id
+          WHERE cc.chunk_text ILIKE '%' || $1 || '%' ESCAPE '\\'
+            ${typeClause}
+            ${typesClause}
+            ${excludeSlugsClause}
+            ${detailFilter}
+            ${languageClause}
+            ${symbolKindClause}
+            ${afterDateClause}
+            ${beforeDateClause}
+            ${sourceClause}
+            ${hardExcludeClause}
+            ${visibilityClause}
+            -- v0.27.1: hide image rows from text-keyword search so OCR text
+            -- doesn't drown text-page hits (same as the FTS path).
+            AND cc.modality = 'text'
+          ORDER BY score DESC
+          LIMIT ${innerLimitParam}
+        ),
+        ${buildBestPerPagePoolCte('ranked_chunks')}
+        SELECT slug, page_id, title, type, source_id,
+          effective_date, effective_date_source,
+          chunk_id, chunk_index, chunk_text, chunk_source, score,
+          false AS stale
+        FROM best_per_page
+        ORDER BY score DESC
+        LIMIT ${limitParam}
+        OFFSET ${offsetParam}
+      `;
+    } else {
+      params.push(limit);
+      const limitParam = `$${params.length}`;
+      params.push(offset);
+      const offsetParam = `$${params.length}`;
+      rawQuery = `
+        SELECT
+          p.slug, p.id as page_id, p.title, p.type, p.source_id,
+          p.effective_date, p.effective_date_source,
+          cc.id as chunk_id, cc.chunk_index, cc.chunk_text, cc.chunk_source,
+          ${scoreExpr} AS score,
+          false AS stale
+        FROM content_chunks cc
+        JOIN pages p ON p.id = cc.page_id
+        JOIN sources s ON s.id = p.source_id
+        WHERE cc.chunk_text ILIKE '%' || $1 || '%' ESCAPE '\\'
+          ${typeClause}
+          ${typesClause}
+          ${excludeSlugsClause}
+          ${detailFilter}
+          ${languageClause}
+          ${symbolKindClause}
+          ${afterDateClause}
+          ${beforeDateClause}
+          ${sourceClause}
+          ${hardExcludeClause}
+          ${visibilityClause}
+        ORDER BY score DESC
+        LIMIT ${limitParam}
+        OFFSET ${offsetParam}
+      `;
+    }
+
+    // Search-only timeout + RLS scope binding, same contract as the FTS
+    // paths post-#2940: withScopedReadTransaction owns the sql.begin()
+    // wrap (alwaysTransaction — SET LOCAL statement_timeout must be
+    // transaction-scoped so the GUC can never leak onto a pooled
+    // connection), and with GBRAIN_RLS_SCOPE_BINDING on, the fallback
+    // shares the same set_config('app.scopes') transaction as the FTS
+    // arm — the CJK path can never widen a caller's source scope.
+    const rows = await this.withScopedReadTransaction(opts?.sourceIds, opts?.sourceId, async (tx) => {
+      await tx`SET LOCAL statement_timeout = '8s'`;
+      return await tx.unsafe(rawQuery, params as Parameters<typeof tx.unsafe>[1]);
+    }, { alwaysTransaction: true });
+    return rows.map(rowToSearchResult);
+  }
+
+  /**
    * v0.20.0 Cathedral II Layer 3 (1b) chunk-grain keyword search.
    * Ranks chunks via content_chunks.search_vector WITHOUT the
    * dedup-to-page pass searchKeyword applies. Used by A2 two-pass
@@ -1844,6 +2067,26 @@ export class PostgresEngine implements BrainEngine {
     const sourceFactorCase = buildSourceFactorCase('p.slug', boostMap, opts?.detail);
     const hardExcludePrefixes = resolveHardExcludes(opts?.exclude_slug_prefixes, opts?.include_slug_prefixes);
     const hardExcludeClause = buildHardExcludeClause('p.slug', hardExcludePrefixes);
+
+    // v0.26.5: visibility filter for searchKeywordChunks (anchor primitive).
+    // (Hoisted above the CJK branch so the fallback can reuse it.)
+    const visibilityClause = buildVisibilityClause('p', 's');
+
+    // v0.32.7 CJK branch (Postgres parity): same as searchKeyword but
+    // without page-dedup — english tsquery can't tokenize CJK, so route to
+    // the ILIKE + occurrence-count fallback (mirrors the PGLite engine's
+    // chunk-grain CJK call site).
+    if (hasCJK(query)) {
+      return this._searchKeywordCJK(query, {
+        limit, offset,
+        innerLimit: 0,             // unused on chunk-grain (no inner CTE)
+        sourceFactorCase,
+        hardExcludeClause, visibilityClause,
+        detailFilter: detailLow ? `AND cc.chunk_source = 'compiled_truth'` : '',
+        opts,
+        dedup: false,
+      });
+    }
 
     const params: unknown[] = [query];
     let typeClause = '';
@@ -1900,8 +2143,8 @@ export class PostgresEngine implements BrainEngine {
     params.push(offset);
     const offsetParam = `$${params.length}`;
 
-    // v0.26.5: visibility filter for searchKeywordChunks (anchor primitive).
-    const visibilityClause = buildVisibilityClause('p', 's');
+    // visibilityClause already declared above (v0.32.7 parity: hoisted so
+    // the CJK branch can reuse it).
     // FTS config name (e.g. 'english', 'pt_br'). Validated by getFtsLanguage()
     // — safe to interpolate into raw SQL.
     const ftsLang = getFtsLanguage();

--- a/test/e2e/engine-parity.test.ts
+++ b/test/e2e/engine-parity.test.ts
@@ -76,6 +76,23 @@ const SEED_PAGES: SeedPage[] = [
     body: 'example founder unrelated content for distraction',
     embeddingDim: 50,
   },
+  // v0.32.7 CJK branch (Postgres parity) fixtures — synthetic Korean text
+  // about a fictional "그리팅 서비스". Multi-hit page (3× 그리팅) must
+  // outrank the one-hit page under occurrence-count ranking on BOTH engines.
+  {
+    slug: 'concepts/greeting-service',
+    type: 'concept',
+    title: '그리팅 서비스 개요',
+    body: '그리팅 서비스는 가상의 인사 자동화 플랫폼입니다. 그리팅 봇이 아침마다 인사를 보냅니다. 오늘도 그리팅 팀은 새로운 인사말을 준비했습니다.',
+    embeddingDim: 33,
+  },
+  {
+    slug: 'notes/greeting-one-hit',
+    type: 'note',
+    title: '가상 메모',
+    body: '어제 회의에서 그리팅 이야기가 잠깐 나왔다. 나머지는 다른 주제였다.',
+    embeddingDim: 34,
+  },
 ];
 
 async function seedEngine(eng: BrainEngine) {
@@ -140,6 +157,48 @@ describeBoth('Engine parity — Postgres vs PGLite', () => {
       expect(new Set(pgSlugs)).toEqual(new Set(pgliteSlugs));
     });
   }
+
+  // v0.32.7 CJK branch (Postgres parity): websearch_to_tsquery('english')
+  // can't tokenize CJK, so both engines route CJK queries to the ILIKE +
+  // occurrence-count fallback. These pin the fallback's cross-engine
+  // contract with purely synthetic Korean fixtures.
+  test('CJK parity: searchKeyword("그리팅") finds the same pages, same top rank', async () => {
+    const pgResults = await pgEngine.searchKeyword('그리팅', { limit: 5 });
+    const pgliteResults = await pgliteEngine.searchKeyword('그리팅', { limit: 5 });
+
+    // Without the fallback the Postgres engine returned [] here (empty
+    // english tsquery) while PGLite matched — the exact drift this pins.
+    expect(pgResults.length).toBeGreaterThan(0);
+    expect(pgliteResults.length).toBeGreaterThan(0);
+
+    // Occurrence-count ranking: 3-hit page outranks 1-hit page on BOTH.
+    expect(pgResults[0].slug).toBe('concepts/greeting-service');
+    expect(pgliteResults[0].slug).toBe('concepts/greeting-service');
+
+    const pgSlugs = pgResults.map((r: SearchResult) => r.slug);
+    const pgliteSlugs = pgliteResults.map((r: SearchResult) => r.slug);
+    expect(pgSlugs).toContain('notes/greeting-one-hit');
+    expect(new Set(pgSlugs)).toEqual(new Set(pgliteSlugs));
+  });
+
+  test('CJK parity: chunk-grain searchKeywordChunks matches across engines', async () => {
+    const pgResults = await pgEngine.searchKeywordChunks('그리팅', { limit: 5 });
+    const pgliteResults = await pgliteEngine.searchKeywordChunks('그리팅', { limit: 5 });
+
+    expect(pgResults.length).toBeGreaterThan(0);
+    expect(pgliteResults.length).toBeGreaterThan(0);
+    expect(pgResults[0].slug).toBe(pgliteResults[0].slug);
+  });
+
+  test('CJK parity: LIKE-meta-char escape — literal % query does not wildcard-match', async () => {
+    // After escapeLikePattern, ILIKE looks for a literal `%` character,
+    // which no seeded fixture contains. Both engines must return empty
+    // rather than treating % as a wildcard.
+    const pgResults = await pgEngine.searchKeyword('100% 그리팅');
+    const pgliteResults = await pgliteEngine.searchKeyword('100% 그리팅');
+    expect(pgResults.length).toBe(0);
+    expect(pgliteResults.length).toBe(0);
+  });
 
   test('searchVector: top result matches between engines', async () => {
     const queryVec = basisEmbedding(7); // article direction

--- a/test/postgres-engine.test.ts
+++ b/test/postgres-engine.test.ts
@@ -128,6 +128,58 @@ describe('postgres-engine / search date filtering', () => {
   });
 });
 
+// v0.32.7 CJK branch (Postgres parity) guardrails. Live-DB coverage of the
+// fallback lives in test/e2e/engine-parity.test.ts (Korean parity case);
+// this block stays DB-free and locks in the source-level invariants that
+// make the port faithful to pglite-engine.ts `_searchKeywordCJK`.
+describe('postgres-engine / CJK keyword fallback (v0.32.7 parity)', () => {
+  test('searchKeyword routes CJK queries to _searchKeywordCJK', () => {
+    const fn = stripComments(extractMethod(SRC, 'searchKeyword'));
+    expect(fn).toMatch(/if\s*\(\s*hasCJK\s*\(\s*query\s*\)\s*\)/);
+    expect(fn).toMatch(/this\._searchKeywordCJK\s*\(/);
+  });
+
+  test('searchKeywordChunks routes CJK queries to _searchKeywordCJK (chunk-grain, no dedup)', () => {
+    const fn = stripComments(extractMethod(SRC, 'searchKeywordChunks'));
+    expect(fn).toMatch(/if\s*\(\s*hasCJK\s*\(\s*query\s*\)\s*\)/);
+    expect(fn).toMatch(/this\._searchKeywordCJK\s*\(/);
+    expect(fn).toMatch(/dedup:\s*false/);
+  });
+
+  test('_searchKeywordCJK matches via ILIKE with explicit ESCAPE, never tsquery', () => {
+    const fn = extractCJKHelper(SRC);
+    // ILIKE '%' || $1 || '%' ESCAPE '\' — the escaped-pattern binding.
+    expect(fn).toMatch(/ILIKE\s+'%'\s*\|\|\s*\$1\s*\|\|\s*'%'\s+ESCAPE/);
+    // The fallback must not route back through the english tokenizer it
+    // exists to bypass.
+    expect(stripComments(fn)).not.toMatch(/websearch_to_tsquery/);
+  });
+
+  test('_searchKeywordCJK keeps the two-binding discipline (qLike escaped, qRaw for ranking)', () => {
+    const fn = stripComments(extractCJKHelper(SRC));
+    // $1 comes from escapeLikePattern; $2 is the raw string used by the
+    // REPLACE/POSITION occurrence-count scoring. Escaped chars cannot be
+    // reused as ranking substrings (codex outside-voice C8).
+    expect(fn).toMatch(/escapeLikePattern\s*\(\s*qRaw\s*\)/);
+    expect(fn).toMatch(/REPLACE\(cc\.chunk_text,\s*\$2/);
+    expect(fn).toMatch(/POSITION\(\$2\s+IN\s+cc\.chunk_text\)/);
+  });
+
+  test('_searchKeywordCJK honors the pool-safety + RLS-scope contract (withScopedReadTransaction alwaysTransaction + SET LOCAL)', () => {
+    const fn = extractCJKHelper(SRC);
+    expect(fn).toMatch(/withScopedReadTransaction\s*\(/);
+    expect(fn).toMatch(/alwaysTransaction:\s*true/);
+    expect(fn).toMatch(/SET\s+LOCAL\s+statement_timeout/);
+    expect(stripComments(fn)).not.toMatch(/SET\s+statement_timeout\s*=\s*['"]?0/);
+  });
+
+  test('_searchKeywordCJK seals source-isolation on the fallback path (#861 parity)', () => {
+    const fn = stripComments(extractCJKHelper(SRC));
+    expect(fn).toMatch(/p\.source_id = ANY\(\$\$\{params\.length\}::text\[\]\)/);
+    expect(fn).toMatch(/opts\?\.sourceId/);
+  });
+});
+
 function stripComments(s: string): string {
   return s
     .replace(/\/\*[\s\S]*?\*\//g, '')
@@ -136,6 +188,18 @@ function stripComments(s: string): string {
 
 function countOccurrences(s: string, needle: string): number {
   return s.split(needle).length - 1;
+}
+
+// _searchKeywordCJK's signature contains an object-type literal (the ctx
+// param), so extractMethod's first-brace matcher would stop at the type.
+// Slice from the declaration to the method's 2-space-indent closing brace
+// instead (nested blocks all sit deeper).
+function extractCJKHelper(source: string): string {
+  const start = source.indexOf('private async _searchKeywordCJK(');
+  if (start < 0) throw new Error('_searchKeywordCJK not found in postgres-engine.ts');
+  const end = source.indexOf('\n  }', start);
+  if (end < 0) throw new Error('no closing brace for _searchKeywordCJK');
+  return source.slice(start, end + 4);
 }
 
 // extractMethod grabs the body of a class method by brace-matching from


### PR DESCRIPTION
## Summary

Ports the CJK keyword-search fallback from the PGLite engine to the Postgres engine. PGLite has routed CJK queries around `websearch_to_tsquery('english', ...)` since v0.32.7 — `hasCJK()` switches to ILIKE with occurrence-count ranking — but the Postgres engine's two FTS sites never got that branch, so the keyword arm of hybrid search quietly degrades for Korean/Chinese/Japanese brains running on Postgres.

## The gap in practice

The english parser does index space-delimited CJK tokens verbatim, so exact-word queries still match. What misses is everything inflected. Korean is agglutinative: `수급자` (beneficiary) shows up in text as `수급자의`, `수급자를`, `수급자가` — none of which the english stemmer relates to the bare form. On a private production Korean corpus (~74k chunks), a particle-suffixed two-word query returned 7 rows through english FTS and 152 through the ILIKE fallback; a common substring query, 21 vs 847. That is a 20-40x recall gap on the keyword arm, invisible unless you diff the arms directly.

## Change

`postgres-engine.ts` gains the `hasCJK(query)` branch at both FTS sites (the `searchKeyword` dedup path and the `searchKeywordChunks` chunk-grain path), delegating to a new private `_searchKeywordCJK`. The scoring expression, the escaped-pattern/raw-string two-binding discipline, the ILIKE `ESCAPE '\'` predicate, and the dedup vs chunk-grain split are carried over from PGLite unchanged. Where the two engines already diverge, the port sides with its host: `sql.begin` with `SET LOCAL statement_timeout`, named limit params, and the Postgres paths' own extra-filter set (`types`, `exclude_slugs`, its `COALESCE(updated_at, created_at)` date column). The ASCII path is untouched, and the stale PGLite docblock claiming the Postgres engine was intentionally left out is corrected.

This complements the open FTS-language work (#580/#581/#582): a configurable tsvector language fixes stemming for single-language brains, while this fallback covers CJK queries regardless of the configured language — the same layered design PGLite already ships.

## Validation

- 6 source-guardrail tests in `test/postgres-engine.test.ts`: routing at both call sites, ILIKE/ESCAPE discipline, the two-binding scoring contract, pool safety, and #861 source isolation on the fallback path.
- 3 Postgres-vs-PGLite parity e2e tests in `test/e2e/engine-parity.test.ts` with synthetic Korean fixtures, including a ranking assertion (3-occurrence chunk above 1-occurrence) and a LIKE-metachar query that must return nothing.
- `bun run verify` 31/31; touched-area suites 204 pass / 0 fail.
