### PR TITLE
fix: give autopilot a shared wedge watchdog

### DIFF
--- a/docs/guides/queue-operations-runbook.md
+++ b/docs/guides/queue-operations-runbook.md
@@ -23,16 +23,20 @@ container health), but its DB connection died (common behind a transaction
 pooler) and never came back, so it claims no jobs and finishes nothing. Jobs
 pile up with **0 active**. Liveness checks all pass; nothing crashes.
 
-As of v0.42.22.0 this self-heals — you usually won't have to do anything:
+The dead-pool path has self-healed since v0.42.22.0, so you usually won't have
+to do anything. Current managed-worker paths also share the same progress
+watchdog: standalone `gbrain jobs supervisor` and the worker embedded by
+`gbrain autopilot`:
 
 - **The worker exits on its own dead pool.** Under a supervisor, the worker's
   DB-liveness probe runs and self-exits (`db_dead`) after ~3 minutes; the
-  supervisor respawns it with a fresh pool.
-- **The supervisor restarts a worker that stops making progress.** If a queue
+  composing process respawns it with a fresh pool.
+- **The manager restarts a worker that stops making progress.** If a queue
   has claimable work, **0 live-lock active jobs**, and no completions for 15
-  minutes while the child is alive, the supervisor restarts it (covers stuck
-  handlers too, not just dead pools). Tune with `--wedge-restart-minutes` /
-  `--wedge-restart-checks` on `gbrain jobs supervisor` (0 disables).
+  minutes while the child is alive, its shared watchdog restarts it (covers
+  stuck handlers too, not just dead pools). Standalone deployments can tune
+  this with `--wedge-restart-minutes` / `--wedge-restart-checks` on
+  `gbrain jobs supervisor` (0 disables); autopilot uses the documented defaults.
 
 The signal is loud now — check either:
 
@@ -45,7 +49,12 @@ gbrain doctor --json | jq '.checks[] | select(.name == "wedged_queue")'
 stale completions). Manual fix if you ever need it:
 
 ```bash
-gbrain jobs supervisor stop && gbrain jobs supervisor start   # fresh pool
+# Standalone supervisor:
+gbrain jobs supervisor stop && gbrain jobs supervisor start
+
+# Canonical macOS autopilot install:
+launchctl kickstart -k gui/$(id -u)/com.gbrain.autopilot
+
 gbrain jobs retry <id>                                        # dead-lettered jobs
 ```
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -298,9 +298,11 @@ What `gbrain autopilot --install` does:
   detected (use `--no-inject` to opt out).
 - On **Linux without systemd**: installs a crontab entry (every 5 min).
 
-Autopilot then supervises the Minions worker as a child process. Users get
-sync + extract + embed + backlinks + durable Postgres-backed job processing
-from ONE install step. No separate `gbrain jobs work` daemon to manage.
+Autopilot then supervises the Minions worker as a child process, including the
+same bounded alive-but-wedged progress watchdog used by the standalone
+supervisor. Users get sync + extract + embed + backlinks + durable
+Postgres-backed job processing from ONE install step. No separate
+`gbrain jobs work` daemon to manage.
 
 On PGLite, autopilot runs inline (PGLite's exclusive file lock blocks a
 separate worker process). Everything else still works.

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -5,8 +5,9 @@
  *   - Default path (minion_mode != off AND engine == postgres): spawn a
  *     `gbrain jobs work` child process, submit ONE `autopilot-cycle` job
  *     per interval with an idempotency_key so slow cycles don't stack up.
- *     The forked worker drains the queue durably; restart with 10s backoff
- *     on crash (5-crash cap → autopilot stops with a clear error).
+ *     The forked worker drains the queue durably; the shared progress watchdog
+ *     restarts alive-but-wedged workers, while crash handling uses bounded
+ *     backoff (5-crash soft cap → degraded retry, hard ceiling as backstop).
  *   - Fallback (minion_mode=off, PGLite, or `--inline`): run sync →
  *     extract → embed inline, same as pre-v0.11.1 behavior.
  *
@@ -25,6 +26,12 @@ import type { BrainEngine } from '../core/engine.ts';
 import { loadPreferences } from '../core/preferences.ts';
 import { loadConfig, saveConfig, gbrainPath as gbrainHomePath } from '../core/config.ts';
 import { ChildWorkerSupervisor } from '../core/minions/child-worker-supervisor.ts';
