### PR TITLE
perf: batch loadConfigWithEngine DB reads, fix sources-list N+1

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -603,12 +603,17 @@ export function loadConfig(): GBrainConfig | null {
  * Precedence: env > file > DB > defaults. Env stays the operator escape hatch;
  * file is the durable per-machine config; DB is the user-mutable runtime knob.
  *
- * Today only the v0.27.1 multimodal flags participate in DB-merge. Existing
- * fields (embedding_model, etc.) keep their file/env-only loading because they
- * size the schema and must be stable across engine connect.
+ * DB-merge covers embedding/multimodal flags, embedding_columns +
+ * search_embedding_column, content_sanity.*, and dream.synthesize/patterns
+ * keys (see ALL_DB_KEYS below). Existing fields (embedding_model, etc.) keep
+ * their file/env-only loading because they size the schema and must be
+ * stable across engine connect.
  */
 export async function loadConfigWithEngine(
-  engine: { getConfig(key: string): Promise<string | null | undefined> },
+  engine: {
+    getConfig(key: string): Promise<string | null | undefined>;
+    getConfigBatch?(keys: string[]): Promise<Record<string, string>>;
+  },
   base?: GBrainConfig | null,
 ): Promise<GBrainConfig | null> {
   // Codex /ship finding #3: when there's no file config AND no env DB URL,
@@ -624,38 +629,75 @@ export async function loadConfigWithEngine(
     (base !== undefined ? base : loadConfig()) ??
     ({ engine: 'postgres' } as GBrainConfig);
 
-  // DB-plane reads. Quiet failures — if the config table doesn't exist yet
-  // (pre-v36 brain mid-migration), treat as null and let file/env defaults
-  // win. The migration runner reads file/env directly anyway.
-  async function dbBool(key: string): Promise<boolean | undefined> {
-    try {
-      const v = await engine.getConfig(key);
-      if (v === undefined || v === null || v === '') return undefined;
-      return v === 'true';
-    } catch {
-      return undefined;
+  // DB-plane reads. This function reads 20 config keys across three
+  // unrelated feature groups (embeddings, content_sanity, dream). Reading
+  // them one getConfig() call at a time paid one network round trip per key
+  // — 20 serial round trips to a remote pooler on every cold connectEngine()
+  // call, regardless of which CLI command ran (measured ~150-1200ms/call on
+  // a first-connection pool, several seconds total). Prefetch all keys in a
+  // single batched round trip instead; dbBool/dbStr below just read the
+  // resulting map (no further I/O). Falls back to a parallel per-key fetch
+  // for engines that don't implement getConfigBatch (e.g. PGLite, where the
+  // round-trip cost doesn't exist anyway).
+  const ALL_DB_KEYS = [
+    'embedding_multimodal', 'embedding_multimodal_model',
+    'embedding_image_ocr', 'embedding_image_ocr_model',
+    'embedding_columns', 'search_embedding_column',
+    'content_sanity.bytes_warn', 'content_sanity.bytes_block',
+    'content_sanity.junk_patterns_enabled', 'content_sanity.disabled',
+    'content_sanity.junk_disposition', 'content_sanity.max_markup_ratio',
+    'content_sanity.prose_check_enabled',
+    'dream.synthesize.session_corpus_dir', 'dream.synthesize.meeting_transcripts_dir',
+    'dream.synthesize.verdict_model', 'dream.synthesize.max_prompt_tokens',
+    'dream.synthesize.max_chunks_per_transcript',
+    'dream.patterns.lookback_days', 'dream.patterns.min_evidence',
+  ];
+
+  let dbCache: Record<string, string> = {};
+  try {
+    if (typeof engine.getConfigBatch === 'function') {
+      dbCache = await engine.getConfigBatch(ALL_DB_KEYS);
+    } else {
+      const pairs = await Promise.all(ALL_DB_KEYS.map(async (key) => {
+        try {
+          const v = await engine.getConfig(key);
+          return [key, v] as const;
+        } catch {
+          return [key, undefined] as const;
+        }
+      }));
+      for (const [key, v] of pairs) {
+        if (v !== null && v !== undefined) dbCache[key] = v;
+      }
     }
-  }
-  async function dbStr(key: string): Promise<string | undefined> {
-    try {
-      const v = await engine.getConfig(key);
-      if (v === undefined || v === null || v === '') return undefined;
-      return v;
-    } catch {
-      return undefined;
-    }
+  } catch {
+    // Quiet failure — if the config table doesn't exist yet (pre-v36 brain
+    // mid-migration), treat as empty and let file/env defaults win. The
+    // migration runner reads file/env directly anyway.
+    dbCache = {};
   }
 
-  const dbMultimodal = await dbBool('embedding_multimodal');
-  const dbMultimodalModel = await dbStr('embedding_multimodal_model');
-  const dbOcr = await dbBool('embedding_image_ocr');
-  const dbOcrModel = await dbStr('embedding_image_ocr_model');
+  function dbBool(key: string): boolean | undefined {
+    const v = dbCache[key];
+    if (v === undefined || v === '') return undefined;
+    return v === 'true';
+  }
+  function dbStr(key: string): string | undefined {
+    const v = dbCache[key];
+    if (v === undefined || v === '') return undefined;
+    return v;
+  }
+
+  const dbMultimodal = dbBool('embedding_multimodal');
+  const dbMultimodalModel = dbStr('embedding_multimodal_model');
+  const dbOcr = dbBool('embedding_image_ocr');
+  const dbOcrModel = dbStr('embedding_image_ocr_model');
   // v0.36 (D7) — embedding-column registry merge. Stored as JSON string in
   // the config table. Parse + shape-check here; full registry validation
   // (regex on keys, type/dim/provider field shapes) runs in the resolver at
   // first use so a malformed DB row doesn't kill engine connect.
-  const dbEmbeddingColumns = await dbStr('embedding_columns');
-  const dbSearchEmbeddingColumn = await dbStr('search_embedding_column');
+  const dbEmbeddingColumns = dbStr('embedding_columns');
+  const dbSearchEmbeddingColumn = dbStr('search_embedding_column');
 
   // DB applies only when env did NOT win. Env presence is detected by the
   // sync loadConfig() already setting the field. For each flag, prefer the
@@ -694,19 +736,19 @@ export async function loadConfigWithEngine(
   // key; DB fills the gaps. The container object is constructed only if
   // at least one source provides a value, mirroring the env-merge logic
   // in loadConfig().
-  async function dbInt(key: string): Promise<number | undefined> {
-    const v = await dbStr(key);
+  function dbInt(key: string): number | undefined {
+    const v = dbStr(key);
     if (v === undefined) return undefined;
     const n = parseInt(v, 10);
     return Number.isFinite(n) && n > 0 ? n : undefined;
   }
-  const dbWarnBytes = await dbInt('content_sanity.bytes_warn');
-  const dbBlockBytes = await dbInt('content_sanity.bytes_block');
-  const dbJunkEnabled = await dbBool('content_sanity.junk_patterns_enabled');
-  const dbSanityDisabled = await dbBool('content_sanity.disabled');
-  const dbJunkDisposition = await dbStr('content_sanity.junk_disposition');
-  const dbMaxMarkupRatioStr = await dbStr('content_sanity.max_markup_ratio');
-  const dbProseCheckEnabled = await dbBool('content_sanity.prose_check_enabled');
+  const dbWarnBytes = dbInt('content_sanity.bytes_warn');
+  const dbBlockBytes = dbInt('content_sanity.bytes_block');
+  const dbJunkEnabled = dbBool('content_sanity.junk_patterns_enabled');
+  const dbSanityDisabled = dbBool('content_sanity.disabled');
+  const dbJunkDisposition = dbStr('content_sanity.junk_disposition');
+  const dbMaxMarkupRatioStr = dbStr('content_sanity.max_markup_ratio');
+  const dbProseCheckEnabled = dbBool('content_sanity.prose_check_enabled');
 
   const existingCS = merged.content_sanity ?? {};
   const mergedCS: NonNullable<GBrainConfig['content_sanity']> = { ...existingCS };
@@ -744,13 +786,13 @@ export async function loadConfigWithEngine(
   // `extract-atoms.ts` and any other consumer that reads the merged config
   // (vs calling `engine.getConfig()` directly) silently misses dream.*
   // config set via `gbrain config set`.
-  const dbSessionCorpusDir = await dbStr('dream.synthesize.session_corpus_dir');
-  const dbMeetingTranscriptsDir = await dbStr('dream.synthesize.meeting_transcripts_dir');
-  const dbVerdictModel = await dbStr('dream.synthesize.verdict_model');
-  const dbMaxPromptTokens = await dbInt('dream.synthesize.max_prompt_tokens');
-  const dbMaxChunksPerTranscript = await dbInt('dream.synthesize.max_chunks_per_transcript');
-  const dbLookbackDays = await dbInt('dream.patterns.lookback_days');
-  const dbMinEvidence = await dbInt('dream.patterns.min_evidence');
+  const dbSessionCorpusDir = dbStr('dream.synthesize.session_corpus_dir');
+  const dbMeetingTranscriptsDir = dbStr('dream.synthesize.meeting_transcripts_dir');
+  const dbVerdictModel = dbStr('dream.synthesize.verdict_model');
+  const dbMaxPromptTokens = dbInt('dream.synthesize.max_prompt_tokens');
+  const dbMaxChunksPerTranscript = dbInt('dream.synthesize.max_chunks_per_transcript');
+  const dbLookbackDays = dbInt('dream.patterns.lookback_days');
+  const dbMinEvidence = dbInt('dream.patterns.min_evidence');
 
   const existingDream = merged.dream ?? {};
   const existingSynth = existingDream.synthesize ?? {};

--- a/src/core/engine.ts
+++ b/src/core/engine.ts
@@ -2003,6 +2003,13 @@ export interface BrainEngine {
 
   // Config
   getConfig(key: string): Promise<string | null>;
+  /**
+   * Batched form of getConfig — one round trip for many keys instead of one
+   * round trip per key. Optional: engines that don't implement it fall back
+   * to parallel getConfig() calls at the call site (still one RTT wall-time
+   * on a healthy pool, just N connections instead of 1 query).
+   */
+  getConfigBatch?(keys: string[]): Promise<Record<string, string>>;
   setConfig(key: string, value: string): Promise<void>;
   /**
    * v0.32.3 — delete a config row. Returns the number of rows deleted (0 or 1).

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5238,6 +5238,34 @@ export class PostgresEngine implements BrainEngine {
     );
   }
 
+  /**
+   * Batched form of getConfig — one round trip for many keys instead of one
+   * round trip per key. Used by loadConfigWithEngine() to prefetch its ~20
+   * DB-plane keys in a single query instead of 20 serial round trips.
+   */
+  async getConfigBatch(keys: string[]): Promise<Record<string, string>> {
+    if (keys.length === 0) return {};
+    const opts = this.getBulkRetryOpts();
+    const rows = await withRetry(
+      async () => {
+        const sql = this.sql;
+        return sql<{ key: string; value: string }[]>`
+          SELECT key, value FROM config WHERE key = ANY(${keys}::text[])
+        `;
+      },
+      {
+        maxRetries: opts.maxRetries,
+        delayMs: opts.delayMs,
+        delayMaxMs: opts.delayMaxMs,
+        jitter: BULK_RETRY_OPTS.jitter,
+        reconnect: (ctx) => this.reconnect(ctx),
+      },
+    );
+    const out: Record<string, string> = {};
+    for (const r of rows) out[r.key] = r.value;
+    return out;
+  }
+
   async setConfig(key: string, value: string): Promise<void> {
     const sql = this.sql;
     await sql`

--- a/src/core/sources-ops.ts
+++ b/src/core/sources-ops.ts
@@ -220,6 +220,16 @@ async function countPages(engine: BrainEngine, id: string): Promise<number> {
   return rows[0]?.n ?? 0;
 }
 
+/** Batched page counts for all sources, one query instead of N. */
+async function countPagesBatch(engine: BrainEngine): Promise<Record<string, number>> {
+  const rows = await engine.executeRaw<{ source_id: string; n: number }>(
+    `SELECT source_id, COUNT(*)::int AS n FROM pages GROUP BY source_id`,
+  );
+  const out: Record<string, number> = {};
+  for (const r of rows) out[r.source_id] = r.n;
+  return out;
+}
+
 /** Default clone dir for a remote-URL source: $GBRAIN_HOME/clones/<id>/ */
 export function defaultCloneDir(id: string): string {
   return gbrainPath('clones', id);
@@ -566,6 +576,7 @@ export async function listSources(
     `SELECT id, name, local_path, last_sync_at, config
        FROM sources ${archivedFilter} ORDER BY (id = 'default') DESC, id`,
   );
+  const pageCounts = await countPagesBatch(engine);
   const out: SourceListEntry[] = [];
   for (const r of rows) {
     const cfg = parseConfig(r.config);
@@ -575,7 +586,7 @@ export async function listSources(
       local_path: r.local_path,
       remote_url: typeof cfg.remote_url === 'string' ? cfg.remote_url : null,
       federated: cfg.federated === true,
-      page_count: await countPages(engine, r.id),
+      page_count: pageCounts[r.id] ?? 0,
       last_sync_at: r.last_sync_at ? new Date(r.last_sync_at).toISOString() : null,
     });
   }

--- a/test/loadConfig-merge.test.ts
+++ b/test/loadConfig-merge.test.ts
@@ -298,4 +298,60 @@ describe('loadConfigWithEngine (Phase 4 / F3)', () => {
       expect(merged?.engine).toBe('pglite');
     });
   });
+
+  // Perf fix: 20 serial getConfig() round trips per connectEngine() replaced
+  // by one getConfigBatch() call when the engine implements it. Pins that
+  // loadConfigWithEngine() actually prefers the batch path (and still merges
+  // correctly through it) instead of silently falling back to per-key fetch.
+  describe('getConfigBatch() usage', () => {
+    test('uses the batch path when engine implements getConfigBatch, not per-key getConfig', async () => {
+      let batchCalls = 0;
+      let getConfigCalls = 0;
+      const base: GBrainConfig = { engine: 'postgres' };
+      const engine = {
+        async getConfig(_key: string) {
+          getConfigCalls++;
+          throw new Error('per-key getConfig should not be called when batch is available');
+        },
+        async getConfigBatch(keys: string[]) {
+          batchCalls++;
+          return {
+            embedding_multimodal: 'true',
+            search_embedding_column: 'embedding_voyage',
+          };
+        },
+      };
+      const merged = await loadConfigWithEngine(engine, base);
+      expect(batchCalls).toBe(1);
+      expect(getConfigCalls).toBe(0);
+      expect(merged?.embedding_multimodal).toBe(true);
+      expect(merged?.search_embedding_column).toBe('embedding_voyage');
+    });
+
+    test('falls back to per-key getConfig when engine has no getConfigBatch', async () => {
+      const base: GBrainConfig = { engine: 'pglite' };
+      const engine = makeEngine({
+        embedding_multimodal: 'true',
+      });
+      const merged = await loadConfigWithEngine(engine, base);
+      expect(merged?.embedding_multimodal).toBe(true);
+    });
+
+    test('getConfigBatch throwing is non-fatal — file/env config still returned', async () => {
+      const base: GBrainConfig = {
+        engine: 'postgres',
+        embedding_multimodal: true,
+      };
+      const engine = {
+        async getConfig(_key: string): Promise<string | null | undefined> {
+          return undefined;
+        },
+        async getConfigBatch(_keys: string[]): Promise<Record<string, string>> {
+          throw new Error('config table missing');
+        },
+      };
+      const merged = await loadConfigWithEngine(engine, base);
+      expect(merged?.embedding_multimodal).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- `loadConfigWithEngine()` read 20 config keys via 20 serial `getConfig()` round trips on every cold `connectEngine()` call (measured ~150-1200ms/call on a first-connection pool, several seconds total). Adds optional `getConfigBatch()` to the `BrainEngine` interface, implements it on `PostgresEngine` (single `key = ANY($1::text[])` query, reusing the existing retry/reconnect wrapper), and has `loadConfigWithEngine()` prefer it — falling back to a parallel per-key fetch for engines that don't implement it (e.g. PGLite).
- Second N+1: `listSources()` in `sources-ops.ts` ran one `SELECT COUNT(*) FROM pages WHERE source_id = $1` per source instead of a single `GROUP BY`. Replaced with `countPagesBatch()`.
- Updated the stale `loadConfigWithEngine` doc comment — it said only the v0.27.1 multimodal flags participate in DB-merge; actually 20 keys across three feature groups (embeddings, content_sanity.*, dream.*) merge today.
- Added tests pinning `getConfigBatch()` usage: batch path preferred over per-key `getConfig`, fallback when absent, non-fatal on throw.

## Test plan
- [x] `bun test test/loadConfig-merge.test.ts` — 24/24 pass
- [x] `bun test test/sources-ops.test.ts test/sources-mcp.test.ts` — 59/59 pass
- [x] `bun tsc --noEmit -p .` — clean