### PR TITLE
v0.42.57.0 fix(import): normalize mixed-case slugs (#2680)

### DIFF
--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -36,7 +36,7 @@ import {
 } from './embedding-context.ts';
 import { loadSearchModeConfig, resolveSearchMode } from './search/mode.ts';
 import { normalizeAliasList } from './search/alias-normalize.ts';
-import { isUndefinedTableError, warnOncePerProcess } from './utils.ts';
+import { isUndefinedTableError, validateSlug, warnOncePerProcess } from './utils.ts';
 import { computeCorpusGeneration } from './contextual-retrieval-service.ts';
 import { runGuardrails } from './guardrails.ts';
 
@@ -303,6 +303,7 @@ export async function importFromContent(
     };
   }
 
+  slug = validateSlug(slug);
   const parsed = parseMarkdown(content, slug + '.md', { activePack: opts.activePack });
 
   // v0.42 (#1699 trust boundary): strip gate-owned markers from UNTRUSTED

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -38,6 +38,35 @@ afterAll(() => {
 });
 
 describe('importFile', () => {
+  test('normalizes mixed-case importFromContent slug before tag/chunk writes (#2680)', async () => {
+    const engine = mockEngine();
+
+    const result = await importFromContent(engine, 'session/GenerateText-shape-confirmed', `---
+type: concept
+title: Mixed Case
+tags: [llm, shape]
+---
+
+Content here.
+`, { noEmbed: true });
+
+    expect(result.status).toBe('imported');
+    expect(result.slug).toBe('session/generatetext-shape-confirmed');
+
+    const calls = (engine as any)._calls;
+    const putCall = calls.find((c: any) => c.method === 'putPage');
+    expect(putCall.args[0]).toBe('session/generatetext-shape-confirmed');
+
+    const tagCalls = calls.filter((c: any) => c.method === 'addTag');
+    expect(tagCalls.map((c: any) => c.args[0])).toEqual([
+      'session/generatetext-shape-confirmed',
+      'session/generatetext-shape-confirmed',
+    ]);
+
+    const chunkCall = calls.find((c: any) => c.method === 'upsertChunks');
+    expect(chunkCall.args[0]).toBe('session/generatetext-shape-confirmed');
+  });
+
   test('imports a valid markdown file', async () => {
     const filePath = join(TMP, 'test-page.md');
     writeFileSync(filePath, `---


### PR DESCRIPTION
## Summary
- Normalize importFromContent slugs through validateSlug before parsing and transactional writes.
- Keeps putPage, addTag, upsertChunks, and alias projection on the same canonical slug.
- Add a regression test for mixed-case slug imports with frontmatter tags.

Fixes #2680

## Verification
- /tmp/bun/bin/bun test test/import-file.test.ts
- /tmp/bun/bin/bun run typecheck