### PR TITLE
fix(embeddings): wire trust_custom_dims into the actual dimension passthrough

### DIFF
--- a/src/core/ai/dims.ts
+++ b/src/core/ai/dims.ts
@@ -108,12 +108,26 @@ export function isValidOpenAITextEmbedding3Dim(modelId: string, dims: number): b
  * `'document'`. Per-model filtering happens INSIDE the switch — the field
  * is NEVER emitted for providers that don't accept it (OpenAI text-3,
  * DashScope, Zhipu) so the request body stays clean for those endpoints.
+ *
+ * `trustCustomDims` — recipes that declare `trust_custom_dims: true`
+ * (ollama, llama-server) promise every listed embedding model accepts
+ * OpenAI-shaped `dimensions` truncation (Ollama's `/v1/embeddings` honors
+ * it; llama-server serves whatever model the user launched, so the user
+ * is asserting it does too). Before this flag was wired here, it only
+ * relaxed the schema-width validation in embedding-dim-check.ts — a brain
+ * could be configured for a truncated width, but the gateway silently
+ * requested the model's native (larger) output, producing a dim mismatch
+ * that only surfaced at first embed (or in `gbrain doctor`'s live probe).
+ * This is the generic fallback for any openai-compatible recipe that
+ * opts in, so it covers ollama, llama-server, and future local-model
+ * recipes uniformly instead of a per-model allowlist entry each time.
  */
 export function dimsProviderOptions(
   implementation: Implementation,
   modelId: string,
   dims: number,
   inputType?: 'query' | 'document',
+  trustCustomDims?: boolean,
 ): Record<string, any> | undefined {
   switch (implementation) {
     case 'native-openai': {
@@ -227,6 +241,16 @@ export function dimsProviderOptions(
       // inputType==='query' → type:'query', else 'db'.
       if (modelId === 'embo-01') {
         return { openaiCompatible: { type: 'db' } };
+      }
+      // Generic trust_custom_dims fallback (ollama, llama-server, and any
+      // future local-model recipe that opts in). These recipes serve
+      // arbitrary user-launched/pulled models, so there's no fixed model-id
+      // allowlist to match against — the recipe's own `trust_custom_dims`
+      // flag is the signal that its OpenAI-compatible endpoint honors
+      // `dimensions` truncation. Symmetric retrieval assumed — inputType
+      // ignored, matching the DashScope/Zhipu/text-3 branches above.
+      if (trustCustomDims) {
+        return { openaiCompatible: { dimensions: dims } };
       }
       return undefined;
   }

--- a/src/core/ai/gateway.ts
+++ b/src/core/ai/gateway.ts
@@ -1437,6 +1437,7 @@ export async function embed(texts: string[], opts?: EmbedOpts): Promise<Float32A
     modelId,
     effectiveDims,
     opts?.inputType,
+    recipe.touchpoints?.embedding?.trust_custom_dims === true,
   );
   const expected = effectiveDims;
 

--- a/test/ai/dims-trust-custom.test.ts
+++ b/test/ai/dims-trust-custom.test.ts
@@ -1,0 +1,64 @@
+/**
+ * trust_custom_dims passthrough tests.
+ *
+ * Pins the fix for: recipes that declare `trust_custom_dims: true`
+ * (ollama, llama-server) had that flag relax schema-width validation in
+ * embedding-dim-check.ts, but dimsProviderOptions never consulted it — a
+ * generic openai-compatible model outside the explicit ZE/Voyage/text-3/
+ * DashScope/Zhipu/MiniMax allowlist always fell through to `undefined`,
+ * so the gateway silently requested the model's native (untruncated)
+ * output even when the brain was configured for a smaller width. The
+ * mismatch only surfaced at first embed or in `gbrain doctor`'s live
+ * probe, as an opaque "dim mismatch" error.
+ *
+ * Verified against a live Ollama instance during development: Ollama's
+ * `/v1/embeddings` accepts an OpenAI-shaped `dimensions` field and
+ * returns a genuinely truncated vector for qwen3-embedding:8b (confirmed
+ * 4096 → 2000 via curl). This test suite pins the plumbing, not the live
+ * network call.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { dimsProviderOptions } from '../../src/core/ai/dims.ts';
+
+describe('dimsProviderOptions — trustCustomDims fallback', () => {
+  test('ollama-style model with trustCustomDims=true emits dimensions', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'qwen3-embedding:8b', 2000, undefined, true);
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 2000 } });
+  });
+
+  test('llama-server-style model with trustCustomDims=true emits dimensions', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'my-local-gguf', 1024, undefined, true);
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1024 } });
+  });
+
+  test('unknown model WITHOUT trustCustomDims returns undefined (no behavior change)', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'qwen3-embedding:8b', 2000);
+    expect(opts).toBeUndefined();
+  });
+
+  test('trustCustomDims=false is treated the same as omitted', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'qwen3-embedding:8b', 2000, undefined, false);
+    expect(opts).toBeUndefined();
+  });
+
+  test('trustCustomDims does not override the explicit allowlist branches (ZE)', () => {
+    // zembed-1 hits its own branch first regardless of trustCustomDims,
+    // and still enforces its own dim allowlist.
+    const opts = dimsProviderOptions('openai-compatible', 'zembed-1', 1280, undefined, true);
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 1280, input_type: 'document' } });
+  });
+
+  test('trustCustomDims fallback ignores inputType (symmetric assumption)', () => {
+    const opts = dimsProviderOptions('openai-compatible', 'qwen3-embedding:8b', 2000, 'query', true);
+    expect(opts).toEqual({ openaiCompatible: { dimensions: 2000 } });
+    expect(JSON.stringify(opts)).not.toContain('input_type');
+  });
+
+  test('native-openai implementation is unaffected by trustCustomDims', () => {
+    // trustCustomDims is only consulted in the openai-compatible branch;
+    // native-openai keeps its existing text-embedding-3-* gate.
+    const opts = dimsProviderOptions('native-openai', 'some-other-model', 1000, undefined, true);
+    expect(opts).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`trust_custom_dims: true` is declared on the `ollama` and `llama-server` recipes and documented in `types.ts` as opting a local embedding model into custom-dimension truncation. But `dimsProviderOptions()` never actually consulted it — the flag only relaxed the schema-width validation in `embedding-dim-check.ts`. A brain could be configured with a truncated `embedding_dimensions`, but the gateway still requested the model's full native-size output from the provider, because any `openai-compatible` model outside the explicit ZE/Voyage/text-embedding-3/DashScope/Zhipu/MiniMax allowlist fell through to `return undefined`.

The mismatch only surfaces at first embed (or in `gbrain doctor`'s live probe) as an opaque dimension-mismatch error — well after `gbrain init --embedding-model ollama:... --embedding-dimensions N` reports success.

## Repro

```
$ gbrain init --pglite --embedding-model ollama:qwen3-embedding:8b --embedding-dimensions 2000
{"status":"success", ...}   # looks fine

$ gbrain doctor --json
"embedding_provider": "warn — Embedding provider probe failed: Embedding dim mismatch:
  model qwen3-embedding:8b returned 4096 but schema expects 2000."
```

Confirmed independently against a live Ollama instance that this isn't an Ollama limitation — both its native `/api/embed` and OpenAI-compat `/v1/embeddings` endpoints honor a `dimensions` field and return a genuinely truncated vector:

```
$ curl -s http://localhost:11434/v1/embeddings -d '{"model": "qwen3-embedding:8b", "input": "test", "dimensions": 2000}'
# returns a 2000-length embedding vector
```

gbrain just never sent the field for this provider.

## Fix

Thread `trust_custom_dims` through as a 5th `dimsProviderOptions` param, sourced from the resolved recipe at `gateway.ts`'s single `embed()` call site. Add a generic fallback branch *after* the existing per-model matches, so ZE/Voyage/text-3/DashScope/Zhipu/MiniMax keep their explicit (and in some cases dim-validated) handling unchanged, and only truly generic local-model recipes fall through to the new branch.

This covers `ollama` and `llama-server` uniformly instead of adding a new per-model allowlist entry every time a local embedding model ships (e.g. this would otherwise need `nomic-embed-text`, `mxbai-embed-large`, `qwen3-embedding`, `snowflake-arctic-embed-l-v2`, `all-minilm`, ... hardcoded individually).

## Test plan

- [x] New unit tests in `test/ai/dims-trust-custom.test.ts`: fallback fires only when `trustCustomDims=true`, doesn't affect the ZE branch's own dim validation, ignores `inputType` (symmetric assumption), doesn't leak into `native-openai`.
- [x] `bun test test/ai/dims-trust-custom.test.ts test/ai/dims-openai.test.ts test/ai/dims-zeroentropy.test.ts` — 36 pass, 0 fail.
- [x] `bun test test/ai/gateway.test.ts` — 36 pass, 0 fail (no regression from the new call-site param).
- [x] `bun run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)