### PR TITLE
Advance timeline, salience, and schema materialization

### DIFF
--- a/docs/architecture/schema-packs.md
+++ b/docs/architecture/schema-packs.md
@@ -136,7 +136,27 @@ $EDITOR ~/.gbrain/schema-packs/my-pack/pack.yaml
 gbrain schema validate my-pack        # check shape
 gbrain schema use my-pack             # activate
 gbrain schema active                  # confirm
+gbrain schema stats                   # compare stored typing with active-pack conformance
+gbrain schema review-orphans          # review untyped and undeclared-type pages
 ```
+
+### Stored typing vs active-pack conformance
+
+`gbrain schema stats` reports two intentionally different coverage measures:
+
+- **Stored typing coverage** (`coverage`) is the backward-compatible measure:
+  any nonempty `pages.type` value counts as typed, even if the active pack does
+  not declare it.
+- **Active-pack declared coverage** (`declared_coverage`) counts only pages
+  whose stored type is a declared type (or query-equivalent alias) in the
+  resolved active pack. `undeclared_types` contains aggregate type/count rows;
+  it never exposes page bodies.
+
+The counts obey `declared_pages + undeclared_pages + untyped_pages =
+total_pages`. When no pack can be resolved, nonempty stored types remain typed
+for the legacy metric but are classified as undeclared for conformance.
+`schema review-orphans` uses the same classification and labels each bounded
+result as either `untyped` or `undeclared_type`.
 
 A minimal pack:
 

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -471,30 +471,13 @@ export async function extractLinksFromFile(
 
 /** Extract timeline entries from markdown content */
 export function extractTimelineFromContent(content: string, slug: string): ExtractedTimelineEntry[] {
-  const entries: ExtractedTimelineEntry[] = [];
-
-  // Format 1: Bullet — - **YYYY-MM-DD** | Source — Summary
-  const bulletPattern = /^-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*(.+?)\s*[—–-]\s*(.+)$/gm;
-  let match;
-  while ((match = bulletPattern.exec(content)) !== null) {
-    entries.push({ slug, date: match[1], source: match[2].trim(), summary: match[3].trim() });
-  }
-
-  // Format 2: Header — ### YYYY-MM-DD — Title
-  const headerPattern = /^###\s+(\d{4}-\d{2}-\d{2})\s*[—–-]\s*(.+)$/gm;
-  while ((match = headerPattern.exec(content)) !== null) {
-    const afterIdx = match.index + match[0].length;
-    const nextHeader = content.indexOf('\n### ', afterIdx);
-    const nextSection = content.indexOf('\n## ', afterIdx);
-    const endIdx = Math.min(
-      nextHeader >= 0 ? nextHeader : content.length,
-      nextSection >= 0 ? nextSection : content.length,
-    );
-    const detail = content.slice(afterIdx, endIdx).trim();
-    entries.push({ slug, date: match[1], source: 'markdown', summary: match[2].trim(), detail: detail || undefined });
-  }
-
-  return entries;
+  return parseTimelineEntries(content).map((entry) => ({
+    slug,
+    date: entry.date,
+    source: entry.source ?? 'markdown',
+    summary: entry.summary,
+    detail: entry.detail || undefined,
+  }));
 }
 
 // --- Main command ---
@@ -1194,7 +1177,7 @@ async function extractTimelineFromDir(
         const slug = pathToSlug(file.relPath);
         for (const entry of extractTimelineFromContent(content, slug)) {
           if (dryRunSeen) {
-            const key = `${entry.slug}::${entry.date}::${entry.summary}`;
+            const key = `${entry.slug}::${entry.date}::${entry.source}::${entry.summary}`;
             if (dryRunSeen.has(key)) continue;
             dryRunSeen.add(key);
             if (!jsonMode) console.log(`  ${entry.slug}: ${entry.date} — ${entry.summary}`);
@@ -1536,13 +1519,14 @@ async function extractTimelineFromDB(
 
     for (const entry of entries) {
       if (dryRunSeen) {
-        const key = `${source_id}::${slug}::${entry.date}::${entry.summary}`;
+        const key = `${source_id}::${slug}::${entry.date}::${entry.source ?? 'markdown'}::${entry.summary}`;
         if (dryRunSeen.has(key)) continue;
         dryRunSeen.add(key);
         if (jsonMode) {
           process.stdout.write(JSON.stringify({
             action: 'add_timeline', slug, source_id, date: entry.date,
-            summary: entry.summary, ...(entry.detail ? { detail: entry.detail } : {}),
+            source: entry.source ?? 'markdown', summary: entry.summary,
+            ...(entry.detail ? { detail: entry.detail } : {}),
           }) + '\n');
         } else {
           console.log(`  ${slug}: ${entry.date} — ${entry.summary}`);
@@ -1551,7 +1535,7 @@ async function extractTimelineFromDB(
       } else {
         // v0.32.8 F4: thread source_id so the JOIN matches the right page
         // when two sources share the same slug.
-        batch.push({ slug, date: entry.date, summary: entry.summary, detail: entry.detail || '', source_id });
+        batch.push({ slug, date: entry.date, source: entry.source ?? 'markdown', summary: entry.summary, detail: entry.detail || '', source_id });
         if (batch.length >= BATCH_SIZE) await flush();
       }
     }
@@ -1663,7 +1647,7 @@ async function extractStaleFromDB(
         });
       }
       for (const entry of parseTimelineEntries(fullContent)) {
-        timelineRows.push({ slug: page.slug, date: entry.date, summary: entry.summary, detail: entry.detail || '', source_id: page.source_id });
+        timelineRows.push({ slug: page.slug, date: entry.date, source: entry.source ?? 'markdown', summary: entry.summary, detail: entry.detail || '', source_id: page.source_id });
       }
       // EVERY processed page is stamped (incl. zero-link pages). D4 race fix:
       // stamp with the row's READ updated_at, NOT now() — a concurrent edit

--- a/src/commands/salience.ts
+++ b/src/commands/salience.ts
@@ -14,22 +14,26 @@
  */
 
 import type { BrainEngine } from '../core/engine.ts';
+import type { SalienceOpts } from '../core/types.ts';
 import { loadConfig, isThinClient } from '../core/config.ts';
 import { callRemoteTool, unpackToolResult } from '../core/mcp-client.ts';
 
-interface RunOpts {
+export interface SalienceRunOpts {
   days?: number;
   limit?: number;
   slugPrefix?: string;
+  recencyBias?: 'flat' | 'on';
+  includeFuture?: boolean;
   json?: boolean;
 }
 
-function parseArgs(args: string[]): RunOpts | { help: true } {
-  const opts: RunOpts = {};
+export function parseSalienceArgs(args: string[]): SalienceRunOpts | { help: true } {
+  const opts: SalienceRunOpts = {};
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === '--help' || a === '-h') return { help: true };
     if (a === '--json') { opts.json = true; continue; }
+    if (a === '--include-future') { opts.includeFuture = true; continue; }
     if (a === '--days') {
       const n = parseInt(args[++i] ?? '', 10);
       if (Number.isFinite(n) && n >= 0) opts.days = n;
@@ -45,8 +49,35 @@ function parseArgs(args: string[]): RunOpts | { help: true } {
       if (v) opts.slugPrefix = v;
       continue;
     }
+    if (a === '--recency-bias') {
+      const value = args[++i];
+      if (value === 'flat' || value === 'on') opts.recencyBias = value;
+      continue;
+    }
   }
   return opts;
+}
+
+export function buildSalienceQueryArgs(parsed: SalienceRunOpts): {
+  engine: SalienceOpts;
+  remote: Record<string, unknown>;
+} {
+  return {
+    engine: {
+      days: parsed.days,
+      limit: parsed.limit,
+      slugPrefix: parsed.slugPrefix,
+      recency_bias: parsed.recencyBias,
+      includeFuture: parsed.includeFuture,
+    },
+    remote: {
+      days: parsed.days,
+      limit: parsed.limit,
+      slugPrefix: parsed.slugPrefix,
+      recency_bias: parsed.recencyBias,
+      include_future: parsed.includeFuture,
+    },
+  };
 }
 
 const HELP = `Usage: gbrain salience [options]
@@ -59,16 +90,19 @@ Options:
   --limit N           Max results (default 20, capped at 100)
   --kind PREFIX       Slug-prefix filter (e.g. personal, wiki/people)
   --slug-prefix P     Same as --kind
