### PR TITLE
feat(embedding): Qwen3-Embedding Matryoshka dims on local openai-compat providers (ollama)

### DIFF
--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -177,6 +177,12 @@ export function dimsProviderOptions(
       // Anthropic has no embedding model.
       return undefined;
     case 'openai-compatible':
+      // Qwen3-Embedding via Ollama/llama-server — Matryoshka (MRL), accepts
+      // any output dim 32..4096 via the OpenAI-compat `dimensions` param
+      // (verified against Ollama /v1/embeddings). Symmetric — no input_type.
+      if (modelId.startsWith('qwen3-embedding')) {
+        return { openaiCompatible: { dimensions: dims } };
+      }
       // ZE zembed-1 — flexible Matryoshka dims + asymmetric input_type.
       // Lives BEFORE the generic openai-compatible fall-through to avoid
       // sending input_type to providers (Azure/DashScope/Zhipu) that

--- a/src/core/ai/recipes/ollama.ts
+++ b/src/core/ai/recipes/ollama.ts
@@ -24,9 +24,15 @@ export const ollama: Recipe = {
         'all-minilm',
         'qwen3-embed-8b',
         'snowflake-arctic-embed-l-v2',
+        'qwen3-embedding:8b',
+        'qwen3-embedding:4b',
+        'qwen3-embedding:0.6b',
       ],
       default_dims: 768, // nomic-embed-text native dim
       trust_custom_dims: true, // #2271: local models carry varied native dims
+      // Ollama honors the OpenAI `dimensions` param (MRL truncation) for
+      // Matryoshka models like qwen3-embedding; validated dims listed here.
+      dims_options: [256, 512, 768, 1024, 1536, 2048, 2560, 4096],
       cost_per_1m_tokens_usd: 0,
       price_last_verified: '2026-04-20',
       // Ollama's batch capacity depends on the locally loaded model + the

--- a/test/ai/dims-qwen3-ollama.test.ts
+++ b/test/ai/dims-qwen3-ollama.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Qwen3-Embedding Matryoshka (MRL) support on local openai-compat providers.
+ *
+ * Pins:
+ *  - The ollama recipe declares `dims_options` so `gbrain init
+ *    --embedding-model ollama:qwen3-embedding:* --embedding-dimensions N`
+ *    passes the preflight resolver for MRL steps (Tier 1 of
+ *    isCustomDimValidForProvider). Previously every non-default dim was
+ *    rejected as "does not support custom dimensions", making the only
+ *    Matryoshka-capable paths cloud providers — a dead end for
+ *    local-only/data-sovereignty setups.
+ *  - dimsProviderOptions emits `{ openaiCompatible: { dimensions } }` for
+ *    qwen3-embedding* model ids so the truncation request actually reaches
+ *    the server. Ollama honors the OpenAI `dimensions` param for MRL models
+ *    (verified against Ollama 0.31.1 /v1/embeddings: qwen3-embedding:8b
+ *    with dimensions=1536 returns 1536-wide vectors). Without this, the
+ *    gateway silently omits the param and the server returns the native
+ *    4096 — exploding at first write against a vector(1536) column.
+ *  - Qwen3 embeddings are symmetric: no `input_type` is emitted (some
+ *    openai-compat servers reject unknown fields).
+ *  - Non-Matryoshka ollama models (nomic-embed-text etc.) keep returning
+ *    undefined from dimsProviderOptions — no behavior change.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { dimsProviderOptions } from '../../src/core/ai/dims.ts';
+import { resolveSchemaEmbeddingDim } from '../../src/core/embedding-dim-check.ts';
+import { getRecipe } from '../../src/core/ai/recipes/index.ts';
+
+describe('dimsProviderOptions — qwen3-embedding on openai-compatible', () => {
+  test('emits dimensions for qwen3-embedding tags (quant suffixes included)', () => {
+    for (const modelId of [
+      'qwen3-embedding:8b',
+      'qwen3-embedding:8b-fp16',
+      'qwen3-embedding:4b',
+      'qwen3-embedding:0.6b',
+    ]) {
+      expect(dimsProviderOptions('openai-compatible', modelId, 1536)).toEqual({
+        openaiCompatible: { dimensions: 1536 },
+      });
+    }
+  });
+
+  test('symmetric model: no input_type emitted even when inputType is threaded', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'qwen3-embedding:8b', 1024, 'query');
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1024 } });
+  });
+
+  test('non-Matryoshka ollama models keep the no-param behavior', () => {
+    expect(dimsProviderOptions('openai-compatible', 'nomic-embed-text', 768)).toBeUndefined();
+    expect(dimsProviderOptions('openai-compatible', 'mxbai-embed-large', 1024)).toBeUndefined();
+  });
+});
+
+describe('ollama recipe — dims_options preflight (init-time)', () => {
+  test('recipe declares Matryoshka steps including the pgvector-HNSW-safe 1536', () => {
+    const recipe = getRecipe('ollama');
+    expect(recipe).toBeDefined();
+    const dimsOptions = recipe!.touchpoints.embedding?.dims_options ?? [];
+    expect(dimsOptions).toContain(1536);
+    expect(dimsOptions).toContain(4096); // qwen3 native width
+  });
+
+  test('resolveSchemaEmbeddingDim accepts ollama:qwen3-embedding at MRL steps', () => {
+    for (const model of ['ollama:qwen3-embedding:8b', 'ollama:qwen3-embedding:8b-fp16']) {
+      const result = resolveSchemaEmbeddingDim({
+        embedding_model: model,
+        embedding_dimensions: 1536,
+      });
+      expect(result.ok, `expected ok for ${model}: ${result.ok ? '' : result.error}`).toBe(true);
+      if (result.ok) {
+        expect(result.dim).toBe(1536);
+        expect(result.provider).toBe('ollama');
+      }
+    }
+  });
+
+  test('rejects dims outside dims_options with the allowed list', () => {
+    const result = resolveSchemaEmbeddingDim({
+      embedding_model: 'ollama:qwen3-embedding:8b',
+      embedding_dimensions: 1000,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('1536');
+    }
+  });
+
+  test('regression: recipe default stays 768 (nomic-embed-text)', () => {
+    const result = resolveSchemaEmbeddingDim({
+      embedding_model: 'ollama:nomic-embed-text',
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.dim).toBe(768);
+  });
+});


### PR DESCRIPTION
> Supersedes #2526 — same change, resubmitted on a clean single-commit branch rebased to current master (the old PR's head branch had accumulated unrelated commits).

## Problem

Local Matryoshka embedding is currently impossible. Every provider on the custom-dims allow-list (`voyage`, `zeroentropyai`, `openai` text-embedding-3, DashScope, Zhipu) is cloud-hosted, so:

1. `gbrain init --embedding-model ollama:qwen3-embedding:8b --embedding-dimensions 1536` is rejected at preflight with *"does not support custom dimensions"* (Tier 3 of `isCustomDimValidForProvider`), and
2. even past init, `dimsProviderOptions()` never emits the `dimensions` param for unlisted openai-compat models, so the server returns the model's native width (4096 for Qwen3-8B) and the first write explodes against the `vector(1536)` column.

For local-only / data-sovereignty setups that need to stay under pgvector's 2000-dim HNSW cap, there is no stock path — even though Qwen3-Embedding is MRL-capable and tops the MTEB multilingual leaderboard.

## Change (2 seams, mirrors the existing dashscope/zhipu pattern)

- **`src/core/ai/recipes/ollama.ts`** — list the `qwen3-embedding` models and declare `dims_options` so preflight accepts MRL steps (Tier 1).
- **`src/core/ai/dims.ts`** — emit `{ openaiCompatible: { dimensions } }` for `qwen3-embedding*` model ids. Qwen3 embeddings are symmetric, so no `input_type` is emitted.

## Verification

Ollama honors the OpenAI `dimensions` param for MRL models — measured on Ollama 0.31.1: `POST /v1/embeddings` and `POST /api/embed` with `qwen3-embedding:8b` + `dimensions: 1536` both return 1536-wide vectors.

End-to-end on a fresh PGLite brain (`init --embedding-model ollama:qwen3-embedding:8b-fp16 --embedding-dimensions 1536`): doctor reports `1536 dims, DB aligned`, 100% embed coverage, and semantic `query` retrieves a page sharing zero keywords with the query text. Since then also running in production on a postgres brain (v0.42.57.0 base) with the same doctor result.

## Tests

`test/ai/dims-qwen3-ollama.test.ts` pins both seams: dimensions emission (incl. quant-suffix tags), no `input_type` leakage, preflight acceptance at 1536, rejection outside `dims_options`, and the `nomic-embed-text` no-param regression. 7 tests / 0 fail on top of current master; existing dims/recipe/regression suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