+import {
+  DEFAULT_WEDGE_WATCHDOG_OPTIONS,
+  WorkerWedgeWatchdog,
+  deriveClaimableHandlerNames,
+  queryWedgeSignals,
+} from '../core/minions/wedge-watchdog.ts';
 import { VERSION } from '../version.ts';
 import {
   canSelfUpdate,
@@ -381,6 +388,9 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
 
   let stopping = false;
   let childSupervisor: ChildWorkerSupervisor | null = null;
+  let wedgeWatchdog: WorkerWedgeWatchdog | null = null;
+  let wedgeHealthTimer: ReturnType<typeof setInterval> | null = null;
+  let wedgeHealthInFlight = false;
 
   if (spawnManagedWorker) {
     const cliPath = resolveGbrainCliPath();
@@ -396,7 +406,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
       args: ['jobs', 'work', '--max-rss', String(autopilotMaxRssMb)],
       // process.env clone; autopilot doesn't gate shell jobs the way the
       // standalone supervisor does (autopilot is the operator-trust path).
-      env: { ...process.env },
+      env: { ...process.env, GBRAIN_SUPERVISED: '1' },
       maxCrashes: 5,
       isStopping: () => stopping,
       onMaxCrashesExceeded: (count, max) => {
@@ -408,6 +418,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
         // Matches the prior console output shape so operators reading
         // existing logs see the same lines.
         if (event.kind === 'worker_spawned') {
+          wedgeWatchdog?.noteWorkerSpawned();
           console.log(
             `[autopilot] Minions worker spawned (pid: ${event.pid}, watchdog: ${autopilotMaxRssMb}MB${event.tini ? ', tini: active' : ''})`,
           );
@@ -439,6 +450,46 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
         }
       },
     });
