### PR TITLE
fix(schema): bootstrap timeline_entries.event_page_id before schema-blob replay

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -498,7 +498,11 @@ export class PGLiteEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema='public' AND table_name='pages' AND column_name='embedding_signature') AS pages_embedding_signature_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema='public' AND table_name='pages' AND column_name='links_extracted_at') AS pages_links_extracted_at_exists
+                WHERE table_schema='public' AND table_name='pages' AND column_name='links_extracted_at') AS pages_links_extracted_at_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema='public' AND table_name='timeline_entries') AS timeline_entries_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='timeline_entries' AND column_name='event_page_id') AS timeline_event_page_id_exists
     `);
     const probe = rows[0] as {
       pages_exists: boolean;
@@ -541,6 +545,8 @@ export class PGLiteEngine implements BrainEngine {
       pages_generation_exists: boolean;
       pages_embedding_signature_exists: boolean;
       pages_links_extracted_at_exists: boolean;
+      timeline_entries_exists: boolean;
+      timeline_event_page_id_exists: boolean;
     };
 
     const needsPagesBootstrap = probe.pages_exists && !probe.source_id_exists;
@@ -617,6 +623,12 @@ export class PGLiteEngine implements BrainEngine {
     // it; pre-v112 brains crash without the column, so bootstrap adds it before
     // the CREATE INDEX runs. v112 runs later via runMigrations and is idempotent.
     const needsPagesLinksExtractedAt = probe.pages_exists && !probe.pages_links_extracted_at_exists;
+    // v0.42.x (v121): timeline_entries.event_page_id (Life Chronicle event
+    // projection pointer). idx_timeline_event_page + idx_timeline_event_dedup
+    // in PGLITE_SCHEMA_SQL reference it; pre-v121 brains crash on the blob's
+    // CREATE INDEX before runMigrations can apply v121. Bootstrap adds only
+    // the column; FK + partial indexes land via v121 / the blob.
+    const needsTimelineEventPageId = probe.timeline_entries_exists && !probe.timeline_event_page_id_exists;
 
     // Fresh installs (no tables yet) and modern brains both no-op.
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
@@ -628,7 +640,8 @@ export class PGLiteEngine implements BrainEngine {
         && !needsPagesProvenance
         && !needsContextualRetrievalColumns && !needsPagesGeneration
         && !needsPagesEmbeddingSignature
-        && !needsPagesLinksExtractedAt) return;
+        && !needsPagesLinksExtractedAt
+        && !needsTimelineEventPageId) return;
 
     process.stderr.write('  Pre-v0.21 brain detected, applying forward-reference bootstrap\n');
 
@@ -873,6 +886,18 @@ export class PGLiteEngine implements BrainEngine {
       // v112 runs later via runMigrations and is idempotent.
       await this.db.exec(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS links_extracted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsTimelineEventPageId) {
+      // v121 (timeline_entries_event_page_id): Life Chronicle event→timeline
+      // projection pointer. PGLITE_SCHEMA_SQL's idx_timeline_event_page /
+      // idx_timeline_event_dedup reference it, so bootstrap adds the column
+      // before the blob's CREATE INDEX runs. Without this, initSchema on a
+      // pre-v121 brain fails inside the blob replay BEFORE runMigrations can
+      // apply v121 — a self-deadlock. v121 runs later and is idempotent.
+      await this.db.exec(`
+        ALTER TABLE timeline_entries ADD COLUMN IF NOT EXISTS event_page_id INTEGER;
       `);
     }
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -507,7 +507,11 @@ export class PostgresEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'embedding_signature') AS pages_embedding_signature_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'links_extracted_at') AS pages_links_extracted_at_exists
+                WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'links_extracted_at') AS pages_links_extracted_at_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema() AND table_name = 'timeline_entries') AS timeline_entries_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'timeline_entries' AND column_name = 'event_page_id') AS timeline_event_page_id_exists
     `;
     const probe = probeRows[0]!;
 
