### PR TITLE
fix(sync): honor the embedding_disabled sentinel as implicit --no-embed

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -888,6 +888,25 @@ export function buildAutoEmbedArgs(slugs: string[], sourceId?: string): string[]
 }
 
 /**
+ * Resolve sync's effective no-embed mode from CLI args + config.
+ *
+ * The deferred-setup sentinel (`embedding_disabled: true`, written by
+ * `gbrain init --no-embedding`) is an implicit `--no-embed`: without this,
+ * the embed credential preflight demands provider credentials the user
+ * deliberately deferred at init, and every `gbrain sync` on a keyless
+ * brain exits 1. See embed-preflight.ts's skip protocol — the sentinel is
+ * meant to be honored before the credential check ever runs.
+ *
+ * Exported for `test/sync-no-embed-sentinel.test.ts`.
+ */
+export function resolveNoEmbed(
+  args: string[],
+  cfg: { embedding_disabled?: boolean } | null,
+): boolean {
+  return args.includes('--no-embed') || cfg?.embedding_disabled === true;
+}
+
+/**
  * Shell out to git with a generous maxBuffer.
  *
  * Node's default maxBuffer is 1 MiB.  `git diff --name-status -M` on a
@@ -3355,7 +3374,7 @@ See also:
   const dryRun = args.includes('--dry-run');
   const full = args.includes('--full');
   const noPull = args.includes('--no-pull');
-  const noEmbed = args.includes('--no-embed');
+  const noEmbed = resolveNoEmbed(args, loadConfig());
   const noExtract = args.includes('--no-extract'); // v0.42.7 #1696
   const skipFailed = args.includes('--skip-failed');
   const retryFailed = args.includes('--retry-failed');

--- a/test/sync-no-embed-sentinel.test.ts
+++ b/test/sync-no-embed-sentinel.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Deferred-setup sentinel → implicit --no-embed for `gbrain sync`.
+ *
+ * `gbrain init --no-embedding` writes `embedding_disabled: true` to
+ * config.json. init, import, and embed honor that sentinel via
+ * `assertEmbeddingEnabled`, but sync's embed credential preflight
+ * (v0.41.6.0 D1) only checked the `--no-embed` CLI flag — so every
+ * `gbrain sync` on a keyless deferred-setup brain exited 1 with
+ * "Embedding model ... requires <PROVIDER>_API_KEY", even when nothing
+ * needed embedding. embed-preflight.ts's own skip protocol says the
+ * sentinel is owned upstream of the credential check.
+ *
+ * Pure-function tests; no DB, no gateway state.
+ */
+import { describe, test, expect } from 'bun:test';
+import { resolveNoEmbed } from '../src/commands/sync.ts';
+
+describe('resolveNoEmbed', () => {
+  test('--no-embed flag opts out regardless of config', () => {
+    expect(resolveNoEmbed(['--no-embed'], null)).toBe(true);
+    expect(resolveNoEmbed(['--source', 's1', '--no-embed'], { embedding_disabled: false })).toBe(true);
+  });
+
+  test('embedding_disabled: true (deferred setup) is an implicit --no-embed', () => {
+    expect(resolveNoEmbed([], { embedding_disabled: true })).toBe(true);
+    expect(resolveNoEmbed(['--strategy', 'code', '--source', 's1'], { embedding_disabled: true })).toBe(true);
+  });
+
+  test('embedding-enabled brains still embed by default', () => {
+    expect(resolveNoEmbed([], null)).toBe(false);
+    expect(resolveNoEmbed([], {})).toBe(false);
+    expect(resolveNoEmbed([], { embedding_disabled: false })).toBe(false);
+  });
+
+  test('sentinel must be strictly true — junk config values do not disable embedding', () => {
+    expect(resolveNoEmbed([], { embedding_disabled: 'yes' as unknown as boolean })).toBe(false);
+    expect(resolveNoEmbed([], { embedding_disabled: 1 as unknown as boolean })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`gbrain init --no-embedding` writes `embedding_disabled: true` to config.json as the deferred-setup sentinel, and `init`/`import`/`embed` honor it via `assertEmbeddingEnabled` (embedding-dim-check.ts). But `gbrain sync`'s embed credential preflight (v0.41.6.0 D1, sync.ts) only checks the `--no-embed` CLI flag — so on a keyless deferred-setup brain, **every** `gbrain sync` exits 1:

```
Embedding model "zeroentropyai:zembed-1" requires ZEROENTROPY_API_KEY.
```

This hits orchestrated callers hardest: gstack's `/sync-gbrain` invokes `gbrain sync --strategy code --source <id>` without `--no-embed`, so its code stage is permanently red on deferred-setup machines, and the worktree pin/state never gets written.

`embed-preflight.ts`'s own skip protocol already documents the intended contract:

> The deferred-setup sentinel is owned by `assertEmbeddingEnabled` in `embedding-dim-check.ts`; this preflight runs AFTER that check fires.

sync just never wired it in.

## Fix

Derive sync's `noEmbed` from CLI args + config in one exported pure helper:

```ts
export function resolveNoEmbed(args, cfg) {
  return args.includes('--no-embed') || cfg?.embedding_disabled === true;
}
```

The sentinel behaves exactly like an explicit `--no-embed`: import proceeds, embed + credential preflight are skipped, and chunks stay staged for `gbrain embed --stale` once a provider is configured — the documented deferred-setup lifecycle.

## Verification

- New `test/sync-no-embed-sentinel.test.ts` (pure, no DB): flag opt-out, sentinel opt-out, embedding-enabled default, and strict `=== true` so junk config values don't silently disable embedding.
- `bun test test/sync.test.ts test/sync-cost-preview.test.ts` — 93 pass.
- `tsc --noEmit` clean.
- Live repro: on a `pglite` brain with `embedding_disabled: true` and no provider keys, `gbrain sync --strategy code --source <id>` went from exit 1 (credential error) to a clean import (1,211 pages) with the stale-embed backlog correctly reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)