### PR TITLE
fix(autopilot): give full-cycle dispatch a 30-minute timeout floor

### DIFF
--- a/src/commands/autopilot-timeout.ts
+++ b/src/commands/autopilot-timeout.ts
@@ -1,0 +1,9 @@
+export function resolveAutopilotDispatchTimeoutMs(
+  baseIntervalSeconds: number,
+  fullCycle: boolean,
+): number {
+  const intervalDerivedTimeoutMs = Math.max(baseIntervalSeconds * 2 * 1000, 300_000);
+  return fullCycle
+    ? Math.max(intervalDerivedTimeoutMs, 1_800_000)
+    : intervalDerivedTimeoutMs;
+}

--- a/src/commands/autopilot.ts
+++ b/src/commands/autopilot.ts
@@ -38,6 +38,7 @@ import { logSelfUpgrade } from '../core/audit/self-upgrade-audit.ts';
 import { detectInstallMethod } from './upgrade.ts';
 import { evaluateQuietHours } from '../core/minions/quiet-hours.ts';
 import { inspectLock } from '../core/db-lock.ts';
+import { resolveAutopilotDispatchTimeoutMs } from './autopilot-timeout.ts';
 
 /**
  * v0.37.7.0 #1162 — classify autopilot reconnect-loop errors.
@@ -638,7 +639,7 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
         const queue = new MinionQueue(engine);
         const slotMs = Math.floor(Date.now() / (baseInterval * 1000)) * baseInterval * 1000;
         const slot = new Date(slotMs).toISOString();
-        const timeoutMs = Math.max(baseInterval * 2 * 1000, 300_000);
+        const timeoutMs = resolveAutopilotDispatchTimeoutMs(baseInterval, false);
 
         // ── v0.40 D17: per-source freshness check ────────────────────
         // Runs first; independent of score gate. Submits a 'sync' job per
@@ -880,7 +881,9 @@ export async function runAutopilot(engine: BrainEngine, args: string[]) {
           const result = await dispatchPerSource(engine, queue, {
             repoPath,
             slot,
-            timeoutMs,
+            // Full cycles can outlive short daemon intervals. Keep lighter dispatches
+            // interval-derived while giving per-source consolidation enough time.
+            timeoutMs: resolveAutopilotDispatchTimeoutMs(baseInterval, true),
             fanoutMax,
             jsonMode,
           });

--- a/test/autopilot-fanout-wiring.test.ts
+++ b/test/autopilot-fanout-wiring.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { resolveAutopilotDispatchTimeoutMs } from '../src/commands/autopilot-timeout.ts';
 
 const AUTOPILOT_SRC = readFileSync(
   join(import.meta.dir, '..', 'src', 'commands', 'autopilot.ts'),
@@ -46,6 +47,21 @@ describe('autopilot.ts ↔ dispatchPerSource wiring', () => {
     const fullCycleIdx = AUTOPILOT_SRC.indexOf('shouldFullCycle');
     expect(fullCycleIdx).toBeGreaterThan(-1);
     expect(Math.abs(dispatchIdx - fullCycleIdx)).toBeLessThan(3000);
+  });
+
+  test('applies the 30-minute timeout floor only to full-cycle dispatch', () => {
+    const baseIntervalSeconds = 60;
+    const intervalDerivedTimeoutMs = Math.max(baseIntervalSeconds * 2 * 1000, 300_000);
+
+    expect(resolveAutopilotDispatchTimeoutMs(baseIntervalSeconds, true)).toBeGreaterThanOrEqual(30 * 60_000);
+    expect(resolveAutopilotDispatchTimeoutMs(baseIntervalSeconds, false)).toBe(intervalDerivedTimeoutMs);
+
+    expect(AUTOPILOT_SRC).toContain(
+      'const timeoutMs = resolveAutopilotDispatchTimeoutMs(baseInterval, false);',
+    );
+    expect(AUTOPILOT_SRC).toMatch(
+      /dispatchPerSource\(engine, queue, \{[\s\S]{0,300}timeoutMs: resolveAutopilotDispatchTimeoutMs\(baseInterval, true\)/,
+    );
   });
 
   test('updates lastFullCycleAt on dispatch (so the 60-min floor is honored)', () => {


### PR DESCRIPTION
Full autopilot cycles were dying at the 10-minute default: dispatch timeout is interval*2 with a 5-min floor, sized for the light per-interval jobs, and per-source full-cycle consolidation routinely needs more. Healthy cycles got dead-lettered mid-run.

- `resolveAutopilotDispatchTimeoutMs(interval, fullCycle)`: full-cycle dispatch gets a 30-min floor; lighter dispatches keep the interval-derived budget.
- Regression test pins both derivations and both production call sites.

`bun test` on the autopilot wiring/fanout/resolve suites - 38 pass. Typecheck clean. Found on a live install in June; the floor has held since.

@sanchalr 🫡
