### PR TITLE
fix(config): register Life Chronicle keys so the documented enable command works

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -921,6 +921,12 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   // operator had to discover these by reading source. Registered so `config
   // set` accepts them directly. See docs/operations/spend-controls.md.
   'spend.posture',
+  // Life Chronicle (v0.42.56.0, #2390). The release notes' enable command is
+  // `gbrain config set auto_chronicle true`, but the key was never registered
+  // — so the documented command failed with "Unknown config key" and the
+  // operator had to discover --force by reading source. Same class as the
+  // spend-controls registration above.
+  'auto_chronicle',
   'sync.cost_gate_min_usd',
   'sync.federated_v2',
   'embed.backfill_cooldown_min',
@@ -943,6 +949,7 @@ export const KNOWN_CONFIG_KEY_PREFIXES: readonly string[] = [
   'content_sanity.',    // v0.41 content-sanity tunables
   'mcp.',               // mcp.publish_skills, mcp.skills_dir (PR1 skill catalog)
   'autopilot.',         // autopilot.nightly_quality_probe.*, autopilot.auto_drain.* (#1685)
+  'chronicle.',         // chronicle.tz + future Life Chronicle knobs (#2390)
   'self_upgrade.',      // v0.42 self-upgrade (mode, quiet_hours, state)
 ];
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -927,6 +927,10 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   // operator had to discover --force by reading source. Same class as the
   // spend-controls registration above.
   'auto_chronicle',
+  // Takes bootstrap (v0.41.18.0, A12). The onboard remediation's two-gate
+  // consent reads this key, and enabling it is the documented path to
+  // `gbrain takes extract --from-pages` — same unregistered-key class.
+  'takes.bootstrap_enabled',
   'sync.cost_gate_min_usd',
   'sync.federated_v2',
   'embed.backfill_cooldown_min',

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -253,3 +253,13 @@ describe('loadConfig — GBRAIN_MAX_MARKUP_RATIO env (v0.42 #1699)', () => {
     });
   });
 });
+
+describe('KNOWN_CONFIG_KEYS — documented enable commands must be registered', () => {
+  test('Life Chronicle keys are registered (v0.42.56.0 release notes say `config set auto_chronicle true`)', async () => {
+    const { KNOWN_CONFIG_KEYS, KNOWN_CONFIG_KEY_PREFIXES } = await import('../src/core/config.ts');
+    // The flag the chronicle backstop reads (isAutoChronicleEnabled).
+    expect(KNOWN_CONFIG_KEYS).toContain('auto_chronicle');
+    // chronicle.tz (chronicleTz) + future chronicle.* knobs.
+    expect(KNOWN_CONFIG_KEY_PREFIXES.some(p => 'chronicle.tz'.startsWith(p))).toBe(true);
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -259,6 +259,8 @@ describe('KNOWN_CONFIG_KEYS — documented enable commands must be registered', 
     const { KNOWN_CONFIG_KEYS, KNOWN_CONFIG_KEY_PREFIXES } = await import('../src/core/config.ts');
     // The flag the chronicle backstop reads (isAutoChronicleEnabled).
     expect(KNOWN_CONFIG_KEYS).toContain('auto_chronicle');
+    // The takes bootstrap two-gate consent flag (v0.41.18.0 A12).
+    expect(KNOWN_CONFIG_KEYS).toContain('takes.bootstrap_enabled');
     // chronicle.tz (chronicleTz) + future chronicle.* knobs.
     expect(KNOWN_CONFIG_KEY_PREFIXES.some(p => 'chronicle.tz'.startsWith(p))).toBe(true);
   });


### PR DESCRIPTION
## Summary

The v0.42.56.0 release notes tell users to enable Life Chronicle with `gbrain config set auto_chronicle true`. That command fails:

```
[config] Unknown config key "auto_chronicle".
[config] No similar known key. Run `gbrain config show` to see currently-set keys.
```

The key was never registered in `KNOWN_CONFIG_KEYS`, so the documented enable path dead-ends and the operator has to discover `--force` by reading source — the exact class the v0.42.42.0 spend-controls registration fixed for `spend.posture` and friends.

This registers `auto_chronicle` in `KNOWN_CONFIG_KEYS` and adds the `chronicle.` prefix to `KNOWN_CONFIG_KEY_PREFIXES` (covers `chronicle.tz` and future Life Chronicle knobs). A regression test pins both, so a future chronicle key that ships documented-but-unregistered fails CI.

Found while enabling the feature for real on a live brain (same session as #2629/#2630).

## Tests

- `test/config.test.ts`: new case asserting `auto_chronicle` is in `KNOWN_CONFIG_KEYS` and `chronicle.tz` matches a registered prefix. Full file green (23 tests); `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQgByq4aqQq2PP8UHCdnfk
