### PR TITLE
feat(dream): process BirdClaw bookmarks through OpenCode

### DIFF
--- a/docs/ai-providers/opencode-server.md
+++ b/docs/ai-providers/opencode-server.md
@@ -1,0 +1,104 @@
+# OpenCode Server Provider
+
+Use a persistent local OpenCode server as a GBrain chat and subagent provider.
+OpenCode owns ChatGPT OAuth credentials and token refresh; GBrain never reads or
+copies OpenCode's OAuth tokens.
+
+## Architecture
+
+```text
+GBrain gateway/tool loop
+  -> OpenCode local HTTP server
+    -> OpenAI model through OpenCode's ChatGPT OAuth
+      -> structured text or GBrain tool requests
+        -> GBrain executes tools with its normal allow-lists and audit records
+```
+
+OpenCode tools are denied for every adapter-created session. OpenCode returns
+structured tool requests, but GBrain remains the only process that executes
+brain operations. This preserves Minion job receipts, idempotency, source
+scoping, and crash replay.
+
+Define a minimal primary agent in the server's `opencode.json`. Avoid using the
+built-in `build` agent here: its coding instructions add substantial prompt
+tokens that GBrain does not need.
+
+```json
+{
+  "agent": {
+    "gbrain": {
+      "description": "Model transport for GBrain",
+      "mode": "primary",
+      "prompt": "Follow the caller's system and user instructions exactly.",
+      "permission": { "*": "deny" }
+    }
+  }
+}
+```
+
+## Authenticate OpenCode
+
+```bash
+opencode providers login --pure \
+  --provider OpenAI \
+  --method "ChatGPT Pro/Plus (browser)"
+```
+
+Verify that `OpenAI oauth` appears:
+
+```bash
+opencode providers list
+```
+
+## Start the server
+
+Bind the service to loopback. For a single-user workstation, loopback-only mode
+keeps the endpoint off the network. Set `OPENCODE_SERVER_PASSWORD` as well when
+other local users or untrusted local processes are in scope.
+
+```bash
+opencode serve --pure --hostname 127.0.0.1 --port 4097
+```
+
+The default GBrain connection is `http://127.0.0.1:4097`. Optional settings:
+
+| GBrain config.json field | Environment override | Default |
+| --- | --- | --- |
+| `opencode_server_url` | `GBRAIN_OPENCODE_SERVER_URL` | `http://127.0.0.1:4097` |
+| `opencode_server_username` | `GBRAIN_OPENCODE_SERVER_USERNAME` | `opencode` |
+| `opencode_server_password` | `GBRAIN_OPENCODE_SERVER_PASSWORD` | empty |
+| `opencode_server_provider_id` | `GBRAIN_OPENCODE_PROVIDER_ID` | `openai` |
+| `opencode_server_agent` | `GBRAIN_OPENCODE_AGENT` | `gbrain` |
+
+## Configure GBrain
+
+Keep inexpensive utility and verdict calls on their existing provider during
+the initial rollout. Route one expensive task at a time:
+
+```bash
+gbrain config set agent.use_gateway_loop true
+gbrain config set models.dream.synthesize opencode-server:gpt-5.5
+```
+
+After synthesis is proven on a bounded corpus:
+
+```bash
+gbrain config set models.dream.patterns opencode-server:gpt-5.5
+gbrain config set models.think opencode-server:gpt-5.5
+```
+
+Do not use this provider for embeddings. It intentionally exposes only the
+chat touchpoint.
+
+## Operational notes
+
+- A persistent server avoids starting and loading OpenCode for every call.
+- Model input tokens are not eliminated. Each GBrain gateway turn still sends
+  the relevant conversation and tool definitions; provider-side prefix caching
+  may reduce repeated work but is not guaranteed by this adapter.
+- Each adapter call creates a deny-all OpenCode session and deletes it after the
+  response. GBrain owns multi-turn state and tool replay.
+- HTTP 401/403/404 responses are configuration failures. Network, 429, and 5xx
+  failures are retryable provider failures.
+- Keep Anthropic configured as a fallback until live dream and pattern runs are
+  green on representative data.

--- a/docs/guides/birdclaw-native-dream.md
+++ b/docs/guides/birdclaw-native-dream.md
@@ -1,0 +1,46 @@
+# BirdClaw Bookmarks in the Native Dream Cycle
+
+BirdClaw remains the deterministic collector. GBrain owns every reasoning step after import: `extract_atoms` identifies durable ideas and concept references, `synthesize_concepts` builds evidence-linked topic pages, and normal dream phases index and connect the generated knowledge.
+
+## Contract
+
+A bookmark is eligible only when its `media` page carries all three markers:
+
+```yaml
+intake_adapter: birdclaw-bookmarks-to-brain
+content_kind: x-bookmark
+concept_synthesis_candidate: true
+```
+
+Unmarked media never enters atom extraction. Concept promotion from research requires at least two distinct original bookmark pages. Generated concept pages keep bounded `supporting_atoms` and `supporting_sources` records, including `source_id`, and render a `Supporting research` section.
+
+## Safe pilot
+
+1. Leave the existing combined BirdClaw job running while preparing the pilot. Do not let the custom and native synthesizers own the same concept namespace.
+2. Create an isolated brain/database and import a small, representative set of marked bookmarks into a dedicated source.
+3. Activate `gbrain-creator` or `gbrain-everything`; other packs intentionally skip these phases.
+4. Preflight the configured AI gateway and confirm the model route is `opencode-server:*`. Native phases use the gateway; no direct Anthropic or OpenCode HTTP call belongs in the collector.
+5. Run `gbrain dream --phase extract_atoms --drain --window 300` until its backlog reaches zero. Inspect atoms for normalized `concepts`, `source_slug`, and `source_hash`.
+6. Run `gbrain dream --phase synthesize_concepts`. Inspect concept pages for distinct-source support, bounded provenance, and readable bookmark links.
+7. Run the normal dream again. Graph and fact phases precede atom/concept generation in a cycle, so this second pass is required to project links and facts from newly generated pages. Embedding runs after synthesis in the generating cycle.
+8. Run `gbrain doctor`, inspect extraction receipts/rollups, and search for several expected topics. Follow each result back to at least two original bookmarks.
+9. Repeat synthesis once. The bounded support set and evidence order must remain stable, with no duplicate links or timestamp-only rewrite.
+
+## Acceptance signals
+
+- Marked bookmark count advances after collection and sync.
+- `extract_atoms` receipts advance through the backlog with no unrelated media admitted.
+- Native concepts have useful summaries and at least two distinct original sources.
+- Search returns a topic and its supporting research links resolve to imported bookmarks.
+- Provider diagnostics identify the OpenCode gateway route; provider failures appear as native warnings or deterministic fallback, never as a legacy processor invocation.
+- A second dream pass creates the expected graph/fact projections.
+
+## Cutover
+
+After the pilot passes, change the BirdClaw scheduler to collector-only mode. It should collect, import, commit, and run `gbrain sync`, then stop. The ordinary GBrain dream schedule owns extraction and synthesis. Keep the previous combined invocation available for rollback until the native backlog is drained and a quality sample is accepted.
+
+Legacy `pipeline_status`, `needs_enrichment`, and custom analysis timestamps are compatibility metadata only. Native receipts, source hashes, atom pages, and concept provenance become the processing system of record.
+
+## Rollback
+
+Pause native bookmark extraction by removing `concept_synthesis_candidate: true` from new imports or switching to a pack that does not declare the creator phases. Restore the prior combined BirdClaw invocation if necessary. Do not run both synthesizers against the same concept slugs. Existing native pages remain inspectable and can be removed from the isolated pilot brain without affecting collected bookmark files.

--- a/docs/guides/operational-disciplines.md
+++ b/docs/guides/operational-disciplines.md
@@ -116,5 +116,7 @@ on nightly_schedule("02:00"):
 4. Run `gbrain doctor`. Confirm it returns a health report with database status, page count, and any flagged issues.
 5. After a dream cycle runs, check a page that had unlinked entity mentions. Confirm new links were added (`gbrain get_links <slug>`).
 
+For X bookmark research, BirdClaw is only the collector; native creator-pack dream phases perform extraction and concept synthesis. See [BirdClaw Bookmarks in the Native Dream Cycle](birdclaw-native-dream.md) for the eligibility contract, two-pass timing, pilot, cutover, and rollback procedure.
+
 ---
 *Part of the [GBrain Skillpack](../GBRAIN_SKILLPACK.md).*

