### PR TITLE
feat(ai): add MiniMax M3 chat support

### DIFF
--- a/docs/ai-providers/minimax.md
+++ b/docs/ai-providers/minimax.md
@@ -1,0 +1,44 @@
+# MiniMax Chat Models
+
+GBrain exposes `MiniMax-M3` and `MiniMax-M2.7` through two compatible chat
+recipes. Both use `MINIMAX_API_KEY` and preserve the existing `minimax:embo-01`
+embedding configuration.
+
+## OpenAI-Compatible Recipe
+
+Select a model and choose either published region:
+
+```bash
+export MINIMAX_API_KEY=...
+gbrain config set chat_model minimax:MiniMax-M3
+
+# Global
+gbrain config set provider_base_urls.minimax https://api.minimax.io/v1
+
+# China
+gbrain config set provider_base_urls.minimax https://api.minimaxi.com/v1
+```
+
+Use `minimax:MiniMax-M2.7` to select the second registered model.
+
+## Anthropic-Compatible Recipe
+
+The public base URL must end in `/anthropic`. GBrain derives the SDK's internal
+`/v1` segment and does not expose that derived path as configuration.
+
+```bash
+export MINIMAX_API_KEY=...
+gbrain config set chat_model minimax-anthropic:MiniMax-M3
+
+# Global
+gbrain config set provider_base_urls.minimax-anthropic https://api.minimax.io/anthropic
+
+# China
+gbrain config set provider_base_urls.minimax-anthropic https://api.minimaxi.com/anthropic
+```
+
+Verify the selected path with:
+
+```bash
+gbrain providers test --touchpoint chat
+```

--- a/docs/integrations/embedding-providers.md
+++ b/docs/integrations/embedding-providers.md
@@ -129,6 +129,10 @@ Set `MINIMAX_API_KEY`. Optional `MINIMAX_GROUP_ID` for org-scoped accounts. Mode
 
 MiniMax's API takes a `type: 'db' | 'query'` field for asymmetric retrieval. v0.32 routes everything as `type='db'` (symmetric retrieval — same vector space for indexing and queries). Asymmetric query support is a v0.32.x follow-up.
 