+  --recency-bias MODE Recency scoring: flat (default) or on
+  --include-future    Include future-effective pages without salience signals
   --json              JSON output for agents
   --help, -h          Show this help
 `;
 
 export async function runSalience(engine: BrainEngine, args: string[]): Promise<void> {
-  const parsed = parseArgs(args);
+  const parsed = parseSalienceArgs(args);
   if ('help' in parsed) {
     console.log(HELP);
     return;
   }
+  const queryArgs = buildSalienceQueryArgs(parsed);
 
   // v0.31.1 (Issue #734): on thin-client installs, route the engine call
   // through the remote `get_recent_salience` MCP op. Output format is
@@ -77,18 +111,15 @@ export async function runSalience(engine: BrainEngine, args: string[]): Promise<
   let rows;
   const cfg = loadConfig();
   if (isThinClient(cfg)) {
-    const raw = await callRemoteTool(cfg!, 'get_recent_salience', {
-      days: parsed.days,
-      limit: parsed.limit,
-      slugPrefix: parsed.slugPrefix,
-    }, { timeoutMs: 30_000 });
+    const raw = await callRemoteTool(
+      cfg!,
+      'get_recent_salience',
+      queryArgs.remote,
+      { timeoutMs: 30_000 },
+    );
     rows = unpackToolResult<Awaited<ReturnType<BrainEngine['getRecentSalience']>>>(raw);
   } else {
-    rows = await engine.getRecentSalience({
-      days: parsed.days,
-      limit: parsed.limit,
-      slugPrefix: parsed.slugPrefix,
-    });
+    rows = await engine.getRecentSalience(queryArgs.engine);
   }
   if (parsed.json) {
     console.log(JSON.stringify(rows, null, 2));

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -776,16 +776,17 @@ async function runExplainCmd(args: string[]): Promise<void> {
 
 async function runReviewOrphansCmd(args: string[]): Promise<void> {
   const { json, source } = parseFlags(args);
-  const result = await withConnectedEngine((engine) =>
-    runReviewOrphans(engine, { sourceId: source }),
-  );
+  const result = await withConnectedEngine((engine) => {
+    const ctx = { engine, config: loadConfig(), logger: console, dryRun: false, remote: false, sourceId: source ?? 'default' } as never;
+    return runReviewOrphans(ctx, { sourceId: source ?? 'default' });
+  });
   if (json) {
     console.log(JSON.stringify({ schema_version: 1, ...result }, null, 2));
     return;
   }
-  console.log(`Orphan pages (no active-pack type match): ${result.orphan_count}`);
+  console.log(`Active-pack conformance gaps: ${result.orphan_count}`);
   for (const o of result.orphans.slice(0, 20)) {
-    console.log(`  ${o.slug}`);
+    console.log(`  ${o.slug} (${o.reason}${o.stored_type ? `: ${o.stored_type}` : ''})`);
   }
   if (result.orphan_count > 20) {
     console.log(`  ... and ${result.orphan_count - 20} more (use --json to see all)`);
@@ -935,7 +936,7 @@ function handleMutationError(err: unknown): never {
 async function runStatsCmd(args: string[]): Promise<void> {
   const { json, source } = parseFlags(args);
   await withConnectedEngine(async (engine) => {
-    const ctx = { engine, config: {}, logger: console, dryRun: false, remote: false, sourceId: source } as never;
+    const ctx = { engine, config: loadConfig(), logger: console, dryRun: false, remote: false, sourceId: source } as never;
     const result = await runStatsCore(ctx, source ? { sourceId: source } : {});
     if (json) {
       console.log(JSON.stringify(result, null, 2));
@@ -945,9 +946,17 @@ async function runStatsCmd(args: string[]): Promise<void> {
     console.log(`Total pages: ${result.aggregate.total_pages}`);
     console.log(`Typed: ${result.aggregate.typed_pages} (${(result.aggregate.coverage * 100).toFixed(1)}%)`);
     console.log(`Untyped: ${result.aggregate.untyped_pages}`);
+    console.log(`Declared by active pack: ${result.aggregate.declared_pages} (${(result.aggregate.declared_coverage * 100).toFixed(1)}%)`);
+    console.log(`Undeclared stored types: ${result.aggregate.undeclared_pages}`);
     if (result.aggregate.by_type.length > 0) {
       console.log(`\nBy type:`);
       for (const t of result.aggregate.by_type) {
+        console.log(`  ${t.type.padEnd(20)} ${t.count}`);
+      }
+    }
+    if (result.aggregate.undeclared_types.length > 0) {
+      console.log(`\nUndeclared types:`);
+      for (const t of result.aggregate.undeclared_types) {
         console.log(`  ${t.type.padEnd(20)} ${t.count}`);
       }
     }

--- a/src/core/advisor/collect-schema-pack.ts
+++ b/src/core/advisor/collect-schema-pack.ts
@@ -8,6 +8,7 @@
  */
 
 import { loadActivePack } from '../schema-pack/load-active.ts';
+import { runStatsCore } from '../schema-pack/stats.ts';
 import type { AdvisorCollector } from './types.ts';
 
 export const collectSchemaPack: AdvisorCollector = {
@@ -21,7 +22,28 @@ export const collectSchemaPack: AdvisorCollector = {
     }
     try {
       await loadActivePack({ cfg: ctx.config, remote: ctx.remote, dbConfig });
-      return []; // resolves cleanly → nothing to say
+      const stats = await runStatsCore({
+        engine: ctx.engine,
+        config: ctx.config,
+        logger: { info: () => {}, warn: () => {}, error: () => {} },
+        dryRun: false,
+        remote: ctx.remote,
+      } as never);
+      const { total_pages: total, undeclared_pages: undeclared } = stats.aggregate;
+      if (total >= 10 && undeclared >= 10 && undeclared / total >= 0.05) {
+        const typeNames = stats.aggregate.undeclared_types.slice(0, 5).map((row) => row.type);
+        const suffix = stats.aggregate.undeclared_types.length > typeNames.length ? ', …' : '';
+        return [{
+          id: 'schema_pack_undeclared_pages',
+          severity: 'warn',
+          title: `${undeclared} pages use types not declared by the active schema pack.`,
+          detail: `${Math.round((undeclared / total) * 100)}% of scoped pages are outside active-pack conformance. Types: ${typeNames.join(', ')}${suffix}`,
+          fix: { command_argv: ['gbrain', 'schema', 'stats'] },
+          collector: 'schema-pack',
+          ask_user: true,
+        }];
+      }
+      return [];
     } catch (err) {
       const name = dbConfig ?? ctx.config?.schema_pack ?? '(configured)';
       return [

--- a/src/core/advisor/collect-usage-shape.ts
+++ b/src/core/advisor/collect-usage-shape.ts
@@ -19,9 +19,11 @@ export const collectUsageShape: AdvisorCollector = {
     const findings: AdvisorFinding[] = [];
 
     let pageCount = 0;
+    let entityCount = 0;
     try {
       const stats = await ctx.engine.getStats();
       pageCount = stats.page_count;
+      entityCount = (stats.pages_by_type.person ?? 0) + (stats.pages_by_type.company ?? 0);
     } catch {
       return []; // no stats → empty brain or unreachable; nothing to advise
     }
@@ -57,6 +59,28 @@ export const collectUsageShape: AdvisorCollector = {
           severity: 'info',
           title: `${health.dead_links} link${health.dead_links === 1 ? '' : 's'} point to a page that no longer exists.`,
           fix: { command_argv: ['gbrain', 'doctor'] },
+          collector: 'usage-shape',
+          ask_user: true,
+        });
+      }
+      if (entityCount >= 10 && health.link_coverage < 0.5) {
+        findings.push({
+          id: 'low_entity_link_coverage',
+          severity: 'warn',
+          title: `Only ${Math.round(health.link_coverage * 100)}% of entity pages have an inbound link.`,
+          detail: 'Preview stale link extraction before writing, then inspect graph health with doctor.',
+          fix: { command_argv: ['gbrain', 'extract', '--stale', '--dry-run'] },
+          collector: 'usage-shape',
+          ask_user: true,
+        });
+      }
+      if (entityCount >= 10 && health.timeline_coverage < 0.5) {
+        findings.push({
+          id: 'low_entity_timeline_coverage',
+          severity: 'info',
+          title: `Only ${Math.round(health.timeline_coverage * 100)}% of entity pages have a structured timeline entry.`,
+          detail: 'Review timeline extraction in dry-run mode; Chronicle events are measured separately.',
+          fix: { command_argv: ['gbrain', 'extract', '--stale', '--dry-run'] },
           collector: 'usage-shape',
           ask_user: true,
         });

--- a/src/core/link-extraction.ts
+++ b/src/core/link-extraction.ts
@@ -1094,20 +1094,45 @@ export async function extractFrontmatterLinks(
 export interface TimelineCandidate {
   /** ISO date YYYY-MM-DD. */
   date: string;
+  /** Optional provenance parsed from `| Source — Summary` entries. */
+  source?: string;
   /** First-line summary. */
   summary: string;
   /** Optional detail (subsequent lines until next entry/heading). */
   detail: string;
 }
 
-// Match: `- **YYYY-MM-DD** | summary` or `- **YYYY-MM-DD** -- summary`
-// or `- **YYYY-MM-DD** - summary` or just `**YYYY-MM-DD** | summary`.
-const TIMELINE_LINE_RE = /^\s*-?\s*\*\*(\d{4}-\d{2}-\d{2})\*\*\s*[|\-–—]+\s*(.+?)\s*$/;
+const BOLD_PIPE_TIMELINE_RE = /^\s*-?\s*\*\*(\d{4}-\d{2}-\d{2})\*\*\s*\|\s*(.+?)\s*$/;
+const BOLD_DASH_TIMELINE_RE = /^\s*-\s+\*\*(\d{4}-\d{2}-\d{2})\*\*\s*(?:--|[-–—])\s*(.+?)\s*$/;
+const PLAIN_TIMELINE_RE = /^\s*-\s+(\d{4}-\d{2}-\d{2})\s+—\s+(.+?)\s*$/;
+const HEADER_TIMELINE_RE = /^\s*###\s+(\d{4}-\d{2}-\d{2})\s*[—–-]\s*(.+?)\s*$/;
+const SOURCE_SUMMARY_RE = /^(.+?)\s+(?:—|–|--|-)\s+(.+)$/;
+
+type ParsedTimelineLine = Omit<TimelineCandidate, 'detail'> & { kind: 'bullet' | 'header' };
+
+function parseTimelineLine(line: string): ParsedTimelineLine | null {
+  let match = BOLD_PIPE_TIMELINE_RE.exec(line);
+  if (match) {
+    const sourceSummary = SOURCE_SUMMARY_RE.exec(match[2].trim());
+    return sourceSummary
+      ? { date: match[1], source: sourceSummary[1].trim(), summary: sourceSummary[2].trim(), kind: 'bullet' }
+      : { date: match[1], summary: match[2].trim(), kind: 'bullet' };
+  }
+
+  match = BOLD_DASH_TIMELINE_RE.exec(line) ?? PLAIN_TIMELINE_RE.exec(line);
+  if (match) return { date: match[1], summary: match[2].trim(), kind: 'bullet' };
+
+  match = HEADER_TIMELINE_RE.exec(line);
+  if (match) return { date: match[1], summary: match[2].trim(), kind: 'header' };
+
+  return null;
+}
 
 /**
  * Parse timeline entries from content. Looks at:
  *   - The full content (most pages have a top-level "## Timeline" heading).
- *   - Free-form `- **DATE** | text` lines anywhere.
+ *   - Supported bold-date and canonical plain-date bullets anywhere.
+ *   - `### DATE — Title` entries with detail through the next peer/parent heading.
  *
  * Skips dates that don't represent valid calendar dates (e.g. 2026-13-45).
  * Multi-line entries: a date line followed by indented or blank-then-text
