### PR TITLE
fix(mcp): report usable_tools honestly for stdio skill catalog

### DIFF
--- a/src/core/skill-catalog.ts
+++ b/src/core/skill-catalog.ts
@@ -295,7 +295,13 @@ export function confineManifestPath(skillsDir: string, entry: ManifestEntry): st
 function opCallableByCaller(op: Operation, ctx: OperationContext): boolean {
   if (ctx.remote === false) return true; // local CLI — OS is the trust boundary
   if (op.localOnly) return false; // not reachable over a remote transport
-  return hasScope(ctx.auth?.scopes ?? [], op.scope ?? 'read');
+  // Stdio MCP (`gbrain serve` with no AuthInfo): dispatch does NOT scope-gate
+  // (see src/mcp/server.ts). Claiming usable_tools=[] makes list_skills /
+  // get_skill dishonest and breaks skill-following agents (Hermes, Claude
+  // Desktop, etc.). HTTP always attaches AuthInfo and enforces hasScope in
+  // serve-http.ts — that path is unaffected.
+  if (!ctx.auth) return true;
+  return hasScope(ctx.auth.scopes ?? [], op.scope ?? 'read');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Stdio `gbrain serve` dispatches with `remote: true` and **no AuthInfo**, and does not scope-gate tool calls.
- `list_skills` / `get_skill` still ran `hasScope([])`, so they advertised `usable_tools: []` and `available_brain_tools: []`.
- That breaks skill-following agents (Hermes, Claude Desktop, etc.): the catalog says every tool is unavailable even though `search` / `put_page` / … actually work over stdio.

## Fix
When `ctx.auth` is absent (stdio path), treat non-`localOnly` ops as usable. HTTP transports always attach AuthInfo and keep enforcing `hasScope` in `serve-http.ts`.

## Test plan
- [x] Local: stdio-shaped ctx (`remote: true`, no auth) → `brain-ops` usable includes `search/query/get_page/put_page/...`, only `sync_brain` unavailable
- [x] Local: oauth read scope still blocks `put_page`
- [x] Live stdio MCP after restart: `available_brain_tools` ~94; `query` skill `unavailable_tools: []`
- [ ] CI: `bun test test/skill-catalog.test.ts`