### PR TITLE
fix(probe): gate nightly quality probe on real run outcomes only

### DIFF
--- a/src/core/cycle/nightly-quality-probe.ts
+++ b/src/core/cycle/nightly-quality-probe.ts
@@ -23,7 +23,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { logQualityProbeEvent, readRecentQualityProbeEvents } from '../audit-quality-probe.ts';
+import { logQualityProbeEvent, readRecentQualityProbeEvents, type QualityProbeAuditEvent, type QualityProbeOutcome } from '../audit-quality-probe.ts';
 
 /** Run-once gate window in ms. 24h matches the "nightly" cadence. */
 const NIGHTLY_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -102,20 +102,35 @@ export async function runNightlyQualityProbe(deps: NightlyProbeDeps): Promise<Ni
   }
 
   // 24h rate limit — skip + audit "rate_limited".
+  // Only real run outcomes count toward the window. Informational rows
+  // (rate_limited / no_embedding_key / disabled) must not refresh it:
+  // each skip writes an audit row, so counting skips would livelock the
+  // gate on its own trail (one skip row per autopilot tick, forever).
   const now = deps.now();
-  const recent = readRecentQualityProbeEvents(2, now); // 2-day window is enough for 24h check
+  const allRecent = readRecentQualityProbeEvents(2, now); // 2-day window is enough for 24h check
+  const runOutcomes: ReadonlySet<QualityProbeOutcome> = new Set(['pass', 'fail', 'inconclusive', 'error', 'budget_exceeded']);
+  const recent = allRecent.filter((ev) => runOutcomes.has(ev.outcome));
   const decision = shouldRunNightly(now, recent);
   if (!decision.run) {
-    logQualityProbeEvent({
-      outcome: 'rate_limited',
-      exit_code: 0,
-      pass_count: 0,
-      fail_count: 0,
-      inconclusive_count: 0,
-      error_count: 0,
-      est_cost_usd: 0,
-      detail: 'already ran within 24h window',
-    });
+    // Log-once per window: skip the duplicate audit row when the latest
+    // row is already rate_limited (the 5-min tick cadence otherwise
+    // writes ~288 identical rows/day and pollutes probe-health).
+    const latest = allRecent.reduce<QualityProbeAuditEvent | null>(
+      (a, b) => (a === null || Date.parse(b.ts) >= Date.parse(a.ts) ? b : a),
+      null,
+    );
+    if (latest === null || latest.outcome !== 'rate_limited') {
+      logQualityProbeEvent({
+        outcome: 'rate_limited',
+        exit_code: 0,
+        pass_count: 0,
+        fail_count: 0,
+        inconclusive_count: 0,
+        error_count: 0,
+        est_cost_usd: 0,
+        detail: 'already ran within 24h window',
+      });
+    }
     return { outcome: 'rate_limited', exit_code: 0, detail: 'already ran within 24h' };
   }
 

--- a/test/nightly-quality-probe.test.ts
+++ b/test/nightly-quality-probe.test.ts
@@ -17,6 +17,7 @@ import {
   type NightlyProbeResult,
 } from '../src/core/cycle/nightly-quality-probe.ts';
 import { withEnv } from './helpers/with-env.ts';
+import { computeQualityProbeAuditFilename } from '../src/core/audit-quality-probe.ts';
 
 // ---------------------------------------------------------------------------
 // Hermetic audit dir per test
@@ -140,6 +141,39 @@ describe('runNightlyQualityProbe (DI stub harness)', () => {
       // Second run, same hour → rate_limited.
       const r2 = await runNightlyQualityProbe(makeDeps());
       expect(r2.outcome).toBe('rate_limited');
+      const events = await readEvents();
+      expect(events.length).toBe(2);
+      expect(events[1].outcome).toBe('rate_limited');
+    });
+  });
+
+  test('REGRESSION: a history of only rate_limited rows must not block the run (livelock guard)', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditTmp }, async () => {
+      // Seed the current-week audit file with skip rows ONLY — the exact
+      // state the 5-min tick cadence produces after one stale real run.
+      const nowMs = Date.now();
+      const rows: string[] = [];
+      for (let i = 1; i <= 3; i++) {
+        rows.push(JSON.stringify({
+          ts: new Date(nowMs - i * 5 * 60000).toISOString(),
+          outcome: 'rate_limited', exit_code: 0, pass_count: 0, fail_count: 0,
+          inconclusive_count: 0, error_count: 0, est_cost_usd: 0,
+          detail: 'already ran within 24h window',
+        }));
+      }
+      writeFileSync(join(auditTmp, computeQualityProbeAuditFilename(new Date())), rows.join('\n') + '\n');
+      const r = await runNightlyQualityProbe(makeDeps());
+      expect(r.outcome).toBe('pass'); // gate ignored the skip rows and ran
+    });
+  });
+
+  test('REGRESSION: rate_limited audit row is written once per window, not per tick', async () => {
+    await withEnv({ GBRAIN_AUDIT_DIR: auditTmp }, async () => {
+      await runNightlyQualityProbe(makeDeps()); // real run -> pass row
+      const r2 = await runNightlyQualityProbe(makeDeps()); // blocked -> writes ONE rate_limited row
+      const r3 = await runNightlyQualityProbe(makeDeps()); // blocked again -> must NOT write another
+      expect(r2.outcome).toBe('rate_limited');
+      expect(r3.outcome).toBe('rate_limited');
       const events = await readEvents();
       expect(events.length).toBe(2);
       expect(events[1].outcome).toBe('rate_limited');


### PR DESCRIPTION
Running the nightly probe under a 5-min autopilot tick, one rate-limit burst wedged the probe permanently: every blocked tick writes a rate_limited audit row, and the 24h gate counted those rows as activity - so the gate never reopened, and probe-health filled with ~288 identical rows/day.

- Gate now counts only real run outcomes (pass / fail / inconclusive / error / budget_exceeded).
- rate_limited is logged once per window, not per tick (latest-row guard).
- Equal-timestamp tie-break prefers the later row so the guard is stable at ms resolution.

Two regression tests: a skip-only history must not block the run; repeated blocked ticks write exactly one rate_limited row. `bun test test/nightly-quality-probe.test.ts` - 27 pass. Typecheck clean.

Hit this on a daily-driver install; the fix has been running there since mid-June.

@sanchalr 🫡
