### PR TITLE
fix(SQN-3841): hide archival export snapshots

### DIFF
--- a/src/core/operations.ts
+++ b/src/core/operations.ts
@@ -23,6 +23,7 @@ import { stripFactsFence } from './facts-fence.ts';
 import { getContentFlag } from './quarantine.ts';
 import { bumpLastRetrievedAt } from './last-retrieved.ts';
 import { isSearchMode } from './search/mode.ts';
+import { isArchivalExportSlug } from './search/source-boost.ts';
 import { stampEvidence } from './search/evidence.ts';
 import type { SearchResult } from './types.ts';
 import { CJK_SLUG_CHARS } from './cjk.ts';
@@ -643,6 +644,9 @@ const get_page: Operation = {
   },
   handler: async (ctx, p) => {
     const slug = p.slug as string;
+    if (isArchivalExportSlug(slug)) {
+      throw new OperationError('page_not_found', `Page not found: ${slug}`);
+    }
     const fuzzy = (p.fuzzy as boolean) || false;
     const includeDeleted = (p.include_deleted as boolean) === true;
     // #1393: route BOTH the exact-match read and the fuzzy resolveSlugs through
@@ -1415,7 +1419,7 @@ const list_pages: Operation = {
       sort,
       ...scope,
     });
-    return pages.map(pg => ({
+    return pages.filter(pg => !isArchivalExportSlug(pg.slug)).map(pg => ({
       slug: pg.slug,
       type: pg.type,
       title: pg.title,

--- a/src/core/search/source-boost.ts
+++ b/src/core/search/source-boost.ts
@@ -66,7 +66,16 @@ export const DEFAULT_HARD_EXCLUDES: string[] = [
   'test/',
   'attachments/',
   '.raw/',
+  'export/',
+  '_uninstalled/export-',
+  'export/_uninstalled/export-',
 ];
+
+export function isArchivalExportSlug(slug: string): boolean {
+  return slug.startsWith('export/')
+    || slug.startsWith('_uninstalled/export-')
+    || slug.startsWith('export/_uninstalled/export-');
+}
 
 /**
  * Parse GBRAIN_SOURCE_BOOST env var.

--- a/src/core/search/sql-ranking.ts
+++ b/src/core/search/sql-ranking.ts
@@ -18,6 +18,7 @@
  */
 
 import { quarantineFilterFragment } from '../quarantine.ts';
+import { isArchivalExportSlug } from './source-boost.ts';
 
 /**
  * Escape `%`, `_`, and `\` so a string can be used as a LIKE prefix literal.
@@ -109,6 +110,8 @@ export function buildHardExcludeClause(slugColumn: string, prefixes: string[]): 
   if (!likes) return '';
   return `AND NOT (${likes})`;
 }
+
+export { isArchivalExportSlug };
 
 /**
  * v0.26.5 — Build the soft-delete + archived-source visibility filter.

--- a/test/archival-export-ops.test.ts
+++ b/test/archival-export-ops.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test';
+import { operations, OperationError, type OperationContext } from '../src/core/operations.ts';
+import type { BrainEngine } from '../src/core/engine.ts';
+import type { GBrainConfig } from '../src/core/config.ts';
+import type { Page } from '../src/core/types.ts';
+
+const getPageOp = operations.find(o => o.name === 'get_page');
+const listPagesOp = operations.find(o => o.name === 'list_pages');
+if (!getPageOp || !listPagesOp) throw new Error('page operations missing');
+
+function page(slug: string): Page {
+  return {
+    id: Math.floor(Math.random() * 1_000_000),
+    source_id: 'default',
+    slug,
+    type: 'note',
+    title: slug,
+    compiled_truth: 'body',
+    timeline: '',
+    frontmatter: {},
+    content_hash: `hash-${slug}`,
+    created_at: new Date('2026-07-14T00:00:00Z'),
+    updated_at: new Date('2026-07-14T00:00:00Z'),
+    effective_date: null,
+    deleted_at: null,
+  };
+}
+
+function ctxWithPages(pages: Page[]): { ctx: OperationContext; getPageCalls: () => number } {
+  let getPageCalls = 0;
+  const engine = {
+    getPage: async (slug: string) => {
+      getPageCalls++;
+      return pages.find(p => p.slug === slug) ?? null;
+    },
+    listPages: async () => pages,
+    getTags: async () => [],
+    resolveSlugs: async () => [],
+  } as unknown as BrainEngine;
+
+  return {
+    getPageCalls: () => getPageCalls,
+    ctx: {
+      engine,
+      config: { engine: 'pglite' } as unknown as GBrainConfig,
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+      dryRun: false,
+      remote: false,
+      sourceId: 'default',
+    },
+  };
+}
+
+describe('archival export snapshot operation visibility', () => {
+  test('get_page hides root and _uninstalled export snapshots before engine lookup', async () => {
+    const { ctx, getPageCalls } = ctxWithPages([
+      page('export/report'),
+      page('_uninstalled/export-1783954174436/report'),
+      page('export/_uninstalled/export-1783954174436/report'),
+    ]);
+
+    for (const slug of [
+      'export/report',
+      '_uninstalled/export-1783954174436/report',
+      'export/_uninstalled/export-1783954174436/report',
+    ]) {
+      await expect(getPageOp.handler(ctx, { slug })).rejects.toBeInstanceOf(OperationError);
+    }
+    expect(getPageCalls()).toBe(0);
+  });
+
+  test('list_pages omits archival export snapshots from returned rows', async () => {
+    const { ctx } = ctxWithPages([
+      page('notes/live'),
+      page('export/report'),
+      page('_uninstalled/export-1783954174436/report'),
+      page('export/_uninstalled/export-1783954174436/report'),
+    ]);
+
+    const rows = await listPagesOp.handler(ctx, { limit: 10 }) as Array<{ slug: string }>;
+    expect(rows.map(r => r.slug)).toEqual(['notes/live']);
+  });
+});

--- a/test/sql-ranking.test.ts
+++ b/test/sql-ranking.test.ts
@@ -3,6 +3,7 @@ import {
   buildSourceFactorCase,
   buildHardExcludeClause,
   buildVisibilityClause,
+  isArchivalExportSlug,
   escapeLikePattern as topLevelEscapeLikePattern,
   __test__,
 } from '../src/core/search/sql-ranking.ts';
@@ -264,6 +265,9 @@ describe('archive demote (issue #1777)', () => {
     expect(DEFAULT_HARD_EXCLUDES).toContain('test/');
     expect(DEFAULT_HARD_EXCLUDES).toContain('attachments/');
     expect(DEFAULT_HARD_EXCLUDES).toContain('.raw/');
+    expect(DEFAULT_HARD_EXCLUDES).toContain('export/');
+    expect(DEFAULT_HARD_EXCLUDES).toContain('_uninstalled/export-');
+    expect(DEFAULT_HARD_EXCLUDES).toContain('export/_uninstalled/export-');
   });
 
   test('resolveHardExcludes() never includes archive/ by default', () => {
@@ -287,6 +291,29 @@ describe('archive demote (issue #1777)', () => {
   test('escapeLikePattern is exported at top level (CV-3a contract)', () => {
     expect(typeof topLevelEscapeLikePattern).toBe('function');
     expect(topLevelEscapeLikePattern('a_b%c\\d')).toBe('a\\_b\\%c\\\\d');
+  });
+});
+
+describe('archival export snapshot exclusion', () => {
+  test('matches root and uninstalled export snapshots only', () => {
+    expect(isArchivalExportSlug('export/report')).toBe(true);
+    expect(isArchivalExportSlug('_uninstalled/export-1783954174436/report')).toBe(true);
+    expect(isArchivalExportSlug('export/_uninstalled/export-1783954174436/report')).toBe(true);
+    expect(isArchivalExportSlug('archive/export-1783954174436/report')).toBe(false);
+  });
+
+  test('resolveHardExcludes includes archival export prefixes by default', () => {
+    const r = resolveHardExcludes();
+    expect(r).toContain('export/');
+    expect(r).toContain('_uninstalled/export-');
+    expect(r).toContain('export/_uninstalled/export-');
+  });
+
+  test('buildHardExcludeClause hides both uninstalled export snapshot forms', () => {
+    const sql = buildHardExcludeClause('p.slug', resolveHardExcludes());
+    expect(sql).toContain("p.slug LIKE 'export/%'");
+    expect(sql).toContain("p.slug LIKE '\\_uninstalled/export-%'");
+    expect(sql).toContain("p.slug LIKE 'export/\\_uninstalled/export-%'");
   });
 });
 


### PR DESCRIPTION
## Summary
- Hide archival export snapshots from default search hard-excludes: `export/**`, `_uninstalled/export-*/**`, and `export/_uninstalled/export-*/**`.
- Apply the same archival slug predicate to agent-facing `get_page` and `list_pages` reads so snapshots remain stored but non-retrievable through those tools.
- Add focused regression tests for SQL exclusion prefixes and operation-level read filtering.

## Verification
- `npm exec --yes bun@latest -- test test/sql-ranking.test.ts test/archival-export-ops.test.ts` — pass (57 tests).
- `npm exec --yes bun@latest -- run typecheck` — pass.
- `npm exec --yes bun@latest -- run verify` — pass (31 checks).
- `git diff --check` — pass.

## Notes
- Live `gbrain search export`, `gbrain query "export namespace gbrain"`, and `gbrain recall 16870` validation could not run on this VPS because no brain is configured (`No brain configured. Run: gbrain init`).
- Full `bun run test` was attempted through `npm exec --yes bun@latest -- run test`; multiple shards were OS-killed after ~20 minutes, so I stopped the failed resource-bound run.
- Runtime source SLOC added is under the SQN-3841 150-line target.
- No data deletion or migration path is part of this change.