### PR TITLE
fix(#1745): atomic module-singleton rebuild — no null window on reconnect; loud cycle stamp

### DIFF
--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -2127,9 +2127,16 @@ export async function runCycle(
   // the cost of missing a successful write (next cycle will redo work).
   if (opts.sourceId && engine && !dryRun && (status === 'ok' || status === 'clean' || status === 'partial')) {
     try {
-      await engine.updateSourceConfig(opts.sourceId, {
+      const stamped = await engine.updateSourceConfig(opts.sourceId, {
         last_full_cycle_at: new Date().toISOString(),
       });
+      // v0.42.2 (#1745 follow-on): updateSourceConfig returns false when the
+      // UPDATE matched zero rows (missing/renamed source, RLS-filtered row).
+      // Ignoring it produced a SILENTLY unstamped cycle: exit 0, freshness
+      // stale, no trace.  Loud or it did not happen.
+      if (!stamped) {
+        console.warn(`[cycle] last_full_cycle_at NOT stamped for source ${opts.sourceId}: UPDATE matched zero rows (source missing or not visible to this role). cycle_freshness will read stale despite this run.`);
+      }
     } catch (e) {
       // Best-effort; cycle already succeeded by the time we get here.
       console.warn(`[cycle] failed to write last_full_cycle_at for source ${opts.sourceId}: ${e instanceof Error ? e.message : String(e)}`);

--- a/src/core/db.ts
+++ b/src/core/db.ts
@@ -159,6 +159,47 @@ export function getConnection(): ReturnType<typeof postgres> {
   return sql;
 }
 
+/**
+ * v0.42.2 (#1745): build + verify a configured postgres.js client for the
+ * module singleton. Shared by connect() (cold start) and
+ * rebuildConnection() (atomic swap) so both paths carry identical
+ * pooler-detection, timeout, and NOTICE-silencing semantics.
+ */
+async function createModuleClient(url: string): Promise<ReturnType<typeof postgres>> {
+  const prepare = resolvePrepare(url);
+  const timeouts = resolveSessionTimeouts();
+  const opts: Record<string, unknown> = {
+    max: resolvePoolSize(),
+    idle_timeout: 20,
+    connect_timeout: 10,
+    types: {
+      // Register pgvector type
+      bigint: postgres.BigInt,
+    },
+    // Silence postgres NOTICE-level messages by default ("relation already
+    // exists, skipping" floods stdout under idempotent CREATE statements
+    // during migrations + initSchema, and breaks stdout-parsing callers like
+    // `gbrain jobs submit --json | ...`). Opt back in with GBRAIN_PG_NOTICES=1.
+    onnotice: process.env.GBRAIN_PG_NOTICES === '1' ? undefined : () => {},
+  };
+  if (Object.keys(timeouts).length > 0) {
+    opts.connection = timeouts;
+  }
+  if (typeof prepare === 'boolean') {
+    opts.prepare = prepare;
+    if (!prepare) {
+      console.warn(
+        '[gbrain] Prepared statements disabled (PgBouncer transaction-mode convention on port 6543). Override with GBRAIN_PREPARE=true if your pooler runs in session mode.',
+      );
+    }
+  }
+  const client = postgres(url, opts);
+  // Test connection
+  await client`SELECT 1`;
+  await setSessionDefaults(client);
+  return client;
+}
+
 export async function connect(config: EngineConfig): Promise<void> {
   if (sql) {
     // Warn if a different URL is passed — the old connection is still in use
@@ -178,40 +219,8 @@ export async function connect(config: EngineConfig): Promise<void> {
   }
 
   try {
-    const prepare = resolvePrepare(url);
-    const timeouts = resolveSessionTimeouts();
-    const opts: Record<string, unknown> = {
-      max: resolvePoolSize(),
-      idle_timeout: 20,
-      connect_timeout: 10,
-      types: {
-        // Register pgvector type
-        bigint: postgres.BigInt,
-      },
-      // Silence postgres NOTICE-level messages by default ("relation already
-      // exists, skipping" floods stdout under idempotent CREATE statements
-      // during migrations + initSchema, and breaks stdout-parsing callers like
-      // `gbrain jobs submit --json | ...`). Opt back in with GBRAIN_PG_NOTICES=1.
-      onnotice: process.env.GBRAIN_PG_NOTICES === '1' ? undefined : () => {},
-    };
-    if (Object.keys(timeouts).length > 0) {
-      opts.connection = timeouts;
-    }
-    if (typeof prepare === 'boolean') {
-      opts.prepare = prepare;
-      if (!prepare) {
-        console.warn(
-          '[gbrain] Prepared statements disabled (PgBouncer transaction-mode convention on port 6543). Override with GBRAIN_PREPARE=true if your pooler runs in session mode.',
-        );
-      }
-    }
-    sql = postgres(url, opts);
-
-    // Test connection
-    await sql`SELECT 1`;
+    sql = await createModuleClient(url);
     connectedUrl = url;
-
-    await setSessionDefaults(sql);
   } catch (e: unknown) {
     sql = null;
     connectedUrl = null;
@@ -222,6 +231,31 @@ export async function connect(config: EngineConfig): Promise<void> {
       'Check your connection URL in ~/.gbrain/config.json',
     );
   }
+}
+
+/**
+ * v0.42.2 (#1745): atomically rebuild the module singleton. Unlike
+ * disconnect()+connect(), there is NO window where `sql` is null, so
+ * concurrent getConnection() callers never see "connect() has not been
+ * called". Sequence: build + verify a NEW client first, swap the singleton
+ * reference, then drain the old pool in the background (postgres.js end()
+ * lets in-flight queries finish inside the drain timeout instead of dying
+ * against a torn-down reference).
+ *
+ * Fail-loud: if the fresh client cannot be built (auth failure, network
+ * partition), the error propagates AND the old pool is left untouched —
+ * strictly no worse than before the call. No-op when never connected
+ * (cold connect() owns that path).
+ */
+export async function rebuildConnection(): Promise<void> {
+  if (!sql || !connectedUrl) return; // never connected — nothing to swap
+  const fresh = await createModuleClient(connectedUrl);
+  const old = sql;
+  sql = fresh;
+  // Drain the old pool without blocking the caller's retry loop. 5s cap:
+  // anything still running after that was already doomed by whatever broke
+  // the pool in the first place.
+  void old.end({ timeout: 5 }).catch(() => { /* best-effort drain */ });
 }
 
 export async function disconnect(): Promise<void> {

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -4647,16 +4647,34 @@ export class PostgresEngine implements BrainEngine {
   }
 
   /**
-   * Reconnect the engine by tearing down the current pool and creating a fresh one.
-   * No-ops if no saved config (module-singleton mode) or if already reconnecting.
+   * Reconnect the engine.  No-ops if never connected or already reconnecting.
+   *
+   * v0.42.2 (#1745): the two connection styles need OPPOSITE strategies.
+   * - 'instance' pools are engine-private: teardown + rebuild is safe.
+   * - 'module' style shares the db.ts singleton with EVERY other
+   *   module-style consumer in this process (cycle phases, sibling engines,
+   *   the minion supervisor's health loop).  The old disconnect()+connect()
+   *   path nulled that shared singleton mid-flight, opening a window where
+   *   concurrent getConnection() callers threw "connect() has not been
+   *   called" and in-flight sibling queries died with the pool — the #1745
+   *   cascade that killed the dream cycle's sync/synthesize phases.  The
+   *   fix is db.rebuildConnection(): build + verify the fresh client FIRST,
+   *   swap the reference, then drain the old pool.  No null window, ever.
+   *   (Note: the previous docstring claimed module mode no-ops here; it
+   *   never did — connect() saves config unconditionally, so the
+   *   destructive path was live.)
    */
   async reconnect(): Promise<void> {
     if (!this._savedConfig || this._reconnecting) return;
     this._reconnecting = true;
     try {
-      // Tear down old pool (best-effort — it may already be dead)
+      if (this._connectionStyle === 'module') {
+        await db.rebuildConnection();
+        return;
+      }
+      // Instance pool (engine-private): tear down old pool (best-effort —
+      // it may already be dead), then create a fresh one.
       try { await this.disconnect(); } catch { /* swallow */ }
-      // Create fresh pool
       await this.connect(this._savedConfig);
     } finally {
       this._reconnecting = false;


### PR DESCRIPTION
Fixes #1745 ("connect() has not been called" — concurrent minion-worker path not covered by the #1570 fix).

## Root cause
Two callers invoke `PostgresEngine.reconnect()` while a dream cycle is in flight: the minion supervisor's 3-strikes health loop and `batchRetry`'s reconnect hook.  For **module-style** engines (`poolSize` unset), `reconnect()` ran `disconnect()` + `connect()` on the **process-shared db.ts singleton**.  That opens a null window (every concurrent `getConnection()` throws the #1745 error) and `sql.end()` kills in-flight sibling queries.  The #1570 fix protected the three batch primitives after the fact, but plain phase queries (sync, synthesize bookkeeping) have no retry coverage, so the cycle's phases die.

A second defect then hides the damage: the `last_full_cycle_at` stamp ignores `updateSourceConfig`'s boolean return, so a zero-row UPDATE skips the stamp silently and the run exits 0 — `cycle_freshness` reads stale for weeks with no visible failure.  (Note: `reconnect()`'s old docstring claimed module mode no-ops; it never did — `connect()` saves config unconditionally, so the destructive path was live.)

## Fix
- **`db.rebuildConnection()`** (new): build + verify the NEW client first, swap the singleton reference, then drain the old pool in the background (`end({timeout: 5})`).  No null window, ever; in-flight queries get a graceful drain.  Fail-loud: if the fresh client cannot be built, the error propagates and the old pool is left untouched.
- **`PostgresEngine.reconnect()`**: module-style engines route through `rebuildConnection()`; instance pools keep the existing teardown+rebuild (engine-private, safe).
- **`cycle.ts` stamp**: checks the return value and warns loudly on a zero-row UPDATE instead of silently skipping.

## Proof
- `tsc --noEmit` clean; 45/45 nearest unit tests pass (cycle-last-full-cycle-at, autopilot-reconnect-classifier, retry-matcher, doctor-batch-retry).
- Live concurrency test against a real Supabase Postgres: 6 concurrent workers through 8 singleton rebuilds → **444 queries, 0 connect-class errors, 0 other errors** on the fixed path.  Negative control (old disconnect+connect sequence, same load) → **547 "connect() has not been called" errors + 83 in-flight query kills**, reproducing #1745 on demand.

## Repro pedigree
Independently reproduced on three seats (three machines, one shared brain) on 0.41.28 and 0.42.1.0; diagnostics in the #1745 thread.  Real-world impact on our fleet: a source's dream cycle silently dead for ~30 days while recall stayed healthy — the silent-stamp defect made it invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
