### PR TITLE
fix: scope per-source cycle embed and orphan phases

### DIFF
--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1921,10 +1921,17 @@ export async function registerBuiltinHandlers(
     const repoPath: string | null = typeof job.data.repoPath === 'string'
       ? job.data.repoPath
       : ((await engine.getConfig('sync.repo_path')) ?? null);
+    const sourceId =
+      typeof job.data.sourceId === 'string'
+        ? job.data.sourceId
+        : typeof job.data.source_id === 'string'
+          ? job.data.source_id
+          : undefined;
     const report = await runCycle(engine, {
       brainDir: repoPath,
       phases: [phase as any],
       signal: job.signal,
+      ...(sourceId ? { sourceId } : {}),
     });
     return { phase, status: report.status, report };
   };

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -468,13 +468,12 @@ export interface CycleOpts {
    * When unset, the legacy global lock is used (back-compat for autopilot
    * + every existing caller).
    *
-   * **Note for follow-up waves:** this only scopes the LOCK. Several
-   * cycle phases (`embed`, `orphans`, `purge`, `resolve_symbol_edges`,
-   * `grade_takes`, `calibration_profile`) still operate brain-wide
-   * regardless of sourceId — see the `PHASE_SCOPE` taxonomy. Per-source
-   * cycle locks let two cycles RUN, but the global-scoped phases
-   * inside each will still touch the same rows. Genuine per-source
-   * fan-out requires the deferred TODOs in the plan.
+   * **Note for follow-up waves:** this scopes the lock and the phases that
+   * explicitly accept a source filter. Several cycle phases (`purge`,
+   * `resolve_symbol_edges`, `grade_takes`, `calibration_profile`) still
+   * operate brain-wide regardless of sourceId — see the `PHASE_SCOPE`
+   * taxonomy. Per-source cycle locks let two cycles RUN, but unscoped global
+   * phases inside each will still touch the same rows until decomposed.
    *
    * Validated via `assertValidSourceId` in `cycleLockIdFor` (defense-in-depth).
    */
@@ -1169,14 +1168,14 @@ async function runPhaseResolveSymbolEdges(
   }
 }
 
