### PR TITLE
feat(health): env-gated orphan-metric type exclusion

### DIFF
--- a/src/core/health-config.ts
+++ b/src/core/health-config.ts
@@ -1,0 +1,55 @@
+/**
+ * Health-metric configuration knobs (env-gated, default OFF).
+ *
+ * `getHealth().orphan_pages` counts "islanded" pages — no inbound AND no
+ * outbound link. Machine-generated chrome (code-artifact pointers, ingest /
+ * extract / self-test / freshness logs) is islanded by nature: it references no
+ * entity and nothing references it, so it inflates the orphan count without
+ * signalling a real knowledge-graph gap. On a brain that ingests a lot of such
+ * chrome the metric reads ~46% orphaned while the human-knowledge graph is
+ * healthy.
+ *
+ * `GBRAIN_HEALTH_ORPHAN_EXCLUDE_TYPES` is a comma-separated list of page `type`s
+ * to drop from the orphan count. Unset / empty = count every type (the upstream
+ * default — this module is a pure no-op until the operator opts in). Mirrors the
+ * existing `GBRAIN_SEARCH_EXCLUDE` env pattern in `search/source-boost.ts`.
+ *
+ * Reversible: unset the env var to restore the count-everything behavior.
+ */
+
+// Page types are lowercase kebab/underscore tokens (e.g. `artifact_pointer`,
+// `selftest-run`). Validate strictly so a fragment built from this list can be
+// interpolated into SQL with no injection surface (operator-set env only, but
+// keep it fail-closed regardless).
+const TYPE_TOKEN = /^[a-z0-9][a-z0-9_-]*$/;
+
+/**
+ * Parse the configured orphan-exclusion page types. Returns [] when unset/empty
+ * or when every token is malformed — i.e. the safe, count-everything default.
+ */
+export function resolveOrphanExcludeTypes(
+  envValue: string | undefined = process.env.GBRAIN_HEALTH_ORPHAN_EXCLUDE_TYPES,
+): string[] {
+  if (!envValue) return [];
+  return envValue
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0 && TYPE_TOKEN.test(s));
+}
+
+/**
+ * SQL fragment (leading-space, or '') that excludes the configured chrome types
+ * from an orphan subquery. For the raw-string engine (PGLite). Types are
+ * validated against `TYPE_TOKEN` before interpolation.
+ *
+ *   orphanTypeExcludeClause('p')  // "" | " AND p.type NOT IN ('artifact_pointer', ...)"
+ */
+export function orphanTypeExcludeClause(
+  pageAlias: string,
+  envValue?: string,
+): string {
+  const types = resolveOrphanExcludeTypes(envValue);
+  if (types.length === 0) return '';
+  const list = types.map((t) => `'${t}'`).join(', ');
+  return ` AND ${pageAlias}.type NOT IN (${list})`;
+}

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -17,6 +17,7 @@ import type {
   SourceRow,
 } from './engine.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
+import { orphanTypeExcludeClause } from './health-config.ts';
 import { withRetry, BULK_RETRY_OPTS, resolveBulkRetryOpts, computeNextDelay, type BatchAuditSite } from './retry.ts';
 import { logBatchRetry as auditLogBatchRetry, logBatchExhausted as auditLogBatchExhausted } from './audit/batch-retry-audit.ts';
 import { runMigrations } from './migrate.ts';
