### PR TITLE
feat(propose_takes): make extraction output-token budget configurable

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -177,6 +177,14 @@ export interface GBrainConfig {
    * reflex knobs.
    */
   retrieval_reflex_window_turns?: number;
+  /**
+   * Max output tokens for the propose_takes extraction call (default 2048).
+   * Raise it for local models that do a lot of reasoning before answering (e.g.
+   * qwen3 in thinking mode): they can spend the whole default budget reasoning
+   * and get truncated before emitting any JSON, producing an empty extraction.
+   * File-plane / env (GBRAIN_PROPOSE_TAKES_MAX_OUTPUT_TOKENS).
+   */
+  propose_takes_max_output_tokens?: number;
   embedding_image_ocr?: boolean;
   embedding_image_ocr_model?: string;
 
@@ -552,6 +560,10 @@ export function loadConfig(): GBrainConfig | null {
       Number.isFinite(Number(process.env.GBRAIN_RETRIEVAL_REFLEX_WINDOW_TURNS))
       ? { retrieval_reflex_window_turns: Number(process.env.GBRAIN_RETRIEVAL_REFLEX_WINDOW_TURNS) }
       : {}),
+    ...(process.env.GBRAIN_PROPOSE_TAKES_MAX_OUTPUT_TOKENS &&
+      Number.isFinite(Number(process.env.GBRAIN_PROPOSE_TAKES_MAX_OUTPUT_TOKENS))
+      ? { propose_takes_max_output_tokens: Number(process.env.GBRAIN_PROPOSE_TAKES_MAX_OUTPUT_TOKENS) }
+      : {}),
     ...(process.env.GBRAIN_REMOTE_CLIENT_SECRET && fileConfig?.remote_mcp
       ? { remote_mcp: { ...fileConfig.remote_mcp, oauth_client_secret: process.env.GBRAIN_REMOTE_CLIENT_SECRET } }
       : {}),
@@ -821,6 +833,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'expansion_model',
   'chat_model',
   'chat_fallback_chain',
+  'propose_takes_max_output_tokens',
   'provider_base_urls',
   'storage',
   'eval',

--- a/src/core/cycle/propose-takes.ts
+++ b/src/core/cycle/propose-takes.ts
@@ -83,6 +83,14 @@ export const PROPOSE_TAKES_PROMPT_VERSION = 'v0.36.1.0-tuned-cat15';
  * fixtures before bumping PROPOSE_TAKES_PROMPT_VERSION; the train-holdout
  * gap should stay < 0.10 (overfitting threshold).
  */
+/**
+ * Default output-token ceiling for the extraction LLM call. Preserves prior
+ * behavior. Override per-brain via config `propose_takes_max_output_tokens`
+ * (env `GBRAIN_PROPOSE_TAKES_MAX_OUTPUT_TOKENS`) to give local models that do
+ * heavy reasoning enough room to emit JSON before the response is truncated.
+ */
+export const DEFAULT_PROPOSE_TAKES_MAX_OUTPUT_TOKENS = 2048;
+
 export const EXTRACT_TAKES_PROMPT = `Extract gradeable claims from the prose below.
 
 A "gradeable claim" is a prediction, recommendation, or interpretive judgment
@@ -130,6 +138,7 @@ export type ProposeTakesExtractor = (input: {
   pageBody: string;
   existingTakes: Array<{ claim: string; kind: string; holder: string; weight: number }>;
   modelHint?: string;
+  maxOutputTokens?: number;
 }) => Promise<ProposedTake[]>;
 
 export interface ProposeTakesOpts extends BasePhaseOpts {
@@ -230,7 +239,7 @@ export async function defaultExtractor(
   const result = await gatewayChat({
     messages: [{ role: 'user', content: prompt }],
     ...(input.modelHint ? { model: input.modelHint } : {}),
-    maxTokens: 2048,
+    maxTokens: input.maxOutputTokens ?? DEFAULT_PROPOSE_TAKES_MAX_OUTPUT_TOKENS,
   });
 
   // ChatResult.text is already the concatenated text content.
@@ -300,13 +309,20 @@ class ProposeTakesPhase extends BaseCyclePhase {
   protected async process(
     engine: BrainEngine,
     scope: ScopedReadOpts,
-    _ctx: OperationContext,
+    ctx: OperationContext,
     opts: ProposeTakesOpts,
   ): Promise<{ summary: string; details: Record<string, unknown>; status?: PhaseStatus }> {
     const extractor = opts.extractor ?? defaultExtractor;
     const promptVersion = opts.promptVersion ?? PROPOSE_TAKES_PROMPT_VERSION;
     const pageLimit = opts.pageLimit ?? 100;
     const skipPagesWithFence = opts.skipPagesWithFence ?? false;
+    // Output-token ceiling for the extraction call. Configurable (default 2048)
+    // so heavy-reasoning local models get enough headroom to emit JSON.
+    const cfgMaxTokens = ctx.config?.propose_takes_max_output_tokens;
+    const maxOutputTokens =
+      typeof cfgMaxTokens === 'number' && Number.isFinite(cfgMaxTokens) && cfgMaxTokens > 0
+        ? cfgMaxTokens
+        : DEFAULT_PROPOSE_TAKES_MAX_OUTPUT_TOKENS;
     const proposalRunId = `propose-${new Date().toISOString().slice(0, 19).replace(/[-:T]/g, '')}-${randomUUID().slice(0, 8)}`;
 
     const result: ProposeTakesResult = {
@@ -379,6 +395,7 @@ class ProposeTakesPhase extends BaseCyclePhase {
           pageBody: body,
           existingTakes,
           modelHint: opts.model,
+          maxOutputTokens,
         });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/test/config-env.test.ts
+++ b/test/config-env.test.ts
@@ -129,3 +129,43 @@ describe('loadConfig env database URL precedence', () => {
     }
   });
 });
+
+describe('loadConfig GBRAIN_PROPOSE_TAKES_MAX_OUTPUT_TOKENS', () => {
+  test('env sets propose_takes_max_output_tokens; unset leaves it undefined', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'gbrain-config-env-'));
+    try {
+      await withEnv(
+        { GBRAIN_HOME: home, GBRAIN_DATABASE_URL: undefined, DATABASE_URL: undefined },
+        () => {
+          saveConfig({ engine: 'pglite', database_path: '/tmp/local-brain.pglite' });
+        },
+      );
+      // Unset → field absent (the read site falls back to the 2048 default).
+      await withEnv(
+        {
+          GBRAIN_HOME: home,
+          GBRAIN_PROPOSE_TAKES_MAX_OUTPUT_TOKENS: undefined,
+          GBRAIN_DATABASE_URL: undefined,
+          DATABASE_URL: undefined,
+        },
+        () => {
+          expect(loadConfig()?.propose_takes_max_output_tokens).toBeUndefined();
+        },
+      );
+      // Set → parsed onto the config field.
+      await withEnv(
+        {
+          GBRAIN_HOME: home,
+          GBRAIN_PROPOSE_TAKES_MAX_OUTPUT_TOKENS: '8192',
+          GBRAIN_DATABASE_URL: undefined,
+          DATABASE_URL: undefined,
+        },
+        () => {
+          expect(loadConfig()?.propose_takes_max_output_tokens).toBe(8192);
+        },
+      );
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/propose-takes.test.ts
+++ b/test/propose-takes.test.ts
@@ -14,20 +14,26 @@
  *  - parseExtractorOutput unit tests for the raw JSON parser
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, afterEach } from 'bun:test';
 import {
   runPhaseProposeTakes,
+  defaultExtractor,
   parseExtractorOutput,
   contentHash,
   hasCompleteFence,
   extractExistingTakesForDedup,
   PROPOSE_TAKES_PROMPT_VERSION,
+  DEFAULT_PROPOSE_TAKES_MAX_OUTPUT_TOKENS,
   type ProposeTakesExtractor,
   type ProposedTake,
 } from '../src/core/cycle/propose-takes.ts';
 import type { OperationContext } from '../src/core/operations.ts';
 import type { BrainEngine } from '../src/core/engine.ts';
 import type { Page } from '../src/core/types.ts';
+import {
+  __setChatTransportForTests,
+  type ChatResult,
+} from '../src/core/ai/gateway.ts';
 
 // ─── Mock engine ────────────────────────────────────────────────────
 
@@ -80,10 +86,10 @@ function buildPage(opts: { slug: string; body: string; sourceId?: string }): Pag
   } as Page;
 }
 
-function buildCtx(engine: BrainEngine): OperationContext {
+function buildCtx(engine: BrainEngine, config: Record<string, unknown> = {}): OperationContext {
   return {
     engine,
-    config: {} as never,
+    config: config as never,
     logger: { info() {}, warn() {}, error() {} } as never,
     dryRun: false,
     remote: false,
@@ -383,5 +389,58 @@ New prose appended here.`;
     expect(runIdA).toBe(runIdB);
     expect(typeof runIdA).toBe('string');
     expect((runIdA as string).startsWith('propose-')).toBe(true);
+  });
+});
+
+// ─── configurable extraction output-token budget ─────────────────────
+
+describe('propose_takes — configurable output-token budget', () => {
+  afterEach(() => {
+    __setChatTransportForTests(null);
+  });
+
+  function stubChat(capture: { maxTokens?: number }) {
+    __setChatTransportForTests(async (opts): Promise<ChatResult> => {
+      capture.maxTokens = opts.maxTokens;
+      return {
+        text: '[{"claim_text":"X will ship late","kind":"prediction","holder":"brain","weight":0.6,"domain":"test"}]',
+        blocks: [],
+        stopReason: 'end',
+        usage: { input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_creation_tokens: 0 },
+        model: 'test:stub',
+        providerId: 'test',
+      };
+    });
+  }
+
+  test('defaultExtractor defaults to DEFAULT_PROPOSE_TAKES_MAX_OUTPUT_TOKENS (behavior unchanged)', async () => {
+    const cap: { maxTokens?: number } = {};
+    stubChat(cap);
+    const takes = await defaultExtractor({ pagePath: 'notes/x', pageBody: 'I bet X ships late.', existingTakes: [] });
+    expect(cap.maxTokens).toBe(DEFAULT_PROPOSE_TAKES_MAX_OUTPUT_TOKENS);
+    expect(takes).toHaveLength(1);
+  });
+
+  test('defaultExtractor honors an explicit maxOutputTokens override', async () => {
+    const cap: { maxTokens?: number } = {};
+    stubChat(cap);
+    await defaultExtractor({ pagePath: 'notes/x', pageBody: 'I bet X ships late.', existingTakes: [], maxOutputTokens: 8192 });
+    expect(cap.maxTokens).toBe(8192);
+  });
+
+  test('phase passes config propose_takes_max_output_tokens through to the extractor', async () => {
+    let seen: number | undefined;
+    const extractor: ProposeTakesExtractor = async (input) => {
+      seen = input.maxOutputTokens;
+      return [];
+    };
+    // Unset → default.
+    const a = buildMockEngine({ pages: [buildPage({ slug: 'notes/x', body: 'I bet X ships late.' })] });
+    await runPhaseProposeTakes(buildCtx(a.engine), { extractor });
+    expect(seen).toBe(DEFAULT_PROPOSE_TAKES_MAX_OUTPUT_TOKENS);
+    // Configured → override reaches the extractor.
+    const b = buildMockEngine({ pages: [buildPage({ slug: 'notes/y', body: 'I bet Y ships late.' })] });
+    await runPhaseProposeTakes(buildCtx(b.engine, { propose_takes_max_output_tokens: 8192 }), { extractor });
+    expect(seen).toBe(8192);
   });
 });


