### PR TITLE
fix(cycle): synthesize budgets its sequential child waits from remaining job time (#2781 follow-up, stacked on #2959)

### DIFF
--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1964,6 +1964,7 @@ export async function registerBuiltinHandlers(
       brainDir: repoPath,
       phases: [phase as any],
       signal: job.signal,
+      deadlineAtMs: job.deadlineAtMs, // #2781: phases budget sub-work from remaining time
     });
     return { phase, status: report.status, report };
   };

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1780,6 +1780,7 @@ export async function registerBuiltinHandlers(
       brainDir: effectiveBrainDir,
       pull,
       signal: job.signal, // propagate abort so cycle bails on timeout/cancel
+      deadlineAtMs: job.deadlineAtMs, // #2781: phases budget sub-work from remaining time
       ...(sourceId ? { sourceId } : {}),
       ...(requestedPhases && requestedPhases.length > 0 ? { phases: requestedPhases as any } : {}),
       yieldBetweenPhases: async () => {
@@ -1817,6 +1818,7 @@ export async function registerBuiltinHandlers(
       brainDir: repoPath,
       pull: false, // brain-wide DB/maintenance work never git-pulls
       signal: job.signal,
+      deadlineAtMs: job.deadlineAtMs, // #2781: phases budget sub-work from remaining time
       phases,
       yieldBetweenPhases: async () => { await new Promise<void>((r) => setImmediate(r)); },
     });

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -1695,6 +1695,7 @@ export async function runCycle(
           // #1586: scope synthesized writes to the cycle's resolved source
           // (explicit --source wins, else derived from the checkout dir).
           sourceId: cycleSourceId,
+          deadlineAtMs: opts.deadlineAtMs ?? null,
         }));
         result.duration_ms = duration_ms;
         phaseResults.push(result);

--- a/src/core/cycle.ts
+++ b/src/core/cycle.ts
@@ -479,6 +479,16 @@ export interface CycleOpts {
    * Validated via `assertValidSourceId` in `cycleLockIdFor` (defense-in-depth).
    */
   sourceId?: string;
+  /**
+   * Absolute wall-clock deadline (epoch ms) of the enclosing minion job,
+   * from `MinionJobContext.deadlineAtMs` (the claim-time `timeout_at`
+   * stamp). Phases that spawn bounded sub-work (patterns' subagent) clamp
+   * their own timeouts to the REMAINING time so one phase's fixed
+   * worst-case can't blow past the job budget and dead-letter the whole
+   * cycle mid-phase (#2781). Unset for direct callers (`gbrain dream`) —
+   * phases then use their configured timeouts unchanged.
+   */
+  deadlineAtMs?: number | null;
 }
 
 // ─── Lock primitives ───────────────────────────────────────────────
@@ -1888,6 +1898,7 @@ export async function runCycle(
           brainDir,
           dryRun,
           yieldDuringPhase: opts.yieldDuringPhase,
+          deadlineAtMs: opts.deadlineAtMs ?? null,
         }));
         result.duration_ms = duration_ms;
         phaseResults.push(result);

--- a/src/core/cycle/deadline-budget.ts
+++ b/src/core/cycle/deadline-budget.ts
@@ -1,0 +1,69 @@
+/**
+ * #2781 — shared deadline-budget helpers for cycle phases that spawn
+ * subagent children (patterns, synthesize).
+ *
+ * The enclosing minion job carries an absolute deadline
+ * (`MinionJobContext.deadlineAtMs`, from the claim-time `timeout_at`
+ * stamp). Phases clamp their child-job timeouts and wait timeouts to the
+ * REMAINING time so one phase's fixed worst-case can't blow past the job
+ * budget and dead-letter the whole cycle mid-phase.
+ *
+ * Lives in its own module because patterns.ts imports from synthesize.ts
+ * (allow-list helpers) — synthesize importing these back from patterns
+ * would create an import cycle.
+ */
+
+/**
+ * Stop-margin reserved under the parent deadline when clamping subagent
+ * budgets. NOT a promise that tail phases complete — the cycle is allowed
+ * to go partial and resume next tick. This only guarantees the phase's
+ * wait returns and the handler unwinds cleanly before the worker's abort
+ * fires: wait poll interval (5s) + worker force-evict grace (30s) + lock
+ * and DB cleanup headroom.
+ */
+export const CYCLE_DEADLINE_RESERVE_MS = 60 * 1000;
+
+/**
+ * Smallest remaining budget worth submitting a subagent for. Below this,
+ * the LLM call is near-certain to be killed mid-flight — wasted spend and
+ * a guaranteed-timeout child — so the phase skips honestly instead
+ * (`insufficient_cycle_budget`) and the next cycle retries with a fresh
+ * budget.
+ */
+export const MIN_SUBAGENT_START_BUDGET_MS = 2 * 60 * 1000;
+
+/**
+ * Remaining child budget under the parent deadline, or null when the
+ * caller has no deadline (direct `gbrain dream`). May be <= 0 when the
+ * reserve is already breached — callers treat that as "no budget left".
+ */
+export function remainingChildBudgetMs(
+  deadlineAtMs: number | null | undefined,
+  nowMs: number,
+): number | null {
+  if (deadlineAtMs == null) return null;
+  return deadlineAtMs - CYCLE_DEADLINE_RESERVE_MS - nowMs;
+}
+
+/**
+ * Clamp the configured subagent budgets to the remaining parent-job time.
+ * Both timeouts derive from the SAME absolute child deadline
+ * (`deadlineAtMs - reserve`) so the child job's kill switch and our wait
+ * agree. Returns null when the remaining budget is below the minimum —
+ * caller should skip the phase without submitting.
+ */
+export function clampSubagentBudgets(
+  config: { subagentTimeoutMs: number; subagentWaitTimeoutMs: number },
+  deadlineAtMs: number | null | undefined,
+  nowMs: number,
+): { timeoutMs: number; waitTimeoutMs: number } | null {
+  const childBudgetMs = remainingChildBudgetMs(deadlineAtMs, nowMs);
+  if (childBudgetMs === null) {
+    return { timeoutMs: config.subagentTimeoutMs, waitTimeoutMs: config.subagentWaitTimeoutMs };
+  }
+  if (childBudgetMs < MIN_SUBAGENT_START_BUDGET_MS) return null;
+  return {
+    timeoutMs: Math.min(config.subagentTimeoutMs, childBudgetMs),
+    waitTimeoutMs: Math.min(config.subagentWaitTimeoutMs, childBudgetMs),
+  };
+}

--- a/src/core/cycle/patterns.ts
+++ b/src/core/cycle/patterns.ts
@@ -30,6 +30,11 @@ import type { Page, PageType } from '../types.ts';
 // #2415: allow-list + output-root resolution shared with the synthesize
 // phase — both phases must agree on the configured namespace.
 import { loadAllowedSlugPrefixes, loadOutputRoot } from './synthesize.ts';
+import {
+  clampSubagentBudgets,
+  CYCLE_DEADLINE_RESERVE_MS,
+  MIN_SUBAGENT_START_BUDGET_MS,
+} from './deadline-budget.ts';
 import { probeChatModel } from '../ai/gateway.ts';
 import { normalizeModelId } from '../model-id.ts';
 
