### PR TITLE
v0.42.58.0 fix(cli): show dream source help (#2356)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,10 @@ const CLI_ONLY_SELF_HELP = new Set([
   // runCapture saw --help. brainstorm + lsd were already in the set;
   // capture was the holdout.
   'capture',
+  // Issue #2356: `gbrain dream --help` must reach dream.ts's detailed
+  // usage, including --source / --source-id. The generic stub hides the
+  // exact command doctor recommends for cycle_freshness.
+  'dream',
   // v0.42 self-upgrade ships its own usage (flags + the agent-skill story).
   'self-upgrade',
   // v0.43 (#2095): watch ships WATCH_HELP (flags + the stdin-turn protocol).

--- a/test/cli-help-discoverability.test.ts
+++ b/test/cli-help-discoverability.test.ts
@@ -60,6 +60,24 @@ describe('WARN-5 — `gbrain capture --help` reaches the detailed HELP constant'
   });
 });
 
+describe('issue #2356 — `gbrain dream --help` reaches source-scoped help', () => {
+  test('output documents the source flags doctor recommends', () => {
+    const { stdout, status } = runCli(['dream', '--help']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('--source <id>');
+    expect(stdout).toContain('--source-id <id>');
+    expect(stdout).toContain('cycle_freshness');
+    expect(stdout).toContain('gbrain dream --phase synthesize --input');
+  });
+
+  test('output is NOT the generic short-circuit fallback', () => {
+    const { stdout } = runCli(['dream', '--help']);
+    expect(stdout).toContain('Run one brain maintenance cycle');
+    expect(stdout.split('\n').length).toBeGreaterThan(20);
+    expect(stdout).not.toMatch(/^Usage: gbrain dream\s*$/m);
+  });
+});
+
 describe('WARN-6 — main `gbrain --help` lists capture/brainstorm/lsd', () => {
   test('output mentions all three commands by name', () => {
     const { stdout, status } = runCli(['--help']);

--- a/test/types/plugin-sdk-compat.d.ts
+++ b/test/types/plugin-sdk-compat.d.ts
@@ -1,0 +1,1 @@
+export function registerContextEngine(id: string, factory: () => unknown): unknown;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "*plugin-sdk": ["test/types/plugin-sdk-compat.d.ts"]
     }
   },
   "include": ["src", "test"]


### PR DESCRIPTION
## Summary

- Routes `gbrain dream --help` through the command's detailed help handler, so the documented `--source` / `--source-id` repair path is visible instead of the generic CLI-only stub.
- Adds regression coverage that spawns the real CLI dispatcher and asserts `dream --help` includes the source-scoped freshness flags and examples.
- Adds a compile-time-only `*plugin-sdk` path shim for tests, keeping local typecheck stable when an optional parent SDK is resolvable without changing runtime imports.

Fixes #2356.

## Tests

- `bun test test/cli-help-discoverability.test.ts`
  - 8 pass, 0 fail, 39 expect calls
- `gbrain-gate.sh <worktree> test/cli-help-discoverability.test.ts`
  - verify: green except the tolerated macOS-only `check:operations-filter-bypass` guard false-positive
  - unit: 8 pass, 0 fail, 39 expect calls
  - e2e: selector returned the fail-closed all-E2E set for this non-E2E-specific diff; local gate skipped unrelated E2E and CI runs the full suite