@@ -4988,6 +4989,11 @@ export class PGLiteEngine implements BrainEngine {
     // pages_with_timeline) and v0.10.3 graph layer (link_coverage, timeline_coverage,
     // most_connected). Both coexist: master's brain_score is the composite
     // dashboard, v0.10.3 metrics give entity-page-level granularity.
+    // Env-gated chrome exclusion (default OFF): drop machine-generated page
+    // types from the orphan count when GBRAIN_HEALTH_ORPHAN_EXCLUDE_TYPES is
+    // set. Empty → '' (no-op, count everything). Types are strictly validated
+    // before interpolation. Mirrors postgres-engine getHealth.
+    const orphanExclude = orphanTypeExcludeClause('p');
     const { rows: [h] } = await this.db.query(`
       WITH entity_pages AS (
         SELECT id, slug FROM pages WHERE type IN ('person', 'company')
@@ -5003,7 +5009,7 @@ export class PGLiteEngine implements BrainEngine {
         -- See BrainHealth.orphan_pages docstring; docs updated to match this.
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
-           AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+           AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)${orphanExclude}
         ) as orphan_pages,
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -19,6 +19,7 @@ import type {
   DomainBankSampleOpts, CorpusSampleOpts, DomainBankRow,
 } from './types.ts';
 import { MAX_SEARCH_LIMIT, clampSearchLimit } from './engine.ts';
+import { resolveOrphanExcludeTypes } from './health-config.ts';
 import { deriveResolutionTuple, finalizeScorecard } from './takes-resolution.ts';
 import { normalizeWeightForStorage } from './takes-fence.ts';
 import { executeRawJsonb } from './sql-query.ts';
@@ -4975,6 +4976,11 @@ export class PostgresEngine implements BrainEngine {
     // SQL required both — docs now match code so users can trust the
     // number. A hub page that links out to many but has no back-references
     // is working as intended, not an orphan.
+    //
+    // Env-gated chrome exclusion (default OFF): drop machine-generated page
+    // types from the orphan count when GBRAIN_HEALTH_ORPHAN_EXCLUDE_TYPES is
+    // set. Empty list → cardinality=0 → clause is a no-op (count everything).
+    const orphanExcludeTypes = resolveOrphanExcludeTypes();
     const [h] = await sql`
       WITH entity_pages AS (
         SELECT id, slug FROM pages WHERE type IN ('person', 'company')
@@ -4989,6 +4995,8 @@ export class PostgresEngine implements BrainEngine {
         (SELECT count(*) FROM pages p
          WHERE NOT EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = p.id)
            AND NOT EXISTS (SELECT 1 FROM links l WHERE l.from_page_id = p.id)
+           AND (cardinality(${orphanExcludeTypes}::text[]) = 0
+                OR NOT (p.type = ANY(${orphanExcludeTypes}::text[])))
         ) as orphan_pages,
         (SELECT count(*) FROM links l
          WHERE NOT EXISTS (SELECT 1 FROM pages p WHERE p.id = l.to_page_id)

--- a/test/health-config.test.ts
+++ b/test/health-config.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'bun:test';
+import { resolveOrphanExcludeTypes, orphanTypeExcludeClause } from '../src/core/health-config.ts';
+
+describe('resolveOrphanExcludeTypes', () => {
+  it('defaults to [] when unset (count everything)', () => {
+    expect(resolveOrphanExcludeTypes(undefined)).toEqual([]);
+    expect(resolveOrphanExcludeTypes('')).toEqual([]);
+  });
+
+  it('parses a comma list, trimming + lowercasing', () => {
+    expect(resolveOrphanExcludeTypes('artifact_pointer, Ingest_Log ,extract_receipt'))
+      .toEqual(['artifact_pointer', 'ingest_log', 'extract_receipt']);
+  });
+
+  it('keeps kebab + underscore type tokens', () => {
+    expect(resolveOrphanExcludeTypes('selftest-run,freshness_check'))
+      .toEqual(['selftest-run', 'freshness_check']);
+  });
+
+  it('drops malformed tokens (injection-safe fail-closed)', () => {
+    expect(resolveOrphanExcludeTypes("email'); DROP TABLE pages;--,artifact_pointer"))
+      .toEqual(['artifact_pointer']);
+    expect(resolveOrphanExcludeTypes('a b, c*d, ok_type')).toEqual(['ok_type']);
+  });
+});
+
+describe('orphanTypeExcludeClause', () => {
+  it('returns "" when nothing configured (no-op)', () => {
+    expect(orphanTypeExcludeClause('p', undefined)).toBe('');
+    expect(orphanTypeExcludeClause('p', '')).toBe('');
+  });
+
+  it('builds a validated NOT IN fragment', () => {
+    expect(orphanTypeExcludeClause('p', 'artifact_pointer,ingest_log'))
+      .toBe(" AND p.type NOT IN ('artifact_pointer', 'ingest_log')");
+  });
+
+  it('honors the page alias', () => {
+    expect(orphanTypeExcludeClause('pg', 'selftest-run'))
+      .toBe(" AND pg.type NOT IN ('selftest-run')");
+  });
+});


### PR DESCRIPTION
## What

Adds an opt-in env var, `GBRAIN_HEALTH_ORPHAN_EXCLUDE_TYPES`, that drops the listed page `type`s from `getHealth().orphan_pages`. Unset/empty = count every type (the current behavior), so this is a pure no-op until an operator opts in.

## Why

`orphan_pages` counts "islanded" pages (no inbound AND no outbound link). Machine-generated chrome — code-artifact pointers, ingest/extract/self-test/freshness logs — is islanded by nature: nothing references it and it references nothing, so it inflates the orphan count without signalling a real knowledge-graph gap. On a brain that ingests a lot of such chrome the metric can read ~46% orphaned while the human-knowledge graph is healthy.

## How

- New `src/core/health-config.ts`: `resolveOrphanExcludeTypes()` + `orphanTypeExcludeClause()`, with strict token validation so the fragment is injection-safe (operator-set env only, but fail-closed regardless).
- Postgres engine: `cardinality()=0 OR NOT (type = ANY())` guard idiom (the array-param pattern already used elsewhere in the file).
- PGLite engine: validated inline `NOT IN` clause (engine parity).
- 7 unit tests incl. malformed-token rejection.

## Risk / testing

Default OFF, reversible (unset the env). No schema change, no migration. `bun run typecheck` clean; `bun test test/health-config.test.ts` 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)