### PR TITLE
test(doctor): pin embedding dims in hidden-by-search-policy — kill the shard-order 1280/1536 flake

### DIFF
--- a/test/doctor-hidden-by-search-policy.test.ts
+++ b/test/doctor-hidden-by-search-policy.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { configureGateway, resetGateway } from '../src/core/ai/gateway.ts';
 import { resetPgliteState } from './helpers/reset-pglite.ts';
 import { withEnv } from './helpers/with-env.ts';
 import { checkHiddenBySearchPolicy } from '../src/commands/doctor.ts';
@@ -58,6 +59,23 @@ async function seed(
 }
 
 beforeAll(async () => {
+  // Pin the embedding dim to 1536 BEFORE initSchema. basisEmbedding()
+  // hardcodes Float32Array(1536) vectors, but initSchema sizes vector
+  // columns from process-global gateway state (getEmbeddingDimensions(),
+  // default 1280 = zeroentropyai). Whether this file passes therefore
+  // depended on which test files happened to run before it in the shard: a
+  // predecessor that leaves the gateway configured without dims (or a bare
+  // CI env) yields vector(1280) and every upsertChunks here dies with
+  // "expected 1280 dimensions, not 1536". Adding test files to the repo
+  // reshuffles the weight-packed shards, so unrelated PRs trip it (seen on
+  // #2800 CI, test (1)). Same fix + rationale as
+  // engine-find-trajectory.test.ts and cosine-rescore-column.test.ts, which
+  // document this exact class.
+  configureGateway({
+    embedding_model: 'openai:text-embedding-3-large',
+    embedding_dimensions: 1536,
+    env: { OPENAI_API_KEY: 'sk-test-hidden-by-search-policy' },
+  });
   engine = new PGLiteEngine();
   await engine.connect({});
   await engine.initSchema();
@@ -65,6 +83,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await engine.disconnect();
+  resetGateway();
 });
 
 beforeEach(async () => {


### PR DESCRIPTION
## Why

`doctor-hidden-by-search-policy.test.ts` is the latest victim of the documented shard-order flake class: it hardcodes `Float32Array(1536)` vectors (`basisEmbedding`) but lets `initSchema` size its vector columns from process-global gateway state (`getEmbeddingDimensions()`, default 1280). Whether the file passes depends on which test files happen to run before it in the shard — and adding test files to the repo reshuffles the weight-packed shards, so unrelated PRs trip it. Latest sighting: #2800's `test (1)`, where every `upsertChunks` died with `expected 1280 dimensions, not 1536` (triage comment there).

## What

The same one-shot remedy already applied to `engine-find-trajectory.test.ts` and `cosine-rescore-column.test.ts`, which document this exact class: `configureGateway(...)` pinning `embedding_dimensions: 1536` in `beforeAll` **before** `initSchema`, `resetGateway()` in `afterAll`. The suite becomes self-sufficient regardless of predecessor state. One file, +19 lines, no product code.

Honest caveat: the failure isn't reproducible outside CI's exact shard packing (locally something always lands on 1536), so verification is: the suite passes standalone and paired with a 1280-configuring predecessor post-fix, and the pin removes the order-dependence by construction — the same argument that held for the two prior pins.

Unblocks #2800's checks on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)