### PR TITLE
fix(sync): allow file transport only for the trusted local durability origin

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1627,7 +1627,14 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       // pullRepo's own 300s default). The catch below distinguishes
       // timeout (ETIMEDOUT / SIGTERM on err.cause) from ordinary pull
       // failure.
-      pullRepo(repoPath);
+      // Allow the file transport ONLY for the trusted local durability origin:
+      // the default brain source (its origin is the gbrain bare repo under
+      // GBRAIN_HOME). pullRepo re-verifies the origin is local AND contained
+      // under the trusted root, so federated https sources keep full SSRF
+      // hardening. Fixes the autopilot git_pull loop ("transport 'file' not allowed").
+      pullRepo(repoPath, {
+        allowLocalFileOrigin: !opts.sourceId || opts.sourceId === DEFAULT_SOURCE_ID,
+      });
       serr(`[gbrain phase] sync.git_pull done ${Date.now() - _t0}ms`);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);

--- a/src/core/git-remote.ts
+++ b/src/core/git-remote.ts
@@ -15,9 +15,10 @@
  * stderr warning at use site is the operator's signal.
  */
 import { execFileSync } from 'child_process';
-import { lstatSync, existsSync, readdirSync } from 'fs';
-import { join } from 'path';
+import { lstatSync, existsSync, readdirSync, realpathSync } from 'fs';
+import { join, sep } from 'path';
 import { isInternalUrl } from './url-safety.ts';
+import { fileURLToPath } from 'url';
 
 /**
  * Git CLI accepts two flag positions:
@@ -44,6 +45,21 @@ import { isInternalUrl } from './url-safety.ts';
 export const GIT_SSRF_FLAGS = [
   '-c', 'http.followRedirects=false',
   '-c', 'protocol.file.allow=never',
+  '-c', 'protocol.ext.allow=never',
+] as const;
+
+/**
+ * Global git config flags for a TRUSTED LOCAL-FILE origin (the brain's own bare
+ * durability repo under GBRAIN_HOME). A local filesystem remote is not an SSRF
+ * vector — no DNS, no network, no redirects — so the file transport is safe
+ * here. Redirect + external-helper hardening are KEPT; only protocol.file.allow
+ * is relaxed, and submodules stay disabled via GIT_SSRF_SUBCOMMAND_FLAGS so
+ * `always` cannot open a recursive file surface. Used ONLY via pullRepo's
+ * gated allowLocalFileOrigin path.
+ */
+export const GIT_SSRF_FLAGS_LOCAL = [
+  '-c', 'http.followRedirects=false',
+  '-c', 'protocol.file.allow=always',
   '-c', 'protocol.ext.allow=never',
 ] as const;
 
@@ -214,9 +230,82 @@ export function cloneRepo(url: string, destDir: string, opts: CloneOpts = {}): v
   }
 }
 
