### PR TITLE
fix(sources): audit walker inverts pruneDir — nested sources report 0 files scanned

### DIFF
--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -1134,7 +1134,8 @@ async function runAudit(engine: BrainEngine, args: string[]): Promise<void> {
         continue;
       }
       if (stat.isDirectory()) {
-        if (pruneDir(entry, dir)) continue;
+        // pruneDir returns true = descend, false = prune (see core/sync.ts).
+        if (!pruneDir(entry, dir)) continue;
         walk(full);
       } else if (entry.endsWith('.md')) {
         files.push(full);


### PR DESCRIPTION
## Bug

`gbrain sources audit <source>` reports **"Files scanned: 0 markdown files"** for any source whose `local_path` organizes content in subdirectories. Flat sources audit fine.

## Root cause

The audit walk in `src/commands/sources.ts` (~line 1137):

```ts
if (stat.isDirectory()) {
  if (pruneDir(entry, dir)) continue;   // inverted
  walk(full);
}
```

`pruneDir()` in `core/sync.ts` returns **`true` = descend, `false` = prune** ("Should this directory be descended into?"). The audit walker treats it as the opposite, so it:

- **skips every legitimate subdirectory** → any nested source audits 0 files, and
- **descends into exactly the trees it should skip** (`node_modules/`, `.git/`, `vendor/`, `dist/`, `.raw/` sidecars) — the inverse harm, if any of those happen to contain `.md` files they get audited.

The walker's own comment says *"Mirror gbrain sync's descent rules so the file set we audit matches the file set that would actually be ingested"* — the inversion makes it do precisely the opposite: the audited set and the ingested set are disjoint for nested sources.

## Reproduction (real brain, v0.42.56/0.42.57)

A comms source with per-contact subdirectories (`<root>/<contact>/<YYYY-MM>.md`, ~1.1k files, all ingested and searchable by sync):

```
$ gbrain sources audit comms-imessage
Files scanned: 0 markdown files
```

A flat source in the same brain:

```
$ gbrain sources audit comms-gcal
Files scanned: 4 markdown files
```

Related but distinct from #2607 (sync --full git fast path bypassing pruneDir) — this one is the audit command's walker.

## Fix

One-line inversion (plus a comment pinning the contract at the callsite). Happy to add a regression test if you can point at the preferred harness for command-level walkers — the `walk` closure is currently inline in the command, so unit-testing it needs either extraction or the serial CLI harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)