### PR TITLE
fix(dream): stamp incremental extraction watermark

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -516,6 +516,11 @@ export interface ExtractOpts {
    */
   slugs?: string[];
   /**
+   * Source owning `dir` when the incremental cycle path supplies `slugs`.
+   * Required for source-correct edge writes and extraction watermark stamps.
+   */
+  sourceId?: string;
+  /**
    * v0.41.15.0 (D9): in-process parallel file workers for the fs-walk
    * loops. Default 1. PGLite engines clamp to 1 (single-writer; though
    * extract is mostly CPU-bound, the DB batch flush still hits the
@@ -574,7 +579,17 @@ export async function runExtractCore(engine: BrainEngine, opts: ExtractOpts): Pr
       // Nothing changed — skip entirely.
       return result;
     }
-    const r = await extractForSlugs(engine, opts.dir, opts.slugs, opts.mode, dryRun, jsonMode, workers, opts.signal);
+    const r = await extractForSlugs(
+      engine,
+      opts.dir,
+      opts.slugs,
+      opts.mode,
+      dryRun,
+      jsonMode,
+      workers,
+      opts.signal,
+      opts.sourceId,
+    );
     result.links_created = r.links_created;
     result.timeline_entries_created = r.timeline_created;
     result.pages_processed = r.pages;
@@ -953,6 +968,7 @@ async function extractForSlugs(
   // shared counter increments atomic.
   workers: number = 1,
   signal?: AbortSignal,
+  sourceId: string = 'default',
 ): Promise<{ links_created: number; timeline_created: number; pages: number }> {
   // Build the full slug set for link resolution (fast: just readdir, no file reads)
   const allFiles = walkMarkdownFiles(brainDir);
@@ -967,6 +983,7 @@ async function extractForSlugs(
   let linksCreated = 0;
   let timelineCreated = 0;
   let pagesProcessed = 0;
+  const processedRefs: Array<{ slug: string; source_id: string }> = [];
 
   // Issue #972: read the basename flag once per extract run.
   const globalBasename = await isGlobalBasenameEnabled(engine);
@@ -1033,7 +1050,12 @@ async function extractForSlugs(
               if (!jsonMode) console.log(`  ${link.from_slug} → ${link.to_slug} (${link.link_type})`);
               linksCreated++;
             } else {
-              linkBatch.push(link);
+              linkBatch.push({
+                ...link,
+                from_source_id: sourceId,
+                to_source_id: sourceId,
+                origin_source_id: sourceId,
+              });
               if (linkBatch.length >= BATCH_SIZE) await flushLinks();
             }
           }
@@ -1046,13 +1068,21 @@ async function extractForSlugs(
               if (!jsonMode) console.log(`  ${entry.slug}: ${entry.date} — ${entry.summary}`);
               timelineCreated++;
             } else {
-              timelineBatch.push({ slug: entry.slug, date: entry.date, source: entry.source, summary: entry.summary, detail: entry.detail });
+              timelineBatch.push({
+                slug: entry.slug,
+                date: entry.date,
+                source: entry.source,
+                summary: entry.summary,
+                detail: entry.detail,
+                source_id: sourceId,
+              });
               if (timelineBatch.length >= BATCH_SIZE) await flushTimeline();
             }
           }
         }
 
         pagesProcessed++;
+        if (!dryRun) processedRefs.push({ slug, source_id: sourceId });
       } catch { /* skip unreadable */ }
       progress.tick(1);
     },
