### PR TITLE
Fix propose_takes proposal identity

### DIFF
--- a/src/core/cycle/propose-takes.ts
+++ b/src/core/cycle/propose-takes.ts
@@ -6,10 +6,11 @@
  * `take_proposals` queue. User accepts/rejects via `gbrain takes propose`.
  *
  * Idempotency contract (D17 schema spec):
- *   The unique index on (source_id, page_slug, content_hash, prompt_version)
- *   means an unchanged page never re-spends LLM tokens. Bumping
- *   PROPOSE_TAKES_PROMPT_VERSION cleanly invalidates the cache so a tuned
- *   prompt re-runs proposals on every page.
+ *   `take_proposal_scans` is the page-scan cache keyed by
+ *   (source_id, page_slug, content_hash, prompt_version), so unchanged pages
+ *   never re-spend LLM tokens. Individual proposal rows use claim_hash identity
+ *   keyed by (source_id, page_slug, prompt_version, claim_hash), so a page may
+ *   persist multiple claims while reruns do not duplicate the same claim.
  *
  * F2 fence dedup:
  *   The phase reads the page's existing `<!-- gbrain:takes:begin -->` fence
@@ -151,6 +152,7 @@ export interface ProposeTakesResult {
   pages_scanned: number;
   cache_hits: number;
   cache_misses: number;
+  proposals_extracted: number;
   proposals_inserted: number;
   budget_exhausted: boolean;
   warnings: string[];
@@ -163,6 +165,24 @@ export interface ProposeTakesResult {
  */
 export function contentHash(pageBody: string): string {
   return createHash('sha256').update(pageBody).digest('hex');
+}
+
+/**
+ * Canonical proposal identity. Keep this in lockstep with migration v123's
+ * `claim_hash` backfill SQL. Excludes weight/model/run/content metadata so
+ * confidence jitter or page edits do not create duplicate same-claim proposals.
+ */
+export function canonicalProposalIdentity(p: Pick<ProposedTake, 'claim_text' | 'kind' | 'holder'>): string {
+  return [
+    p.claim_text.trim().replace(/\s+/g, ' ').toLowerCase(),
+    p.kind.trim().toLowerCase(),
+    p.holder.trim().toLowerCase(),
+  ].join('\x1f');
+}
+
+/** Deterministic claim identity hash used by runtime inserts and migration backfill. */
+export function proposalClaimHash(p: Pick<ProposedTake, 'claim_text' | 'kind' | 'holder'>): string {
+  return createHash('md5').update(canonicalProposalIdentity(p)).digest('hex');
 }
 
 /**
@@ -307,12 +327,14 @@ class ProposeTakesPhase extends BaseCyclePhase {
     const promptVersion = opts.promptVersion ?? PROPOSE_TAKES_PROMPT_VERSION;
     const pageLimit = opts.pageLimit ?? 100;
     const skipPagesWithFence = opts.skipPagesWithFence ?? false;
+    const modelId = opts.model ?? 'claude-sonnet-4-6';
     const proposalRunId = `propose-${new Date().toISOString().slice(0, 19).replace(/[-:T]/g, '')}-${randomUUID().slice(0, 8)}`;
 
     const result: ProposeTakesResult = {
       pages_scanned: 0,
       cache_hits: 0,
       cache_misses: 0,
+      proposals_extracted: 0,
       proposals_inserted: 0,
       budget_exhausted: false,
       warnings: [],
@@ -342,11 +364,13 @@ class ProposeTakesPhase extends BaseCyclePhase {
       const ch = contentHash(body);
       const existingTakes = extractExistingTakesForDedup(body);
 
-      // Idempotency check. If a row exists for (source_id, page_slug, content_hash,
-      // prompt_version), this page was already processed — skip and count as cache hit.
+      // Idempotency check. If a scan marker exists for (source_id, page_slug,
+      // content_hash, prompt_version), this page was already processed — skip
+      // and count as cache hit. Proposal row identity is separate so same-page
+      // multi-claim runs can persist every claim.
       const sourceId = page.source_id ?? scope.sourceId ?? 'default';
-      const cached = await engine.executeRaw<{ id: number }>(
-        `SELECT id FROM take_proposals
+      const cached = await engine.executeRaw<{ content_hash: string }>(
+        `SELECT content_hash FROM take_proposal_scans
          WHERE source_id = $1 AND page_slug = $2 AND content_hash = $3 AND prompt_version = $4
          LIMIT 1`,
         [sourceId, page.slug, ch, promptVersion],
@@ -359,7 +383,7 @@ class ProposeTakesPhase extends BaseCyclePhase {
 
       // Budget pre-check before the LLM call. Estimate: ~1500 input tokens + 500 output.
       const budget = this.checkBudget({
-        modelId: opts.model ?? 'claude-sonnet-4-6',
+        modelId,
         estimatedInputTokens: 1500,
         maxOutputTokens: 500,
       });
@@ -378,41 +402,64 @@ class ProposeTakesPhase extends BaseCyclePhase {
           pagePath: page.slug,
           pageBody: body,
           existingTakes,
-          modelHint: opts.model,
+          modelHint: modelId,
         });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         result.warnings.push(`extractor failed on ${page.slug}: ${msg}`);
         continue;
       }
+      result.proposals_extracted += proposals.length;
 
-      // Write proposals to take_proposals. Each row is a separate INSERT
-      // because the composite idempotency key is on the per-page tuple — a
-      // bulk UPSERT would collapse a same-page-multi-claim run into one row.
-      for (const p of proposals) {
-        await engine.executeRaw(
-          `INSERT INTO take_proposals
+      // Write proposals and the page-scan marker in one transaction. If the
+      // extractor succeeded but persistence fails, we must NOT mark the page as
+      // scanned; otherwise future cycles would skip data that never landed.
+      const insertedForPage = await engine.transaction(async (tx) => {
+        let inserted = 0;
+        for (const p of proposals) {
+          const rows = await tx.executeRaw<{ id: number }>(
+            `INSERT INTO take_proposals
+               (source_id, page_slug, content_hash, prompt_version, claim_hash, proposal_run_id,
+                claim_text, kind, holder, weight, domain, dedup_against_fence_rows, model_id)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+             ON CONFLICT (source_id, page_slug, prompt_version, claim_hash) DO NOTHING
+             RETURNING id`,
+            [
+              sourceId,
+              page.slug,
+              ch,
+              promptVersion,
+              proposalClaimHash(p),
+              proposalRunId,
+              p.claim_text,
+              p.kind,
+              p.holder,
+              p.weight,
+              p.domain ?? null,
+              JSON.stringify(existingTakes),
+              modelId,
+            ],
+          );
+          if (rows.length > 0) inserted += 1;
+        }
+
+        await tx.executeRaw(
+          `INSERT INTO take_proposal_scans
              (source_id, page_slug, content_hash, prompt_version, proposal_run_id,
-              claim_text, kind, holder, weight, domain, dedup_against_fence_rows, model_id)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-           ON CONFLICT (source_id, page_slug, content_hash, prompt_version) DO NOTHING`,
-          [
-            sourceId,
-            page.slug,
-            ch,
-            promptVersion,
-            proposalRunId,
-            p.claim_text,
-            p.kind,
-            p.holder,
-            p.weight,
-            p.domain ?? null,
-            JSON.stringify(existingTakes),
-            opts.model ?? 'claude-sonnet-4-6',
-          ],
+              extracted_count, inserted_count, model_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+           ON CONFLICT (source_id, page_slug, content_hash, prompt_version) DO UPDATE
+             SET scanned_at = now(),
+                 proposal_run_id = EXCLUDED.proposal_run_id,
+                 extracted_count = EXCLUDED.extracted_count,
+                 inserted_count = EXCLUDED.inserted_count,
+                 model_id = EXCLUDED.model_id`,
+          [sourceId, page.slug, ch, promptVersion, proposalRunId, proposals.length, inserted, modelId],
         );
-        result.proposals_inserted += 1;
-      }
+
+        return inserted;
+      });
+      result.proposals_inserted += insertedForPage;
     }
 
     if (opts.reporter) opts.reporter.finish();

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -5505,6 +5505,100 @@ export const MIGRATIONS: Migration[] = [
         WHERE dimension IS NOT NULL;
     `,
   },
+  {
+    version: 123,
+    name: 'take_proposals_claim_hash_and_scan_markers',
+    // v0.42.x — producer-side propose_takes correctness. The original
+    // `take_proposals_idempotency_idx` used proposal rows as the page-scan
+    // cache via UNIQUE(source_id, page_slug, content_hash, prompt_version), so
+    // claim #2+ from the same page/content/prompt hit ON CONFLICT DO NOTHING
+    // and disappeared. Split the two identities:
+    //   - take_proposal_scans caches completed page scans, including zero-claim
+    //     scans, by (source_id, page_slug, content_hash, prompt_version).
+    //   - take_proposals.claim_hash dedupes individual claims by normalized
+    //     claim_text + kind + holder, independent of content_hash/run/weight.
+    //
+    // Backfill parity: keep the md5(lower(trim/collapse-space claim) + kind +
+    // holder) expression in lockstep with proposalClaimHash() in
+    // src/core/cycle/propose-takes.ts. Legacy duplicate rows are salted after
+    // the first row so existing accepted/rejected audit rows survive while the
+    // canonical first row still blocks future duplicate proposals.
+    idempotent: true,
+    sql: `
+      ALTER TABLE take_proposals ADD COLUMN IF NOT EXISTS claim_hash TEXT;
+
+      WITH normalized AS (
+        SELECT
+          id,
+          source_id,
+          page_slug,
+          prompt_version,
+          lower(regexp_replace(trim(coalesce(claim_text, '')), '\\s+', ' ', 'g')) || chr(31) ||
+          lower(trim(coalesce(kind, ''))) || chr(31) ||
+          lower(trim(coalesce(holder, ''))) AS canonical_identity
+        FROM take_proposals
+        WHERE claim_hash IS NULL
+      ), ranked AS (
+        SELECT
+          id,
+          md5(canonical_identity) AS canonical_hash,
+          row_number() OVER (
+            PARTITION BY source_id, page_slug, prompt_version, md5(canonical_identity)
+            ORDER BY id
+          ) AS rn
+        FROM normalized
+      )
+      UPDATE take_proposals tp
+         SET claim_hash = CASE
+           WHEN ranked.rn = 1 THEN ranked.canonical_hash
+           ELSE md5(ranked.canonical_hash || chr(31) || 'legacy-duplicate:' || ranked.id::text)
+         END
+        FROM ranked
+       WHERE tp.id = ranked.id
+         AND tp.claim_hash IS NULL;
+
+      ALTER TABLE take_proposals ALTER COLUMN claim_hash SET NOT NULL;
+
+      CREATE TABLE IF NOT EXISTS take_proposal_scans (
+        source_id       TEXT        NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+        page_slug       TEXT        NOT NULL,
+        content_hash    TEXT        NOT NULL,
+        prompt_version  TEXT        NOT NULL,
+        scanned_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+        proposal_run_id TEXT,
+        extracted_count INTEGER     NOT NULL DEFAULT 0,
+        inserted_count  INTEGER     NOT NULL DEFAULT 0,
+        model_id        TEXT,
+        PRIMARY KEY (source_id, page_slug, content_hash, prompt_version)
+      );
+
+      INSERT INTO take_proposal_scans
+        (source_id, page_slug, content_hash, prompt_version, proposal_run_id,
+         scanned_at, extracted_count, inserted_count, model_id)
+      SELECT
+        source_id,
+        page_slug,
+        content_hash,
+        prompt_version,
+        min(proposal_run_id),
+        min(proposed_at),
+        count(*)::int,
+        count(*)::int,
+        min(model_id)
+      FROM take_proposals
+      GROUP BY source_id, page_slug, content_hash, prompt_version
+      ON CONFLICT (source_id, page_slug, content_hash, prompt_version) DO NOTHING;
+
+      DROP INDEX IF EXISTS take_proposals_idempotency_idx;
+      CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_claim_identity_idx
+        ON take_proposals (source_id, page_slug, prompt_version, claim_hash);
+      CREATE INDEX IF NOT EXISTS take_proposal_scans_recent_idx
+        ON take_proposal_scans (source_id, scanned_at DESC);
+      CREATE INDEX IF NOT EXISTS take_proposal_scans_run_id_idx
+        ON take_proposal_scans (proposal_run_id)
+        WHERE proposal_run_id IS NOT NULL;
+    `,
+  },
 ];
 
 export const LATEST_VERSION = MIGRATIONS.length > 0

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -518,7 +518,11 @@ export class PGLiteEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema='public' AND table_name='pages' AND column_name='embedding_signature') AS pages_embedding_signature_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema='public' AND table_name='pages' AND column_name='links_extracted_at') AS pages_links_extracted_at_exists
+                WHERE table_schema='public' AND table_name='pages' AND column_name='links_extracted_at') AS pages_links_extracted_at_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema='public' AND table_name='take_proposals') AS take_proposals_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='take_proposals' AND column_name='claim_hash') AS take_proposals_claim_hash_exists
     `);
     const probe = rows[0] as {
       pages_exists: boolean;
@@ -561,6 +565,8 @@ export class PGLiteEngine implements BrainEngine {
       pages_generation_exists: boolean;
       pages_embedding_signature_exists: boolean;
       pages_links_extracted_at_exists: boolean;
+      take_proposals_exists: boolean;
+      take_proposals_claim_hash_exists: boolean;
     };
 
     const needsPagesBootstrap = probe.pages_exists && !probe.source_id_exists;
@@ -637,6 +643,11 @@ export class PGLiteEngine implements BrainEngine {
     // it; pre-v112 brains crash without the column, so bootstrap adds it before
     // the CREATE INDEX runs. v112 runs later via runMigrations and is idempotent.
     const needsPagesLinksExtractedAt = probe.pages_exists && !probe.pages_links_extracted_at_exists;
+    // v123: take_proposals_claim_identity_idx references claim_hash before the
+    // migration backfills and marks it NOT NULL. Bootstrap only adds the
+    // nullable column so SCHEMA_SQL replay can create the index; v123 handles
+    // backfill, constraints, and scan-marker table backfill.
+    const needsTakeProposalClaimHash = probe.take_proposals_exists && !probe.take_proposals_claim_hash_exists;
 
     // Fresh installs (no tables yet) and modern brains both no-op.
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
@@ -648,7 +659,8 @@ export class PGLiteEngine implements BrainEngine {
         && !needsPagesProvenance
         && !needsContextualRetrievalColumns && !needsPagesGeneration
         && !needsPagesEmbeddingSignature
-        && !needsPagesLinksExtractedAt) return;
+        && !needsPagesLinksExtractedAt
+        && !needsTakeProposalClaimHash) return;
 
     process.stderr.write('  Pre-v0.21 brain detected, applying forward-reference bootstrap\n');
 
@@ -893,6 +905,12 @@ export class PGLiteEngine implements BrainEngine {
       // v112 runs later via runMigrations and is idempotent.
       await this.db.exec(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS links_extracted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsTakeProposalClaimHash) {
+      await this.db.exec(`
+        ALTER TABLE take_proposals ADD COLUMN IF NOT EXISTS claim_hash TEXT;
       `);
     }
   }

--- a/src/core/pglite-schema.ts
+++ b/src/core/pglite-schema.ts
@@ -758,6 +758,7 @@ CREATE TABLE IF NOT EXISTS take_proposals (
   page_slug                   TEXT         NOT NULL,
   content_hash                TEXT         NOT NULL,
   prompt_version              TEXT         NOT NULL,
+  claim_hash                  TEXT         NOT NULL,
   wave_version                TEXT         NOT NULL DEFAULT 'v0.36.1.0',
   proposed_at                 TIMESTAMPTZ  NOT NULL DEFAULT now(),
   proposal_run_id             TEXT         NOT NULL,
@@ -776,13 +777,31 @@ CREATE TABLE IF NOT EXISTS take_proposals (
   predicted_brier             REAL,
   predicted_brier_bucket_n    INTEGER
 );
-CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_idempotency_idx
-  ON take_proposals (source_id, page_slug, content_hash, prompt_version);
+CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_claim_identity_idx
+  ON take_proposals (source_id, page_slug, prompt_version, claim_hash);
 CREATE INDEX IF NOT EXISTS take_proposals_pending_idx
   ON take_proposals (source_id, status, proposed_at DESC)
   WHERE status = 'pending';
 CREATE INDEX IF NOT EXISTS take_proposals_run_id_idx
   ON take_proposals (proposal_run_id);
+
+CREATE TABLE IF NOT EXISTS take_proposal_scans (
+  source_id       TEXT        NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+  page_slug       TEXT        NOT NULL,
+  content_hash    TEXT        NOT NULL,
+  prompt_version  TEXT        NOT NULL,
+  scanned_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  proposal_run_id TEXT,
+  extracted_count INTEGER     NOT NULL DEFAULT 0,
+  inserted_count  INTEGER     NOT NULL DEFAULT 0,
+  model_id        TEXT,
+  PRIMARY KEY (source_id, page_slug, content_hash, prompt_version)
+);
+CREATE INDEX IF NOT EXISTS take_proposal_scans_recent_idx
+  ON take_proposal_scans (source_id, scanned_at DESC);
+CREATE INDEX IF NOT EXISTS take_proposal_scans_run_id_idx
+  ON take_proposal_scans (proposal_run_id)
+  WHERE proposal_run_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS take_grade_cache (
   take_id            BIGINT       NOT NULL,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -507,7 +507,11 @@ export class PostgresEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'embedding_signature') AS pages_embedding_signature_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'links_extracted_at') AS pages_links_extracted_at_exists
+                WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'links_extracted_at') AS pages_links_extracted_at_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema() AND table_name = 'take_proposals') AS take_proposals_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'take_proposals' AND column_name = 'claim_hash') AS take_proposals_claim_hash_exists
     `;
     const probe = probeRows[0]!;
 
@@ -584,6 +588,8 @@ export class PostgresEngine implements BrainEngine {
       pages_generation_exists?: boolean;
       pages_embedding_signature_exists?: boolean;
       pages_links_extracted_at_exists?: boolean;
+      take_proposals_exists?: boolean;
+      take_proposals_claim_hash_exists?: boolean;
     };
     const needsContextualRetrievalColumns = (probe.pages_exists
         && (!probeCr.pages_cr_mode_exists || !probeCr.pages_corpus_generation_exists))
@@ -603,6 +609,7 @@ export class PostgresEngine implements BrainEngine {
     // SCHEMA_SQL replay creates the index. v112 runs later via runMigrations
     // and is idempotent.
     const needsPagesLinksExtractedAt = probe.pages_exists && !probeCr.pages_links_extracted_at_exists;
+    const needsTakeProposalClaimHash = !!probeCr.take_proposals_exists && !probeCr.take_proposals_claim_hash_exists;
 
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
         && !needsPagesDeletedAt && !needsMcpLogBootstrap && !needsSubagentProviderId
@@ -613,7 +620,8 @@ export class PostgresEngine implements BrainEngine {
         && !needsPagesProvenance
         && !needsContextualRetrievalColumns && !needsPagesGeneration
         && !needsPagesEmbeddingSignature
-        && !needsPagesLinksExtractedAt) return;
+        && !needsPagesLinksExtractedAt
+        && !needsTakeProposalClaimHash) return;
 
     process.stderr.write('  Pre-v0.21 brain detected, applying forward-reference bootstrap\n');
 
@@ -858,6 +866,12 @@ export class PostgresEngine implements BrainEngine {
       // idempotent.
       await conn.unsafe(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS links_extracted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsTakeProposalClaimHash) {
+      await conn.unsafe(`
+        ALTER TABLE take_proposals ADD COLUMN IF NOT EXISTS claim_hash TEXT;
       `);
     }
   }

--- a/src/core/schema-embedded.ts
+++ b/src/core/schema-embedded.ts
@@ -1268,15 +1268,16 @@ CREATE INDEX IF NOT EXISTS calibration_profiles_published_idx
   ON calibration_profiles (source_id, published, holder)
   WHERE published = true;
 
--- take_proposals: propose_takes phase queue. Idempotency cache via the
--- composite unique index (source_id, page_slug, content_hash, prompt_version)
--- mirrors v0.23 dream_verdicts. proposal_run_id supports --rollback by run.
+-- take_proposals: propose_takes phase queue. Page-scan idempotency lives in
+-- take_proposal_scans; proposal rows use per-claim identity so multi-claim
+-- pages can persist every extracted claim.
 CREATE TABLE IF NOT EXISTS take_proposals (
   id                          BIGSERIAL PRIMARY KEY,
   source_id                   TEXT         NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
   page_slug                   TEXT         NOT NULL,
   content_hash                TEXT         NOT NULL,
   prompt_version              TEXT         NOT NULL,
+  claim_hash                  TEXT         NOT NULL,
   wave_version                TEXT         NOT NULL DEFAULT 'v0.36.1.0',
   proposed_at                 TIMESTAMPTZ  NOT NULL DEFAULT now(),
   proposal_run_id             TEXT         NOT NULL,
@@ -1295,13 +1296,31 @@ CREATE TABLE IF NOT EXISTS take_proposals (
   predicted_brier             REAL,
   predicted_brier_bucket_n    INTEGER
 );
-CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_idempotency_idx
-  ON take_proposals (source_id, page_slug, content_hash, prompt_version);
+CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_claim_identity_idx
+  ON take_proposals (source_id, page_slug, prompt_version, claim_hash);
 CREATE INDEX IF NOT EXISTS take_proposals_pending_idx
   ON take_proposals (source_id, status, proposed_at DESC)
   WHERE status = 'pending';
 CREATE INDEX IF NOT EXISTS take_proposals_run_id_idx
   ON take_proposals (proposal_run_id);
+
+CREATE TABLE IF NOT EXISTS take_proposal_scans (
+  source_id       TEXT        NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+  page_slug       TEXT        NOT NULL,
+  content_hash    TEXT        NOT NULL,
+  prompt_version  TEXT        NOT NULL,
+  scanned_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  proposal_run_id TEXT,
+  extracted_count INTEGER     NOT NULL DEFAULT 0,
+  inserted_count  INTEGER     NOT NULL DEFAULT 0,
+  model_id        TEXT,
+  PRIMARY KEY (source_id, page_slug, content_hash, prompt_version)
+);
+CREATE INDEX IF NOT EXISTS take_proposal_scans_recent_idx
+  ON take_proposal_scans (source_id, scanned_at DESC);
+CREATE INDEX IF NOT EXISTS take_proposal_scans_run_id_idx
+  ON take_proposal_scans (proposal_run_id)
+  WHERE proposal_run_id IS NOT NULL;
 
 -- take_grade_cache: grade_takes verdict cache. Composite PK on
 -- (take_id, prompt_version, judge_model_id, evidence_signature) means
@@ -1429,6 +1448,7 @@ BEGIN
     -- v0.36.1.0 Hindsight calibration wave tables
     ALTER TABLE calibration_profiles ENABLE ROW LEVEL SECURITY;
     ALTER TABLE take_proposals ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE take_proposal_scans ENABLE ROW LEVEL SECURITY;
     ALTER TABLE take_grade_cache ENABLE ROW LEVEL SECURITY;
     ALTER TABLE take_nudge_log ENABLE ROW LEVEL SECURITY;
     -- v0.26 OAuth 2.1 tables

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -1264,15 +1264,16 @@ CREATE INDEX IF NOT EXISTS calibration_profiles_published_idx
   ON calibration_profiles (source_id, published, holder)
   WHERE published = true;
 
--- take_proposals: propose_takes phase queue. Idempotency cache via the
--- composite unique index (source_id, page_slug, content_hash, prompt_version)
--- mirrors v0.23 dream_verdicts. proposal_run_id supports --rollback by run.
+-- take_proposals: propose_takes phase queue. Page-scan idempotency lives in
+-- take_proposal_scans; proposal rows use per-claim identity so multi-claim
+-- pages can persist every extracted claim.
 CREATE TABLE IF NOT EXISTS take_proposals (
   id                          BIGSERIAL PRIMARY KEY,
   source_id                   TEXT         NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
   page_slug                   TEXT         NOT NULL,
   content_hash                TEXT         NOT NULL,
   prompt_version              TEXT         NOT NULL,
+  claim_hash                  TEXT         NOT NULL,
   wave_version                TEXT         NOT NULL DEFAULT 'v0.36.1.0',
   proposed_at                 TIMESTAMPTZ  NOT NULL DEFAULT now(),
   proposal_run_id             TEXT         NOT NULL,
@@ -1291,13 +1292,31 @@ CREATE TABLE IF NOT EXISTS take_proposals (
   predicted_brier             REAL,
   predicted_brier_bucket_n    INTEGER
 );
-CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_idempotency_idx
-  ON take_proposals (source_id, page_slug, content_hash, prompt_version);
+CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_claim_identity_idx
+  ON take_proposals (source_id, page_slug, prompt_version, claim_hash);
 CREATE INDEX IF NOT EXISTS take_proposals_pending_idx
   ON take_proposals (source_id, status, proposed_at DESC)
   WHERE status = 'pending';
 CREATE INDEX IF NOT EXISTS take_proposals_run_id_idx
   ON take_proposals (proposal_run_id);
+
+CREATE TABLE IF NOT EXISTS take_proposal_scans (
+  source_id       TEXT        NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+  page_slug       TEXT        NOT NULL,
+  content_hash    TEXT        NOT NULL,
+  prompt_version  TEXT        NOT NULL,
+  scanned_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  proposal_run_id TEXT,
+  extracted_count INTEGER     NOT NULL DEFAULT 0,
+  inserted_count  INTEGER     NOT NULL DEFAULT 0,
+  model_id        TEXT,
+  PRIMARY KEY (source_id, page_slug, content_hash, prompt_version)
+);
+CREATE INDEX IF NOT EXISTS take_proposal_scans_recent_idx
+  ON take_proposal_scans (source_id, scanned_at DESC);
+CREATE INDEX IF NOT EXISTS take_proposal_scans_run_id_idx
+  ON take_proposal_scans (proposal_run_id)
+  WHERE proposal_run_id IS NOT NULL;
 
 -- take_grade_cache: grade_takes verdict cache. Composite PK on
 -- (take_id, prompt_version, judge_model_id, evidence_signature) means
@@ -1425,6 +1444,7 @@ BEGIN
     -- v0.36.1.0 Hindsight calibration wave tables
     ALTER TABLE calibration_profiles ENABLE ROW LEVEL SECURITY;
     ALTER TABLE take_proposals ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE take_proposal_scans ENABLE ROW LEVEL SECURITY;
     ALTER TABLE take_grade_cache ENABLE ROW LEVEL SECURITY;
     ALTER TABLE take_nudge_log ENABLE ROW LEVEL SECURITY;
     -- v0.26 OAuth 2.1 tables

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -52,6 +52,10 @@ const ALL_TABLES = [
   // v0.43 (#2095): volunteered-context feedback log — no FK to pages (slug
   // join), but stale rows poison stats/count assertions across runs.
   'context_volunteer_events',
+  // v0.36+: proposal queue and scan markers reference sources/pages.
+  'take_nudge_log',
+  'take_proposal_scans',
+  'take_proposals',
   'pages',       // last because of foreign keys
   'config',
   'minion_attachments',

--- a/test/e2e/propose-takes-postgres.test.ts
+++ b/test/e2e/propose-takes-postgres.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Real-Postgres coverage for propose_takes proposal identity.
+ * PGLite caught the local regression; this pins the same unique-index behavior
+ * on Postgres so engine/index parity does not silently drift.
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+
+import { setupDB, teardownDB, hasDatabase, getEngine } from './helpers.ts';
+import type { OperationContext } from '../../src/core/operations.ts';
+import {
+  PROPOSE_TAKES_PROMPT_VERSION,
+  contentHash,
+  proposalClaimHash,
+  runPhaseProposeTakes,
+  type ProposeTakesExtractor,
+} from '../../src/core/cycle/propose-takes.ts';
+
+const RUN = hasDatabase();
+const d = RUN ? describe : describe.skip;
+
+beforeAll(async () => {
+  if (!RUN) return;
+  await setupDB();
+});
+
+afterAll(async () => {
+  if (!RUN) return;
+  await teardownDB();
+});
+
+function ctx(): OperationContext {
+  return {
+    engine: getEngine(),
+    config: {} as never,
+    logger: { info() {}, warn() {}, error() {} } as never,
+    dryRun: false,
+    remote: false,
+    sourceId: 'default',
+  };
+}
+
+d('propose_takes — Postgres proposal identity', () => {
+  test('same-page multi-claim extraction persists every claim', async () => {
+    const engine = getEngine();
+    await engine.putPage('wiki/pg-propose-multi', {
+      title: 'PG propose multi',
+      type: 'analysis',
+      compiled_truth: 'Postgres page with two gradeable claims.',
+    });
+
+    const extractor: ProposeTakesExtractor = async () => [
+      { claim_text: 'Postgres first claim persists', kind: 'take', holder: 'brain', weight: 0.6 },
+      { claim_text: 'Postgres second claim also persists', kind: 'bet', holder: 'brain', weight: 0.7 },
+    ];
+
+    const result = await runPhaseProposeTakes(ctx(), { extractor, pageLimit: 1 });
+    const details = result.details as Record<string, unknown>;
+    expect(details.proposals_extracted).toBe(2);
+    expect(details.proposals_inserted).toBe(2);
+
+    const rows = await engine.executeRaw<{ count: number }>(
+      `SELECT count(*)::int AS count FROM take_proposals WHERE page_slug = 'wiki/pg-propose-multi'`,
+    );
+    expect(rows[0]!.count).toBe(2);
+  });
+
+  test('claim_hash uniqueness blocks duplicate after page content changes', async () => {
+    const engine = getEngine();
+    const oldBody = 'Postgres old body with claim.';
+    const changedBody = 'Postgres changed body with the same claim and extra context.';
+    const claim = { claim_text: 'Postgres duplicate claim blocked', kind: 'take' as const, holder: 'brain' };
+
+    await engine.executeRaw(
+      `INSERT INTO take_proposals
+         (source_id, page_slug, content_hash, prompt_version, claim_hash, proposal_run_id,
+          claim_text, kind, holder, weight, model_id)
+       VALUES ('default', 'wiki/pg-propose-changed', $1, $2, $3, 'legacy-run', $4, 'take', 'brain', 0.5, 'test-model')`,
+      [contentHash(oldBody), PROPOSE_TAKES_PROMPT_VERSION, proposalClaimHash(claim), claim.claim_text],
+    );
+    await engine.putPage('wiki/pg-propose-changed', {
+      title: 'PG propose changed',
+      type: 'analysis',
+      compiled_truth: changedBody,
+    });
+
+    const extractor: ProposeTakesExtractor = async () => [
+      { ...claim, weight: 0.9 },
+    ];
+
+    const result = await runPhaseProposeTakes(ctx(), { extractor, pageLimit: 1 });
+    const details = result.details as Record<string, unknown>;
+    expect(details.proposals_extracted).toBe(1);
+    expect(details.proposals_inserted).toBe(0);
+
+    const rows = await engine.executeRaw<{ count: number }>(
+      `SELECT count(*)::int AS count FROM take_proposals WHERE page_slug = 'wiki/pg-propose-changed'`,
+    );
+    expect(rows[0]!.count).toBe(1);
+  });
+});

--- a/test/propose-takes-pglite.test.ts
+++ b/test/propose-takes-pglite.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Regression coverage for propose_takes proposal identity against real PGLite.
+ * The mock-only unit file does not enforce SQL uniqueness, which is the bug
+ * class that dropped same-page claim #2+.
+ */
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import type { OperationContext } from '../src/core/operations.ts';
+import { MIGRATIONS } from '../src/core/migrate.ts';
+import {
+  PROPOSE_TAKES_PROMPT_VERSION,
+  contentHash,
+  proposalClaimHash,
+  runPhaseProposeTakes,
+  type ProposeTakesExtractor,
+} from '../src/core/cycle/propose-takes.ts';
+import { resetPgliteState } from './helpers/reset-pglite.ts';
+
+let engine: PGLiteEngine;
+
+beforeAll(async () => {
+  engine = new PGLiteEngine();
+  await engine.connect({});
+  await engine.initSchema();
+}, 60_000);
+
+afterAll(async () => {
+  await engine.disconnect();
+});
+
+beforeEach(async () => {
+  await resetPgliteState(engine);
+});
+
+function ctx(): OperationContext {
+  return {
+    engine,
+    config: {} as never,
+    logger: { info() {}, warn() {}, error() {} } as never,
+    dryRun: false,
+    remote: false,
+    sourceId: 'default',
+  };
+}
+
+describe('propose_takes — PGLite proposal identity', () => {
+  test('same-page multi-claim extraction persists every claim and writes one scan marker', async () => {
+    await engine.putPage('wiki/propose-multi', {
+      title: 'Propose multi',
+      type: 'analysis',
+      compiled_truth: 'This page contains two independent gradeable claims.',
+    });
+
+    const extractor: ProposeTakesExtractor = async () => [
+      { claim_text: 'First claim persists', kind: 'take', holder: 'brain', weight: 0.6 },
+      { claim_text: 'Second claim also persists', kind: 'bet', holder: 'brain', weight: 0.7 },
+    ];
+
+    const result = await runPhaseProposeTakes(ctx(), { extractor, pageLimit: 1 });
+    const details = result.details as Record<string, unknown>;
+    expect(details.proposals_extracted).toBe(2);
+    expect(details.proposals_inserted).toBe(2);
+
+    const rows = await engine.executeRaw<{ count: number }>(
+      `SELECT count(*)::int AS count FROM take_proposals WHERE page_slug = 'wiki/propose-multi'`,
+    );
+    expect(rows[0]!.count).toBe(2);
+
+    const scans = await engine.executeRaw<{ extracted_count: number; inserted_count: number }>(
+      `SELECT extracted_count, inserted_count FROM take_proposal_scans WHERE page_slug = 'wiki/propose-multi'`,
+    );
+    expect(scans).toHaveLength(1);
+    expect(scans[0]!.extracted_count).toBe(2);
+    expect(scans[0]!.inserted_count).toBe(2);
+  });
+
+  test('unchanged rerun hits scan cache and does not call extractor again', async () => {
+    await engine.putPage('wiki/propose-cache', {
+      title: 'Propose cache',
+      type: 'analysis',
+      compiled_truth: 'A stable page body.',
+    });
+
+    const calls: string[] = [];
+    const extractor: ProposeTakesExtractor = async ({ pagePath }) => {
+      calls.push(pagePath);
+      if (pagePath !== 'wiki/propose-cache') return [];
+      return [{ claim_text: 'Stable claim', kind: 'take', holder: 'brain', weight: 0.55 }];
+    };
+
+    await runPhaseProposeTakes(ctx(), { extractor, pageLimit: 5 });
+    const second = await runPhaseProposeTakes(ctx(), { extractor, pageLimit: 5 });
+
+    expect(calls.filter(slug => slug === 'wiki/propose-cache')).toHaveLength(1);
+    const details = second.details as Record<string, unknown>;
+    expect(details.cache_hits).toBeGreaterThanOrEqual(1);
+    expect(details.proposals_inserted).toBe(0);
+  });
+
+  test('zero-claim extraction writes a scan marker so unchanged pages do not re-bill', async () => {
+    await engine.putPage('wiki/propose-zero', {
+      title: 'Propose zero',
+      type: 'analysis',
+      compiled_truth: 'Only factual notes, no gradeable claims.',
+    });
+
+    let calls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      calls += 1;
+      return [];
+    };
+
+    const first = await runPhaseProposeTakes(ctx(), { extractor, pageLimit: 1 });
+    const second = await runPhaseProposeTakes(ctx(), { extractor, pageLimit: 1 });
+
+    expect(calls).toBe(1);
+    expect((first.details as Record<string, unknown>).proposals_extracted).toBe(0);
+    expect((second.details as Record<string, unknown>).cache_hits).toBe(1);
+
+    const scans = await engine.executeRaw<{ extracted_count: number; inserted_count: number }>(
+      `SELECT extracted_count, inserted_count FROM take_proposal_scans WHERE page_slug = 'wiki/propose-zero'`,
+    );
+    expect(scans).toHaveLength(1);
+    expect(scans[0]!.extracted_count).toBe(0);
+    expect(scans[0]!.inserted_count).toBe(0);
+  });
+
+  test('backfilled claim_hash blocks duplicate proposal after page content changes', async () => {
+    const oldBody = 'Old body containing a claim.';
+    const changedBody = 'Changed body still containing the same claim plus more context.';
+    const claim = { claim_text: 'The same claim survives editing', kind: 'take' as const, holder: 'brain' };
+
+    await engine.executeRaw(
+      `INSERT INTO take_proposals
+         (source_id, page_slug, content_hash, prompt_version, claim_hash, proposal_run_id,
+          claim_text, kind, holder, weight, model_id)
+       VALUES ('default', 'wiki/propose-changed', $1, $2, $3, 'legacy-run', $4, 'take', 'brain', 0.5, 'test-model')`,
+      [contentHash(oldBody), PROPOSE_TAKES_PROMPT_VERSION, proposalClaimHash(claim), claim.claim_text],
+    );
+    await engine.putPage('wiki/propose-changed', {
+      title: 'Propose changed',
+      type: 'analysis',
+      compiled_truth: changedBody,
+    });
+
+    const extractor: ProposeTakesExtractor = async () => [
+      { ...claim, weight: 0.9 },
+    ];
+
+    const result = await runPhaseProposeTakes(ctx(), { extractor, pageLimit: 1 });
+    const details = result.details as Record<string, unknown>;
+    expect(details.proposals_extracted).toBe(1);
+    expect(details.proposals_inserted).toBe(0);
+
+    const rows = await engine.executeRaw<{ count: number }>(
+      `SELECT count(*)::int AS count FROM take_proposals WHERE page_slug = 'wiki/propose-changed'`,
+    );
+    expect(rows[0]!.count).toBe(1);
+  });
+
+  test('migration v123 backfills claim_hash with runtime canonicalization', async () => {
+    const migration = MIGRATIONS.find(m => m.version === 123);
+    expect(migration).toBeDefined();
+
+    await engine.executeRaw(`DELETE FROM take_proposal_scans`);
+    await engine.executeRaw(`DELETE FROM take_proposals`);
+    await engine.executeRaw(`DROP INDEX IF EXISTS take_proposals_claim_identity_idx`);
+    await engine.executeRaw(`ALTER TABLE take_proposals DROP COLUMN IF EXISTS claim_hash`);
+    await engine.executeRaw(`CREATE UNIQUE INDEX IF NOT EXISTS take_proposals_idempotency_idx
+      ON take_proposals (source_id, page_slug, content_hash, prompt_version)`);
+
+    const claim = { claim_text: '  Same\n\tClaim   Spacing  ', kind: 'take' as const, holder: 'Brain' };
+    await engine.executeRaw(
+      `INSERT INTO take_proposals
+         (source_id, page_slug, content_hash, prompt_version, proposal_run_id,
+          claim_text, kind, holder, weight, model_id)
+       VALUES ('default', 'wiki/migration-parity', $1, $2, 'legacy-run', $3, 'take', 'Brain', 0.5, 'test-model')`,
+      [contentHash('legacy body'), PROPOSE_TAKES_PROMPT_VERSION, claim.claim_text],
+    );
+
+    await (engine as any).db.exec(migration!.sql);
+
+    const rows = await engine.executeRaw<{ claim_hash: string }>(
+      `SELECT claim_hash FROM take_proposals WHERE page_slug = 'wiki/migration-parity'`,
+    );
+    expect(rows[0]!.claim_hash).toBe(proposalClaimHash(claim));
+  });
+});

--- a/test/propose-takes.test.ts
+++ b/test/propose-takes.test.ts
@@ -19,6 +19,8 @@ import {
   runPhaseProposeTakes,
   parseExtractorOutput,
   contentHash,
+  canonicalProposalIdentity,
+  proposalClaimHash,
   hasCompleteFence,
   extractExistingTakesForDedup,
   PROPOSE_TAKES_PROMPT_VERSION,
@@ -38,10 +40,11 @@ interface CapturedSql {
 
 function buildMockEngine(opts: {
   pages: Page[];
-  existingProposals?: Set<string>; // composite-key strings already in take_proposals
+  existingScans?: Set<string>; // composite-key strings already in take_proposal_scans
 }): { engine: BrainEngine; captured: CapturedSql[] } {
   const captured: CapturedSql[] = [];
-  const existing = opts.existingProposals ?? new Set<string>();
+  const existingScans = opts.existingScans ?? new Set<string>();
+  let nextId = 1;
 
   const engine = {
     kind: 'pglite',
@@ -51,14 +54,19 @@ function buildMockEngine(opts: {
     async executeRaw<T>(sql: string, params?: unknown[]): Promise<T[]> {
       captured.push({ sql, params: params ?? [] });
       // SELECT idempotency check
-      if (sql.includes('SELECT id FROM take_proposals')) {
+      if (sql.includes('SELECT content_hash FROM take_proposal_scans')) {
         const [sourceId, slug, ch, pv] = params ?? [];
         const key = `${sourceId}|${slug}|${ch}|${pv}`;
-        if (existing.has(key)) return [{ id: 1 } as unknown as T];
+        if (existingScans.has(key)) return [{ content_hash: ch } as unknown as T];
         return [];
       }
-      // INSERT — return nothing
+      if (sql.includes('INSERT INTO take_proposals')) {
+        return [{ id: nextId++ } as unknown as T];
+      }
       return [];
+    },
+    async transaction<T>(fn: (tx: BrainEngine) => Promise<T>): Promise<T> {
+      return fn(engine as unknown as BrainEngine);
     },
   } as unknown as BrainEngine;
 
@@ -176,6 +184,23 @@ describe('contentHash', () => {
   });
 });
 
+// ─── proposalClaimHash ──────────────────────────────────────────────
+
+describe('proposalClaimHash', () => {
+  test('canonicalizes claim identity exactly for runtime/backfill parity', () => {
+    const a = { claim_text: '  Same\n Claim   Text ', kind: 'take' as const, holder: ' Brain ' };
+    const b = { claim_text: 'same claim text', kind: 'take' as const, holder: 'brain' };
+    expect(canonicalProposalIdentity(a)).toBe('same claim text\x1ftake\x1fbrain');
+    expect(proposalClaimHash(a)).toBe(proposalClaimHash(b));
+  });
+
+  test('excludes confidence/domain/content metadata from identity', () => {
+    const a = { claim_text: 'Same claim', kind: 'bet' as const, holder: 'brain', weight: 0.4, domain: 'macro' };
+    const b = { claim_text: 'Same claim', kind: 'bet' as const, holder: 'brain', weight: 0.9, domain: 'pricing' };
+    expect(proposalClaimHash(a)).toBe(proposalClaimHash(b));
+  });
+});
+
 // ─── hasCompleteFence ───────────────────────────────────────────────
 
 describe('hasCompleteFence', () => {
@@ -256,21 +281,27 @@ describe('runPhaseProposeTakes — phase integration', () => {
     expect(details.pages_scanned).toBe(1);
     expect(details.cache_misses).toBe(1);
     expect(details.cache_hits).toBe(0);
+    expect(details.proposals_extracted).toBe(1);
     expect(details.proposals_inserted).toBe(1);
 
     const inserts = captured.filter(c => c.sql.includes('INSERT INTO take_proposals'));
     expect(inserts).toHaveLength(1);
-    expect(inserts[0]!.params[5]).toBe('Marketplaces with cold-start liquidity win'); // claim_text
-    expect(inserts[0]!.params[6]).toBe('bet'); // kind
-    expect(inserts[0]!.params[9]).toBe('market'); // domain
+    expect(inserts[0]!.params[4]).toBe(proposalClaimHash({ claim_text: 'Marketplaces with cold-start liquidity win', kind: 'bet', holder: 'brain' }));
+    expect(inserts[0]!.params[6]).toBe('Marketplaces with cold-start liquidity win'); // claim_text
+    expect(inserts[0]!.params[7]).toBe('bet'); // kind
+    expect(inserts[0]!.params[10]).toBe('market'); // domain
+    const scans = captured.filter(c => c.sql.includes('INSERT INTO take_proposal_scans'));
+    expect(scans).toHaveLength(1);
+    expect(scans[0]!.params[5]).toBe(1); // extracted_count
+    expect(scans[0]!.params[6]).toBe(1); // inserted_count
   });
 
-  test('cache hit: page already in take_proposals is skipped', async () => {
+  test('cache hit: page already in take_proposal_scans is skipped', async () => {
     const body = 'A page that was already processed.';
     const pages = [buildPage({ slug: 'wiki/old-page', body })];
     const ch = contentHash(body);
     const existing = new Set([`default|wiki/old-page|${ch}|${PROPOSE_TAKES_PROMPT_VERSION}`]);
-    const { engine, captured } = buildMockEngine({ pages, existingProposals: existing });
+    const { engine, captured } = buildMockEngine({ pages, existingScans: existing });
     let extractorCalled = false;
     const extractor: ProposeTakesExtractor = async () => {
       extractorCalled = true;
@@ -378,8 +409,8 @@ New prose appended here.`;
     await runPhaseProposeTakes(buildCtx(engine), { extractor });
     const inserts = captured.filter(c => c.sql.includes('INSERT INTO take_proposals'));
     expect(inserts).toHaveLength(2);
-    const runIdA = inserts[0]!.params[4];
-    const runIdB = inserts[1]!.params[4];
+    const runIdA = inserts[0]!.params[5];
+    const runIdB = inserts[1]!.params[5];
     expect(runIdA).toBe(runIdB);
     expect(typeof runIdA).toBe('string');
     expect((runIdA as string).startsWith('propose-')).toBe(true);

--- a/test/schema-bootstrap-coverage.test.ts
+++ b/test/schema-bootstrap-coverage.test.ts
@@ -168,6 +168,10 @@ const REQUIRED_BOOTSTRAP_COVERAGE: ForwardReference[] = [
   // SCHEMA_SQL replay creates the index. Powers `gbrain extract --stale` + the
   // `links_extraction_lag` doctor check.
   { kind: 'column', table: 'pages', column: 'links_extracted_at' },
+  // v0.42.x (v123) — forward-referenced by take_proposals_claim_identity_idx.
+  // Pre-v123 brains have take_proposals without this column; bootstrap adds it
+  // before SCHEMA_SQL replay creates the new unique index.
+  { kind: 'column', table: 'take_proposals', column: 'claim_hash' },
 ];
 
 test('applyForwardReferenceBootstrap covers every forward reference declared in REQUIRED_BOOTSTRAP_COVERAGE', async () => {
@@ -253,6 +257,9 @@ test('applyForwardReferenceBootstrap covers every forward reference declared in 
       ALTER TABLE pages DROP COLUMN IF EXISTS generation;
       ALTER TABLE pages DROP COLUMN IF EXISTS contextual_retrieval_mode;
       ALTER TABLE pages DROP COLUMN IF EXISTS corpus_generation;
+
+      DROP INDEX IF EXISTS take_proposals_claim_identity_idx;
+      ALTER TABLE take_proposals DROP COLUMN IF EXISTS claim_hash;
     `);
 
     // Note: we don't strip sources.archived* here because they're inline in the
@@ -325,6 +332,9 @@ test('after bootstrap, PGLITE_SCHEMA_SQL replays without crashing on missing for
       ALTER TABLE pages DROP COLUMN IF EXISTS import_filename;
       ALTER TABLE pages DROP COLUMN IF EXISTS salience_touched_at;
       ALTER TABLE pages DROP COLUMN IF EXISTS emotional_weight;
+
+      DROP INDEX IF EXISTS take_proposals_claim_identity_idx;
+      ALTER TABLE take_proposals DROP COLUMN IF EXISTS claim_hash;
     `);
 
     // Bootstrap, then schema replay. Either step crashing fails the test.


### PR DESCRIPTION
## Summary
- split `propose_takes` page-scan idempotency into a new `take_proposal_scans` marker table
- add `take_proposals.claim_hash` per-claim identity so same-page multi-claim extraction persists every claim
- add v123 migration/backfill plus PGLite/Postgres forward-reference bootstrap coverage
- add PGLite and Postgres regression coverage for multi-claim inserts, zero-claim scan caching, and claim-hash backfill parity

## Verification
- `bun test test/propose-takes.test.ts test/propose-takes-pglite.test.ts test/schema-bootstrap-coverage.test.ts test/e2e/propose-takes-postgres.test.ts` ✅ 41 pass / 2 skipped (Postgres E2E skipped because no DATABASE_URL)
- `bun run build` ✅
- `git diff --check` ✅
- `bun run typecheck` ❌ existing unrelated OpenClaw SDK typing drift:
  - `src/core/context-engine.ts(90,44): Property 'buildMemorySystemPromptAddition' does not exist ...`
  - `test/e2e/openclaw-plugin-load-real.test.ts(281,9): Type 'unknown' is not assignable ...`
- `bun run test` full suite was started; first foreground attempt hit the 10-minute tool timeout while still running with no failure surfaced. A background rerun is in progress locally.