+The same provider registry also exposes `MiniMax-M3` and `MiniMax-M2.7` for
+chat. See [MiniMax chat models](../ai-providers/minimax.md) for both compatible
+endpoint families and the global and China base URLs.
+
 ### DashScope (Alibaba)
 
 Set `DASHSCOPE_API_KEY`. International endpoint at `dashscope-intl.aliyuncs.com` by default; override `provider_base_urls.dashscope` for the China endpoint. Models: `text-embedding-v3` (current; Matryoshka 64-1024 dims), `text-embedding-v2`.

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -390,6 +390,55 @@ export function applyOpenAICompatConfig(
 }
 
 /**
+ * Resolve a public Anthropic-compatible base URL for the SDK. The configured
+ * URL stays at the documented `/anthropic` boundary; the SDK version used by
+ * gbrain appends only `/messages`, so the adapter derives `/v1` internally.
+ *
+ * @internal exported for tests.
+ */
+export function applyAnthropicCompatConfig(
+  recipe: Recipe,
+  cfg: AIGatewayConfig,
+): { baseURL: string } {
+  const raw = cfg.base_urls?.[recipe.id] ?? recipe.base_url_default;
+  if (!raw) {
+    throw new AIConfigError(
+      `${recipe.name} requires a base URL.`,
+      recipe.setup_hint,
+    );
+  }
+  const publicBaseURL = raw.trim().replace(/\/+$/, '');
+  if (!publicBaseURL.endsWith('/anthropic')) {
+    throw new AIConfigError(
+      `${recipe.name} base URL must end with /anthropic.`,
+      recipe.setup_hint,
+    );
+  }
+  return { baseURL: `${publicBaseURL}/v1` };
+}
+
+/** @internal exported for tests. */
+export function applyAnthropicCompatAuth(
+  recipe: Recipe,
+  cfg: AIGatewayConfig,
+  touchpoint: 'expansion' | 'chat',
+): { authToken: string } {
+  const resolved = recipe.resolveAuth
+    ? recipe.resolveAuth(cfg.env)
+    : defaultResolveAuth(recipe, cfg.env, touchpoint);
+  if (
+    resolved.headerName !== 'Authorization' ||
+    !resolved.token.startsWith('Bearer ')
+  ) {
+    throw new AIConfigError(
+      `${recipe.name} requires Authorization: Bearer authentication.`,
+      recipe.setup_hint,
+    );
+  }
+  return { authToken: resolved.token.slice('Bearer '.length) };
+}
+
+/**
  * #1250: native providers (anthropic/openai) are instantiated as
  * `create<Provider>({ apiKey })` with NO explicit baseURL, so the AI SDK reads
  * `<PROVIDER>_BASE_URL` verbatim. When a host injects a BARE base URL (Claude
@@ -1265,6 +1314,11 @@ function instantiateEmbedding(recipe: Recipe, modelId: string, cfg: AIGatewayCon
     case 'native-anthropic':
       throw new AIConfigError(
         `Anthropic has no embedding model. Use openai or google for embeddings.`,
+      );
+    case 'anthropic-compatible':
+      throw new AIConfigError(
+        `${recipe.name} does not offer an embedding model.`,
+        recipe.setup_hint,
       );
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
@@ -2182,6 +2236,15 @@ function instantiateExpansion(recipe: Recipe, modelId: string, cfg: AIGatewayCon
       const baseURL = resolveNativeBaseUrl('anthropic', cfg);
       return createAnthropic({ apiKey, ...(baseURL ? { baseURL } : {}) }).languageModel(modelId);
     }
+    case 'anthropic-compatible': {
+      const auth = applyAnthropicCompatAuth(recipe, cfg, 'expansion');
+      const compat = applyAnthropicCompatConfig(recipe, cfg);
+      return createAnthropic({
+        name: `${recipe.id}.messages`,
+        baseURL: compat.baseURL,
+        ...auth,
+      }).languageModel(modelId);
+    }
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).
       const auth = applyResolveAuth(recipe, cfg, 'expansion');
@@ -2555,6 +2618,15 @@ function instantiateChat(recipe: Recipe, modelId: string, cfg: AIGatewayConfig):
       if (!apiKey) throw new AIConfigError(`Anthropic chat requires ANTHROPIC_API_KEY.`, recipe.setup_hint);
       const baseURL = resolveNativeBaseUrl('anthropic', cfg);
       return createAnthropic({ apiKey, ...(baseURL ? { baseURL } : {}) }).languageModel(modelId);
+    }
+    case 'anthropic-compatible': {
+      const auth = applyAnthropicCompatAuth(recipe, cfg, 'chat');
+      const compat = applyAnthropicCompatConfig(recipe, cfg);
+      return createAnthropic({
+        name: `${recipe.id}.messages`,
+        baseURL: compat.baseURL,
+        ...auth,
+      }).languageModel(modelId);
     }
     case 'openai-compatible': {
       // D12=A: unified auth via Recipe.resolveAuth (or default).

--- a/src/core/ai/recipes/index.ts
+++ b/src/core/ai/recipes/index.ts
@@ -18,6 +18,7 @@ import { groq } from './groq.ts';
 import { together } from './together.ts';
 import { llamaServer } from './llama-server.ts';
 import { minimax } from './minimax.ts';
+import { minimaxAnthropic } from './minimax-anthropic.ts';
 import { dashscope } from './dashscope.ts';
 import { zhipu } from './zhipu.ts';
 import { azureOpenAI } from './azure-openai.ts';
@@ -38,6 +39,7 @@ const ALL: Recipe[] = [
   llamaServer,
   llamaServerReranker,
   minimax,
+  minimaxAnthropic,
   dashscope,
   zhipu,
   azureOpenAI,

--- a/src/core/ai/recipes/minimax-anthropic.ts
+++ b/src/core/ai/recipes/minimax-anthropic.ts
@@ -1,0 +1,33 @@
+import type { Recipe } from '../types.ts';
+import {
+  MINIMAX_CHAT_MODELS,
+  MINIMAX_CHAT_PRICING,
+  MINIMAX_ENDPOINTS,
+} from './minimax-shared.ts';
+
+export const minimaxAnthropic: Recipe = {
+  id: 'minimax-anthropic',
+  name: 'MiniMax (Anthropic-compatible)',
+  tier: 'openai-compat',
+  implementation: 'anthropic-compatible',
+  // This is the public base URL. The gateway derives the SDK's internal /v1
+  // prefix without exposing that derived path as user configuration.
+  base_url_default: MINIMAX_ENDPOINTS.global_en.anthropic_base_url,
+  auth_env: {
+    required: ['MINIMAX_API_KEY'],
+    setup_url: 'https://platform.minimax.io/docs/api-reference/api-overview',
+  },
+  touchpoints: {
+    chat: {
+      models: [...MINIMAX_CHAT_MODELS],
+      supports_tools: true,
+      supports_subagent_loop: true,
+      supports_prompt_cache: false,
+      cost_per_1m_input_usd: MINIMAX_CHAT_PRICING.input,
+      cost_per_1m_output_usd: MINIMAX_CHAT_PRICING.output,
+      price_last_verified: MINIMAX_CHAT_PRICING.verified_at,
+    },
+  },
+  setup_hint:
+    'Set MINIMAX_API_KEY, then select minimax-anthropic:<model>. Override provider_base_urls.minimax-anthropic to use another published region.',
+};

--- a/src/core/ai/recipes/minimax-shared.ts
+++ b/src/core/ai/recipes/minimax-shared.ts
@@ -1,0 +1,18 @@
+export const MINIMAX_CHAT_MODELS = ['MiniMax-M3', 'MiniMax-M2.7'] as const;
+
+export const MINIMAX_ENDPOINTS = {
+  global_en: {
+    openai_base_url: 'https://api.minimax.io/v1',
+    anthropic_base_url: 'https://api.minimax.io/anthropic',
+  },
+  cn_zh: {
+    openai_base_url: 'https://api.minimaxi.com/v1',
+    anthropic_base_url: 'https://api.minimaxi.com/anthropic',
+  },
+} as const;
+
+export const MINIMAX_CHAT_PRICING = {
+  input: 0.3,
+  output: 1.2,
+  verified_at: '2026-07-08',
+} as const;

--- a/src/core/ai/recipes/minimax.ts
+++ b/src/core/ai/recipes/minimax.ts
@@ -1,4 +1,9 @@
 import type { Recipe } from '../types.ts';
+import {
+  MINIMAX_CHAT_MODELS,
+  MINIMAX_CHAT_PRICING,
+  MINIMAX_ENDPOINTS,
+} from './minimax-shared.ts';
 
 /**
  * MiniMax (海螺AI). OpenAI-compatible /embeddings endpoint at
@@ -20,7 +25,7 @@ export const minimax: Recipe = {
   name: 'MiniMax (海螺AI)',
   tier: 'openai-compat',
   implementation: 'openai-compatible',
-  base_url_default: 'https://api.minimaxi.com/v1',
+  base_url_default: MINIMAX_ENDPOINTS.cn_zh.openai_base_url,
   auth_env: {
     required: ['MINIMAX_API_KEY'],
     optional: ['MINIMAX_GROUP_ID'],
@@ -37,6 +42,18 @@ export const minimax: Recipe = {
       // hitting whatever undocumented server-side limit exists. Recursive
       // halving in the gateway catches token-limit errors at runtime.
       max_batch_tokens: 4096,
+    },
+    chat: {
+      models: [...MINIMAX_CHAT_MODELS],
+      supports_tools: true,
+      supports_subagent_loop: true,
+      supports_prompt_cache: false,
+      // The registered models have different context limits, so a single
+      // recipe-wide maximum would be unsafe for one model or restrictive for
+      // the other. The upstream API remains the per-model source of truth.
+      cost_per_1m_input_usd: MINIMAX_CHAT_PRICING.input,
+      cost_per_1m_output_usd: MINIMAX_CHAT_PRICING.output,
+      price_last_verified: MINIMAX_CHAT_PRICING.verified_at,
     },
   },
   setup_hint:

--- a/src/core/ai/types.ts
+++ b/src/core/ai/types.ts
@@ -22,6 +22,7 @@ export type Implementation =
   | 'native-openai'
   | 'native-google'
   | 'native-anthropic'
+  | 'anthropic-compatible'
   | 'openai-compatible';
 
 export interface EmbeddingTouchpoint {
@@ -239,7 +240,7 @@ export interface Recipe {
   tier: 'native' | 'openai-compat';
   /** Maps to the gateway's implementation switch. */
   implementation: Implementation;