@@ -1060,6 +1090,13 @@ async function extractForSlugs(
 
   await flushLinks();
   await flushTimeline();
+  // #1696 follow-up: the Dream cycle disables sync's inline extraction and
+  // routes changed slugs through this incremental path. Stamp only after BOTH
+  // link and timeline batches flush; otherwise successfully processed pages
+  // remain permanently visible to `extract --stale` / doctor.
+  if (!dryRun && mode === 'all') {
+    await stampExtracted(engine, processedRefs);
+  }
   progress.finish();
 
   if (!jsonMode) {

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -956,6 +956,7 @@ async function runPhaseExtract(
   dryRun: boolean,
   changedSlugs?: string[],
   signal?: AbortSignal,
+  sourceId?: string,
 ): Promise<PhaseResult> {
   try {
     const { runExtractCore } = await import('../commands/extract.ts');
@@ -977,6 +978,7 @@ async function runPhaseExtract(
       mode: 'all',
       dir: brainDir,
       slugs: changedSlugs,  // undefined = full walk (first run / manual)
+      sourceId,
       signal,
     });
     const linksCreated = result?.links_created ?? 0;
@@ -1706,7 +1708,14 @@ export async function runCycle(
         // If sync didn't run (phases exclude it) or failed, syncPagesAffected
         // is undefined → extract falls back to full walk (safe default).
         progress.start('cycle.extract');
-        const { result, duration_ms } = await timePhase(() => runPhaseExtract(engine, brainDir, dryRun, syncPagesAffected, opts.signal));
+        const { result, duration_ms } = await timePhase(() => runPhaseExtract(
+          engine,
+          brainDir,
+          dryRun,
+          syncPagesAffected,
+          opts.signal,
+          cycleSourceId,
+        ));
         result.duration_ms = duration_ms;
         phaseResults.push(result);
         progress.finish();

--- a/test/cycle-abort.test.ts
+++ b/test/cycle-abort.test.ts
@@ -175,7 +175,9 @@ describe('#1972 — complete cooperative-abort coverage', () => {
     const src = fs.readFileSync(new URL('../src/core/cycle.ts', import.meta.url), 'utf8');
     const body = src.slice(src.indexOf('export async function runCycle'));
     // Each long phase receives the signal.
-    expect(body).toContain('runPhaseExtract(engine, brainDir, dryRun, syncPagesAffected, opts.signal)');
+    expect(body).toContain('runPhaseExtract(');
+    expect(body).toContain('syncPagesAffected,');
+    expect(body).toContain('cycleSourceId,');
     expect(body).toMatch(/runPhaseExtractFacts\([^)]*opts\.signal\)/);
     expect(body).toContain('signal: opts.signal'); // consolidate opts
     expect(body).toContain('runPhaseLint(brainDir, dryRun, engine, opts.signal)');

--- a/test/extract-incremental.test.ts
+++ b/test/extract-incremental.test.ts
@@ -60,6 +60,36 @@ async function seedPage(slug: string, body: string): Promise<void> {
 }
 
 describe('runExtractCore — incremental cycle path (#417)', () => {
+  test('Dream incremental all-mode stamps the source-scoped extraction watermark', async () => {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path) VALUES ($1, $2, $3)`,
+      ['repo-a', 'repo-a', tempDir],
+    );
+    await engine.putPage('people/alice-example', {
+      type: 'person',
+      title: 'alice-example',
+      compiled_truth: '# alice',
+      timeline: '',
+      frontmatter: {},
+      content_hash: 'h',
+    }, { sourceId: 'repo-a' });
+    writeFileSync(join(tempDir, 'people/alice-example.md'), '# alice');
+
+    await runExtractCore(engine as unknown as BrainEngine, {
+      mode: 'all',
+      dir: tempDir,
+      slugs: ['people/alice-example'],
+      sourceId: 'repo-a',
+    });
+
+    const rows = await engine.executeRaw<{ links_extracted_at: string | null }>(
+      `SELECT links_extracted_at FROM pages WHERE slug = $1 AND source_id = $2`,
+      ['people/alice-example', 'repo-a'],
+    );
+    expect(rows[0]?.links_extracted_at).not.toBeNull();
+    expect(await engine.countStalePagesForExtraction({ sourceId: 'repo-a' })).toBe(0);
+  });
+
   test('1. slugs: [] returns immediately with zero counts (early-return path)', async () => {
     await seedPage('people/alice-example', '# alice');
     const result = await runExtractCore(engine as unknown as BrainEngine, {


### PR DESCRIPTION
Closes #2636.

## Problem

When Dream runs `sync` and `extract` together, it disables sync inline extraction and sends `syncPagesAffected` through `runExtractCore({ slugs })`. The incremental `extractForSlugs` path flushes links and timeline rows but never stamps `links_extracted_at`.

The work succeeds while doctor and `extract --stale` continue reporting the same pages as stale. An up-to-date next sync passes an empty slug set, so the backlog is never drained by Dream.

## Fix

- Thread the resolved cycle source id into incremental extraction.
- Source-qualify incremental link and timeline batch rows.
- Track successfully processed pages.
- Stamp the combined extraction watermark only after both batches flush, only for non-dry-run `mode: all`.
- Add a non-default-source regression asserting the page is no longer stale.

## Validation

- `bun test test/extract-incremental.test.ts test/core/cycle.serial.test.ts test/cycle-abort.test.ts test/sync-inline-extract-stamps.serial.test.ts test/extract-stale.test.ts`
  - 63 pass, 0 fail
- `bun run typecheck`
  - pass
- `git diff --check`
  - pass

`bun run verify` on clean upstream/master remains affected by the existing macOS no-`timeout` fallback accounting bug: all 31 checks complete successfully but are recorded as rc=143. This branch does not modify the verify runner.
