### PR TITLE
feat(sync): per-source keep_dirs — exempt named dot-dirs from the sync prune

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -45,7 +45,7 @@ export interface RunImportResult {
 export async function runImport(
   engine: BrainEngine,
   args: string[],
-  opts: { commit?: string; strategy?: SyncStrategy; sourceId?: string; managedBookmark?: boolean } = {},
+  opts: { commit?: string; strategy?: SyncStrategy; sourceId?: string; managedBookmark?: boolean; keepDirs?: string[] } = {},
 ): Promise<RunImportResult> {
   const noEmbed = args.includes('--no-embed');
   const fresh = args.includes('--fresh');
@@ -176,7 +176,7 @@ export async function runImport(
   const strategy: SyncStrategy = opts.strategy ?? 'markdown';
   const _walkT0 = Date.now();
   console.error(`[gbrain phase] import.collect_files start dir=${dir} strategy=${strategy}`);
-  const allFiles = collectSyncableFiles(dir, { strategy });
+  const allFiles = collectSyncableFiles(dir, { strategy, keepDirs: opts.keepDirs });
   console.error(
     `[gbrain phase] import.collect_files done ${Date.now() - _walkT0}ms files=${allFiles.length}`,
   );
@@ -485,6 +485,14 @@ function resolveMaxWalkDepth(): number {
 
 interface CollectOpts {
   strategy?: SyncStrategy;
+  /**
+   * Directory segment names exempted from the `pruneDir` descent prune
+   * (per-source `config.keep_dirs`, e.g. `['.agents']`). Only affects the
+   * recursive FS-walk fallback — the `git ls-files` fast path already
+   * enumerates tracked dot-dir files and is filtered downstream by
+   * `isSyncable({keepDirs})` in the sync classifier.
+   */
+  keepDirs?: string[];
 }
 
 /**
@@ -611,7 +619,8 @@ export function collectSyncableFiles(dir: string, opts: CollectOpts = {}): strin
       // in core/sync.ts) instead of a hand-maintained inline list that drifted
       // from it. Skips hidden dirs (`.git`, `.raw`, etc.), `node_modules`,
       // `vendor`, `dist`, `build`, `venv` (#2020), `ops`, and git submodules.
-      if (!pruneDir(entry, d)) continue;
+      // Per-source `keep_dirs` exempts named segments (e.g. `.agents`).
+      if (!pruneDir(entry, d) && !opts.keepDirs?.includes(entry)) continue;
 
       const full = join(d, entry);
       let stat;

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -16,6 +16,8 @@
  *   gbrain sources detach        — remove .gbrain-source from CWD
  *   gbrain sources federate <id>   — sources.config.federated = true
  *   gbrain sources unfederate <id> — sources.config.federated = false
+ *   gbrain sources keep-dirs <id> [dir ...] [--clear] — sources.config.keep_dirs
+ *       (dot-dir prune exemptions for sync, e.g. `.agents`)
  *
  * NOT in scope for Step 6 (deferred per plan):
  *   - import-from-github (needs SSRF + clone integration)
@@ -729,6 +731,68 @@ async function runFederate(engine: BrainEngine, args: string[], value: boolean):
   }
 }
 
+/**
+ * gbrain sources keep-dirs <id> [dir ...] — per-source sync.keep_dirs.
+ *
+ * Sync's walker/classifier prunes dot-directories (`.agents`, `.claude`, …)
+ * and vendor dirs unconditionally; `config.keep_dirs` exempts the named
+ * directory SEGMENTS for this source so e.g. a repo's `.agents/*.md` policy
+ * docs sync as pages. Files under a kept dir still pass every other gate
+ * (strategy, metafile, include/exclude globs).
+ *
+ *   keep-dirs <id>              show current list
+ *   keep-dirs <id> <dir ...>    replace the list
+ *   keep-dirs <id> --clear      remove the setting
+ */
+async function runKeepDirs(engine: BrainEngine, args: string[]): Promise<void> {
+  const id = args[0];
+  if (!id) {
+    console.error('Usage: gbrain sources keep-dirs <id> [dir ...] [--clear]');
+    process.exit(2);
+  }
+  const src = await fetchSource(engine, id);
+  if (!src) {
+    console.error(`Source "${id}" not found.`);
+    process.exit(4);
+  }
+  const config = parseConfig(src.config);
+  const clear = args.includes('--clear');
+  const dirs = args.slice(1).filter((a) => !a.startsWith('--'));
+
+  if (!clear && dirs.length === 0) {
+    const current = Array.isArray(config.keep_dirs) ? (config.keep_dirs as string[]) : [];
+    console.log(current.length ? current.join(' ') : '(none)');
+    return;
+  }
+
+  if (clear) {
+    delete config.keep_dirs;
+  } else {
+    // Segment names only — keep_dirs matches single path segments, same
+    // granularity as pruneDir. A slash means the caller expected glob/path
+    // semantics this knob doesn't have; refuse loudly instead of silently
+    // never matching.
+    const bad = dirs.filter((d) => d.includes('/'));
+    if (bad.length) {
+      console.error(
+        `keep-dirs entries are directory NAMES, not paths/globs (got: ${bad.join(', ')}). ` +
+          `Use the segment name, e.g. ".agents".`,
+      );
+      process.exit(2);
+    }
+    config.keep_dirs = dirs;
+  }
+  await engine.executeRaw(
+    `UPDATE sources SET config = $1::text::jsonb WHERE id = $2`,
+    [JSON.stringify(config), id],
+  );
+  console.log(
+    clear
+      ? `Source "${id}" keep_dirs cleared.`
+      : `Source "${id}" keep_dirs = [${dirs.join(', ')}]. Takes effect on the next sync; run 'gbrain sync --source ${id}' to pick the dirs up.`,
+  );
+}
+
 // ── v0.40 sources status (D12) ──────────────────────────────
 async function runStatus(engine: BrainEngine, args: string[]): Promise<void> {
   const json = args.includes('--json');
@@ -1317,6 +1381,7 @@ export async function runSources(engine: BrainEngine, args: string[]): Promise<v
     case 'detach':     runDetach(); return;
     case 'federate':   return runFederate(engine, rest, true);
     case 'unfederate': return runFederate(engine, rest, false);
+    case 'keep-dirs':  return runKeepDirs(engine, rest);
     case 'archive':    return runArchive(engine, rest);
     case 'restore':    return runRestore(engine, rest);
     case 'purge':      return runPurge(engine, rest);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -743,6 +743,14 @@ export interface SyncOpts {
   /** Multi-repo: sync strategy override (markdown, code, auto). */
   strategy?: 'markdown' | 'code' | 'auto';
   /**
+   * Directory segment names exempted from the dot-dir/vendor prune
+   * (e.g. `['.agents']`). Normally NOT passed by callers — performSyncInner
+   * hoists it from the source row's `config.keep_dirs` so every entry path
+   * (single-source CLI, --all fan-out, jobs handler, watch) honors it.
+   * Set with `gbrain sources keep-dirs <id> <dir ...>`.
+   */
+  keepDirs?: string[];
+  /**
    * Number of parallel workers for the import phase. When > 1, each worker
    * gets its own small Postgres connection pool and files are dispatched via
    * an atomic queue index (same pattern as `import --workers N`).
@@ -1522,6 +1530,15 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       typeof cfgRows[0]?.config === 'string'
         ? (JSON.parse(cfgRows[0].config as string) as Record<string, unknown>)
         : ((cfgRows[0]?.config ?? {}) as Record<string, unknown>);
+    // Hoist per-source keep_dirs (set via `gbrain sources keep-dirs`) into
+    // opts at this single choke point so every entry path — single-source
+    // CLI, --all fan-out, jobs handler, watch — honors it without each one
+    // re-reading the source row. An explicit opts.keepDirs (tests) wins.
+    if (!opts.keepDirs && Array.isArray(cfg.keep_dirs)) {
+      opts.keepDirs = (cfg.keep_dirs as unknown[]).filter(
+        (s): s is string => typeof s === 'string' && s.length > 0,
+      );
+    }
     const remoteUrl = typeof cfg.remote_url === 'string' ? cfg.remote_url : null;
     if (remoteUrl) {
       const ownSrc = {
@@ -1835,8 +1852,10 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   }
   const manifest = delta.manifest;
 
-  // Filter to syncable files (strategy-aware)
-  const syncOpts = opts.strategy ? { strategy: opts.strategy } : undefined;
+  // Filter to syncable files (strategy-aware; keep_dirs-aware)
+  const syncOpts = (opts.strategy || opts.keepDirs)
+    ? { strategy: opts.strategy, keepDirs: opts.keepDirs }
+    : undefined;
   // #1970 (F-C): a rename whose DESTINATION is unsyncable drops out of BOTH
   // `renamed` (only `r.to` is kept below) AND `deleted` (git emits it as `R`,
   // not `D`), leaving the OLD page stale. Fold the source side into the delete
@@ -2965,7 +2984,7 @@ async function performFullSync(
   // code --dry-run` always reported zero files even when ~1500 code
   // files were waiting.
   if (opts.dryRun) {
-    const allFiles = collectSyncableFiles(repoPath, { strategy: opts.strategy ?? 'markdown' });
+    const allFiles = collectSyncableFiles(repoPath, { strategy: opts.strategy ?? 'markdown', keepDirs: opts.keepDirs });
     slog(
       `Full-sync dry run (strategy=${opts.strategy ?? 'markdown'}): ` +
       `${allFiles.length} file(s) would be imported ` +
@@ -3006,6 +3025,7 @@ async function performFullSync(
   const result = await runImport(engine, importArgs, {
     commit: headCommit,
     strategy: opts.strategy,
+    keepDirs: opts.keepDirs,
     sourceId: opts.sourceId,
     // issue #1939: performFullSync owns the failure ledger + bookmark via the
     // shared gate below; don't let runImport double-record or write its own.
@@ -3104,13 +3124,15 @@ async function performFullSync(
   let reconciledDeletes = 0;
   if (opts.sourceId) {
     const sid = opts.sourceId;
-    const reconcileSyncOpts = opts.strategy ? { strategy: opts.strategy } : undefined;
+    const reconcileSyncOpts = (opts.strategy || opts.keepDirs)
+      ? { strategy: opts.strategy, keepDirs: opts.keepDirs }
+      : undefined;
     // collectSyncableFiles returns ABSOLUTE paths; source_path is stored
     // repo-relative (importFile uses `relative(dir, filePath)`), so relativize
     // to the same form before membership-testing — otherwise every page looks
     // stale and the reconcile would wrongly delete live pages.
     const current = new Set(
-      collectSyncableFiles(repoPath, { strategy: opts.strategy ?? 'markdown' })
+      collectSyncableFiles(repoPath, { strategy: opts.strategy ?? 'markdown', keepDirs: opts.keepDirs })
         .map(abs => relative(repoPath, abs)),
     );
     const rows = await engine.executeRaw<{ slug: string; source_path: string | null }>(

--- a/src/core/sync.ts
+++ b/src/core/sync.ts
@@ -37,6 +37,15 @@ interface SyncableOptions {
   strategy?: SyncStrategy;
   include?: string[];
   exclude?: string[];
+  /**
+   * Directory segment names exempted from the `pruneDir` dot-dir/vendor
+   * exclusion (e.g. `['.agents']` to sync a repo's `.agents/*.md` policy
+   * docs). Sourced from the per-source `config.keep_dirs` array; matched
+   * at single-segment granularity, same as `pruneDir` itself. Files under
+   * a kept dir still pass every OTHER gate (strategy, metafile,
+   * include/exclude globs) — this only lifts the descent/segment prune.
+   */
+  keepDirs?: string[];
 }
 
 // v0.19.0 shipped a 9-extension allowlist (ts/tsx/js/jsx/mjs/cjs/py/rb/go). The
@@ -346,8 +355,15 @@ function classifySync(path: string, opts: SyncableOptions = {}): SyncableReason 
   // Skip every path segment that pruneDir would block walkers from descending
   // into. Catches hidden dirs (`.git`, `.obsidian`), `.raw/` sidecars,
   // `node_modules/` (latent bug fix), and `ops/` at any depth.
+  // Per-source `keep_dirs` (opts.keepDirs) exempts named segments from the
+  // prune — the FILE segment is never exempted (a keep_dirs entry names a
+  // directory, not a file), so `.agents` in keepDirs admits `.agents/x.md`
+  // without also admitting a file literally named `.agents`.
   const segments = path.split('/');
-  if (segments.some(p => !pruneDir(p))) return 'pruned-dir';
+  const keep = opts.keepDirs;
+  const kept = (p: string, i: number) =>
+    !!keep && i < segments.length - 1 && keep.includes(p);
+  if (segments.some((p, i) => !pruneDir(p) && !kept(p, i))) return 'pruned-dir';
 
   // Skip meta files that aren't pages
   const basename = segments[segments.length - 1] || '';

--- a/test/sync-strategy.test.ts
+++ b/test/sync-strategy.test.ts
@@ -62,6 +62,23 @@ describe('isSyncable with strategy', () => {
     expect(isSyncable('dir/.raw/code.ts', { strategy: 'code' })).toBe(false);
   });
 
+  test('keepDirs exempts named dot-dirs from the prune, nothing else', () => {
+    // The motivating case: a repo's .agents/*.md policy docs.
+    expect(isSyncable('.agents/AGENTS.md')).toBe(false);
+    expect(isSyncable('.agents/AGENTS.md', { keepDirs: ['.agents'] })).toBe(true);
+    expect(isSyncable('.agents/nested/notes.md', { keepDirs: ['.agents'] })).toBe(true);
+    // Only the LISTED segment is exempted — other pruned dirs stay pruned.
+    expect(isSyncable('.claude/skills/x.md', { keepDirs: ['.agents'] })).toBe(false);
+    expect(isSyncable('node_modules/pkg/readme-notes.md', { keepDirs: ['.agents'] })).toBe(false);
+    // A pruned segment BELOW a kept dir still prunes.
+    expect(isSyncable('.agents/.git/config.md', { keepDirs: ['.agents'] })).toBe(false);
+    // Every other gate still applies under a kept dir.
+    expect(isSyncable('.agents/README.md', { keepDirs: ['.agents'] })).toBe(false); // metafile
+    expect(isSyncable('.agents/tool.ts', { keepDirs: ['.agents'] })).toBe(false); // strategy
+    // A FILE named like the kept dir is not admitted (keep_dirs names dirs).
+    expect(isSyncable('.agents', { keepDirs: ['.agents'] })).toBe(false);
+  });
+
   test('include globs whitelist specific patterns', () => {
     expect(isSyncable('src/foo.ts', { strategy: 'code', include: ['src/**/*.ts'] })).toBe(true);
     expect(isSyncable('lib/bar.ts', { strategy: 'code', include: ['src/**/*.ts'] })).toBe(false);


### PR DESCRIPTION
## Problem

`pruneDir` unconditionally excludes dot-directories, so a repo's `.agents/*.md` / `.claude/skills/**` policy docs can never sync as pages. Worse, the two enumeration paths disagree about it:

- the **first-sync `git ls-files` fast path** filters by extension only, so tracked dot-dir markdown IS imported;
- the **incremental classifier** (`classifySync`) prunes those same paths, so the first time such a file is modified, sync **deletes the page** as "un-syncable".

Observed live: a sync deleted `.agents/agents`, `.agents/claude`, and two `.claude/skills/*/skill` pages that the initial sync had itself imported.

The existing `include` option can't express this — it's a restrictive allowlist (checked after the prune anyway), so `include: ['.agents/**']` would drop every *other* page as `include-glob-miss`.

## Fix

New per-source **`config.keep_dirs`** — directory segment names exempted from the prune:

- `classifySync` skips the `pruned-dir` rejection for listed segments (file segment never exempted; every other gate — strategy, metafile, include/exclude globs — still applies, and a pruned segment *below* a kept dir still prunes, so `.agents/.git/x.md` stays out).
- `collectSyncableFiles` FS-walk fallback descends into kept dirs (git fast path already enumerates them).
- `performSyncInner` hoists the setting from the source row at one choke point, so single-source CLI, `--all` fan-out, jobs handler, and watch all honor it without each caller re-reading config.
- New CLI: `gbrain sources keep-dirs <id> [dir ...] [--clear]` (mirrors `federate`'s config-flip shape). Entries are segment names, not globs — a `/` is refused loudly.

## Usage

```
gbrain sources keep-dirs my-repo .agents .claude
gbrain sync --source my-repo --full   # restore previously-deleted pages
```

## Testing

- New `keepDirs` block in `test/sync-strategy.test.ts` (kept-dir admitted, unlisted dot-dirs still pruned, metafile/strategy gates still apply, nested prune below a kept dir, file-named-like-dir not admitted) — 17 pass.
- `bun run verify` — all 30 checks green.
- Live-verified on a real source: pages restored by `--full`, and a subsequent incremental sync no longer deletes them on modification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
