### PR TITLE
fix(dream): gate patterns phase on gateway provider reachability, not ANTHROPIC_API_KEY (takeover of #2279)

### DIFF
--- a/src/core/cycle/patterns.ts
+++ b/src/core/cycle/patterns.ts
@@ -27,6 +27,8 @@ import { waitForCompletion, TimeoutError } from '../minions/wait-for-completion.
 import type { MinionJobInput, SubagentHandlerData } from '../minions/types.ts';
 import { serializeMarkdown } from '../markdown.ts';
 import type { Page, PageType } from '../types.ts';
+import { probeChatModel } from '../ai/gateway.ts';
+import { normalizeModelId } from '../model-id.ts';
 
 export interface PatternsPhaseOpts {
   brainDir: string;
@@ -63,9 +65,20 @@ export async function runPhasePatterns(
       });
     }
 
-    // Submit one subagent for pattern detection.
-    if (!process.env.ANTHROPIC_API_KEY) {
-      return skipped('no_api_key', 'ANTHROPIC_API_KEY unset; pattern detection skipped');
+    // Submit one subagent for pattern detection. The subagent dispatches via
+    // the gateway model-tier resolver, so gate on "is the resolved model's
+    // provider reachable" rather than ANTHROPIC_API_KEY specifically — a
+    // hardcoded env gate misclassified non-Anthropic stacks (litellm,
+    // deepseek, openrouter, ...) as "no upstream" even though the subagent
+    // routes them through the gateway (agent.use_gateway_loop), and it missed
+    // Anthropic keys set via `gbrain config set anthropic_api_key`. Same
+    // probe semantics as think/index.ts + synthesize's makeJudgeClient:
+    // unknown provider/model or Anthropic-without-key skips cheaply; other
+    // providers' auth is checked lazily at dispatch and surfaces in the job
+    // outcome. (Takeover of PR #2279's intent by @brettdavies.)
+    const probe = probeChatModel(normalizeModelId(config.model));
+    if (!probe.ok) {
+      return skipped('no_provider', `pattern detection skipped: ${probe.detail}`);
     }
 
     const allowedSlugPrefixes = await loadAllowedSlugPrefixes();

--- a/test/cycle-patterns.test.ts
+++ b/test/cycle-patterns.test.ts
@@ -39,9 +39,14 @@ describe('patterns phase wiring', () => {
     expect(patternsSrc).toContain("tool_name = 'brain_put_page'");
   });
 
-  test('skips when ANTHROPIC_API_KEY missing', () => {
-    expect(patternsSrc).toContain('ANTHROPIC_API_KEY');
-    expect(patternsSrc).toContain('no_api_key');
+  test('gates on gateway provider reachability, not ANTHROPIC_API_KEY (PR #2279)', () => {
+    // The gate must probe the RESOLVED patterns model through the gateway
+    // (any configured provider can run patterns), not hardcode the Anthropic
+    // env var — that misclassified non-Anthropic stacks as "no upstream".
+    expect(patternsSrc).toContain('probeChatModel');
+    expect(patternsSrc).toContain('normalizeModelId');
+    expect(patternsSrc).toContain('no_provider');
+    expect(patternsSrc).not.toContain('process.env.ANTHROPIC_API_KEY');
   });
 
   test('skips when reflections below min_evidence', () => {

--- a/test/e2e/dream-patterns-pglite.test.ts
+++ b/test/e2e/dream-patterns-pglite.test.ts
@@ -9,7 +9,9 @@
  * Anthropic call:
  *   - disabled: dream.patterns.enabled=false → skipped
  *   - insufficient_evidence: <min_evidence reflections → skipped
- *   - no_api_key: enough reflections, no ANTHROPIC_API_KEY → skipped
+ *   - no_provider: enough reflections, no reachable provider for the
+ *     resolved patterns model (default: Anthropic with no key in env OR
+ *     config) → skipped
  *   - dry-run: passes through with reflections_considered + zero pages
  *
  * The Sonnet detection path is structurally covered in
@@ -23,6 +25,7 @@
 import { describe, test, expect } from 'bun:test';
 import { PGLiteEngine } from '../../src/core/pglite-engine.ts';
 import { runPhasePatterns } from '../../src/core/cycle/patterns.ts';
+import { withoutAnthropicKey } from '../helpers/no-anthropic-key.ts';
 
 interface TestRig {
   engine: PGLiteEngine;
@@ -41,17 +44,6 @@ async function setupRig(): Promise<TestRig> {
       try { await engine.disconnect(); } catch { /* */ }
     },
   };
-}
-
-async function withoutAnthropicKey<T>(body: () => Promise<T>): Promise<T> {
-  const saved = process.env.ANTHROPIC_API_KEY;
-  delete process.env.ANTHROPIC_API_KEY;
-  try {
-    return await body();
-  } finally {
-    if (saved === undefined) delete process.env.ANTHROPIC_API_KEY;
-    else process.env.ANTHROPIC_API_KEY = saved;
-  }
 }
 
 /**
@@ -141,18 +133,23 @@ describe('E2E patterns — insufficient_evidence', () => {
   }, 30_000);
 });
 
-describe('E2E patterns — no API key', () => {
-  test('enough reflections, no ANTHROPIC_API_KEY → skipped no_api_key', async () => {
+describe('E2E patterns — no reachable provider', () => {
+  test('enough reflections, no Anthropic key in env OR config → skipped no_provider', async () => {
     const rig = await setupRig();
     try {
       await seedReflections(rig.engine, 5); // above default min_evidence (3)
+      // Default patterns model resolves to Anthropic; with no key reachable
+      // from EITHER source (env + config file — the shared helper neuters
+      // both) the gateway probe reports the provider unavailable. A
+      // non-Anthropic stack (litellm, deepseek, ...) passes this gate and
+      // dispatches through the gateway instead (PR #2279).
       await withoutAnthropicKey(async () => {
         const result = await runPhasePatterns(rig.engine, {
           brainDir: rig.brainDir,
           dryRun: false,
         });
         expect(result.status).toBe('skipped');
-        expect((result.details as { reason?: string }).reason).toBe('no_api_key');
+        expect((result.details as { reason?: string }).reason).toBe('no_provider');
       });
     } finally {
       await rig.cleanup();


### PR DESCRIPTION
Verify-and-salvage takeover of #2279 (by @brettdavies; issue #2278 was closed as its dup).

**Why not merge #2279 as-is:** it removes the `ANTHROPIC_API_KEY` gate with *no replacement*, which (a) breaks the two tests that pin the skip path (`test/cycle-patterns.test.ts` structural check + `test/e2e/dream-patterns-pglite.test.ts` E2E), and (b) on an Anthropic-default install with no key, would submit a subagent job doomed to fail instead of skipping cheaply.

**The correct end-state (this PR), post-#2208:** the patterns phase should run when ANY capable provider is configured, gateway-routed — not gate on the Anthropic env var. The gate now probes the RESOLVED patterns model via `probeChatModel(normalizeModelId(config.model))`, the exact shared predicate `think/index.ts` and synthesize's `makeJudgeClient` already use (one predicate, no drift). This fixes both misclassifications of the old gate:

- Non-Anthropic stacks (litellm, deepseek, openrouter, ...) were skipped as "no upstream" even though the subagent routes them through the gateway (`agent.use_gateway_loop`). They now pass; their auth is checked lazily at dispatch and surfaces in the job outcome — the deliberate degrade contract the probe was built for.
- Anthropic keys set via `gbrain config set anthropic_api_key` (stdio MCP launches without shell env) were treated as missing; `hasAnthropicKey` inside the probe reads both sources.

Skip reason: `no_api_key` → `no_provider` (carries the probe's detail string). No other consumer of the old reason exists in src/docs/skills.

**Tests updated to pin the new behavior:**
- `test/cycle-patterns.test.ts`: asserts `probeChatModel` + `normalizeModelId` + `no_provider` wiring, and that `process.env.ANTHROPIC_API_KEY` is gone from the phase.
- `test/e2e/dream-patterns-pglite.test.ts`: expects `no_provider`; also swaps its local env-only helper for the shared hermetic `test/helpers/no-anthropic-key.ts` (neuters env AND config-file key), so the test can't flip to a live LLM call on a dev machine whose `~/.gbrain/config.json` carries a real key.

Verified: both pinning suites + `test/cycle*` + `dream-synthesize-pglite` E2E — 240 pass / 0 fail; `bun run typecheck` clean; `check-test-isolation` OK.

Credit: @brettdavies (Co-authored-by on the commit). Recommend closing #2279 as superseded by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)