### PR TITLE
fix(chunker): estimated-token hard cap — URL-dense/CJK-fallback chunks overflow strict embedding-server token limits

### DIFF
--- a/src/core/chunkers/code.ts
+++ b/src/core/chunkers/code.ts
@@ -18,8 +18,9 @@
  * at runtime.
  */
 
-import { chunkText as recursiveChunk } from './recursive.ts';
+import { chunkText as recursiveChunk, capByEstimatedTokens, DEFAULT_MAX_EST_TOKENS } from './recursive.ts';
 import { buildQualifiedName } from './qualified-names.ts';
+import { estimateEmbeddingTokens } from '../cjk.ts';
 
 // Embed the tree-sitter runtime + per-language grammars as files.
 // `with { type: 'file' }` returns a path (string) at runtime. Bun bundles
@@ -111,7 +112,15 @@ import G_ZIG from '../../assets/wasm/grammars/tree-sitter-zig.wasm' with { type:
 // chunks get the new columns populated. Without this, the v28 backfill
 // gives every existing chunk a search_vector but subsequent Layer 5 AST
 // work would silently no-op.
-export const CHUNKER_VERSION = 4;
+//
+// v5: estimated-token hard cap on AST-path chunks (capCodeChunks). A node
+// splitLargeNode can't subdivide (giant single-statement function, huge
+// literal) previously shipped WHOLE regardless of size and could overflow
+// strict per-request embedding-token limits (local llama-server crashes
+// past ~2,050 tokens, measured). Mirrors the markdown
+// chunker's v4 cap; fallback-path chunks are already capped inside
+// recursiveChunk.
+export const CHUNKER_VERSION = 5;
 
 // Lazy-loaded tree-sitter module (v0.22.x API: Parser is default export)
 let Parser: typeof import('web-tree-sitter') | null = null;
@@ -718,7 +727,13 @@ export async function chunkCodeTextFull(
     if (chunks.length === 0) {
       return { chunks: capOversizedChunks(fallbackChunks(source, filePath, language, opts), filePath, language, opts), edges: rawEdges };
     }
-    return { chunks: capOversizedChunks(mergeSmallSiblings(chunks, chunkTarget), filePath, language, opts), edges: rawEdges };
+    // Layered with #1675's capOversizedChunks: that pass splits structurally
+    // but triggers on the generic estimateTokens (~3.5 chars/token), which
+    // undercounts CJK (~1 char/token) and URL-dense text — an over-budget
+    // Korean chunk passes it untouched. capCodeChunks re-checks with the
+    // CJK-aware estimateEmbeddingTokens; it is a no-op when all chunks are
+    // already under the estimated cap.
+    return { chunks: capCodeChunks(capOversizedChunks(mergeSmallSiblings(chunks, chunkTarget), filePath, language, opts)), edges: rawEdges };
   } catch {
     return { chunks: fallbackChunks(source, filePath, language, opts), edges: [] };
   } finally {
@@ -799,6 +814,33 @@ function mergeSmallSiblings(chunks: CodeChunk[], chunkTarget: number): CodeChunk
     i = j;
   }
   return merged;
+}
+
+/**
+ * v5 final safety pass for AST-path chunks: split any chunk whose
+ * ESTIMATED embedding tokens (conservative per-char-class heuristic,
+ * cjk.ts) exceed DEFAULT_MAX_EST_TOKENS. Reaches chunks the AST logic
+ * can't subdivide — splitLargeNode returns [] for nodes with < 2 body
+ * children (giant single-statement functions, huge literals), which
+ * previously shipped whole at any size.
+ *
+ * Split pieces inherit the source chunk's metadata verbatim; start/end
+ * lines become approximate for pieces after the first. Acceptable —
+ * these chunks exist for embedding + retrieval, and the alternative was
+ * an embedding request the server rejects (or worse, crashes on).
+ */
+function capCodeChunks(chunks: CodeChunk[]): CodeChunk[] {
+  if (chunks.every((c) => estimateEmbeddingTokens(c.text) <= DEFAULT_MAX_EST_TOKENS)) {
+    return chunks;
+  }
+  const out: CodeChunk[] = [];
+  for (const c of chunks) {
+    const pieces = capByEstimatedTokens(c.text, DEFAULT_MAX_EST_TOKENS);
+    for (const piece of pieces) {
+      out.push({ ...c, text: piece, index: out.length, metadata: { ...c.metadata } });
+    }
+  }
+  return out;
 }
 
 function buildMergedChunk(group: CodeChunk[], index: number): CodeChunk {

--- a/src/core/chunkers/recursive.ts
+++ b/src/core/chunkers/recursive.ts
@@ -17,7 +17,13 @@
  * Lossless invariant: non-overlapping portions reassemble to original.
  */
 
-import { countCJKAwareWords, CJK_SENTENCE_DELIMITERS, CJK_CLAUSE_DELIMITERS } from '../cjk.ts';
+import {
+  countCJKAwareWords,
+  CJK_SENTENCE_DELIMITERS,
+  CJK_CLAUSE_DELIMITERS,
+  charEmbedTokenWeight,
+  estimateEmbeddingTokens,
+} from '../cjk.ts';
 
 /**
  * Markdown chunker version. Folded into the per-page chunker_version column
@@ -33,8 +39,20 @@ import { countCJKAwareWords, CJK_SENTENCE_DELIMITERS, CJK_CLAUSE_DELIMITERS } fr
  * re-embed (not re-chunk) so existing pages pick up the wrapper on the
  * post-upgrade reembed sweep. See
  * `src/core/contextual-retrieval-service.ts`.
+ *
+ * v4: estimated-token hard cap + whitespace-word undercount fix. The word
+ * pipeline counted a 150-char URL as ONE whitespace word, so URL/phone/
+ * email-dense docs (CJK density < 0.30 → whitespace fallback) produced
+ * 3-4K-char chunks that overflow strict per-request embedding-token
+ * limits (measured: local llama-server crashes past ~2,050 tokens; URL
+ * soup tokenizes at ~1.6 chars/token). Two changes:
+ *   1. countWords() floors the count at ceil(nonWhitespaceChars/6) so a
+ *      URL counts roughly per-character, not as one word.
+ *   2. capByEstimatedTokens() final pass guarantees every chunk fits
+ *      `maxTokens` (default 1500) under a conservative per-char-class
+ *      token estimate, regardless of how word counting misjudged it.
  */
-export const MARKDOWN_CHUNKER_VERSION = 3;
+export const MARKDOWN_CHUNKER_VERSION = 4;
 
 const DELIMITERS: string[][] = [
   ['\n\n'],                          // L0: paragraphs
@@ -48,7 +66,19 @@ export interface ChunkOptions {
   chunkSize?: number;    // target words per chunk (default 300)
   chunkOverlap?: number; // overlap words (default 50)
   maxChars?: number;     // hard cap on any chunk's char length (default 6000)
+  /**
+   * v4: hard cap on any chunk's ESTIMATED embedding tokens (default 1500).
+   * Estimate = conservative per-char-class weights (see cjk.ts
+   * estimateEmbeddingTokens) — deliberately high, so the real tokenizer
+   * count stays below this value. Default leaves headroom for the
+   * contextual-retrieval wrapper (≤ ~630 chars) under a ~2,050-token
+   * per-request embedding server limit.
+   */
+  maxTokens?: number;
 }
+
+/** v4 default for ChunkOptions.maxTokens — see the field doc above. */
+export const DEFAULT_MAX_EST_TOKENS = 1500;
 
 export interface TextChunk {
   text: string;
@@ -73,6 +103,7 @@ export function chunkText(text: string, opts?: ChunkOptions): TextChunk[] {
   const chunkSize = opts?.chunkSize || 300;
   const chunkOverlap = opts?.chunkOverlap || 50;
   const maxChars = opts?.maxChars || 6000;
+  const maxTokens = opts?.maxTokens || DEFAULT_MAX_EST_TOKENS;
 
   if (!text || text.trim().length === 0) return [];
 
@@ -89,8 +120,9 @@ export function chunkText(text: string, opts?: ChunkOptions): TextChunk[] {
 
   const wordCount = countWords(stripped);
   if (wordCount <= chunkSize) {
-    // Single-chunk path: still apply the maxChars cap.
-    const capped = capByChars(stripped.trim(), maxChars);
+    // Single-chunk path: still apply the maxChars + maxTokens caps.
+    const capped = capByChars(stripped.trim(), maxChars)
+      .flatMap((t) => capByEstimatedTokens(t, maxTokens));
     return capped.map((t, i) => ({ text: t, index: i }));
   }
 
@@ -101,9 +133,14 @@ export function chunkText(text: string, opts?: ChunkOptions): TextChunk[] {
   // v0.32.7: hard char cap. Catches pathological CJK + whitespace-less text
   // that the word-level pipeline can't bound (a single Chinese paragraph can
   // exceed 8192 OpenAI embedding tokens at any word count).
+  // v4: estimated-token cap on top — the char cap alone passes token-dense
+  // content (URL soup at ~1.6 chars/token) that overflows strict embedding
+  // server limits.
   const capped: string[] = [];
   for (const chunk of withOverlap) {
-    capped.push(...capByChars(chunk.trim(), maxChars));
+    for (const piece of capByChars(chunk.trim(), maxChars)) {
+      capped.push(...capByEstimatedTokens(piece, maxTokens));
+    }
   }
   return capped.map((t, i) => ({ text: t, index: i }));
 }
@@ -128,6 +165,68 @@ function capByChars(text: string, maxChars: number): string[] {
     const slice = text.slice(i, i + maxChars).trim();
     if (slice.length > 0) out.push(slice);
     if (i + maxChars >= text.length) break;
+  }
+  return out;
+}
+
+/**
+ * How far back (in chars) the token cap looks for a friendly cut point
+ * before falling back to a hard cut. 300 covers typical rollup/list line
+ * lengths so forced splits land at line starts, not mid-URL.
+ */
+const TOKEN_CAP_CUT_LOOKBACK = 300;
+
+/**
+ * v4: hard-cap a chunk's ESTIMATED embedding tokens. Final safety pass —
+ * runs after capByChars on every chunk, so no upstream miscounting
+ * (whitespace-word fallback, overlap inflation, char-cap survivors) can
+ * emit a chunk past `maxTokens`.
+ *
+ * Cut placement prefers, within the last TOKEN_CAP_CUT_LOOKBACK chars of
+ * the window: a newline, then any whitespace, then a hard cut. This keeps
+ * forced splits off mid-line/mid-URL positions for list-shaped content
+ * and inside code fences. No overlap is added (pieces stay lossless
+ * modulo the trims the char cap already applies).
+ *
+ * @internal exported for the code chunker (code.ts) and tests.
+ */
+export function capByEstimatedTokens(text: string, maxTokens: number): string[] {
+  if (text.length === 0) return [];
+  if (estimateEmbeddingTokens(text) <= maxTokens) return [text];
+
+  const out: string[] = [];
+  let start = 0;
+  while (start < text.length) {
+    // Greedily extend the window until the next char would break the cap.
+    // Always take at least one char so the loop makes forward progress.
+    let est = 0;
+    let end = start;
+    while (end < text.length) {
+      const w = charEmbedTokenWeight(text.charCodeAt(end));
+      if (est + w > maxTokens && end > start) break;
+      est += w;
+      end++;
+    }
+
+    if (end < text.length) {
+      const windowStart = Math.max(start + 1, end - TOKEN_CAP_CUT_LOOKBACK);
+      let cut = text.lastIndexOf('\n', end - 1);
+      if (cut < windowStart) {
+        cut = -1;
+        for (let i = end - 1; i >= windowStart; i--) {
+          const code = text.charCodeAt(i);
+          if (code === 0x20 || (code >= 0x09 && code <= 0x0d)) {
+            cut = i;
+            break;
+          }
+        }
+      }
+      if (cut >= windowStart) end = cut + 1;
+    }
+
+    const slice = text.slice(start, end).trim();
+    if (slice.length > 0) out.push(slice);
+    start = end;
   }
   return out;
 }
@@ -317,7 +416,19 @@ function extractTrailingContext(text: string, targetWords: number): string {
  * Delegated to src/core/cjk.ts so the slugify whitelist, expansion
  * detection, and PGLite keyword fallback all agree on what "CJK enough"
  * means.
+ *
+ * v4: floored at ceil(nonWhitespaceChars/6). The whitespace fallback
+ * counts a 150-char URL as ONE word, so URL/phone/email-dense docs
+ * (whose ASCII mass pushes CJK density below the 0.30 threshold) were
+ * sized at a fraction of their real bulk and merged into 3-4K-char
+ * chunks. The floor makes long whitespace-less runs count roughly
+ * per-character while leaving normal Latin prose untouched (average
+ * English word ≈ 5 chars < 6, so the whitespace count still wins).
+ * Kept local to the chunker — search/expansion.ts keeps the original
+ * countCJKAwareWords semantics for its query-length check.
  */
 function countWords(text: string): number {
-  return countCJKAwareWords(text);
+  const cjkAware = countCJKAwareWords(text);
+  const nonWhitespace = text.replace(/\s/g, '').length;
+  return Math.max(cjkAware, Math.ceil(nonWhitespace / 6));
 }

--- a/src/core/cjk.ts
+++ b/src/core/cjk.ts
@@ -73,3 +73,64 @@ export function countCJKAwareWords(s: string): number {
 export function escapeLikePattern(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
 }
+
+/**
+ * Conservative per-char-class embedding-token weights (markdown chunker v4).
+ *
+ * Why this exists: the chunker's "word" counting drastically UNDER-counts
+ * whitespace-less ASCII runs (a 150-char URL = 1 whitespace word), so
+ * word-based size targets can emit chunks that overflow an embedding
+ * server's per-request token limit. Measured on a local Qwen3-embedding
+ * llama-server stack:
+ *   - URL/phone/email-dense text tokenizes at ~1.6 chars/token
+ *   - base64-ish / minified blobs approach ~1.3 chars/token (worst case)
+ *   - Korean prose tokenizes NO WORSE than 1 char/token in practice
+ *
+ * Weights are deliberately HIGH (tokens are overestimated) so any cap
+ * based on this estimate is safe against real tokenizers:
+ *   - CJK char        → 1.0 token  (real CJK prose is cheaper)
+ *   - other non-space → 0.75 token (≈1.33 chars/token, covers base64)
+ *   - whitespace      → 0.1 token  (mostly folds into neighbor tokens)
+ */
+export const EMBED_TOKEN_WEIGHT_CJK = 1.0;
+export const EMBED_TOKEN_WEIGHT_OTHER = 0.75;
+export const EMBED_TOKEN_WEIGHT_WS = 0.1;
+
+/** BMP CJK check by UTF-16 code unit — same ranges as CJK_SLUG_CHARS. */
+export function isCJKCodeUnit(code: number): boolean {
+  return (
+    (code >= 0x4e00 && code <= 0x9fff) || // Han
+    (code >= 0x3040 && code <= 0x309f) || // Hiragana
+    (code >= 0x30a0 && code <= 0x30ff) || // Katakana
+    (code >= 0xac00 && code <= 0xd7af)    // Hangul Syllables
+  );
+}
+
+/**
+ * Per-code-unit token weight. Unrecognized whitespace (exotic Unicode
+ * spaces) intentionally falls into OTHER — that only overestimates.
+ */
+export function charEmbedTokenWeight(code: number): number {
+  if (isCJKCodeUnit(code)) return EMBED_TOKEN_WEIGHT_CJK;
+  if (
+    code === 0x20 || (code >= 0x09 && code <= 0x0d) ||
+    code === 0xa0 || code === 0x3000
+  ) {
+    return EMBED_TOKEN_WEIGHT_WS;
+  }
+  return EMBED_TOKEN_WEIGHT_OTHER;
+}
+
+/**
+ * Tokenizer-free embedding-token estimate (conservative overestimate).
+ * See weight docs above. Astral chars count as 2 OTHER code units —
+ * another overestimate, which is the safe direction.
+ */
+export function estimateEmbeddingTokens(s: string): number {
+  if (s.length === 0) return 0;
+  let est = 0;
+  for (let i = 0; i < s.length; i++) {
+    est += charEmbedTokenWeight(s.charCodeAt(i));
+  }
+  return Math.ceil(est);
+}

--- a/test/chunker-version-gate.test.ts
+++ b/test/chunker-version-gate.test.ts
@@ -15,19 +15,22 @@ import { describe, test, expect } from 'bun:test';
 import { CHUNKER_VERSION } from '../src/core/chunkers/code.ts';
 
 describe('Layer 12 — CHUNKER_VERSION constant', () => {
-  test('bumped to 4 for Cathedral II', () => {
+  test('bumped to 5 for the estimated-token hard cap', () => {
     // v3: v0.19.0 Chonkie parity (tokenizer + small-sibling merge).
     // v4: v0.20.0 Cathedral II (qualified names + parent scope + doc_comment
     //     + fence extraction + chunk-grain FTS). Folded into content_hash
     //     so any bump forces clean re-chunks on next sync.
-    expect(CHUNKER_VERSION).toBe(4);
+    // v5: estimated-token hard cap on AST-path chunks (capCodeChunks) so
+    //     un-subdividable giant nodes can't overflow strict embedding
+    //     server token limits.
+    expect(CHUNKER_VERSION).toBe(5);
   });
 
   test('is stable across imports (not recomputed at call time)', async () => {
     const a = (await import('../src/core/chunkers/code.ts')).CHUNKER_VERSION;
     const b = (await import('../src/core/chunkers/code.ts')).CHUNKER_VERSION;
     expect(a).toBe(b);
-    expect(a).toBe(4);
+    expect(a).toBe(5);
   });
 });
 

--- a/test/chunkers/code.test.ts
+++ b/test/chunkers/code.test.ts
@@ -10,8 +10,8 @@ import { describe, test, expect } from 'bun:test';
 import { chunkCodeText, detectCodeLanguage, CHUNKER_VERSION } from '../../src/core/chunkers/code.ts';
 
 describe('CHUNKER_VERSION', () => {
-  test('v0.20.0 Cathedral II Layer 12 bumped to 4', () => {
-    expect(CHUNKER_VERSION).toBe(4);
+  test('v5: estimated-token hard cap on AST-path chunks', () => {
+    expect(CHUNKER_VERSION).toBe(5);
   });
 });
 

--- a/test/chunkers/recursive.test.ts
+++ b/test/chunkers/recursive.test.ts
@@ -135,13 +135,14 @@ describe('Recursive Text Chunker', () => {
 });
 
 describe('CJK chunking (v0.32.7)', () => {
-  test('MARKDOWN_CHUNKER_VERSION is 3', async () => {
+  test('MARKDOWN_CHUNKER_VERSION is 4', async () => {
     // v0.40.3.0: bumped 2→3 to signal the post-upgrade reembed sweep that
-    // contextual retrieval wrapping is now applied at embed time. Chunk
-    // boundaries themselves are unchanged; the bump forces re-embed for
-    // pages where chunker_version < 3.
+    // contextual retrieval wrapping is now applied at embed time.
+    // v4: estimated-token hard cap + whitespace-word undercount floor
+    // (URL-dense docs produced chunks past strict embedding server token
+    // limits). Boundary change → forces re-chunk for chunker_version < 4.
     const mod = await import('../../src/core/chunkers/recursive.ts');
-    expect(mod.MARKDOWN_CHUNKER_VERSION).toBe(3);
+    expect(mod.MARKDOWN_CHUNKER_VERSION).toBe(4);
   });
 
   test('long pure-Chinese paragraph splits into multiple chunks', () => {

--- a/test/chunkers/token-cap.test.ts
+++ b/test/chunkers/token-cap.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Markdown chunker v4 / code chunker v5 — estimated-token hard cap
+ * regression tests.
+ *
+ * Reproduces a field failure: a local llama-server embedding backend
+ * (`-ub 2048`) crashes deterministically (trace/BPT trap → EOF at the
+ * client) when a single chunk exceeds ~2,050 real tokens. Two content
+ * shapes triggered it:
+ *
+ *   1. Korean docs carrying one long source URL per line.
+ *      The URLs' ASCII mass pushes CJK density below 0.30, flipping
+ *      countCJKAwareWords to whitespace counting, where a 150-char URL
+ *      counts as ONE word → chunks ballooned to 3-4K chars ≈ 2,000+
+ *      real tokens (URL soup tokenizes at ~1.6 chars/token).
+ *
+ *   2. Large JSON code blocks (~7K chars) that the word pipeline
+ *      undercounts the same way (few whitespace tokens).
+ *
+ * The fix: every emitted chunk must satisfy
+ *   estimateEmbeddingTokens(chunk) <= maxTokens (default 1500)
+ * where the estimate deliberately OVERSTATES real tokenizer counts.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { chunkText, capByEstimatedTokens, DEFAULT_MAX_EST_TOKENS } from '../../src/core/chunkers/recursive.ts';
+import { chunkCodeText } from '../../src/core/chunkers/code.ts';
+import { estimateEmbeddingTokens } from '../../src/core/cjk.ts';
+
+/** Synthesize the failing shape: Korean rollup lines each ending in a long Notion URL. */
+function urlDenseKoreanRollup(lines: number): string {
+  const out: string[] = ['# 링크가 줄마다 붙는 한국어 예시 문서', ''];
+  for (let i = 0; i < lines; i++) {
+    const hex32 = (i * 2654435761 >>> 0).toString(16).padStart(8, '0').repeat(4);
+    out.push(
+      `- **항목 ${i}**: 이 줄은 청커 동작 검증을 위한 의미 없는 한국어 예시 문장입니다 · 전화 000-0000-${String(1000 + i)} · ` +
+      `이메일 user${i}@example.com · 링크: https://docs.example.com/pages/${hex32}?v=abcdef0123456789&ref=sample`,
+    );
+  }
+  return out.join('\n');
+}
+
+/** Synthesize a large pretty-printed JSON block with CJK values. */
+function bigJsonBlock(targetChars: number): string {
+  const entries: string[] = [];
+  let i = 0;
+  let len = 0;
+  while (len < targetChars) {
+    const row =
+      `  "item_${i}": { "name": "예시-${i}", "url": "https://example.com/api/v2/items/${i}?token=abc${i}def", "qty": ${i % 100}, "memo": "한국어 값이 섞인 예시 데이터" }`;
+    entries.push(row);
+    len += row.length;
+    i++;
+  }
+  return `{\n${entries.join(',\n')}\n}`;
+}
+
+describe('v4 estimated-token cap — URL-dense Korean doc (field-failure shape)', () => {
+  test('every chunk stays under the estimated-token cap', () => {
+    const md = urlDenseKoreanRollup(60);
+    const chunks = chunkText(md);
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const c of chunks) {
+      expect(estimateEmbeddingTokens(c.text)).toBeLessThanOrEqual(DEFAULT_MAX_EST_TOKENS);
+    }
+  });
+
+  test('no chunk reaches the measured 3K-char danger zone for URL soup', () => {
+    const md = urlDenseKoreanRollup(60);
+    const chunks = chunkText(md);
+    // 1500 est tokens at the OTHER weight (0.75/char) bounds chunks to
+    // ~2,000 chars for pure ASCII — well under the ~3,300 chars where
+    // URL-dense content crosses ~2,050 real tokens (1.6 chars/token).
+    for (const c of chunks) {
+      expect(c.text.length).toBeLessThanOrEqual(2600);
+    }
+  });
+
+  test('content is preserved (no lines dropped by the cap)', () => {
+    const md = urlDenseKoreanRollup(60);
+    const chunks = chunkText(md);
+    const joined = chunks.map((c) => c.text).join('\n');
+    // Spot-check first / middle / last rollup lines survive chunking.
+    for (const marker of ['항목 0', '항목 30', '항목 59']) {
+      expect(joined).toContain(marker);
+    }
+  });
+});
+
+describe('v4 estimated-token cap — large JSON blocks', () => {
+  test('7K-char pretty JSON through the prose path stays under the cap', () => {
+    const md = `설정 파일 원문 보존:\n\n\`\`\`\n${bigJsonBlock(7000)}\n\`\`\`\n`;
+    const chunks = chunkText(md);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(estimateEmbeddingTokens(c.text)).toBeLessThanOrEqual(DEFAULT_MAX_EST_TOKENS);
+    }
+  });
+
+  test('7K-char minified JSON (single whitespace-less token) stays under the cap', () => {
+    const minified = bigJsonBlock(7000).replace(/\n\s*/g, '');
+    const chunks = chunkText(minified);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(estimateEmbeddingTokens(c.text)).toBeLessThanOrEqual(DEFAULT_MAX_EST_TOKENS);
+    }
+  });
+
+  test('json fence via the code chunker stays under the cap (+header slack)', async () => {
+    const chunks = await chunkCodeText(bigJsonBlock(7000), 'fence.json');
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const c of chunks) {
+      // buildChunk prepends a short "[JSON] fence.json:…" header AFTER the
+      // body-level cap; allow ~60 est tokens of header slack. Real-token
+      // safety margin (2,050 − overestimated 1,500) absorbs this easily.
+      expect(estimateEmbeddingTokens(c.text)).toBeLessThanOrEqual(DEFAULT_MAX_EST_TOKENS + 60);
+    }
+  });
+});
+
+describe('v4 word-count floor — behavior preserved for normal content', () => {
+  test('Latin prose chunking is unchanged by the floor (avg word < 6 chars)', () => {
+    const prose = Array.from({ length: 120 }, (_, i) =>
+      `This is sentence number ${i} and it talks about ordinary things in plain words.`,
+    ).join(' ');
+    const chunks = chunkText(prose);
+    // Historical behavior: ~1,560 whitespace words → multiple ~300-word chunks.
+    expect(chunks.length).toBeGreaterThan(3);
+    for (const c of chunks) {
+      const words = c.text.split(/\s+/).length;
+      expect(words).toBeLessThanOrEqual(300 * 1.5 + 50); // merge cap + overlap
+    }
+  });
+
+  test('Korean prose (CJK-dense, no URLs) never triggers the token cap', () => {
+    const prose = Array.from({ length: 80 }, (_, i) =>
+      `이 문장은 순수 한국어 산문의 청킹 동작을 확인하기 위한 ${i}번째 예시 문장입니다.`,
+    ).join(' ');
+    const chunks = chunkText(prose);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      // CJK-dense chunks are char-counted (≈450 max) — nowhere near 1500.
+      expect(estimateEmbeddingTokens(c.text)).toBeLessThanOrEqual(700);
+    }
+  });
+});
+
+describe('capByEstimatedTokens unit behavior', () => {
+  test('returns input unchanged when under the cap', () => {
+    expect(capByEstimatedTokens('short text', 1500)).toEqual(['short text']);
+    expect(capByEstimatedTokens('', 1500)).toEqual([]);
+  });
+
+  test('prefers newline cut points within the lookback window', () => {
+    const line = 'x'.repeat(100);
+    const text = Array.from({ length: 40 }, () => line).join('\n');
+    const pieces = capByEstimatedTokens(text, 1000);
+    expect(pieces.length).toBeGreaterThan(1);
+    for (const p of pieces) {
+      // Every piece should be whole lines (multiples of the 100-char line).
+      for (const l of p.split('\n')) {
+        expect(l).toBe(line);
+      }
+    }
+  });
+
+  test('makes forward progress on whitespace-less input (hard cut)', () => {
+    const blob = 'a'.repeat(10_000);
+    const pieces = capByEstimatedTokens(blob, 1000);
+    expect(pieces.length).toBeGreaterThan(1);
+    expect(pieces.join('')).toBe(blob);
+    for (const p of pieces) {
+      expect(estimateEmbeddingTokens(p)).toBeLessThanOrEqual(1000);
+    }
+  });
+});
+
+describe('estimateEmbeddingTokens — weight sanity', () => {
+  test('overestimates URL-dense ASCII (0.75/char ≥ measured ~0.63/char)', () => {
+    const url = 'https://docs.example.com/pages/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4?v=abc&ref=sample';
+    const est = estimateEmbeddingTokens(url);
+    expect(est).toBeGreaterThanOrEqual(Math.floor(url.length * 0.7));
+  });
+
+  test('counts CJK at 1 token/char', () => {
+    expect(estimateEmbeddingTokens('가나다라마')).toBe(5);
+  });
+
+  test('whitespace is nearly free', () => {
+    expect(estimateEmbeddingTokens('   \n\t  ')).toBeLessThanOrEqual(1);
+  });
+
+  test('empty string is 0', () => {
+    expect(estimateEmbeddingTokens('')).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #2826

## Summary

URL/phone/email-dense CJK markdown and large JSON code blocks produce 3–4K-char chunks that overflow strict per-request embedding-server token limits (measured: a local llama-server with `-ub 2048` crashes past ~2,050 tokens per chunk — deterministic EOF for the affected pages; full reproduction and measurements in the linked issue).

Two defects let those chunks form, fixed with defense in depth:

1. **Whitespace-word undercount** — `countCJKAwareWords`' fallback (CJK density < 0.30) counts a 150-char URL as one word, and per-line URLs are exactly what pushes CJK docs below the density threshold. The chunker sizes such docs at a fraction of their bulk; the existing `maxChars: 6000` cap assumes ≥1 char/token and passes URL-dense chunks worth up to ~3,700 real tokens (~1.6 chars/token).
2. **Unbounded AST-path chunks** — a node `splitLargeNode` can't subdivide ships whole at any size.

## Changes

- **`src/core/cjk.ts`** — add `estimateEmbeddingTokens()`: tokenizer-free, per-char-class token estimate (CJK 1.0/char, other non-whitespace 0.75/char, whitespace 0.1/char). Weights are calibrated against measured ratios (URL-dense ~1.6 chars/token, base64-worst ~1.3) and deliberately **overestimate**, so any cap based on the estimate is safe against real tokenizers. Additive only — `countCJKAwareWords` semantics are untouched (search/`expansion.ts`, which imports it, is unaffected).
- **`src/core/chunkers/recursive.ts`** (`MARKDOWN_CHUNKER_VERSION` 3→4):
  - `countWords` floored at `ceil(nonWhitespaceChars / 6)` — long whitespace-less runs (URLs, minified blobs) count roughly per-character. Latin prose is unchanged (average English word < 6 chars, so the whitespace count still wins); pinned by tests.
  - `capByEstimatedTokens()` final pass with new `ChunkOptions.maxTokens` (default 1500 — headroom for the contextual-retrieval wrapper under a ~2,050-token server limit, and far below OpenAI's 8,192 so it is a pure safety win there too; normal 300-word chunks never approach it). Cut points prefer a newline, then whitespace, within a 300-char lookback so forced splits land at line boundaries instead of mid-URL/mid-line.
- **`src/core/chunkers/code.ts`** (`CHUNKER_VERSION` 4→5): `capCodeChunks()` applies the same cap to AST-path chunks (the `splitLargeNode`-returns-empty case previously shipped unbounded).

Version bumps route existing pages through the standard `gbrain reindex --markdown` sweep / `sources.chunker_version` sync gate.

## Measurements (real Qwen3 embedding tokenizer, worst chunk, same inputs)

| input | before | after |
|---|---|---|
| URL-dense Korean rollup (60 lines) | **2,889 tok** | 1,336 tok |
| 7K-char minified JSON | **2,136 tok** | 996 tok |
| 7K-char pretty JSON | 1,967 tok | 994 tok |

The estimator stayed above the real count in every failure-shape case (1,483–1,498 estimated vs 994–1,336 real). One boundary observation from a production-scale sweep (1,454 pages re-chunked, zero embed failures): on whitespace-heavy aligned-table content the estimate can undershoot the real count slightly (worst measured −2.4%: 1,277 est vs 1,308 real on a 4.2K-char chunk that is 72% spaces) — the 550-token headroom between the default cap (1,500) and the measured server limit (~2,050) absorbs this class comfortably.

## Tests

`test/chunkers/token-cap.test.ts` (new, 13 tests): reproduces both failure shapes (URL-dense CJK rollup, large JSON pretty/minified through both the prose path and the `fence.json` code-chunker path), and pins:

- the cap invariant (`estimateEmbeddingTokens(chunk) ≤ maxTokens` for every emitted chunk),
- content preservation (no lines dropped),
- newline-preferring cut placement and forward progress on whitespace-less input,
- **unchanged behavior for normal content** — Latin prose chunk boundaries and CJK-dense prose sizing.

Existing chunker suites updated only for the version-constant assertions (3→4, 4→5).

## Verification

- `bun run verify`: all 31 checks pass (typecheck, `check:test-isolation` R1–R4, privacy checks, etc.). Note: run sequentially per check — the parallel dispatcher is incompatible with my sandboxed shell; every check binary-passes individually.
- Unit suite (`bun test`): full run on this branch vs a master baseline in the same environment — **zero new failures from this change**; chunker/CJK/reindex/re-embed domain suites 100% green (12,515 tests ran; every failure in the delta vs baseline is a load-sensitive timing/subprocess test that passes when its file runs solo — verified; the ~630 remaining failures are environment-dependent on my machine, identical before and after this change).
- `bun run test:slow`: 41/41 pass.
- E2E: skipped locally (no `DATABASE_URL`), per the `test:full` script's documented skip path. The change is engine-agnostic — pure text pipeline in `src/core/chunkers/` + `src/core/cjk.ts`; no engine SQL, no persistence-layer changes (chunk rows flow through both engines' existing `upsertChunks` unchanged).
- **eval replay: not triggered** — the diff touches none of the CONTRIBUTING-listed retrieval trigger paths (`src/core/search/*`, `embedding.ts`, query/search op handlers, engine searchKeyword/searchVector). `cjk.ts` changes are additive exports only; `expansion.ts` behavior is bit-identical. Chunk boundaries change **only** for pathological content that previously produced un-embeddable chunks (i.e., content that currently has no vectors at all on strict backends), plus the >6000-char cap survivors now split at 1500 estimated tokens; normal prose boundaries are pinned unchanged by the test suite.


## Rebase note (2026-07-24) — relation to #1675

Rebased over current master, which now carries #1675's `capOversizedChunks` on the AST path. The two caps are complementary, not redundant, because they measure with different rulers:

- **#1675** splits structurally (recursive re-split, header rebuild, `opts.maxChunkTokens`) but **triggers on the generic `estimateTokens` (~3.5 chars/token)**, which undercounts CJK text (~1 char/token measured) and URL-dense runs (~1.6 chars/token) by 2–3.5×. An over-budget Korean chunk passes its trigger untouched — exactly the failure shape in the table above.
- **This PR's `capCodeChunks`** re-checks with the CJK-aware `estimateEmbeddingTokens` as a final pass, and is a no-op when every chunk is already under the estimated cap.

The AST path now composes them: `capCodeChunks(capOversizedChunks(...))` — #1675's structural split first, CJK-aware safety net last. The markdown path (`recursive.ts`) is untouched by #1675 and still relies solely on this PR's cap. All 73 chunker tests (including the 13 new ones) pass on the rebase; `check:test-names` and typecheck clean.
