### PR TITLE
fix(lint): guard wrapping-fence strip behind code-fence-wrap predicate

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -291,9 +291,19 @@ export function fixContent(content: string): string {
     fixed = fixed.replace(pattern, '');
   }
 
-  // Fix wrapping code fences
-  fixed = fixed.replace(/^```(?:markdown|md)\s*\n/, '');
-  fixed = fixed.replace(/\n```\s*$/, '');
+  // Fix wrapping code fences — guard the strip so it ONLY runs when the page
+  // is genuinely ```markdown/```md-wrapped (opening fence AND matching closing
+  // fence). Previously these replaces ran unconditionally on every fixContent()
+  // call, so any unrelated fixable issue (e.g. frontmatter-nested-quotes) would
+  // trigger a rewrite and silently strip a legit trailing ``` that closed an
+  // interior code block — corrupting code-heavy pages such as technical docs.
+  // The guard mirrors lintContent()'s code-fence-wrap predicate exactly.
+  const isMarkdownWrapped =
+    content.match(/^```(?:markdown|md)\s*\n/m) && content.match(/\n```\s*$/m);
+  if (isMarkdownWrapped) {
+    fixed = fixed.replace(/^```(?:markdown|md)\s*\n/, '');
+    fixed = fixed.replace(/\n```\s*$/, '');
+  }
 
   // Clean up excessive blank lines left by fixes
   fixed = fixed.replace(/\n{3,}/g, '\n\n');

--- a/test/lint.test.ts
+++ b/test/lint.test.ts
@@ -97,6 +97,30 @@ describe('fixContent', () => {
     expect(fixed).toContain('# Title');
   });
 
+  test('does NOT strip a trailing fence from a non-wrapped page (interior code block)', () => {
+    // Regression: fixContent() used to run the wrapping-fence strip
+    // unconditionally. A page with no ```markdown wrapper but with a legit
+    // interior code block lost its closing ``` whenever ANY fixable issue
+    // caused a rewrite. With the guard, a nothing-to-fix page is returned
+    // byte-for-byte unchanged.
+    const input =
+      '---\ntitle: Vec\ntype: concept\ncreated: 2026-07-03\n---\n\n# Vec\n\n```ts\nconst x = 1;\n```\n';
+    const fixed = fixContent(input);
+    expect(fixed).toBe(input);
+    expect(fixed.endsWith('```\n')).toBe(true);
+  });
+
+  test('does NOT strip a trailing fence even when an unrelated fix applies', () => {
+    // Same regression, but with an LLM preamble present so fixContent()
+    // genuinely rewrites the body. The interior code block's closing ```
+    // must survive the preamble removal.
+    const input =
+      'Of course. Here is the brain page.\n\n# T\n\n```ts\nconst x = 1;\n```\n';
+    const fixed = fixContent(input);
+    expect(fixed).not.toContain('Of course');
+    expect(fixed.endsWith('```\n')).toBe(true);
+  });
+
   test('cleans up excessive blank lines after fix', () => {
     const input = 'Of course. Here is the brain page.\n\n\n\n# Title\n\nContent.';
     const fixed = fixContent(input);


### PR DESCRIPTION
## Problem

`fixContent()` in `src/commands/lint.ts` ran the two wrapping-fence strip replaces **unconditionally** on every call. Because `runLintCore()` invokes `fixContent()` whenever *any* fixable issue is present (e.g. `frontmatter-nested-quotes`, `llm-preamble`), an unrelated fixable issue triggered a full rewrite and silently stripped a legit trailing ``` that closed an **interior** code block.

Result: code-heavy pages whose last block is a fenced snippet (e.g. technical docs) lose their closing fence, the code block runs to EOF, and the next lint pass sees an unbalanced fence.

## Root cause

Detection and fix were decoupled. The `code-fence-wrap` *rule* requires both an opening ```` ```markdown ````/```` ```md ```` fence AND a matching closing fence, but `fixContent()` applied the closing-fence strip unconditionally:

```ts
// before — runs on every fixContent() call, regardless of the rule firing
fixed = fixed.replace(/^```(?:markdown|md)\s*\n/, '');
fixed = fixed.replace(/\n```\s*$/, '');
```

## Fix

Guard the strip with the same predicate `lintContent()` uses for the `code-fence-wrap` rule, so it only fires when the page is genuinely wrapped:

```ts
const isMarkdownWrapped =
  content.match(/^```(?:markdown|md)\s*\n/m) && content.match(/\n```\s*$/m);
if (isMarkdownWrapped) {
  fixed = fixed.replace(/^```(?:markdown|md)\s*\n/, '');
  fixed = fixed.replace(/\n```\s*$/, '');
}
```

## Tests

Two regression tests added to `test/lint.test.ts`:
- non-wrapped page with an interior code block → returned byte-for-byte unchanged
- non-wrapped page with an LLM preamble (so `fixContent()` genuinely rewrites the body) → the interior closing fence survives

All 20 tests pass: `bun test test/lint.test.ts`.
