### PR TITLE
fix(db): chunk-row model label falls back to live gateway model, not build-time constant

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -2104,6 +2104,15 @@ export class PGLiteEngine implements BrainEngine {
     const params: unknown[] = [];
     let paramIdx = 1;
 
+    // See postgres-engine.ts _upsertChunksOnce: model-less chunks fall back
+    // to the LIVE gateway model, not the build-time DEFAULT_EMBEDDING_MODEL
+    // constant, which mislabels provenance on non-ZE brains.
+    let fallbackModel: string = DEFAULT_EMBEDDING_MODEL;
+    try {
+      const gw = await import('./ai/gateway.ts');
+      fallbackModel = gw.getEmbeddingModel() || fallbackModel;
+    } catch { /* gateway unconfigured (unit tests) — keep the constant */ }
+
     for (const chunk of chunks) {
       const embeddingStr = chunk.embedding
         ? '[' + Array.from(chunk.embedding).join(',') + ']'
@@ -2136,7 +2145,7 @@ export class PGLiteEngine implements BrainEngine {
       if (embeddingImageStr) params.push(embeddingImageStr);
       params.push(
         pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source,
-        chunk.model || DEFAULT_EMBEDDING_MODEL, chunk.token_count || null,
+        chunk.model || fallbackModel, chunk.token_count || null,
         chunk.language || null, chunk.symbol_name || null, chunk.symbol_type || null,
         chunk.start_line ?? null, chunk.end_line ?? null,
         parentPath, chunk.doc_comment || null, chunk.symbol_name_qualified || null,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -2127,6 +2127,18 @@ export class PostgresEngine implements BrainEngine {
     const params: unknown[] = [];
     let paramIdx = 1;
 
+    // Chunks that don't carry a model label (no ChunkInput builder sets one
+    // today) must fall back to the LIVE gateway model, not the build-time
+    // constant: DEFAULT_EMBEDDING_MODEL stamps 'zeroentropyai:zembed-1' onto
+    // brains configured with any other provider, recording provenance for a
+    // model that never ran. Same resolution pattern as initSchema, which
+    // bakes the correct model into the column DEFAULT for the same reason.
+    let fallbackModel: string = DEFAULT_EMBEDDING_MODEL;
+    try {
+      const gw = await import('./ai/gateway.ts');
+      fallbackModel = gw.getEmbeddingModel() || fallbackModel;
+    } catch { /* gateway unconfigured (unit tests) — keep the constant */ }
+
     for (const chunk of chunks) {
       const embeddingStr = chunk.embedding
         ? '[' + Array.from(chunk.embedding).join(',') + ']'
@@ -2156,7 +2168,7 @@ export class PostgresEngine implements BrainEngine {
       if (embeddingImageStr) params.push(embeddingImageStr);
       params.push(
         pageId, chunk.chunk_index, chunk.chunk_text, chunk.chunk_source,
-        chunk.model || DEFAULT_EMBEDDING_MODEL, chunk.token_count || null,
+        chunk.model || fallbackModel, chunk.token_count || null,
         chunk.language || null, chunk.symbol_name || null, chunk.symbol_type || null,
         chunk.start_line ?? null, chunk.end_line ?? null,
         parentPath, chunk.doc_comment || null, chunk.symbol_name_qualified || null,

--- a/test/v0_37_gap_fill.serial.test.ts
+++ b/test/v0_37_gap_fill.serial.test.ts
@@ -30,11 +30,16 @@ import { configureGateway, resetGateway, __setEmbedTransportForTests } from '../
 import { withEnv } from './helpers/with-env.ts';
 
 // ─────────────────────────────────────────────────────────────────────
-// Lane A.7 — Chunk-row INSERT model default tracks defaults.ts constant
-// (not stale OpenAI literal). Pre-fix `chunk.model || 'text-embedding-3-large'`
-// in both engines; post-fix `chunk.model || DEFAULT_EMBEDDING_MODEL`.
+// Lane A.7 — Chunk-row INSERT model fallback tracks the LIVE gateway
+// model, then ai/defaults.ts (not stale OpenAI literal). History:
+// pre-v0.37 `chunk.model || 'text-embedding-3-large'`; v0.37
+// `chunk.model || DEFAULT_EMBEDDING_MODEL` — which mislabeled every
+// chunk of a brain configured with a non-ZE provider (e.g. ollama)
+// as 'zeroentropyai:zembed-1'; current: `chunk.model || <gateway
+// embedding_model>` with the constant only as the unconfigured-gateway
+// fallback.
 // ─────────────────────────────────────────────────────────────────────
-describe('Lane A.7 — chunk-row INSERT default tracks ai/defaults.ts constant', () => {
+describe('Lane A.7 — chunk-row INSERT model falls back to gateway, then defaults.ts', () => {
   let engine: PGLiteEngine;
 
   beforeAll(async () => {
@@ -45,10 +50,21 @@ describe('Lane A.7 — chunk-row INSERT default tracks ai/defaults.ts constant',
 
   afterAll(async () => {
     await engine.disconnect();
+    // Leave the module-global gateway in the same state Lane A.8 restores
+    // to, so later lanes in this serial file see a configured gateway.
+    configureGateway({
+      embedding_model: 'openai:text-embedding-3-large',
+      embedding_dimensions: 1536,
+      env: { ...process.env },
+    });
   });
 
-  test('upsertChunks without explicit model: row stores DEFAULT_EMBEDDING_MODEL', async () => {
-    const { DEFAULT_EMBEDDING_MODEL } = await import('../src/core/ai/defaults.ts');
+  test('upsertChunks without explicit model: row stores the configured gateway model', async () => {
+    configureGateway({
+      embedding_model: 'ollama:qwen3-embedding:8b-fp16',
+      embedding_dimensions: 1536,
+      env: { ...process.env },
+    });
     await engine.putPage('test/a7', { type: 'note', title: 'A.7', compiled_truth: 'hello' });
     await engine.upsertChunks('test/a7', [
       { chunk_index: 0, chunk_text: 'hello', chunk_source: 'compiled_truth' },
@@ -56,6 +72,24 @@ describe('Lane A.7 — chunk-row INSERT default tracks ai/defaults.ts constant',
 
     const rows = await engine.executeRaw<{ model: string }>(
       `SELECT model FROM content_chunks WHERE chunk_index = 0 LIMIT 1`,
+    );
+    // Provenance regression: pre-fix this row stored DEFAULT_EMBEDDING_MODEL
+    // ('zeroentropyai:zembed-1') — a model that never produced the vectors.
+    expect(rows[0]?.model).toBe('ollama:qwen3-embedding:8b-fp16');
+  });
+
+  test('upsertChunks with gateway unconfigured: row stores DEFAULT_EMBEDDING_MODEL', async () => {
+    const { DEFAULT_EMBEDDING_MODEL } = await import('../src/core/ai/defaults.ts');
+    resetGateway();
+    await engine.putPage('test/a7-unconfigured', { type: 'note', title: 'A.7b', compiled_truth: 'world' });
+    await engine.upsertChunks('test/a7-unconfigured', [
+      { chunk_index: 0, chunk_text: 'world', chunk_source: 'compiled_truth' },
+    ]);
+
+    const rows = await engine.executeRaw<{ model: string }>(
+      `SELECT cc.model FROM content_chunks cc
+        JOIN pages p ON p.id = cc.page_id
+       WHERE p.slug = 'test/a7-unconfigured' LIMIT 1`,
     );
     expect(rows[0]?.model).toBe(DEFAULT_EMBEDDING_MODEL);
     // CDX2-4 regression: would have been 'text-embedding-3-large'


### PR DESCRIPTION
## Problem

Closes #1717.

`content_chunks.model` records `DEFAULT_EMBEDDING_MODEL` (currently `'zeroentropyai:zembed-1'`) for every chunk of a brain configured with any other embedding provider. No `ChunkInput` builder sets `model` — `embed.ts` (3 call sites), `embed-stale.ts`, and `import-file.ts` all leave it undefined — so the `chunk.model || DEFAULT_EMBEDDING_MODEL` fallback in both engines' `_upsertChunksOnce` always wins, stamping provenance for a model that never produced the vectors.

Meanwhile the two *page-level* mechanisms resolved from the gateway are correct (`pages.embedding_signature` and the column DEFAULT baked by `initSchema`), so the row label silently contradicts them. Nothing reads the column for decisions today (stale detection is `embedding IS NULL`; model-swap detection is `pages.embedding_signature`), but any operator inspecting the DB — or any future feature that trusts the column — gets the wrong provider.

This is the recurrence of the v0.37 Lane A.7 fix: that pass replaced the hard-coded `'text-embedding-3-large'` literal with the `DEFAULT_EMBEDDING_MODEL` constant, but a build-time constant still isn't *this brain's* configured model.

## Relationship to #1803

#1803 fixes the same mislabel (#1717) at the `embed` command layer, so it covers `gbrain embed` only. This PR closes the class at the seam every path converges on — `upsertChunks` in both engines — so `put`, `import`, worker `embed-backfill`, and contextual re-index get the correct label too, including any future ChunkInput builder that forgets to set `model`.

## Change (2 files, same seam in both engines)

`_upsertChunksOnce` resolves the fallback from the live gateway (`getEmbeddingModel()`) at upsert time — the same pattern `initSchema` uses to bake the column DEFAULT. The constant remains only when the gateway is unconfigured (unit tests).

## Tests

`test/v0_37_gap_fill.serial.test.ts` Lane A.7 updated to pin both branches: configured gateway model wins; unconfigured gateway falls back to `DEFAULT_EMBEDDING_MODEL`. 13 tests / 0 fail; `tsc --noEmit` clean on top of current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
