### PR TITLE
fix(ai): raise gateway default max output tokens 4096 -> 32000

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -2648,7 +2648,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
     }
   }
   const estimatedInputTokens = estimateChatInputTokens(opts);
-  const maxOutputTokens = opts.maxTokens ?? 4096;
+  const maxOutputTokens = opts.maxTokens ?? 32000;
 
   // TX5: reserve BEFORE the provider call. Throws BudgetExhausted on cost,
   // runtime, or no_pricing (when cap is set). Pre-resolution model id is
@@ -2757,7 +2757,7 @@ export async function chat(opts: ChatOpts): Promise<ChatResult> {
       system: opts.system,
       messages: toModelMessages(opts.messages) as any,
       tools: opts.tools && opts.tools.length > 0 ? tools : undefined,
-      maxOutputTokens: opts.maxTokens ?? 4096,
+      maxOutputTokens: opts.maxTokens ?? 32000,
       // v0.42.20.0 — default a chat timeout (composes with the caller's signal,
       // shorter wins). Covers native-anthropic (the default provider + facts Haiku).
       abortSignal: withDefaultTimeout(opts.abortSignal, AI_CHAT_TIMEOUT_MS),
@@ -2942,7 +2942,7 @@ export interface ToolLoopResult {
  */
 export async function toolLoop(opts: ToolLoopOpts): Promise<ToolLoopResult> {
   const maxTurns = opts.maxTurns ?? 20;
-  const maxTokens = opts.maxTokens ?? 4096;
+  const maxTokens = opts.maxTokens ?? 32000;
   const handlers = opts.toolHandlers;
   const totalUsage: ChatResult['usage'] = {
     input_tokens: 0,


### PR DESCRIPTION
The three toolLoop-path defaults in gateway.ts still cap output at 4096 tokens. On current always-thinking models (Claude Sonnet 5 / Opus 4.7+ / Fable 5), thinking consumes the output budget before a text block is reached, so a caller that does not pass opts.maxTokens gets an empty final text: every turn stops at max_tokens with only thinking content, and downstream consumers see a silent zero-byte result.

We hit this in production: a nightly research-brief subagent on openrouter:anthropic/claude-sonnet-5 returned 0 bytes on every run until these three defaults were raised (audit trail in our deployment notes, 2026-07-04). Bumping the default to 32000 removed the cap (observed per-turn output 147-776 tokens once no longer starved).

4096 predates always-thinking models (last touched ~v0.42.41.0); 32000 is a safe modern default - providers bill actual tokens, not the cap, so the only effect is headroom.