@@ -1119,13 +1144,12 @@ export function parseTimelineEntries(content: string): TimelineCandidate[] {
 
   let i = 0;
   while (i < lines.length) {
-    const m = TIMELINE_LINE_RE.exec(lines[i]);
-    if (!m) {
+    const parsed = parseTimelineLine(lines[i]);
+    if (!parsed) {
       i++;
       continue;
     }
-    const date = m[1];
-    const summary = m[2].trim();
+    const { date, source, summary, kind } = parsed;
     if (!isValidDate(date) || summary.length === 0) {
       i++;
       continue;
@@ -1136,8 +1160,14 @@ export function parseTimelineEntries(content: string): TimelineCandidate[] {
     let j = i + 1;
     while (j < lines.length) {
       const next = lines[j];
-      if (TIMELINE_LINE_RE.test(next)) break;
-      if (/^#{1,6}\s/.test(next)) break;
+      if (parseTimelineLine(next)) break;
+      const heading = /^\s*(#{1,6})\s/.exec(next);
+      if (heading && (kind === 'bullet' || heading[1].length <= 3)) break;
+      if (kind === 'header') {
+        detailLines.push(next.trim());
+        j++;
+        continue;
+      }
       if (next.trim().length === 0 && detailLines.length === 0) {
         // skip leading blank line; if we hit a blank after detail content
         // and still no new entry, treat detail as ended.
@@ -1153,7 +1183,7 @@ export function parseTimelineEntries(content: string): TimelineCandidate[] {
       }
       break;
     }
-    result.push({ date, summary, detail: detailLines.join(' ').trim() });
+    result.push({ date, ...(source ? { source } : {}), summary, detail: detailLines.join(' ').trim() });
     i = j;
   }
   return result;

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -4540,7 +4540,7 @@ const list_schema_packs: Operation = {
 
 const schema_stats: Operation = {
   name: 'schema_stats',
-  description: 'v0.40.6.0: per-type page counts + typed-coverage from the DB. Returns {schema_version:1, pack_identity, aggregate, per_source, dead_prefixes}. Multi-source aware via ctx.sourceId/allowedSources.',
+  description: 'v0.40.6.0: per-type page counts with both stored typing coverage and active-pack declared coverage. Returns {schema_version:1, pack_identity, aggregate, per_source, dead_prefixes}. Multi-source aware via ctx.sourceId/allowedSources.',
   params: {},
   scope: 'read',
   handler: async (ctx) => {
@@ -4639,7 +4639,7 @@ const schema_explain_type: Operation = {
 
 const schema_review_orphans: Operation = {
   name: 'schema_review_orphans',
-  description: 'v0.40.6.0: list pages with no active-pack type match. Returns {orphan_count, orphans: [{slug, source_id}]}.',
+  description: "v0.40.6.0: list active-pack conformance gaps. Returns bounded {orphan_count, orphans: [{slug, source_id, stored_type, reason:'untyped'|'undeclared_type'}]}.",
   params: {
     limit: { type: 'number', description: 'Max orphans to return (default 100)' },
   },
@@ -4647,25 +4647,15 @@ const schema_review_orphans: Operation = {
   handler: async (ctx, p) => {
     const limit = Math.max(1, Math.min(10000, (p.limit as number) ?? 100));
     const scope = sourceScopeOpts(ctx);
-    let where = `WHERE deleted_at IS NULL AND (type IS NULL OR type = '')`;
-    const params: unknown[] = [];
-    if (scope.sourceIds && scope.sourceIds.length > 0) {
-      where += ` AND source_id = ANY($1::text[])`;
-      params.push(scope.sourceIds);
-    } else if (scope.sourceId) {
-      where += ` AND source_id = $1`;
-      params.push(scope.sourceId);
-    }
     try {
-      const rows = await ctx.engine.executeRaw<{ slug: string; source_id: string }>(
-        `SELECT slug, COALESCE(source_id, 'default') AS source_id FROM pages ${where} ORDER BY source_id, slug LIMIT ${limit}`,
-        params,
-      );
-      return {
-        schema_version: 1,
-        orphan_count: rows.length,
-        orphans: rows.map((r) => ({ slug: r.slug, source_id: r.source_id })),
-      };
+      const { runReviewOrphans } = await import('./schema-pack/review.ts');
+      const result = await runReviewOrphans(ctx, {
+        limit,
+        ...(scope.sourceIds && scope.sourceIds.length > 0
+          ? { sourceIds: scope.sourceIds }
+          : scope.sourceId ? { sourceId: scope.sourceId } : {}),
+      });
+      return { schema_version: 1, ...result };
     } catch {
       return { schema_version: 1, orphan_count: 0, orphans: [] };
     }

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -972,6 +972,7 @@ const put_page: Operation = {
             const batch = entries.map(e => ({
               slug,
               date: e.date,
+              source: e.source ?? 'markdown',
               summary: e.summary,
               detail: e.detail || '',
             }));

--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -3282,6 +3282,11 @@ const get_recent_salience: Operation = {
         "                     ('what's been salient lately' vs 'what matters\n" +
         "                     in this brain regardless of when').",
     },
+    include_future: {
+      type: 'boolean',
+      description:
+        'Include future-effective pages even when they have no emotional weight or active takes. Default false.',
+    },
   },
   handler: async (ctx, p) => {
     const recencyBias = p.recency_bias === 'on' ? 'on' : 'flat';
@@ -3290,6 +3295,7 @@ const get_recent_salience: Operation = {
       limit: typeof p.limit === 'number' ? p.limit : undefined,
       slugPrefix: typeof p.slugPrefix === 'string' ? p.slugPrefix : undefined,
       recency_bias: recencyBias,
+      includeFuture: p.include_future === true,
     });
   },
   cliHints: { name: 'salience' },

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -5607,8 +5607,10 @@ export class PGLiteEngine implements BrainEngine {
     const limit = clampSearchLimit(opts.limit, 20, 100);
     const slugPrefix = opts.slugPrefix;
     const boundaryIso = new Date(Date.now() - days * 86400000).toISOString();
+    const nowIso = new Date().toISOString();
+    const includeFuture = opts.includeFuture === true;
 
-    const params: unknown[] = [boundaryIso];
+    const params: unknown[] = [boundaryIso, includeFuture, nowIso];
     let prefixCondition = '';
     if (slugPrefix) {
       const escaped = slugPrefix.replace(/[\\%_]/g, (c) => '\\' + c) + '%';
@@ -5649,6 +5651,17 @@ export class PGLiteEngine implements BrainEngine {
          FROM pages p
          LEFT JOIN takes t ON t.page_id = p.id AND t.active = TRUE
         WHERE GREATEST(p.updated_at, COALESCE(p.salience_touched_at, p.updated_at)) >= $1::timestamptz
+          AND p.deleted_at IS NULL
+          AND (
+            $2::boolean
+            OR p.effective_date IS NULL
+            OR p.effective_date <= $3::timestamptz
+            OR p.emotional_weight > 0
+            OR EXISTS (
+              SELECT 1 FROM takes signal_take
+               WHERE signal_take.page_id = p.id AND signal_take.active = TRUE
+            )
+          )
           ${prefixCondition}
         GROUP BY p.id
         ORDER BY score DESC

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5733,8 +5733,10 @@ export class PostgresEngine implements BrainEngine {
     const days = Math.max(0, opts.days ?? 14);
     const limit = clampSearchLimit(opts.limit, 20, 100);
     const slugPrefix = opts.slugPrefix;
+    const includeFuture = opts.includeFuture === true;
     // Compute the boundary in JS so the SQL is identical across engines (eng review D5).
     const boundaryIso = new Date(Date.now() - days * 86400000).toISOString();
+    const nowIso = new Date().toISOString();
     // Escape LIKE meta for the optional prefix match.
     const prefixCondition = slugPrefix
       ? sql`AND p.slug LIKE ${slugPrefix.replace(/[\\%_]/g, (c) => '\\' + c) + '%'} ESCAPE '\\'`
@@ -5771,6 +5773,17 @@ export class PostgresEngine implements BrainEngine {
         FROM pages p
         LEFT JOIN takes t ON t.page_id = p.id AND t.active = TRUE
        WHERE GREATEST(p.updated_at, COALESCE(p.salience_touched_at, p.updated_at)) >= ${boundaryIso}::timestamptz
+         AND p.deleted_at IS NULL
+         AND (
+           ${includeFuture}
+           OR p.effective_date IS NULL
+           OR p.effective_date <= ${nowIso}::timestamptz
+           OR p.emotional_weight > 0
+           OR EXISTS (
+             SELECT 1 FROM takes signal_take
+              WHERE signal_take.page_id = p.id AND signal_take.active = TRUE
+           )
+         )
          ${prefixCondition}
        GROUP BY p.id
        ORDER BY score DESC

--- a/src/core/schema-pack/review.ts
+++ b/src/core/schema-pack/review.ts
@@ -11,6 +11,8 @@
 // current brain state" so users understand what they're reviewing.
 
 import type { BrainEngine } from '../engine.ts';
+import type { OperationContext } from '../operations.ts';
+import { declaredTypesForPack, resolvePackForSchemaRead } from './stats.ts';
 import { runDetect } from './detect.ts';
 import { loadActivePack } from './load-active.ts';
 import { loadConfig, gbrainPath, configPath } from '../config.ts';
@@ -102,31 +104,63 @@ export async function runReviewCandidates(
 
 export interface ReviewOrphansOpts {
   sourceId?: string;
+  sourceIds?: string[];
+  limit?: number;
 }
 
 export interface ReviewOrphansResult {
-  orphans: Array<{ slug: string; source_id: string }>;
+  orphans: Array<{
+    slug: string;
+    source_id: string;
+    stored_type: string | null;
+    reason: 'untyped' | 'undeclared_type';
+  }>;
   orphan_count: number;
-  source_id: string;
+  source_id: string | null;
+  source_ids?: string[];
 }
 
 export async function runReviewOrphans(
-  engine: BrainEngine,
+  ctx: OperationContext,
   opts: ReviewOrphansOpts = {},
 ): Promise<ReviewOrphansResult> {
-  const sourceId = opts.sourceId ?? 'default';
-  const rows = await engine.executeRaw<{ slug: string; source_id: string }>(
-    `SELECT slug, source_id FROM pages
-     WHERE source_id = $1
-       AND deleted_at IS NULL
-       AND (type IS NULL OR type = '')
-     ORDER BY slug
-     LIMIT 1000`,
-    [sourceId],
+  const limit = Math.max(1, Math.min(10000, opts.limit ?? 1000));
+  const pack = await resolvePackForSchemaRead(ctx);
+  const declaredTypes = declaredTypesForPack(pack);
+
+  const params: unknown[] = [];
+  let where = `WHERE deleted_at IS NULL`;
+  if (opts.sourceIds && opts.sourceIds.length > 0) {
+    params.push(opts.sourceIds);
+    where += ` AND source_id = ANY($${params.length}::text[])`;
+  } else if (opts.sourceId) {
+    params.push(opts.sourceId);
+    where += ` AND source_id = $${params.length}`;
+  }
+  if (declaredTypes.size > 0) {
+    params.push([...declaredTypes]);
+    where += ` AND (type IS NULL OR type = '' OR NOT (type = ANY($${params.length}::text[])))`;
+  }
+  // With no resolvable pack, every nonempty stored type is undeclared and
+  // every empty type is untyped, so no additional type predicate is needed.
+  params.push(limit);
+  const rows = await ctx.engine.executeRaw<{ slug: string; source_id: string | null; stored_type: string | null }>(
+    `SELECT slug, COALESCE(source_id, 'default') AS source_id, NULLIF(type, '') AS stored_type
+     FROM pages
+     ${where}
+     ORDER BY source_id, slug
+     LIMIT $${params.length}`,
+    params,
   );
   return {
-    orphans: rows.map((r) => ({ slug: r.slug, source_id: r.source_id })),
+    orphans: rows.map((r) => ({
+      slug: r.slug,
+      source_id: r.source_id ?? 'default',
+      stored_type: r.stored_type,
+      reason: r.stored_type ? 'undeclared_type' : 'untyped',
+    })),
     orphan_count: rows.length,
-    source_id: sourceId,
+    source_id: opts.sourceId ?? null,
+    ...(opts.sourceIds && opts.sourceIds.length > 0 ? { source_ids: opts.sourceIds } : {}),
   };
 }

--- a/src/core/schema-pack/stats.ts
+++ b/src/core/schema-pack/stats.ts
@@ -16,7 +16,8 @@
 // the operation envelope.
 
 import type { BrainEngine } from '../engine.ts';
-import { loadActivePackBestEffort } from './best-effort.ts';
+import { loadActivePack } from './load-active.ts';
+import type { ResolvedPack } from './registry.ts';
 import type { OperationContext } from '../operations.ts';
 
 export interface StatsOpts {
@@ -38,8 +39,16 @@ export interface PerSourceStats {
   total_pages: number;
   typed_pages: number;
   untyped_pages: number;
+  /** Pages whose stored type is declared by the active schema pack. */
+  declared_pages: number;
+  /** Pages with a nonempty stored type absent from the active schema pack. */
+  undeclared_pages: number;
   coverage: number;
+  /** Active-pack declared pages / total pages. */
+  declared_coverage: number;
   by_type: TypeStats[];
+  /** Aggregate counts only; never includes page bodies or slugs. */
+  undeclared_types: TypeStats[];
 }
 
 export interface DeadPrefixHint {
@@ -65,6 +74,48 @@ interface RawCountRow {
   source_id: string | null;
   type: string | null;
   cnt: string;
+}
+
+/**
+ * Resolve the pack used by schema read surfaces, including the DB-backed
+ * brain-wide and scalar per-source tiers that a plain filesystem-only load
+ * would miss. Failure is represented as null so stats remain available on a
+ * fresh or misconfigured brain.
+ */
+export async function resolvePackForSchemaRead(ctx: OperationContext): Promise<ResolvedPack | null> {
+  let dbConfig: string | undefined;
+  let perSourceDb: ReadonlyMap<string, string> | undefined;
+  try {
+    dbConfig = (await ctx.engine.getConfig('schema_pack')) ?? undefined;
+    if (ctx.sourceId) {
+      const sourcePack = await ctx.engine.getConfig(`schema_pack.source.${ctx.sourceId}`);
+      if (sourcePack) perSourceDb = new Map([[ctx.sourceId, sourcePack]]);
+    }
+  } catch {
+    // Pre-init or unavailable config table: continue through file/env tiers.
+  }
+  try {
+    return await loadActivePack({
+      cfg: ctx.config,
+      remote: ctx.remote,
+      sourceId: ctx.sourceId,
+      perSourceDb,
+      dbConfig,
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** Shared active-pack type membership for stats and orphan review. */
+export function declaredTypesForPack(pack: ResolvedPack | null): Set<string> {
+  const declaredTypes = new Set<string>();
+  if (!pack) return declaredTypes;
+  for (const pageType of pack.manifest.page_types) {
+    declaredTypes.add(pageType.name);
+    for (const alias of pageType.aliases ?? []) declaredTypes.add(alias);
+  }
+  return declaredTypes;
 }
 
 function computeCoverage(typed: number, total: number): number {
@@ -96,8 +147,14 @@ function aggregateRows(rows: RawCountRow[]): PerSourceStats[] {
       total_pages: b.total,
       typed_pages: b.typed,
       untyped_pages: b.untyped,
+      declared_pages: 0,
+      undeclared_pages: b.typed,
       coverage: computeCoverage(b.typed, b.total),
+      declared_coverage: computeCoverage(0, b.total),
       by_type: [...b.byType.entries()]
+        .map(([type, count]) => ({ type, count }))
+        .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type)),
+      undeclared_types: [...b.byType.entries()]
         .map(([type, count]) => ({ type, count }))
         .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type)),
     });
@@ -121,11 +178,29 @@ function mergeAggregate(per: PerSourceStats[]): PerSourceStats {
     total_pages: total,
     typed_pages: typed,
     untyped_pages: untyped,
+    declared_pages: 0,
+    undeclared_pages: typed,
     coverage: computeCoverage(typed, total),
+    declared_coverage: computeCoverage(0, total),
     by_type: [...byType.entries()]
       .map(([type, count]) => ({ type, count }))
       .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type)),
+    undeclared_types: [...byType.entries()]
+      .map(([type, count]) => ({ type, count }))
+      .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type)),
   };
+}
+
+/**
+ * Add active-pack conformance without changing the legacy typed/untyped
+ * contract. Aliases participate because schema-pack aliases are documented as
+ * query-equivalent page types; invalid dangling aliases are harmless here.
+ */
+function applyDeclaredConformance(stats: PerSourceStats, declaredTypes: ReadonlySet<string>): void {
+  stats.undeclared_types = stats.by_type.filter((row) => !declaredTypes.has(row.type));
+  stats.undeclared_pages = stats.undeclared_types.reduce((sum, row) => sum + row.count, 0);
+  stats.declared_pages = stats.typed_pages - stats.undeclared_pages;
+  stats.declared_coverage = computeCoverage(stats.declared_pages, stats.total_pages);
 }
 
 /**
@@ -229,11 +304,15 @@ export async function runStatsCore(
   // Pack identity + dead-prefix scan — best-effort.
   let pack_identity: string | null = null;
   let dead_prefixes: DeadPrefixHint[] = [];
-  const pack = await loadActivePackBestEffort(ctx);
+  const pack = await resolvePackForSchemaRead(ctx);
   if (pack) {
     pack_identity = pack.identity;
     dead_prefixes = await detectDeadPrefixes(ctx.engine, pack, opts);
   }
+
+  const declaredTypes = declaredTypesForPack(pack);
+  for (const stats of per_source) applyDeclaredConformance(stats, declaredTypes);
+  applyDeclaredConformance(aggregate, declaredTypes);
 
   return {
     schema_version: 1,

--- a/src/core/search/sql-ranking.ts
+++ b/src/core/search/sql-ranking.ts
@@ -256,7 +256,11 @@ export function buildRecencyComponentSql(opts: {
   const { slugColumn, dateExpr, decayMap, fallback } = opts;
   const now = opts.now ?? { kind: 'now' };
   const nowSql = nowExprToSql(now);
-  const daysOldSql = `EXTRACT(EPOCH FROM (${nowSql} - ${dateExpr})) / 86400.0`;
+  // Effective dates can legitimately be in the future (calendar events,
+  // plans). Clamp their age to zero so recency stays finite and never turns
+  // into an amplified or singular denominator.
+  const daysOldSql =
+    `GREATEST(0.0, EXTRACT(EPOCH FROM (${nowSql} - ${dateExpr})) / 86400.0)`;
 
   const prefixes = Object.keys(decayMap).sort((a, b) => b.length - a.length);
   const branches: string[] = [];

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -429,6 +429,12 @@ export interface SalienceOpts {
    * Default preserves v0.29.0 ranking; 'on' is opt-in.
    */
   recency_bias?: 'flat' | 'on';
+  /**
+   * Include pages whose effective date is in the future even when they have
+   * no structured salience signal. By default, future-effective pages are
+   * admitted only when they carry emotional weight or an active take.
+   */
+  includeFuture?: boolean;
 }
 
 export interface SalienceResult {

--- a/test/advisor-core.test.ts
+++ b/test/advisor-core.test.ts
@@ -11,6 +11,7 @@ import { rankFindings, runAdvisor } from '../src/core/advisor/run.ts';
 import { collectUsageShape } from '../src/core/advisor/collect-usage-shape.ts';
 import { collectStalledJobs } from '../src/core/advisor/collect-stalled-jobs.ts';
 import { collectSetupSmells } from '../src/core/advisor/collect-setup-smells.ts';
+import { collectSchemaPack } from '../src/core/advisor/collect-schema-pack.ts';
 import { appendAdvisorRun, summarizeDeltas } from '../src/core/advisor/history.ts';
 import { renderAdvisorReport } from '../src/core/advisor/render.ts';
 import type { AdvisorContext, AdvisorFinding, AdvisorReport } from '../src/core/advisor/types.ts';
@@ -101,6 +102,45 @@ describe('collect-usage-shape', () => {
   test('empty brain → no findings', async () => {
     const engine = { getStats: async () => ({ page_count: 0, chunk_count: 0, embedded_count: 0, link_count: 0, tag_count: 0, timeline_entry_count: 0, pages_by_type: {} }) };
     expect(await collectUsageShape.collect(ctx(engine as never))).toEqual([]);
+  });
+
+  test('flags low entity link and timeline coverage only at meaningful scale', async () => {
+    const engine = {
+      getStats: async () => ({
+        page_count: 100, chunk_count: 0, embedded_count: 0, link_count: 0,
+        tag_count: 0, timeline_entry_count: 0, pages_by_type: { person: 8, company: 4 },
+      }),
+      getHealth: async () => ({
+        page_count: 100, embed_coverage: 1, stale_pages: 0, orphan_pages: 0, missing_embeddings: 0,
+        brain_score: 50, dead_links: 0, link_coverage: 0.25, timeline_coverage: 0.1, most_connected: [],
+        embed_coverage_score: 35, link_density_score: 0, timeline_coverage_score: 0,
+        no_orphans_score: 15, no_dead_links_score: 10,
+      }),
+    };
+    const out = await collectUsageShape.collect(ctx(engine as never));
+    expect(out.map((row) => row.id)).toContain('low_entity_link_coverage');
+    expect(out.map((row) => row.id)).toContain('low_entity_timeline_coverage');
+    expect(out.find((row) => row.id === 'low_entity_link_coverage')?.fix.command_argv)
+      .toEqual(['gbrain', 'extract', '--stale', '--dry-run']);
+  });
+});
+
+describe('collect-schema-pack', () => {
+  test('reports aggregate undeclared-type drift without exposing page content', async () => {
+    const engine = {
+      getConfig: async () => null,
+      executeRaw: async (sql: string) => sql.includes('GROUP BY source_id')
+        ? [
+            { source_id: 'default', type: 'person', cnt: '80' },
+            { source_id: 'default', type: 'synthetic-record', cnt: '20' },
+          ]
+        : [{ cnt: '1' }],
+    };
+    const out = await collectSchemaPack.collect(ctx(engine as never));
+    const finding = out.find((row) => row.id === 'schema_pack_undeclared_pages');
+    expect(finding?.title).toContain('20 pages');
+    expect(finding?.detail).toContain('synthetic-record');
+    expect(JSON.stringify(finding)).not.toContain('compiled_truth');
   });
 });
 

--- a/test/chronicle-backfill.test.ts
+++ b/test/chronicle-backfill.test.ts
@@ -43,4 +43,26 @@ describe('chronicle_backfill op', () => {
     const jobs = await engine.executeRaw<{ n: number }>(`SELECT count(*)::int AS n FROM minion_jobs WHERE name='chronicle_extract'`);
     expect(Number(jobs[0].n)).toBe(2);
   });
+
+  test('keeps canonical entity timelines separate from Chronicle eligibility', async () => {
+    await engine.putPage('people/timeline-owner', {
+      type: 'person',
+      title: 'timeline owner',
+      compiled_truth: `${LONG}\n- 2026-07-11 — Canonical entity event`,
+    });
+    await engine.putPage('meetings/eligible', { type: 'meeting', title: 'eligible', compiled_truth: LONG });
+
+    const r = await operationsByName.chronicle_backfill.handler(mkCtx(), {}) as {
+      eligible: number;
+      enqueued: number;
+      errors: unknown[];
+    };
+    expect(r.eligible).toBe(1);
+    expect(r.enqueued).toBe(1);
+    expect(r.errors).toHaveLength(0);
+    const jobs = await engine.executeRaw<{ data: { slug: string } }>(
+      `SELECT data FROM minion_jobs WHERE name='chronicle_extract'`,
+    );
+    expect(jobs.map(job => job.data.slug)).toEqual(['meetings/eligible']);
+  });
 });

--- a/test/e2e/engine-parity-salience.test.ts
+++ b/test/e2e/engine-parity-salience.test.ts
@@ -49,6 +49,44 @@ async function seedFixture(engine: BrainEngine): Promise<void> {
         SET updated_at = now() - interval '1 day' - (random() * interval '29 days')
       WHERE slug LIKE 'notes/random-%'`
   );
+  await engine.executeRaw(
+    `UPDATE pages SET emotional_weight = 0.5
+      WHERE slug LIKE 'personal/wedding/%'`,
+  );
+
+  for (const slug of [
+    'eligibility/past-zero',
+    'eligibility/today-zero',
+    'eligibility/future-zero',
+    'eligibility/future-emotional',
+    'eligibility/future-take',
+    'eligibility/deleted',
+  ]) {
+    await engine.putPage(slug, {
+      type: 'note',
+      title: slug,
+      compiled_truth: 'salience parity fixture',
+    });
+  }
+  await engine.executeRaw(
+    `UPDATE pages
+        SET effective_date = CASE slug
+          WHEN 'eligibility/past-zero' THEN now() - interval '1 day'
+          WHEN 'eligibility/today-zero' THEN now()
+          ELSE now() + interval '30 days'
+        END
+      WHERE slug LIKE 'eligibility/%'`,
+  );
+  await engine.executeRaw(
+    `UPDATE pages SET emotional_weight = 0.1
+      WHERE slug = 'eligibility/future-emotional'`,
+  );
+  await engine.executeRaw(
+    `INSERT INTO takes (page_id, row_num, claim, kind, holder, weight, active)
+       SELECT id, 1, 'future signal', 'take', 'self', 0.7, TRUE
+         FROM pages WHERE slug = 'eligibility/future-take'`,
+  );
+  await engine.softDeletePage('eligibility/deleted');
 }
 
 describeBoth('v0.29 engine parity — getRecentSalience', () => {
@@ -86,6 +124,27 @@ describeBoth('v0.29 engine parity — getRecentSalience', () => {
     const postgresWedding = new Set(postgresRows.filter(r => r.slug.startsWith('personal/wedding/')).map(r => r.slug));
     expect(pgliteWedding.size).toBe(postgresWedding.size);
     for (const s of pgliteWedding) expect(postgresWedding.has(s)).toBe(true);
+  });
+
+  test('future eligibility, deletion, finite scoring, and explicit inclusion match', async () => {
+    for (const includeFuture of [false, true]) {
+      const opts = {
+        days: 7,
+        limit: 20,
+        slugPrefix: 'eligibility/',
+        recency_bias: 'on' as const,
+        includeFuture,
+      };
+      const pgliteRows = await pglite.getRecentSalience(opts);
+      const postgresRows = await postgres.getRecentSalience(opts);
+      const pgliteSlugs = pgliteRows.map(row => row.slug).sort();
+      const postgresSlugs = postgresRows.map(row => row.slug).sort();
+      expect(pgliteSlugs).toEqual(postgresSlugs);
+      expect(pgliteRows.every(row => Number.isFinite(row.score))).toBe(true);
+      expect(postgresRows.every(row => Number.isFinite(row.score))).toBe(true);
+      expect(pgliteSlugs).not.toContain('eligibility/deleted');
+      expect(pgliteSlugs.includes('eligibility/future-zero')).toBe(includeFuture);
+    }
   });
 });
 

--- a/test/e2e/salience-pglite.test.ts
+++ b/test/e2e/salience-pglite.test.ts
@@ -64,6 +64,44 @@ beforeAll(async () => {
     weight: computeEmotionalWeight({ tags: r.tags, takes: r.takes }),
   }));
   await engine.setEmotionalWeightBatch(writes);
+
+  // Eligibility fixture: zero-signal past/today pages remain useful, while
+  // a routine future page is hidden unless requested. Future pages with an
+  // explicit emotional/take signal remain eligible. Soft-deleted rows never
+  // surface, including under includeFuture.
+  for (const slug of [
+    'eligibility/past-zero',
+    'eligibility/today-zero',
+    'eligibility/future-zero',
+    'eligibility/future-emotional',
+    'eligibility/future-take',
+    'eligibility/deleted',
+  ]) {
+    await engine.putPage(slug, {
+      type: 'note',
+      title: slug,
+      compiled_truth: 'salience eligibility fixture',
+    });
+  }
+  await engine.executeRaw(
+    `UPDATE pages
+        SET effective_date = CASE slug
+          WHEN 'eligibility/past-zero' THEN now() - interval '1 day'
+          WHEN 'eligibility/today-zero' THEN now()
+          ELSE now() + interval '30 days'
+        END
+      WHERE slug LIKE 'eligibility/%'`,
+  );
+  await engine.executeRaw(
+    `UPDATE pages SET emotional_weight = 0.1
+      WHERE slug = 'eligibility/future-emotional'`,
+  );
+  await engine.executeRaw(
+    `INSERT INTO takes (page_id, row_num, claim, kind, holder, weight, active)
+       SELECT id, 1, 'future signal', 'take', 'self', 0.7, TRUE
+         FROM pages WHERE slug = 'eligibility/future-take'`,
+  );
+  await engine.softDeletePage('eligibility/deleted');
 });
 
 afterAll(async () => {
@@ -111,5 +149,37 @@ describe('v0.29 E2E — getRecentSalience (Garry test)', () => {
   test('empty-window slugPrefix returns []', async () => {
     const rows = await engine.getRecentSalience({ days: 7, slugPrefix: 'nope/does-not-exist/' });
     expect(rows).toEqual([]);
+  });
+
+  test('default excludes only future zero-signal and soft-deleted fixtures', async () => {
+    const rows = await engine.getRecentSalience({
+      days: 7,
+      limit: 20,
+      slugPrefix: 'eligibility/',
+      recency_bias: 'on',
+    });
+    const slugs = new Set(rows.map(row => row.slug));
+    expect(slugs).toEqual(new Set([
+      'eligibility/past-zero',
+      'eligibility/today-zero',
+      'eligibility/future-emotional',
+      'eligibility/future-take',
+    ]));
+    expect(rows.every(row => Number.isFinite(row.score))).toBe(true);
+  });
+
+  test('includeFuture admits routine future pages but never deleted pages', async () => {
+    const rows = await engine.getRecentSalience({
+      days: 7,
+      limit: 20,
+      slugPrefix: 'eligibility/',
+      recency_bias: 'on',
+      includeFuture: true,
+    });
+    const slugs = new Set(rows.map(row => row.slug));
+    expect(slugs.has('eligibility/future-zero')).toBe(true);
+    expect(slugs.has('eligibility/deleted')).toBe(false);
+    expect(rows).toHaveLength(5);
+    expect(rows.every(row => Number.isFinite(row.score))).toBe(true);
   });
 });

--- a/test/e2e/schema-cathedral.test.ts
+++ b/test/e2e/schema-cathedral.test.ts
@@ -15,6 +15,7 @@ import { runDetect } from '../../src/core/schema-pack/detect.ts';
 import { runReviewCandidates, runReviewOrphans } from '../../src/core/schema-pack/review.ts';
 import { knobsHash } from '../../src/core/search/mode.ts';
 import { detectArtifactKind, validateManifestByKind } from '../../src/core/artifact/index.ts';
+import type { OperationContext } from '../../src/core/operations.ts';
 
 let engine: PGLiteEngine;
 
@@ -98,6 +99,30 @@ describe('v0.39 T22b — federated_read 2-source pack-divergence', () => {
     expect(SchemaPackTrustGateError.prototype).toBeDefined();
     const err = new SchemaPackTrustGateError('test');
     expect(err.code).toBe('permission_denied');
+  });
+});
+
+describe('active-pack orphan review', () => {
+  test('shared core distinguishes untyped from undeclared stored types', async () => {
+    await seedPages([
+      { slug: 'people/declared', type: 'person' },
+      { slug: 'custom/undeclared', type: 'synthetic-record' },
+    ]);
+    await engine.executeRaw(
+      `INSERT INTO pages (slug, source_id, source_path, type, title, compiled_truth, timeline, content_hash)
+       VALUES ('misc/untyped', 'default', 'misc/untyped.md', '', 'untyped', '', '', '')`,
+    );
+    const context = {
+      engine,
+      config: {},
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      dryRun: false,
+      remote: false,
+    } as unknown as OperationContext;
+    const result = await runReviewOrphans(context, { sourceId: 'default' });
+    expect(result.orphans.find((row) => row.slug === 'people/declared')).toBeUndefined();
+    expect(result.orphans.find((row) => row.slug === 'custom/undeclared')?.reason).toBe('undeclared_type');
+    expect(result.orphans.find((row) => row.slug === 'misc/untyped')?.reason).toBe('untyped');
   });
 });
 

--- a/test/e2e/v0_29-mcp-dispatch-pglite.test.ts
+++ b/test/e2e/v0_29-mcp-dispatch-pglite.test.ts
@@ -62,6 +62,16 @@ beforeAll(async () => {
     weight: computeEmotionalWeight({ tags: r.tags, takes: r.takes }),
   }));
   await engine.setEmotionalWeightBatch(rows);
+
+  await engine.putPage('future/routine', {
+    type: 'note',
+    title: 'Routine future page',
+    compiled_truth: 'No structured salience signal.',
+  });
+  await engine.executeRaw(
+    `UPDATE pages SET effective_date = now() + interval '30 days'
+      WHERE slug = 'future/routine'`,
+  );
 });
 
 afterAll(async () => {
@@ -83,6 +93,27 @@ describe('v0.29 E2E — dispatchToolCall for the three new ops', () => {
     expect(rows.length).toBeGreaterThan(0);
     // Wedding pages should be at or near the top (max tag-emotion boost).
     expect(rows[0].slug).toMatch(/^personal\/wedding\//);
+  });
+
+  test('get_recent_salience honors include_future through MCP dispatch', async () => {
+    const hidden = await dispatchToolCall(engine, 'get_recent_salience', {
+      days: 7,
+      slugPrefix: 'future/',
+      recency_bias: 'on',
+    }, { remote: true });
+    const included = await dispatchToolCall(engine, 'get_recent_salience', {
+      days: 7,
+      slugPrefix: 'future/',
+      recency_bias: 'on',
+      include_future: true,
+    }, { remote: true });
+
+    expect(hidden.isError).toBeFalsy();
+    expect(included.isError).toBeFalsy();
+    expect(JSON.parse(hidden.content[0].text)).toEqual([]);
+    const rows = JSON.parse(included.content[0].text);
+    expect(rows.map((row: { slug: string }) => row.slug)).toEqual(['future/routine']);
+    expect(Number.isFinite(rows[0].score)).toBe(true);
   });
 
   test('find_anomalies returns cohort outliers via the MCP dispatch path', async () => {

--- a/test/extract-incremental.test.ts
+++ b/test/extract-incremental.test.ts
@@ -11,7 +11,7 @@ import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } fr
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { runExtractCore } from '../src/commands/extract.ts';
+import { extractTimelineForSlugs, runExtractCore } from '../src/commands/extract.ts';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
@@ -189,5 +189,26 @@ describe('runExtractCore — incremental cycle path (#417)', () => {
     expect(result.pages_processed).toBe(1);
     // Link from alice to bob was extracted successfully via the full allSlugs set
     expect(result.links_created).toBeGreaterThan(0);
+  });
+
+  test('9. canonical timeline projection is source-scoped and idempotent', async () => {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, config) VALUES ('other', 'other', '{}'::jsonb) ON CONFLICT DO NOTHING`,
+    );
+    await engine.putPage('people/alice-example', {
+      type: 'person', title: 'default alice', compiled_truth: '', timeline: '', frontmatter: {}, content_hash: 'default',
+    }, { sourceId: 'default' });
+    await engine.putPage('people/alice-example', {
+      type: 'person', title: 'other alice', compiled_truth: '', timeline: '', frontmatter: {}, content_hash: 'other',
+    }, { sourceId: 'other' });
+    writeFileSync(join(tempDir, 'people/alice-example.md'), '- 2026-07-11 — Canonical event');
+
+    await extractTimelineForSlugs(engine, tempDir, ['people/alice-example'], { sourceId: 'other' });
+    await extractTimelineForSlugs(engine, tempDir, ['people/alice-example'], { sourceId: 'other' });
+
+    expect(await engine.getTimeline('people/alice-example', { sourceId: 'default' })).toHaveLength(0);
+    const otherTimeline = await engine.getTimeline('people/alice-example', { sourceId: 'other' });
+    expect(otherTimeline).toHaveLength(1);
+    expect(otherTimeline[0]).toMatchObject({ source: 'markdown', summary: 'Canonical event' });
   });
 });

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -135,6 +135,16 @@ describe('extractTimelineFromContent', () => {
     const entries = extractTimelineFromContent(content, 'test');
     expect(entries).toHaveLength(1);
   });
+
+  it('is a source-defaulting adapter over the shared canonical parser', () => {
+    expect(extractTimelineFromContent('- 2026-07-11 — Canonical event', 'people/test')).toEqual([{
+      slug: 'people/test',
+      date: '2026-07-11',
+      source: 'markdown',
+      summary: 'Canonical event',
+      detail: undefined,
+    }]);
+  });
 });
 
 describe('walkMarkdownFiles', () => {

--- a/test/link-extraction.test.ts
+++ b/test/link-extraction.test.ts
@@ -662,27 +662,15 @@ describe('inferLinkType', () => {
 // ─── parseTimelineEntries ──────────────────────────────────────
 
 describe('parseTimelineEntries', () => {
-  test('parses standard format: - **YYYY-MM-DD** | summary', () => {
-    const entries = parseTimelineEntries('- **2026-01-15** | Met with Alice');
-    expect(entries.length).toBe(1);
-    expect(entries[0]).toEqual({ date: '2026-01-15', summary: 'Met with Alice', detail: '' });
-  });
-
-  test('parses dash variant: - **YYYY-MM-DD** -- summary', () => {
-    const entries = parseTimelineEntries('- **2026-01-15** -- Met with Bob');
-    expect(entries.length).toBe(1);
-    expect(entries[0].summary).toBe('Met with Bob');
-  });
-
-  test('parses single dash: - **YYYY-MM-DD** - summary', () => {
-    const entries = parseTimelineEntries('- **2026-01-15** - Met with Carol');
-    expect(entries.length).toBe(1);
-    expect(entries[0].summary).toBe('Met with Carol');
-  });
-
-  test('parses without leading dash: **YYYY-MM-DD** | summary', () => {
-    const entries = parseTimelineEntries('**2026-01-15** | Standalone entry');
-    expect(entries.length).toBe(1);
+  test.each([
+    ['- **2026-01-15** | Met with Alice', { date: '2026-01-15', summary: 'Met with Alice', detail: '' }],
+    ['- **2026-01-15** | Meeting — Discussed partnership', { date: '2026-01-15', source: 'Meeting', summary: 'Discussed partnership', detail: '' }],
+    ['- **2026-01-15** -- Met with Bob', { date: '2026-01-15', summary: 'Met with Bob', detail: '' }],
+    ['- **2026-01-15** - Met with Carol', { date: '2026-01-15', summary: 'Met with Carol', detail: '' }],
+    ['**2026-01-15** | Standalone entry', { date: '2026-01-15', summary: 'Standalone entry', detail: '' }],
+    ['- 2026-01-15 — Canonical entity event', { date: '2026-01-15', summary: 'Canonical entity event', detail: '' }],
+  ])('parses supported timeline form %s', (line, expected) => {
+    expect(parseTimelineEntries(line)).toEqual([expected]);
   });
 
   test('parses multiple entries', () => {
@@ -706,7 +694,27 @@ describe('parseTimelineEntries', () => {
   });
 
   test('returns empty when no timeline lines found', () => {
-    expect(parseTimelineEntries('Just some plain text.')).toEqual([]);
+    expect(parseTimelineEntries('Just some plain text about 2026-01-15 — not a timeline bullet.')).toEqual([]);
+  });
+
+  test('preserves duplicate candidates for the idempotent write boundary', () => {
+    const line = '- 2026-01-15 — Repeated event';
+    expect(parseTimelineEntries(`${line}\n${line}`)).toHaveLength(2);
+  });
+
+  test('parses header detail until the next peer heading', () => {
+    const entries = parseTimelineEntries(`### 2026-01-15 — Round Closed
+
+All docs signed.
+#### Participants
+Alice and Bob.
+### 2026-02-01 — Launch`);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toEqual({
+      date: '2026-01-15',
+      summary: 'Round Closed',
+      detail: 'All docs signed. #### Participants Alice and Bob.',
+    });
   });
 
   test('handles mixed content (timeline lines interspersed with prose)', () => {
@@ -1264,4 +1272,3 @@ describe("v0.18.0 migration v22 — links_resolution_type", () => {
     expect(v22!.sql).toContain("unqualified");
   });
 });
-

--- a/test/operations-schema-pack.test.ts
+++ b/test/operations-schema-pack.test.ts
@@ -47,7 +47,7 @@ afterEach(() => {
   }
 });
 
-function ctxOf(opts: { remote?: boolean; clientId?: string; sourceId?: string } = {}): OperationContext {
+function ctxOf(opts: { remote?: boolean; clientId?: string; sourceId?: string; allowedSources?: string[] } = {}): OperationContext {
   return {
     engine,
     config: {},
@@ -55,7 +55,9 @@ function ctxOf(opts: { remote?: boolean; clientId?: string; sourceId?: string } 
     dryRun: false,
     remote: opts.remote ?? true,
     sourceId: opts.sourceId,
-    auth: opts.clientId ? { clientId: opts.clientId, scopes: ['admin'] } : undefined,
+    auth: opts.clientId || opts.allowedSources
+      ? { clientId: opts.clientId ?? 'test-client', scopes: ['admin'], allowedSources: opts.allowedSources }
+      : undefined,
   } as unknown as OperationContext;
 }
 
@@ -242,6 +244,46 @@ describe('schema_review_orphans', () => {
     }
     const result = await operationsByName.schema_review_orphans!.handler(ctxOf(), { limit: 2 }) as Record<string, unknown>;
     expect(result.orphan_count).toBe(2);
+  });
+
+  it('uses active-pack semantics and returns a reason without page content', async () => {
+    await withEnv({ GBRAIN_HOME: tmpDir, GBRAIN_SCHEMA_PACK: 'mine' }, async () => {
+      const packPath = seedPack('mine');
+      __setPackLocatorForTests((name) => name === 'mine' ? packPath : null);
+      await engine.executeRaw(
+        `INSERT INTO pages (slug, source_id, source_path, type, title, compiled_truth, timeline, content_hash)
+         VALUES
+           ('declared', 'default', 'people/declared.md', 'person', 'd', 'private body', '', ''),
+           ('undeclared', 'default', 'custom/u.md', 'custom-record', 'u', 'private body', '', ''),
+           ('untyped', 'default', 'misc/x.md', '', 'x', 'private body', '', '')`,
+      );
+      const result = await operationsByName.schema_review_orphans!.handler(ctxOf(), {}) as {
+        orphan_count: number;
+        orphans: Array<Record<string, unknown>>;
+      };
+      expect(result.orphan_count).toBe(2);
+      expect(result.orphans).toEqual([
+        { slug: 'undeclared', source_id: 'default', stored_type: 'custom-record', reason: 'undeclared_type' },
+        { slug: 'untyped', source_id: 'default', stored_type: null, reason: 'untyped' },
+      ]);
+      expect(JSON.stringify(result)).not.toContain('private body');
+    });
+  });
+
+  it('honors federated source scope before returning conformance gaps', async () => {
+    await engine.executeRaw(`INSERT INTO sources (id, name) VALUES ('src-a','a'), ('src-b','b'), ('src-c','c')`);
+    for (const source of ['src-a', 'src-b', 'src-c']) {
+      await engine.executeRaw(
+        `INSERT INTO pages (slug, source_id, source_path, type, title, compiled_truth, timeline, content_hash)
+         VALUES ($1, $2, $3, '', $1, '', '', '')`,
+        [`gap-${source}`, source, `${source}/gap.md`],
+      );
+    }
+    const result = await operationsByName.schema_review_orphans!.handler(
+      ctxOf({ allowedSources: ['src-a', 'src-b'] }),
+      {},
+    ) as { orphans: Array<{ source_id: string }> };
+    expect(result.orphans.map((row) => row.source_id).sort()).toEqual(['src-a', 'src-b']);
   });
 });
 

--- a/test/recency-decay.test.ts
+++ b/test/recency-decay.test.ts
@@ -160,8 +160,26 @@ describe('buildRecencyComponentSql', () => {
       decayMap: mini,
       fallback: DEFAULT_FALLBACK,
     });
-    expect(sql).toContain('EXTRACT(EPOCH FROM (NOW() - p.updated_at)) / 86400.0');
-    expect(sql).toContain('1.5 * 14.0 / (14.0 + EXTRACT(EPOCH');
+    expect(sql).toContain(
+      'GREATEST(0.0, EXTRACT(EPOCH FROM (NOW() - p.updated_at)) / 86400.0)',
+    );
+    expect(sql).toContain('1.5 * 14.0 / (14.0 + GREATEST(0.0, EXTRACT(EPOCH');
+  });
+
+  test('clamps every non-zero branch and fallback denominator', () => {
+    const sql = buildRecencyComponentSql({
+      slugColumn: 'p.slug',
+      dateExpr: 'COALESCE(p.effective_date, p.updated_at)',
+      decayMap: {
+        'daily/': { halflifeDays: 14, coefficient: 1.5 },
+        'media/': { halflifeDays: 90, coefficient: 0.5 },
+        'concepts/': { halflifeDays: 0, coefficient: 0 },
+      },
+      fallback: { halflifeDays: 30, coefficient: 1 },
+    });
+    const clamps = sql.match(/GREATEST\(0\.0, EXTRACT\(EPOCH/g) ?? [];
+    expect(clamps).toHaveLength(3);
+    expect(sql).not.toMatch(/\+ EXTRACT\(EPOCH/);
   });
 
   test('NowExpr.fixed is escaped (single-quote doubling) and timestamptz-cast', () => {

--- a/test/salience-controls.test.ts
+++ b/test/salience-controls.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildSalienceQueryArgs,
+  parseSalienceArgs,
+  runSalience,
+} from '../src/commands/salience.ts';
+import {
+  operations,
+  type OperationContext,
+} from '../src/core/operations.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+
+describe('salience CLI controls', () => {
+  test('parses explicit recency and future controls', () => {
+    expect(parseSalienceArgs([
+      '--days', '7',
+      '--limit', '12',
+      '--slug-prefix', 'daily/',
+      '--recency-bias', 'on',
+      '--include-future',
+      '--json',
+    ])).toEqual({
+      days: 7,
+      limit: 12,
+      slugPrefix: 'daily/',
+      recencyBias: 'on',
+      includeFuture: true,
+      json: true,
+    });
+  });
+
+  test('maps identical semantics to local camelCase and MCP snake_case', () => {
+    const parsed = parseSalienceArgs([
+      '--recency-bias', 'on',
+      '--include-future',
+    ]);
+    if ('help' in parsed) throw new Error('unexpected help result');
+    const mapped = buildSalienceQueryArgs(parsed);
+    expect(mapped.engine.recency_bias).toBe('on');
+    expect(mapped.engine.includeFuture).toBe(true);
+    expect(mapped.remote.recency_bias).toBe('on');
+    expect(mapped.remote.include_future).toBe(true);
+  });
+
+  test('invalid recency modes do not escape the typed control', () => {
+    expect(parseSalienceArgs(['--recency-bias', 'turbo'])).toEqual({});
+  });
+
+  test('local CLI forwards both controls to the engine', async () => {
+    let captured: unknown;
+    const engine = {
+      getRecentSalience: async (opts: unknown) => {
+        captured = opts;
+        return [];
+      },
+    } as unknown as BrainEngine;
+    const originalLog = console.log;
+    console.log = () => {};
+    try {
+      await runSalience(engine, [
+        '--days', '3',
+        '--recency-bias', 'on',
+        '--include-future',
+        '--json',
+      ]);
+    } finally {
+      console.log = originalLog;
+    }
+    expect(captured).toMatchObject({
+      days: 3,
+      recency_bias: 'on',
+      includeFuture: true,
+    });
+  });
+});
+
+describe('get_recent_salience operation contract', () => {
+  const operation = operations.find(op => op.name === 'get_recent_salience');
+
+  test('publishes include_future as a boolean parameter', () => {
+    expect(operation).toBeDefined();
+    expect(operation!.params.include_future).toMatchObject({ type: 'boolean' });
+  });
+
+  test('normalizes MCP parameters to engine options', async () => {
+    let captured: unknown;
+    const engine = {
+      getRecentSalience: async (opts: unknown) => {
+        captured = opts;
+        return [];
+      },
+    } as unknown as BrainEngine;
+    const ctx = {
+      engine,
+      config: { engine: 'pglite' },
+      logger: { info() {}, warn() {}, error() {} },
+      dryRun: false,
+      remote: true,
+    } as unknown as OperationContext;
+
+    await operation!.handler(ctx, {
+      days: 5,
+      limit: 9,
+      slugPrefix: 'daily/',
+      recency_bias: 'on',
+      include_future: true,
+    });
+
+    expect(captured).toEqual({
+      days: 5,
+      limit: 9,
+      slugPrefix: 'daily/',
+      recency_bias: 'on',
+      includeFuture: true,
+    });
+  });
+});

--- a/test/schema-pack-stats.test.ts
+++ b/test/schema-pack-stats.test.ts
@@ -69,13 +69,13 @@ async function seedPage(slug: string, opts: { type?: string; sourceId?: string; 
   );
 }
 
-function seedTinyPack(packName: string, types: Array<{ name: string; prefix: string }>): void {
+function seedTinyPack(packName: string, types: Array<{ name: string; prefix: string; aliases?: string[] }>): void {
   const dir = join(tmpDir, packName);
   mkdirSync(dir, { recursive: true });
   const path = join(dir, 'pack.yaml');
   let body = `api_version: gbrain-schema-pack-v1\nname: ${packName}\nversion: 1.0.0\ndescription: ""\ngbrain_min_version: 0.38.0\nextends: null\nborrow_from: []\npage_types:\n`;
   for (const t of types) {
-    body += `  - name: ${t.name}\n    primitive: entity\n    path_prefixes:\n      - ${t.prefix}\n    aliases: []\n    extractable: false\n    expert_routing: false\n`;
+    body += `  - name: ${t.name}\n    primitive: entity\n    path_prefixes:\n      - ${t.prefix}\n    aliases: [${(t.aliases ?? []).join(', ')}]\n    extractable: false\n    expert_routing: false\n`;
   }
   body += `link_types: []\nfrontmatter_links: []\ntakes_kinds:\n  - fact\n  - take\n  - bet\n  - hunch\nenrichable_types: []\nfiling_rules: []\n`;
   writeFileSync(path, body, 'utf-8');
@@ -236,6 +236,66 @@ describe('runStatsCore — type/untyped split', () => {
       expect(result.aggregate.typed_pages).toBe(1);
       // empty-string type does NOT appear as its own type bucket.
       expect(result.aggregate.by_type.find((t) => t.type === '')).toBeUndefined();
+    });
+  });
+});
+
+describe('runStatsCore — active-pack conformance', () => {
+  it('adds declared/undeclared metrics without changing legacy coverage', async () => {
+    await withEnv({ GBRAIN_HOME: tmpDir, GBRAIN_SCHEMA_PACK: 'tiny' }, async () => {
+      seedTinyPack('tiny', [
+        { name: 'person', prefix: 'people/', aliases: ['researcher'] },
+        { name: 'researcher', prefix: 'researchers/' },
+      ]);
+      await seedPage('people/a', { type: 'person' });
+      await seedPage('researchers/b', { type: 'researcher' });
+      await seedPage('custom/c', { type: 'custom-record' });
+      await seedPage('untyped/d');
+
+      const result = await runStatsCore(ctxOf());
+      expect(result.schema_version).toBe(1);
+      expect(result.aggregate.typed_pages).toBe(3);
+      expect(result.aggregate.coverage).toBe(0.75);
+      expect(result.aggregate.declared_pages).toBe(2);
+      expect(result.aggregate.undeclared_pages).toBe(1);
+      expect(result.aggregate.untyped_pages).toBe(1);
+      expect(result.aggregate.declared_coverage).toBe(0.5);
+      expect(result.aggregate.undeclared_types).toEqual([{ type: 'custom-record', count: 1 }]);
+      expect(
+        result.aggregate.declared_pages +
+        result.aggregate.undeclared_pages +
+        result.aggregate.untyped_pages,
+      ).toBe(result.aggregate.total_pages);
+    });
+  });
+
+  it('treats all nonempty types as undeclared when no pack resolves', async () => {
+    await withEnv({ GBRAIN_SCHEMA_PACK: 'missing-pack' }, async () => {
+      __setPackLocatorForTests(() => null);
+      await seedPage('a', { type: 'person' });
+      await seedPage('b');
+      const result = await runStatsCore(ctxOf());
+      expect(result.pack_identity).toBeNull();
+      expect(result.aggregate.typed_pages).toBe(1);
+      expect(result.aggregate.declared_pages).toBe(0);
+      expect(result.aggregate.undeclared_pages).toBe(1);
+      expect(result.aggregate.declared_coverage).toBe(0);
+      expect(result.aggregate.undeclared_types).toEqual([{ type: 'person', count: 1 }]);
+    });
+  });
+
+  it('computes conformance independently for each federated source', async () => {
+    await withEnv({ GBRAIN_HOME: tmpDir, GBRAIN_SCHEMA_PACK: 'tiny' }, async () => {
+      seedTinyPack('tiny', [{ name: 'person', prefix: 'people/' }]);
+      await seedPage('a', { type: 'person', sourceId: 'src-a' });
+      await seedPage('b', { type: 'custom-record', sourceId: 'src-b' });
+      await seedPage('c', { type: 'custom-record', sourceId: 'src-c' });
+      const result = await runStatsCore(ctxOf(), { sourceIds: ['src-a', 'src-b'] });
+      expect(result.aggregate.total_pages).toBe(2);
+      expect(result.aggregate.declared_pages).toBe(1);
+      expect(result.aggregate.undeclared_pages).toBe(1);
+      expect(result.per_source.find((s) => s.source_id === 'src-a')?.declared_pages).toBe(1);
+      expect(result.per_source.find((s) => s.source_id === 'src-b')?.undeclared_pages).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Header links

Local artifacts: `.humanlayer/tasks/advance-gbrain-knowledge-system/` · Local walkthrough: `.humanlayer/tasks/advance-gbrain-knowledge-system/pr-walkthrough.html`

## What problems was I solving

GBrain had three generic contract gaps that kept a well-indexed brain from materializing trustworthy structured knowledge:

1. Filesystem timeline extraction used a narrower parser than DB, stale-extraction, and trusted `put_page` paths. A readable canonical bullet such as `- YYYY-MM-DD — event` was ignored, and an incremental sync could stamp a page even though another extraction path would derive different rows.
2. Salience did not filter soft-deleted pages or distinguish routine future-effective pages from meaningful future pages. Recency-biased scoring could also feed negative age into its denominator.
3. Schema stats treated every nonempty stored type as covered, even if the active pack did not declare it. `schema_review_orphans` described active-pack conformance but returned only empty types.

This PR makes the timeline contract deterministic, makes future salience safe and explicit, and adds truthful active-pack conformance without breaking existing response fields.

## What user-facing changes did I ship

- [`src/core/link-extraction.ts`](https://github.com/garrytan/gbrain/pull/2749/files#diff-15e35b73f5c590e8975e1d28807fad726eacc71c48357f09ebccff84fa173d6f) recognizes the existing bold-date forms, canonical plain-date bullets, and dated level-three headings through one validated parser.
- [`src/commands/extract.ts`](https://github.com/garrytan/gbrain/pull/2749/files#diff-ae76a68f8c95649890a583b2626af1c33ab651513ab9fc31b413862aea94a8e6) routes filesystem, DB, incremental, and stale timeline extraction through that shared representation while preserving provenance and source scoping.
- [`src/commands/salience.ts`](https://github.com/garrytan/gbrain/pull/2749/files#diff-24b81ca46d77f4808ac81ce6746d40e39d626f4f7d15b835021d787f77a196a7) adds `--recency-bias flat|on` and `--include-future`, with equivalent thin-client payloads.
- [`src/core/postgres-engine.ts`](https://github.com/garrytan/gbrain/pull/2749/files#diff-16f634ce7f5d182a5954636ce79698778f823d3cfb05dd799f4b7ff8e08cd1c6) and [`src/core/pglite-engine.ts`](https://github.com/garrytan/gbrain/pull/2749/files#diff-6bac3a1062787d9a706dede51b5bb7cc364ce09b7f1e627f2a0efb351632b5c3) exclude deleted pages and suppress future zero-signal pages unless explicitly included.
- [`src/core/schema-pack/stats.ts`](https://github.com/garrytan/gbrain/pull/2749/files#diff-efbd9acdcefb96cce573545e1e9fd7df9a41914af209bd23607c7467d2c9613a) adds declared/undeclared page counts, declared coverage, and bounded undeclared-type aggregates alongside the legacy typed/untyped fields.
- [`src/core/schema-pack/review.ts`](https://github.com/garrytan/gbrain/pull/2749/files#diff-6c9a8c38633101ee9a55672874225738332b0bc4ec0075e1c403a9a61be013d5) makes CLI and MCP orphan review agree on `untyped` versus `undeclared_type`, including federated source scope.
- [`src/core/advisor/collect-schema-pack.ts`](https://github.com/garrytan/gbrain/pull/2749/files#diff-f6031817d21c2313196eaec5614f668707b02c1a2fbac4b428813c3286c5cc3c) surfaces material active-pack drift without auto-mutation.

## How I implemented it

### Timeline materialization

`parseTimelineEntries` is now the only deterministic legacy timeline parser. `extractTimelineFromContent` is a filesystem adapter over it, and every projection maps the optional parsed source or defaults it to `markdown`. Dry-run dedup keys include provenance, so two otherwise identical events from different sources are not silently collapsed. Chronicle remains a separate event-page pipeline for eligible meetings, conversations, and calendar pages.

### Salience safety and parity

The engine contract adds an optional `includeFuture` flag; MCP exposes `include_future`. Both engines apply the same eligibility predicate:

- soft-deleted pages are always excluded;
- past/present/no-effective-date pages remain eligible even with zero structured signal;
- future pages remain eligible when they carry emotional weight or an active take;
- routine future pages require explicit opt-in.

The shared SQL ranking helper clamps age with `GREATEST(0.0, ...)`, keeping future recency finite.

### Schema conformance

The stable stored-typing metric remains unchanged. The new additive invariant is:

```text
declared_pages + undeclared_pages + untyped_pages = total_pages
```

Schema reads resolve the DB-backed active-pack tiers before classifying stored types. The shared review core returns bounded slugs, stored types, and reasons—never page bodies. Advisor findings are thresholded to avoid noise and recommend preview/read operations.

## Deviations from the plan

### Implemented as planned

- Shared parser and canonical timeline syntax, source/default behavior, Chronicle separation, source scoping, and idempotency.
- CLI/MCP future controls, deleted/future eligibility, nonnegative recency, and Postgres/PGLite parity code.
- Additive schema conformance, shared orphan-review semantics, advisor findings, public documentation, and synthetic privacy-safe tests.

### Deviations and surprises

- Advisor is whole-brain because `AdvisorContext` has no source-scope field; CLI/MCP schema stats and orphan review remain source-aware.
- No extraction-lag advisor was added because `getHealth` does not currently expose that value. Doctor remains its canonical surface.
- Low entity link/timeline findings use a ten-entity minimum to avoid noisy advice on tiny brains.
- Timeline dry-run dedup now includes provenance, a contract-consistent addition discovered while unifying parsers.

### Planned but not part of this public PR

- Private schema packs, private health content, deployment configuration, production backfills, and worker scheduling remain deliberately separate.
- Real-Postgres salience parity is encoded in `test/e2e/engine-parity-salience.test.ts`; the local Mac had no Docker/Postgres runtime, so CI is the authoritative execution lane.

## How to verify it

```bash
git fetch origin pull/2749/head:pr-2749
git worktree add ../gbrain-pr-2749 pr-2749
cd ../gbrain-pr-2749
bun install --frozen-lockfile

bun test test/link-extraction.test.ts test/extract.test.ts \
  test/extract-incremental.test.ts test/chronicle-backfill.test.ts
bun test test/salience-controls.test.ts test/recency-decay.test.ts \
  test/e2e/salience-pglite.test.ts test/e2e/v0_29-mcp-dispatch-pglite.test.ts
bun test test/schema-pack-stats.test.ts test/operations-schema-pack.test.ts \
  test/e2e/schema-cathedral.test.ts test/advisor-core.test.ts
bun run verify
```

With `DATABASE_URL` pointing at a disposable pgvector-enabled Postgres database:

```bash
bun test test/e2e/engine-parity-salience.test.ts
```

Manual checks:

- Run filesystem extraction over a page containing `- 2026-07-11 — event`; confirm one `source=markdown` timeline candidate.
- Compare `gbrain salience --json` with and without `--include-future`.
- Compare `gbrain schema stats --json` with `schema_review_orphans` over declared, undeclared, and empty-type fixtures.

## Description for the changelog

Unify timeline extraction, make future salience safe and explicit, and report active-pack schema conformance without breaking legacy metrics.
