### PR TITLE
v0.42.57.0 fix(think): persist --take rows (#2556)

### DIFF
--- a/src/commands/think.ts
+++ b/src/commands/think.ts
@@ -6,7 +6,7 @@
  * degrades to gather-only output with a warning if missing.
  */
 import type { BrainEngine } from '../core/engine.ts';
-import { runThink, persistSynthesis } from '../core/think/index.ts';
+import { runThink, persistSynthesis, persistThinkTake } from '../core/think/index.ts';
 import { loadConfig, isThinClient } from '../core/config.ts';
 import { callRemoteTool, unpackToolResult } from '../core/mcp-client.ts';
 
@@ -92,6 +92,8 @@ prints what would have been the input (exit 0).
   let result: any;
   let savedSlug: string | undefined;
   let evidenceInserted = 0;
+  let takeRow: number | null = null;
+  let takeInserted = 0;
   const cfg = loadConfig();
   if (isThinClient(cfg)) {
     if (save || take) {
@@ -138,6 +140,19 @@ prints what would have been the input (exit 0).
           process.exit(1);
         }
       }
+      if (take) {
+        const persistedTake = await persistThinkTake(engine, result, { anchor });
+        takeRow = persistedTake.rowNum;
+        takeInserted = persistedTake.inserted;
+        for (const w of persistedTake.warnings) result.warnings.push(w);
+        if (!persistedTake.rowNum) {
+          console.error(
+            'think: --take requested but no take row was written (missing anchor, ' +
+            'missing anchor page, or empty synthesis).',
+          );
+          process.exit(1);
+        }
+      }
     } catch (e) {
       // #1698: an unresolvable explicit --model throws here. Clean non-zero exit
       // with the actionable message, not a stack trace.
@@ -151,6 +166,8 @@ prints what would have been the input (exit 0).
       ...result,
       saved_slug: savedSlug ?? null,
       evidence_inserted: evidenceInserted,
+      take_row: takeRow,
+      take_inserted: takeInserted,
     }, null, 2));
     return;
   }