@@ -584,6 +588,8 @@ export class PostgresEngine implements BrainEngine {
       pages_generation_exists?: boolean;
       pages_embedding_signature_exists?: boolean;
       pages_links_extracted_at_exists?: boolean;
+      timeline_entries_exists?: boolean;
+      timeline_event_page_id_exists?: boolean;
     };
     const needsContextualRetrievalColumns = (probe.pages_exists
         && (!probeCr.pages_cr_mode_exists || !probeCr.pages_corpus_generation_exists))
@@ -603,6 +609,14 @@ export class PostgresEngine implements BrainEngine {
     // SCHEMA_SQL replay creates the index. v112 runs later via runMigrations
     // and is idempotent.
     const needsPagesLinksExtractedAt = probe.pages_exists && !probeCr.pages_links_extracted_at_exists;
+    // v0.42.x (v121): timeline_entries.event_page_id (Life Chronicle event
+    // projection pointer). idx_timeline_event_page + idx_timeline_event_dedup
+    // in SCHEMA_SQL reference it; pre-v121 brains crash on the blob's
+    // CREATE INDEX before runMigrations can apply v121 — a bootstrap-or-
+    // deadlock forward reference. Bootstrap adds only the column; the FK
+    // constraint + indexes land via v121's guarded DO block / the blob.
+    const needsTimelineEventPageId = (probeCr as { timeline_entries_exists?: boolean }).timeline_entries_exists === true
+      && !(probeCr as { timeline_event_page_id_exists?: boolean }).timeline_event_page_id_exists;
 
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
         && !needsPagesDeletedAt && !needsMcpLogBootstrap && !needsSubagentProviderId
@@ -613,7 +627,8 @@ export class PostgresEngine implements BrainEngine {
         && !needsPagesProvenance
         && !needsContextualRetrievalColumns && !needsPagesGeneration
         && !needsPagesEmbeddingSignature
-        && !needsPagesLinksExtractedAt) return;
+        && !needsPagesLinksExtractedAt
+        && !needsTimelineEventPageId) return;
 
     process.stderr.write('  Pre-v0.21 brain detected, applying forward-reference bootstrap\n');
 
@@ -858,6 +873,20 @@ export class PostgresEngine implements BrainEngine {
       // idempotent.
       await conn.unsafe(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS links_extracted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsTimelineEventPageId) {
+      // v121 (timeline_entries_event_page_id): Life Chronicle event→timeline
+      // projection pointer. idx_timeline_event_page / idx_timeline_event_dedup
+      // in SCHEMA_SQL reference it, so bootstrap adds the column before the
+      // blob's CREATE INDEX runs. Without this, initSchema on a pre-v121 brain
+      // fails inside the blob replay ("column event_page_id does not exist")
+      // BEFORE runMigrations gets a chance to apply v121 — a self-deadlock.
+      // FK constraint + partial indexes land via v121's guarded DO block and
+      // the blob. v121 runs later via runMigrations and is idempotent.
+      await conn.unsafe(`
+        ALTER TABLE timeline_entries ADD COLUMN IF NOT EXISTS event_page_id INTEGER;
       `);
     }
   }

--- a/test/bootstrap.test.ts
+++ b/test/bootstrap.test.ts
@@ -196,4 +196,40 @@ describe('PGLiteEngine#applyForwardReferenceBootstrap', () => {
       await engine.disconnect();
     }
   }, 30000);
