### PR TITLE
fix: categorize timeline_coverage and register auto_chronicle

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -926,6 +926,11 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'embed.backfill_cooldown_min',
   'embed.backfill_max_usd_per_source_24h',
   'embed.backfill_max_usd',
+  // Life Chronicle (v0.42.56, #2390). Auto-emission of timeline events is OFF
+  // by default; the changelog's "To take advantage" step is `gbrain config set
+  // auto_chronicle true`, so the key must be settable without --force. The
+  // when→date projection timezone rides the `chronicle.` prefix below.
+  'auto_chronicle',
 ];
 
 /**
@@ -944,6 +949,7 @@ export const KNOWN_CONFIG_KEY_PREFIXES: readonly string[] = [
   'mcp.',               // mcp.publish_skills, mcp.skills_dir (PR1 skill catalog)
   'autopilot.',         // autopilot.nightly_quality_probe.*, autopilot.auto_drain.* (#1685)
   'self_upgrade.',      // v0.42 self-upgrade (mode, quiet_hours, state)
+  'chronicle.',         // v0.42.56 Life Chronicle (chronicle.tz projection tz)
 ];
 
 export function saveConfig(config: GBrainConfig): void {

--- a/src/core/doctor-categories.ts
+++ b/src/core/doctor-categories.ts
@@ -103,6 +103,7 @@ export const BRAIN_CHECK_NAMES: ReadonlySet<string> = new Set([
   'sync_failures',
   'sync_freshness',
   'takes_weight_grid',
+  'timeline_coverage',
   'unified_multimodal_coverage',
   'voice_gate_health',
 ]);


### PR DESCRIPTION
Summary:
- categorize `timeline_coverage` as a first-class brain/data completeness check instead of falling back to `meta`
- register `auto_chronicle` in `KNOWN_CONFIG_KEYS`
- add the `chronicle.` prefix so `chronicle.tz` is recognized without `--force`

Why:
- fixes the nightly `[doctor-categories] unknown check name 'timeline_coverage' — defaulting to 'meta'` warning
- makes the documented `gbrain config set auto_chronicle true` flow actually work

Verification:
- `bun test test/doctor-categories.test.ts`
- `bun run src/cli.ts config set auto_chronicle true`

Fragno tracking: FRA-1319