### PR TITLE
fix(gateway): stop misdiagnosing explicit litellm/user-provided embedding models as unset

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -704,21 +704,24 @@ export function diagnoseEmbedding(modelOverride?: string): EmbeddingDiagnosis {
     };
   }
 
-  // Openai-compat recipes with empty models list require a user-provided model.
-  const isUserProvided = (tp as any).user_provided_models === true;
-  if (
-    Array.isArray(tp.models) &&
-    tp.models.length === 0 &&
-    (recipe.id === 'litellm' || isUserProvided)
-  ) {
-    return {
-      ok: false,
-      reason: 'user_provided_model_unset',
-      model: modelStr,
-      provider: parsed.providerId,
-      recipeId: recipe.id,
-    };
-  }
+  // NOTE: there used to be a `user_provided_model_unset` guard here for
+  // openai-compat recipes with an empty models list (litellm, llama-server,
+  // ...). It fired on recipe-STATIC properties (`models: []` +
+  // `user_provided_models: true`) without ever inspecting the user's model
+  // string — so a fully explicit `litellm:zembed-1` was misdiagnosed as
+  // "model unset", isAvailable('embedding') returned false, and hybrid
+  // search silently dropped its vector arm on every litellm /
+  // user-provided-model deployment (writes were unaffected: embed-backfill
+  // does not run this preflight, which made the failure look like
+  // "vectors exist but never match").
+  //
+  // A genuinely missing model part can never reach this point:
+  // parseModelId() throws on bare `litellm` and on `litellm:` (empty model),
+  // and that surfaces above as `unknown_provider` with a paste-ready
+  // format hint. The guard could therefore only ever misfire; removed.
+  // The `user_provided_model_unset` variant stays in EmbeddingDiagnosis
+  // for consumer compatibility (init-embed-check / embed-preflight switch
+  // arms), but diagnoseEmbedding no longer emits it.
 
   const required = recipe.auth_env?.required ?? [];
   const missing = required.filter(k => !_config!.env[k]);

