### PR TITLE
fix(pricing): add Sonnet 5 and Fable 5 to the canonical chat-pricing table

### DIFF
--- a/src/core/model-pricing.ts
+++ b/src/core/model-pricing.ts
@@ -52,11 +52,18 @@ export interface ModelPricing {
  */
 export const CANONICAL_PRICING: Record<string, ModelPricing> = {
   // ── Anthropic ──────────────────────────────────────────────────────────
+  // Fable 5: Anthropic's top tier, above Opus. $10 in / $50 out.
+  'anthropic:claude-fable-5':             { input: 10.00, output: 50.00 },
   // Opus 4.x: $5 in / $25 out. 4.8 (released 2026-05-28) shares 4.7's
   // per-token rate — closes gbrain#1819.
   'anthropic:claude-opus-4-8':            { input:  5.00, output: 25.00 },
   'anthropic:claude-opus-4-7':            { input:  5.00, output: 25.00 },
   'anthropic:claude-opus-4-6':            { input:  5.00, output: 25.00 },
+  // Sonnet 5 (released 2026-06-29): same $3/$15 sticker as 4.6. The launch
+  // intro discount ($2/$10 through 2026-08-31) is deliberately NOT modeled —
+  // the table carries standard rates so estimates stay conservative and
+  // don't need a time-bombed edit when the promo lapses.
+  'anthropic:claude-sonnet-5':            { input:  3.00, output: 15.00 },
   'anthropic:claude-sonnet-4-6':          { input:  3.00, output: 15.00 },
   // Haiku 4.5 — both the dateless canonical id and the dated snapshot.
   'anthropic:claude-haiku-4-5':           { input:  1.00, output:  5.00 },

--- a/src/core/takes-quality-eval/pricing.ts
+++ b/src/core/takes-quality-eval/pricing.ts
@@ -37,6 +37,7 @@ const SUPPORTED_MODELS = [
   'openai:gpt-5.5',
   'anthropic:claude-opus-4-8',
   'anthropic:claude-opus-4-7',
+  'anthropic:claude-sonnet-5',
   'anthropic:claude-sonnet-4-6',
   'anthropic:claude-haiku-4-5',
   'google:gemini-1.5-pro',

--- a/test/model-pricing.test.ts
+++ b/test/model-pricing.test.ts
@@ -43,6 +43,14 @@ describe('CANONICAL_PRICING — table integrity', () => {
     expect(CANONICAL_PRICING['anthropic:claude-opus-4-7']).toEqual({ input: 5.0, output: 25.0 });
   });
 
+  test('Sonnet 5 present at $3/$15 (standard rate, intro discount not modeled)', () => {
+    expect(CANONICAL_PRICING['anthropic:claude-sonnet-5']).toEqual({ input: 3.0, output: 15.0 });
+  });
+
+  test('Fable 5 present at $10/$50', () => {
+    expect(CANONICAL_PRICING['anthropic:claude-fable-5']).toEqual({ input: 10.0, output: 50.0 });
+  });
+
   test('Gemini 2.0 Flash reconciled to $0.10/$0.40; legacy alias agrees', () => {
     expect(CANONICAL_PRICING['google:gemini-2.0-flash']).toEqual({ input: 0.1, output: 0.4 });
     expect(CANONICAL_PRICING['google:gemini-2-flash']).toEqual(


### PR DESCRIPTION
## Why

`claude-sonnet-5` and `claude-fable-5` are GA Anthropic models, but neither is in `CANONICAL_PRICING`. Any brain that routes a tier to them (e.g. `gbrain config set models.tier.reasoning anthropic:claude-sonnet-5`) runs with cost telemetry blind on that tier: `canonicalLookup` misses, the budget meter logs `BUDGET_METER_NO_PRICING` and disables the gate, and cost views under-report actual spend. Hit this on a live brain after moving the reasoning tier to Sonnet 5 — most of the brain's LLM spend became invisible to cost tracking.

## What

- `src/core/model-pricing.ts`: two new canonical rows — `anthropic:claude-sonnet-5` at \$3/\$15 and `anthropic:claude-fable-5` at \$10/\$50, verified against Anthropic's published pricing. Sonnet 5's launch intro discount (\$2/\$10 through 2026-08-31) is deliberately not modeled: the table carries standard rates so estimates stay conservative and the entry needs no time-bombed edit when the promo lapses.
- `src/core/takes-quality-eval/pricing.ts`: `anthropic:claude-sonnet-5` added to the curated `SUPPORTED_MODELS` allowlist — a likely judge override now that Sonnet 5 is the current sonnet-class model. Fable 5 stays out of the allowlist: priced for the warn-only/null consumers, but at \$10/\$50 it is not a plausible budgeted-eval panel model.
- `test/model-pricing.test.ts`: pin tests for both new rows, matching the existing Opus 4.8/4.7 pattern. The drift guards iterate the table, so they need no changes.

Everything downstream derives automatically: the bare-keyed `ANTHROPIC_PRICING` view picks both rows up, so budget-tracker, batch-projection, and budget-meter now price these models too. No behavior change for any model already in the table.

## Receipts

- `bun test` over the 7 pricing/budget test files (`model-pricing`, `anthropic-pricing`, `eval-takes-quality-pricing`, `budget-meter`, `batch-projection`, `budget-tracker`, `cost-tracker-slash`): 93 pass / 0 fail
- `bun run typecheck`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)