### PR TITLE
fix(embedding): per-model native dims for Ollama + explicit dims for …

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,6 +10,7 @@ import { saveConfig, loadConfig, loadConfigFileOnly, toEngineConfig, gbrainPath,
 import { createEngine } from '../core/engine-factory.ts';
 import { discoverOAuth, mintClientCredentialsToken, smokeTestMcp } from '../core/remote-mcp-probe.ts';
 import { runInitEmbedCheck } from '../core/init-embed-check.ts';
+import { effectiveDefaultDims } from '../core/embedding-dim-check.ts';
 
 export async function runInit(args: string[]) {
   // Help guard: cli.ts only routes --help to printOpHelp() for shared-op
@@ -246,7 +247,7 @@ async function resolveAIOptions(opts: ResolveAIOptionsArgs): Promise<ResolvedAIO
       process.exit(1);
     }
     out.embedding_model = `${shorthand}:${firstModel}`;
-    out.embedding_dimensions = recipe.touchpoints.embedding!.default_dims;
+    out.embedding_dimensions = effectiveDefaultDims(recipe.touchpoints.embedding!, firstModel);
   }
 
   if (dimsArg !== null && !Number.isNaN(dimsArg) && dimsArg > 0) {
@@ -271,7 +272,11 @@ async function resolveAIOptions(opts: ResolveAIOptionsArgs): Promise<ResolvedAIO
       process.exit(1);
     }
     if (recipe?.touchpoints.embedding?.default_dims) {
-      out.embedding_dimensions = recipe.touchpoints.embedding.default_dims;
+      // #2170: resolve the SELECTED model's native width (e.g. ollama:bge-m3 →
+      // 1024), not the provider-wide default_dims, so the schema isn't sized
+      // wrong when no --embedding-dimensions was passed.
+      const modelId = out.embedding_model.slice(providerId.length + 1);
+      out.embedding_dimensions = effectiveDefaultDims(recipe.touchpoints.embedding, modelId);
     }
   }
 
@@ -436,7 +441,7 @@ async function resolveEmbeddingByEnv(out: ResolvedAIOptions, nonInteractive: boo
         await import('../core/ai/defaults.ts');
       const dims = fullModel === DEFAULT_EMBEDDING_MODEL
         ? DEFAULT_EMBEDDING_DIMENSIONS
-        : tp.default_dims;
+        : effectiveDefaultDims(tp, model);
       out.embedding_model = fullModel;
       out.embedding_dimensions = dims;
       console.error(

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -13,8 +13,20 @@ export const ollama: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['nomic-embed-text', 'mxbai-embed-large', 'all-minilm'],
-      default_dims: 768, // nomic-embed-text native dim
+      models: ['nomic-embed-text', 'bge-m3', 'mxbai-embed-large', 'all-minilm'],
+      default_dims: 768, // nomic-embed-text native dim (fallback for models absent from model_dims)
+      // #2170: Ollama models emit DIFFERENT fixed native widths, but one
+      // provider-wide default_dims silently built a 768d schema for 1024d models
+      // (bge-m3, mxbai-embed-large) → `gbrain embed` then failed with a dim
+      // mismatch. Declare each model's real native width so the schema is sized
+      // correctly with no flag, and an explicit --embedding-dimensions matching
+      // the native width is accepted.
+      model_dims: {
+        'nomic-embed-text': 768,
+        'bge-m3': 1024,
+        'mxbai-embed-large': 1024,
+        'all-minilm': 384,
+      },
       cost_per_1m_tokens_usd: 0,
       price_last_verified: '2026-04-20',
       // Ollama's batch capacity depends on the locally loaded model + the

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -28,6 +28,18 @@ export interface EmbeddingTouchpoint {
   models: string[];
   default_dims: number;
   dims_options?: number[]; // for Matryoshka-aware providers
+  /**
+   * #2170: per-model native embedding width, for providers whose models emit
+   * DIFFERENT fixed dimensions under one recipe (e.g. Ollama: nomic-embed-text
+   * = 768, bge-m3 = 1024, mxbai-embed-large = 1024, all-minilm = 384). When a
+   * model is named here, this width overrides the provider-wide `default_dims`
+   * for both schema-column sizing and explicit-`--embedding-dimensions`
+   * validation; models absent from the map fall back to `default_dims`. Keys
+   * MUST be a subset of `models`. Distinct from `dims_options` (a set of
+   * *choosable* Matryoshka widths for ONE flexible model) — `model_dims` is
+   * each model's single, fixed native width.
+   */
+  model_dims?: Record<string, number>;
   cost_per_1m_tokens_usd?: number;
   price_last_verified?: string; // ISO date
   /**

--- a/src/core/embedding-dim-check.ts
+++ b/src/core/embedding-dim-check.ts
@@ -17,7 +17,7 @@ import type { BrainEngine } from './engine.ts';
 import { PGVECTOR_HNSW_VECTOR_MAX_DIMS } from './vector-index.ts';
 import { gbrainPath } from './config.ts';
 import { resolveRecipe } from './ai/model-resolver.ts';
-import type { Recipe } from './ai/types.ts';
+import type { Recipe, EmbeddingTouchpoint } from './ai/types.ts';
 import { AIConfigError } from './ai/errors.ts';
 import {
   supportsVoyageOutputDimension,
@@ -272,6 +272,17 @@ export interface ResolveSchemaEmbeddingDimOpts {
  *     `dims_options` list (Matryoshka providers). Otherwise reject — the
  *     user picked a model that doesn't support custom dims.
  */
+/**
+ * The embedding width a specific model actually emits: its per-model override
+ * from `model_dims` (e.g. Ollama `bge-m3` -> 1024) when present, else the
+ * recipe's provider-wide `default_dims`. Single source of truth for "what
+ * width will this model's schema column be" — schema/gateway dim sites resolve
+ * through it instead of reading `default_dims` directly (#2170).
+ */
+export function effectiveDefaultDims(tp: EmbeddingTouchpoint, modelId: string): number {
+  return tp.model_dims?.[modelId] ?? tp.default_dims;
+}
+
 export function resolveSchemaEmbeddingDim(opts: ResolveSchemaEmbeddingDimOpts): ResolveSchemaDimResult {
   try {
     const { recipe, parsed } = resolveRecipe(opts.embedding_model);
@@ -284,7 +295,7 @@ export function resolveSchemaEmbeddingDim(opts: ResolveSchemaEmbeddingDimOpts): 
           `Pick a recipe with an embedding touchpoint (gbrain providers list).`,
       };
     }
-    return validateDimAgainstTouchpoint(parsed.modelId, recipe, tp.default_dims, tp.dims_options, opts.embedding_dimensions);
+    return validateDimAgainstTouchpoint(parsed.modelId, recipe, tp, opts.embedding_dimensions);
   } catch (err) {
     return { ok: false, error: err instanceof AIConfigError ? err.message : String(err) };
   }
@@ -335,7 +346,7 @@ export function resolveSchemaMultimodalDim(opts: ResolveSchemaMultimodalDimOpts)
           `Pick a multimodal-capable model from this provider.`,
       };
     }
