### PR TITLE
fix(facts): normalize null-like extractor entities; recover dash-flattened page slugs

### DIFF
--- a/src/core/facts/backstop.ts
+++ b/src/core/facts/backstop.ts
@@ -324,9 +324,35 @@ async function runPipelineWithBody(
     // D4: notability filter applied post-extraction, pre-insert.
     if (filter === 'high-only' && f.notability !== 'high') continue;
 
-    const resolvedSlug = f.entity_slug
+    let resolvedSlug = f.entity_slug
       ? await resolveEntitySlug(ctx.engine, ctx.sourceId, f.entity_slug)
       : null;
+
+    // Recover dash-flattened references to real pages. Extractors sometimes
+    // emit a page slug with '/' flattened to '-' (e.g. companies-acme for
+    // companies/acme); the resolver's slugify floor then persists that
+    // near-miss as-is. When the resolved slug has no live page in this
+    // source but exactly one live page's slug flattens to it, use that
+    // page. Zero or multiple matches leave the slug unchanged. Gated on
+    // slash-less slugs so properly resolved entities skip the lookups.
+    if (resolvedSlug && !resolvedSlug.includes('/')) {
+      const live = await ctx.engine.executeRaw<{ slug: string }>(
+        `SELECT slug FROM pages
+          WHERE source_id = $1 AND slug = $2 AND deleted_at IS NULL
+          LIMIT 1`,
+        [ctx.sourceId, resolvedSlug],
+      );
+      if (live.length === 0) {
+        const flattened = await ctx.engine.executeRaw<{ slug: string }>(
+          `SELECT slug FROM pages
+            WHERE source_id = $1 AND deleted_at IS NULL
+              AND replace(slug, '/', '-') = $2
+            LIMIT 2`,
+          [ctx.sourceId, resolvedSlug],
+        );
+        if (flattened.length === 1) resolvedSlug = flattened[0].slug;
+      }
+    }
 
     // Dedup against DB candidates (correct per Codex Q7: fence rows
     // have no embeddings; FS lock + sync invariant means DB == fence

--- a/src/core/facts/extract.ts
+++ b/src/core/facts/extract.ts
@@ -146,6 +146,14 @@ const EXTRACTOR_SYSTEM = [
 
 const MAX_TURN_TEXT_CHARS = 8000;
 
+/** Normalize extractor placeholders without inventing or rewriting slugs. */
+export function normalizeExtractorEntitySlug(entity: string | null | undefined): string | null {
+  if (entity == null) return null;
+  const trimmed = entity.trim();
+  if (!trimmed || /^(null|none|n\/a)$/i.test(trimmed)) return null;
+  return entity;
+}
+
 export async function extractFactsFromTurn(input: ExtractInput): Promise<ExtractedFact[]> {
   if (input.isDreamGenerated) return [];
   if (!input.turnText) return [];
@@ -237,7 +245,7 @@ export async function extractFactsFromTurn(input: ExtractInput): Promise<Extract
     facts.push({
       fact: factText,
       kind,
-      entity_slug: candidate.entity ?? null,
+      entity_slug: normalizeExtractorEntitySlug(candidate.entity),
       source: input.source,
       source_session: input.sessionId ?? null,
       confidence,

--- a/test/facts-backstop.test.ts
+++ b/test/facts-backstop.test.ts
@@ -76,6 +76,34 @@ const meetingPage = (slug = 'meetings/test-' + Math.random().toString(36).slice(
   frontmatter: {} as Record<string, unknown>,
 });
 
+describe('runFactsBackstop — flattened entity slug recovery', () => {
+  test('recovers a unique dash-flattened reference to a live page', async () => {
+    const suffix = Math.random().toString(36).slice(2, 9);
+    const realSlug = `companies/recovery-${suffix}`;
+    await engine.putPage(realSlug, {
+      title: 'Recovery Target',
+      type: 'company',
+      compiled_truth: LONG_BODY,
+      frontmatter: {},
+      timeline: '',
+    });
+    chatStub([
+      { fact: `flattened reference ${suffix}`, kind: 'fact', notability: 'high', entity: realSlug.replace('/', '-') },
+    ]);
+
+    const r = await runFactsBackstop(meetingPage(), makeCtx({ mode: 'inline' }));
+    expect(r.mode).toBe('inline');
+    if (r.mode === 'inline') {
+      expect(r.inserted).toBe(1);
+      const rows = await engine.executeRaw<{ entity_slug: string | null }>(
+        `SELECT entity_slug FROM facts WHERE fact = $1`,
+        [`flattened reference ${suffix}`],
+      );
+      expect(rows[0]?.entity_slug).toBe(realSlug);
+    }
+  });
+});
+
 describe('runFactsBackstop — eligibility + kill-switch gates', () => {
   test('skips with extraction_disabled when kill-switch off', async () => {
     await engine.setConfig('facts.extraction_enabled', 'false');

--- a/test/facts-extract-silent-no-op.test.ts
+++ b/test/facts-extract-silent-no-op.test.ts
@@ -146,4 +146,34 @@ describe('facts extract — silent-no-op regression (v0.31.6 bug class)', () => 
     });
     expect(chatCalled).toBe(true);  // ← THE bug-class assertion
   });
+
+  test('normalizes null-like entity strings to null', async () => {
+    configureGateway({
+      chat_model: 'openai:gpt-4o-mini',
+      env: { OPENAI_API_KEY: 'sk-test' },
+    });
+    __setChatTransportForTests(async () => ({
+      text: JSON.stringify({
+        facts: [' null ', 'NONE', ' n/a ', '   '].map((entity, index) => ({
+          fact: `Null-like entity ${index} stays unparented.`,
+          kind: 'fact',
+          entity,
+          confidence: 0.7,
+          notability: 'medium',
+          metric: null,
+          value: null,
+          unit: null,
+          period: null,
+        })),
+      }),
+      blocks: [],
+      stopReason: 'end' as const,
+      usage: { input_tokens: 1, output_tokens: 1, cache_read_tokens: 0, cache_creation_tokens: 0 },
+      model: 'openai:gpt-4o-mini',
+      providerId: 'openai',
+    }));
+
+    const facts = await extractFactsFromTurn({ turnText: 'Extract this.', source: 'test:slug-normalize' });
+    expect(facts.map(f => f.entity_slug)).toEqual([null, null, null, null]);
+  });
 });


### PR DESCRIPTION
### Problem

Extractors sometimes emit placeholder entity strings (the literal "null", "none", "n/a") or page slugs with '/' flattened to '-' (companies-acme for companies/acme). The parser accepts any string entity and the resolver's slugify floor persists these as-is, creating fact rows attached to slugs no page backs.

### Fix

- Normalize null-like extractor entity strings to null before resolution.
- When a resolved slash-less slug has no live page in the source but exactly one live page's slug flattens to it, attach the fact to that page. Zero or multiple matches leave the slug unchanged.

Related: #2532 treats slugify-fallback guesses as unresolved and #2497 reworks the extract_facts guard predicate. This carries the two pieces neither touches.

### Testing

- `bun run typecheck`
- `bun test test/facts-backstop.test.ts test/facts-extract-silent-no-op.test.ts` - 20 passed, 0 failed

@sanchalr 🫡