@@ -168,6 +185,9 @@ prints what would have been the input (exit 0).
   console.log(`Model: ${result.modelUsed} | Pages: ${result.pagesGathered} | Takes: ${result.takesGathered} | Graph: ${result.graphHits} | Citations: ${result.citations.length}`);
   if (savedSlug) {
     console.log(`Saved: ${savedSlug} (${evidenceInserted} evidence rows)`);
+  }
+  if (takeRow !== null) {
+    console.log(`Take: ${anchor}#${takeRow} (${takeInserted} row)`);
   }
   if (result.warnings.length > 0) {
     console.error(`Warnings: ${result.warnings.join(', ')}`);

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -1843,7 +1843,7 @@ const think: Operation = {
     // forwards to findTrajectory. CLI callers don't go through this op
     // and get default scope + remote=false from runThink's CLI path.
     const scope = sourceScopeOpts(ctx);
-    const { runThink, persistSynthesis } = await import('./think/index.ts');
+    const { runThink, persistSynthesis, persistThinkTake } = await import('./think/index.ts');
     const result = await runThink(ctx.engine, {
       question: String(p.question),
       anchor: p.anchor ? String(p.anchor) : undefined,
@@ -1863,15 +1863,30 @@ const think: Operation = {
       ...(scope.sourceIds !== undefined ? { allowedSources: scope.sourceIds } : {}),
       remote: ctx.remote === true,
     });
+    if (remote && (Boolean(p.save) || Boolean(p.take))) {
+      result.warnings.push('REMOTE_PERSISTED_BLOCKED');
+    }
 
     // Persist if --save was passed locally
     let savedSlug: string | undefined;
     let evidenceInserted = 0;
+    let takeRow: number | null = null;
+    let takeInserted = 0;
     if (safeSave) {
       const persisted = await persistSynthesis(ctx.engine, result);
       savedSlug = persisted.slug;
       evidenceInserted = persisted.evidenceInserted;
       for (const w of persisted.warnings) result.warnings.push(w);
+    }
+    if (safeTake) {
+      const persistedTake = await persistThinkTake(ctx.engine, result, {
+        anchor: p.anchor ? String(p.anchor) : undefined,
+        ...(scope.sourceId !== undefined ? { sourceId: scope.sourceId } : {}),
+        ...(scope.sourceIds !== undefined ? { sourceIds: scope.sourceIds } : {}),
+      });
+      takeRow = persistedTake.rowNum;
+      takeInserted = persistedTake.inserted;
+      for (const w of persistedTake.warnings) result.warnings.push(w);
     }
 
     return {
@@ -1880,6 +1895,8 @@ const think: Operation = {
       // falsy) to null so callers never see an empty-string "slug".
       saved_slug: savedSlug || null,
       evidence_inserted: evidenceInserted,
+      take_row: takeRow,
+      take_inserted: takeInserted,
       remote_persisted_blocked: remote && (Boolean(p.save) || Boolean(p.take)),
     };
   },

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -150,6 +150,18 @@ export interface ThinkResult {
   };
 }
 
+export interface PersistThinkTakeOpts {
+  anchor?: string;
+  sourceId?: string;
+  sourceIds?: string[];
+}
+
+export interface PersistThinkTakeResult {
+  rowNum: number | null;
+  inserted: number;
+  warnings: string[];
+}
+
 const DEFAULT_MAX_OUTPUT_TOKENS = 4000;
 
 function inferIntent(question: string, anchor?: string): string {
@@ -570,6 +582,50 @@ export async function persistSynthesis(
 
   const persisted = await persistCitations(engine, page.id, result.citations);
   return { slug, evidenceInserted: persisted.inserted, warnings: persisted.warnings };
+}
+
+/**
+ * Persist `gbrain think --take` as the next append-only take row on the anchor page.
+ * The synthesis answer is the claim; holder=brain because this is gbrain's own analysis.
+ */
+export async function persistThinkTake(
+  engine: BrainEngine,
+  result: ThinkResult,
+  opts: PersistThinkTakeOpts,
+): Promise<PersistThinkTakeResult> {
+  const anchor = opts.anchor?.trim();
+  if (!anchor) {
+    return { rowNum: null, inserted: 0, warnings: ['TAKE_REQUIRES_ANCHOR'] };
+  }
+  if (result.synthesisOk === false || result.answer.trim().length === 0) {
+    return { rowNum: null, inserted: 0, warnings: ['TAKE_EMPTY_NOT_PERSISTED'] };
+  }
+
+  const pageOpts: { sourceId?: string; sourceIds?: string[] } = {};
+  if (opts.sourceIds !== undefined) pageOpts.sourceIds = opts.sourceIds;
+  else if (opts.sourceId !== undefined) pageOpts.sourceId = opts.sourceId;
+  const page = await engine.getPage(anchor, pageOpts);
+  if (!page) {
+    return { rowNum: null, inserted: 0, warnings: [`TAKE_ANCHOR_NOT_FOUND: ${anchor}`] };
+  }
+
+  const rows = await engine.executeRaw<{ next: number | string }>(
+    `SELECT (COALESCE(MAX(row_num), 0) + 1)::int AS next FROM takes WHERE page_id = $1`,
+    [page.id],
+  );
+  const rowNum = Number(rows[0]?.next ?? 1);
+  const inserted = await engine.addTakesBatch([{
+    page_id: page.id,
+    row_num: rowNum,
+    claim: result.answer.trim(),
+    kind: 'take',
+    holder: 'brain',
+    weight: 0.5,
+    source: 'gbrain think',
+    active: true,
+  }]);
+
+  return { rowNum, inserted, warnings: [] };
 }
 
 // ─────────────────────────────────────────────────────────────────

--- a/test/takes-mcp-allowlist.serial.test.ts
+++ b/test/takes-mcp-allowlist.serial.test.ts
@@ -218,9 +218,10 @@ describe('think op — read-only on remote callers (Lane D landed)', () => {
       saved_slug: string | null;
       warnings: string[];
     };
-    // Codex P1 #7: remote save/take is silently disabled.
+    // Codex P1 #7: remote save/take is blocked explicitly at the trust boundary.
     expect(env.remote_persisted_blocked).toBe(true);
     expect(env.saved_slug).toBeNull();
+    expect(env.warnings).toContain('REMOTE_PERSISTED_BLOCKED');
     // Without API key, gather succeeds but synthesis is skipped.
     expect(env.warnings).toContain('NO_ANTHROPIC_API_KEY');
   });

--- a/test/think-pipeline.serial.test.ts
+++ b/test/think-pipeline.serial.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { operationsByName } from '../src/core/operations.ts';
-import { runThink, persistSynthesis, type ThinkLLMClient } from '../src/core/think/index.ts';
+import { runThink, persistSynthesis, persistThinkTake, type ThinkLLMClient } from '../src/core/think/index.ts';
 import { sanitizeTakeForPrompt, renderTakesBlock } from '../src/core/think/sanitize.ts';
 import { resolveCitations, parseInlineCitations, normalizeStructuredCitations } from '../src/core/think/cite-render.ts';
 import { runGather } from '../src/core/think/gather.ts';
@@ -347,6 +347,68 @@ describe('runThink + persistSynthesis — #1698 never persist empty', () => {
     };
     const saved = await persistSynthesis(engine, legacy);
     expect(saved.slug).toContain('synthesis/legacy-backcompat');
+  });
+
+  test('persistThinkTake appends the synthesis answer as the next anchor take (#2556)', async () => {
+    const target = await engine.putPage('notes/think-take-target-example', {
+      title: 'Think take target',
+      type: 'note',
+      compiled_truth: 'A safe placeholder page for think take persistence.',
+    });
+    const result: any = {
+      question: 'what should this page remember?',
+      answer: 'This page should remember the synthesized placeholder insight.',
+      citations: [],
+      gaps: [],
+      pagesGathered: 0,
+      takesGathered: 0,
+      graphHits: 0,
+      modelUsed: 'stub',
+      rounds: 1,
+      warnings: [],
+      synthesisOk: true,
+      diagnostics: { pagesFromHybrid: 0, takesFromKeyword: 0, takesFromVector: 0, graphHits: 0 },
+    };
+
+    const persisted = await persistThinkTake(engine, result, { anchor: target.slug });
+
+    expect(persisted).toEqual({ rowNum: 1, inserted: 1, warnings: [] });
+    const takes = await engine.listTakes({ page_id: target.id });
+    expect(takes).toHaveLength(1);
+    expect(takes[0]).toMatchObject({
+      row_num: 1,
+      claim: 'This page should remember the synthesized placeholder insight.',
+      kind: 'take',
+      holder: 'brain',
+      source: 'gbrain think',
+    });
+  });
+
+  test('persistThinkTake refuses empty/no-LLM synthesis instead of writing a blank take (#2556)', async () => {
+    const target = await engine.putPage('notes/think-take-empty-example', {
+      title: 'Think take empty target',
+      type: 'note',
+      compiled_truth: 'A safe placeholder page for empty think take persistence.',
+    });
+    const result: any = {
+      question: 'empty synthesis',
+      answer: '(no LLM available)',
+      citations: [],
+      gaps: [],
+      pagesGathered: 0,
+      takesGathered: 0,
+      graphHits: 0,
+      modelUsed: 'stub',
+      rounds: 0,
+      warnings: [],
+      synthesisOk: false,
+      diagnostics: { pagesFromHybrid: 0, takesFromKeyword: 0, takesFromVector: 0, graphHits: 0 },
+    };
+
+    const persisted = await persistThinkTake(engine, result, { anchor: target.slug });
+
+    expect(persisted).toEqual({ rowNum: null, inserted: 0, warnings: ['TAKE_EMPTY_NOT_PERSISTED'] });
+    expect(await engine.listTakes({ page_id: target.id })).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `persistThinkTake()` so a successful local `gbrain think --take --anchor <slug>` writes the synthesis answer as the next append-only take on the anchor page.
- Wires the same take persistence into the local `think` operation handler while preserving the remote trust boundary with an explicit `REMOTE_PERSISTED_BLOCKED` warning.
- Extends the CLI/operation response surface with `take_row` and `take_inserted`, and keeps empty/no-LLM synthesis from writing blank take rows.

Fixes #2556.

## Tests

- `bun test test/think-pipeline.serial.test.ts test/takes-mcp-allowlist.serial.test.ts`
  - 43 pass, 0 fail, 116 expect calls
- `gbrain-gate.sh <worktree> test/think-pipeline.serial.test.ts test/takes-mcp-allowlist.serial.test.ts`
  - verify: green except the tolerated macOS-only `check:operations-filter-bypass` guard false-positive
  - unit: 43 pass, 0 fail, 116 expect calls
  - e2e: selector returned the fail-closed all-E2E set for this non-E2E-specific diff; local gate skipped unrelated E2E and CI runs the full suite