--- a/docs/plans/2026-07-12-001-feat-native-bookmark-dream-plan.md
+++ b/docs/plans/2026-07-12-001-feat-native-bookmark-dream-plan.md
@@ -1,0 +1,336 @@
+---
+title: Native Bookmark Knowledge Processing in GBrain Dream
+type: feat
+status: active
+date: 2026-07-12
+---
+
+# Native Bookmark Knowledge Processing in GBrain Dream
+
+## Summary
+
+Move X-bookmark enrichment and knowledge-wiki synthesis from the parallel custom processor into GBrain's existing creator-pack dream lifecycle. BirdClaw remains a deterministic collector, while normal `extract_atoms` and `synthesize_concepts` phases become capable of producing bounded, evidence-linked concepts from bookmark pages through GBrain's configured OpenCode provider.
+
+---
+
+## Problem Frame
+
+The current bookmark pipeline writes into the brain and invokes GBrain indexing, but its reasoning layer is a separate JavaScript system and separate LaunchAgent. This duplicates capabilities already present in the `gbrain-creator` and `gbrain-everything` packs, weakens lifecycle observability, and risks semantic drift from normal dream behavior.
+
+Native creator phases are close to the desired behavior but have three gaps: bookmark pages are not eligible inputs, extracted atoms do not persist concept references, and synthesized concepts do not retain drill-down provenance to atoms and original research pages. The native concept prompt is bounded by sampled evidence, but its persisted output also needs bounded provenance and explicit evidence links.
+
+---
+
+## Requirements
+
+- **R1 — Native lifecycle:** Bookmark-derived enrichment must run through standard `gbrain dream` creator-pack phases, receipts, rollups, locking, budgets, progress, and configured AI gateway.
+- **R2 — Deterministic collection boundary:** BirdClaw collection/import remains separate from dream and must not be reimplemented as model-driven work.
+- **R3 — Bookmark eligibility:** Synced media pages explicitly marked by the BirdClaw importer as concept-synthesis candidates, and meeting existing content and recursion guards, must be discoverable by native atom extraction; unrelated media remains ineligible.
+- **R4 — Durable concepts:** Extracted atoms must carry a bounded, normalized set of concept references suitable for native aggregation.
+- **R5 — Evidence-linked wiki:** Synthesized concept pages must retain bounded, source-aware supporting atom and source-page provenance and expose readable links back to research evidence. Bookmark-backed promotion requires at least two distinct original sources.
+- **R6 — Archive safety:** No phase may send the full bookmark archive in one prompt; model inputs and persisted provenance must remain bounded.
+- **R7 — Idempotency and recursion safety:** Existing source-hash deduplication and leaf-output safeguards must continue to prevent duplicates and dream self-consumption.
+- **R8 — Safe migration:** The parallel custom reasoning scheduler is retired only after a bounded native pilot proves extraction, synthesis, provenance, search, and rerun behavior.
+- **R9 — Existing dream behavior:** Meeting, transcript, article, video, book, source, and original processing must not regress.
+
+---
+
+## Assumptions
+
+- `media` remains a broad generic type; bookmark admission additionally requires the importer's stable `intake_adapter`, `content_kind`, and concept-synthesis opt-in metadata.
+- The creator or everything schema pack will be active in the deployed brain before the native pilot.
+- GBrain's configured `opencode-server:*` models remain the only text-model route; embeddings remain on the configured embedding provider.
+- Deterministic bookmark author metadata stays owned by the importer; normal graph/fact phases handle entities mentioned in generated native pages.
+- The initial migration may preserve existing custom analyses as historical artifacts, but they do not feed native synthesis after cutover.
+
+---
+
+## Scope Boundaries
+
+### In scope
+
+- Extend native atom extraction to eligible media pages.
+- Extract and normalize concept references on atoms.
+- Preserve bounded atom/source provenance on synthesized concepts.
+- Keep concept-model evidence samples bounded.
+- Add regression and integration coverage for the full marked-bookmark-page → atom → concept path, including cross-source provenance.
+- Document and execute a bounded local pilot and cutover checklist.
+
+### Deferred to follow-up work
+
+- Replacing BirdClaw collection with an `IngestionSource` plugin.
+- Rich bookmark-specific person/place/organization pages beyond normal GBrain graph extraction.
+- Hierarchical concept deduplication across semantically similar concept slugs.
+- Per-atom deterministic retry completion for partially written multi-atom extractions.
+
+### Out of scope
+
+- Disabling or replacing the normal nightly dream cycle.
+- Adding BirdClaw or X-specific credentials to GBrain core.
+- Registering an arbitrary shell-command handler or writable handler registry.
+- Importing the existing custom concept pages as native atom evidence.
+
+---
+
+## Key Technical Decisions
+
+1. **Reuse creator-pack phases rather than add bookmark-specific phases.** The existing source-scoped extraction and global synthesis split already matches the required lifecycle and avoids a second orchestration model.
+2. **Use the GBrain AI gateway.** Atom extraction and concept synthesis inherit configured OpenCode OAuth routing, receipts, budgets, progress, abort handling, and provider diagnostics.
+3. **Bound both model evidence and persisted provenance.** Synthesis canonically sorts before sampling a deterministic maximum number of atom titles/bodies and supporting atoms/sources, with total atom and distinct-source counts retained separately.
+4. **Keep raw evidence one-way.** Bookmark media pages may produce atoms; atoms remain non-extractable leaves; concept pages are synthesized outputs and never become atom inputs.
+5. **Pilot before cutover.** Native output is validated in an isolated pilot brain/source so native and custom writers cannot collide on `concepts/<slug>`. Collection continues throughout.
+6. **Accept two-cycle graph consistency.** The generating dream cycle writes and embeds atoms/concepts; a subsequent native extract/facts pass materializes downstream graph/fact projections unless same-write reconciliation is proven by tests.
+
+---
+
+## High-Level Technical Design
+
+> Directional guidance for review, not implementation specification.
+
+```mermaid
+flowchart LR
+    X[X bookmarks] --> B[BirdClaw collector/importer]
+    B --> M[GBrain media pages]
+    M --> S[gbrain sync]
+    S --> A[Dream: extract_atoms<br/>source scoped]
+    A --> C[Atoms with concepts<br/>and source provenance]
+    C --> Y[Dream: synthesize_concepts<br/>global scoped]
+    Y --> W[Evidence-linked concept pages]
+    W --> G[Native graph, facts,<br/>embeddings, search]
+```
+
+Failure isolation remains native: extraction records per-source failures and continues; synthesis falls back deterministically for model failures or exhausted budget; cycle reports remain the operational truth.
+
+---
+
+## Implementation Units
+
+- U1. **Make bookmark media pages native atom inputs**
+
+**Goal:** Allow qualifying bookmark media pages to enter creator-pack extraction without weakening existing recursion or idempotency guards.
+
+**Requirements:** R1, R3, R7, R9
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `src/core/cycle/extract-atoms.ts`
+- Create: `test/cycle/extract-atoms-page-discovery.test.ts`
+- Test: `test/cycle/extract-atoms-synthesize-concepts.test.ts`
+
+**Approach:**
+- Add marked media pages to eligibility while leaving unrelated media excluded. Centralize or share predicate fragments used by discovery and backlog counts so they cannot drift.
+- Preserve minimum-content, source scope, source-hash idempotency, imported-output, and dream-output exclusions.
+- Require stable BirdClaw intake/content markers and explicit concept-synthesis opt-in in addition to the media type.
+
+**Execution note:** Test-first.
+
+**Patterns to follow:**
+- Shared eligibility/query-builder logic in `src/core/cycle/extract-atoms.ts`.
+- Existing discovery/backlog behavior adjacent to `test/cycle/extract-atoms-synthesize-concepts.test.ts`.
+
+**Test scenarios:**
+- Happy path: a marked BirdClaw media page above the minimum content threshold is discovered and extracted into atoms.
+- Edge case: an otherwise identical unmarked media page remains ineligible and absent from backlog counts.
+- Edge case: a short media page remains ineligible.
+- Error path: a media page already represented by an atom source hash is skipped.
+- Integration: discovery and backlog count return consistent results for the same media-page corpus.
+- Regression: existing supported page types and dream/imported-output exclusions remain unchanged.
+
+**Verification:**
+- A bounded media fixture is processed by `extract_atoms`, while duplicate and recursion guards remain green.
+
+---
+
+- U2. **Persist bounded concept references on extracted atoms**
+
+**Goal:** Give native concept synthesis durable topic grouping keys generated during atom extraction.
+
+**Requirements:** R1, R4, R6, R7, R9
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `src/core/cycle/extract-atoms.ts`
+- Test: `test/cycle/extract-atoms-synthesize-concepts.test.ts`
+
+**Approach:**
+- Extend the atom extraction contract with a small concept-reference list.
+- Normalize references to stable slugs, remove duplicates and empty/generic values, and enforce a strict per-atom cap.
+- Persist references in atom frontmatter alongside existing source provenance.
+- Retain tolerant parsing for older or malformed model outputs that omit concepts.
+
+**Execution note:** Test-first.
+
+**Patterns to follow:**
+- Existing tolerant `parseAtomsResponse` validation and bounded string handling.
+- Existing atom frontmatter persistence and source-aware `putPage` flow.
+
+**Test scenarios:**
+- Happy path: valid concept names normalize and persist on the atom.
+- Edge case: duplicate, empty, oversized, and punctuation-heavy concepts normalize deterministically within the cap.
+- Error path: non-array or malformed concept output does not reject an otherwise valid atom.
+- Regression: responses without concepts continue to parse and write exactly as before except for absent optional metadata.
+
+**Verification:**
+- Native atoms created from bookmark media pages contain usable `concepts` frontmatter without changing required atom fields.
+
+---
+
+- U3. **Generate bounded evidence-linked native concept pages**
+
+**Goal:** Make native concepts navigable back to supporting atoms and original bookmark pages while preserving bounded model input.
+
+**Requirements:** R5, R6, R7, R9
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `src/core/cycle/synthesize-concepts.ts`
+- Test: `test/cycle/extract-atoms-synthesize-concepts.test.ts`
+- Test: `test/cycle/synthesize-concepts-progress.test.ts`
+
+**Approach:**
+- Carry atom `source_id`, atom slug, original source slug, and source hash through grouping.
+- Canonically sort by source identity and atom slug before every prompt or provenance cap; shuffled query/input order must produce the same support projection.
+- Deduplicate original sources and keep deterministic bounded samples for prompts, source-aware frontmatter, and rendered supporting-research links.
+- Record total atom count and distinct original-source count separately. Bookmark-backed concepts require at least two distinct original sources; repeated atoms from one bookmark do not promote a concept alone.
+- Preserve tiering, budget fallback, receipts, rollups, and progress semantics.
+- Ensure reruns replace the concept projection deterministically rather than accumulating duplicate links; avoid timestamp-only churn when semantic content and support are unchanged.
+
+**Execution note:** Test-first.
+
+**Patterns to follow:**
+- Per-group bounded title/body sampling already used by `synthesize-concepts`.
+- Source provenance written by `extract-atoms`.
+- Existing concept `putPage` replacement semantics.
+
+**Test scenarios:**
+- Happy path: a concept synthesized from multiple original sources includes readable supporting atom and original-source links with explicit source identity.
+- Edge case: repeated atoms from one bookmark deduplicate the source link, retain total atom count, and do not meet the two-source promotion threshold alone.
+- Edge case: identical slugs in two GBrain sources remain unambiguous in stored provenance.
+- Edge case: a dominant concept with a large corpus respects prompt and provenance caps.
+- Error path: atoms without source provenance still contribute without producing broken links.
+- Integration: shuffled input and a second synthesis run produce the same bounded support set and no duplicate links or timestamp-only rewrite.
+- Regression: T1/T2 model narratives, T3 deterministic narratives, budgets, receipts, and progress remain intact.
+
+**Verification:**
+- Concept pages satisfy the intended wiki drill-down experience without corpus-sized prompts or unbounded frontmatter.
+
+---
+
+- U4. **Document and validate native cutover**
+
+**Goal:** Provide a safe operational path from the parallel custom processor to native dream processing.
+
+**Requirements:** R2, R8
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `docs/guides/operational-disciplines.md`
+- Create: `docs/guides/birdclaw-native-dream.md`
+- Test: `test/e2e/dream.test.ts`
+
+**Approach:**
+- Document creator/everything pack activation, isolated pilot brain/source creation, dream phase drain, expected receipts/rollups, provenance checks, second-pass graph/fact timing, search checks, and rollback.
+- Compare custom and native results across isolated namespaces; never allow both systems to own the same concept slug during pilot.
+- Preflight the configured provider and verify receipts/model diagnostics show the OpenCode route; verify unavailable-provider behavior degrades through native warnings/fallback without invoking legacy processing.
+- Define completion signals and steady-state schedule ownership.
+
+**Test scenarios:**
+- Integration: a bounded marked-media fixture in an isolated source flows through dream extraction and synthesis in creator-pack phase order.
+- Error path: a phase warning is visible in the dream report and does not erase prior native output.
+- Regression: a non-creator pack continues to skip creator-only phases.
+- Integration: the documented second pass materializes graph/fact projections for newly generated pages, or the test proves same-write reconciliation.
+
+**Verification:**
+- The guide contains a reversible pilot/cutover procedure and the e2e dream path proves native orchestration.
+
+---
+
+- U5. **Split live BirdClaw collection from legacy reasoning and cut over**
+
+**Goal:** Retain frequent deterministic collection/import while retiring only the custom analysis/synthesis engine after native validation.
+
+**Requirements:** R2, R8
+
+**Dependencies:** U4
+
+**Target repository:** `gbrain-custom`
+
+**Files:**
+- Modify: `integrations/birdclaw-bookmarks-to-brain/run-pipeline.sh`
+- Modify: `integrations/birdclaw-bookmarks-to-brain/README.md`
+- Modify: `integrations/birdclaw-bookmarks-to-brain/launchd/ai.gbrain.birdclaw-bookmarks-to-brain.plist.template`
+- Test: `integrations/birdclaw-bookmarks-to-brain/test/run-pipeline.test.mjs`
+
+**Approach:**
+- Add a collector/import-only mode that stops before custom analysis/synthesis while retaining sync of newly imported pages.
+- Transfer enrichment-stage truth from legacy `pipeline_status`, `needs_enrichment`, and timestamp fields to native receipts/source-hash evidence; document which legacy fields become compatibility-only or disappear from new imports.
+- Reload the live LaunchAgent into collector-only mode only after isolated native acceptance criteria pass.
+- Preserve a rollback to the prior combined mode until the final native drain and quality audit complete.
+
+**Execution note:** Characterization-first, then test-first for the new operating mode.
+
+**Test scenarios:**
+- Happy path: collector-only mode fetches/imports a new bookmark and syncs it without invoking custom analysis or synthesis.
+- Edge case: rerunning the same slot remains idempotent.
+- Error path: collection/import failure exits visibly without mutating native dream state.
+- Integration: after LaunchAgent reload, imported bookmark count advances while custom analysis count stays fixed and native receipts advance after dream.
+
+**Verification:**
+- Live collection continues independently, legacy reasoning is quiescent, and rollback remains available.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** sync writes marked media pages; source-scoped dream extraction writes atoms; global dream synthesis writes concepts; embedding follows in-cycle, while graph/fact projections are verified on the documented next pass unless same-write reconciliation is proven.
+- **Error propagation:** per-item extraction failures remain warnings; synthesis model failures retain deterministic fallback; phase reports and receipts expose partial outcomes.
+- **State lifecycle risks:** admitting marked bookmark media creates a large one-time atom backlog; source-hash idempotency and page-discovery budgets bound each cycle. Pilot isolation prevents concept namespace collisions.
+- **API surface parity:** direct dream, autopilot source fan-out, and global maintenance must preserve phase scope and pack gating.
+- **Integration coverage:** unit parsing tests alone are insufficient; a creator-pack e2e path must prove page discovery, atom persistence, concept provenance, and retrieval-ready output.
+- **Unchanged invariants:** no credentials in core, no arbitrary shell handler, no atom/concept self-consumption, no global phase per-source fan-out, no replacement of normal dream.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Eligibility accidentally admits unrelated media | Require stable BirdClaw markers plus explicit opt-in in the shared discovery/backlog predicate |
+| Generic model concept labels create topic fragmentation | Normalize/cap concept slugs now; defer semantic merging to follow-up |
+| Large dominant concepts approach context limits | Deterministic prompt sampling and bounded persisted support evidence |
+| Native output lacks rich author/entity pages from the custom system | Preserve deterministic import metadata and rely on normal graph/fact phases; audit after pilot |
+| Parallel native and custom synthesis overwrite the same concept pages | Use an isolated pilot brain/source and prohibit shared concept ownership until atomic cutover |
+| Creator pack is not active | Include schema-pack activation and verification in the runbook |
+| Existing bookmark pages create a large initial backlog | Use the native drain job/phase with budgets, progress, and idempotent checkpoints |
+| Cross-source slugs are ambiguous | Persist `source_id` with atom/source slugs and test identical-slug collisions |
+| New outputs miss graph/fact processing in their generating cycle | Document and verify the required subsequent native pass unless direct reconciliation is proven |
+
+---
+
+## Documentation / Operational Notes
+
+- Recommended pilot order: create an isolated pilot brain/source; activate creator/everything pack; sync marked fixtures; verify OpenCode provider routing; run `extract_atoms`; inspect atoms and source-aware provenance; run `synthesize_concepts`; inspect concept links; run the required graph/fact pass and embed; test search; then drain the remaining backlog.
+- Monitor phase receipts, extract rollups, Minion progress, backlog count, model budget, and repeated source hashes.
+- Surgical rollback leaves creator processing active for other content: disable marked-media eligibility or return the collector LaunchAgent to combined legacy mode. Restoring a non-creator pack is a broader rollback and affects all creator inputs.
+- After successful cutover, restore bookmark collection to its steady-state cadence independently of nightly dream.
+
+---
+
+## Sources & References
+
+- `src/core/cycle/extract-atoms.ts`
+- `src/core/cycle/synthesize-concepts.ts`
+- `src/core/cycle.ts`
+- `src/core/schema-pack/base/gbrain-creator.yaml`
+- `docs/architecture/lens-packs.md`
+- `docs/guides/plugin-handlers.md`
+- `docs/ai-providers/opencode-server.md`
+- `test/cycle/extract-atoms-synthesize-concepts.test.ts`
+- `test/cycle/extract-atoms-page-discovery.test.ts`
+- `test/cycle-pack-gating.test.ts`
+- `test/autopilot-global-maintenance.test.ts`
+- `test/e2e/dream.test.ts`

--- a/docs/plans/2026-07-12-001-feat-native-bookmark-dream-plan.md
+++ b/docs/plans/2026-07-12-001-feat-native-bookmark-dream-plan.md
@@ -1,7 +1,7 @@
 ---
 title: Native Bookmark Knowledge Processing in GBrain Dream
 type: feat
-status: active
+status: completed
 date: 2026-07-12
 ---
 

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -9,8 +9,9 @@ import { listRecipes, getRecipe } from '../core/ai/recipes/index.ts';
 import { configureGateway, embedOne, isAvailable as gwIsAvailable, chat as gwChat } from '../core/ai/gateway.ts';
 import { probeOllama, probeLMStudio } from '../core/ai/probes.ts';
 import { loadConfig } from '../core/config.ts';
+import { buildGatewayConfig } from '../core/ai/build-gateway-config.ts';
 import { AIConfigError, AITransientError } from '../core/ai/errors.ts';
-import type { Recipe } from '../core/ai/types.ts';
+import type { AIGatewayConfig, Recipe } from '../core/ai/types.ts';
 
 const SCHEMA_VERSION = 1;
 
@@ -31,17 +32,9 @@ interface ProviderOption {
   cons: string[];
 }
 
