### PR TITLE
v0.42.58.0 fix(cli): expose book-mirror detailed help (#2774)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -68,6 +68,8 @@ const CLI_ONLY_SELF_HELP = new Set([
   'capture',
   // v0.42 self-upgrade ships its own usage (flags + the agent-skill story).
   'self-upgrade',
+  // book-mirror ships detailed flag/cost help in its command module.
+  'book-mirror',
   // v0.43 (#2095): watch ships WATCH_HELP (flags + the stdin-turn protocol).
   'watch',
   // v0.37 fix wave (Lane D.4 + CDX2-12): sync's --no-embed flag was
@@ -1489,6 +1491,12 @@ async function handleCliOnly(command: string, args: string[]) {
   if (command === 'enrich' && (args.includes('--help') || args.includes('-h'))) {
     const { runEnrich } = await import('./commands/enrich.ts');
     await runEnrich(null as never, args);
+    return;
+  }
+
+  if (command === 'book-mirror' && (args.includes('--help') || args.includes('-h'))) {
+    const { runBookMirrorCmd } = await import('./commands/book-mirror.ts');
+    await runBookMirrorCmd(null as never, args);
     return;
   }
 

--- a/test/book-mirror.test.ts
+++ b/test/book-mirror.test.ts
@@ -6,16 +6,10 @@
  * the opt-in smoke test (test/e2e/skill-smoke-openclaw.test.ts when
  * EVALS=1 EVALS_TIER=skills is set).
  *
- * Constraint: src/cli.ts dispatches connectEngine() BEFORE any
- * CLI_ONLY command's own arg parsing, including --help. This is a
- * pre-existing architectural choice (every CLI_ONLY command —
- * agent, sync, jobs, book-mirror — behaves the same). So we can't
- * exercise help-text or arg-validation paths from a clean tempdir
- * without DATABASE_URL.
- *
  * What we DO test:
  *   - The book-mirror command is registered (CLI dispatches it
  *     instead of "Unknown command").
+ *   - Detailed help is available without a configured brain.
  *   - Without DB, the command fails fast and never reaches the
  *     queue-submission path.
  *   - The command source file is parseable + exports the runner.
@@ -82,6 +76,17 @@ describe('gbrain book-mirror — CLI registration', () => {
     const { stderr, exit } = await runCli(['--slug', 'noop']);
     expect(exit).not.toBe(0);
     expect(stderr).not.toContain('submitted:');
+  }, 30000);
+
+  it('prints detailed help without a configured brain', async () => {
+    const { stdout, stderr, exit } = await runCli(['--help']);
+    expect(exit).toBe(0);
+    expect(stderr).toBe('');
+    expect(stdout).toContain('personalized chapter-by-chapter book analysis');
+    expect(stdout).toContain('--chapters-dir <path>');
+    expect(stdout).toContain('--context-file <path>');
+    expect(stdout).toContain('--dry-run');
+    expect(stdout).not.toContain('run gbrain --help for the full command list');
   }, 30000);
 });
 


### PR DESCRIPTION
## Summary

- route `book-mirror --help` and `book-mirror -h` to the command's detailed help before opening a brain
- keep normal `book-mirror` execution on the existing engine-backed dispatcher
- add a spawned-CLI regression test using an empty `GBRAIN_HOME`

## Root cause

`book-mirror` was already present in `CLI_ONLY`, so normal execution reached its handler. The per-command help short-circuit ran earlier, however, and emitted the generic one-line fallback because `book-mirror` was missing from `CLI_ONLY_SELF_HELP`. Simply bypassing that fallback would still try to connect a brain before the handler parsed `--help`.

The fix follows the existing `capture`/`sync`/`enrich` pattern: mark the command as self-helping and dispatch help before engine connection.

## Validation

- `bun test test/book-mirror.test.ts` (10 pass)
- `bun run typecheck`
- `bun run verify` (31 checks pass)

`ci:local:diff` is unavailable in this environment because the Docker daemon socket is inaccessible and `gitleaks` is not installed.

Fixes #2774
