### PR TITLE
fix(health): distinguish zero entity coverage from no entities

### DIFF
--- a/src/core/pglite-engine.ts
+++ b/src/core/pglite-engine.ts
@@ -5027,6 +5027,7 @@ export class PGLiteEngine implements BrainEngine {
       )
       SELECT
         (SELECT count(*) FROM pages) as page_count,
+        (SELECT count(*) FROM entity_pages) as entity_page_count,
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NOT NULL)::float /
           GREATEST((SELECT count(*) FROM content_chunks), 1)::float as embed_coverage,
         (SELECT count(*) FROM pages p
@@ -5049,7 +5050,13 @@ export class PGLiteEngine implements BrainEngine {
           GREATEST((SELECT count(*) FROM entity_pages), 1)::float as link_coverage,
         (SELECT count(*) FROM entity_pages e
          WHERE EXISTS (SELECT 1 FROM timeline_entries te WHERE te.page_id = e.id))::float /
-          GREATEST((SELECT count(*) FROM entity_pages), 1)::float as timeline_coverage
+          GREATEST((SELECT count(*) FROM entity_pages), 1)::float as timeline_coverage,
+        (SELECT count(*) FROM entity_pages e
+         WHERE EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = e.id))::float /
+          NULLIF((SELECT count(*) FROM entity_pages), 0)::float as entity_link_coverage,
+        (SELECT count(*) FROM entity_pages e
+         WHERE EXISTS (SELECT 1 FROM timeline_entries te WHERE te.page_id = e.id))::float /
+          NULLIF((SELECT count(*) FROM entity_pages), 0)::float as entity_timeline_coverage
     `);
 
     // Top 5 most connected entities by total link count (in + out).
@@ -5069,6 +5076,13 @@ export class PGLiteEngine implements BrainEngine {
     const deadLinks = Number(r.dead_links);
     const linkCount = Number(r.link_count);
     const pagesWithTimeline = Number(r.pages_with_timeline);
+    const entityPageCount = Number(r.entity_page_count);
+    const entityLinkCoverage = r.entity_link_coverage == null ? null : Number(r.entity_link_coverage);
+    const entityTimelineCoverage = r.entity_timeline_coverage == null ? null : Number(r.entity_timeline_coverage);
+    const mostConnected = (connected as { slug: string; link_count: number }[]).map(c => ({
+      slug: c.slug,
+      link_count: Number(c.link_count),
+    }));
 
     const linkDensity = pageCount > 0 ? Math.min(linkCount / pageCount, 1) : 0;
     const timelineCoverageDensity = pageCount > 0 ? Math.min(pagesWithTimeline / pageCount, 1) : 0;
@@ -5100,10 +5114,11 @@ export class PGLiteEngine implements BrainEngine {
       dead_links: deadLinks,
       link_coverage: Number(r.link_coverage),
       timeline_coverage: Number(r.timeline_coverage),
-      most_connected: (connected as { slug: string; link_count: number }[]).map(c => ({
-        slug: c.slug,
-        link_count: Number(c.link_count),
-      })),
+      most_connected: mostConnected,
+      entity_page_count: entityPageCount,
+      entity_link_coverage: entityLinkCoverage,
+      entity_timeline_coverage: entityTimelineCoverage,
+      most_connected_entities: mostConnected,
       embed_coverage_score: embedCoverageScore,
       link_density_score: linkDensityScore,
       timeline_coverage_score: timelineCoverageScore,

--- a/src/core/postgres-engine.ts
+++ b/src/core/postgres-engine.ts
@@ -5011,6 +5011,7 @@ export class PostgresEngine implements BrainEngine {
       )
       SELECT
         (SELECT count(*) FROM pages) as page_count,
+        (SELECT count(*) FROM entity_pages) as entity_page_count,
         (SELECT count(*) FROM content_chunks WHERE embedded_at IS NOT NULL)::float /
           GREATEST((SELECT count(*) FROM content_chunks), 1)::float as embed_coverage,
         (SELECT count(*) FROM pages p
@@ -5031,7 +5032,13 @@ export class PostgresEngine implements BrainEngine {
           GREATEST((SELECT count(*) FROM entity_pages), 1)::float as link_coverage,
         (SELECT count(*) FROM entity_pages e
          WHERE EXISTS (SELECT 1 FROM timeline_entries te WHERE te.page_id = e.id))::float /
-          GREATEST((SELECT count(*) FROM entity_pages), 1)::float as timeline_coverage
+          GREATEST((SELECT count(*) FROM entity_pages), 1)::float as timeline_coverage,
+        (SELECT count(*) FROM entity_pages e
+         WHERE EXISTS (SELECT 1 FROM links l WHERE l.to_page_id = e.id))::float /
+          NULLIF((SELECT count(*) FROM entity_pages), 0)::float as entity_link_coverage,
+        (SELECT count(*) FROM entity_pages e
+         WHERE EXISTS (SELECT 1 FROM timeline_entries te WHERE te.page_id = e.id))::float /
+          NULLIF((SELECT count(*) FROM entity_pages), 0)::float as entity_timeline_coverage
     `;
 
     const connected = await sql`
@@ -5049,6 +5056,13 @@ export class PostgresEngine implements BrainEngine {
     const deadLinks = Number(h.dead_links);
     const linkCount = Number(h.link_count);
     const pagesWithTimeline = Number(h.pages_with_timeline);
+    const entityPageCount = Number(h.entity_page_count);
+    const entityLinkCoverage = h.entity_link_coverage == null ? null : Number(h.entity_link_coverage);
+    const entityTimelineCoverage = h.entity_timeline_coverage == null ? null : Number(h.entity_timeline_coverage);
+    const mostConnected = (connected as unknown as { slug: string; link_count: number }[]).map(c => ({
+      slug: c.slug,
+      link_count: Number(c.link_count),
+    }));
 
     // brain_score: 0-100 weighted average
     const linkDensity = pageCount > 0 ? Math.min(linkCount / pageCount, 1) : 0;
@@ -5080,10 +5094,11 @@ export class PostgresEngine implements BrainEngine {
       dead_links: deadLinks,
       link_coverage: Number(h.link_coverage),
       timeline_coverage: Number(h.timeline_coverage),
-      most_connected: (connected as unknown as { slug: string; link_count: number }[]).map(c => ({
-        slug: c.slug,
-        link_count: Number(c.link_count),
-      })),
+      most_connected: mostConnected,
+      entity_page_count: entityPageCount,
+      entity_link_coverage: entityLinkCoverage,
+      entity_timeline_coverage: entityTimelineCoverage,
+      most_connected_entities: mostConnected,
       embed_coverage_score: embedCoverageScore,
       link_density_score: linkDensityScore,
       timeline_coverage_score: timelineCoverageScore,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1432,6 +1432,16 @@ export interface BrainHealth {
   timeline_coverage: number;
   /** Top 5 entities by total link count (in + out). */
   most_connected: Array<{ slug: string; link_count: number }>;
+  /** Additive contract fields with explicit naming for entity-scoped metrics.
+   *
+   * `entity_page_count` is the denominator used for all entity-scoped metrics.
+   * `entity_link_coverage` / `entity_timeline_coverage` are explicit aliases
+   * that are null when no entities are present.
+   */
+  entity_page_count?: number;
+  entity_link_coverage?: number | null;
+  entity_timeline_coverage?: number | null;
+  most_connected_entities?: Array<{ slug: string; link_count: number }>;
   /**
    * Per-component contribution to brain_score. Sum equals brain_score by
    * construction. Displayed by `gbrain doctor` when brain_score < 100.

--- a/test/e2e/get-health-entity-aliases-postgres.test.ts
+++ b/test/e2e/get-health-entity-aliases-postgres.test.ts
@@ -39,6 +39,8 @@ describeIf('Postgres get_health entity coverage aliases', () => {
     expect(health.timeline_coverage).toBe(0);
     expect(health.entity_link_coverage).toBeNull();
     expect(health.entity_timeline_coverage).toBeNull();
+    expect(health.most_connected).toEqual([]);
+    expect(health.most_connected_entities).toEqual([]);
   });
 
   test('entity-present health aliases match legacy values', async () => {
@@ -60,6 +62,12 @@ describeIf('Postgres get_health entity coverage aliases', () => {
     });
 
     await engine.addLink('people/alice', 'companies/acme', '', 'works_at');
+    await engine.putPage('notes/brief', {
+      type: 'note',
+      title: 'Brief',
+      compiled_truth: 'A plain note for a non-entity target.',
+    });
+    await engine.addLink('companies/acme', 'notes/brief', '', 'mentions');
 
     const health = await engine.getHealth();
 
@@ -70,5 +78,8 @@ describeIf('Postgres get_health entity coverage aliases', () => {
     expect(health.entity_timeline_coverage).toBe(0);
     expect(health.entity_link_coverage).toBe(health.link_coverage);
     expect(health.entity_timeline_coverage).toBe(health.timeline_coverage);
+    expect(health.most_connected_entities).toEqual(health.most_connected);
+    expect(health.most_connected_entities[0]?.slug).toBe('companies/acme');
+    expect(health.most_connected_entities[0]?.link_count).toBe(2);
   });
 });

--- a/test/e2e/get-health-entity-aliases-postgres.test.ts
+++ b/test/e2e/get-health-entity-aliases-postgres.test.ts
@@ -1,8 +1,8 @@
 /**
- * v0.42 E2E (real Postgres): verify legacy entity health metrics versus
- * explicit entity aliases.
- *
- * Run: DATABASE_URL=... bun test test/e2e/get-health-entity-aliases-postgres.test.ts
+ * [test] 2026-07-16
+ * Context: Validate Postgres health reporting where entity health coverage is exposed through explicit aliases without breaking legacy behavior.
+ * Invariant: Health is still zero/null when no entities exist, and coverage aliases remain equal to legacy link/timeline coverage when entities are present.
+ * Rejected alternative: Added no widened PGLite/unit path because that would not execute the real Postgres SQL path where this regression is observable.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';

--- a/test/e2e/get-health-entity-aliases-postgres.test.ts
+++ b/test/e2e/get-health-entity-aliases-postgres.test.ts
@@ -1,0 +1,74 @@
+/**
+ * v0.42 E2E (real Postgres): verify legacy entity health metrics versus
+ * explicit entity aliases.
+ *
+ * Run: DATABASE_URL=... bun test test/e2e/get-health-entity-aliases-postgres.test.ts
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { hasDatabase, setupDB, teardownDB, getEngine } from './helpers.ts';
+
+const skip = !hasDatabase();
+const describeIf = skip ? describe.skip : describe;
+
+if (skip) {
+  console.log('Skipping Postgres get_health entity alias tests (DATABASE_URL not set)');
+}
+
+describeIf('Postgres get_health entity coverage aliases', () => {
+  beforeEach(async () => {
+    await setupDB();
+  });
+
+  afterEach(async () => {
+    await teardownDB();
+  });
+
+  test('no entities keeps legacy zeroes and alias fields null', async () => {
+    const engine = getEngine();
+    await engine.putPage('concepts/health-fixture', {
+      type: 'concept',
+      title: 'Health fixture',
+      compiled_truth: 'No entity pages are present.',
+    });
+
+    const health = await engine.getHealth();
+
+    expect(health.entity_page_count).toBe(0);
+    expect(health.link_coverage).toBe(0);
+    expect(health.timeline_coverage).toBe(0);
+    expect(health.entity_link_coverage).toBeNull();
+    expect(health.entity_timeline_coverage).toBeNull();
+  });
+
+  test('entity-present health aliases match legacy values', async () => {
+    const engine = getEngine();
+    await engine.putPage('people/alice', {
+      type: 'person',
+      title: 'Alice',
+      compiled_truth: 'Alice is a person.',
+    });
+    await engine.putPage('people/bob', {
+      type: 'person',
+      title: 'Bob',
+      compiled_truth: 'Bob is a person.',
+    });
+    await engine.putPage('companies/acme', {
+      type: 'company',
+      title: 'Acme',
+      compiled_truth: 'Acme is a company.',
+    });
+
+    await engine.addLink('people/alice', 'companies/acme', '', 'works_at');
+
+    const health = await engine.getHealth();
+
+    expect(health.entity_page_count).toBe(3);
+    expect(health.link_coverage).toBeCloseTo(1 / 3, 2);
+    expect(health.timeline_coverage).toBe(0);
+    expect(health.entity_link_coverage).toBeCloseTo(1 / 3, 2);
+    expect(health.entity_timeline_coverage).toBe(0);
+    expect(health.entity_link_coverage).toBe(health.link_coverage);
+    expect(health.entity_timeline_coverage).toBe(health.timeline_coverage);
+  });
+});

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -1286,6 +1286,9 @@ describe('PGLiteEngine: getHealth graph metrics', () => {
     await engine.addLink('people/alice', 'companies/acme', '', 'works_at');
     await engine.addLink('people/bob', 'companies/acme', '', 'invested_in');
     const h = await engine.getHealth();
+    if (h.most_connected_entities == null) {
+      throw new Error('Expected most_connected_entities alias to be populated');
+    }
     expect(h.most_connected.length).toBeGreaterThan(0);
     expect(h.most_connected_entities.length).toBeGreaterThan(0);
     expect(h.most_connected_entities).toEqual(h.most_connected);

--- a/test/pglite-engine.test.ts
+++ b/test/pglite-engine.test.ts
@@ -1270,12 +1270,16 @@ describe('PGLiteEngine: getHealth graph metrics', () => {
     await engine.addLink('people/alice', 'companies/acme', '', 'works_at');
     const h = await engine.getHealth();
     expect(h.link_coverage).toBeCloseTo(1 / 3, 2);
+    expect(h.entity_page_count).toBe(3);
+    expect(h.entity_link_coverage).toBeCloseTo(1 / 3, 2);
   });
 
   test('timeline_coverage = % with >= 1 timeline entry', async () => {
     await engine.addTimelineEntry('people/alice', { date: '2026-01-15', summary: 'Joined' });
     const h = await engine.getHealth();
     expect(h.timeline_coverage).toBeCloseTo(1 / 3, 2);
+    expect(h.entity_page_count).toBe(3);
+    expect(h.entity_timeline_coverage).toBeCloseTo(1 / 3, 2);
   });
 
   test('most_connected lists top entities by link count', async () => {
@@ -1283,8 +1287,23 @@ describe('PGLiteEngine: getHealth graph metrics', () => {
     await engine.addLink('people/bob', 'companies/acme', '', 'invested_in');
     const h = await engine.getHealth();
     expect(h.most_connected.length).toBeGreaterThan(0);
+    expect(h.most_connected_entities.length).toBeGreaterThan(0);
+    expect(h.most_connected_entities).toEqual(h.most_connected);
     expect(h.most_connected[0].slug).toBe('companies/acme');
     expect(h.most_connected[0].link_count).toBe(2);
+  });
+
+  test('legacy zero values stay when no entity pages exist', async () => {
+    await truncateAll();
+    await engine.putPage('concepts/note', { ...testPage, type: 'note', title: 'Note' });
+    const h = await engine.getHealth();
+
+    expect(h.entity_page_count).toBe(0);
+    expect(h.link_coverage).toBe(0);
+    expect(h.timeline_coverage).toBe(0);
+    expect(h.entity_link_coverage).toBeNull();
+    expect(h.entity_timeline_coverage).toBeNull();
+    expect(h.most_connected_entities).toEqual([]);
   });
 
   test('orphan_pages: pages with neither inbound nor outbound links', async () => {


### PR DESCRIPTION
## Summary
- preserve legacy link_coverage, timeline_coverage, and most_connected
- add explicit entity-scoped aliases plus entity_page_count
- return null on new coverage aliases when no person/company pages exist
- keep timeline extraction, scoring, schema, dependencies, and automation unchanged

## Why
JSON/MCP consumers currently see zero for entity-only coverage even when there are no eligible entity pages. The additive fields distinguish that state without breaking existing clients or inventing timeline events.

## Verification
- focused PGLite and brain-score tests: 138 passed, 0 failed
- real PostgreSQL health alias E2E: 2 passed, 0 failed
- TypeScript typecheck: passed
- Codex reviews: approved, Critical 0
- independent implementation audit: PASS, Critical 0
- full local CI could not start because host gitleaks is not installed; GitHub upstream does not auto-run checks for this fork PR

## Scope
No database migration, dependency, cron/service, score-weight change, effective-date rewrite, or timeline synthesis.