### PR TITLE
fix(db): bootstrap timeline_entries.event_page_id before schema-blob index replay

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -518,7 +518,11 @@ export class PGLiteEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema='public' AND table_name='pages' AND column_name='embedding_signature') AS pages_embedding_signature_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema='public' AND table_name='pages' AND column_name='links_extracted_at') AS pages_links_extracted_at_exists
+                WHERE table_schema='public' AND table_name='pages' AND column_name='links_extracted_at') AS pages_links_extracted_at_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema='public' AND table_name='timeline_entries') AS timeline_entries_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='timeline_entries' AND column_name='event_page_id') AS timeline_event_page_id_exists
     `);
     const probe = rows[0] as {
       pages_exists: boolean;
@@ -561,6 +565,8 @@ export class PGLiteEngine implements BrainEngine {
       pages_generation_exists: boolean;
       pages_embedding_signature_exists: boolean;
       pages_links_extracted_at_exists: boolean;
+      timeline_entries_exists: boolean;
+      timeline_event_page_id_exists: boolean;
     };
 
     const needsPagesBootstrap = probe.pages_exists && !probe.source_id_exists;
@@ -637,6 +643,15 @@ export class PGLiteEngine implements BrainEngine {
     // it; pre-v112 brains crash without the column, so bootstrap adds it before
     // the CREATE INDEX runs. v112 runs later via runMigrations and is idempotent.
     const needsPagesLinksExtractedAt = probe.pages_exists && !probe.pages_links_extracted_at_exists;
+    // v0.42.x (v121, Life Chronicle #2390): idx_timeline_event_page +
+    // idx_timeline_event_dedup in PGLITE_SCHEMA_SQL reference event_page_id.
+    // `CREATE TABLE IF NOT EXISTS timeline_entries` is a no-op on pre-v121
+    // brains (won't add the column), so the blob's CREATE INDEX crashes with
+    // `column "event_page_id" does not exist` before v121 ever runs. Bootstrap
+    // adds the bare column; the FK + indexes land via v121 / the blob, both
+    // idempotent.
+    const needsTimelineEventPageId = probe.timeline_entries_exists
+      && !probe.timeline_event_page_id_exists;
 
     // Fresh installs (no tables yet) and modern brains both no-op.
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
@@ -648,7 +663,8 @@ export class PGLiteEngine implements BrainEngine {
         && !needsPagesProvenance
         && !needsContextualRetrievalColumns && !needsPagesGeneration
         && !needsPagesEmbeddingSignature
-        && !needsPagesLinksExtractedAt) return;
+        && !needsPagesLinksExtractedAt
+        && !needsTimelineEventPageId) return;
 
     process.stderr.write('  Pre-v0.21 brain detected, applying forward-reference bootstrap\n');
 
@@ -893,6 +909,17 @@ export class PGLiteEngine implements BrainEngine {
       // v112 runs later via runMigrations and is idempotent.
       await this.db.exec(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS links_extracted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsTimelineEventPageId) {
+      // v121 (timeline_entries_event_page_id, Life Chronicle #2390): the
+      // event→timeline projection pointer. PGLITE_SCHEMA_SQL's partial indexes
+      // idx_timeline_event_page + idx_timeline_event_dedup reference it, so
+      // bootstrap adds the bare column before the blob's CREATE INDEX runs.
+      // The FK + indexes land via the blob and v121, both idempotent.
+      await this.db.exec(`
+        ALTER TABLE timeline_entries ADD COLUMN IF NOT EXISTS event_page_id INTEGER;
       `);
     }
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -507,7 +507,11 @@ export class PostgresEngine implements BrainEngine {
         EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'embedding_signature') AS pages_embedding_signature_exists,
         EXISTS (SELECT 1 FROM information_schema.columns
-                WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'links_extracted_at') AS pages_links_extracted_at_exists
+                WHERE table_schema = current_schema() AND table_name = 'pages' AND column_name = 'links_extracted_at') AS pages_links_extracted_at_exists,
+        EXISTS (SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema() AND table_name = 'timeline_entries') AS timeline_entries_exists,
+        EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema() AND table_name = 'timeline_entries' AND column_name = 'event_page_id') AS timeline_event_page_id_exists
     `;
     const probe = probeRows[0]!;
 