-async function runPhaseEmbed(engine: BrainEngine, dryRun: boolean, signal?: AbortSignal): Promise<PhaseResult> {
+async function runPhaseEmbed(engine: BrainEngine, dryRun: boolean, signal?: AbortSignal, sourceId?: string): Promise<PhaseResult> {
   try {
     const { runEmbedCore } = await import('../commands/embed.ts');
     // #1737: thread the cycle's abort signal so the embed phase (the long,
     // 10-15 min one) bails within a batch instead of running to completion
     // after the job was killed — which left gbrain_cycle_locks held and
     // wedged every subsequent autopilot cycle.
-    const result = await runEmbedCore(engine, { stale: true, dryRun, signal });
+    const result = await runEmbedCore(engine, { stale: true, dryRun, signal, sourceId });
     const embeddedCount = dryRun ? result.would_embed : result.embedded;
     return {
       phase: 'embed',
@@ -1353,10 +1352,10 @@ async function runPhasePurge(engine: BrainEngine, dryRun: boolean): Promise<Phas
  *  to avoid a static import (purge phase is only loaded in the autopilot path). */
 const SOFT_DELETE_TTL_HOURS_FOR_PURGE = 72;
 
-async function runPhaseOrphans(engine: BrainEngine): Promise<PhaseResult> {
+async function runPhaseOrphans(engine: BrainEngine, sourceId?: string): Promise<PhaseResult> {
   try {
     const { findOrphans } = await import('../commands/orphans.ts');
-    const result = await findOrphans(engine);
+    const result = await findOrphans(engine, sourceId ? { sourceId } : {});
     const count = result.total_orphans;
     // Orphans are a code-smell signal, not a fatal condition. The
     // original `count > 20` cutoff was tuned for small dev brains; on
@@ -2175,7 +2174,7 @@ export async function runCycle(
         });
       } else {
         progress.start('cycle.embed');
-        const { result, duration_ms } = await timePhase(() => runPhaseEmbed(engine, dryRun, opts.signal));
+        const { result, duration_ms } = await timePhase(() => runPhaseEmbed(engine, dryRun, opts.signal, cycleSourceId));
         result.duration_ms = duration_ms;
         phaseResults.push(result);
         progress.finish();
@@ -2196,7 +2195,7 @@ export async function runCycle(
         });
       } else {
         progress.start('cycle.orphans');
-        const { result, duration_ms } = await timePhase(() => runPhaseOrphans(engine));
+        const { result, duration_ms } = await timePhase(() => runPhaseOrphans(engine, cycleSourceId));
         result.duration_ms = duration_ms;
         phaseResults.push(result);
         progress.finish();

--- a/test/core/cycle.serial.test.ts
+++ b/test/core/cycle.serial.test.ts
@@ -19,8 +19,8 @@ let lintCalls: Array<{ target: string; fix: boolean; dryRun: boolean | undefined
 let backlinksCalls: Array<{ action: string; dir: string; dryRun: boolean | undefined }> = [];
 let syncCalls: Array<{ dryRun: boolean | undefined; noPull: boolean | undefined; noExtract: boolean | undefined; sourceId: string | undefined }> = [];
 let extractCalls: Array<{ mode: string; dir: string; slugs: string[] | undefined }> = [];
-let embedCalls: Array<{ stale: boolean | undefined; dryRun: boolean | undefined }> = [];
-let orphansCalls: number = 0;
+let embedCalls: Array<{ stale: boolean | undefined; dryRun: boolean | undefined; signal: AbortSignal | undefined; sourceId: string | undefined }> = [];
+let orphansCalls: Array<{ sourceId: string | undefined }> = [];
 
 // Mock lint
 mock.module('../../src/commands/lint.ts', () => ({
@@ -83,7 +83,7 @@ mock.module('../../src/commands/extract.ts', () => ({
 // Mock embed
 mock.module('../../src/commands/embed.ts', () => ({
   runEmbedCore: async (_engine: any, opts: any) => {
-    embedCalls.push({ stale: opts.stale, dryRun: opts.dryRun });
+    embedCalls.push({ stale: opts.stale, dryRun: opts.dryRun, signal: opts.signal, sourceId: opts.sourceId });
     return {
       embedded: opts.dryRun ? 0 : 8,
       skipped: 2,
@@ -98,8 +98,8 @@ mock.module('../../src/commands/embed.ts', () => ({
 
 // Mock orphans
 mock.module('../../src/commands/orphans.ts', () => ({
-  findOrphans: async () => {
-    orphansCalls++;
+  findOrphans: async (_engine: any, opts: any = {}) => {
+    orphansCalls.push({ sourceId: opts.sourceId });
     return {
       orphans: [],
       total_orphans: 1,
@@ -147,7 +147,7 @@ beforeEach(() => {
   syncCalls = [];
   extractCalls = [];
   embedCalls = [];
-  orphansCalls = 0;
+  orphansCalls = [];
 });
 
 // ─── dryRun propagation (regression guards) ────────────────────────
@@ -212,8 +212,44 @@ describe('runCycle — phase selection', () => {
 
   test('--phase orphans only runs orphans', async () => {
     await runCycle(sharedEngine,{ brainDir: '/tmp/brain', phases: ['orphans'] });
-    expect(orphansCalls).toBe(1);
+    expect(orphansCalls.length).toBe(1);
     expect(syncCalls.length).toBe(0);
+  });
+});
+
+describe('runCycle — sourceId reaches source-capable global phases', () => {
+  beforeEach(async () => {
+    await truncateCycleLocks(sharedEngine);
+  });
+
+  test('explicit sourceId is forwarded into embed stale sweep', async () => {
+    const signal = new AbortController().signal;
+    await runCycle(sharedEngine, {
+      brainDir: null,
+      phases: ['embed'],
+      dryRun: true,
+      sourceId: 'contracts',
+      signal,
+    });
+
+    expect(embedCalls.length).toBe(1);
+    expect(embedCalls[0]).toMatchObject({
+      stale: true,
+      dryRun: true,
+      sourceId: 'contracts',
+    });
+    expect(embedCalls[0].signal).toBe(signal);
+  });
+
+  test('explicit sourceId is forwarded into orphan discovery', async () => {
+    await runCycle(sharedEngine, {
+      brainDir: null,
+      phases: ['orphans'],
+      dryRun: true,
+      sourceId: 'contracts',
+    });
+
+    expect(orphansCalls).toEqual([{ sourceId: 'contracts' }]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Threads `sourceId` into source-capable `autopilot-cycle` phases: `embed` and `orphans`.
- Preserves `sourceId` / `source_id` for single-phase Minion phase-wrapper jobs.
- Adds regression coverage proving `runCycle` forwards source scope into embed and orphan discovery.

## Why
Per-source `autopilot-cycle` jobs carried `source_id`, but some source-capable phases still ran avoidably whole-brain work. On larger Postgres/Supabase brains this can trigger `statement_timeout` during per-source maintenance jobs.

This patch keeps the fix narrow: no new config, no DB migrations, no global timeout increase.

## Changed files
- `src/core/cycle.ts`
- `src/commands/jobs.ts`
- `test/core/cycle.serial.test.ts`

## Verification
Run locally from `/Users/claudebot/gbrain-autopilot-timeout-fix`:

```bash
git diff --check
# passed
```

```bash
/Users/claudebot/.bun/bin/bun test test/core/cycle.serial.test.ts
# 30 pass, 0 fail, 80 expect() calls
```

```bash
/Users/claudebot/.bun/bin/bun test test/autopilot-fanout.test.ts test/core/cycle.serial.test.ts
# 58 pass, 0 fail, 140 expect() calls
```

```bash
/Users/claudebot/.bun/bin/bun test test/jobs-autopilot-cycle-braindir.serial.test.ts
# 1 pass, 0 fail, 7 expect() calls
```

## Deliberately not changed
- Did not raise or remove Postgres/Supabase `statement_timeout`.
- Did not decompose the remaining truly/global-ish phases (`purge`, `resolve_symbol_edges`, `grade_takes`, `calibration_profile`).
- Did not change queue retry semantics or introduce migrations.
