### PR TITLE
orphan_ratio: config-driven orphan_deny_prefixes to exclude record-type pages

### DIFF
--- a/src/commands/orphans.ts
+++ b/src/commands/orphans.ts
@@ -15,6 +15,7 @@
 import type { BrainEngine } from '../core/engine.ts';
 import { createProgress, startHeartbeat } from '../core/progress.ts';
 import { getCliOptions, cliOptsToProgressOptions } from '../core/cli-options.ts';
+import { loadConfigFileOnly } from '../core/config.ts';
 
 // --- Types ---
 
@@ -58,10 +59,29 @@ const FIRST_SEGMENT_EXCLUSIONS = new Set(['scratch', 'thoughts', 'catalog', 'ent
 // --- Filter logic ---
 
 /**
+ * Brain-local extra deny-prefixes for the orphan denominator, read from
+ * `~/.gbrain/config.json` `orphan_deny_prefixes`. Keeps brain-specific
+ * auto-generated/record taxonomy (shopping orders, imported issue archives,
+ * email history) OUT of the shared tool defaults. Mirrors the audit skill's
+ * GBRAIN_AUDIT_ARCHIVE_ROOTS override. Best-effort: a missing/invalid config
+ * yields no extra prefixes and never breaks an orphan scan.
+ */
+function configDenyPrefixes(): readonly string[] {
+  try {
+    const cfg = loadConfigFileOnly();
+    const p = cfg?.orphan_deny_prefixes;
+    return Array.isArray(p) ? p.filter(x => typeof x === 'string' && x.length > 0) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Returns true if a slug should be excluded from orphan reporting by default.
  * These are pages where having no inbound links is expected / not a content problem.
+ * `extraDenyPrefixes` (from brain config) is applied on top of the built-in lists.
  */
-export function shouldExclude(slug: string): boolean {
+export function shouldExclude(slug: string, extraDenyPrefixes: readonly string[] = []): boolean {
   // Pseudo-pages (exact match)
   if (PSEUDO_SLUGS.has(slug)) return true;
 
@@ -73,9 +93,12 @@ export function shouldExclude(slug: string): boolean {
   // Raw source slugs
   if (slug.includes(RAW_SEGMENT)) return true;
 
-  // Deny-prefix slugs
+  // Deny-prefix slugs (built-in + brain-config `orphan_deny_prefixes`)
   for (const prefix of DENY_PREFIXES) {
     if (slug.startsWith(prefix)) return true;
+  }
+  for (const prefix of extraDenyPrefixes) {
+    if (prefix && slug.startsWith(prefix)) return true;
   }
 
   // First-segment exclusions
@@ -127,9 +150,12 @@ export async function queryOrphanPages(
  */
 export async function findOrphans(
   engine: BrainEngine,
-  opts: { includePseudo?: boolean; sourceId?: string; sourceIds?: string[] } = {},
+  opts: { includePseudo?: boolean; sourceId?: string; sourceIds?: string[]; denyPrefixes?: readonly string[] } = {},
 ): Promise<OrphanResult> {
   const includePseudo = !!opts.includePseudo;
+  // Extra deny-prefixes: explicit opt (tests) wins; else brain config. Applied
+  // to both the numerator (orphan filter) and denominator (excludedAll count).
+  const extraDeny = opts.denyPrefixes ?? configDenyPrefixes();
   // v0.41.29.0: `sourceId` (scalar, from `--source` + single-source MCP
   // clients) or `sourceIds` (federated, from `allowedSources` MCP clients)
   // scopes the candidate set. `sourceIds` wins when both set (mirrors
@@ -176,7 +202,7 @@ export async function findOrphans(
     total = liveRows.length;
     excludedAll = includePseudo
       ? 0
-      : liveRows.reduce((n, r) => n + (shouldExclude(r.slug) ? 1 : 0), 0);
+      : liveRows.reduce((n, r) => n + (shouldExclude(r.slug, extraDeny) ? 1 : 0), 0);
   } finally {
     stopHb();
     progress.finish();
@@ -184,7 +210,7 @@ export async function findOrphans(
 
   const filtered = includePseudo
     ? allOrphans
-    : allOrphans.filter(row => !shouldExclude(row.slug));
+    : allOrphans.filter(row => !shouldExclude(row.slug, extraDeny));
 
   const orphans: OrphanPage[] = filtered.map(row => ({
     slug: row.slug,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -75,6 +75,16 @@ export interface GBrainConfig {
    */
   storage?: unknown;
   /**
+   * v0.42.x — extra slug prefixes excluded from the orphan_ratio "linkable"
+   * denominator, on top of the built-in DENY_PREFIXES in `commands/orphans.ts`.
+   * For brains whose taxonomy includes auto-generated record areas (shopping
+   * orders, imported issue archives, email history) that structurally never
+   * receive inbound links. Brain-local so this taxonomy stays out of the shared
+   * tool defaults. Read via file-plane `loadConfigFileOnly()`. Prefix match
+   * (slug.startsWith). Example: ["personal/shopping/", "wwpf/gitlab/"].
+   */
+  orphan_deny_prefixes?: string[];
+  /**
    * v0.25.0 — session capture settings. Read via file-plane `loadConfig()`
    * at process boot (NOT `gbrain config set` which writes the DB plane —
    * those are different stores). Edit `~/.gbrain/config.json` directly.


### PR DESCRIPTION
## Problem

On a record-heavy brain, `orphan_ratio` structurally FAILs and can't be fixed by linking. The "linkable" denominator counts every live page — including large auto-generated *record* areas (shopping orders, imported issue archives, email history, per-day dashboards) that never receive inbound links by design. On one brain that was ~1,500 of ~1,900 pages, pinning `orphan_ratio` near 90% (FAIL) no matter how well the curated graph was linked.

The built-in `DENY_PREFIXES` (`output/`, `dashboards/`, `scripts/`, `templates/`, `openclaw/config/`) covers common cases, but it can't know a given brain's record taxonomy — and hardcoding brain-specific prefixes into the shared tool isn't right.

## Change

Adds an optional `orphan_deny_prefixes: string[]` to `GBrainConfig`, read from the file plane in `findOrphans`/`shouldExclude` and applied on top of the built-in `DENY_PREFIXES`. Brains declare their own record areas without polluting the shared defaults:

```json
{ "orphan_deny_prefixes": ["personal/shopping/", "archive/issues/"] }
```

- **Backward-compatible**: optional param, empty = prior behavior. Existing `shouldExclude(slug)` calls are unchanged.
- Applied to **both** the numerator (orphan filter) and the denominator (`total_linkable`) so the ratio stays consistent.
- Mirrors the existing `GBRAIN_AUDIT_ARCHIVE_ROOTS` override pattern.
- Best-effort config read: missing/invalid config → no extra prefixes, never breaks a scan.

## Tests

`bun test test/orphans-pure-fn.test.ts test/orphans.test.ts` → **50 pass / 0 fail**.

## Possible follow-up

A cleaner long-term shape might be **page-type-driven** exclusion (let the schema pack mark record types like `shopping-order` / `email-history` as no-inbound-expected) rather than slug prefixes. Submitting the prefix version first since it's minimal and matches the existing prefix-based `DENY_PREFIXES` / `GBRAIN_AUDIT_ARCHIVE_ROOTS` design — happy to rework it type-driven if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
