### PR TITLE
v0.42.58.0 fix(pages): restore soft-deleted rows on putPage (#2760)

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -1012,6 +1012,7 @@ export class PGLiteEngine implements BrainEngine {
          frontmatter = EXCLUDED.frontmatter,
          content_hash = EXCLUDED.content_hash,
          updated_at = now(),
+         deleted_at = NULL,
          effective_date        = COALESCE(EXCLUDED.effective_date,        pages.effective_date),
          effective_date_source = COALESCE(EXCLUDED.effective_date_source, pages.effective_date_source),
          import_filename       = COALESCE(EXCLUDED.import_filename,       pages.import_filename),

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -998,6 +998,7 @@ export class PostgresEngine implements BrainEngine {
         frontmatter = EXCLUDED.frontmatter,
         content_hash = EXCLUDED.content_hash,
         updated_at = now(),
+        deleted_at = NULL,
         effective_date        = COALESCE(EXCLUDED.effective_date,        pages.effective_date),
         effective_date_source = COALESCE(EXCLUDED.effective_date_source, pages.effective_date_source),
         import_filename       = COALESCE(EXCLUDED.import_filename,       pages.import_filename),

--- a/test/e2e/engine-parity.test.ts
+++ b/test/e2e/engine-parity.test.ts
@@ -311,6 +311,28 @@ describeBoth('Engine parity — Postgres vs PGLite', () => {
     expect(pglitePage!.title).toBe('V2');
   });
 
+  test('putPage restores soft-deleted rows on both engines', async () => {
+    const slug = 'notes/put-page-restore-parity';
+    for (const engine of [pgEngine, pgliteEngine]) {
+      await engine.putPage(slug, {
+        type: 'note',
+        title: 'Before delete',
+        compiled_truth: 'before',
+        timeline: '',
+      });
+      await engine.softDeletePage(slug, { sourceId: 'default' });
+      expect(await engine.getPage(slug, { sourceId: 'default' })).toBeNull();
+
+      await engine.putPage(slug, {
+        type: 'note',
+        title: 'After restore',
+        compiled_truth: 'after',
+        timeline: '',
+      });
+      expect((await engine.getPage(slug, { sourceId: 'default' }))?.title).toBe('After restore');
+    }
+  });
+
   test('v0.41.19.0 deletePages parity: both engines return same confirmed-deleted slugs', async () => {
     const realSlugs = ['wiki/dpp-1', 'wiki/dpp-2', 'wiki/dpp-3'];
     for (const slug of realSlugs) {

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -88,6 +88,30 @@ describe('PGLiteEngine: Pages', () => {
     expect(matches.length).toBe(1);
   });
 
+  test('putPage restores a soft-deleted page', async () => {
+    const slug = 'notes/restore-on-put';
+    await engine.putPage(slug, testPage);
+    await engine.upsertChunks(slug, [{
+      chunk_index: 0,
+      chunk_text: 'restored visibility marker',
+      chunk_source: 'compiled_truth',
+      token_count: 3,
+    }]);
+    await engine.softDeletePage(slug, { sourceId: 'default' });
+    expect(await engine.getPage(slug)).toBeNull();
+    expect((await engine.searchKeyword('restored visibility marker')).map(result => result.slug)).not.toContain(slug);
+
+    const restored = await engine.putPage(slug, {
+      ...testPage,
+      title: 'Restored Title',
+      compiled_truth: 'restored visibility marker',
+    });
+
+    expect(restored.title).toBe('Restored Title');
+    expect((await engine.getPage(slug))?.title).toBe('Restored Title');
+    expect((await engine.searchKeyword('restored visibility marker')).map(result => result.slug)).toContain(slug);
+  });
+
   test('getPage returns null for missing slug', async () => {
     const result = await engine.getPage('nonexistent/slug');
     expect(result).toBeNull();


### PR DESCRIPTION
## Summary

- clear `deleted_at` when `putPage` updates an existing `(source_id, slug)` row
- keep the Postgres and PGLite upsert implementations in lockstep
- cover restored default reads and keyword-search visibility, with an additional cross-engine parity case

## Root cause

Both engines upsert page content on `(source_id, slug)`, but their conflict-update clauses preserved `pages.deleted_at`. A caller could therefore receive an updated page from `putPage` while ordinary reads and search continued filtering that same row out as soft-deleted.

The conflict update now sets `deleted_at = NULL`. The composite conflict key continues to scope restoration to the source being written; explicit soft-delete, restore, and purge behavior is otherwise unchanged.

## Validation

- `bun test test/pglite-engine.test.ts` (101 pass; includes read and search visibility regression)
- `bun run typecheck`
- `bun run verify` (31 checks pass)

The Postgres/PGLite parity regression is included in `test/e2e/engine-parity.test.ts`, but was not executed locally because no `DATABASE_URL` is configured. `ci:local:diff` is also unavailable because the Docker daemon socket is inaccessible and `gitleaks` is not installed.

Fixes #2760
