### PR TITLE
fix(scripts): capture check/shard rc before watchdog teardown in no-timeout fallback

### DIFF
--- a/scripts/run-unit-parallel.sh
+++ b/scripts/run-unit-parallel.sh
@@ -133,6 +133,7 @@ for i in $(seq 1 "$N"); do
         env SHARD="$i/$N" \
         bash scripts/run-unit-shard.sh --max-concurrency="$INTRA_CONC" \
         > "$SHARD_LOG" 2>&1
+      rc=$?
     else
       env SHARD="$i/$N" \
         bash scripts/run-unit-shard.sh --max-concurrency="$INTRA_CONC" \
@@ -142,10 +143,20 @@ for i in $(seq 1 "$N"); do
         sleep 5 && kill -KILL "$pid" 2>/dev/null ) &
       cap_pid=$!
       wait "$pid" 2>/dev/null
+      # Capture the shard's exit code from ITS `wait`, before any watchdog
+      # teardown runs. The teardown commands below overwrite $? — the killed
+      # watchdog reports 143 — which used to get stamped into every shard's
+      # sentinel on machines with no gtimeout/timeout: every run "failed"
+      # with rc=143 summaries even when all tests passed.
+      rc=$?
+      # Reap the watchdog's `sleep` child too (pkill -P), then the watchdog.
+      # Killing only the subshell leaves the sleep orphaned until
+      # $SHARD_TIMEOUT elapses — same quirk the heartbeat cleanup below works
+      # around; CI's orphan-process sweep flags those.
+      pkill -P "$cap_pid" 2>/dev/null
       kill "$cap_pid" 2>/dev/null
       wait "$cap_pid" 2>/dev/null
     fi
-    rc=$?
     echo "$rc" > "$LOG_DIR/shard-$i.exit"
     [ "$rc" = "124" ] && echo "WEDGED" > "$LOG_DIR/shard-$i.wedged"
   ) &

--- a/scripts/run-verify-parallel.sh
+++ b/scripts/run-verify-parallel.sh
@@ -126,6 +126,7 @@ for c in "${CHECKS[@]}"; do
   (
     if [ -n "$TIMEOUT_BIN" ]; then
       "$TIMEOUT_BIN" "${TIMEOUT}s" bun run "$c" > "$LOG_FILE" 2>&1
+      rc=$?
     else
       bun run "$c" > "$LOG_FILE" 2>&1 &
       pid=$!
@@ -133,10 +134,20 @@ for c in "${CHECKS[@]}"; do
         sleep 5 && kill -KILL "$pid" 2>/dev/null ) &
       cap_pid=$!
       wait "$pid" 2>/dev/null
+      # Capture the check's exit code from ITS `wait`, before any watchdog
+      # teardown runs. The teardown commands below overwrite $? — the killed
+      # watchdog reports 143 — which used to get stamped into every sentinel
+      # on machines with no gtimeout/timeout: verify reported pass=0
+      # fail=<all> while every per-check log said OK.
+      rc=$?
+      # Reap the watchdog's `sleep` child too (pkill -P), then the watchdog.
+      # Killing only the subshell leaves the sleep orphaned until $TIMEOUT
+      # elapses — same quirk the heartbeat cleanup in run-unit-parallel.sh
+      # works around; CI's orphan-process sweep flags those.
+      pkill -P "$cap_pid" 2>/dev/null
       kill "$cap_pid" 2>/dev/null
       wait "$cap_pid" 2>/dev/null
     fi
-    rc=$?
     echo "$rc" > "$EXIT_FILE"
   ) &
   PIDS+=($!)

--- a/test/scripts/run-unit-parallel.test.ts
+++ b/test/scripts/run-unit-parallel.test.ts
@@ -22,7 +22,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 import { execFileSync, spawnSync } from 'child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, copyFileSync, chmodSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, copyFileSync, chmodSync, symlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
 