-  /** For openai-compatible tier: default base URL. May be overridden by env or wizard. */
+  /** Default compatible API base URL. May be overridden through provider_base_urls. */
   base_url_default?: string;
   /** Env var name(s) for auth; first is required, rest are optional. */
   auth_env?: {

--- a/test/ai/minimax-anthropic-transport.test.ts
+++ b/test/ai/minimax-anthropic-transport.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateText } from 'ai';
+import { MINIMAX_ENDPOINTS } from '../../src/core/ai/recipes/minimax-shared.ts';
+
+describe('MiniMax Anthropic-compatible transport', () => {
+  test('the SDK appends only /messages to the internally derived /v1 base', async () => {
+    let capturedURL = '';
+    const transport = async (input: RequestInfo | URL, init?: RequestInit) => {
+      capturedURL = new Request(input, init).url;
+      throw new Error('capture-complete');
+    };
+    const publicBaseURL = MINIMAX_ENDPOINTS.global_en.anthropic_base_url;
+    const model = createAnthropic({
+      baseURL: `${publicBaseURL}/v1`,
+      authToken: 'test-only',
+      fetch: transport as unknown as typeof fetch,
+    })('MiniMax-M3');
+
+    try {
+      await generateText({ model, prompt: 'ping', maxOutputTokens: 1 });
+    } catch (error) {
+      expect(String(error)).toContain('capture-complete');
+    }
+
+    expect(capturedURL).toBe(`${publicBaseURL}/v1/messages`);
+  });
+});

