### PR TITLE
fix(fences): stop pipe characters from dropping facts and takes

### DIFF
--- a/src/core/fence-shared.ts
+++ b/src/core/fence-shared.ts
@@ -25,19 +25,31 @@
  *
  * Returns `null` when the line is not a table row (doesn't start with `|`
  * or has no second pipe). On a match, returns the cells with surrounding
- * whitespace trimmed, with the outer pipes already stripped.
- *
- * NOTE: does NOT unescape `\|` back to `|`. Round-trip-on-pipes is a
- * separate concern callers handle if their domain text legitimately
- * contains pipes (currently neither takes nor facts do at the LLM-extract
- * layer; if a hand-edit introduces one, escape-on-write at render time
- * protects the table shape).
+ * whitespace trimmed, with the outer pipes already stripped. Escaped pipes
+ * (`\|`) are treated as cell text and unescaped in the returned cells.
  */
 export function parseRowCells(line: string): string[] | null {
   const trimmed = line.trim();
   if (!trimmed.startsWith('|') || !trimmed.includes('|', 1)) return null;
-  const inner = trimmed.replace(/^\|/, '').replace(/\|$/, '');
-  return inner.split('|').map(c => c.trim());
+  const withoutLeading = trimmed.slice(1);
+  const inner = withoutLeading.endsWith('|') && withoutLeading[withoutLeading.length - 2] !== '\\'
+    ? withoutLeading.slice(0, -1)
+    : withoutLeading;
+
+  const cells: string[] = [];
+  let current = '';
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (ch === '|' && inner[i - 1] !== '\\') {
+      cells.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  cells.push(current);
+
+  return cells.map(c => unescapeFenceCell(c.trim()));
 }
 
 /**
@@ -77,11 +89,13 @@ export function parseStringCell(raw: string): string | undefined {
 
 /**
  * Escape a value for safe placement inside a pipe-separated cell. Replaces
- * any literal `|` with `\|` so the table layout stays intact. Inverse is
- * not needed at parse time today (see parseRowCells note); a future
- * `unescapeFenceCell` helper can land alongside any domain that needs to
- * read pipes back out of cell text.
+ * any literal `|` with `\|` so the table layout stays intact.
  */
 export function escapeFenceCell(s: string): string {
   return s.replace(/\|/g, '\\|');
+}
+
+/** Undo escapeFenceCell's pipe escaping after row splitting. */
+export function unescapeFenceCell(s: string): string {
+  return s.replace(/\\\|/g, '|');
 }

--- a/test/facts-fence.test.ts
+++ b/test/facts-fence.test.ts
@@ -381,6 +381,23 @@ describe('round-trip: render then parse returns equivalent rows', () => {
     });
   });
 
+  test('literal pipes in text cells survive render+parse', () => {
+    const original: ParsedFact = minimalFact(1, {
+      claim: 'Founded Acme|Co after A|B testing',
+      source: 'linkedin | crm',
+      context: 'context | with pipes',
+    });
+    const rendered = renderFactsTable([original]);
+    const reparsed = parseFactsFence(rendered);
+    expect(reparsed.warnings).toEqual([]);
+    expect(reparsed.facts).toHaveLength(1);
+    expect(reparsed.facts[0]).toMatchObject({
+      claim: original.claim,
+      source: original.source,
+      context: original.context,
+    });
+  });
+
   test('strikethrough-superseded row round-trips with supersededBy preserved', () => {
     const original: ParsedFact = minimalFact(1, {
       claim: 'Old',
@@ -472,6 +489,32 @@ describe('upsertFactRow', () => {
     expect(out).toContain('~~Old~~');
     expect(out).toContain('superseded by #2');
     expect(out).toContain('Replacement');
+  });
+
+  test('round-trip-preservation: row with literal pipes survives an unrelated append', () => {
+    const body = wrapFenceBody(
+      `| 1 | Existing Acme\\|Co fact | fact | 1.0 | world | high | 2026-01-01 |  | src\\|pipe | context\\|pipe |`,
+    );
+    const { body: out, rowNum } = upsertFactRow(body, {
+      claim: 'Unrelated new fact',
+      kind: 'fact',
+      confidence: 1.0,
+      visibility: 'world',
+      notability: 'medium',
+      validFrom: '2026-02-01',
+      source: 'new source',
+    });
+    const parsed = parseFactsFence(out);
+    expect(rowNum).toBe(2);
+    expect(parsed.warnings).toEqual([]);
+    expect(parsed.facts).toHaveLength(2);
+    expect(parsed.facts[0]).toMatchObject({
+      rowNum: 1,
+      claim: 'Existing Acme|Co fact',
+      source: 'src|pipe',
+      context: 'context|pipe',
+    });
+    expect(parsed.facts[1].rowNum).toBe(2);
   });
 });
 

--- a/test/takes-fence.test.ts
+++ b/test/takes-fence.test.ts
@@ -128,6 +128,26 @@ describe('renderTakesFence', () => {
       expect(after.source).toBe(before.source);
     }
   });
+
+  test('literal pipes in text cells survive render+parse', () => {
+    const rendered = renderTakesFence([{
+      rowNum: 1,
+      claim: 'A|B testing changed conversion',
+      kind: 'take',
+      holder: 'brain',
+      weight: 0.8,
+      sinceDate: '2026-01-01',
+      source: 'crm | linkedin',
+      active: true,
+    }]);
+    const reparsed = parseTakesFence(rendered);
+    expect(reparsed.warnings).toEqual([]);
+    expect(reparsed.takes).toHaveLength(1);
+    expect(reparsed.takes[0]).toMatchObject({
+      claim: 'A|B testing changed conversion',
+      source: 'crm | linkedin',
+    });
+  });
 });
 
 describe('upsertTakeRow', () => {
@@ -183,6 +203,34 @@ ${TAKES_FENCE_END}
       active: true,
     });
     expect(rowNum).toBe(5); // max(2,4)+1, NOT 1 (gap-fill would break refs)
