### PR TITLE
fix(minions): default timeout for contextual reindex

### DIFF
--- a/src/core/minions/handler-timeouts.ts
+++ b/src/core/minions/handler-timeouts.ts
@@ -24,6 +24,7 @@
  */
 
 const THIRTY_MIN_MS = 30 * 60 * 1000;
+const SIXTY_MIN_MS = 60 * 60 * 1000;
 const TEN_MIN_MS = 10 * 60 * 1000;
 
 /**
@@ -42,6 +43,10 @@ export const HANDLER_DEFAULT_TIMEOUT_MS: Readonly<Record<string, number>> = {
   // few writes. Generous 10-min budget (vs the tight null-default) covers a
   // slow gateway without the 30-min loop budget.
   chronicle_extract: TEN_MIN_MS,
+  // Per-page contextual reindex jobs process chunks sequentially with one
+  // rate-leased LLM synopsis call per chunk; large transcript pages need more
+  // than the standard 30-min long-job budget.
+  contextual_reindex_per_chunk: SIXTY_MIN_MS,
 };
 
 /**

--- a/test/minions.test.ts
+++ b/test/minions.test.ts
@@ -354,6 +354,13 @@ describe('MinionQueue: #1737 per-handler default timeout', () => {
     expect(sub.timeout_ms).toBe(30 * 60 * 1000);
   });
 
+  test('contextual per-chunk reindex gets the 60-min default', async () => {
+    const job = await queue.add('contextual_reindex_per_chunk', { page_slug: 'large-transcript' }, undefined, {
+      allowProtectedSubmit: true,
+    });
+    expect(job.timeout_ms).toBe(60 * 60 * 1000);
+  });
+
   test('explicit timeout_ms always wins over the default', async () => {
     const job = await queue.add('embed-backfill', { sourceId: 'x' }, { timeout_ms: 5000 });
     expect(job.timeout_ms).toBe(5000);


### PR DESCRIPTION
## Summary

`contextual_reindex_per_chunk` jobs can currently be submitted without a stamped
`timeout_ms`, which leaves them on the short null-timeout wall-clock fallback.
Add the handler to `HANDLER_DEFAULT_TIMEOUT_MS` with a 60-minute budget.

## Root Cause

`MinionQueue.add()` stamps `opts?.timeout_ms ?? defaultTimeoutMsFor(jobName)` into
`minion_jobs.timeout_ms` at submit time (`src/core/minions/queue.ts`). That path
depends on the per-handler map in `src/core/minions/handler-timeouts.ts`.

The map covers long-running handlers such as `subagent`, `embed-backfill`, and
`autopilot-cycle`, but it does not include `contextual_reindex_per_chunk`. When
that handler is submitted without an explicit timeout, `defaultTimeoutMsFor()`
returns `null`.

`NULL` timeout jobs use the wall-clock fallback in
`MinionQueue.handleWallClockTimeouts()`: `2 * lockDurationMs * max_stalled`.
With the default 30s lock and default `max_stalled = 5`, that is a 5-minute
budget from the first claim.

`contextual_reindex_per_chunk` is not a short job. In per-chunk synopsis mode,
the contextual retrieval service processes all chunks for one page sequentially,
acquiring a synopsis rate lease and making an LLM call per chunk before the final
embedding batch. Large transcript pages can have 100-150 chunks, so the default
5-minute null-timeout budget can dead-letter them even while they are making
normal progress.

## Fix

Add `contextual_reindex_per_chunk` to `HANDLER_DEFAULT_TIMEOUT_MS` with a
60-minute timeout.

The existing 30-minute value remains the baseline for long handlers. This handler
gets the next larger budget because one job can contain a large page's full
sequential per-chunk LLM loop; 60 minutes comfortably covers the observed large
transcript case without changing the short-handler null-timeout behavior.

Existing queued jobs are not backfilled; the default is stamped only when new
jobs are submitted and explicit `timeout_ms` values still win.

## Production Evidence

A production instance hit this on large transcript pages during a full
per-chunk-synopsis backfill. The dead-lettered jobs were the largest transcript
pages and failed with `wall-clock timeout exceeded`; resubmitting the same jobs
with an explicit timeout completed successfully.

## Tests

- Intended touched test: `bun test test/minions.test.ts`
- Local smoke check of the patched timeout map:
  `contextual_reindex_per_chunk=3600000`, `embed-backfill=1800000`, `sync=null`

The change is committed on a branch at upstream HEAD. The added test runs in the
repository's CI (`bun test` via `.github/workflows/test.yml`).
