### PR TITLE
feat(sources): per-source trust-frontmatter-slug opt-in for SLUG_MISMATCH

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -144,6 +144,19 @@ export async function runImport(
       if (nudge) process.stderr.write(nudge + '\n');
     }
   }
+
+  // Per-source SLUG_MISMATCH escape hatch (`gbrain sources trust-frontmatter-slug`).
+  // Load once, thread to every per-file importFile call below — same
+  // load-once-per-command shape as importActivePack above. This is the path
+  // `performFullSync` (sync.ts `--full`) actually runs per-file through, so
+  // it must see the flag too, not just the incremental sync.ts call sites.
+  let trustFrontmatterSlug = false;
+  if (sourceId) {
+    const { fetchSource, isFrontmatterSlugTrusted } = await import('../core/sources-load.ts');
+    const src = await fetchSource(engine, sourceId);
+    if (src) trustFrontmatterSlug = isFrontmatterSlugTrusted(src.config);
+  }
+
   const workersIdx = args.indexOf('--workers');
   const workersArg = workersIdx !== -1 ? args[workersIdx + 1] : null;
   // v0.22.13 (PR #490 Q2): shared parseWorkers helper rejects bad input
@@ -239,7 +252,7 @@ export async function runImport(
       // unreachable when the gate is off; defense-in-depth check anyway.
       const result = isImageFilePath(relativePath) && process.env.GBRAIN_EMBEDDING_MULTIMODAL === 'true'
         ? await importImageFile(eng, filePath, relativePath, { noEmbed, sourceId })
-        : await importFile(eng, filePath, relativePath, { noEmbed, sourceId, activePack: importActivePack });
+        : await importFile(eng, filePath, relativePath, { noEmbed, sourceId, activePack: importActivePack, trustFrontmatterSlug });
       const _fileMs = Date.now() - _fileT0;
       if (_fileMs > 5000) {
         console.error(`[gbrain phase] import.process_file slow ${_fileMs}ms ${relativePath}`);

--- a/src/commands/sources.ts
+++ b/src/commands/sources.ts
@@ -16,6 +16,8 @@
  *   gbrain sources detach        — remove .gbrain-source from CWD
  *   gbrain sources federate <id>   — sources.config.federated = true
  *   gbrain sources unfederate <id> — sources.config.federated = false
+ *   gbrain sources trust-frontmatter-slug <id>   — sources.config.trust_frontmatter_slug = true
+ *   gbrain sources untrust-frontmatter-slug <id> — sources.config.trust_frontmatter_slug = false
  *
  * NOT in scope for Step 6 (deferred per plan):
  *   - import-from-github (needs SSRF + clone integration)
@@ -729,6 +731,38 @@ async function runFederate(engine: BrainEngine, args: string[], value: boolean):
   }
 }
 