+  });
+
+  test('row with literal pipes survives an unrelated append', () => {
+    const body = `## Takes
+
+${TAKES_FENCE_BEGIN}
+| # | claim | kind | who | weight | since | source |
+|---|-------|------|-----|--------|-------|--------|
+| 1 | A\\|B testing changed conversion | take | brain | 0.8 | 2026-01 | crm\\|linkedin |
+${TAKES_FENCE_END}
+`;
+    const { body: out, rowNum } = upsertTakeRow(body, {
+      claim: 'Unrelated append',
+      kind: 'take',
+      holder: 'brain',
+      weight: 0.7,
+      active: true,
+    });
+    const parsed = parseTakesFence(out);
+    expect(rowNum).toBe(2);
+    expect(parsed.warnings).toEqual([]);
+    expect(parsed.takes).toHaveLength(2);
+    expect(parsed.takes[0]).toMatchObject({
+      rowNum: 1,
+      claim: 'A|B testing changed conversion',
+      source: 'crm|linkedin',
+    });
+    expect(parsed.takes[1].rowNum).toBe(2);
   });
 });
 


### PR DESCRIPTION
## What & why

Facts and takes fences escaped literal pipe characters on write (`|` -> `\|`), but the shared row parser still split on every `|`. A row like `Founded Acme\|Co in 2017` was parsed as extra cells, then rejected as malformed. On later fence rewrites, only successfully parsed rows were rendered back, so a pipe-bearing fact or take could disappear from the markdown source of truth.

For users, this meant normal text such as `A|B testing`, `Acme|Co`, or `source: CRM | LinkedIn` could corrupt a facts/takes row. The visible effects were confusing: a newly added fact might not make it into the derived DB, search/trajectory/scorecard results could miss it, and a later unrelated append/update could silently remove the original row from the fence.

This fixes the shared fence parser so escaped pipes are treated as cell text, then unescaped back to literal `|` after splitting. Because facts and takes both use `parseRowCells`, the fix applies to both fences.

## Changes

- `parseRowCells` now splits only on unescaped pipe delimiters.
- Added `unescapeFenceCell` as the inverse of `escapeFenceCell`.
- Added facts regression coverage for:
  - `renderFactsTable -> parseFactsFence` preserving pipes in text cells.
  - `upsertFactRow` preserving an existing pipe-bearing row during an unrelated append.
- Added takes regression coverage for:
  - `renderTakesFence -> parseTakesFence` preserving pipes in text cells.
  - `upsertTakeRow` preserving an existing pipe-bearing row during an unrelated append.

## Verification

- [x] `bun test test/facts-fence.test.ts test/takes-fence.test.ts`
- [x] `bun test test/facts-fence-typed.test.ts test/takes-holder-validation.test.ts test/takes-holder-semantics.test.ts`
- [x] `bun run typecheck`
- [x] `bun run verify` - 31/31 checks green

## Documentation

No README or architecture-doc updates needed for this narrow parser fix. `CONTRIBUTING.md` says changelog/version entries are handled during the ship flow, so this PR leaves `CHANGELOG.md`, `VERSION`, and `package.json` unchanged.