-    return validateDimAgainstTouchpoint(parsed.modelId, recipe, tp.default_dims, tp.dims_options, opts.embedding_multimodal_dimensions);
+    return validateDimAgainstTouchpoint(parsed.modelId, recipe, tp, opts.embedding_multimodal_dimensions);
   } catch (err) {
     return { ok: false, error: err instanceof AIConfigError ? err.message : String(err) };
   }
@@ -362,10 +373,11 @@ export function resolveSchemaMultimodalDim(opts: ResolveSchemaMultimodalDimOpts)
 function validateDimAgainstTouchpoint(
   modelId: string,
   recipe: Recipe,
-  defaultDims: number,
-  dimsOptions: number[] | undefined,
+  tp: EmbeddingTouchpoint,
   requestedDims: number | undefined,
 ): ResolveSchemaDimResult {
+  const defaultDims = effectiveDefaultDims(tp, modelId);
+  const dimsOptions = tp.dims_options;
   const dim = requestedDims ?? defaultDims;
 
   if (!Number.isInteger(dim) || dim <= 0) {
@@ -420,6 +432,16 @@ function isCustomDimValidForProvider(
         `Provider "${recipe.id}" model "${modelId}" rejects custom dimensions ${requestedDims} ` +
         `(allowed: ${dimsOptions.join(', ')}).`,
     };
+  }
+
+  // Tier 1.5: local "bring your own backend" recipes (llama-server, litellm,
+  // and any future user-provided-model local server) accept whatever width the
+  // user explicitly declares — the model set is open-ended, so gbrain cannot
+  // know each model's native dim. The user's --embedding-dimensions IS the
+  // source of truth here (positive-int + pgvector-cap already enforced upstream);
+  // a genuine mismatch surfaces at the engine's vector(N) column on insert. (#2170)
+  if (recipe.touchpoints.embedding?.user_provided_models === true) {
+    return { valid: true, error: '' };
   }
 
   // Tier 2: provider-specific Matryoshka allow-lists.

--- a/test/embedding-dim-check.test.ts
+++ b/test/embedding-dim-check.test.ts
@@ -20,6 +20,7 @@ import {
   PGVECTOR_COLUMN_MAX_DIMS,
 } from '../src/core/embedding-dim-check.ts';
 import { configureGateway, resetGateway } from '../src/core/ai/gateway.ts';
+import { RECIPES } from '../src/core/ai/recipes/index.ts';
 
 // Canonical pattern: single engine per file, init once, disconnect once.
 // The two tests below diverge in whether they want a migrated brain or a
@@ -308,6 +309,95 @@ describe('resolveSchemaEmbeddingDim', () => {
     if (got.ok) {
       expect(got.dim).toBe(1536);
       expect(got.model).toBe('openai:text-embedding-3-large');
+    }
+  });
+});
+
+describe('resolveSchemaEmbeddingDim — Ollama per-model native dims (#2170)', () => {
+  test('bge-m3 resolves at its native 1024 (not the provider default 768)', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:bge-m3' });
+    expect(got).toEqual({
+      ok: true,
+      dim: 1024,
+      model: 'ollama:bge-m3',
+      provider: 'ollama',
+      recipeDefault: 1024,
+    });
+  });
+
+  test('mxbai-embed-large resolves at its native 1024', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:mxbai-embed-large' });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(1024);
+  });
+
+  test('nomic-embed-text resolves at 768 (the provider default)', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:nomic-embed-text' });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(768);
+  });
+
+  test('all-minilm resolves at 384', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:all-minilm' });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(384);
+  });
+
+  test('explicit --embedding-dimensions matching the native width (bge-m3 @ 1024) is accepted', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:bge-m3', embedding_dimensions: 1024 });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(1024);
+  });
+
+  test('explicit dim contradicting the native width (bge-m3 @ 768) is rejected', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:bge-m3', embedding_dimensions: 768 });
+    expect(got.ok).toBe(false);
+    if (!got.ok) expect(got.error).toMatch(/does not support custom dimensions 768|only emits/);
+  });
+
+  test('regression (#2170): ollama:bge-m3 no longer silently builds a 768 schema', () => {
+    // Before the per-model fix this resolved to 768, then `gbrain embed` failed
+    // with "model bge-m3 returned 1024 but schema expects 768".
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'ollama:bge-m3' });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(1024);
+  });
+});
+
+describe('resolveSchemaEmbeddingDim — user-provided-model local providers (#2170 step 2)', () => {
+  test('llama-server accepts an explicit --embedding-dimensions (1024)', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'llama-server:my-embed', embedding_dimensions: 1024 });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(1024);
+  });
+
+  test('litellm accepts an explicit --embedding-dimensions (1536)', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'litellm:some-proxy-model', embedding_dimensions: 1536 });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(1536);
+  });
+
+  test('llama-server accepts a non-standard width (e.g. 896) — user knows their backend', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'llama-server:qwen-embed', embedding_dimensions: 896 });
+    expect(got.ok).toBe(true);
+    if (got.ok) expect(got.dim).toBe(896);
+  });
+
+  test('llama-server WITHOUT an explicit dimension is rejected (default_dims: 0)', () => {
+    const got = resolveSchemaEmbeddingDim({ embedding_model: 'llama-server:my-embed' });
+    expect(got.ok).toBe(false);
+    if (!got.ok) expect(got.error).toMatch(/positive integer/);
+  });
+});
+
+describe('recipe contract — model_dims keys are a subset of models (#2170)', () => {
+  test('every recipe that declares model_dims only maps models it lists', () => {
+    for (const recipe of RECIPES.values()) {
+      const tp = recipe.touchpoints.embedding;
+      if (!tp?.model_dims) continue;
+      for (const modelId of Object.keys(tp.model_dims)) {
+        expect(tp.models).toContain(modelId);
+      }
     }
   });
 });