@@ -152,5 +152,95 @@ describe('failing-on-purpose', () => {
     // Format: `shard 1/2: pass=N fail=N skip=N rc=N`
     expect(summary).toMatch(/shard 1\/2: pass=\d+ fail=\d+ skip=\d+ rc=\d+/);
     expect(summary).toMatch(/shard 2\/2: pass=\d+ fail=\d+ skip=\d+ rc=\d+/);
+  });
+});
+
+describe('run-unit-parallel.sh no-timeout-binary fallback (rc from shard wait, not watchdog teardown)', () => {
+  // Forces the no-gtimeout/no-timeout branch by running the wrapper under a
+  // curated PATH that has every tool the scripts call EXCEPT timeout
+  // binaries (real `bun` symlinked in), so the fallback executes even on
+  // hosts with coreutils installed.
+  //
+  // Regression pinned here: the shard's sentinel .exit file must record the
+  // exit code read right after `wait $pid` (the shard's own rc). The
+  // watchdog subshell is killed with SIGTERM and reports 143; reading `$?`
+  // after that teardown stamped rc=143 into every shard's sentinel — the
+  // wrapper exited non-zero with rc=143 summaries even when every test
+  // passed.
+  let FROOT: string;
+  let FENV: Record<string, string>;
+
+  beforeAll(() => {
+    FROOT = mkdtempSync(join(tmpdir(), 'gbrain-parallel-fallback-'));
+    mkdirSync(join(FROOT, 'scripts'), { recursive: true });
+    mkdirSync(join(FROOT, 'test'), { recursive: true });
+    for (const s of ['run-unit-parallel.sh', 'run-unit-shard.sh', 'run-serial-tests.sh']) {
+      copyFileSync(resolve(REPO_ROOT, 'scripts', s), join(FROOT, 'scripts', s));
+      chmodSync(join(FROOT, 'scripts', s), 0o755);
+    }
+    const passing = `import { describe, it, expect } from 'bun:test';
+describe('passing', () => {
+  it('arithmetic works', () => { expect(1 + 1).toBe(2); });
+});`;
+    writeFileSync(join(FROOT, 'test', 'a-pass.test.ts'), passing);
+    writeFileSync(join(FROOT, 'test', 'b-pass.test.ts'), passing);
+
+    const bin = join(FROOT, 'bin');
+    mkdirSync(bin);
+    for (const tool of ['bash', 'sh', 'env', 'dirname', 'basename', 'mktemp', 'date', 'sleep', 'cat', 'tail', 'head', 'rm', 'mkdir', 'pkill', 'grep', 'sed', 'awk', 'wc', 'tr', 'seq', 'find', 'sort', 'bun']) {
+      const p = Bun.which(tool);
+      if (p) symlinkSync(p, join(bin, tool));
+    }
+    FENV = {
+      PATH: bin,
+      HOME: process.env.HOME ?? FROOT,
+      TMPDIR: process.env.TMPDIR ?? '/tmp',
+      GBRAIN_TEST_SHARD_TIMEOUT: '300',
+    };
+  });
+
+  afterAll(() => {
+    if (FROOT) rmSync(FROOT, { recursive: true, force: true });
+  });
+
+  function runFallbackWrapper(): { code: number; stdout: string; stderr: string } {
+    const result = spawnSync(
+      'bash',
+      [join(FROOT, 'scripts', 'run-unit-parallel.sh'), '--shards', '2'],
+      { cwd: FROOT, encoding: 'utf-8', env: FENV },
+    );
+    return {
+      code: result.status ?? -1,
+      stdout: result.stdout || '',
+      stderr: result.stderr || '',
+    };
+  }
+
+  it('exits zero with rc=0 shard sentinels when all shards pass', () => {
+    const r = runFallbackWrapper();
+    const summary = readFileSync(join(FROOT, '.context', 'test-summary.txt'), 'utf-8');
+    expect(summary).toMatch(/shard 1\/2: pass=\d+ fail=0 skip=0 rc=0/);
+    expect(summary).toMatch(/shard 2\/2: pass=\d+ fail=0 skip=0 rc=0/);
+    expect(summary).not.toContain('rc=143');
+    expect(r.code).toBe(0);
+  });
+
+  it('propagates a failing shard rc as the test runner rc (1), not the watchdog 143', () => {
+    const failing = `import { describe, it, expect } from 'bun:test';
+describe('failing-on-purpose', () => {
+  it('expects 1 to equal 2', () => { expect(1).toBe(2); });
+});`;
+    writeFileSync(join(FROOT, 'test', 'z-fail.test.ts'), failing);
+    try {
+      const r = runFallbackWrapper();
+      expect(r.code).not.toBe(0);
+      const summary = readFileSync(join(FROOT, '.context', 'test-summary.txt'), 'utf-8');
+      expect(summary).toMatch(/shard \d\/2: pass=\d+ fail=1 skip=0 rc=1/);
+      expect(summary).not.toContain('rc=143');
+      const failureLog = readFileSync(join(FROOT, '.context', 'test-failures.log'), 'utf-8');
+      expect(failureLog).toContain('failing-on-purpose');
+    } finally {
+      rmSync(join(FROOT, 'test', 'z-fail.test.ts'), { force: true });
+    }
   });
 });

