### PR TITLE
fix(cycle): abort propose_takes after 3 consecutive retryable transport failures

### DIFF
--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -2428,8 +2428,32 @@ function extractTotals(phases: PhaseResult[]): CycleReport['totals'] {
   return t;
 }
 
-function deriveStatus(phases: PhaseResult[], totals: CycleReport['totals']): CycleStatus {
+/**
+ * True when a phase result must escalate the OVERALL cycle status to
+ * 'failed' (not 'partial'). Used for transport-budget abort: ordinary
+ * per-item phase failures still roll to 'partial', but a dead egress
+ * path that trips the consecutive-transport budget is cycle-fatal so
+ * `gbrain dream` exits nonzero.
+ *
+ * Marker: `details.transport_abort === true` (set by propose_takes when
+ * CONSECUTIVE_TRANSPORT_FAILURE_BUDGET trips).
+ */
+export function phaseForcesCycleFailed(p: PhaseResult): boolean {
+  return p.details?.transport_abort === true;
+}
+
+/**
+ * Derive overall CycleReport.status from phase results + totals.
+ * Exported for unit tests of the transport-abort fatal rollup.
+ */
+export function deriveStatus(phases: PhaseResult[], totals: CycleReport['totals']): CycleStatus {
   if (phases.length === 0) return 'failed';
+  // Transport-budget abort is cycle-fatal. A multi-phase dream where
+  // propose_takes trips and another phase succeeds must NOT roll up to
+  // 'partial' (dream exits nonzero only on overall 'failed' — the
+  // silent-success wedge this patch kills). Ordinary fail+ok stays
+  // 'partial'.
+  if (phases.some(phaseForcesCycleFailed)) return 'failed';
   const anyFailed = phases.some(p => p.status === 'fail');
   const allFailed = phases.every(p => p.status === 'fail');
   const anyWarn = phases.some(p => p.status === 'warn');

--- a/src/core/cycle/propose-takes.ts
+++ b/src/core/cycle/propose-takes.ts
@@ -39,6 +39,10 @@
 
 import { randomUUID, createHash } from 'node:crypto';
 import { BaseCyclePhase, type ScopedReadOpts, type BasePhaseOpts } from './base-phase.ts';
+import {
+  CONSECUTIVE_TRANSPORT_FAILURE_BUDGET,
+  isRetryableTransportFailure,
+} from './transport-failure.ts';
 import { chat as gatewayChat } from '../ai/gateway.ts';
 import { writeReceipt } from '../extract/receipt-writer.ts';
 import { upsertExtractRollup } from '../extract/rollup-writer.ts';
@@ -154,6 +158,16 @@ export interface ProposeTakesResult {
   proposals_inserted: number;
   budget_exhausted: boolean;
   warnings: string[];
+  /** True when the consecutive transport-failure budget tripped mid-run. */
+  transport_abort?: boolean;
+  /** Count of consecutive retryable transport failures at abort (or end). */
+  consecutive_transport_failures?: number;
+  /** Page slugs that produced the consecutive transport failures. */
+  transport_failure_slugs?: string[];
+  /** Last transport-failure messages (one per consecutive failure). */
+  transport_failure_errors?: string[];
+  /** Machine-stable abort reason when transport_abort is true. */
+  abort_reason?: 'consecutive_transport_failures';
 }
 
 /**
@@ -318,6 +332,13 @@ class ProposeTakesPhase extends BaseCyclePhase {
       warnings: [],
     };
 
+    // Consecutive retryable transport failures (timeout / DNS / 5xx).
+    // Resets on any successful extractor response; non-transport errors
+    // neither increment nor reset. Budget trip → phase FAILED (not warn).
+    let consecutiveTransportFailures = 0;
+    const transportFailureSlugs: string[] = [];
+    const transportFailureErrors: string[] = [];
+
     // Load pages eligible for proposal. Source-scoped per BaseCyclePhase.
     const pageFilters: PageFilters = {
       ...scope,
@@ -371,7 +392,10 @@ class ProposeTakesPhase extends BaseCyclePhase {
         break;
       }
 
-      // Call the extractor. Errors on a single page log a warning but do not abort.
+      // Call the extractor. Non-transport errors on a single page log a
+      // warning and continue. Retryable transport failures increment a
+      // consecutive budget; 3 in a row aborts the phase as FAILED so a
+      // dead egress path cannot exit rc=0 with zero work done.
       let proposals: ProposedTake[];
       try {
         proposals = await extractor({
@@ -380,9 +404,35 @@ class ProposeTakesPhase extends BaseCyclePhase {
           existingTakes,
           modelHint: opts.model,
         });
+        // Any successful LLM response resets the consecutive counter
+        // (and the rolling error/slug window used for the abort report).
+        consecutiveTransportFailures = 0;
+        transportFailureSlugs.length = 0;
+        transportFailureErrors.length = 0;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         result.warnings.push(`extractor failed on ${page.slug}: ${msg}`);
+        if (isRetryableTransportFailure(err)) {
+          consecutiveTransportFailures += 1;
+          transportFailureSlugs.push(page.slug);
+          transportFailureErrors.push(msg);
+          if (consecutiveTransportFailures >= CONSECUTIVE_TRANSPORT_FAILURE_BUDGET) {
+            result.transport_abort = true;
+            result.abort_reason = 'consecutive_transport_failures';
+            result.consecutive_transport_failures = consecutiveTransportFailures;
+            result.transport_failure_slugs = transportFailureSlugs.slice(
+              -CONSECUTIVE_TRANSPORT_FAILURE_BUDGET,
+            );
+            result.transport_failure_errors = transportFailureErrors.slice(
+              -CONSECUTIVE_TRANSPORT_FAILURE_BUDGET,
+            );
+            result.warnings.push(
+              `aborted after ${CONSECUTIVE_TRANSPORT_FAILURE_BUDGET} consecutive transport failures ` +
+                `(last: ${page.slug})`,
+            );
+            break;
+          }
+        }
         continue;
       }
 
@@ -441,9 +491,19 @@ class ProposeTakesPhase extends BaseCyclePhase {
     await upsertExtractRollup(engine, {
       kind: 'takes.proposed',
       source_id: sourceIdForReceipt,
-      round_completed_delta: result.budget_exhausted ? 0 : 1,
-      halt_delta: result.budget_exhausted ? 1 : 0,
+      round_completed_delta: result.budget_exhausted || result.transport_abort ? 0 : 1,
+      halt_delta: result.budget_exhausted || result.transport_abort ? 1 : 0,
     });
+
+    if (result.transport_abort) {
+      return {
+        summary:
+          `propose_takes FAILED: ${CONSECUTIVE_TRANSPORT_FAILURE_BUDGET} consecutive transport failures ` +
+          `(scanned ${result.pages_scanned}, ${result.proposals_inserted} proposals before abort; run ${proposalRunId})`,
+        details: { ...result, proposal_run_id: proposalRunId, prompt_version: promptVersion },
+        status: 'fail',
+      };
+    }
 
     return {
       summary: `propose_takes: scanned ${result.pages_scanned} pages, ${result.cache_hits} cached, ${result.proposals_inserted} new proposals (run ${proposalRunId})`,

--- a/src/core/cycle/transport-failure.ts
+++ b/src/core/cycle/transport-failure.ts
@@ -1,0 +1,154 @@
+/**
+ * Retryable LLM-transport failure classifier for cycle phases.
+ *
+ * Used by propose_takes (and available to sibling phases) to decide whether a
+ * per-item extractor/judge error should increment a consecutive-failure abort
+ * budget. A dead egress path (proxy down, DNS blackhole, provider 5xx storm)
+ * previously produced silent catch-and-continue success with zero work done.
+ *
+ * Classification rules (reviewer-locked):
+ *   COUNT: timeout, abort-caused-by-deadline/timeout only, connection/DNS
+ *          (ECONNREFUSED/ENOTFOUND/EAI_AGAIN/…), provider 5xx.
+ *   DO NOT COUNT: bare AbortError (user cancel / unrelated signal), parse
+ *          failures, content rejection, auth/config (4xx except that 5xx is
+ *          counted above), empty results.
+ *
+ * Walk the error cause chain (Error.cause + AggregateError.errors + abort
+ * reason). An SDK retry loop that exhausts and rethrows a wrapper whose only
+ * timeout lives on `.cause` MUST still count — message-string regex alone is
+ * insufficient. AbortError is retryable only when a timeout/deadline shape
+ * appears on the message, cause, or reason.
+ */
+
+/** Consecutive retryable transport failures before the phase aborts as FAILED. */
+export const CONSECUTIVE_TRANSPORT_FAILURE_BUDGET = 3;
+
+const TRANSPORT_CODES = new Set([
+  'ETIMEDOUT',
+  'ESOCKETTIMEDOUT',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ECONNABORTED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EPIPE',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+
+/** Non-retryable HTTP statuses (auth/config). 429 is rate-limit — not in the locked transport set. */
+function isAuthOrConfigStatus(status: number): boolean {
+  return status >= 400 && status < 500;
+}
+
+function getStatus(err: unknown): number | undefined {
+  if (!err || typeof err !== 'object') return undefined;
+  const e = err as { status?: unknown; statusCode?: unknown };
+  if (typeof e.status === 'number') return e.status;
+  if (typeof e.statusCode === 'number') return e.statusCode;
+  return undefined;
+}
+
+function getCode(err: unknown): string | undefined {
+  if (!err || typeof err !== 'object') return undefined;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+function getName(err: unknown): string {
+  if (!err || typeof err !== 'object') return '';
+  const name = (err as { name?: unknown }).name;
+  return typeof name === 'string' ? name : '';
+}
+
+function getMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === 'object') {
+    const msg = (err as { message?: unknown }).message;
+    if (typeof msg === 'string') return msg;
+  }
+  if (typeof err === 'string') return err;
+  return String(err ?? '');
+}
+
+/**
+ * Does this single error node itself look like a retryable transport failure?
+ * Cause-chain walking is handled by the public entry point.
+ */
+function nodeIsRetryableTransport(err: unknown): boolean {
+  if (err == null) return false;
+
+  const status = getStatus(err);
+  if (typeof status === 'number') {
+    if (status >= 500 && status < 600) return true;
+    // Auth/config 4xx are explicitly non-transport — short-circuit this node.
+    if (isAuthOrConfigStatus(status)) return false;
+  }
+
+  const code = getCode(err);
+  if (code && TRANSPORT_CODES.has(code)) return true;
+
+  const name = getName(err);
+  // TimeoutError / ConnectTimeoutError always count. Bare AbortError does NOT —
+  // only abort-caused-by-deadline/timeout counts (message patterns below, or a
+  // timeout-shaped cause / AbortSignal.reason walked by the public entry).
+  // User cancellation and unrelated signals must not burn the transport budget.
+  if (name === 'TimeoutError' || name === 'ConnectTimeoutError') {
+    return true;
+  }
+
+  const msg = getMessage(err);
+  // Secondary signal only — the cause-chain walk is the primary footgun fix.
+  if (
+    /ETIMEDOUT|ESOCKETTIMEDOUT|ECONNREFUSED|ECONNRESET|ENOTFOUND|EAI_AGAIN|EHOSTUNREACH|ENETUNREACH/i.test(
+      msg,
+    )
+  ) {
+    return true;
+  }
+  if (/\btimed?\s*out\b|timeout|deadline exceeded|aborted due to (timeout|deadline)/i.test(msg)) {
+    return true;
+  }
+  if (/fetch failed|network error|socket hang up|connection refused|could not connect/i.test(msg)) {
+    return true;
+  }
+  // Explicit non-transport shapes that message patterns might otherwise mis-fire on.
+  if (/invalid api key|authentication|unauthorized|forbidden|json parse|content rejected|model not configured|safety filter/i.test(msg)) {
+    return false;
+  }
+
+  return false;
+}
+
+/**
+ * True when `err` (or any cause / AggregateError sub-error / abort reason) is a
+ * retryable transport failure that should increment the consecutive-abort budget.
+ */
+export function isRetryableTransportFailure(err: unknown, seen: Set<unknown> = new Set()): boolean {
+  if (err == null) return false;
+  if (typeof err === 'object') {
+    if (seen.has(err)) return false;
+    seen.add(err);
+  }
+
+  if (nodeIsRetryableTransport(err)) return true;
+
+  if (typeof err === 'object') {
+    // Walk cause chain, AggregateError.errors, and AbortSignal/DOMException
+    // abort reason (timeout deadline often lives only on `.reason`).
+    const e = err as { cause?: unknown; errors?: unknown[]; reason?: unknown };
+    if (e.cause != null && isRetryableTransportFailure(e.cause, seen)) return true;
+    if (e.reason != null && isRetryableTransportFailure(e.reason, seen)) return true;
+    if (Array.isArray(e.errors)) {
+      for (const sub of e.errors) {
+        if (isRetryableTransportFailure(sub, seen)) return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/test/cycle/propose-takes-transport-abort.test.ts
+++ b/test/cycle/propose-takes-transport-abort.test.ts
@@ -1,0 +1,423 @@
+/**
+ * Consecutive retryable-transport-failure abort for propose_takes.
+ *
+ * Repro wedge (2026-07-17): dead egress path → per-page catch-and-continue
+ * → phase exits status=ok with "Embedded 0 chunks" / zero proposals and
+ * process rc=0. Budget of 3 consecutive retryable transport failures must
+ * fail the phase (status=fail) with last errors + affected slugs preserved.
+ *
+ * Classification walks the error cause chain (and AggregateError.errors),
+ * not message-string regex alone — an SDK-retry-exhausted wrapper that
+ * only carries the timeout on `.cause` still increments the budget.
+ *
+ * AbortError: only abort-caused-by-deadline/timeout counts; bare AbortError
+ * (user cancel / unrelated signal) must NOT increment the budget.
+ *
+ * Multi-phase rollup: transport_abort on a phase forces overall cycle
+ * status 'failed' (not 'partial') so dream exits nonzero.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import {
+  runPhaseProposeTakes,
+  type ProposeTakesExtractor,
+} from '../../src/core/cycle/propose-takes.ts';
+import {
+  CONSECUTIVE_TRANSPORT_FAILURE_BUDGET,
+  isRetryableTransportFailure,
+} from '../../src/core/cycle/transport-failure.ts';
+import {
+  deriveStatus,
+  phaseForcesCycleFailed,
+  type PhaseResult,
+  type CycleReport,
+} from '../../src/core/cycle.ts';
+import type { OperationContext } from '../../src/core/operations.ts';
+import type { BrainEngine } from '../../src/core/engine.ts';
+import type { Page } from '../../src/core/types.ts';
+
+// ─── Fixtures (mirror test/propose-takes.test.ts mock shape) ────────
+
+function buildMockEngine(pages: Page[]): BrainEngine {
+  return {
+    kind: 'pglite',
+    async listPages() {
+      return pages;
+    },
+    async executeRaw<T>(sql: string, _params?: unknown[]): Promise<T[]> {
+      if (sql.includes('SELECT id FROM take_proposals')) return [];
+      return [];
+    },
+  } as unknown as BrainEngine;
+}
+
+function buildPage(slug: string, body = `prose for ${slug}`): Page {
+  return {
+    id: 1,
+    slug,
+    type: 'analysis',
+    title: slug,
+    compiled_truth: body,
+    timeline: '',
+    frontmatter: {},
+    source_id: 'default',
+    created_at: new Date(),
+    updated_at: new Date(),
+  } as Page;
+}
+
+function buildCtx(engine: BrainEngine): OperationContext {
+  return {
+    engine,
+    config: {} as never,
+    logger: { info() {}, warn() {}, error() {} } as never,
+    dryRun: false,
+    remote: false,
+    sourceId: 'default',
+  };
+}
+
+function makeTimeoutError(message = 'Request timed out'): Error {
+  const err = new Error(message);
+  (err as Error & { code?: string }).code = 'ETIMEDOUT';
+  return err;
+}
+
+function makeConnRefusedError(): Error {
+  const err = new Error('connect ECONNREFUSED 127.0.0.1:11434');
+  (err as Error & { code?: string }).code = 'ECONNREFUSED';
+  return err;
+}
+
+function makeProvider5xx(): Error {
+  const err = new Error('Internal Server Error');
+  (err as Error & { status?: number }).status = 503;
+  return err;
+}
+
+// ─── Classifier unit tests ──────────────────────────────────────────
+
+describe('isRetryableTransportFailure', () => {
+  test('counts timeout / ETIMEDOUT / deadline-shaped AbortError', () => {
+    expect(isRetryableTransportFailure(makeTimeoutError())).toBe(true);
+    // AbortError counts only when timeout/deadline-shaped (message).
+    const abortTimeout = new Error('The operation was aborted due to timeout');
+    abortTimeout.name = 'AbortError';
+    expect(isRetryableTransportFailure(abortTimeout)).toBe(true);
+    // TimeoutError name always counts (incl. DOMException-shaped).
+    const te = new Error('Deadline exceeded');
+    te.name = 'TimeoutError';
+    expect(isRetryableTransportFailure(te)).toBe(true);
+  });
+
+  test('bare AbortError (user cancel / no timeout cause) is NOT retryable', () => {
+    const bare = new Error('This operation was aborted');
+    bare.name = 'AbortError';
+    expect(isRetryableTransportFailure(bare)).toBe(false);
+
+    const cancel = new Error('The user aborted a request');
+    cancel.name = 'AbortError';
+    expect(isRetryableTransportFailure(cancel)).toBe(false);
+  });
+
+  test('AbortError with timeout cause or abort reason IS retryable', () => {
+    const abortWithCause = new Error('The operation was aborted');
+    abortWithCause.name = 'AbortError';
+    (abortWithCause as Error & { cause?: unknown }).cause = makeTimeoutError();
+    expect(isRetryableTransportFailure(abortWithCause)).toBe(true);
+
+    const reason = new Error('Timeout');
+    reason.name = 'TimeoutError';
+    const abortWithReason = new Error('The operation was aborted');
+    abortWithReason.name = 'AbortError';
+    (abortWithReason as Error & { reason?: unknown }).reason = reason;
+    expect(isRetryableTransportFailure(abortWithReason)).toBe(true);
+  });
+
+  test('counts connection / DNS codes', () => {
+    expect(isRetryableTransportFailure(makeConnRefusedError())).toBe(true);
+    const dns = new Error('getaddrinfo ENOTFOUND api.example.com');
+    (dns as Error & { code?: string }).code = 'ENOTFOUND';
+    expect(isRetryableTransportFailure(dns)).toBe(true);
+    const again = new Error('getaddrinfo EAI_AGAIN api.example.com');
+    (again as Error & { code?: string }).code = 'EAI_AGAIN';
+    expect(isRetryableTransportFailure(again)).toBe(true);
+  });
+
+  test('counts provider 5xx via status / statusCode', () => {
+    expect(isRetryableTransportFailure(makeProvider5xx())).toBe(true);
+    const e = new Error('bad gateway');
+    (e as Error & { statusCode?: number }).statusCode = 502;
+    expect(isRetryableTransportFailure(e)).toBe(true);
+  });
+
+  test('does NOT count auth / config / parse / content rejection', () => {
+    const auth = new Error('Invalid API key');
+    (auth as Error & { status?: number }).status = 401;
+    expect(isRetryableTransportFailure(auth)).toBe(false);
+
+    const forbidden = new Error('Forbidden');
+    (forbidden as Error & { status?: number }).status = 403;
+    expect(isRetryableTransportFailure(forbidden)).toBe(false);
+
+    expect(isRetryableTransportFailure(new Error('JSON parse failed at position 0'))).toBe(false);
+    expect(isRetryableTransportFailure(new Error('content rejected by safety filter'))).toBe(false);
+    expect(isRetryableTransportFailure(new Error('model not configured'))).toBe(false);
+  });
+
+  test('walks .cause chain — wrapped/AggregateError timeout still counts', () => {
+    const root = makeTimeoutError('underlying deadline exceeded');
+    const wrapped = new Error('SDK retries exhausted');
+    (wrapped as Error & { cause?: unknown }).cause = root;
+    expect(isRetryableTransportFailure(wrapped)).toBe(true);
+
+    const agg = new AggregateError([new Error('noise'), root], 'multiple failures');
+    expect(isRetryableTransportFailure(agg)).toBe(true);
+
+    // Outer message has no timeout keyword — only the cause does.
+    const silentWrap = new Error('All 3 attempts failed');
+    (silentWrap as Error & { cause?: unknown }).cause = makeTimeoutError();
+    expect(isRetryableTransportFailure(silentWrap)).toBe(true);
+  });
+});
+
+// ─── Phase integration ──────────────────────────────────────────────
+
+describe('propose_takes consecutive transport-failure abort', () => {
+  test(`(a) ${CONSECUTIVE_TRANSPORT_FAILURE_BUDGET} consecutive retryable failures → phase FAILED`, async () => {
+    const pages = [
+      buildPage('wiki/a'),
+      buildPage('wiki/b'),
+      buildPage('wiki/c'),
+      buildPage('wiki/d'), // must NOT be reached after budget trips
+    ];
+    const engine = buildMockEngine(pages);
+    let calls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      calls++;
+      throw makeConnRefusedError();
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    expect(result.status).toBe('fail');
+    expect(calls).toBe(CONSECUTIVE_TRANSPORT_FAILURE_BUDGET);
+    const details = result.details as Record<string, unknown>;
+    expect(details.transport_abort).toBe(true);
+    expect(details.abort_reason).toBe('consecutive_transport_failures');
+    expect(details.consecutive_transport_failures).toBe(CONSECUTIVE_TRANSPORT_FAILURE_BUDGET);
+  });
+
+  test('(b) interleaved success resets the consecutive counter', async () => {
+    const pages = [
+      buildPage('wiki/a'),
+      buildPage('wiki/b'),
+      buildPage('wiki/c'),
+      buildPage('wiki/d'),
+      buildPage('wiki/e'),
+    ];
+    const engine = buildMockEngine(pages);
+    let calls = 0;
+    // fail, fail, success, fail, fail → never 3 consecutive → ok
+    const extractor: ProposeTakesExtractor = async () => {
+      calls++;
+      if (calls === 3) {
+        return [{ claim_text: 'reset claim', kind: 'take', holder: 'brain', weight: 0.5 }];
+      }
+      throw makeTimeoutError();
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    expect(result.status).toBe('ok');
+    expect(calls).toBe(5);
+    const details = result.details as Record<string, unknown>;
+    expect(details.transport_abort).not.toBe(true);
+    expect(details.proposals_inserted).toBe(1);
+  });
+
+  test('(c) non-retryable errors (auth, parse-shaped) do NOT increment the budget', async () => {
+    const pages = [
+      buildPage('wiki/a'),
+      buildPage('wiki/b'),
+      buildPage('wiki/c'),
+      buildPage('wiki/d'),
+    ];
+    const engine = buildMockEngine(pages);
+    let calls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      calls++;
+      // Four auth failures — if counted as transport, budget would trip at 3.
+      const err = new Error('Invalid API key');
+      (err as Error & { status?: number }).status = 401;
+      throw err;
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    expect(result.status).toBe('ok');
+    expect(calls).toBe(4);
+    const details = result.details as Record<string, unknown>;
+    expect(details.transport_abort).not.toBe(true);
+    expect((details.warnings as string[]).length).toBe(4);
+  });
+
+  test('(d) cause-chain classification: wrapped timeout increments the budget', async () => {
+    const pages = [buildPage('wiki/a'), buildPage('wiki/b'), buildPage('wiki/c')];
+    const engine = buildMockEngine(pages);
+    const extractor: ProposeTakesExtractor = async () => {
+      const root = makeTimeoutError('socket hang up after deadline');
+      const wrapped = new Error('AI SDK retry loop exhausted');
+      (wrapped as Error & { cause?: unknown }).cause = root;
+      throw wrapped;
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    expect(result.status).toBe('fail');
+    const details = result.details as Record<string, unknown>;
+    expect(details.transport_abort).toBe(true);
+    expect(details.consecutive_transport_failures).toBe(3);
+  });
+
+  test('(e) last errors + affected page slugs are present in the phase report', async () => {
+    const pages = [buildPage('wiki/alpha'), buildPage('wiki/beta'), buildPage('wiki/gamma')];
+    const engine = buildMockEngine(pages);
+    let n = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      n++;
+      if (n === 1) throw makeConnRefusedError();
+      if (n === 2) throw makeProvider5xx();
+      throw makeTimeoutError('deadline exceeded');
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    expect(result.status).toBe('fail');
+    const details = result.details as Record<string, unknown>;
+    const slugs = details.transport_failure_slugs as string[];
+    const errors = details.transport_failure_errors as string[];
+    expect(slugs).toEqual(['wiki/alpha', 'wiki/beta', 'wiki/gamma']);
+    expect(errors).toHaveLength(3);
+    expect(errors[0]).toMatch(/ECONNREFUSED/);
+    expect(errors[1]).toMatch(/Internal Server Error|503/i);
+    expect(errors[2]).toMatch(/deadline|timeout|ETIMEDOUT/i);
+    // Warnings still carry the per-page messages for operator readability.
+    expect((details.warnings as string[]).some(w => w.includes('wiki/alpha'))).toBe(true);
+  });
+
+  test('(f) bare AbortError does not trip budget — phase completes, no abort', async () => {
+    // Four pages, each throws bare AbortError (user cancel shape). If
+    // misclassified as transport, budget would trip at 3 and status=fail.
+    const pages = [
+      buildPage('wiki/a'),
+      buildPage('wiki/b'),
+      buildPage('wiki/c'),
+      buildPage('wiki/d'),
+    ];
+    const engine = buildMockEngine(pages);
+    let calls = 0;
+    const extractor: ProposeTakesExtractor = async () => {
+      calls++;
+      const err = new Error('This operation was aborted');
+      err.name = 'AbortError';
+      throw err;
+    };
+
+    const result = await runPhaseProposeTakes(buildCtx(engine), { extractor });
+
+    expect(result.status).toBe('ok');
+    expect(calls).toBe(4);
+    const details = result.details as Record<string, unknown>;
+    expect(details.transport_abort).not.toBe(true);
+    expect((details.warnings as string[]).length).toBe(4);
+  });
+});
+
+// ─── Multi-phase rollup + dream exit mapping ────────────────────────
+
+function emptyTotals(): CycleReport['totals'] {
+  return {
+    lint_fixes: 0,
+    backlinks_added: 0,
+    pages_synced: 0,
+    pages_extracted: 0,
+    pages_embedded: 0,
+    orphans_found: 0,
+    transcripts_processed: 0,
+    synth_pages_written: 0,
+    patterns_written: 0,
+    pages_emotional_weight_recomputed: 0,
+    edges_resolved: 0,
+    edges_ambiguous: 0,
+    purged_sources_count: 0,
+    purged_pages_count: 0,
+    facts_consolidated: 0,
+    consolidate_takes_written: 0,
+    phantoms_redirected: 0,
+    phantoms_ambiguous: 0,
+    phantoms_skipped_drift: 0,
+  };
+}
+
+function phase(
+  name: PhaseResult['phase'],
+  status: PhaseResult['status'],
+  details: Record<string, unknown> = {},
+): PhaseResult {
+  return {
+    phase: name,
+    status,
+    duration_ms: 1,
+    summary: `${name}: ${status}`,
+    details,
+  };
+}
+
+describe('transport_abort escalates overall cycle status to failed', () => {
+  test('multi-phase: propose_takes transport_abort + sibling ok → overall failed', () => {
+    // The silent-success wedge: without this escalation, fail+ok rolls
+    // to 'partial' and dream exits 0.
+    const phases: PhaseResult[] = [
+      phase('propose_takes', 'fail', {
+        transport_abort: true,
+        abort_reason: 'consecutive_transport_failures',
+        consecutive_transport_failures: CONSECUTIVE_TRANSPORT_FAILURE_BUDGET,
+      }),
+      phase('embed', 'ok', { embedded: 12 }),
+    ];
+    expect(phaseForcesCycleFailed(phases[0]!)).toBe(true);
+    expect(deriveStatus(phases, emptyTotals())).toBe('failed');
+  });
+
+  test('ordinary per-item fail + ok still rolls to partial (not failed)', () => {
+    // Do not change the meaning of 'partial' for ordinary failures.
+    const phases: PhaseResult[] = [
+      phase('propose_takes', 'fail', {
+        // no transport_abort marker — e.g. unexpected throw envelope
+        error_code: 'UNKNOWN',
+      }),
+      phase('embed', 'ok', { embedded: 3 }),
+    ];
+    expect(phaseForcesCycleFailed(phases[0]!)).toBe(false);
+    expect(deriveStatus(phases, emptyTotals())).toBe('partial');
+  });
+
+  test("dream command exits nonzero only on overall 'failed' (source mapping)", () => {
+    // dream.ts — process.exit(1) when report.status === 'failed'.
+    // Combined with the rollup above, transport_abort → failed → rc≠0.
+    const dreamSource = readFileSync(
+      new URL('../../src/commands/dream.ts', import.meta.url),
+      'utf8',
+    );
+    const exitIdx = dreamSource.indexOf('// Exit non-zero when the cycle failed overall');
+    expect(exitIdx).toBeGreaterThan(0);
+    const exitBlock = dreamSource.slice(exitIdx, exitIdx + 350);
+    // Exit condition is failed only — partial is soft (mentioned in comment,
+    // never in the if condition).
+    expect(exitBlock).toMatch(/if\s*\(\s*report\.status\s*===\s*['"]failed['"]\s*\)/);
+    expect(exitBlock).toMatch(/process\.exit\(1\)/);
+    expect(exitBlock).not.toMatch(/if\s*\([^)]*partial/);
+  });
+});


### PR DESCRIPTION
# fix(cycle): abort propose_takes after 3 consecutive transport failures

## Problem

gbrain cycle phases (including `propose_takes`) catch per-item LLM errors and
continue so one bad page cannot kill the whole run. That is correct for parse
failures and content rejection — but when the **egress path is fully dead**
(proxy packet-drop, DNS blackhole, provider 5xx storm), the same loop becomes
an infinite-retry / silent-success wedge:

- every page's extractor call fails
- each failure is swallowed into `warnings`
- the phase returns **status=ok** with zero proposals written
- process-level **rc=0**

**Evidence (2026-07-17):** under an nftables packet-drop drill against the
proxy port on our box, a fully blocked run exited rc=0 reporting the operator-
visible "Embedded 0 chunks" / zero-work success class. Cron and autopilot
treat that as healthy.

A second wedge exists one layer up: even when the phase correctly returns
`status: 'fail'`, the cycle rollup turns mixed fail+ok into overall
`'partial'`, and `gbrain dream` exits nonzero only on overall `'failed'`.
A normal multi-phase dream that trips the transport budget would still exit
rc=0.

## Fix

Abort `propose_takes` after a budget of **3 consecutive retryable transport
failures**. Phase result is **`status: 'fail'`** with
`details.transport_abort: true`. The cycle rollup treats that marker as
**cycle-fatal**: overall status becomes `'failed'` (not `'partial'`), so
`gbrain dream` exits nonzero — including multi-phase runs where another
phase succeeded. Ordinary per-item phase failures still roll to `'partial'`.

### What counts (retryable transport)

- Timeout / deadline (`TimeoutError`, `ETIMEDOUT`, deadline-exceeded messages)
- **Abort-caused-by-deadline/timeout only** — `AbortError` counts when its
  message, cause chain, or abort `reason` indicates a timeout/deadline
  (e.g. nested `TimeoutError`, "aborted due to timeout"). A **bare
  AbortError** (user cancellation, unrelated signal) does **not** count.
- Connection / DNS (`ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`, `ECONNRESET`, …)
- Provider **5xx** (`status` / `statusCode` 500–599)

### What does **not** count

- Bare `AbortError` without a timeout-shaped cause/reason/message
- Parse failures (extractor returns `[]` today; explicit parse-shaped throws
  also stay non-transport)
- Content rejection / safety filter
- Auth / config errors (401/403 and similar 4xx)
- Empty results

### Cause-chain classification (reviewer footgun)

Classification walks the error **cause chain** (`Error.cause`),
`AggregateError.errors`, and abort **`reason`** (AbortSignal / DOMException).
An SDK retry loop that exhausts and rethrows a wrapper whose only timeout
lives on `.cause` still increments the budget — message-string regex alone
is not sufficient.

### Counter rules

- Increment only on retryable transport failures
- **Reset to 0 after any successful LLM response**
- Non-transport errors neither increment nor reset
- On abort, the phase report preserves:
  - `transport_abort: true`
  - `abort_reason: 'consecutive_transport_failures'`
  - `consecutive_transport_failures`
  - `transport_failure_slugs` (affected page slugs)
  - `transport_failure_errors` (last error messages)

### Cycle rollup

- `deriveStatus` checks `details.transport_abort` via `phaseForcesCycleFailed`
- If any phase has the marker → overall `'failed'`
- Ordinary fail + ok (no marker) → still `'partial'`
- `dream.ts` exits `process.exit(1)` when `report.status === 'failed'`

## Scope

- Budget lives in `propose_takes` (the per-item catch-and-continue seam)
- Shared classifier: `src/core/cycle/transport-failure.ts` (reusable by
  sibling phases later; not retrofitted here — minimal upstream-shaped diff)
- Fatal rollup marker: `cycle.ts` `deriveStatus` + `phaseForcesCycleFailed`
- No cycle-level abort-signal wiring in this PR (consecutive budget is the
  direct fix and takes priority)

## Tests

`test/cycle/propose-takes-transport-abort.test.ts`:

1. 3 consecutive retryable failures → phase `fail` + budget fields
2. Interleaved success resets the counter
3. Auth / non-retryable errors do not increment
4. Wrapped / AggregateError timeout still increments (cause chain)
5. Last errors + page slugs present in the phase report
6. Bare AbortError does not trip budget (phase completes, no abort)
7. Multi-phase: transport_abort + sibling ok → overall `failed`; ordinary
   fail+ok stays `partial`; dream exit mapping is nonzero only on `failed`

## Files

- `src/core/cycle/transport-failure.ts` (new)
- `src/core/cycle/propose-takes.ts` (budget at extractor catch)
- `src/core/cycle.ts` (`phaseForcesCycleFailed` + `deriveStatus` fatal rollup)
- `test/cycle/propose-takes-transport-abort.test.ts` (new)
