### PR TITLE
fix(think): give thinking-default Claude 5 models output-token headroom

### DIFF
--- a/src/core/think/index.ts
+++ b/src/core/think/index.ts
@@ -151,6 +151,21 @@ export interface ThinkResult {
 }
 
 const DEFAULT_MAX_OUTPUT_TOKENS = 4000;
+// Claude 5 family models (claude-sonnet-5, claude-fable-5, ...) run adaptive thinking
+// by default when the request omits a thinking config, and max_tokens caps thinking +
+// answer text COMBINED. On hard questions 4000 is routinely consumed entirely by
+// thinking, so the text block comes back empty and think degrades to an empty answer
+// with synthesisOk: false even though retrieval succeeded. Give those models headroom
+// (their output ceilings are >= 64K); keep the conservative cap for everything else,
+// since some providers hard-reject max_tokens above the model output ceiling.
+const THINKING_DEFAULT_MAX_OUTPUT_TOKENS = 16000;
+const THINKING_BY_DEFAULT_MODEL_RE = /^anthropic[:\/]claude-[a-z0-9]+-5(?:[.-]|$)/;
+
+function maxOutputTokensFor(modelStr: string): number {
+  return THINKING_BY_DEFAULT_MODEL_RE.test(modelStr)
+    ? THINKING_DEFAULT_MAX_OUTPUT_TOKENS
+    : DEFAULT_MAX_OUTPUT_TOKENS;
+}
 
 function inferIntent(question: string, anchor?: string): string {
   if (anchor) return 'entity';
@@ -465,7 +480,7 @@ export async function runThink(
     }
     const result = await client.create({
       model: modelUsed,
-      max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+      max_tokens: maxOutputTokensFor(modelUsed),
       system: systemPrompt,
       messages: [{ role: 'user', content: userMessage }],
     });


### PR DESCRIPTION
## Problem

`gbrain think` returns an empty answer with `synthesisOk: false` (warning `LLM_OUTPUT_NOT_JSON`) on harder questions when `models.think` is set to a Claude 5 family model such as `anthropic:claude-sonnet-5`, even though retrieval succeeds (pages gathered fine). The nightly auto-think path hits the same failure (`status: partial`).

## Root cause

On Claude Sonnet 5 (and the rest of the Claude 5 family), adaptive thinking runs **by default** when the `thinking` parameter is omitted, and `max_tokens` is a hard cap on **thinking + response text combined**. `runThink` calls the LLM with `max_tokens: 4000` (`DEFAULT_MAX_OUTPUT_TOKENS`) and no thinking config, so on hard questions the model spends the entire 4000-token budget on thinking and returns zero text blocks. `chat()` extracts only text parts, `tryParseJSON("")` fails, and think degrades to an empty answer.

## Repro / verification

- `models.think = anthropic:claude-sonnet-5`, two multi-page synthesis questions → ~50s of generation, then `answer: ""`, `warnings: [LLM_OUTPUT_NOT_JSON, CITATIONS_REGEX_FALLBACK]`, `synthesisOk: false` (pagesGathered 20/24, so retrieval was healthy).
- With the headroom, the exact same questions return full cited answers. Simple questions were unaffected before and after (little thinking needed).

## Change

Resolve the max_tokens default per model in `runThink`:

- **16000** for thinking-by-default Claude 5 family models (`/^anthropic[:\/]claude-[a-z0-9]+-5(?:[.-]|$)/`) — their output ceilings are ≥ 64K, so the higher request is always valid.
- **4000 (unchanged)** for everything else, so models and providers with lower output ceilings (local Ollama models, older small models) are not regressed by an unconditionally higher request.

Gate behavior verified: `anthropic:claude-sonnet-5` / `claude-fable-5` → 16000; `claude-opus-4-8`, `claude-haiku-4-5`, `claude-sonnet-4-6`, `ollama:*`, `claude-3-haiku` → 4000. Note the request stays within the 300s `AI_CHAT_TIMEOUT_MS` for realistic generation speeds.

A nicer follow-up could source per-model output ceilings from the provider recipes and/or make this configurable (e.g. `models.think_max_tokens`), but this restores correctness for thinking-default models without touching other paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141fb9RA4uRGNqPGBJaQTXV