### PR TITLE
feat(conversation-parser): wire the LLM parse fallback into the extraction orchestrator

### DIFF
--- a/src/commands/extract-conversation-facts.ts
+++ b/src/commands/extract-conversation-facts.ts
@@ -246,6 +246,9 @@ export interface ExtractConversationFactsResult {
   pages_skipped: number;
   pages_skipped_too_large: number;
   pages_skipped_disappeared: number;
+  /** pages whose built-in regex parse missed but the opt-in LLM fallback
+   *  recovered messages from. Absent/0 when the fallback is off. */
+  pages_llm_fallback?: number;
   /**
    * v0.41.15.0 (D6): pages we attempted to claim but skipped because
    * another worker / parallel process held the advisory lock. The pages
@@ -284,8 +287,11 @@ export interface ExtractConversationFactsResult {
 
 import {
   parseConversation,
+  deriveDateContext,
   type ParseConversationOpts as OrchestratorParseOpts,
 } from '../core/conversation-parser/parse.ts';
+import { runLlmFallback } from '../core/conversation-parser/llm-fallback.ts';
+import { resolveModel } from '../core/model-config.ts';
 
 /**
  * v0.41.13.0 — back-compat shape for direct callers + the existing
@@ -633,6 +639,15 @@ interface ExtractCoreState {
    * batch boundaries + final flush.
    */
   cpMap: Map<string, string>;
+  /**
+   * LLM conversation-parser fallback. Opt-in via
+   * `conversation_parser.llm_fallback_enabled=true`. When enabled and a page's
+   * built-in regex parse returns phase `no_match`, the page body is parsed by
+   * the utility-tier LLM (see `conversation-parser/llm-fallback.ts`). Resolved
+   * ONCE at state construction: model is null when disabled.
+   */
+  llmFallbackEnabled: boolean;
+  llmFallbackModel: string | null;
 }
 
 function cpMapKey(sourceId: string, slug: string): string {
@@ -690,9 +705,45 @@ async function processPage(
   // meant Telegram-bracket pages with frontmatter dates landed at
   // 1970-01-01. Now they pick up the correct date.
   const parseResult = parseConversation(body, { page });
-  const messages = parseResult.messages;
+  let messages = parseResult.messages;
   if (parseResult.timezone_warning) {
     process.stderr.write(parseResult.timezone_warning + '\n');
+  }
+  // LLM fallback: when no built-in regex pattern matched (phase `no_match`) and
+  // the operator has opted in, ask the utility-tier LLM to parse the body. The
+  // prompt returns [] for non-chat content (README/code/etc.), so non-
+  // conversation pages stay skipped. Fail-open: any error leaves `messages`
+  // empty and the page skipped. The page's date is threaded through so time-
+  // only timestamps resolve to the real date (not 1970), which keeps the
+  // parsed messages above the per-page segment watermark.
+  if (
+    messages.length === 0 &&
+    parseResult.phase === 'no_match' &&
+    state.llmFallbackEnabled &&
+    state.llmFallbackModel
+  ) {
+    try {
+      const fb = await runLlmFallback({
+        modelStr: state.llmFallbackModel,
+        body,
+        engine: state.engine,
+        signal: state.signal,
+        fallbackDate: deriveDateContext({ page }).fallbackDate,
+      });
+      if (fb && fb.length > 0) {
+        messages = fb;
+        state.result.pages_llm_fallback = (state.result.pages_llm_fallback ?? 0) + 1;
+        process.stderr.write(
+          `[extract-conversation-facts] LLM-fallback parsed ${fb.length} message(s) for ${page.slug}\n`,
+        );
+      }
+    } catch (err) {
+      if (isAbortError(err)) throw err;
+      if (err instanceof BudgetExhausted) throw err;
+      process.stderr.write(
+        `[extract-conversation-facts] LLM-fallback failed for ${page.slug}: ${(err as Error).message}\n`,
+      );
+    }
   }
   const segments = splitIntoSegments(messages, { sinceIso });
   if (segments.length === 0) {
@@ -920,6 +971,19 @@ export async function runExtractConversationFactsCore(
   );
   const workers = workersResolved.workers;
 
+  // Resolve the LLM conversation-parser fallback gate ONCE. Opt-in:
+  // `gbrain config set conversation_parser.llm_fallback_enabled true`. Utility
+  // tier (Haiku-class) keeps the per-page cost low; the fallback is content-
+  // hash cached in llm-base so re-runs of an already-parsed page are free.
+  const llmFallbackEnabled =
+    (await engine.getConfig('conversation_parser.llm_fallback_enabled'))?.trim() === 'true';
+  const llmFallbackModel = llmFallbackEnabled
+    ? await resolveModel(engine, {
+        tier: 'utility',
+        fallback: 'anthropic:claude-haiku-4-5-20251001',
+      })
+    : null;
+
   const state: ExtractCoreState = {
     result,
     engine,
@@ -930,6 +994,8 @@ export async function runExtractConversationFactsCore(
     types,
     signal,
     cpMap: new Map(),
+    llmFallbackEnabled,
+    llmFallbackModel,
   };
 
   // Run body. Either inside the externally-provided tracker scope (no

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -944,6 +944,7 @@ export const KNOWN_CONFIG_KEY_PREFIXES: readonly string[] = [
   'mcp.',               // mcp.publish_skills, mcp.skills_dir (PR1 skill catalog)
   'autopilot.',         // autopilot.nightly_quality_probe.*, autopilot.auto_drain.* (#1685)
   'self_upgrade.',      // v0.42 self-upgrade (mode, quiet_hours, state)
+  'conversation_parser.', // conversation_parser.llm_fallback_enabled (LLM parse-fallback opt-in)
 ];
 
 export function saveConfig(config: GBrainConfig): void {

--- a/src/core/conversation-parser/llm-fallback.ts
+++ b/src/core/conversation-parser/llm-fallback.ts
@@ -59,6 +59,15 @@ export interface RunLlmFallbackOpts {
   engine?: BrainEngine;
   /** Test seam. */
   chatTransport?: ChatTransport;
+  /**
+   * Conversation date (YYYY-MM-DD) for the page, from the caller's
+   * date-context derivation. Injected into the prompt so the model stamps
+   * time-only timestamps with the real date instead of the 1970-01-01 epoch
+   * default. Load-bearing for the backfill cycle: 1970 timestamps fall below
+   * the per-page segment/checkpoint watermark, so the page never advances and
+   * is re-parsed every cycle. Omitted / '1970-01-01' → prior epoch behavior.
+   */
+  fallbackDate?: string;
 }
 
 /**
@@ -77,10 +86,19 @@ export async function runLlmFallback(
     .slice(0, sampleN)
     .join('\n');
 
+  // Prepend the known conversation date so the model resolves time-only
+  // timestamps to it (not 1970-01-01). Kept in `content` (not `system`) so it
+  // participates in the content-hash cache key — two pages with the same body
+  // but different dates must not share a cached parse.
+  const dateHeader =
+    opts.fallbackDate && opts.fallbackDate !== '1970-01-01'
+      ? `[Conversation date: ${opts.fallbackDate}. Use this date for any time-only timestamps.]\n`
+      : '';
+
   return runLlmCall<MatchedMessage[]>({
     shape: 'fallback',
     modelStr: opts.modelStr,
-    content: sampled,
+    content: dateHeader + sampled,
     system: FALLBACK_SYSTEM_PROMPT,
     signal: opts.signal,
     engine: opts.engine,


### PR DESCRIPTION
## What

Wires `runLlmFallback` — the conversation-parser LLM fallback shipped in v0.41.16.0 — into the extraction orchestrator, so `no_match` pages actually get parsed when an operator opts in.

## Why (this is dead code today)

`runLlmFallback` is defined but **never called** — the only reference outside its own file is a comment in `parse.ts`. So pages whose format no built-in regex pattern matches (phase `no_match`) yield zero segments and therefore zero conversation facts, and the documented opt-in (`config set conversation_parser.llm_fallback_enabled true`) is a no-op: the key was never registered in the config allowlist **and** the value was never read anywhere.

## How

- `extract-conversation-facts.ts` `processPage`: on `no_match` + the opt-in gate, call `runLlmFallback` (utility/Haiku tier) on the body. The prompt returns `[]` for non-chat content, so non-conversation pages stay skipped. Fail-open; content-hash cached in `llm-base` so re-runs of an already-parsed page are free.
- Thread the page's date context into `runLlmFallback` and inject it into the prompt, so time-only timestamps resolve to the real conversation date instead of the `1970-01-01` epoch default. Without this, the fallback's messages fall below the per-page segment/checkpoint watermark, so a backfill pass never advances and re-parses the same page every run.
- Register the `conversation_parser.` config prefix so `config set` accepts the documented flag without `--force`.
- Gate + model resolved once into `ExtractCoreState`; new `pages_llm_fallback` result counter.

## Risk / testing

Opt-in, default OFF (privacy of chat logs). No schema change. `bun run typecheck` clean; conversation + config test suites pass (189/189). Verified end-to-end on a real brain: previously-unparseable pages now extract facts, and re-runs correctly skip already-completed pages (checkpoint advances).

🤖 Generated with [Claude Code](https://claude.com/claude-code)