### PR TITLE
fix(think): honor source scope during gather

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4566,9 +4566,19 @@ export class PGLiteEngine implements BrainEngine {
 
   async searchTakes(
     query: string,
-    opts: { limit?: number; takesHoldersAllowList?: string[] } = {},
+    opts: SearchOpts & { takesHoldersAllowList?: string[] } = {},
   ): Promise<TakeHit[]> {
     const limit = clampSearchLimit(opts.limit, 30, 100);
+    const params: unknown[] = [query, opts.takesHoldersAllowList ?? null];
+    let sourceFilter = '';
+    if (opts.sourceIds && opts.sourceIds.length > 0) {
+      params.push(opts.sourceIds);
+      sourceFilter = `AND p.source_id = ANY($${params.length}::text[])`;
+    } else if (opts.sourceId) {
+      params.push(opts.sourceId);
+      sourceFilter = `AND p.source_id = $${params.length}`;
+    }
+    params.push(limit);
     const { rows } = await this.db.query(
       `SELECT t.id AS take_id, t.page_id, p.slug AS page_slug, t.row_num,
               t.claim, t.kind, t.holder, t.weight,
@@ -4578,19 +4588,30 @@ export class PGLiteEngine implements BrainEngine {
        WHERE t.active
          AND t.claim % $1
          AND ($2::text[] IS NULL OR t.holder = ANY($2::text[]))
+         ${sourceFilter}
        ORDER BY score DESC, t.weight DESC
-       LIMIT $3`,
-      [query, opts.takesHoldersAllowList ?? null, limit]
+       LIMIT $${params.length}`,
+      params
     );
     return rows as unknown as TakeHit[];
   }
 
   async searchTakesVector(
     embedding: Float32Array,
-    opts: { limit?: number; takesHoldersAllowList?: string[] } = {},
+    opts: SearchOpts & { takesHoldersAllowList?: string[] } = {},
   ): Promise<TakeHit[]> {
     const limit = clampSearchLimit(opts.limit, 30, 100);
     const vec = `[${Array.from(embedding).join(',')}]`;
+    const params: unknown[] = [vec, opts.takesHoldersAllowList ?? null];
+    let sourceFilter = '';
+    if (opts.sourceIds && opts.sourceIds.length > 0) {
+      params.push(opts.sourceIds);
+      sourceFilter = `AND p.source_id = ANY($${params.length}::text[])`;
+    } else if (opts.sourceId) {
+      params.push(opts.sourceId);
+      sourceFilter = `AND p.source_id = $${params.length}`;
+    }
+    params.push(limit);
     const { rows } = await this.db.query(
       `SELECT t.id AS take_id, t.page_id, p.slug AS page_slug, t.row_num,
               t.claim, t.kind, t.holder, t.weight,
@@ -4600,9 +4621,10 @@ export class PGLiteEngine implements BrainEngine {
        WHERE t.active
          AND t.embedding IS NOT NULL
          AND ($2::text[] IS NULL OR t.holder = ANY($2::text[]))
+         ${sourceFilter}
        ORDER BY t.embedding <=> $1::vector
-       LIMIT $3`,
-      [vec, opts.takesHoldersAllowList ?? null, limit]
+       LIMIT $${params.length}`,
+      params
     );
     return rows as unknown as TakeHit[];
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4597,6 +4597,11 @@ export class PostgresEngine implements BrainEngine {
   async searchTakes(query: string, opts: SearchOpts & { takesHoldersAllowList?: string[] } = {}): Promise<TakeHit[]> {
     const sql = this.sql;
     const limit = clampSearchLimit(opts.limit, 30, 100);
+    const sourceCondition = opts.sourceIds && opts.sourceIds.length > 0
+      ? sql`AND p.source_id = ANY(${opts.sourceIds}::text[])`
+      : opts.sourceId
+        ? sql`AND p.source_id = ${opts.sourceId}`
+        : sql``;
     const rows = await sql`
       SELECT t.id AS take_id, t.page_id, p.slug AS page_slug, t.row_num,
              t.claim, t.kind, t.holder, t.weight,
@@ -4609,6 +4614,7 @@ export class PostgresEngine implements BrainEngine {
           ${opts.takesHoldersAllowList ?? null}::text[] IS NULL
           OR t.holder = ANY(${opts.takesHoldersAllowList ?? null}::text[])
         )
+        ${sourceCondition}
       ORDER BY score DESC, t.weight DESC
       LIMIT ${limit}
     `;
@@ -4622,6 +4628,11 @@ export class PostgresEngine implements BrainEngine {
     const sql = this.sql;
     const limit = clampSearchLimit(opts.limit, 30, 100);
     const vec = `[${Array.from(embedding).join(',')}]`;
+    const sourceCondition = opts.sourceIds && opts.sourceIds.length > 0
+      ? sql`AND p.source_id = ANY(${opts.sourceIds}::text[])`
+      : opts.sourceId
+        ? sql`AND p.source_id = ${opts.sourceId}`
+        : sql``;
     const rows = await sql`
       SELECT t.id AS take_id, t.page_id, p.slug AS page_slug, t.row_num,
              t.claim, t.kind, t.holder, t.weight,
@@ -4634,6 +4645,7 @@ export class PostgresEngine implements BrainEngine {
           ${opts.takesHoldersAllowList ?? null}::text[] IS NULL
           OR t.holder = ANY(${opts.takesHoldersAllowList ?? null}::text[])
         )
+        ${sourceCondition}
       ORDER BY t.embedding <=> ${vec}::vector
       LIMIT ${limit}
     `;

--- a/src/core/think/gather.ts
+++ b/src/core/think/gather.ts
@@ -17,7 +17,7 @@
 
 import type { BrainEngine, TakeHit, Take } from '../engine.ts';
 import { hybridSearch } from '../search/hybrid.ts';
-import type { SearchResult } from '../types.ts';
+import type { SearchOpts, SearchResult } from '../types.ts';
 import { sanitizeQueryForPrompt } from '../search/expansion.ts';
 
 export interface ThinkGatherOpts {
@@ -34,6 +34,16 @@ export interface ThinkGatherOpts {
   questionEmbedding?: Float32Array;
   /** When set, MCP-bound calls forward this allow-list to takes_search. Local CLI leaves unset. */
   takesHoldersAllowList?: string[];
+  /**
+   * MCP/source-scoped callers thread the active scalar source through gather.
+   * Local CLI callers leave this unset and preserve the existing unscoped search.
+   */
+  sourceId?: string;
+  /**
+   * Federated-read scope. When non-empty it wins over sourceId, matching
+   * SearchOpts/sourceScopeOpts semantics.
+   */
+  sourceIds?: string[];
 }
 
 export interface ThinkGatherResult {
@@ -54,6 +64,18 @@ export interface ThinkGatherResult {
 }
 
 const RRF_K = 60;
+
+type SourceScope = Pick<SearchOpts, 'sourceId' | 'sourceIds'>;
+
+function gatherSourceScope(opts: ThinkGatherOpts): SourceScope {
+  if (opts.sourceIds && opts.sourceIds.length > 0) {
+    return { sourceIds: opts.sourceIds };
+  }
+  if (opts.sourceId !== undefined) {
+    return { sourceId: opts.sourceId };
+  }
+  return {};
+}
 
 /** Reciprocal-rank fusion: 1/(k+rank). Stable, parameter-light, matches search/hybrid.ts k. */
 function rrfScore(rank: number): number {
@@ -101,6 +123,7 @@ export async function runGather(
   const gatherLimit = opts.gatherLimit ?? 40;
   const takesLimit = opts.takesLimit ?? 30;
   const graphDepth = opts.graphDepth ?? 2;
+  const sourceScope = gatherSourceScope(opts);
 
   // Sanitize the question for any path that includes it in an LLM prompt.
   // (Direct DB search is fine — those are parameterized queries.)
@@ -110,6 +133,7 @@ export async function runGather(
   const pagesPromise = hybridSearch(engine, opts.question, {
     limit: gatherLimit,
     expansion: false,  // think provides its own anchor + graph context; no need for re-expansion
+    ...sourceScope,
   }).catch((e) => {
     process.stderr.write(`[think.gather] hybrid stream failed: ${(e as Error).message}\n`);
     return [] as SearchResult[];
@@ -119,6 +143,7 @@ export async function runGather(
   const takesKwPromise = engine.searchTakes(opts.question, {
     limit: takesLimit,
     takesHoldersAllowList: opts.takesHoldersAllowList,
+    ...sourceScope,
   }).catch((e) => {
     process.stderr.write(`[think.gather] takes-keyword stream failed: ${(e as Error).message}\n`);
     return [] as TakeHit[];
@@ -129,6 +154,7 @@ export async function runGather(
     ? engine.searchTakesVector(opts.questionEmbedding, {
         limit: takesLimit,
         takesHoldersAllowList: opts.takesHoldersAllowList,
+        ...sourceScope,
       }).catch((e) => {
         process.stderr.write(`[think.gather] takes-vector stream failed: ${(e as Error).message}\n`);
         return [] as TakeHit[];
@@ -137,7 +163,7 @@ export async function runGather(
 
   // Stream 4: graph walk (anchor only).
   const graphPromise: Promise<string[]> = opts.anchor
-    ? engine.traversePaths(opts.anchor, { depth: graphDepth, direction: 'both' })
+    ? engine.traversePaths(opts.anchor, { depth: graphDepth, direction: 'both', ...sourceScope })
         .then(paths => {
           const slugs = new Set<string>([opts.anchor!]);
           for (const p of paths) {

--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -270,6 +270,8 @@ export async function runThink(
     anchor: opts.anchor,
     questionEmbedding,
     takesHoldersAllowList: opts.takesHoldersAllowList,
+    sourceId: opts.sourceId,
+    sourceIds: opts.allowedSources,
   });
 
   // Render evidence blocks for the prompt

--- a/test/think-pipeline.serial.test.ts
+++ b/test/think-pipeline.serial.test.ts
@@ -14,6 +14,9 @@ beforeAll(async () => {
   engine = new PGLiteEngine();
   await engine.connect({});
   await engine.initSchema();
+  await engine.executeRaw(
+    `INSERT INTO sources (id, name, config) VALUES ('ws-openbrain', 'ws-openbrain', '{}'::jsonb) ON CONFLICT (id) DO NOTHING`,
+  );
   const alice = await engine.putPage('people/alice-example', {
     title: 'Alice', type: 'person', compiled_truth: 'Alice founded Acme.',
   });
@@ -139,6 +142,59 @@ describe('runGather', () => {
     const r = await runGather(engine, { question: 'founder', takesHoldersAllowList: ['world'] });
     expect(r.takes.every(h => h.holder === 'world')).toBe(true);
   });
+
+  test('threads source scope through pages and takes gather streams', async () => {
+    const slug = 'notes/openbrain-founder-trial';
+    const scopedPage = await engine.putPage(slug, {
+      title: 'OpenBrain founder trial',
+      type: 'note',
+      compiled_truth: 'The OpenBrain founder trial conversation covered MCP onboarding, citations, gaps, and trial feedback.',
+    }, { sourceId: 'ws-openbrain' });
+    await engine.upsertChunks(slug, [{
+      chunk_index: 0,
+      chunk_text: 'The OpenBrain founder trial conversation covered MCP onboarding, citations, gaps, and trial feedback.',
+      chunk_source: 'compiled_truth',
+    }], { sourceId: 'ws-openbrain' });
+    await engine.addTakesBatch([
+      {
+        page_id: scopedPage.id,
+        row_num: 1,
+        claim: 'OpenBrain founder trial conversation covered citations and gaps.',
+        kind: 'fact',
+        holder: 'world',
+        weight: 1.0,
+      },
+    ]);
+
+    const question = 'openbrain founder trial conversation citations gaps';
+    const scoped = await runGather(engine, {
+      question,
+      sourceId: 'ws-openbrain',
+      gatherLimit: 10,
+      takesLimit: 10,
+    });
+    expect(scoped.pages.some(p => p.slug === slug)).toBe(true);
+    expect(scoped.takes.some(h => h.page_slug === slug)).toBe(true);
+
+    const wrongScope = await runGather(engine, {
+      question,
+      sourceId: 'default',
+      gatherLimit: 10,
+      takesLimit: 10,
+    });
+    expect(wrongScope.pages.some(p => p.slug === slug)).toBe(false);
+    expect(wrongScope.takes.some(h => h.page_slug === slug)).toBe(false);
+
+    const federated = await runGather(engine, {
+      question,
+      sourceId: 'default',
+      sourceIds: ['ws-openbrain'],
+      gatherLimit: 10,
+      takesLimit: 10,
+    });
+    expect(federated.pages.some(p => p.slug === slug)).toBe(true);
+    expect(federated.takes.some(h => h.page_slug === slug)).toBe(true);
+  });
 });
 
 describe('runThink (with stub client)', () => {
@@ -254,6 +310,45 @@ describe('runThink (with stub client)', () => {
       [page!.id],
     );
     expect(Number(ev[0]?.count)).toBe(1);
+  });
+
+  test('passes source scope into gather before synthesis', async () => {
+    const slug = 'notes/openbrain-founder-trial-think';
+    const scopedPage = await engine.putPage(slug, {
+      title: 'OpenBrain founder trial think',
+      type: 'note',
+      compiled_truth: 'The OpenBrain founder trial think fixture covered MCP onboarding, citations, gaps, and trial feedback.',
+    }, { sourceId: 'ws-openbrain' });
+    await engine.upsertChunks(slug, [{
+      chunk_index: 0,
+      chunk_text: 'The OpenBrain founder trial think fixture covered MCP onboarding, citations, gaps, and trial feedback.',
+      chunk_source: 'compiled_truth',
+    }], { sourceId: 'ws-openbrain' });
+    await engine.addTakesBatch([
+      {
+        page_id: scopedPage.id,
+        row_num: 1,
+        claim: 'OpenBrain founder trial think fixture covered citations and gaps.',
+        kind: 'fact',
+        holder: 'world',
+        weight: 1.0,
+      },
+    ]);
+
+    const result = await runThink(engine, {
+      question: 'openbrain founder trial think fixture citations gaps',
+      sourceId: 'ws-openbrain',
+      withTrajectory: false,
+      stubResponse: {
+        answer: `The trial conversation covered citations and gaps [${slug}#1].`,
+        citations: [{ page_slug: slug, row_num: 1, citation_index: 1 }],
+        gaps: [],
+      },
+    });
+
+    expect(result.pagesGathered).toBeGreaterThan(0);
+    expect(result.takesGathered).toBeGreaterThan(0);
+    expect(result.citations[0]?.page_slug).toBe(slug);
   });
 });
 


### PR DESCRIPTION
## Summary
- thread runThink sourceId/allowedSources into runGather
- apply the same source scope to hybrid page search, takes keyword search, takes vector search, and graph traversal
- make searchTakes/searchTakesVector honor sourceId/sourceIds in both Postgres and PGLite engines

## Why
MCP-bound think calls already receive the caller source scope and trajectory uses it, but gather dropped it. In multi-source brains this made think gather from the wrong source even when query with the same scope could find the evidence.

Observed in a multi-tenant Cloud brain:
- think("what did I discuss with the OpenBrain founder trial conversation") gathered 0 pages / 0 takes
- query("openbrain") on the same scoped brain returned the target record

The root cause was that runThink only applied source scope to trajectory. The gather phase, including takes search, did not consistently use it.

## Tests
- bun test test/think-pipeline.serial.test.ts
- bun test test/takes-mcp-allowlist.serial.test.ts
- bun run typecheck
- git diff --check