--- a/test/diagnose-embedding-user-provided.test.ts
+++ b/test/diagnose-embedding-user-provided.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression: diagnoseEmbedding must accept an EXPLICIT model on
+ * user-provided-models recipes (litellm, llama-server, ...).
+ *
+ * The removed `user_provided_model_unset` guard fired on recipe-STATIC
+ * properties (`models: []` + `user_provided_models: true`) without ever
+ * inspecting the user's model string. A fully explicit `litellm:zembed-1`
+ * was misdiagnosed as "model unset", `isAvailable('embedding')` returned
+ * false, and hybridSearch silently dropped its vector arm on every
+ * litellm-proxied deployment — while embed-backfill (which skips this
+ * preflight) kept writing vectors nobody could ever retrieve.
+ *
+ * A genuinely missing model part cannot reach that guard: parseModelId()
+ * throws on bare `litellm` and on `litellm:` (empty model id), which
+ * diagnoseEmbedding surfaces as `unknown_provider` with the format hint.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  configureGateway,
+  diagnoseEmbedding,
+  isAvailable,
+  resetGateway,
+} from '../src/core/ai/gateway.ts';
+
+beforeEach(() => {
+  resetGateway();
+});
+
+afterEach(() => {
+  resetGateway();
+});
+
+describe('diagnoseEmbedding on user-provided-models recipes', () => {
+  test('explicit litellm:<model> is ok (auth optional)', () => {
+    configureGateway({
+      embedding_model: 'litellm:zembed-1',
+      embedding_dimensions: 1280,
+      env: { LITELLM_BASE_URL: 'http://gateway.internal', LITELLM_API_KEY: 'token' },
+    });
+    const d = diagnoseEmbedding();
+    expect(d.ok).toBe(true);
+    if (d.ok) {
+      expect(d.recipeId).toBe('litellm');
+      expect(d.model).toBe('litellm:zembed-1');
+    }
+    expect(isAvailable('embedding')).toBe(true);
+  });
+
+  test('explicit litellm:<model> is ok even without optional env', () => {
+    // LITELLM_* are optional (unauthenticated local proxy is a supported
+    // shape); availability must not depend on them.
+    configureGateway({ embedding_model: 'litellm:zembed-1', env: {} });
+    expect(diagnoseEmbedding().ok).toBe(true);
+  });
+
+  test('explicit llama-server:<model> is ok', () => {
+    configureGateway({
+      embedding_model: 'llama-server:zembed-1-gguf',
+      env: {},
+    });
+    const d = diagnoseEmbedding();
+    expect(d.ok).toBe(true);
+    if (d.ok) expect(d.recipeId).toBe('llama-server');
+  });
+
+  test('modelOverride litellm:<model> probes ok on a foreign default', () => {
+    // v0.36 (D10) column-override path: global default may be another
+    // provider entirely; the override's recipe is what gets probed.
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-small',
+      env: {},
+    });
+    expect(isAvailable('embedding', 'litellm:zembed-1')).toBe(true);
+  });
+
+  test('bare provider (no model part) surfaces as unknown_provider with format hint', () => {
+    configureGateway({ embedding_model: 'litellm', env: {} });
+    const d = diagnoseEmbedding();
+    expect(d.ok).toBe(false);
+    if (!d.ok) {
+      expect(d.reason).toBe('unknown_provider');
+      if (d.reason === 'unknown_provider') {
+        expect(d.message).toContain('provider');
+      }
+    }
+  });
+
+  test('empty model part (litellm:) surfaces as unknown_provider', () => {
+    configureGateway({ embedding_model: 'litellm:', env: {} });
+    const d = diagnoseEmbedding();
+    expect(d.ok).toBe(false);
+    if (!d.ok) expect(d.reason).toBe('unknown_provider');
+  });
+
+  test('missing_env still fires for recipes with required auth', () => {
+    // Ordering guard: removing the unset-check must not skip the env check.
+    configureGateway({ embedding_model: 'openai:text-embedding-3-small', env: {} });
+    const d = diagnoseEmbedding();
+    expect(d.ok).toBe(false);
+    if (!d.ok) {
+      expect(d.reason).toBe('missing_env');
+      if (d.reason === 'missing_env') {
+        expect(d.missingEnvVars).toContain('OPENAI_API_KEY');
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`diagnoseEmbedding`'s `user_provided_model_unset` guard fires on recipe-**static** properties (`models: []` + `user_provided_models: true`) without ever inspecting the user's model string. A fully explicit `litellm:zembed-1` is diagnosed as "model unset", `isAvailable('embedding')` returns `false`, and `hybridSearch` silently drops its vector arm on every litellm-proxied (or llama-server, or any user-provided-models recipe) deployment.

The failure mode is nasty to debug because it is **read-side only**: `embed-backfill` does not run this preflight, so vectors keep getting written — the corpus looks fully embedded, `gbrain doctor` embedding checks pass, but no query can ever retrieve through the vector arm. `gbrain search diagnose` shows:

```
"vector": { "note": "skipped — no embedding provider configured" }
```

despite `GBRAIN_EMBEDDING_MODEL=litellm:zembed-1` and a reachable proxy.

## Why removal (not a condition) is correct

A genuinely missing model part can never reach this guard:

- bare `litellm` → `parseModelId()` throws "missing a provider prefix"
- `litellm:` (empty model) → `parseModelId()` throws "empty provider or model"

Both surface earlier in `diagnoseEmbedding` as `unknown_provider` with the paste-ready `provider:model` format hint. Every string that reaches the guard therefore has a non-empty parsed model id — the guard could only ever misfire. Removed, with an explanatory comment at the site.

The `user_provided_model_unset` variant stays in `EmbeddingDiagnosis` so consumer switch arms (`init-embed-check.ts`, `embed-preflight.ts`) keep compiling; `diagnoseEmbedding` just no longer emits it.

## Production verification

Found and verified in a production deployment (OpenBrain Cloud) that fronts gbrain with an OpenAI-compatible internal gateway via `LITELLM_BASE_URL`:

- Before: `gbrain search diagnose "personel knowlege memori engin" --target projects/opagent` → vector `skipped — no embedding provider configured`, target absent from hybrid top-50.
- After (same env, recipe gate bypassed): vector arm runs, target present; a CJK long-question probe whose keyword tokens cannot match jumped to **vector rank 2**.

Related: this is the same litellm-recipe blind-spot family as #2600 (litellm chat touchpoint).

## Test plan

- [x] New `test/diagnose-embedding-user-provided.test.ts` (7 cases): explicit `litellm:<model>` ok with and without optional env; `llama-server:<model>` ok; `modelOverride` probe ok against a foreign global default; bare `litellm` and `litellm:` → `unknown_provider`; `missing_env` ordering preserved for recipes with required auth.
- [x] Existing adjacent suites green: `gateway-embed-model-override`, `embed-preflight`, `init-embed-check`, `embed.serial`, `sync-cost-gate.serial`, `cross-modal-hybrid-integration.serial`, `hybrid-meta.serial`, `hybrid-search-lite.serial`, `gateway-model-messages`, `think-gateway-adapter`.

Made with [Cursor](https://cursor.com)