### PR TITLE
fix(sync): never delete put_page pages under pruned dirs on incremental sync

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1885,7 +1885,13 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   const pageOpts = opts.sourceId ? { sourceId: opts.sourceId } : undefined;
   for (const path of unsyncableModified) {
     // v0.41.13 #1433: never delete on metafile classification.
-    if (unsyncableReason(path, syncOpts) === 'metafile') continue;
+    // Same for pruned-dir. A path under a pruned segment (`ops/`,
+    // `node_modules/`, dot-dirs) was NEVER sync-eligible, so any page at
+    // that slug necessarily came from put_page — deleting it when the file
+    // is edited orphans the page and sync can never bring it back.
+    // Tripped in production when a merge-write edited an ops/** page file.
+    const reason = unsyncableReason(path, syncOpts);
+    if (reason === 'metafile' || reason === 'pruned-dir') continue;
     const slug = await resolveSlugByPathOrSourcePath(engine, path, opts.sourceId);
     try {
       const existing = await engine.getPage(slug, pageOpts);

--- a/test/sync-metafile-skip.serial.test.ts
+++ b/test/sync-metafile-skip.serial.test.ts
@@ -133,10 +133,64 @@ describe('#1433 — re-sync preserves previously-indexed metafile pages', () => 
     expect(survivor).not.toBeNull();
   }, 60_000);
 
+  test('ops/** page indexed via direct putPage survives re-sync after file edit (pruned-dir guard)', async () => {
+    // Bug class: `ops` is in PRUNE_DIR_NAMES, so
+    // ops/** files are never sync-eligible and ops pages exist only via
+    // put_page (whose write-through still lands a file in the repo). The
+    // capture pipeline's merge-write edits that file; pre-fix, the next
+    // incremental sync classified it "modified but unsyncable" and deleted
+    // the page — reason 'pruned-dir' wasn't covered by the #1433 guard.
+    writeFileSync(join(repoPath, 'ops.md'), 'placeholder so ops/ dir exists in git\n');
+    mkdirSync(join(repoPath, 'ops/design-history'), { recursive: true });
+    writeFileSync(join(repoPath, 'ops/design-history/strategy.md'), [
+      '---',
+      'type: note',
+      'title: Strategy',
+      '---',
+      '',
+      'Historical design doc.',
+    ].join('\n'));
+    execSync('git add -A && git commit -m "add ops page file"', { cwd: repoPath, stdio: 'pipe' });
+
+    const { performSync } = await import('../src/commands/sync.ts');
+    await performSync(engine, { repoPath, full: true, noPull: true, noEmbed: true });
+
+    // Seed the page directly — the only way ops/** pages come to exist.
+    await engine.putPage('ops/design-history/strategy', {
+      type: 'note',
+      title: 'Strategy',
+      compiled_truth: 'Pre-existing ops page that should survive re-sync.',
+      timeline: '',
+      frontmatter: { type: 'note' },
+    });
+    expect(await engine.getPage('ops/design-history/strategy')).not.toBeNull();
+
+    // Simulate the capture merge-write: append a source note to the file.
+    writeFileSync(join(repoPath, 'ops/design-history/strategy.md'), [
+      '---',
+      'type: note',
+      'title: Strategy',
+      '---',
+      '',
+      'Historical design doc.',
+      '',
+      '## Source notes',
+      '- 2026-07-16: "a captured fact" [via: capture 2026-07-16]',
+    ].join('\n'));
+    execSync('git add -A && git commit -m "capture merge-write"', { cwd: repoPath, stdio: 'pipe' });
+
+    await performSync(engine, { repoPath, noPull: true, noEmbed: true });
+
+    // IRON RULE: the page survives the edit.
+    const survivor = await engine.getPage('ops/design-history/strategy');
+    expect(survivor).not.toBeNull();
+    expect(survivor?.compiled_truth).toContain('Pre-existing ops page');
+  }, 60_000);
+
   test('non-metafile that becomes un-syncable (renamed .md → .txt) IS still cleaned up', async () => {
-    // Negative case: prove the guard is narrow — it only protects
-    // metafile classification, not the broader "this page used to be
-    // sync-eligible but isn't anymore" case.
+    // Negative case: prove the guard is narrow — it only protects the
+    // metafile and pruned-dir classifications, not the broader "this page
+    // used to be sync-eligible but isn't anymore" case.
     const { performSync } = await import('../src/commands/sync.ts');
     await performSync(engine, { repoPath, full: true, noPull: true, noEmbed: true });
 


### PR DESCRIPTION
Extends the v0.41.13 #1433 never-delete-on-metafile guard to the `pruned-dir` classification.

## The bug

A path under a pruned segment (`PRUNE_DIR_NAMES`: `ops/`, `node_modules/`, dot-dirs) is never sync-eligible, so a page at such a slug can only have come from `put_page` — whose write-through still lands a file in the brain repo. When anything edits that file (e.g. a merge-write appending source notes), the next incremental sync classifies it "modified but unsyncable" and **deletes the page from the index**. Sync can never re-create what it deletes there, so the page is orphaned permanently.

We tripped this in production: an `ops/design-history/*` page (created via `put_page`, later edited on disk) was deleted by the following incremental sync and had to be restored by hand.

## The fix

One line: the #1433 guard already skips deletion for the `metafile` classification; skip `pruned-dir` too.

## Tests

New regression test in `test/sync-metafile-skip.serial.test.ts` — red on the old code, green with the fix; the narrow-guard negative case (strategy-reason cleanup still deletes) still passes. `bun run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