@@ -46,48 +51,6 @@ export interface PatternsPhaseOpts {
    * mid-phase and starves every tail phase (#2781).
    */
   deadlineAtMs?: number | null;
-}
-
-/**
- * Stop-margin reserved under the parent deadline when clamping subagent
- * budgets. NOT a promise that tail phases complete — the cycle is allowed
- * to go partial and resume next tick. This only guarantees the phase's
- * wait returns and the handler unwinds cleanly before the worker's abort
- * fires: wait poll interval (5s) + worker force-evict grace (30s) + lock
- * and DB cleanup headroom.
- */
-export const CYCLE_DEADLINE_RESERVE_MS = 60 * 1000;
-
-/**
- * Smallest remaining budget worth submitting a subagent for. Below this,
- * the LLM call is near-certain to be killed mid-flight — wasted spend and
- * a guaranteed-timeout child — so the phase skips honestly instead
- * (`insufficient_cycle_budget`) and the next cycle retries with a fresh
- * budget.
- */
-export const MIN_PATTERNS_SUBAGENT_BUDGET_MS = 2 * 60 * 1000;
-
-/**
- * Clamp the configured subagent budgets to the remaining parent-job time.
- * Both timeouts derive from the SAME absolute child deadline
- * (`deadlineAtMs - reserve`) so the child job's kill switch and our wait
- * agree. Returns null when the remaining budget is below the minimum —
- * caller should skip the phase without submitting.
- */
-export function clampSubagentBudgets(
-  config: { subagentTimeoutMs: number; subagentWaitTimeoutMs: number },
-  deadlineAtMs: number | null | undefined,
-  nowMs: number,
-): { timeoutMs: number; waitTimeoutMs: number } | null {
-  if (deadlineAtMs == null) {
-    return { timeoutMs: config.subagentTimeoutMs, waitTimeoutMs: config.subagentWaitTimeoutMs };
-  }
-  const childBudgetMs = deadlineAtMs - CYCLE_DEADLINE_RESERVE_MS - nowMs;
-  if (childBudgetMs < MIN_PATTERNS_SUBAGENT_BUDGET_MS) return null;
-  return {
-    timeoutMs: Math.min(config.subagentTimeoutMs, childBudgetMs),
-    waitTimeoutMs: Math.min(config.subagentWaitTimeoutMs, childBudgetMs),
-  };
 }
 
 export async function runPhasePatterns(
@@ -149,7 +112,7 @@ export async function runPhasePatterns(
     if (budgets === null) {
       return skipped(
         'insufficient_cycle_budget',
-        `remaining cycle budget under ${Math.round(MIN_PATTERNS_SUBAGENT_BUDGET_MS / 1000)}s ` +
+        `remaining cycle budget under ${Math.round(MIN_SUBAGENT_START_BUDGET_MS / 1000)}s ` +
         `(reserve ${Math.round(CYCLE_DEADLINE_RESERVE_MS / 1000)}s); next cycle retries with a fresh budget`,
       );
     }

--- a/src/core/cycle/patterns.ts
+++ b/src/core/cycle/patterns.ts
@@ -37,6 +37,57 @@ export interface PatternsPhaseOpts {
   brainDir: string;
   dryRun: boolean;
   yieldDuringPhase?: () => Promise<void>;
+  /**
+   * Absolute deadline (epoch ms) of the enclosing minion job, or null for
+   * direct callers (`gbrain dream`). When set, the subagent's job timeout
+   * and the wait timeout are clamped so the phase finishes (or times out)
+   * BEFORE the parent job's budget expires — a fixed 30/35-min default
+   * inside an interval-derived cycle budget dead-letters the whole cycle
+   * mid-phase and starves every tail phase (#2781).
+   */
+  deadlineAtMs?: number | null;
+}
+
+/**
+ * Stop-margin reserved under the parent deadline when clamping subagent
+ * budgets. NOT a promise that tail phases complete — the cycle is allowed
+ * to go partial and resume next tick. This only guarantees the phase's
+ * wait returns and the handler unwinds cleanly before the worker's abort
+ * fires: wait poll interval (5s) + worker force-evict grace (30s) + lock
+ * and DB cleanup headroom.
+ */
+export const CYCLE_DEADLINE_RESERVE_MS = 60 * 1000;
+
+/**
+ * Smallest remaining budget worth submitting a subagent for. Below this,
+ * the LLM call is near-certain to be killed mid-flight — wasted spend and
+ * a guaranteed-timeout child — so the phase skips honestly instead
+ * (`insufficient_cycle_budget`) and the next cycle retries with a fresh
+ * budget.
+ */
+export const MIN_PATTERNS_SUBAGENT_BUDGET_MS = 2 * 60 * 1000;
+
+/**
+ * Clamp the configured subagent budgets to the remaining parent-job time.
+ * Both timeouts derive from the SAME absolute child deadline
+ * (`deadlineAtMs - reserve`) so the child job's kill switch and our wait
+ * agree. Returns null when the remaining budget is below the minimum —
+ * caller should skip the phase without submitting.
+ */
+export function clampSubagentBudgets(
+  config: { subagentTimeoutMs: number; subagentWaitTimeoutMs: number },
+  deadlineAtMs: number | null | undefined,
+  nowMs: number,
+): { timeoutMs: number; waitTimeoutMs: number } | null {
+  if (deadlineAtMs == null) {
+    return { timeoutMs: config.subagentTimeoutMs, waitTimeoutMs: config.subagentWaitTimeoutMs };
+  }
+  const childBudgetMs = deadlineAtMs - CYCLE_DEADLINE_RESERVE_MS - nowMs;
+  if (childBudgetMs < MIN_PATTERNS_SUBAGENT_BUDGET_MS) return null;
+  return {
+    timeoutMs: Math.min(config.subagentTimeoutMs, childBudgetMs),
+    waitTimeoutMs: Math.min(config.subagentWaitTimeoutMs, childBudgetMs),
+  };
 }
 
 export async function runPhasePatterns(
@@ -90,6 +141,19 @@ export async function runPhasePatterns(
         'skills/_brain-filing-rules.json missing dream_synthesize_paths.globs'));
     }
 
+    // #2781: budget the subagent from the REMAINING parent-job time, not
+    // the fixed config default. Checked after the cheap gates (disabled /
+    // insufficient_evidence / no_provider) so a skip for budget reasons
+    // only fires when the phase would otherwise have submitted.
+    const budgets = clampSubagentBudgets(config, opts.deadlineAtMs, Date.now());
+    if (budgets === null) {
+      return skipped(
+        'insufficient_cycle_budget',
+        `remaining cycle budget under ${Math.round(MIN_PATTERNS_SUBAGENT_BUDGET_MS / 1000)}s ` +
+        `(reserve ${Math.round(CYCLE_DEADLINE_RESERVE_MS / 1000)}s); next cycle retries with a fresh budget`,
+      );
+    }
+
     const queue = new MinionQueue(engine);
     const data: SubagentHandlerData = {
       prompt: buildPatternsPrompt(reflections, config.minEvidence, config.outputRoot),
@@ -99,7 +163,7 @@ export async function runPhasePatterns(
     };
     const submitOpts: Partial<MinionJobInput> = {
       max_stalled: 3,
-      timeout_ms: config.subagentTimeoutMs,
+      timeout_ms: budgets.timeoutMs,
     };
     const job = await queue.add('subagent', data as unknown as Record<string, unknown>, submitOpts, {
       allowProtectedSubmit: true,
@@ -108,7 +172,7 @@ export async function runPhasePatterns(
     let outcome: string;
     try {
       const final = await waitForCompletion(queue, job.id, {
-        timeoutMs: config.subagentWaitTimeoutMs,
+        timeoutMs: budgets.waitTimeoutMs,
         pollMs: 5 * 1000,
       });
       outcome = final.status;

--- a/src/core/cycle/patterns.ts
+++ b/src/core/cycle/patterns.ts
@@ -177,8 +177,18 @@ export async function runPhasePatterns(
       });
       outcome = final.status;
     } catch (e) {
-      if (e instanceof TimeoutError) outcome = 'timeout';
-      else throw e;
+      if (e instanceof TimeoutError) {
+        outcome = 'timeout';
+        // The child's own timeout_ms clock starts at ITS claim, not at
+        // submit — a child that sat queued behind other work can outlive
+        // the parent deadline this wait was clamped to. Cancel it so the
+        // subagent can't keep spending/writing after the phase gave up
+        // (waiting child → cancelled immediately; active child → lock
+        // stripped, worker abort fires on next renew tick).
+        try { await queue.cancelJob(job.id); } catch { /* best-effort */ }
+      } else {
+        throw e;
+      }
     }
 
     if (opts.yieldDuringPhase) {

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -602,6 +602,14 @@ export async function runPhaseSynthesize(
           // Same rationale as patterns: a child that sat queued can outlive
           // the deadline this wait was clamped to. Strip it.
           try { await queue.cancelJob(jobId); } catch { /* best-effort */ }
+          // A timeout on a DEADLINE-CLAMPED wait is budget truncation, not
+          // a genuine child overrun — the child never got its full
+          // configured wait. Suppress the cooldown stamp so the next cycle
+          // retries. A timeout at the full configured wait keeps the
+          // pre-existing stamping behavior.
+          if (remainingWaitMs !== null && waitTimeoutMs < config.subagentWaitTimeoutMs) {
+            budgetExhausted = true;
+          }
         } else {
           throw e;
         }

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -39,6 +39,11 @@ import { MinionQueue } from '../minions/queue.ts';
 import { waitForCompletion, TimeoutError } from '../minions/wait-for-completion.ts';
 import type { MinionJobInput, SubagentHandlerData } from '../minions/types.ts';
 import { discoverTranscripts, type DiscoveredTranscript } from './transcript-discovery.ts';
+import {
+  remainingChildBudgetMs,
+  CYCLE_DEADLINE_RESERVE_MS,
+  MIN_SUBAGENT_START_BUDGET_MS,
+} from './deadline-budget.ts';
 import { serializeMarkdown, serializePageToMarkdown } from '../markdown.ts';
 import type { Page, PageType } from '../types.ts';
 import { validateSourceId } from '../utils.ts';
@@ -252,6 +257,15 @@ export interface SynthesizePhaseOpts {
    * correct (source_id, slug) row. Unset → legacy 'default'.
    */
   sourceId?: string;
+  /**
+   * Absolute deadline (epoch ms) of the enclosing minion job, or null for
+   * direct callers (`gbrain dream`). When set, every child's job timeout
+   * is clamped to the remaining time at submit and — unlike patterns'
+   * single wait — the SEQUENTIAL per-child wait loop recomputes the
+   * remaining budget before each wait, so N children can't accumulate
+   * N × subagent_wait_timeout_ms past the parent budget (#2781).
+   */
+  deadlineAtMs?: number | null;
 }
 
 export async function runPhaseSynthesize(
@@ -405,6 +419,21 @@ export async function runPhaseSynthesize(
       });
     }
 
+    // #2781: budget the fan-out from the REMAINING parent-job time.
+    // Checked after the cheap gates (not_configured / cooldown / verdicts /
+    // dry-run) so a budget skip only fires when the phase would otherwise
+    // have submitted Sonnet work. Note the verdict loop above may itself
+    // have consumed wall-clock — that's why this reads Date.now() here,
+    // not at phase entry.
+    const preFanoutBudgetMs = remainingChildBudgetMs(opts.deadlineAtMs, Date.now());
+    if (preFanoutBudgetMs !== null && preFanoutBudgetMs < MIN_SUBAGENT_START_BUDGET_MS) {
+      return skipped(
+        'insufficient_cycle_budget',
+        `remaining cycle budget under ${Math.round(MIN_SUBAGENT_START_BUDGET_MS / 1000)}s ` +
+        `(reserve ${Math.round(CYCLE_DEADLINE_RESERVE_MS / 1000)}s); next cycle retries with a fresh budget`,
+      );
+    }
+
     // Fan-out: submit one subagent per worth-processing transcript (or one
     // per chunk for transcripts that exceed the model's per-prompt budget).
     const allowedSlugPrefixes = await loadAllowedSlugPrefixes(config.outputRoot);
@@ -423,6 +452,16 @@ export async function runPhaseSynthesize(
     const maxCharsPerChunk = computeChunkCharBudget(config.model, config.maxPromptTokens);
 
     for (const t of worthProcessing) {
+      // #2781: the submit loop itself is fast (DB inserts, no LLM), but the
+      // budget can still decay across a long worthProcessing list. Once it's
+      // gone, stop submitting — remaining transcripts re-attempt next cycle
+      // (idempotency keys make the partial fan-out safe to resume).
+      const remainingMs = remainingChildBudgetMs(opts.deadlineAtMs, Date.now());
+      if (remainingMs !== null && remainingMs <= 0) {
+        skipReports.push({ filePath: t.filePath, reason: 'insufficient_cycle_budget' });
+        continue;
+      }
+
       const hash16 = t.contentHash.slice(0, 16);
       const hash6 = t.contentHash.slice(0, 6);
 
@@ -487,11 +526,20 @@ export async function runPhaseSynthesize(
         const idempotency_key = isChunked
           ? `dream:synth:${t.filePath}:${hash16}:c${i}of${chunks.length}`
           : `dream:synth:${t.filePath}:${hash16}`;
+        // #2781: clamp each child's own kill switch to the remaining time
+        // at submit. The child's timeout_ms clock starts at ITS claim, so
+        // this alone can't bound a child that sits queued — the wait loop's
+        // cancel below closes that — but it bounds the common promptly-
+        // claimed case without waiting for the cancel path.
+        const remainingAtSubmitMs = remainingChildBudgetMs(opts.deadlineAtMs, Date.now());
+        const childTimeoutMs = remainingAtSubmitMs === null
+          ? config.subagentTimeoutMs
+          : Math.max(1, Math.min(config.subagentTimeoutMs, remainingAtSubmitMs));
         const submitOpts: Partial<MinionJobInput> = {
           max_stalled: 3,
           on_child_fail: 'continue',
           idempotency_key,
-          timeout_ms: config.subagentTimeoutMs,
+          timeout_ms: childTimeoutMs,
         };
         const child = await queue.add(
           'subagent',
@@ -508,17 +556,45 @@ export async function runPhaseSynthesize(
 
     // Wait for every child to reach a terminal state. Tick yieldDuringPhase
     // every 5 min so the cycle lock TTL refreshes.
+    //
+    // #2781: the waits are SEQUENTIAL, so a fixed per-wait timeout
+    // accumulates N × subagent_wait_timeout_ms across N children — past any
+    // parent budget. Each iteration recomputes the remaining budget against
+    // the same absolute deadline; once it's gone, the rest of the children
+    // are cancelled instead of waited on (their timeout_ms clock starts at
+    // THEIR claim, so an unwaited child could otherwise outlive the parent).
+    // A child that already reached a terminal state on its own keeps its
+    // real status — earlier siblings' waits gave it time to finish, and its
+    // pages still collect normally (cancelJob wouldn't touch a completed
+    // row anyway; the read is for honest reporting).
     const childOutcomes: Array<{ jobId: number; status: string }> = [];
     for (const jobId of childIds) {
+      const remainingWaitMs = remainingChildBudgetMs(opts.deadlineAtMs, Date.now());
+      if (remainingWaitMs !== null && remainingWaitMs <= 0) {
+        const current = await queue.getJob(jobId);
+        if (current && ['completed', 'failed', 'dead', 'cancelled'].includes(current.status)) {
+          childOutcomes.push({ jobId, status: current.status });
+        } else {
+          try { await queue.cancelJob(jobId); } catch { /* best-effort */ }
+          childOutcomes.push({ jobId, status: 'timeout' });
+        }
+        continue;
+      }
+      const waitTimeoutMs = remainingWaitMs === null
+        ? config.subagentWaitTimeoutMs
+        : Math.min(config.subagentWaitTimeoutMs, remainingWaitMs);
       try {
         const job = await waitForCompletion(queue, jobId, {
-          timeoutMs: config.subagentWaitTimeoutMs,
+          timeoutMs: waitTimeoutMs,
           pollMs: 5 * 1000,
         });
         childOutcomes.push({ jobId, status: job.status });
       } catch (e) {
         if (e instanceof TimeoutError) {
           childOutcomes.push({ jobId, status: 'timeout' });
+          // Same rationale as patterns: a child that sat queued can outlive
+          // the deadline this wait was clamped to. Strip it.
+          try { await queue.cancelJob(jobId); } catch { /* best-effort */ }
         } else {
           throw e;
         }

--- a/src/core/cycle/synthesize.ts
+++ b/src/core/cycle/synthesize.ts
@@ -451,13 +451,21 @@ export async function runPhaseSynthesize(
 
     const maxCharsPerChunk = computeChunkCharBudget(config.model, config.maxPromptTokens);
 
+    // Set when the budget runs out anywhere past the pre-fanout gate. A
+    // budget-truncated run must NOT stamp last_completion_ts — the default
+    // 12h cooldown would contradict "next cycle retries with a fresh
+    // budget" and pin the skipped work for half a day.
+    let budgetExhausted = false;
+
     for (const t of worthProcessing) {
       // #2781: the submit loop itself is fast (DB inserts, no LLM), but the
-      // budget can still decay across a long worthProcessing list. Once it's
-      // gone, stop submitting — remaining transcripts re-attempt next cycle
-      // (idempotency keys make the partial fan-out safe to resume).
+      // budget can still decay across a long worthProcessing list. Below
+      // the start minimum, stop submitting — remaining transcripts
+      // re-attempt next cycle (idempotency keys make the partial fan-out
+      // safe to resume).
       const remainingMs = remainingChildBudgetMs(opts.deadlineAtMs, Date.now());
-      if (remainingMs !== null && remainingMs <= 0) {
+      if (remainingMs !== null && remainingMs < MIN_SUBAGENT_START_BUDGET_MS) {
+        budgetExhausted = true;
         skipReports.push({ filePath: t.filePath, reason: 'insufficient_cycle_budget' });
         continue;
       }
@@ -530,11 +538,18 @@ export async function runPhaseSynthesize(
         // at submit. The child's timeout_ms clock starts at ITS claim, so
         // this alone can't bound a child that sits queued — the wait loop's
         // cancel below closes that — but it bounds the common promptly-
-        // claimed case without waiting for the cancel path.
+        // claimed case without waiting for the cancel path. Below the
+        // start minimum, stop submitting this transcript's remaining
+        // chunks (per-chunk idempotency keys resume the rest next cycle).
         const remainingAtSubmitMs = remainingChildBudgetMs(opts.deadlineAtMs, Date.now());
+        if (remainingAtSubmitMs !== null && remainingAtSubmitMs < MIN_SUBAGENT_START_BUDGET_MS) {
+          budgetExhausted = true;
+          skipReports.push({ filePath: t.filePath, reason: 'insufficient_cycle_budget' });
+          break;
+        }
         const childTimeoutMs = remainingAtSubmitMs === null
           ? config.subagentTimeoutMs
-          : Math.max(1, Math.min(config.subagentTimeoutMs, remainingAtSubmitMs));
+          : Math.min(config.subagentTimeoutMs, remainingAtSubmitMs);
         const submitOpts: Partial<MinionJobInput> = {
           max_stalled: 3,
           on_child_fail: 'continue',
@@ -565,21 +580,13 @@ export async function runPhaseSynthesize(
     // THEIR claim, so an unwaited child could otherwise outlive the parent).
     // A child that already reached a terminal state on its own keeps its
     // real status — earlier siblings' waits gave it time to finish, and its
-    // pages still collect normally (cancelJob wouldn't touch a completed
-    // row anyway; the read is for honest reporting).
+    // pages still collect normally.
     const childOutcomes: Array<{ jobId: number; status: string }> = [];
-    for (const jobId of childIds) {
+    let waitIdx = 0;
+    for (; waitIdx < childIds.length; waitIdx++) {
+      const jobId = childIds[waitIdx];
       const remainingWaitMs = remainingChildBudgetMs(opts.deadlineAtMs, Date.now());
-      if (remainingWaitMs !== null && remainingWaitMs <= 0) {
-        const current = await queue.getJob(jobId);
-        if (current && ['completed', 'failed', 'dead', 'cancelled'].includes(current.status)) {
-          childOutcomes.push({ jobId, status: current.status });
-        } else {
-          try { await queue.cancelJob(jobId); } catch { /* best-effort */ }
-          childOutcomes.push({ jobId, status: 'timeout' });
-        }
-        continue;
-      }
+      if (remainingWaitMs !== null && remainingWaitMs <= 0) break;
       const waitTimeoutMs = remainingWaitMs === null
         ? config.subagentWaitTimeoutMs
         : Math.min(config.subagentWaitTimeoutMs, remainingWaitMs);
@@ -602,6 +609,30 @@ export async function runPhaseSynthesize(
       // After each child terminal, give the cycle lock + worker job lock a chance.
       if (opts.yieldDuringPhase) {
         try { await opts.yieldDuringPhase(); } catch { /* best-effort */ }
+      }
+    }
+    // Budget ran out before every child was waited on: settle the rest
+    // without waiting. Cancel-first (one write per child): a non-null
+    // return means we cancelled it; null means it was already terminal —
+    // read its real status so a completed sibling isn't misreported as
+    // timeout. Deliberately sequential per-child rather than one bulk SQL:
+    // cancelJob carries per-job semantics (child_done emission, aggregator
+    // unblocking) a bulk UPDATE would skip, each call is a millisecond-
+    // scale write with NO waits, and realistic fan-outs (children ≤
+    // max_chunks × transcripts per cycle) settle well inside the reserve.
+    if (waitIdx < childIds.length) {
+      budgetExhausted = true;
+      for (; waitIdx < childIds.length; waitIdx++) {
+        const jobId = childIds[waitIdx];
+        let status = 'timeout';
+        try {
+          const cancelled = await queue.cancelJob(jobId);
+          if (cancelled === null) {
+            const current = await queue.getJob(jobId);
+            if (current) status = current.status;
+          }
+        } catch { /* best-effort */ }
+        childOutcomes.push({ jobId, status });
       }
     }
 
@@ -636,8 +667,13 @@ export async function runPhaseSynthesize(
       await writeSummaryPage(engine, opts.brainDir, summarySlug, summaryDate, writtenSlugs, childOutcomes, cycleSourceId);
     }
 
-    // Write completion timestamp ON SUCCESS only.
-    await engine.setConfig('dream.synthesize.last_completion_ts', new Date().toISOString());
+    // Write completion timestamp ON SUCCESS only — and NOT on a
+    // budget-truncated run: stamping would arm the cooldown (default 12h)
+    // over transcripts/children this run never gave a real chance,
+    // contradicting "next cycle retries with a fresh budget" (#2781).
+    if (!budgetExhausted) {
+      await engine.setConfig('dream.synthesize.last_completion_ts', new Date().toISOString());
+    }
 
     const ms = Date.now() - start;
     const submittedTranscripts = worthProcessing.length - skipReports.length;

--- a/src/core/minions/types.ts
+++ b/src/core/minions/types.ts
@@ -200,6 +200,12 @@ export interface MinionJobContext {
   attempts_made: number;
   /** AbortSignal for cooperative cancellation (fires on timeout, cancel, pause, or lock loss). */
   signal: AbortSignal;
+  /** Absolute wall-clock deadline (epoch ms) from the claim-time `timeout_at` stamp,
+   *  or null when the job has no per-job timeout. This is the DB's ground truth —
+   *  the same instant handleTimeouts() dead-letters against — so handlers that
+   *  spawn bounded sub-work (e.g. autopilot-cycle's subagent phases) can budget
+   *  from the REMAINING time instead of a fixed constant that may exceed it. */
+  deadlineAtMs: number | null;
   /** AbortSignal that fires only on worker process SIGTERM/SIGINT. Handlers sensitive
    *  to deploy restarts (e.g. the shell handler, which must run a SIGTERM → 5s → SIGKILL
    *  sequence on its child) listen to this in addition to `signal`. Most handlers can

--- a/src/core/minions/worker.ts
+++ b/src/core/minions/worker.ts
@@ -900,15 +900,22 @@ export class MinionWorker extends EventEmitter {
 
     // Per-job wall-clock timeout (timer-armed only if `timeout_ms` was
     // set on the job; the grace-evict pattern above now lives outside
-    // this branch).
+    // this branch). The delay derives from the claim-time `timeout_at`
+    // stamp when present so this timer, the DB sweeper (handleTimeouts),
+    // and the handler-visible `deadlineAtMs` all agree on ONE absolute
+    // deadline instead of three clocks started at slightly different
+    // instants.
     let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
     if (job.timeout_ms != null) {
+      const delayMs = job.timeout_at != null
+        ? Math.max(0, job.timeout_at.getTime() - Date.now())
+        : job.timeout_ms;
       timeoutTimer = setTimeout(() => {
         if (!abort.signal.aborted) {
           console.warn(`Job ${job.id} (${job.name}) hit per-job timeout (${job.timeout_ms}ms), aborting`);
           abort.abort(new Error('timeout'));
         }
-      }, job.timeout_ms);
+      }, delayMs);
     }
 
     const promise = this.executeJob(job, lockToken, abort, lockTimer)
@@ -964,6 +971,7 @@ export class MinionWorker extends EventEmitter {
       data: job.data,
       attempts_made: job.attempts_made,
       signal: abort.signal,
+      deadlineAtMs: job.timeout_at != null ? job.timeout_at.getTime() : null,
       shutdownSignal: this.shutdownAbort.signal,
       updateProgress: async (progress: unknown) => {
         await this.queue.updateProgress(job.id, lockToken, progress);

--- a/test/cycle-patterns-deadline-budget.test.ts
+++ b/test/cycle-patterns-deadline-budget.test.ts
@@ -1,0 +1,162 @@
+/**
+ * #2781 — patterns phase budgets its subagent from the REMAINING parent-job
+ * time instead of a fixed 30/35-min default that can exceed any
+ * interval-derived cycle budget and dead-letter the whole cycle mid-phase.
+ *
+ * Layers:
+ *   1. Unit tests on the exported pure `clampSubagentBudgets`.
+ *   2. A real-queue check that `claim` stamps `timeout_at` (the DB ground
+ *      truth `deadlineAtMs` derives from) and leaves it null when the job
+ *      has no per-job timeout.
+ *   3. Structural assertions pinning the wiring: worker → context →
+ *      handler → runCycle → patterns (matches the house style of
+ *      test/cycle-patterns.test.ts).
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { readFileSync } from 'fs';
+import { PGLiteEngine } from '../src/core/pglite-engine.ts';
+import { MinionQueue } from '../src/core/minions/queue.ts';
+import {
+  clampSubagentBudgets,
+  CYCLE_DEADLINE_RESERVE_MS,
+  MIN_PATTERNS_SUBAGENT_BUDGET_MS,
+} from '../src/core/cycle/patterns.ts';
+
+const CONFIG = {
+  subagentTimeoutMs: 30 * 60 * 1000,
+  subagentWaitTimeoutMs: 35 * 60 * 1000,
+};
+
+describe('clampSubagentBudgets', () => {
+  const now = 1_000_000_000_000; // fixed epoch ms; the function takes nowMs explicitly
+
+  test('null deadline → config passthrough (direct `gbrain dream` back-compat)', () => {
+    expect(clampSubagentBudgets(CONFIG, null, now)).toEqual({
+      timeoutMs: CONFIG.subagentTimeoutMs,
+      waitTimeoutMs: CONFIG.subagentWaitTimeoutMs,
+    });
+    expect(clampSubagentBudgets(CONFIG, undefined, now)).toEqual({
+      timeoutMs: CONFIG.subagentTimeoutMs,
+      waitTimeoutMs: CONFIG.subagentWaitTimeoutMs,
+    });
+  });
+
+  test('deadline far away → config values win (no clamping)', () => {
+    const deadline = now + 2 * 60 * 60 * 1000; // 2h out
+    expect(clampSubagentBudgets(CONFIG, deadline, now)).toEqual({
+      timeoutMs: CONFIG.subagentTimeoutMs,
+      waitTimeoutMs: CONFIG.subagentWaitTimeoutMs,
+    });
+  });
+
+  test('deadline inside config window → BOTH timeouts clamp to the same child budget', () => {
+    const deadline = now + 10 * 60 * 1000; // 10 min out
+    const childBudget = deadline - CYCLE_DEADLINE_RESERVE_MS - now; // 9 min
+    const budgets = clampSubagentBudgets(CONFIG, deadline, now);
+    expect(budgets).toEqual({ timeoutMs: childBudget, waitTimeoutMs: childBudget });
+    // The child's own kill switch never outlives the parent budget.
+    expect(budgets!.timeoutMs).toBeLessThanOrEqual(deadline - now);
+  });
+
+  test('remaining budget below minimum → null (caller skips, no submit)', () => {
+    const deadline = now + CYCLE_DEADLINE_RESERVE_MS + MIN_PATTERNS_SUBAGENT_BUDGET_MS - 1;
+    expect(clampSubagentBudgets(CONFIG, deadline, now)).toBeNull();
+  });
+
+  test('boundary: exactly the minimum budget → submit allowed', () => {
+    const deadline = now + CYCLE_DEADLINE_RESERVE_MS + MIN_PATTERNS_SUBAGENT_BUDGET_MS;
+    expect(clampSubagentBudgets(CONFIG, deadline, now)).toEqual({
+      timeoutMs: MIN_PATTERNS_SUBAGENT_BUDGET_MS,
+      waitTimeoutMs: MIN_PATTERNS_SUBAGENT_BUDGET_MS,
+    });
+  });
+
+  test('deadline already past → null, never a negative timeout', () => {
+    expect(clampSubagentBudgets(CONFIG, now - 1000, now)).toBeNull();
+  });
+});
+
+describe('claim stamps timeout_at (deadlineAtMs ground truth)', () => {
+  let engine: PGLiteEngine;
+  let queue: MinionQueue;
+
+  beforeAll(async () => {
+    engine = new PGLiteEngine();
+    await engine.connect({ dataDir: 'memory://' });
+    await engine.initSchema();
+    queue = new MinionQueue(engine);
+  });
+
+  afterAll(async () => {
+    await engine.disconnect();
+  });
+
+  test('job with timeout_ms → claim sets timeout_at ≈ now + timeout_ms', async () => {
+    const before = Date.now();
+    await queue.add('sync', {}, { timeout_ms: 600_000 });
+    const claimed = await queue.claim('tok-dl-1', 30000, 'default', ['sync']);
+    const after = Date.now();
+    expect(claimed).not.toBeNull();
+    expect(claimed!.timeout_at).not.toBeNull();
+    const at = claimed!.timeout_at!.getTime();
+    expect(at).toBeGreaterThanOrEqual(before + 600_000 - 5_000);
+    expect(at).toBeLessThanOrEqual(after + 600_000 + 5_000);
+  });
+
+  test('job without timeout_ms and no handler default → timeout_at stays null', async () => {
+    // 'sync' is not in the long-handler default set, so no stamp either way.
+    await queue.add('sync', { which: 'no-timeout' });
+    // Drain the possibly-remaining job from the prior test first.
+    let claimed = await queue.claim('tok-dl-2', 30000, 'default', ['sync']);
+    while (claimed && claimed.timeout_ms != null) {
+      claimed = await queue.claim('tok-dl-2', 30000, 'default', ['sync']);
+    }
+    expect(claimed).not.toBeNull();
+    expect(claimed!.timeout_ms).toBeNull();
+    expect(claimed!.timeout_at).toBeNull();
+  });
+});
+
+describe('deadline plumbing wiring (structural)', () => {
+  const workerSrc = readFileSync(new URL('../src/core/minions/worker.ts', import.meta.url), 'utf-8');
+  const jobsSrc = readFileSync(new URL('../src/commands/jobs.ts', import.meta.url), 'utf-8');
+  const cycleSrc = readFileSync(new URL('../src/core/cycle.ts', import.meta.url), 'utf-8');
+  const patternsSrc = readFileSync(new URL('../src/core/cycle/patterns.ts', import.meta.url), 'utf-8');
+
+  test('worker exposes deadlineAtMs from the claim-time timeout_at stamp', () => {
+    expect(workerSrc).toContain('deadlineAtMs: job.timeout_at != null ? job.timeout_at.getTime() : null');
+  });
+
+  test('worker arms its abort timer from timeout_at when present (one absolute deadline)', () => {
+    expect(workerSrc).toContain('job.timeout_at.getTime() - Date.now()');
+  });
+
+  test('autopilot-cycle AND global-maintenance handlers thread deadlineAtMs into runCycle', () => {
+    const matches = jobsSrc.match(/deadlineAtMs: job\.deadlineAtMs/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
+
+  test('runCycle forwards deadlineAtMs to the patterns phase', () => {
+    expect(cycleSrc).toContain('deadlineAtMs: opts.deadlineAtMs ?? null');
+  });
+
+  test('patterns submits + waits with the CLAMPED budgets, not raw config', () => {
+    expect(patternsSrc).toContain('timeout_ms: budgets.timeoutMs');
+    expect(patternsSrc).toContain('timeoutMs: budgets.waitTimeoutMs');
+    expect(patternsSrc).not.toContain('timeout_ms: config.subagentTimeoutMs');
+    expect(patternsSrc).not.toContain('timeoutMs: config.subagentWaitTimeoutMs');
+  });
+
+  test('patterns skips honestly when the remaining budget is too small', () => {
+    expect(patternsSrc).toContain('insufficient_cycle_budget');
+    // Budget gate sits AFTER the provider probe so a no-provider brain
+    // still reports no_provider (cheaper, more actionable reason).
+    const probeIdx = patternsSrc.indexOf("skipped('no_provider'");
+    // lastIndexOf: the doc comment on MIN_PATTERNS_SUBAGENT_BUDGET_MS
+    // mentions the reason string too; the CALL SITE is the later hit.
+    const budgetIdx = patternsSrc.lastIndexOf('insufficient_cycle_budget');
+    expect(probeIdx).toBeGreaterThan(0);
+    expect(budgetIdx).toBeGreaterThan(probeIdx);
+  });
+});

--- a/test/cycle-patterns-deadline-budget.test.ts
+++ b/test/cycle-patterns-deadline-budget.test.ts
@@ -20,8 +20,8 @@ import { MinionQueue } from '../src/core/minions/queue.ts';
 import {
   clampSubagentBudgets,
   CYCLE_DEADLINE_RESERVE_MS,
-  MIN_PATTERNS_SUBAGENT_BUDGET_MS,
-} from '../src/core/cycle/patterns.ts';
+  MIN_SUBAGENT_START_BUDGET_MS,
+} from '../src/core/cycle/deadline-budget.ts';
 
 const CONFIG = {
   subagentTimeoutMs: 30 * 60 * 1000,
@@ -60,15 +60,15 @@ describe('clampSubagentBudgets', () => {
   });
 
   test('remaining budget below minimum → null (caller skips, no submit)', () => {
-    const deadline = now + CYCLE_DEADLINE_RESERVE_MS + MIN_PATTERNS_SUBAGENT_BUDGET_MS - 1;
+    const deadline = now + CYCLE_DEADLINE_RESERVE_MS + MIN_SUBAGENT_START_BUDGET_MS - 1;
     expect(clampSubagentBudgets(CONFIG, deadline, now)).toBeNull();
   });
 
   test('boundary: exactly the minimum budget → submit allowed', () => {
-    const deadline = now + CYCLE_DEADLINE_RESERVE_MS + MIN_PATTERNS_SUBAGENT_BUDGET_MS;
+    const deadline = now + CYCLE_DEADLINE_RESERVE_MS + MIN_SUBAGENT_START_BUDGET_MS;
     expect(clampSubagentBudgets(CONFIG, deadline, now)).toEqual({
-      timeoutMs: MIN_PATTERNS_SUBAGENT_BUDGET_MS,
-      waitTimeoutMs: MIN_PATTERNS_SUBAGENT_BUDGET_MS,
+      timeoutMs: MIN_SUBAGENT_START_BUDGET_MS,
+      waitTimeoutMs: MIN_SUBAGENT_START_BUDGET_MS,
     });
   });
 
@@ -159,7 +159,7 @@ describe('deadline plumbing wiring (structural)', () => {
     // Budget gate sits AFTER the provider probe so a no-provider brain
     // still reports no_provider (cheaper, more actionable reason).
     const probeIdx = patternsSrc.indexOf("skipped('no_provider'");
-    // lastIndexOf: the doc comment on MIN_PATTERNS_SUBAGENT_BUDGET_MS
+    // lastIndexOf: the doc comment on MIN_SUBAGENT_START_BUDGET_MS
     // mentions the reason string too; the CALL SITE is the later hit.
     const budgetIdx = patternsSrc.lastIndexOf('insufficient_cycle_budget');
     expect(probeIdx).toBeGreaterThan(0);

--- a/test/cycle-patterns-deadline-budget.test.ts
+++ b/test/cycle-patterns-deadline-budget.test.ts
@@ -83,7 +83,7 @@ describe('claim stamps timeout_at (deadlineAtMs ground truth)', () => {
 
   beforeAll(async () => {
     engine = new PGLiteEngine();
-    await engine.connect({ dataDir: 'memory://' });
+    await engine.connect({ database_url: '' }); // in-memory
     await engine.initSchema();
     queue = new MinionQueue(engine);
   });
@@ -132,9 +132,9 @@ describe('deadline plumbing wiring (structural)', () => {
     expect(workerSrc).toContain('job.timeout_at.getTime() - Date.now()');
   });
 
-  test('autopilot-cycle AND global-maintenance handlers thread deadlineAtMs into runCycle', () => {
+  test('autopilot-cycle, global-maintenance AND phase-wrapper handlers thread deadlineAtMs into runCycle', () => {
     const matches = jobsSrc.match(/deadlineAtMs: job\.deadlineAtMs/g) ?? [];
-    expect(matches.length).toBe(2);
+    expect(matches.length).toBe(3);
   });
 
   test('runCycle forwards deadlineAtMs to the patterns phase', () => {
@@ -146,6 +146,12 @@ describe('deadline plumbing wiring (structural)', () => {
     expect(patternsSrc).toContain('timeoutMs: budgets.waitTimeoutMs');
     expect(patternsSrc).not.toContain('timeout_ms: config.subagentTimeoutMs');
     expect(patternsSrc).not.toContain('timeoutMs: config.subagentWaitTimeoutMs');
+  });
+
+  test('patterns cancels the child on wait timeout (child clock starts at ITS claim)', () => {
+    // A child that sat queued can outlive the parent deadline the wait was
+    // clamped to; the timeout path must strip it so it can't keep spending.
+    expect(patternsSrc).toContain('queue.cancelJob(job.id)');
   });
 
   test('patterns skips honestly when the remaining budget is too small', () => {

--- a/test/cycle-synthesize-deadline-budget.test.ts
+++ b/test/cycle-synthesize-deadline-budget.test.ts
@@ -65,9 +65,9 @@ describe('synthesize deadline wiring (structural)', () => {
   });
 
   test('sequential wait loop recomputes the remaining budget EVERY iteration', () => {
-    // The recompute call must be INSIDE the `for (const jobId of childIds)`
-    // loop body — a single pre-loop computation is exactly the bug.
-    const loopIdx = synthSrc.indexOf('for (const jobId of childIds)');
+    // The recompute call must be INSIDE the wait-loop body — a single
+    // pre-loop computation is exactly the accumulation bug.
+    const loopIdx = synthSrc.indexOf('for (; waitIdx < childIds.length; waitIdx++)');
     expect(loopIdx).toBeGreaterThan(0);
     const loopSlice = synthSrc.slice(loopIdx, loopIdx + 800);
     expect(loopSlice).toContain('remainingChildBudgetMs(opts.deadlineAtMs, Date.now())');
@@ -75,17 +75,32 @@ describe('synthesize deadline wiring (structural)', () => {
     expect(synthSrc).not.toContain('timeoutMs: config.subagentWaitTimeoutMs');
   });
 
-  test('exhausted budget cancels un-terminal children but keeps real terminal statuses', () => {
-    const loopIdx = synthSrc.indexOf('for (const jobId of childIds)');
-    const loopSlice = synthSrc.slice(loopIdx, loopIdx + 1600);
-    expect(loopSlice).toContain('queue.getJob(jobId)');
-    expect(loopSlice).toContain('queue.cancelJob(jobId)');
+  test('exhausted budget settles remaining children: cancel-first, real status when already terminal', () => {
+    // Cancel returns null for an already-terminal row → refetch so a
+    // completed sibling isn't misreported as timeout.
+    expect(synthSrc).toContain('cancelled === null');
+    expect(synthSrc).toContain('queue.getJob(jobId)');
   });
 
   test('wait-timeout path cancels the child (queued child can outlive the clamp)', () => {
-    // Two cancel sites in the wait loop: budget-exhausted and TimeoutError.
+    // Two cancel sites: TimeoutError in the wait loop + the settle loop.
     const matches = synthSrc.match(/queue\.cancelJob\(jobId\)/g) ?? [];
     expect(matches.length).toBe(2);
+  });
+
+  test('budget-truncated runs do not arm the synthesize cooldown', () => {
+    expect(synthSrc).toContain('if (!budgetExhausted) {');
+    const stampIdx = synthSrc.indexOf("setConfig('dream.synthesize.last_completion_ts'");
+    const guardIdx = synthSrc.indexOf('if (!budgetExhausted) {');
+    expect(stampIdx).toBeGreaterThan(guardIdx);
+  });
+
+  test('mid-fanout exhaustion stops submitting below the start minimum, not merely at zero', () => {
+    // Both the per-transcript guard and the per-chunk guard compare against
+    // MIN_SUBAGENT_START_BUDGET_MS (a <= 0 guard would still submit
+    // guaranteed-kill children with second-scale timeouts).
+    const matches = synthSrc.match(/< MIN_SUBAGENT_START_BUDGET_MS/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(3); // pre-fanout + transcript + chunk guards
   });
 
   test('shared helpers live in deadline-budget.ts (no patterns↔synthesize cycle)', () => {

--- a/test/cycle-synthesize-deadline-budget.test.ts
+++ b/test/cycle-synthesize-deadline-budget.test.ts
@@ -1,0 +1,98 @@
+/**
+ * #2781 follow-up — synthesize budgets its fan-out and its SEQUENTIAL
+ * per-child waits from the remaining parent-job time. Without the
+ * per-wait recompute, N children accumulate N × subagent_wait_timeout_ms
+ * past any parent budget (patterns' single-wait clamp can't help here).
+ *
+ * Layers mirror test/cycle-patterns-deadline-budget.test.ts:
+ *   1. Unit tests on `remainingChildBudgetMs` (the per-iteration primitive).
+ *   2. Structural pins on the synthesize wiring.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import {
+  remainingChildBudgetMs,
+  CYCLE_DEADLINE_RESERVE_MS,
+} from '../src/core/cycle/deadline-budget.ts';
+
+describe('remainingChildBudgetMs', () => {
+  const now = 1_000_000_000_000;
+
+  test('null deadline → null (direct `gbrain dream` back-compat)', () => {
+    expect(remainingChildBudgetMs(null, now)).toBeNull();
+    expect(remainingChildBudgetMs(undefined, now)).toBeNull();
+  });
+
+  test('subtracts the reserve from the remaining time', () => {
+    const deadline = now + 10 * 60 * 1000;
+    expect(remainingChildBudgetMs(deadline, now)).toBe(10 * 60 * 1000 - CYCLE_DEADLINE_RESERVE_MS);
+  });
+
+  test('goes non-positive once the reserve is breached (callers stop waiting)', () => {
+    expect(remainingChildBudgetMs(now + CYCLE_DEADLINE_RESERVE_MS, now)).toBe(0);
+    expect(remainingChildBudgetMs(now - 1000, now)).toBeLessThan(0);
+  });
+});
+
+describe('synthesize deadline wiring (structural)', () => {
+  const synthSrc = readFileSync(new URL('../src/core/cycle/synthesize.ts', import.meta.url), 'utf-8');
+  const cycleSrc = readFileSync(new URL('../src/core/cycle.ts', import.meta.url), 'utf-8');
+  const patternsSrc = readFileSync(new URL('../src/core/cycle/patterns.ts', import.meta.url), 'utf-8');
+
+  test('runCycle forwards deadlineAtMs to the synthesize phase', () => {
+    // Both subagent-spawning phases receive the deadline (patterns pinned
+    // in its own test file; this pins the synthesize call site).
+    const callSite = cycleSrc.indexOf('runPhaseSynthesize(engine, {');
+    expect(callSite).toBeGreaterThan(0);
+    const callSlice = cycleSrc.slice(callSite, callSite + 600);
+    expect(callSlice).toContain('deadlineAtMs: opts.deadlineAtMs ?? null');
+  });
+
+  test('pre-fanout gate skips honestly before submitting any Sonnet work', () => {
+    expect(synthSrc).toContain('insufficient_cycle_budget');
+    // Gate sits after the verdict loop (which consumes wall-clock) and
+    // before the fan-out submit loop.
+    const gateIdx = synthSrc.indexOf('preFanoutBudgetMs');
+    const fanoutIdx = synthSrc.indexOf('const queue = new MinionQueue(engine)');
+    expect(gateIdx).toBeGreaterThan(0);
+    expect(fanoutIdx).toBeGreaterThan(gateIdx);
+  });
+
+  test('per-child submit clamps timeout_ms to the remaining budget', () => {
+    expect(synthSrc).toContain('timeout_ms: childTimeoutMs');
+    expect(synthSrc).not.toContain('timeout_ms: config.subagentTimeoutMs');
+  });
+
+  test('sequential wait loop recomputes the remaining budget EVERY iteration', () => {
+    // The recompute call must be INSIDE the `for (const jobId of childIds)`
+    // loop body — a single pre-loop computation is exactly the bug.
+    const loopIdx = synthSrc.indexOf('for (const jobId of childIds)');
+    expect(loopIdx).toBeGreaterThan(0);
+    const loopSlice = synthSrc.slice(loopIdx, loopIdx + 800);
+    expect(loopSlice).toContain('remainingChildBudgetMs(opts.deadlineAtMs, Date.now())');
+    expect(synthSrc).toContain('timeoutMs: waitTimeoutMs');
+    expect(synthSrc).not.toContain('timeoutMs: config.subagentWaitTimeoutMs');
+  });
+
+  test('exhausted budget cancels un-terminal children but keeps real terminal statuses', () => {
+    const loopIdx = synthSrc.indexOf('for (const jobId of childIds)');
+    const loopSlice = synthSrc.slice(loopIdx, loopIdx + 1600);
+    expect(loopSlice).toContain('queue.getJob(jobId)');
+    expect(loopSlice).toContain('queue.cancelJob(jobId)');
+  });
+
+  test('wait-timeout path cancels the child (queued child can outlive the clamp)', () => {
+    // Two cancel sites in the wait loop: budget-exhausted and TimeoutError.
+    const matches = synthSrc.match(/queue\.cancelJob\(jobId\)/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
+
+  test('shared helpers live in deadline-budget.ts (no patterns↔synthesize cycle)', () => {
+    expect(synthSrc).toContain("from './deadline-budget.ts'");
+    expect(patternsSrc).toContain("from './deadline-budget.ts'");
+    // patterns must NOT re-define the helpers it now imports.
+    expect(patternsSrc).not.toContain('export function clampSubagentBudgets');
+    expect(patternsSrc).not.toContain('export const CYCLE_DEADLINE_RESERVE_MS');
+  });
+});

--- a/test/cycle-synthesize-deadline-budget.test.ts
+++ b/test/cycle-synthesize-deadline-budget.test.ts
@@ -95,6 +95,13 @@ describe('synthesize deadline wiring (structural)', () => {
     expect(stampIdx).toBeGreaterThan(guardIdx);
   });
 
+  test('a timeout on a deadline-CLAMPED wait counts as budget truncation', () => {
+    // The child never got its full configured wait — suppressing the
+    // cooldown stamp lets the next cycle retry. A timeout at the full
+    // configured wait keeps the pre-existing stamping behavior.
+    expect(synthSrc).toContain('waitTimeoutMs < config.subagentWaitTimeoutMs');
+  });
+
   test('mid-fanout exhaustion stops submitting below the start minimum, not merely at zero', () => {
     // Both the per-transcript guard and the per-chunk guard compare against
     // MIN_SUBAGENT_START_BUDGET_MS (a <= 0 guard would still submit

--- a/test/e2e/ingestion-roundtrip.test.ts
+++ b/test/e2e/ingestion-roundtrip.test.ts
@@ -49,6 +49,7 @@ function makeFakeJobCtx(data: Record<string, unknown>): MinionJobContext {
     data,
     attempts_made: 1,
     signal: new AbortController().signal,
+    deadlineAtMs: null,
     shutdownSignal: new AbortController().signal,
     updateProgress: async () => {},
     updateTokens: async () => {},

--- a/test/e2e/subagent-crash-replay-multi-provider.test.ts
+++ b/test/e2e/subagent-crash-replay-multi-provider.test.ts
@@ -279,6 +279,7 @@ async function makeCrashedCtx(jobId: number, prompt: string, modelId: string): P
     data: { prompt, model: modelId },
     attempts_made: 1, // crashed once
     signal: abortCtrl.signal,
+    deadlineAtMs: null,
     shutdownSignal: shutdownCtrl.signal,
     updateProgress: async () => {},
     updateTokens: async () => {},

--- a/test/e2e/subagent-gateway-path.test.ts
+++ b/test/e2e/subagent-gateway-path.test.ts
@@ -92,6 +92,7 @@ async function makeFakeJob(opts: FakeJobOpts): Promise<{ jobId: number; ctx: Min
     data: { prompt: opts.prompt, model: opts.model, allowed_tools: opts.allowed_tools },
     attempts_made: 0,
     signal: abortCtrl.signal,
+    deadlineAtMs: null,
     shutdownSignal: shutdownCtrl.signal,
     updateProgress: async () => {},
     updateTokens: async (t) => { tokenSink.push(t); },

--- a/test/e2e/subagent-gateway-resume-reconciliation.test.ts
+++ b/test/e2e/subagent-gateway-resume-reconciliation.test.ts
@@ -68,7 +68,7 @@ async function makeJob(prompt: string, model: string): Promise<{ jobId: number; 
   const jobId = rows[0].id;
   const ctx: MinionJobContext = {
     id: jobId, name: 'subagent', data: { prompt, model }, attempts_made: 1,
-    signal: new AbortController().signal, shutdownSignal: new AbortController().signal,
+    signal: new AbortController().signal, deadlineAtMs: null, shutdownSignal: new AbortController().signal,
     updateProgress: async () => {}, updateTokens: async () => {}, log: async () => {},
     isActive: async () => true, readInbox: async () => [],
   };

--- a/test/handlers-embed-backfill.test.ts
+++ b/test/handlers-embed-backfill.test.ts
@@ -48,6 +48,7 @@ function fakeJob(data: Record<string, unknown>): MinionJobContext {
     data,
     attempts_made: 0,
     signal: controller.signal,
+    deadlineAtMs: null,
     shutdownSignal: controller.signal,
     updateProgress: async () => {},
     updateTokens: async () => {},

--- a/test/ingestion/ingest-capture.test.ts
+++ b/test/ingestion/ingest-capture.test.ts
@@ -58,6 +58,7 @@ function makeJob(data: Record<string, unknown>): MinionJobContext {
     data,
     attempts_made: 1,
     signal: new AbortController().signal,
+    deadlineAtMs: null,
     shutdownSignal: new AbortController().signal,
     updateProgress: async () => {},
     updateTokens: async () => {},

--- a/test/minions-shell.test.ts
+++ b/test/minions-shell.test.ts
@@ -52,6 +52,7 @@ function makeCtx(
     data,
     attempts_made: 0,
     signal: opts.signal ?? new AbortController().signal,
+    deadlineAtMs: null,
     shutdownSignal: opts.shutdownSignal ?? new AbortController().signal,
     updateProgress: async () => {},
     updateTokens: async () => {},

--- a/test/subagent-aggregator.test.ts
+++ b/test/subagent-aggregator.test.ts
@@ -40,6 +40,7 @@ function ctxWithInbox(
     data,
     attempts_made: 0,
     signal: new AbortController().signal,
+    deadlineAtMs: null,
     shutdownSignal: new AbortController().signal,
     async updateProgress(p: unknown) { progress.push(p); },
     async updateTokens() {},

--- a/test/subagent-handler.test.ts
+++ b/test/subagent-handler.test.ts
@@ -90,6 +90,7 @@ async function makeCtx(input: unknown): Promise<MinionJobContext> {
     data: (input as Record<string, unknown>) ?? {},
     attempts_made: 0,
     signal: ac.signal,
+    deadlineAtMs: null,
     shutdownSignal: shutdown.signal,
     async updateProgress() {},
     async updateTokens() {},


### PR DESCRIPTION
## What

Part of #2781 — the synthesize half of the remaining-budget work, following the patterns-phase PR (#2959, which this branch is **stacked on**; the first two commits here are that PR).

Patterns needed one clamp because it runs one child and one wait. Synthesize has a second-order problem: it submits N children up-front, then waits for them **sequentially** — so a fixed per-wait timeout accumulates N × `subagent_wait_timeout_ms` past any parent budget. A single up-front clamp can't express that; the budget has to be recomputed as it drains.

- **Shared helpers move to `src/core/cycle/deadline-budget.ts`** (`CYCLE_DEADLINE_RESERVE_MS`, `MIN_SUBAGENT_START_BUDGET_MS`, `clampSubagentBudgets`, new `remainingChildBudgetMs`). patterns.ts already imports from synthesize.ts, so synthesize importing these back from patterns would create an import cycle. `MIN_PATTERNS_SUBAGENT_BUDGET_MS` is renamed `MIN_SUBAGENT_START_BUDGET_MS` — it now guards both phases.
- **Pre-fanout gate**: below the 2-min start minimum, skip honestly (`insufficient_cycle_budget`) before any Sonnet submit. Read after the verdict loop, which itself consumes wall-clock.
- **Per-child submit clamp**: each child's `timeout_ms` clamps to the remaining budget at ITS submit. Both the per-transcript and per-chunk guards stop at the start minimum (not merely ≤ 0 — a near-zero budget would submit guaranteed-kill children with second-scale timeouts). A partial fan-out is safe to resume: the per-chunk idempotency keys dedupe already-submitted work next cycle.
- **Per-iteration wait recompute**: every wait derives `min(config, remaining)` against the same absolute deadline. Once the budget is gone, the remaining children are settled without waiting: cancel-first (one write per child); a null return means the child was already terminal, so its real status is refetched — a completed sibling isn't misreported as timeout, and its pages still collect. The settle loop is deliberately sequential per-child rather than one bulk UPDATE: `cancelJob` carries per-job semantics (child_done emission, aggregator unblocking) a bulk write would skip, and each call is a millisecond-scale write with no waits.
- **Budget-truncated runs don't stamp `last_completion_ts`** — arming the default 12h cooldown over transcripts this run never gave a real chance would contradict "next cycle retries with a fresh budget".
- Wait-timeout path cancels the child, same rationale as patterns (the child's `timeout_ms` clock starts at its claim, so a queued child can outlive the clamp).

Direct callers (`gbrain dream`) pass no deadline and keep the configured behavior unchanged.

## Tests

`test/cycle-synthesize-deadline-budget.test.ts` (new): unit tests on `remainingChildBudgetMs` (null back-compat, reserve subtraction, non-positive on breach) + structural pins (cycle.ts threading, gate placement after the verdict loop, clamped-not-raw submit values, in-loop recompute anchored inside the wait loop body, cancel-first settle with real-status refetch, cooldown suppression, MIN-threshold guards at all three sites). The patterns test file follows the helpers to their new module. 314 pass / 0 fail across the touched-area sweep (all synthesize suites, patterns, minions queue, autopilot-cycle handler, cycle-abort); `bun run typecheck` clean.

Review: three-round external model review; round 1 found the ≤0-vs-minimum submit guard gap, the cooldown stamping contradiction, and the settle-loop reporting race; round 2 caught that a timeout on a deadline-CLAMPED wait must also count as budget truncation (the child never got its full configured wait). All fixed and re-verified.

Related: #2781, #2959 (stacked base — the patterns half), #2852 (dispatch floor, complementary), #1594 (hardcoded-subagent-timeout family).