+// ── Subcommand: trust-frontmatter-slug / untrust-frontmatter-slug ──
+
+async function runTrustFrontmatterSlug(engine: BrainEngine, args: string[], value: boolean): Promise<void> {
+  const id = args[0];
+  if (!id) {
+    console.error(`Usage: gbrain sources ${value ? 'trust-frontmatter-slug' : 'untrust-frontmatter-slug'} <id>`);
+    process.exit(2);
+  }
+  const src = await fetchSource(engine, id);
+  if (!src) {
+    console.error(`Source "${id}" not found.`);
+    process.exit(4);
+  }
+  const config = parseConfig(src.config);
+  config.trust_frontmatter_slug = value;
+  await engine.executeRaw(
+    `UPDATE sources SET config = $1::text::jsonb WHERE id = $2`,
+    [JSON.stringify(config), id],
+  );
+  if (value) {
+    console.log(
+      `Source "${id}" now trusts frontmatter-declared slugs: a page whose path-derived slug ` +
+        `differs from its frontmatter "slug:" is imported under the frontmatter slug instead of ` +
+        `being rejected as SLUG_MISMATCH. Use only for sources where "slug:" is a real external ` +
+        `identity (e.g. a Docusaurus docs site's custom routes) — never for user-writable/PR-mergeable ` +
+        `sources where a mismatched slug could be a page-hijack attempt.`,
+    );
+  } else {
+    console.log(`Source "${id}" no longer trusts frontmatter-declared slugs (anti-spoof restored).`);
+  }
+}
+
 // ── v0.40 sources status (D12) ──────────────────────────────
 async function runStatus(engine: BrainEngine, args: string[]): Promise<void> {
   const json = args.includes('--json');
@@ -1317,6 +1351,8 @@ export async function runSources(engine: BrainEngine, args: string[]): Promise<v
     case 'detach':     runDetach(); return;
     case 'federate':   return runFederate(engine, rest, true);
     case 'unfederate': return runFederate(engine, rest, false);
+    case 'trust-frontmatter-slug':   return runTrustFrontmatterSlug(engine, rest, true);
+    case 'untrust-frontmatter-slug': return runTrustFrontmatterSlug(engine, rest, false);
     case 'archive':    return runArchive(engine, rest);
     case 'restore':    return runRestore(engine, rest);
     case 'purge':      return runPurge(engine, rest);
@@ -1384,6 +1420,10 @@ Subcommands:
                                     targeting the brain you think you are.
   federate <id>                     Make source appear in cross-source default search.
   unfederate <id>                   Isolate source from default search.
+  trust-frontmatter-slug <id>       Import accepts frontmatter "slug:" even when it
+                                    differs from the path-derived slug (e.g. Docusaurus
+                                    custom routes). Only for sources you trust.
+  untrust-frontmatter-slug <id>     Restore path-vs-frontmatter slug anti-spoof (default).
   set-cr-mode <id> <none|title|per_chunk_synopsis>
                                     Per-source contextual retrieval mode
                                     override (v0.40.3.0). Pass "unset" or

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1483,6 +1483,9 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
   // disk/YAML/hash overhead × thousands of files. Best-effort: pack load
   // failure falls through to legacy inferType (parity preserved).
   let syncActivePack: { page_types: ReadonlyArray<{ name: string; path_prefixes: ReadonlyArray<string> }> } | undefined;
+  // Per-source SLUG_MISMATCH escape hatch (`gbrain sources trust-frontmatter-slug`).
+  // Set below once opts.sourceId's config is read; false (anti-spoof intact) by default.
+  let syncTrustFrontmatterSlug = false;
   try {
     // v0.41.37.0 #1569: --no-schema-pack escape hatch. Skip pack load entirely so
     // no user-supplied pack regex (markdown.ts subtype path_pattern) runs during
@@ -1522,6 +1525,9 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       typeof cfgRows[0]?.config === 'string'
         ? (JSON.parse(cfgRows[0].config as string) as Record<string, unknown>)
         : ((cfgRows[0]?.config ?? {}) as Record<string, unknown>);
+    // Per-source opt-in read once per sync, threaded to every importFile call
+    // below (same load-once-per-command shape as syncActivePack above).
+    syncTrustFrontmatterSlug = cfg.trust_frontmatter_slug === true;
     const remoteUrl = typeof cfg.remote_url === 'string' ? cfg.remote_url : null;
     if (remoteUrl) {
       const ownSrc = {
@@ -2309,7 +2315,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
       // Reimport at new path (picks up content changes)
       const filePath = join(repoPath, to);
       if (existsSync(filePath)) {
-        const result = await importFile(engine, filePath, to, { noEmbed, sourceId: opts.sourceId, activePack: syncActivePack });
+        const result = await importFile(engine, filePath, to, { noEmbed, sourceId: opts.sourceId, activePack: syncActivePack, trustFrontmatterSlug: syncTrustFrontmatterSlug });
         if (result.status === 'imported') chunksCreated += result.chunks;
       }
       pagesAffected.push(newSlug);
@@ -2499,7 +2505,7 @@ async function performSyncInner(engine: BrainEngine, opts: SyncOpts): Promise<Sy
         // 'default' was applied even for non-default sources, fabricating
         // duplicate rows that crashed bare-slug subqueries with Postgres 21000.
         const result = await observed(pacer, () =>
-          importFile(eng, filePath, path, { noEmbed, sourceId: opts.sourceId, activePack: syncActivePack }));
+          importFile(eng, filePath, path, { noEmbed, sourceId: opts.sourceId, activePack: syncActivePack, trustFrontmatterSlug: syncTrustFrontmatterSlug }));
         if (result.status === 'imported') {
           chunksCreated += result.chunks;
           pagesAffected.push(result.slug);

--- a/src/core/audit-slug-fallback.ts
+++ b/src/core/audit-slug-fallback.ts
@@ -29,14 +29,22 @@ import { createAuditWriter, computeIsoWeekFilename } from './audit/audit-writer.
 
 export interface SlugFallbackAuditEvent {
   ts: string;
-  /** Resolved slug (the frontmatter slug that overrode the empty path slug). */
+  /** Resolved slug (the frontmatter slug that overrode the path-derived one). */
   slug: string;
-  /** Repo-relative path that produced an empty slugifyPath(). */
+  /** Repo-relative path whose path-derived slug was overridden. */
   source_path: string;
   /** Always 'info' — keeps the schema explicit for future severity tiers. */
   severity: 'info';
   /** Stable code consumed by `gbrain doctor`'s slug_fallback_audit check. */
   code: 'SLUG_FALLBACK_FRONTMATTER';
+  /**
+   * Why the frontmatter slug won. 'empty_path_slug' (default, back-compat):
+   * slugifyPath() on the file's path returned empty (emoji/CJK filenames).
+   * 'trusted_source': the source opted in via `sources trust-frontmatter-slug`
+   * and the path DID derive a slug, but the frontmatter slug (a real external
+   * route, e.g. Docusaurus) was honored instead.
+   */
+  reason?: 'empty_path_slug' | 'trusted_source';
 }
 
 /** ISO-week-rotated filename: `slug-fallback-YYYY-Www.jsonl`. */
@@ -58,16 +66,24 @@ const writer = createAuditWriter<SlugFallbackAuditEvent>({
  * logging). Write failure to the JSONL is logged but does NOT throw — the
  * import succeeds either way.
  */
-export function logSlugFallback(slug: string, sourcePath: string): void {
+export function logSlugFallback(
+  slug: string,
+  sourcePath: string,
+  reason: 'empty_path_slug' | 'trusted_source' = 'empty_path_slug',
+): void {
   // D7 dual logging — every fallback gets an operator-visible stderr line
   // regardless of audit write success. Lives in this caller, not in the
   // shared writer, because only this audit module wants per-call stderr.
-  process.stderr.write(`[gbrain] slug fallback: ${sourcePath} → ${slug} (frontmatter slug; path slugified empty)\n`);
+  const why = reason === 'trusted_source'
+    ? 'frontmatter slug; source trusts frontmatter-declared slugs'
+    : 'frontmatter slug; path slugified empty';
+  process.stderr.write(`[gbrain] slug fallback: ${sourcePath} → ${slug} (${why})\n`);
   writer.log({
     slug,
     source_path: sourcePath,
     severity: 'info',
     code: 'SLUG_FALLBACK_FRONTMATTER',
+    reason,
   });
 }
 

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -1032,6 +1032,21 @@ export async function importFromFile(
     }
   }
 
+  // validateSlug() (src/core/utils.ts, called inside putPage) silently
+  // lowercases before storing, but sibling calls made later in this same
+  // import (addTag, etc. — see importFromContent) use whatever case
+  // resolvedSlug already has. Path-derived slugs are never affected
+  // (slugifyPath() already lowercases every segment), but a
+  // frontmatter-authored slug commonly isn't (e.g. `slug: bingAI`) —
+  // found live via a real docs sync: putPage stored "bingai", then
+  // addTag("bingAI", …) failed with "page not found". Normalize once,
+  // here, so every downstream call in this import agrees with what
+  // putPage will actually persist. No-op on CJK/RTL scripts (toLowerCase
+  // only affects cased Latin/Greek/Cyrillic etc.).
+  if (usedFrontmatterFallback) {
+    resolvedSlug = resolvedSlug.toLowerCase();
+  }
+
   // Emit the dual-channel audit entry AFTER we know we're not going to
   // short-circuit, so we don't log noise for failed imports.
   if (usedFrontmatterFallback) {

--- a/src/core/import-file.ts
+++ b/src/core/import-file.ts
@@ -902,6 +902,15 @@ export async function importFromContent(
  * could declare `slug: people/elon` in frontmatter and overwrite the legitimate
  * `people/elon` page on the next `gbrain sync` or `gbrain import`. In shared
  * brains where PRs are mergeable, this is a silent page-hijack primitive.
+ *
+ * Escape hatch: `opts.trustFrontmatterSlug` (set per-source via
+ * `gbrain sources trust-frontmatter-slug <id>`) lifts the rejection for that
+ * source only. Some federated sources (e.g. a Docusaurus docs site) declare
+ * `slug:` as the page's real published URL rather than a hijack attempt —
+ * blog posts and custom-route pages routinely live at a filesystem path that
+ * has nothing to do with their public route. The opt-in is per-source and
+ * explicit, so the hijack risk stays scoped to sources whose owner declared
+ * the frontmatter authoritative (same trust model as `--federated`).
  */
 export async function importFromFile(
   engine: BrainEngine,
@@ -912,6 +921,8 @@ export async function importFromFile(
     inferFrontmatter?: boolean;
     sourceId?: string;
     forceRechunk?: boolean;
+    /** Per-source opt-in — see function doc. Default false (anti-spoof intact). */
+    trustFrontmatterSlug?: boolean;
     /**
      * v0.39 T1.5: active schema pack threaded through to importFromContent so
      * `parseMarkdown` uses pack-driven type inference. Load ONCE per command;
@@ -967,6 +978,7 @@ export async function importFromFile(
   const expectedSlug = slugifyPath(relativePath);
   let resolvedSlug = expectedSlug;
   let usedFrontmatterFallback = false;
+  let slugFallbackReason: 'empty_path_slug' | 'trusted_source' = 'empty_path_slug';
 
   if (expectedSlug === '') {
     if (parsed.slug && parsed.slug.length > 0) {
@@ -989,22 +1001,41 @@ export async function importFromFile(
       };
     }
   } else if (parsed.slug !== expectedSlug) {
-    // Anti-spoof preserved: path DOES derive a slug, but the frontmatter slug
-    // claims a different one. Reject.
-    return {
-      slug: expectedSlug,
-      status: 'skipped',
-      chunks: 0,
-      error:
-        `Frontmatter slug "${parsed.slug}" does not match path-derived slug "${expectedSlug}" ` +
-        `(from ${relativePath}). Remove the frontmatter "slug:" line or move the file.`,
-    };
+    if (opts.trustFrontmatterSlug) {
+      // Source opted in (`gbrain sources trust-frontmatter-slug <id>`): the
+      // frontmatter slug is this page's real identity (e.g. a Docusaurus
+      // custom route), not a hijack attempt. Honor it — same fallback
+      // mechanism as the empty-path-slug case above, just a different trigger.
+      //
+      // Docusaurus (and most static-site generators) write `slug:` as a
+      // root-relative URL path (`/testing/web`), but gbrain's validateSlug
+      // (src/core/utils.ts) rejects any leading `/` as a security guard
+      // against path-derived spoofing at the storage chokepoint. That guard
+      // stays strict — normalize here instead, since a leading `/` on an
+      // explicitly-trusted slug is a URL-path convention, not an attack.
+      resolvedSlug = parsed.slug.replace(/^\/+/, '');
+      usedFrontmatterFallback = true;
+      slugFallbackReason = 'trusted_source';
+    } else {
+      // Anti-spoof preserved: path DOES derive a slug, but the frontmatter slug
+      // claims a different one. Reject.
+      return {
+        slug: expectedSlug,
+        status: 'skipped',
+        chunks: 0,
+        error:
+          `Frontmatter slug "${parsed.slug}" does not match path-derived slug "${expectedSlug}" ` +
+          `(from ${relativePath}). Remove the frontmatter "slug:" line, move the file, or if this ` +
+          `source's frontmatter slugs are authoritative (e.g. a Docusaurus docs site), run ` +
+          `\`gbrain sources trust-frontmatter-slug ${opts.sourceId ?? '<source-id>'}\`.`,
+      };
+    }
   }
 
   // Emit the dual-channel audit entry AFTER we know we're not going to
   // short-circuit, so we don't log noise for failed imports.
   if (usedFrontmatterFallback) {
-    logSlugFallback(resolvedSlug, relativePath);
+    logSlugFallback(resolvedSlug, relativePath, slugFallbackReason);
   }
 
   // Pass the resolved slug explicitly so that any future change to

--- a/src/core/sources-load.ts
+++ b/src/core/sources-load.ts
@@ -61,6 +61,20 @@ export function isSourceFederated(config: unknown): boolean {
 }
 
 /**
+ * True iff the source's config.trust_frontmatter_slug field is the literal
+ * boolean true. Set via `gbrain sources trust-frontmatter-slug <id>`.
+ *
+ * Opt-in escape hatch for federated sources whose frontmatter `slug:` field
+ * defines a real, external identity (e.g. Docusaurus custom routes / blog
+ * post URLs) rather than being a spoof attempt. See import-file.ts's
+ * SLUG_MISMATCH branch for how this is consumed.
+ */
+export function isFrontmatterSlugTrusted(config: unknown): boolean {
+  const parsed = parseSourceConfig(config);
+  return parsed.trust_frontmatter_slug === true;
+}
+
+/**
  * Enumerate every source. Order: 'default' first, then alphabetical by id.
  *
  * Caller filters in-process when the predicate is cheap (federatedOnly,

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -512,6 +512,111 @@ Content.
   });
 });
 
+// gbrain#3618-shaped fix — federated sources (e.g. Docusaurus docs sites)
+// declare frontmatter `slug:` as the page's real published URL, not a
+// hijack attempt. `trustFrontmatterSlug` is an opt-in per-source escape
+// hatch (set via `gbrain sources trust-frontmatter-slug <id>`) from the
+// path-vs-frontmatter anti-spoof rejection.
+describe('importFile — trustFrontmatterSlug opt-in (SLUG_MISMATCH escape hatch)', () => {
+  test('default (unset): mismatched frontmatter slug is still rejected', async () => {
+    const filePath = join(TMP, 'trust-default-off.md');
+    writeFileSync(filePath, `---
+title: Custom Route Post
+slug: blog/2026/07/16/custom-route-post
+---
+
+Body.
+`);
+    const engine = mockEngine();
+    const result = await importFile(engine, filePath, 'blog-posts/trust-default-off.md', { noEmbed: true });
+    expect(result.status).toBe('skipped');
+    expect(result.error).toContain('does not match path-derived slug');
+    expect((engine as any)._calls.length).toBe(0);
+  });
+
+  test('rejection hint names the opt-in command', async () => {
+    const filePath = join(TMP, 'trust-hint.md');
+    writeFileSync(filePath, `---
+title: Custom Route Post
+slug: blog/2026/07/16/custom-route-post
+---
+
+Body.
+`);
+    const engine = mockEngine();
+    const result = await importFile(engine, filePath, 'blog-posts/trust-hint.md', { noEmbed: true, sourceId: 'shaft-userguide' });
+    expect(result.status).toBe('skipped');
+    expect(result.error).toContain('gbrain sources trust-frontmatter-slug shaft-userguide');
+  });
+
+  test('trustFrontmatterSlug: true — mismatched slug is honored, not rejected', async () => {
+    const filePath = join(TMP, 'trust-on.md');
+    writeFileSync(filePath, `---
+title: Custom Route Post
+slug: blog/2026/07/16/custom-route-post
+---
+
+Body.
+`);
+    const engine = mockEngine();
+    const result = await importFile(engine, filePath, 'blog-posts/trust-on.md', {
+      noEmbed: true,
+      sourceId: 'shaft-userguide',
+      trustFrontmatterSlug: true,
+    });
+    expect(result.status).toBe('imported');
+    expect(result.slug).toBe('blog/2026/07/16/custom-route-post');
+    const putCall = (engine as any)._calls.find((c: any) => c.method === 'putPage');
+    expect(putCall.args[0]).toBe('blog/2026/07/16/custom-route-post');
+    expect(putCall.args[1].source_path).toBe('blog-posts/trust-on.md');
+  });
+
+  test('trustFrontmatterSlug: true — leading "/" (Docusaurus root-relative slug) is stripped', async () => {
+    // Docusaurus/most static-site generators write slug: as a root-relative
+    // URL path. gbrain's validateSlug (src/core/utils.ts) rejects any leading
+    // "/" as a security guard, so the trusted-fallback path must normalize it
+    // away rather than pass it straight to putPage.
+    const filePath = join(TMP, 'trust-leading-slash.md');
+    writeFileSync(filePath, `---
+title: Root Relative Route
+slug: /testing/web
+---
+
+Body.
+`);
+    const engine = mockEngine();
+    const result = await importFile(engine, filePath, 'docs/testing/web.md', {
+      noEmbed: true,
+      sourceId: 'shaft-userguide',
+      trustFrontmatterSlug: true,
+    });
+    expect(result.status).toBe('imported');
+    expect(result.slug).toBe('testing/web');
+    const putCall = (engine as any)._calls.find((c: any) => c.method === 'putPage');
+    expect(putCall.args[0]).toBe('testing/web');
+  });
+
+  test('trustFrontmatterSlug: true — path-derived slug still used when frontmatter has no slug', async () => {
+    // The opt-in only changes behavior on an actual MISMATCH; a file with no
+    // frontmatter slug at all must still resolve to its path-derived slug.
+    const filePath = join(TMP, 'trust-on-no-mismatch.md');
+    writeFileSync(filePath, `---
+title: Plain Doc
+---
+
+Body.
+`);
+    const engine = mockEngine();
+    const result = await importFile(engine, filePath, 'docs/trust-on-no-mismatch.md', {
+      noEmbed: true,
+      sourceId: 'shaft-userguide',
+      trustFrontmatterSlug: true,
+    });
+    expect(result.status).toBe('imported');
+    expect(result.slug).toBe('docs/trust-on-no-mismatch');
+  });
+});
+
 // v0.39.3.0 CV8 Phase 3d — DB content_hash excludes timestamp-bearing
 // frontmatter keys (captured_at, ingested_at) so identical body content
 // from capture-cli produces a stable hash across multiple captures.

--- a/test/import-file.test.ts
+++ b/test/import-file.test.ts
@@ -596,6 +596,33 @@ Body.
     expect(putCall.args[0]).toBe('testing/web');
   });
 
+  test('trustFrontmatterSlug: true — mixed-case frontmatter slug is lowercased', async () => {
+    // putPage's validateSlug() silently lowercases before storing, but
+    // sibling calls in the same import (addTag) use resolvedSlug as-is.
+    // A frontmatter slug with mixed case (unlike a path-derived slug, which
+    // slugifyPath() already lowercases) must be normalized here or addTag
+    // looks up a slug putPage never actually stored. Found live against a
+    // real docs source (`slug: bingAI`).
+    const filePath = join(TMP, 'trust-mixed-case.md');
+    writeFileSync(filePath, `---
+title: Bing AI Comparison
+slug: bingAI
+---
+
+Body.
+`);
+    const engine = mockEngine();
+    const result = await importFile(engine, filePath, 'blog/trust-mixed-case.md', {
+      noEmbed: true,
+      sourceId: 'shaft-userguide',
+      trustFrontmatterSlug: true,
+    });
+    expect(result.status).toBe('imported');
+    expect(result.slug).toBe('bingai');
+    const putCall = (engine as any)._calls.find((c: any) => c.method === 'putPage');
+    expect(putCall.args[0]).toBe('bingai');
+  });
+
   test('trustFrontmatterSlug: true — path-derived slug still used when frontmatter has no slug', async () => {
     // The opt-in only changes behavior on an actual MISMATCH; a file with no
     // frontmatter slug at all must still resolve to its path-derived slug.

--- a/test/sources-load.test.ts
+++ b/test/sources-load.test.ts
@@ -12,6 +12,7 @@ import {
   fetchSource,
   parseSourceConfig,
   isSourceFederated,
+  isFrontmatterSlugTrusted,
 } from '../src/core/sources-load.ts';
 
 let engine: PGLiteEngine;
@@ -130,5 +131,22 @@ describe('isSourceFederated', () => {
     expect(isSourceFederated({ federated: 1 })).toBe(false);
     expect(isSourceFederated({})).toBe(false);
     expect(isSourceFederated(null)).toBe(false);
+  });
+});
+
+describe('isFrontmatterSlugTrusted', () => {
+  test('strict-true requirement', () => {
+    expect(isFrontmatterSlugTrusted({ trust_frontmatter_slug: true })).toBe(true);
+    expect(isFrontmatterSlugTrusted({ trust_frontmatter_slug: false })).toBe(false);
+    expect(isFrontmatterSlugTrusted({ trust_frontmatter_slug: 'true' })).toBe(false); // strict boolean
+    expect(isFrontmatterSlugTrusted({})).toBe(false);
+    expect(isFrontmatterSlugTrusted(null)).toBe(false);
+  });
+
+  test('independent of the federated flag', async () => {
+    await insertSource('trusted-not-federated', { federated: false, config: { trust_frontmatter_slug: true } });
+    const row = await fetchSource(engine, 'trusted-not-federated');
+    expect(isSourceFederated(row!.config)).toBe(false);
+    expect(isFrontmatterSlugTrusted(row!.config)).toBe(true);
   });
 });

--- a/test/sources.test.ts
+++ b/test/sources.test.ts
@@ -250,3 +250,41 @@ describe('sources federate / unfederate', () => {
     expect(parsed.federated).toBe(false);
   });
 });
+
+// ── trust-frontmatter-slug / untrust-frontmatter-slug ──────
+
+describe('sources trust-frontmatter-slug / untrust-frontmatter-slug', () => {
+  test('trust-frontmatter-slug sets config.trust_frontmatter_slug = true', async () => {
+    const { engine, calls } = makeStub({
+      'SELECT id, name, local_path, last_commit, last_sync_at, config, created_at': [
+        { id: 'shaft-userguide', name: 'shaft-userguide', local_path: '/tmp/ug', last_commit: null, last_sync_at: null, config: '{}', created_at: new Date() },
+      ],
+    });
+    await runSources(engine, ['trust-frontmatter-slug', 'shaft-userguide']);
+    const upd = calls.find(c => c.sql.includes('UPDATE sources SET config'));
+    expect(upd).toBeDefined();
+    expect(JSON.parse(upd!.params[0] as string)).toEqual({ trust_frontmatter_slug: true });
+  });
+
+  test('untrust-frontmatter-slug preserves other config keys', async () => {
+    const { engine, calls } = makeStub({
+      'SELECT id, name, local_path, last_commit, last_sync_at, config, created_at': [
+        { id: 'shaft-userguide', name: 'shaft-userguide', local_path: '/tmp/ug', last_commit: null, last_sync_at: null, config: '{"federated":true,"trust_frontmatter_slug":true}', created_at: new Date() },
+      ],
+    });
+    await runSources(engine, ['untrust-frontmatter-slug', 'shaft-userguide']);
+    const upd = calls.find(c => c.sql.includes('UPDATE sources SET config'));
+    const parsed = JSON.parse(upd!.params[0] as string);
+    expect(parsed.federated).toBe(true);
+    expect(parsed.trust_frontmatter_slug).toBe(false);
+  });
+
+  test('trust-frontmatter-slug on unknown source id exits without an UPDATE', async () => {
+    const { engine, calls } = makeStub({
+      'SELECT id, name, local_path, last_commit, last_sync_at, config, created_at': [],
+    });
+    const code = await withExitCapture(() => runSources(engine, ['trust-frontmatter-slug', 'does-not-exist']));
+    expect(code).toBe(4);
+    expect(calls.find(c => c.sql.includes('UPDATE sources SET config'))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

Federated sources whose frontmatter `slug:` declares a real external identity
(e.g. a Docusaurus docs site's custom routes and blog-post URLs) fail the
path-vs-frontmatter anti-spoof check in `importFromFile` and get skipped as
`SLUG_MISMATCH`. There was no way to tell gbrain "this source's frontmatter
slugs are authoritative" short of hand-patching the anti-spoof rejection.

Concretely: `shafthq.github.io` (a Docusaurus site registered as a gbrain
source) has 83/187 markdown files (all blog posts + custom-route docs pages)
whose `slug:` frontmatter is the page's real published URL, not a path match.
`gbrain frontmatter validate --fix` must never run there — it would rewrite
public routes. Full report: [ShaftHQ/SHAFT_ENGINE#3618](https://github.com/ShaftHQ/SHAFT_ENGINE/issues/3618).

## Fix

An explicit, per-source opt-in — same shape as the existing `federated` flag:

```
gbrain sources trust-frontmatter-slug <id>
gbrain sources untrust-frontmatter-slug <id>
```

Stored as `config.trust_frontmatter_slug` (JSONB, same as `federated`).
When set, `importFromFile`'s SLUG_MISMATCH branch honors the frontmatter slug
instead of rejecting it — threaded through both `sync.ts` call sites
(incremental + `--full`) and `import.ts`'s `runImport` (the actual per-file
path `performFullSync` runs through, so `--full` sync sees the flag too, not
just incremental).

Docusaurus-style root-relative slugs (`slug: /testing/web`) are normalized
(leading `/` stripped) before use — `validateSlug`'s leading-slash rejection
in `src/core/utils.ts` is a security guard against path-derived spoofing at
the storage chokepoint and stays strict for every other caller; normalization
happens only on this explicitly-trusted path, found by running the fix
against the real 189-file source (see Verification).

Default is unset/false. The anti-spoof rejection is byte-for-byte unchanged
for every existing source that doesn't opt in — a new regression test pins
this (`default (unset): mismatched frontmatter slug is still rejected`).

## Trust model

Same scoping as `--federated`: explicit, per-source, source-owner opt-in.
The doc comments and CLI success message both call out that this should
never be set on a user-writable/PR-mergeable source, since it's still
possible for a mismatched slug to overwrite another page within that same
source's namespace — the opt-in narrows the anti-spoof hijack surface to
sources whose owner has declared frontmatter slugs authoritative, it doesn't
remove the surface globally.

## Testing

- `bun run typecheck` — clean.
- New unit tests in `test/import-file.test.ts` (default-off regression, opt-in
  honored, error-message hint, no-mismatch-no-op case, leading-slash
  normalization), `test/sources-load.test.ts` (`isFrontmatterSlugTrusted`),
  `test/sources.test.ts` (CLI subcommand pair, config preservation, not-found
  exit code).
- `bun test test/import-file.test.ts test/sources.test.ts test/sources-load.test.ts`
  — 61 pass, 0 fail.

## Verification against a real source

Applied `gbrain sources trust-frontmatter-slug shaft-userguide` and ran
`gbrain sync --source shaft-userguide --full` against the real
`shafthq.github.io` checkout (189 markdown files). First attempt (before the
leading-`/` normalization) surfaced the `validateSlug` rejection immediately
via a live "Invalid slug" error on the very first batch of Docusaurus files —
fixed and re-verified: pages previously rejected as `SLUG_MISMATCH` (e.g.
`docs/testing/web.mdx` → `slug: /testing/web`) now import cleanly under
`testing/web`, no `Invalid slug` errors, only the expected transient
embedding-timeout/content-dedup skips unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)