### PR TITLE
fix(sync): refresh freshness on no-op sync

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1001,6 +1001,23 @@ async function writeSyncAnchor(
   await engine.setConfig(`sync.${which}`, value);
 }
 
+async function markSyncChecked(
+  engine: BrainEngine,
+  sourceId: string | undefined,
+): Promise<void> {
+  if (sourceId) {
+    // Successful no-op syncs are still freshness signal: Dream can run daily
+    // and legitimately find no content changes. Keep the content bookmark
+    // untouched while bumping the "sync check completed" timestamp doctor reads.
+    await engine.executeRaw(
+      `UPDATE sources SET last_sync_at = now() WHERE id = $1`,
+      [sourceId],
+    );
+    return;
+  }
+  await engine.setConfig('sync.last_run', new Date().toISOString());
+}
+
 /**
  * v0.20.0 Cathedral II Layer 12 (SP-1 fix) — read/write the chunker version
  * last used to sync a given source. When it mismatches CURRENT_CHUNKER_VERSION,
@@ -1786,6 +1803,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       detachedWorkingTreeManifest.renamed.length > 0);
 
   if (lastCommit === headCommit && !versionMismatch && !versionNeverSet && !hasDetachedWorkingTreeChanges) {
+    await markSyncChecked(engine, opts.sourceId);
     return {
       status: 'up_to_date',
       fromCommit: lastCommit,

--- a/test/sync-resumable-import.serial.test.ts
+++ b/test/sync-resumable-import.serial.test.ts
@@ -292,6 +292,41 @@ describe('#1794 — resumable incremental sync (pinned target)', () => {
     expect(banked).not.toContain('notes/bad.md');
   }, 60_000);
 
+  test('source-scoped no-op sync refreshes last_sync_at without advancing last_commit', async () => {
+    const { performSync } = await import('../src/commands/sync.ts');
+
+    const sid = 'srcNoopFreshness';
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name, local_path) VALUES ($1, $2, $3)`,
+      [sid, sid, repoPath],
+    );
+
+    const first = await performSync(engine, { repoPath, sourceId: sid, full: true, noPull: true, noEmbed: true });
+    expect(['first_sync', 'synced']).toContain(first.status);
+
+    const beforeRows = await engine.executeRaw<{ last_commit: string | null; last_sync_at: string | Date | null }>(
+      `SELECT last_commit, last_sync_at FROM sources WHERE id = $1`, [sid],
+    );
+    const anchoredCommit = beforeRows[0].last_commit!;
+    expect(anchoredCommit).toBeTruthy();
+
+    await engine.executeRaw(
+      `UPDATE sources SET last_sync_at = TIMESTAMPTZ '2000-01-01T00:00:00Z' WHERE id = $1`,
+      [sid],
+    );
+
+    const noop = await performSync(engine, { repoPath, sourceId: sid, noPull: true, noEmbed: true });
+    expect(noop.status).toBe('up_to_date');
+
+    const afterRows = await engine.executeRaw<{ last_commit: string | null; last_sync_at: string | Date | null }>(
+      `SELECT last_commit, last_sync_at FROM sources WHERE id = $1`, [sid],
+    );
+    expect(afterRows[0].last_commit).toBe(anchoredCommit);
+    expect(new Date(String(afterRows[0].last_sync_at)).getTime()).toBeGreaterThan(
+      Date.parse('2000-01-02T00:00:00Z'),
+    );
+  }, 60_000);
+
   // ── F. Codex #3: file added in range but deleted from disk → skip, not block
   test('[Codex #3] vanished-on-disk added file is skipped, not a failure', async () => {
     const { performSync } = await import('../src/commands/sync.ts');


### PR DESCRIPTION
## Summary

Successful no-op syncs currently return `up_to_date` without updating `sources.last_sync_at`. That makes daily Dream/autopilot cycles that correctly find no changes look stale to `doctor sync_freshness` after the freshness window elapses.

This adds a small `markSyncChecked` helper and calls it on the pure HEAD-equality no-op path. It refreshes `last_sync_at` for source-scoped syncs without advancing `last_commit` or touching `newest_content_at`, preserving the blocked/partial-sync safety invariants.

## Test plan

- `bun test test/sync-resumable-import.serial.test.ts`
- `bunx tsc --noEmit`

## Notes

Validated against a dogfood source where nightly Dream had been running daily with `syncStatus: up_to_date`, while `doctor` reported the source as stale because `last_sync_at` had not changed since the last content-bearing sync.