### PR DESCRIPTION
## The problem

When gbrain runs its maintenance cycle against a **local, self-hosted model**, the `propose_takes` phase can silently produce nothing. It runs, spends time and GPU, and reports success, but inserts **zero** takes. There is no error to go on.

It shows up with some open models that do a lot of reasoning before answering (for example qwen3.6 in thinking mode). It is not every model, only the ones whose reasoning runs long enough to hit the output limit before they answer. People running gbrain locally for privacy, cost, or offline use tend to reach for exactly those models, so a core feature quietly stops working for them.

A second cost makes it worse. When the call returns nothing, the page is never recorded as processed, so there is no negative-result cache for it (see #2106). Every later cycle re-runs the same call on the same file and gets the same empty result, so these pages are re-processed on every run indefinitely, burning local inference each time.

## Why it happens

The extraction call asks the model for at most **2048 output tokens**. A heavy-reasoning model spends output tokens thinking before it emits its JSON answer, and that reasoning can exceed 2048 tokens on its own. The response is cut off (`finish_reason: length`) before any JSON is produced, so the parser sees empty output and the phase proposes nothing.

Measured on qwen3.6 (llama.cpp), same page and prompt, only the cap changed:

| output cap | `finish_reason` | tokens used | JSON returned | takes |
| --- | --- | --- | --- | --- |
| 2048 (current) | `length` | 2048 | none (truncated mid-reasoning) | **0** |
| 8192 | `stop` | 5404 | full array | **4** |

## The fix

Make the output-token ceiling configurable, and leave the default unchanged.

A local user with a heavy-reasoning model opts in:

```bash
gbrain config set propose_takes_max_output_tokens 8192
# or
GBRAIN_PROPOSE_TAKES_MAX_OUTPUT_TOKENS=8192 gbrain dream
```

Everyone else is unaffected. The default stays **2048**, so there is no change to behavior, latency, or cost for existing setups.

The key follows gbrain's existing `embedding_dimensions` convention: a typed `GBrainConfig` field with a matching `GBRAIN_*` override read in `loadConfig()`, registered in `KNOWN_CONFIG_KEYS`. The phase reads the value from `ctx.config` and passes it to the extractor.

Complementary to #2559: that change strips inline `<think>` tags so JSON that arrives can be parsed; this one ensures there is enough budget for the JSON to be emitted in the first place.

## Changes

- `src/core/config.ts`: new `propose_takes_max_output_tokens` field, `GBRAIN_PROPOSE_TAKES_MAX_OUTPUT_TOKENS` env mapping, and `KNOWN_CONFIG_KEYS` entry.
- `src/core/cycle/propose-takes.ts`: default of 2048, resolved from `ctx.config` and threaded to the extractor.

## Tests

New tests for this change:

- `defaultExtractor` uses the default (2048) when unset, and honors an explicit override.
- The phase reads `propose_takes_max_output_tokens` from config and passes it through to the extractor.
- `loadConfig()` reads the value from `GBRAIN_PROPOSE_TAKES_MAX_OUTPUT_TOKENS`.

### Full suite

Ran on a clean checkout of this branch (Bun 1.3.14): the `bun run test` parallel runner plus `bun run verify` (the pre-push gate). I had to fire up a 24 core 64GB RAM VM to get this suite to run!

- **`bun run verify`** — **31/31** checks green.
- **`bun run test`** — **14,175 passing, 2 failing**. Both failures are pre-existing and unrelated to this change (this PR touches only `src/core/config.ts` and `src/core/cycle/propose-takes.ts`):

| Failing test | Introduced by this PR? |
| --- | --- |
| `test/fuzz/filesystem-validators.test.ts` → ``validateUploadPath fuzz (fs-backed) > shaped traversal probes: explicit `..` patterns rejected`` | No — fails identically with this commit removed |
| `test/retrieval-reflex.test.ts` → `logDeliveredReflexPointers logs channel=reflex events through the drained sink` | No — fails identically with this commit removed |

To confirm they aren't introduced here, I checked out `master` (`5008b28`, v0.42.59.0 the commit this branch sits on) and re-ran each file: both fail the same way without this PR's commit present. They could be environment-specific, an fs-backed property/fuzz test and an async drained-sink logging assertion, rather than anything this change affects. The tests added by this PR pass.
