### PR TITLE
write-through: honor GBRAIN_REPO_PATH env override + warn on skipped writes

### DIFF
--- a/src/core/write-through.ts
+++ b/src/core/write-through.ts
@@ -67,11 +67,26 @@ export async function writePageThrough(
 ): Promise<WriteThroughResult> {
   const sourceId = opts.sourceId ?? 'default';
   try {
-    const repoPath = await engine.getConfig('sync.repo_path');
+    // GBRAIN_REPO_PATH env var overrides the `sync.repo_path` config global.
+    // When two machines share one Postgres brain, `sync.repo_path` is a single
+    // row that cannot be a valid filesystem path on both hosts — and
+    // `gbrain import` rewrites it as a side effect, so whichever machine
+    // imported last silently breaks write-through on the other (every capture
+    // returns written:false / repo_not_found with no signal). A host-local env
+    // override pins the hub repo per machine. Skips below also warn through
+    // the logger instead of staying silent, so path drift is loud.
+    const repoPath =
+      process.env.GBRAIN_REPO_PATH || (await engine.getConfig('sync.repo_path'));
     if (!repoPath) {
+      opts.logger?.warn(
+        `[write-through] skipped for ${slug}: no repo configured (GBRAIN_REPO_PATH unset and sync.repo_path unset) — DB-only write`,
+      );
       return { written: false, skipped: 'no_repo_configured' };
     }
     if (!existsSync(repoPath) || !statSync(repoPath).isDirectory()) {
+      opts.logger?.warn(
+        `[write-through] skipped for ${slug}: repo path '${repoPath}' missing or not a directory on this host — DB-only write`,
+      );
       return { written: false, skipped: 'repo_not_found' };
     }
 


### PR DESCRIPTION
## Problem

`sync.repo_path` is a single config row. On a multi-machine brain sharing one Postgres, it cannot be a valid filesystem path on every host — and `gbrain import` rewrites it as a side effect (`src/commands/import.ts`), so whichever machine imported last silently breaks write-through on every other machine: captures return `written:false` / `repo_not_found` with no signal, and the brain quietly degrades to DB-only rows.

Hit in production: a `gbrain import` on machine A repointed the global to an A-only path; a week of captures on machine B went DB-only before anyone noticed (the receipt field was the only trace).

## Fix

- `GBRAIN_REPO_PATH` env var takes precedence over the `sync.repo_path` global in `writePageThrough`, so each host can pin its own hub repo.
- The `no_repo_configured` / `repo_not_found` skips now warn through the existing logger instead of returning silently, so path drift is loud instead of invisible.

No behavior change when the env var is unset and the configured path resolves.