+
+    // Autopilot owns the worker process directly, so it must also own the
+    // cause-agnostic progress watchdog. Reuse the same state machine as
+    // `gbrain jobs supervisor`: waiting claimable work + no live active job +
+    // stale progress for three checks triggers a bounded child restart.
+    let handlerNames: string[] = [];
+    try {
+      handlerNames = await deriveClaimableHandlerNames(engine, 'default');
+    } catch (e) {
+      console.error(
+        `[autopilot] health_warn: wedge_watchdog_inert error=${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+    wedgeWatchdog = new WorkerWedgeWatchdog({
+      queue: 'default',
+      restartMinutes: DEFAULT_WEDGE_WATCHDOG_OPTIONS.restartMinutes,
+      checks: DEFAULT_WEDGE_WATCHDOG_OPTIONS.checks,
+      loopBudget: DEFAULT_WEDGE_WATCHDOG_OPTIONS.loopBudget,
+      loopWindowMs: DEFAULT_WEDGE_WATCHDOG_OPTIONS.loopWindowMs,
+      startupGraceMs: DEFAULT_WEDGE_WATCHDOG_OPTIONS.startupGraceMs,
+      restartGraceMs: DEFAULT_WEDGE_WATCHDOG_OPTIONS.restartGraceMs,
+      getChild: () => childSupervisor,
+      isStopping: () => stopping,
+      onWarn: (fields) => {
+        console.error(`[autopilot] health_warn: ${JSON.stringify(fields)}`);
+      },
+    });
+    wedgeHealthTimer = setInterval(() => {
+      if (wedgeHealthInFlight || stopping) return;
+      wedgeHealthInFlight = true;
+      void queryWedgeSignals(engine, 'default', handlerNames)
+        .then((signals) => wedgeWatchdog?.evaluate(signals))
+        .catch((e) => {
+          console.error(
+            `[autopilot] wedge watchdog probe failed: ${e instanceof Error ? e.message : String(e)}`,
+          );
+        })
+        .finally(() => { wedgeHealthInFlight = false; });
+    }, DEFAULT_WEDGE_WATCHDOG_OPTIONS.healthIntervalMs);
+
     // Fire-and-forget; runs alongside the dispatch loop. shutdown() drives
     // the child-supervisor's isStopping accessor + drain.
     void childSupervisor.run();
@@ -462,6 +513,10 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
     if (stopping) return;
     stopping = true;
     console.log(`Autopilot stopping (${sig}).`);
+    if (wedgeHealthTimer) {
+      clearInterval(wedgeHealthTimer);
+      wedgeHealthTimer = null;
+    }
     if (childSupervisor) {
       childSupervisor.killChild('SIGTERM');
       await childSupervisor.awaitChildExit(35_000);

--- a/src/core/minions/supervisor.ts
+++ b/src/core/minions/supervisor.ts
@@ -46,6 +46,14 @@ import { dirname } from 'path';
 import type { BrainEngine } from '../engine.ts';
 import { tryAcquireDbLock, type DbLockHandle } from '../db-lock.ts';
 import { currentBrainId } from './worker-registry.ts';
+import {
+  DEFAULT_WEDGE_WATCHDOG_OPTIONS,
+  WorkerWedgeWatchdog,
+  deriveClaimableHandlerNames,
+  queryWedgeSignals,
+} from './wedge-watchdog.ts';
+
+export { queryWedgeSignals } from './wedge-watchdog.ts';
 
 export type SupervisorEvent =
   | 'started'
@@ -157,11 +165,11 @@ const DEFAULTS: Omit<SupervisorOpts, 'cliPath'> = {
   // caught faster by the worker's own DB probe (fix #2, ~3 min); this 15-min
   // watchdog is the cause-agnostic backstop for non-DB wedges (stuck handler,
   // deadlock) so it deliberately fires slower to avoid racing fix #2.
-  wedgeRestartMinutes: 15,
-  wedgeRestartChecks: 3,
-  wedgeRestartLoopBudget: 3,
-  wedgeRestartLoopWindowMs: 30 * 60_000,
-  startupGraceMs: 120_000, // overridden to 2× healthInterval in the constructor
+  wedgeRestartMinutes: DEFAULT_WEDGE_WATCHDOG_OPTIONS.restartMinutes,
+  wedgeRestartChecks: DEFAULT_WEDGE_WATCHDOG_OPTIONS.checks,
+  wedgeRestartLoopBudget: DEFAULT_WEDGE_WATCHDOG_OPTIONS.loopBudget,
+  wedgeRestartLoopWindowMs: DEFAULT_WEDGE_WATCHDOG_OPTIONS.loopWindowMs,
+  startupGraceMs: DEFAULT_WEDGE_WATCHDOG_OPTIONS.startupGraceMs,
 };
 
 /**
@@ -187,10 +195,6 @@ export function buildWorkerArgs(
   }
   return args;
 }
-
-/** Grace before SIGKILL when restarting a wedged child — reuses the 35s
- *  shutdown() drain window (issue #1801, D3). */
-const WEDGE_RESTART_GRACE_MS = 35_000;
 
 /**
  * issue #1994: resolve the hard permanent-give-up ceiling. Default
@@ -222,69 +226,6 @@ function isProcessAlive(pid: number): boolean {
   } catch {
     return false;
   }
-}
-
-/**
- * issue #1801 — queue + name-scoped wedge signals. Exported (with the SQL) so
- * the FILTER semantics are testable against a real engine (PGLite) without
- * spinning a supervisor process:
- *   - `activeHealthy` counts only LIVE-lock active rows, so an expired-lock
- *     active row (a worker that died mid-job) does NOT mask the wedge (Codex #6).
- *   - `waitingClaimable` counts waiting OR due-delayed (delay_until <= now) rows
- *     whose name the worker can claim — due-delayed because a dead pool means
- *     promoteDelayed never ran (Codex #5/#7).
- *   - `lastCompletedClaimable` is freshness of progress on claimable names only.
- */
-export interface WedgeSignals {
-  stalled: number;
-  activeHealthy: number;
-  waiting: number;
-  waitingClaimable: number;
-  lastCompleted: Date | null;
-  lastCompletedClaimable: Date | null;
-}
-
-export async function queryWedgeSignals(
-  engine: BrainEngine,
-  queue: string,
-  handlerNames: string[],
-): Promise<WedgeSignals> {
-  const rows = await engine.executeRaw<{
-    stalled: string;
-    active_healthy: string;
-    waiting: string;
-    waiting_claimable: string;
-    last_completed: string | null;
-    last_completed_claimable: string | null;
-  }>(
-    `SELECT
-       count(*) FILTER (WHERE status = 'active' AND lock_until < now())::text AS stalled,
-       count(*) FILTER (WHERE status = 'active' AND lock_until > now())::text AS active_healthy,
-       count(*) FILTER (WHERE status = 'waiting')::text AS waiting,
-       count(*) FILTER (WHERE (status = 'waiting'
-                          OR (status = 'delayed' AND delay_until <= now()))
-                         AND name = ANY($2::text[]))::text AS waiting_claimable,
-       max(updated_at) FILTER (WHERE status = 'completed')::text AS last_completed,
-       max(updated_at) FILTER (WHERE status = 'completed'
-                               AND name = ANY($2::text[]))::text AS last_completed_claimable
-     FROM minion_jobs
-     WHERE queue = $1`,
-    [queue, handlerNames],
-  );
-  const row = rows[0] ?? {
-    stalled: '0', active_healthy: '0', waiting: '0',
-    waiting_claimable: '0', last_completed: null, last_completed_claimable: null,
-  };
-  return {
-    stalled: parseInt(row.stalled ?? '0', 10),
-    activeHealthy: parseInt(row.active_healthy ?? '0', 10),
-    waiting: parseInt(row.waiting ?? '0', 10),
-    waitingClaimable: parseInt(row.waiting_claimable ?? '0', 10),
-    lastCompleted: row.last_completed ? new Date(row.last_completed) : null,
-    lastCompletedClaimable: row.last_completed_claimable
-      ? new Date(row.last_completed_claimable)
-      : null,
-  };
 }
 
 /** Exit codes for documented agent branching. */
@@ -383,23 +324,12 @@ export class MinionSupervisor {
   private dbLock: DbLockHandle | null = null;
   private lockRefreshTimer: ReturnType<typeof setInterval> | null = null;
   private lockRefreshFailures = 0;
-  // issue #1801 progress-watchdog state.
   /** Job names the spawned worker can actually claim. Derived once at start()
    *  from registerBuiltinHandlers so the wedge scopes to real claimable work
    *  (no false-positive on unhandled names). Empty = watchdog inert. */
   private handlerNames: string[] = [];
-  /** Consecutive health checks that saw the wedge condition. */
-  private consecutiveWedgedChecks = 0;
-  /** Timestamps of recent wedge restarts (loop-breaker window). */
-  private wedgeRestartTimestamps: number[] = [];
-  /** Whether the `wedge_restart_loop` give-up alert has already fired for the
-   *  current exhausted window — so it emits once, not every health tick. Re-arms
-   *  when a real restart fires again (window drained below budget). */
-  private wedgeLoopAlerted = false;
-  /** True while a restartCurrentChild() is in flight (suppresses re-escalation). */
-  private escalationInFlight = false;
-  /** Wall-clock of the most recent child spawn (startup-grace anchor). */
-  private childStartedAt: number | null = null;
+  /** Shared with autopilot so both managed-worker paths use one state machine. */
+  private readonly wedgeWatchdog: WorkerWedgeWatchdog;
 
   constructor(engine: BrainEngine, opts: Partial<SupervisorOpts> & { cliPath: string }) {
     this.engine = engine;
@@ -420,6 +350,19 @@ export class MinionSupervisor {
     if (opts.startupGraceMs === undefined) {
       this.opts.startupGraceMs = this.opts.healthInterval * 2;
     }
+
+    this.wedgeWatchdog = new WorkerWedgeWatchdog({
+      queue: this.opts.queue,
+      restartMinutes: this.opts.wedgeRestartMinutes,
+      checks: this.opts.wedgeRestartChecks,
+      loopBudget: this.opts.wedgeRestartLoopBudget,
+      loopWindowMs: this.opts.wedgeRestartLoopWindowMs,
+      startupGraceMs: this.opts.startupGraceMs,
+      restartGraceMs: DEFAULT_WEDGE_WATCHDOG_OPTIONS.restartGraceMs,
+      getChild: () => this.childSupervisor,
+      isStopping: () => this.stopping,
+      onWarn: (fields) => this.emit('health_warn', fields),
+    });
 
     // Detect tini for zombie reaping. Resolved once at construction so we
     // don't shell out on every respawn. Belt-and-suspenders with the
@@ -453,7 +396,9 @@ export class MinionSupervisor {
   /** @internal */
   _setWedgeStateForTests(s: { handlerNames?: string[]; childStartedAt?: number | null }): void {
     if (s.handlerNames !== undefined) this.handlerNames = s.handlerNames;
-    if (s.childStartedAt !== undefined) this.childStartedAt = s.childStartedAt;
+    if (s.childStartedAt !== undefined) {
+      this.wedgeWatchdog._setChildStartedAtForTests(s.childStartedAt);
+    }
   }
   /** @internal Run one health check (the timer body) synchronously. */
   async _healthCheckOnceForTests(): Promise<void> {
@@ -461,11 +406,11 @@ export class MinionSupervisor {
   }
   /** @internal */
   get _consecutiveWedgedChecksForTests(): number {
-    return this.consecutiveWedgedChecks;
+    return this.wedgeWatchdog._consecutiveWedgedChecksForTests;
   }
   /** @internal */
   get _wedgeRestartCountForTests(): number {
-    return this.wedgeRestartTimestamps.length;
+    return this.wedgeWatchdog._restartCountForTests;
   }
 
   /**
@@ -608,19 +553,7 @@ export class MinionSupervisor {
    */
   private async deriveHandlerNames(): Promise<void> {
     try {
-      const [{ MinionWorker }, { registerBuiltinHandlers }] = await Promise.all([
-        import('./worker.ts'),
-        import('../../commands/jobs.ts'),
-      ]);
-      const probe = new MinionWorker(this.engine, {
-        queue: this.opts.queue,
-        healthCheckInterval: 0,
-      });
-      // `shell` is always registered regardless of allowShellJobs (the env only
-      // gates execution), so registeredNames is a static set — `quiet` just
-      // suppresses the informational startup lines during derivation.
-      await registerBuiltinHandlers(probe, this.engine, { quiet: true });
-      this.handlerNames = [...probe.registeredNames];
+      this.handlerNames = await deriveClaimableHandlerNames(this.engine, this.opts.queue);
     } catch (e) {
       this.handlerNames = [];
       this.emit('health_warn', {
@@ -877,8 +810,7 @@ export class MinionSupervisor {
         // issue #1801: anchor the startup grace + reset the wedge counter so a
         // fresh child is judged on its own forward progress, not the prior
         // (possibly wedged) one's stale DB state.
-        this.childStartedAt = Date.now();
-        this.consecutiveWedgedChecks = 0;
+        this.wedgeWatchdog.noteWorkerSpawned();
         this.emit('worker_spawned', {
           pid: event.pid >= 0 ? event.pid : undefined,
           cli_path: this.opts.cliPath,
@@ -960,16 +892,11 @@ export class MinionSupervisor {
       this.consecutiveHealthFailures = 0;
 
       const stalledCount = sig.stalled;
-      const activeHealthyCount = sig.activeHealthy;
       const waitingCount = sig.waiting;
-      const waitingClaimableCount = sig.waitingClaimable;
 
       const now = Date.now();
       const minutesSinceCompletion = sig.lastCompleted
         ? Math.round((now - sig.lastCompleted.getTime()) / 60_000)
-        : null;
-      const minutesSinceClaimable = sig.lastCompletedClaimable
-        ? Math.round((now - sig.lastCompletedClaimable.getTime()) / 60_000)
         : null;
 
       // F2 (per-threshold warns) — each is a distinct health_warn with reason.
@@ -1002,42 +929,7 @@ export class MinionSupervisor {
         });
       }
 
-      // issue #1801 — progress watchdog. A child that is ALIVE but makes no
-      // forward progress on claimable work is invisible to liveness checks
-      // (the dead-pool zombie that caused the 15h halt). Restart it so the
-      // respawn rebuilds a fresh DB pool.
-      //
-      //   - active_healthy === 0 is the real guard: a worker mid-job holds a
-      //     live lock (active_healthy > 0) and resets the counter; an expired-
-      //     lock active row does NOT suppress (Codex #6).
-      //   - waiting_claimable > 0: there is work THIS worker could claim
-      //     (name-scoped; incl. due-delayed) (Codex #5/#7).
-      //   - claimable progress is stale (or never happened) past the window.
-      //   - startup grace: a freshly (re)spawned worker gets a fair claim
-      //     window before the wedge clock applies (Codex #9/#10).
-      const childAgeMs = this.childStartedAt !== null ? now - this.childStartedAt : 0;
-      const pastStartupGrace = childAgeMs > this.opts.startupGraceMs;
-      const claimableStale =
-        minutesSinceClaimable === null || minutesSinceClaimable > this.opts.wedgeRestartMinutes;
-      const wedged =
-        this.opts.wedgeRestartMinutes > 0 &&
-        waitingClaimableCount > 0 &&
-        activeHealthyCount === 0 &&
-        claimableStale &&
-        workerAlive &&
-        !inBackoff &&
-        !this.stopping &&
-        !this.escalationInFlight &&
-        pastStartupGrace;
-
-      if (wedged) {
-        this.consecutiveWedgedChecks++;
-        if (this.consecutiveWedgedChecks >= this.opts.wedgeRestartChecks) {
-          await this.escalateWedgedWorker(waitingClaimableCount, minutesSinceClaimable);
-        }
-      } else {
-        this.consecutiveWedgedChecks = 0;
-      }
+      await this.wedgeWatchdog.evaluate(sig);
     } catch (e) {
       this.consecutiveHealthFailures++;
       const errMsg = e instanceof Error ? e.message : String(e);
@@ -1080,68 +972,4 @@ export class MinionSupervisor {
     }
   }
 
-  /**
-   * issue #1801: forcibly restart an alive-but-wedged child. Bounded by a
-   * sliding-window loop budget — a dead-pool wedge resolves in exactly one
-   * restart (fresh process ⇒ fresh pool), so repeated restarts inside the
-   * window mean restart isn't the fix (e.g. a deterministically-failing
-   * handler); switch to alert-only via `wedge_restart_loop` instead of
-   * thrashing. The kill mechanics live in ChildWorkerSupervisor.restartCurrentChild
-   * (owns child identity + the intentional-restart crash accounting).
-   *
-   * Awaited inside healthCheck()'s try, so `healthInFlight` keeps the next
-   * health tick from overlapping the ~grace-bounded restart, and
-   * `escalationInFlight` keeps the wedge predicate from re-firing.
-   */
-  private async escalateWedgedWorker(
-    waitingClaimable: number,
-    minutesSinceCompletion: number | null,
-  ): Promise<void> {
-    const cs = this.childSupervisor;
-    if (!cs) return;
-
-    const now = Date.now();
-    this.wedgeRestartTimestamps = this.wedgeRestartTimestamps.filter(
-      (t) => t > now - this.opts.wedgeRestartLoopWindowMs,
-    );
-    // `>=` so the budget is a real ceiling (the Nth restart is the last allowed,
-    // not the N+1th) — issue #1801 Codex #13.
-    if (this.wedgeRestartTimestamps.length >= this.opts.wedgeRestartLoopBudget) {
-      // Give up restarting (restart isn't fixing it). Alert ONCE on entry to
-      // the exhausted state — without this flag the wedge predicate re-fires
-      // every health tick for the whole window and floods the audit log with
-      // identical `wedge_restart_loop` warns. Reset the counter so the predicate
-      // doesn't busy-spin; the flag re-arms below once a real restart fires
-      // again (window drained below budget).
-      if (!this.wedgeLoopAlerted) {
-        this.wedgeLoopAlerted = true;
-        this.emit('health_warn', {
-          reason: 'wedge_restart_loop',
-          count: this.wedgeRestartTimestamps.length,
-          window_ms: this.opts.wedgeRestartLoopWindowMs,
-          waiting_claimable: waitingClaimable,
-          queue: this.opts.queue,
-        });
-      }
-      this.consecutiveWedgedChecks = 0;
-      return;
-    }
-
-    this.wedgeLoopAlerted = false; // re-arm: window has room, we're restarting
-    this.wedgeRestartTimestamps.push(now);
-    this.consecutiveWedgedChecks = 0;
-    this.escalationInFlight = true;
-    this.emit('health_warn', {
-      reason: 'restarting_wedged_worker',
-      waiting_claimable: waitingClaimable,
-      minutes_since_completion: minutesSinceCompletion,
-      consecutive_wedged_checks: this.opts.wedgeRestartChecks,
-      queue: this.opts.queue,
-    });
-    try {
-      await cs.restartCurrentChild(WEDGE_RESTART_GRACE_MS);
-    } finally {
-      this.escalationInFlight = false;
-    }
-  }
 }

--- a/src/core/minions/wedge-watchdog.ts
+++ b/src/core/minions/wedge-watchdog.ts
@@ -1,0 +1,216 @@
+/**
+ * Shared alive-but-wedged worker watchdog.
+ *
+ * Both the standalone MinionSupervisor and autopilot supervise a
+ * ChildWorkerSupervisor. This module owns the queue-progress decision and
+ * bounded restart state so the two production paths cannot drift.
+ */
+
+import type { BrainEngine } from '../engine.ts';
+import type { ChildWorkerSupervisor } from './child-worker-supervisor.ts';
+
+export const DEFAULT_WEDGE_WATCHDOG_OPTIONS = {
+  restartMinutes: 15,
+  checks: 3,
+  loopBudget: 3,
+  loopWindowMs: 30 * 60_000,
+  startupGraceMs: 120_000,
+  healthIntervalMs: 60_000,
+  restartGraceMs: 35_000,
+} as const;
+
+export interface WedgeSignals {
+  stalled: number;
+  activeHealthy: number;
+  waiting: number;
+  waitingClaimable: number;
+  lastCompleted: Date | null;
+  lastCompletedClaimable: Date | null;
+}
+
+export async function queryWedgeSignals(
+  engine: BrainEngine,
+  queue: string,
+  handlerNames: string[],
+): Promise<WedgeSignals> {
+  const rows = await engine.executeRaw<{
+    stalled: string;
+    active_healthy: string;
+    waiting: string;
+    waiting_claimable: string;
+    last_completed: string | null;
+    last_completed_claimable: string | null;
+  }>(
+    `SELECT
+       count(*) FILTER (WHERE status = 'active' AND lock_until < now())::text AS stalled,
+       count(*) FILTER (WHERE status = 'active' AND lock_until > now())::text AS active_healthy,
+       count(*) FILTER (WHERE status = 'waiting')::text AS waiting,
+       count(*) FILTER (WHERE (status = 'waiting'
+                          OR (status = 'delayed' AND delay_until <= now()))
+                         AND name = ANY($2::text[]))::text AS waiting_claimable,
+       max(updated_at) FILTER (WHERE status = 'completed')::text AS last_completed,
+       max(updated_at) FILTER (WHERE status = 'completed'
+                               AND name = ANY($2::text[]))::text AS last_completed_claimable
+     FROM minion_jobs
+     WHERE queue = $1`,
+    [queue, handlerNames],
+  );
+  const row = rows[0] ?? {
+    stalled: '0', active_healthy: '0', waiting: '0',
+    waiting_claimable: '0', last_completed: null, last_completed_claimable: null,
+  };
+  return {
+    stalled: parseInt(row.stalled ?? '0', 10),
+    activeHealthy: parseInt(row.active_healthy ?? '0', 10),
+    waiting: parseInt(row.waiting ?? '0', 10),
+    waitingClaimable: parseInt(row.waiting_claimable ?? '0', 10),
+    lastCompleted: row.last_completed ? new Date(row.last_completed) : null,
+    lastCompletedClaimable: row.last_completed_claimable
+      ? new Date(row.last_completed_claimable)
+      : null,
+  };
+}
+
+/** Derive the exact names a normal built-in worker can claim. */
+export async function deriveClaimableHandlerNames(
+  engine: BrainEngine,
+  queue: string,
+): Promise<string[]> {
+  const [{ MinionWorker }, { registerBuiltinHandlers }] = await Promise.all([
+    import('./worker.ts'),
+    import('../../commands/jobs.ts'),
+  ]);
+  const probe = new MinionWorker(engine, { queue, healthCheckInterval: 0 });
+  await registerBuiltinHandlers(probe, engine, { quiet: true });
+  return [...probe.registeredNames];
+}
+
+type RestartableChild = Pick<
+  ChildWorkerSupervisor,
+  'childAlive' | 'inBackoff' | 'restartCurrentChild'
+>;
+
+export interface WorkerWedgeWatchdogOpts {
+  queue: string;
+  restartMinutes: number;
+  checks: number;
+  loopBudget: number;
+  loopWindowMs: number;
+  startupGraceMs: number;
+  restartGraceMs: number;
+  getChild: () => RestartableChild | null;
+  isStopping: () => boolean;
+  onWarn: (fields: Record<string, unknown>) => void;
+  now?: () => number;
+}
+
+export class WorkerWedgeWatchdog {
+  private readonly opts: WorkerWedgeWatchdogOpts;
+  private childStartedAt: number | null = null;
+  private consecutiveWedgedChecks = 0;
+  private restartTimestamps: number[] = [];
+  private loopAlerted = false;
+  private escalationInFlight = false;
+
+  constructor(opts: WorkerWedgeWatchdogOpts) {
+    this.opts = opts;
+  }
+
+  noteWorkerSpawned(at = this.now()): void {
+    this.childStartedAt = at;
+    this.consecutiveWedgedChecks = 0;
+  }
+
+  /** @internal Test seam retained for MinionSupervisor's existing tests. */
+  _setChildStartedAtForTests(at: number | null): void {
+    this.childStartedAt = at;
+  }
+
+  /** @internal */
+  get _consecutiveWedgedChecksForTests(): number {
+    return this.consecutiveWedgedChecks;
+  }
+
+  /** @internal */
+  get _restartCountForTests(): number {
+    return this.restartTimestamps.length;
+  }
+
+  async evaluate(signals: WedgeSignals): Promise<void> {
+    const child = this.opts.getChild();
+    const workerAlive = child !== null && child.childAlive;
+    const inBackoff = child !== null && child.inBackoff;
+    const now = this.now();
+    const minutesSinceClaimable = signals.lastCompletedClaimable
+      ? Math.round((now - signals.lastCompletedClaimable.getTime()) / 60_000)
+      : null;
+    const childAgeMs = this.childStartedAt !== null ? now - this.childStartedAt : 0;
+    const claimableStale =
+      minutesSinceClaimable === null || minutesSinceClaimable > this.opts.restartMinutes;
+    const wedged =
+      this.opts.restartMinutes > 0 &&
+      signals.waitingClaimable > 0 &&
+      signals.activeHealthy === 0 &&
+      claimableStale &&
+      workerAlive &&
+      !inBackoff &&
+      !this.opts.isStopping() &&
+      !this.escalationInFlight &&
+      childAgeMs > this.opts.startupGraceMs;
+
+    if (!wedged) {
+      this.consecutiveWedgedChecks = 0;
+      return;
+    }
+
+    this.consecutiveWedgedChecks++;
+    if (this.consecutiveWedgedChecks < this.opts.checks) return;
+    await this.restart(child!, signals.waitingClaimable, minutesSinceClaimable);
+  }
+
+  private async restart(
+    child: RestartableChild,
+    waitingClaimable: number,
+    minutesSinceCompletion: number | null,
+  ): Promise<void> {
+    const now = this.now();
+    this.restartTimestamps = this.restartTimestamps.filter(
+      (t) => t > now - this.opts.loopWindowMs,
+    );
+    if (this.restartTimestamps.length >= this.opts.loopBudget) {
+      if (!this.loopAlerted) {
+        this.loopAlerted = true;
+        this.opts.onWarn({
+          reason: 'wedge_restart_loop',
+          count: this.restartTimestamps.length,
+          window_ms: this.opts.loopWindowMs,
+          waiting_claimable: waitingClaimable,
+          queue: this.opts.queue,
+        });
+      }
+      this.consecutiveWedgedChecks = 0;
+      return;
+    }
+
+    this.loopAlerted = false;
+    this.restartTimestamps.push(now);
+    this.consecutiveWedgedChecks = 0;
+    this.escalationInFlight = true;
+    this.opts.onWarn({
+      reason: 'restarting_wedged_worker',
+      waiting_claimable: waitingClaimable,
+      minutes_since_completion: minutesSinceCompletion,
+      consecutive_wedged_checks: this.opts.checks,
+      queue: this.opts.queue,
+    });
+    try {
+      await child.restartCurrentChild(this.opts.restartGraceMs);
+    } finally {
+      this.escalationInFlight = false;
+    }
+  }
+
+  private now(): number {
+    return this.opts.now?.() ?? Date.now();
+  }
+}

--- a/test/autopilot-supervisor-wiring.test.ts
+++ b/test/autopilot-supervisor-wiring.test.ts
@@ -68,6 +68,16 @@ describe('autopilot.ts ↔ ChildWorkerSupervisor wiring', () => {
     expect(AUTOPILOT_SRC).toMatch(/maxCrashes:\s*5\b/);
   });
 
+  it('runs the shared progress watchdog around the managed worker', () => {
+    expect(AUTOPILOT_SRC).toContain('WorkerWedgeWatchdog');
+    expect(AUTOPILOT_SRC).toContain('deriveClaimableHandlerNames');
+    expect(AUTOPILOT_SRC).toContain('queryWedgeSignals');
+    expect(AUTOPILOT_SRC).toContain('wedgeWatchdog?.noteWorkerSpawned()');
+    expect(AUTOPILOT_SRC).toContain('wedgeWatchdog?.evaluate(signals)');
+    expect(AUTOPILOT_SRC).toContain("GBRAIN_SUPERVISED: '1'");
+    expect(AUTOPILOT_SRC).toContain('clearInterval(wedgeHealthTimer)');
+  });
+
   it('routes onMaxCrashesExceeded to autopilot.shutdown (not process.exit directly)', () => {
     // Pre-refactor: autopilot.ts called process.exit(1) directly when the
     // crash counter tripped, bypassing its own dispatch-loop cleanup and


### PR DESCRIPTION
## Summary

- share one `WorkerWedgeWatchdog` implementation between the standalone minion supervisor and `gbrain autopilot`
- teach autopilot to restart an alive-but-wedged child after sustained queue/claim stagnation
- keep restart attempts bounded and clear watchdog state during shutdown
- document the watchdog behavior in setup and queue-operations guidance

## Why

`gbrain autopilot` could keep its child process alive while claimable jobs stopped making progress. Because the process itself had not exited, the existing crash-restart loop did not intervene. This left dead or waiting work accumulating until an operator restarted the service.

The standalone supervisor already had the right queue-level signals. This change extracts that logic into a shared component and wires the same protection into the production autopilot path.

## Behavior

- checks queue progress every 60 seconds
- treats a child as wedged only after 15 minutes / 3 consecutive qualifying checks
- derives claimable handlers from the active worker configuration
- allows at most 3 watchdog restarts per 30-minute window
- sets `GBRAIN_SUPERVISED=1` for the child and cancels the timer on shutdown

## Validation

- `bun run typecheck`
- `bun test test/supervisor-wedge.test.ts test/autopilot-supervisor-wiring.test.ts test/child-worker-supervisor.test.ts` (33 tests)
- `bun run check:doc-history`
- `bun run check:admin-build`
- `GBRAIN_HOME=/tmp/gbrain-check-home scripts/check-skill-brain-first.sh`
- static guards: operations filter, gateway routing, worker-pool atomicity, key files, no-double-retry, and batch audit

The Docker/Postgres lane in `ci:local:diff` was not run locally because Docker is not installed on this machine; the hosted CI run is expected to cover it.
