### PR TITLE
fix(import): retain resolved source for page snapshots

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -118,28 +118,20 @@ export async function runImport(
   const flagSourceId = sourceIdIdx !== -1 ? args[sourceIdIdx + 1] : null;
   let sourceId: string | undefined = flagSourceId ?? opts.sourceId;
 
-  // v0.41.13 (#1434): when no explicit source / env / opts.sourceId is set,
-  // fall through to the resolver so the new sole_non_default tier (5.5) can
-  // auto-route to the only registered non-default source. Pre-fix, import
-  // followed the explicit-only design from PR #707 and silently routed
-  // every import to 'default', mirroring the sync bug class.
+  // Resolve every implicit import source before touching a page. Leaving the
+  // seed-default result undefined makes importFromContent find an existing
+  // page across sources, then snapshot source=default, which fails when that
+  // slug exists only under the resolved source.
   //
   // Resolution chain (full 7 tiers): flag → env → dotfile → local_path →
   // brain_default → sole_non_default → seed_default. The nudge fires only
   // when the resolver returns tier='sole_non_default', so explicit users
   // see no behavior change.
-  if (!sourceId && process.env.GBRAIN_SOURCE) {
-    const { resolveSourceId } = await import('../core/source-resolver.ts');
-    sourceId = await resolveSourceId(engine, null);
-  } else if (!sourceId) {
+  if (!sourceId) {
     const { resolveSourceWithTier, formatSoleNonDefaultNudge } = await import('../core/source-resolver.ts');
     const resolved = await resolveSourceWithTier(engine, null);
-    // Only adopt the resolution when it improves on the seed_default
-    // fallback — that preserves the v0.30.x "default-only when unset"
-    // contract for the common case AND opens the sole_non_default
-    // auto-route for the single-source-brain case.
+    sourceId = resolved.source_id;
     if (resolved.tier === 'sole_non_default') {
-      sourceId = resolved.source_id;
       const nudge = formatSoleNonDefaultNudge(sourceId);
       if (nudge) process.stderr.write(nudge + '\n');
     }

--- a/test/import-source-id.test.ts
+++ b/test/import-source-id.test.ts
@@ -19,6 +19,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { PGLiteEngine } from '../src/core/pglite-engine.ts';
 import { runImport } from '../src/commands/import.ts';
+import { withEnv } from './helpers/with-env.ts';
 
 let engine: PGLiteEngine;
 
@@ -37,6 +38,7 @@ async function truncatePages(): Promise<void> {
     await (engine as any).db.exec(`DELETE FROM ${t}`);
   }
   await (engine as any).db.exec(`DELETE FROM sources WHERE id <> 'default'`);
+  await engine.setConfig('sources.default', '');
 }
 
 describe('import --source-id (#1167)', () => {
@@ -78,6 +80,30 @@ describe('import --source-id (#1167)', () => {
     for (const r of rows) {
       expect(r.source_id).toBe('dept-x');
     }
+  });
+
+  test('uses the configured source before snapshotting an existing page', async () => {
+    await engine.executeRaw(
+      `INSERT INTO sources (id, name) VALUES ('capture-cli', 'capture-cli')`,
+    );
+    await engine.setConfig('sources.default', 'capture-cli');
+    await engine.putPage('wiki/alpha', {
+      type: 'note',
+      title: 'Captured alpha',
+      compiled_truth: 'Existing capture-cli page.',
+    }, { sourceId: 'capture-cli' });
+
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-import-home-'));
+    await withEnv({ GBRAIN_HOME: home }, async () => {
+      const result = await runImport(engine, [scratchDir, '--no-embed', '--json', '--fresh']);
+      expect(result.errors).toBe(0);
+    });
+
+    const rows = await engine.executeRaw<{ source_id: string; title: string }>(
+      `SELECT source_id, title FROM pages WHERE slug = $1 ORDER BY source_id`,
+      ['wiki/alpha'],
+    );
+    expect(rows).toEqual([{ source_id: 'capture-cli', title: 'Alpha' }]);
   });
 
   test('--source-id value is NOT treated as a positional dir arg', async () => {


### PR DESCRIPTION
## Problem

`runImport` resolves the active source but only adopts the result for the `sole_non_default` tier (src/commands/import.ts). A source resolved from a dotfile, local path, or `brain_default` config is discarded. `importFromContent` then finds an existing page without a source filter and attempts its version snapshot with an undefined source, which both engines interpret as `default`:

```
Warning: skipped wiki/alpha.md: createVersion failed: page "wiki/alpha" (source=default) not found
```

Any brain where a slug already exists under a non-default source (e.g. pages created via `put`/capture, later imported from files) hits this on every import retry, and each retry can add another collision.

## Fix

Always adopt `resolveSourceWithTier()`'s result before touching pages. Explicit `--source-id` and programmatic `sourceId` keep their existing precedence; the sole-non-default nudge is unchanged.

## Testing

- New regression test reproduces the collision red before the fix (isolated in-memory PGLite + temporary `GBRAIN_HOME`) and passes green after.
- `bun test test/import-source-id.test.ts test/source-resolver.test.ts test/source-resolver-with-tier.test.ts test/e2e/source-routing.test.ts` — 38 pass, 0 fail.
- `bun run verify` — 31/31 checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Wvg44rAhLfwdeZzJfkHeY