### PR TITLE
fix(trajectory): stop negative metrics from inverting regression signals

### DIFF
--- a/src/core/trajectory.ts
+++ b/src/core/trajectory.ts
@@ -34,7 +34,7 @@ export interface TrajectoryRegression {
   from_date: string;   // YYYY-MM-DD
   to_value: number;
   to_date: string;
-  delta_pct: number;   // negative for a drop; range typically [-1, 0)
+  delta_pct: number;   // negative for a numeric drop; may be < -1 across zero
 }
 
 export interface TrajectoryStats {
@@ -82,8 +82,10 @@ function cosineSim(a: Float32Array, b: Float32Array): number {
  *
  * Iterates per-metric (so trajectories that interleave mrr + arr + team_size
  * don't trip false regressions across metric boundaries). Within each metric,
- * walks consecutive value pairs; a pair fires when
- * `(newer - older) / older <= -threshold`.
+ * walks consecutive value pairs; a pair fires when the newer value is lower
+ * than the older value by at least the threshold. The relative delta uses
+ * `abs(older)` as the denominator so negative-valued metrics (net income,
+ * cash flow, etc.) do not invert improvement and regression.
  *
  * Pre-condition: caller passed points sorted by (valid_from ASC, fact_id ASC).
  * The engine's `findTrajectory` enforces this. No re-sort here.
@@ -111,7 +113,7 @@ export function detectRegressions(
       // Guard against division-by-zero: a metric starting at exactly 0
       // can't compute a relative delta. Skip.
       if (oldVal === 0) continue;
-      const delta = (newVal - oldVal) / oldVal;
+      const delta = (newVal - oldVal) / Math.abs(oldVal);
       if (delta <= -threshold) {
         out.push({
           metric,

--- a/test/trajectory.test.ts
+++ b/test/trajectory.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import type { TrajectoryPoint } from '../src/core/engine.ts';
+import {
+  DEFAULT_REGRESSION_THRESHOLD,
+  detectRegressions,
+} from '../src/core/trajectory.ts';
+
+function point(args: {
+  id: number;
+  metric?: string;
+  value: number;
+  date: string;
+}): TrajectoryPoint {
+  return {
+    fact_id: args.id,
+    valid_from: new Date(args.date),
+    metric: args.metric ?? 'net_income',
+    value: args.value,
+    unit: 'USD',
+    period: 'monthly',
+    event_type: null,
+    text: `${args.metric ?? 'net_income'} = ${args.value}`,
+    source_session: null,
+    source_markdown_slug: null,
+    embedding: null,
+  };
+}
+
+describe('detectRegressions', () => {
+  test('keeps existing positive-valued drop behavior', () => {
+    const regs = detectRegressions([
+      point({ id: 1, metric: 'mrr', value: 200000, date: '2026-01-01' }),
+      point({ id: 2, metric: 'mrr', value: 150000, date: '2026-02-01' }),
+    ], DEFAULT_REGRESSION_THRESHOLD);
+
+    expect(regs).toHaveLength(1);
+    expect(regs[0]).toMatchObject({
+      metric: 'mrr',
+      from_value: 200000,
+      to_value: 150000,
+    });
+    expect(regs[0].delta_pct).toBeCloseTo(-0.25, 4);
+  });
+
+  test('does not flag a negative-valued metric improving toward zero', () => {
+    const regs = detectRegressions([
+      point({ id: 1, value: -1000, date: '2026-01-01' }),
+      point({ id: 2, value: -500, date: '2026-02-01' }),
+    ], DEFAULT_REGRESSION_THRESHOLD);
+
+    expect(regs).toEqual([]);
+  });
+
+  test('flags a negative-valued metric worsening away from zero', () => {
+    const regs = detectRegressions([
+      point({ id: 1, value: -500, date: '2026-01-01' }),
+      point({ id: 2, value: -1000, date: '2026-02-01' }),
+    ], DEFAULT_REGRESSION_THRESHOLD);
+
+    expect(regs).toHaveLength(1);
+    expect(regs[0]).toMatchObject({
+      metric: 'net_income',
+      from_value: -500,
+      to_value: -1000,
+      from_date: '2026-01-01',
+      to_date: '2026-02-01',
+    });
+    expect(regs[0].delta_pct).toBeCloseTo(-1.0, 4);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes trajectory regression detection for metrics whose values can be negative, such as net income, profit, cash flow, or loss.

Previously, `detectRegressions` calculated relative change as:

```ts
(newVal - oldVal) / oldVal
```

When `oldVal` was negative, that inverted the meaning of the delta. As a result:

- `-1000 -> -500` was incorrectly flagged as a regression, even though the metric improved
- `-500 -> -1000` was not flagged, even though the metric worsened

This PR keeps the existing "numeric drop is a regression" behavior, but computes relative change against `Math.abs(oldVal)` so negative-valued metrics do not flip improvement and regression.

## User impact

Users looking at company/founder trajectories could previously see misleading regression signals for negative financial metrics.

For example, if net income improved from `-1000` to `-500`, GBrain could report that as a regression. If net income worsened from `-500` to `-1000`, GBrain could miss the regression entirely.

This affects places that consume trajectory regression output, including:

- `gbrain eval trajectory <entity-slug>`
- `gbrain founder scorecard <entity-slug>`
- MCP `find_trajectory`
- trajectory-aware `gbrain think` flows

## Tests

- Added focused `detectRegressions` coverage for:
- existing positive-valued drop behavior
- negative-valued metric improving toward zero
- negative-valued metric worsening away from zero

## Verification

- `bun test test/trajectory.test.ts`
- relevant trajectory / scorecard tests
- `bun run typecheck`
- `bun run verify`
