### PR TITLE
fix(ai): enforce provider item-count batch caps (DashScope hard-limits 10 items/request)

### DIFF
--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -1396,13 +1396,20 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
 
   const embedding = recipe.touchpoints?.embedding;
   const maxBatchTokens = embedding?.max_batch_tokens;
+  const maxBatchItems = embedding?.max_batch_items;
   const charsPerToken = embedding?.chars_per_token ?? DEFAULT_CHARS_PER_TOKEN;
 
   // Pre-split is gated on max_batch_tokens. Recipes without it (e.g. OpenAI)
   // ride the fast path: one embedMany call, no recursion safety net.
-  const batches = maxBatchTokens
+  let batches = maxBatchTokens
     ? splitByTokenBudget(truncated, Math.floor(maxBatchTokens * effectiveSafetyFactor(recipe)), charsPerToken)
     : [truncated];
+  // Providers with a hard ITEM-COUNT ceiling (DashScope: ≤10/request) need a
+  // second subdivision pass — token budget alone can still pack too many
+  // short texts into one request. No-op when max_batch_items is unset.
+  if (maxBatchItems) {
+    batches = splitByItemLimit(batches, maxBatchItems);
+  }
 
   const allEmbeddings: Float32Array[] = [];
   let _embedThrew = false;
@@ -1480,6 +1487,25 @@ export function splitByTokenBudget(
 }
 
 /**
+ * Further subdivide token-budget batches so no sub-batch exceeds `maxItems`
+ * texts, regardless of how far under the token budget it is. Some providers
+ * (DashScope: ≤10 items/request) enforce a hard ITEM-COUNT ceiling
+ * independent of token budget. Pure; order-preserving.
+ *
+ * @internal exported for tests; not part of the public gateway API.
+ */
+export function splitByItemLimit(batches: string[][], maxItems: number): string[][] {
+  if (!maxItems || maxItems <= 0) return batches;
+  const out: string[][] = [];
+  for (const batch of batches) {
+    for (let i = 0; i < batch.length; i += maxItems) {
+      out.push(batch.slice(i, i + maxItems));
+    }
+  }
+  return out;
+}
+
+/**
  * Returns true if the error looks like a provider batch-token-limit error.
  *
  * @internal exported for tests; not part of the public gateway API.
@@ -1493,6 +1519,25 @@ export function isTokenLimitError(err: unknown): boolean {
     // OpenAI embeddings: "Invalid 'input': maximum request size is 300000 tokens per request."
     /maximum request size.*tokens/i.test(msg) ||
     /max.*tokens.*per.*request/i.test(msg)
+  );
+}
+
+/**
+ * Returns true if the error looks like a provider batch ITEM-COUNT-limit
+ * error (distinct from isTokenLimitError's token-budget errors). DashScope's
+ * OpenAI-compatible /embeddings endpoint reports this as "batch size is
+ * invalid, it should not be larger than 10" — contains neither "token" nor
+ * any of isTokenLimitError's five patterns.
+ *
+ * @internal exported for tests; not part of the public gateway API.
+ */
+export function isBatchSizeError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    /batch size.*(?:invalid|larger than|exceed)/i.test(msg) ||
+    /too many (?:items|inputs|documents) in (?:batch|request)/i.test(msg) ||
+    /(?:maximum|max)\s+(?:batch size|items per (?:batch|request|call))/i.test(msg) ||
+    /batch.*(?:exceeds|over).*(?:limit|maximum)/i.test(msg)
   );
 }
 
