### PR TITLE
fix(budget): price non-Anthropic chat models via canonical fallback

### DIFF
--- a/src/core/budget/budget-tracker.ts
+++ b/src/core/budget/budget-tracker.ts
@@ -32,6 +32,7 @@ import { mkdirSync, appendFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { gbrainPath } from '../config.ts';
 import { ANTHROPIC_PRICING, type ModelPricing } from '../anthropic-pricing.ts';
+import { canonicalLookup } from '../model-pricing.ts';
 import { EMBEDDING_PRICING, lookupEmbeddingPrice } from '../embedding-pricing.ts';
 import { splitProviderModelId } from '../model-id.ts';
 import { isoWeekFilename, resolveAuditDir } from '../audit-week-file.ts';
@@ -201,6 +202,11 @@ function lookupPricing(modelId: string, kind: BudgetKind): ModelPricing | null {
   if (kind === 'rerank' && providerId && FREE_LOCAL_RERANK_PROVIDERS.has(providerId)) {
     return { input: 0, output: 0 };
   }
+  // Chat/rerank fall back to the all-provider canonical table so non-Anthropic
+  // chat models (e.g. openai:gpt-5.5) that the bare ANTHROPIC_PRICING view omits
+  // still get priced — CANONICAL_PRICING already carries them.
+  const canon = canonicalLookup(modelId);
+  if (canon) return canon;
   return null;
 }
 

--- a/test/budget-tracker-canonical-pricing.test.ts
+++ b/test/budget-tracker-canonical-pricing.test.ts
@@ -1,0 +1,41 @@
+// The chat budget pricer (lookupPricing) previously searched only the
+// Anthropic-specific ANTHROPIC_PRICING view, so a non-Anthropic chat model that
+// is in CANONICAL_PRICING (e.g. openai:gpt-5.5 = $4/$16) returned null pricing →
+// BudgetExhausted(no_pricing) when a cap was set → facts extraction silently
+// produced 0 facts. The canonical fallback fixes it.
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { BudgetTracker, BudgetExhausted } from '../src/core/budget/budget-tracker.ts';
+
+let tmp: string;
+let auditPath: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'gbrain-budget-canonical-pricing-test-'));
+  auditPath = join(tmp, 'budget.jsonl');
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('BudgetTracker canonical pricing fallback', () => {
+  test('prices openai:gpt-5.5 (chat) via CANONICAL_PRICING — no no_pricing throw under a cap', () => {
+    const t = new BudgetTracker({ label: 'canonical-pricing-test', maxCostUsd: 1.0, auditPath });
+    expect(() =>
+      t.reserve({ modelId: 'openai:gpt-5.5', estimatedInputTokens: 1000, maxOutputTokens: 500, kind: 'chat' }),
+    ).not.toThrow();
+  });
+
+  test('still throws no_pricing for a genuinely-unknown model under a cap', () => {
+    const t = new BudgetTracker({ label: 'canonical-pricing-test', maxCostUsd: 1.0, auditPath });
+    try {
+      t.reserve({ modelId: 'openai:does-not-exist-9.9', estimatedInputTokens: 1000, maxOutputTokens: 500, kind: 'chat' });
+      throw new Error('expected BudgetExhausted');
+    } catch (e) {
+      expect(e instanceof BudgetExhausted).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
With a budget cap set, any chat call routed to a non-Anthropic model failed before the provider was called: `lookupPricing` consulted only ANTHROPIC_PRICING, found nothing, and `reserve()` threw `no_pricing`. CANONICAL_PRICING already carries these ids - fall back to it for chat/rerank ids the Anthropic view omits.

Two regression tests: `openai:gpt-5.5` reserves under a cap; a genuinely-unknown id still throws. 44 pass across the budget/pricing suites. Typecheck clean.

@sanchalr 🫡