--- a/test/scripts/run-verify-parallel.test.ts
+++ b/test/scripts/run-verify-parallel.test.ts
@@ -15,7 +15,16 @@
 
 import { describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -170,6 +179,98 @@ exit 0
       expect(r.stderr).toMatch(/Failed:\s+beta\s+gamma/);
     } finally {
       cleanup(d);
+    }
+  });
+});
+
+describe("run-verify-parallel.sh — no-timeout-binary fallback rc capture (regression)", () => {
+  // macOS ships no `timeout`; without brew coreutils (`gtimeout`) — stock
+  // machines, minimal containers, restricted/sandboxed PATHs — the dispatcher
+  // degrades to the bg-pid + sleep-watchdog branch.
+  //
+  // Regression pinned here: each check's sentinel .exit file must record the
+  // exit code of the CHECK (read right after `wait $pid`), not of the
+  // watchdog teardown. The watchdog subshell is killed with SIGTERM and so
+  // reports 143; reading `$?` after the teardown stamped 143 into every
+  // sentinel — verify reported pass=0 fail=<all> while every per-check log
+  // said OK.
+  //
+  // Hermetic on any host: the script runs from a tempdir copy with `bun`
+  // stubbed (checks complete instantly, no repo needed) and PATH set to a
+  // curated symlink dir containing everything the script calls EXCEPT
+  // gtimeout/timeout — forcing the fallback branch even where coreutils is
+  // installed.
+
+  function makeFallbackHarness(): { root: string; env: Record<string, string> } {
+    const root = mkdtempSync(join(tmpdir(), "verify-fallback-"));
+    mkdirSync(join(root, "scripts"), { recursive: true });
+    copyFileSync(SCRIPT, join(root, "scripts", "run-verify-parallel.sh"));
+
+    const bin = join(root, "bin");
+    mkdirSync(bin);
+    // Everything the dispatcher and its subshells invoke, minus timeout bins.
+    for (const tool of ["bash", "sh", "env", "dirname", "mktemp", "date", "sleep", "cat", "tail", "head", "rm", "mkdir", "pkill", "grep", "sed", "awk"]) {
+      const p = Bun.which(tool);
+      if (p) symlinkSync(p, join(bin, tool));
+    }
+    // `bun run <name>` stand-in: instant, prints OK, exits 7 for the check
+    // named in $STUB_FAIL_CHECK (if any).
+    writeFileSync(
+      join(bin, "bun"),
+      `#!/usr/bin/env bash
+name="\${2:-}"
+echo "stub check OK: $name"
+if [ -n "\${STUB_FAIL_CHECK:-}" ] && [ "$name" = "\${STUB_FAIL_CHECK}" ]; then
+  echo "stub check failing: $name" >&2
+  exit 7
+fi
+exit 0
+`,
+      { mode: 0o755 },
+    );
+
+    return {
+      root,
+      env: {
+        PATH: bin,
+        HOME: process.env.HOME ?? root,
+        TMPDIR: process.env.TMPDIR ?? "/tmp",
+        GBRAIN_VERIFY_TIMEOUT: "30",
+        GBRAIN_VERIFY_LOG_DIR: join(root, "logs"),
+      },
+    };
+  }
+
+  it("all checks passing → exit 0, every sentinel records 0 (not the watchdog's 143)", () => {
+    const { root, env } = makeFallbackHarness();
+    try {
+      const r = spawnSync("bash", [join(root, "scripts", "run-verify-parallel.sh")], { encoding: "utf8", env });
+      expect(r.stderr).toMatch(/pass=\d+ fail=0/);
+      expect(r.status).toBe(0);
+      const exits = readdirSync(join(root, "logs")).filter((f) => f.endsWith(".exit"));
+      expect(exits.length).toBeGreaterThan(10);
+      for (const f of exits) {
+        expect(readFileSync(join(root, "logs", f), "utf8").trim()).toBe("0");
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("one check failing → exit 1, sentinel records the check's own rc (7), not 143", () => {
+    const { root, env } = makeFallbackHarness();
+    try {
+      const r = spawnSync("bash", [join(root, "scripts", "run-verify-parallel.sh")], {
+        encoding: "utf8",
+        env: { ...env, STUB_FAIL_CHECK: "check:jsonb" },
+      });
+      expect(r.status).toBe(1);
+      expect(r.stderr).toContain("--- check:jsonb (rc=7)");
+      expect(r.stderr).toContain("stub check failing: check:jsonb");
+      expect(r.stderr).toMatch(/fail=1\b/);
+      expect(readFileSync(join(root, "logs", "check_jsonb.exit"), "utf8").trim()).toBe("7");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
Fixes #2855

## Summary

On machines with neither `gtimeout` (brew coreutils) nor `timeout` on PATH, both parallel runners fall back to a bg-pid + sleep-watchdog wallclock cap — and record the **watchdog teardown's** exit status instead of the check/shard's own. The watchdog subshell is killed with SIGTERM during teardown, so `wait "$cap_pid"` returns 143, and `rc=$?` (placed after the `fi`) captures that: every sentinel `.exit` file reads 143, and every run reports total failure while every per-check/shard log is green (verify: exit 1, `pass=0 fail=31`; unit: `shard N/2: pass=1 fail=0 skip=0 rc=143`). Full measurements and an eight-line distillation of the mechanism in #2855.

## Changes

Same two-part shape in `scripts/run-verify-parallel.sh` and `scripts/run-unit-parallel.sh`:

1. **Capture `rc=$?` immediately after `wait "$pid"`** in the fallback branch (and immediately after the invocation in the `TIMEOUT_BIN` branch), then write the sentinel from `$rc` after the `fi` — the teardown can no longer clobber it.
2. **Reap the watchdog's `sleep` child before killing the watchdog** (`pkill -P`, children-first). Killing only the subshell orphaned one `sleep $TIMEOUT` per check/shard on this path — the same quirk the heartbeat cleanup in `run-unit-parallel.sh` already documents and works around; CI's orphan-process sweep flags those.

Behavior note: a check/shard that genuinely times out on the fallback path still surfaces as rc=143/137 rather than the `TIMEOUT_BIN` branch's 124 (`TIMED OUT` label / `WEDGED` marker) — pre-existing fallback semantics, deliberately unchanged here.

## Tests

Regression tests in both script suites force the fallback branch **hermetically on any host** (CI's Linux images ship `timeout`, so the fallback would otherwise stay untested there): each test runs the real wrapper under a curated symlink PATH containing every tool the scripts call *except* `gtimeout`/`timeout`.

- `test/scripts/run-verify-parallel.test.ts` — real dispatcher from a tempdir copy with a stubbed `bun` (all 31 checks complete instantly, no repo needed): pins exit 0 + every sentinel `0` when all checks pass, and exit 1 + the check's **own** rc surfaced (`--- check:jsonb (rc=7)`, sentinel `7`, log tail shown) when one fails.
- `test/scripts/run-unit-parallel.test.ts` — real wrapper, real `bun`, two-shard fixture runs: pins `rc=0` sentinels + exit 0 on a green run, and a failing shard recorded as its own `rc=1` (not 143) with failure-log extraction intact.

All four fail against master (every sentinel asserts 143) and pass with the fix; the ten pre-existing tests in these two files are untouched and stay green.

## Verification

- `bun run verify`: 31/31 green on this branch (the `gtimeout` path, 18s) — and, via the new regression tests, green on the fallback path too.
- Unit suite (`bash scripts/run-unit-parallel.sh`, 4 shards): 9,751 pass / 18 skip, with 8 failures + one shard wedge — all environment-dependent on my machine (it hosts a live gbrain install: registered workers, ambient config, network assumptions) and none attributable to this change:
  - the four files that still fail run solo (`retrieval-reflex`, `brain-durability-hook.serial`, `hybrid-meta.serial`, `worker-registry.serial`; one test each) fail **identically on unpatched master @ 5008b287**, measured solo side-by-side;
  - the remaining failures (`commands/capture` ×4, `brain-repo-durability.serial` ×1) pass solo on this branch — full-suite load sensitivity only;
  - the wedged shard is the PGLite-contention flake the shard-clamp comment in `run-unit-parallel.sh` documents; the same shard rerun solo passes 3,671/3,672 across 239 files, the single failure being the same master-identical `retrieval-reflex` test. The wedge run also shows the `TIMEOUT_BIN` path still reports 124 → `WEDGED` correctly with this change.
- `bun run test:slow`: 41/41 pass.
- E2E: skipped (no `DATABASE_URL`) per the `test:full` script's documented skip path.
- Engine coverage: N/A — dev-tooling shell scripts only; no engine or runtime code touched (postgres-engine/pglite-engine behavior unaffected by construction).
- eval replay: not triggered — the diff touches none of the CONTRIBUTING-listed retrieval trigger paths.
