### PR TITLE
fix(health): count 'entity' pages in graph health metrics

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -4990,7 +4990,7 @@ export class PGLiteEngine implements BrainEngine {
     // dashboard, v0.10.3 metrics give entity-page-level granularity.
     const { rows: [h] } = await this.db.query(`
       WITH entity_pages AS (
-        SELECT id, slug FROM pages WHERE type IN ('person', 'company')
+        SELECT id, slug FROM pages WHERE type IN ('entity', 'person', 'company')
       )
       SELECT
         (SELECT count(*) FROM pages) as page_count,
@@ -5024,7 +5024,7 @@ export class PGLiteEngine implements BrainEngine {
       SELECT p.slug,
              (SELECT count(*) FROM links l WHERE l.from_page_id = p.id OR l.to_page_id = p.id)::int as link_count
       FROM pages p
-      WHERE p.type IN ('person', 'company')
+      WHERE p.type IN ('entity', 'person', 'company')
       ORDER BY link_count DESC
       LIMIT 5
     `);

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4977,7 +4977,7 @@ export class PostgresEngine implements BrainEngine {
     // is working as intended, not an orphan.
     const [h] = await sql`
       WITH entity_pages AS (
-        SELECT id, slug FROM pages WHERE type IN ('person', 'company')
+        SELECT id, slug FROM pages WHERE type IN ('entity', 'person', 'company')
       )
       SELECT
         (SELECT count(*) FROM pages) as page_count,
@@ -5008,7 +5008,7 @@ export class PostgresEngine implements BrainEngine {
       SELECT p.slug,
              (SELECT count(*) FROM links l WHERE l.from_page_id = p.id OR l.to_page_id = p.id)::int as link_count
       FROM pages p
-      WHERE p.type IN ('person', 'company')
+      WHERE p.type IN ('entity', 'person', 'company')
       ORDER BY link_count DESC
       LIMIT 5
     `;

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -1257,6 +1257,7 @@ describe('PGLiteEngine: getHealth graph metrics', () => {
     await engine.putPage('people/alice', { ...testPage, type: 'person', title: 'Alice' });
     await engine.putPage('people/bob', { ...testPage, type: 'person', title: 'Bob' });
     await engine.putPage('companies/acme', { ...testPage, type: 'company', title: 'Acme' });
+    await engine.putPage('entities/project-x', { ...testPage, type: 'entity', title: 'Project X' });
   });
 
   test('link_coverage = 0 when no links exist', async () => {
@@ -1265,17 +1266,17 @@ describe('PGLiteEngine: getHealth graph metrics', () => {
   });
 
   test('link_coverage = % of entity pages with >= 1 inbound link', async () => {
-    // Acme gets 1 inbound link (from Alice), Alice/Bob get 0 inbound.
-    // 1 of 3 entity pages has inbound links -> 33%.
+    // Acme gets 1 inbound link (from Alice), Alice/Bob/Reddit get 0 inbound.
+    // 1 of 4 entity pages has inbound links -> 25%.
     await engine.addLink('people/alice', 'companies/acme', '', 'works_at');
     const h = await engine.getHealth();
-    expect(h.link_coverage).toBeCloseTo(1 / 3, 2);
+    expect(h.link_coverage).toBeCloseTo(1 / 4, 2);
   });
 
   test('timeline_coverage = % with >= 1 timeline entry', async () => {
     await engine.addTimelineEntry('people/alice', { date: '2026-01-15', summary: 'Joined' });
     const h = await engine.getHealth();
-    expect(h.timeline_coverage).toBeCloseTo(1 / 3, 2);
+    expect(h.timeline_coverage).toBeCloseTo(1 / 4, 2);
   });
 
   test('most_connected lists top entities by link count', async () => {
@@ -1288,14 +1289,14 @@ describe('PGLiteEngine: getHealth graph metrics', () => {
   });
 
   test('orphan_pages: pages with neither inbound nor outbound links', async () => {
-    // All 3 pages start with no links. Expect 3 orphans.
+    // All 4 pages start with no links. Expect 4 orphans.
     const h = await engine.getHealth();
-    expect(h.orphan_pages).toBe(3);
+    expect(h.orphan_pages).toBe(4);
 
-    // Add alice -> acme. Alice has outbound, acme has inbound, only Bob is orphan.
+    // Add alice -> acme. Alice has outbound, acme has inbound, Bob and Reddit are orphan.
     await engine.addLink('people/alice', 'companies/acme', '', 'works_at');
     const h2 = await engine.getHealth();
-    expect(h2.orphan_pages).toBe(1);
+    expect(h2.orphan_pages).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Problem

`gbrain health` reports 0% entity link/timeline coverage on brains using the **gbrain-base-v2** pack, even when `doctor`'s `graph_coverage` check shows real coverage. The `getHealth` entity_pages CTE and the top-linked-pages query only match the legacy `person`/`company` types, so pages typed `entity` (the v2 pack's canonical entity primitive) are invisible to the health dashboard.

## Fix

Add `'entity'` to both queries, in both engines (PGLite + Postgres, in lockstep per the engine-parity rule). Extend the `getHealth graph metrics` test setup with an entity-typed page so the coverage math pins the new behavior.

## Validation

`bun test test/pglite-engine.test.ts --test-name-pattern 'getHealth graph metrics'` — 5 pass, 0 fail (run against this branch on current master).

Observed on a personal multi-source brain after the `unify-types` pack upgrade: doctor showed 100% entity link coverage while `health` showed 0% until this patch.