--- a/test/ai/recipe-minimax.test.ts
+++ b/test/ai/recipe-minimax.test.ts
@@ -10,9 +10,14 @@
 
 import { describe, expect, test } from 'bun:test';
 import { getRecipe } from '../../src/core/ai/recipes/index.ts';
-import { defaultResolveAuth } from '../../src/core/ai/gateway.ts';
+import {
+  applyAnthropicCompatAuth,
+  applyAnthropicCompatConfig,
+  defaultResolveAuth,
+} from '../../src/core/ai/gateway.ts';
 import { dimsProviderOptions } from '../../src/core/ai/dims.ts';
 import { AIConfigError } from '../../src/core/ai/errors.ts';
+import { MINIMAX_ENDPOINTS } from '../../src/core/ai/recipes/minimax-shared.ts';
 
 describe('recipe: minimax', () => {
   test('registered with expected shape', () => {
@@ -33,6 +38,56 @@ describe('recipe: minimax', () => {
     expect(r.touchpoints.embedding!.default_dims).toBe(1536);
     expect(r.touchpoints.embedding!.user_provided_models ?? false).toBe(false);
     expect(r.touchpoints.embedding!.max_batch_tokens).toBe(4096);
+  });
+
+  test('chat touchpoint declares both target models and standard pricing', () => {
+    const chat = getRecipe('minimax')!.touchpoints.chat!;
+    expect(chat.models).toEqual(['MiniMax-M3', 'MiniMax-M2.7']);
+    expect(chat.supports_tools).toBe(true);
+    expect(chat.supports_subagent_loop).toBe(true);
+    expect(chat.max_context_tokens).toBeUndefined();
+    expect(chat.cost_per_1m_input_usd).toBe(0.3);
+    expect(chat.cost_per_1m_output_usd).toBe(1.2);
+  });
+
+  test('OpenAI-compatible recipe exposes both published regional base URLs', () => {
+    expect(MINIMAX_ENDPOINTS.global_en.openai_base_url).toBe('https://api.minimax.io/v1');
+    expect(MINIMAX_ENDPOINTS.cn_zh.openai_base_url).toBe('https://api.minimaxi.com/v1');
+    expect(getRecipe('minimax')!.base_url_default).toBe(
+      MINIMAX_ENDPOINTS.cn_zh.openai_base_url,
+    );
+  });
+
+  test('Anthropic-compatible recipe preserves public regional base URLs', () => {
+    const r = getRecipe('minimax-anthropic')!;
+    expect(r.implementation).toBe('anthropic-compatible');
+    expect(r.touchpoints.chat!.models).toEqual(['MiniMax-M3', 'MiniMax-M2.7']);
+
+    for (const publicBaseURL of [
+      MINIMAX_ENDPOINTS.global_en.anthropic_base_url,
+      MINIMAX_ENDPOINTS.cn_zh.anthropic_base_url,
+    ]) {
+      expect(publicBaseURL.endsWith('/anthropic')).toBe(true);
+      expect(applyAnthropicCompatConfig(r, {
+        base_urls: { [r.id]: publicBaseURL },
+        env: {},
+      })).toEqual({ baseURL: `${publicBaseURL}/v1` });
+    }
+  });
+
+  test('Anthropic-compatible recipe maps the MiniMax key to Bearer auth', () => {
+    const r = getRecipe('minimax-anthropic')!;
+    expect(applyAnthropicCompatAuth(r, {
+      env: { MINIMAX_API_KEY: 'fake-mm-key' },
+    }, 'chat')).toEqual({ authToken: 'fake-mm-key' });
+  });
+
+  test('Anthropic-compatible recipe rejects a derived or unrelated public base URL', () => {
+    const r = getRecipe('minimax-anthropic')!;
+    expect(() => applyAnthropicCompatConfig(r, {
+      base_urls: { [r.id]: `${MINIMAX_ENDPOINTS.global_en.anthropic_base_url}/v1` },
+      env: {},
+    })).toThrow(AIConfigError);
   });
 
   test('default auth: MINIMAX_API_KEY set → "Bearer <key>"', () => {


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry.

## Summary
- register `MiniMax-M3` and `MiniMax-M2.7` for chat while preserving the existing embedding model
- add a second compatible messages transport with exact global and China public base URLs and internal SDK path derivation
- document regional configuration and add registry, authentication, and request-capture coverage

## Checks
- locked dependency installation passed
- focused registry, transport, gateway, regression, and provider-list tests passed (61 tests)
- static type validation passed
- full repository verification passed (31 checks)