-/** Pull a repo with --ff-only and the same SSRF-defensive flags as cloneRepo. */
-export function pullRepo(repoPath: string, opts: { timeoutMs?: number } = {}): void {
-  const args: string[] = ['-C', repoPath, ...GIT_SSRF_FLAGS, 'pull', ...GIT_SSRF_SUBCOMMAND_FLAGS, '--ff-only'];
+/**
+ * True when a git remote URL uses the local-file transport (no network): a
+ * `file://` URL or a bare filesystem path. Anything with a network scheme
+ * (http/https/ssh/git://) or scp-like `[user@]host:path` is remote.
+ */
+export function isLocalFileRemote(url: string): boolean {
+  if (!url) return false;
+  if (url.startsWith('file://')) return true;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(url)) return false;
+  const colon = url.indexOf(':');
+  const slash = url.indexOf('/');
+  if (colon !== -1 && (slash === -1 || colon < slash)) return false; // scp-like host:path
+  return true;
+}
+
+/**
+ * Resolve the URL of the remote `git pull` would use for repoPath's current
+ * branch (its configured upstream remote, defaulting to `origin`), or null.
+ */
+function pullOriginUrl(repoPath: string): string | null {
+  const run = (args: string[]): string | null => {
+    try {
+      return execFileSync('git', ['-C', repoPath, ...args], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        env: { ...process.env, ...GIT_ENV },
+      }).toString().trim() || null;
+    } catch {
+      return null;
+    }
+  };
+  const branch = run(['symbolic-ref', '--short', '-q', 'HEAD']);
+  const remote = (branch && run(['config', '--get', `branch.${branch}.remote`])) || 'origin';
+  return run(['remote', 'get-url', remote]);
+}
+
+/**
+ * True only when repoPath's pull remote is a local-file path physically
+ * contained under trustedRoot (the gbrain-managed durability bare repo under
+ * GBRAIN_HOME). Gates the file-transport relaxation: a federated source
+ * (https-only via parseRemoteUrl) or any local path outside the trusted root
+ * never qualifies, so hardening cannot be bypassed by configuring a local origin.
+ */
+function isTrustedLocalOrigin(repoPath: string, trustedRoot: string): boolean {
+  const url = pullOriginUrl(repoPath);
+  if (!url || !isLocalFileRemote(url)) return false;
+  const originPath = url.startsWith('file://') ? fileURLToPath(url) : url;
+  try {
+    const real = realpathSync(originPath);
+    const root = realpathSync(trustedRoot);
+    return real === root || real.startsWith(root.endsWith(sep) ? root : root + sep);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pull a repo with --ff-only and SSRF-defensive flags. Strict by default
+ * (protocol.file.allow=never), matching cloneRepo.
+ *
+ * `allowLocalFileOrigin` opts into the file transport ONLY for a trusted local
+ * bare repo — the gbrain durability origin under GBRAIN_HOME (default) or
+ * `trustedOriginRoot`. Even then, pullRepo re-verifies the resolved origin is a
+ * local path contained under that root before relaxing, so network remotes keep
+ * full hardening. Needed because the brain's own durability origin is a local
+ * bare repo (file transport), which the strict flags reject with
+ * "fatal: transport 'file' not allowed".
+ */
+export function pullRepo(
+  repoPath: string,
+  opts: { timeoutMs?: number; allowLocalFileOrigin?: boolean; trustedOriginRoot?: string } = {},
+): void {
+  const trustedRoot = opts.trustedOriginRoot ?? (process.env.GBRAIN_HOME || join(process.env.HOME || '', '.gbrain'));
+  const flags = opts.allowLocalFileOrigin && isTrustedLocalOrigin(repoPath, trustedRoot)
+    ? GIT_SSRF_FLAGS_LOCAL
+    : GIT_SSRF_FLAGS;
+  const args: string[] = ['-C', repoPath, ...flags, 'pull', ...GIT_SSRF_SUBCOMMAND_FLAGS, '--ff-only'];
   try {
     execFileSync('git', args, {
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/test/git-remote.test.ts
+++ b/test/git-remote.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   GIT_SSRF_FLAGS,
+  GIT_SSRF_FLAGS_LOCAL,
   GIT_SSRF_SUBCOMMAND_FLAGS,
   parseRemoteUrl,
   RemoteUrlError,
@@ -23,6 +24,7 @@ import { withEnv } from './helpers/with-env.ts';
 const FAKE_GIT_DIR = join(tmpdir(), `gbrain-git-remote-test-${process.pid}`);
 const FAKE_GIT_LOG = join(FAKE_GIT_DIR, 'argv.log');
 const FAKE_GIT_MODE = join(FAKE_GIT_DIR, 'mode');
+const FAKE_GIT_ORIGIN = join(FAKE_GIT_DIR, 'origin-url');
 
 function writeFakeGit(): void {
   mkdirSync(FAKE_GIT_DIR, { recursive: true });
@@ -30,6 +32,8 @@ function writeFakeGit(): void {
   writeFileSync(FAKE_GIT_MODE, 'ok');
   // Per-invocation argv goes into argv.log (one JSON array per line).
   writeFileSync(FAKE_GIT_LOG, '');
+  // Origin URL emitted by fake-git for `remote get-url` in local-origin mode.
+  writeFileSync(FAKE_GIT_ORIGIN, '');
   const script = `#!/usr/bin/env bash
 # Fake git for git-remote.test.ts
 { printf '['; for arg in "$@"; do printf '%s,' "$(printf '%s' "$arg" | jq -Rs .)"; done; printf 'null]\\n'; } >> "${FAKE_GIT_LOG}"
@@ -38,6 +42,13 @@ case "$mode" in
   fail) exit 1 ;;
   url-drift) echo "https://github.com/different/url" ;;
   url-match) echo "https://github.com/expected/url" ;;
+  local-origin)
+    case " $* " in
+      *" symbolic-ref "*) echo "main" ;;
+      *" get-url "*) cat "${FAKE_GIT_ORIGIN}" 2>/dev/null || true ;;
+      *) : ;;
+    esac
+    ;;
   *) ;;
 esac
 exit 0
@@ -62,8 +73,12 @@ function clearArgvLog(): void {
   writeFileSync(FAKE_GIT_LOG, '');
 }
 
-function setMode(mode: 'ok' | 'fail' | 'url-drift' | 'url-match'): void {
+function setMode(mode: 'ok' | 'fail' | 'url-drift' | 'url-match' | 'local-origin'): void {
   writeFileSync(FAKE_GIT_MODE, mode);
+}
+
+function setOrigin(url: string): void {
+  writeFileSync(FAKE_GIT_ORIGIN, url);
 }
 
 beforeAll(() => writeFakeGit());
@@ -348,6 +363,94 @@ describe('pullRepo', () => {
     await withEnv({ PATH: fakePath() }, async () => {
       expect(() => pullRepo(repo)).toThrow(GitOperationError);
     });
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // local-file origin gating (v0.28 security-sensitive change). pullRepo is
+  // strict by default and only relaxes protocol.file.allow to `always` when
+  // opted-in AND the resolved pull origin is a local-file path physically
+  // contained under the trusted root. We observe the recorded argv's `-c`
+  // block (between the `-C <repo>` prefix and the `pull` verb).
+  // -------------------------------------------------------------------------
+
+  test('default (no opts): -c block is strict — protocol.file.allow=never, origin never resolved', async () => {
+    const repo = join(FAKE_GIT_DIR, 'pull-strict-default');
+    mkdirSync(repo, { recursive: true });
+    await withEnv({ PATH: fakePath() }, async () => {
+      pullRepo(repo);
+    });
+    const calls = readArgvLog();
+    // Strict path short-circuits origin resolution: exactly one git call.
+    expect(calls.length).toBe(1);
+    const argv = calls[0];
+    const flagBlock = argv.slice(2, argv.indexOf('pull'));
+    expect(flagBlock).toEqual([...GIT_SSRF_FLAGS]);
+    expect(flagBlock).toContain('protocol.file.allow=never');
+    expect(flagBlock).not.toContain('protocol.file.allow=always');
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  test('allowLocalFileOrigin + local origin under trusted root: -c block relaxes to GIT_SSRF_FLAGS_LOCAL (protocol.file.allow=always)', async () => {
+    const repo = join(FAKE_GIT_DIR, 'pull-local-trusted');
+    mkdirSync(repo, { recursive: true });
+    // A REAL local bare-repo dir as origin, physically under the trusted root
+    // (realpathSync requires both to exist for the containment check).
+    const originPath = join(FAKE_GIT_DIR, 'local-origin.git');
+    mkdirSync(originPath, { recursive: true });
+    setMode('local-origin');
+    setOrigin(originPath);
+    await withEnv({ PATH: fakePath() }, async () => {
+      pullRepo(repo, { allowLocalFileOrigin: true, trustedOriginRoot: FAKE_GIT_DIR });
+    });
+    const pullCall = readArgvLog().find(c => c.includes('pull'));
+    expect(pullCall).toBeDefined();
+    const flagBlock = pullCall!.slice(2, pullCall!.indexOf('pull'));
+    expect(flagBlock).toEqual([...GIT_SSRF_FLAGS_LOCAL]);
+    expect(flagBlock).toContain('protocol.file.allow=always');
+    expect(flagBlock).not.toContain('protocol.file.allow=never');
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(originPath, { recursive: true, force: true });
+  });
+
+  test('allowLocalFileOrigin + local origin OUTSIDE trusted root: -c block stays strict (protocol.file.allow=never)', async () => {
+    const repo = join(FAKE_GIT_DIR, 'pull-local-outside');
+    mkdirSync(repo, { recursive: true });
+    const originPath = join(FAKE_GIT_DIR, 'local-origin.git');
+    mkdirSync(originPath, { recursive: true });
+    // A real trusted root that does NOT contain originPath.
+    const outsideRoot = join(tmpdir(), `gbrain-outside-root-${process.pid}`);
+    mkdirSync(outsideRoot, { recursive: true });
+    setMode('local-origin');
+    setOrigin(originPath);
+    await withEnv({ PATH: fakePath() }, async () => {
+      pullRepo(repo, { allowLocalFileOrigin: true, trustedOriginRoot: outsideRoot });
+    });
+    const pullCall = readArgvLog().find(c => c.includes('pull'));
+    expect(pullCall).toBeDefined();
+    const flagBlock = pullCall!.slice(2, pullCall!.indexOf('pull'));
+    expect(flagBlock).toEqual([...GIT_SSRF_FLAGS]);
+    expect(flagBlock).toContain('protocol.file.allow=never');
+    expect(flagBlock).not.toContain('protocol.file.allow=always');
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(originPath, { recursive: true, force: true });
+    rmSync(outsideRoot, { recursive: true, force: true });
+  });
+
+  test('allowLocalFileOrigin + https origin: -c block stays strict (network remote never relaxed)', async () => {
+    const repo = join(FAKE_GIT_DIR, 'pull-https-origin');
+    mkdirSync(repo, { recursive: true });
+    setMode('local-origin');
+    setOrigin('https://github.com/example/repo.git');
+    await withEnv({ PATH: fakePath() }, async () => {
+      pullRepo(repo, { allowLocalFileOrigin: true, trustedOriginRoot: FAKE_GIT_DIR });
+    });
+    const pullCall = readArgvLog().find(c => c.includes('pull'));
+    expect(pullCall).toBeDefined();
+    const flagBlock = pullCall!.slice(2, pullCall!.indexOf('pull'));
+    expect(flagBlock).toEqual([...GIT_SSRF_FLAGS]);
+    expect(flagBlock).toContain('protocol.file.allow=never');
+    expect(flagBlock).not.toContain('protocol.file.allow=always');
     rmSync(repo, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Problem

`pullRepo` spreads `GIT_SSRF_FLAGS` unconditionally, so `protocol.file.allow=never` also applies to the brain's own local bare durability origin (`~/.gbrain/brain-origin.git`). On any install whose default brain source pulls from that local bare repo, every autopilot cycle fails `sync.git_pull` with:

```
fatal: transport 'file' not allowed
```

Effects observed on a real install: the durability pull never runs, and `autopilot.err` grows unbounded (183k lines / 6 MB of the same repeating failure). Manual `git pull` and SSH `ls-remote` both succeed, so the repo/remote/auth are fine — only the daemon's hardened pull is broken.

A local filesystem remote is not an SSRF vector (no DNS, no network, no redirects), so rejecting it buys no security on this path while breaking the product's own durability design.

## Fix

Strict stays the default — `pullRepo` behavior is unchanged for every existing caller.

- New `GIT_SSRF_FLAGS_LOCAL`: identical to `GIT_SSRF_FLAGS` except `protocol.file.allow=always`. Redirect + external-helper hardening are kept, and submodules stay disabled via `GIT_SSRF_SUBCOMMAND_FLAGS`, so `always` cannot open a recursive file surface.
- New gated opt-in `pullRepo(repoPath, { allowLocalFileOrigin })`: even when passed, the relaxed flags are used only after re-verifying (realpath containment) that the branch's configured pull remote is a local path physically inside `GBRAIN_HOME` (or an explicit `trustedOriginRoot`). A network remote, an scp-like `host:path`, or a local path outside the trusted root all keep full hardening.
- `sync.ts` passes the opt-in only for the `default` brain source, so federated https sources are double-gated and keep full SSRF hardening.
- `isLocalFileRemote()` exported for the transport classification (file:// URL or bare filesystem path; any URL scheme or scp-like syntax is remote).

## Tests

`bun test test/git-remote.test.ts` → 41 pass / 0 fail (37 existing + 4 new):

- strict default still rejects a file-transport origin,
- opt-in pulls when the origin is contained under the trusted root,
- opt-in still rejects when the trusted root doesn't contain the origin,
- network remotes are never relaxed regardless of the opt-in.

The new tests were mutation-checked: forcing the flags always-strict kills only the relax test; forcing always-relaxed kills the strict tests.

## Repro

1. Point a brain's default source origin at a local bare repo (`git remote set-url origin ~/.gbrain/brain-origin.git`).
2. Run the autopilot (or any `sync` with a pull).
3. Before: `sync.git_pull error … transport 'file' not allowed` every cycle. After: `sync.git_pull done`.