### PR TITLE
feat(extract): per-source outcomes on extract receipts

### DIFF
--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -49,7 +49,7 @@ import type { PhaseResult } from '../cycle.ts';
 import type { GBrainConfig } from '../config.ts';
 import type { ProgressReporter } from '../progress.ts';
 import { chat as gatewayChat } from '../ai/gateway.ts';
-import { writeReceipt } from '../extract/receipt-writer.ts';
+import { writeReceipt, type ExtractReceiptSourceOutcome } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
 
 const DEFAULT_BUDGET_USD = 0.3;
@@ -453,6 +453,11 @@ export async function runPhaseExtractAtoms(
   let transcriptsSkipped = 0;
   let pagesSkipped = 0;
   const failures: Array<{ source: string; error: string }> = [];
+  // Per-source audit trail for the receipt. rows:0 entries are the point:
+  // they prove a source was attempted and yielded nothing, so a keeper
+  // agent auditing ingest coverage never has to guess "processed vs never
+  // reached" from atom-frontmatter joins.
+  const sourceOutcomes: ExtractReceiptSourceOutcome[] = [];
   let estimatedSpendUsd = 0;
   const budgetCap = DEFAULT_BUDGET_USD;
 
@@ -512,6 +517,7 @@ export async function runPhaseExtractAtoms(
       if (atoms.length === 0) {
         if (item.kind === 'transcript') transcriptsProcessed++;
         else pagesProcessed++;
+        sourceOutcomes.push({ ref: originLabel, hash: item.contentHash.slice(0, 16), rows: 0 });
         continue;
       }
 
@@ -554,22 +560,36 @@ export async function runPhaseExtractAtoms(
       }
       if (item.kind === 'transcript') transcriptsProcessed++;
       else pagesProcessed++;
+      sourceOutcomes.push({ ref: originLabel, hash: item.contentHash.slice(0, 16), rows: atoms.length });
       // v0.41.19.0 (T4): one tick per processed item, with a count note.
       // Reporter rate-limits to ~1 line/sec; safe to tick every iter.
       opts.progress?.tick(1, `${totalAtomsExtracted} atoms / ${duplicatesSkipped} skipped`);
     } catch (err) {
-      failures.push({
-        source: originLabel,
-        error: err instanceof Error ? err.message : String(err),
+      const message = err instanceof Error ? err.message : String(err);
+      failures.push({ source: originLabel, error: message });
+      sourceOutcomes.push({
+        ref: originLabel,
+        hash: item.contentHash.slice(0, 16),
+        rows: 0,
+        error: message,
       });
     }
   }
 
-  // v0.42 Wave B2: write extract receipt + rollup row when the phase
-  // actually extracted atoms. Both are best-effort per F-OUT-19 —
-  // audit-trail / search-visibility surfaces don't block the phase result.
-  if (!opts.dryRun && totalAtomsExtracted > 0) {
+  // v0.42 Wave B2: write extract receipt + rollup row. Best-effort per
+  // F-OUT-19 — audit-trail / search-visibility surfaces don't block the
+  // phase result.
+  //
+  // The receipt now writes whenever the round PROCESSED anything (or
+  // failed on something), not only when atoms landed. Pre-fix, a round
+  // that attempted N sources and got 0 atoms from all of them left no
+  // audit trail at all — indistinguishable from "never ran", which is
+  // exactly the case an ingest-coverage audit needs receipts for.
+  const anyWorkTouched =
+    transcriptsProcessed + pagesProcessed + failures.length > 0;
+  if (!opts.dryRun && anyWorkTouched) {
     const runId = `atoms-${Date.now().toString(36)}-${sourceId.slice(0, 4)}`;
+    const zeroYield = sourceOutcomes.filter((s) => s.rows === 0 && !s.error).length;
     try {
       await writeReceipt(engine, {
         kind: 'atoms',
@@ -581,7 +601,10 @@ export async function runPhaseExtractAtoms(
         cost_usd: estimatedSpendUsd,
         summary:
           `Extracted ${totalAtomsExtracted} atoms from ` +
-          `${transcriptsProcessed} transcripts + ${pagesProcessed} pages.`,
+          `${transcriptsProcessed} transcripts + ${pagesProcessed} pages.` +
+          (zeroYield > 0 ? ` ${zeroYield} source(s) yielded 0 atoms.` : '') +
+          (failures.length > 0 ? ` ${failures.length} failed.` : ''),
+        sources: sourceOutcomes,
       });
     } catch (err) {
       console.error(`[extract_atoms] receipt write failed: ${(err as Error).message}`);

--- a/src/core/extract/receipt-writer.ts
+++ b/src/core/extract/receipt-writer.ts
@@ -51,6 +51,57 @@ export type ExtractReceiptRound =
   | 'single';
 
 /**
+ * Per-source outcome row for a receipt. Answers "which sources did this
+ * round actually process, and what did each yield?" — the question an
+ * operator (or a keeper agent auditing ingest coverage) otherwise has to
+ * reconstruct from atom frontmatter joins. A `rows: 0` entry is the
+ * load-bearing case: it proves the source WAS attempted and legitimately
+ * yielded nothing, distinguishing "processed, atom-less" from "never
+ * reached" without any DB forensics.
+ */
+export interface ExtractReceiptSourceOutcome {
+  /** Transcript file path/basename or page slug. */
+  ref: string;
+  /** 16-char content-hash prefix, when the extractor tracks one. */
+  hash?: string;
+  /** Rows extracted from this source (0 = processed, nothing yielded). */
+  rows: number;
+  /** Error message when this source failed instead of completing. */
+  error?: string;
+}
+
+/**
+ * Bound on per-source outcomes recorded in one receipt (frontmatter AND
+ * body). A backlog-drain round can touch hundreds of sources; the receipt
+ * stays a bounded audit page, with `sources_total` recording the true
+ * count when truncation applied.
+ */
+export const MAX_RECEIPT_SOURCES = 200;
+
+/** Rows rendered in the body table before deferring to frontmatter. */
+const BODY_SOURCE_ROWS = 50;
+
+/**
+ * Per-source outcome row for a receipt. Answers "which sources did this
+ * round actually process, and what did each yield?" — the question an
+ * operator (or a keeper agent auditing ingest coverage) otherwise has to
+ * reconstruct by joining atom frontmatter back to staged content. A
+ * `rows: 0` entry is the load-bearing case: it proves the source WAS
+ * attempted and legitimately yielded nothing, distinguishing
+ * "processed, atom-less" from "never reached" without DB forensics.
+ */
+export interface ExtractReceiptSourceOutcome {
+  /** Transcript file path/basename or page slug. */
+  ref: string;
+  /** 16-char content-hash prefix, when the extractor tracks one. */
+  hash?: string;
+  /** Rows extracted from this source (0 = processed, nothing yielded). */
+  rows: number;
+  /** Error message when this source failed instead of completing. */
+  error?: string;
+}
+
+/**
  * Input to writeReceipt. Optional fields are recorded in frontmatter
  * only when the caller provides them, so receipts stay clean for
  * deterministic extractors (no LLM cost or eval to record).
@@ -78,6 +129,12 @@ export interface ExtractReceiptInput {
   eval_score?: number;
   /** Human-readable summary line (1-2 sentences). */
   summary?: string;
+  /**
+   * Per-source outcomes (optional). Capped at MAX_RECEIPT_SOURCES;
+   * when the caller passes more, the first MAX_RECEIPT_SOURCES are
+   * recorded and frontmatter carries the true `sources_total`.
+   */
+  sources?: ExtractReceiptSourceOutcome[];
 }
 
 const RUN_ID_SHORT_LEN = 8;
@@ -145,7 +202,32 @@ function buildReceiptBody(input: ExtractReceiptInput): string {
       : '';
     lines.push(`Eval gate: **${verdict}**${score}`);
   }
+  const sources = cappedSources(input);
+  if (sources.length > 0) {
+    lines.push('');
+    lines.push('## Per-source outcomes');
+    lines.push('');
+    lines.push('| source | hash | rows | note |');
+    lines.push('|---|---|---|---|');
+    for (const s of sources.slice(0, BODY_SOURCE_ROWS)) {
+      // Pipes inside refs/errors would break the table — neutralize them.
+      const ref = s.ref.replace(/\|/g, '\\|');
+      const note = s.error ? `error: ${s.error.slice(0, 80).replace(/\|/g, '\\|')}` : '';
+      lines.push(`| ${ref} | ${s.hash ?? ''} | ${s.rows} | ${note} |`);
+    }
+    const total = input.sources?.length ?? 0;
+    if (total > BODY_SOURCE_ROWS) {
+      lines.push('');
+      lines.push(`…and ${total - BODY_SOURCE_ROWS} more (frontmatter \`sources\` carries up to ${MAX_RECEIPT_SOURCES}).`);
+    }
+  }
   return lines.join('\n') + '\n';
+}
+
+/** Apply the MAX_RECEIPT_SOURCES cap once, shared by body + frontmatter. */
+function cappedSources(input: ExtractReceiptInput): ExtractReceiptSourceOutcome[] {
+  if (!input.sources || input.sources.length === 0) return [];
+  return input.sources.slice(0, MAX_RECEIPT_SOURCES);
 }
 
 /**
@@ -168,6 +250,11 @@ function buildReceiptFrontmatter(input: ExtractReceiptInput): Record<string, unk
   if (input.model_id) fm.model_id = input.model_id;
   if (typeof input.eval_pass === 'boolean') fm.eval_pass = input.eval_pass;
   if (typeof input.eval_score === 'number') fm.eval_score = input.eval_score;
+  const sources = cappedSources(input);
+  if (sources.length > 0) {
+    fm.sources = sources;
+    fm.sources_total = input.sources!.length;
+  }
   return fm;
 }
 

--- a/test/extract-receipt-sources.test.ts
+++ b/test/extract-receipt-sources.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Per-source outcomes on extract receipts + the zero-atom receipt gap.
+ *
+ * Motivation: an ingest-coverage audit ("is every staged transcript
+ * drained?") needs receipts to answer two questions per source:
+ *   1. Was it ATTEMPTED this round?
+ *   2. What did it yield (rows, 0 rows, or an error)?
+ * Pre-fix, receipts carried only aggregate counts ("N atoms from M
+ * transcripts") AND a round whose every source yielded 0 atoms wrote no
+ * receipt at all — "processed, legitimately atom-less" was
+ * indistinguishable from "never reached" without joining atom
+ * frontmatter back to staged content by hand.
+ *
+ * Pins:
+ *  - writeReceipt renders per-source rows in body + frontmatter, with the
+ *    MAX_RECEIPT_SOURCES cap and a true sources_total.
+ *  - runPhaseExtractAtoms writes a receipt on an all-zero-yield round
+ *    (the gap), with rows:0 outcomes for each attempted source.
+ *  - failures carry an error note; mixed rounds record per-source rows.
+ *  - extractors that omit `sources` produce byte-identical receipts to
+ *    before (additive change).
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type { BrainEngine } from '../src/core/engine.ts';
+import {
+  writeReceipt,
+  MAX_RECEIPT_SOURCES,
+  type ExtractReceiptInput,
+} from '../src/core/extract/receipt-writer.ts';
+import { runPhaseExtractAtoms } from '../src/core/cycle/extract-atoms.ts';
+
+type PutPageCall = { slug: string; page: Record<string, unknown> };
+
+function fakeEngine(): { engine: BrainEngine; puts: PutPageCall[] } {
+  const puts: PutPageCall[] = [];
+  const engine = {
+    executeRaw: async () => [],
+    putPage: async (slug: string, page: Record<string, unknown>) => {
+      puts.push({ slug, page });
+      return { slug, ...page };
+    },
+  } as unknown as BrainEngine;
+  return { engine, puts };
+}
+
+function baseInput(overrides: Partial<ExtractReceiptInput> = {}): ExtractReceiptInput {
+  return {
+    kind: 'atoms',
+    source_id: 'default',
+    run_id: 'atoms-testrun-defa',
+    round: 'single',
+    extracted_at: '2026-01-02T03:04:05.000Z',
+    total_rows: 3,
+    cost_usd: 0.01,
+    ...overrides,
+  };
+}
+
+describe('writeReceipt per-source outcomes', () => {
+  it('renders sources in body table + frontmatter, rows:0 and errors included', async () => {
+    const { engine, puts } = fakeEngine();
+    await writeReceipt(engine, baseInput({
+      sources: [
+        { ref: 'session-a.part1.txt', hash: 'aaaa111122223333', rows: 3 },
+        { ref: 'session-a.part2.txt', hash: 'bbbb111122223333', rows: 0 },
+        { ref: 'pages/some-slug', rows: 0, error: 'boom | with pipe' },
+      ],
+    }));
+    expect(puts.length).toBe(1);
+    const body = puts[0].page.compiled_truth as string;
+    expect(body).toContain('## Per-source outcomes');
+    expect(body).toContain('| session-a.part1.txt | aaaa111122223333 | 3 |');
+    expect(body).toContain('| session-a.part2.txt | bbbb111122223333 | 0 |');
+    // pipe in the error is escaped so the table stays a table
+    expect(body).toContain('error: boom \\| with pipe');
+
+    const fm = puts[0].page.frontmatter as Record<string, unknown>;
+    const sources = fm.sources as Array<Record<string, unknown>>;
+    expect(sources.length).toBe(3);
+    expect(fm.sources_total).toBe(3);
+    expect(sources[1]).toEqual({ ref: 'session-a.part2.txt', hash: 'bbbb111122223333', rows: 0 });
+  });
+
+  it('caps recorded sources at MAX_RECEIPT_SOURCES and keeps the true total', async () => {
+    const { engine, puts } = fakeEngine();
+    const many = Array.from({ length: MAX_RECEIPT_SOURCES + 25 }, (_, i) => ({
+      ref: `t-${i}.txt`,
+      rows: 1,
+    }));
+    await writeReceipt(engine, baseInput({ sources: many }));
+    const fm = puts[0].page.frontmatter as Record<string, unknown>;
+    expect((fm.sources as unknown[]).length).toBe(MAX_RECEIPT_SOURCES);
+    expect(fm.sources_total).toBe(MAX_RECEIPT_SOURCES + 25);
+    const body = puts[0].page.compiled_truth as string;
+    expect(body).toContain('more (frontmatter `sources` carries up to');
+  });
+
+  it('omitting sources leaves body + frontmatter unchanged (additive)', async () => {
+    const { engine, puts } = fakeEngine();
+    await writeReceipt(engine, baseInput());
+    const body = puts[0].page.compiled_truth as string;
+    const fm = puts[0].page.frontmatter as Record<string, unknown>;
+    expect(body).not.toContain('Per-source outcomes');
+    expect('sources' in fm).toBe(false);
+    expect('sources_total' in fm).toBe(false);
+  });
+});
+
+const ATOM_JSON = JSON.stringify([
+  { title: 'A real nugget', atom_type: 'critique', body: 'Something learned.' },
+]);
+
+function chatReturning(textBySource: Record<string, string>) {
+  return async (req: { messages: Array<{ content: string }> }) => {
+    const content = req.messages[0].content;
+    const match = Object.keys(textBySource).find((k) => content.includes(k));
+    return {
+      text: match ? textBySource[match] : '[]',
+      usage: { input_tokens: 100, output_tokens: 50 },
+    };
+  };
+}
+
+function transcript(name: string, hash: string) {
+  return {
+    filePath: `/staged/${name}`,
+    content: `Transcript content for ${name}. Long enough to matter.`,
+    contentHash: hash.padEnd(64, '0'),
+  };
+}
+
+describe('runPhaseExtractAtoms receipt coverage', () => {
+  it('writes a receipt with rows:0 outcomes when EVERY source yields 0 atoms (the gap)', async () => {
+    const { engine, puts } = fakeEngine();
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [transcript('s1.part7.txt', 'deadbeefcafe0001')],
+      _pages: [],
+      _loadConfig: () => null,
+      _chat: chatReturning({}) as never, // always returns [] → 0 atoms
+    });
+    expect(result.status).toBe('ok');
+    const receipt = puts.find((p) => p.slug.startsWith('extracts/'));
+    expect(receipt).toBeDefined();
+    const fm = receipt!.page.frontmatter as Record<string, unknown>;
+    expect(fm.total_rows).toBe(0);
+    const sources = fm.sources as Array<Record<string, unknown>>;
+    expect(sources.length).toBe(1);
+    expect(sources[0].rows).toBe(0);
+    expect(sources[0].hash).toBe('deadbeefcafe0001');
+    expect((receipt!.page.compiled_truth as string)).toContain('1 source(s) yielded 0 atoms.');
+  });
+
+  it('records per-source rows and failure notes on a mixed round', async () => {
+    const { engine, puts } = fakeEngine();
+    const failing = transcript('s2.part1.txt', 'aaaa22223333bbbb');
+    const yielding = transcript('s2.part2.txt', 'cccc22223333dddd');
+    const empty = transcript('s2.part3.txt', 'eeee22223333ffff');
+    const chat = async (req: { messages: Array<{ content: string }> }) => {
+      const content = req.messages[0].content;
+      if (content.includes('s2.part1.txt')) throw new Error('provider blew up');
+      return {
+        text: content.includes('s2.part2.txt') ? ATOM_JSON : '[]',
+        usage: { input_tokens: 100, output_tokens: 50 },
+      };
+    };
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [failing, yielding, empty],
+      _pages: [],
+      _loadConfig: () => null,
+      _chat: chat as never,
+    });
+    expect(result.status).toBe('warn'); // failure present
+    const receipt = puts.find((p) => p.slug.startsWith('extracts/'));
+    expect(receipt).toBeDefined();
+    const fm = receipt!.page.frontmatter as Record<string, unknown>;
+    const sources = fm.sources as Array<Record<string, unknown>>;
+    expect(sources.length).toBe(3);
+    const byRef = Object.fromEntries(sources.map((s) => [s.ref as string, s]));
+    expect(byRef['/staged/s2.part1.txt'].error).toContain('provider blew up');
+    expect(byRef['/staged/s2.part2.txt'].rows).toBe(1);
+    expect(byRef['/staged/s2.part3.txt'].rows).toBe(0);
+  });
+
+  it('dry-run still writes no receipt', async () => {
+    const { engine, puts } = fakeEngine();
+    await runPhaseExtractAtoms(engine, {
+      dryRun: true,
+      _transcripts: [transcript('s3.part1.txt', '1111222233334444')],
+      _pages: [],
+      _loadConfig: () => null,
+      _chat: chatReturning({ 's3.part1.txt': ATOM_JSON }) as never,
+    });
+    expect(puts.find((p) => p.slug.startsWith('extracts/'))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Extract receipts now record **which sources a round actually processed and what each yielded**. An ingest-coverage audit ("is every staged transcript actually landing as atoms?") currently requires joining atom frontmatter back to staged content by hand — the receipt knows the answer but doesn't say it.

- New optional `sources` on `ExtractReceiptInput` — `[{ ref, hash?, rows, error? }]`. `rows: 0` is the load-bearing case: it proves a source WAS attempted and legitimately yielded nothing, distinguishing "processed, atom-less" from "never reached" without DB forensics.
- Capped at `MAX_RECEIPT_SOURCES` (200) with `sources_total` in frontmatter carrying the true count when truncated; first `BODY_SOURCE_ROWS` (50) render as a body table, rest live in frontmatter only.
- `extract-atoms` wires its per-source outcomes through (drain + page-discovery paths).
- Additive: extractors that don't track per-source state simply omit the field; receipts unchanged for them.

## Testing

- `test/extract-receipt-sources.test.ts` (new) — per-source outcomes + the zero-atom receipt gap; 13 targeted tests green (`extract-receipt-sources` + `extract-atoms-drain`).
- `bun run verify` — 31/31 checks green; `bun run typecheck` clean.
- Full unit suite run chunked on a constrained box (24G LXC — the stock 4-shard runner OOMs it); the only failures reproduce identically on clean `master` (environment-dependent: git-hook/worker tests against a live gbrain install), none in the extract/receipt area.