### PR TITLE
fix(lint): only remove paired whole-document Markdown fences

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -291,9 +291,10 @@ export function fixContent(content: string): string {
     fixed = fixed.replace(pattern, '');
   }
 
-  // Fix wrapping code fences
-  fixed = fixed.replace(/^```(?:markdown|md)\s*\n/, '');
-  fixed = fixed.replace(/\n```\s*$/, '');
+  // Fix a whole-document markdown wrapper only when both fences are present.
+  // A closing fence at EOF may belong to a legitimate final code example.
+  const wrapper = fixed.match(/^```(?:markdown|md)[^\S\r\n]*\r?\n([\s\S]*?)\r?\n```[^\S\r\n]*$/);
+  if (wrapper) fixed = wrapper[1];
 
   // Clean up excessive blank lines left by fixes
   fixed = fixed.replace(/\n{3,}/g, '\n\n');

--- a/test/lint.test.ts
+++ b/test/lint.test.ts
@@ -97,6 +97,16 @@ describe('fixContent', () => {
     expect(fixed).toContain('# Title');
   });
 
+  test('preserves a normal document ending in a fenced example', () => {
+    const input = '# Format Guide\n\n## Example\n\n```yaml\nkind: Example\n```\n';
+    expect(fixContent(input)).toBe(input);
+  });
+
+  test('preserves multiple fenced examples', () => {
+    const input = '# Examples\n\n```json\n{"ok":true}\n```\n\n```yaml\nok: true\n```\n';
+    expect(fixContent(input)).toBe(input);
+  });
+
   test('cleans up excessive blank lines after fix', () => {
     const input = 'Of course. Here is the brain page.\n\n\n\n# Title\n\nContent.';
     const fixed = fixContent(input);


### PR DESCRIPTION
### Summary

Updates `fixContent()` so it removes a Markdown wrapper only when matching opening and closing fences wrap the entire document.

Previously, the closing fence at EOF was removed independently. This could corrupt otherwise valid Markdown when its final section was a legitimate fenced code example.

### Root cause

The fixer previously applied two independent replacements:

````ts
fixed = fixed.replace(/^```(?:markdown|md)\s*\n/, '');
fixed = fixed.replace(/\n```\s*$/, '');
````

The second replacement did not verify that the document began with a matching whole-document Markdown wrapper.

### Implementation

The independent replacements are replaced with one paired whole-document match:

````ts
const wrapper = fixed.match(
  /^```(?:markdown|md)[^\S\r\n]*\r?\n([\s\S]*?)\r?\n```[^\S\r\n]*$/,
);
if (wrapper) fixed = wrapper[1];
````

This continues to support `markdown` and `md` wrappers and accepts LF or CRLF wrapper boundaries.

### Tests

Added regression coverage confirming that:

* A paired whole-document Markdown wrapper is removed.
* A normal document ending in a fenced YAML example remains unchanged.
* A document containing multiple legitimate fenced examples remains unchanged.
* Existing preamble removal and blank-line normalization continue passing.

### Scope

This change is limited to the lint auto-fixer. It does not change lint detection, parsing, ingestion, or storage behavior.

### Validation

The focused upstream lint suite was run during a clean Docker image build against upstream commit `a25209bbb2bacf1b88e06fd5282b27f1bf4a3e7a`:

```text
bun test test/lint.test.ts

20 pass
0 fail
```
