### PR TITLE
fix(providers): show user-provided chat recipes as chat-capable

### DIFF
--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -73,7 +73,7 @@ export function formatRecipeTable(recipes: Recipe[], env: NodeJS.ProcessEnv = pr
   for (const r of recipes) {
     const hasEmbed = !!r.touchpoints.embedding && (r.touchpoints.embedding.models.length > 0);
     const hasExpand = !!r.touchpoints.expansion;
-    const hasChat = !!r.touchpoints.chat && r.touchpoints.chat.models.length > 0;
+    const hasChat = !!r.touchpoints.chat && (r.touchpoints.chat.models.length > 0 || r.touchpoints.chat.user_provided_models === true);
     const ready = envReady(r, env);
     const status = ready ? '✓ ready' : `✗ missing ${r.auth_env?.required?.[0] ?? 'setup'}`;
     rows.push(

--- a/src/core/ai/recipes/litellm-proxy.ts
+++ b/src/core/ai/recipes/litellm-proxy.ts
@@ -40,6 +40,15 @@ export const litellmProxy: Recipe = {
       // mismatched-dim responses pre-storage).
       supports_multimodal: true,
     },
+    chat: {
+      // Models depend on the proxy's config; users provide their own model
+      // id via --chat-model litellm:<model>.
+      models: [],
+      user_provided_models: true,
+      supports_tools: true,          // pass-through when backend supports it
+      supports_subagent_loop: true,  // pass-through when backend supports it
+      supports_prompt_cache: false,
+    },
   },
   setup_hint: 'Run LiteLLM (https://docs.litellm.ai) in front of any provider; set LITELLM_BASE_URL + pass --embedding-model litellm:<model> and --embedding-dimensions <N>.',
 };

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -204,6 +204,12 @@ export interface RerankerTouchpoint {
 
 export interface ChatTouchpoint {
   models: string[];
+  /**
+   * v0.32: when true, the recipe ships without a fixed model list and users
+   * MUST provide their own model id at runtime. Used by openai-compat
+   * proxy-style recipes (litellm, llama-server).
+   */
+  user_provided_models?: true;
   /** Provider returns native function/tool calling. */
   supports_tools: boolean;
   /**


### PR DESCRIPTION
## Problem

`gbrain providers list` shows user-provided chat recipes (like LiteLLM) as not chat-capable because `hasChat` only checks `chat.models.length > 0`, ignoring the `user_provided_models` flag that proxy-style recipes use when they ship without a fixed model list.

Closes #2602.

## Changes

1. **ChatTouchpoint interface** (`src/core/ai/types.ts`) — added `user_provided_models?: true` field matching the existing `EmbeddingTouchpoint.user_provided_models`.
2. **formatRecipeTable** (`src/commands/providers.ts`) — updated `hasChat` to treat `user_provided_models === true` as chat-capable even when `models` is empty.
3. **litellm-proxy recipe** (`src/core/ai/recipes/litellm-proxy.ts`) — added a `chat` touchpoint with `user_provided_models: true` so `providers list` correctly shows CHAT=yes.

## Verification

Tested on **Windows 11 (Git Bash)**:
- `bun test test/providers.test.ts` — 10/10 pass
- `bun test test/ai/recipe-*.test.ts` — 58/58 pass
- `bun run typecheck` — clean