### PR TITLE
fix(dream): require self-contained opening summary in synthesized pages

### DIFF
--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -964,6 +964,7 @@ OUTPUT POLICY (ALL of these are required)
 2. Cross-reference compulsively: every new page MUST contain at least one wikilink (e.g., \`[ref](people/jane-doe)\` or \`[[people/jane-doe]]\`) to existing brain content. Use the search tool to find existing pages first.
 3. Do NOT write to any path outside the allow-list shown in the put_page schema.
 4. Slug discipline: lowercase alphanumeric and hyphens only, slash-separated segments. NO underscores, NO file extensions.
+5. Self-contained opening: begin every new page's body with a 2-3 sentence summary that a reader unfamiliar with this transcript could understand on its own, before any quotes or detail. Do not assume the reader has the source conversation for context.
 
 TASKS
 A. Reflections (self-knowledge, pattern recognition, emotional processing):


### PR DESCRIPTION
## Summary
Synth pages written by dream synthesize currently open straight into detail (quotes, cross-references) with no framing, so a reader who lands on the page later — without the source transcript in front of them — has no way to tell what it's about without reading the whole thing.

This adds `OUTPUT POLICY` item 5 to the synthesis subagent prompt: every new page's body must open with a 2-3 sentence self-contained summary a reader unfamiliar with the source conversation could understand on its own, before any quotes or detail.

## Change
Single-line addition to `buildSynthesisPrompt()` in `src/core/cycle/synthesize.ts`.

## Test plan
- [x] Syntax-checked via `bun build --target=bun` and `tsc --noEmit` (0 errors)
- [x] Reviewed via `codex review` (gpt-5.6-sol, high effort) — no findings
- [ ] Effect verified on real dream synthesize output (prompt-only change; next nightly dream cycle will exercise it)

Prompts-only change with no code-path implications — does not conflict with the existing synthesis workflow or tool contract.