### PR TITLE
fix(webhook): extract links for incremental push syncs

### DIFF
--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -2004,8 +2004,10 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   //     Other event types (ping, pull_request, etc.) return 202 'ignored'
   //     so GitHub doesn't retry.
   // D15.5: HMAC compare uses the shared safeHexEqual helper.
-  // D18: submits 'sync' job with auto_embed_backfill=true and priority -10
-  //     (above autopilot's 0).
+  // D18: submits 'sync' job with extraction + auto_embed_backfill enabled and
+  //     priority -10 (above autopilot's 0). Webhook sync consumes the source
+  //     commit, so extraction must happen in the same job while pagesAffected
+  //     still identifies the changed pages.
   // ---------------------------------------------------------------------------
   const githubWebhookLimiter = rateLimit({
     windowMs: 60_000,
@@ -2125,6 +2127,7 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
           'sync',
           {
             sourceId: source.id,
+            noExtract: false,
             auto_embed_backfill: true,
             embed_reason: 'webhook',
           },

--- a/src/commands/serve-http.ts
+++ b/src/commands/serve-http.ts
@@ -2005,9 +2005,9 @@ export async function runServeHttp(engine: BrainEngine, options: ServeHttpOption
   //     so GitHub doesn't retry.
   // D15.5: HMAC compare uses the shared safeHexEqual helper.
   // D18: submits 'sync' job with extraction + auto_embed_backfill enabled and
-  //     priority -10 (above autopilot's 0). Webhook sync consumes the source
-  //     commit, so extraction must happen in the same job while pagesAffected
-  //     still identifies the changed pages.
+  //     priority -10 (above autopilot's 0). This opts normal incremental pushes
+  //     into sync's inline extraction while pagesAffected still identifies the
+  //     changed pages. The sync core can still defer large (>100) changes.
   // ---------------------------------------------------------------------------
   const githubWebhookLimiter = rateLimit({
     windowMs: 60_000,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1102,6 +1102,7 @@ See also:
     {
       sourceId: sourceIdArg,
       repoPath: source.local_path,
+      noExtract: false,
       auto_embed_backfill: true,
       embed_reason: 'sync_trigger',
     },

--- a/test/sources-webhook.test.ts
+++ b/test/sources-webhook.test.ts
@@ -132,11 +132,13 @@ describe('Webhook sync job extraction contract', () => {
       'utf8',
     );
     const routeStart = serveSource.indexOf("'/webhooks/github'");
-    const responseStart = serveSource.indexOf('res.status(202)', routeStart);
+    const queueStart = serveSource.indexOf('const job = await queue.add(', routeStart);
+    const responseStart = serveSource.indexOf('res.status(202)', queueStart);
     expect(routeStart).toBeGreaterThanOrEqual(0);
-    expect(responseStart).toBeGreaterThan(routeStart);
+    expect(queueStart).toBeGreaterThan(routeStart);
+    expect(responseStart).toBeGreaterThan(queueStart);
 
-    const routeSource = serveSource.slice(routeStart, responseStart);
+    const routeSource = serveSource.slice(queueStart, responseStart);
     const payload = routeSource.match(
       /queue\.add\(\s*'sync',\s*\{([\s\S]*?)\}\s*,\s*\{/,
     );

--- a/test/sources-webhook.test.ts
+++ b/test/sources-webhook.test.ts
@@ -16,6 +16,7 @@
  */
 import { describe, test, expect } from 'bun:test';
 import { createHmac } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import { safeHexEqual } from '../src/core/timing-safe.ts';
 
 const GITHUB_SECRET = 'super-secret-webhook-key';
@@ -121,5 +122,25 @@ describe('Branch ref construction (D5)', () => {
     const trackedBranch: string = 'main';
     const pushedRef: string = 'refs/heads/feature/new-stuff';
     expect(pushedRef === `refs/heads/${trackedBranch}`).toBe(false);
+  });
+});
+
+describe('Webhook sync job extraction contract', () => {
+  test('opts into extraction before the pushed commit is consumed', () => {
+    const serveSource = readFileSync(
+      new URL('../src/commands/serve-http.ts', import.meta.url),
+      'utf8',
+    );
+    const routeStart = serveSource.indexOf("'/webhooks/github'");
+    const responseStart = serveSource.indexOf('res.status(202)', routeStart);
+    expect(routeStart).toBeGreaterThanOrEqual(0);
+    expect(responseStart).toBeGreaterThan(routeStart);
+
+    const routeSource = serveSource.slice(routeStart, responseStart);
+    const payload = routeSource.match(
+      /queue\.add\(\s*'sync',\s*\{([\s\S]*?)\}\s*,\s*\{/,
+    );
+    expect(payload).not.toBeNull();
+    expect(payload?.[1]).toMatch(/\bnoExtract:\s*false\b/);
   });
 });

--- a/test/sync-trigger-cli.test.ts
+++ b/test/sync-trigger-cli.test.ts
@@ -100,6 +100,7 @@ describe('runSyncTrigger', () => {
     const job = jobs[0];
     expect(job.priority).toBe(-10);
     expect((job.data as { sourceId: string }).sourceId).toBe('default');
+    expect((job.data as { noExtract: boolean }).noExtract).toBe(false);
     expect((job.data as { auto_embed_backfill: boolean }).auto_embed_backfill).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- make the native GitHub webhook explicitly opt into sync's inline extraction path
- align `gbrain sync trigger` with the same push-trigger contract
- pin both queue payloads with regression tests

## Why

The standalone `sync` Minion handler intentionally defaults a missing `noExtract` field to `true`. The webhook and CLI push triggers omitted that field, so a pushed commit could advance the source bookmark without extracting its changed pages. The next autopilot sync then sees an up-to-date source and has no changed slugs to pass to extraction.

Both push triggers now submit `noExtract: false`, preserving the default for callers that deliberately pair sync with a separate extract job.

Related to #2849. This PR intentionally addresses incremental sync batches where `totalChanges <= 100`. The existing large-sync deferral remains unchanged; #2849 should stay open until a consumed-commit-bound, source-scoped extraction follow-up covers `totalChanges > 100`.

## Tests

- RED: webhook queue-payload regression failed because `noExtract: false` was absent
- GREEN: `bun test test/sources-webhook.test.ts test/sync-trigger-cli.test.ts` — 19 pass, 0 fail
- `bun run verify` — 31/31 checks pass
- `git diff --check` — pass
- full `bun run test` reached 3,211 pass / 6 fail in three environment-sensitive serial files; the same three files fail on base `5008b287` under the same local no-embedding/worker-registry environment, so they are unrelated to this diff

The issue and tests use only synthetic examples; no installation-specific names, paths, job IDs, or content are included.
