### PR TITLE
Clear stale sync HEAD sentinels after verified recovery

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -2677,6 +2677,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   //     pin..HEAD diff. Advance to pin.
   //   - pin NOT an ancestor of HEAD (history REWRITE / reset / force-push) →
   //     the tree we imported against is gone. Block; do not advance.
+  let headVerificationSucceeded = false;
   try {
     const currentHead = git(repoPath, ['rev-parse', 'HEAD']);
     if (currentHead !== pin) {
@@ -2692,8 +2693,12 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
           path: '<head>',
           error: `git history rewritten during sync: pinned target ${pin.slice(0, 8)} is no longer an ancestor of HEAD ${currentHead.slice(0, 8)}`,
         });
+      } else {
+        headVerificationSucceeded = true;
       }
       // else: forward progress (enrich committed on top) — safe, advance to pin.
+    } else {
+      headVerificationSucceeded = true;
     }
   } catch (e) {
     // rev-parse failure is itself a drift signal (worktree disappeared).
@@ -2739,6 +2744,10 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
     ...succeededPaths,
     ...filtered.deleted,
     ...filtered.renamed.map(r => r.from),
+    // A prior transient rev-parse timeout records a hard-blocking sentinel that
+    // operators cannot acknowledge manually. Once pin ancestry is verified on
+    // a later run, clear that stale sentinel through the ordinary success path.
+    ...(headVerificationSucceeded ? ['<head>'] : []),
   ];
 
   const gate = await applySyncFailureGate({

--- a/test/sync-failure-ledger.serial.test.ts
+++ b/test/sync-failure-ledger.serial.test.ts
@@ -90,6 +90,17 @@ describe('#4 success clears → consecutive attempts', () => {
     expect(rows.length).toBe(1);
     expect(rows[0].source_id).toBe('s2');
   });
+
+  test('caller-verified HEAD success can clear a prior sentinel', async () => {
+    const { recordFailures, clearFailures, loadSyncFailures } = await L();
+    recordFailures('s', [{ path: '<head>', error: 'git HEAD verification timed out' }], 'c1');
+    expect(loadSyncFailures()[0].state).toBe('open');
+
+    // Sentinels cannot be acknowledged or auto-skipped; the sync caller may
+    // remove one only after it has successfully re-verified pin ancestry.
+    clearFailures('s', ['<head>']);
+    expect(loadSyncFailures()).toEqual([]);
+  });
 });
 
 describe('#3 sentinel never auto-skips', () => {


### PR DESCRIPTION
## Problem
A transient git HEAD verification failure records a hard-blocking `<head>` sentinel. Manual acknowledgement correctly refuses to clear sentinels, but a later successful sync also fails to clear the stale record, leaving doctor warnings indefinitely.

## Fix
Track successful pin/HEAD verification and include `<head>` in the ordinary resolved-path set only after the relationship has been verified. History rewrites still hard-block and remain unacknowledgeable.

## Verification
- `test/sync-failure-ledger.serial.test.ts`: 23 passed
- `bunx tsc --noEmit`: passed
- live four-source sync verified the recorded commit remained an ancestor, then the stale sentinel cleared