### PR TITLE
fix(minions): restore rolling conversation prompt-cache on the direct SDK path

### DIFF
--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -490,6 +490,15 @@ export function makeSubagentHandler(deps: SubagentDeps) {
             }
           }
           const lastMsg = anthroMessages[anthroMessages.length - 1] as any;
+          // A fresh job's seed message has string content (see the
+          // `[{ role: 'user', content: data.prompt }]` init above), which
+          // the array-only check below would silently skip — leaving the
+          // very first call, and thus the common single-tool round-trip,
+          // with no rolling breakpoint at all. Normalize to a one-block
+          // array first so it gets the marker like every later turn.
+          if (typeof lastMsg.content === 'string') {
+            lastMsg.content = [{ type: 'text', text: lastMsg.content }];
+          }
           if (Array.isArray(lastMsg.content) && lastMsg.content.length > 0) {
             const lastBlock = lastMsg.content[lastMsg.content.length - 1];
             if (lastBlock && typeof lastBlock === 'object') {

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -475,6 +475,29 @@ export function makeSubagentHandler(deps: SubagentDeps) {
       // covers the whole request. A mid-call renewal loop would add
       // complexity; for v0.15 we lean on the 120s TTL + abort-on-signal.
       try {
+        // --- Patch B (borrow-ahead, hand-authored): rolling conversation prompt-cache ---
+        // Direct path marks cache_control only on static system(485)+last-tool(498) ~5.2K;
+        // the growing anthroMessages conversation is re-billed every turn (6/18 v0.42.51
+        // regression). Anthropic caches up to the last cache_control block, so mark the last
+        // content block of the last message and strip stale message markers to stay within
+        // the 4-breakpoint API limit (system + last-tool + 1 rolling = 3).
+        if (anthroMessages.length > 0) {
+          for (const m of anthroMessages as any[]) {
+            if (Array.isArray(m.content)) {
+              for (const b of m.content) {
+                if (b && typeof b === 'object' && 'cache_control' in b) delete b.cache_control;
+              }
+            }
+          }
+          const lastMsg = anthroMessages[anthroMessages.length - 1] as any;
+          if (Array.isArray(lastMsg.content) && lastMsg.content.length > 0) {
+            const lastBlock = lastMsg.content[lastMsg.content.length - 1];
+            if (lastBlock && typeof lastBlock === 'object') {
+              lastBlock.cache_control = { type: 'ephemeral' };
+            }
+          }
+        }
+        // --- end Patch B ---
         const params: Anthropic.MessageCreateParamsNonStreaming = {
           // v0.41 Bug 3: strip `provider:` prefix at the SDK call site only.
           // `model` stays qualified everywhere else (persistence, recipe

--- a/src/core/minions/handlers/subagent.ts
+++ b/src/core/minions/handlers/subagent.ts
@@ -479,14 +479,37 @@ export function makeSubagentHandler(deps: SubagentDeps) {
         // Direct path marks cache_control only on static system(485)+last-tool(498) ~5.2K;
         // the growing anthroMessages conversation is re-billed every turn (6/18 v0.42.51
         // regression). Anthropic caches up to the last cache_control block, so mark the last
-        // content block of the last message and strip stale message markers to stay within
-        // the 4-breakpoint API limit (system + last-tool + 1 rolling = 3).
+        // content block of the last message and keep the 4-breakpoint API limit
+        // (system + last-tool + 2 rolling = 4).
+        //
+        // Two rolling markers, not one: Anthropic's automatic cache lookup only walks
+        // back up to 20 content blocks from a breakpoint to find a prior cached prefix
+        // (see prompt-caching docs, "20-block lookback window"). A turn that adds more
+        // than 20 blocks since the last marker (e.g. a large parallel tool_use/tool_result
+        // round) would make a freshly-placed single marker miss the previous cache
+        // entirely. Keeping the immediately-preceding rolling marker in place — and only
+        // evicting anything older than that — guarantees at least that marker's prefix is
+        // still a valid, already-written cache read even when this turn's new marker's
+        // lookback comes up empty.
         if (anthroMessages.length > 0) {
-          for (const m of anthroMessages as any[]) {
+          const markerIndices: number[] = [];
+          for (let i = 0; i < anthroMessages.length; i++) {
+            const m = anthroMessages[i] as any;
             if (Array.isArray(m.content)) {
               for (const b of m.content) {
-                if (b && typeof b === 'object' && 'cache_control' in b) delete b.cache_control;
+                if (b && typeof b === 'object' && 'cache_control' in b) {
+                  markerIndices.push(i);
+                  break;
+                }
               }
+            }
+          }
+          const keepIdx = markerIndices.length > 0 ? markerIndices[markerIndices.length - 1] : -1;
+          for (const i of markerIndices) {
+            if (i === keepIdx) continue;
+            const m = anthroMessages[i] as any;
+            for (const b of m.content) {
+              if (b && typeof b === 'object' && 'cache_control' in b) delete b.cache_control;
             }
           }
           const lastMsg = anthroMessages[anthroMessages.length - 1] as any;


### PR DESCRIPTION
## Summary

Regression since v0.42.51 (`@ai-sdk` bump): on the direct/native subagent path (`agent.use_gateway_loop=false`), `cache_control` is only marked on the static system-prompt and last-tool-def blocks (~5.2K tokens). The `anthroMessages` array — the part of the request that actually grows every turn — carries no cache marker at all, so Anthropic re-bills the full conversation as fresh input on every turn instead of reading it from cache.

Before the regression, `cache_read_input_tokens` grew with the conversation (4.6K → 125K across a session, healthy period ≤ 2026-06-18). Since the regression, `cache_read_input_tokens` is pinned at the ~5.2K static prefix regardless of conversation length — this run alone cost ~$20 with `cacheR/in=0.000`.

## Fix

Mark the last content block of the last message with `cache_control: {type: 'ephemeral'}` on every turn, keeping the immediately-preceding rolling marker in place (not stripping down to a single marker — see below) and stripping anything older. Anthropic caches everything up to the last breakpoint, so this turns the trailing marker into a rolling window over the growing conversation, staying within the 4-breakpoint limit (system + last-tool + 2 rolling = 4).

Two rolling markers, not one: Anthropic's automatic cache lookup only walks back up to 20 content blocks from a breakpoint to find a prior cached prefix ([prompt-caching docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), "20-block lookback window"). A turn that adds more than 20 blocks since the last marker (e.g. a large parallel `tool_use`/`tool_result` round) would make a freshly-placed single marker miss the previous cache entirely. Keeping the immediately-preceding rolling marker guarantees at least that marker's prefix remains a valid, already-cached read even when the new marker's own lookback comes up empty.

A fresh job's seed message is initialized with string `content` (`[{ role: 'user', content: data.prompt }]`), not a content-block array — the array-only breakpoint check would otherwise silently skip the very first API call, leaving the common single-tool round-trip (seed prompt → tool_use → tool_result → done) with zero conversation-cache benefit. Content is normalized to a one-block array before the check so the first call gets the same treatment as every later one.

## Measured impact

Forced dream run on the native path: `cacheR/in` 0.000 → 32–61 across 23 calls (cache_read grows 0 → 122K as the conversation grows; `input_tokens` drops to 1 after turn 1 — the whole conversation is read from cache). Actual cost $1.71 vs. ~$8.5 no-cache-equivalent for the same run (~80% reduction), zero dead-letter jobs.

## Why not the gateway path

Neither the gateway path (`cache_control` placed at the top level, which `@ai-sdk` 3.x silently ignores — #2490) nor #2442 (system + last-tool only) restores this; both leave the conversation body unrecovered. This fix targets the native/direct path specifically (`agent.use_gateway_loop=false`).

## Test plan
- [x] Syntax-checked via `bun build --target=bun` and `tsc --noEmit` (0 errors)
- [x] Reviewed via `codex review` (gpt-5.6-sol, high effort) across 3 iterations — both real findings (seed-message string content, 20-block lookback) fixed; final pass clean
- [x] Verified on a real dream synthesize run (cacheR/in 0.000 → 32-61, ~80% cost reduction, 0 dead-letter — see measured impact above)
- [x] Running in production on this fork's install since 2026-07-04 (v1) / 2026-07-13 (this v2 fix)