### PR DESCRIPTION
…local providers (#2170)

GBrain pins one `default_dims` per provider, so Ollama models with different native widths can't be used, and user-provided-model local providers (llama-server, litellm) reject an explicit dimension:
- ollama:bge-m3 / ollama:mxbai-embed-large emit 1024d, but the Ollama recipe's single default_dims: 768 builds a 768d schema -> `gbrain embed` fails ("returned 1024 but schema expects 768"), and --embedding-dimensions 1024 is refused outright.
- llama-server / litellm (user_provided_models: true, default_dims: 0) hit the same Tier-3 rejection even with an explicit --embedding-dimensions.

Root cause: validateDimAgainstTouchpoint() (src/core/embedding-dim-check.ts) computes `dim = requestedDims ?? defaultDims` from the single provider-wide default_dims (no per-model notion), and isCustomDimValidForProvider() only accepts custom widths for the Matryoshka allow-list (voyage/zeroentropyai/openai). src/commands/init.ts also reads default_dims directly in three spots, bypassing the resolver.

Fix:
- Add optional model_dims?: Record<string, number> to EmbeddingTouchpoint (types.ts).
- Add effectiveDefaultDims(tp, modelId); the resolver uses the per-model width for both schema sizing and the explicit-dim comparison, so the native width is chosen with no flag and an explicit flag equal to it is accepted.
- Ollama recipe declares model_dims (nomic-embed-text 768, bge-m3 1024, mxbai-embed-large 1024, all-minilm 384) and adds bge-m3 to models; default_dims: 768 kept as fallback.
- isCustomDimValidForProvider() accepts any explicit dimension for user_provided_models local recipes (llama-server, litellm); the user's --embedding-dimensions is authoritative (positive-int + pgvector cap still enforced; a real mismatch surfaces at the vector(N) column).
- init.ts: the three direct default_dims reads now route through effectiveDefaultDims.

Tests (test/embedding-dim-check.test.ts): ollama bge-m3->1024, mxbai->1024, nomic->768, all-minilm->384; explicit 1024 accepted; a contradicting dim rejected; llama-server/ litellm accept explicit dims (incl. 896); no-dims rejected; a contract guard that model_dims keys are a subset of models. Red before, green after; tsc --noEmit clean.

Fixes #2170