+
+  test('pre-v121 timeline_entries shape: bootstrap adds event_page_id so schema replay survives', async () => {
+    // Production incident (2026-07): a v119 brain upgraded to a v0.42.56
+    // binary wedged in `init --migrate-only` — the schema blob's
+    // `CREATE INDEX idx_timeline_event_page ON timeline_entries(event_page_id)`
+    // ran BEFORE migration v121 could add the column, and initSchema failed
+    // with `column "event_page_id" does not exist` on every attempt.
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    try {
+      await engine.initSchema();
+      const db = (engine as any).db;
+
+      // Rewind to the pre-v121 shape.
+      await db.exec(`
+        DROP INDEX IF EXISTS idx_timeline_event_page;
+        DROP INDEX IF EXISTS idx_timeline_event_dedup;
+        ALTER TABLE timeline_entries DROP CONSTRAINT IF EXISTS timeline_entries_event_page_id_fkey;
+        ALTER TABLE timeline_entries DROP COLUMN IF EXISTS event_page_id;
+      `);
+
+      await (engine as any).applyForwardReferenceBootstrap();
+
+      const { rows: col } = await db.query(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'timeline_entries' AND column_name = 'event_page_id'
+      `);
+      expect(col).toHaveLength(1);
+
+      // The wedge scenario end-to-end: full initSchema (blob replay including
+      // the two indexes + migrations) must now succeed on the rewound brain.
+      await engine.initSchema();
+    } finally {
+      await engine.disconnect();
+    }
+  }, 30000);
 });

--- a/test/schema-bootstrap-coverage.test.ts
+++ b/test/schema-bootstrap-coverage.test.ts
@@ -168,6 +168,13 @@ const REQUIRED_BOOTSTRAP_COVERAGE: ForwardReference[] = [
   // SCHEMA_SQL replay creates the index. Powers `gbrain extract --stale` + the
   // `links_extraction_lag` doctor check.
   { kind: 'column', table: 'pages', column: 'links_extracted_at' },
+  // v0.42.x (v121) — forward-referenced by `CREATE INDEX
+  // idx_timeline_event_page ON timeline_entries(event_page_id)` and the
+  // partial UNIQUE idx_timeline_event_dedup. Pre-v121 brains crash on the
+  // blob's CREATE INDEX before runMigrations can apply v121 (observed in
+  // production as `column "event_page_id" does not exist` wedging
+  // `init --migrate-only`); bootstrap adds the column first.
+  { kind: 'column', table: 'timeline_entries', column: 'event_page_id' },
 ];
 
 test('applyForwardReferenceBootstrap covers every forward reference declared in REQUIRED_BOOTSTRAP_COVERAGE', async () => {


### PR DESCRIPTION
## Summary

`initSchema` replays the embedded schema blob **before** running numbered migrations. The blob contains

```sql
CREATE INDEX IF NOT EXISTS idx_timeline_event_page ON timeline_entries(event_page_id) ...
CREATE UNIQUE INDEX IF NOT EXISTS idx_timeline_event_dedup ON timeline_entries(event_page_id, date) ...
```

but `event_page_id` is only added by migration **v121** (`timeline_entries_event_page_id`). On any pre-v121 brain the blob replay fails with `column "event_page_id" does not exist` — *before* v121 ever gets a chance to run. Both `gbrain init --migrate-only` and the automatic on-connect migration path wedge permanently, and every CLI command warns:

```
Schema probe failed: column "event_page_id" does not exist
Re-run: `gbrain apply-migrations --yes`
```

(`apply-migrations` also fails, for the same reason — its Phase A schema step hits the identical replay.)

This is the same bootstrap-or-deadlock forward-reference class as #239 / #266 / #357 / #375 (links / chunks / pages columns), which `applyForwardReferenceBootstrap` exists to prevent — v121's column just never got a bootstrap entry.

## Fix

Follows the established pattern exactly:

- `applyForwardReferenceBootstrap` (both engines) probes `timeline_entries.event_page_id` and adds the bare column before the blob replay. The FK constraint and both partial indexes still land through v121's guarded DO block / the blob's `CREATE INDEX IF NOT EXISTS`; v121 stays idempotent.
- New `REQUIRED_BOOTSTRAP_COVERAGE` entry in `schema-bootstrap-coverage.test.ts` (the CI gate this column slipped past).
- New rewind scenario in `bootstrap.test.ts`: drop the column/indexes/FK, run bootstrap, assert the column returns, then run **full `initSchema`** end-to-end to prove the wedge is gone.

## Production verification

Hit in a production Postgres brain at schema v119 running a v0.42.56 binary: migration to v122 was impossible until the column was added manually (`ALTER TABLE timeline_entries ADD COLUMN IF NOT EXISTS event_page_id INTEGER`), after which v120–v122 applied cleanly. With this patch the same upgrade completes without manual intervention.

## Test plan

- [x] `bun test test/bootstrap.test.ts test/schema-bootstrap-coverage.test.ts` — 16 pass (incl. new pre-v121 rewind + full initSchema replay)

Made with [Cursor](https://cursor.com)