@@ -1600,9 +1645,15 @@ async function embedSubBatch(
   } catch (err) {
     // On token-limit error, tighten the recipe's effective safety factor
     // (so the next embed() pre-splits smaller) and recursively halve THIS
-    // batch to make forward progress without dropping work.
-    if (isTokenLimitError(err) && texts.length > MIN_SUB_BATCH) {
-      shrinkOnMiss(recipe);
+    // batch to make forward progress without dropping work. Item-count-limit
+    // errors (isBatchSizeError) reuse the same halving recovery — halving
+    // reduces both token totals and item counts — but must NOT tighten the
+    // token safety factor: the miss has no token-budget cause, and shrinking
+    // would pollute the adaptive state's semantics.
+    const tokenMiss = isTokenLimitError(err);
+    const itemMiss = !tokenMiss && isBatchSizeError(err);
+    if ((tokenMiss || itemMiss) && texts.length > MIN_SUB_BATCH) {
+      if (tokenMiss) shrinkOnMiss(recipe);
       const mid = Math.ceil(texts.length / 2);
       const left = await embedSubBatch(texts.slice(0, mid), model, providerOpts, expectedDims, recipe, modelId, opts);
       const right = await embedSubBatch(texts.slice(mid), model, providerOpts, expectedDims, recipe, modelId, opts);

--- a/src/core/ai/recipes/dashscope.ts
+++ b/src/core/ai/recipes/dashscope.ts
@@ -24,12 +24,17 @@ export const dashscope: Recipe = {
   },
   touchpoints: {
     embedding: {
-      models: ['text-embedding-v3', 'text-embedding-v2'],
+      models: ['text-embedding-v3', 'text-embedding-v2', 'text-embedding-v4'],
       default_dims: 1024,
       dims_options: [64, 128, 256, 512, 768, 1024],
-      // Alibaba doesn't publish a hard batch-token cap for the OpenAI-compat
-      // path. Conservative declaration so the gateway pre-splits before
-      // hitting whatever undocumented server-side limit exists.
+      // DashScope's OpenAI-compat /embeddings endpoint hard-caps at 10
+      // ITEMS per request regardless of token size (documented as 批次大小=10
+      // in the model-studio reference; empirically confirmed — the endpoint
+      // 400s with "batch size is invalid, it should not be larger than 10").
+      // max_batch_items does the real enforcement; max_batch_tokens reverts
+      // to its original job (guarding against pathologically long aggregate
+      // content) now that it no longer has to double as an item-count proxy.
+      max_batch_items: 10,
       max_batch_tokens: 8192,
       // text-embedding-v3 mixes English + CJK heavily; the tokenizer is
       // closer to Voyage density than OpenAI tiktoken for CJK-dominant

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -40,6 +40,17 @@ export interface EmbeddingTouchpoint {
    */
   max_batch_tokens?: number;
   /**
+   * Maximum number of ITEMS (texts) per batch, independent of token budget.
+   * Some providers (DashScope: ≤10/request) enforce a hard item-count
+   * ceiling regardless of how short each item is — a token-budget-only
+   * pre-split can still pack more than this many short chunks into one
+   * batch. When set, the gateway further subdivides each token-budget
+   * batch so no sub-batch exceeds this count. Composes with
+   * max_batch_tokens; either constraint alone still works if the other
+   * is unset.
+   */
+  max_batch_items?: number;
+  /**
    * Expected character density for this provider's tokenizer (chars per
    * token). OpenAI tiktoken averages ~4 on English text; Voyage averages
    * ~1 on mixed content (code/JSON/CJK). Defaults to 4 if omitted.

--- a/test/ai/adaptive-embed-batch.test.ts
+++ b/test/ai/adaptive-embed-batch.test.ts
@@ -34,7 +34,9 @@ import {
   resetGateway,
   embed,
   splitByTokenBudget,
+  splitByItemLimit,
   isTokenLimitError,
+  isBatchSizeError,
   __setEmbedTransportForTests,
   __getShrinkStateForTests,
 } from '../../src/core/ai/gateway.ts';
@@ -81,6 +83,21 @@ function configureGoogle(): void {
     embedding_model: 'google:gemini-embedding-001',
     embedding_dimensions: 768,
     env: { GOOGLE_GENERATIVE_AI_API_KEY: 'fake' },
+  });
+}
+
+// Real error string returned by DashScope's OpenAI-compatible /embeddings
+// endpoint when a request carries more than 10 items. Note: no "token"
+// wording — none of isTokenLimitError's patterns match it.
+const DASHSCOPE_BATCH_SIZE_ERROR = new Error(
+  'batch size is invalid, it should not be larger than 10',
+);
+
+function configureDashScope(): void {
+  configureGateway({
+    embedding_model: 'dashscope:text-embedding-v4',
+    embedding_dimensions: 1024,
+    env: { DASHSCOPE_API_KEY: 'sk-fake' },
   });
 }
 
@@ -184,6 +201,79 @@ describe('isTokenLimitError (pure helper)', () => {
   });
 });
 
+describe('splitByItemLimit (pure helper)', () => {
+  test('empty input returns empty array', () => {
+    expect(splitByItemLimit([], 10)).toEqual([]);
+  });
+
+  test('batches at or under the limit pass through unchanged', () => {
+    const batches = [['a', 'b'], ['c', 'd', 'e']];
+    expect(splitByItemLimit(batches, 5)).toEqual([['a', 'b'], ['c', 'd', 'e']]);
+    expect(splitByItemLimit(batches, 3)).toEqual([['a', 'b'], ['c', 'd', 'e']]);
+  });
+
+  test('over-limit batch is subdivided into ≤maxItems slices', () => {
+    const batch = Array.from({ length: 12 }, (_, i) => `t${i}`);
+    const result = splitByItemLimit([batch], 10);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toHaveLength(10);
+    expect(result[1]).toHaveLength(2);
+  });
+
+  test('multiple input batches are each subdivided independently', () => {
+    const a = Array.from({ length: 11 }, (_, i) => `a${i}`);
+    const b = Array.from({ length: 21 }, (_, i) => `b${i}`);
+    const result = splitByItemLimit([a, b], 10);
+    expect(result.map(x => x.length)).toEqual([10, 1, 10, 10, 1]);
+  });
+
+  test('maxItems of 0 / negative / undefined passes batches through untouched', () => {
+    const batches = [Array.from({ length: 25 }, (_, i) => `t${i}`)];
+    expect(splitByItemLimit(batches, 0)).toBe(batches);
+    expect(splitByItemLimit(batches, -1)).toBe(batches);
+    expect(splitByItemLimit(batches, undefined as unknown as number)).toBe(batches);
+  });
+
+  test('concatenating the output reproduces the input order exactly', () => {
+    const a = Array.from({ length: 17 }, (_, i) => `a${i}`);
+    const b = Array.from({ length: 4 }, (_, i) => `b${i}`);
+    const result = splitByItemLimit([a, b], 5);
+    expect(result.flat()).toEqual([...a, ...b]);
+    for (const slice of result) {
+      expect(slice.length).toBeLessThanOrEqual(5);
+    }
+  });
+});
+
+describe('isBatchSizeError (pure helper)', () => {
+  test('matches the real DashScope batch-size error verbatim', () => {
+    expect(isBatchSizeError(DASHSCOPE_BATCH_SIZE_ERROR)).toBe(true);
+  });
+
+  test('matches generic item-count-limit variants', () => {
+    expect(isBatchSizeError(new Error('too many inputs in request'))).toBe(true);
+    expect(isBatchSizeError(new Error('too many items in batch'))).toBe(true);
+    expect(isBatchSizeError(new Error('exceeded maximum batch size of 16'))).toBe(true);
+    expect(isBatchSizeError(new Error('max items per request is 32'))).toBe(true);
+    expect(isBatchSizeError(new Error('batch count exceeds the limit'))).toBe(true);
+  });
+
+  test('does not match token-budget or unrelated errors', () => {
+    expect(isBatchSizeError(VOYAGE_TOKEN_LIMIT_ERROR)).toBe(false);
+    expect(isBatchSizeError(new Error('Token limit exceeded for batch request'))).toBe(false);
+    expect(isBatchSizeError(new Error('Connection refused'))).toBe(false);
+    expect(isBatchSizeError(new Error('Invalid API key'))).toBe(false);
+    expect(isBatchSizeError(new Error('429 rate limited'))).toBe(false);
+  });
+
+  test('handles non-Error throwables', () => {
+    expect(isBatchSizeError('batch size is invalid, it should not be larger than 10')).toBe(true);
+    expect(isBatchSizeError({ message: 'some other thing' })).toBe(false);
+    expect(isBatchSizeError(null)).toBe(false);
+    expect(isBatchSizeError(undefined)).toBe(false);
+  });
+});
+
 // --------- 2-4. Recursion via embed() with stubbed transport ---------
 
 describe('embed() recursion via stubbed transport', () => {
@@ -231,6 +321,55 @@ describe('embed() recursion via stubbed transport', () => {
     // preservation despite the embeddings being concatenated from two calls.
     const slotZero = result.map(v => v[0]);
     expect(slotZero).toEqual([0, 1, 2, 3, 4, 0, 1, 2, 3, 4]);
+  });
+
+  test('dashscope recipe: 47 short texts → every transport call carries ≤10 items (regression: live 400)', async () => {
+    // Encodes the exact live-bug shape: many short chunks fit easily inside
+    // the token budget, so a token-budget-only pre-split packs >10 into one
+    // request and DashScope 400s. With max_batch_items: 10 declared, the
+    // gateway must subdivide so NO call ever exceeds 10 items.
+    configureDashScope();
+
+    const stub = mock(async ({ values }: { values: string[] }) => {
+      if (values.length > 10) throw DASHSCOPE_BATCH_SIZE_ERROR;
+      return fakeEmbeddings(values, 1024);
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    const texts = Array.from({ length: 47 }, (_, i) => `short-${i}`);
+    const result = await embed(texts);
+
+    expect(result).toHaveLength(47);
+    // 47 items → pre-split into [10, 10, 10, 10, 7]: five calls, zero errors.
+    expect(stub).toHaveBeenCalledTimes(5);
+    for (const [arg] of stub.mock.calls) {
+      expect((arg as { values: string[] }).values.length).toBeLessThanOrEqual(10);
+    }
+    const callLengths = stub.mock.calls.map(([arg]) => (arg as { values: string[] }).values.length);
+    expect(callLengths).toEqual([10, 10, 10, 10, 7]);
+  });
+
+  test('item-count-limit error triggers halving recovery WITHOUT tightening the token safety factor', async () => {
+    // A recipe with no max_batch_items declared (voyage) can still hit a
+    // provider item-count ceiling. The halving safety net must engage (halving
+    // reduces item counts too), but shrinkOnMiss must NOT fire — the miss has
+    // no token-budget cause.
+    configureVoyage();
+
+    const stub = mock(async ({ values }: { values: string[] }) => {
+      if (values.length > 10) throw DASHSCOPE_BATCH_SIZE_ERROR;
+      return fakeEmbeddings(values, 1024);
+    });
+    __setEmbedTransportForTests(stub as any);
+
+    const texts = Array.from({ length: 16 }, (_, i) => `t${i}`);
+    const result = await embed(texts);
+
+    expect(result).toHaveLength(16);
+    // 16 fails → halves into 8 + 8: three calls total.
+    expect(stub).toHaveBeenCalledTimes(3);
+    // Token safety factor untouched: item misses must not pollute shrink state.
+    expect(__getShrinkStateForTests('voyage')).toBeUndefined();
   });
 
   test('terminal case: single text always fails → normalizes and throws (no infinite loop)', async () => {

--- a/test/ai/recipe-dashscope.test.ts
+++ b/test/ai/recipe-dashscope.test.ts
@@ -55,6 +55,12 @@ describe('recipe: dashscope', () => {
     expect(r.touchpoints.embedding!.chars_per_token).toBeGreaterThan(0);
   });
 
+  test('declares max_batch_items: 10 (DashScope hard item-count cap per request)', () => {
+    const r = getRecipe('dashscope')!;
+    expect(r.touchpoints.embedding!.max_batch_items).toBe(10);
+    expect(r.touchpoints.embedding!.models).toContain('text-embedding-v4');
+  });
+
   test('dimsProviderOptions threads dimensions for text-embedding-v3 (Matryoshka)', async () => {
     // Codex finding #1: DashScope text-embedding-v3 is Matryoshka 64-1024.
     // Without `dimensions` on the wire, user-selected non-default dims are


### PR DESCRIPTION
## Problem

DashScope's OpenAI-compatible `/embeddings` endpoint enforces a hard **item-count** cap: at most **10 texts per request**, regardless of token size. The error is:

```
<400> InternalError.Algo.InvalidParameter: Value error, batch size is invalid, it should not be larger than 10.: input.contents
```

Two gaps in the gateway made this unrecoverable:

1. **Pre-split is token-budget only.** `splitByTokenBudget()` never counts items, and `EmbeddingTouchpoint` has no item-count field — many short chunks easily pack >10 items into one request while staying far under the token budget.
2. **The halving safety net never engages.** `isTokenLimitError()`'s five patterns all require token-ish wording; the DashScope message contains none of it, so the whole `embed()` call fails — including sibling batches that would have succeeded.

Real-world effect: pages with many short chunks fail to embed, and repeatedly hand-tuning `max_batch_tokens` downward (8192 → 2000 → 800) is a probability game — there is no finite token budget that *guarantees* ≤10 items when chunk length has no lower bound.

## Fix (pure-additive, default-off)

- **types.ts** — add optional `EmbeddingTouchpoint.max_batch_items`. Unset ⇒ behavior is byte-identical for every existing recipe.
- **gateway.ts** — add `splitByItemLimit()`: a second subdivision pass after the token pre-split (no-op when the field is unset). Add `isBatchSizeError()` as a semantic sibling of `isTokenLimitError()`; item-count misses reuse the same recursive-halving recovery (halving reduces item counts too) but do **not** call `shrinkOnMiss()` — the miss has no token-budget cause, so tightening the token safety factor would pollute the adaptive state.
- **dashscope.ts** — declare `max_batch_items: 10`, restore `max_batch_tokens` to 8192 (it no longer has to double as an item-count proxy), add `text-embedding-v4` to the models list (registerExtendedModel already allows it at runtime; the static list was stale).

Shape precedent: this is a direct extension of the `max_batch_tokens` / `isTokenLimitError` mechanism (#680).

## Tests

- `splitByItemLimit` pure-helper describe: empty input, ≤limit passthrough, subdivision, independent per-batch splitting, 0/negative/undefined guard, order preservation.
- `isBatchSizeError` pure-helper describe: real DashScope message verbatim, generic variants, no false positives on token-limit/unrelated errors, non-Error throwables.
- Live-bug-shape regression: dashscope recipe + 47 short texts ⇒ transport receives exactly `[10, 10, 10, 10, 7]`, zero errors.
- Item-miss recovery: recipe *without* `max_batch_items` hitting an item-count error ⇒ halving engages, shrink state stays untouched.
- `recipe-dashscope.test.ts`: asserts `max_batch_items: 10` + v4 in models.

`bun test test/ai/`: **328 pass / 0 fail.**

Also verified against the real DashScope API (China endpoint, real key): 12 items direct ⇒ HTTP 400 with the message above; 15 items through the patched gateway ⇒ 15 vectors @1024, no 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)