@@ -603,6 +607,19 @@ export class PostgresEngine implements BrainEngine {
     // SCHEMA_SQL replay creates the index. v112 runs later via runMigrations
     // and is idempotent.
     const needsPagesLinksExtractedAt = probe.pages_exists && !probeCr.pages_links_extracted_at_exists;
+    // v0.42.x (v121, Life Chronicle #2390): idx_timeline_event_page +
+    // idx_timeline_event_dedup in SCHEMA_SQL reference event_page_id.
+    // `CREATE TABLE IF NOT EXISTS timeline_entries` is a no-op on pre-v121
+    // brains (won't add the column), so the blob's CREATE INDEX crashes with
+    // `column "event_page_id" does not exist` before v121 ever runs. Bootstrap
+    // adds the bare column; the FK + indexes land via v121 / the blob, both
+    // idempotent.
+    const probeTimeline = probe as {
+      timeline_entries_exists?: boolean;
+      timeline_event_page_id_exists?: boolean;
+    };
+    const needsTimelineEventPageId = !!probeTimeline.timeline_entries_exists
+      && !probeTimeline.timeline_event_page_id_exists;
 
     if (!needsPagesBootstrap && !needsLinksBootstrap && !needsChunksBootstrap
         && !needsPagesDeletedAt && !needsMcpLogBootstrap && !needsSubagentProviderId
@@ -613,7 +630,8 @@ export class PostgresEngine implements BrainEngine {
         && !needsPagesProvenance
         && !needsContextualRetrievalColumns && !needsPagesGeneration
         && !needsPagesEmbeddingSignature
-        && !needsPagesLinksExtractedAt) return;
+        && !needsPagesLinksExtractedAt
+        && !needsTimelineEventPageId) return;
 
     process.stderr.write('  Pre-v0.21 brain detected, applying forward-reference bootstrap\n');
 
@@ -858,6 +876,17 @@ export class PostgresEngine implements BrainEngine {
       // idempotent.
       await conn.unsafe(`
         ALTER TABLE pages ADD COLUMN IF NOT EXISTS links_extracted_at TIMESTAMPTZ;
+      `);
+    }
+
+    if (needsTimelineEventPageId) {
+      // v121 (timeline_entries_event_page_id, Life Chronicle #2390): the
+      // event→timeline projection pointer. SCHEMA_SQL's partial indexes
+      // idx_timeline_event_page + idx_timeline_event_dedup reference it, so
+      // bootstrap adds the bare column before the blob's CREATE INDEX runs.
+      // The FK + indexes land via the blob and v121, both idempotent.
+      await conn.unsafe(`
+        ALTER TABLE timeline_entries ADD COLUMN IF NOT EXISTS event_page_id INTEGER;
       `);
     }
   }

--- a/test/bootstrap.test.ts
+++ b/test/bootstrap.test.ts
@@ -196,4 +196,41 @@ describe('PGLiteEngine#applyForwardReferenceBootstrap', () => {
       await engine.disconnect();
     }
   }, 30000);
+
+  test('pre-v121 timeline shape: bootstrap adds event_page_id before blob index replay', async () => {
+    // v121 (Life Chronicle #2390) wedge: `CREATE TABLE IF NOT EXISTS
+    // timeline_entries` is a no-op on pre-v121 brains (won't add the column),
+    // so the blob's partial indexes idx_timeline_event_page +
+    // idx_timeline_event_dedup crash with `column "event_page_id" does not
+    // exist` before runMigrations can ever apply v121. Regression test for
+    // the bootstrap entry that closes the gap.
+    const engine = new PGLiteEngine();
+    await engine.connect({});
+    try {
+      await engine.initSchema();
+      const db = (engine as any).db;
+
+      // Mutate to pre-v121 shape: indexes + FK first, then the column.
+      await db.exec(`
+        DROP INDEX IF EXISTS idx_timeline_event_page;
+        DROP INDEX IF EXISTS idx_timeline_event_dedup;
+        ALTER TABLE timeline_entries DROP CONSTRAINT IF EXISTS timeline_entries_event_page_id_fkey;
+        ALTER TABLE timeline_entries DROP COLUMN IF EXISTS event_page_id;
+      `);
+      await engine.setConfig('version', '119');
+
+      // Path under test: bootstrap → PGLITE_SCHEMA_SQL replay → runMigrations
+      await engine.initSchema();
+
+      expect(await engine.getConfig('version')).toBe(String(LATEST_VERSION));
+
+      const { rows } = await db.query(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'timeline_entries' AND column_name = 'event_page_id'
+      `);
+      expect(rows).toHaveLength(1);
+    } finally {
+      await engine.disconnect();
+    }
+  }, 30000);
 });


### PR DESCRIPTION
## Problem

Fixes #2626, #2673.

Upgrading any pre-v121 brain wedges at `initSchema`: the schema blob's `CREATE TABLE IF NOT EXISTS timeline_entries` is a no-op on an existing table (it won't add the v121 column), so the blob's partial indexes `idx_timeline_event_page` + `idx_timeline_event_dedup` crash with `column "event_page_id" does not exist` **before** `runMigrations` can ever apply v121. The version stays stamped at the old number and every retry hits the same wall. Reproduced on a real v119 postgres brain upgrading to v0.42.57.0 (`gbrain init --migrate-only` dies with that one-line error).

Same wedge family as #239/#266/#357/#366/#374/#375/#378/#396: a column-with-index added to the schema blob without a corresponding `applyForwardReferenceBootstrap` entry.

## Relationship to #2548 / #2623

Both open PRs address the same wedge — offered here as an alternative in case either stalls; happy to close this if one of them lands. What this one adds:

- Bootstrap entry follows the exact house pattern in **both** engines (single-round-trip probe extension + guarded `ADD COLUMN IF NOT EXISTS` for the bare column only — FK and indexes land via the blob and v121, both idempotent).
- A red/green regression in `test/bootstrap.test.ts`: down-mutate a fresh brain to pre-v121 shape (drop indexes + FK + column, stamp version 119) and assert `initSchema` reaches `LATEST_VERSION` with the column restored. Verified the test fails on master without the fix and passes with it.
- Verified end-to-end against a real v119 → v122 postgres upgrade (migrations 120–122 apply, doctor reports latest).

## Tests

`bun test test/bootstrap.test.ts test/migration-v120.test.ts`: 9 tests / 0 fail; `tsc --noEmit` clean on top of current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
