### PR TITLE
test+ci: unbreak master — symlink-walker probe files + OSV caller permissions

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -24,6 +24,10 @@ jobs:
     permissions:
       actions: read
       contents: read
+      # Required by the reusable workflow's own top-level permissions block —
+      # GitHub validates the caller grants a superset AT STARTUP, even with
+      # upload-sarif: false (nothing is actually uploaded; see #2117 upstream).
+      security-events: write
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
     with:
       upload-sarif: false

--- a/test/sync-walker-symlink.test.ts
+++ b/test/sync-walker-symlink.test.ts
@@ -34,7 +34,7 @@ afterEach(() => {
 describe('collectSyncableFiles symlink + cycle hardening', () => {
   test('1. self-referencing symlink does not loop', async () => {
     await withEnv({ GBRAIN_EMBEDDING_MULTIMODAL: undefined }, () => {
-      writeFileSync(join(tmp, 'README.md'), '# top\n');
+      writeFileSync(join(tmp, 'notes.md'), '# top\n');
       // Symlink "loop" inside tempdir pointing back to itself.
       symlinkSync(tmp, join(tmp, 'loop'));
 
@@ -43,7 +43,7 @@ describe('collectSyncableFiles symlink + cycle hardening', () => {
       const ms = Date.now() - t0;
 
       expect(ms).toBeLessThan(1000); // would hang if walker followed the loop
-      expect(files).toContain(join(tmp, 'README.md'));
+      expect(files).toContain(join(tmp, 'notes.md'));
       expect(files.every(f => !f.includes('/loop/'))).toBe(true);
     });
   });
@@ -88,7 +88,7 @@ describe('collectSyncableFiles symlink + cycle hardening', () => {
 
   test('4. strategy filter admits the right files', async () => {
     await withEnv({ GBRAIN_EMBEDDING_MULTIMODAL: undefined }, () => {
-      writeFileSync(join(tmp, 'README.md'), '# r\n');
+      writeFileSync(join(tmp, 'notes.md'), '# r\n');
       writeFileSync(join(tmp, 'foo.ts'), '// f\n');
       writeFileSync(join(tmp, 'bar.py'), '# b\n');
 
@@ -97,8 +97,8 @@ describe('collectSyncableFiles symlink + cycle hardening', () => {
       const auto = collectSyncableFiles(tmp, { strategy: 'auto' });
 
       expect(code.map(f => f.split('/').pop()).sort()).toEqual(['bar.py', 'foo.ts']);
-      expect(markdown.map(f => f.split('/').pop())).toEqual(['README.md']);
-      expect(auto.map(f => f.split('/').pop()).sort()).toEqual(['README.md', 'bar.py', 'foo.ts']);
+      expect(markdown.map(f => f.split('/').pop())).toEqual(['notes.md']);
+      expect(auto.map(f => f.split('/').pop()).sort()).toEqual(['bar.py', 'foo.ts', 'notes.md']);
     });
   });
 


### PR DESCRIPTION
Two unbreak-master fixes:

1. **Symlink-walker tests** probed with README.md, which the import walker deliberately skips since #2315 (closing #345). Each PR was green alone; the intersection broke master's Test run. Probe with notes.md; test intent unchanged. 7/7 locally.
2. **OSV-Scanner workflow startup failure** (first firing, on #2924): GitHub requires the caller of a reusable workflow to grant a superset of the called workflow's declared permissions at startup — google's reusable declares `security-events: write` even when `upload-sarif: false`. Granted on the caller job with a comment. actionlint cannot catch cross-repo permission requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)