-function configureFromEnv(): void {
+function gatewayConfigFromEnv(): AIGatewayConfig {
   const config = loadConfig();
-  configureGateway({
-    embedding_model: config?.embedding_model,
-    embedding_dimensions: config?.embedding_dimensions,
-    expansion_model: config?.expansion_model,
-    chat_model: config?.chat_model,
-    chat_fallback_chain: config?.chat_fallback_chain,
-    base_urls: config?.provider_base_urls,
-    env: { ...process.env },
-  });
+  return config ? buildGatewayConfig(config) : { env: { ...process.env } };
 }
 
 export function envReady(recipe: Recipe, env: NodeJS.ProcessEnv = process.env): boolean {
@@ -89,7 +82,7 @@ export function formatRecipeTable(recipes: Recipe[], env: NodeJS.ProcessEnv = pr
 }
 
 export async function runProviders(subcommand: string | undefined, args: string[]): Promise<void> {
-  configureFromEnv();
+  configureGateway(gatewayConfigFromEnv());
 
   switch (subcommand) {
     case 'list':
@@ -183,14 +176,14 @@ async function runTest(args: string[]): Promise<void> {
     if (tpArg === 'embedding') {
       const dims = recipe?.touchpoints.embedding?.default_dims ?? 1536;
       configureGateway({
+        ...gatewayConfigFromEnv(),
         embedding_model: modelArg,
         embedding_dimensions: dims,
-        env: { ...process.env },
       });
     } else {
       configureGateway({
+        ...gatewayConfigFromEnv(),
         chat_model: modelArg,
-        env: { ...process.env },
       });
     }
     void modelId; // intentionally unused but preserved for readability
@@ -209,10 +202,21 @@ async function runTest(args: string[]): Promise<void> {
       const ms = Date.now() - start;
       console.log(`  ✓ ${ms}ms, ${v.length} dims`);
     } else {
-      const result = await gwChat({
-        messages: [{ role: 'user', content: 'Reply with just the word: pong' }],
-        maxTokens: 16,
+      let result = await gwChat({
+        messages: [{ role: 'user', content: 'This is a connectivity test. In your final answer, write READY. Do not call tools.' }],
+        // Structured transports need enough headroom for their JSON envelope
+        // even when the visible response is one word.
+        maxTokens: 128,
       });
+      if (!result.text.trim()) {
+        result = await gwChat({
+          messages: [{ role: 'user', content: 'Connectivity test: provide a non-empty final response containing READY.' }],
+          maxTokens: 128,
+        });
+      }
+      if (!result.text.trim()) {
+        throw new AITransientError('Chat provider returned empty smoke-test responses twice.');
+      }
       const ms = Date.now() - start;
       const preview = (result.text || '<empty>').replace(/\s+/g, ' ').slice(0, 80);
       console.log(`  ✓ ${ms}ms · model=${result.model} · stop=${result.stopReason} · in=${result.usage.input_tokens}/out=${result.usage.output_tokens} · "${preview}"`);

--- a/src/core/ai/build-gateway-config.ts
+++ b/src/core/ai/build-gateway-config.ts
@@ -34,6 +34,11 @@ export function buildGatewayConfig(c: GBrainConfig): AIGatewayConfig {
   // plane field now exists (GBrainConfig type) and gets mapped here, so
   // setting it via `~/.gbrain/config.json` propagates into the gateway.
   if (c.zeroentropy_api_key) envFromConfig.ZEROENTROPY_API_KEY = c.zeroentropy_api_key;
+  if (c.opencode_server_url) envFromConfig.GBRAIN_OPENCODE_SERVER_URL = c.opencode_server_url;
+  if (c.opencode_server_username) envFromConfig.GBRAIN_OPENCODE_SERVER_USERNAME = c.opencode_server_username;
+  if (c.opencode_server_password) envFromConfig.GBRAIN_OPENCODE_SERVER_PASSWORD = c.opencode_server_password;
+  if (c.opencode_server_provider_id) envFromConfig.GBRAIN_OPENCODE_PROVIDER_ID = c.opencode_server_provider_id;
+  if (c.opencode_server_agent) envFromConfig.GBRAIN_OPENCODE_AGENT = c.opencode_server_agent;
 
   // v0.32 codex finding #4+#5 fix: thread local-server _BASE_URL env vars
   // into base_urls so the gateway hits the user's configured port. Without

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -52,6 +52,7 @@ import { dimsProviderOptions } from './dims.ts';
 import { hasAnthropicKey } from './anthropic-key.ts';
 import { AIConfigError, AITransientError, normalizeAIError } from './errors.ts';
 import { runGuardrails, hasGuardrails, type GuardrailHook } from '../guardrails.ts';
+import { OpenCodeServerLanguageModel } from './providers/opencode-server-language-model.ts';
 
 // ---- Gateway-wide AI-HTTP timeout (v0.42.20.0, #1762/#1775) ----
 //
@@ -1266,6 +1267,10 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
       throw new AIConfigError(
         `Anthropic has no embedding model. Use openai or google for embeddings.`,
       );
+    case 'opencode-server':
+      throw new AIConfigError(
+        `opencode-server has no embedding model. Use openai, zeroentropyai, or google for embeddings.`,
+      );
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
       const auth = applyResolveAuth(recipe, cfg, 'embedding');
@@ -2182,6 +2187,14 @@ function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayCon
       const baseURL = resolveNativeBaseUrl('anthropic', cfg);
       return createAnthropic({ apiKey, ...(baseURL ? { baseURL } : {}) }).languageModel(modelId);
     }
+    case 'opencode-server':
+      return new OpenCodeServerLanguageModel(modelId, {
+        baseUrl: cfg.env.GBRAIN_OPENCODE_SERVER_URL,
+        username: cfg.env.GBRAIN_OPENCODE_SERVER_USERNAME,
+        password: cfg.env.GBRAIN_OPENCODE_SERVER_PASSWORD,
+        providerId: cfg.env.GBRAIN_OPENCODE_PROVIDER_ID,
+        agent: cfg.env.GBRAIN_OPENCODE_AGENT,
+      });
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
       const auth = applyResolveAuth(recipe, cfg, 'expansion');
@@ -2556,6 +2569,14 @@ function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig):
       const baseURL = resolveNativeBaseUrl('anthropic', cfg);
       return createAnthropic({ apiKey, ...(baseURL ? { baseURL } : {}) }).languageModel(modelId);
     }
+    case 'opencode-server':
+      return new OpenCodeServerLanguageModel(modelId, {
+        baseUrl: cfg.env.GBRAIN_OPENCODE_SERVER_URL,
+        username: cfg.env.GBRAIN_OPENCODE_SERVER_USERNAME,
+        password: cfg.env.GBRAIN_OPENCODE_SERVER_PASSWORD,
+        providerId: cfg.env.GBRAIN_OPENCODE_PROVIDER_ID,
+        agent: cfg.env.GBRAIN_OPENCODE_AGENT,
+      });
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
       const auth = applyResolveAuth(recipe, cfg, 'chat');

--- a/src/core/ai/providers/opencode-server-language-model.ts
+++ b/src/core/ai/providers/opencode-server-language-model.ts
@@ -126,6 +126,7 @@ function toolInstructions(tools: LanguageModelV2FunctionTool[]): string {
     'GBrain owns tool execution. Do not use any OpenCode tools.',
     'Return only one JSON object with exactly these fields: text (string) and tool_calls (array).',
     'If a GBrain tool is required, return it in tool_calls and leave text empty.',
+    'If the conversation already contains a matching [tool_result ...], use it to answer and do not request that tool again.',
     'If the task is complete, return prose in text and an empty tool_calls array.',
     'Available GBrain tools:',
     JSON.stringify(specs),
@@ -183,6 +184,7 @@ function parseStructuredResult(
   const obj = value as Record<string, unknown>;
   const text = typeof obj.text === 'string' ? obj.text : '';
   if (!Array.isArray(obj.tool_calls)) {
+    if (allowPlainText) return { text, tool_calls: [] };
     throw new AITransientError('OpenCode structured response omitted tool_calls.');
   }
   const toolCalls = obj.tool_calls.map((entry, index) => {
@@ -190,13 +192,17 @@ function parseStructuredResult(
       throw new AITransientError(`OpenCode returned malformed tool call at index ${index}.`);
     }
     const call = entry as Record<string, unknown>;
-    if (typeof call.name !== 'string' || !call.input || typeof call.input !== 'object' || Array.isArray(call.input)) {
+    let input = call.input ?? call.arguments;
+    if (typeof input === 'string') {
+      try { input = JSON.parse(input); } catch { /* rejected below */ }
+    }
+    if (typeof call.name !== 'string' || !input || typeof input !== 'object' || Array.isArray(input)) {
       throw new AITransientError(`OpenCode returned malformed tool call at index ${index}.`);
     }
     return {
       id: typeof call.id === 'string' && call.id ? call.id : `toolu_opencode_${index}`,
       name: call.name,
-      input: call.input as Record<string, unknown>,
+      input: input as Record<string, unknown>,
     };
   });
   return { text, tool_calls: toolCalls };

--- a/src/core/ai/providers/opencode-server-language-model.ts
+++ b/src/core/ai/providers/opencode-server-language-model.ts
@@ -51,6 +51,33 @@ interface OpenCodeMessageResponse {
   parts?: Array<{ type?: string; text?: string }>;
 }
 
+function responseText(payload: OpenCodeMessageResponse): string {
+  return payload.parts
+    ?.filter(part => part.type === 'text')
+    .map(part => part.text ?? '')
+    .join('\n')
+    .trim() ?? '';
+}
+
+function parseJsonText(rawText: string): unknown {
+  let text = rawText.trim();
+  if (!text) return undefined;
+  text = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+  try { return JSON.parse(text); } catch { /* try extracting an embedded object below */ }
+  const firstBrace = text.indexOf('{');
+  const lastBrace = text.lastIndexOf('}');
+  if (firstBrace >= 0 && lastBrace > firstBrace) text = text.slice(firstBrace, lastBrace + 1);
+  try { return JSON.parse(text); } catch { return undefined; }
+}
+
+function parseJsonResponse(payload: OpenCodeMessageResponse): unknown {
+  const value = payload.info?.structured ?? parseJsonText(responseText(payload));
+  if (value === undefined || value === null) {
+    throw new AITransientError('OpenCode server returned no JSON response.');
+  }
+  return value;
+}
+
 function normalizeModel(model: string): string {
   const prefix = 'opencode-server:';
   return model.startsWith(prefix) ? model.slice(prefix.length) : model;
@@ -165,16 +192,9 @@ function parseStructuredResult(
 ): OpenCodeStructuredResult {
   let value = payload.info?.structured;
   let rawText = '';
-  if (!value) {
-    rawText = payload.parts?.filter(part => part.type === 'text').map(part => part.text ?? '').join('\n').trim() ?? '';
-    let text = rawText;
-    if (text) {
-      text = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
-      const firstBrace = text.indexOf('{');
-      const lastBrace = text.lastIndexOf('}');
-      if (firstBrace >= 0 && lastBrace > firstBrace) text = text.slice(firstBrace, lastBrace + 1);
-      try { value = JSON.parse(text); } catch { /* handled below */ }
-    }
+  if (value === undefined || value === null) {
+    rawText = responseText(payload);
+    value = parseJsonText(rawText);
   }
 
   if (!value || typeof value !== 'object') {
@@ -282,6 +302,10 @@ export class OpenCodeServerLanguageModel implements LanguageModelV2 {
     warnings: never[];
   }> {
     const tools = functionTools(options.tools);
+    const jsonFormat = options.responseFormat?.type === 'json' ? options.responseFormat : undefined;
+    if (jsonFormat && tools.length > 0) {
+      throw new AIConfigError('OpenCode JSON response format cannot be combined with GBrain tools.');
+    }
     const knownToolNames = new Set(tools.map(tool => tool.name));
     const { systemText, conversationText } = renderOpenCodePrompt(options.prompt);
     const directory = encodeURIComponent(this.directory);
@@ -301,23 +325,35 @@ export class OpenCodeServerLanguageModel implements LanguageModelV2 {
       sessionId = session.id;
 
       const messagePath = `/session/${encodeURIComponent(sessionId)}/message?directory=${directory}`;
+      const responseInstructions = jsonFormat
+        ? [
+            'Return only JSON that matches the requested schema.',
+            jsonFormat.description ?? '',
+          ].filter(Boolean).join('\n\n')
+        : toolInstructions(tools);
       const baseMessage = {
         model: { providerID: this.providerId, modelID: this.modelId },
         agent: this.agent,
-        system: [systemText, toolInstructions(tools)].filter(Boolean).join('\n\n'),
+        system: [systemText, responseInstructions].filter(Boolean).join('\n\n'),
         parts: [{ type: 'text', text: conversationText }],
       };
+      const requestedSchema = jsonFormat
+        ? (jsonFormat.schema ?? {})
+        : outputSchema(tools);
       let response = await this.request(messagePath, {
         method: 'POST',
         body: JSON.stringify({
           ...baseMessage,
-          format: { type: 'json_schema', schema: outputSchema(tools), retryCount: 2 },
+          format: { type: 'json_schema', schema: requestedSchema, retryCount: 2 },
         }),
       }, options.abortSignal);
       let payload = await response.json() as OpenCodeMessageResponse;
       let retryUsage: { input?: number; output?: number; total?: number } | undefined;
       if (this.isStructuredOutputError(payload)) {
         retryUsage = payload.info?.tokens;
+        const retryInstruction = jsonFormat
+          ? 'IMPORTANT: Return only the required JSON value. Do not return prose or markdown outside it.'
+          : 'IMPORTANT: Return only the required JSON object. Do not return prose or markdown outside it.';
         response = await this.request(messagePath, {
           method: 'POST',
           body: JSON.stringify({
@@ -325,7 +361,7 @@ export class OpenCodeServerLanguageModel implements LanguageModelV2 {
             format: { type: 'text' },
             parts: [{
               type: 'text',
-              text: `${conversationText}\n\nIMPORTANT: Return only the required JSON object. Do not return prose or markdown outside it.`,
+              text: `${conversationText}\n\n${retryInstruction}`,
             }],
           }),
         }, options.abortSignal);
@@ -333,6 +369,19 @@ export class OpenCodeServerLanguageModel implements LanguageModelV2 {
       }
       if (payload.info?.error) {
         throw new AITransientError(`OpenCode assistant error: ${JSON.stringify(payload.info.error).slice(0, 500)}`);
+      }
+      const inputTokens = (payload.info?.tokens?.input ?? 0) + (retryUsage?.input ?? 0);
+      const outputTokens = (payload.info?.tokens?.output ?? 0) + (retryUsage?.output ?? 0);
+      const totalTokens = (payload.info?.tokens?.total ?? 0) + (retryUsage?.total ?? 0) ||
+        (inputTokens + outputTokens || undefined);
+
+      if (jsonFormat) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify(parseJsonResponse(payload)) }],
+          finishReason: 'stop',
+          usage: { inputTokens, outputTokens, totalTokens },
+          warnings: [],
+        };
       }
       // Plain text is safe only when GBrain offered no tools. Tool-capable turns
       // must retain the validated JSON boundary so OpenCode cannot bypass the
@@ -356,10 +405,6 @@ export class OpenCodeServerLanguageModel implements LanguageModelV2 {
       }
       if (content.length === 0) content.push({ type: 'text', text: '' });
 
-      const inputTokens = (payload.info?.tokens?.input ?? 0) + (retryUsage?.input ?? 0);
-      const outputTokens = (payload.info?.tokens?.output ?? 0) + (retryUsage?.output ?? 0);
-      const totalTokens = (payload.info?.tokens?.total ?? 0) + (retryUsage?.total ?? 0) ||
-        (inputTokens + outputTokens || undefined);
       return {
         content,
         finishReason: result.tool_calls.length > 0 ? 'tool-calls' : 'stop',

--- a/src/core/ai/providers/opencode-server-language-model.ts
+++ b/src/core/ai/providers/opencode-server-language-model.ts
@@ -202,7 +202,11 @@ function parseStructuredResult(
     throw new AITransientError('OpenCode server returned no structured response.');
   }
   const obj = value as Record<string, unknown>;
-  const text = typeof obj.text === 'string' ? obj.text : '';
+  const text = typeof obj.text === 'string'
+    ? obj.text
+    : typeof obj.output_text === 'string'
+      ? obj.output_text
+      : '';
   if (!Array.isArray(obj.tool_calls)) {
     if (allowPlainText) return { text, tool_calls: [] };
     throw new AITransientError('OpenCode structured response omitted tool_calls.');
@@ -349,7 +353,13 @@ export class OpenCodeServerLanguageModel implements LanguageModelV2 {
       }, options.abortSignal);
       let payload = await response.json() as OpenCodeMessageResponse;
       let retryUsage: { input?: number; output?: number; total?: number } | undefined;
-      if (this.isStructuredOutputError(payload)) {
+      let recoveredToolFreeText = false;
+      if (this.isStructuredOutputError(payload) && !jsonFormat && tools.length === 0) {
+        try {
+          recoveredToolFreeText = Boolean(parseStructuredResult(payload, true).text);
+        } catch { /* retry below */ }
+      }
+      if (this.isStructuredOutputError(payload) && !recoveredToolFreeText) {
         retryUsage = payload.info?.tokens;
         const retryInstruction = jsonFormat
           ? 'IMPORTANT: Return only the required JSON value. Do not return prose or markdown outside it.'
@@ -367,7 +377,7 @@ export class OpenCodeServerLanguageModel implements LanguageModelV2 {
         }, options.abortSignal);
         payload = await response.json() as OpenCodeMessageResponse;
       }
-      if (payload.info?.error) {
+      if (payload.info?.error && !recoveredToolFreeText) {
         throw new AITransientError(`OpenCode assistant error: ${JSON.stringify(payload.info.error).slice(0, 500)}`);
       }
       const inputTokens = (payload.info?.tokens?.input ?? 0) + (retryUsage?.input ?? 0);

--- a/src/core/ai/providers/opencode-server-language-model.ts
+++ b/src/core/ai/providers/opencode-server-language-model.ts
@@ -1,0 +1,375 @@
+/**
+ * AI SDK LanguageModelV2 adapter for OpenCode's persistent local server.
+ *
+ * OpenCode owns ChatGPT OAuth and token refresh. The adapter uses OpenCode only
+ * as a structured model transport: every OpenCode session denies all tools,
+ * and structured tool requests are returned to GBrain's gateway for audited
+ * execution. This preserves GBrain's allow-lists, job receipts, and replay
+ * semantics instead of letting a second agent write to the brain out of band.
+ */
+import { mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  LanguageModelV2,
+  LanguageModelV2CallOptions,
+  LanguageModelV2Content,
+  LanguageModelV2FunctionTool,
+  LanguageModelV2Message,
+  LanguageModelV2Prompt,
+  LanguageModelV2ProviderDefinedTool,
+} from '@ai-sdk/provider';
+import { AIConfigError, AITransientError } from '../errors.ts';
+
+const DEFAULT_SERVER_URL = 'http://127.0.0.1:4097';
+const DEFAULT_USERNAME = 'opencode';
+const DEFAULT_PROVIDER_ID = 'openai';
+const DEFAULT_AGENT = 'gbrain';
+const CLEAN_CWD = join(tmpdir(), 'gbrain-opencode-server');
+
+export interface OpenCodeServerOptions {
+  baseUrl?: string;
+  username?: string;
+  password?: string;
+  providerId?: string;
+  agent?: string;
+  directory?: string;
+  fetch?: typeof globalThis.fetch;
+}
+
+interface OpenCodeStructuredResult {
+  text: string;
+  tool_calls: Array<{ id: string; name: string; input: Record<string, unknown> }>;
+}
+
+interface OpenCodeMessageResponse {
+  info?: {
+    structured?: unknown;
+    error?: unknown;
+    tokens?: { input?: number; output?: number; total?: number };
+  };
+  parts?: Array<{ type?: string; text?: string }>;
+}
+
+function normalizeModel(model: string): string {
+  const prefix = 'opencode-server:';
+  return model.startsWith(prefix) ? model.slice(prefix.length) : model;
+}
+
+function outputToText(output: unknown): string {
+  if (typeof output === 'string') return output;
+  try {
+    return JSON.stringify(output);
+  } catch {
+    return String(output);
+  }
+}
+
+/** Render the AI SDK conversation into one deterministic OpenCode prompt. */
+export function renderOpenCodePrompt(prompt: LanguageModelV2Prompt): {
+  systemText: string;
+  conversationText: string;
+} {
+  const systemParts: string[] = [];
+  const conversation: string[] = [];
+
+  for (const msg of prompt as ReadonlyArray<LanguageModelV2Message>) {
+    if (msg.role === 'system') {
+      systemParts.push(msg.content);
+      continue;
+    }
+    if (msg.role === 'user') {
+      const text = msg.content
+        .map(part => part.type === 'text' ? part.text : `[file ${part.mediaType ?? 'unknown'}]`)
+        .join('\n');
+      conversation.push(`User: ${text}`);
+      continue;
+    }
+    if (msg.role === 'assistant') {
+      const text = msg.content.map(part => {
+        if (part.type === 'text') return part.text;
+        if (part.type === 'reasoning') return '';
+        if (part.type === 'tool-call') return `[tool_use ${part.toolName}(${part.input})]`;
+        if (part.type === 'tool-result') return `[tool_result ${outputToText(part.output)}]`;
+        return '';
+      }).filter(Boolean).join('\n');
+      if (text) conversation.push(`Assistant: ${text}`);
+      continue;
+    }
+    if (msg.role === 'tool') {
+      const text = msg.content
+        .map(part => `[tool_result ${outputToText(part.output)}]`)
+        .join('\n');
+      conversation.push(`User: ${text}`);
+    }
+  }
+
+  return { systemText: systemParts.join('\n\n'), conversationText: conversation.join('\n\n') };
+}
+
+function functionTools(
+  tools: ReadonlyArray<LanguageModelV2FunctionTool | LanguageModelV2ProviderDefinedTool> | undefined,
+): LanguageModelV2FunctionTool[] {
+  return (tools ?? []).filter((tool): tool is LanguageModelV2FunctionTool => tool.type === 'function');
+}
+
+function toolInstructions(tools: LanguageModelV2FunctionTool[]): string {
+  if (tools.length === 0) {
+    return 'No tools are available. Return the final answer in text and an empty tool_calls array.';
+  }
+  const specs = tools.map(tool => ({
+    name: tool.name,
+    description: tool.description ?? '',
+    input_schema: tool.inputSchema ?? { type: 'object', properties: {} },
+  }));
+  return [
+    'GBrain owns tool execution. Do not use any OpenCode tools.',
+    'Return only one JSON object with exactly these fields: text (string) and tool_calls (array).',
+    'If a GBrain tool is required, return it in tool_calls and leave text empty.',
+    'If the task is complete, return prose in text and an empty tool_calls array.',
+    'Available GBrain tools:',
+    JSON.stringify(specs),
+  ].join('\n\n');
+}
+
+function outputSchema(tools: LanguageModelV2FunctionTool[]): Record<string, unknown> {
+  const names = tools.map(tool => tool.name);
+  return {
+    type: 'object',
+    properties: {
+      text: { type: 'string' },
+      tool_calls: {
+        type: 'array',
+        ...(names.length === 0 ? { maxItems: 0 } : {}),
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: names.length > 0 ? { type: 'string', enum: names } : { type: 'string' },
+            input: { type: 'object', additionalProperties: true },
+          },
+          required: ['id', 'name', 'input'],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ['text', 'tool_calls'],
+    additionalProperties: false,
+  };
+}
+
+function parseStructuredResult(
+  payload: OpenCodeMessageResponse,
+  allowPlainText = false,
+): OpenCodeStructuredResult {
+  let value = payload.info?.structured;
+  let rawText = '';
+  if (!value) {
+    rawText = payload.parts?.filter(part => part.type === 'text').map(part => part.text ?? '').join('\n').trim() ?? '';
+    let text = rawText;
+    if (text) {
+      text = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+      const firstBrace = text.indexOf('{');
+      const lastBrace = text.lastIndexOf('}');
+      if (firstBrace >= 0 && lastBrace > firstBrace) text = text.slice(firstBrace, lastBrace + 1);
+      try { value = JSON.parse(text); } catch { /* handled below */ }
+    }
+  }
+
+  if (!value || typeof value !== 'object') {
+    if (allowPlainText && rawText) return { text: rawText, tool_calls: [] };
+    throw new AITransientError('OpenCode server returned no structured response.');
+  }
+  const obj = value as Record<string, unknown>;
+  const text = typeof obj.text === 'string' ? obj.text : '';
+  if (!Array.isArray(obj.tool_calls)) {
+    throw new AITransientError('OpenCode structured response omitted tool_calls.');
+  }
+  const toolCalls = obj.tool_calls.map((entry, index) => {
+    if (!entry || typeof entry !== 'object') {
+      throw new AITransientError(`OpenCode returned malformed tool call at index ${index}.`);
+    }
+    const call = entry as Record<string, unknown>;
+    if (typeof call.name !== 'string' || !call.input || typeof call.input !== 'object' || Array.isArray(call.input)) {
+      throw new AITransientError(`OpenCode returned malformed tool call at index ${index}.`);
+    }
+    return {
+      id: typeof call.id === 'string' && call.id ? call.id : `toolu_opencode_${index}`,
+      name: call.name,
+      input: call.input as Record<string, unknown>,
+    };
+  });
+  return { text, tool_calls: toolCalls };
+}
+
+export class OpenCodeServerLanguageModel implements LanguageModelV2 {
+  readonly specificationVersion = 'v2' as const;
+  readonly provider = 'opencode-server';
+  readonly modelId: string;
+  readonly supportedUrls = {};
+
+  private readonly baseUrl: string;
+  private readonly username: string;
+  private readonly password: string;
+  private readonly providerId: string;
+  private readonly agent: string;
+  private readonly directory: string;
+  private readonly fetchImpl: typeof globalThis.fetch;
+
+  constructor(modelId: string, options: OpenCodeServerOptions = {}) {
+    this.modelId = normalizeModel(modelId);
+    this.baseUrl = (options.baseUrl ?? DEFAULT_SERVER_URL).replace(/\/$/, '');
+    this.username = options.username ?? DEFAULT_USERNAME;
+    this.password = options.password ?? '';
+    this.providerId = options.providerId ?? DEFAULT_PROVIDER_ID;
+    this.agent = options.agent ?? DEFAULT_AGENT;
+    this.directory = options.directory ?? CLEAN_CWD;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    mkdirSync(this.directory, { recursive: true });
+    try { new URL(this.baseUrl); } catch {
+      throw new AIConfigError(`Invalid OpenCode server URL: ${this.baseUrl}`);
+    }
+  }
+
+  private headers(): Record<string, string> {
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    if (this.password) {
+      headers.authorization = `Basic ${Buffer.from(`${this.username}:${this.password}`).toString('base64')}`;
+    }
+    return headers;
+  }
+
+  private isStructuredOutputError(payload: OpenCodeMessageResponse): boolean {
+    const error = payload.info?.error;
+    return Boolean(
+      error &&
+      typeof error === 'object' &&
+      (error as Record<string, unknown>).name === 'StructuredOutputError',
+    );
+  }
+
+  private async request(path: string, init: RequestInit, signal?: AbortSignal): Promise<Response> {
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        ...init,
+        headers: { ...this.headers(), ...(init.headers ?? {}) },
+        signal,
+      });
+    } catch (error) {
+      if (signal?.aborted) throw error;
+      throw new AITransientError(`OpenCode server request failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    if (response.ok) return response;
+    const detail = (await response.text().catch(() => '')).slice(0, 500);
+    const message = `OpenCode server HTTP ${response.status}${detail ? `: ${detail}` : ''}`;
+    if (response.status === 401 || response.status === 403 || response.status === 404) {
+      throw new AIConfigError(message, 'Check the OpenCode server URL, password, and ChatGPT OAuth login.');
+    }
+    throw new AITransientError(message);
+  }
+
+  async doGenerate(options: LanguageModelV2CallOptions): Promise<{
+    content: LanguageModelV2Content[];
+    finishReason: 'stop' | 'length' | 'content-filter' | 'tool-calls' | 'error' | 'other' | 'unknown';
+    usage: { inputTokens: number | undefined; outputTokens: number | undefined; totalTokens: number | undefined };
+    warnings: never[];
+  }> {
+    const tools = functionTools(options.tools);
+    const knownToolNames = new Set(tools.map(tool => tool.name));
+    const { systemText, conversationText } = renderOpenCodePrompt(options.prompt);
+    const directory = encodeURIComponent(this.directory);
+    let sessionId: string | null = null;
+
+    try {
+      const sessionResponse = await this.request(`/session?directory=${directory}`, {
+        method: 'POST',
+        body: JSON.stringify({
+          title: `GBrain ${this.modelId}`,
+          model: { id: this.modelId, providerID: this.providerId },
+          permission: [{ permission: '*', pattern: '*', action: 'deny' }],
+        }),
+      }, options.abortSignal);
+      const session = await sessionResponse.json() as { id?: string };
+      if (!session.id) throw new AITransientError('OpenCode server did not return a session id.');
+      sessionId = session.id;
+
+      const messagePath = `/session/${encodeURIComponent(sessionId)}/message?directory=${directory}`;
+      const baseMessage = {
+        model: { providerID: this.providerId, modelID: this.modelId },
+        agent: this.agent,
+        system: [systemText, toolInstructions(tools)].filter(Boolean).join('\n\n'),
+        parts: [{ type: 'text', text: conversationText }],
+      };
+      let response = await this.request(messagePath, {
+        method: 'POST',
+        body: JSON.stringify({
+          ...baseMessage,
+          format: { type: 'json_schema', schema: outputSchema(tools), retryCount: 2 },
+        }),
+      }, options.abortSignal);
+      let payload = await response.json() as OpenCodeMessageResponse;
+      let retryUsage: { input?: number; output?: number; total?: number } | undefined;
+      if (this.isStructuredOutputError(payload)) {
+        retryUsage = payload.info?.tokens;
+        response = await this.request(messagePath, {
+          method: 'POST',
+          body: JSON.stringify({
+            ...baseMessage,
+            format: { type: 'text' },
+            parts: [{
+              type: 'text',
+              text: `${conversationText}\n\nIMPORTANT: Return only the required JSON object. Do not return prose or markdown outside it.`,
+            }],
+          }),
+        }, options.abortSignal);
+        payload = await response.json() as OpenCodeMessageResponse;
+      }
+      if (payload.info?.error) {
+        throw new AITransientError(`OpenCode assistant error: ${JSON.stringify(payload.info.error).slice(0, 500)}`);
+      }
+      // Plain text is safe only when GBrain offered no tools. Tool-capable turns
+      // must retain the validated JSON boundary so OpenCode cannot bypass the
+      // gateway's tool allowlist or argument validation.
+      const result = parseStructuredResult(payload, tools.length === 0);
+      for (const call of result.tool_calls) {
+        if (!knownToolNames.has(call.name)) {
+          throw new AITransientError(`OpenCode requested unknown GBrain tool "${call.name}".`);
+        }
+      }
+
+      const content: LanguageModelV2Content[] = [];
+      if (result.text) content.push({ type: 'text', text: result.text });
+      for (const call of result.tool_calls) {
+        content.push({
+          type: 'tool-call',
+          toolCallId: call.id,
+          toolName: call.name,
+          input: JSON.stringify(call.input),
+        });
+      }
+      if (content.length === 0) content.push({ type: 'text', text: '' });
+
+      const inputTokens = (payload.info?.tokens?.input ?? 0) + (retryUsage?.input ?? 0);
+      const outputTokens = (payload.info?.tokens?.output ?? 0) + (retryUsage?.output ?? 0);
+      const totalTokens = (payload.info?.tokens?.total ?? 0) + (retryUsage?.total ?? 0) ||
+        (inputTokens + outputTokens || undefined);
+      return {
+        content,
+        finishReason: result.tool_calls.length > 0 ? 'tool-calls' : 'stop',
+        usage: { inputTokens, outputTokens, totalTokens },
+        warnings: [],
+      };
+    } finally {
+      if (sessionId) {
+        await this.request(`/session/${encodeURIComponent(sessionId)}?directory=${directory}`, {
+          method: 'DELETE',
+        }, AbortSignal.timeout(5_000)).catch(() => {});
+      }
+    }
+  }
+
+  async doStream(): Promise<never> {
+    throw new Error('OpenCode server adapter does not support streaming; use doGenerate.');
+  }
+}

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -23,6 +23,7 @@ import { zhipu } from './zhipu.ts';
 import { azureOpenAI } from './azure-openai.ts';
 import { zeroentropyai } from './zeroentropyai.ts';
 import { llamaServerReranker } from './llama-server-reranker.ts';
+import { opencodeServer } from './opencode-server.ts';
 
 const ALL: Recipe[] = [
   openai,
@@ -42,6 +43,7 @@ const ALL: Recipe[] = [
   zhipu,
   azureOpenAI,
   zeroentropyai,
+  opencodeServer,
 ];
 
 /** Map from `provider:id` key to recipe. */

--- a/src/core/ai/recipes/opencode-server.ts
+++ b/src/core/ai/recipes/opencode-server.ts
@@ -22,11 +22,15 @@ export const opencodeServer: Recipe = {
   },
   touchpoints: {
     chat: {
-      models: ['gpt-5.5', 'gpt-5.5-fast', 'gpt-5.4'],
+      models: ['gpt-5.5', 'gpt-5.5-fast', 'gpt-5.4', 'gpt-5.4-mini'],
       supports_tools: true,
       supports_subagent_loop: true,
       supports_prompt_cache: false,
       max_context_tokens: 200000,
+      price_last_verified: '2026-07-10',
+    },
+    expansion: {
+      models: ['gpt-5.4-mini', 'gpt-5.4', 'gpt-5.5'],
       price_last_verified: '2026-07-10',
     },
   },

--- a/src/core/ai/recipes/opencode-server.ts
+++ b/src/core/ai/recipes/opencode-server.ts
@@ -1,0 +1,37 @@
+import type { Recipe } from '../types.ts';
+
+/**
+ * OpenCode's persistent local server, using credentials owned and refreshed by
+ * OpenCode. This is intentionally separate from the OpenCode Zen HTTP API.
+ */
+export const opencodeServer: Recipe = {
+  id: 'opencode-server',
+  name: 'OpenCode Server (local OAuth)',
+  tier: 'native',
+  implementation: 'opencode-server',
+  auth_env: {
+    required: [],
+    optional: [
+      'GBRAIN_OPENCODE_SERVER_URL',
+      'GBRAIN_OPENCODE_SERVER_USERNAME',
+      'GBRAIN_OPENCODE_SERVER_PASSWORD',
+      'GBRAIN_OPENCODE_PROVIDER_ID',
+      'GBRAIN_OPENCODE_AGENT',
+    ],
+    setup_url: 'https://opencode.ai/docs/server/',
+  },
+  touchpoints: {
+    chat: {
+      models: ['gpt-5.5', 'gpt-5.5-fast', 'gpt-5.4'],
+      supports_tools: true,
+      supports_subagent_loop: true,
+      supports_prompt_cache: false,
+      max_context_tokens: 200000,
+      price_last_verified: '2026-07-10',
+    },
+  },
+  setup_hint:
+    'Run `opencode providers login --provider OpenAI`, then keep a local-only ' +
+    '`opencode serve` process running. Optional connection settings live in ' +
+    'GBRAIN_OPENCODE_SERVER_URL/USERNAME/PASSWORD/PROVIDER_ID/AGENT.',
+};

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -22,7 +22,8 @@ export type Implementation =
   | 'native-openai'
   | 'native-google'
   | 'native-anthropic'
-  | 'openai-compatible';
+  | 'openai-compatible'
+  | 'opencode-server';
 
 export interface EmbeddingTouchpoint {
   models: string[];

--- a/src/core/brainstorm/orchestrator.ts
+++ b/src/core/brainstorm/orchestrator.ts
@@ -32,7 +32,7 @@
  */
 
 import type { BrainEngine } from '../engine.ts';
-import { chat as defaultChat, embedQuery, type ChatResult, type ChatOpts } from '../ai/gateway.ts';
+import { chat as defaultChat, embedQuery, getChatModel, type ChatResult, type ChatOpts } from '../ai/gateway.ts';
 import { hybridSearch, hybridSearchCached } from '../search/hybrid.ts';
 import { fetchFar, type CloseRef, type FarPage } from './domain-bank.ts';
 import { StructuredAgentError } from '../errors.ts';
@@ -538,7 +538,7 @@ async function _runBrainstormInner(
   const embedFn = opts.embedQueryFn ?? embedQuery;
 
   // ---- Phase 0: cost preview + TTY grace ----
-  const modelStr = opts.modelOverride ?? 'anthropic:claude-sonnet-4-6';
+  const modelStr = opts.modelOverride ?? getChatModel();
   const { aborted, estimate } = await previewCostAndWait({
     profile,
     model: modelStr,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -876,6 +876,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'models.chat',
   'models.eval.longmemeval',
   'facts.extraction_model',
+  // Required for non-Anthropic subagent models.
+  'agent.use_gateway_loop',
   // Dream cycle config
   'dream.synthesize.session_corpus_dir',
   'dream.synthesize.meeting_transcripts_dir',

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -41,6 +41,12 @@ export interface GBrainConfig {
    * merge → buildGatewayConfig env dict → recipe reads ZEROENTROPY_API_KEY.
    */
   zeroentropy_api_key?: string;
+  /** Persistent local OpenCode server used for subscription-backed chat. */
+  opencode_server_url?: string;
+  opencode_server_username?: string;
+  opencode_server_password?: string;
+  opencode_server_provider_id?: string;
+  opencode_server_agent?: string;
   /** AI gateway config (v0.14+). v0.36+ default: "zeroentropyai:zembed-1" / 1280 / "anthropic:claude-haiku-4-5-20251001". */
   embedding_model?: string;
   embedding_dimensions?: number;

--- a/src/core/contextual-retrieval-service.ts
+++ b/src/core/contextual-retrieval-service.ts
@@ -43,6 +43,7 @@ import { createHash } from 'crypto';
 import * as fs from 'node:fs';
 import { embedBatch } from './embedding.ts';
 import { resolveContextualRetrievalMode } from './contextual-retrieval-resolver.ts';
+import { getChatModel } from './ai/gateway.ts';
 import {
   buildContextualPrefix,
   extractFirstTwoSentences,
@@ -200,8 +201,6 @@ export interface ReembedPageArgs {
   releaseSynopsisLease?: () => Promise<void>;
 }
 
-const DEFAULT_HAIKU_MODEL = 'anthropic:claude-haiku-4-5-20251001';
-
 /**
  * Re-embed one page through the active CR mode. Implements the D26 P0-2
  * two-phase build pattern.
@@ -245,6 +244,7 @@ export async function reembedPageWithContextualRetrieval(
     return { kind: 'skipped', reason: 'mode_none' };
   }
 
+  const synopsisModel = args.haikuModel ?? getChatModel();
   const chunks = await args.engine.getChunks(args.pageSlug, { sourceId: args.sourceId });
   if (chunks.length === 0) {
     // No chunks but page exists (frontmatter-only or empty). Stamp the
@@ -253,7 +253,7 @@ export async function reembedPageWithContextualRetrieval(
       args.pageSlug,
       args.sourceId,
       resolution.mode,
-      computeCorpusGeneration({ crMode: resolution.mode, haikuModel: args.haikuModel ?? DEFAULT_HAIKU_MODEL }),
+      computeCorpusGeneration({ crMode: resolution.mode, haikuModel: synopsisModel }),
     );
     return { kind: 'skipped', reason: 'no_chunks' };
   }
@@ -264,7 +264,7 @@ export async function reembedPageWithContextualRetrieval(
   // fall-back path is the D14 page-level consistency guarantee: a
   // single bad chunk demotes the whole page to title-only so all
   // chunks on the page share the same wrapper shape.
-  const haikuModel = args.haikuModel ?? DEFAULT_HAIKU_MODEL;
+  const haikuModel = synopsisModel;
   let attemptMode: CRMode = resolution.mode;
   let fallbackReason: SynopsisFailureKind | null = null;
 

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -66,10 +66,19 @@ const ATOM_TYPES = [
 // active pack manifest (symmetric with the existing
 // src/core/facts/eligibility.ts:49 TODO).
 const EXTRACTABLE_PAGE_TYPES = [
-  'meeting', 'source', 'article', 'video', 'book', 'original',
+  'meeting', 'source', 'article', 'video', 'book', 'original', 'media',
 ] as const;
+const MEDIA_EXTRACTION_PREDICATE = `(p.type <> 'media' OR (
+  p.frontmatter->>'intake_adapter' = 'birdclaw-bookmarks-to-brain'
+  AND p.frontmatter->>'content_kind' = 'x-bookmark'
+  AND lower(COALESCE(p.frontmatter->>'concept_synthesis_candidate', '')) = 'true'
+))`;
 const PAGE_DISCOVERY_BUDGET = 50;
 const MIN_PAGE_CHARS_FOR_EXTRACTION = 500;
+const MAX_CONCEPT_REFS = 5;
+const GENERIC_CONCEPT_REFS = new Set([
+  'ai', 'artificial-intelligence', 'technology', 'software', 'innovation',
+]);
 
 export interface ExtractAtomsOpts {
   brainDir?: string;
@@ -120,9 +129,10 @@ interface ExtractedAtom {
   lesson?: string;
   virality_score?: number;
   emotional_register?: string;
+  concepts?: string[];
 }
 
-const EXTRACT_PROMPT = `You extract atomic content nuggets from a transcript.
+const EXTRACT_PROMPT = `You extract atomic content nuggets from a research source.
 
 An atom is a single-source, self-contained idea that could become a tweet,
 quote, or short essay angle. Each atom must:
@@ -134,7 +144,7 @@ Output a JSON array of atoms (1-3 per transcript, never more than 3).
 Each atom: {title (≤80 chars), atom_type, body (2-4 sentences),
 source_quote (verbatim ≤200 chars), lesson (one sentence), virality_score
 (0-100), emotional_register (one of: shocking, inspiring, funny, sobering,
-practical, controversial)}.
+practical, controversial), concepts (1-5 specific durable topic names)}.
 
 atom_type MUST be one of: ${ATOM_TYPES.join(', ')}.
 
@@ -176,6 +186,7 @@ export async function discoverExtractablePages(
     FROM pages p
     WHERE p.source_id = $1
       AND p.type = ANY($2::text[])
+      AND ${MEDIA_EXTRACTION_PREDICATE}
       AND p.deleted_at IS NULL
       AND p.content_hash IS NOT NULL
       AND COALESCE(p.frontmatter->>'imported_from',   '') <> 'markdown-greenfield'
@@ -248,6 +259,7 @@ export async function countExtractAtomsBacklog(
       ? `SELECT COUNT(*) AS cnt FROM pages p
          WHERE p.source_id = $1
            AND p.type = ANY($2::text[])
+           AND ${MEDIA_EXTRACTION_PREDICATE}
            AND p.deleted_at IS NULL
            AND p.content_hash IS NOT NULL
            AND COALESCE(p.frontmatter->>'imported_from',   '') <> 'markdown-greenfield'
@@ -261,6 +273,7 @@ export async function countExtractAtomsBacklog(
            )`
       : `SELECT COUNT(*) AS cnt FROM pages p
          WHERE p.type = ANY($1::text[])
+           AND ${MEDIA_EXTRACTION_PREDICATE}
            AND p.deleted_at IS NULL
            AND p.content_hash IS NOT NULL
            AND COALESCE(p.frontmatter->>'imported_from',   '') <> 'markdown-greenfield'
@@ -540,6 +553,7 @@ export async function runPhaseExtractAtoms(
                 ...(atom.lesson && { lesson: atom.lesson }),
                 ...(atom.virality_score !== undefined && { virality_score: atom.virality_score }),
                 ...(atom.emotional_register && { emotional_register: atom.emotional_register }),
+                ...(atom.concepts && { concepts: atom.concepts }),
                 extracted_at: new Date().toISOString(),
                 extracted_by: 'extract_atoms-v0.41.2.1',
               },
@@ -682,9 +696,25 @@ export function parseAtomsResponse(raw: string): ExtractedAtom[] {
           : undefined,
       emotional_register:
         typeof obj.emotional_register === 'string' ? obj.emotional_register : undefined,
+      concepts: normalizeConceptRefs(obj.concepts),
     });
   }
   return atoms;
+}
+
+function normalizeConceptRefs(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const concepts: string[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (typeof item !== 'string') continue;
+    const slug = slugify(item);
+    if (!slug || GENERIC_CONCEPT_REFS.has(slug) || seen.has(slug)) continue;
+    seen.add(slug);
+    concepts.push(slug);
+    if (concepts.length === MAX_CONCEPT_REFS) break;
+  }
+  return concepts.length > 0 ? concepts : undefined;
 }
 
 function todayDate(): string {

--- a/src/core/cycle/extract-atoms.ts
+++ b/src/core/cycle/extract-atoms.ts
@@ -51,6 +51,7 @@ import type { ProgressReporter } from '../progress.ts';
 import { chat as gatewayChat } from '../ai/gateway.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
+import { createHash } from 'node:crypto';
 
 const DEFAULT_BUDGET_USD = 0.3;
 
@@ -529,8 +530,14 @@ export async function runPhaseExtractAtoms(
       }
 
       if (!opts.dryRun) {
-        for (const atom of atoms) {
-          const slug = `atoms/${todayDate()}/${slugify(atom.title)}`;
+        for (const [atomIndex, atom] of atoms.entries()) {
+          // Model titles are not identities: unrelated sources commonly
+          // produce the same short title. Source hash + response position
+          // keeps writes deterministic without allowing one atom to replace
+          // another in the same source.
+          const sourceIdentity = createHash('sha256').update(item.contentHash).digest('hex').slice(0, 12);
+          const identitySuffix = `${sourceIdentity}-${atomIndex + 1}`;
+          const slug = `atoms/${todayDate()}/${slugify(atom.title)}-${identitySuffix}`;
           const originFrontmatter =
             item.kind === 'transcript'
               ? { source_path: item.filePath }

--- a/src/core/cycle/patterns.ts
+++ b/src/core/cycle/patterns.ts
@@ -27,6 +27,8 @@ import { waitForCompletion, TimeoutError } from '../minions/wait-for-completion.
 import type { MinionJobInput, SubagentHandlerData } from '../minions/types.ts';
 import { serializeMarkdown } from '../markdown.ts';
 import type { Page, PageType } from '../types.ts';
+import { hasAnthropicKey } from '../ai/anthropic-key.ts';
+import { isAnthropicProvider, resolveModel } from '../model-config.ts';
 
 export interface PatternsPhaseOpts {
   brainDir: string;
@@ -64,7 +66,7 @@ export async function runPhasePatterns(
     }
 
     // Submit one subagent for pattern detection.
-    if (!process.env.ANTHROPIC_API_KEY) {
+    if (isAnthropicProvider(config.model) && !hasAnthropicKey()) {
       return skipped('no_api_key', 'ANTHROPIC_API_KEY unset; pattern detection skipped');
     }
 
@@ -143,7 +145,6 @@ async function loadPatternsConfig(engine: BrainEngine): Promise<PatternsConfig> 
   const lookbackStr = await engine.getConfig('dream.patterns.lookback_days');
   const minEvidenceStr = await engine.getConfig('dream.patterns.min_evidence');
   // v0.28: unified model resolution
-  const { resolveModel } = await import('../model-config.ts');
   const model = await resolveModel(engine, {
     configKey: 'models.dream.patterns',
     deprecatedConfigKey: 'dream.patterns.model',

--- a/src/core/cycle/synthesize-concepts.ts
+++ b/src/core/cycle/synthesize-concepts.ts
@@ -160,7 +160,8 @@ export async function runPhaseSynthesizeConcepts(
     );
     // Research-derived atoms promote by distinct original sources. Legacy
     // transcript atoms have no source_slug and retain count-based behavior.
-    const supportCount = sourceBacked.length > 0 ? supportingSources.length : ordered.length;
+    const legacyEvidenceCount = ordered.length - sourceBacked.length;
+    const supportCount = supportingSources.length + legacyEvidenceCount;
     if (supportCount < TIER_T3_MIN) continue;
     const tier: AtomGroup['tier'] =
       supportCount >= TIER_T1_MIN ? 'T1' : supportCount >= TIER_T2_MIN ? 'T2' : 'T3';
@@ -171,6 +172,7 @@ export async function runPhaseSynthesizeConcepts(
       supportingAtoms: dedupeEvidence(ordered.map((atom) => ({
         source_id: atom.source_id ?? 'default',
         slug: atom.slug,
+        ...(atom.source_hash && { source_hash: atom.source_hash }),
       }))),
       supportingSources,
       supportCount,
@@ -263,21 +265,31 @@ export async function runPhaseSynthesizeConcepts(
 
     if (!opts.dryRun) {
       const title = group.conceptSlug.split('/').pop() ?? group.conceptSlug;
-      const evidenceSection = renderEvidence(group.supportingSources);
-      await engine.putPage(`concepts/${title}`, {
+      const evidenceSection = renderEvidence(group.supportingSources, group.supportingAtoms);
+      const compiledTruth = evidenceSection ? `${narrative}\n\n${evidenceSection}` : narrative;
+      const frontmatter = {
+        type: 'concept',
+        tier: group.tier,
+        mention_count: group.atomTitles.length,
+        composite_score: group.supportCount,
+        support_count: group.supportCount,
+        supporting_atoms: group.supportingAtoms.slice(0, MAX_SUPPORTING_ATOMS),
+        supporting_sources: group.supportingSources.slice(0, MAX_SUPPORTING_SOURCES),
+        synthesized_by: 'synthesize_concepts-v0.41',
+      };
+      const conceptSlug = `concepts/${title}`;
+      const existing = await engine.getPage(conceptSlug, { sourceId: 'default' });
+      if (conceptPageMatches(existing, compiledTruth, frontmatter)) {
+        conceptsWritten++;
+        opts.progress?.tick(1, `${conceptsWritten} concepts`);
+        await maybeYield();
+        continue;
+      }
+      await engine.putPage(conceptSlug, {
         title: title.replace(/-/g, ' '),
         type: 'concept',
-        compiled_truth: evidenceSection ? `${narrative}\n\n${evidenceSection}` : narrative,
-        frontmatter: {
-          type: 'concept',
-          tier: group.tier,
-          mention_count: group.atomTitles.length,
-          composite_score: group.atomTitles.length,
-          support_count: group.supportCount,
-          supporting_atoms: group.supportingAtoms.slice(0, MAX_SUPPORTING_ATOMS),
-          supporting_sources: group.supportingSources.slice(0, MAX_SUPPORTING_SOURCES),
-          synthesized_by: 'synthesize_concepts-v0.41',
-        },
+        compiled_truth: compiledTruth,
+        frontmatter,
         timeline: '',
       });
     }
@@ -358,12 +370,41 @@ function dedupeEvidence(refs: EvidenceRef[]): EvidenceRef[] {
   );
 }
 
-function renderEvidence(sources: EvidenceRef[]): string {
-  if (sources.length === 0) return '';
-  const links = sources.slice(0, MAX_SUPPORTING_SOURCES).map((source) =>
-    `- [[${source.slug}]] (source: ${source.source_id})`,
+function renderEvidence(sources: EvidenceRef[], atoms: EvidenceRef[]): string {
+  if (sources.length === 0 && atoms.length === 0) return '';
+  const sourceLinks = sources.slice(0, MAX_SUPPORTING_SOURCES).map((source) =>
+    `- [[${source.source_id}:${source.slug}]]`,
   );
-  return `## Supporting research\n\n${links.join('\n')}`;
+  const atomLinks = atoms.slice(0, MAX_SUPPORTING_ATOMS).map((atom) =>
+    `- [[${atom.source_id}:${atom.slug}]]`,
+  );
+  return [
+    ...(sourceLinks.length > 0 ? [`## Supporting research\n\n${sourceLinks.join('\n')}`] : []),
+    ...(atomLinks.length > 0 ? [`## Supporting atoms\n\n${atomLinks.join('\n')}`] : []),
+  ].join('\n\n');
+}
+
+function conceptPageMatches(
+  existing: Awaited<ReturnType<BrainEngine['getPage']>>,
+  compiledTruth: string,
+  expectedFrontmatter: Record<string, unknown>,
+): boolean {
+  if (!existing || existing.compiled_truth !== compiledTruth) return false;
+  const actual = existing.frontmatter as Record<string, unknown>;
+  return Object.entries(expectedFrontmatter).every(([key, value]) =>
+    canonicalJson(actual[key]) === canonicalJson(value),
+  );
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value !== null && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${canonicalJson(nested)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
 }
 
 /**

--- a/src/core/cycle/synthesize-concepts.ts
+++ b/src/core/cycle/synthesize-concepts.ts
@@ -29,6 +29,24 @@ const DEFAULT_BUDGET_USD = 1.5;
 const TIER_T1_MIN = 10;
 const TIER_T2_MIN = 5;
 const TIER_T3_MIN = 2;
+const MAX_SUPPORTING_ATOMS = 20;
+const MAX_SUPPORTING_SOURCES = 20;
+
+interface ConceptAtom {
+  slug: string;
+  concept_refs: string[];
+  body: string;
+  title: string;
+  source_id?: string;
+  source_slug?: string;
+  source_hash?: string;
+}
+
+interface EvidenceRef {
+  source_id: string;
+  slug: string;
+  source_hash?: string;
+}
 
 export interface SynthesizeConceptsOpts {
   brainDir?: string;
@@ -44,13 +62,16 @@ export interface SynthesizeConceptsOpts {
   /** Test seam: alternative chat function. */
   _chat?: typeof gatewayChat;
   /** Test seam: skip DB query; cluster these atoms directly. */
-  _atoms?: Array<{ slug: string; concept_refs: string[]; body: string; title: string }>;
+  _atoms?: ConceptAtom[];
 }
 
 interface AtomGroup {
   conceptSlug: string;
   atomTitles: string[];
   atomBodies: string[];
+  supportingAtoms: EvidenceRef[];
+  supportingSources: EvidenceRef[];
+  supportCount: number;
   tier: 'T1' | 'T2' | 'T3' | 'T4';
 }
 
@@ -75,9 +96,15 @@ export async function runPhaseSynthesizeConcepts(
         slug: string;
         title: string;
         compiled_truth: string;
-        frontmatter: { concepts?: string[]; imported_from?: string };
+        source_id: string;
+        frontmatter: {
+          concepts?: string[];
+          imported_from?: string;
+          source_slug?: string;
+          source_hash?: string;
+        };
       }>(
-        `SELECT slug, title, compiled_truth, frontmatter
+        `SELECT slug, source_id, title, compiled_truth, frontmatter
            FROM pages
           WHERE type = 'atom'
             AND deleted_at IS NULL
@@ -90,6 +117,9 @@ export async function runPhaseSynthesizeConcepts(
           title: r.title,
           body: r.compiled_truth,
           concept_refs: r.frontmatter!.concepts!,
+          source_id: r.source_id,
+          source_slug: r.frontmatter?.source_slug,
+          source_hash: r.frontmatter?.source_hash,
         }));
     } catch {
       // No atoms table or query failed — phase no-ops cleanly.
@@ -107,12 +137,11 @@ export async function runPhaseSynthesizeConcepts(
   }
 
   // 2. Group atoms by concept slug
-  const groups = new Map<string, { titles: string[]; bodies: string[] }>();
+  const groups = new Map<string, ConceptAtom[]>();
   for (const atom of atoms) {
     for (const conceptSlug of atom.concept_refs) {
-      const existing = groups.get(conceptSlug) ?? { titles: [], bodies: [] };
-      existing.titles.push(atom.title);
-      existing.bodies.push(atom.body);
+      const existing = groups.get(conceptSlug) ?? [];
+      existing.push(atom);
       groups.set(conceptSlug, existing);
     }
   }
@@ -120,17 +149,35 @@ export async function runPhaseSynthesizeConcepts(
   // 3. Filter to count ≥2, assign tier
   const atomGroups: AtomGroup[] = [];
   for (const [conceptSlug, data] of groups) {
-    const count = data.titles.length;
-    if (count < TIER_T3_MIN) continue;
+    const ordered = [...data].sort((a, b) => evidenceKey(a).localeCompare(evidenceKey(b)));
+    const sourceBacked = ordered.filter((atom) => atom.source_slug);
+    const supportingSources = dedupeEvidence(
+      sourceBacked.map((atom) => ({
+        source_id: atom.source_id ?? 'default',
+        slug: atom.source_slug!,
+        ...(atom.source_hash && { source_hash: atom.source_hash }),
+      })),
+    );
+    // Research-derived atoms promote by distinct original sources. Legacy
+    // transcript atoms have no source_slug and retain count-based behavior.
+    const supportCount = sourceBacked.length > 0 ? supportingSources.length : ordered.length;
+    if (supportCount < TIER_T3_MIN) continue;
     const tier: AtomGroup['tier'] =
-      count >= TIER_T1_MIN ? 'T1' : count >= TIER_T2_MIN ? 'T2' : 'T3';
+      supportCount >= TIER_T1_MIN ? 'T1' : supportCount >= TIER_T2_MIN ? 'T2' : 'T3';
     atomGroups.push({
       conceptSlug,
-      atomTitles: data.titles,
-      atomBodies: data.bodies,
+      atomTitles: ordered.map((atom) => atom.title),
+      atomBodies: ordered.map((atom) => atom.body),
+      supportingAtoms: dedupeEvidence(ordered.map((atom) => ({
+        source_id: atom.source_id ?? 'default',
+        slug: atom.slug,
+      }))),
+      supportingSources,
+      supportCount,
       tier,
     });
   }
+  atomGroups.sort((a, b) => a.conceptSlug.localeCompare(b.conceptSlug));
 
   if (atomGroups.length === 0) {
     return {
@@ -216,16 +263,19 @@ export async function runPhaseSynthesizeConcepts(
 
     if (!opts.dryRun) {
       const title = group.conceptSlug.split('/').pop() ?? group.conceptSlug;
+      const evidenceSection = renderEvidence(group.supportingSources);
       await engine.putPage(`concepts/${title}`, {
         title: title.replace(/-/g, ' '),
         type: 'concept',
-        compiled_truth: narrative,
+        compiled_truth: evidenceSection ? `${narrative}\n\n${evidenceSection}` : narrative,
         frontmatter: {
           type: 'concept',
           tier: group.tier,
           mention_count: group.atomTitles.length,
           composite_score: group.atomTitles.length,
-          synthesized_at: new Date().toISOString(),
+          support_count: group.supportCount,
+          supporting_atoms: group.supportingAtoms.slice(0, MAX_SUPPORTING_ATOMS),
+          supporting_sources: group.supportingSources.slice(0, MAX_SUPPORTING_SOURCES),
           synthesized_by: 'synthesize_concepts-v0.41',
         },
         timeline: '',
@@ -294,6 +344,26 @@ export async function runPhaseSynthesizeConcepts(
       dry_run: opts.dryRun ?? false,
     },
   };
+}
+
+function evidenceKey(atom: ConceptAtom): string {
+  return `${atom.source_id ?? 'default'}::${atom.source_slug ?? atom.slug}::${atom.slug}`;
+}
+
+function dedupeEvidence(refs: EvidenceRef[]): EvidenceRef[] {
+  const unique = new Map<string, EvidenceRef>();
+  for (const ref of refs) unique.set(`${ref.source_id}::${ref.slug}`, ref);
+  return [...unique.values()].sort((a, b) =>
+    `${a.source_id}::${a.slug}`.localeCompare(`${b.source_id}::${b.slug}`),
+  );
+}
+
+function renderEvidence(sources: EvidenceRef[]): string {
+  if (sources.length === 0) return '';
+  const links = sources.slice(0, MAX_SUPPORTING_SOURCES).map((source) =>
+    `- [[${source.slug}]] (source: ${source.source_id})`,
+  );
+  return `## Supporting research\n\n${links.join('\n')}`;
 }
 
 /**

--- a/src/core/cycle/synthesize-concepts.ts
+++ b/src/core/cycle/synthesize-concepts.ts
@@ -193,6 +193,8 @@ export async function runPhaseSynthesizeConcepts(
 
   // 4. Per group: synthesize narrative (LLM for T1/T2, deterministic for T3+)
   let conceptsWritten = 0;
+  let conceptsProcessed = 0;
+  let conceptsUnchanged = 0;
   let estimatedSpendUsd = 0;
   const budgetCap = DEFAULT_BUDGET_USD;
   const failures: Array<{ concept: string; error: string }> = [];
@@ -280,8 +282,9 @@ export async function runPhaseSynthesizeConcepts(
       const conceptSlug = `concepts/${title}`;
       const existing = await engine.getPage(conceptSlug, { sourceId: 'default' });
       if (conceptPageMatches(existing, compiledTruth, frontmatter)) {
-        conceptsWritten++;
-        opts.progress?.tick(1, `${conceptsWritten} concepts`);
+        conceptsProcessed++;
+        conceptsUnchanged++;
+        opts.progress?.tick(1, `${conceptsProcessed} concepts`);
         await maybeYield();
         continue;
       }
@@ -294,8 +297,9 @@ export async function runPhaseSynthesizeConcepts(
       });
     }
     conceptsWritten++;
+    conceptsProcessed++;
     // v0.41.19.0 (T4): one tick per concept group with running count.
-    opts.progress?.tick(1, `${conceptsWritten} concepts`);
+    opts.progress?.tick(1, `${conceptsProcessed} concepts`);
 
     // v0.41.19.0 (T3): replaced bare per-iteration fire with throttled
     // helper. Same hook, same cycle-lock refresh effect, just at the
@@ -347,6 +351,7 @@ export async function runPhaseSynthesizeConcepts(
       (failures.length > 0 ? ` (${failures.length} LLM-failed → template fallback)` : ''),
     details: {
       concepts_written: conceptsWritten,
+      concepts_unchanged: conceptsUnchanged,
       tier_counts: tierCounts,
       groups_found: atomGroups.length,
       atoms_seen: atoms.length,

--- a/src/core/extract-takes-from-pages.ts
+++ b/src/core/extract-takes-from-pages.ts
@@ -174,7 +174,7 @@ export async function extractTakesFromPages(
     let response: { text: string };
     try {
       response = await chat({
-        model: opts.model ?? 'anthropic:claude-haiku-4-5',
+        model: opts.model,
         system: CLASSIFIER_SYSTEM,
         messages: [
           {

--- a/src/core/facts/classify.ts
+++ b/src/core/facts/classify.ts
@@ -35,6 +35,8 @@ export interface ClassifyOpts {
   model?: string;
   /** Abort signal for shutdown. */
   abortSignal?: AbortSignal;
+  /** Test/diagnostic override for deterministic gateway-unavailable fallback. */
+  chatAvailable?: boolean;
 }
 
 /**
@@ -95,7 +97,7 @@ export async function classifyAgainstCandidates(
   }
 
   // Try the classifier. On failure, fall back to cosine ≥ 0.92 → DUPLICATE.
-  if (!isAvailable('chat')) {
+  if (!(opts.chatAvailable ?? isAvailable('chat'))) {
     if (topId !== null && topScore >= fallback) {
       return { decision: 'duplicate', matched_id: topId, reason: 'cosine_fallback' };
     }
@@ -105,7 +107,7 @@ export async function classifyAgainstCandidates(
   let classifierResult: ChatResult | null = null;
   try {
     classifierResult = await chat({
-      model: opts.model ?? 'anthropic:claude-haiku-4-5-20251001',
+      model: opts.model,
       system: CLASSIFIER_SYSTEM,
       messages: [
         {

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -39,6 +39,7 @@ import { normalizeAliasList } from './search/alias-normalize.ts';
 import { isUndefinedTableError, warnOncePerProcess } from './utils.ts';
 import { computeCorpusGeneration } from './contextual-retrieval-service.ts';
 import { runGuardrails } from './guardrails.ts';
+import { getChatModel } from './ai/gateway.ts';
 
 /**
  * v0.20.0 Cathedral II Layer 8 D2 — markdown fence extraction helper.
@@ -721,7 +722,7 @@ export async function importFromContent(
       ? null
       : computeCorpusGeneration({
           crMode: effectiveCRMode,
-          haikuModel: 'anthropic:claude-haiku-4-5-20251001',
+          haikuModel: getChatModel(),
         });
 
   // Transaction wraps all DB writes. Every per-page tx call carries the

--- a/src/core/page-summary.ts
+++ b/src/core/page-summary.ts
@@ -41,9 +41,6 @@ import { sanitizeSynopsis } from './embedding-context.ts';
  */
 const HAIKU_MAX_TOKENS = 200;
 
-/** Default model when caller doesn't override. Resolves through the gateway. */
-const DEFAULT_SYNOPSIS_MODEL = 'anthropic:claude-haiku-4-5-20251001';
-
 /**
  * Synopsis prompt version. Folded into corpus_generation so prompt edits
  * invalidate prior embeddings via the v0.40.3.0 query_cache.page_generations
@@ -120,7 +117,7 @@ export async function generatePerChunkSynopsis(
   const userPrompt = buildUserPrompt(args.pageTitle, args.documentText, args.chunkText);
 
   const chatOpts: ChatOpts = {
-    model: args.model ?? DEFAULT_SYNOPSIS_MODEL,
+    model: args.model,
     system: SYSTEM_PROMPT,
     messages: [{ role: 'user', content: userPrompt }],
     maxTokens: HAIKU_MAX_TOKENS,

--- a/test/ai/build-gateway-config.test.ts
+++ b/test/ai/build-gateway-config.test.ts
@@ -117,3 +117,21 @@ describe('buildGatewayConfig env empty-string clobber guard (#1249)', () => {
     );
   });
 });
+
+describe('buildGatewayConfig OpenCode server file-plane settings', () => {
+  test('maps connection settings into the gateway environment', () => {
+    const cfg = buildGatewayConfig({
+      opencode_server_url: 'http://127.0.0.1:4900',
+      opencode_server_username: 'gbrain',
+      opencode_server_password: 'secret-value',
+      opencode_server_provider_id: 'openai',
+      opencode_server_agent: 'gbrain',
+    } as unknown as GBrainConfig);
+
+    expect(cfg.env.GBRAIN_OPENCODE_SERVER_URL).toBe('http://127.0.0.1:4900');
+    expect(cfg.env.GBRAIN_OPENCODE_SERVER_USERNAME).toBe('gbrain');
+    expect(cfg.env.GBRAIN_OPENCODE_SERVER_PASSWORD).toBe('secret-value');
+    expect(cfg.env.GBRAIN_OPENCODE_PROVIDER_ID).toBe('openai');
+    expect(cfg.env.GBRAIN_OPENCODE_AGENT).toBe('gbrain');
+  });
+});

--- a/test/ai/opencode-server-gateway.serial.test.ts
+++ b/test/ai/opencode-server-gateway.serial.test.ts
@@ -1,0 +1,92 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import {
+  configureGateway,
+  resetGateway,
+  toolLoop,
+  type ToolHandler,
+} from '../../src/core/ai/gateway.ts';
+
+let server: ReturnType<typeof Bun.serve>;
+let promptCount = 0;
+let deletedSessions = 0;
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (request.method === 'POST' && url.pathname === '/session') {
+        return Response.json({ id: `ses_${promptCount}` });
+      }
+      if (request.method === 'POST' && /\/session\/ses_\d+\/message/.test(url.pathname)) {
+        const body = await request.json() as any;
+        promptCount++;
+        const replayedToolResult = body.parts?.[0]?.text?.includes('Found one iOS page');
+        return Response.json({
+          info: {
+            structured: replayedToolResult
+              ? { text: 'The brain contains one relevant iOS page.', tool_calls: [] }
+              : {
+                  text: '',
+                  tool_calls: [{ id: 'toolu_search', name: 'brain_search', input: { query: 'iOS' } }],
+                },
+            tokens: { input: replayedToolResult ? 20 : 10, output: replayedToolResult ? 5 : 3, total: replayedToolResult ? 25 : 13 },
+          },
+          parts: [],
+        });
+      }
+      if (request.method === 'DELETE' && url.pathname.startsWith('/session/')) {
+        deletedSessions++;
+        return Response.json(true);
+      }
+      return new Response('not found', { status: 404 });
+    },
+  });
+  configureGateway({
+    chat_model: 'opencode-server:gpt-5.5',
+    env: { GBRAIN_OPENCODE_SERVER_URL: `http://127.0.0.1:${server.port}` },
+  });
+});
+
+afterAll(() => {
+  resetGateway();
+  server.stop(true);
+});
+
+describe('OpenCode server through the real GBrain gateway loop', () => {
+  test('executes a GBrain-owned tool and replays its result to a final response', async () => {
+    let handledInput: unknown;
+    const handler: ToolHandler = {
+      idempotent: true,
+      async execute(input) {
+        handledInput = input;
+        return { summary: 'Found one iOS page' };
+      },
+    };
+
+    const result = await toolLoop({
+      model: 'opencode-server:gpt-5.5',
+      initialMessages: [{ role: 'user', content: 'What do I know about iOS?' }],
+      tools: [{
+        name: 'brain_search',
+        description: 'Search GBrain',
+        inputSchema: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+          additionalProperties: false,
+        },
+      }],
+      toolHandlers: new Map([['brain_search', handler]]),
+    });
+
+    expect(handledInput).toEqual({ query: 'iOS' });
+    expect(result.finalText).toBe('The brain contains one relevant iOS page.');
+    expect(result.stopReason).toBe('end');
+    expect(result.totalTurns).toBe(1);
+    expect(result.totalUsage.input_tokens).toBe(30);
+    expect(result.totalUsage.output_tokens).toBe(8);
+    expect(promptCount).toBe(2);
+    expect(deletedSessions).toBe(2);
+  });
+});

--- a/test/config-set.test.ts
+++ b/test/config-set.test.ts
@@ -27,6 +27,7 @@ describe('KNOWN_CONFIG_KEYS', () => {
   test('contains the models-tier keys (v0.31.12)', () => {
     expect(KNOWN_CONFIG_KEYS).toContain('models.default');
     expect(KNOWN_CONFIG_KEYS).toContain('models.tier.subagent');
+    expect(KNOWN_CONFIG_KEYS).toContain('agent.use_gateway_loop');
   });
 
   test('contains the spend-control keys (v0.42.42.0, #2139) — no --force archaeology', () => {

--- a/test/cycle/extract-atoms-synthesize-concepts.test.ts
+++ b/test/cycle/extract-atoms-synthesize-concepts.test.ts
@@ -352,4 +352,63 @@ describe('v0.41 T6: runPhaseSynthesizeConcepts via stubbed chat', () => {
     );
     expect(rows[0].compiled_truth).toContain('Custom synthesized narrative');
   });
+
+  test('research concepts require two distinct original sources', async () => {
+    const oneSource = [1, 2, 3].map((i) => ({
+      slug: `atoms/a${i}`,
+      title: `A${i}`,
+      body: `body ${i}`,
+      concept_refs: ['ios-development'],
+      source_id: 'birdclaw',
+      source_slug: 'bookmarks/post-1',
+    }));
+    const result = await runPhaseSynthesizeConcepts(engine, { _atoms: oneSource });
+    expect(result.status).toBe('skipped');
+  });
+
+  test('writes bounded source-aware evidence for research concepts', async () => {
+    const atoms = Array.from({ length: 25 }, (_, i) => ({
+      slug: `atoms/a${i}`,
+      title: `A${i}`,
+      body: `body ${i}`,
+      concept_refs: ['ios-development'],
+      source_id: i === 0 ? 'other-source' : 'birdclaw',
+      source_slug: `bookmarks/post-${i}`,
+      source_hash: `hash-${i}`,
+    })).reverse();
+    await runPhaseSynthesizeConcepts(engine, { _atoms: atoms, _chat: stubChat('Native summary.') });
+    const rows = await engine.executeRaw<{
+      compiled_truth: string;
+      frontmatter: {
+        support_count: number;
+        supporting_atoms: Array<{ source_id: string; slug: string }>;
+        supporting_sources: Array<{ source_id: string; slug: string; source_hash?: string }>;
+        synthesized_at?: string;
+      };
+    }>(`SELECT compiled_truth, frontmatter FROM pages WHERE slug = 'concepts/ios-development'`);
+    expect(rows[0].frontmatter.support_count).toBe(25);
+    expect(rows[0].frontmatter.supporting_atoms).toHaveLength(20);
+    expect(rows[0].frontmatter.supporting_sources).toHaveLength(20);
+    expect(rows[0].frontmatter.supporting_sources[0]).toEqual({
+      source_id: 'birdclaw',
+      slug: 'bookmarks/post-1',
+      source_hash: 'hash-1',
+    });
+    expect(rows[0].compiled_truth).toContain('## Supporting research');
+    expect(rows[0].compiled_truth).toContain('[[bookmarks/post-1]] (source: birdclaw)');
+    expect(rows[0].frontmatter.synthesized_at).toBeUndefined();
+  });
+
+  test('same source slug in different source ids counts as distinct evidence', async () => {
+    const atoms = ['source-a', 'source-b'].map((source_id) => ({
+      slug: `atoms/${source_id}`,
+      title: source_id,
+      body: source_id,
+      concept_refs: ['shared-topic'],
+      source_id,
+      source_slug: 'bookmarks/same-slug',
+    }));
+    const result = await runPhaseSynthesizeConcepts(engine, { _atoms: atoms });
+    expect(result.details?.concepts_written).toBe(1);
+  });
 });

--- a/test/cycle/extract-atoms-synthesize-concepts.test.ts
+++ b/test/cycle/extract-atoms-synthesize-concepts.test.ts
@@ -470,12 +470,19 @@ describe('v0.41 T6: runPhaseSynthesizeConcepts via stubbed chat', () => {
     const before = await engine.executeRaw<{ updated_at: string; content_hash: string }>(
       `SELECT updated_at::text, content_hash FROM pages WHERE slug = 'concepts/stable-topic'`,
     );
+    const receiptsBefore = await engine.executeRaw<{ count: number }>(
+      `SELECT COUNT(*)::int AS count FROM pages WHERE type = 'extract_receipt'`,
+    );
     await new Promise((resolve) => setTimeout(resolve, 5));
     await runPhaseSynthesizeConcepts(engine, { _atoms: [...atoms].reverse() });
     const after = await engine.executeRaw<{ updated_at: string; content_hash: string }>(
       `SELECT updated_at::text, content_hash FROM pages WHERE slug = 'concepts/stable-topic'`,
     );
     expect(after[0]).toEqual(before[0]);
+    const receiptsAfter = await engine.executeRaw<{ count: number }>(
+      `SELECT COUNT(*)::int AS count FROM pages WHERE type = 'extract_receipt'`,
+    );
+    expect(receiptsAfter[0].count).toBe(receiptsBefore[0].count);
     const page = await engine.getPage('concepts/stable-topic');
     expect(page?.compiled_truth.match(/## Supporting atoms/g)).toHaveLength(1);
   });

--- a/test/cycle/extract-atoms-synthesize-concepts.test.ts
+++ b/test/cycle/extract-atoms-synthesize-concepts.test.ts
@@ -101,6 +101,29 @@ describe('v0.41 T5: parseAtomsResponse', () => {
     expect(parseAtomsResponse(`[{"title":"a","atom_type":"insight","body":"b","virality_score":-5}]`)[0].virality_score).toBeUndefined();
     expect(parseAtomsResponse(`[{"title":"a","atom_type":"insight","body":"b","virality_score":75}]`)[0].virality_score).toBe(75);
   });
+
+  test('normalizes, deduplicates, and caps concept references', () => {
+    const raw = JSON.stringify([{
+      title: 'Conceptful atom', atom_type: 'insight', body: 'body',
+      concepts: [' Agent Workflows ', 'agent workflows', 'iOS Development!', '', 'AI',
+        'Enterprise Architecture', 'Knowledge Graphs', 'Local Models', 'ignored sixth'],
+    }]);
+    expect(parseAtomsResponse(raw)[0].concepts).toEqual([
+      'agent-workflows',
+      'ios-development',
+      'enterprise-architecture',
+      'knowledge-graphs',
+      'local-models',
+    ]);
+  });
+
+  test('ignores malformed concepts without rejecting a valid atom', () => {
+    const atom = parseAtomsResponse(
+      `[{"title":"T","atom_type":"insight","body":"b","concepts":"not-an-array"}]`,
+    )[0];
+    expect(atom).toBeDefined();
+    expect(atom.concepts).toBeUndefined();
+  });
 });
 
 describe('v0.41 T5: runPhaseExtractAtoms via stubbed chat', () => {
@@ -132,6 +155,19 @@ describe('v0.41 T5: runPhaseExtractAtoms via stubbed chat', () => {
       `SELECT slug, type FROM pages WHERE type = 'atom'`,
     );
     expect(rows.length).toBe(2);
+  });
+
+  test('persists normalized concepts in atom frontmatter', async () => {
+    const chat = stubChat(`[{"title":"Native bookmark concepts","atom_type":"insight","body":"body","concepts":["Agent Workflows","iOS Development"]}]`);
+    await runPhaseExtractAtoms(engine, {
+      _transcripts: [],
+      _pages: [{ slug: 'media/x/bookmark', content: 'source', contentHash: 'bookmark-hash' }],
+      _chat: chat,
+    });
+    const rows = await engine.executeRaw<{ frontmatter: { concepts?: string[] } }>(
+      `SELECT frontmatter FROM pages WHERE type = 'atom'`,
+    );
+    expect(rows[0].frontmatter.concepts).toEqual(['agent-workflows', 'ios-development']);
   });
 
   test('dry-run counts but does NOT write', async () => {

--- a/test/cycle/extract-atoms-synthesize-concepts.test.ts
+++ b/test/cycle/extract-atoms-synthesize-concepts.test.ts
@@ -170,6 +170,27 @@ describe('v0.41 T5: runPhaseExtractAtoms via stubbed chat', () => {
     expect(rows[0].frontmatter.concepts).toEqual(['agent-workflows', 'ios-development']);
   });
 
+  test('same model title from different sources creates distinct atoms', async () => {
+    const chat = stubChat(`[{"title":"Shared title","atom_type":"insight","body":"body","concepts":["Shared Topic"]}]`);
+    await runPhaseExtractAtoms(engine, {
+      _transcripts: [],
+      _pages: [
+        { slug: 'media/x/one', content: 'one', contentHash: 'hash-source-one' },
+        { slug: 'media/x/two', content: 'two', contentHash: 'hash-source-two' },
+      ],
+      _chat: chat,
+    });
+    const rows = await engine.executeRaw<{ slug: string; frontmatter: { source_slug: string } }>(
+      `SELECT slug, frontmatter FROM pages WHERE type = 'atom' ORDER BY slug`,
+    );
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((row) => row.slug)).size).toBe(2);
+    expect(rows.map((row) => row.frontmatter.source_slug).sort()).toEqual([
+      'media/x/one',
+      'media/x/two',
+    ]);
+  });
+
   test('dry-run counts but does NOT write', async () => {
     const chat = stubChat(`[{"title":"x","atom_type":"insight","body":"b"}]`);
     const result = await runPhaseExtractAtoms(engine, {
@@ -381,7 +402,7 @@ describe('v0.41 T6: runPhaseSynthesizeConcepts via stubbed chat', () => {
       compiled_truth: string;
       frontmatter: {
         support_count: number;
-        supporting_atoms: Array<{ source_id: string; slug: string }>;
+        supporting_atoms: Array<{ source_id: string; slug: string; source_hash?: string }>;
         supporting_sources: Array<{ source_id: string; slug: string; source_hash?: string }>;
         synthesized_at?: string;
       };
@@ -395,7 +416,12 @@ describe('v0.41 T6: runPhaseSynthesizeConcepts via stubbed chat', () => {
       source_hash: 'hash-1',
     });
     expect(rows[0].compiled_truth).toContain('## Supporting research');
-    expect(rows[0].compiled_truth).toContain('[[bookmarks/post-1]] (source: birdclaw)');
+    expect(rows[0].compiled_truth).toContain('[[birdclaw:bookmarks/post-1]]');
+    expect(rows[0].frontmatter.supporting_atoms[0]).toEqual({
+      source_id: 'birdclaw',
+      slug: 'atoms/a1',
+      source_hash: 'hash-1',
+    });
     expect(rows[0].frontmatter.synthesized_at).toBeUndefined();
   });
 
@@ -410,5 +436,47 @@ describe('v0.41 T6: runPhaseSynthesizeConcepts via stubbed chat', () => {
     }));
     const result = await runPhaseSynthesizeConcepts(engine, { _atoms: atoms });
     expect(result.details?.concepts_written).toBe(1);
+  });
+
+  test('legacy atoms retain count-based promotion in a mixed evidence group', async () => {
+    const atoms = Array.from({ length: 9 }, (_, i) => ({
+      slug: `atoms/legacy-${i}`,
+      title: `Legacy ${i}`,
+      body: `legacy ${i}`,
+      concept_refs: ['established-topic'],
+    }));
+    atoms.push({
+      slug: 'atoms/bookmark',
+      title: 'Bookmark',
+      body: 'bookmark',
+      concept_refs: ['established-topic'],
+      source_id: 'birdclaw',
+      source_slug: 'media/x/bookmark',
+    } as (typeof atoms)[number]);
+    const result = await runPhaseSynthesizeConcepts(engine, {
+      _atoms: atoms,
+      _chat: stubChat('Established summary.'),
+    });
+    expect(result.details?.concepts_written).toBe(1);
+    expect((result.details?.tier_counts as Record<string, number>).T1).toBe(1);
+  });
+
+  test('unchanged deterministic synthesis does not rewrite the concept page', async () => {
+    const atoms = [
+      { slug: 'atoms/one', title: 'One', body: 'one', concept_refs: ['stable-topic'] },
+      { slug: 'atoms/two', title: 'Two', body: 'two', concept_refs: ['stable-topic'] },
+    ];
+    await runPhaseSynthesizeConcepts(engine, { _atoms: atoms });
+    const before = await engine.executeRaw<{ updated_at: string; content_hash: string }>(
+      `SELECT updated_at::text, content_hash FROM pages WHERE slug = 'concepts/stable-topic'`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await runPhaseSynthesizeConcepts(engine, { _atoms: [...atoms].reverse() });
+    const after = await engine.executeRaw<{ updated_at: string; content_hash: string }>(
+      `SELECT updated_at::text, content_hash FROM pages WHERE slug = 'concepts/stable-topic'`,
+    );
+    expect(after[0]).toEqual(before[0]);
+    const page = await engine.getPage('concepts/stable-topic');
+    expect(page?.compiled_truth.match(/## Supporting atoms/g)).toHaveLength(1);
   });
 });

--- a/test/doctor-extract-atoms-backlog.test.ts
+++ b/test/doctor-extract-atoms-backlog.test.ts
@@ -76,6 +76,26 @@ describe('countExtractAtomsBacklog (issue #1678)', () => {
     });
     expect(await countExtractAtomsBacklog(engine)).toBe(0);
   });
+
+  it('counts marked media with the same eligibility rule as discovery', async () => {
+    await engine.putPage('media/x/bookmark', {
+      type: 'media', title: 'bookmark', compiled_truth: BODY,
+      frontmatter: {
+        intake_adapter: 'birdclaw-bookmarks-to-brain',
+        content_kind: 'x-bookmark',
+        concept_synthesis_candidate: true,
+      },
+    });
+    await engine.putPage('media/x/unmarked', {
+      type: 'media', title: 'unmarked', compiled_truth: BODY,
+    });
+    await engine.putPage('media/x/untrusted-opt-in', {
+      type: 'media', title: 'untrusted', compiled_truth: BODY,
+      frontmatter: { concept_synthesis_candidate: true },
+    });
+    expect(await countExtractAtomsBacklog(engine)).toBe(1);
+    expect(await countExtractAtomsBacklog(engine, 'default')).toBe(1);
+  });
 });
 
 describe('computeExtractAtomsBacklogCheck (issue #1678)', () => {

--- a/test/e2e/dream.test.ts
+++ b/test/e2e/dream.test.ts
@@ -181,6 +181,7 @@ describeE2E('E2E: gbrain dream CLI against real Postgres', () => {
       const concept = await engine.getPage('concepts/native-bookmark-research');
       expect(concept).not.toBeNull();
       expect(concept?.compiled_truth).toContain('## Supporting research');
+      expect(concept?.compiled_truth).toContain('[[default:media/x/bookmark-one]]');
       const supporting = concept?.frontmatter.supporting_sources as Array<{ slug: string }>;
       expect(supporting.map((source) => source.slug)).toEqual([
         'media/x/bookmark-one',

--- a/test/e2e/dream.test.ts
+++ b/test/e2e/dream.test.ts
@@ -23,6 +23,22 @@ mock.module('../../src/core/embedding.ts', () => ({
   currentEmbeddingSignature: () => 'test:model:1536',
 }));
 
+mock.module('../../src/core/ai/gateway.ts', () => ({
+  chat: async () => ({
+    text: JSON.stringify([{
+      title: 'Native bookmark insight',
+      atom_type: 'insight',
+      body: 'A durable insight extracted through the native dream phase.',
+      source_quote: 'A representative source quote.',
+      lesson: 'Use the native dream lifecycle.',
+      virality_score: 40,
+      emotional_register: 'practical',
+      concepts: ['Native Bookmark Research'],
+    }]),
+    usage: { input_tokens: 10, output_tokens: 10 },
+  }),
+}));
+
 const { runDream } = await import('../../src/commands/dream.ts');
 
 const skip = !hasDatabase();
@@ -138,4 +154,41 @@ describeE2E('E2E: gbrain dream CLI against real Postgres', () => {
     // Read-only phase selection doesn't touch the lock table.
     expect(after[0].n).toBe(before[0].n);
   });
+
+  test('creator-pack dream phases turn marked bookmarks into an evidence-linked concept', async () => {
+    const engine = getEngine();
+    const previousPack = process.env.GBRAIN_SCHEMA_PACK;
+    process.env.GBRAIN_SCHEMA_PACK = 'gbrain-creator';
+    try {
+      for (const id of ['one', 'two']) {
+        await engine.putPage(`media/x/bookmark-${id}`, {
+          title: `Bookmark ${id}`,
+          type: 'media',
+          compiled_truth: `Research bookmark ${id}. ${'Useful native research context. '.repeat(25)}`,
+          frontmatter: {
+            type: 'media',
+            intake_adapter: 'birdclaw-bookmarks-to-brain',
+            content_kind: 'x-bookmark',
+            concept_synthesis_candidate: true,
+          },
+          timeline: '',
+        });
+      }
+
+      await captureLog(() => runDream(engine, ['--dir', repo, '--phase', 'extract_atoms', '--json']));
+      await captureLog(() => runDream(engine, ['--dir', repo, '--phase', 'synthesize_concepts', '--json']));
+
+      const concept = await engine.getPage('concepts/native-bookmark-research');
+      expect(concept).not.toBeNull();
+      expect(concept?.compiled_truth).toContain('## Supporting research');
+      const supporting = concept?.frontmatter.supporting_sources as Array<{ slug: string }>;
+      expect(supporting.map((source) => source.slug)).toEqual([
+        'media/x/bookmark-one',
+        'media/x/bookmark-two',
+      ]);
+    } finally {
+      if (previousPack === undefined) delete process.env.GBRAIN_SCHEMA_PACK;
+      else process.env.GBRAIN_SCHEMA_PACK = previousPack;
+    }
+  }, 60_000);
 });

--- a/test/extract-atoms-page-discovery.test.ts
+++ b/test/extract-atoms-page-discovery.test.ts
@@ -127,6 +127,39 @@ describe('v0.41.2.1: discoverExtractablePages SQL contract', () => {
     ]);
   });
 
+  test('admits only explicitly marked media pages', async () => {
+    await seedPage({
+      slug: 'media/x/bookmark',
+      type: 'media',
+      frontmatter: {
+        intake_adapter: 'birdclaw-bookmarks-to-brain',
+        content_kind: 'x-bookmark',
+        concept_synthesis_candidate: true,
+      },
+    });
+    await seedPage({ slug: 'media/x/unmarked', type: 'media' });
+    await seedPage({
+      slug: 'media/x/string-marked',
+      type: 'media',
+      frontmatter: {
+        intake_adapter: 'birdclaw-bookmarks-to-brain',
+        content_kind: 'x-bookmark',
+        concept_synthesis_candidate: 'true',
+      },
+    });
+    await seedPage({
+      slug: 'media/x/untrusted-opt-in',
+      type: 'media',
+      frontmatter: { concept_synthesis_candidate: true },
+    });
+
+    const discovered = await discoverExtractablePages(engine, 'default');
+    expect(discovered.map((d) => d.slug).sort()).toEqual([
+      'media/x/bookmark',
+      'media/x/string-marked',
+    ]);
+  });
+
   test('NOT EXISTS subquery skips pages whose source_hash has existing atoms', async () => {
     // Page content_hash is 20 chars; substring(from 1 for 16) yields the
     // first 16 chars. The seeded atom must carry exactly those 16 chars

--- a/test/facts-classify.test.ts
+++ b/test/facts-classify.test.ts
@@ -93,9 +93,10 @@ describe('classifyAgainstCandidates', () => {
     const result = await classifyAgainstCandidates(
       { fact: 'new', kind: 'fact', embedding: a },
       candidates,
+      { chatAvailable: false },
     );
-    // Without API key in test env, isAvailable('chat') is false → straight to
-    // cosine fallback. cos ≈ 0.93 ≥ 0.92 → duplicate.
+    // Force gateway-unavailable behavior so this unit test never depends on
+    // the developer machine's configured provider. cos ≈ 0.93 ≥ 0.92.
     expect(result.decision).toBe('duplicate');
     expect((result as { reason: string }).reason).toBe('cosine_fallback');
   });
@@ -105,9 +106,10 @@ describe('classifyAgainstCandidates', () => {
     const result = await classifyAgainstCandidates(
       { fact: 'new', kind: 'fact', embedding: null },
       candidates,
+      { chatAvailable: false },
     );
-    // Without API key in test env, isAvailable('chat') is false → cosine fallback path.
-    // newFact has no embedding so cosine fallback can't compute → independent.
+    // Force the cosine-fallback path. With no embedding it cannot compute a
+    // match, so the fact remains independent.
     expect(result.decision).toBe('independent');
     expect((result as { reason: string }).reason).toBe('cosine_fallback');
   });

--- a/test/opencode-server-language-model.test.ts
+++ b/test/opencode-server-language-model.test.ts
@@ -63,6 +63,7 @@ describe('opencode-server recipe', () => {
     expect(recipe?.touchpoints.chat?.supports_tools).toBe(true);
     expect(recipe?.touchpoints.chat?.supports_subagent_loop).toBe(true);
     expect(recipe?.touchpoints.chat?.models).toContain('gpt-5.5');
+    expect(recipe?.touchpoints.expansion?.models).toContain('gpt-5.4-mini');
   });
 });
 
@@ -105,6 +106,63 @@ describe('OpenCodeServerLanguageModel', () => {
 
     expect(result.content).toEqual([{ type: 'text', text: 'Done.' }]);
     expect(result.finishReason).toBe('stop');
+  });
+
+  test('uses the caller JSON schema for AI SDK structured generation', async () => {
+    const fake = fakeServer({ queries: ['Swift development', 'iOS architecture'] });
+    const model = new OpenCodeServerLanguageModel('gpt-5.4-mini', { baseUrl: fake.baseUrl });
+    const schema = {
+      type: 'object',
+      properties: { queries: { type: 'array', items: { type: 'string' } } },
+      required: ['queries'],
+      additionalProperties: false,
+    } as const;
+
+    const result = await model.doGenerate({
+      ...options(),
+      responseFormat: { type: 'json', schema },
+    });
+
+    expect(result.content).toEqual([{
+      type: 'text',
+      text: '{"queries":["Swift development","iOS architecture"]}',
+    }]);
+    expect(result.finishReason).toBe('stop');
+    expect(fake.requests[1].body.format.schema).toEqual(schema);
+    expect(fake.requests[1].body.system).toContain('matches the requested schema');
+    expect(fake.requests[1].body.system).not.toContain('tool_calls');
+  });
+
+  test('preserves top-level arrays in plain-text JSON fallback', async () => {
+    let messageCalls = 0;
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const path = new URL(request.url).pathname;
+        if (request.method === 'POST' && path === '/session') return Response.json({ id: 'ses_test' });
+        if (request.method === 'POST' && path === '/session/ses_test/message') {
+          messageCalls++;
+          if (messageCalls === 1) {
+            return Response.json({ info: { error: { name: 'StructuredOutputError' } }, parts: [] });
+          }
+          return Response.json({ info: {}, parts: [{ type: 'text', text: '```json\n[{"name":"iOS"}]\n```' }] });
+        }
+        if (request.method === 'DELETE') return Response.json(true);
+        return new Response('not found', { status: 404 });
+      },
+    });
+    servers.push(server);
+    const model = new OpenCodeServerLanguageModel('gpt-5.4-mini', {
+      baseUrl: `http://127.0.0.1:${server.port}`,
+    });
+
+    const result = await model.doGenerate({
+      ...options(),
+      responseFormat: { type: 'json', schema: { type: 'array', items: { type: 'object' } } },
+    });
+
+    expect(result.content).toEqual([{ type: 'text', text: '[{"name":"iOS"}]' }]);
+    expect(messageCalls).toBe(2);
   });
 
   test('converts structured requests into native AI SDK tool calls', async () => {

--- a/test/opencode-server-language-model.test.ts
+++ b/test/opencode-server-language-model.test.ts
@@ -97,6 +97,16 @@ describe('OpenCodeServerLanguageModel', () => {
     expect(fake.requests[1].body.format.type).toBe('json_schema');
   });
 
+  test('normalizes an omitted tool_calls field only when no tools were offered', async () => {
+    const fake = fakeServer({ text: 'Done.' });
+    const model = new OpenCodeServerLanguageModel('gpt-5.5', { baseUrl: fake.baseUrl });
+
+    const result = await model.doGenerate(options());
+
+    expect(result.content).toEqual([{ type: 'text', text: 'Done.' }]);
+    expect(result.finishReason).toBe('stop');
+  });
+
   test('converts structured requests into native AI SDK tool calls', async () => {
     const fake = fakeServer({
       text: '',
@@ -125,6 +135,28 @@ describe('OpenCodeServerLanguageModel', () => {
     }]);
     expect(fake.requests[1].body.format.schema.properties.tool_calls.items.properties.name.enum)
       .toEqual(['brain_search']);
+    expect(fake.requests[1].body.system).toContain('do not request that tool again');
+  });
+
+  test('accepts OpenAI OAuth tool arguments as an input alias', async () => {
+    const fake = fakeServer({
+      text: '',
+      tool_calls: [{ name: 'brain_search', arguments: { query: 'iOS' } }],
+    });
+    const model = new OpenCodeServerLanguageModel('gpt-5.5', { baseUrl: fake.baseUrl });
+
+    const result = await model.doGenerate(options([{
+      type: 'function',
+      name: 'brain_search',
+      inputSchema: { type: 'object', properties: { query: { type: 'string' } } },
+    }]));
+
+    expect(result.content).toEqual([{
+      type: 'tool-call',
+      toolCallId: 'toolu_opencode_0',
+      toolName: 'brain_search',
+      input: '{"query":"iOS"}',
+    }]);
   });
 
   test('falls back to strict text JSON when a model lacks structured output', async () => {

--- a/test/opencode-server-language-model.test.ts
+++ b/test/opencode-server-language-model.test.ts
@@ -165,6 +165,39 @@ describe('OpenCodeServerLanguageModel', () => {
     expect(messageCalls).toBe(2);
   });
 
+  test('recovers OpenAI OAuth output_text when OpenCode flags structured output', async () => {
+    let messageCalls = 0;
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const path = new URL(request.url).pathname;
+        if (request.method === 'POST' && path === '/session') return Response.json({ id: 'ses_test' });
+        if (request.method === 'POST' && path === '/session/ses_test/message') {
+          messageCalls++;
+          return Response.json({
+            info: {
+              error: { name: 'StructuredOutputError' },
+              tokens: { input: 176, output: 29, total: 205 },
+            },
+            parts: [{ type: 'text', text: '{"output_text":"READY"}' }],
+          });
+        }
+        if (request.method === 'DELETE') return Response.json(true);
+        return new Response('not found', { status: 404 });
+      },
+    });
+    servers.push(server);
+    const model = new OpenCodeServerLanguageModel('gpt-5.5', {
+      baseUrl: `http://127.0.0.1:${server.port}`,
+    });
+
+    const result = await model.doGenerate(options());
+
+    expect(result.content).toEqual([{ type: 'text', text: 'READY' }]);
+    expect(result.usage).toEqual({ inputTokens: 176, outputTokens: 29, totalTokens: 205 });
+    expect(messageCalls).toBe(1);
+  });
+
   test('converts structured requests into native AI SDK tool calls', async () => {
     const fake = fakeServer({
       text: '',
@@ -217,7 +250,7 @@ describe('OpenCodeServerLanguageModel', () => {
     }]);
   });
 
-  test('falls back to strict text JSON when a model lacks structured output', async () => {
+  test('falls back to strict text JSON on tool-capable turns', async () => {
     let messageCalls = 0;
     const server = Bun.serve({
       port: 0,
@@ -252,7 +285,11 @@ describe('OpenCodeServerLanguageModel', () => {
       baseUrl: `http://127.0.0.1:${server.port}`,
     });
 
-    const result = await model.doGenerate(options());
+    const result = await model.doGenerate(options([{
+      type: 'function',
+      name: 'brain_search',
+      inputSchema: { type: 'object', properties: {} },
+    }]));
 
     expect(result.content).toEqual([{ type: 'text', text: 'READY' }]);
     expect(result.usage).toEqual({ inputTokens: 30, outputTokens: 6, totalTokens: 36 });

--- a/test/opencode-server-language-model.test.ts
+++ b/test/opencode-server-language-model.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { LanguageModelV2CallOptions } from '@ai-sdk/provider';
+import { AIConfigError, AITransientError } from '../src/core/ai/errors.ts';
+import {
+  OpenCodeServerLanguageModel,
+  renderOpenCodePrompt,
+} from '../src/core/ai/providers/opencode-server-language-model.ts';
+import { getRecipe } from '../src/core/ai/recipes/index.ts';
+
+const servers: Array<ReturnType<typeof Bun.serve>> = [];
+
+afterEach(() => {
+  for (const server of servers.splice(0)) server.stop(true);
+});
+
+function options(tools: LanguageModelV2CallOptions['tools'] = []): LanguageModelV2CallOptions {
+  return {
+    prompt: [
+      { role: 'system', content: 'You are a careful knowledge worker.' },
+      { role: 'user', content: [{ type: 'text', text: 'Process this bookmark.' }] },
+    ],
+    tools,
+  } as LanguageModelV2CallOptions;
+}
+
+function fakeServer(result: unknown, opts: { status?: number; password?: string } = {}) {
+  const requests: Array<{ method: string; path: string; body: any; authorization: string | null }> = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      const body = request.method === 'POST' ? await request.json() : null;
+      requests.push({
+        method: request.method,
+        path: url.pathname,
+        body,
+        authorization: request.headers.get('authorization'),
+      });
+      if (opts.status) return new Response('failure', { status: opts.status });
+      if (request.method === 'POST' && url.pathname === '/session') {
+        return Response.json({ id: 'ses_test' });
+      }
+      if (request.method === 'POST' && url.pathname === '/session/ses_test/message') {
+        return Response.json({
+          info: { structured: result, tokens: { input: 120, output: 30, total: 150 } },
+          parts: [],
+        });
+      }
+      if (request.method === 'DELETE' && url.pathname === '/session/ses_test') {
+        return Response.json(true);
+      }
+      return new Response('not found', { status: 404 });
+    },
+  });
+  servers.push(server);
+  return { baseUrl: `http://127.0.0.1:${server.port}`, requests };
+}
+
+describe('opencode-server recipe', () => {
+  test('is registered as a tool-capable native chat provider', () => {
+    const recipe = getRecipe('opencode-server');
+    expect(recipe?.implementation).toBe('opencode-server');
+    expect(recipe?.touchpoints.chat?.supports_tools).toBe(true);
+    expect(recipe?.touchpoints.chat?.supports_subagent_loop).toBe(true);
+    expect(recipe?.touchpoints.chat?.models).toContain('gpt-5.5');
+  });
+});
+
+describe('OpenCodeServerLanguageModel', () => {
+  test('preserves provider-native colons inside model ids', () => {
+    const model = new OpenCodeServerLanguageModel('qwen3.6:35b', { providerId: 'ollama' });
+    expect(model.modelId).toBe('qwen3.6:35b');
+  });
+
+  test('returns final text, usage, deny-all permissions, and deletes the session', async () => {
+    const fake = fakeServer({ text: 'Done.', tool_calls: [] });
+    const model = new OpenCodeServerLanguageModel('opencode-server:gpt-5.5', {
+      baseUrl: fake.baseUrl,
+      directory: '/tmp/gbrain-opencode-test',
+    });
+
+    const result = await model.doGenerate(options());
+
+    expect(result.content).toEqual([{ type: 'text', text: 'Done.' }]);
+    expect(result.finishReason).toBe('stop');
+    expect(result.usage).toEqual({ inputTokens: 120, outputTokens: 30, totalTokens: 150 });
+    expect(fake.requests.map(request => `${request.method} ${request.path}`)).toEqual([
+      'POST /session',
+      'POST /session/ses_test/message',
+      'DELETE /session/ses_test',
+    ]);
+    expect(fake.requests[0].body.permission).toEqual([
+      { permission: '*', pattern: '*', action: 'deny' },
+    ]);
+    expect(fake.requests[1].body.model).toEqual({ providerID: 'openai', modelID: 'gpt-5.5' });
+    expect(fake.requests[1].body.agent).toBe('gbrain');
+    expect(fake.requests[1].body.format.type).toBe('json_schema');
+  });
+
+  test('converts structured requests into native AI SDK tool calls', async () => {
+    const fake = fakeServer({
+      text: '',
+      tool_calls: [{ id: 'toolu_1', name: 'brain_search', input: { query: 'iOS' } }],
+    });
+    const model = new OpenCodeServerLanguageModel('gpt-5.5', { baseUrl: fake.baseUrl });
+
+    const result = await model.doGenerate(options([{
+      type: 'function',
+      name: 'brain_search',
+      description: 'Search the brain',
+      inputSchema: {
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+        additionalProperties: false,
+      },
+    }]));
+
+    expect(result.finishReason).toBe('tool-calls');
+    expect(result.content).toEqual([{
+      type: 'tool-call',
+      toolCallId: 'toolu_1',
+      toolName: 'brain_search',
+      input: '{"query":"iOS"}',
+    }]);
+    expect(fake.requests[1].body.format.schema.properties.tool_calls.items.properties.name.enum)
+      .toEqual(['brain_search']);
+  });
+
+  test('falls back to strict text JSON when a model lacks structured output', async () => {
+    let messageCalls = 0;
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const path = new URL(request.url).pathname;
+        if (request.method === 'POST' && path === '/session') return Response.json({ id: 'ses_test' });
+        if (request.method === 'POST' && path === '/session/ses_test/message') {
+          messageCalls++;
+          if (messageCalls === 1) {
+            return Response.json({
+              info: {
+                error: { name: 'StructuredOutputError' },
+                tokens: { input: 10, output: 2, total: 12 },
+              },
+              parts: [{ type: 'text', text: 'not json' }],
+            });
+          }
+          const body = await request.json() as any;
+          expect(body.format).toEqual({ type: 'text' });
+          expect(body.parts[0].text).toContain('Return only the required JSON object');
+          return Response.json({
+            info: { tokens: { input: 20, output: 4, total: 24 } },
+            parts: [{ type: 'text', text: '```json\n{"text":"READY","tool_calls":[]}\n```' }],
+          });
+        }
+        if (request.method === 'DELETE') return Response.json(true);
+        return new Response('not found', { status: 404 });
+      },
+    });
+    servers.push(server);
+    const model = new OpenCodeServerLanguageModel('gpt-5.5', {
+      baseUrl: `http://127.0.0.1:${server.port}`,
+    });
+
+    const result = await model.doGenerate(options());
+
+    expect(result.content).toEqual([{ type: 'text', text: 'READY' }]);
+    expect(result.usage).toEqual({ inputTokens: 30, outputTokens: 6, totalTokens: 36 });
+    expect(messageCalls).toBe(2);
+  });
+
+  test('accepts fallback plain text only when no GBrain tools were offered', async () => {
+    let messageCalls = 0;
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const path = new URL(request.url).pathname;
+        if (request.method === 'POST' && path === '/session') return Response.json({ id: 'ses_test' });
+        if (request.method === 'POST' && path === '/session/ses_test/message') {
+          messageCalls++;
+          if (messageCalls === 1) {
+            return Response.json({ info: { error: { name: 'StructuredOutputError' } }, parts: [] });
+          }
+          return Response.json({ info: {}, parts: [{ type: 'text', text: 'READY' }] });
+        }
+        if (request.method === 'DELETE') return Response.json(true);
+        return new Response('not found', { status: 404 });
+      },
+    });
+    servers.push(server);
+    const model = new OpenCodeServerLanguageModel('gpt-5.5', {
+      baseUrl: `http://127.0.0.1:${server.port}`,
+    });
+
+    const result = await model.doGenerate(options());
+
+    expect(result.content).toEqual([{ type: 'text', text: 'READY' }]);
+    expect(result.finishReason).toBe('stop');
+  });
+
+  test('rejects a structured call for an unregistered tool', async () => {
+    const fake = fakeServer({
+      text: '',
+      tool_calls: [{ id: 'toolu_1', name: 'bash', input: { command: 'whoami' } }],
+    });
+    const model = new OpenCodeServerLanguageModel('gpt-5.5', { baseUrl: fake.baseUrl });
+
+    await expect(model.doGenerate(options([{
+      type: 'function',
+      name: 'brain_search',
+      inputSchema: { type: 'object', properties: {} },
+    }]))).rejects.toThrow('unknown GBrain tool "bash"');
+    expect(fake.requests.at(-1)?.method).toBe('DELETE');
+  });
+
+  test('sends optional HTTP Basic credentials without exposing them in payloads', async () => {
+    const fake = fakeServer({ text: 'ok', tool_calls: [] });
+    const model = new OpenCodeServerLanguageModel('gpt-5.5', {
+      baseUrl: fake.baseUrl,
+      username: 'gbrain',
+      password: 'test-password',
+    });
+
+    await model.doGenerate(options());
+
+    expect(fake.requests[0].authorization).toBe(
+      `Basic ${Buffer.from('gbrain:test-password').toString('base64')}`,
+    );
+    expect(JSON.stringify(fake.requests.map(request => request.body))).not.toContain('test-password');
+  });
+
+  test('classifies authentication errors as configuration failures', async () => {
+    const fake = fakeServer({}, { status: 401 });
+    const model = new OpenCodeServerLanguageModel('gpt-5.5', { baseUrl: fake.baseUrl });
+
+    try {
+      await model.doGenerate(options());
+      throw new Error('expected failure');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AIConfigError);
+      expect((error as Error).message).toContain('HTTP 401');
+    }
+  });
+
+  test('classifies server errors as retryable failures', async () => {
+    const fake = fakeServer({}, { status: 503 });
+    const model = new OpenCodeServerLanguageModel('gpt-5.5', { baseUrl: fake.baseUrl });
+
+    try {
+      await model.doGenerate(options());
+      throw new Error('expected failure');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AITransientError);
+      expect((error as Error).message).toContain('HTTP 503');
+    }
+  });
+
+  test('renders prior GBrain tool results into replay context', () => {
+    const rendered = renderOpenCodePrompt([
+      { role: 'system', content: 'system' },
+      { role: 'assistant', content: [{
+        type: 'tool-call',
+        toolCallId: 'toolu_1',
+        toolName: 'brain_search',
+        input: '{"query":"iOS"}',
+      }] },
+      { role: 'tool', content: [{
+        type: 'tool-result',
+        toolCallId: 'toolu_1',
+        toolName: 'brain_search',
+        output: { type: 'text', value: 'Found 3 pages' },
+      }] },
+    ] as any);
+
+    expect(rendered.systemText).toBe('system');
+    expect(rendered.conversationText).toContain('brain_search');
+    expect(rendered.conversationText).toContain('Found 3 pages');
+  });
+});


### PR DESCRIPTION
## Summary

GBrain can now process BirdClaw X bookmarks through its normal creator-pack dream lifecycle using ChatGPT OAuth through a persistent OpenCode server. BirdClaw remains a deterministic collector; GBrain owns atom extraction, evidence-backed concept synthesis, indexing, and the later graph/fact pass.

This ships the provider and dream changes together because bookmark reasoning must follow the same configured gateway, budget, receipts, and lifecycle controls as every other native GBrain workload.

```mermaid
flowchart TB
  X[X bookmarks] --> B[BirdClaw collector]
  B --> M[Marked media pages]
  M --> S[gbrain sync]
  S --> E[Dream: extract_atoms]
  E --> A[Source-aware atoms]
  A --> C[Dream: synthesize_concepts]
  C --> W[Evidence-linked concepts]
  W --> D[Next normal dream pass]
  D --> G[Graph, facts, embeddings, search]
  O[OpenCode OAuth server] --> E
  O --> C
```

## Design decisions

- Media eligibility requires all 3 BirdClaw markers, so unrelated media cannot enter the extraction backlog.
- Research concepts require 2 distinct original sources. Multiple atoms from one bookmark cannot manufacture support.
- Concept pages persist bounded, source-qualified links to both original bookmarks and supporting atoms. Identical slugs in different sources remain unambiguous.
- Atom identities include a stable source digest and response ordinal, preventing same-titled insights from overwriting one another.
- Deterministic support ordering and semantic no-op detection prevent duplicate links, page rewrites, and false extraction receipts on reruns.
- Legacy transcript concepts retain count-based promotion, including mixed legacy/research groups.
- OpenCode remains behind GBrain's provider-agnostic gateway, keeping OAuth reuse, budgets, diagnostics, and fallback behavior native.

## Validation

- `bun run verify` (31 checks passed)
- 53 focused bookmark/dream tests passed
- 156 synthesis and link-extraction tests passed during autofix re-review
- BirdClaw collector-only shell and Node tests passed in the integration repository
- TypeScript typecheck passed
- Postgres dream E2E coverage was added and is gated by `DATABASE_URL`; the PGLite suite always covers the critical collision and rerun paths
- Browser testing was not applicable because the diff has no web routes or UI surface

## Post-Deploy Monitoring & Validation

- **Window and owner:** first 24 hours after activation; brain operator owns validation.
- **Logs:** watch for `extract_atoms`, `synthesize_concepts`, `not_in_active_pack`, `provider_unavailable`, and `cycle_already_running`.
- **Healthy signals:** extract backlog falls; native atom/concept receipts advance; concept pages have at least 2 distinct `supporting_sources`; OpenCode diagnostics show the configured `opencode-server:*` route; search resolves qualified evidence links.
- **Failure signals:** unrelated media is admitted, backlog is flat across 2 scheduled cycles, provider warnings persist, evidence links are unresolved, or legacy `build-research-wiki` commands continue after collector-only cutover.
- **Rollback trigger:** on any failure signal, restore the prior BirdClaw combined invocation, switch the active pack back to `gbrain-base-v2`, and stop native bookmark admission until diagnosed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
