### PR TITLE
fix(mcp): treat stdio serve as a trusted local pipe (remote=false)

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -15,6 +15,35 @@ import {
 } from '../core/context/resolve-ipc.ts';
 import { resolveEntitiesToPointers, logDeliveredReflexPointers } from '../core/context/retrieval-reflex.ts';
 
+/**
+ * Dispatch context defaults for the stdio MCP transport.
+ *
+ * stdio serve runs over a local pipe on the owner's own machine — the same
+ * trust boundary as `gbrain call` (which passes `remote: false` in src/cli.ts).
+ * Treating it as remote/untrusted (`remote: true`) meant `whoami` and every
+ * write op fail-closed with `unknown_transport`, because a local pipe never
+ * threads `ctx.auth` (there is no per-token auth). The whoami op's own error
+ * text prescribes the fix: "populate ctx.auth OR set ctx.remote === false".
+ *
+ * Private "takes" stay gated by `takesHoldersAllowList` — an INDEPENDENT filter
+ * (`WHERE holder = ANY(...)`), not coupled to `remote` — so trusting the local
+ * pipe here does not widen hunch visibility: agent-facing stdio still sees only
+ * world-visible takes via takes_list / takes_search / query.
+ */
+export function stdioDispatchDefaults(): {
+  remote: boolean;
+  takesHoldersAllowList: string[];
+  sourceId: string;
+} {
+  return {
+    remote: false,
+    takesHoldersAllowList: ['world'],
+    // source defaults to 'default' for stdio (no per-token scope). Override with
+    // GBRAIN_SOURCE in the env, or use --source via `gbrain call`.
+    sourceId: process.env.GBRAIN_SOURCE || 'default',
+  };
+}
+
 export async function startMcpServer(engine: BrainEngine) {
   const server = new Server(
     { name: 'gbrain', version: VERSION },
@@ -29,24 +58,13 @@ export async function startMcpServer(engine: BrainEngine) {
   }));
 
   // Dispatch tool calls via shared dispatch.ts (parity with HTTP transport).
-  // MCP stdio callers are remote/untrusted; dispatch defaults remote=true.
   // The MCP SDK's response type widened in 1.29 to allow a managed-task wrapper;
   // gbrain ops are synchronous, so we return the legacy `{ content, isError? }`
   // shape and cast through `any` (the SDK accepts it via the ServerResult union).
   server.setRequestHandler(CallToolRequestSchema, async (request: any): Promise<any> => {
     const { name, arguments: params } = request.params;
-    // v0.28: stdio MCP has no per-token auth (local pipe). Default the
-    // takes-holder allow-list to ['world'] so agent-facing callers don't
-    // see private hunches via takes_list / takes_search / query. Operators
-    // who want stdio to see everything should call ops directly via
-    // `gbrain call <op>` (sets remote=false in src/cli.ts).
     return dispatchToolCall(engine, name, params, {
-      remote: true,
-      takesHoldersAllowList: ['world'],
-      // v0.31: source defaults to 'default' for stdio (no per-token scope).
-      // Operators who want a different source on stdio MCP should set
-      // GBRAIN_SOURCE in the env or use --source via `gbrain call`.
-      sourceId: process.env.GBRAIN_SOURCE || 'default',
+      ...stdioDispatchDefaults(),
       // v0.31 (eD3): _meta.brain_hot_memory injection so Claude Desktop /
       // Code see the brain's relevant hot memory automatically alongside
       // every tool-call response. Best-effort; absorbs errors.

--- a/test/mcp-stdio-dispatch.test.ts
+++ b/test/mcp-stdio-dispatch.test.ts
@@ -1,0 +1,30 @@
+/**
+ * stdio MCP dispatch-defaults contract test.
+ *
+ * Regression guard for the stdio transport running as a trusted local pipe:
+ * `remote: false` so whoami + write ops don't fail-closed with
+ * `unknown_transport`, while private takes stay gated by the independent
+ * takes-holder allow-list. Pure test — reads the exported defaults, spins up
+ * no server and touches no DB (mirrors test/whoami.test.ts's op-contract style).
+ */
+
+import { test, expect, describe } from 'bun:test';
+import { stdioDispatchDefaults } from '../src/mcp/server.ts';
+
+describe('stdio MCP dispatch defaults', () => {
+  test('runs as a trusted local pipe (remote=false) so whoami/writes work', () => {
+    expect(stdioDispatchDefaults().remote).toBe(false);
+  });
+
+  test('still gates private takes to world-visible holders only', () => {
+    expect(stdioDispatchDefaults().takesHoldersAllowList).toEqual(['world']);
+  });
+
+  test('defaults the source scope to "default"', () => {
+    // Asserts the fallback branch only when the ambient env leaves it unset,
+    // so the test never mutates process.env (test-isolation R1).
+    if (!process.env.GBRAIN_SOURCE) {
+      expect(stdioDispatchDefaults().sourceId).toBe('default');
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Over the **stdio** MCP transport (Claude Desktop / Claude Code / any local pipe), `whoami` and **every write op** fail-closed:

```
{"error":"unknown_transport","message":"whoami called over a remote transport that did not thread ctx.auth. ..."}
```

`src/mcp/server.ts` dispatches stdio tool calls with `remote: true`, but a local pipe never threads `ctx.auth` (there's no per-token auth), so auth-gated ops throw. Reads work; writes and `whoami` are unusable over stdio.

## Fix

Treat stdio serve as the **trusted local pipe it is** — the same trust boundary as `gbrain call`, which already passes `remote: false` (`src/cli.ts`). This is exactly the whoami op's own prescribed remedy: *"populate ctx.auth OR set ctx.remote === false."*

- Extract the stdio dispatch context into an exported `stdioDispatchDefaults()` helper and set `remote: false`.
- **Private takes stay private:** `takesHoldersAllowList: ['world']` is an independent filter (`WHERE holder = ANY(...)`), not coupled to `remote`. Agent-facing stdio still sees only world-visible takes via `takes_list` / `takes_search` / `query`. (The old comment conflated the two — the allow-list, not `remote`, is what gates hunches.)

## Test

Adds `test/mcp-stdio-dispatch.test.ts` pinning the defaults (`remote === false`, allow-list preserved) — pure, no server/DB, matching `test/whoami.test.ts`'s op-contract style.

## Verification

```
bun test test/mcp-stdio-dispatch.test.ts test/whoami.test.ts   # 12 pass
bun run verify                                                  # 31 checks green
```

Manually confirmed against a freshly-spawned `gbrain serve`: `whoami` → `{transport:"local"}` and `put_page` writes succeed.
