### PR TITLE
fix(cycle): enforce extract-atoms drain deadline

### DIFF
--- a/src/commands/dream.ts
+++ b/src/commands/dream.ts
@@ -449,7 +449,6 @@ async function runDrain(
   engine: BrainEngine,
   opts: DreamArgs,
   resolvedSourceId: string | undefined,
-  brainDir: string | null,
 ): Promise<void> {
   const { LockUnavailableError } = await import('../core/db-lock.ts');
   const { countExtractAtomsBacklog } = await import('../core/cycle/extract-atoms.ts');
@@ -479,7 +478,6 @@ async function runDrain(
     result = await runExtractAtomsDrainForSource(engine, {
       sourceId: resolvedSourceId,
       windowSeconds: opts.windowSeconds,
-      brainDir: brainDir ?? undefined,
       onBatch: opts.json ? undefined : ({ batch, extracted, remaining }) => {
         process.stderr.write(`[drain] batch ${batch}: +${extracted} atom(s), ~${remaining ?? '?'} remaining\n`);
       },
@@ -578,7 +576,7 @@ export async function runDream(engine: BrainEngine | null, args: string[]): Prom
       console.error('gbrain dream --drain requires a connected brain (no engine available)');
       process.exit(1);
     }
-    return runDrain(engine, opts, resolvedSourceId, brainDir);
+    return runDrain(engine, opts, resolvedSourceId);
   }
 
   const phases: CyclePhase[] | undefined = opts.phase ? [opts.phase] : undefined;

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1951,15 +1951,11 @@ export async function registerBuiltinHandlers(
     const sourceId = typeof job.data.sourceId === 'string' ? job.data.sourceId : undefined;
     const windowSeconds =
       typeof job.data.window === 'number' && job.data.window > 0 ? job.data.window : 120;
-    const repoPath =
-      typeof job.data.repoPath === 'string'
-        ? job.data.repoPath
-        : ((await engine.getConfig('sync.repo_path')) ?? undefined);
     try {
       return await runExtractAtomsDrainForSource(engine, {
         sourceId,
         windowSeconds,
-        brainDir: repoPath,
+        abortSignal: job.signal,
       });
     } catch (e) {
       if (e instanceof LockUnavailableError) {

--- a/src/core/cycle/extract-atoms-drain.ts
+++ b/src/core/cycle/extract-atoms-drain.ts
@@ -18,11 +18,14 @@
  *
  * Pure over injected deps: no DB, no LLM, no lock primitive imported here, so
  * the loop logic is unit-testable. The wiring helper `runExtractAtomsDrainForSource`
- * (below) builds the real deps; it uses DYNAMIC imports so this module's static
- * graph stays empty and the pure-loop unit tests don't drag in db-lock / cycle.
+ * (below) builds the real deps; it uses DYNAMIC imports so the pure-loop unit
+ * tests don't drag in db-lock / cycle.
  */
 
 import type { BrainEngine } from '../engine.ts';
+import { anySignal } from '../abort-check.ts';
+
+const LOCK_RELEASE_GRACE_MS = 5_000;
 
 export interface ExtractAtomsDrainDeps {
   /**
@@ -32,11 +35,11 @@ export interface ExtractAtomsDrainDeps {
    * the caller can report `cycle_already_running` and exit, matching the
    * routine cycle's skip contract.
    */
-  withLock: <T>(work: () => Promise<T>) => Promise<T>;
-  /** Process one bounded batch (rediscovers eligibility). Returns counts. */
-  runBatch: () => Promise<{ extracted: number; skipped: number }>;
+  withLock: <T>(work: () => Promise<T>, signal: AbortSignal) => Promise<T>;
+  /** Process one batch. The signal aborts at the drain wallclock deadline. */
+  runBatch: (signal: AbortSignal) => Promise<{ extracted: number; skipped: number }>;
   /** Count remaining eligible-but-unextracted pages, or null on query error. */
-  countRemaining: () => Promise<number | null>;
+  countRemaining: (signal: AbortSignal) => Promise<number | null>;
   /** Injectable clock. Production: Date.now. */
   now: () => number;
   /** Optional progress sink (one line per batch). */
@@ -48,6 +51,8 @@ export interface ExtractAtomsDrainOpts {
   windowMs: number;
   /** Hard cap on batches (belt-and-suspenders against a 0-progress loop). Default 1000. */
   maxBatches?: number;
+  /** Test seam / caller cancellation. Production uses a window timeout. */
+  abortSignal?: AbortSignal;
 }
 
 export interface ExtractAtomsDrainResult {
@@ -68,24 +73,51 @@ export async function runExtractAtomsDrain(
   opts: ExtractAtomsDrainOpts,
 ): Promise<ExtractAtomsDrainResult> {
   const maxBatches = opts.maxBatches ?? 1000;
-  return deps.withLock(async () => {
-    const deadline = deps.now() + opts.windowMs;
+  const deadline = deps.now() + opts.windowMs;
+  const signal = anySignal(
+    AbortSignal.timeout(Math.max(1, opts.windowMs)),
+    opts.abortSignal,
+  );
+  const result: ExtractAtomsDrainResult = await deps.withLock(async () => {
     let extracted = 0;
     let skipped = 0;
     let batches = 0;
+    let lastRemaining: number | null = null;
     let stopped: ExtractAtomsDrainResult['stopped'] = 'window';
 
-    while (deps.now() < deadline) {
+    while (true) {
+      if (deps.now() >= deadline) break;
       if (batches >= maxBatches) { stopped = 'max_batches'; break; }
 
-      const before = await deps.countRemaining();
+      let before: number | null;
+      try {
+        before = await deps.countRemaining(signal);
+      } catch (err) {
+        if (signal.aborted) break;
+        throw err;
+      }
+      lastRemaining = before;
       if (before === 0) { stopped = 'drained'; break; }
 
-      const r = await deps.runBatch();
+      // The backlog query consumes the same wallclock budget. Recompute after
+      // it returns so a slow count cannot hand the batch a stale larger window.
+      if (deadline - deps.now() <= 0 || signal.aborted) break;
+
+      let r: { extracted: number; skipped: number };
+      try {
+        r = await deps.runBatch(signal);
+      } catch (err) {
+        if (signal.aborted) break;
+        throw err;
+      }
       extracted += r.extracted;
       skipped += r.skipped;
       batches++;
       deps.onBatch?.({ batch: batches, extracted: r.extracted, remaining: before });
+
+      // A batch may return because its deadline signal aborted a hung gateway
+      // call. Window exhaustion wins over the generic zero-progress label.
+      if (deps.now() >= deadline || signal.aborted) { stopped = 'window'; break; }
 
       // Stop if a batch made zero forward progress — extraction is failing or
       // everything left is ineligible (e.g. all skipped). Prevents a hot loop
@@ -93,10 +125,23 @@ export async function runExtractAtomsDrain(
       if (r.extracted === 0 && r.skipped === 0) { stopped = 'no_progress'; break; }
     }
 
-    const remaining = await deps.countRemaining();
+    const windowElapsed = signal.aborted || deps.now() >= deadline;
+    let remaining: number | null = windowElapsed ? null : lastRemaining;
+    if (!windowElapsed) {
+      try {
+        remaining = await deps.countRemaining(signal);
+      } catch (err) {
+        if (!signal.aborted) throw err;
+        remaining = null;
+      }
+    }
     if (remaining === 0) stopped = 'drained';
     return { phase: 'extract_atoms', status: 'ok', extracted, skipped, remaining, batches, stopped };
-  });
+  }, signal);
+  // Internal window expiry is a normal partial result. External worker
+  // cancel/timeout/lock-loss must reject so Minion records an aborted job.
+  if (opts.abortSignal?.aborted) throw opts.abortSignal.reason;
+  return result;
 }
 
 // ─── Shared wiring helper (v0.42.x #1685 DECISION 5A) ──────────────────────
@@ -128,18 +173,23 @@ export interface DrainForSourceOpts {
   sourceId: string | undefined;
   /** Wallclock budget in seconds. */
   windowSeconds: number;
-  /** Brain checkout dir, threaded to `runPhaseExtractAtoms` (optional — DB-only ok). */
-  brainDir?: string;
   /** Hard batch cap (belt-and-suspenders). */
   maxBatches?: number;
   /** Optional per-batch progress sink (stderr line in dream; job progress in the handler). */
   onBatch?: ExtractAtomsDrainDeps['onBatch'];
+  /** Worker cancellation / lock-loss / shutdown signal. */
+  abortSignal?: AbortSignal;
 }
 
 export async function runExtractAtomsDrainForSource(
   engine: BrainEngine,
   opts: DrainForSourceOpts,
 ): Promise<ExtractAtomsDrainResult> {
+  if (engine.supportsQueryCancellation === false) {
+    throw new Error(
+      'extract_atoms drain requires an engine with real query cancellation; PGLite cannot safely guarantee the deadline',
+    );
+  }
   const { withRefreshingLock } = await import('../db-lock.ts');
   const { runPhaseExtractAtoms, countExtractAtomsBacklog } = await import('./extract-atoms.ts');
   const { cycleLockIdFor } = await import('../cycle.ts');
@@ -149,12 +199,19 @@ export async function runExtractAtomsDrainForSource(
 
   return runExtractAtomsDrain(
     {
-      withLock: (work) => withRefreshingLock(engine, lockId, work, { ttlMinutes: 5 }),
-      runBatch: async () => {
+      withLock: (work, signal) => withRefreshingLock(engine, lockId, work, {
+        ttlMinutes: 5,
+        signal,
+        releaseTimeoutMs: LOCK_RELEASE_GRACE_MS,
+      }),
+      runBatch: async (signal) => {
         const r = await runPhaseExtractAtoms(engine, {
           sourceId: extractionSourceId,
           dryRun: false,
-          brainDir: opts.brainDir,
+          abortSignal: signal,
+          // Drain backlog/count is DB-page-only. Suppress synchronous corpus
+          // discovery inside the lock; routine cycles still process transcripts.
+          _transcripts: [],
         });
         const d = (r.details ?? {}) as Record<string, unknown>;
         return {
@@ -162,10 +219,14 @@ export async function runExtractAtomsDrainForSource(
           skipped: Number(d.duplicates_skipped ?? 0),
         };
       },
-      countRemaining: () => countExtractAtomsBacklog(engine, extractionSourceId),
+      countRemaining: (signal) => countExtractAtomsBacklog(engine, extractionSourceId, signal),
       now: Date.now,
       onBatch: opts.onBatch,
     },
-    { windowMs: opts.windowSeconds * 1000, maxBatches: opts.maxBatches },
+    {
+      windowMs: opts.windowSeconds * 1000,
+      maxBatches: opts.maxBatches,
+      abortSignal: opts.abortSignal,
+    },
   );
 }

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -51,8 +51,12 @@ import type { ProgressReporter } from '../progress.ts';
 import { chat as gatewayChat } from '../ai/gateway.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
+import { contentHash } from '../utils.ts';
+import { sanitizeForJsonb } from '../batch-rows.ts';
+import { createHash } from 'crypto';
 
 const DEFAULT_BUDGET_USD = 0.3;
+const BOOKKEEPING_GRACE_MS = 5_000;
 
 // v0.42+ TODO: read atom_type enum from active pack manifest at runtime.
 const ATOM_TYPES = [
@@ -110,6 +114,8 @@ export interface ExtractAtomsOpts {
    * `heartbeat()` on the passed reporter.
    */
   progress?: ProgressReporter;
+  /** Optional caller deadline/cancellation, forwarded to every gateway call. */
+  abortSignal?: AbortSignal;
 }
 
 interface ExtractedAtom {
@@ -167,6 +173,7 @@ export async function discoverExtractablePages(
   engine: BrainEngine,
   sourceId: string,
   affectedSlugs?: string[],
+  abortSignal?: AbortSignal,
 ): Promise<DiscoveredPage[]> {
   const hasFilter = Array.isArray(affectedSlugs) && affectedSlugs.length > 0;
   const sql = `
@@ -206,13 +213,14 @@ export async function discoverExtractablePages(
       slug: string;
       compiled_truth: string;
       content_hash: string;
-    }>(sql, params);
+    }>(sql, params, { signal: abortSignal });
     return rows.map((r) => ({
       slug: r.slug,
       content: r.compiled_truth,
       contentHash: r.content_hash,
     }));
   } catch (err) {
+    if (abortSignal?.aborted) throw err;
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[extract_atoms] page-discovery query failed: ${msg}`);
     return []; // fail-soft: transcript path still proceeds
@@ -237,6 +245,7 @@ export async function discoverExtractablePages(
 export async function countExtractAtomsBacklog(
   engine: BrainEngine,
   sourceId?: string,
+  abortSignal?: AbortSignal,
 ): Promise<number | null> {
   try {
     // Two modes: scoped (the phase's per-source `remaining`) vs brain-wide
@@ -275,9 +284,10 @@ export async function countExtractAtomsBacklog(
     const params = scoped
       ? [sourceId, EXTRACTABLE_PAGE_TYPES as unknown as string[], MIN_PAGE_CHARS_FOR_EXTRACTION]
       : [EXTRACTABLE_PAGE_TYPES as unknown as string[], MIN_PAGE_CHARS_FOR_EXTRACTION];
-    const rows = await engine.executeRaw<{ cnt: string | number }>(sql, params);
+    const rows = await engine.executeRaw<{ cnt: string | number }>(sql, params, { signal: abortSignal });
     return Number(rows[0]?.cnt ?? 0);
   } catch (err) {
+    if (abortSignal?.aborted) throw err;
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[extract_atoms] backlog count failed: ${msg}`);
     return null;
@@ -304,6 +314,7 @@ export async function atomsExistingForHashes(
   engine: BrainEngine,
   sourceId: string,
   contentHash16s: string[],
+  abortSignal?: AbortSignal,
 ): Promise<Set<string>> {
   if (contentHash16s.length === 0) return new Set();
   try {
@@ -315,9 +326,11 @@ export async function atomsExistingForHashes(
           AND deleted_at IS NULL
           AND frontmatter->>'source_hash' = ANY($2::text[])`,
       [sourceId, contentHash16s],
+      { signal: abortSignal },
     );
     return new Set(rows.map(r => r.h));
   } catch (err) {
+    if (abortSignal?.aborted) throw err;
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`[extract_atoms] batch idempotency check failed (assuming none extracted): ${msg}`);
     return new Set();
@@ -338,6 +351,7 @@ export async function runPhaseExtractAtoms(
 ): Promise<PhaseResult> {
   const sourceId = opts.sourceId ?? 'default';
   const chat = opts._chat ?? gatewayChat;
+  if (opts.abortSignal?.aborted) throw opts.abortSignal.reason;
 
   // 1a. Get transcripts (test seam OR production discovery).
   //     v0.41.2.1: config loader switched to loadConfigWithEngine() so the
@@ -379,7 +393,7 @@ export async function runPhaseExtractAtoms(
   if (opts._pages !== undefined) {
     pages = opts._pages;
   } else {
-    pages = await discoverExtractablePages(engine, sourceId, opts.affectedSlugs);
+    pages = await discoverExtractablePages(engine, sourceId, opts.affectedSlugs, opts.abortSignal);
   }
 
   // 2. Apply transcript-side source-hash idempotency in ONE batch query
@@ -391,7 +405,7 @@ export async function runPhaseExtractAtoms(
   // Surface a heartbeat before the batch query so even an instant
   // short-circuit shows a sign of life (closes Issue 2 silent-phase pain).
   opts.progress?.heartbeat(`checking existing atoms for ${allHashes16.length} transcripts`);
-  const existingHashes = await atomsExistingForHashes(engine, sourceId, allHashes16);
+  const existingHashes = await atomsExistingForHashes(engine, sourceId, allHashes16, opts.abortSignal);
   for (const t of transcripts) {
     if (existingHashes.has(t.contentHash.slice(0, 16))) {
       duplicatesSkipped++;
@@ -455,6 +469,7 @@ export async function runPhaseExtractAtoms(
   const failures: Array<{ source: string; error: string }> = [];
   let estimatedSpendUsd = 0;
   const budgetCap = DEFAULT_BUDGET_USD;
+  let deadlineAborted = false;
 
   // v0.41.19.0 (T3): throttled yield helper. Fires `opts.yieldDuringPhase`
   // every 30s. Cycle.ts threads `buildYieldDuringPhase(lock, outer)` so
@@ -480,6 +495,10 @@ export async function runPhaseExtractAtoms(
   }
 
   for (const item of work) {
+    if (opts.abortSignal?.aborted) {
+      deadlineAborted = true;
+      break;
+    }
     await maybeYield();
     if (estimatedSpendUsd >= budgetCap) {
       if (item.kind === 'transcript') transcriptsSkipped++;
@@ -498,15 +517,20 @@ export async function runPhaseExtractAtoms(
           },
         ],
         maxTokens: 2000,
+        abortSignal: opts.abortSignal,
       });
+      // A completed gateway call is billable even if the caller deadline fires
+      // immediately afterward. Record usage before observing post-await abort.
+      estimatedSpendUsd +=
+        (result.usage.input_tokens * 0.8 + result.usage.output_tokens * 4.0) / 1_000_000;
+      if (opts.abortSignal?.aborted) {
+        deadlineAborted = true;
+        break;
+      }
       // Post-await yield: closes the "long LLM call past TTL" hazard
       // codex flagged. The 30s throttle inside maybeYield bounds the
       // actual refresh rate so this is cheap when calls are fast.
       await maybeYield();
-
-      // Rough cost estimate — Haiku at ~$0.80/M input + $4/M output
-      estimatedSpendUsd +=
-        (result.usage.input_tokens * 0.8 + result.usage.output_tokens * 4.0) / 1_000_000;
 
       const atoms = parseAtomsResponse(result.text);
       if (atoms.length === 0) {
@@ -515,42 +539,104 @@ export async function runPhaseExtractAtoms(
         continue;
       }
 
+      const extractedAt = new Date().toISOString();
+      const originHash = createHash('sha256').update(originLabel).digest('hex').slice(0, 10);
+      const slugHashes = new Map<string, string>();
+      const rows: Array<{
+        slug: string;
+        title: string;
+        compiled_truth: string;
+        frontmatter: Record<string, unknown>;
+        content_hash: string;
+      }> = [];
+      for (const atom of atoms) {
+        const title = sanitizeForJsonb(atom.title);
+        const body = sanitizeForJsonb(atom.body);
+        const originFrontmatter = item.kind === 'transcript'
+          ? { source_path: item.filePath }
+          : { source_slug: item.slug };
+        const page = {
+          title,
+          type: 'atom' as const,
+          compiled_truth: body,
+          timeline: '',
+          frontmatter: {
+            type: 'atom',
+            atom_type: atom.atom_type,
+            ...originFrontmatter,
+            source_hash: item.contentHash.slice(0, 16),
+            ...(atom.source_quote && { source_quote: sanitizeForJsonb(atom.source_quote) }),
+            ...(atom.lesson && { lesson: sanitizeForJsonb(atom.lesson) }),
+            ...(atom.virality_score !== undefined && { virality_score: atom.virality_score }),
+            ...(atom.emotional_register && {
+              emotional_register: sanitizeForJsonb(atom.emotional_register),
+            }),
+            extracted_at: extractedAt,
+            extracted_by: 'extract_atoms-v0.41.2.1',
+          },
+        };
+        const pageHash = contentHash(page);
+        // Slug identity must survive re-extraction timestamps/source hashes.
+        // Use only stable sanitized semantic fields for collision suffixes.
+        const semanticHash = contentHash({
+          title,
+          type: 'atom',
+          compiled_truth: body,
+          timeline: '',
+          frontmatter: { atom_type: atom.atom_type },
+        });
+        const baseSlug = `atoms/${todayDate()}/${slugify(title)}-${originHash}`;
+        const baseHash = slugHashes.get(baseSlug);
+        if (baseHash === semanticHash) continue; // exact semantic duplicate from the model
+        let slug = baseHash === undefined ? baseSlug : `${baseSlug}-${semanticHash.slice(0, 12)}`;
+        const collisionHash = slugHashes.get(slug);
+        if (collisionHash === semanticHash) continue;
+        if (collisionHash !== undefined) slug = `${baseSlug}-${semanticHash}`;
+        slugHashes.set(slug, semanticHash);
+        rows.push({
+          slug,
+          title: page.title,
+          compiled_truth: page.compiled_truth,
+          frontmatter: page.frontmatter,
+          content_hash: pageHash,
+        });
+      }
+
       if (!opts.dryRun) {
-        for (const atom of atoms) {
-          const slug = `atoms/${todayDate()}/${slugify(atom.title)}`;
-          const originFrontmatter =
-            item.kind === 'transcript'
-              ? { source_path: item.filePath }
-              : { source_slug: item.slug };
-          // v0.41.2.1 D9 #1 — thread sourceId through every putPage so
-          // atoms land in the source we discovered them from. Pre-fix
-          // the third arg was missing and atoms always wrote to 'default'.
-          await engine.putPage(
-            slug,
-            {
-              title: atom.title,
-              type: 'atom',
-              compiled_truth: atom.body,
-              frontmatter: {
-                type: 'atom',
-                atom_type: atom.atom_type,
-                ...originFrontmatter,
-                source_hash: item.contentHash.slice(0, 16),
-                ...(atom.source_quote && { source_quote: atom.source_quote }),
-                ...(atom.lesson && { lesson: atom.lesson }),
-                ...(atom.virality_score !== undefined && { virality_score: atom.virality_score }),
-                ...(atom.emotional_register && { emotional_register: atom.emotional_register }),
-                extracted_at: new Date().toISOString(),
-                extracted_by: 'extract_atoms-v0.41.2.1',
-              },
-              timeline: '',
-            },
-            { sourceId },
-          );
-          totalAtomsExtracted++;
-        }
+        // One source response is the idempotency unit: discovery treats ANY
+        // atom with this source_hash as complete. One INSERT statement commits
+        // all 1–3 atoms atomically and is directly cancellable by Postgres.
+        await engine.executeRaw(
+          `WITH input AS (
+             SELECT elem->>'slug' AS slug,
+                    elem->>'title' AS title,
+                    elem->>'compiled_truth' AS compiled_truth,
+                    elem->'frontmatter' AS frontmatter,
+                    elem->>'content_hash' AS content_hash
+               FROM jsonb_array_elements($1::text::jsonb) elem
+           )
+           INSERT INTO pages (
+             source_id, slug, type, page_kind, title, compiled_truth,
+             timeline, frontmatter, content_hash, updated_at
+           )
+           SELECT $2, slug, 'atom', 'markdown', title, compiled_truth,
+                  '', frontmatter, content_hash, NOW()
+             FROM input
+           ON CONFLICT (source_id, slug) DO UPDATE SET
+             type = EXCLUDED.type,
+             page_kind = EXCLUDED.page_kind,
+             title = EXCLUDED.title,
+             compiled_truth = EXCLUDED.compiled_truth,
+             timeline = EXCLUDED.timeline,
+             frontmatter = EXCLUDED.frontmatter,
+             content_hash = EXCLUDED.content_hash,
+             updated_at = NOW()`,
+          [JSON.stringify(rows), sourceId],
+          { signal: opts.abortSignal },
+        );
+        totalAtomsExtracted += rows.length;
       } else {
-        totalAtomsExtracted += atoms.length; // count for dry-run reporting
+        totalAtomsExtracted += rows.length; // count final deduped rows in dry-run
       }
       if (item.kind === 'transcript') transcriptsProcessed++;
       else pagesProcessed++;
@@ -558,6 +644,10 @@ export async function runPhaseExtractAtoms(
       // Reporter rate-limits to ~1 line/sec; safe to tick every iter.
       opts.progress?.tick(1, `${totalAtomsExtracted} atoms / ${duplicatesSkipped} skipped`);
     } catch (err) {
+      if (opts.abortSignal?.aborted) {
+        deadlineAborted = true;
+        break;
+      }
       failures.push({
         source: originLabel,
         error: err instanceof Error ? err.message : String(err),
@@ -568,6 +658,13 @@ export async function runPhaseExtractAtoms(
   // v0.42 Wave B2: write extract receipt + rollup row when the phase
   // actually extracted atoms. Both are best-effort per F-OUT-19 —
   // audit-trail / search-visibility surfaces don't block the phase result.
+  // If the caller deadline fired after partial writes, use a short fresh
+  // signal for bookkeeping. Otherwise those committed atoms become
+  // idempotency-skipped next run while their cost/receipt disappears forever.
+  // Always start a fresh grace window. The work deadline may fire while the
+  // first bookkeeping write is in flight; reusing it would abort both receipt
+  // and rollup even though the atom writes already committed.
+  const bookkeepingSignal = AbortSignal.timeout(BOOKKEEPING_GRACE_MS);
   if (!opts.dryRun && totalAtomsExtracted > 0) {
     const runId = `atoms-${Date.now().toString(36)}-${sourceId.slice(0, 4)}`;
     try {
@@ -582,19 +679,23 @@ export async function runPhaseExtractAtoms(
         summary:
           `Extracted ${totalAtomsExtracted} atoms from ` +
           `${transcriptsProcessed} transcripts + ${pagesProcessed} pages.`,
-      });
+      }, { signal: bookkeepingSignal });
     } catch (err) {
       console.error(`[extract_atoms] receipt write failed: ${(err as Error).message}`);
     }
   }
   if (!opts.dryRun) {
-    await upsertExtractRollup(engine, {
-      kind: 'atoms',
-      source_id: sourceId,
-      cost_delta: estimatedSpendUsd,
-      round_completed_delta: failures.length === 0 ? 1 : 0,
-      halt_delta: failures.length > 0 ? 1 : 0,
-    });
+    try {
+      await upsertExtractRollup(engine, {
+        kind: 'atoms',
+        source_id: sourceId,
+        cost_delta: estimatedSpendUsd,
+        round_completed_delta: failures.length === 0 && !deadlineAborted ? 1 : 0,
+        halt_delta: failures.length > 0 ? 1 : 0,
+      }, { signal: bookkeepingSignal });
+    } catch (err) {
+      console.error(`[extract_atoms] rollup write failed: ${(err as Error).message}`);
+    }
   }
 
   return {
@@ -623,6 +724,7 @@ export async function runPhaseExtractAtoms(
       budget_usd: budgetCap,
       source_id: sourceId,
       dry_run: opts.dryRun ?? false,
+      deadline_aborted: deadlineAborted,
     },
   };
 }

--- a/src/core/db-lock.ts
+++ b/src/core/db-lock.ts
@@ -26,12 +26,19 @@ import type { BrainEngine } from './engine.ts';
 
 export interface DbLockHandle {
   id: string;
-  release: () => Promise<void>;
-  refresh: () => Promise<void>;
+  release: (signal?: AbortSignal) => Promise<void>;
+  refresh: (signal?: AbortSignal) => Promise<void>;
 }
 
 /** Default TTL: 30 minutes, same as cycle lock. */
 const DEFAULT_TTL_MINUTES = 30;
+let lastLockAttemptMs = 0;
+
+function nextLockAttemptAt(): Date {
+  const now = Date.now();
+  lastLockAttemptMs = Math.max(now, lastLockAttemptMs + 1);
+  return new Date(lastLockAttemptMs);
+}
 
 /**
  * v0.42 (#1780 Gap 3): grace window before a same-host dead-pid lock is
@@ -173,9 +180,14 @@ export async function tryAcquireDbLock(
   engine: BrainEngine,
   lockId: string,
   ttlMinutes: number = DEFAULT_TTL_MINUTES,
+  opts: { signal?: AbortSignal } = {},
 ): Promise<DbLockHandle | null> {
   const pid = process.pid;
   const host = hostname();
+  // `acquired_at` doubles as an attempt-unique owner token. Guarding every
+  // refresh/release/abort-cleanup with it prevents a cancelled second acquire
+  // in the same PID from deleting the first live lock.
+  const acquiredAt = nextLockAttemptAt();
   // v0.42.x (#1794): a holder that refreshed within this window is protected
   // from the ON CONFLICT steal even if its TTL lapsed (starved-but-alive).
   const stealGraceSeconds = resolveStealGraceSeconds(ttlMinutes);
@@ -205,30 +217,50 @@ export async function tryAcquireDbLock(
     // `gbrain sync --break-lock --max-age <s>` uses last_refreshed_at (not
     // acquired_at) to identify wedged-but-alive holders without stealing
     // healthy long-running holders that are actively refreshing.
-    const rows: Array<{ id: string }> = await sql`
+    let rows: Array<{ id: string }>;
+    try {
+      rows = await engine.executeRaw<{ id: string }>(`
       INSERT INTO gbrain_cycle_locks (id, holder_pid, holder_host, acquired_at, ttl_expires_at, last_refreshed_at)
-      VALUES (${lockId}, ${pid}, ${host}, NOW(), NOW() + ${ttl}::interval, NOW())
+      VALUES ($1, $2, $3, $6, NOW() + $4::interval, NOW())
       ON CONFLICT (id) DO UPDATE
-        SET holder_pid = ${pid},
-            holder_host = ${host},
-            acquired_at = NOW(),
-            ttl_expires_at = NOW() + ${ttl}::interval,
+        SET holder_pid = $2,
+            holder_host = $3,
+            acquired_at = $6,
+            ttl_expires_at = NOW() + $4::interval,
             last_refreshed_at = NOW()
         WHERE gbrain_cycle_locks.ttl_expires_at < NOW()
           AND (gbrain_cycle_locks.last_refreshed_at IS NULL
-               OR gbrain_cycle_locks.last_refreshed_at < NOW() - ${stealGraceSeconds} * INTERVAL '1 second')
+               OR gbrain_cycle_locks.last_refreshed_at < NOW() - $5 * INTERVAL '1 second')
       RETURNING id
-    `;
+      `, [lockId, pid, host, ttl, stealGraceSeconds, acquiredAt], { signal: opts.signal });
+    } catch (err) {
+      if (opts.signal?.aborted) {
+        // Query cancellation is normally transactional, but response loss can
+        // make commit status ambiguous. Remove only this process/host holder.
+        const cleanupSignal = AbortSignal.timeout(5_000);
+        try {
+          await engine.executeRawDirect(
+            `DELETE FROM gbrain_cycle_locks
+              WHERE id = $1 AND holder_pid = $2 AND holder_host = $3
+                AND acquired_at = $4`,
+            [lockId, pid, host, acquiredAt],
+            { signal: cleanupSignal },
+          );
+        } catch { /* TTL remains the final backstop */ }
+      }
+      throw err;
+    }
     if (rows.length === 0) return null;
     const deregister = registerCleanup(`db-lock:${lockId}`, async () => {
       await sql`
         DELETE FROM gbrain_cycle_locks
         WHERE id = ${lockId} AND holder_pid = ${pid}
+          AND holder_host = ${host} AND acquired_at = ${acquiredAt}
       `;
     });
     return {
       id: lockId,
-      refresh: async () => {
+      refresh: async (signal) => {
         // v0.41.13.0: bump BOTH ttl_expires_at AND last_refreshed_at.
         // v0.42.x (#1794): route through the DIRECT session pool, not the
         // transaction pool, so a Supavisor pooler exhaustion (EMAXCONNSESSION)
@@ -237,16 +269,21 @@ export async function tryAcquireDbLock(
           `UPDATE gbrain_cycle_locks
               SET ttl_expires_at = NOW() + ($1)::interval,
                   last_refreshed_at = NOW()
-            WHERE id = $2 AND holder_pid = $3`,
-          [ttl, lockId, pid],
+            WHERE id = $2 AND holder_pid = $3 AND holder_host = $4
+              AND acquired_at = $5`,
+          [ttl, lockId, pid, host, acquiredAt],
+          { signal },
         );
       },
-      release: async () => {
+      release: async (signal) => {
         deregister();
-        await sql`
-          DELETE FROM gbrain_cycle_locks
-          WHERE id = ${lockId} AND holder_pid = ${pid}
-        `;
+        await engine.executeRawDirect(
+          `DELETE FROM gbrain_cycle_locks
+            WHERE id = $1 AND holder_pid = $2 AND holder_host = $3
+              AND acquired_at = $4`,
+          [lockId, pid, host, acquiredAt],
+          { signal },
+        );
       },
     };
   }
@@ -256,24 +293,25 @@ export async function tryAcquireDbLock(
     const ttl = `${ttlMinutes} minutes`;
     const { rows } = await db.query(
       `INSERT INTO gbrain_cycle_locks (id, holder_pid, holder_host, acquired_at, ttl_expires_at, last_refreshed_at)
-       VALUES ($1, $2, $3, NOW(), NOW() + $4::interval, NOW())
+       VALUES ($1, $2, $3, $6, NOW() + $4::interval, NOW())
        ON CONFLICT (id) DO UPDATE
          SET holder_pid = $2,
              holder_host = $3,
-             acquired_at = NOW(),
+             acquired_at = $6,
              ttl_expires_at = NOW() + $4::interval,
              last_refreshed_at = NOW()
          WHERE gbrain_cycle_locks.ttl_expires_at < NOW()
            AND (gbrain_cycle_locks.last_refreshed_at IS NULL
                 OR gbrain_cycle_locks.last_refreshed_at < NOW() - $5 * INTERVAL '1 second')
        RETURNING id`,
-      [lockId, pid, host, ttl, stealGraceSeconds],
+      [lockId, pid, host, ttl, stealGraceSeconds, acquiredAt],
     );
     if (rows.length === 0) return null;
     const deregister = registerCleanup(`db-lock:${lockId}`, async () => {
       await db.query(
-        `DELETE FROM gbrain_cycle_locks WHERE id = $1 AND holder_pid = $2`,
-        [lockId, pid],
+        `DELETE FROM gbrain_cycle_locks
+          WHERE id = $1 AND holder_pid = $2 AND holder_host = $3 AND acquired_at = $4`,
+        [lockId, pid, host, acquiredAt],
       );
     });
     return {
@@ -283,15 +321,16 @@ export async function tryAcquireDbLock(
           `UPDATE gbrain_cycle_locks
               SET ttl_expires_at = NOW() + $1::interval,
                   last_refreshed_at = NOW()
-            WHERE id = $2 AND holder_pid = $3`,
-          [ttl, lockId, pid],
+            WHERE id = $2 AND holder_pid = $3 AND holder_host = $4 AND acquired_at = $5`,
+          [ttl, lockId, pid, host, acquiredAt],
         );
       },
       release: async () => {
         deregister();
         await db.query(
-          `DELETE FROM gbrain_cycle_locks WHERE id = $1 AND holder_pid = $2`,
-          [lockId, pid],
+          `DELETE FROM gbrain_cycle_locks
+            WHERE id = $1 AND holder_pid = $2 AND holder_host = $3 AND acquired_at = $4`,
+          [lockId, pid, host, acquiredAt],
         );
       },
     };
@@ -302,6 +341,12 @@ export async function tryAcquireDbLock(
 
   const first = await acquireOnce();
   if (first) return first;
+
+  // Deadline-bound callers prefer an honest busy result over entering the
+  // best-effort same-host takeover path, whose inspection/delete calls do not
+  // share one cancellable transaction. The initial upsert already reclaims
+  // expired locks; live-TTL dead holders remain a normal contention result.
+  if (opts.signal) return null;
 
   // v0.42 (#1780 Gap 3): the lock is held and its TTL hasn't expired (the
   // upsert's ON CONFLICT ... WHERE ttl_expires_at < NOW() returned no row).
@@ -796,6 +841,10 @@ export interface WithRefreshingLockOpts {
   ttlMinutes?: number;
   /** Heartbeat-fail threshold in ms — abort if SELECT 1 takes longer. Default 30000. */
   heartbeatTimeoutMs?: number;
+  /** Cancel lock acquisition with the caller's total deadline. */
+  signal?: AbortSignal;
+  /** Fresh cleanup budget for lock release after caller abort. Default 5000. */
+  releaseTimeoutMs?: number;
 }
 
 /**
@@ -815,7 +864,7 @@ export async function withRefreshingLock<T>(
   // Refresh 6x per TTL window so a missed tick doesn't expire the lock.
   const refreshIntervalMs = Math.max(15000, (ttlMinutes * 60 * 1000) / 6);
 
-  const handle = await tryAcquireDbLock(engine, lockId, ttlMinutes);
+  const handle = await tryAcquireDbLock(engine, lockId, ttlMinutes, { signal: opts.signal });
   if (!handle) throw new LockUnavailableError(lockId);
 
   let healthOk = true;
@@ -854,7 +903,10 @@ export async function withRefreshingLock<T>(
     return await work();
   } finally {
     clearInterval(interval);
-    try { await handle.release(); } catch { /* idempotent */ }
+    const releaseSignal = opts.signal
+      ? AbortSignal.timeout(opts.releaseTimeoutMs ?? 5_000)
+      : undefined;
+    try { await handle.release(releaseSignal); } catch { /* idempotent; TTL backstop */ }
     if (!healthOk) {
       // Surface that the heartbeat detected backend trouble — caller can
       // log to the connection-events audit if desired.

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -647,6 +647,8 @@ export function clampSearchLimit(limit: number | undefined, defaultLimit = 20, c
 }
 
 export interface BrainEngine {
+  /** True when AbortSignal cancels the underlying DB query, not only its waiter. */
+  readonly supportsQueryCancellation?: boolean;
   /** Discriminator: lets migrations and other consumers branch on engine kind without instanceof + dynamic imports. */
   readonly kind: 'postgres' | 'pglite';
 
@@ -687,7 +689,11 @@ export interface BrainEngine {
    * DO UPDATE actually targets the intended row instead of fabricating a
    * duplicate at (default, slug). Multi-source brains MUST pass sourceId.
    */
-  putPage(slug: string, page: PageInput, opts?: { sourceId?: string }): Promise<Page>;
+  putPage(
+    slug: string,
+    page: PageInput,
+    opts?: { sourceId?: string; signal?: AbortSignal },
+  ): Promise<Page>;
   /**
    * v0.41.13 (#1309) — identity-based dedup pre-check for the import pipeline.
    *

--- a/src/core/extract/receipt-writer.ts
+++ b/src/core/extract/receipt-writer.ts
@@ -187,6 +187,7 @@ function buildReceiptFrontmatter(input: ExtractReceiptInput): Record<string, unk
 export async function writeReceipt(
   engine: BrainEngine,
   input: ExtractReceiptInput,
+  opts?: { signal?: AbortSignal },
 ): Promise<{ slug: string; page: Page }> {
   const slug = receiptSlug(input);
   const title = `${input.kind} — ${input.round} — ${input.source_id}`;
@@ -201,7 +202,7 @@ export async function writeReceipt(
       compiled_truth,
       frontmatter,
     },
-    { sourceId: input.source_id },
+    { sourceId: input.source_id, signal: opts?.signal },
   );
 
   return { slug, page };

--- a/src/core/extract/rollup-writer.ts
+++ b/src/core/extract/rollup-writer.ts
@@ -70,6 +70,7 @@ function today(): string {
 export async function upsertExtractRollup(
   engine: BrainEngine,
   input: RollupUpsertInput,
+  opts?: { signal?: AbortSignal },
 ): Promise<{ ok: boolean; error?: string }> {
   const day = input.day ?? today();
   const cost = input.cost_delta ?? 0;
@@ -96,9 +97,11 @@ export async function upsertExtractRollup(
          rollup_write_failures  = extract_rollup_7d.rollup_write_failures  + EXCLUDED.rollup_write_failures,
          updated_at             = now()`,
       [input.kind, input.source_id, day, cost, halts, evalFails, evalPasses, completed, failures],
+      { signal: opts?.signal },
     );
     return { ok: true };
   } catch (err) {
+    if (opts?.signal?.aborted) throw err;
     const msg = (err as Error).message || String(err);
     // Don't spam: log once per process per (kind, day) error class.
     rollupErrorLogOnce(input.kind, day, msg);

--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -246,6 +246,7 @@ async function preservingProcessExitCode<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 export class PGLiteEngine implements BrainEngine {
+  readonly supportsQueryCancellation = false;
   readonly kind = 'pglite' as const;
   private _db: PGLiteDB | null = null;
   private _lock: LockHandle | null = null;
@@ -969,7 +970,12 @@ export class PGLiteEngine implements BrainEngine {
     return { slug: r.slug, id: Number(r.id) };
   }
 
-  async putPage(slug: string, page: PageInput, opts?: { sourceId?: string }): Promise<Page> {
+  async putPage(
+    slug: string,
+    page: PageInput,
+    opts?: { sourceId?: string; signal?: AbortSignal },
+  ): Promise<Page> {
+    if (opts?.signal?.aborted) throw opts.signal.reason;
     slug = validateSlug(slug);
     const hash = page.content_hash || contentHash(page);
     const frontmatter = page.frontmatter || {};
@@ -1000,7 +1006,7 @@ export class PGLiteEngine implements BrainEngine {
     const sourceUri = page.source_uri ?? null;
     const ingestedVia = page.ingested_via ?? null;
     const ingestedAt = (sourceKind || sourceUri || ingestedVia) ? new Date().toISOString() : null;
-    const { rows } = await this.db.query(
+    const rows = await this.executeRaw<Record<string, unknown>>(
       `INSERT INTO pages (source_id, slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at, effective_date, effective_date_source, import_filename, chunker_version, source_path, source_kind, source_uri, ingested_via, ingested_at)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, now(), $10::timestamptz, $11, $12, COALESCE($13, 1), $14, $15, $16, $17, $18::timestamptz)
        ON CONFLICT (source_id, slug) DO UPDATE SET
@@ -1022,7 +1028,8 @@ export class PGLiteEngine implements BrainEngine {
          ingested_via          = COALESCE(EXCLUDED.ingested_via,          pages.ingested_via),
          ingested_at           = COALESCE(EXCLUDED.ingested_at,           pages.ingested_at)
        RETURNING id, source_id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at, effective_date, effective_date_source, import_filename, source_kind, source_uri, ingested_via, ingested_at`,
-      [sourceId, slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash, effectiveDate, effectiveDateSource, importFilename, chunkerVersion, sourcePath, sourceKind, sourceUri, ingestedVia, ingestedAt]
+      [sourceId, slug, page.type, pageKind, page.title, page.compiled_truth, page.timeline || '', JSON.stringify(frontmatter), hash, effectiveDate, effectiveDateSource, importFilename, chunkerVersion, sourcePath, sourceKind, sourceUri, ingestedVia, ingestedAt],
+      { signal: opts?.signal },
     );
     return rowToPage(rows[0] as Record<string, unknown>);
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -70,6 +70,27 @@ function escapeSqlStringLiteral(value: string): string {
   return value.replace(/'/g, "''");
 }
 
+function waitForSignal<T>(work: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return work;
+  if (signal.aborted) return Promise.reject(new DOMException('aborted', 'AbortError'));
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener('abort', onAbort);
+      fn();
+    };
+    const onAbort = () => finish(() => reject(new DOMException('aborted', 'AbortError')));
+    signal.addEventListener('abort', onAbort, { once: true });
+    if (signal.aborted) onAbort();
+    work.then(
+      (value) => finish(() => resolve(value)),
+      (err) => finish(() => reject(err)),
+    );
+  });
+}
+
 export function getPostgresSchema(
   dims: number = DEFAULT_EMBEDDING_DIMENSIONS,
   model: string = DEFAULT_EMBEDDING_MODEL,
@@ -96,6 +117,7 @@ export function getPostgresSchema(
 // follow-up that will reintroduce a typed retry mechanism.
 
 export class PostgresEngine implements BrainEngine {
+  readonly supportsQueryCancellation = true;
   readonly kind = 'postgres' as const;
   private _sql: ReturnType<typeof postgres> | null = null;
   /** Saved config for reconnection. */
@@ -951,7 +973,12 @@ export class PostgresEngine implements BrainEngine {
     return { slug: r.slug, id: Number(r.id) };
   }
 
-  async putPage(slug: string, page: PageInput, opts?: { sourceId?: string }): Promise<Page> {
+  async putPage(
+    slug: string,
+    page: PageInput,
+    opts?: { sourceId?: string; signal?: AbortSignal },
+  ): Promise<Page> {
+    if (opts?.signal?.aborted) throw opts.signal.reason;
     slug = validateSlug(slug);
     const sql = this.sql;
     const hash = page.content_hash || contentHash(page);
@@ -986,7 +1013,7 @@ export class PostgresEngine implements BrainEngine {
     const sourceUri = page.source_uri ?? null;
     const ingestedVia = page.ingested_via ?? null;
     const ingestedAt = (sourceKind || sourceUri || ingestedVia) ? new Date() : null;
-    const rows = await sql`
+    const pending = sql`
       INSERT INTO pages (source_id, slug, type, page_kind, title, compiled_truth, timeline, frontmatter, content_hash, updated_at, effective_date, effective_date_source, import_filename, chunker_version, source_path, source_kind, source_uri, ingested_via, ingested_at)
       VALUES (${sourceId}, ${slug}, ${page.type}, ${pageKind}, ${page.title}, ${page.compiled_truth}, ${page.timeline || ''}, ${sql.json(frontmatter as Parameters<typeof sql.json>[0])}, ${hash}, now(), ${effectiveDate}, ${effectiveDateSource}, ${importFilename}, COALESCE(${chunkerVersion}::smallint, 1), ${sourcePath}, ${sourceKind}, ${sourceUri}, ${ingestedVia}, ${ingestedAt})
       ON CONFLICT (source_id, slug) DO UPDATE SET
@@ -1009,6 +1036,21 @@ export class PostgresEngine implements BrainEngine {
         ingested_at           = COALESCE(EXCLUDED.ingested_at,           pages.ingested_at)
       RETURNING id, source_id, slug, type, title, compiled_truth, timeline, frontmatter, content_hash, created_at, updated_at, effective_date, effective_date_source, import_filename, source_kind, source_uri, ingested_via, ingested_at
     `;
+    let rows: Awaited<typeof pending>;
+    if (opts?.signal) {
+      const onAbort = () => {
+        try { (pending as unknown as { cancel?: () => void }).cancel?.(); } catch { /* best-effort */ }
+      };
+      opts.signal.addEventListener('abort', onAbort, { once: true });
+      if (opts.signal.aborted) onAbort();
+      try {
+        rows = await pending;
+      } finally {
+        opts.signal.removeEventListener('abort', onAbort);
+      }
+    } else {
+      rows = await pending;
+    }
     return rowToPage(rows[0]);
   }
 
@@ -5352,18 +5394,11 @@ export class PostgresEngine implements BrainEngine {
     params?: unknown[],
     opts?: { signal?: AbortSignal },
   ): Promise<T[]> {
-    const pending = conn.unsafe(sql, params as Parameters<typeof conn.unsafe>[1]);
     if (opts?.signal) {
       if (opts.signal.aborted) {
-        // .cancel() is fire-and-forget; the awaited query rejects with the
-        // postgres "query was cancelled" error which the caller catches.
-        try {
-          (pending as unknown as { cancel?: () => void }).cancel?.();
-        } catch {
-          // best-effort
-        }
         throw new DOMException('aborted', 'AbortError');
       }
+      const pending = conn.unsafe(sql, params as Parameters<typeof conn.unsafe>[1]);
       const onAbort = () => {
         try {
           (pending as unknown as { cancel?: () => void }).cancel?.();
@@ -5372,11 +5407,12 @@ export class PostgresEngine implements BrainEngine {
         }
       };
       opts.signal.addEventListener('abort', onAbort, { once: true });
+      if (opts.signal.aborted) onAbort();
       return (pending as unknown as Promise<T[]>).finally(() => {
         opts.signal?.removeEventListener('abort', onAbort);
       });
     }
-    return pending as unknown as Promise<T[]>;
+    return conn.unsafe(sql, params as Parameters<typeof conn.unsafe>[1]) as unknown as Promise<T[]>;
   }
 
   async executeRaw<T = Record<string, unknown>>(
@@ -5414,11 +5450,12 @@ export class PostgresEngine implements BrainEngine {
     params?: unknown[],
     opts?: { signal?: AbortSignal },
   ): Promise<T[]> {
+    if (opts?.signal?.aborted) throw new DOMException('aborted', 'AbortError');
     // Inside an open transaction, _sql is the reserved tx connection (set via
     // defineProperty in transaction()); never reroute off it.
     const inTransaction = this._sql !== null && this.connectionManager?.peekReadPool() !== this._sql;
     const conn = (!inTransaction && this.connectionManager?.isDualPoolActive())
-      ? await this.connectionManager.ddl()
+      ? await waitForSignal(this.connectionManager.ddl(), opts?.signal)
       : this.sql;
     return this.runUnsafe<T>(conn, sql, params, opts);
   }

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5394,11 +5394,11 @@ export class PostgresEngine implements BrainEngine {
     params?: unknown[],
     opts?: { signal?: AbortSignal },
   ): Promise<T[]> {
+    if (opts?.signal?.aborted) {
+      throw new DOMException('aborted', 'AbortError');
+    }
+    const pending = conn.unsafe(sql, params as Parameters<typeof conn.unsafe>[1]);
     if (opts?.signal) {
-      if (opts.signal.aborted) {
-        throw new DOMException('aborted', 'AbortError');
-      }
-      const pending = conn.unsafe(sql, params as Parameters<typeof conn.unsafe>[1]);
       const onAbort = () => {
         try {
           (pending as unknown as { cancel?: () => void }).cancel?.();
@@ -5412,7 +5412,7 @@ export class PostgresEngine implements BrainEngine {
         opts.signal?.removeEventListener('abort', onAbort);
       });
     }
-    return conn.unsafe(sql, params as Parameters<typeof conn.unsafe>[1]) as unknown as Promise<T[]>;
+    return pending as unknown as Promise<T[]>;
   }
 
   async executeRaw<T = Record<string, unknown>>(

--- a/test/cycle/extract-atoms-synthesize-concepts.test.ts
+++ b/test/cycle/extract-atoms-synthesize-concepts.test.ts
@@ -17,6 +17,7 @@ import { runPhaseExtractAtoms, parseAtomsResponse } from '../../src/core/cycle/e
 import { runPhaseSynthesizeConcepts } from '../../src/core/cycle/synthesize-concepts.ts';
 import { resetPgliteState } from '../helpers/reset-pglite.ts';
 import type { ChatResult, ChatOpts } from '../../src/core/ai/gateway.ts';
+import type { BrainEngine } from '../../src/core/engine.ts';
 
 let engine: PGLiteEngine;
 
@@ -175,6 +176,296 @@ describe('v0.41 T5: runPhaseExtractAtoms via stubbed chat', () => {
     expect(result.status).toBe('warn');
     expect(result.details?.atoms_extracted).toBe(1);
     expect((result.details?.failures as unknown[]).length).toBe(1);
+  });
+
+  test('caller deadline aborts a hung chat before processing the next item', async () => {
+    let calls = 0;
+    const chat = async (opts: ChatOpts) => {
+      calls++;
+      return await new Promise<never>((_resolve, reject) => {
+        const signal = opts.abortSignal;
+        if (!signal) return reject(new Error('missing abort signal'));
+        if (signal.aborted) return reject(signal.reason);
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+    };
+    const started = Date.now();
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [
+        { filePath: '/hung.txt', content: 'a', contentHash: 'hung-a' },
+        { filePath: '/never.txt', content: 'b', contentHash: 'hung-b' },
+      ],
+      _pages: [],
+      _chat: chat as typeof import('../../src/core/ai/gateway.ts').chat,
+      abortSignal: AbortSignal.timeout(25),
+    });
+    expect(Date.now() - started).toBeLessThan(250);
+    expect(calls).toBe(1);
+    expect(result.status).toBe('ok');
+    expect(result.details?.deadline_aborted).toBe(true);
+    expect(result.details?.atoms_extracted).toBe(0);
+    expect(result.details?.failures).toEqual([]);
+  });
+
+  test('billable chat usage is counted when deadline fires as the response resolves', async () => {
+    const controller = new AbortController();
+    const chat = async (opts: ChatOpts): Promise<ChatResult> => {
+      controller.abort(new DOMException('deadline', 'TimeoutError'));
+      return stubChat(`[{"title":"late","atom_type":"insight","body":"b"}]`, {
+        input_tokens: 1_000,
+        output_tokens: 500,
+      })(opts);
+    };
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [{ filePath: '/late.txt', content: 'a', contentHash: 'late' }],
+      _pages: [],
+      _chat: chat,
+      abortSignal: controller.signal,
+    });
+    expect(result.details?.deadline_aborted).toBe(true);
+    expect(Number(result.details?.estimated_spend_usd)).toBeGreaterThan(0);
+    expect(result.details?.atoms_extracted).toBe(0);
+  });
+
+  test('caller deadline cancels a hung atom write and stops the phase', async () => {
+    const controller = new AbortController();
+    let notifyWriteStarted!: () => void;
+    const writeStarted = new Promise<void>((resolve) => { notifyWriteStarted = resolve; });
+    let writeCalls = 0;
+    const signalAwareEngine = {
+      executeRaw: async (sql: string, _params?: unknown[], opts?: { signal?: AbortSignal }) => {
+        if (!sql.includes('INSERT INTO pages')) return [];
+        writeCalls++;
+        notifyWriteStarted();
+        return await new Promise<never>((_resolve, reject) => {
+          const signal = opts?.signal;
+          if (!signal) return reject(new Error('missing abort signal'));
+          if (signal.aborted) return reject(signal.reason);
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        });
+      },
+    } as unknown as BrainEngine;
+
+    const pending = runPhaseExtractAtoms(signalAwareEngine, {
+      _transcripts: [{ filePath: '/hung-write.txt', content: 'a', contentHash: 'hung-write' }],
+      _pages: [],
+      _chat: stubChat(`[{
+        "title":"hung write","atom_type":"insight","body":"b"
+      }]`),
+      abortSignal: controller.signal,
+    });
+    await writeStarted;
+    controller.abort(new DOMException('deadline', 'TimeoutError'));
+    const result = await pending;
+
+    expect(writeCalls).toBe(1);
+    expect(result.details?.deadline_aborted).toBe(true);
+    expect(result.details?.atoms_extracted).toBe(0);
+  });
+
+  test('deadline after partial progress still writes receipt and incomplete rollup', async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    let notifySecondChat!: () => void;
+    const secondChatStarted = new Promise<void>((resolve) => { notifySecondChat = resolve; });
+    const chat = async (opts: ChatOpts): Promise<ChatResult> => {
+      calls++;
+      if (calls === 1) {
+        return stubChat(`[{"title":"committed","atom_type":"insight","body":"b"}]`)(opts);
+      }
+      notifySecondChat();
+      return await new Promise<never>((_resolve, reject) => {
+        const signal = opts.abortSignal;
+        if (!signal) return reject(new Error('missing abort signal'));
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+    };
+
+    const pending = runPhaseExtractAtoms(engine, {
+      _transcripts: [
+        { filePath: '/committed.txt', content: 'a', contentHash: 'committed-a' },
+        { filePath: '/hung.txt', content: 'b', contentHash: 'hung-b' },
+      ],
+      _pages: [],
+      _chat: chat,
+      abortSignal: controller.signal,
+    });
+    await secondChatStarted;
+    controller.abort(new DOMException('deadline', 'TimeoutError'));
+    const result = await pending;
+
+    const atoms = await engine.executeRaw<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM pages WHERE type = 'atom'`,
+    );
+    const receipts = await engine.executeRaw<{ n: number }>(
+      `SELECT COUNT(*)::int AS n FROM pages WHERE type = 'extract_receipt'`,
+    );
+    const rollups = await engine.executeRaw<{
+      cost_usd: string | number;
+      round_completed_count: string | number;
+    }>(
+      `SELECT cost_usd, round_completed_count
+         FROM extract_rollup_7d
+        WHERE kind = 'atoms' AND source_id = 'default'`,
+    );
+    expect(result.details?.deadline_aborted).toBe(true);
+    expect(atoms[0].n).toBe(1);
+    expect(receipts[0].n).toBe(1);
+    expect(Number(rollups[0].cost_usd)).toBeGreaterThan(0);
+    expect(Number(rollups[0].round_completed_count)).toBe(0);
+  });
+
+  test('work deadline firing during receipt does not cancel bookkeeping grace', async () => {
+    const controller = new AbortController();
+    let putCalls = 0;
+    let receiptSignal: AbortSignal | undefined;
+    let rollupSignal: AbortSignal | undefined;
+    const signalAwareEngine = {
+      executeRaw: async (sql: string, _params?: unknown[], opts?: { signal?: AbortSignal }) => {
+        if (sql.includes('INSERT INTO extract_rollup_7d')) rollupSignal = opts?.signal;
+        return [];
+      },
+      putPage: async (_slug: string, _page: unknown, opts?: { signal?: AbortSignal }) => {
+        putCalls++;
+        if (putCalls === 1) {
+          receiptSignal = opts?.signal;
+          controller.abort(new DOMException('work deadline', 'TimeoutError'));
+        }
+        return {};
+      },
+    } as unknown as BrainEngine;
+
+    const result = await runPhaseExtractAtoms(signalAwareEngine, {
+      _transcripts: [{ filePath: '/one.txt', content: 'a', contentHash: 'one' }],
+      _pages: [],
+      _chat: stubChat(`[{"title":"one","atom_type":"insight","body":"b"}]`),
+      abortSignal: controller.signal,
+    });
+
+    expect(result.details?.atoms_extracted).toBe(1);
+    expect(putCalls).toBe(1);
+    expect(receiptSignal).toBeDefined();
+    expect(receiptSignal).not.toBe(controller.signal);
+    expect(receiptSignal?.aborted).toBe(false);
+    expect(rollupSignal).toBe(receiptSignal);
+  });
+
+  test('deadline cancels the one atomic statement without partial atom commits', async () => {
+    const controller = new AbortController();
+    let atomicCalls = 0;
+    let batchRows = 0;
+    const atomicEngine = {
+      executeRaw: async (sql: string, params?: unknown[]) => {
+        if (sql.includes('INSERT INTO pages')) {
+          atomicCalls++;
+          batchRows = JSON.parse(String(params?.[0])).length;
+          controller.abort(new DOMException('deadline', 'TimeoutError'));
+          throw controller.signal.reason;
+        }
+        return [];
+      },
+    } as unknown as BrainEngine;
+
+    const result = await runPhaseExtractAtoms(atomicEngine, {
+      _transcripts: [{ filePath: '/two-atoms.txt', content: 'a', contentHash: 'two-atoms' }],
+      _pages: [],
+      _chat: stubChat(`[
+        {"title":"one","atom_type":"insight","body":"b"},
+        {"title":"two","atom_type":"insight","body":"b"}
+      ]`),
+      abortSignal: controller.signal,
+    });
+
+    expect(result.details?.deadline_aborted).toBe(true);
+    expect(result.details?.atoms_extracted).toBe(0);
+    expect(atomicCalls).toBe(1);
+    expect(batchRows).toBe(2);
+  });
+
+  test('slug-colliding atom titles commit as distinct stable rows', async () => {
+    const chat = stubChat(`[
+      {"title":"Same!","atom_type":"insight","body":"first body"},
+      {"title":"same","atom_type":"insight","body":"second body"}
+    ]`);
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [{ filePath: '/collide.txt', content: 'a', contentHash: 'collide' }],
+      _pages: [],
+      _chat: chat,
+    });
+    const firstRows = await engine.executeRaw<{ slug: string }>(
+      `SELECT slug FROM pages WHERE type = 'atom' ORDER BY slug`,
+    );
+    expect(result.details?.atoms_extracted).toBe(2);
+    expect(firstRows.length).toBe(2);
+    expect(new Set(firstRows.map((r) => r.slug)).size).toBe(2);
+
+    await runPhaseExtractAtoms(engine, {
+      _transcripts: [{ filePath: '/collide.txt', content: 'changed', contentHash: 'collide-v2' }],
+      _pages: [],
+      _chat: chat,
+    });
+    const secondRows = await engine.executeRaw<{ slug: string }>(
+      `SELECT slug FROM pages WHERE type = 'atom' ORDER BY slug`,
+    );
+    expect(secondRows.map((r) => r.slug)).toEqual(firstRows.map((r) => r.slug));
+  });
+
+  test('same atom title from two origins stays distinct and both become idempotent', async () => {
+    let chatCalls = 0;
+    const chat = async (opts: ChatOpts) => {
+      chatCalls++;
+      return stubChat(`[{"title":"Shared title","atom_type":"insight","body":"same body"}]`)(opts);
+    };
+    const transcripts = [
+      { filePath: '/origin-a.txt', content: 'a', contentHash: 'origin-a-hash' },
+      { filePath: '/origin-b.txt', content: 'b', contentHash: 'origin-b-hash' },
+    ];
+    const first = await runPhaseExtractAtoms(engine, {
+      _transcripts: transcripts,
+      _pages: [],
+      _chat: chat,
+    });
+    const firstRows = await engine.executeRaw<{ slug: string }>(
+      `SELECT slug FROM pages WHERE type = 'atom' ORDER BY slug`,
+    );
+    expect(first.details?.atoms_extracted).toBe(2);
+    expect(firstRows.length).toBe(2);
+    expect(new Set(firstRows.map((r) => r.slug)).size).toBe(2);
+
+    chatCalls = 0;
+    const second = await runPhaseExtractAtoms(engine, {
+      _transcripts: transcripts,
+      _pages: [],
+      _chat: chat,
+    });
+    expect(second.details?.atoms_extracted).toBe(0);
+    expect(second.details?.duplicates_skipped).toBe(2);
+    expect(chatCalls).toBe(0);
+  });
+
+  test('bulk JSONB path sanitizes NUL and lone surrogates in LLM prose', async () => {
+    const raw = JSON.stringify([{
+      title: 'bad\0\ud800 title',
+      atom_type: 'insight',
+      body: 'body\0\ud800 text',
+      source_quote: 'quote\0\ud800',
+      lesson: 'lesson\0\ud800',
+    }]);
+    const result = await runPhaseExtractAtoms(engine, {
+      _transcripts: [{ filePath: '/poison.txt', content: 'a', contentHash: 'poison' }],
+      _pages: [],
+      _chat: stubChat(raw),
+    });
+    const rows = await engine.executeRaw<{
+      title: string;
+      compiled_truth: string;
+      frontmatter: Record<string, unknown>;
+    }>(`SELECT title, compiled_truth, frontmatter FROM pages WHERE type = 'atom'`);
+    const serialized = JSON.stringify(rows);
+    expect(result.details?.atoms_extracted).toBe(1);
+    expect(serialized.includes('\0')).toBe(false);
+    expect(serialized.includes('\ud800')).toBe(false);
+    expect(serialized.includes('�')).toBe(true);
   });
 
   // v0.41.2.1 regression case (D9 #14 wording): with _pages:[] and same

--- a/test/extract-atoms-drain.test.ts
+++ b/test/extract-atoms-drain.test.ts
@@ -13,8 +13,11 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import {
   runExtractAtomsDrain,
+  runExtractAtomsDrainForSource,
   type ExtractAtomsDrainDeps,
 } from '../src/core/cycle/extract-atoms-drain.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+import { tryAcquireDbLock } from '../src/core/db-lock.ts';
 import { isProtectedJobName, PROTECTED_JOB_NAMES } from '../src/core/minions/protected-names.ts';
 
 function seq(values: Array<number | null>): () => Promise<number | null> {
@@ -44,23 +47,129 @@ describe('runExtractAtomsDrain (issue #1678)', () => {
   });
 
   it('stops at the wallclock window with remaining > 0', async () => {
-    // SYNC stepping clock: now() #1 sets deadline (0+100=100); the while-check
-    // then sees 50, 50 (two batches), then 999999 → past deadline → stop.
-    const times = [0, 50, 50, 999_999];
-    let ti = 0;
-    const now = () => times[Math.min(ti++, times.length - 1)];
+    let now = 0;
     const result = await runExtractAtomsDrain(
       {
         withLock: passThroughLock,
         countRemaining: async () => 5, // never drains
-        runBatch: async () => ({ extracted: 1, skipped: 0 }),
-        now,
+        runBatch: async () => {
+          now += 60;
+          return { extracted: 1, skipped: 0 };
+        },
+        now: () => now,
       },
       { windowMs: 100 },
     );
     expect(result.stopped).toBe('window');
-    expect(result.remaining).toBe(5);
+    expect(result.remaining).toBeNull();
     expect(result.batches).toBe(2);
+  });
+
+  it('passes one drain-level deadline signal into count and batch', async () => {
+    const seen: AbortSignal[] = [];
+    const controller = new AbortController();
+    let now = 0;
+    const result = await runExtractAtomsDrain(
+      {
+        withLock: passThroughLock,
+        countRemaining: async (signal) => {
+          seen.push(signal);
+          return 5;
+        },
+        runBatch: async (signal) => {
+          seen.push(signal);
+          now = 100;
+          return { extracted: 1, skipped: 0 };
+        },
+        now: () => now,
+      },
+      { windowMs: 100, abortSignal: controller.signal },
+    );
+    expect(result.stopped).toBe('window');
+    expect(result.batches).toBe(1);
+    expect(seen.length).toBe(2);
+    expect(seen[0]).toBe(seen[1]);
+    expect(seen[0]).not.toBe(controller.signal);
+  });
+
+  it('aborts a hung backlog count and releases the lock', async () => {
+    let released = false;
+    const result = await runExtractAtomsDrain(
+      {
+        withLock: async (work) => {
+          try { return await work(); }
+          finally { released = true; }
+        },
+        countRemaining: (signal) => new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        }),
+        runBatch: async () => ({ extracted: 0, skipped: 0 }),
+        now: () => 0,
+      },
+      { windowMs: 10 },
+    );
+    expect(result.stopped).toBe('window');
+    expect(result.remaining).toBeNull();
+    expect(released).toBe(true);
+  });
+
+  it('rethrows external cancellation after releasing the lock', async () => {
+    const controller = new AbortController();
+    let released = false;
+    const pending = runExtractAtomsDrain(
+      {
+        withLock: async (work) => {
+          try { return await work(); }
+          finally { released = true; }
+        },
+        countRemaining: (signal) => new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        }),
+        runBatch: async () => ({ extracted: 0, skipped: 0 }),
+        now: () => 0,
+      },
+      { windowMs: 1_000, abortSignal: controller.signal },
+    );
+    controller.abort(new DOMException('worker timeout', 'AbortError'));
+    await expect(pending).rejects.toThrow('worker timeout');
+    expect(released).toBe(true);
+  });
+
+  it('classifies a deadline-aborted zero-progress batch as window', async () => {
+    let now = 0;
+    const result = await runExtractAtomsDrain(
+      {
+        withLock: passThroughLock,
+        countRemaining: async () => 5,
+        runBatch: async () => {
+          now = 100;
+          return { extracted: 0, skipped: 0 };
+        },
+        now: () => now,
+      },
+      { windowMs: 100 },
+    );
+    expect(result.stopped).toBe('window');
+    expect(result.batches).toBe(1);
+  });
+
+  it('reports remaining unknown when the last extraction lands at deadline', async () => {
+    let now = 0;
+    const result = await runExtractAtomsDrain(
+      {
+        withLock: passThroughLock,
+        countRemaining: async () => 1,
+        runBatch: async () => {
+          now = 100;
+          return { extracted: 1, skipped: 0 };
+        },
+        now: () => now,
+      },
+      { windowMs: 100 },
+    );
+    expect(result.stopped).toBe('window');
+    expect(result.extracted).toBe(1);
+    expect(result.remaining).toBeNull();
   });
 
   it('stops on a zero-progress batch (no hot loop)', async () => {
@@ -92,6 +201,22 @@ describe('runExtractAtomsDrain (issue #1678)', () => {
         { windowMs: 1000 },
       ),
     ).rejects.toThrow('held');
+  });
+
+  it('bounds a hung lock acquisition with the drain deadline signal', async () => {
+    const started = Date.now();
+    await expect(runExtractAtomsDrain(
+      {
+        withLock: (_work, signal) => new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        }),
+        countRemaining: async () => 1,
+        runBatch: async () => ({ extracted: 0, skipped: 0 }),
+        now: Date.now,
+      },
+      { windowMs: 10 },
+    )).rejects.toThrow();
+    expect(Date.now() - started).toBeLessThan(250);
   });
 
   it('respects maxBatches as a belt-and-suspenders cap', async () => {
@@ -128,9 +253,61 @@ describe('shared wiring helper holds the cycle lock (5A)', () => {
     join(import.meta.dir, '../src/core/cycle/extract-atoms-drain.ts'),
     'utf8',
   );
+  const jobsSrc = readFileSync(join(import.meta.dir, '../src/commands/jobs.ts'), 'utf8');
   it('runExtractAtomsDrainForSource uses cycleLockIdFor(opts.sourceId) + withRefreshingLock', () => {
     expect(src).toContain('runExtractAtomsDrainForSource');
     expect(src).toContain('cycleLockIdFor(opts.sourceId)');
     expect(src).toContain('withRefreshingLock(engine, lockId');
+    expect(src).toContain('abortSignal: signal');
+    expect(src).toContain('countExtractAtomsBacklog(engine, extractionSourceId, signal)');
+    expect(src).toContain('_transcripts: []');
+    expect(jobsSrc).toContain('abortSignal: job.signal');
+  });
+
+  it('refuses PGLite because its query abort only abandons the waiter', async () => {
+    const engine = { supportsQueryCancellation: false } as BrainEngine;
+    await expect(runExtractAtomsDrainForSource(engine, {
+      sourceId: 'default',
+      windowSeconds: 1,
+    })).rejects.toThrow('requires an engine with real query cancellation');
+  });
+
+});
+
+describe('deadline-bound DB lock acquisition', () => {
+  it('an aborted second attempt cannot delete the first lock from the same PID', async () => {
+    const controller = new AbortController();
+    let heldAttempt: Date | null = null;
+    let acquireCalls = 0;
+    const engine = {
+      kind: 'postgres',
+      sql: () => Promise.resolve([]),
+      executeRaw: async (_sql: string, params?: unknown[]) => {
+        acquireCalls++;
+        const attempt = params?.[5] as Date;
+        if (acquireCalls === 1) {
+          heldAttempt = attempt;
+          return [{ id: 'same-lock' }];
+        }
+        controller.abort(new DOMException('deadline', 'TimeoutError'));
+        throw controller.signal.reason;
+      },
+      executeRawDirect: async (sql: string, params?: unknown[]) => {
+        if (sql.includes('DELETE FROM gbrain_cycle_locks')) {
+          const attempt = params?.[3] as Date;
+          if (heldAttempt?.getTime() === attempt.getTime()) heldAttempt = null;
+        }
+        return [];
+      },
+    } as unknown as BrainEngine;
+
+    const first = await tryAcquireDbLock(engine, 'same-lock');
+    const firstAttempt = heldAttempt;
+    await expect(tryAcquireDbLock(engine, 'same-lock', 5, {
+      signal: controller.signal,
+    })).rejects.toThrow();
+    expect(heldAttempt).toEqual(firstAttempt);
+    await first?.release();
+    expect(heldAttempt).toBeNull();
   });
 });

--- a/test/postgres-execute-raw-direct.test.ts
+++ b/test/postgres-execute-raw-direct.test.ts
@@ -98,14 +98,64 @@ describe('PostgresEngine.executeRawDirect — routing decision (PR #1816)', () =
   });
 
   test('already-aborted signal short-circuits with AbortError before routing the query', async () => {
-    const readConn = fakeSql('read');
+    let unsafeCalls = 0;
+    let ddlCalls = 0;
+    const readConn: FakeSql = { unsafe: async () => { unsafeCalls++; return []; } };
     const directConn = fakeSql('direct');
     const engine = makeEngine({ dualPoolActive: true, readConn, directConn });
+    const e = engine as unknown as { connectionManager: { ddl: () => Promise<FakeSql> } };
+    e.connectionManager.ddl = async () => { ddlCalls++; return directConn; };
 
     const ac = new AbortController();
     ac.abort();
     await expect(
       engine.executeRawDirect('UPDATE minion_jobs SET x=1', [], { signal: ac.signal }),
     ).rejects.toThrow(/abort/i);
+    expect(ddlCalls).toBe(0);
+    expect(unsafeCalls).toBe(0);
+  });
+
+  test('signal bounds stalled direct-pool acquisition before unsafe starts', async () => {
+    let unsafeCalls = 0;
+    const readConn: FakeSql = { unsafe: async () => { unsafeCalls++; return []; } };
+    const directConn = fakeSql('direct');
+    const engine = makeEngine({ dualPoolActive: true, readConn, directConn });
+    const e = engine as unknown as { connectionManager: { ddl: () => Promise<FakeSql> } };
+    e.connectionManager.ddl = () => new Promise<FakeSql>(() => {});
+
+    const started = Date.now();
+    await expect(engine.executeRawDirect(
+      'DELETE FROM gbrain_cycle_locks',
+      [],
+      { signal: AbortSignal.timeout(10) },
+    )).rejects.toThrow(/abort/i);
+    expect(Date.now() - started).toBeLessThan(250);
+    expect(unsafeCalls).toBe(0);
+  });
+
+  test('abort during unsafe creation is observed by the post-listener recheck', async () => {
+    const ac = new AbortController();
+    let cancelCalls = 0;
+    let rejectPending!: (err: unknown) => void;
+    const pending = new Promise<unknown[]>((_resolve, reject) => { rejectPending = reject; }) as
+      Promise<unknown[]> & { cancel?: () => void };
+    pending.cancel = () => {
+      cancelCalls++;
+      rejectPending(new DOMException('aborted', 'AbortError'));
+    };
+    const readConn: FakeSql = {
+      unsafe: () => {
+        ac.abort();
+        return pending;
+      },
+    };
+    const engine = makeEngine({ dualPoolActive: false, readConn, directConn: fakeSql('direct') });
+
+    await expect(engine.executeRawDirect(
+      'UPDATE minion_jobs SET x=1',
+      [],
+      { signal: ac.signal },
+    )).rejects.toThrow(/abort/i);
+    expect(cancelCalls).toBe(1);
   });
 });


### PR DESCRIPTION
Closes #2750.

## What changed
- threads the drain deadline through lock acquisition, backlog count, chat/query work, writes, and lock release
- cancels external worker/query work when the window expires
- gives receipts/rollups and lock release a bounded bookkeeping grace period
- refuses the unsupported PGLite path where a real query cancel cannot be guaranteed
- preserves the existing single-statement/no-inline-retry invariant in `PostgresEngine.runUnsafe`
- adds regression coverage for hung chat, hung write, partial progress, atomicity, and deadline bookkeeping

## Verification
- 75/75 targeted tests across deadline, synthesize, direct-query, and connection-resilience suites
- `bun run typecheck`
- `bun run verify` (31/31)
- live Postgres canary: prior drain job ran 282.5s; patched runtime returned in 0.369s with backlog preserved

A full unit fan-out was sampled for 14 minutes and stopped because the repository runner was on pace to exceed its own 25-minute timeout. It surfaced the pre-existing single-statement static invariant; that was fixed in `29272f1d` and its owning test now passes. Other observed failures were unrelated parallel-test fixtures (git tag editor isolation and ambient-channel state).
