### PR TITLE
test(e2e): production guard — setupDB refuses non-test databases

### DIFF
--- a/test/e2e/db-guard.test.ts
+++ b/test/e2e/db-guard.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for the setupDB production guard (assertSafeE2eDatabaseUrl).
+ * Pure — no database connection; runs with or without DATABASE_URL set.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { assertSafeE2eDatabaseUrl } from './helpers.ts';
+
+const NO_ENV = {} as Record<string, string | undefined>;
+
+describe('assertSafeE2eDatabaseUrl', () => {
+  test('allows the canonical CI test database', () => {
+    expect(() =>
+      assertSafeE2eDatabaseUrl('postgresql://postgres:postgres@localhost:5433/gbrain_test', NO_ENV),
+    ).not.toThrow();
+  });
+
+  test('allows test as any word segment', () => {
+    for (const name of ['test', 'test_gbrain', 'e2e-test', 'gbrain_test_2', 'TEST_DB']) {
+      expect(() =>
+        assertSafeE2eDatabaseUrl(`postgresql://u:p@localhost:5432/${name}`, NO_ENV),
+      ).not.toThrow();
+    }
+  });
+
+  test('refuses production-looking database names', () => {
+    for (const name of ['gbrain', 'postgres', 'prod', 'gbrain_live', 'contest', 'latest']) {
+      expect(() =>
+        assertSafeE2eDatabaseUrl(`postgresql://u:p@localhost:5432/${name}`, NO_ENV),
+      ).toThrow(/does not look like a test database/);
+    }
+  });
+
+  test('refuses a Supabase-style pooler URL with a bare postgres db', () => {
+    expect(() =>
+      assertSafeE2eDatabaseUrl(
+        'postgresql://postgres.ref:pw@aws-0-us-east-1.pooler.supabase.com:6543/postgres',
+        NO_ENV,
+      ),
+    ).toThrow(/does not look like a test database/);
+  });
+
+  test('explicit exact-name override opts a non-test database in', () => {
+    expect(() =>
+      assertSafeE2eDatabaseUrl('postgresql://u:p@localhost:5432/gbrain', {
+        GBRAIN_E2E_ALLOW_DB: 'gbrain',
+      }),
+    ).not.toThrow();
+  });
+
+  test('override must match the exact database name', () => {
+    expect(() =>
+      assertSafeE2eDatabaseUrl('postgresql://u:p@localhost:5432/gbrain', {
+        GBRAIN_E2E_ALLOW_DB: 'other_db',
+      }),
+    ).toThrow(/does not look like a test database/);
+  });
+
+  test('refuses unparseable URLs and missing database names', () => {
+    expect(() => assertSafeE2eDatabaseUrl('not a url', NO_ENV)).toThrow(/not a parseable URL/);
+    expect(() => assertSafeE2eDatabaseUrl('postgresql://u:p@localhost:5432/', NO_ENV)).toThrow(
+      /no database name/,
+    );
+  });
+});

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -67,6 +67,40 @@ export function hasDatabase(): boolean {
 }
 
 /**
+ * Production guard: setupDB() TRUNCATEs every data table on whatever
+ * DATABASE_URL points at, and run-e2e.sh deliberately preserves an exported
+ * DATABASE_URL — so a developer with a production URL in their environment
+ * would wipe their real brain by running the suite. Refuse unless the
+ * database name identifies itself as a test database ("test" as a word
+ * segment, e.g. gbrain_test — the CI/.env.testing.example convention), or
+ * the operator explicitly opts the exact name in via GBRAIN_E2E_ALLOW_DB.
+ *
+ * Exported for unit testing; pure — no connection is made.
+ */
+export function assertSafeE2eDatabaseUrl(
+  url: string,
+  env: Record<string, string | undefined> = process.env,
+): void {
+  let dbName: string;
+  try {
+    dbName = decodeURIComponent(new URL(url).pathname.replace(/^\//, ''));
+  } catch {
+    throw new Error(`E2E guard: DATABASE_URL is not a parseable URL; refusing to run destructive setup.`);
+  }
+  if (!dbName) {
+    throw new Error(`E2E guard: DATABASE_URL has no database name; refusing to run destructive setup.`);
+  }
+  if (/(^|[_-])test([_-]|$)/i.test(dbName)) return;
+  if (env.GBRAIN_E2E_ALLOW_DB && env.GBRAIN_E2E_ALLOW_DB === dbName) return;
+  throw new Error(
+    `E2E guard: database "${dbName}" does not look like a test database ` +
+    `(expected "test" as a name segment, e.g. gbrain_test). setupDB() would ` +
+    `TRUNCATE every data table in it. If this is intentional, set ` +
+    `GBRAIN_E2E_ALLOW_DB=${dbName} to opt in explicitly.`,
+  );
+}
+
+/**
  * Connect to DB, run schema init, truncate all tables.
  * Call in beforeAll() of each test file.
  */
@@ -74,6 +108,7 @@ export async function setupDB(): Promise<PostgresEngine> {
   if (!DATABASE_URL) {
     throw new Error('DATABASE_URL not set. Copy .env.testing.example to .env.testing and configure it.');
   }
+  assertSafeE2eDatabaseUrl(DATABASE_URL);
 
   // Disconnect any prior connection (clean slate)
   await db.disconnect();


### PR DESCRIPTION
## Summary

`setupDB()` TRUNCATEs every data table on whatever `DATABASE_URL` points at, and `run-e2e.sh` deliberately preserves an exported `DATABASE_URL` — so a developer with a production URL in their environment is one suite run away from wiping a real brain. There is currently no guard of any kind (no dbname check, no sentinel, no row-count sanity).

## Change

`assertSafeE2eDatabaseUrl` (pure, exported for testing) runs at the top of `setupDB()` before any connection:

- **allowed**: database names carrying `test` as a word segment — `gbrain_test` (the CI and `.env.testing.example` convention), `test_db`, `e2e-test`, … so nothing in CI changes;
- **allowed**: an exact-name opt-in via `GBRAIN_E2E_ALLOW_DB=<dbname>` for intentional cases;
- **refused loudly** otherwise, with an actionable message — including near-misses like `contest`/`latest` (word-segment rule) and the realistic footguns (`gbrain`, a Supabase-pooler `/postgres` URL).

## Verification

- `bun run typecheck` — pass
- `bun test test/e2e/db-guard.test.ts` — 7 pass (pure; no DB needed)
- `bun test test/e2e/engine-parity.test.ts` — 30 skip locally without `DATABASE_URL` (gate unchanged); CI executes as before since `gbrain_test` passes the guard

Found during an independent review pass while adding e2e coverage in #2956.

🤖 Generated with [Claude Code](https://claude.com/claude-code)