### PR TITLE
fix: scope autopilot fan-out to source path

### DIFF
--- a/src/commands/autopilot-fanout.ts
+++ b/src/commands/autopilot-fanout.ts
@@ -434,7 +434,9 @@ export async function dispatchPerSource(
       const job = await queue.add(
         'autopilot-cycle',
         {
-          repoPath: opts.repoPath,
+          // A fan-out job is scoped to this source. Carrying the daemon's
+          // launch path here can make an unrelated source import that repo.
+          repoPath: src.local_path,
           source_id: src.id,
           pull: !!remoteUrl,
           // #2194 fix #3 (cycle split): per-source cycles run ONLY source-scoped

--- a/test/autopilot-fanout.test.ts
+++ b/test/autopilot-fanout.test.ts
@@ -220,6 +220,18 @@ describe('dispatchPerSource — integration with stubbed engine + queue', () => 
     // source_id threaded through job data
     const sourceIds = added.map(j => (j.data as Record<string, unknown>).source_id).sort();
     expect(sourceIds).toEqual(['alpha', 'beta']);
+    // Each job must import its own registered path, not the daemon launch path.
+    // Keep the pairing intact: independent sorted arrays would miss a swap.
+    const sourcePathPairs = added
+      .map(j => {
+        const data = j.data as Record<string, unknown>;
+        return [data.source_id, data.repoPath];
+      })
+      .sort(([a], [b]) => String(a).localeCompare(String(b)));
+    expect(sourcePathPairs).toEqual([
+      ['alpha', '/tmp/alpha'],
+      ['beta', '/tmp/beta'],
+    ]);
   });
 
   test('pull: true only when source.config.remote_url is set', async () => {


### PR DESCRIPTION
## Summary
- Make each per-source `autopilot-cycle` job use that source\u2019s registered `local_path`, rather than the launch daemon\u2019s shared repo path.
- Add a regression assertion for source-ID-to-repo-path pairing.

## Why
A daemon launched from the Jarvis workspace could enqueue unrelated source IDs with the workspace path, causing repeated full imports and statement timeouts.

## Verification
- `bun test test/autopilot-fanout.test.ts` \u2014 28 pass, 0 fail
- `bun run typecheck` \u2014 pass
- All 31 `verify` checks \u2014 passed when run sequentially

## Deliberately not changed
- No source registration/migration
- No scheduler re-enable
- No retry or reconciliation policy changes