### PR TITLE
feat(guardrails): add ./guardrails to public exports

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -52,7 +52,7 @@ import APIs.
 ## Writing a guardrail provider
 
 ```ts
-import { registerGuardrailProvider, type GuardrailInput } from 'gbrain/core/guardrails';
+import { registerGuardrailProvider, type GuardrailInput } from 'gbrain/guardrails';
 
 registerGuardrailProvider({
   id: 'my-firewall',

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "./search/hybrid": "./src/core/search/hybrid.ts",
     "./search/expansion": "./src/core/search/expansion.ts",
     "./ai/gateway": "./src/core/ai/gateway.ts",
+    "./guardrails": "./src/core/guardrails.ts",
     "./extract": "./src/commands/extract.ts",
     "./ingestion": "./src/core/ingestion/index.ts",
     "./ingestion/test-harness": "./src/core/ingestion/test-harness.ts"

--- a/scripts/check-exports-count.sh
+++ b/scripts/check-exports-count.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-EXPECTED_COUNT=20
+EXPECTED_COUNT=21
 
 # Count top-level keys in the exports object. `node -e` parses JSON
 # reliably without needing jq (which isn't in every CI environment).

--- a/test/public-exports.test.ts
+++ b/test/public-exports.test.ts
@@ -50,6 +50,7 @@ const EXPECTED_EXPORTS: ExpectedExport[] = [
   { subpath: 'gbrain/search/hybrid', canary: ['hybridSearch', 'rrfFusion'] },
   { subpath: 'gbrain/search/expansion', canary: ['expandQuery'] },
   { subpath: 'gbrain/ai/gateway', canary: ['configureGateway', 'embed'] },
+  { subpath: 'gbrain/guardrails', canary: ['registerGuardrailProvider', 'runGuardrails', 'hasGuardrails'] },
   { subpath: 'gbrain/extract', canary: [] },
   { subpath: 'gbrain/ingestion', canary: ['INGESTION_SOURCE_API_VERSION', 'validateIngestionEvent', 'computeContentHash'] },
   { subpath: 'gbrain/ingestion/test-harness', canary: ['IngestionTestHarness', 'expectEvent'] },
@@ -68,7 +69,7 @@ describe('public exports — package.json exports map', () => {
     // Adding new exports: increment this + add to EXPECTED_EXPORTS below.
     // Removing exports: see CLAUDE.md "Removing any of these is a
     // breaking change going forward" — bump minor and update this count.
-    expect(count).toBe(20);
+    expect(count).toBe(21);
   });
 
   test('EXPECTED_EXPORTS list matches the exports map exactly (no drift)', () => {


### PR DESCRIPTION
## What

Adds the `./guardrails` subpath to the package.json exports map, so external guardrail providers can import the seam the way `docs/guardrails.md` already documents:

```ts
import { registerGuardrailProvider } from 'gbrain/guardrails';
```

Today the doc shows a package import, but the subpath is missing from the exports map, so out-of-tree providers can only deep-import `src/` paths.

## Changes

- `package.json`: add `"./guardrails": "./src/core/guardrails.ts"` (exports surface 20 → 21)
- `scripts/check-exports-count.sh`: bump `EXPECTED_COUNT` to 21
- `test/public-exports.test.ts`: bump the count assertion and pin canary symbols (`registerGuardrailProvider`, `runGuardrails`, `hasGuardrails`)
- `docs/guardrails.md`: align the example import path with the real subpath form

No behavior change to the seam itself — additive public-API surface only, per the exports policy in CLAUDE.md.

## Motivation

We're building an out-of-tree, shadow-mode PHI/PII detection provider on the guardrail seams (the exact use case the seam doc describes). A clean package import keeps providers off gbrain's internal file layout.

## Testing

- `bun test test/guardrails.test.ts test/public-exports.test.ts` — 52 pass / 0 fail
- `bash scripts/check-exports-count.sh` — 21 entries, matches baseline
- `bun run verify` — all 31 checks green
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)